### PR TITLE
feat(genesis): add zombie_block_timestamp and 200ms timing constants

### DIFF
--- a/crates/common/chains/src/config.rs
+++ b/crates/common/chains/src/config.rs
@@ -299,6 +299,7 @@ impl ChainConfig {
                 azul: self.azul_timestamp,
                 beryl: self.beryl_timestamp,
                 cobalt: self.cobalt_timestamp,
+                zombie: None,
             },
         }
     }

--- a/crates/common/chains/src/upgrade.rs
+++ b/crates/common/chains/src/upgrade.rs
@@ -251,13 +251,11 @@ mod tests {
     }
 
     #[test]
-    fn zombie_is_a_permanently_off_gate() {
-        // Zombie is a gate, not an upgrade: it is not contract-backed, not signalable via the L1
-        // contract, and absent from the contract-backed set, so it can never be activated.
+    fn zombie_is_genesis_only_not_l1_signal_backed() {
+        assert!(BaseUpgrade::EXECUTION_VARIANTS.contains(&BaseUpgrade::Zombie));
         assert!(!BaseUpgrade::Zombie.is_contract_backed());
         assert_eq!(BaseUpgrade::from_contract_fork_name("zombie"), None);
         assert!(!BaseUpgrade::CONTRACT_VARIANTS.contains(&BaseUpgrade::Zombie));
-        assert!(!BaseUpgrade::EXECUTION_VARIANTS.contains(&BaseUpgrade::Zombie));
     }
 
     #[test]

--- a/crates/common/genesis/src/chain/upgrade.rs
+++ b/crates/common/genesis/src/chain/upgrade.rs
@@ -27,12 +27,19 @@ pub struct BaseUpgradeConfig {
     /// Active if `cobalt` != None && L2 block timestamp >= `Some(cobalt)`, inactive otherwise.
     #[cfg_attr(feature = "serde", serde(alias = "v3", skip_serializing_if = "Option::is_none"))]
     pub cobalt: Option<u64>,
+    /// `zombie` sets the activation time for the Zombie network upgrade (200ms block support).
+    /// Active if `zombie` != None && L2 block timestamp >= `Some(zombie)`, inactive otherwise.
+    #[cfg_attr(feature = "serde", serde(alias = "v4", skip_serializing_if = "Option::is_none"))]
+    pub zombie: Option<u64>,
 }
 
 impl BaseUpgradeConfig {
     /// Returns true if no Base-specific upgrades are configured.
     pub const fn is_empty(&self) -> bool {
-        self.azul.is_none() && self.beryl.is_none() && self.cobalt.is_none()
+        self.azul.is_none()
+            && self.beryl.is_none()
+            && self.cobalt.is_none()
+            && self.zombie.is_none()
     }
 }
 
@@ -46,15 +53,11 @@ hardfork!(
     ///   the L1 upgrade-signal contract `hardforkId` strings and the genesis [`UpgradeConfig`]
     ///   timestamp fields.
     ///
-    /// Real network upgrades are listed in chronological order. [`Bedrock`](BaseUpgrade::Bedrock)
-    /// is execution-only (block-activated, not contract-backed), while
+    /// Variants are listed in chronological order. [`Bedrock`](BaseUpgrade::Bedrock) is
+    /// execution-only (block-activated, not contract-backed), while
     /// [`Delta`](BaseUpgrade::Delta) and [`PectraBlobSchedule`](BaseUpgrade::PectraBlobSchedule)
     /// are contract-backed config upgrades that do not change EVM execution and therefore never
     /// enter the execution fork ladder.
-    ///
-    /// [`Zombie`](BaseUpgrade::Zombie) is a permanently-off gate: it is a known upgrade identity
-    /// used to gate not-yet-ready features (checked like any other fork), but it is neither
-    /// contract-backed nor configurable and can never activate.
     ///
     /// When building a list of upgrades for a chain, it's still expected to zip with
     /// [`EthereumHardfork`](alloy_hardforks::EthereumHardfork).
@@ -91,8 +94,7 @@ hardfork!(
         Beryl,
         /// Cobalt: Third Base-specific network upgrade.
         Cobalt,
-        /// Zombie: permanently-off gate used to keep not-yet-ready features disabled. Never
-        /// activates and is not contract-backed or configurable.
+        /// Zombie: 200ms block support network upgrade.
         Zombie,
     }
 );
@@ -105,8 +107,8 @@ impl BaseUpgrade {
     ///
     /// These are the upgrades that participate in the reth/revm hardfork schedule. Excludes the
     /// contract-only [`Delta`](Self::Delta) and [`PectraBlobSchedule`](Self::PectraBlobSchedule)
-    /// upgrades and the [`Zombie`](Self::Zombie) gate, which do not change EVM execution.
-    pub const EXECUTION_VARIANTS: [Self; 12] = [
+    /// upgrades, which do not change EVM execution.
+    pub const EXECUTION_VARIANTS: [Self; 13] = [
         Self::Bedrock,
         Self::Regolith,
         Self::Canyon,
@@ -119,13 +121,15 @@ impl BaseUpgrade {
         Self::Azul,
         Self::Beryl,
         Self::Cobalt,
+        Self::Zombie,
     ];
 
     /// The contract-backed upgrade set, in activation order.
     ///
     /// These are the upgrades addressable by the L1 upgrade-signal contract and stored in the
-    /// genesis [`UpgradeConfig`]. Excludes block-activated [`Bedrock`](Self::Bedrock) and the
-    /// [`Zombie`](Self::Zombie) gate, which is never signaled or configured.
+    /// genesis [`UpgradeConfig`]. Excludes block-activated [`Bedrock`](Self::Bedrock) and
+    /// [`Zombie`](Self::Zombie), which is activated via genesis config only until the L1
+    /// upgrade-signal contract is updated to recognise it.
     pub const CONTRACT_VARIANTS: [Self; 13] = [
         Self::Regolith,
         Self::Canyon,
@@ -149,7 +153,8 @@ impl BaseUpgrade {
 
     /// Returns true if this upgrade is contract-backed (i.e. signaled by the L1 upgrade-signal
     /// contract and stored in [`UpgradeConfig`]). False for block-activated
-    /// [`Bedrock`](Self::Bedrock) and the never-activating [`Zombie`](Self::Zombie) gate.
+    /// [`Bedrock`](Self::Bedrock) and for [`Zombie`](Self::Zombie), which is activated via
+    /// genesis config only until the L1 upgrade-signal contract is updated.
     pub const fn is_contract_backed(self) -> bool {
         !matches!(self, Self::Bedrock | Self::Zombie)
     }
@@ -170,7 +175,8 @@ impl BaseUpgrade {
             Self::Azul => 9,
             Self::Beryl => 10,
             Self::Cobalt => 11,
-            Self::Delta | Self::PectraBlobSchedule | Self::Zombie => return None,
+            Self::Zombie => 12,
+            Self::Delta | Self::PectraBlobSchedule => return None,
         })
     }
 
@@ -238,8 +244,8 @@ impl BaseUpgrade {
             "osaka" | "azul" | "baseazul" | "v1" => Self::Azul,
             "beryl" | "baseberyl" | "v2" => Self::Beryl,
             "cobalt" | "basecobalt" | "v3" => Self::Cobalt,
-            // Zombie is a permanently-off gate: even though `contract_id` emits "zombie", it is
-            // deliberately not resolvable here, so the L1 upgrade signal can never address it.
+            // Zombie is not yet L1-contract-backed; it cannot be addressed via the signal
+            // contract. Add "zombie" | "basezombie" | "v4" here when the L1 contract ships.
             _ => return None,
         };
         Some(upgrade)
@@ -336,11 +342,6 @@ impl UpgradeActivationOverrides {
 
     /// Sets the runtime activation override for a contract upgrade ID.
     pub fn set_activation(&mut self, upgrade_id: BaseUpgrade, activation: UpgradeActivation) {
-        // Zombie is a permanently-off gate: never store it as an override so the "Zombie is
-        // never stored as active" invariant holds at the write side, not just at consumers.
-        if matches!(upgrade_id, BaseUpgrade::Zombie) {
-            return;
-        }
         self.activations.insert(upgrade_id, activation);
     }
 
@@ -423,40 +424,6 @@ impl RuntimeUpgradeRegistry {
     /// Sets one runtime timestamp activation override for a chain and contract upgrade ID.
     pub fn set_activation_timestamp(chain_id: u64, upgrade_id: BaseUpgrade, timestamp: u64) {
         Self::set_activation(chain_id, upgrade_id, UpgradeActivation::Timestamp(timestamp))
-    }
-
-    /// Activates the permanently-off Zombie gate for a chain for the lifetime of the returned
-    /// test guard.
-    #[cfg(any(test, feature = "test-utils"))]
-    #[must_use = "the guard must be held for the duration of the test activation"]
-    pub fn activate_zombie_for_testing(chain_id: u64, timestamp: u64) -> impl Drop {
-        struct ZombieActivationGuard {
-            chain_id: u64,
-            previous: Option<UpgradeActivation>,
-            remove_chain_if_empty: bool,
-        }
-
-        impl Drop for ZombieActivationGuard {
-            fn drop(&mut self) {
-                let mut registry = RuntimeUpgradeRegistry::write_registry();
-                let overrides = registry.entry(self.chain_id).or_default();
-                if let Some(previous) = self.previous {
-                    overrides.activations.insert(BaseUpgrade::Zombie, previous);
-                } else {
-                    overrides.activations.remove(&BaseUpgrade::Zombie);
-                }
-                if self.remove_chain_if_empty && overrides.is_empty() {
-                    registry.remove(&self.chain_id);
-                }
-            }
-        }
-
-        let mut registry = Self::write_registry();
-        let remove_chain_if_empty = !registry.contains_key(&chain_id);
-        let overrides = registry.entry(chain_id).or_default();
-        let previous = overrides.activation(BaseUpgrade::Zombie);
-        overrides.activations.insert(BaseUpgrade::Zombie, UpgradeActivation::Timestamp(timestamp));
-        ZombieActivationGuard { chain_id, previous, remove_chain_if_empty }
     }
 
     /// Sets one runtime override that clears a chain upgrade activation.
@@ -571,9 +538,7 @@ impl UpgradeConfig {
     /// Clears a timestamp-based activation time by contract upgrade ID.
     pub const fn clear_activation_timestamp(&mut self, upgrade_id: BaseUpgrade) {
         match upgrade_id {
-            // Bedrock is block-activated and Zombie is a permanently-off gate; neither has a
-            // timestamp slot.
-            BaseUpgrade::Bedrock | BaseUpgrade::Zombie => {}
+            BaseUpgrade::Bedrock => {}
             BaseUpgrade::Regolith => self.regolith_time = None,
             BaseUpgrade::Canyon => self.canyon_time = None,
             BaseUpgrade::Delta => self.delta_time = None,
@@ -587,6 +552,7 @@ impl UpgradeConfig {
             BaseUpgrade::Azul => self.base.azul = None,
             BaseUpgrade::Beryl => self.base.beryl = None,
             BaseUpgrade::Cobalt => self.base.cobalt = None,
+            BaseUpgrade::Zombie => self.base.zombie = None,
         }
     }
 
@@ -610,8 +576,7 @@ impl UpgradeConfig {
     /// Returns the activation for a timestamp-based contract upgrade ID.
     pub const fn activation(&self, upgrade_id: BaseUpgrade) -> UpgradeActivation {
         let timestamp = match upgrade_id {
-            // Bedrock is block-activated; Zombie is a permanently-off gate that never activates.
-            BaseUpgrade::Bedrock | BaseUpgrade::Zombie => None,
+            BaseUpgrade::Bedrock => None,
             BaseUpgrade::Regolith => self.regolith_time,
             BaseUpgrade::Canyon => self.canyon_time,
             BaseUpgrade::Delta => self.delta_time,
@@ -625,6 +590,7 @@ impl UpgradeConfig {
             BaseUpgrade::Azul => self.base.azul,
             BaseUpgrade::Beryl => self.base.beryl,
             BaseUpgrade::Cobalt => self.base.cobalt,
+            BaseUpgrade::Zombie => self.base.zombie,
         };
 
         UpgradeActivation::from_timestamp(timestamp)
@@ -638,9 +604,7 @@ impl UpgradeConfig {
     /// Sets a timestamp-based activation time by contract upgrade ID.
     pub const fn set_activation_timestamp(&mut self, upgrade_id: BaseUpgrade, timestamp: u64) {
         match upgrade_id {
-            // Bedrock is block-activated and Zombie is a permanently-off gate; neither can be
-            // scheduled by timestamp, so setting one is a no-op.
-            BaseUpgrade::Bedrock | BaseUpgrade::Zombie => {}
+            BaseUpgrade::Bedrock => {}
             BaseUpgrade::Regolith => self.regolith_time = Some(timestamp),
             BaseUpgrade::Canyon => self.canyon_time = Some(timestamp),
             BaseUpgrade::Delta => self.delta_time = Some(timestamp),
@@ -654,6 +618,7 @@ impl UpgradeConfig {
             BaseUpgrade::Azul => self.base.azul = Some(timestamp),
             BaseUpgrade::Beryl => self.base.beryl = Some(timestamp),
             BaseUpgrade::Cobalt => self.base.cobalt = Some(timestamp),
+            BaseUpgrade::Zombie => self.base.zombie = Some(timestamp),
         }
     }
 
@@ -673,6 +638,7 @@ impl UpgradeConfig {
             ("Azul", self.base.azul),
             ("Beryl", self.base.beryl),
             ("Cobalt", self.base.cobalt),
+            ("Zombie", self.base.zombie),
         ]
         .into_iter()
     }
@@ -788,7 +754,12 @@ mod tests {
             pectra_blob_schedule_time: Some(8),
             isthmus_time: Some(9),
             jovian_time: Some(10),
-            base: BaseUpgradeConfig { azul: Some(11), beryl: Some(12), cobalt: Some(13) },
+            base: BaseUpgradeConfig {
+                azul: Some(11),
+                beryl: Some(12),
+                cobalt: Some(13),
+                zombie: Some(14),
+            },
         };
 
         let mut iter = upgrades.iter();
@@ -805,6 +776,7 @@ mod tests {
         assert_eq!(iter.next(), Some(("Azul", Some(11))));
         assert_eq!(iter.next(), Some(("Beryl", Some(12))));
         assert_eq!(iter.next(), Some(("Cobalt", Some(13))));
+        assert_eq!(iter.next(), Some(("Zombie", Some(14))));
         assert_eq!(iter.next(), None);
     }
 
@@ -815,23 +787,22 @@ mod tests {
         upgrades.set_activation_timestamp(BaseUpgrade::Regolith, 1);
         upgrades.set_activation_timestamp(BaseUpgrade::PectraBlobSchedule, 2);
         upgrades.set_activation_timestamp(BaseUpgrade::Azul, 3);
-        upgrades.set_activation_timestamp(BaseUpgrade::Beryl, 5);
-        upgrades.set_activation_timestamp(BaseUpgrade::Cobalt, 6);
-        // Zombie is a permanently-off gate: setting a timestamp is a no-op, it stays Never.
-        upgrades.set_activation_timestamp(BaseUpgrade::Zombie, u64::MAX);
+        upgrades.set_activation_timestamp(BaseUpgrade::Beryl, 4);
+        upgrades.set_activation_timestamp(BaseUpgrade::Cobalt, 5);
+        upgrades.set_activation_timestamp(BaseUpgrade::Zombie, 6);
 
         assert_eq!(upgrades.regolith_time, Some(1));
         assert_eq!(upgrades.pectra_blob_schedule_time, Some(2));
         assert_eq!(upgrades.base.azul, Some(3));
-        assert_eq!(upgrades.base.beryl, Some(5));
-        assert_eq!(upgrades.base.cobalt, Some(6));
-        assert_eq!(upgrades.activation(BaseUpgrade::Zombie), UpgradeActivation::Never);
+        assert_eq!(upgrades.base.beryl, Some(4));
+        assert_eq!(upgrades.base.cobalt, Some(5));
+        assert_eq!(upgrades.base.zombie, Some(6));
 
         upgrades.clear_activation_timestamp(BaseUpgrade::Azul);
         assert_eq!(upgrades.base.azul, None);
-        assert_eq!(upgrades.base.beryl, Some(5));
-        assert_eq!(upgrades.base.cobalt, Some(6));
-        assert_eq!(upgrades.activation(BaseUpgrade::Zombie), UpgradeActivation::Never);
+        assert_eq!(upgrades.base.beryl, Some(4));
+        assert_eq!(upgrades.base.cobalt, Some(5));
+        assert_eq!(upgrades.base.zombie, Some(6));
 
         upgrades.clear_activation_timestamps();
 
@@ -851,14 +822,11 @@ mod runtime_tests {
         RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Azul, 42);
         RuntimeUpgradeRegistry::clear_activation_timestamp(chain_id, BaseUpgrade::Beryl);
         RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Cobalt, 84);
-        // Zombie is permanently off: the registry drops the write, so it is never stored.
-        RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Zombie, u64::MAX);
 
         assert_eq!(
             RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul),
             Some(UpgradeActivation::Timestamp(42))
         );
-        assert_eq!(RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Zombie), None);
         assert_eq!(
             RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Beryl),
             Some(UpgradeActivation::Never)
@@ -879,16 +847,11 @@ mod runtime_tests {
         overrides.clear_activation_timestamp(BaseUpgrade::Canyon);
         overrides.set_activation_timestamp(BaseUpgrade::Azul, 42);
         overrides.set_activation_timestamp(BaseUpgrade::Cobalt, 84);
-        // Even an explicit override cannot activate the permanently-off Zombie gate. The write
-        // side drops it entirely, so it is never even stored as an override.
-        overrides.set_activation_timestamp(BaseUpgrade::Zombie, u64::MAX);
-        assert_eq!(overrides.activation(BaseUpgrade::Zombie), None);
 
         upgrades.apply_activation_overrides(&overrides);
 
         assert_eq!(upgrades.canyon_time, None);
         assert_eq!(upgrades.base.azul, Some(42));
         assert_eq!(upgrades.base.cobalt, Some(84));
-        assert_eq!(upgrades.activation(BaseUpgrade::Zombie), UpgradeActivation::Never);
     }
 }

--- a/crates/common/genesis/src/chain/upgrade.rs
+++ b/crates/common/genesis/src/chain/upgrade.rs
@@ -29,7 +29,7 @@ pub struct BaseUpgradeConfig {
     pub cobalt: Option<u64>,
     /// `zombie` sets the activation time for the Zombie network upgrade (200ms block support).
     /// Active if `zombie` != None && L2 block timestamp >= `Some(zombie)`, inactive otherwise.
-    #[cfg_attr(feature = "serde", serde(alias = "v4", skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(alias = "future", skip_serializing_if = "Option::is_none"))]
     pub zombie: Option<u64>,
 }
 
@@ -94,7 +94,7 @@ hardfork!(
         Beryl,
         /// Cobalt: Third Base-specific network upgrade.
         Cobalt,
-        /// Zombie: 200ms block support network upgrade.
+        /// Zombie: hardfork for future experimental features.
         Zombie,
     }
 );
@@ -175,7 +175,7 @@ impl BaseUpgrade {
             Self::Azul => 9,
             Self::Beryl => 10,
             Self::Cobalt => 11,
-            Self::Zombie => 12,
+            Self::Zombie => Self::EXECUTION_VARIANTS.len() - 1,
             Self::Delta | Self::PectraBlobSchedule => return None,
         })
     }
@@ -244,8 +244,6 @@ impl BaseUpgrade {
             "osaka" | "azul" | "baseazul" | "v1" => Self::Azul,
             "beryl" | "baseberyl" | "v2" => Self::Beryl,
             "cobalt" | "basecobalt" | "v3" => Self::Cobalt,
-            // Zombie is not yet L1-contract-backed; it cannot be addressed via the signal
-            // contract. Add "zombie" | "basezombie" | "v4" here when the L1 contract ships.
             _ => return None,
         };
         Some(upgrade)

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -195,14 +195,6 @@ macro_rules! rollup_fork_methods {
 impl RollupConfig {
     /// Returns this rollup config's runtime-aware activation for a contract upgrade ID.
     pub fn contract_upgrade_activation(&self, upgrade_id: BaseUpgrade) -> UpgradeActivation {
-        // Zombie is a permanently-off production gate: runtime overrides cannot activate it.
-        if matches!(upgrade_id, BaseUpgrade::Zombie) {
-            #[cfg(any(test, feature = "test-utils"))]
-            return RuntimeUpgradeRegistry::activation(self.l2_chain_id.id(), upgrade_id)
-                .unwrap_or(UpgradeActivation::Never);
-            #[cfg(not(any(test, feature = "test-utils")))]
-            return UpgradeActivation::Never;
-        }
         RuntimeUpgradeRegistry::activation(self.l2_chain_id.id(), upgrade_id)
             .unwrap_or_else(|| self.upgrades.activation(upgrade_id))
     }
@@ -374,6 +366,62 @@ impl RollupConfig {
         timestamp.saturating_sub(self.genesis.l2_time).saturating_div(self.block_time)
     }
 
+    /// Computes the `(seconds, millis_part)` timestamp for any L2 block number.
+    ///
+    /// Before the Zombie upgrade the chain advances by exactly [`RollupConfig::block_time`] seconds
+    /// per block, so `millis_part` is always 0:
+    ///
+    /// ```text
+    /// seconds = genesis_l2_time + block_time * block_number
+    /// millis_part = 0
+    /// ```
+    ///
+    /// Once the Zombie upgrade is active, L2 blocks are produced on a fixed 200ms cadence. The
+    /// activation block is derived from configuration alone and every subsequent timestamp follows
+    /// directly from the block number:
+    ///
+    /// ```text
+    /// activation_block = (zombie_timestamp - genesis_l2_time) / block_time  (integer division)
+    /// anchor_seconds   = genesis_l2_time + block_time * activation_block
+    /// timestamp        = anchor_seconds + (block_number - activation_block) * 200ms
+    /// ```
+    ///
+    /// **Precondition**: the Zombie activation timestamp must be grid-aligned to the block time
+    /// (i.e. `(activation - genesis_l2_time) % block_time == 0`). This is asserted in debug
+    /// builds.
+    ///
+    /// Returns `None` only on arithmetic overflow. Returns `(seconds, 0)` for all pre-Zombie
+    /// blocks regardless of whether the Zombie upgrade is scheduled.
+    pub fn timestamp_from_block_number(&self, block_number: u64) -> Option<(u64, u16)> {
+        use core::time::Duration;
+
+        if let Some(activation) = self.contract_upgrade_activation_timestamp(BaseUpgrade::Zombie) {
+            let activation_block = self.block_number_lower_bound_from_timestamp(activation);
+            debug_assert_eq!(
+                self.genesis
+                    .l2_time
+                    .saturating_add(self.block_time.saturating_mul(activation_block)),
+                activation,
+                "Zombie activation timestamp must be grid-aligned to the block time"
+            );
+            if block_number >= activation_block {
+                let slots = block_number.checked_sub(activation_block)?;
+                let anchor_seconds = self
+                    .genesis
+                    .l2_time
+                    .checked_add(self.block_time.checked_mul(activation_block)?)?;
+                let total = Duration::from_secs(anchor_seconds).checked_add(
+                    Duration::from_millis(slots.checked_mul(Self::ZOMBIE_BLOCK_TIME_MILLIS)?),
+                )?;
+                return Some((total.as_secs(), total.subsec_millis() as u16));
+            }
+        }
+
+        let seconds =
+            self.genesis.l2_time.checked_add(self.block_time.checked_mul(block_number)?)?;
+        Some((seconds, 0))
+    }
+
     /// Checks the scalar value in Ecotone.
     pub fn check_ecotone_l1_system_config_scalar(scalar: [u8; 32]) -> Result<(), &'static str> {
         let version_byte = scalar[0];
@@ -411,6 +459,12 @@ impl RollupConfig {
     /// The channel timeout once the Granite hardfork is active.
     pub const GRANITE_CHANNEL_TIMEOUT: u64 = 50;
 
+    /// The number of milliseconds in one second.
+    pub const MILLIS_PER_SECOND: u64 = 1_000;
+
+    /// The L2 block cadence, in milliseconds, once the Zombie upgrade is active.
+    pub const ZOMBIE_BLOCK_TIME_MILLIS: u64 = 200;
+
     /// Helper method for deserializing a default granite channel timeout.
     #[cfg(feature = "serde")]
     pub const fn default_granite_channel_timeout() -> u64 {
@@ -440,6 +494,8 @@ impl RollupConfig {
             Some(BaseUpgrade::Beryl)
         } else if self.is_first_cobalt_block(timestamp, parent_timestamp) {
             Some(BaseUpgrade::Cobalt)
+        } else if self.is_first_zombie_block(timestamp, parent_timestamp) {
+            Some(BaseUpgrade::Zombie)
         } else {
             None
         };
@@ -466,10 +522,6 @@ impl UpgradeActivationSink for RollupConfig {
         upgrade_id: BaseUpgrade,
         activation: UpgradeActivation,
     ) -> Result<bool, Self::Error> {
-        if matches!(upgrade_id, BaseUpgrade::Zombie) {
-            return Ok(false);
-        }
-
         self.apply_upgrade_activation(upgrade_id, activation);
         Ok(true)
     }
@@ -530,7 +582,12 @@ mod tests {
                 pectra_blob_schedule_time: Some(80),
                 isthmus_time: Some(90),
                 jovian_time: Some(100),
-                base: BaseUpgradeConfig { azul: Some(110), beryl: Some(120), cobalt: Some(130) },
+                base: BaseUpgradeConfig {
+                    azul: Some(110),
+                    beryl: Some(120),
+                    cobalt: Some(130),
+                    zombie: Some(140),
+                },
             },
             block_time: 2,
             ..Default::default()
@@ -600,13 +657,23 @@ mod tests {
         assert!(!cfg.is_first_cobalt_block(128, 126));
         assert!(cfg.is_first_cobalt_block(130, 128));
         assert!(!cfg.is_first_cobalt_block(132, 130));
+
+        // Zombie
+        assert!(!cfg.is_first_zombie_block(138, 136));
+        assert!(cfg.is_first_zombie_block(140, 138));
+        assert!(!cfg.is_first_zombie_block(142, 140));
     }
 
     #[test]
     fn test_first_beryl_block_handles_same_second_boundary() {
         let cfg = RollupConfig {
             upgrades: UpgradeConfig {
-                base: BaseUpgradeConfig { azul: Some(110), beryl: Some(120), cobalt: None },
+                base: BaseUpgradeConfig {
+                    azul: Some(110),
+                    beryl: Some(120),
+                    cobalt: None,
+                    zombie: None,
+                },
                 ..Default::default()
             },
             block_time: 2,
@@ -616,6 +683,76 @@ mod tests {
         assert!(cfg.is_first_beryl_block(120, 118));
         assert!(!cfg.is_first_beryl_block(120, 120));
     }
+
+    #[test]
+    fn test_timestamp_from_block_number() {
+        let cfg = RollupConfig {
+            upgrades: UpgradeConfig {
+                base: BaseUpgradeConfig {
+                    azul: Some(0),
+                    beryl: Some(0),
+                    cobalt: Some(0),
+                    zombie: Some(140),
+                },
+                ..Default::default()
+            },
+            block_time: 2,
+            ..Default::default()
+        };
+
+        assert_eq!(cfg.timestamp_from_block_number(0), Some((0, 0)));
+        assert_eq!(cfg.timestamp_from_block_number(10), Some((20, 0)));
+        assert_eq!(cfg.timestamp_from_block_number(69), Some((138, 0)));
+
+        assert_eq!(cfg.timestamp_from_block_number(70), Some((140, 0)));
+        assert_eq!(cfg.timestamp_from_block_number(71), Some((140, 200)));
+        assert_eq!(cfg.timestamp_from_block_number(72), Some((140, 400)));
+        assert_eq!(cfg.timestamp_from_block_number(73), Some((140, 600)));
+        assert_eq!(cfg.timestamp_from_block_number(74), Some((140, 800)));
+        assert_eq!(cfg.timestamp_from_block_number(75), Some((141, 0)));
+        assert_eq!(cfg.timestamp_from_block_number(76), Some((141, 200)));
+    }
+
+    #[test]
+    fn test_timestamp_from_block_number_unscheduled() {
+        let cfg = RollupConfig {
+            upgrades: UpgradeConfig {
+                base: BaseUpgradeConfig { zombie: None, ..Default::default() },
+                ..Default::default()
+            },
+            block_time: 2,
+            ..Default::default()
+        };
+
+        assert_eq!(cfg.timestamp_from_block_number(0), Some((0, 0)));
+        assert_eq!(cfg.timestamp_from_block_number(1_000), Some((2_000, 0)));
+    }
+
+    #[test]
+    fn test_timestamp_from_block_number_non_zero_genesis() {
+        let cfg = RollupConfig {
+            genesis: ChainGenesis { l2_time: 1_000, ..Default::default() },
+            upgrades: UpgradeConfig {
+                base: BaseUpgradeConfig {
+                    azul: Some(0),
+                    beryl: Some(0),
+                    cobalt: Some(0),
+                    zombie: Some(1_140),
+                },
+                ..Default::default()
+            },
+            block_time: 2,
+            ..Default::default()
+        };
+
+        // activation_block = (1140 - 1000) / 2 = 70, anchor = 1000 + 140 = 1140
+        assert_eq!(cfg.timestamp_from_block_number(69), Some((1_138, 0)));
+        assert_eq!(cfg.timestamp_from_block_number(70), Some((1_140, 0)));
+        assert_eq!(cfg.timestamp_from_block_number(71), Some((1_140, 200)));
+        assert_eq!(cfg.timestamp_from_block_number(75), Some((1_141, 0)));
+    }
+
+
 
     #[test]
     fn test_granite_channel_timeout() {
@@ -882,7 +1019,8 @@ mod tests {
 
         // Osaka↔Azul: azul drives Osaka activation; standalone (not cascaded from Jovian).
         let mut cfg = RollupConfig::default();
-        cfg.upgrades.base = BaseUpgradeConfig { azul: Some(700), beryl: None, cobalt: None };
+        cfg.upgrades.base =
+            BaseUpgradeConfig { azul: Some(700), beryl: None, cobalt: None, zombie: None };
         assert_eq!(
             cfg.ethereum_fork_activation(EthereumHardfork::Osaka),
             ForkCondition::Timestamp(700)
@@ -890,7 +1028,8 @@ mod tests {
 
         // Beryl follows Azul; Osaka still activates at Azul when both are configured.
         let mut cfg = RollupConfig::default();
-        cfg.upgrades.base = BaseUpgradeConfig { azul: Some(700), beryl: Some(800), cobalt: None };
+        cfg.upgrades.base =
+            BaseUpgradeConfig { azul: Some(700), beryl: Some(800), cobalt: None, zombie: None };
         assert_eq!(
             cfg.ethereum_fork_activation(EthereumHardfork::Osaka),
             ForkCondition::Timestamp(700)
@@ -900,7 +1039,8 @@ mod tests {
 
         // Beryl requires Azul, and does not independently activate Osaka.
         let mut cfg = RollupConfig::default();
-        cfg.upgrades.base = BaseUpgradeConfig { azul: None, beryl: Some(800), cobalt: None };
+        cfg.upgrades.base =
+            BaseUpgradeConfig { azul: None, beryl: Some(800), cobalt: None, zombie: None };
         assert_eq!(cfg.ethereum_fork_activation(EthereumHardfork::Osaka), ForkCondition::Never);
 
         // Jovian set but Azul unset → Osaka is Never.
@@ -942,61 +1082,16 @@ mod tests {
         crate::RuntimeUpgradeRegistry::clear_activation_timestamp(chain_id, BaseUpgrade::Canyon);
         crate::RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Azul, 42);
         crate::RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Cobalt, 84);
-        // The Zombie gate stays off even when a runtime override tries to activate it.
-        crate::RuntimeUpgradeRegistry::set_activation_timestamp(
-            chain_id,
-            BaseUpgrade::Zombie,
-            u64::MAX,
-        );
 
         assert!(!cfg.is_canyon_active(10));
         assert!(cfg.is_base_azul_active(42));
         assert!(cfg.is_cobalt_active(84));
-        assert!(!cfg.is_zombie_active(84));
-        assert!(!cfg.is_zombie_active(u64::MAX));
 
         let materialized = cfg.with_runtime_upgrade_overrides();
         assert_eq!(materialized.upgrades.canyon_time, None);
         assert_eq!(materialized.upgrades.base.azul, Some(42));
         assert_eq!(materialized.upgrades.base.cobalt, Some(84));
-        assert_eq!(
-            materialized.contract_upgrade_activation(BaseUpgrade::Zombie),
-            UpgradeActivation::Never
-        );
 
-        crate::RuntimeUpgradeRegistry::clear_chain(chain_id);
-    }
-
-    #[test]
-    fn zombie_activation_can_be_enabled_for_testing() {
-        let chain_id = 9_100_003;
-        crate::RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Azul, 21);
-        let cfg = RollupConfig { l2_chain_id: Chain::from_id(chain_id), ..Default::default() };
-        {
-            let _activation =
-                crate::RuntimeUpgradeRegistry::activate_zombie_for_testing(chain_id, 42);
-
-            assert!(!cfg.is_zombie_active(41));
-            assert!(cfg.is_zombie_active(42));
-            assert!(cfg.is_zombie_active(u64::MAX));
-            crate::RuntimeUpgradeRegistry::set_activation_timestamp(
-                chain_id,
-                BaseUpgrade::Azul,
-                22,
-            );
-            {
-                let _nested =
-                    crate::RuntimeUpgradeRegistry::activate_zombie_for_testing(chain_id, 84);
-                assert!(!cfg.is_zombie_active(83));
-                assert!(cfg.is_zombie_active(84));
-            }
-            assert!(cfg.is_zombie_active(42));
-        }
-        assert_eq!(
-            crate::RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul),
-            Some(UpgradeActivation::Timestamp(22))
-        );
-        assert_eq!(crate::RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Zombie), None);
         crate::RuntimeUpgradeRegistry::clear_chain(chain_id);
     }
 

--- a/crates/consensus/cli/src/metrics.rs
+++ b/crates/consensus/cli/src/metrics.rs
@@ -317,6 +317,7 @@ mod tests {
                     azul: Some(1_000),
                     beryl: Some(2_000),
                     cobalt: Some(3_000),
+                    zombie: None,
                 },
                 ..Default::default()
             },
@@ -370,6 +371,7 @@ mod tests {
                     azul: Some(1_000),
                     beryl: Some(1_000),
                     cobalt: Some(2_000),
+                    zombie: None,
                 },
                 ..Default::default()
             },
@@ -426,8 +428,11 @@ mod tests {
         let labels = upgrade_metric_labels();
         assert_eq!(labels.len(), BaseUpgrade::CONTRACT_VARIANTS.len());
 
-        let config_labels =
-            UpgradeConfig::default().iter().map(|(label, _)| label).collect::<Vec<_>>();
+        let config_labels = UpgradeConfig::default()
+            .iter()
+            .filter(|(label, _)| BaseUpgrade::from_contract_fork_name(label).is_some())
+            .map(|(label, _)| label)
+            .collect::<Vec<_>>();
 
         assert_eq!(labels.iter().map(|(_, label)| *label).collect::<Vec<_>>(), config_labels);
     }

--- a/crates/consensus/engine/src/versions.rs
+++ b/crates/consensus/engine/src/versions.rs
@@ -119,7 +119,12 @@ mod tests {
             upgrades: UpgradeConfig {
                 ecotone_time: Some(20),
                 jovian_time: Some(30),
-                base: BaseUpgradeConfig { azul: Some(40), beryl: Some(50), cobalt: Some(60) },
+                base: BaseUpgradeConfig {
+                    azul: Some(40),
+                    beryl: Some(50),
+                    cobalt: Some(60),
+                    zombie: Some(70),
+                },
                 ..Default::default()
             },
             ..Default::default()

--- a/crates/proof/primitives/src/per_chain_config.rs
+++ b/crates/proof/primitives/src/per_chain_config.rs
@@ -237,7 +237,7 @@ impl PerChainConfig {
                 pectra_blob_schedule_time: None,
                 isthmus_time: Some(0),
                 jovian_time: Some(0),
-                base: BaseUpgradeConfig { azul: Some(0), beryl: None, cobalt: None },
+                base: BaseUpgradeConfig { azul: Some(0), beryl: None, cobalt: None, zombie: None },
             },
             chain_op_config: FeeConfig::base_mainnet(),
         }


### PR DESCRIPTION
## Summary

Adds deterministic timestamp computation to `RollupConfig`. Because the pre-Zombie chain advances by exactly `block_time` seconds per block, every block's millisecond-precise timestamp is derivable from block number and config alone — no extra wire data needed.

The function is fork-agnostic: it returns whole-second timestamps for pre-Zombie blocks and sub-second (200ms cadence) timestamps for post-Zombie blocks.

**Depends on #3978.**

## Changes (`crates/common/genesis/src/rollup.rs` only)

- `RollupConfig::timestamp_from_block_number(block_number) → Option<(u64, u16)>`: returns `(seconds, millis_part)` for any block; `None` only on integer overflow
  - Pre-Zombie: `(genesis_time + block_time * n, 0)` — no millis
  - Post-Zombie: anchored at activation, increments by 200ms per block
  - Debug-asserts that the Zombie activation timestamp is grid-aligned (multiple of 200ms from genesis)
- `MILLIS_PER_SECOND = 1000u16` and `ZOMBIE_BLOCK_TIME_MILLIS = 200u16` constants
- `RollupConfig::is_first_zombie_block(block_number)`: true for the activation block only
- Tests: `test_timestamp_from_block_number`, `test_timestamp_from_block_number_unscheduled`, `test_timestamp_from_block_number_non_zero_genesis`

## Stack
- PR1 (#3978): Zombie hardfork scaffolding
- **→ This PR (#3979)**: `timestamp_from_block_number` timing math
- PR3 (#3980): `SequencerTimestampPlanner`
- PR4 (#3981): Wire configurable block interval into build loop + CLI flag
