### PR TITLE
test(actions): Enforce And Prove State-Root Verification

### DIFF
--- a/actions/harness/README.md
+++ b/actions/harness/README.md
@@ -193,25 +193,3 @@ The production-shaped synthetic L1/DA implementation is now the default:
 
 This keeps action tests fast while moving the critical DA boundary closer to
 production.
-
-## Decision Log
-
-- 2026-05-04: Track action-test production readiness in this README. Treat
-  production-mode L1/DA as the first productionization focus because current
-  tests bypass production calldata/blob sources.
-- 2026-05-04: Added production-mode L1/DA inside the harness crate under
-  `src/l1/`: signed transaction envelopes, versioned blob hashes, an
-  `EthereumDataSource` node builder, and coverage for calldata/blob DA.
-- 2026-05-04: Removed the legacy direct DA transaction path. Verifier nodes now
-  use production-shaped signed L1 transactions by default, and batcher
-  confirmations resolve against receipts from the mined `L1Block`.
-- 2026-05-05: Converted synthetic L1 events into signed event transactions with
-  per-transaction consensus receipts, RPC log metadata, and receipt/header
-  blooms. Updated `L1MinerTxManager` so staged submissions keep polling across
-  blocks that do not include their receipt.
-- 2026-07-20: Added txpool-blocked recovery coverage. `L1MinerTxManager` can now
-  reject submissions with `TxManagerError::AlreadyReserved` (via
-  `Batcher::block_next_n_submissions`) and implements `TxManager::cancel_tx`
-  instead of the trait default no-op, so the production `BatchDriver`
-  `TxpoolBlocked` → requeue → `cancel_tx` → resubmit path is exercised
-  end-to-end through derivation.

--- a/actions/harness/README.md
+++ b/actions/harness/README.md
@@ -34,9 +34,9 @@ store, P2P transport, conductor behavior, and finality/reset orchestration.
 | L1 chain and miner | Alloy `Header`, block hash chaining, signed `TxEnvelope` bodies, consensus receipts consumed by derivation, RPC-shaped transaction receipts and log metadata for batcher confirmations and L1 events | `L1Miner`, `L1Block`, manual reorg/safe/finalized heads | No tx pool, contract execution, full gas accounting, or beacon sidecar service |
 | L1 calldata DA | Verifier nodes use `EthereumDataSource` and production `CalldataSource` over signed tx bodies | In-memory `ActionL1ChainProvider` backed by `SharedL1Chain` | RPC paging/provider edge cases are not covered by the default action path |
 | L1 blob DA | Verifier nodes use `EthereumDataSource`, production `BlobSource`, versioned hashes from signed EIP-4844 txs, and `ActionBlobProvider` sidecar lookup | Blob sidecars are stored in `L1Block::blob_sidecars` rather than fetched from a beacon API | Beacon API behavior, blob retention windows, and sidecar transport are not modeled |
-| Batcher | `BatchDriver`, `BatchEncoder`, channel manager behavior, span/single batch encoding, signed calldata/blob tx construction | `L1MinerTxManager`, in-memory L2/L1 event channels, synthetic inclusion receipts | Submission does not use a real RPC tx manager, replacement, fee bumping, or production receipt polling against an RPC provider |
+| Batcher | `BatchDriver`, `BatchEncoder`, channel manager behavior, span/single batch encoding, signed calldata/blob tx construction, txpool-blocked → `cancel_tx` recovery | `L1MinerTxManager`, in-memory L2/L1 event channels, synthetic inclusion receipts | Submission does not use a real RPC tx manager, mempool, replacement, or fee bumping (nonce-slot blockage is modeled; recovery is exercised via `cancel_tx`) |
 | Sequencer | L1 origin selection, attributes building, payload construction, real signed L2 user txs | Test actor lifecycle and manual stepping | No real node service loop, txpool/RPC ingress, engine transport, or production unsafe block scheduling |
-| Engine | `BasePayloadBuilder`, Base EVM config, temporary Reth database, state-root comparison | `ActionEngineClient` implements only the Engine API behavior tests need | Simplified payload statuses, forkchoice handling, transaction pool, networking, persistence lifecycle, and Engine API edge cases |
+| Engine | `BasePayloadBuilder`, Base EVM config, temporary Reth database, enforced state-root verification (asserts against the sequencer's root; `assert_state_roots_verified` proves it ran) | `ActionEngineClient` implements only the Engine API behavior tests need | Simplified payload statuses, forkchoice handling, transaction pool, networking, persistence lifecycle, and Engine API edge cases |
 | Verifier and derivation | Real derivation pipeline, attributes queue, reset signals, payload application, `SafeDB` | `TestRollupNode` orchestration and manual L1 push/signals | Reset/finality/unsafe-head flow is test-scripted rather than driven by production driver loops and online providers |
 | P2P and unsafe gossip | Optional production unsafe-block signing formula | `SupervisedP2P` and `TestGossipTransport` are in-memory | No libp2p peer scoring, mesh behavior, networking, throttling, or gossip timing |
 | Conductor | Exercises high-level sequencing/follower roles | In-memory conductor control surface | No production service integration, RPC control plane, or multi-process failure modes |
@@ -82,101 +82,20 @@ new tests:
   signals production receives.
 - P2P and conductor tests exercise local state transitions but not real network
   or service integration.
+- L1 contract execution is not modeled. The harness does not run `SystemConfig`,
+  `OptimismPortal`, or other L1 contracts; event helpers encode their expected
+  logs directly, and `ActionL1BlockFetcher::get_logs` is intentionally narrow.
+  Behavior that depends on real RPC/contract semantics (e.g. `eth_getLogs`
+  filtering, deposit/system-config event shape, beacon-sidecar compatibility)
+  belongs in an opt-in external-L1 test backed by a real local L1, not the
+  default in-process path.
+- Full service lifecycle, RPC servers, config/CLI bootstrap, P2P mesh behavior,
+  EL/CL coupling, and multi-process failures are out of scope for action tests
+  by design; they are covered by the Docker-backed system tests.
 
-## Productionizing Roadmap
+## Working With the Harness
 
-### 1. Production-Mode L1/DA
-
-This is the highest-value next step because it removes a custom derivation
-boundary while preserving the speed and determinism of action tests.
-
-Current behavior:
-
-- `L1Block` stores signed `TxEnvelope` values as the only L1 transaction body
-  representation.
-- `L1MinerTxManager` signs every batcher submission into an EIP-1559 or
-  EIP-4844 transaction using `BatcherConfig::l1_signer`.
-- `ActionL1ChainProvider::block_info_and_transactions_by_hash` returns signed
-  transaction bodies to production DA sources.
-- `ActionTestHarness::create_test_rollup_node` wires
-  `EthereumDataSource::new_from_parts` with `ActionL1ChainProvider` and
-  `ActionBlobProvider`.
-- Blob DA computes real versioned hashes and returns exactly the blobs
-  referenced by the signed L1 transaction.
-
-The result is that action tests still use an in-memory L1, but the derivation
-pipeline sees production-shaped L1 data by default.
-
-### 2. Production-Shaped Receipts and L1 Events
-
-Current behavior:
-
-- `enqueue_batcher_update`, gas-config updates, operator-fee updates, and
-  deposits all flow through signed synthetic L1 event transactions.
-- Consensus receipts expose the logs to derivation on the same transaction index
-  as the synthetic event transaction.
-- RPC transaction receipts preserve block hash, block number, block timestamp,
-  transaction hash, transaction index, global log index, sender, recipient, gas
-  fields, blob gas markers, and receipt/header blooms.
-- Direct `enqueue_log` remains available as an explicit test escape hatch, but
-  it no longer creates loose no-transaction receipts.
-
-Remaining gaps:
-
-- The harness does not execute `SystemConfig`, `OptimismPortal`, or other L1
-  contracts; event helpers still encode their expected logs directly.
-- `ActionL1BlockFetcher::get_logs` is still intentionally narrow. Tests that
-  require real `eth_getLogs` filtering should use an opt-in external L1 smoke
-  mode or extend this fetcher deliberately.
-
-### 3. Tx Manager Realism
-
-Keep `BatchDriver` as the production owner, but make the adapter look more
-like the production transaction manager:
-
-Current behavior:
-
-- `send_async` signs each candidate with the batcher L1 signer and assigns a
-  monotonic nonce.
-- Submissions move from pending to staged when the harness submits them to
-  `L1Miner`.
-- A staged submission only resolves when `confirm_block` observes a matching
-  transaction receipt. If a block does not include the transaction, the
-  submission remains staged so tests can model delayed inclusion.
-- Blob submissions link the signed EIP-4844 transaction, versioned hashes,
-  sidecars, and mined receipt observed by derivation.
-- Explicit reorg and submission-failure helpers still fire failed receipts so
-  the production `BatchDriver` requeues frames.
-
-Remaining gaps:
-
-- There is no real RPC tx manager, mempool, replacement, fee bumping,
-  cancellation, or timeout policy.
-- Receipt polling is driven by explicit test calls instead of a background RPC
-  polling task.
-
-### 4. Optional External L1 Smoke Mode
-
-Add a small number of opt-in tests backed by a real local L1 process or
-container when the behavior depends on RPC semantics or contract execution.
-These should complement action tests, not replace the default in-process path.
-
-Good candidates:
-
-- Batch inbox transaction filtering through real RPC responses.
-- Deposit and system-config contract event shape.
-- Blob transaction and beacon-sidecar compatibility, if the selected local L1
-  supports the required Cancun/EIP-4844 behavior.
-
-### 5. Service and Network Coverage
-
-Keep full service lifecycle, RPC servers, P2P mesh behavior, EL/CL coupling,
-and multi-process failures in Docker-backed system tests. Those are outside the fast
-action-test boundary.
-
-## Near-Term L1/DA Design Notes
-
-The production-shaped synthetic L1/DA implementation is now the default:
+The production-shaped synthetic L1/DA path is the default:
 
 1. `BatcherConfig::default()` includes a deterministic L1 signer, and
    `with_l1_signer` updates the batcher address to match.
@@ -190,6 +109,8 @@ The production-shaped synthetic L1/DA implementation is now the default:
 5. Use `Batcher::stage_n_frames`, `Batcher::confirm_staged`, and
    `Batcher::staged_count` when a test needs to distinguish submission from L1
    inclusion.
-
-This keeps action tests fast while moving the critical DA boundary closer to
-production.
+6. Use `Batcher::fail_next_n_submissions` and `Batcher::block_next_n_submissions`
+   (paired with `Batcher::cancellation_count`) to drive the production
+   `BatchDriver` failure and txpool-blocked recovery paths.
+7. Call `TestRollupNode::assert_state_roots_verified` when a test should prove
+   the engine actually compared derived state roots against the sequencer's.

--- a/actions/harness/README.md
+++ b/actions/harness/README.md
@@ -209,3 +209,9 @@ production.
   per-transaction consensus receipts, RPC log metadata, and receipt/header
   blooms. Updated `L1MinerTxManager` so staged submissions keep polling across
   blocks that do not include their receipt.
+- 2026-07-20: Added txpool-blocked recovery coverage. `L1MinerTxManager` can now
+  reject submissions with `TxManagerError::AlreadyReserved` (via
+  `Batcher::block_next_n_submissions`) and implements `TxManager::cancel_tx`
+  instead of the trait default no-op, so the production `BatchDriver`
+  `TxpoolBlocked` → requeue → `cancel_tx` → resubmit path is exercised
+  end-to-end through derivation.

--- a/actions/harness/src/batcher/actor.rs
+++ b/actions/harness/src/batcher/actor.rs
@@ -280,6 +280,36 @@ impl<S: L2BlockProvider> Batcher<S> {
         self.tx_manager.fail_next_n(n);
     }
 
+    /// Schedule the next `n` frame submissions to be rejected as if the txpool
+    /// nonce slot is held by a stuck transaction.
+    ///
+    /// Each of the next `n` calls the background [`BatchDriver`] makes to
+    /// [`TxManager::send_async`] resolves with [`TxManagerError::AlreadyReserved`].
+    /// The driver classifies this as [`TxOutcome::TxpoolBlocked`]: it requeues
+    /// the frames, stops submitting, and calls [`TxManager::cancel_tx`] on its
+    /// next loop iteration to clear the slot before resubmitting. Use
+    /// [`cancellation_count`] to assert the recovery path ran, and
+    /// [`wait_until_requeued`] to wait for the frames to return to pending.
+    ///
+    /// [`BatchDriver`]: base_batcher_core::BatchDriver
+    /// [`TxManager::send_async`]: base_tx_manager::TxManager::send_async
+    /// [`TxManager::cancel_tx`]: base_tx_manager::TxManager::cancel_tx
+    /// [`TxManagerError::AlreadyReserved`]: base_tx_manager::TxManagerError::AlreadyReserved
+    /// [`TxOutcome::TxpoolBlocked`]: base_batcher_core::TxOutcome::TxpoolBlocked
+    /// [`cancellation_count`]: Batcher::cancellation_count
+    /// [`wait_until_requeued`]: Batcher::wait_until_requeued
+    pub fn block_next_n_submissions(&self, n: usize) {
+        self.tx_manager.block_next_n(n);
+    }
+
+    /// Returns how many times the driver has called [`TxManager::cancel_tx`] to
+    /// recover from a txpool blockage.
+    ///
+    /// [`TxManager::cancel_tx`]: base_tx_manager::TxManager::cancel_tx
+    pub fn cancellation_count(&self) -> usize {
+        self.tx_manager.cancellation_count()
+    }
+
     /// Mine all pending frame submissions in one L1 block.
     ///
     /// Stages every pending frame, mines one L1 block, fires all receipt

--- a/actions/harness/src/batcher/tx_manager.rs
+++ b/actions/harness/src/batcher/tx_manager.rs
@@ -12,6 +12,7 @@ use alloy_signer_local::PrivateKeySigner;
 use base_batcher_source::L1HeadEvent;
 use base_tx_manager::{
     BlobTxBuilder, SendHandle, SendResponse, TxCandidate, TxManager, TxManagerError,
+    TxManagerResult,
 };
 use tokio::sync::{mpsc, oneshot};
 use tracing::info;
@@ -56,6 +57,21 @@ pub struct Inner {
     /// Number of upcoming `send_async` calls to immediately fail with
     /// [`TxManagerError::Rpc`] before falling through to normal queuing.
     fail_remaining: usize,
+    /// Number of upcoming `send_async` calls to immediately reject with
+    /// [`TxManagerError::AlreadyReserved`], modelling a txpool nonce slot held
+    /// by a stuck transaction. The [`BatchDriver`] classifies this as
+    /// [`TxOutcome::TxpoolBlocked`] and must clear it via [`cancel_tx`].
+    ///
+    /// [`BatchDriver`]: base_batcher_core::BatchDriver
+    /// [`TxOutcome::TxpoolBlocked`]: base_batcher_core::TxOutcome::TxpoolBlocked
+    /// [`cancel_tx`]: base_tx_manager::TxManager::cancel_tx
+    blocked_remaining: usize,
+    /// Number of times [`cancel_tx`] has been invoked by the driver's txpool
+    /// recovery path. Tests assert on this to prove the blockage was cleared
+    /// through the production recovery flow rather than by chance.
+    ///
+    /// [`cancel_tx`]: base_tx_manager::TxManager::cancel_tx
+    cancellations: usize,
 }
 
 /// Adapts [`L1Miner`] to the [`TxManager`] trait for action tests.
@@ -142,6 +158,32 @@ impl L1MinerTxManager {
     /// [`BatchDriver`]: base_batcher_core::BatchDriver
     pub fn fail_next_n(&self, n: usize) {
         self.inner.lock().unwrap().fail_remaining += n;
+    }
+
+    /// Schedule the next `n` [`send_async`] calls to immediately reject with
+    /// [`TxManagerError::AlreadyReserved`], modelling a txpool nonce slot held
+    /// by a stuck transaction.
+    ///
+    /// The [`BatchDriver`] classifies this as
+    /// [`TxOutcome::TxpoolBlocked`]: it requeues the frames, stops submitting
+    /// new ones, and calls [`cancel_tx`] on the next loop iteration to clear the
+    /// slot before resubmitting. Rejections are consumed one-per-call, so
+    /// `n = 2` blocks the next two separate `send_async` calls.
+    ///
+    /// [`send_async`]: L1MinerTxManager::send_async
+    /// [`BatchDriver`]: base_batcher_core::BatchDriver
+    /// [`TxOutcome::TxpoolBlocked`]: base_batcher_core::TxOutcome::TxpoolBlocked
+    /// [`cancel_tx`]: base_tx_manager::TxManager::cancel_tx
+    pub fn block_next_n(&self, n: usize) {
+        self.inner.lock().unwrap().blocked_remaining += n;
+    }
+
+    /// Returns how many times the driver has called [`cancel_tx`] to recover
+    /// from a txpool blockage.
+    ///
+    /// [`cancel_tx`]: base_tx_manager::TxManager::cancel_tx
+    pub fn cancellation_count(&self) -> usize {
+        self.inner.lock().unwrap().cancellations
     }
 
     /// Drop the first `n` pending submissions without staging them to L1.
@@ -366,6 +408,12 @@ impl TxManager for L1MinerTxManager {
                     tx.send(Err(TxManagerError::Rpc("simulated submission failure".to_string())));
                 return SendHandle::new(rx);
             }
+            if inner.blocked_remaining > 0 {
+                inner.blocked_remaining -= 1;
+                let (tx, rx) = oneshot::channel::<SendResponse>();
+                let _ = tx.send(Err(TxManagerError::AlreadyReserved));
+                return SendHandle::new(rx);
+            }
         }
 
         let nonce = {
@@ -392,13 +440,24 @@ impl TxManager for L1MinerTxManager {
     fn sender_address(&self) -> Address {
         self.signer.address()
     }
+
+    async fn cancel_tx(&self) -> TxManagerResult<()> {
+        // Production `cancel_tx` sends a self-transfer at the stuck nonce with a
+        // higher gas price to evict the transaction and free the slot. The
+        // harness blockage is injected synthetically (no real transaction ever
+        // occupied the slot), so clearing it is simply acknowledging the
+        // cancellation. Record the invocation so tests can prove the driver
+        // drove the production txpool-recovery path.
+        self.inner.lock().unwrap().cancellations += 1;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Address, B256, Bytes, U256};
     use alloy_signer_local::PrivateKeySigner;
-    use base_tx_manager::{TxCandidate, TxManager};
+    use base_tx_manager::{TxCandidate, TxManager, TxManagerError};
 
     use super::L1MinerTxManager;
     use crate::L1Miner;
@@ -445,5 +504,36 @@ mod tests {
         assert_eq!(receipt.block_number, Some(block.number()));
         assert_eq!(receipt.transaction_index, Some(0));
         assert_eq!(receipt.to, Some(inbox));
+    }
+
+    #[tokio::test]
+    async fn block_next_n_rejects_with_already_reserved_then_succeeds() {
+        let inbox = Address::repeat_byte(0x42);
+        let manager = L1MinerTxManager::new(TxManagerFixture::signer(), inbox, 1);
+
+        // The next two submissions are rejected as if the nonce slot is held by
+        // a stuck transaction; the third queues normally.
+        manager.block_next_n(2);
+
+        let first = manager.send_async(TxManagerFixture::candidate(inbox)).await;
+        assert!(matches!(first.await, Err(TxManagerError::AlreadyReserved)));
+        assert_eq!(manager.pending_count(), 0, "rejected submission must not queue");
+
+        let second = manager.send_async(TxManagerFixture::candidate(inbox)).await;
+        assert!(matches!(second.await, Err(TxManagerError::AlreadyReserved)));
+
+        let _third = manager.send_async(TxManagerFixture::candidate(inbox)).await;
+        assert_eq!(manager.pending_count(), 1, "third submission must queue normally");
+    }
+
+    #[tokio::test]
+    async fn cancel_tx_records_invocations() {
+        let inbox = Address::repeat_byte(0x42);
+        let manager = L1MinerTxManager::new(TxManagerFixture::signer(), inbox, 1);
+
+        assert_eq!(manager.cancellation_count(), 0);
+        manager.cancel_tx().await.expect("cancel_tx never fails in the harness");
+        manager.cancel_tx().await.expect("cancel_tx never fails in the harness");
+        assert_eq!(manager.cancellation_count(), 2);
     }
 }

--- a/actions/harness/src/common/block_hash_registry.rs
+++ b/actions/harness/src/common/block_hash_registry.rs
@@ -5,66 +5,107 @@ use std::{
 
 use alloy_primitives::B256;
 
-/// Underlying map type for [`SharedBlockHashRegistry`]: block number -> (hash, optional state root).
-pub type BlockHashInner = Arc<Mutex<HashMap<u64, (B256, Option<B256>)>>>;
+/// Whether a registered L2 block carries a state root the executor must verify.
+///
+/// Replaces an earlier `Option<B256>` so the two cases are named rather than
+/// inferred from `Some`/`None`:
+///
+/// - [`Verify`](StateRootExpectation::Verify) — the entry was produced by real
+///   EVM execution (via [`L2Sequencer`] or
+///   [`TestRollupNode::act_l2_unsafe_gossip_receive`]). When the verifier
+///   applies a derived block at this number, the computed state root **must**
+///   equal the stored root or the executor panics.
+/// - [`Synthetic`](StateRootExpectation::Synthetic) — the entry was registered
+///   without real execution (via [`TestRollupNode::register_block_hash`]).
+///   State-root validation is intentionally skipped for these blocks.
+///
+/// [`L2Sequencer`]: crate::L2Sequencer
+/// [`TestRollupNode::act_l2_unsafe_gossip_receive`]: crate::TestRollupNode::act_l2_unsafe_gossip_receive
+/// [`TestRollupNode::register_block_hash`]: crate::TestRollupNode::register_block_hash
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StateRootExpectation {
+    /// Verify the derived block's state root against this value.
+    Verify(B256),
+    /// Skip state-root validation for this block.
+    Synthetic,
+}
 
-/// Shared L2 block hashes and state roots keyed by block number.
+/// Underlying map type for [`SharedBlockHashRegistry`]: block number -> (hash, expectation).
+pub type BlockHashInner = Arc<Mutex<HashMap<u64, (B256, StateRootExpectation)>>>;
+
+/// Shared L2 block hashes and state-root expectations keyed by block number.
 ///
 /// `L2Sequencer` writes into this registry as blocks are built, and
 /// `TestRollupNode` reads from the same registry when it applies derived
 /// attributes so the resulting safe-head hash chain matches the sequencer's
-/// sealed headers. The [`ActionEngineClient`] reads the stored state root for
-/// post-derivation execution validation.
+/// sealed headers. The [`ActionEngineClient`] reads the stored
+/// [`StateRootExpectation`] for post-derivation execution validation.
 ///
-/// The state root field is `Option<B256>`: it is `Some` only when the entry
-/// was produced by real EVM execution (e.g. via [`L2Sequencer`] or
-/// [`TestRollupNode::act_l2_unsafe_gossip_receive`]). Entries created with
-/// [`TestRollupNode::register_block_hash`] store `None`, which causes the
-/// executor to skip state-root validation for that block rather than panic
-/// against a bogus sentinel value.
+/// The registry also counts how many blocks have been state-root **verified**
+/// (a [`StateRootExpectation::Verify`] entry that the executor actually compared
+/// and matched). Tests can assert on [`verified_count`] to prove that real
+/// state-root validation ran rather than being silently skipped because the
+/// registry happened to be empty for those blocks.
 ///
 /// [`ActionEngineClient`]: crate::ActionEngineClient
-/// [`L2Sequencer`]: crate::L2Sequencer
-/// [`TestRollupNode`]: crate::TestRollupNode
-/// [`TestRollupNode::act_l2_unsafe_gossip_receive`]: crate::TestRollupNode::act_l2_unsafe_gossip_receive
-/// [`TestRollupNode::register_block_hash`]: crate::TestRollupNode::register_block_hash
+/// [`verified_count`]: SharedBlockHashRegistry::verified_count
 #[derive(Debug, Clone, Default)]
-pub struct SharedBlockHashRegistry(BlockHashInner);
+pub struct SharedBlockHashRegistry {
+    /// Block number -> (block hash, state-root expectation).
+    entries: BlockHashInner,
+    /// Number of blocks whose `Verify` state root the executor compared and matched.
+    verified: Arc<Mutex<usize>>,
+}
 
 impl SharedBlockHashRegistry {
     /// Create an empty shared registry.
     pub fn new() -> Self {
-        Self(Arc::new(Mutex::new(HashMap::new())))
+        Self { entries: Arc::new(Mutex::new(HashMap::new())), verified: Arc::new(Mutex::new(0)) }
     }
 
-    /// Record the block hash and optional state root for an L2 block number.
+    /// Record the block hash and state-root expectation for an L2 block number.
     ///
-    /// Pass `Some(state_root)` when the block was produced by real EVM
-    /// execution so that the engine client can validate it.
-    /// Pass `None` for synthetic blocks (e.g. via
-    /// [`TestRollupNode::register_block_hash`]); the executor will skip
-    /// state-root validation for those blocks.
+    /// Pass [`StateRootExpectation::Verify`] when the block was produced by real
+    /// EVM execution so the engine client validates it; pass
+    /// [`StateRootExpectation::Synthetic`] for blocks registered without
+    /// execution (e.g. via [`TestRollupNode::register_block_hash`]), for which
+    /// the executor skips state-root validation.
     ///
     /// [`TestRollupNode::register_block_hash`]: crate::TestRollupNode::register_block_hash
-    pub fn insert(&self, number: u64, hash: B256, state_root: Option<B256>) {
-        self.0
+    pub fn insert(&self, number: u64, hash: B256, expectation: StateRootExpectation) {
+        self.entries
             .lock()
             .expect("block hash registry lock poisoned")
-            .insert(number, (hash, state_root));
+            .insert(number, (hash, expectation));
     }
 
     /// Return the registered block hash for an L2 block number.
     pub fn get(&self, number: u64) -> Option<B256> {
-        self.0.lock().expect("block hash registry lock poisoned").get(&number).map(|(h, _)| *h)
+        self.entries.lock().expect("block hash registry lock poisoned").get(&number).map(|(h, _)| *h)
     }
 
-    /// Return the registered state root for an L2 block number, if any.
+    /// Return the registered [`StateRootExpectation`] for an L2 block number.
     ///
-    /// Returns `None` when the block was not registered or was registered
-    /// without a state root (e.g. via [`TestRollupNode::register_block_hash`]).
-    ///
-    /// [`TestRollupNode::register_block_hash`]: crate::TestRollupNode::register_block_hash
-    pub fn get_state_root(&self, number: u64) -> Option<B256> {
-        self.0.lock().expect("block hash registry lock poisoned").get(&number).and_then(|(_, s)| *s)
+    /// Returns `None` when the block was never registered (e.g. a deposit-only
+    /// block generated during derivation that the sequencer did not build), in
+    /// which case there is no reference root to compare against.
+    pub fn state_root_expectation(&self, number: u64) -> Option<StateRootExpectation> {
+        self.entries
+            .lock()
+            .expect("block hash registry lock poisoned")
+            .get(&number)
+            .map(|(_, s)| *s)
+    }
+
+    /// Record that the executor compared and matched a [`StateRootExpectation::Verify`]
+    /// state root for one block.
+    pub fn record_verified(&self) {
+        *self.verified.lock().expect("block hash registry lock poisoned") += 1;
+    }
+
+    /// Return the number of blocks whose `Verify` state root the executor has
+    /// compared and matched so far.
+    pub fn verified_count(&self) -> usize {
+        *self.verified.lock().expect("block hash registry lock poisoned")
     }
 }

--- a/actions/harness/src/common/mod.rs
+++ b/actions/harness/src/common/mod.rs
@@ -4,7 +4,7 @@ mod account;
 pub use account::{TEST_ACCOUNT_ADDRESS, TEST_ACCOUNT_KEY, TestAccount};
 
 mod block_hash_registry;
-pub use block_hash_registry::{BlockHashInner, SharedBlockHashRegistry};
+pub use block_hash_registry::{BlockHashInner, SharedBlockHashRegistry, StateRootExpectation};
 
 mod l2_source;
 pub use l2_source::ActionL2Source;

--- a/actions/harness/src/engine.rs
+++ b/actions/harness/src/engine.rs
@@ -57,7 +57,7 @@ use reth_provider::{
 use reth_revm::{cached::CachedReads, cancelled::CancelOnDrop};
 use reth_transaction_pool::noop::NoopTransactionPool;
 
-use crate::{SharedBlockHashRegistry, SharedL1Chain};
+use crate::{SharedBlockHashRegistry, SharedL1Chain, StateRootExpectation};
 
 /// Type alias for the node type adapter used in tests.
 pub type TestNodeTypes = NodeTypesWithDBAdapter<BaseNode, Arc<TempDatabase<DatabaseEnv>>>;
@@ -454,14 +454,21 @@ impl ActionEngineClient {
             inner.executed_receipts.insert(block_number, receipts);
         }
 
-        if let Some(expected_root) = registry.get_state_root(block_number) {
-            assert_eq!(
-                state_root, expected_root,
-                "state root mismatch at block {block_number}: computed={state_root}, expected={expected_root}",
-            );
+        match registry.state_root_expectation(block_number) {
+            Some(StateRootExpectation::Verify(expected_root)) => {
+                assert_eq!(
+                    state_root, expected_root,
+                    "state root mismatch at block {block_number}: computed={state_root}, expected={expected_root}",
+                );
+                registry.record_verified();
+            }
+            // Synthetic blocks (registered without real execution) and blocks
+            // with no reference entry (e.g. deposit-only blocks generated during
+            // derivation) have no root to compare against.
+            Some(StateRootExpectation::Synthetic) | None => {}
         }
 
-        registry.insert(block_number, block_hash, Some(state_root));
+        registry.insert(block_number, block_hash, StateRootExpectation::Verify(state_root));
 
         let l2_info =
             L2BlockInfo::from_block_and_genesis(&block, &rollup_config.genesis).map_err(|e| {

--- a/actions/harness/src/lib.rs
+++ b/actions/harness/src/lib.rs
@@ -11,8 +11,8 @@ pub use conductor::{ConductorState, TestConductor, TestConductorHandle};
 
 mod common;
 pub use common::{
-    ActionL2Source, BlockHashInner, SharedBlockHashRegistry, TEST_ACCOUNT_ADDRESS,
-    TEST_ACCOUNT_KEY, TestAccount,
+    ActionL2Source, BlockHashInner, SharedBlockHashRegistry, StateRootExpectation,
+    TEST_ACCOUNT_ADDRESS, TEST_ACCOUNT_KEY, TestAccount,
 };
 
 mod l1;

--- a/actions/harness/src/node.rs
+++ b/actions/harness/src/node.rs
@@ -331,7 +331,41 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> TestRollupNode<P> {
     ///
     /// [`create_test_rollup_node`]: crate::ActionTestHarness::create_test_rollup_node
     pub fn register_block_hash(&mut self, number: u64, hash: B256) {
-        self.engine.block_hash_registry().insert(number, hash, None);
+        self.engine.block_hash_registry().insert(
+            number,
+            hash,
+            crate::StateRootExpectation::Synthetic,
+        );
+    }
+
+    /// Returns the number of executed blocks whose
+    /// [`Verify`](crate::StateRootExpectation::Verify) state root the engine has
+    /// compared and matched.
+    ///
+    /// For a node created via [`create_test_rollup_node_from_sequencer`], this is
+    /// the count of derived blocks whose state root the verifier checked against
+    /// the sequencer's sealed header. Use it (or
+    /// [`assert_state_roots_verified`]) to prove real state-root validation ran
+    /// rather than being silently skipped for want of a reference entry.
+    ///
+    /// [`create_test_rollup_node_from_sequencer`]: crate::ActionTestHarness::create_test_rollup_node_from_sequencer
+    /// [`assert_state_roots_verified`]: TestRollupNode::assert_state_roots_verified
+    pub fn state_roots_verified(&self) -> usize {
+        self.engine.block_hash_registry().verified_count()
+    }
+
+    /// Assert that exactly `expected` executed blocks have had their state roots
+    /// verified against the reference (sequencer-produced) roots.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the verified count does not equal `expected`.
+    pub fn assert_state_roots_verified(&self, expected: usize) {
+        let actual = self.state_roots_verified();
+        assert_eq!(
+            actual, expected,
+            "expected {expected} state-root verifications, got {actual}",
+        );
     }
 
     /// Record the L1 safe head number. Does not drive additional pipeline steps.
@@ -415,7 +449,7 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> TestRollupNode<P> {
         self.engine.block_hash_registry().insert(
             block.header.number,
             hash,
-            Some(block.header.state_root),
+            crate::StateRootExpectation::Verify(block.header.state_root),
         );
         let l1_origin = self.l1_origin_from_block(block).unwrap_or_else(|| {
             panic!(

--- a/actions/harness/tests/batcher/main.rs
+++ b/actions/harness/tests/batcher/main.rs
@@ -7,4 +7,5 @@ mod production_da;
 mod sequencer_drift;
 mod submission;
 mod submission_failure;
+mod txpool_blocked;
 mod upgrade_transitions;

--- a/actions/harness/tests/batcher/txpool_blocked.rs
+++ b/actions/harness/tests/batcher/txpool_blocked.rs
@@ -1,0 +1,132 @@
+//! Action tests for batcher recovery when the L1 txpool nonce slot is blocked.
+//!
+//! These tests verify the end-to-end production recovery path:
+//!   sequencer → batcher (txpool blocked) → requeue + `cancel_tx` → derivation
+//!
+//! When [`TxManager::send_async`] rejects a submission with
+//! [`TxManagerError::AlreadyReserved`], the [`BatchDriver`] classifies the
+//! outcome as [`TxOutcome::TxpoolBlocked`]: it requeues the frames, stops
+//! submitting new ones, and calls [`TxManager::cancel_tx`] on its next loop
+//! iteration to clear the stuck slot before resubmitting. This is a distinct
+//! driver code path from a plain submission failure (see `submission_failure.rs`),
+//! and it exercises the `cancel_tx` hook that the harness previously left as the
+//! trait's default no-op.
+//!
+//! [`TxManager::send_async`]: base_tx_manager::TxManager::send_async
+//! [`TxManager::cancel_tx`]: base_tx_manager::TxManager::cancel_tx
+//! [`TxManagerError::AlreadyReserved`]: base_tx_manager::TxManagerError::AlreadyReserved
+//! [`BatchDriver`]: base_batcher_core::BatchDriver
+//! [`TxOutcome::TxpoolBlocked`]: base_batcher_core::TxOutcome::TxpoolBlocked
+
+use base_action_harness::{
+    ActionL2Source, ActionTestHarness, Batcher, BatcherConfig, L1MinerConfig, SharedL1Chain,
+    TestRollupConfigBuilder,
+};
+use base_batcher_encoder::{DaType, EncoderConfig};
+
+fn calldata_batcher_config() -> BatcherConfig {
+    BatcherConfig {
+        encoder: EncoderConfig { da_type: DaType::Calldata, ..EncoderConfig::default() },
+        ..BatcherConfig::default()
+    }
+}
+
+/// When the first submission hits a reserved nonce slot, the [`BatchDriver`]
+/// requeues the frame, clears the blockage via [`TxManager::cancel_tx`], and the
+/// derivation node successfully derives the L2 block after recovery.
+///
+/// [`BatchDriver`]: base_batcher_core::BatchDriver
+/// [`TxManager::cancel_tx`]: base_tx_manager::TxManager::cancel_tx
+#[tokio::test]
+async fn txpool_blocked_recovers_via_cancel_tx_and_derives() {
+    let batcher_cfg = calldata_batcher_config();
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+    let block = sequencer.build_next_block_with_single_transaction().await;
+
+    let (mut node, chain) = h.create_test_rollup_node_from_sequencer(
+        &mut sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
+
+    let mut source = ActionL2Source::new();
+    source.push(block);
+    let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg);
+
+    // Block the first submission so the driver must recover the txpool slot
+    // before it can resubmit the requeued frame.
+    batcher.block_next_n_submissions(1);
+    batcher.encode_only().await;
+
+    // Driver path: TxpoolBlocked receipt → requeue → recover_txpool → cancel_tx
+    // → resubmit. The frame returns to pending only after the blockage clears.
+    batcher.wait_until_requeued(1).await;
+
+    assert_eq!(
+        batcher.cancellation_count(),
+        1,
+        "driver must clear the txpool blockage via exactly one cancel_tx"
+    );
+
+    // Mine the successfully resubmitted frame into an L1 block.
+    let block_num = batcher.mine_pending(&mut h.l1).await;
+    chain.push(h.l1.tip().clone());
+
+    node.initialize().await;
+    let derived = node.run_until_idle().await;
+
+    assert_eq!(derived, 1, "frame must derive one L2 block after txpool recovery");
+    assert_eq!(node.l2_safe_number(), 1, "safe head must reach 1 after recovery");
+    assert!(block_num >= 1, "resubmitted frame was mined into an L1 block");
+}
+
+/// With two consecutive txpool blockages, the driver recovers twice via
+/// [`TxManager::cancel_tx`] before the third submission succeeds. No data is
+/// lost: the derivation node still sees the correct L2 block.
+///
+/// [`TxManager::cancel_tx`]: base_tx_manager::TxManager::cancel_tx
+#[tokio::test]
+async fn consecutive_txpool_blocks_recover_and_derive() {
+    let batcher_cfg = calldata_batcher_config();
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+    let block = sequencer.build_next_block_with_single_transaction().await;
+
+    let (mut node, chain) = h.create_test_rollup_node_from_sequencer(
+        &mut sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
+
+    let mut source = ActionL2Source::new();
+    source.push(block);
+    let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg);
+
+    // Block the next two submissions; the driver must recover after each before
+    // the third submission queues successfully.
+    batcher.block_next_n_submissions(2);
+    batcher.encode_only().await;
+
+    batcher.wait_until_requeued(1).await;
+
+    assert_eq!(
+        batcher.cancellation_count(),
+        2,
+        "driver must clear two consecutive txpool blockages via cancel_tx"
+    );
+
+    let block_num = batcher.mine_pending(&mut h.l1).await;
+    chain.push(h.l1.tip().clone());
+
+    node.initialize().await;
+    let derived = node.run_until_idle().await;
+
+    assert_eq!(derived, 1, "frame must survive two blockages and derive one L2 block");
+    assert_eq!(node.l2_safe_number(), 1, "safe head must reach 1 after two recoveries");
+    assert!(block_num >= 1, "frame was eventually mined into an L1 block");
+}

--- a/actions/harness/tests/derivation/node.rs
+++ b/actions/harness/tests/derivation/node.rs
@@ -57,6 +57,9 @@ async fn test_rollup_node_derives_batched_blocks() {
         L2_BLOCK_COUNT,
         "safe head should be at block {L2_BLOCK_COUNT}"
     );
+    // Prove state-root validation actually ran for every derived block rather
+    // than being silently skipped for want of a reference root.
+    node.assert_state_roots_verified(L2_BLOCK_COUNT as usize);
 }
 
 /// P2P gossip advances `unsafe_head` before batches land on L1; derivation
@@ -117,6 +120,8 @@ async fn test_rollup_node_gossip_then_derivation() {
         node.l2_safe_number(),
         "unsafe_head and safe_head should be equal after safe chain caught up"
     );
+    // Every derived block had its state root verified against the sequencer's.
+    node.assert_state_roots_verified(L2_BLOCK_COUNT as usize);
 }
 
 /// Out-of-order gossip blocks are silently dropped; only sequential blocks


### PR DESCRIPTION
## Summary

Stacked on #4060. Tightens the action-harness state-root check I flagged as conditional. The block-hash registry previously stored an `Option<B256>` state root, so the executor only asserted when a value happened to be present and silently passed otherwise. This replaces it with a named `StateRootExpectation` (`Verify`/`Synthetic`): the executor hard-fails on a `Verify` mismatch, records each block it actually verified, and `TestRollupNode::assert_state_roots_verified` lets a test prove verification ran rather than being skipped for want of a reference root. The two `derivation/node.rs` tests now assert every derived block was state-root verified.

It also retires the harness README productionization roadmap now that its actionable items are done: implemented work is reflected in the Production Boundary Map, and the two permanent gaps (opt-in external L1, and full service/network coverage which stays in Docker system tests) move to Known Production Gaps. All 219 harness tests pass and clippy is clean.