### PR TITLE
refactor(challenger): simplify test utilities

### DIFF
--- a/crates/proof/challenge/src/anchor.rs
+++ b/crates/proof/challenge/src/anchor.rs
@@ -310,7 +310,7 @@ mod tests {
     use super::*;
     use crate::test_utils::{
         MockAggregateVerifier, MockAnchorStateRegistry, MockDisputeGameFactory, MockL2Provider,
-        SharedMockTxManager, addr, build_test_header_and_account, mock_state, receipt_with_status,
+        MockTxManager, addr, build_test_header_and_account, mock_state, receipt_with_status,
     };
 
     const ASR_ADDRESS: Address = Address::new([0xAA; 20]);
@@ -346,8 +346,8 @@ mod tests {
 
     fn submitter(
         responses: Vec<base_tx_manager::SendResponse>,
-    ) -> (ChallengeSubmitter<SharedMockTxManager>, SharedMockTxManager) {
-        let tx_manager = SharedMockTxManager::with_responses(responses);
+    ) -> (ChallengeSubmitter<MockTxManager>, MockTxManager) {
+        let tx_manager = MockTxManager::with_responses(responses);
         (ChallengeSubmitter::new(tx_manager.clone()), tx_manager)
     }
 
@@ -373,7 +373,7 @@ mod tests {
         let tx_hash = B256::repeat_byte(0xDD);
         let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
         let anchor_registry = Arc::new(MockAnchorStateRegistry::new(Address::ZERO));
-        let mut l2 = MockL2Provider::new();
+        let mut l2 = MockL2Provider::default();
         let output_root = insert_l2_block(&mut l2, BLOCK_INTERVAL);
         insert_next_game(&factory, ASR_ADDRESS, output_root, game);
         let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
@@ -396,7 +396,7 @@ mod tests {
         let game = addr(1);
         let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
         let anchor_registry = Arc::new(MockAnchorStateRegistry::new(Address::ZERO));
-        let mut l2 = MockL2Provider::new();
+        let mut l2 = MockL2Provider::default();
         let output_root = insert_l2_block(&mut l2, BLOCK_INTERVAL);
         insert_next_game(&factory, ASR_ADDRESS, output_root, game);
         let state = mock_state(GameStatus::InProgress, Address::ZERO, 100);
@@ -416,7 +416,7 @@ mod tests {
         let tx_hash = B256::repeat_byte(0xDD);
         let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
         let anchor_registry = Arc::new(MockAnchorStateRegistry::new(Address::ZERO));
-        let mut l2 = MockL2Provider::new();
+        let mut l2 = MockL2Provider::default();
         let output_root = insert_l2_block(&mut l2, BLOCK_INTERVAL);
         insert_next_game(&factory, ASR_ADDRESS, output_root, game);
         let state = mock_state(GameStatus::InProgress, Address::ZERO, 100);
@@ -446,7 +446,7 @@ mod tests {
         let tx_hash = B256::repeat_byte(0xDD);
         let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
         let anchor_registry = Arc::new(MockAnchorStateRegistry::new(Address::ZERO));
-        let mut l2 = MockL2Provider::new();
+        let mut l2 = MockL2Provider::default();
         let output_root = insert_l2_block(&mut l2, BLOCK_INTERVAL);
         insert_next_game(&factory, ASR_ADDRESS, output_root, game);
         let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
@@ -470,7 +470,7 @@ mod tests {
         let challenger_win = addr(10);
         let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
         let anchor_registry = Arc::new(MockAnchorStateRegistry::new(Address::ZERO));
-        let mut l2 = MockL2Provider::new();
+        let mut l2 = MockL2Provider::default();
         let output_root = insert_l2_block(&mut l2, BLOCK_INTERVAL);
         insert_next_game(&factory, ASR_ADDRESS, output_root, challenger_win);
 
@@ -496,7 +496,7 @@ mod tests {
         let tx_hash = B256::repeat_byte(0xDD);
         let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
         let anchor_registry = Arc::new(MockAnchorStateRegistry::new(anchor_game));
-        let mut l2 = MockL2Provider::new();
+        let mut l2 = MockL2Provider::default();
         let output_root = insert_l2_block(&mut l2, BLOCK_INTERVAL);
         insert_next_game(&factory, anchor_game, output_root, next_game);
         let mut next_state = mock_state(GameStatus::DefenderWins, Address::ZERO, 200);
@@ -521,7 +521,7 @@ mod tests {
         let game = addr(1);
         let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
         let anchor_registry = Arc::new(MockAnchorStateRegistry::new(Address::ZERO));
-        let mut l2 = MockL2Provider::new();
+        let mut l2 = MockL2Provider::default();
         let output_root = insert_l2_block(&mut l2, BLOCK_INTERVAL);
         insert_next_game(&factory, ASR_ADDRESS, output_root, game);
         let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -489,7 +489,7 @@ mod tests {
 
     use super::*;
     use crate::test_utils::{
-        MockAggregateVerifier, MockDisputeGameFactory, MockL2Provider, SharedMockTxManager,
+        MockAggregateVerifier, MockDisputeGameFactory, MockL2Provider, MockTxManager,
         TEST_DISCOVERY_INTERVAL, addr, build_test_header_and_account, factory_game, mock_state,
         receipt_with_status,
     };
@@ -551,7 +551,7 @@ mod tests {
         metrics_enabled: bool,
     ) -> BondManager<FixedClock> {
         let factory = Arc::new(MockDisputeGameFactory::new(vec![factory_game(0, 0)]));
-        let mut l2_provider = MockL2Provider::new();
+        let mut l2_provider = MockL2Provider::default();
         let (header, account) = build_test_header_and_account(100, B256::ZERO);
         l2_provider.insert_block(100, header, account);
         BondManager::new(
@@ -570,8 +570,8 @@ mod tests {
 
     fn bond_submitter(
         responses: Vec<base_tx_manager::SendResponse>,
-    ) -> (ChallengeSubmitter<SharedMockTxManager>, SharedMockTxManager) {
-        let tx_manager = SharedMockTxManager::with_responses(responses);
+    ) -> (ChallengeSubmitter<MockTxManager>, MockTxManager) {
+        let tx_manager = MockTxManager::with_responses(responses);
         (ChallengeSubmitter::new(tx_manager.clone()), tx_manager)
     }
 
@@ -719,7 +719,7 @@ mod tests {
         ])));
         let factory =
             Arc::new(MockDisputeGameFactory::new(vec![factory_game(0, 0), factory_game(1, 0)]));
-        let mut l2_provider = MockL2Provider::new();
+        let mut l2_provider = MockL2Provider::default();
         let (header, account) = build_test_header_and_account(100, B256::ZERO);
         l2_provider.insert_block(100, header, account);
         l2_provider.header_delay = Some(FINALITY_METRIC_TIMEOUT + Duration::from_secs(1));

--- a/crates/proof/challenge/src/proof_manager.rs
+++ b/crates/proof/challenge/src/proof_manager.rs
@@ -688,7 +688,7 @@ mod tests {
         let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
         let proof_requester = Arc::new(MockZkProofProvider::default());
         let manager = DisputeProofManager::new(
-            OutputValidator::new(Arc::new(MockL2Provider::new())),
+            OutputValidator::new(Arc::new(MockL2Provider::default())),
             Arc::clone(&proof_requester),
             Arc::new(MockL1::failure("unused")) as Arc<dyn L1Provider>,
             verifier as Arc<dyn AggregateVerifierClient>,

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -606,3 +606,712 @@ impl GameScanner {
         Ok(interval)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashMap,
+        sync::{Arc, Mutex},
+    };
+
+    use alloy_primitives::{Address, B256, Bytes, U256};
+    use async_trait::async_trait;
+    use base_proof_contracts::{
+        AggregateVerifierClient, AnchorStateRegistryClient, ContractError,
+        DisputeGameFactoryClient, GameAtIndex, GameStatus,
+    };
+
+    use super::*;
+    use crate::test_utils::{
+        MockAggregateVerifier, MockAnchorStateRegistry, MockDisputeGameFactory, addr, factory_game,
+        mock_anchor_registry, mock_state, mock_state_with_tee,
+    };
+
+    /// Mock factory that records queried indices and can return errors for specific indices.
+    #[derive(Debug)]
+    struct RecordingDisputeGameFactory {
+        /// The inner factory providing normal game data.
+        inner: MockDisputeGameFactory,
+        /// Indices that should return an error when queried.
+        error_indices: Vec<u64>,
+        /// Factory indices queried through `game_at_index`.
+        queried_indices: Mutex<Vec<u64>>,
+    }
+
+    impl RecordingDisputeGameFactory {
+        /// Creates a new recording factory.
+        fn new(games: Vec<GameAtIndex>, error_indices: Vec<u64>) -> Self {
+            Self {
+                inner: MockDisputeGameFactory::new(games),
+                error_indices,
+                queried_indices: Mutex::new(Vec::new()),
+            }
+        }
+
+        /// Returns all indices queried so far.
+        fn queried_indices(&self) -> Vec<u64> {
+            self.queried_indices.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl DisputeGameFactoryClient for RecordingDisputeGameFactory {
+        async fn game_count(&self) -> Result<u64, ContractError> {
+            self.inner.game_count().await
+        }
+
+        async fn game_at_index(&self, index: u64) -> Result<GameAtIndex, ContractError> {
+            self.queried_indices.lock().unwrap().push(index);
+            if self.error_indices.contains(&index) {
+                return Err(ContractError::Validation(format!("simulated error at index {index}")));
+            }
+            self.inner.game_at_index(index).await
+        }
+
+        async fn init_bonds(&self, game_type: u32) -> Result<U256, ContractError> {
+            self.inner.init_bonds(game_type).await
+        }
+
+        async fn game_impls(&self, game_type: u32) -> Result<Address, ContractError> {
+            self.inner.game_impls(game_type).await
+        }
+
+        async fn games(
+            &self,
+            game_type: u32,
+            root_claim: B256,
+            extra_data: Bytes,
+        ) -> Result<Address, ContractError> {
+            self.inner.games(game_type, root_claim, extra_data).await
+        }
+    }
+
+    /// Happy path: mixed games, only `IN_PROGRESS` / non-nullified returned.
+    #[tokio::test]
+    async fn test_scan_happy_path() {
+        // Game 0: type 1, IN_PROGRESS, TEE only -> candidate (InvalidTeeProposal)
+        // Game 1: type 99, IN_PROGRESS, TEE only -> candidate (all types scanned)
+        // Game 2: type 1, status=1 (not in progress) -> skipped
+        // Game 3: type 1, IN_PROGRESS, TEE + ZK (dual proof) -> candidate (InvalidDualProposal)
+        // Game 4: type 1, IN_PROGRESS, TEE only -> candidate (InvalidTeeProposal)
+        let factory = Arc::new(MockDisputeGameFactory::new(vec![
+            factory_game(0, 1),
+            factory_game(1, 99),
+            factory_game(2, 1),
+            factory_game(3, 1),
+            factory_game(4, 1),
+        ]));
+
+        let challenger_addr = Address::repeat_byte(0xCC);
+        let mut verifier_games = HashMap::new();
+        verifier_games.insert(addr(0), mock_state(GameStatus::InProgress, Address::ZERO, 100));
+        verifier_games.insert(addr(1), mock_state(GameStatus::InProgress, Address::ZERO, 150));
+        verifier_games.insert(addr(2), mock_state(GameStatus::ChallengerWins, Address::ZERO, 200));
+        verifier_games.insert(addr(3), mock_state(GameStatus::InProgress, challenger_addr, 300));
+        verifier_games.insert(addr(4), mock_state(GameStatus::InProgress, Address::ZERO, 400));
+
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
+
+        let mut scanner = GameScanner::new(
+            factory,
+            Arc::clone(&verifier) as Arc<dyn AggregateVerifierClient>,
+            mock_anchor_registry(Address::ZERO),
+        );
+
+        let candidates = scanner.scan().await.unwrap();
+
+        // start = max(0, 5-1000) = 0, so games 0..=4 scanned
+        // Game 0: TEE only -> candidate. Game 1: TEE only -> candidate.
+        // Game 2: status != 0 -> skipped.
+        // Game 3: dual proof (TEE+ZK, no challenge) -> candidate.
+        // Game 4: TEE only -> candidate.
+        assert_eq!(candidates.len(), 4);
+        assert_eq!(candidates[0].index, 0);
+        assert_eq!(candidates[0].factory.game_type, 1);
+        assert_eq!(candidates[0].info.l2_block_number, 100);
+        assert_eq!(candidates[1].index, 1);
+        assert_eq!(candidates[1].factory.game_type, 99);
+        assert_eq!(candidates[1].info.l2_block_number, 150);
+        assert_eq!(candidates[2].index, 3);
+        assert_eq!(candidates[2].category, GameCategory::InvalidDualProposal);
+        assert_eq!(candidates[3].index, 4);
+        assert_eq!(candidates[3].factory.game_type, 1);
+        assert_eq!(candidates[3].info.l2_block_number, 400);
+        assert_eq!(
+            verifier.intermediate_block_interval_reads.lock().unwrap().as_slice(),
+            &[Address::repeat_byte(0x11)],
+        );
+    }
+
+    /// Dual-proof games (TEE + ZK, no challenge) are now candidates.
+    #[tokio::test]
+    async fn test_scan_dual_proof_games_are_candidates() {
+        let zk_addr = Address::repeat_byte(0xAA);
+
+        let factory = Arc::new(MockDisputeGameFactory::new(vec![
+            factory_game(0, 1),
+            factory_game(1, 1),
+            factory_game(2, 1),
+        ]));
+
+        let mut verifier_games = HashMap::new();
+        // Game 0: TEE + ZK (dual proof, no challenge) -> candidate (InvalidDualProposal)
+        verifier_games.insert(addr(0), mock_state(GameStatus::InProgress, zk_addr, 100));
+        // Game 1: TEE only -> candidate (InvalidTeeProposal)
+        verifier_games.insert(addr(1), mock_state(GameStatus::InProgress, Address::ZERO, 200));
+        // Game 2: TEE + ZK (dual proof, no challenge) -> candidate (InvalidDualProposal)
+        verifier_games.insert(addr(2), mock_state(GameStatus::InProgress, zk_addr, 300));
+
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
+
+        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
+
+        let candidates = scanner.scan().await.unwrap();
+
+        assert_eq!(candidates.len(), 3);
+        assert_eq!(candidates[0].index, 0);
+        assert_eq!(candidates[0].category, GameCategory::InvalidDualProposal);
+        assert_eq!(candidates[1].index, 1);
+        assert_eq!(candidates[1].category, GameCategory::InvalidTeeProposal);
+        assert_eq!(candidates[2].index, 2);
+        assert_eq!(candidates[2].category, GameCategory::InvalidDualProposal);
+    }
+
+    /// Empty factory returns empty vec without error.
+    #[tokio::test]
+    async fn test_scan_empty_factory() {
+        let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
+        let verifier = Arc::new(MockAggregateVerifier::new(HashMap::new()));
+
+        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
+
+        let candidates = scanner.scan().await.unwrap();
+
+        assert!(candidates.is_empty());
+    }
+
+    /// Anchor lower bound: only games after the current anchor game are scanned.
+    #[tokio::test]
+    async fn test_scan_starts_after_anchor_game() {
+        // Factory with 100 games and anchor at index 96 -> scan indices 97, 98, 99.
+        let mut games = Vec::new();
+        let mut verifier_games = HashMap::new();
+
+        for i in 0..100u64 {
+            games.push(factory_game(i, 1));
+            verifier_games
+                .insert(addr(i), mock_state(GameStatus::InProgress, Address::ZERO, i * 10));
+        }
+
+        let factory = Arc::new(MockDisputeGameFactory::new(games));
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
+
+        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(addr(96)));
+
+        let candidates = scanner.scan().await.unwrap();
+
+        assert_eq!(candidates.len(), 3);
+        assert_eq!(candidates[0].index, 97);
+        assert_eq!(candidates[1].index, 98);
+        assert_eq!(candidates[2].index, 99);
+    }
+
+    /// Cold anchor lookup searches the latest batch first and skips individual
+    /// lookup errors without aborting the whole search.
+    #[tokio::test]
+    async fn test_find_game_index_searches_tail_batch_and_skips_errors() {
+        let game_count = GameScanner::ANCHOR_SEARCH_BATCH_SIZE + 10;
+        let target_index = game_count - 1;
+        let error_index = target_index - 1;
+
+        let games = (0..game_count).map(|i| factory_game(i, 1)).collect();
+        let factory = Arc::new(RecordingDisputeGameFactory::new(games, vec![error_index]));
+        let verifier = Arc::new(MockAggregateVerifier::new(HashMap::new()));
+        let scanner = GameScanner::new(
+            Arc::clone(&factory) as Arc<dyn DisputeGameFactoryClient>,
+            verifier,
+            mock_anchor_registry(Address::ZERO),
+        );
+
+        let (found, had_errors) = scanner.find_game_index(addr(target_index), 0, game_count).await;
+
+        assert_eq!(found, Some(target_index));
+        assert!(had_errors, "lookup should report skipped per-index errors");
+
+        let queried = factory.queried_indices();
+        let first_tail_index = game_count - GameScanner::ANCHOR_SEARCH_BATCH_SIZE;
+        assert_eq!(queried.len() as u64, GameScanner::ANCHOR_SEARCH_BATCH_SIZE);
+        assert!(
+            queried.iter().all(|&i| i >= first_tail_index && i < game_count),
+            "cold lookup should only query the latest anchor search batch"
+        );
+    }
+
+    /// If a factory ever reused a proxy address, anchor lookup should return
+    /// the matching index nearest the end of the searched range.
+    #[tokio::test]
+    async fn test_find_game_index_returns_match_closest_to_end() {
+        let target = addr(99);
+        let mut games =
+            vec![factory_game(0, 1), factory_game(1, 1), factory_game(2, 1), factory_game(3, 1)];
+        games[1].proxy = target;
+        games[3].proxy = target;
+
+        let factory = Arc::new(RecordingDisputeGameFactory::new(games, vec![]));
+        let verifier = Arc::new(MockAggregateVerifier::new(HashMap::new()));
+        let scanner = GameScanner::new(
+            Arc::clone(&factory) as Arc<dyn DisputeGameFactoryClient>,
+            verifier,
+            mock_anchor_registry(Address::ZERO),
+        );
+
+        let (found, had_errors) = scanner.find_game_index(target, 0, 4).await;
+
+        assert_eq!(found, Some(3));
+        assert!(!had_errors);
+    }
+
+    /// If reading the anchor snapshot fails after a cache has been populated,
+    /// the scanner keeps using the cached anchor instead of scanning genesis.
+    #[tokio::test]
+    async fn test_scan_uses_cached_anchor_when_anchor_snapshot_fails() {
+        let mut games = Vec::new();
+        let mut verifier_games = HashMap::new();
+
+        for i in 0..5u64 {
+            games.push(factory_game(i, 1));
+            verifier_games
+                .insert(addr(i), mock_state(GameStatus::InProgress, Address::ZERO, i * 10));
+        }
+
+        let factory = Arc::new(MockDisputeGameFactory::new(games));
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
+        let anchor_registry = Arc::new(MockAnchorStateRegistry::new(addr(2)));
+        let mut scanner = GameScanner::new(
+            factory,
+            verifier,
+            Arc::clone(&anchor_registry) as Arc<dyn AnchorStateRegistryClient>,
+        );
+
+        let initial = scanner.scan().await.unwrap();
+        assert_eq!(initial.iter().map(|c| c.index).collect::<Vec<_>>(), vec![3, 4]);
+
+        anchor_registry.set_fail_snapshot(true);
+        let cached = scanner.scan().await.unwrap();
+
+        assert_eq!(cached.iter().map(|c| c.index).collect::<Vec<_>>(), vec![3, 4]);
+    }
+
+    /// When the anchor advances, tracked indices behind it are pruned from the
+    /// in-progress tracking map.
+    #[tokio::test]
+    async fn test_scan_prunes_tracking_when_anchor_advances() {
+        let mut games = Vec::new();
+        let mut verifier_games = HashMap::new();
+
+        for i in 0..5u64 {
+            games.push(factory_game(i, 1));
+            verifier_games
+                .insert(addr(i), mock_state(GameStatus::InProgress, Address::ZERO, i * 10));
+        }
+
+        let factory = Arc::new(MockDisputeGameFactory::new(games));
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
+        let anchor_registry = Arc::new(MockAnchorStateRegistry::new(Address::ZERO));
+        let mut scanner = GameScanner::new(
+            factory,
+            verifier,
+            Arc::clone(&anchor_registry) as Arc<dyn AnchorStateRegistryClient>,
+        );
+
+        scanner.scan().await.unwrap();
+        assert_eq!(scanner.tracked_indices_len(), 5);
+
+        anchor_registry.set_anchor_game(addr(2));
+        let candidates = scanner.scan().await.unwrap();
+
+        assert_eq!(candidates.iter().map(|c| c.index).collect::<Vec<_>>(), vec![3, 4]);
+        assert_eq!(scanner.tracked_indices_len(), 2);
+    }
+
+    /// Error resilience: a per-game error is logged and skipped, other games still returned.
+    /// Errored games are naturally retried on the next scan since the full post-anchor
+    /// range is always evaluated.
+    #[tokio::test]
+    async fn test_scan_skips_errored_games() {
+        // 3 games: index 1 will error, indices 0 and 2 are valid candidates
+        let factory = Arc::new(RecordingDisputeGameFactory::new(
+            vec![factory_game(0, 1), factory_game(1, 1), factory_game(2, 1)],
+            vec![1],
+        ));
+
+        let mut verifier_games = HashMap::new();
+        verifier_games.insert(addr(0), mock_state(GameStatus::InProgress, Address::ZERO, 100));
+        // index 1 won't be queried on the verifier because the factory errors first
+        verifier_games.insert(addr(2), mock_state(GameStatus::InProgress, Address::ZERO, 300));
+
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
+
+        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
+
+        // Index 0 -> candidate. Index 1 errors -> skipped. Index 2 -> candidate.
+        let candidates = scanner.scan().await.unwrap();
+
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(candidates[0].index, 0);
+        assert_eq!(candidates[1].index, 2);
+        assert_eq!(
+            scanner.tracked_indices_len(),
+            2,
+            "tail-only errors should not inflate in-progress tracking"
+        );
+    }
+
+    /// Games with a non-zero TEE prover but zero ZK prover are still candidates.
+    ///
+    /// A non-zero `teeProver` with `zkProver == ZERO` is the normal initial
+    /// state for an unchallenged game. The scanner should return these as
+    /// candidates.
+    #[tokio::test]
+    async fn test_scan_tee_prover_nonzero_still_candidate() {
+        let tee_addr = Address::repeat_byte(0xEE);
+
+        let factory =
+            Arc::new(MockDisputeGameFactory::new(vec![factory_game(0, 1), factory_game(1, 1)]));
+
+        let mut verifier_games = HashMap::new();
+        // Game 0: IN_PROGRESS, no ZK prover, has a TEE prover -> candidate
+        verifier_games.insert(
+            addr(0),
+            mock_state_with_tee(GameStatus::InProgress, Address::ZERO, tee_addr, 100),
+        );
+        // Game 1: IN_PROGRESS, no ZK prover, has default TEE prover -> candidate
+        verifier_games.insert(addr(1), mock_state(GameStatus::InProgress, Address::ZERO, 200));
+
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
+
+        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
+
+        let candidates = scanner.scan().await.unwrap();
+
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(candidates[0].index, 0);
+        assert_eq!(candidates[1].index, 1);
+    }
+
+    /// Error at the first index (0) skips that game, rest still returned.
+    #[tokio::test]
+    async fn test_scan_error_at_first_index() {
+        let factory = Arc::new(RecordingDisputeGameFactory::new(
+            vec![factory_game(0, 1), factory_game(1, 1)],
+            vec![0],
+        ));
+
+        let mut verifier_games = HashMap::new();
+        verifier_games.insert(addr(1), mock_state(GameStatus::InProgress, Address::ZERO, 200));
+
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
+
+        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
+
+        let candidates = scanner.scan().await.unwrap();
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].index, 1);
+        assert_eq!(
+            scanner.tracked_indices_len(),
+            1,
+            "tail-only errors should not inflate in-progress tracking"
+        );
+    }
+
+    /// A challenged game (TEE + ZK provers non-zero, `countered_index` > 0) is
+    /// returned as a [`GameCategory::FraudulentZkChallenge`] candidate.
+    #[tokio::test]
+    async fn test_scan_challenged_game_returns_fraudulent_zk_challenge() {
+        let tee_addr = Address::repeat_byte(0xEE);
+        let zk_addr = Address::repeat_byte(0xCC);
+
+        let factory = Arc::new(MockDisputeGameFactory::new(vec![factory_game(0, 1)]));
+
+        let mut verifier_games = HashMap::new();
+        let mut state = mock_state_with_tee(GameStatus::InProgress, zk_addr, tee_addr, 100);
+        state.countered_index = 3; // 1-based: challenged at 0-based index 2
+        verifier_games.insert(addr(0), state);
+
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
+        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
+
+        let candidates = scanner.scan().await.unwrap();
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(
+            candidates[0].category,
+            GameCategory::FraudulentZkChallenge { challenged_index: 2 }
+        );
+    }
+
+    /// A ZK-proposed game (`tee_prover` == 0, `zk_prover` != 0, unchallenged) is
+    /// returned as a [`GameCategory::InvalidZkProposal`] candidate.
+    #[tokio::test]
+    async fn test_scan_zk_proposal_returns_invalid_zk_proposal() {
+        let zk_addr = Address::repeat_byte(0xCC);
+
+        let factory = Arc::new(MockDisputeGameFactory::new(vec![factory_game(0, 1)]));
+
+        let mut verifier_games = HashMap::new();
+        // tee_prover == ZERO, zk_prover != ZERO, countered_index == 0
+        verifier_games.insert(
+            addr(0),
+            mock_state_with_tee(GameStatus::InProgress, zk_addr, Address::ZERO, 100),
+        );
+
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
+        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
+
+        let candidates = scanner.scan().await.unwrap();
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].category, GameCategory::InvalidZkProposal);
+    }
+
+    /// A TEE-proposed unchallenged game is returned as
+    /// [`GameCategory::InvalidTeeProposal`].
+    #[tokio::test]
+    async fn test_scan_tee_proposal_returns_invalid_tee_proposal() {
+        let factory = Arc::new(MockDisputeGameFactory::new(vec![factory_game(0, 1)]));
+
+        let mut verifier_games = HashMap::new();
+        verifier_games.insert(addr(0), mock_state(GameStatus::InProgress, Address::ZERO, 100));
+
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
+        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
+
+        let candidates = scanner.scan().await.unwrap();
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].category, GameCategory::InvalidTeeProposal);
+    }
+
+    /// A game with both proofs verified (TEE + ZK, no challenge) is a
+    /// candidate for validation. Both proofs may verify a wrong root.
+    #[tokio::test]
+    async fn test_scan_both_proofs_verified_is_candidate() {
+        let tee_addr = Address::repeat_byte(0xEE);
+        let zk_addr = Address::repeat_byte(0xCC);
+
+        let factory = Arc::new(MockDisputeGameFactory::new(vec![factory_game(0, 1)]));
+
+        let mut verifier_games = HashMap::new();
+        // Both provers non-zero, countered_index == 0 (added via verifyProposalProof)
+        verifier_games
+            .insert(addr(0), mock_state_with_tee(GameStatus::InProgress, zk_addr, tee_addr, 100));
+
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
+        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
+
+        let candidates = scanner.scan().await.unwrap();
+
+        assert_eq!(candidates.len(), 1, "dual-proof game should be a candidate");
+        assert_eq!(candidates[0].category, GameCategory::InvalidDualProposal);
+    }
+
+    /// Games with both `teeProver` and `zkProver` at `Address::ZERO` are
+    /// filtered out. Every game is initialized with at least one prover, so
+    /// both being zero indicates a prior nullification.
+    #[tokio::test]
+    async fn test_scan_filters_nullified_games() {
+        let tee_addr = Address::repeat_byte(0xEE);
+
+        let factory = Arc::new(MockDisputeGameFactory::new(vec![
+            factory_game(0, 1),
+            factory_game(1, 1),
+            factory_game(2, 1),
+        ]));
+
+        let mut verifier_games = HashMap::new();
+        // Game 0: both provers zeroed (nullified) → filtered out
+        verifier_games.insert(
+            addr(0),
+            mock_state_with_tee(GameStatus::InProgress, Address::ZERO, Address::ZERO, 100),
+        );
+        // Game 1: TEE prover active, ZK prover zero → candidate
+        verifier_games.insert(
+            addr(1),
+            mock_state_with_tee(GameStatus::InProgress, Address::ZERO, tee_addr, 200),
+        );
+        // Game 2: both provers zeroed (nullified) → filtered out
+        verifier_games.insert(
+            addr(2),
+            mock_state_with_tee(GameStatus::InProgress, Address::ZERO, Address::ZERO, 300),
+        );
+
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
+
+        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
+
+        let candidates = scanner.scan().await.unwrap();
+
+        assert_eq!(candidates.len(), 1, "only the non-nullified game should be a candidate");
+        assert_eq!(candidates[0].index, 1);
+    }
+
+    /// A game remains covered after new games are appended because the scanner
+    /// evaluates the full post-anchor range rather than a rolling tail.
+    #[tokio::test]
+    async fn test_scan_revisits_old_post_anchor_in_progress_games() {
+        let tee_addr = Address::repeat_byte(0xEE);
+        let zk_addr = Address::repeat_byte(0xCC);
+
+        // Initial state: 3 games after the starting anchor.
+        let factory = Arc::new(MockDisputeGameFactory::new(vec![
+            factory_game(0, 1),
+            factory_game(1, 1),
+            factory_game(2, 1),
+        ]));
+
+        let mut verifier_games = HashMap::new();
+        verifier_games.insert(
+            addr(0),
+            mock_state_with_tee(GameStatus::InProgress, Address::ZERO, tee_addr, 100),
+        );
+        verifier_games.insert(
+            addr(1),
+            mock_state_with_tee(GameStatus::InProgress, Address::ZERO, tee_addr, 200),
+        );
+        verifier_games.insert(
+            addr(2),
+            mock_state_with_tee(GameStatus::InProgress, Address::ZERO, tee_addr, 300),
+        );
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
+
+        let mut scanner = GameScanner::new(
+            Arc::clone(&factory) as Arc<dyn DisputeGameFactoryClient>,
+            Arc::clone(&verifier) as Arc<dyn AggregateVerifierClient>,
+            mock_anchor_registry(Address::ZERO),
+        );
+
+        // First tick: all three games are post-anchor and discovered.
+        let initial = scanner.scan().await.unwrap();
+        assert_eq!(initial.len(), 3, "all three initial games are actionable");
+        assert!(initial.iter().any(|c| c.index == 0));
+        assert_eq!(scanner.tracked_indices_len(), 3);
+
+        // Simulate a late ZK challenge against game 0 while it remains
+        // IN_PROGRESS, then push three new games into the factory.
+        let mut challenged_state =
+            mock_state_with_tee(GameStatus::InProgress, zk_addr, tee_addr, 100);
+        challenged_state.countered_index = 2; // 1-based → challenged_index = 1
+        verifier.update_game(addr(0), challenged_state);
+
+        for i in 3..6u64 {
+            factory.push(factory_game(i, 1));
+            verifier.update_game(
+                addr(i),
+                mock_state_with_tee(GameStatus::InProgress, Address::ZERO, tee_addr, i * 100),
+            );
+        }
+
+        // Second tick: game 0 is still post-anchor, so it must be returned by scan().
+        let late = scanner.scan().await.unwrap();
+        let game_zero = late
+            .iter()
+            .find(|c| c.index == 0)
+            .expect("old post-anchor in-progress game must still be returned by scan()");
+        assert_eq!(
+            game_zero.category,
+            GameCategory::FraudulentZkChallenge { challenged_index: 1 },
+            "old game should now classify under its late state transition"
+        );
+    }
+
+    /// Resolved games are dropped from the persistent tracking set so that
+    /// memory use does not grow unbounded with the total factory size.
+    #[tokio::test]
+    async fn test_scan_drops_resolved_games_from_tracking() {
+        let tee_addr = Address::repeat_byte(0xEE);
+
+        let factory = Arc::new(MockDisputeGameFactory::new(vec![factory_game(0, 1)]));
+
+        let mut verifier_games = HashMap::new();
+        verifier_games.insert(
+            addr(0),
+            mock_state_with_tee(GameStatus::InProgress, Address::ZERO, tee_addr, 100),
+        );
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
+
+        let mut scanner = GameScanner::new(
+            Arc::clone(&factory) as Arc<dyn DisputeGameFactoryClient>,
+            Arc::clone(&verifier) as Arc<dyn AggregateVerifierClient>,
+            mock_anchor_registry(Address::ZERO),
+        );
+
+        // First tick: game 0 is in progress and gets tracked.
+        let initial = scanner.scan().await.unwrap();
+        assert_eq!(initial.len(), 1);
+        assert_eq!(scanner.tracked_indices_len(), 1);
+
+        // Resolve game 0 and add newer games.
+        let mut resolved =
+            mock_state_with_tee(GameStatus::InProgress, Address::ZERO, tee_addr, 100);
+        resolved.status = GameStatus::ChallengerWins;
+        verifier.update_game(addr(0), resolved);
+        for i in 1..4u64 {
+            factory.push(factory_game(i, 1));
+            verifier.update_game(
+                addr(i),
+                mock_state_with_tee(GameStatus::InProgress, Address::ZERO, tee_addr, i * 100),
+            );
+        }
+
+        let _ = scanner.scan().await.unwrap();
+
+        // Tracking should hold only the three new IN_PROGRESS games — the
+        // resolved game must be dropped.
+        assert_eq!(scanner.tracked_indices_len(), 3);
+    }
+
+    /// Fully nullified games (both provers zero) are dropped from the
+    /// persistent tracking set even while they remain `IN_PROGRESS`,
+    /// because no on-chain transition can make them actionable again.
+    #[tokio::test]
+    async fn test_scan_drops_fully_nullified_games_from_tracking() {
+        let tee_addr = Address::repeat_byte(0xEE);
+
+        let factory = Arc::new(MockDisputeGameFactory::new(vec![factory_game(0, 1)]));
+
+        let mut verifier_games = HashMap::new();
+        verifier_games.insert(
+            addr(0),
+            mock_state_with_tee(GameStatus::InProgress, Address::ZERO, tee_addr, 100),
+        );
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
+
+        let mut scanner = GameScanner::new(
+            Arc::clone(&factory) as Arc<dyn DisputeGameFactoryClient>,
+            Arc::clone(&verifier) as Arc<dyn AggregateVerifierClient>,
+            mock_anchor_registry(Address::ZERO),
+        );
+
+        scanner.scan().await.unwrap();
+        assert_eq!(scanner.tracked_indices_len(), 1);
+
+        // Fully nullify the game (both provers zero) while keeping it IN_PROGRESS.
+        verifier.update_game(
+            addr(0),
+            mock_state_with_tee(GameStatus::InProgress, Address::ZERO, Address::ZERO, 100),
+        );
+        for i in 1..4u64 {
+            factory.push(factory_game(i, 1));
+            verifier.update_game(
+                addr(i),
+                mock_state_with_tee(GameStatus::InProgress, Address::ZERO, tee_addr, i * 100),
+            );
+        }
+
+        scanner.scan().await.unwrap();
+
+        // Only the three new live games remain tracked.
+        assert_eq!(scanner.tracked_indices_len(), 3);
+    }
+}

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -472,11 +472,7 @@ pub const DEFAULT_L1_HEAD: B256 = B256::repeat_byte(0xAA);
 ///
 /// Uses [`DEFAULT_TEE_PROVER`] as the TEE prover address. Use
 /// [`mock_state_with_tee`] to override.
-pub fn mock_state(
-    status: GameStatus,
-    zk_prover: Address,
-    block_number: u64,
-) -> MockGameState {
+pub fn mock_state(status: GameStatus, zk_prover: Address, block_number: u64) -> MockGameState {
     mock_state_with_tee(status, zk_prover, DEFAULT_TEE_PROVER, block_number)
 }
 

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -63,26 +63,12 @@ pub struct MockGameState {
     pub bond_unlocked: bool,
     /// Whether the bond has been claimed.
     pub bond_claimed: bool,
-    /// Expected resolution timestamp.
-    pub expected_resolution: u64,
-    /// Number of verified proofs.
-    pub proof_count: u8,
-    /// Timestamp at which the game was created.
-    pub created_at: u64,
     /// Address of the `DelayedWETH` contract.
     pub delayed_weth: Address,
     /// Address of the `AnchorStateRegistry` contract.
     pub anchor_state_registry: Address,
-    /// Whether the game is blacklisted in the `AnchorStateRegistry`.
-    pub is_blacklisted: bool,
     /// Whether the game is finalized in the `AnchorStateRegistry`.
     pub is_finalized: bool,
-    /// Whether the game is respected in the `AnchorStateRegistry`.
-    pub is_respected: bool,
-    /// Whether the game is retired in the `AnchorStateRegistry`.
-    pub is_retired: bool,
-    /// Whether the `AnchorStateRegistry` is currently paused.
-    pub is_paused: bool,
     /// Current anchor root returned by the `AnchorStateRegistry`.
     pub anchor_root: AnchorRoot,
 }
@@ -107,16 +93,9 @@ impl Default for MockGameState {
             bond_recipient: Address::ZERO,
             bond_unlocked: false,
             bond_claimed: false,
-            expected_resolution: u64::MAX,
-            proof_count: 0,
-            created_at: 0,
             delayed_weth: Address::ZERO,
             anchor_state_registry: Address::ZERO,
-            is_blacklisted: false,
             is_finalized: true,
-            is_respected: true,
-            is_retired: false,
-            is_paused: false,
             anchor_root: AnchorRoot { root: B256::ZERO, l2_block_number: 0 },
         }
     }
@@ -258,16 +237,6 @@ pub struct MockAggregateVerifier {
     pub game_info_reads: Mutex<Vec<Address>>,
     /// Addresses passed to `status`, used by tests that assert cached reads.
     pub status_reads: Mutex<Vec<Address>>,
-    /// Addresses passed to `zk_prover`, used by tests that assert cheap pending polls.
-    pub zk_prover_reads: Mutex<Vec<Address>>,
-    /// Addresses passed to `tee_prover`, used by tests that assert cheap pending polls.
-    pub tee_prover_reads: Mutex<Vec<Address>>,
-    /// Addresses passed to `countered_index`, used by tests that assert cheap pending polls.
-    pub countered_index_reads: Mutex<Vec<Address>>,
-    /// Addresses passed to `game_over`, used by tests that assert cheap pending polls.
-    pub game_over_reads: Mutex<Vec<Address>>,
-    /// Addresses passed to `anchor_state_registry`, used by tests that assert cached reads.
-    pub anchor_state_registry_reads: Mutex<Vec<Address>>,
     /// Addresses passed to `delayed_weth`, used by tests that assert cached reads.
     pub delayed_weth_reads: Mutex<Vec<Address>>,
     /// Addresses passed to `read_intermediate_block_interval`, used by cache tests.
@@ -281,11 +250,6 @@ impl MockAggregateVerifier {
             games: Mutex::new(games),
             game_info_reads: Mutex::new(Vec::new()),
             status_reads: Mutex::new(Vec::new()),
-            zk_prover_reads: Mutex::new(Vec::new()),
-            tee_prover_reads: Mutex::new(Vec::new()),
-            countered_index_reads: Mutex::new(Vec::new()),
-            game_over_reads: Mutex::new(Vec::new()),
-            anchor_state_registry_reads: Mutex::new(Vec::new()),
             delayed_weth_reads: Mutex::new(Vec::new()),
             intermediate_block_interval_reads: Mutex::new(Vec::new()),
         }
@@ -312,16 +276,6 @@ impl MockAggregateVerifier {
     /// Returns how many times `status` was read for a game.
     pub fn status_read_count(&self, game_address: Address) -> usize {
         self.status_reads
-            .lock()
-            .unwrap()
-            .iter()
-            .filter(|&&read_address| read_address == game_address)
-            .count()
-    }
-
-    /// Returns how many times `anchor_state_registry` was read for a game.
-    pub fn anchor_state_registry_read_count(&self, game_address: Address) -> usize {
-        self.anchor_state_registry_reads
             .lock()
             .unwrap()
             .iter()
@@ -356,12 +310,10 @@ impl AggregateVerifierClient for MockAggregateVerifier {
     }
 
     async fn zk_prover(&self, game_address: Address) -> Result<Address, ContractError> {
-        self.zk_prover_reads.lock().unwrap().push(game_address);
         self.get(game_address, |s| s.zk_prover)
     }
 
     async fn tee_prover(&self, game_address: Address) -> Result<Address, ContractError> {
-        self.tee_prover_reads.lock().unwrap().push(game_address);
         self.get(game_address, |s| s.tee_prover)
     }
 
@@ -407,12 +359,10 @@ impl AggregateVerifierClient for MockAggregateVerifier {
     }
 
     async fn countered_index(&self, game_address: Address) -> Result<u64, ContractError> {
-        self.countered_index_reads.lock().unwrap().push(game_address);
         self.get(game_address, |s| s.countered_index)
     }
 
     async fn game_over(&self, game_address: Address) -> Result<bool, ContractError> {
-        self.game_over_reads.lock().unwrap().push(game_address);
         self.get(game_address, |s| s.game_over)
     }
 
@@ -433,15 +383,15 @@ impl AggregateVerifierClient for MockAggregateVerifier {
     }
 
     async fn expected_resolution(&self, game_address: Address) -> Result<u64, ContractError> {
-        self.get(game_address, |s| s.expected_resolution)
+        self.get(game_address, |_| u64::MAX)
     }
 
     async fn proof_count(&self, game_address: Address) -> Result<u8, ContractError> {
-        self.get(game_address, |s| s.proof_count)
+        self.get(game_address, |_| 0)
     }
 
     async fn created_at(&self, game_address: Address) -> Result<u64, ContractError> {
-        self.get(game_address, |s| s.created_at)
+        self.get(game_address, |_| 0)
     }
 
     async fn delayed_weth(&self, game_address: Address) -> Result<Address, ContractError> {
@@ -450,7 +400,6 @@ impl AggregateVerifierClient for MockAggregateVerifier {
     }
 
     async fn anchor_state_registry(&self, game_address: Address) -> Result<Address, ContractError> {
-        self.anchor_state_registry_reads.lock().unwrap().push(game_address);
         self.get(game_address, |s| s.anchor_state_registry)
     }
 
@@ -488,10 +437,10 @@ impl AggregateVerifierClient for MockAggregateVerifier {
             )));
         }
         Ok(AnchorPreflight {
-            blacklisted: state.is_blacklisted,
-            retired: state.is_retired,
-            respected: state.is_respected,
-            paused: state.is_paused,
+            blacklisted: false,
+            retired: false,
+            respected: true,
+            paused: false,
             anchor_root: state.anchor_root,
         })
     }
@@ -509,11 +458,6 @@ pub fn factory_game(index: u64, game_type: u32) -> GameAtIndex {
     GameAtIndex { game_type, timestamp: 1_000_000 + index, proxy: addr(index) }
 }
 
-/// Helper to create an empty [`MockDisputeGameFactory`] behind an `Arc`.
-pub fn empty_factory() -> Arc<dyn DisputeGameFactoryClient> {
-    Arc::new(MockDisputeGameFactory::new(vec![]))
-}
-
 /// Default TEE prover address used by [`mock_state`].
 ///
 /// Every game in the multiproof system is initialized with at least one
@@ -528,7 +472,7 @@ pub const DEFAULT_L1_HEAD: B256 = B256::repeat_byte(0xAA);
 ///
 /// Uses [`DEFAULT_TEE_PROVER`] as the TEE prover address. Use
 /// [`mock_state_with_tee`] to override.
-pub const fn mock_state(
+pub fn mock_state(
     status: GameStatus,
     zk_prover: Address,
     block_number: u64,
@@ -537,7 +481,7 @@ pub const fn mock_state(
 }
 
 /// Helper to build mock game state with an explicit TEE prover address.
-pub const fn mock_state_with_tee(
+pub fn mock_state_with_tee(
     status: GameStatus,
     zk_prover: Address,
     tee_prover: Address,
@@ -554,123 +498,7 @@ pub const fn mock_state_with_tee(
         },
         starting_block_number: block_number.saturating_sub(10),
         l1_head: DEFAULT_L1_HEAD,
-        intermediate_output_roots: vec![],
-        countered_index: 0,
-        game_over: false,
-        resolved_at: 0,
-        bond_recipient: Address::ZERO,
-        bond_unlocked: false,
-        bond_claimed: false,
-        expected_resolution: u64::MAX,
-        proof_count: 0,
-        created_at: 0,
-        delayed_weth: Address::ZERO,
-        anchor_state_registry: Address::ZERO,
-        is_blacklisted: false,
-        is_finalized: true,
-        is_respected: true,
-        is_retired: false,
-        is_paused: false,
-        anchor_root: AnchorRoot { root: B256::ZERO, l2_block_number: 0 },
-    }
-}
-
-/// Mock factory that returns an error for specific indices.
-#[derive(Debug)]
-pub struct ErrorOnIndexFactory {
-    /// The inner factory providing normal game data.
-    pub inner: MockDisputeGameFactory,
-    /// Indices that should return an error when queried.
-    pub error_indices: Vec<u64>,
-}
-
-#[async_trait]
-impl DisputeGameFactoryClient for ErrorOnIndexFactory {
-    async fn game_count(&self) -> Result<u64, ContractError> {
-        self.inner.game_count().await
-    }
-
-    async fn game_at_index(&self, index: u64) -> Result<GameAtIndex, ContractError> {
-        if self.error_indices.contains(&index) {
-            return Err(ContractError::Validation(format!("simulated error at index {index}")));
-        }
-        self.inner.game_at_index(index).await
-    }
-
-    async fn init_bonds(&self, game_type: u32) -> Result<U256, ContractError> {
-        self.inner.init_bonds(game_type).await
-    }
-
-    async fn game_impls(&self, game_type: u32) -> Result<Address, ContractError> {
-        self.inner.game_impls(game_type).await
-    }
-
-    async fn games(
-        &self,
-        game_type: u32,
-        root_claim: B256,
-        extra_data: Bytes,
-    ) -> Result<Address, ContractError> {
-        self.inner.games(game_type, root_claim, extra_data).await
-    }
-}
-
-/// Mock factory that records queried indices and can return errors for specific indices.
-#[derive(Debug)]
-pub struct RecordingDisputeGameFactory {
-    /// The inner factory providing normal game data.
-    pub inner: MockDisputeGameFactory,
-    /// Indices that should return an error when queried.
-    pub error_indices: Vec<u64>,
-    /// Factory indices queried through `game_at_index`.
-    pub queried_indices: Mutex<Vec<u64>>,
-}
-
-impl RecordingDisputeGameFactory {
-    /// Creates a new recording factory.
-    pub fn new(games: Vec<GameAtIndex>, error_indices: Vec<u64>) -> Self {
-        Self {
-            inner: MockDisputeGameFactory::new(games),
-            error_indices,
-            queried_indices: Mutex::new(Vec::new()),
-        }
-    }
-
-    /// Returns all indices queried so far.
-    pub fn queried_indices(&self) -> Vec<u64> {
-        self.queried_indices.lock().unwrap().clone()
-    }
-}
-
-#[async_trait]
-impl DisputeGameFactoryClient for RecordingDisputeGameFactory {
-    async fn game_count(&self) -> Result<u64, ContractError> {
-        self.inner.game_count().await
-    }
-
-    async fn game_at_index(&self, index: u64) -> Result<GameAtIndex, ContractError> {
-        self.queried_indices.lock().unwrap().push(index);
-        if self.error_indices.contains(&index) {
-            return Err(ContractError::Validation(format!("simulated error at index {index}")));
-        }
-        self.inner.game_at_index(index).await
-    }
-
-    async fn init_bonds(&self, game_type: u32) -> Result<U256, ContractError> {
-        self.inner.init_bonds(game_type).await
-    }
-
-    async fn game_impls(&self, game_type: u32) -> Result<Address, ContractError> {
-        self.inner.game_impls(game_type).await
-    }
-
-    async fn games(
-        &self,
-        game_type: u32,
-        root_claim: B256,
-        extra_data: Bytes,
-    ) -> Result<Address, ContractError> {
-        self.inner.games(game_type, root_claim, extra_data).await
+        ..Default::default()
     }
 }
 
@@ -692,11 +520,6 @@ pub struct MockL2Provider {
 }
 
 impl MockL2Provider {
-    /// Creates a new empty mock L2 provider.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     /// Inserts a block header and corresponding account proof.
     ///
     /// The consensus header is wrapped in an RPC header with the hash computed
@@ -763,10 +586,8 @@ impl L2Provider for MockL2Provider {
 }
 
 /// Mock prover-service requester for testing ZK proof flows in the driver.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct MockZkProofProvider {
-    /// Session ID returned by [`prove_block_range`](ProofRequesterProvider::prove_block_range).
-    pub session_id: String,
     /// Mutable proof state returned by [`get_proof`](ProofRequesterProvider::get_proof).
     pub state: Mutex<MockZkProofState>,
 }
@@ -800,12 +621,6 @@ impl Default for MockZkProofState {
             error_message: None,
             prove_block_range_log: Vec::new(),
         }
-    }
-}
-
-impl Default for MockZkProofProvider {
-    fn default() -> Self {
-        Self { session_id: String::new(), state: Mutex::new(MockZkProofState::default()) }
     }
 }
 
@@ -943,47 +758,31 @@ impl L1Provider for MockL1 {
 }
 
 /// Mock transaction manager for testing the driver and submitter.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MockTxManager {
     /// Queue of responses returned by [`send`](TxManager::send).
-    pub responses: Mutex<VecDeque<SendResponse>>,
+    pub responses: Arc<Mutex<VecDeque<SendResponse>>>,
     /// Transaction candidates submitted through [`send`](TxManager::send).
-    pub calls: Mutex<Vec<TxCandidate>>,
+    pub calls: Arc<Mutex<Vec<TxCandidate>>>,
 }
 
 impl MockTxManager {
     /// Creates a new mock with a single pre-configured response.
     pub fn new(response: SendResponse) -> Self {
-        Self { responses: Mutex::new(VecDeque::from([response])), calls: Mutex::new(Vec::new()) }
+        Self::with_responses(vec![response])
     }
 
     /// Creates a new mock with multiple responses returned in order.
     pub fn with_responses(responses: Vec<SendResponse>) -> Self {
-        Self { responses: Mutex::new(VecDeque::from(responses)), calls: Mutex::new(Vec::new()) }
+        Self {
+            responses: Arc::new(Mutex::new(VecDeque::from(responses))),
+            calls: Arc::new(Mutex::new(Vec::new())),
+        }
     }
 
     /// Returns the recorded transaction candidates.
     pub fn recorded_calls(&self) -> Vec<TxCandidate> {
         self.calls.lock().unwrap().clone()
-    }
-}
-
-/// Cloneable handle around [`MockTxManager`] for tests that need to inspect
-/// calls after moving a tx manager into another type.
-#[derive(Debug, Clone)]
-pub struct SharedMockTxManager {
-    inner: Arc<MockTxManager>,
-}
-
-impl SharedMockTxManager {
-    /// Creates a shared mock with multiple responses returned in order.
-    pub fn with_responses(responses: Vec<SendResponse>) -> Self {
-        Self { inner: Arc::new(MockTxManager::with_responses(responses)) }
-    }
-
-    /// Returns the recorded transaction candidates.
-    pub fn recorded_calls(&self) -> Vec<TxCandidate> {
-        self.inner.recorded_calls()
     }
 }
 
@@ -999,20 +798,6 @@ impl TxManager for MockTxManager {
 
     fn sender_address(&self) -> Address {
         Address::ZERO
-    }
-}
-
-impl TxManager for SharedMockTxManager {
-    async fn send(&self, candidate: TxCandidate) -> SendResponse {
-        self.inner.send(candidate).await
-    }
-
-    async fn send_async(&self, candidate: TxCandidate) -> SendHandle {
-        self.inner.send_async(candidate).await
-    }
-
-    fn sender_address(&self) -> Address {
-        self.inner.sender_address()
     }
 }
 
@@ -1098,646 +883,12 @@ pub fn build_test_header_and_account_for_address(
 mod tests {
 
     use super::*;
-    use crate::scanner::{GameCategory, GameScanner};
 
     #[tokio::test]
     #[should_panic(expected = "MockL2Provider::header_by_number does not support tag finalized")]
     async fn test_mock_l2_provider_rejects_block_tags() {
-        let provider = MockL2Provider::new();
+        let provider = MockL2Provider::default();
 
         let _ = provider.header_by_number(BlockNumberOrTag::Finalized).await;
-    }
-
-    /// Happy path: mixed games, only `IN_PROGRESS` / non-nullified returned.
-    #[tokio::test]
-    async fn test_scan_happy_path() {
-        // Game 0: type 1, IN_PROGRESS, TEE only -> candidate (InvalidTeeProposal)
-        // Game 1: type 99, IN_PROGRESS, TEE only -> candidate (all types scanned)
-        // Game 2: type 1, status=1 (not in progress) -> skipped
-        // Game 3: type 1, IN_PROGRESS, TEE + ZK (dual proof) -> candidate (InvalidDualProposal)
-        // Game 4: type 1, IN_PROGRESS, TEE only -> candidate (InvalidTeeProposal)
-        let factory = Arc::new(MockDisputeGameFactory::new(vec![
-            factory_game(0, 1),
-            factory_game(1, 99),
-            factory_game(2, 1),
-            factory_game(3, 1),
-            factory_game(4, 1),
-        ]));
-
-        let challenger_addr = Address::repeat_byte(0xCC);
-        let mut verifier_games = HashMap::new();
-        verifier_games.insert(addr(0), mock_state(GameStatus::InProgress, Address::ZERO, 100));
-        verifier_games.insert(addr(1), mock_state(GameStatus::InProgress, Address::ZERO, 150));
-        verifier_games.insert(addr(2), mock_state(GameStatus::ChallengerWins, Address::ZERO, 200));
-        verifier_games.insert(addr(3), mock_state(GameStatus::InProgress, challenger_addr, 300));
-        verifier_games.insert(addr(4), mock_state(GameStatus::InProgress, Address::ZERO, 400));
-
-        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-
-        let mut scanner = GameScanner::new(
-            factory,
-            Arc::clone(&verifier) as Arc<dyn AggregateVerifierClient>,
-            mock_anchor_registry(Address::ZERO),
-        );
-
-        let candidates = scanner.scan().await.unwrap();
-
-        // start = max(0, 5-1000) = 0, so games 0..=4 scanned
-        // Game 0: TEE only -> candidate. Game 1: TEE only -> candidate.
-        // Game 2: status != 0 -> skipped.
-        // Game 3: dual proof (TEE+ZK, no challenge) -> candidate.
-        // Game 4: TEE only -> candidate.
-        assert_eq!(candidates.len(), 4);
-        assert_eq!(candidates[0].index, 0);
-        assert_eq!(candidates[0].factory.game_type, 1);
-        assert_eq!(candidates[0].info.l2_block_number, 100);
-        assert_eq!(candidates[1].index, 1);
-        assert_eq!(candidates[1].factory.game_type, 99);
-        assert_eq!(candidates[1].info.l2_block_number, 150);
-        assert_eq!(candidates[2].index, 3);
-        assert_eq!(candidates[2].category, GameCategory::InvalidDualProposal);
-        assert_eq!(candidates[3].index, 4);
-        assert_eq!(candidates[3].factory.game_type, 1);
-        assert_eq!(candidates[3].info.l2_block_number, 400);
-        assert_eq!(
-            verifier.intermediate_block_interval_reads.lock().unwrap().as_slice(),
-            &[Address::repeat_byte(0x11)],
-        );
-    }
-
-    /// Dual-proof games (TEE + ZK, no challenge) are now candidates.
-    #[tokio::test]
-    async fn test_scan_dual_proof_games_are_candidates() {
-        let zk_addr = Address::repeat_byte(0xAA);
-
-        let factory = Arc::new(MockDisputeGameFactory::new(vec![
-            factory_game(0, 1),
-            factory_game(1, 1),
-            factory_game(2, 1),
-        ]));
-
-        let mut verifier_games = HashMap::new();
-        // Game 0: TEE + ZK (dual proof, no challenge) -> candidate (InvalidDualProposal)
-        verifier_games.insert(addr(0), mock_state(GameStatus::InProgress, zk_addr, 100));
-        // Game 1: TEE only -> candidate (InvalidTeeProposal)
-        verifier_games.insert(addr(1), mock_state(GameStatus::InProgress, Address::ZERO, 200));
-        // Game 2: TEE + ZK (dual proof, no challenge) -> candidate (InvalidDualProposal)
-        verifier_games.insert(addr(2), mock_state(GameStatus::InProgress, zk_addr, 300));
-
-        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-
-        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
-
-        let candidates = scanner.scan().await.unwrap();
-
-        assert_eq!(candidates.len(), 3);
-        assert_eq!(candidates[0].index, 0);
-        assert_eq!(candidates[0].category, GameCategory::InvalidDualProposal);
-        assert_eq!(candidates[1].index, 1);
-        assert_eq!(candidates[1].category, GameCategory::InvalidTeeProposal);
-        assert_eq!(candidates[2].index, 2);
-        assert_eq!(candidates[2].category, GameCategory::InvalidDualProposal);
-    }
-
-    /// Empty factory returns empty vec without error.
-    #[tokio::test]
-    async fn test_scan_empty_factory() {
-        let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
-        let verifier = Arc::new(MockAggregateVerifier::new(HashMap::new()));
-
-        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
-
-        let candidates = scanner.scan().await.unwrap();
-
-        assert!(candidates.is_empty());
-    }
-
-    /// Anchor lower bound: only games after the current anchor game are scanned.
-    #[tokio::test]
-    async fn test_scan_starts_after_anchor_game() {
-        // Factory with 100 games and anchor at index 96 -> scan indices 97, 98, 99.
-        let mut games = Vec::new();
-        let mut verifier_games = HashMap::new();
-
-        for i in 0..100u64 {
-            games.push(factory_game(i, 1));
-            verifier_games
-                .insert(addr(i), mock_state(GameStatus::InProgress, Address::ZERO, i * 10));
-        }
-
-        let factory = Arc::new(MockDisputeGameFactory::new(games));
-        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-
-        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(addr(96)));
-
-        let candidates = scanner.scan().await.unwrap();
-
-        assert_eq!(candidates.len(), 3);
-        assert_eq!(candidates[0].index, 97);
-        assert_eq!(candidates[1].index, 98);
-        assert_eq!(candidates[2].index, 99);
-    }
-
-    /// Cold anchor lookup searches the latest batch first and skips individual
-    /// lookup errors without aborting the whole search.
-    #[tokio::test]
-    async fn test_find_game_index_searches_tail_batch_and_skips_errors() {
-        let game_count = GameScanner::ANCHOR_SEARCH_BATCH_SIZE + 10;
-        let target_index = game_count - 1;
-        let error_index = target_index - 1;
-
-        let games = (0..game_count).map(|i| factory_game(i, 1)).collect();
-        let factory = Arc::new(RecordingDisputeGameFactory::new(games, vec![error_index]));
-        let verifier = Arc::new(MockAggregateVerifier::new(HashMap::new()));
-        let scanner = GameScanner::new(
-            Arc::clone(&factory) as Arc<dyn DisputeGameFactoryClient>,
-            verifier,
-            mock_anchor_registry(Address::ZERO),
-        );
-
-        let (found, had_errors) = scanner.find_game_index(addr(target_index), 0, game_count).await;
-
-        assert_eq!(found, Some(target_index));
-        assert!(had_errors, "lookup should report skipped per-index errors");
-
-        let queried = factory.queried_indices();
-        let first_tail_index = game_count - GameScanner::ANCHOR_SEARCH_BATCH_SIZE;
-        assert_eq!(queried.len() as u64, GameScanner::ANCHOR_SEARCH_BATCH_SIZE);
-        assert!(
-            queried.iter().all(|&i| i >= first_tail_index && i < game_count),
-            "cold lookup should only query the latest anchor search batch"
-        );
-    }
-
-    /// If a factory ever reused a proxy address, anchor lookup should return
-    /// the matching index nearest the end of the searched range.
-    #[tokio::test]
-    async fn test_find_game_index_returns_match_closest_to_end() {
-        let target = addr(99);
-        let mut games =
-            vec![factory_game(0, 1), factory_game(1, 1), factory_game(2, 1), factory_game(3, 1)];
-        games[1].proxy = target;
-        games[3].proxy = target;
-
-        let factory = Arc::new(RecordingDisputeGameFactory::new(games, vec![]));
-        let verifier = Arc::new(MockAggregateVerifier::new(HashMap::new()));
-        let scanner = GameScanner::new(
-            Arc::clone(&factory) as Arc<dyn DisputeGameFactoryClient>,
-            verifier,
-            mock_anchor_registry(Address::ZERO),
-        );
-
-        let (found, had_errors) = scanner.find_game_index(target, 0, 4).await;
-
-        assert_eq!(found, Some(3));
-        assert!(!had_errors);
-    }
-
-    /// If reading the anchor snapshot fails after a cache has been populated,
-    /// the scanner keeps using the cached anchor instead of scanning genesis.
-    #[tokio::test]
-    async fn test_scan_uses_cached_anchor_when_anchor_snapshot_fails() {
-        let mut games = Vec::new();
-        let mut verifier_games = HashMap::new();
-
-        for i in 0..5u64 {
-            games.push(factory_game(i, 1));
-            verifier_games
-                .insert(addr(i), mock_state(GameStatus::InProgress, Address::ZERO, i * 10));
-        }
-
-        let factory = Arc::new(MockDisputeGameFactory::new(games));
-        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-        let anchor_registry = Arc::new(MockAnchorStateRegistry::new(addr(2)));
-        let mut scanner = GameScanner::new(
-            factory,
-            verifier,
-            Arc::clone(&anchor_registry) as Arc<dyn AnchorStateRegistryClient>,
-        );
-
-        let initial = scanner.scan().await.unwrap();
-        assert_eq!(initial.iter().map(|c| c.index).collect::<Vec<_>>(), vec![3, 4]);
-
-        anchor_registry.set_fail_snapshot(true);
-        let cached = scanner.scan().await.unwrap();
-
-        assert_eq!(cached.iter().map(|c| c.index).collect::<Vec<_>>(), vec![3, 4]);
-    }
-
-    /// When the anchor advances, tracked indices behind it are pruned from the
-    /// in-progress tracking map.
-    #[tokio::test]
-    async fn test_scan_prunes_tracking_when_anchor_advances() {
-        let mut games = Vec::new();
-        let mut verifier_games = HashMap::new();
-
-        for i in 0..5u64 {
-            games.push(factory_game(i, 1));
-            verifier_games
-                .insert(addr(i), mock_state(GameStatus::InProgress, Address::ZERO, i * 10));
-        }
-
-        let factory = Arc::new(MockDisputeGameFactory::new(games));
-        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-        let anchor_registry = Arc::new(MockAnchorStateRegistry::new(Address::ZERO));
-        let mut scanner = GameScanner::new(
-            factory,
-            verifier,
-            Arc::clone(&anchor_registry) as Arc<dyn AnchorStateRegistryClient>,
-        );
-
-        scanner.scan().await.unwrap();
-        assert_eq!(scanner.tracked_indices_len(), 5);
-
-        anchor_registry.set_anchor_game(addr(2));
-        let candidates = scanner.scan().await.unwrap();
-
-        assert_eq!(candidates.iter().map(|c| c.index).collect::<Vec<_>>(), vec![3, 4]);
-        assert_eq!(scanner.tracked_indices_len(), 2);
-    }
-
-    /// Error resilience: a per-game error is logged and skipped, other games still returned.
-    /// Errored games are naturally retried on the next scan since the full post-anchor
-    /// range is always evaluated.
-    #[tokio::test]
-    async fn test_scan_skips_errored_games() {
-        // 3 games: index 1 will error, indices 0 and 2 are valid candidates
-        let factory = Arc::new(ErrorOnIndexFactory {
-            inner: MockDisputeGameFactory::new(vec![
-                factory_game(0, 1),
-                factory_game(1, 1),
-                factory_game(2, 1),
-            ]),
-            error_indices: vec![1],
-        });
-
-        let mut verifier_games = HashMap::new();
-        verifier_games.insert(addr(0), mock_state(GameStatus::InProgress, Address::ZERO, 100));
-        // index 1 won't be queried on the verifier because the factory errors first
-        verifier_games.insert(addr(2), mock_state(GameStatus::InProgress, Address::ZERO, 300));
-
-        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-
-        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
-
-        // Index 0 -> candidate. Index 1 errors -> skipped. Index 2 -> candidate.
-        let candidates = scanner.scan().await.unwrap();
-
-        assert_eq!(candidates.len(), 2);
-        assert_eq!(candidates[0].index, 0);
-        assert_eq!(candidates[1].index, 2);
-        assert_eq!(
-            scanner.tracked_indices_len(),
-            2,
-            "tail-only errors should not inflate in-progress tracking"
-        );
-    }
-
-    /// Games with a non-zero TEE prover but zero ZK prover are still candidates.
-    ///
-    /// A non-zero `teeProver` with `zkProver == ZERO` is the normal initial
-    /// state for an unchallenged game. The scanner should return these as
-    /// candidates.
-    #[tokio::test]
-    async fn test_scan_tee_prover_nonzero_still_candidate() {
-        let tee_addr = Address::repeat_byte(0xEE);
-
-        let factory =
-            Arc::new(MockDisputeGameFactory::new(vec![factory_game(0, 1), factory_game(1, 1)]));
-
-        let mut verifier_games = HashMap::new();
-        // Game 0: IN_PROGRESS, no ZK prover, has a TEE prover -> candidate
-        verifier_games.insert(
-            addr(0),
-            mock_state_with_tee(GameStatus::InProgress, Address::ZERO, tee_addr, 100),
-        );
-        // Game 1: IN_PROGRESS, no ZK prover, has default TEE prover -> candidate
-        verifier_games.insert(addr(1), mock_state(GameStatus::InProgress, Address::ZERO, 200));
-
-        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-
-        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
-
-        let candidates = scanner.scan().await.unwrap();
-
-        assert_eq!(candidates.len(), 2);
-        assert_eq!(candidates[0].index, 0);
-        assert_eq!(candidates[1].index, 1);
-    }
-
-    /// Error at the first index (0) skips that game, rest still returned.
-    #[tokio::test]
-    async fn test_scan_error_at_first_index() {
-        let factory = Arc::new(ErrorOnIndexFactory {
-            inner: MockDisputeGameFactory::new(vec![factory_game(0, 1), factory_game(1, 1)]),
-            error_indices: vec![0],
-        });
-
-        let mut verifier_games = HashMap::new();
-        verifier_games.insert(addr(1), mock_state(GameStatus::InProgress, Address::ZERO, 200));
-
-        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-
-        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
-
-        let candidates = scanner.scan().await.unwrap();
-
-        assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].index, 1);
-        assert_eq!(
-            scanner.tracked_indices_len(),
-            1,
-            "tail-only errors should not inflate in-progress tracking"
-        );
-    }
-
-    /// A challenged game (TEE + ZK provers non-zero, `countered_index` > 0) is
-    /// returned as a [`GameCategory::FraudulentZkChallenge`] candidate.
-    #[tokio::test]
-    async fn test_scan_challenged_game_returns_fraudulent_zk_challenge() {
-        let tee_addr = Address::repeat_byte(0xEE);
-        let zk_addr = Address::repeat_byte(0xCC);
-
-        let factory = Arc::new(MockDisputeGameFactory::new(vec![factory_game(0, 1)]));
-
-        let mut verifier_games = HashMap::new();
-        let mut state = mock_state_with_tee(GameStatus::InProgress, zk_addr, tee_addr, 100);
-        state.countered_index = 3; // 1-based: challenged at 0-based index 2
-        verifier_games.insert(addr(0), state);
-
-        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
-
-        let candidates = scanner.scan().await.unwrap();
-
-        assert_eq!(candidates.len(), 1);
-        assert_eq!(
-            candidates[0].category,
-            GameCategory::FraudulentZkChallenge { challenged_index: 2 }
-        );
-    }
-
-    /// A ZK-proposed game (`tee_prover` == 0, `zk_prover` != 0, unchallenged) is
-    /// returned as a [`GameCategory::InvalidZkProposal`] candidate.
-    #[tokio::test]
-    async fn test_scan_zk_proposal_returns_invalid_zk_proposal() {
-        let zk_addr = Address::repeat_byte(0xCC);
-
-        let factory = Arc::new(MockDisputeGameFactory::new(vec![factory_game(0, 1)]));
-
-        let mut verifier_games = HashMap::new();
-        // tee_prover == ZERO, zk_prover != ZERO, countered_index == 0
-        verifier_games.insert(
-            addr(0),
-            mock_state_with_tee(GameStatus::InProgress, zk_addr, Address::ZERO, 100),
-        );
-
-        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
-
-        let candidates = scanner.scan().await.unwrap();
-
-        assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].category, GameCategory::InvalidZkProposal);
-    }
-
-    /// A TEE-proposed unchallenged game is returned as
-    /// [`GameCategory::InvalidTeeProposal`].
-    #[tokio::test]
-    async fn test_scan_tee_proposal_returns_invalid_tee_proposal() {
-        let factory = Arc::new(MockDisputeGameFactory::new(vec![factory_game(0, 1)]));
-
-        let mut verifier_games = HashMap::new();
-        verifier_games.insert(addr(0), mock_state(GameStatus::InProgress, Address::ZERO, 100));
-
-        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
-
-        let candidates = scanner.scan().await.unwrap();
-
-        assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].category, GameCategory::InvalidTeeProposal);
-    }
-
-    /// A game with both proofs verified (TEE + ZK, no challenge) is a
-    /// candidate for validation. Both proofs may verify a wrong root.
-    #[tokio::test]
-    async fn test_scan_both_proofs_verified_is_candidate() {
-        let tee_addr = Address::repeat_byte(0xEE);
-        let zk_addr = Address::repeat_byte(0xCC);
-
-        let factory = Arc::new(MockDisputeGameFactory::new(vec![factory_game(0, 1)]));
-
-        let mut verifier_games = HashMap::new();
-        // Both provers non-zero, countered_index == 0 (added via verifyProposalProof)
-        verifier_games
-            .insert(addr(0), mock_state_with_tee(GameStatus::InProgress, zk_addr, tee_addr, 100));
-
-        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
-
-        let candidates = scanner.scan().await.unwrap();
-
-        assert_eq!(candidates.len(), 1, "dual-proof game should be a candidate");
-        assert_eq!(candidates[0].category, GameCategory::InvalidDualProposal);
-    }
-
-    /// Games with both `teeProver` and `zkProver` at `Address::ZERO` are
-    /// filtered out. Every game is initialized with at least one prover, so
-    /// both being zero indicates a prior nullification.
-    #[tokio::test]
-    async fn test_scan_filters_nullified_games() {
-        let tee_addr = Address::repeat_byte(0xEE);
-
-        let factory = Arc::new(MockDisputeGameFactory::new(vec![
-            factory_game(0, 1),
-            factory_game(1, 1),
-            factory_game(2, 1),
-        ]));
-
-        let mut verifier_games = HashMap::new();
-        // Game 0: both provers zeroed (nullified) → filtered out
-        verifier_games.insert(
-            addr(0),
-            mock_state_with_tee(GameStatus::InProgress, Address::ZERO, Address::ZERO, 100),
-        );
-        // Game 1: TEE prover active, ZK prover zero → candidate
-        verifier_games.insert(
-            addr(1),
-            mock_state_with_tee(GameStatus::InProgress, Address::ZERO, tee_addr, 200),
-        );
-        // Game 2: both provers zeroed (nullified) → filtered out
-        verifier_games.insert(
-            addr(2),
-            mock_state_with_tee(GameStatus::InProgress, Address::ZERO, Address::ZERO, 300),
-        );
-
-        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-
-        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
-
-        let candidates = scanner.scan().await.unwrap();
-
-        assert_eq!(candidates.len(), 1, "only the non-nullified game should be a candidate");
-        assert_eq!(candidates[0].index, 1);
-    }
-
-    /// A game remains covered after new games are appended because the scanner
-    /// evaluates the full post-anchor range rather than a rolling tail.
-    #[tokio::test]
-    async fn test_scan_revisits_old_post_anchor_in_progress_games() {
-        let tee_addr = Address::repeat_byte(0xEE);
-        let zk_addr = Address::repeat_byte(0xCC);
-
-        // Initial state: 3 games after the starting anchor.
-        let factory = Arc::new(MockDisputeGameFactory::new(vec![
-            factory_game(0, 1),
-            factory_game(1, 1),
-            factory_game(2, 1),
-        ]));
-
-        let mut verifier_games = HashMap::new();
-        verifier_games.insert(
-            addr(0),
-            mock_state_with_tee(GameStatus::InProgress, Address::ZERO, tee_addr, 100),
-        );
-        verifier_games.insert(
-            addr(1),
-            mock_state_with_tee(GameStatus::InProgress, Address::ZERO, tee_addr, 200),
-        );
-        verifier_games.insert(
-            addr(2),
-            mock_state_with_tee(GameStatus::InProgress, Address::ZERO, tee_addr, 300),
-        );
-        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-
-        let mut scanner = GameScanner::new(
-            Arc::clone(&factory) as Arc<dyn DisputeGameFactoryClient>,
-            Arc::clone(&verifier) as Arc<dyn AggregateVerifierClient>,
-            mock_anchor_registry(Address::ZERO),
-        );
-
-        // First tick: all three games are post-anchor and discovered.
-        let initial = scanner.scan().await.unwrap();
-        assert_eq!(initial.len(), 3, "all three initial games are actionable");
-        assert!(initial.iter().any(|c| c.index == 0));
-        assert_eq!(scanner.tracked_indices_len(), 3);
-
-        // Simulate a late ZK challenge against game 0 while it remains
-        // IN_PROGRESS, then push three new games into the factory.
-        let mut challenged_state =
-            mock_state_with_tee(GameStatus::InProgress, zk_addr, tee_addr, 100);
-        challenged_state.countered_index = 2; // 1-based → challenged_index = 1
-        verifier.update_game(addr(0), challenged_state);
-
-        for i in 3..6u64 {
-            factory.push(factory_game(i, 1));
-            verifier.update_game(
-                addr(i),
-                mock_state_with_tee(GameStatus::InProgress, Address::ZERO, tee_addr, i * 100),
-            );
-        }
-
-        // Second tick: game 0 is still post-anchor, so it must be returned by scan().
-        let late = scanner.scan().await.unwrap();
-        let game_zero = late
-            .iter()
-            .find(|c| c.index == 0)
-            .expect("old post-anchor in-progress game must still be returned by scan()");
-        assert_eq!(
-            game_zero.category,
-            GameCategory::FraudulentZkChallenge { challenged_index: 1 },
-            "old game should now classify under its late state transition"
-        );
-    }
-
-    /// Resolved games are dropped from the persistent tracking set so that
-    /// memory use does not grow unbounded with the total factory size.
-    #[tokio::test]
-    async fn test_scan_drops_resolved_games_from_tracking() {
-        let tee_addr = Address::repeat_byte(0xEE);
-
-        let factory = Arc::new(MockDisputeGameFactory::new(vec![factory_game(0, 1)]));
-
-        let mut verifier_games = HashMap::new();
-        verifier_games.insert(
-            addr(0),
-            mock_state_with_tee(GameStatus::InProgress, Address::ZERO, tee_addr, 100),
-        );
-        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-
-        let mut scanner = GameScanner::new(
-            Arc::clone(&factory) as Arc<dyn DisputeGameFactoryClient>,
-            Arc::clone(&verifier) as Arc<dyn AggregateVerifierClient>,
-            mock_anchor_registry(Address::ZERO),
-        );
-
-        // First tick: game 0 is in progress and gets tracked.
-        let initial = scanner.scan().await.unwrap();
-        assert_eq!(initial.len(), 1);
-        assert_eq!(scanner.tracked_indices_len(), 1);
-
-        // Resolve game 0 and add newer games.
-        let mut resolved =
-            mock_state_with_tee(GameStatus::InProgress, Address::ZERO, tee_addr, 100);
-        resolved.status = GameStatus::ChallengerWins;
-        verifier.update_game(addr(0), resolved);
-        for i in 1..4u64 {
-            factory.push(factory_game(i, 1));
-            verifier.update_game(
-                addr(i),
-                mock_state_with_tee(GameStatus::InProgress, Address::ZERO, tee_addr, i * 100),
-            );
-        }
-
-        let _ = scanner.scan().await.unwrap();
-
-        // Tracking should hold only the three new IN_PROGRESS games — the
-        // resolved game must be dropped.
-        assert_eq!(scanner.tracked_indices_len(), 3);
-    }
-
-    /// Fully nullified games (both provers zero) are dropped from the
-    /// persistent tracking set even while they remain `IN_PROGRESS`,
-    /// because no on-chain transition can make them actionable again.
-    #[tokio::test]
-    async fn test_scan_drops_fully_nullified_games_from_tracking() {
-        let tee_addr = Address::repeat_byte(0xEE);
-
-        let factory = Arc::new(MockDisputeGameFactory::new(vec![factory_game(0, 1)]));
-
-        let mut verifier_games = HashMap::new();
-        verifier_games.insert(
-            addr(0),
-            mock_state_with_tee(GameStatus::InProgress, Address::ZERO, tee_addr, 100),
-        );
-        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-
-        let mut scanner = GameScanner::new(
-            Arc::clone(&factory) as Arc<dyn DisputeGameFactoryClient>,
-            Arc::clone(&verifier) as Arc<dyn AggregateVerifierClient>,
-            mock_anchor_registry(Address::ZERO),
-        );
-
-        scanner.scan().await.unwrap();
-        assert_eq!(scanner.tracked_indices_len(), 1);
-
-        // Fully nullify the game (both provers zero) while keeping it IN_PROGRESS.
-        verifier.update_game(
-            addr(0),
-            mock_state_with_tee(GameStatus::InProgress, Address::ZERO, Address::ZERO, 100),
-        );
-        for i in 1..4u64 {
-            factory.push(factory_game(i, 1));
-            verifier.update_game(
-                addr(i),
-                mock_state_with_tee(GameStatus::InProgress, Address::ZERO, tee_addr, i * 100),
-            );
-        }
-
-        scanner.scan().await.unwrap();
-
-        // Only the three new live games remain tracked.
-        assert_eq!(scanner.tracked_indices_len(), 3);
     }
 }

--- a/crates/proof/challenge/src/validator.rs
+++ b/crates/proof/challenge/src/validator.rs
@@ -416,7 +416,7 @@ mod tests {
     /// Creates a mock L2 provider with multiple blocks and returns a vec of
     /// expected output roots (one per block).
     fn mock_with_blocks(block_numbers: &[u64]) -> (MockL2Provider, Vec<B256>) {
-        let mut provider = MockL2Provider::new();
+        let mut provider = MockL2Provider::default();
         let mut roots = Vec::new();
 
         for &block_number in block_numbers {
@@ -555,7 +555,7 @@ mod tests {
     /// Missing L2 block: returns `ValidatorError::BlockNotAvailable` instead of panicking.
     #[tokio::test]
     async fn test_missing_l2_block() {
-        let mut provider = MockL2Provider::new();
+        let mut provider = MockL2Provider::default();
         // Mark block 100 as an error block (not yet produced)
         provider.error_blocks.push(100);
 
@@ -575,7 +575,7 @@ mod tests {
     /// Zero intermediate block interval returns `ValidatorError::InvalidInterval`.
     #[tokio::test]
     async fn test_zero_intermediate_interval() {
-        let provider = MockL2Provider::new();
+        let provider = MockL2Provider::default();
         let validator = OutputValidator::new(Arc::new(provider));
         let game_address = Address::repeat_byte(0x07);
 
@@ -606,7 +606,7 @@ mod tests {
         #[case] expected: usize,
         #[case] actual: usize,
     ) {
-        let provider = MockL2Provider::new();
+        let provider = MockL2Provider::default();
         let validator = OutputValidator::new(Arc::new(provider));
         let game_address = Address::repeat_byte(0x08);
 
@@ -731,7 +731,7 @@ mod tests {
         let (header_100, _) = build_test_header_and_account(100, storage_hash);
         let hash_100 = header_100.hash_slow();
 
-        let mut provider = MockL2Provider::new();
+        let mut provider = MockL2Provider::default();
         provider.insert_block(95, header_95, account_95);
         // Insert header for block 100 but omit the proof so get_proof fails.
         let rpc_header_100 = RpcHeader { hash: hash_100, inner: header_100, ..Default::default() };
@@ -766,7 +766,7 @@ mod tests {
         let (consensus_header, account) = build_test_header_and_account(100, storage_hash);
         let correct_hash = consensus_header.hash_slow();
 
-        let mut provider = MockL2Provider::new();
+        let mut provider = MockL2Provider::default();
         // Insert block normally first, then tamper with the header hash
         provider.insert_block(100, consensus_header.clone(), account);
         // Overwrite the header with a mismatched hash
@@ -808,7 +808,7 @@ mod tests {
             ..Default::default()
         };
 
-        let mut provider = MockL2Provider::new();
+        let mut provider = MockL2Provider::default();
         // Insert the wrong-root header but the account proof built for a
         // different state root.
         let block_hash = header_wrong_root.hash_slow();
@@ -841,7 +841,7 @@ mod tests {
         let substituted_root =
             OutputRoot::from_parts(header.state_root, storage_hash, header.hash_slow()).hash();
 
-        let mut provider = MockL2Provider::new();
+        let mut provider = MockL2Provider::default();
         provider.insert_block(100, header, account);
 
         let validator = OutputValidator::new(Arc::new(provider));

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -118,7 +118,7 @@ fn test_driver_with_l1_provider(
 }
 
 fn default_zk_prover() -> Arc<MockZkProofProvider> {
-    Arc::new(MockZkProofProvider { session_id: "test-session".to_string(), ..Default::default() })
+    Arc::new(MockZkProofProvider::default())
 }
 
 fn default_tx_manager() -> MockTxManager {
@@ -126,7 +126,7 @@ fn default_tx_manager() -> MockTxManager {
 }
 
 fn default_l2() -> Arc<MockL2Provider> {
-    Arc::new(MockL2Provider::new())
+    Arc::new(MockL2Provider::default())
 }
 
 fn single_game_factory() -> Arc<MockDisputeGameFactory> {
@@ -168,9 +168,8 @@ fn default_ready_proof(intent: DisputeIntent) -> PendingProof {
     )
 }
 
-fn succeeded_zk_prover(session_id: &str, receipt: Vec<u8>) -> Arc<MockZkProofProvider> {
+fn succeeded_zk_prover(receipt: Vec<u8>) -> Arc<MockZkProofProvider> {
     Arc::new(MockZkProofProvider {
-        session_id: session_id.to_string(),
         state: Mutex::new(MockZkProofState {
             proof_status: ProofStatus::Succeeded,
             proof: receipt,
@@ -179,9 +178,8 @@ fn succeeded_zk_prover(session_id: &str, receipt: Vec<u8>) -> Arc<MockZkProofPro
     })
 }
 
-fn failed_zk_prover(session_id: &str) -> Arc<MockZkProofProvider> {
+fn failed_zk_prover() -> Arc<MockZkProofProvider> {
     Arc::new(MockZkProofProvider {
-        session_id: session_id.to_string(),
         state: Mutex::new(MockZkProofState {
             proof_status: ProofStatus::Failed,
             ..Default::default()
@@ -200,7 +198,7 @@ fn base_game_mocks() -> (Arc<MockL2Provider>, Arc<MockDisputeGameFactory>, B256,
     let root_20 =
         OutputRoot::from_parts(header_20.state_root, STORAGE_HASH, header_20.hash_slow()).hash();
 
-    let mut l2 = MockL2Provider::new();
+    let mut l2 = MockL2Provider::default();
     l2.insert_block(15, header_15, account_15);
     l2.insert_block(20, header_20, account_20);
     let l2 = Arc::new(l2);
@@ -278,7 +276,7 @@ async fn test_step_validation_error_blocks_not_available() {
         ..game_state(20)
     });
 
-    let mut l2 = MockL2Provider::new();
+    let mut l2 = MockL2Provider::default();
     l2.error_blocks.push(15);
     l2.error_blocks.push(20);
     let l2 = Arc::new(l2);
@@ -292,7 +290,7 @@ async fn test_step_validation_error_blocks_not_available() {
 async fn test_step_invalid_game_proof_succeeded() {
     let (l2, factory, verifier) = invalid_game_mocks();
 
-    let zk = succeeded_zk_prover("proof-123", vec![0xDE, 0xAD]);
+    let zk = succeeded_zk_prover(vec![0xDE, 0xAD]);
 
     let tx_manager = default_tx_manager();
 
@@ -323,7 +321,7 @@ async fn test_step_invalid_game_proof_succeeded() {
 async fn test_step_invalid_game_proof_failed() {
     let (l2, factory, verifier) = invalid_game_mocks();
 
-    let zk = failed_zk_prover("proof-fail");
+    let zk = failed_zk_prover();
 
     let tx_manager = default_tx_manager();
 
@@ -435,7 +433,6 @@ async fn test_step_pending_proof_skips_prove_block() {
     let (l2, factory, verifier) = invalid_game_mocks();
 
     let zk = Arc::new(MockZkProofProvider {
-        session_id: "pending-session".to_string(),
         state: Mutex::new(MockZkProofState { proof: vec![0xBE, 0xEF], ..Default::default() }),
     });
 
@@ -473,7 +470,7 @@ async fn test_step_pending_proof_skips_prove_block() {
 async fn test_step_nullification_failure_preserves_proof() {
     let (l2, factory, verifier) = invalid_game_mocks();
 
-    let zk = succeeded_zk_prover("proof-ok", vec![0xDE, 0xAD]);
+    let zk = succeeded_zk_prover(vec![0xDE, 0xAD]);
 
     // First tx call fails (NonceTooLow), second succeeds.
     let tx_manager = MockTxManager::with_responses(vec![
@@ -577,7 +574,6 @@ async fn test_step_proof_retry_succeeds() {
     let (l2, factory, verifier) = invalid_game_mocks();
 
     let zk = Arc::new(MockZkProofProvider {
-        session_id: "retry-session".to_string(),
         state: Mutex::new(MockZkProofState {
             proof_status: ProofStatus::Failed,
             proof: vec![0xBE, 0xEF],
@@ -633,7 +629,6 @@ async fn test_step_proof_retry_reuses_deterministic_session_id() {
     let (l2, factory, verifier) = invalid_game_mocks();
 
     let zk = Arc::new(MockZkProofProvider {
-        session_id: String::new(),
         state: Mutex::new(MockZkProofState {
             proof_status: ProofStatus::Failed,
             error_message: Some("transient backend error".into()),
@@ -711,7 +706,7 @@ async fn test_step_proof_retry_reuses_deterministic_session_id() {
 async fn test_step_proof_exceeds_max_retries() {
     let (l2, factory, verifier) = invalid_game_mocks();
 
-    let zk = failed_zk_prover("fail-forever");
+    let zk = failed_zk_prover();
 
     let tx_manager = default_tx_manager();
     let mut driver = test_driver(factory, Arc::clone(&verifier), l2, zk, tx_manager);
@@ -795,7 +790,7 @@ async fn test_step_invalid_game_tee_fails_zk_fallback() {
 async fn test_step_invalid_game_tee_fails_zk_succeeds() {
     let (l2, factory, verifier) = invalid_game_mocks();
 
-    let zk = succeeded_zk_prover("zk-after-tee-fail", vec![0xDE, 0xAD]);
+    let zk = succeeded_zk_prover(vec![0xDE, 0xAD]);
 
     let tx_manager = default_tx_manager();
 
@@ -855,7 +850,6 @@ async fn test_step_invalid_game_tee_proof_succeeds() {
         schedule_id: B256::ZERO,
     };
     let proof_requester = Arc::new(MockZkProofProvider {
-        session_id: String::new(),
         state: Mutex::new(MockZkProofState {
             proof_status: ProofStatus::Succeeded,
             result: Some(tee_api_result(aggregate_proposal)),
@@ -928,7 +922,6 @@ async fn test_step_tee_contract_revert_falls_back_to_zk() {
         schedule_id: B256::ZERO,
     };
     let zk = Arc::new(MockZkProofProvider {
-        session_id: String::new(),
         state: Mutex::new(MockZkProofState {
             proof_status: ProofStatus::Succeeded,
             result: Some(tee_api_result(aggregate_proposal)),
@@ -1023,7 +1016,6 @@ async fn test_step_invalid_tee_result_falls_back_to_zk_without_timeout() {
         schedule_id: B256::ZERO,
     };
     let proof_requester = Arc::new(MockZkProofProvider {
-        session_id: String::new(),
         state: Mutex::new(MockZkProofState {
             proof_status: ProofStatus::Succeeded,
             result: Some(tee_api_result(bad_aggregate_proposal)),
@@ -1374,7 +1366,6 @@ async fn test_step_dual_proof_invalid_with_tee_provider_nullifies_tee_first() {
         schedule_id: B256::ZERO,
     };
     let proof_requester = Arc::new(MockZkProofProvider {
-        session_id: String::new(),
         state: Mutex::new(MockZkProofState {
             proof_status: ProofStatus::Succeeded,
             result: Some(tee_api_result(aggregate_proposal)),
@@ -1536,7 +1527,6 @@ const fn minimal_prove_request() -> SnarkPlonkProofRequest {
 #[tokio::test]
 async fn test_poll_failed_status_triggers_retry() {
     let zk = Arc::new(MockZkProofProvider {
-        session_id: "failed-session".to_string(),
         state: Mutex::new(MockZkProofState {
             proof_status: ProofStatus::Failed,
             ..Default::default()
@@ -1565,7 +1555,6 @@ async fn test_poll_failed_status_triggers_retry() {
 #[tokio::test]
 async fn test_poll_running_within_timeout_stays_pending() {
     let zk = Arc::new(MockZkProofProvider {
-        session_id: "running-session".to_string(),
         state: Mutex::new(MockZkProofState {
             proof_status: ProofStatus::Running,
             ..Default::default()
@@ -1597,7 +1586,6 @@ async fn test_poll_running_within_timeout_stays_pending() {
 #[tokio::test]
 async fn test_poll_running_timeout_triggers_retry() {
     let zk = Arc::new(MockZkProofProvider {
-        session_id: "stuck-session".to_string(),
         state: Mutex::new(MockZkProofState {
             proof_status: ProofStatus::Running,
             ..Default::default()
@@ -1695,7 +1683,6 @@ mod metrics_emission {
 
             rt.block_on(async {
                 let zk = Arc::new(MockZkProofProvider {
-                    session_id: "stuck-session".to_string(),
                     state: Mutex::new(MockZkProofState {
                         proof_status: ProofStatus::Running,
                         ..Default::default()
@@ -1736,7 +1723,6 @@ mod metrics_emission {
 
             rt.block_on(async {
                 let zk = Arc::new(MockZkProofProvider {
-                    session_id: "failed-session".to_string(),
                     state: Mutex::new(MockZkProofState {
                         proof_status: ProofStatus::Failed,
                         ..Default::default()
@@ -1778,7 +1764,6 @@ mod metrics_emission {
 
             rt.block_on(async {
                 let zk = Arc::new(MockZkProofProvider {
-                    session_id: "malformed-session".to_string(),
                     state: Mutex::new(MockZkProofState {
                         proof_status: ProofStatus::Succeeded,
                         omit_result_on_success: true,
@@ -1832,7 +1817,6 @@ mod metrics_emission {
                     schedule_id: B256::ZERO,
                 };
                 let zk = Arc::new(MockZkProofProvider {
-                    session_id: "tee-bad-root-session".to_string(),
                     state: Mutex::new(MockZkProofState {
                         proof_status: ProofStatus::Succeeded,
                         result: Some(tee_api_result(bad_proposal)),
@@ -1874,7 +1858,7 @@ mod metrics_emission {
 
             rt.block_on(async {
                 let (l2, factory, verifier) = invalid_game_mocks();
-                let zk = failed_zk_prover("fail-forever");
+                let zk = failed_zk_prover();
                 let tx_manager = default_tx_manager();
                 let mut driver = test_driver(factory, Arc::clone(&verifier), l2, zk, tx_manager);
 


### PR DESCRIPTION
### What changed? Why?

- Simplified challenger test doubles by relying on defaults and removing unused mock state.
- Moved scanner-specific tests next to `scanner.rs`, keeping shared test utilities focused on reusable mocks.

### Notes to reviewers

- This is a test-only refactor; challenger runtime behavior is unchanged.

### How has it been tested?

- `cargo test -p base-challenger`