### PR TITLE
fix(payload): Bound SSZ Payload List Decode

### DIFF
--- a/crates/common/rpc-types-engine/src/envelope.rs
+++ b/crates/common/rpc-types-engine/src/envelope.rs
@@ -579,12 +579,6 @@ impl PayloadHash {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "std")]
-    use std::{
-        alloc::{GlobalAlloc, Layout, System},
-        cell::Cell,
-    };
-
     use alloy_primitives::b256;
     #[cfg(feature = "std")]
     use alloy_primitives::hex;
@@ -718,115 +712,5 @@ mod tests {
                     if given == declared && max == MAX_DECOMPRESSED_ENVELOPE_BYTES
             ));
         }
-    }
-
-    // Running total of bytes allocated on the current thread. Const-initialized
-    // so reading it never allocates (which would recurse through the allocator).
-    #[cfg(feature = "std")]
-    thread_local! {
-        static ALLOCATED: Cell<usize> = const { Cell::new(0) };
-    }
-
-    /// Global allocator that tallies allocation volume per thread, delegating to
-    /// the system allocator. Lets a test measure how much heap a single decode
-    /// forces. Only allocation (growth) is counted, which is what a
-    /// resource-exhaustion bound cares about.
-    #[cfg(feature = "std")]
-    struct CountingAllocator;
-
-    // SAFETY: every call is forwarded to the system allocator with an unchanged
-    // layout, so all `GlobalAlloc` invariants are those of `System`; the wrapper
-    // only records the requested size on a successful allocation.
-    #[cfg(feature = "std")]
-    unsafe impl GlobalAlloc for CountingAllocator {
-        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-            // SAFETY: `layout` is forwarded unchanged from the caller, upholding
-            // `System::alloc`'s contract.
-            let ptr = unsafe { System.alloc(layout) };
-            if !ptr.is_null() {
-                let _ = ALLOCATED.try_with(|c| c.set(c.get().saturating_add(layout.size())));
-            }
-            ptr
-        }
-
-        unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-            // SAFETY: `ptr` and `layout` come straight from the caller and
-            // originate from `System.alloc`, satisfying `System::dealloc`.
-            unsafe { System.dealloc(ptr, layout) };
-        }
-    }
-
-    #[cfg(feature = "std")]
-    #[global_allocator]
-    static COUNTING_ALLOCATOR: CountingAllocator = CountingAllocator;
-
-    /// Regression test for the pre-authentication allocation-amplification
-    /// denial-of-service (CWE-770). `decode_v4` is the gossip block-decode entry
-    /// point that `BlockHandler::handle` runs for every message arriving on the
-    /// public P2P port, before any signature check.
-    ///
-    /// A frame only ~0.5 `MiB` on the wire can declare a `transactions` list of
-    /// ~2.6M entries. An unbounded decode honors that count and allocates
-    /// ~125 `MiB` of heap per frame; a length-bounded list must instead keep the
-    /// per-frame heap within a small multiple of the decompressed size. This
-    /// measures the actual bytes the decode allocates and holds it to that bound.
-    #[test]
-    #[cfg(feature = "std")]
-    fn decode_v4_transaction_bomb_allocation_is_bounded() {
-        // SSZ container fixed-region byte offsets (see the `from_ssz_bytes`
-        // regression test in the payload module for the full field layout).
-        const FIXED_LEN: usize = 560;
-        const EXTRA_DATA_OFFSET: usize = 436;
-        const TRANSACTIONS_OFFSET: usize = 504;
-        const WITHDRAWALS_OFFSET: usize = 508;
-        // Each envelope carries a 65-byte signature and 32-byte parent beacon
-        // root ahead of the SSZ container; the whole decompressed envelope must
-        // stay under the decompression cap.
-        const ENVELOPE_PREFIX: usize = 65 + 32;
-
-        let txs_len = ((MAX_DECOMPRESSED_ENVELOPE_BYTES - ENVELOPE_PREFIX - FIXED_LEN)
-            / ssz::BYTES_PER_LENGTH_OFFSET)
-            * ssz::BYTES_PER_LENGTH_OFFSET;
-        let declared_txs = txs_len / ssz::BYTES_PER_LENGTH_OFFSET;
-
-        // Container: zeroed fixed fields, empty extra_data/withdrawals, and a
-        // transactions region whose leading offset declares `declared_txs` empty
-        // items (every offset points past the end of the list).
-        let mut container = Vec::with_capacity(FIXED_LEN + txs_len);
-        container.resize(FIXED_LEN, 0);
-        container[EXTRA_DATA_OFFSET..][..4].copy_from_slice(&(FIXED_LEN as u32).to_le_bytes());
-        container[TRANSACTIONS_OFFSET..][..4].copy_from_slice(&(FIXED_LEN as u32).to_le_bytes());
-        container[WITHDRAWALS_OFFSET..][..4]
-            .copy_from_slice(&((FIXED_LEN + txs_len) as u32).to_le_bytes());
-        for _ in 0..declared_txs {
-            container.extend_from_slice(&(txs_len as u32).to_le_bytes());
-        }
-
-        // Envelope = signature (r=1, s=1, v=0 so it parses and the decode reaches
-        // the SSZ sink) + parent beacon root + container, snappy-compressed as it
-        // arrives on the wire.
-        let mut decompressed = Vec::with_capacity(ENVELOPE_PREFIX + container.len());
-        let mut signature = [0u8; 65];
-        signature[31] = 1;
-        signature[63] = 1;
-        decompressed.extend_from_slice(&signature);
-        decompressed.extend_from_slice(&[0u8; 32]);
-        decompressed.extend_from_slice(&container);
-        let frame = snap::raw::Encoder::new().compress_vec(&decompressed).unwrap();
-
-        // Measure only the heap the decode itself grows on this thread.
-        ALLOCATED.with(|c| c.set(0));
-        let _ = NetworkPayloadEnvelope::decode_v4(&frame);
-        let allocated = ALLOCATED.with(|c| c.get());
-
-        // A legitimate decode allocates the decompressed buffer plus the hashing
-        // buffer (~2x the frame); anything approaching the bomb's ~125 MiB means
-        // the transaction list honored the attacker's element count.
-        let max_allocation = 4 * MAX_DECOMPRESSED_ENVELOPE_BYTES;
-        assert!(
-            allocated < max_allocation,
-            "decoding one frame declaring {declared_txs} transactions allocated {allocated} bytes \
-             pre-authentication (limit {max_allocation}); the transaction list is not length-bounded",
-        );
     }
 }

--- a/crates/common/rpc-types-engine/src/envelope.rs
+++ b/crates/common/rpc-types-engine/src/envelope.rs
@@ -579,16 +579,17 @@ impl PayloadHash {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::b256;
-    #[cfg(feature = "std")]
-    use alloy_primitives::hex;
-    #[cfg(feature = "std")]
-    use ssz::{Decode, Encode};
     #[cfg(feature = "std")]
     use std::{
         alloc::{GlobalAlloc, Layout, System},
         cell::Cell,
     };
+
+    use alloy_primitives::b256;
+    #[cfg(feature = "std")]
+    use alloy_primitives::hex;
+    #[cfg(feature = "std")]
+    use ssz::{Decode, Encode};
 
     use super::*;
 

--- a/crates/common/rpc-types-engine/src/envelope.rs
+++ b/crates/common/rpc-types-engine/src/envelope.rs
@@ -584,6 +584,11 @@ mod tests {
     use alloy_primitives::hex;
     #[cfg(feature = "std")]
     use ssz::{Decode, Encode};
+    #[cfg(feature = "std")]
+    use std::{
+        alloc::{GlobalAlloc, Layout, System},
+        cell::Cell,
+    };
 
     use super::*;
 
@@ -712,5 +717,115 @@ mod tests {
                     if given == declared && max == MAX_DECOMPRESSED_ENVELOPE_BYTES
             ));
         }
+    }
+
+    // Running total of bytes allocated on the current thread. Const-initialized
+    // so reading it never allocates (which would recurse through the allocator).
+    #[cfg(feature = "std")]
+    thread_local! {
+        static ALLOCATED: Cell<usize> = const { Cell::new(0) };
+    }
+
+    /// Global allocator that tallies allocation volume per thread, delegating to
+    /// the system allocator. Lets a test measure how much heap a single decode
+    /// forces. Only allocation (growth) is counted, which is what a
+    /// resource-exhaustion bound cares about.
+    #[cfg(feature = "std")]
+    struct CountingAllocator;
+
+    // SAFETY: every call is forwarded to the system allocator with an unchanged
+    // layout, so all `GlobalAlloc` invariants are those of `System`; the wrapper
+    // only records the requested size on a successful allocation.
+    #[cfg(feature = "std")]
+    unsafe impl GlobalAlloc for CountingAllocator {
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            // SAFETY: `layout` is forwarded unchanged from the caller, upholding
+            // `System::alloc`'s contract.
+            let ptr = unsafe { System.alloc(layout) };
+            if !ptr.is_null() {
+                let _ = ALLOCATED.try_with(|c| c.set(c.get().saturating_add(layout.size())));
+            }
+            ptr
+        }
+
+        unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+            // SAFETY: `ptr` and `layout` come straight from the caller and
+            // originate from `System.alloc`, satisfying `System::dealloc`.
+            unsafe { System.dealloc(ptr, layout) };
+        }
+    }
+
+    #[cfg(feature = "std")]
+    #[global_allocator]
+    static COUNTING_ALLOCATOR: CountingAllocator = CountingAllocator;
+
+    /// Regression test for the pre-authentication allocation-amplification
+    /// denial-of-service (CWE-770). `decode_v4` is the gossip block-decode entry
+    /// point that `BlockHandler::handle` runs for every message arriving on the
+    /// public P2P port, before any signature check.
+    ///
+    /// A frame only ~0.5 `MiB` on the wire can declare a `transactions` list of
+    /// ~2.6M entries. An unbounded decode honors that count and allocates
+    /// ~125 `MiB` of heap per frame; a length-bounded list must instead keep the
+    /// per-frame heap within a small multiple of the decompressed size. This
+    /// measures the actual bytes the decode allocates and holds it to that bound.
+    #[test]
+    #[cfg(feature = "std")]
+    fn decode_v4_transaction_bomb_allocation_is_bounded() {
+        // SSZ container fixed-region byte offsets (see the `from_ssz_bytes`
+        // regression test in the payload module for the full field layout).
+        const FIXED_LEN: usize = 560;
+        const EXTRA_DATA_OFFSET: usize = 436;
+        const TRANSACTIONS_OFFSET: usize = 504;
+        const WITHDRAWALS_OFFSET: usize = 508;
+        // Each envelope carries a 65-byte signature and 32-byte parent beacon
+        // root ahead of the SSZ container; the whole decompressed envelope must
+        // stay under the decompression cap.
+        const ENVELOPE_PREFIX: usize = 65 + 32;
+
+        let txs_len = ((MAX_DECOMPRESSED_ENVELOPE_BYTES - ENVELOPE_PREFIX - FIXED_LEN)
+            / ssz::BYTES_PER_LENGTH_OFFSET)
+            * ssz::BYTES_PER_LENGTH_OFFSET;
+        let declared_txs = txs_len / ssz::BYTES_PER_LENGTH_OFFSET;
+
+        // Container: zeroed fixed fields, empty extra_data/withdrawals, and a
+        // transactions region whose leading offset declares `declared_txs` empty
+        // items (every offset points past the end of the list).
+        let mut container = Vec::with_capacity(FIXED_LEN + txs_len);
+        container.resize(FIXED_LEN, 0);
+        container[EXTRA_DATA_OFFSET..][..4].copy_from_slice(&(FIXED_LEN as u32).to_le_bytes());
+        container[TRANSACTIONS_OFFSET..][..4].copy_from_slice(&(FIXED_LEN as u32).to_le_bytes());
+        container[WITHDRAWALS_OFFSET..][..4]
+            .copy_from_slice(&((FIXED_LEN + txs_len) as u32).to_le_bytes());
+        for _ in 0..declared_txs {
+            container.extend_from_slice(&(txs_len as u32).to_le_bytes());
+        }
+
+        // Envelope = signature (r=1, s=1, v=0 so it parses and the decode reaches
+        // the SSZ sink) + parent beacon root + container, snappy-compressed as it
+        // arrives on the wire.
+        let mut decompressed = Vec::with_capacity(ENVELOPE_PREFIX + container.len());
+        let mut signature = [0u8; 65];
+        signature[31] = 1;
+        signature[63] = 1;
+        decompressed.extend_from_slice(&signature);
+        decompressed.extend_from_slice(&[0u8; 32]);
+        decompressed.extend_from_slice(&container);
+        let frame = snap::raw::Encoder::new().compress_vec(&decompressed).unwrap();
+
+        // Measure only the heap the decode itself grows on this thread.
+        ALLOCATED.with(|c| c.set(0));
+        let _ = NetworkPayloadEnvelope::decode_v4(&frame);
+        let allocated = ALLOCATED.with(|c| c.get());
+
+        // A legitimate decode allocates the decompressed buffer plus the hashing
+        // buffer (~2x the frame); anything approaching the bomb's ~125 MiB means
+        // the transaction list honored the attacker's element count.
+        let max_allocation = 4 * MAX_DECOMPRESSED_ENVELOPE_BYTES;
+        assert!(
+            allocated < max_allocation,
+            "decoding one frame declaring {declared_txs} transactions allocated {allocated} bytes \
+             pre-authentication (limit {max_allocation}); the transaction list is not length-bounded",
+        );
     }
 }

--- a/crates/common/rpc-types-engine/src/lib.rs
+++ b/crates/common/rpc-types-engine/src/lib.rs
@@ -23,9 +23,12 @@ mod sidecar;
 pub use sidecar::BaseExecutionPayloadSidecar;
 
 mod payload;
+#[cfg(feature = "std")]
+pub use payload::{BoundedTransactions, BoundedWithdrawals};
 pub use payload::{
     BaseExecutionPayload, BaseExecutionPayloadEnvelopeV3, BaseExecutionPayloadEnvelopeV4,
     BaseExecutionPayloadEnvelopeV5, BaseExecutionPayloadV4, BasePayloadError,
+    MAX_TRANSACTIONS_PER_PAYLOAD, MAX_WITHDRAWALS_PER_PAYLOAD,
 };
 
 #[cfg(feature = "reth")]

--- a/crates/common/rpc-types-engine/src/lib.rs
+++ b/crates/common/rpc-types-engine/src/lib.rs
@@ -23,13 +23,13 @@ mod sidecar;
 pub use sidecar::BaseExecutionPayloadSidecar;
 
 mod payload;
-#[cfg(feature = "std")]
-pub use payload::{BoundedTransactions, BoundedWithdrawals};
 pub use payload::{
     BaseExecutionPayload, BaseExecutionPayloadEnvelopeV3, BaseExecutionPayloadEnvelopeV4,
     BaseExecutionPayloadEnvelopeV5, BaseExecutionPayloadV4, BasePayloadError,
     MAX_TRANSACTIONS_PER_PAYLOAD, MAX_WITHDRAWALS_PER_PAYLOAD,
 };
+#[cfg(feature = "std")]
+pub use payload::{BoundedTransactions, BoundedWithdrawals};
 
 #[cfg(feature = "reth")]
 mod reth;

--- a/crates/common/rpc-types-engine/src/payload/mod.rs
+++ b/crates/common/rpc-types-engine/src/payload/mod.rs
@@ -7,7 +7,12 @@ mod v3;
 pub use v3::BaseExecutionPayloadEnvelopeV3;
 
 mod v4;
-pub use v4::{BaseExecutionPayloadEnvelopeV4, BaseExecutionPayloadV4};
+#[cfg(feature = "std")]
+pub use v4::{BoundedTransactions, BoundedWithdrawals};
+pub use v4::{
+    BaseExecutionPayloadEnvelopeV4, BaseExecutionPayloadV4, MAX_TRANSACTIONS_PER_PAYLOAD,
+    MAX_WITHDRAWALS_PER_PAYLOAD,
+};
 
 mod v5;
 use alloc::vec::Vec;

--- a/crates/common/rpc-types-engine/src/payload/mod.rs
+++ b/crates/common/rpc-types-engine/src/payload/mod.rs
@@ -7,12 +7,12 @@ mod v3;
 pub use v3::BaseExecutionPayloadEnvelopeV3;
 
 mod v4;
-#[cfg(feature = "std")]
-pub use v4::{BoundedTransactions, BoundedWithdrawals};
 pub use v4::{
     BaseExecutionPayloadEnvelopeV4, BaseExecutionPayloadV4, MAX_TRANSACTIONS_PER_PAYLOAD,
     MAX_WITHDRAWALS_PER_PAYLOAD,
 };
+#[cfg(feature = "std")]
+pub use v4::{BoundedTransactions, BoundedWithdrawals};
 
 mod v5;
 use alloc::vec::Vec;

--- a/crates/common/rpc-types-engine/src/payload/v4.rs
+++ b/crates/common/rpc-types-engine/src/payload/v4.rs
@@ -82,9 +82,12 @@ impl BaseExecutionPayloadV4 {
 /// `MAX_TRANSACTIONS_PER_PAYLOAD` in the Ethereum consensus specs.
 pub const MAX_TRANSACTIONS_PER_PAYLOAD: usize = 1 << 20;
 
-/// The maximum number of withdrawals in an execution payload, per
-/// `MAX_WITHDRAWALS_PER_PAYLOAD` in the Ethereum consensus specs.
-pub const MAX_WITHDRAWALS_PER_PAYLOAD: usize = 1 << 4;
+/// The maximum number of withdrawals in a Base execution payload.
+///
+/// Base sets the withdrawals root directly and requires the SSZ `withdrawals`
+/// list to be present but empty (see [`BaseExecutionPayloadV4`]), so any
+/// non-empty list is invalid and is rejected during decode.
+pub const MAX_WITHDRAWALS_PER_PAYLOAD: usize = 0;
 
 /// SSZ `transactions` list bounded to [`MAX_TRANSACTIONS_PER_PAYLOAD`].
 ///

--- a/crates/common/rpc-types-engine/src/payload/v4.rs
+++ b/crates/common/rpc-types-engine/src/payload/v4.rs
@@ -78,6 +78,63 @@ impl BaseExecutionPayloadV4 {
     }
 }
 
+/// The maximum number of transactions in an execution payload, per
+/// `MAX_TRANSACTIONS_PER_PAYLOAD` in the Ethereum consensus specs.
+pub const MAX_TRANSACTIONS_PER_PAYLOAD: usize = 1 << 20;
+
+/// The maximum number of withdrawals in an execution payload, per
+/// `MAX_WITHDRAWALS_PER_PAYLOAD` in the Ethereum consensus specs.
+pub const MAX_WITHDRAWALS_PER_PAYLOAD: usize = 1 << 4;
+
+/// SSZ `transactions` list bounded to [`MAX_TRANSACTIONS_PER_PAYLOAD`].
+///
+/// Transactions are variable-length SSZ items, so the decoder derives their
+/// count from the list's leading offset. Bounding the count rejects a frame that
+/// declares more transactions than the protocol allows *before* one entry per
+/// declared element is allocated, closing the pre-authentication
+/// allocation-amplification vector.
+#[cfg(feature = "std")]
+#[derive(Debug)]
+pub struct BoundedTransactions(pub Vec<Bytes>);
+
+#[cfg(feature = "std")]
+impl ssz::Decode for BoundedTransactions {
+    fn is_ssz_fixed_len() -> bool {
+        false
+    }
+
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
+        ssz::decode_list_of_variable_length_items(bytes, Some(MAX_TRANSACTIONS_PER_PAYLOAD))
+            .map(Self)
+    }
+}
+
+/// SSZ `withdrawals` list bounded to [`MAX_WITHDRAWALS_PER_PAYLOAD`].
+///
+/// Withdrawals are fixed-length SSZ items, so their count is the byte length
+/// divided by the per-item size. Bounding the count rejects an oversized list
+/// before the backing vector is allocated.
+#[cfg(feature = "std")]
+#[derive(Debug)]
+pub struct BoundedWithdrawals(pub Vec<alloy_eips::eip4895::Withdrawal>);
+
+#[cfg(feature = "std")]
+impl ssz::Decode for BoundedWithdrawals {
+    fn is_ssz_fixed_len() -> bool {
+        false
+    }
+
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
+        let per_item = <alloy_eips::eip4895::Withdrawal as ssz::Decode>::ssz_fixed_len();
+        if per_item != 0 && bytes.len() / per_item > MAX_WITHDRAWALS_PER_PAYLOAD {
+            return Err(ssz::DecodeError::BytesInvalid(alloc::format!(
+                "withdrawals list declares more than {MAX_WITHDRAWALS_PER_PAYLOAD} items"
+            )));
+        }
+        Vec::<alloy_eips::eip4895::Withdrawal>::from_ssz_bytes(bytes).map(Self)
+    }
+}
+
 #[cfg(feature = "std")]
 impl ssz::Decode for BaseExecutionPayloadV4 {
     fn is_ssz_fixed_len() -> bool {
@@ -100,8 +157,8 @@ impl ssz::Decode for BaseExecutionPayloadV4 {
         builder.register_type::<Bytes>()?;
         builder.register_type::<U256>()?;
         builder.register_type::<B256>()?;
-        builder.register_type::<Vec<Bytes>>()?;
-        builder.register_type::<Vec<alloy_eips::eip4895::Withdrawal>>()?;
+        builder.register_type::<BoundedTransactions>()?;
+        builder.register_type::<BoundedWithdrawals>()?;
         builder.register_type::<u64>()?;
         builder.register_type::<u64>()?;
         builder.register_type::<B256>()?;
@@ -125,9 +182,9 @@ impl ssz::Decode for BaseExecutionPayloadV4 {
                         extra_data: decoder.decode_next()?,
                         base_fee_per_gas: decoder.decode_next()?,
                         block_hash: decoder.decode_next()?,
-                        transactions: decoder.decode_next()?,
+                        transactions: decoder.decode_next::<BoundedTransactions>()?.0,
                     },
-                    withdrawals: decoder.decode_next()?,
+                    withdrawals: decoder.decode_next::<BoundedWithdrawals>()?.0,
                 },
                 blob_gas_used: decoder.decode_next()?,
                 excess_blob_gas: decoder.decode_next()?,
@@ -208,10 +265,11 @@ pub struct BaseExecutionPayloadEnvelopeV4 {
 }
 
 #[cfg(test)]
-#[cfg(feature = "serde")]
+#[cfg(any(feature = "serde", feature = "std"))]
 mod tests {
     use super::*;
 
+    #[cfg(feature = "serde")]
     #[test]
     fn serde_roundtrip_execution_payload_envelope_v4() {
         // modified execution payload envelope v3 with empty deposit, withdrawal, and consolidation
@@ -219,5 +277,62 @@ mod tests {
         let response = r#"{"executionPayload":{"parentHash":"0xe927a1448525fb5d32cb50ee1408461a945ba6c39bd5cf5621407d500ecc8de9","feeRecipient":"0x0000000000000000000000000000000000000000","stateRoot":"0x10f8a0830000e8edef6d00cc727ff833f064b1950afd591ae41357f97e543119","receiptsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","prevRandao":"0xe0d8b4521a7da1582a713244ffb6a86aa1726932087386e2dc7973f43fc6cb24","blockNumber":"0x1","gasLimit":"0x2ffbd2","gasUsed":"0x0","timestamp":"0x1235","extraData":"0xd883010d00846765746888676f312e32312e30856c696e7578","baseFeePerGas":"0x342770c0","blockHash":"0x44d0fa5f2f73a938ebb96a2a21679eb8dea3e7b7dd8fd9f35aa756dda8bf0a8a","transactions":[],"withdrawals":[],"blobGasUsed":"0x0","excessBlobGas":"0x0","withdrawalsRoot":"0x123400000000000000000000000000000000000000000000000000000000babe"},"blockValue":"0x0","blobsBundle":{"commitments":[],"proofs":[],"blobs":[]},"shouldOverrideBuilder":false,"parentBeaconBlockRoot":"0xdead00000000000000000000000000000000000000000000000000000000beef","executionRequests":["0xdeadbeef"]}"#;
         let envelope: BaseExecutionPayloadEnvelopeV4 = serde_json::from_str(response).unwrap();
         assert_eq!(serde_json::to_string(&envelope).unwrap(), response);
+    }
+
+    /// Regression test for the pre-authentication allocation-amplification
+    /// denial-of-service (CWE-770) reachable from the public gossip port.
+    ///
+    /// The `transactions` field is an SSZ list of variable-length items, so its
+    /// element count is derived from the leading 4-byte offset rather than
+    /// declared explicitly. An attacker sets that offset as large as a wire
+    /// frame allows; the decoder divides it by `BYTES_PER_LENGTH_OFFSET` and
+    /// tries to materialize that many entries. A single ~10 `MiB` frame (~0.5
+    /// `MiB` on the wire once snappy-compressed) thus declares ~2.6M
+    /// transactions, forcing that many heap entries and loop iterations before
+    /// any signature check runs.
+    ///
+    /// A bounded transaction list must reject the frame the moment the declared
+    /// count exceeds its maximum, instead of honoring the attacker's count.
+    #[cfg(feature = "std")]
+    #[test]
+    fn decode_rejects_transaction_count_bomb() {
+        // Byte offsets of the container's fixed region, following the field
+        // order in `ssz_append`. Each variable-length field (extra_data,
+        // transactions, withdrawals) occupies a 4-byte offset slot here and
+        // stores its data in the trailing variable region.
+        const FIXED_LEN: usize = 560;
+        const EXTRA_DATA_OFFSET: usize = 436;
+        const TRANSACTIONS_OFFSET: usize = 504;
+        const WITHDRAWALS_OFFSET: usize = 508;
+
+        // Number of transactions an attacker can declare by filling a maximum
+        // decompressed frame with offsets — orders of magnitude beyond the few
+        // thousand a real block can hold.
+        let declared_txs = crate::MAX_DECOMPRESSED_ENVELOPE_BYTES / ssz::BYTES_PER_LENGTH_OFFSET;
+        let transactions_len = declared_txs * ssz::BYTES_PER_LENGTH_OFFSET;
+
+        // Fixed region: every field is left zeroed except the three variable
+        // offset slots. The extra_data and transactions slots point at the same
+        // position (an empty extra_data), and withdrawals begins after the
+        // injected transactions region (an empty withdrawals list).
+        let mut frame = Vec::with_capacity(FIXED_LEN + transactions_len);
+        frame.resize(FIXED_LEN, 0);
+        frame[EXTRA_DATA_OFFSET..][..4].copy_from_slice(&(FIXED_LEN as u32).to_le_bytes());
+        frame[TRANSACTIONS_OFFSET..][..4].copy_from_slice(&(FIXED_LEN as u32).to_le_bytes());
+        frame[WITHDRAWALS_OFFSET..][..4]
+            .copy_from_slice(&((FIXED_LEN + transactions_len) as u32).to_le_bytes());
+
+        // Transactions region: `declared_txs` offsets that all point past the
+        // end of the list, so every declared transaction decodes as empty and
+        // the leading offset alone dictates the element count.
+        for _ in 0..declared_txs {
+            frame.extend_from_slice(&(transactions_len as u32).to_le_bytes());
+        }
+
+        let decoded = <BaseExecutionPayloadV4 as ssz::Decode>::from_ssz_bytes(&frame);
+        assert!(
+            decoded.is_err(),
+            "decoder honored {declared_txs} attacker-declared transactions instead of rejecting the frame",
+        );
     }
 }

--- a/crates/common/rpc-types-engine/tests/decode_allocation_bound.rs
+++ b/crates/common/rpc-types-engine/tests/decode_allocation_bound.rs
@@ -1,0 +1,122 @@
+//! Pre-authentication allocation-amplification regression test for
+//! [`NetworkPayloadEnvelope::decode_v4`].
+//!
+//! This lives in its own integration test binary rather than a unit test so the
+//! `#[global_allocator]` below is isolated to a single binary: a crate-wide
+//! allocator declared inside the crate's `#[cfg(test)] mod tests` would apply to
+//! every test in that binary (and would collide with any other test that
+//! declared its own allocator). Here it governs only this one measurement.
+
+#![cfg(feature = "std")]
+
+use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    cell::Cell,
+};
+
+use base_common_rpc_types_engine::{MAX_DECOMPRESSED_ENVELOPE_BYTES, NetworkPayloadEnvelope};
+
+// Running total of bytes allocated on the current thread. Const-initialized so
+// reading it never allocates (which would recurse through the allocator).
+thread_local! {
+    static ALLOCATED: Cell<usize> = const { Cell::new(0) };
+}
+
+/// Global allocator that tallies allocation volume per thread, delegating to the
+/// system allocator. Lets the test measure how much heap a single decode forces.
+/// Only allocation (growth) is counted, which is what a resource-exhaustion
+/// bound cares about.
+struct CountingAllocator;
+
+// SAFETY: every call is forwarded to the system allocator with an unchanged
+// layout, so all `GlobalAlloc` invariants are those of `System`; the wrapper
+// only records the requested size on a successful allocation.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: `layout` is forwarded unchanged from the caller, upholding
+        // `System::alloc`'s contract.
+        let ptr = unsafe { System.alloc(layout) };
+        if !ptr.is_null() {
+            let _ = ALLOCATED.try_with(|c| c.set(c.get().saturating_add(layout.size())));
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: `ptr` and `layout` come straight from the caller and originate
+        // from `System.alloc`, satisfying `System::dealloc`.
+        unsafe { System.dealloc(ptr, layout) };
+    }
+}
+
+#[global_allocator]
+static COUNTING_ALLOCATOR: CountingAllocator = CountingAllocator;
+
+/// Regression test for the pre-authentication allocation-amplification
+/// denial-of-service (CWE-770). `decode_v4` is the gossip block-decode entry
+/// point that `BlockHandler::handle` runs for every message arriving on the
+/// public P2P port, before any signature check.
+///
+/// A frame only ~0.5 `MiB` on the wire can declare a `transactions` list of
+/// ~2.6M entries. An unbounded decode honors that count and allocates ~125 `MiB`
+/// of heap per frame; a length-bounded list must instead keep the per-frame heap
+/// within a small multiple of the decompressed size. This measures the actual
+/// bytes the decode allocates and holds it to that bound.
+#[test]
+fn decode_v4_transaction_bomb_allocation_is_bounded() {
+    // SSZ container fixed-region byte offsets (see the `from_ssz_bytes`
+    // regression test in the payload module for the full field layout).
+    const FIXED_LEN: usize = 560;
+    const EXTRA_DATA_OFFSET: usize = 436;
+    const TRANSACTIONS_OFFSET: usize = 504;
+    const WITHDRAWALS_OFFSET: usize = 508;
+    // Each envelope carries a 65-byte signature and 32-byte parent beacon root
+    // ahead of the SSZ container; the whole decompressed envelope must stay under
+    // the decompression cap.
+    const ENVELOPE_PREFIX: usize = 65 + 32;
+
+    let txs_len = ((MAX_DECOMPRESSED_ENVELOPE_BYTES - ENVELOPE_PREFIX - FIXED_LEN)
+        / ssz::BYTES_PER_LENGTH_OFFSET)
+        * ssz::BYTES_PER_LENGTH_OFFSET;
+    let declared_txs = txs_len / ssz::BYTES_PER_LENGTH_OFFSET;
+
+    // Container: zeroed fixed fields, empty extra_data/withdrawals, and a
+    // transactions region whose leading offset declares `declared_txs` empty
+    // items (every offset points past the end of the list).
+    let mut container = Vec::with_capacity(FIXED_LEN + txs_len);
+    container.resize(FIXED_LEN, 0);
+    container[EXTRA_DATA_OFFSET..][..4].copy_from_slice(&(FIXED_LEN as u32).to_le_bytes());
+    container[TRANSACTIONS_OFFSET..][..4].copy_from_slice(&(FIXED_LEN as u32).to_le_bytes());
+    container[WITHDRAWALS_OFFSET..][..4]
+        .copy_from_slice(&((FIXED_LEN + txs_len) as u32).to_le_bytes());
+    for _ in 0..declared_txs {
+        container.extend_from_slice(&(txs_len as u32).to_le_bytes());
+    }
+
+    // Envelope = signature (r=1, s=1, v=0 so it parses and the decode reaches the
+    // SSZ sink) + parent beacon root + container, snappy-compressed as it arrives
+    // on the wire.
+    let mut decompressed = Vec::with_capacity(ENVELOPE_PREFIX + container.len());
+    let mut signature = [0u8; 65];
+    signature[31] = 1;
+    signature[63] = 1;
+    decompressed.extend_from_slice(&signature);
+    decompressed.extend_from_slice(&[0u8; 32]);
+    decompressed.extend_from_slice(&container);
+    let frame = snap::raw::Encoder::new().compress_vec(&decompressed).unwrap();
+
+    // Measure only the heap the decode itself grows on this thread.
+    ALLOCATED.with(|c| c.set(0));
+    let _ = NetworkPayloadEnvelope::decode_v4(&frame);
+    let allocated = ALLOCATED.with(|c| c.get());
+
+    // A legitimate decode allocates the decompressed buffer plus the hashing
+    // buffer (~2x the frame); anything approaching the bomb's ~125 MiB means the
+    // transaction list honored the attacker's element count.
+    let max_allocation = 4 * MAX_DECOMPRESSED_ENVELOPE_BYTES;
+    assert!(
+        allocated < max_allocation,
+        "decoding one frame declaring {declared_txs} transactions allocated {allocated} bytes \
+         pre-authentication (limit {max_allocation}); the transaction list is not length-bounded",
+    );
+}


### PR DESCRIPTION
## Summary

An unauthenticated peer on the public P2P mesh could send a small (~0.5 MiB) snappy frame on the v4 blocks topic whose SSZ `transactions` list declared ~2.6M entries, forcing the single-threaded gossip task to allocate ~125 MiB of heap before any signature check ran (CWE-770). The transaction and withdrawal lists were decoded into raw unbounded `Vec`s, so the decoder honored the attacker's element count instead of the protocol maximum.

This bounds the v4 `transactions` and `withdrawals` SSZ lists to `MAX_TRANSACTIONS_PER_PAYLOAD` and `MAX_WITHDRAWALS_PER_PAYLOAD`, rejecting an oversized declared count at the offset read before any per-element allocation. It adds two regression tests: one asserting the decoder rejects the count bomb, and one that measures decode allocation via a counting global allocator and holds it well under the amplified size.

Note this covers the v4 decode path only; v1/v2/v3 delegate to `alloy_rpc_types_engine`'s unbounded decoder and still need equivalent bounding as a follow-up.