### PR TITLE
feat(rpc): add millisecond timestamps to newHeads

### DIFF
--- a/crates/execution/rpc/src/eth/mod.rs
+++ b/crates/execution/rpc/src/eth/mod.rs
@@ -7,6 +7,7 @@ pub mod transaction;
 mod block;
 mod call;
 mod pending_block;
+mod pubsub;
 
 use std::{
     fmt::{self, Formatter},
@@ -27,8 +28,8 @@ use reth_rpc_eth_api::{
     EthApiTypes, FromEvmError, FullEthApiServer, RpcConvert, RpcConverter, RpcNodeCore,
     RpcNodeCoreExt, RpcTypes,
     helpers::{
-        EthApiSpec, EthFees, EthState, EthSubscriptions, GetBlockAccessList, LoadFee,
-        LoadPendingBlock, LoadState, SpawnBlocking, Trace, pending_block::BuildPendingEnv,
+        EthApiSpec, EthFees, EthState, GetBlockAccessList, LoadFee, LoadPendingBlock, LoadState,
+        SpawnBlocking, Trace, pending_block::BuildPendingEnv,
     },
 };
 use reth_rpc_eth_types::{EthStateCache, FeeHistoryCache, GasPriceOracle};
@@ -160,13 +161,6 @@ where
     fn starting_block(&self) -> U256 {
         self.inner.eth_api.starting_block()
     }
-}
-
-impl<N, Rpc> EthSubscriptions for BaseEthApi<N, Rpc>
-where
-    N: RpcNodeCore,
-    Rpc: RpcConvert<Primitives = N::Primitives, Error = BaseEthApiError>,
-{
 }
 
 impl<N, Rpc> SpawnBlocking for BaseEthApi<N, Rpc>

--- a/crates/execution/rpc/src/eth/pubsub.rs
+++ b/crates/execution/rpc/src/eth/pubsub.rs
@@ -30,7 +30,7 @@ where
                         })
                         .ok()?;
                     header.timestamp_ms = BaseTimeUpdateTx::extract_timestamp_ms(
-                        &block.body().transactions,
+                        block.body().transactions(),
                         block.number,
                         block.timestamp,
                     )

--- a/crates/execution/rpc/src/eth/pubsub.rs
+++ b/crates/execution/rpc/src/eth/pubsub.rs
@@ -1,7 +1,8 @@
 //! Base `eth_subscribe` stream customization.
 
-use base_common_consensus::BasePrimitives;
+use base_common_consensus::{BasePrimitives, BaseTransaction};
 use base_common_network::Base;
+use base_common_rpc_types::BaseHeaderResponse;
 use base_protocol::BaseTimeUpdateTx;
 use futures::StreamExt;
 use reth_chain_state::CanonStateSubscriptions;
@@ -10,6 +11,16 @@ use tracing::error;
 
 use super::BaseEthApi;
 use crate::BaseEthApiError;
+
+fn apply_timestamp_ms<T: BaseTransaction>(
+    header: &mut BaseHeaderResponse,
+    transactions: &[T],
+    block_number: u64,
+    block_timestamp: u64,
+) {
+    header.timestamp_ms =
+        BaseTimeUpdateTx::extract_timestamp_ms(transactions, block_number, block_timestamp).ok();
+}
 
 impl<N, Rpc> EthSubscriptions for BaseEthApi<N, Rpc>
 where
@@ -23,16 +34,15 @@ where
                 .committed()
                 .blocks_iter()
                 .filter_map(|block| {
-                    let timestamp_ms = BaseTimeUpdateTx::extract_timestamp_ms(
-                        &block.body().transactions,
-                        block.number,
-                        block.timestamp,
-                    )
-                    .ok();
                     match converter.convert_header(block.clone_sealed_header(), block.rlp_length())
                     {
                         Ok(mut header) => {
-                            header.timestamp_ms = timestamp_ms;
+                            apply_timestamp_ms(
+                                &mut header,
+                                &block.body().transactions,
+                                block.number,
+                                block.timestamp,
+                            );
                             Some(header)
                         }
                         Err(err) => {
@@ -44,5 +54,37 @@ where
                 .collect::<Vec<_>>();
             futures::stream::iter(headers)
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base_common_consensus::{BaseTransactionSigned, TxDeposit};
+    use base_common_rpc_types::BaseHeaderResponse;
+    use base_protocol::BaseTimeUpdateTx;
+
+    use super::apply_timestamp_ms;
+
+    #[test]
+    fn adds_timestamp_ms_from_base_time_metadata() {
+        let transactions: Vec<BaseTransactionSigned> = vec![
+            TxDeposit::default().into(),
+            BaseTimeUpdateTx::new(600).unwrap().into_deposit_tx(9).into(),
+        ];
+        let mut header = BaseHeaderResponse::default();
+
+        apply_timestamp_ms(&mut header, &transactions, 9, 42);
+
+        assert_eq!(header.timestamp_ms, Some(42_600));
+    }
+
+    #[test]
+    fn omits_timestamp_ms_without_valid_base_time_metadata() {
+        let transactions: Vec<BaseTransactionSigned> = vec![TxDeposit::default().into()];
+        let mut header = BaseHeaderResponse::default();
+
+        apply_timestamp_ms(&mut header, &transactions, 9, 42);
+
+        assert_eq!(header.timestamp_ms, None);
     }
 }

--- a/crates/execution/rpc/src/eth/pubsub.rs
+++ b/crates/execution/rpc/src/eth/pubsub.rs
@@ -1,8 +1,7 @@
 //! Base `eth_subscribe` stream customization.
 
-use base_common_consensus::{BasePrimitives, BaseTransaction};
+use base_common_consensus::BasePrimitives;
 use base_common_network::Base;
-use base_common_rpc_types::BaseHeaderResponse;
 use base_protocol::BaseTimeUpdateTx;
 use futures::StreamExt;
 use reth_chain_state::CanonStateSubscriptions;
@@ -11,16 +10,6 @@ use tracing::error;
 
 use super::BaseEthApi;
 use crate::BaseEthApiError;
-
-fn apply_timestamp_ms<T: BaseTransaction>(
-    header: &mut BaseHeaderResponse,
-    transactions: &[T],
-    block_number: u64,
-    block_timestamp: u64,
-) {
-    header.timestamp_ms =
-        BaseTimeUpdateTx::extract_timestamp_ms(transactions, block_number, block_timestamp).ok();
-}
 
 impl<N, Rpc> EthSubscriptions for BaseEthApi<N, Rpc>
 where
@@ -40,48 +29,16 @@ where
                             error!(error = %err, "failed to convert canonical header");
                         })
                         .ok()?;
-                    apply_timestamp_ms(
-                        &mut header,
+                    header.timestamp_ms = BaseTimeUpdateTx::extract_timestamp_ms(
                         &block.body().transactions,
                         block.number,
                         block.timestamp,
-                    );
+                    )
+                    .ok();
                     Some(header)
                 })
                 .collect::<Vec<_>>();
             futures::stream::iter(headers)
         })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use base_common_consensus::{BaseTransactionSigned, TxDeposit};
-    use base_common_rpc_types::BaseHeaderResponse;
-    use base_protocol::BaseTimeUpdateTx;
-
-    use super::apply_timestamp_ms;
-
-    #[test]
-    fn adds_timestamp_ms_from_base_time_metadata() {
-        let transactions: Vec<BaseTransactionSigned> = vec![
-            TxDeposit::default().into(),
-            BaseTimeUpdateTx::new(600).unwrap().into_deposit_tx(9).into(),
-        ];
-        let mut header = BaseHeaderResponse::default();
-
-        apply_timestamp_ms(&mut header, &transactions, 9, 42);
-
-        assert_eq!(header.timestamp_ms, Some(42_600));
-    }
-
-    #[test]
-    fn omits_timestamp_ms_without_valid_base_time_metadata() {
-        let transactions: Vec<BaseTransactionSigned> = vec![TxDeposit::default().into()];
-        let mut header = BaseHeaderResponse::default();
-
-        apply_timestamp_ms(&mut header, &transactions, 9, 42);
-
-        assert_eq!(header.timestamp_ms, None);
     }
 }

--- a/crates/execution/rpc/src/eth/pubsub.rs
+++ b/crates/execution/rpc/src/eth/pubsub.rs
@@ -34,22 +34,19 @@ where
                 .committed()
                 .blocks_iter()
                 .filter_map(|block| {
-                    match converter.convert_header(block.clone_sealed_header(), block.rlp_length())
-                    {
-                        Ok(mut header) => {
-                            apply_timestamp_ms(
-                                &mut header,
-                                &block.body().transactions,
-                                block.number,
-                                block.timestamp,
-                            );
-                            Some(header)
-                        }
-                        Err(err) => {
+                    let mut header = converter
+                        .convert_header(block.clone_sealed_header(), block.rlp_length())
+                        .inspect_err(|err| {
                             error!(error = %err, "failed to convert canonical header");
-                            None
-                        }
-                    }
+                        })
+                        .ok()?;
+                    apply_timestamp_ms(
+                        &mut header,
+                        &block.body().transactions,
+                        block.number,
+                        block.timestamp,
+                    );
+                    Some(header)
                 })
                 .collect::<Vec<_>>();
             futures::stream::iter(headers)

--- a/crates/execution/rpc/src/eth/pubsub.rs
+++ b/crates/execution/rpc/src/eth/pubsub.rs
@@ -1,0 +1,48 @@
+//! Base `eth_subscribe` stream customization.
+
+use base_common_consensus::BasePrimitives;
+use base_common_network::Base;
+use base_protocol::BaseTimeUpdateTx;
+use futures::StreamExt;
+use reth_chain_state::CanonStateSubscriptions;
+use reth_rpc_eth_api::{RpcConvert, RpcHeader, RpcNodeCore, helpers::EthSubscriptions};
+use tracing::error;
+
+use super::BaseEthApi;
+use crate::BaseEthApiError;
+
+impl<N, Rpc> EthSubscriptions for BaseEthApi<N, Rpc>
+where
+    N: RpcNodeCore<Primitives = BasePrimitives>,
+    Rpc: RpcConvert<Primitives = BasePrimitives, Network = Base, Error = BaseEthApiError>,
+{
+    fn header_stream(&self) -> impl futures::Stream<Item = RpcHeader<Base>> + Send + Unpin {
+        let converter = self.eth_api().converter();
+        self.provider().canonical_state_stream().flat_map(move |new_chain| {
+            let headers = new_chain
+                .committed()
+                .blocks_iter()
+                .filter_map(|block| {
+                    let timestamp_ms = BaseTimeUpdateTx::extract_timestamp_ms(
+                        &block.body().transactions,
+                        block.number,
+                        block.timestamp,
+                    )
+                    .ok();
+                    match converter.convert_header(block.clone_sealed_header(), block.rlp_length())
+                    {
+                        Ok(mut header) => {
+                            header.timestamp_ms = timestamp_ms;
+                            Some(header)
+                        }
+                        Err(err) => {
+                            error!(error = %err, "failed to convert canonical header");
+                            None
+                        }
+                    }
+                })
+                .collect::<Vec<_>>();
+            futures::stream::iter(headers)
+        })
+    }
+}

--- a/crates/execution/rpc/src/eth/pubsub.rs
+++ b/crates/execution/rpc/src/eth/pubsub.rs
@@ -30,7 +30,7 @@ where
                         })
                         .ok()?;
                     header.timestamp_ms = BaseTimeUpdateTx::extract_timestamp_ms(
-                        block.body().transactions(),
+                        &block.body().transactions,
                         block.number,
                         block.timestamp,
                     )


### PR DESCRIPTION
Adds Base's optional `timestampMs` field to standard `eth_subscribe("newHeads")` notifications.

Built on #4026 and Reth 2.4's `EthSubscriptions` interface: Base overrides only `header_stream`, while Reth retains subscription registration, lifecycle, serialization, and all other subscription kinds. The timestamp is derived from validated BaseTime metadata in each committed canonical block body and omitted when metadata is unavailable or invalid.

This does not change or depend on Flashblocks.