### PR TITLE
test(system): fuzz the batch-encode/derive span-batch round-trip

### DIFF
--- a/etc/systems/tests/fuzz_build_validate.rs
+++ b/etc/systems/tests/fuzz_build_validate.rs
@@ -13,6 +13,12 @@
 //! implementation invariants (gas within limit), and a second test asserts
 //! determinism: the same seed builds byte-identical blocks twice.
 //!
+//! Alongside build-vs-validate, `fuzz_derive_roundtrip` covers the other chain-
+//! halting agreement boundary: batch-encode vs. derive. It runs fuzzed
+//! transactions through Base's own span-batch codec (encode as the batcher does,
+//! read back as the derivation pipeline does) and requires the reconstructed
+//! blocks to match byte-for-byte.
+//!
 //! Runs fully in-process (no devnet, no Docker), forces exactly the generated
 //! transactions into each block (`no_tx_pool`), and uses a fixed per-block
 //! timestamp, so a run is deterministic and a failing seed replays exactly.
@@ -36,6 +42,7 @@ use base_common_consensus::{Call, Eip8130Constants, Eip8130Signed, TxEip8130};
 use base_common_rpc_types::BaseTransactionRequest;
 use base_execution_chainspec::BaseChainSpec;
 use base_node_runner::test_utils::{L1_BLOCK_INFO_DEPOSIT_TX, TestHarness};
+use base_protocol::{RawSpanBatch, SingleBatch, SpanBatch};
 use base_test_utils::{AccessListContract, Account, DEVNET_CHAIN_ID, build_test_genesis_cobalt};
 use eyre::{Result, eyre};
 use rand::{Rng, SeedableRng, rngs::StdRng};
@@ -68,6 +75,18 @@ const TX_GAS_LIMIT_8130: u64 = 500_000;
 /// A far-future expiry (well past any block timestamp here) used to fuzz the
 /// `expiry` field without ever letting a transaction lapse and get dropped.
 const FAR_FUTURE_EXPIRY: u64 = 4_000_000_000;
+
+/// Blocks per fuzzed span batch in the derive round-trip.
+const DERIVE_BLOCKS: usize = 8;
+/// User transactions per block in the derive round-trip.
+const DERIVE_TXS_PER_BLOCK: usize = 6;
+/// L2 block time used to encode/derive the span batch (must match on both sides).
+const DERIVE_BLOCK_TIME: u64 = 2;
+/// Genesis timestamp the span batch's relative timestamps are computed against.
+const DERIVE_GENESIS_TS: u64 = 0;
+/// A single fixed L1 origin (epoch) for the whole span, so the derived epoch
+/// numbers reconstruct deterministically from the origin bits.
+const DERIVE_EPOCH: u64 = 1;
 
 #[tokio::test]
 async fn fuzz_build_validate() -> Result<()> {
@@ -586,4 +605,121 @@ fn sign_8130(shape: &Eip8130Shape, sequence: u64) -> Result<Bytes> {
     };
 
     Ok(Eip8130Signed::new(tx, sender_auth, payer_auth).encoded_2718().into())
+}
+
+/// Batch-encode ↔ derive round-trip over Base's own span-batch codec
+/// (`base_protocol`), the other chain-halting agreement boundary: the batcher
+/// encodes L2 blocks into a span batch and the derivation pipeline must
+/// reconstruct exactly those blocks. A mismatch splits the chain.
+///
+/// This drives the real codec end to end, in-process (no L1, no devnet): fuzzed
+/// user transactions (a mix of 1559/2930 and Base's EIP-8130) are grouped into
+/// blocks, appended into a [`SpanBatch`] the way the batcher does
+/// (`append_singular_batch`), serialized (`to_raw_span_batch` → `encode`), then
+/// read back the way derivation does (`RawSpanBatch::decode` → `derive`), and
+/// the reconstructed blocks must match the originals — transactions byte-for-
+/// byte, plus epoch and timestamp. Deposits are excluded, as they are never
+/// carried in span batches. Deterministic per seed; override with `FUZZ_SEED`.
+#[test]
+fn fuzz_derive_roundtrip() -> Result<()> {
+    let seed = seed_from_env();
+    let mut mix = StdRng::seed_from_u64(seed);
+    let mut tx_gen = FuzzTxGenerator::new(seed);
+    let mut tx8130_gen = Eip8130Generator::new(seed ^ 0x8130);
+    let mut nonces = [0u64; SENDERS.len()];
+    let mut sequences = [0u64; SENDERS.len()];
+    // Calls target a funded EOA; the codec round-trip is independent of state, so
+    // no contract needs to be deployed here.
+    let recipient = SENDERS[0].address();
+
+    // The per-block user transaction sets (no deposits — those are never span-batched).
+    let mut block_txs: Vec<Vec<Bytes>> = Vec::with_capacity(DERIVE_BLOCKS);
+    for _ in 0..DERIVE_BLOCKS {
+        let mut txs = Vec::with_capacity(DERIVE_TXS_PER_BLOCK);
+        for _ in 0..DERIVE_TXS_PER_BLOCK {
+            // ~1/3 EIP-8130 (Base-specific span-batch tx data), the rest 1559/2930.
+            let raw = if mix.random_range(0..3) == 0 {
+                let shape = tx8130_gen.next_shape();
+                let raw = sign_8130(&shape, sequences[shape.sender])?;
+                sequences[shape.sender] += 1;
+                raw
+            } else {
+                let shape = tx_gen.next_shape(recipient);
+                let raw = sign_tx(&SENDERS[shape.sender], &shape, nonces[shape.sender])?;
+                nonces[shape.sender] += 1;
+                raw
+            };
+            txs.push(raw);
+        }
+        block_txs.push(txs);
+    }
+
+    // Encode side (batcher): append each block as a singular batch on a single
+    // fixed L1 origin, with timestamps on the block-time grid so derive reproduces
+    // them exactly.
+    let parent_hash = B256::repeat_byte(0x11);
+    let epoch_hash = B256::repeat_byte(0x22);
+    let mut span = SpanBatch {
+        chain_id: DEVNET_CHAIN_ID,
+        genesis_timestamp: DERIVE_GENESIS_TS,
+        ..Default::default()
+    };
+    for (i, txs) in block_txs.iter().enumerate() {
+        let single = SingleBatch {
+            parent_hash,
+            epoch_num: DERIVE_EPOCH,
+            epoch_hash,
+            timestamp: DERIVE_GENESIS_TS + DERIVE_BLOCK_TIME * (i as u64 + 1),
+            transactions: txs.clone(),
+        };
+        span.append_singular_batch(single, i as u64)
+            .map_err(|e| eyre!("span batch append failed at block {i} (seed={seed:#x}): {e:?}"))?;
+    }
+
+    // Serialize, then read back exactly as the derivation pipeline does.
+    let raw = span
+        .to_raw_span_batch()
+        .map_err(|e| eyre!("to_raw_span_batch failed (seed={seed:#x}): {e:?}"))?;
+    let mut buf = Vec::new();
+    raw.encode(&mut buf).map_err(|e| eyre!("span batch encode failed (seed={seed:#x}): {e:?}"))?;
+    let mut decoded = RawSpanBatch::decode(&mut buf.as_slice())
+        .map_err(|e| eyre!("span batch decode failed (seed={seed:#x}): {e:?}"))?;
+    let derived = decoded
+        .derive(DERIVE_BLOCK_TIME, DERIVE_GENESIS_TS, DEVNET_CHAIN_ID)
+        .map_err(|e| eyre!("span batch derive failed (seed={seed:#x}): {e:?}"))?;
+
+    // Derivation must reconstruct exactly what the batcher encoded.
+    if derived.batches.len() != block_txs.len() {
+        return Err(eyre!(
+            "derive round-trip block count mismatch (seed={seed:#x}): {} != {}",
+            derived.batches.len(),
+            block_txs.len()
+        ));
+    }
+    for (i, (element, original)) in derived.batches.iter().zip(block_txs.iter()).enumerate() {
+        if element.transactions != *original {
+            return Err(eyre!(
+                "batch-encode/derive divergence at block {i} (seed={seed:#x}): \
+                 encoded {} transactions, derived {} that do not match byte-for-byte",
+                original.len(),
+                element.transactions.len()
+            ));
+        }
+        let expected_ts = DERIVE_GENESIS_TS + DERIVE_BLOCK_TIME * (i as u64 + 1);
+        if element.timestamp != expected_ts {
+            return Err(eyre!(
+                "derive round-trip timestamp mismatch at block {i} (seed={seed:#x}): \
+                 {} != {expected_ts}",
+                element.timestamp
+            ));
+        }
+        if element.epoch_num != DERIVE_EPOCH {
+            return Err(eyre!(
+                "derive round-trip epoch mismatch at block {i} (seed={seed:#x}): {} != {DERIVE_EPOCH}",
+                element.epoch_num
+            ));
+        }
+    }
+
+    Ok(())
 }

--- a/etc/systems/tests/fuzz_build_validate.rs
+++ b/etc/systems/tests/fuzz_build_validate.rs
@@ -654,39 +654,11 @@ fn fuzz_derive_roundtrip() -> Result<()> {
         block_txs.push(txs);
     }
 
-    // Encode side (batcher): append each block as a singular batch on a single
-    // fixed L1 origin, with timestamps on the block-time grid so derive reproduces
-    // them exactly.
-    let parent_hash = B256::repeat_byte(0x11);
-    let epoch_hash = B256::repeat_byte(0x22);
-    let mut span = SpanBatch {
-        chain_id: DEVNET_CHAIN_ID,
-        genesis_timestamp: DERIVE_GENESIS_TS,
-        ..Default::default()
-    };
-    for (i, txs) in block_txs.iter().enumerate() {
-        let single = SingleBatch {
-            parent_hash,
-            epoch_num: DERIVE_EPOCH,
-            epoch_hash,
-            timestamp: DERIVE_GENESIS_TS + DERIVE_BLOCK_TIME * (i as u64 + 1),
-            transactions: txs.clone(),
-        };
-        span.append_singular_batch(single, i as u64)
-            .map_err(|e| eyre!("span batch append failed at block {i} (seed={seed:#x}): {e:?}"))?;
-    }
-
-    // Serialize, then read back exactly as the derivation pipeline does.
-    let raw = span
-        .to_raw_span_batch()
-        .map_err(|e| eyre!("to_raw_span_batch failed (seed={seed:#x}): {e:?}"))?;
-    let mut buf = Vec::new();
-    raw.encode(&mut buf).map_err(|e| eyre!("span batch encode failed (seed={seed:#x}): {e:?}"))?;
-    let mut decoded = RawSpanBatch::decode(&mut buf.as_slice())
-        .map_err(|e| eyre!("span batch decode failed (seed={seed:#x}): {e:?}"))?;
-    let derived = decoded
-        .derive(DERIVE_BLOCK_TIME, DERIVE_GENESIS_TS, DEVNET_CHAIN_ID)
-        .map_err(|e| eyre!("span batch derive failed (seed={seed:#x}): {e:?}"))?;
+    // Encode as the batcher does, then read back exactly as the derivation
+    // pipeline does.
+    let span = assemble_span(&block_txs).map_err(|e| eyre!("{e} (seed={seed:#x})"))?;
+    let bytes = encode_span(&span).map_err(|e| eyre!("{e} (seed={seed:#x})"))?;
+    let derived = derive_encoded(&bytes).map_err(|e| eyre!("{e} (seed={seed:#x})"))?;
 
     // Derivation must reconstruct exactly what the batcher encoded.
     if derived.batches.len() != block_txs.len() {
@@ -722,4 +694,162 @@ fn fuzz_derive_roundtrip() -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Assemble a [`SpanBatch`] from per-block transaction sets the way the batcher
+/// does: one singular batch per block on a single fixed L1 origin, with
+/// timestamps on the block-time grid so `derive` reconstructs them exactly.
+fn assemble_span(block_txs: &[Vec<Bytes>]) -> Result<SpanBatch> {
+    let parent_hash = B256::repeat_byte(0x11);
+    let epoch_hash = B256::repeat_byte(0x22);
+    let mut span = SpanBatch {
+        chain_id: DEVNET_CHAIN_ID,
+        genesis_timestamp: DERIVE_GENESIS_TS,
+        ..Default::default()
+    };
+    for (i, txs) in block_txs.iter().enumerate() {
+        let single = SingleBatch {
+            parent_hash,
+            epoch_num: DERIVE_EPOCH,
+            epoch_hash,
+            timestamp: DERIVE_GENESIS_TS + DERIVE_BLOCK_TIME * (i as u64 + 1),
+            transactions: txs.clone(),
+        };
+        span.append_singular_batch(single, i as u64)
+            .map_err(|e| eyre!("span batch append failed at block {i}: {e:?}"))?;
+    }
+    Ok(span)
+}
+
+/// Serialize a span batch the way the batcher posts it (`to_raw_span_batch` -> `encode`).
+fn encode_span(span: &SpanBatch) -> Result<Vec<u8>> {
+    let raw = span.to_raw_span_batch().map_err(|e| eyre!("to_raw_span_batch failed: {e:?}"))?;
+    let mut buf = Vec::new();
+    raw.encode(&mut buf).map_err(|e| eyre!("span batch encode failed: {e:?}"))?;
+    Ok(buf)
+}
+
+/// Read a span batch back the way the derivation pipeline does
+/// (`RawSpanBatch::decode` -> `derive`).
+fn derive_encoded(bytes: &[u8]) -> Result<SpanBatch> {
+    let mut decoded = RawSpanBatch::decode(&mut &bytes[..])
+        .map_err(|e| eyre!("span batch decode failed: {e:?}"))?;
+    decoded
+        .derive(DERIVE_BLOCK_TIME, DERIVE_GENESIS_TS, DEVNET_CHAIN_ID)
+        .map_err(|e| eyre!("span batch derive failed: {e:?}"))
+}
+
+/// Build a signed, EIP-2718 encoded transaction of an explicit type (`0` legacy,
+/// `1` EIP-2930, `2` EIP-1559), with fixed fields, for the derive round-trip
+/// regression vectors.
+fn fixed_typed_tx(
+    account: &Account,
+    nonce: u64,
+    tx_type: u8,
+    access_list: AccessList,
+) -> Result<Bytes> {
+    let signer = account.signer();
+    let mut request = BaseTransactionRequest::default()
+        .from(signer.address())
+        .to(SENDERS[1].address())
+        .value(U256::from(nonce + 1))
+        .transaction_type(tx_type)
+        .with_gas_limit(50_000)
+        .with_chain_id(DEVNET_CHAIN_ID)
+        .with_nonce(nonce);
+    request = if tx_type == 2 {
+        request.with_max_fee_per_gas(1_000_000_000).with_max_priority_fee_per_gas(0)
+    } else {
+        request.with_gas_price(1_000_000_000)
+    };
+    if !access_list.0.is_empty() {
+        request = request.with_access_list(access_list);
+    }
+    finish(&signer, request)
+}
+
+/// A fixed EIP-8130 shape (one value-less call phase) for the regression vectors.
+fn fixed_8130_shape(sender: usize, payer: Option<usize>) -> Eip8130Shape {
+    Eip8130Shape {
+        sender,
+        payer,
+        phases: vec![vec![SENDERS[(sender + 1) % SENDERS.len()].address()]],
+        expiry: 0,
+        metadata: Bytes::from_static(&[0xaa, 0xbb]),
+    }
+}
+
+/// Regression: one transaction of every span-batchable type round-trips through
+/// Base's span-batch codec byte-for-byte. The fuzzer only emits 1559 and 8130, so
+/// this pins the legacy and EIP-2930 codec paths too; a regression that corrupts
+/// any single type's encode/decode turns this red immediately.
+#[test]
+fn derive_roundtrip_all_tx_types() -> Result<()> {
+    let alice = Account::Alice;
+    let access = AccessList(vec![AccessListItem {
+        address: SENDERS[0].address(),
+        storage_keys: vec![B256::from(U256::from(1u64)), B256::from(U256::from(2u64))],
+    }]);
+    let block_txs = vec![vec![
+        fixed_typed_tx(&alice, 0, 0, AccessList::default())?, // legacy
+        fixed_typed_tx(&alice, 1, 1, access.clone())?,        // EIP-2930
+        fixed_typed_tx(&alice, 2, 2, access)?,                // EIP-1559
+        sign_8130(&fixed_8130_shape(0, None), 0)?,            // EIP-8130 self-pay
+        sign_8130(&fixed_8130_shape(1, Some(2)), 0)?,         // EIP-8130 sponsored
+    ]];
+
+    // Guard that the vector really covers distinct types (a legacy tx has no type
+    // byte and starts with an RLP list header >= 0xc0; typed txs lead with their
+    // type byte), so "all tx types" can't silently degrade to all-1559.
+    let leads = &block_txs[0];
+    assert!(leads[0][0] >= 0xc0, "tx 0 must be legacy (RLP list), got {:#x}", leads[0][0]);
+    assert_eq!(leads[1][0], 0x01, "tx 1 must be EIP-2930");
+    assert_eq!(leads[2][0], 0x02, "tx 2 must be EIP-1559");
+    assert_eq!(leads[3][0], 0x79, "tx 3 must be EIP-8130");
+    assert_eq!(leads[4][0], 0x79, "tx 4 must be EIP-8130");
+
+    let derived = derive_encoded(&encode_span(&assemble_span(&block_txs)?)?)?;
+    let original = &block_txs[0];
+    let got = derived.batches.first().map(|b| &b.transactions);
+    if got != Some(original) {
+        return Err(eyre!(
+            "per-type span-batch round-trip changed the transactions: {} encoded, {:?} derived",
+            original.len(),
+            got.map(Vec::len)
+        ));
+    }
+    Ok(())
+}
+
+/// Regression / prove-red for the codec oracle: a corrupted span-batch encoding
+/// must be caught, so the byte-for-byte equality check above is meaningful rather
+/// than vacuous. Flipping a single byte of the encoding must make the round-trip
+/// either error or reconstruct different transactions.
+#[test]
+fn derive_roundtrip_detects_corruption() -> Result<()> {
+    let alice = Account::Alice;
+    let block_txs = vec![vec![
+        fixed_typed_tx(&alice, 0, 2, AccessList::default())?,
+        sign_8130(&fixed_8130_shape(0, None), 0)?,
+    ]];
+    let mut bytes = encode_span(&assemble_span(&block_txs)?)?;
+
+    // Flip the last byte (tail of the transaction data).
+    let last = bytes.len() - 1;
+    bytes[last] ^= 0xff;
+
+    match derive_encoded(&bytes) {
+        // Decode/derive rejected the corruption outright.
+        Err(_) => Ok(()),
+        // Or it decoded to something, which must differ from the original.
+        Ok(derived) => {
+            if derived.batches.first().map(|b| &b.transactions) == Some(&block_txs[0]) {
+                Err(eyre!(
+                    "corrupted span batch round-tripped unchanged; the equality check is not meaningful"
+                ))
+            } else {
+                Ok(())
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Description

Covers the second chain-halting **agreement boundary** in-process: **batch-encode vs. derive**. The batcher encodes L2 blocks into a span batch; the derivation pipeline must reconstruct exactly those blocks. A mismatch splits the chain.

`fuzz_derive_roundtrip` drives Base's own span-batch codec (`base_protocol`) end to end, fully in-process (no L1, no devnet):

1. fuzzed user transactions — a mix of 1559/2930 and **EIP-8130** — are grouped into blocks;
2. appended into a `SpanBatch` the way the batcher does (`append_singular_batch`);
3. serialized (`to_raw_span_batch` → `encode`);
4. read back the way derivation does (`RawSpanBatch::decode` → `derive`).

The reconstructed blocks must match the originals: **transactions byte-for-byte**, plus epoch and timestamp. Deposits are excluded, as they are never carried in span batches.

## Notes

- This exercises the real reconstruction logic — span-batch transaction decomposition and the `full_txs` rebuild, including Base's EIP-8130 transaction data — not a trivial encode/decode inverse.
- Pure codec, ~0.07s, so it adds no meaningful cost to the per-PR gate (which already targets `binary(fuzz_build_validate)`).
- Reuses the suite's existing transaction generators and signing helpers.

Stacked on the EIP-8130 PR; base will retarget as the stack merges down to `main`.