### PR TITLE
feat(eip8130): align actor scope and storage model

### DIFF
--- a/crates/common/consensus/src/transaction/eip8130/account_changes.rs
+++ b/crates/common/consensus/src/transaction/eip8130/account_changes.rs
@@ -51,35 +51,45 @@ impl Scope {
         self.0
     }
 
-    /// Returns true if the scope grants the `SCOPE_SIGNATURE` context.
-    pub const fn has_signature(&self) -> bool {
-        self.0 & Eip8130Constants::SCOPE_SIGNATURE != 0
-    }
-
-    /// Returns true if the scope grants the `SCOPE_SENDER` context.
+    /// Returns true if the scope grants the ungated `SCOPE_SENDER` context.
     pub const fn has_sender(&self) -> bool {
         self.0 & Eip8130Constants::SCOPE_SENDER != 0
     }
 
-    /// Returns true if the scope grants the `SCOPE_PAYER` context.
-    pub const fn has_payer(&self) -> bool {
-        self.0 & Eip8130Constants::SCOPE_PAYER != 0
+    /// Returns true if the scope enables policy gating.
+    pub const fn has_policy(&self) -> bool {
+        self.0 & Eip8130Constants::SCOPE_POLICY != 0
     }
 
-    /// Returns true if the scope grants the `SCOPE_CONFIG` context.
-    pub const fn has_config(&self) -> bool {
-        self.0 & Eip8130Constants::SCOPE_CONFIG != 0
+    /// Returns true if the scope grants the nonce context.
+    pub const fn has_nonce(&self) -> bool {
+        self.0 & Eip8130Constants::SCOPE_NONCE != 0
+    }
+
+    /// Returns true if the scope grants self-pay (`payer == sender`).
+    pub const fn has_self_payer(&self) -> bool {
+        self.0 & Eip8130Constants::SCOPE_SELF_PAYER != 0
+    }
+
+    /// Returns true if the scope grants sponsorship (`payer != sender`).
+    pub const fn has_sponsor_payer(&self) -> bool {
+        self.0 & Eip8130Constants::SCOPE_SPONSOR_PAYER != 0
     }
 }
 
 /// Initial actor installed on a newly-created account.
 ///
-/// Per [EIP-8130], a create entry's initial actors are `[actorId, authenticator]`
-/// tuples, always registered as unrestricted owners (`scope = 0x00`, no expiry,
-/// no policy). Scope, expiry, and policy are deliberately not expressible here
-/// and default to their zero values; restricted keys are added afterwards via a
-/// [`ConfigChange`]. The field order matches the wire encoding and the
-/// address-derivation commitment (`actorId || authenticator`).
+/// Per [EIP-8130], a create entry's initial actors are
+/// `[actorId, authenticator, scope, policyData]` tuples. `scope` is stored
+/// verbatim (`0x00` = unrestricted admin; unknown bits allowed), and `policyData`
+/// is empty unless `scope` sets `POLICY`, in which case it is exactly
+/// `manager (20) || commitment (32)`. Two things are deliberately **not**
+/// expressible here and are added afterwards via a [`ConfigChange`]: `expiry`
+/// (initial actors are always non-expiring, committed as `0`) and a
+/// self-referential `manager = account` (the account address is not known at
+/// commitment time). The field order matches the wire encoding and the
+/// address-derivation commitment (`actorId || authenticator || scope ||
+/// policyData`).
 ///
 /// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
 #[derive(Debug, Clone, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable)]
@@ -91,6 +101,19 @@ pub struct InitialActor {
     pub actor_id: B256,
     /// Address of the authenticator contract (e.g. an ERC-1271 authenticator).
     pub authenticator: Address,
+    /// Scope byte (`0x00` = unrestricted admin), stored verbatim.
+    pub scope: u8,
+    /// Policy data: empty unless `scope` sets `POLICY`, otherwise exactly
+    /// `manager (20) || commitment (32)`. Committed to the derived address.
+    pub policy_data: Bytes,
+}
+
+impl InitialActor {
+    /// Constructs an unrestricted admin initial actor (`scope == 0x00`, no
+    /// policy), the common owner case.
+    pub const fn owner(actor_id: B256, authenticator: Address) -> Self {
+        Self { actor_id, authenticator, scope: 0, policy_data: Bytes::new() }
+    }
 }
 
 /// Operation performed by an [`ActorChange`] inside a [`ConfigChange`].
@@ -127,7 +150,7 @@ impl ActorChangeType {
 ///
 /// Per [EIP-8130], `data` is the operation-specific, contract-ABI-encoded blob:
 /// `abi.encode(ActorConfig, bytes policyData)` for an `Authorize` (carrying the
-/// new actor's authenticator, scope, expiry, policy type, and policy data), and
+/// new actor's authenticator, scope, expiry, and policy data), and
 /// empty for a `Revoke`. It is opaque at this layer — decoded only where the
 /// change is applied (native authorization or `applySignedActorChanges`) — and
 /// is the value hashed (`keccak256(data)`) in the config-change signature
@@ -218,7 +241,7 @@ pub struct ConfigChange {
     pub sequence: u64,
     /// Actor authorize/revoke operations applied in order.
     pub actor_changes: Vec<ActorChange>,
-    /// Authorization payload validated against an existing actor with `SCOPE_CONFIG`.
+    /// Authorization payload validated against an admin actor (`scope == 0`).
     pub auth: Bytes,
 }
 
@@ -318,16 +341,18 @@ mod tests {
     #[test]
     fn scope_bit_helpers() {
         let s = Scope(
-            Eip8130Constants::SCOPE_SIGNATURE
-                | Eip8130Constants::SCOPE_SENDER
-                | Eip8130Constants::SCOPE_PAYER
-                | Eip8130Constants::SCOPE_CONFIG,
+            Eip8130Constants::SCOPE_SENDER
+                | Eip8130Constants::SCOPE_POLICY
+                | Eip8130Constants::SCOPE_NONCE
+                | Eip8130Constants::SCOPE_SELF_PAYER
+                | Eip8130Constants::SCOPE_SPONSOR_PAYER,
         );
-        assert!(s.has_signature());
         assert!(s.has_sender());
-        assert!(s.has_payer());
-        assert!(s.has_config());
-        assert!(!Scope::UNRESTRICTED.has_signature());
+        assert!(s.has_policy());
+        assert!(s.has_nonce());
+        assert!(s.has_self_payer());
+        assert!(s.has_sponsor_payer());
+        assert!(!Scope::UNRESTRICTED.has_sender());
     }
 
     #[test]
@@ -363,6 +388,10 @@ mod tests {
                     "0x3333333333333333333333333333333333333333333333333333333333333333"
                 ),
                 authenticator: address!("0x00000000000000000000000000000000000000bb"),
+                scope: Eip8130Constants::SCOPE_POLICY,
+                policy_data: bytes!(
+                    "00000000000000000000000000000000000000cc4444444444444444444444444444444444444444444444444444444444444444"
+                ),
             }],
         });
         let mut buf = Vec::new();

--- a/crates/common/consensus/src/transaction/eip8130/constants.rs
+++ b/crates/common/consensus/src/transaction/eip8130/constants.rs
@@ -43,17 +43,30 @@ impl Eip8130Constants {
     /// and replay protection relies on `expiry` (which must be non-zero).
     pub const NONCE_KEY_MAX: U256 = U256::MAX;
 
-    /// Actor scope bit: ERC-1271 `verifySignature()` context.
-    pub const SCOPE_SIGNATURE: u8 = 0x01;
+    /// Actor scope bit: ungated `sender_auth` validation context; may originate
+    /// transactions to any `call.to`.
+    pub const SCOPE_SENDER: u8 = 0x01;
 
-    /// Actor scope bit: `sender_auth` validation context.
-    pub const SCOPE_SENDER: u8 = 0x02;
+    /// Actor scope bit: policy-gated sender context; may originate transactions
+    /// only to the actor's `policy_manager`.
+    pub const SCOPE_POLICY: u8 = 0x02;
 
-    /// Actor scope bit: `payer_auth` validation context.
-    pub const SCOPE_PAYER: u8 = 0x04;
+    /// Actor scope bit: nonce authorization context; permits a restricted actor
+    /// to use sequenced `nonce_key`s (otherwise nonceless-only).
+    pub const SCOPE_NONCE: u8 = 0x04;
 
-    /// Actor scope bit: config change `auth` context.
-    pub const SCOPE_CONFIG: u8 = 0x08;
+    /// Actor scope bit: self-pay gas; authorizes paying the account's own gas
+    /// when `payer == sender`.
+    pub const SCOPE_SELF_PAYER: u8 = 0x08;
+
+    /// Actor scope bit: sponsor gas; authorizes acting as `payer_auth` for a
+    /// different sender (`payer != sender`).
+    pub const SCOPE_SPONSOR_PAYER: u8 = 0x10;
+
+    // ERC-1271 signing rides on operational authority (admin `scope == 0x00`, or
+    // a SENDER actor without POLICY); it is not its own scope bit, so there is no
+    // `SCOPE_SIGNATURE`. Bits `0x20`, `0x40`, and `0x80` are spare, reserved for
+    // future pure grants.
 
     /// Unrestricted scope value (actor is valid in all contexts).
     pub const SCOPE_UNRESTRICTED: u8 = 0x00;
@@ -107,6 +120,25 @@ impl Eip8130Constants {
     /// or revoking the self-actor; once set it is never cleared (monotonic), so
     /// an explicit self-actor entry always implies the flag is set.
     pub const DEFAULT_EOA_REVOKED: u8 = 0x01;
+
+    /// `AccountState.flags` bit (spec `LOCKED`): when set, actor configuration is
+    /// frozen — every config change and delegation is rejected on both the native
+    /// and EVM paths. The only permitted operation is `applySignedLockChanges`'s
+    /// unlock op. Set/cleared exclusively through the EVM `applySignedLockChanges`
+    /// entry point.
+    pub const FLAG_LOCKED: u8 = 0x02;
+
+    /// `AccountState.flags` bit (spec `UNLOCK_INITIATED`): selects how the packed
+    /// `lock_union` field is interpreted. While clear, `lock_union` holds the
+    /// configured `unlock_delay` (seconds, `uint16` range); while set, it holds
+    /// `unlocks_at` (the timestamp at which the pending unlock takes effect). Only
+    /// meaningful when [`Self::FLAG_LOCKED`] is set.
+    pub const FLAG_UNLOCK_INITIATED: u8 = 0x04;
+
+    /// Exact byte length of a policy-bearing actor's `policyData`:
+    /// `manager (20) || commitment (32)`. Required when `scope & SCOPE_POLICY`
+    /// is set; `policyData` MUST be empty otherwise.
+    pub const POLICY_DATA_LEN: usize = 52;
 
     /// Maximum number of `ConfigChange` entries the mempool accepts in a single
     /// transaction. The spec marks this as a node policy ("Nodes SHOULD enforce
@@ -187,10 +219,11 @@ mod tests {
     #[test]
     fn scope_bits_are_orthogonal() {
         let bits = [
-            Eip8130Constants::SCOPE_SIGNATURE,
             Eip8130Constants::SCOPE_SENDER,
-            Eip8130Constants::SCOPE_PAYER,
-            Eip8130Constants::SCOPE_CONFIG,
+            Eip8130Constants::SCOPE_POLICY,
+            Eip8130Constants::SCOPE_NONCE,
+            Eip8130Constants::SCOPE_SELF_PAYER,
+            Eip8130Constants::SCOPE_SPONSOR_PAYER,
         ];
         let mut acc: u8 = 0;
         for b in bits {

--- a/crates/common/evm/src/eip8130.rs
+++ b/crates/common/evm/src/eip8130.rs
@@ -104,10 +104,10 @@ pub struct Eip8130Outcome {
     /// The authenticated sender actor's id (published to the transaction context
     /// and used as the policy-gate subject).
     pub sender_actor_id: B256,
-    /// The sender actor's policy type; `0` means ungated (no policy gate).
-    pub policy_type: u8,
+    /// Whether the authenticated sender actor has `SCOPE_POLICY`.
+    pub policy_gated: bool,
     /// The policy gate target (`policy_manager(sender, actorId)`) resolved once
-    /// at authorization; every `call.to` must equal this when `policy_type != 0`.
+    /// at authorization; every `call.to` must equal this when policy-gated.
     pub policy_target: Address,
     /// The transaction's `gas_limit` (the sender-signed budget for sender
     /// authentication, intrinsic costs, account changes, and call execution).
@@ -689,8 +689,32 @@ impl Eip8130Executor {
             let acc = AccountConfigurationStorage::new(sctx);
             let sender_actor_id = acting_actor_hint
                 .unwrap_or_else(|| AccountConfigurationStorage::self_actor_id(sender));
-            let (policy_type, policy_target, _) =
-                acc.get_policy(sender, sender_actor_id).map_err(BaseTransactionError::eip8130)?;
+            // Resolve the acting scope with a single `actor_config` read (plus one
+            // `account_state` read only for the inline self-key path), then derive
+            // both the policy gate flag and target from it. Reading the target via
+            // `get_policy_manager` only when gated avoids `get_policy`'s extra
+            // `actor_config`/`account_state`/`policy_commitment` SLOADs on this
+            // estimation hot path (the commitment is unused here).
+            let actor_config = acc
+                .get_actor_config(sender, sender_actor_id)
+                .map_err(BaseTransactionError::eip8130)?;
+            let actor_scope = if !actor_config.authenticator.is_zero() {
+                actor_config.scope
+            } else if sender_actor_id == AccountConfigurationStorage::self_actor_id(sender) {
+                // Inline secp256k1 self key: scope lives in `account_state`, and a
+                // revoked default EOA resolves as ungated (mirrors `get_policy`).
+                let state = acc.get_account_state(sender).map_err(BaseTransactionError::eip8130)?;
+                if state.default_eoa_revoked() { 0 } else { state.default_eoa_scope }
+            } else {
+                0
+            };
+            let policy_gated = actor_scope & Eip8130Constants::SCOPE_POLICY != 0;
+            let policy_target = if policy_gated {
+                acc.get_policy_manager(sender, sender_actor_id)
+                    .map_err(BaseTransactionError::eip8130)?
+            } else {
+                Address::ZERO
+            };
 
             // 4. Auto-delegate a code-less sender to the default account. Unlike
             //    the verifying path this is unconditional on a code-less sender: a
@@ -718,7 +742,7 @@ impl Eip8130Executor {
                 sender,
                 payer,
                 sender_actor_id,
-                policy_type,
+                policy_gated,
                 policy_target,
                 gas_limit,
                 sender_intrinsic,
@@ -785,6 +809,16 @@ impl Eip8130Executor {
             let sender_actor = applied_tx.actors.sender.resolved;
             let sender = applied_tx.actors.sender.account;
             let payer = applied_tx.actors.payer.as_ref().map_or(sender, |p| p.account);
+            // Defense-in-depth: `authorize_and_apply` -> `verify_sender` already
+            // gates `allows_sequenced_nonce(nonce_key)` on both the configured and
+            // EOA sender paths, so this is redundant on the current call graph. It
+            // is kept as a local guard so this execution entry point stays sound if
+            // the sender-resolution path is ever refactored to skip that check.
+            if !sender_actor.allows_sequenced_nonce(nonce_key) {
+                return Err(BaseTransactionError::eip8130(
+                    "sender actor scope does not authorize sequenced nonces",
+                ));
+            }
 
             // 2. Install the deferred account-*code* effects (created-account
             //    bytecode, delegation indicator) the apply step surfaced.
@@ -879,7 +913,7 @@ impl Eip8130Executor {
                 sender,
                 payer,
                 sender_actor_id: sender_actor.actor_id,
-                policy_type: sender_actor.policy_type,
+                policy_gated: sender_actor.is_policy_gated(),
                 policy_target: sender_actor.policy_target,
                 gas_limit,
                 sender_intrinsic,
@@ -991,7 +1025,7 @@ impl Eip8130Executor {
                 // `call.to` must equal the resolved policy target. A mismatched
                 // call is not dispatched and fails the phase deterministically
                 // with `ActorPolicyViolation`, charging no call gas for it.
-                if outcome.policy_type != 0 && call.to != outcome.policy_target {
+                if outcome.policy_gated && call.to != outcome.policy_target {
                     phase_reverted = true;
                     phase_output =
                         Self::actor_policy_violation_data(outcome.sender_actor_id, call.to);
@@ -1915,7 +1949,6 @@ mod tests {
             address authenticator;
             uint8 scope;
             uint48 expiry;
-            uint8 policyType;
         }
     }
 
@@ -1925,14 +1958,12 @@ mod tests {
         authenticator: Address,
         scope: u8,
         expiry: u64,
-        policy_type: u8,
         policy_data: &[u8],
     ) -> Bytes {
         let abi = ActorConfigAbi {
             authenticator,
             scope,
             expiry: alloy_primitives::aliases::U48::from(expiry),
-            policyType: policy_type,
         };
         Bytes::from((abi, Bytes::copy_from_slice(policy_data)).abi_encode_params())
     }
@@ -1967,9 +1998,8 @@ mod tests {
                 actor_id: session_actor,
                 data: authorize_change_data(
                     Eip8130Constants::K1_AUTHENTICATOR,
-                    Eip8130Constants::SCOPE_SENDER,
+                    Eip8130Constants::SCOPE_SENDER | Eip8130Constants::SCOPE_POLICY,
                     0,
-                    1,
                     &policy_data,
                 ),
             }],
@@ -2409,11 +2439,10 @@ mod tests {
     }
 
     /// Canonical Solidity packing of an `ActorConfig` word.
-    fn pack_actor(authenticator: Address, scope: u8, expiry: u64, policy_type: u8) -> U256 {
+    fn pack_actor(authenticator: Address, scope: u8, expiry: u64) -> U256 {
         U256::from_be_slice(authenticator.as_slice())
             | (U256::from(scope) << 160)
             | (U256::from(expiry) << 168)
-            | (U256::from(policy_type) << 216)
     }
 
     /// Signs `tx` for a configured sender as `K1_AUTHENTICATOR || sig`.
@@ -2425,7 +2454,7 @@ mod tests {
         Eip8130Signed::new(tx, Bytes::from(auth), Bytes::new())
     }
 
-    /// Seeds a gated (`policy_type = 1`) `SENDER | PAYER` k1 actor for `account`,
+    /// Seeds a policy-gated `SENDER | PAYER` k1 actor for `account`,
     /// authorized to the `signer` key and gated to `target`, then commits it.
     fn seed_gated_sender(
         evm: &mut BaseEvm<InMemoryDB, NoOpInspector, PrecompilesMap>,
@@ -2446,9 +2475,11 @@ mod tests {
                     .at_mut(&account)
                     .write(pack_actor(
                         Eip8130Constants::K1_AUTHENTICATOR,
-                        Eip8130Constants::SCOPE_SENDER | Eip8130Constants::SCOPE_PAYER,
+                        Eip8130Constants::SCOPE_SENDER
+                            | Eip8130Constants::SCOPE_SELF_PAYER
+                            | Eip8130Constants::SCOPE_NONCE
+                            | Eip8130Constants::SCOPE_POLICY,
                         0,
-                        1,
                     ))
                     .unwrap();
                 acc.policy_manager.at_mut(&actor_id).at_mut(&account).write(target).unwrap();
@@ -2533,7 +2564,7 @@ mod tests {
             B256::from_slice(&id)
         };
         let initial_actors =
-            vec![InitialActor { actor_id, authenticator: Eip8130Constants::K1_AUTHENTICATOR }];
+            vec![InitialActor::owner(actor_id, Eip8130Constants::K1_AUTHENTICATOR)];
         let create = CreateEntry {
             user_salt: B256::ZERO,
             code: code.clone(),

--- a/crates/consensus/protocol/src/batch/transactions.rs
+++ b/crates/consensus/protocol/src/batch/transactions.rs
@@ -674,10 +674,10 @@ mod tests {
                 AccountChange::Create(CreateEntry {
                     user_salt: B256::repeat_byte(0x01),
                     code: bytes!("60006000fd"),
-                    initial_actors: vec![InitialActor {
-                        actor_id: B256::repeat_byte(0x02),
-                        authenticator: address!("00000000000000000000000000000000000000cc"),
-                    }],
+                    initial_actors: vec![InitialActor::owner(
+                        B256::repeat_byte(0x02),
+                        address!("00000000000000000000000000000000000000cc"),
+                    )],
                 }),
                 AccountChange::ConfigChange(ConfigChange {
                     chain_id: EIP8130_CHAIN_ID,

--- a/crates/execution/eip8130/src/account_config.rs
+++ b/crates/execution/eip8130/src/account_config.rs
@@ -25,9 +25,9 @@ use base_precompile_storage::{Handler, Mapping, Result};
 pub struct AccountConfigurationStorage {
     /// slot 0: per-actor configuration (packed `ActorConfig` word).
     pub actor_config: Mapping<B256, Mapping<Address, U256>>,
-    /// slot 1: per-actor signed policy commitment (set when `policy_type != 0`).
+    /// slot 1: per-actor signed policy commitment (set for `SCOPE_POLICY` actors).
     pub policy_commitment: Mapping<B256, Mapping<Address, B256>>,
-    /// slot 2: per-actor policy manager (set when `policy_type != 0`).
+    /// slot 2: per-actor policy manager (set for `SCOPE_POLICY` actors).
     pub policy_manager: Mapping<B256, Mapping<Address, Address>>,
     /// slot 3: per-account state (packed `AccountState` word).
     pub account_state: Mapping<Address, U256>,
@@ -66,36 +66,36 @@ impl AccountConfigurationStorage<'_> {
     }
 
     /// Mirrors `AccountConfiguration.getPolicy`: resolves an actor's policy
-    /// sub-type, gate target, and signed commitment. An ungated actor resolves
-    /// to `(0, address(0), bytes32(0))`; a gated one to `(policy_type, manager,
-    /// commitment)`. The secp256k1 self key's policy lives inline in
+    /// gate target and signed commitment. An ungated actor resolves to
+    /// `(address(0), bytes32(0))`; a gated one to `(manager, commitment)`.
+    /// The secp256k1 self key's policy scope lives inline in
     /// `AccountState` (read only while the self key is live); a non-k1 self and
     /// every other actor resolve from `actor_config`.
-    pub fn get_policy(&self, account: Address, actor_id: B256) -> Result<(u8, Address, B256)> {
+    pub fn get_policy(&self, account: Address, actor_id: B256) -> Result<(Address, B256)> {
         let stored = self.get_actor_config(account, actor_id)?;
-        let policy_type = if stored.authenticator != Address::ZERO {
-            stored.policy_type
+        let scope = if stored.authenticator != Address::ZERO {
+            stored.scope
         } else if actor_id == Self::self_actor_id(account) {
             let state = self.get_account_state(account)?;
             if state.default_eoa_revoked() {
-                return Ok((0, Address::ZERO, B256::ZERO));
+                return Ok((Address::ZERO, B256::ZERO));
             }
-            state.default_eoa_policy_type
+            state.default_eoa_scope
         } else {
-            return Ok((0, Address::ZERO, B256::ZERO));
+            return Ok((Address::ZERO, B256::ZERO));
         };
-        if policy_type == 0 {
-            return Ok((0, Address::ZERO, B256::ZERO));
+        if scope & Eip8130Constants::SCOPE_POLICY == 0 {
+            return Ok((Address::ZERO, B256::ZERO));
         }
         let manager = self.policy_manager.at(&actor_id).at(&account).read()?;
         let commitment = self.policy_commitment.at(&actor_id).at(&account).read()?;
-        Ok((policy_type, manager, commitment))
+        Ok((manager, commitment))
     }
 
     /// Reads only the stored policy *manager* slot for `(account, actor_id)`,
     /// without the `actor_config` re-read that [`Self::get_policy`] performs to
-    /// gate on `policy_type`. Callers that already hold the [`ActorConfig`] (and
-    /// have confirmed `policy_type != 0`) use this to resolve a policy target with
+    /// gate on `SCOPE_POLICY`. Callers that already hold the [`ActorConfig`] (and
+    /// have confirmed that bit) use this to resolve a policy target with
     /// a single trie/DB hit on the validation hot path. Mirrors the manager read
     /// in `AccountConfiguration._resolvePolicyTarget`.
     pub fn get_policy_manager(&self, account: Address, actor_id: B256) -> Result<Address> {
@@ -106,7 +106,7 @@ impl AccountConfigurationStorage<'_> {
     /// the single-SLOAD read a policy manager performs to validate a dispatched
     /// 8130 transaction against the actor's signed commitment. The
     /// `_authorizeActor`/`_revokeActor` invariant is that this slot is non-zero
-    /// iff the actor has a non-zero `policy_type` (across both self homes), so a
+    /// iff the actor has `SCOPE_POLICY` (across both self homes), so a
     /// zero return unambiguously means "no policy / no actor". Mirrors
     /// `AccountConfiguration.getPolicyCommitment`.
     pub fn get_policy_commitment(&self, account: Address, actor_id: B256) -> Result<B256> {
@@ -130,23 +130,18 @@ impl AccountConfigurationStorage<'_> {
         Ok(self.get_account_state(account)?.local_sequence > 0)
     }
 
-    /// Mirrors `AccountConfiguration.isLocked`: locked while `now < unlocks_at`.
+    /// Mirrors `AccountConfiguration._isLocked`: not locked unless `FLAG_LOCKED`
+    /// is set; hard-locked (frozen) while `FLAG_UNLOCK_INITIATED` is clear; once
+    /// an unlock is initiated, frozen only until `now >= lock_union` (`unlocks_at`).
     /// `now` is supplied by the caller (block timestamp at inclusion, wall-clock
     /// in the pool), since the reader has no block context.
     pub fn is_locked(&self, account: Address, now: u64) -> Result<bool> {
-        Ok(now < self.get_account_state(account)?.unlocks_at)
+        Ok(self.get_account_state(account)?.is_locked(now))
     }
 
     /// Mirrors `AccountConfiguration.getLockStatus`.
     pub fn get_lock_status(&self, account: Address, now: u64) -> Result<LockStatus> {
-        let state = self.get_account_state(account)?;
-        Ok(LockStatus {
-            locked: now < state.unlocks_at,
-            has_initiated_unlock: state.unlocks_at != 0
-                && state.unlocks_at != AccountState::UNLOCKS_AT_MAX,
-            unlocks_at: state.unlocks_at,
-            unlock_delay: state.unlock_delay,
-        })
+        Ok(self.get_account_state(account)?.lock_status(now))
     }
 
     /// The implicit-EOA self-actor id for `account`: `bytes32(bytes20(account))`,
@@ -201,13 +196,13 @@ impl AccountConfigurationStorage<'_> {
 
 /// Decoded `AccountConfiguration.ActorConfig` (one packed storage slot).
 ///
-/// Solidity layout `{address authenticator; uint8 scope; uint48 expiry; uint8
-/// policyType;}` packs right-aligned in declaration order, lowest-order field
+/// Solidity layout `{address authenticator; uint8 scope; uint48 expiry;}` packs
+/// right-aligned in declaration order, lowest-order field
 /// first, into a single 32-byte slot:
 ///
 /// ```text
-/// bytes (big-endian):  [0..4) unused | [4] policyType | [5..11) expiry | [11] scope | [12..32) authenticator
-/// bits  (LSB-first):   authenticator 0..160 | scope 160..168 | expiry 168..216 | policyType 216..224
+/// bytes (big-endian):  [0..5) reserved | [5..11) expiry | [11] scope | [12..32) authenticator
+/// bits  (LSB-first):   authenticator 0..160 | scope 160..168 | expiry 168..216 | reserved 216..256
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
@@ -220,14 +215,17 @@ pub struct ActorConfig {
     /// Unix-seconds expiry; `0 = no expiry`. The actor is invalid once
     /// `block.timestamp > expiry`.
     pub expiry: u64,
-    /// Policy sub-type byte; `0 = ungated`.
-    pub policy_type: u8,
 }
 
 impl ActorConfig {
     /// The empty (unset) actor config: a zeroed storage slot.
-    pub const EMPTY: Self =
-        Self { authenticator: Address::ZERO, scope: 0, expiry: 0, policy_type: 0 };
+    pub const EMPTY: Self = Self { authenticator: Address::ZERO, scope: 0, expiry: 0 };
+
+    /// Returns whether the reserved high 40 bits of a packed word are non-zero.
+    #[must_use]
+    pub fn has_nonzero_reserved(word: U256) -> bool {
+        word.to_be_bytes::<32>()[..5].iter().any(|&byte| byte != 0)
+    }
 
     /// Unpacks a raw `ActorConfig` storage word.
     #[must_use]
@@ -239,7 +237,6 @@ impl ActorConfig {
             authenticator: Address::from_slice(&b[12..32]),
             scope: b[11],
             expiry: u64::from_be_bytes(expiry),
-            policy_type: b[4],
         }
     }
 
@@ -262,21 +259,27 @@ impl ActorConfig {
         b[12..32].copy_from_slice(self.authenticator.as_slice());
         b[11] = self.scope;
         b[5..11].copy_from_slice(&self.expiry.to_be_bytes()[2..]); // uint48: low 6 bytes
-        b[4] = self.policy_type;
         U256::from_be_bytes(b)
     }
 }
 
 /// Decoded `AccountConfiguration.AccountState` (one packed storage slot).
 ///
-/// Solidity layout `{uint64 multichainSequence; uint64 localSequence; uint40
-/// unlocksAt; uint16 unlockDelay; uint8 flags; uint8 defaultEOAScope; uint8
-/// defaultEOAPolicyType; uint48 defaultEOAExpiry;}`, packed right-aligned,
-/// lowest-order field first, filling the slot to exactly 32 bytes:
+/// Solidity layout `{uint64 multichainSequence; uint64 localSequence; uint8
+/// flags; uint40 lockUnion; uint8 defaultEOAScope; uint48 defaultEOAExpiry;}`,
+/// packed right-aligned, lowest-order field first; the top 3 bytes of the slot
+/// are reserved padding that MUST stay zero:
 ///
 /// ```text
-/// bits (LSB-first): multichain 0..64 | local 64..128 | unlocksAt 128..168 | unlockDelay 168..184 | flags 184..192 | defaultEOAScope 192..200 | defaultEOAPolicyType 200..208 | defaultEOAExpiry 208..256
+/// bits (LSB-first): multichain 0..64 | local 64..128 | flags 128..136 | lock_union 136..176 | defaultEOAScope 176..184 | defaultEOAExpiry 184..232 | reserved 232..256
 /// ```
+///
+/// `lock_union` is a `uint40` union field (see [Account Lock] in the spec): while
+/// [`Eip8130Constants::FLAG_UNLOCK_INITIATED`] is clear it holds the configured
+/// `unlock_delay` (seconds, `uint16` range); while set it holds `unlocks_at` (the
+/// timestamp at which a pending unlock takes effect). Lock state is mutated only
+/// through the EVM `applySignedLockChanges` entry point; the native path only
+/// reads it (see [`Self::is_locked`]).
 ///
 /// The `default_eoa_*` fields are the inline home for the account's own
 /// secp256k1 ("self") key: when `DEFAULT_EOA_REVOKED` is unset, a k1 signature
@@ -286,6 +289,8 @@ impl ActorConfig {
 /// `actor_config(self)` slot is reserved for a *non*-k1 self authenticator
 /// (e.g. a post-quantum verifier returning the self-actorId); the inline k1
 /// self and a non-k1 self are mutually exclusive.
+///
+/// [Account Lock]: https://eips.ethereum.org/EIPS/eip-8130
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct AccountState {
@@ -294,28 +299,28 @@ pub struct AccountState {
     /// Sequence for local (`chain_id == block.chainid`) changes; `> 0` also marks
     /// the account initialized.
     pub local_sequence: u64,
-    /// Unlock timestamp (`uint40`). Locked while `now < unlocks_at`;
-    /// [`Self::UNLOCKS_AT_MAX`] means locked with no unlock initiated.
-    pub unlocks_at: u64,
-    /// Unlock delay in seconds.
-    pub unlock_delay: u16,
-    /// Account flags bitfield; bit 0 ([`Eip8130Constants::DEFAULT_EOA_REVOKED`])
-    /// disables the inline secp256k1 self key (both the implicit full owner and
-    /// any inline-scoped self).
+    /// Account flags bitfield: bit 0 ([`Eip8130Constants::DEFAULT_EOA_REVOKED`])
+    /// disables the inline secp256k1 self key; bit 1
+    /// ([`Eip8130Constants::FLAG_LOCKED`]) freezes actor configuration; bit 2
+    /// ([`Eip8130Constants::FLAG_UNLOCK_INITIATED`]) selects the `lock_union`
+    /// interpretation.
     pub flags: u8,
+    /// `uint40` lock union: `unlock_delay` (seconds) while `FLAG_UNLOCK_INITIATED`
+    /// is clear, else `unlocks_at` (Unix-seconds timestamp).
+    pub lock_union: u64,
     /// Inline self-key scope bitfield (`0` = unrestricted full owner). Governs
     /// only when the self key is live (`!default_eoa_revoked()`).
     pub default_eoa_scope: u8,
-    /// Inline self-key policy sub-type (`0` = ungated).
-    pub default_eoa_policy_type: u8,
     /// Inline self-key Unix-seconds expiry (`0` = no expiry). The self key is
     /// invalid once `now > default_eoa_expiry`.
     pub default_eoa_expiry: u64,
 }
 
 impl AccountState {
-    /// `type(uint40).max` — the sentinel `unlocks_at` written by `lock()` before
-    /// an unlock is initiated (locked indefinitely).
+    /// `type(uint40).max` — the `unlocks_at` value `getLockStatus` synthesizes for
+    /// a hard-locked account (`FLAG_LOCKED` set, `FLAG_UNLOCK_INITIATED` clear),
+    /// where `lock_union` actually stores the configured delay rather than a
+    /// timestamp. Not a stored sentinel.
     pub const UNLOCKS_AT_MAX: u64 = (1 << 40) - 1;
 
     /// Unpacks a raw `AccountState` storage word.
@@ -324,22 +329,18 @@ impl AccountState {
         let b = word.to_be_bytes::<32>();
         let mut multichain = [0u8; 8];
         let mut local = [0u8; 8];
-        let mut unlocks_at = [0u8; 8];
-        let mut unlock_delay = [0u8; 2];
+        let mut lock_union = [0u8; 8];
         let mut default_eoa_expiry = [0u8; 8];
-        multichain.copy_from_slice(&b[24..32]); // uint64
-        local.copy_from_slice(&b[16..24]); // uint64
-        unlocks_at[3..].copy_from_slice(&b[11..16]); // uint40: 5 bytes, big-endian
-        unlock_delay.copy_from_slice(&b[9..11]); // uint16
-        default_eoa_expiry[2..].copy_from_slice(&b[0..6]); // uint48: 6 bytes, big-endian
+        multichain.copy_from_slice(&b[24..32]); // uint64 at bits 0..64
+        local.copy_from_slice(&b[16..24]); // uint64 at bits 64..128
+        lock_union[3..].copy_from_slice(&b[10..15]); // uint40 at bits 136..176
+        default_eoa_expiry[2..].copy_from_slice(&b[3..9]); // uint48 at bits 184..232
         Self {
             multichain_sequence: u64::from_be_bytes(multichain),
             local_sequence: u64::from_be_bytes(local),
-            unlocks_at: u64::from_be_bytes(unlocks_at),
-            unlock_delay: u16::from_be_bytes(unlock_delay),
-            flags: b[8],                   // uint8 at bits 184..192
-            default_eoa_scope: b[7],       // uint8 at bits 192..200
-            default_eoa_policy_type: b[6], // uint8 at bits 200..208
+            flags: b[15], // uint8 at bits 128..136
+            lock_union: u64::from_be_bytes(lock_union),
+            default_eoa_scope: b[9], // uint8 at bits 176..184
             default_eoa_expiry: u64::from_be_bytes(default_eoa_expiry),
         }
     }
@@ -351,16 +352,64 @@ impl AccountState {
         self.flags & Eip8130Constants::DEFAULT_EOA_REVOKED != 0
     }
 
+    /// Mirrors `AccountConfiguration._isLocked`: configuration is frozen while
+    /// `FLAG_LOCKED` is set, except once an unlock has been initiated
+    /// (`FLAG_UNLOCK_INITIATED`), when it stays frozen only until `now` reaches
+    /// the stored `unlocks_at` (`lock_union`).
+    #[must_use]
+    pub const fn is_locked(&self, now: u64) -> bool {
+        if self.flags & Eip8130Constants::FLAG_LOCKED == 0 {
+            return false; // not locked
+        }
+        if self.flags & Eip8130Constants::FLAG_UNLOCK_INITIATED == 0 {
+            return true; // hard-locked, no pending unlock
+        }
+        now < self.lock_union // pending unlock: frozen until the timestamp elapses
+    }
+
+    /// Mirrors `AccountConfiguration.getLockStatus`, deriving the human-readable
+    /// lock view from the packed `flags`/`lock_union` union.
+    #[must_use]
+    pub const fn lock_status(&self, now: u64) -> LockStatus {
+        if self.flags & Eip8130Constants::FLAG_LOCKED == 0 {
+            return LockStatus {
+                locked: false,
+                has_initiated_unlock: false,
+                unlocks_at: 0,
+                unlock_delay: 0,
+            };
+        }
+        if self.flags & Eip8130Constants::FLAG_UNLOCK_INITIATED == 0 {
+            // Hard-locked: lock_union holds the configured delay; synthesize the
+            // max sentinel for `unlocks_at`. The delay is stored in `uint16` range
+            // by the lock op; mask explicitly to make the truncation intentional
+            // and mirror the contract's `uint16(config.lockUnion)` cast.
+            return LockStatus {
+                locked: true,
+                has_initiated_unlock: false,
+                unlocks_at: Self::UNLOCKS_AT_MAX,
+                unlock_delay: (self.lock_union & 0xFFFF) as u16,
+            };
+        }
+        // Unlock initiated: lock_union holds the effective unlock timestamp.
+        LockStatus {
+            locked: now < self.lock_union,
+            has_initiated_unlock: true,
+            unlocks_at: self.lock_union,
+            unlock_delay: 0,
+        }
+    }
+
     /// Packs this state into its raw storage word — the exact inverse of
     /// [`Self::from_word`].
     ///
-    /// `unlocks_at` must fit in `uint40` and `default_eoa_expiry` in `uint48`
+    /// `lock_union` must fit in `uint40` and `default_eoa_expiry` in `uint48`
     /// (their storage field widths); higher bytes are dropped. Values sourced
     /// from [`Self::from_word`] or ABI decoding always satisfy this, so the
     /// `debug_assert!`s only guard hand-constructed misuse.
     #[must_use]
     pub fn to_word(&self) -> U256 {
-        debug_assert!(self.unlocks_at >> 40 == 0, "unlocks_at exceeds uint40 storage width");
+        debug_assert!(self.lock_union >> 40 == 0, "lock_union exceeds uint40 storage width");
         debug_assert!(
             self.default_eoa_expiry >> 48 == 0,
             "default_eoa_expiry exceeds uint48 storage width"
@@ -368,12 +417,10 @@ impl AccountState {
         let mut b = [0u8; 32];
         b[24..32].copy_from_slice(&self.multichain_sequence.to_be_bytes());
         b[16..24].copy_from_slice(&self.local_sequence.to_be_bytes());
-        b[11..16].copy_from_slice(&self.unlocks_at.to_be_bytes()[3..]); // uint40: low 5 bytes
-        b[9..11].copy_from_slice(&self.unlock_delay.to_be_bytes());
-        b[8] = self.flags;
-        b[7] = self.default_eoa_scope;
-        b[6] = self.default_eoa_policy_type;
-        b[0..6].copy_from_slice(&self.default_eoa_expiry.to_be_bytes()[2..]); // uint48: low 6 bytes
+        b[15] = self.flags;
+        b[10..15].copy_from_slice(&self.lock_union.to_be_bytes()[3..]); // uint40: low 5 bytes
+        b[9] = self.default_eoa_scope;
+        b[3..9].copy_from_slice(&self.default_eoa_expiry.to_be_bytes()[2..]); // uint48 at bits 184..232
         U256::from_be_bytes(b)
     }
 }
@@ -382,14 +429,16 @@ impl AccountState {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct LockStatus {
-    /// `true` while `now < unlocks_at`.
+    /// `true` while the account is frozen at the queried timestamp.
     pub locked: bool,
-    /// `true` once `initiateUnlock` has run (`unlocks_at` set to a real time, not
-    /// `0` and not [`AccountState::UNLOCKS_AT_MAX`]).
+    /// `true` once the `applySignedLockChanges` unlock op (`UNLOCK_OP`) has run
+    /// (`FLAG_UNLOCK_INITIATED` set), i.e. an unlock is pending.
     pub has_initiated_unlock: bool,
-    /// The stored unlock timestamp.
+    /// The effective unlock timestamp: the stored `unlocks_at` once an unlock is
+    /// initiated, or [`AccountState::UNLOCKS_AT_MAX`] synthesized while
+    /// hard-locked.
     pub unlocks_at: u64,
-    /// The stored unlock delay in seconds.
+    /// The configured unlock delay in seconds (reported only while hard-locked).
     pub unlock_delay: u16,
 }
 
@@ -406,39 +455,33 @@ mod tests {
     /// Canonical Solidity packing of `ActorConfig` (each field at its bit
     /// offset). Independent of the byte-slice [`ActorConfig::from_word`] decoder,
     /// so agreement cross-checks the layout.
-    fn pack_actor_config(authenticator: Address, scope: u8, expiry: u64, policy_type: u8) -> U256 {
+    fn pack_actor_config(authenticator: Address, scope: u8, expiry: u64) -> U256 {
         U256::from_be_slice(authenticator.as_slice())
             | (U256::from(scope) << 160)
             | (U256::from(expiry) << 168)
-            | (U256::from(policy_type) << 216)
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn pack_account_state(
         multichain: u64,
         local: u64,
-        unlocks_at: u64,
-        unlock_delay: u16,
         flags: u8,
+        lock_union: u64,
         default_eoa_scope: u8,
-        default_eoa_policy_type: u8,
         default_eoa_expiry: u64,
     ) -> U256 {
         U256::from(multichain)
             | (U256::from(local) << 64)
-            | (U256::from(unlocks_at) << 128)
-            | (U256::from(unlock_delay) << 168)
-            | (U256::from(flags) << 184)
-            | (U256::from(default_eoa_scope) << 192)
-            | (U256::from(default_eoa_policy_type) << 200)
-            | (U256::from(default_eoa_expiry) << 208)
+            | (U256::from(flags) << 128)
+            | (U256::from(lock_union) << 136)
+            | (U256::from(default_eoa_scope) << 176)
+            | (U256::from(default_eoa_expiry) << 184)
     }
 
     #[test]
     fn actor_config_unpacks_each_field_from_its_slot_position() {
         let authenticator = address!("0x1234567890abcDEF1234567890aBcdef12345678");
         let expiry = (1u64 << 48) - 1; // full uint48
-        let word = pack_actor_config(authenticator, 0xAB, expiry, 0xCD);
+        let word = pack_actor_config(authenticator, 0xAB, expiry);
 
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, |ctx| {
@@ -448,7 +491,6 @@ mod tests {
             assert_eq!(config.authenticator, authenticator);
             assert_eq!(config.scope, 0xAB);
             assert_eq!(config.expiry, expiry);
-            assert_eq!(config.policy_type, 0xCD);
             assert!(!config.is_empty());
         });
     }
@@ -484,16 +526,7 @@ mod tests {
             // Empty slot, self actor id, DEFAULT_EOA_REVOKED set -> not an actor.
             acc.account_state
                 .at_mut(&ACCOUNT)
-                .write(pack_account_state(
-                    0,
-                    1,
-                    0,
-                    0,
-                    Eip8130Constants::DEFAULT_EOA_REVOKED,
-                    0,
-                    0,
-                    0,
-                ))
+                .write(pack_account_state(0, 1, Eip8130Constants::DEFAULT_EOA_REVOKED, 0, 0, 0))
                 .unwrap();
             assert!(!acc.is_actor(ACCOUNT, self_id).unwrap());
 
@@ -513,16 +546,16 @@ mod tests {
         StorageCtx::enter(&mut storage, |ctx| {
             let mut acc = AccountConfigurationStorage::new(ctx);
 
-            // Ungated actor (policy_type 0) -> zeroed regardless of stored slots.
+            // Ungated actor -> zeroed regardless of stored slots.
             acc.actor_config.at_mut(&ACTOR).at_mut(&ACCOUNT).write(pack(manager)).unwrap();
             acc.policy_manager.at_mut(&ACTOR).at_mut(&ACCOUNT).write(manager).unwrap();
-            assert_eq!(acc.get_policy(ACCOUNT, ACTOR).unwrap(), (0, Address::ZERO, B256::ZERO));
+            assert_eq!(acc.get_policy(ACCOUNT, ACTOR).unwrap(), (Address::ZERO, B256::ZERO));
 
-            // Gated actor -> (policy_type, manager, commitment).
-            let gated = pack_actor_config(manager, 0, 0, 7);
+            // Gated actor -> (manager, commitment).
+            let gated = pack_actor_config(manager, Eip8130Constants::SCOPE_POLICY, 0);
             acc.actor_config.at_mut(&ACTOR).at_mut(&ACCOUNT).write(gated).unwrap();
             acc.policy_commitment.at_mut(&ACTOR).at_mut(&ACCOUNT).write(commitment).unwrap();
-            assert_eq!(acc.get_policy(ACCOUNT, ACTOR).unwrap(), (7, manager, commitment));
+            assert_eq!(acc.get_policy(ACCOUNT, ACTOR).unwrap(), (manager, commitment));
         });
     }
 
@@ -538,31 +571,22 @@ mod tests {
             acc.policy_manager.at_mut(&self_id).at_mut(&ACCOUNT).write(manager).unwrap();
             acc.policy_commitment.at_mut(&self_id).at_mut(&ACCOUNT).write(commitment).unwrap();
 
-            // Live full-owner self (inline policy_type 0) -> ungated, slots ignored.
-            assert_eq!(acc.get_policy(ACCOUNT, self_id).unwrap(), (0, Address::ZERO, B256::ZERO));
+            // Live full-owner self -> ungated, slots ignored.
+            assert_eq!(acc.get_policy(ACCOUNT, self_id).unwrap(), (Address::ZERO, B256::ZERO));
 
-            // Live scoped self with an inline gate -> (policy_type, manager, commitment).
+            // Live scoped self with an inline gate -> (manager, commitment).
             acc.account_state
                 .at_mut(&ACCOUNT)
-                .write(pack_account_state(0, 1, 0, 0, 0, 0, 9, 0))
+                .write(pack_account_state(0, 1, 0, 0, Eip8130Constants::SCOPE_POLICY, 0))
                 .unwrap();
-            assert_eq!(acc.get_policy(ACCOUNT, self_id).unwrap(), (9, manager, commitment));
+            assert_eq!(acc.get_policy(ACCOUNT, self_id).unwrap(), (manager, commitment));
 
-            // Revoked self -> ungated regardless of the inline policy_type.
+            // Revoked self -> ungated regardless of the inline scope.
             acc.account_state
                 .at_mut(&ACCOUNT)
-                .write(pack_account_state(
-                    0,
-                    1,
-                    0,
-                    0,
-                    Eip8130Constants::DEFAULT_EOA_REVOKED,
-                    0,
-                    9,
-                    0,
-                ))
+                .write(pack_account_state(0, 1, Eip8130Constants::DEFAULT_EOA_REVOKED, 0, 0, 0))
                 .unwrap();
-            assert_eq!(acc.get_policy(ACCOUNT, self_id).unwrap(), (0, Address::ZERO, B256::ZERO));
+            assert_eq!(acc.get_policy(ACCOUNT, self_id).unwrap(), (Address::ZERO, B256::ZERO));
         });
     }
 
@@ -581,14 +605,13 @@ mod tests {
     #[test]
     fn account_state_unpacks_sequences_and_lock_fields() {
         let expiry = (1u64 << 48) - 1; // full uint48
+        let lock_union = (1u64 << 40) - 1; // full uint40
         let word = pack_account_state(
             7,
             3,
-            (1u64 << 40) - 1,
-            0xBEEF,
-            Eip8130Constants::DEFAULT_EOA_REVOKED,
+            Eip8130Constants::DEFAULT_EOA_REVOKED | Eip8130Constants::FLAG_LOCKED,
+            lock_union,
             0xAB,
-            0xCD,
             expiry,
         );
         let mut storage = HashMapStorageProvider::new(1);
@@ -599,11 +622,9 @@ mod tests {
             let state = acc.get_account_state(ACCOUNT).unwrap();
             assert_eq!(state.multichain_sequence, 7);
             assert_eq!(state.local_sequence, 3);
-            assert_eq!(state.unlocks_at, AccountState::UNLOCKS_AT_MAX);
-            assert_eq!(state.unlock_delay, 0xBEEF);
+            assert_eq!(state.lock_union, lock_union);
             assert!(state.default_eoa_revoked());
             assert_eq!(state.default_eoa_scope, 0xAB);
-            assert_eq!(state.default_eoa_policy_type, 0xCD);
             assert_eq!(state.default_eoa_expiry, expiry);
             assert_eq!(acc.get_change_sequences(ACCOUNT).unwrap(), (7, 3));
             assert!(acc.is_initialized(ACCOUNT).unwrap());
@@ -617,21 +638,30 @@ mod tests {
         StorageCtx::enter(&mut storage, |ctx| {
             let mut acc = AccountConfigurationStorage::new(ctx);
 
-            // lock(): unlocks_at = max, delay set. Locked, no unlock initiated.
+            // LOCK_OP: FLAG_LOCKED set, lock_union holds the delay. Hard-locked,
+            // no unlock initiated — frozen regardless of `now`.
             acc.account_state
                 .at_mut(&ACCOUNT)
-                .write(pack_account_state(0, 1, AccountState::UNLOCKS_AT_MAX, delay, 0, 0, 0, 0))
+                .write(pack_account_state(0, 1, Eip8130Constants::FLAG_LOCKED, delay as u64, 0, 0))
                 .unwrap();
             assert!(acc.is_locked(ACCOUNT, 1_000).unwrap());
             let status = acc.get_lock_status(ACCOUNT, 1_000).unwrap();
             assert!(status.locked);
             assert!(!status.has_initiated_unlock);
+            assert_eq!(status.unlocks_at, AccountState::UNLOCKS_AT_MAX);
             assert_eq!(status.unlock_delay, delay);
 
-            // initiateUnlock(): unlocks_at = real future time, delay cleared.
+            // UNLOCK_OP: FLAG_UNLOCK_INITIATED set, lock_union holds unlocks_at.
             acc.account_state
                 .at_mut(&ACCOUNT)
-                .write(pack_account_state(0, 1, 2_000, 0, 0, 0, 0, 0))
+                .write(pack_account_state(
+                    0,
+                    1,
+                    Eip8130Constants::FLAG_LOCKED | Eip8130Constants::FLAG_UNLOCK_INITIATED,
+                    2_000,
+                    0,
+                    0,
+                ))
                 .unwrap();
             assert!(acc.is_locked(ACCOUNT, 1_000).unwrap()); // before unlocks_at
             assert!(!acc.is_locked(ACCOUNT, 2_000).unwrap()); // at/after unlocks_at
@@ -640,11 +670,8 @@ mod tests {
             assert!(status.has_initiated_unlock);
             assert_eq!(status.unlocks_at, 2_000);
 
-            // Never locked: unlocks_at = 0.
-            acc.account_state
-                .at_mut(&ACCOUNT)
-                .write(pack_account_state(0, 1, 0, 0, 0, 0, 0, 0))
-                .unwrap();
+            // Never locked: no lock flags set.
+            acc.account_state.at_mut(&ACCOUNT).write(pack_account_state(0, 1, 0, 0, 0, 0)).unwrap();
             assert!(!acc.is_locked(ACCOUNT, 0).unwrap());
             assert!(!acc.get_lock_status(ACCOUNT, 0).unwrap().has_initiated_unlock);
         });
@@ -654,14 +681,20 @@ mod tests {
     fn actor_config_to_word_inverts_from_word_and_matches_packing() {
         let authenticator = address!("0x1234567890abcDEF1234567890aBcdef12345678");
         let config =
-            ActorConfig::from_word(pack_actor_config(authenticator, 0xAB, (1u64 << 48) - 1, 0xCD));
+            ActorConfig::from_word(pack_actor_config(authenticator, 0xAB, (1u64 << 48) - 1));
         // to_word matches the independent Solidity packing, and round-trips.
-        assert_eq!(
-            config.to_word(),
-            pack_actor_config(authenticator, 0xAB, (1u64 << 48) - 1, 0xCD)
-        );
+        assert_eq!(config.to_word(), pack_actor_config(authenticator, 0xAB, (1u64 << 48) - 1));
         assert_eq!(ActorConfig::from_word(config.to_word()), config);
         assert_eq!(ActorConfig::EMPTY.to_word(), U256::ZERO);
+    }
+
+    #[test]
+    fn actor_config_reserved_bits_are_detected_and_cleared_on_write() {
+        let word = pack_actor_config(ACCOUNT, 0xAB, 42) | (U256::from(1) << 216);
+        assert!(ActorConfig::has_nonzero_reserved(word));
+        let config = ActorConfig::from_word(word);
+        assert!(!ActorConfig::has_nonzero_reserved(config.to_word()));
+        assert_eq!(config.to_word(), pack_actor_config(ACCOUNT, 0xAB, 42));
     }
 
     #[test]
@@ -669,11 +702,9 @@ mod tests {
         let word = pack_account_state(
             7,
             3,
+            Eip8130Constants::DEFAULT_EOA_REVOKED | Eip8130Constants::FLAG_UNLOCK_INITIATED,
             (1u64 << 40) - 1,
-            0xBEEF,
-            Eip8130Constants::DEFAULT_EOA_REVOKED,
             0xAB,
-            0xCD,
             (1u64 << 48) - 1,
         );
         let state = AccountState::from_word(word);
@@ -691,6 +722,6 @@ mod tests {
     /// Packs an `ActorConfig` carrying only an authenticator (scope/expiry/policy
     /// zero) — the common shape for the `is_actor` predicate.
     fn pack(authenticator: Address) -> U256 {
-        pack_actor_config(authenticator, 0, 0, 0)
+        pack_actor_config(authenticator, 0, 0)
     }
 }

--- a/crates/execution/eip8130/src/apply.rs
+++ b/crates/execution/eip8130/src/apply.rs
@@ -3,7 +3,7 @@
 //! delegation, mirroring `AccountConfiguration`'s write semantics.
 //!
 //! [`ConfigChangeAuthorizer`] authenticates a config change and gates it on
-//! `SCOPE_CONFIG`, but does not decode each [`ActorChange`]'s `data` or mutate
+//! admin scope (`scope == 0`), but does not decode each [`ActorChange`]'s `data` or mutate
 //! `actor_config`; that is this module's job. It is the native mirror of
 //! `AccountConfiguration.applySignedActorChanges`'s mutation tail
 //! (`_authorizeActor` / `_revokeActor` / `_slicePolicy`), of `createAccount` /
@@ -38,7 +38,6 @@ sol! {
         address authenticator;
         uint8 scope;
         uint48 expiry;
-        uint8 policyType;
     }
 }
 
@@ -63,15 +62,9 @@ pub enum ApplyError {
     #[error("authenticator address(0) is not a valid selector")]
     InvalidAuthenticator,
 
-    /// A policy-bearing actor is unrestricted or holds `SCOPE_CONFIG`. The policy
-    /// gate only covers SENDER-context calls, so such a key could escape its
-    /// policy. Mirrors `_authorizeActor`'s policy/scope `require`.
-    #[error("policy-bearing actor must be scope-restricted and may not hold CONFIG scope")]
-    PolicyScope,
-
-    /// `policyData` did not match its `policyType` (non-empty for `POLICY_NONE`,
-    /// not exactly `manager(20) || commitment(32)` for a gated actor, or a zero
-    /// manager/commitment). Mirrors `_slicePolicy`.
+    /// `policyData` did not match the actor's `SCOPE_POLICY` bit (non-empty for
+    /// an ungated actor, or not exactly `manager(20) || commitment(32)` for a
+    /// gated actor). Mirrors `_slicePolicy`.
     #[error("policy data does not match policy type")]
     MalformedPolicyData,
 
@@ -258,15 +251,7 @@ impl AccountChangeApplier {
             return Err(ApplyError::InvalidAuthenticator);
         }
 
-        // A policy-bearing actor must be scope-restricted and may not hold CONFIG
-        // scope (the policy gate covers only SENDER-context calls).
-        if config.policy_type != 0
-            && (config.scope == 0 || config.scope & Eip8130Constants::SCOPE_CONFIG != 0)
-        {
-            return Err(ApplyError::PolicyScope);
-        }
-
-        let (manager, commitment) = Self::slice_policy(config.policy_type, policy_data)?;
+        let (manager, commitment) = Self::slice_policy(config.scope, policy_data)?;
         let self_id = AccountConfigurationStorage::self_actor_id(account);
 
         if actor_id == self_id {
@@ -277,7 +262,6 @@ impl AccountChangeApplier {
                 // Mutual exclusion: drop any non-k1 self and move into the inline home.
                 storage.clear_actor_config(account, actor_id)?;
                 state.default_eoa_scope = config.scope;
-                state.default_eoa_policy_type = config.policy_type;
                 state.default_eoa_expiry = config.expiry;
                 state.flags &= !Eip8130Constants::DEFAULT_EOA_REVOKED;
             } else {
@@ -286,7 +270,6 @@ impl AccountChangeApplier {
                 // Mutual exclusion: disable and clear the inline k1 self.
                 state.flags |= Eip8130Constants::DEFAULT_EOA_REVOKED;
                 state.default_eoa_scope = 0;
-                state.default_eoa_policy_type = 0;
                 state.default_eoa_expiry = 0;
             }
             storage.set_account_state(account, state)?;
@@ -299,7 +282,7 @@ impl AccountChangeApplier {
         // Non-self actor: a single `actor_config` home. Upsert: overwrite in
         // place. `set_policy` writes both policy slots (zero clears), resetting
         // any stale policy so an actor moving policy-bearing -> none can't leak
-        // state, preserving the "commitment non-zero iff policy_type non-zero"
+        // state, preserving the "commitment non-zero iff SCOPE_POLICY is set"
         // invariant.
         storage.set_actor_config(account, actor_id, config)?;
         storage.set_policy(account, actor_id, manager, commitment)?;
@@ -323,7 +306,6 @@ impl AccountChangeApplier {
             let mut state = storage.get_account_state(account)?;
             state.flags |= Eip8130Constants::DEFAULT_EOA_REVOKED;
             state.default_eoa_scope = 0;
-            state.default_eoa_policy_type = 0;
             state.default_eoa_expiry = 0;
             storage.set_account_state(account, state)?;
         }
@@ -362,8 +344,10 @@ impl AccountChangeApplier {
         Ok(CreatedAccount { address, code: entry.code.clone() })
     }
 
-    /// Registers a create entry's initial actors as unrestricted owners, enforcing
-    /// the non-empty and strictly-ascending invariants. Mirrors
+    /// Registers a create entry's initial actors, enforcing the non-empty and
+    /// strictly-ascending invariants. Each actor carries its `scope` and
+    /// `policyData` verbatim (validated by `authorizeActor`'s frozen `policyData`
+    /// rule); `expiry` is not expressible at create and is always `0`. Mirrors
     /// `_initializeAccount`.
     fn initialize_actors(
         storage: &mut AccountConfigurationStorage<'_>,
@@ -379,14 +363,11 @@ impl AccountChangeApplier {
                 return Err(ApplyError::UnsortedInitialActors);
             }
             previous = actor.actor_id;
-            // Initial actors are always unrestricted owners: scope/expiry/policy 0.
-            let config = ActorConfig {
-                authenticator: actor.authenticator,
-                scope: 0,
-                expiry: 0,
-                policy_type: 0,
-            };
-            Self::authorize_actor(storage, account, actor.actor_id, config, &[])?;
+            // Scope is verbatim and expiry is forced to 0 at create; `policyData`
+            // is validated and written by `authorize_actor` / `slice_policy`.
+            let config =
+                ActorConfig { authenticator: actor.authenticator, scope: actor.scope, expiry: 0 };
+            Self::authorize_actor(storage, account, actor.actor_id, config, &actor.policy_data)?;
         }
         Ok(())
     }
@@ -399,32 +380,28 @@ impl AccountChangeApplier {
             authenticator: abi.authenticator,
             scope: abi.scope,
             expiry: abi.expiry.to::<u64>(),
-            policy_type: abi.policyType,
         };
         Ok((config, policy_data))
     }
 
-    /// Validates `policy_data` against `policy_type`, returning `(manager,
-    /// commitment)`. Mirrors `_slicePolicy`: `POLICY_NONE` requires empty data; a
-    /// gated actor requires `manager(20) || commitment(32)`, both non-zero.
-    pub fn slice_policy(
-        policy_type: u8,
-        policy_data: &[u8],
-    ) -> Result<(Address, B256), ApplyError> {
-        if policy_type == 0 {
+    /// Validates `policy_data` against `scope`, returning `(manager,
+    /// commitment)`. Mirrors `_slicePolicy`: an actor without `SCOPE_POLICY`
+    /// requires empty data; a gated actor requires exactly
+    /// `manager(20) || commitment(32)`, written verbatim. Neither field need be
+    /// nonzero — a zero `commitment` is a valid "no parameters" value and a zero
+    /// `manager` gates the key to `address(0)` (no productive target).
+    pub fn slice_policy(scope: u8, policy_data: &[u8]) -> Result<(Address, B256), ApplyError> {
+        if scope & Eip8130Constants::SCOPE_POLICY == 0 {
             if !policy_data.is_empty() {
                 return Err(ApplyError::MalformedPolicyData);
             }
             return Ok((Address::ZERO, B256::ZERO));
         }
-        if policy_data.len() != 52 {
+        if policy_data.len() != Eip8130Constants::POLICY_DATA_LEN {
             return Err(ApplyError::MalformedPolicyData);
         }
         let manager = Address::from_slice(&policy_data[..20]);
-        let commitment = B256::from_slice(&policy_data[20..52]);
-        if manager.is_zero() || commitment.is_zero() {
-            return Err(ApplyError::MalformedPolicyData);
-        }
+        let commitment = B256::from_slice(&policy_data[20..Eip8130Constants::POLICY_DATA_LEN]);
         Ok((manager, commitment))
     }
 
@@ -455,13 +432,19 @@ impl AccountChangeApplier {
         keccak256(packed)
     }
 
-    /// The packed commitment over the initial actor set, 52 bytes per actor:
-    /// `actorId(32) || authenticator(20)`. Mirrors `_computeActorsCommitment`.
+    /// The packed commitment over the initial actor set. The per-actor
+    /// contribution is `actorId(32) || authenticator(20) || scope(1) ||
+    /// policyData` — 53 bytes for a non-policy actor, 105 bytes when `POLICY`
+    /// is set (appending `manager (20) || commitment (32)`). `expiry` does not
+    /// participate. The per-actor length is fully determined by `scope`, so the
+    /// concatenation is unambiguous. Mirrors `_computeActorsCommitment`.
     fn actors_commitment(initial_actors: &[InitialActor]) -> B256 {
-        let mut packed = Vec::with_capacity(initial_actors.len() * 52);
+        let mut packed = Vec::with_capacity(initial_actors.len() * 53);
         for actor in initial_actors {
             packed.extend_from_slice(actor.actor_id.as_slice());
             packed.extend_from_slice(actor.authenticator.as_slice());
+            packed.push(actor.scope);
+            packed.extend_from_slice(&actor.policy_data);
         }
         keccak256(packed)
     }
@@ -517,13 +500,12 @@ mod tests {
             authenticator: config.authenticator,
             scope: config.scope,
             expiry: alloy_primitives::aliases::U48::from(config.expiry),
-            policyType: config.policy_type,
         };
         Bytes::from((abi, Bytes::copy_from_slice(policy_data)).abi_encode_params())
     }
 
     fn ungated(authenticator: Address, scope: u8) -> ActorConfig {
-        ActorConfig { authenticator, scope, expiry: 0, policy_type: 0 }
+        ActorConfig { authenticator, scope, expiry: 0 }
     }
 
     #[test]
@@ -540,17 +522,22 @@ mod tests {
         let mut data = Vec::new();
         data.extend_from_slice(MANAGER.as_slice());
         data.extend_from_slice(COMMITMENT.as_slice());
-        assert_eq!(AccountChangeApplier::slice_policy(1, &data).unwrap(), (MANAGER, COMMITMENT));
-
-        // Wrong length, and zero manager/commitment, all reject.
         assert_eq!(
-            AccountChangeApplier::slice_policy(1, &data[..51]),
+            AccountChangeApplier::slice_policy(Eip8130Constants::SCOPE_POLICY, &data).unwrap(),
+            (MANAGER, COMMITMENT)
+        );
+
+        // Wrong length rejects.
+        assert_eq!(
+            AccountChangeApplier::slice_policy(Eip8130Constants::SCOPE_POLICY, &data[..51]),
             Err(ApplyError::MalformedPolicyData)
         );
+        // Per the frozen rule, neither field need be nonzero: a zero
+        // manager/commitment is well-formed (`manager(20) || commitment(32)`).
         let zero_mgr = [0u8; 52];
         assert_eq!(
-            AccountChangeApplier::slice_policy(1, &zero_mgr),
-            Err(ApplyError::MalformedPolicyData)
+            AccountChangeApplier::slice_policy(Eip8130Constants::SCOPE_POLICY, &zero_mgr).unwrap(),
+            (Address::ZERO, B256::ZERO)
         );
     }
 
@@ -563,7 +550,7 @@ mod tests {
             assert!(acc.is_actor(ACCOUNT, NON_SELF).unwrap());
 
             // Upsert: re-authorizing an occupied slot overwrites it in place.
-            let rescoped = ungated(AUTHENTICATOR, Eip8130Constants::SCOPE_PAYER);
+            let rescoped = ungated(AUTHENTICATOR, Eip8130Constants::SCOPE_SELF_PAYER);
             AccountChangeApplier::authorize_actor(acc, ACCOUNT, NON_SELF, rescoped, &[]).unwrap();
             assert_eq!(acc.get_actor_config(ACCOUNT, NON_SELF).unwrap(), rescoped);
 
@@ -589,41 +576,27 @@ mod tests {
     }
 
     #[test]
-    fn policy_bearing_actor_scope_constraints() {
+    fn policy_scope_controls_policy_data() {
         with_storage(|acc| {
             let mut data = Vec::new();
             data.extend_from_slice(MANAGER.as_slice());
             data.extend_from_slice(COMMITMENT.as_slice());
 
-            // Unrestricted (scope 0) policy-bearing actor rejected.
-            let unrestricted =
-                ActorConfig { authenticator: AUTHENTICATOR, scope: 0, expiry: 0, policy_type: 1 };
+            // Policy data without SCOPE_POLICY is rejected.
+            let unrestricted = ActorConfig { authenticator: AUTHENTICATOR, scope: 0, expiry: 0 };
             assert_eq!(
                 AccountChangeApplier::authorize_actor(acc, ACCOUNT, NON_SELF, unrestricted, &data),
-                Err(ApplyError::PolicyScope)
+                Err(ApplyError::MalformedPolicyData)
             );
 
-            // CONFIG-scoped policy-bearing actor rejected.
-            let config_scoped = ActorConfig {
-                authenticator: AUTHENTICATOR,
-                scope: Eip8130Constants::SCOPE_CONFIG,
-                expiry: 0,
-                policy_type: 1,
-            };
-            assert_eq!(
-                AccountChangeApplier::authorize_actor(acc, ACCOUNT, NON_SELF, config_scoped, &data),
-                Err(ApplyError::PolicyScope)
-            );
-
-            // SENDER-scoped policy-bearing actor accepted; policy slots written.
+            // SCOPE_POLICY actor accepted; policy slots written.
             let ok = ActorConfig {
                 authenticator: AUTHENTICATOR,
-                scope: Eip8130Constants::SCOPE_SENDER,
+                scope: Eip8130Constants::SCOPE_POLICY,
                 expiry: 0,
-                policy_type: 1,
             };
             AccountChangeApplier::authorize_actor(acc, ACCOUNT, NON_SELF, ok, &data).unwrap();
-            assert_eq!(acc.get_policy(ACCOUNT, NON_SELF).unwrap(), (1, MANAGER, COMMITMENT));
+            assert_eq!(acc.get_policy(ACCOUNT, NON_SELF).unwrap(), (MANAGER, COMMITMENT));
         });
     }
 
@@ -637,19 +610,18 @@ mod tests {
             // Authorize a policy-bearing actor; policy slots populated.
             let gated = ActorConfig {
                 authenticator: AUTHENTICATOR,
-                scope: Eip8130Constants::SCOPE_SENDER,
+                scope: Eip8130Constants::SCOPE_POLICY,
                 expiry: 0,
-                policy_type: 1,
             };
             AccountChangeApplier::authorize_actor(acc, ACCOUNT, NON_SELF, gated, &data).unwrap();
-            assert_eq!(acc.get_policy(ACCOUNT, NON_SELF).unwrap(), (1, MANAGER, COMMITMENT));
+            assert_eq!(acc.get_policy(ACCOUNT, NON_SELF).unwrap(), (MANAGER, COMMITMENT));
 
             // Upsert the same actor down to no policy: the stale manager/commitment
-            // must be cleared (commitment-non-zero-iff-policy_type invariant).
+            // must be cleared (policy slots are written only while SCOPE_POLICY is set).
             let ungated_cfg = ungated(AUTHENTICATOR, Eip8130Constants::SCOPE_SENDER);
             AccountChangeApplier::authorize_actor(acc, ACCOUNT, NON_SELF, ungated_cfg, &[])
                 .unwrap();
-            assert_eq!(acc.get_policy(ACCOUNT, NON_SELF).unwrap(), (0, Address::ZERO, B256::ZERO));
+            assert_eq!(acc.get_policy(ACCOUNT, NON_SELF).unwrap(), (Address::ZERO, B256::ZERO));
             assert_eq!(acc.get_policy_manager(ACCOUNT, NON_SELF).unwrap(), Address::ZERO);
         });
     }
@@ -669,11 +641,11 @@ mod tests {
 
             // Upsert: re-authorizing a live self rescopes the inline config in
             // place (no prior revoke required).
-            let rescoped = ungated(K1, Eip8130Constants::SCOPE_PAYER);
+            let rescoped = ungated(K1, Eip8130Constants::SCOPE_SELF_PAYER);
             AccountChangeApplier::authorize_actor(acc, ACCOUNT, self_id, rescoped, &[]).unwrap();
             let state = acc.get_account_state(ACCOUNT).unwrap();
             assert!(!state.default_eoa_revoked());
-            assert_eq!(state.default_eoa_scope, Eip8130Constants::SCOPE_PAYER);
+            assert_eq!(state.default_eoa_scope, Eip8130Constants::SCOPE_SELF_PAYER);
 
             // Revoke sets the flag and clears the inline config.
             AccountChangeApplier::revoke_actor(acc, ACCOUNT, self_id).unwrap();
@@ -736,10 +708,7 @@ mod tests {
                     "0x2222222222222222222222222222222222222222222222222222222222222222"
                 ),
                 code: Bytes::from_static(&[0x60, 0x00]),
-                initial_actors: vec![InitialActor {
-                    actor_id: NON_SELF,
-                    authenticator: AUTHENTICATOR,
-                }],
+                initial_actors: vec![InitialActor::owner(NON_SELF, AUTHENTICATOR)],
             };
             let expected = AccountChangeApplier::compute_address(
                 entry.user_salt,
@@ -778,10 +747,7 @@ mod tests {
                     "0x3333333333333333333333333333333333333333333333333333333333333333"
                 ),
                 code: Bytes::from_static(&[0x60, 0x00]),
-                initial_actors: vec![InitialActor {
-                    actor_id: NON_SELF,
-                    authenticator: AUTHENTICATOR,
-                }],
+                initial_actors: vec![InitialActor::owner(NON_SELF, AUTHENTICATOR)],
             };
             let expected = AccountChangeApplier::compute_address(
                 entry.user_salt,
@@ -818,8 +784,8 @@ mod tests {
                 user_salt: B256::ZERO,
                 code: Bytes::new(),
                 initial_actors: vec![
-                    InitialActor { actor_id: B256::repeat_byte(2), authenticator: AUTHENTICATOR },
-                    InitialActor { actor_id: B256::repeat_byte(1), authenticator: AUTHENTICATOR },
+                    InitialActor::owner(B256::repeat_byte(2), AUTHENTICATOR),
+                    InitialActor::owner(B256::repeat_byte(1), AUTHENTICATOR),
                 ],
             };
             assert_eq!(

--- a/crates/execution/eip8130/src/authorize.rs
+++ b/crates/execution/eip8130/src/authorize.rs
@@ -78,12 +78,16 @@ impl ActorAuthorizer {
                 nested_actor_id,
             } => {
                 // Discharge the nested actor against the delegated account's
-                // config and require it to carry SIGNATURE scope, then authorize
+                // config and require it to be admin (`scope == 0`), then authorize
                 // the outer delegate actor against the originating account.
-                // Mirrors `DelegateAuthenticator` calling
-                // `verifySignature(delegate, ...)` (which accepts only an
-                // unrestricted or `SCOPE_SIGNATURE` actor) followed by the outer
-                // `_actorConfig[bytes20(delegate)][account]` binding check.
+                // Mirrors `DelegateAuthenticator`, which calls
+                // `authenticateActor(delegate, ...)` and explicitly requires the
+                // resolved `scope == 0`. This admin requirement is independent of
+                // `verifySignature` (now operational: admin, or a SENDER actor
+                // without POLICY): an operational key may sign for its own account
+                // but MUST NOT vouch as a delegate, to preserve non-escalation.
+                // Followed by the outer `_actorConfig[bytes20(delegate)][account]`
+                // binding check.
                 let nested = Self::resolve_bound(
                     storage,
                     delegate_account,
@@ -91,7 +95,7 @@ impl ActorAuthorizer {
                     nested_authenticator,
                     now,
                 )?;
-                if nested.scope != 0 && nested.scope & Eip8130Constants::SCOPE_SIGNATURE == 0 {
+                if nested.scope != 0 {
                     return Err(AuthorizeError::NestedSignatureScope { actor_id: nested_actor_id });
                 }
                 Self::resolve_bound(
@@ -113,7 +117,7 @@ impl ActorAuthorizer {
     /// the account-state slot, a single SLOAD: a set `DEFAULT_EOA_REVOKED` flag
     /// disables it (revoked, or a non-k1 self is the live self authenticator), an
     /// all-zero inline config is the implicit full owner, and a non-zero inline
-    /// `scope`/`policy_type`/`expiry` is a scoped self. Every *other* recovered
+    /// `scope`/`expiry` is a scoped self. Every *other* recovered
     /// signer must carry an explicit k1 `actor_config` entry, validated by
     /// [`Self::resolve_bound`].
     ///
@@ -150,7 +154,7 @@ impl ActorAuthorizer {
             // `_resolvePolicyTarget`: address(0) when ungated, else the policy
             // manager (keyed by the self-actorId, shared keyspace). An ungated
             // (full-owner) self costs no extra read.
-            let policy_target = if state.default_eoa_policy_type == 0 {
+            let policy_target = if state.default_eoa_scope & Eip8130Constants::SCOPE_POLICY == 0 {
                 Address::ZERO
             } else {
                 storage.get_policy_manager(account, recovered)?
@@ -158,7 +162,6 @@ impl ActorAuthorizer {
             return Ok(ResolvedActor {
                 actor_id: recovered,
                 scope: state.default_eoa_scope,
-                policy_type: state.default_eoa_policy_type,
                 policy_target,
             });
         }
@@ -167,7 +170,7 @@ impl ActorAuthorizer {
 
     /// Loads `actor_config[actor_id][account]`, requires it to be bound to
     /// `authenticator` and not expired, and returns the authorization surface
-    /// (`scope`, `policy_type`, resolved `policy_target`). Mirrors the shared tail
+    /// (`scope`, resolved `policy_target`). Mirrors the shared tail
     /// of `_authenticate` / `_authenticateK1`.
     fn resolve_bound(
         storage: &AccountConfigurationStorage<'_>,
@@ -191,17 +194,12 @@ impl ActorAuthorizer {
         // (never the signed commitment). Resolved from the `config` already in
         // hand so an ungated actor costs no extra read and a gated one reads only
         // the manager slot (no `actor_config` re-read).
-        let policy_target = if config.policy_type == 0 {
+        let policy_target = if config.scope & Eip8130Constants::SCOPE_POLICY == 0 {
             Address::ZERO
         } else {
             storage.get_policy_manager(account, actor_id)?
         };
-        Ok(ResolvedActor {
-            actor_id,
-            scope: config.scope,
-            policy_type: config.policy_type,
-            policy_target,
-        })
+        Ok(ResolvedActor { actor_id, scope: config.scope, policy_target })
     }
 }
 
@@ -221,21 +219,17 @@ mod tests {
     const ACCOUNT: Address = address!("0x00000000000000000000000000000000000000a1");
 
     /// Canonical Solidity packing of `ActorConfig` (each field at its bit offset).
-    fn pack(authenticator: Address, scope: u8, expiry: u64, policy_type: u8) -> U256 {
+    fn pack(authenticator: Address, scope: u8, expiry: u64) -> U256 {
         U256::from_be_slice(authenticator.as_slice())
             | (U256::from(scope) << 160)
             | (U256::from(expiry) << 168)
-            | (U256::from(policy_type) << 216)
     }
 
     /// Packs an `AccountState` word carrying the inline secp256k1 self config
     /// (each field at its bit offset; sequences/lock left zero).
-    fn pack_self(scope: u8, policy_type: u8, expiry: u64, revoked: bool) -> U256 {
+    fn pack_self(scope: u8, expiry: u64, revoked: bool) -> U256 {
         let flags = if revoked { Eip8130Constants::DEFAULT_EOA_REVOKED } else { 0 };
-        (U256::from(flags) << 184)
-            | (U256::from(scope) << 192)
-            | (U256::from(policy_type) << 200)
-            | (U256::from(expiry) << 208)
+        (U256::from(flags) << 128) | (U256::from(scope) << 176) | (U256::from(expiry) << 184)
     }
 
     fn actor_id(address: Address) -> B256 {
@@ -316,7 +310,7 @@ mod tests {
             // DEFAULT_EOA_REVOKED set: the inline k1 self is disabled (revoked, or a
             // non-k1 self is the live self authenticator), so a k1 signature
             // recovering to the account is rejected outright.
-            acc.account_state.at_mut(&account).write(pack_self(0, 0, 0, true)).unwrap();
+            acc.account_state.at_mut(&account).write(pack_self(0, 0, true)).unwrap();
             assert_eq!(
                 ActorAuthorizer::authenticate_actor(acc, account, HASH, &auth, NOW),
                 Err(AuthorizeError::DefaultEoaRevoked { account }),
@@ -335,13 +329,12 @@ mod tests {
             // resolves from the account-state slot alone (no `actor_config` read).
             acc.account_state
                 .at_mut(&account)
-                .write(pack_self(Eip8130Constants::SCOPE_SENDER, 0, 0, false))
+                .write(pack_self(Eip8130Constants::SCOPE_SENDER, 0, false))
                 .unwrap();
             let resolved =
                 ActorAuthorizer::authenticate_actor(acc, account, HASH, &auth, NOW).unwrap();
             assert_eq!(resolved.actor_id, self_id);
             assert_eq!(resolved.scope, Eip8130Constants::SCOPE_SENDER);
-            assert_eq!(resolved.policy_type, 0);
             assert_eq!(resolved.policy_target, Address::ZERO);
         });
     }
@@ -353,7 +346,7 @@ mod tests {
         let auth = blob(Eip8130Constants::K1_AUTHENTICATOR, &k1_sig(&key, HASH));
         with_storage(|acc| {
             // Inline expiry in the past: the self key is no longer valid.
-            acc.account_state.at_mut(&account).write(pack_self(0, 0, NOW - 1, false)).unwrap();
+            acc.account_state.at_mut(&account).write(pack_self(0, NOW - 1, false)).unwrap();
             assert_eq!(
                 ActorAuthorizer::authenticate_actor(acc, account, HASH, &auth, NOW),
                 Err(AuthorizeError::Expired { actor_id: actor_id(account), expiry: NOW - 1 }),
@@ -369,14 +362,17 @@ mod tests {
         let manager = address!("0x00000000000000000000000000000000000000d4");
         let auth = blob(Eip8130Constants::K1_AUTHENTICATOR, &k1_sig(&key, HASH));
         with_storage(|acc| {
-            // Inline policy_type set: the self key is gated and resolves its policy
+            // Inline SCOPE_POLICY set: the self key is gated and resolves its policy
             // target from `policy_manager[self][account]`.
-            acc.account_state.at_mut(&account).write(pack_self(0, 5, 0, false)).unwrap();
+            acc.account_state
+                .at_mut(&account)
+                .write(pack_self(Eip8130Constants::SCOPE_POLICY, 0, false))
+                .unwrap();
             acc.policy_manager.at_mut(&self_id).at_mut(&account).write(manager).unwrap();
             let resolved =
                 ActorAuthorizer::authenticate_actor(acc, account, HASH, &auth, NOW).unwrap();
             assert_eq!(resolved.actor_id, self_id);
-            assert_eq!(resolved.policy_type, 5);
+            assert!(resolved.is_policy_gated());
             assert_eq!(resolved.policy_target, manager);
         });
     }
@@ -407,18 +403,13 @@ mod tests {
             acc.actor_config
                 .at_mut(&id)
                 .at_mut(&ACCOUNT)
-                .write(pack(Eip8130Constants::K1_AUTHENTICATOR, 0x04, 0, 0))
+                .write(pack(Eip8130Constants::K1_AUTHENTICATOR, 0x04, 0))
                 .unwrap();
             let resolved =
                 ActorAuthorizer::authenticate_actor(acc, ACCOUNT, HASH, &auth, NOW).unwrap();
             assert_eq!(
                 resolved,
-                ResolvedActor {
-                    actor_id: id,
-                    scope: 0x04,
-                    policy_type: 0,
-                    policy_target: Address::ZERO
-                }
+                ResolvedActor { actor_id: id, scope: 0x04, policy_target: Address::ZERO }
             );
         });
     }
@@ -448,7 +439,7 @@ mod tests {
             acc.actor_config
                 .at_mut(&id)
                 .at_mut(&ACCOUNT)
-                .write(pack(Eip8130Constants::K1_AUTHENTICATOR, 0, 500, 0))
+                .write(pack(Eip8130Constants::K1_AUTHENTICATOR, 0, 500))
                 .unwrap();
             // Valid at/under expiry.
             assert!(ActorAuthorizer::authenticate_actor(acc, ACCOUNT, HASH, &auth, 500).is_ok());
@@ -470,12 +461,12 @@ mod tests {
             acc.actor_config
                 .at_mut(&id)
                 .at_mut(&ACCOUNT)
-                .write(pack(Eip8130Constants::K1_AUTHENTICATOR, 0, 0, 1))
+                .write(pack(Eip8130Constants::K1_AUTHENTICATOR, Eip8130Constants::SCOPE_POLICY, 0))
                 .unwrap();
             acc.policy_manager.at_mut(&id).at_mut(&ACCOUNT).write(manager).unwrap();
             let resolved =
                 ActorAuthorizer::authenticate_actor(acc, ACCOUNT, HASH, &auth, NOW).unwrap();
-            assert_eq!(resolved.policy_type, 1);
+            assert!(resolved.is_policy_gated());
             assert_eq!(resolved.policy_target, manager);
         });
     }
@@ -489,18 +480,13 @@ mod tests {
             acc.actor_config
                 .at_mut(&id)
                 .at_mut(&ACCOUNT)
-                .write(pack(Eip8130Contracts::P256_AUTHENTICATOR, 0x02, 0, 0))
+                .write(pack(Eip8130Contracts::P256_AUTHENTICATOR, 0x02, 0))
                 .unwrap();
             let resolved =
                 ActorAuthorizer::authenticate_actor(acc, ACCOUNT, HASH, &auth, NOW).unwrap();
             assert_eq!(
                 resolved,
-                ResolvedActor {
-                    actor_id: id,
-                    scope: 0x02,
-                    policy_type: 0,
-                    policy_target: Address::ZERO
-                }
+                ResolvedActor { actor_id: id, scope: 0x02, policy_target: Address::ZERO }
             );
         });
     }
@@ -526,24 +512,19 @@ mod tests {
             acc.actor_config
                 .at_mut(&nested_id)
                 .at_mut(&delegate_account)
-                .write(pack(Eip8130Constants::K1_AUTHENTICATOR, 0, 0, 0))
+                .write(pack(Eip8130Constants::K1_AUTHENTICATOR, 0, 0))
                 .unwrap();
             // Outer delegate actor on the originating account carries the surface.
             acc.actor_config
                 .at_mut(&outer_id)
                 .at_mut(&ACCOUNT)
-                .write(pack(Eip8130Contracts::DELEGATE_AUTHENTICATOR, 0x08, 0, 0))
+                .write(pack(Eip8130Contracts::DELEGATE_AUTHENTICATOR, 0x08, 0))
                 .unwrap();
             let resolved =
                 ActorAuthorizer::authenticate_actor(acc, ACCOUNT, HASH, &auth, NOW).unwrap();
             assert_eq!(
                 resolved,
-                ResolvedActor {
-                    actor_id: outer_id,
-                    scope: 0x08,
-                    policy_type: 0,
-                    policy_target: Address::ZERO
-                }
+                ResolvedActor { actor_id: outer_id, scope: 0x08, policy_target: Address::ZERO }
             );
         });
     }
@@ -556,15 +537,15 @@ mod tests {
         let outer_id = actor_id(delegate_account);
         let auth = delegate_auth(delegate_account, &nested_key);
         with_storage(|acc| {
-            // Nested actor is bound on B but scoped PAYER only (no SIGNATURE bit),
-            // so `verifySignature(delegate, ...)` would reject it on-chain.
+            // Nested actor is bound on B but scoped (non-admin), so the delegate
+            // vouch — which `DelegateAuthenticator` requires to be admin
+            // (`scope == 0`) — rejects it.
             acc.actor_config
                 .at_mut(&nested_id)
                 .at_mut(&delegate_account)
                 .write(pack(
                     Eip8130Constants::K1_AUTHENTICATOR,
-                    Eip8130Constants::SCOPE_PAYER,
-                    0,
+                    Eip8130Constants::SCOPE_SELF_PAYER,
                     0,
                 ))
                 .unwrap();
@@ -574,7 +555,6 @@ mod tests {
                 .write(pack(
                     Eip8130Contracts::DELEGATE_AUTHENTICATOR,
                     Eip8130Constants::SCOPE_SENDER,
-                    0,
                     0,
                 ))
                 .unwrap();
@@ -593,16 +573,12 @@ mod tests {
         let outer_id = actor_id(delegate_account);
         let auth = delegate_auth(delegate_account, &nested_key);
         with_storage(|acc| {
-            // Nested actor scoped exactly SIGNATURE satisfies the delegate gate.
+            // Nested actor is admin (`scope == 0`), the predicate the delegate
+            // vouch requires, so it satisfies the delegate gate.
             acc.actor_config
                 .at_mut(&nested_id)
                 .at_mut(&delegate_account)
-                .write(pack(
-                    Eip8130Constants::K1_AUTHENTICATOR,
-                    Eip8130Constants::SCOPE_SIGNATURE,
-                    0,
-                    0,
-                ))
+                .write(pack(Eip8130Constants::K1_AUTHENTICATOR, 0, 0))
                 .unwrap();
             acc.actor_config
                 .at_mut(&outer_id)
@@ -610,7 +586,6 @@ mod tests {
                 .write(pack(
                     Eip8130Contracts::DELEGATE_AUTHENTICATOR,
                     Eip8130Constants::SCOPE_SENDER,
-                    0,
                     0,
                 ))
                 .unwrap();
@@ -633,7 +608,7 @@ mod tests {
             acc.actor_config
                 .at_mut(&outer_id)
                 .at_mut(&ACCOUNT)
-                .write(pack(Eip8130Contracts::DELEGATE_AUTHENTICATOR, 0x08, 0, 0))
+                .write(pack(Eip8130Contracts::DELEGATE_AUTHENTICATOR, 0x08, 0))
                 .unwrap();
             assert_eq!(
                 ActorAuthorizer::authenticate_actor(acc, ACCOUNT, HASH, &auth, NOW),
@@ -657,7 +632,7 @@ mod tests {
             acc.actor_config
                 .at_mut(&nested_id)
                 .at_mut(&delegate_account)
-                .write(pack(Eip8130Constants::K1_AUTHENTICATOR, 0, 0, 0))
+                .write(pack(Eip8130Constants::K1_AUTHENTICATOR, 0, 0))
                 .unwrap();
             assert_eq!(
                 ActorAuthorizer::authenticate_actor(acc, ACCOUNT, HASH, &auth, NOW),
@@ -681,7 +656,7 @@ mod tests {
             acc.actor_config
                 .at_mut(&nested_id)
                 .at_mut(&Address::ZERO)
-                .write(pack(Eip8130Constants::K1_AUTHENTICATOR, 0, 0, 0))
+                .write(pack(Eip8130Constants::K1_AUTHENTICATOR, 0, 0))
                 .unwrap();
             assert_eq!(
                 ActorAuthorizer::authenticate_actor(acc, ACCOUNT, HASH, &auth, NOW),

--- a/crates/execution/eip8130/src/authorize_error.rs
+++ b/crates/execution/eip8130/src/authorize_error.rs
@@ -57,13 +57,14 @@ pub enum AuthorizeError {
         expiry: u64,
     },
 
-    /// The nested actor in a delegate authentication lacks `SCOPE_SIGNATURE` on
-    /// the delegate account. Mirrors `DelegateAuthenticator` requiring
-    /// `verifySignature(delegate, ...)`, which accepts only an unrestricted
-    /// (`scope == 0`) or `SCOPE_SIGNATURE` actor.
-    #[error("delegate nested actor {actor_id} lacks SIGNATURE scope on the delegate account")]
+    /// The nested actor in a delegate authentication is not admin on the
+    /// delegate account. Mirrors `DelegateAuthenticator`, which calls
+    /// `authenticateActor(delegate, ...)` and explicitly requires the resolved
+    /// `scope == 0`. This is independent of `verifySignature` (operational
+    /// signing): a delegate vouch requires admin to preserve non-escalation.
+    #[error("delegate nested actor {actor_id} is not admin on the delegate account")]
     NestedSignatureScope {
-        /// The nested actor id that failed the SIGNATURE-scope check.
+        /// The nested actor id that failed the admin-only delegate-vouch check.
         actor_id: B256,
     },
 }

--- a/crates/execution/eip8130/src/config.rs
+++ b/crates/execution/eip8130/src/config.rs
@@ -1,4 +1,4 @@
-//! Account-configuration change authorization — the `SCOPE_CONFIG` path of the
+//! Account-configuration change authorization — the admin-only path of the
 //! EIP-8130 validation flow.
 
 use alloy_primitives::{Address, B256, Keccak256, b256, keccak256};
@@ -13,10 +13,10 @@ use crate::{
 /// struct, identical to the one hashed by `AccountConfiguration` (the trailing
 /// `ActorChange(...)` is the referenced struct's type, per the EIP-712 encoding
 /// rules):
-/// `keccak256("SignedActorChanges(address account,uint64 chainId,uint64 sequence,ActorChange[] actorChanges)ActorChange(uint8 changeType,bytes32 actorId,bytes data)")`.
+/// `keccak256("SignedActorChanges(address account,uint256 chainId,uint64 sequence,ActorChange[] actorChanges)ActorChange(uint8 changeType,bytes32 actorId,bytes data)")`.
 /// Pinned to its preimage by `typehashes_match_their_preimages`.
 const SIGNED_ACTOR_CHANGES_TYPEHASH: B256 =
-    b256!("3528344db25dddc3f16dbdc7302aacb555665c0af1beedc07d5fe28e8512bb3f");
+    b256!("57a5948eb1eec1ba33786cd9cf803674888bd5b4d3588347ba1bef0bd8c5ba53");
 /// Precomputed `keccak256` typehash for the per-change `ActorChange` leaves:
 /// `keccak256("ActorChange(uint8 changeType,bytes32 actorId,bytes data)")`.
 /// Pinned to its preimage by `typehashes_match_their_preimages`.
@@ -29,7 +29,7 @@ const ACTOR_CHANGE_TYPEHASH: B256 =
 /// Native mirror of `AccountConfiguration.applySignedActorChanges`'s
 /// authorization tail: it reconstructs the `SignedActorChanges` digest, runs the
 /// entry's `auth` through the stateful [`ActorAuthorizer`], and enforces the
-/// `SCOPE_CONFIG` gate, the account lock, the chain binding, and the sequence
+/// admin (`scope == 0`) gate, the account lock, the chain binding, and the sequence
 /// channel. It does **not** apply the actor changes (decode `data`, mutate
 /// `actor_config`) — that is the consuming validator's responsibility.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -77,7 +77,7 @@ impl ConfigChangeAuthorizer {
     /// order.
     ///
     /// Performs every check `authorize` does (lock, chain binding, sequence,
-    /// digest reconstruction, actor authorization, `SCOPE_CONFIG` gate) except
+    /// digest reconstruction, actor authorization, admin gate) except
     /// that the sequence is compared against `expected_sequence`.
     pub fn authorize_at_sequence(
         storage: &AccountConfigurationStorage<'_>,
@@ -107,7 +107,7 @@ impl ConfigChangeAuthorizer {
             });
         }
 
-        // Reconstruct the digest, authorize the entry's auth, and require CONFIG scope.
+        // Reconstruct the digest, authorize the entry's auth, and require admin scope.
         let digest = Self::signed_actor_changes_digest(account, change);
         let resolved =
             ActorAuthorizer::authenticate_actor(storage, account, digest, &change.auth, now)?;
@@ -139,7 +139,7 @@ impl ConfigChangeAuthorizer {
         }
         let actor_changes_hash = packed.finalize();
 
-        // abi.encode(bytes32, address, uint64, uint64, bytes32): five right-aligned words.
+        // abi.encode(bytes32, address, uint256, uint64, bytes32): five words.
         let mut outer = [0u8; 160];
         outer[..32].copy_from_slice(SIGNED_ACTOR_CHANGES_TYPEHASH.as_slice());
         outer[44..64].copy_from_slice(account.as_slice());
@@ -168,7 +168,7 @@ mod tests {
         assert_eq!(
             SIGNED_ACTOR_CHANGES_TYPEHASH,
             keccak256(
-                b"SignedActorChanges(address account,uint64 chainId,uint64 sequence,ActorChange[] actorChanges)ActorChange(uint8 changeType,bytes32 actorId,bytes data)"
+                b"SignedActorChanges(address account,uint256 chainId,uint64 sequence,ActorChange[] actorChanges)ActorChange(uint8 changeType,bytes32 actorId,bytes data)"
             )
         );
         assert_eq!(
@@ -208,19 +208,19 @@ mod tests {
     }
 
     /// Canonical Solidity packing of `ActorConfig`.
-    fn pack(authenticator: Address, scope: u8, expiry: u64, policy_type: u8) -> U256 {
+    fn pack(authenticator: Address, scope: u8, expiry: u64) -> U256 {
         U256::from_be_slice(authenticator.as_slice())
             | (U256::from(scope) << 160)
             | (U256::from(expiry) << 168)
-            | (U256::from(policy_type) << 216)
     }
 
-    /// Canonical Solidity packing of `AccountState`.
-    fn pack_state(multichain: u64, local: u64, unlocks_at: u64) -> U256 {
+    /// Canonical Solidity packing of `AccountState` (sequences + lock fields).
+    fn pack_state(multichain: u64, local: u64, flags: u8, lock_union: u64) -> U256 {
         let mut b = [0u8; 32];
         b[24..32].copy_from_slice(&multichain.to_be_bytes());
         b[16..24].copy_from_slice(&local.to_be_bytes());
-        b[11..16].copy_from_slice(&unlocks_at.to_be_bytes()[3..]);
+        b[15] = flags;
+        b[10..15].copy_from_slice(&lock_union.to_be_bytes()[3..]);
         U256::from_be_bytes(b)
     }
 
@@ -268,12 +268,12 @@ mod tests {
         with_storage(|acc| {
             let resolved =
                 ConfigChangeAuthorizer::authorize(acc, account, LOCAL, &change, NOW).unwrap();
-            assert!(resolved.is_unrestricted());
+            assert!(resolved.is_admin());
         });
     }
 
     #[test]
-    fn configured_config_actor_authorizes() {
+    fn configured_admin_actor_authorizes() {
         let k = key(0x22);
         let account = address!("0x00000000000000000000000000000000000000aa");
         let id = actor_id(addr(&k));
@@ -282,11 +282,11 @@ mod tests {
             acc.actor_config
                 .at_mut(&id)
                 .at_mut(&account)
-                .write(pack(K1, Eip8130Constants::SCOPE_CONFIG, 0, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_UNRESTRICTED, 0))
                 .unwrap();
             let resolved =
                 ConfigChangeAuthorizer::authorize(acc, account, LOCAL, &change, NOW).unwrap();
-            assert_eq!(resolved.scope, Eip8130Constants::SCOPE_CONFIG);
+            assert!(resolved.is_admin());
         });
     }
 
@@ -301,7 +301,7 @@ mod tests {
             acc.actor_config
                 .at_mut(&id)
                 .at_mut(&account)
-                .write(pack(K1, Eip8130Constants::SCOPE_SENDER, 0, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_SENDER, 0))
                 .unwrap();
             assert_eq!(
                 ConfigChangeAuthorizer::authorize(acc, account, LOCAL, &change, NOW),
@@ -319,8 +319,11 @@ mod tests {
         let account = addr(&k);
         let change = signed_change(account, K1, &k, 0, 0, vec![revoke(0x01)]);
         with_storage(|acc| {
-            // Locked until after `now`.
-            acc.account_state.at_mut(&account).write(pack_state(0, 0, NOW + 1)).unwrap();
+            // Hard-locked (FLAG_LOCKED, no unlock initiated): frozen regardless of `now`.
+            acc.account_state
+                .at_mut(&account)
+                .write(pack_state(0, 0, Eip8130Constants::FLAG_LOCKED, 0))
+                .unwrap();
             assert_eq!(
                 ConfigChangeAuthorizer::authorize(acc, account, LOCAL, &change, NOW),
                 Err(TxAuthError::AccountLocked),
@@ -362,10 +365,10 @@ mod tests {
         // Local channel (chain_id == LOCAL); the entry must match local_sequence.
         let change = signed_change(account, K1, &k, LOCAL, 3, vec![revoke(0x01)]);
         with_storage(|acc| {
-            acc.account_state.at_mut(&account).write(pack_state(0, 3, 0)).unwrap();
+            acc.account_state.at_mut(&account).write(pack_state(0, 3, 0, 0)).unwrap();
             let resolved =
                 ConfigChangeAuthorizer::authorize(acc, account, LOCAL, &change, NOW).unwrap();
-            assert!(resolved.is_unrestricted());
+            assert!(resolved.is_admin());
         });
     }
 

--- a/crates/execution/eip8130/src/intrinsic.rs
+++ b/crates/execution/eip8130/src/intrinsic.rs
@@ -534,10 +534,7 @@ mod tests {
         // since initial actors are unrestricted owners).
         let code = vec![0x60u8; 4];
         let initial_actors = (0u8..3)
-            .map(|i| InitialActor {
-                actor_id: alloy_primitives::B256::repeat_byte(i + 1),
-                authenticator: K1,
-            })
+            .map(|i| InitialActor::owner(alloy_primitives::B256::repeat_byte(i + 1), K1))
             .collect();
         let tx = TxEip8130 {
             account_changes: vec![AccountChange::Create(CreateEntry {

--- a/crates/execution/eip8130/src/intrinsic.rs
+++ b/crates/execution/eip8130/src/intrinsic.rs
@@ -170,18 +170,22 @@ impl IntrinsicGas {
                     bytecode = bytecode
                         .saturating_add(Eip8130GasSchedule::CREATE_BASE_COST)
                         .saturating_add(deposit);
-                    // Each initial actor writes one fresh `actor_config` slot (an
-                    // unrestricted owner: `scope = 0`, `expiry = 0`,
-                    // `policyType = 0`, so no policy slots). These slot writes are
-                    // metered per actor, mirroring the `ConfigChange` per-slot
-                    // accounting below — creation must not register actors for
-                    // free relative to a later config change authorizing the same
-                    // set.
-                    let initial_actor_cost = Eip8130GasSchedule::ACTOR_SLOT_SET_COST
-                        .saturating_mul(
-                            u64::try_from(entry.initial_actors.len()).unwrap_or(u64::MAX),
-                        );
-                    account_changes = account_changes.saturating_add(initial_actor_cost);
+                    // Each initial actor writes one fresh `actor_config` slot, plus
+                    // the two policy slots (`policy_manager` + `policy_commitment`)
+                    // when it sets `SCOPE_POLICY` — a POLICY initial actor is 3
+                    // slot-sets versus 1 for a non-policy actor. These slot writes
+                    // are metered per actor, mirroring the `ConfigChange` per-slot
+                    // accounting below — creation must not register actors for free
+                    // relative to a later config change authorizing the same set.
+                    for actor in &entry.initial_actors {
+                        let mut cost = Eip8130GasSchedule::ACTOR_SLOT_SET_COST;
+                        if actor.scope & Eip8130Constants::SCOPE_POLICY != 0 {
+                            cost = cost.saturating_add(
+                                Eip8130GasSchedule::ACTOR_SLOT_SET_COST.saturating_mul(2),
+                            );
+                        }
+                        account_changes = account_changes.saturating_add(cost);
+                    }
                 }
                 AccountChange::ConfigChange(cc) => {
                     // `cfg.auth` is always `authenticator || data` (never a bare
@@ -354,11 +358,11 @@ impl IntrinsicGas {
         }
     }
 
-    /// Whether an authorize's ABI-encoded `(ActorConfig, bytes)` `data` carries a
-    /// non-zero `policyType`. `ActorConfig` is `(address, uint8 scope, uint48
-    /// expiry, uint8 policyType)`, so `policyType` is the fourth 32-byte word.
+    /// Whether an authorize's ABI-encoded `(ActorConfig, bytes)` `data` carries
+    /// `SCOPE_POLICY`. `ActorConfig` is `(address, uint8 scope, uint48 expiry)`,
+    /// so scope is the second 32-byte word.
     fn authorize_has_policy(data: &[u8]) -> bool {
-        data.len() >= 128 && data[96..128].iter().any(|&byte| byte != 0)
+        data.len() >= 64 && data[63] & Eip8130Constants::SCOPE_POLICY != 0
     }
 
     /// Worst-case extra cost for self-targeted actor changes in a config change.
@@ -433,25 +437,20 @@ mod tests {
             address authenticator;
             uint8 scope;
             uint48 expiry;
-            uint8 policyType;
         }
     }
 
     #[test]
-    fn authorize_has_policy_reads_the_policy_type_word() {
+    fn authorize_has_policy_reads_the_scope_word() {
         use alloy_sol_types::SolValue;
 
-        // Drift tripwire: `authorize_has_policy` decodes `policyType` at a hardcoded
-        // 32-byte offset (bytes 96..128) of the ABI-encoded `(ActorConfig, bytes)`
-        // authorize payload. If the `ActorConfig` field layout ever changes, this
-        // catches it: a non-zero `policyType` must be detected, and non-zero values
-        // in *every other* field (authenticator, scope, expiry) must not be.
+        // Drift tripwire: `authorize_has_policy` reads SCOPE_POLICY from the low
+        // byte of the second ABI word.
         let gated = (
             ActorConfigAbi {
                 authenticator: Address::ZERO,
-                scope: 0,
+                scope: Eip8130Constants::SCOPE_POLICY,
                 expiry: alloy_primitives::Uint::ZERO,
-                policyType: 7,
             },
             Bytes::new(),
         )
@@ -459,9 +458,8 @@ mod tests {
         let ungated = (
             ActorConfigAbi {
                 authenticator: address!("0xffffffffffffffffffffffffffffffffffffffff"),
-                scope: 0xff,
+                scope: Eip8130Constants::SCOPE_SENDER,
                 expiry: alloy_primitives::Uint::from(0xffff_ffff_ffffu64),
-                policyType: 0,
             },
             Bytes::new(),
         )
@@ -469,9 +467,7 @@ mod tests {
 
         assert!(IntrinsicGas::authorize_has_policy(&gated));
         assert!(!IntrinsicGas::authorize_has_policy(&ungated));
-        // `policyType = 7` lands in the low byte of the fourth word.
-        assert_eq!(gated[96..128].iter().rposition(|&b| b != 0), Some(31));
-        assert_eq!(gated[127], 7);
+        assert_eq!(gated[63], Eip8130Constants::SCOPE_POLICY);
     }
 
     #[test]
@@ -530,8 +526,7 @@ mod tests {
     fn create_charges_bytecode_plus_per_initial_actor_slot() {
         // A create entry pays `bytecode_cost` (base + per-byte deposit) plus one
         // fresh `actor_config` slot write per initial actor — the same per-slot
-        // model as a config change authorizing the same actors (no policy slots,
-        // since initial actors are unrestricted owners).
+        // model as a config change authorizing the same actors.
         let code = vec![0x60u8; 4];
         let initial_actors = (0u8..3)
             .map(|i| InitialActor::owner(alloy_primitives::B256::repeat_byte(i + 1), K1))
@@ -550,6 +545,38 @@ mod tests {
             Eip8130GasSchedule::CREATE_BASE_COST + Eip8130GasSchedule::CODE_DEPOSIT_PER_BYTE * 4
         );
         assert_eq!(gas.account_changes, Eip8130GasSchedule::ACTOR_SLOT_SET_COST * 3);
+    }
+
+    #[test]
+    fn create_charges_three_slots_for_policy_initial_actor() {
+        // A POLICY initial actor also writes `policy_manager` and
+        // `policy_commitment`: 3 slot-sets versus 1 for a non-policy actor.
+        let policy_data = {
+            let mut d = vec![0u8; 52];
+            d[19] = 0xcc; // manager
+            d[51] = 0x44; // commitment
+            Bytes::from(d)
+        };
+        let actors = vec![
+            InitialActor::owner(alloy_primitives::B256::repeat_byte(1), K1),
+            InitialActor {
+                actor_id: alloy_primitives::B256::repeat_byte(2),
+                authenticator: K1,
+                scope: Eip8130Constants::SCOPE_POLICY,
+                policy_data,
+            },
+        ];
+        let tx = TxEip8130 {
+            account_changes: vec![AccountChange::Create(CreateEntry {
+                user_salt: Default::default(),
+                code: Bytes::from(vec![0x60u8; 4]),
+                initial_actors: actors,
+            })],
+            ..Default::default()
+        };
+        let gas = intrinsic(&signed(tx, vec![0; 65], vec![]), &EXISTING_KEY);
+        // 1 (non-policy) + 3 (policy) = 4 slot-sets.
+        assert_eq!(gas.account_changes, Eip8130GasSchedule::ACTOR_SLOT_SET_COST * 4);
     }
 
     #[test]
@@ -610,8 +637,8 @@ mod tests {
             + Eip8130GasSchedule::ACTOR_SLOT_RESET_COST;
         assert_eq!(gas.account_changes, expected);
 
-        // With a non-zero policyType, the authorize also writes the two policy slots.
-        authorize_data[127] = 0x01;
+        // With SCOPE_POLICY, the authorize also writes the two policy slots.
+        authorize_data[63] = Eip8130Constants::SCOPE_POLICY;
         let cc = ConfigChange {
             chain_id: 0,
             sequence: 0,

--- a/crates/execution/eip8130/src/resolved.rs
+++ b/crates/execution/eip8130/src/resolved.rs
@@ -1,13 +1,14 @@
 //! The authorization surface returned by a successful authorize step.
 
-use alloy_primitives::{Address, B256};
+use alloy_primitives::{Address, B256, U256};
+use base_common_consensus::Eip8130Constants;
 
 /// A resolved and authorized actor: the output of
 /// [`ActorAuthorizer::authenticate_actor`](crate::ActorAuthorizer::authenticate_actor),
 /// mirroring `AccountConfiguration.authenticateActor`'s return tuple.
 ///
 /// Authorization is **scope + policy**, not scope alone: `scope` is the actor's
-/// capability set and `policy_type`/`policy_target` describe its policy gate. The
+/// capability set and `policy_target` describes its policy gate. The
 /// consuming validator combines these with the transaction's operation (sender,
 /// payer, or config change) to make the final scope/policy decision.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -18,8 +19,6 @@ pub struct ResolvedActor {
     pub actor_id: B256,
     /// The actor's scope bitfield (`0 = unrestricted`).
     pub scope: u8,
-    /// The actor's policy sub-type byte (`0 = ungated`).
-    pub policy_type: u8,
     /// The actor's policy gate target (the policy *manager*), or
     /// [`Address::ZERO`] when ungated. Never the signed policy commitment.
     pub policy_target: Address,
@@ -30,12 +29,52 @@ impl ResolvedActor {
     /// shape of any actor with `scope == 0` and no policy.
     #[must_use]
     pub const fn unrestricted(actor_id: B256) -> Self {
-        Self { actor_id, scope: 0, policy_type: 0, policy_target: Address::ZERO }
+        Self { actor_id, scope: 0, policy_target: Address::ZERO }
     }
 
-    /// `true` if the actor carries no elevated scope (`scope == 0`).
+    /// `true` if the actor is an unrestricted administrator (`scope == 0`).
+    ///
+    /// EIP-8130 defines these as the same concept: there is no separate admin
+    /// grant bit and no restricted administrator.
     #[must_use]
-    pub const fn is_unrestricted(&self) -> bool {
+    pub const fn is_admin(&self) -> bool {
         self.scope == 0
+    }
+
+    /// `true` if the actor's sender authorization is policy-gated.
+    #[must_use]
+    pub const fn is_policy_gated(&self) -> bool {
+        self.scope & Eip8130Constants::SCOPE_POLICY != 0
+    }
+
+    /// Whether this actor may use the transaction's nonce key.
+    ///
+    /// Unrestricted actors and nonce-free transactions are always allowed;
+    /// scoped actors need `SCOPE_NONCE` for sequenced nonce channels.
+    #[must_use]
+    pub fn allows_sequenced_nonce(&self, nonce_key: U256) -> bool {
+        self.scope == Eip8130Constants::SCOPE_UNRESTRICTED
+            || nonce_key == Eip8130Constants::NONCE_KEY_MAX
+            || self.scope & Eip8130Constants::SCOPE_NONCE != 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn actor(scope: u8) -> ResolvedActor {
+        ResolvedActor { actor_id: B256::ZERO, scope, policy_target: Address::ZERO }
+    }
+
+    #[test]
+    fn nonce_scope_allows_expected_keys() {
+        assert!(actor(0).allows_sequenced_nonce(U256::ZERO));
+        assert!(
+            actor(Eip8130Constants::SCOPE_SENDER)
+                .allows_sequenced_nonce(Eip8130Constants::NONCE_KEY_MAX)
+        );
+        assert!(actor(Eip8130Constants::SCOPE_NONCE).allows_sequenced_nonce(U256::from(1)));
+        assert!(!actor(Eip8130Constants::SCOPE_SENDER).allows_sequenced_nonce(U256::ZERO));
     }
 }

--- a/crates/execution/eip8130/src/scope.rs
+++ b/crates/execution/eip8130/src/scope.rs
@@ -1,48 +1,95 @@
-//! Per-operation scope gating for resolved actors.
+//! Per-operation scope gating for resolved actors, including admin-only config
+//! changes and policy-gated sender authorization.
 
 use base_common_consensus::Eip8130Constants;
 
 use crate::ResolvedActor;
 
-/// The transaction context an actor is being authorized for. Each maps to the
-/// EIP-8130 scope bit that gates it.
+/// The transaction context an actor is being authorized for.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Operation {
-    /// Authorizing the transaction sender (`SCOPE_SENDER`).
+    /// Authorizing the transaction sender (`SCOPE_SENDER` or `SCOPE_POLICY`).
     Sender,
-    /// Authorizing a gas payer (`SCOPE_PAYER`).
-    Payer,
-    /// Authorizing an account-configuration change (`SCOPE_CONFIG`).
+    /// Authorizing an actor to pay the account's own gas when `payer == sender`
+    /// (`SCOPE_SELF_PAYER`).
+    SelfPayer,
+    /// Authorizing an actor to sponsor a different sender's gas
+    /// (`payer != sender`, `SCOPE_SPONSOR_PAYER`).
+    SponsorPayer,
+    /// Authorizing an account-configuration change (admin only, `scope == 0`).
     Config,
-    /// Authorizing a message signature, ERC-1271 style (`SCOPE_SIGNATURE`).
-    Signature,
 }
 
 impl Operation {
-    /// The scope bit that grants this operation.
+    /// The scope bit that grants this operation, or unrestricted scope for
+    /// admin-only configuration changes.
     #[must_use]
     pub const fn required_bit(self) -> u8 {
         match self {
             Self::Sender => Eip8130Constants::SCOPE_SENDER,
-            Self::Payer => Eip8130Constants::SCOPE_PAYER,
-            Self::Config => Eip8130Constants::SCOPE_CONFIG,
-            Self::Signature => Eip8130Constants::SCOPE_SIGNATURE,
+            Self::SelfPayer => Eip8130Constants::SCOPE_SELF_PAYER,
+            Self::SponsorPayer => Eip8130Constants::SCOPE_SPONSOR_PAYER,
+            Self::Config => Eip8130Constants::SCOPE_UNRESTRICTED,
         }
     }
 
-    /// Whether `scope` grants this operation. An unrestricted actor
-    /// (`scope == 0`) is valid in every context; otherwise the operation's bit
-    /// must be set. Mirrors `AccountConfiguration`'s
-    /// `scope == 0 || scope & REQUIRED != 0`.
+    /// Whether `scope` grants this operation.
     #[must_use]
     pub const fn is_granted_by(self, scope: u8) -> bool {
-        scope == Eip8130Constants::SCOPE_UNRESTRICTED || scope & self.required_bit() != 0
+        match self {
+            Self::Config => scope == Eip8130Constants::SCOPE_UNRESTRICTED,
+            Self::Sender => {
+                scope == Eip8130Constants::SCOPE_UNRESTRICTED
+                    || scope & Eip8130Constants::SCOPE_SENDER != 0
+                    || scope & Eip8130Constants::SCOPE_POLICY != 0
+            }
+            Self::SelfPayer => {
+                scope == Eip8130Constants::SCOPE_UNRESTRICTED
+                    || scope & Eip8130Constants::SCOPE_SELF_PAYER != 0
+            }
+            Self::SponsorPayer => {
+                scope == Eip8130Constants::SCOPE_UNRESTRICTED
+                    || scope & Eip8130Constants::SCOPE_SPONSOR_PAYER != 0
+            }
+        }
     }
 
     /// Whether the resolved actor's scope grants this operation.
     #[must_use]
     pub const fn is_granted(self, actor: &ResolvedActor) -> bool {
         self.is_granted_by(actor.scope)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_is_admin_only() {
+        assert!(Operation::Config.is_granted_by(Eip8130Constants::SCOPE_UNRESTRICTED));
+        assert!(!Operation::Config.is_granted_by(Eip8130Constants::SCOPE_SENDER));
+        assert!(!Operation::Config.is_granted_by(Eip8130Constants::SCOPE_POLICY));
+    }
+
+    #[test]
+    fn sender_accepts_sender_or_policy() {
+        assert!(Operation::Sender.is_granted_by(Eip8130Constants::SCOPE_UNRESTRICTED));
+        assert!(Operation::Sender.is_granted_by(Eip8130Constants::SCOPE_SENDER));
+        assert!(Operation::Sender.is_granted_by(Eip8130Constants::SCOPE_POLICY));
+        assert!(!Operation::Sender.is_granted_by(Eip8130Constants::SCOPE_SELF_PAYER));
+    }
+
+    #[test]
+    fn payer_grants_are_split_by_self_vs_sponsor() {
+        // Self-pay requires SELF_PAYER (or admin); sponsor requires SPONSOR_PAYER.
+        assert!(Operation::SelfPayer.is_granted_by(Eip8130Constants::SCOPE_UNRESTRICTED));
+        assert!(Operation::SelfPayer.is_granted_by(Eip8130Constants::SCOPE_SELF_PAYER));
+        assert!(!Operation::SelfPayer.is_granted_by(Eip8130Constants::SCOPE_SPONSOR_PAYER));
+
+        assert!(Operation::SponsorPayer.is_granted_by(Eip8130Constants::SCOPE_UNRESTRICTED));
+        assert!(Operation::SponsorPayer.is_granted_by(Eip8130Constants::SCOPE_SPONSOR_PAYER));
+        assert!(!Operation::SponsorPayer.is_granted_by(Eip8130Constants::SCOPE_SELF_PAYER));
     }
 }

--- a/crates/execution/eip8130/src/transaction.rs
+++ b/crates/execution/eip8130/src/transaction.rs
@@ -178,9 +178,7 @@ mod tests {
     use k256::ecdsa::SigningKey as K256SigningKey;
 
     use super::*;
-    use crate::{
-        AccountChangeApplier, ApplyError, AuthorizeError, ConfigChangeAuthorizer, Operation,
-    };
+    use crate::{AccountChangeApplier, ApplyError, AuthorizeError, ConfigChangeAuthorizer};
 
     const NOW: u64 = 1_000;
     const LOCAL: u64 = 8453;
@@ -217,20 +215,20 @@ mod tests {
     }
 
     /// Canonical Solidity packing of `ActorConfig`.
-    fn pack(authenticator: Address, scope: u8, expiry: u64, policy_type: u8) -> U256 {
+    fn pack(authenticator: Address, scope: u8, expiry: u64) -> U256 {
         U256::from_be_slice(authenticator.as_slice())
             | (U256::from(scope) << 160)
             | (U256::from(expiry) << 168)
-            | (U256::from(policy_type) << 216)
     }
 
     /// Canonical Solidity packing of `AccountState` (`multichain`, `local`
-    /// sequences and `unlocks_at`).
-    fn pack_state(multichain: u64, local: u64, unlocks_at: u64) -> U256 {
+    /// sequences, `flags`, and the `lock_union`).
+    fn pack_state(multichain: u64, local: u64, flags: u8, lock_union: u64) -> U256 {
         let mut b = [0u8; 32];
         b[24..32].copy_from_slice(&multichain.to_be_bytes());
         b[16..24].copy_from_slice(&local.to_be_bytes());
-        b[11..16].copy_from_slice(&unlocks_at.to_be_bytes()[3..]);
+        b[15] = flags;
+        b[10..15].copy_from_slice(&lock_union.to_be_bytes()[3..]);
         U256::from_be_bytes(b)
     }
 
@@ -303,7 +301,7 @@ mod tests {
             assert_eq!(out.actors.sender.account, account);
             assert!(out.actors.payer.is_none());
             assert_eq!(out.config_changes.len(), 2);
-            assert!(out.config_changes.iter().all(ResolvedActor::is_unrestricted));
+            assert!(out.config_changes.iter().all(ResolvedActor::is_admin));
             // Both entries applied: the multichain channel advanced by two.
             assert_eq!(acc.get_change_sequences(account).unwrap(), (2, 0));
         });
@@ -396,7 +394,7 @@ mod tests {
         let at_max = signed_change(account, K1, &k, 0, u64::MAX, vec![]);
         let signed = eoa_signed(tx_with(None, None, vec![AccountChange::ConfigChange(at_max)]), &k);
         with_storage(|acc| {
-            acc.account_state.at_mut(&account).write(pack_state(u64::MAX, 0, 0)).unwrap();
+            acc.account_state.at_mut(&account).write(pack_state(u64::MAX, 0, 0, 0)).unwrap();
             assert_eq!(
                 TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW),
                 Err(TxAuthError::Apply(ApplyError::SequenceOverflow)),
@@ -418,7 +416,7 @@ mod tests {
             id[..20].copy_from_slice(signer_addr.as_slice());
             id
         });
-        let initial_actors = vec![InitialActor { actor_id: actor_id_k, authenticator: K1 }];
+        let initial_actors = vec![InitialActor::owner(actor_id_k, K1)];
         let create_entry = CreateEntry {
             user_salt: B256::ZERO,
             code: Bytes::from_static(&[0x60, 0x00]),
@@ -472,7 +470,7 @@ mod tests {
             id[..20].copy_from_slice(signer_addr.as_slice());
             id
         });
-        let initial_actors = vec![InitialActor { actor_id: actor_id_k, authenticator: K1 }];
+        let initial_actors = vec![InitialActor::owner(actor_id_k, K1)];
         let create_entry = CreateEntry {
             user_salt: B256::ZERO,
             code: Bytes::from_static(&[0x60, 0x00]),
@@ -513,13 +511,11 @@ mod tests {
     }
 
     #[test]
-    fn config_changes_authorized_before_final_sender_check() {
+    fn admin_config_actor_also_passes_final_sender_check() {
         // Account changes are authorized and applied first; the sender/payer
         // signatures are only checked against the resulting post-apply state. A
-        // sender that holds CONFIG scope (so its config change applies) but lacks
-        // SENDER scope is therefore rejected at the final sender check — proving
-        // the config stage ran before the sender gate, the opposite of the old
-        // "authorize sender first" ordering.
+        // An admin actor authorizes config and, because unrestricted scope grants
+        // sender operations, also passes the final sender check.
         let sk = key(0x22);
         let account = address!("0x00000000000000000000000000000000000000aa");
         let sid = actor_id(addr(&sk));
@@ -531,17 +527,10 @@ mod tests {
             acc.actor_config
                 .at_mut(&sid)
                 .at_mut(&account)
-                .write(pack(K1, Eip8130Constants::SCOPE_CONFIG, 0, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_UNRESTRICTED, 0))
                 .unwrap();
-            assert_eq!(
-                TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW),
-                Err(TxAuthError::Scope {
-                    operation: Operation::Sender,
-                    scope: Eip8130Constants::SCOPE_CONFIG,
-                }),
-            );
-            // The config change applied (channel advanced) before the sender
-            // check failed; the caller is responsible for discarding these writes.
+            let out = TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW).unwrap();
+            assert!(out.config_changes[0].is_admin());
             assert_eq!(acc.get_change_sequences(account).unwrap(), (1, 0));
         });
     }
@@ -574,23 +563,23 @@ mod tests {
             acc.actor_config
                 .at_mut(&sid)
                 .at_mut(&sender_account)
-                .write(pack(K1, Eip8130Constants::SCOPE_SENDER, 0, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_SENDER | Eip8130Constants::SCOPE_NONCE, 0))
                 .unwrap();
             acc.actor_config
                 .at_mut(&pid)
                 .at_mut(&payer_account)
-                .write(pack(K1, Eip8130Constants::SCOPE_PAYER, 0, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_SPONSOR_PAYER, 0))
                 .unwrap();
             acc.actor_config
                 .at_mut(&cid)
                 .at_mut(&sender_account)
-                .write(pack(K1, Eip8130Constants::SCOPE_CONFIG, 0, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_UNRESTRICTED, 0))
                 .unwrap();
             let out = TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW).unwrap();
             assert_eq!(out.actors.sender.account, sender_account);
             assert_eq!(out.actors.payer.expect("payer present").account, payer_account);
             assert_eq!(out.config_changes.len(), 1);
-            assert_eq!(out.config_changes[0].scope, Eip8130Constants::SCOPE_CONFIG);
+            assert!(out.config_changes[0].is_admin());
         });
     }
 
@@ -611,7 +600,7 @@ mod tests {
             id[..20].copy_from_slice(signer_addr.as_slice());
             id
         });
-        let initial_actors = vec![InitialActor { actor_id: actor_id_val, authenticator: K1 }];
+        let initial_actors = vec![InitialActor::owner(actor_id_val, K1)];
         // Non-empty runtime code so the derived CREATE2 address and code hash
         // match a production-admissible transaction: the structural validator
         // rejects an empty-code create before it reaches authorize_and_apply.
@@ -662,10 +651,7 @@ mod tests {
             let out = TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW)
                 .expect("create tx on empty account must authorize");
             assert_eq!(out.actors.sender.account, derived);
-            assert!(
-                out.actors.sender.resolved.is_unrestricted(),
-                "create sender must be unrestricted"
-            );
+            assert!(out.actors.sender.resolved.is_admin(), "create sender must be unrestricted");
             assert!(out.actors.payer.is_none());
             assert!(out.config_changes.is_empty());
         });
@@ -685,7 +671,7 @@ mod tests {
             id[..20].copy_from_slice(signer_addr.as_slice());
             id
         });
-        let initial_actors = vec![InitialActor { actor_id: actor_id_val, authenticator: K1 }];
+        let initial_actors = vec![InitialActor::owner(actor_id_val, K1)];
         let create = CreateEntry {
             user_salt: B256::ZERO,
             code: Bytes::new(),
@@ -742,7 +728,7 @@ mod tests {
             id[..20].copy_from_slice(attacker_addr.as_slice());
             id
         });
-        let initial_actors = vec![InitialActor { actor_id: actor_id_val, authenticator: K1 }];
+        let initial_actors = vec![InitialActor::owner(actor_id_val, K1)];
         let create = CreateEntry {
             user_salt: B256::ZERO,
             code: Bytes::new(),
@@ -795,7 +781,7 @@ mod tests {
             id[..20].copy_from_slice(signer_addr.as_slice());
             id
         });
-        let initial_actors = vec![InitialActor { actor_id: actor_id_val, authenticator: K1 }];
+        let initial_actors = vec![InitialActor::owner(actor_id_val, K1)];
         let create = CreateEntry { user_salt: B256::ZERO, code: Bytes::new(), initial_actors };
         let tx = TxEip8130 {
             chain_id: LOCAL,

--- a/crates/execution/eip8130/src/verify.rs
+++ b/crates/execution/eip8130/src/verify.rs
@@ -26,8 +26,9 @@ pub struct AuthorizedActor {
 pub struct TxActors {
     /// The transaction sender, scope-gated for [`Operation::Sender`].
     pub sender: AuthorizedActor,
-    /// The gas payer, scope-gated for [`Operation::Payer`], or `None` when the
-    /// sender pays (`tx.payer == None`).
+    /// The gas payer, scope-gated for [`Operation::SelfPayer`] (explicit
+    /// self-pay) or [`Operation::SponsorPayer`] (distinct sponsor), or `None`
+    /// when the sender implicitly pays (`tx.payer == None`).
     pub payer: Option<AuthorizedActor>,
 }
 
@@ -69,9 +70,11 @@ impl ActorTxVerifier {
 
         let payer = match tx.payer {
             None => {
-                if !Operation::Payer.is_granted(&sender.resolved) {
+                // Implicit self-pay: the sender covers its own gas, so its actor
+                // must be granted SELF_PAYER (or be admin).
+                if !Operation::SelfPayer.is_granted(&sender.resolved) {
                     return Err(TxAuthError::Scope {
-                        operation: Operation::Payer,
+                        operation: Operation::SelfPayer,
                         scope: sender.resolved.scope,
                     });
                 }
@@ -80,12 +83,19 @@ impl ActorTxVerifier {
             Some(account) => {
                 // The payer digest binds to the resolved sender account.
                 let hash = tx.payer_signature_hash(sender.account);
+                // `payer == sender` is explicit self-pay (SELF_PAYER); a distinct
+                // payer is sponsorship (SPONSOR_PAYER).
+                let operation = if account == sender.account {
+                    Operation::SelfPayer
+                } else {
+                    Operation::SponsorPayer
+                };
                 let resolved = Self::authorize_scoped(
                     storage,
                     account,
                     hash,
                     signed.payer_auth(),
-                    Operation::Payer,
+                    operation,
                     now,
                 )?;
                 Some(AuthorizedActor { account, resolved })
@@ -113,6 +123,12 @@ impl ActorTxVerifier {
                 Operation::Sender,
                 now,
             )?;
+            if !resolved.allows_sequenced_nonce(signed.tx().nonce_key) {
+                return Err(TxAuthError::Scope {
+                    operation: Operation::Sender,
+                    scope: resolved.scope,
+                });
+            }
             return Ok(AuthorizedActor { account, resolved });
         }
 
@@ -135,6 +151,9 @@ impl ActorTxVerifier {
 
         let resolved = ActorAuthorizer::authorize_k1(storage, account, recovered, now)?;
         if !Operation::Sender.is_granted(&resolved) {
+            return Err(TxAuthError::Scope { operation: Operation::Sender, scope: resolved.scope });
+        }
+        if !resolved.allows_sequenced_nonce(signed.tx().nonce_key) {
             return Err(TxAuthError::Scope { operation: Operation::Sender, scope: resolved.scope });
         }
         Ok(AuthorizedActor { account, resolved })
@@ -202,11 +221,10 @@ mod tests {
     }
 
     /// Canonical Solidity packing of `ActorConfig`.
-    fn pack(authenticator: Address, scope: u8, expiry: u64, policy_type: u8) -> U256 {
+    fn pack(authenticator: Address, scope: u8, expiry: u64) -> U256 {
         U256::from_be_slice(authenticator.as_slice())
             | (U256::from(scope) << 160)
             | (U256::from(expiry) << 168)
-            | (U256::from(policy_type) << 216)
     }
 
     fn base_tx(sender: Option<Address>, payer: Option<Address>) -> TxEip8130 {
@@ -241,7 +259,7 @@ mod tests {
         with_storage(|acc| {
             let actors = ActorTxVerifier::verify(&signed, acc, NOW).unwrap();
             assert_eq!(actors.sender.account, account);
-            assert!(actors.sender.resolved.is_unrestricted());
+            assert!(actors.sender.resolved.is_admin());
             assert!(actors.payer.is_none());
         });
     }
@@ -260,8 +278,9 @@ mod tests {
                 .at_mut(&account)
                 .write(pack(
                     K1,
-                    Eip8130Constants::SCOPE_SENDER | Eip8130Constants::SCOPE_PAYER,
-                    0,
+                    Eip8130Constants::SCOPE_SENDER
+                        | Eip8130Constants::SCOPE_SELF_PAYER
+                        | Eip8130Constants::SCOPE_NONCE,
                     0,
                 ))
                 .unwrap();
@@ -269,7 +288,9 @@ mod tests {
             assert_eq!(actors.sender.account, account);
             assert_eq!(
                 actors.sender.resolved.scope,
-                Eip8130Constants::SCOPE_SENDER | Eip8130Constants::SCOPE_PAYER
+                Eip8130Constants::SCOPE_SENDER
+                    | Eip8130Constants::SCOPE_SELF_PAYER
+                    | Eip8130Constants::SCOPE_NONCE
             );
             assert!(actors.payer.is_none());
         });
@@ -287,13 +308,13 @@ mod tests {
             acc.actor_config
                 .at_mut(&id)
                 .at_mut(&account)
-                .write(pack(K1, Eip8130Constants::SCOPE_SENDER, 0, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_SENDER | Eip8130Constants::SCOPE_NONCE, 0))
                 .unwrap();
             assert_eq!(
                 ActorTxVerifier::verify(&signed, acc, NOW),
                 Err(TxAuthError::Scope {
-                    operation: Operation::Payer,
-                    scope: Eip8130Constants::SCOPE_SENDER,
+                    operation: Operation::SelfPayer,
+                    scope: Eip8130Constants::SCOPE_SENDER | Eip8130Constants::SCOPE_NONCE,
                 }),
             );
         });
@@ -312,13 +333,13 @@ mod tests {
             acc.actor_config
                 .at_mut(&id)
                 .at_mut(&account)
-                .write(pack(K1, Eip8130Constants::SCOPE_PAYER, 0, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_SELF_PAYER, 0))
                 .unwrap();
             assert_eq!(
                 ActorTxVerifier::verify(&signed, acc, NOW),
                 Err(TxAuthError::Scope {
                     operation: Operation::Sender,
-                    scope: Eip8130Constants::SCOPE_PAYER,
+                    scope: Eip8130Constants::SCOPE_SELF_PAYER,
                 }),
             );
         });
@@ -345,17 +366,17 @@ mod tests {
             acc.actor_config
                 .at_mut(&sid)
                 .at_mut(&sender_account)
-                .write(pack(K1, Eip8130Constants::SCOPE_SENDER, 0, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_SENDER | Eip8130Constants::SCOPE_NONCE, 0))
                 .unwrap();
             acc.actor_config
                 .at_mut(&pid)
                 .at_mut(&payer_account)
-                .write(pack(K1, Eip8130Constants::SCOPE_PAYER, 0, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_SPONSOR_PAYER, 0))
                 .unwrap();
             let actors = ActorTxVerifier::verify(&signed, acc, NOW).unwrap();
             let payer = actors.payer.expect("payer present");
             assert_eq!(payer.account, payer_account);
-            assert_eq!(payer.resolved.scope, Eip8130Constants::SCOPE_PAYER);
+            assert_eq!(payer.resolved.scope, Eip8130Constants::SCOPE_SPONSOR_PAYER);
         });
     }
 
@@ -384,14 +405,14 @@ mod tests {
             acc.actor_config
                 .at_mut(&pid)
                 .at_mut(&payer_account)
-                .write(pack(K1, Eip8130Constants::SCOPE_PAYER, 0, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_SPONSOR_PAYER, 0))
                 .unwrap();
             let actors = ActorTxVerifier::verify(&signed, acc, NOW).unwrap();
             assert_eq!(actors.sender.account, sender_account);
-            assert!(actors.sender.resolved.is_unrestricted());
+            assert!(actors.sender.resolved.is_admin());
             let payer = actors.payer.expect("payer present");
             assert_eq!(payer.account, payer_account);
-            assert_eq!(payer.resolved.scope, Eip8130Constants::SCOPE_PAYER);
+            assert_eq!(payer.resolved.scope, Eip8130Constants::SCOPE_SPONSOR_PAYER);
         });
     }
 
@@ -418,7 +439,7 @@ mod tests {
             acc.actor_config
                 .at_mut(&pid)
                 .at_mut(&payer_account)
-                .write(pack(K1, Eip8130Constants::SCOPE_PAYER, 0, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_SPONSOR_PAYER, 0))
                 .unwrap();
             // The payer signs the wrong digest, so it recovers a different actor
             // that is not bound on the payer account.
@@ -450,18 +471,18 @@ mod tests {
             acc.actor_config
                 .at_mut(&sid)
                 .at_mut(&sender_account)
-                .write(pack(K1, Eip8130Constants::SCOPE_SENDER, 0, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_SENDER | Eip8130Constants::SCOPE_NONCE, 0))
                 .unwrap();
-            // Payer actor bound but lacking SCOPE_PAYER.
+            // Payer actor bound but lacking SCOPE_SPONSOR_PAYER.
             acc.actor_config
                 .at_mut(&pid)
                 .at_mut(&payer_account)
-                .write(pack(K1, Eip8130Constants::SCOPE_SENDER, 0, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_SENDER, 0))
                 .unwrap();
             assert_eq!(
                 ActorTxVerifier::verify(&signed, acc, NOW),
                 Err(TxAuthError::Scope {
-                    operation: Operation::Payer,
+                    operation: Operation::SponsorPayer,
                     scope: Eip8130Constants::SCOPE_SENDER,
                 }),
             );

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -921,7 +921,6 @@ where
             ApplyError::Storage(_) => "account configuration write failed",
             ApplyError::MalformedAuthorizeData => "actor change authorize data is malformed",
             ApplyError::InvalidAuthenticator => "actor authenticator is not canonical",
-            ApplyError::PolicyScope => "policy-bearing actor scope is invalid",
             ApplyError::MalformedPolicyData => "actor policy data is malformed",
             ApplyError::NotAnActor { .. } => "revoked actor is not authorized",
             ApplyError::NoInitialActors => "create entry has no initial actors",
@@ -1199,8 +1198,13 @@ where
     /// Validates `Create.initial_actors`: the slice length is bounded by
     /// [`Eip8130Constants::MAX_ACTORS_PER_ENTRY`] (anti-DoS cap on memory + work
     /// spent on duplicate detection), every `authenticator` is at or above the
-    /// `K1_AUTHENTICATOR` floor (i.e. not the `address(0)` empty sentinel), and no
-    /// two entries share the same `actor_id`.
+    /// `K1_AUTHENTICATOR` floor (i.e. not the `address(0)` empty sentinel), no
+    /// two entries share the same `actor_id`, and each entry's `policy_data` is
+    /// structurally consistent with its `scope`: empty unless `SCOPE_POLICY` is
+    /// set, otherwise exactly `manager (20) || commitment (32)` (52 bytes). The
+    /// same consistency is enforced downstream in `authorize_actor`/`slice_policy`;
+    /// checking it here rejects malformed creates before the expensive overlay
+    /// path runs.
     fn validate_initial_actors(actors: &[InitialActor]) -> Result<(), InvalidPoolTransactionError> {
         if actors.len() > Eip8130Constants::MAX_ACTORS_PER_ENTRY {
             return Err(InvalidTransactionError::TxTypeNotSupported.into());
@@ -1211,6 +1215,11 @@ where
                 return Err(InvalidTransactionError::TxTypeNotSupported.into());
             }
             if previous.is_some_and(|previous| actor.actor_id <= previous) {
+                return Err(InvalidTransactionError::TxTypeNotSupported.into());
+            }
+            let policy = actor.scope & Eip8130Constants::SCOPE_POLICY != 0;
+            let expected_policy_len = if policy { Eip8130Constants::POLICY_DATA_LEN } else { 0 };
+            if actor.policy_data.len() != expected_policy_len {
                 return Err(InvalidTransactionError::TxTypeNotSupported.into());
             }
             previous = Some(actor.actor_id);
@@ -1704,10 +1713,7 @@ mod tests {
     }
 
     fn make_initial_actor(actor_id_byte: u8) -> InitialActor {
-        InitialActor {
-            actor_id: B256::repeat_byte(actor_id_byte),
-            authenticator: ok_authenticator(),
-        }
+        InitialActor::owner(B256::repeat_byte(actor_id_byte), ok_authenticator())
     }
 
     /// Builds an `Authorize` actor-change whose ABI-encoded `data` carries
@@ -1817,6 +1823,52 @@ mod tests {
             &sign_eoa_eip8130(tx),
             test_chain_id(),
         ));
+    }
+
+    #[test]
+    fn rejects_eip8130_create_with_policy_data_on_ungated_actor() {
+        let mut entry = make_valid_create_entry();
+        entry.initial_actors[0].scope = 0;
+        entry.initial_actors[0].policy_data = vec![0u8; Eip8130Constants::POLICY_DATA_LEN].into();
+        let tx = TxEip8130 {
+            account_changes: vec![AccountChange::Create(entry)],
+            ..minimal_valid_eoa_tx()
+        };
+        assert_unsupported(TestValidator::validate_account_changes(
+            &sign_eoa_eip8130(tx),
+            test_chain_id(),
+        ));
+    }
+
+    #[test]
+    fn rejects_eip8130_create_with_wrong_length_policy_data() {
+        let mut entry = make_valid_create_entry();
+        entry.initial_actors[0].scope = Eip8130Constants::SCOPE_POLICY;
+        entry.initial_actors[0].policy_data =
+            vec![0u8; Eip8130Constants::POLICY_DATA_LEN - 1].into();
+        let tx = TxEip8130 {
+            account_changes: vec![AccountChange::Create(entry)],
+            ..minimal_valid_eoa_tx()
+        };
+        assert_unsupported(TestValidator::validate_account_changes(
+            &sign_eoa_eip8130(tx),
+            test_chain_id(),
+        ));
+    }
+
+    #[test]
+    fn accepts_eip8130_create_with_well_formed_policy_data() {
+        let mut entry = make_valid_create_entry();
+        entry.initial_actors[0].scope = Eip8130Constants::SCOPE_POLICY;
+        entry.initial_actors[0].policy_data = vec![0u8; Eip8130Constants::POLICY_DATA_LEN].into();
+        let tx = TxEip8130 {
+            account_changes: vec![AccountChange::Create(entry)],
+            ..minimal_valid_eoa_tx()
+        };
+        assert!(
+            TestValidator::validate_account_changes(&sign_eoa_eip8130(tx), test_chain_id(),)
+                .is_ok()
+        );
     }
 
     #[test]
@@ -2278,7 +2330,7 @@ mod tests {
             B256::from_slice(&id)
         };
         let initial_actors =
-            vec![InitialActor { actor_id, authenticator: Eip8130Constants::K1_AUTHENTICATOR }];
+            vec![InitialActor::owner(actor_id, Eip8130Constants::K1_AUTHENTICATOR)];
         let create = CreateEntry {
             user_salt: B256::ZERO,
             // Non-empty code: the structural gate rejects create.code.is_empty(),


### PR DESCRIPTION
## Summary
- adopt the finalized actor grants, including nonce authorization and split self/sponsor payer scopes
- replace `policyType` with `SCOPE_POLICY` and commit initial actor scope/policy data
- align packed actor/account state and lock-union behavior with the reference contracts
- meter policy-bearing config and initial actors using the finalized three-field `ActorConfig` ABI

## Stack
- PR 1 of 3, extracted from #3921
- Next: #3958 — canonical nonce-free replay ID and txpool handling
- Final: #3959 — nonce-free gas schedule

## Review follow-up
- Updated `authorize_has_policy` for the three-field `ActorConfig` ABI: it now reads `SCOPE_POLICY` from the scope word instead of treating the dynamic `policyData` offset as the removed `policyType` word.
- Policy-bearing initial actors now pay for all three initialized slots: `actor_config`, `policy_manager`, and `policy_commitment`.
- Added regression tests for both cases in `intrinsic.rs`.

## Test plan
- [x] `cargo check -p base-common-consensus -p base-execution-eip8130 -p base-common-evm -p base-execution-txpool`
- [x] `cargo test -p base-common-consensus --lib eip8130`
- [x] `cargo test -p base-execution-eip8130 --lib`
- [x] `cargo test -p base-common-evm --lib eip8130`
- [x] `cargo test -p base-execution-txpool --lib eip8130`
- [x] `cargo test -p base-execution-eip8130 --lib intrinsic`
- [x] `cargo +nightly fmt --all -- --check`