### PR TITLE
feat(BOP-441): add seize plumbing (scope, role, event, storage, guard)

### DIFF
--- a/crates/common/precompile-macros/src/accounting.rs
+++ b/crates/common/precompile-macros/src/accounting.rs
@@ -251,6 +251,7 @@ fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
                         self.b20.transfer_executor_policy_id()
                     }
                     crate::B20PolicyType::MintReceiver => self.b20.mint_receiver_policy_id(),
+                    crate::B20PolicyType::Seizable => self.b20.seizable_policy_id(),
                 }
             }
 
@@ -271,6 +272,9 @@ fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
                     }
                     crate::B20PolicyType::MintReceiver => {
                         self.b20.set_mint_receiver_policy_id(policy_id)
+                    }
+                    crate::B20PolicyType::Seizable => {
+                        self.b20.set_seizable_policy_id(policy_id)
                     }
                 }
             }

--- a/crates/common/precompile-macros/src/accounting.rs
+++ b/crates/common/precompile-macros/src/accounting.rs
@@ -251,7 +251,7 @@ fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
                         self.b20.transfer_executor_policy_id()
                     }
                     crate::B20PolicyType::MintReceiver => self.b20.mint_receiver_policy_id(),
-                    crate::B20PolicyType::Seizable => self.b20.seizable_policy_id(),
+                    crate::B20PolicyType::SeizableAccount => self.b20.seizable_policy_id(),
                 }
             }
 
@@ -273,7 +273,7 @@ fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
                     crate::B20PolicyType::MintReceiver => {
                         self.b20.set_mint_receiver_policy_id(policy_id)
                     }
-                    crate::B20PolicyType::Seizable => {
+                    crate::B20PolicyType::SeizableAccount => {
                         self.b20.set_seizable_policy_id(policy_id)
                     }
                 }

--- a/crates/common/precompiles/src/common/abi.rs
+++ b/crates/common/precompiles/src/common/abi.rs
@@ -47,6 +47,7 @@ sol! {
         event Approval(address indexed owner, address indexed spender, uint256 amount);
         event Memo(address indexed caller, bytes32 indexed memo);
         event BurnedBlocked(address indexed caller, address indexed from, uint256 amount);
+        event TransferredFromSeizable(address indexed caller, address indexed from, address indexed to, uint256 amount);
         event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);
         event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender);
         event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole);

--- a/crates/common/precompiles/src/common/core_storage.rs
+++ b/crates/common/precompiles/src/common/core_storage.rs
@@ -78,9 +78,9 @@ pub struct B20CoreStorage {
     #[accessor(name = nonce, keys(owner))]
     #[mutator(name = set_nonce, keys(owner), value = nonce)]
     pub nonces: Mapping<Address, U256>, // offset 13
-    /// Seizable-account policy ID, consulted by the seize operations. base-std keeps its mock-only
-    /// `initialized` flag trailing (offset 15), which this impl omits, so seize lands at offset 14
-    /// on both sides.
+    // The base-std mock keeps an `initialized` bootstrap flag as its last field; this impl checks
+    // factory-init via deployed marker bytecode instead, so it stores no such field.
+    /// Seizable-account policy ID, consulted by the seize operations.
     #[accessor]
     #[mutator]
     pub seizable_policy_id: u64, // slot 14, offset 0

--- a/crates/common/precompiles/src/common/core_storage.rs
+++ b/crates/common/precompiles/src/common/core_storage.rs
@@ -78,15 +78,14 @@ pub struct B20CoreStorage {
     #[accessor(name = nonce, keys(owner))]
     #[mutator(name = set_nonce, keys(owner), value = nonce)]
     pub nonces: Mapping<Address, U256>, // offset 13
-    /// Unused full-slot hole where base-std pins its `initialized` flag; kept empty so
-    /// `seizable_policy_id` lands at offset 15 as in base-std.
-    pub initialized_hole: FixedBytes<32>, // offset 14 (unused; base-std `initialized`)
-    /// Seizable-account policy ID, consulted by the seize operations.
+    /// Seizable-account policy ID, consulted by the seize operations. base-std keeps its mock-only
+    /// `initialized` flag trailing (offset 15), which this impl omits, so seize lands at offset 14
+    /// on both sides.
     #[accessor]
     #[mutator]
-    pub seizable_policy_id: u64, // slot 15, offset 0
-    /// Reserved padding to close slot 15.
-    pub seize_reserved: FixedBytes<24>, // slot 15, offset 8
+    pub seizable_policy_id: u64, // slot 14, offset 0
+    /// Reserved padding to close slot 14.
+    pub seize_reserved: FixedBytes<24>, // slot 14, offset 8
 }
 
 #[cfg(test)]
@@ -130,10 +129,9 @@ mod tests {
         assert_eq!(__packing_b20_core_storage::PAUSED_LOC.offset_slots, 11);
         assert_eq!(__packing_b20_core_storage::SUPPLY_CAP_LOC.offset_slots, 12);
         assert_eq!(__packing_b20_core_storage::NONCES_LOC.offset_slots, 13);
-        assert_eq!(__packing_b20_core_storage::INITIALIZED_HOLE_LOC.offset_slots, 14);
-        assert_eq!(__packing_b20_core_storage::SEIZABLE_POLICY_ID_LOC.offset_slots, 15);
+        assert_eq!(__packing_b20_core_storage::SEIZABLE_POLICY_ID_LOC.offset_slots, 14);
         assert_eq!(__packing_b20_core_storage::SEIZABLE_POLICY_ID_LOC.offset_bytes, 0);
-        assert_eq!(__packing_b20_core_storage::SEIZE_RESERVED_LOC.offset_slots, 15);
+        assert_eq!(__packing_b20_core_storage::SEIZE_RESERVED_LOC.offset_slots, 14);
         assert_eq!(__packing_b20_core_storage::SEIZE_RESERVED_LOC.offset_bytes, 8);
     }
 }

--- a/crates/common/precompiles/src/common/core_storage.rs
+++ b/crates/common/precompiles/src/common/core_storage.rs
@@ -78,6 +78,21 @@ pub struct B20CoreStorage {
     #[accessor(name = nonce, keys(owner))]
     #[mutator(name = set_nonce, keys(owner), value = nonce)]
     pub nonces: Mapping<Address, U256>, // offset 13
+    /// Reserved full-slot hole mirroring base-std's `initialized` bootstrap flag.
+    ///
+    /// base-std pins `bool initialized` to its own slot at offset 14. This Rust impl distinguishes
+    /// the factory-init window through a different mechanism and stores no such flag, but must leave
+    /// this slot empty so that `seizable_policy_id` lands at the same offset (15) base-std uses.
+    /// Do not collapse this hole, or the mock and precompile storage layouts diverge and fork tests
+    /// break.
+    pub initialized_hole: FixedBytes<32>, // offset 14 (unused; base-std `initialized`)
+    /// Seizable-account policy ID, consulted by the seize operations. Appended after the
+    /// `initialized` hole so no pre-existing field offset shifts on already-deployed tokens.
+    #[accessor]
+    #[mutator]
+    pub seizable_policy_id: u64, // slot 15, offset 0
+    /// Reserved padding to fill the remainder of slot 15.
+    pub seize_reserved: FixedBytes<24>, // slot 15, offset 8 (fills remaining 24 bytes)
 }
 
 #[cfg(test)]
@@ -121,5 +136,12 @@ mod tests {
         assert_eq!(__packing_b20_core_storage::PAUSED_LOC.offset_slots, 11);
         assert_eq!(__packing_b20_core_storage::SUPPLY_CAP_LOC.offset_slots, 12);
         assert_eq!(__packing_b20_core_storage::NONCES_LOC.offset_slots, 13);
+        // Offset 14 is the unused `initialized` hole (base-std pins its bootstrap flag here); the
+        // seizable policy id is appended after it at offset 15, byte 0, mirroring base-std.
+        assert_eq!(__packing_b20_core_storage::INITIALIZED_HOLE_LOC.offset_slots, 14);
+        assert_eq!(__packing_b20_core_storage::SEIZABLE_POLICY_ID_LOC.offset_slots, 15);
+        assert_eq!(__packing_b20_core_storage::SEIZABLE_POLICY_ID_LOC.offset_bytes, 0);
+        assert_eq!(__packing_b20_core_storage::SEIZE_RESERVED_LOC.offset_slots, 15);
+        assert_eq!(__packing_b20_core_storage::SEIZE_RESERVED_LOC.offset_bytes, 8);
     }
 }

--- a/crates/common/precompiles/src/common/core_storage.rs
+++ b/crates/common/precompiles/src/common/core_storage.rs
@@ -78,21 +78,15 @@ pub struct B20CoreStorage {
     #[accessor(name = nonce, keys(owner))]
     #[mutator(name = set_nonce, keys(owner), value = nonce)]
     pub nonces: Mapping<Address, U256>, // offset 13
-    /// Reserved full-slot hole mirroring base-std's `initialized` bootstrap flag.
-    ///
-    /// base-std pins `bool initialized` to its own slot at offset 14. This Rust impl distinguishes
-    /// the factory-init window through a different mechanism and stores no such flag, but must leave
-    /// this slot empty so that `seizable_policy_id` lands at the same offset (15) base-std uses.
-    /// Do not collapse this hole, or the mock and precompile storage layouts diverge and fork tests
-    /// break.
+    /// Unused full-slot hole where base-std pins its `initialized` flag; kept empty so
+    /// `seizable_policy_id` lands at offset 15 as in base-std.
     pub initialized_hole: FixedBytes<32>, // offset 14 (unused; base-std `initialized`)
-    /// Seizable-account policy ID, consulted by the seize operations. Appended after the
-    /// `initialized` hole so no pre-existing field offset shifts on already-deployed tokens.
+    /// Seizable-account policy ID, consulted by the seize operations.
     #[accessor]
     #[mutator]
     pub seizable_policy_id: u64, // slot 15, offset 0
-    /// Reserved padding to fill the remainder of slot 15.
-    pub seize_reserved: FixedBytes<24>, // slot 15, offset 8 (fills remaining 24 bytes)
+    /// Reserved padding to close slot 15.
+    pub seize_reserved: FixedBytes<24>, // slot 15, offset 8
 }
 
 #[cfg(test)]
@@ -136,8 +130,6 @@ mod tests {
         assert_eq!(__packing_b20_core_storage::PAUSED_LOC.offset_slots, 11);
         assert_eq!(__packing_b20_core_storage::SUPPLY_CAP_LOC.offset_slots, 12);
         assert_eq!(__packing_b20_core_storage::NONCES_LOC.offset_slots, 13);
-        // Offset 14 is the unused `initialized` hole (base-std pins its bootstrap flag here); the
-        // seizable policy id is appended after it at offset 15, byte 0, mirroring base-std.
         assert_eq!(__packing_b20_core_storage::INITIALIZED_HOLE_LOC.offset_slots, 14);
         assert_eq!(__packing_b20_core_storage::SEIZABLE_POLICY_ID_LOC.offset_slots, 15);
         assert_eq!(__packing_b20_core_storage::SEIZABLE_POLICY_ID_LOC.offset_bytes, 0);

--- a/crates/common/precompiles/src/common/ops/guards.rs
+++ b/crates/common/precompiles/src/common/ops/guards.rs
@@ -91,7 +91,7 @@ impl B20Guards {
     /// not authorize it. Used by the seize operation class. Enforced unconditionally, including in
     /// the factory bootstrap window.
     pub fn ensure_seizable<T: Token + ?Sized>(token: &T, account: Address) -> Result<()> {
-        let policy_scope = B20PolicyType::Seizable.id();
+        let policy_scope = B20PolicyType::SeizableAccount.id();
         let policy_id = token.accounting().policy_id(policy_scope)?;
         if token.policy().is_authorized(token.policy_storage(), policy_id, account)? {
             Err(BasePrecompileError::revert(IB20::AccountNotBlocked { account }))
@@ -125,7 +125,7 @@ mod tests {
 
     fn token_with_seizable_policy(account: Address) -> TestToken {
         let mut accounting = InMemoryTokenAccounting::new(Address::repeat_byte(0x20));
-        accounting.policy_ids.insert(B20PolicyType::Seizable.id(), EXTERNAL_POLICY_ID);
+        accounting.policy_ids.insert(B20PolicyType::SeizableAccount.id(), EXTERNAL_POLICY_ID);
 
         let mut policy = FakePolicyAccounting::new();
         policy.allow(EXTERNAL_POLICY_ID, account);
@@ -183,12 +183,21 @@ mod tests {
     fn test_ensure_seizable_is_independent_of_transfer_sender_policy() {
         // A token with the transfer-sender policy set must NOT make an account seizable: the
         // seizable scope is unset (ALWAYS_ALLOW), so every account is authorized => not seizable.
-        let account = Address::repeat_byte(0xaa);
-        let token = token_with_transfer_sender_policy(account);
+        let allowed = Address::repeat_byte(0xaa);
+        let denied = Address::repeat_byte(0xbb);
+        let token = token_with_transfer_sender_policy(allowed);
 
+        // `allowed` is authorized by transfer-sender AND by unset seizable (ALWAYS_ALLOW).
         assert_eq!(
-            B20Guards::ensure_seizable(&token, account).unwrap_err(),
-            BasePrecompileError::revert(IB20::AccountNotBlocked { account })
+            B20Guards::ensure_seizable(&token, allowed).unwrap_err(),
+            BasePrecompileError::revert(IB20::AccountNotBlocked { account: allowed })
+        );
+
+        // `denied` is NOT authorized by transfer-sender, but still not seizable because the
+        // seizable policy is unset (ALWAYS_ALLOW) — proving the two scopes are independent.
+        assert_eq!(
+            B20Guards::ensure_seizable(&token, denied).unwrap_err(),
+            BasePrecompileError::revert(IB20::AccountNotBlocked { account: denied })
         );
     }
 

--- a/crates/common/precompiles/src/common/ops/guards.rs
+++ b/crates/common/precompiles/src/common/ops/guards.rs
@@ -83,6 +83,22 @@ impl B20Guards {
             Ok(())
         }
     }
+
+    /// Ensures `account` is seizable, i.e. blocked by the current seizable-account policy.
+    ///
+    /// Mirrors [`Self::ensure_blocked`] but consults `SEIZABLE_ACCOUNT_POLICY` instead of the
+    /// transfer-sender policy: an account is seizable only when the configured registry policy does
+    /// not authorize it. Used by the seize operation class. Enforced unconditionally, including in
+    /// the factory bootstrap window.
+    pub fn ensure_seizable<T: Token + ?Sized>(token: &T, account: Address) -> Result<()> {
+        let policy_scope = B20PolicyType::Seizable.id();
+        let policy_id = token.accounting().policy_id(policy_scope)?;
+        if token.policy().is_authorized(token.policy_storage(), policy_id, account)? {
+            Err(BasePrecompileError::revert(IB20::AccountNotBlocked { account }))
+        } else {
+            Ok(())
+        }
+    }
 }
 
 #[cfg(test)]
@@ -100,6 +116,16 @@ mod tests {
     fn token_with_transfer_sender_policy(account: Address) -> TestToken {
         let mut accounting = InMemoryTokenAccounting::new(Address::repeat_byte(0x20));
         accounting.policy_ids.insert(B20PolicyType::TransferSender.id(), EXTERNAL_POLICY_ID);
+
+        let mut policy = FakePolicyAccounting::new();
+        policy.allow(EXTERNAL_POLICY_ID, account);
+
+        TestToken::with_storage_and_policy(accounting, policy)
+    }
+
+    fn token_with_seizable_policy(account: Address) -> TestToken {
+        let mut accounting = InMemoryTokenAccounting::new(Address::repeat_byte(0x20));
+        accounting.policy_ids.insert(B20PolicyType::Seizable.id(), EXTERNAL_POLICY_ID);
 
         let mut policy = FakePolicyAccounting::new();
         policy.allow(EXTERNAL_POLICY_ID, account);
@@ -136,6 +162,34 @@ mod tests {
             BasePrecompileError::revert(IB20::AccountNotBlocked { account: allowed })
         );
         B20Guards::ensure_blocked(&token, denied).unwrap();
+    }
+
+    #[test]
+    fn test_ensure_seizable_uses_external_policy_authorization() {
+        let allowed = Address::repeat_byte(0xaa);
+        let denied = Address::repeat_byte(0xbb);
+        let token = token_with_seizable_policy(allowed);
+
+        // Authorized (allowed) under the seizable policy => not seizable => reverts.
+        assert_eq!(
+            B20Guards::ensure_seizable(&token, allowed).unwrap_err(),
+            BasePrecompileError::revert(IB20::AccountNotBlocked { account: allowed })
+        );
+        // Not authorized (denied) => seizable => ok.
+        B20Guards::ensure_seizable(&token, denied).unwrap();
+    }
+
+    #[test]
+    fn test_ensure_seizable_is_independent_of_transfer_sender_policy() {
+        // A token with the transfer-sender policy set must NOT make an account seizable: the
+        // seizable scope is unset (ALWAYS_ALLOW), so every account is authorized => not seizable.
+        let account = Address::repeat_byte(0xaa);
+        let token = token_with_transfer_sender_policy(account);
+
+        assert_eq!(
+            B20Guards::ensure_seizable(&token, account).unwrap_err(),
+            BasePrecompileError::revert(IB20::AccountNotBlocked { account })
+        );
     }
 
     #[test]

--- a/crates/common/precompiles/src/common/ops/roles.rs
+++ b/crates/common/precompiles/src/common/ops/roles.rs
@@ -10,6 +10,8 @@ const MINT_ROLE: B256 = b256!("154c00819833dac601ee5ddded6fda79d9d8b506b911b3dbd
 const BURN_ROLE: B256 = b256!("e97b137254058bd94f28d2f3eb79e2d34074ffb488d042e3bc958e0a57d2fa22");
 const BURN_BLOCKED_ROLE: B256 =
     b256!("7408fdc0d31c7bcb349eab611f5d1168acd4303574993f8cdc98b1cd18c41cae");
+const TRANSFER_FROM_SEIZABLE_ROLE: B256 =
+    b256!("466d0fa97b99b3315998c229880e8a3a6aa5f5586b46f762a35e210facb4ea63");
 const PAUSE_ROLE: B256 = b256!("139c2898040ef16910dc9f44dc697df79363da767d8bc92f2e310312b816e46d");
 const UNPAUSE_ROLE: B256 =
     b256!("265b220c5a8891efdd9e1b1b7fa72f257bd5169f8d87e319cf3dad6ff52b94ae");
@@ -27,6 +29,9 @@ pub enum B20TokenRole {
     Burn,
     /// Role required for `burnBlocked`; permits burning from blocked accounts without `BURN_ROLE`.
     BurnBlocked,
+    /// Role required for `transferFromSeizableWithMemo`; permits reassigning a blocked account's
+    /// balance without `TRANSFER_SENDER_POLICY` authorization.
+    TransferFromSeizable,
     /// Role required for `pause`.
     Pause,
     /// Role required for `unpause`.
@@ -43,6 +48,7 @@ impl B20TokenRole {
             Self::Mint => MINT_ROLE,
             Self::Burn => BURN_ROLE,
             Self::BurnBlocked => BURN_BLOCKED_ROLE,
+            Self::TransferFromSeizable => TRANSFER_FROM_SEIZABLE_ROLE,
             Self::Pause => PAUSE_ROLE,
             Self::Unpause => UNPAUSE_ROLE,
             Self::Metadata => METADATA_ROLE,
@@ -73,6 +79,12 @@ pub trait RoleManaged: Token {
     /// Role required for `burnBlocked`; permits burning from blocked accounts without `BURN_ROLE`.
     fn burn_blocked_role() -> B256 {
         B20TokenRole::BurnBlocked.id()
+    }
+
+    /// Role required for `transferFromSeizableWithMemo`; permits reassigning a blocked account's
+    /// balance without `TRANSFER_SENDER_POLICY` authorization.
+    fn transfer_from_seizable_role() -> B256 {
+        B20TokenRole::TransferFromSeizable.id()
     }
 
     /// Role required for `pause`.
@@ -264,7 +276,7 @@ pub trait RoleManaged: Token {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{Address, B256, U256};
+    use alloy_primitives::{Address, B256, U256, keccak256};
     use alloy_sol_types::SolEvent;
     use base_precompile_storage::BasePrecompileError;
 
@@ -296,6 +308,23 @@ mod tests {
     #[test]
     fn default_admin_role_matches_access_control_zero() {
         assert_eq!(B20TokenRole::DefaultAdmin.id(), B256::ZERO);
+    }
+
+    /// Cross-impl parity: keccak-derived role ids must equal `keccak256` of the exact strings
+    /// base-std uses, so the two implementations cannot silently diverge. `DefaultAdmin` is the
+    /// `AccessControl` zero sentinel, not a keccak, so it is excluded.
+    #[test]
+    fn role_ids_match_base_std_keccak() {
+        assert_eq!(B20TokenRole::Mint.id(), keccak256("MINT_ROLE"));
+        assert_eq!(B20TokenRole::Burn.id(), keccak256("BURN_ROLE"));
+        assert_eq!(B20TokenRole::BurnBlocked.id(), keccak256("BURN_BLOCKED_ROLE"));
+        assert_eq!(
+            B20TokenRole::TransferFromSeizable.id(),
+            keccak256("TRANSFER_FROM_SEIZABLE_ROLE")
+        );
+        assert_eq!(B20TokenRole::Pause.id(), keccak256("PAUSE_ROLE"));
+        assert_eq!(B20TokenRole::Unpause.id(), keccak256("UNPAUSE_ROLE"));
+        assert_eq!(B20TokenRole::Metadata.id(), keccak256("METADATA_ROLE"));
     }
 
     #[test]

--- a/crates/common/precompiles/src/common/policy_type.rs
+++ b/crates/common/precompiles/src/common/policy_type.rs
@@ -10,6 +10,8 @@ const TRANSFER_EXECUTOR_POLICY: B256 =
     b256!("10be5173aff2a44e748bd9acd8b19fe34689581398a9db7ba2fb671e786ff7d8");
 const MINT_RECEIVER_POLICY: B256 =
     b256!("a0d5ae037e66a09119acf080a1d807abb9b6d03b6b9130eb19f7c1e6bdb8ffc8");
+const SEIZABLE_ACCOUNT_POLICY: B256 =
+    b256!("3efcaab33335f8757bc9054f42ac0ae92950f9727a52ff4db8681fc9521c9e25");
 
 /// Built-in B-20 policy slots.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -22,6 +24,9 @@ pub enum B20PolicyType {
     TransferExecutor,
     /// Policy slot checked against mint receivers.
     MintReceiver,
+    /// Policy slot consulted against `from` by the seize operations. A `from` is seizable only when
+    /// it is NOT authorized by this policy (mirroring the `burnBlocked` "blocked" semantics).
+    Seizable,
 }
 
 impl B20PolicyType {
@@ -35,6 +40,8 @@ impl B20PolicyType {
             Some(Self::TransferExecutor)
         } else if id == MINT_RECEIVER_POLICY {
             Some(Self::MintReceiver)
+        } else if id == SEIZABLE_ACCOUNT_POLICY {
+            Some(Self::Seizable)
         } else {
             None
         }
@@ -47,6 +54,34 @@ impl B20PolicyType {
             Self::TransferReceiver => TRANSFER_RECEIVER_POLICY,
             Self::TransferExecutor => TRANSFER_EXECUTOR_POLICY,
             Self::MintReceiver => MINT_RECEIVER_POLICY,
+            Self::Seizable => SEIZABLE_ACCOUNT_POLICY,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::keccak256;
+
+    use crate::B20PolicyType;
+
+    /// Cross-impl parity: the built-in scope ids must equal `keccak256` of the exact strings
+    /// base-std uses, so the two implementations cannot silently diverge.
+    #[test]
+    fn policy_ids_match_base_std_keccak() {
+        assert_eq!(B20PolicyType::TransferSender.id(), keccak256("TRANSFER_SENDER_POLICY"));
+        assert_eq!(B20PolicyType::TransferReceiver.id(), keccak256("TRANSFER_RECEIVER_POLICY"));
+        assert_eq!(B20PolicyType::TransferExecutor.id(), keccak256("TRANSFER_EXECUTOR_POLICY"));
+        assert_eq!(B20PolicyType::MintReceiver.id(), keccak256("MINT_RECEIVER_POLICY"));
+        assert_eq!(B20PolicyType::Seizable.id(), keccak256("SEIZABLE_ACCOUNT_POLICY"));
+    }
+
+    /// `from_id` is the inverse of `id`, including for the seizable scope.
+    #[test]
+    fn seizable_scope_round_trips() {
+        assert_eq!(
+            B20PolicyType::from_id(B20PolicyType::Seizable.id()),
+            Some(B20PolicyType::Seizable)
+        );
     }
 }

--- a/crates/common/precompiles/src/common/policy_type.rs
+++ b/crates/common/precompiles/src/common/policy_type.rs
@@ -26,7 +26,7 @@ pub enum B20PolicyType {
     MintReceiver,
     /// Policy slot consulted against `from` by the seize operations. A `from` is seizable only when
     /// it is NOT authorized by this policy (mirroring the `burnBlocked` "blocked" semantics).
-    Seizable,
+    SeizableAccount,
 }
 
 impl B20PolicyType {
@@ -41,7 +41,7 @@ impl B20PolicyType {
         } else if id == MINT_RECEIVER_POLICY {
             Some(Self::MintReceiver)
         } else if id == SEIZABLE_ACCOUNT_POLICY {
-            Some(Self::Seizable)
+            Some(Self::SeizableAccount)
         } else {
             None
         }
@@ -54,7 +54,7 @@ impl B20PolicyType {
             Self::TransferReceiver => TRANSFER_RECEIVER_POLICY,
             Self::TransferExecutor => TRANSFER_EXECUTOR_POLICY,
             Self::MintReceiver => MINT_RECEIVER_POLICY,
-            Self::Seizable => SEIZABLE_ACCOUNT_POLICY,
+            Self::SeizableAccount => SEIZABLE_ACCOUNT_POLICY,
         }
     }
 }
@@ -73,15 +73,15 @@ mod tests {
         assert_eq!(B20PolicyType::TransferReceiver.id(), keccak256("TRANSFER_RECEIVER_POLICY"));
         assert_eq!(B20PolicyType::TransferExecutor.id(), keccak256("TRANSFER_EXECUTOR_POLICY"));
         assert_eq!(B20PolicyType::MintReceiver.id(), keccak256("MINT_RECEIVER_POLICY"));
-        assert_eq!(B20PolicyType::Seizable.id(), keccak256("SEIZABLE_ACCOUNT_POLICY"));
+        assert_eq!(B20PolicyType::SeizableAccount.id(), keccak256("SEIZABLE_ACCOUNT_POLICY"));
     }
 
     /// `from_id` is the inverse of `id`, including for the seizable scope.
     #[test]
     fn seizable_scope_round_trips() {
         assert_eq!(
-            B20PolicyType::from_id(B20PolicyType::Seizable.id()),
-            Some(B20PolicyType::Seizable)
+            B20PolicyType::from_id(B20PolicyType::SeizableAccount.id()),
+            Some(B20PolicyType::SeizableAccount)
         );
     }
 }


### PR DESCRIPTION
## Summary

PR3 of the seize stack (BOP-441). Adds the **additive base/base plumbing** for the seize operation class, mirroring the base-std reference ([base-std#177](https://github.com/base/base-std/pull/177)). This is inert plumbing: **no new selectors, no dispatch arms, and no change to any existing selector's behavior.** The entrypoints, ABI getters, `SEIZE` pause vector, and per-version gating land in PR4 (the first PR where seize is callable).

Was stacked on #4168 (`move_balance`), now merged; this branch is rebased onto `main`.

## What's included

- **Policy scope** (`policy_type.rs`): `SEIZABLE_ACCOUNT_POLICY` constant + `B20PolicyType::SeizableAccount`, wired through `from_id`/`id`.
- **Role** (`roles.rs`): `TRANSFER_FROM_SEIZABLE_ROLE` constant + `B20TokenRole::TransferFromSeizable` + `RoleManaged::transfer_from_seizable_role()` accessor.
- **Event** (`abi.rs`): `TransferredFromSeizable(caller, from, to, amount)` (event only — adds no call-enum variant).
- **Storage** (`core_storage.rs`): `seizable_policy_id` at **offset 14** (right after `nonces`). base-std keeps its mock-only `initialized` flag trailing at offset 15; this impl stores no such flag (factory-init is checked via deployed marker bytecode), so it omits that trailing slot and seize lands at offset 14 on both sides — no filler.
- **Accounting macro** (`precompile-macros`): wire the `SeizableAccount` scope to the new storage field in the generated `policy_id`/`set_policy_id`.
- **Guard** (`guards.rs`): `ensure_seizable` — mirror of `ensure_blocked` on the seizable scope (`!isAuthorized` semantics).

## Design notes

- **Storage offsets are stable.** Offsets 0–13 are untouched; `seizable_policy_id` is appended at offset 14, so already-deployed tokens are undisturbed. An offset-pin test asserts offset 14 and the byte offsets within the slot.
- **Keccak parity.** New tests assert the scope/role ids equal `keccak256` of the exact strings base-std uses, so the two implementations cannot silently diverge.
- **Versioning.** The seizable scope is recognized globally (matching the base-std reference); per-version gating (so frozen V1 keeps rejecting it while V2 accepts it) is folded into the in-flight ABI-versioning work and PR4.

## Deferred to PR4

`transferFromSeizableWithMemo` / `burnBlockedWithMemo` entrypoints + dispatch arms + logic; the `TRANSFER_FROM_SEIZABLE_ROLE()` / `SEIZABLE_ACCOUNT_POLICY()` getters; the `SEIZE` `PausableFeature` member; golden-matrix coverage. Those all add shared call-enum variants / change arg-enum decode and require the version gating, so they belong with the callable surface.

## Testing

- `cargo test -p base-common-precompiles --features test-utils`: all pass, incl. frozen V1 goldens (asset 102, stablecoin 80) unchanged.
- New unit tests: keccak parity (scope + role), storage-offset pin, `ensure_seizable` behavior (authorized => not seizable; independent of transfer-sender policy).
- `cargo +nightly fmt --check` and `cargo clippy --all-targets --features test-utils` clean.
