### PR TITLE
test(precompiles): add golden tests for asset V1 (BOP-423)

### DIFF
--- a/crates/common/precompiles/Cargo.toml
+++ b/crates/common/precompiles/Cargo.toml
@@ -38,6 +38,10 @@ name = "base_precompiles"
 harness = false
 required-features = ["test-utils"]
 
+[[test]]
+name = "b20_asset_v1_golden"
+required-features = ["test-utils"]
+
 [features]
 default = [ "blst", "c-kzg", "portable", "secp256k1", "std" ]
 std = [

--- a/crates/common/precompiles/tests/b20_asset_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v1_golden.rs
@@ -21,7 +21,7 @@
 //!    --test b20_asset_v1_golden -- --nocapture` and copy the printed `GOLDEN_ROOT` values.
 
 use alloy_primitives::{Address, B256, Bytes, U256, b256, keccak256};
-use alloy_sol_types::{SolCall, SolError, SolEvent, SolInterface, SolValue};
+use alloy_sol_types::{SolCall, SolError, SolEvent, SolValue};
 use base_common_genesis::BaseUpgrade;
 use base_common_precompiles::{
     Asset, AssetAccounting, AssetV1, AssetVersion, AssetVersions, B20_MAX_SUPPLY_CAP, B20AssetInit,
@@ -1734,23 +1734,158 @@ fn dispatch_reverts_when_uninitialized() {
 }
 
 // ============================================================================
-// meta: op coverage tripwire
+// meta: op coverage checklist
 // ============================================================================
 
-// Compile-time coverage tripwire.
-//
-// The dispatcher's `match` over `IB20Calls` / `IB20AssetCalls` is compiler-exhaustive,
-// so `SolInterface::COUNT` (a compile-time constant on the generated interface) is the
-// authoritative op count. Pinning it here fails the build whenever the ABI op surface
-// changes — forcing a golden case to be added above and this count bumped. Every op
-// counted here has a golden case in this suite (audited at review time).
-const _: () = {
-    assert!(
-        <IB20::IB20Calls as SolInterface>::COUNT == 50,
-        "inherited IB20 op surface changed: add golden case(s) above and update this count",
-    );
-    assert!(
-        <IB20Asset::IB20AssetCalls as SolInterface>::COUNT == 12,
-        "IB20Asset op surface changed: add golden case(s) above and update this count",
-    );
-};
+/// Compile-time coverage checklist — never called; it exists only for its two
+/// exhaustive `match`es (no `_` arm), each arm naming the golden `#[test]` fn(s) that
+/// pin the op via [`covered`].
+///
+/// This gives two compile-time guarantees:
+///   * add an op to the ABI (a new `IB20Calls` / `IB20AssetCalls` variant) → the
+///     wildcard-free match fails to build until an arm (and thus a golden) is added;
+///   * rename or remove a golden `#[test]` fn → the `covered(&[...])` reference fails
+///     to build.
+///
+/// Because Asset V1 is **frozen**, this checklist is NOT expected to ever be updated:
+/// a compile error here means the frozen V1 op surface changed, which must be reviewed.
+#[allow(dead_code)]
+fn v1_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Asset::IB20AssetCalls) {
+    use IB20::IB20Calls as C;
+    use IB20Asset::IB20AssetCalls as SC;
+
+    // No-op: forces each arm to name real golden `#[test]` fns by path.
+    fn covered(_goldens: &[fn()]) {}
+
+    match call {
+        // ERC-20 core
+        C::transfer(_) => covered(&[
+            golden_transfer_privileged,
+            golden_transfer_unprivileged_allowed,
+            golden_transfer_unprivileged_blocked_sender_reverts,
+            golden_transfer_reverts_zero_receiver,
+            golden_transfer_reverts_insufficient_balance,
+            golden_transfer_reverts_when_paused,
+        ]),
+        C::transferFrom(_) => covered(&[
+            golden_transfer_from_finite_allowance_decrements,
+            golden_transfer_from_infinite_allowance_not_decremented,
+            golden_transfer_from_reverts_insufficient_allowance,
+            golden_transfer_from_unprivileged_enforces_executor_policy,
+        ]),
+        C::approve(_) => {
+            covered(&[golden_approve_sets_allowance_and_emits, golden_approve_reverts_zero_spender])
+        }
+        C::transferWithMemo(_) => covered(&[golden_transfer_with_memo_emits_transfer_then_memo]),
+        C::transferFromWithMemo(_) => covered(&[golden_transfer_from_with_memo]),
+
+        // mint / burn
+        C::mint(_) => covered(&[
+            golden_mint_privileged_still_enforces_receiver_policy,
+            golden_mint_unprivileged_requires_role_and_policy,
+            golden_mint_reverts_over_supply_cap,
+        ]),
+        C::mintWithMemo(_) => covered(&[golden_mint_with_memo]),
+        C::burn(_) => covered(&[golden_burn_requires_role_then_reduces_supply]),
+        C::burnWithMemo(_) => covered(&[golden_burn_with_memo]),
+        C::burnBlocked(_) => covered(&[
+            golden_burn_blocked_destroys_from_blocked_account,
+            golden_burn_blocked_reverts_when_not_blocked,
+        ]),
+
+        // pause / config / roles / policy / permit
+        C::pause(_) => covered(&[
+            golden_pause_sets_feature_bit,
+            golden_pause_reverts_empty_feature_set,
+            golden_pause_unprivileged_requires_role,
+        ]),
+        C::unpause(_) => covered(&[golden_unpause_clears_feature_bit]),
+        C::updateSupplyCap(_) => {
+            covered(&[golden_update_supply_cap, golden_update_supply_cap_reverts_below_supply])
+        }
+        C::updateName(_) => covered(&[golden_update_name_emits_name_and_domain_changed]),
+        C::updateSymbol(_) => covered(&[golden_update_symbol]),
+        C::updateContractURI(_) => covered(&[golden_update_contract_uri]),
+        C::grantRole(_) => covered(&[golden_grant_role]),
+        C::revokeRole(_) => covered(&[golden_revoke_role, golden_revoke_last_admin_rejected]),
+        C::renounceRole(_) => {
+            covered(&[golden_renounce_role, golden_renounce_role_bad_confirmation])
+        }
+        C::renounceLastAdmin(_) => {
+            covered(&[golden_renounce_last_admin, golden_renounce_last_admin_reverts_when_not_sole])
+        }
+        C::setRoleAdmin(_) => covered(&[golden_set_role_admin]),
+        C::updatePolicy(_) => {
+            covered(&[golden_update_policy, golden_update_policy_reverts_missing_policy])
+        }
+        C::permit(_) => covered(&[
+            golden_permit_sets_allowance_and_increments_nonce,
+            golden_permit_reverts_when_expired,
+        ]),
+
+        // computed reads
+        C::isPaused(_) | C::pausedFeatures(_) => {
+            covered(&[golden_read_is_paused_and_paused_features])
+        }
+        C::policyId(_) => covered(&[golden_read_policy_id_and_unsupported_scope]),
+        C::DOMAIN_SEPARATOR(_) => covered(&[golden_read_domain_separator]),
+        C::eip712Domain(_) => covered(&[golden_read_eip712_domain]),
+
+        // direct reads
+        C::name(_)
+        | C::symbol(_)
+        | C::decimals(_)
+        | C::totalSupply(_)
+        | C::balanceOf(_)
+        | C::allowance(_)
+        | C::supplyCap(_)
+        | C::nonces(_)
+        | C::contractURI(_)
+        | C::hasRole(_)
+        | C::getRoleAdmin(_) => covered(&[golden_read_metadata_and_supply]),
+
+        // role / policy-id constants
+        C::DEFAULT_ADMIN_ROLE(_)
+        | C::MINT_ROLE(_)
+        | C::BURN_ROLE(_)
+        | C::BURN_BLOCKED_ROLE(_)
+        | C::PAUSE_ROLE(_)
+        | C::UNPAUSE_ROLE(_)
+        | C::METADATA_ROLE(_)
+        | C::TRANSFER_SENDER_POLICY(_)
+        | C::TRANSFER_RECEIVER_POLICY(_)
+        | C::TRANSFER_EXECUTOR_POLICY(_)
+        | C::MINT_RECEIVER_POLICY(_) => covered(&[golden_read_role_and_policy_constants]),
+    }
+
+    match ext {
+        SC::OPERATOR_ROLE(_)
+        | SC::WAD_PRECISION(_)
+        | SC::multiplier(_)
+        | SC::extraMetadata(_)
+        | SC::isAnnouncementIdUsed(_) => covered(&[golden_read_asset_constants_and_multiplier]),
+        SC::toScaledBalance(_) | SC::toRawBalance(_) | SC::scaledBalanceOf(_) => {
+            covered(&[golden_read_scaled_balances_with_multiplier])
+        }
+        SC::updateMultiplier(_) => covered(&[
+            golden_update_multiplier,
+            golden_update_multiplier_requires_operator_role,
+            golden_update_multiplier_rejects_zero,
+        ]),
+        SC::batchMint(_) => covered(&[
+            golden_batch_mint,
+            golden_batch_mint_reverts_length_mismatch,
+            golden_batch_mint_reverts_empty_batch,
+        ]),
+        SC::updateExtraMetadata(_) => {
+            covered(&[golden_update_extra_metadata, golden_update_extra_metadata_rejects_empty_key])
+        }
+        SC::announce(_) => covered(&[
+            golden_announce_runs_internal_calls_and_brackets_events,
+            golden_announce_reverts_on_reused_id,
+            golden_announce_reverts_on_nested_announce,
+            golden_announce_wraps_failing_internal_call,
+            golden_announce_reverts_on_malformed_internal_call,
+        ]),
+    }
+}

--- a/crates/common/precompiles/tests/b20_asset_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v1_golden.rs
@@ -28,6 +28,7 @@ use base_common_precompiles::{
     B20AssetStorage, B20AssetToken, B20PolicyType, B20TokenRole, IB20, IB20Asset, InMemoryPolicy,
     NoopPrecompileCallObserver, PermitArgs, TokenAccounting,
 };
+use base_common_precompiles::{IB20::IB20Calls as C, IB20Asset::IB20AssetCalls as SC};
 use base_precompile_storage::{BasePrecompileError, HashMapStorageProvider, StorageCtx};
 use k256::ecdsa::SigningKey;
 
@@ -2516,9 +2517,6 @@ fn golden_gas_footprints() {
 /// a compile error here means the frozen V1 op surface changed, which must be reviewed.
 #[allow(dead_code)]
 fn v1_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Asset::IB20AssetCalls) {
-    use IB20::IB20Calls as C;
-    use IB20Asset::IB20AssetCalls as SC;
-
     // No-op: forces each arm to name real golden `#[test]` fns by path.
     fn covered(_goldens: &[fn()]) {}
 

--- a/crates/common/precompiles/tests/b20_asset_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v1_golden.rs
@@ -20,7 +20,7 @@
 //! `BLESS_GOLDEN=1 cargo test -p base-common-precompiles --features test-utils \
 //!    --test b20_asset_v1_golden -- --nocapture` and copy the printed `GOLDEN_ROOT` values.
 
-use alloy_primitives::{Address, B256, Bytes, U256, b256, keccak256};
+use alloy_primitives::{Address, B256, Bytes, LogData, U256, b256, keccak256};
 use alloy_sol_types::{SolCall, SolError, SolEvent, SolValue};
 use base_common_genesis::BaseUpgrade;
 use base_common_precompiles::{
@@ -59,68 +59,68 @@ const PRIVATE_KEY: [u8; 32] =
 
 const ROOT_FRESH: B256 = b256!("ecd76a0f8f4f5c3d735866149f7ff14fd5df8dc68f646d16f57985b13aaceeda");
 const ROOT_TRANSFER_PRIV: B256 =
-    b256!("96136372a76712e6d2b146058285317ecbfe4ed254edfa9027cceb76b6f48c62");
+    b256!("bd55f18f8eb0aff72d53288be7c9c7bb8d9f21f938b4fa70f5bb64679eff1235");
 const ROOT_TRANSFER_UNPRIV: B256 =
-    b256!("481488b45b52011f054573a761b0bd97e30328f286acf8da4853478f8b7345bc");
+    b256!("4e4bed68e9a048e18f0f74a689dc9349dde084ff280aaeb7af62a3a08bb444e7");
 const ROOT_TRANSFER_WITH_MEMO: B256 =
-    b256!("96136372a76712e6d2b146058285317ecbfe4ed254edfa9027cceb76b6f48c62");
+    b256!("77694c1634ce0f20315fa6f8ae798a150e4762a39e3d1f76fe71dfac86c13a1f");
 const ROOT_TRANSFER_FROM_FINITE: B256 =
-    b256!("2cd788a8aff3e96627ea1d461f7c35af8064e09491e4a8f4332de3de001e6d15");
+    b256!("930f9451df79bdb8f93ced37a0cc1150e33023cdf12880d98c7cdb8125e84c97");
 const ROOT_TRANSFER_FROM_INFINITE: B256 =
-    b256!("863cfb8676e127c8a26f595029bb78ba24914925bc064275fb659b69fe882cd8");
+    b256!("c46b2107a45a3316224ff2ddaf5cf7d21cef77c1edc81e773007155fbd712ea2");
 const ROOT_TRANSFER_FROM_WITH_MEMO: B256 =
-    b256!("40faf2e88c394b7f0de368b3e7bb9040b4ba8be83e482ec04be05da65739f275");
+    b256!("d63918245e6c33af1d37d212bbedd02ef0942ed779759d44a9323087a394df98");
 const ROOT_APPROVE: B256 =
-    b256!("da80ed7616e0890f42d85f49c7aabced174bafb7a0a019c76432ba855ec8b185");
+    b256!("457affc6597cc95beaff5de5e4803ffa95094d5204ffcd791b5130dcad9922bc");
 const ROOT_MINT_PRIV: B256 =
-    b256!("4e1ee427e3c44b48a6f87b7a49c2c770fcb75e2d2adbfbe4e590940a2066fdbd");
+    b256!("567e558c4f349d16ad67942738e26e4e791b955226842560b80faa491d9ed4f7");
 const ROOT_MINT_UNPRIV: B256 =
-    b256!("9f2dc6d3b0f77e513ea7c500bb3b08235efcd95254bdcbb1058f29382b4646a0");
+    b256!("0afb28dd855b7e7bb1f3b75303e231795a61246504a9a79775853d4d038f7027");
 const ROOT_MINT_WITH_MEMO: B256 =
-    b256!("54c114db87fb17d73e11b586fc68c213841f947675eee2d18afbf712eddb0e2c");
-const ROOT_BURN: B256 = b256!("44d6f01a44eaf4649175dca71b8c7e361ae6b63206c3fbb60a8e1dddc4ad2564");
+    b256!("c2fd04e62d5be7071fc051204c4472a92ad0a5ff2794d1ea4962485cd9dadcd8");
+const ROOT_BURN: B256 = b256!("85cee0ea4d722ce67f83150ffcafbf23fb3045c90f5043b2764f3ed91daefafb");
 const ROOT_BURN_WITH_MEMO: B256 =
-    b256!("44d6f01a44eaf4649175dca71b8c7e361ae6b63206c3fbb60a8e1dddc4ad2564");
+    b256!("bdcac1ddc9013662761b897ff953d954bafdab086181e0a6965ae5f1ee9d9ae2");
 const ROOT_BURN_BLOCKED: B256 =
-    b256!("177e7b581f34fe13c680fbd3006195c47476eb7c00ac83c6ae05f823254be604");
-const ROOT_PAUSE: B256 = b256!("5db18b351d26832b17e7c5e087e839d7b1c3f33ea940271790eff58aa9754eb6");
+    b256!("10e525753a1265dd9353af53544b8f8e1233b3e4427d3a378d9c3eaabf189c36");
+const ROOT_PAUSE: B256 = b256!("f15abadf64611e38c13be8e860612264ffb7df782719ff33a702a6cf6c70f4b6");
 const ROOT_UNPAUSE: B256 =
-    b256!("1b2266695094856d8d6ba8c3bfb4ddad06eb62e2e84f7a0b7aad73d7ced77c8b");
+    b256!("13854daf203d625a639412c6a0db8a790a9a73a778ae774f6de9f3e5348368ac");
 const ROOT_UPDATE_SUPPLY_CAP: B256 =
-    b256!("c015947401c254de0048d23829260de53f8336e931303f6a834cfbadbc26cadf");
+    b256!("8cb7e9658b49d9d55d09cac6651beed064078ddf981f5ecf349a166e981f1d61");
 const ROOT_UPDATE_NAME: B256 =
-    b256!("b85866e5c928bb1bc3bd6a1a37997e810b8f12a4f954ffa8be864201e768d408");
+    b256!("8aa174b0a6507c67bf8400a540505cd9a1c9a44da27ec05444bef3917fe36a78");
 const ROOT_UPDATE_SYMBOL: B256 =
-    b256!("4ceb55698e686f56e42acd2b520aa11d3a721fffad18b2c84b919d845b8ea05c");
+    b256!("b2d90d93686822cfe668f3d81e17de3f3c5d5669490bbc18fd3b38a3ead418a7");
 const ROOT_UPDATE_CONTRACT_URI: B256 =
-    b256!("105a00417a775dc6952d888da191665eea83bc0da04055ec399b23e0af4b784f");
+    b256!("65c9f8d814cfbafa23dddcd943a319b201828166383472ea0ede7980c9d5c974");
 const ROOT_GRANT_ROLE: B256 =
-    b256!("466d162a8569f3ed273ea3689aff08281147acafe9880be40875abaa2f23da01");
+    b256!("8f961185963d121cc90a6f26f7f2c1d7471f0dcf8c4f6992488ff0f60c5bddcf");
 const ROOT_REVOKE_ROLE: B256 =
-    b256!("e02df46d329afcff5fe3d109b3a33184cdf8d87811bceb9c409014deb2f3f6e8");
+    b256!("b7ec0c7336c431b45f81cc4b0015e16d26c62fb6659b7d0c157bed92533ba8ad");
 const ROOT_RENOUNCE_ROLE: B256 =
-    b256!("e02df46d329afcff5fe3d109b3a33184cdf8d87811bceb9c409014deb2f3f6e8");
+    b256!("96e3d3f6b7afad034bc17652d89d434e9e24eb9a6c45fefe086e022d7e63316a");
 const ROOT_RENOUNCE_LAST_ADMIN: B256 =
-    b256!("bd0a4b40f729d855f33e56d59ab7d54caa9c17309b09283dd97a8adcfeb06bea");
+    b256!("398d33be3d71a30d908b12aa086801f1f38a73bc5b69eb8798320e37849b73e0");
 const ROOT_SET_ROLE_ADMIN: B256 =
-    b256!("29e24a05fe68557c945411e65b7a8b4fe28e6c3a0ea9a3ffd6c1b4ad4b4f83ff");
+    b256!("a5d4520fbef2745695430cc687f32276cf81633f063f68fbdd9e17d996015368");
 const ROOT_UPDATE_POLICY: B256 =
-    b256!("2930532eb1606d19001dd17bbd6a48d00ec12fe72a1e6ae50ca00ea314b05b3b");
-const ROOT_PERMIT: B256 = b256!("65cdbfcff466d847e7360f1d72ca45be64356af1e77eea83533faf425966e836");
+    b256!("631687761415ff5034f80d3e6d029854f75dfece34cf9bbb2929fb76be79a343");
+const ROOT_PERMIT: B256 = b256!("11cf56d1d65755ac20e8db15c67056a0597cc8870e598629683e929f2ec40b66");
 const ROOT_UPDATE_MULTIPLIER: B256 =
-    b256!("46294ac17788ce1755c5f9504a08af0c1d0689fc2bfb739032cbb335a9d9d904");
+    b256!("80cba89b0ac378b954dd622f35ed3c0a66c2067d8e03ab822c919f932741f9c9");
 const ROOT_UPDATE_EXTRA_METADATA: B256 =
-    b256!("4e461dd1b6f3383297f97e4d19848fd5484b7adb5adc780d721d149805fac16a");
+    b256!("5e3b7da0cdd4193e4f3c46702560b7a0c7d549b6f94fed71de101953b46a7244");
 const ROOT_BATCH_MINT: B256 =
-    b256!("abeeb4354269e4994a293dc1decc3c33a61c566f8d8b8479a018c8a03bd744b0");
+    b256!("c58dd84264e3bdf4fed1ecb91a83d23c18d0030f9776e0225d416944373215b8");
 const ROOT_ANNOUNCE: B256 =
-    b256!("18badab132a0ba9de303e277d69816df82091fdc024322ea600bdbd3a6147068");
+    b256!("439f65ccf6b663f2e3e014084049f40d831fca102fcb0683a3efa05df240a193");
 const ROOT_GRANT_DEFAULT_ADMIN: B256 =
-    b256!("df78d6e3c794391187702ecd8f74b31c027363c342984bb972e7583b69a03f2f");
+    b256!("e0a76929f30db7c62da21ffc2ff780869b29c9a656157e42a9374f82d222dd29");
 const ROOT_GRANT_IDEMPOTENT: B256 =
     b256!("39658b6dcaf82dc5e146d5d44fed26ba96b03220e92aa1fe9bd7cecb23437e22");
 const ROOT_GRANT_UNCHECKED: B256 =
-    b256!("6cdfdb30b62a059f71f67cec831aa1e1ddc44750e483bcd02c641b030cc4b8f4");
+    b256!("62b96b5458bad3edc693aad2f51c79f1f9de3102454cec8581351a43ff169b25");
 
 // --- harness ----------------------------------------------------------------
 
@@ -210,13 +210,23 @@ fn last_topic0(storage: &HashMapStorageProvider) -> B256 {
     storage.get_events(TOKEN).last().expect("an emitted event").topics()[0]
 }
 
-/// Deterministic keccak hash over the sorted `(address, slot, value)` storage triples.
+/// Deterministic keccak hash of the per-case snapshot: the token's emitted events
+/// (topics + data) followed by its sorted `(address, slot, value)` storage triples.
 ///
-/// This is a plain content hash of the KV pairs, not an MPT state root.
+/// A plain content hash (not an MPT state root). Events are included so a regression in
+/// an event's payload — indexed args or data not otherwise reflected in storage, e.g. a
+/// `Memo`'s bytes — is pinned here even though logs are not storage.
 fn hash_state(storage: HashMapStorageProvider) -> B256 {
+    let events: Vec<LogData> = storage.get_events(TOKEN).clone();
     let mut triples: Vec<(Address, U256, U256)> = storage.into_storage().collect();
     triples.sort();
-    let mut buf = Vec::with_capacity(triples.len() * 84);
+    let mut buf = Vec::with_capacity(triples.len() * 84 + events.len() * 64);
+    for log in &events {
+        for topic in log.topics() {
+            buf.extend_from_slice(topic.as_slice());
+        }
+        buf.extend_from_slice(&log.data);
+    }
     for (addr, slot, value) in triples {
         buf.extend_from_slice(addr.as_slice());
         buf.extend_from_slice(&slot.to_be_bytes::<32>());
@@ -229,7 +239,7 @@ fn hash_state(storage: HashMapStorageProvider) -> B256 {
 #[track_caller]
 fn assert_root(label: &str, storage: HashMapStorageProvider, expected: B256) {
     let got = hash_state(storage);
-    if std::env::var_os("BLESS_GOLDEN").is_some() {
+    if std::env::var("BLESS_GOLDEN").ok().as_deref() == Some("1") {
         println!("GOLDEN_ROOT {label} = {got:#x}");
         return;
     }
@@ -2490,7 +2500,7 @@ fn golden_gas_footprints() {
         ("announce", (1, 2, 0)),
     ];
 
-    if std::env::var_os("BLESS_GOLDEN").is_some() {
+    if std::env::var("BLESS_GOLDEN").ok().as_deref() == Some("1") {
         for (label, counts) in &actual {
             println!("GAS {label} = {counts:?}");
         }

--- a/crates/common/precompiles/tests/b20_asset_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v1_golden.rs
@@ -2216,6 +2216,289 @@ fn golden_grant_role_unchecked_bootstraps_first_admin() {
 }
 
 // ============================================================================
+// gas: storage-access footprint per op
+// ============================================================================
+//
+// `gas_deducted` is 0 under the test gas schedule, so we pin the deterministic,
+// schedule-independent signal instead: the SLOAD / SSTORE / KECCAK256 op counts a
+// call performs. These are the storage-access footprint that drives real gas, so a
+// change here (e.g. an extra SLOAD in V1) is caught even when bytes/state/events match.
+
+/// Runs `calldata` privileged after `setup`, returning `(sload, sstore, keccak256)` counts.
+fn gas(
+    setup: impl FnOnce(&mut B20AssetStorage<'_>),
+    caller: Address,
+    policy: InMemoryPolicy,
+    calldata: Vec<u8>,
+) -> (u64, u64, u64) {
+    let mut s = fresh();
+    seed(&mut s, setup);
+    s.set_caller(caller);
+    s.reset_counters();
+    StorageCtx::enter(&mut s, |ctx| {
+        B20AssetToken::with_storage_and_policy(B20AssetStorage::from_address(TOKEN, ctx), policy)
+            .inner_with_privilege(ctx, &calldata, true)
+    })
+    .expect("gas-footprint op must succeed");
+    (s.counter_sload(), s.counter_sstore(), s.counter_keccak256())
+}
+
+/// An `InMemoryPolicy` authorizing `who` under the default (0) scope.
+fn allow0(who: Address) -> InMemoryPolicy {
+    let mut p = InMemoryPolicy::new();
+    p.allow(0, who);
+    p
+}
+
+#[test]
+fn golden_gas_footprints() {
+    let announce_internal =
+        Bytes::from(IB20Asset::updateMultiplierCall { newMultiplier: wad() * u(2) }.abi_encode());
+    let actual: Vec<(&str, (u64, u64, u64))> = vec![
+        (
+            "transfer",
+            gas(
+                |t| fund(t, ALICE, u(100)),
+                ALICE,
+                InMemoryPolicy::new(),
+                IB20::transferCall { to: BOB, amount: u(30) }.abi_encode(),
+            ),
+        ),
+        (
+            "transfer_from",
+            gas(
+                |t| {
+                    fund(t, ALICE, u(100));
+                    t.set_allowance(ALICE, BOB, u(40)).unwrap();
+                },
+                BOB,
+                InMemoryPolicy::new(),
+                IB20::transferFromCall { from: ALICE, to: BOB, amount: u(30) }.abi_encode(),
+            ),
+        ),
+        (
+            "approve",
+            gas(
+                |_t| {},
+                ALICE,
+                InMemoryPolicy::new(),
+                IB20::approveCall { spender: BOB, amount: u(50) }.abi_encode(),
+            ),
+        ),
+        (
+            "mint",
+            gas(
+                |_t| {},
+                ADMIN,
+                allow0(BOB),
+                IB20::mintCall { to: BOB, amount: u(100) }.abi_encode(),
+            ),
+        ),
+        (
+            "burn",
+            gas(
+                |t| {
+                    fund(t, ALICE, u(100));
+                    give_role(t, B20TokenRole::Burn.id(), ALICE);
+                },
+                ALICE,
+                InMemoryPolicy::new(),
+                IB20::burnCall { amount: u(40) }.abi_encode(),
+            ),
+        ),
+        (
+            "burn_blocked",
+            gas(
+                |t| {
+                    fund(t, ALICE, u(100));
+                    t.set_policy_id(B20PolicyType::TransferSender.id(), POLICY_ID).unwrap();
+                },
+                ADMIN,
+                InMemoryPolicy::new(),
+                IB20::burnBlockedCall { from: ALICE, amount: u(40) }.abi_encode(),
+            ),
+        ),
+        (
+            "pause",
+            gas(
+                |_t| {},
+                ADMIN,
+                InMemoryPolicy::new(),
+                IB20::pauseCall { features: vec![IB20::PausableFeature::MINT] }.abi_encode(),
+            ),
+        ),
+        (
+            "unpause",
+            gas(
+                |_t| {},
+                ADMIN,
+                InMemoryPolicy::new(),
+                IB20::unpauseCall { features: vec![IB20::PausableFeature::MINT] }.abi_encode(),
+            ),
+        ),
+        (
+            "update_supply_cap",
+            gas(
+                |_t| {},
+                ADMIN,
+                InMemoryPolicy::new(),
+                IB20::updateSupplyCapCall { newSupplyCap: u(1_000) }.abi_encode(),
+            ),
+        ),
+        (
+            "update_name",
+            gas(
+                |_t| {},
+                ADMIN,
+                InMemoryPolicy::new(),
+                IB20::updateNameCall { newName: "New Name".into() }.abi_encode(),
+            ),
+        ),
+        (
+            "update_symbol",
+            gas(
+                |_t| {},
+                ADMIN,
+                InMemoryPolicy::new(),
+                IB20::updateSymbolCall { newSymbol: "RWX".into() }.abi_encode(),
+            ),
+        ),
+        (
+            "update_contract_uri",
+            gas(
+                |_t| {},
+                ADMIN,
+                InMemoryPolicy::new(),
+                IB20::updateContractURICall { newURI: "ipfs://x".into() }.abi_encode(),
+            ),
+        ),
+        (
+            "grant_role",
+            gas(
+                |_t| {},
+                ADMIN,
+                InMemoryPolicy::new(),
+                IB20::grantRoleCall { role: B20TokenRole::Mint.id(), account: ALICE }.abi_encode(),
+            ),
+        ),
+        (
+            "revoke_role",
+            gas(
+                |t| give_role(t, B20TokenRole::Mint.id(), ALICE),
+                ADMIN,
+                InMemoryPolicy::new(),
+                IB20::revokeRoleCall { role: B20TokenRole::Mint.id(), account: ALICE }.abi_encode(),
+            ),
+        ),
+        (
+            "set_role_admin",
+            gas(
+                |_t| {},
+                ADMIN,
+                InMemoryPolicy::new(),
+                IB20::setRoleAdminCall {
+                    role: B20TokenRole::Mint.id(),
+                    newAdminRole: B20TokenRole::Metadata.id(),
+                }
+                .abi_encode(),
+            ),
+        ),
+        (
+            "update_policy",
+            gas(
+                |_t| {},
+                ADMIN,
+                {
+                    let mut p = InMemoryPolicy::new();
+                    p.create_existing_policy(7);
+                    p
+                },
+                IB20::updatePolicyCall {
+                    policyScope: B20PolicyType::TransferSender.id(),
+                    newPolicyId: 7,
+                }
+                .abi_encode(),
+            ),
+        ),
+        (
+            "update_multiplier",
+            gas(
+                |_t| {},
+                ADMIN,
+                InMemoryPolicy::new(),
+                IB20Asset::updateMultiplierCall { newMultiplier: wad() * u(2) }.abi_encode(),
+            ),
+        ),
+        (
+            "update_extra_metadata",
+            gas(
+                |_t| {},
+                ADMIN,
+                InMemoryPolicy::new(),
+                IB20Asset::updateExtraMetadataCall { key: "category".into(), value: "fund".into() }
+                    .abi_encode(),
+            ),
+        ),
+        (
+            "batch_mint",
+            gas(
+                |_t| {},
+                ADMIN,
+                allow0(BOB),
+                IB20Asset::batchMintCall { recipients: vec![BOB], amounts: vec![u(100)] }
+                    .abi_encode(),
+            ),
+        ),
+        (
+            "announce",
+            gas(
+                |_t| {},
+                ADMIN,
+                InMemoryPolicy::new(),
+                IB20Asset::announceCall {
+                    internalCalls: vec![announce_internal],
+                    id: "g".into(),
+                    description: String::new(),
+                    uri: String::new(),
+                }
+                .abi_encode(),
+            ),
+        ),
+    ];
+
+    let expected: &[(&str, (u64, u64, u64))] = &[
+        ("transfer", (3, 2, 0)),
+        ("transfer_from", (4, 3, 0)),
+        ("approve", (0, 1, 0)),
+        ("mint", (5, 2, 0)),
+        ("burn", (4, 2, 0)),
+        ("burn_blocked", (4, 2, 0)),
+        ("pause", (1, 1, 0)),
+        ("unpause", (1, 1, 0)),
+        ("update_supply_cap", (2, 1, 0)),
+        ("update_name", (0, 1, 0)),
+        ("update_symbol", (0, 1, 0)),
+        ("update_contract_uri", (0, 1, 0)),
+        ("grant_role", (1, 1, 0)),
+        ("revoke_role", (1, 1, 0)),
+        ("set_role_admin", (1, 1, 0)),
+        ("update_policy", (2, 1, 0)),
+        ("update_multiplier", (0, 1, 0)),
+        ("update_extra_metadata", (0, 1, 0)),
+        ("batch_mint", (6, 2, 0)),
+        ("announce", (1, 2, 0)),
+    ];
+
+    if std::env::var_os("BLESS_GOLDEN").is_some() {
+        for (label, counts) in &actual {
+            println!("GAS {label} = {counts:?}");
+        }
+        return;
+    }
+    assert_eq!(actual, expected, "storage-access footprint (sload, sstore, keccak256) drift");
+}
+
+// ============================================================================
 // meta: op coverage checklist
 // ============================================================================
 

--- a/crates/common/precompiles/tests/b20_asset_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v1_golden.rs
@@ -1732,3 +1732,46 @@ fn dispatch_reverts_when_uninitialized() {
     assert!(out.is_revert());
     assert!(out.bytes.is_empty());
 }
+
+// ============================================================================
+// meta: op coverage guard
+// ============================================================================
+
+/// Extracts op identifiers from `C::<op>(` / `SC::<op>(` dispatch match arms.
+///
+/// The dispatcher's `match` over `IB20Calls` / `IB20AssetCalls` is a
+/// compiler-exhaustive list of every routable op, so this is the authoritative
+/// method surface.
+fn dispatch_ops(src: &str) -> std::collections::BTreeSet<String> {
+    let mut ops = std::collections::BTreeSet::new();
+    for (idx, _) in src.match_indices("C::") {
+        let rest = &src[idx + "C::".len()..];
+        let ident: String =
+            rest.chars().take_while(|c| c.is_ascii_alphanumeric() || *c == '_').collect();
+        if !ident.is_empty() && rest[ident.len()..].starts_with('(') {
+            ops.insert(ident);
+        }
+    }
+    ops
+}
+
+/// Meta-coverage guard: every op the dispatcher routes must be constructed by at
+/// least one golden case above. Fails if a new op is wired into `dispatch.rs`
+/// without a corresponding golden case in this suite.
+#[test]
+fn every_dispatch_op_has_a_golden_case() {
+    const DISPATCH: &str = include_str!("../src/b20_asset/dispatch.rs");
+    const SUITE: &str = include_str!("b20_asset_v1_golden.rs");
+
+    let ops = dispatch_ops(DISPATCH);
+    assert!(
+        ops.len() >= 40,
+        "parser found too few dispatch ops ({}) — did the format change?",
+        ops.len()
+    );
+
+    // Golden cases construct each op as `IB20::<op>Call` / `IB20Asset::<op>Call`.
+    let missing: Vec<&String> =
+        ops.iter().filter(|op| !SUITE.contains(&format!("::{op}Call"))).collect();
+    assert!(missing.is_empty(), "dispatch ops with no golden case: {missing:?}");
+}

--- a/crates/common/precompiles/tests/b20_asset_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v1_golden.rs
@@ -25,10 +25,10 @@ use alloy_sol_types::{SolCall, SolError, SolEvent, SolValue};
 use base_common_genesis::BaseUpgrade;
 use base_common_precompiles::{
     Asset, AssetAccounting, AssetV1, AssetVersion, AssetVersions, B20_MAX_SUPPLY_CAP, B20AssetInit,
-    B20AssetStorage, B20AssetToken, B20PolicyType, B20TokenRole, IB20, IB20Asset, InMemoryPolicy,
-    NoopPrecompileCallObserver, PermitArgs, TokenAccounting,
+    B20AssetStorage, B20AssetToken, B20PolicyType, B20TokenRole, IB20, IB20::IB20Calls as C,
+    IB20Asset, IB20Asset::IB20AssetCalls as SC, InMemoryPolicy, NoopPrecompileCallObserver,
+    PermitArgs, TokenAccounting,
 };
-use base_common_precompiles::{IB20::IB20Calls as C, IB20Asset::IB20AssetCalls as SC};
 use base_precompile_storage::{BasePrecompileError, HashMapStorageProvider, StorageCtx};
 use k256::ecdsa::SigningKey;
 

--- a/crates/common/precompiles/tests/b20_asset_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v1_golden.rs
@@ -7,7 +7,7 @@
 //!   1. exact returned ABI bytes (or the typed revert),
 //!   2. resulting state (balances / supply / roles / allowances / multiplier / metadata / storage),
 //!   3. emitted events, and
-//!   4. a per-case keccak storage **state-root** snapshot (the frozen-manifest baseline).
+//!   4. a per-case keccak storage **hash** snapshot (the frozen-manifest baseline).
 //!
 //! Beyond the shared B-20 surface this also pins the asset-specific ops: `updateMultiplier`,
 //! `updateExtraMetadata`, `batchMint`, `announce` (incl. its internal-call loop), and the
@@ -16,7 +16,7 @@
 //! Privileged behavior is exercised via `inner_with_privilege`; the guard envelope
 //! (nonpayable / uninitialized / pre-Beryl) via the full `dispatch_with_observer`.
 //!
-//! ## Blessing state-roots
+//! ## Blessing storage hashes
 //! `BLESS_GOLDEN=1 cargo test -p base-common-precompiles --features test-utils \
 //!    --test b20_asset_v1_golden -- --nocapture` and copy the printed `GOLDEN_ROOT` values.
 
@@ -54,7 +54,7 @@ const POLICY_ID: u64 = 7;
 const PRIVATE_KEY: [u8; 32] =
     alloy_primitives::hex!("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80");
 
-// --- pinned state-roots (bless with BLESS_GOLDEN=1; see module docs) --------
+// --- pinned storage hashes (bless with BLESS_GOLDEN=1; see module docs) --------
 
 const ROOT_FRESH: B256 = b256!("ecd76a0f8f4f5c3d735866149f7ff14fd5df8dc68f646d16f57985b13aaceeda");
 const ROOT_TRANSFER_PRIV: B256 =
@@ -203,8 +203,10 @@ fn last_topic0(storage: &HashMapStorageProvider) -> B256 {
     storage.get_events(TOKEN).last().expect("an emitted event").topics()[0]
 }
 
-/// Deterministic keccak state-root over the sorted `(address, slot, value)` storage triples.
-fn state_root(storage: HashMapStorageProvider) -> B256 {
+/// Deterministic keccak hash over the sorted `(address, slot, value)` storage triples.
+///
+/// This is a plain content hash of the KV pairs, not an MPT state root.
+fn hash_state(storage: HashMapStorageProvider) -> B256 {
     let mut triples: Vec<(Address, U256, U256)> = storage.into_storage().collect();
     triples.sort();
     let mut buf = Vec::with_capacity(triples.len() * 84);
@@ -216,15 +218,15 @@ fn state_root(storage: HashMapStorageProvider) -> B256 {
     keccak256(&buf)
 }
 
-/// Asserts the storage state-root, or prints it under `BLESS_GOLDEN` for (re)pinning.
+/// Asserts the storage hash, or prints it under `BLESS_GOLDEN` for (re)pinning.
 #[track_caller]
 fn assert_root(label: &str, storage: HashMapStorageProvider, expected: B256) {
-    let got = state_root(storage);
+    let got = hash_state(storage);
     if std::env::var_os("BLESS_GOLDEN").is_some() {
         println!("GOLDEN_ROOT {label} = {got:#x}");
         return;
     }
-    assert_eq!(got, expected, "V1 storage state-root drift for `{label}`");
+    assert_eq!(got, expected, "V1 storage hash drift for `{label}`");
 }
 
 /// Grants `role` to `who` and bumps the role member count (setup only).

--- a/crates/common/precompiles/tests/b20_asset_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v1_golden.rs
@@ -21,7 +21,7 @@
 //!    --test b20_asset_v1_golden -- --nocapture` and copy the printed `GOLDEN_ROOT` values.
 
 use alloy_primitives::{Address, B256, Bytes, U256, b256, keccak256};
-use alloy_sol_types::{SolCall, SolError, SolEvent, SolValue};
+use alloy_sol_types::{SolCall, SolError, SolEvent, SolInterface, SolValue};
 use base_common_genesis::BaseUpgrade;
 use base_common_precompiles::{
     Asset, AssetAccounting, AssetV1, AssetVersion, AssetVersions, B20_MAX_SUPPLY_CAP, B20AssetInit,
@@ -1734,44 +1734,23 @@ fn dispatch_reverts_when_uninitialized() {
 }
 
 // ============================================================================
-// meta: op coverage guard
+// meta: op coverage tripwire
 // ============================================================================
 
-/// Extracts op identifiers from `C::<op>(` / `SC::<op>(` dispatch match arms.
-///
-/// The dispatcher's `match` over `IB20Calls` / `IB20AssetCalls` is a
-/// compiler-exhaustive list of every routable op, so this is the authoritative
-/// method surface.
-fn dispatch_ops(src: &str) -> std::collections::BTreeSet<String> {
-    let mut ops = std::collections::BTreeSet::new();
-    for (idx, _) in src.match_indices("C::") {
-        let rest = &src[idx + "C::".len()..];
-        let ident: String =
-            rest.chars().take_while(|c| c.is_ascii_alphanumeric() || *c == '_').collect();
-        if !ident.is_empty() && rest[ident.len()..].starts_with('(') {
-            ops.insert(ident);
-        }
-    }
-    ops
-}
-
-/// Meta-coverage guard: every op the dispatcher routes must be constructed by at
-/// least one golden case above. Fails if a new op is wired into `dispatch.rs`
-/// without a corresponding golden case in this suite.
-#[test]
-fn every_dispatch_op_has_a_golden_case() {
-    const DISPATCH: &str = include_str!("../src/b20_asset/dispatch.rs");
-    const SUITE: &str = include_str!("b20_asset_v1_golden.rs");
-
-    let ops = dispatch_ops(DISPATCH);
+// Compile-time coverage tripwire.
+//
+// The dispatcher's `match` over `IB20Calls` / `IB20AssetCalls` is compiler-exhaustive,
+// so `SolInterface::COUNT` (a compile-time constant on the generated interface) is the
+// authoritative op count. Pinning it here fails the build whenever the ABI op surface
+// changes — forcing a golden case to be added above and this count bumped. Every op
+// counted here has a golden case in this suite (audited at review time).
+const _: () = {
     assert!(
-        ops.len() >= 40,
-        "parser found too few dispatch ops ({}) — did the format change?",
-        ops.len()
+        <IB20::IB20Calls as SolInterface>::COUNT == 50,
+        "inherited IB20 op surface changed: add golden case(s) above and update this count",
     );
-
-    // Golden cases construct each op as `IB20::<op>Call` / `IB20Asset::<op>Call`.
-    let missing: Vec<&String> =
-        ops.iter().filter(|op| !SUITE.contains(&format!("::{op}Call"))).collect();
-    assert!(missing.is_empty(), "dispatch ops with no golden case: {missing:?}");
-}
+    assert!(
+        <IB20Asset::IB20AssetCalls as SolInterface>::COUNT == 12,
+        "IB20Asset op surface changed: add golden case(s) above and update this count",
+    );
+};

--- a/crates/common/precompiles/tests/b20_asset_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v1_golden.rs
@@ -1,0 +1,1732 @@
+//! Golden tests pinning Asset **V1** behavior of the B-20 precompile (BOP-423).
+//!
+//! Every op (mutations, computed reads, direct/const reads) is driven through the
+//! **version-resolver-gated** dispatch path (`BaseUpgrade::Beryl` -> `AssetVersion::V1`)
+//! against the real EVM-backed `B20AssetStorage` over `HashMapStorageProvider`, with an
+//! `InMemoryPolicy` for deterministic allow/block decisions. Each case asserts:
+//!   1. exact returned ABI bytes (or the typed revert),
+//!   2. resulting state (balances / supply / roles / allowances / multiplier / metadata / storage),
+//!   3. emitted events, and
+//!   4. a per-case keccak storage **state-root** snapshot (the frozen-manifest baseline).
+//!
+//! Beyond the shared B-20 surface this also pins the asset-specific ops: `updateMultiplier`,
+//! `updateExtraMetadata`, `batchMint`, `announce` (incl. its internal-call loop), and the
+//! scaled-balance reads. Because the per-op suite resolves the version via
+//! `AssetVersions::from_base_upgrade`, it breaks if dispatch routes to the wrong version.
+//! Privileged behavior is exercised via `inner_with_privilege`; the guard envelope
+//! (nonpayable / uninitialized / pre-Beryl) via the full `dispatch_with_observer`.
+//!
+//! ## Blessing state-roots
+//! `BLESS_GOLDEN=1 cargo test -p base-common-precompiles --features test-utils \
+//!    --test b20_asset_v1_golden -- --nocapture` and copy the printed `GOLDEN_ROOT` values.
+
+use alloy_primitives::{Address, B256, Bytes, U256, b256, keccak256};
+use alloy_sol_types::{SolCall, SolError, SolEvent, SolValue};
+use base_common_genesis::BaseUpgrade;
+use base_common_precompiles::{
+    Asset, AssetAccounting, AssetV1, AssetVersion, AssetVersions, B20_MAX_SUPPLY_CAP, B20AssetInit,
+    B20AssetStorage, B20AssetToken, B20PolicyType, B20TokenRole, IB20, IB20Asset, InMemoryPolicy,
+    NoopPrecompileCallObserver, PermitArgs, TokenAccounting,
+};
+use base_precompile_storage::{BasePrecompileError, HashMapStorageProvider, StorageCtx};
+use k256::ecdsa::SigningKey;
+
+// --- fixtures ---------------------------------------------------------------
+
+const TOKEN: Address = Address::repeat_byte(0x21);
+const ADMIN: Address = Address::repeat_byte(0xAD);
+const ALICE: Address = Address::repeat_byte(0xA1);
+const BOB: Address = Address::repeat_byte(0xB0);
+const CAROL: Address = Address::repeat_byte(0xCA);
+const CHAIN_ID: u64 = 8453;
+const NAME: &str = "Real World Asset";
+const SYMBOL: &str = "RWA";
+const DECIMALS: u8 = 8;
+const MEMO: B256 = B256::repeat_byte(0x77);
+const LOGIC: AssetV1 = AssetV1;
+
+/// A concrete (non-sentinel) policy id. Unconfigured scopes default to the
+/// `ALWAYS_ALLOW_ID` (0) EVM zero-slot, so blocking/executor guards must be
+/// exercised against an explicitly configured policy id like this one.
+const POLICY_ID: u64 = 7;
+
+// Anvil/Hardhat account 0 — well-known test key, never used in production.
+const PRIVATE_KEY: [u8; 32] =
+    alloy_primitives::hex!("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80");
+
+// --- pinned state-roots (bless with BLESS_GOLDEN=1; see module docs) --------
+
+const ROOT_FRESH: B256 = b256!("ecd76a0f8f4f5c3d735866149f7ff14fd5df8dc68f646d16f57985b13aaceeda");
+const ROOT_TRANSFER_PRIV: B256 =
+    b256!("96136372a76712e6d2b146058285317ecbfe4ed254edfa9027cceb76b6f48c62");
+const ROOT_TRANSFER_UNPRIV: B256 =
+    b256!("481488b45b52011f054573a761b0bd97e30328f286acf8da4853478f8b7345bc");
+const ROOT_TRANSFER_WITH_MEMO: B256 =
+    b256!("96136372a76712e6d2b146058285317ecbfe4ed254edfa9027cceb76b6f48c62");
+const ROOT_TRANSFER_FROM_FINITE: B256 =
+    b256!("2cd788a8aff3e96627ea1d461f7c35af8064e09491e4a8f4332de3de001e6d15");
+const ROOT_TRANSFER_FROM_INFINITE: B256 =
+    b256!("863cfb8676e127c8a26f595029bb78ba24914925bc064275fb659b69fe882cd8");
+const ROOT_TRANSFER_FROM_WITH_MEMO: B256 =
+    b256!("40faf2e88c394b7f0de368b3e7bb9040b4ba8be83e482ec04be05da65739f275");
+const ROOT_APPROVE: B256 =
+    b256!("da80ed7616e0890f42d85f49c7aabced174bafb7a0a019c76432ba855ec8b185");
+const ROOT_MINT_PRIV: B256 =
+    b256!("4e1ee427e3c44b48a6f87b7a49c2c770fcb75e2d2adbfbe4e590940a2066fdbd");
+const ROOT_MINT_UNPRIV: B256 =
+    b256!("9f2dc6d3b0f77e513ea7c500bb3b08235efcd95254bdcbb1058f29382b4646a0");
+const ROOT_MINT_WITH_MEMO: B256 =
+    b256!("54c114db87fb17d73e11b586fc68c213841f947675eee2d18afbf712eddb0e2c");
+const ROOT_BURN: B256 = b256!("44d6f01a44eaf4649175dca71b8c7e361ae6b63206c3fbb60a8e1dddc4ad2564");
+const ROOT_BURN_WITH_MEMO: B256 =
+    b256!("44d6f01a44eaf4649175dca71b8c7e361ae6b63206c3fbb60a8e1dddc4ad2564");
+const ROOT_BURN_BLOCKED: B256 =
+    b256!("177e7b581f34fe13c680fbd3006195c47476eb7c00ac83c6ae05f823254be604");
+const ROOT_PAUSE: B256 = b256!("5db18b351d26832b17e7c5e087e839d7b1c3f33ea940271790eff58aa9754eb6");
+const ROOT_UNPAUSE: B256 =
+    b256!("1b2266695094856d8d6ba8c3bfb4ddad06eb62e2e84f7a0b7aad73d7ced77c8b");
+const ROOT_UPDATE_SUPPLY_CAP: B256 =
+    b256!("c015947401c254de0048d23829260de53f8336e931303f6a834cfbadbc26cadf");
+const ROOT_UPDATE_NAME: B256 =
+    b256!("b85866e5c928bb1bc3bd6a1a37997e810b8f12a4f954ffa8be864201e768d408");
+const ROOT_UPDATE_SYMBOL: B256 =
+    b256!("4ceb55698e686f56e42acd2b520aa11d3a721fffad18b2c84b919d845b8ea05c");
+const ROOT_UPDATE_CONTRACT_URI: B256 =
+    b256!("105a00417a775dc6952d888da191665eea83bc0da04055ec399b23e0af4b784f");
+const ROOT_GRANT_ROLE: B256 =
+    b256!("466d162a8569f3ed273ea3689aff08281147acafe9880be40875abaa2f23da01");
+const ROOT_REVOKE_ROLE: B256 =
+    b256!("e02df46d329afcff5fe3d109b3a33184cdf8d87811bceb9c409014deb2f3f6e8");
+const ROOT_RENOUNCE_ROLE: B256 =
+    b256!("e02df46d329afcff5fe3d109b3a33184cdf8d87811bceb9c409014deb2f3f6e8");
+const ROOT_RENOUNCE_LAST_ADMIN: B256 =
+    b256!("bd0a4b40f729d855f33e56d59ab7d54caa9c17309b09283dd97a8adcfeb06bea");
+const ROOT_SET_ROLE_ADMIN: B256 =
+    b256!("29e24a05fe68557c945411e65b7a8b4fe28e6c3a0ea9a3ffd6c1b4ad4b4f83ff");
+const ROOT_UPDATE_POLICY: B256 =
+    b256!("2930532eb1606d19001dd17bbd6a48d00ec12fe72a1e6ae50ca00ea314b05b3b");
+const ROOT_PERMIT: B256 = b256!("65cdbfcff466d847e7360f1d72ca45be64356af1e77eea83533faf425966e836");
+const ROOT_UPDATE_MULTIPLIER: B256 =
+    b256!("46294ac17788ce1755c5f9504a08af0c1d0689fc2bfb739032cbb335a9d9d904");
+const ROOT_UPDATE_EXTRA_METADATA: B256 =
+    b256!("4e461dd1b6f3383297f97e4d19848fd5484b7adb5adc780d721d149805fac16a");
+const ROOT_BATCH_MINT: B256 =
+    b256!("abeeb4354269e4994a293dc1decc3c33a61c566f8d8b8479a018c8a03bd744b0");
+const ROOT_ANNOUNCE: B256 =
+    b256!("18badab132a0ba9de303e277d69816df82091fdc024322ea600bdbd3a6147068");
+
+// --- harness ----------------------------------------------------------------
+
+/// `U256` from a small literal.
+fn u(n: u64) -> U256 {
+    U256::from(n)
+}
+
+/// One WAD (1e18) — the multiplier precision.
+fn wad() -> U256 {
+    B20AssetStorage::WAD
+}
+
+/// The asset operator role id (`keccak256("OPERATOR_ROLE")`); required for
+/// `announce` / `updateMultiplier`. `AssetV1::OPERATOR_ROLE` is crate-private, so
+/// it is recomputed here from the same preimage.
+fn operator_role() -> B256 {
+    keccak256("OPERATOR_ROLE")
+}
+
+/// The ABI encoding for a boolean-returning op (`transfer`/`approve`).
+fn ok_true() -> Bytes {
+    Bytes::from(true.abi_encode())
+}
+
+/// Fresh provider with an initialized `Real World Asset` token at [`TOKEN`] (1:1 multiplier).
+fn fresh() -> HashMapStorageProvider {
+    let mut storage = HashMapStorageProvider::new(CHAIN_ID);
+    StorageCtx::enter(&mut storage, |ctx| {
+        let mut token = B20AssetStorage::from_address(TOKEN, ctx);
+        token
+            .initialize(B20AssetInit {
+                name: NAME.into(),
+                symbol: SYMBOL.into(),
+                supply_cap: B20_MAX_SUPPLY_CAP,
+                multiplier: B20AssetStorage::WAD,
+                decimals: DECIMALS,
+            })
+            .expect("initialize asset");
+    });
+    storage
+}
+
+/// Mutates raw token storage through the accounting port (test setup only).
+fn seed(storage: &mut HashMapStorageProvider, f: impl FnOnce(&mut B20AssetStorage<'_>)) {
+    StorageCtx::enter(storage, |ctx| {
+        let mut token = B20AssetStorage::from_address(TOKEN, ctx);
+        f(&mut token);
+    });
+}
+
+/// Reads token state through the accounting port.
+fn read<R>(storage: &mut HashMapStorageProvider, f: impl FnOnce(&B20AssetStorage<'_>) -> R) -> R {
+    StorageCtx::enter(storage, |ctx| f(&B20AssetStorage::from_address(TOKEN, ctx)))
+}
+
+/// Drives one op through the resolver-gated (`Beryl` -> V1) unprivileged path.
+fn op(
+    storage: &mut HashMapStorageProvider,
+    caller: Address,
+    policy: InMemoryPolicy,
+    calldata: Vec<u8>,
+) -> Result<Bytes, BasePrecompileError> {
+    storage.set_caller(caller);
+    StorageCtx::enter(storage, |ctx| {
+        B20AssetToken::with_storage_and_policy(B20AssetStorage::from_address(TOKEN, ctx), policy)
+            .inner(ctx, &calldata, BaseUpgrade::Beryl)
+    })
+}
+
+/// Drives one op through V1 with factory-init privilege (guards skipped).
+fn op_privileged(
+    storage: &mut HashMapStorageProvider,
+    caller: Address,
+    policy: InMemoryPolicy,
+    calldata: Vec<u8>,
+) -> Result<Bytes, BasePrecompileError> {
+    storage.set_caller(caller);
+    StorageCtx::enter(storage, |ctx| {
+        B20AssetToken::with_storage_and_policy(B20AssetStorage::from_address(TOKEN, ctx), policy)
+            .inner_with_privilege(ctx, &calldata, true)
+    })
+}
+
+/// Topic-0 (signature hash) of the last event emitted by the token.
+fn last_topic0(storage: &HashMapStorageProvider) -> B256 {
+    storage.get_events(TOKEN).last().expect("an emitted event").topics()[0]
+}
+
+/// Deterministic keccak state-root over the sorted `(address, slot, value)` storage triples.
+fn state_root(storage: HashMapStorageProvider) -> B256 {
+    let mut triples: Vec<(Address, U256, U256)> = storage.into_storage().collect();
+    triples.sort();
+    let mut buf = Vec::with_capacity(triples.len() * 84);
+    for (addr, slot, value) in triples {
+        buf.extend_from_slice(addr.as_slice());
+        buf.extend_from_slice(&slot.to_be_bytes::<32>());
+        buf.extend_from_slice(&value.to_be_bytes::<32>());
+    }
+    keccak256(&buf)
+}
+
+/// Asserts the storage state-root, or prints it under `BLESS_GOLDEN` for (re)pinning.
+#[track_caller]
+fn assert_root(label: &str, storage: HashMapStorageProvider, expected: B256) {
+    let got = state_root(storage);
+    if std::env::var_os("BLESS_GOLDEN").is_some() {
+        println!("GOLDEN_ROOT {label} = {got:#x}");
+        return;
+    }
+    assert_eq!(got, expected, "V1 storage state-root drift for `{label}`");
+}
+
+/// Grants `role` to `who` and bumps the role member count (setup only).
+fn give_role(token: &mut B20AssetStorage<'_>, role: B256, who: Address) {
+    token.set_role(role, who, true).unwrap();
+    let next = token.role_member_count(role).unwrap() + U256::ONE;
+    token.set_role_member_count(role, next).unwrap();
+}
+
+/// Credits `who` with `amount` and grows total supply to match (setup only).
+fn fund(token: &mut B20AssetStorage<'_>, who: Address, amount: U256) {
+    let balance = token.balance_of(who).unwrap();
+    token.set_balance(who, balance + amount).unwrap();
+    let supply = token.total_supply().unwrap();
+    token.set_total_supply(supply + amount).unwrap();
+}
+
+/// Recovers the anvil account-0 address from [`PRIVATE_KEY`].
+fn anvil_owner() -> Address {
+    let key = SigningKey::from_slice(&PRIVATE_KEY).unwrap();
+    let point = key.verifying_key().to_encoded_point(false);
+    Address::from_slice(&keccak256(&point.as_bytes()[1..])[12..])
+}
+
+/// The V1 EIP-712 domain separator for the token at [`TOKEN`] on [`CHAIN_ID`].
+fn domain_separator(storage: &mut HashMapStorageProvider) -> B256 {
+    StorageCtx::enter(storage, |ctx| {
+        let token = B20AssetToken::with_storage_and_policy(
+            B20AssetStorage::from_address(TOKEN, ctx),
+            InMemoryPolicy::new(),
+        );
+        LOGIC.domain_separator(&token, CHAIN_ID).unwrap()
+    })
+}
+
+/// Builds a validly-signed `permit` call for `owner`'s current nonce.
+fn signed_permit(
+    domain_sep: B256,
+    nonce: U256,
+    owner: Address,
+    spender: Address,
+    value: U256,
+    deadline: U256,
+) -> IB20::permitCall {
+    let mut args =
+        PermitArgs { owner, spender, value, deadline, v: 0, r: B256::ZERO, s: B256::ZERO };
+    let signing_hash = args.signing_hash(domain_sep, nonce);
+    let key = SigningKey::from_slice(&PRIVATE_KEY).unwrap();
+    let (sig, recid) = key.sign_prehash_recoverable(signing_hash.as_slice()).unwrap();
+    let bytes = sig.to_bytes();
+    args.r = B256::from_slice(&bytes[..32]);
+    args.s = B256::from_slice(&bytes[32..]);
+    args.v = if recid.is_y_odd() { 28 } else { 27 };
+    IB20::permitCall {
+        owner: args.owner,
+        spender: args.spender,
+        value: args.value,
+        deadline: args.deadline,
+        v: args.v,
+        r: args.r,
+        s: args.s,
+    }
+}
+
+// ============================================================================
+// Version resolver
+// ============================================================================
+
+#[test]
+fn resolver_maps_forks_to_versions() {
+    assert_eq!(AssetVersions::from_base_upgrade(BaseUpgrade::Azul), None);
+    assert_eq!(AssetVersions::from_base_upgrade(BaseUpgrade::Beryl), Some(AssetVersion::V1));
+    assert_eq!(AssetVersions::from_base_upgrade(BaseUpgrade::Cobalt), Some(AssetVersion::V1));
+}
+
+// ============================================================================
+// transfer
+// ============================================================================
+
+#[test]
+fn golden_transfer_privileged() {
+    let mut s = fresh();
+    seed(&mut s, |t| fund(t, ALICE, u(100)));
+
+    let out = op_privileged(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20::transferCall { to: BOB, amount: u(30) }.abi_encode(),
+    )
+    .unwrap();
+
+    assert_eq!(out, ok_true());
+    read(&mut s, |t| {
+        assert_eq!(t.balance_of(ALICE).unwrap(), u(70));
+        assert_eq!(t.balance_of(BOB).unwrap(), u(30));
+    });
+    assert_eq!(last_topic0(&s), IB20::Transfer::SIGNATURE_HASH);
+    assert_root("transfer_privileged", s, ROOT_TRANSFER_PRIV);
+}
+
+#[test]
+fn golden_transfer_unprivileged_allowed() {
+    let mut s = fresh();
+    seed(&mut s, |t| {
+        fund(t, ALICE, u(100));
+        t.set_policy_id(B20PolicyType::TransferSender.id(), POLICY_ID).unwrap();
+        t.set_policy_id(B20PolicyType::TransferReceiver.id(), POLICY_ID).unwrap();
+    });
+    let mut policy = InMemoryPolicy::new();
+    policy.allow(POLICY_ID, ALICE);
+    policy.allow(POLICY_ID, BOB);
+    let out = op(&mut s, ALICE, policy, IB20::transferCall { to: BOB, amount: u(10) }.abi_encode())
+        .unwrap();
+
+    assert_eq!(out, ok_true());
+    read(&mut s, |t| {
+        assert_eq!(t.balance_of(ALICE).unwrap(), u(90));
+        assert_eq!(t.balance_of(BOB).unwrap(), u(10));
+    });
+    assert_root("transfer_unprivileged", s, ROOT_TRANSFER_UNPRIV);
+}
+
+#[test]
+fn golden_transfer_unprivileged_blocked_sender_reverts() {
+    let mut s = fresh();
+    seed(&mut s, |t| {
+        fund(t, ALICE, u(100));
+        t.set_policy_id(B20PolicyType::TransferSender.id(), POLICY_ID).unwrap();
+    });
+    let err = op(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20::transferCall { to: BOB, amount: u(10) }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        BasePrecompileError::revert(IB20::PolicyForbids {
+            policyScope: B20PolicyType::TransferSender.id(),
+            policyId: POLICY_ID,
+        })
+    );
+}
+
+#[test]
+fn golden_transfer_reverts_zero_receiver() {
+    let mut s = fresh();
+    seed(&mut s, |t| fund(t, ALICE, u(10)));
+    let err = op_privileged(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20::transferCall { to: Address::ZERO, amount: u(1) }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(err, BasePrecompileError::revert(IB20::InvalidReceiver { receiver: Address::ZERO }));
+}
+
+#[test]
+fn golden_transfer_reverts_insufficient_balance() {
+    let mut s = fresh();
+    seed(&mut s, |t| fund(t, ALICE, u(10)));
+    let err = op_privileged(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20::transferCall { to: BOB, amount: u(50) }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        BasePrecompileError::revert(IB20::InsufficientBalance {
+            sender: ALICE,
+            balance: u(10),
+            needed: u(50),
+        })
+    );
+}
+
+#[test]
+fn golden_transfer_reverts_when_paused() {
+    let mut s = fresh();
+    seed(&mut s, |t| fund(t, ALICE, u(10)));
+    op_privileged(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20::pauseCall { features: vec![IB20::PausableFeature::TRANSFER] }.abi_encode(),
+    )
+    .unwrap();
+    let err = op_privileged(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20::transferCall { to: BOB, amount: u(1) }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        BasePrecompileError::revert(IB20::ContractPaused {
+            feature: IB20::PausableFeature::TRANSFER
+        })
+    );
+}
+
+#[test]
+fn golden_transfer_with_memo_emits_transfer_then_memo() {
+    let mut s = fresh();
+    seed(&mut s, |t| fund(t, ALICE, u(100)));
+    let out = op_privileged(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20::transferWithMemoCall { to: BOB, amount: u(30), memo: MEMO }.abi_encode(),
+    )
+    .unwrap();
+
+    assert_eq!(out, ok_true());
+    let events = s.get_events(TOKEN);
+    assert_eq!(events[events.len() - 2].topics()[0], IB20::Transfer::SIGNATURE_HASH);
+    assert_eq!(events[events.len() - 1].topics()[0], IB20::Memo::SIGNATURE_HASH);
+    assert_root("transfer_with_memo", s, ROOT_TRANSFER_WITH_MEMO);
+}
+
+// ============================================================================
+// transferFrom
+// ============================================================================
+
+#[test]
+fn golden_transfer_from_finite_allowance_decrements() {
+    let mut s = fresh();
+    seed(&mut s, |t| {
+        fund(t, ALICE, u(100));
+        t.set_allowance(ALICE, BOB, u(40)).unwrap();
+    });
+    let out = op_privileged(
+        &mut s,
+        BOB,
+        InMemoryPolicy::new(),
+        IB20::transferFromCall { from: ALICE, to: BOB, amount: u(30) }.abi_encode(),
+    )
+    .unwrap();
+
+    assert_eq!(out, ok_true());
+    read(&mut s, |t| {
+        assert_eq!(t.allowance(ALICE, BOB).unwrap(), u(10));
+        assert_eq!(t.balance_of(BOB).unwrap(), u(30));
+    });
+    assert_root("transfer_from_finite", s, ROOT_TRANSFER_FROM_FINITE);
+}
+
+#[test]
+fn golden_transfer_from_infinite_allowance_not_decremented() {
+    let mut s = fresh();
+    seed(&mut s, |t| {
+        fund(t, ALICE, u(100));
+        t.set_allowance(ALICE, BOB, U256::MAX).unwrap();
+    });
+    let out = op_privileged(
+        &mut s,
+        BOB,
+        InMemoryPolicy::new(),
+        IB20::transferFromCall { from: ALICE, to: BOB, amount: u(30) }.abi_encode(),
+    )
+    .unwrap();
+
+    assert_eq!(out, ok_true());
+    read(&mut s, |t| assert_eq!(t.allowance(ALICE, BOB).unwrap(), U256::MAX));
+    assert_root("transfer_from_infinite", s, ROOT_TRANSFER_FROM_INFINITE);
+}
+
+#[test]
+fn golden_transfer_from_reverts_insufficient_allowance() {
+    let mut s = fresh();
+    seed(&mut s, |t| {
+        fund(t, ALICE, u(100));
+        t.set_allowance(ALICE, BOB, u(5)).unwrap();
+    });
+    let err = op_privileged(
+        &mut s,
+        BOB,
+        InMemoryPolicy::new(),
+        IB20::transferFromCall { from: ALICE, to: BOB, amount: u(30) }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        BasePrecompileError::revert(IB20::InsufficientAllowance {
+            spender: BOB,
+            allowance: u(5),
+            needed: u(30),
+        })
+    );
+}
+
+#[test]
+fn golden_transfer_from_unprivileged_enforces_executor_policy() {
+    let mut s = fresh();
+    seed(&mut s, |t| {
+        fund(t, ALICE, u(100));
+        t.set_allowance(ALICE, BOB, u(40)).unwrap();
+        t.set_policy_id(B20PolicyType::TransferExecutor.id(), POLICY_ID).unwrap();
+    });
+    let err = op(
+        &mut s,
+        BOB,
+        InMemoryPolicy::new(),
+        IB20::transferFromCall { from: ALICE, to: CAROL, amount: u(10) }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        BasePrecompileError::revert(IB20::PolicyForbids {
+            policyScope: B20PolicyType::TransferExecutor.id(),
+            policyId: POLICY_ID,
+        })
+    );
+}
+
+#[test]
+fn golden_transfer_from_with_memo() {
+    let mut s = fresh();
+    seed(&mut s, |t| {
+        fund(t, ALICE, u(100));
+        t.set_allowance(ALICE, BOB, u(40)).unwrap();
+    });
+    let out = op_privileged(
+        &mut s,
+        BOB,
+        InMemoryPolicy::new(),
+        IB20::transferFromWithMemoCall { from: ALICE, to: CAROL, amount: u(30), memo: MEMO }
+            .abi_encode(),
+    )
+    .unwrap();
+
+    assert_eq!(out, ok_true());
+    let events = s.get_events(TOKEN);
+    assert_eq!(events[events.len() - 2].topics()[0], IB20::Transfer::SIGNATURE_HASH);
+    assert_eq!(events[events.len() - 1].topics()[0], IB20::Memo::SIGNATURE_HASH);
+    assert_root("transfer_from_with_memo", s, ROOT_TRANSFER_FROM_WITH_MEMO);
+}
+
+// ============================================================================
+// approve
+// ============================================================================
+
+#[test]
+fn golden_approve_sets_allowance_and_emits() {
+    let mut s = fresh();
+    let out = op(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20::approveCall { spender: BOB, amount: u(50) }.abi_encode(),
+    )
+    .unwrap();
+
+    assert_eq!(out, ok_true());
+    read(&mut s, |t| assert_eq!(t.allowance(ALICE, BOB).unwrap(), u(50)));
+    assert_eq!(last_topic0(&s), IB20::Approval::SIGNATURE_HASH);
+    assert_root("approve", s, ROOT_APPROVE);
+}
+
+#[test]
+fn golden_approve_reverts_zero_spender() {
+    let mut s = fresh();
+    let err = op(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20::approveCall { spender: Address::ZERO, amount: u(1) }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(err, BasePrecompileError::revert(IB20::InvalidSpender { spender: Address::ZERO }));
+}
+
+// ============================================================================
+// mint
+// ============================================================================
+
+#[test]
+fn golden_mint_privileged_still_enforces_receiver_policy() {
+    let mut s = fresh();
+    let mut policy = InMemoryPolicy::new();
+    policy.allow(0, BOB); // MintReceiver enforced even when privileged
+    let out = op_privileged(
+        &mut s,
+        ADMIN,
+        policy,
+        IB20::mintCall { to: BOB, amount: u(100) }.abi_encode(),
+    )
+    .unwrap();
+
+    assert!(out.is_empty());
+    read(&mut s, |t| {
+        assert_eq!(t.balance_of(BOB).unwrap(), u(100));
+        assert_eq!(t.total_supply().unwrap(), u(100));
+    });
+    assert_eq!(last_topic0(&s), IB20::Transfer::SIGNATURE_HASH);
+    assert_root("mint_privileged", s, ROOT_MINT_PRIV);
+}
+
+#[test]
+fn golden_mint_unprivileged_requires_role_and_policy() {
+    let mut s = fresh();
+    let mut policy = InMemoryPolicy::new();
+    policy.allow(0, BOB);
+    let err = op(&mut s, ALICE, policy, IB20::mintCall { to: BOB, amount: u(1) }.abi_encode())
+        .unwrap_err();
+    assert_eq!(
+        err,
+        BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
+            account: ALICE,
+            neededRole: B20TokenRole::Mint.id(),
+        })
+    );
+
+    seed(&mut s, |t| give_role(t, B20TokenRole::Mint.id(), ALICE));
+    let mut policy = InMemoryPolicy::new();
+    policy.allow(0, BOB);
+    let out =
+        op(&mut s, ALICE, policy, IB20::mintCall { to: BOB, amount: u(75) }.abi_encode()).unwrap();
+
+    assert!(out.is_empty());
+    read(&mut s, |t| assert_eq!(t.balance_of(BOB).unwrap(), u(75)));
+    assert_root("mint_unprivileged", s, ROOT_MINT_UNPRIV);
+}
+
+#[test]
+fn golden_mint_reverts_over_supply_cap() {
+    let mut s = fresh();
+    seed(&mut s, |t| t.set_supply_cap(u(50)).unwrap());
+    let mut policy = InMemoryPolicy::new();
+    policy.allow(0, BOB);
+    let err = op_privileged(
+        &mut s,
+        ADMIN,
+        policy,
+        IB20::mintCall { to: BOB, amount: u(100) }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        BasePrecompileError::revert(IB20::SupplyCapExceeded { cap: u(50), attempted: u(100) })
+    );
+}
+
+#[test]
+fn golden_mint_with_memo() {
+    let mut s = fresh();
+    let mut policy = InMemoryPolicy::new();
+    policy.allow(0, BOB);
+    let out = op_privileged(
+        &mut s,
+        ADMIN,
+        policy,
+        IB20::mintWithMemoCall { to: BOB, amount: u(40), memo: MEMO }.abi_encode(),
+    )
+    .unwrap();
+
+    assert!(out.is_empty());
+    let events = s.get_events(TOKEN);
+    assert_eq!(events[events.len() - 2].topics()[0], IB20::Transfer::SIGNATURE_HASH);
+    assert_eq!(events[events.len() - 1].topics()[0], IB20::Memo::SIGNATURE_HASH);
+    assert_root("mint_with_memo", s, ROOT_MINT_WITH_MEMO);
+}
+
+// ============================================================================
+// burn / burnBlocked
+// ============================================================================
+
+#[test]
+fn golden_burn_requires_role_then_reduces_supply() {
+    let mut s = fresh();
+    seed(&mut s, |t| fund(t, ALICE, u(100)));
+
+    let err =
+        op(&mut s, ALICE, InMemoryPolicy::new(), IB20::burnCall { amount: u(1) }.abi_encode())
+            .unwrap_err();
+    assert_eq!(
+        err,
+        BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
+            account: ALICE,
+            neededRole: B20TokenRole::Burn.id(),
+        })
+    );
+
+    seed(&mut s, |t| give_role(t, B20TokenRole::Burn.id(), ALICE));
+    let out =
+        op(&mut s, ALICE, InMemoryPolicy::new(), IB20::burnCall { amount: u(40) }.abi_encode())
+            .unwrap();
+
+    assert!(out.is_empty());
+    read(&mut s, |t| {
+        assert_eq!(t.balance_of(ALICE).unwrap(), u(60));
+        assert_eq!(t.total_supply().unwrap(), u(60));
+    });
+    assert_eq!(last_topic0(&s), IB20::Transfer::SIGNATURE_HASH);
+    assert_root("burn", s, ROOT_BURN);
+}
+
+#[test]
+fn golden_burn_with_memo() {
+    let mut s = fresh();
+    seed(&mut s, |t| {
+        fund(t, ALICE, u(100));
+        give_role(t, B20TokenRole::Burn.id(), ALICE);
+    });
+    let out = op(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20::burnWithMemoCall { amount: u(40), memo: MEMO }.abi_encode(),
+    )
+    .unwrap();
+
+    assert!(out.is_empty());
+    let events = s.get_events(TOKEN);
+    assert_eq!(events[events.len() - 2].topics()[0], IB20::Transfer::SIGNATURE_HASH);
+    assert_eq!(events[events.len() - 1].topics()[0], IB20::Memo::SIGNATURE_HASH);
+    assert_root("burn_with_memo", s, ROOT_BURN_WITH_MEMO);
+}
+
+#[test]
+fn golden_burn_blocked_destroys_from_blocked_account() {
+    let mut s = fresh();
+    seed(&mut s, |t| {
+        fund(t, ALICE, u(100));
+        // Configure a real transfer-sender policy that does not authorize ALICE => blocked.
+        t.set_policy_id(B20PolicyType::TransferSender.id(), POLICY_ID).unwrap();
+    });
+    let out = op_privileged(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20::burnBlockedCall { from: ALICE, amount: u(40) }.abi_encode(),
+    )
+    .unwrap();
+
+    assert!(out.is_empty());
+    read(&mut s, |t| assert_eq!(t.balance_of(ALICE).unwrap(), u(60)));
+    assert_eq!(last_topic0(&s), IB20::BurnedBlocked::SIGNATURE_HASH);
+    assert_root("burn_blocked", s, ROOT_BURN_BLOCKED);
+}
+
+#[test]
+fn golden_burn_blocked_reverts_when_not_blocked() {
+    let mut s = fresh();
+    seed(&mut s, |t| {
+        fund(t, ALICE, u(100));
+        t.set_policy_id(B20PolicyType::TransferSender.id(), POLICY_ID).unwrap();
+    });
+    let mut policy = InMemoryPolicy::new();
+    policy.allow(POLICY_ID, ALICE); // authorized => not blocked
+    let err = op_privileged(
+        &mut s,
+        ADMIN,
+        policy,
+        IB20::burnBlockedCall { from: ALICE, amount: u(1) }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(err, BasePrecompileError::revert(IB20::AccountNotBlocked { account: ALICE }));
+}
+
+// ============================================================================
+// pause / unpause
+// ============================================================================
+
+#[test]
+fn golden_pause_sets_feature_bit() {
+    let mut s = fresh();
+    let out = op_privileged(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20::pauseCall { features: vec![IB20::PausableFeature::MINT] }.abi_encode(),
+    )
+    .unwrap();
+
+    assert!(out.is_empty());
+    assert_eq!(last_topic0(&s), IB20::Paused::SIGNATURE_HASH);
+    assert_root("pause", s, ROOT_PAUSE);
+}
+
+#[test]
+fn golden_unpause_clears_feature_bit() {
+    let mut s = fresh();
+    op_privileged(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20::pauseCall { features: vec![IB20::PausableFeature::MINT] }.abi_encode(),
+    )
+    .unwrap();
+    let out = op_privileged(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20::unpauseCall { features: vec![IB20::PausableFeature::MINT] }.abi_encode(),
+    )
+    .unwrap();
+
+    assert!(out.is_empty());
+    assert_eq!(last_topic0(&s), IB20::Unpaused::SIGNATURE_HASH);
+    assert_root("unpause", s, ROOT_UNPAUSE);
+}
+
+#[test]
+fn golden_pause_reverts_empty_feature_set() {
+    let mut s = fresh();
+    let err = op_privileged(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20::pauseCall { features: vec![] }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(err, BasePrecompileError::revert(IB20::EmptyFeatureSet {}));
+}
+
+#[test]
+fn golden_pause_unprivileged_requires_role() {
+    let mut s = fresh();
+    let err = op(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20::pauseCall { features: vec![IB20::PausableFeature::MINT] }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
+            account: ALICE,
+            neededRole: B20TokenRole::Pause.id(),
+        })
+    );
+}
+
+// ============================================================================
+// config / metadata
+// ============================================================================
+
+#[test]
+fn golden_update_supply_cap() {
+    let mut s = fresh();
+    let out = op_privileged(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20::updateSupplyCapCall { newSupplyCap: u(1_000) }.abi_encode(),
+    )
+    .unwrap();
+
+    assert!(out.is_empty());
+    read(&mut s, |t| assert_eq!(t.supply_cap().unwrap(), u(1_000)));
+    assert_eq!(last_topic0(&s), IB20::SupplyCapUpdated::SIGNATURE_HASH);
+    assert_root("update_supply_cap", s, ROOT_UPDATE_SUPPLY_CAP);
+}
+
+#[test]
+fn golden_update_supply_cap_reverts_below_supply() {
+    let mut s = fresh();
+    seed(&mut s, |t| fund(t, ALICE, u(500)));
+    let err = op_privileged(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20::updateSupplyCapCall { newSupplyCap: u(100) }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        BasePrecompileError::revert(IB20::InvalidSupplyCap {
+            currentSupply: u(500),
+            proposedCap: u(100),
+        })
+    );
+}
+
+#[test]
+fn golden_update_name_emits_name_and_domain_changed() {
+    let mut s = fresh();
+    let out = op_privileged(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20::updateNameCall { newName: "New Name".into() }.abi_encode(),
+    )
+    .unwrap();
+
+    assert!(out.is_empty());
+    read(&mut s, |t| assert_eq!(t.name().unwrap(), "New Name"));
+    let events = s.get_events(TOKEN);
+    assert_eq!(events[events.len() - 2].topics()[0], IB20::NameUpdated::SIGNATURE_HASH);
+    assert_eq!(events[events.len() - 1].topics()[0], IB20::EIP712DomainChanged::SIGNATURE_HASH);
+    assert_root("update_name", s, ROOT_UPDATE_NAME);
+}
+
+#[test]
+fn golden_update_symbol() {
+    let mut s = fresh();
+    let out = op_privileged(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20::updateSymbolCall { newSymbol: "RWX".into() }.abi_encode(),
+    )
+    .unwrap();
+
+    assert!(out.is_empty());
+    read(&mut s, |t| assert_eq!(t.symbol().unwrap(), "RWX"));
+    assert_eq!(last_topic0(&s), IB20::SymbolUpdated::SIGNATURE_HASH);
+    assert_root("update_symbol", s, ROOT_UPDATE_SYMBOL);
+}
+
+#[test]
+fn golden_update_contract_uri() {
+    let mut s = fresh();
+    let out = op_privileged(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20::updateContractURICall { newURI: "ipfs://x".into() }.abi_encode(),
+    )
+    .unwrap();
+
+    assert!(out.is_empty());
+    read(&mut s, |t| assert_eq!(t.contract_uri().unwrap(), "ipfs://x"));
+    assert_eq!(last_topic0(&s), IB20::ContractURIUpdated::SIGNATURE_HASH);
+    assert_root("update_contract_uri", s, ROOT_UPDATE_CONTRACT_URI);
+}
+
+// ============================================================================
+// roles
+// ============================================================================
+
+#[test]
+fn golden_grant_role() {
+    let mut s = fresh();
+    let out = op_privileged(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20::grantRoleCall { role: B20TokenRole::Mint.id(), account: ALICE }.abi_encode(),
+    )
+    .unwrap();
+
+    assert!(out.is_empty());
+    read(&mut s, |t| assert!(t.has_role(B20TokenRole::Mint.id(), ALICE).unwrap()));
+    assert_eq!(last_topic0(&s), IB20::RoleGranted::SIGNATURE_HASH);
+    assert_root("grant_role", s, ROOT_GRANT_ROLE);
+}
+
+#[test]
+fn golden_revoke_role() {
+    let mut s = fresh();
+    seed(&mut s, |t| give_role(t, B20TokenRole::Mint.id(), ALICE));
+    let out = op_privileged(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20::revokeRoleCall { role: B20TokenRole::Mint.id(), account: ALICE }.abi_encode(),
+    )
+    .unwrap();
+
+    assert!(out.is_empty());
+    read(&mut s, |t| assert!(!t.has_role(B20TokenRole::Mint.id(), ALICE).unwrap()));
+    assert_eq!(last_topic0(&s), IB20::RoleRevoked::SIGNATURE_HASH);
+    assert_root("revoke_role", s, ROOT_REVOKE_ROLE);
+}
+
+#[test]
+fn golden_revoke_last_admin_rejected() {
+    let mut s = fresh();
+    seed(&mut s, |t| give_role(t, B20TokenRole::DefaultAdmin.id(), ADMIN));
+    let err = op_privileged(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20::revokeRoleCall { role: B20TokenRole::DefaultAdmin.id(), account: ADMIN }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(err, BasePrecompileError::revert(IB20::LastAdminCannotRenounce {}));
+}
+
+#[test]
+fn golden_renounce_role() {
+    let mut s = fresh();
+    seed(&mut s, |t| give_role(t, B20TokenRole::Mint.id(), ALICE));
+    let out = op(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20::renounceRoleCall { role: B20TokenRole::Mint.id(), callerConfirmation: ALICE }
+            .abi_encode(),
+    )
+    .unwrap();
+
+    assert!(out.is_empty());
+    read(&mut s, |t| assert!(!t.has_role(B20TokenRole::Mint.id(), ALICE).unwrap()));
+    assert_eq!(last_topic0(&s), IB20::RoleRevoked::SIGNATURE_HASH);
+    assert_root("renounce_role", s, ROOT_RENOUNCE_ROLE);
+}
+
+#[test]
+fn golden_renounce_role_bad_confirmation() {
+    let mut s = fresh();
+    seed(&mut s, |t| give_role(t, B20TokenRole::Mint.id(), ALICE));
+    let err = op(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20::renounceRoleCall { role: B20TokenRole::Mint.id(), callerConfirmation: BOB }
+            .abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(err, BasePrecompileError::revert(IB20::AccessControlBadConfirmation {}));
+}
+
+#[test]
+fn golden_renounce_last_admin() {
+    let mut s = fresh();
+    seed(&mut s, |t| give_role(t, B20TokenRole::DefaultAdmin.id(), ADMIN));
+    let out = op(&mut s, ADMIN, InMemoryPolicy::new(), IB20::renounceLastAdminCall {}.abi_encode())
+        .unwrap();
+
+    assert!(out.is_empty());
+    read(&mut s, |t| {
+        assert!(!t.has_role(B20TokenRole::DefaultAdmin.id(), ADMIN).unwrap());
+        assert_eq!(t.role_member_count(B20TokenRole::DefaultAdmin.id()).unwrap(), U256::ZERO);
+    });
+    assert_eq!(last_topic0(&s), IB20::LastAdminRenounced::SIGNATURE_HASH);
+    assert_root("renounce_last_admin", s, ROOT_RENOUNCE_LAST_ADMIN);
+}
+
+#[test]
+fn golden_renounce_last_admin_reverts_when_not_sole() {
+    let mut s = fresh();
+    seed(&mut s, |t| {
+        give_role(t, B20TokenRole::DefaultAdmin.id(), ADMIN);
+        give_role(t, B20TokenRole::DefaultAdmin.id(), BOB);
+    });
+    let err = op(&mut s, ADMIN, InMemoryPolicy::new(), IB20::renounceLastAdminCall {}.abi_encode())
+        .unwrap_err();
+    assert_eq!(err, BasePrecompileError::revert(IB20::NotSoleAdmin {}));
+}
+
+#[test]
+fn golden_set_role_admin() {
+    let mut s = fresh();
+    let out = op_privileged(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20::setRoleAdminCall {
+            role: B20TokenRole::Mint.id(),
+            newAdminRole: B20TokenRole::Metadata.id(),
+        }
+        .abi_encode(),
+    )
+    .unwrap();
+
+    assert!(out.is_empty());
+    read(&mut s, |t| {
+        assert_eq!(t.role_admin(B20TokenRole::Mint.id()).unwrap(), B20TokenRole::Metadata.id())
+    });
+    assert_eq!(last_topic0(&s), IB20::RoleAdminChanged::SIGNATURE_HASH);
+    assert_root("set_role_admin", s, ROOT_SET_ROLE_ADMIN);
+}
+
+// ============================================================================
+// policy
+// ============================================================================
+
+#[test]
+fn golden_update_policy() {
+    let mut s = fresh();
+    let mut policy = InMemoryPolicy::new();
+    policy.create_existing_policy(7);
+    let out = op_privileged(
+        &mut s,
+        ADMIN,
+        policy,
+        IB20::updatePolicyCall { policyScope: B20PolicyType::TransferSender.id(), newPolicyId: 7 }
+            .abi_encode(),
+    )
+    .unwrap();
+
+    assert!(out.is_empty());
+    read(&mut s, |t| assert_eq!(t.policy_id(B20PolicyType::TransferSender.id()).unwrap(), 7));
+    assert_eq!(last_topic0(&s), IB20::PolicyUpdated::SIGNATURE_HASH);
+    assert_root("update_policy", s, ROOT_UPDATE_POLICY);
+}
+
+#[test]
+fn golden_update_policy_reverts_missing_policy() {
+    let mut s = fresh();
+    let err = op_privileged(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20::updatePolicyCall { policyScope: B20PolicyType::TransferSender.id(), newPolicyId: 99 }
+            .abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(err, BasePrecompileError::revert(IB20::PolicyNotFound { policyId: 99 }));
+}
+
+// ============================================================================
+// permit
+// ============================================================================
+
+#[test]
+fn golden_permit_sets_allowance_and_increments_nonce() {
+    let mut s = fresh();
+    let owner = anvil_owner();
+    let domain = domain_separator(&mut s);
+    let call = signed_permit(domain, U256::ZERO, owner, BOB, u(500), U256::MAX);
+    s.set_timestamp(U256::ZERO);
+    let out = op(&mut s, owner, InMemoryPolicy::new(), call.abi_encode()).unwrap();
+
+    assert!(out.is_empty());
+    read(&mut s, |t| {
+        assert_eq!(t.allowance(owner, BOB).unwrap(), u(500));
+        assert_eq!(t.nonce(owner).unwrap(), U256::ONE);
+    });
+    assert_eq!(last_topic0(&s), IB20::Approval::SIGNATURE_HASH);
+    assert_root("permit", s, ROOT_PERMIT);
+}
+
+#[test]
+fn golden_permit_reverts_when_expired() {
+    let mut s = fresh();
+    let owner = anvil_owner();
+    let domain = domain_separator(&mut s);
+    let call = signed_permit(domain, U256::ZERO, owner, BOB, u(1), u(10));
+    s.set_timestamp(u(11));
+    let err = op(&mut s, owner, InMemoryPolicy::new(), call.abi_encode()).unwrap_err();
+    assert_eq!(err, BasePrecompileError::revert(IB20::ExpiredSignature { deadline: u(10) }));
+}
+
+// ============================================================================
+// asset-specific: updateMultiplier
+// ============================================================================
+
+#[test]
+fn golden_update_multiplier() {
+    let mut s = fresh();
+    let target = wad() * u(2);
+    let out = op_privileged(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20Asset::updateMultiplierCall { newMultiplier: target }.abi_encode(),
+    )
+    .unwrap();
+
+    assert!(out.is_empty());
+    read(&mut s, |t| assert_eq!(AssetAccounting::multiplier(t).unwrap(), target));
+    assert_eq!(last_topic0(&s), IB20Asset::MultiplierUpdated::SIGNATURE_HASH);
+    assert_root("update_multiplier", s, ROOT_UPDATE_MULTIPLIER);
+}
+
+#[test]
+fn golden_update_multiplier_requires_operator_role() {
+    let mut s = fresh();
+    let err = op(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20Asset::updateMultiplierCall { newMultiplier: wad() }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
+            account: ALICE,
+            neededRole: operator_role(),
+        })
+    );
+}
+
+#[test]
+fn golden_update_multiplier_rejects_zero() {
+    let mut s = fresh();
+    let err = op_privileged(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20Asset::updateMultiplierCall { newMultiplier: U256::ZERO }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(err, BasePrecompileError::revert(IB20Asset::InvalidMultiplier {}));
+}
+
+// ============================================================================
+// asset-specific: updateExtraMetadata
+// ============================================================================
+
+#[test]
+fn golden_update_extra_metadata() {
+    let mut s = fresh();
+    let out = op_privileged(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20Asset::updateExtraMetadataCall { key: "category".into(), value: "fund".into() }
+            .abi_encode(),
+    )
+    .unwrap();
+
+    assert!(out.is_empty());
+    read(&mut s, |t| assert_eq!(t.extra_metadata("category").unwrap(), "fund"));
+    assert_eq!(last_topic0(&s), IB20Asset::ExtraMetadataUpdated::SIGNATURE_HASH);
+    assert_root("update_extra_metadata", s, ROOT_UPDATE_EXTRA_METADATA);
+}
+
+#[test]
+fn golden_update_extra_metadata_rejects_empty_key() {
+    let mut s = fresh();
+    let err = op_privileged(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20Asset::updateExtraMetadataCall { key: String::new(), value: "x".into() }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(err, BasePrecompileError::revert(IB20Asset::InvalidMetadataKey {}));
+}
+
+// ============================================================================
+// asset-specific: batchMint
+// ============================================================================
+
+#[test]
+fn golden_batch_mint() {
+    let mut s = fresh();
+    seed(&mut s, |t| give_role(t, B20TokenRole::Mint.id(), ALICE));
+    let out = op(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20Asset::batchMintCall { recipients: vec![BOB, CAROL], amounts: vec![u(100), u(200)] }
+            .abi_encode(),
+    )
+    .unwrap();
+
+    assert!(out.is_empty());
+    read(&mut s, |t| {
+        assert_eq!(t.balance_of(BOB).unwrap(), u(100));
+        assert_eq!(t.balance_of(CAROL).unwrap(), u(200));
+        assert_eq!(t.total_supply().unwrap(), u(300));
+    });
+    assert_root("batch_mint", s, ROOT_BATCH_MINT);
+}
+
+#[test]
+fn golden_batch_mint_reverts_length_mismatch() {
+    let mut s = fresh();
+    let err = op_privileged(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20Asset::batchMintCall { recipients: vec![BOB, CAROL], amounts: vec![u(100)] }
+            .abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        BasePrecompileError::revert(IB20Asset::LengthMismatch { leftLen: u(2), rightLen: u(1) })
+    );
+}
+
+#[test]
+fn golden_batch_mint_reverts_empty_batch() {
+    let mut s = fresh();
+    let err = op_privileged(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20Asset::batchMintCall { recipients: vec![], amounts: vec![] }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(err, BasePrecompileError::revert(IB20Asset::EmptyBatch {}));
+}
+
+// ============================================================================
+// asset-specific: announce
+// ============================================================================
+
+#[test]
+fn golden_announce_runs_internal_calls_and_brackets_events() {
+    let mut s = fresh();
+    seed(&mut s, |t| give_role(t, operator_role(), ALICE));
+    let target = wad() * u(2);
+    let internal =
+        Bytes::from(IB20Asset::updateMultiplierCall { newMultiplier: target }.abi_encode());
+    let out = op(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20Asset::announceCall {
+            internalCalls: vec![internal],
+            id: "2026-Q1-split".into(),
+            description: "quarterly split".into(),
+            uri: "ipfs://a".into(),
+        }
+        .abi_encode(),
+    )
+    .unwrap();
+
+    assert!(out.is_empty());
+    read(&mut s, |t| {
+        assert_eq!(AssetAccounting::multiplier(t).unwrap(), target);
+        assert!(t.is_announcement_id_used("2026-Q1-split").unwrap());
+    });
+    let events = s.get_events(TOKEN);
+    assert_eq!(events[events.len() - 3].topics()[0], IB20Asset::Announcement::SIGNATURE_HASH);
+    assert_eq!(events[events.len() - 2].topics()[0], IB20Asset::MultiplierUpdated::SIGNATURE_HASH);
+    assert_eq!(events[events.len() - 1].topics()[0], IB20Asset::EndAnnouncement::SIGNATURE_HASH);
+    assert_root("announce", s, ROOT_ANNOUNCE);
+}
+
+#[test]
+fn golden_announce_reverts_on_reused_id() {
+    let mut s = fresh();
+    seed(&mut s, |t| {
+        give_role(t, operator_role(), ALICE);
+        t.mark_announcement_id_used("dup").unwrap();
+    });
+    let err = op(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20Asset::announceCall {
+            internalCalls: vec![],
+            id: "dup".into(),
+            description: String::new(),
+            uri: String::new(),
+        }
+        .abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        BasePrecompileError::revert(IB20Asset::AnnouncementIdAlreadyUsed { id: "dup".into() })
+    );
+}
+
+#[test]
+fn golden_announce_reverts_on_nested_announce() {
+    let mut s = fresh();
+    seed(&mut s, |t| give_role(t, operator_role(), ALICE));
+    let nested = Bytes::from(
+        IB20Asset::announceCall {
+            internalCalls: vec![],
+            id: "inner".into(),
+            description: String::new(),
+            uri: String::new(),
+        }
+        .abi_encode(),
+    );
+    let err = op(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20Asset::announceCall {
+            internalCalls: vec![nested],
+            id: "outer".into(),
+            description: String::new(),
+            uri: String::new(),
+        }
+        .abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(err, BasePrecompileError::revert(IB20Asset::AnnouncementInProgress {}));
+}
+
+#[test]
+fn golden_announce_wraps_failing_internal_call() {
+    let mut s = fresh();
+    // ALICE has OPERATOR_ROLE (for announce) but not MINT_ROLE (for the inner mint).
+    seed(&mut s, |t| give_role(t, operator_role(), ALICE));
+    let inner = Bytes::from(IB20::mintCall { to: BOB, amount: U256::ONE }.abi_encode());
+    let err = op(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20Asset::announceCall {
+            internalCalls: vec![inner.clone()],
+            id: "split".into(),
+            description: String::new(),
+            uri: String::new(),
+        }
+        .abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(err, BasePrecompileError::revert(IB20Asset::InternalCallFailed { call: inner }));
+}
+
+#[test]
+fn golden_announce_reverts_on_malformed_internal_call() {
+    let mut s = fresh();
+    seed(&mut s, |t| give_role(t, operator_role(), ALICE));
+    let malformed = Bytes::from(vec![0x01, 0x02]);
+    let err = op(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20Asset::announceCall {
+            internalCalls: vec![malformed.clone()],
+            id: "split".into(),
+            description: String::new(),
+            uri: String::new(),
+        }
+        .abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        BasePrecompileError::revert(IB20Asset::InternalCallMalformed { call: malformed })
+    );
+}
+
+// ============================================================================
+// computed reads
+// ============================================================================
+
+#[test]
+fn golden_read_is_paused_and_paused_features() {
+    let mut s = fresh();
+    op_privileged(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20::pauseCall { features: vec![IB20::PausableFeature::MINT] }.abi_encode(),
+    )
+    .unwrap();
+
+    let paused_mint = op(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20::isPausedCall { feature: IB20::PausableFeature::MINT }.abi_encode(),
+    )
+    .unwrap();
+    assert_eq!(paused_mint, Bytes::from(true.abi_encode()));
+
+    let paused_transfer = op(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20::isPausedCall { feature: IB20::PausableFeature::TRANSFER }.abi_encode(),
+    )
+    .unwrap();
+    assert_eq!(paused_transfer, Bytes::from(false.abi_encode()));
+
+    let features =
+        op(&mut s, ALICE, InMemoryPolicy::new(), IB20::pausedFeaturesCall {}.abi_encode()).unwrap();
+    assert_eq!(features, Bytes::from(vec![IB20::PausableFeature::MINT].abi_encode()));
+}
+
+#[test]
+fn golden_read_policy_id_and_unsupported_scope() {
+    let mut s = fresh();
+    let ok = op(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20::policyIdCall { policyScope: B20PolicyType::TransferSender.id() }.abi_encode(),
+    )
+    .unwrap();
+    assert_eq!(ok, Bytes::from(0u64.abi_encode()));
+
+    let bad_scope = B256::repeat_byte(0xEE);
+    let err = op(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20::policyIdCall { policyScope: bad_scope }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        BasePrecompileError::revert(IB20::UnsupportedPolicyType { policyScope: bad_scope })
+    );
+}
+
+#[test]
+fn golden_read_domain_separator() {
+    let mut s = fresh();
+    let expected = domain_separator(&mut s);
+    let out = op(&mut s, ALICE, InMemoryPolicy::new(), IB20::DOMAIN_SEPARATORCall {}.abi_encode())
+        .unwrap();
+    assert_eq!(out, Bytes::from(expected.abi_encode()));
+    assert_root("read_domain_separator", s, ROOT_FRESH);
+}
+
+#[test]
+fn golden_read_eip712_domain() {
+    let mut s = fresh();
+    let out =
+        op(&mut s, ALICE, InMemoryPolicy::new(), IB20::eip712DomainCall {}.abi_encode()).unwrap();
+    let decoded = IB20::eip712DomainCall::abi_decode_returns(&out).unwrap();
+    assert_eq!(decoded.name, NAME);
+    assert_eq!(decoded.version, "1");
+    assert_eq!(decoded.chainId, U256::from(CHAIN_ID));
+    assert_eq!(decoded.verifyingContract, TOKEN);
+    assert_eq!(decoded.fields, alloy_primitives::FixedBytes::<1>::from([0x0f]));
+}
+
+// ============================================================================
+// asset-specific reads (multiplier / scaled balances / metadata / announce ids)
+// ============================================================================
+
+#[test]
+fn golden_read_asset_constants_and_multiplier() {
+    let mut s = fresh();
+    let cases: Vec<(Vec<u8>, Bytes)> = vec![
+        (IB20Asset::multiplierCall {}.abi_encode(), Bytes::from(wad().abi_encode())),
+        (IB20Asset::WAD_PRECISIONCall {}.abi_encode(), Bytes::from(wad().abi_encode())),
+        (IB20Asset::OPERATOR_ROLECall {}.abi_encode(), Bytes::from(operator_role().abi_encode())),
+        (
+            IB20Asset::extraMetadataCall { key: "category".into() }.abi_encode(),
+            Bytes::from(String::new().abi_encode()),
+        ),
+        (
+            IB20Asset::isAnnouncementIdUsedCall { id: "x".into() }.abi_encode(),
+            Bytes::from(false.abi_encode()),
+        ),
+    ];
+    for (calldata, expected) in cases {
+        let out = op(&mut s, ALICE, InMemoryPolicy::new(), calldata).unwrap();
+        assert_eq!(out, expected);
+    }
+    assert_root("read_asset_constants", s, ROOT_FRESH);
+}
+
+#[test]
+fn golden_read_scaled_balances_with_multiplier() {
+    let mut s = fresh();
+    // 2x multiplier: scaled = raw * 2; raw = scaled / 2.
+    seed(&mut s, |t| {
+        t.set_multiplier(wad() * u(2)).unwrap();
+        t.set_balance(ALICE, u(50)).unwrap();
+    });
+
+    let scaled = op(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20Asset::toScaledBalanceCall { rawBalance: u(50) }.abi_encode(),
+    )
+    .unwrap();
+    assert_eq!(scaled, Bytes::from(u(100).abi_encode()));
+
+    let raw = op(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20Asset::toRawBalanceCall { scaledBalance: u(100) }.abi_encode(),
+    )
+    .unwrap();
+    assert_eq!(raw, Bytes::from(u(50).abi_encode()));
+
+    let scaled_of = op(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20Asset::scaledBalanceOfCall { account: ALICE }.abi_encode(),
+    )
+    .unwrap();
+    assert_eq!(scaled_of, Bytes::from(u(100).abi_encode()));
+}
+
+// ============================================================================
+// direct + constant reads
+// ============================================================================
+
+#[test]
+fn golden_read_metadata_and_supply() {
+    let mut s = fresh();
+    let cases: Vec<(Vec<u8>, Bytes)> = vec![
+        (IB20::nameCall {}.abi_encode(), Bytes::from(NAME.abi_encode())),
+        (IB20::symbolCall {}.abi_encode(), Bytes::from(SYMBOL.abi_encode())),
+        (IB20::decimalsCall {}.abi_encode(), Bytes::from(u(DECIMALS as u64).abi_encode())),
+        (IB20::totalSupplyCall {}.abi_encode(), Bytes::from(U256::ZERO.abi_encode())),
+        (IB20::supplyCapCall {}.abi_encode(), Bytes::from(B20_MAX_SUPPLY_CAP.abi_encode())),
+        (IB20::contractURICall {}.abi_encode(), Bytes::from(String::new().abi_encode())),
+        (IB20::balanceOfCall { account: ALICE }.abi_encode(), Bytes::from(U256::ZERO.abi_encode())),
+        (
+            IB20::allowanceCall { owner: ALICE, spender: BOB }.abi_encode(),
+            Bytes::from(U256::ZERO.abi_encode()),
+        ),
+        (IB20::noncesCall { owner: ALICE }.abi_encode(), Bytes::from(U256::ZERO.abi_encode())),
+        (
+            IB20::hasRoleCall { role: B20TokenRole::Mint.id(), account: ALICE }.abi_encode(),
+            Bytes::from(false.abi_encode()),
+        ),
+        (
+            IB20::getRoleAdminCall { role: B20TokenRole::Mint.id() }.abi_encode(),
+            Bytes::from(B20TokenRole::DefaultAdmin.id().abi_encode()),
+        ),
+    ];
+    for (calldata, expected) in cases {
+        let out = op(&mut s, ALICE, InMemoryPolicy::new(), calldata).unwrap();
+        assert_eq!(out, expected);
+    }
+    assert_root("read_metadata", s, ROOT_FRESH);
+}
+
+#[test]
+fn golden_read_role_and_policy_constants() {
+    let mut s = fresh();
+    let cases: Vec<(Vec<u8>, B256)> = vec![
+        (IB20::DEFAULT_ADMIN_ROLECall {}.abi_encode(), B20TokenRole::DefaultAdmin.id()),
+        (IB20::MINT_ROLECall {}.abi_encode(), B20TokenRole::Mint.id()),
+        (IB20::BURN_ROLECall {}.abi_encode(), B20TokenRole::Burn.id()),
+        (IB20::BURN_BLOCKED_ROLECall {}.abi_encode(), B20TokenRole::BurnBlocked.id()),
+        (IB20::PAUSE_ROLECall {}.abi_encode(), B20TokenRole::Pause.id()),
+        (IB20::UNPAUSE_ROLECall {}.abi_encode(), B20TokenRole::Unpause.id()),
+        (IB20::METADATA_ROLECall {}.abi_encode(), B20TokenRole::Metadata.id()),
+        (IB20::TRANSFER_SENDER_POLICYCall {}.abi_encode(), B20PolicyType::TransferSender.id()),
+        (IB20::TRANSFER_RECEIVER_POLICYCall {}.abi_encode(), B20PolicyType::TransferReceiver.id()),
+        (IB20::TRANSFER_EXECUTOR_POLICYCall {}.abi_encode(), B20PolicyType::TransferExecutor.id()),
+        (IB20::MINT_RECEIVER_POLICYCall {}.abi_encode(), B20PolicyType::MintReceiver.id()),
+    ];
+    for (calldata, expected) in cases {
+        let out = op(&mut s, ALICE, InMemoryPolicy::new(), calldata).unwrap();
+        assert_eq!(out, Bytes::from(expected.abi_encode()));
+    }
+    assert_root("read_constants", s, ROOT_FRESH);
+}
+
+// ============================================================================
+// dispatch envelope (full path: nonpayable / uninitialized / pre-Beryl)
+// ============================================================================
+
+#[test]
+fn dispatch_rejects_nonzero_value() {
+    let mut s = fresh();
+    let calldata = IB20::balanceOfCall { account: ALICE }.abi_encode();
+    s.set_call_value(U256::ONE);
+    let out = StorageCtx::enter(&mut s, |ctx| {
+        B20AssetToken::with_storage_and_policy(
+            B20AssetStorage::from_address(TOKEN, ctx),
+            InMemoryPolicy::new(),
+        )
+        .dispatch_with_observer(
+            ctx,
+            &calldata,
+            BaseUpgrade::Beryl,
+            NoopPrecompileCallObserver,
+        )
+    })
+    .expect("dispatch must not fatally error");
+    assert!(out.is_revert());
+    assert_eq!(out.bytes, Bytes::from(IB20::NonPayable {}.abi_encode()));
+}
+
+#[test]
+fn dispatch_reverts_before_beryl() {
+    let mut s = fresh();
+    let calldata = IB20::balanceOfCall { account: ALICE }.abi_encode();
+    let out = StorageCtx::enter(&mut s, |ctx| {
+        B20AssetToken::with_storage_and_policy(
+            B20AssetStorage::from_address(TOKEN, ctx),
+            InMemoryPolicy::new(),
+        )
+        .dispatch_with_observer(
+            ctx,
+            &calldata,
+            BaseUpgrade::Azul,
+            NoopPrecompileCallObserver,
+        )
+    })
+    .expect("dispatch must not fatally error");
+    assert!(out.is_revert());
+    assert!(out.bytes.is_empty());
+}
+
+#[test]
+fn dispatch_reverts_when_uninitialized() {
+    // No `fresh()` init and no marker bytecode => is_initialized is false.
+    let mut s = HashMapStorageProvider::new(CHAIN_ID);
+    let calldata = IB20::balanceOfCall { account: ALICE }.abi_encode();
+    let out = StorageCtx::enter(&mut s, |ctx| {
+        B20AssetToken::with_storage_and_policy(
+            B20AssetStorage::from_address(TOKEN, ctx),
+            InMemoryPolicy::new(),
+        )
+        .dispatch_with_observer(
+            ctx,
+            &calldata,
+            BaseUpgrade::Beryl,
+            NoopPrecompileCallObserver,
+        )
+    })
+    .expect("dispatch must not fatally error");
+    assert!(out.is_revert());
+    assert!(out.bytes.is_empty());
+}

--- a/crates/common/precompiles/tests/b20_asset_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v1_golden.rs
@@ -114,6 +114,12 @@ const ROOT_BATCH_MINT: B256 =
     b256!("abeeb4354269e4994a293dc1decc3c33a61c566f8d8b8479a018c8a03bd744b0");
 const ROOT_ANNOUNCE: B256 =
     b256!("18badab132a0ba9de303e277d69816df82091fdc024322ea600bdbd3a6147068");
+const ROOT_GRANT_DEFAULT_ADMIN: B256 =
+    b256!("df78d6e3c794391187702ecd8f74b31c027363c342984bb972e7583b69a03f2f");
+const ROOT_GRANT_IDEMPOTENT: B256 =
+    b256!("39658b6dcaf82dc5e146d5d44fed26ba96b03220e92aa1fe9bd7cecb23437e22");
+const ROOT_GRANT_UNCHECKED: B256 =
+    b256!("6cdfdb30b62a059f71f67cec831aa1e1ddc44750e483bcd02c641b030cc4b8f4");
 
 // --- harness ----------------------------------------------------------------
 
@@ -1734,6 +1740,482 @@ fn dispatch_reverts_when_uninitialized() {
 }
 
 // ============================================================================
+// additional branch coverage: unprivileged auth guards + revert edges
+// ============================================================================
+
+#[test]
+fn golden_transfer_reverts_zero_sender() {
+    let mut s = fresh();
+    let err = op_privileged(
+        &mut s,
+        Address::ZERO,
+        InMemoryPolicy::new(),
+        IB20::transferCall { to: BOB, amount: u(1) }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(err, BasePrecompileError::revert(IB20::InvalidSender { sender: Address::ZERO }));
+}
+
+#[test]
+fn golden_transfer_from_reverts_zero_receiver() {
+    let mut s = fresh();
+    let err = op_privileged(
+        &mut s,
+        BOB,
+        InMemoryPolicy::new(),
+        IB20::transferFromCall { from: ALICE, to: Address::ZERO, amount: u(1) }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(err, BasePrecompileError::revert(IB20::InvalidReceiver { receiver: Address::ZERO }));
+}
+
+#[test]
+fn golden_transfer_from_reverts_zero_sender() {
+    let mut s = fresh();
+    let err = op_privileged(
+        &mut s,
+        BOB,
+        InMemoryPolicy::new(),
+        IB20::transferFromCall { from: Address::ZERO, to: CAROL, amount: u(1) }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(err, BasePrecompileError::revert(IB20::InvalidSender { sender: Address::ZERO }));
+}
+
+#[test]
+fn golden_approve_reverts_zero_approver() {
+    let mut s = fresh();
+    let err = op(
+        &mut s,
+        Address::ZERO,
+        InMemoryPolicy::new(),
+        IB20::approveCall { spender: BOB, amount: u(1) }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(err, BasePrecompileError::revert(IB20::InvalidApprover { approver: Address::ZERO }));
+}
+
+#[test]
+fn golden_mint_reverts_zero_receiver() {
+    let mut s = fresh();
+    let err = op_privileged(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20::mintCall { to: Address::ZERO, amount: u(1) }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(err, BasePrecompileError::revert(IB20::InvalidReceiver { receiver: Address::ZERO }));
+}
+
+#[test]
+fn golden_burn_reverts_insufficient_balance() {
+    let mut s = fresh();
+    seed(&mut s, |t| {
+        fund(t, ALICE, u(10));
+        give_role(t, B20TokenRole::Burn.id(), ALICE);
+    });
+    let err =
+        op(&mut s, ALICE, InMemoryPolicy::new(), IB20::burnCall { amount: u(50) }.abi_encode())
+            .unwrap_err();
+    assert_eq!(
+        err,
+        BasePrecompileError::revert(IB20::InsufficientBalance {
+            sender: ALICE,
+            balance: u(10),
+            needed: u(50),
+        })
+    );
+}
+
+#[test]
+fn golden_burn_blocked_unprivileged_requires_role() {
+    let mut s = fresh();
+    seed(&mut s, |t| fund(t, ALICE, u(100)));
+    let err = op(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20::burnBlockedCall { from: BOB, amount: u(1) }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
+            account: ALICE,
+            neededRole: B20TokenRole::BurnBlocked.id(),
+        })
+    );
+}
+
+#[test]
+fn golden_unpause_reverts_empty_feature_set() {
+    let mut s = fresh();
+    let err = op_privileged(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20::unpauseCall { features: vec![] }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(err, BasePrecompileError::revert(IB20::EmptyFeatureSet {}));
+}
+
+#[test]
+fn golden_unpause_unprivileged_requires_role() {
+    let mut s = fresh();
+    let err = op(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20::unpauseCall { features: vec![IB20::PausableFeature::MINT] }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
+            account: ALICE,
+            neededRole: B20TokenRole::Unpause.id(),
+        })
+    );
+}
+
+/// Asserts an unprivileged metadata/admin op reverts for a caller lacking `role`.
+fn assert_unprivileged_requires_role(calldata: Vec<u8>, role: B256) {
+    let mut s = fresh();
+    let err = op(&mut s, ALICE, InMemoryPolicy::new(), calldata).unwrap_err();
+    assert_eq!(
+        err,
+        BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
+            account: ALICE,
+            neededRole: role,
+        })
+    );
+}
+
+#[test]
+fn golden_update_supply_cap_unprivileged_requires_role() {
+    assert_unprivileged_requires_role(
+        IB20::updateSupplyCapCall { newSupplyCap: u(1) }.abi_encode(),
+        B20TokenRole::DefaultAdmin.id(),
+    );
+}
+
+#[test]
+fn golden_update_name_unprivileged_requires_role() {
+    assert_unprivileged_requires_role(
+        IB20::updateNameCall { newName: "x".into() }.abi_encode(),
+        B20TokenRole::Metadata.id(),
+    );
+}
+
+#[test]
+fn golden_update_symbol_unprivileged_requires_role() {
+    assert_unprivileged_requires_role(
+        IB20::updateSymbolCall { newSymbol: "x".into() }.abi_encode(),
+        B20TokenRole::Metadata.id(),
+    );
+}
+
+#[test]
+fn golden_update_contract_uri_unprivileged_requires_role() {
+    assert_unprivileged_requires_role(
+        IB20::updateContractURICall { newURI: "x".into() }.abi_encode(),
+        B20TokenRole::Metadata.id(),
+    );
+}
+
+#[test]
+fn golden_update_policy_unprivileged_requires_role() {
+    assert_unprivileged_requires_role(
+        IB20::updatePolicyCall { policyScope: B20PolicyType::TransferSender.id(), newPolicyId: 1 }
+            .abi_encode(),
+        B20TokenRole::DefaultAdmin.id(),
+    );
+}
+
+#[test]
+fn golden_update_multiplier_unprivileged_is_requires_operator_role() {
+    // Covered by golden_update_multiplier_requires_operator_role; kept for symmetry.
+    assert_unprivileged_requires_role(
+        IB20Asset::updateMultiplierCall { newMultiplier: wad() }.abi_encode(),
+        operator_role(),
+    );
+}
+
+#[test]
+fn golden_batch_mint_unprivileged_requires_role() {
+    let mut s = fresh();
+    let err = op(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20Asset::batchMintCall { recipients: vec![BOB], amounts: vec![u(1)] }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
+            account: ALICE,
+            neededRole: B20TokenRole::Mint.id(),
+        })
+    );
+}
+
+#[test]
+fn golden_update_extra_metadata_unprivileged_requires_role() {
+    let mut s = fresh();
+    let err = op(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20Asset::updateExtraMetadataCall { key: "k".into(), value: "v".into() }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
+            account: ALICE,
+            neededRole: B20TokenRole::Metadata.id(),
+        })
+    );
+}
+
+#[test]
+fn golden_announce_unprivileged_requires_operator_role() {
+    let mut s = fresh();
+    let err = op(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20Asset::announceCall {
+            internalCalls: vec![],
+            id: "x".into(),
+            description: String::new(),
+            uri: String::new(),
+        }
+        .abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
+            account: ALICE,
+            neededRole: operator_role(),
+        })
+    );
+}
+
+#[test]
+fn golden_grant_role_unprivileged_no_admin_reverts() {
+    let mut s = fresh();
+    let err = op(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20::grantRoleCall { role: B20TokenRole::Mint.id(), account: BOB }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
+            account: ALICE,
+            neededRole: B20TokenRole::DefaultAdmin.id(),
+        })
+    );
+}
+
+#[test]
+fn golden_grant_role_unprivileged_non_admin_caller_reverts() {
+    let mut s = fresh();
+    seed(&mut s, |t| give_role(t, B20TokenRole::DefaultAdmin.id(), ADMIN));
+    let err = op(
+        &mut s,
+        ALICE,
+        InMemoryPolicy::new(),
+        IB20::grantRoleCall { role: B20TokenRole::Mint.id(), account: BOB }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
+            account: ALICE,
+            neededRole: B20TokenRole::DefaultAdmin.id(),
+        })
+    );
+}
+
+#[test]
+fn golden_revoke_role_unprivileged_non_admin_caller_reverts() {
+    let mut s = fresh();
+    seed(&mut s, |t| give_role(t, B20TokenRole::DefaultAdmin.id(), ADMIN));
+    let err = op(
+        &mut s,
+        BOB,
+        InMemoryPolicy::new(),
+        IB20::revokeRoleCall { role: B20TokenRole::Mint.id(), account: ALICE }.abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
+            account: BOB,
+            neededRole: B20TokenRole::DefaultAdmin.id(),
+        })
+    );
+}
+
+#[test]
+fn golden_set_role_admin_unprivileged_non_admin_caller_reverts() {
+    let mut s = fresh();
+    seed(&mut s, |t| give_role(t, B20TokenRole::DefaultAdmin.id(), ADMIN));
+    let err = op(
+        &mut s,
+        BOB,
+        InMemoryPolicy::new(),
+        IB20::setRoleAdminCall {
+            role: B20TokenRole::Mint.id(),
+            newAdminRole: B20TokenRole::Metadata.id(),
+        }
+        .abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
+            account: BOB,
+            neededRole: B20TokenRole::DefaultAdmin.id(),
+        })
+    );
+}
+
+#[test]
+fn golden_renounce_role_reverts_last_admin() {
+    let mut s = fresh();
+    seed(&mut s, |t| give_role(t, B20TokenRole::DefaultAdmin.id(), ADMIN));
+    let err = op(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20::renounceRoleCall { role: B20TokenRole::DefaultAdmin.id(), callerConfirmation: ADMIN }
+            .abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(err, BasePrecompileError::revert(IB20::LastAdminCannotRenounce {}));
+}
+
+#[test]
+fn golden_grant_default_admin_bumps_member_count() {
+    let mut s = fresh();
+    seed(&mut s, |t| give_role(t, B20TokenRole::DefaultAdmin.id(), ADMIN));
+    let out = op_privileged(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20::grantRoleCall { role: B20TokenRole::DefaultAdmin.id(), account: ALICE }.abi_encode(),
+    )
+    .unwrap();
+
+    assert!(out.is_empty());
+    read(&mut s, |t| {
+        assert!(t.has_role(B20TokenRole::DefaultAdmin.id(), ALICE).unwrap());
+        assert_eq!(t.role_member_count(B20TokenRole::DefaultAdmin.id()).unwrap(), u(2));
+    });
+    assert_eq!(last_topic0(&s), IB20::RoleGranted::SIGNATURE_HASH);
+    assert_root("grant_default_admin", s, ROOT_GRANT_DEFAULT_ADMIN);
+}
+
+#[test]
+fn golden_grant_role_idempotent_when_already_held() {
+    let mut s = fresh();
+    seed(&mut s, |t| {
+        give_role(t, B20TokenRole::DefaultAdmin.id(), ADMIN);
+        give_role(t, B20TokenRole::Mint.id(), ALICE);
+    });
+    let out = op_privileged(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20::grantRoleCall { role: B20TokenRole::Mint.id(), account: ALICE }.abi_encode(),
+    )
+    .unwrap();
+
+    assert!(out.is_empty());
+    read(&mut s, |t| assert!(t.has_role(B20TokenRole::Mint.id(), ALICE).unwrap()));
+    assert_root("grant_idempotent", s, ROOT_GRANT_IDEMPOTENT);
+}
+
+#[test]
+fn golden_revoke_role_noop_when_not_held() {
+    let mut s = fresh();
+    let out = op_privileged(
+        &mut s,
+        ADMIN,
+        InMemoryPolicy::new(),
+        IB20::revokeRoleCall { role: B20TokenRole::Mint.id(), account: ALICE }.abi_encode(),
+    )
+    .unwrap();
+
+    assert!(out.is_empty());
+    read(&mut s, |t| assert!(!t.has_role(B20TokenRole::Mint.id(), ALICE).unwrap()));
+    assert_root("revoke_noop", s, ROOT_FRESH);
+}
+
+// ============================================================================
+// dispatch harness wrappers (no-observer dispatch, inner gating, factory bootstrap)
+// ============================================================================
+
+#[test]
+fn golden_dispatch_no_observer_wrapper_reverts_uninitialized() {
+    let mut s = HashMapStorageProvider::new(CHAIN_ID);
+    s.set_caller(ALICE);
+    let calldata = IB20::balanceOfCall { account: ALICE }.abi_encode();
+    let out = StorageCtx::enter(&mut s, |ctx| {
+        B20AssetToken::with_storage_and_policy(
+            B20AssetStorage::from_address(TOKEN, ctx),
+            InMemoryPolicy::new(),
+        )
+        .dispatch(ctx, &calldata, BaseUpgrade::Beryl)
+    })
+    .expect("dispatch must not fatally error");
+    assert!(out.is_revert());
+}
+
+#[test]
+fn golden_inner_reverts_before_beryl() {
+    let mut s = fresh();
+    let calldata = IB20::balanceOfCall { account: ALICE }.abi_encode();
+    let err = StorageCtx::enter(&mut s, |ctx| {
+        B20AssetToken::with_storage_and_policy(
+            B20AssetStorage::from_address(TOKEN, ctx),
+            InMemoryPolicy::new(),
+        )
+        .inner(ctx, &calldata, BaseUpgrade::Azul)
+    })
+    .unwrap_err();
+    assert_eq!(err, BasePrecompileError::Revert(Bytes::new()));
+}
+
+#[test]
+fn golden_grant_role_unchecked_bootstraps_first_admin() {
+    let mut s = fresh();
+    s.set_caller(TOKEN);
+    StorageCtx::enter(&mut s, |ctx| {
+        let mut token = B20AssetToken::with_storage_and_policy(
+            B20AssetStorage::from_address(TOKEN, ctx),
+            InMemoryPolicy::new(),
+        );
+        token.grant_role_unchecked(B20TokenRole::DefaultAdmin.id(), ADMIN, TOKEN).unwrap();
+    });
+    read(&mut s, |t| {
+        assert!(t.has_role(B20TokenRole::DefaultAdmin.id(), ADMIN).unwrap());
+        assert_eq!(t.role_member_count(B20TokenRole::DefaultAdmin.id()).unwrap(), U256::ONE);
+    });
+    assert_eq!(last_topic0(&s), IB20::RoleGranted::SIGNATURE_HASH);
+    assert_root("grant_unchecked", s, ROOT_GRANT_UNCHECKED);
+}
+
+// ============================================================================
 // meta: op coverage checklist
 // ============================================================================
 
@@ -1766,16 +2248,21 @@ fn v1_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Asset::IB20AssetCall
             golden_transfer_reverts_zero_receiver,
             golden_transfer_reverts_insufficient_balance,
             golden_transfer_reverts_when_paused,
+            golden_transfer_reverts_zero_sender,
         ]),
         C::transferFrom(_) => covered(&[
             golden_transfer_from_finite_allowance_decrements,
             golden_transfer_from_infinite_allowance_not_decremented,
             golden_transfer_from_reverts_insufficient_allowance,
             golden_transfer_from_unprivileged_enforces_executor_policy,
+            golden_transfer_from_reverts_zero_receiver,
+            golden_transfer_from_reverts_zero_sender,
         ]),
-        C::approve(_) => {
-            covered(&[golden_approve_sets_allowance_and_emits, golden_approve_reverts_zero_spender])
-        }
+        C::approve(_) => covered(&[
+            golden_approve_sets_allowance_and_emits,
+            golden_approve_reverts_zero_spender,
+            golden_approve_reverts_zero_approver,
+        ]),
         C::transferWithMemo(_) => covered(&[golden_transfer_with_memo_emits_transfer_then_memo]),
         C::transferFromWithMemo(_) => covered(&[golden_transfer_from_with_memo]),
 
@@ -1784,13 +2271,18 @@ fn v1_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Asset::IB20AssetCall
             golden_mint_privileged_still_enforces_receiver_policy,
             golden_mint_unprivileged_requires_role_and_policy,
             golden_mint_reverts_over_supply_cap,
+            golden_mint_reverts_zero_receiver,
         ]),
         C::mintWithMemo(_) => covered(&[golden_mint_with_memo]),
-        C::burn(_) => covered(&[golden_burn_requires_role_then_reduces_supply]),
+        C::burn(_) => covered(&[
+            golden_burn_requires_role_then_reduces_supply,
+            golden_burn_reverts_insufficient_balance,
+        ]),
         C::burnWithMemo(_) => covered(&[golden_burn_with_memo]),
         C::burnBlocked(_) => covered(&[
             golden_burn_blocked_destroys_from_blocked_account,
             golden_burn_blocked_reverts_when_not_blocked,
+            golden_burn_blocked_unprivileged_requires_role,
         ]),
 
         // pause / config / roles / policy / permit
@@ -1799,25 +2291,57 @@ fn v1_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Asset::IB20AssetCall
             golden_pause_reverts_empty_feature_set,
             golden_pause_unprivileged_requires_role,
         ]),
-        C::unpause(_) => covered(&[golden_unpause_clears_feature_bit]),
-        C::updateSupplyCap(_) => {
-            covered(&[golden_update_supply_cap, golden_update_supply_cap_reverts_below_supply])
+        C::unpause(_) => covered(&[
+            golden_unpause_clears_feature_bit,
+            golden_unpause_reverts_empty_feature_set,
+            golden_unpause_unprivileged_requires_role,
+        ]),
+        C::updateSupplyCap(_) => covered(&[
+            golden_update_supply_cap,
+            golden_update_supply_cap_reverts_below_supply,
+            golden_update_supply_cap_unprivileged_requires_role,
+        ]),
+        C::updateName(_) => covered(&[
+            golden_update_name_emits_name_and_domain_changed,
+            golden_update_name_unprivileged_requires_role,
+        ]),
+        C::updateSymbol(_) => {
+            covered(&[golden_update_symbol, golden_update_symbol_unprivileged_requires_role])
         }
-        C::updateName(_) => covered(&[golden_update_name_emits_name_and_domain_changed]),
-        C::updateSymbol(_) => covered(&[golden_update_symbol]),
-        C::updateContractURI(_) => covered(&[golden_update_contract_uri]),
-        C::grantRole(_) => covered(&[golden_grant_role]),
-        C::revokeRole(_) => covered(&[golden_revoke_role, golden_revoke_last_admin_rejected]),
-        C::renounceRole(_) => {
-            covered(&[golden_renounce_role, golden_renounce_role_bad_confirmation])
-        }
+        C::updateContractURI(_) => covered(&[
+            golden_update_contract_uri,
+            golden_update_contract_uri_unprivileged_requires_role,
+        ]),
+        C::grantRole(_) => covered(&[
+            golden_grant_role,
+            golden_grant_role_unprivileged_no_admin_reverts,
+            golden_grant_role_unprivileged_non_admin_caller_reverts,
+            golden_grant_default_admin_bumps_member_count,
+            golden_grant_role_idempotent_when_already_held,
+        ]),
+        C::revokeRole(_) => covered(&[
+            golden_revoke_role,
+            golden_revoke_last_admin_rejected,
+            golden_revoke_role_unprivileged_non_admin_caller_reverts,
+            golden_revoke_role_noop_when_not_held,
+        ]),
+        C::renounceRole(_) => covered(&[
+            golden_renounce_role,
+            golden_renounce_role_bad_confirmation,
+            golden_renounce_role_reverts_last_admin,
+        ]),
         C::renounceLastAdmin(_) => {
             covered(&[golden_renounce_last_admin, golden_renounce_last_admin_reverts_when_not_sole])
         }
-        C::setRoleAdmin(_) => covered(&[golden_set_role_admin]),
-        C::updatePolicy(_) => {
-            covered(&[golden_update_policy, golden_update_policy_reverts_missing_policy])
-        }
+        C::setRoleAdmin(_) => covered(&[
+            golden_set_role_admin,
+            golden_set_role_admin_unprivileged_non_admin_caller_reverts,
+        ]),
+        C::updatePolicy(_) => covered(&[
+            golden_update_policy,
+            golden_update_policy_reverts_missing_policy,
+            golden_update_policy_unprivileged_requires_role,
+        ]),
         C::permit(_) => covered(&[
             golden_permit_sets_allowance_and_increments_nonce,
             golden_permit_reverts_when_expired,
@@ -1871,21 +2395,26 @@ fn v1_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Asset::IB20AssetCall
             golden_update_multiplier,
             golden_update_multiplier_requires_operator_role,
             golden_update_multiplier_rejects_zero,
+            golden_update_multiplier_unprivileged_is_requires_operator_role,
         ]),
         SC::batchMint(_) => covered(&[
             golden_batch_mint,
             golden_batch_mint_reverts_length_mismatch,
             golden_batch_mint_reverts_empty_batch,
+            golden_batch_mint_unprivileged_requires_role,
         ]),
-        SC::updateExtraMetadata(_) => {
-            covered(&[golden_update_extra_metadata, golden_update_extra_metadata_rejects_empty_key])
-        }
+        SC::updateExtraMetadata(_) => covered(&[
+            golden_update_extra_metadata,
+            golden_update_extra_metadata_rejects_empty_key,
+            golden_update_extra_metadata_unprivileged_requires_role,
+        ]),
         SC::announce(_) => covered(&[
             golden_announce_runs_internal_calls_and_brackets_events,
             golden_announce_reverts_on_reused_id,
             golden_announce_reverts_on_nested_announce,
             golden_announce_wraps_failing_internal_call,
             golden_announce_reverts_on_malformed_internal_call,
+            golden_announce_unprivileged_requires_operator_role,
         ]),
     }
 }


### PR DESCRIPTION
## Summary

Adds a golden/snapshot test suite pinning current **Asset V1** behavior of the B-20 precompile (BOP-423), before/while it is frozen behind the versioning seam from #3969 (BOP-417). Sibling of the stablecoin golden suite (#3971).

Every op is driven through the **version-resolver-gated** path (`inner(..., BaseUpgrade::Beryl)` → `AssetVersions::from_base_upgrade` → V1) against the real EVM-backed `B20AssetStorage` over `HashMapStorageProvider`, with `InMemoryPolicy` for deterministic allow/block. Each mutation case asserts:

1. exact returned ABI bytes (or the typed revert),
2. resulting state (balances / supply / roles / allowances / multiplier / metadata / storage),
3. emitted event signature(s), and
4. a pinned keccak **storage hash** over the sorted storage triples (`hash_state`) — a reference baseline for the CI frozen-manifest check (BOP-421).

Plus a dedicated `golden_gas_footprints` test pinning each mutating op's **storage-access footprint** — the `(SLOAD, SSTORE, KECCAK256)` op counts, the deterministic gas-schedule-independent signal that drives real gas — so an extra storage access in V1 is caught even when bytes/state/events match.

**Op coverage:** the shared B-20 surface (transfer / transferFrom / approve + memo variants, mint / burn / burnBlocked, pause / unpause, updateSupplyCap|Name|Symbol|ContractURI, grant/revoke/renounce/renounceLastAdmin/setRoleAdmin, updatePolicy, permit, all reads + role/policy constants), **plus the asset-specific ops**: `updateMultiplier` (operator role, zero-reject), `updateExtraMetadata` (metadata role, empty-key reject), `batchMint` (mint role, length-mismatch / empty-batch), `announce` (operator role, internal-call loop, reused-id, nested-announce, malformed / failing internal call), and the scaled-balance reads (`multiplier`, `toScaledBalance`, `toRawBalance`, `scaledBalanceOf`, configurable `decimals`). Privileged vs unprivileged via `inner_with_privilege` vs `inner`; the guard envelope (nonpayable / uninitialized / pre-Beryl) via `dispatch_with_observer`; plus the factory `grant_role_unchecked` bootstrap.

**Edge cases:** zero-address (sender / receiver / approver), insufficient balance/allowance, supply-cap, paused, policy-blocked sender + executor policy, empty-feature-set, last-admin protection (revoke/renounce), expired permit, and every **unprivileged authorization revert** (caller lacking the required role) — including the asset-specific `batchMint` / `updateExtraMetadata` / `announce` / `updateMultiplier` role checks.

**Meta coverage guard:** a compile-time `v1_op_coverage_checklist` — an exhaustive `match` over the generated `IB20Calls` / `IB20AssetCalls` enums whose arms reference the covering golden `#[test]` fns. Adding an ABI op fails the build (non-exhaustive match) until a golden is added; renaming/removing a golden fails the build (missing fn reference). This intentionally couples to the shared ABI surface: when a future version extends the ABI, this suite is expected to be updated to assert the new op reverts for V1.

No source/logic changes — frozen V1 is untouched; only a new integration test file and one `[[test]]` stanza are added.

## Coverage

Region/line coverage of the frozen logic from this suite alone (via `cargo llvm-cov`, this test target only):

- `b20_asset/logic/v1.rs`: **100% line, 100% function, 91.1% region**
- `b20_asset/dispatch.rs`: **97.2% line, 92.7% region**

Remaining uncovered regions are defensive `checked_*().ok_or_else(under_overflow)` closures (incl. the scaled-balance overflow guard) and `&&`/`||` short-circuit halves — unreachable without contriving arithmetic overflow.

## Testing

- `cargo test -p base-common-precompiles --features test-utils --test b20_asset_v1_golden` → **98 passed**
- full crate (`cargo test -p base-common-precompiles --features test-utils`) green; clippy (`--all-targets`) + fmt clean

State hashes are pinned; regenerate with `BLESS_GOLDEN=1 cargo test ... -- --nocapture` (documented in the file header).
