### PR TITLE
fix(reth-cli): update snapshot URLs

### DIFF
--- a/crates/utilities/reth-cli/src/snapshots.rs
+++ b/crates/utilities/reth-cli/src/snapshots.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 use reth_cli_commands::download::DownloadDefaults;
 
 pub(crate) const DEFAULT_DOWNLOAD_URL: &str = "https://v2-snapshots-ui.vercel.app/8453";
-const SNAPSHOT_API_URL: &str = "https://v2-snapshots-ui.vercel.app/api/snapshots";
+const SNAPSHOT_API_URL: &str = "https://chain.base.org/api/snapshots";
 
 /// Reth snapshot download URLs initialization for Base execution layer binaries
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/crates/utilities/reth-cli/src/snapshots.rs
+++ b/crates/utilities/reth-cli/src/snapshots.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 use reth_cli_commands::download::DownloadDefaults;
 
-pub(crate) const DEFAULT_DOWNLOAD_URL: &str = "https://v2-snapshots-ui.vercel.app/8453";
+pub(crate) const DEFAULT_DOWNLOAD_URL: &str = "https://chain.base.org/8453";
 const SNAPSHOT_API_URL: &str = "https://chain.base.org/api/snapshots";
 
 /// Reth snapshot download URLs initialization for Base execution layer binaries
@@ -25,8 +25,8 @@ impl Snapshots {
         let download_defaults = DownloadDefaults {
             available_snapshots: vec![
                 Cow::Owned(format!("{DEFAULT_DOWNLOAD_URL} (mainnet)")),
-                Cow::Borrowed("https://v2-snapshots-ui.vercel.app/84532 (sepolia)"),
-                Cow::Borrowed("https://v2-snapshots-ui.vercel.app/763360 (zeronet)"),
+                Cow::Borrowed("https://chain.base.org/84532 (sepolia)"),
+                Cow::Borrowed("https://chain.base.org/763360 (zeronet)"),
             ],
             default_base_url: Cow::Borrowed(DEFAULT_DOWNLOAD_URL),
             default_chain_aware_base_url: None,


### PR DESCRIPTION
## Summary

- replace every `https://v2-snapshots-ui.vercel.app` snapshot URL with `https://chain.base.org`
- preserve the mainnet, Sepolia, Zeronet, and API URL paths

## Testing

- `cargo check -p base-reth-cli`
- verified no references to the old host remain