### PR TITLE
fix(zk-backend): return on-chain SP1 seal bytes for SNARK downloads

### DIFF
--- a/crates/proof/zk/backend/src/succinct/cluster.rs
+++ b/crates/proof/zk/backend/src/succinct/cluster.rs
@@ -936,8 +936,10 @@ impl ZkProver for ClusterZkProver {
         // SNARK clients need the on-chain seal (`proof.bytes()`), not a bincode receipt.
         let proof = match session_type {
             SessionType::Snark => proof.bytes(),
-            SessionType::Stark => bincode::serde::encode_to_vec(&proof, bincode::config::standard())
-                .map_err(|e| backend_error!("failed to serialize proof: {e}"))?,
+            SessionType::Stark => {
+                bincode::serde::encode_to_vec(&proof, bincode::config::standard())
+                    .map_err(|e| backend_error!("failed to serialize proof: {e}"))?
+            }
         };
         let proof = ZkProofResult { zk_vm: ZkVm::Sp1, proof: proof.into(), execution_stats: None };
         match session_type {

--- a/crates/proof/zk/backend/src/succinct/cluster.rs
+++ b/crates/proof/zk/backend/src/succinct/cluster.rs
@@ -933,9 +933,7 @@ impl ZkProver for ClusterZkProver {
         }
 
         let proof = self.download_cluster_proof(&session).await?;
-        let proof = bincode::serde::encode_to_vec(&proof, bincode::config::standard())
-            .map_err(|e| backend_error!("failed to serialize proof: {e}"))?;
-
+        let proof = super::encode_downloaded_proof(&proof, session_type)?;
         let proof = ZkProofResult { zk_vm: ZkVm::Sp1, proof: proof.into(), execution_stats: None };
         match session_type {
             SessionType::Snark => Ok(ProofResult::SnarkPlonk(SnarkPlonkProofResult { proof })),

--- a/crates/proof/zk/backend/src/succinct/cluster.rs
+++ b/crates/proof/zk/backend/src/succinct/cluster.rs
@@ -933,7 +933,12 @@ impl ZkProver for ClusterZkProver {
         }
 
         let proof = self.download_cluster_proof(&session).await?;
-        let proof = super::encode_downloaded_proof(&proof, session_type)?;
+        // SNARK clients need the on-chain seal (`proof.bytes()`), not a bincode receipt.
+        let proof = match session_type {
+            SessionType::Snark => proof.bytes(),
+            SessionType::Stark => bincode::serde::encode_to_vec(&proof, bincode::config::standard())
+                .map_err(|e| backend_error!("failed to serialize proof: {e}"))?,
+        };
         let proof = ZkProofResult { zk_vm: ZkVm::Sp1, proof: proof.into(), execution_stats: None };
         match session_type {
             SessionType::Snark => Ok(ProofResult::SnarkPlonk(SnarkPlonkProofResult { proof })),

--- a/crates/proof/zk/backend/src/succinct/mod.rs
+++ b/crates/proof/zk/backend/src/succinct/mod.rs
@@ -3,6 +3,10 @@
 //! Each backend implements [`base_proof_zk_host::ZkProver`] for a different SP1
 //! execution target.
 
+use base_proof_zk_host::ZkProverError;
+use base_prover_service_protocol::SessionType;
+use sp1_sdk::SP1ProofWithPublicValues;
+
 mod provider;
 pub use provider::{L1HeadSource, OpSuccinctWitnessProvider, WitnessError, WitnessParams};
 
@@ -22,3 +26,67 @@ pub use network::{NetworkZkProver, NetworkZkProverConfig, SuccinctNetworkBackend
 
 mod dry_run;
 pub use dry_run::{DRY_RUN_SNARK_PREFIX, DRY_RUN_STARK_PREFIX, DryRunZkProver};
+
+/// Encode a downloaded SP1 proof for prover-service clients.
+///
+/// SNARK/PLONK results must use [`SP1ProofWithPublicValues::bytes`] — the on-chain seal that
+/// starts with the SP1 verifier selector. Bincode of the full receipt is not verifiable by
+/// `SP1VerifierGateway` and surfaces as `RouteNotFound` on challenge submission.
+///
+/// Compressed/STARK results keep the full bincode receipt for downstream aggregation.
+fn encode_downloaded_proof(
+    proof: &SP1ProofWithPublicValues,
+    session_type: SessionType,
+) -> Result<Vec<u8>, ZkProverError> {
+    match session_type {
+        SessionType::Snark => Ok(proof.bytes()),
+        SessionType::Stark => bincode::serde::encode_to_vec(proof, bincode::config::standard())
+            .map_err(|e| {
+                ZkProverError::Backend(
+                    std::io::Error::other(format!("failed to serialize compressed proof: {e}"))
+                        .into(),
+                )
+            }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base_prover_service_protocol::SessionType;
+    use sp1_sdk::{SP1Proof, SP1ProofWithPublicValues, SP1PublicValues};
+
+    use super::encode_downloaded_proof;
+
+    /// Minimal PLONK proof shape: `bytes()` = vkey_hash[:4] || hex_decode(encoded_proof).
+    fn plonk_proof(selector: [u8; 4], encoded_proof_hex: &str) -> SP1ProofWithPublicValues {
+        let mut plonk_vkey_hash = [0u8; 32];
+        plonk_vkey_hash[..4].copy_from_slice(&selector);
+        // SP1Proof::Plonk payload is constructed via Default + field overrides so we do not
+        // depend on sp1-verifier's PlonkBn254Proof type being re-exported from sp1-sdk.
+        let mut proof = SP1ProofWithPublicValues {
+            proof: SP1Proof::Plonk(Default::default()),
+            public_values: SP1PublicValues::new(),
+            sp1_version: "test".to_owned(),
+            tee_proof: None,
+        };
+        match &mut proof.proof {
+            SP1Proof::Plonk(plonk) => {
+                plonk.encoded_proof = encoded_proof_hex.to_owned();
+                plonk.plonk_vkey_hash = plonk_vkey_hash;
+            }
+            _ => unreachable!(),
+        }
+        proof
+    }
+
+    #[test]
+    fn snark_download_uses_onchain_seal_not_bincode() {
+        let proof = plonk_proof([0x5a, 0x09, 0x3a, 0x2f], "abcd");
+        let snark = encode_downloaded_proof(&proof, SessionType::Snark).expect("snark encode");
+        assert_eq!(snark, [0x5a, 0x09, 0x3a, 0x2f, 0xab, 0xcd]);
+
+        let stark = encode_downloaded_proof(&proof, SessionType::Stark).expect("stark encode");
+        assert_ne!(stark, snark, "compressed path must not return the on-chain seal encoding");
+        assert_ne!(&stark[..4], &[0x5a, 0x09, 0x3a, 0x2f]);
+    }
+}

--- a/crates/proof/zk/backend/src/succinct/mod.rs
+++ b/crates/proof/zk/backend/src/succinct/mod.rs
@@ -3,10 +3,6 @@
 //! Each backend implements [`base_proof_zk_host::ZkProver`] for a different SP1
 //! execution target.
 
-use base_proof_zk_host::ZkProverError;
-use base_prover_service_protocol::SessionType;
-use sp1_sdk::SP1ProofWithPublicValues;
-
 mod provider;
 pub use provider::{L1HeadSource, OpSuccinctWitnessProvider, WitnessError, WitnessParams};
 
@@ -26,67 +22,3 @@ pub use network::{NetworkZkProver, NetworkZkProverConfig, SuccinctNetworkBackend
 
 mod dry_run;
 pub use dry_run::{DRY_RUN_SNARK_PREFIX, DRY_RUN_STARK_PREFIX, DryRunZkProver};
-
-/// Encode a downloaded SP1 proof for prover-service clients.
-///
-/// SNARK/PLONK results must use [`SP1ProofWithPublicValues::bytes`] — the on-chain seal that
-/// starts with the SP1 verifier selector. Bincode of the full receipt is not verifiable by
-/// `SP1VerifierGateway` and surfaces as `RouteNotFound` on challenge submission.
-///
-/// Compressed/STARK results keep the full bincode receipt for downstream aggregation.
-fn encode_downloaded_proof(
-    proof: &SP1ProofWithPublicValues,
-    session_type: SessionType,
-) -> Result<Vec<u8>, ZkProverError> {
-    match session_type {
-        SessionType::Snark => Ok(proof.bytes()),
-        SessionType::Stark => bincode::serde::encode_to_vec(proof, bincode::config::standard())
-            .map_err(|e| {
-                ZkProverError::Backend(
-                    std::io::Error::other(format!("failed to serialize compressed proof: {e}"))
-                        .into(),
-                )
-            }),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use base_prover_service_protocol::SessionType;
-    use sp1_sdk::{SP1Proof, SP1ProofWithPublicValues, SP1PublicValues};
-
-    use super::encode_downloaded_proof;
-
-    /// Minimal PLONK proof shape: `bytes()` = vkey_hash[:4] || hex_decode(encoded_proof).
-    fn plonk_proof(selector: [u8; 4], encoded_proof_hex: &str) -> SP1ProofWithPublicValues {
-        let mut plonk_vkey_hash = [0u8; 32];
-        plonk_vkey_hash[..4].copy_from_slice(&selector);
-        // SP1Proof::Plonk payload is constructed via Default + field overrides so we do not
-        // depend on sp1-verifier's PlonkBn254Proof type being re-exported from sp1-sdk.
-        let mut proof = SP1ProofWithPublicValues {
-            proof: SP1Proof::Plonk(Default::default()),
-            public_values: SP1PublicValues::new(),
-            sp1_version: "test".to_owned(),
-            tee_proof: None,
-        };
-        match &mut proof.proof {
-            SP1Proof::Plonk(plonk) => {
-                plonk.encoded_proof = encoded_proof_hex.to_owned();
-                plonk.plonk_vkey_hash = plonk_vkey_hash;
-            }
-            _ => unreachable!(),
-        }
-        proof
-    }
-
-    #[test]
-    fn snark_download_uses_onchain_seal_not_bincode() {
-        let proof = plonk_proof([0x5a, 0x09, 0x3a, 0x2f], "abcd");
-        let snark = encode_downloaded_proof(&proof, SessionType::Snark).expect("snark encode");
-        assert_eq!(snark, [0x5a, 0x09, 0x3a, 0x2f, 0xab, 0xcd]);
-
-        let stark = encode_downloaded_proof(&proof, SessionType::Stark).expect("stark encode");
-        assert_ne!(stark, snark, "compressed path must not return the on-chain seal encoding");
-        assert_ne!(&stark[..4], &[0x5a, 0x09, 0x3a, 0x2f]);
-    }
-}

--- a/crates/proof/zk/backend/src/succinct/network.rs
+++ b/crates/proof/zk/backend/src/succinct/network.rs
@@ -3,7 +3,7 @@
 //! This backend ports the old SP1 network range-proof path into the new
 //! stateless worker shape. `submit` generates the range witness and submits it to
 //! the network, `poll` checks the network proof request status, and `download`
-//! fetches and serializes the completed proof for `submitProof`.
+//! fetches the completed proof for `submitProof` (on-chain seal for SNARK, bincode for STARK).
 
 use std::{fmt, sync::Arc, time::Duration};
 
@@ -526,9 +526,7 @@ impl ZkProver for NetworkZkProver {
                 return Err(backend_error!("network proof {backend_session_id} was not found"));
             }
         };
-        let proof = bincode::serde::encode_to_vec(&proof, bincode::config::standard())
-            .map_err(|e| backend_error!("failed to serialize proof: {e}"))?;
-
+        let proof = super::encode_downloaded_proof(&proof, session_type)?;
         let proof = ZkProofResult { zk_vm: ZkVm::Sp1, proof: proof.into(), execution_stats: None };
         match session_type {
             SessionType::Snark => Ok(ProofResult::SnarkPlonk(SnarkPlonkProofResult { proof })),

--- a/crates/proof/zk/backend/src/succinct/network.rs
+++ b/crates/proof/zk/backend/src/succinct/network.rs
@@ -529,8 +529,10 @@ impl ZkProver for NetworkZkProver {
         // SNARK clients need the on-chain seal (`proof.bytes()`), not a bincode receipt.
         let proof = match session_type {
             SessionType::Snark => proof.bytes(),
-            SessionType::Stark => bincode::serde::encode_to_vec(&proof, bincode::config::standard())
-                .map_err(|e| backend_error!("failed to serialize proof: {e}"))?,
+            SessionType::Stark => {
+                bincode::serde::encode_to_vec(&proof, bincode::config::standard())
+                    .map_err(|e| backend_error!("failed to serialize proof: {e}"))?
+            }
         };
         let proof = ZkProofResult { zk_vm: ZkVm::Sp1, proof: proof.into(), execution_stats: None };
         match session_type {

--- a/crates/proof/zk/backend/src/succinct/network.rs
+++ b/crates/proof/zk/backend/src/succinct/network.rs
@@ -3,7 +3,7 @@
 //! This backend ports the old SP1 network range-proof path into the new
 //! stateless worker shape. `submit` generates the range witness and submits it to
 //! the network, `poll` checks the network proof request status, and `download`
-//! fetches the completed proof for `submitProof` (on-chain seal for SNARK, bincode for STARK).
+//! fetches and serializes the completed proof for `submitProof`.
 
 use std::{fmt, sync::Arc, time::Duration};
 
@@ -526,7 +526,12 @@ impl ZkProver for NetworkZkProver {
                 return Err(backend_error!("network proof {backend_session_id} was not found"));
             }
         };
-        let proof = super::encode_downloaded_proof(&proof, session_type)?;
+        // SNARK clients need the on-chain seal (`proof.bytes()`), not a bincode receipt.
+        let proof = match session_type {
+            SessionType::Snark => proof.bytes(),
+            SessionType::Stark => bincode::serde::encode_to_vec(&proof, bincode::config::standard())
+                .map_err(|e| backend_error!("failed to serialize proof: {e}"))?,
+        };
         let proof = ZkProofResult { zk_vm: ZkVm::Sp1, proof: proof.into(), execution_stats: None };
         match session_type {
             SessionType::Snark => Ok(ProofResult::SnarkPlonk(SnarkPlonkProofResult { proof })),


### PR DESCRIPTION
## Summary
- SNARK downloads from the network and cluster SP1 backends now return `SP1ProofWithPublicValues::bytes()` (verifier selector + encoded proof) instead of a bincode receipt.
- Compressed/STARK downloads still use bincode.

Without this, `challenge()` hit `SP1VerifierGateway.RouteNotFound(0x024b3238)` because the gateway treated the bincode prefix as a verifier route selector.