### PR TITLE
fix(eip8130): honor default EOA in nested delegate auth

### DIFF
--- a/crates/execution/eip8130/src/authorize.rs
+++ b/crates/execution/eip8130/src/authorize.rs
@@ -79,7 +79,7 @@ impl ActorAuthorizer {
                 // `actor_config`), then requires admin (`scope == 0`). Nested
                 // discharge must not skip to `resolve_bound`: that would reject a
                 // live default EOA whose key lives only in `AccountState`, the
-                // common 7702-EOA-as-parent case. This is also the single nested
+                // common EOA-as-parent case. This is also the single nested
                 // signature verification (dispatch's delegate step is structural
                 // only), so there is no redundant ecrecover. The admin gate is
                 // independent of `verifySignature` (now operational: admin, or a
@@ -652,7 +652,7 @@ mod tests {
 
     #[test]
     fn delegate_accepts_nested_default_eoa_self() {
-        // 7702 EOA as parent: nested k1 recovers to the delegate account itself,
+        // EOA as parent: nested k1 recovers to the delegate account itself,
         // with no `actor_config` entry — only the live inline default EOA.
         // `DelegateAuthenticator` → `authenticateActor` must honor that path;
         // bare `resolve_bound` would incorrectly return NotBound.

--- a/crates/execution/eip8130/src/authorize.rs
+++ b/crates/execution/eip8130/src/authorize.rs
@@ -71,7 +71,7 @@ impl ActorAuthorizer {
             DispatchOutcome::Authenticated { actor_id } => {
                 Self::resolve_bound(storage, account, actor_id, authenticator, now)
             }
-            DispatchOutcome::Delegated { actor_id, delegate_account, .. } => {
+            DispatchOutcome::Delegated { actor_id, delegate_account } => {
                 // `data` = delegate_account(20) || nested_auth. Mirror
                 // `DelegateAuthenticator`, which calls
                 // `authenticateActor(delegate, hash, nestedAuth)` — the *full*
@@ -79,10 +79,12 @@ impl ActorAuthorizer {
                 // `actor_config`), then requires admin (`scope == 0`). Nested
                 // discharge must not skip to `resolve_bound`: that would reject a
                 // live default EOA whose key lives only in `AccountState`, the
-                // common 7702-EOA-as-parent case. The admin gate is independent
-                // of `verifySignature` (now operational: admin, or a SENDER
-                // actor without POLICY): an operational key may sign for its own
-                // account but MUST NOT vouch as a delegate, to preserve
+                // common 7702-EOA-as-parent case. This is also the single nested
+                // signature verification (dispatch's delegate step is structural
+                // only), so there is no redundant ecrecover. The admin gate is
+                // independent of `verifySignature` (now operational: admin, or a
+                // SENDER actor without POLICY): an operational key may sign for
+                // its own account but MUST NOT vouch as a delegate, to preserve
                 // non-escalation. Followed by the outer
                 // `_actorConfig[bytes20(delegate)][account]` binding check.
                 let nested =

--- a/crates/execution/eip8130/src/authorize.rs
+++ b/crates/execution/eip8130/src/authorize.rs
@@ -71,32 +71,24 @@ impl ActorAuthorizer {
             DispatchOutcome::Authenticated { actor_id } => {
                 Self::resolve_bound(storage, account, actor_id, authenticator, now)
             }
-            DispatchOutcome::Delegated {
-                actor_id,
-                delegate_account,
-                nested_authenticator,
-                nested_actor_id,
-            } => {
-                // Discharge the nested actor against the delegated account's
-                // config and require it to be admin (`scope == 0`), then authorize
-                // the outer delegate actor against the originating account.
-                // Mirrors `DelegateAuthenticator`, which calls
-                // `authenticateActor(delegate, ...)` and explicitly requires the
-                // resolved `scope == 0`. This admin requirement is independent of
-                // `verifySignature` (now operational: admin, or a SENDER actor
-                // without POLICY): an operational key may sign for its own account
-                // but MUST NOT vouch as a delegate, to preserve non-escalation.
-                // Followed by the outer `_actorConfig[bytes20(delegate)][account]`
-                // binding check.
-                let nested = Self::resolve_bound(
-                    storage,
-                    delegate_account,
-                    nested_actor_id,
-                    nested_authenticator,
-                    now,
-                )?;
+            DispatchOutcome::Delegated { actor_id, delegate_account, .. } => {
+                // `data` = delegate_account(20) || nested_auth. Mirror
+                // `DelegateAuthenticator`, which calls
+                // `authenticateActor(delegate, hash, nestedAuth)` — the *full*
+                // auth path (inline default-EOA k1 self *or* explicit
+                // `actor_config`), then requires admin (`scope == 0`). Nested
+                // discharge must not skip to `resolve_bound`: that would reject a
+                // live default EOA whose key lives only in `AccountState`, the
+                // common 7702-EOA-as-parent case. The admin gate is independent
+                // of `verifySignature` (now operational: admin, or a SENDER
+                // actor without POLICY): an operational key may sign for its own
+                // account but MUST NOT vouch as a delegate, to preserve
+                // non-escalation. Followed by the outer
+                // `_actorConfig[bytes20(delegate)][account]` binding check.
+                let nested =
+                    Self::authenticate_actor(storage, delegate_account, hash, &data[20..], now)?;
                 if nested.scope != 0 {
-                    return Err(AuthorizeError::NestedSignatureScope { actor_id: nested_actor_id });
+                    return Err(AuthorizeError::NestedSignatureScope { actor_id: nested.actor_id });
                 }
                 Self::resolve_bound(
                     storage,
@@ -616,6 +608,80 @@ mod tests {
                     actor_id: nested_id,
                     authenticator: Eip8130Constants::K1_AUTHENTICATOR,
                 }),
+            );
+        });
+    }
+
+    #[test]
+    fn delegate_accepts_nested_default_eoa_self() {
+        // 7702 EOA as parent: nested k1 recovers to the delegate account itself,
+        // with no `actor_config` entry — only the live inline default EOA.
+        // `DelegateAuthenticator` → `authenticateActor` must honor that path;
+        // bare `resolve_bound` would incorrectly return NotBound.
+        let nested_key = k1_key(0x55);
+        let delegate_account = k1_address(&nested_key);
+        let outer_id = actor_id(delegate_account);
+        let auth = delegate_auth(delegate_account, &nested_key);
+        with_storage(|acc| {
+            acc.actor_config
+                .at_mut(&outer_id)
+                .at_mut(&ACCOUNT)
+                .write(pack(Eip8130Contracts::DELEGATE_AUTHENTICATOR, 0x08, 0))
+                .unwrap();
+            let resolved =
+                ActorAuthorizer::authenticate_actor(acc, ACCOUNT, HASH, &auth, NOW).unwrap();
+            assert_eq!(
+                resolved,
+                ResolvedActor { actor_id: outer_id, scope: 0x08, policy_target: Address::ZERO }
+            );
+        });
+    }
+
+    #[test]
+    fn delegate_rejects_nested_default_eoa_when_revoked() {
+        let nested_key = k1_key(0x56);
+        let delegate_account = k1_address(&nested_key);
+        let outer_id = actor_id(delegate_account);
+        let auth = delegate_auth(delegate_account, &nested_key);
+        with_storage(|acc| {
+            acc.account_state
+                .at_mut(&delegate_account)
+                .write(pack_self(0, 0, true))
+                .unwrap();
+            acc.actor_config
+                .at_mut(&outer_id)
+                .at_mut(&ACCOUNT)
+                .write(pack(Eip8130Contracts::DELEGATE_AUTHENTICATOR, 0x08, 0))
+                .unwrap();
+            assert_eq!(
+                ActorAuthorizer::authenticate_actor(acc, ACCOUNT, HASH, &auth, NOW),
+                Err(AuthorizeError::DefaultEoaRevoked { account: delegate_account }),
+            );
+        });
+    }
+
+    #[test]
+    fn delegate_rejects_nested_scoped_default_eoa() {
+        // Live but scoped (non-admin) default EOA may sign for its own account,
+        // yet must not vouch as a delegate.
+        let nested_key = k1_key(0x57);
+        let delegate_account = k1_address(&nested_key);
+        let nested_id = actor_id(delegate_account);
+        let outer_id = actor_id(delegate_account);
+        let auth = delegate_auth(delegate_account, &nested_key);
+        with_storage(|acc| {
+            acc.account_state
+                .at_mut(&delegate_account)
+                .write(pack_self(Eip8130Constants::SCOPE_SENDER, 0, false))
+                .unwrap();
+            acc.actor_config
+                .at_mut(&outer_id)
+                .at_mut(&ACCOUNT)
+                .write(pack(Eip8130Contracts::DELEGATE_AUTHENTICATOR, 0x08, 0))
+                .unwrap();
+            assert_eq!(
+                ActorAuthorizer::authenticate_actor(acc, ACCOUNT, HASH, &auth, NOW),
+                Err(AuthorizeError::NestedSignatureScope { actor_id: nested_id }),
             );
         });
     }

--- a/crates/execution/eip8130/src/authorize.rs
+++ b/crates/execution/eip8130/src/authorize.rs
@@ -89,11 +89,12 @@ impl ActorAuthorizer {
                 // `_actorConfig[bytes20(delegate)][account]` binding check.
                 //
                 // Independent depth-1 guard: `authenticate_actor` re-enters the
-                // public dispatch with `allow_delegate = true`, so reject a nested
-                // delegate here before re-entry. `AuthenticatorDispatch::delegate`
-                // already enforces this structurally; this second, layer-local
-                // check keeps single-hop intact even if either layer is later
-                // refactored. (`data` is `delegate_account(20) || nested_auth`, so
+                // public dispatch, which routes a delegate authenticator straight
+                // to the (structural) delegate step, so reject a nested delegate
+                // here before re-entry. `AuthenticatorDispatch::delegate` already
+                // enforces this structurally; this second, layer-local check keeps
+                // single-hop intact even if either layer is later refactored.
+                // (`data` is `delegate_account(20) || nested_auth`, so
                 // `data[20..40]` is the nested authenticator; the outer dispatch
                 // guarantees `data.len() >= 40`.)
                 let nested_authenticator = Address::from_slice(&data[20..40]);
@@ -678,10 +679,7 @@ mod tests {
         let outer_id = actor_id(delegate_account);
         let auth = delegate_auth(delegate_account, &nested_key);
         with_storage(|acc| {
-            acc.account_state
-                .at_mut(&delegate_account)
-                .write(pack_self(0, 0, true))
-                .unwrap();
+            acc.account_state.at_mut(&delegate_account).write(pack_self(0, 0, true)).unwrap();
             acc.actor_config
                 .at_mut(&outer_id)
                 .at_mut(&ACCOUNT)

--- a/crates/execution/eip8130/src/authorize.rs
+++ b/crates/execution/eip8130/src/authorize.rs
@@ -87,6 +87,19 @@ impl ActorAuthorizer {
                 // its own account but MUST NOT vouch as a delegate, to preserve
                 // non-escalation. Followed by the outer
                 // `_actorConfig[bytes20(delegate)][account]` binding check.
+                //
+                // Independent depth-1 guard: `authenticate_actor` re-enters the
+                // public dispatch with `allow_delegate = true`, so reject a nested
+                // delegate here before re-entry. `AuthenticatorDispatch::delegate`
+                // already enforces this structurally; this second, layer-local
+                // check keeps single-hop intact even if either layer is later
+                // refactored. (`data` is `delegate_account(20) || nested_auth`, so
+                // `data[20..40]` is the nested authenticator; the outer dispatch
+                // guarantees `data.len() >= 40`.)
+                let nested_authenticator = Address::from_slice(&data[20..40]);
+                if nested_authenticator == Eip8130Contracts::DELEGATE_AUTHENTICATOR {
+                    return Err(AuthError::NestedDelegate.into());
+                }
                 let nested =
                     Self::authenticate_actor(storage, delegate_account, hash, &data[20..], now)?;
                 if nested.scope != 0 {
@@ -610,6 +623,25 @@ mod tests {
                     actor_id: nested_id,
                     authenticator: Eip8130Constants::K1_AUTHENTICATOR,
                 }),
+            );
+        });
+    }
+
+    #[test]
+    fn delegate_rejects_nested_delegate_at_authorize_layer() {
+        // Depth-2: DELEGATE || delegate_account(20) || DELEGATE || .... The
+        // authorize layer's independent guard rejects the nested delegate before
+        // re-entering `authenticate_actor`, mirroring the dispatch-level check.
+        let delegate_account = address!("0x00000000000000000000000000000000000000bb");
+        let mut data = Vec::new();
+        data.extend_from_slice(delegate_account.as_slice());
+        data.extend_from_slice(Eip8130Contracts::DELEGATE_AUTHENTICATOR.as_slice());
+        data.extend_from_slice(&[0u8; 65]);
+        let auth = blob(Eip8130Contracts::DELEGATE_AUTHENTICATOR, &data);
+        with_storage(|acc| {
+            assert_eq!(
+                ActorAuthorizer::authenticate_actor(acc, ACCOUNT, HASH, &auth, NOW),
+                Err(AuthorizeError::Authenticate(AuthError::NestedDelegate)),
             );
         });
     }

--- a/crates/execution/eip8130/src/authorize.rs
+++ b/crates/execution/eip8130/src/authorize.rs
@@ -629,10 +629,13 @@ mod tests {
     }
 
     #[test]
-    fn delegate_rejects_nested_delegate_at_authorize_layer() {
-        // Depth-2: DELEGATE || delegate_account(20) || DELEGATE || .... The
-        // authorize layer's independent guard rejects the nested delegate before
-        // re-entering `authenticate_actor`, mirroring the dispatch-level check.
+    fn nested_delegate_is_rejected() {
+        // Depth-2: DELEGATE || delegate_account(20) || DELEGATE || .... Single-hop
+        // is rejected. On the public path the dispatch-level structural check
+        // (`AuthenticatorDispatch::delegate`) fires first, so that is what this
+        // test exercises; the authorize-layer guard is redundant defense-in-depth
+        // that only becomes reachable if the dispatch check were removed. Both
+        // surface the same `NestedDelegate` error.
         let delegate_account = address!("0x00000000000000000000000000000000000000bb");
         let mut data = Vec::new();
         data.extend_from_slice(delegate_account.as_slice());

--- a/crates/execution/eip8130/src/dispatch.rs
+++ b/crates/execution/eip8130/src/dispatch.rs
@@ -60,21 +60,16 @@ impl AuthenticatorDispatch {
     /// change digest); the caller computes it. For the native secp256k1 path the
     /// caller passes [`Eip8130Constants::K1_AUTHENTICATOR`] as `authenticator`
     /// with the raw 65-byte signature as `data`.
+    ///
+    /// Routes by authenticator address. The delegate authenticator is dispatched
+    /// structurally only (see [`Self::delegate`]): it never verifies the nested
+    /// signature here, so this routes one level deep and single-hop is enforced by
+    /// [`Self::delegate`] plus the authorize layer's own guard before it re-enters
+    /// the full auth path against the delegate account.
     pub fn authenticate(
         hash: B256,
         authenticator: Address,
         data: &[u8],
-    ) -> Result<DispatchOutcome, AuthError> {
-        Self::authenticate_inner(hash, authenticator, data, true)
-    }
-
-    /// Routes by authenticator address. `allow_delegate` is `false` for the
-    /// nested authentication inside a delegate blob (depth-1 only).
-    fn authenticate_inner(
-        hash: B256,
-        authenticator: Address,
-        data: &[u8],
-        allow_delegate: bool,
     ) -> Result<DispatchOutcome, AuthError> {
         // `address(0)` is the empty / "no actor configured" sentinel and is never
         // a valid authenticator selector; it falls through to `NotCanonical`.
@@ -91,9 +86,6 @@ impl AuthenticatorDispatch {
             return Ok(DispatchOutcome::Authenticated { actor_id: Self::webauthn(hash, data)? });
         }
         if authenticator == Eip8130Contracts::DELEGATE_AUTHENTICATOR {
-            if !allow_delegate {
-                return Err(AuthError::NestedDelegate);
-            }
             return Self::delegate(data);
         }
         Err(AuthError::NotCanonical(authenticator))

--- a/crates/execution/eip8130/src/dispatch.rs
+++ b/crates/execution/eip8130/src/dispatch.rs
@@ -94,7 +94,7 @@ impl AuthenticatorDispatch {
             if !allow_delegate {
                 return Err(AuthError::NestedDelegate);
             }
-            return Self::delegate(hash, data);
+            return Self::delegate(data);
         }
         Err(AuthError::NotCanonical(authenticator))
     }
@@ -228,32 +228,32 @@ impl AuthenticatorDispatch {
     }
 
     /// Delegate authenticator. `data = delegate_account(20) || nested_auth`, where
-    /// `nested_auth = nested_authenticator(20) || nested_data`. Verifies the nested
-    /// signature (canonical, non-delegate) and surfaces the nested actor as a
-    /// [`DispatchOutcome::Delegated`] obligation.
-    fn delegate(hash: B256, data: &[u8]) -> Result<DispatchOutcome, AuthError> {
+    /// `nested_auth = nested_authenticator(20) || nested_data`.
+    ///
+    /// Structural only, mirroring the deployed `DelegateAuthenticator`: it derives
+    /// `actorId = bytes32(bytes20(delegate))`, enforces the single-hop rule
+    /// (`nested_authenticator != DELEGATE_AUTHENTICATOR`), and surfaces a
+    /// [`DispatchOutcome::Delegated`] obligation. It does **not** verify the nested
+    /// signature or resolve the nested actor — the deployed contract likewise only
+    /// calls `ACCOUNT_CONFIGURATION.authenticateActor(delegate, ...)`, which the
+    /// authorize stage mirrors by re-entering the full auth path against the
+    /// delegate account. Verifying here would be a redundant second ecrecover and
+    /// would skip the delegate account's inline default-EOA key.
+    fn delegate(data: &[u8]) -> Result<DispatchOutcome, AuthError> {
         if data.len() < 40 {
             return Err(AuthError::MalformedAuth);
         }
         let delegate_account = Address::from_slice(&data[..20]);
-        let nested = &data[20..];
-        let nested_authenticator = Address::from_slice(&nested[..20]);
-        let nested_data = &nested[20..];
+        let nested_authenticator = Address::from_slice(&data[20..40]);
 
+        // Only one delegation hop is permitted (depth-1).
         if nested_authenticator == Eip8130Contracts::DELEGATE_AUTHENTICATOR {
             return Err(AuthError::NestedDelegate);
         }
-        let nested_actor_id =
-            match Self::authenticate_inner(hash, nested_authenticator, nested_data, false)? {
-                DispatchOutcome::Authenticated { actor_id } => actor_id,
-                DispatchOutcome::Delegated { .. } => return Err(AuthError::NestedDelegate),
-            };
 
         Ok(DispatchOutcome::Delegated {
             actor_id: Self::address_actor_id(delegate_account),
             delegate_account,
-            nested_authenticator,
-            nested_actor_id,
         })
     }
 }
@@ -470,14 +470,18 @@ mod tests {
     }
 
     #[test]
-    fn delegate_surfaces_nested_obligation() {
-        let nested_key = k1_key();
+    fn delegate_surfaces_obligation_without_verifying_nested() {
+        // Dispatch is structural only: it surfaces the delegate account without
+        // verifying the nested signature (the authorize stage does that via the
+        // full `authenticateActor` path). A garbage nested signature still yields
+        // the obligation here — a canonical nested authenticator is all that is
+        // structurally required.
         let delegate_account = address!("0x00000000000000000000000000000000000000bb");
 
         let mut data = Vec::new();
         data.extend_from_slice(delegate_account.as_slice());
         data.extend_from_slice(Eip8130Constants::K1_AUTHENTICATOR.as_slice());
-        data.extend_from_slice(&k1_sig(&nested_key, HASH));
+        data.extend_from_slice(&[0u8; 65]);
 
         let out = AuthenticatorDispatch::authenticate(
             HASH,
@@ -490,8 +494,6 @@ mod tests {
             DispatchOutcome::Delegated {
                 actor_id: AuthenticatorDispatch::address_actor_id(delegate_account),
                 delegate_account,
-                nested_authenticator: Eip8130Constants::K1_AUTHENTICATOR,
-                nested_actor_id: AuthenticatorDispatch::address_actor_id(k1_address(&nested_key)),
             }
         );
     }
@@ -515,20 +517,17 @@ mod tests {
     }
 
     #[test]
-    fn delegate_rejects_non_canonical_nested() {
-        let delegate_account = address!("0x00000000000000000000000000000000000000bb");
-        let mut data = Vec::new();
-        data.extend_from_slice(delegate_account.as_slice());
-        data.extend_from_slice(address!("0x00000000000000000000000000000000deadbeef").as_slice());
-        data.extend_from_slice(&[0u8; 65]);
-        assert!(matches!(
+    fn delegate_rejects_short_data() {
+        // Below the 40-byte delegate(20) || nested_authenticator(20) prefix.
+        let data = [0u8; 39];
+        assert_eq!(
             AuthenticatorDispatch::authenticate(
                 HASH,
                 Eip8130Contracts::DELEGATE_AUTHENTICATOR,
                 &data,
             ),
-            Err(AuthError::NotCanonical(_)),
-        ));
+            Err(AuthError::MalformedAuth),
+        );
     }
 
     #[test]

--- a/crates/execution/eip8130/src/outcome.rs
+++ b/crates/execution/eip8130/src/outcome.rs
@@ -16,13 +16,13 @@ pub enum DispatchOutcome {
         actor_id: B256,
     },
 
-    /// The delegate authenticator: the nested signature has been cryptographically
-    /// verified, but the protocol must still **authorize** the nested actor against
-    /// the delegated account via the full `authenticateActor` path (inline
-    /// default-EOA k1 self *or* an explicit `actor_config` entry) and require
-    /// admin (`scope == 0`). That stateful check is performed by the authorize
-    /// stage; dispatch only proves the nested signature is valid and surfaces
-    /// the obligation here.
+    /// The delegate authenticator: dispatch has only *structurally* parsed the
+    /// blob (delegate account + single-hop check). The nested signature is **not**
+    /// verified here; the authorize stage must run the full `authenticateActor`
+    /// path against the delegated account (inline default-EOA k1 self *or* an
+    /// explicit `actor_config` entry) and require admin (`scope == 0`). This
+    /// mirrors the deployed `DelegateAuthenticator`, which itself only calls
+    /// `ACCOUNT_CONFIGURATION.authenticateActor(delegate, ...)`.
     Delegated {
         /// Outer actor id registered on the originating account:
         /// `bytes32(bytes20(delegate_account))`.
@@ -30,10 +30,5 @@ pub enum DispatchOutcome {
         /// The delegated account (B) whose config the nested actor must be
         /// authorized against via `authenticateActor`.
         delegate_account: Address,
-        /// The nested (canonical, non-delegate) authenticator that verified the
-        /// nested signature.
-        nested_authenticator: Address,
-        /// The nested actor id resolved by the nested authenticator.
-        nested_actor_id: B256,
     },
 }

--- a/crates/execution/eip8130/src/outcome.rs
+++ b/crates/execution/eip8130/src/outcome.rs
@@ -18,19 +18,20 @@ pub enum DispatchOutcome {
 
     /// The delegate authenticator: the nested signature has been cryptographically
     /// verified, but the protocol must still **authorize** the nested actor against
-    /// the delegated account's `actor_config` in SIGNATURE context. That stateful
-    /// check is performed by the authorize stage; dispatch only proves the nested
-    /// signature is valid and surfaces the obligation here.
+    /// the delegated account via the full `authenticateActor` path (inline
+    /// default-EOA k1 self *or* an explicit `actor_config` entry) and require
+    /// admin (`scope == 0`). That stateful check is performed by the authorize
+    /// stage; dispatch only proves the nested signature is valid and surfaces
+    /// the obligation here.
     Delegated {
         /// Outer actor id registered on the originating account:
         /// `bytes32(bytes20(delegate_account))`.
         actor_id: B256,
         /// The delegated account (B) whose config the nested actor must be
-        /// authorized against, in SIGNATURE context.
+        /// authorized against via `authenticateActor`.
         delegate_account: Address,
         /// The nested (canonical, non-delegate) authenticator that verified the
-        /// nested signature. The authorize stage must check this matches the
-        /// nested actor's stored authenticator on `delegate_account`.
+        /// nested signature.
         nested_authenticator: Address,
         /// The nested actor id resolved by the nested authenticator.
         nested_actor_id: B256,


### PR DESCRIPTION
## Summary
- Nested discharge under `DELEGATE` now re-enters `authenticate_actor` (mirroring Solidity `DelegateAuthenticator` → `authenticateActor`), so a live inline default-EOA k1 self can vouch as a parent.
- Previously `resolve_bound` alone rejected EOAs with no explicit `actor_config` entry (`actor is not bound`), while native smart accounts with an explicit k1 binding worked.
- Adds unit coverage for default-EOA nested vouch success, revoked default EOA, and scoped (non-admin) default EOA rejection.

## Test plan
- [x] `cargo test -p base-execution-eip8130 authorize:: --lib`