### PR TITLE
ci(BOP-455): pin Beryl fork-test snapshots

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -32,6 +32,9 @@ inputs:
   rust-cache-save:
     description: Whether to save the Rust cache
     default: "false"
+  just:
+    description: Install just
+    default: "true"
 
 runs:
   using: composite
@@ -107,6 +110,7 @@ runs:
         cache-targets: "false"
 
     - name: Install just
+      if: inputs.just == 'true'
       uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
       with:
         just-version: "1.43.1"

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -54,6 +54,7 @@ jobs:
           foundry: "true"
           native-deps: "true"
           rust-cache-shared-key: "base-std-fork-tests"
+          just: "false"
 
       - name: Checkout pinned fork-test pair
         shell: bash

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -10,11 +10,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Pinned base-anvil commit so this job is decoupled from base-anvil-fork
-  # branch movement. Bump in lockstep with base/base's reth/revm version; a
-  # cutover to a new base-anvil (e.g. reth 2.3.0) rides in the same base/base PR.
-  BASE_ANVIL_REF: dccbdfd0b37d364cc50e0e15f1686ab029543c6f
-  BASE_STD_REF: main
   CARGO_TERM_COLOR: always
   RUSTC_WRAPPER: "sccache"
   SCCACHE_GHA_ENABLED: "true"
@@ -25,10 +20,23 @@ permissions:
 
 jobs:
   fork-tests:
-    name: Base Std Interface Tests
+    name: Base Std Interface Tests (${{ matrix.fork }})
     runs-on:
       group: BasePerfRunnerGroup
     timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - fork: Beryl
+            key: beryl
+            base_anvil_ref: dccbdfd0b37d364cc50e0e15f1686ab029543c6f
+            base_std_ref: 4658f1b7b54ccc61b036adc32830594018ea507e
+    env:
+      FORK_NAME: ${{ matrix.fork }}
+      FORK_KEY: ${{ matrix.key }}
+      BASE_ANVIL_REF: ${{ matrix.base_anvil_ref }}
+      BASE_STD_REF: ${{ matrix.base_std_ref }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -47,7 +55,7 @@ jobs:
           native-deps: "true"
           rust-cache-shared-key: "base-std-fork-tests"
 
-      - name: Clone fork-test repositories
+      - name: Checkout pinned fork-test pair
         shell: bash
         env:
           # BASE_STD_TOKEN must be a PAT with Contents:Read on base/base-std.
@@ -56,61 +64,39 @@ jobs:
         run: |
           set -euo pipefail
 
-          workdir="$RUNNER_TEMP/base-std-fork-tests"
+          workdir="$RUNNER_TEMP/base-std-fork-tests/$FORK_KEY"
           rm -rf "$workdir"
           mkdir -p "$workdir"
 
-          # base-std is internal — use gh CLI with a cross-repo PAT.
           gh repo clone base/base-std "$workdir/base-std" -- \
-            --depth 1 --single-branch --branch "$BASE_STD_REF" \
-            --recurse-submodules --shallow-submodules
+            --filter=blob:none --no-checkout
+          git -C "$workdir/base-std" fetch --depth 1 origin "$BASE_STD_REF"
+          git -C "$workdir/base-std" checkout --detach "$BASE_STD_REF"
+          git -C "$workdir/base-std" submodule update --init --recursive --depth 1
+
           git clone --filter=blob:none --no-checkout \
             https://github.com/base/base-anvil.git "$workdir/base-anvil"
+          git -C "$workdir/base-anvil" fetch --depth 1 origin "$BASE_ANVIL_REF"
           git -C "$workdir/base-anvil" checkout --detach "$BASE_ANVIL_REF"
 
-          echo "BASE_STD_DIR=$workdir/base-std" >> "$GITHUB_ENV"
-          echo "BASE_ANVIL_DIR=$workdir/base-anvil" >> "$GITHUB_ENV"
-
-          # Capture commit SHAs for the running comment and final results.
+          base_sha=$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)
           base_std_sha=$(git -C "$workdir/base-std" rev-parse HEAD)
           base_anvil_sha=$(git -C "$workdir/base-anvil" rev-parse HEAD)
+
+          if [ "$base_std_sha" != "$BASE_STD_REF" ]; then
+            echo "::error::base-std checkout mismatch: expected $BASE_STD_REF, got $base_std_sha"
+            exit 1
+          fi
+          if [ "$base_anvil_sha" != "$BASE_ANVIL_REF" ]; then
+            echo "::error::base-anvil checkout mismatch: expected $BASE_ANVIL_REF, got $base_anvil_sha"
+            exit 1
+          fi
+
+          echo "BASE_SHA=$base_sha" >> "$GITHUB_ENV"
           echo "BASE_STD_SHA=$base_std_sha" >> "$GITHUB_ENV"
           echo "BASE_ANVIL_SHA=$base_anvil_sha" >> "$GITHUB_ENV"
-
-      - name: Post "running" comment on PR
-        if: github.event_name == 'pull_request'
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-
-          marker="<!-- fork-test-results -->"
-          versions="| Dependency | Ref | Commit |
-          |---|---|---|
-          | [base-std](https://github.com/base/base-std) | \`${BASE_STD_REF}\` | [\`${BASE_STD_SHA:0:8}\`](https://github.com/base/base-std/commit/${BASE_STD_SHA}) |
-          | [base-anvil](https://github.com/base/base-anvil) | \`${BASE_ANVIL_REF}\` | [\`${BASE_ANVIL_SHA:0:8}\`](https://github.com/base/base-anvil/commit/${BASE_ANVIL_SHA}) |"
-
-          body=$(printf '%s\n\n%s\n\n%s\n\n[View run](%s)' \
-            "${marker}" \
-            "### 🔄 base-std fork tests: running..." \
-            "${versions}" \
-            "${WORKFLOW_RUN_URL}")
-
-          existing_id=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-            --jq ".[] | select(.body | startswith(\"${marker}\")) | .id" \
-            | head -1)
-
-          if [ -n "$existing_id" ]; then
-            gh api "repos/${REPO}/issues/comments/${existing_id}" \
-              -X PATCH --field body="$body" > /dev/null
-          else
-            gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-              --field body="$body" > /dev/null
-          fi
+          echo "BASE_STD_DIR=$workdir/base-std" >> "$GITHUB_ENV"
+          echo "BASE_ANVIL_DIR=$workdir/base-anvil" >> "$GITHUB_ENV"
 
       - name: Build patched base-anvil binaries
         shell: bash
@@ -138,11 +124,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-
           cd "$BASE_STD_DIR"
           make smoke-setup PYTHON=python3
 
       - name: Run base-std fork tests
+        id: fork_tests
+        continue-on-error: true
         shell: bash
         run: |
           set -euo pipefail
@@ -153,67 +140,137 @@ jobs:
             ANVIL_LOG="$RUNNER_TEMP/base-std-anvil.log" \
             make fork-tests 2>&1 | tee "$RUNNER_TEMP/fork-test-output.txt"
 
-      - name: Comment fork test results on PR
+      - name: Record fork-test result
+        if: always()
+        shell: bash
+        env:
+          FORK_TEST_OUTCOME: ${{ steps.fork_tests.outcome }}
+        run: |
+          output="$RUNNER_TEMP/fork-test-output.txt"
+          result_dir="$RUNNER_TEMP/fork-test-results"
+          mkdir -p "$result_dir/results" "$result_dir/logs" "$result_dir/outputs"
+
+          passed=$(grep -c '\[PASS\]' "$output" 2>/dev/null || true)
+          failed=$(grep -c '\[FAIL' "$output" 2>/dev/null || true)
+          skipped=$(grep -c '\[SKIP\]' "$output" 2>/dev/null || true)
+          passed=${passed:-0}
+          failed=${failed:-0}
+          skipped=${skipped:-0}
+          total=$((passed + failed + skipped))
+          status=failure
+          if [ "$FORK_TEST_OUTCOME" = "success" ] && [ "$total" -gt 0 ] && [ "$failed" -eq 0 ]; then
+            status=success
+          fi
+
+          printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$FORK_NAME" "$status" "$passed" "$failed" "$skipped" \
+            "${BASE_SHA:-unknown}" "${BASE_ANVIL_SHA:-$BASE_ANVIL_REF}" \
+            "${BASE_STD_SHA:-$BASE_STD_REF}" \
+            > "$result_dir/results/$FORK_KEY.tsv"
+
+          if [ -f "$output" ]; then
+            cp "$output" "$result_dir/outputs/$FORK_KEY.txt"
+          fi
+          if [ -f "$RUNNER_TEMP/base-std-anvil.log" ]; then
+            cp "$RUNNER_TEMP/base-std-anvil.log" "$result_dir/logs/$FORK_KEY-anvil.log"
+          fi
+
+      - name: Upload fork-test result
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: base-std-fork-${{ matrix.key }}
+          path: ${{ runner.temp }}/fork-test-results
+          if-no-files-found: error
+
+      - name: Enforce fork-test result
+        if: always()
+        shell: bash
+        run: |
+          status=$(cut -f2 "$RUNNER_TEMP/fork-test-results/results/$FORK_KEY.tsv")
+          if [ "$status" != "success" ]; then
+            echo "::error::$FORK_NAME fork-test snapshot failed or ran no tests"
+            exit 1
+          fi
+
+  aggregate:
+    name: Base Std Interface Tests
+    if: always()
+    needs: fork-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Download fork-test results
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: base-std-fork-*
+          path: ${{ runner.temp }}/fork-test-results
+          merge-multiple: true
+
+      - name: Aggregate fork-test results
+        id: aggregate
+        shell: bash
+        env:
+          WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          result_files=("$RUNNER_TEMP"/fork-test-results/results/*.tsv)
+          body="$RUNNER_TEMP/fork-test-comment.md"
+          overall=success
+
+          {
+            echo '<!-- fork-test-results -->'
+            echo
+            echo '### Base Std historical fork tests'
+            echo
+            echo '| Fork | Result | Passed | Failed | Skipped | base/base | base-anvil | base-std |'
+            echo '|---|---|---:|---:|---:|---|---|---|'
+
+            if [ ${#result_files[@]} -eq 0 ]; then
+              overall=failure
+              echo '| unknown | failure: no results | 0 | 0 | 0 | unknown | unknown | unknown |'
+            else
+              for result_file in "${result_files[@]}"; do
+                IFS=$'\t' read -r fork status passed failed skipped base_sha base_anvil_sha base_std_sha < "$result_file"
+                if [ "$status" = "success" ]; then
+                  display_status='pass'
+                else
+                  display_status='failure'
+                  overall=failure
+                fi
+                base_link="[\`${base_sha:0:8}\`](https://github.com/base/base/commit/${base_sha})"
+                base_anvil_link="[\`${base_anvil_sha:0:8}\`](https://github.com/base/base-anvil/commit/${base_anvil_sha})"
+                base_std_link="[\`${base_std_sha:0:8}\`](https://github.com/base/base-std/commit/${base_std_sha})"
+                echo "| $fork | $display_status | $passed | $failed | $skipped | $base_link | $base_anvil_link | $base_std_link |"
+              done
+            fi
+
+            echo
+            echo "[View run]($WORKFLOW_RUN_URL)"
+          } > "$body"
+
+          cat "$body" >> "$GITHUB_STEP_SUMMARY"
+          echo "overall=$overall" >> "$GITHUB_OUTPUT"
+
+      - name: Comment fork-test results on PR
         if: github.event_name == 'pull_request' && always()
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
-          output="$RUNNER_TEMP/fork-test-output.txt"
-          passed=$(grep -c '\[PASS\]' "$output" 2>/dev/null || true)
-          failed=$(grep -c '\[FAIL' "$output" 2>/dev/null || true)
-          passed=${passed:-0}
-          failed=${failed:-0}
-          marker="<!-- fork-test-results -->"
-
-          # Version table included in every outcome so reviewers always know what was tested.
-          base_std_sha="${BASE_STD_SHA:-unknown}"
-          base_anvil_sha="${BASE_ANVIL_SHA:-unknown}"
-          base_std_ref="${BASE_STD_REF:-unknown}"
-          base_anvil_ref="${BASE_ANVIL_REF:-unknown}"
-          if [ "${base_std_sha}" != "unknown" ]; then
-            base_std_link="[\`${base_std_sha:0:8}\`](https://github.com/base/base-std/commit/${base_std_sha})"
-          else
-            base_std_link="\`unknown\`"
-          fi
-          if [ "${base_anvil_sha}" != "unknown" ]; then
-            base_anvil_link="[\`${base_anvil_sha:0:8}\`](https://github.com/base/base-anvil/commit/${base_anvil_sha})"
-          else
-            base_anvil_link="\`unknown\`"
-          fi
-          versions="| Dependency | Ref | Commit |
-          |---|---|---|
-          | [base-std](https://github.com/base/base-std) | \`${base_std_ref}\` | ${base_std_link} |
-          | [base-anvil](https://github.com/base/base-anvil) | \`${base_anvil_ref}\` | ${base_anvil_link} |"
-
-          if [ ! -s "$output" ] || [ "$((passed + failed))" -eq 0 ]; then
-            body=$(printf '%s\n\n%s\n\n%s\n\n%s' \
-              "${marker}" \
-              "### ❌ base-std fork tests did not run" \
-              "The build or setup step failed before any tests could execute. Check the [workflow logs](${WORKFLOW_RUN_URL}) for details." \
-              "${versions}")
-          elif [ "$failed" -eq 0 ]; then
-            body=$(printf '%s\n\n%s\n\n%s\n\n%s' \
-              "${marker}" \
-              "### ✅ base-std fork tests: all ${passed} passed" \
-              "base/base is fully in sync with the base-std spec." \
-              "${versions}")
-          else
-            failing=$(grep '\[FAIL' "$output" \
-              | sed 's/\x1B\[[0-9;]*m//g' \
-              | sed 's/^\[FAIL: \(.*\)\] \(.*\) (runs.*$/- **\2**: `\1`/' \
-              | sort -u || true)
-            body=$(printf '%s\n\n%s\n\n%s\n\n%s\n\n<details>\n<summary>Failing tests</summary>\n\n%s\n\n</details>' \
-              "${marker}" \
-              "### ❌ base-std fork tests: ${failed} failed, ${passed} passed" \
-              "base/base diverges from the base-std spec." \
-              "${versions}" \
-              "${failing}")
-          fi
-
+          set -euo pipefail
+          marker='<!-- fork-test-results -->'
+          body=$(cat "$RUNNER_TEMP/fork-test-comment.md")
           existing_id=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
             --jq ".[] | select(.body | startswith(\"${marker}\")) | .id" \
             | head -1)
@@ -224,4 +281,16 @@ jobs:
           else
             gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
               --field body="$body" > /dev/null
+          fi
+
+      - name: Enforce aggregate result
+        if: always()
+        shell: bash
+        env:
+          OVERALL: ${{ steps.aggregate.outputs.overall }}
+          MATRIX_RESULT: ${{ needs['fork-tests'].result }}
+        run: |
+          if [ "$OVERALL" != "success" ] || [ "$MATRIX_RESULT" != "success" ]; then
+            echo "::error::One or more historical Base Std fork-test snapshots failed"
+            exit 1
           fi

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -28,9 +28,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # base_anvil_ref / base_std_ref are release tags (readable, per-repo).
-          # A future backport can re-point the tag without editing this workflow;
-          # the resolved commit SHA is recorded in the result artifact and PR comment.
+          # Refs may be release tags or commit SHAs. The resolved commit SHA is
+          # recorded in the result artifact and PR comment.
           - fork: Beryl
             key: beryl
             base_anvil_ref: v1.1.1
@@ -72,19 +71,18 @@ jobs:
           rm -rf "$workdir"
           mkdir -p "$workdir"
 
-          # Fetch from the tag namespace so a same-named branch can't be used and
-          # annotated tags (e.g. base-anvil v1.1.1) resolve to their target commit.
-          # A missing tag makes the fetch fail (set -e) — that is the checkout guard.
+          # FETCH_HEAD supports commit SHAs and tags (including annotated tags),
+          # keeping refs independently configurable for each repository.
           gh repo clone base/base-std "$workdir/base-std" -- \
             --filter=blob:none --no-checkout
-          git -C "$workdir/base-std" fetch --depth 1 origin "refs/tags/${BASE_STD_REF}:refs/tags/${BASE_STD_REF}"
-          git -C "$workdir/base-std" checkout --detach "refs/tags/${BASE_STD_REF}"
+          git -C "$workdir/base-std" fetch --depth 1 origin "$BASE_STD_REF"
+          git -C "$workdir/base-std" checkout --detach FETCH_HEAD
           git -C "$workdir/base-std" submodule update --init --recursive --depth 1
 
           git clone --filter=blob:none --no-checkout \
             https://github.com/base/base-anvil.git "$workdir/base-anvil"
-          git -C "$workdir/base-anvil" fetch --depth 1 origin "refs/tags/${BASE_ANVIL_REF}:refs/tags/${BASE_ANVIL_REF}"
-          git -C "$workdir/base-anvil" checkout --detach "refs/tags/${BASE_ANVIL_REF}"
+          git -C "$workdir/base-anvil" fetch --depth 1 origin "$BASE_ANVIL_REF"
+          git -C "$workdir/base-anvil" checkout --detach FETCH_HEAD
 
           # Record the resolved commit SHAs for the audit trail. Tags are readable
           # pointers; the SHA below is the source of truth for what actually ran.

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -28,10 +28,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # base_anvil_ref / base_std_ref are release tags (readable, per-repo).
+          # A future backport can re-point the tag without editing this workflow;
+          # the resolved commit SHA is recorded in the result artifact and PR comment.
           - fork: Beryl
             key: beryl
-            base_anvil_ref: dccbdfd0b37d364cc50e0e15f1686ab029543c6f
-            base_std_ref: 4658f1b7b54ccc61b036adc32830594018ea507e
+            base_anvil_ref: v1.1.1
+            base_std_ref: v1.0.0
     env:
       FORK_NAME: ${{ matrix.fork }}
       FORK_KEY: ${{ matrix.key }}
@@ -69,29 +72,25 @@ jobs:
           rm -rf "$workdir"
           mkdir -p "$workdir"
 
+          # Fetch from the tag namespace so a same-named branch can't be used and
+          # annotated tags (e.g. base-anvil v1.1.1) resolve to their target commit.
+          # A missing tag makes the fetch fail (set -e) — that is the checkout guard.
           gh repo clone base/base-std "$workdir/base-std" -- \
             --filter=blob:none --no-checkout
-          git -C "$workdir/base-std" fetch --depth 1 origin "$BASE_STD_REF"
-          git -C "$workdir/base-std" checkout --detach "$BASE_STD_REF"
+          git -C "$workdir/base-std" fetch --depth 1 origin "refs/tags/${BASE_STD_REF}:refs/tags/${BASE_STD_REF}"
+          git -C "$workdir/base-std" checkout --detach "refs/tags/${BASE_STD_REF}"
           git -C "$workdir/base-std" submodule update --init --recursive --depth 1
 
           git clone --filter=blob:none --no-checkout \
             https://github.com/base/base-anvil.git "$workdir/base-anvil"
-          git -C "$workdir/base-anvil" fetch --depth 1 origin "$BASE_ANVIL_REF"
-          git -C "$workdir/base-anvil" checkout --detach "$BASE_ANVIL_REF"
+          git -C "$workdir/base-anvil" fetch --depth 1 origin "refs/tags/${BASE_ANVIL_REF}:refs/tags/${BASE_ANVIL_REF}"
+          git -C "$workdir/base-anvil" checkout --detach "refs/tags/${BASE_ANVIL_REF}"
 
+          # Record the resolved commit SHAs for the audit trail. Tags are readable
+          # pointers; the SHA below is the source of truth for what actually ran.
           base_sha=$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)
           base_std_sha=$(git -C "$workdir/base-std" rev-parse HEAD)
           base_anvil_sha=$(git -C "$workdir/base-anvil" rev-parse HEAD)
-
-          if [ "$base_std_sha" != "$BASE_STD_REF" ]; then
-            echo "::error::base-std checkout mismatch: expected $BASE_STD_REF, got $base_std_sha"
-            exit 1
-          fi
-          if [ "$base_anvil_sha" != "$BASE_ANVIL_REF" ]; then
-            echo "::error::base-anvil checkout mismatch: expected $BASE_ANVIL_REF, got $base_anvil_sha"
-            exit 1
-          fi
 
           echo "BASE_SHA=$base_sha" >> "$GITHUB_ENV"
           echo "BASE_STD_SHA=$base_std_sha" >> "$GITHUB_ENV"

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -259,7 +259,7 @@ jobs:
           echo "overall=$overall" >> "$GITHUB_OUTPUT"
 
       - name: Comment fork-test results on PR
-        if: github.event_name == 'pull_request' && always()
+        if: github.event_name == 'pull_request' && steps.aggregate.outcome == 'success'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- use readable per-repo release tags in the Beryl matrix (`base-anvil` `v1.1.1`, `base-std` `v1.0.0`) instead of raw commit SHAs
- keep refs generic: each repository can specify a release tag or commit SHA; `git fetch` + detached `FETCH_HEAD` checkout supports both, including annotated tags
- record the resolved commit SHA in the result artifact and PR comment as the audit-trail source of truth
- introduce the hardfork matrix shape (Beryl entry), per-fork artifacts, zero-test detection, and a single aggregate result/comment
- continue patching the current `base/base` implementation into the selected harness so historical tests guard the PR under test
- let workflows opt out of the shared `just` installation and disable it here because this job does not use it

## Beryl refs (currently resolve to these commits)

- `base-anvil` `v1.1.1` -> `dccbdfd0b37d364cc50e0e15f1686ab029543c6f`
- `base-std` `v1.0.0` -> `4658f1b7b54ccc61b036adc32830594018ea507e`

## Testing

- `actionlint` + `yq` on the workflow
- rehearsed the generic ref checkout with both tags and raw commit SHAs; both forms resolve to the commits above, and base-std recursive submodules initialize
- patched base-anvil release build + full Base Std suite locally: 629 total, 616 passed, 0 failed, 13 intentional skips
- GitHub `Base Std Interface Tests (Beryl)` and aggregate `Base Std Interface Tests` jobs pass

## Follow-up

BOP-453 will publish the Cobalt pair (its own per-repo refs) and append one matrix row before BOP-456 validates and enables the blocking full-history gate.