### PR TITLE
refactor(txobs): accept only BASE_TRANSACTION_EVENTS_* for reth

### DIFF
--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -526,9 +526,7 @@ impl TransactionEventEnv {
 }
 
 fn transaction_event_journal_env_enabled() -> bool {
-    env::var("BASE_TRANSACTION_EVENTS_ENABLED")
-        .map(transaction_event_env_bool)
-        .unwrap_or(false)
+    env::var("BASE_TRANSACTION_EVENTS_ENABLED").map(transaction_event_env_bool).unwrap_or(false)
 }
 
 fn transaction_event_env_bool(value: String) -> bool {

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -491,7 +491,7 @@ fn transaction_event_writer_config(
             || {
                 eyre::eyre!(
                     "--enable-transaction-event-journal requires --transaction-event-journal-path \
-                 or BASE_TRANSACTION_EVENTS_PATH/TRANSACTION_EVENTS_PATH"
+                 or BASE_TRANSACTION_EVENTS_PATH"
                 )
             },
         )?;
@@ -517,9 +517,7 @@ impl TransactionEventEnv {
     fn read() -> Self {
         Self {
             enabled: transaction_event_journal_env_enabled(),
-            path: env::var_os("BASE_TRANSACTION_EVENTS_PATH")
-                .or_else(|| env::var_os("TRANSACTION_EVENTS_PATH"))
-                .map(PathBuf::from),
+            path: env::var_os("BASE_TRANSACTION_EVENTS_PATH").map(PathBuf::from),
             network: env::var("BASE_TRANSACTION_EVENTS_NETWORK")
                 .or_else(|_| env::var("BASE_NODE_NETWORK"))
                 .unwrap_or_else(|_| "unknown".to_string()),
@@ -529,7 +527,6 @@ impl TransactionEventEnv {
 
 fn transaction_event_journal_env_enabled() -> bool {
     env::var("BASE_TRANSACTION_EVENTS_ENABLED")
-        .or_else(|_| env::var("TRANSACTION_EVENTS_ENABLED"))
         .map(transaction_event_env_bool)
         .unwrap_or(false)
 }


### PR DESCRIPTION
## Summary
- Drop unprefixed `TRANSACTION_EVENTS_PATH` / `TRANSACTION_EVENTS_ENABLED` fallbacks from the reth transaction-event journal config.
- Keep `BASE_TRANSACTION_EVENTS_PATH` and `BASE_TRANSACTION_EVENTS_ENABLED` so execution matches the existing `BASE_*` env pattern.
- Companion chart change will stop setting the unprefixed alias.

## Test plan
- [ ] Confirm docker-compose ingress still enables the client journal via `BASE_TRANSACTION_EVENTS_*`
- [ ] Confirm private base chart follow-up wires only `BASE_TRANSACTION_EVENTS_PATH`
- [ ] Unit/compile check for `crates/execution/cli` if CI covers it

type=routine
risk=low
impact=sev5