### PR TITLE
feat(consensus): support authoritative payload insertion

### DIFF
--- a/actions/harness/src/sequencer/driver.rs
+++ b/actions/harness/src/sequencer/driver.rs
@@ -276,6 +276,7 @@ impl L2Sequencer {
             conductor: Some(ActionConductor::new(Arc::clone(&self.conductor))),
             engine_client,
             is_active: false,
+            shadow_blocks_per_cycle: None,
             recovery_mode: RecoveryModeGuard::new(false),
             rollup_config: self.actor_rollup_config(),
             unsafe_payload_gossip_client: ActionUnsafePayloadGossipClient,

--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -363,7 +363,7 @@ impl ConsensusNodeArgs {
     /// Validates that a non-shadow sequencer has a signing key configured.
     pub fn validate_sequencer_key(&self) -> eyre::Result<()> {
         if self.config.node_mode.is_sequencer()
-            && self.config.sequencer_flags.shadow_blocks_per_cycle.is_none()
+            && !self.config.sequencer_flags.config().is_shadow_sequencer()
         {
             let signer = &self.config.p2p_flags.signer;
             if signer.sequencer_key.is_none()

--- a/crates/consensus/engine/src/lib.rs
+++ b/crates/consensus/engine/src/lib.rs
@@ -13,9 +13,9 @@ mod task_queue;
 pub use task_queue::{
     BuildTaskError, ConsolidateInput, ConsolidateTask, ConsolidateTaskError, Engine,
     EngineBuildError, EngineResetError, EngineTask, EngineTaskError, EngineTaskErrorSeverity,
-    EngineTaskErrors, EngineTaskExt, FinalizeTask, FinalizeTaskError, InsertPayloadSafety,
-    InsertTask, InsertTaskError, InsertTaskResult, SealTask, SealTaskError, SynchronizeTask,
-    SynchronizeTaskError,
+    EngineTaskErrors, EngineTaskExt, FinalizeTask, FinalizeTaskError, InsertPayloadPolicy,
+    InsertPayloadSafety, InsertTask, InsertTaskError, InsertTaskResult, SealTask, SealTaskError,
+    SynchronizeTask, SynchronizeTaskError,
 };
 
 mod attributes;

--- a/crates/consensus/engine/src/task_queue/core.rs
+++ b/crates/consensus/engine/src/task_queue/core.rs
@@ -15,9 +15,10 @@ use super::EngineTaskExt;
 use crate::{
     BuildTaskError, EngineBuildError, EngineClient, EngineForkchoiceVersion,
     EngineGetPayloadVersion, EngineState, EngineSyncStateUpdate, EngineTask, EngineTaskError,
-    EngineTaskErrorSeverity, ForkchoiceCheckpointReader, Metrics, NoopForkchoiceCheckpointReader,
-    SealTaskError, SyncStartError, SynchronizeTask, SynchronizeTaskError,
-    find_starting_forkchoice_with_checkpoint_reader, task_queue::EngineTaskErrors,
+    EngineTaskErrorSeverity, ForkchoiceCheckpointReader, InsertTask, InsertTaskError, Metrics,
+    NoopForkchoiceCheckpointReader, SealTaskError, SyncStartError, SynchronizeTask,
+    SynchronizeTaskError, find_starting_forkchoice_with_checkpoint_reader,
+    task_queue::EngineTaskErrors,
 };
 
 /// The [`Engine`] task queue.
@@ -395,6 +396,31 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
         self.tasks.push((task, Reverse(sequence)));
         self.task_queue_length.send_replace(self.tasks.len());
         Metrics::engine_task_queue_depth().set(self.tasks.len() as f64);
+    }
+
+    /// Sequentially inserts payloads that authoritatively replace the current unsafe chain.
+    ///
+    /// Existing safe and finalized heads are preserved, while local-safe is reset to safe after
+    /// the unsafe-chain replacement. The caller is responsible for providing payloads in
+    /// contiguous canonical order.
+    pub async fn insert_authoritative_payloads(
+        &mut self,
+        client: Arc<EngineClient_>,
+        config: Arc<RollupConfig>,
+        payloads: Vec<BaseExecutionPayloadEnvelope>,
+    ) -> Result<L2BlockInfo, InsertTaskError> {
+        let mut head = self.state.sync_state.unsafe_head();
+        for envelope in payloads {
+            head = InsertTask::authoritative_payload(
+                Arc::clone(&client),
+                Arc::clone(&config),
+                envelope,
+            )
+            .execute_with_result(&mut self.state)
+            .await?;
+            self.state_sender.send_replace(self.state);
+        }
+        Ok(head)
     }
 
     /// Resets the engine by finding a plausible sync starting point via

--- a/crates/consensus/engine/src/task_queue/core.rs
+++ b/crates/consensus/engine/src/task_queue/core.rs
@@ -403,12 +403,22 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
     /// Existing safe and finalized heads are preserved, while local-safe is reset to safe after
     /// the unsafe-chain replacement. The caller is responsible for providing payloads in
     /// contiguous canonical order.
+    ///
+    /// Each acknowledged payload is applied and published immediately. If a later insertion
+    /// fails, earlier progress is retained. Callers may safely retry the full sequence because
+    /// authoritative duplicate payloads still require an acknowledged forkchoice update.
+    ///
+    /// Returns [`InsertTaskError::EmptyAuthoritativePayloads`] when `payloads` is empty.
     pub async fn insert_authoritative_payloads(
         &mut self,
         client: Arc<EngineClient_>,
         config: Arc<RollupConfig>,
         payloads: Vec<BaseExecutionPayloadEnvelope>,
     ) -> Result<L2BlockInfo, InsertTaskError> {
+        if payloads.is_empty() {
+            return Err(InsertTaskError::EmptyAuthoritativePayloads);
+        }
+
         let mut head = self.state.sync_state.unsafe_head();
         for envelope in payloads {
             head = InsertTask::authoritative_payload(

--- a/crates/consensus/engine/src/task_queue/tasks/insert/error.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/insert/error.rs
@@ -16,6 +16,9 @@ use crate::{
 /// [InsertTask]: crate::InsertTask
 #[derive(Debug, thiserror::Error)]
 pub enum InsertTaskError {
+    /// No payloads were provided for authoritative insertion.
+    #[error("Authoritative insertion requires at least one payload")]
+    EmptyAuthoritativePayloads,
     /// Error converting a payload into a block.
     #[error(transparent)]
     FromBlockError(#[from] BasePayloadError),
@@ -39,13 +42,27 @@ pub enum InsertTaskError {
 impl EngineTaskError for InsertTaskError {
     fn severity(&self) -> EngineTaskErrorSeverity {
         match self {
-            Self::FromBlockError(_) | Self::L2BlockInfoConstruction(_) => {
-                EngineTaskErrorSeverity::Critical
-            }
+            Self::EmptyAuthoritativePayloads
+            | Self::FromBlockError(_)
+            | Self::L2BlockInfoConstruction(_) => EngineTaskErrorSeverity::Critical,
             Self::InsertFailed(_)
             | Self::UnexpectedPayloadStatus(_)
             | Self::ForkchoiceUpdateDidNotAdvance => EngineTaskErrorSeverity::Temporary,
             Self::ForkchoiceUpdateFailed(inner) => inner.severity(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::InsertTaskError;
+    use crate::{EngineTaskError, EngineTaskErrorSeverity};
+
+    #[test]
+    fn empty_authoritative_payloads_is_not_retryable() {
+        assert_eq!(
+            InsertTaskError::EmptyAuthoritativePayloads.severity(),
+            EngineTaskErrorSeverity::Critical
+        );
     }
 }

--- a/crates/consensus/engine/src/task_queue/tasks/insert/mod.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/insert/mod.rs
@@ -1,7 +1,7 @@
 //! Task to insert a payload into the execution engine.
 
 mod task;
-pub use task::{InsertPayloadSafety, InsertTask, InsertTaskResult};
+pub use task::{InsertPayloadPolicy, InsertPayloadSafety, InsertTask, InsertTaskResult};
 
 mod error;
 pub use error::InsertTaskError;

--- a/crates/consensus/engine/src/task_queue/tasks/insert/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/insert/task.rs
@@ -217,6 +217,9 @@ impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
     }
 
     /// Inserts the payload and returns the engine-acknowledged unsafe head.
+    ///
+    /// After successfully inserting an authoritative payload, this also resets the local-safe
+    /// head to the current safe head.
     pub async fn execute_with_result(&self, state: &mut EngineState) -> InsertTaskResult {
         let time_start = Instant::now();
 

--- a/crates/consensus/engine/src/task_queue/tasks/insert/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/insert/task.rs
@@ -47,6 +47,30 @@ impl InsertPayloadSafety {
     }
 }
 
+/// Determines whether an unsafe payload must extend the current unsafe head.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InsertPayloadPolicy {
+    /// Only insert payloads that can extend the current unsafe chain.
+    ExtendingOnly,
+    /// Insert an authoritative payload even when replacing the current unsafe chain.
+    Authoritative,
+}
+
+impl InsertPayloadPolicy {
+    /// Returns whether this policy permits replacing the current unsafe chain.
+    pub const fn is_authoritative(self) -> bool {
+        matches!(self, Self::Authoritative)
+    }
+
+    /// Returns the label used for structured logs.
+    pub const fn as_label(self) -> &'static str {
+        match self {
+            Self::ExtendingOnly => "extending_only",
+            Self::Authoritative => "authoritative",
+        }
+    }
+}
+
 /// The task to insert a payload into the execution engine.
 #[derive(Debug, Clone)]
 pub struct InsertTask<EngineClient_: EngineClient> {
@@ -58,6 +82,8 @@ pub struct InsertTask<EngineClient_: EngineClient> {
     envelope: BaseExecutionPayloadEnvelope,
     /// Whether the inserted payload should advance the safe head.
     payload_safety: InsertPayloadSafety,
+    /// Whether the payload must extend the current unsafe chain.
+    payload_policy: InsertPayloadPolicy,
     /// Optional response channel used by callers that need insertion acknowledgement.
     result_tx: Option<mpsc::Sender<InsertTaskResult>>,
 }
@@ -70,7 +96,14 @@ impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
         envelope: BaseExecutionPayloadEnvelope,
         payload_safety: InsertPayloadSafety,
     ) -> Self {
-        Self { client, rollup_config, envelope, payload_safety, result_tx: None }
+        Self {
+            client,
+            rollup_config,
+            envelope,
+            payload_safety,
+            payload_policy: InsertPayloadPolicy::ExtendingOnly,
+            result_tx: None,
+        }
     }
 
     /// Creates a new task to insert an unsafe payload.
@@ -94,7 +127,24 @@ impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
             rollup_config,
             envelope,
             payload_safety: InsertPayloadSafety::Unsafe,
+            payload_policy: InsertPayloadPolicy::ExtendingOnly,
             result_tx: Some(result_tx),
+        }
+    }
+
+    /// Creates a task that authoritatively replaces the current unsafe chain with this payload.
+    pub const fn authoritative_payload(
+        client: Arc<EngineClient_>,
+        rollup_config: Arc<RollupConfig>,
+        envelope: BaseExecutionPayloadEnvelope,
+    ) -> Self {
+        Self {
+            client,
+            rollup_config,
+            envelope,
+            payload_safety: InsertPayloadSafety::Unsafe,
+            payload_policy: InsertPayloadPolicy::Authoritative,
+            result_tx: None,
         }
     }
 
@@ -118,6 +168,10 @@ impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
         new_unsafe_ref: &L2BlockInfo,
     ) -> bool {
         if self.payload_safety.advances_safe_head() {
+            return true;
+        }
+
+        if self.payload_policy.is_authoritative() {
             return true;
         }
 
@@ -162,7 +216,8 @@ impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
         true
     }
 
-    async fn insert_payload(&self, state: &mut EngineState) -> InsertTaskResult {
+    /// Inserts the payload and returns the engine-acknowledged unsafe head.
+    pub async fn execute_with_result(&self, state: &mut EngineState) -> InsertTaskResult {
         let time_start = Instant::now();
 
         // Form a block ref before insertion so stale unsafe payloads can be dropped before import.
@@ -227,6 +282,7 @@ impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
                     target: "engine",
                     error = %e,
                     payload_safety = self.payload_safety.as_label(),
+                    payload_policy = self.payload_policy.as_label(),
                     "Failed to insert new payload"
                 );
                 return Err(InsertTaskError::InsertFailed(e));
@@ -239,21 +295,38 @@ impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
 
         let advances_safe_head = self.payload_safety.advances_safe_head();
         // Send a FCU to canonicalize the imported block.
-        SynchronizeTask::new(
-            Arc::clone(&self.client),
-            Arc::clone(&self.rollup_config),
-            EngineSyncStateUpdate {
-                unsafe_head: Some(new_block_ref),
-                local_safe_head: advances_safe_head.then_some(new_block_ref),
-                safe_head: advances_safe_head.then_some(new_block_ref),
-                ..Default::default()
-            },
-        )
-        .execute(state)
-        .await?;
+        let state_update = EngineSyncStateUpdate {
+            unsafe_head: Some(new_block_ref),
+            local_safe_head: advances_safe_head.then_some(new_block_ref),
+            safe_head: advances_safe_head.then_some(new_block_ref),
+            ..Default::default()
+        };
+        let synchronize_task = if self.payload_policy.is_authoritative() {
+            SynchronizeTask::new_forced(
+                Arc::clone(&self.client),
+                Arc::clone(&self.rollup_config),
+                state_update,
+            )
+        } else {
+            SynchronizeTask::new(
+                Arc::clone(&self.client),
+                Arc::clone(&self.rollup_config),
+                state_update,
+            )
+        };
+        synchronize_task.execute(state).await?;
 
-        if self.result_tx.is_some() && state.sync_state.unsafe_head() != new_block_ref {
+        if (self.result_tx.is_some() || self.payload_policy.is_authoritative())
+            && state.sync_state.unsafe_head() != new_block_ref
+        {
             return Err(InsertTaskError::ForkchoiceUpdateDidNotAdvance);
+        }
+
+        if self.payload_policy.is_authoritative() {
+            state.sync_state = state.sync_state.apply_update(EngineSyncStateUpdate {
+                local_safe_head: Some(state.sync_state.safe_head()),
+                ..Default::default()
+            });
         }
 
         let total_duration = time_start.elapsed();
@@ -263,6 +336,7 @@ impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
             hash = %new_block_ref.block_info.hash,
             number = new_block_ref.block_info.number,
             payload_safety = self.payload_safety.as_label(),
+            payload_policy = self.payload_policy.as_label(),
             total_duration = ?total_duration,
             insert_duration = ?insert_duration,
             "Inserted new payload"
@@ -286,7 +360,7 @@ impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
     type Error = InsertTaskError;
 
     async fn execute(&self, state: &mut EngineState) -> Result<(), InsertTaskError> {
-        let result = self.insert_payload(state).await;
+        let result = self.execute_with_result(state).await;
         if self.result_tx.is_some() {
             self.send_channel_result(result).await;
             Ok(())
@@ -307,9 +381,9 @@ mod tests {
     use base_common_rpc_types_engine::{BaseExecutionPayload, BaseExecutionPayloadEnvelope};
     use base_protocol::{BlockInfo, L1BlockInfoBedrock, L2BlockInfo};
 
-    use super::{InsertPayloadSafety, InsertTask};
+    use super::{InsertPayloadPolicy, InsertPayloadSafety, InsertTask};
     use crate::{
-        EngineTaskExt,
+        Engine, EngineTaskExt,
         test_utils::{TestEngineStateBuilder, test_engine_client_builder},
     };
 
@@ -585,5 +659,117 @@ mod tests {
         );
         assert_eq!(state.sync_state.unsafe_head().block_info.number, 5);
         assert_eq!(state.sync_state.unsafe_head().block_info.parent_hash, current_unsafe.hash());
+    }
+
+    #[tokio::test]
+    async fn authoritative_payload_replaces_newer_unsafe_head() {
+        let client = test_client();
+        let current_unsafe = l2_block_info(10, B256::with_last_byte(10), B256::with_last_byte(9));
+        let canonical_anchor = l2_block_info(7, B256::with_last_byte(7), B256::with_last_byte(6));
+        let mut state = TestEngineStateBuilder::new()
+            .with_unsafe_head(current_unsafe)
+            .with_safe_head(canonical_anchor)
+            .with_finalized_head(canonical_anchor)
+            .build();
+        let envelope = BaseExecutionPayloadEnvelope {
+            parent_beacon_block_root: None,
+            execution_payload: bedrock_payload_with_parent(8, B256::with_last_byte(7)),
+        };
+
+        let inserted_head = InsertTask::authoritative_payload(
+            Arc::clone(&client),
+            Arc::new(base_common_genesis::RollupConfig::default()),
+            envelope,
+        )
+        .execute_with_result(&mut state)
+        .await
+        .expect("authoritative payload should replace the newer unsafe head");
+
+        assert!(client.last_new_payload_v2().await.is_some());
+        assert_eq!(inserted_head.block_info.number, 8);
+        assert_eq!(state.sync_state.unsafe_head(), inserted_head);
+        assert_eq!(state.sync_state.local_safe_head(), canonical_anchor);
+        assert_eq!(state.sync_state.safe_head(), canonical_anchor);
+        assert_eq!(state.sync_state.finalized_head(), canonical_anchor);
+    }
+
+    #[test]
+    fn insert_payload_policy_labels_are_stable() {
+        assert_eq!(InsertPayloadPolicy::ExtendingOnly.as_label(), "extending_only");
+        assert_eq!(InsertPayloadPolicy::Authoritative.as_label(), "authoritative");
+    }
+
+    #[tokio::test]
+    async fn engine_inserts_authoritative_payloads_in_order() {
+        let client = test_client();
+        let config = Arc::new(base_common_genesis::RollupConfig::default());
+        let current_unsafe = l2_block_info(10, B256::with_last_byte(10), B256::with_last_byte(9));
+        let canonical_anchor = l2_block_info(7, B256::with_last_byte(7), B256::with_last_byte(6));
+        let initial_state = TestEngineStateBuilder::new()
+            .with_unsafe_head(current_unsafe)
+            .with_safe_head(canonical_anchor)
+            .with_finalized_head(canonical_anchor)
+            .build();
+        let (state_tx, state_rx) = tokio::sync::watch::channel(initial_state);
+        let (queue_tx, _) = tokio::sync::watch::channel(0usize);
+        let mut engine = Engine::new(initial_state, state_tx, queue_tx);
+        let payloads = vec![
+            BaseExecutionPayloadEnvelope {
+                parent_beacon_block_root: None,
+                execution_payload: bedrock_payload_with_parent(8, B256::with_last_byte(7)),
+            },
+            BaseExecutionPayloadEnvelope {
+                parent_beacon_block_root: None,
+                execution_payload: bedrock_payload_with_parent(9, B256::with_last_byte(8)),
+            },
+        ];
+
+        let reconciled_head = engine
+            .insert_authoritative_payloads(client, config, payloads)
+            .await
+            .expect("ordered authoritative payloads should be inserted");
+
+        assert_eq!(reconciled_head.block_info.number, 9);
+        assert_eq!(engine.state().sync_state.unsafe_head(), reconciled_head);
+        assert_eq!(engine.state().sync_state.local_safe_head(), canonical_anchor);
+        assert_eq!(engine.state().sync_state.safe_head(), canonical_anchor);
+        assert_eq!(engine.state().sync_state.finalized_head(), canonical_anchor);
+        assert_eq!(state_rx.borrow().sync_state.unsafe_head(), reconciled_head);
+        assert_eq!(state_rx.borrow().sync_state.local_safe_head(), canonical_anchor);
+        assert_eq!(state_rx.borrow().sync_state.safe_head(), canonical_anchor);
+        assert_eq!(state_rx.borrow().sync_state.finalized_head(), canonical_anchor);
+    }
+
+    #[tokio::test]
+    async fn authoritative_duplicate_payload_forces_forkchoice_acknowledgement() {
+        let config = Arc::new(base_common_genesis::RollupConfig::default());
+        let envelope = BaseExecutionPayloadEnvelope {
+            parent_beacon_block_root: None,
+            execution_payload: bedrock_payload(1),
+        };
+        let mut state = TestEngineStateBuilder::new().build();
+        InsertTask::unsafe_payload(test_client(), Arc::clone(&config), envelope.clone())
+            .execute(&mut state)
+            .await
+            .expect("initial payload should be inserted");
+
+        let client_without_fcu = Arc::new(
+            test_engine_client_builder()
+                .with_new_payload_v2_response(valid_payload_status())
+                .build(),
+        );
+        let result = InsertTask::authoritative_payload(
+            client_without_fcu,
+            Arc::clone(&config),
+            envelope.clone(),
+        )
+        .execute_with_result(&mut state)
+        .await;
+        assert!(result.is_err(), "authoritative duplicate must require an FCU response");
+
+        InsertTask::authoritative_payload(test_client(), config, envelope)
+            .execute_with_result(&mut state)
+            .await
+            .expect("authoritative duplicate should accept a valid FCU response");
     }
 }

--- a/crates/consensus/engine/src/task_queue/tasks/insert/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/insert/task.rs
@@ -383,7 +383,7 @@ mod tests {
 
     use super::{InsertPayloadPolicy, InsertPayloadSafety, InsertTask};
     use crate::{
-        Engine, EngineTaskExt,
+        Engine, EngineTaskExt, InsertTaskError,
         test_utils::{TestEngineStateBuilder, test_engine_client_builder},
     };
 
@@ -771,5 +771,20 @@ mod tests {
             .execute_with_result(&mut state)
             .await
             .expect("authoritative duplicate should accept a valid FCU response");
+    }
+
+    #[tokio::test]
+    async fn engine_rejects_empty_authoritative_payloads() {
+        let client = test_client();
+        let config = Arc::new(base_common_genesis::RollupConfig::default());
+        let initial_state = TestEngineStateBuilder::new().build();
+        let (state_tx, _) = tokio::sync::watch::channel(initial_state);
+        let (queue_tx, _) = tokio::sync::watch::channel(0usize);
+        let mut engine = Engine::new(initial_state, state_tx, queue_tx);
+
+        let result = engine.insert_authoritative_payloads(client, config, vec![]).await;
+
+        assert!(matches!(result, Err(InsertTaskError::EmptyAuthoritativePayloads)));
+        assert_eq!(engine.state(), &initial_state);
     }
 }

--- a/crates/consensus/engine/src/task_queue/tasks/mod.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/mod.rs
@@ -9,7 +9,9 @@ mod synchronize;
 pub use synchronize::{SynchronizeTask, SynchronizeTaskError};
 
 mod insert;
-pub use insert::{InsertPayloadSafety, InsertTask, InsertTaskError, InsertTaskResult};
+pub use insert::{
+    InsertPayloadPolicy, InsertPayloadSafety, InsertTask, InsertTaskError, InsertTaskResult,
+};
 
 mod build;
 pub use build::{BuildTaskError, EngineBuildError};

--- a/crates/consensus/engine/src/task_queue/tasks/seal/error.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/seal/error.rs
@@ -73,7 +73,8 @@ impl SealTaskError {
                         | SynchronizeTaskError::UnexpectedPayloadStatus(_) => false,
                     }
                 }
-                InsertTaskError::FromBlockError(_)
+                InsertTaskError::EmptyAuthoritativePayloads
+                | InsertTaskError::FromBlockError(_)
                 | InsertTaskError::L2BlockInfoConstruction(_) => true,
                 InsertTaskError::InsertFailed(_)
                 | InsertTaskError::UnexpectedPayloadStatus(_)

--- a/crates/consensus/engine/src/task_queue/tasks/synchronize/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/synchronize/task.rs
@@ -6,7 +6,6 @@ use alloy_rpc_types_engine::{INVALID_FORK_CHOICE_STATE_ERROR, PayloadStatusEnum}
 use async_trait::async_trait;
 use base_common_genesis::RollupConfig;
 use base_protocol::L2BlockInfo;
-use derive_more::Constructor;
 use tokio::time::Instant;
 
 use crate::{
@@ -36,7 +35,7 @@ use crate::{
 /// [`InsertTask`]: crate::InsertTask
 /// [`ConsolidateTask`]: crate::ConsolidateTask  
 /// [`FinalizeTask`]: crate::FinalizeTask
-#[derive(Debug, Clone, Constructor)]
+#[derive(Debug, Clone)]
 pub struct SynchronizeTask<EngineClient_: EngineClient> {
     /// The engine client.
     pub client: Arc<EngineClient_>,
@@ -44,9 +43,29 @@ pub struct SynchronizeTask<EngineClient_: EngineClient> {
     pub rollup: Arc<RollupConfig>,
     /// The sync state update to apply to the engine state.
     pub state_update: EngineSyncStateUpdate,
+    /// Whether to send an FCU when the requested state already matches the current state.
+    pub force: bool,
 }
 
 impl<EngineClient_: EngineClient> SynchronizeTask<EngineClient_> {
+    /// Creates a synchronization task that skips redundant forkchoice updates.
+    pub const fn new(
+        client: Arc<EngineClient_>,
+        rollup: Arc<RollupConfig>,
+        state_update: EngineSyncStateUpdate,
+    ) -> Self {
+        Self { client, rollup, state_update, force: false }
+    }
+
+    /// Creates a synchronization task that always sends a forkchoice update.
+    pub const fn new_forced(
+        client: Arc<EngineClient_>,
+        rollup: Arc<RollupConfig>,
+        state_update: EngineSyncStateUpdate,
+    ) -> Self {
+        Self { client, rollup, state_update, force: true }
+    }
+
     /// Computes the sync-state update to apply when the EL responds with `Syncing`.
     ///
     /// Until the EL has finished syncing, the state is left untouched. Once EL sync has
@@ -135,7 +154,10 @@ impl<EngineClient_: EngineClient> EngineTaskExt for SynchronizeTask<EngineClient
         // We shouldn't retry the synchronize task there. Since the `sync_state` is only updated
         // inside the `SynchronizeTask` (except inside the ConsolidateTask, when the block is not
         // the last in the batch) - the engine will get stuck retrying the `SynchronizeTask`
-        if state.sync_state != Default::default() && state.sync_state == new_sync_state {
+        if !self.force
+            && state.sync_state != Default::default()
+            && state.sync_state == new_sync_state
+        {
             debug!(target: "engine", ?new_sync_state, "No forkchoice update needed");
             return Ok(());
         }

--- a/crates/consensus/engine/src/task_queue/tasks/synchronize/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/synchronize/task.rs
@@ -44,7 +44,7 @@ pub struct SynchronizeTask<EngineClient_: EngineClient> {
     /// The sync state update to apply to the engine state.
     pub state_update: EngineSyncStateUpdate,
     /// Whether to send an FCU when the requested state already matches the current state.
-    pub force: bool,
+    force: bool,
 }
 
 impl<EngineClient_: EngineClient> SynchronizeTask<EngineClient_> {

--- a/crates/consensus/service/src/actors/sequencer/actor.rs
+++ b/crates/consensus/service/src/actors/sequencer/actor.rs
@@ -1,6 +1,7 @@
 //! The [`SequencerActor`].
 
 use std::{
+    num::NonZeroU64,
     sync::Arc,
     time::{Duration, Instant, UNIX_EPOCH},
 };
@@ -65,6 +66,8 @@ pub struct SequencerActor<
     pub engine_client: Arc<SequencerEngineClient_>,
     /// Whether the sequencer is active.
     pub is_active: bool,
+    /// Number of private blocks to build per shadow sequencing cycle.
+    pub shadow_blocks_per_cycle: Option<NonZeroU64>,
     /// Shared recovery mode flag.
     pub recovery_mode: RecoveryModeGuard,
     /// The rollup configuration.
@@ -116,7 +119,11 @@ where
         Metrics::sequencer_total_transactions_sequenced()
             .increment(handle.attributes_with_parent.count_transactions());
 
-        Ok(PayloadSealer::new(envelope))
+        if self.shadow_blocks_per_cycle.is_some() {
+            Ok(PayloadSealer::new_private(envelope))
+        } else {
+            Ok(PayloadSealer::new(envelope))
+        }
     }
 
     /// Attempts to seal a pre-built payload, first checking whether it is still fresh.

--- a/crates/consensus/service/src/actors/sequencer/actor.rs
+++ b/crates/consensus/service/src/actors/sequencer/actor.rs
@@ -103,6 +103,11 @@ where
     SequencerEngineClient_: SequencerEngineClient,
     UnsafePayloadGossipClient_: UnsafePayloadGossipClient,
 {
+    /// Returns whether this actor is running as a shadow sequencer.
+    pub const fn is_shadow_sequencer(&self) -> bool {
+        self.shadow_blocks_per_cycle.is_some()
+    }
+
     /// Fetches the sealed payload envelope from the engine for the given unsealed handle.
     pub(super) async fn seal_payload(
         &self,
@@ -119,7 +124,7 @@ where
         Metrics::sequencer_total_transactions_sequenced()
             .increment(handle.attributes_with_parent.count_transactions());
 
-        if self.shadow_blocks_per_cycle.is_some() {
+        if self.is_shadow_sequencer() {
             Ok(PayloadSealer::new_private(envelope))
         } else {
             Ok(PayloadSealer::new(envelope))

--- a/crates/consensus/service/src/actors/sequencer/config.rs
+++ b/crates/consensus/service/src/actors/sequencer/config.rs
@@ -39,6 +39,13 @@ pub struct SequencerConfig {
     pub l1_conf_delay: u64,
 }
 
+impl SequencerConfig {
+    /// Returns whether shadow sequencer mode is enabled.
+    pub const fn is_shadow_sequencer(&self) -> bool {
+        self.shadow_blocks_per_cycle.is_some()
+    }
+}
+
 impl Default for SequencerConfig {
     fn default() -> Self {
         Self {

--- a/crates/consensus/service/src/actors/sequencer/seal.rs
+++ b/crates/consensus/service/src/actors/sequencer/seal.rs
@@ -23,6 +23,8 @@ pub enum SealState {
     Committed,
     /// Gossiped to peers. Ready for engine insertion.
     Gossiped,
+    /// Private payload ready for engine insertion without conductor commit or gossip.
+    Private,
 }
 
 /// Result from one seal pipeline step.
@@ -40,7 +42,7 @@ impl SealState {
         match self {
             Self::Sealed => "conductor",
             Self::Committed => "gossip",
-            Self::Gossiped => "insert",
+            Self::Gossiped | Self::Private => "insert",
         }
     }
 }
@@ -79,6 +81,13 @@ impl PayloadSealer {
         );
 
         Self { envelope, state: SealState::Sealed, seal_span, started_at: Instant::now() }
+    }
+
+    /// Creates a private sealer that skips conductor commit and gossip.
+    pub fn new_private(envelope: BaseExecutionPayloadEnvelope) -> Self {
+        let mut sealer = Self::new(envelope);
+        sealer.state = SealState::Private;
+        sealer
     }
 
     /// Performs one step of the seal pipeline.
@@ -127,7 +136,7 @@ impl PayloadSealer {
                 self.state = SealState::Gossiped;
                 Ok(SealStepOutcome::Pending)
             }
-            SealState::Gossiped => {
+            SealState::Gossiped | SealState::Private => {
                 self.seal_span.in_scope(
                     || debug!(target: "sequencer", step = "insert", "seal pipeline step"),
                 );

--- a/crates/consensus/service/src/actors/sequencer/seal.rs
+++ b/crates/consensus/service/src/actors/sequencer/seal.rs
@@ -23,7 +23,7 @@ pub enum SealState {
     Committed,
     /// Gossiped to peers. Ready for engine insertion.
     Gossiped,
-    /// Private payload ready for engine insertion without conductor commit or gossip.
+    /// Shadow sequencer payload ready for private engine insertion without commit or gossip.
     Private,
 }
 
@@ -144,9 +144,14 @@ impl PayloadSealer {
                 Ok(SealStepOutcome::Pending)
             }
             SealState::Gossiped | SealState::Private => {
-                self.seal_span.in_scope(
-                    || debug!(target: "sequencer", step = "insert", "seal pipeline step"),
-                );
+                self.seal_span.in_scope(|| {
+                    debug!(
+                        target: "sequencer",
+                        step = "insert",
+                        state = ?self.state,
+                        "seal pipeline step"
+                    );
+                });
                 let inserted_head = engine_client
                     .insert_unsafe_payload(self.envelope.clone())
                     .instrument(self.seal_span.clone())

--- a/crates/consensus/service/src/actors/sequencer/seal.rs
+++ b/crates/consensus/service/src/actors/sequencer/seal.rs
@@ -85,9 +85,16 @@ impl PayloadSealer {
 
     /// Creates a private sealer that skips conductor commit and gossip.
     pub fn new_private(envelope: BaseExecutionPayloadEnvelope) -> Self {
-        let mut sealer = Self::new(envelope);
-        sealer.state = SealState::Private;
-        sealer
+        let block_hash = envelope.execution_payload.block_hash();
+        let block_num = envelope.execution_payload.block_number();
+        let seal_span = tracing::info_span!(
+            "seal_payload_pipeline",
+            block_hash = %block_hash,
+            block_number = block_num,
+            mode = "shadow",
+        );
+
+        Self { envelope, state: SealState::Private, seal_span, started_at: Instant::now() }
     }
 
     /// Performs one step of the seal pipeline.

--- a/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::{num::NonZeroU64, sync::Arc, time::Duration};
 
 use alloy_primitives::B256;
 use alloy_rpc_types_engine::ExecutionPayloadV1;
@@ -259,6 +259,26 @@ async fn test_seal_payload_success_returns_sealer() {
 }
 
 #[tokio::test]
+async fn test_shadow_seal_payload_returns_private_sealer() {
+    let envelope = dummy_envelope();
+
+    let mut client = MockSequencerEngineClient::new();
+    client.expect_get_sealed_payload().times(1).return_once(move |_, _| Ok(envelope));
+
+    let mut actor = test_actor();
+    actor.engine_client = Arc::new(client);
+    actor.shadow_blocks_per_cycle = NonZeroU64::new(10);
+
+    let handle = UnsealedPayloadHandle {
+        payload_id: Default::default(),
+        attributes_with_parent: dummy_attributes_with_parent(),
+    };
+    let sealer = actor.seal_payload(&handle).await.unwrap();
+
+    assert_eq!(sealer.state, SealState::Private);
+}
+
+#[tokio::test]
 async fn test_seal_payload_failure_propagates() {
     let mut client = MockSequencerEngineClient::new();
     client
@@ -279,6 +299,49 @@ async fn test_seal_payload_failure_propagates() {
 }
 
 // --- PayloadSealer::step tests ---
+
+#[tokio::test]
+async fn test_private_sealer_only_inserts() {
+    let envelope = dummy_envelope();
+
+    let mut conductor = MockConductor::new();
+    conductor.expect_commit_unsafe_payload().times(0);
+
+    let mut gossip = MockUnsafePayloadGossipClient::new();
+    gossip.expect_schedule_execution_payload_gossip().times(0);
+
+    let mut engine = MockSequencerEngineClient::new();
+    engine.expect_insert_unsafe_payload().times(1).return_once(|_| Ok(L2BlockInfo::default()));
+
+    let mut sealer = PayloadSealer::new_private(envelope);
+    let result = sealer.step(&Some(conductor), &gossip, &engine).await;
+
+    assert_eq!(result.unwrap(), SealStepOutcome::Inserted(L2BlockInfo::default()));
+    assert_eq!(sealer.state, SealState::Private);
+}
+
+#[tokio::test]
+async fn test_private_sealer_insert_failure_stays_private() {
+    let envelope = dummy_envelope();
+
+    let mut conductor = MockConductor::new();
+    conductor.expect_commit_unsafe_payload().times(0);
+
+    let mut gossip = MockUnsafePayloadGossipClient::new();
+    gossip.expect_schedule_execution_payload_gossip().times(0);
+
+    let mut engine = MockSequencerEngineClient::new();
+    engine
+        .expect_insert_unsafe_payload()
+        .times(1)
+        .return_once(|_| Err(EngineClientError::RequestError("channel closed".to_string())));
+
+    let mut sealer = PayloadSealer::new_private(envelope);
+    let result = sealer.step(&Some(conductor), &gossip, &engine).await;
+
+    assert!(matches!(result.unwrap_err(), SealStepError::Insert(_)));
+    assert_eq!(sealer.state, SealState::Private);
+}
 
 #[tokio::test]
 async fn test_sealer_full_pipeline_no_conductor() {

--- a/crates/consensus/service/src/actors/sequencer/tests/test_util.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/test_util.rs
@@ -41,6 +41,7 @@ pub(super) fn test_actor() -> SequencerActor<
         conductor: None,
         engine_client,
         is_active: true,
+        shadow_blocks_per_cycle: None,
         recovery_mode,
         rollup_config,
         unsafe_payload_gossip_client: MockUnsafePayloadGossipClient::new(),

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -573,6 +573,7 @@ impl RollupNode {
                     conductor,
                     engine_client,
                     is_active: self.sequencer_config.sequencer_stopped.not(),
+                    shadow_blocks_per_cycle: self.sequencer_config.shadow_blocks_per_cycle,
                     recovery_mode,
                     rollup_config: Arc::clone(&self.config),
                     unsafe_payload_gossip_client: queued_gossip_client,


### PR DESCRIPTION
## Summary
- add an explicit authoritative insertion policy alongside the existing extending-only policy
- allow authoritative unsafe payloads to replace a divergent or newer unsafe head
- force forkchoice acknowledgement for every authoritative insertion, including duplicate heads
- sequentially insert ordered authoritative payloads and publish acknowledged engine state updates
- preserve safe/finalized heads and reset local-safe to the canonical safe head after replacement

## Scope
It only provides the execution-engine primitive needed by future reconciliation. All existing insertion constructors remain extending-only. P2P buffering and reconciliation requests are intentionally deferred.