### PR TITLE
refactor(consensus): collapse upgrade signal builder fields into one

### DIFF
--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -8,7 +8,10 @@ use alloy_rpc_types_engine::JwtSecret;
 use base_cli_utils::{LogConfig, RuntimeManager};
 use base_common_chains::ChainConfig;
 use base_common_genesis::RollupConfig;
-use base_consensus_node::{EngineConfig, L1ConfigBuilder, NodeMode, RollupNode, RollupNodeBuilder};
+use base_consensus_node::{
+    EngineConfig, L1ConfigBuilder, NodeMode, RollupNode, RollupNodeBuilder,
+    UpgradeSignalBuilderConfig,
+};
 use base_upgrade_signal::{
     UpgradeSignalArgs, UpgradeSignalConfig, UpgradeSignalMetricLayer, UpgradeSignalRuntimeApplier,
     UpgradeSignalRuntimeValidation, UpgradeSignalSchedule, UpgradeSignalStartupMode,
@@ -486,9 +489,11 @@ impl ConsensusNodeArgs {
             rpc_config,
         )
         .with_sequencer_config(self.config.sequencer_flags.config())
-        .with_upgrade_signal_metrics_config(upgrade_signal_config)
-        .with_upgrade_signal_runtime_validation(Some(runtime_validation))
-        .with_upgrade_signal_l1_rpc(upgrade_signal_l1_rpc);
+        .with_upgrade_signal_config(UpgradeSignalBuilderConfig {
+            metrics_config: upgrade_signal_config,
+            l1_rpc: upgrade_signal_l1_rpc,
+            runtime_validation: Some(runtime_validation),
+        });
 
         if let Some(path) = self.config.checkpoint_path.clone() {
             builder = builder.with_checkpoint_path(path);

--- a/crates/consensus/service/src/lib.rs
+++ b/crates/consensus/service/src/lib.rs
@@ -13,6 +13,7 @@ mod service;
 pub use service::{
     DerivationDelegateConfig, FollowNode, FollowNodeConfig, HEAD_STREAM_POLL_INTERVAL, L1Config,
     L1ConfigBuilder, NodeMode, RollupNode, RollupNodeBuilder, ShutdownSignal,
+    UpgradeSignalBuilderConfig,
 };
 
 mod follow;

--- a/crates/consensus/service/src/service/builder.rs
+++ b/crates/consensus/service/src/service/builder.rs
@@ -18,6 +18,17 @@ use crate::{
     actors::DerivationDelegateClient, service::node::L1Config,
 };
 
+/// Upgrade signal configuration for the [`RollupNodeBuilder`].
+#[derive(Debug, Clone, Default)]
+pub struct UpgradeSignalBuilderConfig {
+    /// Optional L1 upgrade signal metrics observer configuration.
+    pub metrics_config: Option<UpgradeSignalConfig>,
+    /// Optional L1 RPC endpoint override for upgrade signal reads.
+    pub l1_rpc: Option<Url>,
+    /// Optional runtime upgrade signal validation context.
+    pub runtime_validation: Option<UpgradeSignalRuntimeValidation>,
+}
+
 /// Configuration for Derivation Delegate mode.
 #[derive(Debug, Clone)]
 pub struct DerivationDelegateConfig {
@@ -84,12 +95,8 @@ pub struct RollupNodeBuilder {
     /// When set, enables persistent safe head tracking via redb and serves
     /// `optimism_safeHeadAtL1Block` RPC requests from the database.
     pub safedb_path: Option<PathBuf>,
-    /// Optional L1 upgrade signal metrics observer configuration.
-    pub upgrade_signal_metrics_config: Option<UpgradeSignalConfig>,
-    /// Optional L1 RPC endpoint override for upgrade signal reads.
-    pub upgrade_signal_l1_rpc: Option<Url>,
-    /// Optional runtime upgrade signal validation context.
-    pub upgrade_signal_runtime_validation: Option<UpgradeSignalRuntimeValidation>,
+    /// Upgrade signal configuration.
+    pub upgrade_signal_config: UpgradeSignalBuilderConfig,
 }
 
 impl RollupNodeBuilder {
@@ -128,9 +135,11 @@ impl RollupNodeBuilder {
             finalized_poll_interval: None,
             checkpoint_path: None,
             safedb_path: None,
-            upgrade_signal_metrics_config: None,
-            upgrade_signal_l1_rpc: None,
-            upgrade_signal_runtime_validation: None,
+            upgrade_signal_config: UpgradeSignalBuilderConfig {
+                metrics_config: None,
+                l1_rpc: None,
+                runtime_validation: None,
+            },
         }
     }
 
@@ -177,22 +186,9 @@ impl RollupNodeBuilder {
         Self { checkpoint_path: Some(path), ..self }
     }
 
-    /// Sets the optional L1 upgrade signal metrics observer configuration.
-    pub fn with_upgrade_signal_metrics_config(self, config: Option<UpgradeSignalConfig>) -> Self {
-        Self { upgrade_signal_metrics_config: config, ..self }
-    }
-
-    /// Sets the optional L1 RPC endpoint override for upgrade signal reads.
-    pub fn with_upgrade_signal_l1_rpc(self, l1_rpc: Option<Url>) -> Self {
-        Self { upgrade_signal_l1_rpc: l1_rpc, ..self }
-    }
-
-    /// Sets the optional runtime upgrade signal validation context.
-    pub fn with_upgrade_signal_runtime_validation(
-        self,
-        validation: Option<UpgradeSignalRuntimeValidation>,
-    ) -> Self {
-        Self { upgrade_signal_runtime_validation: validation, ..self }
+    /// Sets the upgrade signal configuration.
+    pub fn with_upgrade_signal_config(self, config: UpgradeSignalBuilderConfig) -> Self {
+        Self { upgrade_signal_config: config, ..self }
     }
 
     /// Assembles the [`RollupNode`] service.
@@ -241,13 +237,13 @@ impl RollupNodeBuilder {
             )
         });
 
-        let upgrade_signal_config = self.upgrade_signal_metrics_config.map(|config| {
+        let upgrade_signal_config = self.upgrade_signal_config.metrics_config.map(|config| {
             UpgradeSignalNodeConfig::resolve(
                 config,
-                self.upgrade_signal_l1_rpc.as_ref(),
+                self.upgrade_signal_config.l1_rpc.as_ref(),
                 l1_config.engine_provider.clone(),
                 rollup_config.l2_chain_id.id(),
-                self.upgrade_signal_runtime_validation,
+                self.upgrade_signal_config.runtime_validation,
             )
         });
 

--- a/crates/consensus/service/src/service/mod.rs
+++ b/crates/consensus/service/src/service/mod.rs
@@ -4,7 +4,9 @@
 //! [`NodeActor`]: crate::NodeActor
 
 mod builder;
-pub use builder::{DerivationDelegateConfig, L1ConfigBuilder, RollupNodeBuilder};
+pub use builder::{
+    DerivationDelegateConfig, L1ConfigBuilder, RollupNodeBuilder, UpgradeSignalBuilderConfig,
+};
 
 pub use crate::follow::{FollowNode, FollowNodeConfig};
 


### PR DESCRIPTION
## Summary 
Groups the three upgrade-signal fields on RollupNodeBuilder (metrics config, L1 RPC override, runtime validation) into a single UpgradeSignalBuilderConfig struct with one setter, per review feedback.

ref:
https://github.com/base/base/pull/3726#discussion_r3466307483