### PR TITLE
chore(ci): Update Base-Anvil Commit Pin

### DIFF
--- a/.github/workflows/base-anvil-package.yml
+++ b/.github/workflows/base-anvil-package.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  BASE_ANVIL_REF: ${{ github.event.inputs.base_anvil_ref || '0ef004d2653f2bce87293ab399846a3720b9ceb7' }}
+  BASE_ANVIL_REF: ${{ github.event.inputs.base_anvil_ref || 'ae7557c4f8602caa1da0be33143bb2504c85b0c8' }}
   BASE_STD_REF: ${{ github.event.inputs.base_std_ref || 'main' }}
   CARGO_TERM_COLOR: always
   REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/base-anvil

--- a/.github/workflows/base-anvil-package.yml
+++ b/.github/workflows/base-anvil-package.yml
@@ -9,7 +9,7 @@ on:
       base_anvil_ref:
         description: "base/base-anvil ref to build from"
         required: false
-        default: 0ef004d2653f2bce87293ab399846a3720b9ceb7
+        default: ae7557c4f8602caa1da0be33143bb2504c85b0c8
       base_std_ref:
         description: "base/base-std ref to smoke test against"
         required: false
@@ -355,7 +355,7 @@ jobs:
           primary_tag="sha-$GITHUB_SHA"
           tags=("$REGISTRY_IMAGE:$primary_tag")
 
-          if [[ "$GITHUB_REF_NAME" == "main" && "$BASE_ANVIL_REF" == "0ef004d2653f2bce87293ab399846a3720b9ceb7" && "$BASE_STD_REF" == "main" ]]; then
+          if [[ "$GITHUB_REF_NAME" == "main" && "$BASE_ANVIL_REF" == "ae7557c4f8602caa1da0be33143bb2504c85b0c8" && "$BASE_STD_REF" == "main" ]]; then
             tags+=("$REGISTRY_IMAGE:main")
             tags+=("$REGISTRY_IMAGE:main-$commit_date-$short_sha")
           else

--- a/.github/workflows/base-anvil-package.yml
+++ b/.github/workflows/base-anvil-package.yml
@@ -9,7 +9,7 @@ on:
       base_anvil_ref:
         description: "base/base-anvil ref to build from"
         required: false
-        default: d3bdb810084e510acd1a57c63b1bcf8b801db40a
+        default: 0ef004d2653f2bce87293ab399846a3720b9ceb7
       base_std_ref:
         description: "base/base-std ref to smoke test against"
         required: false
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  BASE_ANVIL_REF: ${{ github.event.inputs.base_anvil_ref || 'd3bdb810084e510acd1a57c63b1bcf8b801db40a' }}
+  BASE_ANVIL_REF: ${{ github.event.inputs.base_anvil_ref || '0ef004d2653f2bce87293ab399846a3720b9ceb7' }}
   BASE_STD_REF: ${{ github.event.inputs.base_std_ref || 'main' }}
   CARGO_TERM_COLOR: always
   REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/base-anvil
@@ -355,7 +355,7 @@ jobs:
           primary_tag="sha-$GITHUB_SHA"
           tags=("$REGISTRY_IMAGE:$primary_tag")
 
-          if [[ "$GITHUB_REF_NAME" == "main" && "$BASE_ANVIL_REF" == "d3bdb810084e510acd1a57c63b1bcf8b801db40a" && "$BASE_STD_REF" == "main" ]]; then
+          if [[ "$GITHUB_REF_NAME" == "main" && "$BASE_ANVIL_REF" == "0ef004d2653f2bce87293ab399846a3720b9ceb7" && "$BASE_STD_REF" == "main" ]]; then
             tags+=("$REGISTRY_IMAGE:main")
             tags+=("$REGISTRY_IMAGE:main-$commit_date-$short_sha")
           else

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -32,7 +32,7 @@ jobs:
           # recorded in the result artifact and PR comment.
           - fork: Beryl
             key: beryl
-            base_anvil_ref: d3bdb810084e510acd1a57c63b1bcf8b801db40a
+            base_anvil_ref: 0ef004d2653f2bce87293ab399846a3720b9ceb7
             base_std_ref: v1.0.0
     env:
       FORK_NAME: ${{ matrix.fork }}

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -32,7 +32,7 @@ jobs:
           # recorded in the result artifact and PR comment.
           - fork: Beryl
             key: beryl
-            base_anvil_ref: 0ef004d2653f2bce87293ab399846a3720b9ceb7
+            base_anvil_ref: ae7557c4f8602caa1da0be33143bb2504c85b0c8
             base_std_ref: v1.0.0
     env:
       FORK_NAME: ${{ matrix.fork }}


### PR DESCRIPTION
## Summary

Updates the pinned base/base-anvil commit used by the base-anvil packaging and base-std fork test workflows to `0ef004d2653f2bce87293ab399846a3720b9ceb7`. This picks up the latest changes from the base-anvil repository. The pin is updated consistently across the input default, the environment fallback, the auto-publish guard, and the fork-test matrix.