### PR TITLE
feat(nitro-prover): record witness size

### DIFF
--- a/crates/proof/host/src/metrics/mod.rs
+++ b/crates/proof/host/src/metrics/mod.rs
@@ -34,6 +34,9 @@ base_metrics::define_metrics! {
     #[describe("Number of preimages captured in the last witness build")]
     preimage_count: gauge,
 
+    #[describe("Size of a witness submitted to a Nitro enclave in bytes")]
+    witness_size_bytes: histogram,
+
     #[describe("End-to-end proof generation duration")]
     proof_duration_seconds: histogram,
 

--- a/crates/proof/tee/nitro-host/src/transport.rs
+++ b/crates/proof/tee/nitro-host/src/transport.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use base_proof_host::Metrics;
 use base_proof_preimage::PreimageKey;
 use base_proof_primitives::ProofResult;
 use base_proof_tee_nitro_enclave::Server;
@@ -37,6 +38,9 @@ impl NitroTransport {
         &self,
         preimages: Vec<(PreimageKey, Vec<u8>)>,
     ) -> Result<ProofResult, NitroHostError> {
+        Metrics::witness_size_bytes()
+            .record(preimages.iter().map(|(_, value)| value.len()).sum::<usize>() as f64);
+
         Ok(match self {
             #[cfg(target_os = "linux")]
             Self::Vsock(t) => t.prove(preimages).await?,


### PR DESCRIPTION
### What changed? Why?

Adds a `base_proof_host.witness_size_bytes` histogram and records the total preimage-value bytes before each Nitro transport submission. This makes enclave witness sizes visible for capacity monitoring.

### Notes to reviewers

The metric is emitted by shared Nitro transport, covering both production vsock and local in-process enclave execution.

### How has it been tested?

- `cargo check -p base-prover-nitro-host --quiet`
- `cargo test -p base-proof-tee-nitro-host --lib --features metrics --quiet`