### PR TITLE
feat(nitro-host): track L2 proof node RPC latency

### DIFF
--- a/crates/proof/host/src/handler.rs
+++ b/crates/proof/host/src/handler.rs
@@ -363,17 +363,20 @@ impl PayloadWitnessPrefetcher {
             }
         };
 
-        let execute_payload_response = match self
-            .inner
-            .providers
-            .l2
-            .client()
-            .request::<(B256, BasePayloadAttributes), ExecutionWitness>(
-                "debug_executePayload",
-                (parent_block_hash, payload_attributes),
-            )
-            .await
-        {
+        let execute_payload_response = match base_metrics::time!(
+            Metrics::l2_proof_node_rpc_latency_seconds(),
+            {
+                self.inner
+                    .providers
+                    .l2
+                    .client()
+                    .request::<(B256, BasePayloadAttributes), ExecutionWitness>(
+                        "debug_executePayload",
+                        (parent_block_hash, payload_attributes),
+                    )
+                    .await
+            }
+        ) {
             Ok(response) => response,
             Err(err) => {
                 error!(
@@ -1273,15 +1276,19 @@ async fn handle_hint_inner(
             let payload_attributes: BasePayloadAttributes =
                 serde_json::from_slice(encoded_payload_attributes)?;
 
-            let execute_payload_response = match providers
-                .l2
-                .client()
-                .request::<(B256, BasePayloadAttributes), ExecutionWitness>(
-                    "debug_executePayload",
-                    (parent_block_hash, payload_attributes),
-                )
-                .await
-            {
+            let execute_payload_response = match base_metrics::time!(
+                Metrics::l2_proof_node_rpc_latency_seconds(),
+                {
+                    providers
+                        .l2
+                        .client()
+                        .request::<(B256, BasePayloadAttributes), ExecutionWitness>(
+                            "debug_executePayload",
+                            (parent_block_hash, payload_attributes),
+                        )
+                        .await
+                }
+            ) {
                 Ok(response) => response,
                 Err(e) => {
                     error!(error = %e, "debug_executePayload failed");

--- a/crates/proof/host/src/handler.rs
+++ b/crates/proof/host/src/handler.rs
@@ -363,9 +363,8 @@ impl PayloadWitnessPrefetcher {
             }
         };
 
-        let execute_payload_response = match base_metrics::time!(
-            Metrics::l2_proof_node_rpc_latency_seconds(),
-            {
+        let execute_payload_response =
+            match base_metrics::time!(Metrics::l2_proof_node_rpc_latency_seconds(), {
                 self.inner
                     .providers
                     .l2
@@ -375,20 +374,19 @@ impl PayloadWitnessPrefetcher {
                         (parent_block_hash, payload_attributes),
                     )
                     .await
-            }
-        ) {
-            Ok(response) => response,
-            Err(err) => {
-                error!(
-                    target: HOST_SERVER_TARGET,
-                    block_number,
-                    ?parent_block_hash,
-                    error = %err,
-                    "payload witness prefetch failed: debug_executePayload failed"
-                );
-                return false;
-            }
-        };
+            }) {
+                Ok(response) => response,
+                Err(err) => {
+                    error!(
+                        target: HOST_SERVER_TARGET,
+                        block_number,
+                        ?parent_block_hash,
+                        error = %err,
+                        "payload witness prefetch failed: debug_executePayload failed"
+                    );
+                    return false;
+                }
+            };
 
         if let Err(err) =
             insert_execution_witness_preimages_batched(Arc::clone(&kv), execute_payload_response)
@@ -1276,9 +1274,8 @@ async fn handle_hint_inner(
             let payload_attributes: BasePayloadAttributes =
                 serde_json::from_slice(encoded_payload_attributes)?;
 
-            let execute_payload_response = match base_metrics::time!(
-                Metrics::l2_proof_node_rpc_latency_seconds(),
-                {
+            let execute_payload_response =
+                match base_metrics::time!(Metrics::l2_proof_node_rpc_latency_seconds(), {
                     providers
                         .l2
                         .client()
@@ -1287,14 +1284,13 @@ async fn handle_hint_inner(
                             (parent_block_hash, payload_attributes),
                         )
                         .await
-                }
-            ) {
-                Ok(response) => response,
-                Err(e) => {
-                    error!(error = %e, "debug_executePayload failed");
-                    return Ok(());
-                }
-            };
+                }) {
+                    Ok(response) => response,
+                    Err(e) => {
+                        error!(error = %e, "debug_executePayload failed");
+                        return Ok(());
+                    }
+                };
 
             insert_execution_witness_preimages(Arc::clone(&kv), execute_payload_response).await?;
 

--- a/crates/proof/host/src/metrics/mod.rs
+++ b/crates/proof/host/src/metrics/mod.rs
@@ -37,6 +37,9 @@ base_metrics::define_metrics! {
     #[describe("Size of a witness submitted to a Nitro enclave in bytes")]
     witness_size_bytes: histogram,
 
+    #[describe("Latency in seconds for debug_executePayload RPC calls to the L2 proof node")]
+    l2_proof_node_rpc_latency_seconds: histogram,
+
     #[describe("End-to-end proof generation duration")]
     proof_duration_seconds: histogram,
 


### PR DESCRIPTION
### What changed? Why?

Adds `base_proof_host_l2_proof_node_rpc_latency_seconds` to measure each `debug_executePayload` response from the L2 proof node. It covers foreground witness fetching and lookahead prefetches without changing proof behavior.

### Notes to reviewers

The histogram includes failed RPC calls because their latency still reflects L2 proof-node responsiveness.

### How has it been tested?

- `cargo test -p base-proof-host --features metrics`
- `cargo check -p base-prover-nitro-host --features local`
- `cargo fmt --check`