### PR TITLE
refactor(builder-core): componentize the flashblock build loop into gates + a reporter

### DIFF
--- a/crates/builder/core/src/execution.rs
+++ b/crates/builder/core/src/execution.rs
@@ -239,15 +239,33 @@ impl ExecutionInfo {
         }
     }
 
-    /// Returns true if the transaction would exceed the block limits:
-    /// - block gas limit: ensures the transaction still fits into the block.
+    /// Returns an error if the transaction would exceed any block limit.
+    ///
+    /// Checks the hard limits first (see [`is_tx_over_hard_limits`](Self::is_tx_over_hard_limits)),
+    /// then the metering limits (see
+    /// [`is_tx_over_metering_limits`](Self::is_tx_over_metering_limits)). The split lets callers
+    /// evaluate the two classes independently — hard limits are always enforced, while metering
+    /// limits depend on metering-service predictions and may run in dry-run mode.
+    pub fn is_tx_over_limits(
+        &self,
+        tx: &TxResources,
+        limits: &ResourceLimits,
+    ) -> Result<(), TxnExecutionError> {
+        self.is_tx_over_hard_limits(tx, limits)?;
+        self.is_tx_over_metering_limits(tx, limits)?;
+        Ok(())
+    }
+
+    /// Returns an error if the transaction would exceed a hard limit. Hard limits require no
+    /// metering data and are always enforced:
     /// - tx DA limit: if configured, ensures the tx does not exceed the maximum allowed DA limit
     ///   per tx.
     /// - block DA limit: if configured, ensures the transaction's DA size does not exceed the
     ///   maximum allowed DA limit per block.
-    /// - execution time limit: if configured with metering data, ensures the transaction's
-    ///   predicted execution time does not exceed the per-transaction limit.
-    pub fn is_tx_over_limits(
+    /// - DA footprint limit: post-Jovian, ensures the block DA footprint stays within budget.
+    /// - block gas limit: ensures the transaction still fits into the block.
+    /// - block uncompressed size limit: if configured, ensures the block stays within budget.
+    pub fn is_tx_over_hard_limits(
         &self,
         tx: &TxResources,
         limits: &ResourceLimits,
@@ -305,13 +323,28 @@ impl ExecutionInfo {
             }
         }
 
+        Ok(())
+    }
+
+    /// Returns an error if the transaction would exceed a metering limit. Metering limits depend on
+    /// metering-service predictions and are only checked when the prediction is present:
+    /// - per-transaction execution time limit: if configured with metering data, ensures the
+    ///   transaction's predicted execution time does not exceed the per-transaction limit.
+    ///
+    /// Returns [`ExecutionMeteringLimitExceeded`] (not [`TxnExecutionError`]) so callers can apply
+    /// dry-run/enforce handling without matching on the broader error enum.
+    pub const fn is_tx_over_metering_limits(
+        &self,
+        tx: &TxResources,
+        limits: &ResourceLimits,
+    ) -> Result<(), ExecutionMeteringLimitExceeded> {
         // Check execution time limits (if metering data is available)
         if let Some(tx_time) = tx.execution_time_us {
             // Check per-transaction execution time limit
             if let Some(tx_limit) = limits.tx_execution_time_limit_us
                 && tx_time > tx_limit
             {
-                return Err(TransactionExecutionTime(tx_time, tx_limit).into());
+                return Err(TransactionExecutionTime(tx_time, tx_limit));
             }
         }
 
@@ -568,5 +601,63 @@ mod tests {
             TxResources { gas_limit: 21_000, uncompressed_size: 1_000_000, ..Default::default() };
 
         assert!(info.is_tx_over_limits(&tx, &limits).is_ok());
+    }
+
+    // ==================== Hard vs Metering Split Tests ====================
+
+    #[test]
+    fn test_hard_limits_ignore_execution_time() {
+        // A tx over its per-tx execution time limit is *not* a hard-limit violation.
+        let info = ExecutionInfo::with_capacity(10);
+        let limits =
+            ResourceLimits { tx_execution_time_limit_us: Some(1_000_000), ..default_limits() };
+        let tx = TxResources {
+            gas_limit: 21_000,
+            execution_time_us: Some(1_500_000),
+            ..Default::default()
+        };
+
+        assert!(info.is_tx_over_hard_limits(&tx, &limits).is_ok());
+    }
+
+    #[test]
+    fn test_hard_limits_catch_gas() {
+        let mut info = ExecutionInfo::with_capacity(10);
+        info.cumulative_gas_used = 29_990_000;
+        let limits = default_limits();
+        let tx = TxResources { gas_limit: 21_000, ..Default::default() };
+
+        assert!(matches!(
+            info.is_tx_over_hard_limits(&tx, &limits),
+            Err(TxnExecutionError::TransactionGasLimitExceeded { .. })
+        ));
+    }
+
+    #[test]
+    fn test_metering_limits_ignore_hard_limits() {
+        // A tx over the block gas limit is *not* a metering-limit violation.
+        let mut info = ExecutionInfo::with_capacity(10);
+        info.cumulative_gas_used = 29_990_000;
+        let limits = default_limits();
+        let tx = TxResources { gas_limit: 21_000, ..Default::default() };
+
+        assert!(info.is_tx_over_metering_limits(&tx, &limits).is_ok());
+    }
+
+    #[test]
+    fn test_metering_limits_catch_execution_time() {
+        let info = ExecutionInfo::with_capacity(10);
+        let limits =
+            ResourceLimits { tx_execution_time_limit_us: Some(1_000_000), ..default_limits() };
+        let tx = TxResources {
+            gas_limit: 21_000,
+            execution_time_us: Some(1_500_000),
+            ..Default::default()
+        };
+
+        assert!(matches!(
+            info.is_tx_over_metering_limits(&tx, &limits),
+            Err(ExecutionMeteringLimitExceeded::TransactionExecutionTime(1_500_000, 1_000_000))
+        ));
     }
 }

--- a/crates/builder/core/src/flashblocks/candidate_source.rs
+++ b/crates/builder/core/src/flashblocks/candidate_source.rs
@@ -1,0 +1,139 @@
+//! Pool candidate sourcing for the flashblock build loop.
+//!
+//! [`PoolCandidateSource`] wraps the payload transaction iterator and yields raw, fully
+//! materialized [`Candidate`]s. It makes no admission decisions — bundle-window validity travels
+//! on the candidate as a [`BundleWindow`] for the gates to judge — so the build walk owns the gate
+//! sequence and the source owns only iteration and materialization.
+
+use alloy_consensus::Transaction;
+use alloy_eips::Encodable2718;
+use alloy_primitives::{Address, B256, TxHash};
+use base_bundles::MeterBundleResponse;
+use base_common_consensus::BaseTransactionSigned;
+use base_execution_txpool::{
+    BasePooledTx, BundleTransaction, TimestampedTransaction, WatchManifest,
+    estimated_da_size::DataAvailabilitySized,
+};
+use reth_primitives_traits::Recovered;
+use reth_transaction_pool::PoolTransaction;
+
+use crate::{PayloadTxsBounds, TxResources};
+
+/// A bundle transaction's validity window, carried on a [`Candidate`] so the gate can evaluate a
+/// materialized candidate without retaining the pool transaction.
+///
+/// Implements [`BundleTransaction`] purely so it reuses that trait's default `is_bundle_expired` /
+/// `is_bundle_not_yet_valid` predicates — the single source of truth for bundle-window logic.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BundleWindow {
+    /// The target block number, if set.
+    pub target_block: Option<u64>,
+    /// The minimum validity timestamp in milliseconds, if set.
+    pub min_timestamp_millis: Option<u64>,
+    /// The maximum validity timestamp in milliseconds, if set.
+    pub max_timestamp_millis: Option<u64>,
+}
+
+impl BundleTransaction for BundleWindow {
+    fn target_block_number(&self) -> Option<u64> {
+        self.target_block
+    }
+
+    fn min_timestamp_millis(&self) -> Option<u64> {
+        self.min_timestamp_millis
+    }
+
+    fn max_timestamp_millis(&self) -> Option<u64> {
+        self.max_timestamp_millis
+    }
+}
+
+/// A materialized pool candidate threaded through the admission gates.
+///
+/// The source populates everything except the metering-derived fields: [`resources`] starts with
+/// no execution-time prediction and [`resource_usage`] is `None`. The resource-limits gate enriches
+/// both from metering-service data during evaluation.
+///
+/// [`resources`]: Candidate::resources
+/// [`resource_usage`]: Candidate::resource_usage
+#[derive(Debug)]
+pub struct Candidate {
+    /// Recovered consensus transaction.
+    pub tx: Recovered<BaseTransactionSigned>,
+    /// Transaction hash.
+    pub tx_hash: TxHash,
+    /// Time the transaction was received, in milliseconds since the Unix epoch.
+    pub received_at_ms: u128,
+    /// Bundle validity window (empty for non-bundle transactions).
+    pub bundle: BundleWindow,
+    /// EIP-8130 authorization manifest to revalidate against on-chain state, if the transaction
+    /// carries one.
+    pub watch_manifest: Option<WatchManifest>,
+    /// EIP-8130 replay identifier, if applicable. Nonce-free replay-ID entries are independent, so
+    /// a manifest-precheck drop must not mark the sender's other entries invalid.
+    pub eip8130_replay_id: Option<B256>,
+    /// Effective priority fee (tip per gas), used as the value for rejection metrics.
+    pub priority_fee: f64,
+    /// Estimated resource usage; execution time is filled in by the resource-limits gate.
+    pub resources: TxResources,
+    /// Raw metering response, if any; filled in by the resource-limits gate.
+    pub resource_usage: Option<MeterBundleResponse>,
+}
+
+/// Sources fully materialized candidate transactions from a payload transaction iterator.
+#[derive(Debug)]
+pub struct PoolCandidateSource<'a, T> {
+    best_txs: &'a mut T,
+    base_fee: u64,
+}
+
+impl<'a, T: PayloadTxsBounds> PoolCandidateSource<'a, T> {
+    /// Creates a source over the given iterator, using `base_fee` to compute each candidate's
+    /// priority fee.
+    pub const fn new(best_txs: &'a mut T, base_fee: u64) -> Self {
+        Self { best_txs, base_fee }
+    }
+
+    /// Returns the next fully materialized candidate, or `None` when the pool is drained.
+    pub fn next_candidate(&mut self) -> Option<Candidate> {
+        let tx = self.best_txs.next(())?;
+
+        let bundle = BundleWindow {
+            target_block: tx.target_block_number(),
+            min_timestamp_millis: tx.min_timestamp_millis(),
+            max_timestamp_millis: tx.max_timestamp_millis(),
+        };
+        let da_size = tx.estimated_da_size();
+        let received_at_ms = tx.received_at();
+        // Capture the EIP-8130 manifest and replay id before `into_consensus` drops the pool tx.
+        let watch_manifest = tx.watch_manifest().cloned();
+        let eip8130_replay_id = tx.eip8130_replay_id();
+        let tx = tx.into_consensus();
+        let tx_hash = tx.tx_hash();
+        let uncompressed_size = tx.encode_2718_len() as u64;
+        let gas_limit = tx.gas_limit();
+        let priority_fee = tx.effective_tip_per_gas(self.base_fee).unwrap_or(0) as f64;
+
+        Some(Candidate {
+            tx,
+            tx_hash,
+            received_at_ms,
+            bundle,
+            watch_manifest,
+            eip8130_replay_id,
+            priority_fee,
+            resources: TxResources {
+                da_size,
+                gas_limit,
+                execution_time_us: None,
+                uncompressed_size,
+            },
+            resource_usage: None,
+        })
+    }
+
+    /// Marks a sender/nonce as invalid on the underlying iterator so its descendants are skipped.
+    pub fn mark_invalid(&mut self, sender: Address, nonce: u64) {
+        self.best_txs.mark_invalid(sender, nonce);
+    }
+}

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -1,8 +1,5 @@
 use core::fmt::Debug;
-use std::{
-    sync::Arc,
-    time::{Instant, SystemTime, UNIX_EPOCH},
-};
+use std::{sync::Arc, time::Instant};
 
 use alloy_consensus::{Eip658Value, Transaction};
 use alloy_eips::{Encodable2718, Typed2718};
@@ -11,7 +8,7 @@ use alloy_evm::Database;
 use alloy_primitives::B256;
 use alloy_primitives::{BlockHash, Bytes, TxHash, U256};
 use alloy_rpc_types_eth::Withdrawals;
-use base_bundles::{MeterBundleResponse, RejectedTransaction, RejectionReason};
+use base_bundles::RejectedTransaction;
 use base_common_chains::Upgrades;
 use base_common_consensus::{BaseReceipt, BaseTransactionSigned, DepositReceipt, OpTxType};
 use base_common_evm::{BaseReceiptBuilder, BaseSpecId, L1BlockInfo};
@@ -20,11 +17,6 @@ use base_execution_evm::{BaseEvmConfig, BaseNextBlockEnvAttributes};
 use base_execution_payload_builder::{
     BasePayloadBuilderAttributes, error::BasePayloadBuilderError,
 };
-use base_execution_txpool::{
-    BasePooledTx, BundleTransaction, GuardMetrics, TimestampedTransaction,
-    estimated_da_size::DataAvailabilitySized,
-};
-use base_observability_events::TransactionEventType;
 use reth_basic_payload_builder::PayloadConfig;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_evm::{
@@ -35,26 +27,24 @@ use reth_payload_builder::PayloadId;
 use reth_payload_primitives::PayloadAttributes;
 use reth_primitives_traits::{InMemorySize, SealedHeader, SignedTransaction};
 use reth_revm::{State, context::Block};
-use reth_transaction_pool::{BestTransactionsAttributes, PoolTransaction};
+use reth_transaction_pool::BestTransactionsAttributes;
 use revm::{DatabaseCommit, context::result::ResultAndState, interpreter::as_u64_saturated};
-use serde::Serialize;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{Level, debug, span, trace, warn};
 
 use crate::{
     BuilderConfig, BuilderMetrics, ExecutionInfo, ExecutionMeteringLimitExceeded, PayloadTxsBounds,
-    ResourceLimits, TxResources, TxnExecutionError, TxnOutcome,
-    transaction_events::{
-        BuilderAcceptedEventData, BuilderConsideredEventData, BuilderRejectedEventData,
-        BuilderTransactionEventContext, emit_builder_transaction_event, rejection_reason_code,
+    ResourceLimits, TxnExecutionError,
+    flashblocks::{
+        candidate_source::{Candidate, PoolCandidateSource},
+        gates::{
+            BundleGate, Gate, GateRejection, GateVerdict, ManifestGate, ResourceLimitsGate,
+            SequencerGate,
+        },
+        reporter::{OutcomeReporter, ReportedTx},
     },
 };
-
-/// Records the priority fee of a rejected transaction with the given reason as a label.
-fn record_rejected_tx_priority_fee(reason: &TxnExecutionError, priority_fee: f64) {
-    BuilderMetrics::rejected_tx_priority_fee(rejection_reason_code(reason)).record(priority_fee);
-}
 
 /// Diagnostics captured during a single flashblock's transaction execution.
 ///
@@ -410,32 +400,6 @@ impl BasePayloadBuilderCtx {
         self.chain_spec.chain_id()
     }
 
-    fn record_rejected_tx(
-        &self,
-        info: &mut ExecutionInfo,
-        tx_hash: TxHash,
-        reason: RejectionReason,
-        metering: MeterBundleResponse,
-    ) {
-        if self.rejected_tx_sender.is_none() {
-            return;
-        }
-
-        if info.rejected_txs.len() >= self.builder_config.max_rejected_txs_per_block {
-            BuilderMetrics::rejected_tx_per_block_drops().increment(1);
-            return;
-        }
-
-        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
-        info.rejected_txs.push(RejectedTransaction {
-            tx_hash,
-            block_number: self.block_number(),
-            reason,
-            timestamp: now,
-            metering,
-        });
-    }
-
     /// Flushes all accumulated rejected transactions to the audit-archiver channel
     /// as a single per-block batch.
     pub fn flush_rejected_txs(&self, info: &mut ExecutionInfo) {
@@ -456,44 +420,6 @@ impl BasePayloadBuilderCtx {
                 );
             }
         }
-    }
-
-    fn builder_transaction_event_context(
-        &self,
-        payload_id: &str,
-        ordering_position: Option<u64>,
-        block_hash: Option<BlockHash>,
-    ) -> BuilderTransactionEventContext {
-        BuilderTransactionEventContext {
-            payload_id: payload_id.to_string(),
-            block_number: self.block_number(),
-            block_hash,
-            parent_hash: self.parent_hash(),
-            flashblock_index: Some(self.flashblock_index()),
-            target_flashblock_count: self.target_flashblock_count(),
-            ordering_position,
-            builder_mode: "flashblocks",
-            source_queue: "txpool_best",
-        }
-    }
-
-    fn emit_builder_decision_event<D, F>(
-        &self,
-        payload_id: &str,
-        event_type: TransactionEventType,
-        tx_hash: TxHash,
-        ordering_position: Option<u64>,
-        data: F,
-    ) where
-        D: Serialize,
-        F: FnOnce() -> D,
-    {
-        emit_builder_transaction_event(
-            self.builder_transaction_event_context(payload_id, ordering_position, None),
-            event_type,
-            tx_hash,
-            data,
-        );
     }
 }
 
@@ -675,396 +601,71 @@ impl BasePayloadBuilderCtx {
         let block_number = as_u64_saturated!(self.evm_env.block_env.number);
         let block_timestamp = self.attributes().timestamp();
         let payload_id = self.payload_id().to_string();
+        let reporter = OutcomeReporter::new(self, &payload_id);
+        let gates = BundleGate::new(block_number, block_timestamp)
+            .then(ManifestGate::new(self.builder_config.manifest_precheck_enabled, block_timestamp))
+            .then(ResourceLimitsGate::new(
+                &self.builder_config.metering_provider,
+                self.builder_config.metering_wait_duration,
+                self.builder_config.execution_metering_mode,
+            ))
+            .then(SequencerGate);
+        let mut source = PoolCandidateSource::new(best_txs, base_fee);
 
-        while let Some(tx) = best_txs.next(()) {
-            if let Some(target) = tx.target_block_number()
-                && target != block_number
-            {
-                let tx_hash = *tx.hash();
-                num_txs_considered += 1;
-                let ordering_position = num_txs_considered;
-                trace!(
-                    target: "payload_builder",
-                    tx_hash = ?tx_hash,
-                    target_block = target,
-                    current_block = block_number,
-                    "skipping bundle tx: wrong target block"
-                );
-                self.emit_builder_decision_event(
-                    &payload_id,
-                    TransactionEventType::BuilderConsidered,
-                    tx_hash,
-                    Some(ordering_position),
-                    || {
-                        BuilderConsideredEventData::new(info, limits, None)
-                            .with_bundle_target_block(target)
-                    },
-                );
-                self.emit_builder_decision_event(
-                    &payload_id,
-                    TransactionEventType::BuilderRejected,
-                    tx_hash,
-                    Some(ordering_position),
-                    || {
-                        BuilderRejectedEventData::new(
-                            "wrong_target_block",
-                            "bundle target block does not match current block",
-                            false,
-                            info,
-                            limits,
-                            None,
-                        )
-                        .with_bundle_target_block(target)
-                        .with_current_block(block_number)
-                    },
-                );
-                best_txs.mark_invalid(tx.sender(), tx.nonce());
-                continue;
-            }
-
-            if tx.is_bundle_expired(block_number, block_timestamp) {
-                let tx_hash = *tx.hash();
-                num_txs_considered += 1;
-                let ordering_position = num_txs_considered;
-                trace!(
-                    target: "payload_builder",
-                    tx_hash = ?tx_hash,
-                    block = block_number,
-                    timestamp = block_timestamp,
-                    "skipping bundle tx: expired"
-                );
-                self.emit_builder_decision_event(
-                    &payload_id,
-                    TransactionEventType::BuilderConsidered,
-                    tx_hash,
-                    Some(ordering_position),
-                    || BuilderConsideredEventData::new(info, limits, None),
-                );
-                self.emit_builder_decision_event(
-                    &payload_id,
-                    TransactionEventType::BuilderRejected,
-                    tx_hash,
-                    Some(ordering_position),
-                    || {
-                        BuilderRejectedEventData::new(
-                            "bundle_expired",
-                            "bundle validity window expired",
-                            false,
-                            info,
-                            limits,
-                            None,
-                        )
-                        .with_block_timestamp(block_timestamp)
-                    },
-                );
-                best_txs.mark_invalid(tx.sender(), tx.nonce());
-                continue;
-            }
-
-            if tx.is_bundle_not_yet_valid(block_timestamp) {
-                let tx_hash = *tx.hash();
-                num_txs_considered += 1;
-                let ordering_position = num_txs_considered;
-                trace!(
-                    target: "payload_builder",
-                    tx_hash = ?tx_hash,
-                    block = block_number,
-                    timestamp = block_timestamp,
-                    "skipping bundle tx: not yet valid"
-                );
-                self.emit_builder_decision_event(
-                    &payload_id,
-                    TransactionEventType::BuilderConsidered,
-                    tx_hash,
-                    Some(ordering_position),
-                    || BuilderConsideredEventData::new(info, limits, None),
-                );
-                self.emit_builder_decision_event(
-                    &payload_id,
-                    TransactionEventType::BuilderRejected,
-                    tx_hash,
-                    Some(ordering_position),
-                    || {
-                        BuilderRejectedEventData::new(
-                            "bundle_not_yet_valid",
-                            "bundle validity window has not started",
-                            false,
-                            info,
-                            limits,
-                            None,
-                        )
-                        .with_block_timestamp(block_timestamp)
-                    },
-                );
-                best_txs.mark_invalid(tx.sender(), tx.nonce());
-                continue;
-            }
-
-            if self.builder_config.manifest_precheck_enabled
-                && let Some(manifest) = tx.watch_manifest()
-                && let Err(stale) = manifest.revalidate(evm.db_mut(), block_timestamp)
-            {
-                let tx_hash = *tx.hash();
-                num_txs_considered += 1;
-                let ordering_position = num_txs_considered;
-                trace!(
-                    target: "payload_builder",
-                    tx_hash = ?tx_hash,
-                    cause = stale.cause(),
-                    "skipping EIP-8130 transaction with stale authorization manifest"
-                );
-                GuardMetrics::record_builder_precheck_drop(&stale);
-                self.emit_builder_decision_event(
-                    &payload_id,
-                    TransactionEventType::BuilderConsidered,
-                    tx_hash,
-                    Some(ordering_position),
-                    || BuilderConsideredEventData::new(info, limits, None),
-                );
-                self.emit_builder_decision_event(
-                    &payload_id,
-                    TransactionEventType::BuilderRejected,
-                    tx_hash,
-                    Some(ordering_position),
-                    || {
-                        BuilderRejectedEventData::new(
-                            "manifest_precheck_stale",
-                            stale.cause(),
-                            false,
-                            info,
-                            limits,
-                            None,
-                        )
-                    },
-                );
-                diag.txs_rejected_other += 1;
-                // Nonce-free replay-ID entries are independent. The upstream
-                // payload adapter invalidates by sender (not by replay ID), so
-                // marking one would suppress unrelated entries from this sender.
-                // This transaction has already been consumed from the iterator.
-                if tx.eip8130_replay_id().is_none() {
-                    best_txs.mark_invalid(tx.sender(), tx.nonce());
-                }
-                continue;
-            }
-
-            let tx_da_size = tx.estimated_da_size();
-            let tx_received_at_ms = tx.received_at();
-            let tx = tx.into_consensus();
-            let tx_hash = tx.tx_hash();
-            let tx_uncompressed_size = tx.encode_2718_len() as u64;
-
-            let log_txn = |result: Result<TxnOutcome, TxnExecutionError>| {
-                let result_str = match &result {
-                    Ok(outcome) => outcome.to_string(),
-                    Err(err) => err.to_string(),
-                };
-                debug!(
-                    target: "payload_builder",
-                    message = "Considering transaction",
-                    tx_hash = ?tx_hash,
-                    tx_da_size = ?tx_da_size,
-                    result = %result_str,
-                );
-            };
-
+        while let Some(mut candidate) = source.next_candidate() {
             num_txs_considered += 1;
             let ordering_position = num_txs_considered;
 
-            let resource_usage = self.builder_config.metering_provider.get(&tx_hash);
-
-            // Skip transactions that are too young and don't have metering data yet
-            if self.builder_config.metering_provider.is_enabled()
-                && resource_usage.is_none()
-                && let Some(wait_duration) = self.builder_config.metering_wait_duration
-            {
-                let now_ms = SystemTime::now()
-                    .duration_since(SystemTime::UNIX_EPOCH)
-                    .map(|d| d.as_millis())
-                    .unwrap_or(0);
-                let tx_age_ms = now_ms.saturating_sub(tx_received_at_ms);
-                if tx_age_ms < wait_duration.as_millis() {
-                    let err = TxnExecutionError::MeteringDataPending;
-                    let tx_resources = TxResources {
-                        da_size: tx_da_size,
-                        gas_limit: tx.gas_limit(),
-                        execution_time_us: None,
-                        uncompressed_size: tx_uncompressed_size,
-                    };
-                    self.emit_builder_decision_event(
-                        &payload_id,
-                        TransactionEventType::BuilderConsidered,
-                        tx_hash,
-                        Some(ordering_position),
-                        || {
-                            BuilderConsideredEventData::new(info, limits, Some(&tx_resources))
-                                .with_metering_wait(tx_age_ms, wait_duration.as_millis())
-                        },
-                    );
-                    self.emit_builder_decision_event(
-                        &payload_id,
-                        TransactionEventType::BuilderRejected,
-                        tx_hash,
-                        Some(ordering_position),
-                        || {
-                            BuilderRejectedEventData::from_error(
-                                &err,
-                                info,
-                                limits,
-                                Some(&tx_resources),
-                            )
-                            .with_metering_wait(tx_age_ms, wait_duration.as_millis())
-                        },
-                    );
-                    log_txn(Err(err));
-                    BuilderMetrics::metering_data_pending_skip().increment(1);
-                    self.builder_config.metering_provider.skip(&tx_hash);
-                    best_txs.mark_invalid(tx.signer(), tx.nonce());
-                    continue;
-                }
-            }
-
-            // Extract predicted execution time from metering data
-            let predicted_execution_time_us =
-                resource_usage.as_ref().map(|m| m.total_execution_time_us);
-
-            // Build tx resources struct
-            let tx_resources = TxResources {
-                da_size: tx_da_size,
-                gas_limit: tx.gas_limit(),
-                execution_time_us: predicted_execution_time_us,
-                uncompressed_size: tx_uncompressed_size,
-            };
-            self.emit_builder_decision_event(
-                &payload_id,
-                TransactionEventType::BuilderConsidered,
-                tx_hash,
-                Some(ordering_position),
-                || BuilderConsideredEventData::new(info, limits, Some(&tx_resources)),
+            // Emit the considered event up front, before any gate, so its timestamp marks when the
+            // builder began evaluating the candidate. Decision-specific context (bundle window,
+            // metering wait, dry-run) and the metering estimate land on the terminal event.
+            reporter.considered(
+                ReportedTx {
+                    tx_hash: candidate.tx_hash,
+                    ordering_position,
+                    resources: Some(&candidate.resources),
+                    priority_fee: candidate.priority_fee,
+                },
+                info,
+                limits,
             );
 
-            // ensure we still have capacity for this transaction
-            if let Err(err) = info.is_tx_over_limits(&tx_resources, limits) {
-                // Check if this is an execution metering limit that should be handled
-                // according to the metering mode (dry-run vs enforce)
-                if let TxnExecutionError::ExecutionMeteringLimitExceeded(ref limit_err) = err {
-                    // Record metrics for the exceeded limit
-                    self.record_execution_metering_limit_exceeded(limit_err);
+            // Run the compound admission gate; it stops at the first rejection. The resource-limits
+            // gate enriches the candidate with its metering estimate along the way.
+            let rejection = match gates.evaluate(&mut candidate, info, limits, evm.db_mut()) {
+                GateVerdict::Admit => None,
+                GateVerdict::Reject(r) => Some(r),
+            };
 
-                    let priority_fee = tx.effective_tip_per_gas(base_fee).unwrap_or(0) as f64;
-                    let dry_run = self.builder_config.execution_metering_mode.is_dry_run();
+            let Candidate {
+                tx,
+                tx_hash,
+                resources: tx_resources,
+                resource_usage,
+                priority_fee,
+                eip8130_replay_id,
+                ..
+            } = candidate;
+            let tx_da_size = tx_resources.da_size;
+            let tx_uncompressed_size = tx_resources.uncompressed_size;
+            let predicted_execution_time_us = tx_resources.execution_time_us;
 
-                    warn!(
-                        target: "payload_builder",
-                        message = if dry_run {
-                            "Metering throttle: transaction would be rejected (dry-run)"
-                        } else {
-                            "Metering throttle: transaction rejected"
-                        },
-                        tx_hash = ?tx_hash,
-                        limit = %limit_err,
-                        priority_fee,
-                        dry_run,
-                    );
+            let reported = ReportedTx {
+                tx_hash,
+                ordering_position,
+                resources: Some(&tx_resources),
+                priority_fee,
+            };
 
-                    if !dry_run {
-                        diag.record_rejection(&err);
-                        record_rejected_tx_priority_fee(&err, priority_fee);
-                        if err.is_permanent() {
-                            diag.permanently_rejected_txs.push(tx_hash);
-                        }
-
-                        let ExecutionMeteringLimitExceeded::TransactionExecutionTime(
-                            tx_time_us,
-                            limit_us,
-                        ) = limit_err;
-                        // Only record per-tx execution time limits for the audit trail for now
-                        self.record_rejected_tx(
-                            info,
-                            tx_hash,
-                            RejectionReason::ExecutionTimeExceeded {
-                                tx_time_us: *tx_time_us,
-                                limit_us: *limit_us,
-                            },
-                            resource_usage.unwrap_or_default(),
-                        );
-
-                        self.emit_builder_decision_event(
-                            &payload_id,
-                            TransactionEventType::BuilderRejected,
-                            tx_hash,
-                            Some(ordering_position),
-                            || {
-                                BuilderRejectedEventData::from_error(
-                                    &err,
-                                    info,
-                                    limits,
-                                    Some(&tx_resources),
-                                )
-                                .with_dry_run(false)
-                            },
-                        );
-                        log_txn(Err(err));
-                        best_txs.mark_invalid(tx.signer(), tx.nonce());
-                        continue;
-                    }
-                } else {
-                    // DA size limits, DA footprint, and gas limits are always enforced
-                    diag.record_rejection(&err);
-                    self.record_static_limit_exceeded(&err);
-
-                    let priority_fee = tx.effective_tip_per_gas(base_fee).unwrap_or(0) as f64;
-                    record_rejected_tx_priority_fee(&err, priority_fee);
-                    if err.is_permanent() {
-                        diag.permanently_rejected_txs.push(tx_hash);
-                    }
-
-                    self.emit_builder_decision_event(
-                        &payload_id,
-                        TransactionEventType::BuilderRejected,
-                        tx_hash,
-                        Some(ordering_position),
-                        || {
-                            BuilderRejectedEventData::from_error(
-                                &err,
-                                info,
-                                limits,
-                                Some(&tx_resources),
-                            )
-                        },
-                    );
-                    log_txn(Err(err));
-                    best_txs.mark_invalid(tx.signer(), tx.nonce());
-                    continue;
+            if let Some(rejection) = rejection {
+                // Nonce-free EIP-8130 replay-ID entries are independent, so a stale-manifest drop
+                // must not mark the sender's unrelated entries invalid.
+                let skip_mark_invalid = matches!(rejection, GateRejection::ManifestStale { .. })
+                    && eip8130_replay_id.is_some();
+                reporter.reject(reported, rejection, info, limits, &mut diag);
+                if !skip_mark_invalid {
+                    source.mark_invalid(tx.signer(), tx.nonce());
                 }
-            }
-
-            // Record execution time prediction accuracy metrics
-            if let Some(predicted_us) = predicted_execution_time_us {
-                BuilderMetrics::tx_predicted_execution_time_us().record(predicted_us as f64);
-            }
-            // A sequencer's block should never contain blob or deposit transactions from the pool.
-            if tx.is_eip4844() || tx.is_deposit() {
-                let err = TxnExecutionError::SequencerTransaction;
-                diag.record_rejection(&err);
-                let priority_fee = tx.effective_tip_per_gas(base_fee).unwrap_or(0) as f64;
-                record_rejected_tx_priority_fee(&err, priority_fee);
-                self.emit_builder_decision_event(
-                    &payload_id,
-                    TransactionEventType::BuilderRejected,
-                    tx_hash,
-                    Some(ordering_position),
-                    || {
-                        BuilderRejectedEventData::from_error(
-                            &err,
-                            info,
-                            limits,
-                            Some(&tx_resources),
-                        )
-                    },
-                );
-                log_txn(Err(err));
-                best_txs.mark_invalid(tx.signer(), tx.nonce());
                 continue;
             }
 
@@ -1092,58 +693,38 @@ impl BasePayloadBuilderCtx {
                     if let Some(err) = err.as_invalid_tx_err() {
                         if err.is_nonce_too_low() {
                             // if the nonce is too low, we can skip this transaction
-                            let diag_err = TxnExecutionError::NonceTooLow;
-                            diag.record_rejection(&diag_err);
-                            let priority_fee =
-                                tx.effective_tip_per_gas(base_fee).unwrap_or(0) as f64;
-                            record_rejected_tx_priority_fee(&diag_err, priority_fee);
-                            self.emit_builder_decision_event(
-                                &payload_id,
-                                TransactionEventType::BuilderRejected,
-                                tx_hash,
-                                Some(ordering_position),
-                                || {
-                                    BuilderRejectedEventData::from_error(
-                                        &diag_err,
-                                        info,
-                                        limits,
-                                        Some(&tx_resources),
-                                    )
-                                },
+                            reporter.execution_rejected(
+                                reported,
+                                &TxnExecutionError::NonceTooLow,
+                                info,
+                                limits,
+                                &mut diag,
                             );
-                            log_txn(Err(diag_err));
                             trace!(target: "payload_builder", %err, ?tx, "skipping nonce too low transaction");
                         } else {
                             // if the transaction is invalid, we can skip it and all of its
                             // descendants
-                            let diag_err = TxnExecutionError::InternalError(err.clone());
-                            diag.record_rejection(&diag_err);
-                            let priority_fee =
-                                tx.effective_tip_per_gas(base_fee).unwrap_or(0) as f64;
-                            record_rejected_tx_priority_fee(&diag_err, priority_fee);
-                            self.emit_builder_decision_event(
-                                &payload_id,
-                                TransactionEventType::BuilderRejected,
-                                tx_hash,
-                                Some(ordering_position),
-                                || {
-                                    BuilderRejectedEventData::from_error(
-                                        &diag_err,
-                                        info,
-                                        limits,
-                                        Some(&tx_resources),
-                                    )
-                                },
+                            reporter.execution_rejected(
+                                reported,
+                                &TxnExecutionError::InternalError(err.clone()),
+                                info,
+                                limits,
+                                &mut diag,
                             );
-                            log_txn(Err(diag_err));
                             trace!(target: "payload_builder", %err, ?tx, "skipping invalid transaction and its descendants");
-                            best_txs.mark_invalid(tx.signer(), tx.nonce());
+                            source.mark_invalid(tx.signer(), tx.nonce());
                         }
 
                         continue;
                     }
                     // this is an error that we should treat as fatal for this attempt
-                    log_txn(Err(TxnExecutionError::EvmError));
+                    debug!(
+                        target: "payload_builder",
+                        message = "Considering transaction",
+                        tx_hash = ?tx_hash,
+                        tx_da_size = ?tx_da_size,
+                        result = %TxnExecutionError::EvmError,
+                    );
                     return Err(PayloadBuilderError::evm(err));
                 }
             };
@@ -1178,11 +759,9 @@ impl BasePayloadBuilderCtx {
             let gas_used = result.tx_gas_used();
             let is_success = result.is_success();
             if is_success {
-                log_txn(Ok(TxnOutcome::Success));
                 num_txs_simulated_success += 1;
                 BuilderMetrics::successful_tx_gas_used().record(gas_used as f64);
             } else {
-                log_txn(Ok(TxnOutcome::Reverted));
                 num_txs_simulated_fail += 1;
                 reverted_gas_used += gas_used;
                 BuilderMetrics::reverted_tx_gas_used().record(gas_used as f64);
@@ -1193,29 +772,14 @@ impl BasePayloadBuilderCtx {
             if let Some(max_gas_per_txn) = self.builder_config.max_gas_per_txn
                 && gas_used > max_gas_per_txn
             {
-                let err = TxnExecutionError::MaxGasUsageExceeded;
-                diag.record_rejection(&err);
-                let priority_fee = tx.effective_tip_per_gas(base_fee).unwrap_or(0) as f64;
-                record_rejected_tx_priority_fee(&err, priority_fee);
-                if err.is_permanent() {
-                    diag.permanently_rejected_txs.push(tx_hash);
-                }
-                self.emit_builder_decision_event(
-                    &payload_id,
-                    TransactionEventType::BuilderRejected,
-                    tx_hash,
-                    Some(ordering_position),
-                    || {
-                        BuilderRejectedEventData::from_error(
-                            &err,
-                            info,
-                            limits,
-                            Some(&tx_resources),
-                        )
-                    },
+                reporter.execution_rejected(
+                    reported,
+                    &TxnExecutionError::MaxGasUsageExceeded,
+                    info,
+                    limits,
+                    &mut diag,
                 );
-                log_txn(Err(err));
-                best_txs.mark_invalid(tx.signer(), tx.nonce());
+                source.mark_invalid(tx.signer(), tx.nonce());
                 continue;
             }
 
@@ -1225,21 +789,7 @@ impl BasePayloadBuilderCtx {
             // record uncompressed tx size
             info.cumulative_uncompressed_bytes += tx_uncompressed_size;
 
-            self.emit_builder_decision_event(
-                &payload_id,
-                TransactionEventType::BuilderAccepted,
-                tx_hash,
-                Some(ordering_position),
-                || {
-                    BuilderAcceptedEventData::new(
-                        if is_success { "success" } else { "reverted" },
-                        gas_used,
-                        info,
-                        limits,
-                        Some(&tx_resources),
-                    )
-                },
-            );
+            reporter.accepted(reported, is_success, gas_used, info, limits);
             // Push transaction changeset and calculate header bloom filter for receipt.
             let ctx = ReceiptBuilderCtx {
                 tx_type: tx.tx_type(),
@@ -1300,38 +850,6 @@ impl BasePayloadBuilderCtx {
             txs_rejected = num_txs_simulated_fail,
         );
         Ok(diag)
-    }
-
-    /// Record metrics for a limit that can be evaluated via static analysis (always enforced).
-    fn record_static_limit_exceeded(&self, err: &TxnExecutionError) {
-        match err {
-            TxnExecutionError::TransactionDASizeExceeded(_, _) => {
-                BuilderMetrics::tx_da_size_exceeded_total().increment(1);
-            }
-            TxnExecutionError::BlockDASizeExceeded { .. } => {
-                BuilderMetrics::block_da_size_exceeded_total().increment(1);
-            }
-            TxnExecutionError::DAFootprintLimitExceeded { .. } => {
-                BuilderMetrics::da_footprint_exceeded_total().increment(1);
-            }
-            TxnExecutionError::TransactionGasLimitExceeded { .. } => {
-                BuilderMetrics::gas_limit_exceeded_total().increment(1);
-            }
-            TxnExecutionError::BlockUncompressedSizeExceeded { .. } => {
-                BuilderMetrics::block_uncompressed_size_exceeded_total().increment(1);
-            }
-            _ => {}
-        }
-    }
-
-    /// Record metrics for a limit that requires execution data (enforcement is configurable).
-    fn record_execution_metering_limit_exceeded(&self, limit: &ExecutionMeteringLimitExceeded) {
-        BuilderMetrics::resource_limit_would_reject_total().increment(1);
-        match limit {
-            ExecutionMeteringLimitExceeded::TransactionExecutionTime(_, _) => {
-                BuilderMetrics::tx_execution_time_exceeded_total().increment(1);
-            }
-        }
     }
 }
 

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -718,13 +718,6 @@ impl BasePayloadBuilderCtx {
                         continue;
                     }
                     // this is an error that we should treat as fatal for this attempt
-                    debug!(
-                        target: "payload_builder",
-                        message = "Considering transaction",
-                        tx_hash = ?tx_hash,
-                        tx_da_size = ?tx_da_size,
-                        result = %TxnExecutionError::EvmError,
-                    );
                     return Err(PayloadBuilderError::evm(err));
                 }
             };

--- a/crates/builder/core/src/flashblocks/gates.rs
+++ b/crates/builder/core/src/flashblocks/gates.rs
@@ -1,0 +1,343 @@
+//! Admission gates for the flashblock build loop.
+//!
+//! A [`Gate`] inspects a [`Candidate`] and returns a [`GateVerdict`] — either admitting it or
+//! rejecting it with a [`GateRejection`] the [`OutcomeReporter`](super::reporter::OutcomeReporter)
+//! knows how to render. The build walk runs the gates in order and stops at the first rejection.
+//!
+//! The open build walk composes four gates:
+//! - [`BundleGate`] — bundle-window validity (target block, expiry, not-yet-valid).
+//! - [`ManifestGate`] — revalidates EIP-8130 authorization manifests against on-chain state.
+//! - [`ResourceLimitsGate`] — metering estimation (and its wait/skip), the always-enforced hard
+//!   limits, and the dry-run/enforce metering limit.
+//! - [`SequencerGate`] — rejects blob/deposit transactions sourced from the pool.
+
+use std::time::{Duration, SystemTime};
+
+use alloy_eips::Typed2718;
+use base_bundles::MeterBundleResponse;
+use base_execution_txpool::{BundleTransaction, GuardMetrics};
+use revm::Database;
+use tracing::warn;
+
+use super::candidate_source::Candidate;
+use crate::{
+    BuilderMetrics, ExecutionInfo, ExecutionMeteringLimitExceeded, ExecutionMeteringMode,
+    ResourceLimits, SharedMeteringProvider, TxnExecutionError,
+};
+
+/// The outcome of evaluating a candidate against a [`Gate`].
+#[derive(Debug)]
+pub enum GateVerdict {
+    /// The candidate passes this gate.
+    Admit,
+    /// The candidate is rejected; the reporter renders the rejection.
+    Reject(GateRejection),
+}
+
+/// A gate rejection, carrying everything the reporter needs to record and emit it.
+#[derive(Debug)]
+pub enum GateRejection {
+    /// Bundle targets a block other than the one being built.
+    BundleWrongTarget {
+        /// The bundle's requested target block.
+        target: u64,
+        /// The block being built.
+        current: u64,
+    },
+    /// Bundle validity window has already passed.
+    BundleExpired {
+        /// The block timestamp checked against.
+        block_timestamp: u64,
+    },
+    /// Bundle validity window has not started yet.
+    BundleNotYetValid {
+        /// The block timestamp checked against.
+        block_timestamp: u64,
+    },
+    /// Metering is enabled but data has not yet arrived and the candidate is within the wait window.
+    MeteringPending {
+        /// Age of the candidate in milliseconds.
+        tx_age_ms: u128,
+        /// Configured wait duration in milliseconds.
+        wait_duration_ms: u128,
+    },
+    /// An always-enforced hard limit exceeded (DA, footprint, gas, uncompressed size).
+    Limit(TxnExecutionError),
+    /// A blob or deposit transaction, which must never be sourced from the pool.
+    Sequencer,
+    /// An EIP-8130 authorization manifest that no longer revalidates against on-chain state.
+    ManifestStale {
+        /// The reason the manifest is stale (from [`ManifestStale::cause`]).
+        ///
+        /// [`ManifestStale::cause`]: base_execution_txpool::ManifestStale::cause
+        cause: &'static str,
+    },
+    /// A metering limit exceeded in enforce mode.
+    MeteringLimit {
+        /// The exceeded limit.
+        limit: ExecutionMeteringLimitExceeded,
+        /// Raw metering response for the rejected-tx audit trail. Boxed to keep the enum small,
+        /// since the metering response dwarfs the other rejection variants.
+        resource_usage: Option<Box<MeterBundleResponse>>,
+    },
+}
+
+/// A build-loop admission gate. Implementors inspect the candidate and admit or reject it.
+///
+/// Evaluation is given `&mut db` so a gate can revalidate against current on-chain state (used by
+/// [`ManifestGate`]); gates that don't need it simply ignore it.
+pub trait Gate {
+    /// Evaluates the candidate, optionally enriching it (e.g. with a resource estimate).
+    fn evaluate(
+        &self,
+        candidate: &mut Candidate,
+        info: &ExecutionInfo,
+        limits: &ResourceLimits,
+        db: &mut impl Database,
+    ) -> GateVerdict;
+
+    /// Chains `next` to run after this gate, producing a single compound gate. The chain admits
+    /// only if both admit and returns the first rejection, so `a.then(b).then(c)` composes the
+    /// admission sequence with static dispatch.
+    fn then<G: Gate>(self, next: G) -> Chain<Self, G>
+    where
+        Self: Sized,
+    {
+        Chain { first: self, next }
+    }
+}
+
+/// Two gates run in sequence: `next` is evaluated only if `first` admits. Produced by
+/// [`Gate::then`].
+#[derive(Debug, Clone, Copy)]
+pub struct Chain<A, B> {
+    first: A,
+    next: B,
+}
+
+impl<A: Gate, B: Gate> Gate for Chain<A, B> {
+    fn evaluate(
+        &self,
+        candidate: &mut Candidate,
+        info: &ExecutionInfo,
+        limits: &ResourceLimits,
+        db: &mut impl Database,
+    ) -> GateVerdict {
+        match self.first.evaluate(candidate, info, limits, &mut *db) {
+            GateVerdict::Admit => self.next.evaluate(candidate, info, limits, db),
+            reject => reject,
+        }
+    }
+}
+
+/// Rejects bundle transactions whose validity window does not include the block being built.
+#[derive(Debug, Clone, Copy)]
+pub struct BundleGate {
+    block_number: u64,
+    block_timestamp: u64,
+}
+
+impl BundleGate {
+    /// Creates a bundle gate for the block being built.
+    pub const fn new(block_number: u64, block_timestamp: u64) -> Self {
+        Self { block_number, block_timestamp }
+    }
+}
+
+impl Gate for BundleGate {
+    fn evaluate(
+        &self,
+        candidate: &mut Candidate,
+        _info: &ExecutionInfo,
+        _limits: &ResourceLimits,
+        _db: &mut impl Database,
+    ) -> GateVerdict {
+        let bundle = &candidate.bundle;
+
+        if let Some(target) = bundle.target_block_number()
+            && target != self.block_number
+        {
+            return GateVerdict::Reject(GateRejection::BundleWrongTarget {
+                target,
+                current: self.block_number,
+            });
+        }
+
+        if bundle.is_bundle_expired(self.block_number, self.block_timestamp) {
+            return GateVerdict::Reject(GateRejection::BundleExpired {
+                block_timestamp: self.block_timestamp,
+            });
+        }
+
+        if bundle.is_bundle_not_yet_valid(self.block_timestamp) {
+            return GateVerdict::Reject(GateRejection::BundleNotYetValid {
+                block_timestamp: self.block_timestamp,
+            });
+        }
+
+        GateVerdict::Admit
+    }
+}
+
+/// Revalidates a candidate's EIP-8130 authorization manifest against current on-chain state,
+/// dropping it (with [`GateRejection::ManifestStale`]) when the authorization has gone stale.
+///
+/// Only transactions carrying a manifest are affected; the check is a no-op when prechecking is
+/// disabled or the candidate has no manifest.
+#[derive(Debug, Clone, Copy)]
+pub struct ManifestGate {
+    enabled: bool,
+    block_timestamp: u64,
+}
+
+impl ManifestGate {
+    /// Creates a manifest gate for the block being built.
+    pub const fn new(enabled: bool, block_timestamp: u64) -> Self {
+        Self { enabled, block_timestamp }
+    }
+}
+
+impl Gate for ManifestGate {
+    fn evaluate(
+        &self,
+        candidate: &mut Candidate,
+        _info: &ExecutionInfo,
+        _limits: &ResourceLimits,
+        db: &mut impl Database,
+    ) -> GateVerdict {
+        if self.enabled
+            && let Some(manifest) = &candidate.watch_manifest
+            && let Err(stale) = manifest.revalidate(db, self.block_timestamp)
+        {
+            GuardMetrics::record_builder_precheck_drop(&stale);
+            return GateVerdict::Reject(GateRejection::ManifestStale { cause: stale.cause() });
+        }
+        GateVerdict::Admit
+    }
+}
+
+/// Estimates a candidate's resources from metering-service data, then enforces the resource limits.
+///
+/// On evaluation this gate:
+/// 1. looks up metering data and, when metering is enabled and data has not arrived within the wait
+///    window, defers the candidate (rejecting with [`GateRejection::MeteringPending`]);
+/// 2. enriches the candidate's resource estimate with the predicted execution time;
+/// 3. enforces the always-on hard limits ([`GateRejection::Limit`]);
+/// 4. enforces the metering limit under the configured mode — recording the would-reject metric in
+///    both modes, admitting in dry-run, and rejecting with [`GateRejection::MeteringLimit`] in
+///    enforce mode.
+#[derive(Debug, Clone, Copy)]
+pub struct ResourceLimitsGate<'a> {
+    provider: &'a SharedMeteringProvider,
+    wait_duration: Option<Duration>,
+    metering_mode: ExecutionMeteringMode,
+}
+
+impl<'a> ResourceLimitsGate<'a> {
+    /// Creates a resource-limits gate over the given metering provider, wait duration, and mode.
+    pub const fn new(
+        provider: &'a SharedMeteringProvider,
+        wait_duration: Option<Duration>,
+        metering_mode: ExecutionMeteringMode,
+    ) -> Self {
+        Self { provider, wait_duration, metering_mode }
+    }
+}
+
+impl Gate for ResourceLimitsGate<'_> {
+    fn evaluate(
+        &self,
+        candidate: &mut Candidate,
+        info: &ExecutionInfo,
+        limits: &ResourceLimits,
+        _db: &mut impl Database,
+    ) -> GateVerdict {
+        let resource_usage = self.provider.get(&candidate.tx_hash);
+
+        // Skip transactions that are too young and don't have metering data yet.
+        if self.provider.is_enabled()
+            && resource_usage.is_none()
+            && let Some(wait_duration) = self.wait_duration
+        {
+            let now_ms = SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .map(|d| d.as_millis())
+                .unwrap_or(0);
+            let tx_age_ms = now_ms.saturating_sub(candidate.received_at_ms);
+            if tx_age_ms < wait_duration.as_millis() {
+                self.provider.skip(&candidate.tx_hash);
+                return GateVerdict::Reject(GateRejection::MeteringPending {
+                    tx_age_ms,
+                    wait_duration_ms: wait_duration.as_millis(),
+                });
+            }
+        }
+
+        // Enrich the estimate with the predicted execution time.
+        let predicted_execution_time_us =
+            resource_usage.as_ref().map(|m| m.total_execution_time_us);
+        candidate.resources.execution_time_us = predicted_execution_time_us;
+        candidate.resource_usage = resource_usage;
+
+        // Hard limits are always enforced.
+        if let Err(err) = info.is_tx_over_hard_limits(&candidate.resources, limits) {
+            return GateVerdict::Reject(GateRejection::Limit(err));
+        }
+
+        // Metering limits are checked under the configured dry-run/enforce mode.
+        if let Err(limit) = info.is_tx_over_metering_limits(&candidate.resources, limits) {
+            BuilderMetrics::resource_limit_would_reject_total().increment(1);
+            let ExecutionMeteringLimitExceeded::TransactionExecutionTime(_, _) = limit;
+            BuilderMetrics::tx_execution_time_exceeded_total().increment(1);
+
+            let dry_run = self.metering_mode.is_dry_run();
+            warn!(
+                target: "payload_builder",
+                message = if dry_run {
+                    "Metering throttle: transaction would be rejected (dry-run)"
+                } else {
+                    "Metering throttle: transaction rejected"
+                },
+                tx_hash = ?candidate.tx_hash,
+                limit = %limit,
+                priority_fee = candidate.priority_fee,
+                dry_run,
+            );
+
+            if !dry_run {
+                return GateVerdict::Reject(GateRejection::MeteringLimit {
+                    limit,
+                    // Move the metering response out of the candidate (which is dropped right after
+                    // this returns) rather than cloning its `Vec<TransactionResult>`.
+                    resource_usage: candidate.resource_usage.take().map(Box::new),
+                });
+            }
+        }
+
+        // Admitted: record the prediction-accuracy input.
+        if let Some(predicted_us) = predicted_execution_time_us {
+            BuilderMetrics::tx_predicted_execution_time_us().record(predicted_us as f64);
+        }
+
+        GateVerdict::Admit
+    }
+}
+
+/// Rejects blob and deposit transactions, which must never be sourced from the pool.
+#[derive(Debug, Clone, Copy)]
+pub struct SequencerGate;
+
+impl Gate for SequencerGate {
+    fn evaluate(
+        &self,
+        candidate: &mut Candidate,
+        _info: &ExecutionInfo,
+        _limits: &ResourceLimits,
+        _db: &mut impl Database,
+    ) -> GateVerdict {
+        if candidate.tx.is_eip4844() || candidate.tx.is_deposit() {
+            return GateVerdict::Reject(GateRejection::Sequencer);
+        }
+        GateVerdict::Admit
+    }
+}

--- a/crates/builder/core/src/flashblocks/mod.rs
+++ b/crates/builder/core/src/flashblocks/mod.rs
@@ -17,6 +17,18 @@ pub use context::{
     BasePayloadBuilderCtx, FlashblockDiagnostics, FlashblockSelectionOutcome, FlashblocksExtraCtx,
 };
 
+mod candidate_source;
+pub use candidate_source::{BundleWindow, Candidate, PoolCandidateSource};
+
+mod gates;
+pub use gates::{
+    BundleGate, Chain, Gate, GateRejection, GateVerdict, ManifestGate, ResourceLimitsGate,
+    SequencerGate,
+};
+
+mod reporter;
+pub use reporter::{OutcomeReporter, ReportedTx};
+
 mod payload;
 
 mod service;

--- a/crates/builder/core/src/flashblocks/reporter.rs
+++ b/crates/builder/core/src/flashblocks/reporter.rs
@@ -1,0 +1,387 @@
+//! Outcome reporting for the flashblock build loop.
+//!
+//! [`OutcomeReporter`] is the single layer that turns build-loop decisions into their observable
+//! side effects: builder transaction events, rejection diagnostics, metrics, and the rejected-tx
+//! audit trail. Gates return a [`GateRejection`](super::gates::GateRejection) and the build walk
+//! delegates every emission/recording to this reporter, so no other layer emits events. A future
+//! closed build walk supplies its own reporter with its own event vocabulary while reusing the
+//! same gates.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use alloy_primitives::TxHash;
+use base_bundles::{MeterBundleResponse, RejectedTransaction, RejectionReason};
+use base_observability_events::TransactionEventType;
+use serde::Serialize;
+use tracing::{debug, trace};
+
+use super::{
+    context::{BasePayloadBuilderCtx, FlashblockDiagnostics},
+    gates::GateRejection,
+};
+use crate::{
+    BuilderMetrics, ExecutionInfo, ExecutionMeteringLimitExceeded, ResourceLimits, TxResources,
+    TxnExecutionError, TxnOutcome,
+    transaction_events::{
+        BuilderAcceptedEventData, BuilderBudgetFields, BuilderRejectedEventData,
+        BuilderTransactionEventContext, emit_builder_transaction_event, rejection_reason_code,
+    },
+};
+
+/// A candidate transaction as seen by outcome reporting.
+///
+/// Bundles the per-candidate fields shared across a candidate's considered/rejected/accepted
+/// reports: its hash, one-based scan position, estimated resources (absent before the candidate is
+/// materialized), and priority fee (used as the value for rejection metrics).
+#[derive(Debug, Clone, Copy)]
+pub struct ReportedTx<'a> {
+    /// Transaction hash.
+    pub tx_hash: TxHash,
+    /// One-based ordering position within this scan.
+    pub ordering_position: u64,
+    /// Estimated resources for the candidate, if known.
+    pub resources: Option<&'a TxResources>,
+    /// Effective priority fee (tip per gas), used as the value for rejection metrics.
+    pub priority_fee: f64,
+}
+
+/// Records the observable outcomes of build-loop decisions: transaction events, rejection
+/// diagnostics, metrics, and the rejected-tx audit trail.
+///
+/// Holds the payload builder context (for configuration, block identity, and the audit channel)
+/// and the payload id used as the event join key.
+#[derive(Debug, Clone, Copy)]
+pub struct OutcomeReporter<'a> {
+    ctx: &'a BasePayloadBuilderCtx,
+    payload_id: &'a str,
+}
+
+impl<'a> OutcomeReporter<'a> {
+    /// Creates a reporter for the given context and payload id.
+    pub const fn new(ctx: &'a BasePayloadBuilderCtx, payload_id: &'a str) -> Self {
+        Self { ctx, payload_id }
+    }
+
+    /// Emits a builder transaction event through the global event writer.
+    fn emit<D, F>(
+        &self,
+        event_type: TransactionEventType,
+        tx_hash: TxHash,
+        ordering_position: u64,
+        data: F,
+    ) where
+        D: Serialize,
+        F: FnOnce() -> D,
+    {
+        emit_builder_transaction_event(
+            BuilderTransactionEventContext {
+                payload_id: self.payload_id.to_string(),
+                block_number: self.ctx.block_number(),
+                block_hash: None,
+                parent_hash: self.ctx.parent_hash(),
+                flashblock_index: Some(self.ctx.flashblock_index()),
+                target_flashblock_count: self.ctx.target_flashblock_count(),
+                ordering_position: Some(ordering_position),
+                builder_mode: "flashblocks",
+                source_queue: "txpool_best",
+            },
+            event_type,
+            tx_hash,
+            data,
+        );
+    }
+
+    /// Reports that the builder has begun evaluating a candidate, emitting the considered event.
+    ///
+    /// Emitted up front, before the gate chain runs, so its timestamp marks the start of
+    /// evaluation rather than a successful admission.
+    pub fn considered(&self, tx: ReportedTx<'_>, info: &ExecutionInfo, limits: &ResourceLimits) {
+        self.emit(
+            TransactionEventType::BuilderConsidered,
+            tx.tx_hash,
+            tx.ordering_position,
+            || BuilderBudgetFields::new(info, limits, tx.resources),
+        );
+    }
+
+    /// Reports a gate rejection: emits the rejected event and records its diagnostics, metrics,
+    /// audit-trail entry, and per-candidate trace.
+    ///
+    /// The candidate's [`considered`](Self::considered) event was already emitted up front, so this
+    /// emits only the rejected event — carrying the decision-specific context (bundle window,
+    /// metering wait, dry-run) that is not present on the considered event. Takes the rejection by
+    /// value so it can move the error and the metering response out rather than cloning them on the
+    /// per-candidate hot path.
+    pub fn reject(
+        &self,
+        tx: ReportedTx<'_>,
+        rejection: GateRejection,
+        info: &mut ExecutionInfo,
+        limits: &ResourceLimits,
+        diag: &mut FlashblockDiagnostics,
+    ) {
+        match rejection {
+            GateRejection::BundleWrongTarget { target, current } => {
+                self.emit(
+                    TransactionEventType::BuilderRejected,
+                    tx.tx_hash,
+                    tx.ordering_position,
+                    || {
+                        BuilderRejectedEventData::new(
+                            "wrong_target_block",
+                            "bundle target block does not match current block",
+                            false,
+                            info,
+                            limits,
+                            tx.resources,
+                        )
+                        .with_bundle_target_block(target)
+                        .with_current_block(current)
+                    },
+                );
+            }
+            GateRejection::BundleExpired { block_timestamp } => {
+                self.emit(
+                    TransactionEventType::BuilderRejected,
+                    tx.tx_hash,
+                    tx.ordering_position,
+                    || {
+                        BuilderRejectedEventData::new(
+                            "bundle_expired",
+                            "bundle validity window expired",
+                            false,
+                            info,
+                            limits,
+                            tx.resources,
+                        )
+                        .with_block_timestamp(block_timestamp)
+                    },
+                );
+            }
+            GateRejection::BundleNotYetValid { block_timestamp } => {
+                self.emit(
+                    TransactionEventType::BuilderRejected,
+                    tx.tx_hash,
+                    tx.ordering_position,
+                    || {
+                        BuilderRejectedEventData::new(
+                            "bundle_not_yet_valid",
+                            "bundle validity window has not started",
+                            false,
+                            info,
+                            limits,
+                            tx.resources,
+                        )
+                        .with_block_timestamp(block_timestamp)
+                    },
+                );
+            }
+            GateRejection::MeteringPending { tx_age_ms, wait_duration_ms } => {
+                let err = TxnExecutionError::MeteringDataPending;
+                diag.record_rejection(&err);
+                self.emit(
+                    TransactionEventType::BuilderRejected,
+                    tx.tx_hash,
+                    tx.ordering_position,
+                    || {
+                        BuilderRejectedEventData::from_error(&err, info, limits, tx.resources)
+                            .with_metering_wait(tx_age_ms, wait_duration_ms)
+                    },
+                );
+                BuilderMetrics::metering_data_pending_skip().increment(1);
+                self.log_outcome(tx, Err(&err));
+            }
+            GateRejection::Limit(err) => self.reject_with_error(tx, &err, info, limits, diag),
+            GateRejection::Sequencer => self.reject_with_error(
+                tx,
+                &TxnExecutionError::SequencerTransaction,
+                info,
+                limits,
+                diag,
+            ),
+            GateRejection::ManifestStale { cause } => {
+                diag.txs_rejected_other += 1;
+                self.emit(
+                    TransactionEventType::BuilderRejected,
+                    tx.tx_hash,
+                    tx.ordering_position,
+                    || {
+                        BuilderRejectedEventData::new(
+                            "manifest_precheck_stale",
+                            cause,
+                            false,
+                            info,
+                            limits,
+                            tx.resources,
+                        )
+                    },
+                );
+                trace!(
+                    target: "payload_builder",
+                    tx_hash = ?tx.tx_hash,
+                    cause,
+                    "skipping EIP-8130 transaction with stale authorization manifest"
+                );
+            }
+            GateRejection::MeteringLimit { limit, resource_usage } => {
+                let ExecutionMeteringLimitExceeded::TransactionExecutionTime(tx_time_us, limit_us) =
+                    limit;
+                let err = TxnExecutionError::ExecutionMeteringLimitExceeded(
+                    ExecutionMeteringLimitExceeded::TransactionExecutionTime(tx_time_us, limit_us),
+                );
+                diag.record_rejection(&err);
+                Self::record_rejected_tx_priority_fee(&err, tx.priority_fee);
+                if err.is_permanent() {
+                    diag.permanently_rejected_txs.push(tx.tx_hash);
+                }
+                // Only record per-tx execution time limits for the audit trail for now. Unbox and
+                // move the metering response in rather than cloning it.
+                self.record_rejected_tx(
+                    info,
+                    tx.tx_hash,
+                    RejectionReason::ExecutionTimeExceeded { tx_time_us, limit_us },
+                    resource_usage.map(|usage| *usage).unwrap_or_default(),
+                );
+                self.emit(
+                    TransactionEventType::BuilderRejected,
+                    tx.tx_hash,
+                    tx.ordering_position,
+                    || {
+                        BuilderRejectedEventData::from_error(&err, info, limits, tx.resources)
+                            .with_dry_run(false)
+                    },
+                );
+                self.log_outcome(tx, Err(&err));
+            }
+        }
+    }
+
+    /// Reports a rejection discovered during execution (nonce-too-low, invalid, max-gas).
+    ///
+    /// The considered event was already emitted, so this emits the rejected event and records the
+    /// rejection's diagnostics, metrics, and trace — the error arrives as its own
+    /// [`TxnExecutionError`] rather than a gate decision.
+    pub fn execution_rejected(
+        &self,
+        tx: ReportedTx<'_>,
+        err: &TxnExecutionError,
+        info: &ExecutionInfo,
+        limits: &ResourceLimits,
+        diag: &mut FlashblockDiagnostics,
+    ) {
+        self.reject_with_error(tx, err, info, limits, diag);
+    }
+
+    /// Records and emits an error-typed rejection: rejection diagnostics, the static-limit and
+    /// priority-fee metrics, the permanent-rejection cache, the rejected event, and the trace.
+    /// Shared by the hard-limit and sequencer gate rejections and the execution-discovered ones.
+    fn reject_with_error(
+        &self,
+        tx: ReportedTx<'_>,
+        err: &TxnExecutionError,
+        info: &ExecutionInfo,
+        limits: &ResourceLimits,
+        diag: &mut FlashblockDiagnostics,
+    ) {
+        diag.record_rejection(err);
+        Self::record_static_limit_exceeded(err);
+        Self::record_rejected_tx_priority_fee(err, tx.priority_fee);
+        if err.is_permanent() {
+            diag.permanently_rejected_txs.push(tx.tx_hash);
+        }
+        self.emit(TransactionEventType::BuilderRejected, tx.tx_hash, tx.ordering_position, || {
+            BuilderRejectedEventData::from_error(err, info, limits, tx.resources)
+        });
+        self.log_outcome(tx, Err(err));
+    }
+
+    /// Emits the per-candidate `"Considering transaction"` debug trace with its terminal outcome.
+    fn log_outcome(&self, tx: ReportedTx<'_>, result: Result<TxnOutcome, &TxnExecutionError>) {
+        let result_str = match result {
+            Ok(outcome) => outcome.to_string(),
+            Err(err) => err.to_string(),
+        };
+        debug!(
+            target: "payload_builder",
+            message = "Considering transaction",
+            tx_hash = ?tx.tx_hash,
+            tx_da_size = ?tx.resources.map(|r| r.da_size),
+            result = %result_str,
+        );
+    }
+
+    /// Reports a committed transaction, emitting the accepted event and its terminal trace.
+    pub fn accepted(
+        &self,
+        tx: ReportedTx<'_>,
+        is_success: bool,
+        gas_used: u64,
+        info: &ExecutionInfo,
+        limits: &ResourceLimits,
+    ) {
+        let (outcome, execution_outcome) = if is_success {
+            (TxnOutcome::Success, "success")
+        } else {
+            (TxnOutcome::Reverted, "reverted")
+        };
+        self.emit(TransactionEventType::BuilderAccepted, tx.tx_hash, tx.ordering_position, || {
+            BuilderAcceptedEventData::new(execution_outcome, gas_used, info, limits, tx.resources)
+        });
+        self.log_outcome(tx, Ok(outcome));
+    }
+
+    /// Records the priority fee of a rejected transaction with the given reason as a label.
+    fn record_rejected_tx_priority_fee(reason: &TxnExecutionError, priority_fee: f64) {
+        BuilderMetrics::rejected_tx_priority_fee(rejection_reason_code(reason))
+            .record(priority_fee);
+    }
+
+    /// Records metrics for a limit that can be evaluated via static analysis (always enforced).
+    fn record_static_limit_exceeded(err: &TxnExecutionError) {
+        match err {
+            TxnExecutionError::TransactionDASizeExceeded(_, _) => {
+                BuilderMetrics::tx_da_size_exceeded_total().increment(1);
+            }
+            TxnExecutionError::BlockDASizeExceeded { .. } => {
+                BuilderMetrics::block_da_size_exceeded_total().increment(1);
+            }
+            TxnExecutionError::DAFootprintLimitExceeded { .. } => {
+                BuilderMetrics::da_footprint_exceeded_total().increment(1);
+            }
+            TxnExecutionError::TransactionGasLimitExceeded { .. } => {
+                BuilderMetrics::gas_limit_exceeded_total().increment(1);
+            }
+            TxnExecutionError::BlockUncompressedSizeExceeded { .. } => {
+                BuilderMetrics::block_uncompressed_size_exceeded_total().increment(1);
+            }
+            _ => {}
+        }
+    }
+
+    /// Pushes a rejected transaction onto the block's audit trail, to be flushed after finalization.
+    fn record_rejected_tx(
+        &self,
+        info: &mut ExecutionInfo,
+        tx_hash: TxHash,
+        reason: RejectionReason,
+        metering: MeterBundleResponse,
+    ) {
+        if self.ctx.rejected_tx_sender.is_none() {
+            return;
+        }
+
+        if info.rejected_txs.len() >= self.ctx.builder_config.max_rejected_txs_per_block {
+            BuilderMetrics::rejected_tx_per_block_drops().increment(1);
+            return;
+        }
+
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+        info.rejected_txs.push(RejectedTransaction {
+            tx_hash,
+            block_number: self.ctx.block_number(),
+            reason,
+            timestamp: now,
+            metering,
+        });
+    }
+}

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -42,8 +42,10 @@ pub use rejection_cache::RejectionCache;
 mod flashblocks;
 pub use flashblocks::{
     BasePayloadBuilderCtx, BestFlashblocksTxs, BlockPayloadJob, BlockPayloadJobGenerator,
-    BuildArguments, FlashblockDiagnostics, FlashblockSelectionOutcome, FlashblocksExtraCtx,
-    FlashblocksServiceBuilder, PayloadBuilder, PayloadHandler, ResolvePayload,
+    BuildArguments, BundleGate, BundleWindow, Candidate, Chain, FlashblockDiagnostics,
+    FlashblockSelectionOutcome, FlashblocksExtraCtx, FlashblocksServiceBuilder, Gate,
+    GateRejection, GateVerdict, ManifestGate, OutcomeReporter, PayloadBuilder, PayloadHandler,
+    PoolCandidateSource, ReportedTx, ResolvePayload, ResourceLimitsGate, SequencerGate,
 };
 
 mod extension;

--- a/crates/builder/core/src/transaction_events.rs
+++ b/crates/builder/core/src/transaction_events.rs
@@ -72,6 +72,10 @@ struct BuilderEventData<T> {
 }
 
 /// Budget and resource fields shared by builder transaction decision events.
+///
+/// Also serves directly as the considered-event payload: that event is emitted up front, when the
+/// builder begins evaluating a candidate, and carries only this budget context — decision-specific
+/// details (bundle window, metering wait, dry-run) live on the terminal rejected/accepted event.
 #[derive(Debug, Serialize)]
 pub(crate) struct BuilderBudgetFields {
     cumulative_gas_used: u64,
@@ -125,52 +129,6 @@ impl From<&TxResources> for BuilderTransactionResources {
             tx_execution_time_us: resources.execution_time_us,
             tx_uncompressed_size: resources.uncompressed_size,
         }
-    }
-}
-
-/// Fields emitted when the builder considers a transaction.
-#[derive(Debug, Serialize)]
-pub(crate) struct BuilderConsideredEventData {
-    #[serde(flatten)]
-    budget: BuilderBudgetFields,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    bundle_target_block: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    tx_age_ms: Option<u128>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    metering_wait_duration_ms: Option<u128>,
-}
-
-impl BuilderConsideredEventData {
-    /// Creates a considered-event payload with no additional decision details.
-    pub(crate) fn new(
-        info: &ExecutionInfo,
-        limits: &ResourceLimits,
-        resources: Option<&TxResources>,
-    ) -> Self {
-        Self {
-            budget: BuilderBudgetFields::new(info, limits, resources),
-            bundle_target_block: None,
-            tx_age_ms: None,
-            metering_wait_duration_ms: None,
-        }
-    }
-
-    /// Adds the target block associated with a bundle transaction.
-    pub(crate) const fn with_bundle_target_block(mut self, block_number: u64) -> Self {
-        self.bundle_target_block = Some(block_number);
-        self
-    }
-
-    /// Adds metering wait details to the considered-event payload.
-    pub(crate) const fn with_metering_wait(
-        mut self,
-        tx_age_ms: u128,
-        metering_wait_duration_ms: u128,
-    ) -> Self {
-        self.tx_age_ms = Some(tx_age_ms);
-        self.metering_wait_duration_ms = Some(metering_wait_duration_ms);
-        self
     }
 }
 


### PR DESCRIPTION
## What

Restructures `BasePayloadBuilderCtx::execute_best_transactions` (the ~575-line flashblock build loop) into a thin walk that composes reusable components.

## Shape

The walk is now: **source raw candidate → emit `Considered` → run gate chain → execute → emit terminal event**.

- **`PoolCandidateSource`** yields raw, fully materialized `Candidate`s. Bundle-window
  validity travels on the candidate as raw facts (`BundleWindow`); the source makes no
  admission decisions.
- **`Gate` trait**, run as an ordered chain (first rejection wins):
  - **`BundleGate`** — bundle-window validity (target block, expiry, not-yet-valid).
  - **`ResourceLimitsGate`** — metering estimation (and its wait/skip), the
    always-enforced hard limits, and the dry-run/enforce metering limit, folded into
    one gate. It produces the estimate once and preserves the hard-before-metering
    precedence. Metering is checked live (`is_enabled()`), so runtime toggling works.
  - **`SequencerGate`** — rejects blob/deposit transactions sourced from the pool.
- **`OutcomeReporter`** is the single layer that emits every builder transaction event
  and records rejection diagnostics, metrics, and the rejected-tx audit trail. Gates
  return a `GateRejection` the reporter renders; nothing else emits.
- Execution-time rejections (nonce-too-low, invalid, max-gas) reuse the same reporter
  via `GateRejection::Limit`; they stay inline pending a future post-execution gate.

## Behavior

Block contents, diagnostics, metrics, and the rejected-tx audit trail are **unchanged**.
The builder transaction **events** change in two intended ways:

1. **`Considered` is emitted once, up front**, when the builder begins evaluating a
   candidate — so its timestamp marks the start of evaluation and the
   `Considered`→terminal interval is a uniform measure of evaluation time.
2. **Decision-specific context** (bundle target/current block, metering wait, dry-run)
   is emitted **only on the terminal `Rejected` event**, no longer duplicated onto
   `Considered` (a small bugfix). The metering execution-time prediction likewise lands
   on the terminal event — it is an evaluation result, not known when the candidate is
   first considered (and the metering cache's LRU `get` can't be probed for
   bundle-gated candidates).

## Commits

1. **Split `is_tx_over_limits`** into hard + metering checks (byte-identical).
2. **Componentize into gates + a reporter** (the restructure above).

## Testing

`cargo clippy -p base-builder-core --lib` (clean, no allow-lints);
`cargo test -p base-builder-core --lib`; `--test data_availability
uncompressed_block_size miner_gas_limit bundles`; and `RUST_TEST_THREADS=1 --test
flashblocks`.