### PR TITLE
test(consensus): expect genesis on pruned history fallback

### DIFF
--- a/etc/systems/tests/consensus_pruned_history.rs
+++ b/etc/systems/tests/consensus_pruned_history.rs
@@ -79,8 +79,8 @@ impl ForkchoiceCheckpointReader for StaticCheckpointReader {
 /// A validator seeds its unsafe head from reth, accepts its first unsafe payload, then performs the
 /// initial reset after EL sync completes. Some pruned reth nodes return `4444: pruned history
 /// unavailable` for full historical labeled-block requests during that reset. The consensus
-/// service should treat the labeled block as unavailable and continue startup instead of exiting
-/// the engine processor.
+/// service should treat the labeled block as unavailable, fall back to genesis, and continue
+/// startup instead of exiting the engine processor.
 ///
 /// The observed failure mode is an engine task exit with
 /// `EngineReset(SyncStart(RpcError(...)))`.
@@ -99,6 +99,7 @@ struct PrunedHistoryStartup {
     rollup: Arc<RollupConfig>,
     client: Arc<MockEngineClient>,
     checkpointed_finalized_head: L2BlockInfo,
+    genesis_head: L2BlockInfo,
     reth_latest_head: L2BlockInfo,
     next_unsafe_hash: B256,
 }
@@ -107,6 +108,7 @@ impl PrunedHistoryStartup {
     fn new() -> Self {
         let rollup = test_rollup_config();
         let genesis_block = genesis_l2_block();
+        let genesis_head = block_info_from_rpc_block(&genesis_block);
         let finalized_block = pruned_l2_block(FINALIZED_BLOCK_NUMBER, rollup.genesis.l2.hash);
         let checkpointed_finalized_head = block_info_from_rpc_block(&finalized_block);
         let finalized_block_by_hash =
@@ -140,7 +142,14 @@ impl PrunedHistoryStartup {
                 .build(),
         );
 
-        Self { rollup, client, checkpointed_finalized_head, reth_latest_head, next_unsafe_hash }
+        Self {
+            rollup,
+            client,
+            checkpointed_finalized_head,
+            genesis_head,
+            reth_latest_head,
+            next_unsafe_hash,
+        }
     }
 
     fn start_validator_processor(self) -> RunningValidatorProcessor {
@@ -167,7 +176,7 @@ impl PrunedHistoryStartup {
             state_rx,
             request_tx,
             handle,
-            checkpointed_finalized_head: self.checkpointed_finalized_head,
+            genesis_head: self.genesis_head,
             reth_latest_head: self.reth_latest_head,
             next_unsafe_hash: self.next_unsafe_hash,
         }
@@ -178,7 +187,7 @@ struct RunningValidatorProcessor {
     state_rx: watch::Receiver<EngineState>,
     request_tx: mpsc::Sender<EngineActorRequest>,
     handle: JoinHandle<Result<(), EngineError>>,
-    checkpointed_finalized_head: L2BlockInfo,
+    genesis_head: L2BlockInfo,
     reth_latest_head: L2BlockInfo,
     next_unsafe_hash: B256,
 }
@@ -207,8 +216,8 @@ impl RunningValidatorProcessor {
     async fn assert_completes_initial_reset(&mut self) {
         let wait_for_reset = self.state_rx.wait_for(|state| {
             state.el_sync_finished
-                && state.sync_state.safe_head() == self.checkpointed_finalized_head
-                && state.sync_state.finalized_head() == self.checkpointed_finalized_head
+                && state.sync_state.safe_head() == self.genesis_head
+                && state.sync_state.finalized_head() == self.genesis_head
         });
 
         tokio::select! {


### PR DESCRIPTION
## Summary

Fix `validator_initial_reset_survives_pruned_history_unavailable_from_reth` to assert the behavior implemented by the sync-start path. When reth returns EIP-4444 `pruned history unavailable`, the labeled block is treated as unavailable and the initial reset falls back to genesis.

The previous assertion expected the persisted checkpoint even though that path requires a labeled block header for checkpoint validation, causing a deterministic timeout.