### PR TITLE
feat(upgrade-signal): auto-apply live L1 updates in runtime-admin mode

### DIFF
--- a/crates/consensus/service/src/actors/upgrade_signal.rs
+++ b/crates/consensus/service/src/actors/upgrade_signal.rs
@@ -8,7 +8,7 @@ use base_upgrade_signal::{
     UpgradeSignalRuntimeValidation,
 };
 use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::warn;
 use url::Url;
 
 use crate::NodeActor;
@@ -45,9 +45,18 @@ impl UpgradeSignalNodeConfig {
         Self { config, l1_provider, chain_id, runtime_validation }
     }
 
-    /// Builds the consensus metrics actor.
-    pub fn metrics_actor(&self, cancellation: CancellationToken) -> UpgradeSignalMetricsActor {
-        UpgradeSignalMetricsActor::new(self.config.clone(), self.l1_provider.clone(), cancellation)
+    /// Builds the consensus metrics actor, with live auto-apply when runtime refresh is enabled.
+    pub fn metrics_actor(
+        &self,
+        refresher: Option<UpgradeSignalRefresher>,
+        cancellation: CancellationToken,
+    ) -> UpgradeSignalMetricsActor {
+        UpgradeSignalMetricsActor::new(
+            self.config.clone(),
+            self.l1_provider.clone(),
+            refresher,
+            cancellation,
+        )
     }
 
     /// Builds the runtime admin refresher when enabled.
@@ -64,7 +73,8 @@ impl UpgradeSignalNodeConfig {
     }
 }
 
-/// Actor that records live L1 upgrade signal metrics without mutating node configuration.
+/// Actor that records live L1 upgrade signal metrics and, when runtime refresh is enabled,
+/// automatically re-applies the schedule on observed L1 changes.
 #[derive(Debug)]
 pub struct UpgradeSignalMetricsActor {
     /// L1 upgrade signal reader.
@@ -73,6 +83,8 @@ pub struct UpgradeSignalMetricsActor {
     pub upgrade_ids: Vec<BaseUpgrade>,
     /// Live metrics state.
     pub monitor: UpgradeSignalMonitor,
+    /// Runtime refresher applied automatically on observed live updates, when enabled.
+    pub refresher: Option<UpgradeSignalRefresher>,
     /// Cancellation token shared with the rollup node.
     pub cancellation: CancellationToken,
 }
@@ -82,23 +94,29 @@ impl UpgradeSignalMetricsActor {
     pub fn new(
         config: UpgradeSignalConfig,
         l1_provider: RootProvider,
+        refresher: Option<UpgradeSignalRefresher>,
         cancellation: CancellationToken,
     ) -> Self {
         let reader = config.reader(l1_provider);
         let monitor =
             UpgradeSignalMonitor::new(UpgradeSignalMetricLayer::Consensus, &config.upgrade_ids);
 
-        Self { reader, upgrade_ids: config.upgrade_ids, monitor, cancellation }
+        Self { reader, upgrade_ids: config.upgrade_ids, monitor, refresher, cancellation }
     }
 
-    /// Polls L1 upgrade signal state and records metrics without mutating local config.
+    /// Polls L1 upgrade signal state, records metrics, and auto-applies observed changes when
+    /// runtime refresh is enabled.
     pub async fn poll_l1_signal(&mut self) {
-        let updated_signals = self.monitor.poll(&self.reader, &self.upgrade_ids).await;
-        if updated_signals > 0 {
-            info!(
+        let Some(schedule) = self.monitor.poll(&self.reader, &self.upgrade_ids).await else {
+            return;
+        };
+        if let Some(refresher) = &self.refresher
+            && let Err(error) = refresher.apply(&schedule)
+        {
+            warn!(
                 target: "upgrade_signal",
-                updated_signals,
-                "observed live L1 upgrade signal update"
+                error = %error,
+                "failed to auto-apply live upgrade signal update"
             );
         }
     }

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -535,10 +535,14 @@ impl RollupNode {
             derivation_origin_rx,
             cancellation.clone(),
         );
-        let upgrade_signal_metrics_actor =
-            self.upgrade_signal_config.as_ref().map(|c| c.metrics_actor(cancellation.clone()));
+        // One refresher instance is shared between the metrics actor (live auto-apply) and the
+        // sequencer admin RPC.
         let upgrade_signal_refresher =
             self.upgrade_signal_config.as_ref().and_then(|c| c.refresher());
+        let upgrade_signal_metrics_actor = self
+            .upgrade_signal_config
+            .as_ref()
+            .map(|c| c.metrics_actor(upgrade_signal_refresher.clone(), cancellation.clone()));
         let node_mode = self.mode();
         // Create the sequencer if needed
         let (sequencer_actor, sequencer_admin_client) = if node_mode.is_sequencer() {

--- a/crates/execution/cli/Cargo.toml
+++ b/crates/execution/cli/Cargo.toml
@@ -41,7 +41,6 @@ base-flashblocks.workspace = true
 base-node-runner.workspace = true
 base-observability-events.workspace = true
 base-common-chains.workspace = true
-base-common-genesis.workspace = true
 base-execution-evm.workspace = true
 base-tx-forwarding.workspace = true
 base-txpool-tracing.workspace = true
@@ -79,6 +78,7 @@ base-common-consensus = { workspace = true, features = ["reth"] }
 
 [dev-dependencies]
 alloy-primitives.workspace = true
+base-common-genesis.workspace = true
 rstest.workspace = true
 tempfile.workspace = true
 axum = { workspace = true, features = ["tokio", "http1"] }
@@ -118,7 +118,6 @@ serde = [
 	"alloy-eips/serde",
 	"base-common-chains/serde",
 	"base-common-consensus/serde",
-	"base-common-genesis/serde",
 	"base-execution-chainspec/serde",
 	"reth-network/serde",
 	"secp256k1/serde",

--- a/crates/execution/cli/src/upgrade_signal.rs
+++ b/crates/execution/cli/src/upgrade_signal.rs
@@ -1,12 +1,11 @@
 //! Execution-node upgrade signal schedule application.
 
 use alloy_provider::RootProvider;
-use base_common_genesis::BaseUpgrade;
 use base_execution_chainspec::BaseChainSpec;
 use base_node_runner::{BaseNodeExtension, BaseRpcContext, FromExtensionConfig, NodeHooks};
 use base_upgrade_signal::{
-    AlloyUpgradeSignalReader, UpgradeSignalApplySummary, UpgradeSignalConfig,
-    UpgradeSignalDefaults, UpgradeSignalMetricLayer, UpgradeSignalMonitor, UpgradeSignalRefresher,
+    UpgradeSignalApplySummary, UpgradeSignalConfig, UpgradeSignalDefaults,
+    UpgradeSignalMetricLayer, UpgradeSignalMonitor, UpgradeSignalRefresher,
     UpgradeSignalRuntimeApplier, UpgradeSignalRuntimeValidation, UpgradeSignalSchedule,
 };
 use jsonrpsee::{RpcModule, core::RpcResult, types::ErrorObject};
@@ -80,38 +79,15 @@ impl ExecutionUpgradeSignal {
     pub async fn refresh_runtime_upgrade_signal(
         refresher: &ExecutionUpgradeSignalRuntimeRefresher,
     ) -> RpcResult<UpgradeSignalApplySummary> {
-        match refresher.refresher.read_validated_schedule().await {
-            Ok(schedule) => {
-                if let Err(error) =
-                    Self::validate_runtime_schedule_for_chain_spec(&refresher.chain_spec, &schedule)
-                {
-                    warn!(
-                        target: "upgrade_signal",
-                        error = %error,
-                        "failed to validate execution runtime upgrade signal"
-                    );
-                    return Err(ErrorObject::owned(
-                        -32005,
-                        "failed to validate upgrade signal",
-                        None::<()>,
-                    ));
-                }
-                let summary = UpgradeSignalRuntimeApplier::apply_schedule(
-                    refresher.refresher.chain_id,
-                    &schedule,
-                );
-                info!(
+        match refresher.refresher.read_schedule().await {
+            Ok(schedule) => refresher.apply(&schedule).map_err(|error| {
+                warn!(
                     target: "upgrade_signal",
-                    chain_id = summary.chain_id,
-                    l1_block_number = ?summary.l1_block_number,
-                    applied_upgrades = summary.applied_upgrades,
-                    cleared_upgrades = summary.cleared_upgrades,
-                    ignored_upgrades = summary.ignored_upgrades,
-                    configured_upgrades = summary.configured_upgrades,
-                    "refreshed execution runtime upgrade signal"
+                    error = %error,
+                    "failed to validate execution runtime upgrade signal"
                 );
-                Ok(summary)
-            }
+                ErrorObject::owned(-32005, "failed to validate upgrade signal", None::<()>)
+            }),
             Err(error) => {
                 warn!(
                     target: "upgrade_signal",
@@ -133,8 +109,8 @@ impl ExecutionUpgradeSignal {
         }
 
         let chain_id = ctx.config().chain.chain().id();
-        // Execution validates each refresh against the live chain spec in
-        // `refresh_runtime_upgrade_signal`, so the shared refresher itself stays unvalidated.
+        // Chain-spec validation happens per-apply in the execution wrapper, so the shared
+        // refresher itself carries no runtime validation.
         let refresher = ExecutionUpgradeSignalRuntimeRefresher::new(
             UpgradeSignalRefresher::new(
                 config.signal_config,
@@ -171,6 +147,18 @@ impl ExecutionUpgradeSignalRuntimeRefresher {
     pub const fn new(refresher: UpgradeSignalRefresher, chain_spec: BaseChainSpec) -> Self {
         Self { refresher, chain_spec }
     }
+
+    /// Validates an already-read schedule against the execution chain spec and applies it.
+    pub fn apply(
+        &self,
+        schedule: &UpgradeSignalSchedule,
+    ) -> eyre::Result<UpgradeSignalApplySummary> {
+        ExecutionUpgradeSignal::validate_runtime_schedule_for_chain_spec(
+            &self.chain_spec,
+            schedule,
+        )?;
+        Ok(self.refresher.apply(schedule)?)
+    }
 }
 
 /// Execution-node extension that registers runtime admin refresh and optional live metrics.
@@ -184,22 +172,6 @@ impl ExecutionUpgradeSignalRuntimeExtension {
     /// Creates a new execution upgrade signal runtime extension.
     pub const fn new(config: ExecutionUpgradeSignalConfig) -> Self {
         Self { config }
-    }
-
-    /// Polls L1 upgrade signal state and records metrics without mutating local config.
-    pub async fn poll_l1_signal(
-        monitor: &mut UpgradeSignalMonitor,
-        reader: &AlloyUpgradeSignalReader,
-        upgrade_ids: &[BaseUpgrade],
-    ) {
-        let updated_upgrades = monitor.poll(reader, upgrade_ids).await;
-        if updated_upgrades > 0 {
-            info!(
-                target: "upgrade_signal",
-                updated_upgrades,
-                "observed live L1 upgrade signal update"
-            );
-        }
     }
 }
 
@@ -217,9 +189,23 @@ impl BaseNodeExtension for ExecutionUpgradeSignalRuntimeExtension {
         };
 
         hooks.add_node_started_hook(move |ctx| {
-            let reader = config
-                .signal_config
-                .reader(RootProvider::new_http(config.l1_rpc.clone()));
+            let l1_provider = RootProvider::new_http(config.l1_rpc.clone());
+            let reader = config.signal_config.reader(l1_provider.clone());
+            // Live updates are validated against the startup chain spec and re-applied
+            // automatically, matching the manual `admin_refreshUpgradeSignal` path.
+            let auto_refresher = config.signal_config.mode.allows_runtime_admin().then(|| {
+                let chain_spec = ctx.chain_spec();
+                ExecutionUpgradeSignalRuntimeRefresher::new(
+                    UpgradeSignalRefresher::new(
+                        config.signal_config.clone(),
+                        l1_provider,
+                        chain_spec.chain().id(),
+                        UpgradeSignalRuntimeValidation::disabled(),
+                        UpgradeSignalMetricLayer::Execution,
+                    ),
+                    chain_spec.as_ref().clone(),
+                )
+            });
             let upgrade_ids = config.signal_config.upgrade_ids;
             let mut monitor =
                 UpgradeSignalMonitor::new(UpgradeSignalMetricLayer::Execution, &upgrade_ids);
@@ -237,7 +223,18 @@ impl BaseNodeExtension for ExecutionUpgradeSignalRuntimeExtension {
                             _ = interval.tick() => {
                                 tokio::select! {
                                     _ = &mut signal => break,
-                                    _ = Self::poll_l1_signal(&mut monitor, &reader, &upgrade_ids) => {}
+                                    polled = monitor.poll(&reader, &upgrade_ids) => {
+                                        if let Some(refresher) = &auto_refresher
+                                            && let Some(schedule) = polled
+                                            && let Err(error) = refresher.apply(&schedule)
+                                        {
+                                            warn!(
+                                                target: "upgrade_signal",
+                                                error = %error,
+                                                "failed to auto-apply live upgrade signal update"
+                                            );
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -261,10 +258,39 @@ impl FromExtensionConfig for ExecutionUpgradeSignalRuntimeExtension {
 
 #[cfg(test)]
 mod tests {
-    use base_common_genesis::BaseUpgrade;
+    use alloy_primitives::Address;
+    use base_common_genesis::{BaseUpgrade, RuntimeUpgradeRegistry, UpgradeActivation};
     use reth_chainspec::{ChainSpec, EthereumHardfork, ForkCondition};
 
     use super::*;
+
+    fn runtime_refresher(
+        chain_id: u64,
+        chain_spec: BaseChainSpec,
+    ) -> ExecutionUpgradeSignalRuntimeRefresher {
+        ExecutionUpgradeSignalRuntimeRefresher::new(
+            UpgradeSignalRefresher::new(
+                UpgradeSignalConfig::new(Address::ZERO, BaseUpgrade::Azul),
+                RootProvider::new_http("http://127.0.0.1:1".parse().unwrap()),
+                chain_id,
+                UpgradeSignalRuntimeValidation::disabled(),
+                UpgradeSignalMetricLayer::Execution,
+            ),
+            chain_spec,
+        )
+    }
+
+    fn versioned_schedule(
+        upgrade_id: BaseUpgrade,
+        activation_timestamp: u64,
+    ) -> UpgradeSignalSchedule {
+        UpgradeSignalSchedule::new(vec![base_upgrade_signal::UpgradeSignal {
+            upgrade_id,
+            activation_timestamp,
+            protocol_version: UpgradeSignalDefaults::node_protocol_version(),
+            l1_block_number: 1,
+        }])
+    }
 
     fn schedule(signals: &[(BaseUpgrade, u64)]) -> UpgradeSignalSchedule {
         UpgradeSignalSchedule::new(
@@ -354,5 +380,36 @@ mod tests {
 
         assert!(error.to_string().contains("missing activation admin address"));
         assert_eq!(chain_spec.fork(BaseUpgrade::Beryl), ForkCondition::Never);
+    }
+
+    #[test]
+    fn apply_applies_validated_schedule_to_registry() {
+        let chain_id = 9_100_004;
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+
+        let summary = runtime_refresher(chain_id, BaseChainSpec::devnet())
+            .apply(&versioned_schedule(BaseUpgrade::Azul, 42))
+            .unwrap();
+
+        assert_eq!(summary.applied_upgrades, 1);
+        assert_eq!(
+            RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul),
+            Some(UpgradeActivation::Timestamp(42))
+        );
+
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+    }
+
+    #[test]
+    fn apply_rejects_invalid_schedule_without_mutating_registry() {
+        let chain_id = 9_100_005;
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+
+        let error = runtime_refresher(chain_id, BaseChainSpec::from(ChainSpec::default()))
+            .apply(&versioned_schedule(BaseUpgrade::Beryl, 42))
+            .unwrap_err();
+
+        assert!(error.to_string().contains("missing activation admin address"));
+        assert_eq!(RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Beryl), None);
     }
 }

--- a/crates/utilities/upgrade-signal/src/config/schedule.rs
+++ b/crates/utilities/upgrade-signal/src/config/schedule.rs
@@ -154,8 +154,8 @@ impl UpgradeSignalConfig {
         Ok(())
     }
 
-    /// Reads, records, logs, and validates the L1 schedule.
-    pub async fn read_validated_schedule(
+    /// Reads the L1 schedule with retries, recording metrics and logging each signal.
+    pub async fn read_schedule(
         &self,
         reader: &AlloyUpgradeSignalReader,
         log_context: &'static str,
@@ -184,6 +184,17 @@ impl UpgradeSignalConfig {
             );
         }
 
+        Ok(schedule)
+    }
+
+    /// Reads the L1 schedule via [`Self::read_schedule`] and validates its protocol versions.
+    pub async fn read_validated_schedule(
+        &self,
+        reader: &AlloyUpgradeSignalReader,
+        log_context: &'static str,
+        metrics_layers: &[UpgradeSignalMetricLayer],
+    ) -> Result<UpgradeSignalSchedule, UpgradeSignalError> {
+        let schedule = self.read_schedule(reader, log_context, metrics_layers).await?;
         self.validate_schedule_protocol_versions(&schedule)?;
 
         Ok(schedule)

--- a/crates/utilities/upgrade-signal/src/config/types.rs
+++ b/crates/utilities/upgrade-signal/src/config/types.rs
@@ -8,7 +8,8 @@ pub enum UpgradeSignalMode {
     MetricsOnly,
     /// Apply the L1 signal once before startup; live polling remains metrics-only.
     StartupApply,
-    /// Apply the L1 signal before startup and expose manual runtime admin refresh.
+    /// Apply the L1 signal before startup, automatically re-apply observed live L1 changes,
+    /// and expose manual runtime admin refresh.
     RuntimeAdmin,
 }
 

--- a/crates/utilities/upgrade-signal/src/runtime/refresher.rs
+++ b/crates/utilities/upgrade-signal/src/runtime/refresher.rs
@@ -37,23 +37,17 @@ impl UpgradeSignalRefresher {
         Self { config, reader, chain_id, runtime_validation, metrics_layer }
     }
 
-    /// Reads, metrics-records, logs, and validates the current L1 schedule.
-    pub async fn read_validated_schedule(
+    /// Validates and applies an already-read schedule without touching L1.
+    ///
+    /// Callers do not retry failures: validation failures are deterministic, and failed reads
+    /// never advance the monitor baseline, so changed signals are re-detected next poll.
+    pub fn apply(
         &self,
-    ) -> Result<UpgradeSignalSchedule, UpgradeSignalError> {
-        let schedule = self
-            .config
-            .read_validated_schedule(&self.reader, "runtime refresh", &[self.metrics_layer])
-            .await?;
-        self.runtime_validation.validate_schedule(self.chain_id, &schedule)?;
-
-        Ok(schedule)
-    }
-
-    /// Reads, validates, metrics-records, logs, and applies the current L1 schedule.
-    pub async fn refresh(&self) -> Result<UpgradeSignalApplySummary, UpgradeSignalError> {
-        let schedule = self.read_validated_schedule().await?;
-        let summary = UpgradeSignalRuntimeApplier::apply_schedule(self.chain_id, &schedule);
+        schedule: &UpgradeSignalSchedule,
+    ) -> Result<UpgradeSignalApplySummary, UpgradeSignalError> {
+        self.config.validate_schedule_protocol_versions(schedule)?;
+        self.runtime_validation.validate_schedule(self.chain_id, schedule)?;
+        let summary = UpgradeSignalRuntimeApplier::apply_schedule(self.chain_id, schedule);
         info!(
             target: "upgrade_signal",
             chain_id = summary.chain_id,
@@ -66,5 +60,100 @@ impl UpgradeSignalRefresher {
         );
 
         Ok(summary)
+    }
+
+    /// Reads the current L1 schedule with retries, recording this refresher's metric layer.
+    pub async fn read_schedule(&self) -> Result<UpgradeSignalSchedule, UpgradeSignalError> {
+        self.config.read_schedule(&self.reader, "runtime refresh", &[self.metrics_layer]).await
+    }
+
+    /// Reads, metrics-records, logs, and applies the current L1 schedule.
+    ///
+    /// Validation happens once in [`Self::apply`].
+    pub async fn refresh(&self) -> Result<UpgradeSignalApplySummary, UpgradeSignalError> {
+        let schedule = self.read_schedule().await?;
+        self.apply(&schedule)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, U256};
+    use base_common_genesis::{BaseUpgrade, RuntimeUpgradeRegistry, UpgradeActivation};
+
+    use super::*;
+    use crate::{UpgradeSignal, UpgradeSignalDefaults};
+
+    fn refresher(
+        chain_id: u64,
+        runtime_validation: UpgradeSignalRuntimeValidation,
+    ) -> UpgradeSignalRefresher {
+        UpgradeSignalRefresher::new(
+            UpgradeSignalConfig::new(Address::ZERO, BaseUpgrade::Azul),
+            RootProvider::new_http("http://127.0.0.1:1".parse().unwrap()),
+            chain_id,
+            runtime_validation,
+            UpgradeSignalMetricLayer::Consensus,
+        )
+    }
+
+    fn schedule(
+        upgrade_id: BaseUpgrade,
+        activation_timestamp: u64,
+        protocol_version: U256,
+    ) -> UpgradeSignalSchedule {
+        UpgradeSignalSchedule::new(vec![UpgradeSignal {
+            upgrade_id,
+            activation_timestamp,
+            protocol_version,
+            l1_block_number: 1,
+        }])
+    }
+
+    #[test]
+    fn apply_applies_valid_schedule_to_registry() {
+        let chain_id = 9_100_001;
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+
+        let summary = refresher(chain_id, UpgradeSignalRuntimeValidation::disabled())
+            .apply(&schedule(BaseUpgrade::Azul, 42, UpgradeSignalDefaults::node_protocol_version()))
+            .unwrap();
+
+        assert_eq!(summary.applied_upgrades, 1);
+        assert_eq!(
+            RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul),
+            Some(UpgradeActivation::Timestamp(42))
+        );
+
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+    }
+
+    #[test]
+    fn apply_rejects_unsupported_protocol_version_without_mutating_registry() {
+        let chain_id = 9_100_002;
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+
+        let unsupported = UpgradeSignalDefaults::node_protocol_version() + U256::from(1);
+        refresher(chain_id, UpgradeSignalRuntimeValidation::disabled())
+            .apply(&schedule(BaseUpgrade::Azul, 42, unsupported))
+            .unwrap_err();
+
+        assert_eq!(RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul), None);
+    }
+
+    #[test]
+    fn apply_rejects_positive_beryl_schedule_when_fail_closed_without_mutating_registry() {
+        let chain_id = 9_100_003;
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+
+        refresher(chain_id, UpgradeSignalRuntimeValidation::fail_closed())
+            .apply(&schedule(
+                BaseUpgrade::Beryl,
+                42,
+                UpgradeSignalDefaults::node_protocol_version(),
+            ))
+            .unwrap_err();
+
+        assert_eq!(RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Beryl), None);
     }
 }

--- a/crates/utilities/upgrade-signal/src/state.rs
+++ b/crates/utilities/upgrade-signal/src/state.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 
 use alloy_primitives::U256;
 use base_common_genesis::BaseUpgrade;
+use tracing::info;
 
 use crate::{AlloyUpgradeSignalReader, UpgradeSignalMetricLayer, UpgradeSignalMetrics};
 
@@ -59,6 +60,18 @@ enum UpgradeSignalStateUpdate {
     Changed,
 }
 
+impl UpgradeSignalStateUpdate {
+    /// Returns true when this update requires re-applying the schedule.
+    ///
+    /// [`Self::Initialized`] requires apply: a signal observed live for the first time may carry
+    /// a schedule change that landed after the baseline should have been established (an upgrade
+    /// registered on L1 after node start, or a startup window of failed reads), so it must not be
+    /// silently adopted as the baseline.
+    const fn requires_apply(self) -> bool {
+        matches!(self, Self::Initialized | Self::Changed)
+    }
+}
+
 /// Stateful live metrics tracker for one contract-backed upgrade.
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
 struct UpgradeSignalState {
@@ -107,21 +120,35 @@ impl UpgradeSignalMonitor {
         Self { metrics_layer, states }
     }
 
-    /// Tolerantly polls the reader, records live metrics, and returns the number of changed signals.
+    /// Tolerantly polls the reader, records live metrics, and returns the schedule that was read
+    /// when any signals updated.
     ///
     /// This is the single live-poll routine shared by the consensus actor and the execution
-    /// metrics extension; read failures are recorded but do not abort the poll.
+    /// metrics extension; read failures are recorded but do not abort the poll. See
+    /// [`UpgradeSignalStateUpdate::requires_apply`] for why a first observation counts as an
+    /// update.
     pub async fn poll(
         &mut self,
         reader: &AlloyUpgradeSignalReader,
         upgrade_ids: &[BaseUpgrade],
-    ) -> usize {
+    ) -> Option<UpgradeSignalSchedule> {
         let metrics_layers = [self.metrics_layer];
         let schedule = reader.read_schedule_tolerant(upgrade_ids, &metrics_layers).await;
-        self.update_schedule(schedule)
+        let updated_signals = self
+            .update_schedule(schedule.clone())
             .iter()
-            .filter(|update| matches!(update, UpgradeSignalStateUpdate::Changed))
-            .count()
+            .filter(|update| update.requires_apply())
+            .count();
+        if updated_signals == 0 {
+            return None;
+        }
+
+        info!(
+            target: "upgrade_signal",
+            updated_signals,
+            "observed live L1 upgrade signal update"
+        );
+        Some(schedule)
     }
 
     /// Applies signals read from L1 and records corresponding live metrics.
@@ -197,5 +224,50 @@ mod tests {
         updated_signal.l1_block_number = 2;
 
         assert_eq!(state.update_signal(updated_signal), UpgradeSignalStateUpdate::Unchanged);
+    }
+
+    fn monitor() -> UpgradeSignalMonitor {
+        UpgradeSignalMonitor::new(UpgradeSignalMetricLayer::Consensus, &[BaseUpgrade::Azul])
+    }
+
+    fn schedule(timestamp: u64) -> UpgradeSignalSchedule {
+        UpgradeSignalSchedule::new(vec![signal(timestamp)])
+    }
+
+    #[test]
+    fn first_observation_and_change_require_apply_but_unchanged_does_not() {
+        assert!(UpgradeSignalStateUpdate::Initialized.requires_apply());
+        assert!(UpgradeSignalStateUpdate::Changed.requires_apply());
+        assert!(!UpgradeSignalStateUpdate::Unchanged.requires_apply());
+    }
+
+    #[test]
+    fn monitor_counts_first_observation_as_update() {
+        let mut monitor = monitor();
+
+        let updates = monitor.update_schedule(schedule(10));
+
+        assert_eq!(updates, vec![UpgradeSignalStateUpdate::Initialized]);
+    }
+
+    #[test]
+    fn monitor_ignores_unchanged_signal() {
+        let mut monitor = monitor();
+
+        monitor.update_schedule(schedule(10));
+
+        assert_eq!(
+            monitor.update_schedule(schedule(10)),
+            vec![UpgradeSignalStateUpdate::Unchanged]
+        );
+    }
+
+    #[test]
+    fn monitor_detects_changed_signal() {
+        let mut monitor = monitor();
+
+        monitor.update_schedule(schedule(10));
+
+        assert_eq!(monitor.update_schedule(schedule(12)), vec![UpgradeSignalStateUpdate::Changed]);
     }
 }


### PR DESCRIPTION
## Summary

Wires live auto-apply into the runtime-admin upgrade signal mode.

Runtime-admin previously applied the L1 signal only at startup and via the manual
`admin_refreshUpgradeSignal` RPC; live polling was metrics-only, so a schedule change after
startup was never applied unless every node was manually refreshed.

This PR makes live polling apply observed changes by:

- returning the read schedule from `UpgradeSignalMonitor::poll` when any signals updated
- splitting `UpgradeSignalRefresher` into `apply` (validate + apply an already-read schedule),
  `read_schedule`, and `refresh` (read + `apply`)
- giving the consensus metrics actor an optional refresher that auto-applies the polled schedule
  on observed changes
- routing the execution observer and the manual admin RPC through the same
  `ExecutionUpgradeSignalRuntimeRefresher::apply` path, validated against the startup chain spec

The polled schedule is applied directly rather than re-read, so the apply always matches what the
monitor observed. Apply failures are logged but not retried (validation is deterministic); failed
reads don't advance the baseline, so those are re-detected on the next poll. Metrics-only and
startup-apply modes still never auto-apply, though the first successful poll now logs an observed
update where it previously stayed silent.

## Tests

```
git diff --check
cargo +nightly fmt --check
cargo test -p base-upgrade-signal -p base-consensus-node -p base-execution-cli
cargo clippy -p base-upgrade-signal -p base-consensus-node -p base-execution-cli -- -D warnings
