### PR TITLE
ci(fork-tests): pin Beryl base_anvil_ref to base-anvil#59

### DIFF
--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -32,7 +32,7 @@ jobs:
           # recorded in the result artifact and PR comment.
           - fork: Beryl
             key: beryl
-            base_anvil_ref: ae7557c4f8602caa1da0be33143bb2504c85b0c8
+            base_anvil_ref: 6d744e03224977edd42a36699ba9ff42be25e8cb
             base_std_ref: v1.0.0
     env:
       FORK_NAME: ${{ matrix.fork }}


### PR DESCRIPTION
## Motivation

`base-std-fork-tests.yml`'s Beryl entry pins `base_anvil_ref: ae7557c4…`, which is the merge commit of [base-anvil #58](https://github.com/base/base-anvil/pull/58) — the *mainline* fix layered on top of the Beryl→Cobalt retarget. Per [base-anvil #59](https://github.com/base/base-anvil/pull/59), that fix is not valid for the Beryl line (it pulls in Cobalt behavior), so the Beryl fork test should not build from it.

## Change

Point the Beryl matrix entry's `base_anvil_ref` at base-anvil #59's merge commit [`6d744e03`](https://github.com/base/base-anvil/commit/6d744e03224977edd42a36699ba9ff42be25e8cb) — the head of the `release/v1.1.x` Beryl maintenance line. That commit threads `BaseUpgrade` through `ActivationRegistry::install` while keeping `BaseUpgrade::Beryl` semantics (static-fallback activation admin, no Cobalt-only precompiles), which is exactly what the Beryl fork test needs to compile stale base-anvil against current `base/base`.

`base_std_ref` stays `v1.0.0`. This is the follow-up base-anvil #59 called out: *"base/base's base-std-fork-tests.yml still pins base_anvil_ref: d3bdb810…; that job stays red until the pin moves to this commit."*

## Verification

Config-only change to a CI matrix pin. The Beryl fork-tests job will re-resolve and build against `6d744e03` on the next run; the resolved SHA is recorded in the result artifact / PR comment.

Generated with Claude Code