### PR TITLE
feat(basectl): route reachability checks by network

### DIFF
--- a/bin/basectl/README.md
+++ b/bin/basectl/README.md
@@ -144,11 +144,12 @@ Read-only p2p commands also support:
 | `--json` | Emit humanized JSON instead of the pretty table output.                                                                      |
 | `--raw`  | With `--json`, emit raw nested RPC payloads instead of the humanized summary. Errors at parse time if used without `--json`. |
 
-`p2p reachability` requires `--telemetry-url <URL>` or
-`BASECTL_TELEMETRY_URL` and supports `--json`. It accepts an explicit enode and
-does not require EL or CL JSON-RPC access. It exits non-zero when the probe
-completes with any outcome other than `reachable`, so scripts can rely on the
-exit code.
+`p2p reachability` uses the selected config's L2 RPC to detect the live chain,
+then routes the request to the hosted Base mainnet or Base Sepolia telemetry
+service. The default config remains mainnet. Unsupported chains and failed
+network detection return an error. The command supports `--json` and exits
+non-zero when the probe completes with any outcome other than `reachable`, so
+scripts can rely on the exit code.
 
 The returned `stage` shows where the check stopped:
 
@@ -309,19 +310,19 @@ built-in preset, optional YAML override, or explicit config path through global
 specific node when the config points at shared/public endpoints.
 
 Checks include declared network vs. live chain ID, p2p endpoint context,
-canonical bootnode config context, advertised endpoint sanity, optional
+canonical bootnode config context, advertised endpoint sanity,
 telemetry-backed external EL reachability, EL/CL peer counts, EL head vs. public
 tip, safe-head recency, optional `reth.toml` headers/bodies limits,
 consensus-node RPC presence, and L1 RPC reachability. Doctor does not mutate
-node state. Without `--telemetry-url`, advertised endpoint checks remain limited
-to local config and exposed RPC metadata.
+node state. The effective `--el-rpc` chain ID selects the hosted Base mainnet or
+Base Sepolia telemetry service; the check is skipped when detection fails or
+the chain is unsupported.
 
 | Flag                                  | Description                                                                                                                                      |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `--el-rpc <URL>`                      | Override the execution-layer RPC URL used for local-node checks. Defaults to the selected config's `rpc` field.                                  |
 | `--cl-rpc <URL>`                      | Override the consensus-node RPC URL. If omitted and the selected config has no `consensus_node_rpc`, CL-dependent checks are skipped with hints. |
 | `--reth-config <PATH>`                | Path to the local `reth.toml` file. If omitted, the reth limits check is skipped.                                                                |
-| `--telemetry-url <URL>`               | Base telemetry service used to probe the enode returned by `admin_nodeInfo`. May also be set with `BASECTL_TELEMETRY_URL`.                       |
 | `--peer-warn-threshold <COUNT>`       | Connected peer count below which EL/CL peer checks warn. Default `5`.                                                                            |
 | `--head-lag-warn-blocks <BLOCKS>`     | EL head lag behind the public tip above which doctor warns. Default `10`.                                                                        |
 | `--head-lag-fail-blocks <BLOCKS>`     | EL head lag behind the public tip above which doctor fails. Default `20`.                                                                        |
@@ -452,7 +453,7 @@ basectl -c sepolia p2p info --el-rpc https://your-el.example/ --cl-rpc https://y
 basectl -c sepolia p2p peers --el-rpc https://your-el.example/ --cl-rpc https://your-cl.example/ --json | jq '{el: .el | length, cl: .cl | length}'
 
 # Probe an explicit EL enode from the telemetry service's network
-basectl p2p reachability enode://<node-id>@203.0.113.10:30303 --telemetry-url http://127.0.0.1:8080 --json
+basectl -c sepolia p2p reachability enode://<node-id>@203.0.113.10:30303 --json
 
 # Add an execution-layer peer after confirmation
 basectl -c sepolia p2p add-peer enode://<node-id>@203.0.113.10:30303 --el-rpc https://your-el.example/
@@ -529,7 +530,7 @@ basectl -c mainnet doctor
 basectl -c mainnet doctor --el-rpc https://your-el.example/ --cl-rpc https://your-cl.example/
 
 # Include an external EL reachability probe
-basectl -c mainnet doctor --el-rpc https://your-el.example/ --telemetry-url http://127.0.0.1:8080
+basectl -c mainnet doctor --el-rpc https://your-el.example/
 
 # Include local reth headers/bodies limit validation and JSON output
 basectl -c mainnet doctor --el-rpc https://your-el.example/ --cl-rpc https://your-cl.example/ --reth-config /etc/reth/reth.toml --json

--- a/bin/basectl/src/cli.rs
+++ b/bin/basectl/src/cli.rs
@@ -137,9 +137,6 @@ pub(crate) struct DoctorArgs {
     /// Path to the local `reth.toml` file.
     #[arg(long = "reth-config", value_name = "PATH")]
     pub(crate) reth_config: Option<PathBuf>,
-    /// Base telemetry service URL used for external EL reachability checks.
-    #[arg(long = "telemetry-url", env = "BASECTL_TELEMETRY_URL", value_name = "URL")]
-    pub(crate) telemetry_url: Option<Url>,
     /// Connected peer count below which peer checks warn.
     #[arg(long = "peer-warn-threshold", value_name = "COUNT", default_value_t = 5)]
     pub(crate) peer_warn_threshold: u32,
@@ -277,9 +274,6 @@ pub(crate) enum P2pCommands {
         /// Execution-layer `enode://` URL to probe.
         #[arg(value_name = "ENODE")]
         enode: String,
-        /// Base telemetry service URL.
-        #[arg(long = "telemetry-url", env = "BASECTL_TELEMETRY_URL", value_name = "URL")]
-        telemetry_url: Url,
         /// Emit the telemetry response as JSON.
         #[arg(long)]
         json: bool,
@@ -673,6 +667,7 @@ mod tests {
 
     #[test]
     fn p2p_reachability_parses() {
+        assert!(try_parse(["basectl", "p2p", "reachability", "enode://example", "--json"]).is_ok());
         assert!(
             try_parse([
                 "basectl",
@@ -681,9 +676,16 @@ mod tests {
                 "enode://example",
                 "--telemetry-url",
                 "http://127.0.0.1:8080",
-                "--json",
             ])
-            .is_ok()
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn doctor_rejects_removed_telemetry_url_flag() {
+        assert!(try_parse(["basectl", "doctor"]).is_ok());
+        assert!(
+            try_parse(["basectl", "doctor", "--telemetry-url", "http://127.0.0.1:8080",]).is_err()
         );
     }
 

--- a/bin/basectl/src/doctor.rs
+++ b/bin/basectl/src/doctor.rs
@@ -24,7 +24,6 @@ pub(crate) async fn run(config: MonitoringConfig, args: DoctorArgs) -> Result<Co
         el_rpc: args.el_rpc.unwrap_or_else(|| config.rpc.clone()),
         cl_rpc: args.cl_rpc.or_else(|| config.consensus_node_rpc.clone()),
         reth_config: args.reth_config,
-        telemetry_url: args.telemetry_url,
         thresholds: DoctorThresholds {
             peer_warn_threshold: args.peer_warn_threshold,
             head_lag_warn_blocks: args.head_lag_warn_blocks,
@@ -304,7 +303,6 @@ mod tests {
             el_rpc: Some(Url::parse("http://127.0.0.1:8545").unwrap()),
             cl_rpc: None,
             reth_config: Option::<PathBuf>::None,
-            telemetry_url: None,
             peer_warn_threshold: 5,
             head_lag_warn_blocks: 10,
             head_lag_fail_blocks: 20,

--- a/bin/basectl/src/p2p.rs
+++ b/bin/basectl/src/p2p.rs
@@ -2,13 +2,13 @@
 
 use std::io::{self, Write};
 
-use anyhow::Result;
+use anyhow::{Context, Result, anyhow};
 use base_consensus_peers::BootNode;
 use basectl_cli::{
     ElReachabilityOutcome, JsonOutput, KeyValueTable, MonitoringConfig, P2pCommandError,
     P2pInfoJson, P2pInfoTable, P2pTargetError, PeerListReport, PeerSummary, TelemetryClient,
     add_peer, ban_peer, connect_peer, disconnect_peer, fetch_connected_peers, fetch_info,
-    fetch_raw_info, fetch_raw_peers, list_banned_peers, remove_peer, unban_peer,
+    fetch_l2_chain_id, fetch_raw_info, fetch_raw_peers, list_banned_peers, remove_peer, unban_peer,
 };
 use serde::Serialize;
 use url::Url;
@@ -24,8 +24,9 @@ use crate::{
 /// Runs the `basectl p2p` command group.
 pub(crate) async fn run(config: &str, command: P2pCommands) -> Result<CommandOutcome> {
     match command {
-        P2pCommands::Reachability { enode, telemetry_url, json } => {
-            run_reachability(&enode, telemetry_url, json).await
+        P2pCommands::Reachability { enode, json } => {
+            let config = MonitoringConfig::load(config).await?;
+            run_reachability(&config, &enode, json).await
         }
         other => {
             let config = MonitoringConfig::load(config).await?;
@@ -46,7 +47,20 @@ pub(crate) async fn run(config: &str, command: P2pCommands) -> Result<CommandOut
 
 /// Runs `basectl p2p reachability`, exiting non-zero when the probe completed
 /// but the node was not reachable.
-async fn run_reachability(enode: &str, telemetry_url: Url, json: bool) -> Result<CommandOutcome> {
+async fn run_reachability(
+    config: &MonitoringConfig,
+    enode: &str,
+    json: bool,
+) -> Result<CommandOutcome> {
+    let chain_id = fetch_l2_chain_id(&config.rpc).await.with_context(|| {
+        format!("could not detect network from selected config RPC {}", config.rpc)
+    })?;
+    let telemetry_url =
+        TelemetryClient::reachability_url_for_chain_id(chain_id).ok_or_else(|| {
+            anyhow!(
+                "hosted reachability checks are unavailable for chain ID {chain_id}; supported chain IDs are 8453 (Base mainnet) and 84532 (Base Sepolia)"
+            )
+        })?;
     let response = TelemetryClient::new(telemetry_url)?.check_el_reachability(enode).await?;
     let reachable = response.outcome == ElReachabilityOutcome::Reachable;
     if json {
@@ -667,7 +681,7 @@ mod tests {
     use super::{
         AddTarget, PeerAction, PeerActionJson, PeerBulkActionResultJson, RemoveTarget,
         fail_unban_all_if_partial, parse_add_target, parse_cl_peer_id, parse_remove_target,
-        resolve_cl_rpc, run,
+        resolve_cl_rpc, run, run_reachability,
     };
     use crate::cli::P2pCommands;
 
@@ -729,19 +743,29 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reachability_does_not_load_monitoring_config() {
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let address = listener.local_addr().unwrap();
-        drop(listener);
-        let command = P2pCommands::Reachability {
-            enode: VALID_ENODE.to_string(),
-            telemetry_url: Url::parse(&format!("http://{address}")).unwrap(),
-            json: false,
-        };
+    async fn reachability_loads_selected_monitoring_config() {
+        let command = P2pCommands::Reachability { enode: VALID_ENODE.to_string(), json: false };
 
         let error = run("/definitely/missing/basectl.yaml", command).await.unwrap_err();
 
-        assert!(error.to_string().starts_with("telemetry service unavailable:"));
+        assert!(
+            error.to_string().starts_with("Config '/definitely/missing/basectl.yaml' not found")
+        );
+    }
+
+    #[tokio::test]
+    async fn reachability_reports_network_detection_failure() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        drop(listener);
+        let mut config = test_config(None);
+        config.rpc = Url::parse(&format!("http://{address}")).unwrap();
+
+        let error = run_reachability(&config, VALID_ENODE, false).await.unwrap_err();
+
+        assert!(
+            format!("{error:#}").starts_with("could not detect network from selected config RPC")
+        );
     }
 
     #[test]

--- a/crates/infra/basectl/src/doctor.rs
+++ b/crates/infra/basectl/src/doctor.rs
@@ -39,8 +39,6 @@ pub struct DoctorOptions {
     pub cl_rpc: Option<Url>,
     /// Optional local `reth.toml` path.
     pub reth_config: Option<PathBuf>,
-    /// Optional Base telemetry service URL for external EL reachability checks.
-    pub telemetry_url: Option<Url>,
     /// Classification thresholds for graded checks.
     pub thresholds: DoctorThresholds,
 }
@@ -215,37 +213,31 @@ impl DoctorStatus {
 impl Doctor {
     /// Runs doctor checks and returns a complete report.
     pub async fn run(config: MonitoringConfig, options: DoctorOptions) -> DoctorReport {
-        let inputs = DoctorInputs {
-            el_rpc: options.el_rpc.clone(),
-            cl_rpc: options.cl_rpc.clone(),
-            l1_rpc: config.l1_rpc.clone(),
-            public_tip_rpc: config.rpc.clone(),
-            reth_config: options.reth_config.clone(),
-            telemetry_url: options.telemetry_url.clone(),
-        };
-
-        let telemetry_url = options.telemetry_url.clone();
         let el_rpc = options.el_rpc.clone();
         let (
-            (el_info, el_reachability),
+            (el_info, chain_id, telemetry_url, el_reachability),
             cl_info,
-            chain_id,
             local_head,
             public_head,
             sync_status,
             l1_head,
         ) = tokio::join!(
             async move {
-                let el_info = fetch_el_info(&el_rpc).await;
+                let (el_info, chain_id) =
+                    tokio::join!(fetch_el_info(&el_rpc), fetch_l2_chain_id(&el_rpc));
+                let telemetry_url = chain_id
+                    .as_ref()
+                    .ok()
+                    .and_then(|chain_id| TelemetryClient::reachability_url_for_chain_id(*chain_id));
                 let enode = el_info.as_ref().ok().and_then(|info| info.identity.enode.clone());
-                let reachability = match (telemetry_url, enode) {
-                    (Some(url), Some(enode)) => Some(match TelemetryClient::new(url) {
+                let reachability = match (telemetry_url.as_ref(), enode) {
+                    (Some(url), Some(enode)) => Some(match TelemetryClient::new(url.clone()) {
                         Ok(client) => client.check_el_reachability(&enode).await,
                         Err(error) => Err(error),
                     }),
                     _ => None,
                 };
-                (el_info, reachability)
+                (el_info, chain_id, telemetry_url, reachability)
             },
             async {
                 match &options.cl_rpc {
@@ -253,7 +245,6 @@ impl Doctor {
                     None => None,
                 }
             },
-            fetch_l2_chain_id(&options.el_rpc),
             fetch_l2_block_number(&options.el_rpc),
             fetch_l2_block_number(&config.rpc),
             async {
@@ -265,12 +256,22 @@ impl Doctor {
             fetch_l1_block_number(&config.l1_rpc),
         );
 
+        let inputs = DoctorInputs {
+            el_rpc: options.el_rpc.clone(),
+            cl_rpc: options.cl_rpc.clone(),
+            l1_rpc: config.l1_rpc.clone(),
+            public_tip_rpc: config.rpc.clone(),
+            reth_config: options.reth_config.clone(),
+            telemetry_url: telemetry_url.clone(),
+        };
+
         let checks = vec![
             Self::p2p_config_check(&el_info, cl_info.as_ref()),
             Self::bootnode_check(chain_id.as_ref().ok(), &config),
             Self::advertised_endpoint_check(&el_info, cl_info.as_ref()),
             Self::external_el_reachability_check(
-                options.telemetry_url.as_ref(),
+                &chain_id,
+                telemetry_url.as_ref(),
                 el_reachability.as_ref(),
             ),
             Self::declared_network_check(&config, &chain_id),
@@ -294,18 +295,41 @@ impl Doctor {
 
     /// Builds the external execution-layer reachability doctor check.
     fn external_el_reachability_check(
+        chain_id: &Result<u64>,
         telemetry_url: Option<&Url>,
         result: Option<&Result<ElReachabilityResponse, TelemetryClientError>>,
     ) -> DoctorCheck {
+        let chain_id = match chain_id {
+            Ok(chain_id) => *chain_id,
+            Err(error) => {
+                return DoctorCheck::new(
+                    "external_el_reachability",
+                    DoctorStatus::Skip,
+                    "could not detect network for external EL reachability check",
+                    json!({
+                        "telemetryUrl": null,
+                        "error": error.to_string(),
+                    }),
+                    json!({ "pass": "reachable" }),
+                    Some(
+                        "Check the effective `--el-rpc` endpoint and ensure `eth_chainId` is available."
+                            .to_string(),
+                    ),
+                );
+            }
+        };
         let Some(telemetry_url) = telemetry_url else {
             return DoctorCheck::new(
                 "external_el_reachability",
                 DoctorStatus::Skip,
-                "external EL reachability check is not configured",
-                json!({ "telemetryUrl": null }),
+                format!("external EL reachability checks are unavailable for chain ID {chain_id}"),
+                json!({
+                    "chainId": chain_id,
+                    "telemetryUrl": null,
+                }),
                 json!({ "pass": "reachable" }),
                 Some(
-                    "Pass `--telemetry-url <URL>` or set `BASECTL_TELEMETRY_URL` to enable the check."
+                    "Hosted reachability checks support Base mainnet (8453) and Base Sepolia (84532)."
                         .to_string(),
                 ),
             );
@@ -1105,6 +1129,7 @@ mod tests {
         path::PathBuf,
     };
 
+    use anyhow::anyhow;
     use serde_json::json;
     use url::Url;
 
@@ -1206,15 +1231,22 @@ mod tests {
     #[test]
     fn external_reachability_classifies_probe_outcomes() {
         let telemetry_url = Url::parse("http://127.0.0.1:8080").unwrap();
+        let chain_id = Ok(8453);
         let reachable = Ok(reachability(ElReachabilityOutcome::Reachable));
         let failed = Ok(reachability(ElReachabilityOutcome::ConnectionFailed));
 
         assert_eq!(
-            Doctor::external_el_reachability_check(Some(&telemetry_url), Some(&reachable),).status,
+            Doctor::external_el_reachability_check(
+                &chain_id,
+                Some(&telemetry_url),
+                Some(&reachable),
+            )
+            .status,
             DoctorStatus::Pass,
         );
         assert_eq!(
-            Doctor::external_el_reachability_check(Some(&telemetry_url), Some(&failed),).status,
+            Doctor::external_el_reachability_check(&chain_id, Some(&telemetry_url), Some(&failed),)
+                .status,
             DoctorStatus::Fail,
         );
     }
@@ -1222,23 +1254,56 @@ mod tests {
     #[test]
     fn external_reachability_preserves_client_error_classification() {
         let telemetry_url = Url::parse("http://127.0.0.1:8080").unwrap();
+        let chain_id = Ok(8453);
         let invalid = Err(TelemetryClientError::InvalidRequest);
         let saturated = Err(TelemetryClientError::Saturated);
         let unavailable =
             Err(TelemetryClientError::Unavailable { message: "connection refused".to_string() });
 
         assert_eq!(
-            Doctor::external_el_reachability_check(Some(&telemetry_url), Some(&invalid),).status,
+            Doctor::external_el_reachability_check(
+                &chain_id,
+                Some(&telemetry_url),
+                Some(&invalid),
+            )
+            .status,
             DoctorStatus::Fail,
         );
         assert_eq!(
-            Doctor::external_el_reachability_check(Some(&telemetry_url), Some(&saturated),).status,
+            Doctor::external_el_reachability_check(
+                &chain_id,
+                Some(&telemetry_url),
+                Some(&saturated),
+            )
+            .status,
             DoctorStatus::Warn,
         );
         assert_eq!(
-            Doctor::external_el_reachability_check(Some(&telemetry_url), Some(&unavailable),)
-                .status,
+            Doctor::external_el_reachability_check(
+                &chain_id,
+                Some(&telemetry_url),
+                Some(&unavailable),
+            )
+            .status,
             DoctorStatus::Skip,
+        );
+    }
+
+    #[test]
+    fn external_reachability_skips_unsupported_and_undetected_networks() {
+        let unsupported = Doctor::external_el_reachability_check(&Ok(1), None, None);
+        let undetected = Doctor::external_el_reachability_check(
+            &Err(anyhow!("eth_chainId unavailable")),
+            None,
+            None,
+        );
+
+        assert_eq!(unsupported.status, DoctorStatus::Skip);
+        assert!(unsupported.message.contains("chain ID 1"));
+        assert_eq!(undetected.status, DoctorStatus::Skip);
+        assert_eq!(
+            undetected.message,
+            "could not detect network for external EL reachability check"
         );
     }
 

--- a/crates/infra/basectl/src/rpc/telemetry.rs
+++ b/crates/infra/basectl/src/rpc/telemetry.rs
@@ -131,6 +131,16 @@ pub struct TelemetryClient {
 }
 
 impl TelemetryClient {
+    /// Returns the hosted reachability service URL for a supported Base chain.
+    pub fn reachability_url_for_chain_id(chain_id: u64) -> Option<Url> {
+        Url::parse(match chain_id {
+            8453 => "https://mainnet.telemetry.base.org",
+            84532 => "https://sepolia.telemetry.base.org",
+            _ => return None,
+        })
+        .ok()
+    }
+
     /// Creates a telemetry client with a timeout longer than the backend probe deadline.
     pub fn new(base_url: Url) -> Result<Self, TelemetryClientError> {
         let http = reqwest::Client::builder().timeout(TELEMETRY_REQUEST_TIMEOUT).build()?;
@@ -242,6 +252,19 @@ mod tests {
         assert_eq!(ElReachabilityStage::TcpConnect.as_str(), "tcp_connect");
         assert_eq!(ElReachabilityStage::EncryptedHandshake.as_str(), "encrypted_handshake");
         assert_eq!(ElReachabilityStage::Devp2pHello.as_str(), "devp2p_hello");
+    }
+
+    #[test]
+    fn maps_supported_chain_ids_to_hosted_reachability_services() {
+        assert_eq!(
+            TelemetryClient::reachability_url_for_chain_id(8453),
+            Url::parse("https://mainnet.telemetry.base.org").ok(),
+        );
+        assert_eq!(
+            TelemetryClient::reachability_url_for_chain_id(84532),
+            Url::parse("https://sepolia.telemetry.base.org").ok(),
+        );
+        assert_eq!(TelemetryClient::reachability_url_for_chain_id(1), None);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Route reachability checks to hosted telemetry services using the detected chain ID.
- Support Base mainnet and Base Sepolia, skipping or erroring clearly for unsupported or undetectable
    networks.
- Remove the `--telemetry-url` flag and `BASECTL_TELEMETRY_URL` environment override.

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p basectl-cli -p basectl`
- [x] `cargo
    clippy -p basectl-cli -p basectl --all-targets --all-features -- -D warnings`

## Stack
- Stacked on #4070 and targets `atharv/p2p-rate-limiting`, not `main`.

## Breaking Changes
- Removes the
    `--telemetry-url` flag and `BASECTL_TELEMETRY_URL` environment override.