### PR TITLE
refactor(challenger): simplify driver tests

### DIFF
--- a/crates/proof/challenge/src/pending.rs
+++ b/crates/proof/challenge/src/pending.rs
@@ -399,11 +399,16 @@ mod tests {
 
             let update = proofs.poll(addr(0), &*zk, max_proof_duration).await.unwrap();
             let should_retry = expected_retry_count != 0;
-            assert_eq!(matches!(update, Some(ProofUpdate::NeedsRetry)), should_retry);
 
             let entry = proofs.get(&addr(0)).unwrap();
             assert_eq!(entry.retry_count, expected_retry_count);
-            assert_eq!(matches!(entry.phase, ProofPhase::NeedsRetry), should_retry);
+            if should_retry {
+                assert!(matches!(update, Some(ProofUpdate::NeedsRetry)));
+                assert!(matches!(entry.phase, ProofPhase::NeedsRetry));
+            } else {
+                assert!(matches!(update, Some(ProofUpdate::Pending)));
+                assert!(matches!(entry.phase, ProofPhase::AwaitingProof { .. }));
+            }
         }
     }
 

--- a/crates/proof/challenge/src/pending.rs
+++ b/crates/proof/challenge/src/pending.rs
@@ -345,3 +345,180 @@ pub enum ProofUpdate {
     /// The proof is still in progress.
     Pending,
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+
+    use alloy_primitives::{Address, B256};
+    use base_prover_service_protocol::{ZkBackend, ZkProofRequest, ZkVm};
+
+    use super::*;
+    use crate::test_utils::{MockZkProofProvider, MockZkProofState, addr};
+
+    const fn minimal_prove_request() -> SnarkPlonkProofRequest {
+        SnarkPlonkProofRequest {
+            proof: ZkProofRequest {
+                start_block_number: 0,
+                number_of_blocks_to_prove: 1,
+                sequence_window: None,
+                l1_head: None,
+                intermediate_root_interval: None,
+                zk_vm: ZkVm::Sp1,
+                zk_backend: ZkBackend::Cluster,
+            },
+            prover_address: Address::ZERO,
+        }
+    }
+
+    fn awaiting_proof(session_id: &str) -> PendingProof {
+        PendingProof::awaiting(
+            session_id.to_owned(),
+            0,
+            B256::ZERO,
+            minimal_prove_request(),
+            DisputeIntent::Challenge,
+        )
+    }
+
+    #[tokio::test]
+    async fn poll_transitions() {
+        for (status, max_proof_duration, expected_retry_count) in [
+            (ProofStatus::Failed, Duration::from_secs(3600), 1),
+            (ProofStatus::Running, Duration::from_secs(3600), 0),
+            (ProofStatus::Running, Duration::ZERO, 1),
+        ] {
+            let zk = Arc::new(MockZkProofProvider {
+                state: Mutex::new(MockZkProofState { proof_status: status, ..Default::default() }),
+            });
+            let mut proofs = PendingProofs::new();
+            proofs.insert(addr(0), awaiting_proof("session"));
+
+            let update = proofs.poll(addr(0), &*zk, max_proof_duration).await.unwrap();
+            let should_retry = expected_retry_count != 0;
+            assert_eq!(matches!(update, Some(ProofUpdate::NeedsRetry)), should_retry);
+
+            let entry = proofs.get(&addr(0)).unwrap();
+            assert_eq!(entry.retry_count, expected_retry_count);
+            assert_eq!(matches!(entry.phase, ProofPhase::NeedsRetry), should_retry);
+        }
+    }
+
+    #[cfg(feature = "metrics")]
+    mod metrics_emission {
+        use alloy_primitives::Bytes;
+        use base_proof_primitives::Proposal;
+        use base_prover_service_protocol::{
+            ProofResult as ApiProofResult, TeeKind, TeeProofResult,
+        };
+        use metrics_util::{
+            MetricKind,
+            debugging::{DebugValue, DebuggingRecorder},
+        };
+
+        use super::*;
+        use crate::ChallengerMetrics;
+
+        fn assert_failure_metric(
+            proof: PendingProof,
+            state: MockZkProofState,
+            max_proof_duration: Duration,
+            expected_reason: &str,
+        ) {
+            let recorder = DebuggingRecorder::new();
+            let snapshotter = recorder.snapshotter();
+            metrics::with_local_recorder(&recorder, || {
+                let runtime =
+                    tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+                runtime.block_on(async {
+                    let zk = MockZkProofProvider { state: Mutex::new(state) };
+                    let mut proofs = PendingProofs::new();
+                    proofs.insert(addr(0), proof);
+                    proofs.poll(addr(0), &zk, max_proof_duration).await.unwrap();
+                });
+
+                let snapshot = snapshotter.snapshot().into_vec();
+                let count = snapshot.iter().find_map(|(key, _, _, value)| {
+                    if key.kind() != MetricKind::Counter
+                        || key.key().name() != "base_challenger.proof_session_failures_total"
+                        || !key.key().labels().any(|label| {
+                            label.key() == "reason" && label.value() == expected_reason
+                        })
+                    {
+                        return None;
+                    }
+                    match value {
+                        DebugValue::Counter(value) => Some(*value),
+                        _ => None,
+                    }
+                });
+
+                assert_eq!(count, Some(1));
+            });
+        }
+
+        #[test]
+        fn poll_emits_failure_metrics() {
+            let expected_root = B256::repeat_byte(0xaa);
+            let bad_proposal = Proposal {
+                output_root: B256::repeat_byte(0xbb),
+                signature: Bytes::from_static(&[0; 65]),
+                l1_origin_hash: B256::ZERO,
+                l1_origin_number: 0,
+                l2_block_number: 0,
+                prev_output_root: B256::ZERO,
+                config_hash: B256::ZERO,
+                schedule_id: B256::ZERO,
+            };
+
+            for (proof, state, max_proof_duration, expected_reason) in [
+                (
+                    awaiting_proof("stuck-session"),
+                    MockZkProofState { proof_status: ProofStatus::Running, ..Default::default() },
+                    Duration::ZERO,
+                    ChallengerMetrics::PROOF_FAILURE_TIMEOUT,
+                ),
+                (
+                    awaiting_proof("failed-session"),
+                    MockZkProofState { proof_status: ProofStatus::Failed, ..Default::default() },
+                    Duration::from_secs(3600),
+                    ChallengerMetrics::PROOF_FAILURE_FAILED,
+                ),
+                (
+                    awaiting_proof("malformed-session"),
+                    MockZkProofState {
+                        proof_status: ProofStatus::Succeeded,
+                        omit_result_on_success: true,
+                        ..Default::default()
+                    },
+                    Duration::from_secs(3600),
+                    ChallengerMetrics::PROOF_FAILURE_MALFORMED,
+                ),
+                (
+                    PendingProof::awaiting_tee(
+                        "tee-bad-root-session".to_owned(),
+                        0,
+                        expected_root,
+                        Some((minimal_prove_request(), DisputeIntent::Challenge)),
+                    ),
+                    MockZkProofState {
+                        proof_status: ProofStatus::Succeeded,
+                        result: Some(ApiProofResult::Tee(TeeProofResult {
+                            aggregate_proposal: bad_proposal,
+                            proposals: Vec::new(),
+                            tee_kind: TeeKind::AwsNitro,
+                        })),
+                        ..Default::default()
+                    },
+                    Duration::from_secs(3600),
+                    ChallengerMetrics::PROOF_FAILURE_TEE_VALIDATION,
+                ),
+            ] {
+                assert_failure_metric(proof, state, max_proof_duration, expected_reason);
+            }
+        }
+    }
+}

--- a/crates/proof/challenge/src/proof_manager.rs
+++ b/crates/proof/challenge/src/proof_manager.rs
@@ -887,4 +887,54 @@ mod tests {
 
         assert_zk_fallback_requested(&manager, &proof_requester);
     }
+
+    #[cfg(feature = "metrics")]
+    mod metrics_emission {
+        use metrics_util::{
+            MetricKind,
+            debugging::{DebugValue, DebuggingRecorder},
+        };
+
+        use super::*;
+
+        #[test]
+        fn proof_exhaustion_emits_metric() {
+            let recorder = DebuggingRecorder::new();
+            let snapshotter = recorder.snapshotter();
+            metrics::with_local_recorder(&recorder, || {
+                let runtime =
+                    tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+                runtime.block_on(async {
+                    let (mut manager, _, _) = manager_with_tx_manager(MockTxManager::new(Ok(
+                        receipt_with_status(true, B256::ZERO),
+                    )));
+                    insert_ready_proof(&mut manager);
+
+                    let entry = manager
+                        .pending_proofs
+                        .get_mut(&addr(0))
+                        .expect("entry should exist after insertion");
+                    entry.retry_count = TestManager::MAX_PROOF_RETRIES + 1;
+                    entry.phase = ProofPhase::NeedsRetry;
+
+                    manager.handle_proof_retry(addr(0)).await.unwrap();
+                });
+
+                let snapshot = snapshotter.snapshot().into_vec();
+                let count = snapshot.iter().find_map(|(key, _, _, value)| {
+                    if key.kind() != MetricKind::Counter
+                        || key.key().name() != "base_challenger.proof_retries_exhausted_total"
+                    {
+                        return None;
+                    }
+                    match value {
+                        DebugValue::Counter(value) => Some(*value),
+                        _ => None,
+                    }
+                });
+
+                assert_eq!(count, Some(1));
+            });
+        }
+    }
 }

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -17,9 +17,7 @@ use base_challenger::{
         mock_state, mock_state_with_tee, receipt_with_status,
     },
 };
-use base_proof_contracts::{
-    AggregateVerifierClient, DisputeGameFactoryClient, GameStatus,
-};
+use base_proof_contracts::{AggregateVerifierClient, DisputeGameFactoryClient, GameStatus};
 use base_proof_primitives::Proposal;
 use base_proof_rpc::L1Provider;
 use base_protocol::OutputRoot;

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -110,7 +110,7 @@ fn test_driver_with_l1_provider(
     })
 }
 
-fn tee_proposal(output_root: B256, prev_output_root: B256) -> Proposal {
+const fn tee_proposal(output_root: B256, prev_output_root: B256) -> Proposal {
     Proposal {
         output_root,
         signature: Bytes::from_static(&[0; 65]),
@@ -653,7 +653,7 @@ async fn test_step_tee_contract_revert_falls_back_to_zk() {
     ]);
 
     let mut driver = test_driver_with_l1_provider(
-        factory.clone(),
+        Arc::<MockDisputeGameFactory>::clone(&factory),
         Arc::clone(&verifier),
         l2,
         Arc::clone(&zk),

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -9,8 +9,7 @@ use std::{
 use alloy_primitives::{Address, B256, Bytes};
 use base_challenger::{
     AnchorUpdater, ChallengeSubmitter, ChallengerProofAdapter, DisputeIntent, DisputeProofManager,
-    Driver, DriverComponents, GameScanner, OutputValidator, PendingProof, PendingProofs, ProofKind,
-    ProofPhase, ProofUpdate,
+    Driver, DriverComponents, GameScanner, OutputValidator, PendingProof, ProofKind, ProofPhase,
     test_utils::{
         DEFAULT_L1_HEAD, DEFAULT_TEE_PROVER, MockAggregateVerifier, MockDisputeGameFactory,
         MockGameState, MockL1, MockL2Provider, MockTxManager, MockZkProofProvider,
@@ -19,7 +18,7 @@ use base_challenger::{
     },
 };
 use base_proof_contracts::{
-    AggregateVerifierClient, ContractError, DisputeGameFactoryClient, GameAtIndex, GameStatus,
+    AggregateVerifierClient, DisputeGameFactoryClient, GameStatus,
 };
 use base_proof_primitives::Proposal;
 use base_proof_rpc::L1Provider;
@@ -53,13 +52,9 @@ fn game_state(l2_block_number: u64) -> MockGameState {
     }
 }
 
-fn empty_verifier() -> Arc<MockAggregateVerifier> {
-    Arc::new(MockAggregateVerifier::new(HashMap::new()))
-}
-
 /// Builds a test driver with the given mocks.
 fn test_driver(
-    factory: Arc<MockDisputeGameFactory>,
+    factory: Arc<dyn DisputeGameFactoryClient>,
     verifier: Arc<MockAggregateVerifier>,
     l2_provider: Arc<MockL2Provider>,
     zk_prover: Arc<MockZkProofProvider>,
@@ -77,7 +72,7 @@ fn test_driver(
 
 /// Builds a test driver with an L1 provider for TEE proof requests.
 fn test_driver_with_l1_provider(
-    factory: Arc<MockDisputeGameFactory>,
+    factory: Arc<dyn DisputeGameFactoryClient>,
     verifier: Arc<MockAggregateVerifier>,
     l2_provider: Arc<MockL2Provider>,
     zk_prover: Arc<MockZkProofProvider>,
@@ -86,7 +81,7 @@ fn test_driver_with_l1_provider(
 ) -> Driver<MockL2Provider, MockZkProofProvider, MockTxManager> {
     let anchor_registry = mock_anchor_registry(Address::ZERO);
     let scanner = GameScanner::new(
-        Arc::clone(&factory) as Arc<dyn DisputeGameFactoryClient>,
+        Arc::clone(&factory),
         Arc::clone(&verifier) as Arc<dyn AggregateVerifierClient>,
         Arc::clone(&anchor_registry),
     );
@@ -117,6 +112,19 @@ fn test_driver_with_l1_provider(
     })
 }
 
+fn tee_proposal(output_root: B256, prev_output_root: B256) -> Proposal {
+    Proposal {
+        output_root,
+        signature: Bytes::from_static(&[0; 65]),
+        l1_origin_hash: DEFAULT_L1_HEAD,
+        l1_origin_number: 1000,
+        l2_block_number: 20,
+        prev_output_root,
+        config_hash: B256::ZERO,
+        schedule_id: B256::ZERO,
+    }
+}
+
 fn default_zk_prover() -> Arc<MockZkProofProvider> {
     Arc::new(MockZkProofProvider::default())
 }
@@ -135,14 +143,6 @@ fn single_game_factory() -> Arc<MockDisputeGameFactory> {
 
 fn single_game_verifier(state: MockGameState) -> Arc<MockAggregateVerifier> {
     Arc::new(MockAggregateVerifier::new(HashMap::from([(addr(0), state)])))
-}
-
-const fn tee_api_result(aggregate_proposal: Proposal) -> ApiProofResult {
-    ApiProofResult::Tee(TeeProofResult {
-        aggregate_proposal,
-        proposals: Vec::new(),
-        tee_kind: TeeKind::AwsNitro,
-    })
 }
 
 fn default_ready_proof(intent: DisputeIntent) -> PendingProof {
@@ -178,10 +178,15 @@ fn succeeded_zk_prover(receipt: Vec<u8>) -> Arc<MockZkProofProvider> {
     })
 }
 
-fn failed_zk_prover() -> Arc<MockZkProofProvider> {
+fn succeeded_tee_prover(aggregate_proposal: Proposal) -> Arc<MockZkProofProvider> {
     Arc::new(MockZkProofProvider {
         state: Mutex::new(MockZkProofState {
-            proof_status: ProofStatus::Failed,
+            proof_status: ProofStatus::Succeeded,
+            result: Some(ApiProofResult::Tee(TeeProofResult {
+                aggregate_proposal,
+                proposals: Vec::new(),
+                tee_kind: TeeKind::AwsNitro,
+            })),
             ..Default::default()
         }),
     })
@@ -241,28 +246,28 @@ fn driver_with_ready_proof(
 }
 
 #[tokio::test]
-async fn test_step_no_candidates() {
-    let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
-    let verifier = empty_verifier();
-    let l2 = default_l2();
+async fn test_step_valid_proposals_are_skipped() {
+    for game_state in [
+        MockGameState { tee_prover: DEFAULT_TEE_PROVER, ..game_state(14) },
+        MockGameState { zk_prover: ZK_PROVER_ADDR, ..game_state(14) },
+        MockGameState {
+            tee_prover: DEFAULT_TEE_PROVER,
+            zk_prover: ZK_PROVER_ADDR,
+            ..game_state(14)
+        },
+    ] {
+        let mut driver = test_driver(
+            single_game_factory(),
+            single_game_verifier(game_state),
+            default_l2(),
+            default_zk_prover(),
+            default_tx_manager(),
+        );
 
-    let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
+        driver.step().await.unwrap();
 
-    driver.step().await.unwrap();
-}
-
-#[tokio::test]
-async fn test_step_valid_game_skipped() {
-    // l2_block_number - starting_block_number < intermediate_block_interval
-    // → expected_count = 0 → trivially valid, no proof requested.
-    let factory = single_game_factory();
-    let verifier =
-        single_game_verifier(MockGameState { tee_prover: DEFAULT_TEE_PROVER, ..game_state(14) });
-    let l2 = default_l2();
-
-    let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
-
-    driver.step().await.unwrap();
+        assert_eq!(driver.proof_manager.pending_proofs_len(), 0);
+    }
 }
 
 #[tokio::test]
@@ -318,155 +323,6 @@ async fn test_step_invalid_game_proof_succeeded() {
 }
 
 #[tokio::test]
-async fn test_step_invalid_game_proof_failed() {
-    let (l2, factory, verifier) = invalid_game_mocks();
-
-    let zk = failed_zk_prover();
-
-    let tx_manager = default_tx_manager();
-
-    let mut driver = test_driver(factory, verifier, l2, zk, tx_manager);
-
-    // Step 1: proof initiated but not yet polled (deferred to next tick).
-    driver.step().await.unwrap();
-    assert!(
-        driver.proof_manager.pending_proofs().contains_key(&addr(0)),
-        "proof should be pending after initiation"
-    );
-
-    // Step 2: poll discovers Failed → NeedsRetry → handle_proof_retry
-    // re-initiates with retry_count == 1.
-    driver.step().await.unwrap();
-
-    // Entry should be retained in AwaitingProof phase (re-initiated) with retry_count == 1.
-    let entry = driver
-        .proof_manager
-        .pending_proofs()
-        .get(&addr(0))
-        .expect("entry should be retained after failure");
-    assert!(
-        matches!(entry.phase, ProofPhase::AwaitingProof { .. }),
-        "phase should be AwaitingProof after re-initiation"
-    );
-    assert_eq!(entry.retry_count, 1);
-}
-
-#[tokio::test]
-async fn test_step_scan_error_propagated() {
-    /// Factory that always fails on `game_count`.
-    #[derive(Debug)]
-    struct FailingFactory;
-
-    #[async_trait::async_trait]
-    impl base_proof_contracts::DisputeGameFactoryClient for FailingFactory {
-        async fn game_count(&self) -> Result<u64, ContractError> {
-            Err(ContractError::Validation("simulated game_count failure".into()))
-        }
-
-        async fn game_at_index(&self, _index: u64) -> Result<GameAtIndex, ContractError> {
-            unreachable!()
-        }
-
-        async fn init_bonds(
-            &self,
-            _game_type: u32,
-        ) -> Result<alloy_primitives::U256, ContractError> {
-            unreachable!()
-        }
-
-        async fn game_impls(&self, _game_type: u32) -> Result<Address, ContractError> {
-            unreachable!()
-        }
-
-        async fn games(
-            &self,
-            _game_type: u32,
-            _root_claim: alloy_primitives::B256,
-            _extra_data: alloy_primitives::Bytes,
-        ) -> Result<alloy_primitives::Address, ContractError> {
-            unreachable!()
-        }
-    }
-
-    let factory = Arc::new(FailingFactory);
-    let anchor_registry = mock_anchor_registry(Address::ZERO);
-    let verifier = empty_verifier();
-    let scanner = GameScanner::new(
-        Arc::clone(&factory) as Arc<dyn DisputeGameFactoryClient>,
-        Arc::clone(&verifier) as Arc<dyn AggregateVerifierClient>,
-        Arc::clone(&anchor_registry),
-    );
-
-    let l2 = default_l2();
-    let validator = OutputValidator::new(Arc::clone(&l2));
-    let submitter = ChallengeSubmitter::new(default_tx_manager());
-
-    let mut driver = Driver::new(DriverComponents {
-        scanner,
-        validator,
-        proof_requester: default_zk_prover(),
-        submitter,
-        l1_provider: Arc::new(MockL1::failure("unused")),
-        verifier_client: verifier as Arc<dyn AggregateVerifierClient>,
-        bond_manager: None,
-        anchor_updater: AnchorUpdater::new(
-            factory,
-            anchor_registry,
-            l2 as Arc<dyn base_proof_rpc::L2Provider>,
-            Address::repeat_byte(0xAA),
-            1,
-            100,
-            100,
-        ),
-        poll_interval: Duration::from_millis(10),
-        max_proof_duration: Duration::from_secs(4 * 60 * 60),
-        tee_submit_retry_limit: 3,
-        cancel: CancellationToken::new(),
-    });
-
-    let result = driver.step().await;
-    assert!(result.is_err(), "scan error should propagate");
-}
-
-#[tokio::test]
-async fn test_step_pending_proof_skips_prove_block() {
-    let (l2, factory, verifier) = invalid_game_mocks();
-
-    let zk = Arc::new(MockZkProofProvider {
-        state: Mutex::new(MockZkProofState { proof: vec![0xBE, 0xEF], ..Default::default() }),
-    });
-
-    let tx_manager = default_tx_manager();
-
-    let mut driver = test_driver(factory, Arc::clone(&verifier), l2, Arc::clone(&zk), tx_manager);
-
-    // Step 1: proof is initiated → session stored in AwaitingProof. The mock's
-    // proof_status is not polled this tick (pending_proofs is empty at poll time).
-    driver.step().await.unwrap();
-    assert!(
-        driver.proof_manager.pending_proofs().contains_key(&addr(0)),
-        "session should be stored in pending_proofs"
-    );
-
-    // Simulate the proof completing before the next poll.
-    zk.state.lock().unwrap().proof_status = ProofStatus::Succeeded;
-
-    // Simulate the onchain effect: game is resolved after challenge tx.
-    verifier.update_game(
-        addr(0),
-        MockGameState { status: GameStatus::ChallengerWins, ..game_state(20) },
-    );
-
-    // Step 2: same game re-discovered → polls existing session, proof succeeds,
-    // challenge tx submitted, session removed from pending_proofs.
-    driver.step().await.unwrap();
-    assert!(
-        !driver.proof_manager.pending_proofs().contains_key(&addr(0)),
-        "session should be removed after proof succeeded"
-    );
-}
-
-#[tokio::test]
 async fn test_step_nullification_failure_preserves_proof() {
     let (l2, factory, verifier) = invalid_game_mocks();
 
@@ -513,52 +369,23 @@ async fn test_step_nullification_failure_preserves_proof() {
 }
 
 #[tokio::test]
-async fn test_poll_or_submit_drops_resolved_game() {
-    // Game has resolved (ChallengerWins) — driver should drop the
-    // pending proof without attempting submission.
-    let mut driver =
-        driver_with_ready_proof(mock_state(GameStatus::ChallengerWins, Address::ZERO, 20));
-    driver.step().await.unwrap();
-    assert!(
-        !driver.proof_manager.pending_proofs().contains_key(&addr(0)),
-        "resolved game should be removed from pending_proofs"
-    );
-}
+async fn test_poll_or_submit_drops_stale_challenge_proofs() {
+    for game_state in [
+        mock_state(GameStatus::ChallengerWins, Address::ZERO, 20),
+        mock_state(GameStatus::InProgress, ZK_PROVER_ADDR, 20),
+        mock_state_with_tee(GameStatus::InProgress, Address::ZERO, Address::ZERO, 20),
+    ] {
+        let mut driver = driver_with_ready_proof(game_state);
+        driver.step().await.unwrap();
 
-#[tokio::test]
-async fn test_poll_or_submit_drops_already_challenged_game() {
-    // Game is still IN_PROGRESS but already challenged (zk_prover != ZERO)
-    // — driver should drop the pending proof.
-    let mut driver =
-        driver_with_ready_proof(mock_state(GameStatus::InProgress, ZK_PROVER_ADDR, 20));
-    driver.step().await.unwrap();
-    assert!(
-        !driver.proof_manager.pending_proofs().contains_key(&addr(0)),
-        "already-challenged game should be removed from pending_proofs"
-    );
-}
-
-#[tokio::test]
-async fn test_poll_or_submit_drops_nullified_game() {
-    // Game is still IN_PROGRESS but both provers are ZERO (nullified)
-    // — driver should drop the pending proof without attempting submission.
-    let mut driver = driver_with_ready_proof(mock_state_with_tee(
-        GameStatus::InProgress,
-        Address::ZERO,
-        Address::ZERO,
-        20,
-    ));
-    driver.step().await.unwrap();
-    assert!(
-        !driver.proof_manager.pending_proofs().contains_key(&addr(0)),
-        "nullified game should be removed from pending_proofs"
-    );
+        assert!(!driver.proof_manager.pending_proofs().contains_key(&addr(0)));
+    }
 }
 
 #[tokio::test]
 async fn test_run_cancellation() {
     let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
-    let verifier = empty_verifier();
+    let verifier = Arc::new(MockAggregateVerifier::new(HashMap::new()));
     let l2 = default_l2();
 
     let driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
@@ -567,56 +394,6 @@ async fn test_run_cancellation() {
     tokio::time::timeout(Duration::from_secs(2), driver.run())
         .await
         .expect("driver.run() should exit promptly after cancellation");
-}
-
-#[tokio::test]
-async fn test_step_proof_retry_succeeds() {
-    let (l2, factory, verifier) = invalid_game_mocks();
-
-    let zk = Arc::new(MockZkProofProvider {
-        state: Mutex::new(MockZkProofState {
-            proof_status: ProofStatus::Failed,
-            proof: vec![0xBE, 0xEF],
-            ..Default::default()
-        }),
-    });
-
-    let tx_manager = default_tx_manager();
-
-    let mut driver = test_driver(factory, Arc::clone(&verifier), l2, Arc::clone(&zk), tx_manager);
-
-    // Step 1: proof initiated, not yet polled.
-    driver.step().await.unwrap();
-    assert!(
-        driver.proof_manager.pending_proofs().contains_key(&addr(0)),
-        "proof should be pending after initiation"
-    );
-
-    // Step 2: proof polled → Failed → NeedsRetry → handle_proof_retry
-    // re-initiates prove_block → AwaitingProof with retry_count == 1.
-    driver.step().await.unwrap();
-    let entry = driver.proof_manager.pending_proofs().get(&addr(0)).expect("entry should exist");
-    assert!(
-        matches!(entry.phase, ProofPhase::AwaitingProof { .. }),
-        "phase should be AwaitingProof after retry re-initiation"
-    );
-    assert_eq!(entry.retry_count, 1);
-
-    // Simulate proof succeeding on the retry session.
-    zk.state.lock().unwrap().proof_status = ProofStatus::Succeeded;
-
-    // Simulate the onchain effect of a successful challenge: game is resolved.
-    verifier.update_game(
-        addr(0),
-        MockGameState { status: GameStatus::ChallengerWins, ..game_state(20) },
-    );
-
-    // Step 3: proof succeeds, challenge tx submitted, entry removed.
-    driver.step().await.unwrap();
-    assert!(
-        !driver.proof_manager.pending_proofs().contains_key(&addr(0)),
-        "entry should be removed after successful challenge submission"
-    );
 }
 
 // Regression test for CHAIN-4297 / Immunefi #75829: after a FAILED proof, the
@@ -664,11 +441,6 @@ async fn test_step_proof_retry_reuses_deterministic_session_id() {
             expected_session_id.as_str(),
             "retry must reuse the deterministic session_id so the service can requeue",
         );
-        assert_eq!(
-            log[0].proof.session_id.as_str(),
-            log[1].proof.session_id.as_str(),
-            "the deterministic session_id must be stable across retries",
-        );
     }
 
     let entry = driver
@@ -706,7 +478,12 @@ async fn test_step_proof_retry_reuses_deterministic_session_id() {
 async fn test_step_proof_exceeds_max_retries() {
     let (l2, factory, verifier) = invalid_game_mocks();
 
-    let zk = failed_zk_prover();
+    let zk = Arc::new(MockZkProofProvider {
+        state: Mutex::new(MockZkProofState {
+            proof_status: ProofStatus::Failed,
+            ..Default::default()
+        }),
+    });
 
     let tx_manager = default_tx_manager();
     let mut driver = test_driver(factory, Arc::clone(&verifier), l2, zk, tx_manager);
@@ -752,47 +529,12 @@ async fn test_step_proof_exceeds_max_retries() {
 // ── TEE-first proof sourcing tests ─────────────────────────────────────────
 
 #[tokio::test]
-async fn test_step_invalid_game_tee_fails_zk_fallback() {
-    // TEE request construction fails → driver falls back to ZK.
-    let (l2, factory, verifier) = invalid_game_mocks();
-
-    let tx_manager = default_tx_manager();
-    let l1_provider = Arc::new(MockL1::failure("dummy"));
-    let mut driver = test_driver_with_l1_provider(
-        factory,
-        Arc::clone(&verifier),
-        l2,
-        default_zk_prover(),
-        tx_manager,
-        Arc::clone(&l1_provider) as Arc<dyn L1Provider>,
-    );
-
-    driver.step().await.unwrap();
-
-    let entry = driver
-        .proof_manager
-        .pending_proofs()
-        .get(&addr(0))
-        .expect("ZK proof should be pending after TEE fallback");
-    assert!(
-        matches!(entry.phase, ProofPhase::AwaitingProof { .. }),
-        "phase should be AwaitingProof (ZK fallback)"
-    );
-    assert!(matches!(entry.kind, ProofKind::Zk { .. }), "fallback must use a ZK proof");
-    assert_eq!(
-        *l1_provider.header_by_hash_requests.lock().unwrap(),
-        vec![DEFAULT_L1_HEAD],
-        "TEE attempt must resolve the game's L1 head before falling back",
-    );
-}
-
-#[tokio::test]
 async fn test_step_invalid_game_tee_fails_zk_succeeds() {
     let (l2, factory, verifier) = invalid_game_mocks();
 
     let zk = succeeded_zk_prover(vec![0xDE, 0xAD]);
-
     let tx_manager = default_tx_manager();
+    let l1_provider = Arc::new(MockL1::failure("dummy"));
 
     let mut driver = test_driver_with_l1_provider(
         factory,
@@ -800,16 +542,20 @@ async fn test_step_invalid_game_tee_fails_zk_succeeds() {
         l2,
         zk,
         tx_manager,
-        Arc::new(MockL1::failure("dummy")),
+        Arc::clone(&l1_provider) as Arc<dyn L1Provider>,
     );
 
     // Step 1: TEE path is attempted (fails building request), falls back
     // to ZK, proof session initiated (polled on next tick).
     driver.step().await.unwrap();
-    assert!(
-        driver.proof_manager.pending_proofs().contains_key(&addr(0)),
-        "ZK proof should be pending after TEE fallback"
-    );
+    let entry = driver
+        .proof_manager
+        .pending_proofs()
+        .get(&addr(0))
+        .expect("ZK proof should be pending after TEE fallback");
+    assert!(matches!(entry.phase, ProofPhase::AwaitingProof { .. }));
+    assert!(matches!(entry.kind, ProofKind::Zk { .. }));
+    assert_eq!(*l1_provider.header_by_hash_requests.lock().unwrap(), vec![DEFAULT_L1_HEAD]);
 
     // Simulate the onchain effect of a successful challenge: game is resolved.
     verifier.update_game(
@@ -839,23 +585,8 @@ async fn test_step_invalid_game_tee_proof_succeeds() {
 
     let l1_head = Arc::new(MockL1::success(DEFAULT_L1_HEAD, 100));
 
-    let aggregate_proposal = Proposal {
-        output_root: root_20,
-        signature: Bytes::from(vec![0u8; 65]),
-        l1_origin_hash: DEFAULT_L1_HEAD,
-        l1_origin_number: 1000,
-        l2_block_number: 20,
-        prev_output_root: root_15,
-        config_hash: B256::ZERO,
-        schedule_id: B256::ZERO,
-    };
-    let proof_requester = Arc::new(MockZkProofProvider {
-        state: Mutex::new(MockZkProofState {
-            proof_status: ProofStatus::Succeeded,
-            result: Some(tee_api_result(aggregate_proposal)),
-            ..Default::default()
-        }),
-    });
+    let aggregate_proposal = tee_proposal(root_20, root_15);
+    let proof_requester = succeeded_tee_prover(aggregate_proposal);
 
     let tx_manager = default_tx_manager();
 
@@ -911,23 +642,8 @@ async fn test_step_tee_contract_revert_falls_back_to_zk() {
 
     let l1_head = Arc::new(MockL1::success(DEFAULT_L1_HEAD, 100));
 
-    let aggregate_proposal = Proposal {
-        output_root: root_20,
-        signature: Bytes::from(vec![0u8; 65]),
-        l1_origin_hash: DEFAULT_L1_HEAD,
-        l1_origin_number: 1000,
-        l2_block_number: 20,
-        prev_output_root: root_15,
-        config_hash: B256::ZERO,
-        schedule_id: B256::ZERO,
-    };
-    let zk = Arc::new(MockZkProofProvider {
-        state: Mutex::new(MockZkProofState {
-            proof_status: ProofStatus::Succeeded,
-            result: Some(tee_api_result(aggregate_proposal)),
-            ..Default::default()
-        }),
-    });
+    let aggregate_proposal = tee_proposal(root_20, root_15);
+    let zk = succeeded_tee_prover(aggregate_proposal);
 
     // TEE nullify() tx reverts, ZK challenge() tx succeeds.
     let tx_manager = MockTxManager::with_responses(vec![
@@ -939,7 +655,7 @@ async fn test_step_tee_contract_revert_falls_back_to_zk() {
     ]);
 
     let mut driver = test_driver_with_l1_provider(
-        Arc::clone(&factory),
+        factory.clone(),
         Arc::clone(&verifier),
         l2,
         Arc::clone(&zk),
@@ -1005,23 +721,8 @@ async fn test_step_invalid_tee_result_falls_back_to_zk_without_timeout() {
 
     let l1_head = Arc::new(MockL1::success(DEFAULT_L1_HEAD, 100));
 
-    let bad_aggregate_proposal = Proposal {
-        output_root: B256::repeat_byte(0x42),
-        signature: Bytes::from(vec![0u8; 65]),
-        l1_origin_hash: DEFAULT_L1_HEAD,
-        l1_origin_number: 1000,
-        l2_block_number: 20,
-        prev_output_root: root_15,
-        config_hash: B256::ZERO,
-        schedule_id: B256::ZERO,
-    };
-    let proof_requester = Arc::new(MockZkProofProvider {
-        state: Mutex::new(MockZkProofState {
-            proof_status: ProofStatus::Succeeded,
-            result: Some(tee_api_result(bad_aggregate_proposal)),
-            ..Default::default()
-        }),
-    });
+    let bad_aggregate_proposal = tee_proposal(B256::repeat_byte(0x42), root_15);
+    let proof_requester = succeeded_tee_prover(bad_aggregate_proposal);
 
     let mut driver = test_driver_with_l1_provider(
         factory,
@@ -1046,27 +747,6 @@ async fn test_step_invalid_tee_result_falls_back_to_zk_without_timeout() {
         .expect("ZK fallback proof should be pending after invalid TEE result");
     assert!(matches!(entry.kind, base_challenger::ProofKind::Zk { .. }));
     assert!(matches!(entry.phase, ProofPhase::AwaitingProof { .. }));
-}
-
-#[tokio::test]
-async fn test_step_nullified_game_not_reprocessed() {
-    // Both provers zeroed (post-nullification) → scanner filters it out.
-    let (l2, factory, root_15, _root_20) = base_game_mocks();
-
-    let verifier = single_game_verifier(MockGameState {
-        intermediate_output_roots: vec![root_15, BOGUS_ROOT],
-        ..game_state(20)
-    });
-    let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
-
-    // Run two steps — the game should be filtered by the scanner on both.
-    driver.step().await.unwrap();
-    driver.step().await.unwrap();
-
-    assert!(
-        driver.proof_manager.pending_proofs_len() == 0,
-        "no proofs should be pending for a nullified game"
-    );
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -1287,24 +967,6 @@ async fn test_step_invalid_zk_proposal_initiates_zk_nullification() {
     assert_eq!(entry.intent, DisputeIntent::Nullify, "intent should be Nullify for ZK proposals");
 }
 
-#[tokio::test]
-async fn test_step_valid_zk_proposal_skipped() {
-    // A ZK-proposed game with valid intermediate roots should not trigger
-    // any action.
-    let factory = single_game_factory();
-    let verifier =
-        single_game_verifier(MockGameState { zk_prover: ZK_PROVER_ADDR, ..game_state(14) });
-    let l2 = default_l2();
-
-    let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
-    driver.step().await.unwrap();
-
-    assert!(
-        driver.proof_manager.pending_proofs_len() == 0,
-        "valid ZK proposal should not trigger any proof"
-    );
-}
-
 // ──────────────────────────────────────────────────────────────────────────
 // Dual-proof games: both TEE and ZK proofs verified (no challenge)
 // ──────────────────────────────────────────────────────────────────────────
@@ -1355,23 +1017,8 @@ async fn test_step_dual_proof_invalid_with_tee_provider_nullifies_tee_first() {
 
     let l1_head = Arc::new(MockL1::success(DEFAULT_L1_HEAD, 100));
 
-    let aggregate_proposal = Proposal {
-        output_root: root_20,
-        signature: Bytes::from(vec![0u8; 65]),
-        l1_origin_hash: DEFAULT_L1_HEAD,
-        l1_origin_number: 1000,
-        l2_block_number: 20,
-        prev_output_root: root_15,
-        config_hash: B256::ZERO,
-        schedule_id: B256::ZERO,
-    };
-    let proof_requester = Arc::new(MockZkProofProvider {
-        state: Mutex::new(MockZkProofState {
-            proof_status: ProofStatus::Succeeded,
-            result: Some(tee_api_result(aggregate_proposal)),
-            ..Default::default()
-        }),
-    });
+    let aggregate_proposal = tee_proposal(root_20, root_15);
+    let proof_requester = succeeded_tee_prover(aggregate_proposal);
 
     let tx_manager = default_tx_manager();
 
@@ -1405,63 +1052,6 @@ async fn test_step_dual_proof_invalid_with_tee_provider_nullifies_tee_first() {
         .expect("ZK proof should be pending after TEE nullification");
     assert!(matches!(entry.kind, base_challenger::ProofKind::Zk { .. }));
     assert_eq!(entry.intent, DisputeIntent::Nullify);
-}
-
-#[tokio::test]
-async fn test_step_dual_proof_valid_skipped() {
-    // A game with both TEE and ZK proofs verified where output roots are
-    // valid should not trigger any action.
-    let factory = single_game_factory();
-    let verifier = single_game_verifier(MockGameState {
-        tee_prover: DEFAULT_TEE_PROVER,
-        zk_prover: ZK_PROVER_ADDR,
-        ..game_state(14)
-    });
-    let l2 = default_l2();
-
-    let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
-    driver.step().await.unwrap();
-
-    assert!(
-        driver.proof_manager.pending_proofs_len() == 0,
-        "valid dual-proof game should not trigger any proof"
-    );
-}
-
-#[tokio::test]
-async fn test_step_dual_proof_tee_fails_falls_back_to_zk_nullify() {
-    // A dual-proof game where the TEE proof fails should fall back to ZK
-    // with DisputeIntent::Nullify (not Challenge).
-    let (l2, factory, root_15, _root_20) = base_game_mocks();
-
-    let verifier = single_game_verifier(MockGameState {
-        tee_prover: DEFAULT_TEE_PROVER,
-        zk_prover: ZK_PROVER_ADDR,
-        intermediate_output_roots: vec![root_15, BOGUS_ROOT],
-        ..game_state(20)
-    });
-
-    let mut driver = test_driver_with_l1_provider(
-        factory,
-        verifier,
-        l2,
-        default_zk_prover(),
-        default_tx_manager(),
-        Arc::new(MockL1::failure("dummy")),
-    );
-
-    driver.step().await.unwrap();
-
-    let entry = driver
-        .proof_manager
-        .pending_proofs()
-        .get(&addr(0))
-        .expect("ZK proof should be pending after TEE fallback for dual-proof game");
-    assert_eq!(
-        entry.intent,
-        DisputeIntent::Nullify,
-        "dual-proof TEE fallback must use Nullify intent, not Challenge"
-    );
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -1507,388 +1097,4 @@ async fn test_step_checkpoint_count_mismatch_surfaces_error() {
         "no proof should be initiated when checkpoint count mismatches — \
          the error should be surfaced, not silently swallowed"
     );
-}
-
-const fn minimal_prove_request() -> SnarkPlonkProofRequest {
-    SnarkPlonkProofRequest {
-        proof: ZkProofRequest {
-            start_block_number: 0,
-            number_of_blocks_to_prove: 1,
-            sequence_window: None,
-            l1_head: None,
-            intermediate_root_interval: None,
-            zk_vm: ZkVm::Sp1,
-            zk_backend: ZkBackend::Cluster,
-        },
-        prover_address: Address::ZERO,
-    }
-}
-
-#[tokio::test]
-async fn test_poll_failed_status_triggers_retry() {
-    let zk = Arc::new(MockZkProofProvider {
-        state: Mutex::new(MockZkProofState {
-            proof_status: ProofStatus::Failed,
-            ..Default::default()
-        }),
-    });
-
-    let mut proofs = PendingProofs::new();
-    proofs.insert(
-        addr(0),
-        PendingProof::awaiting(
-            "failed-session".to_string(),
-            0,
-            B256::ZERO,
-            minimal_prove_request(),
-            DisputeIntent::Challenge,
-        ),
-    );
-
-    let update = proofs.poll(addr(0), &*zk, Duration::from_secs(3600)).await.unwrap();
-    assert!(matches!(update, Some(ProofUpdate::NeedsRetry)), "Failed should trigger NeedsRetry");
-    let entry = proofs.get(&addr(0)).unwrap();
-    assert_eq!(entry.retry_count, 1);
-    assert!(matches!(entry.phase, ProofPhase::NeedsRetry));
-}
-
-#[tokio::test]
-async fn test_poll_running_within_timeout_stays_pending() {
-    let zk = Arc::new(MockZkProofProvider {
-        state: Mutex::new(MockZkProofState {
-            proof_status: ProofStatus::Running,
-            ..Default::default()
-        }),
-    });
-
-    let mut proofs = PendingProofs::new();
-    proofs.insert(
-        addr(0),
-        PendingProof::awaiting(
-            "running-session".to_string(),
-            0,
-            B256::ZERO,
-            minimal_prove_request(),
-            DisputeIntent::Challenge,
-        ),
-    );
-
-    let update = proofs.poll(addr(0), &*zk, Duration::from_secs(3600)).await.unwrap();
-    assert!(
-        matches!(update, Some(ProofUpdate::Pending)),
-        "Running within timeout should stay Pending"
-    );
-    let entry = proofs.get(&addr(0)).unwrap();
-    assert_eq!(entry.retry_count, 0);
-    assert!(matches!(entry.phase, ProofPhase::AwaitingProof { .. }));
-}
-
-#[tokio::test]
-async fn test_poll_running_timeout_triggers_retry() {
-    let zk = Arc::new(MockZkProofProvider {
-        state: Mutex::new(MockZkProofState {
-            proof_status: ProofStatus::Running,
-            ..Default::default()
-        }),
-    });
-
-    let mut proofs = PendingProofs::new();
-    proofs.insert(
-        addr(0),
-        PendingProof::awaiting(
-            "stuck-session".to_string(),
-            0,
-            B256::ZERO,
-            minimal_prove_request(),
-            DisputeIntent::Challenge,
-        ),
-    );
-
-    // Zero timeout: already expired on the first poll.
-    let update = proofs.poll(addr(0), &*zk, Duration::ZERO).await.unwrap();
-    assert!(
-        matches!(update, Some(ProofUpdate::NeedsRetry)),
-        "Timed-out Running should trigger NeedsRetry"
-    );
-    let entry = proofs.get(&addr(0)).unwrap();
-    assert_eq!(entry.retry_count, 1);
-    assert!(matches!(entry.phase, ProofPhase::NeedsRetry));
-}
-
-// Metric emission tests for `proof_session_failures_total{reason}` and
-// `proof_retries_exhausted_total`. Each test installs a local
-// `DebuggingRecorder` and asserts on the resulting snapshot.
-#[cfg(feature = "metrics")]
-mod metrics_emission {
-    use base_challenger::ChallengerMetrics;
-    use metrics_util::{
-        CompositeKey, MetricKind,
-        debugging::{DebugValue, DebuggingRecorder, Snapshotter},
-    };
-
-    use super::*;
-
-    type SnapEntry =
-        (CompositeKey, Option<metrics::Unit>, Option<metrics::SharedString>, DebugValue);
-
-    /// Installs a local `DebuggingRecorder` for the closure and snapshots its
-    /// metrics afterward.
-    fn with_recorder<F>(f: F)
-    where
-        F: FnOnce(Snapshotter),
-    {
-        let recorder = DebuggingRecorder::new();
-        let snapshotter = recorder.snapshotter();
-        metrics::with_local_recorder(&recorder, || f(snapshotter));
-    }
-
-    /// Returns the value of `proof_session_failures_total` whose `reason`
-    /// label matches `expected_reason`, if present in the snapshot.
-    fn find_failure_counter_with_reason(snap: &[SnapEntry], expected_reason: &str) -> Option<u64> {
-        snap.iter().find_map(|(ck, _, _, v)| {
-            if ck.kind() != MetricKind::Counter
-                || ck.key().name() != "base_challenger.proof_session_failures_total"
-            {
-                return None;
-            }
-            let reason_match =
-                ck.key().labels().any(|l| l.key() == "reason" && l.value() == expected_reason);
-            if !reason_match {
-                return None;
-            }
-            match v {
-                DebugValue::Counter(n) => Some(*n),
-                _ => None,
-            }
-        })
-    }
-
-    /// Returns the value of a bare counter by name, if present.
-    fn find_counter(snap: &[SnapEntry], name: &str) -> Option<u64> {
-        snap.iter().find_map(|(ck, _, _, v)| {
-            if ck.kind() != MetricKind::Counter || ck.key().name() != name {
-                return None;
-            }
-            match v {
-                DebugValue::Counter(n) => Some(*n),
-                _ => None,
-            }
-        })
-    }
-
-    #[test]
-    fn test_poll_timeout_emits_failure_metric() {
-        with_recorder(|snap| {
-            let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
-
-            rt.block_on(async {
-                let zk = Arc::new(MockZkProofProvider {
-                    state: Mutex::new(MockZkProofState {
-                        proof_status: ProofStatus::Running,
-                        ..Default::default()
-                    }),
-                });
-
-                let mut proofs = PendingProofs::new();
-                proofs.insert(
-                    addr(0),
-                    PendingProof::awaiting(
-                        "stuck-session".to_string(),
-                        0,
-                        B256::ZERO,
-                        minimal_prove_request(),
-                        DisputeIntent::Challenge,
-                    ),
-                );
-
-                proofs.poll(addr(0), &*zk, Duration::ZERO).await.unwrap();
-            });
-
-            let snapshot = snap.snapshot().into_vec();
-            assert_eq!(
-                find_failure_counter_with_reason(
-                    &snapshot,
-                    ChallengerMetrics::PROOF_FAILURE_TIMEOUT,
-                ),
-                Some(1),
-                "timeout path must increment proof_session_failures_total{{reason=timeout}}",
-            );
-        });
-    }
-
-    #[test]
-    fn test_poll_failed_status_emits_failure_metric() {
-        with_recorder(|snap| {
-            let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
-
-            rt.block_on(async {
-                let zk = Arc::new(MockZkProofProvider {
-                    state: Mutex::new(MockZkProofState {
-                        proof_status: ProofStatus::Failed,
-                        ..Default::default()
-                    }),
-                });
-
-                let mut proofs = PendingProofs::new();
-                proofs.insert(
-                    addr(0),
-                    PendingProof::awaiting(
-                        "failed-session".to_string(),
-                        0,
-                        B256::ZERO,
-                        minimal_prove_request(),
-                        DisputeIntent::Challenge,
-                    ),
-                );
-
-                proofs.poll(addr(0), &*zk, Duration::from_secs(3600)).await.unwrap();
-            });
-
-            let snapshot = snap.snapshot().into_vec();
-            assert_eq!(
-                find_failure_counter_with_reason(
-                    &snapshot,
-                    ChallengerMetrics::PROOF_FAILURE_FAILED,
-                ),
-                Some(1),
-                "explicit Failed status must increment \
-                 proof_session_failures_total{{reason=failed}}",
-            );
-        });
-    }
-
-    #[test]
-    fn test_poll_succeeded_without_result_emits_malformed_metric() {
-        with_recorder(|snap| {
-            let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
-
-            rt.block_on(async {
-                let zk = Arc::new(MockZkProofProvider {
-                    state: Mutex::new(MockZkProofState {
-                        proof_status: ProofStatus::Succeeded,
-                        omit_result_on_success: true,
-                        ..Default::default()
-                    }),
-                });
-
-                let mut proofs = PendingProofs::new();
-                proofs.insert(
-                    addr(0),
-                    PendingProof::awaiting(
-                        "malformed-session".to_string(),
-                        0,
-                        B256::ZERO,
-                        minimal_prove_request(),
-                        DisputeIntent::Challenge,
-                    ),
-                );
-
-                proofs.poll(addr(0), &*zk, Duration::from_secs(3600)).await.unwrap();
-            });
-
-            let snapshot = snap.snapshot().into_vec();
-            assert_eq!(
-                find_failure_counter_with_reason(
-                    &snapshot,
-                    ChallengerMetrics::PROOF_FAILURE_MALFORMED,
-                ),
-                Some(1),
-                "Succeeded with no result must increment \
-                 proof_session_failures_total{{reason=malformed}}",
-            );
-        });
-    }
-
-    #[test]
-    fn test_poll_tee_validation_failure_emits_metric() {
-        with_recorder(|snap| {
-            let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
-
-            rt.block_on(async {
-                let expected_root = B256::repeat_byte(0xaa);
-                let bad_proposal = Proposal {
-                    output_root: B256::repeat_byte(0xbb),
-                    signature: Bytes::from(vec![0u8; 65]),
-                    l1_origin_hash: DEFAULT_L1_HEAD,
-                    l1_origin_number: 1000,
-                    l2_block_number: 20,
-                    prev_output_root: B256::ZERO,
-                    config_hash: B256::ZERO,
-                    schedule_id: B256::ZERO,
-                };
-                let zk = Arc::new(MockZkProofProvider {
-                    state: Mutex::new(MockZkProofState {
-                        proof_status: ProofStatus::Succeeded,
-                        result: Some(tee_api_result(bad_proposal)),
-                        ..Default::default()
-                    }),
-                });
-
-                let mut proofs = PendingProofs::new();
-                proofs.insert(
-                    addr(0),
-                    PendingProof::awaiting_tee(
-                        "tee-bad-root-session".to_string(),
-                        0,
-                        expected_root,
-                        Some((minimal_prove_request(), DisputeIntent::Challenge)),
-                    ),
-                );
-
-                proofs.poll(addr(0), &*zk, Duration::from_secs(3600)).await.unwrap();
-            });
-
-            let snapshot = snap.snapshot().into_vec();
-            assert_eq!(
-                find_failure_counter_with_reason(
-                    &snapshot,
-                    ChallengerMetrics::PROOF_FAILURE_TEE_VALIDATION,
-                ),
-                Some(1),
-                "TEE root mismatch must increment \
-                 proof_session_failures_total{{reason=tee_validation_failed}}",
-            );
-        });
-    }
-
-    #[test]
-    fn test_step_proof_exhaustion_emits_metric() {
-        with_recorder(|snap| {
-            let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
-
-            rt.block_on(async {
-                let (l2, factory, verifier) = invalid_game_mocks();
-                let zk = failed_zk_prover();
-                let tx_manager = default_tx_manager();
-                let mut driver = test_driver(factory, Arc::clone(&verifier), l2, zk, tx_manager);
-
-                // Step 1: initiate the proof.
-                driver.step().await.unwrap();
-
-                // Force the entry past the retry budget so the next `step()`
-                // exhausts. The scanner re-creates a fresh entry with
-                // `retry_count = 0` in the same call, so we assert on the
-                // metric only.
-                let max_retries =
-                    DisputeProofManager::<MockL2Provider, MockZkProofProvider>::MAX_PROOF_RETRIES;
-                let entry = driver
-                    .proof_manager
-                    .pending_proofs_mut()
-                    .get_mut(&addr(0))
-                    .expect("entry should exist after initiation");
-                entry.retry_count = max_retries + 1;
-                entry.phase = ProofPhase::NeedsRetry;
-                let _ = &verifier; // game already InProgress from invalid_game_mocks
-
-                driver.step().await.unwrap();
-            });
-
-            let snapshot = snap.snapshot().into_vec();
-            assert_eq!(
-                find_counter(&snapshot, "base_challenger.proof_retries_exhausted_total"),
-                Some(1),
-                "retry exhaustion must increment proof_retries_exhausted_total",
-            );
-        });
-    }
 }


### PR DESCRIPTION
### What changed? Why?

Moved proof-polling and retry-metric coverage next to the challenger components under test, then consolidated equivalent driver scenarios. This removes duplicated driver fixtures and keeps the integration suite focused on end-to-end behavior.

### Notes to reviewers

The driver tests retain the workflow coverage; `PendingProofs` and `DisputeProofManager` now own their direct behavior and metric assertions.

### How has it been tested?

`cargo test -p base-challenger --features metrics`