### PR TITLE
test(system): in-process differential build/validate fuzz harness

### DIFF
--- a/.github/workflows/fuzz-differential.yml
+++ b/.github/workflows/fuzz-differential.yml
@@ -1,0 +1,85 @@
+# Differential build/validate fuzz: runs the in-process fuzz test (no devnet).
+# On PRs touching execution-layer code it gates with a fixed set of seeds
+# (deterministic and fast). Nightly it sweeps a fresh random seed per shard. A
+# failing run prints the seed so it can be replayed via the dispatch input.
+name: Fuzz Differential
+
+on:
+  pull_request:
+    # Deterministic + fast, so it can gate. Scoped to code that affects block
+    # building/validation to avoid taxing unrelated PRs.
+    paths:
+      - "crates/execution/**"
+      - "crates/common/**"
+      - "crates/builder/**"
+      - "etc/systems/tests/fuzz_build_validate.rs"
+      - ".github/workflows/fuzz-differential.yml"
+  schedule:
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+    inputs:
+      seed:
+        description: "Seed to replay (hex or decimal). Blank = matrix seeds (PR) or random (nightly)."
+        required: false
+        type: string
+
+concurrency:
+  group: fuzz-differential-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  differential:
+    name: Differential fuzz (build/validate)
+    runs-on:
+      group: BasePerfRunnerGroup
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        seed: ["0xD1FF0000", "0x1", "0xDEADBEEF", "0xC0FFEE"]
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+      - uses: ./.github/actions/setup
+        with:
+          free-disk: "true"
+          native-deps: "true"
+          foundry: "true"
+          tools: cargo-nextest
+          rust-cache-shared-key: "stable"
+      - name: Build test contracts
+        # base-test-utils embeds Foundry artifacts (contracts/out/*.json) at compile
+        # time; they are gitignored build output, so generate them before building.
+        run: cd crates/utilities/test-utils/contracts && forge soldeer install && forge build
+      - name: Pick fuzz seed
+        # Dispatch input replays a specific seed; nightly picks a fresh random seed
+        # per shard; PRs use the fixed matrix seeds for a deterministic gate. The
+        # input is passed via env (not interpolated into the script) to avoid
+        # shell injection.
+        env:
+          SEED_INPUT: ${{ github.event.inputs.seed }}
+          MATRIX_SEED: ${{ matrix.seed }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ -n "$SEED_INPUT" ]; then
+            SEED="$SEED_INPUT"
+          elif [ "$EVENT_NAME" = "schedule" ]; then
+            SEED="0x$(openssl rand -hex 8)"
+          else
+            SEED="$MATRIX_SEED"
+          fi
+          echo "FUZZ_SEED=$SEED" >> "$GITHUB_ENV"
+          echo "::notice::Differential fuzz seed $SEED (replay via workflow_dispatch input seed=$SEED)"
+      - name: Run differential fuzz test
+        # FUZZ_SEED is exported by the "Pick fuzz seed" step above. In-process, no Docker.
+        run: |
+          cargo nextest run -P ci --locked -p base-system-tests \
+            --cargo-profile ci --no-capture -E 'binary(fuzz_build_validate)'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6405,6 +6405,7 @@ dependencies = [
  "base-prover-service-client",
  "base-prover-service-protocol",
  "base-runtime",
+ "base-test-utils",
  "base-tx-forwarding",
  "base-tx-manager",
  "base-txpool-rpc",

--- a/crates/execution/runner/src/test_utils/harness.rs
+++ b/crates/execution/runner/src/test_utils/harness.rs
@@ -7,11 +7,11 @@ use alloy_primitives::{B64, B256, Bytes};
 use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_client::RpcClient;
 use alloy_rpc_types::BlockNumberOrTag;
-use alloy_rpc_types_engine::PayloadAttributes;
+use alloy_rpc_types_engine::{PayloadAttributes, PayloadStatus};
 use base_common_consensus::{BaseBlock, BaseTxEnvelope};
 use base_common_network::Base;
 use base_common_rpc_types::GenesisInfo;
-use base_common_rpc_types_engine::BasePayloadAttributes;
+use base_common_rpc_types_engine::{BaseExecutionPayloadV4, BasePayloadAttributes};
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_payload_builder::BasePayloadBuilderAttributes;
 use base_test_utils::build_test_genesis;
@@ -40,6 +40,25 @@ pub struct PreparedBlock {
     pub new_block_hash: B256,
     /// Number of the newly-built block.
     pub new_block_number: u64,
+}
+
+/// A block payload built via `getPayload` but not yet validated or promoted.
+///
+/// Holds the raw payload plus the inputs `engine_newPayload` needs, so a caller can
+/// validate it (optionally after tampering, for negative tests) on this or another
+/// node.
+#[derive(Debug, Clone)]
+pub struct BuiltPayload {
+    /// Hash of the parent the payload was built on.
+    pub parent_hash: B256,
+    /// Parent beacon block root the payload was built with.
+    pub parent_beacon_block_root: B256,
+    /// Number of the newly-built block.
+    pub new_block_number: u64,
+    /// The built execution payload.
+    pub execution_payload: BaseExecutionPayloadV4,
+    /// Execution requests accompanying the payload.
+    pub execution_requests: Requests,
 }
 
 /// Builder for configuring and launching a test harness.
@@ -158,6 +177,30 @@ impl TestHarness {
     /// final FCU themselves — useful for benchmarks that want to time only the
     /// canonical FCU step.
     pub async fn prepare_unsafe_block(&self, transactions: Vec<Bytes>) -> Result<PreparedBlock> {
+        let built = self.build_payload(transactions).await?;
+        let payload_status = self.validate_payload(&built).await?;
+
+        if payload_status.status.is_invalid() {
+            return Err(eyre!("Engine rejected payload: {:?}", payload_status));
+        }
+
+        let new_block_hash = payload_status
+            .latest_valid_hash
+            .ok_or_else(|| eyre!("Payload status missing latest_valid_hash"))?;
+
+        Ok(PreparedBlock {
+            parent_hash: built.parent_hash,
+            new_block_hash,
+            new_block_number: built.new_block_number,
+        })
+    }
+
+    /// Build a block's payload via `getPayload`, without validating or promoting it.
+    ///
+    /// Returns the raw payload and the inputs needed to validate it, so callers can
+    /// re-validate it (optionally after tampering, for negative tests) via
+    /// [`validate_payload`](Self::validate_payload).
+    pub async fn build_payload(&self, transactions: Vec<Bytes>) -> Result<BuiltPayload> {
         let latest_block = self
             .provider()
             .get_block_by_number(BlockNumberOrTag::Latest)
@@ -225,20 +268,26 @@ impl TestHarness {
             Requests::new(execution_requests)
         };
 
-        let payload_status = self
-            .engine
-            .new_payload(execution_payload, vec![], parent_beacon_block_root, execution_requests)
-            .await?;
+        Ok(BuiltPayload {
+            parent_hash,
+            parent_beacon_block_root,
+            new_block_number,
+            execution_payload,
+            execution_requests,
+        })
+    }
 
-        if payload_status.status.is_invalid() {
-            return Err(eyre!("Engine rejected payload: {:?}", payload_status));
-        }
-
-        let new_block_hash = payload_status
-            .latest_valid_hash
-            .ok_or_else(|| eyre!("Payload status missing latest_valid_hash"))?;
-
-        Ok(PreparedBlock { parent_hash, new_block_hash, new_block_number })
+    /// Validate a built payload via `engine_newPayload` on this node, returning the
+    /// raw status. Does not check the status or promote the block.
+    pub async fn validate_payload(&self, built: &BuiltPayload) -> Result<PayloadStatus> {
+        self.engine
+            .new_payload(
+                built.execution_payload.clone(),
+                vec![],
+                built.parent_beacon_block_root,
+                built.execution_requests.clone(),
+            )
+            .await
     }
 
     /// Build a block using the provided transactions and push it through the engine.

--- a/crates/execution/runner/src/test_utils/mod.rs
+++ b/crates/execution/runner/src/test_utils/mod.rs
@@ -20,7 +20,7 @@ mod fixtures;
 pub use fixtures::{create_provider_factory, load_chain_spec};
 
 mod harness;
-pub use harness::{PreparedBlock, TestHarness, TestHarnessBuilder};
+pub use harness::{BuiltPayload, PreparedBlock, TestHarness, TestHarnessBuilder};
 
 mod node;
 pub use node::{LocalNode, LocalNodeProvider};

--- a/etc/systems/Cargo.toml
+++ b/etc/systems/Cargo.toml
@@ -97,6 +97,9 @@ clap = { workspace = true, features = ["derive"] }
 # load testing
 base-load-tests.workspace = true
 
+# test utils
+base-test-utils.workspace = true
+
 # consensus
 base-consensus-derive.workspace = true
 base-consensus-engine = { workspace = true, features = ["test-utils"] }

--- a/etc/systems/tests/fuzz_build_validate.rs
+++ b/etc/systems/tests/fuzz_build_validate.rs
@@ -6,9 +6,12 @@
 //! `newPayload` (the validator path); an error there means the builder produced a
 //! block the validator rejects, the class of disagreement that halts the chain.
 //!
-//! Beyond build-vs-validate, each block is checked against single-implementation
-//! invariants (gas within limit), and a second test asserts determinism: the same
-//! seed builds byte-identical blocks (matching state roots and hashes) twice.
+//! A contract is deployed into an early block so later transactions can call it
+//! and touch storage; transactions carry fuzzed EIP-2930 access lists that warm
+//! (or leave cold) those slots, exercising the warm/cold gas accounting builder
+//! and validator must agree on. Each block is also checked against single-
+//! implementation invariants (gas within limit), and a second test asserts
+//! determinism: the same seed builds byte-identical blocks twice.
 //!
 //! Runs fully in-process (no devnet, no Docker), forces exactly the generated
 //! transactions into each block (`no_tx_pool`), and uses a fixed per-block
@@ -25,20 +28,24 @@ use alloy_network::TransactionBuilder;
 use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_provider::Provider;
 use alloy_signer::SignerSync;
+use alloy_signer_local::PrivateKeySigner;
+use alloy_sol_types::SolCall;
 use base_common_rpc_types::BaseTransactionRequest;
 use base_node_runner::test_utils::TestHarness;
-use base_test_utils::{Account, DEVNET_CHAIN_ID};
+use base_test_utils::{AccessListContract, Account, DEVNET_CHAIN_ID};
 use eyre::{Result, eyre};
 use rand::{Rng, SeedableRng, rngs::StdRng};
 
 /// Default seed so a run replays deterministically. Override with `FUZZ_SEED`.
 const DEFAULT_SEED: u64 = 0x_D1FF_0000;
-/// Blocks to build in one run.
+/// Blocks of fuzzed transactions to build in one run (after the deploy block).
 const NUM_BLOCKS: u64 = 20;
 /// Transactions per block.
 const TXS_PER_BLOCK: usize = 12;
 /// Generous per-tx gas so generated transactions are always includable.
-const TX_GAS_LIMIT: u64 = 200_000;
+const TX_GAS_LIMIT: u64 = 500_000;
+/// Gas for the contract-deployment transaction.
+const DEPLOY_GAS_LIMIT: u64 = 3_000_000;
 
 /// Pre-funded test accounts used as senders (all allocated in the test genesis).
 const SENDERS: [Account; 3] = [Account::Alice, Account::Bob, Account::Charlie];
@@ -90,9 +97,12 @@ async fn oracle_rejects_tampered_block() -> Result<()> {
     let mut generator = FuzzTxGenerator::new(seed_from_env());
     let mut nonces = [0u64; SENDERS.len()];
 
+    // No contract deployed here; calls target an EOA (valid no-op) since this test
+    // only needs a validly-built block to then tamper with.
+    let contract = SENDERS[0].address();
     let mut txs = Vec::new();
     for _ in 0..5 {
-        let shape = generator.next_shape();
+        let shape = generator.next_shape(contract);
         txs.push(sign_tx(&SENDERS[shape.sender], &shape, nonces[shape.sender])?);
         nonces[shape.sender] += 1;
     }
@@ -138,19 +148,30 @@ struct BlockObs {
     gas_limit: u64,
 }
 
-/// Build `NUM_BLOCKS` blocks of fuzzed transactions on a fresh in-process node,
-/// asserting build-vs-validate agreement and per-block invariants, and return the
-/// per-block observations.
+/// Deploy the access-list contract in a seed block, then build `NUM_BLOCKS` blocks
+/// of fuzzed transactions on a fresh in-process node, asserting build-vs-validate
+/// agreement and per-block invariants, and return the per-block observations.
 async fn run_sequence(seed: u64) -> Result<Vec<BlockObs>> {
     let harness = TestHarness::new().await?;
     let mut generator = FuzzTxGenerator::new(seed);
     let mut nonces = [0u64; SENDERS.len()];
-    let mut observations = Vec::with_capacity(NUM_BLOCKS as usize);
 
+    // Seed pre-state: deploy the contract from the first sender so later blocks can
+    // call it and touch storage. The CREATE address is deterministic (sender + nonce).
+    let deployer = &SENDERS[0];
+    let deploy = deploy_tx(deployer, nonces[0])?;
+    harness
+        .build_block_from_transactions(vec![deploy])
+        .await
+        .map_err(|e| eyre!("deploy block failed (seed={seed:#x}): {e}"))?;
+    let contract = deployer.address().create(nonces[0]);
+    nonces[0] += 1;
+
+    let mut observations = Vec::with_capacity(NUM_BLOCKS as usize);
     for block in 0..NUM_BLOCKS {
         let mut txs = Vec::with_capacity(TXS_PER_BLOCK);
         for _ in 0..TXS_PER_BLOCK {
-            let shape = generator.next_shape();
+            let shape = generator.next_shape(contract);
             let raw = sign_tx(&SENDERS[shape.sender], &shape, nonces[shape.sender])?;
             nonces[shape.sender] += 1;
             txs.push(raw);
@@ -210,9 +231,9 @@ struct TxShape {
     access_list: AccessList,
 }
 
-/// Seeded generator for the fuzzed transaction stream. Kept simple for a first cut:
-/// valid transfers and small random calldata across the funded senders. The
-/// adversarial permutation layer (access lists, gas edges, tx-type mix) slots in here.
+/// Seeded generator for the fuzzed transaction stream: transfers, random calldata,
+/// and contract calls that touch storage, each with a fuzzed access list. The
+/// adversarial permutation layer (gas edges, more tx types) slots in here.
 struct FuzzTxGenerator {
     rng: StdRng,
 }
@@ -222,42 +243,67 @@ impl FuzzTxGenerator {
         Self { rng: StdRng::seed_from_u64(seed) }
     }
 
-    fn next_shape(&mut self) -> TxShape {
+    fn next_shape(&mut self, contract: Address) -> TxShape {
         let sender = self.rng.random_range(0..SENDERS.len());
-        let to = SENDERS[self.rng.random_range(0..SENDERS.len())].address();
-        let value = U256::from(self.rng.random_range(1..=1_000_000u64));
-        // ~1 in 5 transactions carry small random calldata.
-        let input = if self.rng.random_range(0..5) == 0 {
-            let len = self.rng.random_range(0..64usize);
-            let mut bytes = vec![0u8; len];
-            self.rng.fill(&mut bytes[..]);
-            Bytes::from(bytes)
-        } else {
-            Bytes::new()
+        let access_list = self.next_access_list(contract);
+        let (to, value, input) = match self.rng.random_range(0..5) {
+            // ~40%: call the contract, touching a storage slot (SSTORE).
+            0 | 1 => (contract, U256::ZERO, self.contract_call()),
+            // ~20%: random calldata to an account.
+            2 => {
+                let len = self.rng.random_range(0..64usize);
+                let mut bytes = vec![0u8; len];
+                self.rng.fill(&mut bytes[..]);
+                (self.random_recipient(), U256::ZERO, Bytes::from(bytes))
+            }
+            // ~40%: plain transfer.
+            _ => (
+                self.random_recipient(),
+                U256::from(self.rng.random_range(1..=1_000_000u64)),
+                Bytes::new(),
+            ),
         };
-        TxShape { sender, to, value, input, access_list: self.next_access_list() }
+        TxShape { sender, to, value, input, access_list }
     }
 
-    /// Generate an EIP-2930 access list over a small shared pool of addresses and
-    /// storage slots. Because the pool is small and only ~40% of txs carry a list,
-    /// the same slots recur across txs (declared/warm in some, absent/cold in
-    /// others), exercising the access-list gas accounting and warm/cold set setup
-    /// that builder and validator must agree on.
-    fn next_access_list(&mut self) -> AccessList {
+    fn random_recipient(&mut self) -> Address {
+        SENDERS[self.rng.random_range(0..SENDERS.len())].address()
+    }
+
+    /// Encode a call that writes a contract storage slot (`updateValue` -> slot 0),
+    /// so subsequent access-list warming has a real SSTORE to account for.
+    fn contract_call(&mut self) -> Bytes {
+        let new_value = U256::from(self.rng.random_range(0..1_000u64));
+        AccessListContract::updateValueCall { newValue: new_value }.abi_encode().into()
+    }
+
+    /// Generate an EIP-2930 access list that, ~40% of the time, declares the
+    /// contract's low storage slots (warming them). Because only some txs declare
+    /// them, the same slots are warm in some blocks and cold in others, exercising
+    /// the warm/cold gas accounting builder and validator must agree on.
+    fn next_access_list(&mut self, contract: Address) -> AccessList {
         if self.rng.random_range(0..5) >= 2 {
             return AccessList::default();
         }
-        let items = (0..self.rng.random_range(1..=2))
-            .map(|_| {
-                let address = SENDERS[self.rng.random_range(0..SENDERS.len())].address();
-                let storage_keys = (0..self.rng.random_range(0..=3))
-                    .map(|_| B256::from(U256::from(self.rng.random_range(0..8u64))))
-                    .collect();
-                AccessListItem { address, storage_keys }
-            })
-            .collect();
-        AccessList(items)
+        let storage_keys =
+            (0..self.rng.random_range(0..=2)).map(|i| B256::from(U256::from(i as u64))).collect();
+        AccessList(vec![AccessListItem { address: contract, storage_keys }])
     }
+}
+
+/// Build a signed contract-deployment transaction for the access-list contract.
+fn deploy_tx(account: &Account, nonce: u64) -> Result<Bytes> {
+    let signer = account.signer();
+    let request = BaseTransactionRequest::default()
+        .from(signer.address())
+        .with_deploy_code(AccessListContract::BYTECODE.clone())
+        .transaction_type(2)
+        .with_gas_limit(DEPLOY_GAS_LIMIT)
+        .with_max_fee_per_gas(1_000_000_000)
+        .with_max_priority_fee_per_gas(0)
+        .with_chain_id(DEVNET_CHAIN_ID)
+        .with_nonce(nonce);
+    finish(&signer, request)
 }
 
 /// Complete a shape into a signed, EIP-2718 encoded transaction on the test chain.
@@ -275,6 +321,11 @@ fn sign_tx(account: &Account, shape: &TxShape, nonce: u64) -> Result<Bytes> {
         .with_chain_id(DEVNET_CHAIN_ID)
         .with_access_list(shape.access_list.clone())
         .with_nonce(nonce);
+    finish(&signer, request)
+}
+
+/// Build, sign, and EIP-2718 encode a transaction request.
+fn finish(signer: &PrivateKeySigner, request: BaseTransactionRequest) -> Result<Bytes> {
     let typed =
         request.build_typed_tx().map_err(|req| eyre!("invalid transaction request: {req:?}"))?;
     let signature = signer.sign_hash_sync(&typed.signature_hash())?;

--- a/etc/systems/tests/fuzz_build_validate.rs
+++ b/etc/systems/tests/fuzz_build_validate.rs
@@ -50,6 +50,11 @@ const DEPLOY_GAS_LIMIT: u64 = 3_000_000;
 /// Pre-funded test accounts used as senders (all allocated in the test genesis).
 const SENDERS: [Account; 3] = [Account::Alice, Account::Bob, Account::Charlie];
 
+/// Regression corpus: seeds that must always build cleanly. When a fuzz run finds a
+/// build/validate divergence, add its seed here so the case replays deterministically
+/// on every run forever. Seeded here with a spread of known-good starting points.
+const CORPUS: &[u64] = &[DEFAULT_SEED, 0x1, 0xC0FFEE, 0xDEAD_BEEF];
+
 #[tokio::test]
 async fn fuzz_build_validate() -> Result<()> {
     let seed = seed_from_env();
@@ -82,6 +87,19 @@ async fn fuzz_build_validate_deterministic() -> Result<()> {
                 a.number
             ));
         }
+    }
+    Ok(())
+}
+
+/// Regression corpus: every committed seed must build cleanly. This is the
+/// deterministic replay gate — a divergence found by the nightly sweep is pinned
+/// here (by seed) and re-checked on every run, so a fixed bug never regresses.
+#[tokio::test]
+async fn fuzz_build_validate_corpus() -> Result<()> {
+    for &seed in CORPUS {
+        run_sequence(seed)
+            .await
+            .map_err(|e| eyre!("regression corpus seed {seed:#x} failed: {e}"))?;
     }
     Ok(())
 }

--- a/etc/systems/tests/fuzz_build_validate.rs
+++ b/etc/systems/tests/fuzz_build_validate.rs
@@ -288,11 +288,20 @@ impl FuzzTxGenerator {
         SENDERS[self.rng.random_range(0..SENDERS.len())].address()
     }
 
-    /// Encode a call that writes a contract storage slot (`updateValue` -> slot 0),
-    /// so subsequent access-list warming has a real SSTORE to account for.
+    /// Encode a call that writes contract storage, so access-list warming has real
+    /// SSTOREs to account for. Alternates between a fixed slot (`updateValue` ->
+    /// slot 0) and mapping slots (`insertMultiple` -> keccak-derived slots), which
+    /// broadens the warm/cold storage surface.
     fn contract_call(&mut self) -> Bytes {
-        let new_value = U256::from(self.rng.random_range(0..1_000u64));
-        AccessListContract::updateValueCall { newValue: new_value }.abi_encode().into()
+        if self.rng.random_range(0..2) == 0 {
+            let new_value = U256::from(self.rng.random_range(0..1_000u64));
+            AccessListContract::updateValueCall { newValue: new_value }.abi_encode().into()
+        } else {
+            let n = self.rng.random_range(1..=4usize);
+            let keys = (0..n).map(|_| U256::from(self.rng.random_range(0..16u64))).collect();
+            let values = (0..n).map(|_| U256::from(self.rng.random_range(0..1_000u64))).collect();
+            AccessListContract::insertMultipleCall { keys, values }.abi_encode().into()
+        }
     }
 
     /// Generate an EIP-2930 access list that, ~40% of the time, declares the

--- a/etc/systems/tests/fuzz_build_validate.rs
+++ b/etc/systems/tests/fuzz_build_validate.rs
@@ -75,6 +75,54 @@ async fn fuzz_build_validate_deterministic() -> Result<()> {
     Ok(())
 }
 
+/// Prove-red: the validator path (`newPayload`) actually rejects a bad block, so a
+/// green build/validate run is meaningful rather than a rubber stamp. Builds a valid
+/// payload, confirms it validates, then validates a tampered version (a wrong
+/// `parent_beacon_block_root`, which makes the recomputed block hash mismatch the
+/// payload's claimed hash) and requires an INVALID result.
+#[tokio::test]
+async fn oracle_rejects_tampered_block() -> Result<()> {
+    let harness = TestHarness::new().await?;
+    let mut generator = FuzzTxGenerator::new(seed_from_env());
+    let mut nonces = [0u64; SENDERS.len()];
+
+    let mut txs = Vec::new();
+    for _ in 0..5 {
+        let shape = generator.next_shape();
+        txs.push(sign_tx(&SENDERS[shape.sender], &shape, nonces[shape.sender])?);
+        nonces[shape.sender] += 1;
+    }
+
+    let built = harness.build_payload(txs).await?;
+
+    // Sanity: the untampered payload is accepted.
+    let clean = harness.validate_payload(&built).await?;
+    assert!(!clean.status.is_invalid(), "untampered payload should validate, got {clean:?}");
+
+    // Inject a divergence: a wrong parent_beacon_block_root makes the recomputed block
+    // hash mismatch the payload's claimed hash, so the validator must reject it.
+    let bad_pbbr = if built.parent_beacon_block_root == B256::repeat_byte(0xAB) {
+        B256::ZERO
+    } else {
+        B256::repeat_byte(0xAB)
+    };
+    let tampered = harness
+        .engine()
+        .new_payload(
+            built.execution_payload.clone(),
+            vec![],
+            bad_pbbr,
+            built.execution_requests.clone(),
+        )
+        .await?;
+    assert!(
+        tampered.status.is_invalid(),
+        "validator accepted a tampered block (parent_beacon_block_root mismatch): {tampered:?}"
+    );
+
+    Ok(())
+}
+
 /// Observations recorded for each built block, used for invariants and the
 /// determinism comparison.
 #[derive(Debug, PartialEq, Eq)]

--- a/etc/systems/tests/fuzz_build_validate.rs
+++ b/etc/systems/tests/fuzz_build_validate.rs
@@ -6,15 +6,20 @@
 //! `newPayload` (the validator path); an error there means the builder produced a
 //! block the validator rejects, the class of disagreement that halts the chain.
 //!
-//! Unlike the sync-parity test, this runs fully in-process (no devnet, no Docker),
-//! forces exactly the generated transactions into each block (`no_tx_pool`), and
-//! uses a fixed per-block timestamp, so a run is deterministic and a failing seed
-//! replays exactly. Override the seed with `FUZZ_SEED`.
+//! Beyond build-vs-validate, each block is checked against single-implementation
+//! invariants (gas within limit), and a second test asserts determinism: the same
+//! seed builds byte-identical blocks (matching state roots and hashes) twice.
+//!
+//! Runs fully in-process (no devnet, no Docker), forces exactly the generated
+//! transactions into each block (`no_tx_pool`), and uses a fixed per-block
+//! timestamp, so a run is deterministic and a failing seed replays exactly.
+//! Override the seed with `FUZZ_SEED`.
 
 use alloy_consensus::SignableTransaction;
-use alloy_eips::eip2718::Encodable2718;
+use alloy_eips::{BlockNumberOrTag, eip2718::Encodable2718};
 use alloy_network::TransactionBuilder;
-use alloy_primitives::{Address, Bytes, U256};
+use alloy_primitives::{Address, B256, Bytes, U256};
+use alloy_provider::Provider;
 use alloy_signer::SignerSync;
 use base_common_rpc_types::BaseTransactionRequest;
 use base_node_runner::test_utils::TestHarness;
@@ -37,10 +42,58 @@ const SENDERS: [Account; 3] = [Account::Alice, Account::Bob, Account::Charlie];
 #[tokio::test]
 async fn fuzz_build_validate() -> Result<()> {
     let seed = seed_from_env();
-    let harness = TestHarness::new().await?;
+    // Building the sequence exercises build-vs-validate (an error is a divergence)
+    // and the per-block invariants; the observations are discarded here.
+    run_sequence(seed).await?;
+    Ok(())
+}
 
+/// Determinism oracle: the same seed must build byte-identical blocks (matching
+/// state roots and hashes) across independent runs. A mismatch means block
+/// production is non-deterministic, which would make any divergence unreplayable.
+#[tokio::test]
+async fn fuzz_build_validate_deterministic() -> Result<()> {
+    let seed = seed_from_env();
+    let first = run_sequence(seed).await?;
+    let second = run_sequence(seed).await?;
+
+    if first.len() != second.len() {
+        return Err(eyre!(
+            "nondeterministic block count (seed={seed:#x}): {} != {}",
+            first.len(),
+            second.len()
+        ));
+    }
+    for (a, b) in first.iter().zip(second.iter()) {
+        if a != b {
+            return Err(eyre!(
+                "nondeterministic build at block {} (seed={seed:#x}): {a:?} != {b:?}",
+                a.number
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Observations recorded for each built block, used for invariants and the
+/// determinism comparison.
+#[derive(Debug, PartialEq, Eq)]
+struct BlockObs {
+    number: u64,
+    hash: B256,
+    state_root: B256,
+    gas_used: u64,
+    gas_limit: u64,
+}
+
+/// Build `NUM_BLOCKS` blocks of fuzzed transactions on a fresh in-process node,
+/// asserting build-vs-validate agreement and per-block invariants, and return the
+/// per-block observations.
+async fn run_sequence(seed: u64) -> Result<Vec<BlockObs>> {
+    let harness = TestHarness::new().await?;
     let mut generator = FuzzTxGenerator::new(seed);
     let mut nonces = [0u64; SENDERS.len()];
+    let mut observations = Vec::with_capacity(NUM_BLOCKS as usize);
 
     for block in 0..NUM_BLOCKS {
         let mut txs = Vec::with_capacity(TXS_PER_BLOCK);
@@ -56,9 +109,34 @@ async fn fuzz_build_validate() -> Result<()> {
         harness.build_block_from_transactions(txs).await.map_err(|e| {
             eyre!("build/validate divergence at block {block} (seed={seed:#x}): {e}")
         })?;
+
+        let header = harness
+            .provider()
+            .get_block_by_number(BlockNumberOrTag::Latest)
+            .await?
+            .ok_or_else(|| eyre!("no block found after building block {block} (seed={seed:#x})"))?
+            .header;
+
+        // Invariant: a block can never use more gas than its own limit.
+        if header.gas_used > header.gas_limit {
+            return Err(eyre!(
+                "invariant violated at block {block} (seed={seed:#x}): \
+                 gas_used {} > gas_limit {}",
+                header.gas_used,
+                header.gas_limit
+            ));
+        }
+
+        observations.push(BlockObs {
+            number: header.number,
+            hash: header.hash,
+            state_root: header.state_root,
+            gas_used: header.gas_used,
+            gas_limit: header.gas_limit,
+        });
     }
 
-    Ok(())
+    Ok(observations)
 }
 
 fn seed_from_env() -> u64 {

--- a/etc/systems/tests/fuzz_build_validate.rs
+++ b/etc/systems/tests/fuzz_build_validate.rs
@@ -1,0 +1,129 @@
+//! Deterministic in-process build/validate differential fuzz test.
+//!
+//! Builds blocks from fuzzed transaction sets on a single in-process node and
+//! checks that the executor accepts what the payload builder produced.
+//! `build_block_from_transactions` runs `getPayload` (the builder path) and then
+//! `newPayload` (the validator path); an error there means the builder produced a
+//! block the validator rejects, the class of disagreement that halts the chain.
+//!
+//! Unlike the sync-parity test, this runs fully in-process (no devnet, no Docker),
+//! forces exactly the generated transactions into each block (`no_tx_pool`), and
+//! uses a fixed per-block timestamp, so a run is deterministic and a failing seed
+//! replays exactly. Override the seed with `FUZZ_SEED`.
+
+use alloy_consensus::SignableTransaction;
+use alloy_eips::eip2718::Encodable2718;
+use alloy_network::TransactionBuilder;
+use alloy_primitives::{Address, Bytes, U256};
+use alloy_signer::SignerSync;
+use base_common_rpc_types::BaseTransactionRequest;
+use base_node_runner::test_utils::TestHarness;
+use base_test_utils::{Account, DEVNET_CHAIN_ID};
+use eyre::{Result, eyre};
+use rand::{Rng, SeedableRng, rngs::StdRng};
+
+/// Default seed so a run replays deterministically. Override with `FUZZ_SEED`.
+const DEFAULT_SEED: u64 = 0x_D1FF_0000;
+/// Blocks to build in one run.
+const NUM_BLOCKS: u64 = 20;
+/// Transactions per block.
+const TXS_PER_BLOCK: usize = 12;
+/// Generous per-tx gas so generated transactions are always includable.
+const TX_GAS_LIMIT: u64 = 200_000;
+
+/// Pre-funded test accounts used as senders (all allocated in the test genesis).
+const SENDERS: [Account; 3] = [Account::Alice, Account::Bob, Account::Charlie];
+
+#[tokio::test]
+async fn fuzz_build_validate() -> Result<()> {
+    let seed = seed_from_env();
+    let harness = TestHarness::new().await?;
+
+    let mut generator = FuzzTxGenerator::new(seed);
+    let mut nonces = [0u64; SENDERS.len()];
+
+    for block in 0..NUM_BLOCKS {
+        let mut txs = Vec::with_capacity(TXS_PER_BLOCK);
+        for _ in 0..TXS_PER_BLOCK {
+            let shape = generator.next_shape();
+            let raw = sign_tx(&SENDERS[shape.sender], &shape, nonces[shape.sender])?;
+            nonces[shape.sender] += 1;
+            txs.push(raw);
+        }
+
+        // Build (getPayload) then validate (newPayload). An error is a build-vs-validate
+        // divergence: the builder produced a block the validator rejects.
+        harness.build_block_from_transactions(txs).await.map_err(|e| {
+            eyre!("build/validate divergence at block {block} (seed={seed:#x}): {e}")
+        })?;
+    }
+
+    Ok(())
+}
+
+fn seed_from_env() -> u64 {
+    match std::env::var("FUZZ_SEED") {
+        Ok(s) if !s.is_empty() => s
+            .strip_prefix("0x")
+            .map_or_else(|| s.parse(), |h| u64::from_str_radix(h, 16))
+            .unwrap_or_else(|_| panic!("FUZZ_SEED={s:?} is not a valid u64")),
+        _ => DEFAULT_SEED,
+    }
+}
+
+/// A generated transaction shape, before nonce assignment and signing.
+struct TxShape {
+    sender: usize,
+    to: Address,
+    value: U256,
+    input: Bytes,
+}
+
+/// Seeded generator for the fuzzed transaction stream. Kept simple for a first cut:
+/// valid transfers and small random calldata across the funded senders. The
+/// adversarial permutation layer (access lists, gas edges, tx-type mix) slots in here.
+struct FuzzTxGenerator {
+    rng: StdRng,
+}
+
+impl FuzzTxGenerator {
+    fn new(seed: u64) -> Self {
+        Self { rng: StdRng::seed_from_u64(seed) }
+    }
+
+    fn next_shape(&mut self) -> TxShape {
+        let sender = self.rng.random_range(0..SENDERS.len());
+        let to = SENDERS[self.rng.random_range(0..SENDERS.len())].address();
+        let value = U256::from(self.rng.random_range(1..=1_000_000u64));
+        // ~1 in 5 transactions carry small random calldata.
+        let input = if self.rng.random_range(0..5) == 0 {
+            let len = self.rng.random_range(0..64usize);
+            let mut bytes = vec![0u8; len];
+            self.rng.fill(&mut bytes[..]);
+            Bytes::from(bytes)
+        } else {
+            Bytes::new()
+        };
+        TxShape { sender, to, value, input }
+    }
+}
+
+/// Complete a shape into a signed, EIP-2718 encoded transaction on the test chain.
+fn sign_tx(account: &Account, shape: &TxShape, nonce: u64) -> Result<Bytes> {
+    let signer = account.signer();
+    let request = BaseTransactionRequest::default()
+        .from(signer.address())
+        .to(shape.to)
+        .value(shape.value)
+        .with_input(shape.input.clone())
+        .transaction_type(2)
+        .with_gas_limit(TX_GAS_LIMIT)
+        .with_max_fee_per_gas(1_000_000_000)
+        .with_max_priority_fee_per_gas(0)
+        .with_chain_id(DEVNET_CHAIN_ID)
+        .with_nonce(nonce);
+    let typed =
+        request.build_typed_tx().map_err(|req| eyre!("invalid transaction request: {req:?}"))?;
+    let signature = signer.sign_hash_sync(&typed.signature_hash())?;
+    Ok(typed.into_signed(signature).encoded_2718().into())
+}

--- a/etc/systems/tests/fuzz_build_validate.rs
+++ b/etc/systems/tests/fuzz_build_validate.rs
@@ -16,7 +16,11 @@
 //! Override the seed with `FUZZ_SEED`.
 
 use alloy_consensus::SignableTransaction;
-use alloy_eips::{BlockNumberOrTag, eip2718::Encodable2718};
+use alloy_eips::{
+    BlockNumberOrTag,
+    eip2718::Encodable2718,
+    eip2930::{AccessList, AccessListItem},
+};
 use alloy_network::TransactionBuilder;
 use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_provider::Provider;
@@ -203,6 +207,7 @@ struct TxShape {
     to: Address,
     value: U256,
     input: Bytes,
+    access_list: AccessList,
 }
 
 /// Seeded generator for the fuzzed transaction stream. Kept simple for a first cut:
@@ -230,7 +235,28 @@ impl FuzzTxGenerator {
         } else {
             Bytes::new()
         };
-        TxShape { sender, to, value, input }
+        TxShape { sender, to, value, input, access_list: self.next_access_list() }
+    }
+
+    /// Generate an EIP-2930 access list over a small shared pool of addresses and
+    /// storage slots. Because the pool is small and only ~40% of txs carry a list,
+    /// the same slots recur across txs (declared/warm in some, absent/cold in
+    /// others), exercising the access-list gas accounting and warm/cold set setup
+    /// that builder and validator must agree on.
+    fn next_access_list(&mut self) -> AccessList {
+        if self.rng.random_range(0..5) >= 2 {
+            return AccessList::default();
+        }
+        let items = (0..self.rng.random_range(1..=2))
+            .map(|_| {
+                let address = SENDERS[self.rng.random_range(0..SENDERS.len())].address();
+                let storage_keys = (0..self.rng.random_range(0..=3))
+                    .map(|_| B256::from(U256::from(self.rng.random_range(0..8u64))))
+                    .collect();
+                AccessListItem { address, storage_keys }
+            })
+            .collect();
+        AccessList(items)
     }
 }
 
@@ -247,6 +273,7 @@ fn sign_tx(account: &Account, shape: &TxShape, nonce: u64) -> Result<Bytes> {
         .with_max_fee_per_gas(1_000_000_000)
         .with_max_priority_fee_per_gas(0)
         .with_chain_id(DEVNET_CHAIN_ID)
+        .with_access_list(shape.access_list.clone())
         .with_nonce(nonce);
     let typed =
         request.build_typed_tx().map_err(|req| eyre!("invalid transaction request: {req:?}"))?;


### PR DESCRIPTION
Adds a deterministic, in-process fuzz test that builds blocks from fuzzed transaction sets and checks the executor accepts what the payload builder produced. It drives base-node-runner's `TestHarness` (`getPayload` build → `newPayload` validate); an error there is a builder/validator disagreement, the kind that can stall the chain. No devnet or Docker, so it runs in ~9s.

## Why we want this

We run block building and block validation as separate code paths, and the real risk is they disagree on the same input. This exercises that boundary directly and deterministically, so a divergence is caught (and replayable) before it ships.

## Description

- Deploys a storage contract in a seed block, then fuzzes transfers, calldata, and contract calls (`updateValue`, `insertMultiple`) that SSTORE fixed and mapping slots.
- Carries fuzzed EIP-2930 access lists that warm or leave cold those slots, exercising the warm/cold gas accounting builder and validator must agree on.
- Oracles: build-vs-validate (an error is a divergence), a determinism check (same seed builds identical blocks), a gas invariant (gas_used <= gas_limit), and a prove-red test confirming the validator rejects a tampered block.
- A regression corpus of seeds replays deterministically on every run, so a fixed divergence never regresses.

Reuses `base-test-utils` funded accounts and the existing signing pattern. Failures carry the seed for replay (override with `FUZZ_SEED`).

## Coming next (follow-ups)

- EIP-8130 transaction generation (needs domain-separated auth proofs and Cobalt).
- Derive round-trip oracle (batch-encode then re-derive equals the built block).

## Testing

`cargo test -p base-system-tests --test fuzz_build_validate` runs 4 tests in-process, ~17s. Ran across several `FUZZ_SEED` values; fmt and clippy clean.

## Where this runs

`.github/workflows/fuzz-differential.yml` gates PRs touching execution-layer code with a fixed 4-seed matrix (deterministic) and sweeps a random seed per shard nightly.
