### PR TITLE
refactor: rename Zombie → Zenith hardfork

### DIFF
--- a/crates/common/chains/src/chain.rs
+++ b/crates/common/chains/src/chain.rs
@@ -121,7 +121,7 @@ impl Index<EthereumHardfork> for ChainUpgrades {
 mod tests {
     use BaseUpgrade::{
         Azul, Bedrock, Beryl, Canyon, Cobalt, Ecotone, Fjord, Granite, Holocene, Isthmus, Jovian,
-        Regolith, Zombie,
+        Regolith, Zenith,
     };
     use alloy_hardforks::EthereumHardfork;
 
@@ -176,7 +176,7 @@ mod tests {
             ForkCondition::Timestamp(ChainConfig::mainnet().beryl_timestamp.unwrap())
         );
         assert_eq!(base_mainnet_forks[Cobalt], ForkCondition::Never);
-        assert_eq!(base_mainnet_forks[Zombie], ForkCondition::Never);
+        assert_eq!(base_mainnet_forks[Zenith], ForkCondition::Never);
     }
 
     #[test]
@@ -227,7 +227,7 @@ mod tests {
             ForkCondition::Timestamp(ChainConfig::sepolia().beryl_timestamp.unwrap())
         );
         assert_eq!(base_sepolia_forks[Cobalt], ForkCondition::Never);
-        assert_eq!(base_sepolia_forks[Zombie], ForkCondition::Never);
+        assert_eq!(base_sepolia_forks[Zenith], ForkCondition::Never);
     }
 
     #[test]
@@ -311,13 +311,13 @@ mod tests {
     }
 
     #[test]
-    fn is_zombie_active_at_timestamp() {
+    fn is_zenith_active_at_timestamp() {
         let base_mainnet_forks = ChainUpgrades::mainnet();
-        assert!(!base_mainnet_forks.is_zombie_active_at_timestamp(0));
-        assert!(!base_mainnet_forks.is_zombie_active_at_timestamp(u64::MAX));
+        assert!(!base_mainnet_forks.is_zenith_active_at_timestamp(0));
+        assert!(!base_mainnet_forks.is_zenith_active_at_timestamp(u64::MAX));
 
         let devnet_forks = ChainUpgrades::devnet();
-        assert!(!devnet_forks.is_zombie_active_at_timestamp(0));
+        assert!(!devnet_forks.is_zenith_active_at_timestamp(0));
     }
 
     #[test]

--- a/crates/common/chains/src/config.rs
+++ b/crates/common/chains/src/config.rs
@@ -325,7 +325,7 @@ impl ChainConfig {
                 azul: self.azul_timestamp,
                 beryl: self.beryl_timestamp,
                 cobalt: self.cobalt_timestamp,
-                zombie: None,
+                zenith: None,
             },
         }
     }

--- a/crates/common/chains/src/upgrade.rs
+++ b/crates/common/chains/src/upgrade.rs
@@ -56,7 +56,7 @@ impl BaseUpgradeExt for BaseUpgrade {
             | Self::Holocene
             | Self::PectraBlobSchedule => SpecId::CANCUN,
             Self::Isthmus | Self::Jovian => SpecId::PRAGUE,
-            // Azul, Beryl, Cobalt, Zombie, and newer Base upgrades inherit the latest known
+            // Azul, Beryl, Cobalt, Zenith, and newer Base upgrades inherit the latest known
             // Ethereum spec until explicitly mapped.
             _ => SpecId::OSAKA,
         }
@@ -126,7 +126,7 @@ mod tests {
     fn check_base_upgrade_from_str() {
         let upgrade_str = [
             "beDrOck", "rEgOlITH", "cAnYoN", "eCoToNe", "FJorD", "GRaNiTe", "hOlOcEnE", "isthMUS",
-            "jOvIaN", "aZuL", "bErYl", "cObAlT", "zOmBiE",
+            "jOvIaN", "aZuL", "bErYl", "cObAlT", "zEnItH",
         ];
         let expected_upgrades = [
             BaseUpgrade::Bedrock,
@@ -141,7 +141,7 @@ mod tests {
             BaseUpgrade::Azul,
             BaseUpgrade::Beryl,
             BaseUpgrade::Cobalt,
-            BaseUpgrade::Zombie,
+            BaseUpgrade::Zenith,
         ];
 
         let upgrades: alloc::vec::Vec<BaseUpgrade> =
@@ -224,7 +224,7 @@ mod tests {
             (BaseUpgrade::Azul, SpecId::OSAKA),
             (BaseUpgrade::Beryl, SpecId::OSAKA),
             (BaseUpgrade::Cobalt, SpecId::OSAKA),
-            (BaseUpgrade::Zombie, SpecId::OSAKA),
+            (BaseUpgrade::Zenith, SpecId::OSAKA),
         ];
 
         for (base_upgrade, eth_spec) in test_cases {
@@ -251,13 +251,13 @@ mod tests {
     }
 
     #[test]
-    fn zombie_is_genesis_only_not_l1_signal_backed() {
-        // Zombie activates via genesis config only: it is not contract-backed, not signalable
+    fn zenith_is_genesis_only_not_l1_signal_backed() {
+        // Zenith activates via genesis config only: it is not contract-backed, not signalable
         // via the L1 contract, and absent from both the contract-backed and execution sets.
-        assert!(!BaseUpgrade::Zombie.is_contract_backed());
-        assert_eq!(BaseUpgrade::from_contract_fork_name("zombie"), None);
-        assert!(!BaseUpgrade::CONTRACT_VARIANTS.contains(&BaseUpgrade::Zombie));
-        assert!(!BaseUpgrade::EXECUTION_VARIANTS.contains(&BaseUpgrade::Zombie));
+        assert!(!BaseUpgrade::Zenith.is_contract_backed());
+        assert_eq!(BaseUpgrade::from_contract_fork_name("zenith"), None);
+        assert!(!BaseUpgrade::CONTRACT_VARIANTS.contains(&BaseUpgrade::Zenith));
+        assert!(!BaseUpgrade::EXECUTION_VARIANTS.contains(&BaseUpgrade::Zenith));
     }
 
     #[test]

--- a/crates/common/chains/src/upgrades.rs
+++ b/crates/common/chains/src/upgrades.rs
@@ -79,11 +79,11 @@ pub trait Upgrades: EthereumHardforks {
         self.upgrade_activation(BaseUpgrade::Cobalt).active_at_timestamp(timestamp)
     }
 
-    /// Returns `true` if the [`Zombie`](BaseUpgrade::Zombie) gate is active at the given block
-    /// timestamp. Zombie is a permanently-off gate, so this always returns `false`; use it to
+    /// Returns `true` if the [`Zenith`](BaseUpgrade::Zenith) gate is active at the given block
+    /// timestamp. Zenith is a permanently-off gate, so this always returns `false`; use it to
     /// keep not-yet-ready features disabled behind a fork check like any other upgrade.
-    fn is_zombie_active_at_timestamp(&self, timestamp: u64) -> bool {
-        self.upgrade_activation(BaseUpgrade::Zombie).active_at_timestamp(timestamp)
+    fn is_zenith_active_at_timestamp(&self, timestamp: u64) -> bool {
+        self.upgrade_activation(BaseUpgrade::Zenith).active_at_timestamp(timestamp)
     }
 }
 
@@ -135,7 +135,7 @@ impl Upgrades for RollupConfig {
                 .contract_upgrade_activation_timestamp(BaseUpgrade::Cobalt)
                 .map(ForkCondition::Timestamp)
                 .unwrap_or(ForkCondition::Never),
-            // Contract-only upgrades (Delta, PectraBlobSchedule), the permanently-off Zombie gate,
+            // Contract-only upgrades (Delta, PectraBlobSchedule), the permanently-off Zenith gate,
             // and any future variants are absent from the execution fork ladder.
             _ => ForkCondition::Never,
         }
@@ -172,7 +172,7 @@ mod tests {
         assert_eq!(cfg.upgrade_activation(BaseUpgrade::Azul), ForkCondition::Never);
         assert_eq!(cfg.upgrade_activation(BaseUpgrade::Beryl), ForkCondition::Never);
         assert_eq!(cfg.upgrade_activation(BaseUpgrade::Cobalt), ForkCondition::Never);
-        assert_eq!(cfg.upgrade_activation(BaseUpgrade::Zombie), ForkCondition::Never);
+        assert_eq!(cfg.upgrade_activation(BaseUpgrade::Zenith), ForkCondition::Never);
     }
 
     #[cfg(feature = "std")]
@@ -194,15 +194,15 @@ mod tests {
             BaseUpgrade::Cobalt,
             ACTIVATION + 1,
         );
-        // Even a runtime override cannot activate the permanently-off Zombie gate.
-        RuntimeUpgradeRegistry::set_activation_timestamp(CHAIN_ID, BaseUpgrade::Zombie, u64::MAX);
+        // Even a runtime override cannot activate the permanently-off Zenith gate.
+        RuntimeUpgradeRegistry::set_activation_timestamp(CHAIN_ID, BaseUpgrade::Zenith, u64::MAX);
 
         assert_eq!(cfg.upgrade_activation(BaseUpgrade::Azul), ForkCondition::Timestamp(ACTIVATION));
         assert_eq!(
             cfg.upgrade_activation(BaseUpgrade::Cobalt),
             ForkCondition::Timestamp(ACTIVATION + 1)
         );
-        assert_eq!(cfg.upgrade_activation(BaseUpgrade::Zombie), ForkCondition::Never);
+        assert_eq!(cfg.upgrade_activation(BaseUpgrade::Zenith), ForkCondition::Never);
 
         RuntimeUpgradeRegistry::clear_chain(CHAIN_ID);
     }

--- a/crates/common/evm/src/base_time.rs
+++ b/crates/common/evm/src/base_time.rs
@@ -93,7 +93,7 @@ impl BaseTime {
     /// [`Predeploys::PROXY_ADMIN`] in its EIP-1967 admin slot. This transition validates that
     /// historical invariant; it does not install or repair proxy state.
     ///
-    /// The transition is staged behind the `Zombie` activation condition. The implementation slot
+    /// The transition is staged behind the `Zenith` activation condition. The implementation slot
     /// is the durable migration marker: any existing linkage is preserved so later execution cannot
     /// rewrite the initial deployment or undo a governance upgrade.
     pub fn ensure_predeploy<DB>(
@@ -104,7 +104,7 @@ impl BaseTime {
     where
         DB: Database + DatabaseCommit,
     {
-        if !chain_spec.is_zombie_active_at_timestamp(timestamp) {
+        if !chain_spec.is_zenith_active_at_timestamp(timestamp) {
             return Ok(());
         }
 
@@ -416,7 +416,7 @@ mod tests {
 
     impl Upgrades for TestUpgrades {
         fn upgrade_activation(&self, fork: BaseUpgrade) -> ForkCondition {
-            if fork == BaseUpgrade::Zombie && self.0 {
+            if fork == BaseUpgrade::Zenith && self.0 {
                 ForkCondition::Timestamp(100)
             } else {
                 ForkCondition::Never

--- a/crates/common/genesis/src/chain/upgrade.rs
+++ b/crates/common/genesis/src/chain/upgrade.rs
@@ -27,13 +27,13 @@ pub struct BaseUpgradeConfig {
     /// Active if `cobalt` != None && L2 block timestamp >= `Some(cobalt)`, inactive otherwise.
     #[cfg_attr(feature = "serde", serde(alias = "v3", skip_serializing_if = "Option::is_none"))]
     pub cobalt: Option<u64>,
-    /// `zombie` sets the activation time for the Zombie network upgrade.
-    /// Active if `zombie` != None && L2 block timestamp >= `Some(zombie)`, inactive otherwise.
+    /// `zenith` sets the activation time for the Zenith network upgrade.
+    /// Active if `zenith` != None && L2 block timestamp >= `Some(zenith)`, inactive otherwise.
     #[cfg_attr(
         feature = "serde",
         serde(alias = "future", skip_serializing_if = "Option::is_none")
     )]
-    pub zombie: Option<u64>,
+    pub zenith: Option<u64>,
 }
 
 impl BaseUpgradeConfig {
@@ -42,7 +42,7 @@ impl BaseUpgradeConfig {
         self.azul.is_none()
             && self.beryl.is_none()
             && self.cobalt.is_none()
-            && self.zombie.is_none()
+            && self.zenith.is_none()
     }
 }
 
@@ -62,7 +62,7 @@ hardfork!(
     /// are contract-backed config upgrades that do not change EVM execution and therefore never
     /// enter the execution fork ladder.
     ///
-    /// [`Zombie`](BaseUpgrade::Zombie) is a hardfork for future experimental features. It is
+    /// [`Zenith`](BaseUpgrade::Zenith) is a hardfork for future experimental features. It is
     /// genesis-configurable but not contract-backed, since the L1 upgrade-signal contract does
     /// not yet recognise it.
     ///
@@ -101,8 +101,8 @@ hardfork!(
         Beryl,
         /// Cobalt: Third Base-specific network upgrade.
         Cobalt,
-        /// Zombie: hardfork for future experimental features.
-        Zombie,
+        /// Zenith: hardfork for future experimental features.
+        Zenith,
     }
 );
 
@@ -114,7 +114,7 @@ impl BaseUpgrade {
     ///
     /// These are the upgrades that participate in the reth/revm hardfork schedule. Excludes the
     /// contract-only [`Delta`](Self::Delta) and [`PectraBlobSchedule`](Self::PectraBlobSchedule)
-    /// upgrades, and [`Zombie`](Self::Zombie), which does not yet change EVM execution.
+    /// upgrades, and [`Zenith`](Self::Zenith), which does not yet change EVM execution.
     pub const EXECUTION_VARIANTS: [Self; 12] = [
         Self::Bedrock,
         Self::Regolith,
@@ -134,7 +134,7 @@ impl BaseUpgrade {
     ///
     /// These are the upgrades addressable by the L1 upgrade-signal contract and stored in the
     /// genesis [`UpgradeConfig`]. Excludes block-activated [`Bedrock`](Self::Bedrock) and
-    /// [`Zombie`](Self::Zombie), which is activated via genesis config only until the L1
+    /// [`Zenith`](Self::Zenith), which is activated via genesis config only until the L1
     /// upgrade-signal contract is updated to recognise it.
     ///
     /// Order is load-bearing: `map_schedule` and `ScheduleId::from_upgrades` attribute onchain
@@ -165,10 +165,10 @@ impl BaseUpgrade {
 
     /// Returns true if this upgrade is contract-backed (i.e. signaled by the L1 upgrade-signal
     /// contract and stored in [`UpgradeConfig`]). False for block-activated
-    /// [`Bedrock`](Self::Bedrock) and for [`Zombie`](Self::Zombie), which is activated via
+    /// [`Bedrock`](Self::Bedrock) and for [`Zenith`](Self::Zenith), which is activated via
     /// genesis config only until the L1 upgrade-signal contract is updated.
     pub const fn is_contract_backed(self) -> bool {
-        !matches!(self, Self::Bedrock | Self::Zombie)
+        !matches!(self, Self::Bedrock | Self::Zenith)
     }
 
     /// Returns this upgrade's index within [`EXECUTION_VARIANTS`](Self::EXECUTION_VARIANTS), or
@@ -187,7 +187,7 @@ impl BaseUpgrade {
             Self::Azul => 9,
             Self::Beryl => 10,
             Self::Cobalt => 11,
-            Self::Delta | Self::PectraBlobSchedule | Self::Zombie => return None,
+            Self::Delta | Self::PectraBlobSchedule | Self::Zenith => return None,
         })
     }
 
@@ -212,7 +212,7 @@ impl BaseUpgrade {
             Self::Azul => "azul",
             Self::Beryl => "beryl",
             Self::Cobalt => "cobalt",
-            Self::Zombie => "zombie",
+            Self::Zenith => "zenith",
         }
     }
 
@@ -255,7 +255,7 @@ impl BaseUpgrade {
             "osaka" | "azul" | "baseazul" | "v1" => Self::Azul,
             "beryl" | "baseberyl" | "v2" => Self::Beryl,
             "cobalt" | "basecobalt" | "v3" => Self::Cobalt,
-            // Zombie is not contract-backed: even though `contract_id` emits "zombie", it is
+            // Zenith is not contract-backed: even though `contract_id` emits "zenith", it is
             // deliberately not resolvable here, so the L1 upgrade signal can never address it.
             _ => return None,
         };
@@ -369,9 +369,9 @@ impl UpgradeActivationOverrides {
 
     /// Sets the runtime activation override for a contract upgrade ID.
     pub fn set_activation(&mut self, upgrade_id: BaseUpgrade, activation: UpgradeActivation) {
-        // Zombie is not contract-backed: it must never be set via the L1-signal-driven runtime
+        // Zenith is not contract-backed: it must never be set via the L1-signal-driven runtime
         // override path. Its activation comes from genesis config only.
-        if matches!(upgrade_id, BaseUpgrade::Zombie) {
+        if matches!(upgrade_id, BaseUpgrade::Zenith) {
             return;
         }
         self.activations.insert(upgrade_id, activation);
@@ -458,25 +458,25 @@ impl RuntimeUpgradeRegistry {
         Self::set_activation(chain_id, upgrade_id, UpgradeActivation::Timestamp(timestamp))
     }
 
-    /// Activates Zombie for a chain via the runtime registry, bypassing the normal
+    /// Activates Zenith for a chain via the runtime registry, bypassing the normal
     /// override block, for the lifetime of the returned test guard.
     #[cfg(any(test, feature = "test-utils"))]
     #[must_use = "the guard must be held for the duration of the test activation"]
-    pub fn activate_zombie_for_testing(chain_id: u64, timestamp: u64) -> impl Drop {
-        struct ZombieActivationGuard {
+    pub fn activate_zenith_for_testing(chain_id: u64, timestamp: u64) -> impl Drop {
+        struct ZenithActivationGuard {
             chain_id: u64,
             previous: Option<UpgradeActivation>,
             remove_chain_if_empty: bool,
         }
 
-        impl Drop for ZombieActivationGuard {
+        impl Drop for ZenithActivationGuard {
             fn drop(&mut self) {
                 let mut registry = RuntimeUpgradeRegistry::write_registry();
                 let overrides = registry.entry(self.chain_id).or_default();
                 if let Some(previous) = self.previous {
-                    overrides.activations.insert(BaseUpgrade::Zombie, previous);
+                    overrides.activations.insert(BaseUpgrade::Zenith, previous);
                 } else {
-                    overrides.activations.remove(&BaseUpgrade::Zombie);
+                    overrides.activations.remove(&BaseUpgrade::Zenith);
                 }
                 if self.remove_chain_if_empty && overrides.is_empty() {
                     registry.remove(&self.chain_id);
@@ -487,9 +487,9 @@ impl RuntimeUpgradeRegistry {
         let mut registry = Self::write_registry();
         let remove_chain_if_empty = !registry.contains_key(&chain_id);
         let overrides = registry.entry(chain_id).or_default();
-        let previous = overrides.activation(BaseUpgrade::Zombie);
-        overrides.activations.insert(BaseUpgrade::Zombie, UpgradeActivation::Timestamp(timestamp));
-        ZombieActivationGuard { chain_id, previous, remove_chain_if_empty }
+        let previous = overrides.activation(BaseUpgrade::Zenith);
+        overrides.activations.insert(BaseUpgrade::Zenith, UpgradeActivation::Timestamp(timestamp));
+        ZenithActivationGuard { chain_id, previous, remove_chain_if_empty }
     }
 
     /// Sets one runtime override that clears a chain upgrade activation.
@@ -605,7 +605,7 @@ impl UpgradeConfig {
             azul: Some(1_779_991_200),
             beryl: Some(1_782_410_400),
             cobalt: None,
-            zombie: None,
+            zenith: None,
         },
     };
 
@@ -628,7 +628,7 @@ impl UpgradeConfig {
             azul: Some(1_776_708_000),
             beryl: Some(1_781_805_600),
             cobalt: None,
-            zombie: None,
+            zenith: None,
         },
     };
 
@@ -677,7 +677,7 @@ impl UpgradeConfig {
             BaseUpgrade::Azul => self.base.azul = None,
             BaseUpgrade::Beryl => self.base.beryl = None,
             BaseUpgrade::Cobalt => self.base.cobalt = None,
-            BaseUpgrade::Zombie => self.base.zombie = None,
+            BaseUpgrade::Zenith => self.base.zenith = None,
         }
     }
 
@@ -716,7 +716,7 @@ impl UpgradeConfig {
             BaseUpgrade::Azul => self.base.azul,
             BaseUpgrade::Beryl => self.base.beryl,
             BaseUpgrade::Cobalt => self.base.cobalt,
-            BaseUpgrade::Zombie => self.base.zombie,
+            BaseUpgrade::Zenith => self.base.zenith,
         };
 
         UpgradeActivation::from_timestamp(timestamp)
@@ -745,7 +745,7 @@ impl UpgradeConfig {
             BaseUpgrade::Azul => self.base.azul = Some(timestamp),
             BaseUpgrade::Beryl => self.base.beryl = Some(timestamp),
             BaseUpgrade::Cobalt => self.base.cobalt = Some(timestamp),
-            BaseUpgrade::Zombie => self.base.zombie = Some(timestamp),
+            BaseUpgrade::Zenith => self.base.zenith = Some(timestamp),
         }
     }
 
@@ -876,7 +876,7 @@ mod tests {
                 azul: Some(11),
                 beryl: Some(12),
                 cobalt: Some(13),
-                zombie: Some(14),
+                zenith: Some(14),
             },
         };
 
@@ -899,20 +899,20 @@ mod tests {
         upgrades.set_activation_timestamp(BaseUpgrade::Azul, 3);
         upgrades.set_activation_timestamp(BaseUpgrade::Beryl, 5);
         upgrades.set_activation_timestamp(BaseUpgrade::Cobalt, 6);
-        upgrades.set_activation_timestamp(BaseUpgrade::Zombie, 7);
+        upgrades.set_activation_timestamp(BaseUpgrade::Zenith, 7);
 
         assert_eq!(upgrades.regolith_time, Some(1));
         assert_eq!(upgrades.pectra_blob_schedule_time, Some(2));
         assert_eq!(upgrades.base.azul, Some(3));
         assert_eq!(upgrades.base.beryl, Some(5));
         assert_eq!(upgrades.base.cobalt, Some(6));
-        assert_eq!(upgrades.activation(BaseUpgrade::Zombie), UpgradeActivation::Timestamp(7));
+        assert_eq!(upgrades.activation(BaseUpgrade::Zenith), UpgradeActivation::Timestamp(7));
 
         upgrades.clear_activation_timestamp(BaseUpgrade::Azul);
         assert_eq!(upgrades.base.azul, None);
         assert_eq!(upgrades.base.beryl, Some(5));
         assert_eq!(upgrades.base.cobalt, Some(6));
-        assert_eq!(upgrades.activation(BaseUpgrade::Zombie), UpgradeActivation::Timestamp(7));
+        assert_eq!(upgrades.activation(BaseUpgrade::Zenith), UpgradeActivation::Timestamp(7));
 
         upgrades.clear_activation_timestamps();
 
@@ -936,14 +936,14 @@ mod runtime_tests {
         RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Azul, 42);
         RuntimeUpgradeRegistry::clear_activation_timestamp(chain_id, BaseUpgrade::Beryl);
         RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Cobalt, 84);
-        // Zombie is not contract-backed: the registry drops the write, so it is never stored.
-        RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Zombie, u64::MAX);
+        // Zenith is not contract-backed: the registry drops the write, so it is never stored.
+        RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Zenith, u64::MAX);
 
         assert_eq!(
             RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul),
             Some(UpgradeActivation::Timestamp(42))
         );
-        assert_eq!(RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Zombie), None);
+        assert_eq!(RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Zenith), None);
         assert_eq!(
             RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Beryl),
             Some(UpgradeActivation::Never)
@@ -964,17 +964,17 @@ mod runtime_tests {
         overrides.clear_activation_timestamp(BaseUpgrade::Canyon);
         overrides.set_activation_timestamp(BaseUpgrade::Azul, 42);
         overrides.set_activation_timestamp(BaseUpgrade::Cobalt, 84);
-        // Even an explicit override cannot activate Zombie, since it is not contract-backed.
+        // Even an explicit override cannot activate Zenith, since it is not contract-backed.
         // The write side drops it entirely, so it is never even stored as an override.
-        overrides.set_activation_timestamp(BaseUpgrade::Zombie, u64::MAX);
-        assert_eq!(overrides.activation(BaseUpgrade::Zombie), None);
+        overrides.set_activation_timestamp(BaseUpgrade::Zenith, u64::MAX);
+        assert_eq!(overrides.activation(BaseUpgrade::Zenith), None);
 
         upgrades.apply_activation_overrides(&overrides);
 
         assert_eq!(upgrades.canyon_time, None);
         assert_eq!(upgrades.base.azul, Some(42));
         assert_eq!(upgrades.base.cobalt, Some(84));
-        assert_eq!(upgrades.activation(BaseUpgrade::Zombie), UpgradeActivation::Never);
+        assert_eq!(upgrades.activation(BaseUpgrade::Zenith), UpgradeActivation::Never);
     }
 
     #[test]

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -325,10 +325,10 @@ impl RollupConfig {
         [contract_upgrade_activation_timestamp(BaseUpgrade::Cobalt)],
         "Cobalt";
 
-        is_zombie_active,
-        is_first_zombie_block,
-        [contract_upgrade_activation_timestamp(BaseUpgrade::Zombie)],
-        "Zombie";
+        is_zenith_active,
+        is_first_zenith_block,
+        [contract_upgrade_activation_timestamp(BaseUpgrade::Zenith)],
+        "Zenith";
     }
 
     /// Returns the max sequencer drift for the given timestamp.
@@ -458,7 +458,7 @@ impl UpgradeActivationSink for RollupConfig {
         upgrade_id: BaseUpgrade,
         activation: UpgradeActivation,
     ) -> Result<bool, Self::Error> {
-        if matches!(upgrade_id, BaseUpgrade::Zombie) {
+        if matches!(upgrade_id, BaseUpgrade::Zenith) {
             return Ok(false);
         }
 
@@ -526,7 +526,7 @@ mod tests {
                     azul: Some(110),
                     beryl: Some(120),
                     cobalt: Some(130),
-                    zombie: None,
+                    zenith: None,
                 },
             },
             block_time: 2,
@@ -607,7 +607,7 @@ mod tests {
                     azul: Some(110),
                     beryl: Some(120),
                     cobalt: None,
-                    zombie: None,
+                    zenith: None,
                 },
                 ..Default::default()
             },
@@ -885,7 +885,7 @@ mod tests {
         // Osaka↔Azul: azul drives Osaka activation; standalone (not cascaded from Jovian).
         let mut cfg = RollupConfig::default();
         cfg.upgrades.base =
-            BaseUpgradeConfig { azul: Some(700), beryl: None, cobalt: None, zombie: None };
+            BaseUpgradeConfig { azul: Some(700), beryl: None, cobalt: None, zenith: None };
         assert_eq!(
             cfg.ethereum_fork_activation(EthereumHardfork::Osaka),
             ForkCondition::Timestamp(700)
@@ -894,7 +894,7 @@ mod tests {
         // Beryl follows Azul; Osaka still activates at Azul when both are configured.
         let mut cfg = RollupConfig::default();
         cfg.upgrades.base =
-            BaseUpgradeConfig { azul: Some(700), beryl: Some(800), cobalt: None, zombie: None };
+            BaseUpgradeConfig { azul: Some(700), beryl: Some(800), cobalt: None, zenith: None };
         assert_eq!(
             cfg.ethereum_fork_activation(EthereumHardfork::Osaka),
             ForkCondition::Timestamp(700)
@@ -905,7 +905,7 @@ mod tests {
         // Beryl requires Azul, and does not independently activate Osaka.
         let mut cfg = RollupConfig::default();
         cfg.upgrades.base =
-            BaseUpgradeConfig { azul: None, beryl: Some(800), cobalt: None, zombie: None };
+            BaseUpgradeConfig { azul: None, beryl: Some(800), cobalt: None, zenith: None };
         assert_eq!(cfg.ethereum_fork_activation(EthereumHardfork::Osaka), ForkCondition::Never);
 
         // Jovian set but Azul unset → Osaka is Never.
@@ -947,25 +947,25 @@ mod tests {
         crate::RuntimeUpgradeRegistry::clear_activation_timestamp(chain_id, BaseUpgrade::Canyon);
         crate::RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Azul, 42);
         crate::RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Cobalt, 84);
-        // The Zombie gate stays off even when a runtime override tries to activate it.
+        // The Zenith gate stays off even when a runtime override tries to activate it.
         crate::RuntimeUpgradeRegistry::set_activation_timestamp(
             chain_id,
-            BaseUpgrade::Zombie,
+            BaseUpgrade::Zenith,
             u64::MAX,
         );
 
         assert!(!cfg.is_canyon_active(10));
         assert!(cfg.is_base_azul_active(42));
         assert!(cfg.is_cobalt_active(84));
-        assert!(!cfg.is_zombie_active(84));
-        assert!(!cfg.is_zombie_active(u64::MAX));
+        assert!(!cfg.is_zenith_active(84));
+        assert!(!cfg.is_zenith_active(u64::MAX));
 
         let materialized = cfg.with_runtime_upgrade_overrides();
         assert_eq!(materialized.upgrades.canyon_time, None);
         assert_eq!(materialized.upgrades.base.azul, Some(42));
         assert_eq!(materialized.upgrades.base.cobalt, Some(84));
         assert_eq!(
-            materialized.contract_upgrade_activation(BaseUpgrade::Zombie),
+            materialized.contract_upgrade_activation(BaseUpgrade::Zenith),
             UpgradeActivation::Never
         );
 
@@ -973,17 +973,17 @@ mod tests {
     }
 
     #[test]
-    fn zombie_activation_can_be_enabled_for_testing() {
+    fn zenith_activation_can_be_enabled_for_testing() {
         let chain_id = 9_100_003;
         crate::RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Azul, 21);
         let cfg = RollupConfig { l2_chain_id: Chain::from_id(chain_id), ..Default::default() };
         {
             let _activation =
-                crate::RuntimeUpgradeRegistry::activate_zombie_for_testing(chain_id, 42);
+                crate::RuntimeUpgradeRegistry::activate_zenith_for_testing(chain_id, 42);
 
-            assert!(!cfg.is_zombie_active(41));
-            assert!(cfg.is_zombie_active(42));
-            assert!(cfg.is_zombie_active(u64::MAX));
+            assert!(!cfg.is_zenith_active(41));
+            assert!(cfg.is_zenith_active(42));
+            assert!(cfg.is_zenith_active(u64::MAX));
             crate::RuntimeUpgradeRegistry::set_activation_timestamp(
                 chain_id,
                 BaseUpgrade::Azul,
@@ -991,33 +991,33 @@ mod tests {
             );
             {
                 let _nested =
-                    crate::RuntimeUpgradeRegistry::activate_zombie_for_testing(chain_id, 84);
-                assert!(!cfg.is_zombie_active(83));
-                assert!(cfg.is_zombie_active(84));
+                    crate::RuntimeUpgradeRegistry::activate_zenith_for_testing(chain_id, 84);
+                assert!(!cfg.is_zenith_active(83));
+                assert!(cfg.is_zenith_active(84));
             }
-            assert!(cfg.is_zombie_active(42));
+            assert!(cfg.is_zenith_active(42));
         }
         assert_eq!(
             crate::RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul),
             Some(UpgradeActivation::Timestamp(22))
         );
-        assert_eq!(crate::RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Zombie), None);
+        assert_eq!(crate::RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Zenith), None);
         crate::RuntimeUpgradeRegistry::clear_chain(chain_id);
     }
 
     #[test]
-    fn zombie_activates_via_genesis_config() {
+    fn zenith_activates_via_genesis_config() {
         let cfg = RollupConfig {
             upgrades: UpgradeConfig {
-                base: BaseUpgradeConfig { zombie: Some(100), ..Default::default() },
+                base: BaseUpgradeConfig { zenith: Some(100), ..Default::default() },
                 ..Default::default()
             },
             ..Default::default()
         };
 
-        assert!(!cfg.is_zombie_active(99));
-        assert!(cfg.is_zombie_active(100));
-        assert!(cfg.is_zombie_active(u64::MAX));
+        assert!(!cfg.is_zenith_active(99));
+        assert!(cfg.is_zenith_active(100));
+        assert!(cfg.is_zenith_active(u64::MAX));
     }
 
     #[test]

--- a/crates/common/precompiles/src/provider.rs
+++ b/crates/common/precompiles/src/provider.rs
@@ -48,9 +48,9 @@ impl<S: BasePrecompileSpec> BasePrecompiles<S> {
             BaseUpgrade::Jovian => Self::jovian(),
             BaseUpgrade::Azul => Self::azul(),
             BaseUpgrade::Beryl => Self::beryl(),
-            // Zombie is a placeholder that never activates; it tracks the latest precompile set so
+            // Zenith is a placeholder that never activates; it tracks the latest precompile set so
             // it evolves with the newest hardfork (keep it grouped with the latest arm).
-            BaseUpgrade::Cobalt | BaseUpgrade::Zombie => Self::cobalt(),
+            BaseUpgrade::Cobalt | BaseUpgrade::Zenith => Self::cobalt(),
             upgrade => panic!("unsupported Base precompile upgrade: {upgrade}"),
         };
 

--- a/crates/common/rpc-types/src/genesis.rs
+++ b/crates/common/rpc-types/src/genesis.rs
@@ -35,8 +35,8 @@ impl TryFrom<&OtherFields> for ChainInfo {
 
 /// Base-specific upgrade configuration in a genesis file.
 ///
-/// `deny_unknown_fields` ensures a genesis cannot smuggle in a `zombie` (or any other unknown)
-/// activation time: Zombie is a permanently-off gate and is not configurable.
+/// `deny_unknown_fields` ensures a genesis cannot smuggle in a `zenith` (or any other unknown)
+/// activation time: Zenith is a permanently-off gate and is not configurable.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct UpgradeInfo {

--- a/crates/consensus/cli/src/metrics.rs
+++ b/crates/consensus/cli/src/metrics.rs
@@ -315,7 +315,7 @@ mod tests {
                     azul: Some(1_000),
                     beryl: Some(2_000),
                     cobalt: Some(3_000),
-                    zombie: None,
+                    zenith: None,
                 },
                 ..Default::default()
             },
@@ -369,7 +369,7 @@ mod tests {
                     azul: Some(1_000),
                     beryl: Some(1_000),
                     cobalt: Some(2_000),
-                    zombie: None,
+                    zenith: None,
                 },
                 ..Default::default()
             },

--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -181,7 +181,7 @@ where
         let mut encoded_l1_info_tx = Vec::with_capacity(l1_info_tx_envelope.length());
         l1_info_tx_envelope.encode_2718(&mut encoded_l1_info_tx);
 
-        let base_time_active = self.rollup_cfg.is_zombie_active(next_l2_time);
+        let base_time_active = self.rollup_cfg.is_zenith_active(next_l2_time);
         let mut txs = Vec::with_capacity(
             1 + usize::from(base_time_active)
                 + deposit_transactions.len()
@@ -539,7 +539,7 @@ mod tests {
         let timestamp = 100;
         let chain_id = 9_100_004;
         let _activation =
-            base_common_genesis::RuntimeUpgradeRegistry::activate_zombie_for_testing(chain_id, 102);
+            base_common_genesis::RuntimeUpgradeRegistry::activate_zenith_for_testing(chain_id, 102);
         let cfg = Arc::new(RollupConfig {
             block_time,
             l2_chain_id: chain_id.into(),

--- a/crates/consensus/engine/src/versions.rs
+++ b/crates/consensus/engine/src/versions.rs
@@ -123,7 +123,7 @@ mod tests {
                     azul: Some(40),
                     beryl: Some(50),
                     cobalt: Some(60),
-                    zombie: None,
+                    zenith: None,
                 },
                 ..Default::default()
             },

--- a/crates/consensus/service/src/actors/sequencer/actor.rs
+++ b/crates/consensus/service/src/actors/sequencer/actor.rs
@@ -312,7 +312,7 @@ where
 
     /// Wall-clock time at which a block with the given absolute timestamp should be sealed,
     /// compensating for the time already spent sealing the previous block. A present
-    /// `timestamp_millis_part` selects millisecond-accurate (Zombie 200ms) scheduling.
+    /// `timestamp_millis_part` selects millisecond-accurate (Zenith 200ms) scheduling.
     ///
     /// The compensation is capped at half the block interval so a single slow seal cannot
     /// collapse the next block's build window to zero. Uncapped, a seal that overruns the
@@ -419,7 +419,7 @@ where
 
         // Sub-second remainder of the most recently sealed block. `L2BlockInfo` records
         // only whole seconds, so this is threaded into the next `build_on` to keep the
-        // Zombie timestamp planner's monotonicity guard strict.
+        // Zenith timestamp planner's monotonicity guard strict.
         let mut last_sealed_millis_part: Option<u16> = None;
 
         let mut last_block_complete_at: Option<Instant> = None;
@@ -614,7 +614,7 @@ where
                                 last_seal_duration = dur;
                                 last_sealed_millis_part = handle_timestamp_millis_part;
                                 self.sealer = Some(new_sealer);
-                                let next_block_time = if self.rollup_config.is_zombie_active(
+                                let next_block_time = if self.rollup_config.is_zenith_active(
                                     handle_timestamp,
                                 ) {
                                     let cadence_millis = (self.block_interval.as_millis()

--- a/crates/consensus/service/src/actors/sequencer/actor.rs
+++ b/crates/consensus/service/src/actors/sequencer/actor.rs
@@ -276,11 +276,8 @@ where
         pending_build_parent.take();
         let canonical_head = self.engine_client.get_unsafe_head().await?;
         *shadow_cycle = Some(ShadowCycle::building(canonical_head)?);
-        *next_payload_to_seal = if self.is_active {
-            self.builder.build_on(canonical_head, None).await?
-        } else {
-            None
-        };
+        *next_payload_to_seal =
+            if self.is_active { self.builder.build_on(canonical_head, None).await? } else { None };
         if self.is_active && next_payload_to_seal.is_none() {
             build_ticker.reset_immediately();
         }
@@ -491,7 +488,7 @@ where
                         Ok(Some(head)) => {
                             shadow_cycle.as_mut().expect("shadow reconciliation requires cycle state").reconcile(head)?;
                             if self.is_active {
-                                next_payload_to_seal = self.builder.build_on(head).await?;
+                                next_payload_to_seal = self.builder.build_on(head, None).await?;
                                 if next_payload_to_seal.is_none() {
                                     build_ticker.reset_immediately();
                                 }
@@ -555,29 +552,18 @@ where
                                     warn!(target: "sequencer", "Failed to send deferred stop_sequencer response");
                                 }
                             }
-                            if self.is_active {
-                                if self.is_shadow_sequencer() {
-                                    if shadow_cycle
-                                        .and_then(ShadowCycle::reconciliation_target)
-                                        .is_none()
-                                    {
-                                        // Queue the acknowledged parent instead of starting its child
-                                        // here. Its timestamp is a hard lower bound for the steady-state
-                                        // child build because variable getPayload durations can make
-                                        // insertion complete early.
-                                        let parent_timestamp = inserted_head.block_info.timestamp;
-                                        pending_build_parent = Some(inserted_head);
-                                        build_ticker.reset_at_unix_timestamp(parent_timestamp);
-                                    }
-                                } else {
-                                    next_payload_to_seal = self
-                                        .builder
-                                        .build_on(inserted_head, last_sealed_millis_part)
-                                        .await?;
-                                    if next_payload_to_seal.is_none() {
-                                        build_ticker.reset_immediately();
-                                    }
-                                }
+                            if self.is_active
+                                && shadow_cycle
+                                    .and_then(ShadowCycle::reconciliation_target)
+                                    .is_none()
+                            {
+                                // Queue the acknowledged parent instead of starting its child
+                                // here. Its timestamp is a hard lower bound for the steady-state
+                                // child build because variable getPayload durations can make
+                                // insertion complete early.
+                                let parent_timestamp = inserted_head.block_info.timestamp;
+                                pending_build_parent = Some(inserted_head);
+                                build_ticker.reset_at_unix_timestamp(parent_timestamp);
                             }
                         }
                         Ok(SealStepOutcome::Pending) => {}
@@ -628,14 +614,31 @@ where
                                 last_seal_duration = dur;
                                 last_sealed_millis_part = handle_timestamp_millis_part;
                                 self.sealer = Some(new_sealer);
-                                // Schedule the next tick for the next block's target seal time.
-                                // Use the just-sealed block's timestamp; the next block's
-                                // timestamp is one block_time later.
-                                let next_block_time = self.next_block_seal_target(
+                                let next_block_time = if self.rollup_config.is_zombie_active(
                                     handle_timestamp,
-                                    handle_timestamp_millis_part,
-                                    last_seal_duration,
-                                );
+                                ) {
+                                    let cadence_millis = (self.block_interval.as_millis()
+                                        .min(u128::from(u64::MAX))
+                                        as u64)
+                                        .max(1);
+                                    let current_millis = handle_timestamp
+                                        .saturating_mul(1_000)
+                                        .saturating_add(u64::from(
+                                            handle_timestamp_millis_part.unwrap_or(0),
+                                        ));
+                                    let next_millis = current_millis.saturating_add(cadence_millis);
+                                    self.block_seal_target(
+                                        next_millis / 1_000,
+                                        Some((next_millis % 1_000) as u16),
+                                        last_seal_duration,
+                                    )
+                                } else {
+                                    self.next_block_seal_target(
+                                        handle_timestamp,
+                                        None,
+                                        last_seal_duration,
+                                    )
+                                };
                                 build_ticker.reset_at(next_block_time);
                                 // Do not call build() here. The next payload is built after the
                                 // engine acknowledges insertion of the sealed payload.

--- a/crates/consensus/service/src/actors/sequencer/build.rs
+++ b/crates/consensus/service/src/actors/sequencer/build.rs
@@ -70,7 +70,7 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
     pub async fn build(&mut self) -> Result<Option<UnsealedPayloadHandle>, SequencerActorError> {
         let unsafe_head = self.engine_client.get_unsafe_head().await?;
         // The watch-channel unsafe head is an `L2BlockInfo`, which records only whole
-        // seconds, so no sub-second remainder is available here. Zombie timestamp planning
+        // seconds, so no sub-second remainder is available here. Zenith timestamp planning
         // derives both seconds and millis from the deterministic child-block-number formula,
         // so this path safely passes `None`.
         self.build_on(unsafe_head, None).await
@@ -174,7 +174,7 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
 
     /// Plans the next block's timestamp.
     ///
-    /// After Zombie activation, or when `block_interval` overrides the rollup `block_time`,
+    /// After Zenith activation, or when `block_interval` overrides the rollup `block_time`,
     /// uses `SequencerTimestampPlanner::sub_second` aligned to the configured cadence.
     /// Otherwise advances by the whole-second `block_time` via
     /// `SequencerTimestampPlanner::legacy`.
@@ -189,7 +189,7 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
             SequencerTimestampPlanner::legacy(parent_timestamp, self.rollup_config.block_time)?;
         let uses_override =
             self.block_interval != Duration::from_secs(self.rollup_config.block_time);
-        if self.rollup_config.is_zombie_active(legacy.timestamp) || uses_override {
+        if self.rollup_config.is_zenith_active(legacy.timestamp) || uses_override {
             let cadence_millis = u64::try_from(self.block_interval.as_millis())
                 .map_err(|_| SequencerTimestampPlannerError::TimestampOverflow)?
                 .max(1);

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -447,7 +447,7 @@ impl BaseChainSpec {
             inserted = true;
         }
         // Only execution-ladder upgrades enter the reth hardfork schedule; contract-only
-        // upgrades (Delta, PectraBlobSchedule) and the permanently-off Zombie gate are ignored.
+        // upgrades (Delta, PectraBlobSchedule) and the permanently-off Zenith gate are ignored.
         if hardfork_id.is_execution() {
             hardforks.insert(hardfork_id, condition);
             inserted = true;
@@ -960,13 +960,13 @@ mod tests {
     }
 
     #[test]
-    fn builtin_chain_specs_never_activate_zombie() {
-        // Zombie is a permanently-off gate: it never enters any chain's fork schedule, so it is
+    fn builtin_chain_specs_never_activate_zenith() {
+        // Zenith is a permanently-off gate: it never enters any chain's fork schedule, so it is
         // always `Never` and never active.
         for spec in [BaseChainSpec::mainnet(), BaseChainSpec::sepolia(), BaseChainSpec::devnet()] {
-            assert_eq!(spec.fork(BaseUpgrade::Zombie), ForkCondition::Never);
-            assert!(!spec.is_fork_active_at_timestamp(BaseUpgrade::Zombie, 0));
-            assert!(!spec.is_fork_active_at_timestamp(BaseUpgrade::Zombie, u64::MAX));
+            assert_eq!(spec.fork(BaseUpgrade::Zenith), ForkCondition::Never);
+            assert!(!spec.is_fork_active_at_timestamp(BaseUpgrade::Zenith, 0));
+            assert!(!spec.is_fork_active_at_timestamp(BaseUpgrade::Zenith, u64::MAX));
         }
     }
 
@@ -1258,9 +1258,9 @@ mod tests {
         assert!(!chain_spec.is_fork_active_at_timestamp(BaseUpgrade::Cobalt, 64));
         assert!(chain_spec.is_fork_active_at_timestamp(BaseUpgrade::Cobalt, 65));
 
-        // Zombie is a permanently-off gate: never scheduled, always Never.
-        assert_eq!(chain_spec.fork(BaseUpgrade::Zombie), ForkCondition::Never);
-        assert!(!chain_spec.is_fork_active_at_timestamp(BaseUpgrade::Zombie, 9999));
+        // Zenith is a permanently-off gate: never scheduled, always Never.
+        assert_eq!(chain_spec.fork(BaseUpgrade::Zenith), ForkCondition::Never);
+        assert!(!chain_spec.is_fork_active_at_timestamp(BaseUpgrade::Zenith, 9999));
     }
 
     #[test]

--- a/crates/execution/consensus/src/lib.rs
+++ b/crates/execution/consensus/src/lib.rs
@@ -230,8 +230,8 @@ impl HeaderValidator<Header> for BaseBeaconConsensus {
         validate_against_parent_hash_number(header.header(), parent)?;
 
         let allows_same_timestamp =
-            self.chain_spec.is_zombie_active_at_timestamp(header.timestamp())
-                && self.chain_spec.is_zombie_active_at_timestamp(parent.timestamp());
+            self.chain_spec.is_zenith_active_at_timestamp(header.timestamp())
+                && self.chain_spec.is_zenith_active_at_timestamp(parent.timestamp());
         let timestamp_is_invalid = header.timestamp() < parent.timestamp()
             || (header.timestamp() == parent.timestamp() && !allows_same_timestamp);
         if self.chain_spec.is_bedrock_active_at_block(header.number()) && timestamp_is_invalid {
@@ -331,7 +331,7 @@ mod tests {
     #[test]
     fn activated_parent_validation_allows_same_second_headers() {
         let mut chain_spec = BaseChainSpec::mainnet();
-        chain_spec.set_fork(BaseUpgrade::Zombie, ForkCondition::Timestamp(10));
+        chain_spec.set_fork(BaseUpgrade::Zenith, ForkCondition::Timestamp(10));
         let parent_header = Header {
             number: 8,
             timestamp: 10,
@@ -358,7 +358,7 @@ mod tests {
     #[test]
     fn activated_parent_validation_rejects_timestamp_in_past() {
         let mut chain_spec = BaseChainSpec::mainnet();
-        chain_spec.set_fork(BaseUpgrade::Zombie, ForkCondition::Timestamp(10));
+        chain_spec.set_fork(BaseUpgrade::Zenith, ForkCondition::Timestamp(10));
         let parent_header = Header {
             number: 8,
             timestamp: 11,

--- a/crates/execution/consensus/src/validation/mod.rs
+++ b/crates/execution/consensus/src/validation/mod.rs
@@ -30,7 +30,7 @@ pub fn validate_base_time_metadata(
     block_number: u64,
     transactions: &[BaseTxEnvelope],
 ) -> Result<(), BaseTimeMetadataError> {
-    if chain_spec.is_zombie_active_at_timestamp(timestamp) {
+    if chain_spec.is_zenith_active_at_timestamp(timestamp) {
         BaseTimeUpdateTx::extract_from_transactions(transactions, block_number)?;
     }
 
@@ -299,7 +299,7 @@ mod tests {
     #[test]
     fn validates_base_time_metadata_only_after_activation() {
         let mut chain_spec = BaseChainSpec::sepolia();
-        chain_spec.set_fork(BaseUpgrade::Zombie, ForkCondition::Timestamp(10));
+        chain_spec.set_fork(BaseUpgrade::Zenith, ForkCondition::Timestamp(10));
 
         validate_base_time_metadata(&chain_spec, 10, 9, &base_time_transactions(9, 400)).unwrap();
         assert!(matches!(

--- a/crates/execution/evm/tests/block_execution.rs
+++ b/crates/execution/evm/tests/block_execution.rs
@@ -89,7 +89,7 @@ fn execute_same_block_base_time_read(getter_selector: [u8; 4]) -> U256 {
     let chain_spec = Arc::new(
         BaseChainSpecBuilder::base_mainnet()
             .cobalt_activated()
-            .with_fork(BaseUpgrade::Zombie, ForkCondition::Timestamp(0))
+            .with_fork(BaseUpgrade::Zenith, ForkCondition::Timestamp(0))
             .build(),
     );
 

--- a/crates/execution/node/src/engine.rs
+++ b/crates/execution/node/src/engine.rs
@@ -172,8 +172,8 @@ where
             block.header(),
         )?;
 
-        if !self.chain_spec().is_zombie_active_at_timestamp(timestamp)
-            || !self.chain_spec().is_zombie_active_at_timestamp(parent_header.timestamp())
+        if !self.chain_spec().is_zenith_active_at_timestamp(timestamp)
+            || !self.chain_spec().is_zenith_active_at_timestamp(parent_header.timestamp())
         {
             return Ok(());
         }
@@ -217,7 +217,7 @@ where
         header: &<Self::Block as Block>::Header,
     ) -> Result<(), InvalidPayloadAttributesError> {
         let timestamp = attributes.timestamp();
-        if !self.chain_spec().is_zombie_active_at_timestamp(timestamp) {
+        if !self.chain_spec().is_zenith_active_at_timestamp(timestamp) {
             return (timestamp > header.timestamp())
                 .then_some(())
                 .ok_or(InvalidPayloadAttributesError::InvalidTimestamp);
@@ -327,16 +327,16 @@ where
             ));
         }
 
-        let zombie_active = self
+        let zenith_active = self
             .chain_spec()
-            .is_zombie_active_at_timestamp(attributes.payload_attributes.timestamp);
+            .is_zenith_active_at_timestamp(attributes.payload_attributes.timestamp);
         match attributes.timestamp_millis_part {
-            Some(_) if !zombie_active => {
+            Some(_) if !zenith_active => {
                 return Err(EngineObjectValidationError::InvalidParams(
                     "TimestampMillisPartNotAllowed".to_string().into(),
                 ));
             }
-            None if zombie_active => {
+            None if zenith_active => {
                 return Err(EngineObjectValidationError::InvalidParams(
                     "MissingTimestampMillisPartInPayloadAttributes".to_string().into(),
                 ));
@@ -419,7 +419,7 @@ mod tests {
     use super::*;
     use crate::engine;
 
-    const ZOMBIE_TIMESTAMP: u64 = 1_800_000_001;
+    const ZENITH_TIMESTAMP: u64 = 1_800_000_001;
 
     fn validator_with_chain_spec(
         chain_spec: BaseChainSpec,
@@ -433,10 +433,10 @@ mod tests {
         validator_with_chain_spec(BaseChainSpec::sepolia())
     }
 
-    fn zombie_validator() -> BaseEngineValidator<BaseTxEnvelope, BaseChainSpec> {
+    fn zenith_validator() -> BaseEngineValidator<BaseTxEnvelope, BaseChainSpec> {
         validator_with_chain_spec(
             BaseChainSpecBuilder::base_mainnet()
-                .with_fork(BaseUpgrade::Zombie, ForkCondition::Timestamp(ZOMBIE_TIMESTAMP))
+                .with_fork(BaseUpgrade::Zenith, ForkCondition::Timestamp(ZENITH_TIMESTAMP))
                 .build(),
         )
     }
@@ -482,7 +482,7 @@ mod tests {
         .expect("valid test payload attributes")
     }
 
-    fn zombie_attributes(timestamp: u64) -> BasePayloadBuilderAttributes<BaseTxEnvelope> {
+    fn zenith_attributes(timestamp: u64) -> BasePayloadBuilderAttributes<BaseTxEnvelope> {
         get_attributes(Some(b64!("0000000000000000")), Some(1), timestamp)
     }
 
@@ -642,9 +642,9 @@ mod tests {
     }
 
     #[test]
-    fn test_malformed_attributes_post_zombie_without_timestamp_millis_part() {
-        let validator = zombie_validator();
-        let attributes = zombie_attributes(ZOMBIE_TIMESTAMP);
+    fn test_malformed_attributes_post_zenith_without_timestamp_millis_part() {
+        let validator = zenith_validator();
+        let attributes = zenith_attributes(ZENITH_TIMESTAMP);
 
         let result = <engine::BaseEngineValidator<_, _> as EngineApiValidator<
             BaseEngineTypes,
@@ -655,9 +655,9 @@ mod tests {
     }
 
     #[test]
-    fn test_malformed_attributes_post_zombie_with_invalid_timestamp_millis_part() {
-        let validator = zombie_validator();
-        let mut attributes = zombie_attributes(ZOMBIE_TIMESTAMP);
+    fn test_malformed_attributes_post_zenith_with_invalid_timestamp_millis_part() {
+        let validator = zenith_validator();
+        let mut attributes = zenith_attributes(ZENITH_TIMESTAMP);
         attributes.timestamp_millis_part = Some(100);
 
         let result = <engine::BaseEngineValidator<_, _> as EngineApiValidator<
@@ -669,9 +669,9 @@ mod tests {
     }
 
     #[test]
-    fn test_well_formed_attributes_post_zombie_with_valid_timestamp_millis_part() {
-        let validator = zombie_validator();
-        let mut attributes = zombie_attributes(ZOMBIE_TIMESTAMP);
+    fn test_well_formed_attributes_post_zenith_with_valid_timestamp_millis_part() {
+        let validator = zenith_validator();
+        let mut attributes = zenith_attributes(ZENITH_TIMESTAMP);
         attributes.timestamp_millis_part = Some(200);
 
         let result = <engine::BaseEngineValidator<_, _> as EngineApiValidator<
@@ -688,7 +688,7 @@ mod tests {
         timestamp_millis_part: Option<u16>,
         parent_timestamp: u64,
     ) -> Result<(), InvalidPayloadAttributesError> {
-        let mut attributes = zombie_attributes(timestamp);
+        let mut attributes = zenith_attributes(timestamp);
         attributes.timestamp_millis_part = timestamp_millis_part;
         let header = Header { timestamp: parent_timestamp, ..Default::default() };
 
@@ -697,51 +697,51 @@ mod tests {
     }
 
     #[test]
-    fn test_payload_attributes_post_zombie_accept_same_second() {
-        let validator = zombie_validator();
+    fn test_payload_attributes_post_zenith_accept_same_second() {
+        let validator = zenith_validator();
 
         assert!(
-            validate_against_parent(&validator, ZOMBIE_TIMESTAMP, Some(200), ZOMBIE_TIMESTAMP,)
+            validate_against_parent(&validator, ZENITH_TIMESTAMP, Some(200), ZENITH_TIMESTAMP,)
                 .is_ok()
         );
     }
 
     #[test]
-    fn test_payload_attributes_post_zombie_accept_next_second() {
-        let validator = zombie_validator();
+    fn test_payload_attributes_post_zenith_accept_next_second() {
+        let validator = zenith_validator();
 
         assert!(
-            validate_against_parent(&validator, ZOMBIE_TIMESTAMP + 1, Some(0), ZOMBIE_TIMESTAMP,)
+            validate_against_parent(&validator, ZENITH_TIMESTAMP + 1, Some(0), ZENITH_TIMESTAMP,)
                 .is_ok()
         );
     }
 
     #[test]
-    fn test_payload_attributes_post_zombie_reject_backwards_seconds() {
-        let validator = zombie_validator();
+    fn test_payload_attributes_post_zenith_reject_backwards_seconds() {
+        let validator = zenith_validator();
 
         assert!(matches!(
-            validate_against_parent(&validator, ZOMBIE_TIMESTAMP, Some(800), ZOMBIE_TIMESTAMP + 1,),
+            validate_against_parent(&validator, ZENITH_TIMESTAMP, Some(800), ZENITH_TIMESTAMP + 1,),
             Err(InvalidPayloadAttributesError::InvalidTimestamp)
         ));
     }
 
     #[test]
-    fn test_payload_attributes_post_zombie_require_millis_part() {
-        let validator = zombie_validator();
+    fn test_payload_attributes_post_zenith_require_millis_part() {
+        let validator = zenith_validator();
 
         assert!(matches!(
-            validate_against_parent(&validator, ZOMBIE_TIMESTAMP, None, ZOMBIE_TIMESTAMP),
+            validate_against_parent(&validator, ZENITH_TIMESTAMP, None, ZENITH_TIMESTAMP),
             Err(InvalidPayloadAttributesError::InvalidTimestamp)
         ));
     }
 
     #[test]
-    fn test_payload_attributes_post_zombie_reject_invalid_millis_part() {
-        let validator = zombie_validator();
+    fn test_payload_attributes_post_zenith_reject_invalid_millis_part() {
+        let validator = zenith_validator();
 
         assert!(matches!(
-            validate_against_parent(&validator, ZOMBIE_TIMESTAMP, Some(999), ZOMBIE_TIMESTAMP,),
+            validate_against_parent(&validator, ZENITH_TIMESTAMP, Some(999), ZENITH_TIMESTAMP,),
             Err(InvalidPayloadAttributesError::InvalidTimestamp)
         ));
     }
@@ -749,7 +749,7 @@ mod tests {
     fn post_execution_block(withdrawals_root: B256) -> RecoveredBlock<BaseBlock> {
         let block = BaseBlock {
             header: Header {
-                timestamp: ZOMBIE_TIMESTAMP,
+                timestamp: ZENITH_TIMESTAMP,
                 withdrawals_root: Some(withdrawals_root),
                 ..Default::default()
             },
@@ -804,7 +804,7 @@ mod tests {
     ) -> Result<(), InsertBlockErrorKind> {
         let validator = validator_with_chain_spec(
             BaseChainSpecBuilder::base_mainnet()
-                .with_fork(BaseUpgrade::Zombie, ForkCondition::Timestamp(ZOMBIE_TIMESTAMP))
+                .with_fork(BaseUpgrade::Zenith, ForkCondition::Timestamp(ZENITH_TIMESTAMP))
                 .build(),
         );
         let block = base_time_block(child_timestamp, child_millis_part, withdrawals_root);
@@ -833,13 +833,13 @@ mod tests {
     fn post_execution_skips_base_time_at_activation_but_checks_isthmus() {
         let block = post_execution_block(EMPTY_ROOT_HASH);
         let parent = SealedHeader::seal_slow(Header {
-            timestamp: ZOMBIE_TIMESTAMP - 1,
+            timestamp: ZENITH_TIMESTAMP - 1,
             ..Default::default()
         });
         let state_updates = HashedPostState::default();
         let error =
             PayloadValidator::<BaseEngineTypes>::validate_block_post_execution_with_hashed_state(
-                &zombie_validator(),
+                &zenith_validator(),
                 || &state_updates,
                 &block,
                 &parent,
@@ -856,26 +856,26 @@ mod tests {
     #[test]
     fn post_execution_validates_exact_200ms_progression() {
         validate_base_time_progression(
-            ZOMBIE_TIMESTAMP,
+            ZENITH_TIMESTAMP,
             200,
-            ZOMBIE_TIMESTAMP,
+            ZENITH_TIMESTAMP,
             400,
             EMPTY_ROOT_HASH,
         )
         .unwrap();
         validate_base_time_progression(
-            ZOMBIE_TIMESTAMP,
+            ZENITH_TIMESTAMP,
             800,
-            ZOMBIE_TIMESTAMP + 1,
+            ZENITH_TIMESTAMP + 1,
             0,
             EMPTY_ROOT_HASH,
         )
         .unwrap();
 
         let error = validate_base_time_progression(
-            ZOMBIE_TIMESTAMP,
+            ZENITH_TIMESTAMP,
             200,
-            ZOMBIE_TIMESTAMP + 1,
+            ZENITH_TIMESTAMP + 1,
             400,
             EMPTY_ROOT_HASH,
         )
@@ -892,9 +892,9 @@ mod tests {
     #[test]
     fn post_execution_validates_isthmus_before_base_time() {
         let error = validate_base_time_progression(
-            ZOMBIE_TIMESTAMP,
+            ZENITH_TIMESTAMP,
             200,
-            ZOMBIE_TIMESTAMP + 1,
+            ZENITH_TIMESTAMP + 1,
             400,
             B256::ZERO,
         )

--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -2594,7 +2594,7 @@ mod tests {
         assert_eq!(target_upgrade(&chain, 100), Some("Beryl"));
 
         chain.apply_upgrades(&UpgradeConfig {
-            base: BaseUpgradeConfig { azul: Some(10), beryl: Some(12), cobalt: None, zombie: None },
+            base: BaseUpgradeConfig { azul: Some(10), beryl: Some(12), cobalt: None, zenith: None },
             ..UpgradeConfig::default()
         });
 
@@ -2613,7 +2613,7 @@ mod tests {
         };
         chain.apply_upgrades(&UpgradeConfig {
             jovian_time: Some(10),
-            base: BaseUpgradeConfig { azul: Some(20), beryl: None, cobalt: None, zombie: None },
+            base: BaseUpgradeConfig { azul: Some(20), beryl: None, cobalt: None, zenith: None },
             ..UpgradeConfig::default()
         });
 
@@ -2632,7 +2632,7 @@ mod tests {
         let delta = chain.specs.iter().find(|spec| spec.name == "Delta").unwrap().timestamp;
 
         chain.apply_upgrades(&UpgradeConfig {
-            base: BaseUpgradeConfig { azul: Some(20), beryl: None, cobalt: None, zombie: None },
+            base: BaseUpgradeConfig { azul: Some(20), beryl: None, cobalt: None, zenith: None },
             ..UpgradeConfig::default()
         });
 

--- a/crates/proof/primitives/src/per_chain_config.rs
+++ b/crates/proof/primitives/src/per_chain_config.rs
@@ -237,7 +237,7 @@ impl PerChainConfig {
                 pectra_blob_schedule_time: None,
                 isthmus_time: Some(0),
                 jovian_time: Some(0),
-                base: BaseUpgradeConfig { azul: Some(0), beryl: None, cobalt: None, zombie: None },
+                base: BaseUpgradeConfig { azul: Some(0), beryl: None, cobalt: None, zenith: None },
             },
             chain_op_config: FeeConfig::base_mainnet(),
         }

--- a/crates/proof/proof/src/boot.rs
+++ b/crates/proof/proof/src/boot.rs
@@ -450,7 +450,7 @@ mod tests {
         let chain_config = BaseChainConfig::MAINNET;
         let upgrades = UpgradeConfig {
             canyon_time: Some(123),
-            base: BaseUpgradeConfig { azul: Some(456), beryl: None, cobalt: None, zombie: None },
+            base: BaseUpgradeConfig { azul: Some(456), beryl: None, cobalt: None, zenith: None },
             ..Default::default()
         };
         let mut rollup_config = chain_config.rollup_config();

--- a/crates/proof/proof/src/schedule_id.rs
+++ b/crates/proof/proof/src/schedule_id.rs
@@ -52,7 +52,7 @@ mod tests {
         let upgrades = UpgradeConfig {
             regolith_time: Some(10),
             canyon_time: Some(20),
-            base: BaseUpgradeConfig { azul: Some(30), beryl: None, cobalt: None, zombie: None },
+            base: BaseUpgradeConfig { azul: Some(30), beryl: None, cobalt: None, zenith: None },
             ..Default::default()
         };
         assert_eq!(
@@ -66,13 +66,13 @@ mod tests {
         let a = UpgradeConfig {
             regolith_time: Some(1),
             canyon_time: Some(2),
-            base: BaseUpgradeConfig { azul: Some(3), beryl: None, cobalt: None, zombie: None },
+            base: BaseUpgradeConfig { azul: Some(3), beryl: None, cobalt: None, zenith: None },
             ..Default::default()
         };
         let b = UpgradeConfig {
             regolith_time: Some(1),
             canyon_time: Some(4),
-            base: BaseUpgradeConfig { azul: Some(3), beryl: None, cobalt: None, zombie: None },
+            base: BaseUpgradeConfig { azul: Some(3), beryl: None, cobalt: None, zenith: None },
             ..Default::default()
         };
 

--- a/crates/proof/succinct/utils/client/src/precompiles/mod.rs
+++ b/crates/proof/succinct/utils/client/src/precompiles/mod.rs
@@ -461,7 +461,7 @@ mod tests {
             (BaseUpgrade::Azul, false),
             (BaseUpgrade::Beryl, true),
             (BaseUpgrade::Cobalt, true),
-            (BaseUpgrade::Zombie, true),
+            (BaseUpgrade::Zenith, true),
         ] {
             let spec = BaseSpecId::new(upgrade);
             let base_precompiles = BasePrecompiles::new_with_spec(spec).install();

--- a/crates/utilities/upgrade-signal/src/runtime/sink.rs
+++ b/crates/utilities/upgrade-signal/src/runtime/sink.rs
@@ -30,7 +30,7 @@ impl UpgradeActivationSink for RuntimeRegistrySink {
         upgrade_id: BaseUpgrade,
         activation: UpgradeActivation,
     ) -> Result<bool, Self::Error> {
-        if matches!(upgrade_id, BaseUpgrade::Zombie) {
+        if matches!(upgrade_id, BaseUpgrade::Zenith) {
             return Ok(false);
         }
 


### PR DESCRIPTION
## Summary

Renames the `Zombie` hardfork to `Zenith` across the entire codebase.

## Changes

- **25 files** across 6 logical layers
- All identifiers renamed: `Zombie`/`zombie`/`ZOMBIE` → `Zenith`/`zenith`/`ZENITH`
- Covers enum variants, struct fields, method names, constants, comments, and doc strings
- No behavioral changes — pure rename

## Commits

- `refactor(genesis)`: `common/genesis` (upgrade definitions, rollup config, `BaseUpgradeConfig.zenith` field)
- `refactor(chains)`: `common/chains` (chain upgrade, config, runtime upgrade registry)
- `refactor(common)`: `common/evm`, `common/precompiles`, `common/rpc-types`
- `refactor(execution)`: chainspec, consensus validation, EVM tests, engine validator
- `refactor(consensus)`: derive, sequencer actor/build, engine versions, CLI metrics
- `refactor(proof,infra)`: proof boot/schedule_id, succinct precompiles, per-chain config, basectl, upgrade-signal