### PR TITLE
feat(challenger): report game finality time

### DIFF
--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -2,11 +2,13 @@
 
 use std::{collections::HashSet, sync::Arc, time::Duration};
 
+use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::Address;
 use base_proof_contracts::{
     AggregateVerifierClient, DelayedWETHClient, DelayedWETHContractClient,
     DisputeGameFactoryClient, encode_claim_credit_calldata, encode_resolve_calldata,
 };
+use base_proof_rpc::L2Provider;
 use base_runtime::Clock;
 use base_tx_manager::TxManager;
 use futures::stream::{self, StreamExt};
@@ -38,6 +40,7 @@ pub struct BondManager<C: Clock> {
     l1_rpc_url: url::Url,
     clock: C,
     factory_client: Arc<dyn DisputeGameFactoryClient>,
+    l2_provider: Arc<dyn L2Provider>,
     last_scan: Option<Duration>,
     lookback: u64,
     discovery_interval: Duration,
@@ -55,6 +58,7 @@ impl<C: Clock> BondManager<C> {
         claim_addresses: Vec<Address>,
         l1_rpc_url: url::Url,
         factory_client: Arc<dyn DisputeGameFactoryClient>,
+        l2_provider: Arc<dyn L2Provider>,
         lookback: u64,
         discovery_interval: Duration,
         clock: C,
@@ -67,6 +71,7 @@ impl<C: Clock> BondManager<C> {
             l1_rpc_url,
             clock,
             factory_client,
+            l2_provider,
             last_scan: None,
             lookback,
             discovery_interval,
@@ -257,9 +262,10 @@ impl<C: Clock> BondManager<C> {
     ) {
         let game_address = action.game_address();
         let result = match action {
-            BondAction::Resolve(game_address) => {
-                self.try_resolve(game_address, submitter).await.map_err(|e| eyre::eyre!(e))
-            }
+            BondAction::Resolve(game_address) => self
+                .try_resolve(game_address, verifier_client, submitter)
+                .await
+                .map_err(|e| eyre::eyre!(e)),
             BondAction::Unlock(game_address) => {
                 Self::send_claim_credit(game_address, "unlock", submitter)
                     .await
@@ -279,6 +285,7 @@ impl<C: Clock> BondManager<C> {
     async fn try_resolve<T: TxManager>(
         &self,
         game_address: Address,
+        verifier_client: &dyn AggregateVerifierClient,
         submitter: &ChallengeSubmitter<T>,
     ) -> Result<(), ChallengeSubmitError> {
         let calldata = encode_resolve_calldata();
@@ -288,6 +295,7 @@ impl<C: Clock> BondManager<C> {
                 info!(game = %game_address, tx_hash = %tx_hash, "resolve transaction confirmed");
                 ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_SUCCESS)
                     .increment(1);
+                self.record_finality_time(game_address, verifier_client).await;
                 Ok(())
             }
             Err(e) => {
@@ -296,6 +304,43 @@ impl<C: Clock> BondManager<C> {
                 Err(e)
             }
         }
+    }
+
+    async fn record_finality_time(
+        &self,
+        game_address: Address,
+        verifier_client: &dyn AggregateVerifierClient,
+    ) {
+        let l2_block_number = match verifier_client.game_info(game_address).await {
+            Ok(game_info) => game_info.l2_block_number,
+            Err(error) => {
+                warn!(
+                    game = %game_address,
+                    error = %error,
+                    "failed to read game info for finality metric"
+                );
+                return;
+            }
+        };
+        let header = match self
+            .l2_provider
+            .header_by_number(BlockNumberOrTag::Number(l2_block_number))
+            .await
+        {
+            Ok(header) => header,
+            Err(error) => {
+                warn!(
+                    game = %game_address,
+                    l2_block_number,
+                    error = %error,
+                    "failed to read L2 block timestamp for finality metric"
+                );
+                return;
+            }
+        };
+
+        let finality_time_secs = self.clock.wall_clock_unix_secs().saturating_sub(header.timestamp);
+        ChallengerMetrics::game_finality_time_seconds().record(finality_time_secs as f64);
     }
 
     async fn try_withdraw_if_ready<T: TxManager>(
@@ -390,11 +435,17 @@ mod tests {
 
     use alloy_primitives::B256;
     use futures::stream::BoxStream;
+    #[cfg(feature = "metrics")]
+    use metrics_util::{
+        MetricKind,
+        debugging::{DebugValue, DebuggingRecorder},
+    };
 
     use super::*;
     use crate::test_utils::{
-        MockAggregateVerifier, MockDisputeGameFactory, SharedMockTxManager,
-        TEST_DISCOVERY_INTERVAL, addr, factory_game, mock_state, receipt_with_status,
+        MockAggregateVerifier, MockDisputeGameFactory, MockL2Provider, SharedMockTxManager,
+        TEST_DISCOVERY_INTERVAL, addr, build_test_header_and_account, factory_game, mock_state,
+        receipt_with_status,
     };
 
     struct FixedClock {
@@ -453,7 +504,18 @@ mod tests {
         clock: FixedClock,
     ) -> BondManager<FixedClock> {
         let factory = Arc::new(MockDisputeGameFactory::new(vec![factory_game(0, 0)]));
-        BondManager::new(vec![claim_addr], rpc_url, factory, 1000, TEST_DISCOVERY_INTERVAL, clock)
+        let mut l2_provider = MockL2Provider::new();
+        let (header, account) = build_test_header_and_account(100, B256::ZERO);
+        l2_provider.insert_block(100, header, account);
+        BondManager::new(
+            vec![claim_addr],
+            rpc_url,
+            factory,
+            Arc::new(l2_provider),
+            1000,
+            TEST_DISCOVERY_INTERVAL,
+            clock,
+        )
     }
 
     fn bond_submitter(
@@ -556,6 +618,40 @@ mod tests {
         mgr.discover_claimable_games(&*verifier, &submitter).await.unwrap();
 
         assert_eq!(tx_manager.recorded_calls().len(), 1);
+    }
+
+    #[cfg(feature = "metrics")]
+    #[test]
+    fn scan_records_finality_time_when_resolving_game() {
+        let claim_addr = claim_addr();
+        let state = game_state(Address::repeat_byte(0xDD), claim_addr, 0, false);
+        let verifier = verifier(state);
+        let (submitter, _) = bond_submitter(vec![Ok(receipt_with_status(true, B256::ZERO))]);
+        let mut mgr = manager(
+            claim_addr,
+            "http://localhost:8545".parse().unwrap(),
+            fixed_clock(2_000_000_000),
+        );
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+
+        metrics::with_local_recorder(&recorder, || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("test runtime must build")
+                .block_on(async {
+                    mgr.discover_claimable_games(&*verifier, &submitter).await.unwrap();
+                });
+        });
+
+        let snapshot = snapshotter.snapshot().into_vec();
+        let finality_time = snapshot.iter().find_map(|(key, _, _, value)| {
+            (key.kind() == MetricKind::Histogram
+                && key.key().name() == "base_challenger.game_finality_time_seconds")
+                .then_some(value)
+        });
+        assert_eq!(finality_time, Some(&DebugValue::Histogram(vec![2_000_000_000.0.into()])),);
     }
 
     #[tokio::test]

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -23,6 +23,8 @@ enum BondAction {
     WithdrawIfReady { game_address: Address, bond_recipient: Address },
 }
 
+const FINALITY_METRIC_TIMEOUT: Duration = Duration::from_secs(5);
+
 impl BondAction {
     const fn game_address(self) -> Address {
         match self {
@@ -115,11 +117,15 @@ impl<C: Clock> BondManager<C> {
         ChallengerMetrics::bond_discovery_scans_total("full").increment(1);
         let actions = self.bond_actions(start_index..game_count, verifier_client).await;
         let action_count = actions.len();
+        let mut finality_metric_records = Vec::new();
 
         for action in actions {
-            self.process_action(action, verifier_client, submitter).await;
+            if let Some(record) = self.process_action(action, verifier_client, submitter).await {
+                finality_metric_records.push(record);
+            }
         }
 
+        self.record_finality_metrics(finality_metric_records, verifier_client).await;
         self.last_scan = Some(now);
 
         if action_count > 0 {
@@ -262,35 +268,41 @@ impl<C: Clock> BondManager<C> {
         action: BondAction,
         verifier_client: &dyn AggregateVerifierClient,
         submitter: &ChallengeSubmitter<T>,
-    ) {
+    ) -> Option<(Address, u64)> {
         let game_address = action.game_address();
         let result = match action {
             BondAction::Resolve(game_address) => self
-                .try_resolve(game_address, verifier_client, submitter)
+                .try_resolve(game_address, submitter)
                 .await
+                .map(Some)
                 .map_err(|e| eyre::eyre!(e)),
             BondAction::Unlock(game_address) => {
                 Self::send_claim_credit(game_address, "unlock", submitter)
                     .await
+                    .map(|()| None)
                     .map_err(|e| eyre::eyre!(e))
             }
-            BondAction::WithdrawIfReady { game_address, bond_recipient } => {
-                self.try_withdraw_if_ready(game_address, bond_recipient, verifier_client, submitter)
-                    .await
-            }
+            BondAction::WithdrawIfReady { game_address, bond_recipient } => self
+                .try_withdraw_if_ready(game_address, bond_recipient, verifier_client, submitter)
+                .await
+                .map(|()| None),
         };
 
-        if let Err(e) = result {
-            warn!(game = %game_address, error = %e, "failed to advance bond claim");
+        match result {
+            Ok(Some(confirmed_at)) if self.metrics_enabled => Some((game_address, confirmed_at)),
+            Ok(_) => None,
+            Err(e) => {
+                warn!(game = %game_address, error = %e, "failed to advance bond claim");
+                None
+            }
         }
     }
 
     async fn try_resolve<T: TxManager>(
         &self,
         game_address: Address,
-        verifier_client: &dyn AggregateVerifierClient,
         submitter: &ChallengeSubmitter<T>,
-    ) -> Result<(), ChallengeSubmitError> {
+    ) -> Result<u64, ChallengeSubmitError> {
         let calldata = encode_resolve_calldata();
         info!(game = %game_address, "submitting resolve transaction");
         match submitter.send_bond_tx(game_address, game_address, calldata).await {
@@ -299,16 +311,32 @@ impl<C: Clock> BondManager<C> {
                 info!(game = %game_address, tx_hash = %tx_hash, "resolve transaction confirmed");
                 ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_SUCCESS)
                     .increment(1);
-                if self.metrics_enabled {
-                    self.record_finality_time(game_address, verifier_client, confirmed_at).await;
-                }
-                Ok(())
+                Ok(confirmed_at)
             }
             Err(e) => {
                 ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
                     .increment(1);
                 Err(e)
             }
+        }
+    }
+
+    async fn record_finality_metrics(
+        &self,
+        records: Vec<(Address, u64)>,
+        verifier_client: &dyn AggregateVerifierClient,
+    ) {
+        let collection = stream::iter(records).for_each_concurrent(
+            GameScanner::SCAN_CONCURRENCY,
+            |(game_address, confirmed_at)| async move {
+                self.record_finality_time(game_address, verifier_client, confirmed_at).await;
+            },
+        );
+        if tokio::time::timeout(FINALITY_METRIC_TIMEOUT, collection).await.is_err() {
+            warn!(
+                timeout_secs = FINALITY_METRIC_TIMEOUT.as_secs(),
+                "timed out collecting finality metrics"
+            );
         }
     }
 
@@ -665,6 +693,46 @@ mod tests {
         });
         assert_eq!(finality_time, Some(&DebugValue::Histogram(vec![2_000_000_000.0.into()])),);
         assert_eq!(verifier.game_info_read_count(addr(0)), 1);
+    }
+
+    #[cfg(feature = "metrics")]
+    #[tokio::test(start_paused = true)]
+    async fn scan_advances_all_bonds_before_waiting_for_finality_metrics() {
+        let claim_addr = claim_addr();
+        let state = game_state(Address::repeat_byte(0xDD), claim_addr, 0, false);
+        let verifier = Arc::new(MockAggregateVerifier::new(HashMap::from([
+            (addr(0), state.clone()),
+            (addr(1), state),
+        ])));
+        let factory =
+            Arc::new(MockDisputeGameFactory::new(vec![factory_game(0, 0), factory_game(1, 0)]));
+        let mut l2_provider = MockL2Provider::new();
+        let (header, account) = build_test_header_and_account(100, B256::ZERO);
+        l2_provider.insert_block(100, header, account);
+        l2_provider.header_delay = Some(FINALITY_METRIC_TIMEOUT + Duration::from_secs(1));
+        let mut mgr = BondManager::new(
+            vec![claim_addr],
+            "http://localhost:8545".parse().unwrap(),
+            factory,
+            Arc::new(l2_provider),
+            1000,
+            TEST_DISCOVERY_INTERVAL,
+            true,
+            fixed_clock(2_000_000_000),
+        );
+        let (submitter, tx_manager) = bond_submitter(vec![
+            Ok(receipt_with_status(true, B256::ZERO)),
+            Ok(receipt_with_status(true, B256::ZERO)),
+        ]);
+
+        let scan =
+            tokio::spawn(async move { mgr.discover_claimable_games(&*verifier, &submitter).await });
+        tokio::task::yield_now().await;
+
+        assert_eq!(tx_manager.recorded_calls().len(), 2);
+
+        tokio::time::advance(FINALITY_METRIC_TIMEOUT).await;
+        scan.await.unwrap().unwrap();
     }
 
     #[tokio::test]

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -44,6 +44,7 @@ pub struct BondManager<C: Clock> {
     last_scan: Option<Duration>,
     lookback: u64,
     discovery_interval: Duration,
+    metrics_enabled: bool,
 }
 
 impl<C: Clock> std::fmt::Debug for BondManager<C> {
@@ -61,6 +62,7 @@ impl<C: Clock> BondManager<C> {
         l2_provider: Arc<dyn L2Provider>,
         lookback: u64,
         discovery_interval: Duration,
+        metrics_enabled: bool,
         clock: C,
     ) -> Self {
         let set: HashSet<Address> = claim_addresses.into_iter().collect();
@@ -75,6 +77,7 @@ impl<C: Clock> BondManager<C> {
             last_scan: None,
             lookback,
             discovery_interval,
+            metrics_enabled,
         }
     }
 
@@ -292,10 +295,13 @@ impl<C: Clock> BondManager<C> {
         info!(game = %game_address, "submitting resolve transaction");
         match submitter.send_bond_tx(game_address, game_address, calldata).await {
             Ok(tx_hash) => {
+                let confirmed_at = self.clock.wall_clock_unix_secs();
                 info!(game = %game_address, tx_hash = %tx_hash, "resolve transaction confirmed");
                 ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_SUCCESS)
                     .increment(1);
-                self.record_finality_time(game_address, verifier_client).await;
+                if self.metrics_enabled {
+                    self.record_finality_time(game_address, verifier_client, confirmed_at).await;
+                }
                 Ok(())
             }
             Err(e) => {
@@ -310,6 +316,7 @@ impl<C: Clock> BondManager<C> {
         &self,
         game_address: Address,
         verifier_client: &dyn AggregateVerifierClient,
+        confirmed_at: u64,
     ) {
         let l2_block_number = match verifier_client.game_info(game_address).await {
             Ok(game_info) => game_info.l2_block_number,
@@ -339,7 +346,7 @@ impl<C: Clock> BondManager<C> {
             }
         };
 
-        let finality_time_secs = self.clock.wall_clock_unix_secs().saturating_sub(header.timestamp);
+        let finality_time_secs = confirmed_at.saturating_sub(header.timestamp);
         ChallengerMetrics::game_finality_time_seconds().record(finality_time_secs as f64);
     }
 
@@ -502,6 +509,7 @@ mod tests {
         claim_addr: Address,
         rpc_url: url::Url,
         clock: FixedClock,
+        metrics_enabled: bool,
     ) -> BondManager<FixedClock> {
         let factory = Arc::new(MockDisputeGameFactory::new(vec![factory_game(0, 0)]));
         let mut l2_provider = MockL2Provider::new();
@@ -514,6 +522,7 @@ mod tests {
             Arc::new(l2_provider),
             1000,
             TEST_DISCOVERY_INTERVAL,
+            metrics_enabled,
             clock,
         )
     }
@@ -613,11 +622,13 @@ mod tests {
             claim_addr,
             "http://localhost:8545".parse().unwrap(),
             fixed_clock(2_000_000_000),
+            false,
         );
 
         mgr.discover_claimable_games(&*verifier, &submitter).await.unwrap();
 
         assert_eq!(tx_manager.recorded_calls().len(), 1);
+        assert_eq!(verifier.game_info_read_count(addr(0)), 0);
     }
 
     #[cfg(feature = "metrics")]
@@ -631,6 +642,7 @@ mod tests {
             claim_addr,
             "http://localhost:8545".parse().unwrap(),
             fixed_clock(2_000_000_000),
+            true,
         );
         let recorder = DebuggingRecorder::new();
         let snapshotter = recorder.snapshotter();
@@ -652,6 +664,7 @@ mod tests {
                 .then_some(value)
         });
         assert_eq!(finality_time, Some(&DebugValue::Histogram(vec![2_000_000_000.0.into()])),);
+        assert_eq!(verifier.game_info_read_count(addr(0)), 1);
     }
 
     #[tokio::test]
@@ -663,6 +676,7 @@ mod tests {
             Address::ZERO,
             "http://localhost:8545".parse().unwrap(),
             fixed_clock(2_000_000_000),
+            false,
         );
 
         mgr.discover_claimable_games(&*verifier, &submitter).await.unwrap();
@@ -681,6 +695,7 @@ mod tests {
             claim_addr,
             "http://localhost:8545".parse().unwrap(),
             fixed_clock(2_000_000_000),
+            false,
         );
 
         mgr.discover_claimable_games(&*verifier, &submitter).await.unwrap();
@@ -696,7 +711,7 @@ mod tests {
         let (rpc_url, handle) =
             delayed_weth_rpc(vec![u256(60), format!("{}{}", u256(1), u256(100))]);
         let (submitter, tx_manager) = bond_submitter(vec![]);
-        let mut mgr = manager(claim_addr, rpc_url, fixed_clock(150));
+        let mut mgr = manager(claim_addr, rpc_url, fixed_clock(150), false);
 
         mgr.discover_claimable_games(&*verifier, &submitter).await.unwrap();
         handle.join().unwrap();
@@ -714,7 +729,7 @@ mod tests {
             delayed_weth_rpc(vec![u256(60), format!("{}{}", u256(1), u256(100))]);
         let (submitter, tx_manager) =
             bond_submitter(vec![Ok(receipt_with_status(true, B256::ZERO))]);
-        let mut mgr = manager(claim_addr, rpc_url, fixed_clock(160));
+        let mut mgr = manager(claim_addr, rpc_url, fixed_clock(160), false);
 
         mgr.discover_claimable_games(&*verifier, &submitter).await.unwrap();
         handle.join().unwrap();

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -25,6 +25,21 @@ enum BondAction {
 
 const FINALITY_METRIC_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Configuration for bond discovery and claiming.
+#[derive(Debug)]
+pub struct BondManagerConfig {
+    /// Addresses whose bonds can be claimed.
+    pub claim_addresses: Vec<Address>,
+    /// L1 RPC endpoint used to read the delayed WETH contract.
+    pub l1_rpc_url: url::Url,
+    /// Number of recent factory games to scan.
+    pub lookback: u64,
+    /// Minimum interval between full discovery scans.
+    pub discovery_interval: Duration,
+    /// Whether finality metrics are recorded.
+    pub metrics_enabled: bool,
+}
+
 impl BondAction {
     const fn game_address(self) -> Address {
         match self {
@@ -56,30 +71,26 @@ impl<C: Clock> std::fmt::Debug for BondManager<C> {
 }
 
 impl<C: Clock> BondManager<C> {
-    /// Creates a new bond manager for the given set of claim addresses.
+    /// Creates a new bond manager from its configuration and contract clients.
     pub fn new(
-        claim_addresses: Vec<Address>,
-        l1_rpc_url: url::Url,
+        config: BondManagerConfig,
         factory_client: Arc<dyn DisputeGameFactoryClient>,
         l2_provider: Arc<dyn L2Provider>,
-        lookback: u64,
-        discovery_interval: Duration,
-        metrics_enabled: bool,
         clock: C,
     ) -> Self {
-        let set: HashSet<Address> = claim_addresses.into_iter().collect();
+        let set: HashSet<Address> = config.claim_addresses.into_iter().collect();
         info!(count = set.len(), "bond manager initialized with claim addresses");
         Self {
             claim_addresses: set,
             weth_delay: None,
-            l1_rpc_url,
+            l1_rpc_url: config.l1_rpc_url,
             clock,
             factory_client,
             l2_provider,
             last_scan: None,
-            lookback,
-            discovery_interval,
-            metrics_enabled,
+            lookback: config.lookback,
+            discovery_interval: config.discovery_interval,
+            metrics_enabled: config.metrics_enabled,
         }
     }
 
@@ -544,13 +555,15 @@ mod tests {
         let (header, account) = build_test_header_and_account(100, B256::ZERO);
         l2_provider.insert_block(100, header, account);
         BondManager::new(
-            vec![claim_addr],
-            rpc_url,
+            BondManagerConfig {
+                claim_addresses: vec![claim_addr],
+                l1_rpc_url: rpc_url,
+                lookback: 1000,
+                discovery_interval: TEST_DISCOVERY_INTERVAL,
+                metrics_enabled,
+            },
             factory,
             Arc::new(l2_provider),
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            metrics_enabled,
             clock,
         )
     }
@@ -711,13 +724,15 @@ mod tests {
         l2_provider.insert_block(100, header, account);
         l2_provider.header_delay = Some(FINALITY_METRIC_TIMEOUT + Duration::from_secs(1));
         let mut mgr = BondManager::new(
-            vec![claim_addr],
-            "http://localhost:8545".parse().unwrap(),
+            BondManagerConfig {
+                claim_addresses: vec![claim_addr],
+                l1_rpc_url: "http://localhost:8545".parse().unwrap(),
+                lookback: 1000,
+                discovery_interval: TEST_DISCOVERY_INTERVAL,
+                metrics_enabled: true,
+            },
             factory,
             Arc::new(l2_provider),
-            1000,
-            TEST_DISCOVERY_INTERVAL,
-            true,
             fixed_clock(2_000_000_000),
         );
         let (submitter, tx_manager) = bond_submitter(vec![

--- a/crates/proof/challenge/src/lib.rs
+++ b/crates/proof/challenge/src/lib.rs
@@ -51,7 +51,7 @@ mod verify;
 pub use verify::{AccountProofError, AccountProofVerifier};
 
 mod bond;
-pub use bond::BondManager;
+pub use bond::{BondManager, BondManagerConfig};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;

--- a/crates/proof/challenge/src/metrics.rs
+++ b/crates/proof/challenge/src/metrics.rs
@@ -127,6 +127,11 @@ base_metrics::define_metrics! {
     #[no_zero]
     anchor_l2_block_number: gauge,
 
+    #[describe(
+        "Elapsed time in seconds from a resolved game's L2 block timestamp to resolve transaction confirmation"
+    )]
+    game_finality_time_seconds: histogram,
+
     #[describe("Challenger account balance in wei")]
     account_balance_wei: gauge,
 }

--- a/crates/proof/challenge/src/service.rs
+++ b/crates/proof/challenge/src/service.rs
@@ -203,6 +203,7 @@ impl ChallengerService {
                 Arc::clone(&l2_client) as Arc<dyn L2Provider>,
                 config.bond_discovery_lookback_games,
                 config.bond_discovery_interval,
+                config.metrics.enabled,
                 TokioRuntime::new(),
             ))
         } else {

--- a/crates/proof/challenge/src/service.rs
+++ b/crates/proof/challenge/src/service.rs
@@ -23,8 +23,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::{
-    AnchorUpdater, BondManager, ChallengeSubmitter, ChallengerConfig, ChallengerMetrics, Driver,
-    DriverComponents, DriverConfig, GameScanner, OutputValidator,
+    AnchorUpdater, BondManager, BondManagerConfig, ChallengeSubmitter, ChallengerConfig,
+    ChallengerMetrics, Driver, DriverComponents, DriverConfig, GameScanner, OutputValidator,
 };
 
 /// Top-level challenger service.
@@ -197,13 +197,15 @@ impl ChallengerService {
 
         let bond_manager = if !config.bond_claim_addresses.is_empty() {
             Some(BondManager::new(
-                config.bond_claim_addresses,
-                l1_rpc_url,
+                BondManagerConfig {
+                    claim_addresses: config.bond_claim_addresses,
+                    l1_rpc_url,
+                    lookback: config.bond_discovery_lookback_games,
+                    discovery_interval: config.bond_discovery_interval,
+                    metrics_enabled: config.metrics.enabled,
+                },
                 Arc::clone(&factory_client) as Arc<dyn DisputeGameFactoryClient>,
                 Arc::clone(&l2_client) as Arc<dyn L2Provider>,
-                config.bond_discovery_lookback_games,
-                config.bond_discovery_interval,
-                config.metrics.enabled,
                 TokioRuntime::new(),
             ))
         } else {

--- a/crates/proof/challenge/src/service.rs
+++ b/crates/proof/challenge/src/service.rs
@@ -200,6 +200,7 @@ impl ChallengerService {
                 config.bond_claim_addresses,
                 l1_rpc_url,
                 Arc::clone(&factory_client) as Arc<dyn DisputeGameFactoryClient>,
+                Arc::clone(&l2_client) as Arc<dyn L2Provider>,
                 config.bond_discovery_lookback_games,
                 config.bond_discovery_interval,
                 TokioRuntime::new(),

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -685,6 +685,8 @@ pub struct MockL2Provider {
     pub proofs: HashMap<B256, EIP1186AccountProofResponse>,
     /// Block numbers that should return an error (simulating missing blocks).
     pub error_blocks: Vec<u64>,
+    /// Delay applied before returning a header.
+    pub header_delay: Option<Duration>,
 }
 
 impl MockL2Provider {
@@ -733,6 +735,9 @@ impl L2Provider for MockL2Provider {
             BlockNumberOrTag::Number(number) => number,
             other => panic!("MockL2Provider::header_by_number does not support tag {other:?}"),
         };
+        if let Some(delay) = self.header_delay {
+            tokio::time::sleep(delay).await;
+        }
         if self.error_blocks.contains(&block_number) {
             return Err(RpcError::BlockNotFound(format!("block {block_number} not available")));
         }


### PR DESCRIPTION
### What changed? Why?

Adds the `base_challenger.game_finality_time_seconds` histogram for games this challenger resolves. It measures the elapsed seconds from the game's L2 block timestamp to confirmation of its `resolve()` transaction, providing a direct game-finality signal.

`BondManager` now receives its settings through `BondManagerConfig` and an L2 provider so it can read the resolved game's L2 header. Metric collection runs only when challenger metrics are enabled, after the scan has advanced every discovered bond action.

### Notes to reviewers

Finality-metric reads run concurrently and are capped at five seconds per scan. Failures to read game metadata or L2 headers, and a collection timeout, are logged but do not fail bond actions. The elapsed time uses saturating subtraction.

The added tests verify the histogram value, confirm disabled metrics avoid the additional game-info read, and ensure a delayed header lookup does not delay processing the rest of a scan's bond actions.

### How has it been tested?

- `cargo test -p base-challenger --features metrics bond::tests`
- `cargo test -p base-challenger bond::tests`
- `cargo clippy -p base-challenger --all-targets --features metrics -- -D warnings`