### PR TITLE
feat(load-tests): open-loop load generation + B20/EVM payloads (umbrella)

### DIFF
--- a/crates/common/flashblocks/src/block.rs
+++ b/crates/common/flashblocks/src/block.rs
@@ -12,7 +12,12 @@ use super::{
 };
 
 /// Maximum allowed decoded flashblock payload size, in bytes.
-pub const MAX_DECOMPRESSED_FLASHBLOCK_BYTES: usize = 5 * 1024 * 1024;
+///
+/// Sized above the largest flashblock a fully saturated builder emits: at over a
+/// billion gas per flashblock a single delta can exceed ten megabytes of transaction
+/// bytes, so a smaller cap would reject valid producer output. This value covers
+/// observed peaks while still bounding decompression memory.
+pub const MAX_DECOMPRESSED_FLASHBLOCK_BYTES: usize = 32 * 1024 * 1024;
 
 /// A flashblock containing partial block data.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
@@ -169,6 +174,24 @@ mod tests {
                 max: MAX_DECOMPRESSED_FLASHBLOCK_BYTES,
             } if given == MAX_DECOMPRESSED_FLASHBLOCK_BYTES + 1
         ));
+    }
+
+    #[test]
+    fn try_decode_message_accepts_multi_megabyte_saturated_flashblock() {
+        let mut payload = sample_payload(serde_json::json!({ "block_number": 1234 }));
+        let tx = PrimitiveBytes::from(vec![0x11u8; 256]);
+        payload.diff.transactions = vec![tx; 40_000];
+
+        let encoded = encode_plain(&payload);
+        assert!(
+            encoded.len() > 5 * 1024 * 1024,
+            "fixture must exceed the former 5 MiB cap to be a regression"
+        );
+        assert!(encoded.len() < MAX_DECOMPRESSED_FLASHBLOCK_BYTES);
+
+        let decoded = Flashblock::try_decode_message(encoded)
+            .expect("a saturated multi-megabyte flashblock must decode");
+        assert_eq!(decoded.diff.transactions.len(), 40_000);
     }
 
     fn encode_plain(payload: &FlashblocksPayloadV1) -> Bytes {

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -11,7 +11,7 @@ mod provider;
 pub use provider::BasePrecompiles;
 
 mod lookup;
-pub use lookup::{BerylLookup, BerylLookupWithObserver};
+pub use lookup::{B20_PRECOMPILE_EXCLUDE_ENV, BerylLookup, BerylLookupWithObserver};
 
 mod spec;
 pub use spec::BasePrecompileSpec;

--- a/crates/common/precompiles/src/lookup.rs
+++ b/crates/common/precompiles/src/lookup.rs
@@ -1,5 +1,7 @@
 //! Dynamic lookup for Beryl-native precompiles.
 
+use std::sync::OnceLock;
+
 use alloy_evm::precompiles::{DynPrecompile, PrecompileLookup, PrecompilesMap};
 use alloy_primitives::Address;
 use base_common_genesis::BaseUpgrade;
@@ -8,6 +10,16 @@ use crate::{
     B20AssetPrecompile, B20StablecoinPrecompile, B20Variant, NoopPrecompileCallObserver,
     PrecompileCallObserver,
 };
+
+/// Environment variable that, when set to a hex address, forces [`BerylLookup`] to return `None`
+/// for that address so EVM bytecode deployed there executes instead of the native precompile.
+///
+/// This exists solely for benchmarking the deployed Solidity B-20 reference implementation against
+/// the native precompile at an identical storage layout. It must never be set in production.
+pub const B20_PRECOMPILE_EXCLUDE_ENV: &str = "B20_PRECOMPILE_EXCLUDE_ADDRESS";
+
+/// Caches the parsed exclusion address so the hot lookup path avoids repeated env reads.
+static EXCLUDED_ADDRESS: OnceLock<Option<Address>> = OnceLock::new();
 
 /// Dynamic precompile lookup installed for Beryl and later forks.
 #[derive(Debug, Default, Clone, Copy)]
@@ -31,6 +43,20 @@ impl BerylLookup {
         precompiles.set_precompile_lookup(BerylLookupWithObserver::new(observer, upgrade));
     }
 
+    /// Returns the benchmark-only excluded address parsed from [`B20_PRECOMPILE_EXCLUDE_ENV`].
+    pub fn excluded_address() -> Option<Address> {
+        *EXCLUDED_ADDRESS.get_or_init(|| {
+            std::env::var(B20_PRECOMPILE_EXCLUDE_ENV)
+                .ok()
+                .and_then(|raw| raw.parse().ok())
+        })
+    }
+
+    /// Returns whether `address` is excluded from native B-20 dispatch for benchmarking.
+    pub fn is_excluded(address: &Address) -> bool {
+        Self::excluded_address() == Some(*address)
+    }
+
     /// Returns the B-20 variant precompile for `address` at `upgrade`, if it encodes one.
     pub fn lookup(address: &Address, upgrade: BaseUpgrade) -> Option<DynPrecompile> {
         Self::lookup_with_observer(address, upgrade, NoopPrecompileCallObserver)
@@ -48,6 +74,10 @@ impl BerylLookup {
     where
         O: PrecompileCallObserver,
     {
+        if Self::is_excluded(address) {
+            return None;
+        }
+
         match B20Variant::from_address(*address)? {
             B20Variant::Stablecoin => {
                 Some(B20StablecoinPrecompile::create_precompile_with_observer(

--- a/crates/infra/load-tests/src/config/real_token.rs
+++ b/crates/infra/load-tests/src/config/real_token.rs
@@ -155,6 +155,7 @@ fn validate_real_token_pair_matches_swaps(
             | TxTypeConfig::Calldata { .. }
             | TxTypeConfig::Erc20 { .. }
             | TxTypeConfig::B20
+            | TxTypeConfig::B20Evm { .. }
             | TxTypeConfig::Precompile { .. }
             | TxTypeConfig::Storage { .. }
             | TxTypeConfig::Osaka { .. } => continue,

--- a/crates/infra/load-tests/src/config/test_config.rs
+++ b/crates/infra/load-tests/src/config/test_config.rs
@@ -55,6 +55,14 @@ pub struct TestConfig {
     /// Maximum in-flight transactions per sender.
     pub in_flight_per_sender: u32,
 
+    /// Enables open-loop submission mode with pre-signed transactions.
+    #[serde(default)]
+    pub open_loop: bool,
+
+    /// Number of transactions to pre-sign per sender in open-loop mode.
+    #[serde(default)]
+    pub prefill_per_sender: u32,
+
     /// Number of transactions to batch together before submitting to the RPC.
     pub batch_size: u32,
 
@@ -126,6 +134,8 @@ impl Default for TestConfig {
             sender_count: 100,
             sender_offset: 0,
             in_flight_per_sender: 256,
+            open_loop: false,
+            prefill_per_sender: 0,
             batch_size: 50,
             batch_timeout: Some("100ms".to_string()),
             duration: Some("60s".to_string()),
@@ -154,6 +164,8 @@ impl fmt::Debug for TestConfig {
             .field("sender_count", &self.sender_count)
             .field("sender_offset", &self.sender_offset)
             .field("in_flight_per_sender", &self.in_flight_per_sender)
+            .field("open_loop", &self.open_loop)
+            .field("prefill_per_sender", &self.prefill_per_sender)
             .field("duration", &self.duration)
             .field("target_gps", &self.target_gps)
             .field("seed", &self.seed)
@@ -266,6 +278,13 @@ pub enum TxTypeConfig {
     /// B-20 precompile token transfer. Each sender creates and transfers its own token, created
     /// per run during setup.
     B20,
+
+    /// B-20 EVM contract token transfer. Requires a pre-deployed contract and DB-seeded sender
+    /// balances.
+    B20Evm {
+        /// Pre-deployed EVM token contract address.
+        contract: String,
+    },
 
     /// Aerodrome Slipstream (concentrated liquidity) swap.
     AerodromeCl {
@@ -593,6 +612,8 @@ impl TestConfig {
                 .clone()
                 .ok_or_else(|| BaselineError::Config("flashblocks_ws is required".into()))?,
             fresh_recipient_ratio: self.fresh_recipient_ratio,
+            open_loop: self.open_loop,
+            prefill_per_sender: self.prefill_per_sender,
         })
     }
 
@@ -643,6 +664,10 @@ impl TestConfig {
                 }
             }
             TxTypeConfig::B20 => TxType::B20,
+            TxTypeConfig::B20Evm { contract } => {
+                let address = parse_address(contract, "b20_evm contract")?;
+                TxType::B20Evm { contract: address }
+            }
             TxTypeConfig::Osaka { target } => TxType::Osaka { target: target.clone() },
             TxTypeConfig::UniswapV3 {
                 router,

--- a/crates/infra/load-tests/src/lib.rs
+++ b/crates/infra/load-tests/src/lib.rs
@@ -33,10 +33,10 @@ pub use metrics::{
 
 mod workload;
 pub use workload::{
-    AccountPool, AerodromeClPayload, B20TransferPayload, CalldataPayload, Erc20Payload,
-    FundedAccount, KeyStream, OsakaPayload, Payload, PrecompileLooper, PrecompilePayload,
-    SeededRng, StoragePayload, TransferPayload, UniswapV3Payload, WorkloadGenerator,
-    parse_precompile_id,
+    AccountPool, AerodromeClPayload, B20EvmTransferPayload, B20TransferPayload, CalldataPayload,
+    Erc20Payload, FundedAccount, KeyStream, OsakaPayload, Payload, PrecompileLooper,
+    PrecompilePayload, SeededRng, StoragePayload, TransferPayload, UniswapV3Payload,
+    WorkloadGenerator, parse_precompile_id,
 };
 
 mod runner;
@@ -44,7 +44,8 @@ pub use runner::{
     AdaptiveBackoff, BatchTxError, BlockObservation, BlockReceipt, BlockWatcher,
     DEFAULT_MAX_GAS_PRICE, DisplaySnapshot, FlashblockInclusion, FlashblockWatcher, LoadConfig,
     LoadRunner, LoadTestDisplay, MAX_FEE_BASE_FEE_MULTIPLIER, MAX_SENDER_WORKER_COUNT,
-    MAX_SIGNER_WORKER_COUNT, PipelineQueue, PreparedBatch, PreparedTransaction,
+    MAX_SIGNER_WORKER_COUNT, PipelineQueue, PipelineStartConfig, PreparedBatch,
+    PreparedTransaction,
     QueuedSubmitFailures, RateLimiter, RealTokenAcquisition, RealTokenPairTokenSetup,
     RealTokenRecoverySummary, RealTokenSetup, ResultsTracker, SENDER_WORKERS_PER_RPC,
     SIGNER_WORKERS_PER_RPC, SUBMIT_BATCH_QUEUE_BUFFER, SUBMIT_MAX_ATTEMPTS, SenderContext,

--- a/crates/infra/load-tests/src/metrics/aggregator.rs
+++ b/crates/infra/load-tests/src/metrics/aggregator.rs
@@ -36,7 +36,7 @@ impl<'a> MetricsAggregator<'a> {
     ) -> MetricsSummary {
         let mut top_failure_reasons: Vec<(String, u64)> =
             submission.failure_reasons.iter().map(|(k, v)| (k.clone(), *v)).collect();
-        top_failure_reasons.sort_by(|a, b| b.1.cmp(&a.1));
+        top_failure_reasons.sort_by_key(|entry| std::cmp::Reverse(entry.1));
         top_failure_reasons.truncate(3);
 
         let tps_values: Vec<f64> = throughput_samples.iter().map(|s| s.tps).collect();

--- a/crates/infra/load-tests/src/runner/config.rs
+++ b/crates/infra/load-tests/src/runner/config.rs
@@ -58,6 +58,11 @@ pub enum TxType {
     /// B-20 precompile token transfer. Each sender creates and transfers its own token, created
     /// per run during setup.
     B20,
+    /// B-20 EVM contract token transfer against a fixed pre-deployed contract.
+    B20Evm {
+        /// EVM contract address (pre-deployed at DB level).
+        contract: Address,
+    },
     /// Osaka (Base Azul) opcode or precompile transaction.
     Osaka {
         /// Target Osaka feature.
@@ -232,6 +237,10 @@ pub struct LoadConfig {
     /// Fraction of transactions that draw a fresh recipient address instead of cycling through
     /// the sender pool. Used to drive account-trie fan-out for account-create workloads.
     pub fresh_recipient_ratio: f64,
+    /// Enables open-loop submission mode with pre-signed transactions.
+    pub open_loop: bool,
+    /// Number of pre-signed transactions to generate per sender in open-loop mode.
+    pub prefill_per_sender: u32,
 }
 
 impl LoadConfig {
@@ -257,6 +266,8 @@ impl LoadConfig {
             max_gas_price: DEFAULT_MAX_GAS_PRICE,
             flashblocks_ws: "ws://localhost:7111".parse().expect("valid default flashblocks_ws"),
             fresh_recipient_ratio: 0.0,
+            open_loop: false,
+            prefill_per_sender: 0,
         }
     }
 

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -7,10 +7,13 @@ use std::{
     time::{Duration, Instant},
 };
 
+use alloy_consensus::transaction::SignableTransaction;
+use alloy_eips::Encodable2718;
 use alloy_network::{Ethereum, EthereumWallet, TransactionBuilder};
 use alloy_primitives::{Address, B256, Bytes, TxHash, U256, utils::format_ether};
 use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_types::{BlockNumberOrTag, TransactionRequest};
+use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::{SolCall, sol};
 use base_common_network::Base;
@@ -18,7 +21,7 @@ use base_tx_manager::NonceManager;
 use futures::{StreamExt, stream};
 use indicatif::{ProgressBar, ProgressStyle};
 use revm::precompile::PrecompileId;
-use tokio::sync::{mpsc, watch};
+use tokio::{sync::{mpsc, watch}, task};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, warn};
 
@@ -32,9 +35,9 @@ const FUNDING_BATCH_SIZE: usize = 16;
 pub(super) const BATCH_SIZE: usize = FUNDING_BATCH_SIZE;
 
 use super::{
-    BlockWatcher, DisplaySnapshot, FlashblockWatcher, LoadConfig, LoadTestDisplay, PreparedBatch,
-    PreparedTransaction, QueuedSubmitFailures, RateLimiter, ResultsTracker, SubmissionPipeline,
-    SubmitEvent, TxType,
+    BlockWatcher, DisplaySnapshot, FlashblockWatcher, LoadConfig, LoadTestDisplay,
+    PipelineStartConfig, PreparedBatch, PreparedTransaction, QueuedSubmitFailures, RateLimiter,
+    ResultsTracker, SignedBatch, SignedTransaction, SubmissionPipeline, SubmitEvent, TxType,
 };
 use crate::{
     BaselineError, Result,
@@ -45,9 +48,9 @@ use crate::{
         create_wallet_provider,
     },
     workload::{
-        AccountPool, AerodromeClPayload, B20TransferPayload, CalldataPayload, Erc20Payload,
-        KeyStream, OsakaPayload, PrecompilePayload, SeededRng, StoragePayload, TransferPayload,
-        UniswapV3Payload, WorkloadGenerator,
+        AccountPool, AerodromeClPayload, B20EvmTransferPayload, B20TransferPayload, CalldataPayload,
+        Erc20Payload, KeyStream, OsakaPayload, PrecompilePayload, SeededRng, StoragePayload,
+        TransferPayload, UniswapV3Payload, WorkloadGenerator,
     },
 };
 
@@ -58,6 +61,46 @@ const PENDING_CONFIRMATION_TIMEOUT: Duration = Duration::from_secs(200);
 const CONFIRMATION_DRAIN_TIMEOUT: Duration = Duration::from_secs(200);
 const TXPOOL_CLEAR_CONCURRENCY: usize = 64;
 const FRESH_RECIPIENT_RNG_SALT: u64 = 0x6672_6573_685f_7263; // "fresh_rc"
+const OPEN_LOOP_SIGNED_BATCH_SIZE: usize = 200;
+const OPEN_LOOP_IDLE_SLEEP: Duration = Duration::from_millis(10);
+const OPEN_LOOP_HEADROOM_RECHECK_INTERVAL: Duration = Duration::from_millis(100);
+const OPEN_LOOP_HEADROOM_STALL_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug)]
+struct OpenLoopSenderJob {
+    sender_index: usize,
+    from: Address,
+    start_nonce: u64,
+    prepared_txs: Vec<PreparedTransaction>,
+}
+
+#[derive(Debug)]
+struct OpenLoopSignedSender {
+    sender_index: usize,
+    signed_txs: Vec<SignedTransaction>,
+}
+
+struct OpenLoopDrainState<'a> {
+    submit_event_rx: &'a mut mpsc::Receiver<SubmitEvent>,
+    queued_per_sender: &'a mut HashMap<Address, u64>,
+    collector: &'a mut MetricsCollector,
+    results_tracker: &'a ResultsTracker,
+}
+
+impl OpenLoopDrainState<'_> {
+    fn apply_submit_event(&mut self, event: SubmitEvent) {
+        LoadRunner::apply_submit_event(event, self.queued_per_sender, self.collector);
+    }
+
+    fn drain_run_events(&mut self) {
+        LoadRunner::drain_run_events(
+            self.submit_event_rx,
+            self.queued_per_sender,
+            self.collector,
+            self.results_tracker,
+        );
+    }
+}
 
 /// Executes load tests by generating and submitting transactions at a target rate.
 pub struct LoadRunner {
@@ -298,6 +341,16 @@ impl LoadRunner {
                         );
                     }
                 }
+                TxType::B20Evm { contract } => {
+                    generator = generator.with_payload(
+                        B20EvmTransferPayload::new(
+                            *contract,
+                            U256::from(1000),
+                            U256::from(10000),
+                        ),
+                        weight_pct,
+                    );
+                }
                 TxType::Osaka { target } => {
                     generator =
                         generator.with_payload(OsakaPayload::new(target.clone()), weight_pct);
@@ -371,7 +424,7 @@ impl LoadRunner {
                 TxType::Calldata { max_size, .. } => 21_000 + (*max_size as u64 * 16),
                 TxType::Erc20 { .. } => 65_000,
                 TxType::Storage { slots_per_tx, .. } => u64::from(*slots_per_tx) * 22_000 + 21_000,
-                TxType::B20 => 100_000,
+                TxType::B20 | TxType::B20Evm { .. } => 100_000,
                 TxType::Precompile { target, iterations, blake2f_rounds, .. } => {
                     let per_call = match target {
                         PrecompileId::Identity | PrecompileId::Bn254Add => 22_000,
@@ -746,6 +799,7 @@ impl LoadRunner {
                 | TxType::Erc20 { .. }
                 | TxType::Storage { .. }
                 | TxType::B20
+                | TxType::B20Evm { .. }
                 | TxType::Precompile { .. }
                 | TxType::Osaka { .. } => {}
             }
@@ -766,6 +820,7 @@ impl LoadRunner {
                 | TxType::Erc20 { .. }
                 | TxType::Storage { .. }
                 | TxType::B20
+                | TxType::B20Evm { .. }
                 | TxType::Precompile { .. }
                 | TxType::Osaka { .. } => {}
             }
@@ -1129,22 +1184,34 @@ impl LoadRunner {
         // feedback have a non-zero gas figure before canonical receipt gas lands.
         self.collector.set_estimated_gas(initial_avg_gas);
         let mut rate_limiter = RateLimiter::new(self.config.target_gps, initial_avg_gas);
-        let start = Instant::now();
+        let mut start = Instant::now();
         let mut current_account_idx = 0usize;
         let account_count = self.accounts.len();
 
         let batch_size = self.config.batch_size;
         let batch_timeout = self.config.batch_timeout;
 
-        info!(
-            target_gps = self.config.target_gps,
-            initial_avg_gas,
-            effective_tps = rate_limiter.effective_tps(),
-            max_in_flight_per_sender,
-            batch_size,
-            batch_timeout_ms = batch_timeout.as_millis(),
-            "starting load test with per-sender in-flight limiting"
-        );
+        if self.config.open_loop {
+            info!(
+                prefill_per_sender = self.config.prefill_per_sender,
+                sender_count = account_count,
+                max_sender_workers = SubmissionPipeline::sender_worker_count_for_mode(
+                    self.submission_batch_rpcs.len(),
+                    true,
+                ),
+                "starting load test in open-loop pre-signed mode"
+            );
+        } else {
+            info!(
+                target_gps = self.config.target_gps,
+                initial_avg_gas,
+                effective_tps = rate_limiter.effective_tps(),
+                max_in_flight_per_sender,
+                batch_size,
+                batch_timeout_ms = batch_timeout.as_millis(),
+                "starting load test with per-sender in-flight limiting"
+            );
+        }
 
         let mut pending_batch: Vec<PreparedTransaction> = Vec::with_capacity(batch_size);
         let signers = Arc::clone(&self.signers);
@@ -1156,16 +1223,22 @@ impl LoadRunner {
             submission_batch_rpcs,
             results_tracker.clone(),
             submit_event_tx.clone(),
-            self.config.chain_id,
-            self.config.max_gas_price,
+            PipelineStartConfig {
+                chain_id: self.config.chain_id,
+                max_gas_price: self.config.max_gas_price,
+                open_loop: self.config.open_loop,
+            },
         );
         let next_submit_batch_id = AtomicU64::new(0);
         let mut queued_per_sender: HashMap<Address, u64> =
             self.accounts.accounts().iter().map(|a| (a.address, 0)).collect();
+        let mut presigned_remaining = 0u64;
 
         let mut last_base_fee_refresh = Instant::now();
         let mut last_rate_limiter_update = Instant::now();
         let mut last_progress_report = Instant::now();
+        let mut last_submitted_sample_count = 0u64;
+        let mut last_submitted_sample_at = Instant::now();
         // Refresh once per block so the cached base fee tracks the climb the load
         // test itself induces; a stale fee mints underwater (unincludable) txs.
         const BASE_FEE_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
@@ -1194,12 +1267,65 @@ impl LoadRunner {
             }
         }
 
+        let mut open_loop_enqueue_error: Option<BaselineError> = None;
+        if self.config.open_loop {
+            let pre_sign_started = Instant::now();
+            let presigned_by_sender = self.pre_sign_open_loop_transactions().await?;
+            let presigned_total = presigned_by_sender
+                .iter()
+                .map(|sender_txs| sender_txs.len() as u64)
+                .sum::<u64>();
+            presigned_remaining = presigned_total;
+
+            let target_in_flight =
+                max_in_flight_per_sender.saturating_mul(account_count as u64);
+
+            info!(
+                presigned_total,
+                target_in_flight,
+                elapsed_secs = pre_sign_started.elapsed().as_secs_f64(),
+                "open-loop pre-signing complete"
+            );
+
+            // Restart the measurement clock after pre-signing. For fresh-recipient
+            // runs the pre-sign phase can take tens of seconds; leaving it inside the
+            // `duration` window would consume most of the run before a single tx is
+            // enqueued, so the enqueue deadline and main-loop budget below must be
+            // measured from the moment submission actually begins.
+            start = Instant::now();
+
+            let enqueue_deadline = self.config.duration.map(|d| start + d);
+
+            let enqueue_result = Self::enqueue_open_loop_signed_transactions(
+                &submission_pipeline,
+                &next_submit_batch_id,
+                presigned_by_sender,
+                &mut presigned_remaining,
+                target_in_flight,
+                enqueue_deadline,
+                &mut OpenLoopDrainState {
+                    submit_event_rx: &mut submit_event_rx,
+                    queued_per_sender: &mut queued_per_sender,
+                    collector: &mut self.collector,
+                    results_tracker: &results_tracker,
+                },
+            )
+            .await;
+
+            if let Err(err) = enqueue_result {
+                warn!(%err, presigned_remaining, "open-loop enqueue aborted; proceeding to drain and shutdown");
+                open_loop_enqueue_error = Some(err);
+            } else {
+                info!(presigned_remaining, "open-loop pre-signed enqueue phase complete");
+            }
+        }
+
         while self.config.duration.is_none_or(|d| start.elapsed() < d)
             && !self.stop_flag.load(Ordering::SeqCst)
         {
             // --- Housekeeping (runs once per batch iteration) ---
 
-            if last_base_fee_refresh.elapsed() >= BASE_FEE_REFRESH_INTERVAL {
+            if !self.config.open_loop && last_base_fee_refresh.elapsed() >= BASE_FEE_REFRESH_INTERVAL {
                 if let Ok(new_base_fee) = self.client.get_base_fee().await
                     && new_base_fee != self.base_fee
                 {
@@ -1209,17 +1335,20 @@ impl LoadRunner {
                 last_base_fee_refresh = Instant::now();
             }
 
-            if last_rate_limiter_update.elapsed() >= RATE_LIMITER_UPDATE_INTERVAL {
+            if !self.config.open_loop
+                && last_rate_limiter_update.elapsed() >= RATE_LIMITER_UPDATE_INTERVAL
+            {
                 if let Some(avg_gas) = self.collector.avg_gas_used() {
                     rate_limiter.update_avg_gas(avg_gas);
                 }
                 last_rate_limiter_update = Instant::now();
             }
 
-            Self::drain_submit_events(
+            Self::drain_run_events(
                 &mut submit_event_rx,
                 &mut queued_per_sender,
                 &mut self.collector,
+                &results_tracker,
             );
 
             // Drain flashblock observations for the rolling window (separate from
@@ -1267,15 +1396,26 @@ impl LoadRunner {
                 let (p50, p99) = self.collector.rolling_p50_p99();
                 let (flashblocks_p50, flashblocks_p99) =
                     self.collector.rolling_flashblocks_p50_p99();
+                let report_now = Instant::now();
+                let report_elapsed_secs =
+                    report_now.saturating_duration_since(last_submitted_sample_at).as_secs_f64();
+                let submitted_delta = submitted.saturating_sub(last_submitted_sample_count);
+                let submitted_per_sec = if report_elapsed_secs > 0.0 {
+                    submitted_delta as f64 / report_elapsed_secs
+                } else {
+                    0.0
+                };
                 info!(
                     elapsed_secs,
                     submitted,
+                    submitted_per_sec,
                     confirmed,
                     failed,
                     in_flight,
                     pending,
                     total_queued,
                     senders_blocked,
+                    presigned_remaining,
                     base_fee = self.base_fee,
                     p50_ms = p50.as_millis() as u64,
                     p99_ms = p99.as_millis() as u64,
@@ -1283,7 +1423,14 @@ impl LoadRunner {
                     flashblocks_p99_ms = flashblocks_p99.as_millis() as u64,
                     "progress"
                 );
+                last_submitted_sample_count = submitted;
+                last_submitted_sample_at = report_now;
                 last_progress_report = Instant::now();
+            }
+
+            if self.config.open_loop {
+                tokio::time::sleep(OPEN_LOOP_IDLE_SLEEP).await;
+                continue;
             }
 
             // --- Inner loop: fill batch without sleeping ---
@@ -1552,7 +1699,403 @@ impl LoadRunner {
         if let Some(fresh_recipient_count) = summary.fresh_recipient_count {
             info!(fresh_recipient_count, "fresh recipient generation complete");
         }
+
+        if let Some(err) = open_loop_enqueue_error {
+            return Err(err);
+        }
         Ok(summary)
+    }
+
+    async fn pre_sign_open_loop_transactions(&mut self) -> Result<Vec<Vec<SignedTransaction>>> {
+        let sender_jobs = self.build_open_loop_sender_jobs().await?;
+        let sender_count = sender_jobs.len();
+        let total_presigned = sender_jobs
+            .iter()
+            .map(|sender_job| sender_job.prepared_txs.len() as u64)
+            .sum::<u64>();
+
+        info!(
+            sender_count,
+            prefill_per_sender = self.config.prefill_per_sender,
+            total_presigned,
+            "pre-signing open-loop transactions"
+        );
+
+        self.sign_open_loop_sender_jobs(sender_jobs).await
+    }
+
+    async fn build_open_loop_sender_jobs(&mut self) -> Result<Vec<OpenLoopSenderJob>> {
+        let sender_addresses: Vec<Address> =
+            self.accounts.accounts().iter().map(|account| account.address).collect();
+        let sender_count = sender_addresses.len();
+        let prefill_per_sender = self.config.prefill_per_sender as usize;
+
+        let mut sender_jobs = Vec::with_capacity(sender_count);
+        for (sender_index, from) in sender_addresses.iter().copied().enumerate() {
+            let Some(nonce_manager) = self.nonce_managers.get(&from) else {
+                return Err(BaselineError::Transaction(format!(
+                    "missing nonce manager for sender {from}"
+                )));
+            };
+
+            let nonce_guard = nonce_manager.next_nonce().await.map_err(|e| {
+                BaselineError::Transaction(format!(
+                    "failed to fetch starting nonce for sender {from}: {e}"
+                ))
+            })?;
+            let start_nonce = nonce_guard.nonce();
+            nonce_guard.rollback();
+
+            let sender_pool_recipient = sender_addresses[(sender_index + 1) % sender_count];
+            let mut prepared_txs = Vec::with_capacity(prefill_per_sender);
+            for _ in 0..prefill_per_sender {
+                let payload = self.generator.select_payload()?;
+                let to = if payload.uses_runner_recipient() {
+                    self.select_recipient(sender_pool_recipient)?
+                } else {
+                    sender_pool_recipient
+                };
+
+                let tx_request = self.generator.generate_selected_payload(&payload, from, to);
+                let to_addr = tx_request.to.and_then(|kind| kind.to().copied());
+                let value = tx_request.value.unwrap_or(U256::ZERO);
+                let data = tx_request.input.input().cloned().unwrap_or_default();
+                let gas_limit = tx_request.gas.unwrap_or(21_000);
+
+                prepared_txs.push(PreparedTransaction {
+                    from,
+                    to: to_addr,
+                    value,
+                    data,
+                    gas_limit,
+                });
+            }
+
+            sender_jobs.push(OpenLoopSenderJob {
+                sender_index,
+                from,
+                start_nonce,
+                prepared_txs,
+            });
+        }
+
+        Ok(sender_jobs)
+    }
+
+    async fn sign_open_loop_sender_jobs(
+        &self,
+        sender_jobs: Vec<OpenLoopSenderJob>,
+    ) -> Result<Vec<Vec<SignedTransaction>>> {
+        let sender_count = sender_jobs.len();
+        if sender_count == 0 {
+            return Ok(Vec::new());
+        }
+
+        let priority_fee = (self.base_fee / 10).max(1);
+        let max_fee =
+            SubmissionPipeline::submission_max_fee(self.base_fee, priority_fee, self.config.max_gas_price);
+
+        let mut signing_tasks = Vec::with_capacity(sender_count);
+        for sender_job in sender_jobs {
+            let Some(signer) = self.signers.get(&sender_job.from).cloned() else {
+                return Err(BaselineError::Transaction(format!(
+                    "missing signer for sender {}",
+                    sender_job.from
+                )));
+            };
+
+            let chain_id = self.config.chain_id;
+            signing_tasks.push(task::spawn_blocking(move || {
+                Self::sign_open_loop_sender_job(sender_job, signer, chain_id, priority_fee, max_fee)
+            }));
+        }
+
+        let mut signed_by_sender: Vec<Option<Vec<SignedTransaction>>> =
+            std::iter::repeat_with(|| None).take(sender_count).collect();
+
+        for signing_task in signing_tasks {
+            let signed_sender = signing_task
+                .await
+                .map_err(|e| BaselineError::Transaction(format!("open-loop signing task failed: {e}")))??;
+
+            let sender_index = signed_sender.sender_index;
+            if signed_by_sender[sender_index].is_some() {
+                return Err(BaselineError::Transaction(format!(
+                    "duplicate signed sender result for index {sender_index}"
+                )));
+            }
+            signed_by_sender[sender_index] = Some(signed_sender.signed_txs);
+        }
+
+        let mut ordered_signed_txs = Vec::with_capacity(sender_count);
+        for (sender_index, sender_txs) in signed_by_sender.into_iter().enumerate() {
+            let sender_txs = sender_txs.ok_or_else(|| {
+                BaselineError::Transaction(format!(
+                    "missing signed transaction set for sender index {sender_index}"
+                ))
+            })?;
+            ordered_signed_txs.push(sender_txs);
+        }
+
+        Ok(ordered_signed_txs)
+    }
+
+    fn sign_open_loop_sender_job(
+        sender_job: OpenLoopSenderJob,
+        signer: PrivateKeySigner,
+        chain_id: u64,
+        priority_fee: u128,
+        max_fee: u128,
+    ) -> Result<OpenLoopSignedSender> {
+        let mut signed_txs = Vec::with_capacity(sender_job.prepared_txs.len());
+
+        for (nonce_offset, prepared) in sender_job.prepared_txs.into_iter().enumerate() {
+            let nonce_offset = u64::try_from(nonce_offset).map_err(|e| {
+                BaselineError::Transaction(format!("failed to convert nonce offset to u64: {e}"))
+            })?;
+            let nonce = sender_job.start_nonce.checked_add(nonce_offset).ok_or_else(|| {
+                BaselineError::Transaction(format!(
+                    "nonce overflow for sender {} at offset {nonce_offset}",
+                    sender_job.from
+                ))
+            })?;
+
+            let mut tx = TransactionRequest::default()
+                .with_from(prepared.from)
+                .with_value(prepared.value)
+                .with_input(prepared.data)
+                .with_nonce(nonce)
+                .with_chain_id(chain_id)
+                .with_max_fee_per_gas(max_fee)
+                .with_max_priority_fee_per_gas(priority_fee)
+                .with_gas_limit(prepared.gas_limit);
+            if let Some(to) = prepared.to {
+                tx = tx.with_to(to);
+            }
+
+            let typed_tx = tx.build_typed_tx().map_err(|e| {
+                BaselineError::Transaction(format!(
+                    "failed to build typed tx for sender {} nonce {}: {e:?}",
+                    prepared.from, nonce
+                ))
+            })?;
+
+            let sig_hash = typed_tx.signature_hash();
+            let signature = signer.sign_hash_sync(&sig_hash).map_err(|e| {
+                BaselineError::Transaction(format!(
+                    "failed to sign tx for sender {} nonce {}: {e}",
+                    prepared.from, nonce
+                ))
+            })?;
+
+            let signed = typed_tx.into_signed(signature);
+            let tx_hash = *signed.hash();
+            let raw = Bytes::from(signed.encoded_2718());
+
+            signed_txs.push(SignedTransaction { raw, tx_hash, from: prepared.from, nonce });
+        }
+
+        Ok(OpenLoopSignedSender { sender_index: sender_job.sender_index, signed_txs })
+    }
+
+    async fn enqueue_signed_while_draining(
+        submission_pipeline: &SubmissionPipeline,
+        batch: SignedBatch,
+        drain_state: &mut OpenLoopDrainState<'_>,
+    ) -> std::result::Result<(), SignedBatch> {
+        let enqueue = submission_pipeline.enqueue_signed(batch);
+        tokio::pin!(enqueue);
+
+        loop {
+            tokio::select! {
+                result = enqueue.as_mut() => {
+                    drain_state.drain_run_events();
+                    return result;
+                }
+                maybe_event = drain_state.submit_event_rx.recv() => {
+                    match maybe_event {
+                        Some(event) => {
+                            drain_state.apply_submit_event(event);
+                            drain_state.drain_run_events();
+                        }
+                        None => return enqueue.as_mut().await,
+                    }
+                }
+            }
+        }
+    }
+
+    /// Blocks new submissions while the in-flight (submitted-but-unconfirmed) count
+    /// is at or above `target_in_flight`, draining confirmation and submit events in
+    /// the meantime.
+    ///
+    /// This paces the open-loop fill to the builder's drain rate so the pool holds a
+    /// steady depth instead of being flooded in one burst and then draining empty.
+    /// A `target_in_flight` of 0 disables pacing (unbounded fill).
+    ///
+    /// In-flight is released by the block watcher mutating the shared `ResultsTracker`
+    /// out-of-band, not by submit events, so the wait re-reads `total_in_flight` on a
+    /// fixed interval rather than only when a submit event arrives; a `recv` timeout
+    /// means "re-check", never "grant headroom". If in-flight fails to fall for
+    /// `OPEN_LOOP_HEADROOM_STALL_TIMEOUT` the confirmation path is dead and the gate
+    /// fails closed (returns `Err`) instead of hanging or flooding the pool.
+    async fn wait_for_inflight_headroom(
+        target_in_flight: u64,
+        deadline: Option<Instant>,
+        drain_state: &mut OpenLoopDrainState<'_>,
+    ) -> Result<()> {
+        if target_in_flight == 0 {
+            return Ok(());
+        }
+
+        let mut last_in_flight = drain_state.results_tracker.total_in_flight();
+        let mut last_progress = Instant::now();
+
+        while drain_state.results_tracker.total_in_flight() >= target_in_flight {
+            if deadline.is_some_and(|d| Instant::now() >= d) {
+                return Ok(());
+            }
+
+            match tokio::time::timeout(
+                OPEN_LOOP_HEADROOM_RECHECK_INTERVAL,
+                drain_state.submit_event_rx.recv(),
+            )
+            .await
+            {
+                Ok(Some(event)) => {
+                    drain_state.apply_submit_event(event);
+                    drain_state.drain_run_events();
+                }
+                Ok(None) => return Ok(()),
+                Err(_) => drain_state.drain_run_events(),
+            }
+
+            let current = drain_state.results_tracker.total_in_flight();
+            if current < last_in_flight {
+                last_in_flight = current;
+                last_progress = Instant::now();
+            } else if last_progress.elapsed() >= OPEN_LOOP_HEADROOM_STALL_TIMEOUT {
+                return Err(BaselineError::Timeout {
+                    operation: format!(
+                        "open-loop in-flight headroom (stuck at {current} in-flight, target {target_in_flight})"
+                    ),
+                    duration: OPEN_LOOP_HEADROOM_STALL_TIMEOUT,
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn enqueue_open_loop_signed_transactions(
+        submission_pipeline: &SubmissionPipeline,
+        next_submit_batch_id: &AtomicU64,
+        signed_by_sender: Vec<Vec<SignedTransaction>>,
+        presigned_remaining: &mut u64,
+        target_in_flight: u64,
+        deadline: Option<Instant>,
+        drain_state: &mut OpenLoopDrainState<'_>,
+    ) -> Result<()> {
+        let mut sender_iters = signed_by_sender
+            .into_iter()
+            .map(Vec::into_iter)
+            .collect::<Vec<_>>();
+        let mut pending_signed_batch = Vec::with_capacity(OPEN_LOOP_SIGNED_BATCH_SIZE);
+
+        loop {
+            if deadline.is_some_and(|d| Instant::now() >= d) {
+                return Ok(());
+            }
+
+            let mut made_progress = false;
+
+            for sender_iter in &mut sender_iters {
+                if let Some(signed_tx) = sender_iter.next() {
+                    made_progress = true;
+                    pending_signed_batch.push(signed_tx);
+
+                    if pending_signed_batch.len() >= OPEN_LOOP_SIGNED_BATCH_SIZE {
+                        Self::wait_for_inflight_headroom(target_in_flight, deadline, drain_state)
+                            .await?;
+                        if deadline.is_some_and(|d| Instant::now() >= d) {
+                            return Ok(());
+                        }
+                        if !Self::enqueue_open_loop_signed_batch(
+                            submission_pipeline,
+                            next_submit_batch_id,
+                            &mut pending_signed_batch,
+                            presigned_remaining,
+                            drain_state,
+                        )
+                        .await
+                        {
+                            return Ok(());
+                        }
+                    }
+                }
+            }
+
+            if !made_progress {
+                break;
+            }
+        }
+
+        if !pending_signed_batch.is_empty() {
+            Self::wait_for_inflight_headroom(target_in_flight, deadline, drain_state).await?;
+            let _ = Self::enqueue_open_loop_signed_batch(
+                submission_pipeline,
+                next_submit_batch_id,
+                &mut pending_signed_batch,
+                presigned_remaining,
+                drain_state,
+            )
+            .await;
+        }
+
+        Ok(())
+    }
+
+    async fn enqueue_open_loop_signed_batch(
+        submission_pipeline: &SubmissionPipeline,
+        next_submit_batch_id: &AtomicU64,
+        pending_signed_batch: &mut Vec<SignedTransaction>,
+        presigned_remaining: &mut u64,
+        drain_state: &mut OpenLoopDrainState<'_>,
+    ) -> bool {
+        let signed_txs = std::mem::replace(
+            pending_signed_batch,
+            Vec::with_capacity(OPEN_LOOP_SIGNED_BATCH_SIZE),
+        );
+        let batch_len = signed_txs.len();
+        let batch_id = next_submit_batch_id.fetch_add(1, Ordering::SeqCst);
+
+        for signed_tx in &signed_txs {
+            drain_state
+                .queued_per_sender
+                .entry(signed_tx.from)
+                .and_modify(|count| *count = count.saturating_add(1))
+                .or_insert(1);
+        }
+
+        let batch = SignedBatch { id: batch_id, attempt: 0, txs: signed_txs };
+        match Self::enqueue_signed_while_draining(submission_pipeline, batch, drain_state).await {
+            Ok(()) => {
+                *presigned_remaining = presigned_remaining.saturating_sub(batch_len as u64);
+                debug!(batch_id, batch_len, presigned_remaining = *presigned_remaining, "queued open-loop signed batch");
+                true
+            }
+            Err(batch) => {
+                warn!(batch_id, batch_len, "submit queue closed while enqueuing open-loop signed batch");
+                let failed_count = batch.txs.len() as u64;
+                for signed_tx in &batch.txs {
+                    if let Some(count) = drain_state.queued_per_sender.get_mut(&signed_tx.from) {
+                        *count = count.saturating_sub(1);
+                    }
+                }
+                drain_state.collector.record_failures("submit queue closed", failed_count);
+                false
+            }
+        }
     }
 
     fn build_snapshot(
@@ -1588,23 +2131,45 @@ impl LoadRunner {
         }
     }
 
+    fn apply_submit_event(
+        event: SubmitEvent,
+        queued_per_sender: &mut HashMap<Address, u64>,
+        collector: &mut MetricsCollector,
+    ) {
+        match event {
+            SubmitEvent::Submitted(tx_hash) => collector.record_submitted(tx_hash),
+            SubmitEvent::Failed(reason) => {
+                collector.record_failed(TxHash::ZERO, &reason);
+            }
+            SubmitEvent::Released(from) => {
+                if let Some(count) = queued_per_sender.get_mut(&from) {
+                    *count = count.saturating_sub(1);
+                }
+            }
+        }
+    }
+
     fn drain_submit_events(
         submit_event_rx: &mut mpsc::Receiver<SubmitEvent>,
         queued_per_sender: &mut HashMap<Address, u64>,
         collector: &mut MetricsCollector,
     ) {
         while let Ok(event) = submit_event_rx.try_recv() {
-            match event {
-                SubmitEvent::Submitted(tx_hash) => collector.record_submitted(tx_hash),
-                SubmitEvent::Failed(reason) => {
-                    collector.record_failed(TxHash::ZERO, &reason);
-                }
-                SubmitEvent::Released(from) => {
-                    if let Some(count) = queued_per_sender.get_mut(&from) {
-                        *count = count.saturating_sub(1);
-                    }
-                }
-            }
+            Self::apply_submit_event(event, queued_per_sender, collector);
+        }
+    }
+
+    fn drain_run_events(
+        submit_event_rx: &mut mpsc::Receiver<SubmitEvent>,
+        queued_per_sender: &mut HashMap<Address, u64>,
+        collector: &mut MetricsCollector,
+        results_tracker: &ResultsTracker,
+    ) {
+        while let Ok(event) = submit_event_rx.try_recv() {
+            Self::apply_submit_event(event, queued_per_sender, collector);
+        }
+        for metrics in results_tracker.drain_confirmed_metrics() {
+            collector.record_confirmed(metrics);
         }
     }
 
@@ -2009,5 +2574,214 @@ impl std::fmt::Debug for LoadRunner {
             .field("accounts", &self.accounts.len())
             .field("signers_cached", &self.signers.len())
             .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashMap,
+        sync::Arc,
+        time::Duration,
+    };
+
+    use alloy_primitives::{Address, Bytes, TxHash};
+    use tokio::sync::mpsc;
+
+    use super::{
+        LoadRunner, MetricsCollector, OpenLoopDrainState, PipelineStartConfig, ResultsTracker,
+        SignedBatch, SignedTransaction, SubmissionPipeline, SubmitEvent,
+    };
+    use crate::runner::SUBMIT_BATCH_QUEUE_BUFFER;
+
+    fn test_signed_batch(id: u64, from: Address) -> SignedBatch {
+        SignedBatch {
+            id,
+            attempt: 0,
+            txs: vec![SignedTransaction {
+                raw: Bytes::new(),
+                tx_hash: TxHash::repeat_byte((id % 0xff) as u8),
+                from,
+                nonce: id,
+            }],
+        }
+    }
+
+    #[tokio::test]
+    async fn enqueue_signed_while_draining_makes_progress_when_enqueue_is_backpressured() {
+        let sender = Address::repeat_byte(0x11);
+        let tracked_senders = vec![sender];
+        let results_tracker = ResultsTracker::new(&tracked_senders);
+        let mut collector = MetricsCollector::new();
+        let mut queued_per_sender = HashMap::from([(sender, 1_u64)]);
+
+        let (submit_event_tx, mut submit_event_rx) = mpsc::channel(1);
+        let mut submission_pipeline = SubmissionPipeline::start(
+            Arc::new(HashMap::new()),
+            Arc::new(HashMap::new()),
+            Arc::new(Vec::new()),
+            results_tracker.clone(),
+            submit_event_tx.clone(),
+            PipelineStartConfig { chain_id: 1, max_gas_price: u128::MAX, open_loop: false },
+        );
+
+        submission_pipeline.shutdown_and_join(Duration::from_secs(1)).await;
+
+        for batch_id in 0..SUBMIT_BATCH_QUEUE_BUFFER {
+            submission_pipeline
+                .enqueue_signed(test_signed_batch(batch_id as u64, sender))
+                .await
+                .expect("signed queue should accept up to capacity");
+        }
+
+        submit_event_tx
+            .send(SubmitEvent::Released(sender))
+            .await
+            .expect("event queue should accept first event");
+
+        let release_after_event_drain = async {
+            submit_event_tx
+                .send(SubmitEvent::Submitted(TxHash::repeat_byte(0xaa)))
+                .await
+                .expect("second send should unblock only after event drain");
+            let _ = submission_pipeline.close_and_fail_queued("test queue close").await;
+        };
+
+        let (enqueue_result, ()) = {
+            let mut drain_state = OpenLoopDrainState {
+                submit_event_rx: &mut submit_event_rx,
+                queued_per_sender: &mut queued_per_sender,
+                collector: &mut collector,
+                results_tracker: &results_tracker,
+            };
+            let enqueue_attempt = LoadRunner::enqueue_signed_while_draining(
+                &submission_pipeline,
+                test_signed_batch((SUBMIT_BATCH_QUEUE_BUFFER + 1) as u64, sender),
+                &mut drain_state,
+            );
+            tokio::time::timeout(
+                Duration::from_secs(2),
+                async { tokio::join!(enqueue_attempt, release_after_event_drain) },
+            )
+            .await
+            .expect("enqueue should complete once event drain unblocks it")
+        };
+
+        assert!(enqueue_result.is_err(), "enqueue should fail after queue is closed");
+        assert_eq!(queued_per_sender.get(&sender).copied(), Some(0));
+        assert_eq!(collector.submitted_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn headroom_gate_resumes_when_block_watcher_lowers_in_flight_without_submit_event() {
+        use std::time::Instant;
+
+        use super::super::results_tracker::{BlockObservation, SentTransaction};
+
+        let sender = Address::repeat_byte(0x22);
+        let results_tracker = ResultsTracker::new(&[sender]);
+        let mut collector = MetricsCollector::new();
+        let mut queued_per_sender = HashMap::new();
+        let (_submit_event_tx, mut submit_event_rx) = mpsc::channel::<SubmitEvent>(1);
+
+        let tx_hash = TxHash::repeat_byte(0x22);
+        results_tracker.sent_transactions(vec![SentTransaction { tx_hash, from: sender }]);
+        assert_eq!(results_tracker.total_in_flight(), 1);
+
+        let tracker_for_watcher = results_tracker.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            tracker_for_watcher.on_new_block_hashes(
+                BlockObservation { number: 1, observed_at: Instant::now() },
+                vec![tx_hash],
+            );
+        });
+
+        let mut drain_state = OpenLoopDrainState {
+            submit_event_rx: &mut submit_event_rx,
+            queued_per_sender: &mut queued_per_sender,
+            collector: &mut collector,
+            results_tracker: &results_tracker,
+        };
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(5),
+            LoadRunner::wait_for_inflight_headroom(1, None, &mut drain_state),
+        )
+        .await
+        .expect("gate must not hang when in-flight is released out-of-band");
+
+        assert!(result.is_ok(), "gate should resume once in-flight drops below target");
+        assert_eq!(results_tracker.total_in_flight(), 0);
+    }
+
+    #[tokio::test]
+    async fn headroom_gate_returns_immediately_when_pacing_disabled() {
+        use super::super::results_tracker::SentTransaction;
+
+        let sender = Address::repeat_byte(0x44);
+        let results_tracker = ResultsTracker::new(&[sender]);
+        let mut collector = MetricsCollector::new();
+        let mut queued_per_sender = HashMap::new();
+        let (_submit_event_tx, mut submit_event_rx) = mpsc::channel::<SubmitEvent>(1);
+
+        results_tracker.sent_transactions(vec![SentTransaction {
+            tx_hash: TxHash::repeat_byte(0x44),
+            from: sender,
+        }]);
+
+        let mut drain_state = OpenLoopDrainState {
+            submit_event_rx: &mut submit_event_rx,
+            queued_per_sender: &mut queued_per_sender,
+            collector: &mut collector,
+            results_tracker: &results_tracker,
+        };
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            LoadRunner::wait_for_inflight_headroom(0, None, &mut drain_state),
+        )
+        .await
+        .expect("target 0 must return without waiting even while in-flight is high");
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn headroom_gate_returns_ok_when_past_deadline() {
+        use std::time::Instant;
+
+        use super::super::results_tracker::SentTransaction;
+
+        let sender = Address::repeat_byte(0x55);
+        let results_tracker = ResultsTracker::new(&[sender]);
+        let mut collector = MetricsCollector::new();
+        let mut queued_per_sender = HashMap::new();
+        let (_submit_event_tx, mut submit_event_rx) = mpsc::channel::<SubmitEvent>(1);
+
+        results_tracker.sent_transactions(vec![SentTransaction {
+            tx_hash: TxHash::repeat_byte(0x55),
+            from: sender,
+        }]);
+
+        let mut drain_state = OpenLoopDrainState {
+            submit_event_rx: &mut submit_event_rx,
+            queued_per_sender: &mut queued_per_sender,
+            collector: &mut collector,
+            results_tracker: &results_tracker,
+        };
+
+        let past_deadline = Some(Instant::now() - Duration::from_secs(1));
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            LoadRunner::wait_for_inflight_headroom(1, past_deadline, &mut drain_state),
+        )
+        .await
+        .expect("gate must stop waiting once the load window deadline has passed");
+        assert!(result.is_ok(), "past-deadline gate returns Ok without failing closed");
+        assert_eq!(
+            results_tracker.total_in_flight(),
+            1,
+            "in-flight stays high; gate returns because window ended, not because it drained"
+        );
     }
 }

--- a/crates/infra/load-tests/src/runner/mod.rs
+++ b/crates/infra/load-tests/src/runner/mod.rs
@@ -26,7 +26,7 @@ pub use results_tracker::{
 mod submission;
 pub use submission::{
     BatchTxError, MAX_FEE_BASE_FEE_MULTIPLIER, MAX_SENDER_WORKER_COUNT, MAX_SIGNER_WORKER_COUNT,
-    PipelineQueue, PreparedBatch, PreparedTransaction, QueuedSubmitFailures,
+    PipelineQueue, PipelineStartConfig, PreparedBatch, PreparedTransaction, QueuedSubmitFailures,
     SENDER_WORKERS_PER_RPC, SIGNER_WORKERS_PER_RPC, SUBMIT_BATCH_QUEUE_BUFFER, SUBMIT_MAX_ATTEMPTS,
     SenderContext, SignedBatch, SignedTransaction, SignerContext, SubmissionPipeline, SubmitEvent,
 };

--- a/crates/infra/load-tests/src/runner/submission.rs
+++ b/crates/infra/load-tests/src/runner/submission.rs
@@ -241,6 +241,8 @@ pub struct SenderContext {
     pub results_tracker: ResultsTracker,
     /// Events emitted to the runner.
     pub submit_event_tx: mpsc::Sender<SubmitEvent>,
+    /// Whether nonce return is enabled for rejected signed transactions.
+    pub return_reserved_nonces: bool,
 }
 
 impl fmt::Debug for SenderContext {
@@ -248,6 +250,7 @@ impl fmt::Debug for SenderContext {
         f.debug_struct("SenderContext")
             .field("submission_batch_rpcs", &self.submission_batch_rpcs.len())
             .field("nonce_managers", &self.nonce_managers.len())
+            .field("return_reserved_nonces", &self.return_reserved_nonces)
             .finish_non_exhaustive()
     }
 }
@@ -255,11 +258,23 @@ impl fmt::Debug for SenderContext {
 /// Running submission pipeline.
 pub struct SubmissionPipeline {
     prepared_batch_tx: Option<mpsc::Sender<PreparedBatch>>,
+    signed_batch_tx: Option<mpsc::Sender<SignedBatch>>,
     prepared_queue: Arc<PipelineQueue<PreparedBatch>>,
     signed_queue: Arc<PipelineQueue<SignedBatch>>,
     shutdown: CancellationToken,
     signer_workers: Vec<JoinHandle<()>>,
     sender_workers: Vec<JoinHandle<()>>,
+}
+
+/// Runtime configuration for submission pipeline workers and signing.
+#[derive(Debug, Clone, Copy)]
+pub struct PipelineStartConfig {
+    /// Chain ID used for transaction signing.
+    pub chain_id: u64,
+    /// Maximum allowed gas price.
+    pub max_gas_price: u128,
+    /// Whether the runner is operating in open-loop mode.
+    pub open_loop: bool,
 }
 
 impl fmt::Debug for SubmissionPipeline {
@@ -281,8 +296,7 @@ impl SubmissionPipeline {
         submission_batch_rpcs: Arc<Vec<BatchRpcClient>>,
         results_tracker: ResultsTracker,
         submit_event_tx: mpsc::Sender<SubmitEvent>,
-        chain_id: u64,
-        max_gas_price: u128,
+        config: PipelineStartConfig,
     ) -> Self {
         let (prepared_batch_tx, prepared_batch_rx) =
             mpsc::channel::<PreparedBatch>(SUBMIT_BATCH_QUEUE_BUFFER);
@@ -292,9 +306,11 @@ impl SubmissionPipeline {
         let signed_queue = Arc::new(PipelineQueue::new(signed_batch_rx));
         let shutdown = CancellationToken::new();
         let signer_worker_count = Self::signer_worker_count(submission_batch_rpcs.len());
-        let sender_worker_count = Self::sender_worker_count(submission_batch_rpcs.len());
+        let sender_worker_count =
+            Self::sender_worker_count_for_mode(submission_batch_rpcs.len(), config.open_loop);
 
         info!(
+            open_loop = config.open_loop,
             signer_worker_count,
             sender_worker_count,
             submit_rpc_count = submission_batch_rpcs.len(),
@@ -307,8 +323,8 @@ impl SubmissionPipeline {
                 signers: Arc::clone(&signers),
                 nonce_managers: Arc::clone(&nonce_managers),
                 submit_event_tx: submit_event_tx.clone(),
-                chain_id,
-                max_gas_price,
+                chain_id: config.chain_id,
+                max_gas_price: config.max_gas_price,
                 signed_batch_tx: signed_batch_tx.clone(),
                 signed_queue: Arc::clone(&signed_queue),
             };
@@ -326,6 +342,7 @@ impl SubmissionPipeline {
                 nonce_managers: Arc::clone(&nonce_managers),
                 results_tracker: results_tracker.clone(),
                 submit_event_tx: submit_event_tx.clone(),
+                return_reserved_nonces: !config.open_loop,
             };
             let queue = Arc::clone(&signed_queue);
             let shutdown = shutdown.clone();
@@ -334,10 +351,9 @@ impl SubmissionPipeline {
             }));
         }
 
-        drop(signed_batch_tx);
-
         Self {
             prepared_batch_tx: Some(prepared_batch_tx),
+            signed_batch_tx: Some(signed_batch_tx),
             prepared_queue,
             signed_queue,
             shutdown,
@@ -356,6 +372,15 @@ impl SubmissionPipeline {
         (submission_rpc_count * SENDER_WORKERS_PER_RPC).clamp(1, MAX_SENDER_WORKER_COUNT)
     }
 
+    /// Returns sender worker count for a submission RPC count and mode.
+    pub fn sender_worker_count_for_mode(submission_rpc_count: usize, open_loop: bool) -> usize {
+        if open_loop {
+            MAX_SENDER_WORKER_COUNT
+        } else {
+            Self::sender_worker_count(submission_rpc_count)
+        }
+    }
+
     /// Enqueues a prepared batch for signing.
     pub async fn enqueue_prepared(
         &self,
@@ -370,6 +395,22 @@ impl SubmissionPipeline {
             Ok(()) => Ok(()),
             Err(e) => {
                 self.prepared_queue.pending_batches.fetch_sub(1, Ordering::SeqCst);
+                Err(e.0)
+            }
+        }
+    }
+
+    /// Enqueues a signed batch for sending.
+    pub async fn enqueue_signed(&self, batch: SignedBatch) -> std::result::Result<(), SignedBatch> {
+        let Some(tx) = &self.signed_batch_tx else {
+            return Err(batch);
+        };
+
+        self.signed_queue.pending_batches.fetch_add(1, Ordering::SeqCst);
+        match tx.send(batch).await {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                self.signed_queue.pending_batches.fetch_sub(1, Ordering::SeqCst);
                 Err(e.0)
             }
         }
@@ -789,6 +830,10 @@ impl SubmissionPipeline {
     }
 
     async fn return_signed_nonce(ctx: &SenderContext, signed: &SignedTransaction) {
+        if !ctx.return_reserved_nonces {
+            return;
+        }
+
         let Some(nonce_manager) = ctx.nonce_managers.get(&signed.from) else {
             warn!(from = %signed.from, nonce = signed.nonce, "no nonce manager for nonce return");
             return;
@@ -1027,6 +1072,7 @@ mod tests {
 
         let pipeline = SubmissionPipeline {
             prepared_batch_tx: None,
+            signed_batch_tx: None,
             prepared_queue,
             signed_queue,
             shutdown: CancellationToken::new(),

--- a/crates/infra/load-tests/src/workload/mod.rs
+++ b/crates/infra/load-tests/src/workload/mod.rs
@@ -11,9 +11,9 @@ pub use key_stream::KeyStream;
 
 mod payloads;
 pub use payloads::{
-    AerodromeClPayload, B20TransferPayload, CalldataPayload, Erc20Payload, OsakaPayload, Payload,
-    PrecompileLooper, PrecompilePayload, StoragePayload, TransferPayload, UniswapV3Payload,
-    parse_precompile_id,
+    AerodromeClPayload, B20EvmTransferPayload, B20TransferPayload, CalldataPayload, Erc20Payload,
+    OsakaPayload, Payload, PrecompileLooper, PrecompilePayload, StoragePayload, TransferPayload,
+    UniswapV3Payload, parse_precompile_id,
 };
 pub(crate) use payloads::{b20_salt_for, b20_token_for};
 

--- a/crates/infra/load-tests/src/workload/payloads/b20_evm.rs
+++ b/crates/infra/load-tests/src/workload/payloads/b20_evm.rs
@@ -1,0 +1,90 @@
+//! B-20 EVM contract token transfer payload for load testing.
+
+use alloy_network::TransactionBuilder;
+use alloy_primitives::{Address, Bytes, U256};
+use alloy_rpc_types::TransactionRequest;
+use alloy_sol_types::SolCall;
+use base_common_precompiles::IB20;
+
+use super::Payload;
+use crate::workload::SeededRng;
+
+/// Generates B-20 EVM contract token transfer transactions against a fixed pre-deployed contract.
+///
+/// Unlike the precompile variant, every sender transfers from the same shared token contract that
+/// was deployed and funded at the DB level before the benchmark run. No per-run setup is needed.
+#[derive(Debug, Clone)]
+pub struct B20EvmTransferPayload {
+    /// Pre-deployed EVM token contract address.
+    pub contract: Address,
+    /// Minimum transfer amount.
+    pub min_amount: U256,
+    /// Maximum transfer amount.
+    pub max_amount: U256,
+}
+
+impl B20EvmTransferPayload {
+    /// Creates a new payload bound to a pre-deployed EVM token contract.
+    pub const fn new(contract: Address, min_amount: U256, max_amount: U256) -> Self {
+        Self { contract, min_amount, max_amount }
+    }
+}
+
+impl Payload for B20EvmTransferPayload {
+    fn name(&self) -> &'static str {
+        "b20_evm"
+    }
+
+    fn uses_runner_recipient(&self) -> bool {
+        true
+    }
+
+    fn generate(&self, rng: &mut SeededRng, _from: Address, to: Address) -> TransactionRequest {
+        let amount = if self.min_amount == self.max_amount {
+            self.min_amount
+        } else {
+            let min: u128 = self.min_amount.try_into().expect("b20_evm min_amount must fit in u128");
+            let max: u128 = self.max_amount.try_into().expect("b20_evm max_amount must fit in u128");
+            U256::from(rng.gen_range(min..=max))
+        };
+
+        let call = IB20::transferCall { to, amount };
+
+        TransactionRequest::default()
+            .with_to(self.contract)
+            .with_input(Bytes::from(call.abi_encode()))
+            .with_gas_limit(100_000)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{address, U256};
+
+    use super::*;
+    use crate::workload::SeededRng;
+
+    #[test]
+    fn generate_targets_fixed_contract() {
+        let contract = address!("b200000000000000000000000000000000000ee2");
+        let sender = address!("00000000000000000000000000000000000000a1");
+        let recipient = address!("00000000000000000000000000000000000000b2");
+        let payload =
+            B20EvmTransferPayload::new(contract, U256::from(1000), U256::from(1000));
+        let mut rng = SeededRng::new(7);
+
+        let tx = payload.generate(&mut rng, sender, recipient);
+
+        assert_eq!(
+            tx.to,
+            Some(alloy_primitives::TxKind::Call(contract)),
+            "transfer must target the fixed EVM contract, not the sender"
+        );
+
+        let expected = IB20::transferCall { to: recipient, amount: U256::from(1000) };
+        assert_eq!(
+            tx.input.input().expect("input set").as_ref(),
+            expected.abi_encode().as_slice(),
+        );
+    }
+}

--- a/crates/infra/load-tests/src/workload/payloads/mod.rs
+++ b/crates/infra/load-tests/src/workload/payloads/mod.rs
@@ -33,6 +33,9 @@ mod b20;
 pub use b20::B20TransferPayload;
 pub(crate) use b20::{b20_salt_for, b20_token_for};
 
+mod b20_evm;
+pub use b20_evm::B20EvmTransferPayload;
+
 mod osaka;
 pub use osaka::OsakaPayload;
 


### PR DESCRIPTION
## Summary

Umbrella PR for the **open-loop load-testing feature** used to benchmark builder throughput (ETH vs. B20 token transfers). It is intentionally large and **will be split into smaller reviewable PRs** — opening as a draft to surface the full feature set for discussion first.

## What's included

- **Open-loop load generation** (`run_open_loop`): all transactions are pre-signed and fired without waiting for confirmations, so the builder is what's measured, not client submission speed. The measurement clock is **reset after the pre-signing phase** so the (potentially long) pre-sign step is excluded from the run window.
- **B20 payloads**: native-precompile and deployed-EVM-bytecode (`B20EvmTransferPayload`) token-transfer workloads, plus **fresh-recipient** support (send to brand-new vs. existing accounts).
- **Precompile-exclude env toggle** (`crates/common/precompiles`): run the same token via the native precompile or its EVM bytecode.
- **32MB flashblock decode cap** (`crates/common/flashblocks`).

## Planned split

1. Open-loop mode + pre-sign measurement-clock fix
2. B20 native + EVM-bytecode payloads
3. Fresh-recipient support
4. Precompile-exclude toggle
5. Flashblock decode cap

## Notes

- Ported onto `main`; builds (`cargo build --release --bin base-load-tester`) and `cargo clippy -p base-load-tests` are clean.
- Companion base-bench changes (benchmark harness) are in base/benchmark#204 (report) and base/benchmark#205 (saturated-window GPS metric).
- The `state-populate` state-seeding tool used alongside this is already up as #4045.