### PR TITLE
test(actions): Cover Batcher Txpool-Blocked Recovery

### DIFF
--- a/actions/harness/README.md
+++ b/actions/harness/README.md
@@ -193,25 +193,3 @@ The production-shaped synthetic L1/DA implementation is now the default:
 
 This keeps action tests fast while moving the critical DA boundary closer to
 production.
-
-## Decision Log
-
-- 2026-05-04: Track action-test production readiness in this README. Treat
-  production-mode L1/DA as the first productionization focus because current
-  tests bypass production calldata/blob sources.
-- 2026-05-04: Added production-mode L1/DA inside the harness crate under
-  `src/l1/`: signed transaction envelopes, versioned blob hashes, an
-  `EthereumDataSource` node builder, and coverage for calldata/blob DA.
-- 2026-05-04: Removed the legacy direct DA transaction path. Verifier nodes now
-  use production-shaped signed L1 transactions by default, and batcher
-  confirmations resolve against receipts from the mined `L1Block`.
-- 2026-05-05: Converted synthetic L1 events into signed event transactions with
-  per-transaction consensus receipts, RPC log metadata, and receipt/header
-  blooms. Updated `L1MinerTxManager` so staged submissions keep polling across
-  blocks that do not include their receipt.
-- 2026-07-20: Added txpool-blocked recovery coverage. `L1MinerTxManager` can now
-  reject submissions with `TxManagerError::AlreadyReserved` (via
-  `Batcher::block_next_n_submissions`) and implements `TxManager::cancel_tx`
-  instead of the trait default no-op, so the production `BatchDriver`
-  `TxpoolBlocked` → requeue → `cancel_tx` → resubmit path is exercised
-  end-to-end through derivation.

--- a/actions/harness/README.md
+++ b/actions/harness/README.md
@@ -209,3 +209,9 @@ production.
   per-transaction consensus receipts, RPC log metadata, and receipt/header
   blooms. Updated `L1MinerTxManager` so staged submissions keep polling across
   blocks that do not include their receipt.
+- 2026-07-20: Added txpool-blocked recovery coverage. `L1MinerTxManager` can now
+  reject submissions with `TxManagerError::AlreadyReserved` (via
+  `Batcher::block_next_n_submissions`) and implements `TxManager::cancel_tx`
+  instead of the trait default no-op, so the production `BatchDriver`
+  `TxpoolBlocked` → requeue → `cancel_tx` → resubmit path is exercised
+  end-to-end through derivation.

--- a/actions/harness/src/batcher/actor.rs
+++ b/actions/harness/src/batcher/actor.rs
@@ -280,6 +280,36 @@ impl<S: L2BlockProvider> Batcher<S> {
         self.tx_manager.fail_next_n(n);
     }
 
+    /// Schedule the next `n` frame submissions to be rejected as if the txpool
+    /// nonce slot is held by a stuck transaction.
+    ///
+    /// Each of the next `n` calls the background [`BatchDriver`] makes to
+    /// [`TxManager::send_async`] resolves with [`TxManagerError::AlreadyReserved`].
+    /// The driver classifies this as [`TxOutcome::TxpoolBlocked`]: it requeues
+    /// the frames, stops submitting, and calls [`TxManager::cancel_tx`] on its
+    /// next loop iteration to clear the slot before resubmitting. Use
+    /// [`cancellation_count`] to assert the recovery path ran, and
+    /// [`wait_until_requeued`] to wait for the frames to return to pending.
+    ///
+    /// [`BatchDriver`]: base_batcher_core::BatchDriver
+    /// [`TxManager::send_async`]: base_tx_manager::TxManager::send_async
+    /// [`TxManager::cancel_tx`]: base_tx_manager::TxManager::cancel_tx
+    /// [`TxManagerError::AlreadyReserved`]: base_tx_manager::TxManagerError::AlreadyReserved
+    /// [`TxOutcome::TxpoolBlocked`]: base_batcher_core::TxOutcome::TxpoolBlocked
+    /// [`cancellation_count`]: Batcher::cancellation_count
+    /// [`wait_until_requeued`]: Batcher::wait_until_requeued
+    pub fn block_next_n_submissions(&self, n: usize) {
+        self.tx_manager.block_next_n(n);
+    }
+
+    /// Returns how many times the driver has called [`TxManager::cancel_tx`] to
+    /// recover from a txpool blockage.
+    ///
+    /// [`TxManager::cancel_tx`]: base_tx_manager::TxManager::cancel_tx
+    pub fn cancellation_count(&self) -> usize {
+        self.tx_manager.cancellation_count()
+    }
+
     /// Mine all pending frame submissions in one L1 block.
     ///
     /// Stages every pending frame, mines one L1 block, fires all receipt

--- a/actions/harness/src/batcher/tx_manager.rs
+++ b/actions/harness/src/batcher/tx_manager.rs
@@ -12,6 +12,7 @@ use alloy_signer_local::PrivateKeySigner;
 use base_batcher_source::L1HeadEvent;
 use base_tx_manager::{
     BlobTxBuilder, SendHandle, SendResponse, TxCandidate, TxManager, TxManagerError,
+    TxManagerResult,
 };
 use tokio::sync::{mpsc, oneshot};
 use tracing::info;
@@ -56,6 +57,21 @@ pub struct Inner {
     /// Number of upcoming `send_async` calls to immediately fail with
     /// [`TxManagerError::Rpc`] before falling through to normal queuing.
     fail_remaining: usize,
+    /// Number of upcoming `send_async` calls to immediately reject with
+    /// [`TxManagerError::AlreadyReserved`], modelling a txpool nonce slot held
+    /// by a stuck transaction. The [`BatchDriver`] classifies this as
+    /// [`TxOutcome::TxpoolBlocked`] and must clear it via [`cancel_tx`].
+    ///
+    /// [`BatchDriver`]: base_batcher_core::BatchDriver
+    /// [`TxOutcome::TxpoolBlocked`]: base_batcher_core::TxOutcome::TxpoolBlocked
+    /// [`cancel_tx`]: base_tx_manager::TxManager::cancel_tx
+    blocked_remaining: usize,
+    /// Number of times [`cancel_tx`] has been invoked by the driver's txpool
+    /// recovery path. Tests assert on this to prove the blockage was cleared
+    /// through the production recovery flow rather than by chance.
+    ///
+    /// [`cancel_tx`]: base_tx_manager::TxManager::cancel_tx
+    cancellations: usize,
 }
 
 /// Adapts [`L1Miner`] to the [`TxManager`] trait for action tests.
@@ -142,6 +158,32 @@ impl L1MinerTxManager {
     /// [`BatchDriver`]: base_batcher_core::BatchDriver
     pub fn fail_next_n(&self, n: usize) {
         self.inner.lock().unwrap().fail_remaining += n;
+    }
+
+    /// Schedule the next `n` [`send_async`] calls to immediately reject with
+    /// [`TxManagerError::AlreadyReserved`], modelling a txpool nonce slot held
+    /// by a stuck transaction.
+    ///
+    /// The [`BatchDriver`] classifies this as
+    /// [`TxOutcome::TxpoolBlocked`]: it requeues the frames, stops submitting
+    /// new ones, and calls [`cancel_tx`] on the next loop iteration to clear the
+    /// slot before resubmitting. Rejections are consumed one-per-call, so
+    /// `n = 2` blocks the next two separate `send_async` calls.
+    ///
+    /// [`send_async`]: L1MinerTxManager::send_async
+    /// [`BatchDriver`]: base_batcher_core::BatchDriver
+    /// [`TxOutcome::TxpoolBlocked`]: base_batcher_core::TxOutcome::TxpoolBlocked
+    /// [`cancel_tx`]: base_tx_manager::TxManager::cancel_tx
+    pub fn block_next_n(&self, n: usize) {
+        self.inner.lock().unwrap().blocked_remaining += n;
+    }
+
+    /// Returns how many times the driver has called [`cancel_tx`] to recover
+    /// from a txpool blockage.
+    ///
+    /// [`cancel_tx`]: base_tx_manager::TxManager::cancel_tx
+    pub fn cancellation_count(&self) -> usize {
+        self.inner.lock().unwrap().cancellations
     }
 
     /// Drop the first `n` pending submissions without staging them to L1.
@@ -366,6 +408,12 @@ impl TxManager for L1MinerTxManager {
                     tx.send(Err(TxManagerError::Rpc("simulated submission failure".to_string())));
                 return SendHandle::new(rx);
             }
+            if inner.blocked_remaining > 0 {
+                inner.blocked_remaining -= 1;
+                let (tx, rx) = oneshot::channel::<SendResponse>();
+                let _ = tx.send(Err(TxManagerError::AlreadyReserved));
+                return SendHandle::new(rx);
+            }
         }
 
         let nonce = {
@@ -392,13 +440,24 @@ impl TxManager for L1MinerTxManager {
     fn sender_address(&self) -> Address {
         self.signer.address()
     }
+
+    async fn cancel_tx(&self) -> TxManagerResult<()> {
+        // Production `cancel_tx` sends a self-transfer at the stuck nonce with a
+        // higher gas price to evict the transaction and free the slot. The
+        // harness blockage is injected synthetically (no real transaction ever
+        // occupied the slot), so clearing it is simply acknowledging the
+        // cancellation. Record the invocation so tests can prove the driver
+        // drove the production txpool-recovery path.
+        self.inner.lock().unwrap().cancellations += 1;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Address, B256, Bytes, U256};
     use alloy_signer_local::PrivateKeySigner;
-    use base_tx_manager::{TxCandidate, TxManager};
+    use base_tx_manager::{TxCandidate, TxManager, TxManagerError};
 
     use super::L1MinerTxManager;
     use crate::L1Miner;
@@ -445,5 +504,36 @@ mod tests {
         assert_eq!(receipt.block_number, Some(block.number()));
         assert_eq!(receipt.transaction_index, Some(0));
         assert_eq!(receipt.to, Some(inbox));
+    }
+
+    #[tokio::test]
+    async fn block_next_n_rejects_with_already_reserved_then_succeeds() {
+        let inbox = Address::repeat_byte(0x42);
+        let manager = L1MinerTxManager::new(TxManagerFixture::signer(), inbox, 1);
+
+        // The next two submissions are rejected as if the nonce slot is held by
+        // a stuck transaction; the third queues normally.
+        manager.block_next_n(2);
+
+        let first = manager.send_async(TxManagerFixture::candidate(inbox)).await;
+        assert!(matches!(first.await, Err(TxManagerError::AlreadyReserved)));
+        assert_eq!(manager.pending_count(), 0, "rejected submission must not queue");
+
+        let second = manager.send_async(TxManagerFixture::candidate(inbox)).await;
+        assert!(matches!(second.await, Err(TxManagerError::AlreadyReserved)));
+
+        let _third = manager.send_async(TxManagerFixture::candidate(inbox)).await;
+        assert_eq!(manager.pending_count(), 1, "third submission must queue normally");
+    }
+
+    #[tokio::test]
+    async fn cancel_tx_records_invocations() {
+        let inbox = Address::repeat_byte(0x42);
+        let manager = L1MinerTxManager::new(TxManagerFixture::signer(), inbox, 1);
+
+        assert_eq!(manager.cancellation_count(), 0);
+        manager.cancel_tx().await.expect("cancel_tx never fails in the harness");
+        manager.cancel_tx().await.expect("cancel_tx never fails in the harness");
+        assert_eq!(manager.cancellation_count(), 2);
     }
 }

--- a/actions/harness/tests/batcher/main.rs
+++ b/actions/harness/tests/batcher/main.rs
@@ -7,4 +7,5 @@ mod production_da;
 mod sequencer_drift;
 mod submission;
 mod submission_failure;
+mod txpool_blocked;
 mod upgrade_transitions;

--- a/actions/harness/tests/batcher/txpool_blocked.rs
+++ b/actions/harness/tests/batcher/txpool_blocked.rs
@@ -1,0 +1,132 @@
+//! Action tests for batcher recovery when the L1 txpool nonce slot is blocked.
+//!
+//! These tests verify the end-to-end production recovery path:
+//!   sequencer → batcher (txpool blocked) → requeue + `cancel_tx` → derivation
+//!
+//! When [`TxManager::send_async`] rejects a submission with
+//! [`TxManagerError::AlreadyReserved`], the [`BatchDriver`] classifies the
+//! outcome as [`TxOutcome::TxpoolBlocked`]: it requeues the frames, stops
+//! submitting new ones, and calls [`TxManager::cancel_tx`] on its next loop
+//! iteration to clear the stuck slot before resubmitting. This is a distinct
+//! driver code path from a plain submission failure (see `submission_failure.rs`),
+//! and it exercises the `cancel_tx` hook that the harness previously left as the
+//! trait's default no-op.
+//!
+//! [`TxManager::send_async`]: base_tx_manager::TxManager::send_async
+//! [`TxManager::cancel_tx`]: base_tx_manager::TxManager::cancel_tx
+//! [`TxManagerError::AlreadyReserved`]: base_tx_manager::TxManagerError::AlreadyReserved
+//! [`BatchDriver`]: base_batcher_core::BatchDriver
+//! [`TxOutcome::TxpoolBlocked`]: base_batcher_core::TxOutcome::TxpoolBlocked
+
+use base_action_harness::{
+    ActionL2Source, ActionTestHarness, Batcher, BatcherConfig, L1MinerConfig, SharedL1Chain,
+    TestRollupConfigBuilder,
+};
+use base_batcher_encoder::{DaType, EncoderConfig};
+
+fn calldata_batcher_config() -> BatcherConfig {
+    BatcherConfig {
+        encoder: EncoderConfig { da_type: DaType::Calldata, ..EncoderConfig::default() },
+        ..BatcherConfig::default()
+    }
+}
+
+/// When the first submission hits a reserved nonce slot, the [`BatchDriver`]
+/// requeues the frame, clears the blockage via [`TxManager::cancel_tx`], and the
+/// derivation node successfully derives the L2 block after recovery.
+///
+/// [`BatchDriver`]: base_batcher_core::BatchDriver
+/// [`TxManager::cancel_tx`]: base_tx_manager::TxManager::cancel_tx
+#[tokio::test]
+async fn txpool_blocked_recovers_via_cancel_tx_and_derives() {
+    let batcher_cfg = calldata_batcher_config();
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+    let block = sequencer.build_next_block_with_single_transaction().await;
+
+    let (mut node, chain) = h.create_test_rollup_node_from_sequencer(
+        &mut sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
+
+    let mut source = ActionL2Source::new();
+    source.push(block);
+    let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg);
+
+    // Block the first submission so the driver must recover the txpool slot
+    // before it can resubmit the requeued frame.
+    batcher.block_next_n_submissions(1);
+    batcher.encode_only().await;
+
+    // Driver path: TxpoolBlocked receipt → requeue → recover_txpool → cancel_tx
+    // → resubmit. The frame returns to pending only after the blockage clears.
+    batcher.wait_until_requeued(1).await;
+
+    assert_eq!(
+        batcher.cancellation_count(),
+        1,
+        "driver must clear the txpool blockage via exactly one cancel_tx"
+    );
+
+    // Mine the successfully resubmitted frame into an L1 block.
+    let block_num = batcher.mine_pending(&mut h.l1).await;
+    chain.push(h.l1.tip().clone());
+
+    node.initialize().await;
+    let derived = node.run_until_idle().await;
+
+    assert_eq!(derived, 1, "frame must derive one L2 block after txpool recovery");
+    assert_eq!(node.l2_safe_number(), 1, "safe head must reach 1 after recovery");
+    assert!(block_num >= 1, "resubmitted frame was mined into an L1 block");
+}
+
+/// With two consecutive txpool blockages, the driver recovers twice via
+/// [`TxManager::cancel_tx`] before the third submission succeeds. No data is
+/// lost: the derivation node still sees the correct L2 block.
+///
+/// [`TxManager::cancel_tx`]: base_tx_manager::TxManager::cancel_tx
+#[tokio::test]
+async fn consecutive_txpool_blocks_recover_and_derive() {
+    let batcher_cfg = calldata_batcher_config();
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+    let block = sequencer.build_next_block_with_single_transaction().await;
+
+    let (mut node, chain) = h.create_test_rollup_node_from_sequencer(
+        &mut sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
+
+    let mut source = ActionL2Source::new();
+    source.push(block);
+    let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg);
+
+    // Block the next two submissions; the driver must recover after each before
+    // the third submission queues successfully.
+    batcher.block_next_n_submissions(2);
+    batcher.encode_only().await;
+
+    batcher.wait_until_requeued(1).await;
+
+    assert_eq!(
+        batcher.cancellation_count(),
+        2,
+        "driver must clear two consecutive txpool blockages via cancel_tx"
+    );
+
+    let block_num = batcher.mine_pending(&mut h.l1).await;
+    chain.push(h.l1.tip().clone());
+
+    node.initialize().await;
+    let derived = node.run_until_idle().await;
+
+    assert_eq!(derived, 1, "frame must survive two blockages and derive one L2 block");
+    assert_eq!(node.l2_safe_number(), 1, "safe head must reach 1 after two recoveries");
+    assert!(block_num >= 1, "frame was eventually mined into an L1 block");
+}


### PR DESCRIPTION
## Summary

Closes a real gap in the action-harness batcher coverage. The production `BatchDriver` treats a `TxManagerError::AlreadyReserved` submission result as `TxpoolBlocked`: it requeues the frames, stops submitting, and calls `TxManager::cancel_tx` on its next loop iteration to clear the stuck nonce slot before resubmitting. The harness previously could only produce `Failed` outcomes and relied on the `cancel_tx` trait default no-op, so this recovery path was never exercised end-to-end.

This adds txpool-blocked failure injection (`Batcher::block_next_n_submissions`) and a real `cancel_tx` implementation with an invocation counter to `L1MinerTxManager`, plus two integration tests that drive a full sequencer to batcher to derivation flow through single and consecutive blockages and assert the frames recover and the safe head advances. This is the first of a small series of PRs that tighten the harness toward the production service paths.