### PR TITLE
test(system-tests): add shadow sequencer harness and test

### DIFF
--- a/etc/systems/src/l2/mod.rs
+++ b/etc/systems/src/l2/mod.rs
@@ -18,5 +18,8 @@ pub use in_process_consensus::{InProcessConsensus, InProcessConsensusConfig};
 mod in_process_follow_consensus;
 pub use in_process_follow_consensus::{InProcessFollowConsensus, InProcessFollowConsensusConfig};
 
+mod shadow_sequencer;
+pub use shadow_sequencer::{ShadowSequencer, ShadowSequencerConfig};
+
 mod stack;
 pub use stack::{L2ClientConsensus, L2ClientConsensusMode, L2Stack, L2StackConfig};

--- a/etc/systems/src/l2/shadow_sequencer.rs
+++ b/etc/systems/src/l2/shadow_sequencer.rs
@@ -55,7 +55,6 @@ pub struct ShadowSequencerConfig {
 #[derive(Debug)]
 pub struct ShadowSequencer {
     index: usize,
-    sequencer_key: B256,
     builder: InProcessBuilder,
     consensus: InProcessConsensus,
 }
@@ -117,17 +116,12 @@ impl ShadowSequencer {
 
         consensus.start_sequencer().await.wrap_err("Failed to start shadow sequencer")?;
 
-        Ok(Self { index: config.index, sequencer_key: config.sequencer_key, builder, consensus })
+        Ok(Self { index: config.index, builder, consensus })
     }
 
     /// Returns the zero-based index of this shadow sequencer.
     pub const fn index(&self) -> usize {
         self.index
-    }
-
-    /// Returns the signing key used by this shadow sequencer.
-    pub const fn sequencer_key(&self) -> B256 {
-        self.sequencer_key
     }
 
     /// Returns a reference to the shadow's builder execution layer.

--- a/etc/systems/src/l2/shadow_sequencer.rs
+++ b/etc/systems/src/l2/shadow_sequencer.rs
@@ -1,0 +1,152 @@
+//! Shadow sequencer node for L2 system test stacks.
+//!
+//! A shadow sequencer is a full `NodeMode::Sequencer` node (its own builder
+//! execution layer plus an in-process consensus node) that runs in parallel to
+//! the active sequencer. It builds and seals real blocks from its own mempool,
+//! but signs them with a distinct key so the rest of the network rejects them as
+//! non-canonical. This mirrors the "Shadow" role in the Shadow Block Builder
+//! design: build candidate blocks to validate new code without ever advancing
+//! the canonical chain tip observed by other nodes.
+//!
+//! The build-but-forget reorg behavior (a shadow re-orging itself back to the
+//! active sequencer's canonical state) is intentionally NOT implemented here; it
+//! is the subject of a follow-up change. Tests may therefore assert the desired
+//! end state and observe it fail against the current node implementation.
+
+use alloy_genesis::ChainConfig;
+use alloy_primitives::B256;
+use alloy_rpc_types_engine::JwtSecret;
+use alloy_signer_local::PrivateKeySigner;
+use base_common_genesis::RollupConfig;
+use base_consensus_node::NodeMode;
+use eyre::{Result, WrapErr};
+use url::Url;
+
+use super::{
+    InProcessBuilder, InProcessBuilderConfig, InProcessConsensus, InProcessConsensusConfig,
+};
+
+/// Configuration for starting a single [`ShadowSequencer`].
+#[derive(Debug, Clone)]
+pub struct ShadowSequencerConfig {
+    /// Zero-based index of this shadow sequencer, used only for logging/identity.
+    pub index: usize,
+    /// Distinct sequencer signing key. Must differ from the active sequencer key
+    /// so that blocks built by this shadow are rejected as non-canonical.
+    pub sequencer_key: B256,
+    /// L2 genesis JSON content (shared with the active stack).
+    pub l2_genesis: Vec<u8>,
+    /// Parsed rollup configuration (shared with the active stack).
+    pub rollup_config: RollupConfig,
+    /// Parsed L1 chain configuration (shared with the active stack).
+    pub l1_chain_config: ChainConfig,
+    /// JWT secret for Engine API authentication.
+    pub jwt_secret: JwtSecret,
+    /// L1 RPC endpoint URL.
+    pub l1_rpc_url: Url,
+    /// L1 beacon API endpoint URL.
+    pub l1_beacon_url: Url,
+    /// P2P multiaddr of the active sequencer's consensus node to peer with.
+    pub active_consensus_p2p_addr: String,
+}
+
+/// A running shadow sequencer: an isolated builder execution layer plus a
+/// consensus node running in `NodeMode::Sequencer`.
+#[derive(Debug)]
+pub struct ShadowSequencer {
+    index: usize,
+    sequencer_key: B256,
+    builder: InProcessBuilder,
+    consensus: InProcessConsensus,
+}
+
+impl ShadowSequencer {
+    /// Starts a shadow sequencer and activates block production.
+    ///
+    /// Startup order mirrors the active sequencer path: the builder EL starts
+    /// first, then the consensus node (Sequencer mode, started stopped), which is
+    /// peered to the active sequencer before block production is enabled.
+    ///
+    /// The consensus node uses its own signing address as `unsafe_block_signer`,
+    /// so it does not accept the active sequencer's gossiped blocks and instead
+    /// builds an independent chain from its own mempool. Its own blocks are in
+    /// turn rejected by the active network because they are signed with a key the
+    /// rest of the network does not trust.
+    pub async fn start(config: ShadowSequencerConfig) -> Result<Self> {
+        let unsafe_block_signer = PrivateKeySigner::from_bytes(&config.sequencer_key)
+            .wrap_err("Failed to derive shadow sequencer address")?
+            .address();
+
+        let builder = InProcessBuilder::start(InProcessBuilderConfig {
+            genesis_json: config.l2_genesis,
+            jwt_secret: config.jwt_secret,
+            http_port: None,
+            ws_port: None,
+            auth_port: None,
+            p2p_port: None,
+            flashblocks_port: None,
+        })
+        .await
+        .wrap_err("Failed to start shadow builder")?;
+
+        let consensus = InProcessConsensus::start(InProcessConsensusConfig {
+            rollup_config: config.rollup_config,
+            l1_chain_config: config.l1_chain_config,
+            jwt_secret: config.jwt_secret,
+            l1_rpc_url: config.l1_rpc_url,
+            l1_beacon_url: config.l1_beacon_url,
+            l2_engine_url: builder.engine_url()?,
+            mode: NodeMode::Sequencer,
+            sequencer_key: Some(config.sequencer_key),
+            p2p_key: None,
+            rpc_port: None,
+            p2p_tcp_port: None,
+            p2p_udp_port: None,
+            unsafe_block_signer,
+            l1_slot_duration_override: Some(4),
+            sequencer_stopped: true,
+            verifier_l1_confs: 0,
+        })
+        .await
+        .wrap_err("Failed to start shadow consensus")?;
+
+        consensus
+            .connect_peer(&config.active_consensus_p2p_addr)
+            .await
+            .wrap_err("Failed to connect shadow consensus to active sequencer")?;
+
+        consensus.start_sequencer().await.wrap_err("Failed to start shadow sequencer")?;
+
+        Ok(Self { index: config.index, sequencer_key: config.sequencer_key, builder, consensus })
+    }
+
+    /// Returns the zero-based index of this shadow sequencer.
+    pub const fn index(&self) -> usize {
+        self.index
+    }
+
+    /// Returns the signing key used by this shadow sequencer.
+    pub const fn sequencer_key(&self) -> B256 {
+        self.sequencer_key
+    }
+
+    /// Returns a reference to the shadow's builder execution layer.
+    pub const fn builder(&self) -> &InProcessBuilder {
+        &self.builder
+    }
+
+    /// Returns a reference to the shadow's consensus node.
+    pub const fn consensus(&self) -> &InProcessConsensus {
+        &self.consensus
+    }
+
+    /// Returns the shadow builder's HTTP RPC URL.
+    pub fn rpc_url(&self) -> Result<Url> {
+        self.builder.rpc_url()
+    }
+
+    /// Returns the shadow consensus node's RPC URL.
+    pub fn consensus_rpc_url(&self) -> Url {
+        self.consensus.rpc_url()
+    }
+}

--- a/etc/systems/src/l2/stack.rs
+++ b/etc/systems/src/l2/stack.rs
@@ -20,7 +20,8 @@ use url::Url;
 use super::{
     InProcessBatcher, InProcessBatcherConfig, InProcessBuilder, InProcessBuilderConfig,
     InProcessClient, InProcessClientConfig, InProcessConsensus, InProcessConsensusConfig,
-    InProcessFollowConsensus, InProcessFollowConsensusConfig, L2ContainerConfig,
+    InProcessFollowConsensus, InProcessFollowConsensusConfig, L2ContainerConfig, ShadowSequencer,
+    ShadowSequencerConfig,
 };
 use crate::config::SEQUENCER;
 
@@ -65,6 +66,11 @@ pub struct L2StackConfig {
     pub verifier_l1_confs: u64,
     /// Consensus mode for the L2 client node.
     pub client_consensus_mode: L2ClientConsensusMode,
+    /// Signing keys for shadow sequencers. Each entry spawns one shadow sequencer
+    /// running alongside the active sequencer. Each key must be distinct from
+    /// [`sequencer_key`](Self::sequencer_key) so the shadow's blocks are rejected
+    /// as non-canonical by the rest of the network.
+    pub shadow_sequencer_keys: Vec<B256>,
 }
 
 /// Running L2 client consensus node.
@@ -106,6 +112,7 @@ pub struct L2Stack {
     batcher: InProcessBatcher,
     client: InProcessClient,
     client_consensus: L2ClientConsensus,
+    shadow_sequencers: Vec<ShadowSequencer>,
 }
 
 impl std::fmt::Debug for L2Stack {
@@ -116,6 +123,7 @@ impl std::fmt::Debug for L2Stack {
             .field("batcher", &self.batcher)
             .field("client", &self.client)
             .field("client_consensus", &self.client_consensus)
+            .field("shadow_sequencers", &self.shadow_sequencers)
             .finish()
     }
 }
@@ -221,11 +229,11 @@ impl L2Stack {
         let client_consensus = match config.client_consensus_mode {
             L2ClientConsensusMode::Validator => {
                 let client_consensus_config = InProcessConsensusConfig {
-                    rollup_config,
-                    l1_chain_config,
+                    rollup_config: rollup_config.clone(),
+                    l1_chain_config: l1_chain_config.clone(),
                     jwt_secret: config.jwt_secret,
-                    l1_rpc_url,
-                    l1_beacon_url,
+                    l1_rpc_url: l1_rpc_url.clone(),
+                    l1_beacon_url: l1_beacon_url.clone(),
                     l2_engine_url: client.engine_url()?,
                     mode: NodeMode::Validator,
                     sequencer_key: None,
@@ -254,9 +262,9 @@ impl L2Stack {
                 // Follow-mode consensus polls the builder RPC directly, so it does not need a P2P
                 // peer connection before the sequencer starts producing blocks.
                 let client_consensus_config = InProcessFollowConsensusConfig {
-                    rollup_config,
+                    rollup_config: rollup_config.clone(),
                     jwt_secret: config.jwt_secret,
-                    l1_rpc_url,
+                    l1_rpc_url: l1_rpc_url.clone(),
                     local_l2_rpc_url: client.rpc_url()?,
                     source_l2_rpc_url: builder.rpc_url()?,
                     l2_engine_url: client.engine_url()?,
@@ -276,7 +284,34 @@ impl L2Stack {
             .await
             .wrap_err("Failed to start sequencer after peer connection")?;
 
-        Ok(Self { builder, builder_consensus, batcher, client, client_consensus })
+        // 7. Start shadow sequencers, each peered to the active sequencer.
+        let active_consensus_p2p_addr = builder_consensus.p2p_addr();
+        let mut shadow_sequencers = Vec::with_capacity(config.shadow_sequencer_keys.len());
+        for (index, shadow_key) in config.shadow_sequencer_keys.iter().enumerate() {
+            let shadow = ShadowSequencer::start(ShadowSequencerConfig {
+                index,
+                sequencer_key: *shadow_key,
+                l2_genesis: config.l2_genesis.clone(),
+                rollup_config: rollup_config.clone(),
+                l1_chain_config: l1_chain_config.clone(),
+                jwt_secret: config.jwt_secret,
+                l1_rpc_url: l1_rpc_url.clone(),
+                l1_beacon_url: l1_beacon_url.clone(),
+                active_consensus_p2p_addr: active_consensus_p2p_addr.clone(),
+            })
+            .await
+            .wrap_err_with(|| format!("Failed to start shadow sequencer {index}"))?;
+            shadow_sequencers.push(shadow);
+        }
+
+        Ok(Self {
+            builder,
+            builder_consensus,
+            batcher,
+            client,
+            client_consensus,
+            shadow_sequencers,
+        })
     }
 
     /// Returns a reference to the in-process builder.
@@ -302,6 +337,16 @@ impl L2Stack {
     /// Returns a reference to the client's consensus node.
     pub const fn client_consensus(&self) -> &L2ClientConsensus {
         &self.client_consensus
+    }
+
+    /// Returns the shadow sequencers running alongside the active sequencer.
+    pub fn shadow_sequencers(&self) -> &[ShadowSequencer] {
+        &self.shadow_sequencers
+    }
+
+    /// Returns the shadow sequencer at `index`, if present.
+    pub fn shadow_sequencer(&self, index: usize) -> Option<&ShadowSequencer> {
+        self.shadow_sequencers.get(index)
     }
 
     /// Returns the builder's HTTP RPC URL.

--- a/etc/systems/src/lib.rs
+++ b/etc/systems/src/lib.rs
@@ -50,7 +50,8 @@ pub use l2::{
     InProcessBatcher, InProcessBatcherConfig, InProcessBuilder, InProcessBuilderConfig,
     InProcessClient, InProcessClientConfig, InProcessConsensus, InProcessConsensusConfig,
     InProcessFollowConsensus, InProcessFollowConsensusConfig, L2ClientConsensus,
-    L2ClientConsensusMode, L2ContainerConfig, L2Stack, L2StackConfig,
+    L2ClientConsensusMode, L2ContainerConfig, L2Stack, L2StackConfig, ShadowSequencer,
+    ShadowSequencerConfig,
 };
 
 mod network;

--- a/etc/systems/src/smoke.rs
+++ b/etc/systems/src/smoke.rs
@@ -3,12 +3,14 @@
 use std::path::PathBuf;
 
 use alloy_network::Ethereum;
+use alloy_primitives::B256;
 use alloy_provider::RootProvider;
 use alloy_rpc_client::RpcClient;
 use alloy_rpc_types_engine::JwtSecret;
+use alloy_signer_local::PrivateKeySigner;
 use base_common_network::Base;
 use base_tx_forwarding::TxForwardingConfig;
-use eyre::{Result, WrapErr};
+use eyre::{OptionExt, Result, WrapErr};
 use tempfile::TempDir;
 use url::Url;
 
@@ -109,6 +111,22 @@ impl SystemTestStack {
         Ok(RootProvider::<Base>::new(client))
     }
 
+    /// Returns the number of shadow sequencers running in this stack.
+    pub fn shadow_sequencer_count(&self) -> usize {
+        self.l2_stack().shadow_sequencers().len()
+    }
+
+    /// Returns a builder provider for the shadow sequencer at `index`.
+    pub fn l2_shadow_builder_provider(&self, index: usize) -> Result<RootProvider<Base>> {
+        let shadow = self
+            .l2_stack()
+            .shadow_sequencer(index)
+            .ok_or_eyre("no shadow sequencer at the requested index")?;
+        let url = shadow.rpc_url()?;
+        let client = RpcClient::builder().http(url);
+        Ok(RootProvider::<Base>::new(client))
+    }
+
     /// Returns all RPC URLs for this system test stack.
     pub async fn urls(&self) -> Result<crate::SystemTestUrls> {
         Ok(crate::SystemTestUrls {
@@ -136,6 +154,7 @@ pub struct SystemTestStackBuilder {
     tx_forwarding_config: Option<TxForwardingConfig>,
     verifier_l1_confs: u64,
     client_consensus_mode: L2ClientConsensusMode,
+    shadow_sequencer_count: usize,
 }
 
 impl SystemTestStackBuilder {
@@ -216,6 +235,16 @@ impl SystemTestStackBuilder {
     /// Runs the L2 client consensus node in follow mode against the builder RPC.
     pub const fn with_follow_mode_client_consensus(mut self) -> Self {
         self.client_consensus_mode = L2ClientConsensusMode::Follow;
+        self
+    }
+
+    /// Runs `count` shadow sequencers alongside the active sequencer.
+    ///
+    /// Each shadow sequencer builds real blocks from its own mempool but signs
+    /// them with a distinct key, so its blocks are non-canonical to the rest of
+    /// the network.
+    pub const fn with_shadow_sequencers(mut self, count: usize) -> Self {
+        self.shadow_sequencer_count = count;
         self
     }
 
@@ -321,6 +350,12 @@ impl SystemTestStackBuilder {
         let l1_genesis_bytes =
             std::fs::read(l1_genesis.el_genesis_path()).wrap_err("Failed to read L1 genesis")?;
 
+        let shadow_sequencer_keys: Vec<B256> = (0..self.shadow_sequencer_count)
+            .map(|_| {
+                B256::from_slice(PrivateKeySigner::random().credential().to_bytes().as_slice())
+            })
+            .collect();
+
         let l2_config = L2StackConfig {
             l2_genesis: l2_genesis_bytes,
             rollup_config: rollup_config_bytes,
@@ -335,6 +370,7 @@ impl SystemTestStackBuilder {
             tx_forwarding_config: self.tx_forwarding_config,
             verifier_l1_confs: self.verifier_l1_confs,
             client_consensus_mode: self.client_consensus_mode,
+            shadow_sequencer_keys,
         };
 
         let l2_stack = L2Stack::start(l2_config).await.wrap_err("Failed to start L2 stack")?;

--- a/etc/systems/tests/shadow_sequencer.rs
+++ b/etc/systems/tests/shadow_sequencer.rs
@@ -1,0 +1,209 @@
+//! System tests for shadow sequencers.
+//!
+//! A shadow sequencer builds real blocks from its own mempool but signs them
+//! with a distinct key, so the rest of the network treats those blocks as
+//! non-canonical. These tests assert that a shadow sequencer builds blocks
+//! successfully while the canonical chain tip continues to reflect the active
+//! sequencer.
+
+use std::time::{Duration, Instant};
+
+use alloy_consensus::SignableTransaction;
+use alloy_eips::eip2718::Encodable2718;
+use alloy_network::TransactionBuilder;
+use alloy_primitives::{Address, B256, Bytes, U256};
+use alloy_provider::{Provider, RootProvider};
+use alloy_signer::SignerSync;
+use alloy_signer_local::PrivateKeySigner;
+use base_common_network::Base;
+use base_common_rpc_types::BaseTransactionRequest;
+use base_system_tests::{ANVIL_ACCOUNT_1, ANVIL_ACCOUNT_2, SystemTestStackBuilder};
+use eyre::{Result, WrapErr};
+use tokio::time::{sleep, timeout};
+
+const L1_CHAIN_ID: u64 = 1337;
+const L2_CHAIN_ID: u64 = 84538453;
+const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(30);
+const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
+const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(60);
+const NON_CANONICAL_OBSERVATION_WINDOW: Duration = Duration::from_secs(15);
+const SHADOW_REORG_TIMEOUT: Duration = Duration::from_secs(30);
+
+static SHADOW_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+#[tokio::test]
+async fn shadow_builds_blocks_but_canonical_tip_reflects_active() -> Result<()> {
+    let _guard = SHADOW_TEST_LOCK.lock().await;
+    let system = SystemTestStackBuilder::new()
+        .with_l1_chain_id(L1_CHAIN_ID)
+        .with_l2_chain_id(L2_CHAIN_ID)
+        .with_shadow_sequencers(1)
+        .build()
+        .await?;
+
+    assert_eq!(system.shadow_sequencer_count(), 1, "expected exactly one shadow sequencer");
+
+    let active_builder = system.l2_builder_provider()?;
+    let client = system.l2_client_provider()?;
+    let shadow_builder = system.l2_shadow_builder_provider(0)?;
+
+    wait_for_block(&active_builder, 2).await.wrap_err("active sequencer did not produce blocks")?;
+    wait_for_block(&shadow_builder, 2).await.wrap_err("shadow sequencer did not produce blocks")?;
+
+    let active_sender = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_1.private_key)
+        .wrap_err("failed to parse active-path signer")?;
+    wait_for_balance(&active_builder, active_sender.address()).await?;
+    wait_for_balance(&client, active_sender.address()).await?;
+    let canonical_nonce = client.get_transaction_count(active_sender.address()).await?;
+    let canonical_tx =
+        send_transfer(&client, &active_sender, canonical_nonce, dead_address(0x01)).await?;
+    wait_for_receipt(&active_builder, canonical_tx, TX_RECEIPT_TIMEOUT)
+        .await
+        .wrap_err("canonical tx never landed on the active sequencer")?;
+    wait_for_receipt(&client, canonical_tx, TX_RECEIPT_TIMEOUT)
+        .await
+        .wrap_err("canonical tx never landed on the client")?;
+
+    // Send a transaction that only the shadow sequencer sees. The shadow builder
+    // runs an isolated execution layer, so this transaction never reaches the
+    // active sequencer's mempool.
+    let shadow_sender = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_2.private_key)
+        .wrap_err("failed to parse shadow-path signer")?;
+    wait_for_balance(&shadow_builder, shadow_sender.address()).await?;
+    let shadow_nonce = shadow_builder.get_transaction_count(shadow_sender.address()).await?;
+    let shadow_tx =
+        send_transfer(&shadow_builder, &shadow_sender, shadow_nonce, dead_address(0x02)).await?;
+
+    let shadow_receipt = wait_for_receipt(&shadow_builder, shadow_tx, TX_RECEIPT_TIMEOUT)
+        .await
+        .wrap_err("shadow sequencer failed to build a block containing the shadow-only tx")?;
+    assert!(
+        shadow_receipt.inner.block_number.is_some(),
+        "shadow receipt should reference a block number",
+    );
+
+    assert_never_included(&active_builder, shadow_tx, NON_CANONICAL_OBSERVATION_WINDOW)
+        .await
+        .wrap_err("shadow-only tx unexpectedly appeared on the active sequencer")?;
+    assert_never_included(&client, shadow_tx, NON_CANONICAL_OBSERVATION_WINDOW)
+        .await
+        .wrap_err("shadow-only tx unexpectedly appeared on the client")?;
+
+    // TARGET BEHAVIOR (future PR): once the shadow sequencer follows the
+    // canonical chain, it reorgs away its shadow-built blocks and forgets the
+    // shadow-only tx. This assertion is expected to FAIL today because the
+    // shadow reorg logic does not exist yet.
+    wait_for_shadow_to_forget(&shadow_builder, shadow_tx, SHADOW_REORG_TIMEOUT)
+        .await
+        .wrap_err("shadow sequencer did not reorg to canonical and forget its shadow-only tx")?;
+
+    Ok(())
+}
+
+const fn dead_address(byte: u8) -> Address {
+    Address::repeat_byte(byte)
+}
+
+async fn send_transfer(
+    provider: &RootProvider<Base>,
+    signer: &PrivateKeySigner,
+    nonce: u64,
+    recipient: Address,
+) -> Result<B256> {
+    let tx_request = BaseTransactionRequest::default()
+        .from(signer.address())
+        .to(recipient)
+        .value(U256::from(1_000_000_000u64))
+        .transaction_type(2)
+        .with_gas_limit(21000)
+        .with_max_fee_per_gas(1_000_000_000)
+        .with_max_priority_fee_per_gas(0)
+        .with_chain_id(L2_CHAIN_ID)
+        .with_nonce(nonce);
+
+    let tx = tx_request.build_typed_tx().map_err(|_| eyre::eyre!("invalid transaction request"))?;
+    let signature = signer.sign_hash_sync(&tx.signature_hash())?;
+    let signed_tx = tx.into_signed(signature);
+    let raw_tx: Bytes = signed_tx.encoded_2718().into();
+    let expected_hash = *signed_tx.hash();
+
+    let pending = provider.send_raw_transaction(&raw_tx).await.wrap_err("failed to send tx")?;
+    assert_eq!(*pending.tx_hash(), expected_hash, "transaction hash mismatch");
+    Ok(expected_hash)
+}
+
+async fn wait_for_block(provider: &RootProvider<Base>, min_block: u64) -> Result<u64> {
+    timeout(BLOCK_PRODUCTION_TIMEOUT, async {
+        loop {
+            let block = provider.get_block_number().await?;
+            if block >= min_block {
+                return Ok::<_, eyre::Error>(block);
+            }
+            sleep(BLOCK_POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .wrap_err("block production timed out")?
+}
+
+async fn wait_for_balance(provider: &RootProvider<Base>, address: Address) -> Result<()> {
+    timeout(Duration::from_secs(30), async {
+        loop {
+            if provider.get_balance(address).await? > U256::ZERO {
+                return Ok::<_, eyre::Error>(());
+            }
+            sleep(BLOCK_POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .wrap_err("timed out waiting for a funded account")?
+}
+
+async fn wait_for_receipt(
+    provider: &RootProvider<Base>,
+    tx_hash: B256,
+    within: Duration,
+) -> Result<base_common_rpc_types::BaseTransactionReceipt> {
+    timeout(within, async {
+        loop {
+            if let Some(receipt) = provider.get_transaction_receipt(tx_hash).await? {
+                return Ok::<_, eyre::Error>(receipt);
+            }
+            sleep(Duration::from_secs(2)).await;
+        }
+    })
+    .await
+    .wrap_err("transaction receipt timed out")?
+}
+
+async fn assert_never_included(
+    provider: &RootProvider<Base>,
+    tx_hash: B256,
+    window: Duration,
+) -> Result<()> {
+    let deadline = Instant::now() + window;
+    while Instant::now() < deadline {
+        if provider.get_transaction_receipt(tx_hash).await?.is_some() {
+            eyre::bail!("transaction was included when it should not have been");
+        }
+        sleep(BLOCK_POLL_INTERVAL).await;
+    }
+    Ok(())
+}
+
+async fn wait_for_shadow_to_forget(
+    provider: &RootProvider<Base>,
+    tx_hash: B256,
+    within: Duration,
+) -> Result<()> {
+    timeout(within, async {
+        loop {
+            if provider.get_transaction_receipt(tx_hash).await?.is_none() {
+                return Ok::<_, eyre::Error>(());
+            }
+            sleep(Duration::from_secs(2)).await;
+        }
+    })
+    .await
+    .wrap_err("shadow sequencer still reports the shadow-only tx as included")?
+}

--- a/etc/systems/tests/shadow_sequencer.rs
+++ b/etc/systems/tests/shadow_sequencer.rs
@@ -16,7 +16,7 @@ use alloy_provider::{Provider, RootProvider};
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use base_common_network::Base;
-use base_common_rpc_types::BaseTransactionRequest;
+use base_common_rpc_types::{BaseTransactionReceipt, BaseTransactionRequest};
 use base_system_tests::{ANVIL_ACCOUNT_1, ANVIL_ACCOUNT_2, SystemTestStackBuilder};
 use eyre::{Result, WrapErr};
 use tokio::time::{sleep, timeout};
@@ -26,6 +26,7 @@ const L2_CHAIN_ID: u64 = 84538453;
 const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(30);
 const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(60);
+const BALANCE_SYNC_TIMEOUT: Duration = Duration::from_secs(30);
 const NON_CANONICAL_OBSERVATION_WINDOW: Duration = Duration::from_secs(15);
 const SHADOW_REORG_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -121,7 +122,9 @@ async fn send_transfer(
         .with_chain_id(L2_CHAIN_ID)
         .with_nonce(nonce);
 
-    let tx = tx_request.build_typed_tx().map_err(|_| eyre::eyre!("invalid transaction request"))?;
+    let tx = tx_request
+        .build_typed_tx()
+        .map_err(|e| eyre::eyre!("invalid transaction request: {e:?}"))?;
     let signature = signer.sign_hash_sync(&tx.signature_hash())?;
     let signed_tx = tx.into_signed(signature);
     let raw_tx: Bytes = signed_tx.encoded_2718().into();
@@ -147,7 +150,7 @@ async fn wait_for_block(provider: &RootProvider<Base>, min_block: u64) -> Result
 }
 
 async fn wait_for_balance(provider: &RootProvider<Base>, address: Address) -> Result<()> {
-    timeout(Duration::from_secs(30), async {
+    timeout(BALANCE_SYNC_TIMEOUT, async {
         loop {
             if provider.get_balance(address).await? > U256::ZERO {
                 return Ok::<_, eyre::Error>(());
@@ -163,7 +166,7 @@ async fn wait_for_receipt(
     provider: &RootProvider<Base>,
     tx_hash: B256,
     within: Duration,
-) -> Result<base_common_rpc_types::BaseTransactionReceipt> {
+) -> Result<BaseTransactionReceipt> {
     timeout(within, async {
         loop {
             if let Some(receipt) = provider.get_transaction_receipt(tx_hash).await? {


### PR DESCRIPTION
## Summary

Adds reusable system-test support for running **N shadow sequencers** alongside the active sequencer, plus a test asserting a shadow builds blocks while the canonical tip stays with the active sequencer.

## What

- `ShadowSequencer` / `ShadowSequencerConfig`: an isolated in-process builder + consensus (`NodeMode::Sequencer`) with its own **autogenerated** signing key.
- `L2Stack` starts a configurable number of shadows, each peered to the active consensus; `SystemTestStackBuilder::with_shadow_sequencers(n)` wires it up.
- New test `shadow_sequencer.rs`: shadow includes a shadow-only tx in a block (build works), while the tx never appears on the active sequencer or client (canonical tip reflects active).

## Why

- Distinct per-shadow keys make every shadow non-canonical to the rest of the network and keep shadows isolated from each other regardless of p2p topology.
- Prepares the harness for the upcoming shadow-block-builder work.

## Notes

- The final assertion encodes the **target behavior from a follow-up PR** (shadow reorgs to canonical and forgets its shadow-only tx). It is **expected to fail** until that logic lands.
- Related issue: _TBD — link before marking ready for review._

## Testing

- `cargo check -p base-system-tests --tests` and `cargo clippy -p base-system-tests --tests` pass.
- The container-based system test itself is not run in this PR (long-running; requires Docker).