### PR TITLE
ci: bump BASE_ANVIL_REF to include versioned B-20 lookup

### DIFF
--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -13,7 +13,7 @@ env:
   # Pinned base-anvil commit so this job is decoupled from base-anvil-fork
   # branch movement. Bump in lockstep with base/base's reth/revm version; a
   # cutover to a new base-anvil (e.g. reth 2.3.0) rides in the same base/base PR.
-  BASE_ANVIL_REF: 0092692587d8d064dd2c6923ce26a682c58f3694
+  BASE_ANVIL_REF: f4370bc97756557d0ef1a6c325ad7d2532e71112
   BASE_STD_REF: main
   CARGO_TERM_COLOR: always
   RUSTC_WRAPPER: "sccache"


### PR DESCRIPTION
## What

Bump the fork-test workflow's pinned `BASE_ANVIL_REF` `0092692 → f4370bc`.

## Why

#3960 (BOP-419) restructured the stablecoin precompile into the versioned SOLID shape and changed the B-20 `create_precompile` / `BerylLookup` path to take a `BaseUpgrade`. `base-std-fork-tests.yml` patches the local precompile crates into the pinned base-anvil and rebuilds `anvil`/`forge` — so with the new API on `main`, the previously-pinned base-anvil (`0092692`, which still called `create_precompile(address)` with one arg) fails to compile (`E0061`), breaking the fork-test job on every base/base PR.

base-anvil was updated to thread the upgrade through the versioned lookup (base/base-anvil#50, merged to `base-anvil-fork` at `f4370bc`). This bump points the workflow at that commit so the patched build compiles against `main`'s versioned precompile API.

## Notes

- CI-only change (single env value); no runtime/code impact.
- `base-anvil-fork@f4370bc` also carries the CI-hygiene fixes from base/base-anvil#51 (deny advisories, nightly rustdoc lint, forge-std pin), so the fork-test job's build/setup is green apart from the pre-existing `test external` mainnet-fork-over-public-RPC flake (tracked separately; needs the `HTTP_ARCHIVE_URLS` secret).
