### PR TITLE
refactor(challenger): simplify service setup

### DIFF
--- a/crates/proof/challenge/src/service.rs
+++ b/crates/proof/challenge/src/service.rs
@@ -34,37 +34,20 @@ pub struct ChallengerService;
 impl ChallengerService {
     /// Runs the full challenger service lifecycle.
     ///
-    /// # Lifecycle
-    ///
-    /// 1. Install TLS provider
-    /// 2. Create the cancellation token and signal handler
-    /// 3. Create L1 provider, tx-manager, and challenge submitter
-    /// 4. Create contract clients and read onchain config
-    /// 5. Create L2 and ZK clients
-    /// 6. Assemble scanner, validator, and driver
-    /// 7. Start health HTTP server
-    /// 8. Start driver loop
-    /// 9. Wait for shutdown signal
-    /// 10. Graceful shutdown
-    ///
     /// # Errors
     ///
     /// Returns an error if RPC clients cannot connect or onchain
     /// configuration is invalid.
     pub async fn run(config: ChallengerConfig) -> Result<()> {
-        // ── 1. Install TLS provider ──────────────────────────────────────────
         // Install the default rustls CryptoProvider before any TLS connections are created.
         let _ = rustls::crypto::ring::default_provider().install_default();
 
         info!(version = env!("CARGO_PKG_VERSION"), "Challenger starting");
 
-        // ── 2. Cancellation token and signal handler ─────────────────────────
         let cancel = CancellationToken::new();
         let signal_handle = RuntimeManager::install_signal_handler(cancel.clone());
 
-        // ── 3. Construct tx-manager and challenge submitter ──────────────────
-        let signer_config = config.signing;
-        let sender_addr = signer_config.address();
+        let sender_addr = config.signing.address();
         let l1_rpc_url = config.l1_eth_rpc.clone();
         let l1_provider = if config.metrics.enabled {
             let (layer, mut balance_rx) = BalanceMonitorLayer::new(
@@ -90,7 +73,7 @@ impl ChallengerService {
             .map_err(|e| eyre::eyre!("failed to fetch L1 chain ID: {e}"))?;
         let tx_manager = SimpleTxManager::new(
             l1_provider,
-            signer_config,
+            config.signing,
             config.tx_manager,
             chain_id,
             Arc::new(BaseTxMetrics::new("challenger")),
@@ -99,7 +82,6 @@ impl ChallengerService {
         .map_err(|e| eyre::eyre!("failed to construct tx manager: {e}"))?;
         let submitter = ChallengeSubmitter::new(tx_manager);
 
-        // ── 4. Contract clients and onchain config ───────────────────────────
         let factory_client = DisputeGameFactoryContractClient::new(
             config.dispute_game_factory_addr,
             l1_rpc_url.clone(),
@@ -149,45 +131,32 @@ impl ChallengerService {
             "AnchorStateRegistry client initialized"
         );
 
-        let factory_client = Arc::new(factory_client);
+        let factory_client: Arc<dyn DisputeGameFactoryClient> = Arc::new(factory_client);
         let verifier_client: Arc<dyn AggregateVerifierClient> = Arc::new(verifier_client);
-        let anchor_registry_client = Arc::new(anchor_registry_client);
+        let anchor_registry_client: Arc<dyn AnchorStateRegistryClient> =
+            Arc::new(anchor_registry_client);
 
-        // ── 5. L2 client ─────────────────────────────────────────────────────
-        let l2_config = L2ClientConfig::new(config.l2_eth_rpc.clone());
-        let l2_client = Arc::new(L2Client::new(l2_config)?);
+        let l2_client = Arc::new(L2Client::new(L2ClientConfig::new(config.l2_eth_rpc.clone()))?);
         info!(endpoint = %config.l2_eth_rpc, "L2 client initialized");
 
-        // ── 6. Prover-service requester client ───────────────────────────────
         let proof_requester_config = ProverServiceClientConfig::new(config.zk_rpc_url.to_string())
             .with_request_timeout(config.zk_request_timeout);
         let proof_requester = Arc::new(ProofRequesterClient::connect(&proof_requester_config)?);
         info!(endpoint = %config.zk_rpc_url, "Prover-service requester client initialized");
 
-        // ── 6b. TEE proof provider ──────────────────────────────────────────
-        //
-        // TEE-first proof sourcing is the steady-state mode. TEE proofs flow
-        // through the same `proof_requester` as ZK proofs; `tee` carries the
-        // L1 head provider used to build the TEE proof request
-        // envelope. The driver automatically falls back to the ZK path when a
-        // TEE proof is unavailable for a given session, so TEE-first is safe
-        // to run even in deployments where TEE proofs are not yet generated
-        // for every session.
-        let l1_config = L1ClientConfig::new(l1_rpc_url.clone());
-        let l1_client = L1Client::new(l1_config)
+        let l1_client = L1Client::new(L1ClientConfig::new(l1_rpc_url.clone()))
             .map_err(|e| eyre::eyre!("failed to create TEE L1 client: {e}"))?;
         let tee: Option<Arc<dyn crate::L1HeadProvider>> = Some(Arc::new(l1_client));
 
-        // ── 7. Scanner, anchor updater, and bond manager ──────────────────
         let scanner = GameScanner::new(
-            Arc::clone(&factory_client) as Arc<dyn DisputeGameFactoryClient>,
+            Arc::clone(&factory_client),
             Arc::clone(&verifier_client),
-            Arc::clone(&anchor_registry_client) as Arc<dyn AnchorStateRegistryClient>,
+            Arc::clone(&anchor_registry_client),
         );
 
         let anchor_updater = AnchorUpdater::new(
-            Arc::clone(&factory_client) as Arc<dyn DisputeGameFactoryClient>,
-            Arc::clone(&anchor_registry_client) as Arc<dyn AnchorStateRegistryClient>,
+            Arc::clone(&factory_client),
+            Arc::clone(&anchor_registry_client),
             Arc::clone(&l2_client) as Arc<dyn L2Provider>,
             config.anchor_state_registry_addr,
             config.game_type,
@@ -204,7 +173,7 @@ impl ChallengerService {
                     discovery_interval: config.bond_discovery_interval,
                     metrics_enabled: config.metrics.enabled,
                 },
-                Arc::clone(&factory_client) as Arc<dyn DisputeGameFactoryClient>,
+                Arc::clone(&factory_client),
                 Arc::clone(&l2_client) as Arc<dyn L2Provider>,
                 TokioRuntime::new(),
             ))
@@ -213,19 +182,15 @@ impl ChallengerService {
             None
         };
 
-        // ── 7b. Assemble validator and driver ──────────────────────────────
         let validator = OutputValidator::new(l2_client);
 
-        // ── 8. Start health HTTP server ──────────────────────────────────────
         let ready = Arc::new(AtomicBool::new(false));
-        let health_handle = {
-            let addr = config.health_addr;
-            let ready_flag = Arc::clone(&ready);
-            let health_cancel = cancel.clone();
-            tokio::spawn(async move { HealthServer::serve(addr, ready_flag, health_cancel).await })
-        };
+        let health_handle = tokio::spawn(HealthServer::serve(
+            config.health_addr,
+            Arc::clone(&ready),
+            cancel.clone(),
+        ));
 
-        // ── 9. Run driver ────────────────────────────────────────────────────
         let driver = Driver::new(DriverComponents {
             scanner,
             validator,
@@ -251,7 +216,6 @@ impl ChallengerService {
         driver.run().await;
         drop(cancel_guard);
 
-        // ── 10. Graceful shutdown ────────────────────────────────────────────
         info!("Driver stopped, shutting down...");
         ready.store(false, Ordering::SeqCst);
 


### PR DESCRIPTION
### What changed? Why?

Simplified challenger-service initialization by creating trait-object clients at their declaration, inlining one-use configuration values, simplifying health-server startup, and removing redundant lifecycle comments.

### Notes to reviewers

This is a refactor-only change; service flow and behavior are unchanged.

### How has it been tested?

Not run (refactor-only change).