### PR TITLE
fix(consensus): recover follow safe-head divergence via FCU sync

### DIFF
--- a/crates/consensus/service/src/follow/engine.rs
+++ b/crates/consensus/service/src/follow/engine.rs
@@ -7,11 +7,12 @@ use base_consensus_engine::{
     EngineClient, EngineState, EngineSyncStateUpdate, EngineTask, EngineTaskExt, InsertTask,
     SynchronizeTask,
 };
-use base_protocol::L2BlockInfo;
+use base_protocol::{BlockInfo, L2BlockInfo};
 use tokio::sync::Mutex;
 
 use crate::follow::error::FollowError;
 
+#[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub(super) trait FollowEngine: Debug + Send + Sync {
     async fn insert_payload(
@@ -24,6 +25,17 @@ pub(super) trait FollowEngine: Debug + Send + Sync {
         safe: Option<L2BlockInfo>,
         finalized: Option<L2BlockInfo>,
     ) -> Result<(), FollowError>;
+
+    /// Sends a forced forkchoice update and reports whether the EL confirmed `head`.
+    ///
+    /// On `Syncing`, the unsafe head is left unconfirmed. Callers must not treat a `false`
+    /// return as progress toward recovery.
+    async fn request_forkchoice(
+        &self,
+        head: BlockInfo,
+        safe: BlockInfo,
+        finalized: BlockInfo,
+    ) -> Result<bool, FollowError>;
 }
 
 #[derive(Debug)]
@@ -78,17 +90,47 @@ impl<E: EngineClient + Debug + 'static> FollowEngine for EngineApiFollowEngine<E
             return Ok(());
         }
 
+        let mut state = self.state.lock().await;
+        let current_unsafe = state.sync_state.unsafe_head();
+        let unsafe_head = safe.filter(|safe_head| {
+            safe_head.block_info.number == current_unsafe.block_info.number
+                && safe_head.block_info.hash == current_unsafe.block_info.hash
+        });
         let task = SynchronizeTask::new(
             Arc::clone(&self.client),
             Arc::clone(&self.rollup_config),
             EngineSyncStateUpdate {
+                unsafe_head,
                 local_safe_head: safe,
                 safe_head: safe,
                 finalized_head: finalized,
-                ..Default::default()
             },
         );
-        task.execute(&mut *self.state.lock().await).await.map_err(FollowError::engine_task)
+        task.execute(&mut state).await.map_err(FollowError::engine_task)
+    }
+
+    async fn request_forkchoice(
+        &self,
+        head: BlockInfo,
+        safe: BlockInfo,
+        finalized: BlockInfo,
+    ) -> Result<bool, FollowError> {
+        let requested_head = L2BlockInfo { block_info: head, ..Default::default() };
+        let requested_safe = L2BlockInfo { block_info: safe, ..Default::default() };
+        let requested_finalized = L2BlockInfo { block_info: finalized, ..Default::default() };
+        let task = SynchronizeTask::new_forced(
+            Arc::clone(&self.client),
+            Arc::clone(&self.rollup_config),
+            EngineSyncStateUpdate {
+                unsafe_head: Some(requested_head),
+                local_safe_head: Some(requested_safe),
+                safe_head: Some(requested_safe),
+                finalized_head: Some(requested_finalized),
+            },
+        );
+        let mut state = self.state.lock().await;
+        task.execute(&mut state).await.map_err(FollowError::engine_task)?;
+        Ok(state.sync_state.unsafe_head().block_info.hash == head.hash)
     }
 }
 
@@ -116,6 +158,16 @@ mod tests {
 
     fn valid_forkchoice_updated() -> ForkchoiceUpdated {
         ForkchoiceUpdated { payload_status: valid_payload_status(), payload_id: None }
+    }
+
+    fn syncing_forkchoice_updated() -> ForkchoiceUpdated {
+        ForkchoiceUpdated {
+            payload_status: PayloadStatus {
+                status: PayloadStatusEnum::Syncing,
+                latest_valid_hash: None,
+            },
+            payload_id: None,
+        }
     }
 
     fn l1_info_deposit_tx() -> Vec<u8> {
@@ -156,6 +208,58 @@ mod tests {
                 block_hash: B256::with_last_byte(number as u8),
                 transactions: vec![l1_info_deposit_tx().into()],
             }),
+        }
+    }
+
+    #[tokio::test]
+    async fn unknown_head_remains_unconfirmed_until_valid_forkchoice() {
+        let rollup_config = Arc::new(RollupConfig::default());
+        let client = Arc::new(
+            test_engine_client_builder()
+                .with_config(Arc::clone(&rollup_config))
+                .with_fork_choice_updated_v3_response(syncing_forkchoice_updated())
+                .build(),
+        );
+        let local_tip = l2_block_info(10);
+        let finalized = l2_block_info(3);
+        let engine = EngineApiFollowEngine::new(
+            Arc::clone(&client),
+            rollup_config,
+            local_tip,
+            l2_block_info(8),
+            finalized,
+        );
+        let target = l2_block_info(8).block_info;
+
+        assert!(
+            !engine
+                .request_forkchoice(target, finalized.block_info, finalized.block_info)
+                .await
+                .expect("syncing forkchoice")
+        );
+        // Syncing must not advance the unconfirmed source tip into engine state.
+        assert_eq!(engine.state.lock().await.sync_state.unsafe_head(), local_tip);
+        assert_eq!(engine.state.lock().await.sync_state.safe_head(), l2_block_info(8));
+
+        client.set_fork_choice_updated_v3_response(valid_forkchoice_updated()).await;
+        assert!(
+            engine
+                .request_forkchoice(target, finalized.block_info, finalized.block_info)
+                .await
+                .expect("valid forkchoice")
+        );
+        assert_eq!(engine.state.lock().await.sync_state.unsafe_head().block_info, target);
+        assert_eq!(engine.state.lock().await.sync_state.safe_head(), finalized);
+        assert!(client.last_new_payload_v2().await.is_none());
+
+        let storage = client.storage();
+        let storage = storage.read().await;
+        assert_eq!(storage.fork_choice_updated_v3_requests.len(), 2);
+        for (forkchoice, has_attributes) in &storage.fork_choice_updated_v3_requests {
+            assert_eq!(forkchoice.head_block_hash, target.hash);
+            assert_eq!(forkchoice.safe_block_hash, finalized.block_info.hash);
+            assert_eq!(forkchoice.finalized_block_hash, finalized.block_info.hash);
+            assert!(!has_attributes);
         }
     }
 

--- a/crates/consensus/service/src/follow/error.rs
+++ b/crates/consensus/service/src/follow/error.rs
@@ -22,6 +22,15 @@ pub enum FollowError {
         source: alloy_transport::TransportError,
     },
 
+    /// Fetching a block from the local L2 node by hash failed.
+    #[error("failed to fetch local L2 block {hash}: {source}")]
+    LocalBlockHashFetch {
+        /// Requested local block hash.
+        hash: B256,
+        /// Underlying transport error.
+        source: alloy_transport::TransportError,
+    },
+
     /// Converting a local L2 block into block info failed.
     #[error("failed to build local L2 block info: {0}")]
     LocalBlockInfo(#[from] FromBlockError),
@@ -72,6 +81,27 @@ pub enum FollowError {
         /// Hash returned by the source L2 node.
         remote: B256,
     },
+
+    /// The source and local nodes disagree on a finalized block hash.
+    #[error(
+        "source finalized block hash {remote} does not match local block hash {local} at block {number}"
+    )]
+    FinalizedDivergence {
+        /// Finalized block number compared across the source and local nodes.
+        number: u64,
+        /// Hash returned by the local L2 node.
+        local: B256,
+        /// Hash returned by the source L2 node.
+        remote: B256,
+    },
+
+    /// A transient safe-head recovery failure. The runtime should retry after re-reading labels.
+    #[error("follow recovery failed: {0}")]
+    RecoveryFailed(&'static str),
+
+    /// Follow-mode recovery was cancelled.
+    #[error("follow-mode recovery cancelled")]
+    RecoveryCancelled,
 
     /// The local engine rejected a follow-mode task.
     #[error("engine task failed with {severity} severity: {error}")]

--- a/crates/consensus/service/src/follow/local.rs
+++ b/crates/consensus/service/src/follow/local.rs
@@ -21,9 +21,35 @@ struct ProofsSyncStatus {
 pub(super) trait FollowLocalClient: Debug + Send + Sync {
     async fn block_info(&self, tag: BlockNumberOrTag) -> Result<Option<L2BlockInfo>, FollowError>;
 
+    async fn block_info_by_hash(&self, hash: B256) -> Result<Option<L2BlockInfo>, FollowError>;
+
     async fn l1_block_hash(&self, number: u64) -> Result<Option<B256>, FollowError>;
 
     async fn proofs_latest(&self) -> Result<Option<u64>, FollowError>;
+}
+
+/// Verifies that a block's L1 origin is canonical in the local L1 view.
+pub(super) async fn validate_block_l1_origin<Local>(
+    local: &Local,
+    block: &L2BlockInfo,
+) -> Result<(), FollowError>
+where
+    Local: FollowLocalClient + ?Sized,
+{
+    let origin = block.l1_origin;
+    let local_hash = local
+        .l1_block_hash(origin.number)
+        .await?
+        .ok_or(FollowError::LocalL1BlockUnavailable(origin.number))?;
+    if local_hash != origin.hash {
+        return Err(FollowError::L2OriginNotCanonical {
+            l2_number: block.block_info.number,
+            l1_number: origin.number,
+            local_l1: local_hash,
+            l2_origin: origin.hash,
+        });
+    }
+    Ok(())
 }
 
 #[derive(Clone, Debug)]
@@ -52,6 +78,27 @@ impl FollowLocalClient for LocalL2Client {
             .full()
             .await
             .map_err(|source| FollowError::LocalBlockFetch { tag, source })?;
+        let Some(block) = block else {
+            return Ok(None);
+        };
+        L2BlockInfo::from_block_and_genesis(
+            &block
+                .map_header(|header| header.into_inner())
+                .into_consensus()
+                .map_transactions(|tx| tx.inner.inner.into_inner()),
+            &self.rollup_config.genesis,
+        )
+        .map(Some)
+        .map_err(FollowError::from)
+    }
+
+    async fn block_info_by_hash(&self, hash: B256) -> Result<Option<L2BlockInfo>, FollowError> {
+        let block = self
+            .provider
+            .get_block_by_hash(hash)
+            .full()
+            .await
+            .map_err(|source| FollowError::LocalBlockHashFetch { hash, source })?;
         let Some(block) = block else {
             return Ok(None);
         };

--- a/crates/consensus/service/src/follow/mod.rs
+++ b/crates/consensus/service/src/follow/mod.rs
@@ -10,6 +10,7 @@ pub use node::{FollowNode, FollowNodeConfig};
 
 mod prefetcher;
 mod proof_gate;
+mod recovery;
 mod rpc;
 mod runtime;
 mod source;

--- a/crates/consensus/service/src/follow/recovery.rs
+++ b/crates/consensus/service/src/follow/recovery.rs
@@ -1,0 +1,165 @@
+//! Follow-mode recovery via Engine API forkchoice sync.
+//!
+//! On safe-head divergence, prove the current source-safe branch still contains the local
+//! finalized hash, then send a source-accurate forkchoice update. The local EL is expected to
+//! backfill missing bodies from peers; follow does not replay payloads with `newPayload` during
+//! recovery.
+
+use std::{sync::Arc, time::Duration};
+
+use alloy_eips::BlockNumberOrTag;
+use base_protocol::{BlockInfo, L2BlockInfo};
+use tokio::time::{self, Instant};
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+
+use crate::follow::{
+    engine::FollowEngine,
+    error::FollowError,
+    local::{FollowLocalClient, validate_block_l1_origin},
+    source::RemoteClient,
+};
+
+const FINALIZED_LOOKUP_LIMIT: usize = 4_096;
+const HEAD_SYNC_TIMEOUT: Duration = Duration::from_secs(120);
+const HEAD_SYNC_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+#[derive(Debug)]
+pub(super) struct FollowRecovery;
+
+impl FollowRecovery {
+    /// Reads fresh source-safe and local finalized labels, then recovers onto that source-safe head.
+    pub(super) async fn recover<Local, Remote>(
+        local: Arc<Local>,
+        source: Arc<Remote>,
+        engine: Arc<dyn FollowEngine>,
+        cancellation: CancellationToken,
+    ) -> Result<L2BlockInfo, FollowError>
+    where
+        Local: FollowLocalClient + 'static,
+        Remote: RemoteClient + 'static,
+    {
+        let source_safe = source.get_block_info(BlockNumberOrTag::Safe).await?;
+        let finalized = local
+            .block_info(BlockNumberOrTag::Finalized)
+            .await?
+            .ok_or(FollowError::LocalBlockUnavailable(BlockNumberOrTag::Finalized))?;
+
+        Self::ensure_finalized_on_source_branch(
+            source.as_ref(),
+            &cancellation,
+            source_safe,
+            &finalized,
+        )
+        .await?;
+
+        let deadline = Instant::now() + HEAD_SYNC_TIMEOUT;
+        let mut attempts = 0_u64;
+        loop {
+            if Instant::now() >= deadline {
+                return Err(FollowError::RecoveryFailed(
+                    "execution layer did not confirm source-safe head",
+                ));
+            }
+            attempts = attempts.saturating_add(1);
+
+            // Keep safe/finalized pinned to the verified local finalized fence while the EL may
+            // still be Syncing. Promoting source-safe as safe is deferred until Valid confirmation.
+            let confirmed = tokio::select! {
+                _ = cancellation.cancelled() => return Err(FollowError::RecoveryCancelled),
+                result = engine.request_forkchoice(
+                    source_safe,
+                    finalized.block_info,
+                    finalized.block_info,
+                ) => result?,
+            };
+            if confirmed {
+                break;
+            }
+
+            tokio::select! {
+                _ = cancellation.cancelled() => return Err(FollowError::RecoveryCancelled),
+                _ = time::sleep(HEAD_SYNC_POLL_INTERVAL) => {}
+            }
+        }
+
+        let recovered = local.block_info_by_hash(source_safe.hash).await?.ok_or(
+            FollowError::RecoveryFailed(
+                "confirmed source-safe head was unavailable from the local execution layer",
+            ),
+        )?;
+        if recovered.block_info != source_safe {
+            return Err(FollowError::SourceBlockHashMismatch {
+                number: source_safe.number,
+                local: recovered.block_info.hash,
+                remote: source_safe.hash,
+            });
+        }
+        validate_block_l1_origin(local.as_ref(), &recovered).await?;
+
+        engine.update_safe_finalized_blocks(Some(recovered), None).await?;
+        info!(
+            target: "follow",
+            number = recovered.block_info.number,
+            hash = %recovered.block_info.hash,
+            finalized_number = finalized.block_info.number,
+            finalized_hash = %finalized.block_info.hash,
+            attempts,
+            "Recovered follow mode onto source-safe head via forkchoice sync",
+        );
+        Ok(recovered)
+    }
+
+    /// Walks the source-safe branch by parent hash until the local finalized hash appears.
+    async fn ensure_finalized_on_source_branch<Remote>(
+        source: &Remote,
+        cancellation: &CancellationToken,
+        source_safe: BlockInfo,
+        finalized: &L2BlockInfo,
+    ) -> Result<(), FollowError>
+    where
+        Remote: RemoteClient,
+    {
+        let finalized_number = finalized.block_info.number;
+        let finalized_hash = finalized.block_info.hash;
+        let mut source_block = source_safe;
+        let mut lookups = 0;
+
+        loop {
+            if source_block.hash == finalized_hash {
+                if source_block.number != finalized_number {
+                    return Err(FollowError::RecoveryFailed(
+                        "source finalized hash appeared at an unexpected block number",
+                    ));
+                }
+                return Ok(());
+            }
+            if source_block.number <= finalized_number {
+                return Err(FollowError::FinalizedDivergence {
+                    number: finalized_number,
+                    local: finalized_hash,
+                    remote: source_block.hash,
+                });
+            }
+            if lookups >= FINALIZED_LOOKUP_LIMIT {
+                return Err(FollowError::RecoveryFailed(
+                    "exceeded finalized-ancestry lookup budget",
+                ));
+            }
+            lookups += 1;
+
+            let parent = tokio::select! {
+                _ = cancellation.cancelled() => return Err(FollowError::RecoveryCancelled),
+                result = source.get_block_info_by_hash(source_block.parent_hash) => result?,
+            };
+            if parent.hash != source_block.parent_hash
+                || parent.number.saturating_add(1) != source_block.number
+            {
+                return Err(FollowError::RecoveryFailed(
+                    "source parent lookup did not return the claimed parent",
+                ));
+            }
+            source_block = parent;
+        }
+    }
+}

--- a/crates/consensus/service/src/follow/runtime.rs
+++ b/crates/consensus/service/src/follow/runtime.rs
@@ -7,6 +7,7 @@ use tokio::{
     time::{self, MissedTickBehavior},
 };
 use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, info, warn};
 
 use crate::{
     Metrics,
@@ -16,11 +17,24 @@ use crate::{
         local::FollowLocalClient,
         prefetcher::{PREFETCH_WINDOW, PayloadPrefetcher, PrefetchedPayload},
         proof_gate::ProofGate,
+        recovery::FollowRecovery,
         source::RemoteClient,
     },
 };
 
 const SAFETY_POLL_INTERVAL: Duration = Duration::from_secs(30);
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum SafetyUpdate {
+    Updated,
+    Recover,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum GenerationOutcome {
+    Stopped,
+    Recover,
+}
 
 #[derive(Debug)]
 pub(super) struct FollowRuntime<Local, Remote, Gate> {
@@ -94,79 +108,69 @@ where
         }
     }
 
-    async fn run_update_safe_finalized_heads_loop(
-        local: Arc<Local>,
-        source: Arc<Remote>,
-        engine: Arc<dyn FollowEngine>,
-        cancellation: CancellationToken,
-    ) -> Result<(), FollowError> {
-        let mut ticker = time::interval(SAFETY_POLL_INTERVAL);
-        ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
-
-        loop {
-            if cancellation.is_cancelled() {
-                return Ok(());
-            }
-
-            ticker.tick().await;
-            if let Err(e) = Self::update_safe_and_finalized(
-                Arc::clone(&local),
-                Arc::clone(&source),
-                Arc::clone(&engine),
-            )
-            .await
-            {
-                warn!(target: "follow", error = %e, "Failed to update safe/finalized labels");
-            }
-        }
-    }
-
     async fn update_safe_and_finalized(
         local: Arc<Local>,
         source: Arc<Remote>,
         engine: Arc<dyn FollowEngine>,
-    ) -> Result<(), FollowError> {
+    ) -> Result<SafetyUpdate, FollowError> {
         let latest = local
             .block_info(BlockNumberOrTag::Latest)
             .await?
             .ok_or(FollowError::LocalBlockUnavailable(BlockNumberOrTag::Latest))?;
         let Some(local_safe) = local.block_info(BlockNumberOrTag::Safe).await? else {
             debug!(target: "follow", "Skipping safe/finalized update because local safe label is unavailable");
-            return Ok(());
+            return Ok(SafetyUpdate::Updated);
         };
         let local_finalized = local.block_info(BlockNumberOrTag::Finalized).await?;
 
         // Read number and hash from the same response, matching op-node's `L2BlockRefByLabel`.
         let source_safe = source.get_block_info(BlockNumberOrTag::Safe).await?;
-        let safe = Self::verified_local_block(
+        let source_finalized = source.get_block_info(BlockNumberOrTag::Finalized).await?;
+
+        // Check finalized before safe recovery. A finalized disagreement is never recoverable and
+        // must only alert while ordinary following remains active.
+        let local_finalized_number =
+            local_finalized.map(|block| block.block_info.number).unwrap_or_default();
+        let finalized_ceiling =
+            latest.block_info.number.min(source_safe.number.max(local_safe.block_info.number));
+        let finalized = match Self::verified_local_block(
+            &local,
+            &source_finalized,
+            local_finalized_number,
+            finalized_ceiling,
+        )
+        .await
+        {
+            Ok(finalized) => finalized,
+            Err(FollowError::SourceBlockHashMismatch { number, local, remote }) => {
+                return Err(FollowError::FinalizedDivergence { number, local, remote });
+            }
+            Err(error) => return Err(error),
+        };
+        if let Some(finalized_block) = finalized.as_ref() {
+            Self::log_l2_origin_validation(local.as_ref(), finalized_block).await;
+        }
+
+        let safe = match Self::verified_local_block(
             &local,
             &source_safe,
             local_safe.block_info.number,
             latest.block_info.number,
         )
-        .await?;
+        .await
+        {
+            Ok(safe) => safe,
+            Err(FollowError::SourceBlockHashMismatch { .. }) => {
+                return Ok(SafetyUpdate::Recover);
+            }
+            Err(error) => return Err(error),
+        };
         if let Some(safe_block) = safe.as_ref() {
             Self::log_l2_origin_validation(local.as_ref(), safe_block).await;
         }
 
-        let safe_limit = safe.as_ref().unwrap_or(&local_safe).block_info.number;
-
-        // Finalized floor at the local finalized head (never unwind), ceiling at the safe head.
-        let source_finalized = source.get_block_info(BlockNumberOrTag::Finalized).await?;
-        let local_finalized_number =
-            local_finalized.map(|block| block.block_info.number).unwrap_or_default();
-        let finalized = Self::verified_local_block(
-            &local,
-            &source_finalized,
-            local_finalized_number,
-            latest.block_info.number.min(safe_limit),
-        )
-        .await?;
-        if let Some(finalized_block) = finalized.as_ref() {
-            Self::log_l2_origin_validation(local.as_ref(), finalized_block).await;
-        }
-
-        engine.update_safe_finalized_blocks(safe, finalized).await
+        engine.update_safe_finalized_blocks(safe, finalized).await?;
+        Ok(SafetyUpdate::Updated)
     }
 
     /// Returns the local block at a coherent source label's height (`{number, hash}` from a single
@@ -266,34 +270,162 @@ where
     Remote: RemoteClient + 'static,
     Gate: ProofGate + 'static,
 {
-    pub(super) async fn start(mut self) -> Result<(), FollowError> {
-        let next_insert = self.follow_from_block.block_info.number.saturating_add(1);
+    async fn run_generation(&mut self, start_block: u64) -> Result<GenerationOutcome, FollowError> {
+        let generation_cancellation = self.cancellation.child_token();
         let (blocks_to_insert_tx, blocks_to_insert_rx) = mpsc::channel(PREFETCH_WINDOW);
         let prefetcher = PayloadPrefetcher::new(
             Arc::clone(&self.source),
-            self.cancellation.clone(),
+            generation_cancellation.clone(),
             blocks_to_insert_tx,
         );
-        let fetch_loop = prefetcher.run(self.follow_from_block.block_info.number);
+        let fetch_loop = prefetcher.run(start_block);
         let insert_loop = Self::run_ordered_insert_loop(
             Arc::clone(&self.engine),
-            self.cancellation.clone(),
+            generation_cancellation.clone(),
             blocks_to_insert_rx,
-            next_insert,
+            start_block.saturating_add(1),
             &mut self.proof_gate,
             self.insert_delay,
         );
-        let safety_loop = Self::run_update_safe_finalized_heads_loop(
+        let mut ticker =
+            time::interval_at(time::Instant::now() + SAFETY_POLL_INTERVAL, SAFETY_POLL_INTERVAL);
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        tokio::pin!(fetch_loop);
+        tokio::pin!(insert_loop);
+
+        loop {
+            tokio::select! {
+                _ = self.cancellation.cancelled() => {
+                    generation_cancellation.cancel();
+                    return Ok(GenerationOutcome::Stopped);
+                }
+                result = &mut fetch_loop => {
+                    generation_cancellation.cancel();
+                    result?;
+                    return Ok(GenerationOutcome::Stopped);
+                }
+                result = &mut insert_loop => {
+                    generation_cancellation.cancel();
+                    result?;
+                    return Ok(GenerationOutcome::Stopped);
+                }
+                _ = ticker.tick() => {
+                    match Self::update_safe_and_finalized(
+                        Arc::clone(&self.local),
+                        Arc::clone(&self.source),
+                        Arc::clone(&self.engine),
+                    )
+                    .await
+                    {
+                        Ok(SafetyUpdate::Updated) => {}
+                        Ok(SafetyUpdate::Recover) => {
+                            warn!(
+                                target: "follow",
+                                "Detected safe-head divergence; pausing payload insertion"
+                            );
+                            generation_cancellation.cancel();
+                            return Ok(GenerationOutcome::Recover);
+                        }
+                        Err(error @ FollowError::FinalizedDivergence { .. }) => {
+                            error!(
+                                target: "follow",
+                                error = %error,
+                                "Detected finalized-head divergence"
+                            );
+                        }
+                        Err(error) => {
+                            warn!(
+                                target: "follow",
+                                error = %error,
+                                "Failed to update safe/finalized labels"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub(super) async fn start(mut self) -> Result<(), FollowError> {
+        let mut start_block = self.follow_from_block.block_info.number;
+        let mut needs_recovery = match Self::update_safe_and_finalized(
             Arc::clone(&self.local),
             Arc::clone(&self.source),
             Arc::clone(&self.engine),
-            self.cancellation.clone(),
-        );
+        )
+        .await
+        {
+            Ok(SafetyUpdate::Recover) => true,
+            Ok(SafetyUpdate::Updated) => false,
+            Err(error @ FollowError::FinalizedDivergence { .. }) => {
+                error!(
+                    target: "follow",
+                    error = %error,
+                    "Detected finalized-head divergence"
+                );
+                false
+            }
+            Err(error) => {
+                warn!(
+                    target: "follow",
+                    error = %error,
+                    "Failed initial safe/finalized update"
+                );
+                false
+            }
+        };
 
-        tokio::select! {
-            result = fetch_loop => result,
-            result = insert_loop => result,
-            result = safety_loop => result,
+        loop {
+            if self.cancellation.is_cancelled() {
+                return Ok(());
+            }
+
+            if needs_recovery {
+                match FollowRecovery::recover(
+                    Arc::clone(&self.local),
+                    Arc::clone(&self.source),
+                    Arc::clone(&self.engine),
+                    self.cancellation.clone(),
+                )
+                .await
+                {
+                    Ok(recovered) => {
+                        start_block = recovered.block_info.number;
+                        needs_recovery = false;
+                        info!(
+                            target: "follow",
+                            number = start_block,
+                            hash = %recovered.block_info.hash,
+                            "Safe-head recovery completed; restarting payload insertion"
+                        );
+                    }
+                    Err(FollowError::RecoveryCancelled) if self.cancellation.is_cancelled() => {
+                        return Ok(());
+                    }
+                    Err(error @ FollowError::FinalizedDivergence { .. }) => {
+                        error!(
+                            target: "follow",
+                            error = %error,
+                            "Safe-head recovery hit finalized divergence; keeping payload insertion paused"
+                        );
+                        time::sleep(SAFETY_POLL_INTERVAL).await;
+                    }
+                    Err(error) => {
+                        warn!(
+                            target: "follow",
+                            error = %error,
+                            "Safe-head recovery failed; re-reading labels before retry"
+                        );
+                        time::sleep(SAFETY_POLL_INTERVAL).await;
+                    }
+                }
+                continue;
+            }
+
+            match self.run_generation(start_block).await? {
+                GenerationOutcome::Stopped => return Ok(()),
+                GenerationOutcome::Recover => needs_recovery = true,
+            }
         }
     }
 }
@@ -321,7 +453,7 @@ mod tests {
     use crate::{
         MockRemoteClient,
         follow::{
-            engine::FollowEngine,
+            engine::{FollowEngine, MockFollowEngine},
             local::MockFollowLocalClient,
             proof_gate::{ActiveProofGate, NoopProofGate},
         },
@@ -340,6 +472,30 @@ mod tests {
     struct DelayedSource {
         latest: u64,
         fetch_delay: Duration,
+    }
+
+    #[derive(Debug)]
+    struct RecoveryRecordingEngine {
+        inserted: Mutex<Vec<u64>>,
+        forkchoices: Mutex<Vec<(BlockInfo, BlockInfo, BlockInfo)>>,
+        labels: Mutex<Vec<(Option<u64>, Option<u64>)>>,
+        head_requests: AtomicU64,
+    }
+
+    #[derive(Debug)]
+    struct PauseFirstGeneration {
+        first_wait: bool,
+    }
+
+    #[async_trait]
+    impl ProofGate for PauseFirstGeneration {
+        async fn wait_til_ready(&mut self, _current_block: u64) -> Result<(), FollowError> {
+            if self.first_wait {
+                self.first_wait = false;
+                std::future::pending::<()>().await;
+            }
+            Ok(())
+        }
     }
 
     #[async_trait]
@@ -364,6 +520,13 @@ mod tests {
                 BlockNumberOrTag::Number(number) => source_block_info(number),
                 _ => source_block_info(0),
             })
+        }
+
+        async fn get_block_info_by_hash(
+            &self,
+            hash: B256,
+        ) -> Result<BlockInfo, crate::RemoteL2ClientError> {
+            Ok(source_block_info(u64::from(hash.as_slice()[31])))
         }
 
         async fn get_payload_by_number(
@@ -401,6 +564,48 @@ mod tests {
                 .push((safe.map(|v| v.block_info.number), finalized.map(|v| v.block_info.number)));
             Ok(())
         }
+
+        async fn request_forkchoice(
+            &self,
+            _head: BlockInfo,
+            _safe: BlockInfo,
+            _finalized: BlockInfo,
+        ) -> Result<bool, FollowError> {
+            Ok(true)
+        }
+    }
+
+    #[async_trait]
+    impl FollowEngine for RecoveryRecordingEngine {
+        async fn insert_payload(
+            &self,
+            envelope: BaseExecutionPayloadEnvelope,
+        ) -> Result<(), FollowError> {
+            self.inserted.lock().await.push(envelope.execution_payload.block_number());
+            Ok(())
+        }
+
+        async fn update_safe_finalized_blocks(
+            &self,
+            safe: Option<L2BlockInfo>,
+            finalized: Option<L2BlockInfo>,
+        ) -> Result<(), FollowError> {
+            self.labels
+                .lock()
+                .await
+                .push((safe.map(|v| v.block_info.number), finalized.map(|v| v.block_info.number)));
+            Ok(())
+        }
+
+        async fn request_forkchoice(
+            &self,
+            head: BlockInfo,
+            safe: BlockInfo,
+            finalized: BlockInfo,
+        ) -> Result<bool, FollowError> {
+            self.forkchoices.lock().await.push((head, safe, finalized));
+            Ok(self.head_requests.fetch_add(1, Ordering::SeqCst) > 0)
+        }
     }
 
     fn block_info(number: u64) -> L2BlockInfo {
@@ -415,7 +620,16 @@ mod tests {
     }
 
     fn source_block_info(number: u64) -> BlockInfo {
-        BlockInfo { number, hash: B256::from([number as u8; 32]), ..Default::default() }
+        BlockInfo {
+            number,
+            hash: B256::from([number as u8; 32]),
+            parent_hash: if number == 0 {
+                B256::ZERO
+            } else {
+                B256::from([number.saturating_sub(1) as u8; 32])
+            },
+            ..Default::default()
+        }
     }
 
     fn payload(number: u64) -> BaseExecutionPayloadEnvelope {
@@ -765,14 +979,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn safe_label_rejects_source_hash_mismatch() {
-        // Safe label hash disagrees with the local block at that height; returns
-        // SourceBlockHashMismatch and does not promote labels.
+    async fn safe_label_requests_recovery_on_source_hash_mismatch() {
+        // Safe label hash disagrees with the local block at that height, so label promotion pauses
+        // and signals recovery.
         let local = Arc::new(local_client(10, 8, 7, 100));
         let mut source = MockRemoteClient::new();
         source.expect_get_block_info().with(eq(BlockNumberOrTag::Safe)).times(1).returning(|_| {
             Ok(BlockInfo { number: 10, hash: B256::from([99; 32]), ..Default::default() })
         });
+        source
+            .expect_get_block_info()
+            .with(eq(BlockNumberOrTag::Finalized))
+            .returning(|_| Ok(source_block_info(6)));
         let engine = Arc::new(RecordingEngine {
             inserted: Mutex::new(Vec::new()),
             labels: Mutex::new(Vec::new()),
@@ -780,16 +998,16 @@ mod tests {
         });
         let engine_for_update: Arc<dyn FollowEngine> = Arc::<RecordingEngine>::clone(&engine);
 
-        let error =
+        let update =
             FollowRuntime::<MockFollowLocalClient, MockRemoteClient, NoopProofGate>::update_safe_and_finalized(
                 local,
                 Arc::new(source),
                 engine_for_update,
             )
             .await
-            .expect_err("mismatched source hash");
+            .expect("safe divergence recovery request");
 
-        assert!(matches!(error, FollowError::SourceBlockHashMismatch { number: 10, .. }));
+        assert_eq!(update, SafetyUpdate::Recover);
         assert!(engine.labels.lock().await.is_empty());
     }
 
@@ -881,8 +1099,8 @@ mod tests {
 
     #[tokio::test]
     async fn finalized_label_rejects_source_hash_mismatch() {
-        // Safe label is consistent so evaluation reaches finalized; the in-range finalized hash
-        // disagrees with local, which returns SourceBlockHashMismatch.
+        // The in-range finalized hash disagrees with local and reports a dedicated non-recoverable
+        // divergence.
         let local = Arc::new(local_client(10, 9, 7, 100));
         let mut source = MockRemoteClient::new();
         source
@@ -892,24 +1110,131 @@ mod tests {
         source.expect_get_block_info().with(eq(BlockNumberOrTag::Finalized)).times(1).returning(
             |_| Ok(BlockInfo { number: 8, hash: B256::from([99; 32]), ..Default::default() }),
         );
-        let engine = Arc::new(RecordingEngine {
-            inserted: Mutex::new(Vec::new()),
-            labels: Mutex::new(Vec::new()),
-            delay: Duration::ZERO,
-        });
-        let engine_for_update: Arc<dyn FollowEngine> = Arc::<RecordingEngine>::clone(&engine);
+        let mut engine = MockFollowEngine::new();
+        engine.expect_insert_payload().times(0);
+        engine.expect_update_safe_finalized_blocks().times(0);
+        engine.expect_request_forkchoice().times(0);
 
         let error =
             FollowRuntime::<MockFollowLocalClient, MockRemoteClient, NoopProofGate>::update_safe_and_finalized(
                 local,
                 Arc::new(source),
-                engine_for_update,
+                Arc::new(engine),
             )
             .await
             .expect_err("mismatched finalized hash");
 
-        assert!(matches!(error, FollowError::SourceBlockHashMismatch { number: 8, .. }));
-        assert!(engine.labels.lock().await.is_empty());
+        assert!(matches!(error, FollowError::FinalizedDivergence { number: 8, .. }));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn safe_divergence_pauses_and_resumes_after_fcu_sync() {
+        let target = BlockInfo {
+            number: 10,
+            hash: B256::from([99; 32]),
+            parent_hash: source_block_info(9).hash,
+            ..Default::default()
+        };
+        let recovered = L2BlockInfo { block_info: target, ..Default::default() };
+        let finalized = block_info(7);
+
+        let mut local = MockFollowLocalClient::new();
+        local.expect_block_info().returning(|tag| {
+            Ok(Some(match tag {
+                BlockNumberOrTag::Latest | BlockNumberOrTag::Number(10) => block_info(10),
+                BlockNumberOrTag::Safe | BlockNumberOrTag::Number(8) => block_info(8),
+                BlockNumberOrTag::Finalized | BlockNumberOrTag::Number(7) => block_info(7),
+                BlockNumberOrTag::Number(9) => block_info(9),
+                _ => panic!("unexpected local block lookup: {tag:?}"),
+            }))
+        });
+        local
+            .expect_block_info_by_hash()
+            .with(eq(target.hash))
+            .once()
+            .return_once(move |_| Ok(Some(recovered)));
+        local.expect_l1_block_hash().returning(|_| Ok(Some(B256::ZERO)));
+
+        let mut source = MockRemoteClient::new();
+        let source_safe_calls = Arc::new(AtomicU64::new(0));
+        let source_safe_calls_for_mock = Arc::clone(&source_safe_calls);
+        // Initial label check matches, safety-tick detection diverges, recovery re-reads Safe.
+        source.expect_get_block_info().with(eq(BlockNumberOrTag::Safe)).times(3).returning(
+            move |_| {
+                if source_safe_calls_for_mock.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Ok(source_block_info(8))
+                } else {
+                    Ok(target)
+                }
+            },
+        );
+        source
+            .expect_get_block_info()
+            .with(eq(BlockNumberOrTag::Finalized))
+            .times(2)
+            .returning(|_| Ok(source_block_info(7)));
+        source.expect_get_block_info_by_hash().returning(|hash| {
+            let number = u64::from(hash.as_slice()[31]);
+            Ok(source_block_info(number))
+        });
+        source.expect_get_block_number().with(eq(BlockNumberOrTag::Latest)).returning(|_| Ok(11));
+        source.expect_get_payload_by_number().with(eq(11)).times(2).returning(|_| Ok(payload(11)));
+
+        let engine = Arc::new(RecoveryRecordingEngine {
+            inserted: Mutex::new(Vec::new()),
+            forkchoices: Mutex::new(Vec::new()),
+            labels: Mutex::new(Vec::new()),
+            head_requests: AtomicU64::new(0),
+        });
+        let cancellation = CancellationToken::new();
+        let engine_for_runtime: Arc<dyn FollowEngine> =
+            Arc::<RecoveryRecordingEngine>::clone(&engine);
+        let runtime = FollowRuntime::new(
+            Arc::new(local),
+            Arc::new(source),
+            engine_for_runtime,
+            cancellation.clone(),
+            block_info(10),
+            PauseFirstGeneration { first_wait: true },
+            Duration::ZERO,
+        );
+        let handle = tokio::spawn(async move { runtime.start().await });
+
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+        assert!(engine.inserted.lock().await.is_empty());
+
+        time::advance(SAFETY_POLL_INTERVAL).await;
+        for _ in 0..100 {
+            if engine.head_requests.load(Ordering::SeqCst) == 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(engine.head_requests.load(Ordering::SeqCst), 1);
+        assert!(engine.inserted.lock().await.is_empty());
+
+        time::advance(Duration::from_secs(1)).await;
+        for _ in 0..100 {
+            if !engine.inserted.lock().await.is_empty() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        cancellation.cancel();
+        handle.await.expect("join").expect("runtime");
+
+        let forkchoices = engine.forkchoices.lock().await.clone();
+        assert_eq!(forkchoices.len(), 2);
+        for (head, safe, fcu_finalized) in &forkchoices {
+            assert_eq!(*head, target);
+            assert_eq!(*safe, finalized.block_info);
+            assert_eq!(*fcu_finalized, finalized.block_info);
+        }
+        assert_eq!(engine.head_requests.load(Ordering::SeqCst), 2);
+        assert_eq!(engine.labels.lock().await.last(), Some(&(Some(10), None)));
+        assert_eq!(*engine.inserted.lock().await, vec![11]);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/consensus/service/src/follow/source.rs
+++ b/crates/consensus/service/src/follow/source.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 
 use alloy_consensus::Block;
 use alloy_eips::BlockNumberOrTag;
+use alloy_primitives::B256;
 use alloy_provider::{Provider, RootProvider};
 use async_trait::async_trait;
 use base_common_consensus::BaseTxEnvelope;
@@ -38,6 +39,9 @@ pub trait RemoteClient: Debug + Send + Sync {
     /// Fetches the block info at the given tag.
     async fn get_block_info(&self, tag: BlockNumberOrTag)
     -> Result<BlockInfo, RemoteL2ClientError>;
+
+    /// Fetches block info by hash.
+    async fn get_block_info_by_hash(&self, hash: B256) -> Result<BlockInfo, RemoteL2ClientError>;
 
     /// Fetches a block by number and converts it to an [`BaseExecutionPayloadEnvelope`].
     async fn get_payload_by_number(
@@ -83,6 +87,18 @@ impl RemoteClient for RemoteL2Client {
             .await
             .map_err(|e| RemoteL2ClientError::FetchBlock { tag: format!("{tag:?}"), source: e })?
             .ok_or_else(|| RemoteL2ClientError::BlockNotFound(format!("{tag:?}")))?;
+        let block = block.map_header(|header| header.into_inner());
+
+        Ok(BlockInfo::from(&block))
+    }
+
+    async fn get_block_info_by_hash(&self, hash: B256) -> Result<BlockInfo, RemoteL2ClientError> {
+        let block = self
+            .provider
+            .get_block_by_hash(hash)
+            .await
+            .map_err(|e| RemoteL2ClientError::FetchBlock { tag: hash.to_string(), source: e })?
+            .ok_or_else(|| RemoteL2ClientError::BlockNotFound(hash.to_string()))?;
         let block = block.map_header(|header| header.into_inner());
 
         Ok(BlockInfo::from(&block))


### PR DESCRIPTION
## Summary
- Pause follow payload insertion when the source safe label hash diverges from the local block at that height
- Prove the current source-safe branch still contains the local finalized hash, then poll a source-accurate forced forkchoice until the EL confirms the head
- Rely on EL peer backfill instead of CL `newPayload` replay; keep inserts paused and retry after re-reading labels on transient recovery failure

## Test plan
- [x] `cargo test -p base-consensus-node follow:: --lib`
- [x] `cargo clippy -p base-consensus-node --all-targets -- -D warnings`
- [x] Warm local devnet QA of follow-mode safe-head recovery (**PASS**, image `base:follow-fcu-812901d6db39`)
  - Empty follow-EL catch-up via mesh + FCU (no client datadir seed, no hydrate)
  - Controlled diverge: peers 2→3, hash mismatch at diverge tip, builder bodies missing pre-recovery (0/3)
  - Recovery marker: `Recovered follow mode onto source-safe head via forkchoice sync`
  - Tip converged after recovery (follow tip matched builder)
  - Evidence: `~/workspace/tmp/2026-07-23-follow-fcu-recovery-qa/` (`keepalive-exp-summary.txt`, `logs/keepalive-qa4.log`)
- [x] Confirm finalized divergence remains non-fatal alert-only (no reset) — covered by unit test `finalized_label_rejects_source_hash_mismatch`

type=routine
risk=low
impact=sev5