### PR TITLE
fix(consensus): wait for peer connection state

### DIFF
--- a/crates/consensus/rpc/Cargo.toml
+++ b/crates/consensus/rpc/Cargo.toml
@@ -44,6 +44,7 @@ jsonrpsee = { workspace = true, features = ["macros", "server"] }
 [dev-dependencies]
 rstest.workspace = true
 serde_json = { workspace = true, features = ["std"] }
+tokio = { workspace = true, features = ["macros", "rt", "sync"] }
 
 [features]
 default = []

--- a/crates/consensus/rpc/src/p2p.rs
+++ b/crates/consensus/rpc/src/p2p.rs
@@ -13,6 +13,16 @@ use jsonrpsee::{
 
 use crate::{BaseP2PApiServer, net::P2pRpc};
 
+const PEER_STATE_WAIT_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn peer_state_result(actual: bool, expected: bool, error_message: &'static str) -> RpcResult<()> {
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(ErrorObject::borrowed(ErrorCode::InvalidParams.code(), error_message, None))
+    }
+}
+
 #[async_trait]
 impl BaseP2PApiServer for P2pRpc {
     async fn opp2p_self(&self) -> RpcResult<PeerInfo> {
@@ -184,9 +194,32 @@ impl BaseP2PApiServer for P2pRpc {
             .map_err(|_| ErrorObject::from(ErrorCode::InternalError))
     }
 
-    async fn opp2p_connect_peer(&self, _peer: String) -> RpcResult<()> {
+    async fn opp2p_connect_peer(&self, peer: String) -> RpcResult<()> {
         Metrics::rpc_calls("opp2p_connectPeer").increment(1.0);
-        let ma = libp2p::Multiaddr::from_str(&_peer).map_err(|_| {
+        self.connect_peer_with_backoff(
+            peer,
+            ExponentialBuilder::default().with_total_delay(Some(PEER_STATE_WAIT_TIMEOUT)),
+        )
+        .await
+    }
+
+    async fn opp2p_disconnect_peer(&self, peer_id: String) -> RpcResult<()> {
+        Metrics::rpc_calls("opp2p_disconnectPeer").increment(1.0);
+        self.disconnect_peer_with_backoff(
+            peer_id,
+            ExponentialBuilder::default().with_total_delay(Some(PEER_STATE_WAIT_TIMEOUT)),
+        )
+        .await
+    }
+}
+
+impl P2pRpc {
+    async fn connect_peer_with_backoff(
+        &self,
+        peer: String,
+        backoff: ExponentialBuilder,
+    ) -> RpcResult<()> {
+        let ma = libp2p::Multiaddr::from_str(&peer).map_err(|_| {
             ErrorObject::borrowed(ErrorCode::InvalidParams.code(), "Invalid multiaddr", None)
         })?;
 
@@ -226,25 +259,22 @@ impl BaseP2PApiServer for P2pRpc {
                 ErrorObject::borrowed(ErrorCode::InternalError.code(), "Failed to get peers", None)
             })?;
 
-            Ok::<bool, ErrorObject<'_>>(peers.peers.contains_key(&peer_id.to_string()))
+            peer_state_result(
+                peers.peers.contains_key(&peer_id.to_string()),
+                true,
+                "Peer not connected",
+            )
         };
 
-        if !is_connected
-            .retry(ExponentialBuilder::default().with_total_delay(Some(Duration::from_secs(10))))
-            .await?
-        {
-            return Err(ErrorObject::borrowed(
-                ErrorCode::InvalidParams.code(),
-                "Peer not connected",
-                None,
-            ));
-        }
-
+        is_connected.retry(backoff).await?;
         Ok(())
     }
 
-    async fn opp2p_disconnect_peer(&self, peer_id: String) -> RpcResult<()> {
-        Metrics::rpc_calls("opp2p_disconnectPeer").increment(1.0);
+    async fn disconnect_peer_with_backoff(
+        &self,
+        peer_id: String,
+        backoff: ExponentialBuilder,
+    ) -> RpcResult<()> {
         let peer_id = match peer_id.parse() {
             Ok(id) => id,
             Err(err) => {
@@ -273,27 +303,137 @@ impl BaseP2PApiServer for P2pRpc {
                 ErrorObject::borrowed(ErrorCode::InternalError.code(), "Failed to get peers", None)
             })?;
 
-            Ok::<bool, ErrorObject<'_>>(!peers.peers.contains_key(&peer_id.to_string()))
+            peer_state_result(
+                !peers.peers.contains_key(&peer_id.to_string()),
+                true,
+                "Peers are still connected",
+            )
         };
 
-        if !is_not_connected
-            .retry(ExponentialBuilder::default().with_total_delay(Some(Duration::from_secs(10))))
-            .await?
-        {
-            return Err(ErrorObject::borrowed(
-                ErrorCode::InvalidParams.code(),
-                "Peers are still connected",
-                None,
-            ));
-        }
-
+        is_not_connected.retry(backoff).await?;
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use std::{
+        collections::VecDeque,
+        str::FromStr,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        time::Duration,
+    };
+
+    use backon::ExponentialBuilder;
+    use base_consensus_gossip::{P2pRpcRequest, PeerDump, PeerInfo};
+    use tokio::sync::mpsc;
+
+    use crate::net::P2pRpc;
+
+    fn test_backoff() -> ExponentialBuilder {
+        ExponentialBuilder::default()
+            .with_min_delay(Duration::from_millis(1))
+            .with_total_delay(Some(Duration::from_millis(20)))
+    }
+
+    async fn respond_to_peer_state_requests(
+        mut requests: mpsc::Receiver<P2pRpcRequest>,
+        peer_id: libp2p::PeerId,
+        mut connected_states: VecDeque<bool>,
+        default_connected: bool,
+        attempts: Arc<AtomicUsize>,
+    ) {
+        while let Some(request) = requests.recv().await {
+            match request {
+                P2pRpcRequest::ConnectPeer { .. } | P2pRpcRequest::DisconnectPeer { .. } => {}
+                P2pRpcRequest::Peers { out, connected: true } => {
+                    attempts.fetch_add(1, Ordering::Relaxed);
+                    let connected = connected_states.pop_front().unwrap_or(default_connected);
+                    let mut dump = PeerDump::default();
+                    if connected {
+                        dump.total_connected = 1;
+                        dump.peers.insert(peer_id.to_string(), PeerInfo::default());
+                    }
+                    let _ = out.send(dump);
+                }
+                _ => panic!("unexpected p2p request"),
+            }
+        }
+    }
+
+    fn peer_multiaddr(peer_id: &libp2p::PeerId) -> String {
+        format!("/ip4/127.0.0.1/tcp/30303/p2p/{peer_id}")
+    }
+
+    #[tokio::test]
+    async fn connect_peer_waits_for_multiple_peer_state_responses() {
+        let (sender, requests) = mpsc::channel(8);
+        let rpc = P2pRpc::new(sender);
+        let peer_id = libp2p::PeerId::random();
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let handler = tokio::spawn(respond_to_peer_state_requests(
+            requests,
+            peer_id,
+            VecDeque::from([false, false, true]),
+            false,
+            Arc::clone(&attempts),
+        ));
+
+        let result = rpc.connect_peer_with_backoff(peer_multiaddr(&peer_id), test_backoff()).await;
+
+        assert!(result.is_ok());
+        assert_eq!(attempts.load(Ordering::Relaxed), 3);
+        drop(rpc);
+        handler.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn disconnect_peer_waits_for_multiple_peer_state_responses() {
+        let (sender, requests) = mpsc::channel(8);
+        let rpc = P2pRpc::new(sender);
+        let peer_id = libp2p::PeerId::random();
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let handler = tokio::spawn(respond_to_peer_state_requests(
+            requests,
+            peer_id,
+            VecDeque::from([true, true, false]),
+            true,
+            Arc::clone(&attempts),
+        ));
+
+        let result = rpc.disconnect_peer_with_backoff(peer_id.to_string(), test_backoff()).await;
+
+        assert!(result.is_ok());
+        assert_eq!(attempts.load(Ordering::Relaxed), 3);
+        drop(rpc);
+        handler.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn connect_peer_returns_error_after_timeout() {
+        let (sender, requests) = mpsc::channel(8);
+        let rpc = P2pRpc::new(sender);
+        let peer_id = libp2p::PeerId::random();
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let handler = tokio::spawn(respond_to_peer_state_requests(
+            requests,
+            peer_id,
+            VecDeque::new(),
+            false,
+            Arc::clone(&attempts),
+        ));
+
+        let result = rpc.connect_peer_with_backoff(peer_multiaddr(&peer_id), test_backoff()).await;
+
+        let error = result.expect_err("an absent peer should eventually time out");
+        assert_eq!(error.message(), "Peer not connected");
+        assert!(attempts.load(Ordering::Relaxed) > 1);
+        drop(rpc);
+        handler.await.unwrap();
+    }
 
     #[test]
     fn test_parse_multiaddr_string() {

--- a/crates/consensus/rpc/src/p2p.rs
+++ b/crates/consensus/rpc/src/p2p.rs
@@ -15,8 +15,8 @@ use crate::{BaseP2PApiServer, net::P2pRpc};
 
 const PEER_STATE_WAIT_TIMEOUT: Duration = Duration::from_secs(10);
 
-fn peer_state_result(actual: bool, expected: bool, error_message: &'static str) -> RpcResult<()> {
-    if actual == expected {
+fn peer_state_result(ok: bool, error_message: &'static str) -> RpcResult<()> {
+    if ok {
         Ok(())
     } else {
         Err(ErrorObject::borrowed(ErrorCode::InvalidParams.code(), error_message, None))
@@ -259,14 +259,13 @@ impl P2pRpc {
                 ErrorObject::borrowed(ErrorCode::InternalError.code(), "Failed to get peers", None)
             })?;
 
-            peer_state_result(
-                peers.peers.contains_key(&peer_id.to_string()),
-                true,
-                "Peer not connected",
-            )
+            peer_state_result(peers.peers.contains_key(&peer_id.to_string()), "Peer not connected")
         };
 
-        is_connected.retry(backoff).await?;
+        is_connected
+            .retry(backoff)
+            .when(|error| error.code() == ErrorCode::InvalidParams.code())
+            .await?;
         Ok(())
     }
 
@@ -305,12 +304,14 @@ impl P2pRpc {
 
             peer_state_result(
                 !peers.peers.contains_key(&peer_id.to_string()),
-                true,
                 "Peers are still connected",
             )
         };
 
-        is_not_connected.retry(backoff).await?;
+        is_not_connected
+            .retry(backoff)
+            .when(|error| error.code() == ErrorCode::InvalidParams.code())
+            .await?;
         Ok(())
     }
 }

--- a/crates/consensus/rpc/src/p2p.rs
+++ b/crates/consensus/rpc/src/p2p.rs
@@ -15,11 +15,28 @@ use crate::{BaseP2PApiServer, net::P2pRpc};
 
 const PEER_STATE_WAIT_TIMEOUT: Duration = Duration::from_secs(10);
 
-fn peer_state_result(ok: bool, error_message: &'static str) -> RpcResult<()> {
-    if ok {
+/// Retryable peer-state miss for Backon wait loops.
+///
+/// `InvalidParams` marks "desired state not reached yet" so connect/disconnect waits can
+/// distinguish it from terminal `InternalError`s (e.g. a dropped gossip RPC channel), which
+/// must fail fast instead of burning the wait timeout.
+fn peer_state_miss(error_message: &'static str) -> ErrorObject<'static> {
+    ErrorObject::borrowed(ErrorCode::InvalidParams.code(), error_message, None)
+}
+
+fn require_peer_connected(peers: &PeerDump, peer_id: &libp2p::PeerId) -> RpcResult<()> {
+    if peers.peers.contains_key(&peer_id.to_string()) {
         Ok(())
     } else {
-        Err(ErrorObject::borrowed(ErrorCode::InvalidParams.code(), error_message, None))
+        Err(peer_state_miss("Peer not connected"))
+    }
+}
+
+fn require_peer_disconnected(peers: &PeerDump, peer_id: &libp2p::PeerId) -> RpcResult<()> {
+    if peers.peers.contains_key(&peer_id.to_string()) {
+        Err(peer_state_miss("Peers are still connected"))
+    } else {
+        Ok(())
     }
 }
 
@@ -259,9 +276,10 @@ impl P2pRpc {
                 ErrorObject::borrowed(ErrorCode::InternalError.code(), "Failed to get peers", None)
             })?;
 
-            peer_state_result(peers.peers.contains_key(&peer_id.to_string()), "Peer not connected")
+            require_peer_connected(&peers, &peer_id)
         };
 
+        // Retry only peer-state misses; do not retry channel failures.
         is_connected
             .retry(backoff)
             .when(|error| error.code() == ErrorCode::InvalidParams.code())
@@ -302,12 +320,10 @@ impl P2pRpc {
                 ErrorObject::borrowed(ErrorCode::InternalError.code(), "Failed to get peers", None)
             })?;
 
-            peer_state_result(
-                !peers.peers.contains_key(&peer_id.to_string()),
-                "Peers are still connected",
-            )
+            require_peer_disconnected(&peers, &peer_id)
         };
 
+        // Retry only peer-state misses; do not retry channel failures.
         is_not_connected
             .retry(backoff)
             .when(|error| error.code() == ErrorCode::InvalidParams.code())


### PR DESCRIPTION
## Summary

- Fix the peer-state polling bug in `opp2p_connectPeer` and `opp2p_disconnectPeer`.
- The functional change is small: an unsatisfied peer state now returns `Err` instead of `Ok(false)`, allowing Backon to retry.
- This PR does not remove `PendingOutgoing` slot usage. It prevents this path from burning through those slots in a rapid dial flood.
- The remaining diff extracts the existing RPC bodies so tests can inject a short backoff and exercise real request/response flows.

## Root cause

Backon retries only errors. Before this change, the peer-state check returned `Ok(false)` when a peer was not yet connected. Backon treated that as success, so the RPC returned immediately while the libp2p dial was still pending.

The registry then interpreted the response as successful and started another dial, often for the same peer or another entry from the stale S3 peer list. Each dial consumed one `PendingOutgoing` slot. Because RPCs returned immediately, dials were started faster than they could complete or time out, quickly saturating the 16-slot limit. Subsequent dials, including needed ones, failed with `PendingOutgoing` exhaustion.

## PendingOutgoing impact

Every connection attempt still starts one libp2p dial and can consume one `PendingOutgoing` slot.

The change is in the pacing:

- Before: `Ok(false)` caused an immediate RPC success, allowing the registry to start another dial almost immediately.
- After: the unsatisfied state becomes a retryable error. The RPC remains pending while it polls for up to the existing 10-second bound, then returns `Peer not connected`.
- The retries are state checks; they do not issue additional `ConnectPeer` dials.
- A synchronous caller therefore cannot immediately treat the attempt as successful and start another dial through this path.

This makes saturation from this path much harder, but does not make it impossible. Registry deduplication, stale-peer pruning, and global dial concurrency remain separate concerns and are out of scope for this PR.

## Implementation

- Convert unsuccessful state observations into retryable RPC errors:
  - `Peer not connected`
  - `Peers are still connected`
- Preserve the existing bounded exponential retry configuration.
- Apply the same confirmed-state behavior to disconnects.
- Keep registry pruning and peer-record deduplication out of this PR.

The private `*_with_backoff` methods and Tokio test features are testability support only. They do not add another production dial path or change the RPC protocol.

## Validation

- `cargo test -p base-consensus-rpc --lib --locked` — 64 passed.
- Focused clippy — passed.
- Nightly formatting check — passed.
- Tests cover delayed connect/disconnect success and timeout/error behavior through actual `P2pRpcRequest` responses.

## Devnet QA

Ran the PR image in an isolated local devnet with real L1/L2 EL and CL services, Engine APIs, and consensus P2P RPCs.

The test exercised the exact failure path:

- Disconnected the target peer.
- Called `opp2p_connectPeer` with an unreachable multiaddr.
- Received `Peer not connected` after 7.116594 seconds instead of immediate success.

This confirms that an unsatisfied peer state now becomes a retryable error, preventing the registry from treating an in-progress or failed dial as successful and immediately enqueueing another dial. Disconnect/reconnect behavior also passed, and the builder produced L2 blocks during the run.

End-to-end liveness remained inconclusive because of unrelated devnet environment issues.

type=routine
risk=low
impact=sev5
