### PR TITLE
feat(devnet): harden CL gossip fast-path against single-peer stalls

### DIFF
--- a/etc/docker/docker-compose.ha.yml
+++ b/etc/docker/docker-compose.ha.yml
@@ -179,6 +179,16 @@ services:
       - ${SEQUENCER_KEY}
       - --p2p.scoring
       - Off
+      # Devnet runs a tiny gossip mesh that never reaches the mesh low-watermark,
+      # so the topic mesh cannot stabilize. Flood publishing sends unsafe payloads
+      # to every known peer on the topic regardless of mesh state, removing the
+      # single-peer fast-path fragility that stalls followers.
+      - --p2p.gossip.mesh.floodpublish
+      - "true"
+      # Reconnect quickly after a transient drop instead of waiting the default
+      # 60m redial period before the dial counter resets.
+      - --p2p.redial.period
+      - "1"
       - -vvv
     healthcheck:
       <<: *node-healthcheck
@@ -288,6 +298,16 @@ services:
       - ${SEQUENCER_KEY}
       - --p2p.scoring
       - Off
+      # Devnet runs a tiny gossip mesh that never reaches the mesh low-watermark,
+      # so the topic mesh cannot stabilize. Flood publishing sends unsafe payloads
+      # to every known peer on the topic regardless of mesh state, removing the
+      # single-peer fast-path fragility that stalls followers.
+      - --p2p.gossip.mesh.floodpublish
+      - "true"
+      # Reconnect quickly after a transient drop instead of waiting the default
+      # 60m redial period before the dial counter resets.
+      - --p2p.redial.period
+      - "1"
       - -vvv
     healthcheck:
       <<: *node-healthcheck

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -351,6 +351,16 @@ services:
       - ${SEQUENCER_KEY}
       - --p2p.scoring
       - Off
+      # Devnet runs a tiny (1-2 peer) gossip mesh that never reaches the mesh
+      # low-watermark, so the topic mesh cannot stabilize. Flood publishing sends
+      # unsafe payloads to every known peer on the topic regardless of mesh state,
+      # removing the single-peer fast-path fragility that stalls followers.
+      - --p2p.gossip.mesh.floodpublish
+      - "true"
+      # Reconnect quickly after a transient drop instead of waiting the default
+      # 60m redial period before the dial counter resets.
+      - --p2p.redial.period
+      - "1"
       - -vvv
     healthcheck:
       <<: *node-healthcheck
@@ -498,6 +508,16 @@ services:
       - "${L2_CL_BOOTNODE_ENR_PATH}"
       - --p2p.scoring
       - Off
+      # Devnet runs a tiny (1-2 peer) gossip mesh that never reaches the mesh
+      # low-watermark, so the topic mesh cannot stabilize. Flood publishing sends
+      # unsafe payloads to every known peer on the topic regardless of mesh state,
+      # removing the single-peer fast-path fragility that stalls followers.
+      - --p2p.gossip.mesh.floodpublish
+      - "true"
+      # Reconnect quickly after a transient drop instead of waiting the default
+      # 60m redial period before the dial counter resets.
+      - --p2p.redial.period
+      - "1"
       - --l1.verifier-confs
       - "${BASE_NODE_VERIFIER_L1_CONFS}"
       - -vvv
@@ -599,6 +619,16 @@ services:
       - "${L2_CL_BOOTNODE_ENR_PATH}"
       - --p2p.scoring
       - Off
+      # Devnet runs a tiny (1-2 peer) gossip mesh that never reaches the mesh
+      # low-watermark, so the topic mesh cannot stabilize. Flood publishing sends
+      # unsafe payloads to every known peer on the topic regardless of mesh state,
+      # removing the single-peer fast-path fragility that stalls followers.
+      - --p2p.gossip.mesh.floodpublish
+      - "true"
+      # Reconnect quickly after a transient drop instead of waiting the default
+      # 60m redial period before the dial counter resets.
+      - --p2p.redial.period
+      - "1"
       - --l1.verifier-confs
       - "${BASE_NODE_VERIFIER_L1_CONFS}"
       - -vvv


### PR DESCRIPTION
## Summary

Hardens the devnet CL gossip fast-path to prevent the follower unsafe-head freeze we saw where the sequencer kept producing blocks but the follower's unsafe head stalled (RPC stopped advancing).

Root cause: devnet CL nodes run a tiny (1-2 peer) gossip mesh. With the default target mesh degree of 8 and low-watermark of 6, the gossipsub topic mesh can never stabilize on a 1-2 peer topology, so live unsafe-payload delivery falls back to fragile fanout. Any hiccup on the single gossip link (transient disconnect, or an `AllQueuesFull`-class publish stall during a flashblock burst) cuts off live payloads. The follower then has to rely on L1 derivation, and once it lags past reth's 64-block in-memory trie changeset cache window, every block's state root drops to DB-based computation (~1 block/sec) and it can never catch up — a self-reinforcing livelock.

The in-process test harness already enables flood publish for exactly this reason (small meshes never form), but the devnet compose files did not.

Changes (config-only):
- Enable `--p2p.gossip.mesh.floodpublish true` on all devnet CL gossip participants: `base-builder`, `base-client`, `base-rpc` (main compose) and both HA sequencers (`docker-compose.ha.yml`). This sends unsafe payloads to every known peer on the topic regardless of mesh state, removing the single-peer fast-path fragility.
- Set `--p2p.redial.period 1` (minutes) so a transient peer drop reconnects in ~1m instead of the 60m default.

This is Tier 1 of a broader hardening plan; Tier 2 (surface `AllQueuesFull` as a metric + unsafe-head-stall watchdog) and Tier 3 (break the derivation livelock / trigger resync) are follow-ups.

## Test plan

- [ ] `docker compose -f etc/docker/docker-compose.yml config` parses cleanly
- [ ] Bring up the devnet and confirm builder + client + rpc CL nodes reach a stable gossip peer set and the follower unsafe head tracks the sequencer
- [ ] Simulate a transient gossip link drop and confirm the follower recovers via gossip (redial) rather than falling back to L1 derivation
- [ ] Bring up the HA compose and confirm both sequencers gossip unsafe payloads to followers