### PR TITLE
feat(eip8130): implement canonical nonce-free replay ID

### DIFF
--- a/crates/common/consensus/src/transaction/eip8130/constants.rs
+++ b/crates/common/consensus/src/transaction/eip8130/constants.rs
@@ -68,6 +68,17 @@ impl Eip8130Constants {
     // `SCOPE_SIGNATURE`. Bits `0x20`, `0x40`, and `0x80` are spare, reserved for
     // future pure grants.
 
+    /// Domain-separation prefix for the `replay_id` preimage
+    /// (`keccak256(REPLAY_ID_TYPE || rlp([...])`).
+    ///
+    /// Pinned to the EIP-8130 constant-table value `REPLAY_ID_TYPE = 0x7901`. It
+    /// shares the `AA_TX_TYPE` first byte (`0x79`) but appends `0x01`: the
+    /// sender/payer signing hashes hash `EIP8130_TX_TYPE`/`EIP8130_PAYER_TYPE`
+    /// followed by an RLP list header (always `>= 0xc0`), so the trailing `0x01`
+    /// can never coincide with a valid list header and the preimage spaces cannot
+    /// collide.
+    pub const REPLAY_ID_TYPE: [u8; 2] = [0x79, 0x01];
+
     /// Unrestricted scope value (actor is valid in all contexts).
     pub const SCOPE_UNRESTRICTED: u8 = 0x00;
 

--- a/crates/common/consensus/src/transaction/eip8130/tx.rs
+++ b/crates/common/consensus/src/transaction/eip8130/tx.rs
@@ -145,10 +145,11 @@ impl TxEip8130 {
         Ok(phases)
     }
 
-    /// Length of all RLP fields (no list header).
-    pub fn rlp_encoded_fields_length(&self) -> usize {
+    /// Length of all RLP fields (no list header), encoding `sender` in place of
+    /// the transaction's stored sender.
+    fn rlp_encoded_fields_length_with_sender(&self, sender: &Option<Address>) -> usize {
         self.chain_id.length()
-            + Self::address_opt_encoded_length(&self.sender)
+            + Self::address_opt_encoded_length(sender)
             + self.nonce_key.length()
             + self.nonce_sequence.length()
             + self.expiry.length()
@@ -161,10 +162,11 @@ impl TxEip8130 {
             + Self::address_opt_encoded_length(&self.payer)
     }
 
-    /// Encodes the RLP fields (no list header) in canonical order.
-    pub fn rlp_encode_fields(&self, out: &mut dyn BufMut) {
+    /// Encodes the RLP fields (no list header) in canonical order, encoding
+    /// `sender` in place of the transaction's stored sender.
+    fn rlp_encode_fields_with_sender(&self, sender: &Option<Address>, out: &mut dyn BufMut) {
         self.chain_id.encode(out);
-        Self::encode_address_opt(&self.sender, out);
+        Self::encode_address_opt(sender, out);
         self.nonce_key.encode(out);
         self.nonce_sequence.encode(out);
         self.expiry.encode(out);
@@ -175,6 +177,16 @@ impl TxEip8130 {
         Self::encode_calls(&self.calls, out);
         self.metadata.encode(out);
         Self::encode_address_opt(&self.payer, out);
+    }
+
+    /// Length of all RLP fields (no list header).
+    pub fn rlp_encoded_fields_length(&self) -> usize {
+        self.rlp_encoded_fields_length_with_sender(&self.sender)
+    }
+
+    /// Encodes the RLP fields (no list header) in canonical order.
+    pub fn rlp_encode_fields(&self, out: &mut dyn BufMut) {
+        self.rlp_encode_fields_with_sender(&self.sender, out);
     }
 
     /// Decodes the RLP fields (no list header) in canonical order.
@@ -279,6 +291,40 @@ impl TxEip8130 {
         keccak256(&buf)
     }
 
+    /// Returns the fee- and signature-invariant replay identifier.
+    ///
+    /// Used only for nonce-free (`nonce_key == NONCE_KEY_MAX`) transactions, which
+    /// always carry `(NONCE_KEY_MAX, 0)`; `nonce_key`/`nonce_sequence` therefore
+    /// carry no entropy and are omitted from the preimage. The resolved sender is
+    /// encoded in place of the nullable wire sender:
+    /// `keccak256(REPLAY_ID_TYPE || rlp([chain_id, resolved_sender, expiry,
+    /// account_changes, calls, metadata, payer]))`.
+    #[must_use]
+    pub fn replay_id(&self, resolved_sender: Address) -> B256 {
+        let payload_length = self.chain_id.length()
+            + resolved_sender.length()
+            + self.expiry.length()
+            + self.account_changes.length()
+            + Self::calls_encoded_length(&self.calls)
+            + self.metadata.length()
+            + Self::address_opt_encoded_length(&self.payer);
+        let mut buf = Vec::with_capacity(
+            Eip8130Constants::REPLAY_ID_TYPE.len()
+                + length_of_length(payload_length)
+                + payload_length,
+        );
+        buf.put_slice(&Eip8130Constants::REPLAY_ID_TYPE);
+        Header { list: true, payload_length }.encode(&mut buf);
+        self.chain_id.encode(&mut buf);
+        resolved_sender.encode(&mut buf);
+        self.expiry.encode(&mut buf);
+        self.account_changes.encode(&mut buf);
+        Self::encode_calls(&self.calls, &mut buf);
+        self.metadata.encode(&mut buf);
+        Self::encode_address_opt(&self.payer, &mut buf);
+        keccak256(&buf)
+    }
+
     /// Signing-hash preimage for the payer, per [EIP-8130].
     ///
     /// `keccak256(EIP8130_PAYER_TYPE || rlp([all body fields through `payer`]))`
@@ -289,10 +335,12 @@ impl TxEip8130 {
     ///
     /// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
     pub fn payer_signature_hash(&self, resolved_sender: Address) -> B256 {
-        let with_resolved = Self { sender: Some(resolved_sender), ..self.clone() };
-        let mut buf = Vec::with_capacity(with_resolved.rlp_encoded_length() + 1);
+        let sender = Some(resolved_sender);
+        let payload_length = self.rlp_encoded_fields_length_with_sender(&sender);
+        let mut buf = Vec::with_capacity(1 + length_of_length(payload_length) + payload_length);
         buf.put_u8(Eip8130Constants::EIP8130_PAYER_TYPE);
-        with_resolved.rlp_encode(&mut buf);
+        Header { list: true, payload_length }.encode(&mut buf);
+        self.rlp_encode_fields_with_sender(&sender, &mut buf);
         keccak256(&buf)
     }
 
@@ -679,6 +727,47 @@ mod tests {
         let tx = sample_tx();
         let h = tx.sender_signature_hash();
         assert_ne!(h, B256::ZERO);
+    }
+
+    #[test]
+    fn replay_id_ignores_fee_fields() {
+        let tx = sample_tx();
+        let sender = tx.sender.unwrap();
+        let mut other = tx.clone();
+        other.max_priority_fee_per_gas += 1;
+        other.max_fee_per_gas += 2;
+        other.gas_limit += 3;
+        assert_eq!(tx.replay_id(sender), other.replay_id(sender));
+    }
+
+    #[test]
+    fn replay_id_ignores_nonce_fields() {
+        // Nonce-free txs always carry `(NONCE_KEY_MAX, 0)`, so `nonce_key` and
+        // `nonce_sequence` are omitted from the preimage and cannot alter identity.
+        let tx = sample_tx();
+        let sender = tx.sender.unwrap();
+        let mut other = tx.clone();
+        other.nonce_key = U256::from(7u64);
+        other.nonce_sequence = 42;
+        assert_eq!(tx.replay_id(sender), other.replay_id(sender));
+    }
+
+    #[test]
+    fn replay_id_commits_to_payer_calls_and_expiry() {
+        let tx = sample_tx();
+        let sender = tx.sender.unwrap();
+
+        let mut changed = tx.clone();
+        changed.payer = Some(address!("0x00000000000000000000000000000000000000dd"));
+        assert_ne!(tx.replay_id(sender), changed.replay_id(sender));
+
+        changed = tx.clone();
+        changed.calls[0][0].data = bytes!("01");
+        assert_ne!(tx.replay_id(sender), changed.replay_id(sender));
+
+        changed = tx.clone();
+        changed.expiry = 1;
+        assert_ne!(tx.replay_id(sender), changed.replay_id(sender));
     }
 
     #[test]

--- a/crates/common/evm/src/eip8130.rs
+++ b/crates/common/evm/src/eip8130.rs
@@ -784,7 +784,6 @@ impl Eip8130Executor {
         let max_fee = tx.max_fee_per_gas;
         let max_priority = tx.max_priority_fee_per_gas;
         let expiry = tx.expiry;
-        let sender_sig_hash = tx.sender_signature_hash();
 
         let internals = EvmInternals::from_context(ctx);
         let mut provider = JournalStorageProvider::new(internals, Address::ZERO);
@@ -850,7 +849,6 @@ impl Eip8130Executor {
             NonceValidator::validate(
                 tx,
                 sender,
-                sender_sig_hash,
                 protocol_nonce,
                 &nonce_mgr,
                 NonceMode::Inclusion,
@@ -861,7 +859,7 @@ impl Eip8130Executor {
             // 4. Advance the nonce. The protocol (basic-account) nonce is bumped
             //    in `prepay`; channel and expiring nonces are journal storage.
             let bump_protocol_nonce = if nonce_key == Eip8130Constants::NONCE_KEY_MAX {
-                let replay = NonceValidator::replay_hash(sender, sender_sig_hash);
+                let replay = NonceValidator::replay_hash(tx, sender);
                 nonce_mgr
                     .check_and_mark_expiring_nonce(replay, expiry)
                     .map_err(BaseTransactionError::eip8130)?;

--- a/crates/common/precompiles/src/nonce/storage.rs
+++ b/crates/common/precompiles/src/nonce/storage.rs
@@ -38,7 +38,7 @@ pub struct NonceManagerStorage {
     /// Circular buffer of recorded replay hashes, indexed by ring position.
     pub expiring_nonce_ring: Mapping<u32, B256>,
     /// Current circular-buffer write position; wraps at
-    /// [`Self::EXPIRING_NONCE_SET_CAPACITY`].
+    /// [`Self::REPLAY_BUFFER_CAPACITY`].
     pub expiring_nonce_ring_ptr: u32,
 }
 
@@ -58,17 +58,23 @@ impl NonceManagerStorage<'_> {
     /// without instantiating the precompile. Pair with [`Self::nonce_slot`].
     pub const NONCES_BASE_SLOT: U256 = slots::NONCES;
 
-    /// Capacity of the expiring-nonce ring buffer.
+    /// Fixed capacity of the nonce-free `replay_id` ring buffer
+    /// (`REPLAY_BUFFER_CAPACITY` in the EIP-8130 constant table).
     ///
-    /// Sized to absorb a sustained burst (~10k TPS for ~30s) so that, by the time
-    /// the write pointer wraps back to a slot, the entry it holds has expired and
-    /// can be reclaimed.
-    pub const EXPIRING_NONCE_SET_CAPACITY: u32 = 300_000;
+    /// A consensus chain parameter: identical for every node on the chain, not a
+    /// per-node choice. Sized together with [`Self::NONCE_FREE_EXPIRY_WINDOW`] so
+    /// that `peak accepted nonce-free throughput × NONCE_FREE_EXPIRY_WINDOW` stays
+    /// within capacity (~10k TPS for ~30s), so that by the time the write pointer
+    /// wraps back to a slot, the entry it holds has expired and can be reclaimed.
+    pub const REPLAY_BUFFER_CAPACITY: u32 = 300_000;
 
-    /// Maximum lifetime of an expiring-nonce transaction, in seconds.
+    /// Maximum `expiry` window accepted for a nonce-free transaction, in seconds
+    /// (`NONCE_FREE_EXPIRY_WINDOW` in the EIP-8130 constant table).
     ///
-    /// A transaction's `valid_before` must fall in `(now, now + this]`.
-    pub const EXPIRING_NONCE_MAX_EXPIRY_SECS: u64 = 30;
+    /// A consensus chain parameter (not a per-node choice), sized together with
+    /// [`Self::REPLAY_BUFFER_CAPACITY`]. A transaction's `valid_before` must fall
+    /// in `(now, now + this]`.
+    pub const NONCE_FREE_EXPIRY_WINDOW: u64 = 30;
 
     /// Nonce key reserved for the protocol nonce, which is held in account state.
     const PROTOCOL_NONCE_KEY: U256 = U256::ZERO;
@@ -173,7 +179,7 @@ impl NonceManagerStorage<'_> {
     ///
     /// # Errors
     /// - [`INonceManager::InvalidExpiringNonceExpiry`] — `valid_before` is not in
-    ///   `(now, now + EXPIRING_NONCE_MAX_EXPIRY_SECS]`.
+    ///   `(now, now + NONCE_FREE_EXPIRY_WINDOW]`.
     /// - [`INonceManager::ExpiringNonceReplay`] — the hash is already recorded and unexpired.
     /// - [`INonceManager::ExpiringNonceSetFull`] — the ring slot holds an unexpired entry
     ///   that cannot be reclaimed.
@@ -185,8 +191,7 @@ impl NonceManagerStorage<'_> {
         let now: u64 = self.storage.timestamp().saturating_to();
 
         // 1. Validate the expiry window: must be in (now, now + MAX_EXPIRY_SECS].
-        if valid_before <= now
-            || valid_before > now.saturating_add(Self::EXPIRING_NONCE_MAX_EXPIRY_SECS)
+        if valid_before <= now || valid_before > now.saturating_add(Self::NONCE_FREE_EXPIRY_WINDOW)
         {
             return Err(BasePrecompileError::revert(INonceManager::InvalidExpiringNonceExpiry {}));
         }
@@ -231,7 +236,7 @@ impl NonceManagerStorage<'_> {
         // `wrapping_add` is defensive: a corrupted ptr at u32::MAX wraps to 0
         // (still < capacity) rather than panicking in debug builds.
         let incremented = ptr.wrapping_add(1);
-        let next = if incremented >= Self::EXPIRING_NONCE_SET_CAPACITY { 0 } else { incremented };
+        let next = if incremented >= Self::REPLAY_BUFFER_CAPACITY { 0 } else { incremented };
         self.expiring_nonce_ring_ptr.write(next)?;
 
         checkpoint.commit();
@@ -380,7 +385,7 @@ mod tests {
             assert_eq!(
                 mgr.check_and_mark_expiring_nonce(
                     hash,
-                    now + NonceManagerStorage::EXPIRING_NONCE_MAX_EXPIRY_SECS + 1
+                    now + NonceManagerStorage::NONCE_FREE_EXPIRY_WINDOW + 1
                 )
                 .unwrap_err(),
                 invalid
@@ -389,7 +394,7 @@ mod tests {
             // Exactly at the max window succeeds.
             mgr.check_and_mark_expiring_nonce(
                 hash,
-                now + NonceManagerStorage::EXPIRING_NONCE_MAX_EXPIRY_SECS,
+                now + NonceManagerStorage::NONCE_FREE_EXPIRY_WINDOW,
             )
             .unwrap();
         });
@@ -420,7 +425,7 @@ mod tests {
             let mut mgr = NonceManagerStorage::new(ctx);
             // Seed the pointer just below capacity so the next write wraps it.
             mgr.expiring_nonce_ring_ptr
-                .write(NonceManagerStorage::EXPIRING_NONCE_SET_CAPACITY - 1)
+                .write(NonceManagerStorage::REPLAY_BUFFER_CAPACITY - 1)
                 .unwrap();
 
             mgr.check_and_mark_expiring_nonce(B256::repeat_byte(0x77), valid_before).unwrap();

--- a/crates/common/precompiles/src/nonce/storage.rs
+++ b/crates/common/precompiles/src/nonce/storage.rs
@@ -164,9 +164,11 @@ impl NonceManagerStorage<'_> {
     /// Validates and records an expiring-nonce transaction, providing replay
     /// protection for nonce-free EIP-8130 transactions.
     ///
-    /// `expiring_nonce_hash` is the signature-invariant replay hash
-    /// (`keccak256(resolved_sender || sender_signature_hash)`), so re-signed
-    /// fee-payer variants of one logical transaction collapse to a single entry.
+    /// `expiring_nonce_hash` is the canonical `TxEip8130::replay_id`:
+    /// `keccak256(REPLAY_ID_TYPE || rlp([chain_id, resolved_sender, expiry,
+    /// account_changes, calls, metadata, payer]))`. Fees, nonce fields, and
+    /// authentication blobs are omitted, so fee-bumped or re-signed variants of
+    /// one logical transaction collapse to a single entry.
     /// The hash is recorded in a circular buffer that reclaims expired slots as
     /// the write pointer advances.
     ///

--- a/crates/execution/eip8130/src/validate.rs
+++ b/crates/execution/eip8130/src/validate.rs
@@ -3,7 +3,7 @@
 
 use core::cmp::Ordering;
 
-use alloy_primitives::{Address, B256, Keccak256, U256};
+use alloy_primitives::{Address, B256, U256};
 use base_common_consensus::{Eip8130Constants, TxEip8130};
 use base_common_precompiles::NonceManagerStorage;
 
@@ -45,12 +45,6 @@ impl NonceValidator {
     /// Validates `tx`'s `(nonce_key, nonce_sequence)` for `account` (the resolved
     /// transaction sender).
     ///
-    /// `sender_signature_hash` is [`TxEip8130::sender_signature_hash`], taken as
-    /// a parameter because the earlier authenticate stage has already computed it
-    /// — recomputing it here (an RLP encode + keccak256) would be redundant work
-    /// on the nonce-free hot path. It is consulted only for the nonce-free
-    /// (`NONCE_KEY_MAX`) replay hash.
-    ///
     /// `protocol_nonce` is the account's current basic nonce, read by the caller
     /// from account state; it is consulted only for the protocol channel
     /// (`nonce_key == 0`). `storage` serves the 2D channels and the nonce-free
@@ -64,7 +58,6 @@ impl NonceValidator {
     pub fn validate(
         tx: &TxEip8130,
         account: Address,
-        sender_signature_hash: B256,
         protocol_nonce: u64,
         storage: &NonceManagerStorage<'_>,
         mode: NonceMode,
@@ -76,7 +69,7 @@ impl NonceValidator {
             // `Eip8130Signed::validate_timestamp`; the only stateful check is
             // that this logical transaction's replay hash is not already
             // recorded and unexpired.
-            let replay = Self::replay_hash(account, sender_signature_hash);
+            let replay = Self::replay_hash(tx, account);
             if storage.is_expiring_nonce_seen(replay, now)? {
                 return Err(NonceError::Replay);
             }
@@ -103,19 +96,14 @@ impl NonceValidator {
         }
     }
 
-    /// The signature-invariant nonce-free replay hash,
-    /// `keccak256(account ‖ sender_signature_hash)`, matching the value the nonce
-    /// manager records in its expiring-nonce set.
+    /// The transaction's signature- and fee-invariant replay identifier.
     ///
     /// Public so the execution layer can recompute the identical key when it
     /// records the nonce via `check_and_mark_expiring_nonce` at block inclusion,
     /// rather than duplicating the derivation and risking divergence.
     #[must_use]
-    pub fn replay_hash(account: Address, sender_signature_hash: B256) -> B256 {
-        let mut hasher = Keccak256::new();
-        hasher.update(account.as_slice());
-        hasher.update(sender_signature_hash.as_slice());
-        hasher.finalize()
+    pub fn replay_hash(tx: &TxEip8130, account: Address) -> B256 {
+        tx.replay_id(account)
     }
 }
 
@@ -146,15 +134,7 @@ mod tests {
         StorageCtx::enter(&mut storage, |ctx| {
             let mut mgr = NonceManagerStorage::new(ctx);
             seed(&mut mgr);
-            NonceValidator::validate(
-                tx,
-                ACCOUNT,
-                tx.sender_signature_hash(),
-                protocol_nonce,
-                &mgr,
-                mode,
-                now,
-            )
+            NonceValidator::validate(tx, ACCOUNT, protocol_nonce, &mgr, mode, now)
         })
     }
 
@@ -220,7 +200,7 @@ mod tests {
     fn nonce_free_replay_is_rejected() {
         let now = 1_000u64;
         let tx = tx_with(Eip8130Constants::NONCE_KEY_MAX, 0);
-        let replay = NonceValidator::replay_hash(ACCOUNT, tx.sender_signature_hash());
+        let replay = NonceValidator::replay_hash(&tx, ACCOUNT);
         let seed = |mgr: &mut NonceManagerStorage<'_>| {
             mgr.check_and_mark_expiring_nonce(replay, now + 20).unwrap();
         };

--- a/crates/execution/txpool/src/pool.rs
+++ b/crates/execution/txpool/src/pool.rs
@@ -164,7 +164,9 @@ where
     fn eip8130_replay_already_seen(&self, transaction: &T) -> Option<TxHash> {
         let key = (transaction.sender(), transaction.eip8130_replay_id()?);
         let hash = self.eip8130_replays.read().get(&key).copied()?;
-        if self.protocol_pool.get(&hash).is_some() || self.nonce_pool.read().contains(&hash) {
+        // Only nonce-free transactions have replay IDs, and those live in the
+        // protocol pool; channelized transactions live in `nonce_pool`.
+        if self.protocol_pool.get(&hash).is_some() {
             return Some(hash);
         }
         self.eip8130_replays.write().remove(&key);
@@ -422,16 +424,11 @@ where
             return Ok(events);
         }
 
-        let replay_id = transaction.eip8130_replay_id();
-        let sender = transaction.sender();
         let hash = *transaction.hash();
         let (events, listener) = self.listeners.write().subscribe_hash(hash);
         if let Err(error) = self.add_sidecar_transaction(origin, transaction).await {
             self.listeners.write().unsubscribe_hash_listener(&hash, &listener);
             return Err(error);
-        }
-        if let Some(replay_id) = replay_id {
-            self.track_eip8130_replay_id(sender, replay_id, hash);
         }
         Ok(events)
     }
@@ -449,16 +446,12 @@ where
                 reth_transaction_pool::error::PoolErrorKind::AlreadyImported,
             ));
         }
-        let replay_id = transaction.eip8130_replay_id();
-        let sender = transaction.sender();
-        let hash = *transaction.hash();
         if self.is_sidecar_transaction(&transaction) {
-            let outcome = self.add_sidecar_transaction(origin, transaction).await?;
-            if let Some(replay_id) = replay_id {
-                self.track_eip8130_replay_id(sender, replay_id, hash);
-            }
-            Ok(outcome)
+            self.add_sidecar_transaction(origin, transaction).await
         } else {
+            let replay_id = transaction.eip8130_replay_id();
+            let sender = transaction.sender();
+            let hash = *transaction.hash();
             let outcome = self.protocol_pool.add_transaction(origin, transaction).await?;
             if let Some(replay_id) = replay_id {
                 self.track_eip8130_replay_id(sender, replay_id, hash);

--- a/crates/execution/txpool/src/pool.rs
+++ b/crates/execution/txpool/src/pool.rs
@@ -52,7 +52,7 @@ pub struct BaseTransactionPool<
         Pool<TransactionValidationTaskExecutor<BaseTransactionValidator<Client, T, Evm>>, O, S>,
     ordering: O,
     nonce_pool: Arc<RwLock<TwoDNoncePool<T>>>,
-    nonce_free_replays: Arc<RwLock<HashMap<B256, TxHash>>>,
+    eip8130_replays: Arc<RwLock<HashMap<(Address, B256), TxHash>>>,
     listeners: Arc<RwLock<SidecarListeners<T>>>,
 }
 
@@ -84,7 +84,7 @@ where
             protocol_pool: self.protocol_pool.clone(),
             ordering: self.ordering.clone(),
             nonce_pool: Arc::clone(&self.nonce_pool),
-            nonce_free_replays: Arc::clone(&self.nonce_free_replays),
+            eip8130_replays: Arc::clone(&self.eip8130_replays),
             listeners: Arc::clone(&self.listeners),
         }
     }
@@ -124,7 +124,7 @@ where
             protocol_pool,
             ordering,
             nonce_pool: Arc::new(RwLock::new(TwoDNoncePool::new(price_bump_config))),
-            nonce_free_replays: Arc::new(RwLock::new(HashMap::new())),
+            eip8130_replays: Arc::new(RwLock::new(HashMap::new())),
             listeners: Arc::new(RwLock::new(SidecarListeners::default())),
         }
     }
@@ -148,52 +148,76 @@ where
         transaction.eip8130_nonce_channel_key().is_some()
     }
 
-    fn nonce_free_replay_already_seen(&self, transaction: &T) -> Option<TxHash> {
-        let replay_id = transaction.eip8130_nonce_free_replay_id()?;
-        let mut index = self.nonce_free_replays.write();
-        let hash = index.get(&replay_id).copied()?;
-        if self.protocol_pool.get(&hash).is_some() {
+    /// Best-effort replay-id dedup lookup for the mempool admission path.
+    ///
+    /// This check and the subsequent [`Self::track_eip8130_replay_id`] insert are
+    /// deliberately **not** atomic: the index lock is released between them (and
+    /// between this check and the actual pool insert). Two concurrent admissions
+    /// of the same `(sender, replay_id)` can therefore both pass and enter the
+    /// pool. That is acceptable because the index is only a mempool optimization,
+    /// not a consensus control: identical transactions collapse by tx-hash in the
+    /// underlying pool, and any surviving nonce-free duplicate is rejected at
+    /// execution by the enshrined replay buffer. Holding the index lock across the
+    /// validate+insert would also serialize admission and reintroduce cross-lock
+    /// nesting, so the looser guarantee is intentional. A stale entry whose target
+    /// is no longer pooled is opportunistically evicted here.
+    fn eip8130_replay_already_seen(&self, transaction: &T) -> Option<TxHash> {
+        let key = (transaction.sender(), transaction.eip8130_replay_id()?);
+        let hash = self.eip8130_replays.read().get(&key).copied()?;
+        if self.protocol_pool.get(&hash).is_some() || self.nonce_pool.read().contains(&hash) {
             return Some(hash);
         }
-        index.remove(&replay_id);
+        self.eip8130_replays.write().remove(&key);
         None
     }
 
-    fn track_nonce_free_replay_id(&self, replay_id: B256, hash: TxHash) {
+    fn track_eip8130_replay_id(&self, sender: Address, replay_id: B256, hash: TxHash) {
         {
-            let mut index = self.nonce_free_replays.write();
-            index.insert(replay_id, hash);
+            let mut index = self.eip8130_replays.write();
+            index.insert((sender, replay_id), hash);
         }
-        self.reconcile_nonce_free_replays_if_needed();
+        self.reconcile_eip8130_replays_if_needed();
     }
 
-    fn reconcile_nonce_free_replays_if_needed(&self) {
-        let pool_size = self.protocol_pool.pool_size().total;
-        let mut index = self.nonce_free_replays.write();
-        if index.len() <= pool_size {
+    fn reconcile_eip8130_replays_if_needed(&self) {
+        let pool_size = self.pool_size().total;
+        // Fast path: bail while within bound, holding only the index read lock.
+        if self.eip8130_replays.read().len() <= pool_size {
             return;
         }
+        // Snapshot and rebuild the index from the live pool *without* holding the
+        // `eip8130_replays` lock. `pooled_transactions()` takes `nonce_pool.read()`,
+        // so acquiring the index write lock first (as the naive `write(); rebuild()`
+        // would) establishes an `eip8130_replays -> nonce_pool` lock order. Building
+        // the replacement outside the lock keeps the two locks strictly disjoint,
+        // avoiding a lock-order inversion with any path that touches the index after
+        // the nonce pool. Entries added between this snapshot and the write below are
+        // best-effort only (the index is a dedup optimization, not consensus state).
         let mut rebuilt = HashMap::new();
-        for transaction in self.protocol_pool.pooled_transactions() {
-            if let Some(replay_id) = transaction.transaction.eip8130_nonce_free_replay_id() {
-                rebuilt.insert(replay_id, *transaction.hash());
+        for transaction in self.pooled_transactions() {
+            if let Some(replay_id) = transaction.transaction.eip8130_replay_id() {
+                rebuilt.insert((transaction.transaction.sender(), replay_id), *transaction.hash());
             }
         }
-        *index = rebuilt;
+        let mut index = self.eip8130_replays.write();
+        // Re-check under the write lock: only overwrite while still oversized.
+        if index.len() > pool_size {
+            *index = rebuilt;
+        }
     }
 
-    fn untrack_nonce_free_replays(&self, transactions: &[Arc<ValidPoolTransaction<T>>]) {
-        let mut index = self.nonce_free_replays.write();
+    fn untrack_eip8130_replays(&self, transactions: &[Arc<ValidPoolTransaction<T>>]) {
+        let mut index = self.eip8130_replays.write();
         for transaction in transactions {
-            if let Some(replay_id) = transaction.transaction.eip8130_nonce_free_replay_id() {
-                index.remove(&replay_id);
+            if let Some(replay_id) = transaction.transaction.eip8130_replay_id() {
+                index.remove(&(transaction.transaction.sender(), replay_id));
             }
         }
     }
 
-    fn untrack_nonce_free_hashes(&self, hashes: &[TxHash]) {
+    fn untrack_eip8130_hashes(&self, hashes: &[TxHash]) {
         let hashes = hashes.iter().collect::<HashSet<_>>();
-        let mut index = self.nonce_free_replays.write();
+        let mut index = self.eip8130_replays.write();
         index.retain(|_, indexed_hash| !hashes.contains(indexed_hash));
     }
 
@@ -378,28 +402,36 @@ where
         origin: TransactionOrigin,
         transaction: Self::Transaction,
     ) -> PoolResult<TransactionEvents> {
-        if self.nonce_free_replay_already_seen(&transaction).is_some() {
+        if self.eip8130_replay_already_seen(&transaction).is_some() {
+            // TODO: Replace the indexed transaction when the new priority fee
+            // satisfies the pool's configured price bump.
             return Err(reth_transaction_pool::error::PoolError::new(
                 *transaction.hash(),
                 reth_transaction_pool::error::PoolErrorKind::AlreadyImported,
             ));
         }
         if !self.is_sidecar_transaction(&transaction) {
-            let replay_id = transaction.eip8130_nonce_free_replay_id();
+            let replay_id = transaction.eip8130_replay_id();
+            let sender = transaction.sender();
             let hash = *transaction.hash();
             let events =
                 self.protocol_pool.add_transaction_and_subscribe(origin, transaction).await?;
             if let Some(replay_id) = replay_id {
-                self.track_nonce_free_replay_id(replay_id, hash);
+                self.track_eip8130_replay_id(sender, replay_id, hash);
             }
             return Ok(events);
         }
 
+        let replay_id = transaction.eip8130_replay_id();
+        let sender = transaction.sender();
         let hash = *transaction.hash();
         let (events, listener) = self.listeners.write().subscribe_hash(hash);
         if let Err(error) = self.add_sidecar_transaction(origin, transaction).await {
             self.listeners.write().unsubscribe_hash_listener(&hash, &listener);
             return Err(error);
+        }
+        if let Some(replay_id) = replay_id {
+            self.track_eip8130_replay_id(sender, replay_id, hash);
         }
         Ok(events)
     }
@@ -409,20 +441,27 @@ where
         origin: TransactionOrigin,
         transaction: Self::Transaction,
     ) -> PoolResult<AddedTransactionOutcome> {
-        if self.nonce_free_replay_already_seen(&transaction).is_some() {
+        if self.eip8130_replay_already_seen(&transaction).is_some() {
+            // TODO: Replace the indexed transaction when the new priority fee
+            // satisfies the pool's configured price bump.
             return Err(reth_transaction_pool::error::PoolError::new(
                 *transaction.hash(),
                 reth_transaction_pool::error::PoolErrorKind::AlreadyImported,
             ));
         }
+        let replay_id = transaction.eip8130_replay_id();
+        let sender = transaction.sender();
+        let hash = *transaction.hash();
         if self.is_sidecar_transaction(&transaction) {
-            self.add_sidecar_transaction(origin, transaction).await
+            let outcome = self.add_sidecar_transaction(origin, transaction).await?;
+            if let Some(replay_id) = replay_id {
+                self.track_eip8130_replay_id(sender, replay_id, hash);
+            }
+            Ok(outcome)
         } else {
-            let replay_id = transaction.eip8130_nonce_free_replay_id();
-            let hash = *transaction.hash();
             let outcome = self.protocol_pool.add_transaction(origin, transaction).await?;
             if let Some(replay_id) = replay_id {
-                self.track_nonce_free_replay_id(replay_id, hash);
+                self.track_eip8130_replay_id(sender, replay_id, hash);
             }
             Ok(outcome)
         }
@@ -696,9 +735,10 @@ where
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         let (protocol_hashes, sidecar_hashes) = self.partition_hashes_by_pool(hashes);
         let mut removed = self.protocol_pool.remove_transactions(protocol_hashes);
-        self.untrack_nonce_free_replays(&removed);
+        self.untrack_eip8130_replays(&removed);
         let sidecar_removed = self.nonce_pool.write().remove_transactions(&sidecar_hashes);
         if !sidecar_removed.is_empty() {
+            self.untrack_eip8130_replays(&sidecar_removed);
             self.listeners.write().on_discarded(&sidecar_removed);
         }
         removed.extend(sidecar_removed);
@@ -711,10 +751,11 @@ where
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         let (protocol_hashes, sidecar_hashes) = self.partition_hashes_by_pool(hashes);
         let mut removed = self.protocol_pool.remove_transactions_and_descendants(protocol_hashes);
-        self.untrack_nonce_free_replays(&removed);
+        self.untrack_eip8130_replays(&removed);
         let sidecar_removed =
             self.nonce_pool.write().remove_transactions_and_descendants(&sidecar_hashes);
         if !sidecar_removed.is_empty() {
+            self.untrack_eip8130_replays(&sidecar_removed);
             self.listeners.write().on_discarded(&sidecar_removed);
         }
         removed.extend(sidecar_removed);
@@ -726,9 +767,10 @@ where
         sender: Address,
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         let mut removed = self.protocol_pool.remove_transactions_by_sender(sender);
-        self.untrack_nonce_free_replays(&removed);
+        self.untrack_eip8130_replays(&removed);
         let sidecar_removed = self.nonce_pool.write().remove_transactions_by_sender(sender);
         if !sidecar_removed.is_empty() {
+            self.untrack_eip8130_replays(&sidecar_removed);
             self.listeners.write().on_discarded(&sidecar_removed);
         }
         removed.extend(sidecar_removed);
@@ -741,8 +783,9 @@ where
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         let (protocol_hashes, sidecar_hashes) = self.partition_hashes_by_pool(hashes);
         let mut removed = self.protocol_pool.prune_transactions(protocol_hashes);
-        self.untrack_nonce_free_replays(&removed);
+        self.untrack_eip8130_replays(&removed);
         let pruned = self.nonce_pool.write().prune_mined(&sidecar_hashes);
+        self.untrack_eip8130_replays(&pruned.removed);
         removed.extend(pruned.removed);
         removed
     }
@@ -970,7 +1013,7 @@ where
     ) {
         let block_hash = update.hash();
         let mined_transactions = update.mined_transactions.clone();
-        self.untrack_nonce_free_hashes(&mined_transactions);
+        self.untrack_eip8130_hashes(&mined_transactions);
         self.protocol_pool.on_canonical_state_change(update);
         let mut nonce_pool = self.nonce_pool.write();
         let pruned = nonce_pool.prune_mined(&mined_transactions);
@@ -983,6 +1026,7 @@ where
     fn update_accounts(&self, accounts: Vec<ChangedAccount>) {
         let removed = self.nonce_pool.write().remove_unaffordable(&accounts);
         if !removed.is_empty() {
+            self.untrack_eip8130_replays(&removed);
             self.listeners.write().on_discarded(&removed);
         }
         self.protocol_pool.update_accounts(accounts)

--- a/crates/execution/txpool/src/pool.rs
+++ b/crates/execution/txpool/src/pool.rs
@@ -52,7 +52,7 @@ pub struct BaseTransactionPool<
         Pool<TransactionValidationTaskExecutor<BaseTransactionValidator<Client, T, Evm>>, O, S>,
     ordering: O,
     nonce_pool: Arc<RwLock<TwoDNoncePool<T>>>,
-    eip8130_replays: Arc<RwLock<HashMap<(Address, B256), TxHash>>>,
+    eip8130_replays: Arc<RwLock<HashMap<B256, TxHash>>>,
     listeners: Arc<RwLock<SidecarListeners<T>>>,
 }
 
@@ -153,7 +153,7 @@ where
     /// This check and the subsequent [`Self::track_eip8130_replay_id`] insert are
     /// deliberately **not** atomic: the index lock is released between them (and
     /// between this check and the actual pool insert). Two concurrent admissions
-    /// of the same `(sender, replay_id)` can therefore both pass and enter the
+    /// of the same `replay_id` can therefore both pass and enter the
     /// pool. That is acceptable because the index is only a mempool optimization,
     /// not a consensus control: identical transactions collapse by tx-hash in the
     /// underlying pool, and any surviving nonce-free duplicate is rejected at
@@ -162,8 +162,10 @@ where
     /// nesting, so the looser guarantee is intentional. A stale entry whose target
     /// is no longer pooled is opportunistically evicted here.
     fn eip8130_replay_already_seen(&self, transaction: &T) -> Option<TxHash> {
-        let key = (transaction.sender(), transaction.eip8130_replay_id()?);
-        let hash = self.eip8130_replays.read().get(&key).copied()?;
+        // `replay_id` already commits to the resolved sender, so it alone keys the
+        // index (matching the enshrined replay buffer, which keys by `replay_id`).
+        let replay_id = transaction.eip8130_replay_id()?;
+        let hash = self.eip8130_replays.read().get(&replay_id).copied()?;
         // Only nonce-free transactions have replay IDs, and those are only ever
         // admitted to the protocol pool; channelized transactions live in
         // `nonce_pool` and never carry a replay ID. Guard that routing invariant
@@ -176,14 +178,14 @@ where
         if self.protocol_pool.get(&hash).is_some() {
             return Some(hash);
         }
-        self.eip8130_replays.write().remove(&key);
+        self.eip8130_replays.write().remove(&replay_id);
         None
     }
 
-    fn track_eip8130_replay_id(&self, sender: Address, replay_id: B256, hash: TxHash) {
+    fn track_eip8130_replay_id(&self, replay_id: B256, hash: TxHash) {
         {
             let mut index = self.eip8130_replays.write();
-            index.insert((sender, replay_id), hash);
+            index.insert(replay_id, hash);
         }
         self.reconcile_eip8130_replays_if_needed();
     }
@@ -205,7 +207,7 @@ where
         let mut rebuilt = HashMap::new();
         for transaction in self.pooled_transactions() {
             if let Some(replay_id) = transaction.transaction.eip8130_replay_id() {
-                rebuilt.insert((transaction.transaction.sender(), replay_id), *transaction.hash());
+                rebuilt.insert(replay_id, *transaction.hash());
             }
         }
         let mut index = self.eip8130_replays.write();
@@ -219,7 +221,7 @@ where
         let mut index = self.eip8130_replays.write();
         for transaction in transactions {
             if let Some(replay_id) = transaction.transaction.eip8130_replay_id() {
-                index.remove(&(transaction.transaction.sender(), replay_id));
+                index.remove(&replay_id);
             }
         }
     }
@@ -421,12 +423,11 @@ where
         }
         if !self.is_sidecar_transaction(&transaction) {
             let replay_id = transaction.eip8130_replay_id();
-            let sender = transaction.sender();
             let hash = *transaction.hash();
             let events =
                 self.protocol_pool.add_transaction_and_subscribe(origin, transaction).await?;
             if let Some(replay_id) = replay_id {
-                self.track_eip8130_replay_id(sender, replay_id, hash);
+                self.track_eip8130_replay_id(replay_id, hash);
             }
             return Ok(events);
         }
@@ -457,11 +458,10 @@ where
             self.add_sidecar_transaction(origin, transaction).await
         } else {
             let replay_id = transaction.eip8130_replay_id();
-            let sender = transaction.sender();
             let hash = *transaction.hash();
             let outcome = self.protocol_pool.add_transaction(origin, transaction).await?;
             if let Some(replay_id) = replay_id {
-                self.track_eip8130_replay_id(sender, replay_id, hash);
+                self.track_eip8130_replay_id(replay_id, hash);
             }
             Ok(outcome)
         }

--- a/crates/execution/txpool/src/pool.rs
+++ b/crates/execution/txpool/src/pool.rs
@@ -164,8 +164,15 @@ where
     fn eip8130_replay_already_seen(&self, transaction: &T) -> Option<TxHash> {
         let key = (transaction.sender(), transaction.eip8130_replay_id()?);
         let hash = self.eip8130_replays.read().get(&key).copied()?;
-        // Only nonce-free transactions have replay IDs, and those live in the
-        // protocol pool; channelized transactions live in `nonce_pool`.
+        // Only nonce-free transactions have replay IDs, and those are only ever
+        // admitted to the protocol pool; channelized transactions live in
+        // `nonce_pool` and never carry a replay ID. Guard that routing invariant
+        // so the protocol-pool-only liveness check below stays sound if routing
+        // or replay-id derivation ever evolve independently.
+        debug_assert!(
+            !self.nonce_pool.read().contains(&hash),
+            "eip8130 replay index points at a sidecar-pool transaction",
+        );
         if self.protocol_pool.get(&hash).is_some() {
             return Some(hash);
         }

--- a/crates/execution/txpool/src/transaction.rs
+++ b/crates/execution/txpool/src/transaction.rs
@@ -11,7 +11,7 @@ use alloy_eips::{
     eip7594::BlobTransactionSidecarVariant,
     eip7702::SignedAuthorization,
 };
-use alloy_primitives::{Address, B256, Bytes, TxHash, TxKind, U256, keccak256};
+use alloy_primitives::{Address, B256, Bytes, TxHash, TxKind, U256};
 use base_common_consensus::{BaseTransactionSigned, Eip8130Constants, Eip8130Signed};
 use c_kzg::KzgSettings;
 use reth_primitives_traits::{InMemorySize, SignedTransaction};
@@ -348,8 +348,8 @@ pub trait BasePooledTx: PoolTransaction + DataAvailabilitySized {
         None
     }
 
-    /// Returns the EIP-8130 nonce-free replay identifier, if applicable.
-    fn eip8130_nonce_free_replay_id(&self) -> Option<B256> {
+    /// Returns the EIP-8130 replay identifier, if applicable.
+    fn eip8130_replay_id(&self) -> Option<B256> {
         None
     }
 }
@@ -374,14 +374,18 @@ where
         (!nonce_key.is_zero() && nonce_key != Eip8130Constants::NONCE_KEY_MAX).then_some(nonce_key)
     }
 
-    fn eip8130_nonce_free_replay_id(&self) -> Option<B256> {
+    fn eip8130_replay_id(&self) -> Option<B256> {
         let signed = self.as_eip8130()?;
-        (signed.tx().nonce_key == Eip8130Constants::NONCE_KEY_MAX).then(|| {
-            let mut buf = Vec::with_capacity(52);
-            buf.extend_from_slice(self.sender().as_slice());
-            buf.extend_from_slice(signed.tx().sender_signature_hash().as_slice());
-            keccak256(buf)
-        })
+        // `replay_id` keys mempool dedup/replacement only for nonce-free
+        // (`nonce_key == NONCE_KEY_MAX`) transactions, which have no nonce slot.
+        // Standard and 2D transactions dedupe/replace on
+        // `(sender, nonce_key, nonce_sequence)` under the standard nonce rules,
+        // so they must not be tracked by `replay_id` (which excludes fees and
+        // would otherwise block legitimate replace-by-fee at the same sequence).
+        if signed.tx().nonce_key != Eip8130Constants::NONCE_KEY_MAX {
+            return None;
+        }
+        Some(signed.tx().replay_id(self.sender()))
     }
 }
 

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -715,7 +715,6 @@ where
             NonceValidator::validate(
                 signed.tx(),
                 sender,
-                signed.tx().sender_signature_hash(),
                 protocol_nonce,
                 &nonce_storage,
                 NonceMode::Pool,


### PR DESCRIPTION
## Summary
- derive nonce-free replay IDs from the canonical fee-, nonce-, and signature-invariant preimage
- apply replay-ID deduplication only to nonce-free transactions
- align replay-buffer chain parameter names and harden txpool reconciliation against lock inversion

## Stack
- PR 2 of 3; #3957 is merged
- Extracted from #3921
- Next: #3959 — nonce-free gas schedule

## Review follow-up
- Updated the nonce-manager documentation to describe the canonical `TxEip8130::replay_id` preimage.
- Removed unreachable replay-index tracking from channelized sidecar admission paths.
- Removed the unnecessary `nonce_pool` lookup from replay deduplication; nonce-free replay-ID transactions live only in the protocol pool.
- Rebasing onto current `main` leaves this PR with two replay-specific commits.

## Test plan
- [x] `cargo check -p base-common-consensus -p base-common-precompiles -p base-execution-eip8130 -p base-common-evm -p base-execution-txpool`
- [x] `cargo test -p base-common-consensus --lib eip8130`
- [x] `cargo test -p base-common-precompiles --lib nonce`
- [x] `cargo test -p base-execution-eip8130 --lib validate`
- [x] `cargo test -p base-common-evm --lib eip8130`
- [x] `cargo test -p base-execution-txpool --lib eip8130`
- [x] `cargo +nightly fmt --all -- --check`