### PR TITLE
feat(shadow-builder): add ShadowDrive mode (build on canonical head,

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4390,6 +4390,8 @@ dependencies = [
  "base-node-runner",
  "base-observability-events",
  "base-proofs-extension",
+ "base-shadow-canary",
+ "base-shadow-canary-db",
  "base-tx-forwarding",
  "base-txpool-rpc",
  "base-txpool-tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6161,6 +6161,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-shadow-canary"
+version = "0.0.0"
+dependencies = [
+ "base-node-runner",
+ "base-shadow-canary-db",
+ "chrono",
+ "eyre",
+ "futures",
+ "reth-execution-types",
+ "reth-exex",
+ "reth-node-api",
+ "reth-primitives-traits",
+ "reth-tasks",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "base-shadow-canary-db"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "base-sidecrush"
 version = "0.0.0"
 dependencies = [
@@ -6307,6 +6338,8 @@ dependencies = [
  "base-prover-service-client",
  "base-prover-service-protocol",
  "base-runtime",
+ "base-shadow-canary",
+ "base-shadow-canary-db",
  "base-tx-forwarding",
  "base-tx-manager",
  "base-txpool-rpc",
@@ -6330,6 +6363,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "testcontainers",
+ "testcontainers-modules",
  "tokio",
  "tokio-util",
  "tracing",
@@ -12518,6 +12552,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12554,7 +12554,6 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
- "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,6 +198,8 @@ base-execution-evm = { path = "crates/execution/evm" }
 base-execution-rpc = { path = "crates/execution/rpc" }
 base-metering = { path = "crates/execution/metering" }
 base-node-runner = { path = "crates/execution/runner" }
+base-shadow-canary = { path = "crates/execution/shadow-canary" }
+base-shadow-canary-db = { path = "crates/execution/shadow-canary-db" }
 base-execution-exex = { path = "crates/execution/exex" }
 base-execution-trie = { path = "crates/execution/trie" }
 base-txpool-rpc = { path = "crates/execution/txpool-rpc" }

--- a/crates/consensus/cli/src/lib.rs
+++ b/crates/consensus/cli/src/lib.rs
@@ -46,6 +46,9 @@ pub use rpc::{EmbeddedRpcArgs, RpcArgs};
 mod sequencer;
 pub use sequencer::SequencerArgs;
 
+mod shadow_drive;
+pub use shadow_drive::ShadowDriveArgs;
+
 pub mod signer;
 pub use signer::{SignerArgs, SignerArgsParseError};
 

--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -1,6 +1,6 @@
 //! Reusable consensus node arguments and launch helpers.
 
-use std::{path::PathBuf, sync::Arc};
+use std::{path::PathBuf, str::FromStr, sync::Arc};
 
 use alloy_primitives::Address;
 use alloy_provider::RootProvider;
@@ -27,7 +27,7 @@ use url::Url;
 use crate::{
     ConsensusChainArgs, EmbeddedL2ClientArgs, EmbeddedP2PArgs, EmbeddedRpcArgs, L1ClientArgs,
     L1ConfigFile, L2ClientArgs, L2ConfigFile, LogArgs, MetricsArgs, P2PArgs, RpcArgs,
-    SequencerArgs, metrics::CliMetrics,
+    SequencerArgs, ShadowDriveArgs, metrics::CliMetrics,
 };
 
 /// Overrides supplied by callers that embed consensus alongside another service.
@@ -186,6 +186,15 @@ pub struct ConsensusNodeConfigArgs {
         long = "mode",
         default_value_t = NodeMode::Validator,
         env = "BASE_NODE_MODE",
+        value_parser = |arg: &str| -> Result<NodeMode, <NodeMode as FromStr>::Err> {
+            let normalized = arg.trim().to_ascii_lowercase().replace('-', "").replace('_', "");
+            match normalized.as_str() {
+                "validator" => Ok(NodeMode::Validator),
+                "sequencer" => Ok(NodeMode::Sequencer),
+                "shadowdrive" => Ok(NodeMode::ShadowDrive),
+                _ => NodeMode::from_str(arg),
+            }
+        },
         help = format!(
             "The mode to run the node in. Supported modes are: {}",
             NodeMode::iter()
@@ -223,6 +232,10 @@ pub struct ConsensusNodeConfigArgs {
     /// SEQUENCER CLI arguments.
     #[command(flatten)]
     pub sequencer_flags: SequencerArgs,
+
+    /// Shadow-drive CLI arguments.
+    #[command(flatten)]
+    pub shadow_drive_flags: ShadowDriveArgs,
 
     /// Path to the `SafeDB` directory. If not set, safe head tracking is disabled.
     #[arg(long = "safedb.path", env = "BASE_NODE_SAFEDB_PATH")]
@@ -324,6 +337,7 @@ impl From<EmbeddedConsensusNodeConfigArgs> for ConsensusNodeConfigArgs {
             p2p_flags: args.p2p_flags.into(),
             rpc_flags: args.rpc_flags.into(),
             sequencer_flags: SequencerArgs::default(),
+            shadow_drive_flags: ShadowDriveArgs::default(),
             safedb_path: args.safedb_path,
             checkpoint_path: args.checkpoint_path,
             upgrade_signal: UpgradeSignalArgs::default(),
@@ -342,6 +356,7 @@ impl From<EmbeddedSequencerConsensusNodeConfigArgs> for ConsensusNodeConfigArgs 
             p2p_flags: args.p2p_flags,
             rpc_flags: args.rpc_flags.into(),
             sequencer_flags: args.sequencer_flags,
+            shadow_drive_flags: ShadowDriveArgs::default(),
             safedb_path: args.safedb_path,
             checkpoint_path: args.checkpoint_path,
             upgrade_signal: UpgradeSignalArgs::default(),
@@ -473,6 +488,11 @@ impl ConsensusNodeArgs {
             mode: self.config.node_mode,
         };
 
+        let shadow_drive_config = self
+            .config
+            .node_mode
+            .is_shadow_drive()
+            .then(|| self.config.shadow_drive_flags.config());
         let mut builder = RollupNodeBuilder::new(
             cfg,
             l1_config,
@@ -482,6 +502,7 @@ impl ConsensusNodeArgs {
             rpc_config,
         )
         .with_sequencer_config(self.config.sequencer_flags.config())
+        .with_shadow_drive_config(shadow_drive_config)
         .with_upgrade_signal_config(UpgradeSignalBuilderConfig {
             metrics_config: upgrade_signal_config,
             l1_rpc: upgrade_signal_l1_rpc,
@@ -630,6 +651,7 @@ mod tests {
             p2p_flags: P2PArgs::default(),
             rpc_flags: RpcArgs::default(),
             sequencer_flags: SequencerArgs::default(),
+            shadow_drive_flags: ShadowDriveArgs::default(),
             safedb_path: None,
             checkpoint_path: None,
             upgrade_signal: UpgradeSignalArgs::default(),
@@ -640,6 +662,20 @@ mod tests {
     struct CommandParser<T: Args> {
         #[command(flatten)]
         args: T,
+    }
+
+    fn parse_config(args: &[&str]) -> ConsensusNodeConfigArgs {
+        let required = [
+            "base-consensus",
+            "--l1-eth-rpc",
+            "http://localhost:8545",
+            "--l1-beacon",
+            "http://localhost:5052",
+            "--l2-engine-rpc",
+            "http://localhost:8551",
+        ];
+        CommandParser::<ConsensusNodeConfigArgs>::parse_from([required.as_slice(), args].concat())
+            .args
     }
 
     #[test]
@@ -661,6 +697,18 @@ mod tests {
             args.upgrade_signal.contract_address,
             Some(address!("0000000000000000000000000000000000000001"))
         );
+    }
+
+    #[test]
+    fn parses_shadow_drive_mode_aliases() {
+        let args = parse_config(&["--mode", "shadow-drive"]);
+        assert_eq!(args.node_mode, NodeMode::ShadowDrive);
+
+        let args = parse_config(&["--mode", "ShadowDrive"]);
+        assert_eq!(args.node_mode, NodeMode::ShadowDrive);
+
+        let args = parse_config(&["--mode", "sequencer"]);
+        assert_eq!(args.node_mode, NodeMode::Sequencer);
     }
 
     fn upgrade_schedule(signals: &[(BaseUpgrade, u64)]) -> UpgradeSignalSchedule {

--- a/crates/consensus/cli/src/shadow_drive.rs
+++ b/crates/consensus/cli/src/shadow_drive.rs
@@ -1,0 +1,58 @@
+//! Shadow-drive CLI flags.
+
+use std::{num::ParseIntError, time::Duration};
+
+use base_consensus_node::ShadowDriveConfig;
+use clap::Parser;
+use url::Url;
+
+/// Shadow-drive CLI flags.
+#[derive(Parser, Clone, Debug, PartialEq, Eq)]
+pub struct ShadowDriveArgs {
+    /// The L2 RPC URL for the shadow-drive source node.
+    #[arg(
+        long = "source",
+        visible_alias = "shadow.source",
+        default_value = "http://localhost:8545",
+        env = "BASE_NODE_SHADOW_SOURCE_L2_RPC"
+    )]
+    pub source_l2_rpc: Url,
+
+    /// Deadline for building shadow payloads, in milliseconds.
+    #[arg(
+        long = "shadow-build-deadline-ms",
+        visible_alias = "shadow.build-deadline-ms",
+        default_value = "0",
+        value_parser = |arg: &str| -> Result<Duration, ParseIntError> {
+            Ok(Duration::from_millis(arg.parse()?))
+        },
+        env = "BASE_NODE_SHADOW_BUILD_DEADLINE_MS"
+    )]
+    pub build_deadline: Duration,
+
+    /// Maximum number of blocks to reorg when shadow-drive detects divergence.
+    #[arg(
+        long = "shadow-max-reorg-depth",
+        visible_alias = "shadow.max-reorg-depth",
+        default_value_t = 1,
+        env = "BASE_NODE_SHADOW_MAX_REORG_DEPTH"
+    )]
+    pub max_reorg_depth: u64,
+}
+
+impl Default for ShadowDriveArgs {
+    fn default() -> Self {
+        Self::parse_from::<[_; 0], &str>([])
+    }
+}
+
+impl ShadowDriveArgs {
+    /// Creates a [`ShadowDriveConfig`] from the [`ShadowDriveArgs`].
+    pub fn config(&self) -> ShadowDriveConfig {
+        ShadowDriveConfig {
+            source_l2_rpc: self.source_l2_rpc.clone(),
+            build_deadline: self.build_deadline,
+            max_reorg_depth: self.max_reorg_depth,
+        }
+    }
+}

--- a/crates/consensus/cli/src/shadow_drive.rs
+++ b/crates/consensus/cli/src/shadow_drive.rs
@@ -18,11 +18,12 @@ pub struct ShadowDriveArgs {
     )]
     pub source_l2_rpc: Url,
 
-    /// Deadline for building shadow payloads, in milliseconds.
+    /// Deadline for building shadow payloads, in milliseconds. Must be > 0 (a zero deadline
+    /// expires immediately, forcing every slot to fall back to re-anchoring to the parent).
     #[arg(
         long = "shadow-build-deadline-ms",
         visible_alias = "shadow.build-deadline-ms",
-        default_value = "0",
+        default_value = "2000",
         value_parser = |arg: &str| -> Result<Duration, ParseIntError> {
             Ok(Duration::from_millis(arg.parse()?))
         },

--- a/crates/consensus/engine/src/lib.rs
+++ b/crates/consensus/engine/src/lib.rs
@@ -14,8 +14,9 @@ pub use task_queue::{
     BuildTaskError, ConsolidateInput, ConsolidateTask, ConsolidateTaskError, Engine,
     EngineBuildError, EngineResetError, EngineTask, EngineTaskError, EngineTaskErrorSeverity,
     EngineTaskErrors, EngineTaskExt, FinalizeTask, FinalizeTaskError, InsertPayloadPolicy,
-    InsertPayloadSafety, InsertTask, InsertTaskError, InsertTaskResult, SealTask, SealTaskError,
-    SynchronizeTask, SynchronizeTaskError,
+    InsertPayloadSafety, InsertTask, InsertTaskError, InsertTaskResult, ReanchorTask,
+    ReanchorTaskError, ReanchorTaskResult, SealTask, SealTaskError, SynchronizeTask,
+    SynchronizeTaskError,
 };
 
 mod attributes;

--- a/crates/consensus/engine/src/task_queue/tasks/mod.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/mod.rs
@@ -13,6 +13,9 @@ pub use insert::{
     InsertPayloadPolicy, InsertPayloadSafety, InsertTask, InsertTaskError, InsertTaskResult,
 };
 
+mod reanchor;
+pub use reanchor::{ReanchorTask, ReanchorTaskError, ReanchorTaskResult};
+
 mod build;
 pub use build::{BuildTaskError, EngineBuildError};
 

--- a/crates/consensus/engine/src/task_queue/tasks/reanchor/error.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/reanchor/error.rs
@@ -4,7 +4,9 @@ use alloy_rpc_types_engine::PayloadStatusEnum;
 use alloy_transport::{RpcError, TransportErrorKind};
 use base_protocol::FromBlockError;
 
-use crate::{EngineTaskError, SynchronizeTaskError, task_queue::tasks::task::EngineTaskErrorSeverity};
+use crate::{
+    EngineTaskError, SynchronizeTaskError, task_queue::tasks::task::EngineTaskErrorSeverity,
+};
 
 /// An error that occurs when re-anchoring the unsafe head.
 #[derive(Debug, thiserror::Error)]
@@ -29,9 +31,9 @@ pub enum ReanchorTaskError {
 impl EngineTaskError for ReanchorTaskError {
     fn severity(&self) -> EngineTaskErrorSeverity {
         match self {
-            Self::InsertFailed(_) | Self::UnexpectedPayloadStatus(_) | Self::ForkchoiceUpdateDidNotAdvance => {
-                EngineTaskErrorSeverity::Temporary
-            }
+            Self::InsertFailed(_)
+            | Self::UnexpectedPayloadStatus(_)
+            | Self::ForkchoiceUpdateDidNotAdvance => EngineTaskErrorSeverity::Temporary,
             Self::L2BlockInfoConstruction(_) => EngineTaskErrorSeverity::Critical,
             Self::ForkchoiceUpdateFailed(inner) => inner.severity(),
         }

--- a/crates/consensus/engine/src/task_queue/tasks/reanchor/error.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/reanchor/error.rs
@@ -1,0 +1,39 @@
+//! Error types for the re-anchor task.
+
+use alloy_rpc_types_engine::PayloadStatusEnum;
+use alloy_transport::{RpcError, TransportErrorKind};
+use base_protocol::FromBlockError;
+
+use crate::{EngineTaskError, SynchronizeTaskError, task_queue::tasks::task::EngineTaskErrorSeverity};
+
+/// An error that occurs when re-anchoring the unsafe head.
+#[derive(Debug, thiserror::Error)]
+pub enum ReanchorTaskError {
+    /// Failed to insert new payload.
+    #[error("Failed to insert new payload: {0}")]
+    InsertFailed(RpcError<TransportErrorKind>),
+    /// Unexpected payload status.
+    #[error("Unexpected payload status: {0}")]
+    UnexpectedPayloadStatus(PayloadStatusEnum),
+    /// Error converting the payload + chain genesis into an L2 block info.
+    #[error(transparent)]
+    L2BlockInfoConstruction(#[from] FromBlockError),
+    /// The forkchoice update call to canonicalize the payload failed.
+    #[error(transparent)]
+    ForkchoiceUpdateFailed(#[from] SynchronizeTaskError),
+    /// The forkchoice update completed without advancing the unsafe head to the payload.
+    #[error("Forkchoice update did not advance to the re-anchored payload")]
+    ForkchoiceUpdateDidNotAdvance,
+}
+
+impl EngineTaskError for ReanchorTaskError {
+    fn severity(&self) -> EngineTaskErrorSeverity {
+        match self {
+            Self::InsertFailed(_) | Self::UnexpectedPayloadStatus(_) | Self::ForkchoiceUpdateDidNotAdvance => {
+                EngineTaskErrorSeverity::Temporary
+            }
+            Self::L2BlockInfoConstruction(_) => EngineTaskErrorSeverity::Critical,
+            Self::ForkchoiceUpdateFailed(inner) => inner.severity(),
+        }
+    }
+}

--- a/crates/consensus/engine/src/task_queue/tasks/reanchor/mod.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/reanchor/mod.rs
@@ -1,0 +1,7 @@
+//! Task to re-anchor the unsafe head to a canonical payload.
+
+mod task;
+pub use task::{ReanchorTask, ReanchorTaskResult};
+
+mod error;
+pub use error::ReanchorTaskError;

--- a/crates/consensus/engine/src/task_queue/tasks/reanchor/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/reanchor/task.rs
@@ -66,7 +66,8 @@ impl<EngineClient_: EngineClient> ReanchorTask<EngineClient_> {
 
         let response = match execution_payload {
             BaseExecutionPayload::V1(payload) => {
-                let payload_input = ExecutionPayloadInputV2 { execution_payload: payload, withdrawals: None };
+                let payload_input =
+                    ExecutionPayloadInputV2 { execution_payload: payload, withdrawals: None };
                 self.client.new_payload_v2(payload_input).await
             }
             BaseExecutionPayload::V2(payload) => {
@@ -77,10 +78,14 @@ impl<EngineClient_: EngineClient> ReanchorTask<EngineClient_> {
                 self.client.new_payload_v2(payload_input).await
             }
             BaseExecutionPayload::V3(payload) => {
-                self.client.new_payload_v3(payload, parent_beacon_block_root.unwrap_or_default()).await
+                self.client
+                    .new_payload_v3(payload, parent_beacon_block_root.unwrap_or_default())
+                    .await
             }
             BaseExecutionPayload::V4(payload) => {
-                self.client.new_payload_v4(payload, parent_beacon_block_root.unwrap_or_default()).await
+                self.client
+                    .new_payload_v4(payload, parent_beacon_block_root.unwrap_or_default())
+                    .await
             }
         };
 

--- a/crates/consensus/engine/src/task_queue/tasks/reanchor/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/reanchor/task.rs
@@ -1,0 +1,142 @@
+//! Task to re-anchor the unsafe head to a canonical payload.
+
+use std::sync::Arc;
+
+use alloy_rpc_types_engine::{ExecutionPayloadInputV2, PayloadStatusEnum};
+use async_trait::async_trait;
+use base_common_genesis::RollupConfig;
+use base_common_rpc_types_engine::{BaseExecutionPayload, BaseExecutionPayloadEnvelope};
+use base_protocol::L2BlockInfo;
+use tokio::sync::mpsc;
+
+use crate::{
+    EngineClient, EngineState, EngineTaskExt, ReanchorTaskError, SynchronizeTask,
+    state::EngineSyncStateUpdate,
+};
+
+/// Result sent to callers waiting for re-anchor acknowledgement.
+pub type ReanchorTaskResult = Result<L2BlockInfo, ReanchorTaskError>;
+
+/// The task to re-anchor the unsafe head to a canonical payload.
+#[derive(Debug, Clone)]
+pub struct ReanchorTask<EngineClient_: EngineClient> {
+    /// The engine client.
+    client: Arc<EngineClient_>,
+    /// The rollup config.
+    rollup_config: Arc<RollupConfig>,
+    /// The payload envelope.
+    envelope: BaseExecutionPayloadEnvelope,
+    /// Optional response channel used by callers that need acknowledgement.
+    result_tx: Option<mpsc::Sender<ReanchorTaskResult>>,
+}
+
+impl<EngineClient_: EngineClient> ReanchorTask<EngineClient_> {
+    /// Creates a new re-anchor task.
+    pub const fn new(
+        client: Arc<EngineClient_>,
+        rollup_config: Arc<RollupConfig>,
+        envelope: BaseExecutionPayloadEnvelope,
+    ) -> Self {
+        Self { client, rollup_config, envelope, result_tx: None }
+    }
+
+    /// Creates a new re-anchor task and send acknowledgement on completion.
+    pub const fn with_result(
+        client: Arc<EngineClient_>,
+        rollup_config: Arc<RollupConfig>,
+        envelope: BaseExecutionPayloadEnvelope,
+        result_tx: mpsc::Sender<ReanchorTaskResult>,
+    ) -> Self {
+        Self { client, rollup_config, envelope, result_tx: Some(result_tx) }
+    }
+
+    /// Checks the response of the `engine_newPayload` call.
+    const fn check_new_payload_status(&self, status: &PayloadStatusEnum) -> bool {
+        matches!(status, PayloadStatusEnum::Valid | PayloadStatusEnum::Syncing)
+    }
+
+    async fn reanchor_payload(&self, state: &mut EngineState) -> ReanchorTaskResult {
+        let parent_beacon_block_root = self.envelope.parent_beacon_block_root;
+        let execution_payload = self.envelope.execution_payload.clone();
+        let new_block_ref = L2BlockInfo::from_payload_and_genesis(
+            execution_payload.clone(),
+            parent_beacon_block_root,
+            &self.rollup_config.genesis,
+        )?;
+
+        let response = match execution_payload {
+            BaseExecutionPayload::V1(payload) => {
+                let payload_input = ExecutionPayloadInputV2 { execution_payload: payload, withdrawals: None };
+                self.client.new_payload_v2(payload_input).await
+            }
+            BaseExecutionPayload::V2(payload) => {
+                let payload_input = ExecutionPayloadInputV2 {
+                    execution_payload: payload.payload_inner,
+                    withdrawals: Some(payload.withdrawals),
+                };
+                self.client.new_payload_v2(payload_input).await
+            }
+            BaseExecutionPayload::V3(payload) => {
+                self.client.new_payload_v3(payload, parent_beacon_block_root.unwrap_or_default()).await
+            }
+            BaseExecutionPayload::V4(payload) => {
+                self.client.new_payload_v4(payload, parent_beacon_block_root.unwrap_or_default()).await
+            }
+        };
+
+        let response = match response {
+            Ok(resp) => resp,
+            Err(err) => {
+                warn!(target: "engine", error = %err, "Failed to insert re-anchor payload");
+                return Err(ReanchorTaskError::InsertFailed(err));
+            }
+        };
+        if !self.check_new_payload_status(&response.status) {
+            return Err(ReanchorTaskError::UnexpectedPayloadStatus(response.status));
+        }
+
+        SynchronizeTask::new(
+            Arc::clone(&self.client),
+            Arc::clone(&self.rollup_config),
+            EngineSyncStateUpdate { unsafe_head: Some(new_block_ref), ..Default::default() },
+        )
+        .execute(state)
+        .await?;
+
+        if self.result_tx.is_some() && state.sync_state.unsafe_head() != new_block_ref {
+            return Err(ReanchorTaskError::ForkchoiceUpdateDidNotAdvance);
+        }
+
+        info!(
+            target: "engine",
+            hash = %new_block_ref.block_info.hash,
+            number = new_block_ref.block_info.number,
+            "Re-anchored unsafe head"
+        );
+
+        Ok(new_block_ref)
+    }
+
+    async fn send_channel_result(&self, result: ReanchorTaskResult) {
+        let Some(result_tx) = &self.result_tx else { return };
+        if result_tx.send(result).await.is_err() {
+            warn!(target: "engine", "Sending re-anchor result failed");
+        }
+    }
+}
+
+#[async_trait]
+impl<EngineClient_: EngineClient> EngineTaskExt for ReanchorTask<EngineClient_> {
+    type Output = ();
+    type Error = ReanchorTaskError;
+
+    async fn execute(&self, state: &mut EngineState) -> Result<(), Self::Error> {
+        let result = self.reanchor_payload(state).await;
+        if self.result_tx.is_some() {
+            self.send_channel_result(result).await;
+            Ok(())
+        } else {
+            result.map(|_| ())
+        }
+    }
+}

--- a/crates/consensus/engine/src/task_queue/tasks/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/task.rs
@@ -9,10 +9,10 @@ use derive_more::Display;
 use thiserror::Error;
 use tokio::task::yield_now;
 
-use super::{ConsolidateTask, FinalizeTask, InsertTask};
+use super::{ConsolidateTask, FinalizeTask, InsertTask, ReanchorTask};
 use crate::{
     BuildTaskError, ConsolidateTaskError, EngineClient, EngineState, FinalizeTaskError,
-    InsertTaskError, Metrics,
+    InsertTaskError, Metrics, ReanchorTaskError,
     task_queue::{SealTask, SealTaskError},
 };
 
@@ -75,6 +75,9 @@ pub enum EngineTaskErrors {
     /// An error that occurred while finalizing an L2 block.
     #[error(transparent)]
     Finalize(#[from] FinalizeTaskError),
+    /// An error that occurred while re-anchoring the unsafe head.
+    #[error(transparent)]
+    Reanchor(#[from] ReanchorTaskError),
 }
 
 impl EngineTaskErrorSeverity {
@@ -97,6 +100,7 @@ impl EngineTaskError for EngineTaskErrors {
             Self::Seal(inner) => inner.severity(),
             Self::Consolidate(inner) => inner.severity(),
             Self::Finalize(inner) => inner.severity(),
+            Self::Reanchor(inner) => inner.severity(),
         }
     }
 }
@@ -116,6 +120,8 @@ pub enum EngineTask<EngineClient_: EngineClient> {
     Consolidate(Box<ConsolidateTask<EngineClient_>>),
     /// Finalizes an L2 block
     Finalize(Box<FinalizeTask<EngineClient_>>),
+    /// Re-anchors the unsafe head to a canonical payload.
+    Reanchor(Box<ReanchorTask<EngineClient_>>),
 }
 
 impl<EngineClient_: EngineClient> EngineTask<EngineClient_> {
@@ -126,6 +132,7 @@ impl<EngineClient_: EngineClient> EngineTask<EngineClient_> {
             Self::Seal(task) => task.execute(state).await?,
             Self::Consolidate(task) => task.execute(state).await?,
             Self::Finalize(task) => task.execute(state).await?,
+            Self::Reanchor(task) => task.execute(state).await?,
         };
 
         Ok(())
@@ -137,13 +144,14 @@ impl<EngineClient_: EngineClient> EngineTask<EngineClient_> {
             Self::Consolidate(_) => Metrics::CONSOLIDATE_TASK_LABEL,
             Self::Seal(_) => Metrics::SEAL_TASK_LABEL,
             Self::Finalize(_) => Metrics::FINALIZE_TASK_LABEL,
+            Self::Reanchor(_) => Metrics::DELEGATED_FORKCHOICE_TASK_LABEL,
         }
     }
 
     const fn task_priority(&self) -> u8 {
         match self {
             Self::Seal(_) => 4,
-            Self::Insert(_) => 3,
+            Self::Insert(_) | Self::Reanchor(_) => 3,
             Self::Consolidate(_) => 2,
             Self::Finalize(_) => 1,
         }
@@ -158,6 +166,7 @@ impl<EngineClient_: EngineClient> PartialEq for EngineTask<EngineClient_> {
                 | (Self::Seal(_), Self::Seal(_))
                 | (Self::Consolidate(_), Self::Consolidate(_))
                 | (Self::Finalize(_), Self::Finalize(_))
+                | (Self::Reanchor(_), Self::Reanchor(_))
         )
     }
 }

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -8,7 +8,7 @@ use base_consensus_engine::{
     ConsolidateTask, Engine, EngineClient, EngineSyncStateUpdate, EngineTask, EngineTaskError,
     EngineTaskErrorSeverity, EngineTaskErrors, FinalizeTask, ForkchoiceCheckpointLabel,
     ForkchoiceCheckpointReader, InsertTask, InsertTaskResult, Metrics as EngineMetrics,
-    NoopForkchoiceCheckpointReader, SealTaskError,
+    NoopForkchoiceCheckpointReader, ReanchorTask, SealTaskError,
 };
 use base_protocol::L2BlockInfo;
 use opentelemetry::context::FutureExt as OtelFutureExt;
@@ -20,7 +20,7 @@ use tokio::{
 use crate::{
     BuildRequest, CheckpointWriter, Conductor, EngineActorRequest, EngineClientError,
     EngineDerivationClient, EngineError, GetPayloadRequest, InsertUnsafePayloadRequest, NodeMode,
-    NoopCheckpointWriter,
+    NoopCheckpointWriter, ShadowReanchorRequest,
 };
 
 /// Requires that the implementor handles engine requests via the provided channel.
@@ -528,6 +528,20 @@ where
         self.enqueue_unsafe_payload_insert(envelope, result_tx);
     }
 
+    fn handle_shadow_reanchor(
+        &mut self,
+        envelope: BaseExecutionPayloadEnvelope,
+        result_tx: mpsc::Sender<Result<L2BlockInfo, base_consensus_engine::ReanchorTaskError>>,
+    ) {
+        let task = EngineTask::Reanchor(Box::new(ReanchorTask::with_result(
+            Arc::clone(&self.client),
+            Arc::clone(&self.rollup),
+            envelope,
+            result_tx,
+        )));
+        self.engine.enqueue(task);
+    }
+
     async fn mark_el_sync_complete_and_notify_derivation_actor(
         &mut self,
     ) -> Result<(), EngineError> {
@@ -942,6 +956,11 @@ where
                         // Attach for the synchronous enqueue call only — no await, no Send issue.
                         let _guard = otel_cx.attach();
                         self.handle_local_unsafe_l2_block(envelope, result_tx);
+                    }
+                    EngineActorRequest::ProcessShadowReanchorRequest(reanchor_request) => {
+                        let ShadowReanchorRequest { envelope, result_tx, otel_cx } = *reanchor_request;
+                        let _guard = otel_cx.attach();
+                        self.handle_shadow_reanchor(envelope, result_tx);
                     }
                     EngineActorRequest::ResetRequest(reset_request) => {
                         // Do not reset the engine while the EL is still syncing. A Reset sends a

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -958,7 +958,8 @@ where
                         self.handle_local_unsafe_l2_block(envelope, result_tx);
                     }
                     EngineActorRequest::ProcessShadowReanchorRequest(reanchor_request) => {
-                        let ShadowReanchorRequest { envelope, result_tx, otel_cx } = *reanchor_request;
+                        let ShadowReanchorRequest { envelope, result_tx, otel_cx } =
+                            *reanchor_request;
                         let _guard = otel_cx.attach();
                         self.handle_shadow_reanchor(envelope, result_tx);
                     }

--- a/crates/consensus/service/src/actors/engine/mod.rs
+++ b/crates/consensus/service/src/actors/engine/mod.rs
@@ -15,7 +15,7 @@ pub use error::EngineError;
 mod request;
 pub use request::{
     BuildRequest, EngineActorRequest, EngineClientError, EngineClientResult, EngineRpcRequest,
-    GetPayloadRequest, InsertUnsafePayloadRequest, ResetRequest,
+    GetPayloadRequest, InsertUnsafePayloadRequest, ResetRequest, ShadowReanchorRequest,
 };
 
 mod engine_request_processor;

--- a/crates/consensus/service/src/actors/engine/request.rs
+++ b/crates/consensus/service/src/actors/engine/request.rs
@@ -1,7 +1,8 @@
 use alloy_rpc_types_engine::PayloadId;
 use base_common_rpc_types_engine::BaseExecutionPayloadEnvelope;
 use base_consensus_engine::{
-    BuildTaskError, ConsolidateInput, EngineQueries, InsertTaskError, SealTaskError,
+    BuildTaskError, ConsolidateInput, EngineQueries, InsertTaskError, ReanchorTaskError,
+    SealTaskError,
 };
 use base_protocol::{AttributesWithParent, L2BlockInfo};
 use opentelemetry::Context;
@@ -62,6 +63,8 @@ pub enum EngineActorRequest {
     ProcessAdminUnsafeL2BlockRequest(Box<BaseExecutionPayloadEnvelope>),
     /// Request to insert a locally produced sequencer unsafe block.
     ProcessLocalUnsafeL2BlockRequest(Box<InsertUnsafePayloadRequest>),
+    /// Request to re-anchor the unsafe head to a canonical payload.
+    ProcessShadowReanchorRequest(Box<ShadowReanchorRequest>),
     /// Request to reset engine forkchoice.
     ResetRequest(Box<ResetRequest>),
 }
@@ -101,6 +104,17 @@ pub struct InsertUnsafePayloadRequest {
     pub envelope: BaseExecutionPayloadEnvelope,
     /// Optional response channel used by the sequencer to wait for actual insertion.
     pub result_tx: Option<mpsc::Sender<Result<L2BlockInfo, InsertTaskError>>>,
+    /// [`opentelemetry::Context`] from the requester, for trace propagation.
+    pub otel_cx: Context,
+}
+
+/// A request to re-anchor the unsafe head to a canonical payload.
+#[derive(Debug)]
+pub struct ShadowReanchorRequest {
+    /// The payload envelope to re-anchor to.
+    pub envelope: BaseExecutionPayloadEnvelope,
+    /// Response channel used by callers that need acknowledgement.
+    pub result_tx: mpsc::Sender<Result<L2BlockInfo, ReanchorTaskError>>,
     /// [`opentelemetry::Context`] from the requester, for trace propagation.
     pub otel_cx: Context,
 }

--- a/crates/consensus/service/src/actors/mod.rs
+++ b/crates/consensus/service/src/actors/mod.rs
@@ -19,6 +19,7 @@ pub use engine::{
     EngineClientResult, EngineConfig, EngineDerivationClient, EngineError, EngineProcessor,
     EngineProcessorOptions, EngineRequestReceiver, EngineRpcProcessor, EngineRpcRequest,
     GetPayloadRequest, InsertUnsafePayloadRequest, QueuedEngineDerivationClient, ResetRequest,
+    ShadowReanchorRequest,
 };
 
 mod rpc;
@@ -67,3 +68,6 @@ pub use sequencer::{
 };
 #[cfg(test)]
 pub use sequencer::{MockConductor, MockOriginSelector, MockSequencerEngineClient};
+
+mod shadow_drive;
+pub use shadow_drive::{ShadowDriveActor, ShadowDriveActorError};

--- a/crates/consensus/service/src/actors/mod.rs
+++ b/crates/consensus/service/src/actors/mod.rs
@@ -70,4 +70,4 @@ pub use sequencer::{
 pub use sequencer::{MockConductor, MockOriginSelector, MockSequencerEngineClient};
 
 mod shadow_drive;
-pub use shadow_drive::{ShadowDriveActor, ShadowDriveActorError};
+pub use shadow_drive::{ShadowDriveActor, ShadowDriveActorError, SlotOutcome, WaitOutcome};

--- a/crates/consensus/service/src/actors/shadow_drive/actor.rs
+++ b/crates/consensus/service/src/actors/shadow_drive/actor.rs
@@ -1,0 +1,458 @@
+//! The [`ShadowDriveActor`].
+
+use std::{fmt::Debug, sync::Arc, time::Duration};
+
+use alloy_eips::BlockNumberOrTag;
+use async_trait::async_trait;
+use base_common_genesis::RollupConfig;
+use base_common_rpc_types_engine::BaseExecutionPayloadEnvelope;
+use base_consensus_derive::{AttributesBuilder, PipelineErrorKind};
+use base_consensus_engine::ReanchorTaskError;
+use base_protocol::{AttributesWithParent, L2BlockInfo};
+use opentelemetry::Context as OtelContext;
+use tokio::{
+    select,
+    sync::{mpsc, watch},
+    time::{Instant, sleep, timeout},
+};
+use tokio_util::sync::{CancellationToken, WaitForCancellationFuture};
+
+use crate::{
+    CancellableContext, EngineActorRequest, EngineClientError, NodeActor, ShadowDriveConfig,
+    ShadowReanchorRequest,
+    actors::{OriginSelector, SequencerEngineClient},
+    follow::RemoteClient,
+};
+
+const SOURCE_POLL_INTERVAL: Duration = Duration::from_millis(200);
+
+/// The [`ShadowDriveActor`] coordinates shadow-drive candidate builds and re-anchors.
+///
+/// ## Forkchoice authority
+///
+/// This actor **never** issues Engine API forkchoice updates directly. Re-anchors are routed
+/// through the node's single `EngineActor` via `EngineActorRequest::ProcessShadowReanchorRequest`
+/// so there is only one forkchoice authority driving the execution layer.
+#[derive(Debug)]
+pub struct ShadowDriveActor<AttributesBuilder_, OriginSelector_, SequencerEngineClient_, Source_>
+where
+    AttributesBuilder_: AttributesBuilder + Sync,
+    OriginSelector_: OriginSelector,
+    SequencerEngineClient_: SequencerEngineClient,
+    Source_: RemoteClient,
+{
+    /// The payload attributes builder.
+    pub attributes_builder: AttributesBuilder_,
+    /// The L1 origin selector.
+    pub origin_selector: OriginSelector_,
+    /// The engine client used for build + commit.
+    pub engine_client: Arc<SequencerEngineClient_>,
+    /// Channel for issuing re-anchor requests.
+    pub engine_actor_request_tx: mpsc::Sender<EngineActorRequest>,
+    /// Canonical source client.
+    pub source: Arc<Source_>,
+    /// Rollup configuration.
+    pub rollup_config: Arc<RollupConfig>,
+    /// Shadow-drive runtime configuration.
+    pub shadow_config: ShadowDriveConfig,
+    /// Cancellation token.
+    pub cancellation_token: CancellationToken,
+    /// Engine state watch channel for coherence checks.
+    pub engine_state_rx: watch::Receiver<base_consensus_engine::EngineState>,
+}
+
+#[derive(Debug, thiserror::Error)]
+/// Errors produced by the [`ShadowDriveActor`] during its per-slot build/commit/re-anchor loop.
+pub enum ShadowDriveActorError {
+    /// Shadow-drive configuration is invalid.
+    #[error("shadow-drive max reorg depth must be > 0")]
+    InvalidMaxReorgDepth,
+    /// Failed to fetch from the canonical source.
+    #[error(transparent)]
+    Source(#[from] crate::RemoteL2ClientError),
+    /// Engine client error during build or commit.
+    #[error(transparent)]
+    Engine(#[from] EngineClientError),
+    /// Origin selector error.
+    #[error(transparent)]
+    Origin(#[from] crate::L1OriginSelectorError),
+    /// Payload attribute preparation failed.
+    #[error(transparent)]
+    Attributes(#[from] PipelineErrorKind),
+    /// Failed to decode L2 block info from a payload.
+    #[error(transparent)]
+    BlockInfo(#[from] base_protocol::FromBlockError),
+    /// Failed to send a re-anchor request to the engine actor.
+    #[error("failed to send re-anchor request to engine actor")]
+    ReanchorRequestSend,
+    /// Re-anchor response channel closed unexpectedly.
+    #[error("re-anchor response channel closed")]
+    ReanchorResponseClosed,
+    /// The build deadline elapsed before the source produced the next head.
+    #[error("shadow-drive build deadline exceeded waiting for block {expected} (latest={latest})")]
+    BuildDeadlineExceeded {
+        /// The block number the actor was waiting for.
+        expected: u64,
+        /// The latest block number observed from the source at time of failure.
+        latest: u64,
+    },
+    /// Re-anchor task failed.
+    #[error(transparent)]
+    Reanchor(#[from] ReanchorTaskError),
+}
+
+impl<AttributesBuilder_, OriginSelector_, SequencerEngineClient_, Source_>
+    ShadowDriveActor<AttributesBuilder_, OriginSelector_, SequencerEngineClient_, Source_>
+where
+    AttributesBuilder_: AttributesBuilder + Send + Sync,
+    OriginSelector_: OriginSelector + Send,
+    SequencerEngineClient_: SequencerEngineClient + Send + Sync,
+    Source_: RemoteClient + Send + Sync,
+{
+    async fn fetch_source_payload(&self, number: u64) -> Result<BaseExecutionPayloadEnvelope, ShadowDriveActorError> {
+        Ok(self.source.get_payload_by_number(number).await?)
+    }
+
+    async fn fetch_source_head(&self) -> Result<L2BlockInfo, ShadowDriveActorError> {
+        let latest = self.source.get_block_number(BlockNumberOrTag::Latest).await?;
+        let payload = self.fetch_source_payload(latest).await?;
+        let info = L2BlockInfo::from_payload_and_genesis(
+            payload.execution_payload.clone(),
+            payload.parent_beacon_block_root,
+            &self.rollup_config.genesis,
+        )?;
+        Ok(info)
+    }
+
+    async fn build_candidate(
+        &mut self,
+        parent: L2BlockInfo,
+    ) -> Result<L2BlockInfo, ShadowDriveActorError> {
+        let l1_origin = self.origin_selector.next_l1_origin(parent, false).await?;
+        let attributes = self
+            .attributes_builder
+            .prepare_payload_attributes(parent, l1_origin.id())
+            .await?;
+        let attrs_with_parent = AttributesWithParent::new(attributes, parent, None, false);
+
+        let payload_id = self.engine_client.start_build_block(attrs_with_parent.clone()).await?;
+        let payload = self.engine_client.get_sealed_payload(payload_id, attrs_with_parent).await?;
+        let inserted_head = self.engine_client.insert_unsafe_payload(payload).await?;
+
+        Ok(inserted_head)
+    }
+
+    async fn wait_for_real_next_payload(
+        &self,
+        expected_number: u64,
+    ) -> Result<(BaseExecutionPayloadEnvelope, L2BlockInfo), ShadowDriveActorError> {
+        let deadline = Instant::now() + self.shadow_config.build_deadline;
+
+        loop {
+            let latest = self.source.get_block_number(BlockNumberOrTag::Latest).await?;
+            if latest >= expected_number {
+                let payload = self.fetch_source_payload(expected_number).await?;
+                let info = L2BlockInfo::from_payload_and_genesis(
+                    payload.execution_payload.clone(),
+                    payload.parent_beacon_block_root,
+                    &self.rollup_config.genesis,
+                )?;
+                return Ok((payload, info));
+            }
+
+            if Instant::now() >= deadline {
+                return Err(ShadowDriveActorError::BuildDeadlineExceeded {
+                    expected: expected_number,
+                    latest,
+                });
+            }
+
+            sleep(SOURCE_POLL_INTERVAL).await;
+        }
+    }
+
+    async fn reanchor_to(
+        &self,
+        payload: BaseExecutionPayloadEnvelope,
+    ) -> Result<L2BlockInfo, ShadowDriveActorError> {
+        let (result_tx, mut result_rx) = mpsc::channel(1);
+        self.engine_actor_request_tx
+            .send(EngineActorRequest::ProcessShadowReanchorRequest(Box::new(
+                ShadowReanchorRequest { envelope: payload, result_tx, otel_cx: OtelContext::current() },
+            )))
+            .await
+            .map_err(|_| ShadowDriveActorError::ReanchorRequestSend)?;
+
+        result_rx
+            .recv()
+            .await
+            .ok_or(ShadowDriveActorError::ReanchorResponseClosed)?
+            .map_err(ShadowDriveActorError::Reanchor)
+    }
+
+    async fn assert_engine_head(&self, expected: L2BlockInfo) {
+        let mut state_rx = self.engine_state_rx.clone();
+        let expected_hash = expected.block_info.hash;
+        let expected_number = expected.block_info.number;
+        let wait_result = timeout(Duration::from_secs(2), state_rx.wait_for(|state| {
+            let head = state.sync_state.unsafe_head();
+            head.block_info.hash == expected_hash && head.block_info.number == expected_number
+        }))
+        .await;
+        let success = matches!(wait_result, Ok(Ok(_)));
+        drop(wait_result);
+
+        if success {
+            debug_assert!(state_rx.borrow().sync_state.unsafe_head() == expected);
+        } else {
+            let current = state_rx.borrow().sync_state.unsafe_head();
+            error!(
+                target: "shadow_drive",
+                expected_hash = %expected_hash,
+                expected_number,
+                actual_hash = %current.block_info.hash,
+                actual_number = current.block_info.number,
+                "ShadowDrive re-anchor did not update unsafe head"
+            );
+        }
+    }
+
+    async fn run_slot(&mut self, parent: L2BlockInfo) -> Result<L2BlockInfo, ShadowDriveActorError> {
+        let reorg_depth = 1u64;
+        if reorg_depth > self.shadow_config.max_reorg_depth {
+            warn!(
+                target: "shadow_drive",
+                reorg_depth,
+                max_reorg_depth = self.shadow_config.max_reorg_depth,
+                "ShadowDrive reorg depth exceeds configured maximum; skipping slot"
+            );
+            return self.fetch_source_head().await;
+        }
+
+        let candidate_head = self.build_candidate(parent).await?;
+        info!(
+            target: "shadow_drive",
+            candidate_number = candidate_head.block_info.number,
+            candidate_hash = %candidate_head.block_info.hash,
+            reorg_depth,
+            "ShadowDrive candidate committed"
+        );
+
+        let (real_payload, real_head) = match self
+            .wait_for_real_next_payload(parent.block_info.number.saturating_add(1))
+            .await
+        {
+            Ok(result) => result,
+            Err(ShadowDriveActorError::BuildDeadlineExceeded { expected, latest }) => {
+                warn!(
+                    target: "shadow_drive",
+                    expected,
+                    latest,
+                    deadline = ?self.shadow_config.build_deadline,
+                    "ShadowDrive build deadline exceeded; re-anchoring to parent"
+                );
+                let parent_payload = self.fetch_source_payload(parent.block_info.number).await?;
+                let reanchored = self.reanchor_to(parent_payload).await?;
+                return Ok(reanchored);
+            }
+            Err(err) => return Err(err),
+        };
+
+        let reanchored = self.reanchor_to(real_payload).await?;
+        info!(
+            target: "shadow_drive",
+            reanchor_number = reanchored.block_info.number,
+            reanchor_hash = %reanchored.block_info.hash,
+            reorg_depth,
+            "ShadowDrive re-anchor applied"
+        );
+
+        self.assert_engine_head(real_head).await;
+
+        Ok(real_head)
+    }
+}
+
+#[async_trait]
+impl<AttributesBuilder_, OriginSelector_, SequencerEngineClient_, Source_> NodeActor
+    for ShadowDriveActor<AttributesBuilder_, OriginSelector_, SequencerEngineClient_, Source_>
+where
+    AttributesBuilder_: AttributesBuilder + Send + Sync + 'static,
+    OriginSelector_: OriginSelector + Send + 'static,
+    SequencerEngineClient_: SequencerEngineClient + Send + Sync + 'static,
+    Source_: RemoteClient + Send + Sync + 'static,
+{
+    type Error = ShadowDriveActorError;
+    type StartData = ();
+
+    async fn start(mut self, _: Self::StartData) -> Result<(), Self::Error> {
+        if self.shadow_config.max_reorg_depth == 0 {
+            return Err(ShadowDriveActorError::InvalidMaxReorgDepth);
+        }
+
+        info!(target: "shadow_drive", "ShadowDrive active");
+        let mut parent = self.fetch_source_head().await?;
+        let cancellation = self.cancellation_token.clone();
+
+        loop {
+            select! {
+                _ = cancellation.cancelled() => {
+                    info!(target: "shadow_drive", "Received shutdown signal. Exiting ShadowDrive task.");
+                    return Ok(());
+                }
+                result = self.run_slot(parent) => {
+                    parent = result?;
+                }
+            }
+        }
+    }
+}
+
+impl<AttributesBuilder_, OriginSelector_, SequencerEngineClient_, Source_> CancellableContext
+    for ShadowDriveActor<AttributesBuilder_, OriginSelector_, SequencerEngineClient_, Source_>
+where
+    AttributesBuilder_: AttributesBuilder + Sync,
+    OriginSelector_: OriginSelector,
+    SequencerEngineClient_: SequencerEngineClient,
+    Source_: RemoteClient,
+{
+    fn cancelled(&self) -> WaitForCancellationFuture<'_> {
+        self.cancellation_token.cancelled()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, time::Duration};
+
+    use alloy_eips::eip2718::Encodable2718;
+    use alloy_primitives::{Address, B256, Bloom, U256};
+    use alloy_rpc_types_engine::ExecutionPayloadV1;
+    use base_common_consensus::{BaseTxEnvelope, TxDeposit};
+    use base_common_genesis::RollupConfig;
+    use base_common_rpc_types_engine::{BaseExecutionPayload, BaseExecutionPayloadEnvelope, BasePayloadAttributes};
+    use base_protocol::{BlockInfo, L2BlockInfo, L1BlockInfoBedrock};
+    use base_consensus_derive::test_utils::TestAttributesBuilder;
+    use tokio::sync::{mpsc, watch};
+    use tokio_util::sync::CancellationToken;
+
+    use super::ShadowDriveActor;
+    use crate::{
+        EngineActorRequest, MockOriginSelector, MockRemoteClient, MockSequencerEngineClient,
+        ShadowDriveConfig,
+    };
+
+    fn l1_info_deposit_tx() -> Vec<u8> {
+        BaseTxEnvelope::from(TxDeposit {
+            input: L1BlockInfoBedrock::default().encode_calldata(),
+            ..Default::default()
+        })
+        .encoded_2718()
+    }
+
+    fn payload_envelope(block_number: u64, parent_hash: B256, block_hash: B256) -> BaseExecutionPayloadEnvelope {
+        BaseExecutionPayloadEnvelope {
+            parent_beacon_block_root: None,
+            execution_payload: BaseExecutionPayload::V1(ExecutionPayloadV1 {
+                parent_hash,
+                fee_recipient: Address::ZERO,
+                state_root: B256::ZERO,
+                receipts_root: B256::ZERO,
+                logs_bloom: Bloom::ZERO,
+                prev_randao: B256::ZERO,
+                block_number,
+                gas_limit: 30_000_000,
+                gas_used: 0,
+                timestamp: block_number,
+                extra_data: Default::default(),
+                base_fee_per_gas: U256::ZERO,
+                block_hash,
+                transactions: vec![l1_info_deposit_tx().into()],
+            }),
+        }
+    }
+
+    fn block_info(number: u64, hash: B256, parent_hash: B256) -> L2BlockInfo {
+        L2BlockInfo { block_info: BlockInfo::new(hash, number, parent_hash, number), ..Default::default() }
+    }
+
+    #[tokio::test]
+    async fn shadow_drive_commit_and_reanchor_once() {
+        let rollup_config = Arc::new(RollupConfig::default());
+        let parent_hash = B256::with_last_byte(1);
+        let candidate_hash = B256::with_last_byte(2);
+        let real_hash = B256::with_last_byte(3);
+        let parent = block_info(1, parent_hash, B256::ZERO);
+
+        let candidate_payload = payload_envelope(2, parent_hash, candidate_hash);
+        let real_payload = payload_envelope(2, parent_hash, real_hash);
+        let reanchor_head = L2BlockInfo::from_payload_and_genesis(
+            real_payload.execution_payload.clone(),
+            real_payload.parent_beacon_block_root,
+            &rollup_config.genesis,
+        )
+        .expect("real head");
+
+        let mut origin_selector = MockOriginSelector::new();
+        origin_selector
+            .expect_next_l1_origin()
+            .returning(|_, _| Ok(BlockInfo::new(B256::with_last_byte(9), 10, B256::ZERO, 0)));
+
+        let mut engine_client = MockSequencerEngineClient::new();
+        engine_client.expect_start_build_block().returning(|_| Ok(alloy_rpc_types_engine::PayloadId::new([1; 8])));
+        engine_client
+            .expect_get_sealed_payload()
+            .returning(move |_, _| Ok(candidate_payload.clone()));
+        engine_client
+            .expect_insert_unsafe_payload()
+            .returning(move |_| Ok(block_info(2, candidate_hash, parent_hash)));
+
+        let mut source = MockRemoteClient::new();
+        source.expect_get_block_number().returning(|_| Ok(2));
+        source.expect_get_payload_by_number().returning(move |_| Ok(real_payload.clone()));
+
+        let (engine_actor_request_tx, mut engine_actor_request_rx) = mpsc::channel(1);
+        let (state_tx, state_rx) = watch::channel(base_consensus_engine::EngineState::default());
+
+        let mut actor = ShadowDriveActor {
+            attributes_builder: TestAttributesBuilder {
+                attributes: vec![Ok(BasePayloadAttributes::default())],
+            },
+            origin_selector,
+            engine_client: Arc::new(engine_client),
+            engine_actor_request_tx,
+            source: Arc::new(source),
+            rollup_config: Arc::clone(&rollup_config),
+            shadow_config: ShadowDriveConfig {
+                source_l2_rpc: "http://localhost:9545".parse().expect("url"),
+                build_deadline: Duration::from_secs(1),
+                max_reorg_depth: 1,
+            },
+            cancellation_token: CancellationToken::new(),
+            engine_state_rx: state_rx,
+        };
+
+        let reanchor_task = tokio::spawn(async move {
+            let request = engine_actor_request_rx.recv().await.expect("reanchor request");
+            let EngineActorRequest::ProcessShadowReanchorRequest(request) = request else {
+                panic!("expected reanchor request");
+            };
+            request
+                .result_tx
+                .send(Ok(reanchor_head))
+                .await
+                .expect("send reanchor result");
+
+            let mut state = base_consensus_engine::EngineState::default();
+            state.sync_state = state.sync_state.apply_update(base_consensus_engine::EngineSyncStateUpdate {
+                unsafe_head: Some(reanchor_head),
+                ..Default::default()
+            });
+            state_tx.send_replace(state);
+        });
+
+        let next = actor.run_slot(parent).await.expect("shadow drive slot");
+        assert_eq!(next.block_info.hash, reanchor_head.block_info.hash);
+        reanchor_task.await.expect("reanchor task");
+    }
+}

--- a/crates/consensus/service/src/actors/shadow_drive/actor.rs
+++ b/crates/consensus/service/src/actors/shadow_drive/actor.rs
@@ -67,6 +67,9 @@ pub enum ShadowDriveActorError {
     /// Shadow-drive configuration is invalid.
     #[error("shadow-drive max reorg depth must be > 0")]
     InvalidMaxReorgDepth,
+    /// Shadow-drive build deadline is zero.
+    #[error("shadow-drive build deadline must be > 0")]
+    InvalidBuildDeadline,
     /// Failed to fetch from the canonical source.
     #[error(transparent)]
     Source(#[from] crate::RemoteL2ClientError),
@@ -88,17 +91,34 @@ pub enum ShadowDriveActorError {
     /// Re-anchor response channel closed unexpectedly.
     #[error("re-anchor response channel closed")]
     ReanchorResponseClosed,
-    /// The build deadline elapsed before the source produced the next head.
-    #[error("shadow-drive build deadline exceeded waiting for block {expected} (latest={latest})")]
-    BuildDeadlineExceeded {
-        /// The block number the actor was waiting for.
-        expected: u64,
-        /// The latest block number observed from the source at time of failure.
-        latest: u64,
-    },
     /// Re-anchor task failed.
     #[error(transparent)]
     Reanchor(#[from] ReanchorTaskError),
+}
+
+/// Outcome of waiting for the canonical source to produce the next real payload.
+#[derive(Debug)]
+pub enum WaitOutcome {
+    /// The source produced the expected block; carries its payload and decoded block info.
+    Ready(Box<BaseExecutionPayloadEnvelope>, L2BlockInfo),
+    /// The build deadline elapsed before the source produced the next head.
+    DeadlineExceeded {
+        /// The block number the actor was waiting for.
+        expected: u64,
+        /// The latest block number observed from the source at the deadline.
+        latest: u64,
+    },
+    /// Cancellation was observed while waiting; the actor should shut down.
+    Cancelled,
+}
+
+/// Outcome of running a single shadow-drive slot.
+#[derive(Debug)]
+pub enum SlotOutcome {
+    /// The slot completed and the unsafe head advanced to the contained block.
+    Advanced(L2BlockInfo),
+    /// Cancellation was observed mid-slot; the actor should exit its loop.
+    Shutdown,
 }
 
 impl<AttributesBuilder_, OriginSelector_, SequencerEngineClient_, Source_>
@@ -109,7 +129,10 @@ where
     SequencerEngineClient_: SequencerEngineClient + Send + Sync,
     Source_: RemoteClient + Send + Sync,
 {
-    async fn fetch_source_payload(&self, number: u64) -> Result<BaseExecutionPayloadEnvelope, ShadowDriveActorError> {
+    async fn fetch_source_payload(
+        &self,
+        number: u64,
+    ) -> Result<BaseExecutionPayloadEnvelope, ShadowDriveActorError> {
         Ok(self.source.get_payload_by_number(number).await?)
     }
 
@@ -145,7 +168,7 @@ where
     async fn wait_for_real_next_payload(
         &self,
         expected_number: u64,
-    ) -> Result<(BaseExecutionPayloadEnvelope, L2BlockInfo), ShadowDriveActorError> {
+    ) -> Result<WaitOutcome, ShadowDriveActorError> {
         let deadline = Instant::now() + self.shadow_config.build_deadline;
 
         loop {
@@ -157,17 +180,41 @@ where
                     payload.parent_beacon_block_root,
                     &self.rollup_config.genesis,
                 )?;
-                return Ok((payload, info));
+                return Ok(WaitOutcome::Ready(Box::new(payload), info));
             }
 
             if Instant::now() >= deadline {
-                return Err(ShadowDriveActorError::BuildDeadlineExceeded {
-                    expected: expected_number,
-                    latest,
-                });
+                return Ok(WaitOutcome::DeadlineExceeded { expected: expected_number, latest });
             }
 
-            sleep(SOURCE_POLL_INTERVAL).await;
+            // Only the poll sleep is cancellable; `biased` ensures a pending cancellation wins the
+            // race so shutdown is not delayed by a full poll interval. The build -> re-anchor
+            // sequence itself stays atomic (outside any cancellation select).
+            select! {
+                biased;
+                _ = self.cancellation_token.cancelled() => return Ok(WaitOutcome::Cancelled),
+                _ = sleep(SOURCE_POLL_INTERVAL) => {}
+            }
+        }
+    }
+
+    async fn reanchor_or_resync(
+        &self,
+        payload: BaseExecutionPayloadEnvelope,
+    ) -> Result<L2BlockInfo, ShadowDriveActorError> {
+        match self.reanchor_to(payload).await {
+            Ok(head) => Ok(head),
+            Err(err) => {
+                // A re-anchor failure must not terminate the actor (which would cancel the root
+                // token and bring down the whole node). The orphan candidate is only reorg-depth-1
+                // and self-heals via derivation; resync the parent from ground truth and continue.
+                error!(
+                    target: "shadow_drive",
+                    error = %err,
+                    "ShadowDrive re-anchor failed; resyncing parent from source"
+                );
+                self.fetch_source_head().await
+            }
         }
     }
 
@@ -178,7 +225,11 @@ where
         let (result_tx, mut result_rx) = mpsc::channel(1);
         self.engine_actor_request_tx
             .send(EngineActorRequest::ProcessShadowReanchorRequest(Box::new(
-                ShadowReanchorRequest { envelope: payload, result_tx, otel_cx: OtelContext::current() },
+                ShadowReanchorRequest {
+                    envelope: payload,
+                    result_tx,
+                    otel_cx: OtelContext::current(),
+                },
             )))
             .await
             .map_err(|_| ShadowDriveActorError::ReanchorRequestSend)?;
@@ -194,17 +245,17 @@ where
         let mut state_rx = self.engine_state_rx.clone();
         let expected_hash = expected.block_info.hash;
         let expected_number = expected.block_info.number;
-        let wait_result = timeout(Duration::from_secs(2), state_rx.wait_for(|state| {
-            let head = state.sync_state.unsafe_head();
-            head.block_info.hash == expected_hash && head.block_info.number == expected_number
-        }))
+        let wait_result = timeout(
+            Duration::from_secs(2),
+            state_rx.wait_for(|state| {
+                let head = state.sync_state.unsafe_head();
+                head.block_info.hash == expected_hash && head.block_info.number == expected_number
+            }),
+        )
         .await;
-        let success = matches!(wait_result, Ok(Ok(_)));
+        let updated = matches!(wait_result, Ok(Ok(_)));
         drop(wait_result);
-
-        if success {
-            debug_assert!(state_rx.borrow().sync_state.unsafe_head() == expected);
-        } else {
+        if !updated {
             let current = state_rx.borrow().sync_state.unsafe_head();
             error!(
                 target: "shadow_drive",
@@ -217,7 +268,13 @@ where
         }
     }
 
-    async fn run_slot(&mut self, parent: L2BlockInfo) -> Result<L2BlockInfo, ShadowDriveActorError> {
+    async fn run_slot(
+        &mut self,
+        parent: L2BlockInfo,
+    ) -> Result<SlotOutcome, ShadowDriveActorError> {
+        // TODO(shadow-drive): reorg depth is fixed at 1 (build one candidate, re-anchor back one).
+        // This guard is a forward-looking placeholder for configurable multi-block reorg depths;
+        // it is currently unreachable because `max_reorg_depth` is validated to be >= 1 at startup.
         let reorg_depth = 1u64;
         if reorg_depth > self.shadow_config.max_reorg_depth {
             warn!(
@@ -226,7 +283,7 @@ where
                 max_reorg_depth = self.shadow_config.max_reorg_depth,
                 "ShadowDrive reorg depth exceeds configured maximum; skipping slot"
             );
-            return self.fetch_source_head().await;
+            return Ok(SlotOutcome::Advanced(self.fetch_source_head().await?));
         }
 
         let candidate_head = self.build_candidate(parent).await?;
@@ -238,12 +295,20 @@ where
             "ShadowDrive candidate committed"
         );
 
-        let (real_payload, real_head) = match self
-            .wait_for_real_next_payload(parent.block_info.number.saturating_add(1))
-            .await
-        {
-            Ok(result) => result,
-            Err(ShadowDriveActorError::BuildDeadlineExceeded { expected, latest }) => {
+        match self.wait_for_real_next_payload(parent.block_info.number.saturating_add(1)).await? {
+            WaitOutcome::Ready(real_payload, real_head) => {
+                let reanchored = self.reanchor_or_resync(*real_payload).await?;
+                info!(
+                    target: "shadow_drive",
+                    reanchor_number = reanchored.block_info.number,
+                    reanchor_hash = %reanchored.block_info.hash,
+                    reorg_depth,
+                    "ShadowDrive re-anchor applied"
+                );
+                self.assert_engine_head(real_head).await;
+                Ok(SlotOutcome::Advanced(reanchored))
+            }
+            WaitOutcome::DeadlineExceeded { expected, latest } => {
                 warn!(
                     target: "shadow_drive",
                     expected,
@@ -252,24 +317,25 @@ where
                     "ShadowDrive build deadline exceeded; re-anchoring to parent"
                 );
                 let parent_payload = self.fetch_source_payload(parent.block_info.number).await?;
-                let reanchored = self.reanchor_to(parent_payload).await?;
-                return Ok(reanchored);
+                let reanchored = self.reanchor_or_resync(parent_payload).await?;
+                Ok(SlotOutcome::Advanced(reanchored))
             }
-            Err(err) => return Err(err),
-        };
-
-        let reanchored = self.reanchor_to(real_payload).await?;
-        info!(
-            target: "shadow_drive",
-            reanchor_number = reanchored.block_info.number,
-            reanchor_hash = %reanchored.block_info.hash,
-            reorg_depth,
-            "ShadowDrive re-anchor applied"
-        );
-
-        self.assert_engine_head(real_head).await;
-
-        Ok(real_head)
+            WaitOutcome::Cancelled => {
+                warn!(
+                    target: "shadow_drive",
+                    "ShadowDrive cancelled mid-slot; best-effort re-anchor to parent before exit"
+                );
+                let parent_payload = self.fetch_source_payload(parent.block_info.number).await?;
+                if let Err(err) = self.reanchor_to(parent_payload).await {
+                    warn!(
+                        target: "shadow_drive",
+                        error = %err,
+                        "ShadowDrive shutdown re-anchor failed; engine likely already stopped"
+                    );
+                }
+                Ok(SlotOutcome::Shutdown)
+            }
+        }
     }
 }
 
@@ -289,19 +355,25 @@ where
         if self.shadow_config.max_reorg_depth == 0 {
             return Err(ShadowDriveActorError::InvalidMaxReorgDepth);
         }
+        if self.shadow_config.build_deadline.is_zero() {
+            return Err(ShadowDriveActorError::InvalidBuildDeadline);
+        }
 
         info!(target: "shadow_drive", "ShadowDrive active");
         let mut parent = self.fetch_source_head().await?;
-        let cancellation = self.cancellation_token.clone();
 
         loop {
-            select! {
-                _ = cancellation.cancelled() => {
-                    info!(target: "shadow_drive", "Received shutdown signal. Exiting ShadowDrive task.");
+            // Cancellation is only checked between slots and inside the poll wait, never between
+            // `build_candidate` and its re-anchor, so a slot's build -> re-anchor is always atomic.
+            if self.cancellation_token.is_cancelled() {
+                info!(target: "shadow_drive", "Received shutdown signal. Exiting ShadowDrive task.");
+                return Ok(());
+            }
+            match self.run_slot(parent).await? {
+                SlotOutcome::Advanced(next) => parent = next,
+                SlotOutcome::Shutdown => {
+                    info!(target: "shadow_drive", "ShadowDrive slot observed shutdown. Exiting.");
                     return Ok(());
-                }
-                result = self.run_slot(parent) => {
-                    parent = result?;
                 }
             }
         }
@@ -330,13 +402,15 @@ mod tests {
     use alloy_rpc_types_engine::ExecutionPayloadV1;
     use base_common_consensus::{BaseTxEnvelope, TxDeposit};
     use base_common_genesis::RollupConfig;
-    use base_common_rpc_types_engine::{BaseExecutionPayload, BaseExecutionPayloadEnvelope, BasePayloadAttributes};
-    use base_protocol::{BlockInfo, L2BlockInfo, L1BlockInfoBedrock};
+    use base_common_rpc_types_engine::{
+        BaseExecutionPayload, BaseExecutionPayloadEnvelope, BasePayloadAttributes,
+    };
     use base_consensus_derive::test_utils::TestAttributesBuilder;
+    use base_protocol::{BlockInfo, L1BlockInfoBedrock, L2BlockInfo};
     use tokio::sync::{mpsc, watch};
     use tokio_util::sync::CancellationToken;
 
-    use super::ShadowDriveActor;
+    use super::{ShadowDriveActor, SlotOutcome};
     use crate::{
         EngineActorRequest, MockOriginSelector, MockRemoteClient, MockSequencerEngineClient,
         ShadowDriveConfig,
@@ -350,7 +424,11 @@ mod tests {
         .encoded_2718()
     }
 
-    fn payload_envelope(block_number: u64, parent_hash: B256, block_hash: B256) -> BaseExecutionPayloadEnvelope {
+    fn payload_envelope(
+        block_number: u64,
+        parent_hash: B256,
+        block_hash: B256,
+    ) -> BaseExecutionPayloadEnvelope {
         BaseExecutionPayloadEnvelope {
             parent_beacon_block_root: None,
             execution_payload: BaseExecutionPayload::V1(ExecutionPayloadV1 {
@@ -373,7 +451,10 @@ mod tests {
     }
 
     fn block_info(number: u64, hash: B256, parent_hash: B256) -> L2BlockInfo {
-        L2BlockInfo { block_info: BlockInfo::new(hash, number, parent_hash, number), ..Default::default() }
+        L2BlockInfo {
+            block_info: BlockInfo::new(hash, number, parent_hash, number),
+            ..Default::default()
+        }
     }
 
     #[tokio::test]
@@ -399,7 +480,9 @@ mod tests {
             .returning(|_, _| Ok(BlockInfo::new(B256::with_last_byte(9), 10, B256::ZERO, 0)));
 
         let mut engine_client = MockSequencerEngineClient::new();
-        engine_client.expect_start_build_block().returning(|_| Ok(alloy_rpc_types_engine::PayloadId::new([1; 8])));
+        engine_client
+            .expect_start_build_block()
+            .returning(|_| Ok(alloy_rpc_types_engine::PayloadId::new([1; 8])));
         engine_client
             .expect_get_sealed_payload()
             .returning(move |_, _| Ok(candidate_payload.clone()));
@@ -437,21 +520,21 @@ mod tests {
             let EngineActorRequest::ProcessShadowReanchorRequest(request) = request else {
                 panic!("expected reanchor request");
             };
-            request
-                .result_tx
-                .send(Ok(reanchor_head))
-                .await
-                .expect("send reanchor result");
+            request.result_tx.send(Ok(reanchor_head)).await.expect("send reanchor result");
 
             let mut state = base_consensus_engine::EngineState::default();
-            state.sync_state = state.sync_state.apply_update(base_consensus_engine::EngineSyncStateUpdate {
-                unsafe_head: Some(reanchor_head),
-                ..Default::default()
-            });
+            state.sync_state =
+                state.sync_state.apply_update(base_consensus_engine::EngineSyncStateUpdate {
+                    unsafe_head: Some(reanchor_head),
+                    ..Default::default()
+                });
             state_tx.send_replace(state);
         });
 
-        let next = actor.run_slot(parent).await.expect("shadow drive slot");
+        let SlotOutcome::Advanced(next) = actor.run_slot(parent).await.expect("shadow drive slot")
+        else {
+            panic!("expected slot to advance");
+        };
         assert_eq!(next.block_info.hash, reanchor_head.block_info.hash);
         reanchor_task.await.expect("reanchor task");
     }

--- a/crates/consensus/service/src/actors/shadow_drive/actor.rs
+++ b/crates/consensus/service/src/actors/shadow_drive/actor.rs
@@ -131,7 +131,7 @@ where
         let l1_origin = self.origin_selector.next_l1_origin(parent, false).await?;
         let attributes = self
             .attributes_builder
-            .prepare_payload_attributes(parent, l1_origin.id())
+            .prepare_payload_attributes(parent, l1_origin.id(), None)
             .await?;
         let attrs_with_parent = AttributesWithParent::new(attributes, parent, None, false);
 

--- a/crates/consensus/service/src/actors/shadow_drive/mod.rs
+++ b/crates/consensus/service/src/actors/shadow_drive/mod.rs
@@ -1,4 +1,4 @@
 //! The `ShadowDriveActor` and its coordinator loop.
 
 mod actor;
-pub use actor::{ShadowDriveActor, ShadowDriveActorError};
+pub use actor::{ShadowDriveActor, ShadowDriveActorError, SlotOutcome, WaitOutcome};

--- a/crates/consensus/service/src/actors/shadow_drive/mod.rs
+++ b/crates/consensus/service/src/actors/shadow_drive/mod.rs
@@ -1,0 +1,4 @@
+//! The `ShadowDriveActor` and its coordinator loop.
+
+mod actor;
+pub use actor::{ShadowDriveActor, ShadowDriveActorError};

--- a/crates/consensus/service/src/lib.rs
+++ b/crates/consensus/service/src/lib.rs
@@ -12,7 +12,7 @@ extern crate tracing;
 mod service;
 pub use service::{
     DerivationDelegateConfig, FollowNode, FollowNodeConfig, HEAD_STREAM_POLL_INTERVAL, L1Config,
-    L1ConfigBuilder, NodeMode, RollupNode, RollupNodeBuilder, ShutdownSignal,
+    L1ConfigBuilder, NodeMode, RollupNode, RollupNodeBuilder, ShadowDriveConfig, ShutdownSignal,
     UpgradeSignalBuilderConfig,
 };
 
@@ -42,7 +42,8 @@ pub use actors::{
     QueuedSequencerEngineClient, QueuedUnsafePayloadGossipClient, RecoveryModeGuard, ResetRequest,
     RpcActor, RpcActorError, RpcContext, ScheduledTicker, SealState, SealStepError,
     SealStepOutcome, SequencerActor, SequencerActorError, SequencerAdminQuery, SequencerConfig,
-    SequencerEngineClient, UnsafePayloadGossipClient, UnsafePayloadGossipClientError,
+    SequencerEngineClient, ShadowDriveActor, ShadowDriveActorError, ShadowReanchorRequest,
+    UnsafePayloadGossipClient, UnsafePayloadGossipClientError,
     UnsealedPayloadHandle, UpgradeSignalMetricsActor, UpgradeSignalNodeConfig,
 };
 

--- a/crates/consensus/service/src/lib.rs
+++ b/crates/consensus/service/src/lib.rs
@@ -43,8 +43,8 @@ pub use actors::{
     RpcActor, RpcActorError, RpcContext, ScheduledTicker, SealState, SealStepError,
     SealStepOutcome, SequencerActor, SequencerActorError, SequencerAdminQuery, SequencerConfig,
     SequencerEngineClient, ShadowDriveActor, ShadowDriveActorError, ShadowReanchorRequest,
-    UnsafePayloadGossipClient, UnsafePayloadGossipClientError,
-    UnsealedPayloadHandle, UpgradeSignalMetricsActor, UpgradeSignalNodeConfig,
+    SlotOutcome, UnsafePayloadGossipClient, UnsafePayloadGossipClientError, UnsealedPayloadHandle,
+    UpgradeSignalMetricsActor, UpgradeSignalNodeConfig, WaitOutcome,
 };
 
 mod metrics;

--- a/crates/consensus/service/src/service/builder.rs
+++ b/crates/consensus/service/src/service/builder.rs
@@ -35,6 +35,17 @@ pub struct DerivationDelegateConfig {
     pub l2_cl_url: Url,
 }
 
+/// Configuration for shadow-drive mode.
+#[derive(Debug, Clone)]
+pub struct ShadowDriveConfig {
+    /// The L2 RPC URL for the shadow-drive source node.
+    pub source_l2_rpc: Url,
+    /// Deadline for building shadow payloads.
+    pub build_deadline: Duration,
+    /// Maximum number of blocks to reorg when shadow-drive detects divergence.
+    pub max_reorg_depth: u64,
+}
+
 impl Default for DerivationDelegateConfig {
     fn default() -> Self {
         Self { l2_cl_url: Url::parse("http://localhost:9545").unwrap() }
@@ -79,6 +90,8 @@ pub struct RollupNodeBuilder {
     /// Optional configuration for Derivation Delegate mode.
     /// When present, the node does not run derivation, instead trusting the configured delegate.
     pub derivation_delegate_config: Option<DerivationDelegateConfig>,
+    /// Optional configuration for shadow-drive mode.
+    pub shadow_drive_config: Option<ShadowDriveConfig>,
     /// Override for the finalized-block poll interval.
     ///
     /// When `None`, [`L1Config::default_finalized_poll_interval`] is used to select a
@@ -130,6 +143,7 @@ impl RollupNodeBuilder {
             rpc_config,
             sequencer_config: None,
             derivation_delegate_config: None,
+            shadow_drive_config: None,
             finalized_poll_interval: None,
             checkpoint_path: None,
             safedb_path: None,
@@ -171,6 +185,11 @@ impl RollupNodeBuilder {
         derivation_delegate_config: Option<DerivationDelegateConfig>,
     ) -> Self {
         Self { derivation_delegate_config, ..self }
+    }
+
+    /// Sets the shadow-drive configuration.
+    pub fn with_shadow_drive_config(self, shadow_drive_config: Option<ShadowDriveConfig>) -> Self {
+        Self { shadow_drive_config, ..self }
     }
 
     /// Enables persistent safe head tracking by setting the path to the redb database file.
@@ -253,6 +272,7 @@ impl RollupNodeBuilder {
             p2p_config,
             sequencer_config,
             derivation_delegate_provider,
+            shadow_drive_config: self.shadow_drive_config,
             checkpoint_path,
             safedb_path: self.safedb_path,
             upgrade_signal_config,

--- a/crates/consensus/service/src/service/mod.rs
+++ b/crates/consensus/service/src/service/mod.rs
@@ -5,7 +5,8 @@
 
 mod builder;
 pub use builder::{
-    DerivationDelegateConfig, L1ConfigBuilder, RollupNodeBuilder, UpgradeSignalBuilderConfig,
+    DerivationDelegateConfig, L1ConfigBuilder, RollupNodeBuilder, ShadowDriveConfig,
+    UpgradeSignalBuilderConfig,
 };
 
 pub use crate::follow::{FollowNode, FollowNodeConfig};

--- a/crates/consensus/service/src/service/mode.rs
+++ b/crates/consensus/service/src/service/mode.rs
@@ -22,6 +22,9 @@ pub enum NodeMode {
     /// Sequencer mode.
     #[display("Sequencer")]
     Sequencer,
+    /// Shadow-drive mode.
+    #[display("ShadowDrive")]
+    ShadowDrive,
 }
 
 impl NodeMode {
@@ -33,5 +36,10 @@ impl NodeMode {
     /// Returns `true` if [`Self`] is [`Self::Sequencer`].
     pub const fn is_sequencer(&self) -> bool {
         matches!(self, Self::Sequencer)
+    }
+
+    /// Returns `true` if [`Self`] is [`Self::ShadowDrive`].
+    pub const fn is_shadow_drive(&self) -> bool {
+        matches!(self, Self::ShadowDrive)
     }
 }

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -33,8 +33,8 @@ use crate::{
     NodeActor, NodeMode, PayloadBuilder, QueuedDerivationEngineClient,
     QueuedEngineDerivationClient, QueuedEngineRpcClient, QueuedL1WatcherDerivationClient,
     QueuedNetworkEngineClient, QueuedSequencerAdminAPIClient, QueuedSequencerEngineClient,
-    RecoveryModeGuard, RpcActor, RpcContext, SequencerActor, SequencerConfig,
-    UpgradeSignalNodeConfig,
+    RecoveryModeGuard, RemoteL2Client, RpcActor, RpcContext, SequencerActor, SequencerConfig,
+    ShadowDriveActor, ShadowDriveConfig, UpgradeSignalNodeConfig,
     actors::{BlockStream, NetworkInboundData, QueuedUnsafePayloadGossipClient},
 };
 
@@ -105,6 +105,8 @@ pub struct RollupNode {
     pub sequencer_config: SequencerConfig,
     /// Optional derivation delegate provider.
     pub derivation_delegate_provider: Option<DerivationDelegateClient>,
+    /// Optional shadow-drive configuration.
+    pub shadow_drive_config: Option<ShadowDriveConfig>,
     /// Path to the mandatory checkpoint database.
     ///
     /// The node records safe/finalized forkchoice checkpoints here so restart can recover
@@ -243,8 +245,11 @@ impl RollupNode {
         unsafe_head_tx: watch::Sender<L2BlockInfo>,
         conductor: Option<Arc<dyn Conductor>>,
         checkpoint_client: CheckpointClient,
-    ) -> (EngineActor<EngineProcessor<E, QueuedEngineDerivationClient>>, EngineRpcProcessor<E>)
-    {
+    ) -> (
+        EngineActor<EngineProcessor<E, QueuedEngineDerivationClient>>,
+        EngineRpcProcessor<E>,
+        watch::Receiver<EngineState>,
+    ) {
         let engine_state = EngineState::default();
         let (engine_state_tx, engine_state_rx) = watch::channel(engine_state);
         let (engine_queue_length_tx, engine_queue_length_rx) = watch::channel(0);
@@ -261,7 +266,11 @@ impl RollupNode {
             engine,
             EngineProcessorOptions {
                 node_mode: mode,
-                unsafe_head_tx: if mode.is_sequencer() { Some(unsafe_head_tx) } else { None },
+                unsafe_head_tx: if mode.is_sequencer() || mode.is_shadow_drive() {
+                    Some(unsafe_head_tx)
+                } else {
+                    None
+                },
                 conductor,
                 sequencer_stopped: self.sequencer_config.sequencer_stopped,
                 shadow_sequencer: mode.is_sequencer()
@@ -271,6 +280,7 @@ impl RollupNode {
             checkpoint_writer,
         );
 
+        let engine_state_rx_shadow = engine_state_rx.clone();
         let engine_rpc_processor = EngineRpcProcessor::new(
             Arc::clone(&engine_client),
             Arc::clone(&self.config),
@@ -281,7 +291,7 @@ impl RollupNode {
         let engine_actor =
             EngineActor::new(cancellation_token, engine_request_rx, engine_processor);
 
-        (engine_actor, engine_rpc_processor)
+        (engine_actor, engine_rpc_processor, engine_state_rx_shadow)
     }
 
     /// Starts the rollup node service.
@@ -432,7 +442,7 @@ impl RollupNode {
         let engine_conductor: Option<Arc<dyn Conductor>> =
             conductor.clone().map(|c| Arc::new(c) as Arc<dyn Conductor>);
 
-        let (engine_actor, engine_rpc_processor) = self.create_engine_actor(
+        let (engine_actor, engine_rpc_processor, engine_state_rx) = self.create_engine_actor(
             engine_client,
             cancellation.clone(),
             engine_actor_request_rx,
@@ -441,6 +451,7 @@ impl RollupNode {
             engine_conductor,
             checkpoint_client,
         );
+        let mut engine_state_rx_shadow = Some(engine_state_rx);
 
         // Select the concrete derivation actor implementation based on
         // RollupNode configuration.
@@ -498,8 +509,8 @@ impl RollupNode {
             self.sequencer_config.l1_conf_delay,
         );
 
-        let delayed_origin_selector =
-            L1OriginSelector::new(Arc::clone(&self.config), delayed_l1_provider);
+        let mut delayed_origin_selector =
+            Some(L1OriginSelector::new(Arc::clone(&self.config), delayed_l1_provider));
 
         // Create the L1 Watcher actor
 
@@ -546,8 +557,10 @@ impl RollupNode {
             .as_ref()
             .map(|c| c.metrics_actor(upgrade_signal_refresher.clone(), cancellation.clone()));
         let node_mode = self.mode();
-        // Create the sequencer if needed
-        let (sequencer_actor, sequencer_admin_client) = if node_mode.is_sequencer() {
+        // Create the sequencer or shadow-drive actor if needed.
+        let (sequencer_actor, sequencer_admin_client, shadow_drive_actor) = if node_mode.is_sequencer() {
+            let delayed_origin_selector =
+                delayed_origin_selector.take().expect("origin selector must be available");
             let sequencer_engine_client = QueuedSequencerEngineClient {
                 engine_actor_request_tx: engine_actor_request_tx.clone(),
                 unsafe_head_rx,
@@ -583,10 +596,42 @@ impl RollupNode {
                     pending_stop: None,
                 }),
                 Some(QueuedSequencerAdminAPIClient::new(sequencer_admin_api_tx)),
+                None,
+            )
+        } else if node_mode.is_shadow_drive() {
+            let delayed_origin_selector =
+                delayed_origin_selector.take().expect("origin selector must be available");
+            let shadow_drive_config = self
+                .shadow_drive_config
+                .clone()
+                .ok_or_else(|| "shadow-drive config missing for shadow-drive mode".to_string())?;
+            let shadow_engine_client = QueuedSequencerEngineClient {
+                engine_actor_request_tx: engine_actor_request_tx.clone(),
+                unsafe_head_rx,
+            };
+            let source = RemoteL2Client::new(shadow_drive_config.source_l2_rpc.clone());
+            let actor = ShadowDriveActor {
+                attributes_builder: self.create_attributes_builder(),
+                origin_selector: delayed_origin_selector,
+                engine_client: Arc::new(shadow_engine_client),
+                engine_actor_request_tx: engine_actor_request_tx.clone(),
+                source: Arc::new(source),
+                rollup_config: Arc::clone(&self.config),
+                shadow_config: shadow_drive_config,
+                cancellation_token: cancellation.clone(),
+                engine_state_rx: engine_state_rx_shadow
+                    .take()
+                    .expect("engine state receiver must be available"),
+            };
+            (
+                None,
+                None,
+                Some(actor),
             )
         } else {
-            (None, None)
+            (None, None, None)
         };
+        let _ = delayed_origin_selector;
 
         // Create the RPC server actor.
         let rpc_builder = self.rpc_builder();
@@ -602,6 +647,15 @@ impl RollupNode {
                 upgrade_signal_refresher,
             )
         });
+
+        let derivation_actor = if node_mode.is_shadow_drive() {
+            // ShadowDrive mode re-anchors forkchoice directly; running derivation would issue
+            // independent FCUs via consolidation and violate single-writer invariants. Skipping
+            // derivation here is safe because el_sync_complete is only used to notify derivation.
+            None
+        } else {
+            Some(derivation)
+        };
 
         crate::service::spawn_and_wait!(
             cancellation,
@@ -620,10 +674,11 @@ impl RollupNode {
                 Some((l1_watcher, ())),
                 Some((l1_query_processor, ())),
                 upgrade_signal_metrics_actor.map(|actor| (actor, ())),
-                Some((derivation, ())),
+                derivation_actor.map(|actor| (actor, ())),
                 Some((checkpoint_actor, cancellation.clone())),
                 Some((engine_actor, ())),
                 engine_rpc_actor,
+                shadow_drive_actor.map(|actor| (actor, ())),
             ]
         );
         Ok(())

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -558,79 +558,75 @@ impl RollupNode {
             .map(|c| c.metrics_actor(upgrade_signal_refresher.clone(), cancellation.clone()));
         let node_mode = self.mode();
         // Create the sequencer or shadow-drive actor if needed.
-        let (sequencer_actor, sequencer_admin_client, shadow_drive_actor) = if node_mode.is_sequencer() {
-            let delayed_origin_selector =
-                delayed_origin_selector.take().expect("origin selector must be available");
-            let sequencer_engine_client = QueuedSequencerEngineClient {
-                engine_actor_request_tx: engine_actor_request_tx.clone(),
-                unsafe_head_rx,
-            };
+        let (sequencer_actor, sequencer_admin_client, shadow_drive_actor) =
+            if node_mode.is_sequencer() {
+                let delayed_origin_selector =
+                    delayed_origin_selector.take().expect("origin selector must be available");
+                let sequencer_engine_client = QueuedSequencerEngineClient {
+                    engine_actor_request_tx: engine_actor_request_tx.clone(),
+                    unsafe_head_rx,
+                };
 
-            // Create the admin API channel
-            let (sequencer_admin_api_tx, sequencer_admin_api_rx) = mpsc::channel(1024);
-            let queued_gossip_client =
-                QueuedUnsafePayloadGossipClient::new(gossip_payload_tx.clone());
+                // Create the admin API channel
+                let (sequencer_admin_api_tx, sequencer_admin_api_rx) = mpsc::channel(1024);
+                let queued_gossip_client =
+                    QueuedUnsafePayloadGossipClient::new(gossip_payload_tx.clone());
 
-            let recovery_mode =
-                RecoveryModeGuard::new(self.sequencer_config.sequencer_recovery_mode);
-            let engine_client = Arc::new(sequencer_engine_client);
-            (
-                Some(SequencerActor {
-                    admin_api_rx: sequencer_admin_api_rx,
-                    builder: PayloadBuilder {
-                        attributes_builder: self.create_attributes_builder(),
-                        engine_client: Arc::clone(&engine_client),
-                        origin_selector: delayed_origin_selector,
-                        recovery_mode: recovery_mode.clone(),
+                let recovery_mode =
+                    RecoveryModeGuard::new(self.sequencer_config.sequencer_recovery_mode);
+                let engine_client = Arc::new(sequencer_engine_client);
+                (
+                    Some(SequencerActor {
+                        admin_api_rx: sequencer_admin_api_rx,
+                        builder: PayloadBuilder {
+                            attributes_builder: self.create_attributes_builder(),
+                            engine_client: Arc::clone(&engine_client),
+                            origin_selector: delayed_origin_selector,
+                            recovery_mode: recovery_mode.clone(),
+                            rollup_config: Arc::clone(&self.config),
+                        },
+                        cancellation_token: cancellation.clone(),
+                        conductor,
+                        engine_client,
+                        is_active: self.sequencer_config.sequencer_stopped.not(),
+                        shadow_blocks_per_cycle: self.sequencer_config.shadow_blocks_per_cycle,
+                        recovery_mode,
                         rollup_config: Arc::clone(&self.config),
-                    },
-                    cancellation_token: cancellation.clone(),
-                    conductor,
-                    engine_client,
-                    is_active: self.sequencer_config.sequencer_stopped.not(),
-                    shadow_blocks_per_cycle: self.sequencer_config.shadow_blocks_per_cycle,
-                    recovery_mode,
+                        unsafe_payload_gossip_client: queued_gossip_client,
+                        sealer: None,
+                        pending_stop: None,
+                    }),
+                    Some(QueuedSequencerAdminAPIClient::new(sequencer_admin_api_tx)),
+                    None,
+                )
+            } else if node_mode.is_shadow_drive() {
+                let delayed_origin_selector =
+                    delayed_origin_selector.take().expect("origin selector must be available");
+                let shadow_drive_config = self.shadow_drive_config.clone().ok_or_else(|| {
+                    "shadow-drive config missing for shadow-drive mode".to_string()
+                })?;
+                let shadow_engine_client = QueuedSequencerEngineClient {
+                    engine_actor_request_tx: engine_actor_request_tx.clone(),
+                    unsafe_head_rx,
+                };
+                let source = RemoteL2Client::new(shadow_drive_config.source_l2_rpc.clone());
+                let actor = ShadowDriveActor {
+                    attributes_builder: self.create_attributes_builder(),
+                    origin_selector: delayed_origin_selector,
+                    engine_client: Arc::new(shadow_engine_client),
+                    engine_actor_request_tx: engine_actor_request_tx.clone(),
+                    source: Arc::new(source),
                     rollup_config: Arc::clone(&self.config),
-                    unsafe_payload_gossip_client: queued_gossip_client,
-                    sealer: None,
-                    pending_stop: None,
-                }),
-                Some(QueuedSequencerAdminAPIClient::new(sequencer_admin_api_tx)),
-                None,
-            )
-        } else if node_mode.is_shadow_drive() {
-            let delayed_origin_selector =
-                delayed_origin_selector.take().expect("origin selector must be available");
-            let shadow_drive_config = self
-                .shadow_drive_config
-                .clone()
-                .ok_or_else(|| "shadow-drive config missing for shadow-drive mode".to_string())?;
-            let shadow_engine_client = QueuedSequencerEngineClient {
-                engine_actor_request_tx: engine_actor_request_tx.clone(),
-                unsafe_head_rx,
+                    shadow_config: shadow_drive_config,
+                    cancellation_token: cancellation.clone(),
+                    engine_state_rx: engine_state_rx_shadow
+                        .take()
+                        .expect("engine state receiver must be available"),
+                };
+                (None, None, Some(actor))
+            } else {
+                (None, None, None)
             };
-            let source = RemoteL2Client::new(shadow_drive_config.source_l2_rpc.clone());
-            let actor = ShadowDriveActor {
-                attributes_builder: self.create_attributes_builder(),
-                origin_selector: delayed_origin_selector,
-                engine_client: Arc::new(shadow_engine_client),
-                engine_actor_request_tx: engine_actor_request_tx.clone(),
-                source: Arc::new(source),
-                rollup_config: Arc::clone(&self.config),
-                shadow_config: shadow_drive_config,
-                cancellation_token: cancellation.clone(),
-                engine_state_rx: engine_state_rx_shadow
-                    .take()
-                    .expect("engine state receiver must be available"),
-            };
-            (
-                None,
-                None,
-                Some(actor),
-            )
-        } else {
-            (None, None, None)
-        };
         let _ = delayed_origin_selector;
 
         // Create the RPC server actor.

--- a/crates/execution/cli/Cargo.toml
+++ b/crates/execution/cli/Cargo.toml
@@ -49,6 +49,8 @@ base-execution-trie.workspace = true
 base-execution-eip8130-rpc-node.workspace = true
 base-bundle-extension.workspace = true
 base-proofs-extension.workspace = true
+base-shadow-canary.workspace = true
+base-shadow-canary-db.workspace = true
 base-execution-chainspec.workspace = true
 base-execution-consensus.workspace = true
 base-upgrade-signal = { workspace = true, features = ["metrics"] }

--- a/crates/execution/cli/src/lib.rs
+++ b/crates/execution/cli/src/lib.rs
@@ -42,7 +42,7 @@ use reth_node_core::{
 use reth_node_metrics as _;
 use reth_rpc_server_types::{LenientRpcModuleValidator, RpcModuleValidator};
 pub use standard_node::{
-    MeteringArgs, RpcStandardNodeArgs, StandardBaseRethNode, StandardNodeArgs,
+    MeteringArgs, RpcStandardNodeArgs, ShadowCanaryArgs, StandardBaseRethNode, StandardNodeArgs,
 };
 mod upgrade_signal;
 pub use upgrade_signal::{

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -14,6 +14,8 @@ use base_observability_events::{
     TransactionEventWriterConfig,
 };
 use base_proofs_extension::ProofsHistoryExtension;
+use base_shadow_canary::{ShadowCanaryConfig, ShadowCanaryExtension};
+use base_shadow_canary_db::ShadowDbConfig;
 use base_tx_forwarding::{
     DEFAULT_MAX_BATCH_SIZE, DEFAULT_MAX_RPS, DEFAULT_RESEND_AFTER_MS, TxForwardingConfig,
     TxForwardingExtension,
@@ -27,6 +29,61 @@ use url::Url;
 use crate::upgrade_signal::{
     ExecutionUpgradeSignal, ExecutionUpgradeSignalConfig, ExecutionUpgradeSignalRuntimeExtension,
 };
+
+/// Default maximum number of shadow-canary database pool connections.
+const DEFAULT_SHADOW_CANARY_MAX_CONNECTIONS: u32 = 5;
+
+/// CLI arguments for the shadow-canary block-capture pipeline.
+///
+/// All arguments are optional. Persistence stays disabled unless
+/// `--enable-shadow-canary` is set, in which case `--shadow-canary.db-url`
+/// becomes required.
+#[derive(Debug, Clone, PartialEq, Eq, Default, clap::Args)]
+pub struct ShadowCanaryArgs {
+    /// Enable the shadow-canary `ExEx` that captures committed blocks to Postgres.
+    #[arg(long = "enable-shadow-canary", value_name = "ENABLE_SHADOW_CANARY")]
+    pub enable_shadow_canary: bool,
+
+    /// Postgres connection URL for shadow-canary block persistence.
+    ///
+    /// Required when `--enable-shadow-canary` is set.
+    #[arg(
+        long = "shadow-canary.db-url",
+        env = "BASE_NODE_SHADOW_CANARY_DB_URL",
+        value_name = "SHADOW_CANARY_DB_URL",
+        requires = "enable_shadow_canary"
+    )]
+    pub shadow_canary_db_url: Option<String>,
+
+    /// Maximum number of open connections in the shadow-canary database pool.
+    #[arg(
+        long = "shadow-canary.max-connections",
+        value_name = "SHADOW_CANARY_MAX_CONNECTIONS",
+        default_value_t = DEFAULT_SHADOW_CANARY_MAX_CONNECTIONS,
+        requires = "enable_shadow_canary"
+    )]
+    pub shadow_canary_max_connections: u32,
+
+    /// Timeout when acquiring a shadow-canary database connection.
+    #[arg(
+        long = "shadow-canary.connection-timeout",
+        value_name = "SHADOW_CANARY_CONNECTION_TIMEOUT",
+        default_value = "5s",
+        value_parser = humantime::parse_duration,
+        requires = "enable_shadow_canary"
+    )]
+    pub shadow_canary_connection_timeout: Duration,
+
+    /// Builder version string attached to persisted shadow-canary rows.
+    ///
+    /// Defaults to the node's crate version when omitted.
+    #[arg(
+        long = "shadow-canary.builder-version",
+        value_name = "SHADOW_CANARY_BUILDER_VERSION",
+        requires = "enable_shadow_canary"
+    )]
+    pub shadow_canary_builder_version: Option<String>,
+}
 
 /// CLI arguments for metering RPC and priority-fee resource budgets.
 #[derive(Debug, Clone, PartialEq, Eq, Default, clap::Args)]
@@ -85,6 +142,10 @@ pub struct StandardNodeArgs {
     /// Metering RPC and priority-fee resource budget arguments.
     #[command(flatten)]
     pub metering: MeteringArgs,
+
+    /// Shadow-canary block-capture arguments.
+    #[command(flatten)]
+    pub shadow_canary: ShadowCanaryArgs,
 
     /// Enable transaction forwarding for mempool nodes to builder RPC endpoints
     #[arg(
@@ -208,6 +269,7 @@ impl From<RpcStandardNodeArgs> for StandardNodeArgs {
         Self {
             rpc: args,
             metering: MeteringArgs::default(),
+            shadow_canary: ShadowCanaryArgs::default(),
             enable_tx_forwarding: false,
             builder_rpc_urls: Vec::new(),
             tx_forwarding_resend_after_ms: DEFAULT_RESEND_AFTER_MS,
@@ -244,6 +306,36 @@ impl From<&StandardNodeArgs> for TxForwardingConfig {
             .with_resend_after_ms(args.tx_forwarding_resend_after_ms)
             .with_max_batch_size(args.tx_forwarding_batch_size)
             .with_max_rps(args.tx_forwarding_max_rps)
+    }
+}
+
+impl TryFrom<&ShadowCanaryArgs> for ShadowCanaryConfig {
+    type Error = eyre::Error;
+
+    fn try_from(args: &ShadowCanaryArgs) -> eyre::Result<Self> {
+        let db = ShadowDbConfig {
+            url: args.shadow_canary_db_url.clone().unwrap_or_default(),
+            max_connections: args.shadow_canary_max_connections,
+            connection_timeout: args.shadow_canary_connection_timeout,
+        };
+
+        if !args.enable_shadow_canary {
+            return Ok(Self { enabled: false, db, builder_version: String::new() });
+        }
+
+        if args.shadow_canary_db_url.is_none() {
+            eyre::bail!(
+                "--enable-shadow-canary requires --shadow-canary.db-url (env \
+                 BASE_NODE_SHADOW_CANARY_DB_URL)"
+            );
+        }
+
+        let builder_version = args
+            .shadow_canary_builder_version
+            .clone()
+            .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
+
+        Ok(Self { enabled: true, db, builder_version })
     }
 }
 
@@ -428,6 +520,7 @@ impl StandardBaseRethNode {
         };
         runner.install_ext::<FlashblocksExtension>(flashblocks_config);
         runner.install_ext::<Eip8130RpcExtension>(eip8130_rpc_mode);
+        runner.install_ext::<ShadowCanaryExtension>((&args.shadow_canary).try_into()?);
         Ok(runner)
     }
 
@@ -771,5 +864,116 @@ mod tests {
 
         assert_eq!(args.metering.metering_execution_time_us, Some(5_000_000));
         assert_eq!(args.metering.metering_state_root_time_us, Some(1_000_000));
+    }
+
+    #[test]
+    fn test_shadow_canary_flags_parse_into_args() {
+        let args = CommandParser::<StandardNodeArgs>::parse_from([
+            "reth",
+            "--enable-shadow-canary",
+            "--shadow-canary.db-url",
+            "postgres://localhost/shadow",
+            "--shadow-canary.max-connections",
+            "12",
+            "--shadow-canary.connection-timeout",
+            "10s",
+            "--shadow-canary.builder-version",
+            "v1.2.3",
+        ])
+        .args
+        .shadow_canary;
+
+        assert!(args.enable_shadow_canary);
+        assert_eq!(args.shadow_canary_db_url.as_deref(), Some("postgres://localhost/shadow"));
+        assert_eq!(args.shadow_canary_max_connections, 12);
+        assert_eq!(args.shadow_canary_connection_timeout, Duration::from_secs(10));
+        assert_eq!(args.shadow_canary_builder_version.as_deref(), Some("v1.2.3"));
+    }
+
+    #[test]
+    fn test_shadow_canary_defaults_when_disabled() {
+        let args =
+            CommandParser::<StandardNodeArgs>::parse_from(["reth"]).args.shadow_canary;
+
+        assert!(!args.enable_shadow_canary);
+        assert_eq!(args.shadow_canary_db_url, None);
+        assert_eq!(
+            args.shadow_canary_max_connections,
+            DEFAULT_SHADOW_CANARY_MAX_CONNECTIONS
+        );
+        assert_eq!(args.shadow_canary_connection_timeout, Duration::from_secs(5));
+        assert_eq!(args.shadow_canary_builder_version, None);
+    }
+
+    #[test]
+    fn test_shadow_canary_db_url_requires_enable() {
+        let error = CommandParser::<StandardNodeArgs>::try_parse_from([
+            "reth",
+            "--shadow-canary.db-url",
+            "postgres://localhost/shadow",
+        ])
+        .expect_err("db url should require --enable-shadow-canary");
+
+        assert!(error.to_string().contains("--enable-shadow-canary"));
+    }
+
+    #[test]
+    fn test_shadow_canary_config_disabled_by_default() {
+        let config = ShadowCanaryConfig::try_from(&ShadowCanaryArgs::default())
+            .expect("disabled config is valid");
+
+        assert!(!config.enabled);
+        assert_eq!(config.db.max_connections, 0);
+        assert!(config.builder_version.is_empty());
+    }
+
+    #[test]
+    fn test_shadow_canary_config_requires_db_url_when_enabled() {
+        let args = ShadowCanaryArgs {
+            enable_shadow_canary: true,
+            shadow_canary_db_url: None,
+            shadow_canary_max_connections: DEFAULT_SHADOW_CANARY_MAX_CONNECTIONS,
+            shadow_canary_connection_timeout: Duration::from_secs(5),
+            shadow_canary_builder_version: None,
+        };
+
+        let error = ShadowCanaryConfig::try_from(&args)
+            .expect_err("enabled shadow canary should require a db url");
+
+        assert!(error.to_string().contains("--shadow-canary.db-url"));
+    }
+
+    #[test]
+    fn test_shadow_canary_config_builds_when_enabled() {
+        let args = ShadowCanaryArgs {
+            enable_shadow_canary: true,
+            shadow_canary_db_url: Some("postgres://localhost/shadow".to_string()),
+            shadow_canary_max_connections: 7,
+            shadow_canary_connection_timeout: Duration::from_secs(9),
+            shadow_canary_builder_version: Some("v9.9.9".to_string()),
+        };
+
+        let config = ShadowCanaryConfig::try_from(&args).expect("enabled config is valid");
+
+        assert!(config.enabled);
+        assert_eq!(config.db.url, "postgres://localhost/shadow");
+        assert_eq!(config.db.max_connections, 7);
+        assert_eq!(config.db.connection_timeout, Duration::from_secs(9));
+        assert_eq!(config.builder_version, "v9.9.9");
+    }
+
+    #[test]
+    fn test_shadow_canary_config_defaults_builder_version_to_crate_version() {
+        let args = ShadowCanaryArgs {
+            enable_shadow_canary: true,
+            shadow_canary_db_url: Some("postgres://localhost/shadow".to_string()),
+            shadow_canary_max_connections: DEFAULT_SHADOW_CANARY_MAX_CONNECTIONS,
+            shadow_canary_connection_timeout: Duration::from_secs(5),
+            shadow_canary_builder_version: None,
+        };
+
+        let config = ShadowCanaryConfig::try_from(&args).expect("enabled config is valid");
+
+        assert_eq!(config.builder_version, env!("CARGO_PKG_VERSION"));
     }
 }

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -892,15 +892,11 @@ mod tests {
 
     #[test]
     fn test_shadow_canary_defaults_when_disabled() {
-        let args =
-            CommandParser::<StandardNodeArgs>::parse_from(["reth"]).args.shadow_canary;
+        let args = CommandParser::<StandardNodeArgs>::parse_from(["reth"]).args.shadow_canary;
 
         assert!(!args.enable_shadow_canary);
         assert_eq!(args.shadow_canary_db_url, None);
-        assert_eq!(
-            args.shadow_canary_max_connections,
-            DEFAULT_SHADOW_CANARY_MAX_CONNECTIONS
-        );
+        assert_eq!(args.shadow_canary_max_connections, DEFAULT_SHADOW_CANARY_MAX_CONNECTIONS);
         assert_eq!(args.shadow_canary_connection_timeout, Duration::from_secs(5));
         assert_eq!(args.shadow_canary_builder_version, None);
     }

--- a/crates/execution/shadow-canary-db/Cargo.toml
+++ b/crates/execution/shadow-canary-db/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 
 [dependencies]
 # database
-sqlx = { workspace = true, features = ["runtime-tokio", "postgres", "chrono", "json", "migrate", "macros", "tls-native-tls", "sqlite"] }
+sqlx = { workspace = true, features = ["runtime-tokio", "postgres", "chrono", "json", "migrate", "macros", "tls-native-tls"] }
 
 # serialization
 serde_json.workspace = true

--- a/crates/execution/shadow-canary-db/Cargo.toml
+++ b/crates/execution/shadow-canary-db/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "base-shadow-canary-db"
+description = "Shadow canary database access layer"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# database
+sqlx = { workspace = true, features = ["runtime-tokio", "postgres", "chrono", "json", "migrate", "macros", "tls-native-tls", "sqlite"] }
+
+# serialization
+serde_json.workspace = true
+serde.workspace = true
+chrono.workspace = true
+
+# async
+tokio.workspace = true
+
+# error handling
+anyhow.workspace = true
+
+# tracing
+tracing.workspace = true

--- a/crates/execution/shadow-canary-db/README.md
+++ b/crates/execution/shadow-canary-db/README.md
@@ -1,0 +1,3 @@
+# `base-shadow-canary-db`
+
+Database access layer for shadow canary block persistence.

--- a/crates/execution/shadow-canary-db/migrations/0001_init.sql
+++ b/crates/execution/shadow-canary-db/migrations/0001_init.sql
@@ -1,0 +1,18 @@
+CREATE TABLE shadow_blocks(
+  number BIGINT,
+  hash TEXT,
+  parent_hash TEXT,
+  timestamp BIGINT,
+  tx_count INT,
+  gas_used BIGINT,
+  da_bytes BIGINT,
+  state_root TEXT,
+  build_latency_ms BIGINT,
+  deadline_miss BOOL,
+  fb_count INT,
+  panicked BOOL,
+  builder_version TEXT,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  PRIMARY KEY(number, hash)
+);
+CREATE INDEX idx_shadow_blocks_number ON shadow_blocks(number DESC);

--- a/crates/execution/shadow-canary-db/migrations/0002_reorg.sql
+++ b/crates/execution/shadow-canary-db/migrations/0002_reorg.sql
@@ -1,2 +1,2 @@
-ALTER TABLE shadow_blocks ADD COLUMN reorged_out BOOL DEFAULT false;
+ALTER TABLE shadow_blocks ADD COLUMN reorged_out BOOL NOT NULL DEFAULT false;
 ALTER TABLE shadow_blocks ADD COLUMN canonical_hash TEXT;

--- a/crates/execution/shadow-canary-db/migrations/0002_reorg.sql
+++ b/crates/execution/shadow-canary-db/migrations/0002_reorg.sql
@@ -1,0 +1,2 @@
+ALTER TABLE shadow_blocks ADD COLUMN reorged_out BOOL DEFAULT false;
+ALTER TABLE shadow_blocks ADD COLUMN canonical_hash TEXT;

--- a/crates/execution/shadow-canary-db/src/config.rs
+++ b/crates/execution/shadow-canary-db/src/config.rs
@@ -1,0 +1,38 @@
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use sqlx::{postgres::PgPoolOptions, PgPool};
+
+/// Configuration for the shadow canary database.
+#[derive(Clone, Debug)]
+pub struct ShadowDbConfig {
+    /// Database connection URL.
+    pub url: String,
+    /// Maximum number of open connections.
+    pub max_connections: u32,
+    /// Timeout when acquiring a connection.
+    pub connection_timeout: Duration,
+}
+
+impl ShadowDbConfig {
+    /// Initialize the database connection pool and run migrations.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the connection or migrations fail.
+    pub async fn init_pool(&self) -> Result<PgPool> {
+        let pool = PgPoolOptions::new()
+            .max_connections(self.max_connections)
+            .acquire_timeout(self.connection_timeout)
+            .connect(&self.url)
+            .await
+            .context("failed to connect to shadow canary database")?;
+
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .context("failed to run shadow canary database migrations")?;
+
+        Ok(pool)
+    }
+}

--- a/crates/execution/shadow-canary-db/src/config.rs
+++ b/crates/execution/shadow-canary-db/src/config.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use sqlx::{postgres::PgPoolOptions, PgPool};
+use sqlx::{PgPool, postgres::PgPoolOptions};
 
 /// Configuration for the shadow canary database.
 #[derive(Clone, Debug)]

--- a/crates/execution/shadow-canary-db/src/lib.rs
+++ b/crates/execution/shadow-canary-db/src/lib.rs
@@ -1,0 +1,10 @@
+#![doc = include_str!("../README.md")]
+
+mod config;
+pub use config::ShadowDbConfig;
+
+mod repo;
+pub use repo::ShadowBlockRepo;
+
+mod models;
+pub use models::ShadowBlockRow;

--- a/crates/execution/shadow-canary-db/src/models.rs
+++ b/crates/execution/shadow-canary-db/src/models.rs
@@ -1,0 +1,38 @@
+use chrono::{DateTime, Utc};
+
+/// Row representation for a shadow canary block.
+#[derive(Clone, Debug, sqlx::FromRow)]
+pub struct ShadowBlockRow {
+    /// Block number.
+    pub number: i64,
+    /// Block hash.
+    pub hash: String,
+    /// Parent block hash.
+    pub parent_hash: String,
+    /// Block timestamp.
+    pub timestamp: i64,
+    /// Number of transactions in the block.
+    pub tx_count: i32,
+    /// Total gas used.
+    pub gas_used: i64,
+    /// Data availability bytes.
+    pub da_bytes: i64,
+    /// State root hash.
+    pub state_root: String,
+    /// Build latency in milliseconds.
+    pub build_latency_ms: Option<i64>,
+    /// Whether the block missed its deadline.
+    pub deadline_miss: bool,
+    /// Fallback block count.
+    pub fb_count: Option<i32>,
+    /// Whether the builder panicked.
+    pub panicked: bool,
+    /// Whether the block was reorged out.
+    pub reorged_out: bool,
+    /// Canonical block hash at the same height after reorg.
+    pub canonical_hash: Option<String>,
+    /// Builder version string.
+    pub builder_version: String,
+    /// Row creation time.
+    pub created_at: DateTime<Utc>,
+}

--- a/crates/execution/shadow-canary-db/src/repo.rs
+++ b/crates/execution/shadow-canary-db/src/repo.rs
@@ -12,7 +12,7 @@ pub struct ShadowBlockRepo {
 impl ShadowBlockRepo {
     /// Create a new repository backed by the provided pool.
     #[must_use]
-    pub fn new(pool: PgPool) -> Self {
+    pub const fn new(pool: PgPool) -> Self {
         Self { pool }
     }
 
@@ -69,7 +69,8 @@ impl ShadowBlockRepo {
                 .await
                 .context("failed to insert shadow block batch")?;
 
-            inserted = inserted.saturating_add(result.rows_affected() as usize);
+            inserted = inserted
+                .saturating_add(usize::try_from(result.rows_affected()).unwrap_or(usize::MAX));
         }
 
         Ok(inserted)

--- a/crates/execution/shadow-canary-db/src/repo.rs
+++ b/crates/execution/shadow-canary-db/src/repo.rs
@@ -1,0 +1,95 @@
+use anyhow::{Context, Result};
+use sqlx::{PgPool, Postgres, QueryBuilder, query_as};
+
+use crate::ShadowBlockRow;
+
+/// Repository for shadow canary block persistence.
+#[derive(Debug)]
+pub struct ShadowBlockRepo {
+    pool: PgPool,
+}
+
+impl ShadowBlockRepo {
+    /// Create a new repository backed by the provided pool.
+    #[must_use]
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Insert a batch of shadow block rows.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the insert fails.
+    pub async fn insert_batch(&self, rows: &[ShadowBlockRow]) -> Result<usize> {
+        const CHUNK_SIZE: usize = 5_000;
+
+        if rows.is_empty() {
+            return Ok(0);
+        }
+
+        let mut inserted = 0usize;
+
+        for chunk in rows.chunks(CHUNK_SIZE) {
+            let mut query_builder: QueryBuilder<'_, Postgres> = QueryBuilder::new(
+                "INSERT INTO shadow_blocks \
+                 (number, hash, parent_hash, timestamp, tx_count, gas_used, da_bytes, \
+                  state_root, build_latency_ms, deadline_miss, fb_count, panicked, \
+                  reorged_out, canonical_hash, builder_version, created_at) ",
+            );
+
+            query_builder.push_values(chunk, |mut row, entry| {
+                row.push_bind(entry.number)
+                    .push_bind(&entry.hash)
+                    .push_bind(&entry.parent_hash)
+                    .push_bind(entry.timestamp)
+                    .push_bind(entry.tx_count)
+                    .push_bind(entry.gas_used)
+                    .push_bind(entry.da_bytes)
+                    .push_bind(&entry.state_root)
+                    .push_bind(entry.build_latency_ms)
+                    .push_bind(entry.deadline_miss)
+                    .push_bind(entry.fb_count)
+                    .push_bind(entry.panicked)
+                    .push_bind(entry.reorged_out)
+                    .push_bind(&entry.canonical_hash)
+                    .push_bind(&entry.builder_version)
+                    .push_bind(entry.created_at);
+            });
+
+            query_builder.push(
+                " ON CONFLICT (number, hash) DO UPDATE SET \
+                 reorged_out = EXCLUDED.reorged_out, \
+                 canonical_hash = EXCLUDED.canonical_hash",
+            );
+
+            let result = query_builder
+                .build()
+                .execute(&self.pool)
+                .await
+                .context("failed to insert shadow block batch")?;
+
+            inserted = inserted.saturating_add(result.rows_affected() as usize);
+        }
+
+        Ok(inserted)
+    }
+
+    /// Lists shadow block rows with block numbers in the provided inclusive range.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query fails.
+    pub async fn list_by_number_range(&self, start: i64, end: i64) -> Result<Vec<ShadowBlockRow>> {
+        let rows = query_as::<_, ShadowBlockRow>(
+            "SELECT * FROM shadow_blocks WHERE number BETWEEN $1 AND $2 ORDER BY number, created_at",
+        )
+        .bind(start)
+        .bind(end)
+        .fetch_all(&self.pool)
+        .await
+        .context("failed to list shadow blocks by number range")?;
+
+        Ok(rows)
+    }
+}

--- a/crates/execution/shadow-canary/Cargo.toml
+++ b/crates/execution/shadow-canary/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "base-shadow-canary"
+description = "Shadow canary ExEx for capturing executed blocks"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# workspace
+base-node-runner.workspace = true
+base-shadow-canary-db = { path = "../shadow-canary-db" }
+
+# reth
+reth-exex.workspace = true
+reth-execution-types.workspace = true
+reth-node-api.workspace = true
+reth-primitives-traits.workspace = true
+reth-tasks.workspace = true
+
+# tokio
+tokio.workspace = true
+
+# tracing
+tracing = { workspace = true, features = ["std"] }
+
+# misc
+chrono.workspace = true
+eyre.workspace = true
+futures.workspace = true

--- a/crates/execution/shadow-canary/README.md
+++ b/crates/execution/shadow-canary/README.md
@@ -1,0 +1,4 @@
+# `base-shadow-canary`
+
+Shadow canary Execution Extension (`ExEx`) that captures committed execution blocks and persists
+their metadata to the shadow canary database.

--- a/crates/execution/shadow-canary/src/exex.rs
+++ b/crates/execution/shadow-canary/src/exex.rs
@@ -1,28 +1,27 @@
+use base_shadow_canary_db::ShadowBlockRow;
 use chrono::Utc;
 use eyre::Result;
 use futures::TryStreamExt;
-use reth_exex::{ExExContext, ExExEvent, ExExNotification};
 use reth_execution_types::Chain;
+use reth_exex::{ExExContext, ExExEvent, ExExNotification};
 use reth_node_api::FullNodeComponents;
 use reth_primitives_traits::{AlloyBlockHeader, NodePrimitives};
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
-use base_shadow_canary_db::ShadowBlockRow;
-
-/// Shadow canary ExEx handler.
+/// Shadow canary `ExEx` handler.
 #[derive(Debug)]
 pub struct ShadowCanaryExEx {
     tx: mpsc::Sender<ShadowBlockRow>,
 }
 
 impl ShadowCanaryExEx {
-    /// Create a new shadow canary ExEx handler.
+    /// Create a new shadow canary `ExEx` handler.
     pub const fn new(tx: mpsc::Sender<ShadowBlockRow>) -> Self {
         Self { tx }
     }
 
-    /// Runs the shadow canary ExEx loop.
+    /// Runs the shadow canary `ExEx` loop.
     pub async fn run<Node>(self, mut ctx: ExExContext<Node>) -> Result<()>
     where
         Node: FullNodeComponents,
@@ -92,18 +91,15 @@ impl ShadowCanaryExEx {
         reorged_out: bool,
         canonical_hash: Option<String>,
     ) -> Result<ShadowBlockRow> {
-        let number = i64::try_from(header.number()).map_err(|error| {
-            eyre::eyre!("block number overflow for shadow canary row: {error}")
-        })?;
-        let timestamp = i64::try_from(header.timestamp()).map_err(|error| {
-            eyre::eyre!("timestamp overflow for shadow canary row: {error}")
-        })?;
+        let number = i64::try_from(header.number())
+            .map_err(|error| eyre::eyre!("block number overflow for shadow canary row: {error}"))?;
+        let timestamp = i64::try_from(header.timestamp())
+            .map_err(|error| eyre::eyre!("timestamp overflow for shadow canary row: {error}"))?;
         let tx_count = i32::try_from(tx_count).map_err(|error| {
             eyre::eyre!("transaction count overflow for shadow canary row: {error}")
         })?;
-        let gas_used = i64::try_from(header.gas_used()).map_err(|error| {
-            eyre::eyre!("gas used overflow for shadow canary row: {error}")
-        })?;
+        let gas_used = i64::try_from(header.gas_used())
+            .map_err(|error| eyre::eyre!("gas used overflow for shadow canary row: {error}"))?;
         let created_at = Utc::now();
 
         Ok(ShadowBlockRow {
@@ -218,11 +214,8 @@ impl ShadowCanaryExEx {
     }
 }
 
-/// Runs the shadow canary ExEx loop.
-pub async fn run_exex<Node>(
-    ctx: ExExContext<Node>,
-    tx: mpsc::Sender<ShadowBlockRow>,
-) -> Result<()>
+/// Runs the shadow canary `ExEx` loop.
+pub async fn run_exex<Node>(ctx: ExExContext<Node>, tx: mpsc::Sender<ShadowBlockRow>) -> Result<()>
 where
     Node: FullNodeComponents,
 {

--- a/crates/execution/shadow-canary/src/exex.rs
+++ b/crates/execution/shadow-canary/src/exex.rs
@@ -1,0 +1,230 @@
+use chrono::Utc;
+use eyre::Result;
+use futures::TryStreamExt;
+use reth_exex::{ExExContext, ExExEvent, ExExNotification};
+use reth_execution_types::Chain;
+use reth_node_api::FullNodeComponents;
+use reth_primitives_traits::{AlloyBlockHeader, NodePrimitives};
+use tokio::sync::mpsc;
+use tracing::{debug, info, warn};
+
+use base_shadow_canary_db::ShadowBlockRow;
+
+/// Shadow canary ExEx handler.
+#[derive(Debug)]
+pub struct ShadowCanaryExEx {
+    tx: mpsc::Sender<ShadowBlockRow>,
+}
+
+impl ShadowCanaryExEx {
+    /// Create a new shadow canary ExEx handler.
+    pub const fn new(tx: mpsc::Sender<ShadowBlockRow>) -> Self {
+        Self { tx }
+    }
+
+    /// Runs the shadow canary ExEx loop.
+    pub async fn run<Node>(self, mut ctx: ExExContext<Node>) -> Result<()>
+    where
+        Node: FullNodeComponents,
+    {
+        while let Some(notification) = ctx.notifications.try_next().await? {
+            let fully_processed = match &notification {
+                ExExNotification::ChainCommitted { new } => {
+                    debug!(
+                        target: "base::shadow-canary",
+                        block_number = new.tip().header().number(),
+                        block_hash = ?new.tip().hash(),
+                        "Committed chain notification received"
+                    );
+                    self.handle_chain_committed(new).await?
+                }
+                ExExNotification::ChainReorged { old, new } => {
+                    info!(
+                        target: "base::shadow-canary",
+                        old_block_number = old.tip().header().number(),
+                        old_block_hash = ?old.tip().hash(),
+                        new_block_number = new.tip().header().number(),
+                        new_block_hash = ?new.tip().hash(),
+                        "ChainReorged notification received"
+                    );
+                    self.handle_chain_reorged(old, new).await?
+                }
+                ExExNotification::ChainReverted { old } => {
+                    info!(
+                        target: "base::shadow-canary",
+                        old_block_number = old.tip().header().number(),
+                        old_block_hash = ?old.tip().hash(),
+                        "ChainReverted notification ignored for S1 MVP"
+                    );
+                    true
+                }
+            };
+
+            if let Some(committed_chain) = notification.committed_chain() {
+                let tip = committed_chain.tip().num_hash();
+                if fully_processed {
+                    debug!(
+                        target: "base::shadow-canary",
+                        block_number = tip.number,
+                        block_hash = ?tip.hash,
+                        "Sending FinishedHeight event"
+                    );
+                    ctx.events.send(ExExEvent::FinishedHeight(tip))?;
+                } else {
+                    warn!(
+                        target: "base::shadow-canary",
+                        block_number = tip.number,
+                        block_hash = ?tip.hash,
+                        "Skipping FinishedHeight event after partial processing"
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn build_row_from_header(
+        &self,
+        header: &impl AlloyBlockHeader,
+        block_hash: String,
+        tx_count: usize,
+        reorged_out: bool,
+        canonical_hash: Option<String>,
+    ) -> Result<ShadowBlockRow> {
+        let number = i64::try_from(header.number()).map_err(|error| {
+            eyre::eyre!("block number overflow for shadow canary row: {error}")
+        })?;
+        let timestamp = i64::try_from(header.timestamp()).map_err(|error| {
+            eyre::eyre!("timestamp overflow for shadow canary row: {error}")
+        })?;
+        let tx_count = i32::try_from(tx_count).map_err(|error| {
+            eyre::eyre!("transaction count overflow for shadow canary row: {error}")
+        })?;
+        let gas_used = i64::try_from(header.gas_used()).map_err(|error| {
+            eyre::eyre!("gas used overflow for shadow canary row: {error}")
+        })?;
+        let created_at = Utc::now();
+
+        Ok(ShadowBlockRow {
+            number,
+            hash: block_hash,
+            parent_hash: header.parent_hash().to_string(),
+            timestamp,
+            tx_count,
+            gas_used,
+            // Placeholder until builder metrics are wired for DA bytes.
+            da_bytes: 0,
+            state_root: header.state_root().to_string(),
+            build_latency_ms: None,
+            deadline_miss: false,
+            fb_count: None,
+            panicked: false,
+            reorged_out,
+            canonical_hash,
+            // The writer injects the configured builder version before persistence.
+            builder_version: String::new(),
+            created_at,
+        })
+    }
+
+    async fn handle_chain_committed<N>(&self, chain: &Chain<N>) -> Result<bool>
+    where
+        N: NodePrimitives,
+    {
+        for (block, receipts) in chain.blocks_and_receipts() {
+            let header = block.header();
+            let row = self.build_row_from_header(
+                header,
+                block.hash().to_string(),
+                receipts.len(),
+                false,
+                None,
+            )?;
+
+            if !self.send_row(row).await? {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+
+    async fn handle_chain_reorged<N>(&self, old: &Chain<N>, new: &Chain<N>) -> Result<bool>
+    where
+        N: NodePrimitives,
+    {
+        for (block, receipts) in old.blocks_and_receipts() {
+            let header = block.header();
+            let canonical_hash = new
+                .blocks()
+                .get(&header.number())
+                .map(|canonical_block| canonical_block.hash().to_string());
+
+            if canonical_hash.is_none() {
+                warn!(
+                    target: "base::shadow-canary",
+                    block_number = header.number(),
+                    old_block_hash = ?block.hash(),
+                    new_tip_number = new.tip().header().number(),
+                    new_tip_hash = ?new.tip().hash(),
+                    "Missing canonical block for reorged shadow row"
+                );
+            }
+
+            let row = self.build_row_from_header(
+                header,
+                block.hash().to_string(),
+                receipts.len(),
+                true,
+                canonical_hash,
+            )?;
+
+            if !self.send_row(row).await? {
+                return Ok(false);
+            }
+        }
+
+        for (block, receipts) in new.blocks_and_receipts() {
+            let header = block.header();
+            let row = self.build_row_from_header(
+                header,
+                block.hash().to_string(),
+                receipts.len(),
+                false,
+                None,
+            )?;
+
+            if !self.send_row(row).await? {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+
+    async fn send_row(&self, row: ShadowBlockRow) -> Result<bool> {
+        match self.tx.send(row).await {
+            Ok(()) => Ok(true),
+            Err(error) => {
+                info!(
+                    target: "base::shadow-canary",
+                    error = ?error,
+                    "Shadow canary writer channel closed"
+                );
+                Ok(false)
+            }
+        }
+    }
+}
+
+/// Runs the shadow canary ExEx loop.
+pub async fn run_exex<Node>(
+    ctx: ExExContext<Node>,
+    tx: mpsc::Sender<ShadowBlockRow>,
+) -> Result<()>
+where
+    Node: FullNodeComponents,
+{
+    ShadowCanaryExEx::new(tx).run(ctx).await
+}

--- a/crates/execution/shadow-canary/src/extension.rs
+++ b/crates/execution/shadow-canary/src/extension.rs
@@ -1,8 +1,8 @@
 use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
+use base_shadow_canary_db::ShadowDbConfig;
 use tokio::sync::mpsc;
 
 use crate::{run_exex, spawn_writer};
-use base_shadow_canary_db::ShadowDbConfig;
 
 /// Configuration for the shadow canary extension.
 #[derive(Clone, Debug)]
@@ -15,7 +15,7 @@ pub struct ShadowCanaryConfig {
     pub builder_version: String,
 }
 
-/// Wires the shadow canary ExEx into the Base node.
+/// Wires the shadow canary `ExEx` into the Base node.
 #[derive(Debug)]
 pub struct ShadowCanaryExtension {
     cfg: ShadowCanaryConfig,
@@ -41,7 +41,7 @@ impl BaseNodeExtension for ShadowCanaryExtension {
 
         hooks
             .add_node_started_hook(move |node| {
-                spawn_writer(node.task_executor.clone(), rx, db, builder_version);
+                spawn_writer(node.task_executor, rx, db, builder_version);
                 Ok(())
             })
             .install_exex("shadow-canary", move |ctx| async move { Ok(run_exex(ctx, tx)) })

--- a/crates/execution/shadow-canary/src/extension.rs
+++ b/crates/execution/shadow-canary/src/extension.rs
@@ -1,0 +1,49 @@
+use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
+use tokio::sync::mpsc;
+
+use crate::{run_exex, spawn_writer};
+use base_shadow_canary_db::ShadowDbConfig;
+
+/// Configuration for the shadow canary extension.
+#[derive(Clone, Debug)]
+pub struct ShadowCanaryConfig {
+    /// Whether the shadow canary pipeline is enabled.
+    pub enabled: bool,
+    /// Database configuration for the shadow canary writer.
+    pub db: ShadowDbConfig,
+    /// Builder version string to attach to persisted rows.
+    pub builder_version: String,
+}
+
+/// Wires the shadow canary ExEx into the Base node.
+#[derive(Debug)]
+pub struct ShadowCanaryExtension {
+    cfg: ShadowCanaryConfig,
+}
+
+impl FromExtensionConfig for ShadowCanaryExtension {
+    type Config = ShadowCanaryConfig;
+
+    fn from_config(config: Self::Config) -> Self {
+        Self { cfg: config }
+    }
+}
+
+impl BaseNodeExtension for ShadowCanaryExtension {
+    fn apply(self: Box<Self>, hooks: NodeHooks) -> NodeHooks {
+        if !self.cfg.enabled {
+            return hooks;
+        }
+
+        let (tx, rx) = mpsc::channel(1024);
+        let db = self.cfg.db.clone();
+        let builder_version = self.cfg.builder_version.clone();
+
+        hooks
+            .add_node_started_hook(move |node| {
+                spawn_writer(node.task_executor.clone(), rx, db, builder_version);
+                Ok(())
+            })
+            .install_exex("shadow-canary", move |ctx| async move { Ok(run_exex(ctx, tx)) })
+    }
+}

--- a/crates/execution/shadow-canary/src/lib.rs
+++ b/crates/execution/shadow-canary/src/lib.rs
@@ -4,7 +4,7 @@ mod extension;
 pub use extension::{ShadowCanaryConfig, ShadowCanaryExtension};
 
 mod exex;
-pub use exex::{run_exex, ShadowCanaryExEx};
+pub use exex::{ShadowCanaryExEx, run_exex};
 
 mod writer;
-pub use writer::{spawn_writer, ShadowWriter};
+pub use writer::{ShadowWriter, spawn_writer};

--- a/crates/execution/shadow-canary/src/lib.rs
+++ b/crates/execution/shadow-canary/src/lib.rs
@@ -1,0 +1,10 @@
+#![doc = include_str!("../README.md")]
+
+mod extension;
+pub use extension::{ShadowCanaryConfig, ShadowCanaryExtension};
+
+mod exex;
+pub use exex::{run_exex, ShadowCanaryExEx};
+
+mod writer;
+pub use writer::{spawn_writer, ShadowWriter};

--- a/crates/execution/shadow-canary/src/writer.rs
+++ b/crates/execution/shadow-canary/src/writer.rs
@@ -1,15 +1,19 @@
 use std::time::Duration;
 
+use base_shadow_canary_db::{ShadowBlockRepo, ShadowBlockRow, ShadowDbConfig};
 use chrono::Utc;
 use reth_tasks::TaskExecutor;
-use tokio::sync::mpsc;
-use tokio::time::{MissedTickBehavior, interval};
-use tracing::{error, info};
-
-use base_shadow_canary_db::{ShadowBlockRepo, ShadowBlockRow, ShadowDbConfig};
+use tokio::{
+    sync::mpsc,
+    time::{MissedTickBehavior, interval},
+};
+use tracing::{error, info, warn};
 
 const BATCH_SIZE: usize = 100;
 const FLUSH_INTERVAL: Duration = Duration::from_secs(1);
+/// Upper bound on buffered rows retained across failed flushes. Beyond this the oldest rows are
+/// dropped so a persistent DB failure cannot grow the buffer unboundedly.
+const MAX_BUFFERED_ROWS: usize = BATCH_SIZE * 100;
 
 /// Shadow canary writer task.
 #[derive(Debug)]
@@ -104,6 +108,16 @@ impl ShadowWriter {
                     batch_size,
                     "Failed to insert shadow canary rows"
                 );
+                if buffer.len() > MAX_BUFFERED_ROWS {
+                    let dropped = buffer.len() - MAX_BUFFERED_ROWS;
+                    buffer.drain(0..dropped);
+                    warn!(
+                        target: "base::shadow-canary",
+                        dropped,
+                        retained = buffer.len(),
+                        "Shadow canary buffer exceeded cap after repeated flush failures; dropped oldest rows"
+                    );
+                }
             }
         }
     }

--- a/crates/execution/shadow-canary/src/writer.rs
+++ b/crates/execution/shadow-canary/src/writer.rs
@@ -1,0 +1,128 @@
+use std::time::Duration;
+
+use chrono::Utc;
+use reth_tasks::TaskExecutor;
+use tokio::sync::mpsc;
+use tokio::time::{MissedTickBehavior, interval};
+use tracing::{error, info};
+
+use base_shadow_canary_db::{ShadowBlockRepo, ShadowBlockRow, ShadowDbConfig};
+
+const BATCH_SIZE: usize = 100;
+const FLUSH_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Shadow canary writer task.
+#[derive(Debug)]
+pub struct ShadowWriter {
+    rx: mpsc::Receiver<ShadowBlockRow>,
+    db_config: ShadowDbConfig,
+    builder_version: String,
+}
+
+impl ShadowWriter {
+    /// Spawns the writer task on the provided executor.
+    pub fn spawn(
+        executor: TaskExecutor,
+        rx: mpsc::Receiver<ShadowBlockRow>,
+        db_config: ShadowDbConfig,
+        builder_version: String,
+    ) {
+        let writer = Self { rx, db_config, builder_version };
+        executor.spawn_critical_task("shadow-canary-writer", async move {
+            writer.run().await;
+        });
+    }
+
+    async fn run(mut self) {
+        info!(target: "base::shadow-canary", "Starting shadow canary writer");
+
+        let pool = match self.db_config.init_pool().await {
+            Ok(pool) => pool,
+            Err(error) => {
+                error!(
+                    target: "base::shadow-canary",
+                    error = ?error,
+                    "Failed to initialize shadow canary database pool"
+                );
+                return;
+            }
+        };
+        let repo = ShadowBlockRepo::new(pool);
+        let mut interval = interval(FLUSH_INTERVAL);
+        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        let mut buffer = Vec::with_capacity(BATCH_SIZE);
+
+        loop {
+            tokio::select! {
+                maybe_row = self.rx.recv() => {
+                    match maybe_row {
+                        Some(row) => {
+                            buffer.push(row);
+                            if buffer.len() >= BATCH_SIZE {
+                                self.flush(&repo, &mut buffer).await;
+                            }
+                        }
+                        None => {
+                            if !buffer.is_empty() {
+                                self.flush(&repo, &mut buffer).await;
+                            }
+                            break;
+                        }
+                    }
+                }
+                _ = interval.tick() => {
+                    if !buffer.is_empty() {
+                        self.flush(&repo, &mut buffer).await;
+                    }
+                }
+            }
+        }
+    }
+
+    async fn flush(&self, repo: &ShadowBlockRepo, buffer: &mut Vec<ShadowBlockRow>) {
+        if buffer.is_empty() {
+            return;
+        }
+
+        self.stamp_rows(buffer);
+        let batch_size = buffer.len();
+
+        match repo.insert_batch(buffer).await {
+            Ok(inserted) => {
+                info!(
+                    target: "base::shadow-canary",
+                    inserted,
+                    batch_size,
+                    "Inserted shadow canary rows"
+                );
+                buffer.clear();
+            }
+            Err(error) => {
+                error!(
+                    target: "base::shadow-canary",
+                    error = ?error,
+                    batch_size,
+                    "Failed to insert shadow canary rows"
+                );
+            }
+        }
+    }
+
+    fn stamp_rows(&self, rows: &mut [ShadowBlockRow]) {
+        let created_at = Utc::now();
+        for row in rows {
+            row.builder_version = self.builder_version.clone();
+            row.created_at = created_at;
+        }
+    }
+}
+
+/// Spawns the shadow canary writer task.
+pub fn spawn_writer(
+    executor: TaskExecutor,
+    rx: mpsc::Receiver<ShadowBlockRow>,
+    db_config: ShadowDbConfig,
+    builder_version: String,
+) {
+    ShadowWriter::spawn(executor, rx, db_config, builder_version);
+}

--- a/etc/systems/Cargo.toml
+++ b/etc/systems/Cargo.toml
@@ -26,6 +26,7 @@ base-consensus-rpc = { workspace = true, features = ["client"] }
 base-protocol = { workspace = true, features = ["serde", "std"] }
 base-node-runner = { workspace = true, features = ["test-utils"] }
 base-builder-core = { workspace = true, features = ["test-utils"] }
+base-shadow-canary.workspace = true
 
 # consensus
 base-consensus-disc.workspace = true
@@ -96,6 +97,7 @@ clap = { workspace = true, features = ["derive"] }
 # consensus
 base-consensus-derive.workspace = true
 base-consensus-engine = { workspace = true, features = ["test-utils"] }
+base-shadow-canary-db.workspace = true
 
 # alloy
 alloy-json-rpc.workspace = true
@@ -112,6 +114,7 @@ base-prover-service-protocol.workspace = true
 # misc
 indicatif.workspace = true
 async-trait.workspace = true
+testcontainers-modules = { workspace = true, features = ["postgres"] }
 
 [[bench]]
 name = "b20_zk_proving"

--- a/etc/systems/src/l2/in_process_builder.rs
+++ b/etc/systems/src/l2/in_process_builder.rs
@@ -14,6 +14,7 @@ use base_execution_chainspec::BaseChainSpec;
 use base_execution_txpool::{BasePooledTransaction, BuilderApiImpl, BuilderApiServer};
 use base_node_core::{args::RollupArgs, node::BasePoolBuilder};
 use base_node_runner::BaseNode;
+use base_shadow_canary::{ShadowCanaryConfig, run_exex, spawn_writer};
 use eyre::{Result, WrapErr, eyre};
 use nanoid::nanoid;
 use reth_db::{
@@ -27,6 +28,7 @@ use reth_node_core::{
     exit::NodeExitFuture,
 };
 use reth_tasks::{Runtime, RuntimeBuilder, RuntimeConfig};
+use tokio::sync::mpsc;
 use tracing::warn;
 use url::Url;
 
@@ -49,6 +51,8 @@ pub struct InProcessBuilderConfig {
     pub p2p_port: Option<u16>,
     /// Optional fixed Flashblocks port (uses random if None).
     pub flashblocks_port: Option<u16>,
+    /// Optional shadow canary ExEx configuration.
+    pub shadow_canary: Option<ShadowCanaryConfig>,
 }
 
 /// An in-process builder node that replaces Docker-based `BuilderContainer`.
@@ -138,7 +142,7 @@ impl InProcessBuilder {
         let node_config = create_node_config(chain_spec, &data_path, &jwt_path, &config)?;
         let p2p_port = node_config.network.port;
 
-        let node_builder = NodeBuilder::new(node_config.clone())
+        let mut node_builder = NodeBuilder::new(node_config.clone())
             .with_database(db)
             .with_launch_context(runtime.clone())
             .with_types::<BaseNode>()
@@ -157,8 +161,22 @@ impl InProcessBuilder {
                 Ok(())
             });
 
+        let mut shadow_writer = None;
+        if let Some(config) = config.shadow_canary.clone().filter(|cfg| cfg.enabled) {
+            let (tx, rx) = mpsc::channel(1024);
+            let db = config.db.clone();
+            let builder_version = config.builder_version.clone();
+            node_builder = node_builder
+                .install_exex("shadow-canary", move |ctx| async move { Ok(run_exex(ctx, tx)) });
+            shadow_writer = Some((rx, db, builder_version));
+        }
+
         let NodeHandle { node: node_handle, node_exit_future } =
             node_builder.launch().await.wrap_err("Failed to launch builder node")?;
+
+        if let Some((rx, db, builder_version)) = shadow_writer {
+            spawn_writer(node_handle.task_executor.clone(), rx, db, builder_version);
+        }
 
         let http_api_addr = node_handle
             .rpc_server_handle()

--- a/etc/systems/src/l2/in_process_client.rs
+++ b/etc/systems/src/l2/in_process_client.rs
@@ -12,6 +12,7 @@ use base_flashblocks::FlashblocksConfig;
 use base_flashblocks_node::FlashblocksExtension;
 use base_node_core::args::RollupArgs;
 use base_node_runner::{BaseNode, BaseNodeExtension, FromExtensionConfig, NodeHooks};
+use base_shadow_canary::{ShadowCanaryConfig, ShadowCanaryExtension};
 use base_tx_forwarding::{TxForwardingConfig, TxForwardingExtension};
 use base_txpool_rpc::{TxPoolRpcConfig, TxPoolRpcExtension};
 use base_txpool_tracing::{TxPoolExtension, TxpoolConfig};
@@ -53,6 +54,8 @@ pub struct InProcessClientConfig {
     /// Optional transaction forwarding configuration.
     /// When set, the client will forward transactions to builder RPC endpoints.
     pub tx_forwarding_config: Option<TxForwardingConfig>,
+    /// Optional shadow canary ExEx configuration.
+    pub shadow_canary: Option<ShadowCanaryConfig>,
 }
 
 /// In-process Base client node that syncs from a builder.
@@ -269,6 +272,10 @@ impl InProcessClient {
         // TxForwarding extension (optional - forwards txs to builder RPC)
         if let Some(ref tx_fwd_config) = config.tx_forwarding_config {
             extensions.push(Box::new(TxForwardingExtension::from_config(tx_fwd_config.clone())));
+        }
+
+        if let Some(config) = config.shadow_canary.clone().filter(|cfg| cfg.enabled) {
+            extensions.push(Box::new(ShadowCanaryExtension::from_config(config)));
         }
 
         // Flashblocks extension (must be last - uses replace_configured)

--- a/etc/systems/src/l2/in_process_consensus.rs
+++ b/etc/systems/src/l2/in_process_consensus.rs
@@ -20,6 +20,7 @@ use base_common_genesis::RollupConfig;
 use base_consensus_disc::LocalNode;
 use base_consensus_node::{
     EngineConfig, L1ConfigBuilder, NetworkConfig, NodeMode, RollupNodeBuilder, SequencerConfig,
+    ShadowDriveConfig,
 };
 use base_consensus_peers::{PeerScoreLevel, SecretKeyLoader};
 use base_consensus_rpc::{AdminApiClient, BaseP2PApiClient, RollupNodeApiClient, RpcBuilder};
@@ -52,7 +53,7 @@ pub struct InProcessConsensusConfig {
     pub l1_beacon_url: Url,
     /// L2 engine API URL (builder or client).
     pub l2_engine_url: Url,
-    /// Node mode (Sequencer or Validator).
+    /// Node mode (Sequencer, Validator, or ShadowDrive).
     pub mode: NodeMode,
     /// Sequencer signing key (required for Sequencer mode).
     pub sequencer_key: Option<B256>,
@@ -72,6 +73,8 @@ pub struct InProcessConsensusConfig {
     pub sequencer_stopped: bool,
     /// Number of L1 blocks to keep distance from the L1 head for the verifier.
     pub verifier_l1_confs: u64,
+    /// Optional shadow-drive configuration.
+    pub shadow_drive_config: Option<ShadowDriveConfig>,
 }
 
 /// A running in-process consensus node.
@@ -189,7 +192,8 @@ impl InProcessConsensus {
             net_config,
             Some(rpc_config),
         )
-        .with_checkpoint_path(checkpoint_path);
+        .with_checkpoint_path(checkpoint_path)
+        .with_shadow_drive_config(config.shadow_drive_config);
 
         if config.mode == NodeMode::Sequencer {
             builder = builder.with_sequencer_config(SequencerConfig {

--- a/etc/systems/src/l2/stack.rs
+++ b/etc/systems/src/l2/stack.rs
@@ -285,12 +285,12 @@ impl L2Stack {
                 L2ClientConsensus::Follow(client_consensus)
             }
             L2ClientConsensusMode::ShadowDrive => {
-                let build_deadline = config.shadow_drive_build_deadline.ok_or_else(|| {
-                    eyre::eyre!("shadow drive build deadline is required")
-                })?;
-                let max_reorg_depth = config.shadow_drive_max_reorg_depth.ok_or_else(|| {
-                    eyre::eyre!("shadow drive max reorg depth is required")
-                })?;
+                let build_deadline = config
+                    .shadow_drive_build_deadline
+                    .ok_or_else(|| eyre::eyre!("shadow drive build deadline is required"))?;
+                let max_reorg_depth = config
+                    .shadow_drive_max_reorg_depth
+                    .ok_or_else(|| eyre::eyre!("shadow drive max reorg depth is required"))?;
                 let shadow_drive_config = ShadowDriveConfig {
                     source_l2_rpc: builder.rpc_url()?,
                     build_deadline,

--- a/etc/systems/src/l2/stack.rs
+++ b/etc/systems/src/l2/stack.rs
@@ -12,7 +12,8 @@ use alloy_genesis::ChainConfig;
 use alloy_primitives::B256;
 use alloy_rpc_types_engine::JwtSecret;
 use base_common_genesis::RollupConfig;
-use base_consensus_node::NodeMode;
+use base_consensus_node::{NodeMode, ShadowDriveConfig};
+use base_shadow_canary::ShadowCanaryConfig;
 use base_tx_forwarding::TxForwardingConfig;
 use eyre::{Result, WrapErr};
 use url::Url;
@@ -32,6 +33,8 @@ pub enum L2ClientConsensusMode {
     Validator,
     /// Run the client consensus node in follow mode against the builder RPC.
     Follow,
+    /// Run the client consensus node in shadow-drive mode against the builder RPC.
+    ShadowDrive,
 }
 
 /// Configuration for the L2 stack.
@@ -65,6 +68,12 @@ pub struct L2StackConfig {
     pub verifier_l1_confs: u64,
     /// Consensus mode for the L2 client node.
     pub client_consensus_mode: L2ClientConsensusMode,
+    /// Shadow-drive build deadline (only used when `client_consensus_mode` is ShadowDrive).
+    pub shadow_drive_build_deadline: Option<Duration>,
+    /// Shadow-drive max reorg depth (only used when `client_consensus_mode` is ShadowDrive).
+    pub shadow_drive_max_reorg_depth: Option<u64>,
+    /// Optional shadow canary ExEx configuration for the client node.
+    pub shadow_canary_config: Option<ShadowCanaryConfig>,
 }
 
 /// Running L2 client consensus node.
@@ -74,6 +83,8 @@ pub enum L2ClientConsensus {
     Validator(InProcessConsensus),
     /// Follow-mode consensus node.
     Follow(InProcessFollowConsensus),
+    /// Shadow-drive consensus node.
+    ShadowDrive(InProcessConsensus),
 }
 
 impl L2ClientConsensus {
@@ -82,6 +93,7 @@ impl L2ClientConsensus {
         match self {
             Self::Validator(consensus) => consensus.rpc_url(),
             Self::Follow(consensus) => consensus.rpc_url(),
+            Self::ShadowDrive(consensus) => consensus.rpc_url(),
         }
     }
 }
@@ -146,6 +158,7 @@ impl L2Stack {
             auth_port: container_config.and_then(|c| c.builder_auth_port),
             p2p_port: container_config.and_then(|c| c.builder_p2p_port),
             flashblocks_port: container_config.and_then(|c| c.builder_flashblocks_port),
+            shadow_canary: None,
         };
         let builder = InProcessBuilder::start(builder_config)
             .await
@@ -172,6 +185,7 @@ impl L2Stack {
             l1_slot_duration_override: Some(4),
             sequencer_stopped: true,
             verifier_l1_confs: 0,
+            shadow_drive_config: None,
         };
         let builder_consensus = InProcessConsensus::start(builder_consensus_config)
             .await
@@ -212,6 +226,7 @@ impl L2Stack {
             auth_port: container_config.and_then(|c| c.client_auth_port),
             p2p_port: container_config.and_then(|c| c.client_p2p_port),
             tx_forwarding_config,
+            shadow_canary: config.shadow_canary_config.clone(),
         };
         let client = InProcessClient::start(client_config)
             .await
@@ -237,6 +252,7 @@ impl L2Stack {
                     l1_slot_duration_override: Some(4),
                     sequencer_stopped: false,
                     verifier_l1_confs: config.verifier_l1_confs,
+                    shadow_drive_config: None,
                 };
                 let client_consensus = InProcessConsensus::start(client_consensus_config)
                     .await
@@ -267,6 +283,42 @@ impl L2Stack {
                     .await
                     .wrap_err("Failed to start follow client consensus")?;
                 L2ClientConsensus::Follow(client_consensus)
+            }
+            L2ClientConsensusMode::ShadowDrive => {
+                let build_deadline = config.shadow_drive_build_deadline.ok_or_else(|| {
+                    eyre::eyre!("shadow drive build deadline is required")
+                })?;
+                let max_reorg_depth = config.shadow_drive_max_reorg_depth.ok_or_else(|| {
+                    eyre::eyre!("shadow drive max reorg depth is required")
+                })?;
+                let shadow_drive_config = ShadowDriveConfig {
+                    source_l2_rpc: builder.rpc_url()?,
+                    build_deadline,
+                    max_reorg_depth,
+                };
+                let client_consensus_config = InProcessConsensusConfig {
+                    rollup_config,
+                    l1_chain_config,
+                    jwt_secret: config.jwt_secret,
+                    l1_rpc_url,
+                    l1_beacon_url,
+                    l2_engine_url: client.engine_url()?,
+                    mode: NodeMode::ShadowDrive,
+                    sequencer_key: None,
+                    p2p_key: None,
+                    rpc_port: container_config.and_then(|c| c.client_consensus_rpc_port),
+                    p2p_tcp_port: container_config.and_then(|c| c.client_consensus_p2p_tcp_port),
+                    p2p_udp_port: container_config.and_then(|c| c.client_consensus_p2p_udp_port),
+                    unsafe_block_signer: SEQUENCER.address,
+                    l1_slot_duration_override: Some(4),
+                    sequencer_stopped: false,
+                    verifier_l1_confs: config.verifier_l1_confs,
+                    shadow_drive_config: Some(shadow_drive_config),
+                };
+                let client_consensus = InProcessConsensus::start(client_consensus_config)
+                    .await
+                    .wrap_err("Failed to start shadow-drive client consensus")?;
+                L2ClientConsensus::ShadowDrive(client_consensus)
             }
         };
 

--- a/etc/systems/src/smoke.rs
+++ b/etc/systems/src/smoke.rs
@@ -1,12 +1,13 @@
 //! System test stack orchestration and lifecycle management.
 
-use std::path::PathBuf;
+use std::{path::PathBuf, time::Duration};
 
 use alloy_network::Ethereum;
 use alloy_provider::RootProvider;
 use alloy_rpc_client::RpcClient;
 use alloy_rpc_types_engine::JwtSecret;
 use base_common_network::Base;
+use base_shadow_canary::ShadowCanaryConfig;
 use base_tx_forwarding::TxForwardingConfig;
 use eyre::{Result, WrapErr};
 use tempfile::TempDir;
@@ -109,6 +110,13 @@ impl SystemTestStack {
         Ok(RootProvider::<Base>::new(client))
     }
 
+    /// Returns an L2 shadow-drive provider with Base network.
+    pub fn l2_shadow_drive_provider(&self) -> Result<RootProvider<Base>> {
+        let url = self.l2_client_rpc_url()?;
+        let client = RpcClient::builder().http(url);
+        Ok(RootProvider::<Base>::new(client))
+    }
+
     /// Returns all RPC URLs for this system test stack.
     pub async fn urls(&self) -> Result<crate::SystemTestUrls> {
         Ok(crate::SystemTestUrls {
@@ -136,6 +144,9 @@ pub struct SystemTestStackBuilder {
     tx_forwarding_config: Option<TxForwardingConfig>,
     verifier_l1_confs: u64,
     client_consensus_mode: L2ClientConsensusMode,
+    shadow_drive_build_deadline: Option<Duration>,
+    shadow_drive_max_reorg_depth: Option<u64>,
+    shadow_canary_config: Option<ShadowCanaryConfig>,
 }
 
 impl SystemTestStackBuilder {
@@ -216,6 +227,24 @@ impl SystemTestStackBuilder {
     /// Runs the L2 client consensus node in follow mode against the builder RPC.
     pub const fn with_follow_mode_client_consensus(mut self) -> Self {
         self.client_consensus_mode = L2ClientConsensusMode::Follow;
+        self
+    }
+
+    /// Runs the L2 client consensus node in shadow-drive mode against the builder RPC.
+    pub fn with_shadow_drive_client_consensus(
+        mut self,
+        build_deadline_ms: u64,
+        max_reorg_depth: u64,
+    ) -> Self {
+        self.client_consensus_mode = L2ClientConsensusMode::ShadowDrive;
+        self.shadow_drive_build_deadline = Some(Duration::from_millis(build_deadline_ms));
+        self.shadow_drive_max_reorg_depth = Some(max_reorg_depth);
+        self
+    }
+
+    /// Configures the shadow canary ExEx for the L2 client node.
+    pub fn with_shadow_canary_config(mut self, config: ShadowCanaryConfig) -> Self {
+        self.shadow_canary_config = Some(config);
         self
     }
 
@@ -335,6 +364,9 @@ impl SystemTestStackBuilder {
             tx_forwarding_config: self.tx_forwarding_config,
             verifier_l1_confs: self.verifier_l1_confs,
             client_consensus_mode: self.client_consensus_mode,
+            shadow_drive_build_deadline: self.shadow_drive_build_deadline,
+            shadow_drive_max_reorg_depth: self.shadow_drive_max_reorg_depth,
+            shadow_canary_config: self.shadow_canary_config,
         };
 
         let l2_stack = L2Stack::start(l2_config).await.wrap_err("Failed to start L2 stack")?;

--- a/etc/systems/tests/shadow_builder.rs
+++ b/etc/systems/tests/shadow_builder.rs
@@ -1,0 +1,357 @@
+//! Shadow builder canary: system-test primitives for the two release-canary
+//! failure classes.
+//!
+//! - Validity: a follow-mode client must re-execute every block from the
+//!   sequencer's combined builder to identical block hashes.
+//! - Liveness (primary "would halt the chain" signal): the combined builder must
+//!   keep producing blocks at slot cadence without stalling.
+//!
+//! The ExEx-based block-capture canary is exercised in `shadow_s6_reorg_capture`,
+//! which drives a shadow-drive client and asserts end-to-end reorg capture.
+
+use std::{collections::BTreeMap, time::Duration};
+
+use alloy_eips::BlockNumberOrTag;
+use alloy_provider::{Provider, RootProvider};
+use base_common_network::Base;
+use base_shadow_canary::ShadowCanaryConfig;
+use base_shadow_canary_db::{ShadowBlockRepo, ShadowDbConfig, ShadowBlockRow};
+use base_system_tests::SystemTestStackBuilder;
+use eyre::{Result, WrapErr};
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+use tokio::time::{sleep, timeout};
+
+const L1_CHAIN_ID: u64 = 1337;
+const L2_CHAIN_ID: u64 = 84538453;
+const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(30);
+const FOLLOWER_SYNC_TIMEOUT: Duration = Duration::from_secs(60);
+const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+const TARGET_BUILDER_BLOCK: u64 = 5;
+const PARITY_BLOCKS: u64 = 3;
+
+const LIVENESS_OBSERVE_BLOCKS: u64 = 5;
+const MAX_BLOCK_STALL: Duration = Duration::from_secs(15);
+const CADENCE_BLOCKS: u64 = 4;
+const MAX_TS_GAP_SECS: u64 = 8;
+
+const SHADOW_DRIVE_BUILD_DEADLINE_MS: u64 = 2000;
+const SHADOW_DRIVE_MAX_REORG_DEPTH: u64 = 1;
+
+static SHADOW_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+#[tokio::test]
+async fn shadow_builder_follow_mode_block_parity() -> Result<()> {
+    let _guard = SHADOW_TEST_LOCK.lock().await;
+    base_node_runner::test_utils::init_silenced_tracing();
+
+    let system = SystemTestStackBuilder::new()
+        .with_l1_chain_id(L1_CHAIN_ID)
+        .with_l2_chain_id(L2_CHAIN_ID)
+        .with_follow_mode_client_consensus()
+        .build()
+        .await?;
+
+    let builder_provider = system.l2_builder_provider()?;
+    let follower_provider = system.l2_client_provider()?;
+
+    wait_for_block(&builder_provider, TARGET_BUILDER_BLOCK)
+        .await
+        .wrap_err("builder block production timed out")?;
+
+    wait_for_block_with_timeout(&follower_provider, PARITY_BLOCKS, FOLLOWER_SYNC_TIMEOUT)
+        .await
+        .wrap_err("follow-mode client failed to sync")?;
+
+    for number in 1..=PARITY_BLOCKS {
+        let builder_hash = block_hash(&builder_provider, number)
+            .await
+            .wrap_err_with(|| format!("missing builder block {number}"))?;
+        let follower_hash = block_hash(&follower_provider, number)
+            .await
+            .wrap_err_with(|| format!("missing follower block {number}"))?;
+
+        assert_eq!(
+            builder_hash, follower_hash,
+            "block {number} hash diverged between builder and follow-mode client"
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn shadow_builder_block_production_liveness() -> Result<()> {
+    let _guard = SHADOW_TEST_LOCK.lock().await;
+    base_node_runner::test_utils::init_silenced_tracing();
+
+    let system = SystemTestStackBuilder::new()
+        .with_l1_chain_id(L1_CHAIN_ID)
+        .with_l2_chain_id(L2_CHAIN_ID)
+        .build()
+        .await?;
+
+    let builder_provider = system.l2_builder_provider()?;
+
+    let mut last_block = wait_for_block(&builder_provider, 1).await?;
+    let mut last_advance = tokio::time::Instant::now();
+    let mut observed = 0u64;
+
+    while observed < LIVENESS_OBSERVE_BLOCKS {
+        let stalled_for = last_advance.elapsed();
+        assert!(
+            stalled_for < MAX_BLOCK_STALL,
+            "builder stalled for {stalled_for:?} at block {last_block}"
+        );
+
+        let current = builder_provider.get_block_number().await?;
+        if current > last_block {
+            observed += current - last_block;
+            last_block = current;
+            last_advance = tokio::time::Instant::now();
+        } else {
+            sleep(BLOCK_POLL_INTERVAL).await;
+        }
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn shadow_builder_block_timestamp_cadence() -> Result<()> {
+    let _guard = SHADOW_TEST_LOCK.lock().await;
+    base_node_runner::test_utils::init_silenced_tracing();
+
+    let system = SystemTestStackBuilder::new()
+        .with_l1_chain_id(L1_CHAIN_ID)
+        .with_l2_chain_id(L2_CHAIN_ID)
+        .build()
+        .await?;
+
+    let builder_provider = system.l2_builder_provider()?;
+    wait_for_block(&builder_provider, CADENCE_BLOCKS).await?;
+
+    let mut prev_ts: Option<u64> = None;
+    for number in 1..=CADENCE_BLOCKS {
+        let ts = block_timestamp(&builder_provider, number)
+            .await
+            .wrap_err_with(|| format!("missing builder block {number}"))?;
+
+        if let Some(prev) = prev_ts {
+            assert!(ts > prev, "block {number} timestamp {ts} did not advance past {prev}");
+            let delta = ts - prev;
+            assert!(
+                delta <= MAX_TS_GAP_SECS,
+                "block {number} cadence gap {delta}s exceeds {MAX_TS_GAP_SECS}s"
+            );
+        }
+        prev_ts = Some(ts);
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn shadow_s6_reorg_capture() -> Result<()> {
+    let _guard = SHADOW_TEST_LOCK.lock().await;
+    base_node_runner::test_utils::init_silenced_tracing();
+
+    let container = Postgres::default().start().await?;
+    let port = container.get_host_port_ipv4(5432).await?;
+    let database_url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
+
+    let db_config = ShadowDbConfig {
+        url: database_url,
+        max_connections: 5,
+        connection_timeout: Duration::from_secs(5),
+    };
+    let pool = db_config
+        .init_pool()
+        .await
+        .map_err(|error| eyre::eyre!(error))?;
+    let repo = ShadowBlockRepo::new(pool);
+
+    let system = SystemTestStackBuilder::new()
+        .with_l1_chain_id(L1_CHAIN_ID)
+        .with_l2_chain_id(L2_CHAIN_ID)
+        .with_shadow_canary_config(ShadowCanaryConfig {
+            enabled: true,
+            db: db_config.clone(),
+            builder_version: "shadow-drive-system-test".to_string(),
+        })
+        .with_shadow_drive_client_consensus(
+            SHADOW_DRIVE_BUILD_DEADLINE_MS,
+            SHADOW_DRIVE_MAX_REORG_DEPTH,
+        )
+        .build()
+        .await?;
+
+    let builder_provider = system.l2_builder_provider()?;
+    let shadow_provider = system.l2_shadow_drive_provider()?;
+
+    let builder_tip = wait_for_block(&builder_provider, TARGET_BUILDER_BLOCK)
+        .await
+        .wrap_err("builder block production timed out")?;
+
+    let observe_start = builder_tip.saturating_sub(PARITY_BLOCKS.saturating_sub(1)).max(1);
+    let observe_end = builder_tip;
+
+    for number in observe_start..=observe_end {
+        wait_for_block_with_timeout(&shadow_provider, number, FOLLOWER_SYNC_TIMEOUT)
+            .await
+            .wrap_err_with(|| format!("shadow-drive client did not reach block {number}"))?;
+        wait_for_shadow_match(&builder_provider, &shadow_provider, number)
+            .await
+            .wrap_err_with(|| format!("shadow-drive head drifted at block {number}"))?;
+    }
+
+    let shadow_rows = wait_for_shadow_rows(
+        &repo,
+        i64::try_from(observe_start)?,
+        i64::try_from(observe_end)?,
+    )
+    .await?;
+
+    let mut reorged_numbers = Vec::new();
+    for row in &shadow_rows {
+        if row.reorged_out {
+            reorged_numbers.push(row.number);
+        }
+    }
+    reorged_numbers.sort();
+    reorged_numbers.dedup();
+
+    assert!(
+        !reorged_numbers.is_empty(),
+        "expected at least one reorged-out shadow row in observed range"
+    );
+
+    for number_i64 in reorged_numbers {
+        let number = u64::try_from(number_i64)?;
+        let builder_hash = block_hash(&builder_provider, number)
+            .await
+            .wrap_err_with(|| format!("missing builder block {number}"))?
+            .to_string();
+
+        let reorged_row = shadow_rows.iter().find(|row| {
+            row.number == number_i64
+                && row.reorged_out
+                && row.canonical_hash.as_deref() == Some(builder_hash.as_str())
+        });
+        assert!(
+            reorged_row.is_some(),
+            "missing reorged-out shadow row with canonical hash at block {number}"
+        );
+
+        let candidate_row = shadow_rows
+            .iter()
+            .find(|row| row.number == number_i64 && !row.reorged_out);
+        assert!(
+            candidate_row.is_some(),
+            "missing committed shadow candidate row at block {number}"
+        );
+    }
+
+    Ok(())
+}
+
+async fn wait_for_block(provider: &RootProvider<Base>, min_block: u64) -> Result<u64> {
+    wait_for_block_with_timeout(provider, min_block, BLOCK_PRODUCTION_TIMEOUT).await
+}
+
+async fn wait_for_block_with_timeout(
+    provider: &RootProvider<Base>,
+    min_block: u64,
+    deadline: Duration,
+) -> Result<u64> {
+    timeout(deadline, async {
+        loop {
+            let block = provider.get_block_number().await?;
+            if block >= min_block {
+                return Ok::<_, eyre::Error>(block);
+            }
+            sleep(BLOCK_POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .wrap_err("block production timed out")?
+}
+
+async fn block_hash(provider: &RootProvider<Base>, number: u64) -> Result<alloy_primitives::B256> {
+    let block = provider
+        .get_block_by_number(BlockNumberOrTag::Number(number))
+        .await
+        .wrap_err("failed to fetch block")?
+        .ok_or_else(|| eyre::eyre!("block {number} not found"))?;
+    Ok(block.header.hash_slow())
+}
+
+async fn block_timestamp(provider: &RootProvider<Base>, number: u64) -> Result<u64> {
+    let block = provider
+        .get_block_by_number(BlockNumberOrTag::Number(number))
+        .await
+        .wrap_err("failed to fetch block")?
+        .ok_or_else(|| eyre::eyre!("block {number} not found"))?;
+    Ok(block.header.timestamp)
+}
+
+async fn wait_for_shadow_rows(
+    repo: &ShadowBlockRepo,
+    start: i64,
+    end: i64,
+) -> Result<Vec<ShadowBlockRow>> {
+    timeout(FOLLOWER_SYNC_TIMEOUT, async {
+        loop {
+            let rows = repo
+                .list_by_number_range(start, end)
+                .await
+                .map_err(|error| eyre::eyre!(error))?;
+            if shadow_rows_ready(&rows, start, end) {
+                return Ok::<_, eyre::Error>(rows);
+            }
+            sleep(BLOCK_POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .wrap_err("shadow canary rows did not become ready")?
+}
+
+async fn wait_for_shadow_match(
+    builder: &RootProvider<Base>,
+    shadow: &RootProvider<Base>,
+    number: u64,
+) -> Result<()> {
+    timeout(FOLLOWER_SYNC_TIMEOUT, async {
+        loop {
+            let builder_hash = block_hash(builder, number).await?;
+            let shadow_hash = block_hash(shadow, number).await?;
+            if builder_hash == shadow_hash {
+                return Ok::<_, eyre::Error>(());
+            }
+            sleep(BLOCK_POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .wrap_err("shadow-drive head did not re-anchor to builder")?
+}
+
+fn shadow_rows_ready(rows: &[ShadowBlockRow], start: i64, end: i64) -> bool {
+    let mut readiness: BTreeMap<i64, (bool, bool)> =
+        (start..=end).map(|number| (number, (false, false))).collect();
+
+    for row in rows {
+        if let Some(flags) = readiness.get_mut(&row.number) {
+            if row.reorged_out {
+                flags.0 = true;
+            } else {
+                flags.1 = true;
+            }
+        }
+    }
+
+    let any_reorged = readiness.values().any(|(reorged, _)| *reorged);
+    let any_committed = readiness.values().any(|(_, committed)| *committed);
+
+    any_reorged && any_committed
+}

--- a/etc/systems/tests/shadow_builder.rs
+++ b/etc/systems/tests/shadow_builder.rs
@@ -15,7 +15,7 @@ use alloy_eips::BlockNumberOrTag;
 use alloy_provider::{Provider, RootProvider};
 use base_common_network::Base;
 use base_shadow_canary::ShadowCanaryConfig;
-use base_shadow_canary_db::{ShadowBlockRepo, ShadowDbConfig, ShadowBlockRow};
+use base_shadow_canary_db::{ShadowBlockRepo, ShadowBlockRow, ShadowDbConfig};
 use base_system_tests::SystemTestStackBuilder;
 use eyre::{Result, WrapErr};
 use testcontainers::runners::AsyncRunner;
@@ -166,10 +166,7 @@ async fn shadow_s6_reorg_capture() -> Result<()> {
         max_connections: 5,
         connection_timeout: Duration::from_secs(5),
     };
-    let pool = db_config
-        .init_pool()
-        .await
-        .map_err(|error| eyre::eyre!(error))?;
+    let pool = db_config.init_pool().await.map_err(|error| eyre::eyre!(error))?;
     let repo = ShadowBlockRepo::new(pool);
 
     let system = SystemTestStackBuilder::new()
@@ -206,12 +203,9 @@ async fn shadow_s6_reorg_capture() -> Result<()> {
             .wrap_err_with(|| format!("shadow-drive head drifted at block {number}"))?;
     }
 
-    let shadow_rows = wait_for_shadow_rows(
-        &repo,
-        i64::try_from(observe_start)?,
-        i64::try_from(observe_end)?,
-    )
-    .await?;
+    let shadow_rows =
+        wait_for_shadow_rows(&repo, i64::try_from(observe_start)?, i64::try_from(observe_end)?)
+            .await?;
 
     let mut reorged_numbers = Vec::new();
     for row in &shadow_rows {
@@ -244,9 +238,8 @@ async fn shadow_s6_reorg_capture() -> Result<()> {
             "missing reorged-out shadow row with canonical hash at block {number}"
         );
 
-        let candidate_row = shadow_rows
-            .iter()
-            .find(|row| row.number == number_i64 && !row.reorged_out);
+        let candidate_row =
+            shadow_rows.iter().find(|row| row.number == number_i64 && !row.reorged_out);
         assert!(
             candidate_row.is_some(),
             "missing committed shadow candidate row at block {number}"
@@ -303,10 +296,8 @@ async fn wait_for_shadow_rows(
 ) -> Result<Vec<ShadowBlockRow>> {
     timeout(FOLLOWER_SYNC_TIMEOUT, async {
         loop {
-            let rows = repo
-                .list_by_number_range(start, end)
-                .await
-                .map_err(|error| eyre::eyre!(error))?;
+            let rows =
+                repo.list_by_number_range(start, end).await.map_err(|error| eyre::eyre!(error))?;
             if shadow_rows_ready(&rows, start, end) {
                 return Ok::<_, eyre::Error>(rows);
             }


### PR DESCRIPTION
### What changed? Why?

- **ShadowDrive mode**: candidate builder that builds on the real head every slot, commits the candidate so shadow-canary captures it, then re-anchors back to the real block (bounded reorg depth of 1, single forkchoice authority).
- **shadow-canary CLI flags**: expose the shadow-canary Postgres block-capture pipeline through the standard execution node. Adds optional `--enable-shadow-canary` plus `--shadow-canary.{db-url,max-connections,connection-timeout,builder-version}`, building `ShadowCanaryConfig` via `TryFrom<&ShadowCanaryArgs>` and installing `ShadowCanaryExtension` in the runner. Persistence stays disabled unless enabled, matching the metering/tx-forwarding extension pattern.
- **Fixes** found while hardening the devnet smoke test: an actor-crashing `debug_assert`, a silently-dropped DB write on reorg, a missing canonical-chain row insert, and a rebase compile fix aligning the shadow-drive actor with `main`'s `prepare_payload_attributes` signature.

### Notes to reviewers

- Shadow-canary flags live on `StandardNodeArgs` alongside the other self-gating optional extensions; the extension is installed unconditionally with a disabled config when the flag is off.
- `--shadow-canary.db-url` is required when `--enable-shadow-canary` is set (enforced by clap `requires` and re-validated in `TryFrom`); `builder-version` defaults to the crate version.

### How has it been tested?

- `cargo test -p base-execution-cli shadow_canary` (7 tests: flag parsing, `requires` enforcement, config construction/validation, builder-version default)
- `cargo clippy -p base-execution-cli --all-targets`
- devnet shadow_builder system test
