### PR TITLE
refactor(challenge): clean up config

### DIFF
--- a/bin/challenger/src/cli.rs
+++ b/bin/challenger/src/cli.rs
@@ -15,8 +15,8 @@ pub(crate) struct Cli {
 impl Cli {
     /// Run the challenger service.
     pub(crate) fn run(self) -> eyre::Result<()> {
+        base_cli_utils::LogConfig::from(self.args.logging.clone()).init_tracing_subscriber()?;
         let config = base_challenger::ChallengerConfig::from_cli(self.args)?;
-        config.log.init_tracing_subscriber()?;
         config
             .metrics
             .init_with(|| {

--- a/crates/proof/challenge/src/cli.rs
+++ b/crates/proof/challenge/src/cli.rs
@@ -77,16 +77,6 @@ pub struct ChallengerArgs {
     #[arg(long = "zk-rpc-url", env = cli_env!("ZK_RPC_URL"))]
     pub zk_rpc_url: Url,
 
-    /// Timeout for establishing the initial gRPC connection to the ZK proof
-    /// service (e.g., "10s", "1m").
-    #[arg(
-        long = "zk-connect-timeout",
-        env = cli_env!("ZK_CONNECT_TIMEOUT"),
-        default_value = "10s",
-        value_parser = humantime::parse_duration
-    )]
-    pub zk_connect_timeout: Duration,
-
     /// Timeout for individual gRPC requests to the ZK proof service
     /// (e.g., "30s", "1m").
     #[arg(

--- a/crates/proof/challenge/src/config.rs
+++ b/crates/proof/challenge/src/config.rs
@@ -1,92 +1,22 @@
 //! Configuration types and validation for the challenger.
 
-use std::{fmt, net::SocketAddr, ops::Deref, time::Duration};
+use std::{net::SocketAddr, time::Duration};
 
 use alloy_primitives::Address;
-use base_cli_utils::{LogConfig, MetricsConfig};
+use base_cli_utils::MetricsConfig;
 use base_tx_manager::{SignerConfig, TxManagerConfig};
-use thiserror::Error;
+use eyre::{Result, WrapErr, ensure};
 use url::Url;
 
 use crate::cli::Cli;
 
-/// Error returned when URL validation fails.
-#[derive(Debug, Error)]
-#[error("missing host")]
-pub struct UrlValidationError;
-
-/// A wrapper that guarantees the inner value has been validated.
-#[derive(Debug, Clone)]
-pub struct Validated<T>(T);
-
-impl TryFrom<Url> for Validated<Url> {
-    type Error = UrlValidationError;
-
-    fn try_from(url: Url) -> Result<Self, Self::Error> {
-        if url.host().is_none() {
-            return Err(UrlValidationError);
-        }
-        Ok(Self(url))
-    }
-}
-
-impl<T> Deref for Validated<T> {
-    type Target = T;
-
-    fn deref(&self) -> &T {
-        &self.0
-    }
-}
-
-impl<T> AsRef<T> for Validated<T> {
-    fn as_ref(&self) -> &T {
-        &self.0
-    }
-}
-
-impl<T: fmt::Display> fmt::Display for Validated<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-/// Errors that can occur during configuration validation.
-#[derive(Debug, Error)]
-pub enum ConfigError {
-    /// Invalid URL format.
-    #[error("invalid {field} URL: missing host")]
-    InvalidUrl {
-        /// The field name that contains the invalid URL.
-        field: &'static str,
-    },
-    /// A field value is out of the allowed range.
-    #[error("{field} must be {constraint}, got {value}")]
-    OutOfRange {
-        /// The field name that is out of range.
-        field: &'static str,
-        /// The constraint description.
-        constraint: &'static str,
-        /// The actual value.
-        value: &'static str,
-    },
-    /// Invalid metrics configuration.
-    #[error("invalid metrics config: {0}")]
-    Metrics(&'static str),
-    /// Invalid signing configuration.
-    #[error("invalid signing config: {0}")]
-    Signer(base_tx_manager::ConfigError),
-    /// Invalid transaction manager configuration.
-    #[error("invalid tx manager config: {0}")]
-    TxManager(base_tx_manager::ConfigError),
-}
-
-/// Validated challenger configuration.
+/// Challenger configuration.
 #[derive(Debug)]
 pub struct ChallengerConfig {
     /// URL of the L1 Ethereum RPC endpoint.
-    pub l1_eth_rpc: Validated<Url>,
+    pub l1_eth_rpc: Url,
     /// URL of the L2 Ethereum RPC endpoint.
-    pub l2_eth_rpc: Validated<Url>,
+    pub l2_eth_rpc: Url,
     /// Address of the `DisputeGameFactory` contract on L1.
     pub dispute_game_factory_addr: Address,
     /// Address of the `AnchorStateRegistry` contract on L1.
@@ -96,9 +26,7 @@ pub struct ChallengerConfig {
     /// Polling interval for new dispute games.
     pub poll_interval: Duration,
     /// URL of the ZK RPC endpoint.
-    pub zk_rpc_url: Validated<Url>,
-    /// Timeout for establishing the initial gRPC connection to the ZK proof service.
-    pub zk_connect_timeout: Duration,
+    pub zk_rpc_url: Url,
     /// Timeout for individual gRPC requests to the ZK proof service.
     pub zk_request_timeout: Duration,
     /// Maximum wall-clock time to wait for a ZK proof session before treating it as failed.
@@ -117,8 +45,6 @@ pub struct ChallengerConfig {
     pub bond_claim_addresses: Vec<Address>,
     /// Health server socket address.
     pub health_addr: SocketAddr,
-    /// Logging configuration (from base-cli-utils).
-    pub log: LogConfig,
     /// Metrics server configuration.
     pub metrics: MetricsConfig,
 }
@@ -126,402 +52,164 @@ pub struct ChallengerConfig {
 impl ChallengerConfig {
     /// Creates a validated [`ChallengerConfig`] from parsed CLI arguments.
     ///
-    /// # Validation
-    ///
-    /// - Every URL field must have a scheme and host.
-    /// - `poll_interval` must be greater than zero.
-    /// - When metrics are enabled, the metrics port must be non-zero.
-    /// - Exactly one signing method must be configured: either
-    ///   `--private-key` (local/dev) **or** both
-    ///   `--signer-endpoint` and `--signer-address` (remote/production).
-    ///
     /// # Errors
     ///
-    /// Returns [`ConfigError`] if any validation check fails.
-    pub fn from_cli(cli: Cli) -> Result<Self, ConfigError> {
-        let validate_url = |url: Url, field: &'static str| -> Result<Validated<Url>, ConfigError> {
-            Validated::try_from(url).map_err(|_| ConfigError::InvalidUrl { field })
-        };
+    /// Returns an error if any validation check fails.
+    pub fn from_cli(cli: Cli) -> Result<Self> {
+        let Cli { challenger, metrics, health, .. } = cli;
 
-        let require_nonzero = |value: u64, field: &'static str| -> Result<(), ConfigError> {
-            if value == 0 {
-                return Err(ConfigError::OutOfRange {
-                    field,
-                    constraint: "greater than 0",
-                    value: "0",
-                });
-            }
-            Ok(())
-        };
-
-        let require_nonzero_duration =
-            |d: Duration, field: &'static str| -> Result<(), ConfigError> {
-                if d.is_zero() {
-                    return Err(ConfigError::OutOfRange {
-                        field,
-                        constraint: "greater than 0",
-                        value: "0",
-                    });
-                }
-                Ok(())
-            };
-
-        let l1_eth_rpc = validate_url(cli.challenger.l1_eth_rpc, "l1-eth-rpc")?;
-        let l2_eth_rpc = validate_url(cli.challenger.l2_eth_rpc, "l2-eth-rpc")?;
-        let zk_rpc_url = validate_url(cli.challenger.zk_rpc_url, "zk-rpc-url")?;
-
-        if cli.challenger.anchor_state_registry_addr == Address::ZERO {
-            return Err(ConfigError::OutOfRange {
-                field: "anchor-state-registry-addr",
-                constraint: "non-zero",
-                value: "0x0000000000000000000000000000000000000000",
-            });
+        for (url, message) in [
+            (&challenger.l1_eth_rpc, "invalid l1-eth-rpc URL: missing host"),
+            (&challenger.l2_eth_rpc, "invalid l2-eth-rpc URL: missing host"),
+            (&challenger.zk_rpc_url, "invalid zk-rpc-url URL: missing host"),
+        ] {
+            ensure!(url.has_host(), message);
         }
 
-        require_nonzero_duration(cli.challenger.poll_interval, "poll-interval")?;
-        require_nonzero_duration(cli.challenger.zk_connect_timeout, "zk-connect-timeout")?;
-        require_nonzero_duration(cli.challenger.zk_request_timeout, "zk-request-timeout")?;
-        require_nonzero_duration(cli.challenger.max_proof_duration, "max-proof-duration")?;
+        ensure!(
+            challenger.anchor_state_registry_addr != Address::ZERO,
+            "anchor-state-registry-addr must be non-zero"
+        );
 
-        require_nonzero(
-            cli.challenger.bond_discovery_lookback_games,
-            "bond-discovery-lookback-games",
-        )?;
-        require_nonzero_duration(
-            cli.challenger.bond_discovery_interval,
-            "bond-discovery-interval",
-        )?;
-
-        // Health server is always started, so the port must be valid.
-        require_nonzero(cli.health.port.into(), "health.port")?;
-
-        if cli.metrics.enabled && cli.metrics.port == 0 {
-            return Err(ConfigError::Metrics(
-                "metrics port must be non-zero when metrics are enabled",
-            ));
+        for (duration, message) in [
+            (challenger.poll_interval, "poll-interval must be greater than 0"),
+            (challenger.zk_request_timeout, "zk-request-timeout must be greater than 0"),
+            (challenger.max_proof_duration, "max-proof-duration must be greater than 0"),
+            (challenger.bond_discovery_interval, "bond-discovery-interval must be greater than 0"),
+        ] {
+            ensure!(!duration.is_zero(), message);
         }
 
-        let signing = SignerConfig::try_from(cli.challenger.signer).map_err(ConfigError::Signer)?;
+        ensure!(
+            challenger.bond_discovery_lookback_games != 0,
+            "bond-discovery-lookback-games must be greater than 0"
+        );
 
-        let tx_manager =
-            TxManagerConfig::try_from(cli.challenger.tx_manager).map_err(ConfigError::TxManager)?;
+        ensure!(health.port != 0, "health.port must be greater than 0");
 
-        let health_addr = cli.health.socket_addr();
+        ensure!(
+            !metrics.enabled || metrics.port != 0,
+            "metrics.port must be greater than 0 when metrics are enabled"
+        );
 
         Ok(Self {
-            l1_eth_rpc,
-            l2_eth_rpc,
-            dispute_game_factory_addr: cli.challenger.dispute_game_factory_addr,
-            anchor_state_registry_addr: cli.challenger.anchor_state_registry_addr,
-            game_type: cli.challenger.game_type,
-            poll_interval: cli.challenger.poll_interval,
-            zk_rpc_url,
-            zk_connect_timeout: cli.challenger.zk_connect_timeout,
-            zk_request_timeout: cli.challenger.zk_request_timeout,
-            max_proof_duration: cli.challenger.max_proof_duration,
-            tee_submit_retry_limit: cli.challenger.tee_submit_retry_limit,
-            signing,
-            tx_manager,
-            bond_discovery_lookback_games: cli.challenger.bond_discovery_lookback_games,
-            bond_discovery_interval: cli.challenger.bond_discovery_interval,
-            bond_claim_addresses: cli.challenger.bond_claim_addresses,
-            health_addr,
-            log: LogConfig::from(cli.logging),
-            metrics: cli.metrics.into(),
+            l1_eth_rpc: challenger.l1_eth_rpc,
+            l2_eth_rpc: challenger.l2_eth_rpc,
+            dispute_game_factory_addr: challenger.dispute_game_factory_addr,
+            anchor_state_registry_addr: challenger.anchor_state_registry_addr,
+            game_type: challenger.game_type,
+            poll_interval: challenger.poll_interval,
+            zk_rpc_url: challenger.zk_rpc_url,
+            zk_request_timeout: challenger.zk_request_timeout,
+            max_proof_duration: challenger.max_proof_duration,
+            tee_submit_retry_limit: challenger.tee_submit_retry_limit,
+            signing: SignerConfig::try_from(challenger.signer)
+                .wrap_err("invalid signing config")?,
+            tx_manager: TxManagerConfig::try_from(challenger.tx_manager)
+                .wrap_err("invalid tx manager config")?,
+            bond_discovery_lookback_games: challenger.bond_discovery_lookback_games,
+            bond_discovery_interval: challenger.bond_discovery_interval,
+            bond_claim_addresses: challenger.bond_claim_addresses,
+            health_addr: health.socket_addr(),
+            metrics: metrics.into(),
         })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use base_cli_utils::LogFormat;
     use clap::Parser;
-    use rstest::rstest;
 
     use super::*;
-    use crate::cli::{LogArgs, MetricsArgs};
+    use crate::cli::SignerCli;
 
-    /// Parse a mock CLI command with required args plus any overrides.
-    ///
-    /// The base defaults do **not** include signer flags (`--private-key` /
-    /// `--signer-endpoint` / `--signer-address`). Tests that need a signer
-    /// should pass those flags via `extra_args`.
-    ///
-    /// Keys present in `extra_args` replace their base defaults so clap never
-    /// sees the same flag twice.
-    fn cli_from_args(extra_args: &[&str]) -> Cli {
-        let base: &[(&str, &str)] = &[
-            ("--l1-eth-rpc", "http://localhost:8545"),
-            ("--l2-eth-rpc", "http://localhost:9545"),
-            ("--dispute-game-factory-addr", "0x1234567890123456789012345678901234567890"),
-            ("--anchor-state-registry-addr", "0x2234567890123456789012345678901234567890"),
-            ("--game-type", "1"),
-            ("--zk-rpc-url", "http://localhost:5000"),
-        ];
-
-        let mut args = vec!["challenger"];
-        for (key, value) in base {
-            if !extra_args.contains(key) {
-                args.push(key);
-                args.push(value);
-            }
-        }
-        args.extend_from_slice(extra_args);
-        Cli::try_parse_from(args).unwrap()
+    fn minimal_cli() -> Cli {
+        Cli::try_parse_from([
+            "challenger",
+            "--l1-eth-rpc",
+            "http://localhost:8545",
+            "--l2-eth-rpc",
+            "http://localhost:9545",
+            "--dispute-game-factory-addr",
+            "0x1234567890123456789012345678901234567890",
+            "--anchor-state-registry-addr",
+            "0x2234567890123456789012345678901234567890",
+            "--game-type",
+            "1",
+            "--zk-rpc-url",
+            "http://localhost:5000",
+            "--private-key",
+            "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+        ])
+        .unwrap()
     }
-
-    /// Remote signer CLI flags for tests that need a valid signing configuration.
-    const SIGNER_ARGS: [&str; 4] = [
-        "--signer-endpoint",
-        "http://localhost:8546",
-        "--signer-address",
-        "0x1234567890123456789012345678901234567890",
-    ];
-
-    /// Local signer CLI flags for tests that need a valid signing configuration.
-    const LOCAL_SIGNER_ARGS: [&str; 2] =
-        ["--private-key", "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"];
 
     #[test]
     fn test_valid_config() {
-        let cli = cli_from_args(&SIGNER_ARGS);
+        let mut cli = minimal_cli();
+        cli.metrics.port = 0;
         let config = ChallengerConfig::from_cli(cli).unwrap();
-        assert_eq!(config.poll_interval, Duration::from_secs(12));
-        assert_eq!(config.zk_connect_timeout, Duration::from_secs(10));
-        assert_eq!(config.zk_request_timeout, Duration::from_secs(30));
-        assert_eq!(config.tee_submit_retry_limit, 3);
-        assert_eq!(
-            config.anchor_state_registry_addr,
-            "0x2234567890123456789012345678901234567890".parse::<Address>().unwrap()
-        );
         assert_eq!(config.game_type, 1);
-        assert_eq!(config.bond_discovery_lookback_games, 1000);
-        assert_eq!(config.bond_discovery_interval, Duration::from_secs(300));
-        assert_eq!(config.health_addr, "0.0.0.0:8080".parse::<SocketAddr>().unwrap());
-        assert!(matches!(config.signing, SignerConfig::Remote { .. }));
-        assert_eq!(config.tx_manager.num_confirmations, 10);
-        assert_eq!(config.tx_manager.safe_abort_nonce_too_low_count, 3);
-        assert_eq!(config.tx_manager.fee_limit_multiplier, 5);
+        assert_eq!(config.metrics.port, 0);
+        assert!(matches!(config.signing, SignerConfig::Local { .. }));
+        assert_eq!(config.tx_manager, TxManagerConfig::default());
     }
 
     #[test]
-    fn test_bond_discovery_lookback_games_configurable() {
-        let all_args = [&SIGNER_ARGS[..], &["--bond-discovery-lookback-games", "2048"]].concat();
-        let cli = cli_from_args(&all_args);
-        let config = ChallengerConfig::from_cli(cli).unwrap();
-        assert_eq!(config.bond_discovery_lookback_games, 2048);
-    }
+    fn test_invalid_config_rejected() {
+        let cases: [(fn(&mut Cli), &'static str); 10] = [
+            (
+                |cli| cli.challenger.poll_interval = Duration::ZERO,
+                "poll-interval must be greater than 0",
+            ),
+            (
+                |cli| cli.challenger.zk_request_timeout = Duration::ZERO,
+                "zk-request-timeout must be greater than 0",
+            ),
+            (
+                |cli| cli.challenger.bond_discovery_lookback_games = 0,
+                "bond-discovery-lookback-games must be greater than 0",
+            ),
+            (
+                |cli| cli.challenger.bond_discovery_interval = Duration::ZERO,
+                "bond-discovery-interval must be greater than 0",
+            ),
+            (
+                |cli| cli.challenger.max_proof_duration = Duration::ZERO,
+                "max-proof-duration must be greater than 0",
+            ),
+            (|cli| cli.health.port = 0, "health.port must be greater than 0"),
+            (
+                |cli| cli.challenger.anchor_state_registry_addr = Address::ZERO,
+                "anchor-state-registry-addr must be non-zero",
+            ),
+            (
+                |cli| {
+                    cli.metrics.enabled = true;
+                    cli.metrics.port = 0;
+                },
+                "metrics.port must be greater than 0 when metrics are enabled",
+            ),
+            (
+                |cli| {
+                    cli.challenger.signer = SignerCli {
+                        private_key: None,
+                        signer_endpoint: None,
+                        signer_address: None,
+                    };
+                },
+                "invalid signing config",
+            ),
+            (
+                |cli| cli.challenger.zk_rpc_url = Url::parse("file:///no/host").unwrap(),
+                "invalid zk-rpc-url URL: missing host",
+            ),
+        ];
 
-    #[test]
-    fn test_tee_submit_retry_limit_configurable() {
-        let all_args = [&SIGNER_ARGS[..], &["--tee-submit-retry-limit", "7"]].concat();
-        let cli = cli_from_args(&all_args);
-        let config = ChallengerConfig::from_cli(cli).unwrap();
-        assert_eq!(config.tee_submit_retry_limit, 7);
-    }
-
-    #[rstest]
-    #[case::poll_interval("--poll-interval", "0s", "poll-interval")]
-    #[case::zk_connect_timeout("--zk-connect-timeout", "0s", "zk-connect-timeout")]
-    #[case::zk_request_timeout("--zk-request-timeout", "0s", "zk-request-timeout")]
-    #[case::bond_discovery_lookback_games(
-        "--bond-discovery-lookback-games",
-        "0",
-        "bond-discovery-lookback-games"
-    )]
-    #[case::bond_discovery_interval("--bond-discovery-interval", "0s", "bond-discovery-interval")]
-    #[case::max_proof_duration("--max-proof-duration", "0s", "max-proof-duration")]
-    fn test_zero_value_rejected(#[case] flag: &str, #[case] value: &str, #[case] field: &str) {
-        let all_args = [&LOCAL_SIGNER_ARGS[..], &[flag, value]].concat();
-        let cli = cli_from_args(&all_args);
-        let result = ChallengerConfig::from_cli(cli);
-        assert!(matches!(result, Err(ConfigError::OutOfRange { field: f, .. }) if f == field));
-    }
-
-    #[test]
-    fn test_health_port_zero_rejected() {
-        let all_args = [&SIGNER_ARGS[..], &["--health.port", "0"]].concat();
-        let cli = cli_from_args(&all_args);
-        let result = ChallengerConfig::from_cli(cli);
-        assert!(matches!(result, Err(ConfigError::OutOfRange { field: "health.port", .. })));
-    }
-
-    #[test]
-    fn test_anchor_state_registry_zero_rejected() {
-        let all_args = [
-            &SIGNER_ARGS[..],
-            &["--anchor-state-registry-addr", "0x0000000000000000000000000000000000000000"],
-        ]
-        .concat();
-        let cli = cli_from_args(&all_args);
-        let result = ChallengerConfig::from_cli(cli);
-        assert!(matches!(
-            result,
-            Err(ConfigError::OutOfRange { field: "anchor-state-registry-addr", .. })
-        ));
-    }
-
-    #[rstest]
-    #[case::enabled(&["--metrics.enabled", "--metrics.port", "0"], true)]
-    #[case::disabled(&["--metrics.port", "0"], false)]
-    fn test_metrics_port_zero(#[case] args: &[&str], #[case] expect_error: bool) {
-        let all_args = [args, &SIGNER_ARGS].concat();
-        let cli = cli_from_args(&all_args);
-        let result = ChallengerConfig::from_cli(cli);
-        if expect_error {
-            assert!(matches!(result, Err(ConfigError::Metrics(_))));
-        } else {
-            assert!(result.is_ok());
+        for (mutate, expected) in cases {
+            let mut cli = minimal_cli();
+            mutate(&mut cli);
+            assert_eq!(ChallengerConfig::from_cli(cli).unwrap_err().to_string(), expected);
         }
-    }
-
-    #[test]
-    fn test_log_config_from_args() {
-        use tracing::level_filters::LevelFilter;
-
-        let args = LogArgs {
-            level: 4,
-            stdout_quiet: false,
-            stdout_format: LogFormat::Json,
-            ..Default::default()
-        };
-        let config = LogConfig::from(args);
-        assert_eq!(config.global_level, LevelFilter::DEBUG);
-        assert!(config.stdout_logs.is_some());
-        assert!(config.file_logs.is_none());
-
-        let args = LogArgs {
-            level: 3,
-            stdout_quiet: true,
-            stdout_format: LogFormat::Full,
-            ..Default::default()
-        };
-        let config = LogConfig::from(args);
-        assert!(config.stdout_logs.is_none());
-    }
-
-    #[test]
-    fn test_metrics_config_from_args() {
-        let args = MetricsArgs {
-            enabled: true,
-            addr: "127.0.0.1".parse().unwrap(),
-            port: 9090,
-            ..Default::default()
-        };
-        let config = MetricsConfig::from(args);
-        assert!(config.enabled);
-        assert_eq!(config.port, 9090);
-    }
-
-    #[test]
-    fn test_url_without_host() {
-        let url = Url::parse("file:///some/path").unwrap();
-        let result = Validated::try_from(url);
-        assert!(matches!(result, Err(UrlValidationError)));
-    }
-
-    #[rstest]
-    #[case::invalid_url(
-        ConfigError::InvalidUrl { field: "l1-eth-rpc" },
-        "invalid l1-eth-rpc URL: missing host"
-    )]
-    #[case::out_of_range(
-        ConfigError::OutOfRange { field: "poll-interval", constraint: "greater than 0", value: "0" },
-        "poll-interval must be greater than 0, got 0"
-    )]
-    #[case::metrics(
-        ConfigError::Metrics("port must be non-zero"),
-        "invalid metrics config: port must be non-zero"
-    )]
-    fn test_config_error_display(#[case] error: ConfigError, #[case] expected: &str) {
-        assert_eq!(error.to_string(), expected);
-    }
-
-    #[test]
-    fn test_signing_config_local() {
-        let cli = cli_from_args(&LOCAL_SIGNER_ARGS);
-        let result = ChallengerConfig::from_cli(cli);
-        assert!(result.is_ok(), "expected Ok, got {result:?}");
-        assert!(matches!(result.unwrap().signing, SignerConfig::Local { .. }));
-    }
-
-    #[test]
-    fn test_signing_config_remote() {
-        let cli = cli_from_args(&SIGNER_ARGS);
-        let result = ChallengerConfig::from_cli(cli);
-        assert!(result.is_ok(), "expected Ok, got {result:?}");
-        assert!(matches!(result.unwrap().signing, SignerConfig::Remote { .. }));
-    }
-
-    #[test]
-    fn test_signing_config_none_provided() {
-        let cli = cli_from_args(&[]);
-        let result = ChallengerConfig::from_cli(cli);
-        assert!(matches!(result, Err(ConfigError::Signer(_))));
-    }
-
-    #[test]
-    fn test_signing_config_conflicting_rejected_by_clap() {
-        let result = Cli::try_parse_from([
-            "challenger",
-            "--l1-eth-rpc",
-            "http://localhost:8545",
-            "--l2-eth-rpc",
-            "http://localhost:9545",
-            "--dispute-game-factory-addr",
-            "0x1234567890123456789012345678901234567890",
-            "--anchor-state-registry-addr",
-            "0x2234567890123456789012345678901234567890",
-            "--zk-rpc-url",
-            "http://localhost:5000",
-            "--private-key",
-            "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
-            "--signer-endpoint",
-            "http://localhost:8546",
-            "--signer-address",
-            "0x1234567890123456789012345678901234567890",
-        ]);
-        assert!(result.is_err(), "clap should reject conflicting signer args");
-    }
-
-    #[test]
-    fn test_signing_config_endpoint_without_address_rejected_by_clap() {
-        let result = Cli::try_parse_from([
-            "challenger",
-            "--l1-eth-rpc",
-            "http://localhost:8545",
-            "--l2-eth-rpc",
-            "http://localhost:9545",
-            "--dispute-game-factory-addr",
-            "0x1234567890123456789012345678901234567890",
-            "--anchor-state-registry-addr",
-            "0x2234567890123456789012345678901234567890",
-            "--zk-rpc-url",
-            "http://localhost:5000",
-            "--signer-endpoint",
-            "http://localhost:8546",
-        ]);
-        assert!(result.is_err(), "clap should reject endpoint without address");
-    }
-
-    #[test]
-    fn test_zk_rpc_url_validated() {
-        let cli = cli_from_args(&[
-            "--zk-rpc-url",
-            "file:///no/host",
-            "--private-key",
-            "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
-        ]);
-        let result = ChallengerConfig::from_cli(cli);
-        assert!(matches!(result, Err(ConfigError::InvalidUrl { field: "zk-rpc-url", .. })));
-    }
-
-    #[test]
-    fn test_health_addr_configurable() {
-        let args =
-            [&SIGNER_ARGS[..], &["--health.addr", "127.0.0.1", "--health.port", "9090"]].concat();
-        let cli = cli_from_args(&args);
-        let config = ChallengerConfig::from_cli(cli).unwrap();
-        assert_eq!(config.health_addr, "127.0.0.1:9090".parse::<SocketAddr>().unwrap());
     }
 }

--- a/crates/proof/challenge/src/config.rs
+++ b/crates/proof/challenge/src/config.rs
@@ -123,6 +123,8 @@ mod tests {
     use super::*;
     use crate::cli::SignerCli;
 
+    type InvalidConfigCase = (fn(&mut Cli), &'static str);
+
     fn minimal_cli() -> Cli {
         Cli::try_parse_from([
             "challenger",
@@ -157,7 +159,7 @@ mod tests {
 
     #[test]
     fn test_invalid_config_rejected() {
-        let cases: [(fn(&mut Cli), &'static str); 10] = [
+        let cases: [InvalidConfigCase; 10] = [
             (
                 |cli| cli.challenger.poll_interval = Duration::ZERO,
                 "poll-interval must be greater than 0",

--- a/crates/proof/challenge/src/lib.rs
+++ b/crates/proof/challenge/src/lib.rs
@@ -13,7 +13,7 @@ mod anchor;
 pub use anchor::AnchorUpdater;
 
 mod config;
-pub use config::{ChallengerConfig, ConfigError, UrlValidationError, Validated};
+pub use config::ChallengerConfig;
 
 mod driver;
 pub use driver::{Driver, DriverComponents, DriverConfig, TeeConfig};

--- a/crates/proof/challenge/src/service.rs
+++ b/crates/proof/challenge/src/service.rs
@@ -65,7 +65,7 @@ impl ChallengerService {
         // ── 3. Construct tx-manager and challenge submitter ──────────────────
         let signer_config = config.signing;
         let sender_addr = signer_config.address();
-        let l1_rpc_url = config.l1_eth_rpc.as_ref().clone();
+        let l1_rpc_url = config.l1_eth_rpc.clone();
         let l1_provider = if config.metrics.enabled {
             let (layer, mut balance_rx) = BalanceMonitorLayer::new(
                 sender_addr,
@@ -154,7 +154,7 @@ impl ChallengerService {
         let anchor_registry_client = Arc::new(anchor_registry_client);
 
         // ── 5. L2 client ─────────────────────────────────────────────────────
-        let l2_config = L2ClientConfig::new(config.l2_eth_rpc.as_ref().clone());
+        let l2_config = L2ClientConfig::new(config.l2_eth_rpc.clone());
         let l2_client = Arc::new(L2Client::new(l2_config)?);
         info!(endpoint = %config.l2_eth_rpc, "L2 client initialized");
 


### PR DESCRIPTION
### What changed? Why?

Simplifies challenger config construction by removing the Validated wrapper and custom ConfigError type in favor of eyre validation. Drops the unused ZK connect timeout CLI option and keeps logging initialization in the binary before config parsing so config only carries runtime settings.

### Notes to reviewers

Validation behavior is kept at the config boundary with simpler error strings. Metrics port 0 remains allowed when metrics are disabled.

### How has it been tested?

`cargo test -p base-challenger -p base-challenger-bin`