### PR TITLE
refactor(builder): drive metering store from execution-metering-mode

### DIFF
--- a/crates/builder/cli/src/args.rs
+++ b/crates/builder/cli/src/args.rs
@@ -179,8 +179,10 @@ pub struct Args {
     #[arg(long = "builder.extra-block-deadline-secs", default_value = "20")]
     pub extra_block_deadline_secs: u64,
 
-    /// Whether to enable TIPS Resource Metering
-    #[arg(long = "builder.enable-resource-metering", default_value = "false")]
+    /// Deprecated and ignored. Metering store enablement follows
+    /// `--builder.execution-metering-mode` (`dry-run` / `enforce`).
+    /// Scheduled for removal in v1.4.0 after rolling deployments have migrated.
+    #[arg(long = "builder.enable-resource-metering", hide = true, default_value = "false")]
     pub enable_resource_metering: bool,
 
     /// Maximum cumulative uncompressed (EIP-2718 encoded) block size in bytes
@@ -246,9 +248,11 @@ pub struct Args {
 
 impl Args {
     /// Creates a [`MeteringStore`] from the CLI arguments.
+    ///
+    /// The store is enabled when [`ExecutionMeteringMode`] is `dry-run` or `enforce`.
     pub fn build_metering_store(&self) -> MeteringStore {
         MeteringStore::new(
-            self.enable_resource_metering || self.execution_metering_mode.is_enabled(),
+            self.execution_metering_mode.is_enabled(),
             self.tx_data_store_buffer_size,
             Duration::from_secs(self.metering_store_ttl_secs),
         )
@@ -429,7 +433,10 @@ mod tests {
     fn metering_data_written_to_provider_is_readable_from_config() {
         let metering_provider: SharedMeteringProvider =
             Arc::new(MeteringStore::new(true, 100, Duration::from_secs(30)));
-        let args = Args { enable_resource_metering: true, ..Default::default() };
+        let args = Args {
+            execution_metering_mode: ExecutionMeteringMode::DryRun,
+            ..Default::default()
+        };
         let config = args
             .into_builder_config(Arc::clone(&metering_provider))
             .expect("conversion should succeed");
@@ -472,7 +479,7 @@ mod tests {
     fn metering_store_ttl_propagates_to_store() {
         let args = Args {
             metering_store_ttl_secs: 60,
-            enable_resource_metering: true,
+            execution_metering_mode: ExecutionMeteringMode::DryRun,
             ..Default::default()
         };
         let store = args.build_metering_store();
@@ -501,6 +508,26 @@ mod tests {
         assert_eq!(args.metering_store_ttl_secs, 30);
     }
 
+    #[rstest]
+    #[case::off(ExecutionMeteringMode::Off, false)]
+    #[case::dry_run(ExecutionMeteringMode::DryRun, true)]
+    #[case::enforce(ExecutionMeteringMode::Enforce, true)]
+    fn metering_store_follows_execution_metering_mode(
+        #[case] mode: ExecutionMeteringMode,
+        #[case] expected_enabled: bool,
+    ) {
+        let args = Args { execution_metering_mode: mode, ..Default::default() };
+        let store = args.build_metering_store();
+        assert_eq!(store.is_enabled(), expected_enabled);
+    }
+
+    #[test]
+    fn deprecated_enable_resource_metering_flag_does_not_enable_store() {
+        let args = Args { enable_resource_metering: true, ..Default::default() };
+        let store = args.build_metering_store();
+        assert!(!store.is_enabled());
+    }
+
     #[test]
     fn deprecated_resource_limit_flags_remain_accepted() {
         let args = CommandParser::parse_from([
@@ -513,6 +540,7 @@ mod tests {
             "0.1",
             "--builder.state-root-gas-anchor-us",
             "5000",
+            "--builder.enable-resource-metering",
         ])
         .args;
 
@@ -520,6 +548,8 @@ mod tests {
         assert_eq!(args.block_state_root_gas_limit, Some(1_000_000));
         assert_eq!(args.state_root_gas_coefficient, Some(0.1));
         assert_eq!(args.state_root_gas_anchor_us, Some(5_000));
+        assert!(args.enable_resource_metering);
+        assert!(!args.build_metering_store().is_enabled());
     }
 
     #[test]

--- a/crates/builder/cli/src/args.rs
+++ b/crates/builder/cli/src/args.rs
@@ -305,6 +305,12 @@ impl Args {
         {
             warn!("deprecated builder resource limit flags are ignored");
         }
+        if self.enable_resource_metering {
+            warn!(
+                "--builder.enable-resource-metering is deprecated and ignored; \
+                 use --builder.execution-metering-mode instead"
+            );
+        }
 
         let flashblocks_ws_addr = SocketAddr::new(
             self.flashblocks.flashblocks_addr.parse()?,

--- a/crates/builder/metering/src/store.rs
+++ b/crates/builder/metering/src/store.rs
@@ -39,13 +39,13 @@ impl core::fmt::Debug for MeteringStore {
 }
 
 impl MeteringStore {
-    /// Creates a new [`MeteringStore`] with the given metering flag, max capacity, and TTL.
+    /// Creates a new [`MeteringStore`] with the given enabled flag, max capacity, and TTL.
     ///
     /// Uses LRU eviction (not `TinyLFU`) because this cache is write-once-read-once:
     /// entries are inserted on metering arrival and read once at inclusion time.
     /// `TinyLFU` would reject new entries with zero frequency since `insert()` does
     /// not increment the frequency sketch — only `get()` does.
-    pub fn new(enable_resource_metering: bool, max_capacity: usize, ttl: Duration) -> Self {
+    pub fn new(enabled: bool, max_capacity: usize, ttl: Duration) -> Self {
         let cache = Cache::builder()
             .max_capacity(max_capacity as u64)
             .eviction_policy(EvictionPolicy::lru())
@@ -66,7 +66,7 @@ impl MeteringStore {
             .time_to_live(ttl)
             .build();
 
-        Self { cache, needed_at, metering_enabled: AtomicBool::new(enable_resource_metering) }
+        Self { cache, needed_at, metering_enabled: AtomicBool::new(enabled) }
     }
 
     /// Returns the number of stored entries.

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -312,7 +312,7 @@ services:
       - --flashblocks.block-time=200
       - --rollup.chain-block-time=2000
       - --metrics=0.0.0.0:${L2_BUILDER_METRICS_PORT}
-      - --builder.enable-resource-metering
+      - --builder.execution-metering-mode=dry-run
       - --builder.max-rejected-txs-per-block=${BUILDER_MAX_REJECTED_TXS_PER_BLOCK}
       - --txpool.nolocals
       - --rollup.txpool-max-inflight-delegated-slots=32768


### PR DESCRIPTION
## Summary
- Collapse the redundant `--builder.enable-resource-metering` boolean into `--builder.execution-metering-mode`: the `MeteringStore` is now enabled only for `dry-run` / `enforce`.
- Keep the old flag as a hidden no-op (same pattern as the other obsolete resource-limit flags) so existing chart/Config Service args do not break startups until deployments migrate.
- Point local docker-compose at `execution-metering-mode=dry-run` instead of the deprecated flag.

Follow-up in `protocols/base`: stop emitting `BUILDER_ENABLE_RESOURCE_METERING` / `--builder.enable-resource-metering`, and update the resource-metering runbook/monitors to treat `execution_metering_mode=off` as the kill switch.

## Test plan
- [x] `cargo test -p base-builder-cli -p base-builder-metering --lib`
- [ ] Confirm prod/sepolia/zeronet already run `dry-run` or `enforce` (store stays on after this change)
- [ ] After merge: chart PR to drop `BUILDER_ENABLE_RESOURCE_METERING` wiring