### PR TITLE
fix(devnet): keep node transaction event journals in core compose

### DIFF
--- a/docs/transaction-events/README.md
+++ b/docs/transaction-events/README.md
@@ -94,8 +94,11 @@ and `privateKey` before ingest.
 
 ## Local Devnet Verification
 
-The ingress devnet stack runs a local Postgres, Vector shipper, and
-Postgres-backed `audit-archiver` ingest path:
+Core devnet (`just devnet up` / `just devnet up-single`) enables durable
+transaction event journals on `base-client` and `base-builder`, writing JSONL
+under `.devnet/transaction-events/`. The ingress overlay adds the collection
+pipeline (Vector, Postgres, `audit-archiver`) plus ingress/proxyd producers; it
+does not own node journal config.
 
 ```bash
 just devnet ingress

--- a/etc/docker/docker-compose.ingress.yml
+++ b/etc/docker/docker-compose.ingress.yml
@@ -5,23 +5,6 @@ x-rust-service-build: &rust-service-build
     PROFILE: "${CARGO_PROFILE:-dev}"
 
 services:
-  base-builder:
-    volumes:
-      - ../../.devnet/transaction-events:/var/log/transaction-events
-    environment:
-      - BUILDER_TRANSACTION_EVENTS_ENABLED=true
-      - BUILDER_TRANSACTION_EVENTS_PATH=/var/log/transaction-events/base-builder/events.jsonl
-      - BUILDER_TRANSACTION_EVENTS_NETWORK=base-devnet
-
-  base-client:
-    volumes:
-      - ../../.devnet/transaction-events:/var/log/transaction-events
-    environment:
-      - BASE_TRANSACTION_EVENTS_ENABLED=true
-      - BASE_TRANSACTION_EVENTS_PATH=/var/log/transaction-events/base-client/events.jsonl
-      - BASE_TRANSACTION_EVENTS_NETWORK=base-devnet
-      - BASE_TRANSACTION_EVENTS_NODE_ROLE=devnet-client
-
   minio:
     image: minio/minio:latest
     container_name: minio

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -432,6 +432,7 @@ services:
       - NODE_HEALTHCHECK_HTTP_PORT=${L2_CLIENT_HTTP_PORT}
       - NODE_HEALTHCHECK_CL_RPC_PORT=${L2_CLIENT_CL_RPC_PORT}
       - OTEL_SERVICE_NAME=base-client
+      - BASE_TRANSACTION_EVENTS_ENABLED=true
       - BASE_TRANSACTION_EVENTS_PATH=/var/log/transaction-events/base-client/events.jsonl
       - BASE_TRANSACTION_EVENTS_NETWORK=base-devnet
       - BASE_TRANSACTION_EVENTS_NODE_ROLE=devnet-client

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -268,6 +268,7 @@ services:
       - ../../.devnet/l2/cl-bootnode-enr:/bootnodes:ro
       - ../../.devnet/l1/configs:/genesis:ro
       - ../../.devnet/l2/configs:/genesis/l2:ro
+      - ../../.devnet/transaction-events:/var/log/transaction-events
     environment:
       - BASE_CHAIN_NAME=dev
       - BASE_CHAIN_L1_CHAIN_ID=${L1_CHAIN_ID}
@@ -275,6 +276,9 @@ services:
       - NODE_HEALTHCHECK_HTTP_PORT=${L2_BUILDER_HTTP_PORT}
       - NODE_HEALTHCHECK_CL_RPC_PORT=${L2_BUILDER_CL_RPC_PORT}
       - OTEL_SERVICE_NAME=base-builder
+      - BUILDER_TRANSACTION_EVENTS_ENABLED=true
+      - BUILDER_TRANSACTION_EVENTS_PATH=/var/log/transaction-events/base-builder/events.jsonl
+      - BUILDER_TRANSACTION_EVENTS_NETWORK=base-devnet
     entrypoint: /app/base-entrypoint.sh
     command:
       - sequencer
@@ -420,6 +424,7 @@ services:
       - ../../.devnet/l2/cl-bootnode-enr:/bootnodes:ro
       - ../../.devnet/l1/configs:/genesis:ro
       - ../../.devnet/l2/configs:/genesis/l2:ro
+      - ../../.devnet/transaction-events:/var/log/transaction-events
     environment:
       - BASE_CHAIN_NAME=dev
       - BASE_CHAIN_L1_CHAIN_ID=${L1_CHAIN_ID}
@@ -427,7 +432,9 @@ services:
       - NODE_HEALTHCHECK_HTTP_PORT=${L2_CLIENT_HTTP_PORT}
       - NODE_HEALTHCHECK_CL_RPC_PORT=${L2_CLIENT_CL_RPC_PORT}
       - OTEL_SERVICE_NAME=base-client
-      - BASE_TRANSACTION_EVENTS_PATH=/tmp/base-client-transaction-events.jsonl
+      - BASE_TRANSACTION_EVENTS_PATH=/var/log/transaction-events/base-client/events.jsonl
+      - BASE_TRANSACTION_EVENTS_NETWORK=base-devnet
+      - BASE_TRANSACTION_EVENTS_NODE_ROLE=devnet-client
     entrypoint: /app/base-entrypoint.sh
     command:
       - rpc


### PR DESCRIPTION
## Summary
- Move `base-client` and `base-builder` transaction event journal volume/env config from the ingress overlay into core `docker-compose.yml`.
- Replace the temporary `/tmp` journal path from #4087 with the shared `.devnet/transaction-events` layout Vector already tails.
- Leave ingress owning only the collection pipeline (Vector/Postgres/audit-archiver) and ingress/proxyd producers.

## Test plan
- [ ] `just devnet up-single` starts with healthy `base-client` / `base-builder` (`restart=0`)
- [ ] JSONL files appear under `.devnet/transaction-events/base-client/` and `base-builder/`
- [ ] `just devnet ingress` still starts without redefining node journal env
- [ ] `just devnet tx-observability-smoke` passes

type=routine
risk=low
impact=sev5