### PR TITLE
refactor(proposer): share recovery snapshots

### DIFF
--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -6,6 +6,7 @@
 //! [`ProposerDriverControl`] trait for the admin JSON-RPC server.
 
 use std::{
+    panic::AssertUnwindSafe,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -17,11 +18,15 @@ use alloy_primitives::{Address, B256};
 use async_trait::async_trait;
 use base_proof_rpc::RollupProvider;
 use eyre::Result;
-use tokio::{sync::Mutex as TokioMutex, task::JoinHandle};
+use futures::FutureExt;
+use tokio::{
+    sync::{Mutex as TokioMutex, watch},
+    task::JoinHandle,
+};
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
-use crate::pipeline::ProvingPipeline;
+use crate::{pipeline::ProvingPipeline, proof_recovery::ProofRecovery};
 
 // ---------------------------------------------------------------------------
 // Core types
@@ -118,6 +123,8 @@ where
     R: RollupProvider + 'static,
 {
     pipeline: Arc<ProvingPipeline<R>>,
+    proof_recovery: Arc<ProofRecovery>,
+    recovery_poll_interval: Duration,
     session: TokioMutex<Session>,
     global_cancel: CancellationToken,
     running: Arc<AtomicBool>,
@@ -138,11 +145,18 @@ impl<R> PipelineHandle<R>
 where
     R: RollupProvider + 'static,
 {
-    /// Creates a new [`PipelineHandle`] wrapping the given proving pipeline.
-    pub fn new(pipeline: ProvingPipeline<R>, global_cancel: CancellationToken) -> Self {
+    /// Creates a new [`PipelineHandle`] wrapping the pipeline and recovery loop.
+    pub fn new(
+        pipeline: ProvingPipeline<R>,
+        proof_recovery: Arc<ProofRecovery>,
+        recovery_poll_interval: Duration,
+        global_cancel: CancellationToken,
+    ) -> Self {
         let session = Session { cancel: global_cancel.child_token(), task: None };
         Self {
             pipeline: Arc::new(pipeline),
+            proof_recovery,
+            recovery_poll_interval,
             session: TokioMutex::new(session),
             global_cancel,
             running: Arc::new(AtomicBool::new(false)),
@@ -175,11 +189,44 @@ where
 
         let cancel = self.global_cancel.child_token();
         let pipeline = Arc::clone(&self.pipeline);
+        let proof_recovery = Arc::clone(&self.proof_recovery);
+        let recovery_poll_interval = self.recovery_poll_interval;
 
         let running = Arc::clone(&self.running);
         let run_cancel = cancel.clone();
         let handle = tokio::spawn(async move {
-            pipeline.run(run_cancel).await;
+            info!("Starting proving pipeline");
+
+            loop {
+                let (recovery_tx, recovery_rx) = watch::channel(None);
+                let pipeline_cancel = run_cancel.clone();
+                let session = async {
+                    tokio::select! {
+                        biased;
+                        () = run_cancel.cancelled() => false,
+                        () = proof_recovery.run(recovery_poll_interval, recovery_tx) => true,
+                        restart = pipeline.run(pipeline_cancel, recovery_rx) => restart,
+                    }
+                };
+                let restart =
+                    AssertUnwindSafe(session).catch_unwind().await.unwrap_or_else(|panic| {
+                        let panic = panic
+                            .downcast_ref::<&'static str>()
+                            .copied()
+                            .or_else(|| panic.downcast_ref::<String>().map(String::as_str))
+                            .unwrap_or("unknown panic payload");
+                        warn!(panic = %panic, "Proposer session panicked, restarting");
+                        true
+                    });
+
+                if !restart {
+                    break;
+                }
+
+                info!("Restarting proposer recovery session");
+            }
+
+            info!("Proving pipeline stopped");
             running.store(false, Ordering::Release);
         });
 
@@ -298,9 +345,9 @@ mod tests {
             config.block_interval,
             config.submit_timeout,
         );
-        let pipeline =
-            ProvingPipeline::new(config, proof_dispatcher, proof_recovery, proof_collector);
-        PipelineHandle::new(pipeline, global_cancel)
+        let recovery_poll_interval = config.poll_interval;
+        let pipeline = ProvingPipeline::new(config, proof_dispatcher, proof_collector);
+        PipelineHandle::new(pipeline, proof_recovery, recovery_poll_interval, global_cancel)
     }
 
     #[tokio::test]

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -285,6 +285,7 @@ mod tests {
                 game_type: config.game_type,
                 anchor_state_registry_address: config.anchor_state_registry_address,
                 scan_concurrency: config.recovery_scan_concurrency,
+                rpc_timeout: Duration::from_secs(30),
             },
             Arc::<MockRollupClient>::clone(&rollup),
             anchor_registry,

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -169,6 +169,9 @@ where
                     dispatched_through.store(current.l2_block_number, Ordering::Relaxed);
                 }
             }
+
+            // A pending watch update must not bypass the configured retry delay.
+            tokio::time::sleep(self.config.poll_interval).await;
         }
     }
 
@@ -210,6 +213,9 @@ where
             if restart {
                 break;
             }
+
+            // A pending watch update must not bypass the configured retry delay.
+            tokio::time::sleep(self.config.poll_interval).await;
         }
     }
 }
@@ -231,7 +237,7 @@ mod tests {
     use base_prover_service_client::{ProofRequesterProvider, ProverServiceClientError};
     use base_prover_service_protocol::{
         DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest,
-        ListProofsResponse, ProveBlockRangeRequest, ProveBlockRangeResponse,
+        ListProofsResponse, ProofStatus, ProveBlockRangeRequest, ProveBlockRangeResponse,
     };
     use tokio_util::sync::CancellationToken;
 
@@ -247,6 +253,8 @@ mod tests {
     #[derive(Debug, Default)]
     struct RejectingProofRequester {
         prove_count: AtomicUsize,
+        get_count: AtomicUsize,
+        request_delay: Duration,
         panic_on_first_prove: bool,
     }
 
@@ -257,6 +265,7 @@ mod tests {
             _request: ProveBlockRangeRequest,
         ) -> Result<ProveBlockRangeResponse, ProverServiceClientError> {
             let prove_count = self.prove_count.fetch_add(1, Ordering::SeqCst);
+            tokio::time::sleep(self.request_delay).await;
             if self.panic_on_first_prove && prove_count == 0 {
                 panic!("simulated dispatch panic");
             }
@@ -267,7 +276,9 @@ mod tests {
             &self,
             _request: GetProofRequest,
         ) -> Result<GetProofResponse, ProverServiceClientError> {
-            Err(ProverServiceClientError::Timeout("simulated poll failure".into()))
+            self.get_count.fetch_add(1, Ordering::SeqCst);
+            tokio::time::sleep(self.request_delay).await;
+            Ok(GetProofResponse { status: ProofStatus::Running, error_message: None, result: None })
         }
 
         async fn delete_proof_request(
@@ -285,7 +296,9 @@ mod tests {
         }
     }
 
-    fn test_pipeline(requester: Arc<RejectingProofRequester>) -> ProvingPipeline<MockRollupClient> {
+    fn test_pipeline(
+        requester: Arc<RejectingProofRequester>,
+    ) -> (ProvingPipeline<MockRollupClient>, Arc<MockDisputeGameFactory>) {
         let proof_requester: Arc<dyn ProofRequesterProvider> =
             Arc::<RejectingProofRequester>::clone(&requester);
         let l1 = Arc::new(MockL1::new(1000));
@@ -300,8 +313,9 @@ mod tests {
                 anchor_root: test_anchor_root(0),
                 anchor_game: Address::ZERO,
             });
-        let factory: Arc<dyn DisputeGameFactoryClient> =
-            Arc::new(MockDisputeGameFactory::default());
+        let factory = Arc::new(MockDisputeGameFactory::default());
+        let recovery_factory: Arc<dyn DisputeGameFactoryClient> =
+            Arc::<MockDisputeGameFactory>::clone(&factory);
         let verifier = Arc::new(MockAggregateVerifier::default());
         let output_proposer: Arc<dyn OutputProposer> = Arc::new(MockOutputProposer::default());
         let config = DriverConfig {
@@ -324,10 +338,11 @@ mod tests {
                 game_type: config.game_type,
                 anchor_state_registry_address: config.anchor_state_registry_address,
                 scan_concurrency: config.recovery_scan_concurrency,
+                rpc_timeout: Duration::from_secs(30),
             },
             Arc::<MockRollupClient>::clone(&rollup),
             anchor_registry,
-            factory,
+            recovery_factory,
         ));
         let proof_submitter = ProofSubmitter::new(
             output_proposer,
@@ -343,29 +358,42 @@ mod tests {
             config.block_interval,
             config.submit_timeout,
         );
-        ProvingPipeline::new(config, proof_dispatcher, proof_recovery, proof_collector)
+        (ProvingPipeline::new(config, proof_dispatcher, proof_recovery, proof_collector), factory)
     }
 
-    #[tokio::test]
-    async fn dispatcher_failure_keeps_dispatcher_loop_running() {
-        let requester = Arc::new(RejectingProofRequester::default());
-        let pipeline = test_pipeline(Arc::clone(&requester));
+    #[tokio::test(start_paused = true)]
+    async fn shared_recovery_polls_once_and_retries_both_slow_consumers() {
+        let requester = Arc::new(RejectingProofRequester {
+            request_delay: Duration::from_millis(15),
+            ..Default::default()
+        });
+        let (pipeline, factory) = test_pipeline(Arc::clone(&requester));
         let (recovery_tx, recovery_rx) = watch::channel(None);
+        let cancel = CancellationToken::new();
 
         assert!(
-            tokio::time::timeout(Duration::from_millis(100), async {
+            tokio::time::timeout(Duration::from_millis(49), async {
                 tokio::join!(
                     pipeline.recovery_loop(recovery_tx),
-                    pipeline.dispatcher_loop(recovery_rx, Arc::new(AtomicU64::new(0))),
+                    pipeline.dispatcher_loop(recovery_rx.clone(), Arc::new(AtomicU64::new(0)),),
+                    pipeline.collector_loop(&cancel, recovery_rx, Arc::new(AtomicU64::new(0)),),
                 );
             })
             .await
             .is_err(),
-            "dispatcher failures should not end the dispatcher loop"
+            "pipeline loops should keep running"
         );
-        assert!(
-            requester.prove_count.load(Ordering::SeqCst) > 1,
-            "dispatcher should keep retrying after failures"
+        let recovery_count = factory.game_count_calls.load(Ordering::SeqCst);
+        assert_eq!(recovery_count, 5, "recovery should run once per 10ms poll");
+        assert_eq!(
+            requester.prove_count.load(Ordering::SeqCst),
+            2,
+            "dispatcher retries should preserve the post-tick delay"
+        );
+        assert_eq!(
+            requester.get_count.load(Ordering::SeqCst),
+            2,
+            "pending proof retries should preserve the post-tick delay"
         );
     }
 
@@ -373,7 +401,7 @@ mod tests {
     async fn dispatcher_panic_restarts_pipeline_session() {
         let requester =
             Arc::new(RejectingProofRequester { panic_on_first_prove: true, ..Default::default() });
-        let pipeline = test_pipeline(Arc::clone(&requester));
+        let (pipeline, _) = test_pipeline(Arc::clone(&requester));
         let cancel = CancellationToken::new();
         let run = pipeline.run(cancel.clone());
         tokio::pin!(run);

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -10,6 +10,7 @@ use std::{
 
 use base_proof_rpc::RollupProvider;
 use futures::FutureExt;
+use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
@@ -23,9 +24,9 @@ use crate::{
 
 /// The proving pipeline.
 ///
-/// Runs concurrent dispatcher and collector tasks per [`Self::run`] session.
-/// The collector chains ready proofs internally and restarts both tasks only
-/// when it needs fresh onchain state.
+/// Runs concurrent recovery, dispatcher, and collector tasks per [`Self::run`]
+/// session. The collector chains ready proofs internally and restarts the
+/// session only when it needs fresh onchain state.
 pub struct ProvingPipeline<R>
 where
     R: RollupProvider + 'static,
@@ -61,11 +62,11 @@ where
 
     /// Runs the proving pipeline until cancelled.
     ///
-    /// Each session starts a dispatcher task and a collector task. The
-    /// dispatcher can run ahead up to the finalized head, while the collector
-    /// submits ready proofs in order from an internal cursor. Outcomes that
-    /// cannot safely advance that cursor restart both tasks from a fresh
-    /// recovery walk.
+    /// Each session starts recovery, dispatcher, and collector tasks. Recovery
+    /// publishes one shared onchain snapshot per poll. The dispatcher can run
+    /// ahead up to the finalized head, while the collector submits ready proofs
+    /// in order from an internal cursor. Outcomes that cannot safely advance
+    /// that cursor restart the session from a fresh recovery walk.
     pub async fn run(&self, cancel: CancellationToken) {
         info!(
             block_interval = self.config.block_interval,
@@ -76,21 +77,30 @@ where
 
         loop {
             let dispatched_through = Arc::new(AtomicU64::new(0));
+            let (recovery_tx, recovery_rx) = watch::channel(None);
 
-            // dispatcher_loop intentionally does not return; this branch keeps it
-            // polled while collector_loop remains the session restart signal.
-            // Dropping either loop mid-tick is safe: the next recovery walk
+            // The recovery and dispatcher loops intentionally do not return;
+            // collector_loop remains the session restart signal. Dropping any
+            // loop mid-tick is safe: the next recovery walk
             // rediscovers any already-broadcast L1 transaction from onchain state.
             let session = async {
                 tokio::select! {
                     biased;
                     () = cancel.cancelled() => false,
-                    () = self.dispatcher_loop(Arc::clone(&dispatched_through)) => true,
-                    () = self.collector_loop(&cancel, Arc::clone(&dispatched_through)) => true,
+                    () = self.recovery_loop(recovery_tx) => true,
+                    () = self.dispatcher_loop(
+                        recovery_rx.clone(),
+                        Arc::clone(&dispatched_through),
+                    ) => true,
+                    () = self.collector_loop(
+                        &cancel,
+                        recovery_rx,
+                        Arc::clone(&dispatched_through),
+                    ) => true,
                 }
             };
             // Unwind safety: this assertion is scoped to one pipeline session. Session progress
-            // lives in the loop-local caches/cursors above and is discarded on panic; `self` only
+            // lives in the session-local cache/cursors and is discarded on panic; `self` only
             // carries shared clients and static config that are reused after a fresh recovery walk.
             let restart = AssertUnwindSafe(session).catch_unwind().await.unwrap_or_else(|panic| {
                 let panic = panic
@@ -112,22 +122,37 @@ where
         info!("Proving pipeline stopped");
     }
 
-    async fn dispatcher_loop(&self, dispatched_through: Arc<AtomicU64>) {
+    async fn recovery_loop(&self, recovery_tx: watch::Sender<Option<(RecoveredState, u64)>>) {
         let mut cache: Option<ProofRecoveryCache> = None;
+
+        loop {
+            let plan = self.proof_recovery.try_recover_and_plan(&mut cache).await;
+            if let Some((state, finalized_head)) = plan {
+                Metrics::safe_head().set(finalized_head as f64);
+                Metrics::finalized_head().set(finalized_head as f64);
+                Metrics::last_proposed_block().set(state.l2_block_number as f64);
+            }
+            // Publish unchanged plans too so failed dispatches and pending proofs retry.
+            recovery_tx.send_replace(plan);
+
+            tokio::time::sleep(self.config.poll_interval).await;
+        }
+    }
+
+    async fn dispatcher_loop(
+        &self,
+        mut recovery_rx: watch::Receiver<Option<(RecoveredState, u64)>>,
+        dispatched_through: Arc<AtomicU64>,
+    ) {
         let mut cursor_source: Option<RecoveredState> = None;
         let mut cursor: Option<RecoveredState> = None;
 
-        loop {
+        while recovery_rx.changed().await.is_ok() {
             {
                 let _tick_timer = base_metrics::timed!(Metrics::tick_duration_seconds());
+                let plan = *recovery_rx.borrow_and_update();
 
-                if let Some((recovered, finalized_head)) =
-                    self.proof_recovery.try_recover_and_plan(&mut cache).await
-                {
-                    Metrics::safe_head().set(finalized_head as f64);
-                    Metrics::finalized_head().set(finalized_head as f64);
-                    Metrics::last_proposed_block().set(recovered.l2_block_number as f64);
-
+                if let Some((recovered, finalized_head)) = plan {
                     // Dispatch failures retry from the in-memory cursor. A fresh recovery walk is
                     // only needed when onchain state changes; try_recover_and_plan returns that as
                     // a different recovered state, which resets the cursor here.
@@ -144,27 +169,24 @@ where
                     dispatched_through.store(current.l2_block_number, Ordering::Relaxed);
                 }
             }
-
-            tokio::time::sleep(self.config.poll_interval).await;
         }
     }
 
-    async fn collector_loop(&self, cancel: &CancellationToken, dispatched_through: Arc<AtomicU64>) {
-        let mut cache: Option<ProofRecoveryCache> = None;
+    async fn collector_loop(
+        &self,
+        cancel: &CancellationToken,
+        mut recovery_rx: watch::Receiver<Option<(RecoveredState, u64)>>,
+        dispatched_through: Arc<AtomicU64>,
+    ) {
         let mut cursor_source: Option<RecoveredState> = None;
         let mut cursor: Option<RecoveredState> = None;
 
-        loop {
+        while recovery_rx.changed().await.is_ok() {
             let restart = {
                 let _tick_timer = base_metrics::timed!(Metrics::collector_tick_duration_seconds());
+                let plan = *recovery_rx.borrow_and_update();
 
-                if let Some((recovered, finalized_head)) =
-                    self.proof_recovery.try_recover_and_plan(&mut cache).await
-                {
-                    Metrics::safe_head().set(finalized_head as f64);
-                    Metrics::finalized_head().set(finalized_head as f64);
-                    Metrics::last_proposed_block().set(recovered.l2_block_number as f64);
-
+                if let Some((recovered, finalized_head)) = plan {
                     if cursor_source != Some(recovered) || cursor.is_none() {
                         cursor_source = Some(recovered);
                         cursor = Some(recovered);
@@ -188,8 +210,6 @@ where
             if restart {
                 break;
             }
-
-            tokio::time::sleep(self.config.poll_interval).await;
         }
     }
 }
@@ -330,12 +350,15 @@ mod tests {
     async fn dispatcher_failure_keeps_dispatcher_loop_running() {
         let requester = Arc::new(RejectingProofRequester::default());
         let pipeline = test_pipeline(Arc::clone(&requester));
+        let (recovery_tx, recovery_rx) = watch::channel(None);
 
         assert!(
-            tokio::time::timeout(
-                Duration::from_millis(100),
-                pipeline.dispatcher_loop(Arc::new(AtomicU64::new(0)))
-            )
+            tokio::time::timeout(Duration::from_millis(100), async {
+                tokio::join!(
+                    pipeline.recovery_loop(recovery_tx),
+                    pipeline.dispatcher_loop(recovery_rx, Arc::new(AtomicU64::new(0))),
+                );
+            })
             .await
             .is_err(),
             "dispatcher failures should not end the dispatcher loop"

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -12,28 +12,24 @@ use base_proof_rpc::RollupProvider;
 use futures::FutureExt;
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
+use tracing::warn;
 
 use crate::{
     Metrics,
     driver::{DriverConfig, RecoveredState},
     proof_collector::ProofCollector,
     proof_dispatcher::ProofDispatcher,
-    proof_recovery::{ProofRecovery, ProofRecoveryCache},
 };
 
 /// The proving pipeline.
 ///
-/// Runs concurrent recovery, dispatcher, and collector tasks per [`Self::run`]
-/// session. The collector chains ready proofs internally and restarts the
-/// session only when it needs fresh onchain state.
+/// Runs concurrent dispatcher and collector tasks for one recovery session.
 pub struct ProvingPipeline<R>
 where
     R: RollupProvider + 'static,
 {
     config: DriverConfig,
     proof_dispatcher: ProofDispatcher,
-    proof_recovery: Arc<ProofRecovery>,
     proof_collector: ProofCollector<R>,
 }
 
@@ -54,89 +50,49 @@ where
     pub const fn new(
         config: DriverConfig,
         proof_dispatcher: ProofDispatcher,
-        proof_recovery: Arc<ProofRecovery>,
         proof_collector: ProofCollector<R>,
     ) -> Self {
-        Self { config, proof_dispatcher, proof_recovery, proof_collector }
+        Self { config, proof_dispatcher, proof_collector }
     }
 
-    /// Runs the proving pipeline until cancelled.
+    /// Runs the dispatcher and collector loops for one recovery session.
     ///
-    /// Each session starts recovery, dispatcher, and collector tasks. Recovery
-    /// publishes one shared onchain snapshot per poll. The dispatcher can run
-    /// ahead up to the finalized head, while the collector submits ready proofs
-    /// in order from an internal cursor. Outcomes that cannot safely advance
-    /// that cursor restart the session from a fresh recovery walk.
-    pub async fn run(&self, cancel: CancellationToken) {
-        info!(
-            block_interval = self.config.block_interval,
-            poll_interval_secs = self.config.poll_interval.as_secs(),
-            submit_timeout_secs = ?self.config.submit_timeout.map(|timeout| timeout.as_secs()),
-            "Starting proving pipeline"
-        );
+    /// Returns `true` when the driver should start a fresh recovery session.
+    pub async fn run(
+        &self,
+        cancel: CancellationToken,
+        recovery_rx: watch::Receiver<Option<(RecoveredState, u64)>>,
+    ) -> bool {
+        let dispatched_through = Arc::new(AtomicU64::new(0));
 
-        loop {
-            let dispatched_through = Arc::new(AtomicU64::new(0));
-            let (recovery_tx, recovery_rx) = watch::channel(None);
-
-            // The recovery and dispatcher loops intentionally do not return;
-            // collector_loop remains the session restart signal. Dropping any
-            // loop mid-tick is safe: the next recovery walk
-            // rediscovers any already-broadcast L1 transaction from onchain state.
-            let session = async {
-                tokio::select! {
-                    biased;
-                    () = cancel.cancelled() => false,
-                    () = self.recovery_loop(recovery_tx) => true,
-                    () = self.dispatcher_loop(
-                        recovery_rx.clone(),
-                        Arc::clone(&dispatched_through),
-                    ) => true,
-                    () = self.collector_loop(
-                        &cancel,
-                        recovery_rx,
-                        Arc::clone(&dispatched_through),
-                    ) => true,
-                }
-            };
-            // Unwind safety: this assertion is scoped to one pipeline session. Session progress
-            // lives in the session-local cache/cursors and is discarded on panic; `self` only
-            // carries shared clients and static config that are reused after a fresh recovery walk.
-            let restart = AssertUnwindSafe(session).catch_unwind().await.unwrap_or_else(|panic| {
-                let panic = panic
-                    .downcast_ref::<&'static str>()
-                    .copied()
-                    .or_else(|| panic.downcast_ref::<String>().map(String::as_str))
-                    .unwrap_or("unknown panic payload");
-                warn!(panic = %panic, "Pipeline loop panicked, restarting session");
-                true
-            });
-
-            if !restart {
-                break;
+        // dispatcher_loop intentionally does not return; this branch keeps it
+        // polled while collector_loop remains the session restart signal.
+        // Dropping either loop mid-tick is safe: the next recovery session
+        // rediscovers any already-broadcast L1 transaction from onchain state.
+        let session = async {
+            tokio::select! {
+                biased;
+                () = cancel.cancelled() => false,
+                () = self.dispatcher_loop(
+                    recovery_rx.clone(),
+                    Arc::clone(&dispatched_through),
+                ) => true,
+                () = self.collector_loop(
+                    &cancel,
+                    recovery_rx,
+                    Arc::clone(&dispatched_through),
+                ) => true,
             }
-
-            info!("Restarting proving pipeline session");
-        }
-
-        info!("Proving pipeline stopped");
-    }
-
-    async fn recovery_loop(&self, recovery_tx: watch::Sender<Option<(RecoveredState, u64)>>) {
-        let mut cache: Option<ProofRecoveryCache> = None;
-
-        loop {
-            let plan = self.proof_recovery.try_recover_and_plan(&mut cache).await;
-            if let Some((state, finalized_head)) = plan {
-                Metrics::safe_head().set(finalized_head as f64);
-                Metrics::finalized_head().set(finalized_head as f64);
-                Metrics::last_proposed_block().set(state.l2_block_number as f64);
-            }
-            // Publish unchanged plans too so failed dispatches and pending proofs retry.
-            recovery_tx.send_replace(plan);
-
-            tokio::time::sleep(self.config.poll_interval).await;
-        }
+        };
+        AssertUnwindSafe(session).catch_unwind().await.unwrap_or_else(|panic| {
+            let panic = panic
+                .downcast_ref::<&'static str>()
+                .copied()
+                .or_else(|| panic.downcast_ref::<String>().map(String::as_str))
+                .unwrap_or("unknown panic payload");
+            warn!(panic = %panic, "Pipeline loop panicked, restarting session");
+            true
+        })
     }
 
     async fn dispatcher_loop(
@@ -153,9 +109,8 @@ where
                 let plan = *recovery_rx.borrow_and_update();
 
                 if let Some((recovered, finalized_head)) = plan {
-                    // Dispatch failures retry from the in-memory cursor. A fresh recovery walk is
-                    // only needed when onchain state changes; try_recover_and_plan returns that as
-                    // a different recovered state, which resets the cursor here.
+                    // Dispatch failures retry from the in-memory cursor. The recovery publisher
+                    // resets it only when onchain state changes the recovered state.
                     if cursor_source != Some(recovered) || cursor.is_none() {
                         cursor_source = Some(recovered);
                         cursor = Some(recovered);
@@ -233,28 +188,27 @@ mod tests {
 
     use alloy_primitives::{Address, B256};
     use async_trait::async_trait;
-    use base_proof_contracts::{AnchorStateRegistryClient, DisputeGameFactoryClient};
+    use base_proof_contracts::DisputeGameFactoryClient;
     use base_prover_service_client::{ProofRequesterProvider, ProverServiceClientError};
     use base_prover_service_protocol::{
         DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest,
-        ListProofsResponse, ProofStatus, ProveBlockRangeRequest, ProveBlockRangeResponse,
+        ListProofsResponse, ProveBlockRangeRequest, ProveBlockRangeResponse,
     };
+    use tokio::sync::watch;
     use tokio_util::sync::CancellationToken;
 
     use super::*;
     use crate::{
-        OutputProposer, ProofDispatcherConfig, ProofRecoveryConfig, ProofSubmitter,
+        OutputProposer, ProofDispatcherConfig, ProofSubmitter,
         test_utils::{
-            MockAggregateVerifier, MockAnchorStateRegistry, MockDisputeGameFactory, MockL1, MockL2,
-            MockOutputProposer, MockRollupClient, test_anchor_root, test_sync_status,
+            MockAggregateVerifier, MockDisputeGameFactory, MockL1, MockL2, MockOutputProposer,
+            MockRollupClient, test_sync_status,
         },
     };
 
     #[derive(Debug, Default)]
     struct RejectingProofRequester {
         prove_count: AtomicUsize,
-        get_count: AtomicUsize,
-        request_delay: Duration,
         panic_on_first_prove: bool,
     }
 
@@ -265,7 +219,6 @@ mod tests {
             _request: ProveBlockRangeRequest,
         ) -> Result<ProveBlockRangeResponse, ProverServiceClientError> {
             let prove_count = self.prove_count.fetch_add(1, Ordering::SeqCst);
-            tokio::time::sleep(self.request_delay).await;
             if self.panic_on_first_prove && prove_count == 0 {
                 panic!("simulated dispatch panic");
             }
@@ -276,9 +229,7 @@ mod tests {
             &self,
             _request: GetProofRequest,
         ) -> Result<GetProofResponse, ProverServiceClientError> {
-            self.get_count.fetch_add(1, Ordering::SeqCst);
-            tokio::time::sleep(self.request_delay).await;
-            Ok(GetProofResponse { status: ProofStatus::Running, error_message: None, result: None })
+            unimplemented!("pipeline tests do not collect proofs")
         }
 
         async fn delete_proof_request(
@@ -296,9 +247,7 @@ mod tests {
         }
     }
 
-    fn test_pipeline(
-        requester: Arc<RejectingProofRequester>,
-    ) -> (ProvingPipeline<MockRollupClient>, Arc<MockDisputeGameFactory>) {
+    fn test_pipeline(requester: Arc<RejectingProofRequester>) -> ProvingPipeline<MockRollupClient> {
         let proof_requester: Arc<dyn ProofRequesterProvider> =
             Arc::<RejectingProofRequester>::clone(&requester);
         let l1 = Arc::new(MockL1::new(1000));
@@ -308,14 +257,8 @@ mod tests {
             output_roots: HashMap::new(),
             max_safe_block: None,
         });
-        let anchor_registry: Arc<dyn AnchorStateRegistryClient> =
-            Arc::new(MockAnchorStateRegistry {
-                anchor_root: test_anchor_root(0),
-                anchor_game: Address::ZERO,
-            });
-        let factory = Arc::new(MockDisputeGameFactory::default());
-        let recovery_factory: Arc<dyn DisputeGameFactoryClient> =
-            Arc::<MockDisputeGameFactory>::clone(&factory);
+        let factory: Arc<dyn DisputeGameFactoryClient> =
+            Arc::new(MockDisputeGameFactory::default());
         let verifier = Arc::new(MockAggregateVerifier::default());
         let output_proposer: Arc<dyn OutputProposer> = Arc::new(MockOutputProposer::default());
         let config = DriverConfig {
@@ -331,23 +274,10 @@ mod tests {
             Arc::<MockRollupClient>::clone(&rollup),
             ProofDispatcherConfig::from(&config),
         );
-        let proof_recovery = Arc::new(ProofRecovery::new(
-            ProofRecoveryConfig {
-                block_interval: config.block_interval,
-                intermediate_block_interval: config.intermediate_block_interval,
-                game_type: config.game_type,
-                anchor_state_registry_address: config.anchor_state_registry_address,
-                scan_concurrency: config.recovery_scan_concurrency,
-                rpc_timeout: Duration::from_secs(30),
-            },
-            Arc::<MockRollupClient>::clone(&rollup),
-            anchor_registry,
-            recovery_factory,
-        ));
         let proof_submitter = ProofSubmitter::new(
             output_proposer,
             Arc::<MockRollupClient>::clone(&rollup),
-            Arc::new(MockDisputeGameFactory::default()),
+            factory,
             verifier,
             &config,
         );
@@ -358,66 +288,34 @@ mod tests {
             config.block_interval,
             config.submit_timeout,
         );
-        (ProvingPipeline::new(config, proof_dispatcher, proof_recovery, proof_collector), factory)
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn shared_recovery_polls_once_and_retries_both_slow_consumers() {
-        let requester = Arc::new(RejectingProofRequester {
-            request_delay: Duration::from_millis(15),
-            ..Default::default()
-        });
-        let (pipeline, factory) = test_pipeline(Arc::clone(&requester));
-        let (recovery_tx, recovery_rx) = watch::channel(None);
-        let cancel = CancellationToken::new();
-
-        assert!(
-            tokio::time::timeout(Duration::from_millis(49), async {
-                tokio::join!(
-                    pipeline.recovery_loop(recovery_tx),
-                    pipeline.dispatcher_loop(recovery_rx.clone(), Arc::new(AtomicU64::new(0)),),
-                    pipeline.collector_loop(&cancel, recovery_rx, Arc::new(AtomicU64::new(0)),),
-                );
-            })
-            .await
-            .is_err(),
-            "pipeline loops should keep running"
-        );
-        let recovery_count = factory.game_count_calls.load(Ordering::SeqCst);
-        assert_eq!(recovery_count, 5, "recovery should run once per 10ms poll");
-        assert_eq!(
-            requester.prove_count.load(Ordering::SeqCst),
-            2,
-            "dispatcher retries should preserve the post-tick delay"
-        );
-        assert_eq!(
-            requester.get_count.load(Ordering::SeqCst),
-            2,
-            "pending proof retries should preserve the post-tick delay"
-        );
+        ProvingPipeline::new(config, proof_dispatcher, proof_collector)
     }
 
     #[tokio::test]
-    async fn dispatcher_panic_restarts_pipeline_session() {
+    async fn dispatcher_panic_requests_recovery_session_restart() {
         let requester =
             Arc::new(RejectingProofRequester { panic_on_first_prove: true, ..Default::default() });
-        let (pipeline, _) = test_pipeline(Arc::clone(&requester));
-        let cancel = CancellationToken::new();
-        let run = pipeline.run(cancel.clone());
-        tokio::pin!(run);
+        let pipeline = test_pipeline(Arc::clone(&requester));
+        let (recovery_tx, recovery_rx) = watch::channel(None);
+        recovery_tx
+            .send(Some((
+                RecoveredState {
+                    parent_address: Address::ZERO,
+                    output_root: B256::ZERO,
+                    l2_block_number: 0,
+                },
+                200,
+            )))
+            .expect("pipeline should retain the recovery receiver");
 
-        tokio::select! {
-            () = &mut run => panic!("pipeline should restart instead of exiting"),
-            result = tokio::time::timeout(Duration::from_millis(200), async {
-                while requester.prove_count.load(Ordering::SeqCst) < 2 {
-                    tokio::time::sleep(Duration::from_millis(10)).await;
-                }
-            }) => result.expect("pipeline should retry after dispatcher panic"),
-        }
+        let restart = tokio::time::timeout(
+            Duration::from_millis(100),
+            pipeline.run(CancellationToken::new(), recovery_rx),
+        )
+        .await
+        .expect("pipeline should return after a dispatcher panic");
 
-        cancel.cancel();
-        tokio::time::timeout(Duration::from_millis(100), &mut run)
-            .await
-            .expect("pipeline should stop after cancellation");
+        assert!(restart, "dispatcher panic should restart the recovery session");
+        assert_eq!(requester.prove_count.load(Ordering::SeqCst), 1);
     }
 }

--- a/crates/proof/proposer/src/proof_recovery.rs
+++ b/crates/proof/proposer/src/proof_recovery.rs
@@ -1,9 +1,11 @@
 //! Recovers proposer onchain state from submitted dispute games.
 
-use std::sync::Arc;
+use std::{future::Future, sync::Arc, time::Duration};
 
 use alloy_primitives::Address;
-use base_proof_contracts::{AnchorStateRegistryClient, DisputeGameFactoryClient, game_lookup_key};
+use base_proof_contracts::{
+    AnchorStateRegistryClient, ContractError, DisputeGameFactoryClient, game_lookup_key,
+};
 use base_proof_rpc::{RollupProvider, RpcError};
 use futures::{StreamExt, TryStreamExt, stream};
 use tracing::{debug, info, warn};
@@ -26,6 +28,8 @@ pub struct ProofRecoveryConfig {
     pub anchor_state_registry_address: Address,
     /// Maximum number of concurrent rollup RPC calls during root fetching.
     pub scan_concurrency: usize,
+    /// Maximum duration for each contract RPC used during recovery.
+    pub rpc_timeout: Duration,
 }
 
 /// Cached result from the last successful recovery walk.
@@ -113,6 +117,21 @@ impl ProofRecovery {
         Some((state, finalized_head))
     }
 
+    async fn contract_call<T>(
+        &self,
+        operation: &str,
+        call: impl Future<Output = Result<T, ContractError>>,
+    ) -> Result<T, ProposerError> {
+        match tokio::time::timeout(self.config.rpc_timeout, call).await {
+            Ok(Ok(value)) => Ok(value),
+            Ok(Err(error)) => Err(ProposerError::Contract(format!("{operation} failed: {error}"))),
+            Err(_) => Err(ProposerError::Contract(format!(
+                "{operation} timed out after {}s",
+                self.config.rpc_timeout.as_secs_f64()
+            ))),
+        }
+    }
+
     /// Recovers the latest onchain state using a deterministic forward walk
     /// from the anchor root, bounded by `finalized_head`.
     pub async fn recover_latest_state(
@@ -120,19 +139,13 @@ impl ProofRecovery {
         cache: &mut Option<ProofRecoveryCache>,
         finalized_head: u64,
     ) -> Result<RecoveredState, ProposerError> {
-        let count = self
-            .factory_client
-            .game_count()
-            .await
-            .map_err(|e| ProposerError::Contract(format!("recovery game_count failed: {e}")))?;
+        let count =
+            self.contract_call("recovery game_count", self.factory_client.game_count()).await?;
 
         // Read the anchor root and anchor game from one L1 snapshot so
         // recovery cannot combine an old root with a newer anchor game.
-        let anchor_snapshot = self
-            .anchor_registry
-            .anchor_snapshot()
-            .await
-            .map_err(|e| ProposerError::Contract(format!("anchor_snapshot failed: {e}")))?;
+        let anchor_snapshot =
+            self.contract_call("anchor_snapshot", self.anchor_registry.anchor_snapshot()).await?;
         let anchor = anchor_snapshot.anchor_root;
         let usable_cache =
             cache.as_ref().filter(|cached| anchor.l2_block_number <= cached.state.l2_block_number);
@@ -247,16 +260,17 @@ impl ProofRecovery {
             )
             .map_err(|e| ProposerError::Config(e.to_string()))?;
 
+            let operation = format!("games lookup at block {}", key.target_block);
             let lookup = self
-                .factory_client
-                .games(self.config.game_type, key.root_claim, key.extra_data)
-                .await
-                .map_err(|e| {
-                    ProposerError::Contract(format!(
-                        "games lookup failed at block {}: {e}",
-                        key.target_block
-                    ))
-                })?;
+                .contract_call(
+                    &operation,
+                    self.factory_client.games(
+                        self.config.game_type,
+                        key.root_claim,
+                        key.extra_data,
+                    ),
+                )
+                .await?;
 
             if lookup == Address::ZERO {
                 info!(
@@ -289,7 +303,7 @@ impl ProofRecovery {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, sync::Arc};
+    use std::{collections::HashMap, sync::Arc, time::Duration};
 
     use alloy_primitives::{Address, B256};
     use base_proof_contracts::AnchorRoot;
@@ -390,6 +404,7 @@ mod tests {
                 game_type: TEST_GAME_TYPE,
                 anchor_state_registry_address: Address::ZERO,
                 scan_concurrency: 8,
+                rpc_timeout: Duration::from_secs(30),
             },
             Arc::new(MockRollupClient {
                 sync_status: test_sync_status(0, B256::ZERO),
@@ -487,6 +502,28 @@ mod tests {
         let result = recovery.recover_latest_state(&mut cache, u64::MAX).await;
 
         assert!(matches!(result, Err(ProposerError::Contract(_))));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_recovery_times_out_contract_calls() {
+        let factory = MockDisputeGameFactory {
+            game_count_delay: Some(Duration::from_secs(1)),
+            ..Default::default()
+        };
+        let mut recovery = recovery(factory, HashMap::new());
+        recovery.config.rpc_timeout = Duration::from_millis(10);
+        let mut cache: Option<ProofRecoveryCache> = None;
+
+        let result = recovery.recover_latest_state(&mut cache, u64::MAX).await;
+
+        assert!(
+            matches!(
+                result,
+                Err(ProposerError::Contract(message))
+                    if message.contains("recovery game_count timed out")
+            ),
+            "hung contract calls should be bounded by the configured RPC timeout"
+        );
     }
 
     #[tokio::test]

--- a/crates/proof/proposer/src/proof_recovery.rs
+++ b/crates/proof/proposer/src/proof_recovery.rs
@@ -8,10 +8,11 @@ use base_proof_contracts::{
 };
 use base_proof_rpc::{RollupProvider, RpcError};
 use futures::{StreamExt, TryStreamExt, stream};
+use tokio::sync::watch;
 use tracing::{debug, info, warn};
 
 use crate::{
-    driver::RecoveredState, error::ProposerError, proof_target::ProofTarget,
+    Metrics, driver::RecoveredState, error::ProposerError, proof_target::ProofTarget,
     proposal_intervals::ProposalIntervals,
 };
 
@@ -115,6 +116,28 @@ impl ProofRecovery {
         };
 
         Some((state, finalized_head))
+    }
+
+    /// Publishes the latest recovery plan at the given polling interval.
+    pub async fn run(
+        &self,
+        poll_interval: Duration,
+        recovery_tx: watch::Sender<Option<(RecoveredState, u64)>>,
+    ) {
+        let mut cache: Option<ProofRecoveryCache> = None;
+
+        loop {
+            let plan = self.try_recover_and_plan(&mut cache).await;
+            if let Some((state, finalized_head)) = plan {
+                Metrics::safe_head().set(finalized_head as f64);
+                Metrics::finalized_head().set(finalized_head as f64);
+                Metrics::last_proposed_block().set(state.l2_block_number as f64);
+            }
+            // Publish unchanged plans too so failed dispatches and pending proofs retry.
+            recovery_tx.send_replace(plan);
+
+            tokio::time::sleep(poll_interval).await;
+        }
     }
 
     async fn contract_call<T>(
@@ -306,7 +329,8 @@ mod tests {
     use std::{collections::HashMap, sync::Arc, time::Duration};
 
     use alloy_primitives::{Address, B256};
-    use base_proof_contracts::AnchorRoot;
+    use base_proof_contracts::{AnchorRoot, DisputeGameFactoryClient};
+    use tokio::sync::watch;
 
     use super::*;
     use crate::test_utils::{
@@ -524,6 +548,47 @@ mod tests {
             ),
             "hung contract calls should be bounded by the configured RPC timeout"
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn recovery_loop_publishes_one_plan_per_poll() {
+        let factory = Arc::new(MockDisputeGameFactory::default());
+        let factory_client: Arc<dyn DisputeGameFactoryClient> =
+            Arc::<MockDisputeGameFactory>::clone(&factory);
+        let recovery = ProofRecovery::new(
+            ProofRecoveryConfig {
+                block_interval: 100,
+                intermediate_block_interval: 100,
+                game_type: TEST_GAME_TYPE,
+                anchor_state_registry_address: Address::ZERO,
+                scan_concurrency: 8,
+                rpc_timeout: Duration::from_secs(30),
+            },
+            Arc::new(MockRollupClient {
+                sync_status: test_sync_status(200, B256::ZERO),
+                output_roots: HashMap::new(),
+                max_safe_block: None,
+            }),
+            Arc::new(MockAnchorStateRegistry {
+                anchor_root: test_anchor_root(TEST_ANCHOR_BLOCK),
+                anchor_game: Address::ZERO,
+            }),
+            factory_client,
+        );
+        let (recovery_tx, recovery_rx) = watch::channel(None);
+        let run = recovery.run(Duration::from_millis(10), recovery_tx);
+        tokio::pin!(run);
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(49), &mut run).await.is_err(),
+            "recovery loop should keep running"
+        );
+        assert_eq!(
+            factory.game_count_calls.load(std::sync::atomic::Ordering::SeqCst),
+            5,
+            "recovery should run once per 10ms poll"
+        );
+        assert!(recovery_rx.borrow().is_some(), "recovery should publish a plan");
     }
 
     #[tokio::test]

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -261,11 +261,15 @@ impl ProposerService {
             driver_config.block_interval,
             driver_config.submit_timeout,
         );
-        let pipeline =
-            ProvingPipeline::new(driver_config, proof_dispatcher, proof_recovery, proof_collector);
+        let recovery_poll_interval = driver_config.poll_interval;
+        let pipeline = ProvingPipeline::new(driver_config, proof_dispatcher, proof_collector);
         info!("Proving pipeline initialized");
-        let driver_handle: Arc<dyn ProposerDriverControl> =
-            Arc::new(PipelineHandle::new(pipeline, cancel.clone()));
+        let driver_handle: Arc<dyn ProposerDriverControl> = Arc::new(PipelineHandle::new(
+            pipeline,
+            proof_recovery,
+            recovery_poll_interval,
+            cancel.clone(),
+        ));
 
         let ready = Arc::new(AtomicBool::new(false));
         let health_handle: JoinHandle<Result<()>> = {

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -248,6 +248,7 @@ impl ProposerService {
                 game_type: driver_config.game_type,
                 anchor_state_registry_address: driver_config.anchor_state_registry_address,
                 scan_concurrency: driver_config.recovery_scan_concurrency,
+                rpc_timeout: config.rpc_timeout,
             },
             Arc::<RollupClient>::clone(&rollup_client),
             anchor_registry,

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -2,7 +2,11 @@
 
 use std::{
     collections::{HashMap, VecDeque},
-    sync::Mutex,
+    sync::{
+        Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
 };
 
 use alloy_eips::BlockNumberOrTag;
@@ -188,6 +192,10 @@ impl AnchorStateRegistryClient for MockAnchorStateRegistry {
 pub struct MockDisputeGameFactory {
     /// The game count returned by `game_count()`.
     pub game_count: u64,
+    /// Number of calls to `game_count()`.
+    pub game_count_calls: AtomicUsize,
+    /// Optional delay before `game_count()` returns.
+    pub game_count_delay: Option<Duration>,
     /// UUID-keyed game proxy lookups for `games()`.
     pub uuid_games: HashMap<(u32, B256, Bytes), Address>,
     /// Ordered responses for repeated `games()` calls.
@@ -206,6 +214,10 @@ impl MockDisputeGameFactory {
 #[async_trait]
 impl DisputeGameFactoryClient for MockDisputeGameFactory {
     async fn game_count(&self) -> Result<u64, ContractError> {
+        self.game_count_calls.fetch_add(1, Ordering::SeqCst);
+        if let Some(delay) = self.game_count_delay {
+            tokio::time::sleep(delay).await;
+        }
         Ok(self.game_count)
     }
     async fn game_at_index(&self, _: u64) -> Result<GameAtIndex, ContractError> {


### PR DESCRIPTION
### What changed? Why?

The proposer now performs recovery once per poll and publishes the resulting onchain snapshot to both the dispatcher and collector. This removes duplicate forward walks and recovery RPCs while retaining independent dispatcher and collector cursors.

### Notes to reviewers

Unchanged snapshots are published on every poll so failed dispatches and pending proofs continue to retry.

### How has it been tested?

- `cargo test -p base-proposer --lib`
- `cargo clippy -p base-proposer --lib --tests -- -D warnings`