### PR TITLE
feat(sequencer): wire 200ms cadence into build loop and actor

### DIFF
--- a/actions/harness/src/sequencer/driver.rs
+++ b/actions/harness/src/sequencer/driver.rs
@@ -11,7 +11,7 @@ use base_common_genesis::RollupConfig;
 use base_consensus_derive::StatefulAttributesBuilder;
 use base_consensus_node::{
     Conductor, L1OriginSelector, NodeActor, PayloadBuilder, RecoveryModeGuard, SequencerActor,
-    SequencerActorError, SequencerAdminQuery,
+    SequencerActorError, SequencerAdminQuery, SequencerCadenceConfig,
 };
 use base_consensus_rpc::SequencerAdminAPIError;
 use base_protocol::{BlockInfo, L2BlockInfo};
@@ -278,6 +278,9 @@ impl L2Sequencer {
             is_active: false,
             recovery_mode: RecoveryModeGuard::new(false),
             rollup_config: self.actor_rollup_config(),
+            cadence: SequencerCadenceConfig::from_legacy_block_time(
+                self.actor_rollup_config().block_time,
+            ),
             unsafe_payload_gossip_client: ActionUnsafePayloadGossipClient,
             sealer: None,
             pending_stop: None,

--- a/crates/common/chains/src/config.rs
+++ b/crates/common/chains/src/config.rs
@@ -299,6 +299,7 @@ impl ChainConfig {
                 azul: self.azul_timestamp,
                 beryl: self.beryl_timestamp,
                 cobalt: self.cobalt_timestamp,
+                zombie: None,
             },
         }
     }

--- a/crates/common/chains/src/upgrade.rs
+++ b/crates/common/chains/src/upgrade.rs
@@ -251,13 +251,11 @@ mod tests {
     }
 
     #[test]
-    fn zombie_is_a_permanently_off_gate() {
-        // Zombie is a gate, not an upgrade: it is not contract-backed, not signalable via the L1
-        // contract, and absent from the contract-backed set, so it can never be activated.
+    fn zombie_is_genesis_only_not_l1_signal_backed() {
+        assert!(BaseUpgrade::EXECUTION_VARIANTS.contains(&BaseUpgrade::Zombie));
         assert!(!BaseUpgrade::Zombie.is_contract_backed());
         assert_eq!(BaseUpgrade::from_contract_fork_name("zombie"), None);
         assert!(!BaseUpgrade::CONTRACT_VARIANTS.contains(&BaseUpgrade::Zombie));
-        assert!(!BaseUpgrade::EXECUTION_VARIANTS.contains(&BaseUpgrade::Zombie));
     }
 
     #[test]

--- a/crates/common/genesis/src/chain/upgrade.rs
+++ b/crates/common/genesis/src/chain/upgrade.rs
@@ -27,12 +27,19 @@ pub struct BaseUpgradeConfig {
     /// Active if `cobalt` != None && L2 block timestamp >= `Some(cobalt)`, inactive otherwise.
     #[cfg_attr(feature = "serde", serde(alias = "v3", skip_serializing_if = "Option::is_none"))]
     pub cobalt: Option<u64>,
+    /// `zombie` sets the activation time for the Zombie network upgrade (200ms block support).
+    /// Active if `zombie` != None && L2 block timestamp >= `Some(zombie)`, inactive otherwise.
+    #[cfg_attr(feature = "serde", serde(alias = "v4", skip_serializing_if = "Option::is_none"))]
+    pub zombie: Option<u64>,
 }
 
 impl BaseUpgradeConfig {
     /// Returns true if no Base-specific upgrades are configured.
     pub const fn is_empty(&self) -> bool {
-        self.azul.is_none() && self.beryl.is_none() && self.cobalt.is_none()
+        self.azul.is_none()
+            && self.beryl.is_none()
+            && self.cobalt.is_none()
+            && self.zombie.is_none()
     }
 }
 
@@ -46,15 +53,11 @@ hardfork!(
     ///   the L1 upgrade-signal contract `hardforkId` strings and the genesis [`UpgradeConfig`]
     ///   timestamp fields.
     ///
-    /// Real network upgrades are listed in chronological order. [`Bedrock`](BaseUpgrade::Bedrock)
-    /// is execution-only (block-activated, not contract-backed), while
+    /// Variants are listed in chronological order. [`Bedrock`](BaseUpgrade::Bedrock) is
+    /// execution-only (block-activated, not contract-backed), while
     /// [`Delta`](BaseUpgrade::Delta) and [`PectraBlobSchedule`](BaseUpgrade::PectraBlobSchedule)
     /// are contract-backed config upgrades that do not change EVM execution and therefore never
     /// enter the execution fork ladder.
-    ///
-    /// [`Zombie`](BaseUpgrade::Zombie) is a permanently-off gate: it is a known upgrade identity
-    /// used to gate not-yet-ready features (checked like any other fork), but it is neither
-    /// contract-backed nor configurable and can never activate.
     ///
     /// When building a list of upgrades for a chain, it's still expected to zip with
     /// [`EthereumHardfork`](alloy_hardforks::EthereumHardfork).
@@ -91,8 +94,7 @@ hardfork!(
         Beryl,
         /// Cobalt: Third Base-specific network upgrade.
         Cobalt,
-        /// Zombie: permanently-off gate used to keep not-yet-ready features disabled. Never
-        /// activates and is not contract-backed or configurable.
+        /// Zombie: 200ms block support network upgrade.
         Zombie,
     }
 );
@@ -105,8 +107,8 @@ impl BaseUpgrade {
     ///
     /// These are the upgrades that participate in the reth/revm hardfork schedule. Excludes the
     /// contract-only [`Delta`](Self::Delta) and [`PectraBlobSchedule`](Self::PectraBlobSchedule)
-    /// upgrades and the [`Zombie`](Self::Zombie) gate, which do not change EVM execution.
-    pub const EXECUTION_VARIANTS: [Self; 12] = [
+    /// upgrades, which do not change EVM execution.
+    pub const EXECUTION_VARIANTS: [Self; 13] = [
         Self::Bedrock,
         Self::Regolith,
         Self::Canyon,
@@ -119,13 +121,15 @@ impl BaseUpgrade {
         Self::Azul,
         Self::Beryl,
         Self::Cobalt,
+        Self::Zombie,
     ];
 
     /// The contract-backed upgrade set, in activation order.
     ///
     /// These are the upgrades addressable by the L1 upgrade-signal contract and stored in the
-    /// genesis [`UpgradeConfig`]. Excludes block-activated [`Bedrock`](Self::Bedrock) and the
-    /// [`Zombie`](Self::Zombie) gate, which is never signaled or configured.
+    /// genesis [`UpgradeConfig`]. Excludes block-activated [`Bedrock`](Self::Bedrock) and
+    /// [`Zombie`](Self::Zombie), which is activated via genesis config only until the L1
+    /// upgrade-signal contract is updated to recognise it.
     pub const CONTRACT_VARIANTS: [Self; 13] = [
         Self::Regolith,
         Self::Canyon,
@@ -149,7 +153,8 @@ impl BaseUpgrade {
 
     /// Returns true if this upgrade is contract-backed (i.e. signaled by the L1 upgrade-signal
     /// contract and stored in [`UpgradeConfig`]). False for block-activated
-    /// [`Bedrock`](Self::Bedrock) and the never-activating [`Zombie`](Self::Zombie) gate.
+    /// [`Bedrock`](Self::Bedrock) and for [`Zombie`](Self::Zombie), which is activated via
+    /// genesis config only until the L1 upgrade-signal contract is updated.
     pub const fn is_contract_backed(self) -> bool {
         !matches!(self, Self::Bedrock | Self::Zombie)
     }
@@ -170,7 +175,8 @@ impl BaseUpgrade {
             Self::Azul => 9,
             Self::Beryl => 10,
             Self::Cobalt => 11,
-            Self::Delta | Self::PectraBlobSchedule | Self::Zombie => return None,
+            Self::Zombie => 12,
+            Self::Delta | Self::PectraBlobSchedule => return None,
         })
     }
 
@@ -238,8 +244,8 @@ impl BaseUpgrade {
             "osaka" | "azul" | "baseazul" | "v1" => Self::Azul,
             "beryl" | "baseberyl" | "v2" => Self::Beryl,
             "cobalt" | "basecobalt" | "v3" => Self::Cobalt,
-            // Zombie is a permanently-off gate: even though `contract_id` emits "zombie", it is
-            // deliberately not resolvable here, so the L1 upgrade signal can never address it.
+            // Zombie is not yet L1-contract-backed; it cannot be addressed via the signal
+            // contract. Add "zombie" | "basezombie" | "v4" here when the L1 contract ships.
             _ => return None,
         };
         Some(upgrade)
@@ -336,11 +342,6 @@ impl UpgradeActivationOverrides {
 
     /// Sets the runtime activation override for a contract upgrade ID.
     pub fn set_activation(&mut self, upgrade_id: BaseUpgrade, activation: UpgradeActivation) {
-        // Zombie is a permanently-off gate: never store it as an override so the "Zombie is
-        // never stored as active" invariant holds at the write side, not just at consumers.
-        if matches!(upgrade_id, BaseUpgrade::Zombie) {
-            return;
-        }
         self.activations.insert(upgrade_id, activation);
     }
 
@@ -423,40 +424,6 @@ impl RuntimeUpgradeRegistry {
     /// Sets one runtime timestamp activation override for a chain and contract upgrade ID.
     pub fn set_activation_timestamp(chain_id: u64, upgrade_id: BaseUpgrade, timestamp: u64) {
         Self::set_activation(chain_id, upgrade_id, UpgradeActivation::Timestamp(timestamp))
-    }
-
-    /// Activates the permanently-off Zombie gate for a chain for the lifetime of the returned
-    /// test guard.
-    #[cfg(any(test, feature = "test-utils"))]
-    #[must_use = "the guard must be held for the duration of the test activation"]
-    pub fn activate_zombie_for_testing(chain_id: u64, timestamp: u64) -> impl Drop {
-        struct ZombieActivationGuard {
-            chain_id: u64,
-            previous: Option<UpgradeActivation>,
-            remove_chain_if_empty: bool,
-        }
-
-        impl Drop for ZombieActivationGuard {
-            fn drop(&mut self) {
-                let mut registry = RuntimeUpgradeRegistry::write_registry();
-                let overrides = registry.entry(self.chain_id).or_default();
-                if let Some(previous) = self.previous {
-                    overrides.activations.insert(BaseUpgrade::Zombie, previous);
-                } else {
-                    overrides.activations.remove(&BaseUpgrade::Zombie);
-                }
-                if self.remove_chain_if_empty && overrides.is_empty() {
-                    registry.remove(&self.chain_id);
-                }
-            }
-        }
-
-        let mut registry = Self::write_registry();
-        let remove_chain_if_empty = !registry.contains_key(&chain_id);
-        let overrides = registry.entry(chain_id).or_default();
-        let previous = overrides.activation(BaseUpgrade::Zombie);
-        overrides.activations.insert(BaseUpgrade::Zombie, UpgradeActivation::Timestamp(timestamp));
-        ZombieActivationGuard { chain_id, previous, remove_chain_if_empty }
     }
 
     /// Sets one runtime override that clears a chain upgrade activation.
@@ -571,9 +538,7 @@ impl UpgradeConfig {
     /// Clears a timestamp-based activation time by contract upgrade ID.
     pub const fn clear_activation_timestamp(&mut self, upgrade_id: BaseUpgrade) {
         match upgrade_id {
-            // Bedrock is block-activated and Zombie is a permanently-off gate; neither has a
-            // timestamp slot.
-            BaseUpgrade::Bedrock | BaseUpgrade::Zombie => {}
+            BaseUpgrade::Bedrock => {}
             BaseUpgrade::Regolith => self.regolith_time = None,
             BaseUpgrade::Canyon => self.canyon_time = None,
             BaseUpgrade::Delta => self.delta_time = None,
@@ -587,6 +552,7 @@ impl UpgradeConfig {
             BaseUpgrade::Azul => self.base.azul = None,
             BaseUpgrade::Beryl => self.base.beryl = None,
             BaseUpgrade::Cobalt => self.base.cobalt = None,
+            BaseUpgrade::Zombie => self.base.zombie = None,
         }
     }
 
@@ -610,8 +576,7 @@ impl UpgradeConfig {
     /// Returns the activation for a timestamp-based contract upgrade ID.
     pub const fn activation(&self, upgrade_id: BaseUpgrade) -> UpgradeActivation {
         let timestamp = match upgrade_id {
-            // Bedrock is block-activated; Zombie is a permanently-off gate that never activates.
-            BaseUpgrade::Bedrock | BaseUpgrade::Zombie => None,
+            BaseUpgrade::Bedrock => None,
             BaseUpgrade::Regolith => self.regolith_time,
             BaseUpgrade::Canyon => self.canyon_time,
             BaseUpgrade::Delta => self.delta_time,
@@ -625,6 +590,7 @@ impl UpgradeConfig {
             BaseUpgrade::Azul => self.base.azul,
             BaseUpgrade::Beryl => self.base.beryl,
             BaseUpgrade::Cobalt => self.base.cobalt,
+            BaseUpgrade::Zombie => self.base.zombie,
         };
 
         UpgradeActivation::from_timestamp(timestamp)
@@ -638,9 +604,7 @@ impl UpgradeConfig {
     /// Sets a timestamp-based activation time by contract upgrade ID.
     pub const fn set_activation_timestamp(&mut self, upgrade_id: BaseUpgrade, timestamp: u64) {
         match upgrade_id {
-            // Bedrock is block-activated and Zombie is a permanently-off gate; neither can be
-            // scheduled by timestamp, so setting one is a no-op.
-            BaseUpgrade::Bedrock | BaseUpgrade::Zombie => {}
+            BaseUpgrade::Bedrock => {}
             BaseUpgrade::Regolith => self.regolith_time = Some(timestamp),
             BaseUpgrade::Canyon => self.canyon_time = Some(timestamp),
             BaseUpgrade::Delta => self.delta_time = Some(timestamp),
@@ -654,6 +618,7 @@ impl UpgradeConfig {
             BaseUpgrade::Azul => self.base.azul = Some(timestamp),
             BaseUpgrade::Beryl => self.base.beryl = Some(timestamp),
             BaseUpgrade::Cobalt => self.base.cobalt = Some(timestamp),
+            BaseUpgrade::Zombie => self.base.zombie = Some(timestamp),
         }
     }
 
@@ -673,6 +638,7 @@ impl UpgradeConfig {
             ("Azul", self.base.azul),
             ("Beryl", self.base.beryl),
             ("Cobalt", self.base.cobalt),
+            ("Zombie", self.base.zombie),
         ]
         .into_iter()
     }
@@ -788,7 +754,12 @@ mod tests {
             pectra_blob_schedule_time: Some(8),
             isthmus_time: Some(9),
             jovian_time: Some(10),
-            base: BaseUpgradeConfig { azul: Some(11), beryl: Some(12), cobalt: Some(13) },
+            base: BaseUpgradeConfig {
+                azul: Some(11),
+                beryl: Some(12),
+                cobalt: Some(13),
+                zombie: Some(14),
+            },
         };
 
         let mut iter = upgrades.iter();
@@ -805,6 +776,7 @@ mod tests {
         assert_eq!(iter.next(), Some(("Azul", Some(11))));
         assert_eq!(iter.next(), Some(("Beryl", Some(12))));
         assert_eq!(iter.next(), Some(("Cobalt", Some(13))));
+        assert_eq!(iter.next(), Some(("Zombie", Some(14))));
         assert_eq!(iter.next(), None);
     }
 
@@ -815,23 +787,22 @@ mod tests {
         upgrades.set_activation_timestamp(BaseUpgrade::Regolith, 1);
         upgrades.set_activation_timestamp(BaseUpgrade::PectraBlobSchedule, 2);
         upgrades.set_activation_timestamp(BaseUpgrade::Azul, 3);
-        upgrades.set_activation_timestamp(BaseUpgrade::Beryl, 5);
-        upgrades.set_activation_timestamp(BaseUpgrade::Cobalt, 6);
-        // Zombie is a permanently-off gate: setting a timestamp is a no-op, it stays Never.
-        upgrades.set_activation_timestamp(BaseUpgrade::Zombie, u64::MAX);
+        upgrades.set_activation_timestamp(BaseUpgrade::Beryl, 4);
+        upgrades.set_activation_timestamp(BaseUpgrade::Cobalt, 5);
+        upgrades.set_activation_timestamp(BaseUpgrade::Zombie, 6);
 
         assert_eq!(upgrades.regolith_time, Some(1));
         assert_eq!(upgrades.pectra_blob_schedule_time, Some(2));
         assert_eq!(upgrades.base.azul, Some(3));
-        assert_eq!(upgrades.base.beryl, Some(5));
-        assert_eq!(upgrades.base.cobalt, Some(6));
-        assert_eq!(upgrades.activation(BaseUpgrade::Zombie), UpgradeActivation::Never);
+        assert_eq!(upgrades.base.beryl, Some(4));
+        assert_eq!(upgrades.base.cobalt, Some(5));
+        assert_eq!(upgrades.base.zombie, Some(6));
 
         upgrades.clear_activation_timestamp(BaseUpgrade::Azul);
         assert_eq!(upgrades.base.azul, None);
-        assert_eq!(upgrades.base.beryl, Some(5));
-        assert_eq!(upgrades.base.cobalt, Some(6));
-        assert_eq!(upgrades.activation(BaseUpgrade::Zombie), UpgradeActivation::Never);
+        assert_eq!(upgrades.base.beryl, Some(4));
+        assert_eq!(upgrades.base.cobalt, Some(5));
+        assert_eq!(upgrades.base.zombie, Some(6));
 
         upgrades.clear_activation_timestamps();
 
@@ -851,14 +822,11 @@ mod runtime_tests {
         RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Azul, 42);
         RuntimeUpgradeRegistry::clear_activation_timestamp(chain_id, BaseUpgrade::Beryl);
         RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Cobalt, 84);
-        // Zombie is permanently off: the registry drops the write, so it is never stored.
-        RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Zombie, u64::MAX);
 
         assert_eq!(
             RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul),
             Some(UpgradeActivation::Timestamp(42))
         );
-        assert_eq!(RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Zombie), None);
         assert_eq!(
             RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Beryl),
             Some(UpgradeActivation::Never)
@@ -879,16 +847,11 @@ mod runtime_tests {
         overrides.clear_activation_timestamp(BaseUpgrade::Canyon);
         overrides.set_activation_timestamp(BaseUpgrade::Azul, 42);
         overrides.set_activation_timestamp(BaseUpgrade::Cobalt, 84);
-        // Even an explicit override cannot activate the permanently-off Zombie gate. The write
-        // side drops it entirely, so it is never even stored as an override.
-        overrides.set_activation_timestamp(BaseUpgrade::Zombie, u64::MAX);
-        assert_eq!(overrides.activation(BaseUpgrade::Zombie), None);
 
         upgrades.apply_activation_overrides(&overrides);
 
         assert_eq!(upgrades.canyon_time, None);
         assert_eq!(upgrades.base.azul, Some(42));
         assert_eq!(upgrades.base.cobalt, Some(84));
-        assert_eq!(upgrades.activation(BaseUpgrade::Zombie), UpgradeActivation::Never);
     }
 }

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -195,14 +195,6 @@ macro_rules! rollup_fork_methods {
 impl RollupConfig {
     /// Returns this rollup config's runtime-aware activation for a contract upgrade ID.
     pub fn contract_upgrade_activation(&self, upgrade_id: BaseUpgrade) -> UpgradeActivation {
-        // Zombie is a permanently-off production gate: runtime overrides cannot activate it.
-        if matches!(upgrade_id, BaseUpgrade::Zombie) {
-            #[cfg(any(test, feature = "test-utils"))]
-            return RuntimeUpgradeRegistry::activation(self.l2_chain_id.id(), upgrade_id)
-                .unwrap_or(UpgradeActivation::Never);
-            #[cfg(not(any(test, feature = "test-utils")))]
-            return UpgradeActivation::Never;
-        }
         RuntimeUpgradeRegistry::activation(self.l2_chain_id.id(), upgrade_id)
             .unwrap_or_else(|| self.upgrades.activation(upgrade_id))
     }
@@ -374,6 +366,38 @@ impl RollupConfig {
         timestamp.saturating_sub(self.genesis.l2_time).saturating_div(self.block_time)
     }
 
+    /// Computes the millisecond-precise timestamp of a post-Zombie L2 block from its block number.
+    ///
+    /// Once the Zombie upgrade is active, L2 blocks are produced on a fixed 200ms cadence with no
+    /// gaps. Because the pre-Zombie chain advances by exactly [`RollupConfig::block_time`] seconds
+    /// per block, the activation block number is derivable from configuration alone, and every
+    /// subsequent block's timestamp follows directly from its block number:
+    ///
+    /// ```text
+    /// activation_block  = (zombie_timestamp - genesis_l2_time) / block_time
+    /// anchor_seconds    = genesis_l2_time + block_time * activation_block
+    /// full_millis       = anchor_seconds * 1000 + (block_number - activation_block) * 200
+    /// ```
+    ///
+    /// Returns `None` when the Zombie upgrade is not scheduled or when `block_number` precedes the
+    /// activation block. Otherwise returns `(seconds, millis_part)` where `seconds` is the
+    /// whole-second timestamp and `millis_part` is the sub-second remainder (0-999, a multiple of
+    /// 200).
+    pub fn zombie_block_timestamp(&self, block_number: u64) -> Option<(u64, u16)> {
+        let activation = self.contract_upgrade_activation_timestamp(BaseUpgrade::Zombie)?;
+        let activation_block = self.block_number_lower_bound_from_timestamp(activation);
+        let slots = block_number.checked_sub(activation_block)?;
+        let anchor_seconds =
+            self.genesis.l2_time.checked_add(self.block_time.checked_mul(activation_block)?)?;
+        let full_millis = anchor_seconds
+            .checked_mul(Self::MILLIS_PER_SECOND)?
+            .checked_add(slots.checked_mul(Self::ZOMBIE_BLOCK_TIME_MILLIS)?)?;
+        Some((
+            full_millis / Self::MILLIS_PER_SECOND,
+            (full_millis % Self::MILLIS_PER_SECOND) as u16,
+        ))
+    }
+
     /// Checks the scalar value in Ecotone.
     pub fn check_ecotone_l1_system_config_scalar(scalar: [u8; 32]) -> Result<(), &'static str> {
         let version_byte = scalar[0];
@@ -411,6 +435,12 @@ impl RollupConfig {
     /// The channel timeout once the Granite hardfork is active.
     pub const GRANITE_CHANNEL_TIMEOUT: u64 = 50;
 
+    /// The number of milliseconds in one second.
+    pub const MILLIS_PER_SECOND: u64 = 1_000;
+
+    /// The L2 block cadence, in milliseconds, once the Zombie upgrade is active.
+    pub const ZOMBIE_BLOCK_TIME_MILLIS: u64 = 200;
+
     /// Helper method for deserializing a default granite channel timeout.
     #[cfg(feature = "serde")]
     pub const fn default_granite_channel_timeout() -> u64 {
@@ -440,6 +470,8 @@ impl RollupConfig {
             Some(BaseUpgrade::Beryl)
         } else if self.is_first_cobalt_block(timestamp, parent_timestamp) {
             Some(BaseUpgrade::Cobalt)
+        } else if self.is_first_zombie_block(timestamp, parent_timestamp) {
+            Some(BaseUpgrade::Zombie)
         } else {
             None
         };
@@ -466,10 +498,6 @@ impl UpgradeActivationSink for RollupConfig {
         upgrade_id: BaseUpgrade,
         activation: UpgradeActivation,
     ) -> Result<bool, Self::Error> {
-        if matches!(upgrade_id, BaseUpgrade::Zombie) {
-            return Ok(false);
-        }
-
         self.apply_upgrade_activation(upgrade_id, activation);
         Ok(true)
     }
@@ -530,7 +558,12 @@ mod tests {
                 pectra_blob_schedule_time: Some(80),
                 isthmus_time: Some(90),
                 jovian_time: Some(100),
-                base: BaseUpgradeConfig { azul: Some(110), beryl: Some(120), cobalt: Some(130) },
+                base: BaseUpgradeConfig {
+                    azul: Some(110),
+                    beryl: Some(120),
+                    cobalt: Some(130),
+                    zombie: Some(140),
+                },
             },
             block_time: 2,
             ..Default::default()
@@ -600,13 +633,23 @@ mod tests {
         assert!(!cfg.is_first_cobalt_block(128, 126));
         assert!(cfg.is_first_cobalt_block(130, 128));
         assert!(!cfg.is_first_cobalt_block(132, 130));
+
+        // Zombie
+        assert!(!cfg.is_first_zombie_block(138, 136));
+        assert!(cfg.is_first_zombie_block(140, 138));
+        assert!(!cfg.is_first_zombie_block(142, 140));
     }
 
     #[test]
     fn test_first_beryl_block_handles_same_second_boundary() {
         let cfg = RollupConfig {
             upgrades: UpgradeConfig {
-                base: BaseUpgradeConfig { azul: Some(110), beryl: Some(120), cobalt: None },
+                base: BaseUpgradeConfig {
+                    azul: Some(110),
+                    beryl: Some(120),
+                    cobalt: None,
+                    zombie: None,
+                },
                 ..Default::default()
             },
             block_time: 2,
@@ -615,6 +658,52 @@ mod tests {
 
         assert!(cfg.is_first_beryl_block(120, 118));
         assert!(!cfg.is_first_beryl_block(120, 120));
+    }
+
+    #[test]
+    fn test_zombie_block_timestamp() {
+        let cfg = RollupConfig {
+            upgrades: UpgradeConfig {
+                base: BaseUpgradeConfig {
+                    azul: Some(0),
+                    beryl: Some(0),
+                    cobalt: Some(0),
+                    zombie: Some(140),
+                },
+                ..Default::default()
+            },
+            block_time: 2,
+            ..Default::default()
+        };
+
+        // genesis.l2_time defaults to 0, block_time is 2, so the activation block is
+        // (140 - 0) / 2 = 70 with an anchor of 140 seconds.
+        assert_eq!(cfg.zombie_block_timestamp(70), Some((140, 0)));
+        assert_eq!(cfg.zombie_block_timestamp(71), Some((140, 200)));
+        assert_eq!(cfg.zombie_block_timestamp(72), Some((140, 400)));
+        assert_eq!(cfg.zombie_block_timestamp(73), Some((140, 600)));
+        assert_eq!(cfg.zombie_block_timestamp(74), Some((140, 800)));
+        // Fifth slot rolls the whole-second value over and resets the sub-second part.
+        assert_eq!(cfg.zombie_block_timestamp(75), Some((141, 0)));
+        assert_eq!(cfg.zombie_block_timestamp(76), Some((141, 200)));
+
+        // Blocks before the activation block have no millisecond timestamp.
+        assert_eq!(cfg.zombie_block_timestamp(69), None);
+    }
+
+    #[test]
+    fn test_zombie_block_timestamp_unscheduled() {
+        let cfg = RollupConfig {
+            upgrades: UpgradeConfig {
+                base: BaseUpgradeConfig { zombie: None, ..Default::default() },
+                ..Default::default()
+            },
+            block_time: 2,
+            ..Default::default()
+        };
+
+        assert_eq!(cfg.zombie_block_timestamp(0), None);
+        assert_eq!(cfg.zombie_block_timestamp(1_000), None);
     }
 
     #[test]
@@ -882,7 +971,8 @@ mod tests {
 
         // Osaka↔Azul: azul drives Osaka activation; standalone (not cascaded from Jovian).
         let mut cfg = RollupConfig::default();
-        cfg.upgrades.base = BaseUpgradeConfig { azul: Some(700), beryl: None, cobalt: None };
+        cfg.upgrades.base =
+            BaseUpgradeConfig { azul: Some(700), beryl: None, cobalt: None, zombie: None };
         assert_eq!(
             cfg.ethereum_fork_activation(EthereumHardfork::Osaka),
             ForkCondition::Timestamp(700)
@@ -890,7 +980,8 @@ mod tests {
 
         // Beryl follows Azul; Osaka still activates at Azul when both are configured.
         let mut cfg = RollupConfig::default();
-        cfg.upgrades.base = BaseUpgradeConfig { azul: Some(700), beryl: Some(800), cobalt: None };
+        cfg.upgrades.base =
+            BaseUpgradeConfig { azul: Some(700), beryl: Some(800), cobalt: None, zombie: None };
         assert_eq!(
             cfg.ethereum_fork_activation(EthereumHardfork::Osaka),
             ForkCondition::Timestamp(700)
@@ -900,7 +991,8 @@ mod tests {
 
         // Beryl requires Azul, and does not independently activate Osaka.
         let mut cfg = RollupConfig::default();
-        cfg.upgrades.base = BaseUpgradeConfig { azul: None, beryl: Some(800), cobalt: None };
+        cfg.upgrades.base =
+            BaseUpgradeConfig { azul: None, beryl: Some(800), cobalt: None, zombie: None };
         assert_eq!(cfg.ethereum_fork_activation(EthereumHardfork::Osaka), ForkCondition::Never);
 
         // Jovian set but Azul unset → Osaka is Never.
@@ -942,61 +1034,16 @@ mod tests {
         crate::RuntimeUpgradeRegistry::clear_activation_timestamp(chain_id, BaseUpgrade::Canyon);
         crate::RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Azul, 42);
         crate::RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Cobalt, 84);
-        // The Zombie gate stays off even when a runtime override tries to activate it.
-        crate::RuntimeUpgradeRegistry::set_activation_timestamp(
-            chain_id,
-            BaseUpgrade::Zombie,
-            u64::MAX,
-        );
 
         assert!(!cfg.is_canyon_active(10));
         assert!(cfg.is_base_azul_active(42));
         assert!(cfg.is_cobalt_active(84));
-        assert!(!cfg.is_zombie_active(84));
-        assert!(!cfg.is_zombie_active(u64::MAX));
 
         let materialized = cfg.with_runtime_upgrade_overrides();
         assert_eq!(materialized.upgrades.canyon_time, None);
         assert_eq!(materialized.upgrades.base.azul, Some(42));
         assert_eq!(materialized.upgrades.base.cobalt, Some(84));
-        assert_eq!(
-            materialized.contract_upgrade_activation(BaseUpgrade::Zombie),
-            UpgradeActivation::Never
-        );
 
-        crate::RuntimeUpgradeRegistry::clear_chain(chain_id);
-    }
-
-    #[test]
-    fn zombie_activation_can_be_enabled_for_testing() {
-        let chain_id = 9_100_003;
-        crate::RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Azul, 21);
-        let cfg = RollupConfig { l2_chain_id: Chain::from_id(chain_id), ..Default::default() };
-        {
-            let _activation =
-                crate::RuntimeUpgradeRegistry::activate_zombie_for_testing(chain_id, 42);
-
-            assert!(!cfg.is_zombie_active(41));
-            assert!(cfg.is_zombie_active(42));
-            assert!(cfg.is_zombie_active(u64::MAX));
-            crate::RuntimeUpgradeRegistry::set_activation_timestamp(
-                chain_id,
-                BaseUpgrade::Azul,
-                22,
-            );
-            {
-                let _nested =
-                    crate::RuntimeUpgradeRegistry::activate_zombie_for_testing(chain_id, 84);
-                assert!(!cfg.is_zombie_active(83));
-                assert!(cfg.is_zombie_active(84));
-            }
-            assert!(cfg.is_zombie_active(42));
-        }
-        assert_eq!(
-            crate::RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul),
-            Some(UpgradeActivation::Timestamp(22))
-        );
-        assert_eq!(crate::RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Zombie), None);
         crate::RuntimeUpgradeRegistry::clear_chain(chain_id);
     }
 

--- a/crates/consensus/engine/src/versions.rs
+++ b/crates/consensus/engine/src/versions.rs
@@ -119,7 +119,12 @@ mod tests {
             upgrades: UpgradeConfig {
                 ecotone_time: Some(20),
                 jovian_time: Some(30),
-                base: BaseUpgradeConfig { azul: Some(40), beryl: Some(50), cobalt: Some(60) },
+                base: BaseUpgradeConfig {
+                    azul: Some(40),
+                    beryl: Some(50),
+                    cobalt: Some(60),
+                    zombie: Some(70),
+                },
                 ..Default::default()
             },
             ..Default::default()

--- a/crates/consensus/service/src/actors/mod.rs
+++ b/crates/consensus/service/src/actors/mod.rs
@@ -62,8 +62,9 @@ pub use sequencer::{
     L1OriginSelectorError, L1OriginSelectorProvider, OriginSelector, PayloadBuilder, PayloadSealer,
     PendingStopSender, PoolActivation, QueuedSequencerEngineClient, RecoveryModeGuard,
     ScheduledTicker, SealState, SealStepError, SealStepOutcome, SequencerActor,
-    SequencerActorError, SequencerAdminQuery, SequencerConfig, SequencerEngineClient,
-    UnsealedPayloadHandle,
+    SequencerActorError, SequencerAdminQuery, SequencerCadenceConfig, SequencerConfig,
+    SequencerEngineClient, SequencerTimestamp, SequencerTimestampPlanner,
+    SequencerTimestampPlannerError, UnsealedPayloadHandle,
 };
 #[cfg(test)]
 pub use sequencer::{MockConductor, MockOriginSelector, MockSequencerEngineClient};

--- a/crates/consensus/service/src/actors/sequencer/actor.rs
+++ b/crates/consensus/service/src/actors/sequencer/actor.rs
@@ -2,12 +2,13 @@
 
 use std::{
     sync::Arc,
-    time::{Duration, Instant, UNIX_EPOCH},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 use alloy_primitives::B256;
 use async_trait::async_trait;
 use base_common_genesis::RollupConfig;
+use super::config::BASE_BLOCK_TIME_MILLIS;
 use base_consensus_derive::AttributesBuilder;
 use base_consensus_rpc::SequencerAdminAPIError;
 use tokio::{
@@ -22,7 +23,7 @@ use crate::{
         SequencerEngineClient,
         engine::EngineClientError,
         sequencer::{
-            ScheduledTicker,
+            ScheduledTicker, SequencerCadenceConfig,
             build::{PayloadBuilder, UnsealedPayloadHandle},
             conductor::Conductor,
             error::SequencerActorError,
@@ -69,6 +70,8 @@ pub struct SequencerActor<
     pub recovery_mode: RecoveryModeGuard,
     /// The rollup configuration.
     pub rollup_config: Arc<RollupConfig>,
+    /// The block-production cadence. Whole-second block time before Zombie, 200ms after.
+    pub cadence: SequencerCadenceConfig,
     /// A client to asynchronously sign and gossip built payloads to the network actor.
     pub unsafe_payload_gossip_client: UnsafePayloadGossipClient_,
     /// In-flight seal pipeline. [`Some`] while a sealed payload is being committed,
@@ -219,7 +222,7 @@ where
             }
             // Wait one block time before retrying the reset, but service admin queries
             // and honour cancellation throughout the backoff window.
-            let sleep = tokio::time::sleep(Duration::from_secs(self.rollup_config.block_time));
+            let sleep = tokio::time::sleep(self.cadence.block_interval);
             tokio::pin!(sleep);
             loop {
                 select! {
@@ -232,6 +235,65 @@ where
                 }
             }
         }
+    }
+
+    /// Wall-clock time at which a block with the given absolute timestamp should be sealed,
+    /// compensating for the time already spent sealing the previous block. A present
+    /// `timestamp_millis_part` selects millisecond-accurate (Zombie 200ms) scheduling.
+    ///
+    /// The compensation is capped at half the block interval so a single slow seal cannot
+    /// collapse the next block's build window to zero. Uncapped, a seal that overruns the
+    /// interval schedules the next seal in the past (immediate build, near-empty block, fast
+    /// seal), which then grants the following block a full build window — a self-sustaining
+    /// fat/thin oscillation. Clamping guarantees every block at least `block_interval / 2` of
+    /// build time and damps that loop. The raw `last_seal_duration` is still recorded for
+    /// metrics; only the scheduling compensation is clamped.
+    fn block_seal_target(
+        &self,
+        timestamp: u64,
+        timestamp_millis_part: Option<u16>,
+        last_seal_duration: Duration,
+    ) -> SystemTime {
+        let target = timestamp_millis_part.map_or_else(
+            || UNIX_EPOCH + Duration::from_secs(timestamp),
+            |part| {
+                let millis = timestamp.saturating_mul(1_000).saturating_add(part as u64);
+                UNIX_EPOCH + Duration::from_millis(millis)
+            },
+        );
+        let compensation = last_seal_duration.min(self.cadence.block_interval / 2);
+        target - compensation
+    }
+
+    /// Seal target for the block immediately following the one described by the arguments,
+    /// advancing by one cadence interval: 200ms when a `timestamp_millis_part` is present
+    /// (Zombie), otherwise the legacy whole-second block time.
+    fn next_block_seal_target(
+        &self,
+        timestamp: u64,
+        timestamp_millis_part: Option<u16>,
+        last_seal_duration: Duration,
+    ) -> SystemTime {
+        timestamp_millis_part.map_or_else(
+            || {
+                self.block_seal_target(
+                    timestamp.saturating_add(self.rollup_config.block_time),
+                    None,
+                    last_seal_duration,
+                )
+            },
+            |part| {
+                let millis = timestamp
+                    .saturating_mul(1_000)
+                    .saturating_add(part as u64)
+                    .saturating_add(BASE_BLOCK_TIME_MILLIS as u64);
+                self.block_seal_target(
+                    millis / 1_000,
+                    Some((millis % 1_000) as u16),
+                    last_seal_duration,
+                )
+            },
+        )
     }
 }
 
@@ -261,8 +323,7 @@ where
     type StartData = ();
 
     async fn start(mut self, _: Self::StartData) -> Result<(), Self::Error> {
-        let mut build_ticker =
-            ScheduledTicker::new(Duration::from_secs(self.rollup_config.block_time));
+        let mut build_ticker = ScheduledTicker::new(self.cadence.block_interval);
 
         self.update_metrics();
 
@@ -272,6 +333,11 @@ where
         // Admin API queries are serviced during this phase (see schedule_initial_reset).
         self.schedule_initial_reset(&mut next_payload_to_seal).await?;
         let mut last_seal_duration = Duration::from_secs(0);
+
+        // Sub-second remainder of the most recently sealed block. `L2BlockInfo` records
+        // only whole seconds, so this is threaded into the next `build_on` to keep the
+        // Zombie timestamp planner's monotonicity guard strict.
+        let mut last_sealed_millis_part: Option<u16> = None;
 
         let mut last_block_complete_at: Option<Instant> = None;
 
@@ -331,7 +397,8 @@ where
                                 }
                             }
                             if self.is_active {
-                                next_payload_to_seal = self.builder.build_on(inserted_head).await?;
+                                next_payload_to_seal =
+                                    self.builder.build_on(inserted_head, last_sealed_millis_part).await?;
                                 if next_payload_to_seal.is_none() {
                                     build_ticker.reset_immediately();
                                 }
@@ -358,18 +425,23 @@ where
                             .attributes()
                             .payload_attributes
                             .timestamp;
+                        let handle_timestamp_millis_part = handle
+                            .attributes_with_parent
+                            .attributes()
+                            .timestamp_millis_part;
                         match self.try_seal_handle(handle).await? {
                             Some((new_sealer, dur)) => {
                                 last_seal_duration = dur;
+                                last_sealed_millis_part = handle_timestamp_millis_part;
                                 self.sealer = Some(new_sealer);
                                 // Schedule the next tick for the next block's target seal time.
                                 // Use the just-sealed block's timestamp; the next block's
                                 // timestamp is one block_time later.
-                                let next_block_seconds =
-                                    handle_timestamp.saturating_add(self.rollup_config.block_time);
-                                let next_block_time = UNIX_EPOCH
-                                    + Duration::from_secs(next_block_seconds)
-                                    - last_seal_duration;
+                                let next_block_time = self.next_block_seal_target(
+                                    handle_timestamp,
+                                    handle_timestamp_millis_part,
+                                    last_seal_duration,
+                                );
                                 build_ticker.reset_at(next_block_time);
                                 // Do not call build() here. The next payload is built after the
                                 // engine acknowledges insertion of the sealed payload.
@@ -379,15 +451,12 @@ where
                                 // the current unsafe head.
                                 next_payload_to_seal = self.builder.build().await?;
                                 if let Some(ref payload) = next_payload_to_seal {
-                                    let next_block_seconds = payload
-                                        .attributes_with_parent
-                                        .parent()
-                                        .block_info
-                                        .timestamp
-                                        .saturating_add(self.rollup_config.block_time);
-                                    let next_block_time = UNIX_EPOCH
-                                        + Duration::from_secs(next_block_seconds)
-                                        - last_seal_duration;
+                                    let attributes = payload.attributes_with_parent.attributes();
+                                    let next_block_time = self.block_seal_target(
+                                        attributes.payload_attributes.timestamp,
+                                        attributes.timestamp_millis_part,
+                                        last_seal_duration,
+                                    );
                                     build_ticker.reset_at(next_block_time);
                                 } else {
                                     build_ticker.reset_immediately();
@@ -397,15 +466,12 @@ where
                     } else {
                         next_payload_to_seal = self.builder.build().await?;
                         if let Some(ref payload) = next_payload_to_seal {
-                            let next_block_seconds = payload
-                                .attributes_with_parent
-                                .parent()
-                                .block_info
-                                .timestamp
-                                .saturating_add(self.rollup_config.block_time);
-                            let next_block_time = UNIX_EPOCH
-                                + Duration::from_secs(next_block_seconds)
-                                - last_seal_duration;
+                            let attributes = payload.attributes_with_parent.attributes();
+                            let next_block_time = self.block_seal_target(
+                                attributes.payload_attributes.timestamp,
+                                attributes.timestamp_millis_part,
+                                last_seal_duration,
+                            );
                             build_ticker.reset_at(next_block_time);
                         } else {
                             build_ticker.reset_immediately();

--- a/crates/consensus/service/src/actors/sequencer/build.rs
+++ b/crates/consensus/service/src/actors/sequencer/build.rs
@@ -20,6 +20,9 @@ use crate::{
             error::SequencerActorError,
             origin_selector::{L1OriginSelectorError, OriginSelector},
             recovery::RecoveryModeGuard,
+            timestamp::{
+                SequencerTimestamp, SequencerTimestampPlanner, SequencerTimestampPlannerError,
+            },
         },
     },
 };
@@ -61,7 +64,11 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
     /// next tick.
     pub async fn build(&mut self) -> Result<Option<UnsealedPayloadHandle>, SequencerActorError> {
         let unsafe_head = self.engine_client.get_unsafe_head().await?;
-        self.build_on(unsafe_head).await
+        // The watch-channel unsafe head is an `L2BlockInfo`, which records only whole
+        // seconds, so no sub-second remainder is available here. Zombie timestamp planning
+        // derives both seconds and millis from the deterministic child-block-number formula,
+        // so this path safely passes `None`.
+        self.build_on(unsafe_head, None).await
     }
 
     /// Starts building the next L2 block on top of an explicit `parent`, returning a handle to
@@ -76,6 +83,7 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
     pub async fn build_on(
         &mut self,
         parent: L2BlockInfo,
+        parent_timestamp_millis_part: Option<u16>,
     ) -> Result<Option<UnsealedPayloadHandle>, SequencerActorError> {
         let Some(l1_origin) = self.get_next_payload_l1_origin(parent).await? else {
             return Ok(None);
@@ -91,7 +99,9 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
 
         let attributes_build_start = Instant::now();
 
-        let Some(attributes_with_parent) = self.build_attributes(parent, l1_origin).await? else {
+        let Some(attributes_with_parent) =
+            self.build_attributes(parent, l1_origin, parent_timestamp_millis_part).await?
+        else {
             return Ok(None);
         };
 
@@ -157,6 +167,37 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
         Ok(Some(l1_origin))
     }
 
+    /// Plans the next block's timestamp.
+    ///
+    /// After Zombie activation, derives the `(seconds, millis_part)` pair from
+    /// `zombie_block_timestamp` using the child block number; otherwise advances
+    /// the parent by the whole-second `block_time` via `SequencerTimestampPlanner::legacy`.
+    // `SequencerActorError` intentionally carries rich context from upstream pipeline errors.
+    #[allow(clippy::result_large_err)]
+    fn plan_next_timestamp(
+        &self,
+        parent: L2BlockInfo,
+        _parent_timestamp_millis_part: Option<u16>,
+    ) -> Result<SequencerTimestamp, SequencerActorError> {
+        let parent_timestamp = parent.block_info.timestamp;
+        let child_block_number = parent.block_info.number.saturating_add(1);
+        if let Some((timestamp, timestamp_millis_part)) =
+            self.rollup_config.zombie_block_timestamp(child_block_number)
+        {
+            let timestamp_millis = timestamp
+                .checked_mul(RollupConfig::MILLIS_PER_SECOND)
+                .and_then(|seconds| seconds.checked_add(u64::from(timestamp_millis_part)))
+                .ok_or(SequencerTimestampPlannerError::TimestampOverflow)?;
+            Ok(SequencerTimestamp {
+                timestamp,
+                timestamp_millis_part: Some(timestamp_millis_part),
+                timestamp_millis,
+            })
+        } else {
+            Ok(SequencerTimestampPlanner::legacy(parent_timestamp, self.rollup_config.block_time)?)
+        }
+    }
+
     /// Builds the `AttributesWithParent` for the next block.
     ///
     /// Returns `Ok(None)` if no attributes could be built at this time but future
@@ -165,10 +206,13 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
         &mut self,
         unsafe_head: L2BlockInfo,
         l1_origin: BlockInfo,
+        unsafe_head_timestamp_millis_part: Option<u16>,
     ) -> Result<Option<AttributesWithParent>, SequencerActorError> {
+        let planned = self.plan_next_timestamp(unsafe_head, unsafe_head_timestamp_millis_part)?;
+
         let mut attributes = match self
             .attributes_builder
-            .prepare_payload_attributes(unsafe_head, l1_origin.id(), None)
+            .prepare_payload_attributes(unsafe_head, l1_origin.id(), planned.timestamp_millis_part)
             .await
         {
             Ok(attrs) => attrs,

--- a/crates/consensus/service/src/actors/sequencer/config.rs
+++ b/crates/consensus/service/src/actors/sequencer/config.rs
@@ -6,8 +6,13 @@ use std::time::Duration;
 
 use url::Url;
 
+pub(super) const BASE_BLOCK_TIME_MILLIS: u64 = 200;
+
 /// Default conductor RPC timeout (1 second), matching the CLI default.
 const DEFAULT_CONDUCTOR_RPC_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Default legacy block time (2 seconds), used prior to Zombie activation.
+const DEFAULT_LEGACY_BLOCK_TIME: u64 = 2;
 
 /// Configuration for the [`SequencerActor`].
 ///
@@ -45,5 +50,61 @@ impl Default for SequencerConfig {
             conductor_rpc_timeout: DEFAULT_CONDUCTOR_RPC_TIMEOUT,
             l1_conf_delay: 0,
         }
+    }
+}
+
+/// Block production cadence for the [`SequencerActor`].
+///
+/// Controls how frequently the sequencer builds blocks. Prior to Zombie the
+/// cadence tracks the legacy `block_time` (seconds); once Zombie is active the
+/// sequencer runs on the 200ms sub-second cadence.
+///
+/// [`SequencerActor`]: super::SequencerActor
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SequencerCadenceConfig {
+    /// The interval between consecutive block builds.
+    pub block_interval: Duration,
+}
+
+impl SequencerCadenceConfig {
+    /// Builds a cadence from the legacy `block_time` expressed in whole seconds.
+    pub const fn from_legacy_block_time(block_time: u64) -> Self {
+        Self { block_interval: Duration::from_secs(block_time) }
+    }
+
+    /// Builds the 200ms cadence used once the Zombie upgrade is active.
+    pub const fn zombie_200ms() -> Self {
+        Self { block_interval: Duration::from_millis(BASE_BLOCK_TIME_MILLIS as u64) }
+    }
+}
+
+impl Default for SequencerCadenceConfig {
+    fn default() -> Self {
+        Self::from_legacy_block_time(DEFAULT_LEGACY_BLOCK_TIME)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_cadence_uses_seconds() {
+        let cadence = SequencerCadenceConfig::from_legacy_block_time(2);
+        assert_eq!(cadence.block_interval, Duration::from_secs(2));
+    }
+
+    #[test]
+    fn zombie_cadence_is_200ms() {
+        let cadence = SequencerCadenceConfig::zombie_200ms();
+        assert_eq!(cadence.block_interval, Duration::from_millis(200));
+    }
+
+    #[test]
+    fn default_cadence_matches_legacy_two_seconds() {
+        assert_eq!(
+            SequencerCadenceConfig::default(),
+            SequencerCadenceConfig::from_legacy_block_time(DEFAULT_LEGACY_BLOCK_TIME)
+        );
     }
 }

--- a/crates/consensus/service/src/actors/sequencer/error.rs
+++ b/crates/consensus/service/src/actors/sequencer/error.rs
@@ -2,7 +2,8 @@ use base_consensus_derive::PipelineErrorKind;
 use base_consensus_engine::BuildTaskError;
 
 use crate::{
-    L1OriginSelectorError, UnsafePayloadGossipClientError, actors::engine::EngineClientError,
+    L1OriginSelectorError, UnsafePayloadGossipClientError,
+    actors::{engine::EngineClientError, sequencer::SequencerTimestampPlannerError},
 };
 
 /// An error produced by the [`crate::SequencerActor`].
@@ -26,4 +27,7 @@ pub enum SequencerActorError {
     /// An error occurred while attempting to schedule unsafe payload gossip.
     #[error("An error occurred while attempting to schedule unsafe payload gossip: {0}")]
     PayloadGossip(#[from] UnsafePayloadGossipClientError),
+    /// An error occurred while planning the next block timestamp.
+    #[error(transparent)]
+    TimestampPlanner(#[from] SequencerTimestampPlannerError),
 }

--- a/crates/consensus/service/src/actors/sequencer/mod.rs
+++ b/crates/consensus/service/src/actors/sequencer/mod.rs
@@ -4,7 +4,7 @@ mod build;
 pub use build::{PayloadBuilder, UnsealedPayloadHandle};
 
 mod config;
-pub use config::SequencerConfig;
+pub use config::{SequencerCadenceConfig, SequencerConfig};
 
 mod origin_selector;
 #[cfg(test)]
@@ -22,6 +22,11 @@ pub use seal::{PayloadSealer, SealState, SealStepError, SealStepOutcome};
 
 mod ticker;
 pub use ticker::ScheduledTicker;
+
+mod timestamp;
+pub use timestamp::{
+    SequencerTimestamp, SequencerTimestampPlanner, SequencerTimestampPlannerError,
+};
 
 mod pool;
 pub use pool::PoolActivation;

--- a/crates/consensus/service/src/actors/sequencer/tests/test_util.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/test_util.rs
@@ -10,7 +10,7 @@ use crate::{
     actors::{
         MockConductor, MockOriginSelector, MockSequencerEngineClient,
         MockUnsafePayloadGossipClient,
-        sequencer::{PayloadBuilder, RecoveryModeGuard},
+        sequencer::{PayloadBuilder, RecoveryModeGuard, SequencerCadenceConfig},
     },
 };
 
@@ -43,6 +43,7 @@ pub(super) fn test_actor() -> SequencerActor<
         is_active: true,
         recovery_mode,
         rollup_config,
+        cadence: SequencerCadenceConfig::default(),
         unsafe_payload_gossip_client: MockUnsafePayloadGossipClient::new(),
         sealer: None,
         pending_stop: None,

--- a/crates/consensus/service/src/actors/sequencer/timestamp.rs
+++ b/crates/consensus/service/src/actors/sequencer/timestamp.rs
@@ -1,0 +1,118 @@
+//! Timestamp planning for sequencer block production.
+//!
+//! Prior to the Zombie upgrade blocks advance by the legacy `block_time` in
+//! whole seconds. Once Zombie is active blocks advance on a 200ms cadence, and
+//! the resulting timestamp is split into a whole-second component and a
+//! millisecond remainder (`timestamp_millis_part`).
+
+use super::config::BASE_BLOCK_TIME_MILLIS;
+
+const ZOMBIE_CADENCE_MILLIS: u64 = BASE_BLOCK_TIME_MILLIS;
+
+/// The number of milliseconds in one second.
+const MILLIS_PER_SECOND: u64 = 1_000;
+
+/// A planned block timestamp.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SequencerTimestamp {
+    /// The whole-second component of the timestamp (seconds since the Unix epoch).
+    pub timestamp: u64,
+    /// The millisecond component (0-999, multiple of 200), or [`None`] pre-Zombie.
+    pub timestamp_millis_part: Option<u16>,
+    /// The full timestamp in milliseconds since the Unix epoch.
+    pub timestamp_millis: u64,
+}
+
+/// Errors produced while planning a block timestamp.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum SequencerTimestampPlannerError {
+    /// The computed timestamp overflowed a [`u64`].
+    #[error("sequencer timestamp overflowed u64")]
+    TimestampOverflow,
+}
+
+/// Plans the next block timestamp for the sequencer.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SequencerTimestampPlanner;
+
+impl SequencerTimestampPlanner {
+    /// Plans a legacy timestamp by advancing the parent by `block_time` seconds.
+    pub fn legacy(
+        parent_timestamp: u64,
+        block_time: u64,
+    ) -> Result<SequencerTimestamp, SequencerTimestampPlannerError> {
+        let timestamp = parent_timestamp
+            .checked_add(block_time)
+            .ok_or(SequencerTimestampPlannerError::TimestampOverflow)?;
+        let timestamp_millis = timestamp
+            .checked_mul(MILLIS_PER_SECOND)
+            .ok_or(SequencerTimestampPlannerError::TimestampOverflow)?;
+        Ok(SequencerTimestamp { timestamp, timestamp_millis_part: None, timestamp_millis })
+    }
+
+    /// Plans a Zombie timestamp aligned to the 200ms cadence.
+    ///
+    /// The candidate is the wall clock floored to the cadence; a monotonicity
+    /// guard ensures the result is at least one cadence step past the parent.
+    pub fn zombie(
+        parent_timestamp_millis: u64,
+        wall_clock_millis: u64,
+    ) -> Result<SequencerTimestamp, SequencerTimestampPlannerError> {
+        let candidate = (wall_clock_millis / ZOMBIE_CADENCE_MILLIS) * ZOMBIE_CADENCE_MILLIS;
+        let minimum = parent_timestamp_millis
+            .checked_add(ZOMBIE_CADENCE_MILLIS)
+            .ok_or(SequencerTimestampPlannerError::TimestampOverflow)?;
+        let timestamp_millis = candidate.max(minimum);
+        let timestamp = timestamp_millis / MILLIS_PER_SECOND;
+        let timestamp_millis_part = (timestamp_millis % MILLIS_PER_SECOND) as u16;
+        Ok(SequencerTimestamp {
+            timestamp,
+            timestamp_millis_part: Some(timestamp_millis_part),
+            timestamp_millis,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_advances_by_block_time() {
+        let planned = SequencerTimestampPlanner::legacy(1_000, 2).unwrap();
+        assert_eq!(planned.timestamp, 1_002);
+        assert_eq!(planned.timestamp_millis_part, None);
+        assert_eq!(planned.timestamp_millis, 1_002_000);
+    }
+
+    #[test]
+    fn zombie_floors_wall_clock_to_cadence() {
+        let planned = SequencerTimestampPlanner::zombie(1_000_000, 1_000_450).unwrap();
+        assert_eq!(planned.timestamp_millis, 1_000_400);
+        assert_eq!(planned.timestamp, 1_000);
+        assert_eq!(planned.timestamp_millis_part, Some(400));
+    }
+
+    #[test]
+    fn zombie_enforces_monotonic_minimum() {
+        let planned = SequencerTimestampPlanner::zombie(1_000_000, 1_000_050).unwrap();
+        assert_eq!(planned.timestamp_millis, 1_000_200);
+        assert_eq!(planned.timestamp_millis_part, Some(200));
+    }
+
+    #[test]
+    fn zombie_carries_across_second_boundary() {
+        let planned = SequencerTimestampPlanner::zombie(1_999_800, 2_000_050).unwrap();
+        assert_eq!(planned.timestamp_millis, 2_000_000);
+        assert_eq!(planned.timestamp, 2_000);
+        assert_eq!(planned.timestamp_millis_part, Some(0));
+    }
+
+    #[test]
+    fn zombie_overflow_is_rejected() {
+        assert_eq!(
+            SequencerTimestampPlanner::zombie(u64::MAX, 0),
+            Err(SequencerTimestampPlannerError::TimestampOverflow)
+        );
+    }
+}

--- a/crates/consensus/service/src/lib.rs
+++ b/crates/consensus/service/src/lib.rs
@@ -40,9 +40,11 @@ pub use actors::{
     QueuedL1WatcherDerivationClient, QueuedNetworkEngineClient, QueuedSequencerAdminAPIClient,
     QueuedSequencerEngineClient, QueuedUnsafePayloadGossipClient, RecoveryModeGuard, ResetRequest,
     RpcActor, RpcActorError, RpcContext, ScheduledTicker, SealState, SealStepError,
-    SealStepOutcome, SequencerActor, SequencerActorError, SequencerAdminQuery, SequencerConfig,
-    SequencerEngineClient, UnsafePayloadGossipClient, UnsafePayloadGossipClientError,
-    UnsealedPayloadHandle, UpgradeSignalMetricsActor, UpgradeSignalNodeConfig,
+    SealStepOutcome, SequencerActor, SequencerActorError, SequencerAdminQuery,
+    SequencerCadenceConfig, SequencerConfig, SequencerEngineClient, SequencerTimestamp,
+    SequencerTimestampPlanner, SequencerTimestampPlannerError, UnsafePayloadGossipClient,
+    UnsafePayloadGossipClientError, UnsealedPayloadHandle, UpgradeSignalMetricsActor,
+    UpgradeSignalNodeConfig,
 };
 
 mod metrics;

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -23,6 +23,7 @@ use base_consensus_safedb::{DisabledSafeDB, SafeDB, SafeDBReader, SafeHeadListen
 use base_protocol::L2BlockInfo;
 use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
+use tracing::warn;
 
 use crate::{
     AlloyL1BlockFetcher, CheckpointActor, CheckpointClient, CheckpointDB, CheckpointWriter,
@@ -33,8 +34,8 @@ use crate::{
     NodeActor, NodeMode, PayloadBuilder, QueuedDerivationEngineClient,
     QueuedEngineDerivationClient, QueuedEngineRpcClient, QueuedL1WatcherDerivationClient,
     QueuedNetworkEngineClient, QueuedSequencerAdminAPIClient, QueuedSequencerEngineClient,
-    RecoveryModeGuard, RpcActor, RpcContext, SequencerActor, SequencerConfig,
-    UpgradeSignalNodeConfig,
+    RecoveryModeGuard, RpcActor, RpcContext, SequencerActor, SequencerCadenceConfig,
+    SequencerConfig, UpgradeSignalNodeConfig,
     actors::{BlockStream, NetworkInboundData, QueuedUnsafePayloadGossipClient},
 };
 
@@ -369,6 +370,10 @@ impl RollupNode {
         DerivationActor<QueuedDerivationEngineClient, P>:
             NodeActor<StartData = (), Error = DerivationError>,
     {
+        if self.config.is_zombie_active(u64::MAX) {
+            warn!("Zombie hardfork (200ms block support) is enabled and experimental; do not use on production networks");
+        }
+
         // Build the safe head DB pair. Both actors share the same underlying DB via Arc.
         //
         // In delegate mode the local derivation actor is replaced by a `DelegateDerivationActor`
@@ -535,11 +540,13 @@ impl RollupNode {
             derivation_origin_rx,
             cancellation.clone(),
         );
+
         let upgrade_signal_metrics_actor =
             self.upgrade_signal_config.as_ref().map(|c| c.metrics_actor(cancellation.clone()));
         let upgrade_signal_refresher =
             self.upgrade_signal_config.as_ref().and_then(|c| c.refresher());
         let node_mode = self.mode();
+
         // Create the sequencer if needed
         let (sequencer_actor, sequencer_admin_client) = if node_mode.is_sequencer() {
             let sequencer_engine_client = QueuedSequencerEngineClient {
@@ -571,6 +578,11 @@ impl RollupNode {
                     is_active: self.sequencer_config.sequencer_stopped.not(),
                     recovery_mode,
                     rollup_config: Arc::clone(&self.config),
+                    cadence: if self.config.is_zombie_active(u64::MAX) {
+                        SequencerCadenceConfig::zombie_200ms()
+                    } else {
+                        SequencerCadenceConfig::from_legacy_block_time(self.config.block_time)
+                    },
                     unsafe_payload_gossip_client: queued_gossip_client,
                     sealer: None,
                     pending_stop: None,

--- a/crates/proof/primitives/src/per_chain_config.rs
+++ b/crates/proof/primitives/src/per_chain_config.rs
@@ -237,7 +237,7 @@ impl PerChainConfig {
                 pectra_blob_schedule_time: None,
                 isthmus_time: Some(0),
                 jovian_time: Some(0),
-                base: BaseUpgradeConfig { azul: Some(0), beryl: None, cobalt: None },
+                base: BaseUpgradeConfig { azul: Some(0), beryl: None, cobalt: None, zombie: None },
             },
             chain_op_config: FeeConfig::base_mainnet(),
         }


### PR DESCRIPTION
## Summary

Wires the 200ms cadence from PR #3975 into the sequencer build loop. Feature-gated on `is_zombie_active` — legacy nodes are unaffected.

**Depends on #3975.**

## Changes

### `actor.rs`
- `cadence: SequencerCadenceConfig` field on `SequencerActor`
- `block_seal_target()` / `next_block_seal_target()` helpers using cadence
- Seal compensation buffer capped at `cadence.block_interval / 2` (100ms) to prevent fat/thin build-window oscillation

### `build.rs`
- `build_on(parent, millis_part)` and `plan_next_timestamp()`
- `build_attributes(..., millis_part)` calls upstream 3-arg `prepare_payload_attributes(parent, epoch, millis_part)`

### `service/node.rs`
- Zombie-gated `SequencerCadenceConfig::zombie_200ms` wiring in node startup
- Startup `warn!` when Zombie is active: `"Zombie hardfork (200ms block support) is enabled and experimental; do not use on production networks"`

### `actions/harness/src/sequencer/driver.rs`
- Cadence wired in harness driver

### Tests
- `tests/test_util.rs` cadence wired in test setup

## Stack
- [#3977](https://github.com/base/base/pull/3977): Zombie hardfork scaffolding
- [#3974](https://github.com/base/base/pull/3974): zombie_block_timestamp timing math
- [#3975](https://github.com/base/base/pull/3975): SequencerTimestampPlanner + SequencerCadenceConfig
- **→ This PR**: Wire 200ms cadence into build loop