### PR TITLE
feat: read nitro-host rollup config from a file instead of op-node RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6053,7 +6053,6 @@ name = "base-prover-nitro-host"
 version = "0.0.0"
 dependencies = [
  "alloy-primitives",
- "alloy-provider 2.0.5",
  "base-cli-utils",
  "base-common-chains",
  "base-common-genesis",
@@ -6065,6 +6064,8 @@ dependencies = [
  "clap",
  "eyre",
  "serde",
+ "serde_json",
+ "tempfile",
  "tokio",
  "tokio-util",
  "tracing",

--- a/bin/prover/nitro-host/Cargo.toml
+++ b/bin/prover/nitro-host/Cargo.toml
@@ -28,6 +28,7 @@ base-proof-tee-nitro-enclave = { workspace = true, optional = true }
 # CLI / errors
 eyre.workspace = true
 base-cli-utils.workspace = true
+serde_json = { workspace = true, features = ["std"] }
 clap = { workspace = true, features = ["derive", "env"] }
 serde = { workspace = true, features = ["derive", "std"] }
 
@@ -37,7 +38,6 @@ tokio = { workspace = true, features = ["full"] }
 
 # Primitives / identifiers
 alloy-primitives.workspace = true
-alloy-provider = { workspace = true, features = ["reqwest"] }
 uuid = { workspace = true, features = ["v4"] }
 
 # Tracing
@@ -45,6 +45,9 @@ tracing.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 base-proof-tee-nitro-enclave.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
 
 [features]
 local = ["dep:base-proof-tee-nitro-enclave"]

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -6,9 +6,12 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 #[cfg(any(target_os = "linux", feature = "local"))]
 use std::time::Duration;
+use std::{
+    fs::File,
+    path::{Path, PathBuf},
+};
 
 use alloy_primitives::Address;
-use alloy_provider::{Provider, ProviderBuilder};
 use base_cli_utils::{LogConfig, RuntimeManager};
 #[cfg(any(target_os = "linux", feature = "local"))]
 use base_common_chains::rollup_config;
@@ -64,10 +67,10 @@ pub(crate) struct Cli {
 enum Command {
     /// Compute the on-chain config hash for a chain and print it as `0x…`.
     ///
-    /// Resolves the chain's `RollupConfig` (from op-node via `optimism_rollupConfig`)
-    /// and hashes it with the same `PerChainConfig` encoding the enclave uses, so the
-    /// printed value is exactly what must be set as `AggregateVerifier.CONFIG_HASH`.
-    /// Available on all targets — no enclave/NSM required.
+    /// Reads the chain's `RollupConfig` from a JSON file (e.g. `rollup.json`) and hashes
+    /// it with the same `PerChainConfig` encoding the enclave uses, so the printed value is
+    /// exactly what must be set as `AggregateVerifier.CONFIG_HASH`. Computed offline with no
+    /// RPC and no running nodes. Available on all targets — no enclave/NSM required.
     ConfigHash(ConfigHashArgs),
 
     /// Claim Nitro TEE jobs from prover-service and forward them to the enclave over vsock.
@@ -82,14 +85,14 @@ enum Command {
 /// Arguments for the `config-hash` subcommand.
 #[derive(Parser)]
 struct ConfigHashArgs {
-    /// L2 consensus-layer (op-node) RPC URL serving `optimism_rollupConfig`.
-    #[arg(long, env = "L2_CL_URL")]
-    l2_cl_url: String,
+    /// Path to the chain's rollup config JSON (e.g. `rollup.json`).
+    #[arg(long, env = "ROLLUP_CONFIG")]
+    rollup_config: PathBuf,
 }
 
 impl ConfigHashArgs {
-    async fn run(self) -> eyre::Result<()> {
-        let rollup_config = fetch_rollup_config_from_rpc(&self.l2_cl_url).await?;
+    fn run(self) -> eyre::Result<()> {
+        let rollup_config = load_rollup_config(&self.rollup_config)?;
         let mut per_chain = PerChainConfig::from_rollup_config(&rollup_config)
             .ok_or_else(|| eyre!("rollup config is missing genesis.system_config"))?;
         per_chain.force_defaults();
@@ -135,18 +138,12 @@ struct ProverRuntimeArgs {
     #[arg(long, env = "TEE_PROVER_REGISTRY_ADDRESS")]
     tee_prover_registry_address: Option<Address>,
 
-    /// Fetch the full rollup config via `optimism_rollupConfig` RPC at startup.
-    /// Requires `--l2-cl-url`. Intended for devnet/ephemeral chains whose
-    /// chain ID is not in the built-in config table. For built-in chain IDs,
-    /// the enclave's `BootInfo::load` will use the hardcoded config regardless.
-    #[arg(long, env = "FETCH_ROLLUP_CONFIG", requires = "l2_cl_url")]
-    fetch_rollup_config: bool,
-
-    /// L2 consensus-layer (op-node) RPC URL. Required when
-    /// `--fetch-rollup-config` is set — `optimism_rollupConfig` is served by
-    /// op-node, not the execution-layer endpoint.
-    #[arg(long, env = "L2_CL_URL")]
-    l2_cl_url: Option<String>,
+    /// Path to the chain's rollup config JSON (e.g. `rollup.json`), read at startup.
+    /// Intended for devnet/ephemeral chains whose chain ID is not in the built-in
+    /// config table. For built-in chain IDs, the enclave's `BootInfo::load` uses the
+    /// hardcoded config regardless.
+    #[arg(long, env = "ROLLUP_CONFIG")]
+    rollup_config: Option<PathBuf>,
 }
 
 #[cfg(any(target_os = "linux", feature = "local"))]
@@ -176,41 +173,39 @@ impl ProverRuntimeArgs {
         })
     }
 
-    async fn prover_config(self) -> eyre::Result<ProverConfig> {
+    fn prover_config(self) -> eyre::Result<ProverConfig> {
         let l1_beacon_url = self.l1_beacon_url()?;
 
-        let rollup_config = if self.fetch_rollup_config {
-            let cl_url = self
-                .l2_cl_url
-                .as_deref()
-                .expect("clap `requires` guarantees --l2-cl-url is present");
-            let rpc = fetch_rollup_config_from_rpc(cl_url).await?;
+        let rollup_config = if let Some(path) = self.rollup_config.as_deref() {
+            let cfg = load_rollup_config(path)?;
 
-            if rpc.l2_chain_id.id() != self.l2_chain_id {
+            if cfg.l2_chain_id.id() != self.l2_chain_id {
                 return Err(eyre!(
-                    "chain ID mismatch: --l2-chain-id is {} but the L2 node returned {}",
+                    "chain ID mismatch: --l2-chain-id is {} but {} contains {}",
                     self.l2_chain_id,
-                    rpc.l2_chain_id.id(),
+                    path.display(),
+                    cfg.l2_chain_id.id(),
                 ));
             }
 
-            let rpc_sc = rpc.genesis.system_config.as_ref();
+            let sc = cfg.genesis.system_config.as_ref();
             info!(
-                genesis_l1_hash = %rpc.genesis.l1.hash,
-                genesis_l1_number = rpc.genesis.l1.number,
-                genesis_l2_hash = %rpc.genesis.l2.hash,
-                genesis_l2_number = rpc.genesis.l2.number,
-                genesis_l2_time = rpc.genesis.l2_time,
-                block_time = rpc.block_time,
-                deposit_contract = %rpc.deposit_contract_address,
-                system_config_address = %rpc.l1_system_config_address,
-                batcher_address = %rpc_sc.map(|sc| sc.batcher_address.to_string()).unwrap_or_default(),
-                gas_limit = rpc_sc.map(|sc| sc.gas_limit).unwrap_or_default(),
-                scalar = %rpc_sc.map(|sc| sc.scalar).unwrap_or_default(),
-                "using rollup config from L2 node RPC"
+                path = %path.display(),
+                genesis_l1_hash = %cfg.genesis.l1.hash,
+                genesis_l1_number = cfg.genesis.l1.number,
+                genesis_l2_hash = %cfg.genesis.l2.hash,
+                genesis_l2_number = cfg.genesis.l2.number,
+                genesis_l2_time = cfg.genesis.l2_time,
+                block_time = cfg.block_time,
+                deposit_contract = %cfg.deposit_contract_address,
+                system_config_address = %cfg.l1_system_config_address,
+                batcher_address = %sc.map(|sc| sc.batcher_address.to_string()).unwrap_or_default(),
+                gas_limit = sc.map(|sc| sc.gas_limit).unwrap_or_default(),
+                scalar = %sc.map(|sc| sc.scalar).unwrap_or_default(),
+                "using rollup config from file"
             );
 
-            rpc
+            cfg
         } else {
             rollup_config!(self.l2_chain_id)
                 .ok_or_else(|| eyre!("unknown L2 chain ID: {}", self.l2_chain_id))?
@@ -321,7 +316,7 @@ impl Cli {
                 let _ = cancel;
 
                 match command {
-                    Command::ConfigHash(args) => args.run().await,
+                    Command::ConfigHash(args) => args.run(),
                     #[cfg(target_os = "linux")]
                     Command::Server(args) => args.run(cancel).await,
                     #[cfg(feature = "local")]
@@ -407,7 +402,7 @@ async fn run_worker(
 ) -> eyre::Result<()> {
     let registration_health = runtime.registration_health_config();
     let registry_configured = registration_health.is_some();
-    let config = runtime.prover_config().await?;
+    let config = runtime.prover_config()?;
 
     if transports.is_empty() {
         return Err(eyre!("at least one enclave transport is required"));
@@ -514,65 +509,85 @@ enum WorkerTransportMode {
     Local,
 }
 
-async fn fetch_rollup_config_from_rpc(
-    cl_url: &str,
-) -> eyre::Result<base_common_genesis::RollupConfig> {
-    let provider = ProviderBuilder::new()
-        .connect(cl_url)
-        .await
-        .map_err(|e| eyre!("failed to connect to L2 CL node at {cl_url}: {e}"))?;
-
-    provider.raw_request("optimism_rollupConfig".into(), ()).await.map_err(|e| {
-        eyre!(
-            "optimism_rollupConfig RPC failed on {cl_url}: {e}. \
-                 Ensure the L2 node supports this method"
-        )
-    })
+fn load_rollup_config(path: &Path) -> eyre::Result<base_common_genesis::RollupConfig> {
+    let file = File::open(path)
+        .map_err(|e| eyre!("failed to open rollup config file {}: {e}", path.display()))?;
+    serde_json::from_reader(file)
+        .map_err(|e| eyre!("failed to parse rollup config file {}: {e}", path.display()))
 }
 
-#[cfg(all(test, feature = "local"))]
+#[cfg(test)]
 mod tests {
-    use super::ProverRuntimeArgs;
+    use alloy_primitives::b256;
+    use base_common_chains::rollup_config;
 
-    fn args(l1_beacon_url: Option<&str>, l1_calldata_only: bool) -> ProverRuntimeArgs {
-        ProverRuntimeArgs {
-            l1_eth_url: "http://localhost:8545".to_string(),
-            l2_eth_url: "http://localhost:9545".to_string(),
-            l2_node_url: "http://localhost:9546".to_string(),
-            l1_beacon_url: l1_beacon_url.map(str::to_string),
-            l1_calldata_only,
-            l2_chain_id: 8453,
-            enable_experimental_witness_endpoint: false,
-            tee_prover_registry_address: None,
-            fetch_rollup_config: false,
-            l2_cl_url: None,
+    use super::{PerChainConfig, load_rollup_config};
+
+    /// The config hash computed from a `rollup.json` file must be byte-identical to the value
+    /// the enclave derives on the proving path (`server.rs` `config_hash`) for the same chain.
+    /// Round-trips a built-in config through JSON to exercise the file loader end to end.
+    #[test]
+    fn config_hash_from_file_matches_enclave_value() {
+        let rollup = rollup_config!(8453).expect("base mainnet rollup config");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("rollup.json");
+        std::fs::write(&path, serde_json::to_vec(&rollup).expect("serialize rollup config"))
+            .expect("write rollup config");
+
+        let loaded = load_rollup_config(&path).expect("load rollup config");
+        let mut per_chain =
+            PerChainConfig::from_rollup_config(&loaded).expect("per-chain config from rollup");
+        per_chain.force_defaults();
+
+        assert_eq!(
+            per_chain.hash(),
+            b256!("1607709d90d40904f790574404e2ad614eac858f6162faa0ec34c6bf5e5f3c57"),
+        );
+    }
+
+    #[cfg(any(target_os = "linux", feature = "local"))]
+    mod runtime_args {
+        use super::super::ProverRuntimeArgs;
+
+        fn args(l1_beacon_url: Option<&str>, l1_calldata_only: bool) -> ProverRuntimeArgs {
+            ProverRuntimeArgs {
+                l1_eth_url: "http://localhost:8545".to_string(),
+                l2_eth_url: "http://localhost:9545".to_string(),
+                l2_node_url: "http://localhost:9546".to_string(),
+                l1_beacon_url: l1_beacon_url.map(str::to_string),
+                l1_calldata_only,
+                l2_chain_id: 8453,
+                enable_experimental_witness_endpoint: false,
+                tee_prover_registry_address: None,
+                rollup_config: None,
+            }
         }
-    }
 
-    #[test]
-    fn beacon_mode_is_valid() {
-        let l1_beacon_url = args(Some("http://localhost:5052"), false).l1_beacon_url().unwrap();
-        assert_eq!(l1_beacon_url, Some("http://localhost:5052".to_string()));
-    }
+        #[test]
+        fn beacon_mode_is_valid() {
+            let l1_beacon_url = args(Some("http://localhost:5052"), false).l1_beacon_url().unwrap();
+            assert_eq!(l1_beacon_url, Some("http://localhost:5052".to_string()));
+        }
 
-    #[test]
-    fn calldata_only_mode_is_valid() {
-        let l1_beacon_url = args(None, true).l1_beacon_url().unwrap();
-        assert_eq!(l1_beacon_url, None);
-    }
+        #[test]
+        fn calldata_only_mode_is_valid() {
+            let l1_beacon_url = args(None, true).l1_beacon_url().unwrap();
+            assert_eq!(l1_beacon_url, None);
+        }
 
-    #[test]
-    fn neither_mode_is_an_error() {
-        assert!(args(None, false).l1_beacon_url().is_err());
-    }
+        #[test]
+        fn neither_mode_is_an_error() {
+            assert!(args(None, false).l1_beacon_url().is_err());
+        }
 
-    #[test]
-    fn both_modes_are_an_error() {
-        assert!(args(Some("http://localhost:5052"), true).l1_beacon_url().is_err());
-    }
+        #[test]
+        fn both_modes_are_an_error() {
+            assert!(args(Some("http://localhost:5052"), true).l1_beacon_url().is_err());
+        }
 
-    #[test]
-    fn empty_beacon_url_is_treated_as_missing() {
-        assert!(args(Some("  "), false).l1_beacon_url().is_err());
+        #[test]
+        fn empty_beacon_url_is_treated_as_missing() {
+            assert!(args(Some("  "), false).l1_beacon_url().is_err());
+        }
     }
 }

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -254,7 +254,7 @@ services:
   # Post-genesis dev-multiproof registration — two ordered one-shots.
   # AggregateVerifier.CONFIG_HASH is immutable and depends on the L2 rollup config, which only
   # exists after genesis, so SystemDeploy defers the verifier (MULTIPROOF_DEFER_REGISTRATION).
-  # 1) compute-config-hash: read the real hash from the running op-node.
+  # 1) compute-config-hash: compute the hash from the committed rollup config file (no node).
   # 2) register-aggregate-verifier: deploy + register the verifier with that hash.
   # base-l1 profile only: this flow is specific to the L3 / dev-multiproof devnet. In eth-l1 mode
   # multiproof is disabled and the deploy is not deferred, so these services are not created.
@@ -266,8 +266,6 @@ services:
     container_name: compute-config-hash
     profiles: ["base-l1"]
     depends_on:
-      base-builder:
-        condition: service_healthy
       patch-genesis-hash:
         condition: service_completed_successfully
     volumes:
@@ -275,7 +273,7 @@ services:
       - ../../etc/scripts/devnet/compute-config-hash.sh:/compute-config-hash.sh:ro
     user: root
     environment:
-      - L2_CL_URL=http://base-builder:${L2_BUILDER_CL_RPC_PORT}
+      - ROLLUP_CONFIG=/configs/rollup.json
       - OUTPUT_DIR=/configs
     entrypoint: ["/bin/bash", "/compute-config-hash.sh"]
     restart: on-failure
@@ -752,9 +750,10 @@ services:
   # prover_prove JSON-RPC on :8000. L3 (base-l1) only. Runs the enclave in-process and signs with
   # BASE_ENCLAVE_SIGNER_KEY — which must equal DEV_TEE_SIGNER_KEY (the key behind DEV_TEE_SIGNER
   # registered on-chain during SystemDeploy); otherwise proofs are signed by a random key and fail
-  # on-chain verification. FETCH_ROLLUP_CONFIG + L2_CL_URL make it derive the rollup config (and
-  # thus the config hash) from the live op-node, so the ephemeral L2 chain id works without a
-  # built-in config. L1_BEACON_URL is intentionally unset so the entrypoint selects calldata-only.
+  # on-chain verification. ROLLUP_CONFIG points it at the committed rollup.json so it resolves the
+  # rollup config (and thus the config hash) from the file — letting the ephemeral L2 chain id work
+  # without a built-in config or a running op-node. L1_BEACON_URL is intentionally unset so the
+  # entrypoint selects calldata-only.
   nitro-local:
     image: nitro-host-local:local
     build:
@@ -765,13 +764,16 @@ services:
     depends_on:
       base-rpc:
         condition: service_healthy
+      patch-genesis-hash:
+        condition: service_completed_successfully
+    volumes:
+      - ../../.devnet/l2/configs:/configs
     environment:
       - LISTEN_ADDR=0.0.0.0:8000
       - L1_ETH_URL=http://l1-el:${L1_HTTP_PORT}
       - L2_ETH_URL=http://base-rpc:${L2_BASE_RPC_HTTP_PORT}
       - L2_CHAIN_ID=${L2_CHAIN_ID}
-      - FETCH_ROLLUP_CONFIG=true
-      - L2_CL_URL=http://base-rpc:${L2_BASE_RPC_CL_RPC_PORT}
+      - ROLLUP_CONFIG=/configs/rollup.json
       - BASE_ENCLAVE_SIGNER_KEY=${DEV_TEE_SIGNER_KEY}
     healthcheck:
       test: ["CMD", "bash", "-c", "echo > /dev/tcp/localhost/8000"]

--- a/etc/scripts/devnet/compute-config-hash.sh
+++ b/etc/scripts/devnet/compute-config-hash.sh
@@ -3,27 +3,27 @@ set -euo pipefail
 
 # compute-config-hash.sh — first of two post-genesis one-shots for dev multiproof.
 #
-# Resolves the multiproof CONFIG_HASH from the running op-node and writes it to the shared
-# volume for register-aggregate-verifier.sh to consume. Uses `nitro-host config-hash`, which
-# fetches the rollup config via `optimism_rollupConfig` and hashes it with the same
+# Computes the multiproof CONFIG_HASH from the committed rollup config file and writes it to
+# the shared volume for register-aggregate-verifier.sh to consume. Uses `nitro-host
+# config-hash`, which reads the rollup config from `rollup.json` and hashes it with the same
 # PerChainConfig encoding the enclave uses — so the value is exactly what the on-chain
 # AggregateVerifier.CONFIG_HASH must be.
 #
 # Runs inside the nitro-host-local image (which ships the binary at /app/base-prover-nitro-host).
 
-L2_CL_URL="${L2_CL_URL:-http://base-builder-cl:7549}"
 OUTPUT_DIR="${OUTPUT_DIR:-/configs}"
+ROLLUP_CONFIG="${ROLLUP_CONFIG:-$OUTPUT_DIR/rollup.json}"
 HASH_FILE="${HASH_FILE:-$OUTPUT_DIR/multiproof-config-hash}"
 NITRO_HOST="${NITRO_HOST:-/app/base-prover-nitro-host}"
 
 echo "=== Compute multiproof config hash ==="
-echo "L2 CL URL:  $L2_CL_URL"
-echo "Hash file:  $HASH_FILE"
+echo "Rollup config: $ROLLUP_CONFIG"
+echo "Hash file:     $HASH_FILE"
 
 mkdir -p "$OUTPUT_DIR"
 
 # config-hash prints only the hash to stdout; grep guards against any incidental log output.
-HASH="$("$NITRO_HOST" config-hash --l2-cl-url "$L2_CL_URL" | grep -oiE '0x[0-9a-f]{64}' | tail -n1)"
+HASH="$("$NITRO_HOST" config-hash --rollup-config "$ROLLUP_CONFIG" | grep -oiE '0x[0-9a-f]{64}' | tail -n1)"
 if ! [[ "$HASH" =~ ^0x[0-9a-fA-F]{64}$ ]]; then
   echo "ERROR: failed to compute a valid config hash (got: '$HASH')"
   exit 1


### PR DESCRIPTION
## Summary

`nitro-host config-hash` and the `server`/`local` runtime now resolve the rollup
config from a `rollup.json` file instead of fetching it from op-node over
`optimism_rollupConfig`. The config hash is a pure function of the rollup config,
so computing it no longer requires a running node.

Linear: [PRIV-2067](https://linear.app/coinbase/issue/PRIV-2067/nitro-host-config-hash-compute-from-a-rollup-config-file-offline-not)

## Why

This unblocks the node-free, offline contract-deploy and genesis flow for the L3
devnet (PRIV-2064), and lets a permissionless L3 deployer compute their own
`CONFIG_HASH` without standing up infrastructure. The registered value stays
byte-identical to what the enclave derives from `boot_info.rollup_config`, so the
on-chain `proof.config_hash == CONFIG_HASH` check is unchanged. A wrong file is a
fail-safe hash mismatch (loud liveness failure), not a soundness break.

## Changes

- `config-hash`: `--l2-cl-url` -> `--rollup-config <path>` (env `ROLLUP_CONFIG`),
  reading `rollup.json` via `serde_json::from_reader`. Same
  `PerChainConfig::from_rollup_config(..).force_defaults().hash()` pipeline and the
  "missing system_config" error.
- Runtime (`server`/`local`): `--fetch-rollup-config` + `--l2-cl-url` -> optional
  `--rollup-config`; falls back to the built-in chain table when unset.
- Drops `fetch_rollup_config_from_rpc` and the `alloy-provider` dependency.
- Devnet: `compute-config-hash.sh` and the `compute-config-hash` / `nitro-local`
  compose services read the committed `rollup.json`, removing their dependency on a
  running node.

The removed `--l2-cl-url` / `--fetch-rollup-config` flags are l3-only (not present
on base/main), so this is not a breaking change upstream. Both in-tree callers are
updated.

## Testing

- `cargo test -p base-prover-nitro-host` (default + `--features local`) pass.
- `cargo clippy` default clean; `cargo fmt --check` clean.
- `config-hash --help` shows `--rollup-config`; `docker compose --profile base-l1 config` valid.
- Serde parity is already load-bearing: `base-builder` / `base-rpc` load the same
  `rollup.json` into the same `RollupConfig` type via `--l2-config-file`.

Not yet run: full devnet `base-l1` e2e (one-shots + `nitro-local` come up node-free,
`register-aggregate-verifier` / `smoke.sh` pass).