### PR TITLE
fix(ci): wrap bail! in blocks to fix nightly semicolon_in_expressions_from_macros lint

### DIFF
--- a/crates/batcher/service/src/service.rs
+++ b/crates/batcher/service/src/service.rs
@@ -137,8 +137,12 @@ impl ReadyBatcher {
                 () = background_cancellation.cancelled() => {}
                 Some((task_name, result)) = background_tasks.next(), if !background_tasks.is_empty() => {
                     match result {
-                        Ok(()) => eyre::bail!("{task_name} exited unexpectedly"),
-                        Err(error) => eyre::bail!("{task_name} task failed: {error}"),
+                        Ok(()) => {
+                            eyre::bail!("{task_name} exited unexpectedly")
+                        }
+                        Err(error) => {
+                            eyre::bail!("{task_name} task failed: {error}")
+                        }
                     }
                 }
             }

--- a/crates/infra/audit/src/storage.rs
+++ b/crates/infra/audit/src/storage.rs
@@ -433,7 +433,9 @@ impl EventWriter for S3EventReaderWriter {
         let bundle_key = match &event.event {
             BundleEvent::Received { bundle, .. } => format!("{}", bundle.bundle_hash()),
             // TODO: support other event types using bundle hash
-            _ => anyhow::bail!("archive_event only supports Received events"),
+            _ => {
+                anyhow::bail!("archive_event only supports Received events")
+            }
         };
         let transaction_ids = event.event.transaction_ids();
 

--- a/crates/infra/snark-e2e/src/snark_e2e.rs
+++ b/crates/infra/snark-e2e/src/snark_e2e.rs
@@ -81,7 +81,9 @@ impl SnarkE2e {
             ProofResult::Compressed(_) => {
                 bail!("expected SnarkPlonk proof result, got Compressed")
             }
-            ProofResult::Tee(_) => bail!("expected SnarkPlonk proof result, got Tee"),
+            ProofResult::Tee(_) => {
+                bail!("expected SnarkPlonk proof result, got Tee")
+            }
         }
     }
 

--- a/crates/infra/zk-benchmarks/src/runner.rs
+++ b/crates/infra/zk-benchmarks/src/runner.rs
@@ -211,7 +211,9 @@ impl ZkBenchRunner {
             Some(ProofResult::Tee(_)) => {
                 eyre::bail!("proof request {session_id} returned tee result")
             }
-            None => eyre::bail!("proof request {session_id} succeeded without a result"),
+            None => {
+                eyre::bail!("proof request {session_id} succeeded without a result")
+            }
         };
 
         match zk_backend {

--- a/crates/proof/succinct/scripts/bin/parse_receipt.rs
+++ b/crates/proof/succinct/scripts/bin/parse_receipt.rs
@@ -47,7 +47,9 @@ fn main() -> Result<()> {
             parse_aggregation_outputs(&proof_with_pv, &raw_pv, args.export_json.as_deref())?;
         }
         "stark" | "range" => parse_range_outputs(&mut proof_with_pv)?,
-        other => anyhow::bail!("Unknown type '{other}'. Use 'stark' or 'snark'."),
+        other => {
+            anyhow::bail!("Unknown type '{other}'. Use 'stark' or 'snark'.")
+        }
     }
 
     Ok(())

--- a/crates/proof/succinct/utils/host/src/network.rs
+++ b/crates/proof/succinct/utils/host/src/network.rs
@@ -12,9 +12,11 @@ pub fn parse_fulfillment_strategy(value: String) -> Result<FulfillmentStrategy> 
         "reserved" => Ok(FulfillmentStrategy::Reserved),
         "hosted" => Ok(FulfillmentStrategy::Hosted),
         "auction" => Ok(FulfillmentStrategy::Auction),
-        _ => bail!(
-            "Invalid fulfillment strategy '{value}': must be 'reserved', 'hosted', or 'auction'"
-        ),
+        _ => {
+            bail!(
+                "Invalid fulfillment strategy '{value}': must be 'reserved', 'hosted', or 'auction'"
+            )
+        }
     }
 }
 
@@ -82,7 +84,9 @@ pub async fn build_network_prover_from_env(strategy: FulfillmentStrategy) -> Res
     let network_mode = match strategy {
         FulfillmentStrategy::Auction => NetworkMode::Mainnet,
         FulfillmentStrategy::Hosted | FulfillmentStrategy::Reserved => NetworkMode::Reserved,
-        _ => bail!("Fulfillment strategy must be 'reserved', 'hosted', or 'auction'"),
+        _ => {
+            bail!("Fulfillment strategy must be 'reserved', 'hosted', or 'auction'")
+        }
     };
 
     let prover =


### PR DESCRIPTION
## Summary

Fixes the daily **Udeps Report** CI workflow which has been failing since nightly Rust 1.95+ started enforcing `semicolon_in_expressions_from_macros` as a hard error.

**Example failing run**: https://github.com/base/base/actions/runs/30011552783

## Root Cause

The `bail!` / `eyre::bail!` / `anyhow::bail!` macros expand to a `return Err(...)` statement ending with a semicolon. When used directly as a **match arm expression** (without braces), e.g.:

```rust
match result {
    Ok(()) => eyre::bail!("task exited unexpectedly"),  // ❌ expression position
    Err(e) => eyre::bail!("task failed: {e}"),
}
```

Nightly Rust 1.95+ rejects this with:
```
error: trailing semicolon in macro used in expression position
  = note: `#[deny(semicolon_in_expressions_from_macros)]` (part of `#[deny(future_incompatible)]`) on by default
```

## Fix

Wrap each offending match arm body in braces so the `bail!` invocation is in **statement position**:

```rust
match result {
    Ok(()) => {
        eyre::bail!("task exited unexpectedly")  // ✅ statement position
    }
    Err(e) => {
        eyre::bail!("task failed: {e}")
    }
}
```

## Files Changed

- `crates/batcher/service/src/service.rs` — primary CI failure point
- `crates/infra/audit/src/storage.rs`
- `crates/infra/snark-e2e/src/snark_e2e.rs`
- `crates/infra/zk-benchmarks/src/runner.rs`
- `crates/proof/succinct/scripts/bin/parse_receipt.rs`
- `crates/proof/succinct/utils/host/src/network.rs`

## Verification

All changed crates pass `cargo +nightly check --all-features` locally.