### PR TITLE
refactor(BOP-441): extract move_balance from AssetV2 + StablecoinV2 transfer_inner

### DIFF
--- a/crates/common/precompiles/src/b20_asset/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v2.rs
@@ -64,6 +64,22 @@ impl AssetV2 {
             B20Guards::ensure_policy_type(token, B20PolicyType::TransferSender, from)?;
             B20Guards::ensure_policy_type(token, B20PolicyType::TransferReceiver, to)?;
         }
+        self.move_balance(token, from, to, amount)
+    }
+
+    /// Debits `from`, credits `to`, and emits `Transfer(from, to, amount)`.
+    ///
+    /// The shared balance-move primitive: no policy, allowance, pause, or zero-address checks —
+    /// callers apply their own guards first. Both [`Self::transfer_inner`] and the seize path use
+    /// this, so seize never has to reuse the policy-bearing `transfer_inner` (nor the factory
+    /// privileged bypass).
+    fn move_balance<S: AssetAccounting, A: PolicyAccounting>(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        from: Address,
+        to: Address,
+        amount: U256,
+    ) -> Result<()> {
         let from_balance = token.accounting().balance_of(from)?;
         if from_balance < amount {
             return Err(BasePrecompileError::revert(IB20::InsufficientBalance {

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
@@ -48,6 +48,22 @@ impl StablecoinV2 {
             B20Guards::ensure_policy_type(token, B20PolicyType::TransferSender, from)?;
             B20Guards::ensure_policy_type(token, B20PolicyType::TransferReceiver, to)?;
         }
+        self.move_balance(token, from, to, amount)
+    }
+
+    /// Debits `from`, credits `to`, and emits `Transfer(from, to, amount)`.
+    ///
+    /// The shared balance-move primitive: no policy, allowance, pause, or zero-address checks —
+    /// callers apply their own guards first. Both [`Self::transfer_inner`] and the seize path use
+    /// this, so seize never has to reuse the policy-bearing `transfer_inner` (nor the factory
+    /// privileged bypass).
+    fn move_balance<S: StablecoinAccounting, A: PolicyAccounting>(
+        &self,
+        token: &mut B20StablecoinToken<S, A>,
+        from: Address,
+        to: Address,
+        amount: U256,
+    ) -> Result<()> {
         let from_balance = token.accounting().balance_of(from)?;
         if from_balance < amount {
             return Err(BasePrecompileError::revert(IB20::InsufficientBalance {


### PR DESCRIPTION
## Summary

Behavior-preserving refactor that extracts the balance debit/credit + `Transfer` emission out of `transfer_inner` into a shared `move_balance` primitive in **both** `AssetV2` and `StablecoinV2`. `transfer_inner` keeps the zero-address and sender/receiver policy checks and delegates the move.

This is **PR1** of the Transfer Blocked / seize work ([BOP-441](https://linear.app/coinbase/issue/BOP-441)); it lands the shared mover the transfer-based seize entrypoint (`transferFromBlockedWithMemo`, a later PR) will reuse — so seize never goes through the policy-bearing `transfer_inner` nor the factory `privileged` bypass. Mirrors the base-std reference ([base-std#177](https://github.com/base/base-std/pull/177)).

## Stacked PR

Stacked on **#4170** (`StablecoinV2` scaffold), which this needs so the stablecoin extraction has a mutable V2 to live in. Review/merge #4170 first; this PR's diff is just the two `move_balance` extractions.

## Scope

- Asset **V2** and stablecoin **V2** logic only. V1 is frozen and untouched.
- No functional/ABI change; no new selectors.

## Testing

- `cargo test -p base-common-precompiles --features test-utils`: 620 unit + all goldens pass.
- `cargo clippy --all-targets --features test-utils` clean; `cargo +nightly fmt --check` clean.