### PR TITLE
refactor(challenger): extract proof management from driver

### DIFF
--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -1,51 +1,43 @@
 //! Main driver loop for the challenger service.
 //!
-//! The [`Driver`] ties together all challenger components — scanning for
-//! invalid dispute games, validating output roots, requesting proofs, and
-//! submitting dispute transactions — into a single polling loop.
-//!
-//! Four dispute paths are supported:
-//!
-//! 1. **Wrong TEE proof** — nullify with a TEE proof (`nullify()`) or
-//!    challenge with a ZK proof (`challenge()`).
-//! 2. **Correct TEE proof challenged with a wrong ZK proof** — nullify
-//!    the fraudulent ZK challenge with a ZK proof (`nullify()`).
-//! 3. **Wrong ZK proposal** — nullify with a ZK proof (`nullify()`).
-//! 4. **Wrong dual proposal (TEE + ZK, no challenge)** — nullify with a
-//!    TEE proof first (`nullify()`), falling back to ZK `nullify()`.
-//!    After the TEE proof is nullified, the game is re-scanned as Path 3.
+//! The [`Driver`] schedules game scanning, output validation, proof lifecycle
+//! work, bond discovery, and anchor maintenance.
 
-use std::{
-    collections::{HashSet, VecDeque},
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{sync::Arc, time::Duration};
 
-use alloy_primitives::{Address, B256};
-use base_proof_contracts::{AggregateVerifierClient, GameStatus};
-use base_proof_primitives::ProofRequest as TeeProofRequest;
+use base_proof_contracts::AggregateVerifierClient;
 use base_proof_rpc::L2Provider;
-use base_proof_submission::KnownRevert;
 use base_prover_service_client::ProofRequesterProvider;
-use base_prover_service_protocol::{
-    SnarkPlonkProofRequest, TeeKind, ZkBackend, ZkProofRequest, ZkVm,
-};
-use base_runtime::{Clock, TokioRuntime};
-use base_tx_manager::{TxManager, TxManagerError};
+use base_runtime::TokioRuntime;
+use base_tx_manager::TxManager;
 use tokio::select;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 use crate::{
-    AnchorUpdater, BondManager, CandidateGame, ChallengeSubmitError, ChallengeSubmitter,
-    ChallengerMetrics, DisputeIntent, GameCategory, GameScanner, IntermediateValidationParams,
-    L1HeadProvider, OutputValidator, PendingProof, PendingProofs, ProofKind, ProofPhase,
-    ProofUpdate, ValidatorError,
+    AnchorUpdater, BondManager, CandidateGame, ChallengeSubmitter, ChallengerMetrics,
+    DisputeIntent, DisputeProofManager, GameCategory, GameScanner, IntermediateValidationParams,
+    L1HeadProvider, OutputValidator, ValidatorError,
 };
 
-/// Configuration for the challenger [`Driver`].
-#[derive(Debug)]
-pub struct DriverConfig {
+/// Dependencies and runtime settings injected into the [`Driver`].
+pub struct DriverComponents<L2: L2Provider, P: ProofRequesterProvider, T: TxManager> {
+    /// Scans for new dispute games on L1.
+    pub scanner: GameScanner,
+    /// Validates L2 output roots against the local node.
+    pub validator: OutputValidator<L2>,
+    /// Prover-service requester used to generate and poll ZK fault proofs.
+    pub proof_requester: Arc<P>,
+    /// Submits challenge transactions to L1.
+    pub submitter: ChallengeSubmitter<T>,
+    /// Optional L1 head provider for TEE proof requests.
+    pub tee: Option<Arc<dyn L1HeadProvider>>,
+    /// Client for the aggregate verifier contract.
+    pub verifier_client: Arc<dyn AggregateVerifierClient>,
+    /// Bond lifecycle manager (optional; enabled when claim addresses are configured).
+    pub bond_manager: Option<BondManager<TokioRuntime>>,
+    /// Best-effort anchor state updater.
+    pub anchor_updater: AnchorUpdater,
     /// How often the driver polls for new games.
     pub poll_interval: Duration,
     /// Maximum wall-clock time to wait for a ZK proof session before treating it as failed.
@@ -56,52 +48,16 @@ pub struct DriverConfig {
     pub cancel: CancellationToken,
 }
 
-/// TEE proof configuration, bundling the provider and L1 head provider.
-#[derive(Debug)]
-pub struct TeeConfig {
-    /// L1 head provider for fetching the finalized head hash.
-    pub l1_head_provider: Arc<dyn L1HeadProvider>,
-}
-
-/// Service-layer dependencies injected into the [`Driver`].
-pub struct DriverComponents<
-    L2: L2Provider,
-    P: ProofRequesterProvider,
-    T: TxManager,
-    C: Clock = TokioRuntime,
-> {
-    /// Scans for new dispute games on L1.
-    pub scanner: GameScanner,
-    /// Validates L2 output roots against the local node.
-    pub validator: OutputValidator<L2>,
-    /// Prover-service requester used to generate and poll ZK fault proofs.
-    pub proof_requester: Arc<P>,
-    /// Submits challenge transactions to L1.
-    pub submitter: ChallengeSubmitter<T>,
-    /// Optional TEE proof configuration (provider + L1 RPC client).
-    pub tee: Option<TeeConfig>,
-    /// Client for the aggregate verifier contract.
-    pub verifier_client: Arc<dyn AggregateVerifierClient>,
-    /// Bond lifecycle manager (optional; enabled when claim addresses are configured).
-    pub bond_manager: Option<BondManager<C>>,
-    /// Best-effort anchor state updater.
-    pub anchor_updater: AnchorUpdater,
-}
-
-impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> std::fmt::Debug
-    for DriverComponents<L2, P, T, C>
+impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager> std::fmt::Debug
+    for DriverComponents<L2, P, T>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("DriverComponents")
-            .field("scanner", &self.scanner)
-            .field("tee", &self.tee.as_ref().map(|_| ".."))
-            .field("bond_manager", &self.bond_manager.as_ref().map(|_| ".."))
-            .finish_non_exhaustive()
+        f.debug_struct("DriverComponents").finish_non_exhaustive()
     }
 }
 
-/// Orchestrates the challenger pipeline: scan, validate, prove, submit.
-pub struct Driver<L2, P, T, C: Clock = TokioRuntime>
+/// Orchestrates challenger scan, validation, proof, bond, and anchor work.
+pub struct Driver<L2, P, T>
 where
     L2: L2Provider,
     P: ProofRequesterProvider,
@@ -109,113 +65,78 @@ where
 {
     /// Scans for new dispute games on L1.
     pub scanner: GameScanner,
-    /// Validates L2 output roots against the local node.
-    pub validator: OutputValidator<L2>,
-    /// Prover-service requester used to generate and poll ZK fault proofs.
-    pub proof_requester: Arc<P>,
-    /// Submits challenge transactions to L1.
+    /// Submits challenge transactions to L1 and bond/anchor maintenance transactions.
     pub submitter: ChallengeSubmitter<T>,
-    /// Optional TEE proof configuration (provider + L1 RPC client).
-    pub tee: Option<TeeConfig>,
     /// Client for the aggregate verifier contract.
     pub verifier_client: Arc<dyn AggregateVerifierClient>,
-    /// In-flight proof sessions keyed by game address.
-    pub pending_proofs: PendingProofs,
-    /// Games that hit terminal contract reverts and should not be rediscovered.
-    ignored_games: HashSet<Address>,
-    ignored_game_order: VecDeque<Address>,
+    /// Manages proof sessions, retries, submissions, and TEE-to-ZK fallback.
+    pub proof_manager: DisputeProofManager<L2, P>,
     /// Bond lifecycle manager (optional; enabled when claim addresses are configured).
-    pub bond_manager: Option<BondManager<C>>,
+    pub bond_manager: Option<BondManager<TokioRuntime>>,
     /// Best-effort anchor state updater.
     pub anchor_updater: AnchorUpdater,
     /// Interval between polling cycles.
     pub poll_interval: Duration,
-    /// Maximum wall-clock time to wait for a ZK proof session before treating it as failed.
-    pub max_proof_duration: Duration,
-    /// Retryable TEE submission failures to tolerate before falling back to ZK.
-    pub tee_submit_retry_limit: u32,
     /// Token used to signal graceful shutdown.
     pub cancel: CancellationToken,
 }
 
-impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> std::fmt::Debug
-    for Driver<L2, P, T, C>
-{
+impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager> std::fmt::Debug for Driver<L2, P, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Driver")
-            .field("pending_proofs", &self.pending_proofs.len())
-            .field("poll_interval", &self.poll_interval)
-            .field("tee_submit_retry_limit", &self.tee_submit_retry_limit)
-            .finish_non_exhaustive()
+        f.debug_struct("Driver").finish_non_exhaustive()
     }
 }
 
-impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L2, P, T, C> {
-    /// Maximum number of times a failed proof job will be retried before being dropped.
-    pub const MAX_PROOF_RETRIES: u32 = 3;
-
-    /// Maximum number of terminally ignored games retained to avoid rediscovery churn.
-    ///
-    /// Evicted games may be rediscovered by a later scan, then re-ignored after
-    /// one check.
-    pub const MAX_IGNORED_GAMES: usize = 10_000;
-
+impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager> Driver<L2, P, T> {
     /// Creates a new driver with the given components.
-    pub fn new(config: DriverConfig, components: DriverComponents<L2, P, T, C>) -> Self {
+    pub fn new(components: DriverComponents<L2, P, T>) -> Self {
         Self {
             scanner: components.scanner,
-            validator: components.validator,
-            proof_requester: components.proof_requester,
             submitter: components.submitter,
-            tee: components.tee,
+            proof_manager: DisputeProofManager::new(
+                components.validator,
+                components.proof_requester,
+                components.tee,
+                Arc::clone(&components.verifier_client),
+                components.max_proof_duration,
+                components.tee_submit_retry_limit,
+            ),
             verifier_client: components.verifier_client,
-            pending_proofs: PendingProofs::new(),
-            ignored_games: HashSet::new(),
-            ignored_game_order: VecDeque::new(),
             bond_manager: components.bond_manager,
             anchor_updater: components.anchor_updater,
-            poll_interval: config.poll_interval,
-            max_proof_duration: config.max_proof_duration,
-            tee_submit_retry_limit: config.tee_submit_retry_limit,
-            cancel: config.cancel,
+            poll_interval: components.poll_interval,
+            cancel: components.cancel,
         }
     }
 
     /// Runs the main driver loop until the cancellation token is fired.
     pub async fn run(mut self) {
         info!("challenger driver starting");
-        loop {
-            if self.cancel.is_cancelled() {
-                info!("challenger driver shutting down");
-                break;
-            }
-
+        while !self.cancel.is_cancelled() {
             if let Err(e) = self.step().await {
                 warn!(error = %e, "driver step failed");
             }
 
-            ChallengerMetrics::pending_proofs().set(self.pending_proofs.len() as f64);
-            ChallengerMetrics::ignored_games().set(self.ignored_games.len() as f64);
+            ChallengerMetrics::pending_proofs().set(self.proof_manager.pending_proofs_len() as f64);
+            ChallengerMetrics::ignored_games().set(self.proof_manager.ignored_games_len() as f64);
 
             select! {
-                biased;
-                () = self.cancel.cancelled() => {
-                    info!("challenger driver shutting down");
-                    break;
-                }
+                () = self.cancel.cancelled() => break,
                 () = tokio::time::sleep(self.poll_interval) => {}
             }
         }
+        info!("challenger driver shutting down");
     }
 
     /// Executes a single scan-validate-prove-submit cycle.
-    ///
-    /// First polls any in-flight proof sessions that are not in the current
-    /// scan batch, then scans recent games for claimable bonds, polls anchor
-    /// updates, and finally scans for new candidates and processes them.
     pub async fn step(&mut self) -> eyre::Result<()> {
-        self.poll_pending_proofs().await;
-        self.discover_claimable_bonds().await;
+        self.proof_manager.poll_pending_proofs(&self.submitter).await;
+        if let Some(bond_manager) = &mut self.bond_manager
+            && let Err(e) =
+                bond_manager.discover_claimable_games(&*self.verifier_client, &self.submitter).await
+        {
+            warn!(error = %e, "bond discovery scan failed");
+        }
         self.anchor_updater.poll(&*self.verifier_client, &self.submitter).await;
 
         let candidates = self.scanner.scan().await?;
@@ -230,72 +151,44 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
         Ok(())
     }
 
-    /// Scans recent games from scratch and advances ready bond claims.
-    async fn discover_claimable_bonds(&mut self) {
-        let Some(ref mut bond_manager) = self.bond_manager else {
-            return;
-        };
-
-        match bond_manager.discover_claimable_games(&*self.verifier_client, &self.submitter).await {
-            Ok(_) => {}
-            Err(e) => warn!(error = %e, "bond discovery scan failed"),
-        }
-    }
-
-    /// Polls all in-flight proof sessions for completion or retries submission.
-    async fn poll_pending_proofs(&mut self) {
-        let addresses = self.pending_proofs.addresses();
-
-        for game_address in addresses {
-            if let Err(e) = self.poll_or_submit(game_address).await {
-                warn!(
-                    error = %e,
-                    game = %game_address,
-                    "failed to poll/submit pending proof"
-                );
-            }
-        }
-    }
-
-    /// Processes a single candidate game by dispatching to the appropriate
-    /// handler based on the game's [`GameCategory`].
+    /// Processes a candidate game according to its [`GameCategory`].
     async fn process_candidate(&mut self, candidate: CandidateGame) -> eyre::Result<()> {
         let game_address = candidate.factory.proxy;
 
-        if self.ignored_games.contains(&game_address) {
+        if self.proof_manager.is_ignored(game_address) {
             debug!(game = %game_address, "skipping ignored game");
             return Ok(());
         }
 
-        // If this game already has an in-flight proof session, skip it.
-        // Pending proofs are polled separately in `poll_pending_proofs`.
-        if self.pending_proofs.contains_key(&game_address) {
+        if self.proof_manager.has_pending_proof(game_address) {
             debug!(game = %game_address, "skipping game with pending proof session");
             return Ok(());
         }
 
         match candidate.category {
             GameCategory::InvalidTeeProposal => {
-                self.process_invalid_proposal(candidate, DisputeIntent::Challenge).await
+                self.process_invalid_proposal(candidate, DisputeIntent::Challenge, true).await
             }
             GameCategory::FraudulentZkChallenge { challenged_index } => {
                 self.process_fraudulent_zk_challenge(candidate, challenged_index).await
             }
-            GameCategory::InvalidZkProposal | GameCategory::InvalidDualProposal => {
-                self.process_invalid_proposal(candidate, DisputeIntent::Nullify).await
+            GameCategory::InvalidZkProposal => {
+                self.process_invalid_proposal(candidate, DisputeIntent::Nullify, false).await
+            }
+            GameCategory::InvalidDualProposal => {
+                self.process_invalid_proposal(candidate, DisputeIntent::Nullify, true).await
             }
         }
     }
 
     /// Fetches intermediate roots and validates them against the local L2 node.
     ///
-    /// Returns `Ok(Some((result, roots)))` when validation completes, or
-    /// `Ok(None)` when a transient error (e.g. block not yet available) means
-    /// the game should be skipped this tick. Permanent errors are propagated.
+    /// Returns `Ok(Some(result))` when validation completes, or `Ok(None)`
+    /// when a transient error means the game should be retried next tick.
     async fn validate_game(
         &self,
         candidate: &CandidateGame,
-    ) -> eyre::Result<Option<(crate::ValidationResult, Vec<B256>)>> {
+    ) -> eyre::Result<Option<crate::ValidationResult>> {
         let game_address = candidate.factory.proxy;
 
         let intermediate_roots =
@@ -310,63 +203,43 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
             intermediate_roots: &intermediate_roots,
         };
 
-        match self.validator.validate_intermediate_roots(params).await {
-            Ok(result) => Ok(Some((result, intermediate_roots))),
-            Err(e) => {
-                match &e {
-                    // Transient: the L2 node has not produced this block yet.
-                    // Safe to skip — the next scan tick will retry.
-                    ValidatorError::BlockNotAvailable { .. } => {
-                        debug!(
-                            game = %game_address,
-                            error = %e,
-                            "block not yet available, skipping game"
-                        );
-                        Ok(None)
-                    }
-
-                    // Persistent configuration errors: these indicate a
-                    // mismatch between the cached interval and onchain
-                    // state (e.g. after a governance `setImplementation`
-                    // that changed `INTERMEDIATE_BLOCK_INTERVAL`).
-                    // Propagate so the caller logs the error at game level
-                    // and operators are alerted. No log here — the caller
-                    // in `step()` already logs at warn level.
-                    ValidatorError::CheckpointCountMismatch { .. }
-                    | ValidatorError::InvalidInterval
-                    | ValidatorError::InvalidBlockRange { .. } => Err(e.into()),
-
-                    // Other errors (RPC, header hash mismatch, account
-                    // proof failure, arithmetic overflow) are potentially
-                    // transient — skip and retry on the next tick.
-                    _ => {
-                        warn!(
-                            game = %game_address,
-                            error = %e,
-                            "transient validation error, skipping game"
-                        );
-                        Ok(None)
-                    }
+        match self.proof_manager.validator.validate_intermediate_roots(params).await {
+            Ok(result) => Ok(Some(result)),
+            Err(e) => match &e {
+                ValidatorError::BlockNotAvailable { .. } => {
+                    debug!(
+                        game = %game_address,
+                        error = %e,
+                        "block not yet available, skipping game"
+                    );
+                    Ok(None)
                 }
-            }
+                ValidatorError::CheckpointCountMismatch { .. }
+                | ValidatorError::InvalidInterval
+                | ValidatorError::InvalidBlockRange { .. } => Err(e.into()),
+                _ => {
+                    warn!(
+                        game = %game_address,
+                        error = %e,
+                        "transient validation error, skipping game"
+                    );
+                    Ok(None)
+                }
+            },
         }
     }
 
-    /// Processes a game whose proposal may contain an invalid intermediate
-    /// root (Path 1: wrong TEE proof, Path 3: wrong ZK proof, Path 4:
-    /// wrong dual proposal).
-    ///
-    /// Validates the intermediate roots against the local L2 node. If a
-    /// mismatch is found, initiates a proof with the given `intent`.
+    /// Validates an invalid proposal and starts its proof lifecycle.
     async fn process_invalid_proposal(
         &mut self,
         candidate: CandidateGame,
         intent: DisputeIntent,
+        try_tee_first: bool,
     ) -> eyre::Result<()> {
         let game_address = candidate.factory.proxy;
 
         let result = match self.validate_game(&candidate).await? {
-            Some((result, _)) => result,
+            Some(result) => result,
             None => return Ok(()),
         };
 
@@ -389,63 +262,40 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
             "invalid intermediate root detected, requesting proof"
         );
 
-        let try_tee_first = match candidate.category {
-            GameCategory::InvalidTeeProposal => {
-                ChallengerMetrics::invalid_tee_proposal_detected_total().increment(1);
-                true
+        let metric = match intent {
+            DisputeIntent::Challenge => ChallengerMetrics::invalid_tee_proposal_detected_total(),
+            DisputeIntent::Nullify if try_tee_first => {
+                ChallengerMetrics::invalid_dual_proposal_detected_total()
             }
-            GameCategory::InvalidZkProposal => {
-                ChallengerMetrics::invalid_zk_proposal_detected_total().increment(1);
-                false
-            }
-            GameCategory::InvalidDualProposal => {
-                ChallengerMetrics::invalid_dual_proposal_detected_total().increment(1);
-                true
-            }
-            GameCategory::FraudulentZkChallenge { .. } => {
-                error!(
-                    category = ?candidate.category,
-                    game = %game_address,
-                    "unexpected category in process_invalid_proposal"
-                );
-                debug_assert!(
-                    false,
-                    "unexpected category in process_invalid_proposal: {:?}",
-                    candidate.category
-                );
-                return Err(eyre::eyre!(
-                    "unexpected category in process_invalid_proposal: {:?}",
-                    candidate.category
-                ));
-            }
+            DisputeIntent::Nullify => ChallengerMetrics::invalid_zk_proposal_detected_total(),
         };
+        metric.increment(1);
 
-        self.initiate_proof(candidate, invalid_index, expected_root, intent, try_tee_first).await
+        self.proof_manager
+            .initiate_proof(
+                &self.submitter,
+                candidate,
+                invalid_index,
+                expected_root,
+                intent,
+                try_tee_first,
+            )
+            .await
     }
 
-    /// Processes a game whose correct TEE proposal has been challenged with
-    /// a potentially fraudulent ZK proof (Path 2).
-    ///
-    /// Validates the originally proposed root at the challenged index. If the
-    /// original root is correct, the ZK challenge was fraudulent and a ZK
-    /// proof is submitted via `nullify()` to refute it.
+    /// Validates a challenged TEE root and nullifies a fraudulent ZK challenge.
     async fn process_fraudulent_zk_challenge(
         &mut self,
         candidate: CandidateGame,
         challenged_index: u64,
     ) -> eyre::Result<()> {
         let game_address = candidate.factory.proxy;
-
-        // Fetch only the challenged onchain intermediate root (not all roots).
         let on_chain_root =
             self.verifier_client.intermediate_output_root(game_address, challenged_index).await?;
-
-        // Validate only the challenged root — not all intermediate roots.
-        // The checkpoint block for index `i` is:
-        //   starting_block + interval * (i + 1)
         let checkpoint_block = candidate.checkpoint_start_block(challenged_index + 1)?;
 
         let validation = match self
+            .proof_manager
             .validator
             .validate_claimed_root_at_block(game_address, checkpoint_block, on_chain_root)
             .await
@@ -470,8 +320,6 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
             }
         };
 
-        // If the onchain root at the challenged index does not match the
-        // locally computed root, the ZK challenge was legitimate — skip.
         if !validation.is_valid {
             debug!(
                 game = %game_address,
@@ -489,922 +337,16 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager, C: Clock> Driver<L
             on_chain_root = %on_chain_root,
             "fraudulent ZK challenge detected, nullifying with ZK proof"
         );
-
         ChallengerMetrics::fraudulent_zk_challenge_detected_total().increment(1);
 
-        self.initiate_zk_proof(
-            candidate,
-            challenged_index,
-            validation.expected_root,
-            DisputeIntent::Nullify,
-        )
-        .await
-    }
-
-    /// Attempts TEE-first proof sourcing with ZK fallback.
-    ///
-    /// The `intent` determines the onchain action for the ZK fallback path.
-    /// TEE proofs always use `nullify()` regardless of `intent`.
-    ///
-    /// When `try_tee_first` is `true` and the game has a non-zero TEE prover,
-    /// a synchronous TEE proof is attempted before falling back to ZK.
-    /// Path 1 (`InvalidTeeProposal`) sets `try_tee_first = true` with
-    /// `intent = Challenge`; Path 4 (`InvalidDualProposal`) sets
-    /// `try_tee_first = true` with `intent = Nullify` so the ZK fallback
-    /// also calls `nullify()`.
-    async fn initiate_proof(
-        &mut self,
-        candidate: CandidateGame,
-        invalid_index: u64,
-        expected_root: B256,
-        intent: DisputeIntent,
-        try_tee_first: bool,
-    ) -> eyre::Result<()> {
-        let game_address = candidate.factory.proxy;
-
-        // TEE-first: try if the game has a TEE prover, we have a TEE config,
-        // and the caller opted in. Path 1 (InvalidTeeProposal) and Path 4
-        // (InvalidDualProposal) set `try_tee_first = true`.
-        if candidate.tee_prover != Address::ZERO
-            && try_tee_first
-            && let Some(tee) = &self.tee
-        {
-            ChallengerMetrics::tee_proof_attempts_total().increment(1);
-            match self.build_tee_request(&candidate, invalid_index, expected_root, tee).await {
-                Ok(tee_request) => {
-                    let (zk_fallback_request, zk_fallback_intent) =
-                        match self.build_zk_request(&candidate, invalid_index) {
-                            Ok(req) => (Some(req), Some(intent)),
-                            Err(e) => {
-                                warn!(
-                                    error = %e,
-                                    game = %game_address,
-                                    "failed to build ZK fallback request; \
-                                     TEE proof will have no ZK fallback"
-                                );
-                                (None, None)
-                            }
-                        };
-
-                    let request = crate::ChallengerProofAdapter::tee_prove_block_range_request(
-                        game_address,
-                        invalid_index,
-                        tee_request,
-                        TeeKind::AwsNitro,
-                    );
-                    match self.proof_requester.prove_block_range(request).await {
-                        Ok(response) => {
-                            info!(
-                                game = %game_address,
-                                session_id = %response.session_id,
-                                path = "tee",
-                                "TEE proof job initiated"
-                            );
-                            self.pending_proofs.insert(
-                                game_address,
-                                PendingProof::awaiting_tee(
-                                    response.session_id,
-                                    invalid_index,
-                                    expected_root,
-                                    zk_fallback_request,
-                                    zk_fallback_intent,
-                                ),
-                            );
-                            return Ok(());
-                        }
-                        Err(e) => {
-                            warn!(
-                                error = %e,
-                                game = %game_address,
-                                "TEE proof request failed, falling back to ZK"
-                            );
-                        }
-                    }
-                }
-                Err(e) => {
-                    warn!(
-                        error = %e,
-                        game = %game_address,
-                        "failed to build TEE proof request, falling back to ZK"
-                    );
-                }
-            }
-            ChallengerMetrics::tee_proof_fallback_total().increment(1);
-        }
-
-        // ZK fallback (or direct ZK if no TEE prover / intent is Nullify).
-        self.initiate_zk_proof(candidate, invalid_index, expected_root, intent).await
-    }
-
-    /// Builds a TEE proof request for the given candidate game.
-    async fn build_tee_request(
-        &self,
-        candidate: &CandidateGame,
-        invalid_index: u64,
-        expected_root: B256,
-        tee: &TeeConfig,
-    ) -> eyre::Result<TeeProofRequest> {
-        let start_block_number = candidate.checkpoint_start_block(invalid_index)?;
-
-        let claimed_l2_block_number = start_block_number
-            .checked_add(candidate.intermediate_block_interval)
-            .ok_or_else(|| eyre::eyre!("claimed_l2_block_number overflow"))?;
-
-        // Use the game's stored L1 head (from CWIA) so the enclave signs a
-        // journal whose `l1OriginHash` matches what the onchain `nullify()`
-        // will use for verification. Look up its block number concurrently
-        // with the agreed L2 state computation.
-        let l1_head = candidate.l1_head;
-        let (l1_head_number_result, output_root_result) = tokio::join!(
-            tee.l1_head_provider.block_number_by_hash(l1_head),
-            self.validator.compute_output_root_with_hash(start_block_number),
-        );
-        let l1_head_number = l1_head_number_result?;
-        let (agreed_l2_head_hash, agreed_l2_output_root) = output_root_result?;
-
-        Ok(TeeProofRequest {
-            l1_head,
-            agreed_l2_head_hash,
-            agreed_l2_output_root,
-            claimed_l2_output_root: expected_root,
-            claimed_l2_block_number,
-            proposer: self.submitter.sender_address(),
-            intermediate_block_interval: candidate.intermediate_block_interval,
-            l1_head_number,
-            ..Default::default()
-        })
-    }
-
-    /// Builds a [`SnarkPlonkProofRequest`] for the given candidate and invalid index.
-    fn build_zk_request(
-        &self,
-        candidate: &CandidateGame,
-        invalid_index: u64,
-    ) -> eyre::Result<SnarkPlonkProofRequest> {
-        let start_block_number = candidate.checkpoint_start_block(invalid_index)?;
-
-        Ok(SnarkPlonkProofRequest {
-            proof: ZkProofRequest {
-                start_block_number,
-                number_of_blocks_to_prove: candidate.intermediate_block_interval,
-                sequence_window: None,
-                l1_head: Some(candidate.l1_head),
-                intermediate_root_interval: Some(candidate.intermediate_block_interval),
-                zk_vm: ZkVm::Sp1,
-                zk_backend: ZkBackend::Cluster,
-            },
-            prover_address: self.submitter.sender_address(),
-        })
-    }
-
-    /// Requests a ZK proof, stores the session, and polls for the result.
-    async fn initiate_zk_proof(
-        &mut self,
-        candidate: CandidateGame,
-        invalid_index: u64,
-        expected_root: B256,
-        intent: DisputeIntent,
-    ) -> eyre::Result<()> {
-        let game_address = candidate.factory.proxy;
-
-        // The prior intermediate root (or the game's starting root when
-        // invalid_index == 0) is a trusted anchor, so the ZK proof only
-        // needs to cover the single interval that contains the invalid
-        // checkpoint: [prior_checkpoint .. invalid_checkpoint].
-        let proof_request = self.build_zk_request(&candidate, invalid_index)?;
-        let request = crate::ChallengerProofAdapter::snark_plonk_prove_block_range_request(
-            game_address,
-            invalid_index,
-            proof_request.clone(),
-        );
-
-        let prove_response = self.proof_requester.prove_block_range(request).await?;
-
-        info!(
-            game = %game_address,
-            session_id = %prove_response.session_id,
-            "proof job initiated"
-        );
-
-        let pending = PendingProof::awaiting(
-            prove_response.session_id,
-            invalid_index,
-            expected_root,
-            proof_request,
-            intent,
-        );
-        self.pending_proofs.insert(game_address, pending);
-
-        Ok(())
-    }
-
-    /// Advances a pending proof through its lifecycle.
-    ///
-    /// - **`AwaitingProof`** — polls prover service:
-    ///   - `Succeeded` → transitions to `ReadyToSubmit` and falls through to
-    ///     submission.
-    ///   - `Failed` → transitions to `NeedsRetry` so `proveBlockRange` is
-    ///     re-initiated.
-    ///   - Intermediate (`Queued`/`Running`) → returns early
-    ///     without any contract calls.
-    /// - **`ReadyToSubmit`** — submits the dispute tx based on the entry's
-    ///   [`DisputeIntent`]:
-    ///   - [`DisputeIntent::Nullify`] → calls `nullify()`.
-    ///   - [`DisputeIntent::Challenge`] → calls `challenge()`.
-    ///   - On success → removes the entry.
-    ///   - On failure → leaves the entry so it is retried next tick.
-    /// - **`NeedsRetry`** — re-initiates `proveBlockRange`:
-    ///   - If `retry_count > MAX_PROOF_RETRIES` → drops the entry.
-    ///   - Otherwise → calls `proveBlockRange` and transitions to `AwaitingProof`.
-    async fn poll_or_submit(&mut self, game_address: Address) -> eyre::Result<()> {
-        let (invalid_index, expected_root, intent, targets_tee, was_awaiting) =
-            match self.pending_proofs.get(&game_address) {
-                Some(p) => (
-                    p.invalid_index,
-                    p.expected_root,
-                    p.intent,
-                    p.kind.is_tee(),
-                    matches!(p.phase, ProofPhase::AwaitingProof { .. }),
-                ),
-                None => return Ok(()),
-            };
-
-        // Poll proof status first — if still pending, skip the contract
-        // calls that check game liveness. This avoids 3 RPC round-trips
-        // per tick for proofs that are not yet ready.
-        let proof_update = self
-            .pending_proofs
-            .poll(game_address, &*self.proof_requester, self.max_proof_duration)
-            .await?;
-        match &proof_update {
-            Some(ProofUpdate::Pending) => {
-                debug!(game = %game_address, "proof not ready, will retry next tick");
-                return Ok(());
-            }
-            None => return Ok(()),
-            _ => {}
-        }
-
-        // The proof is ready or needs retry — verify the game is still
-        // actionable before doing any work.
-        let (status, tee_prover, zk_prover) = tokio::try_join!(
-            self.verifier_client.status(game_address),
-            self.verifier_client.tee_prover(game_address),
-            self.verifier_client.zk_prover(game_address),
-        )?;
-
-        if status != GameStatus::InProgress {
-            debug!(game = %game_address, status = ?status, "game no longer in progress, dropping pending proof");
-            self.pending_proofs.remove(&game_address);
-            return Ok(());
-        }
-
-        // Nullification zeroes only the targeted prover (TEE or ZK) but
-        // does NOT change the game status (it stays IN_PROGRESS), so
-        // checking status alone would cause infinite retries. Check the
-        // relevant prover slot to detect prior resolution.
-        let already_resolved = match intent {
-            DisputeIntent::Challenge => zk_prover != Address::ZERO || tee_prover == Address::ZERO,
-            DisputeIntent::Nullify => {
-                if targets_tee {
-                    tee_prover == Address::ZERO
-                } else {
-                    zk_prover == Address::ZERO
-                }
-            }
-        };
-
-        if already_resolved {
-            debug!(
-                game = %game_address,
-                intent = ?intent,
-                tee_prover = %tee_prover,
-                zk_prover = %zk_prover,
-                "game already resolved, dropping pending proof"
-            );
-            self.pending_proofs.remove(&game_address);
-            return Ok(());
-        }
-
-        // Dispatch based on proof status.
-        let proof_bytes = match proof_update {
-            Some(ProofUpdate::Ready(proof_bytes)) => {
-                info!(
-                    game = %game_address,
-                    proof_len = proof_bytes.len(),
-                    action = intent.label(),
-                    "proof ready, submitting dispute transaction"
-                );
-                if targets_tee && was_awaiting {
-                    ChallengerMetrics::tee_proof_obtained_total().increment(1);
-                }
-                proof_bytes
-            }
-            Some(ProofUpdate::NeedsRetry) => {
-                return self.handle_proof_retry(game_address).await;
-            }
-            // Pending and None already handled above.
-            Some(ProofUpdate::Pending) | None => unreachable!("handled above"),
-        };
-
-        let result = self
-            .submitter
-            .submit_dispute(game_address, proof_bytes, invalid_index, expected_root, intent)
-            .await;
-        match result {
-            Ok(_) => {
-                self.pending_proofs.remove(&game_address);
-            }
-            Err(e) => {
-                let known_revert = match &e {
-                    ChallengeSubmitError::KnownRevert(revert) => Some(*revert),
-                    ChallengeSubmitError::TxReverted { .. }
-                    | ChallengeSubmitError::TxManager(_) => None,
-                };
-
-                match known_revert {
-                    Some(KnownRevert::GameAlreadyExists) => {
-                        info!(
-                            error = %e,
-                            game = %game_address,
-                            "dispute game already exists, dropping pending proof"
-                        );
-                        self.pending_proofs.remove(&game_address);
-                        return Ok(());
-                    }
-                    Some(KnownRevert::ProofAlreadyVerified) => {
-                        info!(
-                            error = %e,
-                            game = %game_address,
-                            "dispute proof already verified onchain, dropping pending proof"
-                        );
-                        self.pending_proofs.remove(&game_address);
-                        return Ok(());
-                    }
-                    Some(KnownRevert::InvalidParentGame) => {
-                        warn!(
-                            error = %e,
-                            game = %game_address,
-                            "dispute game parent is invalid onchain, ignoring game"
-                        );
-                        self.ignore_game(game_address);
-                        return Ok(());
-                    }
-                    Some(KnownRevert::L1OriginTooOld) => {
-                        warn!(
-                            error = %e,
-                            game = %game_address,
-                            "dispute proof L1 origin is too old, ignoring game"
-                        );
-                        self.ignore_game(game_address);
-                        return Ok(());
-                    }
-                    Some(KnownRevert::InvalidSigner) if !targets_tee => {
-                        warn!(
-                            error = %e,
-                            game = %game_address,
-                            "dispute proof signer is invalid onchain, dropping pending proof"
-                        );
-                        self.pending_proofs.remove(&game_address);
-                        return Ok(());
-                    }
-                    _ if targets_tee && Self::should_fallback_from_tee_submit(&e) => {
-                        warn!(
-                            error = %e,
-                            game = %game_address,
-                            "TEE dispute tx failed, falling back to ZK"
-                        );
-                    }
-                    _ if targets_tee => {
-                        let Some(pending) = self.pending_proofs.get_mut(&game_address) else {
-                            return Ok(());
-                        };
-                        let has_zk_fallback = pending.kind.has_zk_fallback();
-
-                        if pending.tee_submit_retry_count >= self.tee_submit_retry_limit {
-                            warn!(
-                                error = %e,
-                                game = %game_address,
-                                retry_count = pending.tee_submit_retry_count,
-                                retry_limit = self.tee_submit_retry_limit,
-                                has_zk_fallback,
-                                "TEE dispute tx retry limit reached"
-                            );
-                            pending.phase = ProofPhase::NeedsRetry;
-                            return self.handle_proof_retry(game_address).await;
-                        }
-
-                        pending.tee_submit_retry_count =
-                            pending.tee_submit_retry_count.saturating_add(1);
-                        warn!(
-                            error = %e,
-                            game = %game_address,
-                            retry_count = pending.tee_submit_retry_count,
-                            retry_limit = self.tee_submit_retry_limit,
-                            has_zk_fallback,
-                            "TEE dispute tx failed, will retry next tick"
-                        );
-                        return Ok(());
-                    }
-                    _ => {
-                        warn!(
-                            error = %e,
-                            game = %game_address,
-                            "dispute tx failed, will retry next tick"
-                        );
-                        return Ok(());
-                    }
-                }
-
-                if let Some(p) = self.pending_proofs.get_mut(&game_address) {
-                    // Don't retry the failed TEE submission — switch to the ZK
-                    // fallback so the next retry uses the pre-built ZK request.
-                    p.phase = ProofPhase::NeedsRetry;
-                    return self.handle_proof_retry(game_address).await;
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    const fn should_fallback_from_tee_submit(error: &ChallengeSubmitError) -> bool {
-        matches!(
-            error,
-            ChallengeSubmitError::KnownRevert(KnownRevert::InvalidSigner)
-                | ChallengeSubmitError::TxReverted { .. }
-                | ChallengeSubmitError::TxManager(TxManagerError::ExecutionReverted { .. })
-        )
-    }
-
-    fn ignore_game(&mut self, game_address: Address) {
-        self.pending_proofs.remove(&game_address);
-        if self.ignored_games.insert(game_address) {
-            self.ignored_game_order.push_back(game_address);
-        }
-        while self.ignored_games.len() > Self::MAX_IGNORED_GAMES {
-            if let Some(game_address) = self.ignored_game_order.pop_front() {
-                self.ignored_games.remove(&game_address);
-            }
-        }
-        ChallengerMetrics::ignored_games().set(self.ignored_games.len() as f64);
-    }
-
-    /// Handles a proof that needs retrying after failure.
-    ///
-    /// If retries are exhausted the entry is dropped; otherwise `proveBlockRange`
-    /// is called and the phase transitions back to `AwaitingProof`.
-    async fn handle_proof_retry(&mut self, game_address: Address) -> eyre::Result<()> {
-        let pending = match self.pending_proofs.get(&game_address) {
-            Some(p) => p,
-            None => return Ok(()),
-        };
-
-        let retry_count = pending.retry_count;
-        let invalid_index = pending.invalid_index;
-
-        if retry_count > Self::MAX_PROOF_RETRIES {
-            warn!(
-                game = %game_address,
-                retry_count = retry_count,
-                "proof retries exhausted, dropping entry"
-            );
-            ChallengerMetrics::proof_retries_exhausted_total().increment(1);
-            self.pending_proofs.remove(&game_address);
-            return Ok(());
-        }
-
-        // If this was a TEE proof, eagerly transition to ZK *before*
-        // calling `proveBlockRange` so that subsequent retries take the ZK branch
-        // and the fallback metric is emitted exactly once per transition.
-        let request = match &pending.kind {
-            ProofKind::Tee { zk_fallback_request, zk_fallback_intent } => {
-                let (Some(fallback_request), Some(fallback_intent)) =
-                    (zk_fallback_request.clone(), *zk_fallback_intent)
-                else {
-                    // No ZK fallback available — nothing more we can do.
-                    debug!(
-                        game = %game_address,
-                        "TEE proof has no ZK fallback request, dropping entry"
-                    );
-                    self.pending_proofs.remove(&game_address);
-                    return Ok(());
-                };
-
-                debug!(game = %game_address, "TEE proof needs retry, falling back to ZK");
-                ChallengerMetrics::tee_proof_fallback_total().increment(1);
-
-                // Transition eagerly so retries use the ZK path.
-                if let Some(p) = self.pending_proofs.get_mut(&game_address) {
-                    p.kind = ProofKind::Zk { prove_request: fallback_request.clone() };
-                    p.intent = fallback_intent;
-                    p.retry_count = 0;
-                    p.tee_submit_retry_count = 0;
-                }
-
-                fallback_request
-            }
-            ProofKind::Zk { prove_request } => prove_request.clone(),
-        };
-
-        ChallengerMetrics::proof_retries_total().increment(1);
-
-        let prove_request = crate::ChallengerProofAdapter::snark_plonk_prove_block_range_request(
-            game_address,
-            invalid_index,
-            request,
-        );
-
-        match self.proof_requester.prove_block_range(prove_request).await {
-            Ok(response) => {
-                info!(
-                    game = %game_address,
-                    session_id = %response.session_id,
-                    retry_count = retry_count,
-                    "proof job re-initiated"
-                );
-                if let Some(p) = self.pending_proofs.get_mut(&game_address) {
-                    p.phase = ProofPhase::AwaitingProof {
-                        session_id: response.session_id,
-                        started_at: Instant::now(),
-                    };
-                }
-            }
-            Err(e) => {
-                if let Some(p) = self.pending_proofs.get_mut(&game_address) {
-                    p.retry_count += 1;
-                }
-                warn!(
-                    error = %e,
-                    game = %game_address,
-                    retry_count = retry_count,
-                    "proveBlockRange failed on retry, will retry next tick"
-                );
-                // Leave as NeedsRetry for next tick.
-            }
-        }
-
-        Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::{collections::HashMap, sync::Arc, time::Duration};
-
-    use alloy_primitives::{Address, B256, Bytes};
-    use base_proof_contracts::l1_origin_too_old_selector;
-    use base_prover_service_protocol::{SnarkPlonkProofRequest, ZkProofRequest, ZkVm};
-    use base_tx_manager::TxManagerError;
-    use tokio_util::sync::CancellationToken;
-
-    use super::*;
-    use crate::test_utils::{
-        MockAggregateVerifier, MockDisputeGameFactory, MockL2Provider, MockTxManager,
-        MockZkProofProvider, addr, factory_game, mock_anchor_registry, mock_state,
-        receipt_with_status,
-    };
-
-    fn proof_request() -> SnarkPlonkProofRequest {
-        SnarkPlonkProofRequest {
-            proof: ZkProofRequest {
-                start_block_number: 100,
-                number_of_blocks_to_prove: 10,
-                sequence_window: None,
-                l1_head: Some(B256::repeat_byte(0xAA)),
-                intermediate_root_interval: Some(10),
-                zk_vm: ZkVm::Sp1,
-                zk_backend: ZkBackend::Cluster,
-            },
-            prover_address: Address::repeat_byte(0xCC),
-        }
-    }
-
-    fn driver_with_tx_error(
-        err: TxManagerError,
-    ) -> (Driver<MockL2Provider, MockZkProofProvider, MockTxManager>, Arc<MockZkProofProvider>)
-    {
-        driver_with_tx_manager(MockTxManager::new(Err(err)))
-    }
-
-    fn driver_with_tx_manager(
-        tx_manager: MockTxManager,
-    ) -> (Driver<MockL2Provider, MockZkProofProvider, MockTxManager>, Arc<MockZkProofProvider>)
-    {
-        let game_address = addr(0);
-        let mut verifier_games = HashMap::new();
-        verifier_games.insert(game_address, mock_state(GameStatus::InProgress, Address::ZERO, 100));
-        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-        let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
-        let anchor_registry = mock_anchor_registry(Address::ZERO);
-        let scanner = GameScanner::new(
-            Arc::clone(&factory) as Arc<dyn base_proof_contracts::DisputeGameFactoryClient>,
-            Arc::clone(&verifier) as Arc<dyn AggregateVerifierClient>,
-            Arc::clone(&anchor_registry),
-        );
-        let proof_requester = Arc::new(MockZkProofProvider::default());
-        let l2_provider = Arc::new(MockL2Provider::new());
-        let components = DriverComponents {
-            scanner,
-            validator: OutputValidator::new(Arc::clone(&l2_provider)),
-            proof_requester: Arc::clone(&proof_requester),
-            submitter: ChallengeSubmitter::new(tx_manager),
-            tee: None,
-            verifier_client: verifier,
-            bond_manager: None,
-            anchor_updater: AnchorUpdater::new(
-                factory,
-                anchor_registry,
-                l2_provider,
-                Address::repeat_byte(0xAA),
-                1,
-                100,
-                100,
-            ),
-        };
-        let driver = Driver::new(
-            DriverConfig {
-                poll_interval: Duration::from_millis(10),
-                max_proof_duration: Duration::from_secs(60),
-                tee_submit_retry_limit: 3,
-                cancel: CancellationToken::new(),
-            },
-            components,
-        );
-
-        (driver, proof_requester)
-    }
-
-    fn insert_ready_proof(driver: &mut Driver<MockL2Provider, MockZkProofProvider, MockTxManager>) {
-        let game_address = addr(0);
-        driver.pending_proofs.insert(
-            game_address,
-            PendingProof::ready(
-                Bytes::from(vec![0x01, 0xAA]),
-                0,
-                B256::repeat_byte(0x22),
-                proof_request(),
-                DisputeIntent::Challenge,
-            ),
-        );
-    }
-
-    fn insert_ready_tee_proof(
-        driver: &mut Driver<MockL2Provider, MockZkProofProvider, MockTxManager>,
-    ) {
-        let game_address = addr(0);
-        driver.pending_proofs.insert(
-            game_address,
-            PendingProof {
-                phase: ProofPhase::ReadyToSubmit { proof_bytes: Bytes::from(vec![0x00, 0xAA]) },
-                kind: ProofKind::Tee {
-                    zk_fallback_request: Some(proof_request()),
-                    zk_fallback_intent: Some(DisputeIntent::Nullify),
-                },
-                invalid_index: 0,
-                expected_root: B256::repeat_byte(0x22),
-                retry_count: 0,
-                tee_submit_retry_count: 0,
-                intent: DisputeIntent::Nullify,
-            },
-        );
-    }
-
-    fn insert_ready_tee_proof_without_fallback(
-        driver: &mut Driver<MockL2Provider, MockZkProofProvider, MockTxManager>,
-    ) {
-        let game_address = addr(0);
-        driver.pending_proofs.insert(
-            game_address,
-            PendingProof {
-                phase: ProofPhase::ReadyToSubmit { proof_bytes: Bytes::from(vec![0x00, 0xAA]) },
-                kind: ProofKind::Tee { zk_fallback_request: None, zk_fallback_intent: None },
-                invalid_index: 0,
-                expected_root: B256::repeat_byte(0x22),
-                retry_count: 0,
-                tee_submit_retry_count: 0,
-                intent: DisputeIntent::Nullify,
-            },
-        );
-    }
-
-    fn candidate() -> CandidateGame {
-        let state = mock_state(GameStatus::InProgress, Address::ZERO, 100);
-        CandidateGame {
-            index: 0,
-            factory: factory_game(0, 1),
-            info: state.game_info,
-            starting_block_number: state.starting_block_number,
-            intermediate_block_interval: 10,
-            l1_head: state.l1_head,
-            tee_prover: state.tee_prover,
-            category: GameCategory::InvalidZkProposal,
-        }
-    }
-
-    fn assert_ready_tee_proof(driver: &Driver<MockL2Provider, MockZkProofProvider, MockTxManager>) {
-        let pending = driver.pending_proofs.get(&addr(0)).expect("pending proof should remain");
-        assert!(matches!(pending.phase, ProofPhase::ReadyToSubmit { .. }));
-        assert!(pending.kind.is_tee());
-    }
-
-    fn assert_zk_fallback_requested(
-        driver: &Driver<MockL2Provider, MockZkProofProvider, MockTxManager>,
-        proof_requester: &MockZkProofProvider,
-    ) {
-        let pending = driver.pending_proofs.get(&addr(0)).expect("pending proof should remain");
-        assert!(matches!(pending.phase, ProofPhase::AwaitingProof { .. }));
-        assert!(!pending.kind.is_tee());
-        let state = proof_requester.state.lock().unwrap();
-        assert_eq!(state.prove_block_range_log.len(), 1);
-    }
-
-    #[tokio::test]
-    async fn proof_already_verified_revert_drops_pending_proof() {
-        let (mut driver, _proof_requester) =
-            driver_with_tx_error(TxManagerError::ExecutionReverted {
-                reason: Some("AlreadyProven(1)".to_string()),
-                data: None,
-            });
-        insert_ready_proof(&mut driver);
-
-        driver.poll_or_submit(addr(0)).await.unwrap();
-
-        assert!(!driver.pending_proofs.contains_key(&addr(0)));
-    }
-
-    #[tokio::test]
-    async fn game_already_exists_revert_drops_pending_proof() {
-        let (mut driver, _proof_requester) =
-            driver_with_tx_error(TxManagerError::ExecutionReverted {
-                reason: Some("GameAlreadyExists(0x00)".to_string()),
-                data: None,
-            });
-        insert_ready_proof(&mut driver);
-
-        driver.poll_or_submit(addr(0)).await.unwrap();
-
-        assert!(!driver.pending_proofs.contains_key(&addr(0)));
-    }
-
-    #[tokio::test]
-    async fn challenge_success_does_not_track_anchor_update() {
-        let tx_hash = B256::repeat_byte(0x44);
-        let (mut driver, _proof_requester) =
-            driver_with_tx_manager(MockTxManager::new(Ok(receipt_with_status(true, tx_hash))));
-        insert_ready_proof(&mut driver);
-
-        driver.poll_or_submit(addr(0)).await.unwrap();
-
-        assert!(!driver.pending_proofs.contains_key(&addr(0)));
-    }
-
-    #[tokio::test]
-    async fn stale_l1_origin_revert_drops_pending_zk_proof() {
-        let (mut driver, proof_requester) =
-            driver_with_tx_error(TxManagerError::ExecutionReverted {
-                reason: None,
-                data: Some(Bytes::from(l1_origin_too_old_selector().to_vec())),
-            });
-        insert_ready_proof(&mut driver);
-
-        driver.poll_or_submit(addr(0)).await.unwrap();
-
-        assert!(!driver.pending_proofs.contains_key(&addr(0)));
-        assert!(driver.ignored_games.contains(&addr(0)));
-        let state = proof_requester.state.lock().unwrap();
-        assert!(state.prove_block_range_log.is_empty());
-    }
-
-    #[tokio::test]
-    async fn stale_l1_origin_revert_drops_pending_tee_proof_without_requesting_zk() {
-        let (mut driver, proof_requester) =
-            driver_with_tx_error(TxManagerError::ExecutionReverted {
-                reason: None,
-                data: Some(Bytes::from(l1_origin_too_old_selector().to_vec())),
-            });
-        insert_ready_tee_proof(&mut driver);
-
-        driver.poll_or_submit(addr(0)).await.unwrap();
-
-        assert!(!driver.pending_proofs.contains_key(&addr(0)));
-        assert!(driver.ignored_games.contains(&addr(0)));
-        let state = proof_requester.state.lock().unwrap();
-        assert!(state.prove_block_range_log.is_empty());
-    }
-
-    #[test]
-    fn ignored_games_are_bounded() {
-        let (mut driver, _proof_requester) =
-            driver_with_tx_manager(MockTxManager::new(Ok(receipt_with_status(true, B256::ZERO))));
-        let max = Driver::<MockL2Provider, MockZkProofProvider, MockTxManager>::MAX_IGNORED_GAMES;
-
-        for i in 0..=max {
-            driver.ignore_game(addr(i as u64));
-        }
-
-        assert_eq!(driver.ignored_games.len(), max);
-        assert!(!driver.ignored_games.contains(&addr(0)));
-        assert!(driver.ignored_games.contains(&addr(max as u64)));
-    }
-
-    #[tokio::test]
-    async fn tee_submit_nonce_too_low_keeps_ready_proof_without_requesting_zk() {
-        let (mut driver, proof_requester) = driver_with_tx_error(TxManagerError::NonceTooLow);
-        insert_ready_tee_proof(&mut driver);
-
-        driver.poll_or_submit(addr(0)).await.unwrap();
-
-        assert_ready_tee_proof(&driver);
-        let pending = driver.pending_proofs.get(&addr(0)).expect("pending proof should remain");
-        assert_eq!(pending.tee_submit_retry_count, 1);
-        let state = proof_requester.state.lock().unwrap();
-        assert!(state.prove_block_range_log.is_empty());
-    }
-
-    #[tokio::test]
-    async fn tee_submit_retry_limit_falls_back_to_zk() {
-        let (mut driver, proof_requester) =
-            driver_with_tx_manager(MockTxManager::with_responses(vec![
-                Err(TxManagerError::NonceTooLow),
-                Err(TxManagerError::NonceTooLow),
-            ]));
-        driver.tee_submit_retry_limit = 1;
-        insert_ready_tee_proof(&mut driver);
-
-        driver.poll_or_submit(addr(0)).await.unwrap();
-
-        assert_ready_tee_proof(&driver);
-        {
-            let state = proof_requester.state.lock().unwrap();
-            assert!(state.prove_block_range_log.is_empty());
-        }
-
-        driver.poll_or_submit(addr(0)).await.unwrap();
-
-        assert_zk_fallback_requested(&driver, &proof_requester);
-    }
-
-    #[tokio::test]
-    async fn tee_submit_retry_limit_drops_proof_without_zk_fallback() {
-        let (mut driver, proof_requester) =
-            driver_with_tx_manager(MockTxManager::with_responses(vec![
-                Err(TxManagerError::NonceTooLow),
-                Err(TxManagerError::NonceTooLow),
-            ]));
-        driver.tee_submit_retry_limit = 1;
-        insert_ready_tee_proof_without_fallback(&mut driver);
-
-        driver.poll_or_submit(addr(0)).await.unwrap();
-
-        assert_ready_tee_proof(&driver);
-
-        driver.poll_or_submit(addr(0)).await.unwrap();
-
-        assert!(!driver.pending_proofs.contains_key(&addr(0)));
-        let state = proof_requester.state.lock().unwrap();
-        assert!(state.prove_block_range_log.is_empty());
-    }
-
-    #[tokio::test]
-    async fn tee_invalid_signer_revert_falls_back_to_zk() {
-        let (mut driver, proof_requester) =
-            driver_with_tx_error(TxManagerError::ExecutionReverted {
-                reason: Some("InvalidSigner()".to_string()),
-                data: None,
-            });
-        insert_ready_tee_proof(&mut driver);
-
-        driver.poll_or_submit(addr(0)).await.unwrap();
-
-        assert_zk_fallback_requested(&driver, &proof_requester);
-    }
-
-    #[tokio::test]
-    async fn tee_mined_tx_revert_falls_back_to_zk() {
-        let tx_hash = B256::repeat_byte(0x44);
-        let (mut driver, proof_requester) =
-            driver_with_tx_manager(MockTxManager::new(Ok(receipt_with_status(false, tx_hash))));
-        insert_ready_tee_proof(&mut driver);
-
-        driver.poll_or_submit(addr(0)).await.unwrap();
-
-        assert_zk_fallback_requested(&driver, &proof_requester);
-    }
-
-    #[tokio::test]
-    async fn ignored_game_is_not_reprocessed_from_scan() {
-        let (mut driver, proof_requester) =
-            driver_with_tx_error(TxManagerError::ExecutionReverted {
-                reason: None,
-                data: Some(Bytes::from(l1_origin_too_old_selector().to_vec())),
-            });
-        insert_ready_proof(&mut driver);
-
-        driver.poll_or_submit(addr(0)).await.unwrap();
-        driver.process_candidate(candidate()).await.unwrap();
-
-        let state = proof_requester.state.lock().unwrap();
-        assert!(state.prove_block_range_log.is_empty());
+        self.proof_manager
+            .initiate_zk_proof(
+                &self.submitter,
+                candidate,
+                challenged_index,
+                validation.expected_root,
+                DisputeIntent::Nullify,
+            )
+            .await
     }
 }

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -203,7 +203,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager> Driver<L2, P, T> {
             intermediate_roots: &intermediate_roots,
         };
 
-        match self.proof_manager.validator.validate_intermediate_roots(params).await {
+        match self.proof_manager.validate_intermediate_roots(params).await {
             Ok(result) => Ok(Some(result)),
             Err(e) => match &e {
                 ValidatorError::BlockNotAvailable { .. } => {
@@ -296,7 +296,6 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager> Driver<L2, P, T> {
 
         let validation = match self
             .proof_manager
-            .validator
             .validate_claimed_root_at_block(game_address, checkpoint_block, on_chain_root)
             .await
         {

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -12,7 +12,7 @@ use base_runtime::TokioRuntime;
 use base_tx_manager::TxManager;
 use tokio::select;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     AnchorUpdater, BondManager, CandidateGame, ChallengeSubmitter, ChallengerMetrics,
@@ -262,18 +262,38 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager> Driver<L2, P, T> {
             "invalid intermediate root detected, requesting proof"
         );
 
-        let metric = match intent {
-            DisputeIntent::Challenge => ChallengerMetrics::invalid_tee_proposal_detected_total(),
-            DisputeIntent::Nullify if try_tee_first => {
+        let metric = match &candidate.category {
+            GameCategory::InvalidTeeProposal => {
+                ChallengerMetrics::invalid_tee_proposal_detected_total()
+            }
+            GameCategory::InvalidZkProposal => {
+                ChallengerMetrics::invalid_zk_proposal_detected_total()
+            }
+            GameCategory::InvalidDualProposal => {
                 ChallengerMetrics::invalid_dual_proposal_detected_total()
             }
-            DisputeIntent::Nullify => ChallengerMetrics::invalid_zk_proposal_detected_total(),
+            GameCategory::FraudulentZkChallenge { .. } => {
+                error!(
+                    category = ?candidate.category,
+                    game = %game_address,
+                    "unexpected category in process_invalid_proposal"
+                );
+                debug_assert!(
+                    false,
+                    "unexpected category in process_invalid_proposal: {:?}",
+                    candidate.category
+                );
+                return Err(eyre::eyre!(
+                    "unexpected category in process_invalid_proposal: {:?}",
+                    candidate.category
+                ));
+            }
         };
         metric.increment(1);
 
         self.proof_manager
             .initiate_proof(
-                &self.submitter,
+                self.submitter.sender_address(),
                 candidate,
                 invalid_index,
                 expected_root,
@@ -340,7 +360,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager> Driver<L2, P, T> {
 
         self.proof_manager
             .initiate_zk_proof(
-                &self.submitter,
+                self.submitter.sender_address(),
                 candidate,
                 challenged_index,
                 validation.expected_root,

--- a/crates/proof/challenge/src/lib.rs
+++ b/crates/proof/challenge/src/lib.rs
@@ -16,10 +16,13 @@ mod config;
 pub use config::ChallengerConfig;
 
 mod driver;
-pub use driver::{Driver, DriverComponents, DriverConfig, TeeConfig};
+pub use driver::{Driver, DriverComponents};
 
 mod pending;
 pub use pending::{DisputeIntent, PendingProof, PendingProofs, ProofKind, ProofPhase, ProofUpdate};
+
+mod proof_manager;
+pub use proof_manager::DisputeProofManager;
 
 mod proof_adapter;
 pub use proof_adapter::ChallengerProofAdapter;

--- a/crates/proof/challenge/src/proof_manager.rs
+++ b/crates/proof/challenge/src/proof_manager.rs
@@ -25,16 +25,17 @@ use tracing::{debug, info, warn};
 
 use crate::{
     CandidateGame, ChallengeSubmitError, ChallengeSubmitter, ChallengerMetrics,
-    ChallengerProofAdapter, DisputeIntent, L1HeadProvider, OutputValidator, PendingProof,
-    PendingProofs, ProofKind, ProofPhase, ProofUpdate,
+    ChallengerProofAdapter, DisputeIntent, IntermediateValidationParams, L1HeadProvider,
+    OutputValidator, PendingProof, PendingProofs, ProofKind, ProofPhase, ProofUpdate,
+    ValidationResult, ValidatorError,
 };
 
 /// Manages the lifecycle of proofs used to dispute invalid games.
 pub struct DisputeProofManager<L2: L2Provider, P: ProofRequesterProvider> {
     /// Validates output roots and constructs TEE proof commitments.
-    pub validator: OutputValidator<L2>,
+    validator: OutputValidator<L2>,
     /// Prover-service requester used to generate and poll fault proofs.
-    pub proof_requester: Arc<P>,
+    proof_requester: Arc<P>,
     tee: Option<Arc<dyn L1HeadProvider>>,
     verifier_client: Arc<dyn AggregateVerifierClient>,
     /// In-flight proof sessions keyed by game address.
@@ -84,6 +85,26 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
             max_proof_duration,
             tee_submit_retry_limit,
         }
+    }
+
+    /// Validates intermediate output roots against the local L2 node.
+    pub async fn validate_intermediate_roots(
+        &self,
+        params: IntermediateValidationParams<'_>,
+    ) -> Result<ValidationResult, ValidatorError> {
+        self.validator.validate_intermediate_roots(params).await
+    }
+
+    /// Validates a claimed output root at a specific L2 block.
+    pub async fn validate_claimed_root_at_block(
+        &self,
+        game_address: Address,
+        l2_block_number: u64,
+        claimed_root: B256,
+    ) -> Result<ValidationResult, ValidatorError> {
+        self.validator
+            .validate_claimed_root_at_block(game_address, l2_block_number, claimed_root)
+            .await
     }
 
     /// Returns whether a game is terminally ignored.

--- a/crates/proof/challenge/src/proof_manager.rs
+++ b/crates/proof/challenge/src/proof_manager.rs
@@ -124,13 +124,13 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
 
     /// Returns in-flight proof sessions for test inspection.
     #[cfg(any(test, feature = "test-utils"))]
-    pub fn pending_proofs(&self) -> &PendingProofs {
+    pub const fn pending_proofs(&self) -> &PendingProofs {
         &self.pending_proofs
     }
 
     /// Returns in-flight proof sessions for test setup.
     #[cfg(any(test, feature = "test-utils"))]
-    pub fn pending_proofs_mut(&mut self) -> &mut PendingProofs {
+    pub const fn pending_proofs_mut(&mut self) -> &mut PendingProofs {
         &mut self.pending_proofs
     }
 
@@ -161,9 +161,9 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
     ///
     /// When `try_tee_first` is `true` and the game has a non-zero TEE prover,
     /// a synchronous TEE proof is attempted before falling back to ZK.
-    pub async fn initiate_proof<T: TxManager>(
+    pub async fn initiate_proof(
         &mut self,
-        submitter: &ChallengeSubmitter<T>,
+        prover_address: Address,
         candidate: CandidateGame,
         invalid_index: u64,
         expected_root: B256,
@@ -179,7 +179,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
             ChallengerMetrics::tee_proof_attempts_total().increment(1);
             match self
                 .build_tee_request(
-                    submitter,
+                    prover_address,
                     &candidate,
                     invalid_index,
                     expected_root,
@@ -189,7 +189,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
             {
                 Ok(tee_request) => {
                     let (zk_fallback_request, zk_fallback_intent) =
-                        match self.build_zk_request(submitter, &candidate, invalid_index) {
+                        match self.build_zk_request(prover_address, &candidate, invalid_index) {
                             Ok(req) => (Some(req), Some(intent)),
                             Err(e) => {
                                 warn!(
@@ -248,13 +248,14 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
             ChallengerMetrics::tee_proof_fallback_total().increment(1);
         }
 
-        self.initiate_zk_proof(submitter, candidate, invalid_index, expected_root, intent).await
+        self.initiate_zk_proof(prover_address, candidate, invalid_index, expected_root, intent)
+            .await
     }
 
     /// Requests a ZK proof and stores its session for later polling.
-    pub async fn initiate_zk_proof<T: TxManager>(
+    pub async fn initiate_zk_proof(
         &mut self,
-        submitter: &ChallengeSubmitter<T>,
+        prover_address: Address,
         candidate: CandidateGame,
         invalid_index: u64,
         expected_root: B256,
@@ -262,7 +263,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
     ) -> eyre::Result<()> {
         let game_address = candidate.factory.proxy;
 
-        let proof_request = self.build_zk_request(submitter, &candidate, invalid_index)?;
+        let proof_request = self.build_zk_request(prover_address, &candidate, invalid_index)?;
         let request = ChallengerProofAdapter::snark_plonk_prove_block_range_request(
             game_address,
             invalid_index,
@@ -291,9 +292,9 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
         Ok(())
     }
 
-    async fn build_tee_request<T: TxManager>(
+    async fn build_tee_request(
         &self,
-        submitter: &ChallengeSubmitter<T>,
+        proposer: Address,
         candidate: &CandidateGame,
         invalid_index: u64,
         expected_root: B256,
@@ -319,16 +320,16 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
             agreed_l2_output_root,
             claimed_l2_output_root: expected_root,
             claimed_l2_block_number,
-            proposer: submitter.sender_address(),
+            proposer,
             intermediate_block_interval: candidate.intermediate_block_interval,
             l1_head_number,
             ..Default::default()
         })
     }
 
-    fn build_zk_request<T: TxManager>(
+    fn build_zk_request(
         &self,
-        submitter: &ChallengeSubmitter<T>,
+        prover_address: Address,
         candidate: &CandidateGame,
         invalid_index: u64,
     ) -> eyre::Result<SnarkPlonkProofRequest> {
@@ -344,7 +345,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
                 zk_vm: ZkVm::Sp1,
                 zk_backend: ZkBackend::Cluster,
             },
-            prover_address: submitter.sender_address(),
+            prover_address,
         })
     }
 

--- a/crates/proof/challenge/src/proof_manager.rs
+++ b/crates/proof/challenge/src/proof_manager.rs
@@ -1,0 +1,883 @@
+//! Dispute-proof lifecycle management.
+//!
+//! [`DisputeProofManager`] owns in-flight proof sessions from initiation
+//! through proof polling, retries, TEE-to-ZK fallback, and coordination of
+//! onchain dispute submission. The [`Driver`](crate::Driver) remains
+//! responsible for scanning candidate games.
+
+use std::{
+    collections::{HashSet, VecDeque},
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use alloy_primitives::{Address, B256};
+use base_proof_contracts::{AggregateVerifierClient, GameStatus};
+use base_proof_primitives::ProofRequest as TeeProofRequest;
+use base_proof_rpc::L2Provider;
+use base_proof_submission::KnownRevert;
+use base_prover_service_client::ProofRequesterProvider;
+use base_prover_service_protocol::{
+    SnarkPlonkProofRequest, TeeKind, ZkBackend, ZkProofRequest, ZkVm,
+};
+use base_tx_manager::{TxManager, TxManagerError};
+use tracing::{debug, info, warn};
+
+use crate::{
+    CandidateGame, ChallengeSubmitError, ChallengeSubmitter, ChallengerMetrics,
+    ChallengerProofAdapter, DisputeIntent, L1HeadProvider, OutputValidator, PendingProof,
+    PendingProofs, ProofKind, ProofPhase, ProofUpdate,
+};
+
+/// Manages the lifecycle of proofs used to dispute invalid games.
+pub struct DisputeProofManager<L2: L2Provider, P: ProofRequesterProvider> {
+    /// Validates output roots and constructs TEE proof commitments.
+    pub validator: OutputValidator<L2>,
+    /// Prover-service requester used to generate and poll fault proofs.
+    pub proof_requester: Arc<P>,
+    tee: Option<Arc<dyn L1HeadProvider>>,
+    verifier_client: Arc<dyn AggregateVerifierClient>,
+    /// In-flight proof sessions keyed by game address.
+    pub pending_proofs: PendingProofs,
+    ignored_games: HashSet<Address>,
+    ignored_game_order: VecDeque<Address>,
+    max_proof_duration: Duration,
+    tee_submit_retry_limit: u32,
+}
+
+impl<L2: L2Provider, P: ProofRequesterProvider> std::fmt::Debug for DisputeProofManager<L2, P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DisputeProofManager")
+            .field("pending_proofs", &self.pending_proofs.len())
+            .field("tee_submit_retry_limit", &self.tee_submit_retry_limit)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
+    /// Maximum number of times a failed proof job will be retried before being dropped.
+    pub const MAX_PROOF_RETRIES: u32 = 3;
+
+    /// Maximum number of terminally ignored games retained to avoid rediscovery churn.
+    ///
+    /// Evicted games may be rediscovered by a later scan, then re-ignored after
+    /// one check.
+    pub const MAX_IGNORED_GAMES: usize = 10_000;
+
+    /// Creates a proof manager from its validator, proof client, and contract clients.
+    pub fn new(
+        validator: OutputValidator<L2>,
+        proof_requester: Arc<P>,
+        tee: Option<Arc<dyn L1HeadProvider>>,
+        verifier_client: Arc<dyn AggregateVerifierClient>,
+        max_proof_duration: Duration,
+        tee_submit_retry_limit: u32,
+    ) -> Self {
+        Self {
+            validator,
+            proof_requester,
+            tee,
+            verifier_client,
+            pending_proofs: PendingProofs::new(),
+            ignored_games: HashSet::new(),
+            ignored_game_order: VecDeque::new(),
+            max_proof_duration,
+            tee_submit_retry_limit,
+        }
+    }
+
+    /// Returns whether a game is terminally ignored.
+    pub fn is_ignored(&self, game_address: Address) -> bool {
+        self.ignored_games.contains(&game_address)
+    }
+
+    /// Returns whether a game has an in-flight proof session.
+    pub fn has_pending_proof(&self, game_address: Address) -> bool {
+        self.pending_proofs.contains_key(&game_address)
+    }
+
+    /// Returns the number of in-flight proof sessions.
+    pub fn pending_proofs_len(&self) -> usize {
+        self.pending_proofs.len()
+    }
+
+    /// Returns the number of terminally ignored games retained in memory.
+    pub fn ignored_games_len(&self) -> usize {
+        self.ignored_games.len()
+    }
+
+    /// Polls all in-flight proof sessions for completion or retries submission.
+    pub async fn poll_pending_proofs<T: TxManager>(&mut self, submitter: &ChallengeSubmitter<T>) {
+        let addresses = self.pending_proofs.addresses();
+
+        for game_address in addresses {
+            if let Err(e) = self.poll_or_submit(game_address, submitter).await {
+                warn!(
+                    error = %e,
+                    game = %game_address,
+                    "failed to poll/submit pending proof"
+                );
+            }
+        }
+    }
+
+    /// Attempts TEE-first proof sourcing with ZK fallback.
+    ///
+    /// The `intent` determines the onchain action for the ZK fallback path.
+    /// TEE proofs always use `nullify()` regardless of `intent`.
+    ///
+    /// When `try_tee_first` is `true` and the game has a non-zero TEE prover,
+    /// a synchronous TEE proof is attempted before falling back to ZK.
+    pub async fn initiate_proof<T: TxManager>(
+        &mut self,
+        submitter: &ChallengeSubmitter<T>,
+        candidate: CandidateGame,
+        invalid_index: u64,
+        expected_root: B256,
+        intent: DisputeIntent,
+        try_tee_first: bool,
+    ) -> eyre::Result<()> {
+        let game_address = candidate.factory.proxy;
+
+        if candidate.tee_prover != Address::ZERO
+            && try_tee_first
+            && let Some(tee) = &self.tee
+        {
+            ChallengerMetrics::tee_proof_attempts_total().increment(1);
+            match self
+                .build_tee_request(
+                    submitter,
+                    &candidate,
+                    invalid_index,
+                    expected_root,
+                    tee.as_ref(),
+                )
+                .await
+            {
+                Ok(tee_request) => {
+                    let (zk_fallback_request, zk_fallback_intent) =
+                        match self.build_zk_request(submitter, &candidate, invalid_index) {
+                            Ok(req) => (Some(req), Some(intent)),
+                            Err(e) => {
+                                warn!(
+                                    error = %e,
+                                    game = %game_address,
+                                    "failed to build ZK fallback request; \
+                                     TEE proof will have no ZK fallback"
+                                );
+                                (None, None)
+                            }
+                        };
+
+                    let request = ChallengerProofAdapter::tee_prove_block_range_request(
+                        game_address,
+                        invalid_index,
+                        tee_request,
+                        TeeKind::AwsNitro,
+                    );
+                    match self.proof_requester.prove_block_range(request).await {
+                        Ok(response) => {
+                            info!(
+                                game = %game_address,
+                                session_id = %response.session_id,
+                                path = "tee",
+                                "TEE proof job initiated"
+                            );
+                            self.pending_proofs.insert(
+                                game_address,
+                                PendingProof::awaiting_tee(
+                                    response.session_id,
+                                    invalid_index,
+                                    expected_root,
+                                    zk_fallback_request,
+                                    zk_fallback_intent,
+                                ),
+                            );
+                            return Ok(());
+                        }
+                        Err(e) => {
+                            warn!(
+                                error = %e,
+                                game = %game_address,
+                                "TEE proof request failed, falling back to ZK"
+                            );
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        error = %e,
+                        game = %game_address,
+                        "failed to build TEE proof request, falling back to ZK"
+                    );
+                }
+            }
+            ChallengerMetrics::tee_proof_fallback_total().increment(1);
+        }
+
+        self.initiate_zk_proof(submitter, candidate, invalid_index, expected_root, intent).await
+    }
+
+    /// Requests a ZK proof and stores its session for later polling.
+    pub async fn initiate_zk_proof<T: TxManager>(
+        &mut self,
+        submitter: &ChallengeSubmitter<T>,
+        candidate: CandidateGame,
+        invalid_index: u64,
+        expected_root: B256,
+        intent: DisputeIntent,
+    ) -> eyre::Result<()> {
+        let game_address = candidate.factory.proxy;
+
+        let proof_request = self.build_zk_request(submitter, &candidate, invalid_index)?;
+        let request = ChallengerProofAdapter::snark_plonk_prove_block_range_request(
+            game_address,
+            invalid_index,
+            proof_request.clone(),
+        );
+
+        let prove_response = self.proof_requester.prove_block_range(request).await?;
+
+        info!(
+            game = %game_address,
+            session_id = %prove_response.session_id,
+            "proof job initiated"
+        );
+
+        self.pending_proofs.insert(
+            game_address,
+            PendingProof::awaiting(
+                prove_response.session_id,
+                invalid_index,
+                expected_root,
+                proof_request,
+                intent,
+            ),
+        );
+
+        Ok(())
+    }
+
+    async fn build_tee_request<T: TxManager>(
+        &self,
+        submitter: &ChallengeSubmitter<T>,
+        candidate: &CandidateGame,
+        invalid_index: u64,
+        expected_root: B256,
+        l1_head_provider: &dyn L1HeadProvider,
+    ) -> eyre::Result<TeeProofRequest> {
+        let start_block_number = candidate.checkpoint_start_block(invalid_index)?;
+
+        let claimed_l2_block_number = start_block_number
+            .checked_add(candidate.intermediate_block_interval)
+            .ok_or_else(|| eyre::eyre!("claimed_l2_block_number overflow"))?;
+
+        let l1_head = candidate.l1_head;
+        let (l1_head_number_result, output_root_result) = tokio::join!(
+            l1_head_provider.block_number_by_hash(l1_head),
+            self.validator.compute_output_root_with_hash(start_block_number),
+        );
+        let l1_head_number = l1_head_number_result?;
+        let (agreed_l2_head_hash, agreed_l2_output_root) = output_root_result?;
+
+        Ok(TeeProofRequest {
+            l1_head,
+            agreed_l2_head_hash,
+            agreed_l2_output_root,
+            claimed_l2_output_root: expected_root,
+            claimed_l2_block_number,
+            proposer: submitter.sender_address(),
+            intermediate_block_interval: candidate.intermediate_block_interval,
+            l1_head_number,
+            ..Default::default()
+        })
+    }
+
+    fn build_zk_request<T: TxManager>(
+        &self,
+        submitter: &ChallengeSubmitter<T>,
+        candidate: &CandidateGame,
+        invalid_index: u64,
+    ) -> eyre::Result<SnarkPlonkProofRequest> {
+        let start_block_number = candidate.checkpoint_start_block(invalid_index)?;
+
+        Ok(SnarkPlonkProofRequest {
+            proof: ZkProofRequest {
+                start_block_number,
+                number_of_blocks_to_prove: candidate.intermediate_block_interval,
+                sequence_window: None,
+                l1_head: Some(candidate.l1_head),
+                intermediate_root_interval: Some(candidate.intermediate_block_interval),
+                zk_vm: ZkVm::Sp1,
+                zk_backend: ZkBackend::Cluster,
+            },
+            prover_address: submitter.sender_address(),
+        })
+    }
+
+    async fn poll_or_submit<T: TxManager>(
+        &mut self,
+        game_address: Address,
+        submitter: &ChallengeSubmitter<T>,
+    ) -> eyre::Result<()> {
+        let (invalid_index, expected_root, intent, targets_tee, was_awaiting) =
+            match self.pending_proofs.get(&game_address) {
+                Some(p) => (
+                    p.invalid_index,
+                    p.expected_root,
+                    p.intent,
+                    p.kind.is_tee(),
+                    matches!(p.phase, ProofPhase::AwaitingProof { .. }),
+                ),
+                None => return Ok(()),
+            };
+
+        let proof_update = self
+            .pending_proofs
+            .poll(game_address, &*self.proof_requester, self.max_proof_duration)
+            .await?;
+        match &proof_update {
+            Some(ProofUpdate::Pending) => {
+                debug!(game = %game_address, "proof not ready, will retry next tick");
+                return Ok(());
+            }
+            None => return Ok(()),
+            _ => {}
+        }
+
+        let (status, tee_prover, zk_prover) = tokio::try_join!(
+            self.verifier_client.status(game_address),
+            self.verifier_client.tee_prover(game_address),
+            self.verifier_client.zk_prover(game_address),
+        )?;
+
+        if status != GameStatus::InProgress {
+            debug!(game = %game_address, status = ?status, "game no longer in progress, dropping pending proof");
+            self.pending_proofs.remove(&game_address);
+            return Ok(());
+        }
+
+        let already_resolved = match intent {
+            DisputeIntent::Challenge => zk_prover != Address::ZERO || tee_prover == Address::ZERO,
+            DisputeIntent::Nullify => {
+                if targets_tee {
+                    tee_prover == Address::ZERO
+                } else {
+                    zk_prover == Address::ZERO
+                }
+            }
+        };
+
+        if already_resolved {
+            debug!(
+                game = %game_address,
+                intent = ?intent,
+                tee_prover = %tee_prover,
+                zk_prover = %zk_prover,
+                "game already resolved, dropping pending proof"
+            );
+            self.pending_proofs.remove(&game_address);
+            return Ok(());
+        }
+
+        let proof_bytes = match proof_update {
+            Some(ProofUpdate::Ready(proof_bytes)) => {
+                info!(
+                    game = %game_address,
+                    proof_len = proof_bytes.len(),
+                    action = intent.label(),
+                    "proof ready, submitting dispute transaction"
+                );
+                if targets_tee && was_awaiting {
+                    ChallengerMetrics::tee_proof_obtained_total().increment(1);
+                }
+                proof_bytes
+            }
+            Some(ProofUpdate::NeedsRetry) => {
+                return self.handle_proof_retry(game_address).await;
+            }
+            Some(ProofUpdate::Pending) | None => unreachable!("handled above"),
+        };
+
+        let result = submitter
+            .submit_dispute(game_address, proof_bytes, invalid_index, expected_root, intent)
+            .await;
+        match result {
+            Ok(_) => {
+                self.pending_proofs.remove(&game_address);
+            }
+            Err(e) => {
+                match &e {
+                    ChallengeSubmitError::KnownRevert(
+                        revert @ (KnownRevert::GameAlreadyExists
+                        | KnownRevert::ProofAlreadyVerified),
+                    ) => {
+                        info!(
+                            error = %e,
+                            game = %game_address,
+                            revert = ?revert,
+                            "dispute already resolved, dropping pending proof"
+                        );
+                        self.pending_proofs.remove(&game_address);
+                        return Ok(());
+                    }
+                    ChallengeSubmitError::KnownRevert(
+                        revert @ (KnownRevert::InvalidParentGame | KnownRevert::L1OriginTooOld),
+                    ) => {
+                        warn!(
+                            error = %e,
+                            game = %game_address,
+                            revert = ?revert,
+                            "dispute cannot be resolved, ignoring game"
+                        );
+                        self.ignore_game(game_address);
+                        return Ok(());
+                    }
+                    ChallengeSubmitError::KnownRevert(KnownRevert::InvalidSigner)
+                        if !targets_tee =>
+                    {
+                        warn!(
+                            error = %e,
+                            game = %game_address,
+                            "dispute proof signer is invalid onchain, dropping pending proof"
+                        );
+                        self.pending_proofs.remove(&game_address);
+                        return Ok(());
+                    }
+                    _ if targets_tee && Self::should_fallback_from_tee_submit(&e) => {
+                        warn!(
+                            error = %e,
+                            game = %game_address,
+                            "TEE dispute tx failed, falling back to ZK"
+                        );
+                    }
+                    _ if targets_tee => {
+                        let Some(pending) = self.pending_proofs.get_mut(&game_address) else {
+                            return Ok(());
+                        };
+                        let has_zk_fallback = pending.kind.has_zk_fallback();
+
+                        if pending.tee_submit_retry_count >= self.tee_submit_retry_limit {
+                            warn!(
+                                error = %e,
+                                game = %game_address,
+                                retry_count = pending.tee_submit_retry_count,
+                                retry_limit = self.tee_submit_retry_limit,
+                                has_zk_fallback,
+                                "TEE dispute tx retry limit reached"
+                            );
+                            pending.phase = ProofPhase::NeedsRetry;
+                            return self.handle_proof_retry(game_address).await;
+                        }
+
+                        pending.tee_submit_retry_count =
+                            pending.tee_submit_retry_count.saturating_add(1);
+                        warn!(
+                            error = %e,
+                            game = %game_address,
+                            retry_count = pending.tee_submit_retry_count,
+                            retry_limit = self.tee_submit_retry_limit,
+                            has_zk_fallback,
+                            "TEE dispute tx failed, will retry next tick"
+                        );
+                        return Ok(());
+                    }
+                    _ => {
+                        warn!(
+                            error = %e,
+                            game = %game_address,
+                            "dispute tx failed, will retry next tick"
+                        );
+                        return Ok(());
+                    }
+                }
+
+                if let Some(pending) = self.pending_proofs.get_mut(&game_address) {
+                    pending.phase = ProofPhase::NeedsRetry;
+                    return self.handle_proof_retry(game_address).await;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    const fn should_fallback_from_tee_submit(error: &ChallengeSubmitError) -> bool {
+        matches!(
+            error,
+            ChallengeSubmitError::KnownRevert(KnownRevert::InvalidSigner)
+                | ChallengeSubmitError::TxReverted { .. }
+                | ChallengeSubmitError::TxManager(TxManagerError::ExecutionReverted { .. })
+        )
+    }
+
+    fn ignore_game(&mut self, game_address: Address) {
+        self.pending_proofs.remove(&game_address);
+        if self.ignored_games.insert(game_address) {
+            self.ignored_game_order.push_back(game_address);
+        }
+        while self.ignored_games.len() > Self::MAX_IGNORED_GAMES {
+            if let Some(game_address) = self.ignored_game_order.pop_front() {
+                self.ignored_games.remove(&game_address);
+            }
+        }
+        ChallengerMetrics::ignored_games().set(self.ignored_games.len() as f64);
+    }
+
+    async fn handle_proof_retry(&mut self, game_address: Address) -> eyre::Result<()> {
+        let pending = match self.pending_proofs.get(&game_address) {
+            Some(p) => p,
+            None => return Ok(()),
+        };
+
+        let retry_count = pending.retry_count;
+        let invalid_index = pending.invalid_index;
+
+        if retry_count > Self::MAX_PROOF_RETRIES {
+            warn!(
+                game = %game_address,
+                retry_count = retry_count,
+                "proof retries exhausted, dropping entry"
+            );
+            ChallengerMetrics::proof_retries_exhausted_total().increment(1);
+            self.pending_proofs.remove(&game_address);
+            return Ok(());
+        }
+
+        let request = match &pending.kind {
+            ProofKind::Tee { zk_fallback_request, zk_fallback_intent } => {
+                let (Some(fallback_request), Some(fallback_intent)) =
+                    (zk_fallback_request.clone(), *zk_fallback_intent)
+                else {
+                    debug!(
+                        game = %game_address,
+                        "TEE proof has no ZK fallback request, dropping entry"
+                    );
+                    self.pending_proofs.remove(&game_address);
+                    return Ok(());
+                };
+
+                debug!(game = %game_address, "TEE proof needs retry, falling back to ZK");
+                ChallengerMetrics::tee_proof_fallback_total().increment(1);
+
+                if let Some(pending) = self.pending_proofs.get_mut(&game_address) {
+                    pending.kind = ProofKind::Zk { prove_request: fallback_request.clone() };
+                    pending.intent = fallback_intent;
+                    pending.retry_count = 0;
+                    pending.tee_submit_retry_count = 0;
+                }
+
+                fallback_request
+            }
+            ProofKind::Zk { prove_request } => prove_request.clone(),
+        };
+
+        ChallengerMetrics::proof_retries_total().increment(1);
+
+        let prove_request = ChallengerProofAdapter::snark_plonk_prove_block_range_request(
+            game_address,
+            invalid_index,
+            request,
+        );
+
+        match self.proof_requester.prove_block_range(prove_request).await {
+            Ok(response) => {
+                info!(
+                    game = %game_address,
+                    session_id = %response.session_id,
+                    retry_count = retry_count,
+                    "proof job re-initiated"
+                );
+                if let Some(pending) = self.pending_proofs.get_mut(&game_address) {
+                    pending.phase = ProofPhase::AwaitingProof {
+                        session_id: response.session_id,
+                        started_at: Instant::now(),
+                    };
+                }
+            }
+            Err(e) => {
+                if let Some(pending) = self.pending_proofs.get_mut(&game_address) {
+                    pending.retry_count += 1;
+                }
+                warn!(
+                    error = %e,
+                    game = %game_address,
+                    retry_count = retry_count,
+                    "proveBlockRange failed on retry, will retry next tick"
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, sync::Arc, time::Duration};
+
+    use alloy_primitives::{Address, B256, Bytes};
+    use base_proof_contracts::{AggregateVerifierClient, GameStatus, l1_origin_too_old_selector};
+    use base_prover_service_protocol::{SnarkPlonkProofRequest, ZkProofRequest, ZkVm};
+    use base_tx_manager::TxManagerError;
+
+    use super::*;
+    use crate::test_utils::{
+        MockAggregateVerifier, MockL2Provider, MockTxManager, MockZkProofProvider, addr,
+        mock_state, receipt_with_status,
+    };
+
+    type TestManager = DisputeProofManager<MockL2Provider, MockZkProofProvider>;
+    type TestSubmitter = ChallengeSubmitter<MockTxManager>;
+
+    fn proof_request() -> SnarkPlonkProofRequest {
+        SnarkPlonkProofRequest {
+            proof: ZkProofRequest {
+                start_block_number: 100,
+                number_of_blocks_to_prove: 10,
+                sequence_window: None,
+                l1_head: Some(B256::repeat_byte(0xAA)),
+                intermediate_root_interval: Some(10),
+                zk_vm: ZkVm::Sp1,
+                zk_backend: ZkBackend::Cluster,
+            },
+            prover_address: Address::repeat_byte(0xCC),
+        }
+    }
+
+    fn manager_with_tx_error(
+        error: TxManagerError,
+    ) -> (TestManager, TestSubmitter, Arc<MockZkProofProvider>) {
+        manager_with_tx_manager(MockTxManager::new(Err(error)))
+    }
+
+    fn manager_with_tx_manager(
+        tx_manager: MockTxManager,
+    ) -> (TestManager, TestSubmitter, Arc<MockZkProofProvider>) {
+        let game_address = addr(0);
+        let mut verifier_games = HashMap::new();
+        verifier_games.insert(game_address, mock_state(GameStatus::InProgress, Address::ZERO, 100));
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
+        let proof_requester = Arc::new(MockZkProofProvider::default());
+        let manager = DisputeProofManager::new(
+            OutputValidator::new(Arc::new(MockL2Provider::new())),
+            Arc::clone(&proof_requester),
+            None,
+            verifier as Arc<dyn AggregateVerifierClient>,
+            Duration::from_secs(60),
+            3,
+        );
+
+        (manager, ChallengeSubmitter::new(tx_manager), proof_requester)
+    }
+
+    fn insert_ready_proof(manager: &mut TestManager) {
+        manager.pending_proofs.insert(
+            addr(0),
+            PendingProof::ready(
+                Bytes::from(vec![0x01, 0xAA]),
+                0,
+                B256::repeat_byte(0x22),
+                proof_request(),
+                DisputeIntent::Challenge,
+            ),
+        );
+    }
+
+    fn insert_ready_tee_proof(manager: &mut TestManager, with_zk_fallback: bool) {
+        manager.pending_proofs.insert(
+            addr(0),
+            PendingProof {
+                phase: ProofPhase::ReadyToSubmit { proof_bytes: Bytes::from(vec![0x00, 0xAA]) },
+                kind: ProofKind::Tee {
+                    zk_fallback_request: with_zk_fallback.then(proof_request),
+                    zk_fallback_intent: with_zk_fallback.then_some(DisputeIntent::Nullify),
+                },
+                invalid_index: 0,
+                expected_root: B256::repeat_byte(0x22),
+                retry_count: 0,
+                tee_submit_retry_count: 0,
+                intent: DisputeIntent::Nullify,
+            },
+        );
+    }
+
+    fn assert_ready_tee_proof(manager: &TestManager) {
+        let pending = manager.pending_proofs.get(&addr(0)).expect("pending proof should remain");
+        assert!(matches!(pending.phase, ProofPhase::ReadyToSubmit { .. }));
+        assert!(pending.kind.is_tee());
+    }
+
+    fn assert_zk_fallback_requested(manager: &TestManager, proof_requester: &MockZkProofProvider) {
+        let pending = manager.pending_proofs.get(&addr(0)).expect("pending proof should remain");
+        assert!(matches!(pending.phase, ProofPhase::AwaitingProof { .. }));
+        assert!(!pending.kind.is_tee());
+        assert_eq!(proof_requester.state.lock().unwrap().prove_block_range_log.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn proof_already_verified_revert_drops_pending_proof() {
+        let (mut manager, submitter, _) =
+            manager_with_tx_error(TxManagerError::ExecutionReverted {
+                reason: Some("AlreadyProven(1)".to_string()),
+                data: None,
+            });
+        insert_ready_proof(&mut manager);
+
+        manager.poll_or_submit(addr(0), &submitter).await.unwrap();
+
+        assert!(!manager.pending_proofs.contains_key(&addr(0)));
+    }
+
+    #[tokio::test]
+    async fn game_already_exists_revert_drops_pending_proof() {
+        let (mut manager, submitter, _) =
+            manager_with_tx_error(TxManagerError::ExecutionReverted {
+                reason: Some("GameAlreadyExists(0x00)".to_string()),
+                data: None,
+            });
+        insert_ready_proof(&mut manager);
+
+        manager.poll_or_submit(addr(0), &submitter).await.unwrap();
+
+        assert!(!manager.pending_proofs.contains_key(&addr(0)));
+    }
+
+    #[tokio::test]
+    async fn challenge_success_does_not_track_anchor_update() {
+        let tx_hash = B256::repeat_byte(0x44);
+        let (mut manager, submitter, _) =
+            manager_with_tx_manager(MockTxManager::new(Ok(receipt_with_status(true, tx_hash))));
+        insert_ready_proof(&mut manager);
+
+        manager.poll_or_submit(addr(0), &submitter).await.unwrap();
+
+        assert!(!manager.pending_proofs.contains_key(&addr(0)));
+    }
+
+    #[tokio::test]
+    async fn stale_l1_origin_revert_drops_pending_zk_proof() {
+        let (mut manager, submitter, proof_requester) =
+            manager_with_tx_error(TxManagerError::ExecutionReverted {
+                reason: None,
+                data: Some(Bytes::from(l1_origin_too_old_selector().to_vec())),
+            });
+        insert_ready_proof(&mut manager);
+
+        manager.poll_or_submit(addr(0), &submitter).await.unwrap();
+
+        assert!(!manager.pending_proofs.contains_key(&addr(0)));
+        assert!(manager.is_ignored(addr(0)));
+        assert!(proof_requester.state.lock().unwrap().prove_block_range_log.is_empty());
+    }
+
+    #[tokio::test]
+    async fn stale_l1_origin_revert_drops_pending_tee_proof_without_requesting_zk() {
+        let (mut manager, submitter, proof_requester) =
+            manager_with_tx_error(TxManagerError::ExecutionReverted {
+                reason: None,
+                data: Some(Bytes::from(l1_origin_too_old_selector().to_vec())),
+            });
+        insert_ready_tee_proof(&mut manager, true);
+
+        manager.poll_or_submit(addr(0), &submitter).await.unwrap();
+
+        assert!(!manager.pending_proofs.contains_key(&addr(0)));
+        assert!(manager.is_ignored(addr(0)));
+        assert!(proof_requester.state.lock().unwrap().prove_block_range_log.is_empty());
+    }
+
+    #[test]
+    fn ignored_games_are_bounded() {
+        let (mut manager, _, _) =
+            manager_with_tx_manager(MockTxManager::new(Ok(receipt_with_status(true, B256::ZERO))));
+
+        for i in 0..=TestManager::MAX_IGNORED_GAMES {
+            manager.ignore_game(addr(i as u64));
+        }
+
+        assert_eq!(manager.ignored_games_len(), TestManager::MAX_IGNORED_GAMES);
+        assert!(!manager.is_ignored(addr(0)));
+        assert!(manager.is_ignored(addr(TestManager::MAX_IGNORED_GAMES as u64)));
+    }
+
+    #[tokio::test]
+    async fn tee_submit_nonce_too_low_keeps_ready_proof_without_requesting_zk() {
+        let (mut manager, submitter, proof_requester) =
+            manager_with_tx_error(TxManagerError::NonceTooLow);
+        insert_ready_tee_proof(&mut manager, true);
+
+        manager.poll_or_submit(addr(0), &submitter).await.unwrap();
+
+        assert_ready_tee_proof(&manager);
+        let pending = manager.pending_proofs.get(&addr(0)).expect("pending proof should remain");
+        assert_eq!(pending.tee_submit_retry_count, 1);
+        assert!(proof_requester.state.lock().unwrap().prove_block_range_log.is_empty());
+    }
+
+    #[tokio::test]
+    async fn tee_submit_retry_limit_falls_back_to_zk() {
+        let (mut manager, submitter, proof_requester) =
+            manager_with_tx_manager(MockTxManager::with_responses(vec![
+                Err(TxManagerError::NonceTooLow),
+                Err(TxManagerError::NonceTooLow),
+            ]));
+        manager.tee_submit_retry_limit = 1;
+        insert_ready_tee_proof(&mut manager, true);
+
+        manager.poll_or_submit(addr(0), &submitter).await.unwrap();
+
+        assert_ready_tee_proof(&manager);
+        assert!(proof_requester.state.lock().unwrap().prove_block_range_log.is_empty());
+
+        manager.poll_or_submit(addr(0), &submitter).await.unwrap();
+
+        assert_zk_fallback_requested(&manager, &proof_requester);
+    }
+
+    #[tokio::test]
+    async fn tee_submit_retry_limit_drops_proof_without_zk_fallback() {
+        let (mut manager, submitter, proof_requester) =
+            manager_with_tx_manager(MockTxManager::with_responses(vec![
+                Err(TxManagerError::NonceTooLow),
+                Err(TxManagerError::NonceTooLow),
+            ]));
+        manager.tee_submit_retry_limit = 1;
+        insert_ready_tee_proof(&mut manager, false);
+
+        manager.poll_or_submit(addr(0), &submitter).await.unwrap();
+
+        assert_ready_tee_proof(&manager);
+
+        manager.poll_or_submit(addr(0), &submitter).await.unwrap();
+
+        assert!(!manager.pending_proofs.contains_key(&addr(0)));
+        assert!(proof_requester.state.lock().unwrap().prove_block_range_log.is_empty());
+    }
+
+    #[tokio::test]
+    async fn tee_invalid_signer_revert_falls_back_to_zk() {
+        let (mut manager, submitter, proof_requester) =
+            manager_with_tx_error(TxManagerError::ExecutionReverted {
+                reason: Some("InvalidSigner()".to_string()),
+                data: None,
+            });
+        insert_ready_tee_proof(&mut manager, true);
+
+        manager.poll_or_submit(addr(0), &submitter).await.unwrap();
+
+        assert_zk_fallback_requested(&manager, &proof_requester);
+    }
+
+    #[tokio::test]
+    async fn tee_mined_tx_revert_falls_back_to_zk() {
+        let tx_hash = B256::repeat_byte(0x44);
+        let (mut manager, submitter, proof_requester) =
+            manager_with_tx_manager(MockTxManager::new(Ok(receipt_with_status(false, tx_hash))));
+        insert_ready_tee_proof(&mut manager, true);
+
+        manager.poll_or_submit(addr(0), &submitter).await.unwrap();
+
+        assert_zk_fallback_requested(&manager, &proof_requester);
+    }
+}

--- a/crates/proof/challenge/src/proof_manager.rs
+++ b/crates/proof/challenge/src/proof_manager.rs
@@ -39,7 +39,7 @@ pub struct DisputeProofManager<L2: L2Provider, P: ProofRequesterProvider> {
     tee: Option<Arc<dyn L1HeadProvider>>,
     verifier_client: Arc<dyn AggregateVerifierClient>,
     /// In-flight proof sessions keyed by game address.
-    pub pending_proofs: PendingProofs,
+    pending_proofs: PendingProofs,
     ignored_games: HashSet<Address>,
     ignored_game_order: VecDeque<Address>,
     max_proof_duration: Duration,
@@ -120,6 +120,18 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
     /// Returns the number of in-flight proof sessions.
     pub fn pending_proofs_len(&self) -> usize {
         self.pending_proofs.len()
+    }
+
+    /// Returns in-flight proof sessions for test inspection.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn pending_proofs(&self) -> &PendingProofs {
+        &self.pending_proofs
+    }
+
+    /// Returns in-flight proof sessions for test setup.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn pending_proofs_mut(&mut self) -> &mut PendingProofs {
+        &mut self.pending_proofs
     }
 
     /// Returns the number of terminally ignored games retained in memory.

--- a/crates/proof/challenge/src/service.rs
+++ b/crates/proof/challenge/src/service.rs
@@ -24,7 +24,7 @@ use tracing::{info, warn};
 
 use crate::{
     AnchorUpdater, BondManager, BondManagerConfig, ChallengeSubmitter, ChallengerConfig,
-    ChallengerMetrics, Driver, DriverComponents, DriverConfig, GameScanner, OutputValidator,
+    ChallengerMetrics, Driver, DriverComponents, GameScanner, OutputValidator,
 };
 
 /// Top-level challenger service.
@@ -164,11 +164,11 @@ impl ChallengerService {
         let proof_requester = Arc::new(ProofRequesterClient::connect(&proof_requester_config)?);
         info!(endpoint = %config.zk_rpc_url, "Prover-service requester client initialized");
 
-        // ── 6b. TEE proof config ────────────────────────────────────────────
+        // ── 6b. TEE proof provider ──────────────────────────────────────────
         //
         // TEE-first proof sourcing is the steady-state mode. TEE proofs flow
-        // through the same `proof_requester` as ZK proofs; the TEE config only
-        // carries an L1 head provider used to build the TEE proof request
+        // through the same `proof_requester` as ZK proofs; `tee` carries the
+        // L1 head provider used to build the TEE proof request
         // envelope. The driver automatically falls back to the ZK path when a
         // TEE proof is unavailable for a given session, so TEE-first is safe
         // to run even in deployments where TEE proofs are not yet generated
@@ -176,7 +176,7 @@ impl ChallengerService {
         let l1_config = L1ClientConfig::new(l1_rpc_url.clone());
         let l1_client = L1Client::new(l1_config)
             .map_err(|e| eyre::eyre!("failed to create TEE L1 client: {e}"))?;
-        let tee = Some(crate::TeeConfig { l1_head_provider: Arc::new(l1_client) });
+        let tee: Option<Arc<dyn crate::L1HeadProvider>> = Some(Arc::new(l1_client));
 
         // ── 7. Scanner, anchor updater, and bond manager ──────────────────
         let scanner = GameScanner::new(
@@ -226,25 +226,20 @@ impl ChallengerService {
         };
 
         // ── 9. Run driver ────────────────────────────────────────────────────
-        let driver_config = DriverConfig {
+        let driver = Driver::new(DriverComponents {
+            scanner,
+            validator,
+            proof_requester,
+            submitter,
+            tee,
+            verifier_client,
+            bond_manager,
+            anchor_updater,
             poll_interval: config.poll_interval,
             max_proof_duration: config.max_proof_duration,
             tee_submit_retry_limit: config.tee_submit_retry_limit,
             cancel: cancel.child_token(),
-        };
-        let driver = Driver::new(
-            driver_config,
-            DriverComponents {
-                scanner,
-                validator,
-                proof_requester,
-                submitter,
-                tee,
-                verifier_client,
-                bond_manager,
-                anchor_updater,
-            },
-        );
+        });
 
         // Signal readiness immediately after initialization — the driver loop
         // itself is purely operational work that should not gate readiness probes.

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -938,7 +938,7 @@ async fn test_step_tee_contract_revert_falls_back_to_zk() {
         Arc::clone(&factory),
         Arc::clone(&verifier),
         l2,
-        zk,
+        Arc::clone(&zk),
         tx_manager,
         Some(l1_head),
     );
@@ -970,7 +970,7 @@ async fn test_step_tee_contract_revert_falls_back_to_zk() {
     );
 
     {
-        let mut state = driver.proof_manager.proof_requester.state.lock().unwrap();
+        let mut state = zk.state.lock().unwrap();
         state.result = None;
         state.proof = vec![0xDE, 0xAD];
         state.proof_status = ProofStatus::Succeeded;

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -229,7 +229,7 @@ fn driver_with_ready_proof(
     let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
     driver
         .proof_manager
-        .pending_proofs
+        .pending_proofs_mut()
         .insert(addr(0), default_ready_proof(DisputeIntent::Challenge));
     driver
 }
@@ -293,7 +293,7 @@ async fn test_step_invalid_game_proof_succeeded() {
     // Step 1: proof initiated, not yet polled.
     driver.step().await.unwrap();
     assert!(
-        driver.proof_manager.pending_proofs.contains_key(&addr(0)),
+        driver.proof_manager.pending_proofs().contains_key(&addr(0)),
         "proof should be pending after initiation"
     );
 
@@ -306,7 +306,7 @@ async fn test_step_invalid_game_proof_succeeded() {
     // Step 2: proof polled → Succeeded → nullification submitted → entry removed.
     driver.step().await.unwrap();
     assert!(
-        !driver.proof_manager.pending_proofs.contains_key(&addr(0)),
+        !driver.proof_manager.pending_proofs().contains_key(&addr(0)),
         "entry should be removed after successful nullification"
     );
 }
@@ -324,7 +324,7 @@ async fn test_step_invalid_game_proof_failed() {
     // Step 1: proof initiated but not yet polled (deferred to next tick).
     driver.step().await.unwrap();
     assert!(
-        driver.proof_manager.pending_proofs.contains_key(&addr(0)),
+        driver.proof_manager.pending_proofs().contains_key(&addr(0)),
         "proof should be pending after initiation"
     );
 
@@ -335,7 +335,7 @@ async fn test_step_invalid_game_proof_failed() {
     // Entry should be retained in AwaitingProof phase (re-initiated) with retry_count == 1.
     let entry = driver
         .proof_manager
-        .pending_proofs
+        .pending_proofs()
         .get(&addr(0))
         .expect("entry should be retained after failure");
     assert!(
@@ -439,7 +439,7 @@ async fn test_step_pending_proof_skips_prove_block() {
     // proof_status is not polled this tick (pending_proofs is empty at poll time).
     driver.step().await.unwrap();
     assert!(
-        driver.proof_manager.pending_proofs.contains_key(&addr(0)),
+        driver.proof_manager.pending_proofs().contains_key(&addr(0)),
         "session should be stored in pending_proofs"
     );
 
@@ -456,7 +456,7 @@ async fn test_step_pending_proof_skips_prove_block() {
     // challenge tx submitted, session removed from pending_proofs.
     driver.step().await.unwrap();
     assert!(
-        !driver.proof_manager.pending_proofs.contains_key(&addr(0)),
+        !driver.proof_manager.pending_proofs().contains_key(&addr(0)),
         "session should be removed after proof succeeded"
     );
 }
@@ -478,7 +478,7 @@ async fn test_step_nullification_failure_preserves_proof() {
     // Step 1: proof initiated but not yet polled.
     driver.step().await.unwrap();
     assert!(
-        driver.proof_manager.pending_proofs.contains_key(&addr(0)),
+        driver.proof_manager.pending_proofs().contains_key(&addr(0)),
         "proof should be pending after initiation"
     );
 
@@ -487,7 +487,7 @@ async fn test_step_nullification_failure_preserves_proof() {
 
     // Entry must still be in pending_proofs as ReadyToSubmit.
     let entry =
-        driver.proof_manager.pending_proofs.get(&addr(0)).expect("proof should be preserved");
+        driver.proof_manager.pending_proofs().get(&addr(0)).expect("proof should be preserved");
     assert!(entry.is_ready(), "phase should be ReadyToSubmit after tx failure");
 
     // Simulate the onchain effect of a successful challenge: game is resolved.
@@ -499,7 +499,7 @@ async fn test_step_nullification_failure_preserves_proof() {
     // Step 3: poll_pending_proofs re-submits the challenge tx, now it succeeds.
     driver.step().await.unwrap();
     assert!(
-        !driver.proof_manager.pending_proofs.contains_key(&addr(0)),
+        !driver.proof_manager.pending_proofs().contains_key(&addr(0)),
         "entry should be removed after successful submission"
     );
 }
@@ -512,7 +512,7 @@ async fn test_poll_or_submit_drops_resolved_game() {
         driver_with_ready_proof(mock_state(GameStatus::ChallengerWins, Address::ZERO, 20));
     driver.step().await.unwrap();
     assert!(
-        !driver.proof_manager.pending_proofs.contains_key(&addr(0)),
+        !driver.proof_manager.pending_proofs().contains_key(&addr(0)),
         "resolved game should be removed from pending_proofs"
     );
 }
@@ -525,7 +525,7 @@ async fn test_poll_or_submit_drops_already_challenged_game() {
         driver_with_ready_proof(mock_state(GameStatus::InProgress, ZK_PROVER_ADDR, 20));
     driver.step().await.unwrap();
     assert!(
-        !driver.proof_manager.pending_proofs.contains_key(&addr(0)),
+        !driver.proof_manager.pending_proofs().contains_key(&addr(0)),
         "already-challenged game should be removed from pending_proofs"
     );
 }
@@ -542,7 +542,7 @@ async fn test_poll_or_submit_drops_nullified_game() {
     ));
     driver.step().await.unwrap();
     assert!(
-        !driver.proof_manager.pending_proofs.contains_key(&addr(0)),
+        !driver.proof_manager.pending_proofs().contains_key(&addr(0)),
         "nullified game should be removed from pending_proofs"
     );
 }
@@ -581,14 +581,14 @@ async fn test_step_proof_retry_succeeds() {
     // Step 1: proof initiated, not yet polled.
     driver.step().await.unwrap();
     assert!(
-        driver.proof_manager.pending_proofs.contains_key(&addr(0)),
+        driver.proof_manager.pending_proofs().contains_key(&addr(0)),
         "proof should be pending after initiation"
     );
 
     // Step 2: proof polled → Failed → NeedsRetry → handle_proof_retry
     // re-initiates prove_block → AwaitingProof with retry_count == 1.
     driver.step().await.unwrap();
-    let entry = driver.proof_manager.pending_proofs.get(&addr(0)).expect("entry should exist");
+    let entry = driver.proof_manager.pending_proofs().get(&addr(0)).expect("entry should exist");
     assert!(
         matches!(entry.phase, ProofPhase::AwaitingProof { .. }),
         "phase should be AwaitingProof after retry re-initiation"
@@ -607,7 +607,7 @@ async fn test_step_proof_retry_succeeds() {
     // Step 3: proof succeeds, challenge tx submitted, entry removed.
     driver.step().await.unwrap();
     assert!(
-        !driver.proof_manager.pending_proofs.contains_key(&addr(0)),
+        !driver.proof_manager.pending_proofs().contains_key(&addr(0)),
         "entry should be removed after successful challenge submission"
     );
 }
@@ -667,7 +667,7 @@ async fn test_step_proof_retry_reuses_deterministic_session_id() {
 
     let entry = driver
         .proof_manager
-        .pending_proofs
+        .pending_proofs()
         .get(&addr(0))
         .expect("entry should be retained after retry");
     assert!(
@@ -691,7 +691,7 @@ async fn test_step_proof_retry_reuses_deterministic_session_id() {
 
     driver.step().await.unwrap();
     assert!(
-        !driver.proof_manager.pending_proofs.contains_key(&addr(0)),
+        !driver.proof_manager.pending_proofs().contains_key(&addr(0)),
         "entry should be removed after successful retry submission",
     );
 }
@@ -709,7 +709,7 @@ async fn test_step_proof_exceeds_max_retries() {
     driver.step().await.unwrap();
     let entry = driver
         .proof_manager
-        .pending_proofs
+        .pending_proofs()
         .get(&addr(0))
         .expect("entry should exist after initiation");
     assert_eq!(entry.retry_count, 0);
@@ -721,7 +721,7 @@ async fn test_step_proof_exceeds_max_retries() {
         driver.step().await.unwrap();
         let entry = driver
             .proof_manager
-            .pending_proofs
+            .pending_proofs()
             .get(&addr(0))
             .expect("entry should exist during retries");
         assert_eq!(entry.retry_count, i + 1);
@@ -738,7 +738,7 @@ async fn test_step_proof_exceeds_max_retries() {
     // handle_proof_retry sees retry_count > MAX_PROOF_RETRIES and drops the entry.
     driver.step().await.unwrap();
     assert!(
-        !driver.proof_manager.pending_proofs.contains_key(&addr(0)),
+        !driver.proof_manager.pending_proofs().contains_key(&addr(0)),
         "entry should be dropped after exceeding max retries"
     );
 }
@@ -764,7 +764,7 @@ async fn test_step_invalid_game_tee_fails_zk_fallback() {
 
     let entry = driver
         .proof_manager
-        .pending_proofs
+        .pending_proofs()
         .get(&addr(0))
         .expect("ZK proof should be pending after TEE fallback");
     assert!(
@@ -784,7 +784,7 @@ async fn test_step_invalid_game_no_tee_provider_zk_only() {
     driver.step().await.unwrap();
 
     let entry =
-        driver.proof_manager.pending_proofs.get(&addr(0)).expect("ZK proof should be pending");
+        driver.proof_manager.pending_proofs().get(&addr(0)).expect("ZK proof should be pending");
     assert!(
         matches!(entry.phase, ProofPhase::AwaitingProof { .. }),
         "phase should be AwaitingProof (ZK, no TEE provider)"
@@ -812,7 +812,7 @@ async fn test_step_invalid_game_tee_fails_zk_succeeds() {
     // to ZK, proof session initiated (polled on next tick).
     driver.step().await.unwrap();
     assert!(
-        driver.proof_manager.pending_proofs.contains_key(&addr(0)),
+        driver.proof_manager.pending_proofs().contains_key(&addr(0)),
         "ZK proof should be pending after TEE fallback"
     );
 
@@ -825,7 +825,7 @@ async fn test_step_invalid_game_tee_fails_zk_succeeds() {
     // Step 2: proof polled → Succeeded → challenge tx submitted → entry removed.
     driver.step().await.unwrap();
     assert!(
-        !driver.proof_manager.pending_proofs.contains_key(&addr(0)),
+        !driver.proof_manager.pending_proofs().contains_key(&addr(0)),
         "entry should be removed after successful ZK challenge submission"
     );
 }
@@ -886,7 +886,7 @@ async fn test_step_invalid_game_tee_proof_succeeds() {
     driver.step().await.unwrap();
 
     assert!(
-        !driver.proof_manager.pending_proofs.contains_key(&addr(0)),
+        !driver.proof_manager.pending_proofs().contains_key(&addr(0)),
         "no pending proof should remain after TEE nullification is observed"
     );
 }
@@ -952,7 +952,7 @@ async fn test_step_tee_contract_revert_falls_back_to_zk() {
     // The entry should now be a ZK proof in AwaitingProof phase (ZK fallback).
     let entry = driver
         .proof_manager
-        .pending_proofs
+        .pending_proofs()
         .get(&addr(0))
         .expect("ZK fallback proof should be pending after TEE tx failure");
     assert!(
@@ -984,7 +984,7 @@ async fn test_step_tee_contract_revert_falls_back_to_zk() {
     // Step 3: ZK proof polled → Succeeded → challenge tx submitted → entry cleaned up.
     driver.step().await.unwrap();
     assert!(
-        !driver.proof_manager.pending_proofs.contains_key(&addr(0)),
+        !driver.proof_manager.pending_proofs().contains_key(&addr(0)),
         "entry should be removed after ZK fallback completes"
     );
 }
@@ -1038,7 +1038,7 @@ async fn test_step_invalid_tee_result_falls_back_to_zk_without_timeout() {
 
     let entry = driver
         .proof_manager
-        .pending_proofs
+        .pending_proofs()
         .get(&addr(0))
         .expect("ZK fallback proof should be pending after invalid TEE result");
     assert!(matches!(entry.kind, base_challenger::ProofKind::Zk { .. }));
@@ -1061,7 +1061,7 @@ async fn test_step_nullified_game_not_reprocessed() {
     driver.step().await.unwrap();
 
     assert!(
-        driver.proof_manager.pending_proofs.is_empty(),
+        driver.proof_manager.pending_proofs().is_empty(),
         "no proofs should be pending for a nullified game"
     );
 }
@@ -1089,13 +1089,13 @@ async fn test_poll_or_submit_nullify_intent_not_dropped_when_zk_prover_set() {
     let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
     driver
         .proof_manager
-        .pending_proofs
+        .pending_proofs_mut()
         .insert(addr(0), default_ready_proof(DisputeIntent::Nullify));
 
     driver.step().await.unwrap();
 
     assert!(
-        !driver.proof_manager.pending_proofs.contains_key(&addr(0)),
+        !driver.proof_manager.pending_proofs().contains_key(&addr(0)),
         "nullify intent should be submitted, not dropped due to zk_prover"
     );
 }
@@ -1112,7 +1112,7 @@ async fn test_successful_nullify_does_not_track_anchor_update() {
     ));
 
     let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
-    driver.proof_manager.pending_proofs.insert(
+    driver.proof_manager.pending_proofs_mut().insert(
         addr(0),
         PendingProof {
             phase: ProofPhase::ReadyToSubmit { proof_bytes: Bytes::from_static(&[0x00, 0xAA]) },
@@ -1127,7 +1127,7 @@ async fn test_successful_nullify_does_not_track_anchor_update() {
 
     driver.step().await.unwrap();
 
-    assert!(!driver.proof_manager.pending_proofs.contains_key(&addr(0)));
+    assert!(!driver.proof_manager.pending_proofs().contains_key(&addr(0)));
 }
 
 #[tokio::test]
@@ -1147,13 +1147,13 @@ async fn test_poll_or_submit_challenge_intent_dropped_when_zk_prover_set() {
     let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), tx);
     driver
         .proof_manager
-        .pending_proofs
+        .pending_proofs_mut()
         .insert(addr(0), default_ready_proof(DisputeIntent::Challenge));
 
     driver.step().await.unwrap();
 
     assert!(
-        !driver.proof_manager.pending_proofs.contains_key(&addr(0)),
+        !driver.proof_manager.pending_proofs().contains_key(&addr(0)),
         "challenge intent should be dropped when game is already challenged"
     );
 }
@@ -1197,7 +1197,7 @@ async fn test_step_fraudulent_zk_challenge_legitimate_skips() {
     driver.step().await.unwrap();
 
     assert!(
-        driver.proof_manager.pending_proofs.is_empty(),
+        driver.proof_manager.pending_proofs().is_empty(),
         "no proof should be initiated when the ZK challenge is legitimate"
     );
 }
@@ -1214,7 +1214,7 @@ async fn test_step_fraudulent_zk_challenge_nullifies() {
 
     let entry = driver
         .proof_manager
-        .pending_proofs
+        .pending_proofs()
         .get(&addr(0))
         .expect("proof should be pending for fraudulent ZK challenge");
     assert_eq!(
@@ -1246,7 +1246,7 @@ async fn test_step_fraudulent_zk_challenge_nullifies_despite_earlier_invalid_roo
     driver.step().await.unwrap();
 
     let entry =
-        driver.proof_manager.pending_proofs.get(&addr(0)).expect(
+        driver.proof_manager.pending_proofs().get(&addr(0)).expect(
             "proof should be pending — challenged root is valid, ZK challenge is fraudulent",
         );
     assert_eq!(
@@ -1278,7 +1278,7 @@ async fn test_step_invalid_zk_proposal_initiates_zk_nullification() {
 
     let entry = driver
         .proof_manager
-        .pending_proofs
+        .pending_proofs()
         .get(&addr(0))
         .expect("ZK nullification proof should be pending");
     assert_eq!(entry.intent, DisputeIntent::Nullify, "intent should be Nullify for ZK proposals");
@@ -1297,7 +1297,7 @@ async fn test_step_valid_zk_proposal_skipped() {
     driver.step().await.unwrap();
 
     assert!(
-        driver.proof_manager.pending_proofs.is_empty(),
+        driver.proof_manager.pending_proofs().is_empty(),
         "valid ZK proposal should not trigger any proof"
     );
 }
@@ -1325,7 +1325,7 @@ async fn test_step_dual_proof_invalid_without_tee_provider_falls_back_to_zk_null
 
     let entry = driver
         .proof_manager
-        .pending_proofs
+        .pending_proofs()
         .get(&addr(0))
         .expect("ZK nullification proof should be pending for dual-proof game");
     assert_eq!(
@@ -1398,7 +1398,7 @@ async fn test_step_dual_proof_invalid_with_tee_provider_nullifies_tee_first() {
     // invalid ZK proposal and a ZK nullification proof is initiated.
     let entry = driver
         .proof_manager
-        .pending_proofs
+        .pending_proofs()
         .get(&addr(0))
         .expect("ZK proof should be pending after TEE nullification");
     assert!(matches!(entry.kind, base_challenger::ProofKind::Zk { .. }));
@@ -1421,7 +1421,7 @@ async fn test_step_dual_proof_valid_skipped() {
     driver.step().await.unwrap();
 
     assert!(
-        driver.proof_manager.pending_proofs.is_empty(),
+        driver.proof_manager.pending_proofs().is_empty(),
         "valid dual-proof game should not trigger any proof"
     );
 }
@@ -1452,7 +1452,7 @@ async fn test_step_dual_proof_tee_fails_falls_back_to_zk_nullify() {
 
     let entry = driver
         .proof_manager
-        .pending_proofs
+        .pending_proofs()
         .get(&addr(0))
         .expect("ZK proof should be pending after TEE fallback for dual-proof game");
     assert_eq!(
@@ -1501,7 +1501,7 @@ async fn test_step_checkpoint_count_mismatch_surfaces_error() {
     driver.step().await.unwrap();
 
     assert!(
-        driver.proof_manager.pending_proofs.is_empty(),
+        driver.proof_manager.pending_proofs().is_empty(),
         "no proof should be initiated when checkpoint count mismatches — \
          the error should be surfaced, not silently swallowed"
     );
@@ -1879,7 +1879,7 @@ mod metrics_emission {
                     DisputeProofManager::<MockL2Provider, MockZkProofProvider>::MAX_PROOF_RETRIES;
                 let entry = driver
                     .proof_manager
-                    .pending_proofs
+                    .pending_proofs_mut()
                     .get_mut(&addr(0))
                     .expect("entry should exist after initiation");
                 entry.retry_count = max_retries + 1;

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -8,9 +8,9 @@ use std::{
 
 use alloy_primitives::{Address, B256, Bytes};
 use base_challenger::{
-    AnchorUpdater, BondManager, ChallengeSubmitter, ChallengerProofAdapter, DisputeIntent, Driver,
-    DriverComponents, DriverConfig, GameScanner, L1HeadProvider, OutputValidator, PendingProof,
-    PendingProofs, ProofKind, ProofPhase, ProofUpdate, TeeConfig,
+    AnchorUpdater, ChallengeSubmitter, ChallengerProofAdapter, DisputeIntent, DisputeProofManager,
+    Driver, DriverComponents, GameScanner, L1HeadProvider, OutputValidator, PendingProof,
+    PendingProofs, ProofKind, ProofPhase, ProofUpdate,
     test_utils::{
         DEFAULT_L1_HEAD, DEFAULT_TEE_PROVER, MockAggregateVerifier, MockDisputeGameFactory,
         MockGameState, MockL1HeadProvider, MockL2Provider, MockTxManager, MockZkProofProvider,
@@ -27,7 +27,6 @@ use base_prover_service_protocol::{
     ProofResult as ApiProofResult, ProofStatus, SnarkPlonkProofRequest, TeeKind, TeeProofResult,
     ZkBackend, ZkProofRequest, ZkVm,
 };
-use base_runtime::TokioRuntime;
 use base_tx_manager::TxManagerError;
 use tokio_util::sync::CancellationToken;
 
@@ -68,14 +67,14 @@ fn test_driver(
     test_driver_with_tee(factory, verifier, l2_provider, zk_prover, tx_manager, None)
 }
 
-/// Builds a test driver with an optional TEE config.
+/// Builds a test driver with an optional TEE L1 head provider.
 fn test_driver_with_tee(
     factory: Arc<MockDisputeGameFactory>,
     verifier: Arc<MockAggregateVerifier>,
     l2_provider: Arc<MockL2Provider>,
     zk_prover: Arc<MockZkProofProvider>,
     tx_manager: MockTxManager,
-    tee: Option<TeeConfig>,
+    tee: Option<Arc<dyn L1HeadProvider>>,
 ) -> Driver<MockL2Provider, MockZkProofProvider, MockTxManager> {
     let anchor_registry = mock_anchor_registry(Address::ZERO);
     let scanner = GameScanner::new(
@@ -86,34 +85,28 @@ fn test_driver_with_tee(
     let validator = OutputValidator::new(Arc::clone(&l2_provider));
     let submitter = ChallengeSubmitter::new(tx_manager);
 
-    let config = DriverConfig {
+    Driver::new(DriverComponents {
+        scanner,
+        validator,
+        proof_requester: zk_prover,
+        submitter,
+        tee,
+        verifier_client: verifier as Arc<dyn AggregateVerifierClient>,
+        bond_manager: None,
+        anchor_updater: AnchorUpdater::new(
+            factory,
+            anchor_registry,
+            l2_provider as Arc<dyn base_proof_rpc::L2Provider>,
+            Address::repeat_byte(0xAA),
+            1,
+            100,
+            100,
+        ),
         poll_interval: Duration::from_millis(10),
         max_proof_duration: Duration::from_secs(4 * 60 * 60),
         tee_submit_retry_limit: 3,
         cancel: CancellationToken::new(),
-    };
-
-    Driver::new(
-        config,
-        DriverComponents {
-            scanner,
-            validator,
-            proof_requester: zk_prover,
-            submitter,
-            tee,
-            verifier_client: verifier as Arc<dyn AggregateVerifierClient>,
-            bond_manager: None,
-            anchor_updater: AnchorUpdater::new(
-                factory,
-                anchor_registry,
-                l2_provider as Arc<dyn base_proof_rpc::L2Provider>,
-                Address::repeat_byte(0xAA),
-                1,
-                100,
-                100,
-            ),
-        },
-    )
+    })
 }
 
 fn default_zk_prover() -> Arc<MockZkProofProvider> {
@@ -134,10 +127,6 @@ fn single_game_factory() -> Arc<MockDisputeGameFactory> {
 
 fn single_game_verifier(state: MockGameState) -> Arc<MockAggregateVerifier> {
     Arc::new(MockAggregateVerifier::new(HashMap::from([(addr(0), state)])))
-}
-
-fn tee_config(l1_head_provider: Arc<dyn L1HeadProvider>) -> TeeConfig {
-    TeeConfig { l1_head_provider }
 }
 
 const fn tee_api_result(aggregate_proposal: Proposal) -> ApiProofResult {
@@ -238,7 +227,10 @@ fn driver_with_ready_proof(
     let verifier = single_game_verifier(game_state);
     let l2 = default_l2();
     let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
-    driver.pending_proofs.insert(addr(0), default_ready_proof(DisputeIntent::Challenge));
+    driver
+        .proof_manager
+        .pending_proofs
+        .insert(addr(0), default_ready_proof(DisputeIntent::Challenge));
     driver
 }
 
@@ -301,7 +293,7 @@ async fn test_step_invalid_game_proof_succeeded() {
     // Step 1: proof initiated, not yet polled.
     driver.step().await.unwrap();
     assert!(
-        driver.pending_proofs.contains_key(&addr(0)),
+        driver.proof_manager.pending_proofs.contains_key(&addr(0)),
         "proof should be pending after initiation"
     );
 
@@ -314,7 +306,7 @@ async fn test_step_invalid_game_proof_succeeded() {
     // Step 2: proof polled → Succeeded → nullification submitted → entry removed.
     driver.step().await.unwrap();
     assert!(
-        !driver.pending_proofs.contains_key(&addr(0)),
+        !driver.proof_manager.pending_proofs.contains_key(&addr(0)),
         "entry should be removed after successful nullification"
     );
 }
@@ -332,7 +324,7 @@ async fn test_step_invalid_game_proof_failed() {
     // Step 1: proof initiated but not yet polled (deferred to next tick).
     driver.step().await.unwrap();
     assert!(
-        driver.pending_proofs.contains_key(&addr(0)),
+        driver.proof_manager.pending_proofs.contains_key(&addr(0)),
         "proof should be pending after initiation"
     );
 
@@ -341,8 +333,11 @@ async fn test_step_invalid_game_proof_failed() {
     driver.step().await.unwrap();
 
     // Entry should be retained in AwaitingProof phase (re-initiated) with retry_count == 1.
-    let entry =
-        driver.pending_proofs.get(&addr(0)).expect("entry should be retained after failure");
+    let entry = driver
+        .proof_manager
+        .pending_proofs
+        .get(&addr(0))
+        .expect("entry should be retained after failure");
     assert!(
         matches!(entry.phase, ProofPhase::AwaitingProof { .. }),
         "phase should be AwaitingProof after re-initiation"
@@ -400,34 +395,28 @@ async fn test_step_scan_error_propagated() {
     let validator = OutputValidator::new(Arc::clone(&l2));
     let submitter = ChallengeSubmitter::new(default_tx_manager());
 
-    let config = DriverConfig {
+    let mut driver = Driver::new(DriverComponents {
+        scanner,
+        validator,
+        proof_requester: default_zk_prover(),
+        submitter,
+        tee: None,
+        verifier_client: verifier as Arc<dyn AggregateVerifierClient>,
+        bond_manager: None,
+        anchor_updater: AnchorUpdater::new(
+            factory,
+            anchor_registry,
+            l2 as Arc<dyn base_proof_rpc::L2Provider>,
+            Address::repeat_byte(0xAA),
+            1,
+            100,
+            100,
+        ),
         poll_interval: Duration::from_millis(10),
         max_proof_duration: Duration::from_secs(4 * 60 * 60),
         tee_submit_retry_limit: 3,
         cancel: CancellationToken::new(),
-    };
-
-    let mut driver = Driver::new(
-        config,
-        DriverComponents {
-            scanner,
-            validator,
-            proof_requester: default_zk_prover(),
-            submitter,
-            tee: None,
-            verifier_client: verifier as Arc<dyn AggregateVerifierClient>,
-            bond_manager: None::<BondManager<TokioRuntime>>,
-            anchor_updater: AnchorUpdater::new(
-                factory,
-                anchor_registry,
-                l2 as Arc<dyn base_proof_rpc::L2Provider>,
-                Address::repeat_byte(0xAA),
-                1,
-                100,
-                100,
-            ),
-        },
-    );
+    });
 
     let result = driver.step().await;
     assert!(result.is_err(), "scan error should propagate");
@@ -450,7 +439,7 @@ async fn test_step_pending_proof_skips_prove_block() {
     // proof_status is not polled this tick (pending_proofs is empty at poll time).
     driver.step().await.unwrap();
     assert!(
-        driver.pending_proofs.contains_key(&addr(0)),
+        driver.proof_manager.pending_proofs.contains_key(&addr(0)),
         "session should be stored in pending_proofs"
     );
 
@@ -467,7 +456,7 @@ async fn test_step_pending_proof_skips_prove_block() {
     // challenge tx submitted, session removed from pending_proofs.
     driver.step().await.unwrap();
     assert!(
-        !driver.pending_proofs.contains_key(&addr(0)),
+        !driver.proof_manager.pending_proofs.contains_key(&addr(0)),
         "session should be removed after proof succeeded"
     );
 }
@@ -489,7 +478,7 @@ async fn test_step_nullification_failure_preserves_proof() {
     // Step 1: proof initiated but not yet polled.
     driver.step().await.unwrap();
     assert!(
-        driver.pending_proofs.contains_key(&addr(0)),
+        driver.proof_manager.pending_proofs.contains_key(&addr(0)),
         "proof should be pending after initiation"
     );
 
@@ -497,7 +486,8 @@ async fn test_step_nullification_failure_preserves_proof() {
     driver.step().await.unwrap();
 
     // Entry must still be in pending_proofs as ReadyToSubmit.
-    let entry = driver.pending_proofs.get(&addr(0)).expect("proof should be preserved");
+    let entry =
+        driver.proof_manager.pending_proofs.get(&addr(0)).expect("proof should be preserved");
     assert!(entry.is_ready(), "phase should be ReadyToSubmit after tx failure");
 
     // Simulate the onchain effect of a successful challenge: game is resolved.
@@ -509,7 +499,7 @@ async fn test_step_nullification_failure_preserves_proof() {
     // Step 3: poll_pending_proofs re-submits the challenge tx, now it succeeds.
     driver.step().await.unwrap();
     assert!(
-        !driver.pending_proofs.contains_key(&addr(0)),
+        !driver.proof_manager.pending_proofs.contains_key(&addr(0)),
         "entry should be removed after successful submission"
     );
 }
@@ -522,7 +512,7 @@ async fn test_poll_or_submit_drops_resolved_game() {
         driver_with_ready_proof(mock_state(GameStatus::ChallengerWins, Address::ZERO, 20));
     driver.step().await.unwrap();
     assert!(
-        !driver.pending_proofs.contains_key(&addr(0)),
+        !driver.proof_manager.pending_proofs.contains_key(&addr(0)),
         "resolved game should be removed from pending_proofs"
     );
 }
@@ -535,7 +525,7 @@ async fn test_poll_or_submit_drops_already_challenged_game() {
         driver_with_ready_proof(mock_state(GameStatus::InProgress, ZK_PROVER_ADDR, 20));
     driver.step().await.unwrap();
     assert!(
-        !driver.pending_proofs.contains_key(&addr(0)),
+        !driver.proof_manager.pending_proofs.contains_key(&addr(0)),
         "already-challenged game should be removed from pending_proofs"
     );
 }
@@ -552,7 +542,7 @@ async fn test_poll_or_submit_drops_nullified_game() {
     ));
     driver.step().await.unwrap();
     assert!(
-        !driver.pending_proofs.contains_key(&addr(0)),
+        !driver.proof_manager.pending_proofs.contains_key(&addr(0)),
         "nullified game should be removed from pending_proofs"
     );
 }
@@ -591,14 +581,14 @@ async fn test_step_proof_retry_succeeds() {
     // Step 1: proof initiated, not yet polled.
     driver.step().await.unwrap();
     assert!(
-        driver.pending_proofs.contains_key(&addr(0)),
+        driver.proof_manager.pending_proofs.contains_key(&addr(0)),
         "proof should be pending after initiation"
     );
 
     // Step 2: proof polled → Failed → NeedsRetry → handle_proof_retry
     // re-initiates prove_block → AwaitingProof with retry_count == 1.
     driver.step().await.unwrap();
-    let entry = driver.pending_proofs.get(&addr(0)).expect("entry should exist");
+    let entry = driver.proof_manager.pending_proofs.get(&addr(0)).expect("entry should exist");
     assert!(
         matches!(entry.phase, ProofPhase::AwaitingProof { .. }),
         "phase should be AwaitingProof after retry re-initiation"
@@ -617,7 +607,7 @@ async fn test_step_proof_retry_succeeds() {
     // Step 3: proof succeeds, challenge tx submitted, entry removed.
     driver.step().await.unwrap();
     assert!(
-        !driver.pending_proofs.contains_key(&addr(0)),
+        !driver.proof_manager.pending_proofs.contains_key(&addr(0)),
         "entry should be removed after successful challenge submission"
     );
 }
@@ -675,7 +665,11 @@ async fn test_step_proof_retry_reuses_deterministic_session_id() {
         );
     }
 
-    let entry = driver.pending_proofs.get(&addr(0)).expect("entry should be retained after retry");
+    let entry = driver
+        .proof_manager
+        .pending_proofs
+        .get(&addr(0))
+        .expect("entry should be retained after retry");
     assert!(
         matches!(entry.phase, ProofPhase::AwaitingProof { ref session_id, .. } if session_id == &expected_session_id),
         "post-retry phase must be AwaitingProof with the deterministic session_id",
@@ -697,7 +691,7 @@ async fn test_step_proof_retry_reuses_deterministic_session_id() {
 
     driver.step().await.unwrap();
     assert!(
-        !driver.pending_proofs.contains_key(&addr(0)),
+        !driver.proof_manager.pending_proofs.contains_key(&addr(0)),
         "entry should be removed after successful retry submission",
     );
 }
@@ -713,16 +707,23 @@ async fn test_step_proof_exceeds_max_retries() {
 
     // Step 1: proof initiated, not yet polled.
     driver.step().await.unwrap();
-    let entry = driver.pending_proofs.get(&addr(0)).expect("entry should exist after initiation");
+    let entry = driver
+        .proof_manager
+        .pending_proofs
+        .get(&addr(0))
+        .expect("entry should exist after initiation");
     assert_eq!(entry.retry_count, 0);
 
     // Each subsequent step: poll returns Failed → NeedsRetry (retry_count
     // increments), then handle_proof_retry re-initiates → AwaitingProof.
-    let max_retries =
-        Driver::<MockL2Provider, MockZkProofProvider, MockTxManager>::MAX_PROOF_RETRIES;
+    let max_retries = DisputeProofManager::<MockL2Provider, MockZkProofProvider>::MAX_PROOF_RETRIES;
     for i in 0..max_retries {
         driver.step().await.unwrap();
-        let entry = driver.pending_proofs.get(&addr(0)).expect("entry should exist during retries");
+        let entry = driver
+            .proof_manager
+            .pending_proofs
+            .get(&addr(0))
+            .expect("entry should exist during retries");
         assert_eq!(entry.retry_count, i + 1);
     }
 
@@ -737,7 +738,7 @@ async fn test_step_proof_exceeds_max_retries() {
     // handle_proof_retry sees retry_count > MAX_PROOF_RETRIES and drops the entry.
     driver.step().await.unwrap();
     assert!(
-        !driver.pending_proofs.contains_key(&addr(0)),
+        !driver.proof_manager.pending_proofs.contains_key(&addr(0)),
         "entry should be dropped after exceeding max retries"
     );
 }
@@ -756,13 +757,16 @@ async fn test_step_invalid_game_tee_fails_zk_fallback() {
         l2,
         default_zk_prover(),
         tx_manager,
-        Some(tee_config(Arc::new(MockL1HeadProvider::failure("dummy")))),
+        Some(Arc::new(MockL1HeadProvider::failure("dummy"))),
     );
 
     driver.step().await.unwrap();
 
-    let entry =
-        driver.pending_proofs.get(&addr(0)).expect("ZK proof should be pending after TEE fallback");
+    let entry = driver
+        .proof_manager
+        .pending_proofs
+        .get(&addr(0))
+        .expect("ZK proof should be pending after TEE fallback");
     assert!(
         matches!(entry.phase, ProofPhase::AwaitingProof { .. }),
         "phase should be AwaitingProof (ZK fallback)"
@@ -771,7 +775,7 @@ async fn test_step_invalid_game_tee_fails_zk_fallback() {
 
 #[tokio::test]
 async fn test_step_invalid_game_no_tee_provider_zk_only() {
-    // No TEE config → go straight to ZK.
+    // No TEE L1 head provider → go straight to ZK.
     let (l2, factory, verifier) = invalid_game_mocks();
 
     let tx_manager = default_tx_manager();
@@ -779,7 +783,8 @@ async fn test_step_invalid_game_no_tee_provider_zk_only() {
 
     driver.step().await.unwrap();
 
-    let entry = driver.pending_proofs.get(&addr(0)).expect("ZK proof should be pending");
+    let entry =
+        driver.proof_manager.pending_proofs.get(&addr(0)).expect("ZK proof should be pending");
     assert!(
         matches!(entry.phase, ProofPhase::AwaitingProof { .. }),
         "phase should be AwaitingProof (ZK, no TEE provider)"
@@ -800,14 +805,14 @@ async fn test_step_invalid_game_tee_fails_zk_succeeds() {
         l2,
         zk,
         tx_manager,
-        Some(tee_config(Arc::new(MockL1HeadProvider::failure("dummy")))),
+        Some(Arc::new(MockL1HeadProvider::failure("dummy"))),
     );
 
     // Step 1: TEE path is attempted (fails building request), falls back
     // to ZK, proof session initiated (polled on next tick).
     driver.step().await.unwrap();
     assert!(
-        driver.pending_proofs.contains_key(&addr(0)),
+        driver.proof_manager.pending_proofs.contains_key(&addr(0)),
         "ZK proof should be pending after TEE fallback"
     );
 
@@ -820,7 +825,7 @@ async fn test_step_invalid_game_tee_fails_zk_succeeds() {
     // Step 2: proof polled → Succeeded → challenge tx submitted → entry removed.
     driver.step().await.unwrap();
     assert!(
-        !driver.pending_proofs.contains_key(&addr(0)),
+        !driver.proof_manager.pending_proofs.contains_key(&addr(0)),
         "entry should be removed after successful ZK challenge submission"
     );
 }
@@ -866,7 +871,7 @@ async fn test_step_invalid_game_tee_proof_succeeds() {
         l2,
         proof_requester,
         tx_manager,
-        Some(tee_config(l1_head)),
+        Some(l1_head),
     );
 
     driver.step().await.unwrap();
@@ -881,7 +886,7 @@ async fn test_step_invalid_game_tee_proof_succeeds() {
     driver.step().await.unwrap();
 
     assert!(
-        !driver.pending_proofs.contains_key(&addr(0)),
+        !driver.proof_manager.pending_proofs.contains_key(&addr(0)),
         "no pending proof should remain after TEE nullification is observed"
     );
 }
@@ -935,7 +940,7 @@ async fn test_step_tee_contract_revert_falls_back_to_zk() {
         l2,
         zk,
         tx_manager,
-        Some(tee_config(l1_head)),
+        Some(l1_head),
     );
 
     // Step 1: TEE proof job is initiated.
@@ -946,6 +951,7 @@ async fn test_step_tee_contract_revert_falls_back_to_zk() {
 
     // The entry should now be a ZK proof in AwaitingProof phase (ZK fallback).
     let entry = driver
+        .proof_manager
         .pending_proofs
         .get(&addr(0))
         .expect("ZK fallback proof should be pending after TEE tx failure");
@@ -964,7 +970,7 @@ async fn test_step_tee_contract_revert_falls_back_to_zk() {
     );
 
     {
-        let mut state = driver.proof_requester.state.lock().unwrap();
+        let mut state = driver.proof_manager.proof_requester.state.lock().unwrap();
         state.result = None;
         state.proof = vec![0xDE, 0xAD];
         state.proof_status = ProofStatus::Succeeded;
@@ -978,7 +984,7 @@ async fn test_step_tee_contract_revert_falls_back_to_zk() {
     // Step 3: ZK proof polled → Succeeded → challenge tx submitted → entry cleaned up.
     driver.step().await.unwrap();
     assert!(
-        !driver.pending_proofs.contains_key(&addr(0)),
+        !driver.proof_manager.pending_proofs.contains_key(&addr(0)),
         "entry should be removed after ZK fallback completes"
     );
 }
@@ -1020,7 +1026,7 @@ async fn test_step_invalid_tee_result_falls_back_to_zk_without_timeout() {
         l2,
         proof_requester,
         default_tx_manager(),
-        Some(tee_config(l1_head)),
+        Some(l1_head),
     );
 
     // Step 1: TEE proof job is initiated.
@@ -1031,6 +1037,7 @@ async fn test_step_invalid_tee_result_falls_back_to_zk_without_timeout() {
     driver.step().await.unwrap();
 
     let entry = driver
+        .proof_manager
         .pending_proofs
         .get(&addr(0))
         .expect("ZK fallback proof should be pending after invalid TEE result");
@@ -1053,7 +1060,10 @@ async fn test_step_nullified_game_not_reprocessed() {
     driver.step().await.unwrap();
     driver.step().await.unwrap();
 
-    assert!(driver.pending_proofs.is_empty(), "no proofs should be pending for a nullified game");
+    assert!(
+        driver.proof_manager.pending_proofs.is_empty(),
+        "no proofs should be pending for a nullified game"
+    );
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -1077,12 +1087,15 @@ async fn test_poll_or_submit_nullify_intent_not_dropped_when_zk_prover_set() {
     let verifier = single_game_verifier(game_state);
 
     let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
-    driver.pending_proofs.insert(addr(0), default_ready_proof(DisputeIntent::Nullify));
+    driver
+        .proof_manager
+        .pending_proofs
+        .insert(addr(0), default_ready_proof(DisputeIntent::Nullify));
 
     driver.step().await.unwrap();
 
     assert!(
-        !driver.pending_proofs.contains_key(&addr(0)),
+        !driver.proof_manager.pending_proofs.contains_key(&addr(0)),
         "nullify intent should be submitted, not dropped due to zk_prover"
     );
 }
@@ -1099,7 +1112,7 @@ async fn test_successful_nullify_does_not_track_anchor_update() {
     ));
 
     let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
-    driver.pending_proofs.insert(
+    driver.proof_manager.pending_proofs.insert(
         addr(0),
         PendingProof {
             phase: ProofPhase::ReadyToSubmit { proof_bytes: Bytes::from_static(&[0x00, 0xAA]) },
@@ -1114,7 +1127,7 @@ async fn test_successful_nullify_does_not_track_anchor_update() {
 
     driver.step().await.unwrap();
 
-    assert!(!driver.pending_proofs.contains_key(&addr(0)));
+    assert!(!driver.proof_manager.pending_proofs.contains_key(&addr(0)));
 }
 
 #[tokio::test]
@@ -1132,12 +1145,15 @@ async fn test_poll_or_submit_challenge_intent_dropped_when_zk_prover_set() {
 
     let tx = MockTxManager::new(Err(TxManagerError::NonceTooLow)); // Should never be called
     let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), tx);
-    driver.pending_proofs.insert(addr(0), default_ready_proof(DisputeIntent::Challenge));
+    driver
+        .proof_manager
+        .pending_proofs
+        .insert(addr(0), default_ready_proof(DisputeIntent::Challenge));
 
     driver.step().await.unwrap();
 
     assert!(
-        !driver.pending_proofs.contains_key(&addr(0)),
+        !driver.proof_manager.pending_proofs.contains_key(&addr(0)),
         "challenge intent should be dropped when game is already challenged"
     );
 }
@@ -1181,7 +1197,7 @@ async fn test_step_fraudulent_zk_challenge_legitimate_skips() {
     driver.step().await.unwrap();
 
     assert!(
-        driver.pending_proofs.is_empty(),
+        driver.proof_manager.pending_proofs.is_empty(),
         "no proof should be initiated when the ZK challenge is legitimate"
     );
 }
@@ -1197,6 +1213,7 @@ async fn test_step_fraudulent_zk_challenge_nullifies() {
     driver.step().await.unwrap();
 
     let entry = driver
+        .proof_manager
         .pending_proofs
         .get(&addr(0))
         .expect("proof should be pending for fraudulent ZK challenge");
@@ -1228,10 +1245,10 @@ async fn test_step_fraudulent_zk_challenge_nullifies_despite_earlier_invalid_roo
     let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
     driver.step().await.unwrap();
 
-    let entry = driver
-        .pending_proofs
-        .get(&addr(0))
-        .expect("proof should be pending — challenged root is valid, ZK challenge is fraudulent");
+    let entry =
+        driver.proof_manager.pending_proofs.get(&addr(0)).expect(
+            "proof should be pending — challenged root is valid, ZK challenge is fraudulent",
+        );
     assert_eq!(
         entry.intent,
         DisputeIntent::Nullify,
@@ -1259,8 +1276,11 @@ async fn test_step_invalid_zk_proposal_initiates_zk_nullification() {
     let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
     driver.step().await.unwrap();
 
-    let entry =
-        driver.pending_proofs.get(&addr(0)).expect("ZK nullification proof should be pending");
+    let entry = driver
+        .proof_manager
+        .pending_proofs
+        .get(&addr(0))
+        .expect("ZK nullification proof should be pending");
     assert_eq!(entry.intent, DisputeIntent::Nullify, "intent should be Nullify for ZK proposals");
 }
 
@@ -1276,7 +1296,10 @@ async fn test_step_valid_zk_proposal_skipped() {
     let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
     driver.step().await.unwrap();
 
-    assert!(driver.pending_proofs.is_empty(), "valid ZK proposal should not trigger any proof");
+    assert!(
+        driver.proof_manager.pending_proofs.is_empty(),
+        "valid ZK proposal should not trigger any proof"
+    );
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -1284,9 +1307,9 @@ async fn test_step_valid_zk_proposal_skipped() {
 // ──────────────────────────────────────────────────────────────────────────
 
 #[tokio::test]
-async fn test_step_dual_proof_invalid_without_tee_config_falls_back_to_zk_nullify() {
+async fn test_step_dual_proof_invalid_without_tee_provider_falls_back_to_zk_nullify() {
     // A game with both TEE and ZK proofs verified (via verifyProposalProof,
-    // not challenge) where the output roots are invalid and no TEE config is
+    // not challenge) where the output roots are invalid and no TEE provider is
     // available should fall back to a ZK proof with DisputeIntent::Nullify.
     let (l2, factory, root_15, _root_20) = base_game_mocks();
 
@@ -1301,20 +1324,21 @@ async fn test_step_dual_proof_invalid_without_tee_config_falls_back_to_zk_nullif
     driver.step().await.unwrap();
 
     let entry = driver
+        .proof_manager
         .pending_proofs
         .get(&addr(0))
         .expect("ZK nullification proof should be pending for dual-proof game");
     assert_eq!(
         entry.intent,
         DisputeIntent::Nullify,
-        "dual-proof game without TEE config should fall back to ZK Nullify"
+        "dual-proof game without a TEE provider should fall back to ZK Nullify"
     );
 }
 
 #[tokio::test]
-async fn test_step_dual_proof_invalid_with_tee_config_nullifies_tee_first() {
+async fn test_step_dual_proof_invalid_with_tee_provider_nullifies_tee_first() {
     // A game with both TEE and ZK proofs verified where output roots are
-    // invalid and a TEE config is available should attempt TEE nullification
+    // invalid and a TEE provider is available should attempt TEE nullification
     // first (fast path). After TEE nullification the game will be rescanned
     // as InvalidZkProposal on the next tick.
     let (l2, factory, root_15, root_20) = base_game_mocks();
@@ -1355,7 +1379,7 @@ async fn test_step_dual_proof_invalid_with_tee_config_nullifies_tee_first() {
         l2,
         proof_requester,
         tx_manager,
-        Some(tee_config(l1_head)),
+        Some(l1_head),
     );
 
     driver.step().await.unwrap();
@@ -1373,6 +1397,7 @@ async fn test_step_dual_proof_invalid_with_tee_config_nullifies_tee_first() {
     // After TEE nullification is observed, the same game is re-scanned as an
     // invalid ZK proposal and a ZK nullification proof is initiated.
     let entry = driver
+        .proof_manager
         .pending_proofs
         .get(&addr(0))
         .expect("ZK proof should be pending after TEE nullification");
@@ -1395,7 +1420,10 @@ async fn test_step_dual_proof_valid_skipped() {
     let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
     driver.step().await.unwrap();
 
-    assert!(driver.pending_proofs.is_empty(), "valid dual-proof game should not trigger any proof");
+    assert!(
+        driver.proof_manager.pending_proofs.is_empty(),
+        "valid dual-proof game should not trigger any proof"
+    );
 }
 
 #[tokio::test]
@@ -1417,12 +1445,13 @@ async fn test_step_dual_proof_tee_fails_falls_back_to_zk_nullify() {
         l2,
         default_zk_prover(),
         default_tx_manager(),
-        Some(tee_config(Arc::new(MockL1HeadProvider::failure("dummy")))),
+        Some(Arc::new(MockL1HeadProvider::failure("dummy"))),
     );
 
     driver.step().await.unwrap();
 
     let entry = driver
+        .proof_manager
         .pending_proofs
         .get(&addr(0))
         .expect("ZK proof should be pending after TEE fallback for dual-proof game");
@@ -1472,7 +1501,7 @@ async fn test_step_checkpoint_count_mismatch_surfaces_error() {
     driver.step().await.unwrap();
 
     assert!(
-        driver.pending_proofs.is_empty(),
+        driver.proof_manager.pending_proofs.is_empty(),
         "no proof should be initiated when checkpoint count mismatches — \
          the error should be surfaced, not silently swallowed"
     );
@@ -1847,8 +1876,9 @@ mod metrics_emission {
                 // `retry_count = 0` in the same call, so we assert on the
                 // metric only.
                 let max_retries =
-                    Driver::<MockL2Provider, MockZkProofProvider, MockTxManager>::MAX_PROOF_RETRIES;
+                    DisputeProofManager::<MockL2Provider, MockZkProofProvider>::MAX_PROOF_RETRIES;
                 let entry = driver
+                    .proof_manager
                     .pending_proofs
                     .get_mut(&addr(0))
                     .expect("entry should exist after initiation");


### PR DESCRIPTION
### What changed? Why?

Extracted the challenger proof lifecycle from `Driver` into `DisputeProofManager`. The manager now owns proof-request construction, in-flight proof state, polling and retries, terminal-game tracking, onchain proof submission, and TEE-to-ZK fallback. `Driver` retains scanning, candidate validation and dispatch, bond discovery, and anchor updates.

Simplified driver construction by folding `DriverConfig` and `TeeConfig` into `DriverComponents`; the optional L1 head provider is injected directly. The proof manager now receives the prover address when initiating requests rather than the transaction submitter.

Added focused `proof_manager.rs` unit coverage for terminal submission reverts, bounded ignored-game state, and TEE submission retry/fallback behavior. Existing driver integration coverage remains for candidate categories and end-to-end proof flows.

### Notes to reviewers

No challenger behavior change is intended. Invalid TEE and dual proposals still attempt TEE first and fall back to ZK when possible; invalid ZK proposals and fraudulent ZK challenges continue through the ZK nullification path.

The main review boundary is that `Driver` determines which action a candidate needs, while `DisputeProofManager` owns the resulting proof session through submission or terminal cleanup.

### How has it been tested?

- `cargo test -p base-challenger`
- Passing PR CI checks: `ci / Build`, `ci / Clippy`, `ci / Test`, and `no_std (proof)`