### PR TITLE
test(system): add build/validate sync-parity fuzz test

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -5,11 +5,6 @@
 name: Fuzz Nightly
 
 on:
-  # TEMPORARY: run on PRs from any branch so this workflow can be exercised on
-  # the real runners before it is merged. REMOVE this pull_request trigger
-  # before merging (the scheduled + dispatch triggers below are the real ones).
-  pull_request:
-    branches: ["**"]
   schedule:
     # 07:00 UTC daily (after most merges have settled).
     - cron: "0 7 * * *"
@@ -40,10 +35,7 @@ jobs:
         # its own random seed, so the shards fan out for more coverage per night. On
         # a workflow_dispatch replay, every shard uses the supplied seed to reproduce
         # it (parallelism adds no coverage there, which is fine for replay).
-        # TEMPORARY: trimmed to one shard for fast branch iteration. Restore the
-        # full spread before merging:
-        #   shard: [1, 2, 3, 4]
-        shard: [1]
+        shard: [1, 2, 3, 4]
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -1,7 +1,7 @@
-# Nightly fuzz: runs the build/validate sync-parity fuzz test across
-# several seeds to explore more of the input space than a single per-merge run.
-# A failing run prints the seed in its error message so it can be replayed and
-# minted into a deterministic regression test.
+# Nightly fuzz: runs the build/validate sync-parity fuzz test with a fresh random
+# seed each run (several shards in parallel) so every run explores a different
+# transaction stream. The chosen seed is logged; a failing run can be replayed by
+# dispatching this workflow with that seed.
 name: Fuzz Nightly
 
 on:
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
     inputs:
       seed:
-        description: "Single seed to run (hex or decimal). Leave blank to run the default matrix."
+        description: "Seed to replay (hex or decimal). Leave blank to generate a fresh random seed."
         required: false
         type: string
 
@@ -36,10 +36,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TEMPORARY: trimmed to one seed for fast branch iteration. Restore the
-        # full nightly spread before merging:
-        #   seed: ["0xBA5EF0FF", "0x1", "0xDEADBEEF", "0xC0FFEE"]
-        seed: ["0xBA5EF0FF"]
+        # Parallel shards, each with its own random seed, for more coverage per run.
+        # TEMPORARY: trimmed to one shard for fast branch iteration. Restore the
+        # full spread before merging:
+        #   shard: [1, 2, 3, 4]
+        shard: [1]
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -57,6 +58,18 @@ jobs:
           rust-cache-shared-key: "stable"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - name: Pick fuzz seed
+        # Replay a specific seed via the workflow_dispatch input; otherwise generate
+        # a fresh random seed so each run fuzzes a different transaction stream. The
+        # seed is logged (and echoed below) so a failing run can be replayed.
+        run: |
+          if [ -n "${{ github.event.inputs.seed }}" ]; then
+            SEED="${{ github.event.inputs.seed }}"
+          else
+            SEED="0x$(openssl rand -hex 8)"
+          fi
+          echo "FUZZ_SEED=$SEED" >> "$GITHUB_ENV"
+          echo "::notice::Fuzzing with seed $SEED (replay via workflow_dispatch input seed=$SEED)"
       - name: Pre-pull docker images
         run: just devnet pull-images
       - name: Build test contracts
@@ -64,9 +77,7 @@ jobs:
         # time; they are gitignored build output, so generate them before building.
         run: cd crates/utilities/test-utils/contracts && forge soldeer install && forge build
       - name: Run fuzz sync-parity test
-        env:
-          # A manual dispatch seed overrides the matrix seed for this run.
-          FUZZ_SEED: ${{ github.event.inputs.seed || matrix.seed }}
+        # FUZZ_SEED is exported by the "Pick fuzz seed" step above.
         run: |
           cargo nextest run -P ci --locked -p base-system-tests \
             --cargo-profile ci --no-capture -E 'test(fuzz_sync_parity)'
@@ -74,6 +85,6 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: fuzz-log-seed-${{ github.event.inputs.seed || matrix.seed }}
+          name: fuzz-log-shard-${{ matrix.shard }}-${{ github.run_id }}
           path: target/nextest/ci/*.xml
           if-no-files-found: ignore

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -62,9 +62,13 @@ jobs:
         # Replay a specific seed via the workflow_dispatch input; otherwise generate
         # a fresh random seed so each run fuzzes a different transaction stream. The
         # seed is logged (and echoed below) so a failing run can be replayed.
+        # The dispatch input is passed via env (not interpolated into the script) to
+        # avoid shell injection.
+        env:
+          SEED_INPUT: ${{ github.event.inputs.seed }}
         run: |
-          if [ -n "${{ github.event.inputs.seed }}" ]; then
-            SEED="${{ github.event.inputs.seed }}"
+          if [ -n "$SEED_INPUT" ]; then
+            SEED="$SEED_INPUT"
           else
             SEED="0x$(openssl rand -hex 8)"
           fi

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -36,7 +36,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Parallel shards, each with its own random seed, for more coverage per run.
+        # Parallel shards. On scheduled runs each shard is its own job and generates
+        # its own random seed, so the shards fan out for more coverage per night. On
+        # a workflow_dispatch replay, every shard uses the supplied seed to reproduce
+        # it (parallelism adds no coverage there, which is fine for replay).
         # TEMPORARY: trimmed to one shard for fast branch iteration. Restore the
         # full spread before merging:
         #   shard: [1, 2, 3, 4]

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -1,0 +1,79 @@
+# Nightly fuzz: runs the build/validate sync-parity fuzz test across
+# several seeds to explore more of the input space than a single per-merge run.
+# A failing run prints the seed in its error message so it can be replayed and
+# minted into a deterministic regression test.
+name: Fuzz Nightly
+
+on:
+  # TEMPORARY: run on PRs from any branch so this workflow can be exercised on
+  # the real runners before it is merged. REMOVE this pull_request trigger
+  # before merging (the scheduled + dispatch triggers below are the real ones).
+  pull_request:
+    branches: ["**"]
+  schedule:
+    # 07:00 UTC daily (after most merges have settled).
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+    inputs:
+      seed:
+        description: "Single seed to run (hex or decimal). Leave blank to run the default matrix."
+        required: false
+        type: string
+
+concurrency:
+  group: fuzz-nightly-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz-sync-parity:
+    name: Fuzz sync parity
+    runs-on:
+      group: BasePerfRunnerGroup
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        # TEMPORARY: trimmed to one seed for fast branch iteration. Restore the
+        # full nightly spread before merging:
+        #   seed: ["0xBA5EF0FF", "0x1", "0xDEADBEEF", "0xC0FFEE"]
+        seed: ["0xBA5EF0FF"]
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+      - uses: ./.github/actions/setup
+        with:
+          free-disk: "true"
+          native-deps: "true"
+          foundry: "true"
+          tools: cargo-nextest
+          rust-cache-shared-key: "stable"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - name: Pre-pull docker images
+        run: just devnet pull-images
+      - name: Build test contracts
+        # base-test-utils embeds Foundry artifacts (contracts/out/*.json) at compile
+        # time; they are gitignored build output, so generate them before building.
+        run: cd crates/utilities/test-utils/contracts && forge soldeer install && forge build
+      - name: Run fuzz sync-parity test
+        env:
+          # A manual dispatch seed overrides the matrix seed for this run.
+          FUZZ_SEED: ${{ github.event.inputs.seed || matrix.seed }}
+        run: |
+          cargo nextest run -P ci --locked -p base-system-tests \
+            --cargo-profile ci --no-capture -E 'test(fuzz_sync_parity)'
+      - name: Upload run log on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: fuzz-log-seed-${{ github.event.inputs.seed || matrix.seed }}
+          path: target/nextest/ci/*.xml
+          if-no-files-found: ignore

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6297,6 +6297,7 @@ dependencies = [
  "base-execution-txpool",
  "base-flashblocks",
  "base-flashblocks-node",
+ "base-load-tests",
  "base-node-core",
  "base-node-runner",
  "base-optimism-rpc",

--- a/etc/systems/Cargo.toml
+++ b/etc/systems/Cargo.toml
@@ -93,6 +93,9 @@ testcontainers = { workspace = true, features = ["blocking", "host-port-exposure
 # cli
 clap = { workspace = true, features = ["derive"] }
 
+# load testing
+base-load-tests.workspace = true
+
 # consensus
 base-consensus-derive.workspace = true
 base-consensus-engine = { workspace = true, features = ["test-utils"] }

--- a/etc/systems/tests/fuzz_sync_parity.rs
+++ b/etc/systems/tests/fuzz_sync_parity.rs
@@ -16,8 +16,9 @@
 //! can be unit-tested deterministically (see the tests at the bottom); the live
 //! test then drives it against the real devnet.
 //!
-//! The seed is fixed (override with `FUZZ_SEED`) and printed on failure so any
-//! divergence replays.
+//! The seed defaults to a fixed value locally and is overridable with `FUZZ_SEED`
+//! (the nightly workflow picks a random seed per run); it is printed on failure so
+//! any divergence replays.
 
 use std::time::Duration;
 

--- a/etc/systems/tests/fuzz_sync_parity.rs
+++ b/etc/systems/tests/fuzz_sync_parity.rs
@@ -1,0 +1,391 @@
+//! Build/validate sync-parity fuzz test: fuzzed transactions through the devnet, with the
+//! validator's sync to the sequencer as the oracle.
+//!
+//! This exercises agreement between block building and block validation: the
+//! sequencer builds and gossips blocks, and the following validator must stay in
+//! sync. If a fuzzed transaction set makes the sequencer build a block the
+//! validator rejects as invalid, the validator stalls and this test fails.
+//!
+//! Transaction generation reuses the load tester's `WorkloadGenerator` (the paved
+//! road for valid, signed, funded transactions) across a mix of transfer and
+//! calldata payloads, submitted from several funded senders for block variety.
+//! The adversarial permutation layer (access-list and gas-boundary variety, tx
+//! reordering) is the next increment and slots in behind `FuzzTxGenerator`.
+//!
+//! The parity decision is factored into the pure `classify_parity` function so it
+//! can be unit-tested deterministically (see the tests at the bottom); the live
+//! test then drives it against the real devnet.
+//!
+//! The seed is fixed (override with `FUZZ_SEED`) and printed on failure so any
+//! divergence replays.
+
+use std::time::Duration;
+
+use alloy_consensus::SignableTransaction;
+use alloy_eips::{BlockNumberOrTag, eip2718::Encodable2718};
+use alloy_network::TransactionBuilder;
+use alloy_primitives::{Address, B256, Bytes, U256};
+use alloy_provider::{Provider, RootProvider};
+use alloy_signer::SignerSync;
+use alloy_signer_local::PrivateKeySigner;
+use base_common_network::Base;
+use base_common_rpc_types::BaseTransactionRequest;
+use base_load_tests::{CalldataPayload, TransferPayload, WorkloadConfig, WorkloadGenerator};
+use base_system_tests::{
+    ANVIL_ACCOUNT_1, ANVIL_ACCOUNT_2, ANVIL_ACCOUNT_3, ANVIL_ACCOUNT_4, Account,
+    SystemTestStackBuilder,
+};
+use eyre::{Result, WrapErr, eyre};
+use tokio::time::{sleep, timeout};
+use tracing::info;
+
+const L1_CHAIN_ID: u64 = 1337;
+const L2_CHAIN_ID: u64 = 84538453;
+
+/// Default seed so a failing run replays deterministically. Override with the
+/// `FUZZ_SEED` env var to explore more of the input space across runs.
+const DEFAULT_SEED: u64 = 0x_BA5E_F0FF;
+/// Number of fuzzed transactions to submit in one run.
+const NUM_TXS: u64 = 200;
+/// Gas limit applied to every generated transaction. Generous so calldata
+/// payloads are always includable; the generator controls the interesting bits.
+const TX_GAS_LIMIT: u64 = 200_000;
+/// Max attempts per tx while the txpool is full, so submissions pace to block
+/// production instead of bouncing off a full pool.
+const MAX_SEND_ATTEMPTS: u32 = 20;
+const SEND_BACKOFF: Duration = Duration::from_millis(250);
+
+/// How far the validator may lag the sequencer and still count as "in sync".
+/// The sequencer legitimately leads by a block or two, so this is not zero.
+const MAX_LAG: u64 = 2;
+/// Consecutive in-sync polls required before we declare parity. Guards against a
+/// single lucky sample while the validator is actually stalling.
+const PARITY_WINDOW: u32 = 5;
+const PARITY_POLL_INTERVAL: Duration = Duration::from_millis(500);
+const PARITY_TIMEOUT: Duration = Duration::from_secs(90);
+const BALANCE_SYNC_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[tokio::test]
+async fn fuzz_sync_parity() -> Result<()> {
+    base_node_runner::test_utils::init_silenced_tracing();
+    let seed = seed_from_env();
+
+    // 1. Boot the devnet: sequencer (builder) + gossip-following validator (client).
+    let system = SystemTestStackBuilder::new()
+        .with_l1_chain_id(L1_CHAIN_ID)
+        .with_l2_chain_id(L2_CHAIN_ID)
+        .build()
+        .await?;
+    let sequencer = system.l2_builder_provider()?;
+    let validator = system.l2_client_provider()?;
+
+    // 2. Submit a seeded, fuzzed transaction stream to the sequencer.
+    let mut generator = FuzzTxGenerator::new(seed);
+    let submitted =
+        submit_fuzzed_txs(&sequencer, &validator, &mut generator, NUM_TXS, seed).await?;
+    info!(seed, submitted, "submitted fuzzed transactions");
+
+    // Guard against a vacuous pass: if the sequencer accepted (almost) nothing, the
+    // parity check would succeed trivially without exercising the divergence surface.
+    assert!(
+        submitted >= NUM_TXS / 2,
+        "too few transactions accepted (seed={seed:#x}): {submitted}/{NUM_TXS}; parity would pass vacuously"
+    );
+
+    // 3. Oracle: the validator must follow the sequencer to a shared head.
+    assert_sync_parity(&sequencer, &validator, seed).await?;
+    info!(seed, "validator stayed in sync with sequencer");
+
+    Ok(())
+}
+
+fn seed_from_env() -> u64 {
+    // Unset -> default (normal nightly). Set to a valid value -> that seed. Set to
+    // garbage -> panic, so a mistyped workflow_dispatch seed fails loudly instead
+    // of silently running (and reporting success) against the default seed.
+    match std::env::var("FUZZ_SEED") {
+        Ok(s) if !s.is_empty() => s
+            .strip_prefix("0x")
+            .map_or_else(|| s.parse(), |h| u64::from_str_radix(h, 16))
+            .unwrap_or_else(|_| panic!("FUZZ_SEED={s:?} is not a valid u64")),
+        _ => DEFAULT_SEED,
+    }
+}
+
+/// Funded senders used to submit the fuzzed stream. Anvil accounts 1-4 are not
+/// bound to protocol roles (5-9 are), so their nonces are ours to drive.
+fn senders() -> [Account; 4] {
+    [*ANVIL_ACCOUNT_1, *ANVIL_ACCOUNT_2, *ANVIL_ACCOUNT_3, *ANVIL_ACCOUNT_4]
+}
+
+/// Seeded generator for the fuzzed transaction stream, backed by the load
+/// tester's `WorkloadGenerator`.
+///
+/// The adversarial permutation layer (access lists, gas boundaries, tx-type mix,
+/// reordering) is the next increment and lives behind `next_shape`.
+struct FuzzTxGenerator {
+    generator: WorkloadGenerator,
+}
+
+impl FuzzTxGenerator {
+    fn new(seed: u64) -> Self {
+        let generator = WorkloadGenerator::new(WorkloadConfig::new("phase0-fuzz").with_seed(seed))
+            .with_payload(TransferPayload::default(), 0.7)
+            .with_payload(CalldataPayload::new(256).with_min_size(0), 0.3);
+        Self { generator }
+    }
+
+    /// Produce the next transaction shape: recipient, value, and calldata.
+    /// `from`, `nonce`, gas, and fees are completed by the caller (the paved-road
+    /// "semantic completion" step) before signing.
+    fn next_shape(&mut self, from: Address, to: Address) -> Result<FuzzedTx> {
+        let request = self
+            .generator
+            .generate_payload(from, to)
+            .map_err(|e| eyre!("workload generation failed: {e}"))?;
+        Ok(FuzzedTx {
+            to,
+            value: request.value.unwrap_or(U256::ZERO),
+            input: request.input.input().cloned().unwrap_or_default(),
+        })
+    }
+}
+
+/// A generated transaction shape, before semantic completion and signing.
+struct FuzzedTx {
+    to: Address,
+    value: U256,
+    input: Bytes,
+}
+
+/// Sign the fuzzed stream from several funded accounts and submit to the
+/// sequencer. Returns the count actually accepted by the RPC.
+async fn submit_fuzzed_txs(
+    sequencer: &RootProvider<Base>,
+    validator: &RootProvider<Base>,
+    generator: &mut FuzzTxGenerator,
+    count: u64,
+    seed: u64,
+) -> Result<u64> {
+    // Prepare a signer and starting nonce for each sender.
+    let sender_accounts = senders();
+    let mut signers = Vec::new();
+    for account in sender_accounts {
+        let signer = signer_for(&account)?;
+        wait_for_balance(validator, signer.address()).await?;
+        let nonce = sequencer.get_transaction_count(signer.address()).await?;
+        signers.push((signer, nonce));
+    }
+
+    let mut accepted = 0;
+    for i in 0..count {
+        let slot = (i as usize) % signers.len();
+        // Recipient rotates through the other senders so funds stay in-system.
+        let recipient = sender_accounts[(slot + 1) % sender_accounts.len()].address;
+        let (signer, nonce) = &mut signers[slot];
+        let current = *nonce;
+        *nonce += 1;
+        let shape = generator.next_shape(signer.address(), recipient)?;
+        let raw = complete_and_sign(signer, &shape, current)?;
+        if send_with_backoff(sequencer, &raw, current, seed).await {
+            accepted += 1;
+        } else {
+            // Revert the nonce so this sender's subsequent txs don't hit a gap and
+            // cascade into rejections unrelated to builder/validator parity.
+            signers[slot].1 = current;
+        }
+    }
+    Ok(accepted)
+}
+
+/// Submit one signed transaction, backing off and retrying while the txpool is
+/// full (pure backpressure, not a rejection). Other errors are logged as
+/// datapoints and skipped: the oracle is whether the validator follows whatever
+/// the sequencer builds, not whether every tx is accepted.
+async fn send_with_backoff(
+    provider: &RootProvider<Base>,
+    raw: &Bytes,
+    nonce: u64,
+    seed: u64,
+) -> bool {
+    for _ in 0..MAX_SEND_ATTEMPTS {
+        match provider.send_raw_transaction(raw).await {
+            Ok(_) => return true,
+            Err(err) if err.to_string().contains("txpool is full") => {
+                sleep(SEND_BACKOFF).await;
+            }
+            Err(err) => {
+                info!(seed, nonce, error = %err, "tx rejected");
+                return false;
+            }
+        }
+    }
+    info!(seed, nonce, "tx dropped after backoff (pool stayed full)");
+    false
+}
+
+fn signer_for(account: &Account) -> Result<PrivateKeySigner> {
+    Ok(PrivateKeySigner::from_bytes(&account.private_key)?)
+}
+
+/// Complete a fuzzed shape into a signed, EIP-2718 encoded transaction. This is
+/// the "semantic completion" step: fill from/nonce/gas/fees/chain-id, then sign.
+fn complete_and_sign(signer: &PrivateKeySigner, tx: &FuzzedTx, nonce: u64) -> Result<Bytes> {
+    let request = BaseTransactionRequest::default()
+        .from(signer.address())
+        .to(tx.to)
+        .value(tx.value)
+        .with_input(tx.input.clone())
+        .transaction_type(2)
+        .with_gas_limit(TX_GAS_LIMIT)
+        .with_max_fee_per_gas(1_000_000_000)
+        .with_max_priority_fee_per_gas(0)
+        .with_chain_id(L2_CHAIN_ID)
+        .with_nonce(nonce);
+    let typed =
+        request.build_typed_tx().map_err(|req| eyre!("invalid transaction request: {req:?}"))?;
+    let signature = signer.sign_hash_sync(&typed.signature_hash())?;
+    Ok(typed.into_signed(signature).encoded_2718().into())
+}
+
+/// The oracle. Requires the validator to catch the sequencer head and agree on
+/// block hashes at a shared height, sustained across `PARITY_WINDOW` polls.
+///
+/// A stalled validator (divergence) never closes the gap and this
+/// times out; a silent fork is caught by the block-hash comparison.
+async fn assert_sync_parity(
+    sequencer: &RootProvider<Base>,
+    validator: &RootProvider<Base>,
+    seed: u64,
+) -> Result<()> {
+    let outcome = timeout(PARITY_TIMEOUT, async {
+        let mut in_sync_streak = 0u32;
+        loop {
+            let seq_head = sequencer.get_block_number().await?;
+            let val_head = validator.get_block_number().await?;
+
+            // Height both nodes should have; used to compare hashes.
+            let shared = seq_head.saturating_sub(MAX_LAG);
+            let (seq_hash, val_hash) = if val_head >= shared && val_head > 0 {
+                (block_hash(sequencer, shared).await?, block_hash(validator, shared).await.ok())
+            } else {
+                (block_hash(sequencer, shared).await?, None)
+            };
+
+            match classify_parity(seq_head, val_head, seq_hash, val_hash, MAX_LAG) {
+                Parity::InSync => {
+                    in_sync_streak += 1;
+                    if in_sync_streak >= PARITY_WINDOW {
+                        return Ok::<_, eyre::Error>(seq_head);
+                    }
+                }
+                Parity::Forked => {
+                    return Err(eyre!(
+                        "fork at block {shared}: sequencer {seq_hash} != validator {val_hash:?}"
+                    ));
+                }
+                Parity::Lagging => in_sync_streak = 0,
+            }
+            sleep(PARITY_POLL_INTERVAL).await;
+        }
+    })
+    .await;
+
+    match outcome {
+        Ok(Ok(head)) => {
+            info!(seed, head, "reached sync parity");
+            Ok(())
+        }
+        Ok(Err(fork)) => Err(fork.wrap_err(format!("divergence detected (seed={seed:#x})"))),
+        Err(_) => {
+            let seq_head = sequencer.get_block_number().await.unwrap_or_default();
+            let val_head = validator.get_block_number().await.unwrap_or_default();
+            Err(eyre!(
+                "validator failed to stay in sync (seed={seed:#x}): sequencer at {seq_head}, \
+                 validator stalled at {val_head}"
+            ))
+        }
+    }
+}
+
+/// Parity verdict for a single poll. Pure so it can be unit-tested.
+#[derive(Debug, PartialEq, Eq)]
+enum Parity {
+    /// Validator is within `max_lag` of the sequencer and hashes agree.
+    InSync,
+    /// Validator is too far behind (or has not started following).
+    Lagging,
+    /// Validator is caught up in height but on a different block hash.
+    Forked,
+}
+
+/// Decide the parity verdict from the two heads and the hashes at a shared height.
+/// `val_hash` is `None` when the validator does not yet have the shared block.
+fn classify_parity(
+    seq_head: u64,
+    val_head: u64,
+    seq_hash: B256,
+    val_hash: Option<B256>,
+    max_lag: u64,
+) -> Parity {
+    if seq_head.saturating_sub(val_head) > max_lag || val_head == 0 {
+        return Parity::Lagging;
+    }
+    match val_hash {
+        Some(hash) if hash == seq_hash => Parity::InSync,
+        Some(_) => Parity::Forked,
+        None => Parity::Lagging,
+    }
+}
+
+/// Fetch the hash of a block by number, erroring if the node does not have it yet.
+async fn block_hash(provider: &RootProvider<Base>, number: u64) -> Result<B256> {
+    let block = provider
+        .get_block_by_number(BlockNumberOrTag::Number(number))
+        .await?
+        .ok_or_else(|| eyre!("block {number} missing"))?;
+    Ok(block.header.hash)
+}
+
+/// Wait until the funded sender's balance has propagated to a node.
+async fn wait_for_balance(provider: &RootProvider<Base>, address: Address) -> Result<()> {
+    timeout(BALANCE_SYNC_TIMEOUT, async {
+        loop {
+            if provider.get_balance(address).await? > U256::ZERO {
+                return Ok::<_, eyre::Error>(());
+            }
+            sleep(PARITY_POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .wrap_err("timed out waiting for sender balance to sync")?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const H1: B256 = B256::repeat_byte(0x11);
+    const H2: B256 = B256::repeat_byte(0x22);
+
+    #[test]
+    fn in_sync_when_within_lag_and_hashes_agree() {
+        assert_eq!(classify_parity(10, 9, H1, Some(H1), MAX_LAG), Parity::InSync);
+        assert_eq!(classify_parity(10, 10, H1, Some(H1), MAX_LAG), Parity::InSync);
+    }
+
+    #[test]
+    fn lagging_when_validator_falls_behind() {
+        // Divergence: sequencer advances, validator stalls.
+        assert_eq!(classify_parity(50, 10, H1, Some(H1), MAX_LAG), Parity::Lagging);
+        // Validator has not started following yet.
+        assert_eq!(classify_parity(10, 0, H1, None, MAX_LAG), Parity::Lagging);
+        // Caught up in height but missing the shared block.
+        assert_eq!(classify_parity(10, 9, H1, None, MAX_LAG), Parity::Lagging);
+    }
+
+    #[test]
+    fn forked_when_heights_match_but_hashes_differ() {
+        assert_eq!(classify_parity(10, 9, H1, Some(H2), MAX_LAG), Parity::Forked);
+    }
+}

--- a/etc/systems/tests/fuzz_sync_parity.rs
+++ b/etc/systems/tests/fuzz_sync_parity.rs
@@ -129,9 +129,10 @@ struct FuzzTxGenerator {
 
 impl FuzzTxGenerator {
     fn new(seed: u64) -> Self {
-        let generator = WorkloadGenerator::new(WorkloadConfig::new("phase0-fuzz").with_seed(seed))
-            .with_payload(TransferPayload::default(), 0.7)
-            .with_payload(CalldataPayload::new(256).with_min_size(0), 0.3);
+        let generator =
+            WorkloadGenerator::new(WorkloadConfig::new("sync-parity-fuzz").with_seed(seed))
+                .with_payload(TransferPayload::default(), 0.7)
+                .with_payload(CalldataPayload::new(256).with_min_size(0), 0.3);
         Self { generator }
     }
 


### PR DESCRIPTION
Adds a fuzz test that fires seeded, randomized transactions at a devnet sequencer and checks that an independent validator stays in sync. First step toward hardening releases with differential fuzzing: catching blocks the sequencer builds but the validator won't accept, before they ship.

## Why we want this

We run the same block logic in more than one place, and the real risk is those implementations disagreeing. Two boundaries matter:

- Build vs. validate: a block the sequencer builds must be accepted by an independent validator. This PR checks that one.
- Batch-encode vs. derive: a block posted to L1 must re-derive identically. A later boundary, not covered here.

## Description

Submits fuzzed transactions from several funded senders to a system-test devnet, then asserts the following validator tracks the sequencer's head. Specifically:

- A reusable harness on the existing devnet, with fuzzed-tx generation built on the load tester and multi-sender submission.
- A sync-parity oracle written as a pure, unit-tested decision function.
- A nightly workflow that runs it with a fresh random seed each run.

This is a simple first version: it catches when the validator and sequencer disagree, but it can't yet pinpoint what caused the disagreement, and the same run won't reproduce exactly.

## Coming next

- Deterministic, in-process block production so failures replay.
- Finer oracles that diff state root, receipts, and gas, so we know what diverged, not just that something did.
- Pre-seeded state to reach deeper execution paths.
- The batch-encode vs. derive boundary.

The generation, signing, oracle logic, and CI here carry straight into that work.

## Testing

- Unit, no devnet: `cargo test -p base-system-tests --test fuzz_sync_parity -- when`. The `classify_parity` cases (in-sync, lagging, forked) pass.
- Full run against a local devnet (needs Docker + foundry): `cargo test -p base-system-tests --test fuzz_sync_parity -- fuzz_sync_parity --nocapture`. Ran it several times: all 200 fuzzed txs accepted, the validator reached sync parity with the sequencer and held it, ~75s per run.
- Varied `FUZZ_SEED` to confirm each seed produces a distinct, reproducible transaction stream.
- Green in CI: build, clippy, format, and the fuzz job.

## Where this runs

The fuzz test runs in the merge queue (bundled with the system tests) and nightly via the `Fuzz Nightly` workflow (a fresh random seed per run, across 4 parallel shards). It does not run on every PR. To run it on demand, dispatch the `Fuzz Nightly` workflow, optionally with a `seed` input to replay a specific case.
