### PR TITLE
feat(telemetry): rate limit P2P reachability requests by client IP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10379,7 +10379,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand 0.8.6",
+ "rand 0.8.7",
  "smallvec",
  "spinning_top",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5026,6 +5026,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-http-utils"
+version = "0.0.0"
+dependencies = [
+ "http 1.4.2",
+ "ipnet",
+ "tracing",
+]
+
+[[package]]
 name = "base-jwt"
 version = "0.0.0"
 dependencies = [
@@ -6457,7 +6466,10 @@ dependencies = [
  "async-trait",
  "axum 0.8.9",
  "base-health",
+ "base-http-utils",
  "clap",
+ "governor",
+ "ipnet",
  "reqwest 0.13.4",
  "reth-ecies",
  "reth-eth-wire",
@@ -10332,6 +10344,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "governor"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0746aa765db78b521451ef74221663b57ba595bf83f75d0ce23cc09447c8139f"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.8.6",
+ "smallvec",
+ "spinning_top",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13520,6 +13553,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
 name = "no_std_strings"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13549,6 +13588,12 @@ checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "notify"
@@ -22151,6 +22196,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24691,11 +24745,11 @@ version = "0.0.0"
 dependencies = [
  "axum 0.8.9",
  "backoff",
+ "base-http-utils",
  "base-metrics",
  "brotli",
  "futures",
  "http 1.4.2",
- "ipnet",
  "metrics",
  "reqwest 0.13.4",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3120,6 +3120,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-client-ip"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8ba1af5b620232acf37f2eb6d22151ea465491e0b4c25f552d1990f64ec5a67"
+dependencies = [
+ "axum 0.8.9",
+ "client-ip",
+]
+
+[[package]]
 name = "axum-core"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6465,6 +6475,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum 0.8.9",
+ "axum-client-ip",
  "base-health",
  "base-http-utils",
  "clap",
@@ -7809,6 +7820,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "client-ip"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39d2056bf065c8b4bce5a8898d40e175211ff4410add2a84d695845d3937c729"
+dependencies = [
+ "http 1.4.2",
+]
 
 [[package]]
 name = "clipboard-win"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3120,16 +3120,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum-client-ip"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8ba1af5b620232acf37f2eb6d22151ea465491e0b4c25f552d1990f64ec5a67"
-dependencies = [
- "axum 0.8.9",
- "client-ip",
-]
-
-[[package]]
 name = "axum-core"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5041,6 +5031,7 @@ version = "0.0.0"
 dependencies = [
  "http 1.4.2",
  "ipnet",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -6475,12 +6466,12 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum 0.8.9",
- "axum-client-ip",
  "base-health",
  "base-http-utils",
  "clap",
  "governor",
  "ipnet",
+ "mockall",
  "reqwest 0.13.4",
  "reth-ecies",
  "reth-eth-wire",
@@ -7820,15 +7811,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "client-ip"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39d2056bf065c8b4bce5a8898d40e175211ff4410add2a84d695845d3937c729"
-dependencies = [
- "http 1.4.2",
-]
 
 [[package]]
 name = "clipboard-win"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,6 +218,7 @@ base-execution-eip8130 = { path = "crates/execution/eip8130", default-features =
 # Infra
 basectl-cli = { path = "crates/infra/basectl" }
 base-sidecrush = { path = "crates/infra/sidecrush" }
+base-http-utils = { path = "crates/infra/utilities" }
 audit-archiver-lib = { path = "crates/infra/audit" }
 base-snark-e2e = { path = "crates/infra/snark-e2e" }
 base-load-tests = { path = "crates/infra/load-tests" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -489,6 +489,7 @@ http-body = "1.0"
 hyper-util = "0.1.11"
 http-body-util = "0.1.3"
 axum = { version = "0.8.3", default-features = false }
+axum-client-ip = { version = "1.3.1", default-features = false }
 tower-http = { version = "0.6", features = ["limit", "timeout"] }
 
 # p2p

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -489,7 +489,6 @@ http-body = "1.0"
 hyper-util = "0.1.11"
 http-body-util = "0.1.3"
 axum = { version = "0.8.3", default-features = false }
-axum-client-ip = { version = "1.3.1", default-features = false }
 tower-http = { version = "0.6", features = ["limit", "timeout"] }
 
 # p2p

--- a/bin/base-telemetry/README.md
+++ b/bin/base-telemetry/README.md
@@ -10,6 +10,11 @@ base-telemetry --listen-addr 0.0.0.0:8080
 
 The listen address can also be configured with `BASE_TELEMETRY_LISTEN_ADDR`.
 
+Requests are rate limited to 2 per minute per client IP. The client IP is
+read from the `X-Forwarded-For` header only when the direct peer is inside a
+CIDR listed in `BASE_TELEMETRY_TRUSTED_PROXY_CIDRS` (default empty);
+otherwise the peer socket address is used.
+
 The service exposes health routes and an on-demand execution-layer
 reachability check:
 

--- a/bin/base-telemetry/README.md
+++ b/bin/base-telemetry/README.md
@@ -5,15 +5,17 @@ Base telemetry backend service.
 ## Usage
 
 ```sh
-base-telemetry --listen-addr 0.0.0.0:8080
+base-telemetry --listen-addr 0.0.0.0:8080 --p2p-probe-requests-per-minute 2
 ```
 
-The listen address can also be configured with `BASE_TELEMETRY_LISTEN_ADDR`.
+The listen address and P2P probe rate limit can also be configured with
+`BASE_TELEMETRY_LISTEN_ADDR` and
+`BASE_TELEMETRY_P2P_PROBE_REQUESTS_PER_MINUTE`.
 
-Requests are rate limited to 2 per minute per client IP. The client IP is
-read from the `X-Forwarded-For` header only when the direct peer is inside a
-CIDR listed in `BASE_TELEMETRY_TRUSTED_PROXY_CIDRS` (default empty);
-otherwise the peer socket address is used.
+P2P probe requests default to 2 per minute per client IP. The client IP is read
+from the `X-Forwarded-For` header only when the direct peer is inside a CIDR
+listed in `BASE_TELEMETRY_TRUSTED_PROXY_CIDRS` (default empty); otherwise the
+peer socket address is used.
 
 The service exposes health routes and an on-demand execution-layer
 reachability check:
@@ -28,9 +30,8 @@ curl https://telemetry.example/v1/p2p/reachability/el \
 
 The `enode://` URL is printed on node startup and returned by
 `admin_nodeInfo`. Replace `YOUR_NODE_IP` with the node's advertised literal
-`IPv4` or bracketed `IPv6` address. The caller may be the node, an operator, or a
-monitoring system; the service probes the IP and TCP port in the supplied
-enode, including private addresses reachable from the service's network.
+public `IPv4` address. The caller may be the node, an operator, or a monitoring
+system; the service probes the IP and TCP port in the supplied enode.
 
 ## Deployment boundary
 

--- a/bin/basectl/README.md
+++ b/bin/basectl/README.md
@@ -141,11 +141,12 @@ Read-only p2p commands also support:
 | `--json` | Emit humanized JSON instead of the pretty table output.                                                                      |
 | `--raw`  | With `--json`, emit raw nested RPC payloads instead of the humanized summary. Errors at parse time if used without `--json`. |
 
-`p2p reachability` requires `--telemetry-url <URL>` or
-`BASECTL_TELEMETRY_URL` and supports `--json`. It accepts an explicit enode and
-does not require EL or CL JSON-RPC access. It exits non-zero when the probe
-completes with any outcome other than `reachable`, so scripts can rely on the
-exit code.
+`p2p reachability` uses the selected config's L2 RPC to detect the live chain,
+then routes the request to the hosted Base mainnet or Base Sepolia telemetry
+service. The default config remains mainnet. Unsupported chains and failed
+network detection return an error. The command supports `--json` and exits
+non-zero when the probe completes with any outcome other than `reachable`, so
+scripts can rely on the exit code.
 
 The returned `stage` shows where the check stopped:
 
@@ -313,19 +314,19 @@ built-in preset, optional YAML override, or explicit config path through global
 specific node when the config points at shared/public endpoints.
 
 Checks include declared network vs. live chain ID, p2p endpoint context,
-canonical bootnode config context, advertised endpoint sanity, optional
+canonical bootnode config context, advertised endpoint sanity,
 telemetry-backed external EL reachability, EL/CL peer counts, EL head vs. public
 tip, safe-head recency, optional `reth.toml` headers/bodies limits,
 consensus-node RPC presence, and L1 RPC reachability. Doctor does not mutate
-node state. Without `--telemetry-url`, advertised endpoint checks remain limited
-to local config and exposed RPC metadata.
+node state. The effective `--el-rpc` chain ID selects the hosted Base mainnet or
+Base Sepolia telemetry service; the check is skipped when detection fails or
+the chain is unsupported.
 
 | Flag                                  | Description                                                                                                                                      |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `--el-rpc <URL>`                      | Override the execution-layer RPC URL used for local-node checks. Defaults to the selected config's `rpc` field.                                  |
 | `--cl-rpc <URL>`                      | Override the consensus-node RPC URL. If omitted and the selected config has no `consensus_node_rpc`, CL-dependent checks are skipped with hints. |
 | `--reth-config <PATH>`                | Path to the local `reth.toml` file. If omitted, the reth limits check is skipped.                                                                |
-| `--telemetry-url <URL>`               | Base telemetry service used to probe the enode returned by `admin_nodeInfo`. May also be set with `BASECTL_TELEMETRY_URL`.                       |
 | `--peer-warn-threshold <COUNT>`       | Connected peer count below which EL/CL peer checks warn. Default `5`.                                                                            |
 | `--head-lag-warn-blocks <BLOCKS>`     | EL head lag behind the public tip above which doctor warns. Default `10`.                                                                        |
 | `--head-lag-fail-blocks <BLOCKS>`     | EL head lag behind the public tip above which doctor fails. Default `20`.                                                                        |
@@ -456,7 +457,7 @@ basectl -c sepolia p2p info --el-rpc https://your-el.example/ --cl-rpc https://y
 basectl -c sepolia p2p peers --el-rpc https://your-el.example/ --cl-rpc https://your-cl.example/ --json | jq '{el: .el | length, cl: .cl | length}'
 
 # Probe an explicit EL enode from the telemetry service's network
-basectl p2p reachability enode://<node-id>@203.0.113.10:30303 --telemetry-url http://127.0.0.1:8080 --json
+basectl -c sepolia p2p reachability enode://<node-id>@203.0.113.10:30303 --json
 
 # Add an execution-layer peer after confirmation
 basectl -c sepolia p2p add-peer enode://<node-id>@203.0.113.10:30303 --el-rpc https://your-el.example/
@@ -539,7 +540,7 @@ basectl -c mainnet doctor
 basectl -c mainnet doctor --el-rpc https://your-el.example/ --cl-rpc https://your-cl.example/
 
 # Include an external EL reachability probe
-basectl -c mainnet doctor --el-rpc https://your-el.example/ --telemetry-url http://127.0.0.1:8080
+basectl -c mainnet doctor --el-rpc https://your-el.example/
 
 # Include local reth headers/bodies limit validation and JSON output
 basectl -c mainnet doctor --el-rpc https://your-el.example/ --cl-rpc https://your-cl.example/ --reth-config /etc/reth/reth.toml --json

--- a/bin/basectl/src/cli.rs
+++ b/bin/basectl/src/cli.rs
@@ -647,25 +647,6 @@ mod tests {
     #[test]
     fn p2p_reachability_parses() {
         assert!(try_parse(["basectl", "p2p", "reachability", "enode://example", "--json"]).is_ok());
-        assert!(
-            try_parse([
-                "basectl",
-                "p2p",
-                "reachability",
-                "enode://example",
-                "--telemetry-url",
-                "http://127.0.0.1:8080",
-            ])
-            .is_err()
-        );
-    }
-
-    #[test]
-    fn doctor_rejects_removed_telemetry_url_flag() {
-        assert!(try_parse(["basectl", "doctor"]).is_ok());
-        assert!(
-            try_parse(["basectl", "doctor", "--telemetry-url", "http://127.0.0.1:8080",]).is_err()
-        );
     }
 
     #[test]

--- a/bin/basectl/src/cli.rs
+++ b/bin/basectl/src/cli.rs
@@ -137,9 +137,6 @@ pub(crate) struct DoctorArgs {
     /// Path to the local `reth.toml` file.
     #[arg(long = "reth-config", value_name = "PATH")]
     pub(crate) reth_config: Option<PathBuf>,
-    /// Base telemetry service URL used for external EL reachability checks.
-    #[arg(long = "telemetry-url", env = "BASECTL_TELEMETRY_URL", value_name = "URL")]
-    pub(crate) telemetry_url: Option<Url>,
     /// Connected peer count below which peer checks warn.
     #[arg(long = "peer-warn-threshold", value_name = "COUNT", default_value_t = 5)]
     pub(crate) peer_warn_threshold: u32,
@@ -277,9 +274,6 @@ pub(crate) enum P2pCommands {
         /// Execution-layer `enode://` URL to probe.
         #[arg(value_name = "ENODE")]
         enode: String,
-        /// Base telemetry service URL.
-        #[arg(long = "telemetry-url", env = "BASECTL_TELEMETRY_URL", value_name = "URL")]
-        telemetry_url: Url,
         /// Emit the telemetry response as JSON.
         #[arg(long)]
         json: bool,
@@ -652,6 +646,7 @@ mod tests {
 
     #[test]
     fn p2p_reachability_parses() {
+        assert!(try_parse(["basectl", "p2p", "reachability", "enode://example", "--json"]).is_ok());
         assert!(
             try_parse([
                 "basectl",
@@ -660,9 +655,16 @@ mod tests {
                 "enode://example",
                 "--telemetry-url",
                 "http://127.0.0.1:8080",
-                "--json",
             ])
-            .is_ok()
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn doctor_rejects_removed_telemetry_url_flag() {
+        assert!(try_parse(["basectl", "doctor"]).is_ok());
+        assert!(
+            try_parse(["basectl", "doctor", "--telemetry-url", "http://127.0.0.1:8080",]).is_err()
         );
     }
 

--- a/bin/basectl/src/doctor.rs
+++ b/bin/basectl/src/doctor.rs
@@ -24,7 +24,6 @@ pub(crate) async fn run(config: MonitoringConfig, args: DoctorArgs) -> Result<Co
         el_rpc: args.el_rpc.unwrap_or_else(|| config.rpc.clone()),
         cl_rpc: args.cl_rpc.or_else(|| config.consensus_node_rpc.clone()),
         reth_config: args.reth_config,
-        telemetry_url: args.telemetry_url,
         thresholds: DoctorThresholds {
             peer_warn_threshold: args.peer_warn_threshold,
             head_lag_warn_blocks: args.head_lag_warn_blocks,
@@ -304,7 +303,6 @@ mod tests {
             el_rpc: Some(Url::parse("http://127.0.0.1:8545").unwrap()),
             cl_rpc: None,
             reth_config: Option::<PathBuf>::None,
-            telemetry_url: None,
             peer_warn_threshold: 5,
             head_lag_warn_blocks: 10,
             head_lag_fail_blocks: 20,

--- a/bin/basectl/src/doctor.rs
+++ b/bin/basectl/src/doctor.rs
@@ -204,10 +204,7 @@ mod tests {
     use serde_json::json;
     use url::Url;
 
-    use super::{
-        ANSI_CYAN, ANSI_GREEN, ANSI_RED, ANSI_YELLOW, colored_status, status_sort_key,
-        validate_thresholds, write_check,
-    };
+    use super::{ANSI_YELLOW, status_sort_key, validate_thresholds, write_check};
     use crate::cli::DoctorArgs;
 
     #[test]
@@ -255,14 +252,6 @@ mod tests {
                 DoctorStatus::Pass,
             ],
         );
-    }
-
-    #[test]
-    fn pretty_status_labels_are_colored() {
-        assert_eq!(colored_status(DoctorStatus::Fail), format!("{ANSI_RED}FAIL\x1b[0m"));
-        assert_eq!(colored_status(DoctorStatus::Warn), format!("{ANSI_YELLOW}WARN\x1b[0m"));
-        assert_eq!(colored_status(DoctorStatus::Info), format!("{ANSI_CYAN}INFO\x1b[0m"));
-        assert_eq!(colored_status(DoctorStatus::Pass), format!("{ANSI_GREEN}PASS\x1b[0m"));
     }
 
     #[test]

--- a/bin/basectl/src/p2p.rs
+++ b/bin/basectl/src/p2p.rs
@@ -2,14 +2,14 @@
 
 use std::io::{self, Write};
 
-use anyhow::Result;
+use anyhow::{Context, Result, anyhow};
 use base_consensus_peers::BootNode;
 use basectl_cli::{
     ElReachabilityOutcome, JsonOutput, KeyValueTable, MonitoringConfig, P2pCommandError,
     P2pInfoJson, P2pInfoTable, P2pTargetError, PeerListReport, PeerSummary, TelemetryClient,
     add_peer, ban_el_peer, ban_peer, connect_peer, disconnect_peer, el_peer_is_trusted,
-    fetch_connected_peers, fetch_info, fetch_raw_info, fetch_raw_peers, list_banned_peers,
-    remove_peer, unban_el_peer, unban_peer,
+    fetch_connected_peers, fetch_info, fetch_l2_chain_id, fetch_raw_info, fetch_raw_peers,
+    list_banned_peers, remove_peer, unban_el_peer, unban_peer,
 };
 use serde::Serialize;
 use url::Url;
@@ -23,8 +23,9 @@ use crate::{
 /// Runs the `basectl p2p` command group.
 pub(crate) async fn run(config: &str, command: P2pCommands) -> Result<CommandOutcome> {
     match command {
-        P2pCommands::Reachability { enode, telemetry_url, json } => {
-            run_reachability(&enode, telemetry_url, json).await
+        P2pCommands::Reachability { enode, json } => {
+            let config = MonitoringConfig::load(config).await?;
+            run_reachability(&config, &enode, json).await
         }
         other => {
             let config = MonitoringConfig::load(config).await?;
@@ -47,7 +48,20 @@ pub(crate) async fn run(config: &str, command: P2pCommands) -> Result<CommandOut
 
 /// Runs `basectl p2p reachability`, exiting non-zero when the probe completed
 /// but the node was not reachable.
-async fn run_reachability(enode: &str, telemetry_url: Url, json: bool) -> Result<CommandOutcome> {
+async fn run_reachability(
+    config: &MonitoringConfig,
+    enode: &str,
+    json: bool,
+) -> Result<CommandOutcome> {
+    let chain_id = fetch_l2_chain_id(&config.rpc).await.with_context(|| {
+        format!("could not detect network from selected config RPC {}", config.rpc)
+    })?;
+    let telemetry_url =
+        TelemetryClient::reachability_url_for_chain_id(chain_id).ok_or_else(|| {
+            anyhow!(
+                "hosted reachability checks are unavailable for chain ID {chain_id}; supported chain IDs are 8453 (Base mainnet) and 84532 (Base Sepolia)"
+            )
+        })?;
     let response = TelemetryClient::new(telemetry_url)?.check_el_reachability(enode).await?;
     let reachable = response.outcome == ElReachabilityOutcome::Reachable;
     if json {
@@ -709,6 +723,7 @@ mod tests {
     use super::{
         AddTarget, PeerAction, PeerActionJson, PeerBulkActionResultJson, PeerTarget,
         fail_unban_all_if_partial, parse_add_target, parse_peer_target, resolve_cl_rpc, run,
+        run_reachability,
     };
     use crate::cli::P2pCommands;
 
@@ -770,19 +785,29 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reachability_does_not_load_monitoring_config() {
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let address = listener.local_addr().unwrap();
-        drop(listener);
-        let command = P2pCommands::Reachability {
-            enode: VALID_ENODE.to_string(),
-            telemetry_url: Url::parse(&format!("http://{address}")).unwrap(),
-            json: false,
-        };
+    async fn reachability_loads_selected_monitoring_config() {
+        let command = P2pCommands::Reachability { enode: VALID_ENODE.to_string(), json: false };
 
         let error = run("/definitely/missing/basectl.yaml", command).await.unwrap_err();
 
-        assert!(error.to_string().starts_with("telemetry service unavailable:"));
+        assert!(
+            error.to_string().starts_with("Config '/definitely/missing/basectl.yaml' not found")
+        );
+    }
+
+    #[tokio::test]
+    async fn reachability_reports_network_detection_failure() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        drop(listener);
+        let mut config = test_config(None);
+        config.rpc = Url::parse(&format!("http://{address}")).unwrap();
+
+        let error = run_reachability(&config, VALID_ENODE, false).await.unwrap_err();
+
+        assert!(
+            format!("{error:#}").starts_with("could not detect network from selected config RPC")
+        );
     }
 
     #[test]

--- a/bin/basectl/src/p2p.rs
+++ b/bin/basectl/src/p2p.rs
@@ -56,12 +56,11 @@ async fn run_reachability(
     let chain_id = fetch_l2_chain_id(&config.rpc).await.with_context(|| {
         format!("could not detect network from selected config RPC {}", config.rpc)
     })?;
-    let telemetry_url =
-        TelemetryClient::reachability_url_for_chain_id(chain_id).ok_or_else(|| {
-            anyhow!(
-                "hosted reachability checks are unavailable for chain ID {chain_id}; supported chain IDs are 8453 (Base mainnet) and 84532 (Base Sepolia)"
-            )
-        })?;
+    let telemetry_url = TelemetryClient::backend_base_url(chain_id).ok_or_else(|| {
+        anyhow!(
+            "hosted reachability checks are unavailable for chain ID {chain_id}; supported chain IDs are 8453 (Base mainnet) and 84532 (Base Sepolia)"
+        )
+    })?;
     let response = TelemetryClient::new(telemetry_url)?.check_el_reachability(enode).await?;
     let reachable = response.outcome == ElReachabilityOutcome::Reachable;
     if json {

--- a/crates/infra/basectl/src/doctor.rs
+++ b/crates/infra/basectl/src/doctor.rs
@@ -228,7 +228,7 @@ impl Doctor {
                 let telemetry_url = chain_id
                     .as_ref()
                     .ok()
-                    .and_then(|chain_id| TelemetryClient::reachability_url_for_chain_id(*chain_id));
+                    .and_then(|chain_id| TelemetryClient::backend_base_url(*chain_id));
                 let enode = el_info.as_ref().ok().and_then(|info| info.identity.enode.clone());
                 let reachability = match (telemetry_url.as_ref(), enode) {
                     (Some(url), Some(enode)) => Some(match TelemetryClient::new(url.clone()) {
@@ -265,15 +265,59 @@ impl Doctor {
             telemetry_url: telemetry_url.clone(),
         };
 
+        let external_el_reachability =
+            match (chain_id.as_ref(), telemetry_url.as_ref(), el_reachability.as_ref()) {
+                (Err(error), _, _) => DoctorCheck::new(
+                    "external_el_reachability",
+                    DoctorStatus::Skip,
+                    "could not detect network for external EL reachability check",
+                    json!({
+                        "telemetryUrl": null,
+                        "error": error.to_string(),
+                    }),
+                    json!({ "pass": "reachable" }),
+                    Some(
+                        "Check the effective `--el-rpc` endpoint and ensure `eth_chainId` is available."
+                            .to_string(),
+                    ),
+                ),
+                (Ok(chain_id), None, _) => DoctorCheck::new(
+                    "external_el_reachability",
+                    DoctorStatus::Skip,
+                    format!(
+                        "external EL reachability checks are unavailable for chain ID {chain_id}"
+                    ),
+                    json!({
+                        "chainId": chain_id,
+                        "telemetryUrl": null,
+                    }),
+                    json!({ "pass": "reachable" }),
+                    Some(
+                        "Hosted reachability checks support Base mainnet (8453) and Base Sepolia (84532)."
+                            .to_string(),
+                    ),
+                ),
+                (Ok(_), Some(telemetry_url), None) => DoctorCheck::new(
+                    "external_el_reachability",
+                    DoctorStatus::Skip,
+                    "EL enode is unavailable from admin_nodeInfo",
+                    json!({ "telemetryUrl": telemetry_url }),
+                    json!({ "pass": "reachable" }),
+                    Some("Point `--el-rpc` at an admin-enabled execution node RPC.".to_string()),
+                ),
+                (Ok(_), Some(telemetry_url), Some(Ok(response))) => {
+                    Self::external_el_reachability_check(telemetry_url, response)
+                }
+                (Ok(_), Some(telemetry_url), Some(Err(error))) => {
+                    Self::external_el_reachability_error_check(telemetry_url, error)
+                }
+            };
+
         let checks = vec![
             Self::p2p_config_check(&el_info, cl_info.as_ref()),
             Self::bootnode_check(chain_id.as_ref().ok(), &config),
             Self::advertised_endpoint_check(&el_info, cl_info.as_ref()),
-            Self::external_el_reachability_check(
-                &chain_id,
-                telemetry_url.as_ref(),
-                el_reachability.as_ref(),
-            ),
+            external_el_reachability,
             Self::declared_network_check(&config, &chain_id),
             Self::reth_limits_check(options.reth_config.as_deref()),
             Self::consensus_rpc_check(options.cl_rpc.as_ref()),
@@ -295,119 +339,75 @@ impl Doctor {
 
     /// Builds the external execution-layer reachability doctor check.
     fn external_el_reachability_check(
-        chain_id: &Result<u64>,
-        telemetry_url: Option<&Url>,
-        result: Option<&Result<ElReachabilityResponse, TelemetryClientError>>,
+        telemetry_url: &Url,
+        response: &ElReachabilityResponse,
     ) -> DoctorCheck {
-        let chain_id = match chain_id {
-            Ok(chain_id) => *chain_id,
-            Err(error) => {
-                return DoctorCheck::new(
-                    "external_el_reachability",
-                    DoctorStatus::Skip,
-                    "could not detect network for external EL reachability check",
-                    json!({
-                        "telemetryUrl": null,
-                        "error": error.to_string(),
-                    }),
-                    json!({ "pass": "reachable" }),
-                    Some(
-                        "Check the effective `--el-rpc` endpoint and ensure `eth_chainId` is available."
-                            .to_string(),
-                    ),
-                );
-            }
+        let status = if response.outcome == ElReachabilityOutcome::Reachable {
+            DoctorStatus::Pass
+        } else {
+            DoctorStatus::Fail
         };
-        let Some(telemetry_url) = telemetry_url else {
-            return DoctorCheck::new(
-                "external_el_reachability",
-                DoctorStatus::Skip,
-                format!("external EL reachability checks are unavailable for chain ID {chain_id}"),
-                json!({
-                    "chainId": chain_id,
-                    "telemetryUrl": null,
-                }),
-                json!({ "pass": "reachable" }),
-                Some(
-                    "Hosted reachability checks support Base mainnet (8453) and Base Sepolia (84532)."
-                        .to_string(),
-                ),
-            );
-        };
-        match result {
-            Some(Ok(response)) => {
-                let status = if response.outcome == ElReachabilityOutcome::Reachable {
-                    DoctorStatus::Pass
-                } else {
-                    DoctorStatus::Fail
-                };
-                DoctorCheck::new(
-                    "external_el_reachability",
-                    status,
-                    if status == DoctorStatus::Pass {
-                        "telemetry service reached the advertised EL endpoint"
-                    } else {
-                        "telemetry service could not complete the advertised EL handshake"
-                    },
-                    json!({
-                        "telemetryUrl": telemetry_url,
-                        "outcome": response.outcome,
-                        "stage": response.stage,
-                        "observedAddress": response.observed_address,
-                        "elapsedMs": response.elapsed_ms,
-                        "clientVersion": response.client_version.as_deref(),
-                    }),
-                    json!({ "pass": "reachable" }),
-                    (status == DoctorStatus::Fail).then(|| {
-                        "Check the advertised enode, firewall, NAT, and EL p2p listener."
-                            .to_string()
-                    }),
-                )
-            }
-            Some(Err(error)) => {
-                let (status, message, hint) = match error {
-                    TelemetryClientError::InvalidRequest => (
-                        DoctorStatus::Fail,
-                        "telemetry service rejected the advertised EL enode",
-                        "Check the enode returned by `admin_nodeInfo`.",
-                    ),
-                    TelemetryClientError::PayloadTooLarge => (
-                        DoctorStatus::Fail,
-                        "telemetry service rejected the reachability request as too large",
-                        "Check the enode returned by `admin_nodeInfo`.",
-                    ),
-                    TelemetryClientError::Saturated => (
-                        DoctorStatus::Warn,
-                        "telemetry service has no reachability probe capacity",
-                        "Retry the check shortly.",
-                    ),
-                    TelemetryClientError::Unavailable { .. } => (
-                        DoctorStatus::Skip,
-                        "telemetry service is unavailable",
-                        "Check the configured telemetry URL and service health.",
-                    ),
-                };
-                DoctorCheck::new(
-                    "external_el_reachability",
-                    status,
-                    message,
-                    json!({
-                        "telemetryUrl": telemetry_url,
-                        "error": error.to_string(),
-                    }),
-                    json!({ "pass": "reachable" }),
-                    Some(hint.to_string()),
-                )
-            }
-            None => DoctorCheck::new(
-                "external_el_reachability",
-                DoctorStatus::Skip,
-                "EL enode is unavailable from admin_nodeInfo",
-                json!({ "telemetryUrl": telemetry_url }),
-                json!({ "pass": "reachable" }),
-                Some("Point `--el-rpc` at an admin-enabled execution node RPC.".to_string()),
+        DoctorCheck::new(
+            "external_el_reachability",
+            status,
+            if status == DoctorStatus::Pass {
+                "telemetry service reached the advertised EL endpoint"
+            } else {
+                "telemetry service could not complete the advertised EL handshake"
+            },
+            json!({
+                "telemetryUrl": telemetry_url,
+                "outcome": response.outcome,
+                "stage": response.stage,
+                "observedAddress": response.observed_address,
+                "elapsedMs": response.elapsed_ms,
+                "clientVersion": response.client_version.as_deref(),
+            }),
+            json!({ "pass": "reachable" }),
+            (status == DoctorStatus::Fail).then(|| {
+                "Check the advertised enode, firewall, NAT, and EL p2p listener.".to_string()
+            }),
+        )
+    }
+
+    /// Builds a doctor check from a telemetry client error.
+    fn external_el_reachability_error_check(
+        telemetry_url: &Url,
+        error: &TelemetryClientError,
+    ) -> DoctorCheck {
+        let (status, message, hint) = match error {
+            TelemetryClientError::InvalidRequest => (
+                DoctorStatus::Fail,
+                "telemetry service rejected the advertised EL enode",
+                "Check the enode returned by `admin_nodeInfo`.",
             ),
-        }
+            TelemetryClientError::PayloadTooLarge => (
+                DoctorStatus::Fail,
+                "telemetry service rejected the reachability request as too large",
+                "Check the enode returned by `admin_nodeInfo`.",
+            ),
+            TelemetryClientError::Saturated => (
+                DoctorStatus::Warn,
+                "telemetry service has no reachability probe capacity",
+                "Retry the check shortly.",
+            ),
+            TelemetryClientError::Unavailable { .. } => (
+                DoctorStatus::Skip,
+                "telemetry service is unavailable",
+                "Check the configured telemetry URL and service health.",
+            ),
+        };
+        DoctorCheck::new(
+            "external_el_reachability",
+            status,
+            message,
+            json!({
+                "telemetryUrl": telemetry_url,
+                "error": error.to_string(),
+            }),
+            json!({ "pass": "reachable" }),
+            Some(hint.to_string()),
+        )
     }
 
     fn p2p_config_check(
@@ -1129,7 +1129,6 @@ mod tests {
         path::PathBuf,
     };
 
-    use anyhow::anyhow;
     use serde_json::json;
     use url::Url;
 
@@ -1231,22 +1230,15 @@ mod tests {
     #[test]
     fn external_reachability_classifies_probe_outcomes() {
         let telemetry_url = Url::parse("http://127.0.0.1:8080").unwrap();
-        let chain_id = Ok(8453);
-        let reachable = Ok(reachability(ElReachabilityOutcome::Reachable));
-        let failed = Ok(reachability(ElReachabilityOutcome::ConnectionFailed));
+        let reachable = reachability(ElReachabilityOutcome::Reachable);
+        let failed = reachability(ElReachabilityOutcome::ConnectionFailed);
 
         assert_eq!(
-            Doctor::external_el_reachability_check(
-                &chain_id,
-                Some(&telemetry_url),
-                Some(&reachable),
-            )
-            .status,
+            Doctor::external_el_reachability_check(&telemetry_url, &reachable).status,
             DoctorStatus::Pass,
         );
         assert_eq!(
-            Doctor::external_el_reachability_check(&chain_id, Some(&telemetry_url), Some(&failed),)
-                .status,
+            Doctor::external_el_reachability_check(&telemetry_url, &failed).status,
             DoctorStatus::Fail,
         );
     }
@@ -1254,56 +1246,22 @@ mod tests {
     #[test]
     fn external_reachability_preserves_client_error_classification() {
         let telemetry_url = Url::parse("http://127.0.0.1:8080").unwrap();
-        let chain_id = Ok(8453);
-        let invalid = Err(TelemetryClientError::InvalidRequest);
-        let saturated = Err(TelemetryClientError::Saturated);
+        let invalid = TelemetryClientError::InvalidRequest;
+        let saturated = TelemetryClientError::Saturated;
         let unavailable =
-            Err(TelemetryClientError::Unavailable { message: "connection refused".to_string() });
+            TelemetryClientError::Unavailable { message: "connection refused".to_string() };
 
         assert_eq!(
-            Doctor::external_el_reachability_check(
-                &chain_id,
-                Some(&telemetry_url),
-                Some(&invalid),
-            )
-            .status,
+            Doctor::external_el_reachability_error_check(&telemetry_url, &invalid).status,
             DoctorStatus::Fail,
         );
         assert_eq!(
-            Doctor::external_el_reachability_check(
-                &chain_id,
-                Some(&telemetry_url),
-                Some(&saturated),
-            )
-            .status,
+            Doctor::external_el_reachability_error_check(&telemetry_url, &saturated).status,
             DoctorStatus::Warn,
         );
         assert_eq!(
-            Doctor::external_el_reachability_check(
-                &chain_id,
-                Some(&telemetry_url),
-                Some(&unavailable),
-            )
-            .status,
+            Doctor::external_el_reachability_error_check(&telemetry_url, &unavailable).status,
             DoctorStatus::Skip,
-        );
-    }
-
-    #[test]
-    fn external_reachability_skips_unsupported_and_undetected_networks() {
-        let unsupported = Doctor::external_el_reachability_check(&Ok(1), None, None);
-        let undetected = Doctor::external_el_reachability_check(
-            &Err(anyhow!("eth_chainId unavailable")),
-            None,
-            None,
-        );
-
-        assert_eq!(unsupported.status, DoctorStatus::Skip);
-        assert!(unsupported.message.contains("chain ID 1"));
-        assert_eq!(undetected.status, DoctorStatus::Skip);
-        assert_eq!(
-            undetected.message,
-            "could not detect network for external EL reachability check"
         );
     }
 

--- a/crates/infra/basectl/src/doctor.rs
+++ b/crates/infra/basectl/src/doctor.rs
@@ -379,23 +379,26 @@ impl Doctor {
             TelemetryClientError::InvalidRequest => (
                 DoctorStatus::Fail,
                 "telemetry service rejected the advertised EL enode",
-                "Check the enode returned by `admin_nodeInfo`.",
+                Some("Check the enode returned by `admin_nodeInfo`."),
             ),
             TelemetryClientError::PayloadTooLarge => (
                 DoctorStatus::Fail,
                 "telemetry service rejected the reachability request as too large",
-                "Check the enode returned by `admin_nodeInfo`.",
+                Some("Check the enode returned by `admin_nodeInfo`."),
             ),
             TelemetryClientError::Saturated => (
                 DoctorStatus::Warn,
                 "telemetry service has no reachability probe capacity",
-                "Retry the check shortly.",
+                Some("Retry the check shortly."),
             ),
-            TelemetryClientError::Unavailable { .. } => (
-                DoctorStatus::Skip,
-                "telemetry service is unavailable",
-                "Check the configured telemetry URL and service health.",
+            TelemetryClientError::RateLimited => (
+                DoctorStatus::Warn,
+                "telemetry service rate limited the reachability request",
+                Some("Retry the check shortly."),
             ),
+            TelemetryClientError::Unavailable { .. } => {
+                (DoctorStatus::Skip, "telemetry service is unavailable", None)
+            }
         };
         DoctorCheck::new(
             "external_el_reachability",
@@ -406,7 +409,7 @@ impl Doctor {
                 "error": error.to_string(),
             }),
             json!({ "pass": "reachable" }),
-            Some(hint.to_string()),
+            hint.map(str::to_string),
         )
     }
 
@@ -1135,8 +1138,8 @@ mod tests {
     use super::{
         Doctor, DoctorCheck, DoctorStatus, DoctorSummary, DoctorThresholds, ElInfoReport,
         ElReachabilityOutcome, ElReachabilityResponse, RethLimits, TelemetryClientError,
-        bootnode_addrs, bootnode_chain, bootnode_layer_summary, classify_ip, expected_chain_id,
-        peer_count_check, worst_status,
+        bootnode_addrs, bootnode_chain, bootnode_layer_summary, classify_ip, peer_count_check,
+        worst_status,
     };
     use crate::{ElNodeIdentity, ElReachabilityStage};
 
@@ -1164,16 +1167,6 @@ mod tests {
         assert_eq!(peer_count_check("x", "EL", 0, 5).status, DoctorStatus::Fail);
         assert_eq!(peer_count_check("x", "EL", 4, 5).status, DoctorStatus::Warn);
         assert_eq!(peer_count_check("x", "EL", 5, 5).status, DoctorStatus::Pass);
-    }
-
-    #[test]
-    fn default_thresholds_match_doctor_plan() {
-        let thresholds = DoctorThresholds::default();
-
-        assert_eq!(thresholds.head_lag_warn_blocks, 10);
-        assert_eq!(thresholds.head_lag_fail_blocks, 20);
-        assert_eq!(thresholds.safe_recency_warn_blocks, 150);
-        assert_eq!(thresholds.safe_recency_fail_blocks, 300);
     }
 
     #[test]
@@ -1248,6 +1241,7 @@ mod tests {
         let telemetry_url = Url::parse("http://127.0.0.1:8080").unwrap();
         let invalid = TelemetryClientError::InvalidRequest;
         let saturated = TelemetryClientError::Saturated;
+        let rate_limited = TelemetryClientError::RateLimited;
         let unavailable =
             TelemetryClientError::Unavailable { message: "connection refused".to_string() };
 
@@ -1260,18 +1254,13 @@ mod tests {
             DoctorStatus::Warn,
         );
         assert_eq!(
+            Doctor::external_el_reachability_error_check(&telemetry_url, &rate_limited).status,
+            DoctorStatus::Warn,
+        );
+        assert_eq!(
             Doctor::external_el_reachability_error_check(&telemetry_url, &unavailable).status,
             DoctorStatus::Skip,
         );
-    }
-
-    #[test]
-    fn maps_known_config_names_to_chain_ids() {
-        assert_eq!(expected_chain_id("mainnet"), Some(8453));
-        assert_eq!(expected_chain_id("sepolia"), Some(84532));
-        assert_eq!(expected_chain_id("devnet"), Some(1337));
-        assert_eq!(expected_chain_id("zeronet"), Some(763360));
-        assert_eq!(expected_chain_id("custom"), None);
     }
 
     #[test]

--- a/crates/infra/basectl/src/doctor.rs
+++ b/crates/infra/basectl/src/doctor.rs
@@ -39,8 +39,6 @@ pub struct DoctorOptions {
     pub cl_rpc: Option<Url>,
     /// Optional local `reth.toml` path.
     pub reth_config: Option<PathBuf>,
-    /// Optional Base telemetry service URL for external EL reachability checks.
-    pub telemetry_url: Option<Url>,
     /// Classification thresholds for graded checks.
     pub thresholds: DoctorThresholds,
 }
@@ -215,37 +213,31 @@ impl DoctorStatus {
 impl Doctor {
     /// Runs doctor checks and returns a complete report.
     pub async fn run(config: MonitoringConfig, options: DoctorOptions) -> DoctorReport {
-        let inputs = DoctorInputs {
-            el_rpc: options.el_rpc.clone(),
-            cl_rpc: options.cl_rpc.clone(),
-            l1_rpc: config.l1_rpc.clone(),
-            public_tip_rpc: config.rpc.clone(),
-            reth_config: options.reth_config.clone(),
-            telemetry_url: options.telemetry_url.clone(),
-        };
-
-        let telemetry_url = options.telemetry_url.clone();
         let el_rpc = options.el_rpc.clone();
         let (
-            (el_info, el_reachability),
+            (el_info, chain_id, telemetry_url, el_reachability),
             cl_info,
-            chain_id,
             local_head,
             public_head,
             sync_status,
             l1_head,
         ) = tokio::join!(
             async move {
-                let el_info = fetch_el_info(&el_rpc).await;
+                let (el_info, chain_id) =
+                    tokio::join!(fetch_el_info(&el_rpc), fetch_l2_chain_id(&el_rpc));
+                let telemetry_url = chain_id
+                    .as_ref()
+                    .ok()
+                    .and_then(|chain_id| TelemetryClient::reachability_url_for_chain_id(*chain_id));
                 let enode = el_info.as_ref().ok().and_then(|info| info.identity.enode.clone());
-                let reachability = match (telemetry_url, enode) {
-                    (Some(url), Some(enode)) => Some(match TelemetryClient::new(url) {
+                let reachability = match (telemetry_url.as_ref(), enode) {
+                    (Some(url), Some(enode)) => Some(match TelemetryClient::new(url.clone()) {
                         Ok(client) => client.check_el_reachability(&enode).await,
                         Err(error) => Err(error),
                     }),
                     _ => None,
                 };
-                (el_info, reachability)
+                (el_info, chain_id, telemetry_url, reachability)
             },
             async {
                 match &options.cl_rpc {
@@ -253,7 +245,6 @@ impl Doctor {
                     None => None,
                 }
             },
-            fetch_l2_chain_id(&options.el_rpc),
             fetch_l2_block_number(&options.el_rpc),
             fetch_l2_block_number(&config.rpc),
             async {
@@ -265,12 +256,22 @@ impl Doctor {
             fetch_l1_block_number(&config.l1_rpc),
         );
 
+        let inputs = DoctorInputs {
+            el_rpc: options.el_rpc.clone(),
+            cl_rpc: options.cl_rpc.clone(),
+            l1_rpc: config.l1_rpc.clone(),
+            public_tip_rpc: config.rpc.clone(),
+            reth_config: options.reth_config.clone(),
+            telemetry_url: telemetry_url.clone(),
+        };
+
         let checks = vec![
             Self::p2p_config_check(&el_info, cl_info.as_ref()),
             Self::bootnode_check(chain_id.as_ref().ok(), &config),
             Self::advertised_endpoint_check(&el_info, cl_info.as_ref()),
             Self::external_el_reachability_check(
-                options.telemetry_url.as_ref(),
+                &chain_id,
+                telemetry_url.as_ref(),
                 el_reachability.as_ref(),
             ),
             Self::declared_network_check(&config, &chain_id),
@@ -294,18 +295,41 @@ impl Doctor {
 
     /// Builds the external execution-layer reachability doctor check.
     fn external_el_reachability_check(
+        chain_id: &Result<u64>,
         telemetry_url: Option<&Url>,
         result: Option<&Result<ElReachabilityResponse, TelemetryClientError>>,
     ) -> DoctorCheck {
+        let chain_id = match chain_id {
+            Ok(chain_id) => *chain_id,
+            Err(error) => {
+                return DoctorCheck::new(
+                    "external_el_reachability",
+                    DoctorStatus::Skip,
+                    "could not detect network for external EL reachability check",
+                    json!({
+                        "telemetryUrl": null,
+                        "error": error.to_string(),
+                    }),
+                    json!({ "pass": "reachable" }),
+                    Some(
+                        "Check the effective `--el-rpc` endpoint and ensure `eth_chainId` is available."
+                            .to_string(),
+                    ),
+                );
+            }
+        };
         let Some(telemetry_url) = telemetry_url else {
             return DoctorCheck::new(
                 "external_el_reachability",
                 DoctorStatus::Skip,
-                "external EL reachability check is not configured",
-                json!({ "telemetryUrl": null }),
+                format!("external EL reachability checks are unavailable for chain ID {chain_id}"),
+                json!({
+                    "chainId": chain_id,
+                    "telemetryUrl": null,
+                }),
                 json!({ "pass": "reachable" }),
                 Some(
-                    "Pass `--telemetry-url <URL>` or set `BASECTL_TELEMETRY_URL` to enable the check."
+                    "Hosted reachability checks support Base mainnet (8453) and Base Sepolia (84532)."
                         .to_string(),
                 ),
             );
@@ -1105,6 +1129,7 @@ mod tests {
         path::PathBuf,
     };
 
+    use anyhow::anyhow;
     use serde_json::json;
     use url::Url;
 
@@ -1206,15 +1231,22 @@ mod tests {
     #[test]
     fn external_reachability_classifies_probe_outcomes() {
         let telemetry_url = Url::parse("http://127.0.0.1:8080").unwrap();
+        let chain_id = Ok(8453);
         let reachable = Ok(reachability(ElReachabilityOutcome::Reachable));
         let failed = Ok(reachability(ElReachabilityOutcome::ConnectionFailed));
 
         assert_eq!(
-            Doctor::external_el_reachability_check(Some(&telemetry_url), Some(&reachable),).status,
+            Doctor::external_el_reachability_check(
+                &chain_id,
+                Some(&telemetry_url),
+                Some(&reachable),
+            )
+            .status,
             DoctorStatus::Pass,
         );
         assert_eq!(
-            Doctor::external_el_reachability_check(Some(&telemetry_url), Some(&failed),).status,
+            Doctor::external_el_reachability_check(&chain_id, Some(&telemetry_url), Some(&failed),)
+                .status,
             DoctorStatus::Fail,
         );
     }
@@ -1222,23 +1254,56 @@ mod tests {
     #[test]
     fn external_reachability_preserves_client_error_classification() {
         let telemetry_url = Url::parse("http://127.0.0.1:8080").unwrap();
+        let chain_id = Ok(8453);
         let invalid = Err(TelemetryClientError::InvalidRequest);
         let saturated = Err(TelemetryClientError::Saturated);
         let unavailable =
             Err(TelemetryClientError::Unavailable { message: "connection refused".to_string() });
 
         assert_eq!(
-            Doctor::external_el_reachability_check(Some(&telemetry_url), Some(&invalid),).status,
+            Doctor::external_el_reachability_check(
+                &chain_id,
+                Some(&telemetry_url),
+                Some(&invalid),
+            )
+            .status,
             DoctorStatus::Fail,
         );
         assert_eq!(
-            Doctor::external_el_reachability_check(Some(&telemetry_url), Some(&saturated),).status,
+            Doctor::external_el_reachability_check(
+                &chain_id,
+                Some(&telemetry_url),
+                Some(&saturated),
+            )
+            .status,
             DoctorStatus::Warn,
         );
         assert_eq!(
-            Doctor::external_el_reachability_check(Some(&telemetry_url), Some(&unavailable),)
-                .status,
+            Doctor::external_el_reachability_check(
+                &chain_id,
+                Some(&telemetry_url),
+                Some(&unavailable),
+            )
+            .status,
             DoctorStatus::Skip,
+        );
+    }
+
+    #[test]
+    fn external_reachability_skips_unsupported_and_undetected_networks() {
+        let unsupported = Doctor::external_el_reachability_check(&Ok(1), None, None);
+        let undetected = Doctor::external_el_reachability_check(
+            &Err(anyhow!("eth_chainId unavailable")),
+            None,
+            None,
+        );
+
+        assert_eq!(unsupported.status, DoctorStatus::Skip);
+        assert!(unsupported.message.contains("chain ID 1"));
+        assert_eq!(undetected.status, DoctorStatus::Skip);
+        assert_eq!(
+            undetected.message,
+            "could not detect network for external EL reachability check"
         );
     }
 

--- a/crates/infra/basectl/src/rpc/telemetry.rs
+++ b/crates/infra/basectl/src/rpc/telemetry.rs
@@ -94,6 +94,8 @@ pub enum TelemetryApiError {
     PayloadTooLarge,
     /// Probe capacity was exhausted.
     Saturated,
+    /// The client IP exceeded the request rate limit.
+    RateLimited,
 }
 
 /// Error returned by the Base telemetry HTTP client.
@@ -109,6 +111,9 @@ pub enum TelemetryClientError {
     /// The telemetry service had no reachability probe capacity available.
     #[error("telemetry service reachability probe capacity is saturated")]
     Saturated,
+    /// The telemetry service rate limited the client IP.
+    #[error("telemetry service rate limited the reachability request")]
+    RateLimited,
     /// The telemetry service could not be reached or returned an unusable response.
     #[error("telemetry service unavailable: {message}")]
     Unavailable {
@@ -178,6 +183,9 @@ impl TelemetryClient {
             (StatusCode::TOO_MANY_REQUESTS, TelemetryApiError::Saturated) => {
                 Err(TelemetryClientError::Saturated)
             }
+            (StatusCode::TOO_MANY_REQUESTS, TelemetryApiError::RateLimited) => {
+                Err(TelemetryClientError::RateLimited)
+            }
             _ => Err(TelemetryClientError::Unavailable {
                 message: format!("unexpected HTTP {status} response with error {error:?}"),
             }),
@@ -242,6 +250,7 @@ mod tests {
             "invalid" => (StatusCode::BAD_REQUEST, TelemetryApiError::InvalidRequest),
             "large" => (StatusCode::PAYLOAD_TOO_LARGE, TelemetryApiError::PayloadTooLarge),
             "saturated" => (StatusCode::TOO_MANY_REQUESTS, TelemetryApiError::Saturated),
+            "limited" => (StatusCode::TOO_MANY_REQUESTS, TelemetryApiError::RateLimited),
             _ => panic!("unexpected test request"),
         };
         (status, Json(TelemetryErrorResponse { error })).into_response()
@@ -298,6 +307,10 @@ mod tests {
         assert_eq!(
             client.check_el_reachability("saturated").await.unwrap_err(),
             TelemetryClientError::Saturated
+        );
+        assert_eq!(
+            client.check_el_reachability("limited").await.unwrap_err(),
+            TelemetryClientError::RateLimited
         );
         handle.abort();
     }

--- a/crates/infra/basectl/src/rpc/telemetry.rs
+++ b/crates/infra/basectl/src/rpc/telemetry.rs
@@ -247,13 +247,6 @@ mod tests {
         (status, Json(TelemetryErrorResponse { error })).into_response()
     }
 
-    #[test]
-    fn stage_labels_describe_the_probe_step() {
-        assert_eq!(ElReachabilityStage::TcpConnect.as_str(), "tcp_connect");
-        assert_eq!(ElReachabilityStage::EncryptedHandshake.as_str(), "encrypted_handshake");
-        assert_eq!(ElReachabilityStage::Devp2pHello.as_str(), "devp2p_hello");
-    }
-
     #[tokio::test]
     async fn decodes_camel_case_fields_and_snake_case_enums() {
         let router = Router::new().route(EL_REACHABILITY_PATH, post(reachable));

--- a/crates/infra/basectl/src/rpc/telemetry.rs
+++ b/crates/infra/basectl/src/rpc/telemetry.rs
@@ -131,6 +131,16 @@ pub struct TelemetryClient {
 }
 
 impl TelemetryClient {
+    /// Returns the hosted reachability service URL for a supported Base chain.
+    pub fn reachability_url_for_chain_id(chain_id: u64) -> Option<Url> {
+        Url::parse(match chain_id {
+            8453 => "https://mainnet.telemetry.base.org",
+            84532 => "https://sepolia.telemetry.base.org",
+            _ => return None,
+        })
+        .ok()
+    }
+
     /// Creates a telemetry client with a timeout longer than the backend probe deadline.
     pub fn new(base_url: Url) -> Result<Self, TelemetryClientError> {
         let http = reqwest::Client::builder().timeout(TELEMETRY_REQUEST_TIMEOUT).build()?;
@@ -242,6 +252,19 @@ mod tests {
         assert_eq!(ElReachabilityStage::TcpConnect.as_str(), "tcp_connect");
         assert_eq!(ElReachabilityStage::EncryptedHandshake.as_str(), "encrypted_handshake");
         assert_eq!(ElReachabilityStage::Devp2pHello.as_str(), "devp2p_hello");
+    }
+
+    #[test]
+    fn maps_supported_chain_ids_to_hosted_reachability_services() {
+        assert_eq!(
+            TelemetryClient::reachability_url_for_chain_id(8453),
+            Url::parse("https://mainnet.telemetry.base.org").ok(),
+        );
+        assert_eq!(
+            TelemetryClient::reachability_url_for_chain_id(84532),
+            Url::parse("https://sepolia.telemetry.base.org").ok(),
+        );
+        assert_eq!(TelemetryClient::reachability_url_for_chain_id(1), None);
     }
 
     #[tokio::test]

--- a/crates/infra/basectl/src/rpc/telemetry.rs
+++ b/crates/infra/basectl/src/rpc/telemetry.rs
@@ -131,8 +131,8 @@ pub struct TelemetryClient {
 }
 
 impl TelemetryClient {
-    /// Returns the hosted reachability service URL for a supported Base chain.
-    pub fn reachability_url_for_chain_id(chain_id: u64) -> Option<Url> {
+    /// Returns the hosted telemetry backend base URL for a supported Base chain.
+    pub fn backend_base_url(chain_id: u64) -> Option<Url> {
         Url::parse(match chain_id {
             8453 => "https://mainnet.telemetry.base.org",
             84532 => "https://sepolia.telemetry.base.org",
@@ -252,19 +252,6 @@ mod tests {
         assert_eq!(ElReachabilityStage::TcpConnect.as_str(), "tcp_connect");
         assert_eq!(ElReachabilityStage::EncryptedHandshake.as_str(), "encrypted_handshake");
         assert_eq!(ElReachabilityStage::Devp2pHello.as_str(), "devp2p_hello");
-    }
-
-    #[test]
-    fn maps_supported_chain_ids_to_hosted_reachability_services() {
-        assert_eq!(
-            TelemetryClient::reachability_url_for_chain_id(8453),
-            Url::parse("https://mainnet.telemetry.base.org").ok(),
-        );
-        assert_eq!(
-            TelemetryClient::reachability_url_for_chain_id(84532),
-            Url::parse("https://sepolia.telemetry.base.org").ok(),
-        );
-        assert_eq!(TelemetryClient::reachability_url_for_chain_id(1), None);
     }
 
     #[tokio::test]

--- a/crates/infra/telemetry/Cargo.toml
+++ b/crates/infra/telemetry/Cargo.toml
@@ -11,10 +11,13 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
+ipnet.workspace = true
+governor.workspace = true
 tokio-util.workspace = true
 async-trait.workspace = true
 reth-ecies.workspace = true
 reth-eth-wire.workspace = true
+base-http-utils.workspace = true
 alloy-primitives.workspace = true
 anyhow = { workspace = true, features = ["std"] }
 tracing = { workspace = true, features = ["std"] }

--- a/crates/infra/telemetry/Cargo.toml
+++ b/crates/infra/telemetry/Cargo.toml
@@ -19,7 +19,6 @@ reth-ecies.workspace = true
 reth-eth-wire.workspace = true
 base-http-utils.workspace = true
 alloy-primitives.workspace = true
-axum-client-ip.workspace = true
 anyhow = { workspace = true, features = ["std"] }
 tracing = { workspace = true, features = ["std"] }
 thiserror = { workspace = true, features = ["std"] }
@@ -32,4 +31,5 @@ reth-network-peers = { workspace = true, features = ["secp256k1"] }
 tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
 
 [dev-dependencies]
+mockall.workspace = true
 reqwest = { workspace = true, features = ["json"] }

--- a/crates/infra/telemetry/Cargo.toml
+++ b/crates/infra/telemetry/Cargo.toml
@@ -19,6 +19,7 @@ reth-ecies.workspace = true
 reth-eth-wire.workspace = true
 base-http-utils.workspace = true
 alloy-primitives.workspace = true
+axum-client-ip.workspace = true
 anyhow = { workspace = true, features = ["std"] }
 tracing = { workspace = true, features = ["std"] }
 thiserror = { workspace = true, features = ["std"] }

--- a/crates/infra/telemetry/README.md
+++ b/crates/infra/telemetry/README.md
@@ -54,8 +54,10 @@ Completed probes return HTTP `200` with an outcome of `reachable`,
 - `devp2p_hello`: exchanging the Ethereum devp2p Hello message.
 
 Invalid requests return `400`, bodies over 1 `KiB` return `413`, and exhausted
-probe capacity returns `429`. Probes have a 10-second deadline, with at most 32
-running globally. These limits do not apply to the health routes.
+probe capacity returns `429`. Probes have a 10-second deadline. Global probe
+concurrency defaults to 32, configurable with `--p2p-max-concurrent-probes` or
+`BASE_TELEMETRY_P2P_MAX_CONCURRENT_PROBES`. These limits do not apply to the
+health routes.
 
 ## Rate limiting
 
@@ -63,9 +65,12 @@ Reachability requests default to 2 per minute per client IP, configurable with
 `--p2p-probe-requests-per-minute` or
 `BASE_TELEMETRY_P2P_PROBE_REQUESTS_PER_MINUTE`, and enforced with in-memory GCRA
 token buckets. The client IP is taken from the peer socket address unless the
-peer is inside a configured set of trusted proxy CIDRs, in which case the last
-`X-Forwarded-For` entry is extracted with `axum-client-ip`. A missing or
-malformed header from a trusted proxy is treated as a proxy misconfiguration.
+peer is inside a configured set of trusted proxy CIDRs
+(`--trusted-proxy-cidrs` or `BASE_TELEMETRY_TRUSTED_PROXY_CIDRS`), in which
+case the rightmost entry of the last `X-Forwarded-For` header is extracted. A
+missing or malformed header from a trusted proxy is treated as a proxy
+misconfiguration. Deployments exposed directly (no fronting proxy) leave the
+CIDRs empty, so forwarding headers are ignored and the socket peer IP is used.
 Limited requests return `429` with a `Retry-After` header and a JSON body of
 `{"error":"rate_limited"}`. Limits are tracked per replica; health routes are
 never rate limited.
@@ -74,4 +79,5 @@ never rate limited.
 
 The service probes the exact literal public `IPv4` socket address advertised by
 the enode. `IPv6` and non-public `IPv4` addresses (loopback, private, link-local,
-carrier-grade NAT, multicast, and unspecified) are rejected with `400`.
+carrier-grade NAT, multicast, unspecified, and other IANA special-purpose
+ranges) are rejected with `400`.

--- a/crates/infra/telemetry/README.md
+++ b/crates/infra/telemetry/README.md
@@ -69,8 +69,8 @@ peer is inside a configured set of trusted proxy CIDRs
 (`--trusted-proxy-cidrs` or `BASE_TELEMETRY_TRUSTED_PROXY_CIDRS`), in which
 case the `X-Forwarded-For` chain is scanned right to left, skipping trusted
 proxy hops, and the first untrusted entry is used as the client IP. A missing
-or malformed header from a trusted proxy is treated as a proxy
-misconfiguration. Deployments exposed directly (no fronting proxy) leave the
+or malformed header from a trusted proxy falls back to the peer address with
+a warning. Deployments exposed directly (no fronting proxy) leave the
 CIDRs empty, so forwarding headers are ignored and the socket peer IP is used.
 Limited requests return `429` with a `Retry-After` header and a JSON body of
 `{"error":"rate_limited"}`. Limits are tracked per replica; health routes are

--- a/crates/infra/telemetry/README.md
+++ b/crates/infra/telemetry/README.md
@@ -67,8 +67,9 @@ Reachability requests default to 2 per minute per client IP, configurable with
 token buckets. The client IP is taken from the peer socket address unless the
 peer is inside a configured set of trusted proxy CIDRs
 (`--trusted-proxy-cidrs` or `BASE_TELEMETRY_TRUSTED_PROXY_CIDRS`), in which
-case the rightmost entry of the last `X-Forwarded-For` header is extracted. A
-missing or malformed header from a trusted proxy is treated as a proxy
+case the `X-Forwarded-For` chain is scanned right to left, skipping trusted
+proxy hops, and the first untrusted entry is used as the client IP. A missing
+or malformed header from a trusted proxy is treated as a proxy
 misconfiguration. Deployments exposed directly (no fronting proxy) leave the
 CIDRs empty, so forwarding headers are ignored and the socket peer IP is used.
 Limited requests return `429` with a `Retry-After` header and a JSON body of

--- a/crates/infra/telemetry/README.md
+++ b/crates/infra/telemetry/README.md
@@ -20,9 +20,8 @@ because it is at peer capacity) is still `reachable`; its response omits
 `clientVersion`.
 
 The caller may be the node, an operator, or a monitoring system. The enode must
-contain a literal `IPv4` or `IPv6` address; hostnames are not resolved. Private
-addresses are allowed, so results describe reachability from the service's
-network rather than necessarily from the public internet.
+contain a public literal `IPv4` address; hostnames, private addresses, and `IPv6`
+addresses are rejected.
 
 Request:
 
@@ -60,17 +59,19 @@ running globally. These limits do not apply to the health routes.
 
 ## Rate limiting
 
-Reachability requests are rate limited to 2 per minute per client IP,
-enforced with in-memory GCRA token buckets. The client IP is taken from the
-peer socket address unless the peer is inside a configured set of trusted
-proxy CIDRs, in which case the last `X-Forwarded-For` entry is used. Limited
-requests return `429` with a `Retry-After` header and a JSON body of
+Reachability requests default to 2 per minute per client IP, configurable with
+`--p2p-probe-requests-per-minute` or
+`BASE_TELEMETRY_P2P_PROBE_REQUESTS_PER_MINUTE`, and enforced with in-memory GCRA
+token buckets. The client IP is taken from the peer socket address unless the
+peer is inside a configured set of trusted proxy CIDRs, in which case the last
+`X-Forwarded-For` entry is extracted with `axum-client-ip`. A missing or
+malformed header from a trusted proxy is treated as a proxy misconfiguration.
+Limited requests return `429` with a `Retry-After` header and a JSON body of
 `{"error":"rate_limited"}`. Limits are tracked per replica; health routes are
 never rate limited.
 
 ## Target selection
 
-The service probes the exact literal `IPv4` or `IPv6` socket address advertised
-by the enode. Non-public addresses (loopback, private, link-local,
-carrier-grade NAT, unique-local, multicast, and unspecified) are rejected with
-`400` so untrusted enodes cannot steer probes at internal networks.
+The service probes the exact literal public `IPv4` socket address advertised by
+the enode. `IPv6` and non-public `IPv4` addresses (loopback, private, link-local,
+carrier-grade NAT, multicast, and unspecified) are rejected with `400`.

--- a/crates/infra/telemetry/README.md
+++ b/crates/infra/telemetry/README.md
@@ -58,8 +58,19 @@ Invalid requests return `400`, bodies over 1 `KiB` return `413`, and exhausted
 probe capacity returns `429`. Probes have a 10-second deadline, with at most 32
 running globally. These limits do not apply to the health routes.
 
+## Rate limiting
+
+Reachability requests are rate limited to 2 per minute per client IP,
+enforced with in-memory GCRA token buckets. The client IP is taken from the
+peer socket address unless the peer is inside a configured set of trusted
+proxy CIDRs, in which case the last `X-Forwarded-For` entry is used. Limited
+requests return `429` with a `Retry-After` header and a JSON body of
+`{"error":"rate_limited"}`. Limits are tracked per replica; health routes are
+never rate limited.
+
 ## Target selection
 
 The service probes the exact literal `IPv4` or `IPv6` socket address advertised
-by the enode, including private and other non-public addresses. Routing,
-firewall, and egress policy determine whether the backend can reach the target.
+by the enode. Non-public addresses (loopback, private, link-local,
+carrier-grade NAT, unique-local, multicast, and unspecified) are rejected with
+`400` so untrusted enodes cannot steer probes at internal networks.

--- a/crates/infra/telemetry/src/lib.rs
+++ b/crates/infra/telemetry/src/lib.rs
@@ -15,5 +15,11 @@ pub use prober::{
     RlpxProbeStage, RlpxProbeTarget, RlpxProber,
 };
 
+mod rate_limit;
+pub use rate_limit::{
+    CLIENT_IP_HEADER, IpRateLimiter, PerIpRateLimit, RATE_LIMIT_EVICTION_INTERVAL,
+    RATE_LIMIT_PER_IP_REQUESTS_PER_MINUTE, RATE_LIMITED_BODY, RateLimitExceeded,
+};
+
 mod server;
 pub use server::{BaseTelemetryServer, ServerConfig};

--- a/crates/infra/telemetry/src/lib.rs
+++ b/crates/infra/telemetry/src/lib.rs
@@ -4,12 +4,14 @@ mod p2p;
 #[cfg(test)]
 pub use p2p::TEST_NODE_ID;
 pub use p2p::{
-    P2P_REACHABILITY_MAX_CONCURRENT_PROBES, P2P_REACHABILITY_MAX_REQUEST_BYTES,
+    DEFAULT_P2P_REACHABILITY_MAX_CONCURRENT_PROBES, P2P_REACHABILITY_MAX_REQUEST_BYTES,
     P2P_REACHABILITY_PATH, P2pApiError, P2pErrorResponse, P2pReachabilityRequest,
     P2pReachabilityResponse, P2pRoutes, P2pState,
 };
 
 mod prober;
+#[cfg(test)]
+pub use prober::MockReachabilityProber;
 pub use prober::{
     RLPX_PROBE_TIMEOUT, ReachabilityProber, RlpxProbeError, RlpxProbeOutcome, RlpxProbeResult,
     RlpxProbeStage, RlpxProbeTarget, RlpxProber,
@@ -23,3 +25,8 @@ pub use rate_limit::{
 
 mod server;
 pub use server::{BaseTelemetryServer, ServerConfig};
+
+#[cfg(test)]
+mod test_utils;
+#[cfg(test)]
+pub use test_utils::BlockingProber;

--- a/crates/infra/telemetry/src/lib.rs
+++ b/crates/infra/telemetry/src/lib.rs
@@ -17,8 +17,8 @@ pub use prober::{
 
 mod rate_limit;
 pub use rate_limit::{
-    CLIENT_IP_HEADER, IpRateLimiter, PerIpRateLimit, RATE_LIMIT_EVICTION_INTERVAL,
-    RATE_LIMIT_PER_IP_REQUESTS_PER_MINUTE, RATE_LIMITED_BODY, RateLimitExceeded,
+    CLIENT_IP_HEADER, DEFAULT_P2P_PROBE_REQUESTS_PER_MINUTE, IpRateLimiter, PerIpRateLimit,
+    RATE_LIMIT_EVICTION_INTERVAL, RATE_LIMITED_BODY, RateLimitExceeded,
 };
 
 mod server;

--- a/crates/infra/telemetry/src/p2p.rs
+++ b/crates/infra/telemetry/src/p2p.rs
@@ -1,7 +1,11 @@
 //! HTTP API for execution-layer P2P reachability checks: request validation
 //! and probe concurrency limits.
 
-use std::{net::SocketAddr, str::FromStr, sync::Arc};
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    str::FromStr,
+    sync::Arc,
+};
 
 use axum::{
     Json, Router,
@@ -45,7 +49,60 @@ impl P2pReachabilityRequest {
         let record = NodeRecord::from_str(&self.enode).ok()?;
         id2pk(record.id).ok()?;
         let address = record.tcp_addr();
-        (address.port() != 0).then_some(RlpxProbeTarget { address, node_id: record.id })
+        (address.port() != 0 && Self::is_public_ip(address.ip()))
+            .then_some(RlpxProbeTarget { address, node_id: record.id })
+    }
+
+    /// Returns whether `ip` is a publicly routable unicast address. Rejecting
+    /// everything else keeps untrusted enodes from steering probes at
+    /// loopback, link-local (including cloud metadata), or private networks.
+    pub fn is_public_ip(ip: IpAddr) -> bool {
+        match ip {
+            IpAddr::V4(v4) => {
+                !(v4.is_unspecified()
+                    || v4.is_loopback()
+                    || v4.is_private()
+                    || v4.is_link_local()
+                    || v4.is_broadcast()
+                    || v4.is_documentation()
+                    || v4.is_multicast()
+                    // Carrier-grade NAT (100.64.0.0/10).
+                    || (v4.octets()[0] == 100 && v4.octets()[1] & 0xc0 == 0x40))
+            }
+            IpAddr::V6(v6) => {
+                let seg = v6.segments();
+                // IPv6 forms embedding an IPv4 address are judged by that
+                // address, so NAT64/6to4 gateways cannot be steered at
+                // internal targets: IPv4-mapped (::ffff:0:0/96), deprecated
+                // IPv4-compatible (::/96, excluding `::` and `::1`), the
+                // NAT64 well-known prefix (64:ff9b::/96), and 6to4
+                // (2002::/16).
+                let low_32 = || Ipv4Addr::from((u32::from(seg[6]) << 16) | u32::from(seg[7]));
+                let embedded_v4 = v6
+                    .to_ipv4_mapped()
+                    .or_else(|| {
+                        (seg[..6] == [0; 6] && !(v6.is_unspecified() || v6.is_loopback()))
+                            .then(low_32)
+                    })
+                    .or_else(|| (seg[..6] == [0x64, 0xff9b, 0, 0, 0, 0]).then(low_32))
+                    .or_else(|| {
+                        (seg[0] == 0x2002)
+                            .then(|| Ipv4Addr::from((u32::from(seg[1]) << 16) | u32::from(seg[2])))
+                    });
+                embedded_v4.map_or_else(
+                    || {
+                        !(v6.is_unspecified()
+                            || v6.is_loopback()
+                            || v6.is_multicast()
+                            // Unique local (fc00::/7).
+                            || seg[0] & 0xfe00 == 0xfc00
+                            // Link local (fe80::/10).
+                            || seg[0] & 0xffc0 == 0xfe80)
+                    },
+                    |v4| Self::is_public_ip(IpAddr::V4(v4)),
+                )
+            }
+        }
     }
 }
 
@@ -296,9 +353,28 @@ mod tests {
             P2pReachabilityRequest { enode: format!("enode://{TEST_NODE_ID}@example.com:30303") };
         assert!(hostname.target().is_none());
 
-        let private =
-            P2pReachabilityRequest { enode: format!("enode://{TEST_NODE_ID}@10.0.0.1:30303") };
-        assert_eq!(private.target().unwrap().address, SocketAddr::from(([10, 0, 0, 1], 30303)));
+        // Non-public targets are rejected to keep untrusted enodes from
+        // steering probes at internal networks.
+        for ip in [
+            "10.0.0.1",
+            "127.0.0.1",
+            "169.254.169.254",
+            "100.64.0.1",
+            "0.0.0.0",
+            "[::1]",
+            "[fc00::1]",
+            "[fe80::1]",
+            "[::ffff:10.0.0.1]",
+            // NAT64, 6to4, and IPv4-compatible, all embedding 10.0.0.1.
+            "[64:ff9b::a00:1]",
+            "[2002:a00:1::]",
+            "[::a00:1]",
+            "[::]",
+        ] {
+            let non_public =
+                P2pReachabilityRequest { enode: format!("enode://{TEST_NODE_ID}@{ip}:30303") };
+            assert!(non_public.target().is_none(), "expected {ip} to be rejected");
+        }
     }
 
     #[test]
@@ -346,7 +422,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn probes_private_target() {
+    async fn rejects_private_target() {
         let prober = Arc::new(FakeProber::default());
         let router = P2pRoutes::router_with_prober(
             P2P_REACHABILITY_MAX_CONCURRENT_PROBES,
@@ -363,11 +439,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(
-            prober.targets.lock().unwrap_or_else(PoisonError::into_inner)[0].address,
-            SocketAddr::from(([10, 0, 0, 1], 30303))
-        );
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert!(prober.targets.lock().unwrap_or_else(PoisonError::into_inner).is_empty());
         handle.abort();
     }
 

--- a/crates/infra/telemetry/src/p2p.rs
+++ b/crates/infra/telemetry/src/p2p.rs
@@ -25,8 +25,8 @@ use crate::prober::{ReachabilityProber, RlpxProbeOutcome, RlpxProbeStage, RlpxPr
 pub const P2P_REACHABILITY_PATH: &str = "/v1/p2p/reachability/el";
 /// Maximum JSON request body size accepted by the reachability route.
 pub const P2P_REACHABILITY_MAX_REQUEST_BYTES: usize = 1024;
-/// Maximum number of reachability probes allowed in flight globally.
-pub const P2P_REACHABILITY_MAX_CONCURRENT_PROBES: usize = 32;
+/// Default maximum number of reachability probes allowed in flight globally.
+pub const DEFAULT_P2P_REACHABILITY_MAX_CONCURRENT_PROBES: usize = 32;
 /// Valid execution-layer node identity shared by reachability tests.
 #[cfg(test)]
 pub const TEST_NODE_ID: &str = "2bd2e657bb3c8efffb8ff6db9071d9eb7be70d7c6d7d980ff80fc93b2629675c5f750bc0a5ef27cd788c2e491b8795a7e9a4a6e72178c14acc6753c0e5d77ae4";
@@ -59,15 +59,23 @@ impl P2pReachabilityRequest {
     pub const fn is_public_ip(ip: IpAddr) -> bool {
         match ip {
             IpAddr::V4(v4) => {
-                !(v4.is_unspecified()
-                    || v4.is_loopback()
+                !(v4.is_loopback()
                     || v4.is_private()
                     || v4.is_link_local()
-                    || v4.is_broadcast()
                     || v4.is_documentation()
                     || v4.is_multicast()
+                    // "This network" (0.0.0.0/8), including the unspecified address.
+                    || v4.octets()[0] == 0
                     // Carrier-grade NAT (100.64.0.0/10).
-                    || matches!(v4.octets(), [100, 64..=127, _, _]))
+                    || matches!(v4.octets(), [100, 64..=127, _, _])
+                    // Benchmarking (198.18.0.0/15).
+                    || matches!(v4.octets(), [198, 18..=19, _, _])
+                    // IETF Protocol Assignments (192.0.0.0/24).
+                    || matches!(v4.octets(), [192, 0, 0, _])
+                    // Deprecated 6to4 relay anycast (192.88.99.0/24).
+                    || matches!(v4.octets(), [192, 88, 99, _])
+                    // Reserved (240.0.0.0/4), including broadcast.
+                    || v4.octets()[0] >= 240)
             }
             IpAddr::V6(_) => false,
         }
@@ -209,63 +217,20 @@ impl P2pRoutes {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        net::SocketAddr,
-        str::FromStr,
-        sync::{Arc, Mutex, PoisonError},
-        time::Duration,
-    };
+    use std::{net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
 
     use alloy_primitives::B512;
-    use async_trait::async_trait;
     use axum::{Router, http::StatusCode};
     use tokio::{net::TcpListener, sync::Semaphore, task::JoinHandle};
 
     use super::{
-        P2P_REACHABILITY_MAX_CONCURRENT_PROBES, P2P_REACHABILITY_PATH, P2pReachabilityRequest,
-        P2pReachabilityResponse, P2pRoutes, TEST_NODE_ID,
+        DEFAULT_P2P_REACHABILITY_MAX_CONCURRENT_PROBES, P2P_REACHABILITY_PATH,
+        P2pReachabilityRequest, P2pReachabilityResponse, P2pRoutes, TEST_NODE_ID,
     };
     use crate::{
-        ReachabilityProber, RlpxProbeOutcome, RlpxProbeResult, RlpxProbeStage, RlpxProbeTarget,
+        BlockingProber, MockReachabilityProber, RlpxProbeOutcome, RlpxProbeResult, RlpxProbeStage,
+        RlpxProbeTarget,
     };
-
-    #[derive(Debug, Clone, Default)]
-    struct FakeProber {
-        targets: Arc<Mutex<Vec<RlpxProbeTarget>>>,
-    }
-
-    #[async_trait]
-    impl ReachabilityProber for FakeProber {
-        async fn probe(&self, target: RlpxProbeTarget) -> RlpxProbeResult {
-            self.targets.lock().unwrap_or_else(PoisonError::into_inner).push(target);
-            RlpxProbeResult {
-                outcome: RlpxProbeOutcome::Reachable,
-                stage: RlpxProbeStage::Devp2pHello,
-                elapsed: Duration::from_millis(12),
-                client_version: Some("test-peer/1.0".to_string()),
-            }
-        }
-    }
-
-    #[derive(Debug, Clone)]
-    struct BlockingProber {
-        entered: Arc<Semaphore>,
-        release: Arc<Semaphore>,
-    }
-
-    #[async_trait]
-    impl ReachabilityProber for BlockingProber {
-        async fn probe(&self, _: RlpxProbeTarget) -> RlpxProbeResult {
-            self.entered.add_permits(1);
-            self.release.acquire().await.unwrap().forget();
-            RlpxProbeResult {
-                outcome: RlpxProbeOutcome::Reachable,
-                stage: RlpxProbeStage::Devp2pHello,
-                elapsed: Duration::from_millis(1),
-                client_version: None,
-            }
-        }
-    }
 
     async fn start_test_server(router: Router) -> (SocketAddr, JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -324,6 +289,13 @@ mod tests {
             "169.254.169.254",
             "100.64.0.1",
             "0.0.0.0",
+            "0.1.2.3",
+            "198.18.0.1",
+            "198.19.255.255",
+            "192.0.0.8",
+            "192.88.99.1",
+            "240.0.0.1",
+            "255.255.255.255",
             "[2606:4700:4700::1111]",
             "[::1]",
             "[fc00::1]",
@@ -352,10 +324,23 @@ mod tests {
 
     #[tokio::test]
     async fn ignores_forwarded_header_and_probes_enode_address() {
-        let prober = Arc::new(FakeProber::default());
+        // A probe against any other target panics with no matching expectation.
+        let expected = RlpxProbeTarget {
+            address: SocketAddr::from(([8, 8, 8, 8], 30303)),
+            node_id: B512::from_str(TEST_NODE_ID).unwrap(),
+        };
+        let mut prober = MockReachabilityProber::new();
+        prober.expect_probe().times(1).withf(move |target| *target == expected).returning(|_| {
+            RlpxProbeResult {
+                outcome: RlpxProbeOutcome::Reachable,
+                stage: RlpxProbeStage::Devp2pHello,
+                elapsed: Duration::from_millis(12),
+                client_version: Some("test-peer/1.0".to_string()),
+            }
+        });
         let router = P2pRoutes::router_with_prober(
-            P2P_REACHABILITY_MAX_CONCURRENT_PROBES,
-            Arc::clone(&prober),
+            DEFAULT_P2P_REACHABILITY_MAX_CONCURRENT_PROBES,
+            Arc::new(prober),
         );
         let (address, handle) = start_test_server(router).await;
         let request = test_request();
@@ -373,23 +358,16 @@ mod tests {
         assert_eq!(response.outcome, RlpxProbeOutcome::Reachable);
         assert_eq!(response.observed_address, SocketAddr::from(([8, 8, 8, 8], 30303)));
         assert_eq!(response.client_version.as_deref(), Some("test-peer/1.0"));
-        assert_eq!(
-            prober.targets.lock().unwrap_or_else(PoisonError::into_inner).as_slice(),
-            &[RlpxProbeTarget {
-                address: SocketAddr::from(([8, 8, 8, 8], 30303)),
-                node_id: B512::from_str(TEST_NODE_ID).unwrap(),
-            }]
-        );
 
         handle.abort();
     }
 
     #[tokio::test]
     async fn rejects_private_target() {
-        let prober = Arc::new(FakeProber::default());
+        // No expectations: any probe call panics and fails the status assert.
         let router = P2pRoutes::router_with_prober(
-            P2P_REACHABILITY_MAX_CONCURRENT_PROBES,
-            Arc::clone(&prober),
+            DEFAULT_P2P_REACHABILITY_MAX_CONCURRENT_PROBES,
+            Arc::new(MockReachabilityProber::new()),
         );
         let (address, handle) = start_test_server(router).await;
         let request =
@@ -403,15 +381,14 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        assert!(prober.targets.lock().unwrap_or_else(PoisonError::into_inner).is_empty());
         handle.abort();
     }
 
     #[tokio::test]
     async fn rejects_oversized_body() {
         let router = P2pRoutes::router_with_prober(
-            P2P_REACHABILITY_MAX_CONCURRENT_PROBES,
-            Arc::new(FakeProber::default()),
+            DEFAULT_P2P_REACHABILITY_MAX_CONCURRENT_PROBES,
+            Arc::new(MockReachabilityProber::new()),
         );
         let (address, handle) = start_test_server(router).await;
 

--- a/crates/infra/telemetry/src/p2p.rs
+++ b/crates/infra/telemetry/src/p2p.rs
@@ -2,7 +2,7 @@
 //! and probe concurrency limits.
 
 use std::{
-    net::{IpAddr, Ipv4Addr, SocketAddr},
+    net::{IpAddr, SocketAddr},
     str::FromStr,
     sync::Arc,
 };
@@ -53,10 +53,10 @@ impl P2pReachabilityRequest {
             .then_some(RlpxProbeTarget { address, node_id: record.id })
     }
 
-    /// Returns whether `ip` is a publicly routable unicast address. Rejecting
-    /// everything else keeps untrusted enodes from steering probes at
-    /// loopback, link-local (including cloud metadata), or private networks.
-    pub fn is_public_ip(ip: IpAddr) -> bool {
+    /// Returns whether `ip` is a supported, publicly routable `IPv4` address.
+    /// `IPv6` and non-public targets are rejected because the execution P2P
+    /// network currently supports only public `IPv4` reachability probes.
+    pub const fn is_public_ip(ip: IpAddr) -> bool {
         match ip {
             IpAddr::V4(v4) => {
                 !(v4.is_unspecified()
@@ -67,41 +67,9 @@ impl P2pReachabilityRequest {
                     || v4.is_documentation()
                     || v4.is_multicast()
                     // Carrier-grade NAT (100.64.0.0/10).
-                    || (v4.octets()[0] == 100 && v4.octets()[1] & 0xc0 == 0x40))
+                    || matches!(v4.octets(), [100, 64..=127, _, _]))
             }
-            IpAddr::V6(v6) => {
-                let seg = v6.segments();
-                // IPv6 forms embedding an IPv4 address are judged by that
-                // address, so NAT64/6to4 gateways cannot be steered at
-                // internal targets: IPv4-mapped (::ffff:0:0/96), deprecated
-                // IPv4-compatible (::/96, excluding `::` and `::1`), the
-                // NAT64 well-known prefix (64:ff9b::/96), and 6to4
-                // (2002::/16).
-                let low_32 = || Ipv4Addr::from((u32::from(seg[6]) << 16) | u32::from(seg[7]));
-                let embedded_v4 = v6
-                    .to_ipv4_mapped()
-                    .or_else(|| {
-                        (seg[..6] == [0; 6] && !(v6.is_unspecified() || v6.is_loopback()))
-                            .then(low_32)
-                    })
-                    .or_else(|| (seg[..6] == [0x64, 0xff9b, 0, 0, 0, 0]).then(low_32))
-                    .or_else(|| {
-                        (seg[0] == 0x2002)
-                            .then(|| Ipv4Addr::from((u32::from(seg[1]) << 16) | u32::from(seg[2])))
-                    });
-                embedded_v4.map_or_else(
-                    || {
-                        !(v6.is_unspecified()
-                            || v6.is_loopback()
-                            || v6.is_multicast()
-                            // Unique local (fc00::/7).
-                            || seg[0] & 0xfe00 == 0xfc00
-                            // Link local (fe80::/10).
-                            || seg[0] & 0xffc0 == 0xfe80)
-                    },
-                    |v4| Self::is_public_ip(IpAddr::V4(v4)),
-                )
-            }
+            IpAddr::V6(_) => false,
         }
     }
 }
@@ -332,11 +300,6 @@ mod tests {
         };
         assert!(invalid_discport.target().is_none());
 
-        let ipv6 = P2pReachabilityRequest {
-            enode: format!("enode://{TEST_NODE_ID}@[2606:4700:4700::1111]:30303"),
-        };
-        assert_eq!(ipv6.target().unwrap().address, "[2606:4700:4700::1111]:30303".parse().unwrap());
-
         let zero_port =
             P2pReachabilityRequest { enode: format!("enode://{TEST_NODE_ID}@8.8.8.8:0") };
         assert!(zero_port.target().is_none());
@@ -361,11 +324,11 @@ mod tests {
             "169.254.169.254",
             "100.64.0.1",
             "0.0.0.0",
+            "[2606:4700:4700::1111]",
             "[::1]",
             "[fc00::1]",
             "[fe80::1]",
             "[::ffff:10.0.0.1]",
-            // NAT64, 6to4, and IPv4-compatible, all embedding 10.0.0.1.
             "[64:ff9b::a00:1]",
             "[2002:a00:1::]",
             "[::a00:1]",

--- a/crates/infra/telemetry/src/prober.rs
+++ b/crates/infra/telemetry/src/prober.rs
@@ -131,6 +131,7 @@ pub struct RlpxProbeResult {
 }
 
 /// Interface used by the HTTP route to execute reachability probes.
+#[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait ReachabilityProber: fmt::Debug + Send + Sync {
     /// Probes one execution-layer target.

--- a/crates/infra/telemetry/src/rate_limit.rs
+++ b/crates/infra/telemetry/src/rate_limit.rs
@@ -2,7 +2,7 @@
 
 use std::{
     fmt,
-    net::{IpAddr, SocketAddr},
+    net::{IpAddr, Ipv6Addr, SocketAddr},
     num::NonZeroU32,
     sync::Arc,
     time::Duration,
@@ -17,7 +17,6 @@ use axum::{
     middleware::Next,
     response::{IntoResponse, Response},
 };
-use axum_client_ip::{Rejection as ClientIpRejection, RightmostXForwardedFor};
 use base_http_utils::TrustedProxyConfig;
 use governor::{
     DefaultKeyedRateLimiter, Quota, RateLimiter,
@@ -25,7 +24,7 @@ use governor::{
 };
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-use tracing::debug;
+use tracing::{debug, warn};
 
 /// Default P2P probe requests allowed per client IP per minute.
 pub const DEFAULT_P2P_PROBE_REQUESTS_PER_MINUTE: NonZeroU32 = NonZeroU32::new(2).unwrap();
@@ -85,9 +84,25 @@ impl IpRateLimiter {
         Self { limiter: RateLimiter::dashmap_with_clock(quota, clock.clone()), clock }
     }
 
+    /// Returns the rate-limit bucket key for `ip`.
+    ///
+    /// `IPv4` addresses key individually, while `IPv6` addresses key by
+    /// their /64 prefix: clients routinely hold an entire /64 delegation, so
+    /// keying on exact addresses would let them defeat the quota by rotating
+    /// the interface identifier on every request.
+    pub const fn bucket_key(ip: IpAddr) -> IpAddr {
+        match ip.to_canonical() {
+            ip @ IpAddr::V4(_) => ip,
+            IpAddr::V6(v6) => {
+                let seg = v6.segments();
+                IpAddr::V6(Ipv6Addr::new(seg[0], seg[1], seg[2], seg[3], 0, 0, 0, 0))
+            }
+        }
+    }
+
     /// Checks one request for `ip`, returning the retry delay when limited.
     pub fn check(&self, ip: IpAddr) -> Result<(), RateLimitExceeded> {
-        self.limiter.check_key(&ip).map_err(|not_until| RateLimitExceeded {
+        self.limiter.check_key(&Self::bucket_key(ip)).map_err(|not_until| RateLimitExceeded {
             retry_after: not_until.wait_time_from(self.clock.now()),
         })
     }
@@ -124,18 +139,19 @@ impl PerIpRateLimit {
     pub async fn enforce(
         State(state): State<Self>,
         ConnectInfo(peer): ConnectInfo<SocketAddr>,
-        forwarded_ip: Result<RightmostXForwardedFor, ClientIpRejection>,
         request: Request,
         next: Next,
     ) -> Response {
-        let peer_ip = peer.ip().to_canonical();
-        let client_ip = if state.proxy.is_trusted_proxy(peer_ip) {
-            match forwarded_ip {
-                Ok(RightmostXForwardedFor(ip)) => ip.to_canonical(),
-                Err(error) => return error.into_response(),
+        let peer_ip = peer.ip();
+        let client_ip = match state.proxy.try_client_ip(peer_ip, request.headers()) {
+            Ok(ip) => ip,
+            Err(error) => {
+                // A trusted proxy must always supply the client IP header;
+                // its absence means the fronting infrastructure is
+                // misconfigured, not that the client erred.
+                warn!(error = %error, peer = %peer_ip, "trusted proxy sent no valid client IP");
+                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
             }
-        } else {
-            peer_ip
         };
         match state.limiter.check(client_ip) {
             Ok(()) => next.run(request).await,
@@ -170,6 +186,18 @@ mod tests {
         let exceeded = limiter.check(first).unwrap_err();
         assert!(exceeded.retry_after > Duration::ZERO);
         assert!(limiter.check(second).is_ok());
+    }
+
+    #[test]
+    fn ipv6_clients_share_one_bucket_per_64_prefix() {
+        let limiter = IpRateLimiter::per_minute(nz(1));
+        let first: IpAddr = "2001:db8:1:2:aaaa::1".parse().unwrap();
+        let rotated: IpAddr = "2001:db8:1:2:bbbb::2".parse().unwrap();
+        let other_prefix: IpAddr = "2001:db8:1:3::1".parse().unwrap();
+
+        assert!(limiter.check(first).is_ok());
+        assert!(limiter.check(rotated).is_err());
+        assert!(limiter.check(other_prefix).is_ok());
     }
 
     #[test]

--- a/crates/infra/telemetry/src/rate_limit.rs
+++ b/crates/infra/telemetry/src/rate_limit.rs
@@ -24,7 +24,7 @@ use governor::{
 };
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, warn};
+use tracing::debug;
 
 /// Default P2P probe requests allowed per client IP per minute.
 pub const DEFAULT_P2P_PROBE_REQUESTS_PER_MINUTE: NonZeroU32 = NonZeroU32::new(2).unwrap();
@@ -142,17 +142,7 @@ impl PerIpRateLimit {
         request: Request,
         next: Next,
     ) -> Response {
-        let peer_ip = peer.ip();
-        let client_ip = match state.proxy.try_client_ip(peer_ip, request.headers()) {
-            Ok(ip) => ip,
-            Err(error) => {
-                // A trusted proxy must always supply the client IP header;
-                // its absence means the fronting infrastructure is
-                // misconfigured, not that the client erred.
-                warn!(error = %error, peer = %peer_ip, "trusted proxy sent no valid client IP");
-                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
-            }
-        };
+        let client_ip = state.proxy.client_ip(peer.ip(), request.headers());
         match state.limiter.check(client_ip) {
             Ok(()) => next.run(request).await,
             Err(exceeded) => {

--- a/crates/infra/telemetry/src/rate_limit.rs
+++ b/crates/infra/telemetry/src/rate_limit.rs
@@ -17,6 +17,7 @@ use axum::{
     middleware::Next,
     response::{IntoResponse, Response},
 };
+use axum_client_ip::{Rejection as ClientIpRejection, RightmostXForwardedFor};
 use base_http_utils::TrustedProxyConfig;
 use governor::{
     DefaultKeyedRateLimiter, Quota, RateLimiter,
@@ -26,8 +27,8 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
 
-/// Requests allowed per client IP per minute.
-pub const RATE_LIMIT_PER_IP_REQUESTS_PER_MINUTE: NonZeroU32 = NonZeroU32::new(2).unwrap();
+/// Default P2P probe requests allowed per client IP per minute.
+pub const DEFAULT_P2P_PROBE_REQUESTS_PER_MINUTE: NonZeroU32 = NonZeroU32::new(2).unwrap();
 /// Interval between stale rate-limit bucket eviction passes.
 pub const RATE_LIMIT_EVICTION_INTERVAL: Duration = Duration::from_secs(60);
 /// HTTP header carrying the client IP, set by the fronting proxy.
@@ -123,10 +124,19 @@ impl PerIpRateLimit {
     pub async fn enforce(
         State(state): State<Self>,
         ConnectInfo(peer): ConnectInfo<SocketAddr>,
+        forwarded_ip: Result<RightmostXForwardedFor, ClientIpRejection>,
         request: Request,
         next: Next,
     ) -> Response {
-        let client_ip = state.proxy.client_ip(peer.ip(), request.headers());
+        let peer_ip = peer.ip().to_canonical();
+        let client_ip = if state.proxy.is_trusted_proxy(peer_ip) {
+            match forwarded_ip {
+                Ok(RightmostXForwardedFor(ip)) => ip.to_canonical(),
+                Err(error) => return error.into_response(),
+            }
+        } else {
+            peer_ip
+        };
         match state.limiter.check(client_ip) {
             Ok(()) => next.run(request).await,
             Err(exceeded) => {

--- a/crates/infra/telemetry/src/rate_limit.rs
+++ b/crates/infra/telemetry/src/rate_limit.rs
@@ -1,0 +1,185 @@
+//! Per-client-IP request rate limiting middleware for the telemetry HTTP API.
+
+use std::{
+    fmt,
+    net::{IpAddr, SocketAddr},
+    num::NonZeroU32,
+    sync::Arc,
+    time::Duration,
+};
+
+use axum::{
+    extract::{ConnectInfo, Request, State},
+    http::{
+        StatusCode,
+        header::{CONTENT_TYPE, RETRY_AFTER},
+    },
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use base_http_utils::TrustedProxyConfig;
+use governor::{
+    DefaultKeyedRateLimiter, Quota, RateLimiter,
+    clock::{Clock, DefaultClock},
+};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tracing::debug;
+
+/// Requests allowed per client IP per minute.
+pub const RATE_LIMIT_PER_IP_REQUESTS_PER_MINUTE: NonZeroU32 = NonZeroU32::new(2).unwrap();
+/// Interval between stale rate-limit bucket eviction passes.
+pub const RATE_LIMIT_EVICTION_INTERVAL: Duration = Duration::from_secs(60);
+/// HTTP header carrying the client IP, set by the fronting proxy.
+pub const CLIENT_IP_HEADER: &str = "X-Forwarded-For";
+/// JSON body returned when a request exceeds a rate limit.
+pub const RATE_LIMITED_BODY: &str = r#"{"error":"rate_limited"}"#;
+
+/// Rejection produced when a request exceeds a rate limit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RateLimitExceeded {
+    /// Time until the next request conforms to the quota.
+    pub retry_after: Duration,
+}
+
+impl RateLimitExceeded {
+    /// Returns the `Retry-After` value in whole seconds, rounded up.
+    pub fn retry_after_secs(&self) -> u64 {
+        let secs = self.retry_after.as_secs() + u64::from(self.retry_after.subsec_nanos() > 0);
+        secs.max(1)
+    }
+}
+
+impl IntoResponse for RateLimitExceeded {
+    fn into_response(self) -> Response {
+        (
+            StatusCode::TOO_MANY_REQUESTS,
+            [
+                (RETRY_AFTER, self.retry_after_secs().to_string()),
+                (CONTENT_TYPE, "application/json".to_string()),
+            ],
+            RATE_LIMITED_BODY,
+        )
+            .into_response()
+    }
+}
+
+/// GCRA rate limiter keyed by client IP, applied as Axum middleware.
+pub struct IpRateLimiter {
+    limiter: DefaultKeyedRateLimiter<IpAddr>,
+    clock: DefaultClock,
+}
+
+impl fmt::Debug for IpRateLimiter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IpRateLimiter").finish_non_exhaustive()
+    }
+}
+
+impl IpRateLimiter {
+    /// Creates a limiter allowing `per_minute` requests per key.
+    pub fn per_minute(per_minute: NonZeroU32) -> Self {
+        let clock = DefaultClock::default();
+        let quota = Quota::per_minute(per_minute);
+        Self { limiter: RateLimiter::dashmap_with_clock(quota, clock.clone()), clock }
+    }
+
+    /// Checks one request for `ip`, returning the retry delay when limited.
+    pub fn check(&self, ip: IpAddr) -> Result<(), RateLimitExceeded> {
+        self.limiter.check_key(&ip).map_err(|not_until| RateLimitExceeded {
+            retry_after: not_until.wait_time_from(self.clock.now()),
+        })
+    }
+
+    /// Spawns a background task that periodically evicts stale buckets until
+    /// the token is cancelled.
+    pub fn spawn_eviction_task(self: &Arc<Self>, cancel: CancellationToken) -> JoinHandle<()> {
+        let this = Arc::clone(self);
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    () = cancel.cancelled() => break,
+                    () = tokio::time::sleep(RATE_LIMIT_EVICTION_INTERVAL) => this.limiter.retain_recent(),
+                }
+            }
+        })
+    }
+}
+
+/// Axum middleware state enforcing the per-client-IP request quota.
+#[derive(Debug, Clone)]
+pub struct PerIpRateLimit {
+    limiter: Arc<IpRateLimiter>,
+    proxy: Arc<TrustedProxyConfig>,
+}
+
+impl PerIpRateLimit {
+    /// Creates middleware state from a limiter and trusted proxy configuration.
+    pub const fn new(limiter: Arc<IpRateLimiter>, proxy: Arc<TrustedProxyConfig>) -> Self {
+        Self { limiter, proxy }
+    }
+
+    /// Axum middleware entry point; use with `middleware::from_fn_with_state`.
+    pub async fn enforce(
+        State(state): State<Self>,
+        ConnectInfo(peer): ConnectInfo<SocketAddr>,
+        request: Request,
+        next: Next,
+    ) -> Response {
+        let client_ip = state.proxy.client_ip(peer.ip(), request.headers());
+        match state.limiter.check(client_ip) {
+            Ok(()) => next.run(request).await,
+            Err(exceeded) => {
+                debug!(client = %client_ip, retry_after_secs = exceeded.retry_after_secs(), "request rate limited");
+                exceeded.into_response()
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use axum::http::header::RETRY_AFTER;
+
+    use super::*;
+
+    const fn nz(value: u32) -> NonZeroU32 {
+        NonZeroU32::new(value).unwrap()
+    }
+
+    #[test]
+    fn limits_after_quota_and_keys_independently() {
+        let limiter = IpRateLimiter::per_minute(nz(2));
+        let first = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
+        let second = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2));
+
+        assert!(limiter.check(first).is_ok());
+        assert!(limiter.check(first).is_ok());
+        let exceeded = limiter.check(first).unwrap_err();
+        assert!(exceeded.retry_after > Duration::ZERO);
+        assert!(limiter.check(second).is_ok());
+    }
+
+    #[test]
+    fn retry_after_rounds_up_to_at_least_one_second() {
+        assert_eq!(
+            RateLimitExceeded { retry_after: Duration::from_millis(1) }.retry_after_secs(),
+            1
+        );
+        assert_eq!(RateLimitExceeded { retry_after: Duration::ZERO }.retry_after_secs(), 1);
+        assert_eq!(
+            RateLimitExceeded { retry_after: Duration::from_millis(2500) }.retry_after_secs(),
+            3
+        );
+    }
+
+    #[test]
+    fn rate_limited_response_carries_status_and_retry_after() {
+        let response = RateLimitExceeded { retry_after: Duration::from_secs(7) }.into_response();
+
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(response.headers().get(RETRY_AFTER).unwrap(), "7");
+    }
+}

--- a/crates/infra/telemetry/src/server.rs
+++ b/crates/infra/telemetry/src/server.rs
@@ -7,14 +7,19 @@ use std::{
 };
 
 use anyhow::Context;
-use axum::Router;
+use axum::{Router, middleware};
 use base_health::HealthServer;
+use base_http_utils::TrustedProxyConfig;
 use clap::Args;
+use ipnet::IpNet;
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
-use crate::{P2P_REACHABILITY_MAX_CONCURRENT_PROBES, P2pRoutes, RlpxProber};
+use crate::{
+    CLIENT_IP_HEADER, IpRateLimiter, P2P_REACHABILITY_MAX_CONCURRENT_PROBES, P2pRoutes,
+    PerIpRateLimit, RATE_LIMIT_PER_IP_REQUESTS_PER_MINUTE, ReachabilityProber, RlpxProber,
+};
 
 /// Configuration for the Base telemetry HTTP server.
 #[derive(Args, Debug, Clone)]
@@ -22,6 +27,9 @@ pub struct ServerConfig {
     /// Socket address to bind the HTTP server to.
     #[arg(long, env = "BASE_TELEMETRY_LISTEN_ADDR", default_value = "0.0.0.0:8080")]
     pub listen_addr: SocketAddr,
+    /// Comma-separated CIDRs of proxies trusted to supply the `X-Forwarded-For` client IP.
+    #[arg(long, env = "BASE_TELEMETRY_TRUSTED_PROXY_CIDRS", value_delimiter = ',')]
+    pub trusted_proxy_cidrs: Vec<IpNet>,
 }
 
 /// Base telemetry Axum server scaffold.
@@ -29,19 +37,36 @@ pub struct ServerConfig {
 pub struct BaseTelemetryServer;
 
 impl BaseTelemetryServer {
-    /// Returns the application router for the telemetry service.
-    pub fn router(ready: Arc<AtomicBool>) -> Router {
-        HealthServer::router(ready).merge(P2pRoutes::router_with_prober(
-            P2P_REACHABILITY_MAX_CONCURRENT_PROBES,
-            Arc::new(RlpxProber::ephemeral()),
-        ))
+    /// Returns the application router using an injected prober.
+    pub fn router_with_prober<P>(
+        ready: Arc<AtomicBool>,
+        per_ip: PerIpRateLimit,
+        prober: Arc<P>,
+    ) -> Router
+    where
+        P: ReachabilityProber + 'static,
+    {
+        let p2p = P2pRoutes::router_with_prober(P2P_REACHABILITY_MAX_CONCURRENT_PROBES, prober)
+            .layer(middleware::from_fn_with_state(per_ip, PerIpRateLimit::enforce));
+        HealthServer::router(ready).merge(p2p)
     }
 
     /// Starts the telemetry service with the provided configuration.
     pub async fn serve(config: ServerConfig, cancel: CancellationToken) -> anyhow::Result<()> {
-        let ServerConfig { listen_addr } = config;
+        let listen_addr = config.listen_addr;
+        let proxy = Arc::new(TrustedProxyConfig::new(
+            CLIENT_IP_HEADER.to_string(),
+            config.trusted_proxy_cidrs,
+        ));
+        let limiter = Arc::new(IpRateLimiter::per_minute(RATE_LIMIT_PER_IP_REQUESTS_PER_MINUTE));
+        let eviction = limiter.spawn_eviction_task(cancel.clone());
+
         let ready = Arc::new(AtomicBool::new(false));
-        let app = Self::router(Arc::clone(&ready));
+        let app = Self::router_with_prober(
+            Arc::clone(&ready),
+            PerIpRateLimit::new(limiter, proxy),
+            Arc::new(RlpxProber::ephemeral()),
+        );
         let listener = TcpListener::bind(listen_addr)
             .await
             .with_context(|| format!("failed to bind base telemetry server to {listen_addr}"))?;
@@ -52,10 +77,12 @@ impl BaseTelemetryServer {
 
         info!(listen_addr = %listen_addr, "base telemetry server started");
 
-        axum::serve(listener, app)
+        axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>())
             .with_graceful_shutdown(async move { cancel.cancelled().await })
             .await
             .context("base telemetry server exited unexpectedly")?;
+
+        let _ = eviction.await;
 
         Ok(())
     }
@@ -65,20 +92,36 @@ impl BaseTelemetryServer {
 mod tests {
     use std::{
         net::SocketAddr,
+        num::NonZeroU32,
         sync::{Arc, atomic::AtomicBool},
         time::Duration,
     };
 
     use async_trait::async_trait;
     use axum::{Router, http::StatusCode};
-    use base_health::HealthServer;
+    use base_http_utils::TrustedProxyConfig;
     use tokio::{net::TcpListener, sync::Semaphore, task::JoinHandle};
 
     use crate::{
-        BaseTelemetryServer, P2P_REACHABILITY_PATH, P2pReachabilityRequest, P2pRoutes,
-        ReachabilityProber, RlpxProbeOutcome, RlpxProbeResult, RlpxProbeStage, RlpxProbeTarget,
-        TEST_NODE_ID,
+        BaseTelemetryServer, IpRateLimiter, P2P_REACHABILITY_PATH, P2pReachabilityRequest,
+        PerIpRateLimit, ReachabilityProber, RlpxProbeOutcome, RlpxProbeResult, RlpxProbeStage,
+        RlpxProbeTarget, TEST_NODE_ID,
     };
+
+    #[derive(Debug, Clone, Default)]
+    struct FakeProber;
+
+    #[async_trait]
+    impl ReachabilityProber for FakeProber {
+        async fn probe(&self, _: RlpxProbeTarget) -> RlpxProbeResult {
+            RlpxProbeResult {
+                outcome: RlpxProbeOutcome::Reachable,
+                stage: RlpxProbeStage::Devp2pHello,
+                elapsed: Duration::from_millis(1),
+                client_version: None,
+            }
+        }
+    }
 
     #[derive(Debug, Clone)]
     struct BlockingProber {
@@ -100,17 +143,36 @@ mod tests {
         }
     }
 
+    fn per_ip(per_minute: u32, trusted_proxy_cidrs: Vec<&str>) -> PerIpRateLimit {
+        let cidrs = trusted_proxy_cidrs.into_iter().map(|cidr| cidr.parse().unwrap()).collect();
+        PerIpRateLimit::new(
+            Arc::new(IpRateLimiter::per_minute(NonZeroU32::new(per_minute).unwrap())),
+            Arc::new(TrustedProxyConfig::new("x-forwarded-for".to_string(), cidrs)),
+        )
+    }
+
     async fn start_router(router: Router) -> (SocketAddr, JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let handle = tokio::spawn(async move {
-            axum::serve(listener, router).await.unwrap();
+            axum::serve(listener, router.into_make_service_with_connect_info::<SocketAddr>())
+                .await
+                .unwrap();
         });
         (addr, handle)
     }
 
     async fn start_test_server() -> (SocketAddr, JoinHandle<()>) {
-        start_router(BaseTelemetryServer::router(Arc::new(AtomicBool::new(true)))).await
+        start_router(BaseTelemetryServer::router_with_prober(
+            Arc::new(AtomicBool::new(true)),
+            per_ip(1000, vec![]),
+            Arc::new(FakeProber),
+        ))
+        .await
+    }
+
+    fn test_request() -> P2pReachabilityRequest {
+        P2pReachabilityRequest { enode: format!("enode://{TEST_NODE_ID}@8.8.8.8:30303") }
     }
 
     #[tokio::test]
@@ -141,11 +203,13 @@ mod tests {
             entered: Arc::new(Semaphore::new(0)),
             release: Arc::new(Semaphore::new(0)),
         });
-        let router = HealthServer::router(Arc::new(AtomicBool::new(true)))
-            .merge(P2pRoutes::router_with_prober(1, Arc::clone(&prober)));
+        let router = BaseTelemetryServer::router_with_prober(
+            Arc::new(AtomicBool::new(true)),
+            per_ip(1000, vec![]),
+            Arc::clone(&prober),
+        );
         let (addr, handle) = start_router(router).await;
-        let request =
-            P2pReachabilityRequest { enode: format!("enode://{TEST_NODE_ID}@8.8.8.8:30303") };
+        let request = test_request();
         let client = reqwest::Client::new();
         let probe_client = client.clone();
 
@@ -172,6 +236,108 @@ mod tests {
 
         prober.release.add_permits(1);
         assert_eq!(probe.await.unwrap().status(), StatusCode::OK);
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn rate_limits_requests_per_client_ip() {
+        let router = BaseTelemetryServer::router_with_prober(
+            Arc::new(AtomicBool::new(true)),
+            per_ip(1, vec![]),
+            Arc::new(FakeProber),
+        );
+        let (addr, handle) = start_router(router).await;
+        let client = reqwest::Client::new();
+        let url = format!("http://{addr}{P2P_REACHABILITY_PATH}");
+
+        let first = client.post(&url).json(&test_request()).send().await.unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
+
+        let second = client.post(&url).json(&test_request()).send().await.unwrap();
+        assert_eq!(second.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert!(second.headers().contains_key("retry-after"));
+        assert_eq!(second.text().await.unwrap(), r#"{"error":"rate_limited"}"#);
+
+        // Health routes are not subject to the per-IP limit.
+        let health = client.get(format!("http://{addr}/healthz")).send().await.unwrap();
+        assert_eq!(health.status(), StatusCode::OK);
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn ignores_forwarded_header_from_untrusted_peer() {
+        let router = BaseTelemetryServer::router_with_prober(
+            Arc::new(AtomicBool::new(true)),
+            per_ip(1, vec![]),
+            Arc::new(FakeProber),
+        );
+        let (addr, handle) = start_router(router).await;
+        let client = reqwest::Client::new();
+        let url = format!("http://{addr}{P2P_REACHABILITY_PATH}");
+
+        let first = client
+            .post(&url)
+            .header("x-forwarded-for", "198.51.100.1")
+            .json(&test_request())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
+
+        // A spoofed header must not open a fresh rate-limit bucket.
+        let second = client
+            .post(&url)
+            .header("x-forwarded-for", "198.51.100.2")
+            .json(&test_request())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(second.status(), StatusCode::TOO_MANY_REQUESTS);
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn honors_forwarded_header_from_trusted_proxy() {
+        let router = BaseTelemetryServer::router_with_prober(
+            Arc::new(AtomicBool::new(true)),
+            per_ip(1, vec!["127.0.0.0/8"]),
+            Arc::new(FakeProber),
+        );
+        let (addr, handle) = start_router(router).await;
+        let client = reqwest::Client::new();
+        let url = format!("http://{addr}{P2P_REACHABILITY_PATH}");
+
+        let first = client
+            .post(&url)
+            .header("x-forwarded-for", "198.51.100.1")
+            .json(&test_request())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
+
+        // Distinct forwarded clients get independent buckets.
+        let second = client
+            .post(&url)
+            .header("x-forwarded-for", "198.51.100.2")
+            .json(&test_request())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(second.status(), StatusCode::OK);
+
+        // The same forwarded client is limited.
+        let third = client
+            .post(&url)
+            .header("x-forwarded-for", "198.51.100.1")
+            .json(&test_request())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(third.status(), StatusCode::TOO_MANY_REQUESTS);
+
         handle.abort();
     }
 }

--- a/crates/infra/telemetry/src/server.rs
+++ b/crates/infra/telemetry/src/server.rs
@@ -381,7 +381,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rejects_missing_forwarded_header_from_trusted_proxy() {
+    async fn missing_forwarded_header_from_trusted_proxy_falls_back_to_peer() {
         let router = BaseTelemetryServer::router_with_prober(
             Arc::new(AtomicBool::new(true)),
             per_ip(1, vec!["127.0.0.0/8"]),
@@ -389,15 +389,16 @@ mod tests {
             reachable_prober(),
         );
         let (addr, handle) = start_router(router).await;
+        let client = reqwest::Client::new();
+        let url = format!("http://{addr}{P2P_REACHABILITY_PATH}");
 
-        let response = reqwest::Client::new()
-            .post(format!("http://{addr}{P2P_REACHABILITY_PATH}"))
-            .json(&test_request())
-            .send()
-            .await
-            .unwrap();
+        let first = client.post(&url).json(&test_request()).send().await.unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
 
-        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        // Without a forwarding header the peer address keys the bucket.
+        let second = client.post(&url).json(&test_request()).send().await.unwrap();
+        assert_eq!(second.status(), StatusCode::TOO_MANY_REQUESTS);
+
         handle.abort();
     }
 }

--- a/crates/infra/telemetry/src/server.rs
+++ b/crates/infra/telemetry/src/server.rs
@@ -11,16 +11,16 @@ use anyhow::Context;
 use axum::{Router, middleware};
 use base_health::HealthServer;
 use base_http_utils::TrustedProxyConfig;
-use clap::Args;
+use clap::{Args, builder::RangedU64ValueParser};
 use ipnet::IpNet;
-use tokio::net::TcpListener;
+use tokio::{net::TcpListener, sync::Semaphore};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use crate::{
-    CLIENT_IP_HEADER, DEFAULT_P2P_PROBE_REQUESTS_PER_MINUTE, IpRateLimiter,
-    P2P_REACHABILITY_MAX_CONCURRENT_PROBES, P2pRoutes, PerIpRateLimit, ReachabilityProber,
-    RlpxProber,
+    CLIENT_IP_HEADER, DEFAULT_P2P_PROBE_REQUESTS_PER_MINUTE,
+    DEFAULT_P2P_REACHABILITY_MAX_CONCURRENT_PROBES, IpRateLimiter, P2pRoutes, PerIpRateLimit,
+    ReachabilityProber, RlpxProber,
 };
 
 /// Configuration for the Base telemetry HTTP server.
@@ -39,6 +39,14 @@ pub struct ServerConfig {
         default_value_t = DEFAULT_P2P_PROBE_REQUESTS_PER_MINUTE
     )]
     pub p2p_probe_requests_per_minute: NonZeroU32,
+    /// Maximum number of P2P reachability probes allowed in flight globally.
+    #[arg(
+        long,
+        env = "BASE_TELEMETRY_P2P_MAX_CONCURRENT_PROBES",
+        default_value_t = DEFAULT_P2P_REACHABILITY_MAX_CONCURRENT_PROBES,
+        value_parser = RangedU64ValueParser::<usize>::new().range(1..=Semaphore::MAX_PERMITS as u64)
+    )]
+    pub p2p_max_concurrent_probes: usize,
 }
 
 /// Base telemetry Axum server scaffold.
@@ -50,12 +58,13 @@ impl BaseTelemetryServer {
     pub fn router_with_prober<P>(
         ready: Arc<AtomicBool>,
         per_ip: PerIpRateLimit,
+        max_concurrent_probes: usize,
         prober: Arc<P>,
     ) -> Router
     where
         P: ReachabilityProber + 'static,
     {
-        let p2p = P2pRoutes::router_with_prober(P2P_REACHABILITY_MAX_CONCURRENT_PROBES, prober)
+        let p2p = P2pRoutes::router_with_prober(max_concurrent_probes, prober)
             .layer(middleware::from_fn_with_state(per_ip, PerIpRateLimit::enforce));
         HealthServer::router(ready).merge(p2p)
     }
@@ -74,6 +83,7 @@ impl BaseTelemetryServer {
         let app = Self::router_with_prober(
             Arc::clone(&ready),
             PerIpRateLimit::new(limiter, proxy),
+            config.p2p_max_concurrent_probes,
             Arc::new(RlpxProber::ephemeral()),
         );
         let listener = TcpListener::bind(listen_addr)
@@ -106,50 +116,26 @@ mod tests {
         time::Duration,
     };
 
-    use async_trait::async_trait;
     use axum::{Router, http::StatusCode};
     use base_http_utils::TrustedProxyConfig;
     use tokio::{net::TcpListener, sync::Semaphore, task::JoinHandle};
 
     use crate::{
-        BaseTelemetryServer, IpRateLimiter, P2P_REACHABILITY_PATH, P2pReachabilityRequest,
-        PerIpRateLimit, ReachabilityProber, RlpxProbeOutcome, RlpxProbeResult, RlpxProbeStage,
-        RlpxProbeTarget, TEST_NODE_ID,
+        BaseTelemetryServer, BlockingProber, DEFAULT_P2P_REACHABILITY_MAX_CONCURRENT_PROBES,
+        IpRateLimiter, MockReachabilityProber, P2P_REACHABILITY_PATH, P2pReachabilityRequest,
+        PerIpRateLimit, RlpxProbeOutcome, RlpxProbeResult, RlpxProbeStage, TEST_NODE_ID,
     };
 
-    #[derive(Debug, Clone, Default)]
-    struct FakeProber;
-
-    #[async_trait]
-    impl ReachabilityProber for FakeProber {
-        async fn probe(&self, _: RlpxProbeTarget) -> RlpxProbeResult {
-            RlpxProbeResult {
-                outcome: RlpxProbeOutcome::Reachable,
-                stage: RlpxProbeStage::Devp2pHello,
-                elapsed: Duration::from_millis(1),
-                client_version: None,
-            }
-        }
-    }
-
-    #[derive(Debug, Clone)]
-    struct BlockingProber {
-        entered: Arc<Semaphore>,
-        release: Arc<Semaphore>,
-    }
-
-    #[async_trait]
-    impl ReachabilityProber for BlockingProber {
-        async fn probe(&self, _: RlpxProbeTarget) -> RlpxProbeResult {
-            self.entered.add_permits(1);
-            self.release.acquire().await.unwrap().forget();
-            RlpxProbeResult {
-                outcome: RlpxProbeOutcome::Reachable,
-                stage: RlpxProbeStage::Devp2pHello,
-                elapsed: Duration::from_millis(1),
-                client_version: None,
-            }
-        }
+    /// Returns a mock prober that answers every probe as reachable.
+    fn reachable_prober() -> Arc<MockReachabilityProber> {
+        let mut prober = MockReachabilityProber::new();
+        prober.expect_probe().returning(|_| RlpxProbeResult {
+            outcome: RlpxProbeOutcome::Reachable,
+            stage: RlpxProbeStage::Devp2pHello,
+            elapsed: Duration::from_millis(1),
+            client_version: None,
+        });
+        Arc::new(prober)
     }
 
     fn per_ip(per_minute: u32, trusted_proxy_cidrs: Vec<&str>) -> PerIpRateLimit {
@@ -175,7 +161,8 @@ mod tests {
         start_router(BaseTelemetryServer::router_with_prober(
             Arc::new(AtomicBool::new(true)),
             per_ip(1000, vec![]),
-            Arc::new(FakeProber),
+            DEFAULT_P2P_REACHABILITY_MAX_CONCURRENT_PROBES,
+            reachable_prober(),
         ))
         .await
     }
@@ -215,6 +202,7 @@ mod tests {
         let router = BaseTelemetryServer::router_with_prober(
             Arc::new(AtomicBool::new(true)),
             per_ip(1000, vec![]),
+            DEFAULT_P2P_REACHABILITY_MAX_CONCURRENT_PROBES,
             Arc::clone(&prober),
         );
         let (addr, handle) = start_router(router).await;
@@ -253,7 +241,8 @@ mod tests {
         let router = BaseTelemetryServer::router_with_prober(
             Arc::new(AtomicBool::new(true)),
             per_ip(1, vec![]),
-            Arc::new(FakeProber),
+            DEFAULT_P2P_REACHABILITY_MAX_CONCURRENT_PROBES,
+            reachable_prober(),
         );
         let (addr, handle) = start_router(router).await;
         let client = reqwest::Client::new();
@@ -279,7 +268,8 @@ mod tests {
         let router = BaseTelemetryServer::router_with_prober(
             Arc::new(AtomicBool::new(true)),
             per_ip(1, vec![]),
-            Arc::new(FakeProber),
+            DEFAULT_P2P_REACHABILITY_MAX_CONCURRENT_PROBES,
+            reachable_prober(),
         );
         let (addr, handle) = start_router(router).await;
         let client = reqwest::Client::new();
@@ -312,7 +302,8 @@ mod tests {
         let router = BaseTelemetryServer::router_with_prober(
             Arc::new(AtomicBool::new(true)),
             per_ip(1, vec!["127.0.0.0/8"]),
-            Arc::new(FakeProber),
+            DEFAULT_P2P_REACHABILITY_MAX_CONCURRENT_PROBES,
+            reachable_prober(),
         );
         let (addr, handle) = start_router(router).await;
         let client = reqwest::Client::new();
@@ -351,11 +342,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn last_forwarded_header_line_wins_over_spoofed_first() {
+        let router = BaseTelemetryServer::router_with_prober(
+            Arc::new(AtomicBool::new(true)),
+            per_ip(1, vec!["127.0.0.0/8"]),
+            DEFAULT_P2P_REACHABILITY_MAX_CONCURRENT_PROBES,
+            reachable_prober(),
+        );
+        let (addr, handle) = start_router(router).await;
+        let client = reqwest::Client::new();
+        let url = format!("http://{addr}{P2P_REACHABILITY_PATH}");
+
+        // The client smuggles its own X-Forwarded-For line; the trusted proxy
+        // appends a second line with the real address. The proxy-appended
+        // line must key the rate limit.
+        let first = client
+            .post(&url)
+            .header("x-forwarded-for", "203.0.113.1")
+            .header("x-forwarded-for", "198.51.100.1")
+            .json(&test_request())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
+
+        // Rotating the smuggled first line must not open a fresh bucket.
+        let second = client
+            .post(&url)
+            .header("x-forwarded-for", "203.0.113.2")
+            .header("x-forwarded-for", "198.51.100.1")
+            .json(&test_request())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(second.status(), StatusCode::TOO_MANY_REQUESTS);
+
+        handle.abort();
+    }
+
+    #[tokio::test]
     async fn rejects_missing_forwarded_header_from_trusted_proxy() {
         let router = BaseTelemetryServer::router_with_prober(
             Arc::new(AtomicBool::new(true)),
             per_ip(1, vec!["127.0.0.0/8"]),
-            Arc::new(FakeProber),
+            DEFAULT_P2P_REACHABILITY_MAX_CONCURRENT_PROBES,
+            reachable_prober(),
         );
         let (addr, handle) = start_router(router).await;
 

--- a/crates/infra/telemetry/src/server.rs
+++ b/crates/infra/telemetry/src/server.rs
@@ -1,5 +1,6 @@
 use std::{
     net::SocketAddr,
+    num::NonZeroU32,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -17,8 +18,9 @@ use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use crate::{
-    CLIENT_IP_HEADER, IpRateLimiter, P2P_REACHABILITY_MAX_CONCURRENT_PROBES, P2pRoutes,
-    PerIpRateLimit, RATE_LIMIT_PER_IP_REQUESTS_PER_MINUTE, ReachabilityProber, RlpxProber,
+    CLIENT_IP_HEADER, DEFAULT_P2P_PROBE_REQUESTS_PER_MINUTE, IpRateLimiter,
+    P2P_REACHABILITY_MAX_CONCURRENT_PROBES, P2pRoutes, PerIpRateLimit, ReachabilityProber,
+    RlpxProber,
 };
 
 /// Configuration for the Base telemetry HTTP server.
@@ -30,6 +32,13 @@ pub struct ServerConfig {
     /// Comma-separated CIDRs of proxies trusted to supply the `X-Forwarded-For` client IP.
     #[arg(long, env = "BASE_TELEMETRY_TRUSTED_PROXY_CIDRS", value_delimiter = ',')]
     pub trusted_proxy_cidrs: Vec<IpNet>,
+    /// P2P reachability probe requests allowed per minute for each client IP.
+    #[arg(
+        long,
+        env = "BASE_TELEMETRY_P2P_PROBE_REQUESTS_PER_MINUTE",
+        default_value_t = DEFAULT_P2P_PROBE_REQUESTS_PER_MINUTE
+    )]
+    pub p2p_probe_requests_per_minute: NonZeroU32,
 }
 
 /// Base telemetry Axum server scaffold.
@@ -58,7 +67,7 @@ impl BaseTelemetryServer {
             CLIENT_IP_HEADER.to_string(),
             config.trusted_proxy_cidrs,
         ));
-        let limiter = Arc::new(IpRateLimiter::per_minute(RATE_LIMIT_PER_IP_REQUESTS_PER_MINUTE));
+        let limiter = Arc::new(IpRateLimiter::per_minute(config.p2p_probe_requests_per_minute));
         let eviction = limiter.spawn_eviction_task(cancel.clone());
 
         let ready = Arc::new(AtomicBool::new(false));
@@ -278,7 +287,7 @@ mod tests {
 
         let first = client
             .post(&url)
-            .header("x-forwarded-for", "198.51.100.1")
+            .header("x-forwarded-for", "203.0.113.1, 198.51.100.1")
             .json(&test_request())
             .send()
             .await
@@ -288,7 +297,7 @@ mod tests {
         // A spoofed header must not open a fresh rate-limit bucket.
         let second = client
             .post(&url)
-            .header("x-forwarded-for", "198.51.100.2")
+            .header("x-forwarded-for", "203.0.113.1, 198.51.100.2")
             .json(&test_request())
             .send()
             .await
@@ -331,13 +340,33 @@ mod tests {
         // The same forwarded client is limited.
         let third = client
             .post(&url)
-            .header("x-forwarded-for", "198.51.100.1")
+            .header("x-forwarded-for", "203.0.113.2, 198.51.100.1")
             .json(&test_request())
             .send()
             .await
             .unwrap();
         assert_eq!(third.status(), StatusCode::TOO_MANY_REQUESTS);
 
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn rejects_missing_forwarded_header_from_trusted_proxy() {
+        let router = BaseTelemetryServer::router_with_prober(
+            Arc::new(AtomicBool::new(true)),
+            per_ip(1, vec!["127.0.0.0/8"]),
+            Arc::new(FakeProber),
+        );
+        let (addr, handle) = start_router(router).await;
+
+        let response = reqwest::Client::new()
+            .post(format!("http://{addr}{P2P_REACHABILITY_PATH}"))
+            .json(&test_request())
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
         handle.abort();
     }
 }

--- a/crates/infra/telemetry/src/test_utils.rs
+++ b/crates/infra/telemetry/src/test_utils.rs
@@ -1,0 +1,38 @@
+//! Shared test doubles for the telemetry service.
+
+use std::{sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use tokio::sync::Semaphore;
+
+use crate::{
+    ReachabilityProber, RlpxProbeOutcome, RlpxProbeResult, RlpxProbeStage, RlpxProbeTarget,
+};
+
+/// Prober whose probes park until the test releases them.
+///
+/// Hand-rolled instead of [`MockReachabilityProber`](crate::MockReachabilityProber)
+/// because the double must coordinate with the test while calls are in flight
+/// (parking on semaphores inside `probe`), which mockall's synchronous
+/// expectation closures cannot express.
+#[derive(Debug, Clone)]
+pub struct BlockingProber {
+    /// Gains one permit each time a probe enters.
+    pub entered: Arc<Semaphore>,
+    /// Probes park here until the test adds permits.
+    pub release: Arc<Semaphore>,
+}
+
+#[async_trait]
+impl ReachabilityProber for BlockingProber {
+    async fn probe(&self, _: RlpxProbeTarget) -> RlpxProbeResult {
+        self.entered.add_permits(1);
+        self.release.acquire().await.unwrap().forget();
+        RlpxProbeResult {
+            outcome: RlpxProbeOutcome::Reachable,
+            stage: RlpxProbeStage::Devp2pHello,
+            elapsed: Duration::from_millis(1),
+            client_version: None,
+        }
+    }
+}

--- a/crates/infra/utilities/Cargo.toml
+++ b/crates/infra/utilities/Cargo.toml
@@ -15,3 +15,4 @@ workspace = true
 http.workspace = true
 ipnet.workspace = true
 tracing = { workspace = true, features = ["std"] }
+thiserror = { workspace = true, features = ["std"] }

--- a/crates/infra/utilities/Cargo.toml
+++ b/crates/infra/utilities/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "base-http-utils"
+description = "Shared HTTP utilities for Base services"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+http.workspace = true
+ipnet.workspace = true
+tracing = { workspace = true, features = ["std"] }

--- a/crates/infra/utilities/README.md
+++ b/crates/infra/utilities/README.md
@@ -7,6 +7,18 @@ Shared HTTP utilities for Base services.
 Provides [`TrustedProxyConfig`], which resolves the real client IP of an HTTP
 request. Forwarding headers such as `X-Forwarded-For` are honored only when the
 direct peer address falls inside a configured set of trusted proxy CIDRs;
-otherwise the peer socket address is used. `IPv4`-mapped `IPv6` addresses are
-canonicalized so `IPv4` CIDRs match peers on dual-stack listeners and derived
-rate-limit buckets stay consistent across address forms.
+otherwise the peer socket address is used. With no CIDRs configured, forwarding
+headers are never honored, which is the correct mode for directly exposed
+deployments.
+
+Extraction takes the rightmost comma-separated entry of the last occurrence of
+the configured header, matching `axum-client-ip`'s rightmost semantics: proxies
+append the real client address after any client-supplied values, so that is
+the only entry the trusted proxy vouches for. Strict callers use
+[`TrustedProxyConfig::try_client_ip`] and surface extraction failures from
+trusted proxies; lenient callers use [`TrustedProxyConfig::client_ip`], which
+falls back to the peer address with a warning.
+
+`IPv4`-mapped `IPv6` addresses are canonicalized so `IPv4` CIDRs match peers on
+dual-stack listeners and derived rate-limit buckets stay consistent across
+address forms.

--- a/crates/infra/utilities/README.md
+++ b/crates/infra/utilities/README.md
@@ -1,0 +1,12 @@
+# `base-http-utils`
+
+Shared HTTP utilities for Base services.
+
+## Trusted proxy client IP resolution
+
+Provides [`TrustedProxyConfig`], which resolves the real client IP of an HTTP
+request. Forwarding headers such as `X-Forwarded-For` are honored only when the
+direct peer address falls inside a configured set of trusted proxy CIDRs;
+otherwise the peer socket address is used. `IPv4`-mapped `IPv6` addresses are
+canonicalized so `IPv4` CIDRs match peers on dual-stack listeners and derived
+rate-limit buckets stay consistent across address forms.

--- a/crates/infra/utilities/README.md
+++ b/crates/infra/utilities/README.md
@@ -11,10 +11,13 @@ otherwise the peer socket address is used. With no CIDRs configured, forwarding
 headers are never honored, which is the correct mode for directly exposed
 deployments.
 
-Extraction takes the rightmost comma-separated entry of the last occurrence of
-the configured header, matching `axum-client-ip`'s rightmost semantics: proxies
-append the real client address after any client-supplied values, so that is
-the only entry the trusted proxy vouches for. Strict callers use
+All occurrences of the configured header are concatenated in order into a
+forwarding chain, then scanned right to left, skipping any address in the
+trusted proxy CIDRs. The first untrusted address is the real client; if every
+forwarded hop is trusted, resolution falls back to the direct peer. This peels
+our own proxy hops (e.g. Cloudflare in front of an ALB) instead of stopping at
+the innermost proxy, so clients behind multiple trusted hops resolve individually.
+Strict callers use
 [`TrustedProxyConfig::try_client_ip`] and surface extraction failures from
 trusted proxies; lenient callers use [`TrustedProxyConfig::client_ip`], which
 falls back to the peer address with a warning.

--- a/crates/infra/utilities/src/lib.rs
+++ b/crates/infra/utilities/src/lib.rs
@@ -1,4 +1,4 @@
 #![doc = include_str!("../README.md")]
 
 mod trusted_proxy;
-pub use trusted_proxy::TrustedProxyConfig;
+pub use trusted_proxy::{ForwardedClientIpError, TrustedProxyConfig};

--- a/crates/infra/utilities/src/lib.rs
+++ b/crates/infra/utilities/src/lib.rs
@@ -1,0 +1,4 @@
+#![doc = include_str!("../README.md")]
+
+mod trusted_proxy;
+pub use trusted_proxy::TrustedProxyConfig;

--- a/crates/infra/utilities/src/trusted_proxy.rs
+++ b/crates/infra/utilities/src/trusted_proxy.rs
@@ -19,6 +19,12 @@ impl TrustedProxyConfig {
         Self { ip_addr_http_header, trusted_proxy_cidrs }
     }
 
+    /// Returns whether the direct peer belongs to a configured trusted proxy CIDR.
+    pub fn is_trusted_proxy(&self, connect_addr: IpAddr) -> bool {
+        let connect_addr = connect_addr.to_canonical();
+        self.trusted_proxy_cidrs.iter().any(|cidr| cidr.contains(&connect_addr))
+    }
+
     /// Resolves the client IP, trusting forwarding headers only from configured proxy CIDRs.
     pub fn client_ip(&self, connect_addr: IpAddr, headers: &HeaderMap) -> IpAddr {
         // Dual-stack listeners present IPv4 peers as IPv4-mapped IPv6 (`::ffff:x.x.x.x`).
@@ -26,7 +32,7 @@ impl TrustedProxyConfig {
         // consistent across address forms.
         let connect_addr = connect_addr.to_canonical();
 
-        if !self.trusted_proxy_cidrs.iter().any(|cidr| cidr.contains(&connect_addr)) {
+        if !self.is_trusted_proxy(connect_addr) {
             return connect_addr;
         }
 

--- a/crates/infra/utilities/src/trusted_proxy.rs
+++ b/crates/infra/utilities/src/trusted_proxy.rs
@@ -49,27 +49,40 @@ impl TrustedProxyConfig {
     /// Callers must verify the direct peer with [`Self::is_trusted_proxy`]
     /// first; forwarding headers from untrusted peers are attacker-controlled.
     ///
-    /// Only the **last occurrence** of the header is inspected, and within it
-    /// the **rightmost** comma-separated entry wins. Proxies append the real
-    /// client address after any client-supplied values (as a new list entry
-    /// or a new header line), so the rightmost value of the last line is the
-    /// only one the trusted proxy vouches for.
+    /// All header occurrences are concatenated in order into the forwarding
+    /// chain `client, proxy1, proxy2, ...`, then scanned **right to left**,
+    /// skipping any address in `trusted_proxy_cidrs`. The first untrusted
+    /// address is the real client: trusted proxies vouch for everything they
+    /// appended, but the client may have spoofed values further left, so we
+    /// stop at the first hop we did not add ourselves. If every hop is a
+    /// trusted proxy, the outermost (leftmost) entry is used.
     pub fn forwarded_client_ip(
         &self,
         headers: &HeaderMap,
     ) -> Result<IpAddr, ForwardedClientIpError> {
         let header = &self.ip_addr_http_header;
-        let Some(value) = headers.get_all(header).iter().next_back() else {
-            return Err(ForwardedClientIpError::MissingHeader { header: header.clone() });
-        };
-        let value = value.to_str().map_err(|_| ForwardedClientIpError::InvalidIp {
-            header: header.clone(),
-            value: String::from_utf8_lossy(value.as_bytes()).into_owned(),
-        })?;
-        let entry = value.rsplit_once(',').map_or(value, |(_, entry)| entry).trim();
-        entry.parse::<IpAddr>().map(|ip| ip.to_canonical()).map_err(|_| {
-            ForwardedClientIpError::InvalidIp { header: header.clone(), value: entry.to_string() }
-        })
+        let mut outermost_trusted = None;
+        for value in headers.get_all(header).iter().rev() {
+            let value = value.to_str().map_err(|_| ForwardedClientIpError::InvalidIp {
+                header: header.clone(),
+                value: String::from_utf8_lossy(value.as_bytes()).into_owned(),
+            })?;
+            for entry in value.split(',').rev().map(str::trim).filter(|entry| !entry.is_empty()) {
+                let ip = entry.parse::<IpAddr>().map(|ip| ip.to_canonical()).map_err(|_| {
+                    ForwardedClientIpError::InvalidIp {
+                        header: header.clone(),
+                        value: entry.to_string(),
+                    }
+                })?;
+                if self.is_trusted_proxy(ip) {
+                    outermost_trusted = Some(ip);
+                    continue;
+                }
+                return Ok(ip);
+            }
+        }
+        outermost_trusted
+            .ok_or_else(|| ForwardedClientIpError::MissingHeader { header: header.clone() })
     }
 
     /// Resolves the client IP, trusting forwarding headers only from configured proxy CIDRs.
@@ -77,7 +90,8 @@ impl TrustedProxyConfig {
     /// Untrusted or direct peers resolve to their (canonicalized) socket
     /// address and forwarding headers are ignored. A trusted proxy must
     /// supply a valid forwarding header; a missing or invalid one surfaces
-    /// as an error for the caller to handle.
+    /// as an error for the caller to handle. If every forwarded hop is
+    /// trusted, the direct peer address is used.
     pub fn try_client_ip(
         &self,
         connect_addr: IpAddr,
@@ -88,7 +102,9 @@ impl TrustedProxyConfig {
         // consistent across address forms.
         let connect_addr = connect_addr.to_canonical();
         if self.is_trusted_proxy(connect_addr) {
-            self.forwarded_client_ip(headers)
+            self.forwarded_client_ip(headers).map(|client_ip| {
+                if self.is_trusted_proxy(client_ip) { connect_addr } else { client_ip }
+            })
         } else {
             Ok(connect_addr)
         }
@@ -164,7 +180,7 @@ mod tests {
     }
 
     #[test]
-    fn rightmost_entry_of_last_line_wins() {
+    fn rightmost_untrusted_entry_across_lines_wins() {
         let config = xff_config(vec!["127.0.0.0/8"]);
         let real_client = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 7));
 
@@ -173,6 +189,54 @@ mod tests {
         headers.append("x-forwarded-for", HeaderValue::from_static("203.0.113.3, 198.51.100.7"));
 
         assert_eq!(config.forwarded_client_ip(&headers).unwrap(), real_client);
+    }
+
+    #[test]
+    fn joins_header_lines_before_peeling_trusted_hops() {
+        let config = xff_config(vec!["10.0.0.0/8", "104.16.0.0/13"]);
+        let alb = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let client = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10));
+
+        let mut headers = HeaderMap::new();
+        headers.append("x-forwarded-for", HeaderValue::from_static("invalid"));
+        headers.append("x-forwarded-for", HeaderValue::from_static("203.0.113.10"));
+        headers.append("x-forwarded-for", HeaderValue::from_static("104.16.1.1"));
+
+        assert_eq!(config.client_ip(alb, &headers), client);
+    }
+
+    #[test]
+    fn skips_trusted_proxy_hops_scanning_right_to_left() {
+        // Chain is `client, proxy1, proxy2` (proxies in 10.0.0.0/8). The
+        // rightmost entries are our own trusted hops; the real client is the
+        // first untrusted address scanning from the right.
+        let config = xff_config(vec!["10.0.0.0/8"]);
+        let real_client = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 9));
+
+        let mut headers = HeaderMap::new();
+        headers
+            .insert("x-forwarded-for", HeaderValue::from_static("203.0.113.9, 10.0.0.2, 10.0.0.3"));
+        assert_eq!(config.forwarded_client_ip(&headers).unwrap(), real_client);
+
+        // A client-spoofed value to the left of the real client is ignored.
+        headers.insert(
+            "x-forwarded-for",
+            HeaderValue::from_static("10.9.9.9, 203.0.113.9, 10.0.0.2, 10.0.0.3"),
+        );
+        assert_eq!(config.forwarded_client_ip(&headers).unwrap(), real_client);
+    }
+
+    #[test]
+    fn all_trusted_hops_fall_back_to_outermost() {
+        let config = xff_config(vec!["10.0.0.0/8"]);
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 4));
+        let outermost = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", HeaderValue::from_static("10.0.0.1, 10.0.0.2, 10.0.0.3"));
+        assert_eq!(config.forwarded_client_ip(&headers).unwrap(), outermost);
+        assert_eq!(config.try_client_ip(peer, &headers), Ok(peer));
+        assert_eq!(config.client_ip(peer, &headers), peer);
     }
 
     #[test]

--- a/crates/infra/utilities/src/trusted_proxy.rs
+++ b/crates/infra/utilities/src/trusted_proxy.rs
@@ -6,6 +6,25 @@ use http::HeaderMap;
 use ipnet::IpNet;
 use tracing::warn;
 
+/// Failure to extract a client IP from a forwarding header.
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+pub enum ForwardedClientIpError {
+    /// The configured forwarding header is absent from the request.
+    #[error("missing client IP header `{header}`")]
+    MissingHeader {
+        /// The configured header name.
+        header: String,
+    },
+    /// The extracted entry does not parse as an IP address.
+    #[error("client IP header `{header}` entry `{value}` is not a valid IP address")]
+    InvalidIp {
+        /// The configured header name.
+        header: String,
+        /// The entry that failed to parse.
+        value: String,
+    },
+}
+
 /// Configuration for resolving client IPs through trusted proxies.
 #[derive(Clone, Debug)]
 pub struct TrustedProxyConfig {
@@ -25,47 +44,70 @@ impl TrustedProxyConfig {
         self.trusted_proxy_cidrs.iter().any(|cidr| cidr.contains(&connect_addr))
     }
 
+    /// Extracts the client IP from the configured forwarding header.
+    ///
+    /// Callers must verify the direct peer with [`Self::is_trusted_proxy`]
+    /// first; forwarding headers from untrusted peers are attacker-controlled.
+    ///
+    /// Only the **last occurrence** of the header is inspected, and within it
+    /// the **rightmost** comma-separated entry wins. Proxies append the real
+    /// client address after any client-supplied values (as a new list entry
+    /// or a new header line), so the rightmost value of the last line is the
+    /// only one the trusted proxy vouches for.
+    pub fn forwarded_client_ip(
+        &self,
+        headers: &HeaderMap,
+    ) -> Result<IpAddr, ForwardedClientIpError> {
+        let header = &self.ip_addr_http_header;
+        let Some(value) = headers.get_all(header).iter().next_back() else {
+            return Err(ForwardedClientIpError::MissingHeader { header: header.clone() });
+        };
+        let value = value.to_str().map_err(|_| ForwardedClientIpError::InvalidIp {
+            header: header.clone(),
+            value: String::from_utf8_lossy(value.as_bytes()).into_owned(),
+        })?;
+        let entry = value.rsplit_once(',').map_or(value, |(_, entry)| entry).trim();
+        entry.parse::<IpAddr>().map(|ip| ip.to_canonical()).map_err(|_| {
+            ForwardedClientIpError::InvalidIp { header: header.clone(), value: entry.to_string() }
+        })
+    }
+
     /// Resolves the client IP, trusting forwarding headers only from configured proxy CIDRs.
-    pub fn client_ip(&self, connect_addr: IpAddr, headers: &HeaderMap) -> IpAddr {
+    ///
+    /// Untrusted or direct peers resolve to their (canonicalized) socket
+    /// address and forwarding headers are ignored. A trusted proxy must
+    /// supply a valid forwarding header; a missing or invalid one surfaces
+    /// as an error for the caller to handle.
+    pub fn try_client_ip(
+        &self,
+        connect_addr: IpAddr,
+        headers: &HeaderMap,
+    ) -> Result<IpAddr, ForwardedClientIpError> {
         // Dual-stack listeners present IPv4 peers as IPv4-mapped IPv6 (`::ffff:x.x.x.x`).
         // Canonicalize so IPv4 CIDRs still match those peers and rate-limit buckets stay
         // consistent across address forms.
         let connect_addr = connect_addr.to_canonical();
-
-        if !self.is_trusted_proxy(connect_addr) {
-            return connect_addr;
+        if self.is_trusted_proxy(connect_addr) {
+            self.forwarded_client_ip(headers)
+        } else {
+            Ok(connect_addr)
         }
+    }
 
-        let Some(header) = headers.get(&self.ip_addr_http_header) else {
-            return connect_addr;
-        };
-
-        let header_value = match header.to_str() {
-            Ok(header_value) => header_value,
+    /// Resolves the client IP, trusting forwarding headers only from configured proxy CIDRs.
+    ///
+    /// Unlike [`Self::try_client_ip`], this is lenient: a missing or
+    /// invalid header from a trusted proxy falls back to the peer address
+    /// with a warning instead of failing.
+    pub fn client_ip(&self, connect_addr: IpAddr, headers: &HeaderMap) -> IpAddr {
+        let connect_addr = connect_addr.to_canonical();
+        match self.try_client_ip(connect_addr, headers) {
+            Ok(client_ip) => client_ip,
             Err(error) => {
-                warn!(error = %error, "Could not read client IP header");
-                return connect_addr;
+                warn!(error = %error, peer = %connect_addr, "could not resolve forwarded client IP");
+                connect_addr
             }
-        };
-
-        header_value
-            .split(',')
-            .next_back()
-            .and_then(|ip| {
-                let trimmed = ip.trim();
-                match trimmed.parse::<IpAddr>() {
-                    Ok(addr) => Some(addr.to_canonical()),
-                    Err(error) => {
-                        warn!(
-                            error = %error,
-                            value = %trimmed,
-                            "Failed to parse forwarded client IP"
-                        );
-                        None
-                    }
-                }
-            })
-            .unwrap_or(connect_addr)
+        }
     }
 }
 
@@ -75,14 +117,18 @@ mod tests {
 
     use http::{HeaderMap, HeaderValue};
 
-    use super::TrustedProxyConfig;
+    use super::{ForwardedClientIpError, TrustedProxyConfig};
+
+    fn xff_config(cidrs: Vec<&str>) -> TrustedProxyConfig {
+        TrustedProxyConfig::new(
+            "x-forwarded-for".to_string(),
+            cidrs.into_iter().map(|cidr| cidr.parse().unwrap()).collect(),
+        )
+    }
 
     #[test]
     fn trusted_proxy_config_resolves_client_ip() {
-        let config = TrustedProxyConfig::new(
-            "x-forwarded-for".to_string(),
-            vec!["127.0.0.0/8".parse().unwrap()],
-        );
+        let config = xff_config(vec!["127.0.0.0/8"]);
         let trusted_proxy = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let untrusted_peer = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
         let client = IpAddr::V4(Ipv4Addr::new(130, 1, 1, 1));
@@ -101,11 +147,93 @@ mod tests {
     }
 
     #[test]
-    fn trusted_proxy_config_matches_ipv4_mapped_peers() {
-        let config = TrustedProxyConfig::new(
-            "x-forwarded-for".to_string(),
-            vec!["10.0.0.0/8".parse().unwrap()],
+    fn last_header_occurrence_wins_over_spoofed_first_line() {
+        // A client sends its own X-Forwarded-For line; the trusted proxy
+        // appends a second line with the real address. The proxy-appended
+        // line must win.
+        let config = xff_config(vec!["127.0.0.0/8"]);
+        let trusted_proxy = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        let real_client = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 7));
+
+        let mut headers = HeaderMap::new();
+        headers.append("x-forwarded-for", HeaderValue::from_static("203.0.113.99"));
+        headers.append("x-forwarded-for", HeaderValue::from_static("198.51.100.7"));
+
+        assert_eq!(config.client_ip(trusted_proxy, &headers), real_client);
+        assert_eq!(config.forwarded_client_ip(&headers).unwrap(), real_client);
+    }
+
+    #[test]
+    fn rightmost_entry_of_last_line_wins() {
+        let config = xff_config(vec!["127.0.0.0/8"]);
+        let real_client = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 7));
+
+        let mut headers = HeaderMap::new();
+        headers.append("x-forwarded-for", HeaderValue::from_static("203.0.113.1, 203.0.113.2"));
+        headers.append("x-forwarded-for", HeaderValue::from_static("203.0.113.3, 198.51.100.7"));
+
+        assert_eq!(config.forwarded_client_ip(&headers).unwrap(), real_client);
+    }
+
+    #[test]
+    fn empty_trusted_cidrs_always_uses_peer_address() {
+        // Direct deployments (no fronting proxy) configure no CIDRs, so
+        // forwarding headers are never honored.
+        let config = xff_config(vec![]);
+        let peer = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5));
+
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", HeaderValue::from_static("198.51.100.7"));
+
+        assert_eq!(config.client_ip(peer, &headers), peer);
+    }
+
+    #[test]
+    fn try_client_ip_gates_on_trust() {
+        let config = xff_config(vec!["127.0.0.0/8"]);
+        let untrusted = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
+        let headers = HeaderMap::new();
+
+        // Untrusted peers resolve to themselves even without a header.
+        assert_eq!(config.try_client_ip(untrusted, &headers), Ok(untrusted));
+        // Trusted proxies must supply the header.
+        assert!(config.try_client_ip(IpAddr::V4(Ipv4Addr::LOCALHOST), &headers).is_err());
+    }
+
+    #[test]
+    fn forwarded_client_ip_reports_extraction_failures() {
+        let config = xff_config(vec!["127.0.0.0/8"]);
+
+        let headers = HeaderMap::new();
+        assert_eq!(
+            config.forwarded_client_ip(&headers),
+            Err(ForwardedClientIpError::MissingHeader { header: "x-forwarded-for".to_string() })
         );
+
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", HeaderValue::from_static("not-an-ip"));
+        assert_eq!(
+            config.forwarded_client_ip(&headers),
+            Err(ForwardedClientIpError::InvalidIp {
+                header: "x-forwarded-for".to_string(),
+                value: "not-an-ip".to_string(),
+            })
+        );
+
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", HeaderValue::from_bytes(b"\xff").unwrap());
+        assert_eq!(
+            config.forwarded_client_ip(&headers),
+            Err(ForwardedClientIpError::InvalidIp {
+                header: "x-forwarded-for".to_string(),
+                value: "\u{FFFD}".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn trusted_proxy_config_matches_ipv4_mapped_peers() {
+        let config = xff_config(vec!["10.0.0.0/8"]);
         let mapped_proxy = IpAddr::V6("::ffff:10.0.0.1".parse().unwrap());
         let client = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10));
 

--- a/crates/infra/utilities/src/trusted_proxy.rs
+++ b/crates/infra/utilities/src/trusted_proxy.rs
@@ -1,0 +1,114 @@
+//! Client IP resolution through trusted forwarding proxies.
+
+use std::net::IpAddr;
+
+use http::HeaderMap;
+use ipnet::IpNet;
+use tracing::warn;
+
+/// Configuration for resolving client IPs through trusted proxies.
+#[derive(Clone, Debug)]
+pub struct TrustedProxyConfig {
+    ip_addr_http_header: String,
+    trusted_proxy_cidrs: Vec<IpNet>,
+}
+
+impl TrustedProxyConfig {
+    /// Creates a trusted proxy configuration for the given header and proxy CIDRs.
+    pub const fn new(ip_addr_http_header: String, trusted_proxy_cidrs: Vec<IpNet>) -> Self {
+        Self { ip_addr_http_header, trusted_proxy_cidrs }
+    }
+
+    /// Resolves the client IP, trusting forwarding headers only from configured proxy CIDRs.
+    pub fn client_ip(&self, connect_addr: IpAddr, headers: &HeaderMap) -> IpAddr {
+        // Dual-stack listeners present IPv4 peers as IPv4-mapped IPv6 (`::ffff:x.x.x.x`).
+        // Canonicalize so IPv4 CIDRs still match those peers and rate-limit buckets stay
+        // consistent across address forms.
+        let connect_addr = connect_addr.to_canonical();
+
+        if !self.trusted_proxy_cidrs.iter().any(|cidr| cidr.contains(&connect_addr)) {
+            return connect_addr;
+        }
+
+        let Some(header) = headers.get(&self.ip_addr_http_header) else {
+            return connect_addr;
+        };
+
+        let header_value = match header.to_str() {
+            Ok(header_value) => header_value,
+            Err(error) => {
+                warn!(error = %error, "Could not read client IP header");
+                return connect_addr;
+            }
+        };
+
+        header_value
+            .split(',')
+            .next_back()
+            .and_then(|ip| {
+                let trimmed = ip.trim();
+                match trimmed.parse::<IpAddr>() {
+                    Ok(addr) => Some(addr.to_canonical()),
+                    Err(error) => {
+                        warn!(
+                            error = %error,
+                            value = %trimmed,
+                            "Failed to parse forwarded client IP"
+                        );
+                        None
+                    }
+                }
+            })
+            .unwrap_or(connect_addr)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use http::{HeaderMap, HeaderValue};
+
+    use super::TrustedProxyConfig;
+
+    #[test]
+    fn trusted_proxy_config_resolves_client_ip() {
+        let config = TrustedProxyConfig::new(
+            "x-forwarded-for".to_string(),
+            vec!["127.0.0.0/8".parse().unwrap()],
+        );
+        let trusted_proxy = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        let untrusted_peer = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
+        let client = IpAddr::V4(Ipv4Addr::new(130, 1, 1, 1));
+
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", HeaderValue::from_static("129.1.1.1, 130.1.1.1"));
+
+        assert_eq!(config.client_ip(trusted_proxy, &headers), client);
+        assert_eq!(config.client_ip(untrusted_peer, &headers), untrusted_peer);
+
+        headers.insert("x-forwarded-for", HeaderValue::from_static("nonsense"));
+        assert_eq!(config.client_ip(trusted_proxy, &headers), trusted_proxy);
+
+        headers.clear();
+        assert_eq!(config.client_ip(trusted_proxy, &headers), trusted_proxy);
+    }
+
+    #[test]
+    fn trusted_proxy_config_matches_ipv4_mapped_peers() {
+        let config = TrustedProxyConfig::new(
+            "x-forwarded-for".to_string(),
+            vec!["10.0.0.0/8".parse().unwrap()],
+        );
+        let mapped_proxy = IpAddr::V6("::ffff:10.0.0.1".parse().unwrap());
+        let client = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10));
+
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", HeaderValue::from_static("203.0.113.10"));
+
+        assert_eq!(config.client_ip(mapped_proxy, &headers), client);
+
+        headers.insert("x-forwarded-for", HeaderValue::from_static("::ffff:203.0.113.10"));
+        assert_eq!(config.client_ip(mapped_proxy, &headers), client);
+    }
+}

--- a/crates/infra/websocket-proxy/Cargo.toml
+++ b/crates/infra/websocket-proxy/Cargo.toml
@@ -16,10 +16,10 @@ workspace = true
 
 [dependencies]
 http.workspace = true
-ipnet.workspace = true
 futures.workspace = true
 backoff.workspace = true
 tokio-util.workspace = true
+base-http-utils.workspace = true
 tokio-tungstenite.workspace = true
 metrics = { workspace = true, optional = true }
 brotli = { workspace = true, features = ["std"] }

--- a/crates/infra/websocket-proxy/src/server.rs
+++ b/crates/infra/websocket-proxy/src/server.rs
@@ -1,8 +1,4 @@
-use std::{
-    fmt,
-    net::{IpAddr, SocketAddr},
-    sync::Arc,
-};
+use std::{fmt, net::SocketAddr, sync::Arc};
 
 use axum::{
     Error, Router,
@@ -12,8 +8,8 @@ use axum::{
     response::{IntoResponse, Response},
     routing::{any, get},
 };
+pub use base_http_utils::TrustedProxyConfig;
 use http::HeaderMap;
-use ipnet::IpNet;
 use serde::Deserialize;
 use serde_json::json;
 use tokio_util::sync::CancellationToken;
@@ -27,81 +23,6 @@ use crate::{
     rate_limit::{RateLimit, RateLimitError, RateLimitType},
     registry::Registry,
 };
-
-/// Configuration for resolving client IPs through trusted proxies.
-#[derive(Clone, Debug)]
-pub struct TrustedProxyConfig {
-    ip_addr_http_header: String,
-    trusted_proxy_cidrs: Vec<IpNet>,
-}
-
-impl TrustedProxyConfig {
-    /// Creates a trusted proxy configuration for the given header and proxy CIDRs.
-    pub const fn new(ip_addr_http_header: String, trusted_proxy_cidrs: Vec<IpNet>) -> Self {
-        Self { ip_addr_http_header, trusted_proxy_cidrs }
-    }
-
-    /// Resolves the client IP, trusting forwarding headers only from configured proxy CIDRs.
-    ///
-    /// Walks all forwarding-header lines and comma-separated entries right → left (proxies
-    /// may append within a value or add a new line), peeling trusted hops until the first
-    /// untrusted IP.
-    pub fn client_ip(&self, connect_addr: IpAddr, headers: &HeaderMap) -> IpAddr {
-        // Dual-stack listeners present IPv4 peers as IPv4-mapped IPv6 (`::ffff:x.x.x.x`).
-        let connect_addr = Self::canonicalize_ip(connect_addr);
-
-        if !self.is_trusted(connect_addr) {
-            return connect_addr;
-        }
-
-        for header in headers.get_all(&self.ip_addr_http_header).iter().rev() {
-            let header_value = match header.to_str() {
-                Ok(value) => value,
-                Err(error) => {
-                    warn!(error = %error, "Could not read client IP header");
-                    return connect_addr;
-                }
-            };
-
-            for raw in header_value.split(',').rev() {
-                let trimmed = raw.trim();
-                if trimmed.is_empty() {
-                    continue;
-                }
-
-                match trimmed.parse::<IpAddr>() {
-                    Ok(addr) => {
-                        let addr = Self::canonicalize_ip(addr);
-                        if !self.is_trusted(addr) {
-                            return addr;
-                        }
-                    }
-                    Err(error) => {
-                        warn!(
-                            error = %error,
-                            value = %trimmed,
-                            "Failed to parse forwarded client IP"
-                        );
-                        return connect_addr;
-                    }
-                }
-            }
-        }
-
-        connect_addr
-    }
-
-    fn is_trusted(&self, addr: IpAddr) -> bool {
-        self.trusted_proxy_cidrs.iter().any(|cidr| cidr.contains(&addr))
-    }
-
-    fn canonicalize_ip(addr: IpAddr) -> IpAddr {
-        match addr {
-            IpAddr::V6(v6) => v6.to_ipv4_mapped().map(IpAddr::V4).unwrap_or(addr),
-            addr => addr,
-        }
-    }
-}
 
 #[derive(Clone)]
 struct ServerState {
@@ -357,10 +278,6 @@ fn websocket_handler(
 
 #[cfg(test)]
 mod tests {
-    use std::net::Ipv4Addr;
-
-    use http::HeaderValue;
-
     use super::*;
     use crate::filter::FilterType;
 
@@ -425,97 +342,5 @@ mod tests {
             FilterType::None => (),
             _ => panic!("Expected None filter"),
         }
-    }
-
-    #[test]
-    fn trusted_proxy_config_resolves_client_ip() {
-        let config = TrustedProxyConfig::new(
-            "x-forwarded-for".to_string(),
-            vec!["127.0.0.0/8".parse().unwrap()],
-        );
-        let trusted_proxy = IpAddr::V4(Ipv4Addr::LOCALHOST);
-        let untrusted_peer = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
-        let client = IpAddr::V4(Ipv4Addr::new(130, 1, 1, 1));
-
-        let mut headers = HeaderMap::new();
-        headers.insert("x-forwarded-for", HeaderValue::from_static("129.1.1.1, 130.1.1.1"));
-
-        assert_eq!(config.client_ip(trusted_proxy, &headers), client);
-        assert_eq!(config.client_ip(untrusted_peer, &headers), untrusted_peer);
-
-        headers.insert("x-forwarded-for", HeaderValue::from_static("nonsense"));
-        assert_eq!(config.client_ip(trusted_proxy, &headers), trusted_proxy);
-
-        headers.clear();
-        assert_eq!(config.client_ip(trusted_proxy, &headers), trusted_proxy);
-    }
-
-    #[test]
-    fn trusted_proxy_config_skips_trusted_hops_in_xff() {
-        let config = TrustedProxyConfig::new(
-            "x-forwarded-for".to_string(),
-            vec!["10.0.0.0/8".parse().unwrap(), "104.16.0.0/13".parse().unwrap()],
-        );
-        let alb = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
-        let client = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10));
-
-        let mut headers = HeaderMap::new();
-        headers.insert("x-forwarded-for", HeaderValue::from_static("203.0.113.10, 104.16.1.1"));
-        assert_eq!(config.client_ip(alb, &headers), client);
-
-        let alb_only = TrustedProxyConfig::new(
-            "x-forwarded-for".to_string(),
-            vec!["10.0.0.0/8".parse().unwrap()],
-        );
-        let cdn = IpAddr::V4(Ipv4Addr::new(104, 16, 1, 1));
-        assert_eq!(alb_only.client_ip(alb, &headers), cdn);
-
-        headers.insert(
-            "x-forwarded-for",
-            HeaderValue::from_static("198.51.100.1, 203.0.113.10, 104.16.1.1"),
-        );
-        assert_eq!(config.client_ip(alb, &headers), client);
-
-        headers.insert(
-            "x-forwarded-for",
-            HeaderValue::from_static("198.51.100.1, invalid, 104.16.1.1"),
-        );
-        assert_eq!(config.client_ip(alb, &headers), alb);
-    }
-
-    #[test]
-    fn joins_header_lines_before_peeling_trusted_hops() {
-        let config = TrustedProxyConfig::new(
-            "x-forwarded-for".to_string(),
-            vec!["10.0.0.0/8".parse().unwrap(), "104.16.0.0/13".parse().unwrap()],
-        );
-        let alb = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
-        let client = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10));
-
-        // Client-spoofed line, CDN-appended client, ALB-added CDN hop as a new line.
-        let mut headers = HeaderMap::new();
-        headers.append("x-forwarded-for", HeaderValue::from_static("198.51.100.1"));
-        headers.append("x-forwarded-for", HeaderValue::from_static("203.0.113.10"));
-        headers.append("x-forwarded-for", HeaderValue::from_static("104.16.1.1"));
-
-        assert_eq!(config.client_ip(alb, &headers), client);
-    }
-
-    #[test]
-    fn trusted_proxy_config_matches_ipv4_mapped_peers() {
-        let config = TrustedProxyConfig::new(
-            "x-forwarded-for".to_string(),
-            vec!["10.0.0.0/8".parse().unwrap()],
-        );
-        let mapped_proxy = IpAddr::V6("::ffff:10.0.0.1".parse().unwrap());
-        let client = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10));
-
-        let mut headers = HeaderMap::new();
-        headers.insert("x-forwarded-for", HeaderValue::from_static("203.0.113.10"));
-
-        assert_eq!(config.client_ip(mapped_proxy, &headers), client);
-
-        headers.insert("x-forwarded-for", HeaderValue::from_static("::ffff:203.0.113.10"));
-        assert_eq!(config.client_ip(mapped_proxy, &headers), client);
     }
 }


### PR DESCRIPTION
## Summary
- Rate limit P2P reachability requests to two per minute per client IP
- Trust `X-Forwarded-For` only from configured proxy CIDRs using the shared websocket-proxy convention
- Reject non-public probe targets and leave health routes unrestricted

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p base-http-utils -p base-telemetry-service --all-targets -- -D warnings`
-
    [x] `cargo clippy -p websocket-proxy --all-targets -- -D warnings`
- [x] `cargo clippy -p base-telemetry-bin --all-targets -- -D warnings`
- [x] `cargo test -p base-http-utils -p base-telemetry-service`
-
    [x] `cargo test -p websocket-proxy`
- [x] `cargo test -p base-telemetry-bin`