### PR TITLE
fix(eip8130): align nonce-free gas schedule

### DIFF
--- a/crates/common/consensus/src/transaction/eip8130/addresses.rs
+++ b/crates/common/consensus/src/transaction/eip8130/addresses.rs
@@ -50,32 +50,32 @@ impl Eip8130Contracts {
 
     /// Account Configuration system contract (`ACCOUNT_CONFIG_ADDRESS`). The
     /// protocol reads actor/account state directly from this contract's storage.
-    pub const ACCOUNT_CONFIG: Address = address!("0x2403408177dB7F8512a9593343a7C80371D8f2dF");
+    pub const ACCOUNT_CONFIG: Address = address!("0xe7Bb8eF3728ea9f0A8be6D7e9585FeAb12dE086A");
 
     /// keccak256 of the `ACCOUNT_CONFIG` deployment init code (for CREATE2
     /// derivation and bytecode-drift detection).
     pub const ACCOUNT_CONFIG_INIT_CODE_HASH: B256 =
-        b256!("0x742384b2e8ee556f4575e73524f6c3d84780c73b73140ea8770cb65abc143714");
+        b256!("0x7c04a9931efd384c64c7895cf0a254dfdaf3c1d650e23cab1480dac7840633bd");
 
     // ─────────────────────────────────────────────────────────────────────────
     // Account implementations (init code embeds `ACCOUNT_CONFIG`)
     // ─────────────────────────────────────────────────────────────────────────
 
     /// Default wallet implementation, used as the target of default EOA delegation.
-    pub const DEFAULT_ACCOUNT: Address = address!("0xaF0973bbebe12BDaE6B61c96019dc0DcA554b67c");
+    pub const DEFAULT_ACCOUNT: Address = address!("0xDd802113C9FF6964cD2A61A16e075D5271cC82c9");
 
     /// keccak256 of the `DEFAULT_ACCOUNT` deployment init code.
     pub const DEFAULT_ACCOUNT_INIT_CODE_HASH: B256 =
-        b256!("0xf447cb971ef3087ff92c3238b4f90721d73c681661be5525d8937c476c7ac707");
+        b256!("0xa1b68747f3b48894ee02612a0f217b97ed76b1643ea791cb46637c10b4a21595");
 
     /// Wallet variant that blocks ETH transfers when locked, granting higher
     /// EIP-8130 mempool access (rate limits).
     pub const DEFAULT_HIGH_RATE_ACCOUNT: Address =
-        address!("0x6c4230a4101849a3CB6438C40D3d47EdE9aca096");
+        address!("0xe5edfB7E7365893d685c2FbFBAC3e022f51d942F");
 
     /// keccak256 of the `DEFAULT_HIGH_RATE_ACCOUNT` deployment init code.
     pub const DEFAULT_HIGH_RATE_ACCOUNT_INIT_CODE_HASH: B256 =
-        b256!("0x2aa0cfe89cf370c6ece7cc751c00c3fa3c2044a750755ed6f4125119275bc251");
+        b256!("0xe77be0ab8bf7c2cb2743825182e7aa7f11f351c62cbf1b9fe74c9d43075c6ac6");
 
     // ─────────────────────────────────────────────────────────────────────────
     // Canonical authenticators (accepted on the EIP-8130 block-validation path)
@@ -87,28 +87,28 @@ impl Eip8130Contracts {
     // (`address(1)`), handled directly by the protocol, not a deployed contract.
 
     /// secp256r1 / P-256 (raw) authenticator contract.
-    pub const P256_AUTHENTICATOR: Address = address!("0x28096E6f98996799A08fBbCFF0B7c0D512D1f503");
+    pub const P256_AUTHENTICATOR: Address = address!("0xf8847a74F8067CabaE5fe56B70b372A7D670f0f8");
 
     /// keccak256 of the `P256_AUTHENTICATOR` deployment init code.
     pub const P256_AUTHENTICATOR_INIT_CODE_HASH: B256 =
-        b256!("0xf2e69d7271b922c65cb55cc325efca4c7bd22e0c154fd6ff75575cd9f1a4db78");
+        b256!("0x64a6e7ca64d1043c5a9f6c4072ae3e06989b88f7a63df3cbbe4d717763c8b65a");
 
     /// secp256r1 / P-256 (`WebAuthn`) authenticator contract.
     pub const WEBAUTHN_AUTHENTICATOR: Address =
-        address!("0xD9B8d163a34FBaD781057F7B68889F0bbd70D7ed");
+        address!("0x871c72d3950308A028E9c4917591bcfd3D6a1EF7");
 
     /// keccak256 of the `WEBAUTHN_AUTHENTICATOR` deployment init code.
     pub const WEBAUTHN_AUTHENTICATOR_INIT_CODE_HASH: B256 =
-        b256!("0x35cc9b095487cc4debe2956dcda11be5ae0586bb3c985d1b4d90d8e2a1f09460");
+        b256!("0x92bc05424ceb5ef1f1ad17e1d462d45fff83f76daebeef2d5ff1cf0b80733a26");
 
     /// Delegated-validation (1-hop) authenticator contract (init code embeds
     /// `ACCOUNT_CONFIG`).
     pub const DELEGATE_AUTHENTICATOR: Address =
-        address!("0xb1f064A99919E4199b45F1b553b6ecb8d5d62a11");
+        address!("0x1B0195ba5E3FCdB387DD619816eeF8b510Ed0855");
 
     /// keccak256 of the `DELEGATE_AUTHENTICATOR` deployment init code.
     pub const DELEGATE_AUTHENTICATOR_INIT_CODE_HASH: B256 =
-        b256!("0xb4c6b1f40cd6a3a256f20cc7aad6599390ba3540044e08134349b54f7b1439a8");
+        b256!("0x483e360a8f1d8e2d891c1c260d164e433e2080080e111fa8bb78e0f4e8e3f876");
 
     /// The canonical authenticator allowlist: the deployed `IAuthenticator`
     /// contracts a compliant node accepts on the EIP-8130 block-validation path.

--- a/crates/common/evm/src/eip8130.rs
+++ b/crates/common/evm/src/eip8130.rs
@@ -810,11 +810,11 @@ impl Eip8130Executor {
             let sender = applied_tx.actors.sender.account;
             let payer = applied_tx.actors.payer.as_ref().map_or(sender, |p| p.account);
             // Defense-in-depth: `authorize_and_apply` -> `verify_sender` already
-            // gates `allows_sequenced_nonce(nonce_key)` on both the configured and
+            // gates `can_use_nonce_key(nonce_key)` on both the configured and
             // EOA sender paths, so this is redundant on the current call graph. It
             // is kept as a local guard so this execution entry point stays sound if
             // the sender-resolution path is ever refactored to skip that check.
-            if !sender_actor.allows_sequenced_nonce(nonce_key) {
+            if !sender_actor.can_use_nonce_key(nonce_key) {
                 return Err(BaseTransactionError::eip8130(
                     "sender actor scope does not authorize sequenced nonces",
                 ));

--- a/crates/execution/eip8130/README.md
+++ b/crates/execution/eip8130/README.md
@@ -72,7 +72,7 @@ intrinsic_gas = AA_BASE_COST + tx_payload_cost + nonce_key_cost + bytecode_cost
 |---|---|
 | `base` | `AA_BASE_COST` (15,000) |
 | `payload` | EIP-2028 data-availability cost (16/non-zero, 4/zero byte) over the caller-supplied EIP-2718 serialization of the signed transaction |
-| `nonce_key` | nonce-free `14,000`; otherwise first-use `22,100` / existing `5,000` (a cold SLOAD plus an SSTORE set or reset) |
+| `nonce_key` | nonce-free `13,000`; otherwise first-use `22,100` / existing `5,000` (a cold SLOAD plus an SSTORE set or reset) |
 | `bytecode` | per create entry: `32,000 + 200 · code_len` |
 | `account_changes` | per create entry: one fresh `actor_config` slot write per initial actor (unrestricted owner, no policy slots); per config-change entry: its `auth` cost plus each mutated actor slot (`actor_config`, plus `policy_commitment`/`policy_manager` when the authorize carries a policy), plus a worst-case dual-home bump (`22,100`) for a change targeting the account's own self-actor (whose config is inline in the account-state slot and is mutually exclusive with `actor_config(self)`); per delegation entry: the `4,600` indicator deposit |
 | `auto_delegation` | `4,600` when a code-less `sender` EOA is auto-delegated to `DEFAULT_ACCOUNT` |

--- a/crates/execution/eip8130/src/resolved.rs
+++ b/crates/execution/eip8130/src/resolved.rs
@@ -52,7 +52,7 @@ impl ResolvedActor {
     /// Unrestricted actors and nonce-free transactions are always allowed;
     /// scoped actors need `SCOPE_NONCE` for sequenced nonce channels.
     #[must_use]
-    pub fn allows_sequenced_nonce(&self, nonce_key: U256) -> bool {
+    pub fn can_use_nonce_key(&self, nonce_key: U256) -> bool {
         self.scope == Eip8130Constants::SCOPE_UNRESTRICTED
             || nonce_key == Eip8130Constants::NONCE_KEY_MAX
             || self.scope & Eip8130Constants::SCOPE_NONCE != 0
@@ -69,12 +69,12 @@ mod tests {
 
     #[test]
     fn nonce_scope_allows_expected_keys() {
-        assert!(actor(0).allows_sequenced_nonce(U256::ZERO));
+        assert!(actor(0).can_use_nonce_key(U256::ZERO));
         assert!(
             actor(Eip8130Constants::SCOPE_SENDER)
-                .allows_sequenced_nonce(Eip8130Constants::NONCE_KEY_MAX)
+                .can_use_nonce_key(Eip8130Constants::NONCE_KEY_MAX)
         );
-        assert!(actor(Eip8130Constants::SCOPE_NONCE).allows_sequenced_nonce(U256::from(1)));
-        assert!(!actor(Eip8130Constants::SCOPE_SENDER).allows_sequenced_nonce(U256::ZERO));
+        assert!(actor(Eip8130Constants::SCOPE_NONCE).can_use_nonce_key(U256::from(1)));
+        assert!(!actor(Eip8130Constants::SCOPE_SENDER).can_use_nonce_key(U256::ZERO));
     }
 }

--- a/crates/execution/eip8130/src/schedule.rs
+++ b/crates/execution/eip8130/src/schedule.rs
@@ -27,6 +27,8 @@ impl Eip8130GasSchedule {
     // ── EIP-2929 storage access ──────────────────────────────────────────────
     /// Cold `SLOAD` (first access to a slot in the transaction).
     pub const COLD_SLOAD: u64 = 2_100;
+    /// Warm `SLOAD` (repeat access to an already-touched slot).
+    pub const WARM_SLOAD: u64 = 100;
     /// `SSTORE` of a zero slot to a non-zero value.
     pub const SSTORE_SET: u64 = 20_000;
     /// `SSTORE` of an already non-zero slot to another non-zero value.
@@ -41,14 +43,15 @@ impl Eip8130GasSchedule {
     // ── EIP-8130 table values ────────────────────────────────────────────────
     /// Base intrinsic cost for any AA transaction (`AA_BASE_COST`).
     pub const AA_BASE_COST: u64 = Eip8130Constants::EIP8130_BASE_COST;
-    /// `nonce_key_cost` for nonce-free (`NONCE_KEY_MAX`) transactions. A flat,
-    /// amortized charge for the enshrined expiring-nonce circular-buffer replay
-    /// set: a replay-check SLOAD, the ring pointer + ring-slot reads, reclaiming
-    /// one expired entry, recording the new entry, and advancing the pointer. The
-    /// raw per-op SSTORE cost is far higher (an `SSTORE_SET` per insert) but is
-    /// amortized by the ring reclaiming a slot on each write, so EIP-8130 prices
-    /// it as a fixed value rather than metering the individual accesses.
-    pub const NONCE_FREE_COST: u64 = 14_000;
+    /// `nonce_key_cost` for nonce-free (`NONCE_KEY_MAX`) transactions: 13,000 gas
+    /// for the enshrined ring-buffer replay state, composed of 2 cold SLOADs, 1
+    /// warm SLOAD, and 3 warm SSTORE resets. The ring pointer's SLOAD/SSTORE are
+    /// amortized across the block, so EIP-8130 prices this as a fixed composite
+    /// rather than metering the individual accesses (the raw per-op cost, e.g. an
+    /// `SSTORE_SET` per insert, is far higher but amortized by the ring reclaiming
+    /// a slot on each write).
+    pub const NONCE_FREE_COST: u64 =
+        2 * Self::COLD_SLOAD + Self::WARM_SLOAD + 3 * Self::SSTORE_RESET;
     /// `nonce_key_cost` for the first use of a sequence nonce key (cold SLOAD +
     /// SSTORE set).
     pub const NONCE_KEY_FIRST_USE_COST: u64 = Self::COLD_SLOAD + Self::SSTORE_SET;
@@ -133,6 +136,7 @@ mod tests {
     #[test]
     fn gas_primitives_match_evm_reference() {
         assert_eq!(Eip8130GasSchedule::COLD_SLOAD, gas::COLD_SLOAD_COST);
+        assert_eq!(Eip8130GasSchedule::WARM_SLOAD, gas::WARM_STORAGE_READ_COST);
         assert_eq!(Eip8130GasSchedule::SSTORE_SET, gas::SSTORE_SET);
         // revm's `SSTORE_RESET` (5,000) bundles the cold SLOAD; the warm-only
         // reset component is `WARM_SSTORE_RESET` (2,900), which the schedule's
@@ -154,5 +158,12 @@ mod tests {
             Eip8130GasSchedule::NONCE_KEY_EXISTING_COST,
             gas::COLD_SLOAD_COST + gas::WARM_SSTORE_RESET
         );
+        // Nonce-free ring-buffer cost: 2 cold SLOADs + 1 warm SLOAD + 3 warm
+        // SSTORE resets = 13,000 gas.
+        assert_eq!(
+            Eip8130GasSchedule::NONCE_FREE_COST,
+            2 * gas::COLD_SLOAD_COST + gas::WARM_STORAGE_READ_COST + 3 * gas::WARM_SSTORE_RESET
+        );
+        assert_eq!(Eip8130GasSchedule::NONCE_FREE_COST, 13_000);
     }
 }

--- a/crates/execution/eip8130/src/verify.rs
+++ b/crates/execution/eip8130/src/verify.rs
@@ -123,7 +123,7 @@ impl ActorTxVerifier {
                 Operation::Sender,
                 now,
             )?;
-            if !resolved.allows_sequenced_nonce(signed.tx().nonce_key) {
+            if !resolved.can_use_nonce_key(signed.tx().nonce_key) {
                 return Err(TxAuthError::Scope {
                     operation: Operation::Sender,
                     scope: resolved.scope,
@@ -153,7 +153,7 @@ impl ActorTxVerifier {
         if !Operation::Sender.is_granted(&resolved) {
             return Err(TxAuthError::Scope { operation: Operation::Sender, scope: resolved.scope });
         }
-        if !resolved.allows_sequenced_nonce(signed.tx().nonce_key) {
+        if !resolved.can_use_nonce_key(signed.tx().nonce_key) {
             return Err(TxAuthError::Scope { operation: Operation::Sender, scope: resolved.scope });
         }
         Ok(AuthorizedActor { account, resolved })


### PR DESCRIPTION
## Summary
- compose the finalized 13,000 gas nonce-free replay charge from EVM storage primitives
- add drift tripwires for the primitive storage costs
- repin the enshrined EIP-8130 system-contract addresses (AccountConfiguration, DefaultAccount, DefaultHighRateAccount, P256/WebAuthn/Delegate authenticators) with matching init-code hashes to the latest cleaned-up `base/eip-8130` Base Sepolia deployment
- correct the README intrinsic-gas table to 13,000

## Base
- Rebased directly onto `main`: this PR only touches `schedule.rs`, `addresses.rs`, and the README, none of which overlap with #3958, so it no longer needs to stack on the replay-ID work.
- #3957 is merged; #3958 (replay ID) is independent and can land in either order.

## Test plan
- [x] `cargo test -p base-execution-eip8130 --lib schedule`
- [x] `cargo test -p base-common-consensus --lib addresses` (CREATE2 drift test passes for all repinned addresses)
- [x] `cargo +nightly fmt --all -- --check`