### PR TITLE
refactor(precompiles): dedupe B20 golden test harness (BOP-449)

### DIFF
--- a/crates/common/precompiles/tests/b20_asset_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v1_golden.rs
@@ -23,41 +23,28 @@
 //! `BLESS_GOLDEN=1 cargo test -p base-common-precompiles --features test-utils \
 //!    --test b20_asset_v1_golden -- --nocapture` and copy the printed `GOLDEN_ROOT` values.
 
-use alloy_primitives::{Address, B256, Bytes, LogData, U256, b256, keccak256};
+use alloy_primitives::{Address, B256, Bytes, U256, b256, keccak256};
 use alloy_sol_types::{SolCall, SolError, SolEvent, SolValue};
 use base_common_genesis::BaseUpgrade;
 use base_common_precompiles::{
     Asset, AssetAccounting, AssetV1, AssetVersion, AssetVersions, B20_MAX_SUPPLY_CAP, B20AssetInit,
     B20AssetStorage, B20AssetToken, B20PolicyType, B20TokenRole, FakePolicyAccounting, IB20,
-    IB20Asset, NoopPrecompileCallObserver, PermitArgs, PolicyVersion, TokenAccounting,
+    IB20Asset, NoopPrecompileCallObserver, PolicyVersion, TokenAccounting,
 };
 use base_precompile_storage::{BasePrecompileError, HashMapStorageProvider, StorageCtx};
-use k256::ecdsa::SigningKey;
+
+mod common;
+use common::{
+    ADMIN, ALICE, BOB, CAROL, CHAIN_ID, MEMO, POLICY_ID, TOKEN, anvil_owner, bless_or_assert_gas,
+    bless_or_assert_root, hash_token_state, ok_true, signed_permit, u,
+};
 
 // --- fixtures ---------------------------------------------------------------
 
-const TOKEN: Address = Address::repeat_byte(0x22);
-const ADMIN: Address = Address::repeat_byte(0xAD);
-const ALICE: Address = Address::repeat_byte(0xA1);
-const BOB: Address = Address::repeat_byte(0xB0);
-const CAROL: Address = Address::repeat_byte(0xCA);
-const CHAIN_ID: u64 = 8453;
 const NAME: &str = "Base Asset";
 const SYMBOL: &str = "bASSET";
 const DECIMALS: u8 = 6;
-const MEMO: B256 = B256::repeat_byte(0x77);
 const LOGIC: AssetV1 = AssetV1;
-
-/// A concrete (non-sentinel) ALLOWLIST policy id (type byte = 1, counter = 7).
-/// Unconfigured scopes default to the `ALWAYS_ALLOW_ID` (0) EVM zero-slot, so
-/// blocking/executor guards are exercised against an explicit id like this one.
-/// Under V1, ALLOWLIST (type = 1) authorizes exactly its members: `.allow(POLICY_ID, acct)`
-/// grants, and unconfigured accounts are blocked.
-const POLICY_ID: u64 = (1u64 << 56) | 7;
-
-// Anvil/Hardhat account 0 — well-known test key, never used in production.
-const PRIVATE_KEY: [u8; 32] =
-    alloy_primitives::hex!("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80");
 
 // --- pinned storage hashes (bless with BLESS_GOLDEN=1; see module docs) --------
 
@@ -138,16 +125,6 @@ const ROOT_ANNOUNCE: B256 =
 
 // --- harness ----------------------------------------------------------------
 
-/// `U256` from a small literal.
-fn u(n: u64) -> U256 {
-    U256::from(n)
-}
-
-/// The ABI encoding for a boolean-returning op (`transfer`/`approve`).
-fn ok_true() -> Bytes {
-    Bytes::from(true.abi_encode())
-}
-
 /// Fresh provider with an initialized `Base Asset` at [`TOKEN`] (multiplier = 1 WAD).
 fn fresh() -> HashMapStorageProvider {
     let mut storage = HashMapStorageProvider::new(CHAIN_ID);
@@ -220,40 +197,10 @@ fn last_topic0(storage: &HashMapStorageProvider) -> B256 {
     storage.get_events(TOKEN).last().expect("an emitted event").topics()[0]
 }
 
-/// Deterministic keccak hash of the per-case snapshot: the token's emitted events
-/// (topics + data) followed by its sorted `(address, slot, value)` storage triples.
-///
-/// A plain content hash (not an MPT state root). Events are included so a regression in
-/// an event's payload — indexed args or data not otherwise reflected in storage, e.g. a
-/// `Memo`'s bytes — is pinned here even though logs are not storage.
-fn hash_state(storage: HashMapStorageProvider) -> B256 {
-    let events: Vec<LogData> = storage.get_events(TOKEN).clone();
-    let mut triples: Vec<(Address, U256, U256)> = storage.into_storage().collect();
-    triples.sort();
-    let mut buf = Vec::with_capacity(triples.len() * 84 + events.len() * 64);
-    for log in &events {
-        for topic in log.topics() {
-            buf.extend_from_slice(topic.as_slice());
-        }
-        buf.extend_from_slice(&log.data);
-    }
-    for (addr, slot, value) in triples {
-        buf.extend_from_slice(addr.as_slice());
-        buf.extend_from_slice(&slot.to_be_bytes::<32>());
-        buf.extend_from_slice(&value.to_be_bytes::<32>());
-    }
-    keccak256(&buf)
-}
-
-/// Asserts the storage hash, or prints it under `BLESS_GOLDEN` for (re)pinning.
+/// Asserts the token's storage hash, or prints it under `BLESS_GOLDEN` for (re)pinning.
 #[track_caller]
 fn assert_root(label: &str, storage: HashMapStorageProvider, expected: B256) {
-    let got = hash_state(storage);
-    if std::env::var("BLESS_GOLDEN").ok().as_deref() == Some("1") {
-        println!("GOLDEN_ROOT {label} = {got:#x}");
-        return;
-    }
-    assert_eq!(got, expected, "V1 storage hash drift for `{label}`");
+    bless_or_assert_root(label, hash_token_state(storage, TOKEN), expected);
 }
 
 /// Grants `role` to `who` and bumps the role member count (setup only).
@@ -276,13 +223,6 @@ fn operator_role() -> B256 {
     keccak256("OPERATOR_ROLE")
 }
 
-/// Recovers the anvil account-0 address from [`PRIVATE_KEY`].
-fn anvil_owner() -> Address {
-    let key = SigningKey::from_slice(&PRIVATE_KEY).unwrap();
-    let point = key.verifying_key().to_encoded_point(false);
-    Address::from_slice(&keccak256(&point.as_bytes()[1..])[12..])
-}
-
 /// The V1 EIP-712 domain separator for the token at [`TOKEN`] on [`CHAIN_ID`].
 fn domain_separator(storage: &mut HashMapStorageProvider) -> B256 {
     StorageCtx::enter(storage, |ctx| {
@@ -293,35 +233,6 @@ fn domain_separator(storage: &mut HashMapStorageProvider) -> B256 {
         );
         LOGIC.domain_separator(&token, CHAIN_ID).unwrap()
     })
-}
-
-/// Builds a validly-signed `permit` call for `owner`'s current nonce.
-fn signed_permit(
-    domain_sep: B256,
-    nonce: U256,
-    owner: Address,
-    spender: Address,
-    value: U256,
-    deadline: U256,
-) -> IB20::permitCall {
-    let mut args =
-        PermitArgs { owner, spender, value, deadline, v: 0, r: B256::ZERO, s: B256::ZERO };
-    let signing_hash = args.signing_hash(domain_sep, nonce);
-    let key = SigningKey::from_slice(&PRIVATE_KEY).unwrap();
-    let (sig, recid) = key.sign_prehash_recoverable(signing_hash.as_slice()).unwrap();
-    let bytes = sig.to_bytes();
-    args.r = B256::from_slice(&bytes[..32]);
-    args.s = B256::from_slice(&bytes[32..]);
-    args.v = if recid.is_y_odd() { 28 } else { 27 };
-    IB20::permitCall {
-        owner: args.owner,
-        spender: args.spender,
-        value: args.value,
-        deadline: args.deadline,
-        v: args.v,
-        r: args.r,
-        s: args.s,
-    }
 }
 
 // ============================================================================
@@ -2647,13 +2558,7 @@ fn golden_gas_footprints() {
         ("update_extra_metadata", (0, 1, 0)),
     ];
 
-    if std::env::var("BLESS_GOLDEN").ok().as_deref() == Some("1") {
-        for (label, counts) in &actual {
-            println!("GAS {label} = {counts:?}");
-        }
-        return;
-    }
-    assert_eq!(actual, expected, "storage-access footprint (sload, sstore, keccak256) drift");
+    bless_or_assert_gas(&actual, expected);
 }
 
 // ============================================================================

--- a/crates/common/precompiles/tests/b20_factory_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_factory_v1_golden.rs
@@ -19,7 +19,7 @@
 //! `BLESS_GOLDEN=1 cargo test -p base-common-precompiles --features test-utils \
 //!    --test b20_factory_v1_golden -- --nocapture` and copy the printed `GOLDEN_ROOT` values.
 
-use alloy_primitives::{Address, B256, Bytes, LogData, U256, address, b256, keccak256};
+use alloy_primitives::{Address, B256, Bytes, LogData, U256, b256, keccak256};
 use alloy_sol_types::{SolCall, SolError, SolEvent, SolValue};
 use base_common_genesis::BaseUpgrade;
 use base_common_precompiles::{
@@ -30,13 +30,14 @@ use base_common_precompiles::{
 };
 use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
 
+mod common;
+use common::{
+    ACTIVATION_ADMIN, ADMIN, ALICE, CHAIN_ID, bless_or_assert_gas, bless_or_assert_root, u,
+};
+
 // --- fixtures ---------------------------------------------------------------
 
-const CHAIN_ID: u64 = 8453;
 const CREATOR: Address = Address::repeat_byte(0xC0);
-const ADMIN: Address = Address::repeat_byte(0xAD);
-const ALICE: Address = Address::repeat_byte(0xA1);
-const ACTIVATION_ADMIN: Address = address!("0xcb00000000000000000000000000000000000000");
 const SALT: B256 = B256::repeat_byte(0x51);
 const NAME: &str = "Base Asset";
 const SYMBOL: &str = "bASSET";
@@ -59,11 +60,6 @@ const ROOT_CREATE_SC_WITH_INIT_CALLS: B256 =
     b256!("f757f7ed634e58fac4ff7c8fbb82fad003287185337ccb067d5564c8776b2cf2");
 
 // --- harness ----------------------------------------------------------------
-
-/// `U256` from a small literal.
-fn u(n: u64) -> U256 {
-    U256::from(n)
-}
 
 /// The factory precompile's singleton address.
 const fn factory() -> Address {
@@ -204,12 +200,7 @@ fn assert_root(
     event_addrs: &[Address],
     expected: B256,
 ) {
-    let got = hash_state(storage, event_addrs);
-    if std::env::var("BLESS_GOLDEN").ok().as_deref() == Some("1") {
-        println!("GOLDEN_ROOT {label} = {got:#x}");
-        return;
-    }
-    assert_eq!(got, expected, "V1 storage hash drift for `{label}`");
+    bless_or_assert_root(label, hash_state(storage, event_addrs), expected);
 }
 
 // ============================================================================
@@ -760,13 +751,7 @@ fn golden_gas_footprints() {
         ("is_b20_initialized", (0, 0, 0)),
     ];
 
-    if std::env::var("BLESS_GOLDEN").ok().as_deref() == Some("1") {
-        for (label, counts) in &actual {
-            println!("GAS {label} = {counts:?}");
-        }
-        return;
-    }
-    assert_eq!(actual, expected, "storage-access footprint (sload, sstore, keccak256) drift");
+    bless_or_assert_gas(&actual, expected);
 }
 
 // ============================================================================

--- a/crates/common/precompiles/tests/b20_policy_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_policy_v1_golden.rs
@@ -24,7 +24,7 @@
 //!    --test b20_policy_v1_golden -- --nocapture` and copy the printed `GOLDEN_ROOT` values.
 
 use IPolicyRegistry::PolicyType;
-use alloy_primitives::{Address, B256, Bytes, LogData, U256, address, b256, keccak256};
+use alloy_primitives::{Address, B256, Bytes, LogData, U256, b256, keccak256};
 use alloy_sol_types::{SolCall, SolError, SolEvent};
 use base_common_genesis::BaseUpgrade;
 use base_common_precompiles::{
@@ -33,14 +33,14 @@ use base_common_precompiles::{
 };
 use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
 
+mod common;
+use common::{
+    ACTIVATION_ADMIN, ADMIN, ALICE, BOB, CHAIN_ID, bless_or_assert_gas, bless_or_assert_root,
+};
+
 // --- fixtures ---------------------------------------------------------------
 
-const CHAIN_ID: u64 = 8453;
-const ACTIVATION_ADMIN: Address = address!("0xcb00000000000000000000000000000000000000");
-const ADMIN: Address = Address::repeat_byte(0xAD);
 const ADMIN2: Address = Address::repeat_byte(0xA2);
-const ALICE: Address = Address::repeat_byte(0xA1);
-const BOB: Address = Address::repeat_byte(0xB0);
 const OUTSIDER: Address = Address::repeat_byte(0x0F);
 
 /// First custom BLOCKLIST id in a fresh registry: `(0 << 56) | 2`.
@@ -162,12 +162,7 @@ fn hash_state(storage: HashMapStorageProvider) -> B256 {
 /// Asserts the storage hash, or prints it under `BLESS_GOLDEN` for (re)pinning.
 #[track_caller]
 fn assert_root(label: &str, storage: HashMapStorageProvider, expected: B256) {
-    let got = hash_state(storage);
-    if std::env::var("BLESS_GOLDEN").ok().as_deref() == Some("1") {
-        println!("GOLDEN_ROOT {label} = {got:#x}");
-        return;
-    }
-    assert_eq!(got, expected, "V1 storage hash drift for `{label}`");
+    bless_or_assert_root(label, hash_state(storage), expected);
 }
 
 // ============================================================================
@@ -818,13 +813,7 @@ fn golden_gas_footprints() {
         ("is_authorized", (1, 0, 0)),
     ];
 
-    if std::env::var("BLESS_GOLDEN").ok().as_deref() == Some("1") {
-        for (label, counts) in &actual {
-            println!("GAS {label} = {counts:?}");
-        }
-        return;
-    }
-    assert_eq!(actual, expected, "storage-access footprint (sload, sstore, keccak256) drift");
+    bless_or_assert_gas(&actual, expected);
 }
 
 // ============================================================================

--- a/crates/common/precompiles/tests/b20_stablecoin_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_stablecoin_v1_golden.rs
@@ -19,45 +19,29 @@
 //! `BLESS_GOLDEN=1 cargo test -p base-common-precompiles --features test-utils \
 //!    --test b20_stablecoin_v1_golden -- --nocapture` and copy the printed `GOLDEN_ROOT` values.
 
-use alloy_primitives::{Address, B256, Bytes, LogData, U256, b256, keccak256};
+use alloy_primitives::{Address, B256, Bytes, U256, b256};
 use alloy_sol_types::{SolCall, SolError, SolEvent, SolValue};
 use base_common_genesis::BaseUpgrade;
 use base_common_precompiles::{
     B20_MAX_SUPPLY_CAP, B20PolicyType, B20StablecoinInit, B20StablecoinStorage, B20StablecoinToken,
     B20TokenRole, FakePolicyAccounting, IB20, IB20Stablecoin, NoopPrecompileCallObserver,
-    PermitArgs, PolicyVersion, Stablecoin, StablecoinV1, StablecoinVersion, StablecoinVersions,
+    PolicyVersion, Stablecoin, StablecoinV1, StablecoinVersion, StablecoinVersions,
     TokenAccounting,
 };
 use base_precompile_storage::{BasePrecompileError, HashMapStorageProvider, StorageCtx};
-use k256::ecdsa::SigningKey;
+
+mod common;
+use common::{
+    ADMIN, ALICE, BOB, CAROL, CHAIN_ID, MEMO, POLICY_ID, TOKEN, anvil_owner, bless_or_assert_gas,
+    bless_or_assert_root, hash_token_state, ok_true, signed_permit, u,
+};
 
 // --- fixtures ---------------------------------------------------------------
 
-const TOKEN: Address = Address::repeat_byte(0x22);
-const ADMIN: Address = Address::repeat_byte(0xAD);
-const ALICE: Address = Address::repeat_byte(0xA1);
-const BOB: Address = Address::repeat_byte(0xB0);
-const CAROL: Address = Address::repeat_byte(0xCA);
-const CHAIN_ID: u64 = 8453;
 const NAME: &str = "USD Coin";
 const SYMBOL: &str = "USDC";
 const CURRENCY: &str = "USD";
-const MEMO: B256 = B256::repeat_byte(0x77);
 const LOGIC: StablecoinV1 = StablecoinV1;
-
-/// A concrete (non-sentinel) ALLOWLIST policy id (type byte = 1, counter = 7).
-///
-/// Unconfigured scopes default to the `ALWAYS_ALLOW_ID` (0) EVM zero-slot, so
-/// blocking/executor guards must be exercised against an explicitly configured
-/// policy id like this one. Under V1 the top byte encodes the policy type, and
-/// authorization goes through membership: ALLOWLIST (type = 1) authorizes exactly
-/// its members, so `.allow(POLICY_ID, acct)` grants and unconfigured accounts are
-/// blocked. A BLOCKLIST id (top byte 0, e.g. a bare `7`) would invert every guard.
-const POLICY_ID: u64 = (1u64 << 56) | 7;
-
-// Anvil/Hardhat account 0 — well-known test key, never used in production.
-const PRIVATE_KEY: [u8; 32] =
-    alloy_primitives::hex!("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80");
 
 // --- pinned storage hashes (bless with BLESS_GOLDEN=1; see module docs) --------
 
@@ -119,16 +103,6 @@ const ROOT_GRANT_UNCHECKED: B256 =
     b256!("c83dd3df2a6f62c0775fb908d7a921f65c8e0e735bdb9b0adf7d1e489b657688");
 
 // --- harness ----------------------------------------------------------------
-
-/// `U256` from a small literal.
-fn u(n: u64) -> U256 {
-    U256::from(n)
-}
-
-/// The ABI encoding for a boolean-returning op (`transfer`/`approve`).
-fn ok_true() -> Bytes {
-    Bytes::from(true.abi_encode())
-}
 
 /// Fresh provider with an initialized `USD Coin` stablecoin at [`TOKEN`].
 fn fresh() -> HashMapStorageProvider {
@@ -204,40 +178,10 @@ fn last_topic0(storage: &HashMapStorageProvider) -> B256 {
     storage.get_events(TOKEN).last().expect("an emitted event").topics()[0]
 }
 
-/// Deterministic keccak hash of the per-case snapshot: the token's emitted events
-/// (topics + data) followed by its sorted `(address, slot, value)` storage triples.
-///
-/// A plain content hash (not an MPT state root). Events are included so a regression in
-/// an event's payload — indexed args or data not otherwise reflected in storage, e.g. a
-/// `Memo`'s bytes — is pinned here even though logs are not storage.
-fn hash_state(storage: HashMapStorageProvider) -> B256 {
-    let events: Vec<LogData> = storage.get_events(TOKEN).clone();
-    let mut triples: Vec<(Address, U256, U256)> = storage.into_storage().collect();
-    triples.sort();
-    let mut buf = Vec::with_capacity(triples.len() * 84 + events.len() * 64);
-    for log in &events {
-        for topic in log.topics() {
-            buf.extend_from_slice(topic.as_slice());
-        }
-        buf.extend_from_slice(&log.data);
-    }
-    for (addr, slot, value) in triples {
-        buf.extend_from_slice(addr.as_slice());
-        buf.extend_from_slice(&slot.to_be_bytes::<32>());
-        buf.extend_from_slice(&value.to_be_bytes::<32>());
-    }
-    keccak256(&buf)
-}
-
-/// Asserts the storage hash, or prints it under `BLESS_GOLDEN` for (re)pinning.
+/// Asserts the token's storage hash, or prints it under `BLESS_GOLDEN` for (re)pinning.
 #[track_caller]
 fn assert_root(label: &str, storage: HashMapStorageProvider, expected: B256) {
-    let got = hash_state(storage);
-    if std::env::var("BLESS_GOLDEN").ok().as_deref() == Some("1") {
-        println!("GOLDEN_ROOT {label} = {got:#x}");
-        return;
-    }
-    assert_eq!(got, expected, "V1 storage hash drift for `{label}`");
+    bless_or_assert_root(label, hash_token_state(storage, TOKEN), expected);
 }
 
 /// Grants `role` to `who` and bumps the role member count (setup only).
@@ -255,13 +199,6 @@ fn fund(token: &mut B20StablecoinStorage<'_>, who: Address, amount: U256) {
     token.set_total_supply(supply + amount).unwrap();
 }
 
-/// Recovers the anvil account-0 address from [`PRIVATE_KEY`].
-fn anvil_owner() -> Address {
-    let key = SigningKey::from_slice(&PRIVATE_KEY).unwrap();
-    let point = key.verifying_key().to_encoded_point(false);
-    Address::from_slice(&keccak256(&point.as_bytes()[1..])[12..])
-}
-
 /// The V1 EIP-712 domain separator for the token at [`TOKEN`] on [`CHAIN_ID`].
 fn domain_separator(storage: &mut HashMapStorageProvider) -> B256 {
     StorageCtx::enter(storage, |ctx| {
@@ -272,35 +209,6 @@ fn domain_separator(storage: &mut HashMapStorageProvider) -> B256 {
         );
         LOGIC.domain_separator(&token, CHAIN_ID).unwrap()
     })
-}
-
-/// Builds a validly-signed `permit` call for `owner`'s current nonce.
-fn signed_permit(
-    domain_sep: B256,
-    nonce: U256,
-    owner: Address,
-    spender: Address,
-    value: U256,
-    deadline: U256,
-) -> IB20::permitCall {
-    let mut args =
-        PermitArgs { owner, spender, value, deadline, v: 0, r: B256::ZERO, s: B256::ZERO };
-    let signing_hash = args.signing_hash(domain_sep, nonce);
-    let key = SigningKey::from_slice(&PRIVATE_KEY).unwrap();
-    let (sig, recid) = key.sign_prehash_recoverable(signing_hash.as_slice()).unwrap();
-    let bytes = sig.to_bytes();
-    args.r = B256::from_slice(&bytes[..32]);
-    args.s = B256::from_slice(&bytes[32..]);
-    args.v = if recid.is_y_odd() { 28 } else { 27 };
-    IB20::permitCall {
-        owner: args.owner,
-        spender: args.spender,
-        value: args.value,
-        deadline: args.deadline,
-        v: args.v,
-        r: args.r,
-        s: args.s,
-    }
 }
 
 // ============================================================================
@@ -2092,13 +2000,7 @@ fn golden_gas_footprints() {
         ("update_policy", (2, 1, 0)),
     ];
 
-    if std::env::var("BLESS_GOLDEN").ok().as_deref() == Some("1") {
-        for (label, counts) in &actual {
-            println!("GAS {label} = {counts:?}");
-        }
-        return;
-    }
-    assert_eq!(actual, expected, "storage-access footprint (sload, sstore, keccak256) drift");
+    bless_or_assert_gas(&actual, expected);
 }
 
 // ============================================================================

--- a/crates/common/precompiles/tests/common/mod.rs
+++ b/crates/common/precompiles/tests/common/mod.rs
@@ -1,0 +1,10 @@
+//! Shared harness for the B-20 precompile golden test suites.
+//!
+//! The four golden integration tests (`b20_asset_v1_golden`, `b20_stablecoin_v1_golden`,
+//! `b20_factory_v1_golden`, `b20_policy_v1_golden`) each compile this module independently,
+//! so not every binary uses every item. The fixtures and helpers live in [`utils`]; this
+//! module only re-exports them.
+#![allow(dead_code, unreachable_pub)]
+
+mod utils;
+pub use utils::*;

--- a/crates/common/precompiles/tests/common/utils.rs
+++ b/crates/common/precompiles/tests/common/utils.rs
@@ -1,0 +1,135 @@
+//! Fixtures and helpers shared across the B-20 precompile golden test suites.
+
+use alloy_primitives::{Address, B256, Bytes, LogData, U256, address, hex, keccak256};
+use alloy_sol_types::SolValue;
+use base_common_precompiles::{IB20, PermitArgs};
+use base_precompile_storage::HashMapStorageProvider;
+use k256::ecdsa::SigningKey;
+
+// --- shared fixtures --------------------------------------------------------
+
+pub const CHAIN_ID: u64 = 8453;
+pub const ADMIN: Address = Address::repeat_byte(0xAD);
+pub const ALICE: Address = Address::repeat_byte(0xA1);
+pub const BOB: Address = Address::repeat_byte(0xB0);
+pub const CAROL: Address = Address::repeat_byte(0xCA);
+/// The token precompile address shared by the asset/stablecoin per-op suites.
+pub const TOKEN: Address = Address::repeat_byte(0x22);
+pub const MEMO: B256 = B256::repeat_byte(0x77);
+/// The activation admin used by the factory/policy suites.
+pub const ACTIVATION_ADMIN: Address = address!("0xcb00000000000000000000000000000000000000");
+
+/// A concrete (non-sentinel) ALLOWLIST policy id (type byte = 1, counter = 7).
+///
+/// Unconfigured scopes default to the `ALWAYS_ALLOW_ID` (0) EVM zero-slot, so
+/// blocking/executor guards are exercised against an explicit id like this one.
+/// Under V1, ALLOWLIST (type = 1) authorizes exactly its members: `.allow(POLICY_ID, acct)`
+/// grants, and unconfigured accounts are blocked.
+pub const POLICY_ID: u64 = (1u64 << 56) | 7;
+
+// Anvil/Hardhat account 0 — well-known test key, never used in production.
+pub const PRIVATE_KEY: [u8; 32] =
+    hex!("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80");
+
+// --- small value helpers ----------------------------------------------------
+
+/// `U256` from a small literal.
+pub fn u(n: u64) -> U256 {
+    U256::from(n)
+}
+
+/// The ABI encoding for a boolean-returning op (`transfer`/`approve`).
+pub fn ok_true() -> Bytes {
+    Bytes::from(true.abi_encode())
+}
+
+// --- permit signing ---------------------------------------------------------
+
+/// Recovers the anvil account-0 address from [`PRIVATE_KEY`].
+pub fn anvil_owner() -> Address {
+    let key = SigningKey::from_slice(&PRIVATE_KEY).unwrap();
+    let point = key.verifying_key().to_encoded_point(false);
+    Address::from_slice(&keccak256(&point.as_bytes()[1..])[12..])
+}
+
+/// Builds a validly-signed `permit` call for `owner`'s current nonce.
+pub fn signed_permit(
+    domain_sep: B256,
+    nonce: U256,
+    owner: Address,
+    spender: Address,
+    value: U256,
+    deadline: U256,
+) -> IB20::permitCall {
+    let mut args =
+        PermitArgs { owner, spender, value, deadline, v: 0, r: B256::ZERO, s: B256::ZERO };
+    let signing_hash = args.signing_hash(domain_sep, nonce);
+    let key = SigningKey::from_slice(&PRIVATE_KEY).unwrap();
+    let (sig, recid) = key.sign_prehash_recoverable(signing_hash.as_slice()).unwrap();
+    let bytes = sig.to_bytes();
+    args.r = B256::from_slice(&bytes[..32]);
+    args.s = B256::from_slice(&bytes[32..]);
+    args.v = if recid.is_y_odd() { 28 } else { 27 };
+    IB20::permitCall {
+        owner: args.owner,
+        spender: args.spender,
+        value: args.value,
+        deadline: args.deadline,
+        v: args.v,
+        r: args.r,
+        s: args.s,
+    }
+}
+
+// --- golden hashing / blessing ----------------------------------------------
+
+/// Deterministic keccak hash of a single token's per-case snapshot: the token's emitted
+/// events (topics + data) followed by every sorted `(address, slot, value)` storage triple.
+///
+/// A plain content hash (not an MPT state root). Events are included so a regression in
+/// an event's payload — indexed args or data not otherwise reflected in storage, e.g. a
+/// `Memo`'s bytes — is pinned here even though logs are not storage. Used by the asset and
+/// stablecoin per-op suites, whose only stateful address is the token itself.
+pub fn hash_token_state(storage: HashMapStorageProvider, token: Address) -> B256 {
+    let events: Vec<LogData> = storage.get_events(token).clone();
+    let mut triples: Vec<(Address, U256, U256)> = storage.into_storage().collect();
+    triples.sort();
+    let mut buf = Vec::with_capacity(triples.len() * 84 + events.len() * 64);
+    for log in &events {
+        for topic in log.topics() {
+            buf.extend_from_slice(topic.as_slice());
+        }
+        buf.extend_from_slice(&log.data);
+    }
+    for (addr, slot, value) in triples {
+        buf.extend_from_slice(addr.as_slice());
+        buf.extend_from_slice(&slot.to_be_bytes::<32>());
+        buf.extend_from_slice(&value.to_be_bytes::<32>());
+    }
+    keccak256(&buf)
+}
+
+/// Asserts a storage hash equals its pin, or prints it under `BLESS_GOLDEN=1` for (re)pinning.
+#[track_caller]
+pub fn bless_or_assert_root(label: &str, got: B256, expected: B256) {
+    if std::env::var("BLESS_GOLDEN").ok().as_deref() == Some("1") {
+        println!("GOLDEN_ROOT {label} = {got:#x}");
+        return;
+    }
+    assert_eq!(got, expected, "V1 storage hash drift for `{label}`");
+}
+
+/// Asserts per-op gas footprints match their pins, or prints them under `BLESS_GOLDEN=1`.
+#[track_caller]
+pub fn bless_or_assert_gas(
+    actual: &[(&str, (u64, u64, u64))],
+    expected: &[(&str, (u64, u64, u64))],
+) {
+    if std::env::var("BLESS_GOLDEN").ok().as_deref() == Some("1") {
+        for (label, counts) in actual {
+            println!("GAS {label} = {counts:?}");
+        }
+        return;
+    }
+    assert_eq!(actual, expected, "storage-access footprint (sload, sstore, keccak256) drift");
+}


### PR DESCRIPTION
## Summary

Cleanup pass on the B20 precompile golden tests (BOP-449). Extracts the duplicated, type-agnostic test harness into a shared `tests/common/mod.rs` and wires all four golden suites (asset, stablecoin, factory, policy) to use it — following the repo's existing `tests/common/mod.rs` convention.

Moved into `common/mod.rs`:
- Shared fixtures: `CHAIN_ID`, `ADMIN`, `ALICE`, `BOB`, `CAROL`, `TOKEN`, `MEMO`, `ACTIVATION_ADMIN`, `POLICY_ID`, `PRIVATE_KEY`
- Helpers: `u()`, `ok_true()`, `anvil_owner()`, `signed_permit()` (the permit/ECDSA stack was duplicated verbatim in asset + stablecoin)
- Golden plumbing: `hash_token_state()` (byte-identical in asset + stablecoin) plus `bless_or_assert_root()` / `bless_or_assert_gas()`, which centralize the `BLESS_GOLDEN` branch that was copy-pasted into every `assert_root` and `golden_gas_footprints`.

Kept per-file (intentionally): the pinned `ROOT_*` constants, the type-specific harness (`fresh`/`seed`/`read`/`op`/`op_privileged`/`gas`, each bound to its `B20*Storage`/`B20*Token`), the factory/policy-specific `hash_state` scoping, and the compile-time `v1_op_coverage_checklist`s. The near-identical asset/stablecoin test bodies were left explicit — golden tests favor readable per-op assertions over generic-ized bodies.

Net: -219 lines across the four suites, +140 shared lines.

## Testing

- All 230 golden tests pass, unchanged from baseline (asset 101, stablecoin 80, policy 28, factory 21).
- Zero pinned constants changed — no re-blessing. Verified via `BLESS_GOLDEN=1` that regenerated hashes match existing pins exactly.
- `cargo clippy -p base-common-precompiles --features test-utils --tests` clean; `cargo +nightly fmt` clean.