### PR TITLE
feat(consensus): configure shadow sequencing cycles

### DIFF
--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -360,9 +360,11 @@ impl ConsensusNodeArgs {
         self.config.l2_config.load(&self.chain.l2_chain_id).map_err(|e| eyre::eyre!(e))
     }
 
-    /// Validates that a sequencer signing key is configured when running in sequencer mode.
+    /// Validates that a non-shadow sequencer has a signing key configured.
     pub fn validate_sequencer_key(&self) -> eyre::Result<()> {
-        if self.config.node_mode.is_sequencer() {
+        if self.config.node_mode.is_sequencer()
+            && self.config.sequencer_flags.shadow_blocks_per_cycle.is_none()
+        {
             let signer = &self.config.p2p_flags.signer;
             if signer.sequencer_key.is_none()
                 && signer.sequencer_key_path.is_none()
@@ -901,6 +903,23 @@ mod tests {
             },
         );
         assert_eq!(args.validate_sequencer_key().is_ok(), expected_ok);
+    }
+
+    #[test]
+    fn shadow_sequencer_does_not_require_signing_key() {
+        let args = ConsensusNodeArgs::new(
+            ConsensusChainArgs { l2_chain_id: Chain::from(8453_u64) },
+            ConsensusNodeConfigArgs {
+                node_mode: NodeMode::Sequencer,
+                sequencer_flags: SequencerArgs {
+                    shadow_blocks_per_cycle: std::num::NonZeroU64::new(10),
+                    ..SequencerArgs::default()
+                },
+                ..default_node_config_args()
+            },
+        );
+
+        assert!(args.validate_sequencer_key().is_ok());
     }
 
     #[test]

--- a/crates/consensus/cli/src/sequencer.rs
+++ b/crates/consensus/cli/src/sequencer.rs
@@ -1,6 +1,9 @@
 //! Sequencer consensus-control CLI flags.
 
-use std::{num::ParseIntError, time::Duration};
+use std::{
+    num::{NonZeroU64, ParseIntError},
+    time::Duration,
+};
 
 use base_consensus_node::SequencerConfig;
 use clap::Parser;
@@ -30,6 +33,15 @@ pub struct SequencerArgs {
         env = "BASE_NODE_SEQUENCER_RECOVER"
     )]
     pub recover: bool,
+
+    /// Number of private blocks to build before reconciling to canonical P2P payloads.
+    ///
+    /// Providing this value enables shadow sequencer mode.
+    #[arg(
+        long = "sequencer.shadow-blocks-per-cycle",
+        env = "BASE_NODE_SEQUENCER_SHADOW_BLOCKS_PER_CYCLE"
+    )]
+    pub shadow_blocks_per_cycle: Option<NonZeroU64>,
 
     /// Conductor service RPC endpoint. Providing this value enables the conductor service.
     #[arg(long = "conductor.rpc", env = "BASE_NODE_CONDUCTOR_RPC")]
@@ -69,10 +81,43 @@ impl SequencerArgs {
         SequencerConfig {
             sequencer_stopped: self.stopped,
             sequencer_recovery_mode: self.recover,
+            shadow_blocks_per_cycle: self.shadow_blocks_per_cycle,
             conductor_rpc_url: self.conductor_rpc.clone(),
             conductor_binary_commit: self.conductor_binary_commit,
             conductor_rpc_timeout: self.conductor_rpc_timeout,
             l1_conf_delay: self.l1_confs,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU64;
+
+    use clap::Parser;
+
+    use super::SequencerArgs;
+
+    #[test]
+    fn parses_shadow_blocks_per_cycle() {
+        let args = SequencerArgs::parse_from([
+            "base-consensus",
+            "--sequencer.shadow-blocks-per-cycle",
+            "12",
+        ]);
+
+        assert_eq!(args.shadow_blocks_per_cycle, NonZeroU64::new(12));
+        assert_eq!(args.config().shadow_blocks_per_cycle, NonZeroU64::new(12));
+    }
+
+    #[test]
+    fn rejects_zero_shadow_blocks_per_cycle() {
+        let result = SequencerArgs::try_parse_from([
+            "base-consensus",
+            "--sequencer.shadow-blocks-per-cycle",
+            "0",
+        ]);
+
+        assert!(result.is_err());
     }
 }

--- a/crates/consensus/service/src/actors/sequencer/config.rs
+++ b/crates/consensus/service/src/actors/sequencer/config.rs
@@ -2,7 +2,7 @@
 //!
 //! [`SequencerActor`]: super::SequencerActor
 
-use std::time::Duration;
+use std::{num::NonZeroU64, time::Duration};
 
 use url::Url;
 
@@ -18,6 +18,10 @@ pub struct SequencerConfig {
     pub sequencer_stopped: bool,
     /// Whether or not the sequencer is in recovery mode.
     pub sequencer_recovery_mode: bool,
+    /// Number of private blocks to build per cycle when running as a shadow sequencer.
+    ///
+    /// When [`None`], the node runs as a normal sequencer.
+    pub shadow_blocks_per_cycle: Option<NonZeroU64>,
     /// The [`Url`] for the conductor RPC endpoint. If [`Some`], enables the conductor service.
     pub conductor_rpc_url: Option<Url>,
     /// Use the conductor's SSZ-binary commit endpoint (`POST /commit-unsafe-payload`)
@@ -40,6 +44,7 @@ impl Default for SequencerConfig {
         Self {
             sequencer_stopped: false,
             sequencer_recovery_mode: false,
+            shadow_blocks_per_cycle: None,
             conductor_rpc_url: None,
             conductor_binary_commit: false,
             conductor_rpc_timeout: DEFAULT_CONDUCTOR_RPC_TIMEOUT,


### PR DESCRIPTION
## Summary

- add a non-zero `--sequencer.shadow-blocks-per-cycle` option
- propagate the setting into `SequencerConfig`
- allow shadow sequencers to run without a local gossip signing key

This is the first PR in the shadow-sequencer stack, based directly on `main`. It only introduces inert configuration; private sealing, P2P buffering, and reconciliation are layered in follow-up PRs.

## Validation

- `cargo test -p base-consensus-cli sequencer --lib`
- `cargo check -p base-consensus-node -p base-consensus-cli`
- `cargo fmt --all -- --check`