### PR TITLE
ci(fork-tests): add Cobalt row (base-anvil#58 + base-std#173)

### DIFF
--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -30,18 +30,11 @@ jobs:
         include:
           # Refs may be release tags or commit SHAs. The resolved commit SHA is
           # recorded in the result artifact and PR comment.
-          #
-          # Each row must pair a base-anvil that installs that fork's precompile
-          # set with a base-std reference that encodes the same expectations.
-          # base-anvil selects the fork per branch, not via a runtime flag:
-          # release/v1.1.x is Beryl (V1), base-anvil-fork main is Cobalt (V2).
           - fork: Beryl
             key: beryl
             base_anvil_ref: 6d744e03224977edd42a36699ba9ff42be25e8cb
             base_std_ref: v1.0.0
-          # base-std has no Cobalt tag yet; this pins base-std#173 (ERC-8056 /
-          # AssetV2), the head of the Cobalt reference. Repoint at the release
-          # tag once #173 merges and is tagged.
+          # Point to the base-std release tag once the Cobalt hardfork is ready.
           - fork: Cobalt
             key: cobalt
             base_anvil_ref: ae7557c4f8602caa1da0be33143bb2504c85b0c8

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -38,7 +38,7 @@ jobs:
           - fork: Cobalt
             key: cobalt
             base_anvil_ref: ae7557c4f8602caa1da0be33143bb2504c85b0c8
-            base_std_ref: 6908650c9c96c0f56254a6cf4c5ddc81c849f4bd
+            base_std_ref: b0a4f048684c4cd279025bf2ba3aa76c45569fa4
     env:
       FORK_NAME: ${{ matrix.fork }}
       FORK_KEY: ${{ matrix.key }}

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -30,10 +30,22 @@ jobs:
         include:
           # Refs may be release tags or commit SHAs. The resolved commit SHA is
           # recorded in the result artifact and PR comment.
+          #
+          # Each row must pair a base-anvil that installs that fork's precompile
+          # set with a base-std reference that encodes the same expectations.
+          # base-anvil selects the fork per branch, not via a runtime flag:
+          # release/v1.1.x is Beryl (V1), base-anvil-fork main is Cobalt (V2).
           - fork: Beryl
             key: beryl
             base_anvil_ref: 6d744e03224977edd42a36699ba9ff42be25e8cb
             base_std_ref: v1.0.0
+          # base-std has no Cobalt tag yet; this pins base-std#173 (ERC-8056 /
+          # AssetV2), the head of the Cobalt reference. Repoint at the release
+          # tag once #173 merges and is tagged.
+          - fork: Cobalt
+            key: cobalt
+            base_anvil_ref: ae7557c4f8602caa1da0be33143bb2504c85b0c8
+            base_std_ref: 6908650c9c96c0f56254a6cf4c5ddc81c849f4bd
     env:
       FORK_NAME: ${{ matrix.fork }}
       FORK_KEY: ${{ matrix.key }}


### PR DESCRIPTION
## Summary

The `Base Std Interface Tests` matrix only covered **Beryl**. This adds the **Cobalt** row that PR #4173 called out as the follow-up:

> A **Cobalt** row — base-anvil-fork main (`ae7557c`) + the base-std ERC-8056/AssetV2 reference — will be added once base-std #173 merges and is tagged.

```yaml
- fork: Cobalt
  key: cobalt
  base_anvil_ref: ae7557c4f8602caa1da0be33143bb2504c85b0c8
  base_std_ref: b0a4f048684c4cd279025bf2ba3aa76c45569fa4
```

**`base_anvil_ref`** — `ae7557c4`, head of base-anvil-fork (base-anvil's default branch). base-anvil #57 retargeted `inject_precompiles` from `BaseUpgrade::Beryl` to `BaseUpgrade::Cobalt` (state-backed activation admin, plus the TxContext / NonceManager singletons); #58 fixed activation-install compatibility on top. base-anvil selects the fork **per branch**, not via a runtime flag — so this is the Cobalt snapshot, and `release/v1.1.x` (pinned by the Beryl row) stays V1.

**`base_std_ref`** — `b0a4f048`, the merge commit of base-std #173 (ERC-8056 scaled multiplier / AssetV2) and current head of base-std `main`. base-std still has **no Cobalt tag** — `v1.0.0` is Beryl and remains the only tag in the repo — so this pins the commit. The inline comment marks it for repointing at the release tag once Cobalt is tagged.

## Why not pin the existing tag

Pairing the Cobalt base-anvil with `v1.0.0` runs V1 expectations against the V2 precompile set. That is exactly the mismatch #4173 fixed from the other direction, and it fails on the *intended* Cobalt changes rather than on a regression:

- `InvalidMultiplier()` — V2 bounds the multiplier to `uint128` (ERC-8056 packing) where the V1 tests fuzz to `uint256`.
- `log != expected log` — V2 emits `UIMultiplierUpdated`, not V1's `MultiplierUpdated`.

## Test plan

- [x] Workflow YAML parses; both rows present with unique `key`s (distinct artifact names and `results/*.tsv` files for the aggregate step).
- [x] Both pins verified fetchable via the workflow's exact clone/fetch/checkout sequence (`--filter=blob:none --no-checkout` + `fetch --depth 1 origin <sha>` + `checkout --detach FETCH_HEAD`).
- [ ] This PR's own `Base Std Interface Tests (Cobalt)` run goes green. Per #4173 this pairing cross-validated green locally at **646 passed / 0 failed / 13 skipped** in LIVE PRECOMPILE mode; CI is the confirmation.

Generated with Claude Code