### PR TITLE
chore(upgrade-signal): read new ProtocolVersions schedule contract

### DIFF
--- a/crates/utilities/upgrade-signal/README.md
+++ b/crates/utilities/upgrade-signal/README.md
@@ -20,8 +20,9 @@ The contract exposes one global `minimumProtocolVersion()` as a packed-semver `u
 every signal in a schedule.
 
 The node advertises its supported level with
-[`UpgradeSignalDefaults::NODE_PROTOCOL_VERSION`](src/config/mod.rs) (packed semver `1.1.0`). A
-signal is supported when:
+[`UpgradeSignalDefaults::node_protocol_version()`](src/config/mod.rs), which packs the Cargo
+package semver synced from the `GitHub` release tag on release branches. Mainline `0.0.0` builds use
+the latest protocol version implemented on main. A signal is supported when:
 
 - the activation timestamp is positive
 - the contract provides a non-zero minimum protocol version

--- a/crates/utilities/upgrade-signal/README.md
+++ b/crates/utilities/upgrade-signal/README.md
@@ -33,10 +33,11 @@ the latest protocol version implemented on main. A signal is supported when:
 
 The contract's `getSchedule()` returns one `uint64` activation timestamp per registered upgrade,
 ordered by ascending numeric upgrade id. Upgrade names are kept offchain: the node maps schedule
-entries onto its known hardfork ladder in activation (timestamp) order, aligning id `0` (the
-lowest timestamp) with the oldest contract-backed hardfork. Contract entries beyond the ladder
-belong to upgrades newer than this binary knows and are logged and ignored, and hardforks without
-a contract entry produce no signal.
+entries onto its known hardfork ladder by registration id, aligning id `0` with the oldest
+contract-backed hardfork. This is a positional mapping by id, not a sort by timestamp, so the
+timestamps need not be monotonic. Contract entries beyond the ladder belong to upgrades newer than
+this binary knows and are logged and ignored, and hardforks without a contract entry produce no
+signal.
 
 The timestamp semantics are:
 

--- a/crates/utilities/upgrade-signal/README.md
+++ b/crates/utilities/upgrade-signal/README.md
@@ -2,9 +2,9 @@
 
 Shared utilities for reading network upgrade activation signals from L1.
 
-The crate reads an L1 contract interface and decodes the announced activation timestamp and minimum
-node protocol version for each configured upgrade ID. Metrics are recorded for both startup reads
-and live signal changes.
+The crate reads the L1 `ProtocolVersions` contract and decodes the announced activation timestamps
+and the global minimum node protocol version. Metrics are recorded for both startup reads and live
+signal changes.
 
 Three graduated rollout modes are supported:
 
@@ -15,27 +15,32 @@ Three graduated rollout modes are supported:
 
 ## Protocol Versions
 
-The contract exposes protocol versions as `uint256`, so this crate reads them as `U256`. The value
-is not semver onchain.
+The contract exposes one global `minimumProtocolVersion()` as a packed-semver `uint256`
+(`major << 96 | minor << 64 | patch << 32`), so this crate reads it as `U256` and attaches it to
+every signal in a schedule.
 
 The node advertises its supported level with
-[`UpgradeSignalDefaults::NODE_PROTOCOL_VERSION`](src/config/mod.rs). A signal is supported when:
+[`UpgradeSignalDefaults::NODE_PROTOCOL_VERSION`](src/config/mod.rs) (packed semver `1.1.0`). A
+signal is supported when:
 
 - the activation timestamp is positive
-- the signal also provides a non-zero protocol version
+- the contract provides a non-zero minimum protocol version
 - the signaled minimum protocol version is less than or equal to the node's supported protocol
   version
 
 ## Upgrade Timestamps
 
-Each upgrade ID also has an activation timestamp in the contract, exposed as `uint256` and reduced
-to `u64` in the node after decode.
+The contract's `getSchedule()` returns one `uint64` activation timestamp per registered upgrade,
+ordered by ascending numeric upgrade id. Upgrade names are kept offchain: the node maps schedule
+entries onto its known hardfork ladder in activation (timestamp) order, aligning id `0` (the
+lowest timestamp) with the oldest contract-backed hardfork. Contract entries beyond the ladder
+belong to upgrades newer than this binary knows and are logged and ignored, and hardforks without
+a contract entry produce no signal.
 
 The timestamp semantics are:
 
 - `0` means "no activation is currently scheduled"
 - any positive value is an L2 activation timestamp for that upgrade
-- values larger than `u64::MAX` are rejected as malformed contract data
 
 The crate validates timestamps and protocol versions together. A positive timestamp without a
 minimum protocol version is rejected.

--- a/crates/utilities/upgrade-signal/src/config/args.rs
+++ b/crates/utilities/upgrade-signal/src/config/args.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Address, U256};
+use alloy_primitives::Address;
 use base_common_genesis::{BaseUpgrade, UpgradeActivationSink};
 use url::Url;
 
@@ -62,7 +62,7 @@ impl UpgradeSignalArgs {
             upgrade_ids,
             mode: self.mode,
             l1_block_tag: self.l1_block_tag.block_number_or_tag(),
-            node_protocol_version: U256::from(UpgradeSignalDefaults::NODE_PROTOCOL_VERSION),
+            node_protocol_version: UpgradeSignalDefaults::NODE_PROTOCOL_VERSION,
         }))
     }
 
@@ -267,10 +267,7 @@ mod tests {
         assert_eq!(config.contract_address, contract);
         assert_eq!(config.upgrade_ids, [BaseUpgrade::Azul]);
         assert_eq!(config.mode, UpgradeSignalMode::StartupApply);
-        assert_eq!(
-            config.node_protocol_version,
-            U256::from(UpgradeSignalDefaults::NODE_PROTOCOL_VERSION)
-        );
+        assert_eq!(config.node_protocol_version, UpgradeSignalDefaults::NODE_PROTOCOL_VERSION);
     }
 
     #[test]

--- a/crates/utilities/upgrade-signal/src/config/args.rs
+++ b/crates/utilities/upgrade-signal/src/config/args.rs
@@ -62,7 +62,7 @@ impl UpgradeSignalArgs {
             upgrade_ids,
             mode: self.mode,
             l1_block_tag: self.l1_block_tag.block_number_or_tag(),
-            node_protocol_version: UpgradeSignalDefaults::NODE_PROTOCOL_VERSION,
+            node_protocol_version: UpgradeSignalDefaults::node_protocol_version(),
         }))
     }
 
@@ -267,7 +267,7 @@ mod tests {
         assert_eq!(config.contract_address, contract);
         assert_eq!(config.upgrade_ids, [BaseUpgrade::Azul]);
         assert_eq!(config.mode, UpgradeSignalMode::StartupApply);
-        assert_eq!(config.node_protocol_version, UpgradeSignalDefaults::NODE_PROTOCOL_VERSION);
+        assert_eq!(config.node_protocol_version, UpgradeSignalDefaults::node_protocol_version());
     }
 
     #[test]

--- a/crates/utilities/upgrade-signal/src/config/mod.rs
+++ b/crates/utilities/upgrade-signal/src/config/mod.rs
@@ -1,7 +1,6 @@
 //! Upgrade signal configuration and CLI arguments.
 
 use core::time::Duration;
-use std::sync::LazyLock;
 
 use alloy_primitives::U256;
 
@@ -37,7 +36,11 @@ impl UpgradeSignalDefaults {
     /// binaries advertise the release semver as their supported protocol version. Dev builds
     /// (workspace `0.0.0`) advertise `U256::MAX` so no contract minimum rejects them.
     pub fn node_protocol_version() -> U256 {
-        *NODE_PROTOCOL_VERSION
+        Self::advertised_protocol_version(Self::packed_protocol_version(
+            env!("CARGO_PKG_VERSION_MAJOR").parse::<u32>().expect("Cargo package major is numeric"),
+            env!("CARGO_PKG_VERSION_MINOR").parse::<u32>().expect("Cargo package minor is numeric"),
+            env!("CARGO_PKG_VERSION_PATCH").parse::<u32>().expect("Cargo package patch is numeric"),
+        ))
     }
 
     /// Encodes a `major.minor.patch` version into the packed-semver `uint256` layout used by the
@@ -53,17 +56,6 @@ impl UpgradeSignalDefaults {
         if cargo_version == U256::ZERO { U256::MAX } else { cargo_version }
     }
 }
-
-/// Node protocol version derived from the compile-time Cargo package version, computed once.
-static NODE_PROTOCOL_VERSION: LazyLock<U256> = LazyLock::new(|| {
-    UpgradeSignalDefaults::advertised_protocol_version(
-        UpgradeSignalDefaults::packed_protocol_version(
-            env!("CARGO_PKG_VERSION_MAJOR").parse::<u32>().expect("Cargo package major is numeric"),
-            env!("CARGO_PKG_VERSION_MINOR").parse::<u32>().expect("Cargo package minor is numeric"),
-            env!("CARGO_PKG_VERSION_PATCH").parse::<u32>().expect("Cargo package patch is numeric"),
-        ),
-    )
-});
 
 #[cfg(test)]
 mod tests {

--- a/crates/utilities/upgrade-signal/src/config/mod.rs
+++ b/crates/utilities/upgrade-signal/src/config/mod.rs
@@ -30,12 +30,26 @@ impl UpgradeSignalDefaults {
     /// Default backoff between L1 upgrade signal schedule read attempts.
     pub const READ_BACKOFF: Duration = Duration::from_secs(2);
 
-    /// Node protocol version supported by this binary for contract-backed upgrade signals
-    /// (packed semver `1.1.0`).
+    /// Node protocol version supported by this binary for contract-backed upgrade signals.
     ///
-    /// Contract schedules with a higher minimum protocol version are rejected before any timestamp is
-    /// applied. Bump this with the node software that fully implements the next dynamic upgrade.
-    pub const NODE_PROTOCOL_VERSION: U256 = Self::packed_protocol_version(1, 1, 0);
+    /// Release branches sync the Cargo package version to the `GitHub` release tag, so release
+    /// binaries advertise the release semver as their supported protocol version. Dev builds
+    /// (workspace `0.0.0`) advertise `U256::MAX` so no contract minimum rejects them.
+    pub fn node_protocol_version() -> U256 {
+        let cargo_version = Self::packed_protocol_version(
+            env!("CARGO_PKG_VERSION_MAJOR")
+                .parse::<u32>()
+                .expect("Cargo package major version is numeric"),
+            env!("CARGO_PKG_VERSION_MINOR")
+                .parse::<u32>()
+                .expect("Cargo package minor version is numeric"),
+            env!("CARGO_PKG_VERSION_PATCH")
+                .parse::<u32>()
+                .expect("Cargo package patch version is numeric"),
+        );
+
+        if cargo_version == U256::ZERO { U256::MAX } else { cargo_version }
+    }
 
     /// Encodes a `major.minor.patch` version into the packed-semver `uint256` layout used by the
     /// L1 `ProtocolVersions` contract: `major << 96 | minor << 64 | patch << 32`, with the

--- a/crates/utilities/upgrade-signal/src/config/mod.rs
+++ b/crates/utilities/upgrade-signal/src/config/mod.rs
@@ -2,6 +2,8 @@
 
 use core::time::Duration;
 
+use alloy_primitives::U256;
+
 mod args;
 pub use args::{UpgradeSignalArgs, UpgradeSignalL1RpcArgs, UpgradeSignalStartupConfig};
 
@@ -28,9 +30,17 @@ impl UpgradeSignalDefaults {
     /// Default backoff between L1 upgrade signal schedule read attempts.
     pub const READ_BACKOFF: Duration = Duration::from_secs(2);
 
-    /// Node protocol version supported by this binary for contract-backed upgrade signals.
+    /// Node protocol version supported by this binary for contract-backed upgrade signals
+    /// (packed semver `1.1.0`).
     ///
     /// Contract schedules with a higher minimum protocol version are rejected before any timestamp is
     /// applied. Bump this with the node software that fully implements the next dynamic upgrade.
-    pub const NODE_PROTOCOL_VERSION: u64 = 7;
+    pub const NODE_PROTOCOL_VERSION: U256 = Self::packed_protocol_version(1, 1, 0);
+
+    /// Encodes a `major.minor.patch` version into the packed-semver `uint256` layout used by the
+    /// L1 `ProtocolVersions` contract: `major << 96 | minor << 64 | patch << 32`, with the
+    /// prerelease field left zero.
+    pub const fn packed_protocol_version(major: u32, minor: u32, patch: u32) -> U256 {
+        U256::from_limbs([(patch as u64) << 32, ((major as u64) << 32) | minor as u64, 0, 0])
+    }
 }

--- a/crates/utilities/upgrade-signal/src/config/mod.rs
+++ b/crates/utilities/upgrade-signal/src/config/mod.rs
@@ -1,6 +1,7 @@
 //! Upgrade signal configuration and CLI arguments.
 
 use core::time::Duration;
+use std::sync::LazyLock;
 
 use alloy_primitives::U256;
 
@@ -36,11 +37,7 @@ impl UpgradeSignalDefaults {
     /// binaries advertise the release semver as their supported protocol version. Dev builds
     /// (workspace `0.0.0`) advertise `U256::MAX` so no contract minimum rejects them.
     pub fn node_protocol_version() -> U256 {
-        Self::advertised_protocol_version(Self::packed_protocol_version(
-            env!("CARGO_PKG_VERSION_MAJOR").parse::<u32>().expect("Cargo package major is numeric"),
-            env!("CARGO_PKG_VERSION_MINOR").parse::<u32>().expect("Cargo package minor is numeric"),
-            env!("CARGO_PKG_VERSION_PATCH").parse::<u32>().expect("Cargo package patch is numeric"),
-        ))
+        *NODE_PROTOCOL_VERSION
     }
 
     /// Encodes a `major.minor.patch` version into the packed-semver `uint256` layout used by the
@@ -56,6 +53,17 @@ impl UpgradeSignalDefaults {
         if cargo_version == U256::ZERO { U256::MAX } else { cargo_version }
     }
 }
+
+/// Node protocol version derived from the compile-time Cargo package version, computed once.
+static NODE_PROTOCOL_VERSION: LazyLock<U256> = LazyLock::new(|| {
+    UpgradeSignalDefaults::advertised_protocol_version(
+        UpgradeSignalDefaults::packed_protocol_version(
+            env!("CARGO_PKG_VERSION_MAJOR").parse::<u32>().expect("Cargo package major is numeric"),
+            env!("CARGO_PKG_VERSION_MINOR").parse::<u32>().expect("Cargo package minor is numeric"),
+            env!("CARGO_PKG_VERSION_PATCH").parse::<u32>().expect("Cargo package patch is numeric"),
+        ),
+    )
+});
 
 #[cfg(test)]
 mod tests {

--- a/crates/utilities/upgrade-signal/src/config/mod.rs
+++ b/crates/utilities/upgrade-signal/src/config/mod.rs
@@ -36,19 +36,11 @@ impl UpgradeSignalDefaults {
     /// binaries advertise the release semver as their supported protocol version. Dev builds
     /// (workspace `0.0.0`) advertise `U256::MAX` so no contract minimum rejects them.
     pub fn node_protocol_version() -> U256 {
-        let cargo_version = Self::packed_protocol_version(
-            env!("CARGO_PKG_VERSION_MAJOR")
-                .parse::<u32>()
-                .expect("Cargo package major version is numeric"),
-            env!("CARGO_PKG_VERSION_MINOR")
-                .parse::<u32>()
-                .expect("Cargo package minor version is numeric"),
-            env!("CARGO_PKG_VERSION_PATCH")
-                .parse::<u32>()
-                .expect("Cargo package patch version is numeric"),
-        );
-
-        if cargo_version == U256::ZERO { U256::MAX } else { cargo_version }
+        Self::advertised_protocol_version(Self::packed_protocol_version(
+            env!("CARGO_PKG_VERSION_MAJOR").parse::<u32>().expect("Cargo package major is numeric"),
+            env!("CARGO_PKG_VERSION_MINOR").parse::<u32>().expect("Cargo package minor is numeric"),
+            env!("CARGO_PKG_VERSION_PATCH").parse::<u32>().expect("Cargo package patch is numeric"),
+        ))
     }
 
     /// Encodes a `major.minor.patch` version into the packed-semver `uint256` layout used by the
@@ -56,5 +48,29 @@ impl UpgradeSignalDefaults {
     /// prerelease field left zero.
     pub const fn packed_protocol_version(major: u32, minor: u32, patch: u32) -> U256 {
         U256::from_limbs([(patch as u64) << 32, ((major as u64) << 32) | minor as u64, 0, 0])
+    }
+
+    /// Maps a packed Cargo version to the advertised node protocol version, promoting the
+    /// dev-build `0.0.0` (zero) to `U256::MAX` so no contract minimum can reject a dev build.
+    pub fn advertised_protocol_version(cargo_version: U256) -> U256 {
+        if cargo_version == U256::ZERO { U256::MAX } else { cargo_version }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dev_build_advertises_max_protocol_version() {
+        // Dev builds (0.0.0 -> zero) must bypass any contract minimum-version check.
+        let zero = UpgradeSignalDefaults::packed_protocol_version(0, 0, 0);
+        assert_eq!(UpgradeSignalDefaults::advertised_protocol_version(zero), U256::MAX);
+    }
+
+    #[test]
+    fn release_build_advertises_its_own_version() {
+        let version = UpgradeSignalDefaults::packed_protocol_version(1, 2, 0);
+        assert_eq!(UpgradeSignalDefaults::advertised_protocol_version(version), version);
     }
 }

--- a/crates/utilities/upgrade-signal/src/config/schedule.rs
+++ b/crates/utilities/upgrade-signal/src/config/schedule.rs
@@ -37,7 +37,7 @@ impl UpgradeSignalConfig {
             upgrade_ids: vec![upgrade_id],
             mode: UpgradeSignalMode::MetricsOnly,
             l1_block_tag: BlockNumberOrTag::Finalized,
-            node_protocol_version: UpgradeSignalDefaults::NODE_PROTOCOL_VERSION,
+            node_protocol_version: UpgradeSignalDefaults::node_protocol_version(),
         }
     }
 
@@ -203,6 +203,15 @@ mod tests {
         BaseUpgrade::from_contract_fork_name(upgrade_id).unwrap()
     }
 
+    fn supported_config(upgrade_id: &str) -> UpgradeSignalConfig {
+        let mut config = UpgradeSignalConfig::new(
+            address!("0000000000000000000000000000000000000001"),
+            upgrade(upgrade_id),
+        );
+        config.node_protocol_version = UpgradeSignalDefaults::packed_protocol_version(1, 1, 0);
+        config
+    }
+
     #[rstest]
     #[case("azul")]
     #[case("beryl")]
@@ -242,10 +251,7 @@ mod tests {
     #[case("azul")]
     #[case("beryl")]
     fn rejects_signal_above_node_protocol_version(#[case] upgrade_id: &str) {
-        let config = UpgradeSignalConfig::new(
-            address!("0000000000000000000000000000000000000001"),
-            upgrade(upgrade_id),
-        );
+        let config = supported_config(upgrade_id);
         let minimum_protocol_version = config.node_protocol_version + U256::from(1);
 
         assert!(matches!(
@@ -297,10 +303,7 @@ mod tests {
 
     #[test]
     fn schedule_validation_rejects_unsupported_protocol_version() {
-        let config = UpgradeSignalConfig::new(
-            address!("0000000000000000000000000000000000000001"),
-            BaseUpgrade::Azul,
-        );
+        let config = supported_config("azul");
 
         let schedule = UpgradeSignalSchedule::new(vec![
             UpgradeSignal {

--- a/crates/utilities/upgrade-signal/src/config/schedule.rs
+++ b/crates/utilities/upgrade-signal/src/config/schedule.rs
@@ -37,7 +37,7 @@ impl UpgradeSignalConfig {
             upgrade_ids: vec![upgrade_id],
             mode: UpgradeSignalMode::MetricsOnly,
             l1_block_tag: BlockNumberOrTag::Finalized,
-            node_protocol_version: U256::from(UpgradeSignalDefaults::NODE_PROTOCOL_VERSION),
+            node_protocol_version: UpgradeSignalDefaults::NODE_PROTOCOL_VERSION,
         }
     }
 

--- a/crates/utilities/upgrade-signal/src/contract.rs
+++ b/crates/utilities/upgrade-signal/src/contract.rs
@@ -157,7 +157,7 @@ impl AlloyUpgradeSignalReader {
             );
         }
 
-        let signals: Vec<UpgradeSignal> = BaseUpgrade::CONTRACT_VARIANTS
+        let signals: Vec<_> = BaseUpgrade::CONTRACT_VARIANTS
             .iter()
             .zip(timestamps.iter())
             .filter(|(upgrade_id, _)| upgrade_ids.contains(upgrade_id))

--- a/crates/utilities/upgrade-signal/src/contract.rs
+++ b/crates/utilities/upgrade-signal/src/contract.rs
@@ -7,7 +7,7 @@ use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_types_eth::{BlockId, BlockNumberOrTag, TransactionInput, TransactionRequest};
 use alloy_sol_types::{SolCall, sol};
 use base_common_genesis::BaseUpgrade;
-use futures::future::{join_all, try_join};
+use futures::future::try_join;
 use tokio::time::sleep;
 use tracing::warn;
 
@@ -17,21 +17,22 @@ use crate::{
 };
 
 sol! {
-    /// L1 upgrade signal interface.
+    /// L1 `ProtocolVersions` upgrade schedule interface.
     ///
     /// The address can be a proxy. Nodes only depend on this read interface.
-    interface IUpgradeSignal {
-        /// Emitted when an activation timestamp is set for an upgrade ID.
-        event TimestampSet(string indexed upgradeId, uint256 timestamp);
+    interface IProtocolVersions {
+        /// Emitted when an upgrade's activation timestamp is set, cleared, or delayed.
+        event TimestampSet(uint256 indexed id, uint256 timestamp);
 
-        /// Emitted when a protocol version is set for an upgrade ID.
-        event ProtocolVersionSet(string indexed upgradeId, uint256 protocolVersion);
+        /// Emitted when the minimum protocol version clients must run is updated.
+        event MinimumProtocolVersionUpdated(uint256 indexed protocolVersion);
 
-        /// Returns the activation timestamp for `upgradeId`.
-        function getTimestamp(string upgradeId) external view returns (uint256);
+        /// Returns the activation timestamp for every registered upgrade, ordered by ascending
+        /// upgrade id (`0` = not scheduled).
+        function getSchedule() external view returns (uint64[] memory);
 
-        /// Returns the minimum node protocol version for `upgradeId`.
-        function getProtocolVersion(string upgradeId) external view returns (uint256);
+        /// Returns the minimum protocol version clients must run (packed semver).
+        function minimumProtocolVersion() external view returns (uint256);
     }
 }
 
@@ -81,8 +82,9 @@ impl AlloyUpgradeSignalReader {
 
     /// Returns the L1 block number and concrete block ID for the configured block tag.
     ///
-    /// Pinning reads to a concrete block hash ensures every per-upgrade call in a schedule observes
-    /// the same L1 state. The block tag (finalized by default) keeps the schedule reorg-stable.
+    /// Pinning reads to a concrete block hash ensures every contract call in a schedule read
+    /// observes the same L1 state. The block tag (finalized by default) keeps the schedule
+    /// reorg-stable.
     pub async fn pinned_l1_block_id(&self) -> Result<(u64, BlockId), UpgradeSignalError> {
         let block = self
             .provider
@@ -96,62 +98,85 @@ impl AlloyUpgradeSignalReader {
         Ok((block.header.number, BlockId::hash(block.header.hash)))
     }
 
-    /// Converts an ABI uint256 timestamp into the node's `u64` timestamp representation.
-    pub fn decode_timestamp(value: U256) -> Result<u64, UpgradeSignalError> {
-        u64::try_from(value).map_err(|_| UpgradeSignalError::timestamp_overflow(value))
-    }
-
-    /// Reads one upgrade signal using a previously observed L1 block ID.
-    pub async fn read_signal_at_l1_block(
+    /// Reads the contract's id-ordered activation timestamps and the global minimum protocol
+    /// version using a previously observed L1 block ID.
+    pub async fn read_contract_schedule_at_l1_block(
         &self,
-        upgrade_id: BaseUpgrade,
-        l1_block_number: u64,
         l1_block: BlockId,
-    ) -> Result<UpgradeSignal, UpgradeSignalError> {
-        let (timestamp_output, version_output) = try_join(
+    ) -> Result<(Vec<u64>, U256), UpgradeSignalError> {
+        let (schedule_output, version_output) = try_join(
             self.call_at_block(
-                IUpgradeSignal::getTimestampCall {
-                    upgradeId: upgrade_id.contract_id().to_string(),
-                },
+                IProtocolVersions::getScheduleCall {},
                 l1_block,
-                "getTimestamp failed",
+                "getSchedule failed",
             ),
             self.call_at_block(
-                IUpgradeSignal::getProtocolVersionCall {
-                    upgradeId: upgrade_id.contract_id().to_string(),
-                },
+                IProtocolVersions::minimumProtocolVersionCall {},
                 l1_block,
-                "getProtocolVersion failed",
+                "minimumProtocolVersion failed",
             ),
         )
         .await?;
-        let timestamp =
-            IUpgradeSignal::getTimestampCall::abi_decode_returns(timestamp_output.as_ref())
-                .map_err(|error| UpgradeSignalError::decode("getTimestamp decode failed", error))?;
-        let activation_timestamp = Self::decode_timestamp(timestamp)?;
 
-        let protocol_version =
-            IUpgradeSignal::getProtocolVersionCall::abi_decode_returns(version_output.as_ref())
-                .map_err(|error| {
-                    UpgradeSignalError::decode("getProtocolVersion decode failed", error)
-                })?;
+        let timestamps =
+            IProtocolVersions::getScheduleCall::abi_decode_returns(schedule_output.as_ref())
+                .map_err(|error| UpgradeSignalError::decode("getSchedule decode failed", error))?;
 
-        Ok(UpgradeSignal { upgrade_id, activation_timestamp, protocol_version, l1_block_number })
+        let minimum_protocol_version =
+            IProtocolVersions::minimumProtocolVersionCall::abi_decode_returns(
+                version_output.as_ref(),
+            )
+            .map_err(|error| {
+                UpgradeSignalError::decode("minimumProtocolVersion decode failed", error)
+            })?;
+
+        Ok((timestamps, minimum_protocol_version))
     }
 
-    /// Reads the upgrade signal for `upgrade_id`.
-    pub async fn read_signal(
-        &self,
-        upgrade_id: BaseUpgrade,
-    ) -> Result<UpgradeSignal, UpgradeSignalError> {
-        let (l1_block_number, l1_block) = self.pinned_l1_block_id().await?;
-        self.read_signal_at_l1_block(upgrade_id, l1_block_number, l1_block).await
+    /// Maps the contract's id-ordered activation timestamps onto the node's hardfork ladder.
+    ///
+    /// The contract keys upgrades by ascending numeric registration id and keeps names offchain,
+    /// so entries are aligned with [`BaseUpgrade::CONTRACT_VARIANTS`] in activation (timestamp)
+    /// order: id `0` (the lowest timestamp) maps to the oldest contract-backed hardfork, and each
+    /// following id maps to the next hardfork in the ladder. Contract entries beyond the ladder
+    /// belong to upgrades newer than this binary knows and are logged and ignored, hardforks
+    /// without a contract entry produce no signal, and only upgrades in `upgrade_ids` produce
+    /// signals. Every signal carries the contract's global minimum protocol version.
+    pub fn map_schedule(
+        timestamps: &[u64],
+        minimum_protocol_version: U256,
+        l1_block_number: u64,
+        upgrade_ids: &[BaseUpgrade],
+    ) -> UpgradeSignalSchedule {
+        if timestamps.len() > BaseUpgrade::CONTRACT_VARIANTS.len() {
+            warn!(
+                target: "upgrade_signal",
+                contract_upgrades = timestamps.len(),
+                known_upgrades = BaseUpgrade::CONTRACT_VARIANTS.len(),
+                "L1 schedule has more upgrades than this binary knows; newest entries ignored"
+            );
+        }
+
+        let signals: Vec<UpgradeSignal> = BaseUpgrade::CONTRACT_VARIANTS
+            .iter()
+            .zip(timestamps.iter())
+            .filter(|(upgrade_id, _)| upgrade_ids.contains(upgrade_id))
+            .map(|(upgrade_id, activation_timestamp)| UpgradeSignal {
+                upgrade_id: *upgrade_id,
+                activation_timestamp: *activation_timestamp,
+                protocol_version: minimum_protocol_version,
+                l1_block_number,
+            })
+            .collect();
+
+        UpgradeSignalSchedule::new(signals)
     }
 
     /// Reads the upgrade signal schedule for `upgrade_ids`.
     ///
-    /// Records `l1_read_errors_total` on failure: all upgrade IDs if the L1 block fetch fails,
-    /// only the failing upgrade ID if a per-upgrade contract call fails.
+    /// Records `l1_read_errors_total` for all upgrade IDs when the L1 block fetch or the schedule
+    /// read fails; the whole schedule is read with one `getSchedule` call, so per-upgrade failures
+    /// no longer exist.
     pub async fn read_schedule(
         &self,
         upgrade_ids: &[BaseUpgrade],
@@ -164,37 +189,19 @@ impl AlloyUpgradeSignalReader {
                 return Err(error);
             }
         };
-        let mut signals = Vec::with_capacity(upgrade_ids.len());
-        let mut first_error = None;
 
-        for (upgrade_id, result) in
-            join_all(upgrade_ids.iter().copied().map(|upgrade_id| async move {
-                (
-                    upgrade_id,
-                    self.read_signal_at_l1_block(upgrade_id, l1_block_number, l1_block).await,
-                )
-            }))
+        let (timestamps, minimum_protocol_version) = match self
+            .read_contract_schedule_at_l1_block(l1_block)
             .await
         {
-            match result {
-                Ok(signal) => signals.push(signal),
-                Err(error) => {
-                    UpgradeSignalMetrics::record_l1_read_error_for_layers(
-                        metrics_layers,
-                        upgrade_id,
-                    );
-                    if first_error.is_none() {
-                        first_error = Some(error);
-                    }
-                }
+            Ok(values) => values,
+            Err(error) => {
+                UpgradeSignalMetrics::record_l1_read_errors_for_layers(metrics_layers, upgrade_ids);
+                return Err(error);
             }
-        }
+        };
 
-        if let Some(error) = first_error {
-            return Err(error);
-        }
-
-        Ok(UpgradeSignalSchedule::new(signals))
+        Ok(Self::map_schedule(&timestamps, minimum_protocol_version, l1_block_number, upgrade_ids))
     }
 
     /// Reads the schedule, retrying transient failures with a fixed backoff before giving up.
@@ -229,76 +236,118 @@ impl AlloyUpgradeSignalReader {
         }
     }
 
-    /// Reads the schedule, tolerating per-upgrade failures.
+    /// Reads the schedule, tolerating read failures.
     ///
-    /// Records `l1_read_errors_total` for each upgrade that fails and returns the signals that were
-    /// read successfully. Intended for the live metrics poller, which must not abort the whole
-    /// schedule (or the node) because a single upgrade read failed.
+    /// Records `l1_read_errors_total` and returns an empty schedule when the read fails. Intended
+    /// for the live metrics poller, which must not abort the node because a schedule read failed.
     pub async fn read_schedule_tolerant(
         &self,
         upgrade_ids: &[BaseUpgrade],
         metrics_layers: &[UpgradeSignalMetricLayer],
     ) -> UpgradeSignalSchedule {
-        let (l1_block_number, l1_block) = match self.pinned_l1_block_id().await {
-            Ok(block) => block,
+        match self.read_schedule(upgrade_ids, metrics_layers).await {
+            Ok(schedule) => schedule,
             Err(error) => {
-                UpgradeSignalMetrics::record_l1_read_errors_for_layers(metrics_layers, upgrade_ids);
                 warn!(
                     target: "upgrade_signal",
                     error = %error,
-                    "failed to fetch L1 block for upgrade signal poll"
+                    "failed to read live L1 upgrade signal schedule"
                 );
-                return UpgradeSignalSchedule::default();
-            }
-        };
-        let mut signals = Vec::with_capacity(upgrade_ids.len());
-        for (upgrade_id, result) in
-            join_all(upgrade_ids.iter().copied().map(|upgrade_id| async move {
-                (
-                    upgrade_id,
-                    self.read_signal_at_l1_block(upgrade_id, l1_block_number, l1_block).await,
-                )
-            }))
-            .await
-        {
-            match result {
-                Ok(signal) => signals.push(signal),
-                Err(error) => {
-                    UpgradeSignalMetrics::record_l1_read_error_for_layers(
-                        metrics_layers,
-                        upgrade_id,
-                    );
-                    warn!(
-                        target: "upgrade_signal",
-                        upgrade_id = %upgrade_id.contract_id(),
-                        error = %error,
-                        "failed to read live L1 upgrade signal for upgrade"
-                    );
-                }
+                UpgradeSignalSchedule::default()
             }
         }
-        UpgradeSignalSchedule::new(signals)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::U256;
-
     use super::*;
 
-    #[test]
-    fn decodes_u64_timestamp() {
-        assert_eq!(AlloyUpgradeSignalReader::decode_timestamp(U256::from(42)).unwrap(), 42);
+    fn signals(schedule: &UpgradeSignalSchedule) -> Vec<(BaseUpgrade, u64)> {
+        schedule
+            .signals
+            .iter()
+            .map(|signal| (signal.upgrade_id, signal.activation_timestamp))
+            .collect()
     }
 
     #[test]
-    fn rejects_timestamp_overflow() {
-        let value = U256::from(u64::MAX) + U256::from(1);
+    fn maps_partial_schedule_to_oldest_hardforks() {
+        let schedule = AlloyUpgradeSignalReader::map_schedule(
+            &[10, 20, 0],
+            U256::from(7),
+            99,
+            &BaseUpgrade::CONTRACT_VARIANTS,
+        );
 
-        assert!(matches!(
-            AlloyUpgradeSignalReader::decode_timestamp(value).unwrap_err(),
-            UpgradeSignalError::TimestampOverflow(actual) if actual == value
-        ));
+        assert_eq!(
+            signals(&schedule),
+            vec![(BaseUpgrade::Regolith, 10), (BaseUpgrade::Canyon, 20), (BaseUpgrade::Delta, 0)]
+        );
+        assert!(
+            schedule
+                .signals
+                .iter()
+                .all(|signal| signal.protocol_version == U256::from(7)
+                    && signal.l1_block_number == 99)
+        );
+    }
+
+    #[test]
+    fn maps_full_schedule_in_ladder_order() {
+        let timestamps: Vec<u64> = (1..=BaseUpgrade::CONTRACT_VARIANTS.len() as u64).collect();
+
+        let schedule = AlloyUpgradeSignalReader::map_schedule(
+            &timestamps,
+            U256::from(7),
+            1,
+            &BaseUpgrade::CONTRACT_VARIANTS,
+        );
+
+        assert_eq!(
+            signals(&schedule),
+            BaseUpgrade::CONTRACT_VARIANTS.iter().copied().zip(timestamps).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn filters_unconfigured_upgrades() {
+        let schedule = AlloyUpgradeSignalReader::map_schedule(
+            &[10, 20, 30],
+            U256::from(7),
+            1,
+            &[BaseUpgrade::Canyon],
+        );
+
+        assert_eq!(signals(&schedule), vec![(BaseUpgrade::Canyon, 20)]);
+    }
+
+    #[test]
+    fn ignores_entries_newer_than_known_ladder() {
+        let mut timestamps: Vec<u64> = (1..=BaseUpgrade::CONTRACT_VARIANTS.len() as u64).collect();
+        timestamps.push(777);
+
+        let schedule = AlloyUpgradeSignalReader::map_schedule(
+            &timestamps,
+            U256::from(7),
+            1,
+            &BaseUpgrade::CONTRACT_VARIANTS,
+        );
+
+        assert_eq!(schedule.signals.len(), BaseUpgrade::CONTRACT_VARIANTS.len());
+        assert_eq!(signals(&schedule).first().copied(), Some((BaseUpgrade::Regolith, 1)));
+        assert!(!signals(&schedule).iter().any(|(_, timestamp)| *timestamp == 777));
+    }
+
+    #[test]
+    fn produces_no_signal_for_hardforks_without_contract_entries() {
+        let schedule = AlloyUpgradeSignalReader::map_schedule(
+            &[42],
+            U256::from(7),
+            1,
+            &BaseUpgrade::CONTRACT_VARIANTS,
+        );
+
+        assert_eq!(signals(&schedule), vec![(BaseUpgrade::Regolith, 42)]);
     }
 }

--- a/crates/utilities/upgrade-signal/src/contract.rs
+++ b/crates/utilities/upgrade-signal/src/contract.rs
@@ -130,9 +130,10 @@ impl AlloyUpgradeSignalReader {
     /// Maps the contract's id-ordered activation timestamps onto the node's hardfork ladder.
     ///
     /// The contract keys upgrades by ascending numeric registration id and keeps names offchain,
-    /// so entries are aligned with [`BaseUpgrade::CONTRACT_VARIANTS`] in activation (timestamp)
-    /// order: id `0` (the lowest timestamp) maps to the oldest contract-backed hardfork, and each
-    /// following id maps to the next hardfork in the ladder. Contract entries beyond the ladder
+    /// so entries are aligned with [`BaseUpgrade::CONTRACT_VARIANTS`] by registration id: id `0`
+    /// maps to the oldest contract-backed hardfork, and each following id maps to the next
+    /// hardfork in the ladder. This is a positional mapping by id, not a sort by timestamp, so the
+    /// timestamps need not be monotonic. Contract entries beyond the ladder
     /// belong to upgrades newer than this binary knows and are logged and ignored, hardforks
     /// without a contract entry produce no signal, and only upgrades in `upgrade_ids` produce
     /// signals. Every signal carries the contract's global minimum protocol version.

--- a/crates/utilities/upgrade-signal/src/contract.rs
+++ b/crates/utilities/upgrade-signal/src/contract.rs
@@ -21,12 +21,6 @@ sol! {
     ///
     /// The address can be a proxy. Nodes only depend on this read interface.
     interface IProtocolVersions {
-        /// Emitted when an upgrade's activation timestamp is set, cleared, or delayed.
-        event TimestampSet(uint256 indexed id, uint256 timestamp);
-
-        /// Emitted when the minimum protocol version clients must run is updated.
-        event MinimumProtocolVersionUpdated(uint256 indexed protocolVersion);
-
         /// Returns the activation timestamp for every registered upgrade, ordered by ascending
         /// upgrade id (`0` = not scheduled).
         function getSchedule() external view returns (uint64[] memory);

--- a/crates/utilities/upgrade-signal/src/error.rs
+++ b/crates/utilities/upgrade-signal/src/error.rs
@@ -1,7 +1,5 @@
 //! Upgrade signal error types.
 
-use alloy_primitives::U256;
-
 /// Error returned by upgrade signal readers.
 #[derive(Debug, thiserror::Error)]
 pub enum UpgradeSignalError {
@@ -21,9 +19,6 @@ pub enum UpgradeSignalError {
         /// Decode error string.
         error: String,
     },
-    /// The activation timestamp does not fit in a `u64`.
-    #[error("activation timestamp {0} does not fit in u64")]
-    TimestampOverflow(U256),
     /// A positive activation timestamp was not paired with a minimum node protocol version.
     #[error(
         "upgrade signal for {0} has an activation timestamp but no minimum node protocol version"
@@ -58,11 +53,6 @@ impl UpgradeSignalError {
     /// Creates a decode error.
     pub fn decode(context: &'static str, error: impl ToString) -> Self {
         Self::Decode { context, error: error.to_string() }
-    }
-
-    /// Creates a timestamp overflow error.
-    pub const fn timestamp_overflow(value: U256) -> Self {
-        Self::TimestampOverflow(value)
     }
 
     /// Creates a missing protocol version error.

--- a/crates/utilities/upgrade-signal/src/metrics.rs
+++ b/crates/utilities/upgrade-signal/src/metrics.rs
@@ -108,21 +108,15 @@ impl UpgradeSignalMetrics {
             .increment(1);
     }
 
-    /// Converts a protocol version to a compact metric gauge value.
+    /// Converts a packed-semver protocol version to a compact metric gauge value.
     ///
-    /// Packed-semver versions are decoded to `major * 1_000_000 + minor * 1_000 + patch` so the
-    /// gauge stays readable (raw packed values exceed `f64` integer precision). Values without
-    /// packed `major.minor.patch` fields (e.g. legacy plain integers) are emitted as-is.
+    /// Decoded as `major * 1_000_000 + minor * 1_000 + patch` so the gauge stays readable
+    /// (raw packed values exceed `f64` integer precision).
     pub fn protocol_version_to_f64(protocol_version: U256) -> f64 {
         let limbs = protocol_version.as_limbs();
         let major = limbs[1] >> 32;
         let minor = limbs[1] & u64::from(u32::MAX);
         let patch = limbs[0] >> 32;
-
-        if major == 0 && minor == 0 && patch == 0 {
-            return protocol_version.to_string().parse::<f64>().unwrap_or(-1.0);
-        }
-
         (major * 1_000_000 + minor * 1_000 + patch) as f64
     }
 }
@@ -132,14 +126,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn converts_plain_protocol_version_to_metric_value() {
-        assert_eq!(UpgradeSignalMetrics::protocol_version_to_f64(U256::from(7)), 7.0);
-    }
-
-    #[test]
     fn converts_packed_semver_protocol_version_to_metric_value() {
         let version = crate::UpgradeSignalDefaults::packed_protocol_version(1, 1, 0);
-
         assert_eq!(UpgradeSignalMetrics::protocol_version_to_f64(version), 1_001_000.0);
     }
 }

--- a/crates/utilities/upgrade-signal/src/metrics.rs
+++ b/crates/utilities/upgrade-signal/src/metrics.rs
@@ -112,6 +112,8 @@ impl UpgradeSignalMetrics {
     ///
     /// Decoded as `major * 1_000_000 + minor * 1_000 + patch` so the gauge stays readable
     /// (raw packed values exceed `f64` integer precision).
+    ///
+    /// Expects a contract-read packed semver value; non-semver inputs decode to garbage.
     pub fn protocol_version_to_f64(protocol_version: U256) -> f64 {
         let limbs = protocol_version.as_limbs();
         let major = limbs[1] >> 32;

--- a/crates/utilities/upgrade-signal/src/metrics.rs
+++ b/crates/utilities/upgrade-signal/src/metrics.rs
@@ -81,24 +81,6 @@ impl UpgradeSignalMetrics {
         Self::last_l1_read_block(layer, upgrade_id).set(signal.l1_block_number as f64);
     }
 
-    /// Records a failed L1 read for one upgrade ID.
-    pub fn record_l1_read_error(layer: UpgradeSignalMetricLayer, upgrade_id: BaseUpgrade) {
-        Self::init();
-        Self::l1_read_errors_total(layer.label(), upgrade_id.contract_id().to_string())
-            .increment(1);
-    }
-
-    /// Records a failed L1 read for one upgrade ID across all enabled layers.
-    pub fn record_l1_read_error_for_layers(
-        layers: &[UpgradeSignalMetricLayer],
-        upgrade_id: BaseUpgrade,
-    ) {
-        Self::init();
-        for layer in layers {
-            Self::record_l1_read_error(*layer, upgrade_id);
-        }
-    }
-
     /// Records failed L1 reads for all configured upgrade IDs.
     pub fn record_l1_read_errors(layer: UpgradeSignalMetricLayer, upgrade_ids: &[BaseUpgrade]) {
         Self::init();
@@ -126,9 +108,22 @@ impl UpgradeSignalMetrics {
             .increment(1);
     }
 
-    /// Converts a protocol version to a metric gauge value.
+    /// Converts a protocol version to a compact metric gauge value.
+    ///
+    /// Packed-semver versions are decoded to `major * 1_000_000 + minor * 1_000 + patch` so the
+    /// gauge stays readable (raw packed values exceed `f64` integer precision). Values without
+    /// packed `major.minor.patch` fields (e.g. legacy plain integers) are emitted as-is.
     pub fn protocol_version_to_f64(protocol_version: U256) -> f64 {
-        protocol_version.to_string().parse::<f64>().unwrap_or(-1.0)
+        let limbs = protocol_version.as_limbs();
+        let major = limbs[1] >> 32;
+        let minor = limbs[1] & u64::from(u32::MAX);
+        let patch = limbs[0] >> 32;
+
+        if major == 0 && minor == 0 && patch == 0 {
+            return protocol_version.to_string().parse::<f64>().unwrap_or(-1.0);
+        }
+
+        (major * 1_000_000 + minor * 1_000 + patch) as f64
     }
 }
 
@@ -137,7 +132,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn converts_protocol_version_to_metric_value() {
+    fn converts_plain_protocol_version_to_metric_value() {
         assert_eq!(UpgradeSignalMetrics::protocol_version_to_f64(U256::from(7)), 7.0);
+    }
+
+    #[test]
+    fn converts_packed_semver_protocol_version_to_metric_value() {
+        let version = crate::UpgradeSignalDefaults::packed_protocol_version(1, 1, 0);
+
+        assert_eq!(UpgradeSignalMetrics::protocol_version_to_f64(version), 1_001_000.0);
     }
 }

--- a/crates/utilities/upgrade-signal/src/state.rs
+++ b/crates/utilities/upgrade-signal/src/state.rs
@@ -110,7 +110,7 @@ impl UpgradeSignalMonitor {
     /// Tolerantly polls the reader, records live metrics, and returns the number of changed signals.
     ///
     /// This is the single live-poll routine shared by the consensus actor and the execution
-    /// metrics extension; per-upgrade read failures are recorded but do not abort the poll.
+    /// metrics extension; read failures are recorded but do not abort the poll.
     pub async fn poll(
         &mut self,
         reader: &AlloyUpgradeSignalReader,


### PR DESCRIPTION
## Summary

  Adds support for reading dynamic upgrade activation schedules from the L1 `ProtocolVersions` contract.

  This updates the upgrade-signal utility to:

  - read the contract-backed upgrade schedule with `getSchedule()`
  - read the global `minimumProtocolVersion()`
  - map contract schedule entries onto known `BaseUpgrade::CONTRACT_VARIANTS`
  - reject schedules requiring a newer node protocol version than the binary supports
  - derive the node protocol version from the Cargo/GitHub release version
  - allow unreleased `0.0.0` dev builds to bypass the minimum-version rejection with `U256::MAX`

  The Solidity ABI in this crate intentionally includes only the read surface used by nodes, not the
  full contract interface.

  ## Notes

  `CONTRACT_VARIANTS` remains explicit because it is not the same as all `BaseUpgrade` variants. It
  represents the contract-backed upgrade set in L1 schedule order and intentionally excludes non-
  contract-backed upgrades like `Bedrock` and `Zombie`.

  ## Tests

  ```sh
  cargo fmt --check -p base-upgrade-signal
  cargo test -p base-upgrade-signal --all-features
  cargo clippy -p base-upgrade-signal --all-targets --all-features -- -D warnings