### PR TITLE
refactor(challenger): simplify submitter

### DIFF
--- a/crates/proof/challenge/src/submitter.rs
+++ b/crates/proof/challenge/src/submitter.rs
@@ -10,7 +10,7 @@
 
 use std::time::Instant;
 
-use alloy_primitives::{Address, B256, Bytes, U256};
+use alloy_primitives::{Address, B256, Bytes};
 use base_proof_contracts::{encode_challenge_calldata, encode_nullify_calldata};
 use base_tx_manager::{TxCandidate, TxManager};
 use tracing::{debug, info};
@@ -80,7 +80,6 @@ impl<T: TxManager> ChallengeSubmitter<T> {
         let candidate = TxCandidate {
             tx_data: calldata,
             to: Some(game_address),
-            value: U256::ZERO,
             ..Default::default()
         };
 
@@ -89,7 +88,12 @@ impl<T: TxManager> ChallengeSubmitter<T> {
             "sending tx candidate",
         );
 
-        intent.record_submitted();
+        match intent {
+            DisputeIntent::Nullify => ChallengerMetrics::nullify_tx_submitted_total().increment(1),
+            DisputeIntent::Challenge => {
+                ChallengerMetrics::challenge_tx_submitted_total().increment(1)
+            }
+        }
         let start = Instant::now();
         let result = self.tx_manager.send(candidate).await;
         let latency = start.elapsed();
@@ -99,8 +103,16 @@ impl<T: TxManager> ChallengeSubmitter<T> {
             Ok(_) => (ChallengerMetrics::STATUS_REVERTED, false),
             Err(_) => (ChallengerMetrics::STATUS_ERROR, false),
         };
-        intent.record_outcome(status_label);
-        intent.record_latency(latency.as_secs_f64());
+        match intent {
+            DisputeIntent::Nullify => {
+                ChallengerMetrics::nullify_tx_outcome_total(status_label).increment(1);
+                ChallengerMetrics::nullify_tx_latency_seconds().record(latency.as_secs_f64());
+            }
+            DisputeIntent::Challenge => {
+                ChallengerMetrics::challenge_tx_outcome_total(status_label).increment(1);
+                ChallengerMetrics::challenge_tx_latency_seconds().record(latency.as_secs_f64());
+            }
+        }
 
         let receipt = result?;
         let tx_hash = receipt.transaction_hash;
@@ -123,7 +135,6 @@ impl<T: TxManager> ChallengeSubmitter<T> {
         let candidate = TxCandidate {
             tx_data: calldata,
             to: Some(to),
-            value: U256::ZERO,
             ..Default::default()
         };
 
@@ -148,37 +159,12 @@ impl<T: TxManager> ChallengeSubmitter<T> {
     }
 }
 
-/// Metrics recording helpers for [`DisputeIntent`].
 impl DisputeIntent {
     /// Returns a human-readable label for logging and metrics.
     pub const fn label(&self) -> &'static str {
         match self {
             Self::Nullify => "nullify",
             Self::Challenge => "challenge",
-        }
-    }
-
-    /// Records that a dispute transaction has been submitted.
-    pub fn record_submitted(&self) {
-        match self {
-            Self::Nullify => ChallengerMetrics::nullify_tx_submitted_total().increment(1),
-            Self::Challenge => ChallengerMetrics::challenge_tx_submitted_total().increment(1),
-        }
-    }
-
-    /// Records the outcome (success, reverted, error) of a dispute transaction.
-    pub fn record_outcome(&self, status: &'static str) {
-        match self {
-            Self::Nullify => ChallengerMetrics::nullify_tx_outcome_total(status).increment(1),
-            Self::Challenge => ChallengerMetrics::challenge_tx_outcome_total(status).increment(1),
-        }
-    }
-
-    /// Records the latency of a dispute transaction.
-    pub fn record_latency(&self, seconds: f64) {
-        match self {
-            Self::Nullify => ChallengerMetrics::nullify_tx_latency_seconds().record(seconds),
-            Self::Challenge => ChallengerMetrics::challenge_tx_latency_seconds().record(seconds),
         }
     }
 }
@@ -194,22 +180,24 @@ mod tests {
     use crate::test_utils::{MockTxManager, receipt_with_status};
 
     #[tokio::test]
-    async fn submit_dispute_nullify_success_returns_tx_hash() {
-        let tx_hash = B256::repeat_byte(0xAA);
-        let mock = MockTxManager::new(Ok(receipt_with_status(true, tx_hash)));
-        let submitter = ChallengeSubmitter::new(mock);
+    async fn submit_dispute_success_returns_tx_hash() {
+        for intent in [DisputeIntent::Nullify, DisputeIntent::Challenge] {
+            let tx_hash = B256::repeat_byte(0xAA);
+            let mock = MockTxManager::new(Ok(receipt_with_status(true, tx_hash)));
+            let submitter = ChallengeSubmitter::new(mock);
 
-        let result = submitter
-            .submit_dispute(
-                Address::repeat_byte(0x01),
-                Bytes::from(vec![0x00, 0x01]),
-                42,
-                B256::repeat_byte(0xFF),
-                DisputeIntent::Nullify,
-            )
-            .await;
+            let result = submitter
+                .submit_dispute(
+                    Address::repeat_byte(0x01),
+                    Bytes::from(vec![0x00, 0x01]),
+                    42,
+                    B256::repeat_byte(0xFF),
+                    intent,
+                )
+                .await;
 
-        assert_eq!(result.unwrap(), tx_hash);
+            assert_eq!(result.unwrap(), tx_hash);
+        }
     }
 
     #[tokio::test]
@@ -280,24 +268,5 @@ mod tests {
             matches!(err, ChallengeSubmitError::KnownRevert(KnownRevert::L1OriginTooOld)),
             "expected L1OriginTooOld, got {err:?}",
         );
-    }
-
-    #[tokio::test]
-    async fn submit_dispute_challenge_success_returns_tx_hash() {
-        let tx_hash = B256::repeat_byte(0xCC);
-        let mock = MockTxManager::new(Ok(receipt_with_status(true, tx_hash)));
-        let submitter = ChallengeSubmitter::new(mock);
-
-        let result = submitter
-            .submit_dispute(
-                Address::repeat_byte(0x01),
-                Bytes::from(vec![0x01, 0xDE, 0xAD]),
-                5,
-                B256::repeat_byte(0xAB),
-                DisputeIntent::Challenge,
-            )
-            .await;
-
-        assert_eq!(result.unwrap(), tx_hash);
     }
 }

--- a/crates/proof/challenge/src/submitter.rs
+++ b/crates/proof/challenge/src/submitter.rs
@@ -77,11 +77,8 @@ impl<T: TxManager> ChallengeSubmitter<T> {
             "submitting dispute transaction"
         );
 
-        let candidate = TxCandidate {
-            tx_data: calldata,
-            to: Some(game_address),
-            ..Default::default()
-        };
+        let candidate =
+            TxCandidate { tx_data: calldata, to: Some(game_address), ..Default::default() };
 
         debug!(
             tx = ?candidate,
@@ -132,11 +129,7 @@ impl<T: TxManager> ChallengeSubmitter<T> {
         to: Address,
         calldata: Bytes,
     ) -> Result<B256, ChallengeSubmitError> {
-        let candidate = TxCandidate {
-            tx_data: calldata,
-            to: Some(to),
-            ..Default::default()
-        };
+        let candidate = TxCandidate { tx_data: calldata, to: Some(to), ..Default::default() };
 
         info!(
             game = %game_address,


### PR DESCRIPTION
### What changed? Why?

- Simplified challenge transaction construction and dispute metrics handling without changing behavior.
- Kept `DisputeIntent` focused on selecting the submitted action.
- Consolidated successful submission coverage for both dispute intents.

### Notes to reviewers

- Zero-valued transaction fields use `TxCandidate` defaults; metrics remain emitted for each intent.

### How has it been tested?

- Not run (not requested).