### PR TITLE
refactor(challenger): clean proof adapter

### DIFF
--- a/crates/proof/challenge/src/proof_adapter.rs
+++ b/crates/proof/challenge/src/proof_adapter.rs
@@ -14,36 +14,24 @@ pub struct ChallengerProofAdapter;
 
 impl ChallengerProofAdapter {
     /// Namespace used to derive challenger proof session IDs.
-    pub const SESSION_NAMESPACE: &'static [u8] = b"base/challenger/proof-session/v1";
-
-    /// Returns the session-ID proof subtype label for challenger SNARK proofs.
-    pub const fn snark_plonk_session_label() -> &'static str {
-        "zk/sp1/snark_plonk"
-    }
-
-    /// Returns the session-ID proof subtype label for a TEE implementation.
-    pub const fn tee_session_label(tee_kind: TeeKind) -> &'static str {
-        match tee_kind {
-            TeeKind::AwsNitro => "tee/aws_nitro",
-        }
-    }
+    const SESSION_NAMESPACE: &'static [u8] = b"base/challenger/proof-session/v1";
 
     /// Derives an idempotent challenger SNARK proof session ID.
     pub fn snark_plonk_session_id(game_address: Address, invalid_index: u64) -> String {
         let invalid_index = invalid_index.to_be_bytes();
         ProofSessionId::derive_from_components(
             Self::SESSION_NAMESPACE,
-            Self::snark_plonk_session_label(),
+            "zk/sp1/snark_plonk",
             &[game_address.as_slice(), &invalid_index],
         )
     }
 
     /// Derives an idempotent challenger TEE proof session ID.
-    pub fn tee_session_id(game_address: Address, invalid_index: u64, tee_kind: TeeKind) -> String {
+    pub fn tee_session_id(game_address: Address, invalid_index: u64) -> String {
         let invalid_index = invalid_index.to_be_bytes();
         ProofSessionId::derive_from_components(
             Self::SESSION_NAMESPACE,
-            Self::tee_session_label(tee_kind),
+            "tee/aws_nitro",
             &[game_address.as_slice(), &invalid_index],
         )
     }
@@ -65,13 +53,15 @@ impl ChallengerProofAdapter {
         game_address: Address,
         invalid_index: u64,
         request: PrimitiveProofRequest,
-        tee_kind: TeeKind,
     ) -> ProveBlockRangeRequest {
-        let session_id = Self::tee_session_id(game_address, invalid_index, tee_kind);
+        let session_id = Self::tee_session_id(game_address, invalid_index);
         ProveBlockRangeRequest {
             proof: ProofRequest {
                 session_id,
-                request: ProofRequestKind::Tee(TeeProofRequest { proof: request, tee_kind }),
+                request: ProofRequestKind::Tee(TeeProofRequest {
+                    proof: request,
+                    tee_kind: TeeKind::AwsNitro,
+                }),
             },
         }
     }
@@ -118,27 +108,13 @@ impl ChallengerProofAdapter {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Address, B256, Bytes};
-    use base_proof_primitives::{PROOF_TYPE_TEE, Proposal};
+    use base_proof_primitives::{PROOF_TYPE_TEE, ProofRequest, Proposal};
     use base_prover_service_protocol::{
         ProofRequestKind, ProofResult, SnarkPlonkProofRequest, SnarkPlonkProofResult, TeeKind,
-        TeeProofResult, ZkBackend, ZkProofRequest, ZkProofResult, ZkVm,
+        TeeProofRequest, TeeProofResult, ZkBackend, ZkProofRequest, ZkProofResult, ZkVm,
     };
 
     use super::ChallengerProofAdapter;
-
-    fn test_primitive_request(root: B256) -> base_proof_primitives::ProofRequest {
-        base_proof_primitives::ProofRequest {
-            l1_head: B256::repeat_byte(0x01),
-            agreed_l2_head_hash: B256::repeat_byte(0x02),
-            agreed_l2_output_root: B256::repeat_byte(0x03),
-            claimed_l2_output_root: root,
-            claimed_l2_block_number: 600,
-            proposer: Address::repeat_byte(0x04),
-            intermediate_block_interval: 300,
-            l1_head_number: 1200,
-            image_hash: B256::repeat_byte(0x05),
-        }
-    }
 
     fn test_proposal(root: B256) -> Proposal {
         let mut signature = vec![0xab; 65];
@@ -166,7 +142,7 @@ mod tests {
         );
         assert_ne!(
             ChallengerProofAdapter::snark_plonk_session_id(game_address, invalid_index),
-            ChallengerProofAdapter::tee_session_id(game_address, invalid_index, TeeKind::AwsNitro)
+            ChallengerProofAdapter::tee_session_id(game_address, invalid_index)
         );
     }
 
@@ -206,22 +182,11 @@ mod tests {
         let wrapped = ChallengerProofAdapter::snark_plonk_prove_block_range_request(
             game_address,
             invalid_index,
-            request,
+            request.clone(),
         );
 
         assert_eq!(wrapped.proof.session_id, session_id);
-        match wrapped.proof.request {
-            ProofRequestKind::SnarkPlonk(snark) => {
-                assert_eq!(snark.prover_address, prover_address);
-                assert_eq!(snark.proof.start_block_number, 100);
-                assert_eq!(snark.proof.number_of_blocks_to_prove, 300);
-                assert_eq!(snark.proof.sequence_window, Some(10));
-                assert_eq!(snark.proof.l1_head, Some(l1_head));
-                assert_eq!(snark.proof.intermediate_root_interval, Some(150));
-                assert_eq!(snark.proof.zk_vm, ZkVm::Sp1);
-            }
-            other => panic!("unexpected proof request kind: {other:?}"),
-        }
+        assert_eq!(wrapped.proof.request, ProofRequestKind::SnarkPlonk(request));
     }
 
     #[test]
@@ -229,25 +194,30 @@ mod tests {
         let root = B256::repeat_byte(0xaa);
         let game_address = Address::repeat_byte(0xaa);
         let invalid_index = 1;
-        let request = test_primitive_request(root);
-        let session_id =
-            ChallengerProofAdapter::tee_session_id(game_address, invalid_index, TeeKind::AwsNitro);
+        let request = ProofRequest {
+            l1_head: B256::repeat_byte(0x01),
+            agreed_l2_head_hash: B256::repeat_byte(0x02),
+            agreed_l2_output_root: B256::repeat_byte(0x03),
+            claimed_l2_output_root: root,
+            claimed_l2_block_number: 600,
+            proposer: Address::repeat_byte(0x04),
+            intermediate_block_interval: 300,
+            l1_head_number: 1200,
+            image_hash: B256::repeat_byte(0x05),
+        };
+        let session_id = ChallengerProofAdapter::tee_session_id(game_address, invalid_index);
 
         let wrapped = ChallengerProofAdapter::tee_prove_block_range_request(
             game_address,
             invalid_index,
             request.clone(),
-            TeeKind::AwsNitro,
         );
 
         assert_eq!(wrapped.proof.session_id, session_id);
-        match wrapped.proof.request {
-            ProofRequestKind::Tee(tee) => {
-                assert_eq!(tee.proof, request);
-                assert_eq!(tee.tee_kind, TeeKind::AwsNitro);
-            }
-            other => panic!("unexpected proof request kind: {other:?}"),
-        }
+        assert_eq!(
+            wrapped.proof.request,
+            ProofRequestKind::Tee(TeeProofRequest { proof: request, tee_kind: TeeKind::AwsNitro })
+        );
     }
 
     #[test]

--- a/crates/proof/challenge/src/proof_manager.rs
+++ b/crates/proof/challenge/src/proof_manager.rs
@@ -17,9 +17,7 @@ use base_proof_primitives::ProofRequest as TeeProofRequest;
 use base_proof_rpc::L2Provider;
 use base_proof_submission::KnownRevert;
 use base_prover_service_client::ProofRequesterProvider;
-use base_prover_service_protocol::{
-    SnarkPlonkProofRequest, TeeKind, ZkBackend, ZkProofRequest, ZkVm,
-};
+use base_prover_service_protocol::{SnarkPlonkProofRequest, ZkBackend, ZkProofRequest, ZkVm};
 use base_tx_manager::{TxManager, TxManagerError};
 use tracing::{debug, info, warn};
 
@@ -206,7 +204,6 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
                         game_address,
                         invalid_index,
                         tee_request,
-                        TeeKind::AwsNitro,
                     );
                     match self.proof_requester.prove_block_range(request).await {
                         Ok(response) => {


### PR DESCRIPTION
### What changed? Why?

Simplify `ChallengerProofAdapter` by keeping its fixed AWS Nitro TEE configuration and proof-type labels within the adapter. This removes redundant parameters from its public methods and makes the request-construction tests compare the complete request values.

### Notes to reviewers

TEE proof session IDs and requests continue to use `TeeKind::AwsNitro`; this is a cleanup with no intended behavior change.

### How has it been tested?

- `cargo fmt --check`
- `cargo test -p base-challenger proof_adapter`