### PR TITLE
feat(txobs): size-cap transaction event journal rotation

### DIFF
--- a/crates/builder/cli/src/args.rs
+++ b/crates/builder/cli/src/args.rs
@@ -9,7 +9,8 @@ use base_builder_core::{
 use base_builder_metering::MeteringStore;
 use base_node_core::args::RollupArgs;
 use base_observability_events::{
-    DEFAULT_QUEUE_CAPACITY, TransactionEventProducer, TransactionEventWriterConfig,
+    DEFAULT_MAX_FILE_BYTES, DEFAULT_MAX_FILES, DEFAULT_QUEUE_CAPACITY, TransactionEventProducer,
+    TransactionEventWriterConfig,
 };
 use tracing::warn;
 
@@ -75,6 +76,14 @@ pub struct TransactionEventsArgs {
     #[arg(long = "builder.transaction-events.queue-capacity", env = "BUILDER_TRANSACTION_EVENTS_QUEUE_CAPACITY", default_value_t = DEFAULT_QUEUE_CAPACITY)]
     pub queue_capacity: usize,
 
+    /// Maximum size of an active transaction event JSONL segment.
+    #[arg(long = "builder.transaction-events.max-file-bytes", env = "BUILDER_TRANSACTION_EVENTS_MAX_FILE_BYTES", default_value_t = DEFAULT_MAX_FILE_BYTES)]
+    pub max_file_bytes: u64,
+
+    /// Maximum number of transaction event JSONL segments to retain, including the active file.
+    #[arg(long = "builder.transaction-events.max-files", env = "BUILDER_TRANSACTION_EVENTS_MAX_FILES", default_value_t = DEFAULT_MAX_FILES)]
+    pub max_files: usize,
+
     /// Fail builder startup if the transaction event writer cannot open.
     #[arg(
         long = "builder.transaction-events.required",
@@ -98,6 +107,8 @@ impl Default for TransactionEventsArgs {
             enabled: false,
             file_path: PathBuf::from("/var/log/transaction-events/base-builder/events.jsonl"),
             queue_capacity: DEFAULT_QUEUE_CAPACITY,
+            max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+            max_files: DEFAULT_MAX_FILES,
             required: false,
             network: "unknown".to_string(),
         }
@@ -111,6 +122,8 @@ impl TransactionEventsArgs {
             enabled: self.enabled,
             file_path: self.file_path.clone(),
             queue_capacity: self.queue_capacity,
+            max_file_bytes: self.max_file_bytes,
+            max_files: self.max_files,
             required: self.required,
             producer: TransactionEventProducer::BaseBuilder,
             network: self.network.clone(),

--- a/crates/common/observability-events/src/emit.rs
+++ b/crates/common/observability-events/src/emit.rs
@@ -364,9 +364,9 @@ mod tests {
     use serde_json::{Map, json};
 
     use crate::{
-        DEFAULT_QUEUE_CAPACITY, TransactionEventBuilder, TransactionEventEmitOutcome,
-        TransactionEventProducer, TransactionEventType, TransactionEventWriter,
-        TransactionEventWriterConfig,
+        DEFAULT_MAX_FILE_BYTES, DEFAULT_MAX_FILES, DEFAULT_QUEUE_CAPACITY, TransactionEventBuilder,
+        TransactionEventEmitOutcome, TransactionEventProducer, TransactionEventType,
+        TransactionEventWriter, TransactionEventWriterConfig,
     };
 
     fn disabled_writer() -> TransactionEventWriter {
@@ -374,6 +374,8 @@ mod tests {
             enabled: false,
             file_path: PathBuf::from("/tmp/transaction-events.jsonl"),
             queue_capacity: DEFAULT_QUEUE_CAPACITY,
+            max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+            max_files: DEFAULT_MAX_FILES,
             required: false,
             producer: TransactionEventProducer::BaseRethNode,
             network: "base-devnet".to_string(),

--- a/crates/common/observability-events/src/event.rs
+++ b/crates/common/observability-events/src/event.rs
@@ -11,6 +11,12 @@ pub const SCHEMA_VERSION: &str = "transaction-event/v1";
 /// Default bounded channel capacity for the background writer.
 pub const DEFAULT_QUEUE_CAPACITY: usize = 16_384;
 
+/// Default maximum size of an active transaction event journal segment.
+pub const DEFAULT_MAX_FILE_BYTES: u64 = 128 * 1024 * 1024;
+
+/// Default number of transaction event journal segments to retain, including the active file.
+pub const DEFAULT_MAX_FILES: usize = 8;
+
 const MAX_DATA_VALIDATION_DEPTH: usize = 16;
 
 /// Producer identity for a transaction event.

--- a/crates/common/observability-events/src/writer.rs
+++ b/crates/common/observability-events/src/writer.rs
@@ -1,20 +1,21 @@
 use std::{
     fmt,
-    fs::{File, OpenOptions, create_dir_all},
+    fs::{File, OpenOptions, create_dir_all, read_dir, remove_file, rename},
     io::{self, Write},
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
     },
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use tracing::warn;
 use tracing_appender::non_blocking::{ErrorCounter, NonBlocking, NonBlockingBuilder, WorkerGuard};
 
 use crate::{
-    DEFAULT_QUEUE_CAPACITY, Metrics, TransactionEvent, TransactionEventProducer,
-    TransactionEventValidationError,
+    DEFAULT_MAX_FILE_BYTES, DEFAULT_MAX_FILES, DEFAULT_QUEUE_CAPACITY, Metrics, TransactionEvent,
+    TransactionEventProducer, TransactionEventValidationError,
 };
 
 /// Configuration for the dedicated transaction event JSONL writer.
@@ -26,6 +27,10 @@ pub struct TransactionEventWriterConfig {
     pub file_path: PathBuf,
     /// Bounded queue capacity before producers drop instead of blocking.
     pub queue_capacity: usize,
+    /// Maximum size of one JSONL segment before it is rotated.
+    pub max_file_bytes: u64,
+    /// Maximum number of JSONL segments to retain, including the active file.
+    pub max_files: usize,
     /// If true, initialization errors are returned to the caller.
     pub required: bool,
     /// Producer identity expected for events written through this handle.
@@ -45,6 +50,8 @@ impl TransactionEventWriterConfig {
             enabled: false,
             file_path: file_path.into(),
             queue_capacity: DEFAULT_QUEUE_CAPACITY,
+            max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+            max_files: DEFAULT_MAX_FILES,
             required: false,
             producer,
             network: network.into(),
@@ -126,7 +133,7 @@ impl TransactionEventWriter {
             return Ok(Self::disabled(config));
         }
 
-        let file = open_file(&config);
+        let file = SizeRollingFile::new(&config);
 
         let file = match file {
             Ok(file) => file,
@@ -248,11 +255,165 @@ pub enum WriteEventError {
     Invalid(TransactionEventValidationError),
 }
 
-fn open_file(config: &TransactionEventWriterConfig) -> io::Result<File> {
-    if let Some(parent) = config.file_path.parent() {
+struct SizeRollingFile {
+    file: Option<File>,
+    path: PathBuf,
+    current_size: u64,
+    max_file_bytes: u64,
+    max_files: usize,
+}
+
+impl SizeRollingFile {
+    fn new(config: &TransactionEventWriterConfig) -> io::Result<Self> {
+        let file = open_file(&config.file_path)?;
+        let current_size = file.metadata()?.len();
+
+        Ok(Self {
+            file: Some(file),
+            path: config.file_path.clone(),
+            current_size,
+            max_file_bytes: config.max_file_bytes.max(1),
+            max_files: config.max_files.max(1),
+        })
+    }
+
+    fn should_rotate(&self, incoming_bytes: usize) -> bool {
+        self.current_size > 0
+            && self
+                .current_size
+                .saturating_add(incoming_bytes as u64)
+                > self.max_file_bytes
+    }
+
+    fn rotate(&mut self) -> io::Result<()> {
+        let mut file = self.file.take().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::NotConnected, "transaction event file is closed")
+        })?;
+        if let Err(err) = file.flush() {
+            self.file = Some(file);
+            return Err(err);
+        }
+        drop(file);
+
+        let rotated_path = match self.next_rotated_path() {
+            Ok(path) => path,
+            Err(err) => {
+                self.file = open_file(&self.path).ok();
+                return Err(err);
+            }
+        };
+        if let Err(err) = rename(&self.path, &rotated_path) {
+            self.file = open_file(&self.path).ok();
+            return Err(err);
+        }
+
+        match open_file(&self.path) {
+            Ok(file) => {
+                self.file = Some(file);
+                self.current_size = 0;
+                self.prune_rotated_files()?;
+                Ok(())
+            }
+            Err(err) => {
+                let _ = rename(&rotated_path, &self.path);
+                self.file = open_file(&self.path).ok();
+                Err(err)
+            }
+        }
+    }
+
+    fn next_rotated_path(&self) -> io::Result<PathBuf> {
+        let (parent, stem, extension) = file_name_parts(&self.path)?;
+        let mut timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis();
+
+        loop {
+            let candidate = parent.join(format!("{stem}.{timestamp}.{extension}"));
+            if !candidate.exists() {
+                return Ok(candidate);
+            }
+            timestamp = timestamp.saturating_add(1);
+        }
+    }
+
+    fn prune_rotated_files(&self) -> io::Result<()> {
+        let (parent, stem, extension) = file_name_parts(&self.path)?;
+        let prefix = format!("{stem}.");
+        let suffix = format!(".{extension}");
+        let mut rotated_files = read_dir(parent)?
+            .filter_map(Result::ok)
+            .filter_map(|entry| {
+                let name = entry.file_name().into_string().ok()?;
+                let timestamp = name
+                    .strip_prefix(&prefix)?
+                    .strip_suffix(&suffix)?
+                    .parse::<u128>()
+                    .ok()?;
+                Some((timestamp, name, entry.path()))
+            })
+            .collect::<Vec<_>>();
+
+        rotated_files.sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
+        let keep_rotated = self.max_files.saturating_sub(1);
+        while rotated_files.len() > keep_rotated {
+            let (_, _, path) = rotated_files.remove(0);
+            remove_file(path)?;
+        }
+        Ok(())
+    }
+}
+
+impl Write for SizeRollingFile {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if self.should_rotate(buf.len()) {
+            self.rotate()?;
+        }
+
+        let file = self.file.as_mut().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::NotConnected, "transaction event file is closed")
+        })?;
+        let written = file.write(buf)?;
+        self.current_size = self.current_size.saturating_add(written as u64);
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.file
+            .as_mut()
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::NotConnected, "transaction event file is closed")
+            })?
+            .flush()
+    }
+}
+
+fn open_file(path: &Path) -> io::Result<File> {
+    if let Some(parent) = path.parent().filter(|parent| !parent.as_os_str().is_empty()) {
         create_dir_all(parent)?;
     }
-    OpenOptions::new().create(true).append(true).open(&config.file_path)
+    OpenOptions::new().create(true).append(true).open(path)
+}
+
+fn file_name_parts(path: &Path) -> io::Result<(&Path, String, String)> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let file_name = path.file_name().and_then(|name| name.to_str()).ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidInput, "transaction event path has no valid filename")
+    })?;
+    let stem = path.file_stem().and_then(|name| name.to_str()).ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidInput, "transaction event path has no valid stem")
+    })?;
+    let extension = path.extension().and_then(|name| name.to_str()).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("transaction event path has no extension: {file_name}"),
+        )
+    })?;
+    Ok((parent, stem.to_string(), extension.to_string()))
 }
 
 #[cfg(test)]
@@ -302,6 +463,8 @@ mod tests {
             enabled: true,
             file_path: PathBuf::from("test.jsonl"),
             queue_capacity,
+            max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+            max_files: DEFAULT_MAX_FILES,
             required: true,
             producer: TransactionEventProducer::BaseRethNode,
             network: "base-mainnet".to_string(),
@@ -510,6 +673,8 @@ mod tests {
             enabled: true,
             file_path: path.clone(),
             queue_capacity: 8,
+            max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+            max_files: DEFAULT_MAX_FILES,
             required: true,
             producer: TransactionEventProducer::BaseRethNode,
             network: "base-mainnet".to_string(),
@@ -524,6 +689,42 @@ mod tests {
         assert_eq!(lines.len(), 1);
         let value: Value = serde_json::from_str(lines[0]).unwrap();
         assert_eq!(value["schema_version"], SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn size_rolling_file_rotates_and_prunes_old_segments() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("events.jsonl");
+        let config = TransactionEventWriterConfig {
+            enabled: true,
+            file_path: path.clone(),
+            queue_capacity: 8,
+            max_file_bytes: 4,
+            max_files: 3,
+            required: true,
+            producer: TransactionEventProducer::BaseRethNode,
+            network: "base-mainnet".to_string(),
+        };
+        let mut writer = SizeRollingFile::new(&config).unwrap();
+
+        for payload in [&b"aaaa"[..], &b"bbbb"[..], &b"cccc"[..], &b"dddd"[..], &b"eeee"[..]] {
+            writer.write_all(payload).unwrap();
+        }
+        writer.flush().unwrap();
+
+        assert_eq!(fs::metadata(&path).unwrap().len(), 4);
+        let rotated_count = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                let name = entry.file_name();
+                let name = name.to_string_lossy();
+                name != "events.jsonl"
+                    && name.starts_with("events.")
+                    && name.ends_with(".jsonl")
+            })
+            .count();
+        assert_eq!(rotated_count, 2);
     }
 
     #[test]
@@ -562,6 +763,8 @@ mod tests {
             enabled: true,
             file_path: path.clone(),
             queue_capacity: 8,
+            max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+            max_files: DEFAULT_MAX_FILES,
             required: true,
             producer: TransactionEventProducer::BaseRethNode,
             network: "base-mainnet".to_string(),
@@ -583,6 +786,8 @@ mod tests {
             enabled: true,
             file_path: path,
             queue_capacity: 8,
+            max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+            max_files: DEFAULT_MAX_FILES,
             required: true,
             producer: TransactionEventProducer::BaseRethNode,
             network: "base-mainnet".to_string(),

--- a/crates/common/observability-events/src/writer.rs
+++ b/crates/common/observability-events/src/writer.rs
@@ -255,6 +255,8 @@ pub enum WriteEventError {
     Invalid(TransactionEventValidationError),
 }
 
+const MAX_ROTATED_PATH_ATTEMPTS: u32 = 1000;
+
 struct SizeRollingFile {
     file: Option<File>,
     path: PathBuf,
@@ -277,12 +279,9 @@ impl SizeRollingFile {
         })
     }
 
-    fn should_rotate(&self, incoming_bytes: usize) -> bool {
+    const fn should_rotate(&self, incoming_bytes: usize) -> bool {
         self.current_size > 0
-            && self
-                .current_size
-                .saturating_add(incoming_bytes as u64)
-                > self.max_file_bytes
+            && self.current_size.saturating_add(incoming_bytes as u64) > self.max_file_bytes
     }
 
     fn rotate(&mut self) -> io::Result<()> {
@@ -311,7 +310,7 @@ impl SizeRollingFile {
             Ok(file) => {
                 self.file = Some(file);
                 self.current_size = 0;
-                self.prune_rotated_files()?;
+                self.prune_rotated_files();
                 Ok(())
             }
             Err(err) => {
@@ -324,44 +323,55 @@ impl SizeRollingFile {
 
     fn next_rotated_path(&self) -> io::Result<PathBuf> {
         let (parent, stem, extension) = file_name_parts(&self.path)?;
-        let mut timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis();
+        let mut timestamp =
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_millis();
 
-        loop {
+        for _ in 0..MAX_ROTATED_PATH_ATTEMPTS {
             let candidate = parent.join(format!("{stem}.{timestamp}.{extension}"));
             if !candidate.exists() {
                 return Ok(candidate);
             }
             timestamp = timestamp.saturating_add(1);
         }
+
+        Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "could not allocate a unique rotated transaction event path",
+        ))
     }
 
-    fn prune_rotated_files(&self) -> io::Result<()> {
-        let (parent, stem, extension) = file_name_parts(&self.path)?;
+    fn prune_rotated_files(&self) {
+        let Ok((parent, stem, extension)) = file_name_parts(&self.path) else {
+            return;
+        };
         let prefix = format!("{stem}.");
         let suffix = format!(".{extension}");
-        let mut rotated_files = read_dir(parent)?
+        let Ok(entries) = read_dir(parent) else {
+            return;
+        };
+        let mut rotated_files = entries
             .filter_map(Result::ok)
             .filter_map(|entry| {
                 let name = entry.file_name().into_string().ok()?;
-                let timestamp = name
-                    .strip_prefix(&prefix)?
-                    .strip_suffix(&suffix)?
-                    .parse::<u128>()
-                    .ok()?;
+                let timestamp =
+                    name.strip_prefix(&prefix)?.strip_suffix(&suffix)?.parse::<u128>().ok()?;
                 Some((timestamp, name, entry.path()))
             })
             .collect::<Vec<_>>();
 
-        rotated_files.sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
+        rotated_files
+            .sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
         let keep_rotated = self.max_files.saturating_sub(1);
         while rotated_files.len() > keep_rotated {
             let (_, _, path) = rotated_files.remove(0);
-            remove_file(path)?;
+            if let Err(err) = remove_file(&path) {
+                warn!(
+                    path = %path.display(),
+                    error = %err,
+                    "failed to prune rotated transaction event file"
+                );
+            }
         }
-        Ok(())
     }
 }
 
@@ -401,16 +411,13 @@ fn file_name_parts(path: &Path) -> io::Result<(&Path, String, String)> {
         .parent()
         .filter(|parent| !parent.as_os_str().is_empty())
         .unwrap_or_else(|| Path::new("."));
-    let file_name = path.file_name().and_then(|name| name.to_str()).ok_or_else(|| {
-        io::Error::new(io::ErrorKind::InvalidInput, "transaction event path has no valid filename")
-    })?;
     let stem = path.file_stem().and_then(|name| name.to_str()).ok_or_else(|| {
         io::Error::new(io::ErrorKind::InvalidInput, "transaction event path has no valid stem")
     })?;
     let extension = path.extension().and_then(|name| name.to_str()).ok_or_else(|| {
         io::Error::new(
             io::ErrorKind::InvalidInput,
-            format!("transaction event path has no extension: {file_name}"),
+            format!("transaction event path has no extension: {}", path.display()),
         )
     })?;
     Ok((parent, stem.to_string(), extension.to_string()))
@@ -719,9 +726,7 @@ mod tests {
             .filter(|entry| {
                 let name = entry.file_name();
                 let name = name.to_string_lossy();
-                name != "events.jsonl"
-                    && name.starts_with("events.")
-                    && name.ends_with(".jsonl")
+                name != "events.jsonl" && name.starts_with("events.") && name.ends_with(".jsonl")
             })
             .count();
         assert_eq!(rotated_count, 2);

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -10,8 +10,8 @@ use base_metering::{MeteredOpcodes, MeteringConfig, MeteringExtension, MeteringR
 use base_node_core::args::RollupArgs;
 use base_node_runner::{BaseNodeBuilder, BaseNodeRunner, LaunchedBaseNode, PayloadServiceBuilder};
 use base_observability_events::{
-    DEFAULT_MAX_FILE_BYTES, DEFAULT_MAX_FILES, DEFAULT_QUEUE_CAPACITY, GlobalTransactionEventWriter,
-    TransactionEventProducer, TransactionEventWriterConfig,
+    DEFAULT_MAX_FILE_BYTES, DEFAULT_MAX_FILES, DEFAULT_QUEUE_CAPACITY,
+    GlobalTransactionEventWriter, TransactionEventProducer, TransactionEventWriterConfig,
 };
 use base_proofs_extension::ProofsHistoryExtension;
 use base_tx_forwarding::{

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -10,8 +10,8 @@ use base_metering::{MeteredOpcodes, MeteringConfig, MeteringExtension, MeteringR
 use base_node_core::args::RollupArgs;
 use base_node_runner::{BaseNodeBuilder, BaseNodeRunner, LaunchedBaseNode, PayloadServiceBuilder};
 use base_observability_events::{
-    DEFAULT_QUEUE_CAPACITY, GlobalTransactionEventWriter, TransactionEventProducer,
-    TransactionEventWriterConfig,
+    DEFAULT_MAX_FILE_BYTES, DEFAULT_MAX_FILES, DEFAULT_QUEUE_CAPACITY, GlobalTransactionEventWriter,
+    TransactionEventProducer, TransactionEventWriterConfig,
 };
 use base_proofs_extension::ProofsHistoryExtension;
 use base_tx_forwarding::{
@@ -500,6 +500,8 @@ fn transaction_event_writer_config(
         enabled: true,
         file_path,
         queue_capacity: DEFAULT_QUEUE_CAPACITY,
+        max_file_bytes: env.max_file_bytes,
+        max_files: env.max_files,
         required: false,
         producer: TransactionEventProducer::BaseRethNode,
         network: env.network.clone(),
@@ -510,6 +512,8 @@ fn transaction_event_writer_config(
 struct TransactionEventEnv {
     enabled: bool,
     path: Option<PathBuf>,
+    max_file_bytes: u64,
+    max_files: usize,
     network: String,
 }
 
@@ -518,6 +522,14 @@ impl TransactionEventEnv {
         Self {
             enabled: transaction_event_journal_env_enabled(),
             path: env::var_os("BASE_TRANSACTION_EVENTS_PATH").map(PathBuf::from),
+            max_file_bytes: env::var("BASE_TRANSACTION_EVENTS_MAX_FILE_BYTES")
+                .ok()
+                .and_then(|value| value.parse().ok())
+                .unwrap_or(DEFAULT_MAX_FILE_BYTES),
+            max_files: env::var("BASE_TRANSACTION_EVENTS_MAX_FILES")
+                .ok()
+                .and_then(|value| value.parse().ok())
+                .unwrap_or(DEFAULT_MAX_FILES),
             network: env::var("BASE_TRANSACTION_EVENTS_NETWORK")
                 .or_else(|_| env::var("BASE_NODE_NETWORK"))
                 .unwrap_or_else(|_| "unknown".to_string()),
@@ -729,8 +741,13 @@ mod tests {
         ])
         .args;
 
-        let env =
-            TransactionEventEnv { enabled: false, path: None, network: "unknown".to_string() };
+        let env = TransactionEventEnv {
+            enabled: false,
+            path: None,
+            max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+            max_files: DEFAULT_MAX_FILES,
+            network: "unknown".to_string(),
+        };
         let config = transaction_event_writer_config(&args, &env).unwrap().unwrap();
         assert_eq!(config.file_path, PathBuf::from("/tmp/events.jsonl"));
         assert_eq!(config.producer, TransactionEventProducer::BaseRethNode);
@@ -742,6 +759,8 @@ mod tests {
         let env = TransactionEventEnv {
             enabled: true,
             path: Some(PathBuf::from("/tmp/env-events.jsonl")),
+            max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+            max_files: DEFAULT_MAX_FILES,
             network: "base-devnet".to_string(),
         };
         let config = transaction_event_writer_config(&args, &env).unwrap().unwrap();

--- a/crates/infra/ingress-rpc/src/lib.rs
+++ b/crates/infra/ingress-rpc/src/lib.rs
@@ -25,8 +25,8 @@ use alloy_provider::{Provider, RootProvider};
 use base_bundles::MeterBundleResponse;
 use base_common_network::Base;
 use base_observability_events::{
-    DEFAULT_QUEUE_CAPACITY, TransactionEventProducer, TransactionEventType,
-    TransactionEventWriterConfig, transaction_event,
+    DEFAULT_MAX_FILE_BYTES, DEFAULT_MAX_FILES, DEFAULT_QUEUE_CAPACITY, TransactionEventProducer,
+    TransactionEventType, TransactionEventWriterConfig, transaction_event,
 };
 use clap::Args;
 use serde_json::{Map, json};
@@ -156,6 +156,22 @@ pub struct Config {
     )]
     pub transaction_events_queue_capacity: usize,
 
+    /// Maximum size of an active transaction event JSONL segment.
+    #[arg(
+        long,
+        env = "TIPS_INGRESS_TRANSACTION_EVENTS_MAX_FILE_BYTES",
+        default_value_t = DEFAULT_MAX_FILE_BYTES
+    )]
+    pub transaction_events_max_file_bytes: u64,
+
+    /// Maximum number of transaction event JSONL segments to retain, including the active file.
+    #[arg(
+        long,
+        env = "TIPS_INGRESS_TRANSACTION_EVENTS_MAX_FILES",
+        default_value_t = DEFAULT_MAX_FILES
+    )]
+    pub transaction_events_max_files: usize,
+
     /// Fail service initialization if the journal file cannot be opened.
     #[arg(long, env = "TIPS_INGRESS_TRANSACTION_EVENTS_REQUIRED", default_value = "false")]
     pub transaction_events_required: bool,
@@ -172,6 +188,8 @@ impl Config {
             enabled: self.transaction_events_enabled,
             file_path: self.transaction_events_file_path.clone(),
             queue_capacity: self.transaction_events_queue_capacity,
+            max_file_bytes: self.transaction_events_max_file_bytes,
+            max_files: self.transaction_events_max_files,
             required: self.transaction_events_required,
             producer: TransactionEventProducer::IngressRpc,
             network: self.transaction_events_network.clone(),

--- a/crates/infra/ingress-rpc/src/service.rs
+++ b/crates/infra/ingress-rpc/src/service.rs
@@ -13,9 +13,7 @@ use base_bundles::{AcceptedBundle, Bundle, BundleExtensions, MeterBundleResponse
 use base_common_chains::ChainConfig;
 use base_common_consensus::{BaseTxEnvelope, EIP8130_REJECTION_MSG};
 use base_common_network::Base;
-use base_observability_events::{
-    TransactionEventProducer, TransactionEventType, transaction_event,
-};
+use base_observability_events::{TransactionEventProducer, TransactionEventType, transaction_event};
 use jsonrpsee::{
     core::{RpcResult, async_trait},
     proc_macros::rpc,
@@ -458,6 +456,7 @@ mod tests {
 
     use alloy_provider::RootProvider;
     use base_bundles::test_utils::create_test_meter_bundle_response;
+    use base_observability_events::{DEFAULT_MAX_FILE_BYTES, DEFAULT_MAX_FILES};
     use tokio::sync::{broadcast, mpsc};
     use url::Url;
     use wiremock::{Mock, MockServer, ResponseTemplate, matchers::method};
@@ -489,6 +488,8 @@ mod tests {
             transaction_events_enabled: false,
             transaction_events_file_path: "/tmp/transaction-events.jsonl".into(),
             transaction_events_queue_capacity: 1024,
+            transaction_events_max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+            transaction_events_max_files: DEFAULT_MAX_FILES,
             transaction_events_required: false,
             transaction_events_network: "base-mainnet".to_string(),
         }

--- a/crates/infra/ingress-rpc/src/service.rs
+++ b/crates/infra/ingress-rpc/src/service.rs
@@ -13,7 +13,9 @@ use base_bundles::{AcceptedBundle, Bundle, BundleExtensions, MeterBundleResponse
 use base_common_chains::ChainConfig;
 use base_common_consensus::{BaseTxEnvelope, EIP8130_REJECTION_MSG};
 use base_common_network::Base;
-use base_observability_events::{TransactionEventProducer, TransactionEventType, transaction_event};
+use base_observability_events::{
+    TransactionEventProducer, TransactionEventType, transaction_event,
+};
 use jsonrpsee::{
     core::{RpcResult, async_trait},
     proc_macros::rpc,

--- a/docs/transaction-events/README.md
+++ b/docs/transaction-events/README.md
@@ -19,6 +19,8 @@ producer-specific prefix:
 | `enabled` | boolean | Enables transaction event journal writes. |
 | `file_path` | string | Dedicated JSONL file path tailed by Vector. |
 | `queue_capacity` | integer | Bounded in-process event queue size. Producers drop on backpressure instead of blocking transaction serving paths. |
+| `max_file_bytes` | integer | Maximum size of the active JSONL segment before it is renamed and a new segment is opened. |
+| `max_files` | integer | Maximum number of JSONL segments retained, including the active segment. |
 | `required` | boolean | If true, fail service initialization when the file writer cannot open. Runtime write failures remain observable and non-fatal. |
 | `producer` | string | One of the producer identities below. |
 | `network` | string | Network label, for example `base-mainnet` or `base-sepolia`. |
@@ -30,6 +32,8 @@ For Go/proxyd, mirror the same names in TOML:
 enabled = true
 file_path = "/var/log/base/transaction-events.jsonl"
 queue_capacity = 16384
+max_file_bytes = 134217728
+max_files = 8
 required = false
 producer = "base-routing/proxyd"
 network = "base-mainnet"


### PR DESCRIPTION
## Summary
- Add a shared size-capped rename rotator for transaction event JSONL journals.
- Retain the active `events.jsonl` plus up to seven `events.<unix_ms>.jsonl` segments.
- Expose 128 MiB / 8-file defaults and producer-specific CLI/environment overrides.

## Test plan
- [x] `cargo test -p base-observability-events`
- [x] `cargo test -p ingress-rpc-lib`
- [x] `cargo check -p base-builder-cli -p ingress-rpc-lib -p base-execution-cli`