### PR TITLE
docs(agents): document mockall convention for test doubles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,3 +34,5 @@ fn area(&self) -> u32 {
     self.width * self.height
 }
 ```
+
+For test doubles of internal traits, default to `#[cfg_attr(test, mockall::automock)]` (see `crates/consensus/service/src/actors/*/client.rs`, `crates/consensus/service/src/actors/network/gossip.rs`, `crates/consensus/service/src/follow/local.rs`, `crates/consensus/service/src/follow/source.rs` for examples) rather than hand-rolling a fake. Only hand-roll a fake (as in `crates/consensus/service/src/test_utils/fake_engine_client.rs`, `fake_l1.rs`, `fake_gossip.rs`) when `automock` cannot express the required behavior — e.g. the trait method returns a non-constructible builder type (such as alloy's `ProviderCall`/`EthGetBlock`), the double needs a single call log ordered across multiple trait methods, or scripted responses must be mutated by the test while calls are in flight. Document the specific reason a hand-rolled fake was chosen in the module doc comment.


### PR DESCRIPTION
## Summary

Codifies when to use `mockall::automock` vs a hand-rolled fake for internal trait test doubles, per discussion on #3906 (review comment from @0x00101010 asking why `test_utils/fake_engine_client.rs` doesn't use `mockall`).

## Rule added to CLAUDE.md (surfaced via AGENTS.md symlink)

- Default to `#[cfg_attr(test, mockall::automock)]` for test doubles of internal traits (existing examples: `actors/*/client.rs`, `actors/network/gossip.rs`, `follow/local.rs`, `follow/source.rs`).
- Only hand-roll a fake (e.g. `test_utils/fake_engine_client.rs`, `fake_l1.rs`, `fake_gossip.rs`) when `automock` cannot express the required behavior:
  - the trait method returns a non-constructible builder type (e.g. alloy's `ProviderCall`/`EthGetBlock`)
  - the double needs a single call log ordered across multiple trait methods
  - scripted responses must be mutated by the test while calls are in flight
- Document the specific reason a hand-rolled fake was chosen in the module doc comment.