### PR TITLE
[v1.2.0 backport] fix(snapshotter): use exact EL block in manifests

### DIFF
--- a/crates/infra/snapshotter/README.md
+++ b/crates/infra/snapshotter/README.md
@@ -5,11 +5,12 @@ Sidecar for generating and uploading reth node snapshots to S3-compatible storag
 ## Overview
 
 Runs alongside a Base execution layer node (base-node-reth) and orchestrates periodic snapshot
-creation. `Snapshotter` coordinates the full lifecycle: verifying the EL is at chain tip (its
-latest block is within a configurable freshness window, default 10s), stopping the CL and EL
-containers via the Docker socket, generating a snapshot manifest and chunk archives using reth's
-`SnapshotManifestCommand`, uploading all artifacts to an S3-compatible store (e.g. Cloudflare R2),
-then restarting the EL followed by the CL so it reconnects to the EL.
+creation. `Snapshotter` coordinates the full lifecycle: fetching the EL's latest block and verifying
+it is at chain tip (within a configurable freshness window, default 10s), stopping the CL and EL
+containers via the Docker socket, generating a snapshot manifest and chunk archives for the
+captured block height using reth's `SnapshotManifestCommand`, uploading all artifacts to an
+S3-compatible store (e.g. Cloudflare R2), then restarting the EL followed by the CL so it reconnects
+to the EL.
 
 If the EL is not at tip when a run begins, the snapshot is skipped and both containers are left
 running untouched.

--- a/crates/infra/snapshotter/src/config.rs
+++ b/crates/infra/snapshotter/src/config.rs
@@ -83,7 +83,10 @@ pub struct SnapshotterConfig {
     #[arg(long, default_value = "8453")]
     pub chain_id: u64,
 
-    /// Block number for the snapshot. Auto-inferred from the DB if omitted.
+    /// Block number for the snapshot. Defaults to the latest block fetched from the EL before
+    /// stopping its container.
+    ///
+    /// This override is primarily intended for manually snapshotting an earlier block.
     #[arg(long)]
     pub block: Option<u64>,
 

--- a/crates/infra/snapshotter/src/lib.rs
+++ b/crates/infra/snapshotter/src/lib.rs
@@ -20,7 +20,7 @@ mod container;
 pub use container::{ContainerManager, DockerContainerManager};
 
 mod tip;
-pub use tip::{RpcTipChecker, TipChecker};
+pub use tip::{RpcTipChecker, TipChecker, TipStatus};
 
 mod snapshot;
 pub use snapshot::{

--- a/crates/infra/snapshotter/src/orchestrator.rs
+++ b/crates/infra/snapshotter/src/orchestrator.rs
@@ -49,7 +49,7 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
 
     /// Executes the full snapshot lifecycle.
     ///
-    /// 0. Verifies the EL is at chain tip; skips the run if it is not
+    /// 0. Captures the EL's latest block and verifies it is at chain tip; skips the run if it is not
     /// 1. Stops the CL and EL containers
     /// 2. Verifies both containers are stopped
     /// 3. Generates snapshot archives
@@ -76,9 +76,9 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
         // This is acceptable for the default 10s threshold on a 2s block-time
         // chain, but callers tightening the threshold should keep this in mind.
         let threshold = Duration::from_secs(self.config.tip_threshold_secs);
-        let at_tip =
-            self.tip_checker.is_at_tip(threshold).await.context("failed to check EL tip status")?;
-        if !at_tip {
+        let tip =
+            self.tip_checker.check_tip(threshold).await.context("failed to check EL tip status")?;
+        if !tip.at_tip {
             warn!(
                 threshold_secs = self.config.tip_threshold_secs,
                 "EL is not at tip; skipping snapshot run and leaving containers running"
@@ -92,7 +92,7 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
             self.container_manager.stop(&self.config.consensus_container_name).await;
         let result = match cl_stop_result {
             Ok(()) => match self.container_manager.stop(&self.config.container_name).await {
-                Ok(()) => self.generate_and_upload().await,
+                Ok(()) => self.generate_and_upload(tip.block_number).await,
                 Err(e) => Err(e).context("failed to stop EL container"),
             },
             Err(e) => Err(e).context("failed to stop CL container"),
@@ -159,7 +159,7 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
 
     /// Generates snapshot archives and uploads them. Separated from `run` so
     /// the restart guard logic stays clean.
-    async fn generate_and_upload(&self) -> Result<()> {
+    async fn generate_and_upload(&self, latest_block: u64) -> Result<()> {
         let run_timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
 
         let run_output_dir = create_run_output_dir(&self.config.output_dir, run_timestamp)?;
@@ -191,7 +191,7 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
         let source_datadir = self.config.source_datadir.clone();
         let output_dir_for_gen = run_output_dir.clone();
         let chain_id = self.config.chain_id;
-        let block = self.config.block;
+        let block = Some(self.config.block.unwrap_or(latest_block));
         let blocks_per_file = self.config.blocks_per_file;
         let remote_for_gen = remote_static_files;
         let previous_chunk_output_files_for_gen = previous_chunk_output_files;

--- a/crates/infra/snapshotter/src/tip.rs
+++ b/crates/infra/snapshotter/src/tip.rs
@@ -9,15 +9,24 @@ use async_trait::async_trait;
 use tracing::info;
 use url::Url;
 
-/// Checks whether an execution layer node is at chain tip.
+/// Result of checking an execution layer node's latest block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TipStatus {
+    /// Number of the latest block returned by the EL.
+    pub block_number: u64,
+    /// Whether the latest block is within the configured freshness threshold.
+    pub at_tip: bool,
+}
+
+/// Checks whether an execution layer node is at chain tip and reports its block height.
 ///
 /// Abstracted behind a trait (like [`crate::ContainerManager`]) so the
 /// orchestrator can be exercised in tests without a live RPC endpoint.
 #[async_trait]
 pub trait TipChecker: Send + Sync {
-    /// Returns `true` if the EL's latest block is within `threshold` of the
-    /// current wall-clock time.
-    async fn is_at_tip(&self, threshold: Duration) -> Result<bool>;
+    /// Returns the EL's latest block number and whether it is within `threshold`
+    /// of the current wall-clock time.
+    async fn check_tip(&self, threshold: Duration) -> Result<TipStatus>;
 }
 
 /// [`TipChecker`] backed by an execution layer JSON-RPC endpoint.
@@ -39,7 +48,7 @@ impl RpcTipChecker {
 
 #[async_trait]
 impl TipChecker for RpcTipChecker {
-    async fn is_at_tip(&self, threshold: Duration) -> Result<bool> {
+    async fn check_tip(&self, threshold: Duration) -> Result<TipStatus> {
         let provider = ProviderBuilder::new()
             .disable_recommended_fillers()
             .connect(self.rpc_url.as_str())
@@ -73,6 +82,6 @@ impl TipChecker for RpcTipChecker {
             "checked EL tip status"
         );
 
-        Ok(at_tip)
+        Ok(TipStatus { block_number: block.header.number, at_tip })
     }
 }

--- a/crates/infra/snapshotter/tests/e2e_test.rs
+++ b/crates/infra/snapshotter/tests/e2e_test.rs
@@ -15,6 +15,7 @@ use async_trait::async_trait;
 use base_snapshotter::{
     ChunkedArchive, ComponentManifest, ContainerManager, DockerContainerManager,
     OutputFileChecksum, SnapshotGenerator, SnapshotManifest, SnapshotUploader, TipChecker,
+    TipStatus,
 };
 use bollard::{
     Docker,
@@ -114,8 +115,8 @@ impl MockTipChecker {
 
 #[async_trait]
 impl TipChecker for MockTipChecker {
-    async fn is_at_tip(&self, _threshold: std::time::Duration) -> Result<bool> {
-        Ok(self.at_tip)
+    async fn check_tip(&self, _threshold: std::time::Duration) -> Result<TipStatus> {
+        Ok(TipStatus { block_number: 100, at_tip: self.at_tip })
     }
 }
 
@@ -133,7 +134,7 @@ fn test_config(bucket: &str, tmp: &Path) -> base_snapshotter::SnapshotterConfig 
         bucket: bucket.to_string(),
         prefix: "test".to_string(),
         chain_id: 8453,
-        block: Some(100),
+        block: None,
         blocks_per_file: Some(500_000),
         snapshot_threads: None,
         retain_runs: NonZeroUsize::new(3).expect("retain runs should be non-zero"),


### PR DESCRIPTION
Backport of #3967 to `releases/v1.2.0`.

## Summary

- capture the EL latest block number from the existing tip check before stopping containers
- pass the captured height into snapshot manifest generation instead of inferring the end of the latest static-file chunk
- preserve `--block` as an explicit override

## Validation

- `cargo check -p base-snapshotter -p base-snapshotter-bin`
- `cargo test -p base-snapshotter --lib`