### PR TITLE
feat(rpc): populate Base millisecond timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4656,6 +4656,7 @@ dependencies = [
  "base-execution-trie",
  "base-execution-txpool",
  "base-metrics",
+ "base-protocol",
  "derive_more 2.1.1",
  "eyre",
  "futures",

--- a/crates/consensus/protocol/src/base_time.rs
+++ b/crates/consensus/protocol/src/base_time.rs
@@ -92,6 +92,16 @@ impl BaseTimeUpdateTx {
         Ok(base_time)
     }
 
+    /// Extracts the block timestamp in milliseconds from its transactions and header fields.
+    pub fn extract_timestamp_ms<T: BaseTransaction>(
+        transactions: &[T],
+        block_number: u64,
+        timestamp: u64,
+    ) -> Result<u64, BaseTimeMetadataError> {
+        let base_time = Self::extract_from_transactions(transactions, block_number)?;
+        Ok(timestamp.wrapping_mul(1_000).wrapping_add(u64::from(base_time.timestamp_millis_part())))
+    }
+
     /// Validates and decodes a `BaseTime` metadata deposit.
     pub fn validate_deposit(
         deposit: &TxDeposit,
@@ -310,6 +320,16 @@ mod tests {
         let base_time = BaseTimeUpdateTx::extract_from_transactions(&transactions, 9).unwrap();
 
         assert_eq!(base_time.timestamp_millis_part(), 600);
+    }
+
+    #[test]
+    fn extracts_timestamp_ms() {
+        let transactions: Vec<BaseTransactionSigned> = vec![
+            TxDeposit::default().seal_slow().into(),
+            base_time_deposit(9, 600).seal_slow().into(),
+        ];
+
+        assert_eq!(BaseTimeUpdateTx::extract_timestamp_ms(&transactions, 9, 42), Ok(42_600));
     }
 
     #[test]

--- a/crates/execution/rpc/Cargo.toml
+++ b/crates/execution/rpc/Cargo.toml
@@ -35,6 +35,7 @@ reth-basic-payload-builder.workspace = true
 reth-tasks = { workspace = true, features = ["rayon"] }
 
 # op-reth
+base-protocol.workspace = true
 base-common-evm.workspace = true
 base-execution-evm.workspace = true
 base-execution-trie.workspace = true

--- a/crates/execution/rpc/src/eth/block.rs
+++ b/crates/execution/rpc/src/eth/block.rs
@@ -13,22 +13,6 @@ use reth_rpc_eth_api::{
 
 use crate::{BaseEthApi, BaseEthApiError, eth::RpcNodeCore};
 
-impl<N: RpcNodeCore, Rpc: RpcConvert> BaseEthApi<N, Rpc> {
-    fn extract_timestamp_ms<B: BlockBody>(
-        body: &B,
-        block_number: u64,
-        timestamp: u64,
-    ) -> Option<u64>
-    where
-        B::Transaction: BaseTransaction,
-    {
-        let millis = BaseTimeUpdateTx::extract_from_transactions(body.transactions(), block_number)
-            .ok()?
-            .timestamp_millis_part();
-        Some(timestamp.wrapping_mul(1_000).wrapping_add(u64::from(millis)))
-    }
-}
-
 impl<N, Rpc> EthBlocks for BaseEthApi<N, Rpc>
 where
     N: RpcNodeCore,
@@ -45,8 +29,12 @@ where
         Self: FullEthApiTypes,
     {
         let Some(block) = self.recovered_block(block_id).await? else { return Ok(None) };
-        let timestamp_ms =
-            Self::extract_timestamp_ms(block.body(), block.number(), block.timestamp());
+        let timestamp_ms = BaseTimeUpdateTx::extract_timestamp_ms(
+            block.body().transactions(),
+            block.number(),
+            block.timestamp(),
+        )
+        .ok();
         let mut header =
             self.converter().convert_header(block.clone_sealed_header(), block.rlp_length())?;
         header.timestamp_ms = timestamp_ms;
@@ -62,8 +50,12 @@ where
         Self: FullEthApiTypes,
     {
         let Some(block) = self.recovered_block(block_id).await? else { return Ok(None) };
-        let timestamp_ms =
-            Self::extract_timestamp_ms(block.body(), block.number(), block.timestamp());
+        let timestamp_ms = BaseTimeUpdateTx::extract_timestamp_ms(
+            block.body().transactions(),
+            block.number(),
+            block.timestamp(),
+        )
+        .ok();
         let mut block = block.clone_into_rpc_block(
             full.into(),
             |tx, tx_info| self.converter().fill(tx, tx_info),

--- a/crates/execution/rpc/src/eth/block.rs
+++ b/crates/execution/rpc/src/eth/block.rs
@@ -13,16 +13,6 @@ use reth_rpc_eth_api::{
 
 use crate::{BaseEthApi, BaseEthApiError, eth::RpcNodeCore};
 
-trait TimestampMsHeader {
-    fn set_timestamp_ms(&mut self, timestamp_ms: Option<u64>);
-}
-
-impl TimestampMsHeader for BaseHeaderResponse {
-    fn set_timestamp_ms(&mut self, timestamp_ms: Option<u64>) {
-        self.timestamp_ms = timestamp_ms;
-    }
-}
-
 impl<N: RpcNodeCore, Rpc: RpcConvert> BaseEthApi<N, Rpc> {
     fn extract_timestamp_ms<B: BlockBody>(
         body: &B,
@@ -44,8 +34,8 @@ where
     N: RpcNodeCore,
     BaseEthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = BaseEthApiError>,
+    <Self as EthApiTypes>::NetworkTypes: RpcTypes<Header = BaseHeaderResponse>,
     <Self::Primitives as NodePrimitives>::SignedTx: BaseTransaction,
-    <Self::NetworkTypes as RpcTypes>::Header: TimestampMsHeader,
 {
     async fn rpc_block_header(
         &self,
@@ -59,7 +49,7 @@ where
             Self::extract_timestamp_ms(block.body(), block.number(), block.timestamp());
         let mut header =
             self.converter().convert_header(block.clone_sealed_header(), block.rlp_length())?;
-        header.set_timestamp_ms(timestamp_ms);
+        header.timestamp_ms = timestamp_ms;
         Ok(Some(header))
     }
 
@@ -79,7 +69,7 @@ where
             |tx, tx_info| self.converter().fill(tx, tx_info),
             |header, size| self.converter().convert_header(header, size),
         )?;
-        block.header.set_timestamp_ms(timestamp_ms);
+        block.header.timestamp_ms = timestamp_ms;
         Ok(Some(block))
     }
 }

--- a/crates/execution/rpc/src/eth/block.rs
+++ b/crates/execution/rpc/src/eth/block.rs
@@ -23,15 +23,19 @@ impl TimestampMsHeader for BaseHeaderResponse {
     }
 }
 
-fn timestamp_ms<B: BlockBody>(body: &B, block_number: u64, timestamp: u64) -> Option<u64>
-where
-    B::Transaction: BaseTransaction,
-{
-    let millis = BaseTimeUpdateTx::extract_from_transactions(body.transactions(), block_number)
-        .ok()?
-        .timestamp_millis_part();
-    Some(timestamp.wrapping_mul(1_000).wrapping_add(u64::from(millis)))
+trait BaseTimeBlockBody: BlockBody {
+    fn extract_timestamp_ms(&self, block_number: u64, timestamp: u64) -> Option<u64>
+    where
+        Self::Transaction: BaseTransaction,
+    {
+        let millis = BaseTimeUpdateTx::extract_from_transactions(self.transactions(), block_number)
+            .ok()?
+            .timestamp_millis_part();
+        Some(timestamp.wrapping_mul(1_000).wrapping_add(u64::from(millis)))
+    }
 }
+
+impl<B: BlockBody> BaseTimeBlockBody for B {}
 
 impl<N, Rpc> EthBlocks for BaseEthApi<N, Rpc>
 where
@@ -49,7 +53,7 @@ where
         Self: FullEthApiTypes,
     {
         let Some(block) = self.recovered_block(block_id).await? else { return Ok(None) };
-        let timestamp_ms = timestamp_ms(block.body(), block.number(), block.timestamp());
+        let timestamp_ms = block.body().extract_timestamp_ms(block.number(), block.timestamp());
         let mut header =
             self.converter().convert_header(block.clone_sealed_header(), block.rlp_length())?;
         header.set_timestamp_ms(timestamp_ms);
@@ -65,7 +69,7 @@ where
         Self: FullEthApiTypes,
     {
         let Some(block) = self.recovered_block(block_id).await? else { return Ok(None) };
-        let timestamp_ms = timestamp_ms(block.body(), block.number(), block.timestamp());
+        let timestamp_ms = block.body().extract_timestamp_ms(block.number(), block.timestamp());
         let mut block = block.clone_into_rpc_block(
             full.into(),
             |tx, tx_info| self.converter().fill(tx, tx_info),
@@ -109,30 +113,27 @@ mod tests {
         let body =
             body_with_transactions([TxDeposit::default().into(), base_time_transaction(7, 200)]);
 
-        assert_eq!(timestamp_ms(&body, 7, 42), Some(42_200));
+        assert_eq!(body.extract_timestamp_ms(7, 42), Some(42_200));
     }
 
     #[test]
     fn omits_timestamp_ms_without_valid_base_time_transaction_at_index_one() {
         assert_eq!(
-            timestamp_ms(&body_with_transactions([TxDeposit::default().into()]), 7, 42),
+            body_with_transactions([TxDeposit::default().into()]).extract_timestamp_ms(7, 42),
             None
         );
         assert_eq!(
-            timestamp_ms(
-                &body_with_transactions([
-                    TxDeposit::default().into(),
-                    TxDeposit::default().into(),
-                    base_time_transaction(7, 400),
-                ]),
-                7,
-                42,
-            ),
+            body_with_transactions([
+                TxDeposit::default().into(),
+                TxDeposit::default().into(),
+                base_time_transaction(7, 400),
+            ])
+            .extract_timestamp_ms(7, 42),
             None
         );
 
         let wrong_block =
             body_with_transactions([TxDeposit::default().into(), base_time_transaction(8, 400)]);
-        assert_eq!(timestamp_ms(&wrong_block, 7, 42), None);
+        assert_eq!(wrong_block.extract_timestamp_ms(7, 42), None);
     }
 }

--- a/crates/execution/rpc/src/eth/block.rs
+++ b/crates/execution/rpc/src/eth/block.rs
@@ -1,18 +1,79 @@
 //! Loads and formats Base block RPC response.
 
+use alloy_eips::BlockId;
+use base_common_consensus::BaseTransaction;
+use base_common_rpc_types::BaseHeaderResponse;
+use base_protocol::BaseTimeUpdateTx;
+use reth_node_api::BlockBody;
+use reth_primitives_traits::{AlloyBlockHeader, NodePrimitives};
 use reth_rpc_eth_api::{
-    FromEvmError, RpcConvert,
+    EthApiTypes, FromEvmError, FullEthApiTypes, RpcBlock, RpcConvert, RpcHeader, RpcTypes,
     helpers::{EthBlocks, LoadBlock},
 };
 
 use crate::{BaseEthApi, BaseEthApiError, eth::RpcNodeCore};
+
+trait TimestampMsHeader {
+    fn set_timestamp_ms(&mut self, timestamp_ms: Option<u64>);
+}
+
+impl TimestampMsHeader for BaseHeaderResponse {
+    fn set_timestamp_ms(&mut self, timestamp_ms: Option<u64>) {
+        self.timestamp_ms = timestamp_ms;
+    }
+}
+
+fn timestamp_ms<B: BlockBody>(body: &B, block_number: u64, timestamp: u64) -> Option<u64>
+where
+    B::Transaction: BaseTransaction,
+{
+    let millis = BaseTimeUpdateTx::extract_from_transactions(body.transactions(), block_number)
+        .ok()?
+        .timestamp_millis_part();
+    Some(timestamp.wrapping_mul(1_000).wrapping_add(u64::from(millis)))
+}
 
 impl<N, Rpc> EthBlocks for BaseEthApi<N, Rpc>
 where
     N: RpcNodeCore,
     BaseEthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = BaseEthApiError>,
+    <Self::Primitives as NodePrimitives>::SignedTx: BaseTransaction,
+    <Self::NetworkTypes as RpcTypes>::Header: TimestampMsHeader,
 {
+    async fn rpc_block_header(
+        &self,
+        block_id: BlockId,
+    ) -> Result<Option<RpcHeader<Self::NetworkTypes>>, Self::Error>
+    where
+        Self: FullEthApiTypes,
+    {
+        let Some(block) = self.recovered_block(block_id).await? else { return Ok(None) };
+        let timestamp_ms = timestamp_ms(block.body(), block.number(), block.timestamp());
+        let mut header =
+            self.converter().convert_header(block.clone_sealed_header(), block.rlp_length())?;
+        header.set_timestamp_ms(timestamp_ms);
+        Ok(Some(header))
+    }
+
+    async fn rpc_block(
+        &self,
+        block_id: BlockId,
+        full: bool,
+    ) -> Result<Option<RpcBlock<Self::NetworkTypes>>, Self::Error>
+    where
+        Self: FullEthApiTypes,
+    {
+        let Some(block) = self.recovered_block(block_id).await? else { return Ok(None) };
+        let timestamp_ms = timestamp_ms(block.body(), block.number(), block.timestamp());
+        let mut block = block.clone_into_rpc_block(
+            full.into(),
+            |tx, tx_info| self.converter().fill(tx, tx_info),
+            |header, size| self.converter().convert_header(header, size),
+        )?;
+        block.header.set_timestamp_ms(timestamp_ms);
+        Ok(Some(block))
+    }
 }
 
 impl<N, Rpc> LoadBlock for BaseEthApi<N, Rpc>
@@ -21,4 +82,57 @@ where
     BaseEthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = BaseEthApiError>,
 {
+}
+
+#[cfg(test)]
+mod tests {
+    use base_common_consensus::{BaseBlockBody, BaseTxEnvelope, TxDeposit};
+
+    use super::*;
+
+    fn body_with_transactions(
+        transactions: impl IntoIterator<Item = BaseTxEnvelope>,
+    ) -> BaseBlockBody {
+        BaseBlockBody {
+            transactions: transactions.into_iter().collect(),
+            ommers: Vec::new(),
+            withdrawals: None,
+        }
+    }
+
+    fn base_time_transaction(block_number: u64, millis: u16) -> BaseTxEnvelope {
+        BaseTimeUpdateTx::new(millis).unwrap().into_deposit_tx(block_number).into()
+    }
+
+    #[test]
+    fn extracts_timestamp_ms_from_base_time_transaction() {
+        let body =
+            body_with_transactions([TxDeposit::default().into(), base_time_transaction(7, 200)]);
+
+        assert_eq!(timestamp_ms(&body, 7, 42), Some(42_200));
+    }
+
+    #[test]
+    fn omits_timestamp_ms_without_valid_base_time_transaction_at_index_one() {
+        assert_eq!(
+            timestamp_ms(&body_with_transactions([TxDeposit::default().into()]), 7, 42),
+            None
+        );
+        assert_eq!(
+            timestamp_ms(
+                &body_with_transactions([
+                    TxDeposit::default().into(),
+                    TxDeposit::default().into(),
+                    base_time_transaction(7, 400),
+                ]),
+                7,
+                42,
+            ),
+            None
+        );
+
+        let wrong_block =
+            body_with_transactions([TxDeposit::default().into(), base_time_transaction(8, 400)]);
+        assert_eq!(timestamp_ms(&wrong_block, 7, 42), None);
+    }
 }

--- a/crates/execution/rpc/src/eth/block.rs
+++ b/crates/execution/rpc/src/eth/block.rs
@@ -23,19 +23,21 @@ impl TimestampMsHeader for BaseHeaderResponse {
     }
 }
 
-trait BaseTimeBlockBody: BlockBody {
-    fn extract_timestamp_ms(&self, block_number: u64, timestamp: u64) -> Option<u64>
+impl<N: RpcNodeCore, Rpc: RpcConvert> BaseEthApi<N, Rpc> {
+    fn extract_timestamp_ms<B: BlockBody>(
+        body: &B,
+        block_number: u64,
+        timestamp: u64,
+    ) -> Option<u64>
     where
-        Self::Transaction: BaseTransaction,
+        B::Transaction: BaseTransaction,
     {
-        let millis = BaseTimeUpdateTx::extract_from_transactions(self.transactions(), block_number)
+        let millis = BaseTimeUpdateTx::extract_from_transactions(body.transactions(), block_number)
             .ok()?
             .timestamp_millis_part();
         Some(timestamp.wrapping_mul(1_000).wrapping_add(u64::from(millis)))
     }
 }
-
-impl<B: BlockBody> BaseTimeBlockBody for B {}
 
 impl<N, Rpc> EthBlocks for BaseEthApi<N, Rpc>
 where
@@ -53,7 +55,8 @@ where
         Self: FullEthApiTypes,
     {
         let Some(block) = self.recovered_block(block_id).await? else { return Ok(None) };
-        let timestamp_ms = block.body().extract_timestamp_ms(block.number(), block.timestamp());
+        let timestamp_ms =
+            Self::extract_timestamp_ms(block.body(), block.number(), block.timestamp());
         let mut header =
             self.converter().convert_header(block.clone_sealed_header(), block.rlp_length())?;
         header.set_timestamp_ms(timestamp_ms);
@@ -69,7 +72,8 @@ where
         Self: FullEthApiTypes,
     {
         let Some(block) = self.recovered_block(block_id).await? else { return Ok(None) };
-        let timestamp_ms = block.body().extract_timestamp_ms(block.number(), block.timestamp());
+        let timestamp_ms =
+            Self::extract_timestamp_ms(block.body(), block.number(), block.timestamp());
         let mut block = block.clone_into_rpc_block(
             full.into(),
             |tx, tx_info| self.converter().fill(tx, tx_info),
@@ -86,54 +90,4 @@ where
     BaseEthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = BaseEthApiError>,
 {
-}
-
-#[cfg(test)]
-mod tests {
-    use base_common_consensus::{BaseBlockBody, BaseTxEnvelope, TxDeposit};
-
-    use super::*;
-
-    fn body_with_transactions(
-        transactions: impl IntoIterator<Item = BaseTxEnvelope>,
-    ) -> BaseBlockBody {
-        BaseBlockBody {
-            transactions: transactions.into_iter().collect(),
-            ommers: Vec::new(),
-            withdrawals: None,
-        }
-    }
-
-    fn base_time_transaction(block_number: u64, millis: u16) -> BaseTxEnvelope {
-        BaseTimeUpdateTx::new(millis).unwrap().into_deposit_tx(block_number).into()
-    }
-
-    #[test]
-    fn extracts_timestamp_ms_from_base_time_transaction() {
-        let body =
-            body_with_transactions([TxDeposit::default().into(), base_time_transaction(7, 200)]);
-
-        assert_eq!(body.extract_timestamp_ms(7, 42), Some(42_200));
-    }
-
-    #[test]
-    fn omits_timestamp_ms_without_valid_base_time_transaction_at_index_one() {
-        assert_eq!(
-            body_with_transactions([TxDeposit::default().into()]).extract_timestamp_ms(7, 42),
-            None
-        );
-        assert_eq!(
-            body_with_transactions([
-                TxDeposit::default().into(),
-                TxDeposit::default().into(),
-                base_time_transaction(7, 400),
-            ])
-            .extract_timestamp_ms(7, 42),
-            None
-        );
-
-        let wrong_block =
-            body_with_transactions([TxDeposit::default().into(), base_time_transaction(8, 400)]);
-        assert_eq!(wrong_block.extract_timestamp_ms(7, 42), None);
-    }
 }


### PR DESCRIPTION
Populates Base block and header RPC responses with millisecond timestamps derived from the canonical BaseTime metadata deposit while preserving omission for historical or invalid metadata.