### PR TITLE
feat(builder): Add LocalInstance Extension Seams

### DIFF
--- a/crates/builder/core/Cargo.toml
+++ b/crates/builder/core/Cargo.toml
@@ -136,12 +136,12 @@ dirs-next.workspace = true
 secp256k1.workspace = true
 serde_with.workspace = true
 parking_lot.workspace = true
-derive_more.workspace = true
 tar = { workspace = true, optional = true }
 ctor = { workspace = true, optional = true }
 hyper = { workspace = true, optional = true }
 rlimit = { workspace = true, optional = true }
 nanoid = { workspace = true, optional = true }
+derive_more = { workspace = true, features = ["debug"] }
 serde = { workspace = true, features = ["std"] }
 hyper-util = { workspace = true, optional = true }
 thiserror = { workspace = true, features = ["std"] }

--- a/crates/builder/core/src/test_utils/instance.rs
+++ b/crates/builder/core/src/test_utils/instance.rs
@@ -124,22 +124,13 @@ where
 ///     .build()
 ///     .await?;
 /// ```
+#[derive(derive_more::Debug)]
 pub struct LocalInstanceBuilder<S = DefaultCandidateSource> {
     builder_config: BuilderConfig,
     node_config: NodeConfig<BaseChainSpec>,
     candidate_source: S,
+    #[debug("{}", extensions.len())]
     extensions: Vec<Box<dyn BaseNodeExtension>>,
-}
-
-impl<S: core::fmt::Debug> core::fmt::Debug for LocalInstanceBuilder<S> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("LocalInstanceBuilder")
-            .field("builder_config", &self.builder_config)
-            .field("node_config", &self.node_config)
-            .field("candidate_source", &self.candidate_source)
-            .field("extensions", &self.extensions.len())
-            .finish_non_exhaustive()
-    }
 }
 
 impl LocalInstanceBuilder {

--- a/crates/builder/core/src/test_utils/instance.rs
+++ b/crates/builder/core/src/test_utils/instance.rs
@@ -74,7 +74,7 @@ pub struct LocalInstance {
     runtime: Option<Runtime>,
     exit_future: NodeExitFuture,
     node_handle: Option<Box<dyn Any + Send>>,
-    pool_handle: Arc<dyn ExternalTransactionPool>,
+    pool_handle: Option<Arc<dyn ExternalTransactionPool>>,
     pool_observer: TransactionPoolObserver,
     metering_provider: SharedMeteringProvider,
     /// Temporary directory backing the node's database, removed on drop.
@@ -283,10 +283,14 @@ impl LocalInstance {
         // internal node-started hook that captures the running node's transaction pool.
         let hooks = extensions.into_iter().fold(NodeHooks::new(), |hooks, ext| ext.apply(hooks));
         let hooks = hooks.add_node_started_hook(move |full_node| {
-            let _ = txpool_ready_tx.send(full_node.pool.all_transactions_event_listener());
+            if txpool_ready_tx.send(full_node.pool.all_transactions_event_listener()).is_err() {
+                tracing::warn!("txpool ready receiver dropped before node-started hook fired");
+            }
             let pool_handle: Arc<dyn ExternalTransactionPool> =
                 Arc::new(PoolHandle { pool: full_node.pool });
-            let _ = pool_handle_tx.send(pool_handle);
+            if pool_handle_tx.send(pool_handle).is_err() {
+                tracing::warn!("pool handle receiver dropped before node-started hook fired");
+            }
             Ok(())
         });
 
@@ -303,7 +307,7 @@ impl LocalInstance {
             node_config,
             exit_future,
             node_handle: Some(node_handle),
-            pool_handle,
+            pool_handle: Some(pool_handle),
             runtime: Some(runtime),
             pool_observer: TransactionPoolObserver::new(pool_monitor),
             metering_provider,
@@ -367,7 +371,7 @@ impl LocalInstance {
 
     /// Returns a cloned handle for submitting external transactions to the pool.
     pub fn pool_handle(&self) -> Arc<dyn ExternalTransactionPool> {
-        Arc::clone(&self.pool_handle)
+        Arc::clone(self.pool_handle.as_ref().expect("pool handle present"))
     }
 
     /// Returns a reference to the shared metering provider.
@@ -393,8 +397,10 @@ impl Drop for LocalInstance {
     fn drop(&mut self) {
         if let Some(runtime) = self.runtime.take() {
             runtime.graceful_shutdown_with_timeout(Duration::from_secs(10));
-            // Drop the node (and its open database handle) before removing the backing files.
+            // Drop the node and the pool handle (both hold open database handles via the node's
+            // provider / the pool's transaction validator) before removing the backing files.
             drop(self.node_handle.take());
+            drop(self.pool_handle.take());
             if let Err(e) = std::fs::remove_dir_all(self.node_config().datadir().to_string()) {
                 eprintln!(
                     "Warning: failed to remove temporary data directory {}: {e}",

--- a/crates/builder/core/src/test_utils/instance.rs
+++ b/crates/builder/core/src/test_utils/instance.rs
@@ -6,7 +6,10 @@ use core::{
     task::{Context, Poll},
     time::Duration,
 };
-use std::sync::{Arc, LazyLock};
+use std::{
+    path::PathBuf,
+    sync::{Arc, LazyLock},
+};
 
 use alloy_primitives::B256;
 use alloy_provider::{Identity, ProviderBuilder, RootProvider};
@@ -14,18 +17,21 @@ use async_trait::async_trait;
 use base_common_flashblocks::FlashblocksPayloadV1;
 use base_common_network::Base;
 use base_execution_chainspec::BaseChainSpec;
-use base_execution_rpc::BaseEthApiBuilder;
 use base_execution_txpool::BasePooledTransaction;
-use base_node_core::{BasePayloadValidatorBuilder, args::RollupArgs, node::BasePoolBuilder};
-use base_node_runner::{BaseNode, test_utils::init_silenced_tracing};
+use base_node_core::args::RollupArgs;
+use base_node_runner::{
+    BaseNode, BaseNodeExtension, FromExtensionConfig, NodeHooks,
+    PayloadServiceBuilder as BasePayloadServiceBuilder, test_utils::init_silenced_tracing,
+};
 use futures::{FutureExt, StreamExt};
 use nanoid::nanoid;
 use parking_lot::Mutex;
-use reth_node_builder::{NodeBuilder, NodeConfig};
+use reth_node_builder::{Node, NodeBuilder, NodeConfig};
 use reth_node_core::{
     args::{DatadirArgs, NetworkArgs, RpcServerArgs},
     exit::NodeExitFuture,
 };
+use reth_provider::providers::BlockchainProvider;
 use reth_tasks::{Runtime, RuntimeBuilder, RuntimeConfig};
 use reth_transaction_pool::{AllTransactionsEvents, TransactionPool};
 use tokio::{sync::oneshot, task::JoinHandle};
@@ -33,9 +39,11 @@ use tokio_tungstenite::{connect_async, tungstenite::Message};
 use tokio_util::sync::CancellationToken;
 
 use crate::{
-    BuilderConfig, SharedMeteringProvider,
+    BuilderConfig, CandidateSource, DefaultCandidateSource, SharedMeteringProvider,
     flashblocks::FlashblocksServiceBuilder,
-    test_utils::{EngineApi, Ipc, TransactionPoolObserver, create_test_db, driver::ChainDriver},
+    test_utils::{
+        EngineApi, Ipc, TransactionPoolObserver, create_test_db_env, driver::ChainDriver,
+    },
 };
 
 /// Clears OTEL-related environment variables that can interfere with CLI argument parsing.
@@ -65,10 +73,12 @@ pub struct LocalInstance {
     builder_config: BuilderConfig,
     runtime: Option<Runtime>,
     exit_future: NodeExitFuture,
-    _node_handle: Box<dyn Any + Send>,
+    node_handle: Option<Box<dyn Any + Send>>,
     pool_handle: Arc<dyn ExternalTransactionPool>,
     pool_observer: TransactionPoolObserver,
     metering_provider: SharedMeteringProvider,
+    /// Temporary directory backing the node's database, removed on drop.
+    db_dir: PathBuf,
 }
 
 struct PoolHandle<P> {
@@ -101,6 +111,102 @@ where
     }
 }
 
+/// Builder for a [`LocalInstance`] that supports injecting a custom
+/// [`CandidateSource`] and installing node [extensions](BaseNodeExtension).
+///
+/// The resulting node is wired through the same payload-service and extension-hook pipeline used by
+/// the production runner, so extensions installed here run exactly as they would in a real node.
+///
+/// ```ignore
+/// let instance = LocalInstanceBuilder::new(BuilderConfig::for_tests())
+///     .with_candidate_source(my_source)
+///     .install_ext::<MyExtension>(my_config)
+///     .build()
+///     .await?;
+/// ```
+pub struct LocalInstanceBuilder<S = DefaultCandidateSource> {
+    builder_config: BuilderConfig,
+    node_config: NodeConfig<BaseChainSpec>,
+    candidate_source: S,
+    extensions: Vec<Box<dyn BaseNodeExtension>>,
+}
+
+impl<S: core::fmt::Debug> core::fmt::Debug for LocalInstanceBuilder<S> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("LocalInstanceBuilder")
+            .field("builder_config", &self.builder_config)
+            .field("node_config", &self.node_config)
+            .field("candidate_source", &self.candidate_source)
+            .field("extensions", &self.extensions.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl LocalInstanceBuilder {
+    /// Creates a new builder with the given builder configuration, the default node configuration,
+    /// the default candidate source, and no extensions.
+    pub fn new(builder_config: BuilderConfig) -> Self {
+        Self {
+            builder_config,
+            node_config: default_node_config(),
+            candidate_source: DefaultCandidateSource,
+            extensions: Vec::new(),
+        }
+    }
+}
+
+impl<S> LocalInstanceBuilder<S> {
+    /// Overrides the Reth node configuration.
+    #[must_use]
+    pub fn with_node_config(mut self, node_config: NodeConfig<BaseChainSpec>) -> Self {
+        self.node_config = node_config;
+        self
+    }
+
+    /// Replaces the candidate transaction source used by the flashblocks build loop.
+    #[must_use]
+    pub fn with_candidate_source<S2>(self, candidate_source: S2) -> LocalInstanceBuilder<S2> {
+        LocalInstanceBuilder {
+            builder_config: self.builder_config,
+            node_config: self.node_config,
+            candidate_source,
+            extensions: self.extensions,
+        }
+    }
+
+    /// Installs a node extension built from the given config, mirroring
+    /// [`BaseNodeRunner::install_ext`](base_node_runner::BaseNodeRunner::install_ext).
+    #[must_use]
+    pub fn install_ext<T: FromExtensionConfig + 'static>(mut self, config: T::Config) -> Self {
+        self.extensions.push(Box::new(T::from_config(config)));
+        self
+    }
+
+    /// Installs an already-constructed node extension.
+    #[must_use]
+    pub fn with_extension(mut self, extension: Box<dyn BaseNodeExtension>) -> Self {
+        self.extensions.push(extension);
+        self
+    }
+
+    /// Launches the node described by this builder and returns the running [`LocalInstance`].
+    ///
+    /// This method does not prefund any accounts, so before sending any transactions make sure that
+    /// sender accounts are funded.
+    pub async fn build(self) -> eyre::Result<LocalInstance>
+    where
+        S: CandidateSource<BasePooledTransaction> + Clone + Unpin + 'static,
+    {
+        Box::pin(LocalInstance::launch(
+            self.builder_config,
+            self.node_config,
+            self.candidate_source,
+            self.extensions,
+        ))
+        .await
+    }
+}
+
 impl LocalInstance {
     /// Creates a new local instance of the builder node with the given builder configuration,
     /// with the default Reth node configuration.
@@ -108,7 +214,7 @@ impl LocalInstance {
     /// This method does not prefund any accounts, so before sending any transactions
     /// make sure that sender accounts are funded.
     pub async fn new(builder_config: BuilderConfig) -> eyre::Result<Self> {
-        Box::pin(Self::new_with_node_config(builder_config, default_node_config())).await
+        Box::pin(LocalInstanceBuilder::new(builder_config).build()).await
     }
 
     /// Creates a new local instance of the builder node with the given builder configuration,
@@ -120,65 +226,75 @@ impl LocalInstance {
         builder_config: BuilderConfig,
         node_config: NodeConfig<BaseChainSpec>,
     ) -> eyre::Result<Self> {
+        Box::pin(LocalInstanceBuilder::new(builder_config).with_node_config(node_config).build())
+            .await
+    }
+
+    /// Core launch routine shared by all constructors.
+    ///
+    /// Builds the node through the runner's payload-service seam (so a custom [`CandidateSource`]
+    /// can be injected) and applies caller-supplied [extensions](BaseNodeExtension) via the same
+    /// [`NodeHooks`] pipeline used in production, plus an internal hook that captures the running
+    /// node's transaction pool for tests.
+    async fn launch<S>(
+        builder_config: BuilderConfig,
+        node_config: NodeConfig<BaseChainSpec>,
+        candidate_source: S,
+        extensions: Vec<Box<dyn BaseNodeExtension>>,
+    ) -> eyre::Result<Self>
+    where
+        S: CandidateSource<BasePooledTransaction> + Clone + Unpin + 'static,
+    {
         clear_otel_env_vars();
         init_silenced_tracing();
         let runtime = RuntimeBuilder::new(RuntimeConfig::default()).build()?;
-        let base_node = BaseNode::new(RollupArgs::default());
-
-        let (rpc_ready_tx, rpc_ready_rx) = oneshot::channel::<()>();
-        let (txpool_ready_tx, txpool_ready_rx) =
-            oneshot::channel::<AllTransactionsEvents<BasePooledTransaction>>();
-        let (pool_handle_tx, pool_handle_rx) =
-            oneshot::channel::<Arc<dyn ExternalTransactionPool>>();
 
         let da_config = builder_config.da_config.clone();
         let gas_limit_config = builder_config.gas_limit_config.clone();
         let metering_provider = Arc::clone(&builder_config.metering_provider);
 
-        let addons: base_node_runner::BaseAddOns<
-            _,
-            BaseEthApiBuilder,
-            BasePayloadValidatorBuilder,
-        > = base_node
-            .add_ons_builder()
-            .with_da_config(da_config.clone())
-            .with_gas_limit_config(gas_limit_config.clone())
-            .build();
+        let base_node = BaseNode::new(RollupArgs::default())
+            .with_da_config(da_config)
+            .with_gas_limit_config(gas_limit_config);
 
-        let node_builder = NodeBuilder::<_, BaseChainSpec>::new(node_config.clone())
-            .with_database(create_test_db(node_config.clone()))
+        // Build the flashblocks payload service with the (possibly custom) candidate source.
+        let service_builder = FlashblocksServiceBuilder::new(builder_config.clone())
+            .with_candidate_source(candidate_source);
+        let components = service_builder.build_components(&base_node);
+
+        let (txpool_ready_tx, txpool_ready_rx) =
+            oneshot::channel::<AllTransactionsEvents<BasePooledTransaction>>();
+        let (pool_handle_tx, pool_handle_rx) =
+            oneshot::channel::<Arc<dyn ExternalTransactionPool>>();
+
+        // The node types fix the database to the concrete `DatabaseEnv`, so the test database must
+        // be a bare `DatabaseEnv` (not a `TempDatabase`) for the extension hook types to line up.
+        let (db, db_dir) = create_test_db_env(node_config.clone())?;
+
+        let builder = NodeBuilder::<_, BaseChainSpec>::new(node_config.clone())
+            .with_database(db)
             .with_launch_context(runtime.clone())
-            .with_types::<BaseNode>()
-            .with_components(
-                base_node
-                    .components()
-                    .pool(pool_component())
-                    .payload(FlashblocksServiceBuilder::new(builder_config.clone())),
-            )
-            .with_add_ons(addons)
-            .on_rpc_started(move |_, _| {
-                let _ = rpc_ready_tx.send(());
-                Ok(())
-            })
-            .on_node_started(move |ctx| {
-                txpool_ready_tx
-                    .send(ctx.pool.all_transactions_event_listener())
-                    .expect("Failed to send txpool ready signal");
+            .with_types_and_provider::<BaseNode, BlockchainProvider<_>>()
+            .with_components(components)
+            .with_add_ons(base_node.add_ons())
+            .on_component_initialized(move |_ctx| Ok(()));
 
-                let pool_handle: Arc<dyn ExternalTransactionPool> =
-                    Arc::new(PoolHandle { pool: ctx.pool });
-                pool_handle_tx.send(pool_handle).expect("Failed to send pool handle");
+        // Apply caller-supplied extensions through the production hook pipeline, then append an
+        // internal node-started hook that captures the running node's transaction pool.
+        let hooks = extensions.into_iter().fold(NodeHooks::new(), |hooks, ext| ext.apply(hooks));
+        let hooks = hooks.add_node_started_hook(move |full_node| {
+            let _ = txpool_ready_tx.send(full_node.pool.all_transactions_event_listener());
+            let pool_handle: Arc<dyn ExternalTransactionPool> =
+                Arc::new(PoolHandle { pool: full_node.pool });
+            let _ = pool_handle_tx.send(pool_handle);
+            Ok(())
+        });
 
-                Ok(())
-            });
-
-        let node_handle = node_builder.launch().await?;
+        let node_handle = hooks.apply_to(builder).launch().await?;
         let exit_future = node_handle.node_exit_future;
-        let boxed_handle = Box::new(node_handle.node);
-        let node_handle: Box<dyn Any + Send> = boxed_handle;
+        let node_handle: Box<dyn Any + Send> = Box::new(node_handle.node);
 
-        // Wait for all required components to be ready
-        rpc_ready_rx.await.expect("Failed to receive ready signal");
+        // Wait for the node-started hook to publish the pool handles.
         let pool_monitor = txpool_ready_rx.await.expect("Failed to receive txpool ready signal");
         let pool_handle = pool_handle_rx.await.expect("Failed to receive pool handle");
 
@@ -186,11 +302,12 @@ impl LocalInstance {
             builder_config,
             node_config,
             exit_future,
-            _node_handle: node_handle,
+            node_handle: Some(node_handle),
             pool_handle,
             runtime: Some(runtime),
             pool_observer: TransactionPoolObserver::new(pool_monitor),
             metering_provider,
+            db_dir,
         })
     }
 
@@ -276,10 +393,18 @@ impl Drop for LocalInstance {
     fn drop(&mut self) {
         if let Some(runtime) = self.runtime.take() {
             runtime.graceful_shutdown_with_timeout(Duration::from_secs(10));
+            // Drop the node (and its open database handle) before removing the backing files.
+            drop(self.node_handle.take());
             if let Err(e) = std::fs::remove_dir_all(self.node_config().datadir().to_string()) {
                 eprintln!(
                     "Warning: failed to remove temporary data directory {}: {e}",
                     self.node_config().datadir()
+                );
+            }
+            if let Err(e) = std::fs::remove_dir_all(&self.db_dir) {
+                eprintln!(
+                    "Warning: failed to remove temporary database directory {}: {e}",
+                    self.db_dir.display()
                 );
             }
         }
@@ -368,10 +493,6 @@ fn node_config_with_chain_spec(spec: Arc<BaseChainSpec>) -> NodeConfig<BaseChain
         .with_datadir_args(datadir)
         .with_rpc(rpc)
         .with_network(network)
-}
-
-fn pool_component() -> BasePoolBuilder<BasePooledTransaction> {
-    BasePoolBuilder::<BasePooledTransaction>::default()
 }
 
 /// A utility for listening to flashblocks WebSocket messages during tests.

--- a/crates/builder/core/src/test_utils/utils.rs
+++ b/crates/builder/core/src/test_utils/utils.rs
@@ -1,5 +1,5 @@
 use core::future::Future;
-use std::{net::TcpListener, sync::Arc};
+use std::{net::TcpListener, path::PathBuf, sync::Arc};
 
 use alloy_eips::Encodable2718;
 use alloy_primitives::{Address, B256, BlockHash, TxHash, TxKind, U256, hex};
@@ -236,6 +236,31 @@ pub fn create_test_db(config: NodeConfig<BaseChainSpec>) -> Arc<TempDatabase<Dat
     )
     .expect(ERROR_DB_CREATION);
     Arc::new(TempDatabase::new(db, path))
+}
+
+/// Creates a persistent MDBX [`DatabaseEnv`] in a fresh temporary directory.
+///
+/// Unlike [`create_test_db`], this returns the concrete `DatabaseEnv` (not wrapped in
+/// [`TempDatabase`]) so the resulting node matches the production database type used by the node
+/// builder's type bounds. This is required when applying node extensions whose hooks are typed
+/// against the concrete node types. The returned [`PathBuf`] is the temporary directory backing the
+/// database; the caller is responsible for removing it once the database has been dropped.
+pub fn create_test_db_env(
+    config: NodeConfig<BaseChainSpec>,
+) -> eyre::Result<(DatabaseEnv, PathBuf)> {
+    let root = reth_db::test_utils::tempdir_path();
+    let path = reth_node_core::dirs::MaybePlatformPath::<DataDirPath>::from(root.clone());
+    let db_config =
+        config.with_datadir_args(DatadirArgs { datadir: path.clone(), ..Default::default() });
+    let data_dir = path.unwrap_or_chain_default(db_config.chain.chain(), db_config.datadir.clone());
+    let db = init_db(
+        data_dir.db().as_path(),
+        DatabaseArguments::new(ClientVersion::default())
+            .with_max_read_transaction_duration(Some(MaxReadTransactionDuration::Unbounded))
+            .with_geometry_max_size(Some(4 * MEGABYTE))
+            .with_growth_step(Some(4 * KILOBYTE)),
+    )?;
+    Ok((db, root))
 }
 
 /// Gets an available port by first binding to port 0 -- instructing the OS to

--- a/crates/builder/core/tests/extensions.rs
+++ b/crates/builder/core/tests/extensions.rs
@@ -1,0 +1,95 @@
+//! End-to-end tests for the [`LocalInstanceBuilder`] injection seams: a custom
+//! [`CandidateSource`] wired into the flashblocks build loop, and a node
+//! [`BaseNodeExtension`] applied through the same hook pipeline used in production.
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+};
+
+use base_builder_core::{
+    BoxedBestTransactions, BuilderConfig, CandidateSource, test_utils::LocalInstanceBuilder,
+};
+use base_execution_txpool::BasePooledTransaction;
+use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
+use reth_transaction_pool::BestTransactionsAttributes;
+
+/// A candidate source that counts how many times the build loop drains it and otherwise passes the
+/// pool's best-transactions stream through unchanged.
+#[derive(Debug, Clone)]
+struct CountingSource {
+    calls: Arc<AtomicUsize>,
+}
+
+impl CandidateSource<BasePooledTransaction> for CountingSource {
+    fn best_transactions(
+        &self,
+        pool_best: BoxedBestTransactions<BasePooledTransaction>,
+        _attributes: BestTransactionsAttributes,
+    ) -> BoxedBestTransactions<BasePooledTransaction> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        pool_best
+    }
+}
+
+/// A minimal extension that flips a shared flag from its node-started hook, proving the extension's
+/// `apply` runs through the same [`NodeHooks`] pipeline the production runner uses.
+#[derive(Debug)]
+struct StartedFlagExtension {
+    started: Arc<AtomicBool>,
+}
+
+impl BaseNodeExtension for StartedFlagExtension {
+    fn apply(self: Box<Self>, hooks: NodeHooks) -> NodeHooks {
+        let started = self.started;
+        hooks.add_node_started_hook(move |_full_node| {
+            started.store(true, Ordering::SeqCst);
+            Ok(())
+        })
+    }
+}
+
+impl FromExtensionConfig for StartedFlagExtension {
+    type Config = Arc<AtomicBool>;
+
+    fn from_config(config: Self::Config) -> Self {
+        Self { started: config }
+    }
+}
+
+/// A custom [`CandidateSource`] supplied via [`LocalInstanceBuilder::with_candidate_source`] is
+/// actually drained by the real flashblocks build loop when producing a block.
+#[tokio::test]
+async fn injected_candidate_source_is_used_by_the_build_loop() -> eyre::Result<()> {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let instance = LocalInstanceBuilder::new(BuilderConfig::for_tests())
+        .with_candidate_source(CountingSource { calls: Arc::clone(&calls) })
+        .build()
+        .await?;
+
+    let driver = instance.driver().await?;
+    driver.build_new_block().await?;
+
+    assert!(
+        calls.load(Ordering::SeqCst) > 0,
+        "the injected candidate source should be drained by the build loop"
+    );
+    Ok(())
+}
+
+/// An extension installed via [`LocalInstanceBuilder::install_ext`] has its hooks applied through
+/// the production hook pipeline: its node-started hook runs once the node has started.
+#[tokio::test]
+async fn installed_extension_runs_through_the_hook_pipeline() -> eyre::Result<()> {
+    let started = Arc::new(AtomicBool::new(false));
+    let _instance = LocalInstanceBuilder::new(BuilderConfig::for_tests())
+        .install_ext::<StartedFlagExtension>(Arc::clone(&started))
+        .build()
+        .await?;
+
+    assert!(
+        started.load(Ordering::SeqCst),
+        "the installed extension's node-started hook should have run during launch"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds a `LocalInstanceBuilder` to the builder test-utils that lets tests inject a custom `CandidateSource` into the flashblocks build loop and install node extensions through the same `NodeHooks` pipeline the production runner uses. This unblocks action testing where extensions need to be applied to a local node exactly as they would be in production. A `create_test_db_env` helper is added so the local node uses the concrete `DatabaseEnv` that the extension hook types are bound against. End-to-end tests cover both seams, verifying the injected candidate source is drained during block production and that an installed extension's node-started hook runs during launch.