### PR TITLE
chore(deps): Waterfall Workspace Manifest Dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ members = [
   "bin/prover/nitro-enclave",
   "bin/prover/zk-host",
   "bin/prover/service",
-  "crates/consensus/*",
   "crates/proof/mpt",
   "crates/proof/proof",
   "crates/proof/driver",
@@ -48,12 +47,13 @@ members = [
   "crates/proof/succinct/utils/elfs",
   "crates/proof/succinct/scripts",
 
+  "crates/execution/*",
+  "crates/consensus/*",
   "crates/utilities/*",
   "crates/batcher/*",
   "crates/builder/*",
-  "crates/infra/*",
   "crates/common/*",
-  "crates/execution/*",
+  "crates/infra/*",
   "etc/tools/*",
   "etc/systems",
   "actions/*",
@@ -160,13 +160,13 @@ base-common-chains = { path = "crates/common/chains" }
 base-common-network = { path = "crates/common/network" }
 base-common-rpc-types = { path = "crates/common/rpc-types" }
 base-common-flashblocks = { path = "crates/common/flashblocks" }
+base-precompile-macros = { path = "crates/common/precompile-macros" }
 base-common-evm = { path = "crates/common/evm", default-features = false }
 base-common-flz = { path = "crates/common/flz", default-features = false }
-base-precompile-macros = { path = "crates/common/precompile-macros" }
 base-common-genesis = { path = "crates/common/genesis", default-features = false }
 base-common-consensus = { path = "crates/common/consensus", default-features = false }
-base-precompile-storage = { path = "crates/common/precompile-storage", default-features = false }
 base-common-precompiles = { path = "crates/common/precompiles", default-features = false }
+base-precompile-storage = { path = "crates/common/precompile-storage", default-features = false }
 base-common-rpc-types-engine = { path = "crates/common/rpc-types-engine", default-features = false }
 base-observability-events = { path = "crates/common/observability-events", default-features = false }
 
@@ -211,9 +211,9 @@ base-execution-consensus = { path = "crates/execution/consensus" }
 base-txpool-tracing = { path = "crates/execution/txpool-tracing" }
 base-execution-payload-builder = { path = "crates/execution/payload" }
 base-flashblocks-node = { path = "crates/execution/flashblocks-node" }
-base-execution-eip8130 = { path = "crates/execution/eip8130", default-features = false }
 base-execution-eip8130-rpc = { path = "crates/execution/eip8130-rpc" }
 base-execution-eip8130-rpc-node = { path = "crates/execution/eip8130-rpc-node" }
+base-execution-eip8130 = { path = "crates/execution/eip8130", default-features = false }
 
 # Infra
 basectl-cli = { path = "crates/infra/basectl" }
@@ -223,8 +223,8 @@ base-snark-e2e = { path = "crates/infra/snark-e2e" }
 base-load-tests = { path = "crates/infra/load-tests" }
 ingress-rpc-lib = { path = "crates/infra/ingress-rpc" }
 base-snapshotter = { path = "crates/infra/snapshotter" }
-base-telemetry-service = { path = "crates/infra/telemetry" }
 websocket-proxy = { path = "crates/infra/websocket-proxy" }
+base-telemetry-service = { path = "crates/infra/telemetry" }
 base-zk-benchmarks = { path = "crates/infra/zk-benchmarks" }
 
 # Proof
@@ -308,9 +308,9 @@ alloy-contract = "2.0.5"
 alloy-json-rpc = "2.0.5"
 alloy-transport = "2.0.5"
 alloy-rpc-types = "2.0.5"
-alloy-rpc-client = "2.0.5"
 alloy-hardforks = "0.4.7"
 alloy-sol-macro = "1.6.0"
+alloy-rpc-client = "2.0.5"
 alloy-signer-gcp = "2.0.5"
 alloy-signer-local = "2.0.5"
 alloy-transport-ws = "2.0.5"
@@ -328,12 +328,14 @@ alloy-consensus = { version = "2.0.5", default-features = false }
 alloy-sol-types = { version = "1.6.0", default-features = false }
 alloy-primitives = { version = "1.6.0", default-features = false }
 alloy-rpc-types-eth = { version = "2.0.5", default-features = false }
-alloy-rpc-types-txpool = { version = "2.0.5", default-features = false }
 alloy-rpc-types-debug = { version = "2.0.5", default-features = false }
+alloy-rpc-types-txpool = { version = "2.0.5", default-features = false }
 alloy-rpc-types-engine = { version = "2.0.5", default-features = false }
 alloy-network-primitives = { version = "2.0.5", default-features = false }
 
 # reth
+reth-zstd-compressors = { version = "0.4.1", default-features = false }
+reth-primitives-traits = { version = "0.4.1", default-features = false }
 reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-ipc = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
@@ -345,8 +347,6 @@ reth-exex = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-tasks = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-ecies = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
-reth-eth-wire = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
-reth-codecs = { version = "0.4.1", default-features = false, features = ["alloy"] }
 reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-discv4 = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-discv5 = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
@@ -355,6 +355,7 @@ reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-network = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-net-nat = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-tracing = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
+reth-eth-wire = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-node-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
@@ -372,6 +373,7 @@ reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0"
 reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-chain-state = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
+reth-codecs = { version = "0.4.1", default-features = false, features = ["alloy"] }
 reth-payload-util = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-node-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
@@ -385,15 +387,14 @@ reth-network-peers = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.
 reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-execution-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-exex-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
-reth-primitives-traits = { version = "0.4.1", default-features = false }
 reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
 reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0" }
@@ -404,7 +405,6 @@ reth-stages-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0
 reth-storage-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0", default-features = false }
 reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0", default-features = false }
 reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0", default-features = false }
-reth-zstd-compressors = { version = "0.4.1", default-features = false }
 
 # tokio
 tokio = "1.48.0"
@@ -423,8 +423,8 @@ tonic = "0.14"
 tonic-web = "0.14"
 prost-types = "0.14"
 tonic-prost = "0.14"
-tonic-prost-build = "0.14"
 tonic-reflection = "0.14"
+tonic-prost-build = "0.14"
 
 # rpc
 jsonrpsee = "0.26.0"
@@ -532,32 +532,32 @@ blake3 = "1.8"
 snap = "1"
 redb = "2"
 hex = "0.4"
-imbl = "7.0.0"
 url = "2.5"
+quote = "1"
 libc = "0.2"
 ctor = "0.6"
 eyre = "0.6"
-quote = "1"
 lru = "0.16"
 rand = "0.9"
 rkyv = "0.8"
 moka = "0.12"
 uuid = "1.21"
-proc-macro2 = "1"
-dirs = "6.0.0"
 csv = "1.3.0"
+imbl = "7.0.0"
+dirs = "6.0.0"
 log = "0.4.22"
 anyhow = "1.0"
 rayon = "1.11"
 nanoid = "0.4"
 tar = "0.4.44"
 backon = "1.6"
-dotenv = "0.15.0"
 time = "0.3.44"
 base64 = "0.22"
 rlimit = "0.11"
 dashmap = "6.1"
 bytes = "1.11.1"
+proc-macro2 = "1"
+dotenv = "0.15.0"
 arboard = "3.6.1"
 chrono = "0.4.42"
 backoff = "0.4.0"
@@ -573,14 +573,12 @@ auto_impl = "1.2.0"
 shellexpand = "3.1"
 dirs-next = "2.0.0"
 num-format = "0.4.4"
-serde_cbor = "0.11.2"
-lazy_static = { version = "1.5.0", features = ["spin_no_std"] }
-strum_macros = "0.28"
 ambassador = "0.4.2"
+serde_cbor = "0.11.2"
+strum_macros = "0.28"
 miniz_oxide = "0.9.0"
 parking_lot = "0.12.3"
 opentelemetry = "0.31"
-opentelemetry-http = { version = "0.31", default-features = false }
 cargo_metadata = "0.18.1"
 tracing-indicatif = "0.3"
 tikv-jemallocator = "0.6"
@@ -588,20 +586,22 @@ modular-bitfield = "0.13.1"
 crossbeam-channel = "0.5.13"
 tracing-opentelemetry = "0.32"
 opentelemetry-appender-tracing = "0.31.1"
-opentelemetry-otlp = { version = "0.31", default-features = false }
-opentelemetry_sdk = { version = "0.31", default-features = false }
+static_assertions = { version = "1.1.0" }
 rand_08 = { package = "rand", version = "0.8" }
 strum = { version = "0.27", default-features = false }
 brotli = { version = "8.0.2", default-features = false }
 rocksdb = { version = "0.24", default-features = false }
+kzg-rs = { version = "0.2.8", default-features = false }
 thiserror = { version = "2.0", default-features = false }
 either = { version = "1.15.0", default-features = false }
-syn = { version = "2", features = ["full", "extra-traits"] }
-kzg-rs = { version = "0.2.8", default-features = false }
 dotenvy = { version = "0.15.7", default-features = false }
-derive_more = { version = "2.1.0", default-features = false }
 figment = { version = "0.10.19", default-features = false }
-static_assertions = { version = "1.1.0" }
+syn = { version = "2", features = ["full", "extra-traits"] }
+derive_more = { version = "2.1.0", default-features = false }
+lazy_static = { version = "1.5.0", features = ["spin_no_std"] }
+opentelemetry_sdk = { version = "0.31", default-features = false }
+opentelemetry-http = { version = "0.31", default-features = false }
+opentelemetry-otlp = { version = "0.31", default-features = false }
 
 # database
 sqlx = { version = "0.8", default-features = false }


### PR DESCRIPTION
## Summary

Sorted the dependencies in the root workspace `Cargo.toml` into waterfall style, ordering each logical group by line length from shortest to longest. This is a pure reordering that keeps every group's comment header and boundaries intact, with no dependency added, removed, or otherwise modified. The change brings the workspace manifest in line with the repository convention for sorting Cargo.toml dependencies.