### PR TITLE
feat(builder): Pluggable Inclusion Policy Seam

### DIFF
--- a/crates/builder/core/src/assembly.rs
+++ b/crates/builder/core/src/assembly.rs
@@ -1,0 +1,135 @@
+//! Pluggable post-execution inclusion policy for the flashblocks build loop.
+//!
+//! After the builder executes a candidate transaction — but before it commits the result to the
+//! flashblock — it consults an [`InclusionPolicy`] to decide whether the transaction is included or
+//! dropped. The default [`DefaultInclusionPolicy`] includes every executed transaction, reproducing
+//! the builder's historical behavior exactly (where even reverting transactions are committed).
+//!
+//! This is a generic, transaction-agnostic seam. The policy sees only the neutral
+//! [`CandidateOutcome`] — hash, sender, execution result, and block position — and returns an
+//! [`InclusionDecision`]. It carries no knowledge of any particular transaction class; an external
+//! implementation may associate its own metadata with a candidate out of band, keyed by
+//! [`CandidateOutcome::hash`].
+
+use alloy_primitives::{Address, TxHash};
+
+/// The outcome of executing a candidate transaction, presented to an [`InclusionPolicy`] before the
+/// result is committed to the flashblock.
+#[derive(Debug, Clone, Copy)]
+pub struct CandidateOutcome {
+    /// The transaction hash.
+    pub hash: TxHash,
+    /// The transaction sender.
+    pub sender: Address,
+    /// Gas used by the execution.
+    pub gas_used: u64,
+    /// Whether the execution reverted (as opposed to succeeding).
+    pub reverted: bool,
+    /// The transaction's effective tip per gas at the current base fee.
+    pub effective_tip_per_gas: u128,
+    /// Cumulative block gas used before this transaction would be committed.
+    pub cumulative_gas_used: u64,
+    /// The block gas limit being targeted.
+    pub block_gas_limit: u64,
+    /// Index of the flashblock currently being built (0-based).
+    pub flashblock_index: u64,
+    /// Total number of flashblocks targeted for this block.
+    pub target_flashblock_count: u64,
+}
+
+impl CandidateOutcome {
+    /// Whether the flashblock currently being built is the final one of the block.
+    #[must_use]
+    pub const fn is_final_flashblock(&self) -> bool {
+        self.flashblock_index + 1 >= self.target_flashblock_count
+    }
+}
+
+/// Whether an executed candidate is committed to the flashblock or dropped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InclusionDecision {
+    /// Commit the executed transaction to the flashblock (the default).
+    Include,
+    /// Drop the executed transaction: its state changes are discarded and it is not included in the
+    /// block. The builder marks it invalid so dependent transactions from the same sender are
+    /// skipped too, matching how other post-execution rejections behave.
+    Skip,
+}
+
+/// Decides whether an executed candidate transaction is committed to the flashblock.
+///
+/// The builder calls [`InclusionPolicy::decide`] after executing each candidate and before
+/// committing it. The default [`DefaultInclusionPolicy`] returns [`InclusionDecision::Include`] for
+/// every transaction, reproducing the builder's historical behavior (including reverting
+/// transactions).
+pub trait InclusionPolicy: Send + Sync + std::fmt::Debug {
+    /// Decide whether the just-executed candidate should be committed.
+    fn decide(&self, outcome: &CandidateOutcome) -> InclusionDecision;
+}
+
+/// The default inclusion policy: include every executed transaction, unchanged.
+///
+/// This reproduces the builder's pre-seam behavior byte-for-byte — reverting transactions are still
+/// committed to the block.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DefaultInclusionPolicy;
+
+impl InclusionPolicy for DefaultInclusionPolicy {
+    fn decide(&self, _outcome: &CandidateOutcome) -> InclusionDecision {
+        InclusionDecision::Include
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, TxHash};
+
+    use super::*;
+
+    fn outcome(reverted: bool) -> CandidateOutcome {
+        CandidateOutcome {
+            hash: TxHash::ZERO,
+            sender: Address::ZERO,
+            gas_used: 21_000,
+            reverted,
+            effective_tip_per_gas: 1,
+            cumulative_gas_used: 0,
+            block_gas_limit: 30_000_000,
+            flashblock_index: 0,
+            target_flashblock_count: 4,
+        }
+    }
+
+    /// A sample policy that drops reverting transactions — the shape an external revert-protection
+    /// policy takes — exercised here to prove the seam distinguishes reverts.
+    #[derive(Debug)]
+    struct DropReverts;
+    impl InclusionPolicy for DropReverts {
+        fn decide(&self, o: &CandidateOutcome) -> InclusionDecision {
+            if o.reverted { InclusionDecision::Skip } else { InclusionDecision::Include }
+        }
+    }
+
+    #[test]
+    fn default_policy_includes_everything() {
+        assert_eq!(DefaultInclusionPolicy.decide(&outcome(false)), InclusionDecision::Include);
+        // Reverting transactions are still included under the default — historical behavior.
+        assert_eq!(DefaultInclusionPolicy.decide(&outcome(true)), InclusionDecision::Include);
+    }
+
+    #[test]
+    fn alternative_policy_can_drop_reverts() {
+        assert_eq!(DropReverts.decide(&outcome(false)), InclusionDecision::Include);
+        assert_eq!(DropReverts.decide(&outcome(true)), InclusionDecision::Skip);
+    }
+
+    #[test]
+    fn final_flashblock_is_detected() {
+        let mut o = outcome(false);
+        o.flashblock_index = 2;
+        o.target_flashblock_count = 4;
+        assert!(!o.is_final_flashblock());
+        o.flashblock_index = 3;
+        assert!(o.is_final_flashblock());
+    }
+}

--- a/crates/builder/core/src/execution.rs
+++ b/crates/builder/core/src/execution.rs
@@ -155,6 +155,10 @@ pub enum TxnExecutionError {
     /// Metering data has not yet arrived for this transaction.
     #[error("metering data pending")]
     MeteringDataPending,
+
+    /// The configured inclusion policy dropped this transaction after execution.
+    #[error("dropped by inclusion policy")]
+    DroppedByInclusionPolicy,
 }
 
 impl TxnExecutionError {

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -1187,6 +1187,12 @@ impl BasePayloadBuilderCtx {
             // The "simulation" terminology comes from upstream op-rbuilder's name for
             // locally executing a candidate transaction before committing it to the payload;
             // this is not metering service simulation data from MeterBundleResponse.
+            //
+            // These simulation metrics (and the success/revert counters and `log_txn` below)
+            // record every executed candidate, regardless of whether a later post-execution check
+            // rejects it — including the `MaxGasUsageExceeded` and inclusion-policy `Skip` paths
+            // below. They measure simulation work actually performed, not committed contents, so a
+            // policy dropping a large fraction of transactions will still count them here.
             BuilderMetrics::tx_simulation_duration().record(execution_time);
             BuilderMetrics::tx_byte_size().record(tx.inner().size() as f64);
             num_txs_simulated += 1;

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -1280,7 +1280,12 @@ impl BasePayloadBuilderCtx {
                     tx_hash,
                     Some(ordering_position),
                     || {
-                        BuilderRejectedEventData::from_error(&err, info, limits, Some(&tx_resources))
+                        BuilderRejectedEventData::from_error(
+                            &err,
+                            info,
+                            limits,
+                            Some(&tx_resources),
+                        )
                     },
                 );
                 log_txn(Err(err));

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -44,8 +44,9 @@ use tokio_util::sync::CancellationToken;
 use tracing::{Level, debug, span, trace, warn};
 
 use crate::{
-    BuilderConfig, BuilderMetrics, ExecutionInfo, ExecutionMeteringLimitExceeded, PayloadTxsBounds,
-    ResourceLimits, TxResources, TxnExecutionError, TxnOutcome,
+    BuilderConfig, BuilderMetrics, CandidateOutcome, ExecutionInfo, ExecutionMeteringLimitExceeded,
+    InclusionDecision, InclusionPolicy, PayloadTxsBounds, ResourceLimits, TxResources,
+    TxnExecutionError, TxnOutcome,
     transaction_events::{
         BuilderAcceptedEventData, BuilderConsideredEventData, BuilderRejectedEventData,
         BuilderTransactionEventContext, emit_builder_transaction_event, rejection_reason_code,
@@ -182,7 +183,8 @@ impl FlashblockDiagnostics {
             | TxnExecutionError::NonceTooLow
             | TxnExecutionError::InternalError(_)
             | TxnExecutionError::EvmError
-            | TxnExecutionError::MaxGasUsageExceeded => {
+            | TxnExecutionError::MaxGasUsageExceeded
+            | TxnExecutionError::DroppedByInclusionPolicy => {
                 self.txs_rejected_other += 1;
             }
         }
@@ -255,6 +257,9 @@ pub struct BasePayloadBuilderCtx {
     pub builder_config: BuilderConfig,
     /// Sender for forwarding per-block batches of rejected transactions to the audit-archiver.
     pub rejected_tx_sender: Option<mpsc::Sender<Vec<RejectedTransaction>>>,
+    /// Post-execution inclusion policy consulted before committing each candidate. Defaults to
+    /// [`DefaultInclusionPolicy`], which includes every executed transaction unchanged.
+    pub inclusion_policy: Arc<dyn InclusionPolicy>,
 }
 
 impl BasePayloadBuilderCtx {
@@ -1248,6 +1253,41 @@ impl BasePayloadBuilderCtx {
                 continue;
             }
 
+            // Pluggable post-execution inclusion decision. The default policy includes every
+            // executed transaction (reverting or not), reproducing historical behavior; an
+            // alternative policy may drop it (e.g. to enforce revert protection). Dropping discards
+            // the execution's state changes — nothing is committed below — and marks the sender's
+            // subsequent transactions invalid, matching other post-execution rejections.
+            if self.inclusion_policy.decide(&CandidateOutcome {
+                hash: tx_hash,
+                sender: tx.signer(),
+                gas_used,
+                reverted: !is_success,
+                effective_tip_per_gas: tx.effective_tip_per_gas(base_fee).unwrap_or(0),
+                cumulative_gas_used: info.cumulative_gas_used,
+                block_gas_limit: self.block_gas_limit(),
+                flashblock_index: self.flashblock_index(),
+                target_flashblock_count: self.target_flashblock_count(),
+            }) == InclusionDecision::Skip
+            {
+                let err = TxnExecutionError::DroppedByInclusionPolicy;
+                diag.record_rejection(&err);
+                let priority_fee = tx.effective_tip_per_gas(base_fee).unwrap_or(0) as f64;
+                record_rejected_tx_priority_fee(&err, priority_fee);
+                self.emit_builder_decision_event(
+                    &payload_id,
+                    TransactionEventType::BuilderRejected,
+                    tx_hash,
+                    Some(ordering_position),
+                    || {
+                        BuilderRejectedEventData::from_error(&err, info, limits, Some(&tx_resources))
+                    },
+                );
+                log_txn(Err(err));
+                best_txs.mark_invalid(tx.signer(), tx.nonce());
+                continue;
+            }
+
             info.cumulative_gas_used += gas_used;
             // record tx da size
             info.cumulative_da_bytes_used += tx_da_size;
@@ -1415,6 +1455,7 @@ impl BasePayloadBuilderCtx {
             extra: FlashblocksExtraCtx::default(),
             builder_config: crate::BuilderConfig::default(),
             rejected_tx_sender: None,
+            inclusion_policy: Arc::new(crate::DefaultInclusionPolicy),
         }
     }
 }

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -54,7 +54,7 @@ use tracing::{debug, error, info, metadata::Level, span, warn};
 
 use crate::{
     BuilderConfig, BuilderMetrics, CandidateSource, DefaultCandidateSource, ExecutionInfo,
-    PayloadBuilder, ResourceLimits,
+    InclusionPolicy, PayloadBuilder, ResourceLimits,
     flashblocks::{
         FlashblocksExtraCtx, best_txs::BestFlashblocksTxs, context::BasePayloadBuilderCtx,
         generator::BuildArguments,
@@ -135,6 +135,8 @@ pub(super) struct BasePayloadBuilder<Pool, Client, S = DefaultCandidateSource> {
     last_emitted_flashblock_id: Arc<LastEmittedFlashblockId>,
     /// Transforms the candidate transaction stream drained by the build loop.
     candidate_source: S,
+    /// Post-execution inclusion policy consulted before committing each candidate.
+    inclusion_policy: Arc<dyn InclusionPolicy>,
 }
 
 impl<Pool, Client, S> BasePayloadBuilder<Pool, Client, S> {
@@ -146,6 +148,7 @@ impl<Pool, Client, S> BasePayloadBuilder<Pool, Client, S> {
         config: BuilderConfig,
         outputs: BuilderOutputs,
         candidate_source: S,
+        inclusion_policy: Arc<dyn InclusionPolicy>,
     ) -> Self {
         Self {
             evm_config,
@@ -155,6 +158,7 @@ impl<Pool, Client, S> BasePayloadBuilder<Pool, Client, S> {
             outputs,
             last_emitted_flashblock_id: Arc::default(),
             candidate_source,
+            inclusion_policy,
         }
     }
 
@@ -255,6 +259,7 @@ where
             extra,
             builder_config: self.config.clone(),
             rejected_tx_sender: self.outputs.rejected_tx_sender.clone(),
+            inclusion_policy: Arc::clone(&self.inclusion_policy),
         })
     }
 

--- a/crates/builder/core/src/flashblocks/service.rs
+++ b/crates/builder/core/src/flashblocks/service.rs
@@ -25,8 +25,8 @@ use super::{
     payload::{BasePayloadBuilder, BuilderOutputs},
 };
 use crate::{
-    BuilderConfig, CandidateSource, DefaultCandidateSource, DefaultInclusionPolicy, InclusionPolicy,
-    RejectedTxForwarder,
+    BuilderConfig, CandidateSource, DefaultCandidateSource, DefaultInclusionPolicy,
+    InclusionPolicy, RejectedTxForwarder,
     traits::{NodeBounds, PoolBounds},
 };
 

--- a/crates/builder/core/src/flashblocks/service.rs
+++ b/crates/builder/core/src/flashblocks/service.rs
@@ -25,7 +25,8 @@ use super::{
     payload::{BasePayloadBuilder, BuilderOutputs},
 };
 use crate::{
-    BuilderConfig, CandidateSource, DefaultCandidateSource, RejectedTxForwarder,
+    BuilderConfig, CandidateSource, DefaultCandidateSource, DefaultInclusionPolicy, InclusionPolicy,
+    RejectedTxForwarder,
     traits::{NodeBounds, PoolBounds},
 };
 
@@ -41,13 +42,19 @@ use crate::{
 pub struct FlashblocksServiceBuilder<S = DefaultCandidateSource> {
     config: BuilderConfig,
     candidate_source: S,
+    inclusion_policy: Arc<dyn InclusionPolicy>,
 }
 
 impl FlashblocksServiceBuilder {
     /// Create a service builder that uses the default candidate source
-    /// (the pool's priority-ordered best transactions, unchanged).
-    pub const fn new(config: BuilderConfig) -> Self {
-        Self { config, candidate_source: DefaultCandidateSource }
+    /// (the pool's priority-ordered best transactions, unchanged) and the default inclusion policy
+    /// (every executed transaction is committed, unchanged).
+    pub fn new(config: BuilderConfig) -> Self {
+        Self {
+            config,
+            candidate_source: DefaultCandidateSource,
+            inclusion_policy: Arc::new(DefaultInclusionPolicy),
+        }
     }
 }
 
@@ -55,7 +62,21 @@ impl<S> FlashblocksServiceBuilder<S> {
     /// Replace the candidate transaction source used by the flashblocks build loop.
     #[must_use]
     pub fn with_candidate_source<S2>(self, candidate_source: S2) -> FlashblocksServiceBuilder<S2> {
-        FlashblocksServiceBuilder { config: self.config, candidate_source }
+        FlashblocksServiceBuilder {
+            config: self.config,
+            candidate_source,
+            inclusion_policy: self.inclusion_policy,
+        }
+    }
+
+    /// Replace the post-execution inclusion policy consulted before committing each candidate.
+    ///
+    /// Defaults to [`DefaultInclusionPolicy`] (include every executed transaction). An alternative
+    /// policy may drop executed transactions — for example to enforce revert protection.
+    #[must_use]
+    pub fn with_inclusion_policy(mut self, inclusion_policy: Arc<dyn InclusionPolicy>) -> Self {
+        self.inclusion_policy = inclusion_policy;
+        self
     }
 
     fn spawn_payload_builder_service<Node, Pool>(
@@ -90,6 +111,7 @@ impl<S> FlashblocksServiceBuilder<S> {
             self.config.clone(),
             BuilderOutputs { payload_tx: built_payload_tx, ws_pub, rejected_tx_sender },
             self.candidate_source.clone(),
+            Arc::clone(&self.inclusion_policy),
         );
         let payload_generator = BlockPayloadJobGenerator::with_builder(
             ctx.provider().clone(),

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -8,9 +8,7 @@
 #![cfg_attr(not(test), allow(unused_crate_dependencies))]
 
 mod assembly;
-pub use assembly::{
-    CandidateOutcome, DefaultInclusionPolicy, InclusionDecision, InclusionPolicy,
-};
+pub use assembly::{CandidateOutcome, DefaultInclusionPolicy, InclusionDecision, InclusionPolicy};
 
 mod candidate_source;
 pub use candidate_source::{BoxedBestTransactions, CandidateSource, DefaultCandidateSource};

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -7,6 +7,11 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), allow(unused_crate_dependencies))]
 
+mod assembly;
+pub use assembly::{
+    CandidateOutcome, DefaultInclusionPolicy, InclusionDecision, InclusionPolicy,
+};
+
 mod candidate_source;
 pub use candidate_source::{BoxedBestTransactions, CandidateSource, DefaultCandidateSource};
 

--- a/crates/builder/core/src/transaction_events.rs
+++ b/crates/builder/core/src/transaction_events.rs
@@ -427,6 +427,7 @@ pub(crate) const fn rejection_reason_code(err: &TxnExecutionError) -> &'static s
         TxnExecutionError::EvmError => "evm_error",
         TxnExecutionError::MaxGasUsageExceeded => "max_gas_usage_exceeded",
         TxnExecutionError::MeteringDataPending => "metering_data_pending",
+        TxnExecutionError::DroppedByInclusionPolicy => "dropped_by_inclusion_policy",
     }
 }
 


### PR DESCRIPTION
## Summary

This adds a generic, transaction-agnostic inclusion seam to the flashblocks build loop. After executing each candidate transaction and before committing it, the builder now consults an `InclusionPolicy` that returns either Include or Skip. The default `DefaultInclusionPolicy` includes every executed transaction, reproducing the builder's historical behavior exactly, including reverting transactions. The policy is object-safe and carries no knowledge of any transaction class, so downstream implementations can key their own metadata to a candidate hash out of band.