### PR TITLE
refactor(builder): Extract Builder Deadline Logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3608,6 +3608,7 @@ dependencies = [
  "reth-trie-common",
  "revm",
  "rlimit",
+ "rstest",
  "secp256k1 0.30.0",
  "serde",
  "serde_json",

--- a/crates/builder/core/Cargo.toml
+++ b/crates/builder/core/Cargo.toml
@@ -181,6 +181,7 @@ criterion = { workspace = true, features = ["html_reports"] }
 ctor.workspace = true
 hyper.workspace = true
 rlimit.workspace = true
+rstest.workspace = true
 nanoid.workspace = true
 tempfile.workspace = true
 hyper-util.workspace = true

--- a/crates/builder/core/src/flashblocks/deadline.rs
+++ b/crates/builder/core/src/flashblocks/deadline.rs
@@ -1,0 +1,94 @@
+//! Payload job deadline calculation and timer construction.
+
+use core::{pin::Pin, time::Duration};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tokio::time::Sleep;
+use tracing::warn;
+
+/// Calculates how long a payload job remains available and constructs its deadline timer.
+///
+/// The deadline is critical for payload availability: once reached, the payload job stops and
+/// cannot be queried again. Tight deadlines near the block timestamp risk expiring before the node
+/// requests the payload, so this type owns an additional configured leeway.
+///
+/// The leeway also accommodates bursts caused by long batcher channel durations. A batcher update
+/// can trigger hundreds of forkchoice updates and block queries at once, delaying the subsequent
+/// `getPayload` request by several seconds. Retaining payloads beyond their nominal timestamp avoids
+/// losing blocks in that situation.
+///
+/// A longer-term alternative would be cancellation logic that retires existing jobs when new block
+/// building requests arrive.
+#[derive(Debug)]
+pub struct Deadline {
+    extra_block_deadline: Duration,
+}
+
+impl Deadline {
+    /// Creates a deadline calculator that owns the configured additional payload retention time.
+    pub const fn new(extra_block_deadline: Duration) -> Self {
+        Self { extra_block_deadline }
+    }
+
+    /// Calculates the duration until the attributes timestamp plus the configured leeway.
+    ///
+    /// Timestamps at or before the current time receive a minimum one-second base duration. If the
+    /// system clock predates the Unix epoch, only the configured leeway is returned.
+    pub fn calculate(&self, attributes_timestamp: u64) -> Duration {
+        let unix_now = match SystemTime::now().duration_since(UNIX_EPOCH) {
+            Ok(duration) => duration.as_secs(),
+            Err(error) => {
+                warn!(error = %error, "System clock went backward, using configured deadline leeway");
+                return self.extra_block_deadline;
+            }
+        };
+
+        let duration_until = attributes_timestamp.saturating_sub(unix_now);
+        let duration_until = if duration_until == 0 {
+            Duration::from_secs(1)
+        } else {
+            Duration::from_secs(duration_until)
+        };
+
+        duration_until + self.extra_block_deadline
+    }
+
+    /// Returns a pinned timer that completes when the calculated deadline is reached.
+    pub fn sleep(&self, attributes_timestamp: u64) -> Pin<Box<Sleep>> {
+        Box::pin(tokio::time::sleep(self.calculate(attributes_timestamp)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    use rstest::rstest;
+
+    use super::Deadline;
+
+    #[rstest]
+    #[case(Duration::ZERO, Duration::from_secs(1))]
+    #[case(Duration::from_secs(5), Duration::from_secs(6))]
+    fn calculate_applies_minimum_duration_and_leeway(
+        #[case] extra_block_deadline: Duration,
+        #[case] expected: Duration,
+    ) {
+        let deadline = Deadline::new(extra_block_deadline);
+
+        assert_eq!(deadline.calculate(0), expected);
+    }
+
+    #[rstest]
+    #[case(Duration::ZERO)]
+    #[case(Duration::from_secs(5))]
+    fn calculate_uses_attributes_timestamp(#[case] extra_block_deadline: Duration) {
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        let deadline = Deadline::new(extra_block_deadline);
+
+        let calculated = deadline.calculate(now + 60);
+
+        assert!(calculated >= Duration::from_secs(59) + extra_block_deadline);
+        assert!(calculated <= Duration::from_secs(60) + extra_block_deadline);
+    }
+}

--- a/crates/builder/core/src/flashblocks/deadline.rs
+++ b/crates/builder/core/src/flashblocks/deadline.rs
@@ -19,12 +19,12 @@ use tracing::warn;
 ///
 /// A longer-term alternative would be cancellation logic that retires existing jobs when new block
 /// building requests arrive.
-#[derive(Debug)]
-pub struct Deadline {
+#[derive(Debug, Clone, Copy)]
+pub struct PayloadJobDeadline {
     extra_block_deadline: Duration,
 }
 
-impl Deadline {
+impl PayloadJobDeadline {
     /// Creates a deadline calculator that owns the configured additional payload retention time.
     pub const fn new(extra_block_deadline: Duration) -> Self {
         Self { extra_block_deadline }
@@ -65,7 +65,7 @@ mod tests {
 
     use rstest::rstest;
 
-    use super::Deadline;
+    use super::PayloadJobDeadline;
 
     #[rstest]
     #[case(Duration::ZERO, Duration::from_secs(1))]
@@ -74,7 +74,7 @@ mod tests {
         #[case] extra_block_deadline: Duration,
         #[case] expected: Duration,
     ) {
-        let deadline = Deadline::new(extra_block_deadline);
+        let deadline = PayloadJobDeadline::new(extra_block_deadline);
 
         assert_eq!(deadline.calculate(0), expected);
     }
@@ -84,7 +84,7 @@ mod tests {
     #[case(Duration::from_secs(5))]
     fn calculate_uses_attributes_timestamp(#[case] extra_block_deadline: Duration) {
         let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
-        let deadline = Deadline::new(extra_block_deadline);
+        let deadline = PayloadJobDeadline::new(extra_block_deadline);
 
         let calculated = deadline.calculate(now + 60);
 

--- a/crates/builder/core/src/flashblocks/generator.rs
+++ b/crates/builder/core/src/flashblocks/generator.rs
@@ -1,7 +1,4 @@
-use std::{
-    sync::Arc,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::sync::Arc;
 
 use alloy_primitives::B256;
 use futures::{Future, FutureExt};
@@ -17,14 +14,11 @@ use reth_primitives_traits::HeaderTy;
 use reth_provider::{BlockReaderIdExt, CanonStateNotification, StateProviderFactory};
 use reth_revm::cached::CachedReads;
 use reth_tasks::Runtime;
-use tokio::{
-    sync::watch,
-    time::{Duration, Sleep},
-};
+use tokio::{sync::watch, time::Sleep};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, trace, warn};
 
-use crate::PayloadBuilder;
+use crate::{Deadline, PayloadBuilder};
 
 /// The generator type that creates new jobs that build empty blocks.
 #[derive(Debug)]
@@ -41,8 +35,8 @@ pub struct BlockPayloadJobGenerator<Client, Builder> {
     ensure_only_one_payload: bool,
     /// The last payload being processed
     last_payload: Arc<Mutex<CancellationToken>>,
-    /// The extra block deadline in seconds
-    extra_block_deadline: std::time::Duration,
+    /// Calculates and constructs payload job deadline timers.
+    deadline: Deadline,
     /// Stored `cached_reads` for new payload jobs.
     pre_cached: Option<PrecachedState>,
 }
@@ -65,7 +59,7 @@ impl<Client, Builder> BlockPayloadJobGenerator<Client, Builder> {
             builder,
             ensure_only_one_payload,
             last_payload: Arc::new(Mutex::new(CancellationToken::new())),
-            extra_block_deadline,
+            deadline: Deadline::new(extra_block_deadline),
             pre_cached: None,
         }
     }
@@ -128,25 +122,7 @@ where
 
         info!("Spawn block building job");
 
-        // The deadline is critical for payload availability. If we reach the deadline,
-        // the payload job stops and cannot be queried again. With tight deadlines close
-        // to the block number, we risk reaching the deadline before the node queries the payload.
-        //
-        // Adding 0.5 seconds as wiggle room since block times are shorter here.
-        // TODO: A better long-term solution would be to implement cancellation logic
-        // that cancels existing jobs when receiving new block building requests.
-        //
-        // When batcher's max channel duration is big enough (e.g. 10m), the
-        // sequencer would send an avalanche of FCUs/getBlockByNumber on
-        // each batcher update (with 10m channel it's ~800 FCUs at once).
-        // At such moment it can happen that the time b/w FCU and ensuing
-        // getPayload would be on the scale of ~2.5s. Therefore we should
-        // "remember" the payloads long enough to accommodate this corner-case
-        // (without it we are losing blocks). Postponing the deadline for 5s
-        // (not just 0.5s) because of that.
-        let deadline = job_deadline(input.attributes.timestamp()) + self.extra_block_deadline;
-
-        let deadline = Box::pin(tokio::time::sleep(deadline));
+        let deadline = self.deadline.sleep(input.attributes.timestamp());
 
         // Extract hash before moving parent_header into Arc to avoid cloning
         let parent_hash = parent_header.hash();
@@ -197,7 +173,13 @@ use std::{
     task::{Context, Poll},
 };
 
-/// A [`PayloadJob`] that builds empty blocks.
+/// A [`PayloadJob`] that manages the asynchronous construction of a block payload.
+///
+/// [`PayloadJobGenerator::new_payload_job`] creates this job when the
+/// [`PayloadBuilderService`](reth_payload_builder::PayloadBuilderService) receives new payload
+/// attributes from an Engine API forkchoice update. The service polls the job to enforce its
+/// deadline and resolve payload requests, while the job runs its [`PayloadBuilder`] on a blocking
+/// task and receives updated built payloads through a watch channel.
 pub struct BlockPayloadJob<Builder>
 where
     Builder: PayloadBuilder,
@@ -400,26 +382,6 @@ impl<T> Future for ResolvePayload<T> {
     }
 }
 
-fn job_deadline(unix_timestamp_secs: u64) -> std::time::Duration {
-    let unix_now = match SystemTime::now().duration_since(UNIX_EPOCH) {
-        Ok(d) => d.as_secs(),
-        Err(e) => {
-            warn!(error = %e, "System clock went backward, returning zero deadline");
-            return Duration::ZERO;
-        }
-    };
-
-    // Safe subtraction that handles the case where timestamp is in the past
-    let duration_until = unix_timestamp_secs.saturating_sub(unix_now);
-
-    if duration_until == 0 {
-        // Enforce a minimum block time of 1 second by rounding up any duration less than 1 second
-        Duration::from_secs(1)
-    } else {
-        Duration::from_secs(duration_until)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use alloy_eips::eip7685::Requests;
@@ -519,28 +481,6 @@ mod tests {
                 std::thread::sleep(Duration::from_millis(10));
             }
         }
-    }
-
-    #[tokio::test]
-    async fn test_job_deadline() {
-        // Test future deadline
-        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-        let future_timestamp = now + Duration::from_secs(2);
-        // 2 seconds from now
-        let deadline = job_deadline(future_timestamp.as_secs());
-        assert!(deadline <= Duration::from_secs(2));
-        assert!(deadline > Duration::from_secs(0));
-
-        // Test past deadline
-        let past_timestamp = now - Duration::from_secs(10);
-        let deadline = job_deadline(past_timestamp.as_secs());
-        // Should default to 1 second when timestamp is in the past
-        assert_eq!(deadline, Duration::from_secs(1));
-
-        // Test current timestamp
-        let deadline = job_deadline(now.as_secs());
-        // Should use 1 second when timestamp is current
-        assert_eq!(deadline, Duration::from_secs(1));
     }
 
     #[tokio::test]

--- a/crates/builder/core/src/flashblocks/generator.rs
+++ b/crates/builder/core/src/flashblocks/generator.rs
@@ -18,7 +18,7 @@ use tokio::{sync::watch, time::Sleep};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, trace, warn};
 
-use crate::{Deadline, PayloadBuilder};
+use crate::{PayloadBuilder, PayloadJobDeadline};
 
 /// The generator type that creates new jobs that build empty blocks.
 #[derive(Debug)]
@@ -36,7 +36,7 @@ pub struct BlockPayloadJobGenerator<Client, Builder> {
     /// The last payload being processed
     last_payload: Arc<Mutex<CancellationToken>>,
     /// Calculates and constructs payload job deadline timers.
-    deadline: Deadline,
+    deadline: PayloadJobDeadline,
     /// Stored `cached_reads` for new payload jobs.
     pre_cached: Option<PrecachedState>,
 }
@@ -59,7 +59,7 @@ impl<Client, Builder> BlockPayloadJobGenerator<Client, Builder> {
             builder,
             ensure_only_one_payload,
             last_payload: Arc::new(Mutex::new(CancellationToken::new())),
-            deadline: Deadline::new(extra_block_deadline),
+            deadline: PayloadJobDeadline::new(extra_block_deadline),
             pre_cached: None,
         }
     }

--- a/crates/builder/core/src/flashblocks/generator.rs
+++ b/crates/builder/core/src/flashblocks/generator.rs
@@ -20,7 +20,10 @@ use tracing::{debug, info, trace, warn};
 
 use crate::{PayloadBuilder, PayloadJobDeadline};
 
-/// The generator type that creates new jobs that build empty blocks.
+/// Creates payload jobs that build blocks from Engine API payload attributes.
+///
+/// Each generated job delegates payload construction to the configured [`PayloadBuilder`] and
+/// manages its execution, resolution, cancellation, and deadline.
 #[derive(Debug)]
 pub struct BlockPayloadJobGenerator<Client, Builder> {
     /// The client that can interact with the chain.

--- a/crates/builder/core/src/flashblocks/mod.rs
+++ b/crates/builder/core/src/flashblocks/mod.rs
@@ -3,6 +3,9 @@
 mod best_txs;
 pub use best_txs::BestFlashblocksTxs;
 
+mod deadline;
+pub use deadline::Deadline;
+
 mod generator;
 pub use generator::{BlockPayloadJob, BlockPayloadJobGenerator, BuildArguments, ResolvePayload};
 

--- a/crates/builder/core/src/flashblocks/mod.rs
+++ b/crates/builder/core/src/flashblocks/mod.rs
@@ -4,7 +4,7 @@ mod best_txs;
 pub use best_txs::BestFlashblocksTxs;
 
 mod deadline;
-pub use deadline::Deadline;
+pub use deadline::PayloadJobDeadline;
 
 mod generator;
 pub use generator::{BlockPayloadJob, BlockPayloadJobGenerator, BuildArguments, ResolvePayload};

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -45,8 +45,8 @@ pub use rejection_cache::RejectionCache;
 mod flashblocks;
 pub use flashblocks::{
     BasePayloadBuilderCtx, BestFlashblocksTxs, BlockPayloadJob, BlockPayloadJobGenerator,
-    BuildArguments, FlashblockDiagnostics, FlashblockSelectionOutcome, FlashblocksExtraCtx,
-    FlashblocksServiceBuilder, PayloadBuilder, PayloadHandler, ResolvePayload,
+    BuildArguments, Deadline, FlashblockDiagnostics, FlashblockSelectionOutcome,
+    FlashblocksExtraCtx, FlashblocksServiceBuilder, PayloadBuilder, PayloadHandler, ResolvePayload,
 };
 
 mod extension;

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -45,8 +45,8 @@ pub use rejection_cache::RejectionCache;
 mod flashblocks;
 pub use flashblocks::{
     BasePayloadBuilderCtx, BestFlashblocksTxs, BlockPayloadJob, BlockPayloadJobGenerator,
-    BuildArguments, Deadline, FlashblockDiagnostics, FlashblockSelectionOutcome,
-    FlashblocksExtraCtx, FlashblocksServiceBuilder, PayloadBuilder, PayloadHandler, ResolvePayload,
+    BuildArguments, FlashblockDiagnostics, FlashblockSelectionOutcome, FlashblocksExtraCtx,
+    FlashblocksServiceBuilder, PayloadBuilder, PayloadHandler, PayloadJobDeadline, ResolvePayload,
 };
 
 mod extension;

--- a/crates/execution/trie/src/db/rocksdb.rs
+++ b/crates/execution/trie/src/db/rocksdb.rs
@@ -3381,7 +3381,7 @@ mod tests {
         let (tx, rx) = mpsc::channel();
         let task_storage = Arc::clone(&storage);
 
-        thread::spawn(move || {
+        let handle = thread::spawn(move || {
             let result = task_storage
                 .store_trie_updates(block(1, B256::ZERO), BlockStateDiff::default())
                 .map(|_| ());
@@ -3390,6 +3390,8 @@ mod tests {
 
         assert_completes(rx);
         assert_eq!(storage.get_latest_block_number().unwrap(), Some((1, B256::repeat_byte(1))));
+        // Join before the temp dir drops so the worker releases its storage handle first.
+        handle.join().unwrap();
     }
 
     #[test]
@@ -3401,7 +3403,7 @@ mod tests {
         let (tx, rx) = mpsc::channel();
         let task_storage = Arc::clone(&storage);
 
-        thread::spawn(move || {
+        let handle = thread::spawn(move || {
             let result = task_storage
                 .store_trie_updates(block(1, B256::ZERO), BlockStateDiff::default())
                 .map(|_| ());
@@ -3411,6 +3413,8 @@ mod tests {
         assert!(rx.recv_timeout(Duration::from_millis(50)).is_err());
         drop(history_guard);
         assert_completes(rx);
+        // Join before the temp dir drops so the worker releases its storage handle first.
+        handle.join().unwrap();
     }
 
     #[test]
@@ -3422,7 +3426,7 @@ mod tests {
         let (tx, rx) = mpsc::channel();
         let task_storage = Arc::clone(&storage);
 
-        thread::spawn(move || {
+        let handle = thread::spawn(move || {
             let result = task_storage
                 .store_trie_updates(block(1, B256::ZERO), BlockStateDiff::default())
                 .map(|_| ());
@@ -3432,6 +3436,8 @@ mod tests {
         assert!(rx.recv_timeout(Duration::from_millis(50)).is_err());
         drop(append_guard);
         assert_completes(rx);
+        // Join before the temp dir drops so the worker releases its storage handle first.
+        handle.join().unwrap();
     }
 
     #[test]
@@ -3444,7 +3450,7 @@ mod tests {
         let (tx, rx) = mpsc::channel();
         let task_storage = Arc::clone(&storage);
 
-        thread::spawn(move || {
+        let handle = thread::spawn(move || {
             let result = task_storage.replace_updates(BlockNumHash::new(0, B256::ZERO), vec![]);
             tx.send(result).unwrap();
         });
@@ -3452,6 +3458,8 @@ mod tests {
         assert!(rx.recv_timeout(Duration::from_millis(50)).is_err());
         drop(history_guard);
         assert_completes(rx);
+        // Join before the temp dir drops so the worker releases its storage handle first.
+        handle.join().unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This extracts payload job deadline calculation and timer construction into a dedicated Deadline type that owns the configured leeway. The generator now delegates deadline creation to that type, while focused rstest cases cover timestamp and leeway behavior. It also replaces the stale empty-block job documentation with an explanation of how PayloadBuilderService constructs and uses the job.

Part of an ongoing effort to simplify the builder by first decomposing and then improving the abstractions