### PR TITLE
feat(builder): add resource throttle metering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3551,6 +3551,7 @@ dependencies = [
  "base-node-runner",
  "jsonrpsee",
  "moka",
+ "tokio",
  "tracing",
 ]
 

--- a/bin/base/src/commands/sequencer.rs
+++ b/bin/base/src/commands/sequencer.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use base_builder_cli::Args as BuilderArgs;
 use base_builder_core::{BuilderApiExtension, FlashblocksServiceBuilder};
-use base_builder_metering::MeteringStoreExtension;
+use base_builder_metering::{MeteringStoreExtension, MeteringStoreExtensionConfig};
 use base_consensus_cli::{
     CliMetrics, ConsensusNodeArgs, ConsensusNodeConfigArgs, ConsensusNodeOverrides,
     ConsensusNodeStartOptions, EmbeddedSequencerConsensusNodeConfigArgs,
@@ -69,6 +69,7 @@ impl SequencerCommand {
         let metering_provider: base_builder_core::SharedMeteringProvider =
             Arc::new(builder.build_metering_store());
         let builder_config = builder.into_builder_config(Arc::clone(&metering_provider))?;
+        let resource_throttle_store = Arc::clone(&builder_config.resource_throttle_store);
         let da_config = builder_config.da_config.clone();
         let gas_limit_config = builder_config.gas_limit_config.clone();
 
@@ -107,7 +108,10 @@ impl SequencerCommand {
                 .with_da_config(da_config)
                 .with_gas_limit_config(gas_limit_config)
                 .with_service_builder(FlashblocksServiceBuilder(builder_config));
-            runner.install_ext::<MeteringStoreExtension>(metering_provider);
+            runner.install_ext::<MeteringStoreExtension>(MeteringStoreExtensionConfig {
+                metering_provider,
+                resource_throttle_store,
+            });
             runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig { sequencer_rpc });
             runner.install_ext::<BuilderApiExtension>(());
             StandardBaseRethNode::install_upgrade_signal_runtime_extension(

--- a/bin/builder/src/main.rs
+++ b/bin/builder/src/main.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use base_builder_cli::Args;
 use base_builder_core::{BuilderApiExtension, FlashblocksServiceBuilder};
-use base_builder_metering::MeteringStoreExtension;
+use base_builder_metering::{MeteringStoreExtension, MeteringStoreExtensionConfig};
 use base_execution_cli::{Cli, StandardBaseRethNode};
 use base_node_runner::BaseNodeRunner;
 use base_observability_events::GlobalTransactionEventWriter;
@@ -40,9 +40,8 @@ fn main() {
             transaction_events_enabled.then(|| builder_args.transaction_events.writer_config()),
         )?;
 
-        let builder_config = builder_args
-            .into_builder_config(Arc::clone(&metering_provider))
-            .expect("Failed to convert rollup args to builder config");
+        let builder_config = builder_args.into_builder_config(Arc::clone(&metering_provider))?;
+        let resource_throttle_store = Arc::clone(&builder_config.resource_throttle_store);
         let da_config = builder_config.da_config.clone();
         let gas_limit_config = builder_config.gas_limit_config.clone();
 
@@ -50,7 +49,10 @@ fn main() {
             .with_da_config(da_config)
             .with_gas_limit_config(gas_limit_config)
             .with_service_builder(FlashblocksServiceBuilder(builder_config));
-        runner.install_ext::<MeteringStoreExtension>(metering_provider);
+        runner.install_ext::<MeteringStoreExtension>(MeteringStoreExtensionConfig {
+            metering_provider,
+            resource_throttle_store,
+        });
         runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig::default());
         runner.install_ext::<BuilderApiExtension>(());
         StandardBaseRethNode::install_upgrade_signal_runtime_extension(&mut runner, &rollup_args)?;

--- a/crates/builder/cli/README.md
+++ b/crates/builder/cli/README.md
@@ -1,3 +1,16 @@
 # Base Builder CLI
 
 Reusable CLI arguments and config conversion helpers for Base builder nodes.
+
+The builder's optional resource-throttle schedule is loaded at startup with
+`--builder.resource-throttle-schedule=<path>`. It computes builder-local resource units from
+metering results; it does not alter protocol gas prices or transaction gas limits. The schedule can
+also be replaced atomically through the JWT-authenticated `base_replaceResourceThrottleSchedule`
+RPC. Legacy execution-time and state-root-gas limits remain available for rollout and are evaluated
+alongside resource-throttle limits when explicitly configured.
+
+For a safe rollout, start with `--builder.execution-metering-mode=off`, switch to `dry-run` to
+observe would-reject metrics, and use `enforce` only after the schedule and limits are verified.
+Resource-throttle updates take effect on the next payload build. Metering nodes collect only the
+operation names they were configured for, so configure and restart those nodes before adding new
+opcode, precompile, or pseudo-opcode rules to a schedule.

--- a/crates/builder/cli/src/args.rs
+++ b/crates/builder/cli/src/args.rs
@@ -1,10 +1,11 @@
 //! Builder CLI arguments and config conversion helpers.
 
 use core::{net::SocketAddr, time::Duration};
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
 use base_builder_core::{
-    BuilderConfig, ExecutionMeteringMode, RejectionCache, SharedMeteringProvider,
+    BuilderConfig, ExecutionMeteringMode, RejectionCache, ResourceThrottleStore,
+    SharedMeteringProvider,
 };
 use base_builder_metering::MeteringStore;
 use base_node_core::args::RollupArgs;
@@ -134,18 +135,19 @@ pub struct Args {
     #[arg(long = "builder.max_gas_per_txn")]
     pub max_gas_per_txn: Option<u64>,
 
-    /// Maximum execution time per transaction in microseconds (requires resource metering)
+    /// Legacy maximum execution time per transaction in microseconds; evaluated alongside
+    /// resource-throttle limits during rollout.
     #[arg(long = "builder.max-execution-time-per-tx-us")]
     pub max_execution_time_per_tx_us: Option<u128>,
 
-    /// Deprecated and ignored. Kept so older deployment configurations remain accepted.
-    /// Scheduled for removal in v1.4.0 after rolling deployments have migrated.
-    #[arg(long = "builder.flashblock-execution-time-budget-us", hide = true)]
+    /// Legacy flashblock-level execution time budget in microseconds; evaluated alongside
+    /// resource-throttle limits during rollout.
+    #[arg(long = "builder.flashblock-execution-time-budget-us")]
     pub flashblock_execution_time_budget_us: Option<u128>,
 
-    /// Deprecated and ignored. Kept so older deployment configurations remain accepted.
-    /// Scheduled for removal in v1.4.0 after rolling deployments have migrated.
-    #[arg(long = "builder.block-state-root-gas-limit", hide = true)]
+    /// Legacy block-level state root gas limit; evaluated alongside resource-throttle limits during
+    /// rollout.
+    #[arg(long = "builder.block-state-root-gas-limit")]
     pub block_state_root_gas_limit: Option<u64>,
 
     /// Deprecated and ignored. Kept so older deployment configurations remain accepted.
@@ -178,6 +180,10 @@ pub struct Args {
     /// Transactions younger than this without metering data will be skipped.
     #[arg(long = "builder.metering-wait-duration-ms")]
     pub metering_wait_duration_ms: Option<u64>,
+
+    /// JSON file containing the startup resource-throttle schedule.
+    #[arg(long = "builder.resource-throttle-schedule", env = "BUILDER_RESOURCE_THROTTLE_SCHEDULE")]
+    pub resource_throttle_schedule: Option<PathBuf>,
 
     /// URL of the audit-archiver RPC endpoint for forwarding rejected transactions
     #[arg(long = "builder.audit-archiver-url", env = "BUILDER_AUDIT_ARCHIVER_URL")]
@@ -248,6 +254,7 @@ impl Default for Args {
             enable_resource_metering: false,
             max_uncompressed_block_size: None,
             metering_wait_duration_ms: None,
+            resource_throttle_schedule: None,
             audit_archiver_url: None,
             rejected_tx_channel_size: 500,
             max_rejected_txs_per_block: 500,
@@ -282,6 +289,10 @@ impl Args {
             self.flashblocks.flashblocks_addr.parse()?,
             self.flashblocks.flashblocks_port,
         );
+        let resource_throttle_store = match self.resource_throttle_schedule.as_deref() {
+            Some(path) => Arc::new(ResourceThrottleStore::from_file(path)?),
+            None => Arc::new(ResourceThrottleStore::default()),
+        };
 
         Ok(BuilderConfig {
             block_time: Duration::from_millis(self.chain_block_time),
@@ -300,6 +311,7 @@ impl Args {
             max_uncompressed_block_size: self.max_uncompressed_block_size,
             metering_wait_duration: self.metering_wait_duration_ms.map(Duration::from_millis),
             metering_provider,
+            resource_throttle_store,
             rejection_cache: RejectionCache::new(
                 self.rejection_cache_max_capacity,
                 Duration::from_secs(self.rejection_cache_ttl_secs),

--- a/crates/builder/core/README.md
+++ b/crates/builder/core/README.md
@@ -10,6 +10,8 @@ Block builder library for Base. Provides flashblocks payload building infrastruc
 - **`flashblocks`**: Progressive block builder that produces block chunks at short intervals, publishing them via WebSocket before merging into full blocks.
 - **`launcher`**: Node launcher utilities for starting the builder.
 - **`metering`**: Resource metering provider trait and types.
+- **`resource_throttle`**: Versioned multidimensional schedules, compiled pricing, and atomic
+  runtime-replacement storage.
 
 ## Features
 
@@ -27,6 +29,12 @@ base-builder-core = { git = "https://github.com/base/base" }
 ```
 
 To run the builder, use the [`base-builder`](../../../bin/builder/) binary.
+
+Resource-throttle dimensions are builder-local budgets. They price the gas and selectively collected
+operation counts delivered by `meterBundle`; they do not change protocol gas prices or gas limits.
+Use `--builder.resource-throttle-schedule` for startup configuration and the JWT-authenticated
+`base_getResourceThrottleSchedule`/`base_replaceResourceThrottleSchedule` methods for atomic
+next-block updates.
 
 ## License
 

--- a/crates/builder/core/src/config.rs
+++ b/crates/builder/core/src/config.rs
@@ -8,7 +8,10 @@ use std::sync::Arc;
 
 use base_execution_payload_builder::config::{BaseDAConfig, GasLimitConfig};
 
-use crate::{ExecutionMeteringMode, NoopMeteringProvider, RejectionCache, SharedMeteringProvider};
+use crate::{
+    ExecutionMeteringMode, NoopMeteringProvider, RejectionCache, ResourceThrottleStore,
+    SharedMeteringProvider, SharedResourceThrottleStore,
+};
 
 /// Configuration values for the flashblocks builder.
 #[derive(Clone)]
@@ -45,8 +48,33 @@ pub struct BuilderConfig {
     /// Maximum gas a transaction can use before being excluded.
     pub max_gas_per_txn: Option<u64>,
 
-    /// Maximum execution time per transaction in microseconds.
+    /// Legacy maximum execution time per transaction in microseconds.
+    ///
+    /// Retained for rollout compatibility and evaluated alongside resource-throttle limits.
     pub max_execution_time_per_tx_us: Option<u128>,
+
+    /// Legacy flashblock-level execution time budget in microseconds.
+    ///
+    /// Retained for rollout compatibility and evaluated alongside resource-throttle limits.
+    pub flashblock_execution_time_budget_us: Option<u128>,
+
+    /// Legacy block-level state root gas limit.
+    ///
+    /// State root gas is a synthetic resource that accumulates like gas but penalizes
+    /// transactions whose simulated state root cost is disproportionate to their gas usage.
+    /// For each metered transaction: `sr_gas = gas_used × (1 + K × max(0, SR_ms - anchor))`.
+    /// Normal transactions (SR ≤ anchor) pay 1:1. State-heavy transactions pay more.
+    ///
+    /// Retained for rollout compatibility and evaluated alongside resource-throttle limits.
+    pub block_state_root_gas_limit: Option<u64>,
+
+    /// State root gas coefficient (K). Controls how aggressively excess SR time
+    /// inflates the state root gas cost. Default: 0.02.
+    pub state_root_gas_coefficient: f64,
+
+    /// State root gas anchor in microseconds. SR time below this threshold
+    /// produces no penalty (multiplier = 1). Default: 5000 (5ms).
+    pub state_root_gas_anchor_us: u128,
 
     /// Execution metering mode: off, dry-run, or enforce.
     pub execution_metering_mode: ExecutionMeteringMode,
@@ -60,6 +88,9 @@ pub struct BuilderConfig {
 
     /// Resource metering provider
     pub metering_provider: SharedMeteringProvider,
+
+    /// Versioned resource-throttle schedule shared with the runtime RPC.
+    pub resource_throttle_store: SharedResourceThrottleStore,
 
     /// Cache of permanently rejected transaction hashes, shared across blocks.
     /// Transactions in this cache are skipped by the iterator without re-evaluation.
@@ -105,6 +136,7 @@ impl core::fmt::Debug for BuilderConfig {
             .field("max_uncompressed_block_size", &self.max_uncompressed_block_size)
             .field("metering_wait_duration", &self.metering_wait_duration)
             .field("metering_provider", &self.metering_provider)
+            .field("resource_throttle_revision", &self.resource_throttle_store.revision())
             .field("rejection_cache_size", &self.rejection_cache.entry_count())
             .field("audit_archiver_url", &self.audit_archiver_url)
             .field("rejected_tx_channel_size", &self.rejected_tx_channel_size)
@@ -130,6 +162,7 @@ impl Default for BuilderConfig {
             max_uncompressed_block_size: None,
             metering_wait_duration: None,
             metering_provider: Arc::new(NoopMeteringProvider),
+            resource_throttle_store: Arc::new(ResourceThrottleStore::default()),
             rejection_cache: RejectionCache::new(100_000, Duration::from_secs(1800)),
             audit_archiver_url: None,
             rejected_tx_channel_size: 500,

--- a/crates/builder/core/src/execution.rs
+++ b/crates/builder/core/src/execution.rs
@@ -3,8 +3,11 @@
 //! Heavily influenced by [reth](https://github.com/paradigmxyz/reth/blob/1e965caf5fa176f244a31c0d2662ba1b590938db/crates/optimism/payload/src/builder.rs#L570)
 
 use core::fmt::Debug;
+use std::sync::Arc;
 
-use ExecutionMeteringLimitExceeded::TransactionExecutionTime;
+use ExecutionMeteringLimitExceeded::{
+    BlockStateRootGas, FlashblockExecutionTime, ResourceThrottle, TransactionExecutionTime,
+};
 use alloy_primitives::{Address, U256};
 use base_bundles::RejectedTransaction;
 use base_common_consensus::{BaseReceipt, BaseTransactionSigned};
@@ -12,11 +15,16 @@ use base_common_evm::BaseTransactionError;
 use derive_more::Display;
 use thiserror::Error;
 
+use crate::{
+    CompiledResourceThrottleSchedule, ResourceThrottleCheckError, ResourceThrottleLimitExceeded,
+    ResourceThrottleLimitScope, ResourceThrottleUsage,
+};
+
 /// Resource limits configuration for transaction and block constraints.
 ///
 /// This struct encapsulates all the resource limit parameters used to determine
 /// whether a transaction can be included in a block without exceeding various
-/// resource budgets (gas, DA, and per-transaction execution time).
+/// resource budgets (gas, DA, execution time, or resource-throttle units).
 #[derive(Debug, Clone, Default)]
 pub struct ResourceLimits {
     /// The block gas limit.
@@ -33,6 +41,8 @@ pub struct ResourceLimits {
     pub tx_execution_time_limit_us: Option<u128>,
     /// Maximum cumulative uncompressed (EIP-2718 encoded) block size in bytes (optional).
     pub block_uncompressed_size_limit: Option<u64>,
+    /// Snapshot of the resource-throttle schedule for the current block.
+    pub resource_throttle_schedule: Option<Arc<CompiledResourceThrottleSchedule>>,
 }
 
 /// Resource usage for a single transaction.
@@ -49,6 +59,9 @@ pub struct TxResources {
     pub execution_time_us: Option<u128>,
     /// Raw EIP-2718 encoded transaction size in bytes.
     pub uncompressed_size: u64,
+    /// Resource-throttle usage derived from the transaction's metering response, aligned with the
+    /// block schedule snapshot.
+    pub resource_throttle_usage: Option<ResourceThrottleUsage>,
 }
 
 /// Execution metering limits that depend on metering service predictions.
@@ -58,6 +71,17 @@ pub enum ExecutionMeteringLimitExceeded {
     /// A single transaction's predicted execution time exceeded its per-tx limit.
     #[error("transaction execution time exceeded: tx_time_us={0} limit_us={1}")]
     TransactionExecutionTime(u128, u128),
+    /// Cumulative flashblock execution time would exceed the per-flashblock limit.
+    #[error(
+        "flashblock execution time exceeded: flashblock_used_us={0} tx_time_us={1} limit_us={2}"
+    )]
+    FlashblockExecutionTime(u128, u128, u128),
+    /// Cumulative state root gas would exceed the per-block limit.
+    #[error("block state root gas exceeded: cumulative={0} tx_sr_gas={1} block_limit={2}")]
+    BlockStateRootGas(u64, u64, u64),
+    /// A resource-throttle dimension would exceed its transaction or block budget.
+    #[error("{0}")]
+    ResourceThrottle(ResourceThrottleLimitExceeded),
 }
 
 /// Error returned when a transaction fails execution or exceeds block limits.
@@ -122,7 +146,7 @@ pub enum TxnExecutionError {
     },
 
     // Execution metering limits (optionally enforced, depend on metering service predictions)
-    /// Execution metering limit exceeded.
+    /// Execution metering limit exceeded (legacy time/state-root or resource throttle).
     #[error("{0}")]
     ExecutionMeteringLimitExceeded(ExecutionMeteringLimitExceeded),
 
@@ -150,6 +174,10 @@ pub enum TxnExecutionError {
     /// Metering data has not yet arrived for this transaction.
     #[error("metering data pending")]
     MeteringDataPending,
+
+    /// Resource-throttle usage could not be calculated safely.
+    #[error("resource throttle usage calculation failed")]
+    ResourceThrottleCalculationFailed,
 }
 
 impl TxnExecutionError {
@@ -160,14 +188,18 @@ impl TxnExecutionError {
     /// Transient rejections depend on cumulative block state (gas used, DA used, etc.) and may
     /// succeed in a future block or flashblock with different cumulative values.
     pub const fn is_permanent(&self) -> bool {
-        matches!(
-            self,
+        match self {
             Self::TransactionDASizeExceeded(_, _)
-                | Self::ExecutionMeteringLimitExceeded(
-                    ExecutionMeteringLimitExceeded::TransactionExecutionTime(_, _),
-                )
-                | Self::MaxGasUsageExceeded
-        )
+            | Self::ExecutionMeteringLimitExceeded(
+                ExecutionMeteringLimitExceeded::TransactionExecutionTime(_, _),
+            )
+            | Self::ResourceThrottleCalculationFailed
+            | Self::MaxGasUsageExceeded => true,
+            Self::ExecutionMeteringLimitExceeded(
+                ExecutionMeteringLimitExceeded::ResourceThrottle(error),
+            ) => matches!(error.scope, ResourceThrottleLimitScope::Transaction),
+            _ => false,
+        }
     }
 }
 
@@ -210,6 +242,14 @@ pub struct ExecutionInfo {
     pub cumulative_gas_used: u64,
     /// Estimated DA size
     pub cumulative_da_bytes_used: u64,
+    /// Execution time used in the current flashblock in microseconds.
+    /// Reset at the start of each flashblock (see [`ResourceLimits::flashblock_execution_time_limit_us`]).
+    pub flashblock_execution_time_us: u128,
+    /// Cumulative state root gas across the block
+    /// (see [`ResourceLimits::block_state_root_gas_limit`]).
+    pub cumulative_state_root_gas: u64,
+    /// Cumulative resource-throttle usage across the block.
+    pub cumulative_resource_throttle: Vec<u128>,
     /// Cumulative uncompressed (EIP-2718 encoded) bytes used in the block
     pub cumulative_uncompressed_bytes: u64,
     /// Tracks fees from executed mempool transactions
@@ -231,6 +271,9 @@ impl ExecutionInfo {
             receipts: Vec::with_capacity(capacity),
             cumulative_gas_used: 0,
             cumulative_da_bytes_used: 0,
+            flashblock_execution_time_us: 0,
+            cumulative_state_root_gas: 0,
+            cumulative_resource_throttle: Vec::new(),
             cumulative_uncompressed_bytes: 0,
             total_fees: U256::ZERO,
             extra: Default::default(),
@@ -315,12 +358,29 @@ impl ExecutionInfo {
             }
         }
 
+        // Check block-scoped resource-throttle limits (if metering data is available).
+        if let Some(schedule) = limits.resource_throttle_schedule.as_ref()
+            && let Some(usage) = tx.resource_throttle_usage.as_ref()
+        {
+            match schedule.check(usage, &self.cumulative_resource_throttle) {
+                Ok(()) => {}
+                Err(ResourceThrottleCheckError::LimitExceeded(error)) => {
+                    return Err(ResourceThrottle(error).into());
+                }
+                Err(ResourceThrottleCheckError::ArithmeticOverflow) => {
+                    return Err(TxnExecutionError::ResourceThrottleCalculationFailed);
+                }
+            }
+        }
+
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::{ResourceThrottleDimension, ResourceThrottleSchedule};
+
     use super::*;
 
     /// Helper to create default limits with block gas limit set
@@ -468,6 +528,7 @@ mod tests {
             gas_limit: 21_000,
             execution_time_us: Some(2_000_000),
             uncompressed_size: 0,
+            ..Default::default()
         };
 
         let result = info.is_tx_over_limits(&tx, &limits);
@@ -491,6 +552,7 @@ mod tests {
             gas_limit: 100_000,
             execution_time_us: Some(100_000),
             uncompressed_size: 0,
+            ..Default::default()
         };
 
         assert!(info.is_tx_over_limits(&tx, &limits).is_ok());
@@ -568,5 +630,82 @@ mod tests {
             TxResources { gas_limit: 21_000, uncompressed_size: 1_000_000, ..Default::default() };
 
         assert!(info.is_tx_over_limits(&tx, &limits).is_ok());
+    }
+
+    #[test]
+    fn test_resource_throttle_transaction_limit_is_permanent() {
+        let schedule = ResourceThrottleSchedule {
+            dimensions: vec![ResourceThrottleDimension {
+                name: "cpu".to_string(),
+                block_limit: 100,
+                transaction_limit: Some(10),
+                base_gas_weight: 1,
+                operations: Vec::new(),
+            }],
+            ..Default::default()
+        };
+        let limits = ResourceLimits {
+            resource_throttle_schedule: Some(Arc::new(
+                CompiledResourceThrottleSchedule::compile(schedule, 3).unwrap(),
+            )),
+            ..default_limits()
+        };
+        let tx = TxResources {
+            gas_limit: 21_000,
+            resource_throttle_usage: Some(ResourceThrottleUsage { values: vec![11] }),
+            ..Default::default()
+        };
+
+        let error = ExecutionInfo::with_capacity(10).is_tx_over_limits(&tx, &limits).unwrap_err();
+        assert!(error.is_permanent());
+        assert!(matches!(
+            error,
+            TxnExecutionError::ExecutionMeteringLimitExceeded(
+                ExecutionMeteringLimitExceeded::ResourceThrottle(ResourceThrottleLimitExceeded {
+                    scope: ResourceThrottleLimitScope::Transaction,
+                    ..
+                })
+            )
+        ));
+    }
+
+    #[test]
+    fn test_resource_throttle_block_limit_is_transient_and_cumulative() {
+        let schedule = ResourceThrottleSchedule {
+            dimensions: vec![ResourceThrottleDimension {
+                name: "proof".to_string(),
+                block_limit: 100,
+                transaction_limit: None,
+                base_gas_weight: 1,
+                operations: Vec::new(),
+            }],
+            ..Default::default()
+        };
+        let limits = ResourceLimits {
+            resource_throttle_schedule: Some(Arc::new(
+                CompiledResourceThrottleSchedule::compile(schedule, 4).unwrap(),
+            )),
+            ..default_limits()
+        };
+        let tx = TxResources {
+            gas_limit: 21_000,
+            resource_throttle_usage: Some(ResourceThrottleUsage { values: vec![60] }),
+            ..Default::default()
+        };
+        let mut info = ExecutionInfo::with_capacity(10);
+
+        assert!(info.is_tx_over_limits(&tx, &limits).is_ok());
+        info.cumulative_resource_throttle = vec![60];
+        let error = info.is_tx_over_limits(&tx, &limits).unwrap_err();
+        assert!(matches!(
+            error,
+            TxnExecutionError::ExecutionMeteringLimitExceeded(
+                ExecutionMeteringLimitExceeded::ResourceThrottle(ResourceThrottleLimitExceeded {
+                    scope: ResourceThrottleLimitScope::Block,
+                    ..
+                })
+            )
+        ));
+        assert!(!error.is_permanent());
     }
 }

--- a/crates/builder/core/src/execution_metering_mode.rs
+++ b/crates/builder/core/src/execution_metering_mode.rs
@@ -1,19 +1,19 @@
 use clap::ValueEnum;
 
-/// Mode for per-transaction execution-time metering limits.
+/// Mode for execution and resource-throttle metering limits.
 ///
 /// Controls how the builder handles execution metering limits that depend on
-/// metering service predictions. These limits can be gradually rolled out
-/// via dry-run mode before enforcement.
+/// metering service predictions. These limits can be gradually rolled out via
+/// dry-run mode before enforcement.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]
 pub enum ExecutionMeteringMode {
-    /// Execution metering limits are disabled. No time limit checks are performed.
+    /// Metering limits are disabled.
     #[default]
     Off,
-    /// Dry-run mode: collect metrics about transactions that would exceed time limits,
-    /// but don't actually reject them. Useful for gathering data before enforcement.
+    /// Dry-run mode: collect metrics about transactions that would exceed metering limits,
+    /// but don't actually reject them.
     DryRun,
-    /// Enforce mode: reject transactions that exceed time limits.
+    /// Enforce mode: reject transactions that exceed metering limits.
     Enforce,
 }
 

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -42,17 +42,44 @@ use tokio_util::sync::CancellationToken;
 use tracing::{Level, debug, span, trace, warn};
 
 use crate::{
-    BuilderConfig, BuilderMetrics, ExecutionInfo, ExecutionMeteringLimitExceeded, PayloadTxsBounds,
-    ResourceLimits, TxResources, TxnExecutionError, TxnOutcome,
-    transaction_events::{
-        BuilderAcceptedEventData, BuilderConsideredEventData, BuilderRejectedEventData,
-        BuilderTransactionEventContext, emit_builder_transaction_event, rejection_reason_code,
-    },
+    BuilderConfig, BuilderMetrics, CompiledResourceThrottleSchedule, ExecutionInfo,
+    ExecutionMeteringLimitExceeded, PayloadTxsBounds, ResourceLimits, ResourceThrottleLimitScope,
+    TxResources, TxnExecutionError, TxnOutcome,
 };
 
 /// Records the priority fee of a rejected transaction with the given reason as a label.
 fn record_rejected_tx_priority_fee(reason: &TxnExecutionError, priority_fee: f64) {
-    BuilderMetrics::rejected_tx_priority_fee(rejection_reason_code(reason)).record(priority_fee);
+    let r = match reason {
+        TxnExecutionError::TransactionDASizeExceeded(_, _) => "tx_da_size_exceeded",
+        TxnExecutionError::BlockDASizeExceeded { .. } => "block_da_size_exceeded",
+        TxnExecutionError::DAFootprintLimitExceeded { .. } => "da_footprint_limit_exceeded",
+        TxnExecutionError::TransactionGasLimitExceeded { .. } => "transaction_gas_limit_exceeded",
+        TxnExecutionError::BlockUncompressedSizeExceeded { .. } => {
+            "block_uncompressed_size_exceeded"
+        }
+        TxnExecutionError::MeteringDataPending => "metering_data_pending",
+        TxnExecutionError::ExecutionMeteringLimitExceeded(inner) => match inner {
+            ExecutionMeteringLimitExceeded::TransactionExecutionTime(_, _) => {
+                "tx_execution_time_exceeded"
+            }
+            ExecutionMeteringLimitExceeded::FlashblockExecutionTime(_, _, _) => {
+                "flashblock_execution_time_exceeded"
+            }
+            ExecutionMeteringLimitExceeded::BlockStateRootGas(_, _, _) => {
+                "block_state_root_gas_exceeded"
+            }
+            ExecutionMeteringLimitExceeded::ResourceThrottle(_) => "resource_throttle_exceeded",
+        },
+        TxnExecutionError::ResourceThrottleCalculationFailed => {
+            "resource_throttle_calculation_failed"
+        }
+        TxnExecutionError::SequencerTransaction => "sequencer_transaction",
+        TxnExecutionError::NonceTooLow => "nonce_too_low",
+        TxnExecutionError::InternalError(_) => "internal_error",
+        TxnExecutionError::EvmError => "evm_error",
+        TxnExecutionError::MaxGasUsageExceeded => "max_gas_usage_exceeded",
+    };
+    BuilderMetrics::rejected_tx_priority_fee(r).record(priority_fee);
 }
 
 /// Diagnostics captured during a single flashblock's transaction execution.
@@ -97,6 +124,10 @@ pub struct FlashblockDiagnostics {
     pub txs_rejected_da_footprint: u64,
     /// Number rejected by the per-transaction execution time limit.
     pub txs_rejected_execution_time: u64,
+    /// Number rejected by state root time limits (tx or block).
+    pub txs_rejected_state_root_time: u64,
+    /// Number rejected by resource-throttle budgets.
+    pub txs_rejected_resource_throttle: u64,
     /// Number rejected by uncompressed size limit.
     pub txs_rejected_uncompressed_size: u64,
     /// Number skipped because metering data has not yet arrived.
@@ -122,12 +153,14 @@ impl FlashblockDiagnostics {
     }
 
     /// Returns the rejection counts keyed by their metric/log reason labels.
-    pub const fn rejection_counts(&self) -> [(&'static str, u64); 7] {
+    pub const fn rejection_counts(&self) -> [(&'static str, u64); 9] {
         [
             ("gas_limit", self.txs_rejected_gas),
             ("da_size", self.txs_rejected_da),
             ("da_footprint", self.txs_rejected_da_footprint),
             ("execution_time", self.txs_rejected_execution_time),
+            ("state_root_time", self.txs_rejected_state_root_time),
+            ("resource_throttle", self.txs_rejected_resource_throttle),
             ("uncompressed_size", self.txs_rejected_uncompressed_size),
             ("metering_data_pending", self.txs_rejected_metering_data_pending),
             ("other", self.txs_rejected_other),
@@ -148,6 +181,8 @@ impl FlashblockDiagnostics {
             + self.txs_rejected_da
             + self.txs_rejected_da_footprint
             + self.txs_rejected_execution_time
+            + self.txs_rejected_state_root_time
+            + self.txs_rejected_resource_throttle
             + self.txs_rejected_uncompressed_size
             + self.txs_rejected_metering_data_pending
             + self.txs_rejected_other
@@ -169,10 +204,18 @@ impl FlashblockDiagnostics {
             TxnExecutionError::BlockUncompressedSizeExceeded { .. } => {
                 self.txs_rejected_uncompressed_size += 1;
             }
-            TxnExecutionError::ExecutionMeteringLimitExceeded(inner) => {
-                let ExecutionMeteringLimitExceeded::TransactionExecutionTime(_, _) = inner;
-                self.txs_rejected_execution_time += 1;
-            }
+            TxnExecutionError::ExecutionMeteringLimitExceeded(inner) => match inner {
+                ExecutionMeteringLimitExceeded::TransactionExecutionTime(_, _)
+                | ExecutionMeteringLimitExceeded::FlashblockExecutionTime(_, _, _) => {
+                    self.txs_rejected_execution_time += 1;
+                }
+                ExecutionMeteringLimitExceeded::BlockStateRootGas(_, _, _) => {
+                    self.txs_rejected_state_root_time += 1;
+                }
+                ExecutionMeteringLimitExceeded::ResourceThrottle(_) => {
+                    self.txs_rejected_resource_throttle += 1;
+                }
+            },
             TxnExecutionError::MeteringDataPending => {
                 self.txs_rejected_metering_data_pending += 1;
             }
@@ -180,7 +223,8 @@ impl FlashblockDiagnostics {
             | TxnExecutionError::NonceTooLow
             | TxnExecutionError::InternalError(_)
             | TxnExecutionError::EvmError
-            | TxnExecutionError::MaxGasUsageExceeded => {
+            | TxnExecutionError::MaxGasUsageExceeded
+            | TxnExecutionError::ResourceThrottleCalculationFailed => {
                 self.txs_rejected_other += 1;
             }
         }
@@ -251,6 +295,8 @@ pub struct BasePayloadBuilderCtx {
     pub extra: FlashblocksExtraCtx,
     /// Builder configuration containing limits and metering settings.
     pub builder_config: BuilderConfig,
+    /// Immutable resource-throttle schedule snapshot for this payload job.
+    pub resource_throttle_schedule: Arc<CompiledResourceThrottleSchedule>,
     /// Sender for forwarding per-block batches of rejected transactions to the audit-archiver.
     pub rejected_tx_sender: Option<mpsc::Sender<Vec<RejectedTransaction>>>,
 }
@@ -879,12 +925,47 @@ impl BasePayloadBuilderCtx {
             let predicted_execution_time_us =
                 resource_usage.as_ref().map(|m| m.total_execution_time_us);
 
+            let resource_throttle_usage =
+                if !self.builder_config.execution_metering_mode.is_enabled()
+                    || self.resource_throttle_schedule.is_empty()
+                {
+                    None
+                } else if let Some(meter) = resource_usage.as_ref() {
+                    let result = meter.result_for_transaction(&tx_hash);
+                    let gas_used = result.map_or(meter.total_gas_used, |result| result.gas_used);
+                    let opcode_gas = result.map_or(&[][..], |result| result.opcode_gas.as_slice());
+                    match self.resource_throttle_schedule.evaluate(gas_used, opcode_gas) {
+                        Ok(usage) => Some(usage),
+                        Err(error) => {
+                            let err = TxnExecutionError::ResourceThrottleCalculationFailed;
+                            diag.record_rejection(&err);
+                            record_rejected_tx_priority_fee(
+                                &err,
+                                tx.effective_tip_per_gas(base_fee).unwrap_or(0) as f64,
+                            );
+                            diag.permanently_rejected_txs.push(tx_hash);
+                            warn!(
+                                target: "payload_builder",
+                                tx_hash = ?tx_hash,
+                                error = %error,
+                                "resource throttle usage calculation failed",
+                            );
+                            log_txn(Err(err));
+                            best_txs.mark_invalid(tx.signer(), tx.nonce());
+                            continue;
+                        }
+                    }
+                } else {
+                    None
+                };
+
             // Build tx resources struct
             let tx_resources = TxResources {
                 da_size: tx_da_size,
                 gas_limit: tx.gas_limit(),
                 execution_time_us: predicted_execution_time_us,
                 uncompressed_size: tx_uncompressed_size,
+                resource_throttle_usage,
             };
             self.emit_builder_decision_event(
                 &payload_id,
@@ -925,20 +1006,51 @@ impl BasePayloadBuilderCtx {
                             diag.permanently_rejected_txs.push(tx_hash);
                         }
 
-                        let ExecutionMeteringLimitExceeded::TransactionExecutionTime(
-                            tx_time_us,
-                            limit_us,
-                        ) = limit_err;
-                        // Only record per-tx execution time limits for the audit trail for now
-                        self.record_rejected_tx(
-                            info,
-                            tx_hash,
-                            RejectionReason::ExecutionTimeExceeded {
-                                tx_time_us: *tx_time_us,
-                                limit_us: *limit_us,
-                            },
-                            resource_usage.unwrap_or_default(),
-                        );
+                        match limit_err {
+                            ExecutionMeteringLimitExceeded::TransactionExecutionTime(
+                                tx_time_us,
+                                limit_us,
+                            ) => {
+                                self.record_rejected_tx(
+                                    info,
+                                    tx_hash,
+                                    RejectionReason::ExecutionTimeExceeded {
+                                        tx_time_us: *tx_time_us,
+                                        limit_us: *limit_us,
+                                    },
+                                    resource_usage.unwrap_or_default(),
+                                );
+                            }
+                            ExecutionMeteringLimitExceeded::ResourceThrottle(error)
+                                if error.scope == ResourceThrottleLimitScope::Transaction =>
+                            {
+                                BuilderMetrics::resource_throttle_rejected_total(
+                                    error.dimension.clone(),
+                                    error.scope.to_string(),
+                                )
+                                .increment(1);
+                                self.record_rejected_tx(
+                                    info,
+                                    tx_hash,
+                                    RejectionReason::ResourceThrottleExceeded {
+                                        dimension: error.dimension.clone(),
+                                        revision: error.revision,
+                                        transaction_cost: error.transaction_cost,
+                                        used: error.used,
+                                        limit: error.limit,
+                                    },
+                                    resource_usage.unwrap_or_default(),
+                                );
+                            }
+                            ExecutionMeteringLimitExceeded::ResourceThrottle(error) => {
+                                BuilderMetrics::resource_throttle_rejected_total(
+                                    error.dimension.clone(),
+                                    error.scope.to_string(),
+                                )
+                                .increment(1);
+                            }
+                            _ => {}
+                        }
 
                         self.emit_builder_decision_event(
                             &payload_id,
@@ -1175,6 +1287,36 @@ impl BasePayloadBuilderCtx {
             info.cumulative_da_bytes_used += tx_da_size;
             // record uncompressed tx size
             info.cumulative_uncompressed_bytes += tx_uncompressed_size;
+            // record execution time (only from predictions; unmetered txs count as zero)
+            if let Some(execution_time) = predicted_execution_time_us {
+                info.flashblock_execution_time_us += execution_time;
+            }
+            // record state root gas (only from predictions)
+            if let Some(sr_gas) = state_root_gas {
+                info.cumulative_state_root_gas += sr_gas;
+                BuilderMetrics::tx_state_root_gas().record(sr_gas as f64);
+            }
+            if let Some(usage) = tx_resources.resource_throttle_usage.as_ref() {
+                usage
+                    .add_to(&mut info.cumulative_resource_throttle)
+                    .map_err(PayloadBuilderError::other)?;
+                for (dimension, value) in
+                    self.resource_throttle_schedule.dimensions.iter().zip(usage.values.iter())
+                {
+                    BuilderMetrics::resource_throttle_usage(
+                        dimension.name.clone(),
+                        "transaction".to_string(),
+                    )
+                    .record(*value as f64);
+                }
+            }
+            // record state root time / gas ratio for anomaly detection
+            if let Some(state_root_time) = predicted_state_root_time_us
+                && gas_used > 0
+            {
+                let ratio = state_root_time as f64 / gas_used as f64;
+                BuilderMetrics::state_root_time_per_gas_ratio().record(ratio);
+            }
 
             self.emit_builder_decision_event(
                 &payload_id,
@@ -1282,6 +1424,19 @@ impl BasePayloadBuilderCtx {
             ExecutionMeteringLimitExceeded::TransactionExecutionTime(_, _) => {
                 BuilderMetrics::tx_execution_time_exceeded_total().increment(1);
             }
+            ExecutionMeteringLimitExceeded::FlashblockExecutionTime(_, _, _) => {
+                BuilderMetrics::flashblock_execution_time_exceeded_total().increment(1);
+            }
+            ExecutionMeteringLimitExceeded::BlockStateRootGas(_, _, _) => {
+                BuilderMetrics::block_state_root_gas_exceeded_total().increment(1);
+            }
+            ExecutionMeteringLimitExceeded::ResourceThrottle(error) => {
+                BuilderMetrics::resource_throttle_limit_exceeded_total(
+                    error.dimension.clone(),
+                    error.scope.to_string(),
+                )
+                .increment(1);
+            }
         }
     }
 }
@@ -1336,6 +1491,7 @@ impl BasePayloadBuilderCtx {
             cancel: CancellationToken::new(),
             extra: FlashblocksExtraCtx::default(),
             builder_config: crate::BuilderConfig::default(),
+            resource_throttle_schedule: crate::ResourceThrottleStore::default().snapshot(),
             rejected_tx_sender: None,
         }
     }
@@ -1355,7 +1511,7 @@ mod tests {
     use reth_revm::{State, database::StateProviderDatabase};
 
     use super::*;
-    use crate::test_utils::sign_base_tx;
+    use crate::{ResourceThrottleLimitExceeded, test_utils::sign_base_tx};
 
     #[test]
     fn diagnostics_report_selection_outcome() {
@@ -1394,6 +1550,8 @@ mod tests {
                 ("da_size", 0),
                 ("da_footprint", 0),
                 ("execution_time", 0),
+                ("state_root_time", 1),
+                ("resource_throttle", 0),
                 ("uncompressed_size", 0),
                 ("metering_data_pending", 0),
                 ("other", 0),
@@ -1412,6 +1570,27 @@ mod tests {
         assert_eq!(diag.txs_rejected_metering_data_pending, 1);
         assert_eq!(diag.txs_rejected_other, 3);
         assert_eq!(diag.txs_rejected_total(), 4);
+    }
+
+    #[test]
+    fn diagnostics_bucket_resource_throttle_rejections() {
+        let mut diag = FlashblockDiagnostics::default();
+        let error = TxnExecutionError::ExecutionMeteringLimitExceeded(
+            ExecutionMeteringLimitExceeded::ResourceThrottle(ResourceThrottleLimitExceeded {
+                dimension: "proof".to_string(),
+                scope: ResourceThrottleLimitScope::Block,
+                used: 101,
+                transaction_cost: 10,
+                limit: 100,
+                revision: 1,
+            }),
+        );
+
+        diag.record_rejection(&error);
+
+        assert_eq!(diag.txs_rejected_resource_throttle, 1);
+        assert_eq!(diag.txs_rejected_total(), 1);
+        assert_eq!(diag.rejection_reasons(), vec!["resource_throttle"]);
     }
 
     #[test]

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -238,6 +238,7 @@ where
             cancel,
             extra,
             builder_config: self.config.clone(),
+            resource_throttle_schedule: self.config.resource_throttle_store.snapshot(),
             rejected_tx_sender: self.rejected_tx_sender.clone(),
         })
     }
@@ -564,6 +565,10 @@ where
             da_used = info.cumulative_da_bytes_used,
             block_gas_used = ctx.block_gas_limit(),
             target_da_footprint = target_da_footprint_for_batch,
+            flashblock_execution_time_limit_us = ?flashblock_execution_time_limit_us,
+            target_state_root_gas_for_batch = ?target_state_root_gas_for_batch,
+            resource_throttle_revision = ctx.resource_throttle_schedule.revision,
+            resource_throttle_dimensions = ctx.resource_throttle_schedule.dimensions.len(),
             "Building flashblock",
         );
         let flashblock_build_start_time = Instant::now();
@@ -622,6 +627,9 @@ where
             block_da_footprint_limit: target_da_footprint_for_batch,
             tx_execution_time_limit_us: ctx.builder_config.max_execution_time_per_tx_us,
             block_uncompressed_size_limit: ctx.builder_config.max_uncompressed_block_size,
+            resource_throttle_schedule: (ctx.builder_config.execution_metering_mode.is_enabled()
+                && !ctx.resource_throttle_schedule.is_empty())
+            .then(|| Arc::clone(&ctx.resource_throttle_schedule)),
         };
         let diag = ctx
             .execute_best_transactions(info, state, best_txs, &limits)

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -28,6 +28,15 @@ pub use traits::{ClientBounds, NodeBounds, PayloadTxsBounds, PoolBounds};
 mod metering;
 pub use metering::{MeteringProvider, NoopMeteringProvider, SharedMeteringProvider};
 
+mod resource_throttle;
+pub use resource_throttle::{
+    CompiledResourceThrottleDimension, CompiledResourceThrottleSchedule,
+    ResourceThrottleCheckError, ResourceThrottleDimension, ResourceThrottleError,
+    ResourceThrottleLimitExceeded, ResourceThrottleLimitScope, ResourceThrottleOperation,
+    ResourceThrottleSchedule, ResourceThrottleStore, ResourceThrottleStoreError,
+    ResourceThrottleUsage, SharedResourceThrottleStore, VersionedResourceThrottleSchedule,
+};
+
 mod rejected_tx_forwarder;
 pub use rejected_tx_forwarder::RejectedTxForwarder;
 

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -128,6 +128,32 @@ base_metrics::define_metrics! {
     resource_limit_would_reject_total: counter,
     #[describe("Transactions that exceeded per-tx execution time limit")]
     tx_execution_time_exceeded_total: counter,
+    #[describe("Transactions that exceeded flashblock execution time budget")]
+    flashblock_execution_time_exceeded_total: counter,
+    #[describe("Transactions that exceeded block state root gas limit")]
+    block_state_root_gas_exceeded_total: counter,
+    #[describe("Transactions that exceeded a resource-throttle budget")]
+    #[label(dimension)]
+    #[label(scope)]
+    resource_throttle_limit_exceeded_total: counter,
+    #[describe("Transactions rejected by a resource-throttle budget")]
+    #[label(dimension)]
+    #[label(scope)]
+    resource_throttle_rejected_total: counter,
+    #[describe("Resource-throttle units used by included transactions")]
+    #[label(dimension)]
+    #[label(scope)]
+    resource_throttle_usage: histogram,
+    #[describe("Cumulative resource-throttle units used per block")]
+    #[label(dimension)]
+    resource_throttle_block_usage: histogram,
+    #[describe("Resource-throttle units remaining per block")]
+    #[label(dimension)]
+    resource_throttle_block_headroom: histogram,
+    #[describe("Resource-throttle schedule replacements")]
+    resource_throttle_schedule_updates_total: counter,
+    #[describe("Active resource-throttle schedule revision")]
+    resource_throttle_schedule_revision: gauge,
     #[describe("Histogram of (predicted - actual) execution time per transaction in microseconds")]
     execution_time_prediction_error_us: histogram,
     #[describe("Distribution of predicted execution times from metering service (microseconds)")]
@@ -247,6 +273,34 @@ impl BuilderMetrics {
         if let Some(block_data_limit) = limits.block_data_limit {
             Self::flashblock_da_headroom_bytes(flashblock_index.clone())
                 .record(block_data_limit.saturating_sub(info.cumulative_da_bytes_used) as f64);
+        }
+
+        Self::flashblock_execution_time_used_us(flashblock_index.clone())
+            .record(info.flashblock_execution_time_us as f64);
+        if let Some(flashblock_execution_time_limit_us) = limits.flashblock_execution_time_limit_us
+        {
+            Self::flashblock_execution_time_headroom_us(flashblock_index.clone()).record(
+                flashblock_execution_time_limit_us.saturating_sub(info.flashblock_execution_time_us)
+                    as f64,
+            );
+        }
+
+        Self::flashblock_state_root_gas_used(flashblock_index.clone())
+            .record(info.cumulative_state_root_gas as f64);
+        if let Some(block_state_root_gas_limit) = limits.block_state_root_gas_limit {
+            Self::flashblock_state_root_gas_headroom(flashblock_index.clone())
+                .record(block_state_root_gas_limit.saturating_sub(info.cumulative_state_root_gas)
+                    as f64);
+        }
+
+        if let Some(schedule) = limits.resource_throttle_schedule.as_ref() {
+            for (index, dimension) in schedule.dimensions.iter().enumerate() {
+                let used =
+                    info.cumulative_resource_throttle.get(index).copied().unwrap_or_default();
+                Self::resource_throttle_block_usage(dimension.name.clone()).record(used as f64);
+                Self::resource_throttle_block_headroom(dimension.name.clone())
+                    .record(u128::from(dimension.block_limit).saturating_sub(used) as f64);
+            }
         }
 
         for (reason, count) in diag.rejection_counts() {

--- a/crates/builder/core/src/resource_throttle.rs
+++ b/crates/builder/core/src/resource_throttle.rs
@@ -1,0 +1,834 @@
+//! Versioned resource-throttle schedules and their transaction-cost evaluator.
+
+use std::{collections::HashMap, fmt, fs, path::Path, sync::Arc};
+
+use base_bundles::OpcodeGas;
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+const CURRENT_SCHEDULE_VERSION: u32 = 1;
+const MAX_DIMENSIONS: usize = 128;
+const MAX_DIMENSION_NAME_LENGTH: usize = 64;
+const MAX_OPERATIONS_PER_DIMENSION: usize = 512;
+const MAX_OPERATION_NAME_LENGTH: usize = 128;
+
+/// A serializable resource-throttle schedule.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ResourceThrottleSchedule {
+    /// Schedule schema version.
+    pub version: u32,
+    /// Independently budgeted resource dimensions.
+    #[serde(default)]
+    pub dimensions: Vec<ResourceThrottleDimension>,
+}
+
+impl Default for ResourceThrottleSchedule {
+    fn default() -> Self {
+        Self { version: CURRENT_SCHEDULE_VERSION, dimensions: Vec::new() }
+    }
+}
+
+/// One resource-throttle dimension.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ResourceThrottleDimension {
+    /// Stable operator-facing dimension name.
+    pub name: String,
+    /// Cumulative resource-unit budget for a block.
+    pub block_limit: u64,
+    /// Optional resource-unit budget for one transaction.
+    #[serde(default)]
+    pub transaction_limit: Option<u64>,
+    /// Resource units charged per unit of actual transaction gas used.
+    #[serde(default)]
+    pub base_gas_weight: u64,
+    /// Additional prices for measured opcodes, precompiles, and pseudo-opcodes.
+    #[serde(default)]
+    pub operations: Vec<ResourceThrottleOperation>,
+}
+
+/// A price applied to one measured operation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ResourceThrottleOperation {
+    /// Opcode, precompile, or pseudo-opcode name.
+    pub name: String,
+    /// Resource units charged per measured gas unit.
+    #[serde(default)]
+    pub gas_used_weight: u64,
+    /// Resource units charged per execution/count occurrence.
+    #[serde(default)]
+    pub count_cost: u64,
+}
+
+/// A schedule together with the revision at which it became active.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct VersionedResourceThrottleSchedule {
+    /// Monotonically increasing schedule revision.
+    pub revision: u64,
+    /// Active schedule.
+    pub schedule: ResourceThrottleSchedule,
+}
+
+/// Resource-unit usage aligned with a compiled schedule's dimensions.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ResourceThrottleUsage {
+    /// Resource units used by each schedule dimension.
+    pub values: Vec<u128>,
+}
+
+impl ResourceThrottleUsage {
+    /// Creates zero usage for a schedule with `dimension_count` dimensions.
+    pub fn zero(dimension_count: usize) -> Self {
+        Self { values: vec![0; dimension_count] }
+    }
+
+    /// Returns the usage for one dimension, treating missing values as zero.
+    pub fn get(&self, index: usize) -> u128 {
+        self.values.get(index).copied().unwrap_or_default()
+    }
+
+    /// Adds this usage to cumulative block usage.
+    pub fn add_to(&self, cumulative: &mut Vec<u128>) -> Result<(), ResourceThrottleError> {
+        for (index, value) in self.values.iter().copied().enumerate() {
+            let current = cumulative.get(index).copied().unwrap_or_default();
+            current.checked_add(value).ok_or(ResourceThrottleError::ArithmeticOverflow)?;
+        }
+
+        if cumulative.len() < self.values.len() {
+            cumulative.resize(self.values.len(), 0);
+        }
+        for (index, value) in self.values.iter().copied().enumerate() {
+            cumulative[index] += value;
+        }
+        Ok(())
+    }
+}
+
+/// A compiled schedule used by the builder's hot path.
+#[derive(Debug, Clone)]
+pub struct CompiledResourceThrottleSchedule {
+    /// Revision of the source schedule.
+    pub revision: u64,
+    /// Validated source schedule.
+    pub schedule: ResourceThrottleSchedule,
+    /// Compiled dimensions in stable schedule order.
+    pub dimensions: Vec<CompiledResourceThrottleDimension>,
+    operation_index: HashMap<String, Vec<(usize, u64, u64)>>,
+}
+
+/// A compiled resource-throttle dimension.
+#[derive(Debug, Clone)]
+pub struct CompiledResourceThrottleDimension {
+    /// Stable operator-facing dimension name.
+    pub name: String,
+    /// Cumulative resource-unit budget for a block.
+    pub block_limit: u64,
+    /// Optional resource-unit budget for one transaction.
+    pub transaction_limit: Option<u64>,
+    /// Resource units charged per unit of actual transaction gas used.
+    pub base_gas_weight: u64,
+}
+
+impl CompiledResourceThrottleSchedule {
+    /// Compiles a schedule at the supplied revision.
+    pub fn compile(
+        schedule: ResourceThrottleSchedule,
+        revision: u64,
+    ) -> Result<Self, ResourceThrottleError> {
+        schedule.validate()?;
+
+        let mut dimensions = Vec::with_capacity(schedule.dimensions.len());
+        let mut operation_index: HashMap<String, Vec<(usize, u64, u64)>> = HashMap::new();
+
+        for (dimension_index, dimension) in schedule.dimensions.iter().enumerate() {
+            dimensions.push(CompiledResourceThrottleDimension {
+                name: dimension.name.trim().to_string(),
+                block_limit: dimension.block_limit,
+                transaction_limit: dimension.transaction_limit,
+                base_gas_weight: dimension.base_gas_weight,
+            });
+
+            for operation in &dimension.operations {
+                operation_index
+                    .entry(ResourceThrottleSchedule::normalize_operation_name(&operation.name))
+                    .or_default()
+                    .push((dimension_index, operation.gas_used_weight, operation.count_cost));
+            }
+        }
+
+        Ok(Self { revision, schedule, dimensions, operation_index })
+    }
+
+    /// Returns whether the schedule has no throttling dimensions.
+    pub const fn is_empty(&self) -> bool {
+        self.dimensions.is_empty()
+    }
+
+    /// Returns the raw schedule and revision.
+    pub fn versioned(&self) -> VersionedResourceThrottleSchedule {
+        VersionedResourceThrottleSchedule {
+            revision: self.revision,
+            schedule: self.schedule.clone(),
+        }
+    }
+
+    /// Calculates all dimension costs for one metered transaction.
+    pub fn evaluate(
+        &self,
+        gas_used: u64,
+        opcode_gas: &[OpcodeGas],
+    ) -> Result<ResourceThrottleUsage, ResourceThrottleError> {
+        let mut values = vec![0; self.dimensions.len()];
+
+        for (index, dimension) in self.dimensions.iter().enumerate() {
+            values[index] = u128::from(dimension.base_gas_weight)
+                .checked_mul(u128::from(gas_used))
+                .ok_or(ResourceThrottleError::ArithmeticOverflow)?;
+        }
+
+        for entry in opcode_gas {
+            let operation_name = ResourceThrottleSchedule::normalize_operation_name(&entry.opcode);
+            let Some(prices) = self.operation_index.get(&operation_name) else {
+                continue;
+            };
+
+            for &(dimension_index, gas_used_weight, count_price) in prices {
+                let gas_cost = u128::from(gas_used_weight)
+                    .checked_mul(u128::from(entry.gas_used))
+                    .ok_or(ResourceThrottleError::ArithmeticOverflow)?;
+                let count_cost = u128::from(count_price)
+                    .checked_mul(u128::from(entry.count))
+                    .ok_or(ResourceThrottleError::ArithmeticOverflow)?;
+                let operation_cost = gas_cost
+                    .checked_add(count_cost)
+                    .ok_or(ResourceThrottleError::ArithmeticOverflow)?;
+                values[dimension_index] = values[dimension_index]
+                    .checked_add(operation_cost)
+                    .ok_or(ResourceThrottleError::ArithmeticOverflow)?;
+            }
+        }
+
+        Ok(ResourceThrottleUsage { values })
+    }
+
+    /// Checks transaction and cumulative block budgets for one transaction.
+    pub fn check(
+        &self,
+        usage: &ResourceThrottleUsage,
+        cumulative: &[u128],
+    ) -> Result<(), ResourceThrottleCheckError> {
+        for (index, dimension) in self.dimensions.iter().enumerate() {
+            let transaction_cost = usage.get(index);
+
+            if let Some(transaction_limit) = dimension.transaction_limit
+                && transaction_cost > u128::from(transaction_limit)
+            {
+                return Err(ResourceThrottleCheckError::LimitExceeded(
+                    ResourceThrottleLimitExceeded {
+                        dimension: dimension.name.clone(),
+                        scope: ResourceThrottleLimitScope::Transaction,
+                        used: transaction_cost,
+                        transaction_cost,
+                        limit: transaction_limit,
+                        revision: self.revision,
+                    },
+                ));
+            }
+
+            let used = cumulative
+                .get(index)
+                .copied()
+                .unwrap_or_default()
+                .checked_add(transaction_cost)
+                .ok_or(ResourceThrottleCheckError::ArithmeticOverflow)?;
+            if used > u128::from(dimension.block_limit) {
+                return Err(ResourceThrottleCheckError::LimitExceeded(
+                    ResourceThrottleLimitExceeded {
+                        dimension: dimension.name.clone(),
+                        scope: ResourceThrottleLimitScope::Block,
+                        used,
+                        transaction_cost,
+                        limit: dimension.block_limit,
+                        revision: self.revision,
+                    },
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Scope of a resource-throttle budget violation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResourceThrottleLimitScope {
+    /// The transaction exceeded its optional individual budget.
+    Transaction,
+    /// Adding the transaction would exceed the block budget.
+    Block,
+}
+
+impl fmt::Display for ResourceThrottleLimitScope {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Transaction => formatter.write_str("transaction"),
+            Self::Block => formatter.write_str("block"),
+        }
+    }
+}
+
+/// Details of a resource-throttle budget violation.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error(
+    "resource throttle {scope} limit exceeded: dimension={dimension} used={used} \
+     transaction_cost={transaction_cost} limit={limit} revision={revision}"
+)]
+pub struct ResourceThrottleLimitExceeded {
+    /// Dimension whose budget was exceeded.
+    pub dimension: String,
+    /// Budget scope.
+    pub scope: ResourceThrottleLimitScope,
+    /// Usage after adding the transaction, or transaction usage for a transaction budget.
+    pub used: u128,
+    /// Resource units charged by this transaction.
+    pub transaction_cost: u128,
+    /// Configured budget.
+    pub limit: u64,
+    /// Schedule revision used for the decision.
+    pub revision: u64,
+}
+
+/// Failure while checking a resource-throttle budget.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ResourceThrottleCheckError {
+    /// A configured budget was exceeded.
+    #[error("{0}")]
+    LimitExceeded(ResourceThrottleLimitExceeded),
+    /// Cumulative usage overflowed the evaluator's integer range.
+    #[error("resource throttle arithmetic overflow")]
+    ArithmeticOverflow,
+}
+
+/// Failure while validating or evaluating a resource-throttle schedule.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ResourceThrottleError {
+    /// The schedule schema version is not supported.
+    #[error("unsupported resource throttle schedule version: {0}")]
+    UnsupportedVersion(u32),
+    /// A schedule contains more dimensions than the bounded configuration allows.
+    #[error("resource throttle schedule has too many dimensions: {0}")]
+    TooManyDimensions(usize),
+    /// A dimension name is empty.
+    #[error("resource throttle dimension name is empty")]
+    EmptyDimensionName,
+    /// A dimension or operation name is too long or contains whitespace.
+    #[error("invalid resource throttle name: {0}")]
+    InvalidName(String),
+    /// Two dimensions have the same case-insensitive name.
+    #[error("duplicate resource throttle dimension: {0}")]
+    DuplicateDimension(String),
+    /// A dimension has no usable price.
+    #[error("resource throttle dimension has no non-zero price: {0}")]
+    NoopDimension(String),
+    /// An operation rule has no non-zero price.
+    #[error(
+        "resource throttle operation has no non-zero price: dimension={dimension} operation={operation}"
+    )]
+    NoopOperation {
+        /// Dimension containing the no-op rule.
+        dimension: String,
+        /// Operation with the no-op price.
+        operation: String,
+    },
+    /// A dimension has no positive budget.
+    #[error("resource throttle dimension has a zero block limit: {0}")]
+    ZeroBlockLimit(String),
+    /// A transaction budget is larger than the block budget.
+    #[error("resource throttle transaction limit exceeds block limit: dimension={dimension}")]
+    TransactionLimitExceedsBlock {
+        /// Dimension with the invalid transaction limit.
+        dimension: String,
+    },
+    /// A dimension has too many operation rules.
+    #[error(
+        "resource throttle dimension has too many operations: dimension={dimension} count={count}"
+    )]
+    TooManyOperations {
+        /// Dimension containing too many operation rules.
+        dimension: String,
+        /// Number of operation rules.
+        count: usize,
+    },
+    /// Two operation rules in one dimension have the same name.
+    #[error("duplicate resource throttle operation: dimension={dimension} operation={operation}")]
+    DuplicateOperation {
+        /// Dimension containing the duplicate rule.
+        dimension: String,
+        /// Duplicate operation name.
+        operation: String,
+    },
+    /// An arithmetic operation overflowed.
+    #[error("resource throttle arithmetic overflow")]
+    ArithmeticOverflow,
+}
+
+/// Failure while replacing a shared resource-throttle schedule.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ResourceThrottleStoreError {
+    /// The replacement schedule failed validation.
+    #[error("{0}")]
+    InvalidSchedule(#[from] ResourceThrottleError),
+    /// The caller attempted to replace a schedule based on a stale revision.
+    #[error("resource throttle schedule revision conflict: expected={expected} actual={actual}")]
+    RevisionConflict {
+        /// Revision supplied by the caller.
+        expected: u64,
+        /// Current active revision.
+        actual: u64,
+    },
+    /// The active revision could not be incremented.
+    #[error("resource throttle schedule revision overflow")]
+    RevisionOverflow,
+    /// The schedule file could not be read.
+    #[error("failed to read resource throttle schedule: {0}")]
+    ReadFile(String),
+    /// The schedule file was not valid JSON.
+    #[error("failed to parse resource throttle schedule JSON: {0}")]
+    ParseJson(String),
+}
+
+/// Shared, atomically replaceable resource-throttle schedule.
+#[derive(Debug)]
+pub struct ResourceThrottleStore {
+    active: RwLock<Arc<CompiledResourceThrottleSchedule>>,
+}
+
+impl ResourceThrottleStore {
+    /// Creates a store with an empty schedule at revision zero.
+    pub fn empty() -> Self {
+        Self::from_schedule(ResourceThrottleSchedule::default())
+            .expect("the default resource throttle schedule is valid")
+    }
+
+    /// Creates a store from a validated startup schedule.
+    pub fn from_schedule(
+        schedule: ResourceThrottleSchedule,
+    ) -> Result<Self, ResourceThrottleStoreError> {
+        let compiled = CompiledResourceThrottleSchedule::compile(schedule, 0)?;
+        Ok(Self { active: RwLock::new(Arc::new(compiled)) })
+    }
+
+    /// Creates a store from a JSON schedule.
+    pub fn from_json(json: &str) -> Result<Self, ResourceThrottleStoreError> {
+        let schedule = serde_json::from_str(json)
+            .map_err(|error| ResourceThrottleStoreError::ParseJson(error.to_string()))?;
+        Self::from_schedule(schedule)
+    }
+
+    /// Loads a store from a JSON schedule file.
+    pub fn from_file(path: &Path) -> Result<Self, ResourceThrottleStoreError> {
+        let json = fs::read_to_string(path)
+            .map_err(|error| ResourceThrottleStoreError::ReadFile(error.to_string()))?;
+        Self::from_json(&json)
+    }
+
+    /// Returns an immutable schedule snapshot.
+    pub fn snapshot(&self) -> Arc<CompiledResourceThrottleSchedule> {
+        self.active.read().clone()
+    }
+
+    /// Returns the active raw schedule and revision.
+    pub fn get(&self) -> VersionedResourceThrottleSchedule {
+        self.active.read().versioned()
+    }
+
+    /// Returns the active schedule revision.
+    pub fn revision(&self) -> u64 {
+        self.active.read().revision
+    }
+
+    /// Atomically replaces the schedule, optionally checking its current revision.
+    pub fn replace(
+        &self,
+        schedule: ResourceThrottleSchedule,
+        expected_revision: Option<u64>,
+    ) -> Result<u64, ResourceThrottleStoreError> {
+        // Compile before taking the write lock so schedule validation and indexing do not block
+        // payload jobs that only need to snapshot the active schedule.
+        let mut compiled = CompiledResourceThrottleSchedule::compile(schedule, 0)?;
+        let mut active = self.active.write();
+        let actual = active.revision;
+        if let Some(expected) = expected_revision
+            && expected != actual
+        {
+            return Err(ResourceThrottleStoreError::RevisionConflict { expected, actual });
+        }
+
+        let revision = actual.checked_add(1).ok_or(ResourceThrottleStoreError::RevisionOverflow)?;
+        compiled.revision = revision;
+        *active = Arc::new(compiled);
+        Ok(revision)
+    }
+}
+
+impl Default for ResourceThrottleStore {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+/// Type-erased shared resource-throttle store.
+pub type SharedResourceThrottleStore = Arc<ResourceThrottleStore>;
+
+impl ResourceThrottleSchedule {
+    /// Returns the current supported schema version.
+    pub const fn current_version() -> u32 {
+        CURRENT_SCHEDULE_VERSION
+    }
+
+    /// Validates the schedule before it is compiled or activated.
+    pub fn validate(&self) -> Result<(), ResourceThrottleError> {
+        if self.version != CURRENT_SCHEDULE_VERSION {
+            return Err(ResourceThrottleError::UnsupportedVersion(self.version));
+        }
+        if self.dimensions.len() > MAX_DIMENSIONS {
+            return Err(ResourceThrottleError::TooManyDimensions(self.dimensions.len()));
+        }
+
+        let mut dimension_names = HashMap::with_capacity(self.dimensions.len());
+        for dimension in &self.dimensions {
+            Self::validate_name(&dimension.name, MAX_DIMENSION_NAME_LENGTH)?;
+            let dimension_name = dimension.name.trim().to_ascii_lowercase();
+            if dimension_names.insert(dimension_name, ()).is_some() {
+                return Err(ResourceThrottleError::DuplicateDimension(dimension.name.clone()));
+            }
+            if dimension.block_limit == 0 {
+                return Err(ResourceThrottleError::ZeroBlockLimit(dimension.name.clone()));
+            }
+            if let Some(transaction_limit) = dimension.transaction_limit
+                && (transaction_limit == 0 || transaction_limit > dimension.block_limit)
+            {
+                return if transaction_limit == 0 {
+                    Err(ResourceThrottleError::NoopDimension(dimension.name.clone()))
+                } else {
+                    Err(ResourceThrottleError::TransactionLimitExceedsBlock {
+                        dimension: dimension.name.clone(),
+                    })
+                };
+            }
+            if dimension.operations.len() > MAX_OPERATIONS_PER_DIMENSION {
+                return Err(ResourceThrottleError::TooManyOperations {
+                    dimension: dimension.name.clone(),
+                    count: dimension.operations.len(),
+                });
+            }
+
+            let mut operation_names = HashMap::with_capacity(dimension.operations.len());
+            let has_base_price = dimension.base_gas_weight > 0;
+            let mut has_operation_price = false;
+            for operation in &dimension.operations {
+                Self::validate_name(&operation.name, MAX_OPERATION_NAME_LENGTH)?;
+                if operation.gas_used_weight == 0 && operation.count_cost == 0 {
+                    return Err(ResourceThrottleError::NoopOperation {
+                        dimension: dimension.name.clone(),
+                        operation: operation.name.clone(),
+                    });
+                }
+                let operation_name = Self::normalize_operation_name(&operation.name);
+                if operation_names.insert(operation_name, ()).is_some() {
+                    return Err(ResourceThrottleError::DuplicateOperation {
+                        dimension: dimension.name.clone(),
+                        operation: operation.name.clone(),
+                    });
+                }
+                has_operation_price |= operation.gas_used_weight > 0 || operation.count_cost > 0;
+            }
+            if !has_base_price && !has_operation_price {
+                return Err(ResourceThrottleError::NoopDimension(dimension.name.clone()));
+            }
+        }
+
+        Ok(())
+    }
+    /// Validates a dimension or operation identifier.
+    pub fn validate_name(name: &str, max_length: usize) -> Result<(), ResourceThrottleError> {
+        let trimmed = name.trim();
+        if trimmed.is_empty()
+            || name != trimmed
+            || trimmed.len() > max_length
+            || trimmed.chars().any(char::is_whitespace)
+        {
+            return Err(if trimmed.is_empty() {
+                ResourceThrottleError::EmptyDimensionName
+            } else {
+                ResourceThrottleError::InvalidName(name.to_string())
+            });
+        }
+        Ok(())
+    }
+
+    /// Normalizes an operation name for case-insensitive schedule matching.
+    pub fn normalize_operation_name(name: &str) -> String {
+        name.trim().to_ascii_uppercase()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, thread};
+
+    use alloy_primitives::Address;
+
+    use super::*;
+
+    fn operation(name: &str, gas_used_weight: u64, count_cost: u64) -> ResourceThrottleOperation {
+        ResourceThrottleOperation { name: name.to_string(), gas_used_weight, count_cost }
+    }
+
+    fn dimension(
+        name: &str,
+        block_limit: u64,
+        transaction_limit: Option<u64>,
+        base_gas_weight: u64,
+        operations: Vec<ResourceThrottleOperation>,
+    ) -> ResourceThrottleDimension {
+        ResourceThrottleDimension {
+            name: name.to_string(),
+            block_limit,
+            transaction_limit,
+            base_gas_weight,
+            operations,
+        }
+    }
+
+    fn opcode_gas(opcode: &str, count: u64, gas_used: u64) -> OpcodeGas {
+        OpcodeGas { contract_address: Address::ZERO, opcode: opcode.to_string(), count, gas_used }
+    }
+
+    #[test]
+    fn default_schedule_is_empty_and_current() {
+        let schedule = ResourceThrottleSchedule::default();
+        assert_eq!(schedule.version, ResourceThrottleSchedule::current_version());
+        assert!(schedule.dimensions.is_empty());
+        assert!(ResourceThrottleStore::default().snapshot().is_empty());
+    }
+
+    #[test]
+    fn evaluates_base_gas_and_operation_gas_and_count() {
+        let schedule = ResourceThrottleSchedule {
+            dimensions: vec![dimension(
+                "execution",
+                1_000,
+                Some(500),
+                2,
+                vec![operation("SSTORE", 3, 5)],
+            )],
+            ..Default::default()
+        };
+        let compiled = CompiledResourceThrottleSchedule::compile(schedule, 7).unwrap();
+        let usage = compiled.evaluate(100, &[opcode_gas("sstore", 4, 10)]).unwrap();
+
+        assert_eq!(usage.values, vec![250]);
+    }
+
+    #[test]
+    fn prices_zero_gas_events_by_count() {
+        let schedule = ResourceThrottleSchedule {
+            dimensions: vec![dimension(
+                "new-account",
+                100,
+                None,
+                0,
+                vec![operation("TX_EFFECT_ETH_TRANSFER_TO_NONEXISTENT_ACCOUNT", 0, 25)],
+            )],
+            ..Default::default()
+        };
+        let compiled = CompiledResourceThrottleSchedule::compile(schedule, 0).unwrap();
+        let usage = compiled
+            .evaluate(0, &[opcode_gas("TX_EFFECT_ETH_TRANSFER_TO_NONEXISTENT_ACCOUNT", 1, 0)])
+            .unwrap();
+
+        assert_eq!(usage.values, vec![25]);
+    }
+
+    #[test]
+    fn one_operation_can_price_multiple_dimensions() {
+        let schedule = ResourceThrottleSchedule {
+            dimensions: vec![
+                dimension("cpu", 100, None, 0, vec![operation("CALL", 2, 0)]),
+                dimension("proof", 100, None, 0, vec![operation("CALL", 0, 3)]),
+            ],
+            ..Default::default()
+        };
+        let compiled = CompiledResourceThrottleSchedule::compile(schedule, 0).unwrap();
+        let usage = compiled.evaluate(0, &[opcode_gas("CALL", 4, 10)]).unwrap();
+
+        assert_eq!(usage.values, vec![20, 12]);
+    }
+
+    #[test]
+    fn checks_transaction_and_block_limits() {
+        let schedule = ResourceThrottleSchedule {
+            dimensions: vec![dimension("cpu", 100, Some(30), 1, Vec::new())],
+            ..Default::default()
+        };
+        let compiled = CompiledResourceThrottleSchedule::compile(schedule, 4).unwrap();
+        let usage = compiled.evaluate(40, &[]).unwrap();
+
+        let error = compiled.check(&usage, &[]).unwrap_err();
+        assert!(matches!(
+            error,
+            ResourceThrottleCheckError::LimitExceeded(ResourceThrottleLimitExceeded {
+                scope: ResourceThrottleLimitScope::Transaction,
+                ..
+            })
+        ));
+
+        let usage = compiled.evaluate(20, &[]).unwrap();
+        let error = compiled.check(&usage, &[90]).unwrap_err();
+        assert!(matches!(
+            error,
+            ResourceThrottleCheckError::LimitExceeded(ResourceThrottleLimitExceeded {
+                scope: ResourceThrottleLimitScope::Block,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_schedules() {
+        let duplicate = ResourceThrottleSchedule {
+            dimensions: vec![
+                dimension("CPU", 100, None, 1, Vec::new()),
+                dimension("cpu", 100, None, 1, Vec::new()),
+            ],
+            ..Default::default()
+        };
+        assert!(matches!(duplicate.validate(), Err(ResourceThrottleError::DuplicateDimension(_))));
+
+        let noop = ResourceThrottleSchedule {
+            dimensions: vec![dimension("cpu", 100, None, 0, vec![operation("CALL", 0, 0)])],
+            ..Default::default()
+        };
+        assert!(matches!(noop.validate(), Err(ResourceThrottleError::NoopOperation { .. })));
+
+        let noop_dimension = ResourceThrottleSchedule {
+            dimensions: vec![dimension("cpu", 100, None, 0, Vec::new())],
+            ..Default::default()
+        };
+        assert!(matches!(noop_dimension.validate(), Err(ResourceThrottleError::NoopDimension(_))));
+
+        let oversized_transaction_limit = ResourceThrottleSchedule {
+            dimensions: vec![dimension("cpu", 10, Some(11), 1, Vec::new())],
+            ..Default::default()
+        };
+        assert!(matches!(
+            oversized_transaction_limit.validate(),
+            Err(ResourceThrottleError::TransactionLimitExceedsBlock { .. })
+        ));
+    }
+
+    #[test]
+    fn detects_evaluation_overflow() {
+        let schedule = ResourceThrottleSchedule {
+            dimensions: vec![dimension(
+                "overflow",
+                u64::MAX,
+                None,
+                u64::MAX,
+                vec![operation("CALL", u64::MAX, 0)],
+            )],
+            ..Default::default()
+        };
+        let compiled = CompiledResourceThrottleSchedule::compile(schedule, 0).unwrap();
+
+        assert_eq!(
+            compiled.evaluate(u64::MAX, &[opcode_gas("CALL", 1, u64::MAX)]),
+            Err(ResourceThrottleError::ArithmeticOverflow)
+        );
+    }
+
+    #[test]
+    fn replaces_schedule_atomically_with_revision_check() {
+        let store = ResourceThrottleStore::default();
+        let old_snapshot = store.snapshot();
+        let schedule = ResourceThrottleSchedule {
+            dimensions: vec![dimension("cpu", 100, None, 1, Vec::new())],
+            ..Default::default()
+        };
+
+        assert_eq!(store.revision(), 0);
+        assert_eq!(store.replace(schedule.clone(), Some(0)).unwrap(), 1);
+        assert_eq!(store.get().revision, 1);
+        assert_eq!(store.snapshot().dimensions[0].name, "cpu");
+        assert!(old_snapshot.is_empty());
+        assert!(matches!(
+            store.replace(schedule, Some(0)),
+            Err(ResourceThrottleStoreError::RevisionConflict { expected: 0, actual: 1 })
+        ));
+    }
+
+    #[test]
+    fn concurrent_replacements_allow_only_one_revision_match() {
+        let store = Arc::new(ResourceThrottleStore::default());
+        let schedule = ResourceThrottleSchedule {
+            dimensions: vec![dimension("cpu", 100, None, 1, Vec::new())],
+            ..Default::default()
+        };
+
+        let first_store = Arc::clone(&store);
+        let first_schedule = schedule.clone();
+        let first = thread::spawn(move || first_store.replace(first_schedule, Some(0)));
+        let second_store = Arc::clone(&store);
+        let second = thread::spawn(move || second_store.replace(schedule, Some(0)));
+
+        let results = [first.join().unwrap(), second.join().unwrap()];
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| {
+                    matches!(
+                        result,
+                        Err(ResourceThrottleStoreError::RevisionConflict {
+                            expected: 0,
+                            actual: 1
+                        })
+                    )
+                })
+                .count(),
+            1
+        );
+        assert_eq!(store.revision(), 1);
+    }
+
+    #[test]
+    fn parses_versioned_camel_case_json() {
+        let store = ResourceThrottleStore::from_json(
+            r#"{
+                "version": 1,
+                "dimensions": [{
+                    "name": "execution",
+                    "blockLimit": 100,
+                    "transactionLimit": 50,
+                    "baseGasWeight": 2,
+                    "operations": [{
+                        "name": "SSTORE",
+                        "gasUsedWeight": 3,
+                        "countCost": 4
+                    }]
+                }]
+            }"#,
+        )
+        .unwrap();
+
+        let active = store.get();
+        assert_eq!(active.revision, 0);
+        assert_eq!(active.schedule.dimensions[0].transaction_limit, Some(50));
+        assert_eq!(active.schedule.dimensions[0].operations[0].count_cost, 4);
+    }
+}

--- a/crates/builder/metering/Cargo.toml
+++ b/crates/builder/metering/Cargo.toml
@@ -21,3 +21,4 @@ base-builder-core.workspace = true
 moka = { workspace = true, features = ["sync"] }
 
 [dev-dependencies]
+tokio.workspace = true

--- a/crates/builder/metering/README.md
+++ b/crates/builder/metering/README.md
@@ -3,12 +3,14 @@
 <a href="https://github.com/base/base/actions/workflows/ci.yml"><img src="https://github.com/base/base/actions/workflows/ci.yml/badge.svg?label=ci" alt="CI"></a>
 <a href="https://github.com/base/base/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-d1d1f6.svg?label=license&labelColor=2a2f35" alt="MIT License"></a>
 
-Resource metering backend for the Base block builder. Provides a concrete [`MeteringProvider`](../core/) implementation backed by a concurrent cache with LRU eviction, along with JSON-RPC extensions for managing resource metering data.
+Resource metering backend for the Base block builder. Provides a concrete [`MeteringProvider`](../core/) implementation backed by a concurrent cache with LRU eviction, along with JSON-RPC extensions for managing resource metering data and the builder's resource-throttle schedule.
 
 ## Overview
 
 - **`MeteringStore`**: Thread-safe metering data cache using `DashMap` with bounded LRU eviction. Implements `MeteringProvider` from `base-builder-core`.
 - **`MeteringStoreExt`**: JSON-RPC extension exposing `base_setMeteringInformation`, `base_setMeteringEnabled`, and `base_clearMeteringInformation` methods.
+- **`ResourceThrottleExt`**: JWT-authenticated JSON-RPC extension exposing
+  `base_getResourceThrottleSchedule` and `base_replaceResourceThrottleSchedule`.
 
 ## Usage
 
@@ -30,6 +32,92 @@ let store = Arc::new(MeteringStore::new(true, 10_000, Duration::from_secs(30)));
 // Pass `store.clone()` as `SharedMeteringProvider` into `BuilderConfig`
 // Pass `store` into `MeteringStoreExt::new()` for the RPC extension
 ```
+
+## Resource-throttle schedules
+
+Resource throttling is builder-local accounting. It does not change protocol gas prices, transaction
+fees, or the gas limit accepted by the EVM. A schedule converts the gas and selectively collected
+`opcodeGas` entries from `meterBundle` into bounded resource units.
+
+Configure a startup schedule with:
+
+```text
+--builder.resource-throttle-schedule=/etc/base/resource-throttle.json
+```
+
+The same path can be supplied through `BUILDER_RESOURCE_THROTTLE_SCHEDULE`.
+
+The schedule is versioned and contains block-scoped dimensions. `baseGasWeight` charges against
+actual transaction gas used; operation rules can additionally charge measured gas and/or counts.
+The same operation may be priced in multiple dimensions.
+
+```json
+{
+  "version": 1,
+  "dimensions": [
+    {
+      "name": "execution",
+      "blockLimit": 100000000,
+      "transactionLimit": 10000000,
+      "baseGasWeight": 1,
+      "operations": [
+        { "name": "SSTORE", "gasUsedWeight": 2, "countCost": 100 }
+      ]
+    },
+    {
+      "name": "proof",
+      "blockLimit": 50000000,
+      "baseGasWeight": 0,
+      "operations": [
+        { "name": "BLAKE2F", "gasUsedWeight": 4, "countCost": 1000 },
+        { "name": "TX_EFFECT_ETH_TRANSFER_TO_NONEXISTENT_ACCOUNT", "countCost": 25000 }
+      ]
+    }
+  ]
+}
+```
+
+The additive calculation for each dimension is:
+
+```text
+baseGasWeight * gasUsed
+  + sum(gasUsedWeight * opcodeGas.gasUsed + countCost * opcodeGas.count)
+```
+
+Resource-throttle schedules are snapshotted when a block build starts. A runtime replacement
+therefore takes effect on the next payload build and never changes the rules for an in-flight
+block. Both replacement methods are registered only on the JWT-authenticated RPC endpoint:
+
+```text
+base_getResourceThrottleSchedule()
+base_replaceResourceThrottleSchedule(schedule, expectedRevision?)
+```
+
+`expectedRevision` provides compare-and-swap behavior for incident automation. The replacement is
+validated atomically; invalid schedules and stale revisions are rejected. The resource-throttle
+schedule is evaluated only when builder metering is enabled and supports `off`, `dry-run`, and
+`enforce` rollout behavior through `--builder.execution-metering-mode`.
+The legacy execution-time and state-root-gas limits remain available during rollout; if configured,
+they are evaluated alongside resource-throttle budgets.
+
+For example, send these JSON-RPC requests to the authenticated endpoint with the node's JWT:
+
+```json
+{"jsonrpc":"2.0","id":1,"method":"base_getResourceThrottleSchedule","params":[]}
+{"jsonrpc":"2.0","id":2,"method":"base_replaceResourceThrottleSchedule","params":[
+  {"version":1,"dimensions":[]},
+  7
+]}
+```
+
+The replacement response is the new revision. Pass `null` as the second parameter to replace
+unconditionally; using the revision returned by `base_getResourceThrottleSchedule` is safer for
+incident automation.
+
+The schedule can only price data that the builder receives. `meterBundle` nodes must be configured
+with the union of opcode, precompile, and pseudo-opcode names required by the schedule and
+restarted when that collection set changes. An absent `opcodeGas` entry means the operation was not
+observed by the metering node; it is not evidence that the operation is impossible.
 
 ## License
 

--- a/crates/builder/metering/src/ext.rs
+++ b/crates/builder/metering/src/ext.rs
@@ -1,11 +1,15 @@
 //! RPC extensions for the metering store.
 
 use alloy_primitives::TxHash;
-use base_builder_core::SharedMeteringProvider;
+use base_builder_core::{
+    BuilderMetrics, ResourceThrottleSchedule, SharedMeteringProvider, SharedResourceThrottleStore,
+    VersionedResourceThrottleSchedule,
+};
 use base_bundles::MeterBundleResponse;
 use jsonrpsee::{
     core::{RpcResult, async_trait},
     proc_macros::rpc,
+    types::{ErrorCode, ErrorObjectOwned},
 };
 use tracing::info;
 
@@ -30,15 +34,45 @@ pub trait BaseApiExt {
     async fn clear_metering_information(&self) -> RpcResult<()>;
 }
 
+/// JWT-authenticated RPC methods for replacing the builder's resource-throttle schedule.
+#[cfg_attr(not(test), rpc(server, namespace = "base"))]
+#[cfg_attr(test, rpc(server, client, namespace = "base"))]
+pub trait ResourceThrottleApi {
+    /// Returns the active resource-throttle schedule and revision.
+    #[method(name = "getResourceThrottleSchedule")]
+    async fn get_resource_throttle_schedule(&self) -> RpcResult<VersionedResourceThrottleSchedule>;
+
+    /// Atomically replaces the active resource-throttle schedule.
+    #[method(name = "replaceResourceThrottleSchedule")]
+    async fn replace_resource_throttle_schedule(
+        &self,
+        schedule: ResourceThrottleSchedule,
+        expected_revision: Option<u64>,
+    ) -> RpcResult<u64>;
+}
+
 /// RPC extension wrapper around a [`SharedMeteringProvider`].
 #[derive(Debug)]
 pub struct MeteringStoreExt {
     store: SharedMeteringProvider,
 }
 
+/// RPC extension for the JWT-authenticated resource-throttle control methods.
+#[derive(Debug)]
+pub struct ResourceThrottleExt {
+    store: SharedResourceThrottleStore,
+}
+
 impl MeteringStoreExt {
     /// Creates a new [`MeteringStoreExt`] with the given metering provider.
     pub fn new(store: SharedMeteringProvider) -> Self {
+        Self { store }
+    }
+}
+
+impl ResourceThrottleExt {
+    /// Creates a new resource-throttle RPC extension.
+    pub const fn new(store: SharedResourceThrottleStore) -> Self {
         Self { store }
     }
 }
@@ -66,5 +100,87 @@ impl BaseApiExtServer for MeteringStoreExt {
         );
         self.store.clear();
         Ok(())
+    }
+}
+
+#[async_trait]
+impl ResourceThrottleApiServer for ResourceThrottleExt {
+    async fn get_resource_throttle_schedule(&self) -> RpcResult<VersionedResourceThrottleSchedule> {
+        Ok(self.store.get())
+    }
+
+    async fn replace_resource_throttle_schedule(
+        &self,
+        schedule: ResourceThrottleSchedule,
+        expected_revision: Option<u64>,
+    ) -> RpcResult<u64> {
+        let dimensions = schedule.dimensions.len();
+        let revision = self.store.replace(schedule, expected_revision).map_err(|error| {
+            ErrorObjectOwned::owned(ErrorCode::InvalidParams.code(), error.to_string(), None::<()>)
+        })?;
+        BuilderMetrics::resource_throttle_schedule_updates_total().increment(1);
+        BuilderMetrics::resource_throttle_schedule_revision().set(revision as f64);
+        info!(revision, dimensions, "resource throttle schedule replaced");
+        Ok(revision)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use base_builder_core::{
+        NoopMeteringProvider, ResourceThrottleDimension, ResourceThrottleOperation,
+        ResourceThrottleStore,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn resource_throttle_rpc_replaces_schedule_with_revision_check() {
+        let store = Arc::new(ResourceThrottleStore::default());
+        let extension = ResourceThrottleExt::new(Arc::clone(&store));
+        let schedule = ResourceThrottleSchedule {
+            dimensions: vec![ResourceThrottleDimension {
+                name: "execution".to_string(),
+                block_limit: 100,
+                transaction_limit: None,
+                base_gas_weight: 1,
+                operations: vec![ResourceThrottleOperation {
+                    name: "SSTORE".to_string(),
+                    gas_used_weight: 2,
+                    count_cost: 0,
+                }],
+            }],
+            ..Default::default()
+        };
+
+        assert_eq!(extension.get_resource_throttle_schedule().await.unwrap().revision, 0);
+        assert_eq!(
+            extension.replace_resource_throttle_schedule(schedule, Some(0)).await.unwrap(),
+            1
+        );
+        assert_eq!(store.revision(), 1);
+        assert!(
+            extension
+                .replace_resource_throttle_schedule(ResourceThrottleSchedule::default(), Some(0))
+                .await
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn resource_throttle_methods_are_separate_from_regular_metering_methods() {
+        let regular = MeteringStoreExt::new(Arc::new(NoopMeteringProvider)).into_rpc();
+        assert!(!regular.method_names().any(|name| name == "base_getResourceThrottleSchedule"));
+
+        let authenticated =
+            ResourceThrottleExt::new(Arc::new(ResourceThrottleStore::default())).into_rpc();
+        assert!(
+            authenticated.method_names().any(|name| name == "base_getResourceThrottleSchedule")
+        );
+        assert!(
+            authenticated.method_names().any(|name| name == "base_replaceResourceThrottleSchedule")
+        );
     }
 }

--- a/crates/builder/metering/src/extension.rs
+++ b/crates/builder/metering/src/extension.rs
@@ -1,31 +1,49 @@
 //! Builder-specific node extensions.
 
-use base_builder_core::SharedMeteringProvider;
+use base_builder_core::{BuilderMetrics, SharedMeteringProvider, SharedResourceThrottleStore};
 use base_node_runner::{BaseNodeExtension, BaseRpcContext, FromExtensionConfig, NodeHooks};
 
-use crate::{BaseApiExtServer, MeteringStoreExt};
+use crate::{BaseApiExtServer, MeteringStoreExt, ResourceThrottleApiServer, ResourceThrottleExt};
+
+/// Configuration shared by the builder metering ingestion and control RPCs.
+#[derive(Debug, Clone)]
+pub struct MeteringStoreExtensionConfig {
+    /// Provider receiving metering responses.
+    pub metering_provider: SharedMeteringProvider,
+    /// Resource-throttle schedule store used by the builder.
+    pub resource_throttle_store: SharedResourceThrottleStore,
+}
 
 /// Extension that registers the [`MeteringStoreExt`] RPC module.
 #[derive(Debug)]
 pub struct MeteringStoreExtension {
     metering_provider: SharedMeteringProvider,
+    resource_throttle_store: SharedResourceThrottleStore,
 }
 
 impl BaseNodeExtension for MeteringStoreExtension {
     fn apply(self: Box<Self>, hooks: NodeHooks) -> NodeHooks {
         let metering_provider = self.metering_provider;
+        let resource_throttle_store = self.resource_throttle_store;
+        BuilderMetrics::resource_throttle_schedule_revision()
+            .set(resource_throttle_store.revision() as f64);
         hooks.add_rpc_module(move |ctx: &mut BaseRpcContext<'_>| {
             let ext = MeteringStoreExt::new(metering_provider);
             ctx.modules.add_or_replace_configured(ext.into_rpc())?;
+            let resource_throttle_ext = ResourceThrottleExt::new(resource_throttle_store);
+            ctx.auth_module.merge_auth_methods(resource_throttle_ext.into_rpc())?;
             Ok(())
         })
     }
 }
 
 impl FromExtensionConfig for MeteringStoreExtension {
-    type Config = SharedMeteringProvider;
+    type Config = MeteringStoreExtensionConfig;
 
     fn from_config(config: Self::Config) -> Self {
-        Self { metering_provider: config }
+        Self {
+            metering_provider: config.metering_provider,
+            resource_throttle_store: config.resource_throttle_store,
+        }
     }
 }

--- a/crates/builder/metering/src/lib.rs
+++ b/crates/builder/metering/src/lib.rs
@@ -8,10 +8,10 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 mod ext;
-pub use ext::{BaseApiExtServer, MeteringStoreExt};
+pub use ext::{BaseApiExtServer, MeteringStoreExt, ResourceThrottleApiServer, ResourceThrottleExt};
 
 mod extension;
-pub use extension::MeteringStoreExtension;
+pub use extension::{MeteringStoreExtension, MeteringStoreExtensionConfig};
 
 mod store;
 pub use store::MeteringStore;

--- a/crates/common/bundles/src/meter.rs
+++ b/crates/common/bundles/src/meter.rs
@@ -3,14 +3,14 @@
 use alloy_primitives::{Address, B256, TxHash, U256};
 use serde::{Deserialize, Serialize};
 
-/// Per-opcode or precompile gas usage for a single item.
+/// Per-opcode, precompile, or pseudo-opcode gas usage for a single item.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct OpcodeGas {
     /// Address of the contract/precompile whose execution consumed this gas.
     #[serde(default)]
     pub contract_address: Address,
-    /// Opcode or precompile name (e.g., "SSTORE", "BLAKE2F").
+    /// Opcode, precompile, or pseudo-opcode name (e.g., "SSTORE", "BLAKE2F").
     pub opcode: String,
     /// Number of times this opcode/precompile was executed in the transaction.
     pub count: u64,
@@ -77,6 +77,19 @@ pub struct MeterBundleResponse {
     pub total_gas_used: u64,
     /// Total execution time in microseconds.
     pub total_execution_time_us: u128,
+}
+
+impl MeterBundleResponse {
+    /// Returns the result for a transaction in this response.
+    ///
+    /// Single-transaction metering responses are allowed to omit a matching hash in
+    /// compatibility paths, so a response with exactly one result is also accepted.
+    pub fn result_for_transaction(&self, tx_hash: &TxHash) -> Option<&TransactionResult> {
+        self.results
+            .iter()
+            .find(|result| &result.tx_hash == tx_hash)
+            .or_else(|| (self.results.len() == 1).then(|| &self.results[0]))
+    }
 }
 
 #[cfg(test)]

--- a/crates/common/bundles/src/rejected.rs
+++ b/crates/common/bundles/src/rejected.rs
@@ -16,6 +16,20 @@ pub enum RejectionReason {
         /// Per-transaction limit in microseconds.
         limit_us: u128,
     },
+    /// Transaction's predicted resource-throttle usage exceeded a dimension budget.
+    ResourceThrottleExceeded {
+        /// Resource-throttle dimension.
+        dimension: String,
+        /// Resource-throttle schedule revision used for the decision.
+        revision: u64,
+        /// Resource units charged by the transaction.
+        transaction_cost: u128,
+        /// Resource units used after adding the transaction, or transaction usage for a
+        /// transaction-level budget.
+        used: u128,
+        /// Configured resource-unit budget.
+        limit: u64,
+    },
 }
 
 /// A transaction that was rejected during block building.


### PR DESCRIPTION
## Summary
- Add versioned, multidimensional resource-throttle schedules with weighted gas and count pricing.
- Enforce block and transaction resource budgets in the builder with rejection accounting and metrics.
- Wire startup JSON configuration and JWT-authenticated schedule get/replace RPCs, with rollout documentation.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p base-builder-core --lib resource_throttle`
- [ ] Run full workspace CI

type=routine
risk=low
impact=sev5