### PR TITLE
fix(devnet): set base-client transaction event journal path

### DIFF
--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -427,6 +427,7 @@ services:
       - NODE_HEALTHCHECK_HTTP_PORT=${L2_CLIENT_HTTP_PORT}
       - NODE_HEALTHCHECK_CL_RPC_PORT=${L2_CLIENT_CL_RPC_PORT}
       - OTEL_SERVICE_NAME=base-client
+      - BASE_TRANSACTION_EVENTS_PATH=/tmp/base-client-transaction-events.jsonl
     entrypoint: /app/base-entrypoint.sh
     command:
       - rpc


### PR DESCRIPTION

  ## Summary

  Sets `BASE_TRANSACTION_EVENTS_PATH` for `base-client` in devnet so `--enable-transaction-event-journal` has a writable default path.

  This prevents `base-client` from crash-looping on startup while still allowing ingress compose to override the path with its mounted `/var/log/transaction-events/...` location.

  ## Test Plan

  - Reproduced crash on main without the path:
    - `--enable-transaction-event-journal requires --transaction-event-journal-path...`
  - Verified fixed config:
    - `base-client` starts healthy with `restart=0`
    - `/tmp/base-client-transaction-events.jsonl` is created
  - Ran devnet smoke/status successfully after clean startup