### PR TITLE
feat(basectl): poll live rollup config for upgrade schedule updates

### DIFF
--- a/crates/infra/basectl/src/app/core.rs
+++ b/crates/infra/basectl/src/app/core.rs
@@ -111,6 +111,7 @@ impl App {
             self.resources.validators.poll();
             self.resources.proofs.poll();
             self.resources.pods.poll();
+            self.resources.poll_upgrades();
             // When a conductor cluster is configured, bridge the Raft leader's
             // safe head into the DA tracker each tick.  The conductor poller
             // already queries `sync_status` from every node's CL, so the

--- a/crates/infra/basectl/src/app/resources.rs
+++ b/crates/infra/basectl/src/app/resources.rs
@@ -328,10 +328,10 @@ impl Resources {
 
     /// Polls for live upgrade schedule updates from the consensus node.
     pub fn poll_upgrades(&mut self) {
-        if let Some(ref mut rx) = self.upgrades_rx
-            && let Ok(upgrades) = rx.try_recv()
-        {
-            self.config.upgrades = Some(upgrades);
+        if let Some(ref mut rx) = self.upgrades_rx {
+            while let Ok(upgrades) = rx.try_recv() {
+                self.config.upgrades = Some(upgrades);
+            }
         }
     }
 }

--- a/crates/infra/basectl/src/app/resources.rs
+++ b/crates/infra/basectl/src/app/resources.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use base_common_flashblocks::Flashblock;
-use base_common_genesis::SystemConfig;
+use base_common_genesis::{SystemConfig, UpgradeConfig};
 use base_consensus_rpc::ClusterMembership;
 use tokio::sync::{mpsc, watch};
 use url::Url;
@@ -237,6 +237,7 @@ pub struct Resources {
     /// L1 system config fetched from the contract.
     pub system_config: Option<SystemConfig>,
     sys_config_rx: Option<mpsc::Receiver<SystemConfig>>,
+    upgrades_rx: Option<mpsc::Receiver<UpgradeConfig>>,
 }
 
 /// State for DA (data availability) monitoring.
@@ -297,6 +298,7 @@ impl Resources {
             pods: PodsState::default(),
             system_config: None,
             sys_config_rx: None,
+            upgrades_rx: None,
         }
     }
 
@@ -310,12 +312,26 @@ impl Resources {
         self.sys_config_rx = Some(rx);
     }
 
+    /// Sets the channel for receiving live upgrade schedule updates.
+    pub fn set_upgrades_channel(&mut self, rx: mpsc::Receiver<UpgradeConfig>) {
+        self.upgrades_rx = Some(rx);
+    }
+
     /// Polls for a new system config from the background task.
     pub fn poll_sys_config(&mut self) {
         if let Some(ref mut rx) = self.sys_config_rx
             && let Ok(cfg) = rx.try_recv()
         {
             self.system_config = Some(cfg);
+        }
+    }
+
+    /// Polls for live upgrade schedule updates from the consensus node.
+    pub fn poll_upgrades(&mut self) {
+        if let Some(ref mut rx) = self.upgrades_rx
+            && let Ok(upgrades) = rx.try_recv()
+        {
+            self.config.upgrades = Some(upgrades);
         }
     }
 }

--- a/crates/infra/basectl/src/app/runner.rs
+++ b/crates/infra/basectl/src/app/runner.rs
@@ -14,8 +14,8 @@ use crate::{
         PodsSnapshot, ProofsSnapshot, TimestampedFlashblock, ValidatorNodeStatus,
         fetch_full_system_config, fetch_initial_backlog_with_progress, run_block_fetcher,
         run_conductor_poller, run_flashblock_ws, run_flashblock_ws_timestamped,
-        run_l1_blob_watcher, run_pods_poller, run_proofs_poller, run_safe_head_poller,
-        run_validator_poller,
+        run_l1_blob_watcher, run_pods_poller, run_proofs_poller, run_rollup_config_poller,
+        run_safe_head_poller, run_validator_poller,
     },
     tui::Toast,
 };
@@ -114,6 +114,13 @@ pub fn start_background_services(
     tokio::spawn(fetch_initial_backlog_with_progress(config.rpc.to_string(), backlog_tx));
 
     let proofs_toast_tx = toast_tx.clone();
+
+    if let Some(consensus_rpc) = config.consensus_node_rpc.clone() {
+        let (upgrades_tx, upgrades_rx) = mpsc::channel(1);
+        resources.set_upgrades_channel(upgrades_rx);
+        tokio::spawn(run_rollup_config_poller(consensus_rpc, upgrades_tx, toast_tx.clone()));
+    }
+
     tokio::spawn(run_safe_head_poller(config.rpc.to_string(), sync_tx, toast_tx));
 
     let (sys_config_tx, sys_config_rx) = mpsc::channel::<SystemConfig>(1);

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -61,9 +61,9 @@ pub use rpc::{
     fetch_sequencer_active, fetch_sync_status, list_banned_peers, pause_sequencer_node,
     remove_peer, restart_conductor_node, run_block_fetcher, run_conductor_poller,
     run_flashblock_ws, run_flashblock_ws_timestamped, run_l1_blob_watcher, run_pods_poller,
-    run_proofs_poller, run_safe_head_poller, run_validator_poller, start_sequencer,
-    start_sequencer_node, stop_sequencer, stop_sequencer_node, transfer_conductor_leader,
-    unban_peer, unpause_sequencer_node,
+    run_proofs_poller, run_rollup_config_poller, run_safe_head_poller, run_validator_poller,
+    start_sequencer, start_sequencer_node, stop_sequencer, stop_sequencer_node,
+    transfer_conductor_leader, unban_peer, unpause_sequencer_node,
 };
 
 mod tui;

--- a/crates/infra/basectl/src/rpc/mod.rs
+++ b/crates/infra/basectl/src/rpc/mod.rs
@@ -49,7 +49,8 @@ pub use prover::{ProofFinalizeRequest, ProofsClient};
 mod rollup;
 pub use rollup::{
     LatestProposal, ProofsSnapshot, SyncStatusReport, ValidatorNodeStatus, fetch_safe_and_latest,
-    fetch_sync_status, run_proofs_poller, run_safe_head_poller, run_validator_poller,
+    fetch_sync_status, run_proofs_poller, run_rollup_config_poller, run_safe_head_poller,
+    run_validator_poller,
 };
 
 mod txpool;

--- a/crates/infra/basectl/src/rpc/rollup.rs
+++ b/crates/infra/basectl/src/rpc/rollup.rs
@@ -479,7 +479,10 @@ pub async fn run_rollup_config_poller(
     tx: mpsc::Sender<UpgradeConfig>,
     toast_tx: mpsc::Sender<Toast>,
 ) {
-    let client = match HttpClientBuilder::default().build(consensus_rpc.as_str()) {
+    let client = match HttpClientBuilder::default()
+        .request_timeout(ROLLUP_CONFIG_POLL_INTERVAL)
+        .build(consensus_rpc.as_str())
+    {
         Ok(client) => client,
         Err(error) => {
             warn!(

--- a/crates/infra/basectl/src/rpc/rollup.rs
+++ b/crates/infra/basectl/src/rpc/rollup.rs
@@ -7,6 +7,7 @@ use alloy_rpc_types_eth::{BlockNumberOrTag, SyncStatus as EthSyncStatus};
 use alloy_sol_types::sol;
 use alloy_transport_http::Http;
 use anyhow::{Context, Result};
+use base_common_genesis::UpgradeConfig;
 use base_common_network::Base;
 use base_consensus_rpc::{BaseP2PApiClient, RollupNodeApiClient};
 use base_protocol::SyncStatus;
@@ -19,6 +20,8 @@ use crate::{
     config::{ProofsConfig, ValidatorNodeConfig},
     tui::Toast,
 };
+
+const ROLLUP_CONFIG_POLL_INTERVAL: Duration = Duration::from_secs(5);
 
 /// Combined CL `optimism_syncStatus` + EL `eth_syncing` snapshot.
 ///
@@ -468,4 +471,54 @@ async fn find_latest_proposal<P: Provider + Clone>(
     }
 
     None
+}
+
+/// Polls the consensus node's live rollup config for upgrade schedule updates.
+pub async fn run_rollup_config_poller(
+    consensus_rpc: Url,
+    tx: mpsc::Sender<UpgradeConfig>,
+    toast_tx: mpsc::Sender<Toast>,
+) {
+    let client = match HttpClientBuilder::default().build(consensus_rpc.as_str()) {
+        Ok(client) => client,
+        Err(error) => {
+            warn!(
+                error = %error,
+                consensus_rpc = %consensus_rpc,
+                "failed to create consensus RPC client for rollup config polling"
+            );
+            let _ = toast_tx.try_send(Toast::warning("Rollup config poller connection failed"));
+            return;
+        }
+    };
+
+    let mut interval = tokio::time::interval(ROLLUP_CONFIG_POLL_INTERVAL);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut last_upgrades = None;
+
+    loop {
+        interval.tick().await;
+        let config = match RollupNodeApiClient::rollup_config(&client).await {
+            Ok(config) => config,
+            Err(error) => {
+                warn!(
+                    error = %error,
+                    consensus_rpc = %consensus_rpc,
+                    "failed to poll live rollup config"
+                );
+                continue;
+            }
+        };
+
+        if last_upgrades == Some(config.upgrades) {
+            continue;
+        }
+        if tx.send(config.upgrades).await.is_err() {
+            break;
+        }
+        if last_upgrades.is_some() {
+            let _ = toast_tx.try_send(Toast::info("Upgrade schedule updated"));
+        }
+        last_upgrades = Some(config.upgrades);
+    }
 }


### PR DESCRIPTION
## What

Adds a background poller to the basectl TUI that fetches the live rollup config
from the consensus node and keeps the upgrades view in sync with runtime
schedule changes.

Previously the upgrades view only showed the schedule loaded at startup, so
dynamic upgrade-signal changes (reschedules via the on-chain signal contract)
were invisible until basectl was restarted.

## How

- When the chain config has `consensus_node_rpc` set (devnet points at
  `http://localhost:7549` by default), spawn `run_rollup_config_poller`
  alongside the other background services.
- The poller calls `optimism_rollupConfig` via the typed
  `RollupNodeApiClient` every 5s, dedupes against the last seen schedule, and
  pushes changes to the TUI over an mpsc channel.
- `Resources::poll_upgrades` drains the channel each frame and updates
  `config.upgrades`, which the upgrades view re-applies on render.
- The initial schedule is delivered silently; subsequent changes surface an
  "Upgrade schedule updated" toast. Poll failures log a warning and retry on
  the next tick.

## Testing

- `cargo check -p basectl-cli`
- Verified end to end against the contract-driven upgrade-signal devnet:
  rescheduled an upgrade on the mock signal contract, refreshed the nodes via
  `admin_refreshUpgradeSignal`, and watched `basectl -c devnet monitor
  upgrades` pick up the new activation timestamp live (countdown + toast)
  without a restart.