### PR TITLE
fix(registrar): probe readyz to break registration health deadlock

### DIFF
--- a/bin/prover/nitro-host/README.md
+++ b/bin/prover/nitro-host/README.md
@@ -37,8 +37,8 @@ The `just tee nitro-local-worker` recipe wraps the same command.
 The registrar-facing RPC server exposes:
 
 - `GET /readyz` returns 200 once the host HTTP server is accepting requests. It
-  does not require an onchain-registered signer, so registrar target groups
-  should use it to bootstrap new instances.
+  does not require an onchain-registered signer, so the registrar probes it to
+  bootstrap new instances without depending on registration-gated health.
 - When `TEE_PROVER_REGISTRY_ADDRESS` is configured, `GET /healthz` requires a
   valid onchain signer.
 

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -10,11 +10,11 @@
 //!
 //! After a signer deregistration or image rotation the health latch stays set
 //! while the proving guard rejects every request.  The prover will continue
-//! returning 200 from `/healthz` but respond with `-32001` errors. Registrar
-//! target groups use `/readyz`, so their eligibility is independent of this
-//! latch. If another deployment uses `/healthz` as its **sole** load-balancer
-//! signal with no retry layer, switch to a bounded latch (e.g. stay healthy for
-//! N minutes after the last successful validation).
+//! returning 200 from `/healthz` but respond with `-32001` errors. The
+//! registrar probes `/readyz` (not registration-gated) so bootstrap stays
+//! independent of this latch. If another deployment uses `/healthz` as its
+//! **sole** load-balancer signal with no retry layer, switch to a bounded latch
+//! (e.g. stay healthy for N minutes after the last successful validation).
 
 use std::{sync::Arc, time::Duration};
 

--- a/crates/proof/tee/nitro-host/src/server.rs
+++ b/crates/proof/tee/nitro-host/src/server.rs
@@ -360,6 +360,11 @@ mod tests {
                 .await
                 .unwrap();
 
+        let client = jsonrpsee::http_client::HttpClientBuilder::default()
+            .build(format!("http://{addr}"))
+            .unwrap();
+        client.request::<(), _>("readyz", jsonrpsee::rpc_params![]).await.unwrap();
+        assert_eq!(call_count.load(Ordering::Relaxed), 0);
         assert_eq!(http_status(addr, "/readyz").await, 200);
         assert_eq!(call_count.load(Ordering::Relaxed), 0);
         assert_eq!(http_status(addr, "/healthz").await, 500);

--- a/crates/proof/tee/registrar/README.md
+++ b/crates/proof/tee/registrar/README.md
@@ -22,7 +22,7 @@ longer TTLs protect against flakes but delay real cleanup.
 
 - **`service`** — [`RegistrarConfig`] runtime config and lifecycle runner.
 - **`error`** — [`RegistrarError`] enum covering all failure modes.
-- **`prover`** — [`ProverClient`] JSON-RPC client for polling prover signer endpoints.
+- **`prover`** — [`ProverClient`] JSON-RPC client for polling prover readiness and signer endpoints.
 - **`signer_manager`** — [`SignerManager`] lifecycle management for signer proof tasks and registration execution.
 - **`traits`** — [`InstanceDiscovery`] and attestation proof provider trait usage.
 - **`types`** — Core domain types: [`ProverInstance`].

--- a/crates/proof/tee/registrar/README.md
+++ b/crates/proof/tee/registrar/README.md
@@ -4,9 +4,10 @@ Library crate for the prover registrar service.
 
 Implements automated discovery and onchain registration of TEE prover signer
 keys for the Base multi-proof system. The registrar polls AWS ALB target groups
-to detect new Nitro enclave instances, fetches their attestation documents via
-`enclave_signerAttestation`, generates ZK proofs via the Boundless Network
-(RISC Zero / Automata SDK), and submits registration transactions to
+to detect new Nitro enclave instances, probes each instance's `readyz` endpoint
+(independent of registration-gated `healthz`), fetches their attestation
+documents via `enclave_signerAttestation`, generates ZK proofs via the Boundless
+Network (RISC Zero / Automata SDK), and submits registration transactions to
 `TEEProverRegistry` on L1.
 
 ## Discovery Cache TTL

--- a/crates/proof/tee/registrar/src/discovery.rs
+++ b/crates/proof/tee/registrar/src/discovery.rs
@@ -13,8 +13,9 @@ use crate::{InstanceDiscovery, InstanceHealthStatus, ProverInstance, RegistrarEr
 ///
 /// Queries `describe_target_health` to enumerate registered targets, then
 /// resolves each EC2 instance's private IP address via `describe_instances`.
-/// Health state is mapped from the ALB target health state, supporting the
-/// `Initial` warm-up window during which new instances should be registered.
+/// Health state is mapped from the ALB target health state. The registration
+/// driver later overlays non-draining instances with a direct `readyz` probe so
+/// bootstrap does not depend on registration-gated ALB `/healthz` checks.
 #[derive(Debug)]
 pub struct AwsTargetGroupDiscovery {
     elb_client: ElbClient,

--- a/crates/proof/tee/registrar/src/discovery.rs
+++ b/crates/proof/tee/registrar/src/discovery.rs
@@ -13,9 +13,7 @@ use crate::{InstanceDiscovery, InstanceHealthStatus, ProverInstance, RegistrarEr
 ///
 /// Queries `describe_target_health` to enumerate registered targets, then
 /// resolves each EC2 instance's private IP address via `describe_instances`.
-/// Health state is mapped from the ALB target health state. The registration
-/// driver later overlays non-draining instances with a direct `readyz` probe so
-/// bootstrap does not depend on registration-gated ALB `/healthz` checks.
+/// Health state is mapped from the ALB target health state.
 #[derive(Debug)]
 pub struct AwsTargetGroupDiscovery {
     elb_client: ElbClient,

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -312,81 +312,58 @@ where
         last_known_active: &mut HashMap<String, (Vec<Address>, u32)>,
         unhealthy_instance_ids_with_grace: &mut HashSet<String>,
     ) -> Result<DiscoveryResolution> {
-        let mut instances = self.discovery.discover_instances().await?;
+        let instances = self.discovery.discover_instances().await?;
         RegistrarMetrics::discovery_success_total().increment(1);
-
-        // Overlay ALB target health with a direct `readyz` probe. ALB `/healthz`
-        // is registration-gated on nitro-host, so trusting it alone deadlocks
-        // bootstrap. Preserve `Draining` so lifecycle teardown still skips
-        // registration while protecting active signers.
-        let max_concurrency = self.config.max_concurrency.max(1);
-        let readiness = futures::stream::iter(
-            instances
-                .iter_mut()
-                .filter(|instance| instance.health_status != InstanceHealthStatus::Draining),
-        )
-        .for_each_concurrent(max_concurrency, |instance| async {
-            instance.health_status = match self.signer_client.readyz(&instance.endpoint).await {
-                Ok(()) => InstanceHealthStatus::Healthy,
-                Err(e) => {
-                    debug!(
-                        error = %e,
-                        instance = %instance.instance_id,
-                        endpoint = %instance.endpoint,
-                        "readyz probe failed"
-                    );
-                    InstanceHealthStatus::Unhealthy
-                }
-            };
-        });
-        tokio::select! {
-            biased;
-            () = self.config.cancel.cancelled() => return Ok(DiscoveryResolution::default()),
-            () = readiness => {}
-        }
 
         let discovered_instance_ids: HashSet<String> =
             instances.iter().map(|instance| instance.instance_id.clone()).collect();
-        let unhealthy_instance_ids: HashSet<String> = instances
-            .iter()
-            .filter(|instance| instance.health_status == InstanceHealthStatus::Unhealthy)
-            .map(|instance| instance.instance_id.clone())
-            .collect();
-        unhealthy_instance_ids_with_grace
-            .retain(|instance_id| unhealthy_instance_ids.contains(instance_id));
-        for instance_id in &unhealthy_instance_ids {
-            // A process restart has no signer addresses to cache. Keep an
-            // empty cache entry for one unhealthy period so the global orphan
-            // cleanup pass is deferred by the configured grace TTL.
-            if unhealthy_instance_ids_with_grace.insert(instance_id.clone())
-                && !last_known_active.contains_key(instance_id)
-            {
-                last_known_active.insert(instance_id.clone(), (Vec::new(), 0));
-            }
-        }
-        RegistrarMetrics::discovered_instances_count().set(discovered_instance_ids.len() as f64);
+        let max_concurrency = self.config.max_concurrency.max(1);
         let mut resolution = DiscoveryResolution::default();
+        let mut unhealthy_instance_ids = HashSet::new();
 
-        let mut futs = futures::stream::iter(instances.into_iter().map(|instance| {
-            let span = tracing::info_span!(
-                "resolve_instance",
-                instance_id = %instance.instance_id,
-                endpoint = %instance.endpoint,
-                health = ?instance.health_status,
-            );
-            async move {
-                let result = self.resolve_instance(&instance).await;
-                (instance, result)
-            }
-            .instrument(span)
-        }))
-        .buffer_unordered(max_concurrency);
+        // Probe each non-draining target immediately before resolving it. ALB
+        // `/healthz` is registration-gated on nitro-host, so trusting it alone
+        // deadlocks bootstrap. Pairing the probe with resolution lets healthy
+        // targets progress while an unrelated probe waits for its timeout.
+        let mut futs =
+            futures::stream::iter(instances.into_iter().map(|mut instance| async move {
+                if instance.health_status != InstanceHealthStatus::Draining {
+                    let readyz = tokio::select! {
+                        biased;
+                        () = self.config.cancel.cancelled() => return (instance, None),
+                        result = self.signer_client.readyz(&instance.endpoint) => result,
+                    };
+                    instance.health_status = match readyz {
+                        Ok(()) => InstanceHealthStatus::Healthy,
+                        Err(e) => {
+                            debug!(
+                                error = %e,
+                                instance = %instance.instance_id,
+                                endpoint = %instance.endpoint,
+                                "readyz probe failed"
+                            );
+                            InstanceHealthStatus::Unhealthy
+                        }
+                    };
+                }
+                let span = tracing::info_span!(
+                    "resolve_instance",
+                    instance_id = %instance.instance_id,
+                    endpoint = %instance.endpoint,
+                    health = ?instance.health_status,
+                );
+                let result = self.resolve_instance(&instance).instrument(span).await;
+                (instance, Some(result))
+            }))
+            .buffer_unordered(max_concurrency);
 
-        // No cancel-select around `futs.next()`: each future checks
-        // cancellation cooperatively between awaits, so new work is
-        // short-circuited while already-started resolution work reaches a
-        // natural boundary.
         while let Some((instance, result)) = futs.next().await {
+            let Some(result) = result else {
+                continue;
+            };
+            if instance.health_status == InstanceHealthStatus::Unhealthy {
+                unhealthy_instance_ids.insert(instance.instance_id.clone());
+            }
             match result {
                 Ok(outcome) => {
                     let active_signers = outcome.active_signers.iter().copied().collect::<Vec<_>>();
@@ -413,6 +390,24 @@ where
                 }
             }
         }
+
+        if self.config.cancel.is_cancelled() {
+            return Ok(DiscoveryResolution::default());
+        }
+
+        unhealthy_instance_ids_with_grace
+            .retain(|instance_id| unhealthy_instance_ids.contains(instance_id));
+        for instance_id in &unhealthy_instance_ids {
+            // A process restart has no signer addresses to cache. Keep an
+            // empty cache entry for one unhealthy period so the global orphan
+            // cleanup pass is deferred by the configured grace TTL.
+            if unhealthy_instance_ids_with_grace.insert(instance_id.clone())
+                && !last_known_active.contains_key(instance_id)
+            {
+                last_known_active.insert(instance_id.clone(), (Vec::new(), 0));
+            }
+        }
+        RegistrarMetrics::discovered_instances_count().set(discovered_instance_ids.len() as f64);
 
         last_known_active.retain(|instance_id, (addresses, ttl_cycles)| {
             if discovered_instance_ids.contains(instance_id)
@@ -463,11 +458,16 @@ where
 
 #[cfg(test)]
 mod tests {
+    //! Driver tests use a hand-rolled endpoint client because they coordinate
+    //! scripted responses and a shared cross-method call log across concurrent
+    //! readiness, signer-key, and attestation requests.
+
     use std::{
         collections::{HashMap, HashSet},
         sync::{Arc, Mutex},
     };
 
+    use tokio::sync::Notify;
     use tokio_util::sync::CancellationToken;
     use url::Url;
 
@@ -494,6 +494,8 @@ mod tests {
         attestations: HashMap<Url, Vec<Vec<u8>>>,
         fail_attestation: HashSet<Url>,
         fail_readyz: HashSet<Url>,
+        block_readyz: HashMap<Url, Arc<Notify>>,
+        public_key_requested: Arc<Notify>,
         requested_public_keys: RequestedPublicKeys,
         requested_nonces: RequestedNonces,
         requested_readyz: RequestedReadyz,
@@ -521,6 +523,9 @@ mod tests {
     impl EnclaveEndpointClient for MockEnclaveEndpointClient {
         async fn readyz(&self, endpoint: &Url) -> Result<()> {
             self.requested_readyz.lock().unwrap().push(endpoint.clone());
+            if let Some(blocker) = self.block_readyz.get(endpoint) {
+                blocker.notified().await;
+            }
             if self.fail_readyz.contains(endpoint) {
                 return Err(RegistrarError::ProverClient {
                     instance: endpoint.to_string(),
@@ -532,6 +537,7 @@ mod tests {
 
         async fn signer_public_key(&self, endpoint: &Url) -> Result<Vec<Vec<u8>>> {
             self.requested_public_keys.lock().unwrap().push(endpoint.clone());
+            self.public_key_requested.notify_one();
             self.keys.get(endpoint).cloned().ok_or_else(|| RegistrarError::ProverClient {
                 instance: endpoint.to_string(),
                 source: "unreachable".into(),
@@ -730,6 +736,37 @@ mod tests {
         assert!(resolution.active_signers.is_empty());
         assert!(resolution.unresolved_instance_ids.is_empty());
         assert!(requested_readyz.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn discover_and_resolve_pipelines_readyz_with_instance_resolution() {
+        let cancel = CancellationToken::new();
+        let mut signer_client =
+            MockEnclaveEndpointClient::from_keys(&[(EP1, &HARDHAT_KEY_0), (EP2, &HARDHAT_KEY_1)]);
+        signer_client.block_readyz.insert(endpoint_url(EP1), Arc::new(Notify::new()));
+        let public_key_requested = Arc::clone(&signer_client.public_key_requested);
+        let driver = cycle_driver(
+            vec![healthy_prover_instance(EP1), healthy_prover_instance(EP2)],
+            signer_client,
+            cancel.clone(),
+        );
+        let discovery = discover_once(&driver);
+        tokio::pin!(discovery);
+
+        tokio::select! {
+            resolution = &mut discovery => panic!("discovery completed before cancellation: {resolution:?}"),
+            result = tokio::time::timeout(Duration::from_secs(1), public_key_requested.notified()) => {
+                result.expect("healthy instance should resolve while another readyz probe blocks");
+            }
+        }
+
+        cancel.cancel();
+        let resolution = tokio::time::timeout(Duration::from_secs(1), &mut discovery)
+            .await
+            .expect("discovery should stop after cancellation");
+        assert!(resolution.registerable.is_empty());
+        assert!(resolution.active_signers.is_empty());
+        assert!(resolution.unresolved_instance_ids.is_empty());
     }
 
     #[tokio::test]

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -221,10 +221,7 @@ where
             return Ok(outcome);
         }
 
-        if !matches!(
-            instance.health_status,
-            InstanceHealthStatus::Initial | InstanceHealthStatus::Healthy
-        ) {
+        if instance.health_status != InstanceHealthStatus::Healthy {
             debug!(
                 status = ?instance.health_status,
                 instance = %instance.instance_id,
@@ -323,26 +320,25 @@ where
         // bootstrap. Preserve `Draining` so lifecycle teardown still skips
         // registration while protecting active signers.
         let max_concurrency = self.config.max_concurrency.max(1);
-        let readiness = futures::stream::iter(instances.iter_mut()).for_each_concurrent(
-            max_concurrency,
-            |instance| async {
-                if instance.health_status == InstanceHealthStatus::Draining {
-                    return;
+        let readiness = futures::stream::iter(
+            instances
+                .iter_mut()
+                .filter(|instance| instance.health_status != InstanceHealthStatus::Draining),
+        )
+        .for_each_concurrent(max_concurrency, |instance| async {
+            instance.health_status = match self.signer_client.readyz(&instance.endpoint).await {
+                Ok(()) => InstanceHealthStatus::Healthy,
+                Err(e) => {
+                    debug!(
+                        error = %e,
+                        instance = %instance.instance_id,
+                        endpoint = %instance.endpoint,
+                        "readyz probe failed"
+                    );
+                    InstanceHealthStatus::Unhealthy
                 }
-                instance.health_status = match self.signer_client.readyz(&instance.endpoint).await {
-                    Ok(()) => InstanceHealthStatus::Healthy,
-                    Err(e) => {
-                        debug!(
-                            error = %e,
-                            instance = %instance.instance_id,
-                            endpoint = %instance.endpoint,
-                            "readyz probe failed"
-                        );
-                        InstanceHealthStatus::Unhealthy
-                    }
-                };
-            },
-        );
+            };
+        });
         tokio::select! {
             biased;
             () = self.config.cancel.cancelled() => return Ok(DiscoveryResolution::default()),

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -322,12 +322,14 @@ where
         // is registration-gated on nitro-host, so trusting it alone deadlocks
         // bootstrap. Preserve `Draining` so lifecycle teardown still skips
         // registration while protecting active signers.
-        let readiness = futures::stream::iter(instances.iter().enumerate().map(
-            |(index, instance)| async move {
+        let max_concurrency = self.config.max_concurrency.max(1);
+        let readiness = futures::stream::iter(instances.iter_mut()).for_each_concurrent(
+            max_concurrency,
+            |instance| async {
                 if instance.health_status == InstanceHealthStatus::Draining {
-                    return (index, InstanceHealthStatus::Draining);
+                    return;
                 }
-                let status = match self.signer_client.readyz(&instance.endpoint).await {
+                instance.health_status = match self.signer_client.readyz(&instance.endpoint).await {
                     Ok(()) => InstanceHealthStatus::Healthy,
                     Err(e) => {
                         debug!(
@@ -339,14 +341,12 @@ where
                         InstanceHealthStatus::Unhealthy
                     }
                 };
-                (index, status)
             },
-        ))
-        .buffer_unordered(self.config.max_concurrency.max(1))
-        .collect::<Vec<_>>()
-        .await;
-        for (index, status) in readiness {
-            instances[index].health_status = status;
+        );
+        tokio::select! {
+            biased;
+            () = self.config.cancel.cancelled() => return Ok(DiscoveryResolution::default()),
+            () = readiness => {}
         }
 
         let discovered_instance_ids: HashSet<String> =
@@ -384,7 +384,7 @@ where
             }
             .instrument(span)
         }))
-        .buffer_unordered(self.config.max_concurrency.max(1));
+        .buffer_unordered(max_concurrency);
 
         // No cancel-select around `futs.next()`: each future checks
         // cancellation cooperatively between awaits, so new work is
@@ -716,6 +716,24 @@ mod tests {
             )
             .to_vec();
         assert_eq!(*requested_nonces.lock().unwrap(), vec![Some(vec![nonce_a, nonce_b])]);
+    }
+
+    #[tokio::test]
+    async fn discover_and_resolve_skips_readyz_when_cancelled() {
+        let cancel = CancellationToken::new();
+        let signer_client = MockEnclaveEndpointClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
+        let requested_readyz = Arc::clone(&signer_client.requested_readyz);
+        let driver =
+            cycle_driver(vec![healthy_prover_instance(EP1)], signer_client, cancel.clone());
+
+        cancel.cancel();
+
+        let resolution = discover_once(&driver).await;
+
+        assert!(resolution.registerable.is_empty());
+        assert!(resolution.active_signers.is_empty());
+        assert!(resolution.unresolved_instance_ids.is_empty());
+        assert!(requested_readyz.lock().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -315,8 +315,39 @@ where
         last_known_active: &mut HashMap<String, (Vec<Address>, u32)>,
         unhealthy_instance_ids_with_grace: &mut HashSet<String>,
     ) -> Result<DiscoveryResolution> {
-        let instances = self.discovery.discover_instances().await?;
+        let mut instances = self.discovery.discover_instances().await?;
         RegistrarMetrics::discovery_success_total().increment(1);
+
+        // Overlay ALB target health with a direct `readyz` probe. ALB `/healthz`
+        // is registration-gated on nitro-host, so trusting it alone deadlocks
+        // bootstrap. Preserve `Draining` so lifecycle teardown still skips
+        // registration while protecting active signers.
+        let readiness = futures::stream::iter(instances.iter().enumerate().map(
+            |(index, instance)| async move {
+                if instance.health_status == InstanceHealthStatus::Draining {
+                    return (index, InstanceHealthStatus::Draining);
+                }
+                let status = match self.signer_client.readyz(&instance.endpoint).await {
+                    Ok(()) => InstanceHealthStatus::Healthy,
+                    Err(e) => {
+                        debug!(
+                            error = %e,
+                            instance = %instance.instance_id,
+                            endpoint = %instance.endpoint,
+                            "readyz probe failed"
+                        );
+                        InstanceHealthStatus::Unhealthy
+                    }
+                };
+                (index, status)
+            },
+        ))
+        .buffer_unordered(self.config.max_concurrency.max(1))
+        .collect::<Vec<_>>()
+        .await;
+        for (index, status) in readiness {
+            instances[index].health_status = status;
+        }
 
         let discovered_instance_ids: HashSet<String> =
             instances.iter().map(|instance| instance.instance_id.clone()).collect();
@@ -466,12 +497,15 @@ mod tests {
         keys: HashMap<Url, Vec<Vec<u8>>>,
         attestations: HashMap<Url, Vec<Vec<u8>>>,
         fail_attestation: HashSet<Url>,
+        fail_readyz: HashSet<Url>,
         requested_public_keys: RequestedPublicKeys,
         requested_nonces: RequestedNonces,
+        requested_readyz: RequestedReadyz,
     }
 
     type RequestedPublicKeys = Arc<Mutex<Vec<Url>>>;
     type RequestedNonces = Arc<Mutex<Vec<Option<Vec<Vec<u8>>>>>>;
+    type RequestedReadyz = Arc<Mutex<Vec<Url>>>;
 
     impl MockEnclaveEndpointClient {
         fn from_keys(entries: &[(&str, &[u8; 32])]) -> Self {
@@ -489,6 +523,17 @@ mod tests {
     }
 
     impl EnclaveEndpointClient for MockEnclaveEndpointClient {
+        async fn readyz(&self, endpoint: &Url) -> Result<()> {
+            self.requested_readyz.lock().unwrap().push(endpoint.clone());
+            if self.fail_readyz.contains(endpoint) {
+                return Err(RegistrarError::ProverClient {
+                    instance: endpoint.to_string(),
+                    source: "readyz unavailable".into(),
+                });
+            }
+            Ok(())
+        }
+
         async fn signer_public_key(&self, endpoint: &Url) -> Result<Vec<Vec<u8>>> {
             self.requested_public_keys.lock().unwrap().push(endpoint.clone());
             self.keys.get(endpoint).cloned().ok_or_else(|| RegistrarError::ProverClient {
@@ -674,7 +719,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn discover_and_resolve_skips_unhealthy_instances_before_resolving() {
+    async fn discover_and_resolve_skips_instances_that_fail_readyz() {
         let addr_healthy = signer_from_private_key(&HARDHAT_KEY_1);
 
         let instances = vec![
@@ -682,9 +727,11 @@ mod tests {
             healthy_prover_instance(EP2),
         ];
 
-        let signer_client =
+        let mut signer_client =
             MockEnclaveEndpointClient::from_keys(&[(EP1, &HARDHAT_KEY_0), (EP2, &HARDHAT_KEY_1)]);
+        signer_client.fail_readyz.insert(endpoint_url(EP1));
         let requested_public_keys = Arc::clone(&signer_client.requested_public_keys);
+        let requested_readyz = Arc::clone(&signer_client.requested_readyz);
 
         let driver = cycle_driver(instances, signer_client, CancellationToken::new());
 
@@ -694,6 +741,26 @@ mod tests {
         assert!(!resolution.active_signers.contains(&signer_from_private_key(&HARDHAT_KEY_0)));
         assert_eq!(resolution.unresolved_instance_ids, HashSet::from([format!("i-{EP1}")]));
         assert_eq!(*requested_public_keys.lock().unwrap(), vec![endpoint_url(EP2)]);
+        let mut probed = requested_readyz.lock().unwrap().clone();
+        probed.sort();
+        assert_eq!(probed, vec![endpoint_url(EP1), endpoint_url(EP2)]);
+    }
+
+    #[tokio::test]
+    async fn discover_and_resolve_registers_alb_unhealthy_instance_when_readyz_passes() {
+        let addr = signer_from_private_key(&HARDHAT_KEY_0);
+        let instances = vec![prover_instance(EP1, InstanceHealthStatus::Unhealthy)];
+        let signer_client = MockEnclaveEndpointClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
+        let requested_readyz = Arc::clone(&signer_client.requested_readyz);
+
+        let driver = cycle_driver(instances, signer_client, CancellationToken::new());
+
+        let resolution = discover_once(&driver).await;
+        assert_eq!(resolution.registerable.len(), 1);
+        assert_eq!(resolution.registerable[0].signer, addr);
+        assert!(resolution.active_signers.contains(&addr));
+        assert!(resolution.unresolved_instance_ids.is_empty());
+        assert_eq!(*requested_readyz.lock().unwrap(), vec![endpoint_url(EP1)]);
     }
 
     #[tokio::test]
@@ -701,7 +768,8 @@ mod tests {
         const TEST_TTL_CYCLES: u32 = 2;
 
         let instance = prover_instance(EP1, InstanceHealthStatus::Unhealthy);
-        let signer_client = MockEnclaveEndpointClient::default();
+        let mut signer_client = MockEnclaveEndpointClient::default();
+        signer_client.fail_readyz.insert(endpoint_url(EP1));
         let requested_public_keys = Arc::clone(&signer_client.requested_public_keys);
         let driver = cycle_driver_with_instance_cache_ttl(
             vec![instance.clone()],
@@ -755,7 +823,8 @@ mod tests {
 
         let signer = signer_from_private_key(&HARDHAT_KEY_0);
         let instance = prover_instance(EP1, InstanceHealthStatus::Unhealthy);
-        let signer_client = MockEnclaveEndpointClient::default();
+        let mut signer_client = MockEnclaveEndpointClient::default();
+        signer_client.fail_readyz.insert(endpoint_url(EP1));
         let requested_public_keys = Arc::clone(&signer_client.requested_public_keys);
         let driver = cycle_driver_with_instance_cache_ttl(
             vec![instance.clone()],

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -317,7 +317,6 @@ where
 
         let discovered_instance_ids: HashSet<String> =
             instances.iter().map(|instance| instance.instance_id.clone()).collect();
-        let max_concurrency = self.config.max_concurrency.max(1);
         let mut resolution = DiscoveryResolution::default();
         let mut unhealthy_instance_ids = HashSet::new();
 
@@ -355,7 +354,7 @@ where
                 let result = self.resolve_instance(&instance).instrument(span).await;
                 (instance, Some(result))
             }))
-            .buffer_unordered(max_concurrency);
+            .buffer_unordered(self.config.max_concurrency.max(1));
 
         while let Some((instance, result)) = futs.next().await {
             let Some(result) = result else {
@@ -459,8 +458,8 @@ where
 #[cfg(test)]
 mod tests {
     //! Driver tests use a hand-rolled endpoint client because they coordinate
-    //! scripted responses and a shared cross-method call log across concurrent
-    //! readiness, signer-key, and attestation requests.
+    //! scripted responses with a blocked readiness request across concurrent
+    //! calls.
 
     use std::{
         collections::{HashMap, HashSet},
@@ -496,14 +495,13 @@ mod tests {
         fail_readyz: HashSet<Url>,
         block_readyz: HashMap<Url, Arc<Notify>>,
         public_key_requested: Arc<Notify>,
-        requested_public_keys: RequestedPublicKeys,
+        requested_public_keys: RequestedEndpoints,
         requested_nonces: RequestedNonces,
-        requested_readyz: RequestedReadyz,
+        requested_readyz: RequestedEndpoints,
     }
 
-    type RequestedPublicKeys = Arc<Mutex<Vec<Url>>>;
+    type RequestedEndpoints = Arc<Mutex<Vec<Url>>>;
     type RequestedNonces = Arc<Mutex<Vec<Option<Vec<Vec<u8>>>>>>;
-    type RequestedReadyz = Arc<Mutex<Vec<Url>>>;
 
     impl MockEnclaveEndpointClient {
         fn from_keys(entries: &[(&str, &[u8; 32])]) -> Self {

--- a/crates/proof/tee/registrar/src/prover.rs
+++ b/crates/proof/tee/registrar/src/prover.rs
@@ -1,4 +1,4 @@
-//! JSON-RPC client for polling prover instance signer endpoints.
+//! JSON-RPC client for polling prover instance readiness and signer endpoints.
 
 use std::time::Duration;
 
@@ -58,7 +58,6 @@ impl ProverClient {
 
 impl EnclaveEndpointClient for ProverClient {
     async fn readyz(&self, endpoint: &Url) -> Result<()> {
-        debug!(endpoint = %endpoint, "probing prover readyz");
         let client = self.build_client(endpoint)?;
         client.request::<(), _>("readyz", rpc_params![]).await.map_err(|e| {
             RegistrarError::ProverClient { instance: endpoint.to_string(), source: Box::new(e) }

--- a/crates/proof/tee/registrar/src/prover.rs
+++ b/crates/proof/tee/registrar/src/prover.rs
@@ -16,10 +16,10 @@ use url::Url;
 
 use crate::{EnclaveEndpointClient, RegistrarError, Result};
 
-/// JSON-RPC client for prover instance signer endpoints.
+/// JSON-RPC client for prover instance readiness and signer endpoints.
 ///
-/// Implements [`EnclaveEndpointClient`] by making HTTP JSON-RPC calls to the prover's
-/// `enclave_signerPublicKey` and `enclave_signerAttestation` endpoints.
+/// Implements [`EnclaveEndpointClient`] with HTTP JSON-RPC calls to the prover's
+/// `readyz`, `enclave_signerPublicKey`, and `enclave_signerAttestation` endpoints.
 ///
 /// The `timeout` is configured once at construction and applied to all requests.
 #[derive(Debug)]

--- a/crates/proof/tee/registrar/src/prover.rs
+++ b/crates/proof/tee/registrar/src/prover.rs
@@ -5,7 +5,11 @@ use std::time::Duration;
 use alloy_primitives::Address;
 use alloy_signer::utils::public_key_to_address;
 use base_proof_primitives::EnclaveApiClient;
-use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
+use jsonrpsee::{
+    core::client::ClientT,
+    http_client::{HttpClient, HttpClientBuilder},
+    rpc_params,
+};
 use k256::ecdsa::VerifyingKey;
 use tracing::debug;
 use url::Url;
@@ -53,6 +57,14 @@ impl ProverClient {
 }
 
 impl EnclaveEndpointClient for ProverClient {
+    async fn readyz(&self, endpoint: &Url) -> Result<()> {
+        debug!(endpoint = %endpoint, "probing prover readyz");
+        let client = self.build_client(endpoint)?;
+        client.request::<(), _>("readyz", rpc_params![]).await.map_err(|e| {
+            RegistrarError::ProverClient { instance: endpoint.to_string(), source: Box::new(e) }
+        })
+    }
+
     async fn signer_public_key(&self, endpoint: &Url) -> Result<Vec<Vec<u8>>> {
         debug!(endpoint = %endpoint, "fetching signer public keys");
         let client = self.build_client(endpoint)?;

--- a/crates/proof/tee/registrar/src/traits.rs
+++ b/crates/proof/tee/registrar/src/traits.rs
@@ -30,6 +30,12 @@ pub trait InstanceDiscovery: Send + Sync {
 ///
 /// The `endpoint` parameter is a [`Url`] (e.g. `http://10.0.1.5:8000/`).
 pub trait EnclaveEndpointClient: Send + Sync {
+    /// Probes whether the host is accepting requests (`readyz`).
+    ///
+    /// Unlike `healthz`, readiness does not require onchain registration, so the
+    /// registrar can bootstrap new instances without a circular dependency.
+    fn readyz<'a>(&'a self, endpoint: &'a Url) -> impl Future<Output = Result<()>> + Send + 'a;
+
     /// Fetches the SEC1-encoded public key for each enclave signer at the given endpoint.
     fn signer_public_key<'a>(
         &'a self,

--- a/crates/proof/tee/registrar/src/traits.rs
+++ b/crates/proof/tee/registrar/src/traits.rs
@@ -17,12 +17,11 @@ pub trait InstanceDiscovery: Send + Sync {
     fn discover_instances(&self) -> impl Future<Output = Result<Vec<ProverInstance>>> + Send + '_;
 }
 
-/// Fetches signer identity data from a prover instance endpoint.
+/// Communicates with a prover instance endpoint.
 ///
 /// The primary implementation is [`ProverClient`](crate::ProverClient), which
-/// adapts a discovered endpoint [`Url`] to the shared
-/// `base_proof_primitives::EnclaveApiClient` JSON-RPC surface. Test code can
-/// substitute a mock to avoid real HTTP calls.
+/// sends readiness and signer JSON-RPC requests to a discovered endpoint
+/// [`Url`]. Test code can substitute a mock to avoid real HTTP calls.
 ///
 /// Implementations must return public keys and attestations in the same stable
 /// signer order across calls for a given endpoint. The registrar pairs each

--- a/crates/proof/tee/registrar/src/types.rs
+++ b/crates/proof/tee/registrar/src/types.rs
@@ -8,6 +8,11 @@ pub struct ProverInstance {
     /// HTTP endpoint URL for the prover (e.g. `http://10.0.1.5:8000/`).
     pub endpoint: Url,
     /// Current health status of the instance.
+    ///
+    /// Discovery seeds this from ALB target health. The registration driver then
+    /// overlays non-[`Draining`](InstanceHealthStatus::Draining) instances with
+    /// the result of a direct `readyz` probe so bootstrap does not depend on
+    /// registration-gated ALB `/healthz` checks.
     pub health_status: InstanceHealthStatus,
 }
 
@@ -16,9 +21,9 @@ pub struct ProverInstance {
 pub enum InstanceHealthStatus {
     /// ALB health checks are in progress — instance just started.
     Initial,
-    /// Instance is reachable and passing health checks.
+    /// Instance is reachable and passing readiness checks.
     Healthy,
-    /// Instance did not respond to the poll or is failing health checks.
+    /// Instance did not respond to `readyz` or is failing health checks.
     Unhealthy,
     /// ALB is draining connections from this instance.
     Draining,

--- a/crates/proof/tee/registrar/src/types.rs
+++ b/crates/proof/tee/registrar/src/types.rs
@@ -7,12 +7,7 @@ pub struct ProverInstance {
     pub instance_id: String,
     /// HTTP endpoint URL for the prover (e.g. `http://10.0.1.5:8000/`).
     pub endpoint: Url,
-    /// Current health status of the instance.
-    ///
-    /// Discovery seeds this from ALB target health. The registration driver then
-    /// overlays non-[`Draining`](InstanceHealthStatus::Draining) instances with
-    /// the result of a direct `readyz` probe so bootstrap does not depend on
-    /// registration-gated ALB `/healthz` checks.
+    /// Current health status from discovery or direct readiness probing.
     pub health_status: InstanceHealthStatus,
 }
 


### PR DESCRIPTION
## Summary
- Registrar now probes each discovered instance's `readyz` endpoint and overlays ALB health with that result before registration.
- Breaks the bootstrap deadlock where ALB `/healthz` requires onchain registration, but registration waited on ALB healthy/initial status.
- Preserves `Draining` from ALB so teardown still skips registration while protecting active signers.

## Test plan
- [ ] `RISC0_SKIP_BUILD_KERNELS=1 cargo test -p base-proof-tee-registrar --lib`
- [ ] Confirm a new unregistered nitro-host instance that fails ALB `/healthz` but passes `readyz` becomes registerable
- [ ] Confirm a draining instance is not registered and its signers stay protected
- [ ] Confirm `readyz` failure still triggers unhealthy grace / orphan deferral behavior


Made with [Cursor](https://cursor.com)