### PR TITLE
feat(devnet): add opt-in Zenith mode

### DIFF
--- a/crates/common/rpc-types/src/genesis.rs
+++ b/crates/common/rpc-types/src/genesis.rs
@@ -34,9 +34,6 @@ impl TryFrom<&OtherFields> for ChainInfo {
 }
 
 /// Base-specific upgrade configuration in a genesis file.
-///
-/// `deny_unknown_fields` ensures a genesis cannot smuggle in a `zenith` (or any other unknown)
-/// activation time: Zenith is a permanently-off gate and is not configurable.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct UpgradeInfo {
@@ -49,6 +46,9 @@ pub struct UpgradeInfo {
     /// Cobalt upgrade timestamp.
     #[serde(alias = "v3")]
     pub cobalt: Option<u64>,
+    /// Zenith upgrade timestamp.
+    #[serde(alias = "future")]
+    pub zenith: Option<u64>,
 }
 
 /// The Base chain-specific genesis block specification.
@@ -141,7 +141,8 @@ mod tests {
           "ecotoneTime": 0,
           "base": {
             "v1": 14,
-            "v2": 16
+            "v2": 16,
+            "zenith": 1000000
           }
         }
         "#;
@@ -161,10 +162,22 @@ mod tests {
                 holocene_time: None,
                 isthmus_time: None,
                 jovian_time: None,
-                base: UpgradeInfo { azul: Some(14), beryl: Some(16), cobalt: None },
+                base: UpgradeInfo {
+                    azul: Some(14),
+                    beryl: Some(16),
+                    cobalt: None,
+                    zenith: Some(1_000_000),
+                },
                 activation_admin_address: None,
             }
         );
+    }
+
+    #[test]
+    fn upgrade_info_accepts_future_alias() {
+        let upgrades: UpgradeInfo = serde_json::from_str(r#"{"future":18}"#).unwrap();
+
+        assert_eq!(upgrades.zenith, Some(18));
     }
 
     #[test]
@@ -227,7 +240,12 @@ mod tests {
                     holocene_time: None,
                     isthmus_time: None,
                     jovian_time: None,
-                    base: UpgradeInfo { azul: Some(14), beryl: Some(16), cobalt: None },
+                    base: UpgradeInfo {
+                        azul: Some(14),
+                        beryl: Some(16),
+                        cobalt: None,
+                        zenith: None,
+                    },
                     activation_admin_address: None,
                 }),
                 base_fee_info: Some(FeeInfo {
@@ -253,7 +271,12 @@ mod tests {
                     holocene_time: None,
                     isthmus_time: None,
                     jovian_time: None,
-                    base: UpgradeInfo { azul: Some(14), beryl: Some(16), cobalt: None },
+                    base: UpgradeInfo {
+                        azul: Some(14),
+                        beryl: Some(16),
+                        cobalt: None,
+                        zenith: None,
+                    },
                     activation_admin_address: None,
                 }),
                 base_fee_info: Some(FeeInfo {

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -175,6 +175,7 @@ impl BaseChainSpec {
         let azul_time = genesis_info.base.azul;
         let beryl_time = genesis_info.base.beryl;
         let cobalt_time = genesis_info.base.cobalt;
+        let zenith_time = genesis_info.base.zenith;
         let time_upgrade_opts = [
             (BaseUpgrade::Regolith.boxed(), genesis_info.regolith_time),
             (EthereumHardfork::Shanghai.boxed(), genesis_info.canyon_time),
@@ -191,6 +192,7 @@ impl BaseChainSpec {
             (BaseUpgrade::Azul.boxed(), azul_time),
             (BaseUpgrade::Beryl.boxed(), beryl_time),
             (BaseUpgrade::Cobalt.boxed(), cobalt_time),
+            (BaseUpgrade::Zenith.boxed(), zenith_time),
         ];
 
         let mut time_upgrades = time_upgrade_opts
@@ -447,7 +449,7 @@ impl BaseChainSpec {
             inserted = true;
         }
         // Only execution-ladder upgrades enter the reth hardfork schedule; contract-only
-        // upgrades (Delta, PectraBlobSchedule) and the permanently-off Zenith gate are ignored.
+        // upgrades (Delta, PectraBlobSchedule) and genesis-only Zenith are ignored here.
         if hardfork_id.is_execution() {
             hardforks.insert(hardfork_id, condition);
             inserted = true;
@@ -961,8 +963,7 @@ mod tests {
 
     #[test]
     fn builtin_chain_specs_never_activate_zenith() {
-        // Zenith is a permanently-off gate: it never enters any chain's fork schedule, so it is
-        // always `Never` and never active.
+        // Built-in production schedules do not configure the genesis-only Zenith upgrade.
         for spec in [BaseChainSpec::mainnet(), BaseChainSpec::sepolia(), BaseChainSpec::devnet()] {
             assert_eq!(spec.fork(BaseUpgrade::Zenith), ForkCondition::Never);
             assert!(!spec.is_fork_active_at_timestamp(BaseUpgrade::Zenith, 0));
@@ -1214,7 +1215,8 @@ mod tests {
         "base": {
           "v1": 55,
           "v2": 60,
-          "v3": 65
+          "v3": 65,
+          "zenith": 1000000
         },
         "activationAdminAddress": "0xcb00000000000000000000000000000000000000",
         "optimism": {
@@ -1257,10 +1259,8 @@ mod tests {
         assert!(chain_spec.is_fork_active_at_timestamp(BaseUpgrade::Beryl, 60));
         assert!(!chain_spec.is_fork_active_at_timestamp(BaseUpgrade::Cobalt, 64));
         assert!(chain_spec.is_fork_active_at_timestamp(BaseUpgrade::Cobalt, 65));
-
-        // Zenith is a permanently-off gate: never scheduled, always Never.
-        assert_eq!(chain_spec.fork(BaseUpgrade::Zenith), ForkCondition::Never);
-        assert!(!chain_spec.is_fork_active_at_timestamp(BaseUpgrade::Zenith, 9999));
+        assert!(!chain_spec.is_fork_active_at_timestamp(BaseUpgrade::Zenith, 999_999));
+        assert!(chain_spec.is_fork_active_at_timestamp(BaseUpgrade::Zenith, 1_000_000));
     }
 
     #[test]

--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -11,12 +11,12 @@ default:
     @just --justfile {{source_file()}} --list
 
 # Stops devnet, deletes data, and starts fresh (3-node HA conductor cluster)
-up zk='dry-run':
-    just --justfile {{ source_file() }} _up-devnet "ha" {{ quote(zk) }}
+up mode='default' zk='dry-run':
+    just --justfile {{ source_file() }} _up-devnet "ha" {{ quote(mode) }} {{ quote(zk) }}
 
 # Stops devnet, deletes data, and starts fresh with a single sequencer (no conductor)
-up-single zk='dry-run':
-    just --justfile {{ source_file() }} _up-devnet "base" {{ quote(zk) }}
+up-single mode='default' zk='dry-run':
+    just --justfile {{ source_file() }} _up-devnet "base" {{ quote(mode) }} {{ quote(zk) }}
 
 # Stops devnet, deletes data, and starts fresh with profiling (Pyroscope + optimized builds)
 profiling: down _build-setup-image (_build-rust-images "devnet" "profiling")
@@ -179,12 +179,28 @@ _build-rust-images group profile='dev':
     PROFILE="{{ profile }}" ZK_HOST_PROFILE=release BASE_SUCCINCT_ELF_REQUIRE="${elf_require}" PLATFORM_PAIR="${platform_pair}" docker buildx bake -f etc/docker/docker-bake.hcl "{{ group }}" --load
 
 [private]
-_up-devnet compose_profile zk:
+_up-devnet compose_profile mode zk:
     #!/usr/bin/env bash
     set -euo pipefail
     compose_profile={{ quote(compose_profile) }}
+    devnet_mode={{ quote(mode) }}
     zk_mode={{ quote(zk) }}
     zk_mode="${zk_mode#zk=}"
+
+    # Preserve existing `just devnet up zk=cluster` usage.
+    if [[ "$devnet_mode" == zk=* || "$devnet_mode" == "dry-run" || "$devnet_mode" == "cluster" ]]; then
+      zk_mode="${devnet_mode#zk=}"
+      devnet_mode=default
+    fi
+
+    case "$devnet_mode" in
+      default) ;;
+      zenith) export L2_BASE_ZENITH_BLOCK="${L2_BASE_ZENITH_BLOCK:-23}" ;;
+      *)
+        echo "ERROR: mode must be 'default' or 'zenith' (got '${devnet_mode}')" >&2
+        exit 1
+        ;;
+    esac
 
     case "$compose_profile" in
       ha) compose_files=({{ _ha }}) ;;

--- a/etc/docker/README.md
+++ b/etc/docker/README.md
@@ -33,6 +33,13 @@ just devnet logs   # Stream logs from all containers
 just devnet status # Check block numbers and sync status
 ```
 
+Zenith is disabled by default. To activate it at block 23 and switch the sequencer to its 200ms
+cadence, start with:
+
+```bash
+just devnet up zenith
+```
+
 `just devnet up` deploys a local L1 `MockProtocolVersions` contract, writes
 `.devnet/l2/configs/upgrade-signal.env`, and starts the normal L2 nodes in
 `runtime-admin` upgrade-signal mode. You can inspect or update the live schedule

--- a/etc/docker/devnet-env
+++ b/etc/docker/devnet-env
@@ -200,6 +200,7 @@ L2_BASE_BERYL_BLOCK=21
 L2_BASE_COBALT_BLOCK=22
 # Optional: set to a non-negative block number to schedule Base Zenith in devnet.
 # Leave unset to avoid setting base.zenith during genesis generation.
+# L2_BASE_ZENITH_BLOCK=23
 
 # Metering Resource Limits
 # Whole-block budgets for gas and DA.

--- a/etc/docker/devnet-env
+++ b/etc/docker/devnet-env
@@ -198,6 +198,8 @@ L2_BASE_BERYL_BLOCK=21
 # Optional: set to a non-negative block number to schedule Base Cobalt in devnet.
 # Leave unset to avoid setting base.cobalt during genesis generation.
 L2_BASE_COBALT_BLOCK=22
+# Optional: set to a non-negative block number to schedule Base Zenith in devnet.
+# Leave unset to avoid setting base.zenith during genesis generation.
 
 # Metering Resource Limits
 # Whole-block budgets for gas and DA.

--- a/etc/docker/docker-compose.ha.yml
+++ b/etc/docker/docker-compose.ha.yml
@@ -104,9 +104,9 @@ services:
       - NODE_HEALTHCHECK_CL_RPC_PORT=${L2_SEQ1_CL_RPC_PORT}
       - OTEL_SERVICE_NAME=base-sequencer-1
     command:
-      - sequencer
       - --chain
       - dev
+      - sequencer
       - --execution-chain=/genesis/l2/genesis.json
       - --datadir=/data
       - --telemetry.sampling-ratio=1
@@ -213,9 +213,9 @@ services:
       - NODE_HEALTHCHECK_CL_RPC_PORT=${L2_SEQ2_CL_RPC_PORT}
       - OTEL_SERVICE_NAME=base-sequencer-2
     command:
-      - sequencer
       - --chain
       - dev
+      - sequencer
       - --execution-chain=/genesis/l2/genesis.json
       - --datadir=/data
       - --telemetry.sampling-ratio=1

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -169,6 +169,7 @@ services:
       - L2_BASE_AZUL_BLOCK=${L2_BASE_AZUL_BLOCK-}
       - L2_BASE_BERYL_BLOCK=${L2_BASE_BERYL_BLOCK-}
       - L2_BASE_COBALT_BLOCK=${L2_BASE_COBALT_BLOCK-}
+      - L2_BASE_ZENITH_BLOCK=${L2_BASE_ZENITH_BLOCK-}
       - OUTPUT_DIR=/devnet/l2/configs
       - L2_DATA_DIR=/data
       - DEPLOYER_ADDR=${DEPLOYER_ADDR}
@@ -209,9 +210,9 @@ services:
       - BASE_CHAIN_L2_CHAIN_ID=${L2_CHAIN_ID}
     entrypoint: /app/base
     command:
-      - bootnode
       - --chain
       - dev
+      - bootnode
       - --l2-config-file
       - /genesis/l2/rollup.json
       - --v4-addr=0.0.0.0:${L2_EL_BOOTNODE_P2P_PORT}
@@ -281,9 +282,9 @@ services:
       - BUILDER_TRANSACTION_EVENTS_NETWORK=base-devnet
     entrypoint: /app/base-entrypoint.sh
     command:
-      - sequencer
       - --chain
       - dev
+      - sequencer
       - --execution-chain=/genesis/l2/genesis.json
       - --datadir=/data
       - --telemetry.sampling-ratio=1
@@ -438,9 +439,9 @@ services:
       - BASE_TRANSACTION_EVENTS_NODE_ROLE=devnet-client
     entrypoint: /app/base-entrypoint.sh
     command:
-      - rpc
       - --chain
       - dev
+      - rpc
       - --execution-chain=/genesis/l2/genesis.json
       - --datadir=/data
       - --http
@@ -554,9 +555,9 @@ services:
       - OTEL_SERVICE_NAME=base-rpc
     entrypoint: /app/base-entrypoint.sh
     command:
-      - rpc
       - --chain
       - dev
+      - rpc
       - --execution-chain=/genesis/l2/genesis.json
       - --datadir=/data
       - --http

--- a/etc/scripts/devnet/setup-l2.sh
+++ b/etc/scripts/devnet/setup-l2.sh
@@ -11,6 +11,7 @@ L2_BASE_AZUL_BLOCK="${L2_BASE_AZUL_BLOCK:-}"
 L2_BASE_BERYL_BLOCK="${L2_BASE_BERYL_BLOCK:-}"
 L2_ISTHMUS_BLOCK="${L2_ISTHMUS_BLOCK:-}"
 L2_BASE_COBALT_BLOCK="${L2_BASE_COBALT_BLOCK:-}"
+L2_BASE_ZENITH_BLOCK="${L2_BASE_ZENITH_BLOCK:-}"
 L2_ACTIVATION_ADMIN_ADDR="${L2_ACTIVATION_ADMIN_ADDR:-$SEQUENCER_ADDR}"
 L2_EL_BOOTNODE_P2P_KEY="${L2_EL_BOOTNODE_P2P_KEY:-1111111111111111111111111111111111111111111111111111111111111111}"
 L2_EL_BOOTNODE_ENODE_ID="${L2_EL_BOOTNODE_ENODE_ID:-4f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa385b6b1b8ead809ca67454d9683fcf2ba03456d6fe2c4abe2b07f0fbdbb2f1c1}"
@@ -38,6 +39,10 @@ if [ -n "$L2_BASE_COBALT_BLOCK" ] && ! [[ "$L2_BASE_COBALT_BLOCK" =~ ^[0-9]+$ ]]
   echo "ERROR: L2_BASE_COBALT_BLOCK must be a non-negative integer when set, got: $L2_BASE_COBALT_BLOCK"
   exit 1
 fi
+if [ -n "$L2_BASE_ZENITH_BLOCK" ] && ! [[ "$L2_BASE_ZENITH_BLOCK" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: L2_BASE_ZENITH_BLOCK must be a non-negative integer when set, got: $L2_BASE_ZENITH_BLOCK"
+  exit 1
+fi
 if [ -n "$L2_ISTHMUS_BLOCK" ] && ! [[ "$L2_ISTHMUS_BLOCK" =~ ^[0-9]+$ ]]; then
   echo "ERROR: L2_ISTHMUS_BLOCK must be a non-negative integer when set, got: $L2_ISTHMUS_BLOCK"
   exit 1
@@ -62,6 +67,11 @@ if [ -n "$L2_BASE_COBALT_BLOCK" ]; then
   echo "Base Cobalt activation block: $L2_BASE_COBALT_BLOCK"
 else
   echo "Base Cobalt activation block: <unset>"
+fi
+if [ -n "$L2_BASE_ZENITH_BLOCK" ]; then
+  echo "Base Zenith activation block: $L2_BASE_ZENITH_BLOCK"
+else
+  echo "Base Zenith activation block: <unset>"
 fi
 if [ -n "$L2_ISTHMUS_BLOCK" ]; then
   echo "Isthmus activation block: $L2_ISTHMUS_BLOCK"
@@ -324,6 +334,41 @@ else
   echo "L2 genesis time: $L2_GENESIS_TIME"
   echo "L2 block time: $L2_BLOCK_TIME"
   echo "Base Cobalt activation block is unset; leaving base.cobalt unchanged"
+fi
+
+if [ -n "$L2_BASE_ZENITH_BLOCK" ]; then
+  L2_BASE_ZENITH_TIME=$((L2_GENESIS_TIME + L2_BLOCK_TIME * L2_BASE_ZENITH_BLOCK))
+
+  echo ""
+  echo "=== Configuring Base Zenith Activation ==="
+  echo "L2 genesis time: $L2_GENESIS_TIME"
+  echo "L2 block time: $L2_BLOCK_TIME"
+  echo "Base Zenith activation block: $L2_BASE_ZENITH_BLOCK"
+  echo "Derived Base Zenith activation timestamp: $L2_BASE_ZENITH_TIME"
+
+  TMP_ROLLUP=$(mktemp)
+  jq \
+    --argjson zenith_time "$L2_BASE_ZENITH_TIME" \
+    '.base = ((.base // {}) + {zenith: $zenith_time})' \
+    "$OUTPUT_DIR/rollup.json" \
+    >"$TMP_ROLLUP"
+  replace_output_file "$TMP_ROLLUP" "$OUTPUT_DIR/rollup.json"
+
+  TMP_GENESIS=$(mktemp)
+  jq \
+    --argjson zenith_time "$L2_BASE_ZENITH_TIME" \
+    '.config.base = ((.config.base // {}) + {zenith: $zenith_time})' \
+    "$OUTPUT_DIR/genesis.json" \
+    >"$TMP_GENESIS"
+  replace_output_file "$TMP_GENESIS" "$OUTPUT_DIR/genesis.json"
+
+  echo "Patched Base Zenith activation into rollup and genesis configs"
+else
+  echo ""
+  echo "=== Configuring Base Zenith Activation ==="
+  echo "L2 genesis time: $L2_GENESIS_TIME"
+  echo "L2 block time: $L2_BLOCK_TIME"
+  echo "Base Zenith activation block is unset; leaving base.zenith unchanged"
 fi
 
 echo "Writing rollup-conductor.json (base fields stripped for op-conductor compatibility)..."

--- a/etc/systems/src/setup/container.rs
+++ b/etc/systems/src/setup/container.rs
@@ -230,6 +230,7 @@ pub struct SetupContainer {
     base_azul_activation_block: Option<u64>,
     base_beryl_activation_block: Option<u64>,
     base_cobalt_activation_block: Option<u64>,
+    base_zenith_activation_block: Option<u64>,
     network_name: Option<String>,
 }
 
@@ -245,6 +246,7 @@ impl SetupContainer {
             base_azul_activation_block: None,
             base_beryl_activation_block: None,
             base_cobalt_activation_block: None,
+            base_zenith_activation_block: None,
             network_name: None,
         }
     }
@@ -288,6 +290,12 @@ impl SetupContainer {
     /// Sets the L2 block number at which Base Cobalt activates.
     pub const fn with_base_cobalt_activation_block(mut self, block: u64) -> Self {
         self.base_cobalt_activation_block = Some(block);
+        self
+    }
+
+    /// Sets the L2 block number at which Base Zenith activates.
+    pub const fn with_base_zenith_activation_block(mut self, block: u64) -> Self {
+        self.base_zenith_activation_block = Some(block);
         self
     }
 
@@ -390,6 +398,10 @@ impl SetupContainer {
 
         if let Some(block) = self.base_cobalt_activation_block {
             container = container.with_env_var("L2_BASE_COBALT_BLOCK", block.to_string());
+        }
+
+        if let Some(block) = self.base_zenith_activation_block {
+            container = container.with_env_var("L2_BASE_ZENITH_BLOCK", block.to_string());
         }
 
         let _container = container

--- a/etc/systems/src/smoke.rs
+++ b/etc/systems/src/smoke.rs
@@ -260,6 +260,7 @@ pub struct SystemTestStackBuilder {
     base_azul_activation_block: Option<u64>,
     base_beryl_activation_block: Option<u64>,
     base_cobalt_activation_block: Option<u64>,
+    base_zenith_activation_block: Option<u64>,
     output_dir: Option<PathBuf>,
     stable_config: Option<StableSystemTestConfig>,
     tx_forwarding_config: Option<TxForwardingConfig>,
@@ -315,6 +316,12 @@ impl SystemTestStackBuilder {
     /// Sets the L2 block number at which Base Cobalt activates.
     pub const fn with_base_cobalt_activation_block(mut self, block: u64) -> Self {
         self.base_cobalt_activation_block = Some(block);
+        self
+    }
+
+    /// Sets the L2 block number at which Base Zenith activates.
+    pub const fn with_base_zenith_activation_block(mut self, block: u64) -> Self {
+        self.base_zenith_activation_block = Some(block);
         self
     }
 
@@ -417,6 +424,10 @@ impl SystemTestStackBuilder {
 
         if let Some(block) = self.base_cobalt_activation_block {
             setup = setup.with_base_cobalt_activation_block(block);
+        }
+
+        if let Some(block) = self.base_zenith_activation_block {
+            setup = setup.with_base_zenith_activation_block(block);
         }
 
         if let Some(ref config) = self.stable_config {

--- a/etc/systems/tests/smoke.rs
+++ b/etc/systems/tests/smoke.rs
@@ -24,6 +24,30 @@ const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(60);
 static SMOKE_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 #[tokio::test]
+async fn zenith_activation_matches_el_and_cl_configs() -> Result<()> {
+    const ZENITH_ACTIVATION_BLOCK: u64 = 23;
+
+    let _guard = SMOKE_TEST_LOCK.lock().await;
+    let system = SystemTestStackBuilder::new()
+        .with_l1_chain_id(L1_CHAIN_ID)
+        .with_l2_chain_id(L2_CHAIN_ID)
+        .with_base_zenith_activation_block(ZENITH_ACTIVATION_BLOCK)
+        .build()
+        .await?;
+
+    let genesis: serde_json::Value = serde_json::from_str(&system.l2_deployment().read_genesis()?)?;
+    let rollup: serde_json::Value =
+        serde_json::from_str(&system.l2_deployment().read_rollup_config()?)?;
+    let expected = rollup["genesis"]["l2_time"].as_u64().unwrap()
+        + rollup["block_time"].as_u64().unwrap() * ZENITH_ACTIVATION_BLOCK;
+
+    assert_eq!(rollup["base"]["zenith"].as_u64(), Some(expected));
+    assert_eq!(genesis["config"]["base"]["zenith"].as_u64(), Some(expected));
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn smoke_test_system_block_production_and_transactions() -> Result<()> {
     let _guard = SMOKE_TEST_LOCK.lock().await;
     let system = SystemTestStackBuilder::new()


### PR DESCRIPTION
Adds an opt-in `zenith` devnet mode that activates Zenith at L2 block 23, deriving one timestamp for both EL genesis and CL rollup configuration. Normal startup leaves Zenith disabled; `just devnet up zenith` and `just devnet up-single zenith` exercise the fork-controlled 200ms cadence introduced by #3981.