### PR TITLE
refactor(challenger): simplify test dependencies

### DIFF
--- a/crates/proof/challenge/Cargo.toml
+++ b/crates/proof/challenge/Cargo.toml
@@ -68,7 +68,7 @@ rustls = { workspace = true, features = ["ring"] }
 
 # Runtime
 tokio-util.workspace = true
-base-runtime.workspace = true
+base-runtime = { workspace = true, features = ["tokio"] }
 
 # Health
 base-health = { workspace = true, features = ["axum-server"] }

--- a/crates/proof/challenge/Cargo.toml
+++ b/crates/proof/challenge/Cargo.toml
@@ -18,7 +18,7 @@ alloy-eips.workspace = true
 alloy-provider.workspace = true
 alloy-primitives.workspace = true
 alloy-signer-local.workspace = true
-alloy-rpc-types-eth.workspace = true
+alloy-rpc-types-eth = { workspace = true, optional = true }
 alloy-trie = { workspace = true, features = ["std"] }
 alloy-consensus = { workspace = true, optional = true }
 
@@ -34,7 +34,7 @@ base-proof-contracts.workspace = true
 base-proof-submission.workspace = true
 base-prover-service-client.workspace = true
 base-prover-service-protocol.workspace = true
-base-proof-primitives = { workspace = true, features = ["rpc-client"] }
+base-proof-primitives.workspace = true
 
 # Protocol
 base-protocol.workspace = true
@@ -43,7 +43,7 @@ base-common-consensus.workspace = true
 # Async
 tokio.workspace = true
 futures.workspace = true
-async-trait.workspace = true
+async-trait = { workspace = true, optional = true }
 
 # Tracing
 tracing.workspace = true
@@ -68,7 +68,7 @@ rustls = { workspace = true, features = ["ring"] }
 
 # Runtime
 tokio-util.workspace = true
-base-runtime = { workspace = true, features = ["tokio"] }
+base-runtime.workspace = true
 
 # Health
 base-health = { workspace = true, features = ["axum-server"] }
@@ -90,6 +90,8 @@ metrics-util = { workspace = true, features = ["debugging"] }
 metrics = [ "base-metrics/metrics", "base-tx-manager/metrics", "dep:metrics" ]
 test-utils = [
 	"alloy-consensus",
+	"alloy-rpc-types-eth",
+	"async-trait",
 	"base-protocol/test-utils",
 	"base-runtime/test-utils",
 	"serde_json",

--- a/crates/proof/challenge/Cargo.toml
+++ b/crates/proof/challenge/Cargo.toml
@@ -18,9 +18,9 @@ alloy-eips.workspace = true
 alloy-provider.workspace = true
 alloy-primitives.workspace = true
 alloy-signer-local.workspace = true
-alloy-rpc-types-eth = { workspace = true, optional = true }
 alloy-trie = { workspace = true, features = ["std"] }
 alloy-consensus = { workspace = true, optional = true }
+alloy-rpc-types-eth = { workspace = true, optional = true }
 
 # Tx Manager
 base-tx-manager.workspace = true
@@ -31,10 +31,10 @@ base-balance-monitor.workspace = true
 # Proof
 base-proof-rpc.workspace = true
 base-proof-contracts.workspace = true
+base-proof-primitives.workspace = true
 base-proof-submission.workspace = true
 base-prover-service-client.workspace = true
 base-prover-service-protocol.workspace = true
-base-proof-primitives.workspace = true
 
 # Protocol
 base-protocol.workspace = true


### PR DESCRIPTION
### What changed? Why?

Make challenger dependencies used solely by test code optional and enable them through the `test-utils` feature. Remove production-only feature flags from dependencies where the challenger does not require them.

### Notes to reviewers

The production dependency graph no longer includes test helper dependencies or unused dependency features.

### How has it been tested?

Not run (Cargo manifest-only change).