### PR TITLE
ci: pin base-anvil to d3bdb810 (revm 41 / alloy-evm 0.37)

### DIFF
--- a/.github/workflows/base-anvil-package.yml
+++ b/.github/workflows/base-anvil-package.yml
@@ -9,7 +9,7 @@ on:
       base_anvil_ref:
         description: "base/base-anvil ref to build from"
         required: false
-        default: 0092692587d8d064dd2c6923ce26a682c58f3694
+        default: d3bdb810084e510acd1a57c63b1bcf8b801db40a
       base_std_ref:
         description: "base/base-std ref to smoke test against"
         required: false
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  BASE_ANVIL_REF: ${{ github.event.inputs.base_anvil_ref || '0092692587d8d064dd2c6923ce26a682c58f3694' }}
+  BASE_ANVIL_REF: ${{ github.event.inputs.base_anvil_ref || 'd3bdb810084e510acd1a57c63b1bcf8b801db40a' }}
   BASE_STD_REF: ${{ github.event.inputs.base_std_ref || 'main' }}
   CARGO_TERM_COLOR: always
   REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/base-anvil
@@ -355,7 +355,7 @@ jobs:
           primary_tag="sha-$GITHUB_SHA"
           tags=("$REGISTRY_IMAGE:$primary_tag")
 
-          if [[ "$GITHUB_REF_NAME" == "main" && "$BASE_ANVIL_REF" == "0092692587d8d064dd2c6923ce26a682c58f3694" && "$BASE_STD_REF" == "main" ]]; then
+          if [[ "$GITHUB_REF_NAME" == "main" && "$BASE_ANVIL_REF" == "d3bdb810084e510acd1a57c63b1bcf8b801db40a" && "$BASE_STD_REF" == "main" ]]; then
             tags+=("$REGISTRY_IMAGE:main")
             tags+=("$REGISTRY_IMAGE:main-$commit_date-$short_sha")
           else

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -32,7 +32,7 @@ jobs:
           # recorded in the result artifact and PR comment.
           - fork: Beryl
             key: beryl
-            base_anvil_ref: v1.1.1
+            base_anvil_ref: d3bdb810084e510acd1a57c63b1bcf8b801db40a
             base_std_ref: v1.0.0
     env:
       FORK_NAME: ${{ matrix.fork }}


### PR DESCRIPTION

## Problem

The Base Std fork tests (Beryl snapshot) fail on every PR and main push since base/base was bumped to Reth 2.4. The workflow builds base-anvil from source with the current base/base crates patched in, and the pinned ref v1.1.1 still targets revm 40 — so the patched build no longer compiles. The base-anvil package workflow pins an even older SHA and breaks the same way.

## Fix

Bump both workflows to [base/base-anvil@d3bdb810](https://github.com/base/base-anvil/commit/d3bdb810084e510acd1a57c63b1bcf8b801db40a), the base-anvil-fork head carrying the companion dependency bump (base/base-anvil#55: revm 40.0.3 → 41.0.0, alloy-evm 0.36 → 0.37, revm-inspectors 0.40.1 → 0.41.1).
