### PR TITLE
fix(nitro-host): add readiness endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5831,6 +5831,7 @@ dependencies = [
  "eyre",
  "jsonrpsee",
  "k256",
+ "reqwest 0.13.4",
  "thiserror 2.0.19",
  "tokio",
  "tokio-util",

--- a/bin/prover/nitro-host/README.md
+++ b/bin/prover/nitro-host/README.md
@@ -34,6 +34,8 @@ The `just tee nitro-local-worker` recipe wraps the same command.
 
 ## Health checks
 
+The registrar-facing RPC server exposes:
+
 - `GET /readyz` returns 200 once the host HTTP server is accepting requests. It
   does not require an onchain-registered signer, so registrar target groups
   should use it to bootstrap new instances.

--- a/bin/prover/nitro-host/README.md
+++ b/bin/prover/nitro-host/README.md
@@ -32,6 +32,14 @@ cargo run --package base-prover-nitro-host --features local -- local \
 
 The `just tee nitro-local-worker` recipe wraps the same command.
 
+## Health checks
+
+- `GET /readyz` returns 200 once the host HTTP server is accepting requests. It
+  does not require an onchain-registered signer, so registrar target groups
+  should use it to bootstrap new instances.
+- When `TEE_PROVER_REGISTRY_ADDRESS` is configured, `GET /healthz` requires a
+  valid onchain signer.
+
 ## Security Model
 
 This unauthenticated RPC listener is an internal control-plane endpoint. Restrict

--- a/crates/proof/tee/nitro-host/Cargo.toml
+++ b/crates/proof/tee/nitro-host/Cargo.toml
@@ -45,6 +45,7 @@ tokio-vsock.workspace = true
 
 [dev-dependencies]
 chrono.workspace = true
+reqwest.workspace = true
 alloy-genesis.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
 base-common-genesis = { workspace = true, features = ["serde", "std"] }

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -10,12 +10,11 @@
 //!
 //! After a signer deregistration or image rotation the health latch stays set
 //! while the proving guard rejects every request.  The prover will continue
-//! receiving traffic from the load balancer (because `/healthz` returns 200)
-//! but respond with `-32001` errors.  This is intentional: the ASG must not
-//! terminate the instance on a transient L1 blip, and proof-request callers
-//! already retry on other nodes.  If `/healthz` is ever the **sole** LB
-//! signal with no retry layer, switch to a bounded latch (e.g. stay healthy
-//! for N minutes after the last successful validation).
+//! returning 200 from `/healthz` but respond with `-32001` errors. Registrar
+//! target groups use `/readyz`, so their eligibility is independent of this
+//! latch. If another deployment uses `/healthz` as its **sole** load-balancer
+//! signal with no retry layer, switch to a bounded latch (e.g. stay healthy for
+//! N minutes after the last successful validation).
 
 use std::{sync::Arc, time::Duration};
 

--- a/crates/proof/tee/nitro-host/src/server.rs
+++ b/crates/proof/tee/nitro-host/src/server.rs
@@ -265,29 +265,12 @@ mod tests {
     use base_proof_primitives::EnclaveApiServer;
     use base_proof_tee_nitro_enclave::Server as EnclaveServer;
     use jsonrpsee::core::client::ClientT as _;
-    use tokio::{
-        io::{AsyncReadExt, AsyncWriteExt},
-        net::TcpStream,
-    };
 
     use super::*;
     use crate::test_utils::MockRegistry;
 
     async fn http_status(addr: std::net::SocketAddr, path: &str) -> u16 {
-        let mut stream = TcpStream::connect(addr).await.unwrap();
-        stream
-            .write_all(format!("GET {path} HTTP/1.1\r\nHost: {addr}\r\n\r\n").as_bytes())
-            .await
-            .unwrap();
-        let mut response = [0; 128];
-        let bytes = stream.read(&mut response).await.unwrap();
-        std::str::from_utf8(&response[..bytes])
-            .unwrap()
-            .split_whitespace()
-            .nth(1)
-            .unwrap()
-            .parse()
-            .unwrap()
+        reqwest::get(format!("http://{addr}{path}")).await.unwrap().status().as_u16()
     }
 
     #[tokio::test]

--- a/crates/proof/tee/nitro-host/src/server.rs
+++ b/crates/proof/tee/nitro-host/src/server.rs
@@ -347,10 +347,10 @@ mod tests {
     async fn registrar_rpc_server_readyz_bypasses_registration() {
         let server = Arc::new(EnclaveServer::new_local().unwrap());
         let transport = Arc::new(NitroTransport::local(server));
-        let checker = Arc::new(
-            RegistrationChecker::new(vec![Arc::clone(&transport)], MockRegistry::new(false))
-                .unwrap(),
-        );
+        let registry = MockRegistry::new(false);
+        let call_count = Arc::clone(&registry.call_count);
+        let checker =
+            Arc::new(RegistrationChecker::new(vec![Arc::clone(&transport)], registry).unwrap());
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
         drop(listener);
@@ -361,7 +361,9 @@ mod tests {
                 .unwrap();
 
         assert_eq!(http_status(addr, "/readyz").await, 200);
+        assert_eq!(call_count.load(Ordering::Relaxed), 0);
         assert_eq!(http_status(addr, "/healthz").await, 500);
+        assert_eq!(call_count.load(Ordering::Relaxed), 1);
         handle.stop().unwrap();
     }
 

--- a/crates/proof/tee/nitro-host/src/server.rs
+++ b/crates/proof/tee/nitro-host/src/server.rs
@@ -1,7 +1,7 @@
 use std::{fmt, net::SocketAddr, sync::Arc};
 
 use alloy_signer::utils::public_key_to_address;
-use base_health::{HealthzApiServer, HealthzResponse, HealthzRpc};
+use base_health::{HealthzApiServer, HealthzRpc};
 use base_proof_host::ProverConfig;
 use base_proof_primitives::{EnclaveApiServer, ProofRequest, ProofResult, ProverApiServer};
 use jsonrpsee::{
@@ -73,7 +73,7 @@ impl NitroProverServer {
         Self { pool, registration_health: None }
     }
 
-    /// Enables registration-gated `/healthz`; `/readyz` remains registration-independent.
+    /// Enables registration-gated health checks.
     pub fn with_registration_health(mut self, config: RegistrationHealthConfig) -> Self {
         self.registration_health = Some(config);
         self
@@ -84,15 +84,12 @@ impl NitroProverServer {
         // SECURITY: This unauthenticated RPC server is an internal control-plane endpoint.
         // Deployments must restrict it to trusted components on a private network.
         let middleware = tower::ServiceBuilder::new()
-            .layer(ProxyGetRequestLayer::new([("/healthz", "healthz"), ("/readyz", "readyz")])?);
+            .layer(ProxyGetRequestLayer::new([("/healthz", "healthz")])?);
         let server = Server::builder().set_http_middleware(middleware).build(addr).await?;
         let addr = server.local_addr()?;
         info!(addr = %addr, "nitro rpc server started");
 
         let mut module = RpcModule::new(());
-        module.register_method("readyz", |_, _, _| {
-            RpcResult::Ok(HealthzResponse { version: env!("CARGO_PKG_VERSION").to_string() })
-        })?;
         let transports = self.pool.transports();
         let mut pool = self.pool;
 
@@ -145,9 +142,7 @@ impl NitroProverServer {
         info!(addr = %addr, "nitro registrar rpc server started");
 
         let mut module = RpcModule::new(());
-        module.register_method("readyz", |_, _, _| {
-            RpcResult::Ok(HealthzResponse { version: env!("CARGO_PKG_VERSION").to_string() })
-        })?;
+        module.register_method("readyz", |_, _, _| RpcResult::Ok(()))?;
         match registration_checker {
             Some(checker) => {
                 module.merge(

--- a/crates/proof/tee/nitro-host/src/server.rs
+++ b/crates/proof/tee/nitro-host/src/server.rs
@@ -1,7 +1,7 @@
 use std::{fmt, net::SocketAddr, sync::Arc};
 
 use alloy_signer::utils::public_key_to_address;
-use base_health::{HealthzApiServer, HealthzRpc};
+use base_health::{HealthzApiServer, HealthzResponse, HealthzRpc};
 use base_proof_host::ProverConfig;
 use base_proof_primitives::{EnclaveApiServer, ProofRequest, ProofResult, ProverApiServer};
 use jsonrpsee::{
@@ -73,8 +73,7 @@ impl NitroProverServer {
         Self { pool, registration_health: None }
     }
 
-    /// Enables registration-gated health checks. When set, `/healthz` verifies
-    /// the enclave signer is registered in the `TEEProverRegistry` on L1.
+    /// Enables registration-gated `/healthz`; `/readyz` remains registration-independent.
     pub fn with_registration_health(mut self, config: RegistrationHealthConfig) -> Self {
         self.registration_health = Some(config);
         self
@@ -85,12 +84,15 @@ impl NitroProverServer {
         // SECURITY: This unauthenticated RPC server is an internal control-plane endpoint.
         // Deployments must restrict it to trusted components on a private network.
         let middleware = tower::ServiceBuilder::new()
-            .layer(ProxyGetRequestLayer::new([("/healthz", "healthz")])?);
+            .layer(ProxyGetRequestLayer::new([("/healthz", "healthz"), ("/readyz", "readyz")])?);
         let server = Server::builder().set_http_middleware(middleware).build(addr).await?;
         let addr = server.local_addr()?;
         info!(addr = %addr, "nitro rpc server started");
 
         let mut module = RpcModule::new(());
+        module.register_method("readyz", |_, _, _| {
+            RpcResult::Ok(HealthzResponse { version: env!("CARGO_PKG_VERSION").to_string() })
+        })?;
         let transports = self.pool.transports();
         let mut pool = self.pool;
 
@@ -137,12 +139,15 @@ impl NitroProverServer {
         // SECURITY: This unauthenticated RPC server is an internal control-plane endpoint.
         // Deployments must restrict it to trusted components on a private network.
         let middleware = tower::ServiceBuilder::new()
-            .layer(ProxyGetRequestLayer::new([("/healthz", "healthz")])?);
+            .layer(ProxyGetRequestLayer::new([("/healthz", "healthz"), ("/readyz", "readyz")])?);
         let server = Server::builder().set_http_middleware(middleware).build(addr).await?;
         let addr = server.local_addr()?;
         info!(addr = %addr, "nitro registrar rpc server started");
 
         let mut module = RpcModule::new(());
+        module.register_method("readyz", |_, _, _| {
+            RpcResult::Ok(HealthzResponse { version: env!("CARGO_PKG_VERSION").to_string() })
+        })?;
         match registration_checker {
             Some(checker) => {
                 module.merge(
@@ -260,9 +265,30 @@ mod tests {
     use base_proof_primitives::EnclaveApiServer;
     use base_proof_tee_nitro_enclave::Server as EnclaveServer;
     use jsonrpsee::core::client::ClientT as _;
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpStream,
+    };
 
     use super::*;
     use crate::test_utils::MockRegistry;
+
+    async fn http_status(addr: std::net::SocketAddr, path: &str) -> u16 {
+        let mut stream = TcpStream::connect(addr).await.unwrap();
+        stream
+            .write_all(format!("GET {path} HTTP/1.1\r\nHost: {addr}\r\n\r\n").as_bytes())
+            .await
+            .unwrap();
+        let mut response = [0; 128];
+        let bytes = stream.read(&mut response).await.unwrap();
+        std::str::from_utf8(&response[..bytes])
+            .unwrap()
+            .split_whitespace()
+            .nth(1)
+            .unwrap()
+            .parse()
+            .unwrap()
+    }
 
     #[tokio::test]
     async fn signer_public_key_routed_to_transport() {
@@ -336,6 +362,28 @@ mod tests {
             client.request("healthz", jsonrpsee::rpc_params![]).await.unwrap();
         assert_eq!(result.version, env!("CARGO_PKG_VERSION"));
         assert_eq!(call_count.load(Ordering::Relaxed), 1);
+        handle.stop().unwrap();
+    }
+
+    #[tokio::test]
+    async fn registrar_rpc_server_readyz_bypasses_registration() {
+        let server = Arc::new(EnclaveServer::new_local().unwrap());
+        let transport = Arc::new(NitroTransport::local(server));
+        let checker = Arc::new(
+            RegistrationChecker::new(vec![Arc::clone(&transport)], MockRegistry::new(false))
+                .unwrap(),
+        );
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let handle =
+            NitroProverServer::run_registrar_rpc_server(addr, vec![transport], Some(checker))
+                .await
+                .unwrap();
+
+        assert_eq!(http_status(addr, "/readyz").await, 200);
+        assert_eq!(http_status(addr, "/healthz").await, 500);
         handle.stop().unwrap();
     }
 


### PR DESCRIPTION
### What changed? Why?

Adds `GET /readyz` to the Nitro registrar-facing RPC server. The endpoint returns 200 as soon as the HTTP server is accepting requests and does not check signer registration, allowing the registrar target group to discover a new host before its signer is registered onchain.

`GET /healthz` keeps its existing behavior: when registration health is configured, it returns an error until a signer is valid in the TEE prover registry. The Nitro host README now documents which endpoint registrar target groups should use.

### Notes to reviewers

The readiness endpoint is intentionally scoped to `run_registrar_rpc_server`; the full prover RPC server is unchanged. The registrar target group must switch its health check path from `/healthz` to `/readyz` when this is deployed.

The HTTP-level test starts the registrar server with an invalid registry response and verifies that `/readyz` returns 200 while `/healthz` returns 500.

### How has it been tested?

- `cargo fmt --all -- --check`
- `cargo test -p base-proof-tee-nitro-host --lib`
- `cargo clippy -p base-proof-tee-nitro-host --lib --tests -- -D warnings`