### PR TITLE
feat(consensus): buffer shadow sequencer P2P payloads

### DIFF
--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -219,6 +219,10 @@ where
             )
             .await?;
 
+        if self.is_shadow_sequencer() {
+            self.clear_shadow_payload_buffer();
+        }
+
         self.checkpoint_forkchoice_state_if_updated().await;
 
         // Signal the derivation actor to reset.
@@ -337,6 +341,9 @@ where
         }
 
         self.checkpoint_forkchoice_state_if_updated().await;
+        if self.is_shadow_sequencer() {
+            self.prune_shadow_payloads();
+        }
         self.send_derivation_actor_safe_head_if_updated().await?;
 
         if !self.el_sync_complete && self.engine.state().el_sync_finished {
@@ -479,6 +486,16 @@ where
             "Buffered shadow reconciliation payload"
         );
         self.shadow_payloads.insert(block_number, envelope);
+    }
+
+    fn prune_shadow_payloads(&mut self) {
+        let safe_head_number = self.engine.state().sync_state.safe_head().block_info.number;
+        self.shadow_payloads.retain(|block_number, _| *block_number > safe_head_number);
+    }
+
+    fn clear_shadow_payload_buffer(&mut self) {
+        self.shadow_payloads.clear();
+        self.shadow_payload_buffer_faulted = false;
     }
 
     /// Handles an unsafe payload supplied through the admin API.
@@ -1384,6 +1401,50 @@ mod tests {
         assert!(processor.shadow_payload_buffer_faulted);
         assert_eq!(processor.shadow_payloads.len(), EngineProcessorOptions::MAX_SHADOW_PAYLOADS);
         assert!(processor.shadow_payloads.contains_key(&1));
+    }
+
+    #[test]
+    fn shadow_payload_pruning_discards_payloads_at_or_below_safe_head() {
+        let (mut processor, queue_rx) = unsafe_payload_processor(
+            NodeMode::Sequencer,
+            true,
+            l2_head(11, B256::with_last_byte(11)),
+            Some(l2_head(10, B256::with_last_byte(10))),
+        );
+        processor.shadow_sequencer = true;
+
+        for block_number in 9..=11 {
+            processor.buffer_shadow_payload(unsafe_payload(
+                block_number,
+                B256::ZERO,
+                B256::with_last_byte(block_number as u8),
+            ));
+        }
+        processor.prune_shadow_payloads();
+
+        assert_eq!(*queue_rx.borrow(), 0);
+        assert_eq!(processor.shadow_payloads.keys().copied().collect::<Vec<_>>(), vec![11]);
+    }
+
+    #[test]
+    fn clearing_shadow_payload_buffer_removes_payloads_and_fault() {
+        let (mut processor, queue_rx) = unsafe_payload_processor(
+            NodeMode::Sequencer,
+            true,
+            l2_head(10, B256::with_last_byte(10)),
+            None,
+        );
+        processor.shadow_sequencer = true;
+        processor
+            .shadow_payloads
+            .insert(11, unsafe_payload(11, B256::with_last_byte(10), B256::with_last_byte(11)));
+        processor.shadow_payload_buffer_faulted = true;
+
+        processor.clear_shadow_payload_buffer();
+
+        assert_eq!(*queue_rx.borrow(), 0);
+        assert!(processor.shadow_payloads.is_empty());
+        assert!(!processor.shadow_payload_buffer_faulted);
     }
 
     /// Verifies that when a standalone sequencer (no conductor) is beyond genesis and reth

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -1,4 +1,4 @@
-use std::{fmt, sync::Arc};
+use std::{collections::BTreeMap, fmt, sync::Arc};
 
 use alloy_eips::BlockNumberOrTag;
 use base_common_genesis::RollupConfig;
@@ -59,6 +59,8 @@ pub struct EngineProcessorOptions {
     pub conductor: Option<Arc<dyn Conductor>>,
     /// Whether the sequencer starts in a stopped state.
     pub sequencer_stopped: bool,
+    /// Whether the sequencer privately builds blocks and reconciles from P2P payloads.
+    pub shadow_sequencer: bool,
 }
 
 impl EngineProcessorOptions {
@@ -67,6 +69,9 @@ impl EngineProcessorOptions {
     /// Larger gaps are treated as deep CL/EL sync and are left to derivation/EL sync rather than
     /// admitting far-future live gossip into reth.
     pub const MAX_SEQUENCER_EXTERNAL_UNSAFE_GAP: u64 = 300;
+
+    /// Maximum number of active-sequencer payloads retained for shadow reconciliation.
+    pub const MAX_SHADOW_PAYLOADS: usize = 300;
 }
 
 impl fmt::Debug for EngineProcessorOptions {
@@ -76,6 +81,7 @@ impl fmt::Debug for EngineProcessorOptions {
             .field("has_unsafe_head_tx", &self.unsafe_head_tx.is_some())
             .field("has_conductor", &self.conductor.is_some())
             .field("sequencer_stopped", &self.sequencer_stopped)
+            .field("shadow_sequencer", &self.shadow_sequencer)
             .finish()
     }
 }
@@ -100,6 +106,12 @@ where
     /// like a [`BootstrapRole::ConductorFollower`] so it does not issue an active-sequencer
     /// forkchoice update before being explicitly started.
     sequencer_stopped: bool,
+    /// Whether the sequencer privately builds blocks and reconciles from P2P payloads.
+    shadow_sequencer: bool,
+    /// Active-sequencer payloads received from authenticated P2P gossip, keyed by block number.
+    shadow_payloads: BTreeMap<u64, BaseExecutionPayloadEnvelope>,
+    /// Whether a conflicting payload or buffer overflow has made reconciliation unsafe.
+    shadow_payload_buffer_faulted: bool,
     /// The configured node mode.
     node_mode: NodeMode,
     /// The last safe head update sent.
@@ -182,8 +194,16 @@ where
             node_mode: options.node_mode,
             rollup: config,
             sequencer_stopped: options.sequencer_stopped,
+            shadow_sequencer: options.shadow_sequencer,
+            shadow_payloads: BTreeMap::new(),
+            shadow_payload_buffer_faulted: false,
             unsafe_head_tx: options.unsafe_head_tx,
         }
+    }
+
+    /// Returns whether this processor belongs to a shadow sequencer.
+    pub const fn is_shadow_sequencer(&self) -> bool {
+        self.shadow_sequencer
     }
 
     /// Resets the inner [`Engine`] and propagates the reset to the derivation actor.
@@ -352,6 +372,11 @@ where
 
     fn handle_external_unsafe_l2_block(&mut self, envelope: BaseExecutionPayloadEnvelope) {
         let block_number = envelope.execution_payload.block_number();
+        if self.is_shadow_sequencer() {
+            self.buffer_shadow_payload(envelope);
+            return;
+        }
+
         let sync_state = self.engine.state().sync_state;
         let unsafe_head = sync_state.unsafe_head();
 
@@ -395,6 +420,80 @@ where
             unsafe_head_hash = %unsafe_head.block_info.hash,
             "Sequencer dropped external unsafe payload outside gap limit"
         );
+    }
+
+    /// Buffers an authenticated active-sequencer payload for later shadow reconciliation.
+    pub fn buffer_shadow_payload(&mut self, envelope: BaseExecutionPayloadEnvelope) {
+        let block_number = envelope.execution_payload.block_number();
+        let block_hash = envelope.execution_payload.block_hash();
+
+        if self.shadow_payload_buffer_faulted {
+            warn!(
+                target: "engine",
+                block_number,
+                %block_hash,
+                "Ignoring shadow reconciliation payload after buffer fault"
+            );
+            return;
+        }
+
+        if let Some(buffered) = self.shadow_payloads.get(&block_number) {
+            let buffered_hash = buffered.execution_payload.block_hash();
+            if buffered_hash == block_hash {
+                debug!(
+                    target: "engine",
+                    block_number,
+                    %block_hash,
+                    "Ignoring duplicate shadow reconciliation payload"
+                );
+                return;
+            }
+
+            self.shadow_payload_buffer_faulted = true;
+            error!(
+                target: "engine",
+                block_number,
+                %block_hash,
+                %buffered_hash,
+                "Conflicting shadow reconciliation payloads received"
+            );
+            return;
+        }
+
+        if self.shadow_payloads.len() >= EngineProcessorOptions::MAX_SHADOW_PAYLOADS {
+            self.shadow_payload_buffer_faulted = true;
+            error!(
+                target: "engine",
+                block_number,
+                %block_hash,
+                max_shadow_payloads = EngineProcessorOptions::MAX_SHADOW_PAYLOADS,
+                "Shadow reconciliation payload buffer is full"
+            );
+            return;
+        }
+
+        debug!(
+            target: "engine",
+            block_number,
+            %block_hash,
+            "Buffered shadow reconciliation payload"
+        );
+        self.shadow_payloads.insert(block_number, envelope);
+    }
+
+    /// Handles an unsafe payload supplied through the admin API.
+    pub fn handle_admin_unsafe_l2_block(&mut self, envelope: BaseExecutionPayloadEnvelope) {
+        if self.is_shadow_sequencer() {
+            warn!(
+                target: "engine",
+                block_number = envelope.execution_payload.block_number(),
+                block_hash = %envelope.execution_payload.block_hash(),
+                "Ignoring admin unsafe payload on shadow sequencer"
+            );
+            return;
+        }
+
+        self.handle_external_unsafe_l2_block(envelope);
     }
 
     fn handle_local_unsafe_l2_block(
@@ -818,6 +917,9 @@ where
                     EngineActorRequest::ProcessUnsafeL2BlockRequest(envelope) => {
                         self.handle_external_unsafe_l2_block(*envelope);
                     }
+                    EngineActorRequest::ProcessAdminUnsafeL2BlockRequest(envelope) => {
+                        self.handle_admin_unsafe_l2_block(*envelope);
+                    }
                     EngineActorRequest::ProcessLocalUnsafeL2BlockRequest(envelope) => {
                         let InsertUnsafePayloadRequest { envelope, result_tx, otel_cx } = *envelope;
                         // Attach for the synchronous enqueue call only — no await, no Send issue.
@@ -1028,6 +1130,7 @@ mod tests {
                     unsafe_head_tx,
                     conductor: None,
                     sequencer_stopped: false,
+                    shadow_sequencer: false,
                 },
             ),
             queue_rx,
@@ -1163,6 +1266,126 @@ mod tests {
         assert_eq!(*queue_rx.borrow(), expected_queue_len);
     }
 
+    #[test]
+    fn shadow_sequencer_buffers_external_payloads_without_enqueuing() {
+        let (mut processor, queue_rx) = unsafe_payload_processor(
+            NodeMode::Sequencer,
+            true,
+            l2_head(10, B256::with_last_byte(10)),
+            None,
+        );
+        processor.shadow_sequencer = true;
+
+        let later = unsafe_payload(12, B256::with_last_byte(11), B256::with_last_byte(12));
+        let earlier = unsafe_payload(11, B256::with_last_byte(10), B256::with_last_byte(11));
+        processor.handle_external_unsafe_l2_block(later);
+        processor.handle_external_unsafe_l2_block(earlier.clone());
+        processor.handle_external_unsafe_l2_block(earlier);
+
+        assert_eq!(*queue_rx.borrow(), 0);
+        assert_eq!(processor.shadow_payloads.len(), 2);
+        assert_eq!(processor.shadow_payloads.keys().copied().collect::<Vec<_>>(), vec![11, 12]);
+        assert!(!processor.shadow_payload_buffer_faulted);
+    }
+
+    #[test]
+    fn shadow_sequencer_rejects_admin_payloads() {
+        let (mut processor, queue_rx) = unsafe_payload_processor(
+            NodeMode::Sequencer,
+            true,
+            l2_head(10, B256::with_last_byte(10)),
+            None,
+        );
+        processor.shadow_sequencer = true;
+
+        processor.handle_admin_unsafe_l2_block(unsafe_payload(
+            11,
+            B256::with_last_byte(10),
+            B256::with_last_byte(11),
+        ));
+
+        assert_eq!(*queue_rx.borrow(), 0);
+        assert!(processor.shadow_payloads.is_empty());
+        assert!(!processor.shadow_payload_buffer_faulted);
+    }
+
+    #[test]
+    fn normal_sequencer_preserves_admin_payload_insertion() {
+        let (mut processor, queue_rx) = unsafe_payload_processor(
+            NodeMode::Sequencer,
+            true,
+            l2_head(10, B256::with_last_byte(10)),
+            None,
+        );
+
+        processor.handle_admin_unsafe_l2_block(unsafe_payload(
+            11,
+            B256::with_last_byte(10),
+            B256::with_last_byte(11),
+        ));
+
+        assert_eq!(*queue_rx.borrow(), 1);
+        assert!(processor.shadow_payloads.is_empty());
+    }
+
+    #[test]
+    fn shadow_payload_conflict_faults_buffer_and_preserves_first_payload() {
+        let (mut processor, queue_rx) = unsafe_payload_processor(
+            NodeMode::Sequencer,
+            true,
+            l2_head(10, B256::with_last_byte(10)),
+            None,
+        );
+        processor.shadow_sequencer = true;
+
+        let first_hash = B256::with_last_byte(11);
+        processor.handle_external_unsafe_l2_block(unsafe_payload(
+            11,
+            B256::with_last_byte(10),
+            first_hash,
+        ));
+        processor.handle_external_unsafe_l2_block(unsafe_payload(
+            11,
+            B256::with_last_byte(10),
+            B256::with_last_byte(12),
+        ));
+        processor.handle_external_unsafe_l2_block(unsafe_payload(
+            12,
+            first_hash,
+            B256::with_last_byte(13),
+        ));
+
+        assert_eq!(*queue_rx.borrow(), 0);
+        assert!(processor.shadow_payload_buffer_faulted);
+        assert_eq!(processor.shadow_payloads.len(), 1);
+        assert_eq!(processor.shadow_payloads[&11].execution_payload.block_hash(), first_hash);
+    }
+
+    #[test]
+    fn shadow_payload_overflow_faults_buffer_without_eviction() {
+        let (mut processor, queue_rx) =
+            unsafe_payload_processor(NodeMode::Sequencer, true, l2_head(0, B256::ZERO), None);
+        processor.shadow_sequencer = true;
+
+        for block_number in 1..=EngineProcessorOptions::MAX_SHADOW_PAYLOADS as u64 {
+            processor.handle_external_unsafe_l2_block(unsafe_payload(
+                block_number,
+                B256::ZERO,
+                B256::with_last_byte(block_number as u8),
+            ));
+        }
+        processor.handle_external_unsafe_l2_block(unsafe_payload(
+            EngineProcessorOptions::MAX_SHADOW_PAYLOADS as u64 + 1,
+            B256::ZERO,
+            B256::with_last_byte(1),
+        ));
+
+        assert_eq!(*queue_rx.borrow(), 0);
+        assert!(processor.shadow_payload_buffer_faulted);
+        assert_eq!(processor.shadow_payloads.len(), EngineProcessorOptions::MAX_SHADOW_PAYLOADS);
+        assert!(processor.shadow_payloads.contains_key(&1));
+    }
+
     /// Verifies that when a standalone sequencer (no conductor) is beyond genesis and reth
     /// responds Valid to the bootstrap FCU probe, `el_sync_finished` is set immediately so
     /// that `schedule_initial_reset` is not permanently blocked by the `ELSyncing` guard.
@@ -1209,6 +1432,7 @@ mod tests {
                 unsafe_head_tx: Some(unsafe_head_tx),
                 conductor: None,
                 sequencer_stopped: false,
+                shadow_sequencer: false,
             },
         );
 
@@ -1275,6 +1499,7 @@ mod tests {
                 unsafe_head_tx: Some(unsafe_head_tx),
                 conductor: None,
                 sequencer_stopped: false,
+                shadow_sequencer: false,
             },
         );
 
@@ -1353,6 +1578,7 @@ mod tests {
                 unsafe_head_tx: Some(unsafe_head_tx),
                 conductor: Some(Arc::new(mock_conductor)),
                 sequencer_stopped: false,
+                shadow_sequencer: false,
             },
         );
 
@@ -1427,6 +1653,7 @@ mod tests {
                 unsafe_head_tx: None,
                 conductor: None,
                 sequencer_stopped: false,
+                shadow_sequencer: false,
             },
         );
 
@@ -1495,6 +1722,7 @@ mod tests {
                 unsafe_head_tx: None,
                 conductor: None,
                 sequencer_stopped: false,
+                shadow_sequencer: false,
             },
         );
 
@@ -1562,6 +1790,7 @@ mod tests {
                 unsafe_head_tx,
                 conductor,
                 sequencer_stopped,
+                shadow_sequencer: false,
             },
         )
     }
@@ -1718,6 +1947,7 @@ mod tests {
                 unsafe_head_tx: None,
                 conductor: None,
                 sequencer_stopped: false,
+                shadow_sequencer: false,
             },
         );
 
@@ -1910,6 +2140,7 @@ mod tests {
                 unsafe_head_tx: None,
                 conductor: None,
                 sequencer_stopped: false,
+                shadow_sequencer: false,
             },
             Arc::new(TestCheckpointReader { safe: Some(safe_checkpoint), finalized: None }),
             Arc::new(NoopCheckpointWriter),
@@ -1995,6 +2226,7 @@ mod tests {
                 unsafe_head_tx: None,
                 conductor: None,
                 sequencer_stopped: false,
+                shadow_sequencer: false,
             },
         );
 

--- a/crates/consensus/service/src/actors/engine/request.rs
+++ b/crates/consensus/service/src/actors/engine/request.rs
@@ -56,8 +56,10 @@ pub enum EngineActorRequest {
     ProcessSafeL2SignalRequest(ConsolidateInput),
     /// Request to finalize the L2 block at the provided block number.
     ProcessFinalizedL2BlockNumberRequest(Box<u64>),
-    /// Request to insert the provided external unsafe block.
+    /// Request to process an unsafe block authenticated by the P2P gossip layer.
     ProcessUnsafeL2BlockRequest(Box<BaseExecutionPayloadEnvelope>),
+    /// Request to insert an unsafe block supplied through the admin API.
+    ProcessAdminUnsafeL2BlockRequest(Box<BaseExecutionPayloadEnvelope>),
     /// Request to insert a locally produced sequencer unsafe block.
     ProcessLocalUnsafeL2BlockRequest(Box<InsertUnsafePayloadRequest>),
     /// Request to reset engine forkchoice.

--- a/crates/consensus/service/src/actors/network/actor.rs
+++ b/crates/consensus/service/src/actors/network/actor.rs
@@ -204,7 +204,7 @@ where
                     match query {
                         NetworkAdminQuery::PostUnsafePayload { payload } => {
                             debug!(target: "node::p2p", "Forwarding unsafe payload from admin api to engine");
-                            if self.engine_client.send_unsafe_block(*payload).await.is_err() {
+                            if self.engine_client.send_admin_unsafe_block(*payload).await.is_err() {
                                 warn!(target: "node::p2p", "Failed to forward admin api unsafe block to engine");
                             }
                         }

--- a/crates/consensus/service/src/actors/network/engine_client.rs
+++ b/crates/consensus/service/src/actors/network/engine_client.rs
@@ -10,9 +10,17 @@ use crate::{EngineActorRequest, EngineClientError, EngineClientResult};
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait NetworkEngineClient: Debug + Send + Sync {
+    /// Sends an unsafe block authenticated by the P2P gossip layer.
+    ///
     /// Note: a successful response does not mean the block was successfully inserted.
     /// This function just sends the message to the engine. It does not wait for a response.
     async fn send_unsafe_block(
+        &self,
+        block: BaseExecutionPayloadEnvelope,
+    ) -> EngineClientResult<()>;
+
+    /// Sends an unsafe block supplied through the admin API.
+    async fn send_admin_unsafe_block(
         &self,
         block: BaseExecutionPayloadEnvelope,
     ) -> EngineClientResult<()>;
@@ -37,5 +45,68 @@ impl NetworkEngineClient for QueuedNetworkEngineClient {
             .send(EngineActorRequest::ProcessUnsafeL2BlockRequest(Box::new(block)))
             .await
             .map_err(|_| EngineClientError::RequestError("request channel closed.".to_string()))?)
+    }
+
+    async fn send_admin_unsafe_block(
+        &self,
+        block: BaseExecutionPayloadEnvelope,
+    ) -> EngineClientResult<()> {
+        trace!(target: "network", ?block, "Sending admin unsafe block to engine.");
+        Ok(self
+            .engine_actor_request_tx
+            .send(EngineActorRequest::ProcessAdminUnsafeL2BlockRequest(Box::new(block)))
+            .await
+            .map_err(|_| EngineClientError::RequestError("request channel closed.".to_string()))?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, B256, Bloom, U256};
+    use alloy_rpc_types_engine::ExecutionPayloadV1;
+    use base_common_rpc_types_engine::{BaseExecutionPayload, BaseExecutionPayloadEnvelope};
+    use tokio::sync::mpsc;
+
+    use super::{NetworkEngineClient, QueuedNetworkEngineClient};
+    use crate::EngineActorRequest;
+
+    #[tokio::test]
+    async fn queued_client_preserves_unsafe_payload_provenance() {
+        let (engine_actor_request_tx, mut request_rx) = mpsc::channel(2);
+        let client = QueuedNetworkEngineClient { engine_actor_request_tx };
+        let payload = || BaseExecutionPayloadEnvelope {
+            execution_payload: BaseExecutionPayload::V1(ExecutionPayloadV1 {
+                parent_hash: B256::ZERO,
+                fee_recipient: Address::ZERO,
+                state_root: B256::ZERO,
+                receipts_root: B256::ZERO,
+                logs_bloom: Bloom::ZERO,
+                prev_randao: B256::ZERO,
+                block_number: 1,
+                gas_limit: 30_000_000,
+                gas_used: 0,
+                timestamp: 1,
+                extra_data: Default::default(),
+                base_fee_per_gas: U256::ZERO,
+                block_hash: B256::ZERO,
+                transactions: vec![],
+            }),
+            parent_beacon_block_root: None,
+        };
+
+        client
+            .send_unsafe_block(payload())
+            .await
+            .expect("authenticated P2P payload should be sent");
+        client.send_admin_unsafe_block(payload()).await.expect("admin payload should be sent");
+
+        assert!(matches!(
+            request_rx.recv().await,
+            Some(EngineActorRequest::ProcessUnsafeL2BlockRequest(_))
+        ));
+        assert!(matches!(
+            request_rx.recv().await,
+            Some(EngineActorRequest::ProcessAdminUnsafeL2BlockRequest(_))
+        ));
     }
 }

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -264,6 +264,8 @@ impl RollupNode {
                 unsafe_head_tx: if mode.is_sequencer() { Some(unsafe_head_tx) } else { None },
                 conductor,
                 sequencer_stopped: self.sequencer_config.sequencer_stopped,
+                shadow_sequencer: mode.is_sequencer()
+                    && self.sequencer_config.is_shadow_sequencer(),
             },
             checkpoint_reader,
             checkpoint_writer,

--- a/crates/consensus/service/tests/actors/network/mocks/builder.rs
+++ b/crates/consensus/service/tests/actors/network/mocks/builder.rs
@@ -19,7 +19,7 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::error;
 
-use crate::actors::network::TestNetwork;
+use crate::actors::network::{ForwardedUnsafeBlock, TestNetwork};
 
 pub(crate) struct TestNetworkBuilder {
     chain_id: u64,
@@ -114,7 +114,7 @@ impl TestNetworkBuilder {
 
 #[derive(Debug)]
 struct ForwardingNetworkEngineClient {
-    blocks_tx: mpsc::Sender<BaseExecutionPayloadEnvelope>,
+    blocks_tx: mpsc::Sender<ForwardedUnsafeBlock>,
 }
 
 #[async_trait]
@@ -125,7 +125,7 @@ impl NetworkEngineClient for ForwardingNetworkEngineClient {
     ) -> EngineClientResult<()> {
         let _ = self
             .blocks_tx
-            .send(block)
+            .send(ForwardedUnsafeBlock::P2p(block))
             .await
             .inspect_err(|e| error!(target: "net", error = ?e, "Failed to send block"));
         Ok(())
@@ -135,6 +135,11 @@ impl NetworkEngineClient for ForwardingNetworkEngineClient {
         &self,
         block: BaseExecutionPayloadEnvelope,
     ) -> EngineClientResult<()> {
-        self.send_unsafe_block(block).await
+        let _ = self
+            .blocks_tx
+            .send(ForwardedUnsafeBlock::Admin(block))
+            .await
+            .inspect_err(|e| error!(target: "net", error = ?e, "Failed to send admin block"));
+        Ok(())
     }
 }

--- a/crates/consensus/service/tests/actors/network/mocks/builder.rs
+++ b/crates/consensus/service/tests/actors/network/mocks/builder.rs
@@ -130,4 +130,11 @@ impl NetworkEngineClient for ForwardingNetworkEngineClient {
             .inspect_err(|e| error!(target: "net", error = ?e, "Failed to send block"));
         Ok(())
     }
+
+    async fn send_admin_unsafe_block(
+        &self,
+        block: BaseExecutionPayloadEnvelope,
+    ) -> EngineClientResult<()> {
+        self.send_unsafe_block(block).await
+    }
 }

--- a/crates/consensus/service/tests/actors/network/mocks/mod.rs
+++ b/crates/consensus/service/tests/actors/network/mocks/mod.rs
@@ -15,9 +15,14 @@ use tracing::info;
 
 pub(crate) mod builder;
 
+pub(super) enum ForwardedUnsafeBlock {
+    P2p(BaseExecutionPayloadEnvelope),
+    Admin(BaseExecutionPayloadEnvelope),
+}
+
 pub(crate) struct TestNetwork {
     pub(super) inbound_data: NetworkInboundData,
-    pub(super) blocks_rx: mpsc::Receiver<BaseExecutionPayloadEnvelope>,
+    pub(super) blocks_rx: mpsc::Receiver<ForwardedUnsafeBlock>,
     #[allow(dead_code)]
     handle: JoinHandle<Result<(), NetworkActorError>>,
 }

--- a/crates/consensus/service/tests/actors/network/mod.rs
+++ b/crates/consensus/service/tests/actors/network/mod.rs
@@ -1,6 +1,6 @@
 //! Integration tests for the network actor.
 
-use crate::actors::network::mocks::TestNetwork;
+use crate::actors::network::mocks::{ForwardedUnsafeBlock, TestNetwork};
 
 pub(super) mod mocks;
 

--- a/crates/consensus/service/tests/actors/network/sequencer.rs
+++ b/crates/consensus/service/tests/actors/network/sequencer.rs
@@ -1,6 +1,6 @@
 use crate::actors::{
     generator::{block_builder::PayloadVersion, seed::SEED_GENERATOR_BUILDER},
-    network::mocks::builder::TestNetworkBuilder,
+    network::mocks::{ForwardedUnsafeBlock, builder::TestNetworkBuilder},
 };
 
 /// Test that we can properly gossip blocks to the sequencer.
@@ -23,11 +23,17 @@ async fn test_sequencer_network_conn() -> anyhow::Result<()> {
 
     sequencer_network.inbound_data.gossip_payload_tx.send(envelope.clone()).await?;
 
-    let block = validator_network
+    let forwarded_block = validator_network
         .blocks_rx
         .recv()
         .await
         .ok_or_else(|| anyhow::anyhow!("No block received"))?;
+    let block = match forwarded_block {
+        ForwardedUnsafeBlock::P2p(block) => block,
+        ForwardedUnsafeBlock::Admin(block) => {
+            anyhow::bail!("P2P block was forwarded through the admin path: {block:?}")
+        }
+    };
 
     assert_eq!(block.parent_beacon_block_root, envelope.parent_beacon_block_root);
     assert_eq!(block.execution_payload, envelope.execution_payload);
@@ -71,8 +77,14 @@ async fn test_sequencer_network_propagation() -> anyhow::Result<()> {
 
     // Check that the block propagates to all networks.
     for network in &mut validator_networks {
-        let block =
+        let forwarded_block =
             network.blocks_rx.recv().await.ok_or_else(|| anyhow::anyhow!("No block received"))?;
+        let block = match forwarded_block {
+            ForwardedUnsafeBlock::P2p(block) => block,
+            ForwardedUnsafeBlock::Admin(block) => {
+                anyhow::bail!("P2P block was forwarded through the admin path: {block:?}")
+            }
+        };
 
         assert_eq!(block.parent_beacon_block_root, envelope.parent_beacon_block_root);
         assert_eq!(block.execution_payload, envelope.execution_payload);

--- a/etc/systems/tests/consensus_pruned_history.rs
+++ b/etc/systems/tests/consensus_pruned_history.rs
@@ -265,6 +265,7 @@ fn validator_options() -> EngineProcessorOptions {
         unsafe_head_tx: None,
         conductor: None,
         sequencer_stopped: false,
+        shadow_sequencer: false,
     }
 }
 


### PR DESCRIPTION
## Summary
- route authenticated P2P payloads separately from admin-injected unsafe payloads
- buffer active-sequencer P2P payloads by block number on shadow sequencers instead of inserting them into the EL
- bound the buffer and latch a fault on conflicts or overflow while preserving normal sequencer and validator behavior
- reject admin unsafe payloads on shadow sequencers so reconciliation input remains P2P-only

## Stack
- Depends on #4058
- This PR intentionally does not trigger or apply reconciliation; the next stack item will consume and validate the buffered canonical branch using authoritative insertion.