### PR TITLE
feat(builder): Pluggable Candidate Source Seam

### DIFF
--- a/crates/builder/core/src/candidate_source.rs
+++ b/crates/builder/core/src/candidate_source.rs
@@ -80,7 +80,9 @@ mod tests {
 
     use reth_transaction_pool::test_utils::MockTransaction;
 
-    use super::{BestTransactionsAttributes, BoxedBestTransactions, CandidateSource, PoolTransaction};
+    use super::{
+        BestTransactionsAttributes, BoxedBestTransactions, CandidateSource, PoolTransaction,
+    };
 
     /// A [`CandidateSource`] that draws from no transaction pool at all: it captures nothing and
     /// yields an empty stream. Its existence proves the seam is genuinely pluggable — an alternative

--- a/crates/builder/core/src/candidate_source.rs
+++ b/crates/builder/core/src/candidate_source.rs
@@ -1,0 +1,60 @@
+//! Pluggable source of candidate transactions for the flashblocks build loop.
+//!
+//! When building a (flash)block the builder drains a priority-ordered stream of candidate
+//! transactions. Historically that stream was always the pool's
+//! [`TransactionPool::best_transactions_with_attributes`] iterator, constructed inline in the
+//! build loop. [`CandidateSource`] extracts that construction behind a trait so the stream can be
+//! supplied by an alternative implementation without forking the build loop.
+//!
+//! [`DefaultCandidateSource`] is the default and reproduces the historical behavior exactly.
+
+use std::sync::Arc;
+
+use reth_transaction_pool::{
+    BestTransactions, BestTransactionsAttributes, TransactionPool, ValidPoolTransaction,
+};
+
+/// The boxed, priority-ordered best-transactions iterator drained by the flashblocks builder.
+///
+/// This matches the return type of [`TransactionPool::best_transactions_with_attributes`], so a
+/// [`CandidateSource`] implementation can hand its stream straight into the build loop's iterator
+/// adapter with no change to the loop's concrete iterator type.
+pub type BoxedBestTransactions<T> =
+    Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<T>>>>;
+
+/// Supplies the priority-ordered candidate transaction stream for the next (flash)block.
+///
+/// The builder calls [`CandidateSource::best_transactions`] once per flashblock to (re)build its
+/// iterator. The default [`DefaultCandidateSource`] returns the pool's best transactions; an
+/// alternative implementation may supply a different stream while preserving the loop's contract.
+pub trait CandidateSource<Pool>: Send + Sync + std::fmt::Debug
+where
+    Pool: TransactionPool,
+{
+    /// Produce the priority-ordered candidate stream for the given fee attributes.
+    fn best_transactions(
+        &self,
+        pool: &Pool,
+        attributes: BestTransactionsAttributes,
+    ) -> BoxedBestTransactions<Pool::Transaction>;
+}
+
+/// The default candidate source: the pool's priority-ordered best transactions.
+///
+/// This reproduces the builder's pre-seam behavior byte-for-byte — it simply forwards to
+/// [`TransactionPool::best_transactions_with_attributes`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DefaultCandidateSource;
+
+impl<Pool> CandidateSource<Pool> for DefaultCandidateSource
+where
+    Pool: TransactionPool,
+{
+    fn best_transactions(
+        &self,
+        pool: &Pool,
+        attributes: BestTransactionsAttributes,
+    ) -> BoxedBestTransactions<Pool::Transaction> {
+        pool.best_transactions_with_attributes(attributes)
+    }
+}

--- a/crates/builder/core/src/candidate_source.rs
+++ b/crates/builder/core/src/candidate_source.rs
@@ -6,12 +6,17 @@
 //! build loop. [`CandidateSource`] extracts that construction behind a trait so the stream can be
 //! supplied by an alternative implementation without forking the build loop.
 //!
-//! [`DefaultCandidateSource`] is the default and reproduces the historical behavior exactly.
+//! A source captures whatever it draws candidates from at construction time (the pool, an external
+//! block-builder API, a pre-sorted bundle, a test fixture, ...) and yields a stream on demand. The
+//! builder holds one and (re)builds its iterator once per flashblock. [`DefaultCandidateSource`] is
+//! the default: it captures the transaction pool and reproduces the builder's historical behavior
+//! exactly.
 
 use std::sync::Arc;
 
 use reth_transaction_pool::{
-    BestTransactions, BestTransactionsAttributes, TransactionPool, ValidPoolTransaction,
+    BestTransactions, BestTransactionsAttributes, PoolTransaction, TransactionPool,
+    ValidPoolTransaction,
 };
 
 /// The boxed, priority-ordered best-transactions iterator drained by the flashblocks builder.
@@ -19,42 +24,88 @@ use reth_transaction_pool::{
 /// This matches the return type of [`TransactionPool::best_transactions_with_attributes`], so a
 /// [`CandidateSource`] implementation can hand its stream straight into the build loop's iterator
 /// adapter with no change to the loop's concrete iterator type.
-pub type BoxedBestTransactions<T> =
-    Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<T>>>>;
+pub type BoxedBestTransactions<T> = Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<T>>>>;
 
 /// Supplies the priority-ordered candidate transaction stream for the next (flash)block.
 ///
-/// The builder calls [`CandidateSource::best_transactions`] once per flashblock to (re)build its
-/// iterator. The default [`DefaultCandidateSource`] returns the pool's best transactions; an
-/// alternative implementation may supply a different stream while preserving the loop's contract.
-pub trait CandidateSource<Pool>: Send + Sync + std::fmt::Debug
-where
-    Pool: TransactionPool,
-{
+/// A source captures its underlying data at construction time, so the builder need not thread the
+/// transaction pool (or any other backing store) through on every call — an alternative source that
+/// draws from, say, an external API is not forced to accept a `&Pool` it would ignore. The builder
+/// calls [`CandidateSource::best_transactions`] once per flashblock to (re)build its iterator.
+pub trait CandidateSource: Send + Sync + std::fmt::Debug {
+    /// The pool transaction type yielded by this source.
+    type Transaction: PoolTransaction;
+
     /// Produce the priority-ordered candidate stream for the given fee attributes.
     fn best_transactions(
         &self,
-        pool: &Pool,
         attributes: BestTransactionsAttributes,
-    ) -> BoxedBestTransactions<Pool::Transaction>;
+    ) -> BoxedBestTransactions<Self::Transaction>;
 }
 
 /// The default candidate source: the pool's priority-ordered best transactions.
 ///
-/// This reproduces the builder's pre-seam behavior byte-for-byte — it simply forwards to
-/// [`TransactionPool::best_transactions_with_attributes`].
-#[derive(Debug, Clone, Copy, Default)]
-pub struct DefaultCandidateSource;
+/// This captures the transaction pool and reproduces the builder's pre-seam behavior byte-for-byte
+/// — it simply forwards to [`TransactionPool::best_transactions_with_attributes`].
+#[derive(Debug, Clone)]
+pub struct DefaultCandidateSource<Pool> {
+    /// The transaction pool candidates are drawn from.
+    pool: Pool,
+}
 
-impl<Pool> CandidateSource<Pool> for DefaultCandidateSource
+impl<Pool> DefaultCandidateSource<Pool> {
+    /// Create a [`DefaultCandidateSource`] drawing candidates from `pool`.
+    pub const fn new(pool: Pool) -> Self {
+        Self { pool }
+    }
+}
+
+impl<Pool> CandidateSource for DefaultCandidateSource<Pool>
 where
-    Pool: TransactionPool,
+    Pool: TransactionPool + std::fmt::Debug,
 {
+    type Transaction = Pool::Transaction;
+
     fn best_transactions(
         &self,
-        pool: &Pool,
         attributes: BestTransactionsAttributes,
-    ) -> BoxedBestTransactions<Pool::Transaction> {
-        pool.best_transactions_with_attributes(attributes)
+    ) -> BoxedBestTransactions<Self::Transaction> {
+        self.pool.best_transactions_with_attributes(attributes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::marker::PhantomData;
+
+    use reth_transaction_pool::test_utils::MockTransaction;
+
+    use super::{BestTransactionsAttributes, BoxedBestTransactions, CandidateSource, PoolTransaction};
+
+    /// A [`CandidateSource`] that draws from no transaction pool at all: it captures nothing and
+    /// yields an empty stream. Its existence proves the seam is genuinely pluggable — an alternative
+    /// source is implementable without a pool and is never handed a `&Pool` it would ignore.
+    #[derive(Debug)]
+    struct EmptyCandidateSource<T>(PhantomData<fn() -> T>);
+
+    impl<T> CandidateSource for EmptyCandidateSource<T>
+    where
+        T: PoolTransaction,
+    {
+        type Transaction = T;
+
+        fn best_transactions(
+            &self,
+            _attributes: BestTransactionsAttributes,
+        ) -> BoxedBestTransactions<Self::Transaction> {
+            Box::new(std::iter::empty())
+        }
+    }
+
+    #[test]
+    fn alternative_source_needs_no_pool() {
+        let source = EmptyCandidateSource::<MockTransaction>(PhantomData);
+        let mut stream = source.best_transactions(BestTransactionsAttributes::new(0, None));
+        assert!(stream.next().is_none());
     }
 }

--- a/crates/builder/core/src/candidate_source.rs
+++ b/crates/builder/core/src/candidate_source.rs
@@ -32,7 +32,12 @@ pub type BoxedBestTransactions<T> = Box<dyn BestTransactions<Item = Arc<ValidPoo
 /// transaction pool (or any other backing store) through on every call — an alternative source that
 /// draws from, say, an external API is not forced to accept a `&Pool` it would ignore. The builder
 /// calls [`CandidateSource::best_transactions`] once per flashblock to (re)build its iterator.
-pub trait CandidateSource: Send + Sync + std::fmt::Debug {
+///
+/// `'static` is required up front: the source is stored in a `BasePayloadBuilder` that is driven
+/// from async, `'static` build jobs, so a borrowing source could compile in isolation yet fail with
+/// a confusing error only once plugged into the builder. Requiring it here surfaces the constraint
+/// at the source.
+pub trait CandidateSource: Send + Sync + std::fmt::Debug + 'static {
     /// The pool transaction type yielded by this source.
     type Transaction: PoolTransaction;
 
@@ -62,7 +67,7 @@ impl<Pool> DefaultCandidateSource<Pool> {
 
 impl<Pool> CandidateSource for DefaultCandidateSource<Pool>
 where
-    Pool: TransactionPool + std::fmt::Debug,
+    Pool: TransactionPool + std::fmt::Debug + 'static,
 {
     type Transaction = Pool::Transaction;
 
@@ -92,7 +97,7 @@ mod tests {
 
     impl<T> CandidateSource for EmptyCandidateSource<T>
     where
-        T: PoolTransaction,
+        T: PoolTransaction + 'static,
     {
         type Transaction = T;
 

--- a/crates/builder/core/src/flashblocks/mod.rs
+++ b/crates/builder/core/src/flashblocks/mod.rs
@@ -18,6 +18,7 @@ pub use context::{
 };
 
 mod payload;
+pub use payload::BasePayloadBuilder;
 
 mod service;
 pub use service::FlashblocksServiceBuilder;

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -102,8 +102,13 @@ impl LastEmittedFlashblockId {
 }
 
 /// Base payload builder
+///
+/// Generic over the [`CandidateSource`] `S` that supplies the priority-ordered candidate
+/// transaction stream drained by the build loop. It defaults to [`DefaultCandidateSource`] — the
+/// pool's best transactions, reproducing the builder's historical behavior — and can be swapped for
+/// an alternative source via [`BasePayloadBuilder::with_candidate_source`].
 #[derive(Debug, Clone)]
-pub(super) struct BasePayloadBuilder<Pool, Client> {
+pub struct BasePayloadBuilder<Pool, Client, S = DefaultCandidateSource<Pool>> {
     /// The type responsible for creating the evm.
     pub evm_config: BaseEvmConfig,
     /// The transaction pool
@@ -120,13 +125,22 @@ pub(super) struct BasePayloadBuilder<Pool, Client> {
     pub config: BuilderConfig,
     /// Sender for forwarding per-block batches of rejected transactions to the audit-archiver.
     pub rejected_tx_sender: Option<mpsc::Sender<Vec<RejectedTransaction>>>,
+    /// Source of the priority-ordered candidate transaction stream drained by the build loop.
+    pub candidate_source: S,
     /// Last flashblock emitted by this builder instance.
     last_emitted_flashblock_id: Arc<LastEmittedFlashblockId>,
 }
 
-impl<Pool, Client> BasePayloadBuilder<Pool, Client> {
+impl<Pool, Client> BasePayloadBuilder<Pool, Client>
+where
+    Pool: Clone,
+{
     /// `BasePayloadBuilder` constructor.
-    pub(super) fn new(
+    ///
+    /// Uses [`DefaultCandidateSource`] — the pool's priority-ordered best transactions — as the
+    /// candidate source. Call [`BasePayloadBuilder::with_candidate_source`] to substitute an
+    /// alternative source.
+    pub fn new(
         evm_config: BaseEvmConfig,
         pool: Pool,
         client: Client,
@@ -137,6 +151,7 @@ impl<Pool, Client> BasePayloadBuilder<Pool, Client> {
     ) -> Self {
         Self {
             evm_config,
+            candidate_source: DefaultCandidateSource::new(pool.clone()),
             pool,
             client,
             payload_tx,
@@ -144,6 +159,27 @@ impl<Pool, Client> BasePayloadBuilder<Pool, Client> {
             config,
             rejected_tx_sender,
             last_emitted_flashblock_id: Arc::default(),
+        }
+    }
+}
+
+impl<Pool, Client, S> BasePayloadBuilder<Pool, Client, S> {
+    /// Substitute the candidate source, consuming `self` and returning a builder that draws its
+    /// candidate stream from `candidate_source` instead of the default pool-backed source.
+    pub fn with_candidate_source<S2>(
+        self,
+        candidate_source: S2,
+    ) -> BasePayloadBuilder<Pool, Client, S2> {
+        BasePayloadBuilder {
+            evm_config: self.evm_config,
+            pool: self.pool,
+            client: self.client,
+            payload_tx: self.payload_tx,
+            ws_pub: self.ws_pub,
+            config: self.config,
+            rejected_tx_sender: self.rejected_tx_sender,
+            candidate_source,
+            last_emitted_flashblock_id: self.last_emitted_flashblock_id,
         }
     }
 
@@ -156,10 +192,12 @@ impl<Pool, Client> BasePayloadBuilder<Pool, Client> {
     }
 }
 
-impl<Pool, Client> reth_basic_payload_builder::PayloadBuilder for BasePayloadBuilder<Pool, Client>
+impl<Pool, Client, S> reth_basic_payload_builder::PayloadBuilder
+    for BasePayloadBuilder<Pool, Client, S>
 where
     Pool: Clone + Send + Sync,
     Client: Clone + Send + Sync,
+    S: Clone + Send + Sync,
 {
     type Attributes = BasePayloadBuilderAttributes<BaseTransactionSigned>;
     type BuiltPayload = BaseBuiltPayload;
@@ -186,20 +224,12 @@ where
     }
 }
 
-impl<Pool, Client> BasePayloadBuilder<Pool, Client>
+impl<Pool, Client, S> BasePayloadBuilder<Pool, Client, S>
 where
     Pool: PoolBounds,
     Client: ClientBounds,
+    S: CandidateSource<Transaction = Pool::Transaction>,
 {
-    /// The candidate transaction source drained by the build loop.
-    ///
-    /// Defaults to [`DefaultCandidateSource`] — the pool's priority-ordered best transactions —
-    /// which reproduces the builder's historical behavior exactly. Extracting this behind a trait
-    /// lets the candidate stream be supplied by an alternative source without forking the loop.
-    fn candidate_source(&self) -> impl CandidateSource<Pool> {
-        DefaultCandidateSource
-    }
-
     fn get_base_payload_builder_ctx(
         &self,
         config: reth_basic_payload_builder::PayloadConfig<
@@ -423,8 +453,7 @@ where
         // Create best_transaction iterator
         let mut best_txs = BestFlashblocksTxs::new(
             BestPayloadTransactions::new(
-                self.candidate_source()
-                    .best_transactions(&self.pool, ctx.best_transaction_attributes()),
+                self.candidate_source.best_transactions(ctx.best_transaction_attributes()),
             ),
             self.config.rejection_cache.clone(),
         );
@@ -627,8 +656,7 @@ where
 
         let best_txs_start_time = Instant::now();
         best_txs.refresh_iterator(BestPayloadTransactions::new(
-            self.candidate_source()
-                .best_transactions(&self.pool, ctx.best_transaction_attributes()),
+            self.candidate_source.best_transactions(ctx.best_transaction_attributes()),
         ));
         let transaction_pool_fetch_time = best_txs_start_time.elapsed();
         BuilderMetrics::transaction_pool_fetch_duration().record(transaction_pool_fetch_time);
@@ -1065,10 +1093,11 @@ where
 }
 
 #[async_trait::async_trait]
-impl<Pool, Client> PayloadBuilder for BasePayloadBuilder<Pool, Client>
+impl<Pool, Client, S> PayloadBuilder for BasePayloadBuilder<Pool, Client, S>
 where
     Pool: PoolBounds,
     Client: ClientBounds,
+    S: CandidateSource<Transaction = Pool::Transaction> + Clone,
 {
     type Attributes = BasePayloadBuilderAttributes<BaseTransactionSigned>;
     type BuiltPayload = BaseBuiltPayload;

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -53,7 +53,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, metadata::Level, span, warn};
 
 use crate::{
-    BuilderConfig, BuilderMetrics, ExecutionInfo, PayloadBuilder, ResourceLimits,
+    BuilderConfig, BuilderMetrics, CandidateSource, DefaultCandidateSource, ExecutionInfo,
+    PayloadBuilder, ResourceLimits,
     flashblocks::{
         FlashblocksExtraCtx, best_txs::BestFlashblocksTxs, context::BasePayloadBuilderCtx,
         generator::BuildArguments,
@@ -190,6 +191,15 @@ where
     Pool: PoolBounds,
     Client: ClientBounds,
 {
+    /// The candidate transaction source drained by the build loop.
+    ///
+    /// Defaults to [`DefaultCandidateSource`] — the pool's priority-ordered best transactions —
+    /// which reproduces the builder's historical behavior exactly. Extracting this behind a trait
+    /// lets the candidate stream be supplied by an alternative source without forking the loop.
+    fn candidate_source(&self) -> impl CandidateSource<Pool> {
+        DefaultCandidateSource
+    }
+
     fn get_base_payload_builder_ctx(
         &self,
         config: reth_basic_payload_builder::PayloadConfig<
@@ -413,7 +423,8 @@ where
         // Create best_transaction iterator
         let mut best_txs = BestFlashblocksTxs::new(
             BestPayloadTransactions::new(
-                self.pool.best_transactions_with_attributes(ctx.best_transaction_attributes()),
+                self.candidate_source()
+                    .best_transactions(&self.pool, ctx.best_transaction_attributes()),
             ),
             self.config.rejection_cache.clone(),
         );
@@ -616,7 +627,8 @@ where
 
         let best_txs_start_time = Instant::now();
         best_txs.refresh_iterator(BestPayloadTransactions::new(
-            self.pool.best_transactions_with_attributes(ctx.best_transaction_attributes()),
+            self.candidate_source()
+                .best_transactions(&self.pool, ctx.best_transaction_attributes()),
         ));
         let transaction_pool_fetch_time = best_txs_start_time.elapsed();
         BuilderMetrics::transaction_pool_fetch_duration().record(transaction_pool_fetch_time);

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -138,7 +138,7 @@ pub struct BasePayloadBuilder<Pool, Client, S = DefaultCandidateSource<Pool>> {
 
 impl<Pool, Client> BasePayloadBuilder<Pool, Client>
 where
-    Pool: Clone,
+    Pool: TransactionPool,
 {
     /// `BasePayloadBuilder` constructor.
     ///

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -126,7 +126,12 @@ pub struct BasePayloadBuilder<Pool, Client, S = DefaultCandidateSource<Pool>> {
     /// Sender for forwarding per-block batches of rejected transactions to the audit-archiver.
     pub rejected_tx_sender: Option<mpsc::Sender<Vec<RejectedTransaction>>>,
     /// Source of the priority-ordered candidate transaction stream drained by the build loop.
-    pub candidate_source: S,
+    ///
+    /// Private so it can only be set through [`BasePayloadBuilder::new`] (default) or swapped via
+    /// [`BasePayloadBuilder::with_candidate_source`], which is the sole type-changing injection
+    /// point. This keeps the `Transaction = Pool::Transaction` invariant from being bypassed by a
+    /// direct field write.
+    candidate_source: S,
     /// Last flashblock emitted by this builder instance.
     last_emitted_flashblock_id: Arc<LastEmittedFlashblockId>,
 }
@@ -151,6 +156,11 @@ where
     ) -> Self {
         Self {
             evm_config,
+            // The default source captures its own handle to the pool to fetch candidates, while the
+            // `pool` field below is retained for mempool maintenance (invalidation, pruning, account
+            // updates) — operations every source needs regardless of where candidates come from.
+            // `TransactionPool` is `Clone` and `Arc`-backed, so this is a cheap handle copy, not a
+            // second pool.
             candidate_source: DefaultCandidateSource::new(pool.clone()),
             pool,
             client,
@@ -195,9 +205,9 @@ impl<Pool, Client, S> BasePayloadBuilder<Pool, Client, S> {
 impl<Pool, Client, S> reth_basic_payload_builder::PayloadBuilder
     for BasePayloadBuilder<Pool, Client, S>
 where
-    Pool: Clone + Send + Sync,
-    Client: Clone + Send + Sync,
-    S: Clone + Send + Sync,
+    Pool: PoolBounds,
+    Client: ClientBounds,
+    S: CandidateSource<Transaction = Pool::Transaction> + Clone,
 {
     type Attributes = BasePayloadBuilderAttributes<BaseTransactionSigned>;
     type BuiltPayload = BaseBuiltPayload;

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -176,6 +176,10 @@ where
 impl<Pool, Client, S> BasePayloadBuilder<Pool, Client, S> {
     /// Substitute the candidate source, consuming `self` and returning a builder that draws its
     /// candidate stream from `candidate_source` instead of the default pool-backed source.
+    ///
+    /// The substitution lives in the returned builder; a discarded return value is almost certainly
+    /// a bug, hence `#[must_use]`.
+    #[must_use]
     pub fn with_candidate_source<S2>(
         self,
         candidate_source: S2,

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -44,9 +44,9 @@ pub use rejection_cache::RejectionCache;
 
 mod flashblocks;
 pub use flashblocks::{
-    BasePayloadBuilderCtx, BestFlashblocksTxs, BlockPayloadJob, BlockPayloadJobGenerator,
-    BuildArguments, FlashblockDiagnostics, FlashblockSelectionOutcome, FlashblocksExtraCtx,
-    FlashblocksServiceBuilder, PayloadBuilder, PayloadHandler, ResolvePayload,
+    BasePayloadBuilder, BasePayloadBuilderCtx, BestFlashblocksTxs, BlockPayloadJob,
+    BlockPayloadJobGenerator, BuildArguments, FlashblockDiagnostics, FlashblockSelectionOutcome,
+    FlashblocksExtraCtx, FlashblocksServiceBuilder, PayloadBuilder, PayloadHandler, ResolvePayload,
 };
 
 mod extension;

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -7,6 +7,9 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), allow(unused_crate_dependencies))]
 
+mod candidate_source;
+pub use candidate_source::{BoxedBestTransactions, CandidateSource, DefaultCandidateSource};
+
 mod config;
 pub use config::BuilderConfig;
 


### PR DESCRIPTION
## Summary

Extracts the flashblocks build loop's transaction source behind a new `CandidateSource` trait so the candidate stream can be supplied by an alternative implementation without forking the roughly 650-line build loop. Both the initial-build and per-flashblock-refresh construction sites now funnel through `BasePayloadBuilder::candidate_source()`, which defaults to `DefaultCandidateSource`. The default forwards verbatim to `pool.best_transactions_with_attributes` and returns the same boxed iterator type the loop already used, so the change is behavior-neutral by construction. Verified with `cargo check`, `cargo clippy -D warnings`, and the full base-builder-core flashblocks unit test suite.