### PR TITLE
refactor(basectl): 3/4 move operational commands into basectl-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6777,10 +6777,7 @@ version = "0.0.0"
 dependencies = [
  "alloy-primitives",
  "anyhow",
- "base-consensus-peers",
- "base-prover-service-protocol",
  "basectl-cli",
- "chrono",
  "clap",
  "rustls 0.23.42",
  "serde",

--- a/bin/basectl/Cargo.toml
+++ b/bin/basectl/Cargo.toml
@@ -16,8 +16,6 @@ url = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 basectl-cli = { workspace = true }
-base-consensus-peers = { workspace = true }
-base-prover-service-protocol = { workspace = true }
 rustls = { workspace = true, features = ["ring"] }
 clap = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
@@ -25,6 +23,3 @@ serde = { workspace = true, features = ["derive", "std"] }
 alloy-primitives = { workspace = true, features = ["serde"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
-
-[dev-dependencies]
-chrono = { workspace = true }

--- a/bin/basectl/src/main.rs
+++ b/bin/basectl/src/main.rs
@@ -1,10 +1,7 @@
 //! Base infrastructure control CLI binary.
 
 mod conductor;
-mod p2p;
-mod proofs;
 mod sequencer;
-mod txpool;
 
 use basectl_cli::{Cli, Commands, MonitoringConfig, ViewId, run_app, run_flashblocks_json};
 use clap::{CommandFactory, Parser};
@@ -40,15 +37,13 @@ async fn main() -> anyhow::Result<()> {
         Some(Commands::SyncStatus(command)) => {
             command.run(MonitoringConfig::load(config).await?).await
         }
-        Some(Commands::P2p { command }) => {
-            if p2p::run(config, command).await?.has_failures() {
+        Some(Commands::P2p(command)) => {
+            if command.run(config).await?.has_failures() {
                 std::process::exit(1);
             }
             Ok(())
         }
-        Some(Commands::Txpool { command }) => {
-            txpool::run(MonitoringConfig::load(config).await?, command).await
-        }
+        Some(Commands::Txpool(command)) => command.run(MonitoringConfig::load(config).await?).await,
         Some(Commands::Conductor { command }) => {
             if conductor::run(MonitoringConfig::load(config).await?, conductor_rpc, command)
                 .await?
@@ -67,8 +62,8 @@ async fn main() -> anyhow::Result<()> {
             }
             Ok(())
         }
-        Some(Commands::Proofs { command }) => {
-            if proofs::run(MonitoringConfig::load(config).await?, command).await?.has_failures() {
+        Some(Commands::Proofs(command)) => {
+            if command.run(MonitoringConfig::load(config).await?).await?.has_failures() {
                 std::process::exit(1);
             }
             Ok(())

--- a/bin/basectl/src/main.rs
+++ b/bin/basectl/src/main.rs
@@ -38,7 +38,7 @@ async fn main() -> anyhow::Result<()> {
             command.run(MonitoringConfig::load(config).await?).await
         }
         Some(Commands::P2p(command)) => {
-            if command.run(config).await?.has_failures() {
+            if command.run(MonitoringConfig::load(config).await?).await?.has_failures() {
                 std::process::exit(1);
             }
             Ok(())

--- a/crates/infra/basectl/src/commands/cli.rs
+++ b/crates/infra/basectl/src/commands/cli.rs
@@ -1,10 +1,11 @@
 //! CLI arguments and subcommands for basectl.
 
-use alloy_primitives::{Address, B256};
-use clap::{Args, Parser, Subcommand, ValueEnum};
+use clap::{Args, Parser, Subcommand};
 use url::Url;
 
-use super::{BlockCommand, DoctorCommand, SyncStatusCommand};
+use super::{
+    BlockCommand, DoctorCommand, P2pCommand, ProofsCommand, SyncStatusCommand, TxpoolCommand,
+};
 use crate::ViewId;
 
 /// Base infrastructure control CLI.
@@ -46,17 +47,9 @@ pub enum Commands {
     /// Report combined CL `optimism_syncStatus` + EL `eth_syncing`.
     SyncStatus(SyncStatusCommand),
     /// Inspect p2p peers and advertised endpoints.
-    P2p {
-        /// P2P operation to run.
-        #[command(subcommand)]
-        command: P2pCommands,
-    },
+    P2p(P2pCommand),
     /// Inspect and clear execution-layer txpool contents.
-    Txpool {
-        /// Transaction-pool operation to run.
-        #[command(subcommand)]
-        command: TxpoolCommands,
-    },
+    Txpool(TxpoolCommand),
     /// Inspect and control an HA conductor cluster.
     Conductor {
         /// Conductor operation to run.
@@ -72,271 +65,10 @@ pub enum Commands {
     /// Run read-only diagnostics for a single node.
     Doctor(DoctorCommand),
     /// Request and inspect ZK proofs on the internal prover service.
-    Proofs {
-        /// Proof operation to run.
-        #[command(subcommand)]
-        command: ProofsCommands,
-    },
+    Proofs(ProofsCommand),
     /// Stream flashblocks as JSON lines.
     #[command(after_help = "Use `basectl monitor flashblocks` for the TUI.")]
     Flashblocks,
-}
-
-/// Prover-service proof request and inspection commands.
-#[derive(Debug, Subcommand)]
-pub enum ProofsCommands {
-    /// Submit a compressed ZK proof request for a block range to speed up finality.
-    Finalize(ProofsFinalizeArgs),
-    /// Show status and result data for a submitted proof request.
-    Status(ProofsStatusArgs),
-    /// List submitted proof requests.
-    List(ProofsListArgs),
-}
-
-/// Flags for `basectl proofs finalize`.
-#[derive(Debug, Args)]
-pub struct ProofsFinalizeArgs {
-    /// First L2 block number to prove.
-    #[arg(value_name = "START_BLOCK")]
-    pub start_block: u64,
-    /// Number of consecutive L2 blocks to prove.
-    #[arg(value_name = "NUM_BLOCKS", value_parser = clap::value_parser!(u64).range(1..))]
-    pub num_blocks: u64,
-    /// Explicit proof session ID (prover-service idempotency key).
-    ///
-    /// If omitted, basectl derives a deterministic session ID from the
-    /// network name and block range, so re-running the same command resolves
-    /// to the existing prover-service session instead of enqueueing a
-    /// duplicate proof.
-    #[arg(long = "session-id", value_name = "ID")]
-    pub session_id: Option<String>,
-    /// L1 head hash used for witness generation.
-    ///
-    /// If omitted, the prover service picks one.
-    #[arg(long = "l1-head", value_name = "HASH")]
-    pub l1_head: Option<B256>,
-    /// Sequencing window passed to the prover.
-    #[arg(long = "sequence-window", value_name = "N")]
-    pub sequence_window: Option<u64>,
-    /// Intermediate output root interval passed to the prover.
-    #[arg(long = "intermediate-root-interval", value_name = "N")]
-    pub intermediate_root_interval: Option<u64>,
-    /// Poll the prover service until the proof succeeds or fails.
-    ///
-    /// Exits non-zero when the proof fails or does not complete in time.
-    #[arg(long)]
-    pub wait: bool,
-    /// Prover-service RPC URL (also `BASECTL_PROVER_RPC` or config `prover_rpc`).
-    #[arg(long = "prover-rpc", env = "BASECTL_PROVER_RPC", value_name = "URL")]
-    pub prover_rpc: Option<Url>,
-    /// Skip the interactive confirmation prompt.
-    #[arg(long)]
-    pub yes: bool,
-    /// Emit a structured JSON action outcome instead of pretty text.
-    #[arg(long, requires = "yes")]
-    pub json: bool,
-}
-
-/// Flags for `basectl proofs status`.
-#[derive(Debug, Args)]
-pub struct ProofsStatusArgs {
-    /// Proof session ID returned by `basectl proofs finalize`.
-    #[arg(value_name = "SESSION_ID")]
-    pub session_id: String,
-    /// Prover-service RPC URL (also `BASECTL_PROVER_RPC` or config `prover_rpc`).
-    #[arg(long = "prover-rpc", env = "BASECTL_PROVER_RPC", value_name = "URL")]
-    pub prover_rpc: Option<Url>,
-    /// Emit humanized JSON instead of pretty text.
-    #[arg(long)]
-    pub json: bool,
-    /// With `--json`, emit the prover-service wire shape instead of the humanized summary.
-    #[arg(long, requires = "json")]
-    pub raw: bool,
-}
-
-/// Flags for `basectl proofs list`.
-#[derive(Debug, Args)]
-pub struct ProofsListArgs {
-    /// Only list proofs with this status.
-    #[arg(long, value_enum, value_name = "STATUS")]
-    pub status: Option<ProofStatusFilter>,
-    /// Number of rows to skip.
-    #[arg(long, value_name = "N", default_value_t = 0)]
-    pub offset: u64,
-    /// Maximum rows to return.
-    #[arg(long, value_name = "N", default_value_t = 50)]
-    pub limit: u32,
-    /// Prover-service RPC URL (also `BASECTL_PROVER_RPC` or config `prover_rpc`).
-    #[arg(long = "prover-rpc", env = "BASECTL_PROVER_RPC", value_name = "URL")]
-    pub prover_rpc: Option<Url>,
-    /// Emit humanized JSON instead of pretty text.
-    #[arg(long)]
-    pub json: bool,
-}
-
-/// Proof status filter accepted by `basectl proofs list`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
-pub enum ProofStatusFilter {
-    /// Proof request is queued.
-    Queued,
-    /// Proof request is running.
-    Running,
-    /// Proof request completed successfully.
-    Succeeded,
-    /// Proof request failed.
-    Failed,
-}
-
-/// P2P inspection and peer-management commands.
-#[derive(Debug, Subcommand)]
-pub enum P2pCommands {
-    /// List connected peers per layer.
-    Peers(P2pArgs),
-    /// Show advertised endpoints and peer-count summary per layer.
-    Info(P2pArgs),
-    /// Ask the Base telemetry service to probe an execution-layer enode.
-    Reachability {
-        /// Execution-layer `enode://` URL to probe.
-        #[arg(value_name = "ENODE")]
-        enode: String,
-        /// Emit the telemetry response as JSON.
-        #[arg(long)]
-        json: bool,
-    },
-    /// Add a single execution or consensus peer.
-    AddPeer(DestructivePeerArgs),
-    /// Remove a single execution or consensus peer.
-    RemovePeer(DestructivePeerArgs),
-    /// Ban a single execution or consensus peer.
-    Ban(DestructivePeerArgs),
-    /// Unban a single execution or consensus peer.
-    Unban(DestructivePeerArgs),
-    /// Unban all currently banned consensus peers.
-    UnbanAll(DestructiveClBulkArgs),
-}
-
-/// Shared flags for the read-only `basectl p2p` subcommands.
-#[derive(Debug, Args)]
-pub struct P2pArgs {
-    /// Override the execution-layer RPC URL.
-    ///
-    /// Defaults to the chain config's `rpc` field, which on the
-    /// `mainnet` and `sepolia` presets resolves to the public proxyd
-    /// fleet. Pass this flag to query a single node directly.
-    #[arg(long = "el-rpc", value_name = "URL")]
-    pub el_rpc: Option<Url>,
-    /// Override the consensus-node RPC URL.
-    ///
-    /// The mainnet and sepolia presets ship `consensus_node_rpc` unset,
-    /// so non-devnet users must pass this flag (or set the field in
-    /// their YAML config).
-    #[arg(long = "cl-rpc", value_name = "URL")]
-    pub cl_rpc: Option<Url>,
-    /// Emit JSON instead of the pretty table output.
-    #[arg(long)]
-    pub json: bool,
-    /// With `--json`, emit raw RPC wire shapes instead of the humanized summary.
-    #[arg(long, requires = "json")]
-    pub raw: bool,
-}
-
-/// Shared flags for destructive `basectl p2p` subcommands.
-#[derive(Debug, Args)]
-pub struct DestructivePeerArgs {
-    /// Peer target. `enode://...` routes to EL; CL add accepts ENR or multiaddr, while other actions use a peer ID.
-    #[arg(value_name = "TARGET")]
-    pub target: String,
-    /// Override the execution-layer RPC URL.
-    ///
-    /// Defaults to the chain config's `rpc` field, which on the
-    /// `mainnet` and `sepolia` presets resolves to the public proxyd
-    /// fleet. Pass this flag to query a single node directly.
-    #[arg(long = "el-rpc", value_name = "URL")]
-    pub el_rpc: Option<Url>,
-    /// Override the consensus-node RPC URL.
-    ///
-    /// The mainnet and sepolia presets ship `consensus_node_rpc` unset,
-    /// so non-devnet users must pass this flag (or set the field in
-    /// their YAML config).
-    #[arg(long = "cl-rpc", value_name = "URL")]
-    pub cl_rpc: Option<Url>,
-    /// Skip the interactive confirmation prompt.
-    #[arg(long)]
-    pub yes: bool,
-    /// Emit a structured JSON action outcome instead of pretty text.
-    #[arg(long, requires = "yes")]
-    pub json: bool,
-}
-
-/// Shared flags for destructive consensus-only `basectl p2p` bulk subcommands.
-#[derive(Debug, Args)]
-pub struct DestructiveClBulkArgs {
-    /// Override the consensus-node RPC URL.
-    ///
-    /// The mainnet and sepolia presets ship `consensus_node_rpc` unset,
-    /// so non-devnet users must pass this flag (or set the field in
-    /// their YAML config).
-    #[arg(long = "cl-rpc", value_name = "URL")]
-    pub cl_rpc: Option<Url>,
-    /// Skip the interactive confirmation prompt.
-    #[arg(long)]
-    pub yes: bool,
-    /// Emit a structured JSON action outcome instead of pretty text.
-    #[arg(long, requires = "yes")]
-    pub json: bool,
-}
-
-/// Transaction-pool inspection and destructive clearing commands.
-#[derive(Debug, Subcommand)]
-pub enum TxpoolCommands {
-    /// Show pending txpool transactions.
-    Pending(TxpoolReadArgs),
-    /// Show queued txpool transactions.
-    Queued(TxpoolReadArgs),
-    /// Show pending and queued txpool transactions.
-    All(TxpoolReadArgs),
-    /// Clear the txpool or drop every transaction for one sender.
-    Clear(TxpoolClearArgs),
-}
-
-/// Shared flags for read-only `basectl txpool` subcommands.
-#[derive(Debug, Args)]
-pub struct TxpoolReadArgs {
-    /// Optional sender address to filter at the RPC layer.
-    #[arg(value_name = "SENDER")]
-    pub sender: Option<Address>,
-    /// Override the execution-layer RPC URL.
-    ///
-    /// Defaults to the chain config's `rpc` field. Pass this flag to query a
-    /// single node directly.
-    #[arg(long = "el-rpc", value_name = "URL")]
-    pub el_rpc: Option<Url>,
-    /// Emit humanized JSON instead of pretty text.
-    #[arg(long)]
-    pub json: bool,
-    /// With `--json`, emit the txpool wire shape instead of the humanized summary.
-    #[arg(long, requires = "json")]
-    pub raw: bool,
-}
-
-/// Flags for destructive `basectl txpool clear`.
-#[derive(Debug, Args)]
-pub struct TxpoolClearArgs {
-    /// Sender address whose txpool transactions should be dropped.
-    #[arg(long, value_name = "ADDRESS")]
-    pub sender: Option<Address>,
-    /// Override the execution-layer RPC URL.
-    ///
-    /// Defaults to the chain config's `rpc` field. Destructive txpool calls
-    /// usually require an admin-enabled node RPC.
-    #[arg(long = "el-rpc", value_name = "URL")]
-    pub el_rpc: Option<Url>,
-    /// Skip the interactive confirmation prompt.
-    #[arg(long)]
-    pub yes: bool,
-    /// Emit a structured JSON action outcome instead of pretty text.
-    #[arg(long, requires = "yes")]
-    pub json: bool,
 }
 
 /// HA conductor inspection and control commands.

--- a/crates/infra/basectl/src/commands/mod.rs
+++ b/crates/infra/basectl/src/commands/mod.rs
@@ -6,16 +6,33 @@ pub use block::{BlockCommand, BlockSummaryJson};
 mod cli;
 pub use cli::{
     Cli, Commands, ConductorClusterActionArgs, ConductorCommands, ConductorLeaderArgs,
-    ConductorNodeActionArgs, ConductorStatusArgs, DestructiveClBulkArgs, DestructivePeerArgs,
-    MonitorCommands, P2pArgs, P2pCommands, ProofStatusFilter, ProofsCommands, ProofsFinalizeArgs,
-    ProofsListArgs, ProofsStatusArgs, SequencerCommands, SequencerNodeActionArgs,
-    SequencerStartArgs, SequencerStatusArgs, TxpoolClearArgs, TxpoolCommands, TxpoolReadArgs,
+    ConductorNodeActionArgs, ConductorStatusArgs, MonitorCommands, SequencerCommands,
+    SequencerNodeActionArgs, SequencerStartArgs, SequencerStatusArgs,
 };
 
 mod doctor;
 pub use doctor::DoctorCommand;
 
+mod p2p;
+pub use p2p::{
+    AddTarget, BanAction, DestructiveClBulkArgs, DestructivePeerArgs, P2pArgs, P2pCommand,
+    P2pCommands, PeerAction, PeerActionJson, PeerBulkActionResultJson, PeerLayer, PeerTarget,
+    PeersJson,
+};
+
+mod proofs;
+pub use proofs::{
+    ProofResultJson, ProofStatusFilter, ProofSummaryJson, ProofsCommand, ProofsCommands,
+    ProofsFinalizeArgs, ProofsFinalizeJson, ProofsListArgs, ProofsListJson, ProofsStatusArgs,
+    ProofsStatusJson,
+};
+
 mod sync_status;
 pub use sync_status::{
     ElSyncInfoJson, HeadJson, SyncStatusCommand, SyncStatusJson, TipReferenceJson, TipStatus,
+};
+
+mod txpool;
+pub use txpool::{
+    TxpoolClearArgs, TxpoolClearJson, TxpoolCommand, TxpoolCommands, TxpoolReadArgs, TxpoolReadJson,
 };

--- a/crates/infra/basectl/src/commands/p2p.rs
+++ b/crates/infra/basectl/src/commands/p2p.rs
@@ -4,39 +4,150 @@ use std::io::{self, Write};
 
 use anyhow::{Context, Result, anyhow};
 use base_consensus_peers::BootNode;
-use basectl_cli::{
-    CommandOutcome, Confirm, DestructiveClBulkArgs, DestructivePeerArgs, ElReachabilityOutcome,
-    JsonOutput, KeyValueTable, MonitoringConfig, P2pArgs, P2pCommandError, P2pCommands,
-    P2pInfoJson, P2pInfoTable, P2pTargetError, PeerListReport, PeerSummary, TelemetryClient,
-    add_peer, ban_el_peer, ban_peer, connect_peer, disconnect_peer, el_peer_is_trusted,
-    fetch_connected_peers, fetch_info, fetch_l2_chain_id, fetch_raw_info, fetch_raw_peers,
-    list_banned_peers, remove_peer, unban_el_peer, unban_peer,
-};
 use serde::Serialize;
 use url::Url;
 
-/// Runs the `basectl p2p` command group.
-pub(crate) async fn run(config: &str, command: P2pCommands) -> Result<CommandOutcome> {
-    match command {
-        P2pCommands::Reachability { enode, json } => {
-            let config = MonitoringConfig::load(config).await?;
-            run_reachability(&config, &enode, json).await
-        }
-        other => {
-            let config = MonitoringConfig::load(config).await?;
-            match other {
-                P2pCommands::Peers(args) => run_peers(config, args).await?,
-                P2pCommands::Info(args) => run_info(config, args).await?,
-                P2pCommands::AddPeer(args) => run_add_peer(config, args).await?,
-                P2pCommands::RemovePeer(args) => run_remove_peer(config, args).await?,
-                P2pCommands::Ban(args) => run_peer_ban_action(config, args, BanAction::Ban).await?,
-                P2pCommands::Unban(args) => {
-                    run_peer_ban_action(config, args, BanAction::Unban).await?
-                }
-                P2pCommands::UnbanAll(args) => run_unban_all(config, args).await?,
-                P2pCommands::Reachability { .. } => unreachable!(),
+use crate::{
+    CommandOutcome, Confirm, ElReachabilityOutcome, JsonOutput, KeyValueTable, MonitoringConfig,
+    P2pCommandError, P2pInfoJson, P2pInfoTable, P2pTargetError, PeerListReport, PeerSummary,
+    TelemetryClient, add_peer, ban_el_peer, ban_peer, connect_peer, disconnect_peer,
+    el_peer_is_trusted, fetch_connected_peers, fetch_info, fetch_l2_chain_id, fetch_raw_info,
+    fetch_raw_peers, list_banned_peers, remove_peer, unban_el_peer, unban_peer,
+};
+
+/// Inspect p2p peers and advertised endpoints.
+#[derive(Debug, clap::Args)]
+pub struct P2pCommand {
+    /// P2P operation to run.
+    #[command(subcommand)]
+    pub command: P2pCommands,
+}
+
+/// P2P inspection and peer-management commands.
+#[derive(Debug, clap::Subcommand)]
+pub enum P2pCommands {
+    /// List connected peers per layer.
+    Peers(P2pArgs),
+    /// Show advertised endpoints and peer-count summary per layer.
+    Info(P2pArgs),
+    /// Ask the Base telemetry service to probe an execution-layer enode.
+    Reachability {
+        /// Execution-layer `enode://` URL to probe.
+        #[arg(value_name = "ENODE")]
+        enode: String,
+        /// Emit the telemetry response as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Add a single execution or consensus peer.
+    AddPeer(DestructivePeerArgs),
+    /// Remove a single execution or consensus peer.
+    RemovePeer(DestructivePeerArgs),
+    /// Ban a single execution or consensus peer.
+    Ban(DestructivePeerArgs),
+    /// Unban a single execution or consensus peer.
+    Unban(DestructivePeerArgs),
+    /// Unban all currently banned consensus peers.
+    UnbanAll(DestructiveClBulkArgs),
+}
+
+/// Shared flags for the read-only `basectl p2p` subcommands.
+#[derive(Debug, clap::Args)]
+pub struct P2pArgs {
+    /// Override the execution-layer RPC URL.
+    ///
+    /// Defaults to the chain config's `rpc` field, which on the
+    /// `mainnet` and `sepolia` presets resolves to the public proxyd
+    /// fleet. Pass this flag to query a single node directly.
+    #[arg(long = "el-rpc", value_name = "URL")]
+    pub el_rpc: Option<Url>,
+    /// Override the consensus-node RPC URL.
+    ///
+    /// The mainnet and sepolia presets ship `consensus_node_rpc` unset,
+    /// so non-devnet users must pass this flag (or set the field in
+    /// their YAML config).
+    #[arg(long = "cl-rpc", value_name = "URL")]
+    pub cl_rpc: Option<Url>,
+    /// Emit JSON instead of the pretty table output.
+    #[arg(long)]
+    pub json: bool,
+    /// With `--json`, emit raw RPC wire shapes instead of the humanized summary.
+    #[arg(long, requires = "json")]
+    pub raw: bool,
+}
+
+/// Shared flags for destructive `basectl p2p` subcommands.
+#[derive(Debug, clap::Args)]
+pub struct DestructivePeerArgs {
+    /// Peer target. `enode://...` routes to EL; CL add accepts ENR or multiaddr, while other actions use a peer ID.
+    #[arg(value_name = "TARGET")]
+    pub target: String,
+    /// Override the execution-layer RPC URL.
+    ///
+    /// Defaults to the chain config's `rpc` field, which on the
+    /// `mainnet` and `sepolia` presets resolves to the public proxyd
+    /// fleet. Pass this flag to query a single node directly.
+    #[arg(long = "el-rpc", value_name = "URL")]
+    pub el_rpc: Option<Url>,
+    /// Override the consensus-node RPC URL.
+    ///
+    /// The mainnet and sepolia presets ship `consensus_node_rpc` unset,
+    /// so non-devnet users must pass this flag (or set the field in
+    /// their YAML config).
+    #[arg(long = "cl-rpc", value_name = "URL")]
+    pub cl_rpc: Option<Url>,
+    /// Skip the interactive confirmation prompt.
+    #[arg(long)]
+    pub yes: bool,
+    /// Emit a structured JSON action outcome instead of pretty text.
+    #[arg(long, requires = "yes")]
+    pub json: bool,
+}
+
+/// Shared flags for destructive consensus-only `basectl p2p` bulk subcommands.
+#[derive(Debug, clap::Args)]
+pub struct DestructiveClBulkArgs {
+    /// Override the consensus-node RPC URL.
+    ///
+    /// The mainnet and sepolia presets ship `consensus_node_rpc` unset,
+    /// so non-devnet users must pass this flag (or set the field in
+    /// their YAML config).
+    #[arg(long = "cl-rpc", value_name = "URL")]
+    pub cl_rpc: Option<Url>,
+    /// Skip the interactive confirmation prompt.
+    #[arg(long)]
+    pub yes: bool,
+    /// Emit a structured JSON action outcome instead of pretty text.
+    #[arg(long, requires = "yes")]
+    pub json: bool,
+}
+
+impl P2pCommand {
+    /// Runs the selected `basectl p2p` operation.
+    pub async fn run(self, config: &str) -> Result<CommandOutcome> {
+        match self.command {
+            P2pCommands::Reachability { enode, json } => {
+                let config = MonitoringConfig::load(config).await?;
+                run_reachability(&config, &enode, json).await
             }
-            Ok(CommandOutcome::Success)
+            other => {
+                let config = MonitoringConfig::load(config).await?;
+                match other {
+                    P2pCommands::Peers(args) => run_peers(config, args).await?,
+                    P2pCommands::Info(args) => run_info(config, args).await?,
+                    P2pCommands::AddPeer(args) => run_add_peer(config, args).await?,
+                    P2pCommands::RemovePeer(args) => run_remove_peer(config, args).await?,
+                    P2pCommands::Ban(args) => {
+                        run_peer_ban_action(config, args, BanAction::Ban).await?
+                    }
+                    P2pCommands::Unban(args) => {
+                        run_peer_ban_action(config, args, BanAction::Unban).await?
+                    }
+                    P2pCommands::UnbanAll(args) => run_unban_all(config, args).await?,
+                    P2pCommands::Reachability { .. } => unreachable!(),
+                }
+                Ok(CommandOutcome::Success)
+            }
         }
     }
 }
@@ -101,7 +212,7 @@ async fn run_peers(config: MonitoringConfig, args: P2pArgs) -> Result<()> {
 async fn run_add_peer(config: MonitoringConfig, args: DestructivePeerArgs) -> Result<()> {
     let DestructivePeerArgs { target, el_rpc: el_rpc_override, cl_rpc: cl_rpc_override, yes, json } =
         args;
-    let target = parse_add_target(&target)?;
+    let target = AddTarget::parse(&target)?;
 
     match target {
         AddTarget::Enode(enode) => {
@@ -147,7 +258,7 @@ async fn run_add_peer(config: MonitoringConfig, args: DestructivePeerArgs) -> Re
 async fn run_remove_peer(config: MonitoringConfig, args: DestructivePeerArgs) -> Result<()> {
     let DestructivePeerArgs { target, el_rpc: el_rpc_override, cl_rpc: cl_rpc_override, yes, json } =
         args;
-    let target = parse_peer_target(&target)?;
+    let target = PeerTarget::parse(&target)?;
 
     match target {
         PeerTarget::Enode(enode) => {
@@ -204,7 +315,7 @@ async fn run_peer_ban_action(
         BanAction::Ban => ("Ban", "p2p ban"),
         BanAction::Unban => ("Unban", "p2p unban"),
     };
-    match parse_peer_target(&target)? {
+    match PeerTarget::parse(&target)? {
         PeerTarget::Enode(enode) => {
             warn_ignored_rpc_override(
                 cl_rpc_override.as_ref(),
@@ -363,126 +474,169 @@ fn warn_ignored_rpc_override(
     }
 }
 
+/// Parsed peer target accepted by `basectl p2p add-peer`.
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum AddTarget {
+pub enum AddTarget {
+    /// Execution-layer enode target.
     Enode(String),
+    /// Consensus-layer multiaddr target.
     Multiaddr(String),
 }
 
+/// Parsed peer target accepted by remove, ban, and unban operations.
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum PeerTarget {
+pub enum PeerTarget {
+    /// Execution-layer enode target.
     Enode(String),
+    /// Consensus-layer libp2p peer ID.
     PeerId(String),
 }
 
-fn parse_add_target(raw: &str) -> Result<AddTarget, P2pTargetError> {
-    let target = raw.trim();
-    if target.is_empty() {
-        return Err(P2pTargetError::EmptyTarget);
-    }
-    if target.starts_with('/') {
-        if !target.contains("/p2p/") {
-            return Err(P2pTargetError::MultiaddrMissingPeerId { target: target.to_string() });
+impl AddTarget {
+    /// Parses an add-peer target and determines its execution or consensus layer.
+    pub fn parse(raw: &str) -> Result<Self, P2pTargetError> {
+        let target = raw.trim();
+        if target.is_empty() {
+            return Err(P2pTargetError::EmptyTarget);
         }
-        return Ok(AddTarget::Multiaddr(target.to_string()));
-    }
+        if target.starts_with('/') {
+            if !target.contains("/p2p/") {
+                return Err(P2pTargetError::MultiaddrMissingPeerId { target: target.to_string() });
+            }
+            return Ok(Self::Multiaddr(target.to_string()));
+        }
 
-    let bootnode = BootNode::parse_bootnode(target).map_err(|error| {
-        P2pTargetError::InvalidBootnode { target: target.to_string(), message: error.to_string() }
-    })?;
-    match &bootnode {
-        BootNode::Enode(_) => Ok(AddTarget::Enode(target.to_string())),
-        BootNode::Enr(_) => {
-            let multiaddr = bootnode.to_multiaddr().ok_or_else(|| {
-                P2pTargetError::EnrMissingMultiaddr { target: target.to_string() }
+        let bootnode =
+            BootNode::parse_bootnode(target).map_err(|error| P2pTargetError::InvalidBootnode {
+                target: target.to_string(),
+                message: error.to_string(),
             })?;
-            Ok(AddTarget::Multiaddr(multiaddr.to_string()))
+        match &bootnode {
+            BootNode::Enode(_) => Ok(Self::Enode(target.to_string())),
+            BootNode::Enr(_) => {
+                let multiaddr = bootnode.to_multiaddr().ok_or_else(|| {
+                    P2pTargetError::EnrMissingMultiaddr { target: target.to_string() }
+                })?;
+                Ok(Self::Multiaddr(multiaddr.to_string()))
+            }
         }
     }
 }
 
-fn parse_peer_target(raw: &str) -> Result<PeerTarget, P2pTargetError> {
-    let target = raw.trim();
-    if target.is_empty() {
-        return Err(P2pTargetError::EmptyTarget);
-    }
-    if target.starts_with("enr:") {
-        return Err(P2pTargetError::PeerActionEnrTarget { target: target.to_string() });
-    }
-    if target.split_whitespace().count() != 1 {
-        return Err(P2pTargetError::TargetContainsWhitespace { target: target.to_string() });
-    }
+impl PeerTarget {
+    /// Parses a remove, ban, or unban target and determines its peer layer.
+    pub fn parse(raw: &str) -> Result<Self, P2pTargetError> {
+        let target = raw.trim();
+        if target.is_empty() {
+            return Err(P2pTargetError::EmptyTarget);
+        }
+        if target.starts_with("enr:") {
+            return Err(P2pTargetError::PeerActionEnrTarget { target: target.to_string() });
+        }
+        if target.split_whitespace().count() != 1 {
+            return Err(P2pTargetError::TargetContainsWhitespace { target: target.to_string() });
+        }
 
-    if target.starts_with("enode://") {
-        BootNode::parse_bootnode(target).map_err(|error| P2pTargetError::InvalidBootnode {
-            target: target.to_string(),
-            message: error.to_string(),
-        })?;
-        return Ok(PeerTarget::Enode(target.to_string()));
-    }
-    if target.contains(':') || target.contains('/') {
-        return Err(P2pTargetError::PeerActionClTargetNotBarePeerId { target: target.to_string() });
-    }
-    if target.len() < MIN_LIBP2P_PEER_ID_LEN {
-        return Err(P2pTargetError::ClPeerIdTooShort {
-            target: target.to_string(),
-            min_len: MIN_LIBP2P_PEER_ID_LEN,
-        });
-    }
+        if target.starts_with("enode://") {
+            BootNode::parse_bootnode(target).map_err(|error| P2pTargetError::InvalidBootnode {
+                target: target.to_string(),
+                message: error.to_string(),
+            })?;
+            return Ok(Self::Enode(target.to_string()));
+        }
+        if target.contains(':') || target.contains('/') {
+            return Err(P2pTargetError::PeerActionClTargetNotBarePeerId {
+                target: target.to_string(),
+            });
+        }
+        if target.len() < MIN_LIBP2P_PEER_ID_LEN {
+            return Err(P2pTargetError::ClPeerIdTooShort {
+                target: target.to_string(),
+                min_len: MIN_LIBP2P_PEER_ID_LEN,
+            });
+        }
 
-    Ok(PeerTarget::PeerId(target.to_string()))
+        Ok(Self::PeerId(target.to_string()))
+    }
 }
 
+/// Structured JSON outcome for a peer-management action.
 #[derive(Debug, Clone, Serialize)]
 #[serde(untagged, rename_all = "camelCase")]
-enum PeerActionJson {
+pub enum PeerActionJson {
+    /// Execution-layer peer action outcome.
     El {
+        /// Selected network name.
         network: String,
+        /// Peer action performed.
         action: PeerAction,
+        /// Peer layer targeted.
         layer: PeerLayer,
+        /// Enode target.
         target: String,
+        /// Whether the execution client accepted the action.
         accepted: bool,
     },
+    /// Consensus-layer peer action outcome.
     Cl {
+        /// Selected network name.
         network: String,
+        /// Peer action performed.
         action: PeerAction,
+        /// Peer layer targeted.
         layer: PeerLayer,
+        /// Peer target.
         target: String,
+        /// Best-effort disconnect error after a successful ban.
         #[serde(rename = "disconnectError")]
         #[serde(skip_serializing_if = "Option::is_none")]
         disconnect_error: Option<String>,
     },
+    /// Consensus-layer bulk peer action outcome.
     ClBulk {
+        /// Selected network name.
         network: String,
+        /// Peer action performed.
         action: PeerAction,
+        /// Peer layer targeted.
         layer: PeerLayer,
+        /// Number of peers attempted.
         attempted: usize,
+        /// Number of successful actions.
         succeeded: usize,
+        /// Number of failed actions.
         failed: usize,
+        /// Per-peer action results.
         results: Vec<PeerBulkActionResultJson>,
     },
 }
 
+/// Peer-management action represented in command output.
 #[derive(Debug, Clone, Copy, Serialize)]
-enum PeerAction {
+pub enum PeerAction {
+    /// Add or connect a peer.
     #[serde(rename = "addPeer")]
     Add,
+    /// Remove or disconnect a peer.
     #[serde(rename = "removePeer")]
     Remove,
+    /// Ban a peer.
     #[serde(rename = "banPeer")]
     Ban,
+    /// Unban a peer.
     #[serde(rename = "unbanPeer")]
     Unban,
+    /// Unban every banned consensus peer.
     #[serde(rename = "unbanAll")]
     UnbanAll,
 }
 
-/// The two peer actions handled by `run_peer_ban_action`, so the shared handler
-/// is exhaustive over exactly the cases it supports rather than the wider
-/// `PeerAction`.
+/// Ban operation handled by the shared peer ban workflow.
 #[derive(Debug, Clone, Copy)]
-enum BanAction {
+pub enum BanAction {
+    /// Ban a peer.
     Ban,
+    /// Unban a peer.
     Unban,
 }
 
@@ -495,10 +649,13 @@ impl BanAction {
     }
 }
 
+/// Peer layer targeted by a p2p operation.
 #[derive(Debug, Clone, Copy, Serialize)]
-enum PeerLayer {
+pub enum PeerLayer {
+    /// Execution layer.
     #[serde(rename = "el")]
     El,
+    /// Consensus layer.
     #[serde(rename = "cl")]
     Cl,
 }
@@ -559,13 +716,17 @@ impl PeerActionJson {
     }
 }
 
+/// Structured result for one peer in a bulk peer action.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct PeerBulkActionResultJson {
-    target: String,
-    ok: bool,
+pub struct PeerBulkActionResultJson {
+    /// Peer target.
+    pub target: String,
+    /// Whether the action succeeded.
+    pub ok: bool,
+    /// Failure message when the action did not succeed.
     #[serde(skip_serializing_if = "Option::is_none")]
-    error: Option<String>,
+    pub error: Option<String>,
 }
 
 impl PeerBulkActionResultJson {
@@ -653,12 +814,16 @@ fn print_peer_action_pretty(action: &PeerActionJson) -> Result<()> {
     Ok(())
 }
 
+/// Humanized JSON shape for connected peers by layer.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct PeersJson {
-    network: String,
-    el: Option<Vec<PeerSummary>>,
-    cl: Option<Vec<PeerSummary>>,
+pub struct PeersJson {
+    /// Selected network name.
+    pub network: String,
+    /// Connected execution-layer peers, when the RPC exposes them.
+    pub el: Option<Vec<PeerSummary>>,
+    /// Connected consensus-layer peers, when the RPC exposes them.
+    pub cl: Option<Vec<PeerSummary>>,
 }
 
 impl PeersJson {
@@ -710,21 +875,20 @@ mod tests {
     use std::net::TcpListener;
 
     use alloy_primitives::Address;
-    use basectl_cli::{P2pCommandError, P2pCommands, P2pTargetError};
     use serde_json::json;
     use url::Url;
 
     use super::{
-        AddTarget, PeerAction, PeerActionJson, PeerBulkActionResultJson, PeerTarget,
-        fail_unban_all_if_partial, parse_add_target, parse_peer_target, resolve_cl_rpc, run,
-        run_reachability,
+        AddTarget, P2pCommand, P2pCommands, PeerAction, PeerActionJson, PeerBulkActionResultJson,
+        PeerTarget, fail_unban_all_if_partial, resolve_cl_rpc, run_reachability,
     };
+    use crate::{MonitoringConfig, P2pCommandError, P2pTargetError};
 
     const VALID_ENODE: &str = "enode://d7dfaea49c7ef37701e668652bcf1bc63d3abb2ae97593374a949e175e4ff128730a2f35199f3462a56298b981dfc395a5abebd2d6f0284ffe5bdc3d8e258b86@127.0.0.1:30304?discport=30301";
     const VALID_ENR: &str = "enr:-J64QBbwPjPLZ6IOOToOLsSjtFUjjzN66qmBZdUexpO32Klrc458Q24kbty2PdRaLacHM5z-cZQr8mjeQu3pik6jPSOGAYYFIqBfgmlkgnY0gmlwhDaRWFWHb3BzdGFja4SzlAUAiXNlY3AyNTZrMaECmeSnJh7zjKrDSPoNMGXoopeDF4hhpj5I0OsQUUt4u8uDdGNwgiQGg3VkcIIkBg";
 
-    fn test_config(consensus_node_rpc: Option<Url>) -> basectl_cli::MonitoringConfig {
-        basectl_cli::MonitoringConfig {
+    fn test_config(consensus_node_rpc: Option<Url>) -> MonitoringConfig {
+        MonitoringConfig {
             name: "devnet".to_string(),
             rpc: Url::parse("http://127.0.0.1:8545").unwrap(),
             flashblocks_ws: Url::parse("ws://127.0.0.1:7111").unwrap(),
@@ -779,9 +943,11 @@ mod tests {
 
     #[tokio::test]
     async fn reachability_loads_selected_monitoring_config() {
-        let command = P2pCommands::Reachability { enode: VALID_ENODE.to_string(), json: false };
+        let command = P2pCommand {
+            command: P2pCommands::Reachability { enode: VALID_ENODE.to_string(), json: false },
+        };
 
-        let error = run("/definitely/missing/basectl.yaml", command).await.unwrap_err();
+        let error = command.run("/definitely/missing/basectl.yaml").await.unwrap_err();
 
         assert!(
             error.to_string().starts_with("Config '/definitely/missing/basectl.yaml' not found")
@@ -806,14 +972,14 @@ mod tests {
     #[test]
     fn parse_add_target_routes_enode_to_el() {
         assert_eq!(
-            parse_add_target(VALID_ENODE).unwrap(),
+            AddTarget::parse(VALID_ENODE).unwrap(),
             AddTarget::Enode(VALID_ENODE.to_string())
         );
     }
 
     #[test]
     fn parse_add_target_routes_enr_to_cl_multiaddr() {
-        let AddTarget::Multiaddr(multiaddr) = parse_add_target(VALID_ENR).unwrap() else {
+        let AddTarget::Multiaddr(multiaddr) = AddTarget::parse(VALID_ENR).unwrap() else {
             panic!("expected ENR to route to CL multiaddr");
         };
 
@@ -824,7 +990,7 @@ mod tests {
     #[test]
     fn parse_add_target_rejects_garbage() {
         assert!(matches!(
-            parse_add_target("not-a-peer").unwrap_err(),
+            AddTarget::parse("not-a-peer").unwrap_err(),
             P2pTargetError::InvalidBootnode { target, .. } if target == "not-a-peer"
         ));
     }
@@ -834,14 +1000,14 @@ mod tests {
         let multiaddr = "/ip4/127.0.0.1/tcp/9000/p2p/16Uiu2HAmExample";
 
         assert_eq!(
-            parse_add_target(multiaddr).unwrap(),
+            AddTarget::parse(multiaddr).unwrap(),
             AddTarget::Multiaddr(multiaddr.to_string())
         );
     }
 
     #[test]
     fn parse_add_target_rejects_multiaddr_without_peer_id() {
-        let err = parse_add_target("/ip4/127.0.0.1/tcp/9000")
+        let err = AddTarget::parse("/ip4/127.0.0.1/tcp/9000")
             .expect_err("multiaddr without peer ID should be rejected");
 
         assert!(matches!(
@@ -854,7 +1020,7 @@ mod tests {
     #[test]
     fn parse_peer_target_routes_enode_to_el() {
         assert_eq!(
-            parse_peer_target(VALID_ENODE).unwrap(),
+            PeerTarget::parse(VALID_ENODE).unwrap(),
             PeerTarget::Enode(VALID_ENODE.to_string())
         );
     }
@@ -863,13 +1029,13 @@ mod tests {
     fn parse_peer_target_routes_peer_id_to_cl() {
         let peer_id = "16Uiu2HAkxp9nAsXsCthNWPkkpm4yG1eW7L4ENpVyzDZM8HE1yr12";
 
-        assert_eq!(parse_peer_target(peer_id).unwrap(), PeerTarget::PeerId(peer_id.to_string()));
+        assert_eq!(PeerTarget::parse(peer_id).unwrap(), PeerTarget::PeerId(peer_id.to_string()));
     }
 
     #[test]
     fn parse_peer_target_rejects_enr() {
         assert!(matches!(
-            parse_peer_target(VALID_ENR).unwrap_err(),
+            PeerTarget::parse(VALID_ENR).unwrap_err(),
             P2pTargetError::PeerActionEnrTarget { target } if target == VALID_ENR
         ));
     }
@@ -877,7 +1043,7 @@ mod tests {
     #[test]
     fn parse_peer_target_rejects_multiaddr() {
         assert!(matches!(
-            parse_peer_target("/ip4/127.0.0.1/tcp/9000/p2p/16Uiu2HAmExample").unwrap_err(),
+            PeerTarget::parse("/ip4/127.0.0.1/tcp/9000/p2p/16Uiu2HAmExample").unwrap_err(),
             P2pTargetError::PeerActionClTargetNotBarePeerId { .. }
         ));
     }
@@ -885,7 +1051,7 @@ mod tests {
     #[test]
     fn parse_peer_target_rejects_url_like_target() {
         assert!(matches!(
-            parse_peer_target("https://example.com").unwrap_err(),
+            PeerTarget::parse("https://example.com").unwrap_err(),
             P2pTargetError::PeerActionClTargetNotBarePeerId { target }
                 if target == "https://example.com"
         ));
@@ -893,7 +1059,7 @@ mod tests {
 
     #[test]
     fn parse_peer_target_rejects_obviously_short_peer_id() {
-        let err = parse_peer_target("hello").expect_err("short peer ID should be rejected");
+        let err = PeerTarget::parse("hello").expect_err("short peer ID should be rejected");
 
         assert!(matches!(
             err,
@@ -905,7 +1071,7 @@ mod tests {
     #[test]
     fn parse_peer_target_rejects_whitespace() {
         assert!(matches!(
-            parse_peer_target("16Uiu2HAkxp9nAsXsCthNWPkkpm4yG1eW7L4ENpVyzDZM8HE1yr12 extra")
+            PeerTarget::parse("16Uiu2HAkxp9nAsXsCthNWPkkpm4yG1eW7L4ENpVyzDZM8HE1yr12 extra")
                 .unwrap_err(),
             P2pTargetError::TargetContainsWhitespace { .. }
         ));

--- a/crates/infra/basectl/src/commands/p2p.rs
+++ b/crates/infra/basectl/src/commands/p2p.rs
@@ -124,14 +124,12 @@ pub struct DestructiveClBulkArgs {
 
 impl P2pCommand {
     /// Runs the selected `basectl p2p` operation.
-    pub async fn run(self, config: &str) -> Result<CommandOutcome> {
+    pub async fn run(self, config: MonitoringConfig) -> Result<CommandOutcome> {
         match self.command {
             P2pCommands::Reachability { enode, json } => {
-                let config = MonitoringConfig::load(config).await?;
                 run_reachability(&config, &enode, json).await
             }
             other => {
-                let config = MonitoringConfig::load(config).await?;
                 match other {
                     P2pCommands::Peers(args) => run_peers(config, args).await?,
                     P2pCommands::Info(args) => run_info(config, args).await?,
@@ -879,8 +877,8 @@ mod tests {
     use url::Url;
 
     use super::{
-        AddTarget, P2pCommand, P2pCommands, PeerAction, PeerActionJson, PeerBulkActionResultJson,
-        PeerTarget, fail_unban_all_if_partial, resolve_cl_rpc, run_reachability,
+        AddTarget, PeerAction, PeerActionJson, PeerBulkActionResultJson, PeerTarget,
+        fail_unban_all_if_partial, resolve_cl_rpc, run_reachability,
     };
     use crate::{MonitoringConfig, P2pCommandError, P2pTargetError};
 
@@ -939,19 +937,6 @@ mod tests {
                 ..
             } if config_name == "devnet" && command_name == "p2p info"
         ));
-    }
-
-    #[tokio::test]
-    async fn reachability_loads_selected_monitoring_config() {
-        let command = P2pCommand {
-            command: P2pCommands::Reachability { enode: VALID_ENODE.to_string(), json: false },
-        };
-
-        let error = command.run("/definitely/missing/basectl.yaml").await.unwrap_err();
-
-        assert!(
-            error.to_string().starts_with("Config '/definitely/missing/basectl.yaml' not found")
-        );
     }
 
     #[tokio::test]

--- a/crates/infra/basectl/src/commands/proofs.rs
+++ b/crates/infra/basectl/src/commands/proofs.rs
@@ -2,29 +2,154 @@
 
 use std::io::{self, Write};
 
+use alloy_primitives::B256;
 use anyhow::Result;
 use base_prover_service_protocol::{
     GetProofResponse, ListProofsRequest, ProofResult, ProofStatus, ProofSummary, ProofType,
     TeeKind, ZkVm,
 };
-use basectl_cli::{
-    CommandOutcome, Confirm, JsonOutput, KeyValueTable, MonitoringConfig, ProofFinalizeRequest,
-    ProofStatusFilter, ProofsClient, ProofsCommandError, ProofsCommands, ProofsFinalizeArgs,
-    ProofsListArgs, ProofsStatusArgs,
-};
+use clap::{Args, Subcommand, ValueEnum};
 use serde::Serialize;
 use tracing::info;
 use url::Url;
 
-/// Runs the `basectl proofs` command group.
-pub(crate) async fn run(
-    config: MonitoringConfig,
-    command: ProofsCommands,
-) -> Result<CommandOutcome> {
-    match command {
-        ProofsCommands::Finalize(args) => run_finalize(config, args).await,
-        ProofsCommands::Status(args) => run_status(config, args).await,
-        ProofsCommands::List(args) => run_list(config, args).await,
+use crate::{
+    CommandOutcome, Confirm, JsonOutput, KeyValueTable, MonitoringConfig, ProofFinalizeRequest,
+    ProofsClient, ProofsCommandError,
+};
+
+/// Request and inspect ZK proofs on the internal prover service.
+#[derive(Debug, Args)]
+pub struct ProofsCommand {
+    /// Proof operation to run.
+    #[command(subcommand)]
+    pub command: ProofsCommands,
+}
+
+/// Prover-service proof request and inspection commands.
+#[derive(Debug, Subcommand)]
+pub enum ProofsCommands {
+    /// Submit a compressed ZK proof request for a block range to speed up finality.
+    Finalize(ProofsFinalizeArgs),
+    /// Show status and result data for a submitted proof request.
+    Status(ProofsStatusArgs),
+    /// List submitted proof requests.
+    List(ProofsListArgs),
+}
+
+/// Flags for `basectl proofs finalize`.
+#[derive(Debug, Args)]
+pub struct ProofsFinalizeArgs {
+    /// First L2 block number to prove.
+    #[arg(value_name = "START_BLOCK")]
+    pub start_block: u64,
+    /// Number of consecutive L2 blocks to prove.
+    #[arg(value_name = "NUM_BLOCKS", value_parser = clap::value_parser!(u64).range(1..))]
+    pub num_blocks: u64,
+    /// Explicit proof session ID (prover-service idempotency key).
+    ///
+    /// If omitted, basectl derives a deterministic session ID from the
+    /// network name and block range, so re-running the same command resolves
+    /// to the existing prover-service session instead of enqueueing a
+    /// duplicate proof.
+    #[arg(long = "session-id", value_name = "ID")]
+    pub session_id: Option<String>,
+    /// L1 head hash used for witness generation.
+    ///
+    /// If omitted, the prover service picks one.
+    #[arg(long = "l1-head", value_name = "HASH")]
+    pub l1_head: Option<B256>,
+    /// Sequencing window passed to the prover.
+    #[arg(long = "sequence-window", value_name = "N")]
+    pub sequence_window: Option<u64>,
+    /// Intermediate output root interval passed to the prover.
+    #[arg(long = "intermediate-root-interval", value_name = "N")]
+    pub intermediate_root_interval: Option<u64>,
+    /// Poll the prover service until the proof succeeds or fails.
+    ///
+    /// Exits non-zero when the proof fails or does not complete in time.
+    #[arg(long)]
+    pub wait: bool,
+    /// Prover-service RPC URL (also `BASECTL_PROVER_RPC` or config `prover_rpc`).
+    #[arg(long = "prover-rpc", env = "BASECTL_PROVER_RPC", value_name = "URL")]
+    pub prover_rpc: Option<Url>,
+    /// Skip the interactive confirmation prompt.
+    #[arg(long)]
+    pub yes: bool,
+    /// Emit a structured JSON action outcome instead of pretty text.
+    #[arg(long, requires = "yes")]
+    pub json: bool,
+}
+
+/// Flags for `basectl proofs status`.
+#[derive(Debug, Args)]
+pub struct ProofsStatusArgs {
+    /// Proof session ID returned by `basectl proofs finalize`.
+    #[arg(value_name = "SESSION_ID")]
+    pub session_id: String,
+    /// Prover-service RPC URL (also `BASECTL_PROVER_RPC` or config `prover_rpc`).
+    #[arg(long = "prover-rpc", env = "BASECTL_PROVER_RPC", value_name = "URL")]
+    pub prover_rpc: Option<Url>,
+    /// Emit humanized JSON instead of pretty text.
+    #[arg(long)]
+    pub json: bool,
+    /// With `--json`, emit the prover-service wire shape instead of the humanized summary.
+    #[arg(long, requires = "json")]
+    pub raw: bool,
+}
+
+/// Flags for `basectl proofs list`.
+#[derive(Debug, Args)]
+pub struct ProofsListArgs {
+    /// Only list proofs with this status.
+    #[arg(long, value_enum, value_name = "STATUS")]
+    pub status: Option<ProofStatusFilter>,
+    /// Number of rows to skip.
+    #[arg(long, value_name = "N", default_value_t = 0)]
+    pub offset: u64,
+    /// Maximum rows to return.
+    #[arg(long, value_name = "N", default_value_t = 50)]
+    pub limit: u32,
+    /// Prover-service RPC URL (also `BASECTL_PROVER_RPC` or config `prover_rpc`).
+    #[arg(long = "prover-rpc", env = "BASECTL_PROVER_RPC", value_name = "URL")]
+    pub prover_rpc: Option<Url>,
+    /// Emit humanized JSON instead of pretty text.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// Proof status filter accepted by `basectl proofs list`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ProofStatusFilter {
+    /// Proof request is queued.
+    Queued,
+    /// Proof request is running.
+    Running,
+    /// Proof request completed successfully.
+    Succeeded,
+    /// Proof request failed.
+    Failed,
+}
+
+impl From<ProofStatusFilter> for ProofStatus {
+    fn from(filter: ProofStatusFilter) -> Self {
+        match filter {
+            ProofStatusFilter::Queued => Self::Queued,
+            ProofStatusFilter::Running => Self::Running,
+            ProofStatusFilter::Succeeded => Self::Succeeded,
+            ProofStatusFilter::Failed => Self::Failed,
+        }
+    }
+}
+
+impl ProofsCommand {
+    /// Runs the selected proof operation and renders its output.
+    pub async fn run(self, config: MonitoringConfig) -> Result<CommandOutcome> {
+        match self.command {
+            ProofsCommands::Finalize(args) => run_finalize(config, args).await,
+            ProofsCommands::Status(args) => run_status(config, args).await,
+            ProofsCommands::List(args) => run_list(config, args).await,
+        }
     }
 }
 
@@ -150,7 +275,7 @@ async fn run_status(config: MonitoringConfig, args: ProofsStatusArgs) -> Result<
 async fn run_list(config: MonitoringConfig, args: ProofsListArgs) -> Result<CommandOutcome> {
     let ProofsListArgs { status, offset, limit, prover_rpc, json } = args;
     let endpoint = resolve_prover_rpc(&config, prover_rpc)?;
-    let status_filter = status.map(proof_status_from_filter);
+    let status_filter = status.map(ProofStatus::from);
     info!(
         network = %config.name,
         prover_rpc = %endpoint,
@@ -181,58 +306,35 @@ async fn run_list(config: MonitoringConfig, args: ProofsListArgs) -> Result<Comm
     Ok(CommandOutcome::Success)
 }
 
-/// Maps the CLI status filter to the prover-service protocol status.
-const fn proof_status_from_filter(filter: ProofStatusFilter) -> ProofStatus {
-    match filter {
-        ProofStatusFilter::Queued => ProofStatus::Queued,
-        ProofStatusFilter::Running => ProofStatus::Running,
-        ProofStatusFilter::Succeeded => ProofStatus::Succeeded,
-        ProofStatusFilter::Failed => ProofStatus::Failed,
-    }
-}
-
-/// Returns the CLI label for a proof type.
-const fn proof_type_label(proof_type: ProofType) -> &'static str {
-    match proof_type {
-        ProofType::Compressed => "compressed",
-        ProofType::SnarkPlonk => "snark_plonk",
-        ProofType::Tee => "tee",
-    }
-}
-
-/// Returns the CLI label for a ZK virtual machine.
-const fn zk_vm_label(zk_vm: ZkVm) -> &'static str {
-    match zk_vm {
-        ZkVm::Sp1 => "sp1",
-    }
-}
-
-/// Returns the CLI label for a TEE implementation.
-const fn tee_kind_label(tee_kind: TeeKind) -> &'static str {
-    match tee_kind {
-        TeeKind::AwsNitro => "aws_nitro",
-    }
-}
-
 /// Humanized JSON shape for a `basectl proofs finalize` outcome.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct ProofsFinalizeJson {
-    network: String,
-    prover_rpc: String,
-    session_id: String,
-    start_block: u64,
-    end_block: u64,
-    num_blocks: u64,
-    status: &'static str,
+pub struct ProofsFinalizeJson {
+    /// Selected network name.
+    pub network: String,
+    /// Prover-service RPC endpoint.
+    pub prover_rpc: String,
+    /// Prover-service session identifier.
+    pub session_id: String,
+    /// First L2 block in the proof range.
+    pub start_block: u64,
+    /// Last L2 block in the inclusive proof range.
+    pub end_block: u64,
+    /// Number of consecutive L2 blocks in the proof range.
+    pub num_blocks: u64,
+    /// Current proof request status.
+    pub status: &'static str,
+    /// Prover-service failure message, when present.
     #[serde(skip_serializing_if = "Option::is_none")]
-    error_message: Option<String>,
+    pub error_message: Option<String>,
+    /// Humanized proof result, when the proof has completed successfully.
     #[serde(skip_serializing_if = "Option::is_none")]
-    result: Option<ProofResultJson>,
+    pub result: Option<ProofResultJson>,
 }
 
 impl ProofsFinalizeJson {
-    fn submitted(
+    /// Builds the outcome for an accepted proof request that is not being awaited.
+    pub fn submitted(
         network: &str,
         prover_rpc: &Url,
         session_id: &str,
@@ -252,7 +354,8 @@ impl ProofsFinalizeJson {
         }
     }
 
-    fn completed(
+    /// Builds the outcome for a proof request after completion polling.
+    pub fn completed(
         network: &str,
         prover_rpc: &Url,
         session_id: &str,
@@ -272,19 +375,26 @@ impl ProofsFinalizeJson {
 /// Humanized JSON shape for `basectl proofs status`.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct ProofsStatusJson {
-    network: String,
-    prover_rpc: String,
-    session_id: String,
-    status: &'static str,
+pub struct ProofsStatusJson {
+    /// Selected network name.
+    pub network: String,
+    /// Prover-service RPC endpoint.
+    pub prover_rpc: String,
+    /// Prover-service session identifier.
+    pub session_id: String,
+    /// Current proof request status.
+    pub status: &'static str,
+    /// Prover-service failure message, when present.
     #[serde(skip_serializing_if = "Option::is_none")]
-    error_message: Option<String>,
+    pub error_message: Option<String>,
+    /// Humanized proof result, when the proof has completed successfully.
     #[serde(skip_serializing_if = "Option::is_none")]
-    result: Option<ProofResultJson>,
+    pub result: Option<ProofResultJson>,
 }
 
 impl ProofsStatusJson {
-    fn from_response(
+    /// Builds a humanized status from a prover-service response.
+    pub fn from_response(
         network: &str,
         prover_rpc: &Url,
         session_id: &str,
@@ -304,37 +414,56 @@ impl ProofsStatusJson {
 /// Humanized summary of a proof result payload.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct ProofResultJson {
-    proof_type: &'static str,
+pub struct ProofResultJson {
+    /// Kind of proof returned by the prover service.
+    pub proof_type: &'static str,
+    /// ZK virtual machine used for a ZK proof.
     #[serde(skip_serializing_if = "Option::is_none")]
-    zk_vm: Option<&'static str>,
+    pub zk_vm: Option<&'static str>,
+    /// Trusted execution environment used for a TEE proof.
     #[serde(skip_serializing_if = "Option::is_none")]
-    tee_kind: Option<&'static str>,
+    pub tee_kind: Option<&'static str>,
+    /// Encoded proof payload size in bytes, when applicable.
     #[serde(skip_serializing_if = "Option::is_none")]
-    proof_bytes: Option<usize>,
+    pub proof_bytes: Option<usize>,
 }
 
 impl ProofResultJson {
-    fn from_result(result: &ProofResult) -> Self {
+    /// Builds a humanized summary from a prover-service proof result.
+    pub fn from_result(result: &ProofResult) -> Self {
         match result {
             ProofResult::Compressed(zk) => Self {
                 proof_type: "compressed",
-                zk_vm: Some(zk_vm_label(zk.zk_vm)),
+                zk_vm: Some(Self::zk_vm_label(zk.zk_vm)),
                 tee_kind: None,
                 proof_bytes: Some(zk.proof.len()),
             },
             ProofResult::SnarkPlonk(plonk) => Self {
                 proof_type: "snark_plonk",
-                zk_vm: Some(zk_vm_label(plonk.proof.zk_vm)),
+                zk_vm: Some(Self::zk_vm_label(plonk.proof.zk_vm)),
                 tee_kind: None,
                 proof_bytes: Some(plonk.proof.proof.len()),
             },
             ProofResult::Tee(tee) => Self {
                 proof_type: "tee",
                 zk_vm: None,
-                tee_kind: Some(tee_kind_label(tee.tee_kind)),
+                tee_kind: Some(Self::tee_kind_label(tee.tee_kind)),
                 proof_bytes: None,
             },
+        }
+    }
+
+    /// Returns the CLI label for a ZK virtual machine.
+    pub const fn zk_vm_label(zk_vm: ZkVm) -> &'static str {
+        match zk_vm {
+            ZkVm::Sp1 => "sp1",
+        }
+    }
+
+    /// Returns the CLI label for a TEE implementation.
+    pub const fn tee_kind_label(tee_kind: TeeKind) -> &'static str {
+        match tee_kind {
+            TeeKind::AwsNitro => "aws_nitro",
         }
     }
 }
@@ -342,19 +471,27 @@ impl ProofResultJson {
 /// Humanized JSON shape for `basectl proofs list`.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct ProofsListJson {
-    network: String,
-    prover_rpc: String,
-    offset: u64,
-    limit: u32,
+pub struct ProofsListJson {
+    /// Selected network name.
+    pub network: String,
+    /// Prover-service RPC endpoint.
+    pub prover_rpc: String,
+    /// Number of matching rows skipped by the request.
+    pub offset: u64,
+    /// Maximum number of rows requested.
+    pub limit: u32,
+    /// Requested proof status filter, when present.
     #[serde(skip_serializing_if = "Option::is_none")]
-    status_filter: Option<&'static str>,
-    total_count: u64,
-    proofs: Vec<ProofSummaryJson>,
+    pub status_filter: Option<&'static str>,
+    /// Total number of matching proof requests.
+    pub total_count: u64,
+    /// Humanized summaries returned for this page.
+    pub proofs: Vec<ProofSummaryJson>,
 }
 
 impl ProofsListJson {
-    fn from_response(
+    /// Builds a humanized proof list from a prover-service response.
+    pub fn from_response(
         network: &str,
         prover_rpc: &Url,
         offset: u64,
@@ -378,34 +515,53 @@ impl ProofsListJson {
 /// Humanized JSON row for one submitted proof request.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct ProofSummaryJson {
-    session_id: String,
-    proof_type: &'static str,
-    status: &'static str,
-    created_at: String,
-    updated_at: String,
+pub struct ProofSummaryJson {
+    /// Prover-service session identifier.
+    pub session_id: String,
+    /// Requested proof type.
+    pub proof_type: &'static str,
+    /// Current proof request status.
+    pub status: &'static str,
+    /// Request creation timestamp in RFC 3339 format.
+    pub created_at: String,
+    /// Most recent update timestamp in RFC 3339 format.
+    pub updated_at: String,
+    /// Completion timestamp in RFC 3339 format, when complete.
     #[serde(skip_serializing_if = "Option::is_none")]
-    completed_at: Option<String>,
+    pub completed_at: Option<String>,
+    /// Prover-service failure message, when present.
     #[serde(skip_serializing_if = "Option::is_none")]
-    error_message: Option<String>,
+    pub error_message: Option<String>,
+    /// Trusted execution environment requested for a TEE proof.
     #[serde(skip_serializing_if = "Option::is_none")]
-    tee_kind: Option<&'static str>,
+    pub tee_kind: Option<&'static str>,
+    /// ZK virtual machine requested for a ZK proof.
     #[serde(skip_serializing_if = "Option::is_none")]
-    zk_vm: Option<&'static str>,
+    pub zk_vm: Option<&'static str>,
 }
 
 impl ProofSummaryJson {
-    fn from_summary(summary: &ProofSummary) -> Self {
+    /// Builds a humanized row from a prover-service proof summary.
+    pub fn from_summary(summary: &ProofSummary) -> Self {
         Self {
             session_id: summary.session_id.clone(),
-            proof_type: proof_type_label(summary.proof_type),
+            proof_type: Self::proof_type_label(summary.proof_type),
             status: ProofsClient::status_label(summary.status),
             created_at: summary.created_at.to_rfc3339(),
             updated_at: summary.updated_at.to_rfc3339(),
             completed_at: summary.completed_at.map(|at| at.to_rfc3339()),
             error_message: summary.error_message.clone(),
-            tee_kind: summary.tee_kind.map(tee_kind_label),
-            zk_vm: summary.zk_vm.map(zk_vm_label),
+            tee_kind: summary.tee_kind.map(ProofResultJson::tee_kind_label),
+            zk_vm: summary.zk_vm.map(ProofResultJson::zk_vm_label),
+        }
+    }
+
+    /// Returns the CLI label for a proof type.
+    pub const fn proof_type_label(proof_type: ProofType) -> &'static str {
+        match proof_type {
+            ProofType::Compressed => "compressed",
+            ProofType::SnarkPlonk => "snark_plonk",
+            ProofType::Tee => "tee",
         }
     }
 }
@@ -518,7 +674,8 @@ fn print_list_pretty_to<W: Write>(writer: &mut W, list: &ProofsListJson) -> Resu
 #[cfg(test)]
 mod tests {
     use base_prover_service_protocol::{
-        GetProofResponse, ProofResult, ProofStatus, ProofSummary, ProofType, ZkProofResult, ZkVm,
+        GetProofResponse, ProofResult, ProofStatus, ProofSummary, ProofType, SnarkPlonkProofResult,
+        ZkProofResult, ZkVm,
     };
     use url::Url;
 
@@ -703,8 +860,6 @@ mod tests {
 
     #[test]
     fn snark_plonk_result_json_shape() {
-        use base_prover_service_protocol::SnarkPlonkProofResult;
-
         let result =
             ProofResultJson::from_result(&ProofResult::SnarkPlonk(SnarkPlonkProofResult {
                 proof: ZkProofResult {

--- a/crates/infra/basectl/src/commands/txpool.rs
+++ b/crates/infra/basectl/src/commands/txpool.rs
@@ -4,22 +4,86 @@ use std::io::{self, Write};
 
 use alloy_primitives::{Address, TxHash};
 use anyhow::Result;
-use basectl_cli::{
-    Confirm, JsonOutput, KeyValueTable, MonitoringConfig, TxpoolClearArgs, TxpoolClient,
-    TxpoolCommands, TxpoolCounts, TxpoolReadArgs, TxpoolReport, TxpoolScope, TxpoolSenderSummary,
-    TxpoolTransactionRow, format_gas, format_gwei,
-};
+use clap::{Args, Subcommand};
 use serde::Serialize;
 use tracing::{debug, info, warn};
 use url::Url;
 
-/// Runs the `basectl txpool` command group.
-pub(crate) async fn run(config: MonitoringConfig, command: TxpoolCommands) -> Result<()> {
-    match command {
-        TxpoolCommands::Pending(args) => run_read(config, TxpoolScope::Pending, args).await,
-        TxpoolCommands::Queued(args) => run_read(config, TxpoolScope::Queued, args).await,
-        TxpoolCommands::All(args) => run_read(config, TxpoolScope::All, args).await,
-        TxpoolCommands::Clear(args) => run_clear(config, args).await,
+use crate::{
+    Confirm, JsonOutput, KeyValueTable, MonitoringConfig, TxpoolClient, TxpoolCounts, TxpoolReport,
+    TxpoolScope, TxpoolSenderSummary, TxpoolTransactionRow, format_gas, format_gwei,
+};
+
+/// Inspect and clear execution-layer txpool contents.
+#[derive(Debug, Args)]
+pub struct TxpoolCommand {
+    /// Txpool operation to run.
+    #[command(subcommand)]
+    pub command: TxpoolCommands,
+}
+
+/// Transaction-pool inspection and destructive clearing commands.
+#[derive(Debug, Subcommand)]
+pub enum TxpoolCommands {
+    /// Show pending txpool transactions.
+    Pending(TxpoolReadArgs),
+    /// Show queued txpool transactions.
+    Queued(TxpoolReadArgs),
+    /// Show pending and queued txpool transactions.
+    All(TxpoolReadArgs),
+    /// Clear the txpool or drop every transaction for one sender.
+    Clear(TxpoolClearArgs),
+}
+
+/// Shared flags for read-only `basectl txpool` subcommands.
+#[derive(Debug, Args)]
+pub struct TxpoolReadArgs {
+    /// Optional sender address to filter at the RPC layer.
+    #[arg(value_name = "SENDER")]
+    pub sender: Option<Address>,
+    /// Override the execution-layer RPC URL.
+    ///
+    /// Defaults to the chain config's `rpc` field. Pass this flag to query a
+    /// single node directly.
+    #[arg(long = "el-rpc", value_name = "URL")]
+    pub el_rpc: Option<Url>,
+    /// Emit humanized JSON instead of pretty text.
+    #[arg(long)]
+    pub json: bool,
+    /// With `--json`, emit the txpool wire shape instead of the humanized summary.
+    #[arg(long, requires = "json")]
+    pub raw: bool,
+}
+
+/// Flags for destructive `basectl txpool clear`.
+#[derive(Debug, Args)]
+pub struct TxpoolClearArgs {
+    /// Sender address whose txpool transactions should be dropped.
+    #[arg(long, value_name = "ADDRESS")]
+    pub sender: Option<Address>,
+    /// Override the execution-layer RPC URL.
+    ///
+    /// Defaults to the chain config's `rpc` field. Destructive txpool calls
+    /// usually require an admin-enabled node RPC.
+    #[arg(long = "el-rpc", value_name = "URL")]
+    pub el_rpc: Option<Url>,
+    /// Skip the interactive confirmation prompt.
+    #[arg(long)]
+    pub yes: bool,
+    /// Emit a structured JSON action outcome instead of pretty text.
+    #[arg(long, requires = "yes")]
+    pub json: bool,
+}
+
+impl TxpoolCommand {
+    /// Runs the selected txpool subcommand.
+    pub async fn run(self, config: MonitoringConfig) -> Result<()> {
+        match self.command {
+            TxpoolCommands::Pending(args) => run_read(config, TxpoolScope::Pending, args).await,
+            TxpoolCommands::Queued(args) => run_read(config, TxpoolScope::Queued, args).await,
+            TxpoolCommands::All(args) => run_read(config, TxpoolScope::All, args).await,
+            TxpoolCommands::Clear(args) => run_clear(config, args).await,
+        }
     }
 }
 
@@ -28,19 +92,18 @@ async fn run_read(
     scope: TxpoolScope,
     args: TxpoolReadArgs,
 ) -> Result<()> {
-    let TxpoolReadArgs { sender, el_rpc: el_rpc_override, json, raw } = args;
-    let el_rpc = el_rpc_override.unwrap_or_else(|| config.rpc.clone());
+    let el_rpc = args.el_rpc.unwrap_or_else(|| config.rpc.clone());
     info!(
         network = %config.name,
         rpc = %el_rpc,
         scope = %scope.as_str(),
-        sender = ?sender,
-        json,
-        raw,
+        sender = ?args.sender,
+        json = args.json,
+        raw = args.raw,
         "fetching txpool content"
     );
 
-    match (json, raw, sender) {
+    match (args.json, args.raw, args.sender) {
         (true, true, Some(sender)) => {
             let mut content = TxpoolClient::fetch_txpool_content_from(&el_rpc, sender)
                 .await
@@ -131,21 +194,20 @@ async fn run_read(
 }
 
 async fn run_clear(config: MonitoringConfig, args: TxpoolClearArgs) -> Result<()> {
-    let TxpoolClearArgs { sender, el_rpc: el_rpc_override, yes, json } = args;
-    let el_rpc = el_rpc_override.unwrap_or_else(|| config.rpc.clone());
+    let el_rpc = args.el_rpc.unwrap_or_else(|| config.rpc.clone());
     info!(
         network = %config.name,
         rpc = %el_rpc,
-        sender = ?sender,
-        json,
-        yes,
+        sender = ?args.sender,
+        json = args.json,
+        yes = args.yes,
         "running txpool clear command"
     );
 
-    match sender {
+    match args.sender {
         Some(sender) => {
             let prompt = format!("Drop txpool transactions from {sender} through {el_rpc}? [y/N] ");
-            if !Confirm::prompt_or_abort(&prompt, yes)? {
+            if !Confirm::prompt_or_abort(&prompt, args.yes)? {
                 debug!(
                     network = %config.name,
                     rpc = %el_rpc,
@@ -166,7 +228,7 @@ async fn run_clear(config: MonitoringConfig, args: TxpoolClearArgs) -> Result<()
                     );
                 })?;
             let action = TxpoolClearJson::drop_sender(&config.name, &el_rpc, sender, hashes);
-            print_clear_action(&action, json)?;
+            print_clear_action(&action, args.json)?;
             info!(
                 network = %config.name,
                 rpc = %el_rpc,
@@ -177,7 +239,7 @@ async fn run_clear(config: MonitoringConfig, args: TxpoolClearArgs) -> Result<()
         }
         None => {
             let prompt = format!("Clear all txpool transactions through {el_rpc}? [y/N] ");
-            if !Confirm::prompt_or_abort(&prompt, yes)? {
+            if !Confirm::prompt_or_abort(&prompt, args.yes)? {
                 debug!(
                     network = %config.name,
                     rpc = %el_rpc,
@@ -194,7 +256,7 @@ async fn run_clear(config: MonitoringConfig, args: TxpoolClearArgs) -> Result<()
                 );
             })?;
             let action = TxpoolClearJson::clear(&config.name, &el_rpc, removed);
-            print_clear_action(&action, json)?;
+            print_clear_action(&action, args.json)?;
             info!(
                 network = %config.name,
                 rpc = %el_rpc,
@@ -207,21 +269,30 @@ async fn run_clear(config: MonitoringConfig, args: TxpoolClearArgs) -> Result<()
     Ok(())
 }
 
+/// Humanized JSON shape for read-only `basectl txpool` output.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct TxpoolReadJson {
-    network: String,
-    rpc: String,
-    scope: TxpoolScope,
+pub struct TxpoolReadJson {
+    /// Selected network name.
+    pub network: String,
+    /// Execution-layer RPC URL that was queried.
+    pub rpc: String,
+    /// Txpool scope that was requested.
+    pub scope: TxpoolScope,
+    /// Optional sender filter applied to the report.
     #[serde(skip_serializing_if = "Option::is_none")]
-    sender: Option<Address>,
-    counts: TxpoolCounts,
-    senders: Vec<TxpoolSenderSummary>,
-    transactions: Vec<TxpoolTransactionRow>,
+    pub sender: Option<Address>,
+    /// Aggregate pending/queued/total counts for the report.
+    pub counts: TxpoolCounts,
+    /// Per-sender summaries included in the report.
+    pub senders: Vec<TxpoolSenderSummary>,
+    /// Individual transaction rows included in the report.
+    pub transactions: Vec<TxpoolTransactionRow>,
 }
 
 impl TxpoolReadJson {
-    fn from_report(network: &str, rpc: &Url, report: &TxpoolReport) -> Self {
+    /// Builds a humanized read response from a txpool report.
+    pub fn from_report(network: &str, rpc: &Url, report: &TxpoolReport) -> Self {
         Self {
             network: network.to_string(),
             rpc: rpc.to_string(),
@@ -234,28 +305,45 @@ impl TxpoolReadJson {
     }
 }
 
+/// Structured JSON outcome for destructive `basectl txpool clear` actions.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase", tag = "action")]
-enum TxpoolClearJson {
+pub enum TxpoolClearJson {
+    /// Cleared every transaction currently in the txpool.
     #[serde(rename = "clearTxpool")]
-    Clear { network: String, rpc: String, removed: u64 },
+    Clear {
+        /// Selected network name.
+        network: String,
+        /// Execution-layer RPC URL that performed the clear.
+        rpc: String,
+        /// Number of transactions removed.
+        removed: u64,
+    },
+    /// Dropped every txpool transaction belonging to one sender.
     #[serde(rename = "dropSenderTransactions")]
     DropSender {
+        /// Selected network name.
         network: String,
+        /// Execution-layer RPC URL that performed the drop.
         rpc: String,
+        /// Sender whose transactions were dropped.
         sender: Address,
+        /// Number of transactions removed.
         removed: u64,
+        /// Transaction hashes that were dropped.
         #[serde(skip_serializing_if = "Vec::is_empty")]
         hashes: Vec<TxHash>,
     },
 }
 
 impl TxpoolClearJson {
-    fn clear(network: &str, rpc: &Url, removed: u64) -> Self {
+    /// Builds a clear-all action outcome.
+    pub fn clear(network: &str, rpc: &Url, removed: u64) -> Self {
         Self::Clear { network: network.to_string(), rpc: rpc.to_string(), removed }
     }
 
-    fn drop_sender(network: &str, rpc: &Url, sender: Address, hashes: Vec<TxHash>) -> Self {
+    /// Builds a drop-sender action outcome from the dropped transaction hashes.
+    pub fn drop_sender(network: &str, rpc: &Url, sender: Address, hashes: Vec<TxHash>) -> Self {
         let removed = u64::try_from(hashes.len()).unwrap_or(u64::MAX);
         Self::DropSender {
             network: network.to_string(),
@@ -387,16 +475,16 @@ fn print_clear_action_pretty(action: &TxpoolClearJson) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{B256, address};
-    use basectl_cli::{
-        TxpoolCounts, TxpoolReport, TxpoolScope, TxpoolSenderSummary, TxpoolTransactionPool,
-        TxpoolTransactionRow,
-    };
     use serde_json::json;
     use url::Url;
 
     use super::{
         TxpoolClearJson, TxpoolReadJson, format_destination, format_nonce_range,
         format_transaction_fee, print_read_pretty_to,
+    };
+    use crate::{
+        TxpoolCounts, TxpoolReport, TxpoolScope, TxpoolSenderSummary, TxpoolTransactionPool,
+        TxpoolTransactionRow,
     };
 
     fn sample_report() -> TxpoolReport {

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -2,13 +2,16 @@
 
 mod commands;
 pub use commands::{
-    BlockCommand, BlockSummaryJson, Cli, Commands, ConductorClusterActionArgs, ConductorCommands,
-    ConductorLeaderArgs, ConductorNodeActionArgs, ConductorStatusArgs, DestructiveClBulkArgs,
-    DestructivePeerArgs, DoctorCommand, ElSyncInfoJson, HeadJson, MonitorCommands, P2pArgs,
-    P2pCommands, ProofStatusFilter, ProofsCommands, ProofsFinalizeArgs, ProofsListArgs,
-    ProofsStatusArgs, SequencerCommands, SequencerNodeActionArgs, SequencerStartArgs,
-    SequencerStatusArgs, SyncStatusCommand, SyncStatusJson, TipReferenceJson, TipStatus,
-    TxpoolClearArgs, TxpoolCommands, TxpoolReadArgs,
+    AddTarget, BanAction, BlockCommand, BlockSummaryJson, Cli, Commands,
+    ConductorClusterActionArgs, ConductorCommands, ConductorLeaderArgs, ConductorNodeActionArgs,
+    ConductorStatusArgs, DestructiveClBulkArgs, DestructivePeerArgs, DoctorCommand, ElSyncInfoJson,
+    HeadJson, MonitorCommands, P2pArgs, P2pCommand, P2pCommands, PeerAction, PeerActionJson,
+    PeerBulkActionResultJson, PeerLayer, PeerTarget, PeersJson, ProofResultJson, ProofStatusFilter,
+    ProofSummaryJson, ProofsCommand, ProofsCommands, ProofsFinalizeArgs, ProofsFinalizeJson,
+    ProofsListArgs, ProofsListJson, ProofsStatusArgs, ProofsStatusJson, SequencerCommands,
+    SequencerNodeActionArgs, SequencerStartArgs, SequencerStatusArgs, SyncStatusCommand,
+    SyncStatusJson, TipReferenceJson, TipStatus, TxpoolClearArgs, TxpoolClearJson, TxpoolCommand,
+    TxpoolCommands, TxpoolReadArgs, TxpoolReadJson,
 };
 
 mod confirm;


### PR DESCRIPTION
## Summary
- Move txpool, p2p, and proofs command logic from the binary into `basectl-cli`
- Re-export command arguments and output types from the library
- Remove binary dependencies no longer needed after the migration
## Test Plan
- [x] `cargo nextest run -p basectl -p basectl-cli`
- [x] `just check::clippy`
- [x] `just check::udeps`
- [x] Verify txpool, p2p, and proofs help output
## Breaking Changes
None.