### PR TITLE
Add Challenger FORT e2e observation test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,6 +226,7 @@ base-execution-eip8130-rpc-node = { path = "crates/execution/eip8130-rpc-node" }
 # Infra
 basectl-cli = { path = "crates/infra/basectl" }
 base-sidecrush = { path = "crates/infra/sidecrush" }
+base-challenger-e2e = { path = "crates/infra/challenger-e2e" }
 audit-archiver-lib = { path = "crates/infra/audit" }
 base-load-tests = { path = "crates/infra/load-tests" }
 ingress-rpc-lib = { path = "crates/infra/ingress-rpc" }

--- a/bin/challenger-e2e/Cargo.toml
+++ b/bin/challenger-e2e/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "base-challenger-e2e-bin"
+description = "Standalone Challenger E2E observation binary for FORT execution"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "base-challenger-e2e"
+path = "src/main.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+base-challenger-e2e.workspace = true
+
+clap.workspace = true
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["fmt", "json", "env-filter"] }
+tokio = { workspace = true, features = ["full"] }

--- a/bin/challenger-e2e/src/main.rs
+++ b/bin/challenger-e2e/src/main.rs
@@ -1,0 +1,17 @@
+//! Standalone Challenger E2E observation binary for FORT execution.
+
+use base_challenger_e2e::{ChallengerE2e, ChallengerE2eConfig};
+use clap::Parser;
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt().json().with_env_filter(EnvFilter::from_default_env()).init();
+
+    if let Err(err) = ChallengerE2e::run(ChallengerE2eConfig::parse()).await {
+        tracing::error!(error = %err, error_debug = ?err, "Challenger E2E observation failed");
+        std::process::exit(1);
+    }
+
+    tracing::info!("Challenger E2E observation passed");
+}

--- a/crates/infra/challenger-e2e/Cargo.toml
+++ b/crates/infra/challenger-e2e/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "base-challenger-e2e"
+description = "Challenger E2E observation logic for FORT execution"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+base-proof-contracts.workspace = true
+
+alloy-primitives.workspace = true
+alloy-provider.workspace = true
+
+url.workspace = true
+eyre.workspace = true
+tracing.workspace = true
+clap = { workspace = true, features = ["derive", "env"] }
+tokio = { workspace = true, features = ["full"] }

--- a/crates/infra/challenger-e2e/README.md
+++ b/crates/infra/challenger-e2e/README.md
@@ -1,0 +1,5 @@
+# Challenger E2E
+
+FORT-oriented Challenger E2E observation logic.
+
+The check watches the configured L1 `DisputeGameFactory`, verifies an existing dispute game, then waits for a new dispute game after the gate starts.

--- a/crates/infra/challenger-e2e/src/challenger_e2e.rs
+++ b/crates/infra/challenger-e2e/src/challenger_e2e.rs
@@ -1,0 +1,144 @@
+//! Challenger E2E observation implementation.
+
+use std::time::{Duration, Instant};
+
+use alloy_primitives::Address;
+use alloy_provider::{Provider, RootProvider};
+use base_proof_contracts::{DisputeGameFactoryClient, DisputeGameFactoryContractClient, GameAtIndex};
+use clap::Parser;
+use eyre::{Context, Result, bail};
+use url::Url;
+
+/// Challenger E2E observation config.
+#[derive(Debug, Parser)]
+pub struct ChallengerE2eConfig {
+    /// L1 RPC URL used by Challenger.
+    #[arg(long, env = "CHALLENGER_L1_RPC_URL")]
+    pub l1_rpc_url: Url,
+
+    /// DisputeGameFactory address watched by Challenger.
+    #[arg(long, env = "CHALLENGER_DISPUTE_GAME_FACTORY_ADDR")]
+    pub dispute_game_factory_addr: Address,
+
+    /// Optional game type filter.
+    #[arg(long, env = "CHALLENGER_GAME_TYPE")]
+    pub game_type: Option<u32>,
+
+    /// Maximum time to wait for a new dispute game after the gate starts.
+    #[arg(long, env = "CHALLENGER_NEW_GAME_TIMEOUT_SECS", default_value_t = 30 * 60)]
+    pub new_game_timeout_secs: u64,
+
+    /// Poll interval while waiting for a new dispute game.
+    #[arg(long, env = "CHALLENGER_POLL_INTERVAL_SECS", default_value_t = 30)]
+    pub poll_interval_secs: u64,
+
+    /// Maximum number of recent games to scan when looking for a matching game type.
+    #[arg(long, env = "CHALLENGER_LATEST_GAME_SCAN_LIMIT", default_value_t = 100)]
+    pub latest_game_scan_limit: u64,
+}
+
+/// Challenger E2E observation runner.
+#[derive(Debug)]
+pub struct ChallengerE2e;
+
+impl ChallengerE2e {
+    /// Runs the Challenger E2E observation.
+    pub async fn run(config: ChallengerE2eConfig) -> Result<()> {
+        let provider = RootProvider::new_http(config.l1_rpc_url.clone());
+        Self::assert_contract(&provider, config.dispute_game_factory_addr, "DisputeGameFactory")
+            .await?;
+
+        let factory = DisputeGameFactoryContractClient::new(
+            config.dispute_game_factory_addr,
+            config.l1_rpc_url.clone(),
+        )?;
+
+        let initial_count = factory.game_count().await.context("gameCount before wait failed")?;
+        if initial_count == 0 {
+            bail!("DisputeGameFactory has no games");
+        }
+
+        let latest = Self::latest_game(&factory, initial_count, config.game_type, config.latest_game_scan_limit)
+            .await?
+            .ok_or_else(|| eyre::eyre!("no dispute game found for game type {:?} in last {} games", config.game_type, config.latest_game_scan_limit))?;
+        Self::assert_contract(&provider, latest.proxy, "latest dispute game").await?;
+        tracing::info!(
+            game_count = initial_count,
+            game_type = latest.game_type,
+            timestamp = latest.timestamp,
+            proxy = %latest.proxy,
+            "observed latest dispute game before wait",
+        );
+
+        let deadline = Instant::now() + Duration::from_secs(config.new_game_timeout_secs);
+        let poll_interval = Duration::from_secs(config.poll_interval_secs);
+        while Instant::now() < deadline {
+            let count = factory.game_count().await.context("gameCount while waiting failed")?;
+            if count > initial_count {
+                if let Some(game) = Self::latest_game_in_range(
+                    &factory,
+                    initial_count,
+                    count,
+                    config.game_type,
+                    config.latest_game_scan_limit,
+                )
+                .await?
+                {
+                    Self::assert_contract(&provider, game.proxy, "new dispute game").await?;
+                    tracing::info!(
+                        previous_game_count = initial_count,
+                        new_game_count = count,
+                        game_type = game.game_type,
+                        timestamp = game.timestamp,
+                        proxy = %game.proxy,
+                        "observed new dispute game after gate start",
+                    );
+                    return Ok(());
+                }
+            }
+            tokio::time::sleep(poll_interval).await;
+        }
+
+        bail!("no new dispute game observed within {}s", config.new_game_timeout_secs)
+    }
+
+    async fn latest_game(
+        factory: &DisputeGameFactoryContractClient,
+        game_count: u64,
+        game_type: Option<u32>,
+        scan_limit: u64,
+    ) -> Result<Option<GameAtIndex>> {
+        Self::latest_game_in_range(
+            factory,
+            game_count.saturating_sub(scan_limit),
+            game_count,
+            game_type,
+            scan_limit,
+        )
+        .await
+    }
+
+    async fn latest_game_in_range(
+        factory: &DisputeGameFactoryContractClient,
+        from: u64,
+        to: u64,
+        game_type: Option<u32>,
+        scan_limit: u64,
+    ) -> Result<Option<GameAtIndex>> {
+        let lower = from.max(to.saturating_sub(scan_limit));
+        for index in (lower..to).rev() {
+            let game = factory.game_at_index(index).await?;
+            if game_type.is_none_or(|expected| game.game_type == expected) {
+                return Ok(Some(game));
+            }
+        }
+        Ok(None)
+    }
+
+    async fn assert_contract(provider: &RootProvider, address: Address, name: &str) -> Result<()> {
+        if provider.get_code_at(address).await?.is_empty() {
+            bail!("{name} {address} has no code");
+        }
+        Ok(())
+    }
+}

--- a/crates/infra/challenger-e2e/src/lib.rs
+++ b/crates/infra/challenger-e2e/src/lib.rs
@@ -1,0 +1,4 @@
+#![doc = include_str!("../README.md")]
+
+mod challenger_e2e;
+pub use challenger_e2e::{ChallengerE2e, ChallengerE2eConfig};


### PR DESCRIPTION
## Summary

Adds a Rust Challenger E2E observation binary at `bin/challenger-e2e` for FORT execution.

The binary watches the configured L1 `DisputeGameFactory` and verifies that:

- the factory contract exists,
- at least one dispute game already exists,
- the latest dispute game contract has code,
- a new dispute game appears after the gate starts,
- the new dispute game contract has code.

This keeps the release gate focused on the dispute-game flow rather than service health endpoints, and follows the repo's Rust workspace conventions.

## Testing

Not run locally per iteration preference.
