### PR TITLE
feat(precompiles): b20_asset hardfork versioning — fork-routed lookup + V1 seam (Phase 0+1)

### DIFF
--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -1,37 +1,59 @@
-//! ABI dispatch for the asset B-20 variant.
+//! Shared precompile entry for the asset B-20 variant.
 //!
-//! Asset-specific selectors are tried first via `IB20Asset::IB20AssetCalls`.
-//! The `IB20` match block handles inherited selectors.
+//! This is the version-agnostic execution glue: the non-payable check,
+//! calldata-gas deduction, initialization check, and observer/recorder
+//! plumbing. After the init check it resolves to the active
+//! [`B20AssetVersionId`] and hands off to that version's self-contained
+//! selector routing + business logic (see [`crate::b20_asset::logic`]).
 
-use alloc::string::ToString;
-
-use alloy_primitives::{Bytes, U256};
-use alloy_sol_types::{SolCall, SolEvent, SolInterface, SolValue};
+use alloy_primitives::Bytes;
 use base_precompile_storage::{BasePrecompileError, StorageCtx};
 use revm::precompile::PrecompileResult;
 
 use crate::{
-    AssetAccounting, B20AssetStorage, B20AssetToken, B20TokenRole, BerylAuxiliaryMetrics,
-    BerylCallRecorder, BerylMetricLabels, BerylSelector, Burnable, Configurable,
-    IB20::{self, IB20Calls as C},
-    IB20Asset::{self, IB20AssetCalls as SC},
-    Mintable, NoopPrecompileCallObserver, Pausable, PermitArgs, Permittable, Policy,
-    PrecompileCallObserver, RoleManaged, Token, Transferable,
-    macros::decode_precompile_call,
+    AssetAccounting, B20AssetToken, B20AssetVersionId, BerylCallRecorder, BerylMetricLabels,
+    IB20, NoopPrecompileCallObserver, Policy, PrecompileCallObserver, Token,
 };
 
 impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
-    /// ABI-dispatches `calldata` to the appropriate `IB20Asset` handler.
+    /// ABI-dispatches `calldata` using the current (V1) execution logic.
     pub fn dispatch(&mut self, ctx: StorageCtx<'_>, calldata: &[u8]) -> PrecompileResult {
         self.dispatch_with_observer(ctx, calldata, NoopPrecompileCallObserver)
     }
 
-    /// ABI-dispatches `calldata` and observes the decoded asset B-20 operation.
+    /// ABI-dispatches `calldata` and observes the decoded asset B-20 operation,
+    /// using the current (V1) execution logic.
+    ///
+    /// Convenience entry for callers and tests that exercise today's behavior
+    /// directly. The fork-routed entry point is [`dispatch_with_version`], which
+    /// the precompile install path uses to select the version active at the
+    /// current hardfork.
+    ///
+    /// [`dispatch_with_version`]: Self::dispatch_with_version
     pub fn dispatch_with_observer<O>(
         &mut self,
         ctx: StorageCtx<'_>,
         calldata: &[u8],
         observer: O,
+    ) -> PrecompileResult
+    where
+        O: PrecompileCallObserver,
+    {
+        self.dispatch_with_version(ctx, calldata, observer, B20AssetVersionId::V1)
+    }
+
+    /// Shared precompile entry: performs the non-payable check, calldata-gas
+    /// deduction, initialization check, and observer/recorder plumbing, then
+    /// delegates to `version`'s self-contained selector routing + business logic.
+    ///
+    /// Everything up to and including the init check is shared across versions;
+    /// only the final `version.run` hand-off is version-specific.
+    pub fn dispatch_with_version<O>(
+        &mut self,
+        ctx: StorageCtx<'_>,
+        calldata: &[u8],
+        observer: O,
+        version: B20AssetVersionId,
     ) -> PrecompileResult
     where
         O: PrecompileCallObserver,
@@ -54,424 +76,7 @@ impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
             }
             Err(error) => return recorder.record_base_error_result(ctx, error),
         }
-        recorder.record_base_result(ctx, self.inner_with_observer(ctx, calldata, observer), |b| b)
-    }
-
-    /// Decodes calldata and executes the matching `IB20Asset` or inherited `IB20` operation.
-    pub fn inner(
-        &mut self,
-        ctx: StorageCtx<'_>,
-        calldata: &[u8],
-    ) -> base_precompile_storage::Result<Bytes> {
-        self.inner_with_observer(ctx, calldata, NoopPrecompileCallObserver)
-    }
-
-    /// Decodes calldata, observes the decoded operation, and executes the matching handler.
-    pub fn inner_with_observer<O>(
-        &mut self,
-        ctx: StorageCtx<'_>,
-        calldata: &[u8],
-        observer: O,
-    ) -> base_precompile_storage::Result<Bytes>
-    where
-        O: PrecompileCallObserver,
-    {
-        self.inner_with_privilege_and_observer(ctx, calldata, false, observer)
-    }
-
-    /// Decodes calldata and executes it with optional factory-init privilege.
-    pub fn inner_with_privilege(
-        &mut self,
-        ctx: StorageCtx<'_>,
-        calldata: &[u8],
-        privileged: bool,
-    ) -> base_precompile_storage::Result<Bytes> {
-        self.inner_with_privilege_and_observer(
-            ctx,
-            calldata,
-            privileged,
-            NoopPrecompileCallObserver,
-        )
-    }
-
-    /// Decodes calldata, observes the decoded operation, and executes it with optional
-    /// factory-init privilege.
-    pub fn inner_with_privilege_and_observer<O>(
-        &mut self,
-        ctx: StorageCtx<'_>,
-        calldata: &[u8],
-        privileged: bool,
-        observer: O,
-    ) -> base_precompile_storage::Result<Bytes>
-    where
-        O: PrecompileCallObserver,
-    {
-        // Asset-specific and overridden selectors are caught here first.
-        if let Some(selector) = BerylSelector::selector(calldata)
-            && IB20Asset::IB20AssetCalls::valid_selector(selector)
-        {
-            let call =
-                IB20Asset::IB20AssetCalls::abi_decode_validate(calldata).map_err(|error| {
-                    BasePrecompileError::AbiDecodeFailed { selector, error: error.to_string() }
-                })?;
-            let label = call.as_label();
-            let asset_observer = observer.clone();
-            return observer.observe(label, move || {
-                self.handle_asset_call(ctx, call, privileged, asset_observer)
-            });
-        }
-
-        // Fall through to inherited IB20 selectors.
-        let call = decode_precompile_call!(calldata, IB20::IB20Calls);
-        let label = call.as_label();
-
-        observer.observe(label, || self.handle_b20_call(ctx, call, privileged))
-    }
-
-    fn handle_b20_call(
-        &mut self,
-        ctx: StorageCtx<'_>,
-        call: C,
-        privileged: bool,
-    ) -> base_precompile_storage::Result<Bytes> {
-        let encoded: Bytes = match call {
-            // --- Pure reads ---
-            C::name(_) => self.accounting().name()?.abi_encode().into(),
-            C::symbol(_) => self.accounting().symbol()?.abi_encode().into(),
-            C::decimals(_) => {
-                U256::from(AssetAccounting::decimals(self.accounting())?).abi_encode().into()
-            }
-            C::totalSupply(_) => self.accounting().total_supply()?.abi_encode().into(),
-            C::balanceOf(c) => self.accounting().balance_of(c.account)?.abi_encode().into(),
-            C::allowance(c) => self.accounting().allowance(c.owner, c.spender)?.abi_encode().into(),
-            C::supplyCap(_) => self.accounting().supply_cap()?.abi_encode().into(),
-            C::nonces(c) => self.accounting().nonce(c.owner)?.abi_encode().into(),
-            C::contractURI(_) => self.accounting().contract_uri()?.abi_encode().into(),
-
-            // --- Role identifiers ---
-            C::DEFAULT_ADMIN_ROLE(_) => B20TokenRole::DefaultAdmin.id().abi_encode().into(),
-            C::MINT_ROLE(_) => B20TokenRole::Mint.id().abi_encode().into(),
-            C::BURN_ROLE(_) => B20TokenRole::Burn.id().abi_encode().into(),
-            C::BURN_BLOCKED_ROLE(_) => B20TokenRole::BurnBlocked.id().abi_encode().into(),
-            C::PAUSE_ROLE(_) => B20TokenRole::Pause.id().abi_encode().into(),
-            C::UNPAUSE_ROLE(_) => B20TokenRole::Unpause.id().abi_encode().into(),
-            C::METADATA_ROLE(_) => B20TokenRole::Metadata.id().abi_encode().into(),
-
-            // --- Policy type identifiers ---
-            C::TRANSFER_SENDER_POLICY(_) => Self::transfer_sender_policy().abi_encode().into(),
-            C::TRANSFER_RECEIVER_POLICY(_) => Self::transfer_receiver_policy().abi_encode().into(),
-            C::TRANSFER_EXECUTOR_POLICY(_) => Self::transfer_executor_policy().abi_encode().into(),
-            C::MINT_RECEIVER_POLICY(_) => Self::mint_receiver_policy().abi_encode().into(),
-
-            // --- Role reads ---
-            C::hasRole(c) => self.has_role(c.role, c.account)?.abi_encode().into(),
-            C::getRoleAdmin(c) => self.role_admin(c.role)?.abi_encode().into(),
-
-            // --- Pause reads ---
-            C::pausedFeatures(_) => self.paused_features()?.abi_encode().into(),
-            C::isPaused(c) => self.is_paused(c.feature)?.abi_encode().into(),
-
-            // --- Policy reads ---
-            C::policyId(c) => self.policy_id(c.policyScope)?.abi_encode().into(),
-
-            // --- Domain reads ---
-            C::DOMAIN_SEPARATOR(_) => self.domain_separator(ctx.chain_id())?.abi_encode().into(),
-            C::eip712Domain(_) => {
-                let (fields, name, version, chain_id, verifying_contract, salt, extensions) =
-                    self.eip712_domain(ctx.chain_id())?;
-                IB20::eip712DomainCall::abi_encode_returns(&IB20::eip712DomainReturn {
-                    fields,
-                    name,
-                    version,
-                    chainId: chain_id,
-                    verifyingContract: verifying_contract,
-                    salt,
-                    extensions,
-                })
-                .into()
-            }
-
-            // --- ERC-20 mutating ---
-            C::transfer(c) => {
-                let caller = ctx.caller();
-                self.transfer(caller, c.to, c.amount, privileged)?;
-                true.abi_encode().into()
-            }
-            C::transferFrom(c) => {
-                let caller = ctx.caller();
-                self.transfer_from(caller, c.from, c.to, c.amount, privileged)?;
-                true.abi_encode().into()
-            }
-            C::approve(c) => {
-                let caller = ctx.caller();
-                self.approve(caller, c.spender, c.amount)?;
-                true.abi_encode().into()
-            }
-            C::transferWithMemo(c) => {
-                let caller = ctx.caller();
-                self.transfer_with_memo(caller, c.to, c.amount, c.memo, privileged)?;
-                true.abi_encode().into()
-            }
-            C::transferFromWithMemo(c) => {
-                let caller = ctx.caller();
-                self.transfer_from_with_memo(caller, c.from, c.to, c.amount, c.memo, privileged)?;
-                true.abi_encode().into()
-            }
-
-            // --- Mint ---
-            C::mint(c) => {
-                let caller = ctx.caller();
-                self.mint(caller, c.to, c.amount, privileged)?;
-                Bytes::new()
-            }
-            C::mintWithMemo(c) => {
-                let caller = ctx.caller();
-                self.mint_with_memo(caller, c.to, c.amount, c.memo, privileged)?;
-                Bytes::new()
-            }
-
-            // --- Burn ---
-            // Self-burn operations are never factory-privileged: during init the caller is the
-            // factory, not a token holder.
-            C::burn(c) => {
-                let caller = ctx.caller();
-                self.burn(caller, caller, c.amount, false)?;
-                Bytes::new()
-            }
-            C::burnWithMemo(c) => {
-                let caller = ctx.caller();
-                self.burn_with_memo(caller, caller, c.amount, c.memo, false)?;
-                Bytes::new()
-            }
-            C::burnBlocked(c) => {
-                let caller = ctx.caller();
-                self.burn_blocked(caller, c.from, c.amount, privileged)?;
-                Bytes::new()
-            }
-
-            // --- Pause ---
-            C::pause(c) => {
-                let caller = ctx.caller();
-                self.pause(caller, c.features, privileged)?;
-                Bytes::new()
-            }
-            C::unpause(c) => {
-                let caller = ctx.caller();
-                self.unpause(caller, c.features, privileged)?;
-                Bytes::new()
-            }
-
-            // --- Admin ---
-            C::updateSupplyCap(c) => {
-                let caller = ctx.caller();
-                Configurable::update_supply_cap(self, caller, c.newSupplyCap, privileged)?;
-                Bytes::new()
-            }
-            C::updateName(c) => {
-                let caller = ctx.caller();
-                Configurable::update_name(self, caller, c.newName, privileged)?;
-                Bytes::new()
-            }
-            C::updateSymbol(c) => {
-                let caller = ctx.caller();
-                Configurable::update_symbol(self, caller, c.newSymbol, privileged)?;
-                Bytes::new()
-            }
-            C::updateContractURI(c) => {
-                let caller = ctx.caller();
-                Configurable::update_contract_uri(self, caller, c.newURI, privileged)?;
-                Bytes::new()
-            }
-
-            // --- Role mutations ---
-            C::grantRole(c) => {
-                let caller = ctx.caller();
-                self.grant_role(caller, c.role, c.account, privileged)?;
-                Bytes::new()
-            }
-            C::revokeRole(c) => {
-                let caller = ctx.caller();
-                self.revoke_role(caller, c.role, c.account, privileged)?;
-                Bytes::new()
-            }
-            // Renounce operations are never factory-privileged: they are only meaningful for the
-            // role holder making the call after token creation.
-            C::renounceRole(c) => {
-                let caller = ctx.caller();
-                self.renounce_role(caller, c.role, c.callerConfirmation)?;
-                Bytes::new()
-            }
-            C::renounceLastAdmin(_) => {
-                let caller = ctx.caller();
-                self.renounce_last_admin(caller)?;
-                Bytes::new()
-            }
-            C::setRoleAdmin(c) => {
-                let caller = ctx.caller();
-                self.set_role_admin(caller, c.role, c.newAdminRole, privileged)?;
-                Bytes::new()
-            }
-
-            // --- Policy mutations ---
-            C::updatePolicy(c) => {
-                let caller = ctx.caller();
-                self.update_policy(caller, c.policyScope, c.newPolicyId, privileged)?;
-                Bytes::new()
-            }
-
-            // --- Permit ---
-            C::permit(c) => {
-                self.permit(
-                    ctx.chain_id(),
-                    ctx.timestamp(),
-                    PermitArgs {
-                        owner: c.owner,
-                        spender: c.spender,
-                        value: c.value,
-                        deadline: c.deadline,
-                        v: c.v,
-                        r: c.r,
-                        s: c.s,
-                    },
-                )?;
-                Bytes::new()
-            }
-        };
-        Ok(encoded)
-    }
-
-    fn handle_asset_call<O>(
-        &mut self,
-        ctx: StorageCtx<'_>,
-        call: SC,
-        privileged: bool,
-        observer: O,
-    ) -> base_precompile_storage::Result<Bytes>
-    where
-        O: PrecompileCallObserver,
-    {
-        let caller = ctx.caller();
-        let encoded: Bytes = match call {
-            // --- Role / precision constants ---
-            SC::OPERATOR_ROLE(_) => Self::OPERATOR_ROLE.abi_encode().into(),
-            SC::WAD_PRECISION(_) => B20AssetStorage::WAD.abi_encode().into(),
-
-            // --- Multiplier reads ---
-            SC::multiplier(_) => self.accounting().multiplier()?.abi_encode().into(),
-            SC::toScaledBalance(c) => self.to_scaled_balance(c.rawBalance)?.abi_encode().into(),
-            SC::toRawBalance(c) => self.to_raw_balance(c.scaledBalance)?.abi_encode().into(),
-            SC::scaledBalanceOf(c) => self.scaled_balance_of(c.account)?.abi_encode().into(),
-
-            // --- Announcement reads ---
-            SC::isAnnouncementIdUsed(c) => {
-                self.accounting().is_announcement_id_used(c.id.as_str())?.abi_encode().into()
-            }
-
-            // --- Extra metadata reads ---
-            SC::extraMetadata(c) => {
-                self.accounting().extra_metadata(c.key.as_str())?.abi_encode().into()
-            }
-
-            // --- Multiplier mutations ---
-            SC::updateMultiplier(c) => {
-                self.update_multiplier(caller, c.newMultiplier, privileged)?;
-                Bytes::new()
-            }
-
-            // --- Announcement ---
-            SC::announce(c) => {
-                self.announce(ctx, c, privileged, &observer)?;
-                Bytes::new()
-            }
-
-            // --- Batched mint ---
-            SC::batchMint(c) => {
-                observer.record_batch_items(
-                    &BerylAuxiliaryMetrics::b20("asset", "batchMint"),
-                    c.recipients.len(),
-                );
-                self.batch_mint(caller, c.recipients, c.amounts, privileged)?;
-                Bytes::new()
-            }
-
-            // --- Extra metadata mutations ---
-            SC::updateExtraMetadata(c) => {
-                self.update_extra_metadata(caller, c.key, c.value, privileged)?;
-                Bytes::new()
-            }
-        };
-        Ok(encoded)
-    }
-
-    /// Posts an announcement and atomically executes `internal_calls` via self-dispatch.
-    ///
-    /// The selector check in the inner loop prevents recursive invocation.
-    fn announce<O>(
-        &mut self,
-        ctx: StorageCtx<'_>,
-        call: IB20Asset::announceCall,
-        privileged: bool,
-        observer: &O,
-    ) -> base_precompile_storage::Result<()>
-    where
-        O: PrecompileCallObserver,
-    {
-        let caller = ctx.caller();
-        let internal_calls = call.internalCalls;
-        let internal_call_count = internal_calls.len();
-        let internal_call_bytes = internal_calls.iter().map(|call| call.len()).sum();
-        observer.record_internal_calls(
-            &BerylAuxiliaryMetrics::b20("asset", "announce"),
-            internal_call_count,
-            internal_call_bytes,
-        );
-        self.ensure_operator_role(caller, privileged)?;
-
-        let id = call.id;
-        if self.accounting().is_announcement_id_used(id.as_str())? {
-            return Err(BasePrecompileError::revert(IB20Asset::AnnouncementIdAlreadyUsed { id }));
-        }
-        self.accounting_mut().mark_announcement_id_used(id.as_str())?;
-
-        self.accounting_mut().emit_event(
-            IB20Asset::Announcement {
-                caller,
-                id: id.clone(),
-                description: call.description,
-                uri: call.uri,
-            }
-            .encode_log_data(),
-        )?;
-
-        // Each internal call is dispatched via `inner_with_privilege`, a direct Rust function
-        // call. Unlike the base-std Solidity reference which routes each `internalCalls` entry
-        // through a DELEGATECALL (~100 gas opcode overhead + memory expansion), the native
-        // precompile replaces the entire EVM execution path so per-opcode call overhead does not
-        // apply. The cheaper batched cost is intentional: the native precompile pays for the
-        // storage work of each sub-call (the same SLOAD/SSTORE operations as the Solidity
-        // reference) but not for EVM call-frame overhead that exists only in the interpreter.
-        for call in &internal_calls {
-            let call_bytes: &[u8] = call.as_ref();
-            if call_bytes.len() < 4 {
-                return Err(BasePrecompileError::revert(IB20Asset::InternalCallMalformed {
-                    call: call.clone(),
-                }));
-            }
-            if call_bytes[..4] == IB20Asset::announceCall::SELECTOR {
-                return Err(BasePrecompileError::revert(IB20Asset::AnnouncementInProgress {}));
-            }
-            self.inner_with_privilege(ctx, call_bytes, privileged).map_err(|err| {
-                if err.is_system_error() {
-                    err
-                } else {
-                    BasePrecompileError::revert(IB20Asset::InternalCallFailed {
-                        call: call.clone(),
-                    })
-                }
-            })?;
-        }
-
-        self.accounting_mut().emit_event(IB20Asset::EndAnnouncement { id }.encode_log_data())
+        recorder.record_base_result(ctx, version.run(self, ctx, calldata, observer), |b| b)
     }
 }
 

--- a/crates/common/precompiles/src/b20_asset/logic/mod.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/mod.rs
@@ -1,0 +1,9 @@
+//! Self-contained per-version implementations of the `b20_asset` precompile.
+//!
+//! Each version owns the whole [`B20AssetVersion`](crate::B20AssetVersion) seam:
+//! it decodes and routes its own selectors and holds its own business logic.
+//! Storage layout and the ABI stay shared (cross-version invariants); routing
+//! and behavior do not.
+
+mod v1;
+pub use v1::B20AssetV1;

--- a/crates/common/precompiles/src/b20_asset/logic/v1.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v1.rs
@@ -1,0 +1,464 @@
+//! Version 1 of the `b20_asset` precompile, active from Beryl onward.
+//!
+//! Self-contained: V1 owns its own selector routing (the relocated
+//! `inner_with_observer` entry) and delegates to the shared, generic
+//! [`B20AssetToken`] business logic. This is today's behavior wrapped verbatim —
+//! no logic change. Selectors added by future versions fall through to the
+//! existing decode paths, so V1 stays frozen once activated.
+
+use alloc::string::ToString;
+
+use alloy_primitives::{Bytes, U256};
+use alloy_sol_types::{SolCall, SolEvent, SolInterface, SolValue};
+use base_precompile_storage::{BasePrecompileError, Result, StorageCtx};
+
+use crate::{
+    AssetAccounting, B20AssetStorage, B20AssetToken, B20AssetVersion, B20TokenRole,
+    BerylAuxiliaryMetrics, BerylSelector, Burnable, Configurable,
+    IB20::{self, IB20Calls as C},
+    IB20Asset::{self, IB20AssetCalls as SC},
+    Mintable, NoopPrecompileCallObserver, Pausable, PermitArgs, Permittable, Policy,
+    PrecompileCallObserver, RoleManaged, Token, Transferable,
+    macros::decode_precompile_call,
+};
+
+/// First `b20_asset` execution-logic version. Frozen as of its activation at
+/// Beryl; wraps today's routing and business logic verbatim.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct B20AssetV1;
+
+impl B20AssetVersion for B20AssetV1 {
+    fn run<S, P, O>(
+        &self,
+        token: &mut B20AssetToken<S, P>,
+        ctx: StorageCtx<'_>,
+        calldata: &[u8],
+        observer: O,
+    ) -> Result<Bytes>
+    where
+        S: AssetAccounting,
+        P: Policy,
+        O: PrecompileCallObserver,
+    {
+        token.inner_with_observer(ctx, calldata, observer)
+    }
+}
+
+impl<S: AssetAccounting, P: Policy> B20AssetToken<S, P> {
+    /// Decodes calldata and executes the matching `IB20Asset` or inherited `IB20` operation.
+    pub fn inner(
+        &mut self,
+        ctx: StorageCtx<'_>,
+        calldata: &[u8],
+    ) -> base_precompile_storage::Result<Bytes> {
+        self.inner_with_observer(ctx, calldata, NoopPrecompileCallObserver)
+    }
+
+    /// Decodes calldata, observes the decoded operation, and executes the matching handler.
+    pub fn inner_with_observer<O>(
+        &mut self,
+        ctx: StorageCtx<'_>,
+        calldata: &[u8],
+        observer: O,
+    ) -> base_precompile_storage::Result<Bytes>
+    where
+        O: PrecompileCallObserver,
+    {
+        self.inner_with_privilege_and_observer(ctx, calldata, false, observer)
+    }
+
+    /// Decodes calldata and executes it with optional factory-init privilege.
+    pub fn inner_with_privilege(
+        &mut self,
+        ctx: StorageCtx<'_>,
+        calldata: &[u8],
+        privileged: bool,
+    ) -> base_precompile_storage::Result<Bytes> {
+        self.inner_with_privilege_and_observer(
+            ctx,
+            calldata,
+            privileged,
+            NoopPrecompileCallObserver,
+        )
+    }
+
+    /// Decodes calldata, observes the decoded operation, and executes it with optional
+    /// factory-init privilege.
+    pub fn inner_with_privilege_and_observer<O>(
+        &mut self,
+        ctx: StorageCtx<'_>,
+        calldata: &[u8],
+        privileged: bool,
+        observer: O,
+    ) -> base_precompile_storage::Result<Bytes>
+    where
+        O: PrecompileCallObserver,
+    {
+        // Asset-specific and overridden selectors are caught here first.
+        if let Some(selector) = BerylSelector::selector(calldata)
+            && IB20Asset::IB20AssetCalls::valid_selector(selector)
+        {
+            let call =
+                IB20Asset::IB20AssetCalls::abi_decode_validate(calldata).map_err(|error| {
+                    BasePrecompileError::AbiDecodeFailed { selector, error: error.to_string() }
+                })?;
+            let label = call.as_label();
+            let asset_observer = observer.clone();
+            return observer.observe(label, move || {
+                self.handle_asset_call(ctx, call, privileged, asset_observer)
+            });
+        }
+
+        // Fall through to inherited IB20 selectors.
+        let call = decode_precompile_call!(calldata, IB20::IB20Calls);
+        let label = call.as_label();
+
+        observer.observe(label, || self.handle_b20_call(ctx, call, privileged))
+    }
+
+    fn handle_b20_call(
+        &mut self,
+        ctx: StorageCtx<'_>,
+        call: C,
+        privileged: bool,
+    ) -> base_precompile_storage::Result<Bytes> {
+        let encoded: Bytes = match call {
+            // --- Pure reads ---
+            C::name(_) => self.accounting().name()?.abi_encode().into(),
+            C::symbol(_) => self.accounting().symbol()?.abi_encode().into(),
+            C::decimals(_) => {
+                U256::from(AssetAccounting::decimals(self.accounting())?).abi_encode().into()
+            }
+            C::totalSupply(_) => self.accounting().total_supply()?.abi_encode().into(),
+            C::balanceOf(c) => self.accounting().balance_of(c.account)?.abi_encode().into(),
+            C::allowance(c) => self.accounting().allowance(c.owner, c.spender)?.abi_encode().into(),
+            C::supplyCap(_) => self.accounting().supply_cap()?.abi_encode().into(),
+            C::nonces(c) => self.accounting().nonce(c.owner)?.abi_encode().into(),
+            C::contractURI(_) => self.accounting().contract_uri()?.abi_encode().into(),
+
+            // --- Role identifiers ---
+            C::DEFAULT_ADMIN_ROLE(_) => B20TokenRole::DefaultAdmin.id().abi_encode().into(),
+            C::MINT_ROLE(_) => B20TokenRole::Mint.id().abi_encode().into(),
+            C::BURN_ROLE(_) => B20TokenRole::Burn.id().abi_encode().into(),
+            C::BURN_BLOCKED_ROLE(_) => B20TokenRole::BurnBlocked.id().abi_encode().into(),
+            C::PAUSE_ROLE(_) => B20TokenRole::Pause.id().abi_encode().into(),
+            C::UNPAUSE_ROLE(_) => B20TokenRole::Unpause.id().abi_encode().into(),
+            C::METADATA_ROLE(_) => B20TokenRole::Metadata.id().abi_encode().into(),
+
+            // --- Policy type identifiers ---
+            C::TRANSFER_SENDER_POLICY(_) => Self::transfer_sender_policy().abi_encode().into(),
+            C::TRANSFER_RECEIVER_POLICY(_) => Self::transfer_receiver_policy().abi_encode().into(),
+            C::TRANSFER_EXECUTOR_POLICY(_) => Self::transfer_executor_policy().abi_encode().into(),
+            C::MINT_RECEIVER_POLICY(_) => Self::mint_receiver_policy().abi_encode().into(),
+
+            // --- Role reads ---
+            C::hasRole(c) => self.has_role(c.role, c.account)?.abi_encode().into(),
+            C::getRoleAdmin(c) => self.role_admin(c.role)?.abi_encode().into(),
+
+            // --- Pause reads ---
+            C::pausedFeatures(_) => self.paused_features()?.abi_encode().into(),
+            C::isPaused(c) => self.is_paused(c.feature)?.abi_encode().into(),
+
+            // --- Policy reads ---
+            C::policyId(c) => self.policy_id(c.policyScope)?.abi_encode().into(),
+
+            // --- Domain reads ---
+            C::DOMAIN_SEPARATOR(_) => self.domain_separator(ctx.chain_id())?.abi_encode().into(),
+            C::eip712Domain(_) => {
+                let (fields, name, version, chain_id, verifying_contract, salt, extensions) =
+                    self.eip712_domain(ctx.chain_id())?;
+                IB20::eip712DomainCall::abi_encode_returns(&IB20::eip712DomainReturn {
+                    fields,
+                    name,
+                    version,
+                    chainId: chain_id,
+                    verifyingContract: verifying_contract,
+                    salt,
+                    extensions,
+                })
+                .into()
+            }
+
+            // --- ERC-20 mutating ---
+            C::transfer(c) => {
+                let caller = ctx.caller();
+                self.transfer(caller, c.to, c.amount, privileged)?;
+                true.abi_encode().into()
+            }
+            C::transferFrom(c) => {
+                let caller = ctx.caller();
+                self.transfer_from(caller, c.from, c.to, c.amount, privileged)?;
+                true.abi_encode().into()
+            }
+            C::approve(c) => {
+                let caller = ctx.caller();
+                self.approve(caller, c.spender, c.amount)?;
+                true.abi_encode().into()
+            }
+            C::transferWithMemo(c) => {
+                let caller = ctx.caller();
+                self.transfer_with_memo(caller, c.to, c.amount, c.memo, privileged)?;
+                true.abi_encode().into()
+            }
+            C::transferFromWithMemo(c) => {
+                let caller = ctx.caller();
+                self.transfer_from_with_memo(caller, c.from, c.to, c.amount, c.memo, privileged)?;
+                true.abi_encode().into()
+            }
+
+            // --- Mint ---
+            C::mint(c) => {
+                let caller = ctx.caller();
+                self.mint(caller, c.to, c.amount, privileged)?;
+                Bytes::new()
+            }
+            C::mintWithMemo(c) => {
+                let caller = ctx.caller();
+                self.mint_with_memo(caller, c.to, c.amount, c.memo, privileged)?;
+                Bytes::new()
+            }
+
+            // --- Burn ---
+            // Self-burn operations are never factory-privileged: during init the caller is the
+            // factory, not a token holder.
+            C::burn(c) => {
+                let caller = ctx.caller();
+                self.burn(caller, caller, c.amount, false)?;
+                Bytes::new()
+            }
+            C::burnWithMemo(c) => {
+                let caller = ctx.caller();
+                self.burn_with_memo(caller, caller, c.amount, c.memo, false)?;
+                Bytes::new()
+            }
+            C::burnBlocked(c) => {
+                let caller = ctx.caller();
+                self.burn_blocked(caller, c.from, c.amount, privileged)?;
+                Bytes::new()
+            }
+
+            // --- Pause ---
+            C::pause(c) => {
+                let caller = ctx.caller();
+                self.pause(caller, c.features, privileged)?;
+                Bytes::new()
+            }
+            C::unpause(c) => {
+                let caller = ctx.caller();
+                self.unpause(caller, c.features, privileged)?;
+                Bytes::new()
+            }
+
+            // --- Admin ---
+            C::updateSupplyCap(c) => {
+                let caller = ctx.caller();
+                Configurable::update_supply_cap(self, caller, c.newSupplyCap, privileged)?;
+                Bytes::new()
+            }
+            C::updateName(c) => {
+                let caller = ctx.caller();
+                Configurable::update_name(self, caller, c.newName, privileged)?;
+                Bytes::new()
+            }
+            C::updateSymbol(c) => {
+                let caller = ctx.caller();
+                Configurable::update_symbol(self, caller, c.newSymbol, privileged)?;
+                Bytes::new()
+            }
+            C::updateContractURI(c) => {
+                let caller = ctx.caller();
+                Configurable::update_contract_uri(self, caller, c.newURI, privileged)?;
+                Bytes::new()
+            }
+
+            // --- Role mutations ---
+            C::grantRole(c) => {
+                let caller = ctx.caller();
+                self.grant_role(caller, c.role, c.account, privileged)?;
+                Bytes::new()
+            }
+            C::revokeRole(c) => {
+                let caller = ctx.caller();
+                self.revoke_role(caller, c.role, c.account, privileged)?;
+                Bytes::new()
+            }
+            // Renounce operations are never factory-privileged: they are only meaningful for the
+            // role holder making the call after token creation.
+            C::renounceRole(c) => {
+                let caller = ctx.caller();
+                self.renounce_role(caller, c.role, c.callerConfirmation)?;
+                Bytes::new()
+            }
+            C::renounceLastAdmin(_) => {
+                let caller = ctx.caller();
+                self.renounce_last_admin(caller)?;
+                Bytes::new()
+            }
+            C::setRoleAdmin(c) => {
+                let caller = ctx.caller();
+                self.set_role_admin(caller, c.role, c.newAdminRole, privileged)?;
+                Bytes::new()
+            }
+
+            // --- Policy mutations ---
+            C::updatePolicy(c) => {
+                let caller = ctx.caller();
+                self.update_policy(caller, c.policyScope, c.newPolicyId, privileged)?;
+                Bytes::new()
+            }
+
+            // --- Permit ---
+            C::permit(c) => {
+                self.permit(
+                    ctx.chain_id(),
+                    ctx.timestamp(),
+                    PermitArgs {
+                        owner: c.owner,
+                        spender: c.spender,
+                        value: c.value,
+                        deadline: c.deadline,
+                        v: c.v,
+                        r: c.r,
+                        s: c.s,
+                    },
+                )?;
+                Bytes::new()
+            }
+        };
+        Ok(encoded)
+    }
+
+    fn handle_asset_call<O>(
+        &mut self,
+        ctx: StorageCtx<'_>,
+        call: SC,
+        privileged: bool,
+        observer: O,
+    ) -> base_precompile_storage::Result<Bytes>
+    where
+        O: PrecompileCallObserver,
+    {
+        let caller = ctx.caller();
+        let encoded: Bytes = match call {
+            // --- Role / precision constants ---
+            SC::OPERATOR_ROLE(_) => Self::OPERATOR_ROLE.abi_encode().into(),
+            SC::WAD_PRECISION(_) => B20AssetStorage::WAD.abi_encode().into(),
+
+            // --- Multiplier reads ---
+            SC::multiplier(_) => self.accounting().multiplier()?.abi_encode().into(),
+            SC::toScaledBalance(c) => self.to_scaled_balance(c.rawBalance)?.abi_encode().into(),
+            SC::toRawBalance(c) => self.to_raw_balance(c.scaledBalance)?.abi_encode().into(),
+            SC::scaledBalanceOf(c) => self.scaled_balance_of(c.account)?.abi_encode().into(),
+
+            // --- Announcement reads ---
+            SC::isAnnouncementIdUsed(c) => {
+                self.accounting().is_announcement_id_used(c.id.as_str())?.abi_encode().into()
+            }
+
+            // --- Extra metadata reads ---
+            SC::extraMetadata(c) => {
+                self.accounting().extra_metadata(c.key.as_str())?.abi_encode().into()
+            }
+
+            // --- Multiplier mutations ---
+            SC::updateMultiplier(c) => {
+                self.update_multiplier(caller, c.newMultiplier, privileged)?;
+                Bytes::new()
+            }
+
+            // --- Announcement ---
+            SC::announce(c) => {
+                self.announce(ctx, c, privileged, &observer)?;
+                Bytes::new()
+            }
+
+            // --- Batched mint ---
+            SC::batchMint(c) => {
+                observer.record_batch_items(
+                    &BerylAuxiliaryMetrics::b20("asset", "batchMint"),
+                    c.recipients.len(),
+                );
+                self.batch_mint(caller, c.recipients, c.amounts, privileged)?;
+                Bytes::new()
+            }
+
+            // --- Extra metadata mutations ---
+            SC::updateExtraMetadata(c) => {
+                self.update_extra_metadata(caller, c.key, c.value, privileged)?;
+                Bytes::new()
+            }
+        };
+        Ok(encoded)
+    }
+
+    /// Posts an announcement and atomically executes `internal_calls` via self-dispatch.
+    ///
+    /// The selector check in the inner loop prevents recursive invocation.
+    fn announce<O>(
+        &mut self,
+        ctx: StorageCtx<'_>,
+        call: IB20Asset::announceCall,
+        privileged: bool,
+        observer: &O,
+    ) -> base_precompile_storage::Result<()>
+    where
+        O: PrecompileCallObserver,
+    {
+        let caller = ctx.caller();
+        let internal_calls = call.internalCalls;
+        let internal_call_count = internal_calls.len();
+        let internal_call_bytes = internal_calls.iter().map(|call| call.len()).sum();
+        observer.record_internal_calls(
+            &BerylAuxiliaryMetrics::b20("asset", "announce"),
+            internal_call_count,
+            internal_call_bytes,
+        );
+        self.ensure_operator_role(caller, privileged)?;
+
+        let id = call.id;
+        if self.accounting().is_announcement_id_used(id.as_str())? {
+            return Err(BasePrecompileError::revert(IB20Asset::AnnouncementIdAlreadyUsed { id }));
+        }
+        self.accounting_mut().mark_announcement_id_used(id.as_str())?;
+
+        self.accounting_mut().emit_event(
+            IB20Asset::Announcement {
+                caller,
+                id: id.clone(),
+                description: call.description,
+                uri: call.uri,
+            }
+            .encode_log_data(),
+        )?;
+
+        // Each internal call is dispatched via `inner_with_privilege`, a direct Rust function
+        // call. Unlike the base-std Solidity reference which routes each `internalCalls` entry
+        // through a DELEGATECALL (~100 gas opcode overhead + memory expansion), the native
+        // precompile replaces the entire EVM execution path so per-opcode call overhead does not
+        // apply. The cheaper batched cost is intentional: the native precompile pays for the
+        // storage work of each sub-call (the same SLOAD/SSTORE operations as the Solidity
+        // reference) but not for EVM call-frame overhead that exists only in the interpreter.
+        for call in &internal_calls {
+            let call_bytes: &[u8] = call.as_ref();
+            if call_bytes.len() < 4 {
+                return Err(BasePrecompileError::revert(IB20Asset::InternalCallMalformed {
+                    call: call.clone(),
+                }));
+            }
+            if call_bytes[..4] == IB20Asset::announceCall::SELECTOR {
+                return Err(BasePrecompileError::revert(IB20Asset::AnnouncementInProgress {}));
+            }
+            self.inner_with_privilege(ctx, call_bytes, privileged).map_err(|err| {
+                if err.is_system_error() {
+                    err
+                } else {
+                    BasePrecompileError::revert(IB20Asset::InternalCallFailed {
+                        call: call.clone(),
+                    })
+                }
+            })?;
+        }
+
+        self.accounting_mut().emit_event(IB20Asset::EndAnnouncement { id }.encode_log_data())
+    }
+}

--- a/crates/common/precompiles/src/b20_asset/mod.rs
+++ b/crates/common/precompiles/src/b20_asset/mod.rs
@@ -8,6 +8,12 @@ pub use accounting::AssetAccounting;
 
 mod dispatch;
 
+mod versions;
+pub use versions::{B20AssetVersion, B20AssetVersionId, B20AssetVersions};
+
+mod logic;
+pub use logic::B20AssetV1;
+
 mod precompile;
 pub use precompile::B20AssetPrecompile;
 

--- a/crates/common/precompiles/src/b20_asset/precompile.rs
+++ b/crates/common/precompiles/src/b20_asset/precompile.rs
@@ -5,7 +5,7 @@ use alloy_primitives::Address;
 use base_common_genesis::BaseUpgrade;
 
 use crate::{
-    B20AssetStorage, B20AssetToken, NoopPrecompileCallObserver, PolicyHandle,
+    B20AssetStorage, B20AssetToken, B20AssetVersions, NoopPrecompileCallObserver, PolicyHandle,
     PrecompileCallObserver, macros::base_precompile,
 };
 
@@ -17,33 +17,38 @@ use crate::{
 pub struct B20AssetPrecompile;
 
 impl B20AssetPrecompile {
-    /// Returns a [`DynPrecompile`] that dispatches to [`B20AssetToken`] logic at
-    /// `token_address` for `upgrade`.
-    pub fn create_precompile(token_address: Address, upgrade: BaseUpgrade) -> DynPrecompile {
+    /// Returns a [`DynPrecompile`] that dispatches to the [`B20AssetToken`] logic
+    /// active at `upgrade`, or `None` before B-20 activation (pre-Beryl).
+    pub fn create_precompile(
+        token_address: Address,
+        upgrade: BaseUpgrade,
+    ) -> Option<DynPrecompile> {
         Self::create_precompile_with_observer(token_address, NoopPrecompileCallObserver, upgrade)
     }
 
-    /// Returns a [`DynPrecompile`] that observes and dispatches to [`B20AssetToken`] logic at
-    /// `token_address` for `upgrade`.
+    /// Returns a [`DynPrecompile`] that observes and dispatches to the
+    /// [`B20AssetToken`] logic active at `upgrade`, or `None` before B-20
+    /// activation (pre-Beryl).
     ///
-    /// The `_upgrade` fork signal is threaded here in Phase 0 but not yet used to
-    /// select execution logic; behavior is identical across forks. Phase 1 uses
-    /// it to resolve the active [`B20AssetToken`] version.
+    /// The version is resolved once here (at install time) via
+    /// [`B20AssetVersions::resolve`] and baked into the precompile closure, so
+    /// the per-call dispatch path stays free of fork branching.
     pub fn create_precompile_with_observer<O>(
         token_address: Address,
         observer: O,
-        _upgrade: BaseUpgrade,
-    ) -> DynPrecompile
+        upgrade: BaseUpgrade,
+    ) -> Option<DynPrecompile>
     where
         O: PrecompileCallObserver,
     {
-        base_precompile!(alloc::format!("B20AssetToken@{token_address}"), |ctx, calldata| {
+        let version = B20AssetVersions::resolve(upgrade)?;
+        Some(base_precompile!(alloc::format!("B20AssetToken@{token_address}"), |ctx, calldata| {
             let observer = observer.clone();
             B20AssetToken::with_storage_and_policy(
                 B20AssetStorage::from_address(token_address, ctx),
                 PolicyHandle::new(ctx),
             )
-            .dispatch_with_observer(ctx, &calldata, observer)
-        })
+            .dispatch_with_version(ctx, &calldata, observer, version)
+        }))
     }
 }

--- a/crates/common/precompiles/src/b20_asset/precompile.rs
+++ b/crates/common/precompiles/src/b20_asset/precompile.rs
@@ -2,6 +2,7 @@
 
 use alloy_evm::precompiles::DynPrecompile;
 use alloy_primitives::Address;
+use base_common_genesis::BaseUpgrade;
 
 use crate::{
     B20AssetStorage, B20AssetToken, NoopPrecompileCallObserver, PolicyHandle,
@@ -17,14 +18,22 @@ pub struct B20AssetPrecompile;
 
 impl B20AssetPrecompile {
     /// Returns a [`DynPrecompile`] that dispatches to [`B20AssetToken`] logic at
-    /// `token_address`.
-    pub fn create_precompile(token_address: Address) -> DynPrecompile {
-        Self::create_precompile_with_observer(token_address, NoopPrecompileCallObserver)
+    /// `token_address` for `upgrade`.
+    pub fn create_precompile(token_address: Address, upgrade: BaseUpgrade) -> DynPrecompile {
+        Self::create_precompile_with_observer(token_address, NoopPrecompileCallObserver, upgrade)
     }
 
     /// Returns a [`DynPrecompile`] that observes and dispatches to [`B20AssetToken`] logic at
-    /// `token_address`.
-    pub fn create_precompile_with_observer<O>(token_address: Address, observer: O) -> DynPrecompile
+    /// `token_address` for `upgrade`.
+    ///
+    /// The `_upgrade` fork signal is threaded here in Phase 0 but not yet used to
+    /// select execution logic; behavior is identical across forks. Phase 1 uses
+    /// it to resolve the active [`B20AssetToken`] version.
+    pub fn create_precompile_with_observer<O>(
+        token_address: Address,
+        observer: O,
+        _upgrade: BaseUpgrade,
+    ) -> DynPrecompile
     where
         O: PrecompileCallObserver,
     {

--- a/crates/common/precompiles/src/b20_asset/versions.rs
+++ b/crates/common/precompiles/src/b20_asset/versions.rs
@@ -1,0 +1,117 @@
+//! Fork→version resolution and the execution-logic seam for `b20_asset`.
+//!
+//! [`B20AssetVersion`] is the seam every version implements: a single
+//! [`run`](B20AssetVersion::run) entry that performs selector routing plus the
+//! business logic for that version (see [`crate::b20_asset::logic`]).
+//! [`B20AssetVersions::resolve`] centralizes the fork→version mapping so
+//! hardfork logic is auditable in one place and resolved once at install time.
+//!
+//! Unlike the `foo` reference precompile, B20 logic is generic over storage
+//! (`S`), policy (`P`), and observer (`O`), so [`B20AssetVersion::run`] carries
+//! those as generic type parameters. A generic method makes the trait
+//! object-unsafe, so the resolver hands back a small `'static`, `Copy`
+//! [`B20AssetVersionId`] enum that is dispatched statically, rather than a
+//! `&'static dyn B20AssetVersion` trait object. (`foo` can use `&'static dyn`
+//! only because its storage type is concrete and `'static`; B20's
+//! [`B20AssetStorage`](crate::B20AssetStorage)`<'a>` borrows the call's
+//! `StorageCtx`, so it is never `'static`.)
+
+use alloy_primitives::Bytes;
+use base_common_genesis::BaseUpgrade;
+use base_precompile_storage::{Result, StorageCtx};
+
+use crate::{AssetAccounting, B20AssetToken, B20AssetV1, Policy, PrecompileCallObserver};
+
+/// The execution-logic seam every `b20_asset` version implements.
+///
+/// A version fully owns "which selectors exist and what they do":
+/// [`run`](Self::run) is the relocated `inner_with_observer` routing. Storage
+/// layout and the ABI stay shared across versions (they are cross-version
+/// invariants); routing and behavior do not.
+pub trait B20AssetVersion {
+    /// Routes `calldata` to this version's selectors and executes the matching
+    /// business logic against `token`, returning the ABI-encoded output (or an
+    /// error/revert).
+    ///
+    /// Generic over storage (`S`), policy (`P`), and observer (`O`) because B20
+    /// logic lives on the generic [`B20AssetToken`] and dispatch threads a
+    /// generic observer.
+    fn run<S, P, O>(
+        &self,
+        token: &mut B20AssetToken<S, P>,
+        ctx: StorageCtx<'_>,
+        calldata: &[u8],
+        observer: O,
+    ) -> Result<Bytes>
+    where
+        S: AssetAccounting,
+        P: Policy,
+        O: PrecompileCallObserver;
+}
+
+/// The `b20_asset` execution-logic version active at a given hardfork.
+///
+/// Resolved once at install time by [`B20AssetVersions::resolve`] and threaded
+/// as a `'static`, `Copy` handle into the shared dispatch entry, which forwards
+/// to the matching self-contained version via static dispatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum B20AssetVersionId {
+    /// Logic active from Beryl onward — today's behavior, wrapped verbatim as V1.
+    V1,
+}
+
+impl B20AssetVersionId {
+    /// Runs the resolved version's selector routing and business logic against
+    /// `token`, selecting the concrete [`B20AssetVersion`] implementation for
+    /// this fork.
+    pub fn run<S, P, O>(
+        self,
+        token: &mut B20AssetToken<S, P>,
+        ctx: StorageCtx<'_>,
+        calldata: &[u8],
+        observer: O,
+    ) -> Result<Bytes>
+    where
+        S: AssetAccounting,
+        P: Policy,
+        O: PrecompileCallObserver,
+    {
+        match self {
+            Self::V1 => B20AssetV1.run(token, ctx, calldata, observer),
+        }
+    }
+}
+
+/// Fork→version resolver for the `b20_asset` precompile.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct B20AssetVersions;
+
+impl B20AssetVersions {
+    /// Returns the version active at `upgrade`, or `None` before Beryl (where the
+    /// B-20 precompiles are not installed at all).
+    pub fn resolve(upgrade: BaseUpgrade) -> Option<B20AssetVersionId> {
+        (upgrade >= BaseUpgrade::Beryl).then_some(B20AssetVersionId::V1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base_common_genesis::BaseUpgrade;
+
+    use crate::{B20AssetVersionId, B20AssetVersions};
+
+    #[test]
+    fn resolves_none_before_beryl() {
+        assert!(B20AssetVersions::resolve(BaseUpgrade::Azul).is_none());
+    }
+
+    #[test]
+    fn resolves_v1_from_beryl() {
+        assert_eq!(B20AssetVersions::resolve(BaseUpgrade::Beryl), Some(B20AssetVersionId::V1));
+    }
+
+    #[test]
+    fn resolves_v1_from_cobalt() {
+        assert_eq!(B20AssetVersions::resolve(BaseUpgrade::Cobalt), Some(B20AssetVersionId::V1));
+    }
+}

--- a/crates/common/precompiles/src/b20_stablecoin/precompile.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/precompile.rs
@@ -2,6 +2,7 @@
 
 use alloy_evm::precompiles::DynPrecompile;
 use alloy_primitives::Address;
+use base_common_genesis::BaseUpgrade;
 
 use crate::{
     B20StablecoinStorage, B20StablecoinToken, NoopPrecompileCallObserver, PolicyHandle,
@@ -16,14 +17,22 @@ pub struct B20StablecoinPrecompile;
 
 impl B20StablecoinPrecompile {
     /// Returns a [`DynPrecompile`] that dispatches to [`B20StablecoinToken`] logic at
-    /// `token_address`.
-    pub fn create_precompile(token_address: Address) -> DynPrecompile {
-        Self::create_precompile_with_observer(token_address, NoopPrecompileCallObserver)
+    /// `token_address` for `upgrade`.
+    pub fn create_precompile(token_address: Address, upgrade: BaseUpgrade) -> DynPrecompile {
+        Self::create_precompile_with_observer(token_address, NoopPrecompileCallObserver, upgrade)
     }
 
     /// Returns a [`DynPrecompile`] that observes and dispatches to [`B20StablecoinToken`] logic at
-    /// `token_address`.
-    pub fn create_precompile_with_observer<O>(token_address: Address, observer: O) -> DynPrecompile
+    /// `token_address` for `upgrade`.
+    ///
+    /// The stablecoin variant is not version-seamed in this change, so `_upgrade`
+    /// is accepted for signature parity with the asset variant but intentionally
+    /// unused — behavior is identical across forks.
+    pub fn create_precompile_with_observer<O>(
+        token_address: Address,
+        observer: O,
+        _upgrade: BaseUpgrade,
+    ) -> DynPrecompile
     where
         O: PrecompileCallObserver,
     {

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -59,7 +59,7 @@ pub use metrics::{
 mod b20_asset;
 pub use b20_asset::{
     AssetAccounting, B20AssetExtensionStorage, B20AssetInit, B20AssetPrecompile, B20AssetStorage,
-    B20AssetToken, IB20Asset,
+    B20AssetToken, B20AssetV1, B20AssetVersion, B20AssetVersionId, B20AssetVersions, IB20Asset,
 };
 
 mod b20_stablecoin;

--- a/crates/common/precompiles/src/lookup.rs
+++ b/crates/common/precompiles/src/lookup.rs
@@ -2,6 +2,7 @@
 
 use alloy_evm::precompiles::{DynPrecompile, PrecompileLookup, PrecompilesMap};
 use alloy_primitives::Address;
+use base_common_genesis::BaseUpgrade;
 
 use crate::{
     B20AssetPrecompile, B20StablecoinPrecompile, B20Variant, NoopPrecompileCallObserver,
@@ -13,35 +14,48 @@ use crate::{
 pub struct BerylLookup;
 
 impl BerylLookup {
-    /// Installs the Beryl dynamic precompile lookup into `precompiles`.
-    pub fn install(precompiles: &mut PrecompilesMap) {
-        Self::install_with_observer(precompiles, NoopPrecompileCallObserver);
+    /// Installs the Beryl dynamic precompile lookup into `precompiles`, routing
+    /// B-20 token versions for `upgrade`.
+    pub fn install(precompiles: &mut PrecompilesMap, upgrade: BaseUpgrade) {
+        Self::install_with_observer(precompiles, NoopPrecompileCallObserver, upgrade);
     }
 
-    /// Installs the Beryl dynamic precompile lookup with an observer into `precompiles`.
-    pub fn install_with_observer<O>(precompiles: &mut PrecompilesMap, observer: O)
-    where
+    /// Installs the Beryl dynamic precompile lookup with an observer into
+    /// `precompiles`, routing B-20 token versions for `upgrade`.
+    pub fn install_with_observer<O>(
+        precompiles: &mut PrecompilesMap,
+        observer: O,
+        upgrade: BaseUpgrade,
+    ) where
         O: PrecompileCallObserver,
     {
-        precompiles.set_precompile_lookup(BerylLookupWithObserver::new(observer));
+        precompiles.set_precompile_lookup(BerylLookupWithObserver::new(observer, upgrade));
     }
 
-    /// Returns the B-20 variant precompile for `address`, if it encodes one.
-    pub fn lookup(address: &Address) -> Option<DynPrecompile> {
-        Self::lookup_with_observer(address, NoopPrecompileCallObserver)
+    /// Returns the B-20 variant precompile for `address` under `upgrade`, if it
+    /// encodes one.
+    pub fn lookup(address: &Address, upgrade: BaseUpgrade) -> Option<DynPrecompile> {
+        Self::lookup_with_observer(address, NoopPrecompileCallObserver, upgrade)
     }
 
-    /// Returns an observed B-20 variant precompile for `address`, if it encodes one.
-    pub fn lookup_with_observer<O>(address: &Address, observer: O) -> Option<DynPrecompile>
+    /// Returns an observed B-20 variant precompile for `address` under `upgrade`,
+    /// if it encodes one.
+    pub fn lookup_with_observer<O>(
+        address: &Address,
+        observer: O,
+        upgrade: BaseUpgrade,
+    ) -> Option<DynPrecompile>
     where
         O: PrecompileCallObserver,
     {
         match B20Variant::from_address(*address)? {
-            B20Variant::Stablecoin => {
-                Some(B20StablecoinPrecompile::create_precompile_with_observer(*address, observer))
-            }
+            B20Variant::Stablecoin => Some(
+                B20StablecoinPrecompile::create_precompile_with_observer(
+                    *address, observer, upgrade,
+                ),
+            ),
             B20Variant::Asset => {
-                Some(B20AssetPrecompile::create_precompile_with_observer(*address, observer))
+                Some(B20AssetPrecompile::create_precompile_with_observer(*address, observer, upgrade))
             }
         }
     }
@@ -51,12 +65,14 @@ impl BerylLookup {
 #[derive(Debug, Clone)]
 pub struct BerylLookupWithObserver<O> {
     observer: O,
+    upgrade: BaseUpgrade,
 }
 
 impl<O> BerylLookupWithObserver<O> {
-    /// Creates a Beryl dynamic precompile lookup with `observer`.
-    pub const fn new(observer: O) -> Self {
-        Self { observer }
+    /// Creates a Beryl dynamic precompile lookup with `observer`, routing B-20
+    /// token versions for `upgrade`.
+    pub const fn new(observer: O, upgrade: BaseUpgrade) -> Self {
+        Self { observer, upgrade }
     }
 }
 
@@ -65,6 +81,6 @@ where
     O: PrecompileCallObserver,
 {
     fn lookup(&self, address: &Address) -> Option<DynPrecompile> {
-        BerylLookup::lookup_with_observer(address, self.observer.clone())
+        BerylLookup::lookup_with_observer(address, self.observer.clone(), self.upgrade)
     }
 }

--- a/crates/common/precompiles/src/lookup.rs
+++ b/crates/common/precompiles/src/lookup.rs
@@ -55,7 +55,7 @@ impl BerylLookup {
                 ),
             ),
             B20Variant::Asset => {
-                Some(B20AssetPrecompile::create_precompile_with_observer(*address, observer, upgrade))
+                B20AssetPrecompile::create_precompile_with_observer(*address, observer, upgrade)
             }
         }
     }

--- a/crates/common/precompiles/src/provider.rs
+++ b/crates/common/precompiles/src/provider.rs
@@ -205,7 +205,7 @@ impl<S: BasePrecompileSpec> BasePrecompiles<S> {
         // design, since metrics are scoped to the B-20 token call path.
         if self.spec.upgrade() >= BaseUpgrade::Beryl {
             B20Factory::install_with_observer(&mut precompiles, observer.clone());
-            BerylLookup::install_with_observer(&mut precompiles, observer.clone());
+            BerylLookup::install_with_observer(&mut precompiles, observer.clone(), self.spec.upgrade());
             PolicyRegistryPrecompile::install_with_observer(&mut precompiles, observer.clone());
             ActivationRegistry::install_with_observer(
                 &mut precompiles,


### PR DESCRIPTION
## Summary

Applies the P/PS "Option 3 / hybrid" versioning pattern to the B20 asset
precompile: shared ABI + storage + dispatch **entry** (append-only), with
per-version **self-contained** logic + selector routing, selected by a single
fork→version resolver. Storage and the ABI are **not** duplicated per version.

This is delivered as **Phase 0 + Phase 1** (two commits), wrapping today's
behavior as **V1 with zero behavior change**. The existing `b20` test suite
passes **unedited** — that is the proof of "no behavior change."

## Phase 0 — thread the current hardfork (`BaseUpgrade`) into the B20 lookup

B20 tokens are resolved per token-address by `BerylLookup`, a path that
previously carried **no fork signal**. Phase 0 threads it (pure plumbing,
byte-identical behavior):

- `lookup.rs`: `BerylLookupWithObserver` now stores `upgrade`;
  `install`/`install_with_observer`/`lookup`/`lookup_with_observer` accept a
  `BaseUpgrade` and pass it through to the `create_precompile*` calls.
- `b20_asset` / `b20_stablecoin` `create_precompile*` signatures accept
  `upgrade`. In Phase 0 both **accept and ignore** it (`_upgrade`).
- `provider.rs`: installs `BerylLookup` with `self.spec.upgrade()`. The
  precompiles map is already built per-spec (`BasePrecompiles::new_with_spec`
  matches on `spec.upgrade()`), so the active fork is known at install time.

## Phase 1 — version seam on `b20_asset`, wrap today's logic as V1 (code motion)

- **SHARED (unchanged):** `abi.rs`, `storage.rs`, `accounting.rs`, and the
  dispatch **entry** in `dispatch.rs` (non-payable check, calldata-gas
  deduction, init check, observer/recorder plumbing).
- **NEW `versions.rs`:** the `B20AssetVersion` seam trait + `B20AssetVersions::resolve(upgrade)`
  returning `Some(B20AssetVersionId::V1)` from `BaseUpgrade::Beryl` onward, else `None`.
- **NEW `logic/{mod,v1}.rs`:** the selector routing (`inner*`, `handle_b20_call`,
  `handle_asset_call`, `announce`) is **relocated verbatim** (code motion, no
  logic change). `B20AssetV1` (a ZST) implements the seam by delegating to the
  moved `inner_with_observer` routing.
- **`dispatch.rs`:** the shared entry now resolves to a version and delegates:
  after the init check it calls `version.run(self, ctx, calldata, observer)`.
  `dispatch_with_observer` is preserved as a V1 convenience for existing callers
  and tests; the new fork-routed entry is `dispatch_with_version`.
- **`precompile.rs`:** `create_precompile*` resolve via `B20AssetVersions::resolve(upgrade)`
  and return `Option<DynPrecompile>`; `None` (pre-Beryl) does not register.
  `lookup.rs` threads that `None` through.

Phase 1 is `b20_asset` **only**. The stablecoin variant received only the
Phase-0 signature change (accepts and ignores `upgrade`); its logic is not
restructured. Storage/ABI are not duplicated; B20 business logic is not rewritten.

## No behavior change — existing tests pass unedited

The `#[cfg(test)] mod tests` block in `b20_asset/dispatch.rs` is **byte-identical**
to `main`, and `token.rs`'s tests are untouched. No test bodies were edited.
Phase 1 added only new resolver unit tests in `versions.rs` (the `+3`).

## Design decision / compromise on the generic seam

The plan's ideal seam is `B20AssetVersions::resolve(upgrade) -> Option<&'static dyn B20AssetVersion>`.
That is **intractable here**, and this PR takes the documented compromise:

- B20 logic lives on the generic `B20AssetToken<S: AssetAccounting, P: Policy>`
  and dispatch threads a generic `O: PrecompileCallObserver`, so the seam's
  `run<S, P, O>(..)` method is **generic** → the trait is **object-unsafe**
  (no `&dyn`).
- Even a generic-**parameter** trait (`dyn B20AssetVersion<S, P, O>`) can't be
  `&'static`, because in the real path `S = B20AssetStorage<'ctx>` borrows the
  call's `StorageCtx` and is **never `'static`** (unlike `foo`, whose storage is
  concrete and `'static`, which is why `foo` can use `&'static dyn FooVersion: Sync`).

**Chosen structure:** keep the `B20AssetVersion` trait as the extensible per-version
seam (implemented by the `B20AssetV1` ZST), and have `B20AssetVersions::resolve`
return a small `'static`, `Copy` enum `B20AssetVersionId` that is dispatched
**statically** (`match self { V1 => B20AssetV1.run(..) }`). This compiles cleanly,
preserves behavior, centralizes fork→version resolution in one resolver, and keeps
V1's routing in its own file (`logic/v1.rs`). A side benefit: static dispatch means
the seam needs no `Sync` bound (foo required `Sync` only for the `&dyn` closure capture).

## Open risks for reviewers

- The relocated routing methods (`inner*`, `handle_*`, `announce`) remain
  **inherent methods on `B20AssetToken<S,P>`** (just moved into `logic/v1.rs`),
  because `announce` self-recurses via `inner_with_privilege` and existing tests
  call `token.inner(..)` directly. V1's trait impl is the thin seam adapter over
  them. This is deliberate: it keeps the move a true no-op and tests unedited.
- The shared token **business** methods (transfer/mint/`batch_mint`/multiplier/…)
  stay in `token.rs` (shared, generic), invoked by V1's routing. V1 owns "which
  selectors exist and what they do"; it does not fork the arithmetic. Moving those
  buys no isolation (storage is shared) and would only add churn.
- `create_precompile*` now returns `Option<DynPrecompile>`. In the installed
  provider the lookup only exists for `>= Beryl`, where `resolve` is always
  `Some`, so this is byte-identical in practice; the `None` arm is a defensive
  pre-Beryl guard (address simply not registered).

## Test plan

- `cargo test -p base-common-precompiles b20` → **97 passed, 0 failed** (94 pre-existing + 3 new resolver tests).
- `cargo test -p base-common-precompiles --lib` → **429 passed, 0 failed** (full crate).
- `cargo clippy -p base-common-precompiles --all-targets` → **clean** (no `#[allow(...)]` used).
