### PR TITLE
fix(follow): keep L1 origin checks advisory

### DIFF
--- a/crates/consensus/service/src/follow/error.rs
+++ b/crates/consensus/service/src/follow/error.rs
@@ -26,32 +26,32 @@ pub enum FollowError {
     #[error("failed to build local L2 block info: {0}")]
     LocalBlockInfo(#[from] FromBlockError),
 
-    /// Fetching a block from the local L1 node failed.
-    #[error("failed to fetch local L1 block {number}: {source}")]
+    /// Fetching the L2 block's origin block from local L1 failed.
+    #[error("failed to fetch local L1 origin block {number}: {source}")]
     LocalL1BlockFetch {
-        /// Requested L1 block number.
+        /// Requested L1 origin block number.
         number: u64,
         /// Underlying transport error.
         source: alloy_transport::TransportError,
     },
 
-    /// The local L1 node did not return the source label's claimed L1 origin.
-    #[error("local L1 block unavailable at block {0}")]
+    /// The local L1 node did not return the L2 block's origin block.
+    #[error("local L1 origin block unavailable at block {0}")]
     LocalL1BlockUnavailable(u64),
 
-    /// A source L2 label claims an L1 origin that is not canonical locally.
+    /// A hash-verified L2 block points to an L1 origin that is not canonical locally.
     #[error(
-        "source L2 block {l2_number} claims L1 origin {remote} at block {l1_number}, but local L1 has {local}"
+        "L2 block {l2_number} points to L1 origin {l2_origin} at block {l1_number}, but local L1 has {local_l1}"
     )]
-    SourceL1OriginMismatch {
-        /// Source L2 label block number.
+    L2OriginNotCanonical {
+        /// L2 block number whose origin was checked.
         l2_number: u64,
-        /// Claimed L1 origin block number.
+        /// L1 origin block number encoded in the L2 block.
         l1_number: u64,
         /// Hash from the local canonical L1 provider.
-        local: B256,
-        /// L1 origin hash encoded in the source L2 block.
-        remote: B256,
+        local_l1: B256,
+        /// L1 origin hash encoded in the hash-verified L2 block.
+        l2_origin: B256,
     },
 
     /// Fetching the local proofs sync status failed.

--- a/crates/consensus/service/src/follow/node.rs
+++ b/crates/consensus/service/src/follow/node.rs
@@ -52,7 +52,7 @@ where
     pub engine_client: Arc<E>,
     /// Provider for reading local L2 state.
     pub local_l2_provider: RootProvider<Base>,
-    /// Provider for validating source label L1 origins against canonical L1.
+    /// Provider used to check L2 block origins against canonical L1.
     pub l1_provider: RootProvider,
     /// Source L2 client used to fetch payloads to follow.
     pub l2_source: RemoteL2Client,

--- a/crates/consensus/service/src/follow/runtime.rs
+++ b/crates/consensus/service/src/follow/runtime.rs
@@ -143,7 +143,7 @@ where
         )
         .await?;
         if let Some(safe_block) = safe.as_ref() {
-            Self::validate_source_l1_origin(local.as_ref(), safe_block).await?;
+            Self::log_l2_origin_validation(local.as_ref(), safe_block).await;
         }
 
         let safe_limit = safe.as_ref().unwrap_or(&local_safe).block_info.number;
@@ -160,7 +160,7 @@ where
         )
         .await?;
         if let Some(finalized_block) = finalized.as_ref() {
-            Self::validate_source_l1_origin(local.as_ref(), finalized_block).await?;
+            Self::log_l2_origin_validation(local.as_ref(), finalized_block).await;
         }
 
         engine.update_safe_finalized_blocks(safe, finalized).await
@@ -201,8 +201,8 @@ where
         Ok(Some(local_block))
     }
 
-    /// Verifies that a hash-verified local block's L1 origin is canonical in the local L1 view.
-    async fn validate_source_l1_origin(
+    /// Checks whether a hash-verified local block's L1 origin is canonical in the local L1 view.
+    async fn validate_l2_origin_against_local_l1(
         local: &Local,
         block: &L2BlockInfo,
     ) -> Result<(), FollowError> {
@@ -212,14 +212,36 @@ where
             .await?
             .ok_or(FollowError::LocalL1BlockUnavailable(origin.number))?;
         if local_hash != origin.hash {
-            return Err(FollowError::SourceL1OriginMismatch {
+            return Err(FollowError::L2OriginNotCanonical {
                 l2_number: block.block_info.number,
                 l1_number: origin.number,
-                local: local_hash,
-                remote: origin.hash,
+                local_l1: local_hash,
+                l2_origin: origin.hash,
             });
         }
         Ok(())
+    }
+
+    async fn log_l2_origin_validation(local: &Local, block: &L2BlockInfo) {
+        match Self::validate_l2_origin_against_local_l1(local, block).await {
+            Ok(()) => {}
+            Err(FollowError::LocalL1BlockUnavailable(l1_number)) => {
+                info!(
+                    target: "follow",
+                    l2_block = block.block_info.number,
+                    l1_block = l1_number,
+                    "Local L1 origin block unavailable; promoting label without local L1 confirmation"
+                );
+            }
+            Err(error) => {
+                warn!(
+                    target: "follow",
+                    error = %error,
+                    l2_block = block.block_info.number,
+                    "L2 origin check failed; promoting label without local L1 confirmation"
+                );
+            }
+        }
     }
 }
 
@@ -757,7 +779,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn verified_local_l1_origin_must_be_canonical_locally() {
+    async fn l2_origin_mismatch_does_not_block_label_promotion() {
         let mut local = MockFollowLocalClient::new();
         local.expect_block_info().returning(|tag| {
             Ok(Some(match tag {
@@ -780,6 +802,10 @@ mod tests {
             .expect_get_block_info()
             .with(eq(BlockNumberOrTag::Safe))
             .returning(|_| Ok(source_block_info(9)));
+        source
+            .expect_get_block_info()
+            .with(eq(BlockNumberOrTag::Finalized))
+            .returning(|_| Ok(source_block_info(6)));
         let engine = Arc::new(RecordingEngine {
             inserted: Mutex::new(Vec::new()),
             labels: Mutex::new(Vec::new()),
@@ -787,20 +813,55 @@ mod tests {
         });
         let engine_for_update: Arc<dyn FollowEngine> = Arc::<RecordingEngine>::clone(&engine);
 
-        let error =
-            FollowRuntime::<MockFollowLocalClient, MockRemoteClient, NoopProofGate>::update_safe_and_finalized(
-                Arc::new(local),
-                Arc::new(source),
-                engine_for_update,
-            )
-            .await
-            .expect_err("verified local L1 origin must match local canonical L1");
+        FollowRuntime::<MockFollowLocalClient, MockRemoteClient, NoopProofGate>::update_safe_and_finalized(
+            Arc::new(local),
+            Arc::new(source),
+            engine_for_update,
+        )
+        .await
+        .expect("label update");
 
-        assert!(matches!(
-            error,
-            FollowError::SourceL1OriginMismatch { l2_number: 9, l1_number: 0, .. }
-        ));
-        assert!(engine.labels.lock().await.is_empty());
+        assert_eq!(*engine.labels.lock().await, vec![(Some(9), None)]);
+    }
+
+    #[tokio::test]
+    async fn unavailable_l2_origin_does_not_block_label_promotion() {
+        let mut local = MockFollowLocalClient::new();
+        local.expect_block_info().returning(|tag| {
+            Ok(Some(match tag {
+                BlockNumberOrTag::Latest => block_info(10),
+                BlockNumberOrTag::Safe => block_info(8),
+                BlockNumberOrTag::Finalized => block_info(7),
+                BlockNumberOrTag::Number(9) => block_info(9),
+                _ => panic!("unexpected local block lookup: {tag:?}"),
+            }))
+        });
+        local.expect_l1_block_hash().returning(|_| Ok(None));
+        let mut source = MockRemoteClient::new();
+        source
+            .expect_get_block_info()
+            .with(eq(BlockNumberOrTag::Safe))
+            .returning(|_| Ok(source_block_info(9)));
+        source
+            .expect_get_block_info()
+            .with(eq(BlockNumberOrTag::Finalized))
+            .returning(|_| Ok(source_block_info(6)));
+        let engine = Arc::new(RecordingEngine {
+            inserted: Mutex::new(Vec::new()),
+            labels: Mutex::new(Vec::new()),
+            delay: Duration::ZERO,
+        });
+        let engine_for_update: Arc<dyn FollowEngine> = Arc::<RecordingEngine>::clone(&engine);
+
+        FollowRuntime::<MockFollowLocalClient, MockRemoteClient, NoopProofGate>::update_safe_and_finalized(
+            Arc::new(local),
+            Arc::new(source),
+            engine_for_update,
+        )
+        .await
+        .expect("label update");
+
+        assert_eq!(*engine.labels.lock().await, vec![(Some(9), None)]);
     }
 
     #[tokio::test]

--- a/crates/consensus/service/src/follow/runtime.rs
+++ b/crates/consensus/service/src/follow/runtime.rs
@@ -233,12 +233,21 @@ where
                     "Local L1 origin block unavailable; promoting label without local L1 confirmation"
                 );
             }
+            Err(FollowError::LocalL1BlockFetch { number, source }) => {
+                info!(
+                    target: "follow",
+                    error = %source,
+                    l2_block = block.block_info.number,
+                    l1_block = number,
+                    "L1 origin fetch failed; promoting label without local L1 confirmation"
+                );
+            }
             Err(error) => {
                 warn!(
                     target: "follow",
                     error = %error,
                     l2_block = block.block_info.number,
-                    "L2 origin check failed; promoting label without local L1 confirmation"
+                    "L2 origin not canonical on local L1; promoting label anyway"
                 );
             }
         }

--- a/crates/consensus/service/src/follow/runtime.rs
+++ b/crates/consensus/service/src/follow/runtime.rs
@@ -8,13 +8,16 @@ use tokio::{
 };
 use tokio_util::sync::CancellationToken;
 
-use crate::follow::{
-    engine::FollowEngine,
-    error::FollowError,
-    local::FollowLocalClient,
-    prefetcher::{PREFETCH_WINDOW, PayloadPrefetcher, PrefetchedPayload},
-    proof_gate::ProofGate,
-    source::RemoteClient,
+use crate::{
+    Metrics,
+    follow::{
+        engine::FollowEngine,
+        error::FollowError,
+        local::FollowLocalClient,
+        prefetcher::{PREFETCH_WINDOW, PayloadPrefetcher, PrefetchedPayload},
+        proof_gate::ProofGate,
+        source::RemoteClient,
+    },
 };
 
 const SAFETY_POLL_INTERVAL: Duration = Duration::from_secs(30);
@@ -226,6 +229,7 @@ where
         match Self::validate_l2_origin_against_local_l1(local, block).await {
             Ok(()) => {}
             Err(FollowError::LocalL1BlockUnavailable(l1_number)) => {
+                Metrics::follow_l1_origin_check_failures_total("unavailable").increment(1);
                 info!(
                     target: "follow",
                     l2_block = block.block_info.number,
@@ -234,6 +238,7 @@ where
                 );
             }
             Err(FollowError::LocalL1BlockFetch { number, source }) => {
+                Metrics::follow_l1_origin_check_failures_total("fetch_failed").increment(1);
                 info!(
                     target: "follow",
                     error = %source,
@@ -243,6 +248,7 @@ where
                 );
             }
             Err(error) => {
+                Metrics::follow_l1_origin_check_failures_total("not_canonical").increment(1);
                 warn!(
                     target: "follow",
                     error = %error,

--- a/crates/consensus/service/src/metrics/mod.rs
+++ b/crates/consensus/service/src/metrics/mod.rs
@@ -8,6 +8,9 @@ base_metrics::define_metrics! {
     derivation_l1_origin: counter,
     #[describe("Critical errors in the derivation pipeline")]
     derivation_critical_errors: counter,
+    #[describe("Advisory follow-mode L1 origin check failures by reason")]
+    #[label(name = "reason", default = ["unavailable", "fetch_failed", "not_canonical"])]
+    follow_l1_origin_check_failures_total: counter,
     #[describe("Wall-clock duration of a single derivation pipeline step() call")]
     derivation_pipeline_step_duration_seconds: histogram,
     #[describe("Wall-clock duration the derivation actor waits for an inbound request")]


### PR DESCRIPTION
## Summary

- `#3911` already landed follow-mode L1-origin checks against local canonical L1.
- This PR changes those checks from fail-closed to advisory diagnostics.
- Noncanonical origins are logged as warnings; unavailable origin data is logged at info.
- Neither condition blocks promotion of a hash-verified source label.

## Why

Follow mode cannot recover from an L1-origin disagreement the way it can from an L2 hash divergence. Blocking promotion freezes safe/finalized advancement with no local recovery path. Logging preserves liveness while still making origin inconsistencies observable.

## Behavior

After a source safe/finalized label passes the existing local-range and L2-hash checks, follow mode still compares the verified local block's L1 origin to local canonical L1. Mismatches and missing L1 data no longer return errors from the label-update path; promotion continues and the disagreement is logged.

Terminology is updated to match that model: the origin comes from the hash-verified local L2 block, not from a source-claimed origin payload.

## Relationship

Most of the original validation work intended for this PR landed with `#3911`. After rebasing onto `main`, this PR retains only the advisory-semantics change.

## Tests

- L2 origin mismatches do not block label promotion.
- Unavailable L1 origin data does not block label promotion.
- Existing hash-mismatch and out-of-range label behavior remains covered by follow-runtime tests.

type=routine
risk=low
impact=sev5