### PR TITLE
feat(txpool): invalidate at flashblock cadence

### DIFF
--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -26,6 +26,7 @@ use base_common_flashblocks::{
 use base_execution_consensus::{calculate_receipt_root_no_memo, isthmus};
 use base_execution_evm::{BaseEvmConfig, BaseNextBlockEnvAttributes};
 use base_execution_payload_builder::{BaseBuiltPayload, BasePayloadBuilderAttributes};
+use base_execution_txpool::AccountStateDiff;
 use base_observability_events::{GlobalTransactionEventWriter, TransactionEventType};
 use eyre::WrapErr as _;
 use reth_basic_payload_builder::BuildOutcome;
@@ -300,7 +301,7 @@ where
         let skip_flashblocks_building = ctx.attributes().no_tx_pool || flashblocks_per_block == 0;
 
         let prev_flashblock_id = self.previous_flashblock_id();
-        let (payload, fb_payload) = build_block(
+        let (payload, fb_payload, state_diff) = build_block(
             &mut state,
             &ctx,
             &mut info,
@@ -329,6 +330,14 @@ where
                 .publish(&fb_payload, ctx.block_number(), 0)
                 .map_err(PayloadBuilderError::other)?;
             self.record_emitted_flashblock(ctx.block_number(), 0);
+            let invalidated = self.pool.invalidate_from_state_diff(&state_diff);
+            if invalidated > 0 {
+                debug!(
+                    target: "payload_builder",
+                    invalidated,
+                    "transactions invalidated after fallback flashblock publication"
+                );
+            }
             BuilderMetrics::flashblock_byte_size_histogram().record(flashblock_byte_size as f64);
             BuilderMetrics::first_flashblock_time_offset()
                 .record(first_flashblock_offset.as_millis() as f64);
@@ -711,7 +720,7 @@ where
                 BuilderMetrics::invalid_built_blocks_count().increment(1);
                 Err(err).wrap_err("failed to build payload")
             }
-            Ok((new_payload, mut fb_payload)) => {
+            Ok((new_payload, mut fb_payload, state_diff)) => {
                 fb_payload.index = flashblock_index;
                 fb_payload.base = None;
 
@@ -756,6 +765,18 @@ where
                         "Payload building complete, channel closed or job cancelled",
                     );
                     return Ok(None);
+                }
+
+                // Invalidate only after the synchronized publish check accepts
+                // this flashblock. An abandoned build must not evict transactions
+                // based on state that never became visible.
+                let invalidated = self.pool.invalidate_from_state_diff(&state_diff);
+                if invalidated > 0 {
+                    debug!(
+                        target: "payload_builder",
+                        invalidated,
+                        "transactions invalidated after flashblock publication"
+                    );
                 }
 
                 // Send to handler outside mutex.
@@ -919,7 +940,7 @@ where
         let start_time = Instant::now();
 
         // Build the final block WITH state root computed
-        let (final_payload, _) = build_block(state, ctx, info, FlashblockId::default(), true)?;
+        let (final_payload, _, _) = build_block(state, ctx, info, FlashblockId::default(), true)?;
 
         ctx.flush_rejected_txs(info);
         self.emit_final_inclusion_events(ctx, &final_payload);
@@ -1086,7 +1107,7 @@ pub(crate) fn build_block<DB, P>(
     info: &mut ExecutionInfo,
     prev_flashblock_id: FlashblockId,
     calculate_state_root: bool,
-) -> Result<(BaseBuiltPayload, FlashblocksPayloadV1), PayloadBuilderError>
+) -> Result<(BaseBuiltPayload, FlashblocksPayloadV1, Vec<AccountStateDiff>), PayloadBuilderError>
 where
     DB: Database<Error = ProviderError> + AsRef<P> + revm::Database,
     P: StateRootProvider + HashedPostStateProvider + StorageRootProvider,
@@ -1213,7 +1234,10 @@ where
     let recovered_block =
         RecoveredBlock::new_unhashed(block.clone(), info.executed_senders.clone());
 
-    // Read account balances BEFORE take_bundle() empties the bundle state.
+    // Read the invalidation diff before take_bundle() empties the bundle state.
+    // The builder prunes included transactions itself, so nonce advances are
+    // omitted to avoid evicting valid successors promoted in the same lane.
+    let state_diff = AccountStateDiff::collect_for_intra_block(&state.bundle_state);
     let new_account_balances = state
         .bundle_state
         .state
@@ -1323,6 +1347,7 @@ where
             None,
         ),
         fb_payload,
+        state_diff,
     ))
 }
 
@@ -1385,7 +1410,7 @@ mod tests {
         let mut state = State::builder().with_database(db).with_bundle_update().build();
         let mut info = ExecutionInfo::default();
 
-        let (payload, fb_payload) = build_block::<_, NoopProvider>(
+        let (payload, fb_payload, state_diff) = build_block::<_, NoopProvider>(
             &mut state,
             &ctx,
             &mut info,
@@ -1402,6 +1427,7 @@ mod tests {
 
         // The flashblocks payload must reference the same block.
         assert_eq!(fb_payload.diff.block_hash, payload.block().hash(), "hash mismatch");
+        assert!(state_diff.is_empty(), "empty block must produce no invalidation diff");
     }
 
     /// Verify that [`build_block`] exercises the state root calculation path
@@ -1422,7 +1448,7 @@ mod tests {
         let mut state = State::builder().with_database(db).with_bundle_update().build();
         let mut info = ExecutionInfo::default();
 
-        let (payload, _fb_payload) = build_block::<_, NoopProvider>(
+        let (payload, _fb_payload, state_diff) = build_block::<_, NoopProvider>(
             &mut state,
             &ctx,
             &mut info,
@@ -1430,6 +1456,8 @@ mod tests {
             true,
         )
         .expect("build_block with state root should succeed");
+
+        assert!(state_diff.is_empty(), "empty block must produce no invalidation diff");
 
         // NoopProvider returns B256::default() for all state root queries,
         // which equals B256::ZERO.

--- a/crates/builder/core/src/traits.rs
+++ b/crates/builder/core/src/traits.rs
@@ -3,7 +3,9 @@
 use alloy_consensus::Header;
 use base_common_consensus::{BasePrimitives, BaseTransactionSigned};
 use base_execution_chainspec::BaseChainSpec;
-use base_execution_txpool::{BasePooledTx, BundleTransaction, TimestampedTransaction};
+use base_execution_txpool::{
+    BasePooledTx, BundleTransaction, StateDiffInvalidation, TimestampedTransaction,
+};
 use base_node_core::BaseEngineTypes;
 use reth_node_api::{FullNodeTypes, NodeTypes};
 use reth_payload_util::PayloadTransactions;
@@ -40,6 +42,7 @@ pub trait PoolBounds:
                          + BundleTransaction
                          + TimestampedTransaction,
     > + TransactionPoolExt
+    + StateDiffInvalidation
     + Unpin
     + 'static
 where
@@ -55,6 +58,7 @@ where
                              + BundleTransaction
                              + TimestampedTransaction,
         > + TransactionPoolExt
+        + StateDiffInvalidation
         + Unpin
         + 'static,
     <Self as TransactionPool>::Transaction:

--- a/crates/execution/txpool/src/state_diff_maintain.rs
+++ b/crates/execution/txpool/src/state_diff_maintain.rs
@@ -5,6 +5,7 @@
 //! deltas into the EIP-8130 invalidation index.
 
 use alloy_primitives::{B256, U256};
+use base_common_precompiles::NonceManagerStorage;
 use futures::StreamExt;
 use reth_provider::CanonStateNotification;
 use revm::database::BundleState;
@@ -110,6 +111,29 @@ impl AccountStateDiff {
         }
         diffs
     }
+
+    /// Collects watched state changes between flashblocks.
+    ///
+    /// Protocol and channel nonce advances are omitted because the builder has
+    /// already pruned each included transaction, promoting the valid successor
+    /// in that pool lane. Treating an included transaction's nonce advance as
+    /// external invalidation would immediately evict that successor. This is a
+    /// deliberately coarse intra-block filter: canonical invalidation remains
+    /// conservative for unrelated protocol-nonce or nonce-manager writes.
+    #[must_use]
+    pub fn collect_for_intra_block(bundle: &BundleState) -> Vec<Self> {
+        Self::collect(bundle)
+            .into_iter()
+            .filter_map(|mut diff| {
+                diff.nonce_changed = false;
+                if diff.address == NonceManagerStorage::ADDRESS {
+                    diff.changed_slots.clear();
+                }
+                (diff.balance.is_some() || diff.code_changed || !diff.changed_slots.is_empty())
+                    .then_some(diff)
+            })
+            .collect()
+    }
 }
 
 #[cfg(test)]
@@ -186,5 +210,68 @@ mod tests {
         let bundle = bundle(vec![(address, account(Some(info(100, 0)), None, vec![]))]);
         let diffs = AccountStateDiff::collect(&bundle);
         assert_eq!(diffs[0].balance, Some(U256::ZERO));
+    }
+
+    #[test]
+    fn intra_block_diff_omits_protocol_and_channel_nonce_advances() {
+        let sender = Address::repeat_byte(2);
+        let nonce_slot = U256::from(9);
+        let changed_slot =
+            StorageSlot { previous_or_original_value: U256::ZERO, present_value: U256::from(1) };
+        let bundle = bundle(vec![
+            (sender, account(Some(info(100, 1)), Some(info(100, 2)), vec![])),
+            (
+                NonceManagerStorage::ADDRESS,
+                account(Some(info(0, 0)), Some(info(0, 0)), vec![(nonce_slot, changed_slot)]),
+            ),
+        ]);
+
+        assert!(
+            AccountStateDiff::collect_for_intra_block(&bundle).is_empty(),
+            "included nonce advances must not evict newly promoted successors"
+        );
+    }
+
+    #[test]
+    fn intra_block_diff_retains_non_nonce_surfaces() {
+        let account_address = Address::repeat_byte(3);
+        let contract = Address::repeat_byte(4);
+        let contract_slot = U256::from(10);
+        let changed_slot =
+            StorageSlot { previous_or_original_value: U256::ZERO, present_value: U256::from(1) };
+        let bundle = bundle(vec![
+            (account_address, account(Some(info(100, 1)), Some(info(50, 2)), vec![])),
+            (
+                NonceManagerStorage::ADDRESS,
+                account(Some(info(100, 0)), Some(info(50, 0)), vec![(U256::from(9), changed_slot)]),
+            ),
+            (
+                contract,
+                account(
+                    Some(info(100, 0)),
+                    Some(info(100, 0)),
+                    vec![(contract_slot, changed_slot)],
+                ),
+            ),
+        ]);
+
+        let diffs = AccountStateDiff::collect_for_intra_block(&bundle);
+        let account_diff = diffs
+            .iter()
+            .find(|diff| diff.address == account_address)
+            .expect("balance diff retained");
+        assert_eq!(account_diff.balance, Some(U256::from(50)));
+        assert!(!account_diff.nonce_changed);
+
+        let nonce_manager_diff = diffs
+            .iter()
+            .find(|diff| diff.address == NonceManagerStorage::ADDRESS)
+            .expect("nonce manager balance diff retained");
+        assert_eq!(nonce_manager_diff.balance, Some(U256::from(50)));
+        assert!(nonce_manager_diff.changed_slots.is_empty());
+
+        let contract_diff =
+            diffs.iter().find(|diff| diff.address == contract).expect("contract slot retained");
+        assert_eq!(contract_diff.changed_slots, vec![B256::from(contract_slot)]);
     }
 }


### PR DESCRIPTION
## Summary

- return EIP-8130 watched state changes from flashblock block construction
- invalidate guarded transactions only after a flashblock is accepted and published
- suppress intra-block protocol/channel nonce changes so pruning an included transaction does not evict its promoted successor
- retain balance, code, and non-nonce storage invalidation for finite-channel and nonce-free transactions

## Safety

Canceled or abandoned flashblock builds never feed their state diff. Canonical invalidation from the parent PR remains the conservative fallback for commits, reorgs, and state-feed gaps.

Stacked on #4002.