### PR TITLE
fix(challenger): cover shared implementation cache

### DIFF
--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -272,6 +272,8 @@ pub struct MockAggregateVerifier {
     pub anchor_state_registry_reads: Mutex<Vec<Address>>,
     /// Addresses passed to `delayed_weth`, used by tests that assert cached reads.
     pub delayed_weth_reads: Mutex<Vec<Address>>,
+    /// Addresses passed to `read_intermediate_block_interval`, used by cache tests.
+    pub intermediate_block_interval_reads: Mutex<Vec<Address>>,
 }
 
 impl MockAggregateVerifier {
@@ -287,6 +289,7 @@ impl MockAggregateVerifier {
             game_over_reads: Mutex::new(Vec::new()),
             anchor_state_registry_reads: Mutex::new(Vec::new()),
             delayed_weth_reads: Mutex::new(Vec::new()),
+            intermediate_block_interval_reads: Mutex::new(Vec::new()),
         }
     }
 
@@ -378,8 +381,9 @@ impl AggregateVerifierClient for MockAggregateVerifier {
 
     async fn read_intermediate_block_interval(
         &self,
-        _impl_address: Address,
+        impl_address: Address,
     ) -> Result<u64, ContractError> {
+        self.intermediate_block_interval_reads.lock().unwrap().push(impl_address);
         Ok(5)
     }
 
@@ -1100,7 +1104,11 @@ mod tests {
 
         let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
 
-        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
+        let mut scanner = GameScanner::new(
+            factory,
+            Arc::clone(&verifier) as Arc<dyn AggregateVerifierClient>,
+            mock_anchor_registry(Address::ZERO),
+        );
 
         let candidates = scanner.scan().await.unwrap();
 
@@ -1121,6 +1129,10 @@ mod tests {
         assert_eq!(candidates[3].index, 4);
         assert_eq!(candidates[3].factory.game_type, 1);
         assert_eq!(candidates[3].info.l2_block_number, 400);
+        assert_eq!(
+            verifier.intermediate_block_interval_reads.lock().unwrap().as_slice(),
+            &[Address::repeat_byte(0x11)],
+        );
     }
 
     /// Dual-proof games (TEE + ZK, no challenge) are now candidates.


### PR DESCRIPTION
### What changed? Why?

Added call recording to `MockAggregateVerifier` and asserted the mixed-game scanner test reads `INTERMEDIATE_BLOCK_INTERVAL` once for game types `1` and `99`, which share one implementation. This prevents regressions that key the cache by game type as well as implementation address.

### Notes to reviewers

The scanner implementation is unchanged; this is targeted regression coverage for its implementation-address cache key.

### How has it been tested?

`cargo test -p base-challenger test_scan_happy_path --lib`