### PR TITLE
feat(eip8130): inject account-change receipt logs

### DIFF
--- a/crates/common/evm/src/eip8130.rs
+++ b/crates/common/evm/src/eip8130.rs
@@ -32,11 +32,13 @@
 //!
 //! # Scope
 //!
-//! Per-phase receipt status (`phaseStatuses`) and protocol-injected
-//! account-change logs are not yet surfaced; the overall transaction status
-//! (all-phases-succeeded vs reverted) is reported through the returned
-//! [`ExecutionResult`] variant ([`ExecutionResult::Success`] vs
-//! [`ExecutionResult::Revert`]).
+//! Protocol-injected account-change logs (`ActorAuthorized`, `ActorRevoked`,
+//! `AccountCreated`, `DelegationApplied`) are written to the journal during the
+//! pre-call apply step and surface in the transaction receipt ahead of any
+//! `calls` logs. Per-phase receipt status (`phaseStatuses`) is reported on the
+//! EIP-8130 receipt; the overall transaction status (all-phases-succeeded vs
+//! reverted) is reported through the returned [`ExecutionResult`] variant
+//! ([`ExecutionResult::Success`] vs [`ExecutionResult::Revert`]).
 //!
 //! [transaction context]: TxContextStorage
 //! [`BaseEvm::transact_raw`]: crate::BaseEvm
@@ -50,8 +52,9 @@ use base_common_consensus::{
 };
 use base_common_precompiles::{NonceManagerStorage, TxContextStorage};
 use base_execution_eip8130::{
-    AccountChangeApplier, AccountConfigurationStorage, ApplyError, DelegationEffect, FeeCheck,
-    IntrinsicGas, IntrinsicGasInput, NonceMode, NonceValidator, TransactionAuthorizer,
+    AccountChangeApplier, AccountConfigurationEvents, AccountConfigurationStorage, ApplyError,
+    DelegationEffect, FeeCheck, IntrinsicGas, IntrinsicGasInput, NonceMode, NonceValidator,
+    TransactionAuthorizer,
 };
 use base_precompile_storage::{JournalStorageProvider, StorageCtx};
 use revm::{
@@ -310,8 +313,7 @@ impl Eip8130Executor {
         Eip8130PhaseStatuses::set(core::mem::take(&mut calls.phase_statuses));
 
         // The gas refund is already folded into `gas_used` (via `net_used` in
-        // `settle_fees`), so the `refunded` counter is left 0; the per-phase
-        // receipt breakdown is deferred (see the module-level "Scope").
+        // `settle_fees`), so the `refunded` counter is left 0.
         let result_gas = ResultGas::new_with_state_gas(gas_used, 0, 0, 0);
         if calls.reverted {
             // The transaction is still included (nonce consumed, fee paid). Logs
@@ -1424,7 +1426,11 @@ impl Eip8130Executor {
             .with_account_info(sender, |info| Ok(info.is_empty_code_hash()))
             .map_err(BaseTransactionError::eip8130)?;
         if is_codeless {
-            sctx.set_code(sender, Bytecode::new_eip7702(Eip8130Contracts::DEFAULT_ACCOUNT))
+            let target = Eip8130Contracts::DEFAULT_ACCOUNT;
+            sctx.set_code(sender, Bytecode::new_eip7702(target))
+                .map_err(BaseTransactionError::eip8130)?;
+            // Same protocol-injected receipt log as an explicit delegation entry.
+            AccountConfigurationEvents::emit_delegation_applied(sctx, sender, target)
                 .map_err(BaseTransactionError::eip8130)?;
         }
         Ok(is_codeless)

--- a/crates/execution/eip8130/README.md
+++ b/crates/execution/eip8130/README.md
@@ -56,6 +56,10 @@ The crate keeps the protocol stages explicit while avoiding crate sprawl:
   sequence per applied entry — into one authorization verdict (`TransactionAuthorizer`),
   shared by mempool admission and block inclusion. It reads state but never
   mutates it; nonce, gas, and fee/balance checks remain separate stages.
+- **Protocol logs** inject `ActorAuthorized` / `ActorRevoked` / `AccountCreated` /
+  `DelegationApplied` into the journal from the enshrined apply path
+  (`AccountConfigurationEvents`), matching the `IAccountConfiguration` event ABIs
+  so indexers can enumerate actors from 8130 transaction receipts.
 
 ## Intrinsic gas
 

--- a/crates/execution/eip8130/src/apply.rs
+++ b/crates/execution/eip8130/src/apply.rs
@@ -16,8 +16,13 @@
 //! surfaces those code writes as an [`AppliedAccountChanges`] for the execution
 //! layer (which holds the account/state-trie handle) to carry out.
 //!
+//! Successful authorize / revoke / create mutations also inject the matching
+//! `IAccountConfiguration` receipt logs via [`AccountConfigurationEvents`]
+//! (the enshrined path has no EVM LOG opcodes of its own).
+//!
 //! [`ConfigChangeAuthorizer`]: crate::ConfigChangeAuthorizer
 //! [`ActorChange`]: base_common_consensus::ActorChange
+//! [`AccountConfigurationEvents`]: crate::AccountConfigurationEvents
 //! [EIP-7702]: https://eips.ethereum.org/EIPS/eip-7702
 
 use alloy_primitives::{Address, B256, Bytes, keccak256};
@@ -28,7 +33,7 @@ use base_common_consensus::{
 use base_precompile_storage::{BasePrecompileError, StorageCtx};
 use revm::state::Bytecode;
 
-use crate::{AccountConfigurationStorage, ActorConfig};
+use crate::{AccountConfigurationEvents, AccountConfigurationStorage, ActorConfig};
 
 sol! {
     /// ABI shape of the per-actor config carried in an `Authorize` change's
@@ -200,6 +205,9 @@ impl DelegationEffect {
             Bytecode::new_eip7702(self.target)
         };
         sctx.set_code(self.account, code)?;
+        // Protocol-injected: the Solidity contract never emits this on the EVM
+        // path; EIP-8130 requires the receipt log for successful delegation updates.
+        AccountConfigurationEvents::emit_delegation_applied(sctx, self.account, self.target)?;
         Ok(())
     }
 
@@ -324,6 +332,9 @@ impl AccountChangeApplier {
             // Policy manager/commitment share the actor-id keyspace across both
             // self homes: writing both (zero clears) resets then sets in one step.
             storage.set_policy(account, actor_id, manager, commitment)?;
+            AccountConfigurationEvents::emit_actor_authorized(
+                storage, account, actor_id, &config, manager, commitment,
+            )?;
             return Ok(());
         }
 
@@ -334,6 +345,9 @@ impl AccountChangeApplier {
         // invariant.
         storage.set_actor_config(account, actor_id, config)?;
         storage.set_policy(account, actor_id, manager, commitment)?;
+        AccountConfigurationEvents::emit_actor_authorized(
+            storage, account, actor_id, &config, manager, commitment,
+        )?;
         Ok(())
     }
 
@@ -357,6 +371,7 @@ impl AccountChangeApplier {
             state.default_eoa_expiry = 0;
             storage.set_account_state(account, state)?;
         }
+        AccountConfigurationEvents::emit_actor_revoked(storage, account, actor_id)?;
         Ok(())
     }
 
@@ -388,6 +403,14 @@ impl AccountChangeApplier {
         storage.set_account_state(address, state)?;
 
         Self::initialize_actors(storage, address, &entry.initial_actors)?;
+        // After initial actors (each already emitted `ActorAuthorized`), mirror
+        // `createAccount`'s trailing `AccountCreated` log.
+        AccountConfigurationEvents::emit_account_created(
+            storage,
+            address,
+            entry.user_salt,
+            keccak256(&entry.code),
+        )?;
 
         Ok(CreatedAccount { address, code: entry.code.clone() })
     }
@@ -523,11 +546,13 @@ impl AccountChangeApplier {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{address, b256};
+    use alloy_primitives::{LogData, address, b256};
+    use alloy_sol_types::SolEvent;
     use base_precompile_storage::{HashMapStorageProvider, PrecompileStorageProvider, StorageCtx};
     use revm::state::Bytecode;
 
     use super::*;
+    use crate::{AccountCreated, ActorAuthorized, ActorRevoked, DelegationApplied};
 
     const ACCOUNT: Address = address!("0x00000000000000000000000000000000000000a1");
     const K1: Address = Eip8130Constants::K1_AUTHENTICATOR;
@@ -541,6 +566,17 @@ mod tests {
     fn with_storage<R>(body: impl FnOnce(&mut AccountConfigurationStorage<'_>) -> R) -> R {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, |ctx| body(&mut AccountConfigurationStorage::new(ctx)))
+    }
+
+    /// Runs `body` against a fresh provider and returns the Account Configuration logs.
+    fn with_storage_events(
+        body: impl FnOnce(&mut AccountConfigurationStorage<'_>),
+    ) -> Vec<LogData> {
+        let mut provider = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut provider, |ctx| {
+            body(&mut AccountConfigurationStorage::new(ctx));
+        });
+        provider.get_events(AccountConfigurationStorage::ADDRESS).clone()
     }
 
     /// `abi.encode(ActorConfig, bytes policyData)` for an authorize change.
@@ -941,5 +977,99 @@ mod tests {
                 .and_then(|info| info.code.as_ref())
                 .is_some_and(Bytecode::is_empty)
         );
+    }
+
+    #[test]
+    fn authorize_and_revoke_emit_protocol_logs() {
+        let events = with_storage_events(|acc| {
+            let config = ungated(AUTHENTICATOR, Eip8130Constants::SCOPE_SENDER);
+            AccountChangeApplier::authorize_actor(acc, ACCOUNT, NON_SELF, config, &[]).unwrap();
+            AccountChangeApplier::revoke_actor(acc, ACCOUNT, NON_SELF).unwrap();
+        });
+        assert_eq!(events.len(), 2);
+
+        let authorized = ActorAuthorized::decode_log_data(&events[0]).unwrap();
+        assert_eq!(authorized.account, ACCOUNT);
+        assert_eq!(authorized.actorId, NON_SELF);
+        assert_eq!(
+            authorized.actorData,
+            AccountConfigurationEvents::pack_actor_data(
+                &ungated(AUTHENTICATOR, Eip8130Constants::SCOPE_SENDER),
+                Address::ZERO,
+                B256::ZERO,
+            )
+        );
+
+        let revoked = ActorRevoked::decode_log_data(&events[1]).unwrap();
+        assert_eq!(revoked.account, ACCOUNT);
+        assert_eq!(revoked.actorId, NON_SELF);
+    }
+
+    #[test]
+    fn authorize_policy_actor_emits_84_byte_actor_data() {
+        let mut policy = Vec::new();
+        policy.extend_from_slice(MANAGER.as_slice());
+        policy.extend_from_slice(COMMITMENT.as_slice());
+        let config = ActorConfig {
+            authenticator: AUTHENTICATOR,
+            scope: Eip8130Constants::SCOPE_POLICY,
+            expiry: 0,
+        };
+
+        let events = with_storage_events(|acc| {
+            AccountChangeApplier::authorize_actor(acc, ACCOUNT, NON_SELF, config, &policy).unwrap();
+        });
+        assert_eq!(events.len(), 1);
+        let authorized = ActorAuthorized::decode_log_data(&events[0]).unwrap();
+        assert_eq!(authorized.actorData.len(), 84);
+        assert_eq!(
+            authorized.actorData,
+            AccountConfigurationEvents::pack_actor_data(&config, MANAGER, COMMITMENT)
+        );
+    }
+
+    #[test]
+    fn create_emits_actor_authorized_then_account_created() {
+        let entry = CreateEntry {
+            user_salt: b256!("0x2222222222222222222222222222222222222222222222222222222222222222"),
+            code: Bytes::from_static(&[0x60, 0x00]),
+            initial_actors: vec![InitialActor::owner(NON_SELF, AUTHENTICATOR)],
+        };
+        let expected = AccountChangeApplier::compute_address(
+            entry.user_salt,
+            &entry.code,
+            &entry.initial_actors,
+        )
+        .unwrap();
+
+        let events = with_storage_events(|acc| {
+            AccountChangeApplier::apply_create(acc, &entry).unwrap();
+        });
+        assert_eq!(events.len(), 2);
+
+        let authorized = ActorAuthorized::decode_log_data(&events[0]).unwrap();
+        assert_eq!(authorized.account, expected);
+        assert_eq!(authorized.actorId, NON_SELF);
+
+        let created = AccountCreated::decode_log_data(&events[1]).unwrap();
+        assert_eq!(created.account, expected);
+        assert_eq!(created.userSalt, entry.user_salt);
+        assert_eq!(created.codeHash, keccak256(&entry.code));
+    }
+
+    #[test]
+    fn delegation_install_emits_delegation_applied() {
+        let target = Address::repeat_byte(0x33);
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, |sctx| {
+            DelegationEffect::new(ACCOUNT, target).install(sctx)
+        })
+        .unwrap();
+
+        let events = storage.get_events(AccountConfigurationStorage::ADDRESS);
+        assert_eq!(events.len(), 1);
+        let applied = DelegationApplied::decode_log_data(&events[0]).unwrap();
+        assert_eq!(applied.account, ACCOUNT);
+        assert_eq!(applied.target, target);
     }
 }

--- a/crates/execution/eip8130/src/events.rs
+++ b/crates/execution/eip8130/src/events.rs
@@ -11,7 +11,7 @@
 
 use alloy_primitives::{Address, B256, Bytes};
 use alloy_sol_types::{SolEvent, sol};
-use base_common_consensus::{Eip8130Constants, Eip8130Contracts};
+use base_common_consensus::Eip8130Constants;
 use base_precompile_storage::{ContractStorage, Result as StorageResult, StorageCtx};
 
 use crate::{AccountConfigurationStorage, ActorConfig};
@@ -114,15 +114,21 @@ impl AccountConfigurationEvents {
 
     /// Emits [`DelegationApplied`] from the Account Configuration address.
     ///
+    /// Takes a raw [`StorageCtx`] (unlike the other emit helpers) because the
+    /// call sites — [`crate::DelegationEffect::install`] and auto-delegation —
+    /// do not hold an [`AccountConfigurationStorage`] view. The log address is
+    /// still [`AccountConfigurationStorage::ADDRESS`] so it cannot drift from
+    /// the other emit helpers.
+    ///
     /// Used for both explicit delegation entries and auto-delegation of a
-    /// code-less sender to [`Eip8130Contracts::DEFAULT_ACCOUNT`].
+    /// code-less sender to `DEFAULT_ACCOUNT`.
     pub fn emit_delegation_applied(
         sctx: StorageCtx<'_>,
         account: Address,
         target: Address,
     ) -> StorageResult<()> {
         sctx.emit_event(
-            Eip8130Contracts::ACCOUNT_CONFIG,
+            AccountConfigurationStorage::ADDRESS,
             DelegationApplied { account, target }.encode_log_data(),
         )
     }

--- a/crates/execution/eip8130/src/events.rs
+++ b/crates/execution/eip8130/src/events.rs
@@ -1,0 +1,166 @@
+//! Protocol-injected `IAccountConfiguration` receipt logs for EIP-8130 account
+//! changes.
+//!
+//! The enshrined apply path mutates `AccountConfiguration` storage outside an
+//! EVM call frame, so it must inject the same events the Solidity contract
+//! would emit (`ActorAuthorized`, `ActorRevoked`, `AccountCreated`) — plus
+//! `DelegationApplied`, which the contract documents as protocol-injected only
+//! (never emitted on the EVM path). Logs are written to the journal at
+//! [`Eip8130Contracts::ACCOUNT_CONFIG`] and surface in the transaction receipt
+//! ahead of any `calls` logs.
+
+use alloy_primitives::{Address, B256, Bytes};
+use alloy_sol_types::{SolEvent, sol};
+use base_common_consensus::{Eip8130Constants, Eip8130Contracts};
+use base_precompile_storage::{ContractStorage, Result as StorageResult, StorageCtx};
+
+use crate::{AccountConfigurationStorage, ActorConfig};
+
+sol! {
+    /// Events from `IAccountConfiguration` / EIP-8130 protocol-injected receipt logs.
+    interface IAccountConfigurationEvents {
+        /// Emitted when an actor is authorized (or upserted) on an account.
+        event ActorAuthorized(address indexed account, bytes32 indexed actorId, bytes actorData);
+        /// Emitted when an actor is revoked from an account.
+        event ActorRevoked(address indexed account, bytes32 indexed actorId);
+        /// Emitted when a counterfactual account is created.
+        event AccountCreated(address indexed account, bytes32 userSalt, bytes32 codeHash);
+        /// Protocol-injected receipt log for a successful delegation update
+        /// (not emitted by the Solidity contract on the EVM path).
+        event DelegationApplied(address indexed account, address target);
+    }
+}
+
+pub use IAccountConfigurationEvents::{
+    AccountCreated, ActorAuthorized, ActorRevoked, DelegationApplied,
+};
+
+/// Helpers for packing and emitting EIP-8130 protocol-injected account-change
+/// logs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct AccountConfigurationEvents;
+
+impl AccountConfigurationEvents {
+    /// Packs `ActorAuthorized.actorData` as the contract's `_emitActorAuthorized`
+    /// does: `authenticator ‖ scope ‖ expiry ‖ reserved(5 zero bytes)` (32 bytes),
+    /// plus `manager ‖ commitment` when `SCOPE_POLICY` is set (84 bytes total).
+    ///
+    /// This is `abi.encodePacked` order (declaration order, left-to-right) — not
+    /// the right-aligned storage-slot packing of [`ActorConfig::to_word`].
+    #[must_use]
+    pub fn pack_actor_data(config: &ActorConfig, manager: Address, commitment: B256) -> Bytes {
+        let policy = config.scope & Eip8130Constants::SCOPE_POLICY != 0;
+        let mut data = Vec::with_capacity(if policy { 84 } else { 32 });
+        data.extend_from_slice(config.authenticator.as_slice());
+        data.push(config.scope);
+        // uint48 expiry: low 6 bytes of the big-endian u64.
+        data.extend_from_slice(&config.expiry.to_be_bytes()[2..]);
+        data.extend_from_slice(&[0u8; 5]);
+        if policy {
+            data.extend_from_slice(manager.as_slice());
+            data.extend_from_slice(commitment.as_slice());
+        }
+        Bytes::from(data)
+    }
+
+    /// Emits [`ActorAuthorized`] from [`AccountConfigurationStorage::ADDRESS`].
+    pub fn emit_actor_authorized(
+        storage: &AccountConfigurationStorage<'_>,
+        account: Address,
+        actor_id: B256,
+        config: &ActorConfig,
+        manager: Address,
+        commitment: B256,
+    ) -> StorageResult<()> {
+        storage.storage().emit_event(
+            storage.address(),
+            ActorAuthorized {
+                account,
+                actorId: actor_id,
+                actorData: Self::pack_actor_data(config, manager, commitment),
+            }
+            .encode_log_data(),
+        )
+    }
+
+    /// Emits [`ActorRevoked`] from [`AccountConfigurationStorage::ADDRESS`].
+    pub fn emit_actor_revoked(
+        storage: &AccountConfigurationStorage<'_>,
+        account: Address,
+        actor_id: B256,
+    ) -> StorageResult<()> {
+        storage.storage().emit_event(
+            storage.address(),
+            ActorRevoked { account, actorId: actor_id }.encode_log_data(),
+        )
+    }
+
+    /// Emits [`AccountCreated`] from [`AccountConfigurationStorage::ADDRESS`].
+    ///
+    /// `code_hash` is `keccak256` of the create entry's runtime bytecode (the
+    /// same value Solidity's `createAccount` logs).
+    pub fn emit_account_created(
+        storage: &AccountConfigurationStorage<'_>,
+        account: Address,
+        user_salt: B256,
+        code_hash: B256,
+    ) -> StorageResult<()> {
+        storage.storage().emit_event(
+            storage.address(),
+            AccountCreated { account, userSalt: user_salt, codeHash: code_hash }.encode_log_data(),
+        )
+    }
+
+    /// Emits [`DelegationApplied`] from the Account Configuration address.
+    ///
+    /// Used for both explicit delegation entries and auto-delegation of a
+    /// code-less sender to [`Eip8130Contracts::DEFAULT_ACCOUNT`].
+    pub fn emit_delegation_applied(
+        sctx: StorageCtx<'_>,
+        account: Address,
+        target: Address,
+    ) -> StorageResult<()> {
+        sctx.emit_event(
+            Eip8130Contracts::ACCOUNT_CONFIG,
+            DelegationApplied { account, target }.encode_log_data(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::address;
+
+    use super::*;
+
+    #[test]
+    fn pack_actor_data_ungated_is_32_bytes() {
+        let config = ActorConfig {
+            authenticator: address!("0x00000000000000000000000000000000000000bb"),
+            scope: Eip8130Constants::SCOPE_SENDER,
+            expiry: 0x0102_0304_0506,
+        };
+        let data = AccountConfigurationEvents::pack_actor_data(&config, Address::ZERO, B256::ZERO);
+        assert_eq!(data.len(), 32);
+        assert_eq!(&data[..20], config.authenticator.as_slice());
+        assert_eq!(data[20], Eip8130Constants::SCOPE_SENDER);
+        assert_eq!(&data[21..27], &config.expiry.to_be_bytes()[2..]);
+        assert_eq!(&data[27..], &[0u8; 5]);
+    }
+
+    #[test]
+    fn pack_actor_data_policy_gated_is_84_bytes() {
+        let config = ActorConfig {
+            authenticator: address!("0x00000000000000000000000000000000000000bb"),
+            scope: Eip8130Constants::SCOPE_POLICY,
+            expiry: 0,
+        };
+        let manager = address!("0x00000000000000000000000000000000000000cc");
+        let commitment = B256::repeat_byte(0x11);
+        let data = AccountConfigurationEvents::pack_actor_data(&config, manager, commitment);
+        assert_eq!(data.len(), 84);
+        assert_eq!(&data[32..52], manager.as_slice());
+        assert_eq!(&data[52..], commitment.as_slice());
+    }
+}

--- a/crates/execution/eip8130/src/lib.rs
+++ b/crates/execution/eip8130/src/lib.rs
@@ -42,6 +42,11 @@ pub use nonce_error::NonceError;
 mod validate;
 pub use validate::{NonceMode, NonceStatus, NonceValidator};
 
+mod events;
+pub use events::{
+    AccountConfigurationEvents, AccountCreated, ActorAuthorized, ActorRevoked, DelegationApplied,
+};
+
 mod apply;
 pub use apply::{
     AccountChangeApplier, AppliedAccountChanges, ApplyError, CreatedAccount, DelegationEffect,


### PR DESCRIPTION
## Summary

- Inject protocol receipt logs for EIP-8130 account changes so indexers can enumerate actors off-chain (matching `IAccountConfiguration` / EIP-8130 step 5).
- Enshrined apply path now emits `ActorAuthorized`, `ActorRevoked`, and `AccountCreated` from `AccountChangeApplier` (including create initial actors → then `AccountCreated`).
- Emit `DelegationApplied` on successful delegation install (explicit entries via `DelegationEffect::install`) and on auto-delegation of a code-less sender to `DEFAULT_ACCOUNT`.
- Logs are written to the journal at `ACCOUNT_CONFIG` and surface in the receipt ahead of any `calls` logs. Intrinsic gas schedule unchanged (no LOG metering in the enshrined schedule, same EIP-7708 pattern).

## Test plan

- [x] `cargo test -p base-execution-eip8130 --lib` (151 passed)
- [x] `cargo test -p base-common-evm --lib eip8130` (25 passed)
- [x] `cargo clippy -p base-execution-eip8130 -p base-common-evm --all-targets -- -D warnings` clean
- [ ] CI green
- [ ] Spot-check a create + authorize/revoke receipt in a local/devnet node for topic0 + `actorData` packing (32 vs 84 bytes)