### PR TITLE
refactor(challenger): simplify output root validation

### DIFF
--- a/crates/proof/challenge/src/validator.rs
+++ b/crates/proof/challenge/src/validator.rs
@@ -103,8 +103,6 @@ pub struct ValidationResult {
     /// intermediate validation this is the computed root at the first invalid
     /// checkpoint, or `claimed_root` when all checkpoints are valid.
     pub expected_root: B256,
-    /// The root claim from the onchain game.
-    pub claimed_root: B256,
     /// The index of the first invalid intermediate root, if any.
     pub invalid_intermediate_index: Option<usize>,
 }
@@ -124,14 +122,6 @@ pub struct IntermediateValidationParams<'a> {
     pub claimed_root: B256,
     /// The intermediate output roots to validate, one per checkpoint.
     pub intermediate_roots: &'a [B256],
-}
-
-/// A single output root checkpoint to validate.
-struct Checkpoint {
-    /// The L2 block number at this checkpoint.
-    block: u64,
-    /// The onchain-claimed output root at this block.
-    claimed_root: B256,
 }
 
 /// Validates output roots for candidate dispute games.
@@ -228,33 +218,35 @@ impl<L2: L2Provider + ?Sized> OutputValidator<L2> {
     async fn validate_output_roots(
         &self,
         game_address: Address,
-        checkpoints: &[Checkpoint],
+        checkpoints: impl IntoIterator<Item = (u64, B256)>,
     ) -> Result<Option<(usize, B256)>, ValidatorError> {
         let _latency = base_metrics::timed!(ChallengerMetrics::validation_latency_seconds());
 
-        let mut stream = stream::iter(checkpoints.iter().enumerate())
-            .map(|(idx, cp)| async move { (idx, cp, self.compute_output_root(cp.block).await) })
+        let mut stream = stream::iter(checkpoints.into_iter().enumerate())
+            .map(|(idx, (block, claimed_root))| async move {
+                (idx, block, claimed_root, self.compute_output_root(block).await)
+            })
             .buffered(Self::VALIDATION_CONCURRENCY);
 
-        while let Some((idx, cp, result)) = stream.next().await {
+        while let Some((idx, block, claimed_root, result)) = stream.next().await {
             let expected_root = result.inspect_err(|e| {
                 ChallengerMetrics::validation_errors_total().increment(1);
                 warn!(
                     game = %game_address,
-                    block = cp.block,
+                    block,
                     index = idx,
                     error = %e,
                     "output root computation failed"
                 );
             })?;
 
-            if expected_root != cp.claimed_root {
+            if expected_root != claimed_root {
                 warn!(
                     game = %game_address,
-                    block = cp.block,
+                    block,
                     index = idx,
                     expected = %expected_root,
-                    claimed = %cp.claimed_root,
+                    claimed = %claimed_root,
                     "invalid output root detected"
                 );
                 ChallengerMetrics::games_invalid_total().increment(1);
@@ -278,8 +270,8 @@ impl<L2: L2Provider + ?Sized> OutputValidator<L2> {
     ) -> Result<ValidationResult, ValidatorError> {
         info!(game = %game_address, block = l2_block_number, "validating claimed output root");
 
-        let checkpoint = Checkpoint { block: l2_block_number, claimed_root };
-        let mismatch = self.validate_output_roots(game_address, &[checkpoint]).await?;
+        let mismatch =
+            self.validate_output_roots(game_address, [(l2_block_number, claimed_root)]).await?;
         let (is_valid, expected_root) = match mismatch {
             Some((_, expected)) => (false, expected),
             None => (true, claimed_root),
@@ -288,7 +280,6 @@ impl<L2: L2Provider + ?Sized> OutputValidator<L2> {
         Ok(ValidationResult {
             is_valid,
             expected_root,
-            claimed_root,
             invalid_intermediate_index: None,
         })
     }
@@ -338,7 +329,7 @@ impl<L2: L2Provider + ?Sized> OutputValidator<L2> {
 
         // Compute expected checkpoint count so we can verify intermediate_roots
         // covers every required block.
-        let span = l2_block_number.saturating_sub(starting_block_number);
+        let span = l2_block_number - starting_block_number;
         let expected_count = usize::try_from(span / intermediate_block_interval).map_err(|_| {
             ValidatorError::ArithmeticOverflow { block_number: starting_block_number }
         })?;
@@ -354,7 +345,6 @@ impl<L2: L2Provider + ?Sized> OutputValidator<L2> {
             return Ok(ValidationResult {
                 is_valid: true,
                 expected_root: claimed_root,
-                claimed_root,
                 invalid_intermediate_index: None,
             });
         }
@@ -368,29 +358,18 @@ impl<L2: L2Provider + ?Sized> OutputValidator<L2> {
             "validating intermediate output roots"
         );
 
-        let checkpoints = intermediate_roots
-            .iter()
-            .enumerate()
-            .map(|(i, &root)| {
-                let multiplier = u64::try_from(i + 1).map_err(|_| {
-                    ValidatorError::ArithmeticOverflow { block_number: starting_block_number }
-                })?;
-                let offset = intermediate_block_interval.checked_mul(multiplier).ok_or(
-                    ValidatorError::ArithmeticOverflow { block_number: starting_block_number },
-                )?;
-                let block = starting_block_number.checked_add(offset).ok_or(
-                    ValidatorError::ArithmeticOverflow { block_number: starting_block_number },
-                )?;
-                Ok(Checkpoint { block, claimed_root: root })
-            })
-            .collect::<Result<Vec<_>, ValidatorError>>()?;
+        let mut block = starting_block_number;
+        let checkpoints = intermediate_roots.iter().copied().map(move |claimed_root| {
+            block += intermediate_block_interval;
+            (block, claimed_root)
+        });
 
-        let mismatch = self.validate_output_roots(game_address, &checkpoints).await?;
+        let mismatch = self.validate_output_roots(game_address, checkpoints).await?;
         let is_valid = mismatch.is_none();
         let expected_root = mismatch.as_ref().map_or(claimed_root, |(_, root)| *root);
         let invalid_intermediate_index = mismatch.map(|(idx, _)| idx);
 
-        Ok(ValidationResult { is_valid, expected_root, claimed_root, invalid_intermediate_index })
+        Ok(ValidationResult { is_valid, expected_root, invalid_intermediate_index })
     }
 }
 
@@ -453,7 +432,6 @@ mod tests {
 
         assert_eq!(result.is_valid, expect_valid);
         assert_eq!(result.expected_root, expected_root);
-        assert_eq!(result.claimed_root, claimed_root);
         assert_eq!(result.invalid_intermediate_index, None);
     }
 

--- a/crates/proof/challenge/src/validator.rs
+++ b/crates/proof/challenge/src/validator.rs
@@ -277,11 +277,7 @@ impl<L2: L2Provider + ?Sized> OutputValidator<L2> {
             None => (true, claimed_root),
         };
 
-        Ok(ValidationResult {
-            is_valid,
-            expected_root,
-            invalid_intermediate_index: None,
-        })
+        Ok(ValidationResult { is_valid, expected_root, invalid_intermediate_index: None })
     }
 
     /// Validates the intermediate output roots of a candidate dispute game.


### PR DESCRIPTION
### What changed? Why?

- Simplified checkpoint validation by passing `(block, claimed_root)` pairs directly instead of allocating private checkpoint structs.
- Removed the redundant claimed-root field from validation results; callers only use validity, the computed root, and the first invalid checkpoint index.
- Kept the existing ordered, bounded-concurrency validation behavior while eliminating the intermediate checkpoint allocation.

### Notes to reviewers

- The block-range guard precedes direct checkpoint arithmetic, and the expected checkpoint count bounds the iterator.

### How has it been tested?

- `cargo test -p base-challenger validator`