### PR TITLE
feat(builder): Injectable Flashblocks Candidate Source

### DIFF
--- a/bin/base/src/commands/sequencer.rs
+++ b/bin/base/src/commands/sequencer.rs
@@ -103,7 +103,7 @@ impl SequencerCommand {
                 .with_da_config(da_config)
                 .with_gas_limit_config(gas_limit_config)
                 .with_manifest_precheck_enabled(manifest_precheck_enabled)
-                .with_service_builder(FlashblocksServiceBuilder(builder_config));
+                .with_service_builder(FlashblocksServiceBuilder::new(builder_config));
             runner.install_ext::<MeteringStoreExtension>(metering_provider);
             runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig { sequencer_rpc });
             runner.install_ext::<BuilderApiExtension>(());

--- a/bin/builder/src/main.rs
+++ b/bin/builder/src/main.rs
@@ -51,7 +51,7 @@ fn main() {
             .with_da_config(da_config)
             .with_gas_limit_config(gas_limit_config)
             .with_manifest_precheck_enabled(manifest_precheck_enabled)
-            .with_service_builder(FlashblocksServiceBuilder(builder_config));
+            .with_service_builder(FlashblocksServiceBuilder::new(builder_config));
         runner.install_ext::<MeteringStoreExtension>(metering_provider);
         runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig::default());
         runner.install_ext::<BuilderApiExtension>(());

--- a/crates/builder/core/src/candidate_source.rs
+++ b/crates/builder/core/src/candidate_source.rs
@@ -64,3 +64,80 @@ where
         pool_best
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::TxHash;
+    use reth_transaction_pool::{
+        error::InvalidPoolTransactionError,
+        test_utils::{MockTransaction, MockTransactionFactory, MockValidTx},
+    };
+
+    use super::*;
+
+    /// A minimal [`BestTransactions`] backed by a [`Vec`], for exercising [`CandidateSource`]
+    /// implementations without standing up a real pool. The pool-update and blob-skipping hooks are
+    /// no-ops — these tests only care about which transactions flow through the stream.
+    #[derive(Debug)]
+    struct VecBest(std::vec::IntoIter<Arc<MockValidTx>>);
+
+    impl Iterator for VecBest {
+        type Item = Arc<MockValidTx>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            self.0.next()
+        }
+    }
+
+    impl BestTransactions for VecBest {
+        fn mark_invalid(&mut self, _tx: &Self::Item, _kind: InvalidPoolTransactionError) {}
+        fn no_updates(&mut self) {}
+        fn set_skip_blobs(&mut self, _skip_blobs: bool) {}
+    }
+
+    /// An alternative [`CandidateSource`] that transforms the incoming pool stream in place — here
+    /// dropping even-nonce transactions — rather than supplying a stream of its own. Proves the seam
+    /// lets a source wrap/filter `pool_best` while preserving the loop's iterator type.
+    #[derive(Debug)]
+    struct OddNonceOnly;
+
+    impl CandidateSource<MockTransaction> for OddNonceOnly {
+        fn best_transactions(
+            &self,
+            pool_best: BoxedBestTransactions<MockTransaction>,
+            _attributes: BestTransactionsAttributes,
+        ) -> BoxedBestTransactions<MockTransaction> {
+            let kept = pool_best.filter(|tx| tx.nonce() % 2 == 1).collect::<Vec<_>>();
+            Box::new(VecBest(kept.into_iter()))
+        }
+    }
+
+    fn pool_stream(nonces: &[u64]) -> (Vec<TxHash>, BoxedBestTransactions<MockTransaction>) {
+        let mut factory = MockTransactionFactory::default();
+        let txs = nonces
+            .iter()
+            .map(|&n| factory.validated_arc(MockTransaction::eip1559().with_nonce(n).rng_hash()))
+            .collect::<Vec<_>>();
+        let hashes = txs.iter().map(|tx| *tx.hash()).collect();
+        (hashes, Box::new(VecBest(txs.into_iter())))
+    }
+
+    #[test]
+    fn default_source_passes_the_pool_stream_through_unchanged() {
+        let (expected, pool_best) = pool_stream(&[0, 1, 2]);
+        let out = DefaultCandidateSource
+            .best_transactions(pool_best, BestTransactionsAttributes::new(0, None));
+        let got = out.map(|tx| *tx.hash()).collect::<Vec<_>>();
+        assert_eq!(got, expected, "the default source must yield the pool stream unchanged");
+    }
+
+    #[test]
+    fn alternative_source_can_filter_the_pool_stream() {
+        let (all, pool_best) = pool_stream(&[0, 1, 2, 3]);
+        let out =
+            OddNonceOnly.best_transactions(pool_best, BestTransactionsAttributes::new(0, None));
+        let got = out.map(|tx| *tx.hash()).collect::<Vec<_>>();
+        // Only the odd-nonce transactions (indices 1 and 3) survive the transform.
+        assert_eq!(got, vec![all[1], all[3]]);
+    }
+}

--- a/crates/builder/core/src/candidate_source.rs
+++ b/crates/builder/core/src/candidate_source.rs
@@ -2,117 +2,65 @@
 //!
 //! When building a (flash)block the builder drains a priority-ordered stream of candidate
 //! transactions. Historically that stream was always the pool's
-//! [`TransactionPool::best_transactions_with_attributes`] iterator, constructed inline in the
-//! build loop. [`CandidateSource`] extracts that construction behind a trait so the stream can be
-//! supplied by an alternative implementation without forking the build loop.
+//! [`TransactionPool::best_transactions_with_attributes`](reth_transaction_pool::TransactionPool::best_transactions_with_attributes)
+//! iterator, constructed inline in the build loop. [`CandidateSource`] lets that stream be
+//! transformed by an alternative implementation — which receives the pool's best transactions and
+//! returns the stream the loop should drain — without forking the build loop.
 //!
-//! A source captures whatever it draws candidates from at construction time (the pool, an external
-//! block-builder API, a pre-sorted bundle, a test fixture, ...) and yields a stream on demand. The
-//! builder holds one and (re)builds its iterator once per flashblock. [`DefaultCandidateSource`] is
-//! the default: it captures the transaction pool and reproduces the builder's historical behavior
-//! exactly.
+//! [`DefaultCandidateSource`] is the default and returns the pool's stream unchanged, reproducing
+//! the builder's historical behavior exactly.
 
 use std::sync::Arc;
 
 use reth_transaction_pool::{
-    BestTransactions, BestTransactionsAttributes, PoolTransaction, TransactionPool,
-    ValidPoolTransaction,
+    BestTransactions, BestTransactionsAttributes, PoolTransaction, ValidPoolTransaction,
 };
 
 /// The boxed, priority-ordered best-transactions iterator drained by the flashblocks builder.
 ///
-/// This matches the return type of [`TransactionPool::best_transactions_with_attributes`], so a
-/// [`CandidateSource`] implementation can hand its stream straight into the build loop's iterator
-/// adapter with no change to the loop's concrete iterator type.
+/// This matches the return type of
+/// [`TransactionPool::best_transactions_with_attributes`](reth_transaction_pool::TransactionPool::best_transactions_with_attributes),
+/// so a [`CandidateSource`] can receive and return this stream without the loop's concrete iterator
+/// type changing.
 pub type BoxedBestTransactions<T> = Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<T>>>>;
 
-/// Supplies the priority-ordered candidate transaction stream for the next (flash)block.
+/// Transforms the priority-ordered candidate transaction stream drained for the next (flash)block.
 ///
-/// A source captures its underlying data at construction time, so the builder need not thread the
-/// transaction pool (or any other backing store) through on every call — an alternative source that
-/// draws from, say, an external API is not forced to accept a `&Pool` it would ignore. The builder
-/// calls [`CandidateSource::best_transactions`] once per flashblock to (re)build its iterator.
-///
-/// `'static` is required up front: the source is stored in a `BasePayloadBuilder` that is driven
-/// from async, `'static` build jobs, so a borrowing source could compile in isolation yet fail with
-/// a confusing error only once plugged into the builder. Requiring it here surfaces the constraint
-/// at the source.
-pub trait CandidateSource: Send + Sync + std::fmt::Debug + 'static {
-    /// The pool transaction type yielded by this source.
-    type Transaction: PoolTransaction;
-
-    /// Produce the priority-ordered candidate stream for the given fee attributes.
-    fn best_transactions(
-        &self,
-        attributes: BestTransactionsAttributes,
-    ) -> BoxedBestTransactions<Self::Transaction>;
-}
-
-/// The default candidate source: the pool's priority-ordered best transactions.
-///
-/// This captures the transaction pool and reproduces the builder's pre-seam behavior byte-for-byte
-/// — it simply forwards to [`TransactionPool::best_transactions_with_attributes`].
-#[derive(Debug, Clone)]
-pub struct DefaultCandidateSource<Pool> {
-    /// The transaction pool candidates are drawn from.
-    pool: Pool,
-}
-
-impl<Pool> DefaultCandidateSource<Pool> {
-    /// Create a [`DefaultCandidateSource`] drawing candidates from `pool`.
-    pub const fn new(pool: Pool) -> Self {
-        Self { pool }
-    }
-}
-
-impl<Pool> CandidateSource for DefaultCandidateSource<Pool>
+/// The builder calls [`CandidateSource::best_transactions`] once per flashblock, passing the pool's
+/// current best transactions and receiving the stream to drain. The default
+/// [`DefaultCandidateSource`] returns the pool stream unchanged; an alternative implementation may
+/// return a different stream (for example one that composes the pool stream with transactions from
+/// an additional source) while preserving the loop's contract.
+pub trait CandidateSource<T>: Send + Sync + std::fmt::Debug
 where
-    Pool: TransactionPool + std::fmt::Debug + 'static,
+    T: PoolTransaction,
 {
-    type Transaction = Pool::Transaction;
-
+    /// Given the pool's priority-ordered best transactions, produce the stream the build loop drains.
+    ///
+    /// `attributes` are the same fee attributes used to build `pool_best`, provided so an
+    /// implementation can rank any transactions it contributes on the same basis.
     fn best_transactions(
         &self,
+        pool_best: BoxedBestTransactions<T>,
         attributes: BestTransactionsAttributes,
-    ) -> BoxedBestTransactions<Self::Transaction> {
-        self.pool.best_transactions_with_attributes(attributes)
-    }
+    ) -> BoxedBestTransactions<T>;
 }
 
-#[cfg(test)]
-mod tests {
-    use std::marker::PhantomData;
+/// The default candidate source: the pool's priority-ordered best transactions, unchanged.
+///
+/// This reproduces the builder's pre-seam behavior byte-for-byte — it returns `pool_best` as-is.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DefaultCandidateSource;
 
-    use reth_transaction_pool::test_utils::MockTransaction;
-
-    use super::{
-        BestTransactionsAttributes, BoxedBestTransactions, CandidateSource, PoolTransaction,
-    };
-
-    /// A [`CandidateSource`] that draws from no transaction pool at all: it captures nothing and
-    /// yields an empty stream. Its existence proves the seam is genuinely pluggable — an alternative
-    /// source is implementable without a pool and is never handed a `&Pool` it would ignore.
-    #[derive(Debug)]
-    struct EmptyCandidateSource<T>(PhantomData<fn() -> T>);
-
-    impl<T> CandidateSource for EmptyCandidateSource<T>
-    where
-        T: PoolTransaction + 'static,
-    {
-        type Transaction = T;
-
-        fn best_transactions(
-            &self,
-            _attributes: BestTransactionsAttributes,
-        ) -> BoxedBestTransactions<Self::Transaction> {
-            Box::new(std::iter::empty())
-        }
-    }
-
-    #[test]
-    fn alternative_source_needs_no_pool() {
-        let source = EmptyCandidateSource::<MockTransaction>(PhantomData);
-        let mut stream = source.best_transactions(BestTransactionsAttributes::new(0, None));
-        assert!(stream.next().is_none());
+impl<T> CandidateSource<T> for DefaultCandidateSource
+where
+    T: PoolTransaction,
+{
+    fn best_transactions(
+        &self,
+        pool_best: BoxedBestTransactions<T>,
+        _attributes: BestTransactionsAttributes,
+    ) -> BoxedBestTransactions<T> {
+        pool_best
     }
 }

--- a/crates/builder/core/src/flashblocks/mod.rs
+++ b/crates/builder/core/src/flashblocks/mod.rs
@@ -18,7 +18,6 @@ pub use context::{
 };
 
 mod payload;
-pub use payload::BasePayloadBuilder;
 
 mod service;
 pub use service::FlashblocksServiceBuilder;

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -102,13 +102,8 @@ impl LastEmittedFlashblockId {
 }
 
 /// Base payload builder
-///
-/// Generic over the [`CandidateSource`] `S` that supplies the priority-ordered candidate
-/// transaction stream drained by the build loop. It defaults to [`DefaultCandidateSource`] — the
-/// pool's best transactions, reproducing the builder's historical behavior — and can be swapped for
-/// an alternative source via [`BasePayloadBuilder::with_candidate_source`].
 #[derive(Debug, Clone)]
-pub struct BasePayloadBuilder<Pool, Client, S = DefaultCandidateSource<Pool>> {
+pub(super) struct BasePayloadBuilder<Pool, Client, S = DefaultCandidateSource> {
     /// The type responsible for creating the evm.
     pub evm_config: BaseEvmConfig,
     /// The transaction pool
@@ -125,27 +120,16 @@ pub struct BasePayloadBuilder<Pool, Client, S = DefaultCandidateSource<Pool>> {
     pub config: BuilderConfig,
     /// Sender for forwarding per-block batches of rejected transactions to the audit-archiver.
     pub rejected_tx_sender: Option<mpsc::Sender<Vec<RejectedTransaction>>>,
-    /// Source of the priority-ordered candidate transaction stream drained by the build loop.
-    ///
-    /// Private so it can only be set through [`BasePayloadBuilder::new`] (default) or swapped via
-    /// [`BasePayloadBuilder::with_candidate_source`], which is the sole type-changing injection
-    /// point. This keeps the `Transaction = Pool::Transaction` invariant from being bypassed by a
-    /// direct field write.
-    candidate_source: S,
     /// Last flashblock emitted by this builder instance.
     last_emitted_flashblock_id: Arc<LastEmittedFlashblockId>,
+    /// Transforms the candidate transaction stream drained by the build loop.
+    candidate_source: S,
 }
 
-impl<Pool, Client> BasePayloadBuilder<Pool, Client>
-where
-    Pool: TransactionPool,
-{
+impl<Pool, Client, S> BasePayloadBuilder<Pool, Client, S> {
     /// `BasePayloadBuilder` constructor.
-    ///
-    /// Uses [`DefaultCandidateSource`] — the pool's priority-ordered best transactions — as the
-    /// candidate source. Call [`BasePayloadBuilder::with_candidate_source`] to substitute an
-    /// alternative source.
-    pub fn new(
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn new(
         evm_config: BaseEvmConfig,
         pool: Pool,
         client: Client,
@@ -153,15 +137,10 @@ where
         payload_tx: mpsc::Sender<BaseBuiltPayload>,
         ws_pub: Arc<WebSocketPublisher>,
         rejected_tx_sender: Option<mpsc::Sender<Vec<RejectedTransaction>>>,
+        candidate_source: S,
     ) -> Self {
         Self {
             evm_config,
-            // The default source captures its own handle to the pool to fetch candidates, while the
-            // `pool` field below is retained for mempool maintenance (invalidation, pruning, account
-            // updates) — operations every source needs regardless of where candidates come from.
-            // `TransactionPool` is `Clone` and `Arc`-backed, so this is a cheap handle copy, not a
-            // second pool.
-            candidate_source: DefaultCandidateSource::new(pool.clone()),
             pool,
             client,
             payload_tx,
@@ -169,31 +148,7 @@ where
             config,
             rejected_tx_sender,
             last_emitted_flashblock_id: Arc::default(),
-        }
-    }
-}
-
-impl<Pool, Client, S> BasePayloadBuilder<Pool, Client, S> {
-    /// Substitute the candidate source, consuming `self` and returning a builder that draws its
-    /// candidate stream from `candidate_source` instead of the default pool-backed source.
-    ///
-    /// The substitution lives in the returned builder; a discarded return value is almost certainly
-    /// a bug, hence `#[must_use]`.
-    #[must_use]
-    pub fn with_candidate_source<S2>(
-        self,
-        candidate_source: S2,
-    ) -> BasePayloadBuilder<Pool, Client, S2> {
-        BasePayloadBuilder {
-            evm_config: self.evm_config,
-            pool: self.pool,
-            client: self.client,
-            payload_tx: self.payload_tx,
-            ws_pub: self.ws_pub,
-            config: self.config,
-            rejected_tx_sender: self.rejected_tx_sender,
             candidate_source,
-            last_emitted_flashblock_id: self.last_emitted_flashblock_id,
         }
     }
 
@@ -209,9 +164,9 @@ impl<Pool, Client, S> BasePayloadBuilder<Pool, Client, S> {
 impl<Pool, Client, S> reth_basic_payload_builder::PayloadBuilder
     for BasePayloadBuilder<Pool, Client, S>
 where
-    Pool: PoolBounds,
-    Client: ClientBounds,
-    S: CandidateSource<Transaction = Pool::Transaction> + Clone,
+    Pool: Clone + Send + Sync,
+    Client: Clone + Send + Sync,
+    S: Clone + Send + Sync,
 {
     type Attributes = BasePayloadBuilderAttributes<BaseTransactionSigned>;
     type BuiltPayload = BaseBuiltPayload;
@@ -242,7 +197,7 @@ impl<Pool, Client, S> BasePayloadBuilder<Pool, Client, S>
 where
     Pool: PoolBounds,
     Client: ClientBounds,
-    S: CandidateSource<Transaction = Pool::Transaction>,
+    S: CandidateSource<Pool::Transaction>,
 {
     fn get_base_payload_builder_ctx(
         &self,
@@ -465,10 +420,12 @@ where
         ctx = ctx.with_cancel(fb_cancel.clone()).with_extra_ctx(extra);
 
         // Create best_transaction iterator
+        let best_txs_attributes = ctx.best_transaction_attributes();
         let mut best_txs = BestFlashblocksTxs::new(
-            BestPayloadTransactions::new(
-                self.candidate_source.best_transactions(ctx.best_transaction_attributes()),
-            ),
+            BestPayloadTransactions::new(self.candidate_source.best_transactions(
+                self.pool.best_transactions_with_attributes(best_txs_attributes),
+                best_txs_attributes,
+            )),
             self.config.rejection_cache.clone(),
         );
         let interval = self.config.flashblocks_interval;
@@ -669,8 +626,12 @@ where
         }
 
         let best_txs_start_time = Instant::now();
+        let best_txs_attributes = ctx.best_transaction_attributes();
         best_txs.refresh_iterator(BestPayloadTransactions::new(
-            self.candidate_source.best_transactions(ctx.best_transaction_attributes()),
+            self.candidate_source.best_transactions(
+                self.pool.best_transactions_with_attributes(best_txs_attributes),
+                best_txs_attributes,
+            ),
         ));
         let transaction_pool_fetch_time = best_txs_start_time.elapsed();
         BuilderMetrics::transaction_pool_fetch_duration().record(transaction_pool_fetch_time);
@@ -1111,7 +1072,7 @@ impl<Pool, Client, S> PayloadBuilder for BasePayloadBuilder<Pool, Client, S>
 where
     Pool: PoolBounds,
     Client: ClientBounds,
-    S: CandidateSource<Transaction = Pool::Transaction> + Clone,
+    S: CandidateSource<Pool::Transaction> + Clone + Send + Sync + Unpin + 'static,
 {
     type Attributes = BasePayloadBuilderAttributes<BaseTransactionSigned>;
     type BuiltPayload = BaseBuiltPayload;

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -101,6 +101,22 @@ impl LastEmittedFlashblockId {
     }
 }
 
+/// The outbound channels the flashblocks builder emits to.
+///
+/// Grouped so [`BasePayloadBuilder::new`] takes a single cohesive argument rather than threading
+/// each sink through individually.
+#[derive(Debug, Clone)]
+pub(super) struct BuilderOutputs {
+    /// Sender for sending built payloads to [`PayloadHandler`],
+    /// which broadcasts outgoing payloads via p2p.
+    pub payload_tx: mpsc::Sender<BaseBuiltPayload>,
+    /// WebSocket publisher for broadcasting flashblocks
+    /// to all connected subscribers.
+    pub ws_pub: Arc<WebSocketPublisher>,
+    /// Sender for forwarding per-block batches of rejected transactions to the audit-archiver.
+    pub rejected_tx_sender: Option<mpsc::Sender<Vec<RejectedTransaction>>>,
+}
+
 /// Base payload builder
 #[derive(Debug, Clone)]
 pub(super) struct BasePayloadBuilder<Pool, Client, S = DefaultCandidateSource> {
@@ -110,16 +126,11 @@ pub(super) struct BasePayloadBuilder<Pool, Client, S = DefaultCandidateSource> {
     pub pool: Pool,
     /// Node client
     pub client: Client,
-    /// Sender for sending built payloads to [`PayloadHandler`],
-    /// which broadcasts outgoing payloads via p2p.
-    pub payload_tx: mpsc::Sender<BaseBuiltPayload>,
-    /// WebSocket publisher for broadcasting flashblocks
-    /// to all connected subscribers.
-    pub ws_pub: Arc<WebSocketPublisher>,
     /// System configuration for the builder
     pub config: BuilderConfig,
-    /// Sender for forwarding per-block batches of rejected transactions to the audit-archiver.
-    pub rejected_tx_sender: Option<mpsc::Sender<Vec<RejectedTransaction>>>,
+    /// The outbound channels the builder emits built payloads, flashblocks, and rejected
+    /// transactions to.
+    pub outputs: BuilderOutputs,
     /// Last flashblock emitted by this builder instance.
     last_emitted_flashblock_id: Arc<LastEmittedFlashblockId>,
     /// Transforms the candidate transaction stream drained by the build loop.
@@ -128,25 +139,20 @@ pub(super) struct BasePayloadBuilder<Pool, Client, S = DefaultCandidateSource> {
 
 impl<Pool, Client, S> BasePayloadBuilder<Pool, Client, S> {
     /// `BasePayloadBuilder` constructor.
-    #[allow(clippy::too_many_arguments)]
     pub(super) fn new(
         evm_config: BaseEvmConfig,
         pool: Pool,
         client: Client,
         config: BuilderConfig,
-        payload_tx: mpsc::Sender<BaseBuiltPayload>,
-        ws_pub: Arc<WebSocketPublisher>,
-        rejected_tx_sender: Option<mpsc::Sender<Vec<RejectedTransaction>>>,
+        outputs: BuilderOutputs,
         candidate_source: S,
     ) -> Self {
         Self {
             evm_config,
             pool,
             client,
-            payload_tx,
-            ws_pub,
             config,
-            rejected_tx_sender,
+            outputs,
             last_emitted_flashblock_id: Arc::default(),
             candidate_source,
         }
@@ -248,7 +254,7 @@ where
             cancel,
             extra,
             builder_config: self.config.clone(),
-            rejected_tx_sender: self.rejected_tx_sender.clone(),
+            rejected_tx_sender: self.outputs.rejected_tx_sender.clone(),
         })
     }
 
@@ -318,7 +324,7 @@ where
             skip_flashblocks_building, // need to calculate state root for CL sync or if not building flashblocks
         )?;
 
-        self.payload_tx.send(payload.clone()).await.map_err(PayloadBuilderError::other)?;
+        self.outputs.payload_tx.send(payload.clone()).await.map_err(PayloadBuilderError::other)?;
 
         info!(
             target: "payload_builder",
@@ -335,6 +341,7 @@ where
         // flashblocks for the same block.
         if !ctx.attributes().no_tx_pool {
             let flashblock_byte_size = self
+                .outputs
                 .ws_pub
                 .publish(&fb_payload, ctx.block_number(), 0)
                 .map_err(PayloadBuilderError::other)?;
@@ -750,6 +757,7 @@ where
                         (true, 0)
                     } else {
                         let size = self
+                            .outputs
                             .ws_pub
                             .publish(&fb_payload, ctx.block_number(), flashblock_index)
                             .wrap_err("failed to publish flashblock via websocket")?;
@@ -795,7 +803,8 @@ where
                 }
 
                 // Send to handler outside mutex.
-                self.payload_tx
+                self.outputs
+                    .payload_tx
                     .send(new_payload.clone())
                     .await
                     .wrap_err("failed to send built payload to handler")?;
@@ -1072,7 +1081,7 @@ impl<Pool, Client, S> PayloadBuilder for BasePayloadBuilder<Pool, Client, S>
 where
     Pool: PoolBounds,
     Client: ClientBounds,
-    S: CandidateSource<Pool::Transaction> + Clone + Send + Sync + Unpin + 'static,
+    S: CandidateSource<Pool::Transaction> + Clone + Unpin + 'static,
 {
     type Attributes = BasePayloadBuilderAttributes<BaseTransactionSigned>;
     type BuiltPayload = BaseBuiltPayload;

--- a/crates/builder/core/src/flashblocks/service.rs
+++ b/crates/builder/core/src/flashblocks/service.rs
@@ -19,7 +19,11 @@ use reth_payload_builder::{PayloadBuilderHandle, PayloadBuilderService};
 use reth_provider::CanonStateSubscriptions;
 use tracing::info;
 
-use super::{PayloadHandler, generator::BlockPayloadJobGenerator, payload::BasePayloadBuilder};
+use super::{
+    PayloadHandler,
+    generator::BlockPayloadJobGenerator,
+    payload::{BasePayloadBuilder, BuilderOutputs},
+};
 use crate::{
     BuilderConfig, CandidateSource, DefaultCandidateSource, RejectedTxForwarder,
     traits::{NodeBounds, PoolBounds},
@@ -49,6 +53,7 @@ impl FlashblocksServiceBuilder {
 
 impl<S> FlashblocksServiceBuilder<S> {
     /// Replace the candidate transaction source used by the flashblocks build loop.
+    #[must_use]
     pub fn with_candidate_source<S2>(self, candidate_source: S2) -> FlashblocksServiceBuilder<S2> {
         FlashblocksServiceBuilder { config: self.config, candidate_source }
     }
@@ -83,9 +88,7 @@ impl<S> FlashblocksServiceBuilder<S> {
             pool,
             ctx.provider().clone(),
             self.config.clone(),
-            built_payload_tx,
-            ws_pub,
-            rejected_tx_sender,
+            BuilderOutputs { payload_tx: built_payload_tx, ws_pub, rejected_tx_sender },
             self.candidate_source.clone(),
         );
         let payload_generator = BlockPayloadJobGenerator::with_builder(

--- a/crates/builder/core/src/flashblocks/service.rs
+++ b/crates/builder/core/src/flashblocks/service.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use base_builder_publish::WebSocketPublisher;
 use base_execution_evm::BaseEvmConfig;
+use base_execution_txpool::BasePooledTransaction;
 use base_node_core::{
     BaseConsensusBuilder, BaseExecutorBuilder, BaseNetworkBuilder, node::BasePoolBuilder,
 };
@@ -20,19 +21,38 @@ use tracing::info;
 
 use super::{PayloadHandler, generator::BlockPayloadJobGenerator, payload::BasePayloadBuilder};
 use crate::{
-    BuilderConfig, RejectedTxForwarder,
+    BuilderConfig, CandidateSource, DefaultCandidateSource, RejectedTxForwarder,
     traits::{NodeBounds, PoolBounds},
 };
 
 /// Builder for the flashblocks payload service.
 ///
-/// Wraps [`BuilderConfig`] and implements [`BasePayloadServiceBuilder`] to spawn
-/// the flashblocks payload builder service, which produces sub-block chunks
-/// (flashblocks) at sub-second intervals during block construction.
+/// Holds a [`BuilderConfig`] and a [`CandidateSource`], and implements
+/// [`BasePayloadServiceBuilder`] to spawn the flashblocks payload builder service, which produces
+/// sub-block chunks (flashblocks) at sub-second intervals during block construction.
+///
+/// The candidate source defaults to [`DefaultCandidateSource`] (the pool's best transactions,
+/// unchanged); use [`FlashblocksServiceBuilder::with_candidate_source`] to supply an alternative.
 #[derive(Debug)]
-pub struct FlashblocksServiceBuilder(pub BuilderConfig);
+pub struct FlashblocksServiceBuilder<S = DefaultCandidateSource> {
+    config: BuilderConfig,
+    candidate_source: S,
+}
 
 impl FlashblocksServiceBuilder {
+    /// Create a service builder that uses the default candidate source
+    /// (the pool's priority-ordered best transactions, unchanged).
+    pub const fn new(config: BuilderConfig) -> Self {
+        Self { config, candidate_source: DefaultCandidateSource }
+    }
+}
+
+impl<S> FlashblocksServiceBuilder<S> {
+    /// Replace the candidate transaction source used by the flashblocks build loop.
+    pub fn with_candidate_source<S2>(self, candidate_source: S2) -> FlashblocksServiceBuilder<S2> {
+        FlashblocksServiceBuilder { config: self.config, candidate_source }
+    }
+
     fn spawn_payload_builder_service<Node, Pool>(
         self,
         ctx: &BuilderContext<Node>,
@@ -41,11 +61,12 @@ impl FlashblocksServiceBuilder {
     where
         Node: NodeBounds,
         Pool: PoolBounds,
+        S: CandidateSource<Pool::Transaction> + Clone + Unpin + 'static,
     {
         let (built_payload_tx, built_payload_rx) = tokio::sync::mpsc::channel(16);
 
-        let rejected_tx_sender = if let Some(ref url) = self.0.audit_archiver_url {
-            let (tx, rx) = tokio::sync::mpsc::channel(self.0.rejected_tx_channel_size);
+        let rejected_tx_sender = if let Some(ref url) = self.config.audit_archiver_url {
+            let (tx, rx) = tokio::sync::mpsc::channel(self.config.rejected_tx_channel_size);
             let forwarder = RejectedTxForwarder::new(url, rx)
                 .map_err(|e| eyre::eyre!("Failed to create rejected tx forwarder: {e}"))?;
             ctx.task_executor().spawn_task(Box::pin(forwarder.run()));
@@ -56,22 +77,23 @@ impl FlashblocksServiceBuilder {
         };
 
         let ws_pub: Arc<WebSocketPublisher> =
-            WebSocketPublisher::new(self.0.flashblocks_ws_addr)?.into();
+            WebSocketPublisher::new(self.config.flashblocks_ws_addr)?.into();
         let payload_builder = BasePayloadBuilder::new(
             BaseEvmConfig::base(ctx.chain_spec()),
             pool,
             ctx.provider().clone(),
-            self.0.clone(),
+            self.config.clone(),
             built_payload_tx,
             ws_pub,
             rejected_tx_sender,
+            self.candidate_source.clone(),
         );
         let payload_generator = BlockPayloadJobGenerator::with_builder(
             ctx.provider().clone(),
             ctx.task_executor().clone(),
             payload_builder,
             true,
-            self.0.block_time_leeway,
+            self.config.block_time_leeway,
         );
 
         let (payload_service, payload_builder_handle) =
@@ -90,10 +112,12 @@ impl FlashblocksServiceBuilder {
     }
 }
 
-impl<Node, Pool> PayloadServiceBuilder<Node, Pool, BaseEvmConfig> for FlashblocksServiceBuilder
+impl<Node, Pool, S> PayloadServiceBuilder<Node, Pool, BaseEvmConfig>
+    for FlashblocksServiceBuilder<S>
 where
     Node: NodeBounds,
     Pool: PoolBounds,
+    S: CandidateSource<Pool::Transaction> + Clone + Unpin + 'static,
 {
     async fn spawn_payload_builder_service(
         self,
@@ -105,7 +129,10 @@ where
     }
 }
 
-impl BasePayloadServiceBuilder for FlashblocksServiceBuilder {
+impl<S> BasePayloadServiceBuilder for FlashblocksServiceBuilder<S>
+where
+    S: CandidateSource<BasePooledTransaction> + Clone + Unpin + 'static,
+{
     type ComponentsBuilder = ComponentsBuilder<
         BaseNodeTypes,
         BasePoolBuilder,

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -44,9 +44,9 @@ pub use rejection_cache::RejectionCache;
 
 mod flashblocks;
 pub use flashblocks::{
-    BasePayloadBuilder, BasePayloadBuilderCtx, BestFlashblocksTxs, BlockPayloadJob,
-    BlockPayloadJobGenerator, BuildArguments, FlashblockDiagnostics, FlashblockSelectionOutcome,
-    FlashblocksExtraCtx, FlashblocksServiceBuilder, PayloadBuilder, PayloadHandler, ResolvePayload,
+    BasePayloadBuilderCtx, BestFlashblocksTxs, BlockPayloadJob, BlockPayloadJobGenerator,
+    BuildArguments, FlashblockDiagnostics, FlashblockSelectionOutcome, FlashblocksExtraCtx,
+    FlashblocksServiceBuilder, PayloadBuilder, PayloadHandler, ResolvePayload,
 };
 
 mod extension;

--- a/crates/builder/core/src/test_utils/instance.rs
+++ b/crates/builder/core/src/test_utils/instance.rs
@@ -153,7 +153,7 @@ impl LocalInstance {
                 base_node
                     .components()
                     .pool(pool_component())
-                    .payload(FlashblocksServiceBuilder(builder_config.clone())),
+                    .payload(FlashblocksServiceBuilder::new(builder_config.clone())),
             )
             .with_add_ons(addons)
             .on_rpc_started(move |_, _| {

--- a/etc/systems/src/l2/in_process_builder.rs
+++ b/etc/systems/src/l2/in_process_builder.rs
@@ -146,7 +146,7 @@ impl InProcessBuilder {
                 base_node
                     .components()
                     .pool(pool_component(&rollup_args))
-                    .payload(FlashblocksServiceBuilder(builder_config)),
+                    .payload(FlashblocksServiceBuilder::new(builder_config)),
             )
             .with_add_ons(addons)
             .on_component_initialized(move |_ctx| Ok(()))


### PR DESCRIPTION
## Summary

Builds on #4107 to make the flashblocks build loop's candidate transaction source injectable by an external crate. The `CandidateSource` trait is now generic over the pool transaction type and transforms the pool's best-transactions iterator, so the injection bound stays a clean `CandidateSource<BasePooledTransaction>` rather than the concrete pool type. `BasePayloadBuilder` and `FlashblocksServiceBuilder` gain an `S = DefaultCandidateSource` type parameter, with `FlashblocksServiceBuilder::new(config)` for the default and `with_candidate_source(source)` to override. Default behavior is unchanged since `DefaultCandidateSource` returns the pool stream as-is, verified with cargo check, clippy, nightly rustfmt, and the full base-builder-core flashblocks test suite.