### PR TITLE
fix(websocket-proxy): peel trusted hops when resolving client IPs

### DIFF
--- a/bin/websocket-proxy/src/main.rs
+++ b/bin/websocket-proxy/src/main.rs
@@ -84,7 +84,7 @@ struct Args {
         long,
         env,
         value_delimiter = ',',
-        help = "Proxy CIDRs trusted to provide the client IP header"
+        help = "Proxy CIDRs trusted when resolving client IPs; include every forwarding hop"
     )]
     trusted_proxy_cidrs: Vec<IpNet>,
 

--- a/crates/infra/websocket-proxy/README.md
+++ b/crates/infra/websocket-proxy/README.md
@@ -39,8 +39,8 @@ Forwarded client IP headers are ignored by default. Configure `--trusted-proxy-c
 trusted proxy in the forwarding chain. The direct peer must be trusted before the header selected
 by `--ip-addr-http-header` (default: `X-Forwarded-For`) is read.
 
-The header is scanned right to left, skipping trusted proxies and using the first untrusted IP.
-Without trusted CIDRs, connection limits use the direct peer IP.
+All forwarding-header lines are joined, then scanned right to left, skipping trusted proxies and
+using the first untrusted IP. Without trusted CIDRs, connection limits use the direct peer IP.
 
 ## For Developers
 

--- a/crates/infra/websocket-proxy/README.md
+++ b/crates/infra/websocket-proxy/README.md
@@ -39,8 +39,9 @@ Forwarded client IP headers are ignored by default. Configure `--trusted-proxy-c
 trusted proxy in the forwarding chain. The direct peer must be trusted before the header selected
 by `--ip-addr-http-header` (default: `X-Forwarded-For`) is read.
 
-All forwarding-header lines are joined, then scanned right to left, skipping trusted proxies and
-using the first untrusted IP. Without trusted CIDRs, connection limits use the direct peer IP.
+All forwarding-header lines and comma-separated entries are scanned right to left, skipping
+trusted proxies and using the first untrusted IP. Without trusted CIDRs, connection limits use
+the direct peer IP.
 
 ## For Developers
 

--- a/crates/infra/websocket-proxy/README.md
+++ b/crates/infra/websocket-proxy/README.md
@@ -25,7 +25,7 @@ websocket-proxy --upstream-ws ws://sequencer:9000
 # Enable Brotli compression for downstream clients
 websocket-proxy --upstream-ws ws://sequencer:9000 --enable-compression
 
-# Trust client IP forwarding only from the load balancer network
+# Trust client IP forwarding from a proxy network
 websocket-proxy \
   --upstream-ws ws://sequencer:9000 \
   --trusted-proxy-cidrs 10.0.0.0/8
@@ -35,15 +35,12 @@ Run `websocket-proxy --help` for a full list of parameters.
 
 ### Trusted Proxies
 
-Forwarded client IP headers are ignored by default. When the proxy runs behind a load balancer,
-configure `--trusted-proxy-cidrs` with the load balancer networks allowed to provide the header
-selected by `--ip-addr-http-header` (default: `X-Forwarded-For`). Multiple CIDRs can be separated
-with commas. Only proxies that connect directly to the WebSocket proxy need to be listed.
+Forwarded client IP headers are ignored by default. Configure `--trusted-proxy-cidrs` with every
+trusted proxy in the forwarding chain. The direct peer must be trusted before the header selected
+by `--ip-addr-http-header` (default: `X-Forwarded-For`) is read.
 
-Only include networks dedicated to trusted proxies. If no trusted CIDRs are configured, connection
-limits use the TCP peer IP; behind a load balancer, that means clients share the load balancer's
-per-IP connection limit. Trusted proxies must append the connecting client IP to the header or
-replace any client-supplied value.
+The header is scanned right to left, skipping trusted proxies and using the first untrusted IP.
+Without trusted CIDRs, connection limits use the direct peer IP.
 
 ## For Developers
 

--- a/crates/infra/websocket-proxy/src/server.rs
+++ b/crates/infra/websocket-proxy/src/server.rs
@@ -42,17 +42,18 @@ impl TrustedProxyConfig {
     }
 
     /// Resolves the client IP, trusting forwarding headers only from configured proxy CIDRs.
+    ///
+    /// Uses the last header line, then peels trusted hops right → left until the first
+    /// untrusted IP (`Client → CDN → ALB → service`).
     pub fn client_ip(&self, connect_addr: IpAddr, headers: &HeaderMap) -> IpAddr {
         // Dual-stack listeners present IPv4 peers as IPv4-mapped IPv6 (`::ffff:x.x.x.x`).
-        // Canonicalize so IPv4 CIDRs still match those peers and rate-limit buckets stay
-        // consistent across address forms.
         let connect_addr = Self::canonicalize_ip(connect_addr);
 
-        if !self.trusted_proxy_cidrs.iter().any(|cidr| cidr.contains(&connect_addr)) {
+        if !self.is_trusted(connect_addr) {
             return connect_addr;
         }
 
-        let Some(header) = headers.get(&self.ip_addr_http_header) else {
+        let Some(header) = headers.get_all(&self.ip_addr_http_header).iter().next_back() else {
             return connect_addr;
         };
 
@@ -64,24 +65,35 @@ impl TrustedProxyConfig {
             }
         };
 
-        header_value
-            .split(',')
-            .next_back()
-            .and_then(|ip| {
-                let trimmed = ip.trim();
-                match trimmed.parse::<IpAddr>() {
-                    Ok(addr) => Some(Self::canonicalize_ip(addr)),
-                    Err(error) => {
-                        warn!(
-                            error = %error,
-                            value = %trimmed,
-                            "Failed to parse forwarded client IP"
-                        );
-                        None
+        for raw in header_value.split(',').rev() {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            match trimmed.parse::<IpAddr>() {
+                Ok(addr) => {
+                    let addr = Self::canonicalize_ip(addr);
+                    if !self.is_trusted(addr) {
+                        return addr;
                     }
                 }
-            })
-            .unwrap_or(connect_addr)
+                Err(error) => {
+                    warn!(
+                        error = %error,
+                        value = %trimmed,
+                        "Failed to parse forwarded client IP"
+                    );
+                    return connect_addr;
+                }
+            }
+        }
+
+        connect_addr
+    }
+
+    fn is_trusted(&self, addr: IpAddr) -> bool {
+        self.trusted_proxy_cidrs.iter().any(|cidr| cidr.contains(&addr))
     }
 
     fn canonicalize_ip(addr: IpAddr) -> IpAddr {
@@ -437,6 +449,55 @@ mod tests {
 
         headers.clear();
         assert_eq!(config.client_ip(trusted_proxy, &headers), trusted_proxy);
+    }
+
+    #[test]
+    fn trusted_proxy_config_skips_trusted_hops_in_xff() {
+        let config = TrustedProxyConfig::new(
+            "x-forwarded-for".to_string(),
+            vec!["10.0.0.0/8".parse().unwrap(), "104.16.0.0/13".parse().unwrap()],
+        );
+        let alb = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let client = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10));
+
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", HeaderValue::from_static("203.0.113.10, 104.16.1.1"));
+        assert_eq!(config.client_ip(alb, &headers), client);
+
+        let alb_only = TrustedProxyConfig::new(
+            "x-forwarded-for".to_string(),
+            vec!["10.0.0.0/8".parse().unwrap()],
+        );
+        let cdn = IpAddr::V4(Ipv4Addr::new(104, 16, 1, 1));
+        assert_eq!(alb_only.client_ip(alb, &headers), cdn);
+
+        headers.insert(
+            "x-forwarded-for",
+            HeaderValue::from_static("198.51.100.1, 203.0.113.10, 104.16.1.1"),
+        );
+        assert_eq!(config.client_ip(alb, &headers), client);
+
+        headers.insert(
+            "x-forwarded-for",
+            HeaderValue::from_static("198.51.100.1, invalid, 104.16.1.1"),
+        );
+        assert_eq!(config.client_ip(alb, &headers), alb);
+    }
+
+    #[test]
+    fn last_header_occurrence_wins_over_spoofed_first_line() {
+        let config = TrustedProxyConfig::new(
+            "x-forwarded-for".to_string(),
+            vec!["10.0.0.0/8".parse().unwrap(), "104.16.0.0/13".parse().unwrap()],
+        );
+        let alb = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let client = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10));
+
+        let mut headers = HeaderMap::new();
+        headers.append("x-forwarded-for", HeaderValue::from_static("198.51.100.1"));
+        headers.append("x-forwarded-for", HeaderValue::from_static("203.0.113.10, 104.16.1.1"));
+
+        assert_eq!(config.client_ip(alb, &headers), client);
     }
 
     #[test]

--- a/crates/infra/websocket-proxy/src/server.rs
+++ b/crates/infra/websocket-proxy/src/server.rs
@@ -43,8 +43,8 @@ impl TrustedProxyConfig {
 
     /// Resolves the client IP, trusting forwarding headers only from configured proxy CIDRs.
     ///
-    /// Uses the last header line, then peels trusted hops right → left until the first
-    /// untrusted IP (`Client → CDN → ALB → service`).
+    /// Joins all forwarding-header lines (proxies may append within a value or add a new
+    /// line), then peels trusted hops right → left until the first untrusted IP.
     pub fn client_ip(&self, connect_addr: IpAddr, headers: &HeaderMap) -> IpAddr {
         // Dual-stack listeners present IPv4 peers as IPv4-mapped IPv6 (`::ffff:x.x.x.x`).
         let connect_addr = Self::canonicalize_ip(connect_addr);
@@ -53,17 +53,20 @@ impl TrustedProxyConfig {
             return connect_addr;
         }
 
-        let Some(header) = headers.get_all(&self.ip_addr_http_header).iter().next_back() else {
-            return connect_addr;
-        };
-
-        let header_value = match header.to_str() {
-            Ok(header_value) => header_value,
-            Err(error) => {
-                warn!(error = %error, "Could not read client IP header");
-                return connect_addr;
+        let mut values = Vec::new();
+        for header in headers.get_all(&self.ip_addr_http_header) {
+            match header.to_str() {
+                Ok(value) => values.push(value),
+                Err(error) => {
+                    warn!(error = %error, "Could not read client IP header");
+                    return connect_addr;
+                }
             }
-        };
+        }
+        if values.is_empty() {
+            return connect_addr;
+        }
+        let header_value = values.join(", ");
 
         for raw in header_value.split(',').rev() {
             let trimmed = raw.trim();
@@ -485,7 +488,7 @@ mod tests {
     }
 
     #[test]
-    fn last_header_occurrence_wins_over_spoofed_first_line() {
+    fn joins_header_lines_before_peeling_trusted_hops() {
         let config = TrustedProxyConfig::new(
             "x-forwarded-for".to_string(),
             vec!["10.0.0.0/8".parse().unwrap(), "104.16.0.0/13".parse().unwrap()],
@@ -493,9 +496,11 @@ mod tests {
         let alb = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
         let client = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10));
 
+        // Client-spoofed line, CDN-appended client, ALB-added CDN hop as a new line.
         let mut headers = HeaderMap::new();
         headers.append("x-forwarded-for", HeaderValue::from_static("198.51.100.1"));
-        headers.append("x-forwarded-for", HeaderValue::from_static("203.0.113.10, 104.16.1.1"));
+        headers.append("x-forwarded-for", HeaderValue::from_static("203.0.113.10"));
+        headers.append("x-forwarded-for", HeaderValue::from_static("104.16.1.1"));
 
         assert_eq!(config.client_ip(alb, &headers), client);
     }

--- a/crates/infra/websocket-proxy/src/server.rs
+++ b/crates/infra/websocket-proxy/src/server.rs
@@ -43,8 +43,9 @@ impl TrustedProxyConfig {
 
     /// Resolves the client IP, trusting forwarding headers only from configured proxy CIDRs.
     ///
-    /// Joins all forwarding-header lines (proxies may append within a value or add a new
-    /// line), then peels trusted hops right → left until the first untrusted IP.
+    /// Walks all forwarding-header lines and comma-separated entries right → left (proxies
+    /// may append within a value or add a new line), peeling trusted hops until the first
+    /// untrusted IP.
     pub fn client_ip(&self, connect_addr: IpAddr, headers: &HeaderMap) -> IpAddr {
         // Dual-stack listeners present IPv4 peers as IPv4-mapped IPv6 (`::ffff:x.x.x.x`).
         let connect_addr = Self::canonicalize_ip(connect_addr);
@@ -53,41 +54,36 @@ impl TrustedProxyConfig {
             return connect_addr;
         }
 
-        let mut values = Vec::new();
-        for header in headers.get_all(&self.ip_addr_http_header) {
-            match header.to_str() {
-                Ok(value) => values.push(value),
+        for header in headers.get_all(&self.ip_addr_http_header).iter().rev() {
+            let header_value = match header.to_str() {
+                Ok(value) => value,
                 Err(error) => {
                     warn!(error = %error, "Could not read client IP header");
                     return connect_addr;
                 }
-            }
-        }
-        if values.is_empty() {
-            return connect_addr;
-        }
-        let header_value = values.join(", ");
+            };
 
-        for raw in header_value.split(',').rev() {
-            let trimmed = raw.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-
-            match trimmed.parse::<IpAddr>() {
-                Ok(addr) => {
-                    let addr = Self::canonicalize_ip(addr);
-                    if !self.is_trusted(addr) {
-                        return addr;
-                    }
+            for raw in header_value.split(',').rev() {
+                let trimmed = raw.trim();
+                if trimmed.is_empty() {
+                    continue;
                 }
-                Err(error) => {
-                    warn!(
-                        error = %error,
-                        value = %trimmed,
-                        "Failed to parse forwarded client IP"
-                    );
-                    return connect_addr;
+
+                match trimmed.parse::<IpAddr>() {
+                    Ok(addr) => {
+                        let addr = Self::canonicalize_ip(addr);
+                        if !self.is_trusted(addr) {
+                            return addr;
+                        }
+                    }
+                    Err(error) => {
+                        warn!(
+                            error = %error,
+                            value = %trimmed,
+                            "Failed to parse forwarded client IP"
+                        );
+                        return connect_addr;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Fix client IP extraction behind multi-hop proxies (`Client → CDN → ALB → service`) by peeling trusted hops right-to-left instead of taking the rightmost XFF entry.
- Prefer the last forwarding-header line so a client-spoofed first line cannot win.
- Document that `--trusted-proxy-cidrs` must include every hop in the forwarding chain.