### PR TITLE
fix(registrar): prevent processing unhealthy instances

### DIFF
--- a/bin/prover-registrar/README.md
+++ b/bin/prover-registrar/README.md
@@ -8,9 +8,10 @@ their signers on-chain via `TEEProverRegistry`.
 
 ## Discovery Cache TTL
 
-When an instance disappears from otherwise successful AWS/ALB discovery output,
-the registrar preserves its last-known active signers for
-`--instance-cache-ttl-cycles` cycles (`BASE_REGISTRAR_INSTANCE_CACHE_TTL_CYCLES`,
-default `5`). Shorter TTLs can speed up cleanup for genuinely removed instances
-but increase exposure to transient discovery flakes; longer TTLs protect against
-flakes but delay real cleanup.
+When an instance disappears from otherwise successful AWS/ALB discovery output
+or is reported unhealthy, the registrar preserves its last-known active signers
+for `--instance-cache-ttl-cycles` cycles
+(`BASE_REGISTRAR_INSTANCE_CACHE_TTL_CYCLES`, default `5`). Shorter TTLs can
+speed up cleanup for genuinely removed instances but increase exposure to
+transient AWS/ALB flakes; longer TTLs protect against flakes but delay real
+cleanup.

--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -6,8 +6,7 @@ use alloy_primitives::{Address, hex::FromHex};
 use base_proof_tee_nitro_attestation_prover::{BoundlessProver, BoundlessProverConfig};
 use base_proof_tee_registrar::{
     DEFAULT_MAX_CONCURRENCY, DEFAULT_MAX_TX_RETRIES, DEFAULT_TX_RETRY_DELAY_SECS,
-    DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS, INSTANCE_CACHE_TTL_CYCLES, RegistrarConfig,
-    RegistrarError,
+    INSTANCE_CACHE_TTL_CYCLES, RegistrarConfig, RegistrarError,
 };
 use base_tx_manager::{SignerConfig, TxManagerConfig};
 use boundless_market::{
@@ -201,14 +200,6 @@ pub(crate) struct Cli {
     )]
     tx_retry_delay: u64,
 
-    /// Grace period for registering newly launched unhealthy instances.
-    #[arg(
-        long = "unhealthy-registration-window-secs",
-        env = cli_env!("UNHEALTHY_REGISTRATION_WINDOW_SECS"),
-        default_value_t = DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS
-    )]
-    unhealthy_registration_window: u64,
-
     /// `NitroEnclaveVerifier` contract address for CRL checks. Providing this enables CRL checks.
     #[arg(long, env = cli_env!("CRL_NITRO_VERIFIER_ADDRESS"))]
     crl_nitro_verifier_address: Option<Address>,
@@ -277,7 +268,6 @@ impl Cli {
             instance_cache_ttl_cycles: self.instance_cache_ttl_cycles,
             max_tx_retries: self.max_tx_retries,
             tx_retry_delay: Duration::from_secs(self.tx_retry_delay),
-            unhealthy_registration_window: Duration::from_secs(self.unhealthy_registration_window),
             crl_nitro_verifier_address: self.crl_nitro_verifier_address,
             health_addr: self.health.socket_addr(),
             log_config: self.log.into(),
@@ -390,8 +380,6 @@ mod tests {
             "2",
             "--instance-cache-ttl-cycles",
             "3",
-            "--unhealthy-registration-window-secs",
-            "600",
         ]);
 
         assert!(Cli::try_parse_from(args).is_ok());

--- a/crates/proof/tee/registrar/README.md
+++ b/crates/proof/tee/registrar/README.md
@@ -11,11 +11,11 @@ to detect new Nitro enclave instances, fetches their attestation documents via
 
 ## Discovery Cache TTL
 
-When an instance disappears from otherwise successful discovery output, the
-registrar preserves its last-known active signers for `instance_cache_ttl_cycles`
-cycles. Shorter TTLs can speed up cleanup for genuinely removed instances but
-increase exposure to transient AWS/ALB discovery flakes; longer TTLs protect
-against flakes but delay real cleanup.
+When an instance disappears from otherwise successful discovery output or is
+reported unhealthy, the registrar preserves its last-known active signers for
+`instance_cache_ttl_cycles` cycles. Shorter TTLs can speed up cleanup for
+genuinely removed instances but increase exposure to transient AWS/ALB flakes;
+longer TTLs protect against flakes but delay real cleanup.
 
 ## Modules
 

--- a/crates/proof/tee/registrar/src/discovery.rs
+++ b/crates/proof/tee/registrar/src/discovery.rs
@@ -1,9 +1,6 @@
 //! AWS ALB target group instance discovery.
 
-use std::{
-    collections::HashMap,
-    time::{Duration, SystemTime},
-};
+use std::collections::HashMap;
 
 use aws_sdk_ec2::{Client as Ec2Client, types::Reservation};
 use aws_sdk_elasticloadbalancingv2::Client as ElbClient;
@@ -52,24 +49,18 @@ impl AwsTargetGroupDiscovery {
             let Some(health_status) = health_map.remove(instance_id) else {
                 continue;
             };
-            let launch_time = instance
-                .launch_time()
-                .and_then(|dt| u64::try_from(dt.secs()).ok())
-                .map(|secs| SystemTime::UNIX_EPOCH + Duration::from_secs(secs));
             let endpoint = Url::parse(&format!("http://{private_ip}:{port}"))
                 .map_err(|e| RegistrarError::Discovery(Box::new(e)))?;
             debug!(
                 instance_id = %instance_id,
                 endpoint = %endpoint,
                 health = ?health_status,
-                launch_time = ?launch_time,
                 "discovered AWS prover instance"
             );
             instances.push(ProverInstance {
                 instance_id: instance_id.to_string(),
                 endpoint,
                 health_status,
-                launch_time,
             });
         }
         Ok(instances)
@@ -147,10 +138,7 @@ impl InstanceDiscovery for AwsTargetGroupDiscovery {
 
 #[cfg(test)]
 mod tests {
-    use aws_sdk_ec2::{
-        primitives::DateTime,
-        types::{Instance, Reservation},
-    };
+    use aws_sdk_ec2::types::{Instance, Reservation};
     use url::Url;
 
     use super::*;
@@ -159,23 +147,20 @@ mod tests {
         Reservation::builder().set_instances(Some(instances)).build()
     }
 
-    fn instance(id: &str, private_ip: Option<&str>, launch_time_secs: Option<i64>) -> Instance {
+    fn instance(id: &str, private_ip: Option<&str>) -> Instance {
         Instance::builder()
             .instance_id(id)
             .set_private_ip_address(private_ip.map(str::to_string))
-            .set_launch_time(launch_time_secs.map(DateTime::from_secs))
             .build()
     }
 
     #[test]
     fn assemble_prover_instances_preserves_ec2_and_elb_data() {
-        let launch_secs = 1_700_000_000;
-        let launch_time = SystemTime::UNIX_EPOCH + Duration::from_secs(launch_secs as u64);
         let reservations = vec![reservation(vec![
-            instance("i-001", Some("10.0.0.1"), Some(launch_secs)),
-            instance("i-002", Some("10.0.0.2"), None),
-            instance("i-003", Some("10.0.0.3"), None),
-            instance("i-004", Some("10.0.0.4"), None),
+            instance("i-001", Some("10.0.0.1")),
+            instance("i-002", Some("10.0.0.2")),
+            instance("i-003", Some("10.0.0.3")),
+            instance("i-004", Some("10.0.0.4")),
         ])];
         let mut health_map = HashMap::from([
             ("i-001".to_string(), InstanceHealthStatus::Healthy),
@@ -196,18 +181,16 @@ mod tests {
         assert_eq!(instances[0].instance_id, "i-001");
         assert_eq!(instances[0].endpoint, Url::parse("http://10.0.0.1:9000").unwrap());
         assert_eq!(instances[0].health_status, InstanceHealthStatus::Healthy);
-        assert_eq!(instances[0].launch_time, Some(launch_time));
         assert_eq!(instances[1].instance_id, "i-002");
         assert_eq!(instances[1].endpoint, Url::parse("http://10.0.0.2:9000").unwrap());
         assert_eq!(instances[1].health_status, InstanceHealthStatus::Initial);
-        assert_eq!(instances[1].launch_time, None);
         assert_eq!(instances[2].health_status, InstanceHealthStatus::Unhealthy);
         assert_eq!(instances[3].health_status, InstanceHealthStatus::Draining);
     }
 
     #[test]
     fn assemble_prover_instances_returns_url_parse_error() {
-        let reservations = vec![reservation(vec![instance("i-001", Some("bad host"), None)])];
+        let reservations = vec![reservation(vec![instance("i-001", Some("bad host"))])];
         let mut health_map = HashMap::from([("i-001".to_string(), InstanceHealthStatus::Healthy)]);
 
         let err = AwsTargetGroupDiscovery::assemble_prover_instances(
@@ -226,9 +209,9 @@ mod tests {
     #[test]
     fn assemble_prover_instances_leaves_missing_ec2_data_in_health_map() {
         let reservations = vec![reservation(vec![
-            instance("i-001", Some("10.0.0.1"), None),
-            instance("i-002", None, None),
-            instance("i-999", Some("10.0.0.9"), None),
+            instance("i-001", Some("10.0.0.1")),
+            instance("i-002", None),
+            instance("i-999", Some("10.0.0.9")),
         ])];
         let mut health_map = HashMap::from([
             ("i-001".to_string(), InstanceHealthStatus::Healthy),

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -33,8 +33,7 @@ use crate::{
 pub const DEFAULT_MAX_CONCURRENCY: usize = 4;
 
 /// Default number of consecutive discovery cycles to protect last-known active
-/// signers for an instance that disappears from otherwise successful discovery
-/// output.
+/// signers for an instance that disappears from discovery or becomes unhealthy.
 ///
 /// Five cycles is roughly 2.5 minutes with the default 30 second poll interval.
 /// A shorter window is more vulnerable to transient discovery flakes; a longer
@@ -52,8 +51,8 @@ pub struct DriverConfig {
     /// Maximum number of instances resolved concurrently per discovery cycle.
     pub max_concurrency: usize,
     /// Number of consecutive discovery cycles to protect last-known active
-    /// signers for an instance missing from otherwise successful discovery
-    /// output. Defaults to [`INSTANCE_CACHE_TTL_CYCLES`].
+    /// signers for an instance missing from discovery or reported unhealthy.
+    /// Defaults to [`INSTANCE_CACHE_TTL_CYCLES`].
     pub instance_cache_ttl_cycles: u32,
 }
 
@@ -312,6 +311,11 @@ where
 
         let discovered_instance_ids: HashSet<String> =
             instances.iter().map(|instance| instance.instance_id.clone()).collect();
+        let unhealthy_instance_ids: HashSet<String> = instances
+            .iter()
+            .filter(|instance| instance.health_status == InstanceHealthStatus::Unhealthy)
+            .map(|instance| instance.instance_id.clone())
+            .collect();
         RegistrarMetrics::discovered_instances_count().set(discovered_instance_ids.len() as f64);
         let mut resolution = DiscoveryResolution::default();
 
@@ -339,7 +343,9 @@ where
                 Ok(outcome) => {
                     let active_signers = outcome.active_signers.iter().copied().collect::<Vec<_>>();
                     if active_signers.is_empty() {
-                        last_known_active.remove(&instance.instance_id);
+                        if instance.health_status != InstanceHealthStatus::Unhealthy {
+                            last_known_active.remove(&instance.instance_id);
+                        }
                     } else {
                         last_known_active.insert(instance.instance_id, (active_signers, 0));
                     }
@@ -361,7 +367,9 @@ where
         }
 
         last_known_active.retain(|instance_id, (addresses, ttl_cycles)| {
-            if discovered_instance_ids.contains(instance_id) {
+            if discovered_instance_ids.contains(instance_id)
+                && !unhealthy_instance_ids.contains(instance_id)
+            {
                 return true;
             }
 
@@ -372,17 +380,19 @@ where
                     cached_signers = addresses.len(),
                     ttl_cycles = *ttl_cycles,
                     max_ttl_cycles = self.config.instance_cache_ttl_cycles,
-                    "instance missing from discovery, preserving last-known active signers"
+                    "instance unavailable, preserving last-known active signers"
                 );
                 resolution.active_signers.extend(addresses.iter().copied());
-                resolution.unresolved_instance_ids.insert(instance_id.clone());
+                if !unhealthy_instance_ids.contains(instance_id) {
+                    resolution.unresolved_instance_ids.insert(instance_id.clone());
+                }
                 true
             } else {
                 warn!(
                     instance = %instance_id,
                     ttl_cycles = *ttl_cycles,
                     max_ttl_cycles = self.config.instance_cache_ttl_cycles,
-                    "last-known active signer cache expired for missing instance"
+                    "last-known active signer cache expired for unavailable instance"
                 );
                 false
             }
@@ -656,14 +666,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn discover_and_resolve_removes_cached_signers_for_unhealthy_instances() {
+    async fn discover_and_resolve_preserves_cached_signers_for_unhealthy_instances_until_ttl() {
+        const TEST_TTL_CYCLES: u32 = 2;
+
         let signer = signer_from_private_key(&HARDHAT_KEY_0);
         let instance = prover_instance(EP1, InstanceHealthStatus::Unhealthy);
         let signer_client = MockEnclaveEndpointClient::default();
         let requested_public_keys = Arc::clone(&signer_client.requested_public_keys);
-        let driver = cycle_driver(vec![instance.clone()], signer_client, CancellationToken::new());
+        let driver = cycle_driver_with_instance_cache_ttl(
+            vec![instance.clone()],
+            signer_client,
+            CancellationToken::new(),
+            TEST_TTL_CYCLES,
+        );
         let mut last_known_active =
             HashMap::from([(instance.instance_id.clone(), (vec![signer], 0))]);
+
+        for expected_ttl in 1..=TEST_TTL_CYCLES {
+            let resolution = driver.discover_and_resolve(&mut last_known_active).await.unwrap();
+
+            assert!(resolution.active_signers.contains(&signer));
+            assert!(resolution.unresolved_instance_ids.is_empty());
+            assert_eq!(
+                last_known_active.get(&instance.instance_id).map(|(_, ttl)| *ttl),
+                Some(expected_ttl)
+            );
+        }
 
         let resolution = driver.discover_and_resolve(&mut last_known_active).await.unwrap();
 

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -329,8 +329,8 @@ where
             .retain(|instance_id| unhealthy_instance_ids.contains(instance_id));
         for instance_id in &unhealthy_instance_ids {
             // A process restart has no signer addresses to cache. Keep an
-            // empty cache entry for one unhealthy period so orphan cleanup is
-            // deferred by the configured grace TTL rather than running now.
+            // empty cache entry for one unhealthy period so the global orphan
+            // cleanup pass is deferred by the configured grace TTL.
             if unhealthy_instance_ids_with_grace.insert(instance_id.clone())
                 && !last_known_active.contains_key(instance_id)
             {
@@ -404,7 +404,13 @@ where
                     "instance unavailable, preserving last-known active signers"
                 );
                 resolution.active_signers.extend(addresses.iter().copied());
-                if addresses.is_empty() || !unhealthy_instance_ids.contains(instance_id) {
+                if addresses.is_empty() {
+                    // We cannot identify signers to protect for an unhealthy
+                    // instance first observed after a restart.
+                    resolution.unresolved_instance_ids.insert(instance_id.clone());
+                } else if !unhealthy_instance_ids.contains(instance_id) {
+                    // A missing instance could have changed signers since its
+                    // cached addresses were last refreshed.
                     resolution.unresolved_instance_ids.insert(instance_id.clone());
                 }
                 true

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -32,18 +32,6 @@ use crate::{
 /// serialization separately.
 pub const DEFAULT_MAX_CONCURRENCY: usize = 4;
 
-/// Default duration (in seconds) after launch during which unhealthy
-/// instances are still eligible for registration.
-///
-/// New EC2 instances may fail ALB health checks while the application is
-/// still initializing. This window allows the registrar to attempt
-/// registration during that warm-up period rather than waiting for the
-/// instance to become healthy. Set to 0 to disable.
-///
-/// 85 minutes gives a slight buffer ahead of the prove provision timeout
-/// of 90 minutes.
-pub const DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS: u64 = 5100;
-
 /// Default number of consecutive discovery cycles to protect last-known active
 /// signers for an instance that disappears from otherwise successful discovery
 /// output.
@@ -67,11 +55,6 @@ pub struct DriverConfig {
     /// signers for an instance missing from otherwise successful discovery
     /// output. Defaults to [`INSTANCE_CACHE_TTL_CYCLES`].
     pub instance_cache_ttl_cycles: u32,
-    /// Duration after launch during which unhealthy instances are still
-    /// eligible for registration. New instances may fail ALB health checks
-    /// while the application is still initializing. Set to zero to disable.
-    /// Defaults to [`DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS`] seconds.
-    pub unhealthy_registration_window: Duration,
 }
 
 /// A signer and attestation ready to be spawned as a proof task.
@@ -212,6 +195,14 @@ where
             return Ok(DiscoveryResolution::default());
         }
 
+        if instance.health_status == InstanceHealthStatus::Unhealthy {
+            debug!(instance = %instance.instance_id, "unhealthy instance, skipping resolution");
+            return Ok(DiscoveryResolution {
+                unresolved_instance_ids: HashSet::from([instance.instance_id.clone()]),
+                ..Default::default()
+            });
+        }
+
         let public_keys = self.signer_client.signer_public_key(&instance.endpoint).await?;
         let addresses = public_keys
             .iter()
@@ -226,30 +217,16 @@ where
             return Ok(outcome);
         }
 
-        let recently_launched_unhealthy = instance.health_status == InstanceHealthStatus::Unhealthy
-            && instance.launch_time.is_some_and(|lt| {
-                lt.elapsed()
-                    .is_ok_and(|elapsed| elapsed < self.config.unhealthy_registration_window)
-            });
         if !matches!(
             instance.health_status,
             InstanceHealthStatus::Initial | InstanceHealthStatus::Healthy
-        ) && !recently_launched_unhealthy
-        {
+        ) {
             debug!(
                 status = ?instance.health_status,
                 instance = %instance.instance_id,
                 "instance not registerable, skipping registration"
             );
             return Ok(outcome);
-        }
-        if recently_launched_unhealthy {
-            info!(
-                instance = %instance.instance_id,
-                launch_time = ?instance.launch_time,
-                window = ?self.config.unhealthy_registration_window,
-                "unhealthy instance recently launched, attempting registration"
-            );
         }
 
         if self.config.cancel.is_cancelled() {
@@ -364,7 +341,15 @@ where
             match result {
                 Ok(outcome) => {
                     let active_signers = outcome.active_signers.iter().copied().collect::<Vec<_>>();
-                    if active_signers.is_empty() {
+                    if active_signers.is_empty()
+                        && outcome.unresolved_instance_ids.contains(&instance.instance_id)
+                    {
+                        if let Some((cached_signers, _)) =
+                            last_known_active.get(&instance.instance_id)
+                        {
+                            resolution.active_signers.extend(cached_signers.iter().copied());
+                        }
+                    } else if active_signers.is_empty() {
                         last_known_active.remove(&instance.instance_id);
                     } else {
                         last_known_active.insert(instance.instance_id, (active_signers, 0));
@@ -428,7 +413,6 @@ mod tests {
     use std::{
         collections::{HashMap, HashSet},
         sync::{Arc, Mutex},
-        time::SystemTime,
     };
 
     use tokio_util::sync::CancellationToken;
@@ -456,9 +440,11 @@ mod tests {
         keys: HashMap<Url, Vec<Vec<u8>>>,
         attestations: HashMap<Url, Vec<Vec<u8>>>,
         fail_attestation: HashSet<Url>,
+        requested_public_keys: RequestedPublicKeys,
         requested_nonces: RequestedNonces,
     }
 
+    type RequestedPublicKeys = Arc<Mutex<Vec<Url>>>;
     type RequestedNonces = Arc<Mutex<Vec<Option<Vec<Vec<u8>>>>>>;
 
     impl MockEnclaveEndpointClient {
@@ -478,6 +464,7 @@ mod tests {
 
     impl EnclaveEndpointClient for MockEnclaveEndpointClient {
         async fn signer_public_key(&self, endpoint: &Url) -> Result<Vec<Vec<u8>>> {
+            self.requested_public_keys.lock().unwrap().push(endpoint.clone());
             self.keys.get(endpoint).cloned().ok_or_else(|| RegistrarError::ProverClient {
                 instance: endpoint.to_string(),
                 source: "unreachable".into(),
@@ -558,9 +545,6 @@ mod tests {
                 cancel,
                 max_concurrency: DEFAULT_MAX_CONCURRENCY,
                 instance_cache_ttl_cycles,
-                unhealthy_registration_window: Duration::from_secs(
-                    DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS,
-                ),
             },
             None,
             signer_manager,
@@ -570,28 +554,6 @@ mod tests {
     async fn discover_once(driver: &TestDriver) -> DiscoveryResolution {
         let mut last_known_active = HashMap::new();
         driver.discover_and_resolve(&mut last_known_active).await.unwrap()
-    }
-
-    #[tokio::test]
-    async fn discover_and_resolve_admits_recently_launched_unhealthy_to_active_and_registerable() {
-        let addr = signer_from_private_key(&HARDHAT_KEY_0);
-        let launch_time = Some(SystemTime::now() - Duration::from_secs(300));
-
-        let instance_under_test =
-            prover_instance(EP1, InstanceHealthStatus::Unhealthy, launch_time);
-        let signer_client = MockEnclaveEndpointClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
-
-        let driver = cycle_driver(
-            vec![instance_under_test.clone()],
-            signer_client,
-            CancellationToken::new(),
-        );
-
-        let resolution = discover_once(&driver).await;
-        assert_eq!(resolution.registerable.len(), 1);
-        assert_eq!(resolution.registerable[0].signer, addr);
-        assert!(resolution.active_signers.contains(&addr));
-        assert!(resolution.unresolved_instance_ids.is_empty());
     }
 
     #[tokio::test]
@@ -636,7 +598,7 @@ mod tests {
         let addr0 = signer_from_private_key(&HARDHAT_KEY_0);
         let addr1 = signer_from_private_key(&HARDHAT_KEY_1);
 
-        let instances = vec![prover_instance(EP1, InstanceHealthStatus::Draining, None)];
+        let instances = vec![prover_instance(EP1, InstanceHealthStatus::Draining)];
         let signer_client =
             MockEnclaveEndpointClient::multi_enclave(EP1, &[&HARDHAT_KEY_0, &HARDHAT_KEY_1]);
 
@@ -682,25 +644,47 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn discover_and_resolve_unhealthy_instance_is_reachable_but_not_registerable() {
-        let addr_unhealthy = signer_from_private_key(&HARDHAT_KEY_0);
+    async fn discover_and_resolve_skips_unhealthy_instances_before_resolving() {
         let addr_healthy = signer_from_private_key(&HARDHAT_KEY_1);
 
         let instances = vec![
-            prover_instance(EP1, InstanceHealthStatus::Unhealthy, None),
+            prover_instance(EP1, InstanceHealthStatus::Unhealthy),
             healthy_prover_instance(EP2),
         ];
 
         let signer_client =
             MockEnclaveEndpointClient::from_keys(&[(EP1, &HARDHAT_KEY_0), (EP2, &HARDHAT_KEY_1)]);
+        let requested_public_keys = Arc::clone(&signer_client.requested_public_keys);
 
         let driver = cycle_driver(instances, signer_client, CancellationToken::new());
 
         let resolution = discover_once(&driver).await;
         assert_eq!(resolution.registerable.len(), 1);
         assert_eq!(resolution.registerable[0].signer, addr_healthy);
-        assert!(resolution.active_signers.contains(&addr_unhealthy));
-        assert!(resolution.unresolved_instance_ids.is_empty());
+        assert!(!resolution.active_signers.contains(&signer_from_private_key(&HARDHAT_KEY_0)));
+        assert_eq!(resolution.unresolved_instance_ids, HashSet::from([format!("i-{EP1}")]));
+        assert_eq!(*requested_public_keys.lock().unwrap(), vec![endpoint_url(EP2)]);
+    }
+
+    #[tokio::test]
+    async fn discover_and_resolve_preserves_cached_signers_for_unhealthy_instances() {
+        let signer = signer_from_private_key(&HARDHAT_KEY_0);
+        let instance = prover_instance(EP1, InstanceHealthStatus::Unhealthy);
+        let signer_client = MockEnclaveEndpointClient::default();
+        let requested_public_keys = Arc::clone(&signer_client.requested_public_keys);
+        let driver = cycle_driver(vec![instance.clone()], signer_client, CancellationToken::new());
+        let mut last_known_active =
+            HashMap::from([(instance.instance_id.clone(), (vec![signer], 0))]);
+
+        let resolution = driver.discover_and_resolve(&mut last_known_active).await.unwrap();
+
+        assert!(resolution.active_signers.contains(&signer));
+        assert_eq!(
+            resolution.unresolved_instance_ids,
+            HashSet::from([instance.instance_id.clone()])
+        );
+        assert_eq!(last_known_active[&instance.instance_id], (vec![signer], 0));
+        assert!(requested_public_keys.lock().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -197,10 +197,7 @@ where
 
         if instance.health_status == InstanceHealthStatus::Unhealthy {
             debug!(instance = %instance.instance_id, "unhealthy instance, skipping resolution");
-            return Ok(DiscoveryResolution {
-                unresolved_instance_ids: HashSet::from([instance.instance_id.clone()]),
-                ..Default::default()
-            });
+            return Ok(DiscoveryResolution::default());
         }
 
         let public_keys = self.signer_client.signer_public_key(&instance.endpoint).await?;
@@ -662,12 +659,12 @@ mod tests {
         assert_eq!(resolution.registerable.len(), 1);
         assert_eq!(resolution.registerable[0].signer, addr_healthy);
         assert!(!resolution.active_signers.contains(&signer_from_private_key(&HARDHAT_KEY_0)));
-        assert_eq!(resolution.unresolved_instance_ids, HashSet::from([format!("i-{EP1}")]));
+        assert!(resolution.unresolved_instance_ids.is_empty());
         assert_eq!(*requested_public_keys.lock().unwrap(), vec![endpoint_url(EP2)]);
     }
 
     #[tokio::test]
-    async fn discover_and_resolve_preserves_cached_signers_for_unhealthy_instances() {
+    async fn discover_and_resolve_removes_cached_signers_for_unhealthy_instances() {
         let signer = signer_from_private_key(&HARDHAT_KEY_0);
         let instance = prover_instance(EP1, InstanceHealthStatus::Unhealthy);
         let signer_client = MockEnclaveEndpointClient::default();
@@ -678,12 +675,9 @@ mod tests {
 
         let resolution = driver.discover_and_resolve(&mut last_known_active).await.unwrap();
 
-        assert!(resolution.active_signers.contains(&signer));
-        assert_eq!(
-            resolution.unresolved_instance_ids,
-            HashSet::from([instance.instance_id.clone()])
-        );
-        assert_eq!(last_known_active[&instance.instance_id], (vec![signer], 0));
+        assert!(resolution.active_signers.is_empty());
+        assert!(resolution.unresolved_instance_ids.is_empty());
+        assert!(!last_known_active.contains_key(&instance.instance_id));
         assert!(requested_public_keys.lock().unwrap().is_empty());
     }
 

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -33,7 +33,8 @@ use crate::{
 pub const DEFAULT_MAX_CONCURRENCY: usize = 4;
 
 /// Default number of consecutive discovery cycles to protect last-known active
-/// signers for an instance that disappears from discovery or becomes unhealthy.
+/// signers for an instance that disappears from discovery or becomes unhealthy,
+/// and to defer orphan cleanup for newly observed unhealthy instances.
 ///
 /// Five cycles is roughly 2.5 minutes with the default 30 second poll interval.
 /// A shorter window is more vulnerable to transient discovery flakes; a longer
@@ -51,7 +52,8 @@ pub struct DriverConfig {
     /// Maximum number of instances resolved concurrently per discovery cycle.
     pub max_concurrency: usize,
     /// Number of consecutive discovery cycles to protect last-known active
-    /// signers for an instance missing from discovery or reported unhealthy.
+    /// signers for an instance missing from discovery or reported unhealthy,
+    /// and to defer orphan cleanup for newly observed unhealthy instances.
     /// Defaults to [`INSTANCE_CACHE_TTL_CYCLES`].
     pub instance_cache_ttl_cycles: u32,
 }
@@ -133,9 +135,15 @@ where
 
         let mut proof_tasks = ProofTaskSet::default();
         let mut last_known_active = HashMap::new();
+        let mut unhealthy_instance_ids_with_grace = HashSet::new();
 
         loop {
-            let discovery = self.discover_and_resolve(&mut last_known_active).await;
+            let discovery = self
+                .discover_and_resolve(
+                    &mut last_known_active,
+                    &mut unhealthy_instance_ids_with_grace,
+                )
+                .await;
 
             // Keep task state current before reconcile decisions each cycle.
             proof_tasks.reap_finished_tasks();
@@ -305,6 +313,7 @@ where
     async fn discover_and_resolve(
         &self,
         last_known_active: &mut HashMap<String, (Vec<Address>, u32)>,
+        unhealthy_instance_ids_with_grace: &mut HashSet<String>,
     ) -> Result<DiscoveryResolution> {
         let instances = self.discovery.discover_instances().await?;
         RegistrarMetrics::discovery_success_total().increment(1);
@@ -316,6 +325,18 @@ where
             .filter(|instance| instance.health_status == InstanceHealthStatus::Unhealthy)
             .map(|instance| instance.instance_id.clone())
             .collect();
+        unhealthy_instance_ids_with_grace
+            .retain(|instance_id| unhealthy_instance_ids.contains(instance_id));
+        for instance_id in &unhealthy_instance_ids {
+            // A process restart has no signer addresses to cache. Keep an
+            // empty cache entry for one unhealthy period so orphan cleanup is
+            // deferred by the configured grace TTL rather than running now.
+            if unhealthy_instance_ids_with_grace.insert(instance_id.clone())
+                && !last_known_active.contains_key(instance_id)
+            {
+                last_known_active.insert(instance_id.clone(), (Vec::new(), 0));
+            }
+        }
         RegistrarMetrics::discovered_instances_count().set(discovered_instance_ids.len() as f64);
         let mut resolution = DiscoveryResolution::default();
 
@@ -383,7 +404,7 @@ where
                     "instance unavailable, preserving last-known active signers"
                 );
                 resolution.active_signers.extend(addresses.iter().copied());
-                if !unhealthy_instance_ids.contains(instance_id) {
+                if addresses.is_empty() || !unhealthy_instance_ids.contains(instance_id) {
                     resolution.unresolved_instance_ids.insert(instance_id.clone());
                 }
                 true
@@ -552,7 +573,11 @@ mod tests {
 
     async fn discover_once(driver: &TestDriver) -> DiscoveryResolution {
         let mut last_known_active = HashMap::new();
-        driver.discover_and_resolve(&mut last_known_active).await.unwrap()
+        let mut unhealthy_instance_ids_with_grace = HashSet::new();
+        driver
+            .discover_and_resolve(&mut last_known_active, &mut unhealthy_instance_ids_with_grace)
+            .await
+            .unwrap()
     }
 
     #[tokio::test]
@@ -661,8 +686,61 @@ mod tests {
         assert_eq!(resolution.registerable.len(), 1);
         assert_eq!(resolution.registerable[0].signer, addr_healthy);
         assert!(!resolution.active_signers.contains(&signer_from_private_key(&HARDHAT_KEY_0)));
-        assert!(resolution.unresolved_instance_ids.is_empty());
+        assert_eq!(resolution.unresolved_instance_ids, HashSet::from([format!("i-{EP1}")]));
         assert_eq!(*requested_public_keys.lock().unwrap(), vec![endpoint_url(EP2)]);
+    }
+
+    #[tokio::test]
+    async fn discover_and_resolve_defers_orphan_dereg_for_initial_unhealthy_instance() {
+        const TEST_TTL_CYCLES: u32 = 2;
+
+        let instance = prover_instance(EP1, InstanceHealthStatus::Unhealthy);
+        let signer_client = MockEnclaveEndpointClient::default();
+        let requested_public_keys = Arc::clone(&signer_client.requested_public_keys);
+        let driver = cycle_driver_with_instance_cache_ttl(
+            vec![instance.clone()],
+            signer_client,
+            CancellationToken::new(),
+            TEST_TTL_CYCLES,
+        );
+        let mut last_known_active = HashMap::new();
+        let mut unhealthy_instance_ids_with_grace = HashSet::new();
+
+        for expected_ttl in 1..=TEST_TTL_CYCLES {
+            let resolution = driver
+                .discover_and_resolve(
+                    &mut last_known_active,
+                    &mut unhealthy_instance_ids_with_grace,
+                )
+                .await
+                .unwrap();
+
+            assert!(resolution.active_signers.is_empty());
+            assert_eq!(
+                resolution.unresolved_instance_ids,
+                HashSet::from([instance.instance_id.clone()])
+            );
+            assert_eq!(
+                last_known_active.get(&instance.instance_id).map(|(_, ttl)| *ttl),
+                Some(expected_ttl)
+            );
+        }
+
+        let resolution = driver
+            .discover_and_resolve(&mut last_known_active, &mut unhealthy_instance_ids_with_grace)
+            .await
+            .unwrap();
+
+        assert!(resolution.unresolved_instance_ids.is_empty());
+        assert!(!last_known_active.contains_key(&instance.instance_id));
+
+        let resolution = driver
+            .discover_and_resolve(&mut last_known_active, &mut unhealthy_instance_ids_with_grace)
+            .await
+            .unwrap();
+
+        assert!(resolution.unresolved_instance_ids.is_empty());
+        assert!(requested_public_keys.lock().unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -681,9 +759,16 @@ mod tests {
         );
         let mut last_known_active =
             HashMap::from([(instance.instance_id.clone(), (vec![signer], 0))]);
+        let mut unhealthy_instance_ids_with_grace = HashSet::new();
 
         for expected_ttl in 1..=TEST_TTL_CYCLES {
-            let resolution = driver.discover_and_resolve(&mut last_known_active).await.unwrap();
+            let resolution = driver
+                .discover_and_resolve(
+                    &mut last_known_active,
+                    &mut unhealthy_instance_ids_with_grace,
+                )
+                .await
+                .unwrap();
 
             assert!(resolution.active_signers.contains(&signer));
             assert!(resolution.unresolved_instance_ids.is_empty());
@@ -693,7 +778,10 @@ mod tests {
             );
         }
 
-        let resolution = driver.discover_and_resolve(&mut last_known_active).await.unwrap();
+        let resolution = driver
+            .discover_and_resolve(&mut last_known_active, &mut unhealthy_instance_ids_with_grace)
+            .await
+            .unwrap();
 
         assert!(resolution.active_signers.is_empty());
         assert!(resolution.unresolved_instance_ids.is_empty());
@@ -756,12 +844,21 @@ mod tests {
             TEST_TTL_CYCLES,
         );
         let mut last_known_active = HashMap::new();
+        let mut unhealthy_instance_ids_with_grace = HashSet::new();
 
-        first_cycle.discover_and_resolve(&mut last_known_active).await.unwrap();
+        first_cycle
+            .discover_and_resolve(&mut last_known_active, &mut unhealthy_instance_ids_with_grace)
+            .await
+            .unwrap();
 
         for expected_ttl in 1..=TEST_TTL_CYCLES {
-            let resolution =
-                missing_cycle.discover_and_resolve(&mut last_known_active).await.unwrap();
+            let resolution = missing_cycle
+                .discover_and_resolve(
+                    &mut last_known_active,
+                    &mut unhealthy_instance_ids_with_grace,
+                )
+                .await
+                .unwrap();
 
             assert!(resolution.registerable.is_empty());
             assert!(resolution.active_signers.contains(&signer_addr));
@@ -775,8 +872,10 @@ mod tests {
             );
         }
 
-        let expired_resolution =
-            missing_cycle.discover_and_resolve(&mut last_known_active).await.unwrap();
+        let expired_resolution = missing_cycle
+            .discover_and_resolve(&mut last_known_active, &mut unhealthy_instance_ids_with_grace)
+            .await
+            .unwrap();
 
         assert!(expired_resolution.active_signers.is_empty());
         assert!(expired_resolution.unresolved_instance_ids.is_empty());
@@ -792,21 +891,35 @@ mod tests {
             cycle_driver(vec![inst.clone()], signer_client.clone(), CancellationToken::new());
         let missing_cycle = cycle_driver(vec![], signer_client, CancellationToken::new());
         let mut last_known_active = HashMap::new();
+        let mut unhealthy_instance_ids_with_grace = HashSet::new();
 
-        present_cycle.discover_and_resolve(&mut last_known_active).await.unwrap();
-        missing_cycle.discover_and_resolve(&mut last_known_active).await.unwrap();
+        present_cycle
+            .discover_and_resolve(&mut last_known_active, &mut unhealthy_instance_ids_with_grace)
+            .await
+            .unwrap();
+        missing_cycle
+            .discover_and_resolve(&mut last_known_active, &mut unhealthy_instance_ids_with_grace)
+            .await
+            .unwrap();
         assert_eq!(last_known_active.get(&inst.instance_id).map(|(_, ttl)| *ttl), Some(1));
 
-        let refresh_resolution =
-            present_cycle.discover_and_resolve(&mut last_known_active).await.unwrap();
+        let refresh_resolution = present_cycle
+            .discover_and_resolve(&mut last_known_active, &mut unhealthy_instance_ids_with_grace)
+            .await
+            .unwrap();
 
         assert!(refresh_resolution.active_signers.contains(&signer_addr));
         assert!(refresh_resolution.unresolved_instance_ids.is_empty());
         assert_eq!(last_known_active.get(&inst.instance_id).map(|(_, ttl)| *ttl), Some(0));
 
         for expected_ttl in 1..=INSTANCE_CACHE_TTL_CYCLES {
-            let resolution =
-                missing_cycle.discover_and_resolve(&mut last_known_active).await.unwrap();
+            let resolution = missing_cycle
+                .discover_and_resolve(
+                    &mut last_known_active,
+                    &mut unhealthy_instance_ids_with_grace,
+                )
+                .await
+                .unwrap();
 
             assert!(resolution.active_signers.contains(&signer_addr));
             assert_eq!(
@@ -815,8 +928,10 @@ mod tests {
             );
         }
 
-        let expired_resolution =
-            missing_cycle.discover_and_resolve(&mut last_known_active).await.unwrap();
+        let expired_resolution = missing_cycle
+            .discover_and_resolve(&mut last_known_active, &mut unhealthy_instance_ids_with_grace)
+            .await
+            .unwrap();
 
         assert!(expired_resolution.active_signers.is_empty());
         assert!(expired_resolution.unresolved_instance_ids.is_empty());

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -338,15 +338,7 @@ where
             match result {
                 Ok(outcome) => {
                     let active_signers = outcome.active_signers.iter().copied().collect::<Vec<_>>();
-                    if active_signers.is_empty()
-                        && outcome.unresolved_instance_ids.contains(&instance.instance_id)
-                    {
-                        if let Some((cached_signers, _)) =
-                            last_known_active.get(&instance.instance_id)
-                        {
-                            resolution.active_signers.extend(cached_signers.iter().copied());
-                        }
-                    } else if active_signers.is_empty() {
+                    if active_signers.is_empty() {
                         last_known_active.remove(&instance.instance_id);
                     } else {
                         last_known_active.insert(instance.instance_id, (active_signers, 0));

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -12,8 +12,8 @@ pub use discovery::AwsTargetGroupDiscovery;
 
 mod driver;
 pub use driver::{
-    DEFAULT_MAX_CONCURRENCY, DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS, DiscoveryResolution,
-    DriverConfig, INSTANCE_CACHE_TTL_CYCLES, RegisterableSigner, RegistrationDriver,
+    DEFAULT_MAX_CONCURRENCY, DiscoveryResolution, DriverConfig, INSTANCE_CACHE_TTL_CYCLES,
+    RegisterableSigner, RegistrationDriver,
 };
 
 mod error;

--- a/crates/proof/tee/registrar/src/service.rs
+++ b/crates/proof/tee/registrar/src/service.rs
@@ -59,8 +59,6 @@ pub struct RegistrarConfig {
     pub max_tx_retries: u32,
     /// Initial delay between transaction submission retries.
     pub tx_retry_delay: Duration,
-    /// Grace window for registering recently launched unhealthy instances.
-    pub unhealthy_registration_window: Duration,
     /// Optional Nitro verifier address for CRL checks. Providing this enables CRL checks.
     pub crl_nitro_verifier_address: Option<Address>,
     /// Health server bind address.
@@ -88,7 +86,6 @@ impl fmt::Debug for RegistrarConfig {
             .field("instance_cache_ttl_cycles", &self.instance_cache_ttl_cycles)
             .field("max_tx_retries", &self.max_tx_retries)
             .field("tx_retry_delay", &self.tx_retry_delay)
-            .field("unhealthy_registration_window", &self.unhealthy_registration_window)
             .field("crl_nitro_verifier_address", &self.crl_nitro_verifier_address)
             .field("health_addr", &self.health_addr)
             .field("log_config", &self.log_config)
@@ -247,7 +244,6 @@ impl RegistrarConfig {
                 cancel: cancel.clone(),
                 max_concurrency: self.max_concurrency,
                 instance_cache_ttl_cycles: self.instance_cache_ttl_cycles,
-                unhealthy_registration_window: self.unhealthy_registration_window,
             },
             cert_manager,
             signer_manager,
@@ -334,7 +330,6 @@ mod tests {
             instance_cache_ttl_cycles: crate::INSTANCE_CACHE_TTL_CYCLES,
             max_tx_retries: 1,
             tx_retry_delay: Duration::from_secs(1),
-            unhealthy_registration_window: Duration::from_secs(1),
             crl_nitro_verifier_address: None,
             health_addr: "127.0.0.1:0".parse().unwrap(),
             log_config: base_cli_utils::LogConfig::default(),

--- a/crates/proof/tee/registrar/src/test_utils.rs
+++ b/crates/proof/tee/registrar/src/test_utils.rs
@@ -1,7 +1,5 @@
 //! Shared test fixtures for the registrar crate.
 
-use std::time::SystemTime;
-
 use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope};
 use alloy_primitives::{Address, B256};
 use alloy_rpc_types_eth::TransactionReceipt;
@@ -65,22 +63,17 @@ pub fn signer_from_private_key(private_key: &[u8; 32]) -> Address {
 }
 
 /// Builds a test [`ProverInstance`] with a deterministic instance id.
-pub fn prover_instance(
-    host_port: &str,
-    health_status: InstanceHealthStatus,
-    launch_time: Option<SystemTime>,
-) -> ProverInstance {
+pub fn prover_instance(host_port: &str, health_status: InstanceHealthStatus) -> ProverInstance {
     ProverInstance {
         instance_id: format!("i-{host_port}"),
         endpoint: url::Url::parse(&format!("http://{host_port}")).unwrap(),
         health_status,
-        launch_time,
     }
 }
 
-/// Builds a healthy test [`ProverInstance`] with no launch time.
+/// Builds a healthy test [`ProverInstance`].
 pub fn healthy_prover_instance(host_port: &str) -> ProverInstance {
-    prover_instance(host_port, InstanceHealthStatus::Healthy, None)
+    prover_instance(host_port, InstanceHealthStatus::Healthy)
 }
 
 /// Builds a transaction receipt with the requested success status.

--- a/crates/proof/tee/registrar/src/types.rs
+++ b/crates/proof/tee/registrar/src/types.rs
@@ -1,5 +1,3 @@
-use std::time::SystemTime;
-
 use url::Url;
 
 /// A prover instance discovered from the infrastructure layer.
@@ -11,9 +9,6 @@ pub struct ProverInstance {
     pub endpoint: Url,
     /// Current health status of the instance.
     pub health_status: InstanceHealthStatus,
-    /// EC2 launch time of the instance. Used to determine if recently-launched
-    /// unhealthy instances should still be eligible for registration.
-    pub launch_time: Option<SystemTime>,
 }
 
 /// Health status of a discovered prover instance.


### PR DESCRIPTION
### What changed? Why?

The registrar now treats ALB targets reported as unhealthy as unavailable: it skips signer public-key and attestation RPCs and does not start registration work for them. This removes the time-based unhealthy-registration grace window and the EC2 launch-time plumbing that supported it.

For an unhealthy target with cached signers, the registrar preserves those signers through the existing discovery-cache TTL so a transient health-check failure does not immediately trigger onchain deregistration. Resolution remains conclusive, so in-flight registration work for the target is cancelled. If the registrar first sees a target while it is unhealthy (including after a restart), it keeps an empty cache entry for the same TTL and defers orphan reconciliation until the grace period expires. A target that remains unhealthy past the TTL is handled by normal orphan cleanup.

### Notes to reviewers

Healthy and initial targets continue through the registration flow, and draining targets retain their existing behavior. The registrar and binary documentation now describe the cache behavior for unhealthy targets.

### How has it been tested?

- CI: `ci / Format`, `ci / Clippy`, `ci / Build`, and `ci / Test`