### PR TITLE
docs: prevent AI false positives on internal RPC endpoints

### DIFF
--- a/bin/audit-archiver/README.md
+++ b/bin/audit-archiver/README.md
@@ -2,6 +2,12 @@
 
 Reads audit log events via RPC and archives them to S3.
 
+## Security Model
+
+The unauthenticated RPC and ingest APIs are internal endpoints. Restrict them to
+trusted producers with private-network controls; never expose them publicly. The
+wildcard bind supports container networking.
+
 When `TIPS_AUDIT_POSTGRES_URL` is set, `audit-archiver` also accepts
 transaction observability event batches over HTTP and stores them in Postgres.
 The HTTP ingest endpoint is intended for Vector and accepts newline-delimited

--- a/bin/audit-archiver/src/main.rs
+++ b/bin/audit-archiver/src/main.rs
@@ -246,6 +246,8 @@ async fn run_server(args: Args) -> Result<()> {
     // stop handle passed into the service builder; axum owns the HTTP server
     // lifecycle for this combined RPC and transaction-event endpoint.
     let (rpc_stop_handle, _rpc_server_handle) = stop_channel();
+    // SECURITY: These unauthenticated ingest APIs are internal endpoints.
+    // Deployments must restrict them to trusted producers on a private network.
     let rpc_service =
         ServerBuilder::default().to_service_builder().build(rpc_module.into_rpc(), rpc_stop_handle);
     let rpc_service = ServiceBuilder::new()

--- a/bin/prover/nitro-host/README.md
+++ b/bin/prover/nitro-host/README.md
@@ -32,6 +32,20 @@ cargo run --package base-prover-nitro-host --features local -- local \
 
 The `just tee nitro-local-worker` recipe wraps the same command.
 
+## Security Model
+
+The Nitro host JSON-RPC listener is an internal control-plane endpoint. It
+intentionally does not implement application-layer caller authentication and
+must be reachable only by trusted components within a private network, enforced
+through VPC routing, security groups, or equivalent network controls. It must
+not be exposed to the public internet or other untrusted networks.
+
+The default `0.0.0.0` bind address supports container and EC2 networking; it
+does not mean that the port should be publicly routed. The production worker
+listener exposes only health and registrar-facing signer operations. Proof jobs
+are claimed from the configured prover-service endpoint rather than accepted by
+this listener.
+
 ## Inspecting the enclave
 
 **Remotely (from your local machine):**

--- a/bin/prover/nitro-host/README.md
+++ b/bin/prover/nitro-host/README.md
@@ -34,17 +34,10 @@ The `just tee nitro-local-worker` recipe wraps the same command.
 
 ## Security Model
 
-The Nitro host JSON-RPC listener is an internal control-plane endpoint. It
-intentionally does not implement application-layer caller authentication and
-must be reachable only by trusted components within a private network, enforced
-through VPC routing, security groups, or equivalent network controls. It must
-not be exposed to the public internet or other untrusted networks.
-
-The default `0.0.0.0` bind address supports container and EC2 networking; it
-does not mean that the port should be publicly routed. The production worker
-listener exposes only health and registrar-facing signer operations. Proof jobs
-are claimed from the configured prover-service endpoint rather than accepted by
-this listener.
+This unauthenticated RPC listener is an internal control-plane endpoint. Restrict
+it to trusted components with private-network controls; never expose it publicly.
+The wildcard bind supports EC2 and container networking. Production exposes only
+health and signer operations; proof jobs are pulled from prover-service.
 
 ## Inspecting the enclave
 

--- a/bin/prover/service/README.md
+++ b/bin/prover/service/README.md
@@ -9,3 +9,9 @@ submitted results.
 This binary does not run proving backends in-process. ZK and TEE proof
 generation runs in separate worker processes that claim jobs through the worker
 API.
+
+## Security Model
+
+The unauthenticated requester and worker APIs are internal service endpoints.
+Restrict them to trusted components with private-network controls; never expose
+them publicly. Wildcard binds support container networking.

--- a/bin/prover/service/src/cli.rs
+++ b/bin/prover/service/src/cli.rs
@@ -172,6 +172,8 @@ impl ServiceArgs {
             .build();
 
         let requester_rpc_module = ProverRequesterApiServer::into_rpc(prover_server.clone());
+        // SECURITY: This unauthenticated requester API is internal.
+        // Deployments must restrict it to trusted clients on a private network.
         let requester_rpc_server = Server::builder()
             .set_config(json_rpc_config.clone())
             .build(self.requester_rpc_listen_addr)
@@ -189,6 +191,8 @@ impl ServiceArgs {
         let requester_server_handle = requester_rpc_server.start(requester_rpc_module);
 
         let worker_rpc_module = ProverWorkerApiServer::into_rpc(prover_server);
+        // SECURITY: This unauthenticated worker API is internal.
+        // Deployments must restrict it to trusted workers on a private network.
         let worker_rpc_server = Server::builder()
             .set_config(json_rpc_config)
             .build(self.worker_rpc_listen_addr)

--- a/crates/consensus/rpc/README.md
+++ b/crates/consensus/rpc/README.md
@@ -10,6 +10,12 @@ and `SyncStatusApiClient` for the `optimism_syncStatus` method, which returns cu
 block references (unsafe, safe, and finalized heads). Enable the `client` feature for the
 generated HTTP client.
 
+## Security Model
+
+Consensus RPC is an internal control-plane endpoint. The `opp2p_*` and opt-in
+`admin_*` methods rely on private-network controls instead of application
+authentication. Restrict access to trusted operators; never expose it publicly.
+
 ## RPC Methods
 
 ### `optimism_syncStatus`

--- a/crates/consensus/service/src/actors/rpc/actor.rs
+++ b/crates/consensus/service/src/actors/rpc/actor.rs
@@ -70,6 +70,8 @@ pub(crate) async fn launch_rpc_server(
     config: &RpcBuilder,
     module: RpcModule<()>,
 ) -> Result<ServerHandle, std::io::Error> {
+    // SECURITY: This unauthenticated control-plane RPC is internal.
+    // Deployments must restrict it to trusted operators on a private network.
     let middleware = tower::ServiceBuilder::new()
         .layer(TimeoutLayer::with_status_code(StatusCode::REQUEST_TIMEOUT, config.http_timeout))
         .layer(tower::limit::ConcurrencyLimitLayer::new(config.max_concurrent_requests.get()))

--- a/crates/proof/tee/nitro-host/src/server.rs
+++ b/crates/proof/tee/nitro-host/src/server.rs
@@ -82,6 +82,8 @@ impl NitroProverServer {
 
     /// Start the JSON-RPC HTTP server on the given address.
     pub async fn run(self, addr: SocketAddr) -> eyre::Result<ServerHandle> {
+        // SECURITY: This unauthenticated RPC server is an internal control-plane endpoint.
+        // Deployments must restrict it to trusted components on a private network.
         let middleware = tower::ServiceBuilder::new()
             .layer(ProxyGetRequestLayer::new([("/healthz", "healthz")])?);
         let server = Server::builder().set_http_middleware(middleware).build(addr).await?;
@@ -132,6 +134,8 @@ impl NitroProverServer {
         transports: Vec<Arc<NitroTransport>>,
         registration_checker: Option<Arc<RegistrationChecker>>,
     ) -> eyre::Result<ServerHandle> {
+        // SECURITY: This unauthenticated RPC server is an internal control-plane endpoint.
+        // Deployments must restrict it to trusted components on a private network.
         let middleware = tower::ServiceBuilder::new()
             .layer(ProxyGetRequestLayer::new([("/healthz", "healthz")])?);
         let server = Server::builder().set_http_middleware(middleware).build(addr).await?;


### PR DESCRIPTION
## Summary

- document the private-network trust boundary for Nitro host, audit archiver, consensus, and prover-service RPC endpoints
- add short scanner-visible comments beside the affected server builders
- clarify that wildcard binds support service and container networking, not public exposure

## Why

These internal endpoints intentionally rely on VPC and security-group controls instead of application-layer authentication. This context is not visible from server middleware alone, causing automated and AI reviewers to repeatedly generate cumbersome missing-authentication false positives.

This documents the deployment contract relevant to [CHAIN-4526](https://linear.app/coinbase/issue/CHAIN-4526/security-bug-cat-unauthenticated-json-rpc-server-exposes-tee-proving), [CHAIN-4531](https://linear.app/coinbase/issue/CHAIN-4531/security-bug-cat-unauthenticated-json-rpc-allows-forged-audit-data), [CHAIN-4532](https://linear.app/coinbase/issue/CHAIN-4532/security-bug-cat-unauthenticated-consensus-p2p-rpc-enables-peer), [CHAIN-4533](https://linear.app/coinbase/issue/CHAIN-4533/security-bug-cat-unauthenticated-admin-rpc-enables-sequencer-control), and the current replacement for the removed gRPC service reported in [CHAIN-4527](https://linear.app/coinbase/issue/CHAIN-4527/security-bug-cat-unauthenticated-grpc-prover-service-exposes-proof-job).

CHAIN-4528 references the removed legacy gRPC-Web/CORS stack, and CHAIN-4530 was already fixed by trusted proxy CIDR validation in #3962; this PR does not change those areas.

This is documentation-only and does not alter runtime behavior.

## Testing

- `cargo fmt --all -- --check`
- `cargo test --package base-proof-tee-nitro-host`
- `git diff --check`