### PR TITLE
refactor(zk-benchmarks): address CLI and constructor nits

### DIFF
--- a/bin/zk-benchmarks/src/cli.rs
+++ b/bin/zk-benchmarks/src/cli.rs
@@ -3,35 +3,16 @@
 use std::path::PathBuf;
 
 use base_cli_utils::RuntimeManager;
-use base_load_tests::{
-    LoadTestCleanupSummary, LoadTestDisplay, LoadTestExecutor, LoadTestRunOptions, TestConfig,
-};
+use base_load_tests::{LoadTestDisplay, LoadTestExecutor, LoadTestRunOptions, TestConfig};
 use base_prover_service_protocol::ZkBackend;
 use base_zk_benchmarks::{ZkBenchConfig, ZkBenchRunner, ZkBenchSummary};
-use clap::{Args, Parser, ValueEnum};
-use eyre::{Result, bail};
+use clap::{Parser, ValueEnum};
+use eyre::Result;
 
 /// The Base ZK benchmark CLI.
 #[derive(Parser, Clone, Debug)]
 #[command(author, version = env!("CARGO_PKG_VERSION"), about = "Base ZK benchmarks")]
-pub(crate) struct Cli {
-    /// ZK benchmark arguments.
-    #[command(flatten)]
-    args: ZkBenchArgs,
-}
-
-impl Cli {
-    /// Runs the selected benchmark.
-    pub(crate) fn run(self) -> Result<()> {
-        RuntimeManager::new()
-            .tokio_runtime()?
-            .block_on(async move { run_zk_benchmark(self.args).await })
-    }
-}
-
-/// ZK benchmark command arguments.
-#[derive(Args, Clone, Debug)]
-struct ZkBenchArgs {
+pub(crate) struct ZkBenchArgs {
     /// ZK proof backend.
     #[arg(long, value_enum)]
     mode: ZkBackendArg,
@@ -57,6 +38,13 @@ struct ZkBenchArgs {
     config: PathBuf,
 }
 
+impl ZkBenchArgs {
+    /// Runs the selected benchmark.
+    pub(crate) fn run(self) -> Result<()> {
+        RuntimeManager::new().tokio_runtime()?.block_on(async move { run_zk_benchmark(self).await })
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 enum ZkBackendArg {
     DryRun,
@@ -77,16 +65,12 @@ impl From<ZkBackendArg> for ZkBackend {
 async fn run_zk_benchmark(args: ZkBenchArgs) -> Result<()> {
     let _mp = LoadTestDisplay::init_tracing();
 
-    if !args.config.exists() {
-        bail!("config file not found: {}", args.config.display());
-    }
-
     let test_config = TestConfig::load(&args.config)?;
-    let zk_config = ZkBenchConfig::new(
-        args.rollup_rpc_url.clone(),
-        args.prover_service_url.clone(),
-        args.mode.into(),
-    );
+    let zk_config = ZkBenchConfig {
+        zk_backend: args.mode.into(),
+        rollup_rpc_url: args.rollup_rpc_url,
+        prover_url: args.prover_service_url,
+    };
 
     println!("=== Base ZK Benchmark Runner ===");
     println!("Config: {}", args.config.display());
@@ -114,7 +98,6 @@ async fn run_zk_benchmark(args: ZkBenchArgs) -> Result<()> {
             Err(e) => eprintln!("Warning: failed to serialize load test results: {e}"),
         }
     }
-    print_cleanup_warnings(&output.cleanup);
     if let Some(error) = output.run_error {
         return Err(error.into());
     }
@@ -137,15 +120,6 @@ async fn run_zk_benchmark(args: ZkBenchArgs) -> Result<()> {
     }
 
     Ok(())
-}
-
-fn print_cleanup_warnings(cleanup: &LoadTestCleanupSummary) {
-    if let Some(error) = &cleanup.b20_teardown_error {
-        eprintln!("Warning: B-20 teardown failed: {error}");
-    }
-    if let Some(error) = &cleanup.drain_error {
-        eprintln!("Warning: drain failed: {error}");
-    }
 }
 
 fn print_zk_bench_summary(summary: &ZkBenchSummary) {

--- a/bin/zk-benchmarks/src/main.rs
+++ b/bin/zk-benchmarks/src/main.rs
@@ -3,5 +3,5 @@
 mod cli;
 
 fn main() {
-    base_cli_utils::run_cli_main!(cli::Cli);
+    base_cli_utils::run_cli_main!(cli::ZkBenchArgs);
 }

--- a/crates/infra/zk-benchmarks/src/runner.rs
+++ b/crates/infra/zk-benchmarks/src/runner.rs
@@ -40,7 +40,7 @@ impl ZkBenchRunner {
         let (proof, execution_stats) =
             Self::prove_safe_block(&rollup_provider, target.block, config).await?;
 
-        Ok(ZkBenchSummary::new(target, proof, execution_stats))
+        Ok(ZkBenchSummary { target, proof, execution_stats })
     }
 
     fn select_proof_target(summary: &MetricsSummary) -> Result<ZkBenchTarget> {

--- a/crates/infra/zk-benchmarks/src/types.rs
+++ b/crates/infra/zk-benchmarks/src/types.rs
@@ -38,13 +38,6 @@ pub struct ZkBenchConfig {
     pub prover_url: Url,
 }
 
-impl ZkBenchConfig {
-    /// Builds ZK bench config from endpoint URLs and proof backend.
-    pub const fn new(rollup_rpc_url: Url, prover_url: Url, zk_backend: ZkBackend) -> Self {
-        Self { zk_backend, rollup_rpc_url, prover_url }
-    }
-}
-
 /// The single L2 block selected for proof.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ZkBenchTarget {
@@ -83,15 +76,6 @@ pub struct ZkBenchSummary {
 }
 
 impl ZkBenchSummary {
-    /// Builds a completed ZK benchmark summary.
-    pub const fn new(
-        target: ZkBenchTarget,
-        proof: ZkBenchProofOutcome,
-        execution_stats: Option<ExecutionStats>,
-    ) -> Self {
-        Self { target, proof, execution_stats }
-    }
-
     /// Serializes the summary to pretty JSON.
     pub fn to_json(&self) -> serde_json::Result<String> {
         serde_json::to_string_pretty(self)
@@ -109,17 +93,17 @@ mod tests {
 
     #[test]
     fn summary_json_encodes_proof_duration_as_millis() {
-        let summary = ZkBenchSummary::new(
-            ZkBenchTarget { block: 11, reason: "fullest".to_string() },
-            ZkBenchProofOutcome {
+        let summary = ZkBenchSummary {
+            target: ZkBenchTarget { block: 11, reason: "fullest".to_string() },
+            proof: ZkBenchProofOutcome {
                 zk_backend: ZkBackend::DryRun,
                 session_id: "session".to_string(),
                 start_block_number: 10,
                 l1_head: B256::ZERO,
                 proof_duration: Duration::from_millis(1_250),
             },
-            None,
-        );
+            execution_stats: None,
+        };
 
         let json = summary.to_json().unwrap();
         assert!(json.contains("\"proof_duration\": 1250"), "{json}");


### PR DESCRIPTION
## Summary
- Flatten binary CLI onto `ZkBenchArgs` (drop unused `Cli` wrapper)
- Remove redundant config `exists()` check and duplicate cleanup warnings
- Construct `ZkBenchConfig` / `ZkBenchSummary` with struct literals instead of pass-through constructors


Made with [Cursor](https://cursor.com)