### PR TITLE
fix(consensus): default verifier L1 confs to 1

### DIFF
--- a/crates/consensus/cli/src/l1.rs
+++ b/crates/consensus/cli/src/l1.rs
@@ -34,9 +34,9 @@ pub struct L1ClientArgs {
     )]
     pub l1_slot_duration_override: Option<u64>,
     /// Number of L1 blocks to keep distance from the L1 head for the verifier (derivation
-    /// pipeline). Controlled via `BASE_NODE_VERIFIER_L1_CONFS`. Defaults to 0, meaning
-    /// the verifier derives from the latest L1 head with no confirmation delay.
-    #[arg(long = "l1.verifier-confs", default_value = "0", env = "BASE_NODE_VERIFIER_L1_CONFS")]
+    /// pipeline). Controlled via `BASE_NODE_VERIFIER_L1_CONFS`. Defaults to 1, so the
+    /// verifier derives from `head - 1` and avoids tip-adjacent L1 replica inconsistency.
+    #[arg(long = "l1.verifier-confs", default_value = "1", env = "BASE_NODE_VERIFIER_L1_CONFS")]
     pub l1_verifier_confs: u64,
 }
 
@@ -47,7 +47,7 @@ impl Default for L1ClientArgs {
             l1_trust_rpc: DEFAULT_L1_TRUST_RPC,
             l1_beacon: Url::parse("http://localhost:5052").unwrap(),
             l1_slot_duration_override: None,
-            l1_verifier_confs: 0,
+            l1_verifier_confs: 1,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Change the CLI/`BASE_NODE_VERIFIER_L1_CONFS` default from `0` to `1` so derivation follows `head - 1` instead of the live L1 tip.
- Reduces tip-adjacent `BlockNotFound` resets when L1 RPC backends are load-balanced across replicas that can briefly disagree on the newest block.

## Context
With confs `0`, `PollingTraversal::advance_origin` fetches the next L1 block by number and then receipts/headers by hash. A lagging replica can return `null` for that hash and force a derivation reset. Frequent resets amplify finalizer latch issues (see #3895).

Chain Sepolia already sets `BASE_NODE_VERIFIER_L1_CONFS=1`; this aligns the public `base` default with that safer behavior. Explicit `0` remains available for local/dev use.

## Test plan
- [ ] Confirm `base node --help` shows `--l1.verifier-confs` default `1`
- [ ] Confirm unset `BASE_NODE_VERIFIER_L1_CONFS` yields confs depth 1 at startup (`Verifier L1 confirmation delay enabled` / metric)
- [ ] Confirm explicit `BASE_NODE_VERIFIER_L1_CONFS=0` still disables the delay
- [ ] Smoke a verifier against a multi-replica L1 front and check hash `Block not found` reset rate

type=routine
risk=low
impact=sev5