### PR TITLE
fix(common): Restore Activation Registry Install Compatibility

### DIFF
--- a/crates/common/precompiles/src/activation/precompile.rs
+++ b/crates/common/precompiles/src/activation/precompile.rs
@@ -16,16 +16,12 @@ use crate::{
 pub struct ActivationRegistry;
 
 impl ActivationRegistry {
-    /// Installs the activation registry precompile using a static fallback admin.
-    pub fn install(
-        precompiles: &mut PrecompilesMap,
-        activation_admin_address: Option<Address>,
-        upgrade: BaseUpgrade,
-    ) {
+    /// Installs the Beryl activation registry precompile using a static fallback admin.
+    pub fn install(precompiles: &mut PrecompilesMap, activation_admin_address: Option<Address>) {
         Self::install_with_config(
             precompiles,
             ActivationAdminConfig::static_fallback(activation_admin_address),
-            upgrade,
+            BaseUpgrade::Beryl,
         );
     }
 
@@ -86,7 +82,6 @@ impl ActivationRegistry {
 mod tests {
     use alloy_evm::precompiles::PrecompilesMap;
     use alloy_primitives::Address;
-    use base_common_genesis::BaseUpgrade;
     use revm::precompile::Precompiles;
 
     use crate::{ActivationRegistry, ActivationRegistryStorage};
@@ -95,11 +90,7 @@ mod tests {
     fn install_accepts_static_fallback_admin() {
         let mut precompiles = PrecompilesMap::from_static(Precompiles::cancun());
 
-        ActivationRegistry::install(
-            &mut precompiles,
-            Some(Address::repeat_byte(0x11)),
-            BaseUpgrade::Beryl,
-        );
+        ActivationRegistry::install(&mut precompiles, Some(Address::repeat_byte(0x11)));
 
         assert!(precompiles.get(&ActivationRegistryStorage::ADDRESS).is_some());
     }


### PR DESCRIPTION
## Summary

PR #3987 changed `ActivationRegistry::install` to require a `BaseUpgrade` so activation-registry storage semantics could vary by upgrade, but that broke the pinned historical `base-anvil` Beryl snapshot, which still calls the two-argument compatibility API. Because the Base Std workflow patches current Base crates into that snapshot, `foundry-evm-networks` failed to compile before any interface tests could run. This restores the two-argument entry point and makes it explicitly install Beryl semantics, while upgrade-aware callers retain `install_with_config`. The focused precompile tests, crate check, formatting check, and an exact compile of pinned `base-anvil@d3bdb810` against these local crates all pass.