### PR TITLE
feat(consensus): privately seal shadow payloads

### DIFF
--- a/actions/harness/src/sequencer/driver.rs
+++ b/actions/harness/src/sequencer/driver.rs
@@ -276,6 +276,7 @@ impl L2Sequencer {
             conductor: Some(ActionConductor::new(Arc::clone(&self.conductor))),
             engine_client,
             is_active: false,
+            shadow_blocks_per_cycle: None,
             recovery_mode: RecoveryModeGuard::new(false),
             rollup_config: self.actor_rollup_config(),
             unsafe_payload_gossip_client: ActionUnsafePayloadGossipClient,

--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -363,7 +363,7 @@ impl ConsensusNodeArgs {
     /// Validates that a non-shadow sequencer has a signing key configured.
     pub fn validate_sequencer_key(&self) -> eyre::Result<()> {
         if self.config.node_mode.is_sequencer()
-            && self.config.sequencer_flags.shadow_blocks_per_cycle.is_none()
+            && !self.config.sequencer_flags.config().is_shadow_sequencer()
         {
             let signer = &self.config.p2p_flags.signer;
             if signer.sequencer_key.is_none()

--- a/crates/consensus/service/src/actors/sequencer/actor.rs
+++ b/crates/consensus/service/src/actors/sequencer/actor.rs
@@ -1,6 +1,7 @@
 //! The [`SequencerActor`].
 
 use std::{
+    num::NonZeroU64,
     sync::Arc,
     time::{Duration, Instant, UNIX_EPOCH},
 };
@@ -65,6 +66,8 @@ pub struct SequencerActor<
     pub engine_client: Arc<SequencerEngineClient_>,
     /// Whether the sequencer is active.
     pub is_active: bool,
+    /// Number of private blocks to build per shadow sequencing cycle.
+    pub shadow_blocks_per_cycle: Option<NonZeroU64>,
     /// Shared recovery mode flag.
     pub recovery_mode: RecoveryModeGuard,
     /// The rollup configuration.
@@ -116,7 +119,11 @@ where
         Metrics::sequencer_total_transactions_sequenced()
             .increment(handle.attributes_with_parent.count_transactions());
 
-        Ok(PayloadSealer::new(envelope))
+        if self.shadow_blocks_per_cycle.is_some() {
+            Ok(PayloadSealer::new_private(envelope))
+        } else {
+            Ok(PayloadSealer::new(envelope))
+        }
     }
 
     /// Attempts to seal a pre-built payload, first checking whether it is still fresh.

--- a/crates/consensus/service/src/actors/sequencer/actor.rs
+++ b/crates/consensus/service/src/actors/sequencer/actor.rs
@@ -103,6 +103,11 @@ where
     SequencerEngineClient_: SequencerEngineClient,
     UnsafePayloadGossipClient_: UnsafePayloadGossipClient,
 {
+    /// Returns whether this actor is running as a shadow sequencer.
+    pub const fn is_shadow_sequencer(&self) -> bool {
+        self.shadow_blocks_per_cycle.is_some()
+    }
+
     /// Fetches the sealed payload envelope from the engine for the given unsealed handle.
     pub(super) async fn seal_payload(
         &self,
@@ -119,7 +124,7 @@ where
         Metrics::sequencer_total_transactions_sequenced()
             .increment(handle.attributes_with_parent.count_transactions());
 
-        if self.shadow_blocks_per_cycle.is_some() {
+        if self.is_shadow_sequencer() {
             Ok(PayloadSealer::new_private(envelope))
         } else {
             Ok(PayloadSealer::new(envelope))

--- a/crates/consensus/service/src/actors/sequencer/config.rs
+++ b/crates/consensus/service/src/actors/sequencer/config.rs
@@ -39,6 +39,13 @@ pub struct SequencerConfig {
     pub l1_conf_delay: u64,
 }
 
+impl SequencerConfig {
+    /// Returns whether shadow sequencer mode is enabled.
+    pub const fn is_shadow_sequencer(&self) -> bool {
+        self.shadow_blocks_per_cycle.is_some()
+    }
+}
+
 impl Default for SequencerConfig {
     fn default() -> Self {
         Self {

--- a/crates/consensus/service/src/actors/sequencer/seal.rs
+++ b/crates/consensus/service/src/actors/sequencer/seal.rs
@@ -23,6 +23,8 @@ pub enum SealState {
     Committed,
     /// Gossiped to peers. Ready for engine insertion.
     Gossiped,
+    /// Private payload ready for engine insertion without conductor commit or gossip.
+    Private,
 }
 
 /// Result from one seal pipeline step.
@@ -40,7 +42,7 @@ impl SealState {
         match self {
             Self::Sealed => "conductor",
             Self::Committed => "gossip",
-            Self::Gossiped => "insert",
+            Self::Gossiped | Self::Private => "insert",
         }
     }
 }
@@ -79,6 +81,13 @@ impl PayloadSealer {
         );
 
         Self { envelope, state: SealState::Sealed, seal_span, started_at: Instant::now() }
+    }
+
+    /// Creates a private sealer that skips conductor commit and gossip.
+    pub fn new_private(envelope: BaseExecutionPayloadEnvelope) -> Self {
+        let mut sealer = Self::new(envelope);
+        sealer.state = SealState::Private;
+        sealer
     }
 
     /// Performs one step of the seal pipeline.
@@ -127,7 +136,7 @@ impl PayloadSealer {
                 self.state = SealState::Gossiped;
                 Ok(SealStepOutcome::Pending)
             }
-            SealState::Gossiped => {
+            SealState::Gossiped | SealState::Private => {
                 self.seal_span.in_scope(
                     || debug!(target: "sequencer", step = "insert", "seal pipeline step"),
                 );

--- a/crates/consensus/service/src/actors/sequencer/seal.rs
+++ b/crates/consensus/service/src/actors/sequencer/seal.rs
@@ -23,7 +23,7 @@ pub enum SealState {
     Committed,
     /// Gossiped to peers. Ready for engine insertion.
     Gossiped,
-    /// Private payload ready for engine insertion without conductor commit or gossip.
+    /// Shadow sequencer payload ready for private engine insertion without commit or gossip.
     Private,
 }
 
@@ -144,9 +144,14 @@ impl PayloadSealer {
                 Ok(SealStepOutcome::Pending)
             }
             SealState::Gossiped | SealState::Private => {
-                self.seal_span.in_scope(
-                    || debug!(target: "sequencer", step = "insert", "seal pipeline step"),
-                );
+                self.seal_span.in_scope(|| {
+                    debug!(
+                        target: "sequencer",
+                        step = "insert",
+                        state = ?self.state,
+                        "seal pipeline step"
+                    );
+                });
                 let inserted_head = engine_client
                     .insert_unsafe_payload(self.envelope.clone())
                     .instrument(self.seal_span.clone())

--- a/crates/consensus/service/src/actors/sequencer/seal.rs
+++ b/crates/consensus/service/src/actors/sequencer/seal.rs
@@ -85,9 +85,16 @@ impl PayloadSealer {
 
     /// Creates a private sealer that skips conductor commit and gossip.
     pub fn new_private(envelope: BaseExecutionPayloadEnvelope) -> Self {
-        let mut sealer = Self::new(envelope);
-        sealer.state = SealState::Private;
-        sealer
+        let block_hash = envelope.execution_payload.block_hash();
+        let block_num = envelope.execution_payload.block_number();
+        let seal_span = tracing::info_span!(
+            "seal_payload_pipeline",
+            block_hash = %block_hash,
+            block_number = block_num,
+            mode = "shadow",
+        );
+
+        Self { envelope, state: SealState::Private, seal_span, started_at: Instant::now() }
     }
 
     /// Performs one step of the seal pipeline.

--- a/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::{num::NonZeroU64, sync::Arc, time::Duration};
 
 use alloy_primitives::B256;
 use alloy_rpc_types_engine::ExecutionPayloadV1;
@@ -259,6 +259,26 @@ async fn test_seal_payload_success_returns_sealer() {
 }
 
 #[tokio::test]
+async fn test_shadow_seal_payload_returns_private_sealer() {
+    let envelope = dummy_envelope();
+
+    let mut client = MockSequencerEngineClient::new();
+    client.expect_get_sealed_payload().times(1).return_once(move |_, _| Ok(envelope));
+
+    let mut actor = test_actor();
+    actor.engine_client = Arc::new(client);
+    actor.shadow_blocks_per_cycle = NonZeroU64::new(10);
+
+    let handle = UnsealedPayloadHandle {
+        payload_id: Default::default(),
+        attributes_with_parent: dummy_attributes_with_parent(),
+    };
+    let sealer = actor.seal_payload(&handle).await.unwrap();
+
+    assert_eq!(sealer.state, SealState::Private);
+}
+
+#[tokio::test]
 async fn test_seal_payload_failure_propagates() {
     let mut client = MockSequencerEngineClient::new();
     client
@@ -279,6 +299,49 @@ async fn test_seal_payload_failure_propagates() {
 }
 
 // --- PayloadSealer::step tests ---
+
+#[tokio::test]
+async fn test_private_sealer_only_inserts() {
+    let envelope = dummy_envelope();
+
+    let mut conductor = MockConductor::new();
+    conductor.expect_commit_unsafe_payload().times(0);
+
+    let mut gossip = MockUnsafePayloadGossipClient::new();
+    gossip.expect_schedule_execution_payload_gossip().times(0);
+
+    let mut engine = MockSequencerEngineClient::new();
+    engine.expect_insert_unsafe_payload().times(1).return_once(|_| Ok(L2BlockInfo::default()));
+
+    let mut sealer = PayloadSealer::new_private(envelope);
+    let result = sealer.step(&Some(conductor), &gossip, &engine).await;
+
+    assert_eq!(result.unwrap(), SealStepOutcome::Inserted(L2BlockInfo::default()));
+    assert_eq!(sealer.state, SealState::Private);
+}
+
+#[tokio::test]
+async fn test_private_sealer_insert_failure_stays_private() {
+    let envelope = dummy_envelope();
+
+    let mut conductor = MockConductor::new();
+    conductor.expect_commit_unsafe_payload().times(0);
+
+    let mut gossip = MockUnsafePayloadGossipClient::new();
+    gossip.expect_schedule_execution_payload_gossip().times(0);
+
+    let mut engine = MockSequencerEngineClient::new();
+    engine
+        .expect_insert_unsafe_payload()
+        .times(1)
+        .return_once(|_| Err(EngineClientError::RequestError("channel closed".to_string())));
+
+    let mut sealer = PayloadSealer::new_private(envelope);
+    let result = sealer.step(&Some(conductor), &gossip, &engine).await;
+
+    assert!(matches!(result.unwrap_err(), SealStepError::Insert(_)));
+    assert_eq!(sealer.state, SealState::Private);
+}
 
 #[tokio::test]
 async fn test_sealer_full_pipeline_no_conductor() {

--- a/crates/consensus/service/src/actors/sequencer/tests/test_util.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/test_util.rs
@@ -41,6 +41,7 @@ pub(super) fn test_actor() -> SequencerActor<
         conductor: None,
         engine_client,
         is_active: true,
+        shadow_blocks_per_cycle: None,
         recovery_mode,
         rollup_config,
         unsafe_payload_gossip_client: MockUnsafePayloadGossipClient::new(),

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -573,6 +573,7 @@ impl RollupNode {
                     conductor,
                     engine_client,
                     is_active: self.sequencer_config.sequencer_stopped.not(),
+                    shadow_blocks_per_cycle: self.sequencer_config.shadow_blocks_per_cycle,
                     recovery_mode,
                     rollup_config: Arc::clone(&self.config),
                     unsafe_payload_gossip_client: queued_gossip_client,


### PR DESCRIPTION
## Summary
- propagate the shadow sequencing configuration into the sequencer actor
- start shadow payload sealers directly at local engine insertion
- structurally bypass conductor commit and CL payload gossip for shadow-built blocks
- preserve the normal commit, gossip, and insert pipeline for ordinary sequencers

## Scope
This is the second PR in the shadow sequencer stack. It only establishes the private local insertion path. P2P payload buffering, authoritative reconciliation, and cycle counting are intentionally deferred to follow-up PRs.

## Tests
- `cargo test -p base-consensus-node sequencer --lib`
- `cargo check -p base-consensus-node`
- `cargo check -p base-action-harness`
- `cargo fmt --all -- --check`
- `git diff --check`
