### PR TITLE
refactor(consensus): Simplify Sequencer Main Loop

### DIFF
--- a/crates/consensus/service/src/actors/mod.rs
+++ b/crates/consensus/service/src/actors/mod.rs
@@ -59,14 +59,14 @@ pub use network::{
 
 mod sequencer;
 pub use sequencer::{
-    CanonicalReconciliationInputs, CanonicalUnsafeCatchup, Conductor, ConductorClient,
-    ConductorError, DelayedL1OriginSelectorProvider, L1OriginSelector, L1OriginSelectorError,
-    L1OriginSelectorProvider, OriginSelector, PayloadBuilder, PayloadSealer, PendingStopSender,
-    PoolActivation, QueuedSequencerEngineClient, RecoveryModeGuard, ScheduledTicker, SealState,
-    SealStepError, SealStepOutcome, SequencerActor, SequencerActorError, SequencerAdminQuery,
-    SequencerConfig, SequencerEngineClient, SequencerEngineRequestCoordinator,
-    SequencerEngineState, ShadowCycle, ShadowReconciliationGate, ShadowReconciliationTask,
-    UnsealedPayloadHandle,
+    BuildPipelineState, CanonicalReconciliationInputs, CanonicalUnsafeCatchup, Conductor,
+    ConductorClient, ConductorError, DelayedL1OriginSelectorProvider, L1OriginSelector,
+    L1OriginSelectorError, L1OriginSelectorProvider, OriginSelector, PayloadBuilder, PayloadSealer,
+    PendingStopSender, PoolActivation, QueuedSequencerEngineClient, RecoveryModeGuard,
+    ScheduledTicker, SealState, SealStepError, SealStepOutcome, SequencerActor,
+    SequencerActorError, SequencerAdminQuery, SequencerConfig, SequencerEngineClient,
+    SequencerEngineRequestCoordinator, SequencerEngineState, ShadowCycle, ShadowReconciliationGate,
+    ShadowReconciliationTask, ShadowSequencingState, UnsealedPayloadHandle,
 };
 #[cfg(test)]
 pub use sequencer::{MockConductor, MockOriginSelector, MockSequencerEngineClient};

--- a/crates/consensus/service/src/actors/sequencer/actor.rs
+++ b/crates/consensus/service/src/actors/sequencer/actor.rs
@@ -591,7 +591,7 @@ where
 
         self.update_metrics();
 
-        let mut pipeline = BuildPipelineState::new();
+        let mut pipeline = BuildPipelineState::default();
 
         // Reset the engine state prior to beginning block building.
         // Admin API queries are serviced during this phase (see schedule_initial_reset).

--- a/crates/consensus/service/src/actors/sequencer/actor.rs
+++ b/crates/consensus/service/src/actors/sequencer/actor.rs
@@ -15,6 +15,8 @@ use base_protocol::L2BlockInfo;
 use tokio::{
     select,
     sync::{mpsc, oneshot},
+    task::JoinError,
+    time::Interval,
 };
 use tokio_util::sync::{CancellationToken, WaitForCancellationFuture};
 
@@ -22,16 +24,15 @@ use crate::{
     CancellableContext, Metrics, NodeActor, SequencerAdminQuery, UnsafePayloadGossipClient,
     actors::{
         SequencerEngineClient,
-        engine::EngineClientError,
+        engine::{EngineClientError, EngineClientResult},
         sequencer::{
-            ScheduledTicker,
+            BuildPipelineState, ScheduledTicker, ShadowSequencingState,
             build::{PayloadBuilder, UnsealedPayloadHandle},
             conductor::Conductor,
             error::SequencerActorError,
             origin_selector::OriginSelector,
             recovery::RecoveryModeGuard,
-            seal::{PayloadSealer, SealStepOutcome},
-            shadow_cycle::{ShadowCycle, ShadowReconciliationTask},
+            seal::{PayloadSealer, SealStepError, SealStepOutcome},
         },
     },
 };
@@ -261,46 +262,48 @@ where
     /// reconciliation attempt, or actor-side cycle state from before the reset is stale.
     async fn reset_shadow_cycle_after_admin(
         &mut self,
-        shadow_cycle: &mut Option<ShadowCycle>,
-        reconciliation_task: &mut Option<ShadowReconciliationTask>,
-        next_payload_to_seal: &mut Option<UnsealedPayloadHandle>,
-        pending_build_parent: &mut Option<L2BlockInfo>,
+        shadow: &mut Option<ShadowSequencingState>,
+        pipeline: &mut BuildPipelineState,
         build_ticker: &mut ScheduledTicker,
     ) -> Result<(), SequencerActorError> {
-        if let Some(task) = reconciliation_task.take() {
-            task.abort();
+        // A reset discards the in-flight seal outright, so resolve any pending stop response
+        // now rather than leaving it stranded until actor teardown.
+        if let Some(tx) = self.pending_stop.take() {
+            let result = self.resolve_stop_head().await;
+            if tx.send(result).is_err() {
+                warn!(target: "sequencer", "Failed to send deferred stop_sequencer response");
+            }
+        }
+        if let Some(shadow_state) = shadow.as_mut() {
+            shadow_state.abort_reconciliation();
         }
         self.sealer = None;
-        pending_build_parent.take();
+        pipeline.pending_build_parent = None;
         let canonical_head = self.engine_client.get_unsafe_head().await?;
-        *shadow_cycle = Some(ShadowCycle::building(canonical_head)?);
-        *next_payload_to_seal =
+        *shadow = Some(ShadowSequencingState::new(canonical_head)?);
+        pipeline.next_payload_to_seal =
             if self.is_active { self.builder.build_on(canonical_head).await? } else { None };
-        if self.is_active && next_payload_to_seal.is_none() {
+        if self.is_active && pipeline.next_payload_to_seal.is_none() {
             build_ticker.reset_immediately();
         }
         Ok(())
     }
 
-    /// Validates a private insertion acknowledgement, cancelling the node on cycle corruption.
-    fn validate_shadow_insertion(
+    /// Validates and records a private insertion acknowledgement against the current shadow
+    /// cycle, cancelling the node on cycle corruption. Returns whether the cycle has reached its
+    /// private block limit and reconciliation should start.
+    fn on_shadow_insertion(
         &self,
-        cycle: ShadowCycle,
-        inserted_head: L2BlockInfo,
-    ) -> Result<(), EngineClientError> {
-        let sealer = self.sealer.as_ref().expect("inserted payload must have an active sealer");
-        cycle
-            .validate_insertion(sealer, inserted_head)
-            .inspect_err(|_| self.cancellation_token.cancel())
-    }
-
-    /// Advances a private cycle, cancelling the node if its expected progression is violated.
-    fn record_shadow_insertion(
-        &self,
-        cycle: &mut ShadowCycle,
+        shadow_state: &mut ShadowSequencingState,
         inserted_head: L2BlockInfo,
     ) -> Result<bool, EngineClientError> {
-        cycle
+        let sealer = self.sealer.as_ref().expect("inserted payload must have an active sealer");
+        shadow_state
+            .cycle
+            .validate_insertion(sealer, inserted_head)
+            .inspect_err(|_| self.cancellation_token.cancel())?;
+        shadow_state
+            .cycle
             .record_insertion(
                 inserted_head,
                 self.shadow_blocks_per_cycle.expect("shadow mode checked").get(),
@@ -340,6 +343,221 @@ where
     ) -> SystemTime {
         self.block_seal_target(block_number.saturating_add(1), last_seal_duration)
     }
+
+    /// Handles one admin API query received while the main loop is running, applying any
+    /// resulting shadow-cycle reset and active-state bookkeeping.
+    async fn handle_admin_query_tick(
+        &mut self,
+        pipeline: &mut BuildPipelineState,
+        shadow: &mut Option<ShadowSequencingState>,
+        build_ticker: &mut ScheduledTicker,
+        query: SequencerAdminQuery,
+    ) -> Result<(), SequencerActorError> {
+        let active_before = self.is_active;
+
+        let reset_requested =
+            self.handle_admin_query(&mut pipeline.next_payload_to_seal, query).await;
+
+        if reset_requested && self.is_shadow_sequencer() {
+            self.reset_shadow_cycle_after_admin(shadow, pipeline, build_ticker).await?;
+        }
+
+        if active_before && !self.is_active {
+            pipeline.pending_build_parent = None;
+        }
+
+        if !active_before && self.is_active {
+            // Clear the previous completion timestamp so the first block after a stop->start
+            // cycle does not record the entire idle period as sequencer_block_to_block_duration.
+            pipeline.clear_for_active_transition();
+            build_ticker.reset_immediately();
+        }
+
+        Ok(())
+    }
+
+    /// Handles the outcome of a completed reconciliation attempt.
+    async fn handle_reconciliation_result(
+        &mut self,
+        pipeline: &mut BuildPipelineState,
+        shadow: &mut Option<ShadowSequencingState>,
+        reconciliation_ticker: &mut Interval,
+        build_ticker: &mut ScheduledTicker,
+        task_result: Result<EngineClientResult<Option<L2BlockInfo>>, JoinError>,
+    ) -> Result<(), SequencerActorError> {
+        if let Some(shadow_state) = shadow.as_mut() {
+            shadow_state.reconciliation_task = None;
+        }
+        let result = task_result.map_err(|error| {
+            self.cancellation_token.cancel();
+            EngineClientError::ResponseError(format!("shadow reconciliation task failed: {error}"))
+        })?;
+        match result {
+            Ok(Some(head)) => {
+                shadow
+                    .as_mut()
+                    .expect("shadow reconciliation requires cycle state")
+                    .cycle
+                    .reconcile(head)?;
+                if self.is_active {
+                    pipeline.next_payload_to_seal = self.builder.build_on(head).await?;
+                    if pipeline.next_payload_to_seal.is_none() {
+                        build_ticker.reset_immediately();
+                    }
+                }
+            }
+            // The gate is not ready until every canonical P2P payload has arrived. Back off one
+            // block interval instead of hot-looping reconciliation RPCs.
+            Ok(None) => reconciliation_ticker
+                .reset_after(Duration::from_secs(self.rollup_config.block_time)),
+            Err(err) => {
+                error!(target: "sequencer", error = ?err, "Shadow reconciliation failed");
+                self.cancellation_token.cancel();
+                return Err(err.into());
+            }
+        }
+        Ok(())
+    }
+
+    /// Handles the outcome of one seal pipeline step.
+    async fn handle_seal_step_result(
+        &mut self,
+        pipeline: &mut BuildPipelineState,
+        shadow: &mut Option<ShadowSequencingState>,
+        reconciliation_ticker: &mut Interval,
+        build_ticker: &mut ScheduledTicker,
+        result: Result<SealStepOutcome, SealStepError>,
+    ) -> Result<(), SequencerActorError> {
+        match result {
+            Ok(SealStepOutcome::Inserted(inserted_head)) => {
+                let reconcile = match shadow.as_mut() {
+                    Some(shadow_state) => self.on_shadow_insertion(shadow_state, inserted_head)?,
+                    None => false,
+                };
+
+                if let Some(sealer) = self.sealer.take() {
+                    Metrics::sequencer_seal_pipeline_duration().record(sealer.started_at.elapsed());
+                }
+
+                if reconcile {
+                    pipeline.next_payload_to_seal = None;
+                    reconciliation_ticker.reset_immediately();
+                }
+
+                if let Some(elapsed) = pipeline.record_block_complete() {
+                    Metrics::sequencer_block_to_block_duration().record(elapsed);
+                }
+
+                // Respond to a pending stop_sequencer request now that the in-flight seal is
+                // complete.
+                if let Some(tx) = self.pending_stop.take() {
+                    let result = self.resolve_stop_head().await;
+                    if tx.send(result).is_err() {
+                        warn!(target: "sequencer", "Failed to send deferred stop_sequencer response");
+                    }
+                }
+
+                let awaiting_reconciliation =
+                    shadow.as_ref().is_some_and(ShadowSequencingState::is_awaiting_reconciliation);
+                if self.is_active && !awaiting_reconciliation {
+                    // Queue the acknowledged parent instead of starting its child build here. Its
+                    // timestamp is a hard lower bound for the steady-state child build because
+                    // variable getPayload durations can make insertion complete early.
+                    let parent_millis = self
+                        .rollup_config
+                        .l2_block_timestamp_millis(inserted_head.block_info.number);
+                    pipeline.pending_build_parent = Some(inserted_head);
+                    build_ticker.reset_at(UNIX_EPOCH + Duration::from_millis(parent_millis));
+                }
+            }
+            Ok(SealStepOutcome::Pending) => {}
+            Err(err) => {
+                let step = self.sealer.as_ref().map(|s| s.state.label()).unwrap_or("unknown");
+                warn!(target: "sequencer", error = ?err, step, "Seal step failed, will retry");
+            }
+        }
+        Ok(())
+    }
+
+    /// Starts building the queued child on its acknowledged parent. Does not start this build
+    /// before its inserted parent's timestamp: if it is already past, the ticker is immediately
+    /// runnable.
+    async fn start_pending_child_build(
+        &mut self,
+        pipeline: &mut BuildPipelineState,
+        build_ticker: &mut ScheduledTicker,
+    ) -> Result<(), SequencerActorError> {
+        let parent = pipeline.pending_build_parent.take().expect("caller checked Some");
+        pipeline.next_payload_to_seal = self.builder.build_on(parent).await?;
+        let target = pipeline.next_payload_to_seal.as_ref().map(|payload| {
+            self.block_seal_target(payload.block_number(), pipeline.last_seal_duration)
+        });
+        build_ticker.schedule_after_build(target);
+        Ok(())
+    }
+
+    /// Advances the in-flight pre-built payload through sealing, or rebuilds on the current
+    /// unsafe head if the seal attempt discarded it as stale.
+    async fn advance_seal_or_rebuild(
+        &mut self,
+        pipeline: &mut BuildPipelineState,
+        build_ticker: &mut ScheduledTicker,
+    ) -> Result<(), SequencerActorError> {
+        let handle = pipeline.next_payload_to_seal.take().expect("caller checked Some");
+        let handle_block_number = handle.block_number();
+        match self.try_seal_handle(handle).await? {
+            Some((new_sealer, dur)) => {
+                pipeline.last_seal_duration = dur;
+                self.sealer = Some(new_sealer);
+                let target =
+                    self.next_block_seal_target(handle_block_number, pipeline.last_seal_duration);
+                // Do not call build() here. The next payload is built after the engine
+                // acknowledges insertion of the sealed payload.
+                build_ticker.reset_at(target);
+            }
+            None => {
+                // Stale build or non-fatal seal error: rebuild immediately on the current unsafe
+                // head.
+                pipeline.next_payload_to_seal = self.builder.build().await?;
+                let target = pipeline.next_payload_to_seal.as_ref().map(|payload| {
+                    self.block_seal_target(payload.block_number(), pipeline.last_seal_duration)
+                });
+                build_ticker.schedule_after_build(target);
+            }
+        }
+        Ok(())
+    }
+
+    /// Builds fresh on the current unsafe head.
+    async fn build_fresh(
+        &mut self,
+        pipeline: &mut BuildPipelineState,
+        build_ticker: &mut ScheduledTicker,
+    ) -> Result<(), SequencerActorError> {
+        pipeline.next_payload_to_seal = self.builder.build().await?;
+        let target = pipeline.next_payload_to_seal.as_ref().map(|payload| {
+            self.block_seal_target(payload.block_number(), pipeline.last_seal_duration)
+        });
+        build_ticker.schedule_after_build(target);
+        Ok(())
+    }
+
+    /// Dispatches one build-ticker tick to whichever of the three build states is active:
+    /// a queued child build gated on its parent's timestamp, an in-flight payload ready to seal,
+    /// or neither, in which case a fresh build is started on the current unsafe head.
+    async fn handle_build_tick(
+        &mut self,
+        pipeline: &mut BuildPipelineState,
+        build_ticker: &mut ScheduledTicker,
+    ) -> Result<(), SequencerActorError> {
+        if pipeline.pending_build_parent.is_some() {
+            self.start_pending_child_build(pipeline, build_ticker).await
+        } else if pipeline.next_payload_to_seal.is_some() {
+            self.advance_seal_or_rebuild(pipeline, build_ticker).await
+        } else {
+            self.build_fresh(pipeline, build_ticker).await
+        }
+    }
 }
 
 #[async_trait]
@@ -373,108 +591,53 @@ where
 
         self.update_metrics();
 
-        let mut next_payload_to_seal: Option<UnsealedPayloadHandle> = None;
-        // Acknowledged parent whose child build is gated on the parent's timestamp.
-        let mut pending_build_parent = None;
+        let mut pipeline = BuildPipelineState::new();
 
         // Reset the engine state prior to beginning block building.
         // Admin API queries are serviced during this phase (see schedule_initial_reset).
-        self.schedule_initial_reset(&mut next_payload_to_seal).await?;
-        let mut shadow_cycle = if self.is_shadow_sequencer() {
-            Some(ShadowCycle::building(self.engine_client.get_unsafe_head().await?)?)
+        self.schedule_initial_reset(&mut pipeline.next_payload_to_seal).await?;
+        let mut shadow: Option<ShadowSequencingState> = if self.is_shadow_sequencer() {
+            Some(ShadowSequencingState::new(self.engine_client.get_unsafe_head().await?)?)
         } else {
             None
         };
-        let mut reconciliation_task: Option<ShadowReconciliationTask> = None;
         // Reconciliation readiness is polled at block cadence. Skipping missed ticks avoids a
         // retry burst after the actor is delayed by sealing or engine work.
         let mut reconciliation_ticker =
             tokio::time::interval(Duration::from_secs(self.rollup_config.block_time));
         reconciliation_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        let mut last_seal_duration = Duration::from_secs(0);
-
-        let mut last_block_complete_at: Option<Instant> = None;
 
         loop {
             select! {
                 biased;
                 _ = self.cancellation_token.cancelled() => {
-                    if let Some(task) = reconciliation_task.take() {
-                        task.abort();
+                    if let Some(shadow_state) = shadow.as_mut() {
+                        shadow_state.abort_reconciliation();
                     }
                     info!(target: "sequencer", "Received shutdown signal. Exiting sequencer task.");
                     return Ok(());
                 }
                 Some(query) = self.admin_api_rx.recv() => {
-                    let active_before = self.is_active;
-
-                    let reset_requested = self
-                        .handle_admin_query(&mut next_payload_to_seal, query)
-                        .await;
-
-                    if reset_requested && self.is_shadow_sequencer() {
-                        self.reset_shadow_cycle_after_admin(
-                            &mut shadow_cycle,
-                            &mut reconciliation_task,
-                            &mut next_payload_to_seal,
-                            &mut pending_build_parent,
-                            &mut build_ticker,
-                        ).await?;
-                    }
-
-                    if active_before && !self.is_active {
-                        pending_build_parent.take();
-                    }
-
-                    if !active_before && self.is_active {
-                        pending_build_parent.take();
-                        // Clear the previous completion timestamp so the first block
-                        // after a stop->start cycle does not record the entire idle
-                        // period as sequencer_block_to_block_duration.
-                        last_block_complete_at = None;
-                        build_ticker.reset_immediately();
-                    }
+                    self.handle_admin_query_tick(&mut pipeline, &mut shadow, &mut build_ticker, query).await?;
                 }
-                _ = reconciliation_ticker.tick(), if shadow_cycle.and_then(ShadowCycle::reconciliation_target).is_some() && reconciliation_task.is_none() && self.sealer.is_none() => {
-                    reconciliation_task = Some(
-                        shadow_cycle
-                            .expect("reconciliation target checked")
-                            .start_reconciliation(Arc::clone(&self.engine_client))?,
-                    );
+                _ = reconciliation_ticker.tick(), if shadow.as_ref().is_some_and(|s| s.is_awaiting_reconciliation() && s.reconciliation_task.is_none()) && self.sealer.is_none() => {
+                    let shadow_state = shadow.as_mut().expect("reconciliation target checked");
+                    shadow_state.reconciliation_task =
+                        Some(shadow_state.cycle.start_reconciliation(Arc::clone(&self.engine_client))?);
                 }
                 task_result = async {
-                    match reconciliation_task.as_mut() {
+                    match shadow.as_mut().and_then(|s| s.reconciliation_task.as_mut()) {
                         Some(task) => task.await,
                         None => std::future::pending().await,
                     }
                 } => {
-                    reconciliation_task = None;
-                    let result = task_result.map_err(|error| {
-                        self.cancellation_token.cancel();
-                        EngineClientError::ResponseError(format!(
-                            "shadow reconciliation task failed: {error}"
-                        ))
-                    })?;
-                    match result {
-                        Ok(Some(head)) => {
-                            shadow_cycle.as_mut().expect("shadow reconciliation requires cycle state").reconcile(head)?;
-                            if self.is_active {
-                                next_payload_to_seal = self.builder.build_on(head).await?;
-                                if next_payload_to_seal.is_none() {
-                                    build_ticker.reset_immediately();
-                                }
-                            }
-                        }
-                        // The gate is not ready until every canonical P2P payload has arrived.
-                        // Back off one block interval instead of hot-looping reconciliation RPCs.
-                        Ok(None) => reconciliation_ticker
-                            .reset_after(Duration::from_secs(self.rollup_config.block_time)),
-                        Err(err) => {
-                            error!(target: "sequencer", error = ?err, "Shadow reconciliation failed");
-                            self.cancellation_token.cancel();
-                            return Err(err.into());
-                        }
-                    }
+                    self.handle_reconciliation_result(
+                        &mut pipeline,
+                        &mut shadow,
+                        &mut reconciliation_ticker,
+                        &mut build_ticker,
+                        task_result,
+                    ).await?;
                 }
                 // Drive the seal pipeline (commit → gossip → insert) one step per iteration.
                 // The ticker arm is gated on `sealer.is_none()` so the two are mutually
@@ -489,61 +652,13 @@ where
                         None => std::future::pending().await,
                     }
                 } => {
-                    match result {
-                        Ok(SealStepOutcome::Inserted(inserted_head)) => {
-                            if self.is_shadow_sequencer() {
-                                let cycle = shadow_cycle.expect("shadow mode has cycle state");
-                                self.validate_shadow_insertion(cycle, inserted_head)?;
-                            }
-                            if let Some(sealer) = self.sealer.take() {
-                                Metrics::sequencer_seal_pipeline_duration()
-                                    .record(sealer.started_at.elapsed());
-                            }
-                            if self.is_shadow_sequencer() {
-                                let cycle = shadow_cycle.as_mut().expect("shadow mode has cycle state");
-                                let reconcile = self.record_shadow_insertion(cycle, inserted_head)?;
-                                if reconcile {
-                                    next_payload_to_seal = None;
-                                    reconciliation_ticker.reset_immediately();
-                                }
-                            }
-
-                            let now = Instant::now();
-                            if let Some(prev) = last_block_complete_at {
-                                Metrics::sequencer_block_to_block_duration()
-                                    .record(now.duration_since(prev));
-                            }
-                            last_block_complete_at = Some(now);
-
-                            // Respond to a pending stop_sequencer request now that the
-                            // in-flight seal is complete.
-                            if let Some(tx) = self.pending_stop.take() {
-                                let result = self.resolve_stop_head().await;
-                                if tx.send(result).is_err() {
-                                    warn!(target: "sequencer", "Failed to send deferred stop_sequencer response");
-                                }
-                            }
-                            if self.is_active
-                                && shadow_cycle
-                                    .and_then(ShadowCycle::reconciliation_target)
-                                    .is_none()
-                            {
-                                // Queue the acknowledged parent instead of starting its child
-                                // here. Its timestamp is a hard lower bound for the steady-state
-                                // child build because variable getPayload durations can make
-                                // insertion complete early.
-                                let parent_millis =
-                                    self.rollup_config.l2_block_timestamp_millis(inserted_head.block_info.number);
-                                pending_build_parent = Some(inserted_head);
-                                build_ticker.reset_at(UNIX_EPOCH + Duration::from_millis(parent_millis));
-                            }
-                        }
-                        Ok(SealStepOutcome::Pending) => {}
-                        Err(err) => {
-                            let step = self.sealer.as_ref().map(|s| s.state.label()).unwrap_or("unknown");
-                            warn!(target: "sequencer", error = ?err, step, "Seal step failed, will retry");
-                        }
-                    }
+                    self.handle_seal_step_result(
+                        &mut pipeline,
+                        &mut shadow,
+                        &mut reconciliation_ticker,
+                        &mut build_ticker,
+                        result,
+                    ).await?;
                 }
                 // Tick is gated on `self.sealer.is_none()` to make the ticker and sealer arms
                 // mutually exclusive. In catch-up mode reset_immediately() fires every tick,
@@ -551,78 +666,8 @@ where
                 // is Poll::Pending. Disabling the ticker while a seal is in-flight lets the
                 // sealer arm complete all three steps (commit → gossip → insert) before the
                 // next block starts, so the canonical head actually advances.
-                _ = build_ticker.tick(), if self.is_active && self.sealer.is_none() && shadow_cycle.and_then(ShadowCycle::reconciliation_target).is_none() => {
-                    if let Some(parent) = pending_build_parent.take() {
-                        // Do not start a steady-state child build before its inserted parent's
-                        // timestamp. If it is already past, the ticker is immediately runnable.
-                        next_payload_to_seal = self.builder.build_on(parent).await?;
-                        if let Some(ref payload) = next_payload_to_seal {
-                            let next_block_number = payload
-                                .attributes_with_parent
-                                .parent()
-                                .block_info
-                                .number
-                                .saturating_add(1);
-                            let next_block_time =
-                                self.block_seal_target(next_block_number, last_seal_duration);
-                            build_ticker.reset_at(next_block_time);
-                        } else {
-                            // Retry through build() so the next attempt refreshes the unsafe head
-                            // instead of retaining a parent that may have become stale.
-                            build_ticker.reset_immediately();
-                        }
-                    } else if let Some(handle) = next_payload_to_seal.take() {
-                        let handle_block_number = handle
-                            .attributes_with_parent
-                            .parent()
-                            .block_info
-                            .number
-                            .saturating_add(1);
-                        match self.try_seal_handle(handle).await? {
-                            Some((new_sealer, dur)) => {
-                                last_seal_duration = dur;
-                                self.sealer = Some(new_sealer);
-                                let next_block_time =
-                                    self.next_block_seal_target(handle_block_number, last_seal_duration);
-                                build_ticker.reset_at(next_block_time);
-                                // Do not call build() here. The next payload is built after the
-                                // engine acknowledges insertion of the sealed payload.
-                            }
-                            None => {
-                                // Stale build or non-fatal seal error: rebuild immediately on
-                                // the current unsafe head.
-                                next_payload_to_seal = self.builder.build().await?;
-                                if let Some(ref payload) = next_payload_to_seal {
-                                    let next_block_number = payload
-                                        .attributes_with_parent
-                                        .parent()
-                                        .block_info
-                                        .number
-                                        .saturating_add(1);
-                                    let next_block_time =
-                                        self.block_seal_target(next_block_number, last_seal_duration);
-                                    build_ticker.reset_at(next_block_time);
-                                } else {
-                                    build_ticker.reset_immediately();
-                                }
-                            }
-                        }
-                    } else {
-                        next_payload_to_seal = self.builder.build().await?;
-                        if let Some(ref payload) = next_payload_to_seal {
-                            let next_block_number = payload
-                                .attributes_with_parent
-                                .parent()
-                                .block_info
-                                .number
-                                .saturating_add(1);
-                            let next_block_time =
-                                self.block_seal_target(next_block_number, last_seal_duration);
-                            build_ticker.reset_at(next_block_time);
-                        } else {
-                            build_ticker.reset_immediately();
-                        }
-                    }
+                _ = build_ticker.tick(), if self.is_active && self.sealer.is_none() && shadow.as_ref().is_none_or(|s| !s.is_awaiting_reconciliation()) => {
+                    self.handle_build_tick(&mut pipeline, &mut build_ticker).await?;
                 }
             }
         }

--- a/crates/consensus/service/src/actors/sequencer/build.rs
+++ b/crates/consensus/service/src/actors/sequencer/build.rs
@@ -33,6 +33,13 @@ pub struct UnsealedPayloadHandle {
     pub attributes_with_parent: AttributesWithParent,
 }
 
+impl UnsealedPayloadHandle {
+    /// Returns the number of the block represented by this payload.
+    pub const fn block_number(&self) -> u64 {
+        self.attributes_with_parent.parent().block_info.number.saturating_add(1)
+    }
+}
+
 /// Drives payload attribute preparation and block build initiation.
 ///
 /// Owns the build-side dependencies (`attributes_builder`, `origin_selector`,

--- a/crates/consensus/service/src/actors/sequencer/mod.rs
+++ b/crates/consensus/service/src/actors/sequencer/mod.rs
@@ -38,6 +38,12 @@ pub use ticker::ScheduledTicker;
 mod pool;
 pub use pool::PoolActivation;
 
+mod pipeline_state;
+pub use pipeline_state::BuildPipelineState;
+
+mod shadow_state;
+pub use shadow_state::ShadowSequencingState;
+
 mod actor;
 pub use actor::{PendingStopSender, SequencerActor};
 

--- a/crates/consensus/service/src/actors/sequencer/pipeline_state.rs
+++ b/crates/consensus/service/src/actors/sequencer/pipeline_state.rs
@@ -1,0 +1,87 @@
+//! Loop-scoped state tracking the build/seal pipeline across ticks of the sequencer main loop.
+
+use std::time::{Duration, Instant};
+
+use base_protocol::L2BlockInfo;
+
+use crate::UnsealedPayloadHandle;
+
+/// Build/seal pipeline bookkeeping carried between iterations of the sequencer main loop.
+#[derive(Debug)]
+pub struct BuildPipelineState {
+    /// Pre-built payload awaiting sealing.
+    pub next_payload_to_seal: Option<UnsealedPayloadHandle>,
+    /// Acknowledged parent whose child build is gated on the parent's timestamp.
+    pub pending_build_parent: Option<L2BlockInfo>,
+    /// Duration of the most recently completed seal, used as the ticker's lead time.
+    pub last_seal_duration: Duration,
+    /// Wall-clock instant the most recent block finished, used to record
+    /// [`crate::Metrics::sequencer_block_to_block_duration`].
+    pub last_block_complete_at: Option<Instant>,
+}
+
+impl Default for BuildPipelineState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BuildPipelineState {
+    /// Creates an empty pipeline state, as at actor startup.
+    pub const fn new() -> Self {
+        Self {
+            next_payload_to_seal: None,
+            pending_build_parent: None,
+            last_seal_duration: Duration::from_secs(0),
+            last_block_complete_at: None,
+        }
+    }
+
+    /// Records that a block has just completed, returning the elapsed time since the previous
+    /// completion. Returns `None` on the first block after construction or after a stop/start
+    /// cycle cleared the previous timestamp, so that idle time is never recorded as block time.
+    pub fn record_block_complete(&mut self) -> Option<Duration> {
+        let now = Instant::now();
+        let elapsed = self.last_block_complete_at.map(|prev| now.duration_since(prev));
+        self.last_block_complete_at = Some(now);
+        elapsed
+    }
+
+    /// Clears state that must not carry across a stop -> start transition: any queued parent
+    /// build and the previous completion timestamp (so the first block after restart does not
+    /// record the idle period as block-to-block duration).
+    pub const fn clear_for_active_transition(&mut self) {
+        self.pending_build_parent = None;
+        self.last_block_complete_at = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::BuildPipelineState;
+
+    #[test]
+    fn record_block_complete_returns_none_first_time() {
+        let mut state = BuildPipelineState::new();
+        assert!(state.record_block_complete().is_none());
+    }
+
+    #[test]
+    fn record_block_complete_returns_elapsed_on_subsequent_calls() {
+        let mut state = BuildPipelineState::new();
+        state.record_block_complete();
+        std::thread::sleep(Duration::from_millis(5));
+        assert!(state.record_block_complete().is_some());
+    }
+
+    #[test]
+    fn clear_for_active_transition_resets_fields() {
+        let mut state = BuildPipelineState::new();
+        state.record_block_complete();
+        state.clear_for_active_transition();
+        assert!(state.last_block_complete_at.is_none());
+        assert!(state.pending_build_parent.is_none());
+    }
+}

--- a/crates/consensus/service/src/actors/sequencer/pipeline_state.rs
+++ b/crates/consensus/service/src/actors/sequencer/pipeline_state.rs
@@ -7,7 +7,10 @@ use base_protocol::L2BlockInfo;
 use crate::UnsealedPayloadHandle;
 
 /// Build/seal pipeline bookkeeping carried between iterations of the sequencer main loop.
-#[derive(Debug)]
+///
+/// [`Default`] gives the empty state the actor starts with: no pre-built payload, no queued
+/// parent, and no prior seal/completion timing.
+#[derive(Debug, Default)]
 pub struct BuildPipelineState {
     /// Pre-built payload awaiting sealing.
     pub next_payload_to_seal: Option<UnsealedPayloadHandle>,
@@ -20,23 +23,7 @@ pub struct BuildPipelineState {
     pub last_block_complete_at: Option<Instant>,
 }
 
-impl Default for BuildPipelineState {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl BuildPipelineState {
-    /// Creates an empty pipeline state, as at actor startup.
-    pub const fn new() -> Self {
-        Self {
-            next_payload_to_seal: None,
-            pending_build_parent: None,
-            last_seal_duration: Duration::from_secs(0),
-            last_block_complete_at: None,
-        }
-    }
-
     /// Records that a block has just completed, returning the elapsed time since the previous
     /// completion. Returns `None` on the first block after construction or after a stop/start
     /// cycle cleared the previous timestamp, so that idle time is never recorded as block time.
@@ -64,13 +51,13 @@ mod tests {
 
     #[test]
     fn record_block_complete_returns_none_first_time() {
-        let mut state = BuildPipelineState::new();
+        let mut state = BuildPipelineState::default();
         assert!(state.record_block_complete().is_none());
     }
 
     #[test]
     fn record_block_complete_returns_elapsed_on_subsequent_calls() {
-        let mut state = BuildPipelineState::new();
+        let mut state = BuildPipelineState::default();
         state.record_block_complete();
         std::thread::sleep(Duration::from_millis(5));
         assert!(state.record_block_complete().is_some());
@@ -78,7 +65,7 @@ mod tests {
 
     #[test]
     fn clear_for_active_transition_resets_fields() {
-        let mut state = BuildPipelineState::new();
+        let mut state = BuildPipelineState::default();
         state.record_block_complete();
         state.clear_for_active_transition();
         assert!(state.last_block_complete_at.is_none());

--- a/crates/consensus/service/src/actors/sequencer/shadow_state.rs
+++ b/crates/consensus/service/src/actors/sequencer/shadow_state.rs
@@ -1,0 +1,68 @@
+//! Loop-scoped shadow sequencing state: the build/reconciliation cycle plus its in-flight
+//! reconciliation task, carried between iterations of the sequencer main loop.
+
+use base_protocol::L2BlockInfo;
+
+use crate::{EngineClientError, ShadowCycle, ShadowReconciliationTask};
+
+/// Shadow sequencing state carried between iterations of the sequencer main loop while the actor
+/// is running as a shadow sequencer.
+#[derive(Debug)]
+pub struct ShadowSequencingState {
+    /// Progress through the current private build/reconciliation cycle.
+    pub cycle: ShadowCycle,
+    /// Background task performing one reconciliation attempt, if any.
+    pub reconciliation_task: Option<ShadowReconciliationTask>,
+}
+
+impl ShadowSequencingState {
+    /// Starts a fresh private build cycle on the provided canonical head.
+    pub fn new(canonical_head: L2BlockInfo) -> Result<Self, EngineClientError> {
+        Ok(Self { cycle: ShadowCycle::building(canonical_head)?, reconciliation_task: None })
+    }
+
+    /// Returns whether the cycle has reached its private block limit and is waiting for
+    /// canonical payloads to reconcile.
+    pub const fn is_awaiting_reconciliation(&self) -> bool {
+        self.cycle.reconciliation_target().is_some()
+    }
+
+    /// Aborts any in-flight reconciliation task.
+    pub fn abort_reconciliation(&mut self) {
+        if let Some(task) = self.reconciliation_task.take() {
+            task.abort();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::B256;
+    use base_protocol::{BlockInfo, L2BlockInfo};
+
+    use super::ShadowSequencingState;
+
+    fn head(number: u64) -> L2BlockInfo {
+        L2BlockInfo {
+            block_info: BlockInfo {
+                number,
+                hash: B256::with_last_byte(number as u8),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn new_state_is_not_awaiting_reconciliation() {
+        let state = ShadowSequencingState::new(head(0)).unwrap();
+        assert!(!state.is_awaiting_reconciliation());
+    }
+
+    #[test]
+    fn abort_reconciliation_is_a_no_op_without_a_task() {
+        let mut state = ShadowSequencingState::new(head(0)).unwrap();
+        state.abort_reconciliation();
+        assert!(state.reconciliation_task.is_none());
+    }
+}

--- a/crates/consensus/service/src/actors/sequencer/ticker.rs
+++ b/crates/consensus/service/src/actors/sequencer/ticker.rs
@@ -63,6 +63,18 @@ impl ScheduledTicker {
         self.reset_at(SystemTime::now());
     }
 
+    /// Reschedules the ticker based on the outcome of a build attempt.
+    ///
+    /// If `target` is `Some`, schedules for that wall-clock time. If `None` (the build was
+    /// deferred or discarded), fires immediately so the next attempt refreshes state instead of
+    /// retrying a stale target.
+    pub fn schedule_after_build(&mut self, target: Option<SystemTime>) {
+        match target {
+            Some(target) => self.reset_at(target),
+            None => self.reset_immediately(),
+        }
+    }
+
     /// Awaits the next tick.
     ///
     /// On fire, records [`Metrics::sequencer_ticker_drift_seconds`] using the
@@ -83,5 +95,31 @@ impl ScheduledTicker {
     #[cfg(test)]
     pub const fn target(&self) -> Option<SystemTime> {
         self.target
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    use super::ScheduledTicker;
+
+    #[tokio::test]
+    async fn schedule_after_build_uses_target_when_built() {
+        let mut ticker = ScheduledTicker::new(Duration::from_secs(2));
+        let target = UNIX_EPOCH + Duration::from_millis(2_000_000_000);
+
+        ticker.schedule_after_build(Some(target));
+
+        assert_eq!(ticker.target(), Some(target));
+    }
+
+    #[tokio::test]
+    async fn schedule_after_build_fires_immediately_when_no_payload_was_built() {
+        let mut ticker = ScheduledTicker::new(Duration::from_secs(2));
+
+        ticker.schedule_after_build(None);
+
+        assert!(ticker.target().is_some_and(|target| target <= SystemTime::now()));
     }
 }

--- a/crates/consensus/service/src/lib.rs
+++ b/crates/consensus/service/src/lib.rs
@@ -21,7 +21,7 @@ pub use follow::{FollowError, RemoteClient, RemoteL2Client, RemoteL2ClientError}
 
 mod actors;
 pub use actors::{
-    AlloyL1BlockFetcher, BlockStream, BuildRequest, CancellableContext,
+    AlloyL1BlockFetcher, BlockStream, BuildPipelineState, BuildRequest, CancellableContext,
     CanonicalReconciliationInputs, CanonicalUnsafeCatchup, CheckpointActor, CheckpointClient,
     CheckpointDB, CheckpointError, CheckpointRequest, CheckpointWriter, Conductor, ConductorClient,
     ConductorError, DelayedL1OriginSelectorProvider, DelegateDerivationActor, DerivationActor,
@@ -44,9 +44,9 @@ pub use actors::{
     RpcActorError, RpcContext, ScheduledTicker, SealState, SealStepError, SealStepOutcome,
     SequencerActor, SequencerActorError, SequencerAdminQuery, SequencerConfig,
     SequencerEngineClient, SequencerEngineRequestCoordinator, SequencerEngineState, ShadowCycle,
-    ShadowReconciliationGate, ShadowReconciliationTask, UnsafePayloadGossipClient,
-    UnsafePayloadGossipClientError, UnsealedPayloadHandle, UpgradeSignalMetricsActor,
-    UpgradeSignalNodeConfig, ValidatorEngineRequestHandler,
+    ShadowReconciliationGate, ShadowReconciliationTask, ShadowSequencingState,
+    UnsafePayloadGossipClient, UnsafePayloadGossipClientError, UnsealedPayloadHandle,
+    UpgradeSignalMetricsActor, UpgradeSignalNodeConfig, ValidatorEngineRequestHandler,
 };
 
 mod metrics;


### PR DESCRIPTION
## Summary

Restructures the sequencer actor's main event loop so each select! arm dispatches to a small, named method instead of inlining its logic directly. Two new state structs, BuildPipelineState and ShadowSequencingState, replace the half-dozen loose local variables that were previously threaded through the loop, and a shared ScheduledTicker helper removes several duplicated build-scheduling blocks. Behavior is unchanged aside from one bug fix: a pending stop_sequencer response is now resolved during a shadow-cycle admin reset instead of being silently dropped until actor teardown.