### PR TITLE
refactor(cli): Replace Built-In Chain Enum With Selectors

### DIFF
--- a/bin/base/src/cli.rs
+++ b/bin/base/src/cli.rs
@@ -40,22 +40,21 @@ pub(crate) struct BaseCli {
 impl BaseCli {
     /// Runs the selected command with shared process initialization.
     pub(crate) fn run(self) -> eyre::Result<()> {
-        let Self { chain, logging, metrics, command } = self;
-
-        LogConfig::from(logging)
+        LogConfig::from(self.logging)
             .init_tracing_subscriber()
             .wrap_err("failed to initialize tracing")?;
 
-        let metrics_enabled = metrics.enabled;
-        MetricsConfig::from(metrics)
+        let metrics_enabled = self.metrics.enabled;
+        MetricsConfig::from(self.metrics)
             .init_with(|| {
                 base_cli_utils::register_version_metrics!();
             })
             .wrap_err("failed to install Prometheus recorder")?;
 
-        command.run(ChainResolver::new(chain), metrics_enabled)
+        self.command.run(ChainResolver::new(self.chain), metrics_enabled)
     }
 }
+
 #[cfg(test)]
 mod tests {
     use std::ffi::OsStr;
@@ -63,7 +62,6 @@ mod tests {
     use clap::{CommandFactory, Parser};
 
     use super::*;
-    use crate::config::BuiltInChain;
 
     #[test]
     fn parses_default_chain_for_rpc() {
@@ -76,7 +74,7 @@ mod tests {
             "http://localhost:5052",
         ]);
 
-        assert!(matches!(cli.chain, ChainArg::BuiltIn(BuiltInChain::Mainnet)));
+        assert!(matches!(cli.chain, ChainArg::BuiltIn(ref name) if name == "mainnet"));
         assert!(matches!(cli.command, BaseCommand::Rpc(_)));
     }
 
@@ -84,14 +82,14 @@ mod tests {
     fn parses_named_chain_selector() {
         let cli = BaseCli::parse_from(["base", "-c", "sepolia", "bootnode"]);
 
-        assert!(matches!(cli.chain, ChainArg::BuiltIn(BuiltInChain::Sepolia)));
+        assert!(matches!(cli.chain, ChainArg::BuiltIn(ref name) if name == "sepolia"));
     }
 
     #[test]
     fn parses_global_chain_after_subcommand() {
         let cli = BaseCli::parse_from(["base", "bootnode", "--chain", "sepolia"]);
 
-        assert!(matches!(cli.chain, ChainArg::BuiltIn(BuiltInChain::Sepolia)));
+        assert!(matches!(cli.chain, ChainArg::BuiltIn(ref name) if name == "sepolia"));
     }
 
     #[test]

--- a/bin/base/src/commands/rpc.rs
+++ b/bin/base/src/commands/rpc.rs
@@ -165,11 +165,7 @@ mod tests {
     use base_upgrade_signal::UpgradeSignalRuntimeValidation;
     use clap::Parser;
 
-    use crate::{
-        cli::BaseCli,
-        commands::BaseCommand,
-        config::ChainArg,
-    };
+    use crate::{cli::BaseCli, commands::BaseCommand, config::ChainArg};
 
     const RPC_FORWARDING_ENDPOINT_ENV: &str = "OP_RETH_SEQUENCER_HTTP";
     const RPC_FORWARDING_ENDPOINT_ENV_CHILD_TEST: &str =

--- a/bin/base/src/commands/rpc.rs
+++ b/bin/base/src/commands/rpc.rs
@@ -168,7 +168,7 @@ mod tests {
     use crate::{
         cli::BaseCli,
         commands::BaseCommand,
-        config::{BuiltInChain, ChainArg},
+        config::ChainArg,
     };
 
     const RPC_FORWARDING_ENDPOINT_ENV: &str = "OP_RETH_SEQUENCER_HTTP";
@@ -378,7 +378,7 @@ mod tests {
             "-vvv",
         ]);
 
-        assert!(matches!(cli.chain, ChainArg::BuiltIn(BuiltInChain::Dev)));
+        assert!(matches!(cli.chain, ChainArg::BuiltIn(ref name) if name == "dev"));
         let BaseCommand::Rpc(rpc) = cli.command else {
             panic!("expected rpc command");
         };

--- a/bin/base/src/config.rs
+++ b/bin/base/src/config.rs
@@ -1,12 +1,11 @@
 use std::{
-    fmt,
     path::{Path, PathBuf},
     str::FromStr,
     sync::Arc,
 };
 
 use alloy_chains::Chain;
-use base_common_chains::ChainConfig as BuiltInChainConfig;
+use base_common_chains::ChainConfig;
 use base_consensus_cli::ConsensusChainArgs;
 use base_execution_chainspec::BaseChainSpec;
 use eyre::WrapErr;
@@ -19,76 +18,19 @@ use serde::{Deserialize, Serialize};
 /// Prefix for chain configuration environment variables.
 pub(crate) const BASE_CHAIN_ENV_PREFIX: &str = "BASE_CHAIN_";
 
-/// A built-in chain supported by the `base` binary.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub(crate) enum BuiltInChain {
-    /// Base mainnet.
-    Mainnet,
-    /// Base sepolia.
-    Sepolia,
-    /// Base zeronet.
-    Zeronet,
-    /// Local Base devnet.
-    Dev,
-}
-
-impl BuiltInChain {
-    /// Returns the canonical CLI name for this chain.
-    pub(crate) const fn as_str(self) -> &'static str {
-        match self {
-            Self::Mainnet => "mainnet",
-            Self::Sepolia => "sepolia",
-            Self::Zeronet => "zeronet",
-            Self::Dev => "dev",
-        }
-    }
-
-    /// Returns the built-in chain config backing this selection.
-    pub(crate) const fn chain_config(self) -> &'static BuiltInChainConfig {
-        match self {
-            Self::Mainnet => BuiltInChainConfig::mainnet(),
-            Self::Sepolia => BuiltInChainConfig::sepolia(),
-            Self::Zeronet => BuiltInChainConfig::zeronet(),
-            Self::Dev => BuiltInChainConfig::devnet(),
-        }
-    }
-}
-
-impl fmt::Display for BuiltInChain {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-impl FromStr for BuiltInChain {
-    type Err = String;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value.to_ascii_lowercase().as_str() {
-            "mainnet" => Ok(Self::Mainnet),
-            "sepolia" => Ok(Self::Sepolia),
-            "zeronet" => Ok(Self::Zeronet),
-            "dev" => Ok(Self::Dev),
-            _ => Err(format!(
-                "unsupported built-in chain `{value}`; expected one of mainnet, sepolia, zeronet, dev"
-            )),
-        }
-    }
-}
-
 /// CLI input for the root `--chain` flag.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ChainArg {
-    /// Use one of the built-in static chains.
-    BuiltIn(BuiltInChain),
+    /// Use one of the built-in static chains, identified by its Base network
+    /// selector (`mainnet`, `sepolia`, `zeronet`, `dev`).
+    BuiltIn(String),
     /// Load chain settings from a TOML file.
     File(PathBuf),
 }
 
 impl Default for ChainArg {
     fn default() -> Self {
-        Self::BuiltIn(BuiltInChain::Mainnet)
+        Self::BuiltIn("mainnet".to_owned())
     }
 }
 
@@ -96,16 +38,21 @@ impl FromStr for ChainArg {
     type Err = std::convert::Infallible;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        Ok(BuiltInChain::from_str(value)
-            .map_or_else(|_| Self::File(PathBuf::from(value)), Self::BuiltIn))
+        let selector = value.to_ascii_lowercase();
+        Ok(if ChainConfig::from_base_chain(&selector).is_some() {
+            Self::BuiltIn(selector)
+        } else {
+            Self::File(PathBuf::from(value))
+        })
     }
 }
 
 /// The concrete source of a resolved chain config.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) enum ResolvedChainSource {
-    /// The config came from a built-in static chain.
-    BuiltIn(BuiltInChain),
+    /// The config came from a built-in static chain, identified by its Base
+    /// network selector.
+    BuiltIn(String),
     /// The config came from a TOML file.
     File(PathBuf),
 }
@@ -135,14 +82,16 @@ pub(crate) struct ResolvedChainValues {
 }
 
 impl ResolvedChainValues {
-    /// Creates resolved values from a built-in chain.
-    pub(crate) fn from_builtin(chain: BuiltInChain) -> Self {
-        let config = chain.chain_config();
-        Self {
-            name: chain.as_str().to_owned(),
+    /// Creates resolved values from a built-in Base network selector.
+    ///
+    /// Returns `None` if the selector is not a known built-in chain.
+    pub(crate) fn from_builtin(selector: &str) -> Option<Self> {
+        let config = ChainConfig::from_base_chain(selector)?;
+        Some(Self {
+            name: selector.to_owned(),
             l2_chain_id: config.chain_id,
             l1_chain_id: config.l1_chain_id,
-        }
+        })
     }
 }
 
@@ -159,10 +108,9 @@ impl ResolvedChainConfig {
 
     /// Returns the execution chainspec for this chain.
     pub(crate) fn execution_chain_spec(&self) -> eyre::Result<Arc<BaseChainSpec>> {
-        let config =
-            base_common_chains::ChainConfig::by_chain_id(self.l2_chain_id).ok_or_else(|| {
-                eyre::eyre!("no built-in execution chainspec for L2 chain ID {}", self.l2_chain_id)
-            })?;
+        let config = ChainConfig::by_chain_id(self.l2_chain_id).ok_or_else(|| {
+            eyre::eyre!("no built-in execution chainspec for L2 chain ID {}", self.l2_chain_id)
+        })?;
         Ok(Arc::new(BaseChainSpec::try_from(config)?))
     }
 
@@ -189,10 +137,11 @@ impl ChainResolver {
     pub(crate) fn resolve(&self) -> eyre::Result<ResolvedChainConfig> {
         match &self.chain {
             ChainArg::BuiltIn(chain) => {
-                let figment =
-                    Figment::from(Serialized::defaults(ResolvedChainValues::from_builtin(*chain)))
-                        .merge(Env::prefixed(BASE_CHAIN_ENV_PREFIX));
-                Self::extract(figment, ResolvedChainSource::BuiltIn(*chain))
+                let defaults = ResolvedChainValues::from_builtin(chain)
+                    .ok_or_else(|| eyre::eyre!("unknown built-in chain `{chain}`"))?;
+                let figment = Figment::from(Serialized::defaults(defaults))
+                    .merge(Env::prefixed(BASE_CHAIN_ENV_PREFIX));
+                Self::extract(figment, ResolvedChainSource::BuiltIn(chain.clone()))
             }
             ChainArg::File(path) => Self::resolve_file(path),
         }
@@ -241,13 +190,14 @@ mod tests {
     #[allow(clippy::result_large_err)]
     fn resolves_mainnet_builtin() {
         with_cleared_env(|_| {
-            let resolved =
-                ChainResolver::new(ChainArg::BuiltIn(BuiltInChain::Mainnet)).resolve().unwrap();
+            let resolved = ChainResolver::new(ChainArg::BuiltIn("mainnet".to_owned()))
+                .resolve()
+                .unwrap();
 
             assert_eq!(resolved.name, "mainnet");
             assert_eq!(resolved.l2_chain_id, 8453);
             assert_eq!(resolved.l1_chain_id, 1);
-            assert_eq!(resolved.source, ResolvedChainSource::BuiltIn(BuiltInChain::Mainnet));
+            assert_eq!(resolved.source, ResolvedChainSource::BuiltIn("mainnet".to_owned()));
 
             Ok(())
         });
@@ -257,8 +207,9 @@ mod tests {
     #[allow(clippy::result_large_err)]
     fn resolves_sepolia_builtin() {
         with_cleared_env(|_| {
-            let resolved =
-                ChainResolver::new(ChainArg::BuiltIn(BuiltInChain::Sepolia)).resolve().unwrap();
+            let resolved = ChainResolver::new(ChainArg::BuiltIn("sepolia".to_owned()))
+                .resolve()
+                .unwrap();
 
             assert_eq!(resolved.name, "sepolia");
             assert_eq!(resolved.l2_chain_id, 84532);
@@ -272,12 +223,13 @@ mod tests {
     #[allow(clippy::result_large_err)]
     fn resolves_zeronet_builtin() {
         with_cleared_env(|_| {
-            let resolved =
-                ChainResolver::new(ChainArg::BuiltIn(BuiltInChain::Zeronet)).resolve().unwrap();
+            let resolved = ChainResolver::new(ChainArg::BuiltIn("zeronet".to_owned()))
+                .resolve()
+                .unwrap();
 
             assert_eq!(resolved.name, "zeronet");
             assert_eq!(resolved.l2_chain_id, 763360);
-            assert_eq!(resolved.source, ResolvedChainSource::BuiltIn(BuiltInChain::Zeronet));
+            assert_eq!(resolved.source, ResolvedChainSource::BuiltIn("zeronet".to_owned()));
 
             Ok(())
         });
@@ -288,12 +240,12 @@ mod tests {
     fn resolves_dev_builtin() {
         with_cleared_env(|_| {
             let resolved =
-                ChainResolver::new(ChainArg::BuiltIn(BuiltInChain::Dev)).resolve().unwrap();
+                ChainResolver::new(ChainArg::BuiltIn("dev".to_owned())).resolve().unwrap();
 
             assert_eq!(resolved.name, "dev");
             assert_eq!(resolved.l2_chain_id, 1337);
             assert_eq!(resolved.l1_chain_id, 900);
-            assert_eq!(resolved.source, ResolvedChainSource::BuiltIn(BuiltInChain::Dev));
+            assert_eq!(resolved.source, ResolvedChainSource::BuiltIn("dev".to_owned()));
 
             Ok(())
         });

--- a/bin/base/src/config.rs
+++ b/bin/base/src/config.rs
@@ -190,9 +190,8 @@ mod tests {
     #[allow(clippy::result_large_err)]
     fn resolves_mainnet_builtin() {
         with_cleared_env(|_| {
-            let resolved = ChainResolver::new(ChainArg::BuiltIn("mainnet".to_owned()))
-                .resolve()
-                .unwrap();
+            let resolved =
+                ChainResolver::new(ChainArg::BuiltIn("mainnet".to_owned())).resolve().unwrap();
 
             assert_eq!(resolved.name, "mainnet");
             assert_eq!(resolved.l2_chain_id, 8453);
@@ -207,9 +206,8 @@ mod tests {
     #[allow(clippy::result_large_err)]
     fn resolves_sepolia_builtin() {
         with_cleared_env(|_| {
-            let resolved = ChainResolver::new(ChainArg::BuiltIn("sepolia".to_owned()))
-                .resolve()
-                .unwrap();
+            let resolved =
+                ChainResolver::new(ChainArg::BuiltIn("sepolia".to_owned())).resolve().unwrap();
 
             assert_eq!(resolved.name, "sepolia");
             assert_eq!(resolved.l2_chain_id, 84532);
@@ -223,9 +221,8 @@ mod tests {
     #[allow(clippy::result_large_err)]
     fn resolves_zeronet_builtin() {
         with_cleared_env(|_| {
-            let resolved = ChainResolver::new(ChainArg::BuiltIn("zeronet".to_owned()))
-                .resolve()
-                .unwrap();
+            let resolved =
+                ChainResolver::new(ChainArg::BuiltIn("zeronet".to_owned())).resolve().unwrap();
 
             assert_eq!(resolved.name, "zeronet");
             assert_eq!(resolved.l2_chain_id, 763360);

--- a/crates/common/chains/src/config.rs
+++ b/crates/common/chains/src/config.rs
@@ -216,6 +216,32 @@ impl ChainConfig {
         }
     }
 
+    /// Resolves a Base network selector (`mainnet`, `sepolia`, `zeronet`,
+    /// `dev`) to its built-in config.
+    ///
+    /// # Why this differs from [`by_name`](Self::by_name)
+    ///
+    /// [`by_name`](Self::by_name) matches the *namespaced canonical* names in
+    /// [`SUPPORTED_NAMES`](Self::SUPPORTED_NAMES) (`base`, `base-sepolia`,
+    /// `base-zeronet`, `dev`). Those names stay prefixed with `base-` so they do
+    /// not collide with the Ethereum L1 chain names that share this ecosystem.
+    ///
+    /// `from_base_chain` matches the *Base-centric operator aliases*, where
+    /// `mainnet` means Base mainnet — not Ethereum mainnet. These short names
+    /// are the `base` binary's `--chain` surface and are intentionally kept
+    /// distinct from the canonical names. Do not collapse the two methods: the
+    /// name sets differ on purpose, so `from_base_chain("mainnet")` resolves
+    /// while `by_name("mainnet")` returns `None`.
+    pub fn from_base_chain(name: &str) -> Option<&'static Self> {
+        match name {
+            "mainnet" => Some(Self::mainnet()),
+            "sepolia" => Some(Self::sepolia()),
+            "zeronet" => Some(Self::zeronet()),
+            "dev" => Some(Self::devnet()),
+            _ => None,
+        }
+    }
+
     /// Looks up a chain config by L2 chain ID.
     pub const fn by_chain_id(id: u64) -> Option<&'static Self> {
         match id {
@@ -656,6 +682,20 @@ mod tests {
         assert_eq!(ChainConfig::SEPOLIA, ChainConfig::sepolia());
         assert_eq!(ChainConfig::DEVNET, ChainConfig::devnet());
         assert_eq!(ChainConfig::ZERONET, ChainConfig::zeronet());
+    }
+
+    #[test]
+    fn base_chain_aliases_resolve() {
+        assert_eq!(ChainConfig::from_base_chain("mainnet"), Some(ChainConfig::mainnet()));
+        assert_eq!(ChainConfig::from_base_chain("sepolia"), Some(ChainConfig::sepolia()));
+        assert_eq!(ChainConfig::from_base_chain("zeronet"), Some(ChainConfig::zeronet()));
+        assert_eq!(ChainConfig::from_base_chain("dev"), Some(ChainConfig::devnet()));
+        assert_eq!(ChainConfig::from_base_chain("base"), None);
+
+        // The Base-centric aliases are deliberately distinct from the canonical
+        // namespaced names matched by `by_name`.
+        assert_eq!(ChainConfig::by_name("mainnet"), None);
+        assert_eq!(ChainConfig::from_base_chain(ChainConfig::MAINNET_NAME), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Removes the bespoke `BuiltInChain` enum from the `base` binary and resolves the `--chain` flag through Base network selector strings instead. A new `ChainConfig::from_base_chain` helper in the common chains crate maps the operator aliases (`mainnet`, `sepolia`, `zeronet`, `dev`) to their built-in configs, keeping them intentionally distinct from the canonical namespaced names used by `by_name`. This centralizes chain lookup logic and drops duplicated parsing, display, and config-mapping code from the CLI. Tests are updated to exercise the string-based selectors and the new alias resolver.