### PR TITLE
ci: disable musl SIGSEGV test in merge queue

### DIFF
--- a/.github/workflows/ci-merge-queue.yml
+++ b/.github/workflows/ci-merge-queue.yml
@@ -23,7 +23,7 @@ jobs:
       build_command: just build::ci
       clippy_command: just check::clippy-ci
       run_system_tests: true
-      run_sigsegv: true
+      run_sigsegv: false
       save_rust_cache: false
       test_command: just test-ci
     secrets: inherit


### PR DESCRIPTION
## Problem

Ubuntu 24.04's `musl-tools` ships musl 1.2.6 headers where `libc::sched_param` includes extra POSIX sporadic server fields (`sched_ss_*`). The pinned `reth-tasks` crate (rev `2382a2b05a`) uses a struct literal:

```rust
let param = libc::sched_param { sched_priority: 0 };
```

This fails to compile under `x86_64-unknown-linux-musl` on Ubuntu 24.04:

```
error[E0063]: missing fields `sched_ss_init_budget`, `sched_ss_low_priority`, `sched_ss_max_repl` and 1 other field in initializer of `sched_param`
```

This has been causing the `ci / Test SIGSEGV (musl)` job to fail on every merge queue run.

## Fix

Disable `run_sigsegv` in the merge queue (`true` → `false`) until reth bumps to a version that handles `sched_param` portably across musl variants.

## Failing CI run
https://github.com/base/base/actions/runs/30031750535