### PR TITLE
refactor(builder): Extract And Benchmark Flashblock Assembly

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -225,6 +225,11 @@ jobs:
           free-disk: "true"
           native-deps: "true"
           rust-cache-shared-key: "stable"
+          foundry: "true"
+      - name: Build test contracts
+        # base-test-utils embeds Foundry artifacts (contracts/out/*.json) at compile
+        # time; they are gitignored build output, so generate them before building.
+        run: cd crates/utilities/test-utils/contracts && forge soldeer install && forge build
       - name: Smoke-test benchmarks
         run: |
           cargo bench --locked -p base-builder-core --bench flashblock_assembly -- --test

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -225,7 +225,11 @@ jobs:
           free-disk: "true"
           native-deps: "true"
           rust-cache-shared-key: "stable"
-      - run: cargo bench --locked -p base-proof-mpt --bench trie_node -- --test
+      - name: Smoke-test benchmarks
+        run: |
+          cargo bench --locked -p base-builder-core --bench flashblock_assembly -- --test
+          cargo bench --locked -p base-builder-publish --bench publisher -- --test
+          cargo bench --locked -p base-proof-mpt --bench trie_node -- --test
 
   docker:
     name: Docker

--- a/Justfile
+++ b/Justfile
@@ -154,8 +154,14 @@ watch-check:
 
 # Runs all benchmarks
 benches:
+    @just bench-builder
     @just bench-flashblocks
     @just bench-proof-mpt
+
+# Runs production-path builder assembly and publisher benchmarks
+bench-builder:
+    cargo bench -p base-builder-core --bench flashblock_assembly
+    cargo bench -p base-builder-publish --bench publisher
 
 # Runs flashblocks pending state benchmarks
 bench-flashblocks:

--- a/crates/builder/core/Cargo.toml
+++ b/crates/builder/core/Cargo.toml
@@ -188,6 +188,14 @@ tempfile.workspace = true
 hyper-util.workspace = true
 http-body-util.workspace = true
 
+[[bench]]
+name = "state_root"
+harness = false
+
+[[bench]]
+name = "flashblock_assembly"
+harness = false
+
 [features]
 default = [ "jemalloc", "metrics" ]
 metrics = [
@@ -236,7 +244,3 @@ test-utils = [
 	"rlimit",
 	"testcontainers",
 ]
-
-[[bench]]
-name = "state_root"
-harness = false

--- a/crates/builder/core/benches/flashblock_assembly.rs
+++ b/crates/builder/core/benches/flashblock_assembly.rs
@@ -9,7 +9,7 @@ use std::{hint::black_box, sync::Arc};
 use alloy_consensus::{Header, Receipt, TxEip1559};
 use alloy_primitives::{TxKind, U256};
 use base_builder_core::{
-    BasePayloadBuilderCtx, ExecutionInfo, FlashblockAssembler, StateRootMode,
+    BasePayloadBuilderCtx, ExecutionInfo, FlashblockAssembler, FlashblockBaseMode, StateRootMode,
     test_utils::{generate_signer_from_seed, sign_base_tx},
 };
 use base_common_consensus::{BaseReceipt, BaseTypedTransaction};
@@ -106,6 +106,7 @@ fn assembly_benches(c: &mut Criterion) {
                 &mut info,
                 FlashblockId::default(),
                 StateRootMode::Skip,
+                FlashblockBaseMode::Omit,
             )
             .expect("prefix assembly should succeed");
         }
@@ -127,6 +128,7 @@ fn assembly_benches(c: &mut Criterion) {
                         &mut info,
                         FlashblockId::default(),
                         StateRootMode::Skip,
+                        FlashblockBaseMode::Omit,
                     )
                     .expect("assembly should succeed");
                     black_box(assembly.flashblock.diff.block_hash)

--- a/crates/builder/core/benches/flashblock_assembly.rs
+++ b/crates/builder/core/benches/flashblock_assembly.rs
@@ -1,0 +1,143 @@
+//! Benchmarks cumulative payload and incremental flashblock assembly.
+//!
+//! Each case holds the current flashblock delta at ten transactions while increasing the
+//! cumulative transaction prefix. This exposes work that scales with the full block rather than
+//! with newly included transactions.
+
+use std::{hint::black_box, sync::Arc};
+
+use alloy_consensus::{Header, Receipt, TxEip1559};
+use alloy_primitives::{TxKind, U256};
+use base_builder_core::{
+    BasePayloadBuilderCtx, ExecutionInfo, FlashblockAssembler, StateRootMode,
+    test_utils::{generate_signer_from_seed, sign_base_tx},
+};
+use base_common_consensus::{BaseReceipt, BaseTypedTransaction};
+use base_common_flashblocks::FlashblockId;
+use base_execution_chainspec::BaseChainSpec;
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+use reth_chainspec::ChainSpec;
+use reth_primitives_traits::SealedHeader;
+use reth_provider::noop::NoopProvider;
+use reth_revm::{State, database::StateProviderDatabase};
+
+const DELTA_TRANSACTIONS: usize = 10;
+const CUMULATIVE_PREFIXES: &[usize] = &[0, 100, 500, 1_000];
+
+fn minimal_chain_spec() -> Arc<BaseChainSpec> {
+    let genesis: serde_json::Value = serde_json::json!({
+        "config": { "chainId": 901 },
+        "gasLimit": "0x1C9C380",
+        "timestamp": "0x0"
+    });
+    let genesis = serde_json::from_value(genesis).expect("valid genesis");
+    let inner = ChainSpec::builder().chain(901.into()).genesis(genesis).cancun_activated().build();
+    Arc::new(BaseChainSpec::from(inner))
+}
+
+fn context() -> BasePayloadBuilderCtx {
+    let parent = Arc::new(SealedHeader::seal_slow(Header {
+        gas_limit: 30_000_000,
+        timestamp: 0,
+        ..Default::default()
+    }));
+    BasePayloadBuilderCtx::for_test(minimal_chain_spec(), parent)
+}
+
+fn execution_info(transaction_count: usize) -> ExecutionInfo {
+    let signer = generate_signer_from_seed("flashblock-assembly-benchmark");
+    let mut info = ExecutionInfo::with_capacity(transaction_count);
+
+    for nonce in 0..transaction_count {
+        let tx = TxEip1559 {
+            chain_id: 901,
+            nonce: nonce as u64,
+            gas_limit: 21_000,
+            max_fee_per_gas: 1_000_000_000,
+            to: TxKind::Call(signer.address()),
+            value: U256::from(1u64),
+            ..Default::default()
+        };
+        let signed = sign_base_tx(&signer, BaseTypedTransaction::Eip1559(tx))
+            .expect("sign benchmark transaction")
+            .into_inner();
+        let cumulative_gas_used = (nonce as u64 + 1) * 21_000;
+
+        info.executed_transactions.push(signed);
+        info.executed_senders.push(signer.address());
+        info.receipts.push(BaseReceipt::Eip1559(Receipt {
+            status: true.into(),
+            cumulative_gas_used,
+            logs: Vec::new(),
+        }));
+        info.cumulative_gas_used = cumulative_gas_used;
+    }
+
+    info
+}
+
+fn state() -> State<StateProviderDatabase<NoopProvider>> {
+    State::builder()
+        .with_database(StateProviderDatabase::new(NoopProvider::default()))
+        .with_bundle_update()
+        .build()
+}
+
+fn assembly_benches(c: &mut Criterion) {
+    let ctx = context();
+    let all_transactions = execution_info(
+        CUMULATIVE_PREFIXES.iter().copied().max().unwrap_or_default() + DELTA_TRANSACTIONS,
+    );
+    let mut group = c.benchmark_group("flashblock_assembly/fixed_delta");
+
+    for &prefix in CUMULATIVE_PREFIXES {
+        let mut info = ExecutionInfo {
+            executed_transactions: all_transactions.executed_transactions[..prefix].to_vec(),
+            executed_senders: all_transactions.executed_senders[..prefix].to_vec(),
+            receipts: all_transactions.receipts[..prefix].to_vec(),
+            cumulative_gas_used: prefix as u64 * 21_000,
+            ..ExecutionInfo::default()
+        };
+
+        if prefix > 0 {
+            FlashblockAssembler::build::<_, NoopProvider>(
+                &mut state(),
+                &ctx,
+                &mut info,
+                FlashblockId::default(),
+                StateRootMode::Skip,
+            )
+            .expect("prefix assembly should succeed");
+        }
+
+        let end = prefix + DELTA_TRANSACTIONS;
+        info.executed_transactions
+            .extend_from_slice(&all_transactions.executed_transactions[prefix..end]);
+        info.executed_senders.extend_from_slice(&all_transactions.executed_senders[prefix..end]);
+        info.receipts.extend_from_slice(&all_transactions.receipts[prefix..end]);
+        info.cumulative_gas_used = end as u64 * 21_000;
+
+        group.bench_with_input(BenchmarkId::from_parameter(prefix), &info, |b, info| {
+            b.iter_batched(
+                || (state(), info.clone()),
+                |(mut state, mut info)| {
+                    let assembly = FlashblockAssembler::build::<_, NoopProvider>(
+                        &mut state,
+                        &ctx,
+                        &mut info,
+                        FlashblockId::default(),
+                        StateRootMode::Skip,
+                    )
+                    .expect("assembly should succeed");
+                    black_box(assembly.flashblock.diff.block_hash)
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, assembly_benches);
+criterion_main!(benches);

--- a/crates/builder/core/benches/state_root.rs
+++ b/crates/builder/core/benches/state_root.rs
@@ -1,18 +1,18 @@
-//! Benchmarks for state root computation during block building.
+//! Stress benchmarks for state root computation through the Base Proofs external trie overlay.
 //!
-//! Measures the cost of the two `calculate_state_root` modes with 10
-//! flashblocks at varying accounts-per-flashblock sizes:
+//! These benchmarks do not use the concrete `BlockchainProvider` used by the flashblocks payload
+//! builder and therefore do not measure mainnet block-building latency. They compare the shape of
+//! two root-computation strategies with 10 flashblocks at varying accounts-per-flashblock sizes:
 //!
 //! - `finalize_only` (`calculate_state_root = false`) — state root computed
-//!   once over the full accumulated state at finalization. This is the
-//!   **current production behavior**.
+//!   once over the full accumulated state at finalization, mirroring the builder's control flow.
 //!
 //! - `per_flashblock` (`calculate_state_root = true`) — state root
 //!   recomputed from scratch after every flashblock.
 //!
 //! The benchmarks use a RocksDB-backed [`RocksdbProofsStorage`] pre-populated with
 //! 50k base-state accounts so that state root computation exercises real disk
-//! I/O through the production trie overlay path.
+//! I/O through the Base Proofs trie overlay used by proof and RPC functionality.
 //!
 //! [`StateRootProvider::state_root_with_updates`] takes [`HashedPostState`] by
 //! value, so each iteration clones the post state. `finalize_only` clones the
@@ -138,8 +138,7 @@ fn create_populated_storage() -> (TempDir, BaseProofsStorage<Arc<RocksdbProofsSt
     (dir, storage)
 }
 
-/// Benchmarks `calculate_state_root = false`: state root computed once at
-/// finalization over the full accumulated state (current production behavior).
+/// Computes one root over the full accumulated state through the Base Proofs overlay.
 fn finalize_only_benches(c: &mut Criterion) {
     let mut g = c.benchmark_group("state_root/finalize_only");
     g.sample_size(10);
@@ -161,8 +160,7 @@ fn finalize_only_benches(c: &mut Criterion) {
     g.finish();
 }
 
-/// Benchmarks `calculate_state_root = true`: state root recomputed from
-/// scratch after every flashblock.
+/// Recomputes a root from scratch after every synthetic flashblock through the Base Proofs overlay.
 fn per_flashblock_benches(c: &mut Criterion) {
     let mut g = c.benchmark_group("state_root/per_flashblock");
     g.sample_size(10);

--- a/crates/builder/core/src/execution.rs
+++ b/crates/builder/core/src/execution.rs
@@ -203,7 +203,7 @@ pub struct FlashblocksExecutionInfo {
 }
 
 /// Accumulated execution state for the current block being built.
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct ExecutionInfo {
     /// All executed transactions (unrecovered).
     pub executed_transactions: Vec<BaseTransactionSigned>,

--- a/crates/builder/core/src/flashblocks/assembler.rs
+++ b/crates/builder/core/src/flashblocks/assembler.rs
@@ -69,11 +69,22 @@ pub enum StateRootMode {
     Compute,
 }
 
+/// Controls whether assembly populates the `base` field of the flashblock payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlashblockBaseMode {
+    /// Populate `base` for the first (fallback) flashblock of a block, which publishes it as-is.
+    Include,
+    /// Skip constructing `base` for intermediate flashblocks, whose callers discard it anyway.
+    Omit,
+}
+
 impl FlashblockAssembler {
     /// Builds a cumulative payload and the delta since the previous assembly pass.
     ///
     /// Intermediate flashblocks may skip state-root calculation. Final payloads and no-pool
-    /// synchronization payloads must request it. All fallible work runs before the bundle state
+    /// synchronization payloads must request it. Similarly, only the first (fallback) flashblock
+    /// of a block needs `flashblock.base` populated; later callers discard it immediately, so
+    /// `base_mode` lets them skip constructing it. All fallible work runs before the bundle state
     /// is consumed, so a failure can never leave `state` with a taken bundle or an advanced delta
     /// cursor to reuse; the REVM transition state is restored on every exit path (including
     /// failures), so `state` is left safe to reuse. Execution information (`info`) is only mutated
@@ -84,6 +95,7 @@ impl FlashblockAssembler {
         info: &mut ExecutionInfo,
         prev_flashblock_id: FlashblockId,
         state_root_mode: StateRootMode,
+        base_mode: FlashblockBaseMode,
     ) -> Result<FlashblockAssembly, PayloadBuilderError>
     where
         DB: revm::Database<Error = ProviderError> + AsRef<P>,
@@ -267,10 +279,8 @@ impl FlashblockAssembler {
                     }
                 };
 
-            let flashblock = FlashblocksPayloadV1 {
-                payload_id: ctx.payload_id(),
-                index: 0,
-                base: Some(ExecutionPayloadBaseV1 {
+            let base = match base_mode {
+                FlashblockBaseMode::Include => Some(ExecutionPayloadBaseV1 {
                     parent_beacon_block_root,
                     parent_hash: ctx.parent().hash(),
                     fee_recipient: ctx.attributes().payload_attributes.suggested_fee_recipient,
@@ -281,6 +291,13 @@ impl FlashblockAssembler {
                     extra_data,
                     base_fee_per_gas: U256::from(ctx.base_fee()),
                 }),
+                FlashblockBaseMode::Omit => None,
+            };
+
+            let flashblock = FlashblocksPayloadV1 {
+                payload_id: ctx.payload_id(),
+                index: 0,
+                base,
                 diff: ExecutionPayloadFlashblockDeltaV1 {
                     state_root,
                     receipts_root,
@@ -389,6 +406,7 @@ mod tests {
             &mut ExecutionInfo::default(),
             FlashblockId::default(),
             state_root_mode,
+            super::FlashblockBaseMode::Include,
         )
         .expect("assembly should succeed for an empty block")
     }
@@ -408,6 +426,29 @@ mod tests {
         assert_eq!(assembly.payload.block().state_root, B256::ZERO);
         assert_eq!(assembly.payload.block().number, 1);
         assert!(assembly.state_diff.is_empty());
+    }
+
+    #[test]
+    fn omits_base_when_requested() {
+        let ctx = BasePayloadBuilderCtx::for_test(minimal_chain_spec(), genesis_header());
+        let db = StateProviderDatabase::new(NoopProvider::default());
+        let mut state = State::builder().with_database(db).with_bundle_update().build();
+        let assembly = FlashblockAssembler::build::<_, NoopProvider>(
+            &mut state,
+            &ctx,
+            &mut ExecutionInfo::default(),
+            FlashblockId::default(),
+            super::StateRootMode::Skip,
+            super::FlashblockBaseMode::Omit,
+        )
+        .expect("assembly should succeed for an empty block");
+        assert!(assembly.flashblock.base.is_none());
+    }
+
+    #[test]
+    fn includes_base_when_requested() {
+        let assembly = build(super::StateRootMode::Skip);
+        assert!(assembly.flashblock.base.is_some());
     }
 
     #[test]
@@ -450,6 +491,7 @@ mod tests {
                 &mut info,
                 FlashblockId::default(),
                 super::StateRootMode::Skip,
+                super::FlashblockBaseMode::Include,
             )
             .expect("assembly should succeed");
 
@@ -472,6 +514,7 @@ mod tests {
             &mut ExecutionInfo::default(),
             FlashblockId::default(),
             super::StateRootMode::Skip,
+            super::FlashblockBaseMode::Include,
         )
         .expect_err("assembly should reject a block number mismatch");
         assert!(error.to_string().contains("block number mismatch"));
@@ -489,6 +532,7 @@ mod tests {
             &mut ExecutionInfo::default(),
             FlashblockId::default(),
             super::StateRootMode::Skip,
+            super::FlashblockBaseMode::Include,
         )
         .expect_err("assembly should reject a missing beacon block root");
         assert!(error.to_string().contains("parent beacon block root not found"));

--- a/crates/builder/core/src/flashblocks/assembler.rs
+++ b/crates/builder/core/src/flashblocks/assembler.rs
@@ -259,7 +259,6 @@ impl FlashblockAssembler {
                 receipts: Some(receipts_with_hash),
             }
         };
-        info.extra.last_flashblock_index = info.executed_transactions.len();
 
         let flashblock = FlashblocksPayloadV1 {
             payload_id: ctx.payload_id(),
@@ -297,7 +296,10 @@ impl FlashblockAssembler {
             metadata: serde_json::to_value(&metadata).unwrap_or_default(),
         };
 
-        state.take_bundle();
+        // Advance the delta cursor only after every fallible operation above has succeeded, so an
+        // early return never leaves `info` with an advanced cursor and no emitted flashblock.
+        info.extra.last_flashblock_index = info.executed_transactions.len();
+
         state.transition_state = untouched_transition_state;
 
         Ok(FlashblockAssembly {

--- a/crates/builder/core/src/flashblocks/assembler.rs
+++ b/crates/builder/core/src/flashblocks/assembler.rs
@@ -1,0 +1,527 @@
+//! Cumulative block and incremental flashblock assembly.
+
+use std::{sync::Arc, time::Instant};
+
+use alloy_consensus::{
+    BlockBody, EMPTY_OMMER_ROOT_HASH, Header, TxReceipt, constants::EMPTY_WITHDRAWALS, proofs,
+};
+use alloy_eips::{Encodable2718, eip7685::EMPTY_REQUESTS_HASH, merge::BEACON_NONCE};
+use alloy_primitives::{Address, B256, Bloom, U256, logs_bloom, map::foldhash::HashMap};
+use base_common_chains::Upgrades;
+use base_common_consensus::{BaseReceipt, BaseTransactionSigned};
+use base_common_flashblocks::{
+    ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, FlashblockId, FlashblocksPayloadV1,
+    Metadata,
+};
+use base_execution_consensus::{calculate_receipt_root_no_memo, isthmus};
+use base_execution_payload_builder::BaseBuiltPayload;
+use base_execution_txpool::AccountStateDiff;
+use reth_node_api::{BuiltPayloadExecutedBlock, PayloadBuilderError};
+use reth_payload_primitives::PayloadAttributes;
+use reth_primitives_traits::{Block, RecoveredBlock};
+use reth_provider::{
+    BlockExecutionOutput, BlockExecutionResult, HashedPostStateProvider, ProviderError,
+    StateRootProvider, StorageRootProvider,
+};
+use reth_revm::{State, db::states::bundle_state::BundleRetention};
+use reth_trie::{HashedPostState, updates::TrieUpdates};
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+use tracing::{Level, debug, span, warn};
+
+use crate::{BuilderMetrics, ExecutionInfo, flashblocks::BasePayloadBuilderCtx};
+
+/// The complete payload, incremental flashblock update, and pool invalidation state produced by
+/// one assembly pass.
+#[derive(Debug)]
+pub struct FlashblockAssembly {
+    /// Complete cumulative payload containing every transaction executed in the block so far.
+    pub payload: BaseBuiltPayload,
+    /// Incremental flashblock update containing transactions since the previous assembly pass.
+    pub flashblock: FlashblocksPayloadV1,
+    /// Account changes used to invalidate transactions that conflict with newly published state.
+    pub state_diff: Vec<AccountStateDiff>,
+}
+
+/// Metadata serialized into flashblock WebSocket messages.
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FlashblocksMetadata {
+    /// Metadata fields consumed by flashblock clients.
+    #[serde(flatten)]
+    pub metadata: Metadata,
+    /// Receipts for transactions in this flashblock (removed in Base 1.0).
+    pub receipts: Option<HashMap<B256, BaseReceipt>>,
+    /// Changed account balances (removed in Base 1.0).
+    pub new_account_balances: Option<HashMap<Address, U256>>,
+}
+
+/// Builds complete cumulative payloads and incremental flashblock updates from execution state.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FlashblockAssembler;
+
+/// Controls whether assembly computes the canonical state root and trie updates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StateRootMode {
+    /// Skip state-root computation for an intermediate flashblock.
+    Skip,
+    /// Compute the state root and trie updates for a final or synchronization payload.
+    Compute,
+}
+
+impl FlashblockAssembler {
+    /// Builds a cumulative payload and the delta since the previous assembly pass.
+    ///
+    /// Intermediate flashblocks may skip state-root calculation. Final payloads and no-pool
+    /// synchronization payloads must request it. The execution cursor is advanced after the delta
+    /// is captured, and the REVM transition state is restored for the next flashblock. If assembly
+    /// fails, callers must discard the state and execution information rather than retrying them.
+    pub fn build<DB, P>(
+        state: &mut State<DB>,
+        ctx: &BasePayloadBuilderCtx,
+        info: &mut ExecutionInfo,
+        prev_flashblock_id: FlashblockId,
+        state_root_mode: StateRootMode,
+    ) -> Result<FlashblockAssembly, PayloadBuilderError>
+    where
+        DB: revm::Database<Error = ProviderError> + AsRef<P>,
+        P: StateRootProvider + HashedPostStateProvider + StorageRootProvider,
+    {
+        // We use it to preserve state, so we run merge_transitions on transition state at most once
+        let untouched_transition_state = state.transition_state.clone();
+        let state_merge_start_time = Instant::now();
+        state.merge_transitions(BundleRetention::Reverts);
+        let state_transition_merge_time = state_merge_start_time.elapsed();
+        BuilderMetrics::state_transition_merge_duration().record(state_transition_merge_time);
+        BuilderMetrics::state_transition_merge_gauge().set(state_transition_merge_time);
+
+        let block_number = ctx.block_number();
+        let expected = ctx.parent().number + 1;
+        if block_number != expected {
+            return Err(PayloadBuilderError::Other(
+                eyre::eyre!(
+                    "build context block number mismatch: expected {}, got {}",
+                    expected,
+                    block_number
+                )
+                .into(),
+            ));
+        }
+
+        let receipts_root = calculate_receipt_root_no_memo(
+            &info.receipts,
+            &ctx.chain_spec,
+            ctx.attributes().timestamp(),
+        );
+        let logs_bloom: Bloom = logs_bloom(info.receipts.iter().flat_map(|r| r.logs()));
+
+        let state_root_start_time = Instant::now();
+        let mut state_root = B256::ZERO;
+        let mut trie_output = TrieUpdates::default();
+        let mut hashed_state = HashedPostState::default();
+
+        if state_root_mode == StateRootMode::Compute {
+            let state_root_span = span!(
+                Level::INFO,
+                "calculate_state_root",
+                block_number = ctx.block_number(),
+                parent_hash = %ctx.parent().hash(),
+            );
+            let _state_root_span_guard = state_root_span.enter();
+
+            let state_provider = state.database.as_ref();
+            hashed_state = state_provider.hashed_post_state(&state.bundle_state);
+            (state_root, trie_output) = state_provider
+                .state_root_with_updates(hashed_state.clone())
+                .inspect_err(|err| {
+                    warn!(target: "payload_builder",
+                        parent_header=%ctx.parent().hash(),
+                        %err,
+                        "failed to calculate state root for payload"
+                    );
+                })?;
+            let state_root_calculation_time = state_root_start_time.elapsed();
+            BuilderMetrics::state_root_calculation_duration().record(state_root_calculation_time);
+            BuilderMetrics::state_root_calculation_gauge().set(state_root_calculation_time);
+        }
+
+        let mut requests_hash = None;
+        let withdrawals_root =
+            if ctx.chain_spec.is_isthmus_active_at_timestamp(ctx.attributes().timestamp()) {
+                requests_hash = Some(EMPTY_REQUESTS_HASH);
+                Some(
+                    isthmus::withdrawals_root(&state.bundle_state, state.database.as_ref())
+                        .map_err(PayloadBuilderError::other)?,
+                )
+            } else if ctx.chain_spec.is_canyon_active_at_timestamp(ctx.attributes().timestamp()) {
+                Some(EMPTY_WITHDRAWALS)
+            } else {
+                None
+            };
+
+        let transactions_root = proofs::calculate_transaction_root(&info.executed_transactions);
+        let (excess_blob_gas, blob_gas_used) = ctx.blob_fields(info);
+        let extra_data = ctx.extra_data()?;
+
+        let header = Header {
+            parent_hash: ctx.parent().hash(),
+            ommers_hash: EMPTY_OMMER_ROOT_HASH,
+            beneficiary: ctx.evm_env.block_env.beneficiary,
+            state_root,
+            transactions_root,
+            receipts_root,
+            withdrawals_root,
+            logs_bloom,
+            timestamp: ctx.attributes().payload_attributes.timestamp,
+            mix_hash: ctx.attributes().payload_attributes.prev_randao,
+            nonce: BEACON_NONCE.into(),
+            base_fee_per_gas: Some(ctx.base_fee()),
+            number: ctx.parent().number + 1,
+            gas_limit: ctx.block_gas_limit(),
+            difficulty: U256::ZERO,
+            gas_used: info.cumulative_gas_used,
+            extra_data,
+            parent_beacon_block_root: ctx.attributes().payload_attributes.parent_beacon_block_root,
+            blob_gas_used,
+            excess_blob_gas,
+            requests_hash,
+            block_access_list_hash: None,
+            slot_number: ctx.attributes().payload_attributes.slot_number,
+        };
+
+        let block = alloy_consensus::Block::<BaseTransactionSigned>::new(
+            header,
+            BlockBody {
+                transactions: info.executed_transactions.clone(),
+                ommers: vec![],
+                withdrawals: ctx.withdrawals().cloned(),
+            },
+        );
+        let recovered_block =
+            RecoveredBlock::new_unhashed(block.clone(), info.executed_senders.clone());
+
+        // Read the invalidation diff before take_bundle() empties the bundle state.
+        let state_diff = AccountStateDiff::collect_for_intra_block(&state.bundle_state);
+        let legacy_account_balances = (!ctx
+            .chain_spec
+            .is_azul_active_at_timestamp(ctx.attributes().timestamp()))
+        .then(|| {
+            state
+                .bundle_state
+                .state
+                .iter()
+                .filter_map(|(address, account)| {
+                    account.info.as_ref().map(|info| (*address, info.balance))
+                })
+                .collect::<HashMap<Address, U256>>()
+        });
+
+        let executed = BuiltPayloadExecutedBlock {
+            recovered_block: Arc::new(recovered_block),
+            execution_output: Arc::new(BlockExecutionOutput {
+                result: BlockExecutionResult {
+                    receipts: info.receipts.clone(),
+                    requests: vec![].into(),
+                    gas_used: info.cumulative_gas_used,
+                    blob_gas_used: 0,
+                },
+                state: state.take_bundle(),
+            }),
+            hashed_state: Arc::new(hashed_state),
+            trie_updates: Arc::new(trie_output),
+        };
+        debug!(target: "payload_builder", message = "Executed block created");
+
+        let sealed_block = Arc::new(block.seal_slow());
+        debug!(target: "payload_builder", ?sealed_block, "sealed built block");
+        let block_hash = sealed_block.hash();
+
+        let delta_start = info.extra.last_flashblock_index;
+        let new_transactions = &info.executed_transactions[delta_start..];
+        let new_transactions_encoded =
+            new_transactions.iter().map(|tx| tx.encoded_2718().into()).collect::<Vec<_>>();
+
+        let metadata = if ctx.chain_spec.is_azul_active_at_timestamp(ctx.attributes().timestamp()) {
+            FlashblocksMetadata {
+                metadata: Metadata { block_number: ctx.parent().number + 1, prev_flashblock_id },
+                receipts: None,
+                new_account_balances: None,
+            }
+        } else {
+            let receipts_with_hash = new_transactions
+                .iter()
+                .zip(info.receipts[delta_start..].iter())
+                .map(|(tx, receipt)| (tx.tx_hash(), receipt.clone()))
+                .collect::<HashMap<B256, BaseReceipt>>();
+            FlashblocksMetadata {
+                metadata: Metadata { block_number: ctx.parent().number + 1, prev_flashblock_id },
+                new_account_balances: legacy_account_balances,
+                receipts: Some(receipts_with_hash),
+            }
+        };
+        info.extra.last_flashblock_index = info.executed_transactions.len();
+
+        let flashblock = FlashblocksPayloadV1 {
+            payload_id: ctx.payload_id(),
+            index: 0,
+            base: Some(ExecutionPayloadBaseV1 {
+                parent_beacon_block_root: ctx
+                    .attributes()
+                    .payload_attributes
+                    .parent_beacon_block_root
+                    .ok_or_else(|| {
+                        PayloadBuilderError::Other(
+                            eyre::eyre!("parent beacon block root not found").into(),
+                        )
+                    })?,
+                parent_hash: ctx.parent().hash(),
+                fee_recipient: ctx.attributes().payload_attributes.suggested_fee_recipient,
+                prev_randao: ctx.attributes().payload_attributes.prev_randao,
+                block_number: ctx.parent().number + 1,
+                gas_limit: ctx.block_gas_limit(),
+                timestamp: ctx.attributes().payload_attributes.timestamp,
+                extra_data: ctx.extra_data()?,
+                base_fee_per_gas: ctx.base_fee().try_into().unwrap(),
+            }),
+            diff: ExecutionPayloadFlashblockDeltaV1 {
+                state_root,
+                receipts_root,
+                logs_bloom,
+                gas_used: info.cumulative_gas_used,
+                block_hash,
+                transactions: new_transactions_encoded,
+                withdrawals: ctx.withdrawals().cloned().unwrap_or_default().to_vec(),
+                withdrawals_root: withdrawals_root.unwrap_or_default(),
+                blob_gas_used,
+            },
+            metadata: serde_json::to_value(&metadata).unwrap_or_default(),
+        };
+
+        state.take_bundle();
+        state.transition_state = untouched_transition_state;
+
+        Ok(FlashblockAssembly {
+            payload: BaseBuiltPayload::new(
+                ctx.payload_id(),
+                sealed_block,
+                info.total_fees,
+                Some(executed),
+                None,
+            ),
+            flashblock,
+            state_diff,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use alloy_consensus::{Header, Receipt, TxEip1559};
+    use alloy_primitives::{Address, B256, Log, TxKind, U256, map::foldhash::HashMap};
+    use base_common_consensus::{BaseReceipt, BaseTypedTransaction};
+    use base_common_flashblocks::{FlashblockId, Metadata};
+    use base_execution_chainspec::BaseChainSpec;
+    use reth_chainspec::ChainSpec;
+    use reth_primitives_traits::SealedHeader;
+    use reth_provider::noop::NoopProvider;
+    use reth_revm::{State, database::StateProviderDatabase};
+
+    use super::{FlashblockAssembler, FlashblocksMetadata};
+    use crate::{
+        ExecutionInfo,
+        flashblocks::BasePayloadBuilderCtx,
+        test_utils::{generate_signer_from_seed, sign_base_tx},
+    };
+
+    fn minimal_chain_spec() -> Arc<BaseChainSpec> {
+        let genesis = serde_json::from_value(serde_json::json!({
+            "config": { "chainId": 901 },
+            "gasLimit": "0x1C9C380",
+            "timestamp": "0x0"
+        }))
+        .expect("valid genesis");
+        let inner =
+            ChainSpec::builder().chain(901.into()).genesis(genesis).cancun_activated().build();
+        Arc::new(BaseChainSpec::from(inner))
+    }
+
+    fn genesis_header() -> Arc<SealedHeader> {
+        Arc::new(SealedHeader::seal_slow(Header {
+            gas_limit: 30_000_000,
+            timestamp: 0,
+            ..Default::default()
+        }))
+    }
+
+    fn build(state_root_mode: super::StateRootMode) -> super::FlashblockAssembly {
+        let ctx = BasePayloadBuilderCtx::for_test(minimal_chain_spec(), genesis_header());
+        let db = StateProviderDatabase::new(NoopProvider::default());
+        let mut state = State::builder().with_database(db).with_bundle_update().build();
+        FlashblockAssembler::build::<_, NoopProvider>(
+            &mut state,
+            &ctx,
+            &mut ExecutionInfo::default(),
+            FlashblockId::default(),
+            state_root_mode,
+        )
+        .expect("assembly should succeed for an empty block")
+    }
+
+    #[test]
+    fn builds_empty_block_without_state_root() {
+        let assembly = build(super::StateRootMode::Skip);
+        assert_eq!(assembly.payload.block().number, 1);
+        assert_eq!(assembly.payload.block().gas_used, 0);
+        assert_eq!(assembly.flashblock.diff.block_hash, assembly.payload.block().hash());
+        assert!(assembly.state_diff.is_empty());
+    }
+
+    #[test]
+    fn builds_empty_block_with_state_root() {
+        let assembly = build(super::StateRootMode::Compute);
+        assert_eq!(assembly.payload.block().state_root, B256::ZERO);
+        assert_eq!(assembly.payload.block().number, 1);
+        assert!(assembly.state_diff.is_empty());
+    }
+
+    #[test]
+    fn emits_incremental_deltas_for_cumulative_payloads() {
+        let ctx = BasePayloadBuilderCtx::for_test(minimal_chain_spec(), genesis_header());
+        let mut state = State::builder()
+            .with_database(StateProviderDatabase::new(NoopProvider::default()))
+            .with_bundle_update()
+            .build();
+        let signer = generate_signer_from_seed("cumulative-assembly-test");
+        let mut info = ExecutionInfo::with_capacity(2);
+
+        for nonce in 0..2 {
+            let transaction = sign_base_tx(
+                &signer,
+                BaseTypedTransaction::Eip1559(TxEip1559 {
+                    chain_id: 901,
+                    nonce,
+                    gas_limit: 21_000,
+                    max_fee_per_gas: 1_000_000_000,
+                    to: TxKind::Call(signer.address()),
+                    value: U256::from(1u64),
+                    ..Default::default()
+                }),
+            )
+            .expect("sign transaction")
+            .into_inner();
+            info.executed_transactions.push(transaction);
+            info.executed_senders.push(signer.address());
+            info.receipts.push(BaseReceipt::Eip1559(Receipt {
+                status: true.into(),
+                cumulative_gas_used: (nonce + 1) * 21_000,
+                logs: Vec::new(),
+            }));
+            info.cumulative_gas_used = (nonce + 1) * 21_000;
+
+            let assembly = FlashblockAssembler::build::<_, NoopProvider>(
+                &mut state,
+                &ctx,
+                &mut info,
+                FlashblockId::default(),
+                super::StateRootMode::Skip,
+            )
+            .expect("assembly should succeed");
+
+            assert_eq!(assembly.payload.block().body().transactions.len(), nonce as usize + 1);
+            assert_eq!(assembly.flashblock.diff.transactions.len(), 1);
+            assert_eq!(assembly.flashblock.diff.gas_used, (nonce + 1) * 21_000);
+            assert_eq!(assembly.flashblock.diff.block_hash, assembly.payload.block().hash());
+        }
+    }
+
+    #[test]
+    fn rejects_block_number_mismatch() {
+        let mut ctx = BasePayloadBuilderCtx::for_test(minimal_chain_spec(), genesis_header());
+        ctx.evm_env.block_env.number = U256::from(99);
+        let db = StateProviderDatabase::new(NoopProvider::default());
+        let mut state = State::builder().with_database(db).with_bundle_update().build();
+        let error = FlashblockAssembler::build::<_, NoopProvider>(
+            &mut state,
+            &ctx,
+            &mut ExecutionInfo::default(),
+            FlashblockId::default(),
+            super::StateRootMode::Skip,
+        )
+        .expect_err("assembly should reject a block number mismatch");
+        assert!(error.to_string().contains("block number mismatch"));
+    }
+
+    #[test]
+    fn rejects_missing_beacon_block_root() {
+        let mut ctx = BasePayloadBuilderCtx::for_test(minimal_chain_spec(), genesis_header());
+        ctx.config.attributes.payload_attributes.parent_beacon_block_root = None;
+        let db = StateProviderDatabase::new(NoopProvider::default());
+        let mut state = State::builder().with_database(db).with_bundle_update().build();
+        let error = FlashblockAssembler::build::<_, NoopProvider>(
+            &mut state,
+            &ctx,
+            &mut ExecutionInfo::default(),
+            FlashblockId::default(),
+            super::StateRootMode::Skip,
+        )
+        .expect_err("assembly should reject a missing beacon block root");
+        assert!(error.to_string().contains("parent beacon block root not found"));
+    }
+
+    fn metadata() -> FlashblocksMetadata {
+        let tx_hash = B256::from([0xAA; 32]);
+        let address = Address::from([0xBB; 20]);
+        let receipt = BaseReceipt::Eip1559(Receipt {
+            status: true.into(),
+            cumulative_gas_used: 21_000,
+            logs: Vec::<Log>::new(),
+        });
+        FlashblocksMetadata {
+            receipts: Some(HashMap::from_iter([(tx_hash, receipt)])),
+            new_account_balances: Some(HashMap::from_iter([(
+                address,
+                U256::from(1_000_000_000_000_000_000u128),
+            )])),
+            metadata: Metadata {
+                block_number: 42,
+                prev_flashblock_id: FlashblockId { block_number: 41, index: 10 },
+            },
+        }
+    }
+
+    #[test]
+    fn flashblocks_metadata_json_format_is_stable() {
+        let json = serde_json::to_value(metadata()).unwrap();
+        let object = json.as_object().unwrap();
+        let mut keys: Vec<&String> = object.keys().collect();
+        keys.sort();
+        assert_eq!(
+            keys,
+            vec!["block_number", "new_account_balances", "prev_flashblock_id", "receipts"]
+        );
+        assert_eq!(object["block_number"], serde_json::json!(42));
+        assert_eq!(object["prev_flashblock_id"], serde_json::json!("41-10"));
+        let tx_key = format!("{:#x}", B256::from([0xAA; 32]));
+        assert_eq!(object["receipts"][tx_key]["type"], "0x2");
+        let address_key = format!("{:#x}", Address::from([0xBB; 20]));
+        assert!(object["new_account_balances"].get(address_key).is_some());
+    }
+
+    #[test]
+    fn client_metadata_deserializes_from_builder_metadata() {
+        let client: Metadata = serde_json::from_value(serde_json::to_value(metadata()).unwrap())
+            .expect("client metadata should parse builder metadata");
+        assert_eq!(client.block_number, 42);
+        assert_eq!(client.prev_flashblock_id, FlashblockId { block_number: 41, index: 10 });
+    }
+
+    #[test]
+    fn client_metadata_deserializes_from_v0_4_1_format() {
+        let metadata: Metadata =
+            serde_json::from_value(serde_json::json!({"block_number": 123})).unwrap();
+        assert_eq!(metadata.block_number, 123);
+        assert_eq!(metadata.prev_flashblock_id, FlashblockId::default());
+    }
+}

--- a/crates/builder/core/src/flashblocks/assembler.rs
+++ b/crates/builder/core/src/flashblocks/assembler.rs
@@ -312,7 +312,7 @@ impl FlashblockAssembler {
                     withdrawals_root: withdrawals_root.unwrap_or_default(),
                     blob_gas_used,
                 },
-                metadata: serde_json::to_value(&metadata).unwrap_or_default(),
+                metadata: serde_json::to_value(&metadata).map_err(PayloadBuilderError::other)?,
             };
 
             // Advance the delta cursor only after every fallible operation above has succeeded, so an

--- a/crates/builder/core/src/flashblocks/assembler.rs
+++ b/crates/builder/core/src/flashblocks/assembler.rs
@@ -172,11 +172,8 @@ impl FlashblockAssembler {
             let transactions_root = proofs::calculate_transaction_root(&info.executed_transactions);
             let (excess_blob_gas, blob_gas_used) = ctx.blob_fields(info);
             let extra_data = ctx.extra_data()?;
-            let parent_beacon_block_root = ctx
-                .attributes()
-                .payload_attributes
-                .parent_beacon_block_root
-                .ok_or_else(|| {
+            let parent_beacon_block_root =
+                ctx.attributes().payload_attributes.parent_beacon_block_root.ok_or_else(|| {
                     PayloadBuilderError::Other(
                         eyre::eyre!("parent beacon block root not found").into(),
                     )

--- a/crates/builder/core/src/flashblocks/assembler.rs
+++ b/crates/builder/core/src/flashblocks/assembler.rs
@@ -73,8 +73,9 @@ impl FlashblockAssembler {
     /// Builds a cumulative payload and the delta since the previous assembly pass.
     ///
     /// Intermediate flashblocks may skip state-root calculation. Final payloads and no-pool
-    /// synchronization payloads must request it. The execution cursor is advanced after the delta
-    /// is captured, and the REVM transition state is restored on every exit path (including
+    /// synchronization payloads must request it. All fallible work runs before the bundle state
+    /// is consumed, so a failure can never leave `state` with a taken bundle or an advanced delta
+    /// cursor to reuse; the REVM transition state is restored on every exit path (including
     /// failures), so `state` is left safe to reuse. Execution information (`info`) is only mutated
     /// once assembly succeeds; on failure the delta cursor is left untouched.
     pub fn build<DB, P>(
@@ -171,6 +172,15 @@ impl FlashblockAssembler {
             let transactions_root = proofs::calculate_transaction_root(&info.executed_transactions);
             let (excess_blob_gas, blob_gas_used) = ctx.blob_fields(info);
             let extra_data = ctx.extra_data()?;
+            let parent_beacon_block_root = ctx
+                .attributes()
+                .payload_attributes
+                .parent_beacon_block_root
+                .ok_or_else(|| {
+                    PayloadBuilderError::Other(
+                        eyre::eyre!("parent beacon block root not found").into(),
+                    )
+                })?;
 
             let header = Header {
                 parent_hash: ctx.parent().hash(),
@@ -189,11 +199,8 @@ impl FlashblockAssembler {
                 gas_limit: ctx.block_gas_limit(),
                 difficulty: U256::ZERO,
                 gas_used: info.cumulative_gas_used,
-                extra_data,
-                parent_beacon_block_root: ctx
-                    .attributes()
-                    .payload_attributes
-                    .parent_beacon_block_root,
+                extra_data: extra_data.clone(),
+                parent_beacon_block_root: Some(parent_beacon_block_root),
                 blob_gas_used,
                 excess_blob_gas,
                 requests_hash,
@@ -209,8 +216,12 @@ impl FlashblockAssembler {
                     withdrawals: ctx.withdrawals().cloned(),
                 },
             );
-            let recovered_block =
-                RecoveredBlock::new_unhashed(block.clone(), info.executed_senders.clone());
+
+            // Seal once to get the hash, then hand it to the recovered block below so the
+            // latter never has to hash its (identical) header again on first access.
+            let sealed_block = Arc::new(block.clone().seal_slow());
+            let block_hash = sealed_block.hash();
+            debug!(target: "payload_builder", ?sealed_block, "sealed built block");
 
             // Read the invalidation diff before take_bundle() empties the bundle state.
             let state_diff = AccountStateDiff::collect_for_intra_block(&state.bundle_state);
@@ -227,26 +238,6 @@ impl FlashblockAssembler {
                     })
                     .collect::<HashMap<Address, U256>>()
             });
-
-            let executed = BuiltPayloadExecutedBlock {
-                recovered_block: Arc::new(recovered_block),
-                execution_output: Arc::new(BlockExecutionOutput {
-                    result: BlockExecutionResult {
-                        receipts: info.receipts.clone(),
-                        requests: vec![].into(),
-                        gas_used: info.cumulative_gas_used,
-                        blob_gas_used: 0,
-                    },
-                    state: state.take_bundle(),
-                }),
-                hashed_state: Arc::new(hashed_state),
-                trie_updates: Arc::new(trie_output),
-            };
-            debug!(target: "payload_builder", message = "Executed block created");
-
-            let sealed_block = Arc::new(block.seal_slow());
-            debug!(target: "payload_builder", ?sealed_block, "sealed built block");
-            let block_hash = sealed_block.hash();
 
             let delta_start = info.extra.last_flashblock_index;
             let new_transactions = &info.executed_transactions[delta_start..];
@@ -283,23 +274,15 @@ impl FlashblockAssembler {
                 payload_id: ctx.payload_id(),
                 index: 0,
                 base: Some(ExecutionPayloadBaseV1 {
-                    parent_beacon_block_root: ctx
-                        .attributes()
-                        .payload_attributes
-                        .parent_beacon_block_root
-                        .ok_or_else(|| {
-                            PayloadBuilderError::Other(
-                                eyre::eyre!("parent beacon block root not found").into(),
-                            )
-                        })?,
+                    parent_beacon_block_root,
                     parent_hash: ctx.parent().hash(),
                     fee_recipient: ctx.attributes().payload_attributes.suggested_fee_recipient,
                     prev_randao: ctx.attributes().payload_attributes.prev_randao,
                     block_number: ctx.parent().number + 1,
                     gas_limit: ctx.block_gas_limit(),
                     timestamp: ctx.attributes().payload_attributes.timestamp,
-                    extra_data: ctx.extra_data()?,
-                    base_fee_per_gas: ctx.base_fee().try_into().unwrap(),
+                    extra_data,
+                    base_fee_per_gas: U256::from(ctx.base_fee()),
                 }),
                 diff: ExecutionPayloadFlashblockDeltaV1 {
                     state_root,
@@ -315,8 +298,27 @@ impl FlashblockAssembler {
                 metadata: serde_json::to_value(&metadata).map_err(PayloadBuilderError::other)?,
             };
 
-            // Advance the delta cursor only after every fallible operation above has succeeded, so an
-            // early return never leaves `info` with an advanced cursor and no emitted flashblock.
+            // Every fallible operation above has now succeeded, so it's safe to consume the
+            // bundle state and advance the delta cursor: no later `?` can leave `state` or
+            // `info` half-updated.
+            let recovered_block =
+                RecoveredBlock::new(block, info.executed_senders.clone(), block_hash);
+            let executed = BuiltPayloadExecutedBlock {
+                recovered_block: Arc::new(recovered_block),
+                execution_output: Arc::new(BlockExecutionOutput {
+                    result: BlockExecutionResult {
+                        receipts: info.receipts.clone(),
+                        requests: vec![].into(),
+                        gas_used: info.cumulative_gas_used,
+                        blob_gas_used: 0,
+                    },
+                    state: state.take_bundle(),
+                }),
+                hashed_state: Arc::new(hashed_state),
+                trie_updates: Arc::new(trie_output),
+            };
+            debug!(target: "payload_builder", message = "Executed block created");
+
             info.extra.last_flashblock_index = info.executed_transactions.len();
 
             Ok(FlashblockAssembly {

--- a/crates/builder/core/src/flashblocks/assembler.rs
+++ b/crates/builder/core/src/flashblocks/assembler.rs
@@ -74,8 +74,9 @@ impl FlashblockAssembler {
     ///
     /// Intermediate flashblocks may skip state-root calculation. Final payloads and no-pool
     /// synchronization payloads must request it. The execution cursor is advanced after the delta
-    /// is captured, and the REVM transition state is restored for the next flashblock. If assembly
-    /// fails, callers must discard the state and execution information rather than retrying them.
+    /// is captured, and the REVM transition state is restored on every exit path (including
+    /// failures), so `state` is left safe to reuse. Execution information (`info`) is only mutated
+    /// once assembly succeeds; on failure the delta cursor is left untouched.
     pub fn build<DB, P>(
         state: &mut State<DB>,
         ctx: &BasePayloadBuilderCtx,
@@ -87,14 +88,8 @@ impl FlashblockAssembler {
         DB: revm::Database<Error = ProviderError> + AsRef<P>,
         P: StateRootProvider + HashedPostStateProvider + StorageRootProvider,
     {
-        // We use it to preserve state, so we run merge_transitions on transition state at most once
-        let untouched_transition_state = state.transition_state.clone();
-        let state_merge_start_time = Instant::now();
-        state.merge_transitions(BundleRetention::Reverts);
-        let state_transition_merge_time = state_merge_start_time.elapsed();
-        BuilderMetrics::state_transition_merge_duration().record(state_transition_merge_time);
-        BuilderMetrics::state_transition_merge_gauge().set(state_transition_merge_time);
-
+        // Reject a mismatched build context before touching `state`, so a cheap precondition
+        // failure leaves the REVM state completely untouched.
         let block_number = ctx.block_number();
         let expected = ctx.parent().number + 1;
         if block_number != expected {
@@ -108,211 +103,239 @@ impl FlashblockAssembler {
             ));
         }
 
-        let receipts_root = calculate_receipt_root_no_memo(
-            &info.receipts,
-            &ctx.chain_spec,
-            ctx.attributes().timestamp(),
-        );
-        let logs_bloom: Bloom = logs_bloom(info.receipts.iter().flat_map(|r| r.logs()));
+        // Snapshot the transition state before merging so it can be restored on every exit path
+        // (see the end of this function), keeping `state` safe to reuse even if assembly fails.
+        let untouched_transition_state = state.transition_state.clone();
+        let state_merge_start_time = Instant::now();
+        state.merge_transitions(BundleRetention::Reverts);
+        let state_transition_merge_time = state_merge_start_time.elapsed();
+        BuilderMetrics::state_transition_merge_duration().record(state_transition_merge_time);
+        BuilderMetrics::state_transition_merge_gauge().set(state_transition_merge_time);
 
-        let state_root_start_time = Instant::now();
-        let mut state_root = B256::ZERO;
-        let mut trie_output = TrieUpdates::default();
-        let mut hashed_state = HashedPostState::default();
-
-        if state_root_mode == StateRootMode::Compute {
-            let state_root_span = span!(
-                Level::INFO,
-                "calculate_state_root",
-                block_number = ctx.block_number(),
-                parent_hash = %ctx.parent().hash(),
+        // Run all fallible work inside this closure so `state.transition_state` is restored
+        // afterwards whether assembly succeeds or bails out early via `?`.
+        let assembly = (|| -> Result<FlashblockAssembly, PayloadBuilderError> {
+            let receipts_root = calculate_receipt_root_no_memo(
+                &info.receipts,
+                &ctx.chain_spec,
+                ctx.attributes().timestamp(),
             );
-            let _state_root_span_guard = state_root_span.enter();
+            let logs_bloom: Bloom = logs_bloom(info.receipts.iter().flat_map(|r| r.logs()));
 
-            let state_provider = state.database.as_ref();
-            hashed_state = state_provider.hashed_post_state(&state.bundle_state);
-            (state_root, trie_output) = state_provider
-                .state_root_with_updates(hashed_state.clone())
-                .inspect_err(|err| {
-                    warn!(target: "payload_builder",
-                        parent_header=%ctx.parent().hash(),
-                        %err,
-                        "failed to calculate state root for payload"
-                    );
-                })?;
-            let state_root_calculation_time = state_root_start_time.elapsed();
-            BuilderMetrics::state_root_calculation_duration().record(state_root_calculation_time);
-            BuilderMetrics::state_root_calculation_gauge().set(state_root_calculation_time);
-        }
+            let state_root_start_time = Instant::now();
+            let mut state_root = B256::ZERO;
+            let mut trie_output = TrieUpdates::default();
+            let mut hashed_state = HashedPostState::default();
 
-        let mut requests_hash = None;
-        let withdrawals_root =
-            if ctx.chain_spec.is_isthmus_active_at_timestamp(ctx.attributes().timestamp()) {
-                requests_hash = Some(EMPTY_REQUESTS_HASH);
-                Some(
-                    isthmus::withdrawals_root(&state.bundle_state, state.database.as_ref())
-                        .map_err(PayloadBuilderError::other)?,
-                )
-            } else if ctx.chain_spec.is_canyon_active_at_timestamp(ctx.attributes().timestamp()) {
-                Some(EMPTY_WITHDRAWALS)
-            } else {
-                None
-            };
+            if state_root_mode == StateRootMode::Compute {
+                let state_root_span = span!(
+                    Level::INFO,
+                    "calculate_state_root",
+                    block_number = ctx.block_number(),
+                    parent_hash = %ctx.parent().hash(),
+                );
+                let _state_root_span_guard = state_root_span.enter();
 
-        let transactions_root = proofs::calculate_transaction_root(&info.executed_transactions);
-        let (excess_blob_gas, blob_gas_used) = ctx.blob_fields(info);
-        let extra_data = ctx.extra_data()?;
-
-        let header = Header {
-            parent_hash: ctx.parent().hash(),
-            ommers_hash: EMPTY_OMMER_ROOT_HASH,
-            beneficiary: ctx.evm_env.block_env.beneficiary,
-            state_root,
-            transactions_root,
-            receipts_root,
-            withdrawals_root,
-            logs_bloom,
-            timestamp: ctx.attributes().payload_attributes.timestamp,
-            mix_hash: ctx.attributes().payload_attributes.prev_randao,
-            nonce: BEACON_NONCE.into(),
-            base_fee_per_gas: Some(ctx.base_fee()),
-            number: ctx.parent().number + 1,
-            gas_limit: ctx.block_gas_limit(),
-            difficulty: U256::ZERO,
-            gas_used: info.cumulative_gas_used,
-            extra_data,
-            parent_beacon_block_root: ctx.attributes().payload_attributes.parent_beacon_block_root,
-            blob_gas_used,
-            excess_blob_gas,
-            requests_hash,
-            block_access_list_hash: None,
-            slot_number: ctx.attributes().payload_attributes.slot_number,
-        };
-
-        let block = alloy_consensus::Block::<BaseTransactionSigned>::new(
-            header,
-            BlockBody {
-                transactions: info.executed_transactions.clone(),
-                ommers: vec![],
-                withdrawals: ctx.withdrawals().cloned(),
-            },
-        );
-        let recovered_block =
-            RecoveredBlock::new_unhashed(block.clone(), info.executed_senders.clone());
-
-        // Read the invalidation diff before take_bundle() empties the bundle state.
-        let state_diff = AccountStateDiff::collect_for_intra_block(&state.bundle_state);
-        let legacy_account_balances = (!ctx
-            .chain_spec
-            .is_azul_active_at_timestamp(ctx.attributes().timestamp()))
-        .then(|| {
-            state
-                .bundle_state
-                .state
-                .iter()
-                .filter_map(|(address, account)| {
-                    account.info.as_ref().map(|info| (*address, info.balance))
-                })
-                .collect::<HashMap<Address, U256>>()
-        });
-
-        let executed = BuiltPayloadExecutedBlock {
-            recovered_block: Arc::new(recovered_block),
-            execution_output: Arc::new(BlockExecutionOutput {
-                result: BlockExecutionResult {
-                    receipts: info.receipts.clone(),
-                    requests: vec![].into(),
-                    gas_used: info.cumulative_gas_used,
-                    blob_gas_used: 0,
-                },
-                state: state.take_bundle(),
-            }),
-            hashed_state: Arc::new(hashed_state),
-            trie_updates: Arc::new(trie_output),
-        };
-        debug!(target: "payload_builder", message = "Executed block created");
-
-        let sealed_block = Arc::new(block.seal_slow());
-        debug!(target: "payload_builder", ?sealed_block, "sealed built block");
-        let block_hash = sealed_block.hash();
-
-        let delta_start = info.extra.last_flashblock_index;
-        let new_transactions = &info.executed_transactions[delta_start..];
-        let new_transactions_encoded =
-            new_transactions.iter().map(|tx| tx.encoded_2718().into()).collect::<Vec<_>>();
-
-        let metadata = if ctx.chain_spec.is_azul_active_at_timestamp(ctx.attributes().timestamp()) {
-            FlashblocksMetadata {
-                metadata: Metadata { block_number: ctx.parent().number + 1, prev_flashblock_id },
-                receipts: None,
-                new_account_balances: None,
+                let state_provider = state.database.as_ref();
+                hashed_state = state_provider.hashed_post_state(&state.bundle_state);
+                (state_root, trie_output) = state_provider
+                    .state_root_with_updates(hashed_state.clone())
+                    .inspect_err(|err| {
+                        warn!(target: "payload_builder",
+                            parent_header=%ctx.parent().hash(),
+                            %err,
+                            "failed to calculate state root for payload"
+                        );
+                    })?;
+                let state_root_calculation_time = state_root_start_time.elapsed();
+                BuilderMetrics::state_root_calculation_duration()
+                    .record(state_root_calculation_time);
+                BuilderMetrics::state_root_calculation_gauge().set(state_root_calculation_time);
             }
-        } else {
-            let receipts_with_hash = new_transactions
-                .iter()
-                .zip(info.receipts[delta_start..].iter())
-                .map(|(tx, receipt)| (tx.tx_hash(), receipt.clone()))
-                .collect::<HashMap<B256, BaseReceipt>>();
-            FlashblocksMetadata {
-                metadata: Metadata { block_number: ctx.parent().number + 1, prev_flashblock_id },
-                new_account_balances: legacy_account_balances,
-                receipts: Some(receipts_with_hash),
-            }
-        };
 
-        let flashblock = FlashblocksPayloadV1 {
-            payload_id: ctx.payload_id(),
-            index: 0,
-            base: Some(ExecutionPayloadBaseV1 {
+            let mut requests_hash = None;
+            let withdrawals_root =
+                if ctx.chain_spec.is_isthmus_active_at_timestamp(ctx.attributes().timestamp()) {
+                    requests_hash = Some(EMPTY_REQUESTS_HASH);
+                    Some(
+                        isthmus::withdrawals_root(&state.bundle_state, state.database.as_ref())
+                            .map_err(PayloadBuilderError::other)?,
+                    )
+                } else if ctx.chain_spec.is_canyon_active_at_timestamp(ctx.attributes().timestamp())
+                {
+                    Some(EMPTY_WITHDRAWALS)
+                } else {
+                    None
+                };
+
+            let transactions_root = proofs::calculate_transaction_root(&info.executed_transactions);
+            let (excess_blob_gas, blob_gas_used) = ctx.blob_fields(info);
+            let extra_data = ctx.extra_data()?;
+
+            let header = Header {
+                parent_hash: ctx.parent().hash(),
+                ommers_hash: EMPTY_OMMER_ROOT_HASH,
+                beneficiary: ctx.evm_env.block_env.beneficiary,
+                state_root,
+                transactions_root,
+                receipts_root,
+                withdrawals_root,
+                logs_bloom,
+                timestamp: ctx.attributes().payload_attributes.timestamp,
+                mix_hash: ctx.attributes().payload_attributes.prev_randao,
+                nonce: BEACON_NONCE.into(),
+                base_fee_per_gas: Some(ctx.base_fee()),
+                number: ctx.parent().number + 1,
+                gas_limit: ctx.block_gas_limit(),
+                difficulty: U256::ZERO,
+                gas_used: info.cumulative_gas_used,
+                extra_data,
                 parent_beacon_block_root: ctx
                     .attributes()
                     .payload_attributes
-                    .parent_beacon_block_root
-                    .ok_or_else(|| {
-                        PayloadBuilderError::Other(
-                            eyre::eyre!("parent beacon block root not found").into(),
-                        )
-                    })?,
-                parent_hash: ctx.parent().hash(),
-                fee_recipient: ctx.attributes().payload_attributes.suggested_fee_recipient,
-                prev_randao: ctx.attributes().payload_attributes.prev_randao,
-                block_number: ctx.parent().number + 1,
-                gas_limit: ctx.block_gas_limit(),
-                timestamp: ctx.attributes().payload_attributes.timestamp,
-                extra_data: ctx.extra_data()?,
-                base_fee_per_gas: ctx.base_fee().try_into().unwrap(),
-            }),
-            diff: ExecutionPayloadFlashblockDeltaV1 {
-                state_root,
-                receipts_root,
-                logs_bloom,
-                gas_used: info.cumulative_gas_used,
-                block_hash,
-                transactions: new_transactions_encoded,
-                withdrawals: ctx.withdrawals().cloned().unwrap_or_default().to_vec(),
-                withdrawals_root: withdrawals_root.unwrap_or_default(),
+                    .parent_beacon_block_root,
                 blob_gas_used,
-            },
-            metadata: serde_json::to_value(&metadata).unwrap_or_default(),
-        };
+                excess_blob_gas,
+                requests_hash,
+                block_access_list_hash: None,
+                slot_number: ctx.attributes().payload_attributes.slot_number,
+            };
 
-        // Advance the delta cursor only after every fallible operation above has succeeded, so an
-        // early return never leaves `info` with an advanced cursor and no emitted flashblock.
-        info.extra.last_flashblock_index = info.executed_transactions.len();
+            let block = alloy_consensus::Block::<BaseTransactionSigned>::new(
+                header,
+                BlockBody {
+                    transactions: info.executed_transactions.clone(),
+                    ommers: vec![],
+                    withdrawals: ctx.withdrawals().cloned(),
+                },
+            );
+            let recovered_block =
+                RecoveredBlock::new_unhashed(block.clone(), info.executed_senders.clone());
 
+            // Read the invalidation diff before take_bundle() empties the bundle state.
+            let state_diff = AccountStateDiff::collect_for_intra_block(&state.bundle_state);
+            let legacy_account_balances = (!ctx
+                .chain_spec
+                .is_azul_active_at_timestamp(ctx.attributes().timestamp()))
+            .then(|| {
+                state
+                    .bundle_state
+                    .state
+                    .iter()
+                    .filter_map(|(address, account)| {
+                        account.info.as_ref().map(|info| (*address, info.balance))
+                    })
+                    .collect::<HashMap<Address, U256>>()
+            });
+
+            let executed = BuiltPayloadExecutedBlock {
+                recovered_block: Arc::new(recovered_block),
+                execution_output: Arc::new(BlockExecutionOutput {
+                    result: BlockExecutionResult {
+                        receipts: info.receipts.clone(),
+                        requests: vec![].into(),
+                        gas_used: info.cumulative_gas_used,
+                        blob_gas_used: 0,
+                    },
+                    state: state.take_bundle(),
+                }),
+                hashed_state: Arc::new(hashed_state),
+                trie_updates: Arc::new(trie_output),
+            };
+            debug!(target: "payload_builder", message = "Executed block created");
+
+            let sealed_block = Arc::new(block.seal_slow());
+            debug!(target: "payload_builder", ?sealed_block, "sealed built block");
+            let block_hash = sealed_block.hash();
+
+            let delta_start = info.extra.last_flashblock_index;
+            let new_transactions = &info.executed_transactions[delta_start..];
+            let new_transactions_encoded =
+                new_transactions.iter().map(|tx| tx.encoded_2718().into()).collect::<Vec<_>>();
+
+            let metadata =
+                if ctx.chain_spec.is_azul_active_at_timestamp(ctx.attributes().timestamp()) {
+                    FlashblocksMetadata {
+                        metadata: Metadata {
+                            block_number: ctx.parent().number + 1,
+                            prev_flashblock_id,
+                        },
+                        receipts: None,
+                        new_account_balances: None,
+                    }
+                } else {
+                    let receipts_with_hash = new_transactions
+                        .iter()
+                        .zip(info.receipts[delta_start..].iter())
+                        .map(|(tx, receipt)| (tx.tx_hash(), receipt.clone()))
+                        .collect::<HashMap<B256, BaseReceipt>>();
+                    FlashblocksMetadata {
+                        metadata: Metadata {
+                            block_number: ctx.parent().number + 1,
+                            prev_flashblock_id,
+                        },
+                        new_account_balances: legacy_account_balances,
+                        receipts: Some(receipts_with_hash),
+                    }
+                };
+
+            let flashblock = FlashblocksPayloadV1 {
+                payload_id: ctx.payload_id(),
+                index: 0,
+                base: Some(ExecutionPayloadBaseV1 {
+                    parent_beacon_block_root: ctx
+                        .attributes()
+                        .payload_attributes
+                        .parent_beacon_block_root
+                        .ok_or_else(|| {
+                            PayloadBuilderError::Other(
+                                eyre::eyre!("parent beacon block root not found").into(),
+                            )
+                        })?,
+                    parent_hash: ctx.parent().hash(),
+                    fee_recipient: ctx.attributes().payload_attributes.suggested_fee_recipient,
+                    prev_randao: ctx.attributes().payload_attributes.prev_randao,
+                    block_number: ctx.parent().number + 1,
+                    gas_limit: ctx.block_gas_limit(),
+                    timestamp: ctx.attributes().payload_attributes.timestamp,
+                    extra_data: ctx.extra_data()?,
+                    base_fee_per_gas: ctx.base_fee().try_into().unwrap(),
+                }),
+                diff: ExecutionPayloadFlashblockDeltaV1 {
+                    state_root,
+                    receipts_root,
+                    logs_bloom,
+                    gas_used: info.cumulative_gas_used,
+                    block_hash,
+                    transactions: new_transactions_encoded,
+                    withdrawals: ctx.withdrawals().cloned().unwrap_or_default().to_vec(),
+                    withdrawals_root: withdrawals_root.unwrap_or_default(),
+                    blob_gas_used,
+                },
+                metadata: serde_json::to_value(&metadata).unwrap_or_default(),
+            };
+
+            // Advance the delta cursor only after every fallible operation above has succeeded, so an
+            // early return never leaves `info` with an advanced cursor and no emitted flashblock.
+            info.extra.last_flashblock_index = info.executed_transactions.len();
+
+            Ok(FlashblockAssembly {
+                payload: BaseBuiltPayload::new(
+                    ctx.payload_id(),
+                    sealed_block,
+                    info.total_fees,
+                    Some(executed),
+                    None,
+                ),
+                flashblock,
+                state_diff,
+            })
+        })();
+
+        // Restore the transition state on every exit path so the failure contract holds and the
+        // REVM state is left in the shape the next flashblock expects.
         state.transition_state = untouched_transition_state;
-
-        Ok(FlashblockAssembly {
-            payload: BaseBuiltPayload::new(
-                ctx.payload_id(),
-                sealed_block,
-                info.total_fees,
-                Some(executed),
-                None,
-            ),
-            flashblock,
-            state_diff,
-        })
+        assembly
     }
 }
 

--- a/crates/builder/core/src/flashblocks/mod.rs
+++ b/crates/builder/core/src/flashblocks/mod.rs
@@ -1,5 +1,8 @@
 //! Flashblocks builder types.
 
+mod assembler;
+pub use assembler::{FlashblockAssembler, FlashblockAssembly, FlashblocksMetadata, StateRootMode};
+
 mod best_txs;
 pub use best_txs::BestFlashblocksTxs;
 

--- a/crates/builder/core/src/flashblocks/mod.rs
+++ b/crates/builder/core/src/flashblocks/mod.rs
@@ -1,7 +1,9 @@
 //! Flashblocks builder types.
 
 mod assembler;
-pub use assembler::{FlashblockAssembler, FlashblockAssembly, FlashblocksMetadata, StateRootMode};
+pub use assembler::{
+    FlashblockAssembler, FlashblockAssembly, FlashblockBaseMode, FlashblocksMetadata, StateRootMode,
+};
 
 mod best_txs;
 pub use best_txs::BestFlashblocksTxs;

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -40,8 +40,8 @@ use crate::{
     BuilderConfig, BuilderMetrics, CandidateSource, DefaultCandidateSource, ExecutionInfo,
     PayloadBuilder, ResourceLimits,
     flashblocks::{
-        FlashblockAssembler, FlashblocksExtraCtx, StateRootMode, best_txs::BestFlashblocksTxs,
-        context::BasePayloadBuilderCtx, generator::BuildArguments,
+        FlashblockAssembler, FlashblockBaseMode, FlashblocksExtraCtx, StateRootMode,
+        best_txs::BestFlashblocksTxs, context::BasePayloadBuilderCtx, generator::BuildArguments,
     },
     traits::{ClientBounds, PoolBounds},
     transaction_events::{
@@ -298,6 +298,7 @@ where
             &mut info,
             prev_flashblock_id,
             if skip_flashblocks_building { StateRootMode::Compute } else { StateRootMode::Skip },
+            FlashblockBaseMode::Include,
         )?;
         let payload = assembly.payload;
         let fb_payload = assembly.flashblock;
@@ -712,6 +713,7 @@ where
             info,
             prev_flashblock_id,
             if ctx.attributes().no_tx_pool { StateRootMode::Compute } else { StateRootMode::Skip },
+            FlashblockBaseMode::Omit,
         );
         let total_block_built_duration = total_block_built_duration.elapsed();
         BuilderMetrics::total_block_built_duration().record(total_block_built_duration);
@@ -727,7 +729,6 @@ where
                 let mut fb_payload = assembly.flashblock;
                 let state_diff = assembly.state_diff;
                 fb_payload.index = flashblock_index;
-                fb_payload.base = None;
                 let serialized_flashblock = WebSocketPublisher::serialize(&fb_payload)
                     .wrap_err("failed to serialize flashblock for websocket publication")?;
 
@@ -954,6 +955,7 @@ where
             info,
             FlashblockId::default(),
             StateRootMode::Compute,
+            FlashblockBaseMode::Omit,
         )?
         .payload;
 

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -1,54 +1,37 @@
 use core::time::Duration;
 use std::{
     ops::{Div, Rem},
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
+    sync::Arc,
     time::Instant,
 };
 
-use alloy_consensus::{
-    BlockBody, EMPTY_OMMER_ROOT_HASH, Header, Transaction, TxReceipt, constants::EMPTY_WITHDRAWALS,
-    proofs,
-};
-use alloy_eips::{Encodable2718, eip7685::EMPTY_REQUESTS_HASH, merge::BEACON_NONCE};
+use alloy_consensus::Transaction;
 use alloy_evm::Database;
-use alloy_primitives::{Address, B256, Bloom, U256, logs_bloom, map::foldhash::HashMap};
+use alloy_primitives::{Address, B256, U256, map::foldhash::HashMap};
 use base_builder_publish::WebSocketPublisher;
 use base_bundles::RejectedTransaction;
 use base_common_chains::Upgrades;
-use base_common_consensus::{BaseReceipt, BaseTransactionSigned};
-use base_common_flashblocks::{
-    ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, FlashblockId, FlashblocksPayloadV1,
-    Metadata,
-};
-use base_execution_consensus::{calculate_receipt_root_no_memo, isthmus};
+use base_common_consensus::BaseTransactionSigned;
+use base_common_flashblocks::FlashblockId;
 use base_execution_evm::{BaseEvmConfig, BaseNextBlockEnvAttributes};
 use base_execution_payload_builder::{BaseBuiltPayload, BasePayloadBuilderAttributes};
-use base_execution_txpool::AccountStateDiff;
 use base_observability_events::{GlobalTransactionEventWriter, TransactionEventType};
 use eyre::WrapErr as _;
+use parking_lot::RwLock;
 use reth_basic_payload_builder::BuildOutcome;
 use reth_evm::{ConfigureEvm, execute::BlockBuilder};
 use reth_execution_cache::{CachedStateMetrics, CachedStateMetricsSource, CachedStateProvider};
 use reth_execution_types::ChangedAccount;
-use reth_node_api::{Block, BuiltPayloadExecutedBlock, PayloadBuilderError};
+use reth_node_api::PayloadBuilderError;
 use reth_payload_primitives::PayloadAttributes;
 use reth_payload_util::BestPayloadTransactions;
-use reth_primitives_traits::RecoveredBlock;
 use reth_provider::{
-    BlockExecutionOutput, BlockExecutionResult, HashedPostStateProvider, ProviderError,
-    StateRootProvider, StorageRootProvider,
+    HashedPostStateProvider, ProviderError, StateRootProvider, StorageRootProvider,
 };
-use reth_revm::{
-    State, database::StateProviderDatabase, db::states::bundle_state::BundleRetention,
-};
+use reth_revm::{State, database::StateProviderDatabase};
 use reth_transaction_pool::TransactionPool;
-use reth_trie::{HashedPostState, updates::TrieUpdates};
 use revm::Database as _;
-use serde::{Deserialize, Serialize};
-use serde_with::skip_serializing_none;
+use serde::Serialize;
 use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, metadata::Level, span, warn};
@@ -57,8 +40,8 @@ use crate::{
     BuilderConfig, BuilderMetrics, CandidateSource, DefaultCandidateSource, ExecutionInfo,
     PayloadBuilder, ResourceLimits,
     flashblocks::{
-        FlashblocksExtraCtx, best_txs::BestFlashblocksTxs, context::BasePayloadBuilderCtx,
-        generator::BuildArguments,
+        FlashblockAssembler, FlashblocksExtraCtx, StateRootMode, best_txs::BestFlashblocksTxs,
+        context::BasePayloadBuilderCtx, generator::BuildArguments,
     },
     traits::{ClientBounds, PoolBounds},
     transaction_events::{
@@ -81,26 +64,6 @@ type NextBestFlashblocksTxs<Pool> = BestFlashblocksTxs<
             >,
     >,
 >;
-
-#[derive(Debug, Default)]
-struct LastEmittedFlashblockId {
-    block_number: AtomicU64,
-    index: AtomicU64,
-}
-
-impl LastEmittedFlashblockId {
-    fn load(&self) -> FlashblockId {
-        FlashblockId {
-            block_number: self.block_number.load(Ordering::Relaxed),
-            index: self.index.load(Ordering::Relaxed),
-        }
-    }
-
-    fn store(&self, flashblock_id: FlashblockId) {
-        self.block_number.store(flashblock_id.block_number, Ordering::Relaxed);
-        self.index.store(flashblock_id.index, Ordering::Relaxed);
-    }
-}
 
 /// The outbound channels the flashblocks builder emits to.
 ///
@@ -133,7 +96,7 @@ pub(super) struct BasePayloadBuilder<Pool, Client, S = DefaultCandidateSource> {
     /// transactions to.
     pub outputs: BuilderOutputs,
     /// Last flashblock emitted by this builder instance.
-    last_emitted_flashblock_id: Arc<LastEmittedFlashblockId>,
+    last_emitted_flashblock_id: Arc<RwLock<FlashblockId>>,
     /// Transforms the candidate transaction stream drained by the build loop.
     candidate_source: S,
 }
@@ -160,11 +123,11 @@ impl<Pool, Client, S> BasePayloadBuilder<Pool, Client, S> {
     }
 
     fn previous_flashblock_id(&self) -> FlashblockId {
-        self.last_emitted_flashblock_id.load()
+        *self.last_emitted_flashblock_id.read()
     }
 
     fn record_emitted_flashblock(&self, block_number: u64, index: u64) {
-        self.last_emitted_flashblock_id.store(FlashblockId { block_number, index });
+        *self.last_emitted_flashblock_id.write() = FlashblockId { block_number, index };
     }
 }
 
@@ -329,13 +292,16 @@ where
         let skip_flashblocks_building = ctx.attributes().no_tx_pool || flashblocks_per_block == 0;
 
         let prev_flashblock_id = self.previous_flashblock_id();
-        let (payload, fb_payload, state_diff) = build_block(
+        let assembly = FlashblockAssembler::build(
             &mut state,
             &ctx,
             &mut info,
             prev_flashblock_id,
-            skip_flashblocks_building, // need to calculate state root for CL sync or if not building flashblocks
+            if skip_flashblocks_building { StateRootMode::Compute } else { StateRootMode::Skip },
         )?;
+        let payload = assembly.payload;
+        let fb_payload = assembly.flashblock;
+        let state_diff = assembly.state_diff;
 
         self.outputs.payload_tx.send(payload.clone()).await.map_err(PayloadBuilderError::other)?;
 
@@ -740,8 +706,13 @@ where
 
         let total_block_built_duration = Instant::now();
         let prev_flashblock_id = self.previous_flashblock_id();
-        let build_result =
-            build_block(state, ctx, info, prev_flashblock_id, ctx.attributes().no_tx_pool);
+        let build_result = FlashblockAssembler::build(
+            state,
+            ctx,
+            info,
+            prev_flashblock_id,
+            if ctx.attributes().no_tx_pool { StateRootMode::Compute } else { StateRootMode::Skip },
+        );
         let total_block_built_duration = total_block_built_duration.elapsed();
         BuilderMetrics::total_block_built_duration().record(total_block_built_duration);
         BuilderMetrics::total_block_built_gauge().set(total_block_built_duration);
@@ -751,9 +722,14 @@ where
                 BuilderMetrics::invalid_built_blocks_count().increment(1);
                 Err(err).wrap_err("failed to build payload")
             }
-            Ok((new_payload, mut fb_payload, state_diff)) => {
+            Ok(assembly) => {
+                let new_payload = assembly.payload;
+                let mut fb_payload = assembly.flashblock;
+                let state_diff = assembly.state_diff;
                 fb_payload.index = flashblock_index;
                 fb_payload.base = None;
+                let serialized_flashblock = WebSocketPublisher::serialize(&fb_payload)
+                    .wrap_err("failed to serialize flashblock for websocket publication")?;
 
                 // Synchronized check + publish.
                 // The publish_guard mutex ensures that if get_payload (resolve_kind) is called,
@@ -765,11 +741,11 @@ where
                     if block_cancel.is_cancelled() {
                         (true, 0)
                     } else {
-                        let size = self
-                            .outputs
-                            .ws_pub
-                            .publish(&fb_payload, ctx.block_number(), flashblock_index)
-                            .wrap_err("failed to publish flashblock via websocket")?;
+                        let size = self.outputs.ws_pub.publish_serialized(
+                            serialized_flashblock,
+                            ctx.block_number(),
+                            flashblock_index,
+                        );
                         self.record_emitted_flashblock(ctx.block_number(), flashblock_index);
                         (false, size)
                     }
@@ -972,7 +948,14 @@ where
         let start_time = Instant::now();
 
         // Build the final block WITH state root computed
-        let (final_payload, _, _) = build_block(state, ctx, info, FlashblockId::default(), true)?;
+        let final_payload = FlashblockAssembler::build(
+            state,
+            ctx,
+            info,
+            FlashblockId::default(),
+            StateRootMode::Compute,
+        )?
+        .payload;
 
         ctx.flush_rejected_txs(info);
         self.emit_final_inclusion_events(ctx, &final_payload);
@@ -1105,18 +1088,6 @@ where
     }
 }
 
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize)]
-struct FlashblocksMetadata {
-    /// Metadata fields consumed by flashblock clients.
-    #[serde(flatten)]
-    metadata: Metadata,
-    /// Receipts for transactions in this flashblock (removed in Base 1.0)
-    receipts: Option<HashMap<B256, BaseReceipt>>,
-    /// Changed account balances (removed in Base 1.0)
-    new_account_balances: Option<HashMap<Address, U256>>,
-}
-
 pub(crate) fn execute_pre_steps<DB>(
     state: &mut State<DB>,
     ctx: &BasePayloadBuilderCtx,
@@ -1135,300 +1106,11 @@ where
 
     Ok(info)
 }
-
-pub(crate) fn build_block<DB, P>(
-    state: &mut State<DB>,
-    ctx: &BasePayloadBuilderCtx,
-    info: &mut ExecutionInfo,
-    prev_flashblock_id: FlashblockId,
-    calculate_state_root: bool,
-) -> Result<(BaseBuiltPayload, FlashblocksPayloadV1, Vec<AccountStateDiff>), PayloadBuilderError>
-where
-    DB: Database<Error = ProviderError> + AsRef<P> + revm::Database,
-    P: StateRootProvider + HashedPostStateProvider + StorageRootProvider,
-{
-    // We use it to preserve state, so we run merge_transitions on transition state at most once
-    let untouched_transition_state = state.transition_state.clone();
-    let state_merge_start_time = Instant::now();
-    state.merge_transitions(BundleRetention::Reverts);
-    let state_transition_merge_time = state_merge_start_time.elapsed();
-    BuilderMetrics::state_transition_merge_duration().record(state_transition_merge_time);
-    BuilderMetrics::state_transition_merge_gauge().set(state_transition_merge_time);
-
-    let block_number = ctx.block_number();
-    let expected = ctx.parent().number + 1;
-    if block_number != expected {
-        return Err(PayloadBuilderError::Other(
-            eyre::eyre!(
-                "build context block number mismatch: expected {}, got {}",
-                expected,
-                block_number
-            )
-            .into(),
-        ));
-    }
-
-    let receipts_root = calculate_receipt_root_no_memo(
-        &info.receipts,
-        &ctx.chain_spec,
-        ctx.attributes().timestamp(),
-    );
-    let logs_bloom: Bloom = logs_bloom(info.receipts.iter().flat_map(|r| r.logs()));
-
-    // TODO: maybe recreate state with bundle in here
-    // calculate the state root
-    let state_root_start_time = Instant::now();
-    let mut state_root = B256::ZERO;
-    let mut trie_output = TrieUpdates::default();
-    let mut hashed_state = HashedPostState::default();
-
-    if calculate_state_root {
-        let state_root_span = span!(
-            Level::INFO,
-            "calculate_state_root",
-            block_number = ctx.block_number(),
-            parent_hash = %ctx.parent().hash(),
-        );
-        let _state_root_span_guard = state_root_span.enter();
-
-        let state_provider = state.database.as_ref();
-        hashed_state = state_provider.hashed_post_state(&state.bundle_state);
-        (state_root, trie_output) =
-            state_provider.state_root_with_updates(hashed_state.clone()).inspect_err(|err| {
-                warn!(target: "payload_builder",
-                    parent_header=%ctx.parent().hash(),
-                    %err,
-                    "failed to calculate state root for payload"
-                );
-            })?;
-        let state_root_calculation_time = state_root_start_time.elapsed();
-        BuilderMetrics::state_root_calculation_duration().record(state_root_calculation_time);
-        BuilderMetrics::state_root_calculation_gauge().set(state_root_calculation_time);
-    }
-
-    let mut requests_hash = None;
-    let withdrawals_root =
-        if ctx.chain_spec.is_isthmus_active_at_timestamp(ctx.attributes().timestamp()) {
-            // always empty requests hash post isthmus
-            requests_hash = Some(EMPTY_REQUESTS_HASH);
-
-            // withdrawals root field in block header is used for storage root of L2 predeploy
-            // `l2tol1-message-passer`
-            Some(
-                isthmus::withdrawals_root(&state.bundle_state, state.database.as_ref())
-                    .map_err(PayloadBuilderError::other)?,
-            )
-        } else if ctx.chain_spec.is_canyon_active_at_timestamp(ctx.attributes().timestamp()) {
-            Some(EMPTY_WITHDRAWALS)
-        } else {
-            None
-        };
-
-    // create the block header
-    let transactions_root = proofs::calculate_transaction_root(&info.executed_transactions);
-
-    let (excess_blob_gas, blob_gas_used) = ctx.blob_fields(info);
-    let extra_data = ctx.extra_data()?;
-
-    let header = Header {
-        parent_hash: ctx.parent().hash(),
-        ommers_hash: EMPTY_OMMER_ROOT_HASH,
-        beneficiary: ctx.evm_env.block_env.beneficiary,
-        state_root,
-        transactions_root,
-        receipts_root,
-        withdrawals_root,
-        logs_bloom,
-        timestamp: ctx.attributes().payload_attributes.timestamp,
-        mix_hash: ctx.attributes().payload_attributes.prev_randao,
-        nonce: BEACON_NONCE.into(),
-        base_fee_per_gas: Some(ctx.base_fee()),
-        number: ctx.parent().number + 1,
-        gas_limit: ctx.block_gas_limit(),
-        difficulty: U256::ZERO,
-        gas_used: info.cumulative_gas_used,
-        extra_data,
-        parent_beacon_block_root: ctx.attributes().payload_attributes.parent_beacon_block_root,
-        blob_gas_used,
-        excess_blob_gas,
-        requests_hash,
-        block_access_list_hash: None,
-        slot_number: ctx.attributes().payload_attributes.slot_number,
-    };
-
-    // seal the block
-    let block = alloy_consensus::Block::<BaseTransactionSigned>::new(
-        header,
-        BlockBody {
-            transactions: info.executed_transactions.clone(),
-            ommers: vec![],
-            withdrawals: ctx.withdrawals().cloned(),
-        },
-    );
-
-    let recovered_block =
-        RecoveredBlock::new_unhashed(block.clone(), info.executed_senders.clone());
-
-    // Read the invalidation diff before take_bundle() empties the bundle state.
-    // The builder prunes included transactions itself, so nonce advances are
-    // omitted to avoid evicting valid successors promoted in the same lane.
-    let state_diff = AccountStateDiff::collect_for_intra_block(&state.bundle_state);
-    let new_account_balances = state
-        .bundle_state
-        .state
-        .iter()
-        .filter_map(|(address, account)| account.info.as_ref().map(|info| (*address, info.balance)))
-        .collect::<HashMap<Address, U256>>();
-
-    // create the executed block data
-    let executed = BuiltPayloadExecutedBlock {
-        recovered_block: Arc::new(recovered_block),
-        execution_output: Arc::new(BlockExecutionOutput {
-            result: BlockExecutionResult {
-                receipts: info.receipts.clone(),
-                requests: vec![].into(),
-                gas_used: info.cumulative_gas_used,
-                blob_gas_used: 0,
-            },
-            state: state.take_bundle(),
-        }),
-        hashed_state: Arc::new(hashed_state),
-        trie_updates: Arc::new(trie_output),
-    };
-    debug!(target: "payload_builder", message = "Executed block created");
-
-    let sealed_block = Arc::new(block.seal_slow());
-    debug!(target: "payload_builder", ?sealed_block, "sealed built block");
-
-    let block_hash = sealed_block.hash();
-
-    // pick the new transactions from the info field and update the last flashblock index
-    let new_transactions = info.executed_transactions[info.extra.last_flashblock_index..].to_vec();
-
-    let new_transactions_encoded =
-        new_transactions.clone().into_iter().map(|tx| tx.encoded_2718().into()).collect::<Vec<_>>();
-
-    let new_receipts = info.receipts[info.extra.last_flashblock_index..].to_vec();
-    info.extra.last_flashblock_index = info.executed_transactions.len();
-
-    let receipts_with_hash = new_transactions
-        .iter()
-        .zip(new_receipts.iter())
-        .map(|(tx, receipt)| (tx.tx_hash(), receipt.clone()))
-        .collect::<HashMap<B256, BaseReceipt>>();
-
-    let metadata: FlashblocksMetadata =
-        if ctx.chain_spec.is_azul_active_at_timestamp(ctx.attributes().timestamp()) {
-            FlashblocksMetadata {
-                metadata: Metadata { block_number: ctx.parent().number + 1, prev_flashblock_id },
-                receipts: None,
-                new_account_balances: None,
-            }
-        } else {
-            FlashblocksMetadata {
-                metadata: Metadata { block_number: ctx.parent().number + 1, prev_flashblock_id },
-                new_account_balances: Some(new_account_balances),
-                receipts: Some(receipts_with_hash),
-            }
-        };
-
-    // Prepare the flashblocks message
-    let fb_payload = FlashblocksPayloadV1 {
-        payload_id: ctx.payload_id(),
-        index: 0,
-        base: Some(ExecutionPayloadBaseV1 {
-            parent_beacon_block_root: ctx
-                .attributes()
-                .payload_attributes
-                .parent_beacon_block_root
-                .ok_or_else(|| {
-                    PayloadBuilderError::Other(
-                        eyre::eyre!("parent beacon block root not found").into(),
-                    )
-                })?,
-            parent_hash: ctx.parent().hash(),
-            fee_recipient: ctx.attributes().payload_attributes.suggested_fee_recipient,
-            prev_randao: ctx.attributes().payload_attributes.prev_randao,
-            block_number: ctx.parent().number + 1,
-            gas_limit: ctx.block_gas_limit(),
-            timestamp: ctx.attributes().payload_attributes.timestamp,
-            extra_data: ctx.extra_data()?,
-            base_fee_per_gas: ctx.base_fee().try_into().unwrap(),
-        }),
-        diff: ExecutionPayloadFlashblockDeltaV1 {
-            state_root,
-            receipts_root,
-            logs_bloom,
-            gas_used: info.cumulative_gas_used,
-            block_hash,
-            transactions: new_transactions_encoded,
-            withdrawals: ctx.withdrawals().cloned().unwrap_or_default().to_vec(),
-            withdrawals_root: withdrawals_root.unwrap_or_default(),
-            blob_gas_used,
-        },
-        metadata: serde_json::to_value(&metadata).unwrap_or_default(),
-    };
-
-    // We clean bundle and place initial state transaction back
-    state.take_bundle();
-    state.transition_state = untouched_transition_state;
-
-    Ok((
-        BaseBuiltPayload::new(
-            ctx.payload_id(),
-            sealed_block,
-            info.total_fees,
-            Some(executed),
-            None,
-        ),
-        fb_payload,
-        state_diff,
-    ))
-}
-
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
-    use alloy_consensus::{Header, Receipt};
-    use alloy_primitives::{Address, B256, Log, U256, map::foldhash::HashMap};
-    use base_common_consensus::BaseReceipt;
-    use base_common_flashblocks::{FlashblockId, Metadata};
-    use base_execution_chainspec::BaseChainSpec;
-    use reth_chainspec::ChainSpec;
+    use alloy_primitives::{Address, B256, U256};
     use reth_execution_cache::{CachedStateProvider, CachedStatus, ExecutionCache, SavedCache};
-    use reth_primitives_traits::SealedHeader;
     use reth_provider::{StateProviderBox, noop::NoopProvider};
-    use reth_revm::{State, database::StateProviderDatabase};
-
-    use super::{FlashblocksMetadata, build_block};
-    use crate::{ExecutionInfo, flashblocks::context::BasePayloadBuilderCtx};
-
-    /// Creates a minimal [`BaseChainSpec`] with all L1 upgrades through Cancun
-    /// active at genesis but **no** inherited rollup upgrades (Bedrock, Canyon,
-    /// Ecotone, Holocene, Isthmus, Jovian are all absent).
-    ///
-    /// This keeps `build_block` on the simplest code paths: no blob fields,
-    /// default extra data, no withdrawals root calculation.
-    fn minimal_chain_spec() -> Arc<BaseChainSpec> {
-        let genesis: serde_json::Value = serde_json::json!({
-            "config": { "chainId": 901 },
-            "gasLimit": "0x1C9C380",
-            "timestamp": "0x0"
-        });
-        let genesis = serde_json::from_value(genesis).expect("valid genesis");
-
-        let inner =
-            ChainSpec::builder().chain(901.into()).genesis(genesis).cancun_activated().build();
-
-        Arc::new(BaseChainSpec::from(inner))
-    }
-
-    /// Builds a sealed genesis header consistent with [`minimal_chain_spec`].
-    fn genesis_header() -> Arc<SealedHeader> {
-        let header = Header { gas_limit: 30_000_000, timestamp: 0, ..Default::default() };
-        Arc::new(SealedHeader::seal_slow(header))
-    }
 
     #[test]
     fn canonical_state_provider_uses_shared_cache_without_filling_misses() {
@@ -1463,248 +1145,5 @@ mod tests {
         }
 
         assert!(cache.is_available(), "provider must release the shared cache when dropped");
-    }
-
-    /// Verify that [`build_block`] produces a valid empty block when called
-    /// with no transactions and `calculate_state_root = false`.
-    ///
-    /// This exercises the full block-assembly path (receipts root, logs bloom,
-    /// header construction, flashblocks payload) using only in-memory state —
-    /// no node, no disk, no network.
-    #[test]
-    fn build_block_empty_no_state_root() {
-        let chain_spec = minimal_chain_spec();
-        let parent = genesis_header();
-        let ctx = BasePayloadBuilderCtx::for_test(chain_spec, Arc::clone(&parent));
-
-        let db = StateProviderDatabase::new(NoopProvider::default());
-        let mut state = State::builder().with_database(db).with_bundle_update().build();
-        let mut info = ExecutionInfo::default();
-
-        let (payload, fb_payload, state_diff) = build_block::<_, NoopProvider>(
-            &mut state,
-            &ctx,
-            &mut info,
-            FlashblockId::default(),
-            false,
-        )
-        .expect("build_block should succeed for an empty block");
-
-        // Block number must be parent + 1.
-        assert_eq!(payload.block().number, parent.number + 1, "block number should be parent + 1");
-
-        // No transactions were executed, so gas used must be zero.
-        assert_eq!(payload.block().gas_used, 0, "empty block should use zero gas");
-
-        // The flashblocks payload must reference the same block.
-        assert_eq!(fb_payload.diff.block_hash, payload.block().hash(), "hash mismatch");
-        assert!(state_diff.is_empty(), "empty block must produce no invalidation diff");
-    }
-
-    /// Verify that [`build_block`] exercises the state root calculation path
-    /// when `calculate_state_root = true`.
-    ///
-    /// With [`NoopProvider`], both `hashed_post_state` and
-    /// `state_root_with_updates` return defaults, so the state root ends up
-    /// as [`B256::ZERO`].  The important property under test is that the
-    /// `calculate_state_root = true` branch runs without error and the
-    /// resulting header carries the computed root.
-    #[test]
-    fn build_block_empty_with_state_root() {
-        let chain_spec = minimal_chain_spec();
-        let parent = genesis_header();
-        let ctx = BasePayloadBuilderCtx::for_test(chain_spec, Arc::clone(&parent));
-
-        let db = StateProviderDatabase::new(NoopProvider::default());
-        let mut state = State::builder().with_database(db).with_bundle_update().build();
-        let mut info = ExecutionInfo::default();
-
-        let (payload, _fb_payload, state_diff) = build_block::<_, NoopProvider>(
-            &mut state,
-            &ctx,
-            &mut info,
-            FlashblockId::default(),
-            true,
-        )
-        .expect("build_block with state root should succeed");
-
-        assert!(state_diff.is_empty(), "empty block must produce no invalidation diff");
-
-        // NoopProvider returns B256::default() for all state root queries,
-        // which equals B256::ZERO.
-        assert_eq!(
-            payload.block().state_root,
-            B256::ZERO,
-            "NoopProvider should yield a zero state root"
-        );
-
-        assert_eq!(payload.block().number, parent.number + 1);
-    }
-
-    /// [`build_block`] must return an error when the EVM environment's block
-    /// number does not match `parent.number + 1`.
-    ///
-    /// In production this would indicate a bug in context construction or a
-    /// stale parent header.  The guard at the top of `build_block` exists to
-    /// catch exactly this class of misconfiguration.
-    #[test]
-    fn build_block_rejects_block_number_mismatch() {
-        let chain_spec = minimal_chain_spec();
-        let parent = genesis_header();
-        let mut ctx = BasePayloadBuilderCtx::for_test(chain_spec, Arc::clone(&parent));
-
-        // Tamper with the EVM block number so it disagrees with parent + 1.
-        // parent.number is 0, so the expected block number is 1.
-        // Setting it to 99 should trigger the mismatch guard.
-        ctx.evm_env.block_env.number = U256::from(99);
-
-        let db = StateProviderDatabase::new(NoopProvider::default());
-        let mut state = State::builder().with_database(db).with_bundle_update().build();
-        let mut info = ExecutionInfo::default();
-
-        let err = build_block::<_, NoopProvider>(
-            &mut state,
-            &ctx,
-            &mut info,
-            FlashblockId::default(),
-            false,
-        )
-        .expect_err("build_block should fail on block number mismatch");
-
-        let msg = err.to_string();
-        assert!(
-            msg.contains("block number mismatch"),
-            "error should mention block number mismatch, got: {msg}"
-        );
-    }
-
-    /// [`build_block`] must return an error when the payload attributes lack
-    /// a `parent_beacon_block_root`.
-    ///
-    /// The flashblocks payload construction unconditionally reads this field,
-    /// so a `None` value is an unrecoverable configuration error that should
-    /// surface clearly rather than panicking.
-    #[test]
-    fn build_block_rejects_missing_beacon_block_root() {
-        let chain_spec = minimal_chain_spec();
-        let parent = genesis_header();
-        let mut ctx = BasePayloadBuilderCtx::for_test(chain_spec, Arc::clone(&parent));
-
-        // Clear the parent beacon block root that for_test() sets.
-        ctx.config.attributes.payload_attributes.parent_beacon_block_root = None;
-
-        let db = StateProviderDatabase::new(NoopProvider::default());
-        let mut state = State::builder().with_database(db).with_bundle_update().build();
-        let mut info = ExecutionInfo::default();
-
-        let err = build_block::<_, NoopProvider>(
-            &mut state,
-            &ctx,
-            &mut info,
-            FlashblockId::default(),
-            false,
-        )
-        .expect_err("build_block should fail without beacon block root");
-
-        let msg = err.to_string();
-        assert!(
-            msg.contains("parent beacon block root not found"),
-            "error should mention missing beacon block root, got: {msg}"
-        );
-    }
-
-    /// Pin the JSON field names and structure of [`FlashblocksMetadata`].
-    ///
-    /// This struct is serialized into the `metadata` field of the flashblocks
-    /// websocket payload. Changing field names, types, or serde attributes
-    /// without updating downstream consumers is a breaking change.
-    #[test]
-    fn flashblocks_metadata_json_format_is_stable() {
-        let tx_hash = B256::from([0xAA; 32]);
-        let address = Address::from([0xBB; 20]);
-
-        let receipt = BaseReceipt::Eip1559(Receipt {
-            status: true.into(),
-            cumulative_gas_used: 21_000,
-            logs: Vec::<Log>::new(),
-        });
-
-        let mut receipts = HashMap::default();
-        receipts.insert(tx_hash, receipt);
-
-        let mut balances = HashMap::default();
-        balances.insert(address, U256::from(1_000_000_000_000_000_000u128));
-
-        let metadata = FlashblocksMetadata {
-            receipts: Some(receipts),
-            new_account_balances: Some(balances),
-            metadata: Metadata {
-                block_number: 42,
-                prev_flashblock_id: FlashblockId { block_number: 41, index: 10 },
-            },
-        };
-
-        let json = serde_json::to_value(&metadata).unwrap();
-        let obj = json.as_object().unwrap();
-
-        // Verify exact field set
-        let mut keys: Vec<&String> = obj.keys().collect();
-        keys.sort();
-        assert_eq!(
-            keys,
-            vec!["block_number", "new_account_balances", "prev_flashblock_id", "receipts",],
-            "metadata field names changed"
-        );
-
-        // block_number is a plain integer, not hex-encoded
-        assert_eq!(obj["block_number"], serde_json::json!(42));
-        assert_eq!(obj["prev_flashblock_id"], serde_json::json!("41-10"));
-
-        // receipts is a map keyed by tx hash
-        let receipts_obj = obj["receipts"].as_object().unwrap();
-        let tx_key = format!("{tx_hash:#x}");
-        assert!(receipts_obj.contains_key(&tx_key), "receipt should be keyed by tx hash");
-
-        // receipt has internally-tagged type field
-        let receipt_json = &receipts_obj[&tx_key];
-        assert_eq!(receipt_json["type"], "0x2", "EIP-1559 receipt type tag must be 0x2");
-
-        // new_account_balances is a map keyed by address
-        let balances_obj = obj["new_account_balances"].as_object().unwrap();
-        let addr_key = format!("{address:#x}");
-        assert!(balances_obj.contains_key(&addr_key), "balance should be keyed by address");
-    }
-
-    /// The client-side [`Metadata`] type must be able to deserialize from
-    /// `FlashblocksMetadata` JSON, ignoring the extra fields.
-    #[test]
-    fn client_metadata_deserializes_from_builder_metadata() {
-        let metadata = FlashblocksMetadata {
-            receipts: Some(HashMap::default()),
-            new_account_balances: Some(HashMap::default()),
-            metadata: Metadata {
-                block_number: 99,
-                prev_flashblock_id: FlashblockId { block_number: 98, index: 10 },
-            },
-        };
-
-        let json = serde_json::to_value(&metadata).unwrap();
-        let client_metadata: Metadata =
-            serde_json::from_value(json).expect("client Metadata must parse builder metadata");
-        assert_eq!(client_metadata.block_number, 99);
-        assert_eq!(
-            client_metadata.prev_flashblock_id,
-            FlashblockId { block_number: 98, index: 10 }
-        );
-    }
-
-    /// The v0.4.1 metadata format (only `block_number`) must still deserialize
-    /// into the client-side [`Metadata`] type.
-    #[test]
-    fn client_metadata_deserializes_from_v0_4_1_format() {
-        let json = serde_json::json!({"block_number": 123});
-        let metadata: Metadata = serde_json::from_value(json).expect("v0.4.1 metadata must parse");
-        assert_eq!(metadata.block_number, 123);
-        assert_eq!(metadata.prev_flashblock_id, FlashblockId::default());
     }
 }

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -45,8 +45,8 @@ pub use rejection_cache::RejectionCache;
 mod flashblocks;
 pub use flashblocks::{
     BasePayloadBuilderCtx, BestFlashblocksTxs, BlockPayloadJob, BlockPayloadJobGenerator,
-    BuildArguments, FlashblockAssembler, FlashblockAssembly, FlashblockDiagnostics,
-    FlashblockSelectionOutcome, FlashblocksExtraCtx, FlashblocksMetadata,
+    BuildArguments, FlashblockAssembler, FlashblockAssembly, FlashblockBaseMode,
+    FlashblockDiagnostics, FlashblockSelectionOutcome, FlashblocksExtraCtx, FlashblocksMetadata,
     FlashblocksServiceBuilder, PayloadBuilder, PayloadHandler, PayloadJobDeadline, ResolvePayload,
     StateRootMode,
 };

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -45,8 +45,10 @@ pub use rejection_cache::RejectionCache;
 mod flashblocks;
 pub use flashblocks::{
     BasePayloadBuilderCtx, BestFlashblocksTxs, BlockPayloadJob, BlockPayloadJobGenerator,
-    BuildArguments, FlashblockDiagnostics, FlashblockSelectionOutcome, FlashblocksExtraCtx,
+    BuildArguments, FlashblockAssembler, FlashblockAssembly, FlashblockDiagnostics,
+    FlashblockSelectionOutcome, FlashblocksExtraCtx, FlashblocksMetadata,
     FlashblocksServiceBuilder, PayloadBuilder, PayloadHandler, PayloadJobDeadline, ResolvePayload,
+    StateRootMode,
 };
 
 mod extension;

--- a/crates/builder/publish/benches/publisher.rs
+++ b/crates/builder/publish/benches/publisher.rs
@@ -104,6 +104,20 @@ fn bench_publish(c: &mut Criterion) {
             });
         }
     }
+
+    let publisher = publisher_with_subscribers(&rt, 0);
+    for &(label, ref payload) in &payloads {
+        c.bench_function(&format!("serialize/{label}"), |b| {
+            b.iter(|| black_box(WebSocketPublisher::serialize(payload).unwrap()));
+        });
+
+        let serialized = WebSocketPublisher::serialize(payload).unwrap();
+        c.bench_function(&format!("publish_serialized/{label}"), |b| {
+            b.iter(|| {
+                black_box(publisher.publish_serialized(serialized.clone(), 1, 0));
+            });
+        });
+    }
 }
 
 criterion_group!(benches, bench_publish);

--- a/crates/builder/publish/src/publisher.rs
+++ b/crates/builder/publish/src/publisher.rs
@@ -105,6 +105,28 @@ impl WebSocketPublisher {
         block_number: u64,
         flashblock_index: u64,
     ) -> Result<usize, serde_json::Error> {
+        let payload = Self::serialize(payload)?;
+        Ok(self.publish_serialized(payload, block_number, flashblock_index))
+    }
+
+    /// Serializes a payload for a later atomic publication step.
+    ///
+    /// Callers that coordinate publication with cancellation can perform this allocation-heavy
+    /// work before entering their critical section, then call [`Self::publish_serialized`].
+    pub fn serialize(payload: &impl Serialize) -> Result<Utf8Bytes, serde_json::Error> {
+        serde_json::to_string(payload).map(Utf8Bytes::from)
+    }
+
+    /// Stores and broadcasts an already serialized payload.
+    ///
+    /// Returns the payload byte size. Serialization must be performed with [`Self::serialize`] to
+    /// preserve the same JSON wire format as [`Self::publish`].
+    pub fn publish_serialized(
+        &self,
+        payload: Utf8Bytes,
+        block_number: u64,
+        flashblock_index: u64,
+    ) -> usize {
         let publish_span = span!(
             Level::INFO,
             "publish_flashblock",
@@ -114,23 +136,21 @@ impl WebSocketPublisher {
         );
         let _publish_span_guard = publish_span.enter();
 
-        let json = serde_json::to_string(payload)?;
-        let size = json.len();
+        let size = payload.len();
         publish_span.record("byte_size", size);
-        let utf8_bytes = Utf8Bytes::from(json);
         let position = FlashblockPosition { block_number, flashblock_index };
 
         {
             let mut buf = self.ring_buffer.write();
-            buf.push(position, utf8_bytes.clone());
+            buf.push(position, payload.clone());
         }
 
         // Ignore SendError — there may be zero receivers when no clients
         // are connected. The entry is already stored in the ring buffer
         // for replay on future connections.
-        let _ = self.pipe.send((position, utf8_bytes));
+        let _ = self.pipe.send((position, payload));
         self.metrics.on_payload_size(size);
-        Ok(size)
+        size
     }
 }
 
@@ -246,5 +266,23 @@ mod tests {
             .entries_after(&FlashblockPosition { block_number: 100, flashblock_index: 0 })
             .collect();
         assert_eq!(entries.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn serialized_publication_preserves_publish_wire_format() {
+        let publisher = WebSocketPublisher::new("127.0.0.1:0".parse().unwrap()).unwrap();
+        let payload = serde_json::json!({"block": 42});
+        let serialized = WebSocketPublisher::serialize(&payload).unwrap();
+
+        let publish_size = publisher.publish(&payload, 1, 0).unwrap();
+        let serialized_size = publisher.publish_serialized(serialized.clone(), 1, 1);
+
+        assert_eq!(publish_size, serialized.len());
+        assert_eq!(serialized_size, serialized.len());
+        let buf = publisher.ring_buffer.read();
+        let entries = buf
+            .entries_after(&FlashblockPosition { block_number: 0, flashblock_index: 0 })
+            .collect::<Vec<_>>();
+        assert_eq!(entries, vec![&serialized, &serialized]);
     }
 }


### PR DESCRIPTION
## Summary

This extracts cumulative payload and incremental flashblock assembly into a dedicated, testable component while preserving existing state-root behavior. It removes avoidable delta and legacy metadata work, moves websocket serialization outside the getPayload publication critical section, and adds focused assembly and publisher benchmarks. The benchmark wiring now distinguishes production-path builder measurements from the Base Proofs state-root stress benchmark.