### PR TITLE
ci: publish snapshotter image and fix reth publish on l3

### DIFF
--- a/.github/workflows/docker-l3.yml
+++ b/.github/workflows/docker-l3.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [client, base, builder, consensus, proposer, challenger, batcher, da-server, zk-prover]
+        target: [execution, base, builder, consensus, proposer, challenger, batcher, da-server, snapshotter]
 
     runs-on: ubuntu-24.04
 


### PR DESCRIPTION
## Summary

Fixes the Docker (L3) publish matrix so the L3 devnet gets the two images its snapshot-based persistence needs (PRIV-2063, blocks PRIV-2064):

1. the reth-node image carrying the `download` snapshot-restore subcommand, and
2. a published `snapshotter` image.

The main->l3 merge (`54d208c44`) adopted main's `docker-bake.hcl` target names but left `.github/workflows/docker-l3.yml` stale: it still baked `client` and `zk-prover`, which no longer exist as bake targets. Those jobs now fail on `docker buildx bake`, so the reth-node image stopped publishing after the merge and the mirrored image predates the `download` command.

## Change

One line, the `build-rust-services` matrix:

- `client` -> `execution` (renamed target; both build `base-reth-node`, which now carries the merged `download` subcommand)
- drop `zk-prover` (target gone post-merge; L3 uses nitro/TEE proving, not zk)
- add `snapshotter` (target already present in `docker-bake.hcl`; builds `base-snapshotter-bin`)

Both new targets flow through the existing generic job path (tag `:<target>-sha-<sha>`, retag `:<target>-l3`); no other workflow or bake changes are required.

## Acceptance criteria

- [x] The base-reth image we deploy includes the `download` snapshot-restore subcommand (via the `execution` image; command already merged and wired in `crates/execution/cli/src/commands/mod.rs`).
- [x] A `snapshotter` image is published.
- [ ] Mirrored into the consumer repo the same way as other base images — follow-up in `protocols/privacy-enclave` once this publishes the new tags.

## Verification

After merge to `l3` (or via `workflow_dispatch`), confirm the `execution` and `snapshotter` matrix jobs push `ghcr.io/base/node-reth-dev:{execution,snapshotter}-sha-<sha>` (+ `-l3` tags) and that no `client`/`zk-prover` job remains. Then `docker run --rm ...:execution-sha-<sha> --help` should list `download`.

## Out of scope / follow-ups

- `etc/docker/docker-compose.zk-prover.yml` still has a dangling `target: zk-prover` (pre-existing merge artifact, local-compose helper only, not part of the publish flow).
- Mirror-side changes in `protocols/privacy-enclave` (bump script map `client`->`execution`, drop `zk-prover`, add `mirrors/Dockerfile.snapshotter` + `.codeflow.yml` entry).