### PR TITLE
feat(txpool): precheck EIP-8130 authorization manifests

### DIFF
--- a/bin/base/src/commands/sequencer.rs
+++ b/bin/base/src/commands/sequencer.rs
@@ -71,6 +71,7 @@ impl SequencerCommand {
         let builder_config = builder.into_builder_config(Arc::clone(&metering_provider))?;
         let da_config = builder_config.da_config.clone();
         let gas_limit_config = builder_config.gas_limit_config.clone();
+        let manifest_precheck_enabled = builder_config.manifest_precheck_enabled;
 
         CliRunner::try_default_runtime()?.run_command_until_exit(|ctx| async move {
             rollup_args
@@ -101,6 +102,7 @@ impl SequencerCommand {
             let mut runner = BaseNodeRunner::new(rollup_args.clone())
                 .with_da_config(da_config)
                 .with_gas_limit_config(gas_limit_config)
+                .with_manifest_precheck_enabled(manifest_precheck_enabled)
                 .with_service_builder(FlashblocksServiceBuilder(builder_config));
             runner.install_ext::<MeteringStoreExtension>(metering_provider);
             runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig { sequencer_rpc });

--- a/bin/builder/src/main.rs
+++ b/bin/builder/src/main.rs
@@ -45,10 +45,12 @@ fn main() {
             .expect("Failed to convert rollup args to builder config");
         let da_config = builder_config.da_config.clone();
         let gas_limit_config = builder_config.gas_limit_config.clone();
+        let manifest_precheck_enabled = builder_config.manifest_precheck_enabled;
 
         let mut runner = BaseNodeRunner::new(rollup_args.clone())
             .with_da_config(da_config)
             .with_gas_limit_config(gas_limit_config)
+            .with_manifest_precheck_enabled(manifest_precheck_enabled)
             .with_service_builder(FlashblocksServiceBuilder(builder_config));
         runner.install_ext::<MeteringStoreExtension>(metering_provider);
         runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig::default());

--- a/crates/builder/cli/src/args.rs
+++ b/crates/builder/cli/src/args.rs
@@ -212,6 +212,16 @@ pub struct Args {
     #[arg(long = "telemetry.sampling-ratio", env = "SAMPLING_RATIO", default_value = "100")]
     pub sampling_ratio: u64,
 
+    /// Whether to drop positively stale EIP-8130 transactions using their
+    /// captured authorization manifest before execution. Disable with
+    /// `--builder.eip8130-manifest-precheck=false`.
+    #[arg(
+        long = "builder.eip8130-manifest-precheck",
+        default_value_t = true,
+        action = clap::ArgAction::Set
+    )]
+    pub manifest_precheck_enabled: bool,
+
     /// Flashblocks configuration
     #[command(flatten)]
     pub flashblocks: FlashblocksArgs,
@@ -256,6 +266,7 @@ impl Default for Args {
             rejection_cache_max_capacity: 100_000,
             rejection_cache_ttl_secs: 1800,
             sampling_ratio: 100,
+            manifest_precheck_enabled: true,
             flashblocks: FlashblocksArgs::default(),
             transaction_events: TransactionEventsArgs::default(),
         }
@@ -307,6 +318,7 @@ impl Args {
             audit_archiver_url: self.audit_archiver_url,
             rejected_tx_channel_size: self.rejected_tx_channel_size,
             max_rejected_txs_per_block: self.max_rejected_txs_per_block,
+            manifest_precheck_enabled: self.manifest_precheck_enabled,
         })
     }
 }
@@ -339,6 +351,22 @@ mod tests {
         let config = convert(Args::default());
         assert_eq!(config.block_time, Duration::from_millis(1000));
         assert!(config.max_gas_per_txn.is_none());
+        assert!(config.manifest_precheck_enabled);
+    }
+
+    #[rstest]
+    #[case::enabled(true)]
+    #[case::disabled(false)]
+    fn manifest_precheck_flag_maps_to_config(#[case] enabled: bool) {
+        let args = Args { manifest_precheck_enabled: enabled, ..Default::default() };
+        assert_eq!(convert(args).manifest_precheck_enabled, enabled);
+    }
+
+    #[test]
+    fn manifest_precheck_accepts_explicit_false() {
+        let parsed =
+            CommandParser::parse_from(["test", "--builder.eip8130-manifest-precheck=false"]);
+        assert!(!parsed.args.manifest_precheck_enabled);
     }
 
     #[rstest]

--- a/crates/builder/core/src/config.rs
+++ b/crates/builder/core/src/config.rs
@@ -76,6 +76,10 @@ pub struct BuilderConfig {
     /// Maximum number of rejected transactions accumulated per block before
     /// further rejections are dropped. Prevents unbounded `ExecutionInfo` growth.
     pub max_rejected_txs_per_block: usize,
+
+    /// Whether to drop EIP-8130 transactions whose captured authorization
+    /// predicates are positively stale before executing them.
+    pub manifest_precheck_enabled: bool,
 }
 
 impl BuilderConfig {
@@ -109,6 +113,7 @@ impl core::fmt::Debug for BuilderConfig {
             .field("audit_archiver_url", &self.audit_archiver_url)
             .field("rejected_tx_channel_size", &self.rejected_tx_channel_size)
             .field("max_rejected_txs_per_block", &self.max_rejected_txs_per_block)
+            .field("manifest_precheck_enabled", &self.manifest_precheck_enabled)
             .finish()
     }
 }
@@ -134,6 +139,7 @@ impl Default for BuilderConfig {
             audit_archiver_url: None,
             rejected_tx_channel_size: 500,
             max_rejected_txs_per_block: 500,
+            manifest_precheck_enabled: true,
         }
     }
 }
@@ -196,6 +202,13 @@ impl BuilderConfig {
         metering_wait_duration: Option<Duration>,
     ) -> Self {
         self.metering_wait_duration = metering_wait_duration;
+        self
+    }
+
+    /// Toggles the EIP-8130 manifest precheck.
+    #[must_use]
+    pub const fn with_manifest_precheck_enabled(mut self, enabled: bool) -> Self {
+        self.manifest_precheck_enabled = enabled;
         self
     }
 }

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -21,7 +21,8 @@ use base_execution_payload_builder::{
     BasePayloadBuilderAttributes, error::BasePayloadBuilderError,
 };
 use base_execution_txpool::{
-    BundleTransaction, TimestampedTransaction, estimated_da_size::DataAvailabilitySized,
+    BasePooledTx, BundleTransaction, GuardMetrics, TimestampedTransaction,
+    estimated_da_size::DataAvailabilitySized,
 };
 use base_observability_events::TransactionEventType;
 use reth_basic_payload_builder::PayloadConfig;
@@ -796,6 +797,54 @@ impl BasePayloadBuilderCtx {
                     },
                 );
                 best_txs.mark_invalid(tx.sender(), tx.nonce());
+                continue;
+            }
+
+            if self.builder_config.manifest_precheck_enabled
+                && let Some(manifest) = tx.watch_manifest()
+                && let Err(stale) = manifest.revalidate(evm.db_mut(), block_timestamp)
+            {
+                let tx_hash = *tx.hash();
+                num_txs_considered += 1;
+                let ordering_position = num_txs_considered;
+                trace!(
+                    target: "payload_builder",
+                    tx_hash = ?tx_hash,
+                    cause = stale.cause(),
+                    "skipping EIP-8130 transaction with stale authorization manifest"
+                );
+                GuardMetrics::record_builder_precheck_drop(&stale);
+                self.emit_builder_decision_event(
+                    &payload_id,
+                    TransactionEventType::BuilderConsidered,
+                    tx_hash,
+                    Some(ordering_position),
+                    || BuilderConsideredEventData::new(info, limits, None),
+                );
+                self.emit_builder_decision_event(
+                    &payload_id,
+                    TransactionEventType::BuilderRejected,
+                    tx_hash,
+                    Some(ordering_position),
+                    || {
+                        BuilderRejectedEventData::new(
+                            "manifest_precheck_stale",
+                            stale.cause(),
+                            false,
+                            info,
+                            limits,
+                            None,
+                        )
+                    },
+                );
+                diag.txs_rejected_other += 1;
+                // Nonce-free replay-ID entries are independent. The upstream
+                // payload adapter invalidates by sender (not by replay ID), so
+                // marking one would suppress unrelated entries from this sender.
+                // This transaction has already been consumed from the iterator.
+                if tx.eip8130_replay_id().is_none() {
+                    best_txs.mark_invalid(tx.sender(), tx.nonce());
+                }
                 continue;
             }
 

--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -1027,7 +1027,7 @@ where
 }
 
 /// A basic Base payload service builder
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct BasePayloadBuilder<Txs = ()> {
     /// By default the pending block equals the latest block
     /// to save resources and not leak txs from the tx-pool,
@@ -1047,6 +1047,21 @@ pub struct BasePayloadBuilder<Txs = ()> {
     /// Gas limit configuration for the payload builder.
     /// This is used to configure gas limit related constraints for the payload builder.
     pub gas_limit_config: GasLimitConfig,
+    /// Whether to drop positively stale EIP-8130 transactions using their
+    /// captured authorization manifest before execution.
+    pub manifest_precheck_enabled: bool,
+}
+
+impl<Txs: Default> Default for BasePayloadBuilder<Txs> {
+    fn default() -> Self {
+        Self {
+            compute_pending_block: false,
+            best_transactions: Txs::default(),
+            da_config: BaseDAConfig::default(),
+            gas_limit_config: GasLimitConfig::default(),
+            manifest_precheck_enabled: true,
+        }
+    }
 }
 
 impl BasePayloadBuilder {
@@ -1058,6 +1073,7 @@ impl BasePayloadBuilder {
             best_transactions: (),
             da_config: BaseDAConfig::default(),
             gas_limit_config: GasLimitConfig::default(),
+            manifest_precheck_enabled: true,
         }
     }
 
@@ -1072,14 +1088,32 @@ impl BasePayloadBuilder {
         self.gas_limit_config = gas_limit_config;
         self
     }
+
+    /// Configure whether EIP-8130 authorization manifests are checked before execution.
+    pub const fn with_manifest_precheck_enabled(mut self, enabled: bool) -> Self {
+        self.manifest_precheck_enabled = enabled;
+        self
+    }
 }
 
 impl<Txs> BasePayloadBuilder<Txs> {
     /// Configures the type responsible for yielding the transactions that should be included in the
     /// payload.
     pub fn with_transactions<T>(self, best_transactions: T) -> BasePayloadBuilder<T> {
-        let Self { compute_pending_block, da_config, gas_limit_config, .. } = self;
-        BasePayloadBuilder { compute_pending_block, best_transactions, da_config, gas_limit_config }
+        let Self {
+            compute_pending_block,
+            da_config,
+            gas_limit_config,
+            manifest_precheck_enabled,
+            ..
+        } = self;
+        BasePayloadBuilder {
+            compute_pending_block,
+            best_transactions,
+            da_config,
+            gas_limit_config,
+            manifest_precheck_enabled,
+        }
     }
 }
 
@@ -1125,7 +1159,7 @@ where
                 BaseBuilderConfig {
                     da_config: self.da_config.clone(),
                     gas_limit_config: self.gas_limit_config.clone(),
-                    ..Default::default()
+                    manifest_precheck_enabled: self.manifest_precheck_enabled,
                 },
             )
             .with_transactions(self.best_transactions.clone())
@@ -1426,6 +1460,16 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+
+    #[test]
+    fn payload_builder_preserves_manifest_precheck_setting() {
+        let builder = BasePayloadBuilder::new(false)
+            .with_manifest_precheck_enabled(false)
+            .with_transactions(());
+
+        assert!(!builder.manifest_precheck_enabled);
+        assert!(BasePayloadBuilder::<()>::default().manifest_precheck_enabled);
+    }
 
     #[rstest]
     #[case::enabled(false, false, false, false)]

--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -1125,6 +1125,7 @@ where
                 BaseBuilderConfig {
                     da_config: self.da_config.clone(),
                     gas_limit_config: self.gas_limit_config.clone(),
+                    ..Default::default()
                 },
             )
             .with_transactions(self.best_transactions.clone())

--- a/crates/execution/payload/src/builder.rs
+++ b/crates/execution/payload/src/builder.rs
@@ -9,7 +9,7 @@ use alloy_rpc_types_engine::PayloadId;
 use base_common_chains::Upgrades;
 use base_common_consensus::{BaseTransaction, Predeploys};
 use base_common_evm::L1BlockInfo;
-use base_execution_txpool::{BasePooledTx, estimated_da_size::DataAvailabilitySized};
+use base_execution_txpool::{BasePooledTx, GuardMetrics, estimated_da_size::DataAvailabilitySized};
 use reth_basic_payload_builder::{
     BuildArguments, BuildOutcome, BuildOutcomeKind, MissingPayloadBehaviour, PayloadBuilder,
     PayloadConfig, is_better_payload,
@@ -721,7 +721,29 @@ where
         let tx_da_limit = self.builder_config.da_config.max_da_tx_size();
         let base_fee = builder.evm_mut().block().basefee();
 
+        let block_timestamp = self.attributes().timestamp();
         while let Some(tx) = best_txs.next(()) {
+            if self.builder_config.manifest_precheck_enabled
+                && let Some(manifest) = tx.watch_manifest()
+                && let Err(stale) = manifest.revalidate(builder.evm_mut().db_mut(), block_timestamp)
+            {
+                trace!(
+                    target: "payload_builder",
+                    tx_hash = ?tx.hash(),
+                    cause = stale.cause(),
+                    "skipping EIP-8130 transaction with stale authorization manifest"
+                );
+                GuardMetrics::record_builder_precheck_drop(&stale);
+                // Nonce-free replay-ID entries are independent. The upstream
+                // payload adapter invalidates by sender (not by replay ID), so
+                // marking one would suppress unrelated entries from this sender.
+                // This transaction has already been consumed from the iterator.
+                if tx.eip8130_replay_id().is_none() {
+                    best_txs.mark_invalid(tx.sender(), tx.nonce());
+                }
+                continue;
+            }
+
             let tx_da_size = tx.estimated_da_size();
             let tx = tx.into_consensus();
 

--- a/crates/execution/payload/src/config.rs
+++ b/crates/execution/payload/src/config.rs
@@ -3,18 +3,31 @@
 use std::sync::{Arc, atomic::AtomicU64};
 
 /// Settings for the Base payload builder.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct BaseBuilderConfig {
     /// Data availability configuration for the Base payload builder.
     pub da_config: BaseDAConfig,
     /// Gas limit configuration for the Base payload builder.
     pub gas_limit_config: GasLimitConfig,
+    /// Whether to drop positively stale EIP-8130 transactions using their
+    /// captured authorization manifest before execution.
+    pub manifest_precheck_enabled: bool,
+}
+
+impl Default for BaseBuilderConfig {
+    fn default() -> Self {
+        Self {
+            da_config: BaseDAConfig::default(),
+            gas_limit_config: GasLimitConfig::default(),
+            manifest_precheck_enabled: true,
+        }
+    }
 }
 
 impl BaseBuilderConfig {
     /// Creates a new Base payload builder configuration with the given data availability configuration.
     pub const fn new(da_config: BaseDAConfig, gas_limit_config: GasLimitConfig) -> Self {
-        Self { da_config, gas_limit_config }
+        Self { da_config, gas_limit_config, manifest_precheck_enabled: true }
     }
 
     /// Returns the data availability configuration for the Base payload builder, if it has

--- a/crates/execution/payload/src/config.rs
+++ b/crates/execution/payload/src/config.rs
@@ -25,9 +25,13 @@ impl Default for BaseBuilderConfig {
 }
 
 impl BaseBuilderConfig {
-    /// Creates a new Base payload builder configuration with the given data availability configuration.
-    pub const fn new(da_config: BaseDAConfig, gas_limit_config: GasLimitConfig) -> Self {
-        Self { da_config, gas_limit_config, manifest_precheck_enabled: true }
+    /// Creates a new Base payload builder configuration.
+    pub const fn new(
+        da_config: BaseDAConfig,
+        gas_limit_config: GasLimitConfig,
+        manifest_precheck_enabled: bool,
+    ) -> Self {
+        Self { da_config, gas_limit_config, manifest_precheck_enabled }
     }
 
     /// Returns the data availability configuration for the Base payload builder, if it has
@@ -156,6 +160,13 @@ mod tests {
     fn test_da_constrained() {
         let config = BaseBuilderConfig::default();
         assert!(config.constrained_da_config().is_none());
+    }
+
+    #[test]
+    fn new_preserves_manifest_precheck_setting() {
+        let config =
+            BaseBuilderConfig::new(BaseDAConfig::default(), GasLimitConfig::default(), false);
+        assert!(!config.manifest_precheck_enabled);
     }
 
     #[test]

--- a/crates/execution/runner/src/node.rs
+++ b/crates/execution/runner/src/node.rs
@@ -24,7 +24,7 @@ use reth_rpc_api::eth::RpcTypes;
 use crate::{BaseAddOns, BaseAddOnsBuilder};
 
 /// Type configuration for a regular Base node.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct BaseNode {
     /// Additional Base args
@@ -40,6 +40,15 @@ pub struct BaseNode {
     /// Used to control the gas limit of the blocks produced by the payload builder (configured by the
     /// batcher via the `miner_` api)
     pub gas_limit_config: GasLimitConfig,
+    /// Whether to drop positively stale EIP-8130 transactions using their
+    /// captured authorization manifest before execution.
+    pub manifest_precheck_enabled: bool,
+}
+
+impl Default for BaseNode {
+    fn default() -> Self {
+        Self::new(RollupArgs::default())
+    }
 }
 
 impl BaseNode {
@@ -49,6 +58,7 @@ impl BaseNode {
             args,
             da_config: BaseDAConfig::default(),
             gas_limit_config: GasLimitConfig::default(),
+            manifest_precheck_enabled: true,
         }
     }
 
@@ -61,6 +71,12 @@ impl BaseNode {
     /// Configure the gas limit configuration for the payload builder.
     pub fn with_gas_limit_config(mut self, gas_limit_config: GasLimitConfig) -> Self {
         self.gas_limit_config = gas_limit_config;
+        self
+    }
+
+    /// Configure whether EIP-8130 authorization manifests are checked before execution.
+    pub const fn with_manifest_precheck_enabled(mut self, enabled: bool) -> Self {
+        self.manifest_precheck_enabled = enabled;
         self
     }
 
@@ -95,7 +111,8 @@ impl BaseNode {
             .payload(BasicPayloadServiceBuilder::new(
                 BasePayloadBuilder::new(compute_pending_block)
                     .with_da_config(self.da_config.clone())
-                    .with_gas_limit_config(self.gas_limit_config.clone()),
+                    .with_gas_limit_config(self.gas_limit_config.clone())
+                    .with_manifest_precheck_enabled(self.manifest_precheck_enabled),
             ))
             .network(BaseNetworkBuilder::new(disable_txpool_gossip, !discovery_v4))
             .consensus(BaseConsensusBuilder::default())

--- a/crates/execution/runner/src/runner.rs
+++ b/crates/execution/runner/src/runner.rs
@@ -36,6 +36,9 @@ pub struct BaseNodeRunner<SB: PayloadServiceBuilder = DefaultPayloadServiceBuild
     da_config: Option<BaseDAConfig>,
     /// Shared gas-limit configuration for the node and payload builder.
     gas_limit_config: Option<GasLimitConfig>,
+    /// Whether to drop positively stale EIP-8130 transactions using their
+    /// captured authorization manifest before execution.
+    manifest_precheck_enabled: bool,
     /// Binary-owned callbacks to run after the node has started.
     started_callbacks: Vec<StartedCallback>,
 }
@@ -49,6 +52,7 @@ impl BaseNodeRunner<DefaultPayloadServiceBuilder> {
             service_builder: DefaultPayloadServiceBuilder,
             da_config: None,
             gas_limit_config: None,
+            manifest_precheck_enabled: true,
             started_callbacks: Vec::new(),
         }
     }
@@ -61,6 +65,7 @@ impl<SB: PayloadServiceBuilder> fmt::Debug for BaseNodeRunner<SB> {
             .field("extensions", &self.extensions.len())
             .field("da_config", &self.da_config)
             .field("gas_limit_config", &self.gas_limit_config)
+            .field("manifest_precheck_enabled", &self.manifest_precheck_enabled)
             .field("started_callbacks", &self.started_callbacks.len())
             .finish()
     }
@@ -79,6 +84,12 @@ impl<SB: PayloadServiceBuilder> BaseNodeRunner<SB> {
         self
     }
 
+    /// Configures whether EIP-8130 authorization manifests are checked before execution.
+    pub const fn with_manifest_precheck_enabled(mut self, enabled: bool) -> Self {
+        self.manifest_precheck_enabled = enabled;
+        self
+    }
+
     /// Swap the payload service builder.
     pub fn with_service_builder<SB2: PayloadServiceBuilder>(self, sb: SB2) -> BaseNodeRunner<SB2> {
         BaseNodeRunner {
@@ -87,6 +98,7 @@ impl<SB: PayloadServiceBuilder> BaseNodeRunner<SB> {
             service_builder: sb,
             da_config: self.da_config,
             gas_limit_config: self.gas_limit_config,
+            manifest_precheck_enabled: self.manifest_precheck_enabled,
             started_callbacks: self.started_callbacks,
         }
     }
@@ -116,38 +128,22 @@ impl<SB: PayloadServiceBuilder> BaseNodeRunner<SB> {
     /// Applies all Base-specific wiring to the supplied builder and returns a launched node
     /// handle without waiting for shutdown.
     pub async fn launch(self, builder: BaseNodeBuilder) -> Result<LaunchedBaseNode> {
+        let handle = self.launch_node(builder).await?;
+        Ok(LaunchedBaseNode { handle })
+    }
+
+    async fn launch_node(self, builder: BaseNodeBuilder) -> Result<NodeHandleFor<BaseNode>> {
+        info!(target: "base-runner", "starting custom Base node");
+
         let Self {
             rollup_args,
             extensions,
             service_builder,
             da_config,
             gas_limit_config,
+            manifest_precheck_enabled,
             started_callbacks,
         } = self;
-        let handle = Self::launch_node(
-            rollup_args,
-            extensions,
-            service_builder,
-            da_config,
-            gas_limit_config,
-            started_callbacks,
-            builder,
-        )
-        .await?;
-        Ok(LaunchedBaseNode { handle })
-    }
-
-    async fn launch_node(
-        rollup_args: RollupArgs,
-        extensions: Vec<Box<dyn BaseNodeExtension>>,
-        service_builder: SB,
-        da_config: Option<BaseDAConfig>,
-        gas_limit_config: Option<GasLimitConfig>,
-        started_callbacks: Vec<StartedCallback>,
-        builder: BaseNodeBuilder,
-    ) -> Result<NodeHandleFor<BaseNode>> {
-        info!(target: "base-runner", "starting custom Base node");
-
         let mut base_node = BaseNode::new(rollup_args);
         if let Some(da_config) = da_config {
             base_node = base_node.with_da_config(da_config);
@@ -155,6 +151,7 @@ impl<SB: PayloadServiceBuilder> BaseNodeRunner<SB> {
         if let Some(gas_limit_config) = gas_limit_config {
             base_node = base_node.with_gas_limit_config(gas_limit_config);
         }
+        base_node = base_node.with_manifest_precheck_enabled(manifest_precheck_enabled);
         let components = service_builder.build_components(&base_node);
 
         let builder = builder
@@ -195,8 +192,10 @@ mod tests {
         let runner = BaseNodeRunner::new(RollupArgs::default())
             .with_da_config(da_config.clone())
             .with_gas_limit_config(gas_limit_config.clone())
+            .with_manifest_precheck_enabled(false)
             .with_service_builder(TestPayloadServiceBuilder);
 
+        assert!(!runner.manifest_precheck_enabled);
         let configured_da = runner.da_config.expect("DA config should be preserved");
         let configured_gas = runner.gas_limit_config.expect("gas-limit config should be preserved");
 

--- a/crates/execution/txpool/src/lib.rs
+++ b/crates/execution/txpool/src/lib.rs
@@ -16,6 +16,9 @@ pub use guard::{
 mod invalidation;
 pub use invalidation::{InvalidationIndex, InvalidationKey, WatchSet};
 
+mod manifest;
+pub use manifest::{ConfigSlot, ManifestStale, WatchManifest};
+
 mod limits;
 pub use limits::{InflightCounters, PayerBook};
 
@@ -64,6 +67,6 @@ pub use wire::ValidatedTransaction;
 mod two_d_nonce_pool;
 
 mod metrics;
-pub use metrics::GuardMetrics;
+pub use metrics::{GuardMetrics, ValidatorMetrics};
 
 pub mod estimated_da_size;

--- a/crates/execution/txpool/src/manifest.rs
+++ b/crates/execution/txpool/src/manifest.rs
@@ -21,12 +21,18 @@ pub struct ConfigSlot {
 }
 
 /// State predicates captured during EIP-8130 authorization.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WatchManifest {
     config_slots: Vec<ConfigSlot>,
     payer: Address,
     payer_max_cost: U256,
     effective_expiry: u64,
+}
+
+impl Default for WatchManifest {
+    fn default() -> Self {
+        Self::new(Vec::new(), Address::ZERO, U256::ZERO, u64::MAX)
+    }
 }
 
 impl WatchManifest {
@@ -195,6 +201,15 @@ mod tests {
             U256::from(1_000),
             u64::MAX,
         )
+    }
+
+    #[test]
+    fn default_manifest_is_inert() {
+        let manifest = WatchManifest::default();
+        let mut db = InMemoryDB::default();
+
+        assert_eq!(manifest.effective_expiry(), u64::MAX);
+        assert_eq!(manifest.revalidate(&mut db, u64::MAX), Ok(()));
     }
 
     #[test]

--- a/crates/execution/txpool/src/manifest.rs
+++ b/crates/execution/txpool/src/manifest.rs
@@ -1,0 +1,292 @@
+//! Captured authorization read-set for stateless intra-block revalidation.
+//!
+//! EIP-8130 validation snapshots every base-state storage slot read by the
+//! authorizer, together with its value. A [`WatchManifest`] carries that exact
+//! read-set plus payer-balance and expiry predicates to the payload builder,
+//! where stale transactions can be dropped before execution without repeating
+//! signature recovery.
+
+use alloy_primitives::{Address, U256};
+use revm::Database;
+
+/// A storage slot read during EIP-8130 authorization and its expected value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ConfigSlot {
+    /// Contract whose storage slot was read.
+    pub address: Address,
+    /// Storage slot key within `address`.
+    pub slot: U256,
+    /// Value the slot held when the transaction was authorized.
+    pub expected: U256,
+}
+
+/// State predicates captured during EIP-8130 authorization.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WatchManifest {
+    config_slots: Vec<ConfigSlot>,
+    payer: Address,
+    payer_max_cost: U256,
+    effective_expiry: u64,
+}
+
+impl WatchManifest {
+    /// Builds a manifest from the captured authorization read-set and payer and
+    /// expiry predicates.
+    #[must_use]
+    pub const fn new(
+        config_slots: Vec<ConfigSlot>,
+        payer: Address,
+        payer_max_cost: U256,
+        effective_expiry: u64,
+    ) -> Self {
+        Self { config_slots, payer, payer_max_cost, effective_expiry }
+    }
+
+    /// Returns the storage slots and values read during authorization.
+    #[must_use]
+    pub fn config_slots(&self) -> &[ConfigSlot] {
+        &self.config_slots
+    }
+
+    /// Returns the account funding the transaction.
+    #[must_use]
+    pub const fn payer(&self) -> Address {
+        self.payer
+    }
+
+    /// Returns the maximum cost the transaction can charge the payer.
+    #[must_use]
+    pub const fn payer_max_cost(&self) -> U256 {
+        self.payer_max_cost
+    }
+
+    /// Returns the last timestamp at which all captured expiry predicates hold.
+    ///
+    /// Transaction expiry is exclusive while actor expiry is inclusive, so this
+    /// may be one less than the transaction's wire expiry. `u64::MAX` means
+    /// unbounded.
+    #[must_use]
+    pub const fn effective_expiry(&self) -> u64 {
+        self.effective_expiry
+    }
+
+    /// Returns whether authorization read no base-state storage slots.
+    #[must_use]
+    pub const fn has_no_config_slots(&self) -> bool {
+        self.config_slots.is_empty()
+    }
+
+    /// Conservatively rechecks the captured predicates against build-time state.
+    ///
+    /// A positively observed slot change, payer shortfall, or expired deadline
+    /// returns an error so the builder can drop the stale transaction before
+    /// execution. Storage and account read errors fail open because execution
+    /// remains authoritative and a transient read failure must not evict an
+    /// otherwise-valid transaction. A successfully read absent payer is treated
+    /// as an account with zero balance.
+    ///
+    /// `revm::Database` requires mutable access for reads. These reads may warm
+    /// the EVM cache or add storage proofs in witness mode, but do not modify
+    /// execution state.
+    pub fn revalidate<DB: Database>(&self, db: &mut DB, now: u64) -> Result<(), ManifestStale> {
+        if self.effective_expiry != u64::MAX && now > self.effective_expiry {
+            return Err(ManifestStale::Expired { deadline: self.effective_expiry, now });
+        }
+
+        for slot in &self.config_slots {
+            if let Ok(current) = db.storage(slot.address, slot.slot)
+                && current != slot.expected
+            {
+                return Err(ManifestStale::ConfigSlotChanged {
+                    address: slot.address,
+                    slot: slot.slot,
+                });
+            }
+        }
+
+        if !self.payer_max_cost.is_zero()
+            && let Ok(info) = db.basic(self.payer)
+        {
+            let available = info.map_or(U256::ZERO, |info| info.balance);
+            if available < self.payer_max_cost {
+                return Err(ManifestStale::PayerUnderfunded {
+                    payer: self.payer,
+                    required: self.payer_max_cost,
+                    available,
+                });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// A positively observed reason an EIP-8130 transaction is stale at build time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ManifestStale {
+    /// An authorization storage slot no longer has its expected value.
+    ConfigSlotChanged {
+        /// Contract whose slot changed.
+        address: Address,
+        /// Storage slot that changed.
+        slot: U256,
+    },
+    /// The payer can no longer cover the transaction's maximum charge.
+    PayerUnderfunded {
+        /// Account funding the transaction.
+        payer: Address,
+        /// Maximum charge the transaction can incur.
+        required: U256,
+        /// Balance currently available.
+        available: U256,
+    },
+    /// The effective expiry deadline has passed.
+    Expired {
+        /// Effective expiry deadline in Unix seconds.
+        deadline: u64,
+        /// Build timestamp that passed the deadline.
+        now: u64,
+    },
+}
+
+impl ManifestStale {
+    /// Returns a coarse, low-cardinality category suitable for a metric label.
+    #[must_use]
+    pub const fn cause(&self) -> &'static str {
+        match self {
+            Self::ConfigSlotChanged { .. } => "config_slot",
+            Self::PayerUnderfunded { .. } => "payer_balance",
+            Self::Expired { .. } => "expiry",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::B256;
+    use revm::{
+        Database,
+        database::InMemoryDB,
+        database_interface::DBErrorMarker,
+        state::{AccountInfo, Bytecode},
+    };
+
+    use super::*;
+
+    const CONFIG: Address = Address::repeat_byte(0x11);
+    const PAYER: Address = Address::repeat_byte(0x22);
+    const SLOT: U256 = U256::from_limbs([7, 0, 0, 0]);
+    const EXPECTED: U256 = U256::from_limbs([42, 0, 0, 0]);
+
+    fn db_with(slot_value: U256, payer_balance: u64) -> InMemoryDB {
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            PAYER,
+            AccountInfo { balance: U256::from(payer_balance), ..Default::default() },
+        );
+        db.insert_account_storage(CONFIG, SLOT, slot_value).unwrap();
+        db
+    }
+
+    fn manifest() -> WatchManifest {
+        WatchManifest::new(
+            vec![ConfigSlot { address: CONFIG, slot: SLOT, expected: EXPECTED }],
+            PAYER,
+            U256::from(1_000),
+            u64::MAX,
+        )
+    }
+
+    #[test]
+    fn revalidate_passes_when_unchanged_funded_and_unexpired() {
+        let mut db = db_with(EXPECTED, 1_000);
+        assert_eq!(manifest().revalidate(&mut db, 0), Ok(()));
+    }
+
+    #[test]
+    fn revalidate_drops_on_config_slot_change() {
+        let mut db = db_with(U256::from(43), 1_000);
+        assert_eq!(
+            manifest().revalidate(&mut db, 0),
+            Err(ManifestStale::ConfigSlotChanged { address: CONFIG, slot: SLOT })
+        );
+    }
+
+    #[test]
+    fn revalidate_drops_on_payer_shortfall() {
+        let mut db = db_with(EXPECTED, 999);
+        assert_eq!(
+            manifest().revalidate(&mut db, 0),
+            Err(ManifestStale::PayerUnderfunded {
+                payer: PAYER,
+                required: U256::from(1_000),
+                available: U256::from(999),
+            })
+        );
+    }
+
+    #[test]
+    fn revalidate_drops_only_after_expiry() {
+        let manifest = WatchManifest::new(vec![], PAYER, U256::ZERO, 100);
+        let mut db = db_with(EXPECTED, 1_000);
+        assert_eq!(manifest.revalidate(&mut db, 100), Ok(()));
+        assert_eq!(
+            manifest.revalidate(&mut db, 101),
+            Err(ManifestStale::Expired { deadline: 100, now: 101 })
+        );
+    }
+
+    #[test]
+    fn revalidate_treats_absent_payer_as_zero_balance() {
+        let mut db = InMemoryDB::default();
+        db.insert_account_storage(CONFIG, SLOT, EXPECTED).unwrap();
+        assert_eq!(
+            manifest().revalidate(&mut db, 0),
+            Err(ManifestStale::PayerUnderfunded {
+                payer: PAYER,
+                required: U256::from(1_000),
+                available: U256::ZERO,
+            })
+        );
+    }
+
+    #[test]
+    fn revalidate_skips_zero_cost_payer_check() {
+        let manifest = WatchManifest::new(vec![], PAYER, U256::ZERO, u64::MAX);
+        assert_eq!(manifest.revalidate(&mut InMemoryDB::default(), 0), Ok(()));
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("test database read failed")]
+    struct ReadError;
+
+    impl DBErrorMarker for ReadError {}
+
+    #[derive(Debug, Default)]
+    struct FailingDatabase;
+
+    impl Database for FailingDatabase {
+        type Error = ReadError;
+
+        fn basic(&mut self, _address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+            Err(ReadError)
+        }
+
+        fn code_by_hash(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+            Err(ReadError)
+        }
+
+        fn storage(&mut self, _address: Address, _index: U256) -> Result<U256, Self::Error> {
+            Err(ReadError)
+        }
+
+        fn block_hash(&mut self, _number: u64) -> Result<B256, Self::Error> {
+            Err(ReadError)
+        }
+    }
+
+    #[test]
+    fn revalidate_fails_open_on_database_read_errors() {
+        assert_eq!(manifest().revalidate(&mut FailingDatabase, 0), Ok(()));
+    }
+}

--- a/crates/execution/txpool/src/metrics.rs
+++ b/crates/execution/txpool/src/metrics.rs
@@ -1,4 +1,8 @@
-//! Metrics for the EIP-8130 admission and invalidation guard.
+//! Metrics for EIP-8130 admission, invalidation, builder prechecks, and
+//! transaction validation.
+//!
+//! All labels are low-cardinality static categories; addresses and transaction
+//! hashes are never used as label values.
 
 base_metrics::define_metrics! {
     txpool.guard,
@@ -16,6 +20,9 @@ base_metrics::define_metrics! {
     expiry_buckets_fired: counter,
     #[describe("Transactions currently tracked by the admission/invalidation guard")]
     tracked: gauge,
+    #[describe("EIP-8130 drop events from the builder's stateless manifest precheck")]
+    #[label(name = "cause", default = ["config_slot", "payer_balance", "expiry"])]
+    builder_precheck_dropped: counter,
 }
 
 impl GuardMetrics {
@@ -63,4 +70,20 @@ impl GuardMetrics {
             Self::invalidated("reconcile").increment(count as u64);
         }
     }
+
+    /// Records a builder precheck drop by its positively observed stale cause.
+    pub fn record_builder_precheck_drop(stale: &crate::ManifestStale) {
+        Self::builder_precheck_dropped(stale.cause()).increment(1);
+    }
+}
+
+base_metrics::define_metrics! {
+    txpool.validator,
+    struct = ValidatorMetrics,
+    #[describe("End-to-end mempool validation wall time by transaction kind")]
+    #[label(name = "kind", default = ["eip8130", "standard"])]
+    validate_seconds: histogram,
+    #[describe("EIP-8130 authorization wall time by sender authenticator type")]
+    #[label(name = "sig_type", default = ["k1", "p256", "passkey", "delegate", "delegate-k1", "delegate-p256", "delegate-passkey", "other"])]
+    auth_seconds: histogram,
 }

--- a/crates/execution/txpool/src/transaction.rs
+++ b/crates/execution/txpool/src/transaction.rs
@@ -82,6 +82,10 @@ pub struct BasePooledTransaction<
     /// consumed by the pool's admission guard. Unset until classified; see
     /// [`crate::LimitClass`].
     limit_class: OnceLock<crate::LimitClass>,
+    /// The authorization read-set and build-time predicates captured during
+    /// EIP-8130 validation. Unset for other transaction types; see
+    /// [`crate::WatchManifest`].
+    watch_manifest: OnceLock<crate::WatchManifest>,
 }
 
 impl<Cons: SignedTransaction, Pooled> BasePooledTransaction<Cons, Pooled> {
@@ -98,6 +102,7 @@ impl<Cons: SignedTransaction, Pooled> BasePooledTransaction<Cons, Pooled> {
             max_timestamp: None,
             watch_set: OnceLock::new(),
             limit_class: OnceLock::new(),
+            watch_manifest: OnceLock::new(),
         }
     }
 
@@ -120,6 +125,7 @@ impl<Cons: SignedTransaction, Pooled> BasePooledTransaction<Cons, Pooled> {
             max_timestamp: None,
             watch_set: OnceLock::new(),
             limit_class: OnceLock::new(),
+            watch_manifest: OnceLock::new(),
         }
     }
 
@@ -397,6 +403,18 @@ pub trait BasePooledTx: PoolTransaction + DataAvailabilitySized {
     /// Defaults to a no-op.
     fn set_limit_class(&self, _limit_class: crate::LimitClass) {}
 
+    /// Returns build-time predicates captured during EIP-8130 authorization.
+    ///
+    /// Defaults to `None` for transaction types that do not carry a manifest.
+    fn watch_manifest(&self) -> Option<&crate::WatchManifest> {
+        None
+    }
+
+    /// Records build-time predicates captured during EIP-8130 authorization.
+    ///
+    /// Defaults to a no-op for transaction types that do not carry a manifest.
+    fn set_watch_manifest(&self, _watch_manifest: crate::WatchManifest) {}
+
     /// Returns whether this transaction belongs in the EIP-8130 sidecar.
     fn is_eip8130_sidecar_transaction(&self) -> bool {
         self.eip8130_nonce_channel_key().is_some() || self.eip8130_replay_id().is_some()
@@ -447,6 +465,14 @@ where
 
     fn limit_class(&self) -> Option<&crate::LimitClass> {
         self.limit_class.get()
+    }
+
+    fn watch_manifest(&self) -> Option<&crate::WatchManifest> {
+        self.watch_manifest.get()
+    }
+
+    fn set_watch_manifest(&self, watch_manifest: crate::WatchManifest) {
+        let _ = self.watch_manifest.set(watch_manifest);
     }
 
     fn set_limit_class(&self, limit_class: crate::LimitClass) {

--- a/crates/execution/txpool/src/transaction.rs
+++ b/crates/execution/txpool/src/transaction.rs
@@ -237,12 +237,18 @@ impl<Cons: InMemorySize, Pooled> InMemorySize for BasePooledTransaction<Cons, Po
     fn size(&self) -> usize {
         let watch_keys_size =
             self.watch_set.get().map_or(0, |watch_set| core::mem::size_of_val(watch_set.keys()));
+        let manifest_slots_size = self
+            .watch_manifest
+            .get()
+            .map_or(0, |manifest| core::mem::size_of_val(manifest.config_slots()));
         self.inner.size()
             + core::mem::size_of::<u128>()
             + core::mem::size_of::<Option<u64>>() * 3
             + core::mem::size_of::<OnceLock<crate::WatchSet>>()
             + watch_keys_size
             + core::mem::size_of::<OnceLock<crate::LimitClass>>()
+            + core::mem::size_of::<OnceLock<crate::WatchManifest>>()
+            + manifest_slots_size
     }
 }
 
@@ -587,7 +593,8 @@ mod tests {
     };
 
     use crate::{
-        BasePooledTransaction, BasePooledTx, BaseTransactionValidator, InvalidationKey, WatchSet,
+        BasePooledTransaction, BasePooledTx, BaseTransactionValidator, ConfigSlot, InvalidationKey,
+        WatchManifest, WatchSet,
     };
 
     fn signer() -> PrivateKeySigner {
@@ -674,5 +681,29 @@ mod tests {
         transaction.set_watch_set(watch_set);
 
         assert_eq!(transaction.size(), size_without_keys + keys_size);
+    }
+
+    #[test]
+    fn in_memory_size_includes_manifest_slots() {
+        let transaction = eip8130_pooled(U256::ZERO);
+        let size_without_slots = transaction.size();
+        let manifest = WatchManifest::new(
+            vec![
+                ConfigSlot { address: Address::ZERO, slot: U256::ZERO, expected: U256::ZERO },
+                ConfigSlot {
+                    address: Address::repeat_byte(1),
+                    slot: U256::from(1),
+                    expected: U256::from(2),
+                },
+            ],
+            Address::ZERO,
+            U256::ZERO,
+            u64::MAX,
+        );
+        let slots_size = core::mem::size_of_val(manifest.config_slots());
+
+        transaction.set_watch_manifest(manifest);
+
+        assert_eq!(transaction.size(), size_without_slots + slots_size);
     }
 }

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -1003,6 +1003,9 @@ where
             Self::validate_eip8130_create_freshness(&*state, sender, &sender_account)?;
         }
 
+        // Nonce validity is intentionally checked against canonical state, not
+        // authorization's speculative overlay writes. Those writes are effects
+        // of this transaction and cannot satisfy its own admission nonce.
         let mut storage = StateProviderPrecompileStorage::new(&*state, local_chain_id, now);
         StorageCtx::enter(&mut storage, |ctx| {
             let nonce_storage = NonceManagerStorage::new(ctx);

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -6,6 +6,7 @@ use std::{
         Arc,
         atomic::{AtomicU64, Ordering},
     },
+    time::Instant,
 };
 
 use alloy_consensus::{BlockHeader, Transaction, constants::KECCAK_EMPTY};
@@ -48,7 +49,10 @@ use revm::{
     state::{AccountInfo, Bytecode},
 };
 
-use crate::{BasePooledTx, InvalidationKey, LimitClass, WatchSet};
+use crate::{
+    BasePooledTx, ConfigSlot, InvalidationKey, LimitClass, ValidatorMetrics, WatchManifest,
+    WatchSet,
+};
 
 /// Base-specific transaction pool validation errors.
 #[derive(Debug, thiserror::Error)]
@@ -91,6 +95,8 @@ struct Eip8130ValidationState {
     payer_locked: bool,
     payer_trusted: bool,
     payer_max_cost: U256,
+    /// Authorization reads and predicates used for build-time revalidation.
+    manifest: WatchManifest,
 }
 
 const LIMIT_CLASS_CACHE_CAPACITY: NonZeroUsize = NonZeroUsize::new(100_000).unwrap();
@@ -388,7 +394,8 @@ struct OverlayPrecompileStorage<'a> {
     inner: StateProviderPrecompileStorage<'a>,
     storage: BTreeMap<(Address, U256), U256>,
     transient: BTreeMap<(Address, U256), U256>,
-    reads: BTreeSet<(Address, U256)>,
+    /// First base-state value read from each slot during authorization.
+    reads: BTreeMap<(Address, U256), U256>,
     code_reads: BTreeSet<Address>,
 }
 
@@ -398,9 +405,16 @@ impl<'a> OverlayPrecompileStorage<'a> {
             inner,
             storage: BTreeMap::new(),
             transient: BTreeMap::new(),
-            reads: BTreeSet::new(),
+            reads: BTreeMap::new(),
             code_reads: BTreeSet::new(),
         }
+    }
+
+    fn take_reads(&mut self) -> Vec<ConfigSlot> {
+        core::mem::take(&mut self.reads)
+            .into_iter()
+            .map(|((address, slot), expected)| ConfigSlot { address, slot, expected })
+            .collect()
     }
 }
 
@@ -466,7 +480,7 @@ impl PrecompileStorageProvider for OverlayPrecompileStorage<'_> {
             return Ok(*value);
         }
         let value = self.inner.sload(address, key)?;
-        self.reads.insert((address, key));
+        self.reads.entry((address, key)).or_insert(value);
         Ok(value)
     }
 
@@ -827,6 +841,19 @@ where
         transaction: Tx,
         state: &mut Option<Box<dyn AccountInfoReader + Send>>,
     ) -> TransactionValidationOutcome<Tx> {
+        let kind = if transaction.as_eip8130().is_some() { "eip8130" } else { "standard" };
+        let start = Instant::now();
+        let outcome = self.validate_one_with_state_inner(origin, transaction, state);
+        ValidatorMetrics::validate_seconds(kind).record(start.elapsed().as_secs_f64());
+        outcome
+    }
+
+    fn validate_one_with_state_inner(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Tx,
+        state: &mut Option<Box<dyn AccountInfoReader + Send>>,
+    ) -> TransactionValidationOutcome<Tx> {
         if transaction.is_eip4844() {
             return TransactionValidationOutcome::Invalid(
                 transaction,
@@ -847,6 +874,7 @@ where
             let propagate =
                 matches!(origin, TransactionOrigin::External | TransactionOrigin::Local);
             transaction.set_watch_set(state.watch_set.clone());
+            transaction.set_watch_manifest(state.manifest.clone());
             transaction.set_limit_class(LimitClass {
                 sender: state.sender,
                 payer: state.payer,
@@ -869,6 +897,38 @@ where
         }
         let outcome = self.inner.validate_one_with_state(origin, transaction, state);
         self.apply_base_checks(outcome, 0)
+    }
+
+    /// Returns a low-cardinality sender authenticator label for metrics.
+    fn sender_sig_type(signed: &Eip8130Signed) -> &'static str {
+        if signed.explicit_sender().is_none() {
+            return "k1";
+        }
+        Self::classify_authenticator(signed.sender_auth())
+    }
+
+    fn classify_authenticator(auth: &[u8]) -> &'static str {
+        let Some(selector) = auth.get(..20).map(Address::from_slice) else {
+            return "other";
+        };
+        if selector == Eip8130Constants::K1_AUTHENTICATOR {
+            "k1"
+        } else if selector == Eip8130Contracts::P256_AUTHENTICATOR {
+            "p256"
+        } else if selector == Eip8130Contracts::WEBAUTHN_AUTHENTICATOR {
+            "passkey"
+        } else if selector == Eip8130Contracts::DELEGATE_AUTHENTICATOR {
+            match auth.get(40..60).map(Address::from_slice) {
+                Some(nested) if nested == Eip8130Constants::K1_AUTHENTICATOR => "delegate-k1",
+                Some(nested) if nested == Eip8130Contracts::P256_AUTHENTICATOR => "delegate-p256",
+                Some(nested) if nested == Eip8130Contracts::WEBAUTHN_AUTHENTICATOR => {
+                    "delegate-passkey"
+                }
+                _ => "delegate",
+            }
+        } else {
+            "other"
+        }
     }
 
     /// Runs full EIP-8130 admission checks that require account/precompile state:
@@ -899,37 +959,40 @@ where
             local_chain_id,
             now,
         ));
-        let (sender, payer, sender_actor, is_create, payer_actor) =
-            StorageCtx::enter(&mut storage, |ctx| {
-                let applied = {
-                    let mut account_config = AccountConfigurationStorage::new(ctx);
-                    TransactionAuthorizer::authorize_and_apply(
-                        signed,
-                        &mut account_config,
-                        local_chain_id,
-                        now,
-                    )?
-                };
-                if let Some(delegation) = applied.applied.delegation {
-                    delegation.install(ctx).map_err(TxAuthError::from)?;
-                }
+        let auth_start = Instant::now();
+        let auth_result = StorageCtx::enter(&mut storage, |ctx| {
+            let applied = {
+                let mut account_config = AccountConfigurationStorage::new(ctx);
+                TransactionAuthorizer::authorize_and_apply(
+                    signed,
+                    &mut account_config,
+                    local_chain_id,
+                    now,
+                )?
+            };
+            if let Some(delegation) = applied.applied.delegation {
+                delegation.install(ctx).map_err(TxAuthError::from)?;
+            }
 
-                let sender = applied.actors.sender.account;
-                let payer = applied.actors.payer.map_or(sender, |actor| actor.account);
-                // Thread authoritative applied/actor data through rather than
-                // re-scanning account changes or re-resolving actors below.
-                let is_create = applied.applied.created.is_some();
-                Ok::<_, TxAuthError>((
-                    sender,
-                    payer,
-                    applied.actors.sender.resolved,
-                    is_create,
-                    applied.actors.payer.map(|actor| actor.resolved),
-                ))
-            })
-            .map_err(Self::map_tx_auth_error)?;
-        let authorization_reads = storage.reads.clone();
+            let sender = applied.actors.sender.account;
+            let payer = applied.actors.payer.map_or(sender, |actor| actor.account);
+            // Thread authoritative applied/actor data through rather than
+            // re-scanning account changes or re-resolving actors below.
+            let is_create = applied.applied.created.is_some();
+            Ok::<_, TxAuthError>((
+                sender,
+                payer,
+                applied.actors.sender.resolved,
+                is_create,
+                applied.actors.payer.map(|actor| actor.resolved),
+            ))
+        });
+        ValidatorMetrics::auth_seconds(Self::sender_sig_type(signed))
+            .record(auth_start.elapsed().as_secs_f64());
+        let (sender, payer, sender_actor, is_create, payer_actor) =
+            auth_result.map_err(Self::map_tx_auth_error)?;
         let authorization_code_reads = storage.code_reads.clone();
+        let config_reads = storage.take_reads();
 
         let sender_account = state
             .basic_account(&sender)
@@ -1004,17 +1067,14 @@ where
         let payer_auth_charge = U256::from(intrinsic.payer_auth)
             .saturating_mul(U256::from(signed.tx().max_fee_per_gas));
 
-        let effective_expiry = [
-            Self::expiry_or_unbounded(signed.tx().expiry),
-            Self::expiry_or_unbounded(sender_actor.expiry),
-            Self::expiry_or_unbounded(payer_actor.map_or(0, |actor| actor.expiry)),
-        ]
-        .into_iter()
-        .min()
-        .unwrap_or(u64::MAX);
+        let transaction_expiry = Self::expiry_or_unbounded(signed.tx().expiry);
+        let sender_expiry = Self::expiry_or_unbounded(sender_actor.expiry);
+        let payer_expiry = Self::expiry_or_unbounded(payer_actor.map_or(0, |actor| actor.expiry));
+        let effective_expiry =
+            [transaction_expiry, sender_expiry, payer_expiry].into_iter().min().unwrap_or(u64::MAX);
         let mut watch_set = WatchSet::new().watch(InvalidationKey::Balance(payer));
-        for (address, slot) in authorization_reads {
-            watch_set.push(InvalidationKey::Slot { address, slot: B256::from(slot) });
+        for read in &config_reads {
+            watch_set.push(InvalidationKey::Slot { address: read.address, slot: B256::from(read.slot) });
         }
         for address in authorization_code_reads {
             watch_set.push(InvalidationKey::CodeHash(address));
@@ -1088,6 +1148,16 @@ where
         let payer_max_cost = gas_charge
             .saturating_add(additional_fee)
             .saturating_add(if payer == sender { signed.tx().value() } else { U256::ZERO });
+        // Transaction expiry is exclusive (`now < expiry`) while actor expiry
+        // is inclusive (`now <= expiry`). Store the last timestamp at which all
+        // three predicates remain valid so `WatchManifest` can use one boundary.
+        let transaction_valid_through =
+            if signed.tx().expiry == 0 { u64::MAX } else { signed.tx().expiry.saturating_sub(1) };
+        let manifest_expiry = [transaction_valid_through, sender_expiry, payer_expiry]
+            .into_iter()
+            .min()
+            .unwrap_or(u64::MAX);
+        let manifest = WatchManifest::new(config_reads, payer, payer_max_cost, manifest_expiry);
 
         Ok(Eip8130ValidationState {
             sender,
@@ -1103,6 +1173,7 @@ where
             payer_locked,
             payer_trusted,
             payer_max_cost,
+            manifest,
         })
     }
 
@@ -1845,6 +1916,47 @@ mod tests {
             .no_cancun()
             .build(InMemoryBlobStore::default());
         BaseTransactionValidator::with_block_info(inner, BaseL1BlockInfo::default())
+    }
+
+    #[test]
+    fn classify_authenticator_uses_bounded_labels() {
+        let with = |selector: Address, tail: &[u8]| {
+            let mut blob = selector.as_slice().to_vec();
+            blob.extend_from_slice(tail);
+            blob
+        };
+        assert_eq!(
+            TestValidator::classify_authenticator(&with(
+                Eip8130Constants::K1_AUTHENTICATOR,
+                &[0; 65]
+            )),
+            "k1"
+        );
+        assert_eq!(
+            TestValidator::classify_authenticator(&with(
+                Eip8130Contracts::P256_AUTHENTICATOR,
+                &[0; 129]
+            )),
+            "p256"
+        );
+        assert_eq!(
+            TestValidator::classify_authenticator(&with(
+                Eip8130Contracts::WEBAUTHN_AUTHENTICATOR,
+                &[0; 8]
+            )),
+            "passkey"
+        );
+
+        let mut delegate = Eip8130Contracts::DELEGATE_AUTHENTICATOR.as_slice().to_vec();
+        delegate.extend_from_slice(&[0xbb; 20]);
+        delegate.extend_from_slice(Eip8130Contracts::WEBAUTHN_AUTHENTICATOR.as_slice());
+        assert_eq!(TestValidator::classify_authenticator(&delegate), "delegate-passkey");
+        assert_eq!(TestValidator::classify_authenticator(&[0; 10]), "other");
+    }
+
+    #[test]
+    fn sender_sig_type_identifies_eoa_path_as_k1() {
+        assert_eq!(TestValidator::sender_sig_type(&sign_eoa_eip8130(minimal_valid_eoa_tx())), "k1");
     }
 
     /// Returns the chain id the [`build_test_validator`] is configured against.
@@ -2790,6 +2902,44 @@ mod tests {
 
         assert!(!additional_fees.is_zero(), "fixture must charge L1/operator fees");
         assert_eq!(state.payer_max_cost, gas_charge.saturating_add(additional_fees));
+        assert_eq!(state.manifest.payer_max_cost(), state.payer_max_cost);
+    }
+
+    #[test]
+    fn nonce_free_manifest_uses_exclusive_transaction_expiry() {
+        let chain_spec = Arc::new(BaseChainSpecBuilder::base_mainnet().cobalt_activated().build());
+        let signer = PrivateKeySigner::random();
+        let now = 100;
+        let expiry = now + Eip8130Constants::NONCE_FREE_MAX_EXPIRY_WINDOW;
+        let tx = TxEip8130 {
+            nonce_key: Eip8130Constants::NONCE_KEY_MAX,
+            nonce_sequence: 0,
+            expiry,
+            ..minimal_valid_eoa_tx()
+        };
+        let signature = signer.sign_hash_sync(&tx.sender_signature_hash()).unwrap();
+        let signed =
+            Eip8130Signed::new(tx, Bytes::from(signature.as_bytes().to_vec()), Bytes::new());
+
+        let client = MockEthProvider::<BasePrimitives>::new()
+            .with_chain_spec(Arc::clone(&chain_spec))
+            .with_genesis_block();
+        client.add_account(
+            signer.address(),
+            ExtendedAccount::new(0, U256::from(1_000_000_000_000_000_000u64)),
+        );
+        let evm_config = BaseEvmConfig::base(Arc::clone(&chain_spec));
+        let inner = EthTransactionValidatorBuilder::new(client, evm_config)
+            .no_shanghai()
+            .no_cancun()
+            .build(InMemoryBlobStore::default());
+        let validator: TestValidator =
+            BaseTransactionValidator::with_block_info(inner, BaseL1BlockInfo::default());
+        let header = alloy_consensus::Header { timestamp: now, ..Default::default() };
+        validator.update_l1_block_info::<_, TxEip1559>(&header, None);
+
+        let state = validator.validate_eip8130_full(&signed).expect("valid nonce-free tx");
+        assert_eq!(state.manifest.effective_expiry(), expiry - 1);
     }
 
     /// Builds a K1 authenticator-prefixed auth blob (`K1(20) || r || s || v`,
@@ -2922,6 +3072,22 @@ mod tests {
             .expect("create + config change must be admitted via the overlay");
         assert_eq!(state.sender, derived);
         assert_eq!(state.payer, derived, "self-paid create");
+        assert!(!state.manifest.has_no_config_slots(), "authorization reads must be captured");
+        assert_eq!(state.manifest.payer(), derived);
+        for read in state.manifest.config_slots() {
+            assert_eq!(
+                read.expected,
+                U256::ZERO,
+                "overlay-buffered writes must not become base-state dependencies"
+            );
+            assert!(
+                state.watch_set.contains(&InvalidationKey::Slot {
+                    address: read.address,
+                    slot: b256_from_u256(read.slot),
+                }),
+                "captured read must also be indexed for invalidation: {read:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -1077,7 +1077,8 @@ where
             [transaction_expiry, sender_expiry, payer_expiry].into_iter().min().unwrap_or(u64::MAX);
         let mut watch_set = WatchSet::new().watch(InvalidationKey::Balance(payer));
         for read in &config_reads {
-            watch_set.push(InvalidationKey::Slot { address: read.address, slot: B256::from(read.slot) });
+            watch_set
+                .push(InvalidationKey::Slot { address: read.address, slot: B256::from(read.slot) });
         }
         for address in authorization_code_reads {
             watch_set.push(InvalidationKey::CodeHash(address));
@@ -3086,7 +3087,7 @@ mod tests {
             assert!(
                 state.watch_set.contains(&InvalidationKey::Slot {
                     address: read.address,
-                    slot: b256_from_u256(read.slot),
+                    slot: B256::from(read.slot),
                 }),
                 "captured read must also be indexed for invalidation: {read:?}"
             );


### PR DESCRIPTION
## Summary

- capture the exact base-state storage values read during EIP-8130 authorization and carry them as a pooled transaction manifest
- conservatively revalidate authorization slots, payer funding, and expiry against accumulating state in both payload builders
- expose a default-on builder flag and add bounded precheck/validation timing metrics
- preserve independent nonce-free replay-ID lanes when one manifest is stale

## Stack

PR 6. Based on #4002 and independent of the flashblock invalidation feeder in #4003.
