### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+### What changed? Why?
+
+<!-- Describe what your changes do and why. -->
+
+### Related issue
+
+<!--
+  Link the issue this PR resolves (e.g. "Closes #123").
+  PRs require you to be vouched and assigned an issue. See CONTRIBUTING.md.
+-->
+
+### How has it been tested?
+
+<!-- Describe how you verified your changes. Include relevant logs, screenshots, or commands. -->
+
+### Checklist
+
+- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
+- [ ] I have been vouched and assigned the related issue
+- [ ] I have added or updated tests as appropriate
+- [ ] All checks pass locally (`just ci`)


### PR DESCRIPTION
### What changed? Why?

Adds a `.github/pull_request_template.md` so new PRs get a consistent structure. The template is based on the internal template but adapted for this public, open-source repo: the Coinbase-internal change-management, backwards-compatibility, and automerge fields are dropped, and it aligns with our `CONTRIBUTING.md` (vouch + assigned issue requirement, `just ci`). The open-source account-sdk template was consulted for tone/structure.

### How has it been tested?

Markdown-only change; rendered locally to confirm the sections and checklist display correctly.