### PR TITLE
chore(snark-e2e): Extract snark-e2e from zk-service into crates/infra

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6302,7 +6302,28 @@ dependencies = [
 name = "base-snark-e2e"
 version = "0.0.0"
 dependencies = [
- "base-zk-service",
+ "alloy-primitives",
+ "alloy-provider 2.0.5",
+ "alloy-rpc-types 2.0.5",
+ "anyhow",
+ "base-common-network",
+ "base-l1-head",
+ "base-proof-succinct-proof-utils",
+ "base-prover-service-client",
+ "base-prover-service-protocol",
+ "bincode 2.0.1",
+ "sp1-sdk",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.23",
+ "uuid",
+]
+
+[[package]]
+name = "base-snark-e2e-bin"
+version = "0.0.0"
+dependencies = [
+ "base-snark-e2e",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.23",
@@ -6661,7 +6682,6 @@ dependencies = [
  "tower 0.5.3",
  "tower-http",
  "tracing",
- "tracing-subscriber 0.3.23",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ members = [
   "bin/*",
   "bin/prover/nitro-host",
   "bin/prover/nitro-enclave",
-  "bin/prover/snark-e2e",
   "bin/prover/zk",
   "bin/prover/zk-host",
   "bin/prover/service",
@@ -69,7 +68,6 @@ default-members = [
   "bin/prover/nitro-host",
   "bin/prover/nitro-enclave",
   "bin/prover/zk",
-  "bin/prover/snark-e2e",
   "bin/prover/service",
   "bin/prover-registrar",
 ]
@@ -227,6 +225,7 @@ base-execution-eip8130-rpc-node = { path = "crates/execution/eip8130-rpc-node" }
 basectl-cli = { path = "crates/infra/basectl" }
 base-sidecrush = { path = "crates/infra/sidecrush" }
 audit-archiver-lib = { path = "crates/infra/audit" }
+base-snark-e2e = { path = "crates/infra/snark-e2e" }
 base-load-tests = { path = "crates/infra/load-tests" }
 ingress-rpc-lib = { path = "crates/infra/ingress-rpc" }
 base-snapshotter = { path = "crates/infra/snapshotter" }

--- a/bin/snark-e2e/Cargo.toml
+++ b/bin/snark-e2e/Cargo.toml
@@ -16,9 +16,7 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-base-snark-e2e = { workspace = true }
-
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["fmt", "json", "env-filter"] }
-
+base-snark-e2e = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+tracing-subscriber = { workspace = true, features = ["fmt", "json", "env-filter"] }

--- a/bin/snark-e2e/Cargo.toml
+++ b/bin/snark-e2e/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "base-snark-e2e"
+name = "base-snark-e2e-bin"
 description = "Standalone SNARK Groth16 E2E test binary for K8s CronJob execution"
 version.workspace = true
 edition.workspace = true
@@ -16,9 +16,9 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-base-zk-service.workspace = true
+base-snark-e2e = { workspace = true }
 
-tracing.workspace = true
+tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt", "json", "env-filter"] }
 
 tokio = { workspace = true, features = ["full"] }

--- a/bin/snark-e2e/src/main.rs
+++ b/bin/snark-e2e/src/main.rs
@@ -8,7 +8,7 @@ async fn main() {
 
     tracing::info!("starting SNARK Groth16 E2E test");
 
-    if let Err(e) = base_zk_service::SnarkE2e::run().await {
+    if let Err(e) = base_snark_e2e::SnarkE2e::run().await {
         tracing::error!(error = %e, error_debug = ?e, "SNARK E2E test failed");
         std::process::exit(1);
     }

--- a/crates/infra/snark-e2e/Cargo.toml
+++ b/crates/infra/snark-e2e/Cargo.toml
@@ -13,17 +13,17 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-uuid = { workspace = true, features = ["v4"] }
-tracing = { workspace = true }
 sp1-sdk = { workspace = true }
+tracing = { workspace = true }
 base-l1-head = { workspace = true }
 alloy-provider = { workspace = true }
-alloy-primitives = { workspace = true }
 alloy-rpc-types = { workspace = true }
+alloy-primitives = { workspace = true }
 base-common-network = { workspace = true }
-bincode = { workspace = true, features = ["serde"] }
+uuid = { workspace = true, features = ["v4"] }
 base-prover-service-client = { workspace = true }
 base-prover-service-protocol = { workspace = true }
+bincode = { workspace = true, features = ["serde"] }
 base-proof-succinct-proof-utils = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 

--- a/crates/infra/snark-e2e/Cargo.toml
+++ b/crates/infra/snark-e2e/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "base-snark-e2e"
+description = "SNARK Groth16 end-to-end prover verification for K8s CronJob execution"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
+tracing = { workspace = true }
+sp1-sdk = { workspace = true }
+base-l1-head = { workspace = true }
+alloy-provider = { workspace = true }
+alloy-primitives = { workspace = true }
+alloy-rpc-types = { workspace = true }
+base-common-network = { workspace = true }
+bincode = { workspace = true, features = ["serde"] }
+base-prover-service-client = { workspace = true }
+base-prover-service-protocol = { workspace = true }
+base-proof-succinct-proof-utils = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }

--- a/crates/infra/snark-e2e/README.md
+++ b/crates/infra/snark-e2e/README.md
@@ -17,7 +17,6 @@ claims SNARK jobs.
 | `L1_NODE_ADDRESS` | Yes | L1 execution RPC (finalized check) |
 | `BASE_CONSENSUS_ADDRESS` | Yes | Op-node / consensus RPC (L1 origin) |
 | `PROVER_RPC_ADDR` | No (default `http://localhost:9000`) | Prover-service requester JSON-RPC |
-| `BACKEND` | No | Set to `mock` for `MockProver` verification |
 
 ## Usage
 

--- a/crates/infra/snark-e2e/README.md
+++ b/crates/infra/snark-e2e/README.md
@@ -1,0 +1,39 @@
+# `base-snark-e2e`
+
+SNARK Groth16 end-to-end prover verification library.
+
+Submits a one-block SNARK prove request to the JSON-RPC prover-service requester
+API, polls until completion, and cryptographically verifies the receipt. Used by
+the `base-snark-e2e` binary (K8s `CronJob`) and an ignored integration test.
+
+Requires a running `base-prover-service` requester plus a zk-host worker that
+claims SNARK jobs.
+
+## Required environment
+
+| Variable | Required | Purpose |
+|----------|----------|---------|
+| `L2_NODE_ADDRESS` | Yes | L2 execution RPC |
+| `L1_NODE_ADDRESS` | Yes | L1 execution RPC (finalized check) |
+| `BASE_CONSENSUS_ADDRESS` | Yes | Op-node / consensus RPC (L1 origin) |
+| `PROVER_RPC_ADDR` | No (default `http://localhost:9000`) | Prover-service requester JSON-RPC |
+| `BACKEND` | No | Set to `mock` for `MockProver` verification |
+
+## Usage
+
+```toml
+[dependencies]
+base-snark-e2e = { workspace = true }
+```
+
+```rust,ignore
+use base_snark_e2e::SnarkE2e;
+
+SnarkE2e::run().await?;
+```
+
+## Integration test
+
+```bash
+cargo nextest run --run-ignored all -p base-snark-e2e --test snark_groth16_e2e
+```

--- a/crates/infra/snark-e2e/src/lib.rs
+++ b/crates/infra/snark-e2e/src/lib.rs
@@ -1,0 +1,4 @@
+#![doc = include_str!("../README.md")]
+
+mod snark_e2e;
+pub use snark_e2e::SnarkE2e;

--- a/crates/infra/snark-e2e/src/snark_e2e.rs
+++ b/crates/infra/snark-e2e/src/snark_e2e.rs
@@ -1,28 +1,28 @@
 //! Shared SNARK Groth16 end-to-end test logic.
 //!
 //! Used by both the integration test (`tests/snark_groth16_e2e.rs`) and the
-//! standalone binary (`bin/prover/zk/src/bin/snark_e2e.rs`) that runs as a K8s
-//! `CronJob`.
+//! standalone binary (`bin/snark-e2e`) that runs as a K8s `CronJob`.
+//!
+//! Talks to the JSON-RPC prover-service requester API (`prover_proveBlockRange`
+//! / `prover_getProof`), not the legacy zk gRPC service.
 
+use alloy_primitives::Address;
 use alloy_provider::{Identity, Provider, ProviderBuilder};
 use alloy_rpc_types::{BlockId, BlockNumberOrTag};
 use anyhow::{Context, Result, bail};
 use base_common_network::Base;
-use base_zk_client::{
-    GetProofRequest, ProveBlockRequest, get_proof_response,
-    prover_service_client::ProverServiceClient,
+use base_l1_head::L1HeadCalculator;
+use base_prover_service_client::{ProofRequesterClient, ProverServiceClientConfig};
+use base_prover_service_protocol::{
+    GetProofRequest, ProofRequest, ProofRequestKind, ProofResult, ProofStatus,
+    ProveBlockRangeRequest, SnarkGroth16ProofRequest, ZkProofRequest, ZkVm,
 };
 use sp1_sdk::{
     SP1ProofWithPublicValues, SP1VerifyingKey,
     blocking::{CpuProver, MockProver, Prover as BlockingProver},
 };
-use tonic::transport::Channel;
 use tracing::{info, warn};
-
-use crate::L1HeadCalculator;
-
-const PROOF_TYPE_SNARK_GROTH16: i32 = 4;
-const RECEIPT_TYPE_SNARK: i32 = 2; // ReceiptType::Snark
+use uuid::Uuid;
 
 const POLL_INTERVAL_SECS: u64 = 30;
 const POLL_TIMEOUT_SECS: u64 = 14400; // 4 hours
@@ -44,15 +44,13 @@ const MAX_STEP_BACKS: u64 = 300;
 pub struct SnarkE2e;
 
 impl SnarkE2e {
-    async fn connect() -> Result<ProverServiceClient<Channel>> {
-        let addr = std::env::var("PROVER_GRPC_ADDR")
-            .unwrap_or_else(|_| "http://localhost:9090".to_string());
+    fn connect() -> Result<ProofRequesterClient> {
+        let addr = std::env::var("PROVER_RPC_ADDR")
+            .unwrap_or_else(|_| "http://localhost:9000".to_string());
 
         info!(addr = %addr, "connecting to prover-service");
-        let client = ProverServiceClient::connect(addr)
-            .await
-            .context("failed to connect to prover-service")?;
-        Ok(client)
+        let config = ProverServiceClientConfig::new(&addr);
+        ProofRequesterClient::connect(&config).context("failed to connect to prover-service")
     }
 
     /// Verify the SNARK proof using the appropriate prover for the backend.
@@ -101,13 +99,24 @@ impl SnarkE2e {
         Ok(())
     }
 
+    /// Extract SNARK receipt bytes from a successful getProof response.
+    fn snark_receipt_bytes(result: ProofResult) -> Result<Vec<u8>> {
+        match result {
+            ProofResult::SnarkGroth16(r) => Ok(r.proof.proof.to_vec()),
+            ProofResult::Compressed(_) => {
+                bail!("expected SnarkGroth16 proof result, got Compressed")
+            }
+            ProofResult::Tee(_) => bail!("expected SnarkGroth16 proof result, got Tee"),
+        }
+    }
+
     /// Run the full SNARK Groth16 E2E test pipeline:
     ///
     /// 1. Query the L2 node for the safe head block (guaranteed derived from
     ///    L1)
-    /// 2. Submit a `ProveBlock` request with `proof_type=4` (SNARK Groth16)
+    /// 2. Submit a `prover_proveBlockRange` request for `SnarkGroth16`
     ///    - `l1_head` is omitted so the prover service calculates it via `SafeDB`
-    /// 3. Poll `GetProof` with `receipt_type=SNARK` until completion or timeout
+    /// 3. Poll `prover_getProof` until completion or timeout
     /// 4. Deserialize the SNARK receipt
     /// 5. Compute the aggregation verifying key
     /// 6. Verify the SNARK proof (`MockProver` or `CpuProver` based on BACKEND)
@@ -172,8 +181,8 @@ impl SnarkE2e {
             let l1_origin = L1HeadCalculator::get_l1_origin_num(&op_provider, target_block)
                 .await
                 .with_context(|| {
-                format!("failed to fetch L1 origin for target L2 block {target_block}")
-            })?;
+                    format!("failed to fetch L1 origin for target L2 block {target_block}")
+                })?;
 
             if l1_origin + SEQUENCE_WINDOW <= finalized_l1 {
                 info!(
@@ -210,30 +219,40 @@ impl SnarkE2e {
             safe_head = target_block - 1;
         };
 
-        // -- 2. Submit ProveBlock with proof_type=4 (SNARK Groth16) ---------------
+        // -- 2. Submit proveBlockRange (SnarkGroth16) -----------------------------
         //
         // l1_head is omitted -- the prover service calculates it server-side
         // using SafeDB (optimism_safeHeadAtL1Block) with a sequence_window
         // fallback, which is more robust than the client-side l1_origin + 50
         // heuristic.
-        let mut client = Self::connect().await?;
+        let client = Self::connect()?;
+        let session_id = Uuid::new_v4().to_string();
         let prove_resp = client
-            .prove_block(ProveBlockRequest {
-                start_block_number: safe_head,
-                number_of_blocks_to_prove: 1,
-                sequence_window: Some(SEQUENCE_WINDOW),
-                proof_type: PROOF_TYPE_SNARK_GROTH16,
-                session_id: None,
-                prover_address: Some("0x0000000000000000000000000000000000000000".to_string()),
-                l1_head: None,
-                intermediate_root_interval: None,
+            .prove_block_range(ProveBlockRangeRequest {
+                proof: ProofRequest {
+                    session_id: session_id.clone(),
+                    request: ProofRequestKind::SnarkGroth16(SnarkGroth16ProofRequest {
+                        proof: ZkProofRequest {
+                            start_block_number: safe_head,
+                            number_of_blocks_to_prove: 1,
+                            sequence_window: Some(SEQUENCE_WINDOW),
+                            l1_head: None,
+                            intermediate_root_interval: None,
+                            zk_vm: ZkVm::Sp1,
+                        },
+                        prover_address: Address::ZERO,
+                    }),
+                },
             })
             .await
             .with_context(|| {
-                format!("failed to submit ProveBlock for start_block={safe_head}, target_block={target_block}")
+                format!(
+                    "failed to submit proveBlockRange for start_block={safe_head}, \
+                     target_block={target_block}"
+                )
             })?;
 
-        let session_id = prove_resp.into_inner().session_id;
+        let session_id = prove_resp.session_id;
         info!(
             session_id = %session_id,
             start_block = safe_head,
@@ -242,10 +261,10 @@ impl SnarkE2e {
             finalized_l1,
             sequence_window = SEQUENCE_WINDOW,
             step_back_attempts = attempts,
-            "ProveBlock submitted"
+            "proveBlockRange submitted"
         );
 
-        // -- 3. Poll GetProof until SUCCEEDED or timeout --------------------------
+        // -- 3. Poll getProof until Succeeded or timeout --------------------------
         let start = std::time::Instant::now();
         let snark_receipt_bytes = loop {
             if start.elapsed().as_secs() > POLL_TIMEOUT_SECS {
@@ -258,40 +277,48 @@ impl SnarkE2e {
             tokio::time::sleep(std::time::Duration::from_secs(POLL_INTERVAL_SECS)).await;
 
             let resp = client
-                .get_proof(GetProofRequest {
-                    session_id: session_id.clone(),
-                    receipt_type: Some(RECEIPT_TYPE_SNARK),
-                })
+                .get_proof(GetProofRequest { session_id: session_id.clone() })
                 .await
-                .with_context(|| format!("failed to poll GetProof for session_id={session_id}"))?;
+                .with_context(|| format!("failed to poll getProof for session_id={session_id}"))?;
 
-            let inner = resp.into_inner();
-            let status = get_proof_response::Status::try_from(inner.status)
-                .unwrap_or(get_proof_response::Status::Unspecified);
-            let error_message = inner.error_message.as_deref().unwrap_or("");
+            let error_message = resp.error_message.as_deref().unwrap_or("");
+            let receipt_bytes = resp.result.as_ref().map(|r| match r {
+                ProofResult::SnarkGroth16(r) => r.proof.proof.len(),
+                ProofResult::Compressed(r) => r.proof.len(),
+                ProofResult::Tee(_) => 0,
+            });
 
             info!(
                 session_id = %session_id,
                 start_block = safe_head,
                 target_block,
                 elapsed_secs = start.elapsed().as_secs(),
-                status = ?status,
-                receipt_bytes = inner.receipt.len(),
+                status = ?resp.status,
+                receipt_bytes,
                 error_message,
                 "poll status"
             );
 
-            match status {
-                get_proof_response::Status::Succeeded => {
-                    if inner.receipt.is_empty() {
+            match resp.status {
+                ProofStatus::Succeeded => {
+                    let result = resp.result.with_context(|| {
+                        format!(
+                            "SNARK result missing on Succeeded status: \
+                             session_id={session_id}, start_block={safe_head}, \
+                             target_block={target_block}"
+                        )
+                    })?;
+                    let bytes = Self::snark_receipt_bytes(result)?;
+                    if bytes.is_empty() {
                         bail!(
-                            "SNARK receipt is empty on SUCCEEDED status: \
-                             session_id={session_id}, start_block={safe_head}, target_block={target_block}"
+                            "SNARK receipt is empty on Succeeded status: \
+                             session_id={session_id}, start_block={safe_head}, \
+                             target_block={target_block}"
                         );
                     }
-                    break inner.receipt;
+                    break bytes;
                 }
-                get_proof_response::Status::Failed => {
+                ProofStatus::Failed => {
                     let prover_error = if error_message.is_empty() {
                         "no error_message returned by prover"
                     } else {
@@ -304,10 +331,7 @@ impl SnarkE2e {
                         start.elapsed().as_secs()
                     );
                 }
-                get_proof_response::Status::Created
-                | get_proof_response::Status::Pending
-                | get_proof_response::Status::Running
-                | get_proof_response::Status::Unspecified => {
+                ProofStatus::Queued | ProofStatus::Running => {
                     // Still in progress, continue polling
                 }
             }

--- a/crates/infra/snark-e2e/src/snark_e2e.rs
+++ b/crates/infra/snark-e2e/src/snark_e2e.rs
@@ -69,10 +69,7 @@ impl SnarkE2e {
                 .map_err(|e| anyhow::anyhow!("SNARK Groth16 proof verification failed: {e}"))
         })
         .await??;
-        info!(
-            elapsed_secs = t.elapsed().as_secs_f64(),
-            "SNARK Groth16 proof verified (CpuProver)"
-        );
+        info!(elapsed_secs = t.elapsed().as_secs_f64(), "SNARK Groth16 proof verified (CpuProver)");
 
         Ok(())
     }

--- a/crates/infra/snark-e2e/src/snark_e2e.rs
+++ b/crates/infra/snark-e2e/src/snark_e2e.rs
@@ -15,11 +15,11 @@ use base_l1_head::L1HeadCalculator;
 use base_prover_service_client::{ProofRequesterClient, ProverServiceClientConfig};
 use base_prover_service_protocol::{
     GetProofRequest, ProofRequest, ProofRequestKind, ProofResult, ProofStatus,
-    ProveBlockRangeRequest, SnarkGroth16ProofRequest, ZkProofRequest, ZkVm,
+    ProveBlockRangeRequest, SnarkGroth16ProofRequest, ZkBackend, ZkProofRequest, ZkVm,
 };
 use sp1_sdk::{
     SP1ProofWithPublicValues, SP1VerifyingKey,
-    blocking::{CpuProver, MockProver, Prover as BlockingProver},
+    blocking::{CpuProver, Prover as BlockingProver},
 };
 use tracing::{info, warn};
 use uuid::Uuid;
@@ -53,48 +53,26 @@ impl SnarkE2e {
         ProofRequesterClient::connect(&config).context("failed to connect to prover-service")
     }
 
-    /// Verify the SNARK proof using the appropriate prover for the backend.
-    ///
-    /// - Mock backend: uses `MockProver::verify()` (checks public input hashes
-    ///   only)
-    /// - Cluster backend: uses `CpuProver::verify()` (full cryptographic
-    ///   verification)
+    /// Verify the SNARK proof with `CpuProver` (full cryptographic verification).
     async fn verify_snark_proof(
         snark_proof: SP1ProofWithPublicValues,
         agg_vk: SP1VerifyingKey,
-        is_mock: bool,
     ) -> Result<()> {
-        if is_mock {
-            info!("verifying SNARK Groth16 proof with MockProver (BACKEND=mock)");
-            let t = std::time::Instant::now();
-            tokio::task::spawn_blocking(move || {
-                let prover = MockProver::new();
-                prover.verify(&snark_proof, &agg_vk, None).map_err(|e| {
-                    anyhow::anyhow!("SNARK Groth16 mock proof verification failed: {e}")
-                })
-            })
-            .await??;
-            info!(
-                elapsed_secs = t.elapsed().as_secs_f64(),
-                "SNARK Groth16 proof verified (MockProver)"
-            );
-        } else {
-            info!("verifying SNARK Groth16 proof with CpuProver (BACKEND=cluster)");
-            let t = std::time::Instant::now();
-            tokio::task::spawn_blocking(move || {
-                info!("creating CpuProver");
-                let prover = CpuProver::new();
-                info!("CpuProver created, running verify");
-                prover
-                    .verify(&snark_proof, &agg_vk, None)
-                    .map_err(|e| anyhow::anyhow!("SNARK Groth16 proof verification failed: {e}"))
-            })
-            .await??;
-            info!(
-                elapsed_secs = t.elapsed().as_secs_f64(),
-                "SNARK Groth16 proof verified (CpuProver)"
-            );
-        }
+        info!("verifying SNARK Groth16 proof with CpuProver");
+        let t = std::time::Instant::now();
+        tokio::task::spawn_blocking(move || {
+            info!("creating CpuProver");
+            let prover = CpuProver::new();
+            info!("CpuProver created, running verify");
+            prover
+                .verify(&snark_proof, &agg_vk, None)
+                .map_err(|e| anyhow::anyhow!("SNARK Groth16 proof verification failed: {e}"))
+        })
+        .await??;
+        info!(
+            elapsed_secs = t.elapsed().as_secs_f64(),
+            "SNARK Groth16 proof verified (CpuProver)"
+        );
 
         Ok(())
     }
@@ -119,7 +97,7 @@ impl SnarkE2e {
     /// 3. Poll `prover_getProof` until completion or timeout
     /// 4. Deserialize the SNARK receipt
     /// 5. Compute the aggregation verifying key
-    /// 6. Verify the SNARK proof (`MockProver` or `CpuProver` based on BACKEND)
+    /// 6. Verify the SNARK proof with `CpuProver`
     pub async fn run() -> Result<()> {
         let l2_rpc = std::env::var("L2_NODE_ADDRESS").context("L2_NODE_ADDRESS must be set")?;
 
@@ -239,6 +217,7 @@ impl SnarkE2e {
                             l1_head: None,
                             intermediate_root_interval: None,
                             zk_vm: ZkVm::Sp1,
+                            zk_backend: ZkBackend::Cluster,
                         },
                         prover_address: Address::ZERO,
                     }),
@@ -370,9 +349,7 @@ impl SnarkE2e {
         info!(elapsed_secs = t.elapsed().as_secs_f64(), "aggregation verifying key computed");
 
         // -- 6. Verify SNARK proof ------------------------------------------------
-        let is_mock = std::env::var("BACKEND").map(|v| v == "mock").unwrap_or(false);
-
-        Self::verify_snark_proof(snark_proof, agg_vk, is_mock)
+        Self::verify_snark_proof(snark_proof, agg_vk)
             .await
             .with_context(|| format!("failed to verify SNARK proof for session_id={session_id}"))?;
 

--- a/crates/infra/snark-e2e/src/snark_e2e.rs
+++ b/crates/infra/snark-e2e/src/snark_e2e.rs
@@ -181,8 +181,8 @@ impl SnarkE2e {
             let l1_origin = L1HeadCalculator::get_l1_origin_num(&op_provider, target_block)
                 .await
                 .with_context(|| {
-                    format!("failed to fetch L1 origin for target L2 block {target_block}")
-                })?;
+                format!("failed to fetch L1 origin for target L2 block {target_block}")
+            })?;
 
             if l1_origin + SEQUENCE_WINDOW <= finalized_l1 {
                 info!(
@@ -279,7 +279,9 @@ impl SnarkE2e {
             let resp = client
                 .get_proof(GetProofRequest { session_id: session_id.clone() })
                 .await
-                .with_context(|| format!("failed to poll getProof for session_id={session_id}"))?;
+                .with_context(|| {
+                format!("failed to poll getProof for session_id={session_id}")
+            })?;
 
             let error_message = resp.error_message.as_deref().unwrap_or("");
             let receipt_bytes = resp.result.as_ref().map(|r| match r {

--- a/crates/infra/snark-e2e/tests/snark_groth16_e2e.rs
+++ b/crates/infra/snark-e2e/tests/snark_groth16_e2e.rs
@@ -4,13 +4,13 @@
 //! `base-snark-e2e` binary (K8s `CronJob`).
 //!
 //! Requires:
-//! - A running prover-service with real node endpoints
+//! - A running prover-service requester + zk-host worker
 //! - `L2_NODE_ADDRESS` environment variable
 //!
 //! Auto-skips when `L2_NODE_ADDRESS` is not set.
 //!
 #[tokio::test]
-#[ignore = "requires a running prover-service and L2_NODE_ADDRESS; run with `cargo nextest run --run-ignored all -p base-zk-service --test snark_groth16_e2e`"]
+#[ignore = "requires a running prover-service and L2_NODE_ADDRESS; run with `cargo nextest run --run-ignored all -p base-snark-e2e --test snark_groth16_e2e`"]
 async fn snark_groth16_e2e_prove_and_verify() {
     if std::env::var("L2_NODE_ADDRESS").is_err() {
         println!("Skipping: L2_NODE_ADDRESS not set.");
@@ -23,5 +23,5 @@ async fn snark_groth16_e2e_prove_and_verify() {
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .try_init();
 
-    base_zk_service::SnarkE2e::run().await.expect("SNARK e2e test failed");
+    base_snark_e2e::SnarkE2e::run().await.expect("SNARK e2e test failed");
 }

--- a/crates/proof/zk/service/Cargo.toml
+++ b/crates/proof/zk/service/Cargo.toml
@@ -59,7 +59,6 @@ base-zk-client.workspace = true
 chrono.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tonic = { workspace = true, features = ["transport"] }
-tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 uuid = { workspace = true, features = ["v4"] }
 
 [lints]

--- a/crates/proof/zk/service/src/lib.rs
+++ b/crates/proof/zk/service/src/lib.rs
@@ -22,8 +22,5 @@ pub use proxy::{ProxyConfig, ProxyConfigs, RateLimitConfig, start_all_proxies};
 mod server;
 pub use server::ProverServiceServer;
 
-mod snark_e2e;
-pub use snark_e2e::SnarkE2e;
-
 mod worker;
 pub use worker::{ProverWorker, ProverWorkerPool, StatusPoller};


### PR DESCRIPTION
## Summary
Move `SnarkE2e` out of `base-zk-service` into a dedicated `crates/infra/snark-e2e` library (`base-snark-e2e`), matching the sidecrush/snapshotter pattern

Made with [Cursor](https://cursor.com)