### PR TITLE
ci(fork-tests): pin Beryl row to the Beryl base-anvil (release/v1.1.x)

### DIFF
--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -30,9 +30,15 @@ jobs:
         include:
           # Refs may be release tags or commit SHAs. The resolved commit SHA is
           # recorded in the result artifact and PR comment.
+          #
+          # Each fork must pin the base-anvil that installs that fork's precompile
+          # set (base-anvil now selects the fork per branch, not via a runtime
+          # flag): release/v1.1.x stays Beryl (V1); base-anvil-fork main is Cobalt
+          # (V2). A Cobalt row (base-anvil-fork main + the base-std ERC-8056 /
+          # AssetV2 reference) is added once base-std #173 merges and is tagged.
           - fork: Beryl
             key: beryl
-            base_anvil_ref: ae7557c4f8602caa1da0be33143bb2504c85b0c8
+            base_anvil_ref: d3bdb810084e510acd1a57c63b1bcf8b801db40a # base-anvil release/v1.1.x (Beryl)
             base_std_ref: v1.0.0
     env:
       FORK_NAME: ${{ matrix.fork }}


### PR DESCRIPTION
## Summary
The `Base Std historical fork tests` matrix pinned the **Beryl** row's `base_anvil_ref` to `ae7557c` — base-anvil-fork **main**, which under the new per-branch fork model is the **Cobalt** snapshot (`--base` there installs the Cobalt/V2 precompile set). Run against the **Beryl** base-std reference (`v1.0.0`, V1), it exercised V2 behavior against V1 expectations and failed — e.g. on #4121, the fork-test comment reported 7 failures:
- `InvalidMultiplier()` on `test_multiplier_success_returnsStoredValue`, `test_scaledBalanceOf_success_zeroForEmptyAccount`, `test_toScaledBalance_*`, `test_toRawBalance_success_zeroScaledBalance`, `test_updateMultiplier_success_writesSlot` — the tests fuzz the multiplier up to `uint256`; V2 (Cobalt) bounds it to `uint128` (ERC-8056 packs it as `uint128`).
- `log != expected log` on `test_updateMultiplier_success_emitsEvent` — V2 emits `UIMultiplierUpdated` instead of V1's `MultiplierUpdated`.

This repoints the Beryl row to the **Beryl** base-anvil (`release/v1.1.x` = `d3bdb810`, revm 41 / alloy-evm 0.37), so the row runs V1 precompiles against the V1 reference — which is what the Beryl historical row is meant to verify.

## Not an AssetV2 regression
The 7 failures were the intended V1→V2 Cobalt changes surfaced by a fork/anvil mismatch (a Cobalt anvil under the Beryl label), not a change to frozen behavior: `logic/v1.rs` is byte-for-byte unchanged, and per-block fork gating keeps Beryl on V1 in a real node. The `InvalidMultiplier()` reverts are a V2-only check, confirming the "Beryl" row was actually running the Cobalt build.

## Follow-up (not in this PR)
A **Cobalt** row — base-anvil-fork main (`ae7557c`) + the base-std ERC-8056/AssetV2 reference — will be added once base-std #173 merges and is tagged (no stable base-std Cobalt tag exists yet). That pairing already cross-validates green locally: **646 passed / 0 failed / 13 skipped** in LIVE PRECOMPILE mode.

## Test plan
- [ ] This PR's own `Base Std Interface Tests (Beryl)` run goes green with the Beryl base-anvil pin. (If the build step fails, it indicates base-anvil `release/v1.1.x` needs a bump to build against current base/base `main` — flag for a base-anvil release update.)

Made with [Cursor](https://cursor.com)