### PR TITLE
fix(consensus): preserve L1 finality across derivation resets

### DIFF
--- a/actions/harness/src/node.rs
+++ b/actions/harness/src/node.rs
@@ -144,7 +144,7 @@ pub struct TestRollupNode<P: Pipeline + SignalReceiver + Debug + Send = Verifier
     /// Current L2 finalized head.
     finalized_head: L2BlockInfo,
     /// Most recently signalled finalized L1 block number.
-    finalized_l1_number: u64,
+    finalized_l1_number: Option<u64>,
     /// Most recently signalled L1 safe block number.
     safe_l1_number: u64,
     /// History of safe head updates paired with their L1 origin number.
@@ -202,7 +202,7 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> TestRollupNode<P> {
             safe_head,
             unsafe_head: safe_head,
             finalized_head: safe_head,
-            finalized_l1_number: 0,
+            finalized_l1_number: None,
             safe_l1_number: 0,
             safe_head_history: Vec::new(),
             derived_tx_counts: Vec::new(),
@@ -340,17 +340,25 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> TestRollupNode<P> {
         Ok(())
     }
 
-    /// Update the L2 finalized head by scanning safe-head history.
-    ///
-    /// Finds the highest L2 safe block whose L1 origin number is ≤
-    /// `head.number` and promotes it to `finalized_head`.
+    /// Update the retained finalized L1 signal and retry finalization.
     pub async fn act_l1_finalized_signal(&mut self, head: BlockInfo) {
-        self.finalized_l1_number = head.number;
+        if self.finalized_l1_number.is_some_and(|previous| head.number < previous) {
+            return;
+        }
+        self.finalized_l1_number = Some(head.number);
+        self.try_finalize_pending();
+    }
+
+    /// Retry finalization using the retained finalized L1 signal.
+    fn try_finalize_pending(&mut self) {
+        let Some(finalized_l1_number) = self.finalized_l1_number else {
+            return;
+        };
         let candidate = self
             .safe_head_history
             .iter()
             .rev()
-            .find(|(_, l1_origin_number)| *l1_origin_number <= self.finalized_l1_number)
+            .find(|(_, l1_origin_number)| *l1_origin_number <= finalized_l1_number)
             .map(|(l2_info, _)| *l2_info);
         if let Some(l2) = candidate
             && l2.block_info.number > self.finalized_head.block_info.number
@@ -363,7 +371,8 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> TestRollupNode<P> {
     ///
     /// Sends a [`ResetSignal`] to the pipeline, resets all head pointers,
     /// clears all per-block metadata, and replaces the engine with a fresh
-    /// instance that will re-execute from genesis on the new fork.
+    /// instance that will re-execute from genesis on the new fork. The finalized L1 signal is
+    /// retained so re-derived safe heads can be finalized without a duplicate signal.
     pub async fn act_reset(&mut self, l2_safe_head: L2BlockInfo) {
         self.pipeline
             .signal(ResetSignal { l2_safe_head }.signal())
@@ -372,7 +381,6 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> TestRollupNode<P> {
         self.safe_head = l2_safe_head;
         self.unsafe_head = l2_safe_head;
         self.finalized_head = l2_safe_head;
-        self.finalized_l1_number = 0;
         self.safe_l1_number = 0;
         self.safe_head_history.clear();
         self.derived_tx_counts.clear();
@@ -690,6 +698,7 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> TestRollupNode<P> {
         };
         self.l2_provider.insert_block(self.safe_head);
         self.safe_head_history.push((self.safe_head, l1_origin.number));
+        self.try_finalize_pending();
         // `attrs.derived_from` carries the full L1 BlockInfo set by the pipeline's
         // AttributesQueueStage. It is always `Some` for attributes produced by the
         // real derivation pipeline. The `None` fallback is defensive — it triggers

--- a/actions/harness/tests/finalization.rs
+++ b/actions/harness/tests/finalization.rs
@@ -214,8 +214,9 @@ async fn finalization_does_not_exceed_safe_head() {
     assert_eq!(node.l2_finalized_number(), 2, "finalized head should be capped at safe head (2)");
 }
 
-/// After a pipeline reset (simulating a reorg), finalization state is cleared
-/// back to genesis. After re-deriving blocks, finalization can proceed again.
+/// After a pipeline reset (simulating a reorg), the finalized L2 head and
+/// reset-sensitive candidate state return to genesis. After re-deriving blocks,
+/// finalization can proceed again.
 #[tokio::test]
 async fn finalization_reorg_clears_state() {
     let batcher_cfg = BatcherConfig {
@@ -326,6 +327,55 @@ async fn finalization_reorg_clears_state() {
         node.l2_finalized_number(),
         1,
         "finalization should work cleanly after reset and re-derivation"
+    );
+}
+
+/// Finalization resumes after a derivation reset without receiving the unchanged
+/// finalized-L1 signal again.
+#[tokio::test]
+async fn finalization_resumes_after_reset_without_new_l1_signal() {
+    let batcher_cfg = BatcherConfig {
+        encoder: EncoderConfig { da_type: DaType::Calldata, ..EncoderConfig::default() },
+        ..BatcherConfig::default()
+    };
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg.clone());
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+    let block1 = sequencer.build_next_block_with_single_transaction().await;
+    let block2 = sequencer.build_next_block_with_single_transaction().await;
+
+    let (mut node, chain) = h.create_test_rollup_node_from_sequencer(
+        &mut sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
+    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg);
+    for block in [block1, block2] {
+        batcher.push_block(block);
+        batcher.advance(&mut h.l1).await;
+        chain.push(h.l1.tip().clone());
+    }
+
+    node.initialize().await;
+    for _ in 1..=2u64 {
+        node.run_until_idle().await;
+    }
+    assert_eq!(node.l2_safe_number(), 2);
+
+    node.act_l1_finalized_signal(h.l1.block_info_at(1)).await;
+    assert_eq!(node.l2_finalized_number(), 2);
+
+    node.act_reset(h.l2_genesis()).await;
+    assert_eq!(node.l2_finalized_number(), 0);
+
+    node.run_until_idle().await;
+
+    assert_eq!(node.l2_safe_number(), 2);
+    assert_eq!(
+        node.l2_finalized_number(),
+        2,
+        "re-derived safe blocks should use the retained finalized L1 signal"
     );
 }
 

--- a/crates/consensus/service/src/actors/derivation/actor.rs
+++ b/crates/consensus/service/src/actors/derivation/actor.rs
@@ -105,6 +105,19 @@ where
         self.derivation_origin_tx.send_replace(self.pipeline.origin());
     }
 
+    /// Sends a finalized L2 block to the engine when the retained finalized L1 signal makes one
+    /// eligible.
+    async fn try_finalize_pending(&mut self) -> Result<(), DerivationError> {
+        if let Some(l2_block_number) = self.finalizer.try_finalize_pending() {
+            self.engine_client
+                .send_finalized_l2_block(l2_block_number)
+                .await
+                .map_err(|e| DerivationError::Sender(Box::new(e)))?;
+        }
+
+        Ok(())
+    }
+
     /// Handles a [`Signal`] received over the derivation signal receiver channel.
     async fn signal(&mut self, signal: Signal) {
         if let Signal::Reset(ResetSignal { l2_safe_head: _reset_safe_head }) = signal {
@@ -240,8 +253,10 @@ where
                 self.derivation_state_machine.update(&DerivationStateUpdate::SignalProcessed)?;
             }
             DerivationActorRequest::ProcessFinalizedL1Block(finalized_l1_block) => {
-                // Attempt to finalize the block. If successful, notify engine.
-                if let Some(l2_block_number) = self.finalizer.try_finalize_next(*finalized_l1_block)
+                // Retain the signal even when no derived L2 blocks are currently queued. The
+                // finalizer will retry it after derivation rebuilds the safe head.
+                if let Some(l2_block_number) =
+                    self.finalizer.process_finalized_l1_block(*finalized_l1_block)
                 {
                     self.engine_client
                         .send_finalized_l2_block(l2_block_number)
@@ -280,6 +295,11 @@ where
 
                 self.derivation_state_machine
                     .update(&DerivationStateUpdate::NewAttributesConfirmed(safe_head))?;
+
+                // A reset clears derived candidates, but the finalized L1 signal is retained.
+                // Retry after the rebuilt safe head is confirmed, matching op-node's
+                // safe-derived finalization trigger.
+                self.try_finalize_pending().await?;
 
                 self.attempt_derivation().await?;
             }

--- a/crates/consensus/service/src/actors/derivation/finalizer.rs
+++ b/crates/consensus/service/src/actors/derivation/finalizer.rs
@@ -22,6 +22,11 @@ pub struct L2Finalizer {
     /// block is received, the highest L2 block whose inputs are contained within the finalized
     /// L1 chain is finalized.
     awaiting_finalization: BTreeMap<L1BlockNumber, L2BlockNumber>,
+    /// The highest finalized L1 block observed by the finalizer.
+    ///
+    /// This survives derivation resets so that re-derived L2 blocks can be finalized without
+    /// waiting for the L1 watcher to emit the same finalized block again.
+    finalized_l1_block: Option<BlockInfo>,
 }
 
 impl L2Finalizer {
@@ -39,7 +44,32 @@ impl L2Finalizer {
             .or_insert_with(|| attributes.block_number());
     }
 
-    /// Clears the finalization queue.
+    /// Records a finalized L1 block and attempts to finalize any eligible L2 blocks.
+    ///
+    /// Finalized L1 signals are monotonic by block number. Older signals are ignored, while a
+    /// signal at the same height is accepted so that its block identity remains current.
+    pub fn process_finalized_l1_block(
+        &mut self,
+        finalized_l1_block: BlockInfo,
+    ) -> Option<L2BlockNumber> {
+        if self
+            .finalized_l1_block
+            .as_ref()
+            .is_some_and(|previous| finalized_l1_block.number < previous.number)
+        {
+            return None;
+        }
+
+        self.finalized_l1_block = Some(finalized_l1_block);
+        self.try_finalize_pending()
+    }
+
+    /// Attempts to finalize an eligible L2 block using the latest finalized L1 signal.
+    pub fn try_finalize_pending(&mut self) -> Option<L2BlockNumber> {
+        self.try_finalize_next(self.finalized_l1_block?)
+    }
+
+    /// Clears reset-sensitive derived-block tracking while preserving the finalized L1 signal.
     pub fn clear(&mut self) {
         self.awaiting_finalization.clear();
     }
@@ -108,6 +138,16 @@ mod tests {
     }
 
     #[test]
+    fn finalized_l1_signal_is_retained_until_candidates_are_ready() {
+        let mut f = L2Finalizer::default();
+        assert!(f.process_finalized_l1_block(l1_at(5)).is_none());
+
+        f.enqueue_for_finalization(&attrs(9, 5));
+
+        assert_eq!(f.try_finalize_pending(), Some(10));
+    }
+
+    #[test]
     fn single_entry_l1_not_yet_finalized() {
         let mut f = L2Finalizer::default();
         // L2 block 10 came from L1 origin 5. Finalizing at L1=3 should not include it.
@@ -158,6 +198,18 @@ mod tests {
     }
 
     #[test]
+    fn clear_preserves_finalized_l1_signal() {
+        let mut f = L2Finalizer::default();
+        f.process_finalized_l1_block(l1_at(5));
+        f.enqueue_for_finalization(&attrs(4, 1));
+
+        f.clear();
+        f.enqueue_for_finalization(&attrs(9, 5));
+
+        assert_eq!(f.try_finalize_pending(), Some(10));
+    }
+
+    #[test]
     fn drain_preserves_future_entries() {
         // After finalizing up to L1=2, entries at L1=5 must survive.
         let mut f = L2Finalizer::default();
@@ -178,5 +230,16 @@ mod tests {
         assert_eq!(f.try_finalize_next(l1_at(5)), Some(20));
         // Queue is now empty; an older signal cannot regress to a stale entry.
         assert!(f.try_finalize_next(l1_at(2)).is_none());
+    }
+
+    #[test]
+    fn older_finalized_signal_does_not_lower_high_water_mark() {
+        let mut f = L2Finalizer::default();
+        f.process_finalized_l1_block(l1_at(5));
+        assert!(f.process_finalized_l1_block(l1_at(3)).is_none());
+
+        f.enqueue_for_finalization(&attrs(9, 4));
+
+        assert_eq!(f.try_finalize_pending(), Some(10));
     }
 }


### PR DESCRIPTION
## Summary
- Retain the latest finalized L1 signal in `L2Finalizer` across derivation resets, matching op-node's `onReset` / `finalizedL1` behavior.
- Retry finalization after the engine confirms rebuilt safe-head data so L2 finality resumes without waiting for a duplicate L1 finality poll.
- Add unit and action-harness regressions for empty-queue signals, reset retention, and finalization without a new L1 signal.

Fixes #3895

## Test plan
- [x] `cargo nextest run -p base-consensus-node -- finalizer`
- [x] `cargo nextest run -p base-action-harness -- finalization`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `RISC0_SKIP_BUILD_KERNELS=1 BASE_SUCCINCT_ELF_STUB=1 cargo clippy -p base-consensus-node --all-features --all-targets -- -D warnings`
- [x] `RISC0_SKIP_BUILD_KERNELS=1 BASE_SUCCINCT_ELF_STUB=1 cargo clippy -p base-action-harness --all-targets -- -D warnings`
- [x] Fresh local Docker/Podman single-sequencer QA on `6584cc930` (`base:latch-l1-finality-6584cc930fa9`), verifier `BASE_NODE_VERIFIER_L1_CONFS=0`

## Devnet QA
- **Result:** PASS (tier 4 fresh full-stack single-sequencer; no HA/ZK/prover)
- **Image:** `base:latch-l1-finality-6584cc930fa9` @ `6584cc930`
- **Trigger observed:** natural tip-adjacent derivation `Reset` storm on `base-client` at startup (`BlockNotFound` / 9× reset signals) with L1 confs=0
- **Outcome:** L2 finalized advanced after those resets (`Updated finalized head` 18 → 38 → 50 → … → 194+; 12 finalized-head updates); builder/client latest hash parity
- **Limitations:** second calm window had no additional Reset (could not hold `finalized_l1` constant); relied on natural startup resets rather than controlled post-steady L1 fault injection; local L1 finality cadence is not Sepolia-identical

type=routine
risk=low
impact=sev5