### PR TITLE
feat(sequencer): SequencerTimestampPlanner and SequencerCadenceConfig

### DIFF
--- a/crates/consensus/service/src/actors/mod.rs
+++ b/crates/consensus/service/src/actors/mod.rs
@@ -62,8 +62,9 @@ pub use sequencer::{
     L1OriginSelectorError, L1OriginSelectorProvider, OriginSelector, PayloadBuilder, PayloadSealer,
     PendingStopSender, PoolActivation, QueuedSequencerEngineClient, RecoveryModeGuard,
     ScheduledTicker, SealState, SealStepError, SealStepOutcome, SequencerActor,
-    SequencerActorError, SequencerAdminQuery, SequencerConfig, SequencerEngineClient,
-    UnsealedPayloadHandle,
+    SequencerActorError, SequencerAdminQuery, SequencerCadenceConfig, SequencerConfig,
+    SequencerEngineClient, SequencerTimestamp, SequencerTimestampPlanner,
+    SequencerTimestampPlannerError, UnsealedPayloadHandle,
 };
 #[cfg(test)]
 pub use sequencer::{MockConductor, MockOriginSelector, MockSequencerEngineClient};

--- a/crates/consensus/service/src/actors/sequencer/config.rs
+++ b/crates/consensus/service/src/actors/sequencer/config.rs
@@ -6,8 +6,13 @@ use std::time::Duration;
 
 use url::Url;
 
+pub(super) const BASE_BLOCK_TIME_MILLIS: u64 = 200;
+
 /// Default conductor RPC timeout (1 second), matching the CLI default.
 const DEFAULT_CONDUCTOR_RPC_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Default legacy block time (2 seconds), used prior to Zombie activation.
+const DEFAULT_LEGACY_BLOCK_TIME: u64 = 2;
 
 /// Configuration for the [`SequencerActor`].
 ///
@@ -45,5 +50,61 @@ impl Default for SequencerConfig {
             conductor_rpc_timeout: DEFAULT_CONDUCTOR_RPC_TIMEOUT,
             l1_conf_delay: 0,
         }
+    }
+}
+
+/// Block production cadence for the [`SequencerActor`].
+///
+/// Controls how frequently the sequencer builds blocks. Prior to Zombie the
+/// cadence tracks the legacy `block_time` (seconds); once Zombie is active the
+/// sequencer runs on the 200ms sub-second cadence.
+///
+/// [`SequencerActor`]: super::SequencerActor
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SequencerCadenceConfig {
+    /// The interval between consecutive block builds.
+    pub block_interval: Duration,
+}
+
+impl SequencerCadenceConfig {
+    /// Builds a cadence from the legacy `block_time` expressed in whole seconds.
+    pub const fn from_legacy_block_time(block_time: u64) -> Self {
+        Self { block_interval: Duration::from_secs(block_time) }
+    }
+
+    /// Builds the 200ms cadence used once the Zombie upgrade is active.
+    pub const fn zombie_200ms() -> Self {
+        Self { block_interval: Duration::from_millis(BASE_BLOCK_TIME_MILLIS as u64) }
+    }
+}
+
+impl Default for SequencerCadenceConfig {
+    fn default() -> Self {
+        Self::from_legacy_block_time(DEFAULT_LEGACY_BLOCK_TIME)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_cadence_uses_seconds() {
+        let cadence = SequencerCadenceConfig::from_legacy_block_time(2);
+        assert_eq!(cadence.block_interval, Duration::from_secs(2));
+    }
+
+    #[test]
+    fn zombie_cadence_is_200ms() {
+        let cadence = SequencerCadenceConfig::zombie_200ms();
+        assert_eq!(cadence.block_interval, Duration::from_millis(200));
+    }
+
+    #[test]
+    fn default_cadence_matches_legacy_two_seconds() {
+        assert_eq!(
+            SequencerCadenceConfig::default(),
+            SequencerCadenceConfig::from_legacy_block_time(DEFAULT_LEGACY_BLOCK_TIME)
+        );
     }
 }

--- a/crates/consensus/service/src/actors/sequencer/error.rs
+++ b/crates/consensus/service/src/actors/sequencer/error.rs
@@ -2,7 +2,8 @@ use base_consensus_derive::PipelineErrorKind;
 use base_consensus_engine::BuildTaskError;
 
 use crate::{
-    L1OriginSelectorError, UnsafePayloadGossipClientError, actors::engine::EngineClientError,
+    L1OriginSelectorError, UnsafePayloadGossipClientError,
+    actors::{engine::EngineClientError, sequencer::SequencerTimestampPlannerError},
 };
 
 /// An error produced by the [`crate::SequencerActor`].
@@ -26,4 +27,7 @@ pub enum SequencerActorError {
     /// An error occurred while attempting to schedule unsafe payload gossip.
     #[error("An error occurred while attempting to schedule unsafe payload gossip: {0}")]
     PayloadGossip(#[from] UnsafePayloadGossipClientError),
+    /// An error occurred while planning the next block timestamp.
+    #[error(transparent)]
+    TimestampPlanner(#[from] SequencerTimestampPlannerError),
 }

--- a/crates/consensus/service/src/actors/sequencer/mod.rs
+++ b/crates/consensus/service/src/actors/sequencer/mod.rs
@@ -4,7 +4,7 @@ mod build;
 pub use build::{PayloadBuilder, UnsealedPayloadHandle};
 
 mod config;
-pub use config::SequencerConfig;
+pub use config::{SequencerCadenceConfig, SequencerConfig};
 
 mod origin_selector;
 #[cfg(test)]
@@ -22,6 +22,11 @@ pub use seal::{PayloadSealer, SealState, SealStepError, SealStepOutcome};
 
 mod ticker;
 pub use ticker::ScheduledTicker;
+
+mod timestamp;
+pub use timestamp::{
+    SequencerTimestamp, SequencerTimestampPlanner, SequencerTimestampPlannerError,
+};
 
 mod pool;
 pub use pool::PoolActivation;

--- a/crates/consensus/service/src/actors/sequencer/timestamp.rs
+++ b/crates/consensus/service/src/actors/sequencer/timestamp.rs
@@ -1,0 +1,118 @@
+//! Timestamp planning for sequencer block production.
+//!
+//! Prior to the Zombie upgrade blocks advance by the legacy `block_time` in
+//! whole seconds. Once Zombie is active blocks advance on a 200ms cadence, and
+//! the resulting timestamp is split into a whole-second component and a
+//! millisecond remainder (`timestamp_millis_part`).
+
+use super::config::BASE_BLOCK_TIME_MILLIS;
+
+const ZOMBIE_CADENCE_MILLIS: u64 = BASE_BLOCK_TIME_MILLIS;
+
+/// The number of milliseconds in one second.
+const MILLIS_PER_SECOND: u64 = 1_000;
+
+/// A planned block timestamp.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SequencerTimestamp {
+    /// The whole-second component of the timestamp (seconds since the Unix epoch).
+    pub timestamp: u64,
+    /// The millisecond component (0-999, multiple of 200), or [`None`] pre-Zombie.
+    pub timestamp_millis_part: Option<u16>,
+    /// The full timestamp in milliseconds since the Unix epoch.
+    pub timestamp_millis: u64,
+}
+
+/// Errors produced while planning a block timestamp.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum SequencerTimestampPlannerError {
+    /// The computed timestamp overflowed a [`u64`].
+    #[error("sequencer timestamp overflowed u64")]
+    TimestampOverflow,
+}
+
+/// Plans the next block timestamp for the sequencer.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SequencerTimestampPlanner;
+
+impl SequencerTimestampPlanner {
+    /// Plans a legacy timestamp by advancing the parent by `block_time` seconds.
+    pub fn legacy(
+        parent_timestamp: u64,
+        block_time: u64,
+    ) -> Result<SequencerTimestamp, SequencerTimestampPlannerError> {
+        let timestamp = parent_timestamp
+            .checked_add(block_time)
+            .ok_or(SequencerTimestampPlannerError::TimestampOverflow)?;
+        let timestamp_millis = timestamp
+            .checked_mul(MILLIS_PER_SECOND)
+            .ok_or(SequencerTimestampPlannerError::TimestampOverflow)?;
+        Ok(SequencerTimestamp { timestamp, timestamp_millis_part: None, timestamp_millis })
+    }
+
+    /// Plans a Zombie timestamp aligned to the 200ms cadence.
+    ///
+    /// The candidate is the wall clock floored to the cadence; a monotonicity
+    /// guard ensures the result is at least one cadence step past the parent.
+    pub fn zombie(
+        parent_timestamp_millis: u64,
+        wall_clock_millis: u64,
+    ) -> Result<SequencerTimestamp, SequencerTimestampPlannerError> {
+        let candidate = (wall_clock_millis / ZOMBIE_CADENCE_MILLIS) * ZOMBIE_CADENCE_MILLIS;
+        let minimum = parent_timestamp_millis
+            .checked_add(ZOMBIE_CADENCE_MILLIS)
+            .ok_or(SequencerTimestampPlannerError::TimestampOverflow)?;
+        let timestamp_millis = candidate.max(minimum);
+        let timestamp = timestamp_millis / MILLIS_PER_SECOND;
+        let timestamp_millis_part = (timestamp_millis % MILLIS_PER_SECOND) as u16;
+        Ok(SequencerTimestamp {
+            timestamp,
+            timestamp_millis_part: Some(timestamp_millis_part),
+            timestamp_millis,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_advances_by_block_time() {
+        let planned = SequencerTimestampPlanner::legacy(1_000, 2).unwrap();
+        assert_eq!(planned.timestamp, 1_002);
+        assert_eq!(planned.timestamp_millis_part, None);
+        assert_eq!(planned.timestamp_millis, 1_002_000);
+    }
+
+    #[test]
+    fn zombie_floors_wall_clock_to_cadence() {
+        let planned = SequencerTimestampPlanner::zombie(1_000_000, 1_000_450).unwrap();
+        assert_eq!(planned.timestamp_millis, 1_000_400);
+        assert_eq!(planned.timestamp, 1_000);
+        assert_eq!(planned.timestamp_millis_part, Some(400));
+    }
+
+    #[test]
+    fn zombie_enforces_monotonic_minimum() {
+        let planned = SequencerTimestampPlanner::zombie(1_000_000, 1_000_050).unwrap();
+        assert_eq!(planned.timestamp_millis, 1_000_200);
+        assert_eq!(planned.timestamp_millis_part, Some(200));
+    }
+
+    #[test]
+    fn zombie_carries_across_second_boundary() {
+        let planned = SequencerTimestampPlanner::zombie(1_999_800, 2_000_050).unwrap();
+        assert_eq!(planned.timestamp_millis, 2_000_000);
+        assert_eq!(planned.timestamp, 2_000);
+        assert_eq!(planned.timestamp_millis_part, Some(0));
+    }
+
+    #[test]
+    fn zombie_overflow_is_rejected() {
+        assert_eq!(
+            SequencerTimestampPlanner::zombie(u64::MAX, 0),
+            Err(SequencerTimestampPlannerError::TimestampOverflow)
+        );
+    }
+}

--- a/crates/consensus/service/src/lib.rs
+++ b/crates/consensus/service/src/lib.rs
@@ -40,9 +40,11 @@ pub use actors::{
     QueuedL1WatcherDerivationClient, QueuedNetworkEngineClient, QueuedSequencerAdminAPIClient,
     QueuedSequencerEngineClient, QueuedUnsafePayloadGossipClient, RecoveryModeGuard, ResetRequest,
     RpcActor, RpcActorError, RpcContext, ScheduledTicker, SealState, SealStepError,
-    SealStepOutcome, SequencerActor, SequencerActorError, SequencerAdminQuery, SequencerConfig,
-    SequencerEngineClient, UnsafePayloadGossipClient, UnsafePayloadGossipClientError,
-    UnsealedPayloadHandle, UpgradeSignalMetricsActor, UpgradeSignalNodeConfig,
+    SealStepOutcome, SequencerActor, SequencerActorError, SequencerAdminQuery,
+    SequencerCadenceConfig, SequencerConfig, SequencerEngineClient, SequencerTimestamp,
+    SequencerTimestampPlanner, SequencerTimestampPlannerError, UnsafePayloadGossipClient,
+    UnsafePayloadGossipClientError, UnsealedPayloadHandle, UpgradeSignalMetricsActor,
+    UpgradeSignalNodeConfig,
 };
 
 mod metrics;


### PR DESCRIPTION
## Summary

Adds the timestamp planning logic used by the sub-second sequencer. Pure new code — no existing behavior changed.

**Depends on #3979.**

## New types

### `SequencerTimestampPlanner` (`timestamp.rs`)
Wall-clock-aligned sub-second timestamp planner:
- `sub_second(config, clock, cadence_millis)` — builds a planner aligned to the first Zombie block; cadence is a parameter (not hardcoded)
- `legacy(parent_timestamp, block_time)` — whole-second cadence for pre-Zombie chains
- `plan_next(now, last_planned)` — returns `SequencerTimestamp` advancing by the configured cadence, skipping any wall-clock slots that have already passed, with a monotonicity guard
- `SequencerTimestamp` carries the planned `(seconds, millis_part)` pair

### `SequencerTimestampPlannerError`
- `Overflow` and `MonotonicityViolation` variants

All types re-exported from `sequencer::mod`, `actors::mod`, and `lib`.

## Stack
- PR1 (#3978): Zombie hardfork scaffolding
- PR2 (#3979): `timestamp_from_block_number` timing math
- **→ This PR (#3980)**: `SequencerTimestampPlanner`
- PR4 (#3981): Wire configurable block interval into build loop + CLI flag
