### PR TITLE
test(system): pin B20 asset version across the Cobalt upgrade

### DIFF
--- a/crates/common/precompile-macros/src/accounting.rs
+++ b/crates/common/precompile-macros/src/accounting.rs
@@ -323,6 +323,28 @@ fn expand_asset(input: DeriveInput) -> syn::Result<TokenStream> {
                 self.asset.set_multiplier(multiplier)
             }
 
+            fn pending_multiplier(&self) -> ::base_precompile_storage::Result<u128> {
+                self.asset.pending_multiplier()
+            }
+
+            fn pending_effective_at(&self) -> ::base_precompile_storage::Result<u64> {
+                self.asset.pending_effective_at()
+            }
+
+            fn set_pending(
+                &mut self,
+                multiplier: u128,
+                effective_at: u64,
+            ) -> ::base_precompile_storage::Result<()> {
+                self.asset.set_pending_multiplier(multiplier)?;
+                self.asset.set_pending_effective_at(effective_at)
+            }
+
+            fn clear_pending(&mut self) -> ::base_precompile_storage::Result<()> {
+                self.asset.set_pending_multiplier(0)?;
+                self.asset.set_pending_effective_at(0)
+            }
+
             fn extra_metadata(
                 &self,
                 key: &str,

--- a/crates/common/precompile-macros/src/accounting.rs
+++ b/crates/common/precompile-macros/src/accounting.rs
@@ -309,6 +309,12 @@ fn expand_asset(input: DeriveInput) -> syn::Result<TokenStream> {
     let name = input.ident;
     Ok(quote! {
         impl crate::AssetAccounting for #name<'_> {
+            fn timestamp(
+                &self,
+            ) -> ::base_precompile_storage::Result<::alloy_primitives::U256> {
+                Ok(self.storage.timestamp())
+            }
+
             fn multiplier(
                 &self,
             ) -> ::base_precompile_storage::Result<::alloy_primitives::U256> {

--- a/crates/common/precompiles/src/b20_asset/abi.rs
+++ b/crates/common/precompiles/src/b20_asset/abi.rs
@@ -3,7 +3,22 @@
 //! [`IB20Asset`] defines only the asset-specific surface.
 //! All inherited selectors come from [`crate::IB20`] defined in `b20/abi.rs`.
 
+use alloy_primitives::FixedBytes;
 use alloy_sol_types::sol;
+
+/// ERC-165 plus the three ERC-8056 interface IDs advertised by `supportsInterface` from `AssetV2`.
+///
+/// `IERC165` (`0x01ffc9a7`), `IScaledUIAmount` (`0xa60bf13d`), `IScaledUIAmountNewUIMultiplier`
+/// (`0x4bd27648`), and `IScaledUIAmountBalances` (`0xd890fd71`). The ERC-8056 Conversion extension
+/// (`0x57854fc3`) is deliberately absent — B-20 keeps `toScaledBalance`/`toRawBalance` unaliased.
+/// The `erc8056_interface_ids_match_selectors` test pins these against the derived selectors so a
+/// selector rename cannot silently drift them.
+pub const ERC8056_INTERFACE_IDS: [FixedBytes<4>; 4] = [
+    FixedBytes::new([0x01, 0xff, 0xc9, 0xa7]),
+    FixedBytes::new([0xa6, 0x0b, 0xf1, 0x3d]),
+    FixedBytes::new([0x4b, 0xd2, 0x76, 0x48]),
+    FixedBytes::new([0xd8, 0x90, 0xfd, 0x71]),
+];
 
 sol! {
     #[derive(Debug, PartialEq, Eq)]
@@ -16,8 +31,21 @@ sol! {
         /// `updateExtraMetadata` was called with an empty metadata key.
         error InvalidMetadataKey();
 
-        /// `updateMultiplier` was called with a zero multiplier.
+        /// A multiplier setter (`setUIMultiplier` / `updateMultiplier`) was called with a
+        /// multiplier of zero or above the `type(uint128).max` overflow guard.
         error InvalidMultiplier();
+
+        /// `setUIMultiplier` was called with an `effectiveAt` that is not in the future
+        error EffectiveAtInPast(uint256 effectiveAt);
+
+        /// `setUIMultiplier` was called with an `effectiveAt` above`effectiveAt` field size
+        error EffectiveAtTooFar(uint256 effectiveAt);
+
+        /// `setUIMultiplier` was called while a live pending update already exists.
+        error ScheduleOverlap(uint256 pendingEffectiveAt);
+
+        /// `cancelScheduledMultiplier` was called when there is no live pending update.
+        error NoScheduledMultiplier();
 
         /// A batched function was called with parallel arrays of differing lengths.
         error LengthMismatch(uint256 leftLen, uint256 rightLen);
@@ -36,8 +64,16 @@ sol! {
 
         // ── Events ───────────────────────────────────────────────────────────
 
-        /// Emitted by `updateMultiplier`.
+        /// Emitted by `updateMultiplier` (V1, Beryl). Retained for the `AssetV1` version; the
+        /// scheduled-multiplier version `AssetV2` emits `UIMultiplierUpdated` instead.
         event MultiplierUpdated(uint256 multiplier);
+
+        /// ERC-8056. Emitted by both multiplier setters at `AssetV2`: `setUIMultiplier`
+        event UIMultiplierUpdated(uint256 oldMultiplier, uint256 newMultiplier, uint256 effectiveAtTimestamp);
+
+        /// Emitted by `cancelScheduledMultiplier`, and by `updateMultiplier` when it clears a
+        /// live pending update.
+        event MultiplierUpdateCancelled(uint256 cancelledMultiplier, uint256 cancelledEffectiveAt);
 
         /// Emitted by `updateExtraMetadata`. Empty `value` indicates removal.
         event ExtraMetadataUpdated(string key, string value);
@@ -75,6 +111,17 @@ sol! {
         /// The current multiplier, scaled to `WAD_PRECISION`.
         function multiplier() external view returns (uint256);
 
+        /// ERC-8056 alias of `multiplier()` (available from `AssetV2`).
+        function uiMultiplier() external view returns (uint256);
+
+        /// ERC-8056: the multiplier scheduled to take effect, or the current multiplier when no
+        /// scheduled update exists. Available from `AssetV2`.
+        function newUIMultiplier() external view returns (uint256);
+
+        /// ERC-8056: the timestamp at which a scheduled multiplier becomes effective.
+        /// Available from `AssetV2`.
+        function effectiveAt() external view returns (uint256);
+
         /// Converts a raw balance to its scaled view: `rawBalance * multiplier / WAD_PRECISION`.
         function toScaledBalance(uint256 rawBalance) external view returns (uint256);
 
@@ -84,8 +131,27 @@ sol! {
         /// Convenience: `toScaledBalance(balanceOf(account))`.
         function scaledBalanceOf(address account) external view returns (uint256);
 
-        /// Sets a new multiplier. Holder balances are not rewritten; scaled balances derive at read time.
+        /// ERC-8056 Balances extension: alias of `scaledBalanceOf`. Available from `AssetV2`.
+        function balanceOfUI(address account) external view returns (uint256);
+
+        /// ERC-8056 Balances extension: `totalSupply() * multiplier() / WAD_PRECISION`.
+        /// Available from `AssetV2`.
+        function totalSupplyUI() external view returns (uint256);
+
+        /// Schedules a single multiplier update effective at `effectiveAt`.
+        /// The standard corporate-action path. Available from `AssetV2`; `OPERATOR_ROLE`.
+        function setUIMultiplier(uint256 newMultiplier, uint256 effectiveAt) external;
+
+        /// Cancels the single live pending update, restoring the no-pending state.
+        /// Available from `AssetV2`
+        function cancelScheduledMultiplier() external;
+
+        /// Instant failsafe: sets the current multiplier immediately and clears any pending.
+        /// At `AssetV1` emits `MultiplierUpdated` which was replaced in `AssetV2` by `UIMultiplierUpdated`
         function updateMultiplier(uint256 newMultiplier) external;
+
+        /// ERC-165 interface detection (available from `AssetV2`).
+        function supportsInterface(bytes4 interfaceId) external view returns (bool);
 
         // ── Batched issuance and clawback ────────────────────────────────────
 
@@ -114,10 +180,18 @@ impl IB20Asset::IB20AssetCalls {
             Self::announce(_) => "precompile-b20-asset-announce",
             Self::isAnnouncementIdUsed(_) => "precompile-b20-asset-isAnnouncementIdUsed",
             Self::multiplier(_) => "precompile-b20-asset-multiplier",
+            Self::uiMultiplier(_) => "precompile-b20-asset-uiMultiplier",
+            Self::newUIMultiplier(_) => "precompile-b20-asset-newUIMultiplier",
+            Self::effectiveAt(_) => "precompile-b20-asset-effectiveAt",
             Self::toScaledBalance(_) => "precompile-b20-asset-toScaledBalance",
             Self::toRawBalance(_) => "precompile-b20-asset-toRawBalance",
             Self::scaledBalanceOf(_) => "precompile-b20-asset-scaledBalanceOf",
+            Self::balanceOfUI(_) => "precompile-b20-asset-balanceOfUI",
+            Self::totalSupplyUI(_) => "precompile-b20-asset-totalSupplyUI",
+            Self::setUIMultiplier(_) => "precompile-b20-asset-setUIMultiplier",
+            Self::cancelScheduledMultiplier(_) => "precompile-b20-asset-cancelScheduledMultiplier",
             Self::updateMultiplier(_) => "precompile-b20-asset-updateMultiplier",
+            Self::supportsInterface(_) => "precompile-b20-asset-supportsInterface",
             Self::batchMint(_) => "precompile-b20-asset-batchMint",
             Self::extraMetadata(_) => "precompile-b20-asset-extraMetadata",
             Self::updateExtraMetadata(_) => "precompile-b20-asset-updateExtraMetadata",
@@ -127,9 +201,45 @@ impl IB20Asset::IB20AssetCalls {
 
 #[cfg(test)]
 mod tests {
-    use alloy_sol_types::SolInterface;
+    use alloy_primitives::FixedBytes;
+    use alloy_sol_types::{SolCall, SolInterface};
 
-    use crate::{IB20, IB20Asset};
+    use crate::{ERC8056_INTERFACE_IDS, IB20, IB20Asset};
+
+    /// XORs the selectors of an interface's members into its ERC-165 interface id.
+    fn xor(selectors: &[[u8; 4]]) -> FixedBytes<4> {
+        let mut acc = [0u8; 4];
+        for selector in selectors {
+            for (a, s) in acc.iter_mut().zip(selector) {
+                *a ^= *s;
+            }
+        }
+        FixedBytes::new(acc)
+    }
+
+    #[test]
+    fn erc8056_interface_ids_match_selectors() {
+        // IERC165 = supportsInterface(bytes4); the ERC-165 id equals that selector by construction.
+        assert_eq!(ERC8056_INTERFACE_IDS[0], xor(&[IB20Asset::supportsInterfaceCall::SELECTOR]));
+        // IScaledUIAmount = uiMultiplier().
+        assert_eq!(ERC8056_INTERFACE_IDS[1], xor(&[IB20Asset::uiMultiplierCall::SELECTOR]));
+        // IScaledUIAmountNewUIMultiplier = newUIMultiplier() ^ effectiveAt().
+        assert_eq!(
+            ERC8056_INTERFACE_IDS[2],
+            xor(&[IB20Asset::newUIMultiplierCall::SELECTOR, IB20Asset::effectiveAtCall::SELECTOR,])
+        );
+        // IScaledUIAmountBalances = balanceOfUI(address) ^ totalSupplyUI().
+        assert_eq!(
+            ERC8056_INTERFACE_IDS[3],
+            xor(&[IB20Asset::balanceOfUICall::SELECTOR, IB20Asset::totalSupplyUICall::SELECTOR,])
+        );
+    }
+
+    /// The Conversion extension id (`0x57854fc3`) must NOT be advertised.
+    #[test]
+    fn erc8056_conversion_extension_not_claimed() {
+        assert!(!ERC8056_INTERFACE_IDS.contains(&FixedBytes::new([0x57, 0x85, 0x4f, 0xc3])));
+    }
 
     #[test]
     fn asset_call_labels_are_stable() {

--- a/crates/common/precompiles/src/b20_asset/accounting.rs
+++ b/crates/common/precompiles/src/b20_asset/accounting.rs
@@ -12,6 +12,11 @@ use crate::TokenAccounting;
 /// Extra metadata entries are only exposed through the asset-token surface,
 /// not the base B-20 surface.
 pub trait AssetAccounting: TokenAccounting {
+    /// Returns the current block timestamp from the active storage context.
+    fn timestamp(&self) -> Result<U256> {
+        Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]))
+    }
+
     /// Returns the current multiplier scaled to WAD (1e18).
     fn multiplier(&self) -> Result<U256>;
     /// Writes a new multiplier.

--- a/crates/common/precompiles/src/b20_asset/accounting.rs
+++ b/crates/common/precompiles/src/b20_asset/accounting.rs
@@ -3,7 +3,7 @@
 use alloc::string::String;
 
 use alloy_primitives::U256;
-use base_precompile_storage::Result;
+use base_precompile_storage::{BasePrecompileError, Result};
 
 use crate::TokenAccounting;
 
@@ -16,6 +16,26 @@ pub trait AssetAccounting: TokenAccounting {
     fn multiplier(&self) -> Result<U256>;
     /// Writes a new multiplier.
     fn set_multiplier(&mut self, multiplier: U256) -> Result<()>;
+
+    /// Returns the pending scheduled multiplier target (ERC-8056)
+    ///
+    /// Packs with [`Self::pending_effective_at`] into a single slot. Introduced with the
+    /// scheduled-multiplier feature (`AssetV2`); earlier versions never touch this slot.
+    fn pending_multiplier(&self) -> Result<u128> {
+        Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]))
+    }
+    /// Returns the timestamp at which the pending multiplier becomes effective; `0` means none.
+    fn pending_effective_at(&self) -> Result<u64> {
+        Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]))
+    }
+    /// Writes the pending schedule.
+    fn set_pending(&mut self, _multiplier: u128, _effective_at: u64) -> Result<()> {
+        Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]))
+    }
+    /// Clears the pending schedule, restoring the no-pending state.
+    fn clear_pending(&mut self) -> Result<()> {
+        Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]))
+    }
 
     /// Returns the extra-metadata value for `key`, or an empty string if unset.
     fn extra_metadata(&self, key: &str) -> Result<String>;

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -26,6 +26,22 @@ use crate::{
     macros::decode_precompile_call,
 };
 
+/// Selectors introduced with the ERC-8056 scheduled-multiplier surface at `AssetV2` (Cobalt).
+///
+/// Versions that do not advertise scheduling ([`AssetVersion::supports_scheduled_multiplier`] is
+/// false) must treat these as unknown so they fall through to the same `UnknownFunctionSelector`
+/// path as before the shared ABI enum grew to preserve byte-identical Beryl (V1) behavior.
+const SCHEDULED_MULTIPLIER_SELECTORS: [[u8; 4]; 8] = [
+    IB20Asset::uiMultiplierCall::SELECTOR,
+    IB20Asset::newUIMultiplierCall::SELECTOR,
+    IB20Asset::effectiveAtCall::SELECTOR,
+    IB20Asset::balanceOfUICall::SELECTOR,
+    IB20Asset::totalSupplyUICall::SELECTOR,
+    IB20Asset::setUIMultiplierCall::SELECTOR,
+    IB20Asset::cancelScheduledMultiplierCall::SELECTOR,
+    IB20Asset::supportsInterfaceCall::SELECTOR,
+];
+
 impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
     /// ABI-dispatches `calldata` to the appropriate handler for `upgrade`.
     pub fn dispatch(
@@ -103,9 +119,12 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
     where
         O: PrecompileCallObserver,
     {
-        // Asset-specific and overridden selectors are caught here first.
+        // Asset-specific and overridden selectors are caught here first. The ERC-8056
+        // scheduled-multiplier selectors are gated to versions that support them
         if let Some(selector) = BerylSelector::selector(calldata)
             && IB20Asset::IB20AssetCalls::valid_selector(selector)
+            && (version.supports_scheduled_multiplier()
+                || !SCHEDULED_MULTIPLIER_SELECTORS.contains(&selector))
         {
             let call =
                 IB20Asset::IB20AssetCalls::abi_decode_validate(calldata).map_err(|error| {
@@ -346,11 +365,21 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
 
             // --- Multiplier reads ---
             SC::multiplier(_) => logic.multiplier(self)?.abi_encode().into(),
+            SC::uiMultiplier(_) => logic.ui_multiplier(self)?.abi_encode().into(),
+            SC::newUIMultiplier(_) => logic.new_ui_multiplier(self)?.abi_encode().into(),
+            SC::effectiveAt(_) => logic.effective_at(self)?.abi_encode().into(),
             SC::toScaledBalance(c) => {
                 logic.to_scaled_balance(self, c.rawBalance)?.abi_encode().into()
             }
             SC::toRawBalance(c) => logic.to_raw_balance(self, c.scaledBalance)?.abi_encode().into(),
             SC::scaledBalanceOf(c) => logic.scaled_balance_of(self, c.account)?.abi_encode().into(),
+            SC::balanceOfUI(c) => logic.balance_of_ui(self, c.account)?.abi_encode().into(),
+            SC::totalSupplyUI(_) => logic.total_supply_ui(self)?.abi_encode().into(),
+
+            // --- ERC-165 ---
+            SC::supportsInterface(c) => {
+                logic.supports_interface(c.interfaceId)?.abi_encode().into()
+            }
 
             // --- Announcement reads ---
             SC::isAnnouncementIdUsed(c) => {
@@ -363,6 +392,20 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
             // --- Multiplier mutations ---
             SC::updateMultiplier(c) => {
                 logic.update_multiplier(self, caller, c.newMultiplier, privileged)?;
+                Bytes::new()
+            }
+            SC::setUIMultiplier(c) => {
+                logic.set_ui_multiplier(
+                    self,
+                    caller,
+                    c.newMultiplier,
+                    c.effectiveAt,
+                    privileged,
+                )?;
+                Bytes::new()
+            }
+            SC::cancelScheduledMultiplier(_) => {
+                logic.cancel_scheduled_multiplier(self, caller, privileged)?;
                 Bytes::new()
             }
 
@@ -679,6 +722,44 @@ mod tests {
             base_precompile_storage::BasePrecompileError::revert(IB20Asset::InternalCallFailed {
                 call: inner_call
             })
+        );
+    }
+
+    #[test]
+    fn route_v1_rejects_scheduled_selector_as_unknown() {
+        let mut token = make_token();
+        let calldata = IB20Asset::setUIMultiplierCall {
+            newMultiplier: B20AssetStorage::WAD,
+            effectiveAt: U256::from(2u64),
+        }
+        .abi_encode();
+        let selector: [u8; 4] = calldata[..4].try_into().unwrap();
+        // Routed at V1 (Beryl) the ERC-8056 selector is gated out and stays unknown.
+        let err = call_asset(&mut token, ALICE, calldata).unwrap_err();
+        assert_eq!(
+            err,
+            base_precompile_storage::BasePrecompileError::UnknownFunctionSelector(selector)
+        );
+    }
+
+    #[test]
+    fn route_v2_reaches_erroring_default() {
+        let mut token = make_token();
+        let calldata = IB20Asset::setUIMultiplierCall {
+            newMultiplier: B20AssetStorage::WAD,
+            effectiveAt: U256::from(2u64),
+        }
+        .abi_encode();
+        let mut storage = storage_with_caller(ALICE);
+
+        let err = StorageCtx::enter(&mut storage, |ctx| {
+            token.route(ctx, &calldata, AssetVersion::V2, false, NoopPrecompileCallObserver)
+        })
+        .unwrap_err();
+
+        assert_eq!(
+            err,
+            base_precompile_storage::BasePrecompileError::UnknownFunctionSelector([0u8; 4])
         );
     }
 

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -579,6 +579,20 @@ mod tests {
         })
     }
 
+    fn call_asset_v2_at(
+        token: &mut TestAssetToken,
+        caller: Address,
+        now: U256,
+        calldata: Vec<u8>,
+    ) -> Result<Bytes> {
+        let mut storage = storage_with_caller(caller);
+        storage.set_timestamp(now);
+        token.accounting_mut().timestamp = now;
+        StorageCtx::enter(&mut storage, |ctx| {
+            token.route(ctx, calldata.as_ref(), AssetVersion::V2, false, NoopPrecompileCallObserver)
+        })
+    }
+
     fn batch_mint_calldata(recipients: Vec<Address>, amounts: Vec<U256>) -> Vec<u8> {
         IB20Asset::batchMintCall { recipients, amounts }.abi_encode()
     }
@@ -726,6 +740,70 @@ mod tests {
     }
 
     #[test]
+    fn route_v2_schedules_and_flips_multiplier_lazily() {
+        use alloy_sol_types::SolValue;
+
+        let mut token = make_token();
+        token.accounting_mut().roles.insert((AssetV1::OPERATOR_ROLE, ALICE), true);
+        let target = B20AssetStorage::WAD * U256::from(3u64);
+        let effective_at = U256::from(1_000u64);
+
+        call_asset_v2_at(
+            &mut token,
+            ALICE,
+            U256::from(1u64),
+            IB20Asset::setUIMultiplierCall { newMultiplier: target, effectiveAt: effective_at }
+                .abi_encode(),
+        )
+        .unwrap();
+
+        let before = call_asset_v2_at(
+            &mut token,
+            ALICE,
+            U256::from(999u64),
+            IB20Asset::multiplierCall {}.abi_encode(),
+        )
+        .unwrap();
+        assert_eq!(before, Bytes::from(B20AssetStorage::WAD.abi_encode()));
+
+        let after = call_asset_v2_at(
+            &mut token,
+            ALICE,
+            effective_at,
+            IB20Asset::multiplierCall {}.abi_encode(),
+        )
+        .unwrap();
+        assert_eq!(after, Bytes::from(target.abi_encode()));
+
+        let effective_at_read = call_asset_v2_at(
+            &mut token,
+            ALICE,
+            U256::from(1u64),
+            IB20Asset::effectiveAtCall {}.abi_encode(),
+        )
+        .unwrap();
+        assert_eq!(effective_at_read, Bytes::from(effective_at.abi_encode()));
+    }
+
+    #[test]
+    fn route_v2_supports_interface() {
+        use alloy_sol_types::SolValue;
+
+        let mut token = make_token();
+        let out = call_asset_v2_at(
+            &mut token,
+            ALICE,
+            U256::ZERO,
+            IB20Asset::supportsInterfaceCall {
+                interfaceId: alloy_primitives::FixedBytes::new([0x01, 0xff, 0xc9, 0xa7]),
+            }
+            .abi_encode(),
+        )
+        .unwrap();
+        assert_eq!(out, Bytes::from(true.abi_encode()));
+    }
+
+    #[test]
     fn route_v1_rejects_scheduled_selector_as_unknown() {
         let mut token = make_token();
         let calldata = IB20Asset::setUIMultiplierCall {
@@ -739,27 +817,6 @@ mod tests {
         assert_eq!(
             err,
             base_precompile_storage::BasePrecompileError::UnknownFunctionSelector(selector)
-        );
-    }
-
-    #[test]
-    fn route_v2_reaches_erroring_default() {
-        let mut token = make_token();
-        let calldata = IB20Asset::setUIMultiplierCall {
-            newMultiplier: B20AssetStorage::WAD,
-            effectiveAt: U256::from(2u64),
-        }
-        .abi_encode();
-        let mut storage = storage_with_caller(ALICE);
-
-        let err = StorageCtx::enter(&mut storage, |ctx| {
-            token.route(ctx, &calldata, AssetVersion::V2, false, NoopPrecompileCallObserver)
-        })
-        .unwrap_err();
-
-        assert_eq!(
-            err,
-            base_precompile_storage::BasePrecompileError::UnknownFunctionSelector([0u8; 4])
         );
     }
 

--- a/crates/common/precompiles/src/b20_asset/logic/interface.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/interface.rs
@@ -2,8 +2,8 @@
 
 use alloc::{string::String, vec::Vec};
 
-use alloy_primitives::{Address, B256, U256};
-use base_precompile_storage::Result;
+use alloy_primitives::{Address, B256, FixedBytes, U256};
+use base_precompile_storage::{BasePrecompileError, Result};
 
 use crate::{
     AssetAccounting, B20AssetToken, Eip712Domain, IB20, PermitArgs, PolicyAccounting, Token,
@@ -189,7 +189,8 @@ pub trait Asset<S: AssetAccounting, A: PolicyAccounting> {
 
     // --- Asset-specific mutations ---
 
-    /// Sets a new multiplier. Requires the operator role unless privileged.
+    /// Instant failsafe: sets the current multiplier immediately. Requires the operator role
+    /// unless privileged.
     fn update_multiplier(
         &self,
         token: &mut B20AssetToken<S, A>,
@@ -344,7 +345,7 @@ pub trait Asset<S: AssetAccounting, A: PolicyAccounting> {
     /// Converts a raw balance to its scaled view: `rawBalance * multiplier / WAD`.
     fn to_scaled_balance(&self, token: &B20AssetToken<S, A>, balance: U256) -> Result<U256>;
 
-    /// Converts a scaled balance back to its raw representation: `scaledBalance * WAD / multiplier`.
+    /// Converts a scaled balance back to its raw representation: `scaledBalance * WAD / multiplier`
     fn to_raw_balance(&self, token: &B20AssetToken<S, A>, balance: U256) -> Result<U256>;
 
     /// Returns the scaled balance for `account`.
@@ -352,4 +353,63 @@ pub trait Asset<S: AssetAccounting, A: PolicyAccounting> {
 
     /// Returns the asset operator role identifier (required for `announce` / `updateMultiplier`).
     fn operator_role(&self) -> B256;
+
+    // --- ERC-8056 scheduled multiplier (introduced at `AssetV2`, Cobalt) ---
+
+    /// Returns the effective multiplier.
+    fn effective_multiplier(&self, _token: &B20AssetToken<S, A>) -> Result<U256> {
+        Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]))
+    }
+
+    /// ERC-8056 `uiMultiplier()`.
+    fn ui_multiplier(&self, _token: &B20AssetToken<S, A>) -> Result<U256> {
+        Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]))
+    }
+
+    /// ERC-8056 `newUIMultiplier()`.
+    fn new_ui_multiplier(&self, _token: &B20AssetToken<S, A>) -> Result<U256> {
+        Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]))
+    }
+
+    /// ERC-8056 `effectiveAt()`.
+    fn effective_at(&self, _token: &B20AssetToken<S, A>) -> Result<U256> {
+        Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]))
+    }
+
+    /// ERC-8056 Balances extension `balanceOfUI()`.
+    fn balance_of_ui(&self, _token: &B20AssetToken<S, A>, _account: Address) -> Result<U256> {
+        Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]))
+    }
+
+    /// ERC-8056 Balances extension `totalSupplyUI()`.
+    fn total_supply_ui(&self, _token: &B20AssetToken<S, A>) -> Result<U256> {
+        Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]))
+    }
+
+    /// Schedules a multiplier update.
+    fn set_ui_multiplier(
+        &self,
+        _token: &mut B20AssetToken<S, A>,
+        _caller: Address,
+        _new_multiplier: U256,
+        _effective_at: U256,
+        _privileged: bool,
+    ) -> Result<()> {
+        Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]))
+    }
+
+    /// Cancels a scheduled multiplier update.
+    fn cancel_scheduled_multiplier(
+        &self,
+        _token: &mut B20AssetToken<S, A>,
+        _caller: Address,
+        _privileged: bool,
+    ) -> Result<()> {
+        Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]))
+    }
+
+    /// ERC-165 interface support query.
+    fn supports_interface(&self, _interface_id: FixedBytes<4>) -> Result<bool> {
+        Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]))
+    }
 }

--- a/crates/common/precompiles/src/b20_asset/logic/mod.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/mod.rs
@@ -15,6 +15,9 @@ pub use interface::Asset;
 mod v1;
 pub use v1::AssetV1;
 
+mod v2;
+pub use v2::AssetV2;
+
 /// Storage + policy binding the asset logic operates on.
 ///
 /// A minimal `(accounting, policy, policy_version)` holder implementing [`Token`];

--- a/crates/common/precompiles/src/b20_asset/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v2.rs
@@ -1,0 +1,304 @@
+//! Version 2 scaffolding for the asset B-20 precompile, activated at Cobalt.
+//!
+//! This version initially delegates existing behavior to the frozen [`AssetV1`].
+//! ERC-8056 behavior is introduced separately by overriding the interface defaults.
+
+use alloc::{string::String, vec::Vec};
+
+use alloy_primitives::{Address, B256, U256};
+use base_precompile_storage::Result;
+
+use crate::{
+    Asset, AssetAccounting, AssetV1, B20AssetToken, Eip712Domain, IB20, PermitArgs,
+    PolicyAccounting,
+};
+
+/// Second B-20 Asset precompile implementation, introduced at Cobalt.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct AssetV2;
+
+impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
+    fn transfer(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        caller: Address,
+        to: Address,
+        amount: U256,
+        privileged: bool,
+    ) -> Result<()> {
+        AssetV1.transfer(token, caller, to, amount, privileged)
+    }
+
+    fn transfer_from(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        caller: Address,
+        from: Address,
+        to: Address,
+        amount: U256,
+        privileged: bool,
+    ) -> Result<()> {
+        AssetV1.transfer_from(token, caller, from, to, amount, privileged)
+    }
+
+    fn approve(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        caller: Address,
+        spender: Address,
+        amount: U256,
+    ) -> Result<()> {
+        AssetV1.approve(token, caller, spender, amount)
+    }
+
+    fn emit_memo(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        caller: Address,
+        memo: B256,
+    ) -> Result<()> {
+        AssetV1.emit_memo(token, caller, memo)
+    }
+
+    fn mint(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        caller: Address,
+        to: Address,
+        amount: U256,
+        privileged: bool,
+    ) -> Result<()> {
+        AssetV1.mint(token, caller, to, amount, privileged)
+    }
+
+    fn burn(&self, token: &mut B20AssetToken<S, A>, caller: Address, amount: U256) -> Result<()> {
+        AssetV1.burn(token, caller, amount)
+    }
+
+    fn burn_blocked(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        caller: Address,
+        from: Address,
+        amount: U256,
+        privileged: bool,
+    ) -> Result<()> {
+        AssetV1.burn_blocked(token, caller, from, amount, privileged)
+    }
+
+    fn pause(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        caller: Address,
+        features: Vec<IB20::PausableFeature>,
+        privileged: bool,
+    ) -> Result<()> {
+        AssetV1.pause(token, caller, features, privileged)
+    }
+
+    fn unpause(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        caller: Address,
+        features: Vec<IB20::PausableFeature>,
+        privileged: bool,
+    ) -> Result<()> {
+        AssetV1.unpause(token, caller, features, privileged)
+    }
+
+    fn update_supply_cap(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        caller: Address,
+        new_cap: U256,
+        privileged: bool,
+    ) -> Result<()> {
+        AssetV1.update_supply_cap(token, caller, new_cap, privileged)
+    }
+
+    fn update_name(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        caller: Address,
+        name: String,
+        privileged: bool,
+    ) -> Result<()> {
+        AssetV1.update_name(token, caller, name, privileged)
+    }
+
+    fn update_symbol(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        caller: Address,
+        symbol: String,
+        privileged: bool,
+    ) -> Result<()> {
+        AssetV1.update_symbol(token, caller, symbol, privileged)
+    }
+
+    fn update_contract_uri(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        caller: Address,
+        uri: String,
+        privileged: bool,
+    ) -> Result<()> {
+        AssetV1.update_contract_uri(token, caller, uri, privileged)
+    }
+
+    fn grant_role(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        caller: Address,
+        role: B256,
+        account: Address,
+        privileged: bool,
+    ) -> Result<()> {
+        AssetV1.grant_role(token, caller, role, account, privileged)
+    }
+
+    fn revoke_role(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        caller: Address,
+        role: B256,
+        account: Address,
+        privileged: bool,
+    ) -> Result<()> {
+        AssetV1.revoke_role(token, caller, role, account, privileged)
+    }
+
+    fn renounce_role(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        caller: Address,
+        role: B256,
+        confirmation: Address,
+    ) -> Result<()> {
+        AssetV1.renounce_role(token, caller, role, confirmation)
+    }
+
+    fn renounce_last_admin(&self, token: &mut B20AssetToken<S, A>, caller: Address) -> Result<()> {
+        AssetV1.renounce_last_admin(token, caller)
+    }
+
+    fn set_role_admin(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        caller: Address,
+        role: B256,
+        new_admin_role: B256,
+        privileged: bool,
+    ) -> Result<()> {
+        AssetV1.set_role_admin(token, caller, role, new_admin_role, privileged)
+    }
+
+    fn update_policy(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        caller: Address,
+        policy_scope: B256,
+        new_policy_id: u64,
+        privileged: bool,
+    ) -> Result<()> {
+        AssetV1.update_policy(token, caller, policy_scope, new_policy_id, privileged)
+    }
+
+    fn permit(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        chain_id: u64,
+        now: U256,
+        args: PermitArgs,
+    ) -> Result<()> {
+        AssetV1.permit(token, chain_id, now, args)
+    }
+
+    fn update_multiplier(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        caller: Address,
+        new_multiplier: U256,
+        privileged: bool,
+    ) -> Result<()> {
+        AssetV1.update_multiplier(token, caller, new_multiplier, privileged)
+    }
+
+    fn update_extra_metadata(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        caller: Address,
+        key: String,
+        value: String,
+        privileged: bool,
+    ) -> Result<()> {
+        AssetV1.update_extra_metadata(token, caller, key, value, privileged)
+    }
+
+    fn batch_mint(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        caller: Address,
+        recipients: Vec<Address>,
+        amounts: Vec<U256>,
+        privileged: bool,
+    ) -> Result<()> {
+        AssetV1.batch_mint(token, caller, recipients, amounts, privileged)
+    }
+
+    fn begin_announce(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        caller: Address,
+        id: String,
+        description: String,
+        uri: String,
+        privileged: bool,
+    ) -> Result<()> {
+        AssetV1.begin_announce(token, caller, id, description, uri, privileged)
+    }
+
+    fn end_announce(&self, token: &mut B20AssetToken<S, A>, id: String) -> Result<()> {
+        AssetV1.end_announce(token, id)
+    }
+
+    fn is_paused(
+        &self,
+        token: &B20AssetToken<S, A>,
+        feature: IB20::PausableFeature,
+    ) -> Result<bool> {
+        AssetV1.is_paused(token, feature)
+    }
+
+    fn paused_features(&self, token: &B20AssetToken<S, A>) -> Result<Vec<IB20::PausableFeature>> {
+        AssetV1.paused_features(token)
+    }
+
+    fn policy_id(&self, token: &B20AssetToken<S, A>, policy_scope: B256) -> Result<u64> {
+        AssetV1.policy_id(token, policy_scope)
+    }
+
+    fn domain_separator(&self, token: &B20AssetToken<S, A>, chain_id: u64) -> Result<B256> {
+        AssetV1.domain_separator(token, chain_id)
+    }
+
+    fn eip712_domain(&self, token: &B20AssetToken<S, A>, chain_id: u64) -> Result<Eip712Domain> {
+        AssetV1.eip712_domain(token, chain_id)
+    }
+
+    fn to_scaled_balance(&self, token: &B20AssetToken<S, A>, balance: U256) -> Result<U256> {
+        AssetV1.to_scaled_balance(token, balance)
+    }
+
+    fn to_raw_balance(&self, token: &B20AssetToken<S, A>, balance: U256) -> Result<U256> {
+        AssetV1.to_raw_balance(token, balance)
+    }
+
+    fn scaled_balance_of(&self, token: &B20AssetToken<S, A>, account: Address) -> Result<U256> {
+        AssetV1.scaled_balance_of(token, account)
+    }
+
+    fn operator_role(&self) -> B256 {
+        AssetV1::OPERATOR_ROLE
+    }
+}

--- a/crates/common/precompiles/src/b20_asset/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v2.rs
@@ -1,23 +1,229 @@
-//! Version 2 scaffolding for the asset B-20 precompile, activated at Cobalt.
+//! Version 2 of the asset B-20 precompile logic, activated at Cobalt.
 //!
-//! This version initially delegates existing behavior to the frozen [`AssetV1`].
-//! ERC-8056 behavior is introduced separately by overriding the interface defaults.
+//! V2 adds the ERC-8056 "Scaled UI Amount" scheduled-multiplier surface on top of the frozen
+//! [`AssetV1`] behavior: the current multiplier becomes *lazy*, a pending update can be
+//! scheduled and cancelled, the instant `update_multiplier` failsafe is rewired to the pending storage,
+//! and ERC-165 / ERC-8056 aliases are advertised. Storage is append-only,
+//! so a token created under V1 upgrades in place with no migration.
 
 use alloc::{string::String, vec::Vec};
 
 use alloy_primitives::{Address, B256, U256};
-use base_precompile_storage::Result;
+use alloy_sol_types::SolEvent;
+use base_precompile_storage::{BasePrecompileError, Result};
 
 use crate::{
-    Asset, AssetAccounting, AssetV1, B20AssetToken, Eip712Domain, IB20, PermitArgs,
-    PolicyAccounting,
+    Asset, AssetAccounting, AssetV1, B20AssetStorage, B20AssetToken, B20Guards, Eip712Domain, IB20,
+    IB20Asset, PermitArgs, PolicyAccounting, Token,
 };
 
-/// Second B-20 Asset precompile implementation, introduced at Cobalt.
+/// Second B-20 Asset precompile implementation. Introduced at Cobalt; adds ERC-8056 scheduled multipliers.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct AssetV2;
 
 impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
+    // ============================================================
+    //          Multiplier surface — V2-specific behavior
+    // ============================================================
+
+    /// Lazy effective multiplier: flips to a matured pending target once `now >= effectiveAt`.
+    fn multiplier(&self, token: &B20AssetToken<S, A>) -> Result<U256> {
+        self.effective_multiplier(token)
+    }
+
+    fn to_scaled_balance(&self, token: &B20AssetToken<S, A>, balance: U256) -> Result<U256> {
+        let multiplier = self.effective_multiplier(token)?;
+        let product =
+            balance.checked_mul(multiplier).ok_or_else(BasePrecompileError::under_overflow)?;
+        Ok(product / B20AssetStorage::WAD)
+    }
+
+    fn to_raw_balance(&self, token: &B20AssetToken<S, A>, balance: U256) -> Result<U256> {
+        let multiplier = self.effective_multiplier(token)?;
+        let product = balance
+            .checked_mul(B20AssetStorage::WAD)
+            .ok_or_else(BasePrecompileError::under_overflow)?;
+        Ok(product / multiplier)
+    }
+
+    fn scaled_balance_of(&self, token: &B20AssetToken<S, A>, account: Address) -> Result<U256> {
+        let balance = token.accounting().balance_of(account)?;
+        self.to_scaled_balance(token, balance)
+    }
+
+    /// Instantaneous failsafe. Writes the current multiplier immediately, clearing any pending update
+    fn update_multiplier(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        caller: Address,
+        new_multiplier: U256,
+        privileged: bool,
+    ) -> Result<()> {
+        let now = token.accounting().timestamp()?;
+        if !privileged {
+            B20Guards::ensure_role(token, caller, AssetV1::OPERATOR_ROLE)?;
+        }
+        if new_multiplier.is_zero() || new_multiplier > U256::from(u128::MAX) {
+            return Err(BasePrecompileError::revert(IB20Asset::InvalidMultiplier {}));
+        }
+        let pending_multiplier = U256::from(token.accounting().pending_multiplier()?);
+        let pending_effective_at = U256::from(token.accounting().pending_effective_at()?);
+        let live_pending = pending_effective_at > now;
+
+        let old = self.effective_multiplier(token)?;
+        token.accounting_mut().set_multiplier(new_multiplier)?;
+        if pending_effective_at != U256::ZERO {
+            token.accounting_mut().clear_pending()?;
+        }
+        if live_pending {
+            token.accounting_mut().emit_event(
+                IB20Asset::MultiplierUpdateCancelled {
+                    cancelledMultiplier: pending_multiplier,
+                    cancelledEffectiveAt: pending_effective_at,
+                }
+                .encode_log_data(),
+            )?;
+        }
+        token.accounting_mut().emit_event(
+            IB20Asset::UIMultiplierUpdated {
+                oldMultiplier: old,
+                newMultiplier: new_multiplier,
+                effectiveAtTimestamp: now,
+            }
+            .encode_log_data(),
+        )
+    }
+
+    fn effective_multiplier(&self, token: &B20AssetToken<S, A>) -> Result<U256> {
+        let now = token.accounting().timestamp()?;
+        let effective_at = token.accounting().pending_effective_at()?;
+        if effective_at != 0 && now >= U256::from(effective_at) {
+            let pending = token.accounting().pending_multiplier()?;
+            // Both setters reject zero, so a stored pending is never zero. Do not fall back to WAD:
+            // the Solidity reference also returns the raw pending value.
+            debug_assert!(pending != 0, "matured pending multiplier must be non-zero");
+            return Ok(U256::from(pending));
+        }
+        token.accounting().multiplier()
+    }
+
+    fn ui_multiplier(&self, token: &B20AssetToken<S, A>) -> Result<U256> {
+        self.multiplier(token)
+    }
+
+    fn new_ui_multiplier(&self, token: &B20AssetToken<S, A>) -> Result<U256> {
+        let now = token.accounting().timestamp()?;
+        let effective_at = token.accounting().pending_effective_at()?;
+        if U256::from(effective_at) > now {
+            return Ok(U256::from(token.accounting().pending_multiplier()?));
+        }
+        self.multiplier(token)
+    }
+
+    fn effective_at(&self, token: &B20AssetToken<S, A>) -> Result<U256> {
+        Ok(U256::from(token.accounting().pending_effective_at()?))
+    }
+
+    fn balance_of_ui(&self, token: &B20AssetToken<S, A>, account: Address) -> Result<U256> {
+        self.scaled_balance_of(token, account)
+    }
+
+    fn total_supply_ui(&self, token: &B20AssetToken<S, A>) -> Result<U256> {
+        let multiplier = self.effective_multiplier(token)?;
+        let supply = token.accounting().total_supply()?;
+        let product =
+            supply.checked_mul(multiplier).ok_or_else(BasePrecompileError::under_overflow)?;
+        Ok(product / B20AssetStorage::WAD)
+    }
+
+    fn set_ui_multiplier(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        caller: Address,
+        new_multiplier: U256,
+        effective_at: U256,
+        privileged: bool,
+    ) -> Result<()> {
+        let now = token.accounting().timestamp()?;
+        if !privileged {
+            B20Guards::ensure_role(token, caller, AssetV1::OPERATOR_ROLE)?;
+        }
+        if new_multiplier.is_zero() || new_multiplier > U256::from(u128::MAX) {
+            return Err(BasePrecompileError::revert(IB20Asset::InvalidMultiplier {}));
+        }
+        if effective_at <= now {
+            return Err(BasePrecompileError::revert(IB20Asset::EffectiveAtInPast {
+                effectiveAt: effective_at,
+            }));
+        }
+        if effective_at > U256::from(u64::MAX) {
+            return Err(BasePrecompileError::revert(IB20Asset::EffectiveAtTooFar {
+                effectiveAt: effective_at,
+            }));
+        }
+
+        let pending_effective_at = token.accounting().pending_effective_at()?;
+        // A live pending blocks a new schedule.
+        if U256::from(pending_effective_at) > now {
+            return Err(BasePrecompileError::revert(IB20Asset::ScheduleOverlap {
+                pendingEffectiveAt: U256::from(pending_effective_at),
+            }));
+        }
+        // Fold a matured pending into the current multiplier before overwriting it.
+        if pending_effective_at != 0 {
+            let matured = U256::from(token.accounting().pending_multiplier()?);
+            token.accounting_mut().set_multiplier(matured)?;
+        }
+
+        let old = token.accounting().multiplier()?;
+        // Narrowing is safe because the guards above enforce the storage field bounds.
+        token
+            .accounting_mut()
+            .set_pending(new_multiplier.to::<u128>(), effective_at.to::<u64>())?;
+        token.accounting_mut().emit_event(
+            IB20Asset::UIMultiplierUpdated {
+                oldMultiplier: old,
+                newMultiplier: new_multiplier,
+                effectiveAtTimestamp: effective_at,
+            }
+            .encode_log_data(),
+        )
+    }
+
+    fn cancel_scheduled_multiplier(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        caller: Address,
+        privileged: bool,
+    ) -> Result<()> {
+        let now = token.accounting().timestamp()?;
+        if !privileged {
+            B20Guards::ensure_role(token, caller, AssetV1::OPERATOR_ROLE)?;
+        }
+        let pending_multiplier = U256::from(token.accounting().pending_multiplier()?);
+        let pending_effective_at = U256::from(token.accounting().pending_effective_at()?);
+        // A pending maturing at exactly `now` has already taken effect and is not cancellable.
+        if pending_effective_at <= now {
+            return Err(BasePrecompileError::revert(IB20Asset::NoScheduledMultiplier {}));
+        }
+        token.accounting_mut().clear_pending()?;
+        token.accounting_mut().emit_event(
+            IB20Asset::MultiplierUpdateCancelled {
+                cancelledMultiplier: pending_multiplier,
+                cancelledEffectiveAt: pending_effective_at,
+            }
+            .encode_log_data(),
+        )
+    }
+
+    fn supports_interface(&self, interface_id: alloy_primitives::FixedBytes<4>) -> Result<bool> {
+        Ok(crate::ERC8056_INTERFACE_IDS.contains(&interface_id))
+    }
+
+    // ============================================================
+    //   Everything else delegates verbatim to the frozen AssetV1
+    // ============================================================
+
     fn transfer(
         &self,
         token: &mut B20AssetToken<S, A>,
@@ -214,16 +420,6 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
         AssetV1.permit(token, chain_id, now, args)
     }
 
-    fn update_multiplier(
-        &self,
-        token: &mut B20AssetToken<S, A>,
-        caller: Address,
-        new_multiplier: U256,
-        privileged: bool,
-    ) -> Result<()> {
-        AssetV1.update_multiplier(token, caller, new_multiplier, privileged)
-    }
-
     fn update_extra_metadata(
         &self,
         token: &mut B20AssetToken<S, A>,
@@ -286,19 +482,448 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
         AssetV1.eip712_domain(token, chain_id)
     }
 
-    fn to_scaled_balance(&self, token: &B20AssetToken<S, A>, balance: U256) -> Result<U256> {
-        AssetV1.to_scaled_balance(token, balance)
-    }
-
-    fn to_raw_balance(&self, token: &B20AssetToken<S, A>, balance: U256) -> Result<U256> {
-        AssetV1.to_raw_balance(token, balance)
-    }
-
-    fn scaled_balance_of(&self, token: &B20AssetToken<S, A>, account: Address) -> Result<U256> {
-        AssetV1.scaled_balance_of(token, account)
-    }
-
     fn operator_role(&self) -> B256 {
         AssetV1::OPERATOR_ROLE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, FixedBytes, LogData, U256};
+    use alloy_sol_types::SolEvent;
+    use base_precompile_storage::BasePrecompileError;
+
+    use crate::{
+        Asset, AssetAccounting, AssetV1, AssetV2, B20AssetStorage, B20AssetToken,
+        FakePolicyAccounting, IB20, IB20Asset, InMemoryTokenAccounting, PolicyVersion, Token,
+        TokenAccounting,
+    };
+
+    const TOKEN: Address = Address::repeat_byte(0x21);
+    const ALICE: Address = Address::repeat_byte(0xA1);
+    const BOB: Address = Address::repeat_byte(0xB0);
+    const LOGIC: AssetV2 = AssetV2;
+
+    type Tok = B20AssetToken<InMemoryTokenAccounting, FakePolicyAccounting>;
+
+    fn token() -> Tok {
+        // `InMemoryTokenAccounting::new` leaves `multiplier == 0`, which the read surface resolves
+        // to WAD — a fresh 1:1 token, matching the mock's factory default.
+        B20AssetToken::with_storage_and_policy(
+            InMemoryTokenAccounting::new(TOKEN),
+            FakePolicyAccounting::new(),
+            PolicyVersion::V1,
+        )
+    }
+
+    fn wad() -> U256 {
+        B20AssetStorage::WAD
+    }
+
+    fn grant_operator(tok: &mut Tok, who: Address) {
+        tok.accounting_mut().roles.insert((AssetV1::OPERATOR_ROLE, who), true);
+    }
+
+    fn set_now(tok: &mut Tok, now: U256) {
+        tok.accounting_mut().timestamp = now;
+    }
+
+    fn last_event(tok: &Tok) -> LogData {
+        tok.accounting().events.last().unwrap().clone()
+    }
+
+    // --- lazy multiplier ---
+
+    #[test]
+    fn multiplier_defaults_to_wad() {
+        let tok = token();
+        assert_eq!(LOGIC.multiplier(&tok).unwrap(), wad());
+    }
+
+    #[test]
+    fn multiplier_flips_lazily_at_effective_at_boundary() {
+        let mut tok = token();
+        let target = wad() * U256::from(3u64);
+        let effective_at = U256::from(100u64);
+        set_now(&mut tok, U256::from(10u64));
+        LOGIC.set_ui_multiplier(&mut tok, ALICE, target, effective_at, true).unwrap();
+
+        // T-1: still the old (current) multiplier.
+        set_now(&mut tok, U256::from(99u64));
+        assert_eq!(LOGIC.multiplier(&tok).unwrap(), wad());
+        // T: flips to the pending target.
+        set_now(&mut tok, U256::from(100u64));
+        assert_eq!(LOGIC.multiplier(&tok).unwrap(), target);
+        // T+1: stays flipped.
+        set_now(&mut tok, U256::from(101u64));
+        assert_eq!(LOGIC.multiplier(&tok).unwrap(), target);
+        // ui_multiplier is an alias.
+        assert_eq!(LOGIC.ui_multiplier(&tok).unwrap(), target);
+    }
+
+    // --- setUIMultiplier ---
+
+    #[test]
+    fn set_ui_multiplier_emits_event_and_records_pending() {
+        let mut tok = token();
+        let target = wad() * U256::from(2u64);
+        let effective_at = U256::from(500u64);
+        set_now(&mut tok, U256::from(1u64));
+        LOGIC.set_ui_multiplier(&mut tok, ALICE, target, effective_at, true).unwrap();
+
+        assert_eq!(
+            last_event(&tok),
+            IB20Asset::UIMultiplierUpdated {
+                oldMultiplier: wad(),
+                newMultiplier: target,
+                effectiveAtTimestamp: effective_at,
+            }
+            .encode_log_data()
+        );
+        assert_eq!(LOGIC.new_ui_multiplier(&tok).unwrap(), target);
+        assert_eq!(LOGIC.effective_at(&tok).unwrap(), effective_at);
+    }
+
+    #[test]
+    fn set_ui_multiplier_requires_operator_role() {
+        let mut tok = token();
+        set_now(&mut tok, U256::from(1u64));
+        let err =
+            LOGIC.set_ui_multiplier(&mut tok, ALICE, wad(), U256::from(2u64), false).unwrap_err();
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
+                account: ALICE,
+                neededRole: AssetV1::OPERATOR_ROLE,
+            })
+        );
+        // Once granted, the same call succeeds.
+        grant_operator(&mut tok, ALICE);
+        LOGIC.set_ui_multiplier(&mut tok, ALICE, wad(), U256::from(2u64), false).unwrap();
+    }
+
+    #[test]
+    fn set_ui_multiplier_rejects_zero_and_above_uint128() {
+        let mut tok = token();
+        set_now(&mut tok, U256::from(1u64));
+        let zero = LOGIC
+            .set_ui_multiplier(&mut tok, ALICE, U256::ZERO, U256::from(2u64), true)
+            .unwrap_err();
+        assert_eq!(zero, BasePrecompileError::revert(IB20Asset::InvalidMultiplier {}));
+
+        let too_big = U256::from(u128::MAX) + U256::ONE;
+        let over =
+            LOGIC.set_ui_multiplier(&mut tok, ALICE, too_big, U256::from(2u64), true).unwrap_err();
+        assert_eq!(over, BasePrecompileError::revert(IB20Asset::InvalidMultiplier {}));
+    }
+
+    #[test]
+    fn set_ui_multiplier_rejects_effective_at_in_past_and_too_far() {
+        let mut tok = token();
+        let now = U256::from(100u64);
+        set_now(&mut tok, now);
+        // effectiveAt == now is not in the future.
+        let past = LOGIC.set_ui_multiplier(&mut tok, ALICE, wad(), now, true).unwrap_err();
+        assert_eq!(
+            past,
+            BasePrecompileError::revert(IB20Asset::EffectiveAtInPast { effectiveAt: now })
+        );
+
+        let too_far = U256::from(u64::MAX) + U256::ONE;
+        let far = LOGIC.set_ui_multiplier(&mut tok, ALICE, wad(), too_far, true).unwrap_err();
+        assert_eq!(
+            far,
+            BasePrecompileError::revert(IB20Asset::EffectiveAtTooFar { effectiveAt: too_far })
+        );
+    }
+
+    #[test]
+    fn set_ui_multiplier_reverts_on_live_overlap() {
+        let mut tok = token();
+        let first_effective_at = U256::from(1_000u64);
+        set_now(&mut tok, U256::from(1u64));
+        LOGIC
+            .set_ui_multiplier(&mut tok, ALICE, wad() * U256::from(2u64), first_effective_at, true)
+            .unwrap();
+        let err = LOGIC
+            .set_ui_multiplier(
+                &mut tok,
+                ALICE,
+                wad() * U256::from(3u64),
+                U256::from(2_000u64),
+                true,
+            )
+            .unwrap_err();
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20Asset::ScheduleOverlap {
+                pendingEffectiveAt: first_effective_at,
+            })
+        );
+    }
+
+    #[test]
+    fn set_ui_multiplier_materializes_matured_pending() {
+        let mut tok = token();
+        let first = wad() * U256::from(2u64);
+        let first_effective_at = U256::from(100u64);
+        set_now(&mut tok, U256::from(1u64));
+        LOGIC.set_ui_multiplier(&mut tok, ALICE, first, first_effective_at, true).unwrap();
+
+        // After maturity, schedule a second: the matured first must fold into the current slot.
+        let now = U256::from(150u64);
+        set_now(&mut tok, now);
+        assert_eq!(LOGIC.multiplier(&tok).unwrap(), first, "first has matured");
+        let second = wad() * U256::from(3u64);
+        let second_effective_at = U256::from(300u64);
+        LOGIC.set_ui_multiplier(&mut tok, ALICE, second, second_effective_at, true).unwrap();
+
+        // `old` in the emitted event is the folded (matured) value, not the pre-fold WAD.
+        assert_eq!(
+            last_event(&tok),
+            IB20Asset::UIMultiplierUpdated {
+                oldMultiplier: first,
+                newMultiplier: second,
+                effectiveAtTimestamp: second_effective_at,
+            }
+            .encode_log_data()
+        );
+        // Slot 1 (current) now holds the folded matured multiplier and is still effective.
+        assert_eq!(tok.accounting().multiplier().unwrap(), first);
+        assert_eq!(LOGIC.multiplier(&tok).unwrap(), first);
+        // The second flips in on maturity.
+        set_now(&mut tok, second_effective_at);
+        assert_eq!(LOGIC.multiplier(&tok).unwrap(), second);
+    }
+
+    // --- cancelScheduledMultiplier ---
+
+    #[test]
+    fn cancel_clears_pending_and_emits() {
+        let mut tok = token();
+        let target = wad() * U256::from(2u64);
+        let effective_at = U256::from(1_000u64);
+        set_now(&mut tok, U256::from(1u64));
+        LOGIC.set_ui_multiplier(&mut tok, ALICE, target, effective_at, true).unwrap();
+
+        LOGIC.cancel_scheduled_multiplier(&mut tok, ALICE, true).unwrap();
+
+        assert_eq!(
+            last_event(&tok),
+            IB20Asset::MultiplierUpdateCancelled {
+                cancelledMultiplier: target,
+                cancelledEffectiveAt: effective_at,
+            }
+            .encode_log_data()
+        );
+        assert_eq!(LOGIC.effective_at(&tok).unwrap(), U256::ZERO);
+        // No-live-pending invariant.
+        assert_eq!(LOGIC.new_ui_multiplier(&tok).unwrap(), LOGIC.ui_multiplier(&tok).unwrap());
+    }
+
+    #[test]
+    fn cancel_reverts_without_live_pending() {
+        let mut tok = token();
+        set_now(&mut tok, U256::from(1u64));
+        let none = LOGIC.cancel_scheduled_multiplier(&mut tok, ALICE, true).unwrap_err();
+        assert_eq!(none, BasePrecompileError::revert(IB20Asset::NoScheduledMultiplier {}));
+
+        // A matured pending is no longer "live", so cancel still reverts.
+        LOGIC
+            .set_ui_multiplier(&mut tok, ALICE, wad() * U256::from(2u64), U256::from(100u64), true)
+            .unwrap();
+        set_now(&mut tok, U256::from(100u64));
+        let matured = LOGIC.cancel_scheduled_multiplier(&mut tok, ALICE, true).unwrap_err();
+        assert_eq!(matured, BasePrecompileError::revert(IB20Asset::NoScheduledMultiplier {}));
+    }
+
+    // --- updateMultiplier (instant failsafe) ---
+
+    #[test]
+    fn update_multiplier_emits_ui_event_at_now() {
+        let mut tok = token();
+        let now = U256::from(42u64);
+        let target = wad() * U256::from(5u64);
+        set_now(&mut tok, now);
+        LOGIC.update_multiplier(&mut tok, ALICE, target, true).unwrap();
+        assert_eq!(
+            last_event(&tok),
+            IB20Asset::UIMultiplierUpdated {
+                oldMultiplier: wad(),
+                newMultiplier: target,
+                effectiveAtTimestamp: now,
+            }
+            .encode_log_data()
+        );
+        assert_eq!(LOGIC.multiplier(&tok).unwrap(), target);
+    }
+
+    #[test]
+    fn update_multiplier_clears_live_pending_with_cancel_event() {
+        let mut tok = token();
+        let pending = wad() * U256::from(2u64);
+        let pending_effective_at = U256::from(1_000u64);
+        set_now(&mut tok, U256::from(1u64));
+        LOGIC.set_ui_multiplier(&mut tok, ALICE, pending, pending_effective_at, true).unwrap();
+
+        let now = U256::from(10u64);
+        let instant = wad() * U256::from(5u64);
+        set_now(&mut tok, now);
+        LOGIC.update_multiplier(&mut tok, ALICE, instant, true).unwrap();
+
+        let events = &tok.accounting().events;
+        assert_eq!(
+            events[events.len() - 2],
+            IB20Asset::MultiplierUpdateCancelled {
+                cancelledMultiplier: pending,
+                cancelledEffectiveAt: pending_effective_at,
+            }
+            .encode_log_data()
+        );
+        assert_eq!(
+            events[events.len() - 1],
+            IB20Asset::UIMultiplierUpdated {
+                oldMultiplier: wad(),
+                newMultiplier: instant,
+                effectiveAtTimestamp: now,
+            }
+            .encode_log_data()
+        );
+        assert_eq!(LOGIC.effective_at(&tok).unwrap(), U256::ZERO);
+        assert_eq!(LOGIC.multiplier(&tok).unwrap(), instant);
+    }
+
+    #[test]
+    fn update_multiplier_clears_matured_pending_without_cancel_event() {
+        let mut tok = token();
+        let matured = wad() * U256::from(2u64);
+        set_now(&mut tok, U256::from(1u64));
+        LOGIC.set_ui_multiplier(&mut tok, ALICE, matured, U256::from(100u64), true).unwrap();
+
+        let now = U256::from(150u64); // matured
+        let instant = wad() * U256::from(5u64);
+        set_now(&mut tok, now);
+        LOGIC.update_multiplier(&mut tok, ALICE, instant, true).unwrap();
+
+        // Only UIMultiplierUpdated is emitted (matured folds into `old` silently); `old` is the
+        // matured effective value.
+        assert_eq!(
+            last_event(&tok),
+            IB20Asset::UIMultiplierUpdated {
+                oldMultiplier: matured,
+                newMultiplier: instant,
+                effectiveAtTimestamp: now,
+            }
+            .encode_log_data()
+        );
+        let cancelled_sig = IB20Asset::MultiplierUpdateCancelled::SIGNATURE_HASH;
+        assert!(
+            !tok.accounting().events.iter().any(|log| log.topics()[0] == cancelled_sig),
+            "no cancellation event for a matured pending"
+        );
+        assert_eq!(LOGIC.effective_at(&tok).unwrap(), U256::ZERO);
+    }
+
+    #[test]
+    fn update_multiplier_rejects_zero_and_above_uint128() {
+        let mut tok = token();
+        set_now(&mut tok, U256::from(1u64));
+        let zero = LOGIC.update_multiplier(&mut tok, ALICE, U256::ZERO, true).unwrap_err();
+        assert_eq!(zero, BasePrecompileError::revert(IB20Asset::InvalidMultiplier {}));
+        let over = LOGIC
+            .update_multiplier(&mut tok, ALICE, U256::from(u128::MAX) + U256::ONE, true)
+            .unwrap_err();
+        assert_eq!(over, BasePrecompileError::revert(IB20Asset::InvalidMultiplier {}));
+    }
+
+    // --- newUIMultiplier / effectiveAt no-pending & matured semantics ---
+
+    #[test]
+    fn new_ui_multiplier_matured_mirrors_ui_multiplier_and_keeps_past_effective_at() {
+        let mut tok = token();
+        let target = wad() * U256::from(2u64);
+        let effective_at = U256::from(100u64);
+        set_now(&mut tok, U256::from(1u64));
+        LOGIC.set_ui_multiplier(&mut tok, ALICE, target, effective_at, true).unwrap();
+
+        let now = U256::from(150u64);
+        set_now(&mut tok, now);
+        assert_eq!(LOGIC.new_ui_multiplier(&tok).unwrap(), LOGIC.ui_multiplier(&tok).unwrap());
+        assert_eq!(LOGIC.new_ui_multiplier(&tok).unwrap(), target);
+        // A matured pending keeps its (now past) effectiveAt until a set/cancel materializes it.
+        assert_eq!(LOGIC.effective_at(&tok).unwrap(), effective_at);
+    }
+
+    // --- scaled reads route through the effective multiplier ---
+
+    #[test]
+    fn scaled_reads_use_effective_multiplier() {
+        let mut tok = token();
+        tok.accounting_mut().set_balance(ALICE, U256::from(100u64)).unwrap();
+        tok.accounting_mut().set_total_supply(U256::from(100u64)).unwrap();
+        let target = wad() * U256::from(2u64);
+        let effective_at = U256::from(100u64);
+        set_now(&mut tok, U256::from(1u64));
+        LOGIC.set_ui_multiplier(&mut tok, ALICE, target, effective_at, true).unwrap();
+
+        // Before maturity: 1:1.
+        let before = U256::from(50u64);
+        set_now(&mut tok, before);
+        assert_eq!(LOGIC.to_scaled_balance(&tok, U256::from(10u64)).unwrap(), U256::from(10u64));
+        assert_eq!(LOGIC.scaled_balance_of(&tok, ALICE).unwrap(), U256::from(100u64));
+        assert_eq!(LOGIC.balance_of_ui(&tok, ALICE).unwrap(), U256::from(100u64));
+        assert_eq!(LOGIC.total_supply_ui(&tok).unwrap(), U256::from(100u64));
+
+        // After maturity: doubled.
+        let after = U256::from(100u64);
+        set_now(&mut tok, after);
+        assert_eq!(LOGIC.to_scaled_balance(&tok, U256::from(10u64)).unwrap(), U256::from(20u64));
+        assert_eq!(LOGIC.to_raw_balance(&tok, U256::from(20u64)).unwrap(), U256::from(10u64));
+        assert_eq!(LOGIC.scaled_balance_of(&tok, ALICE).unwrap(), U256::from(200u64));
+        assert_eq!(LOGIC.balance_of_ui(&tok, ALICE).unwrap(), U256::from(200u64));
+        assert_eq!(LOGIC.total_supply_ui(&tok).unwrap(), U256::from(200u64));
+    }
+
+    // --- ERC-165 ---
+
+    #[test]
+    fn supports_interface_advertises_claimed_ids_only() {
+        // IERC165, IScaledUIAmount, IScaledUIAmountNewUIMultiplier, IScaledUIAmountBalances.
+        for id in [
+            [0x01, 0xff, 0xc9, 0xa7],
+            [0xa6, 0x0b, 0xf1, 0x3d],
+            [0x4b, 0xd2, 0x76, 0x48],
+            [0xd8, 0x90, 0xfd, 0x71],
+        ] {
+            assert!(
+                <AssetV2 as Asset<InMemoryTokenAccounting, FakePolicyAccounting>>::supports_interface(
+                    &LOGIC,
+                    FixedBytes::new(id)
+                )
+                .unwrap()
+            );
+        }
+        // Conversion extension is NOT claimed; nor is an arbitrary id.
+        for id in [[0x57, 0x85, 0x4f, 0xc3], [0xde, 0xad, 0xbe, 0xef], [0xff, 0xff, 0xff, 0xff]] {
+            assert!(
+                !<AssetV2 as Asset<
+                    InMemoryTokenAccounting,
+                    FakePolicyAccounting,
+                >>::supports_interface(&LOGIC, FixedBytes::new(id))
+                .unwrap()
+            );
+        }
+    }
+
+    // --- unchanged behavior still delegates to V1 ---
+
+    #[test]
+    fn transfer_delegates_to_v1() {
+        let mut tok = token();
+        tok.accounting_mut().set_balance(ALICE, U256::from(100u64)).unwrap();
+        LOGIC.transfer(&mut tok, ALICE, BOB, U256::from(30u64), true).unwrap();
+        assert_eq!(tok.accounting().balance_of(ALICE).unwrap(), U256::from(70u64));
+        assert_eq!(tok.accounting().balance_of(BOB).unwrap(), U256::from(30u64));
+        assert_eq!(last_event(&tok).topics()[0], IB20::Transfer::SIGNATURE_HASH);
     }
 }

--- a/crates/common/precompiles/src/b20_asset/mod.rs
+++ b/crates/common/precompiles/src/b20_asset/mod.rs
@@ -1,7 +1,7 @@
 //! `B20AssetToken` native precompile — asset variant of the B-20 token.
 
 mod abi;
-pub use abi::IB20Asset;
+pub use abi::{ERC8056_INTERFACE_IDS, IB20Asset};
 
 mod accounting;
 pub use accounting::AssetAccounting;
@@ -12,7 +12,7 @@ mod versions;
 pub use versions::{AssetVersion, AssetVersions};
 
 mod logic;
-pub use logic::{Asset, AssetV1, B20AssetToken};
+pub use logic::{Asset, AssetV1, AssetV2, B20AssetToken};
 
 mod precompile;
 pub use precompile::B20AssetPrecompile;

--- a/crates/common/precompiles/src/b20_asset/storage.rs
+++ b/crates/common/precompiles/src/b20_asset/storage.rs
@@ -23,6 +23,14 @@ pub struct B20AssetExtensionStorage {
     pub used_announcement_ids: Mapping<String, bool>, // slot 2
     /// Extra metadata values by metadata key.
     pub extra_metadata: Mapping<String, String>, // slot 3
+    /// Pending scheduled multiplier target (ERC-8056). Introduced with `AssetV2`
+    #[accessor]
+    #[mutator]
+    pub pending_multiplier: u128, // slot 4, offset 0
+    /// Timestamp at which [`Self::pending_multiplier`] becomes effective
+    #[accessor]
+    #[mutator]
+    pub pending_effective_at: u64, // slot 4, offset 16
 }
 
 /// EVM-backed storage for an asset B-20 token.
@@ -128,6 +136,40 @@ mod tests {
             2
         );
         assert_eq!(__packing_b20_asset_extension_storage::EXTRA_METADATA_LOC.offset_slots, 3);
+        // Pending (ERC-8056) packs `uint128 multiplier | uint64 effectiveAt` into slot 4
+        assert_eq!(__packing_b20_asset_extension_storage::PENDING_MULTIPLIER_LOC.offset_slots, 4);
+        assert_eq!(__packing_b20_asset_extension_storage::PENDING_MULTIPLIER_LOC.offset_bytes, 0);
+        assert_eq!(__packing_b20_asset_extension_storage::PENDING_EFFECTIVE_AT_LOC.offset_slots, 4);
+        assert_eq!(
+            __packing_b20_asset_extension_storage::PENDING_EFFECTIVE_AT_LOC.offset_bytes,
+            16
+        );
+    }
+
+    #[test]
+    fn pending_multiplier_and_effective_at_pack_into_slot_four() {
+        let (mut storage, _) = setup_storage();
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut token = B20AssetStorage::from_address(TOKEN, ctx);
+            // 3e18 pending multiplier, effective one year out — distinct, non-zero lanes.
+            let multiplier: u128 = 3_000_000_000_000_000_000;
+            let effective_at: u64 = 1_800_000_000;
+            token.asset.pending_multiplier.write(multiplier).unwrap();
+            token.asset.pending_effective_at.write(effective_at).unwrap();
+
+            let pending_slot = ASSET_ROOT
+                + U256::from(
+                    __packing_b20_asset_extension_storage::PENDING_MULTIPLIER_LOC.offset_slots,
+                );
+            // Solidity packs `uint128 multiplier | uint64 effectiveAt`: multiplier in the low 128
+            // bits, effectiveAt in the next 64. Assert the raw word matches that packing exactly.
+            let expected = U256::from(multiplier) | (U256::from(effective_at) << 128);
+            assert_eq!(ctx.sload(TOKEN, pending_slot).unwrap(), expected);
+
+            assert_eq!(token.asset.pending_multiplier.read().unwrap(), multiplier);
+            assert_eq!(token.asset.pending_effective_at.read().unwrap(), effective_at);
+        });
     }
 
     #[test]

--- a/crates/common/precompiles/src/b20_asset/versions.rs
+++ b/crates/common/precompiles/src/b20_asset/versions.rs
@@ -9,7 +9,7 @@
 
 use base_common_genesis::BaseUpgrade;
 
-use crate::{Asset, AssetAccounting, AssetV1, PolicyAccounting};
+use crate::{Asset, AssetAccounting, AssetV1, AssetV2, PolicyAccounting};
 
 /// An activated version of the asset B-20 precompile logic.
 ///
@@ -18,6 +18,8 @@ use crate::{Asset, AssetAccounting, AssetV1, PolicyAccounting};
 pub enum AssetVersion {
     /// Introduced at Beryl, the asset's activation fork.
     V1,
+    /// Introduced at Cobalt. Adds the ERC-8056 scheduled-multiplier surface
+    V2,
 }
 
 impl AssetVersion {
@@ -28,9 +30,19 @@ impl AssetVersion {
         A: PolicyAccounting + 'l,
     {
         static V1: AssetV1 = AssetV1;
+        static V2: AssetV2 = AssetV2;
         match self {
             Self::V1 => &V1,
+            Self::V2 => &V2,
         }
+    }
+
+    /// Whether this version advertises the ERC-8056 scheduled-multiplier surface
+    ///
+    /// Earlier versions must treat those selectors as unknown,
+    /// so the dispatcher gates them on this predicate.
+    pub const fn supports_scheduled_multiplier(self) -> bool {
+        matches!(self, Self::V2)
     }
 }
 
@@ -44,8 +56,16 @@ pub struct AssetVersions;
 impl AssetVersions {
     /// Returns the version active at `upgrade`, or `None` before the introduction
     /// fork (Beryl), where the asset precompile is not installed at all.
+    ///
+    /// V1 is active from Beryl; V2 supersedes it from Cobalt.
     pub fn from_base_upgrade(upgrade: BaseUpgrade) -> Option<AssetVersion> {
-        if upgrade >= BaseUpgrade::Beryl { Some(AssetVersion::V1) } else { None }
+        if upgrade >= BaseUpgrade::Cobalt {
+            Some(AssetVersion::V2)
+        } else if upgrade >= BaseUpgrade::Beryl {
+            Some(AssetVersion::V1)
+        } else {
+            None
+        }
     }
 }
 
@@ -66,7 +86,13 @@ mod tests {
     }
 
     #[test]
-    fn resolves_v1_at_cobalt() {
-        assert_eq!(AssetVersions::from_base_upgrade(BaseUpgrade::Cobalt), Some(AssetVersion::V1));
+    fn resolves_v2_at_cobalt() {
+        assert_eq!(AssetVersions::from_base_upgrade(BaseUpgrade::Cobalt), Some(AssetVersion::V2));
+    }
+
+    #[test]
+    fn only_v2_supports_scheduled_multiplier() {
+        assert!(!AssetVersion::V1.supports_scheduled_multiplier());
+        assert!(AssetVersion::V2.supports_scheduled_multiplier());
     }
 }

--- a/crates/common/precompiles/src/common/test_utils.rs
+++ b/crates/common/precompiles/src/common/test_utils.rs
@@ -123,6 +123,10 @@ pub struct InMemoryTokenAccounting {
     pub policy_ids: HashMap<B256, u64>,
     /// Multiplier scaled to WAD (1e18). Asset tokens only.
     pub multiplier: U256,
+    /// Pending scheduled multiplier target (ERC-8056). Asset tokens only.
+    pub pending_multiplier: u128,
+    /// Timestamp at which `pending_multiplier` becomes effective; `0` means none. Asset tokens only.
+    pub pending_effective_at: u64,
     /// Extra-metadata values keyed by raw metadata `key`. Asset tokens only.
     pub extra_metadata: HashMap<String, String>,
     /// Consumed announcement ids keyed by raw announcement id. Asset tokens only.
@@ -153,6 +157,8 @@ impl InMemoryTokenAccounting {
             role_admins: HashMap::new(),
             policy_ids: HashMap::new(),
             multiplier: U256::ZERO,
+            pending_multiplier: 0,
+            pending_effective_at: 0,
             extra_metadata: HashMap::new(),
             announcement_ids_used: HashSet::new(),
             events: Vec::new(),
@@ -431,6 +437,26 @@ impl AssetAccounting for InMemoryTokenAccounting {
 
     fn set_multiplier(&mut self, ratio: U256) -> Result<()> {
         self.multiplier = ratio;
+        Ok(())
+    }
+
+    fn pending_multiplier(&self) -> Result<u128> {
+        Ok(self.pending_multiplier)
+    }
+
+    fn pending_effective_at(&self) -> Result<u64> {
+        Ok(self.pending_effective_at)
+    }
+
+    fn set_pending(&mut self, multiplier: u128, effective_at: u64) -> Result<()> {
+        self.pending_multiplier = multiplier;
+        self.pending_effective_at = effective_at;
+        Ok(())
+    }
+
+    fn clear_pending(&mut self) -> Result<()> {
+        self.pending_multiplier = 0;
+        self.pending_effective_at = 0;
         Ok(())
     }
 

--- a/crates/common/precompiles/src/common/test_utils.rs
+++ b/crates/common/precompiles/src/common/test_utils.rs
@@ -121,6 +121,8 @@ pub struct InMemoryTokenAccounting {
     pub role_admins: HashMap<B256, B256>,
     /// Policy IDs keyed by policy type.
     pub policy_ids: HashMap<B256, u64>,
+    /// Current block timestamp. Asset-token tests set this to exercise versioned lazy reads.
+    pub timestamp: U256,
     /// Multiplier scaled to WAD (1e18). Asset tokens only.
     pub multiplier: U256,
     /// Pending scheduled multiplier target (ERC-8056). Asset tokens only.
@@ -156,6 +158,7 @@ impl InMemoryTokenAccounting {
             role_member_counts: HashMap::new(),
             role_admins: HashMap::new(),
             policy_ids: HashMap::new(),
+            timestamp: U256::ZERO,
             multiplier: U256::ZERO,
             pending_multiplier: 0,
             pending_effective_at: 0,
@@ -431,6 +434,10 @@ impl PolicyAccounting for FakePolicyAccounting {
 }
 
 impl AssetAccounting for InMemoryTokenAccounting {
+    fn timestamp(&self) -> Result<U256> {
+        Ok(self.timestamp)
+    }
+
     fn multiplier(&self) -> Result<U256> {
         Ok(if self.multiplier.is_zero() { B20AssetStorage::WAD } else { self.multiplier })
     }

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -58,8 +58,9 @@ pub use metrics::{
 
 mod b20_asset;
 pub use b20_asset::{
-    Asset, AssetAccounting, AssetV1, AssetVersion, AssetVersions, B20AssetExtensionStorage,
-    B20AssetInit, B20AssetPrecompile, B20AssetStorage, B20AssetToken, IB20Asset,
+    Asset, AssetAccounting, AssetV1, AssetV2, AssetVersion, AssetVersions,
+    B20AssetExtensionStorage, B20AssetInit, B20AssetPrecompile, B20AssetStorage, B20AssetToken,
+    ERC8056_INTERFACE_IDS, IB20Asset,
 };
 
 mod b20_stablecoin;

--- a/crates/common/precompiles/tests/b20_asset_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v1_golden.rs
@@ -245,7 +245,30 @@ fn domain_separator(storage: &mut HashMapStorageProvider) -> B256 {
 fn resolver_maps_forks_to_versions() {
     assert_eq!(AssetVersions::from_base_upgrade(BaseUpgrade::Azul), None);
     assert_eq!(AssetVersions::from_base_upgrade(BaseUpgrade::Beryl), Some(AssetVersion::V1));
-    assert_eq!(AssetVersions::from_base_upgrade(BaseUpgrade::Cobalt), Some(AssetVersion::V1));
+    assert_eq!(AssetVersions::from_base_upgrade(BaseUpgrade::Cobalt), Some(AssetVersion::V2));
+}
+
+#[test]
+fn golden_v2_selectors_unknown_at_v1() {
+    let mut s = fresh();
+    let calls: Vec<Vec<u8>> = vec![
+        IB20Asset::uiMultiplierCall {}.abi_encode(),
+        IB20Asset::newUIMultiplierCall {}.abi_encode(),
+        IB20Asset::effectiveAtCall {}.abi_encode(),
+        IB20Asset::balanceOfUICall { account: ALICE }.abi_encode(),
+        IB20Asset::totalSupplyUICall {}.abi_encode(),
+        IB20Asset::setUIMultiplierCall { newMultiplier: u(2), effectiveAt: u(1) }.abi_encode(),
+        IB20Asset::cancelScheduledMultiplierCall {}.abi_encode(),
+        IB20Asset::supportsInterfaceCall {
+            interfaceId: alloy_primitives::FixedBytes::new([0x01, 0xff, 0xc9, 0xa7]),
+        }
+        .abi_encode(),
+    ];
+    for calldata in calls {
+        let selector: [u8; 4] = calldata[..4].try_into().unwrap();
+        let err = op(&mut s, ALICE, FakePolicyAccounting::new(), calldata).unwrap_err();
+        assert_eq!(err, BasePrecompileError::UnknownFunctionSelector(selector));
+    }
 }
 
 // ============================================================================
@@ -2774,5 +2797,17 @@ fn v1_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Asset::IB20AssetCall
             golden_announce_reverts_internal_call_failed,
             golden_announce_unprivileged_requires_role,
         ]),
+
+        // ERC-8056 scheduled-multiplier surface: introduced at V2 (Cobalt). On the frozen V1
+        // (Beryl) these selectors are version-gated and stay unknown; V2 behavior is cross-
+        // validated by the base-std suite in live-precompile mode.
+        SC::uiMultiplier(_)
+        | SC::newUIMultiplier(_)
+        | SC::effectiveAt(_)
+        | SC::balanceOfUI(_)
+        | SC::totalSupplyUI(_)
+        | SC::setUIMultiplier(_)
+        | SC::cancelScheduledMultiplier(_)
+        | SC::supportsInterface(_) => covered(&[golden_v2_selectors_unknown_at_v1]),
     }
 }

--- a/etc/systems/tests/cobalt_b20_asset_version.rs
+++ b/etc/systems/tests/cobalt_b20_asset_version.rs
@@ -1,0 +1,274 @@
+//! System tests pinning the B-20 asset version to the active Base upgrade.
+//!
+//! The B-20 asset precompile resolves its logic version per call from the block's active upgrade
+//! rather than storing a version per token: at Beryl an asset routes to `AssetV1`, and at Cobalt
+//! the same surface routes to `AssetV2`, which adds the ERC-8056 scheduled-multiplier methods
+//! (`uiMultiplier`, `newUIMultiplier`, `effectiveAt`, `balanceOfUI`, `totalSupplyUI`,
+//! `setUIMultiplier`, `cancelScheduledMultiplier`, `supportsInterface`).
+//!
+//! These tests activate the Cobalt upgrade end-to-end over Base node RPC and assert:
+//!   * before Cobalt (Beryl): the asset behaves as `AssetV1` and every ERC-8056 selector reverts as
+//!     an unknown selector, and
+//!   * at Cobalt: the asset behaves as `AssetV2`, advertising the ERC-8056 interface IDs and
+//!     executing the new scheduled-multiplier functionality.
+
+mod common;
+
+use alloy_primitives::{Address, B256, FixedBytes, U256, keccak256};
+use alloy_provider::RootProvider;
+use alloy_signer_local::PrivateKeySigner;
+use alloy_sol_types::{SolCall, SolValue};
+use base_common_network::Base;
+use base_common_precompiles::{ActivationFeature, B20Variant, ERC8056_INTERFACE_IDS, IB20, IB20Asset};
+use base_system_tests::{
+    ANVIL_ACCOUNT_5, B20PrecompileClient, SystemTestStack, SystemTestStackBuilder,
+};
+use eyre::{Result, WrapErr};
+
+/// Block at which Cobalt activates for the Cobalt system stack. Chosen after Beryl (block 3) so the
+/// pre-Cobalt window still exercises `AssetV1` during warm-up.
+const BASE_COBALT_ACTIVATION_BLOCK: u64 = 5;
+/// Initial supply minted to the token admin on creation.
+const INITIAL_SUPPLY: u64 = 1_000_000_000;
+/// One WAD (`1e18`), the fixed-point precision for the asset multiplier.
+const WAD: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
+/// Two WAD (`2e18`), the target of the scheduled multiplier update.
+const DOUBLE_WAD: U256 = U256::from_limbs([2_000_000_000_000_000_000, 0, 0, 0]);
+/// A deterministic far-future `effectiveAt` (2100-01-01T00:00:00Z). Comfortably in the future for a
+/// freshly started devnet yet well within the `u64` field size, so the schedule stays pending for
+/// the duration of the test and never matures into the active multiplier.
+const SCHEDULED_EFFECTIVE_AT: u64 = 4_102_444_800;
+
+/// Boots a system stack with Cobalt active at [`BASE_COBALT_ACTIVATION_BLOCK`] and waits until the
+/// chain has advanced past it, so all subsequent calls resolve against the Cobalt upgrade.
+async fn start_cobalt_system() -> Result<(SystemTestStack, RootProvider<Base>)> {
+    let system = SystemTestStackBuilder::new()
+        .with_l1_chain_id(common::L1_CHAIN_ID)
+        .with_l2_chain_id(common::L2_CHAIN_ID)
+        .with_base_azul_activation_block(common::BASE_AZUL_ACTIVATION_BLOCK)
+        .with_base_beryl_activation_block(common::BASE_BERYL_ACTIVATION_BLOCK)
+        .with_base_cobalt_activation_block(BASE_COBALT_ACTIVATION_BLOCK)
+        .build()
+        .await?;
+    let provider = system.l2_builder_provider()?;
+    common::wait_for_block(&provider, BASE_COBALT_ACTIVATION_BLOCK + 1).await?;
+    Ok((system, provider))
+}
+
+/// Activates the B-20 asset feature and deploys a fresh asset token whose admin holds
+/// [`INITIAL_SUPPLY`], returning the RPC client bound to `provider`/`admin` alongside the token
+/// address.
+async fn create_asset_token<'a>(
+    provider: &'a RootProvider<Base>,
+    admin: &'a PrivateKeySigner,
+    salt: B256,
+    name: &str,
+    symbol: &str,
+) -> Result<(B20PrecompileClient<'a>, Address)> {
+    let b20 = B20PrecompileClient::new(provider, admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+    b20.activate_feature(ActivationFeature::B20Asset.id()).await?;
+    let params = B20PrecompileClient::token_params(
+        name,
+        symbol,
+        admin.address(),
+        U256::from(INITIAL_SUPPLY),
+        admin.address(),
+    );
+    let token = b20.create_token(B20Variant::Asset, params, salt).await?;
+    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
+    Ok((b20, token))
+}
+
+#[tokio::test]
+async fn test_b20_asset_is_v1_before_cobalt() -> Result<()> {
+    let (_system, provider) = common::start_beryl_system().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse admin key")?;
+    common::wait_for_balance(&provider, admin.address()).await?;
+
+    let (b20, token) =
+        create_asset_token(&provider, &admin, B256::repeat_byte(0x51), "Beryl Asset", "BASST")
+            .await?;
+
+    assert_eq!(asset_word(&b20, token, IB20Asset::multiplierCall {}).await?, WAD);
+
+    // The ERC-8056 read selectors do not exist on AssetV1 and must revert as unknown selectors.
+    assert!(
+        b20.call(token, IB20Asset::uiMultiplierCall {}).await.is_err(),
+        "uiMultiplier must revert before Cobalt",
+    );
+    assert!(
+        b20.call(token, IB20Asset::newUIMultiplierCall {}).await.is_err(),
+        "newUIMultiplier must revert before Cobalt",
+    );
+    assert!(
+        b20.call(token, IB20Asset::effectiveAtCall {}).await.is_err(),
+        "effectiveAt must revert before Cobalt",
+    );
+    assert!(
+        b20.call(token, IB20Asset::balanceOfUICall { account: admin.address() }).await.is_err(),
+        "balanceOfUI must revert before Cobalt",
+    );
+    assert!(
+        b20.call(token, IB20Asset::totalSupplyUICall {}).await.is_err(),
+        "totalSupplyUI must revert before Cobalt",
+    );
+    assert!(
+        b20.call(token, IB20Asset::supportsInterfaceCall { interfaceId: ERC8056_INTERFACE_IDS[0] })
+            .await
+            .is_err(),
+        "supportsInterface must revert before Cobalt",
+    );
+
+    // The ERC-8056 write selectors likewise do not exist on AssetV1 and must revert on-chain.
+    assert!(
+        !b20.try_send_call(
+            token,
+            IB20Asset::setUIMultiplierCall {
+                newMultiplier: DOUBLE_WAD,
+                effectiveAt: U256::from(SCHEDULED_EFFECTIVE_AT),
+            },
+            "setUIMultiplier before Cobalt",
+        )
+        .await?,
+        "setUIMultiplier must revert before Cobalt",
+    );
+    assert!(
+        !b20.try_send_call(
+            token,
+            IB20Asset::cancelScheduledMultiplierCall {},
+            "cancelScheduledMultiplier before Cobalt",
+        )
+        .await?,
+        "cancelScheduledMultiplier must revert before Cobalt",
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_b20_asset_is_v2_at_cobalt() -> Result<()> {
+    let (_system, provider) = start_cobalt_system().await?;
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse admin key")?;
+    common::wait_for_balance(&provider, admin.address()).await?;
+
+    let (b20, token) =
+        create_asset_token(&provider, &admin, B256::repeat_byte(0x52), "Cobalt Asset", "CASST")
+            .await?;
+
+    // AssetV2 advertises the ERC-165 + ERC-8056 interface IDs.
+    for interface_id in ERC8056_INTERFACE_IDS {
+        assert!(
+            asset_bool(&b20, token, IB20Asset::supportsInterfaceCall { interfaceId: interface_id })
+                .await?,
+            "supportsInterface must be true for advertised id {interface_id}",
+        );
+    }
+    // The ERC-8056 Conversion extension is deliberately not advertised, and neither is a random id.
+    assert!(
+        !asset_bool(
+            &b20,
+            token,
+            IB20Asset::supportsInterfaceCall { interfaceId: FixedBytes::new([0x57, 0x85, 0x4f, 0xc3]) },
+        )
+        .await?,
+        "conversion-extension interface id must not be advertised",
+    );
+    assert!(
+        !asset_bool(
+            &b20,
+            token,
+            IB20Asset::supportsInterfaceCall { interfaceId: FixedBytes::new([0xde, 0xad, 0xbe, 0xef]) },
+        )
+        .await?,
+        "an unrelated interface id must not be advertised",
+    );
+
+    assert_eq!(asset_word(&b20, token, IB20Asset::uiMultiplierCall {}).await?, WAD);
+    assert_eq!(asset_word(&b20, token, IB20Asset::multiplierCall {}).await?, WAD);
+    assert_eq!(asset_word(&b20, token, IB20Asset::newUIMultiplierCall {}).await?, WAD);
+    assert_eq!(asset_word(&b20, token, IB20Asset::effectiveAtCall {}).await?, U256::ZERO);
+    // The ERC-8056 balance views mirror the raw balances while the multiplier is WAD.
+    assert_eq!(
+        asset_word(&b20, token, IB20Asset::balanceOfUICall { account: admin.address() }).await?,
+        U256::from(INITIAL_SUPPLY),
+    );
+    assert_eq!(
+        asset_word(&b20, token, IB20Asset::totalSupplyUICall {}).await?,
+        U256::from(INITIAL_SUPPLY),
+    );
+
+    // Grant the operator role so the admin may schedule multiplier updates.
+    b20.send_call(
+        token,
+        IB20::grantRoleCall { role: operator_role(), account: admin.address() },
+        "grant B-20 operator role",
+    )
+    .await?;
+
+    // Schedule a far-future multiplier update: the pending target is observable via newUIMultiplier
+    // and effectiveAt, while the effective uiMultiplier stays at WAD until the timestamp is reached.
+    let effective_at = U256::from(SCHEDULED_EFFECTIVE_AT);
+    b20.send_call(
+        token,
+        IB20Asset::setUIMultiplierCall { newMultiplier: DOUBLE_WAD, effectiveAt: effective_at },
+        "schedule B-20 UI multiplier",
+    )
+    .await?;
+    assert_eq!(asset_word(&b20, token, IB20Asset::newUIMultiplierCall {}).await?, DOUBLE_WAD);
+    assert_eq!(asset_word(&b20, token, IB20Asset::effectiveAtCall {}).await?, effective_at);
+    assert_eq!(
+        asset_word(&b20, token, IB20Asset::uiMultiplierCall {}).await?,
+        WAD,
+        "a pending update must not take effect before its timestamp",
+    );
+
+    // A second overlapping schedule must revert while the first is still live.
+    assert!(
+        !b20.try_send_call(
+            token,
+            IB20Asset::setUIMultiplierCall { newMultiplier: DOUBLE_WAD, effectiveAt: effective_at },
+            "overlapping B-20 UI multiplier schedule",
+        )
+        .await?,
+        "an overlapping schedule must revert while a pending update is live",
+    );
+
+    // Cancelling the live pending update restores the no-pending state.
+    b20.send_call(
+        token,
+        IB20Asset::cancelScheduledMultiplierCall {},
+        "cancel scheduled B-20 UI multiplier",
+    )
+    .await?;
+    assert_eq!(asset_word(&b20, token, IB20Asset::effectiveAtCall {}).await?, U256::ZERO);
+    assert_eq!(
+        asset_word(&b20, token, IB20Asset::newUIMultiplierCall {}).await?,
+        WAD,
+        "cancelling must clear the pending target",
+    );
+
+    Ok(())
+}
+
+async fn asset_word<C>(client: &B20PrecompileClient<'_>, token: Address, call: C) -> Result<U256>
+where
+    C: SolCall,
+{
+    let output = client.call(token, call).await?;
+    U256::abi_decode(output.as_ref()).wrap_err("Failed to decode asset word")
+}
+
+async fn asset_bool<C>(client: &B20PrecompileClient<'_>, token: Address, call: C) -> Result<bool>
+where
+    C: SolCall,
+{
+    let output = client.call(token, call).await?;
+    bool::abi_decode(output.as_ref()).wrap_err("Failed to decode asset bool")
+}
+
+fn operator_role() -> B256 {
+    keccak256("OPERATOR_ROLE")
+}

--- a/etc/systems/tests/cobalt_b20_asset_version.rs
+++ b/etc/systems/tests/cobalt_b20_asset_version.rs
@@ -19,7 +19,9 @@ use alloy_provider::RootProvider;
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::{SolCall, SolValue};
 use base_common_network::Base;
-use base_common_precompiles::{ActivationFeature, B20Variant, ERC8056_INTERFACE_IDS, IB20, IB20Asset};
+use base_common_precompiles::{
+    ActivationFeature, B20Variant, ERC8056_INTERFACE_IDS, IB20, IB20Asset,
+};
 use base_system_tests::{
     ANVIL_ACCOUNT_5, B20PrecompileClient, SystemTestStack, SystemTestStackBuilder,
 };
@@ -171,7 +173,9 @@ async fn test_b20_asset_is_v2_at_cobalt() -> Result<()> {
         !asset_bool(
             &b20,
             token,
-            IB20Asset::supportsInterfaceCall { interfaceId: FixedBytes::new([0x57, 0x85, 0x4f, 0xc3]) },
+            IB20Asset::supportsInterfaceCall {
+                interfaceId: FixedBytes::new([0x57, 0x85, 0x4f, 0xc3])
+            },
         )
         .await?,
         "conversion-extension interface id must not be advertised",
@@ -180,7 +184,9 @@ async fn test_b20_asset_is_v2_at_cobalt() -> Result<()> {
         !asset_bool(
             &b20,
             token,
-            IB20Asset::supportsInterfaceCall { interfaceId: FixedBytes::new([0xde, 0xad, 0xbe, 0xef]) },
+            IB20Asset::supportsInterfaceCall {
+                interfaceId: FixedBytes::new([0xde, 0xad, 0xbe, 0xef])
+            },
         )
         .await?,
         "an unrelated interface id must not be advertised",


### PR DESCRIPTION
### What changed? Why?

Adds an end-to-end system test (`etc/systems/tests/cobalt_b20_asset_version.rs`) that activates the Cobalt upgrade over Base node RPC and pins the B-20 asset precompile's logic version to the block's active upgrade. The precompile resolves its version per call from the active upgrade rather than storing a version per token, so a single asset must behave as `AssetV1` at Beryl and as `AssetV2` at Cobalt. This test guards that boundary and the new ERC-8056 scheduled-multiplier surface introduced by AssetV2.

`test_b20_asset_is_v1_before_cobalt` boots a Beryl stack (Cobalt never activated), creates an asset token, and asserts the V1 surface works (`multiplier() == WAD`) while every ERC-8056 selector reverts as unknown: the six reads (`uiMultiplier`, `newUIMultiplier`, `effectiveAt`, `balanceOfUI`, `totalSupplyUI`, `supportsInterface`) revert on `eth_call`, and the two writes (`setUIMultiplier`, `cancelScheduledMultiplier`) revert on-chain.

`test_b20_asset_is_v2_at_cobalt` boots a stack with Cobalt active, creates an asset token, and asserts the same asset now routes to `AssetV2`: `supportsInterface` is true for all four `ERC8056_INTERFACE_IDS` and false for the deliberately-unadvertised conversion-extension id and an unrelated id; the initial multiplier views read `WAD`/`0`; and after granting `OPERATOR_ROLE` the scheduled-multiplier flow works end to end — scheduling a far-future update exposes it via `newUIMultiplier`/`effectiveAt` while `uiMultiplier` stays at `WAD`, an overlapping schedule reverts (`ScheduleOverlap`), and cancellation restores the no-pending state.

### Notes to reviewers

The test lives alongside the existing B-20 system tests and reuses the shared `common` harness (`start_beryl_system`, `wait_for_block`, `wait_for_balance`) plus `B20PrecompileClient`, mirroring `tests/b20_precompile.rs` and `tests/activation_registry.rs`. A local `start_cobalt_system()` helper activates Cobalt at block 5 (after Beryl at block 3) and waits past it.

The scheduled `effectiveAt` is pinned to a deterministic far-future timestamp (2100-01-01) so the pending update never matures mid-test; the flip-at-boundary behavior is already covered by AssetV2 unit tests, so this test focuses on version gating and the new-method surface rather than wall-clock maturation.

### How has it been tested?

- `cargo test -p base-system-tests --test cobalt_b20_asset_version` — both tests pass (in-process node + testcontainers).
- `cargo check -p base-system-tests --test cobalt_b20_asset_version` — clean.