### PR TITLE
feat(proof): add cancelProofRequest RPC for ZK Cluster/Network

### DIFF
--- a/crates/infra/basectl/src/rpc/prover.rs
+++ b/crates/infra/basectl/src/rpc/prover.rs
@@ -222,9 +222,9 @@ mod tests {
     };
 
     use base_prover_service_protocol::{
-        DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest,
-        ListProofsResponse, ProofRequestKind, ProofStatus, ProveBlockRangeRequest,
-        ProveBlockRangeResponse, ProverRequesterApiServer, ZkVm,
+        CancelProofRequest, DeleteProofRequest, GetProofRequest, GetProofResponse,
+        ListProofsRequest, ListProofsResponse, ProofRequestKind, ProofStatus,
+        ProveBlockRangeRequest, ProveBlockRangeResponse, ProverRequesterApiServer, ZkVm,
     };
     use jsonrpsee::{
         core::{RpcResult, async_trait},
@@ -338,6 +338,14 @@ mod tests {
                 .pop_front()
                 .unwrap_or(self.last_status);
             Ok(GetProofResponse { status, error_message: None, result: None })
+        }
+
+        async fn cancel_proof_request(&self, _request: CancelProofRequest) -> RpcResult<()> {
+            Err(ErrorObjectOwned::owned(
+                ErrorCode::MethodNotFound.code(),
+                "not used by tests",
+                None::<()>,
+            ))
         }
 
         async fn delete_proof_request(&self, _request: DeleteProofRequest) -> RpcResult<()> {

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -25,9 +25,9 @@ use base_proof_contracts::{
 use base_proof_rpc::{BaseHeader, L2Provider, RpcError, RpcResult};
 use base_prover_service_client::{ProofRequesterProvider, ProverServiceClientError};
 use base_prover_service_protocol::{
-    DeleteProofRequest, GetProofRequest, GetProofResponse, ProofResult as ApiProofResult,
-    ProofStatus, ProveBlockRangeRequest, ProveBlockRangeResponse, SnarkPlonkProofResult,
-    ZkProofResult, ZkVm,
+    CancelProofRequest, DeleteProofRequest, GetProofRequest, GetProofResponse,
+    ProofResult as ApiProofResult, ProofStatus, ProveBlockRangeRequest, ProveBlockRangeResponse,
+    SnarkPlonkProofResult, ZkProofResult, ZkVm,
 };
 use base_tx_manager::{SendHandle, SendResponse, TxCandidate, TxManager};
 
@@ -845,6 +845,13 @@ impl ProofRequesterProvider for MockZkProofProvider {
             error_message: state.error_message,
             result,
         })
+    }
+
+    async fn cancel_proof_request(
+        &self,
+        _request: CancelProofRequest,
+    ) -> Result<(), ProverServiceClientError> {
+        unimplemented!("tests do not cancel proofs")
     }
 
     async fn delete_proof_request(

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -210,8 +210,8 @@ mod tests {
     use base_proof_contracts::{AnchorStateRegistryClient, DisputeGameFactoryClient};
     use base_prover_service_client::{ProofRequesterProvider, ProverServiceClientError};
     use base_prover_service_protocol::{
-        DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest,
-        ListProofsResponse, ProveBlockRangeRequest, ProveBlockRangeResponse,
+        CancelProofRequest, DeleteProofRequest, GetProofRequest, GetProofResponse,
+        ListProofsRequest, ListProofsResponse, ProveBlockRangeRequest, ProveBlockRangeResponse,
     };
     use tokio_util::sync::CancellationToken;
 
@@ -248,6 +248,13 @@ mod tests {
             _request: GetProofRequest,
         ) -> Result<GetProofResponse, ProverServiceClientError> {
             Err(ProverServiceClientError::Timeout("simulated poll failure".into()))
+        }
+
+        async fn cancel_proof_request(
+            &self,
+            _request: CancelProofRequest,
+        ) -> Result<(), ProverServiceClientError> {
+            unimplemented!("pipeline tests do not cancel proofs")
         }
 
         async fn delete_proof_request(

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -22,8 +22,8 @@ use base_proof_rpc::{
 };
 use base_prover_service_client::{ProofRequesterProvider, ProverServiceClientError};
 use base_prover_service_protocol::{
-    DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse,
-    PROOF_REQUEST_NOT_FOUND_MESSAGE, ProofRequestIdCollisionMessage,
+    CancelProofRequest, DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest,
+    ListProofsResponse, PROOF_REQUEST_NOT_FOUND_MESSAGE, ProofRequestIdCollisionMessage,
     ProofRequestKind as ApiProofRequestKind, ProofResult as ApiProofResult, ProofStatus,
     ProveBlockRangeRequest, ProveBlockRangeResponse, TeeKind, TeeProofResult,
 };
@@ -478,6 +478,13 @@ impl ProofRequesterProvider for MockProofRequester {
                 tee_kind: TeeKind::AwsNitro,
             })),
         })
+    }
+
+    async fn cancel_proof_request(
+        &self,
+        _request: CancelProofRequest,
+    ) -> Result<(), ProverServiceClientError> {
+        unimplemented!("tests do not cancel proofs")
     }
 
     async fn delete_proof_request(

--- a/crates/proof/prover-service/client/src/error.rs
+++ b/crates/proof/prover-service/client/src/error.rs
@@ -11,7 +11,11 @@ use thiserror::Error;
 pub enum ProverServiceClientError {
     /// A JSON-RPC client, server, or transport error occurred.
     #[error("prover-service RPC/transport failure: {0}")]
-    RpcTransport(#[from] JsonRpcClientError),
+    RpcTransport(JsonRpcClientError),
+
+    /// The requester cancelled this proof job.
+    #[error("proof request was cancelled")]
+    ProofCancelled,
 
     /// The prover service reached a terminal failed proof state.
     #[error("proof failed: {message}")]
@@ -53,6 +57,9 @@ impl ProverServiceClientError {
     /// JSON-RPC code used by the prover service for failed preconditions.
     pub const ERROR_FAILED_PRECONDITION: i32 = -32017;
 
+    /// JSON-RPC code used when a requester cancelled a claimed proof job.
+    pub const ERROR_PROOF_CANCELLED: i32 = -32018;
+
     /// Returns `true` when retrying the same client operation may succeed.
     #[must_use]
     pub fn is_retryable(&self) -> bool {
@@ -60,6 +67,7 @@ impl ProverServiceClientError {
             Self::RpcTransport(err) => Self::is_retryable_rpc_error(err),
             Self::Timeout(_) => true,
             Self::ProofFailure { .. }
+            | Self::ProofCancelled
             | Self::WorkerLeaseRejected { .. }
             | Self::MissingResult(_)
             | Self::UnexpectedResultPayload(_) => false,
@@ -86,6 +94,12 @@ impl ProverServiceClientError {
             && call.message() == ProofRequestIdCollisionMessage::for_field(session_id, "l1_head")
     }
 
+    /// Returns `true` when the requester cancelled the proof job.
+    #[must_use]
+    pub const fn is_proof_cancelled(&self) -> bool {
+        matches!(self, Self::ProofCancelled)
+    }
+
     /// Returns `true` when the JSON-RPC error is classified as transient.
     #[must_use]
     pub fn is_retryable_rpc_error(err: &JsonRpcClientError) -> bool {
@@ -103,6 +117,19 @@ impl ProverServiceClientError {
     #[must_use]
     pub const fn is_retryable_rpc_code(code: i32) -> bool {
         code == Self::ERROR_UNAVAILABLE || code == ErrorCode::InternalError.code()
+    }
+}
+
+impl From<JsonRpcClientError> for ProverServiceClientError {
+    fn from(error: JsonRpcClientError) -> Self {
+        if matches!(
+            &error,
+            JsonRpcClientError::Call(call) if call.code() == Self::ERROR_PROOF_CANCELLED
+        ) {
+            Self::ProofCancelled
+        } else {
+            Self::RpcTransport(error)
+        }
     }
 }
 

--- a/crates/proof/prover-service/client/src/requester.rs
+++ b/crates/proof/prover-service/client/src/requester.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use backon::Retryable;
 use base_prover_service_protocol::{
-    DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse,
-    ProveBlockRangeRequest, ProveBlockRangeResponse, ProverRequesterApiClient,
+    CancelProofRequest, DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest,
+    ListProofsResponse, ProveBlockRangeRequest, ProveBlockRangeResponse, ProverRequesterApiClient,
 };
 use base_retry::RetryConfig;
 use jsonrpsee::http_client::HttpClient;
@@ -31,6 +31,12 @@ pub trait ProofRequesterProvider: Send + Sync {
         &self,
         request: GetProofRequest,
     ) -> Result<GetProofResponse, ProverServiceClientError>;
+
+    /// Cancel a queued or running proof request.
+    async fn cancel_proof_request(
+        &self,
+        request: CancelProofRequest,
+    ) -> Result<(), ProverServiceClientError>;
 
     /// Delete a completed proof request so the same session id can be retried.
     async fn delete_proof_request(
@@ -144,6 +150,30 @@ impl ProofRequesterClient {
         .await
     }
 
+    /// Cancel a queued or running proof request.
+    pub async fn cancel_proof_request(
+        &self,
+        request: CancelProofRequest,
+    ) -> Result<(), ProverServiceClientError> {
+        debug!(session_id = %request.session_id, "cancelling proof");
+        (|| {
+            let request = request.clone();
+
+            async move { Ok(self.inner.cancel_proof_request(request).await?) }
+        })
+        .retry(self.retry.to_backoff_builder())
+        .when(ProverServiceClientError::is_retryable)
+        .notify(|error, delay| {
+            warn!(
+                session_id = %request.session_id,
+                backoff_ms = delay.as_millis(),
+                error = %error,
+                "cancel proof failed; retrying"
+            );
+        })
+        .await
+    }
+
     /// Delete a completed proof request so the same session id can be retried.
     pub async fn delete_proof_request(
         &self,
@@ -212,6 +242,13 @@ impl ProofRequesterProvider for ProofRequesterClient {
         Self::get_proof(self, request).await
     }
 
+    async fn cancel_proof_request(
+        &self,
+        request: CancelProofRequest,
+    ) -> Result<(), ProverServiceClientError> {
+        Self::cancel_proof_request(self, request).await
+    }
+
     async fn delete_proof_request(
         &self,
         request: DeleteProofRequest,
@@ -241,10 +278,10 @@ mod tests {
 
     use async_trait::async_trait;
     use base_prover_service_protocol::{
-        DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest,
-        ListProofsResponse, ProofRequest, ProofRequestKind, ProofResult, ProofStatus, ProofSummary,
-        ProofType, ProveBlockRangeRequest, ProveBlockRangeResponse, ProverRequesterApiServer,
-        ZkBackend, ZkProofRequest, ZkProofResult, ZkVm,
+        CancelProofRequest, DeleteProofRequest, GetProofRequest, GetProofResponse,
+        ListProofsRequest, ListProofsResponse, ProofRequest, ProofRequestKind, ProofResult,
+        ProofStatus, ProofSummary, ProofType, ProveBlockRangeRequest, ProveBlockRangeResponse,
+        ProverRequesterApiServer, ZkBackend, ZkProofRequest, ZkProofResult, ZkVm,
     };
     use base_retry::RetryConfig;
     use chrono::Utc;
@@ -283,6 +320,7 @@ mod tests {
     struct MockRequesterState {
         prove_request: Option<ProveBlockRangeRequest>,
         get_request: Option<GetProofRequest>,
+        cancel_request: Option<CancelProofRequest>,
         delete_request: Option<DeleteProofRequest>,
         list_request: Option<ListProofsRequest>,
     }
@@ -431,6 +469,12 @@ mod tests {
             })
         }
 
+        async fn cancel_proof_request(&self, request: CancelProofRequest) -> RpcResult<()> {
+            self.state.lock().expect("state lock should not be poisoned").cancel_request =
+                Some(request);
+            Ok(())
+        }
+
         async fn delete_proof_request(&self, request: DeleteProofRequest) -> RpcResult<()> {
             self.delete_calls.fetch_add(1, Ordering::SeqCst);
             self.state.lock().expect("state lock should not be poisoned").delete_request =
@@ -509,6 +553,12 @@ mod tests {
             other => panic!("unexpected proof result variant: {other:?}"),
         }
 
+        let cancel_request = CancelProofRequest { session_id: "session-get".to_owned() };
+        provider
+            .cancel_proof_request(cancel_request.clone())
+            .await
+            .expect("cancel_proof_request should succeed");
+
         let delete_request = DeleteProofRequest { session_id: "session-get".to_owned() };
         provider
             .delete_proof_request(delete_request.clone())
@@ -527,6 +577,7 @@ mod tests {
             let state = api.state.lock().expect("state lock should not be poisoned");
             assert_eq!(state.prove_request.as_ref(), Some(&prove_request));
             assert_eq!(state.get_request.as_ref(), Some(&get_request));
+            assert_eq!(state.cancel_request.as_ref(), Some(&cancel_request));
             assert_eq!(state.delete_request.as_ref(), Some(&delete_request));
             assert_eq!(state.list_request, Some(list_request));
         }

--- a/crates/proof/prover-service/db/src/lib.rs
+++ b/crates/proof/prover-service/db/src/lib.rs
@@ -8,8 +8,8 @@ pub use conversions::ConversionError;
 
 mod models;
 pub use models::{
-    ApiProofType, ClaimAuth, ClaimProofJob, CompleteClaimedProofJob, CompleteProofResult,
-    CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome,
+    ApiProofType, CancelProofRequestOutcome, ClaimAuth, ClaimProofJob, CompleteClaimedProofJob,
+    CompleteProofResult, CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome,
     CreateProofRequestValidationError, CreateProofSession, DeleteProofRequestOutcome,
     DerivedProofRequestFields, FailExpiredProofJobs, HeartbeatOutcome, HeartbeatProofJob,
     JobLockState, ProofJob, ProofJobStatus, ProofRequest, ProofRequestListItem, ProofRequestPage,

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -234,6 +234,21 @@ impl CreateProofRequestOutcome {
     }
 }
 
+/// Outcome of cancelling a proof request by session id.
+#[derive(Debug, Clone)]
+pub enum CancelProofRequestOutcome {
+    /// A queued or running proof request was terminally failed.
+    Cancelled(Box<ProofJob>),
+    /// The request was already cancelled.
+    AlreadyCancelled,
+    /// No proof request exists for the session id.
+    NotFound,
+    /// The proof backend does not support cancellation.
+    UnsupportedBackend,
+    /// The request had already reached another terminal state.
+    AlreadyTerminal(ProofStatus),
+}
+
 /// Outcome of deleting a completed proof request by session id.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DeleteProofRequestOutcome {

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -1,13 +1,14 @@
 use base_prover_service_protocol::{
-    ProofResult as ProtocolProofResult, SnarkPlonkProofResult, ZkBackend, ZkProofResult, ZkVm,
+    PROOF_REQUEST_CANCELLED_MESSAGE, ProofResult as ProtocolProofResult, SnarkPlonkProofResult,
+    ZkBackend, ZkProofResult, ZkVm,
 };
 use chrono::Utc;
 use sqlx::{PgPool, Result, Row};
 use uuid::Uuid;
 
 use crate::{
-    ApiProofType, ClaimAuth, ClaimProofJob, CompleteClaimedProofJob, CompleteProofResult,
-    CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome,
+    ApiProofType, CancelProofRequestOutcome, ClaimAuth, ClaimProofJob, CompleteClaimedProofJob,
+    CompleteProofResult, CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome,
     CreateProofRequestValidationError, CreateProofSession, DeleteProofRequestOutcome,
     FailExpiredProofJobs, HeartbeatOutcome, HeartbeatProofJob, JobLockState, ProofJob,
     ProofJobStatus, ProofRequest, ProofRequestListItem, ProofRequestPage, ProofSession,
@@ -235,6 +236,97 @@ impl ProofRequestRepo {
                 Ok(CreateProofRequestOutcome::Requeued(existing_id))
             }
         }
+    }
+
+    /// Cancel a non-terminal Cluster or Network proof request by public session id.
+    pub async fn cancel_proof_request_by_session_id(
+        &self,
+        session_id: &str,
+    ) -> Result<CancelProofRequestOutcome> {
+        let session_id = canonical_session_id(session_id)
+            .map_err(|e| sqlx::Error::InvalidArgument(e.to_string()))?;
+        let mut tx = self.pool.begin().await?;
+
+        let row = sqlx::query(
+            r#"
+            SELECT status, error_message, api_proof_type, proof_type, zk_backend
+            FROM proof_requests
+            WHERE COALESCE(session_id, id::text) = $1
+            FOR UPDATE
+            "#,
+        )
+        .bind(&session_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let Some(row) = row else {
+            tx.rollback().await?;
+            return Ok(CancelProofRequestOutcome::NotFound);
+        };
+
+        let proof_type = row
+            .get::<Option<&str>, _>("proof_type")
+            .map(ProofType::try_from)
+            .transpose()
+            .map_err(sqlx::Error::Protocol)?;
+        let api_proof_type = row
+            .get::<Option<&str>, _>("api_proof_type")
+            .map(ApiProofType::try_from)
+            .transpose()
+            .map_err(sqlx::Error::Protocol)?
+            .unwrap_or_else(|| api_proof_type_for_backend(proof_type));
+        let zk_backend = row
+            .get::<Option<&str>, _>("zk_backend")
+            .map(parse_zk_backend)
+            .transpose()?
+            .or_else(|| fallback_zk_backend_for_request(api_proof_type));
+
+        if !matches!(zk_backend, Some(ZkBackend::Cluster | ZkBackend::Network)) {
+            tx.rollback().await?;
+            return Ok(CancelProofRequestOutcome::UnsupportedBackend);
+        }
+
+        let status_str: &str = row.get("status");
+        let status = ProofStatus::try_from(status_str).map_err(|e| {
+            sqlx::Error::Protocol(format!("Unknown proof status '{status_str}': {e}"))
+        })?;
+        if status == ProofStatus::Failed
+            && row.get::<Option<&str>, _>("error_message") == Some(PROOF_REQUEST_CANCELLED_MESSAGE)
+        {
+            tx.rollback().await?;
+            return Ok(CancelProofRequestOutcome::AlreadyCancelled);
+        }
+        if matches!(status, ProofStatus::Succeeded | ProofStatus::Failed) {
+            tx.rollback().await?;
+            return Ok(CancelProofRequestOutcome::AlreadyTerminal(status));
+        }
+
+        let columns = PROOF_JOB_RETURNING_COLUMNS;
+        let sql = format!(
+            r#"
+            UPDATE proof_requests
+            SET status = 'FAILED',
+                job_status = 'FAILED',
+                error_message = $2,
+                completed_at = NOW(),
+                worker_id = NULL,
+                lock_id = NULL,
+                lock_expires_at = NULL,
+                claimed_at = NULL,
+                last_heartbeat_at = NULL
+            WHERE COALESCE(session_id, id::text) = $1
+            RETURNING {columns}
+            "#
+        );
+        let row = sqlx::query(&sql)
+            .bind(&session_id)
+            .bind(PROOF_REQUEST_CANCELLED_MESSAGE)
+            .fetch_one(&mut *tx)
+            .await?;
+        let job = row_to_proof_job(&row)?;
+
+        tx.commit().await?;
+        Ok(CancelProofRequestOutcome::Cancelled(Box::new(job)))
     }
 
     /// Delete a terminal proof request by public session id.

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -16,17 +16,18 @@
 use std::time::Duration;
 
 use base_prover_service_db::{
-    ApiProofType, ClaimProofJob, CompleteClaimedProofJob, CreateProofRequest,
-    CreateProofRequestError, CreateProofRequestOutcome, CreateProofSession,
+    ApiProofType, CancelProofRequestOutcome, ClaimProofJob, CompleteClaimedProofJob,
+    CreateProofRequest, CreateProofRequestError, CreateProofRequestOutcome, CreateProofSession,
     DeleteProofRequestOutcome, FailExpiredProofJobs, HeartbeatOutcome, HeartbeatProofJob,
     ProofJobStatus, ProofRequestPage, ProofRequestRepo, ProofStatus, ProofType,
     RecordSessionOutcome, RetryOutcome, SessionStatus, SessionType, SubmitProofOutcome, TeeKind,
     UpdateProofSession, UpdateReceipt, WorkerSessionUpsert, ZkVmKind,
 };
 use base_prover_service_protocol::{
-    ProofRequest as ProtocolProofRequest, ProofRequestKind as ProtocolProofRequestKind,
-    ProofResult as ProtocolProofResult, SnarkPlonkProofRequest, SnarkPlonkProofResult,
-    TeeKind as ProtocolTeeKind, TeeProofRequest, ZkBackend, ZkProofRequest, ZkProofResult, ZkVm,
+    PROOF_REQUEST_CANCELLED_MESSAGE, ProofRequest as ProtocolProofRequest,
+    ProofRequestKind as ProtocolProofRequestKind, ProofResult as ProtocolProofResult,
+    SnarkPlonkProofRequest, SnarkPlonkProofResult, TeeKind as ProtocolTeeKind, TeeProofRequest,
+    ZkBackend, ZkProofRequest, ZkProofResult, ZkVm,
 };
 use sqlx::{PgPool, postgres::PgPoolOptions};
 use uuid::Uuid;
@@ -1250,6 +1251,41 @@ async fn test_create_for_worker_queue_rejects_succeeded_row_with_new_l1_head() {
         err,
         CreateProofRequestError::IdCollision { id, field: "l1_head" } if id == explicit_id
     ));
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_cancel_proof_request_cluster_only_rejects_tee_and_dry_run() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool.clone());
+
+    let cluster_id = Uuid::new_v4();
+    let cluster_session = cluster_id.to_string();
+    let mut cluster = compressed_request_at_with_backend(100, ZkBackend::Cluster);
+    set_request_session_id(&mut cluster, cluster_session.clone());
+    repo.create_for_worker_queue(cluster, TEST_MAX_PROOF_RETRIES).await.unwrap();
+
+    let CancelProofRequestOutcome::Cancelled(job) =
+        repo.cancel_proof_request_by_session_id(&cluster_session).await.unwrap()
+    else {
+        panic!("cluster cancel should succeed");
+    };
+    assert_eq!(job.job_status, ProofJobStatus::Failed);
+    assert_eq!(job.error_message.as_deref(), Some(PROOF_REQUEST_CANCELLED_MESSAGE));
+    assert!(matches!(
+        repo.cancel_proof_request_by_session_id(&cluster_session).await.unwrap(),
+        CancelProofRequestOutcome::AlreadyCancelled
+    ));
+
+    for mut request in [tee_request(), compressed_request_at_with_backend(100, ZkBackend::DryRun)] {
+        let session_id = Uuid::new_v4().to_string();
+        set_request_session_id(&mut request, session_id.clone());
+        repo.create_for_worker_queue(request, TEST_MAX_PROOF_RETRIES).await.unwrap();
+        assert!(matches!(
+            repo.cancel_proof_request_by_session_id(&session_id).await.unwrap(),
+            CancelProofRequestOutcome::UnsupportedBackend
+        ));
+    }
 }
 
 #[tokio::test]

--- a/crates/proof/prover-service/protocol/src/api.rs
+++ b/crates/proof/prover-service/protocol/src/api.rs
@@ -3,11 +3,11 @@
 use jsonrpsee::proc_macros::rpc;
 
 use crate::{
-    DeleteProofRequest, GetNextProofRequest, GetNextProofResponse, GetProofRequest,
-    GetProofResponse, GetProofSessionRequest, GetProofSessionResponse, HeartbeatRequest,
-    HeartbeatResponse, ListProofsRequest, ListProofsResponse, ProveBlockRangeRequest,
-    ProveBlockRangeResponse, RecordProofSessionRequest, RecordProofSessionResponse,
-    WorkerSubmitProofRequest, WorkerSubmitProofResponse,
+    CancelProofRequest, DeleteProofRequest, GetNextProofRequest, GetNextProofResponse,
+    GetProofRequest, GetProofResponse, GetProofSessionRequest, GetProofSessionResponse,
+    HeartbeatRequest, HeartbeatResponse, ListProofsRequest, ListProofsResponse,
+    ProveBlockRangeRequest, ProveBlockRangeResponse, RecordProofSessionRequest,
+    RecordProofSessionResponse, WorkerSubmitProofRequest, WorkerSubmitProofResponse,
 };
 
 #[cfg_attr(
@@ -37,6 +37,13 @@ pub trait ProverRequesterApi {
         &self,
         request: GetProofRequest,
     ) -> jsonrpsee::core::RpcResult<GetProofResponse>;
+
+    /// Cancel a queued or running proof request.
+    #[method(name = "cancelProofRequest")]
+    async fn cancel_proof_request(
+        &self,
+        request: CancelProofRequest,
+    ) -> jsonrpsee::core::RpcResult<()>;
 
     /// Delete a completed proof request so it can be retried with the same session id.
     #[method(name = "deleteProofRequest")]

--- a/crates/proof/prover-service/protocol/src/lib.rs
+++ b/crates/proof/prover-service/protocol/src/lib.rs
@@ -12,10 +12,11 @@ pub use session::ProofSessionId;
 
 mod types;
 pub use types::{
-    BackendSession, BackendSessionState, DeleteProofRequest, ExecutionStats, GetNextProofRequest,
-    GetNextProofResponse, GetProofRequest, GetProofResponse, GetProofSessionRequest,
-    GetProofSessionResponse, HeartbeatRequest, HeartbeatResponse, ListProofsRequest,
-    ListProofsResponse, PROOF_REQUEST_NOT_FOUND_MESSAGE, ProofJob, ProofJobStatus, ProofRequest,
+    BackendSession, BackendSessionState, CancelProofRequest, DeleteProofRequest, ExecutionStats,
+    GetNextProofRequest, GetNextProofResponse, GetProofRequest, GetProofResponse,
+    GetProofSessionRequest, GetProofSessionResponse, HeartbeatRequest, HeartbeatResponse,
+    ListProofsRequest, ListProofsResponse, PROOF_REQUEST_CANCELLED_MESSAGE,
+    PROOF_REQUEST_NOT_FOUND_MESSAGE, ProofJob, ProofJobStatus, ProofRequest,
     ProofRequestIdCollisionMessage, ProofRequestKind, ProofResult, ProofStatus, ProofSummary,
     ProofType, ProveBlockRangeRequest, ProveBlockRangeResponse, RecordProofSessionRequest,
     RecordProofSessionResponse, SessionType, SnarkPlonkProofRequest, SnarkPlonkProofResult,

--- a/crates/proof/prover-service/protocol/src/types.rs
+++ b/crates/proof/prover-service/protocol/src/types.rs
@@ -10,6 +10,9 @@ use serde::{Deserialize, Serialize};
 /// JSON-RPC error message returned when a proof request session cannot be found.
 pub const PROOF_REQUEST_NOT_FOUND_MESSAGE: &str = "Proof request not found";
 
+/// Failure message stored when a proof request is cancelled.
+pub const PROOF_REQUEST_CANCELLED_MESSAGE: &str = "Proof request cancelled by requester";
+
 /// JSON-RPC error message returned when a session id is reused for a different request.
 #[derive(Debug, Clone, Copy)]
 pub struct ProofRequestIdCollisionMessage;
@@ -131,6 +134,13 @@ pub struct ProveBlockRangeRequest {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProveBlockRangeResponse {
     /// Accepted client-supplied session identifier.
+    pub session_id: String,
+}
+
+/// Request to cancel a queued or running proof request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CancelProofRequest {
+    /// Proof session identifier.
     pub session_id: String,
 }
 

--- a/crates/proof/prover-service/src/server/cancel_proof_request.rs
+++ b/crates/proof/prover-service/src/server/cancel_proof_request.rs
@@ -1,0 +1,49 @@
+use base_prover_service_db::{CancelProofRequestOutcome, canonical_session_id};
+use base_prover_service_protocol::{CancelProofRequest, PROOF_REQUEST_NOT_FOUND_MESSAGE};
+use jsonrpsee::core::RpcResult;
+use tracing::info;
+
+use crate::{
+    metrics,
+    server::{
+        ProverServiceServer, failed_precondition, internal, invalid_argument, not_found,
+        record_rpc_result,
+    },
+};
+
+impl ProverServiceServer {
+    /// Cancels a queued or running Cluster or Network proof request.
+    pub async fn cancel_proof_request_impl(&self, request: CancelProofRequest) -> RpcResult<()> {
+        let start = std::time::Instant::now();
+        let result = self.cancel_proof_request_inner(request).await;
+        record_rpc_result("CancelProofRequest", start, &result);
+
+        result
+    }
+
+    async fn cancel_proof_request_inner(&self, request: CancelProofRequest) -> RpcResult<()> {
+        let session_id = canonical_session_id(&request.session_id)
+            .map_err(|e| invalid_argument(format!("{e}")))?;
+        match self.repo.cancel_proof_request_by_session_id(&session_id).await {
+            Ok(CancelProofRequestOutcome::Cancelled(job)) => {
+                metrics::record_terminal_proof_job(metrics::PROOF_STATUS_FAILED, &job);
+                info!(session_id = %session_id, "Cancelled proof request");
+                Ok(())
+            }
+            Ok(CancelProofRequestOutcome::AlreadyCancelled) => Ok(()),
+            Ok(CancelProofRequestOutcome::NotFound) => {
+                Err(not_found(PROOF_REQUEST_NOT_FOUND_MESSAGE))
+            }
+            Ok(CancelProofRequestOutcome::UnsupportedBackend) => {
+                Err(failed_precondition("cancellation is not available for this proof backend"))
+            }
+            Ok(CancelProofRequestOutcome::AlreadyTerminal(status)) => {
+                Err(failed_precondition(format!(
+                    "session_id {session_id}: proof request status is {}, expected a queued or running request",
+                    status.as_str()
+                )))
+            }
+            Err(e) => Err(internal(format!("Database error: {e}"))),
+        }
+    }
+}

--- a/crates/proof/prover-service/src/server/mod.rs
+++ b/crates/proof/prover-service/src/server/mod.rs
@@ -4,8 +4,8 @@ use std::fmt;
 
 use base_prover_service_db::ProofRequestRepo;
 use base_prover_service_protocol::{
-    DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse,
-    ProveBlockRangeRequest, ProveBlockRangeResponse, ProverRequesterApiServer,
+    CancelProofRequest, DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest,
+    ListProofsResponse, ProveBlockRangeRequest, ProveBlockRangeResponse, ProverRequesterApiServer,
 };
 use jsonrpsee::{
     core::{RpcResult, async_trait},
@@ -14,6 +14,7 @@ use jsonrpsee::{
 
 use crate::WorkerQueueConfig;
 
+mod cancel_proof_request;
 mod delete_proof_request;
 mod get_proof;
 mod list_proofs;
@@ -24,6 +25,7 @@ const ERROR_NOT_FOUND: i32 = -32004;
 const ERROR_UNAVAILABLE: i32 = -32014;
 const ERROR_RESOURCE_EXHAUSTED: i32 = -32016;
 const ERROR_FAILED_PRECONDITION: i32 = -32017;
+const ERROR_PROOF_CANCELLED: i32 = -32018;
 
 /// Lock duration tuning for the worker job API.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -102,6 +104,10 @@ impl ProverRequesterApiServer for ProverServiceServer {
         self.get_proof_impl(request).await
     }
 
+    async fn cancel_proof_request(&self, request: CancelProofRequest) -> RpcResult<()> {
+        self.cancel_proof_request_impl(request).await
+    }
+
     async fn delete_proof_request(&self, request: DeleteProofRequest) -> RpcResult<()> {
         self.delete_proof_request_impl(request).await
     }
@@ -135,6 +141,10 @@ fn failed_precondition(message: impl Into<String>) -> ErrorObjectOwned {
     ErrorObjectOwned::owned(ERROR_FAILED_PRECONDITION, message.into(), None::<()>)
 }
 
+fn proof_cancelled(message: impl Into<String>) -> ErrorObjectOwned {
+    ErrorObjectOwned::owned(ERROR_PROOF_CANCELLED, message.into(), None::<()>)
+}
+
 const fn rpc_status_code_str(code: i32) -> &'static str {
     match code {
         code if code == ErrorCode::InvalidParams.code() => "INVALID_ARGUMENT",
@@ -143,6 +153,7 @@ const fn rpc_status_code_str(code: i32) -> &'static str {
         ERROR_UNAVAILABLE => "UNAVAILABLE",
         ERROR_RESOURCE_EXHAUSTED => "RESOURCE_EXHAUSTED",
         ERROR_FAILED_PRECONDITION => "FAILED_PRECONDITION",
+        ERROR_PROOF_CANCELLED => "CANCELLED",
         _ => "ERROR",
     }
 }

--- a/crates/proof/prover-service/src/server/worker_api.rs
+++ b/crates/proof/prover-service/src/server/worker_api.rs
@@ -6,9 +6,9 @@ use base_prover_service_db::{
 };
 use base_prover_service_protocol::{
     GetNextProofRequest, GetNextProofResponse, GetProofSessionRequest, GetProofSessionResponse,
-    HeartbeatRequest, HeartbeatResponse, ProofJob as ProtocolProofJob, ProverWorkerApiServer,
-    RecordProofSessionRequest, RecordProofSessionResponse, WorkerSubmitProofRequest,
-    WorkerSubmitProofResponse,
+    HeartbeatRequest, HeartbeatResponse, PROOF_REQUEST_CANCELLED_MESSAGE,
+    ProofJob as ProtocolProofJob, ProverWorkerApiServer, RecordProofSessionRequest,
+    RecordProofSessionResponse, WorkerSubmitProofRequest, WorkerSubmitProofResponse,
 };
 use jsonrpsee::{
     core::{RpcResult, async_trait},
@@ -21,7 +21,8 @@ use crate::{
     metrics,
     server::{
         ProverServiceServer, WorkerApiConfig, failed_precondition, internal, invalid_argument,
-        not_found, record_rpc_result, record_worker_rpc_result, rpc_status_code_str,
+        not_found, proof_cancelled, record_rpc_result, record_worker_rpc_result,
+        rpc_status_code_str,
     },
 };
 
@@ -188,6 +189,11 @@ impl ProverServiceServer {
             )),
             HeartbeatOutcome::Expired(_) => {
                 Err(reject_ownership("heartbeat", &session_id, "lock has expired"))
+            }
+            HeartbeatOutcome::Terminal(job)
+                if job.error_message.as_deref() == Some(PROOF_REQUEST_CANCELLED_MESSAGE) =>
+            {
+                Err(proof_cancelled(PROOF_REQUEST_CANCELLED_MESSAGE))
             }
             HeartbeatOutcome::Terminal(_) => Err(reject_ownership(
                 "heartbeat",

--- a/crates/proof/zk/backend/src/succinct/cluster.rs
+++ b/crates/proof/zk/backend/src/succinct/cluster.rs
@@ -22,7 +22,8 @@ use sp1_cluster_common::{
     client::ClusterServiceClient,
     proto::{
         ExecutionFailureCause, ExecutionStatus, ProofRequest as ClusterProtoProofRequest,
-        ProofRequestCreateRequest, ProofRequestGetRequest, ProofRequestStatus,
+        ProofRequestCancelRequest, ProofRequestCreateRequest, ProofRequestGetRequest,
+        ProofRequestStatus,
     },
 };
 use sp1_prover_types::{Artifact, ArtifactClient as _, ArtifactType};
@@ -901,6 +902,16 @@ impl ZkProver for ClusterZkProver {
                 ))
             }
         }
+    }
+
+    async fn cancel(&self, backend_session_id: &str) -> Result<(), ZkProverError> {
+        let session = ClusterSessionId::parse(backend_session_id)?;
+        self.config
+            .cluster
+            .service_client
+            .cancel_proof_request(ProofRequestCancelRequest { proof_id: session.proof_id })
+            .await
+            .map_err(|e| backend_error!("failed to cancel cluster proof request: {e}"))
     }
 
     async fn submit_next(

--- a/crates/proof/zk/backend/src/succinct/network.rs
+++ b/crates/proof/zk/backend/src/succinct/network.rs
@@ -504,6 +504,15 @@ impl ZkProver for NetworkZkProver {
         Ok(state)
     }
 
+    async fn cancel(&self, backend_session_id: &str) -> Result<(), ZkProverError> {
+        let proof_id = Self::parse_proof_id(backend_session_id)?;
+        self.config
+            .network_prover
+            .cancel_request(proof_id)
+            .await
+            .map_err(|e| backend_error!("failed to cancel network proof request: {e}"))
+    }
+
     async fn download(
         &self,
         session_type: SessionType,

--- a/crates/proof/zk/host/src/proof_generator.rs
+++ b/crates/proof/zk/host/src/proof_generator.rs
@@ -420,6 +420,50 @@ where
         }
     }
 
+    async fn cancel_active_backend_sessions(&self, request: &ProofGeneratorRequest) {
+        let Ok(prover) = self.prover_for(&request.request) else {
+            return;
+        };
+        let handle = ProofSessionHandle::new(
+            self.submitter.client().clone(),
+            request.claim.session_id.clone(),
+            request.claim.lock_id.clone(),
+            request.claim.worker_id.clone(),
+        );
+
+        for session_type in [SessionType::Stark, SessionType::Snark] {
+            let session = match handle.get(session_type).await {
+                Ok(Some(session)) if session.state == BackendSessionState::Running => session,
+                Ok(_) => continue,
+                Err(error) => {
+                    warn!(
+                        session_id = %request.claim.session_id,
+                        ?session_type,
+                        error = %error,
+                        "failed to load backend session for cancellation"
+                    );
+                    continue;
+                }
+            };
+
+            match prover.cancel(&session.backend_session_id).await {
+                Ok(()) => info!(
+                    session_id = %request.claim.session_id,
+                    backend_session_id = %session.backend_session_id,
+                    ?session_type,
+                    "requested backend proof cancellation"
+                ),
+                Err(error) => warn!(
+                    session_id = %request.claim.session_id,
+                    backend_session_id = %session.backend_session_id,
+                    ?session_type,
+                    error = %error,
+                    "failed to cancel backend proof session"
+                ),
+            }
+        }
+    }
+
     async fn with_heartbeat_while_generating<Output, Generate>(
         &self,
         request: &ProofGeneratorRequest,
@@ -440,6 +484,14 @@ where
                 source,
             }),
             source = &mut heartbeat => {
+                if source.is_proof_cancelled() {
+                    self.cancel_active_backend_sessions(request).await;
+                    return Err(ProofGeneratorError::Heartbeat {
+                        session_id: request.claim.session_id.clone(),
+                        source,
+                    });
+                }
+
                 match timeout(
                     DEFAULT_PROOF_GENERATOR_HEARTBEAT_FAILURE_DRAIN_TIMEOUT,
                     &mut generate,

--- a/crates/proof/zk/host/src/prover.rs
+++ b/crates/proof/zk/host/src/prover.rs
@@ -118,6 +118,11 @@ pub trait ZkProver: Send + Sync + std::fmt::Debug {
     /// Poll the backend session, returning its current state.
     async fn poll(&self, backend_session_id: &str) -> Result<ZkSessionState, ZkProverError>;
 
+    /// Request cancellation of a running backend session.
+    async fn cancel(&self, _backend_session_id: &str) -> Result<(), ZkProverError> {
+        Err(ZkProverError::Unimplemented)
+    }
+
     /// Download the completed proof for a backend session.
     async fn download(
         &self,


### PR DESCRIPTION
## Summary
- Adds `prover_cancelProofRequest` for non-terminal ZK Cluster and Network proof requests, marking them `FAILED` and fencing late worker submits.
- Rejects TEE and dry-run cancellation with `FAILED_PRECONDITION`.
- Workers observe a dedicated cancelled heartbeat error and best-effort cancel active SP1 Cluster/Network sessions.

## Test plan
- [ ] `cargo test -p base-prover-service-client -p base-proof-zk-host --lib`
- [ ] With Postgres: `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`
- [ ] Cancel a queued/running Cluster or Network request via `cancelProofRequest` and confirm `getProof` reports `failed` with the cancellation message
- [ ] Confirm TEE and dry-run cancel calls return failed-precondition
- [ ] Confirm a second cancel on an already-cancelled session is a no-op


Made with [Cursor](https://cursor.com)