### PR TITLE
test(execution): prove BaseTime same-block visibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4593,6 +4593,7 @@ dependencies = [
  "base-common-rpc-types-engine",
  "base-execution-chainspec",
  "base-execution-consensus",
+ "base-protocol",
  "reth-chainspec",
  "reth-evm",
  "reth-execution-errors",

--- a/crates/execution/evm/Cargo.toml
+++ b/crates/execution/evm/Cargo.toml
@@ -43,6 +43,7 @@ thiserror.workspace = true
 
 [dev-dependencies]
 alloy-genesis.workspace = true
+base-protocol.workspace = true
 base-common-genesis.workspace = true
 reth-evm = { workspace = true, features = ["test-utils"] }
 reth-revm = { workspace = true, features = ["test-utils"] }

--- a/crates/execution/evm/tests/block_execution.rs
+++ b/crates/execution/evm/tests/block_execution.rs
@@ -3,14 +3,25 @@
 use std::{collections::HashMap, str::FromStr, sync::Arc};
 
 use alloy_consensus::{Block, BlockBody, Header, SignableTransaction, TxEip1559};
-use alloy_primitives::{Address, Signature, StorageKey, StorageValue, U256, b256};
-use base_common_consensus::{BaseReceipt, BaseTransactionSigned, Predeploys, TxDeposit};
+use alloy_primitives::{Address, Signature, StorageKey, StorageValue, U256, address, b256, bytes};
+use base_common_chains::BaseUpgrade;
+use base_common_consensus::{
+    BaseReceipt, BaseTransactionSigned, Predeploys, SystemAddresses, TxDeposit,
+};
+use base_common_evm::BaseTime;
 use base_execution_chainspec::{BaseChainSpec, BaseChainSpecBuilder};
 use base_execution_evm::{BaseEvmConfig, BaseRethReceiptBuilder};
-use reth_chainspec::MIN_TRANSACTION_GAS;
+use base_protocol::BaseTimeUpdateTx;
+use reth_chainspec::{ForkCondition, MIN_TRANSACTION_GAS};
 use reth_evm::execute::{BasicBlockExecutor, Executor};
 use reth_primitives_traits::{Account, RecoveredBlock};
 use reth_revm::{database::StateProviderDatabase, test_utils::StateProviderTest};
+
+const BASE_TIME_READER: Address = address!("0x1000000000000000000000000000000000000000");
+const USER: Address = address!("0x1000000000000000000000000000000000000001");
+const BLOCK_TIMESTAMP: u64 = 1_725;
+const PREVIOUS_MILLIS_PART: u16 = 200;
+const CURRENT_MILLIS_PART: u16 = 600;
 
 fn create_base_state_provider() -> StateProviderTest {
     let mut db = StateProviderTest::default();
@@ -40,6 +51,117 @@ fn create_base_state_provider() -> StateProviderTest {
 
 fn evm_config(chain_spec: Arc<BaseChainSpec>) -> BaseEvmConfig {
     BaseEvmConfig::new(chain_spec, BaseRethReceiptBuilder::default())
+}
+
+fn execute_same_block_base_time_read(getter_selector: [u8; 4]) -> U256 {
+    let mut db = create_base_state_provider();
+    let mut base_time_storage = HashMap::default();
+    base_time_storage.insert(
+        StorageKey::from(BaseTime::ADMIN_SLOT.to_be_bytes::<32>()),
+        U256::from_be_slice(Predeploys::PROXY_ADMIN.as_slice()),
+    );
+    base_time_storage.insert(
+        StorageKey::from(BaseTime::TIMESTAMP_MILLIS_PART_SLOT.to_be_bytes::<32>()),
+        U256::from(PREVIOUS_MILLIS_PART),
+    );
+    db.insert_account(
+        Predeploys::BASE_TIME,
+        Account::default(),
+        Some(BaseTime::proxy_bytecode()),
+        base_time_storage,
+    );
+    db.insert_account(
+        BASE_TIME_READER,
+        Account::default(),
+        // Forward the four-byte calldata to BaseTime and store its returned word in slot zero.
+        Some(bytes!(
+            "6004600060003760206000600460007342000000000000000000000000000000000000305afa5060005160005500"
+        )),
+        HashMap::default(),
+    );
+    db.insert_account(
+        USER,
+        Account { balance: U256::MAX, ..Default::default() },
+        None,
+        HashMap::default(),
+    );
+
+    let chain_spec = Arc::new(
+        BaseChainSpecBuilder::base_mainnet()
+            .cobalt_activated()
+            .with_fork(BaseUpgrade::Zombie, ForkCondition::Timestamp(0))
+            .build(),
+    );
+
+    let l1_info_tx: BaseTransactionSigned = TxDeposit {
+        from: SystemAddresses::DEPOSITOR_ACCOUNT,
+        to: Predeploys::L1_BLOCK_INFO.into(),
+        gas_limit: 1_000_000,
+        ..Default::default()
+    }
+    .into();
+    let (_, base_time_tx) = BaseTimeUpdateTx::try_new_with_deposit_tx(
+        &Default::default(),
+        1,
+        CURRENT_MILLIS_PART,
+        BLOCK_TIMESTAMP,
+        BLOCK_TIMESTAMP,
+    )
+    .unwrap();
+    let base_time_tx: BaseTransactionSigned = base_time_tx.into();
+    let user_tx: BaseTransactionSigned = TxEip1559 {
+        chain_id: chain_spec.chain.id(),
+        nonce: 0,
+        gas_limit: 100_000,
+        to: BASE_TIME_READER.into(),
+        input: getter_selector.into(),
+        ..Default::default()
+    }
+    .into_signed(Signature::test_signature())
+    .into();
+
+    let header = Header {
+        timestamp: BLOCK_TIMESTAMP,
+        number: 1,
+        gas_limit: 3_000_000,
+        parent_beacon_block_root: Some(Default::default()),
+        ..Default::default()
+    };
+    let output = BasicBlockExecutor::new(evm_config(chain_spec), StateProviderDatabase::new(&db))
+        .execute(&RecoveredBlock::new_unhashed(
+            Block {
+                header,
+                body: BlockBody {
+                    transactions: vec![l1_info_tx, base_time_tx, user_tx],
+                    ..Default::default()
+                },
+            },
+            vec![SystemAddresses::DEPOSITOR_ACCOUNT, SystemAddresses::DEPOSITOR_ACCOUNT, USER],
+        ))
+        .expect("BaseTime metadata and user reads should execute in order");
+
+    assert_eq!(output.receipts.len(), 3);
+    assert_eq!(
+        output.storage(&Predeploys::BASE_TIME, BaseTime::TIMESTAMP_MILLIS_PART_SLOT),
+        Some(U256::from(CURRENT_MILLIS_PART))
+    );
+    output.storage(&BASE_TIME_READER, U256::ZERO).expect("reader should store the getter result")
+}
+
+#[test]
+fn base_time_millis_part_is_visible_to_user_transaction_in_same_block() {
+    assert_eq!(
+        execute_same_block_base_time_read(BaseTime::TIMESTAMP_MILLIS_PART_SELECTOR),
+        U256::from(CURRENT_MILLIS_PART)
+    );
+}
+
+#[test]
+fn base_time_timestamp_ms_is_visible_to_user_transaction_in_same_block() {
+    assert_eq!(
+        execute_same_block_base_time_read(BaseTime::TIMESTAMP_MS_SELECTOR),
+        U256::from(BLOCK_TIMESTAMP * 1_000 + u64::from(CURRENT_MILLIS_PART))
+    );
 }
 
 #[test]


### PR DESCRIPTION
Adds block-execution coverage proving that user transactions observe the BaseTime millisecond value written by the metadata deposit earlier in the same block. The tests seed a stale prior value and verify both timestampMillisPart() and timestampMs() through the deployed proxy under the post-Cobalt execution environment.