### PR TITLE
feat(txpool): two-tier high-rate payer recognition for upgradeable proxies

### DIFF
--- a/crates/common/consensus/src/transaction/eip8130/addresses.rs
+++ b/crates/common/consensus/src/transaction/eip8130/addresses.rs
@@ -90,6 +90,21 @@ impl Eip8130Contracts {
     pub const CANONICAL_HIGH_RATE_PAYER_PROXY_CODE_HASH: B256 =
         b256!("0x3e37c64c39476e47c52408ea45eb3ae0f07e3ca0fd1d713acbcf17bf3b51312c");
 
+    /// The EIP-1967 implementation storage slot
+    /// (`keccak256("eip1967.proxy.implementation") - 1`), where an upgradeable
+    /// ERC-1967 proxy stores its current implementation address.
+    ///
+    /// Read by the two-tier high-rate payer recognition (see the txpool
+    /// validator): behind a *trusted upgradeable-proxy shell* codehash, the node
+    /// resolves the effective implementation from this slot and checks it against
+    /// the trusted-implementation allowlist. This lets an *upgradeable* account
+    /// qualify for the high-rate tier (provided the shell is a constrained proxy
+    /// that freezes upgrades while locked), whereas the single-tier path
+    /// ([`Self::CANONICAL_HIGH_RATE_PAYER_PROXY_CODE_HASH`]) only recognizes
+    /// immutable ERC-1167 clones.
+    pub const ERC1967_IMPLEMENTATION_SLOT: B256 =
+        b256!("0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc");
+
     // ─────────────────────────────────────────────────────────────────────────
     // Canonical authenticators (accepted on the EIP-8130 block-validation path)
     // ─────────────────────────────────────────────────────────────────────────

--- a/crates/execution/txpool/src/pool.rs
+++ b/crates/execution/txpool/src/pool.rs
@@ -46,6 +46,10 @@ pub struct AccountStateDiff {
     pub code_changed: bool,
     /// Changed contract storage slots.
     pub changed_slots: Vec<B256>,
+    /// New account code hash, when the account is present in the bundle.
+    pub code_hash: Option<B256>,
+    /// New raw ERC-1967 implementation slot value, when that slot changed.
+    pub erc1967_impl_slot: Option<U256>,
 }
 
 impl AccountStateDiff {
@@ -1716,6 +1720,8 @@ mod tests {
             nonce_changed: true,
             code_changed: true,
             changed_slots: vec![slot],
+            code_hash: None,
+            erc1967_impl_slot: None,
         };
         let mut keys = Vec::new();
         diff.push_exact_keys(&mut keys);

--- a/crates/execution/txpool/src/state_diff_maintain.rs
+++ b/crates/execution/txpool/src/state_diff_maintain.rs
@@ -5,6 +5,7 @@
 //! deltas into the EIP-8130 invalidation index.
 
 use alloy_primitives::{B256, U256};
+use base_common_consensus::Eip8130Contracts;
 use base_common_precompiles::NonceManagerStorage;
 use futures::StreamExt;
 use reth_provider::CanonStateNotification;
@@ -127,6 +128,15 @@ impl AccountStateDiff {
                 .map(|(key, _)| B256::from(*key))
                 .collect::<Vec<_>>();
 
+            let code_hash = new_code_hash;
+            let impl_slot_key =
+                U256::from_be_bytes(Eip8130Contracts::ERC1967_IMPLEMENTATION_SLOT.0);
+            let erc1967_impl_slot = account
+                .storage
+                .get(&impl_slot_key)
+                .filter(|slot| slot.is_changed())
+                .map(|slot| slot.present_value);
+
             if balance.is_some() || nonce_changed || code_changed || !changed_slots.is_empty() {
                 diffs.push(Self {
                     address: *address,
@@ -134,6 +144,8 @@ impl AccountStateDiff {
                     nonce_changed,
                     code_changed,
                     changed_slots,
+                    code_hash,
+                    erc1967_impl_slot,
                 });
             }
         }

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -102,6 +102,22 @@ struct Eip8130ValidationState {
 
 const LIMIT_CLASS_CACHE_CAPACITY: NonZeroUsize = NonZeroUsize::new(100_000).unwrap();
 
+/// Whether an account qualifies for the high-rate payer tier, and by which code
+/// shape: an immutable ERC-1167 clone (single-tier), or a trusted upgradeable
+/// proxy shell currently pointing at a trusted implementation (two-tier).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum HighRatePayerClass {
+    None,
+    Immutable,
+    Upgradeable,
+}
+
+impl HighRatePayerClass {
+    const fn is_trusted(self) -> bool {
+        !matches!(self, Self::None)
+    }
+}
+
 /// Cached lock state and trusted-delegation classification by account.
 #[derive(Debug)]
 pub struct LimitClassCache {
@@ -682,6 +698,13 @@ pub struct BaseTransactionValidator<Client, Tx, Evm> {
     /// implementations. Precomputed so classification is an O(1) code-hash lookup
     /// with no code fetch or bytecode parsing.
     trusted_proxy_code_hashes: Arc<HashSet<B256>>,
+    /// Codehashes of trusted *upgradeable* proxy shells (the outer tier of
+    /// two-tier recognition). A match triggers a nested read of the ERC-1967
+    /// implementation slot, whose resolved implementation must be trusted.
+    trusted_upgradeable_proxy_code_hashes: Arc<HashSet<B256>>,
+    /// Codehashes of trusted high-rate implementations an upgradeable proxy shell
+    /// may point at (the inner tier).
+    trusted_implementation_code_hashes: Arc<HashSet<B256>>,
     limit_class_cache: Arc<RwLock<LimitClassCache>>,
     limit_class_cache_generation: Arc<AtomicU64>,
 }
@@ -750,6 +773,39 @@ impl<Client, Tx, Evm> BaseTransactionValidator<Client, Tx, Evm> {
         }
     }
 
+    /// Default trusted upgradeable-proxy shell codehashes (outer tier).
+    ///
+    /// Empty until the constrained upgradeable proxy shell is finalized and
+    /// pinned (like the provisional addresses in `Eip8130Contracts`). While
+    /// empty, the two-tier path is dormant and behavior is identical to the
+    /// single-tier baseline. Operators supply values via
+    /// [`Self::with_trusted_upgradeable_proxies`].
+    pub fn default_trusted_upgradeable_proxy_code_hashes() -> HashSet<B256> {
+        HashSet::new()
+    }
+
+    /// Default trusted high-rate implementation codehashes (inner tier). Empty by
+    /// default; see [`Self::default_trusted_upgradeable_proxy_code_hashes`].
+    pub fn default_trusted_implementation_code_hashes() -> HashSet<B256> {
+        HashSet::new()
+    }
+
+    /// Configures the two-tier upgradeable high-rate allowlists: the trusted proxy
+    /// shell codehashes and the implementation codehashes they may point at.
+    pub fn with_trusted_upgradeable_proxies(
+        self,
+        shell_code_hashes: HashSet<B256>,
+        implementation_code_hashes: HashSet<B256>,
+    ) -> Self {
+        Self {
+            trusted_upgradeable_proxy_code_hashes: Arc::new(shell_code_hashes),
+            trusted_implementation_code_hashes: Arc::new(implementation_code_hashes),
+            limit_class_cache: Arc::default(),
+            limit_class_cache_generation: Arc::default(),
+            ..self
+        }
+    }
+
     /// Returns the cache generation used to close validation/invalidation races.
     pub fn limit_class_cache_generation(&self) -> u64 {
         self.limit_class_cache_generation.load(Ordering::Acquire)
@@ -765,6 +821,14 @@ impl<Client, Tx, Evm> BaseTransactionValidator<Client, Tx, Evm> {
         let mut changed = false;
         for diff in diffs {
             if diff.code_changed {
+                changed = true;
+                cache.invalidate_code(diff.address);
+            }
+            // A write to the ERC-1967 implementation slot re-points a tier-B
+            // (upgradeable-proxy) payer's implementation, which can flip its trust
+            // classification even though the proxy's own code is unchanged. Clear
+            // the cached class so it is recomputed against the new implementation.
+            if diff.changed_slots.contains(&Eip8130Contracts::ERC1967_IMPLEMENTATION_SLOT) {
                 changed = true;
                 cache.invalidate_code(diff.address);
             }
@@ -841,6 +905,12 @@ where
             require_l1_data_gas_fee: true,
             trusted_delegation_targets: Arc::new(trusted_delegation_targets),
             trusted_proxy_code_hashes: Arc::new(trusted_proxy_code_hashes),
+            trusted_upgradeable_proxy_code_hashes: Arc::new(
+                Self::default_trusted_upgradeable_proxy_code_hashes(),
+            ),
+            trusted_implementation_code_hashes: Arc::new(
+                Self::default_trusted_implementation_code_hashes(),
+            ),
             limit_class_cache: Arc::default(),
             limit_class_cache_generation: Arc::default(),
         }
@@ -1217,14 +1287,28 @@ where
         // hard-lock → pending-unlock transition writes the account-state slot, so
         // the slot watch above drains any already-admitted transactions naturally
         // — no timed bucket is needed for the trusted dimension.
-        let payer_trusted = Self::qualifies_as_high_rate_lock(&payer_status)
-            && self.is_high_rate_account(
+        let payer_class = if Self::qualifies_as_high_rate_lock(&payer_status) {
+            self.high_rate_payer_class(
                 payer,
                 payer_account.bytecode_hash,
+                &*state,
                 classification_generation,
-            );
+            )
+        } else {
+            HighRatePayerClass::None
+        };
+        let payer_trusted = payer_class.is_trusted();
         if payer_trusted {
             watch_set.push(InvalidationKey::CodeHash(payer));
+            // Tier-B (upgradeable) trust depends on the ERC-1967 implementation
+            // slot, so watch it: an upgrade re-pointing the impl demotes any
+            // already-admitted transactions from the balance-bounded book.
+            if matches!(payer_class, HighRatePayerClass::Upgradeable) {
+                watch_set.push(InvalidationKey::Slot {
+                    address: payer,
+                    slot: Eip8130Contracts::ERC1967_IMPLEMENTATION_SLOT,
+                });
+            }
         }
 
         let gas_charge = FeeCheck::max_fee_charge(
@@ -1375,48 +1459,125 @@ where
         account_state.lock_status(now)
     }
 
-    /// Whether `account` is a trusted high-rate (balance-bounded) payer: its
-    /// on-chain code hash must exactly equal the canonical immutable ERC-1167
-    /// minimal-proxy runtime of a trusted implementation
-    /// ([`Self::trusted_proxy_code_hashes`]).
+    /// Classifies `account` for the high-rate (balance-bounded) payer tier.
     ///
-    /// `bytecode_hash` is the account's code hash the caller already loaded (the
-    /// fee check reads the payer account), so classification is an O(1) code-hash
-    /// set lookup with no extra account read, code fetch, or bytecode parsing.
+    /// High-rate trust is balance-bounded: the mempool reserves against the
+    /// payer's ETH balance and assumes that reservation cannot be pulled out from
+    /// under it. That holds only if the code the account runs cannot change to
+    /// something that moves ETH while locked. Two shapes satisfy this:
     ///
-    /// High-rate payer trust is *balance-bounded*: the mempool reserves against
-    /// the payer's ETH balance and assumes that reservation cannot be pulled out
-    /// from under it. That guarantee only holds if the payer's code — and thus
-    /// the enshrined "block ETH transfers while locked" behavior of the
-    /// high-rate implementation — can never change. Membership of the code hash
-    /// in `trusted_proxy_code_hashes` is exactly that check: it matches only the
-    /// canonical immutable ERC-1167 minimal-proxy runtime (no upgrade slot) of a
-    /// trusted implementation.
+    /// - [`HighRatePayerClass::Immutable`]: the account's own codehash is the
+    ///   canonical immutable ERC-1167 minimal-proxy runtime of a trusted
+    ///   implementation (`trusted_proxy_code_hashes`). O(1), no state read.
+    /// - [`HighRatePayerClass::Upgradeable`]: the account's codehash is a trusted
+    ///   *constrained* proxy shell (`trusted_upgradeable_proxy_code_hashes`, which
+    ///   freezes upgrades while locked) whose current ERC-1967 implementation
+    ///   resolves to a trusted implementation codehash
+    ///   (`trusted_implementation_code_hashes`). This reads the impl slot; the
+    ///   caller watches that slot so an upgrade demotes already-admitted txs.
     ///
-    /// An **EIP-7702 delegation** deliberately never qualifies: its code is the
-    /// `0xef0100 ‖ impl` designator, whose hash differs from any proxy runtime,
-    /// and the delegating EOA can broadcast a fresh authorization to re-point or
-    /// clear that code at any time — escaping the lock and draining the balance
-    /// the mempool relied on. Only immutable contract deployments are trusted.
-    fn is_high_rate_account(
+    /// An EIP-7702 delegation never qualifies (its `0xef0100 || impl` code hashes
+    /// to neither set and is freely re-pointable). State reads fail closed to
+    /// [`HighRatePayerClass::None`] and are not cached, so a transient provider
+    /// error cannot pin a stale class for the LRU lifetime.
+    fn high_rate_payer_class(
         &self,
         account: Address,
         bytecode_hash: Option<B256>,
+        state: &dyn StateProvider,
         generation: u64,
-    ) -> bool {
-        // Invalidation may advance the generation immediately after this read.
-        // Pool admission rejects the captured classification if that happens.
-        let cached = self.limit_class_cache.write().trusted(account);
-        if let Some(value) = cached {
-            return value;
+    ) -> HighRatePayerClass {
+        // A cached entry records only whether the account is trusted; the tier is
+        // reconstructed from codehash membership (no state read), stable because a
+        // code change invalidates the entry.
+        if let Some(trusted) = self.limit_class_cache.write().trusted(account) {
+            return if trusted {
+                self.trusted_tier(bytecode_hash)
+            } else {
+                HighRatePayerClass::None
+            };
         }
-        let trusted =
-            bytecode_hash.is_some_and(|hash| self.trusted_proxy_code_hashes.contains(&hash));
+
+        let Some(hash) = bytecode_hash else {
+            self.cache_high_rate_trust(account, false, generation);
+            return HighRatePayerClass::None;
+        };
+
+        if self.trusted_proxy_code_hashes.contains(&hash) {
+            self.cache_high_rate_trust(account, true, generation);
+            return HighRatePayerClass::Immutable;
+        }
+
+        if self.trusted_upgradeable_proxy_code_hashes.contains(&hash) {
+            match self.resolve_upgradeable_impl_trusted(account, state) {
+                Err(()) => HighRatePayerClass::None,
+                Ok(trusted) => {
+                    self.cache_high_rate_trust(account, trusted, generation);
+                    if trusted { HighRatePayerClass::Upgradeable } else { HighRatePayerClass::None }
+                }
+            }
+        } else {
+            self.cache_high_rate_trust(account, false, generation);
+            HighRatePayerClass::None
+        }
+    }
+
+    /// Reconstructs the tier for an account already cached as trusted, from its
+    /// codehash membership alone (no state read).
+    fn trusted_tier(&self, bytecode_hash: Option<B256>) -> HighRatePayerClass {
+        match bytecode_hash {
+            Some(hash) if self.trusted_proxy_code_hashes.contains(&hash) => {
+                HighRatePayerClass::Immutable
+            }
+            Some(hash) if self.trusted_upgradeable_proxy_code_hashes.contains(&hash) => {
+                HighRatePayerClass::Upgradeable
+            }
+            _ => HighRatePayerClass::None,
+        }
+    }
+
+    /// Resolves the implementation behind a trusted upgradeable proxy shell and
+    /// returns whether it is trusted. `Err(())` signals a state-read failure, on
+    /// which the caller fails closed without caching.
+    ///
+    /// A zero implementation slot means the account still runs the shell's baked
+    /// default implementation; trusting the shell codehash (which commits to that
+    /// default) implies trusting it. A non-zero slot must decode to an address
+    /// (upper 96 bits zero) whose code hash is in the trusted set.
+    fn resolve_upgradeable_impl_trusted(
+        &self,
+        account: Address,
+        state: &dyn StateProvider,
+    ) -> Result<bool, ()> {
+        let slot = state
+            .storage(account, Eip8130Contracts::ERC1967_IMPLEMENTATION_SLOT)
+            .map_err(|error| {
+                tracing::warn!(error = %error, account = %account, "EIP-8130 impl-slot read failed");
+            })?
+            .unwrap_or_default();
+        if slot.is_zero() {
+            return Ok(true);
+        }
+        if slot >> 160 != U256::ZERO {
+            return Ok(false);
+        }
+        let implementation = Address::from_word(B256::from(slot));
+        let impl_code_hash = state
+            .basic_account(&implementation)
+            .map_err(|error| {
+                tracing::warn!(error = %error, implementation = %implementation, "EIP-8130 impl read failed");
+            })?
+            .and_then(|account| account.bytecode_hash);
+        Ok(impl_code_hash
+            .is_some_and(|hash| self.trusted_implementation_code_hashes.contains(&hash)))
+    }
+
+    /// Caches the high-rate trust bit under the generation guard.
+    fn cache_high_rate_trust(&self, account: Address, trusted: bool, generation: u64) {
         let mut cache = self.limit_class_cache.write();
         if generation == self.limit_class_cache_generation() {
             cache.insert_trusted(account, trusted);
         }
-        trusted
     }
 
     fn validate_eip8130_create_freshness(
@@ -2048,7 +2209,7 @@ where
 mod tests {
     use alloy_consensus::{SignableTransaction, TxEip1559, transaction::SignerRecoverable};
     use alloy_eips::eip2718::Encodable2718;
-    use alloy_primitives::{Address, B256, Bytes, TxKind, U256, bytes, hex::decode};
+    use alloy_primitives::{Address, B256, Bytes, TxKind, U256, bytes, hex::decode, keccak256};
     use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
     use base_common_chains::ChainConfig;
@@ -3514,5 +3675,174 @@ mod tests {
         assert_eq!(state.payer, sender);
         assert_eq!(state.sender_bytecode_hash, Some(expected_hash));
         assert!(state.watch_set.iter().any(|key| *key == InvalidationKey::CodeHash(sender)));
+    }
+
+    // Two-tier (upgradeable proxy) high-rate payer recognition.
+
+    fn upgradeable_validator(
+        payer: Address,
+        payer_account: ExtendedAccount,
+        seeded: &[(Address, ExtendedAccount)],
+        shell_code_hash: B256,
+        impl_code_hash: B256,
+    ) -> TestValidator {
+        let chain_spec = Arc::new(BaseChainSpecBuilder::base_mainnet().cobalt_activated().build());
+        let client = MockEthProvider::<BasePrimitives>::new()
+            .with_chain_spec(Arc::clone(&chain_spec))
+            .with_genesis_block();
+        client.add_account(payer, payer_account);
+        for (address, account) in seeded {
+            client.add_account(*address, account.clone());
+        }
+        let evm_config = BaseEvmConfig::base(Arc::clone(&chain_spec));
+        let inner = EthTransactionValidatorBuilder::new(client, evm_config)
+            .no_shanghai()
+            .no_cancun()
+            .build(InMemoryBlobStore::default());
+        BaseTransactionValidator::with_block_info(inner, BaseL1BlockInfo::default())
+            .with_trusted_upgradeable_proxies(
+                HashSet::from([shell_code_hash]),
+                HashSet::from([impl_code_hash]),
+            )
+    }
+
+    fn impl_slot_value(implementation: Address) -> U256 {
+        U256::from_be_slice(implementation.as_slice())
+    }
+
+    #[test]
+    fn high_rate_class_upgradeable_when_impl_slot_points_at_trusted_impl() {
+        let shell_code = bytes!("60016000");
+        let impl_code = bytes!("60026000");
+        let shell_hash = keccak256(shell_code.as_ref());
+        let impl_hash = keccak256(impl_code.as_ref());
+        let payer = Address::repeat_byte(0x11);
+        let implementation = Address::repeat_byte(0x42);
+
+        let payer_account =
+            ExtendedAccount::new(0, U256::ZERO).with_bytecode(shell_code).extend_storage([(
+                Eip8130Contracts::ERC1967_IMPLEMENTATION_SLOT,
+                impl_slot_value(implementation),
+            )]);
+        let impl_account = ExtendedAccount::new(0, U256::ZERO).with_bytecode(impl_code);
+
+        let validator = upgradeable_validator(
+            payer,
+            payer_account,
+            &[(implementation, impl_account)],
+            shell_hash,
+            impl_hash,
+        );
+        let state = validator.client().latest().unwrap();
+        let generation = validator.limit_class_cache_generation();
+        assert_eq!(
+            validator.high_rate_payer_class(payer, Some(shell_hash), &*state, generation),
+            HighRatePayerClass::Upgradeable,
+        );
+    }
+
+    #[test]
+    fn high_rate_class_none_when_upgradeable_impl_not_trusted() {
+        let shell_code = bytes!("60016000");
+        let impl_code = bytes!("60026000");
+        let shell_hash = keccak256(shell_code.as_ref());
+        let impl_hash = keccak256(impl_code.as_ref());
+        let payer = Address::repeat_byte(0x11);
+        let untrusted_impl = Address::repeat_byte(0x43);
+
+        let payer_account =
+            ExtendedAccount::new(0, U256::ZERO).with_bytecode(shell_code).extend_storage([(
+                Eip8130Contracts::ERC1967_IMPLEMENTATION_SLOT,
+                impl_slot_value(untrusted_impl),
+            )]);
+
+        let validator = upgradeable_validator(payer, payer_account, &[], shell_hash, impl_hash);
+        let state = validator.client().latest().unwrap();
+        let generation = validator.limit_class_cache_generation();
+        assert_eq!(
+            validator.high_rate_payer_class(payer, Some(shell_hash), &*state, generation),
+            HighRatePayerClass::None,
+        );
+    }
+
+    #[test]
+    fn high_rate_class_upgradeable_trusts_baked_default_when_slot_zero() {
+        let shell_code = bytes!("60016000");
+        let shell_hash = keccak256(shell_code.as_ref());
+        let impl_hash = keccak256(bytes!("60026000").as_ref());
+        let payer = Address::repeat_byte(0x11);
+
+        let payer_account = ExtendedAccount::new(0, U256::ZERO).with_bytecode(shell_code);
+        let validator = upgradeable_validator(payer, payer_account, &[], shell_hash, impl_hash);
+        let state = validator.client().latest().unwrap();
+        let generation = validator.limit_class_cache_generation();
+        assert_eq!(
+            validator.high_rate_payer_class(payer, Some(shell_hash), &*state, generation),
+            HighRatePayerClass::Upgradeable,
+        );
+    }
+
+    #[test]
+    fn high_rate_class_none_when_impl_slot_is_malformed() {
+        let shell_code = bytes!("60016000");
+        let shell_hash = keccak256(shell_code.as_ref());
+        let impl_hash = keccak256(bytes!("60026000").as_ref());
+        let payer = Address::repeat_byte(0x11);
+        let malformed = U256::from(1u8) << 200;
+
+        let payer_account = ExtendedAccount::new(0, U256::ZERO)
+            .with_bytecode(shell_code)
+            .extend_storage([(Eip8130Contracts::ERC1967_IMPLEMENTATION_SLOT, malformed)]);
+        let validator = upgradeable_validator(payer, payer_account, &[], shell_hash, impl_hash);
+        let state = validator.client().latest().unwrap();
+        let generation = validator.limit_class_cache_generation();
+        assert_eq!(
+            validator.high_rate_payer_class(payer, Some(shell_hash), &*state, generation),
+            HighRatePayerClass::None,
+        );
+    }
+
+    #[test]
+    fn high_rate_class_immutable_for_canonical_erc1167_clone() {
+        let runtime = Eip8130Contracts::erc1167_proxy_runtime(
+            Eip8130Contracts::CANONICAL_HIGH_RATE_PAYER_ACCOUNT,
+        );
+        let code_hash = keccak256(runtime);
+        let payer = Address::repeat_byte(0x11);
+        let payer_account =
+            ExtendedAccount::new(0, U256::ZERO).with_bytecode(Bytes::copy_from_slice(&runtime));
+        let validator = build_test_validator_with_account(payer, payer_account);
+        let state = validator.client().latest().unwrap();
+        let generation = validator.limit_class_cache_generation();
+        assert_eq!(
+            validator.high_rate_payer_class(payer, Some(code_hash), &*state, generation),
+            HighRatePayerClass::Immutable,
+        );
+    }
+
+    #[test]
+    fn impl_slot_diff_clears_trusted_class_and_advances_generation() {
+        let validator = build_test_validator();
+        let payer = Address::repeat_byte(0x11);
+        validator.limit_class_cache.write().insert_trusted(payer, true);
+        let before = validator.limit_class_cache_generation();
+
+        validator.invalidate_limit_class_cache(&[crate::AccountStateDiff {
+            address: payer,
+            balance: None,
+            nonce_changed: false,
+            code_changed: false,
+            changed_slots: vec![Eip8130Contracts::ERC1967_IMPLEMENTATION_SLOT],
+        }]);
+
+        assert!(
+            validator.limit_class_cache_generation() > before,
+            "an impl-slot write must advance the classification generation"
+        );
+        assert_eq!(
+            validator.limit_class_cache.write().trusted(payer),
+            None,
+            "an impl-slot write must clear the cached trusted class"
+        );
     }
 }

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -699,12 +699,17 @@ pub struct BaseTransactionValidator<Client, Tx, Evm> {
     /// with no code fetch or bytecode parsing.
     trusted_proxy_code_hashes: Arc<HashSet<B256>>,
     /// Codehashes of trusted *upgradeable* proxy shells (the outer tier of
-    /// two-tier recognition). A match triggers a nested read of the ERC-1967
-    /// implementation slot, whose resolved implementation must be trusted.
+    /// two-tier recognition). A shell's eligibility is decided off the admission
+    /// path by the per-block classifier, which resolves its ERC-1967
+    /// implementation from the committed state diff and checks it against
+    /// `trusted_implementation_addresses`.
     trusted_upgradeable_proxy_code_hashes: Arc<HashSet<B256>>,
-    /// Codehashes of trusted high-rate implementations an upgradeable proxy shell
-    /// may point at (the inner tier).
-    trusted_implementation_code_hashes: Arc<HashSet<B256>>,
+    /// Addresses of trusted high-rate implementations an upgradeable proxy shell
+    /// may point at (the inner tier). The state diff exposes the implementation
+    /// by address (the slot value), never by codehash, and the classifier must
+    /// not read the implementation account, so the inner allowlist is keyed by
+    /// address.
+    trusted_implementation_addresses: Arc<AddressSet>,
     limit_class_cache: Arc<RwLock<LimitClassCache>>,
     limit_class_cache_generation: Arc<AtomicU64>,
 }
@@ -784,22 +789,22 @@ impl<Client, Tx, Evm> BaseTransactionValidator<Client, Tx, Evm> {
         HashSet::new()
     }
 
-    /// Default trusted high-rate implementation codehashes (inner tier). Empty by
+    /// Default trusted high-rate implementation addresses (inner tier). Empty by
     /// default; see [`Self::default_trusted_upgradeable_proxy_code_hashes`].
-    pub fn default_trusted_implementation_code_hashes() -> HashSet<B256> {
-        HashSet::new()
+    pub fn default_trusted_implementation_addresses() -> AddressSet {
+        AddressSet::default()
     }
 
     /// Configures the two-tier upgradeable high-rate allowlists: the trusted proxy
-    /// shell codehashes and the implementation codehashes they may point at.
+    /// shell codehashes and the implementation addresses they may point at.
     pub fn with_trusted_upgradeable_proxies(
         self,
         shell_code_hashes: HashSet<B256>,
-        implementation_code_hashes: HashSet<B256>,
+        implementation_addresses: AddressSet,
     ) -> Self {
         Self {
             trusted_upgradeable_proxy_code_hashes: Arc::new(shell_code_hashes),
-            trusted_implementation_code_hashes: Arc::new(implementation_code_hashes),
+            trusted_implementation_addresses: Arc::new(implementation_addresses),
             limit_class_cache: Arc::default(),
             limit_class_cache_generation: Arc::default(),
             ..self
@@ -832,6 +837,29 @@ impl<Client, Tx, Evm> BaseTransactionValidator<Client, Tx, Evm> {
                 changed = true;
                 cache.invalidate_code(diff.address);
             }
+            // Per-block tier-B classifier. Runs after the invalidations above so a
+            // shell's end state is the freshly computed trust bit, not a cleared
+            // entry. Pure: it consumes only the diff (new codehash and, when it
+            // changed this block, the raw ERC-1967 implementation slot value), so
+            // admission never has to read the implementation slot.
+            if diff
+                .code_hash
+                .is_some_and(|hash| self.trusted_upgradeable_proxy_code_hashes.contains(&hash))
+            {
+                let effective_impl = diff.erc1967_impl_slot.or_else(|| {
+                    // A proxy shell never rewrites its own code, so a code change
+                    // to a trusted shell codehash is its creation: it runs the
+                    // baked default implementation the shell codehash commits to,
+                    // which the ERC-1967 slot represents as zero. A shell diff with
+                    // neither an impl-slot change nor a code change carries no
+                    // eligibility-relevant change this block and is left as-is.
+                    diff.code_changed.then_some(U256::ZERO)
+                });
+                if let Some(value) = effective_impl {
+                    cache.insert_trusted(diff.address, self.implementation_value_trusted(value));
+                    changed = true;
+                }
+            }
             if diff.address == AccountConfigurationStorage::ADDRESS {
                 for slot in &diff.changed_slots {
                     changed = true;
@@ -858,6 +886,22 @@ impl<Client, Tx, Evm> BaseTransactionValidator<Client, Tx, Evm> {
         if changed {
             self.limit_class_cache_generation.fetch_add(1, Ordering::Release);
         }
+    }
+
+    /// Whether a raw ERC-1967 implementation slot value resolves to a trusted
+    /// implementation. A zero value is the shell's baked default, which the
+    /// trusted shell codehash already commits to. A value with any of the high 96
+    /// bits set is malformed (not a left-padded address) and never trusted.
+    /// Otherwise the low 20 bytes are the implementation address, checked against
+    /// the trusted-implementation allowlist.
+    fn implementation_value_trusted(&self, value: U256) -> bool {
+        if value.is_zero() {
+            return true;
+        }
+        if value >> 160 != U256::ZERO {
+            return false;
+        }
+        self.trusted_implementation_addresses.contains(&Address::from_word(B256::from(value)))
     }
 
     /// Clears classifications after a state-diff feed gap.
@@ -908,8 +952,8 @@ where
             trusted_upgradeable_proxy_code_hashes: Arc::new(
                 Self::default_trusted_upgradeable_proxy_code_hashes(),
             ),
-            trusted_implementation_code_hashes: Arc::new(
-                Self::default_trusted_implementation_code_hashes(),
+            trusted_implementation_addresses: Arc::new(
+                Self::default_trusted_implementation_addresses(),
             ),
             limit_class_cache: Arc::default(),
             limit_class_cache_generation: Arc::default(),
@@ -1291,7 +1335,6 @@ where
             self.high_rate_payer_class(
                 payer,
                 payer_account.bytecode_hash,
-                &*state,
                 classification_generation,
             )
         } else {
@@ -1459,7 +1502,10 @@ where
         account_state.lock_status(now)
     }
 
-    /// Classifies `account` for the high-rate (balance-bounded) payer tier.
+    /// Classifies `account` for the high-rate (balance-bounded) payer tier using
+    /// only the already-loaded payer codehash and the in-memory cache. Performs
+    /// no state reads: an unaccounted, attacker-influenceable storage read on the
+    /// per-transaction admission path is not acceptable.
     ///
     /// High-rate trust is balance-bounded: the mempool reserves against the
     /// payer's ETH balance and assumes that reservation cannot be pulled out from
@@ -1471,20 +1517,20 @@ where
     ///   implementation (`trusted_proxy_code_hashes`). O(1), no state read.
     /// - [`HighRatePayerClass::Upgradeable`]: the account's codehash is a trusted
     ///   *constrained* proxy shell (`trusted_upgradeable_proxy_code_hashes`, which
-    ///   freezes upgrades while locked) whose current ERC-1967 implementation
-    ///   resolves to a trusted implementation codehash
-    ///   (`trusted_implementation_code_hashes`). This reads the impl slot; the
-    ///   caller watches that slot so an upgrade demotes already-admitted txs.
+    ///   freezes upgrades while locked) whose current ERC-1967 implementation is
+    ///   trusted. That eligibility is only ever populated by the per-block
+    ///   classifier in [`Self::invalidate_limit_class_cache`], which reads the
+    ///   implementation from the committed block's state diff. A cold shell not
+    ///   yet recorded by that classifier is treated conservatively as not
+    ///   high-rate (count-limited) and is intentionally not cached, so caching a
+    ///   `false` here cannot suppress the eligibility the classifier later inserts.
     ///
     /// An EIP-7702 delegation never qualifies (its `0xef0100 || impl` code hashes
-    /// to neither set and is freely re-pointable). State reads fail closed to
-    /// [`HighRatePayerClass::None`] and are not cached, so a transient provider
-    /// error cannot pin a stale class for the LRU lifetime.
+    /// to neither set and is freely re-pointable).
     fn high_rate_payer_class(
         &self,
         account: Address,
         bytecode_hash: Option<B256>,
-        state: &dyn StateProvider,
         generation: u64,
     ) -> HighRatePayerClass {
         // A cached entry records only whether the account is trusted; the tier is
@@ -1509,17 +1555,11 @@ where
         }
 
         if self.trusted_upgradeable_proxy_code_hashes.contains(&hash) {
-            match self.resolve_upgradeable_impl_trusted(account, state) {
-                Err(()) => HighRatePayerClass::None,
-                Ok(trusted) => {
-                    self.cache_high_rate_trust(account, trusted, generation);
-                    if trusted { HighRatePayerClass::Upgradeable } else { HighRatePayerClass::None }
-                }
-            }
-        } else {
-            self.cache_high_rate_trust(account, false, generation);
-            HighRatePayerClass::None
+            return HighRatePayerClass::None;
         }
+
+        self.cache_high_rate_trust(account, false, generation);
+        HighRatePayerClass::None
     }
 
     /// Reconstructs the tier for an account already cached as trusted, from its
@@ -1534,42 +1574,6 @@ where
             }
             _ => HighRatePayerClass::None,
         }
-    }
-
-    /// Resolves the implementation behind a trusted upgradeable proxy shell and
-    /// returns whether it is trusted. `Err(())` signals a state-read failure, on
-    /// which the caller fails closed without caching.
-    ///
-    /// A zero implementation slot means the account still runs the shell's baked
-    /// default implementation; trusting the shell codehash (which commits to that
-    /// default) implies trusting it. A non-zero slot must decode to an address
-    /// (upper 96 bits zero) whose code hash is in the trusted set.
-    fn resolve_upgradeable_impl_trusted(
-        &self,
-        account: Address,
-        state: &dyn StateProvider,
-    ) -> Result<bool, ()> {
-        let slot = state
-            .storage(account, Eip8130Contracts::ERC1967_IMPLEMENTATION_SLOT)
-            .map_err(|error| {
-                tracing::warn!(error = %error, account = %account, "EIP-8130 impl-slot read failed");
-            })?
-            .unwrap_or_default();
-        if slot.is_zero() {
-            return Ok(true);
-        }
-        if slot >> 160 != U256::ZERO {
-            return Ok(false);
-        }
-        let implementation = Address::from_word(B256::from(slot));
-        let impl_code_hash = state
-            .basic_account(&implementation)
-            .map_err(|error| {
-                tracing::warn!(error = %error, implementation = %implementation, "EIP-8130 impl read failed");
-            })?
-            .and_then(|account| account.bytecode_hash);
-        Ok(impl_code_hash
-            .is_some_and(|hash| self.trusted_implementation_code_hashes.contains(&hash)))
     }
 
     /// Caches the high-rate trust bit under the generation guard.
@@ -2330,6 +2334,8 @@ mod tests {
             nonce_changed: false,
             code_changed: false,
             changed_slots: Vec::new(),
+            code_hash: None,
+            erc1967_impl_slot: None,
         }
     }
 
@@ -2370,6 +2376,8 @@ mod tests {
             nonce_changed: true,
             code_changed: false,
             changed_slots: Vec::new(),
+            code_hash: None,
+            erc1967_impl_slot: None,
         };
         validator.invalidate_limit_class_cache(&[nonce_diff]);
         assert_eq!(
@@ -3677,145 +3685,140 @@ mod tests {
         assert!(state.watch_set.iter().any(|key| *key == InvalidationKey::CodeHash(sender)));
     }
 
-    // Two-tier (upgradeable proxy) high-rate payer recognition.
+    // Two-tier (upgradeable proxy) high-rate payer recognition. Admission is
+    // pure (no state provider); tier-B eligibility is driven entirely by the
+    // per-block classifier in `invalidate_limit_class_cache` over synthetic diffs.
 
-    fn upgradeable_validator(
-        payer: Address,
-        payer_account: ExtendedAccount,
-        seeded: &[(Address, ExtendedAccount)],
-        shell_code_hash: B256,
-        impl_code_hash: B256,
-    ) -> TestValidator {
-        let chain_spec = Arc::new(BaseChainSpecBuilder::base_mainnet().cobalt_activated().build());
-        let client = MockEthProvider::<BasePrimitives>::new()
-            .with_chain_spec(Arc::clone(&chain_spec))
-            .with_genesis_block();
-        client.add_account(payer, payer_account);
-        for (address, account) in seeded {
-            client.add_account(*address, account.clone());
-        }
-        let evm_config = BaseEvmConfig::base(Arc::clone(&chain_spec));
-        let inner = EthTransactionValidatorBuilder::new(client, evm_config)
-            .no_shanghai()
-            .no_cancun()
-            .build(InMemoryBlobStore::default());
-        BaseTransactionValidator::with_block_info(inner, BaseL1BlockInfo::default())
-            .with_trusted_upgradeable_proxies(
-                HashSet::from([shell_code_hash]),
-                HashSet::from([impl_code_hash]),
-            )
+    fn upgradeable_validator(shell_code_hash: B256, implementations: AddressSet) -> TestValidator {
+        build_test_validator()
+            .with_trusted_upgradeable_proxies(HashSet::from([shell_code_hash]), implementations)
     }
 
     fn impl_slot_value(implementation: Address) -> U256 {
         U256::from_be_slice(implementation.as_slice())
     }
 
-    #[test]
-    fn high_rate_class_upgradeable_when_impl_slot_points_at_trusted_impl() {
-        let shell_code = bytes!("60016000");
-        let impl_code = bytes!("60026000");
-        let shell_hash = keccak256(shell_code.as_ref());
-        let impl_hash = keccak256(impl_code.as_ref());
-        let payer = Address::repeat_byte(0x11);
-        let implementation = Address::repeat_byte(0x42);
-
-        let payer_account =
-            ExtendedAccount::new(0, U256::ZERO).with_bytecode(shell_code).extend_storage([(
-                Eip8130Contracts::ERC1967_IMPLEMENTATION_SLOT,
-                impl_slot_value(implementation),
-            )]);
-        let impl_account = ExtendedAccount::new(0, U256::ZERO).with_bytecode(impl_code);
-
-        let validator = upgradeable_validator(
-            payer,
-            payer_account,
-            &[(implementation, impl_account)],
-            shell_hash,
-            impl_hash,
-        );
-        let state = validator.client().latest().unwrap();
-        let generation = validator.limit_class_cache_generation();
-        assert_eq!(
-            validator.high_rate_payer_class(payer, Some(shell_hash), &*state, generation),
-            HighRatePayerClass::Upgradeable,
-        );
+    fn shell_commit_diff(
+        payer: Address,
+        shell_hash: B256,
+        code_changed: bool,
+        impl_slot: Option<U256>,
+    ) -> crate::AccountStateDiff {
+        crate::AccountStateDiff {
+            address: payer,
+            balance: None,
+            nonce_changed: false,
+            code_changed,
+            changed_slots: Vec::new(),
+            code_hash: Some(shell_hash),
+            erc1967_impl_slot: impl_slot,
+        }
     }
 
     #[test]
-    fn high_rate_class_none_when_upgradeable_impl_not_trusted() {
-        let shell_code = bytes!("60016000");
-        let impl_code = bytes!("60026000");
-        let shell_hash = keccak256(shell_code.as_ref());
-        let impl_hash = keccak256(impl_code.as_ref());
+    fn high_rate_class_upgradeable_cold_cache_is_none() {
+        let shell_hash = keccak256(bytes!("60016000").as_ref());
+        let impl_addr = Address::repeat_byte(0x42);
         let payer = Address::repeat_byte(0x11);
-        let untrusted_impl = Address::repeat_byte(0x43);
 
-        let payer_account =
-            ExtendedAccount::new(0, U256::ZERO).with_bytecode(shell_code).extend_storage([(
-                Eip8130Contracts::ERC1967_IMPLEMENTATION_SLOT,
-                impl_slot_value(untrusted_impl),
-            )]);
-
-        let validator = upgradeable_validator(payer, payer_account, &[], shell_hash, impl_hash);
-        let state = validator.client().latest().unwrap();
+        let validator = upgradeable_validator(shell_hash, AddressSet::from_iter([impl_addr]));
         let generation = validator.limit_class_cache_generation();
         assert_eq!(
-            validator.high_rate_payer_class(payer, Some(shell_hash), &*state, generation),
+            validator.high_rate_payer_class(payer, Some(shell_hash), generation),
             HighRatePayerClass::None,
         );
     }
 
     #[test]
-    fn high_rate_class_upgradeable_trusts_baked_default_when_slot_zero() {
-        let shell_code = bytes!("60016000");
-        let shell_hash = keccak256(shell_code.as_ref());
-        let impl_hash = keccak256(bytes!("60026000").as_ref());
+    fn commit_classifies_upgradeable_trusted_then_admission_trusts() {
+        let shell_hash = keccak256(bytes!("60016000").as_ref());
+        let impl_addr = Address::repeat_byte(0x42);
         let payer = Address::repeat_byte(0x11);
 
-        let payer_account = ExtendedAccount::new(0, U256::ZERO).with_bytecode(shell_code);
-        let validator = upgradeable_validator(payer, payer_account, &[], shell_hash, impl_hash);
-        let state = validator.client().latest().unwrap();
+        let validator = upgradeable_validator(shell_hash, AddressSet::from_iter([impl_addr]));
+        validator.invalidate_limit_class_cache(&[shell_commit_diff(
+            payer,
+            shell_hash,
+            true,
+            Some(impl_slot_value(impl_addr)),
+        )]);
+
         let generation = validator.limit_class_cache_generation();
         assert_eq!(
-            validator.high_rate_payer_class(payer, Some(shell_hash), &*state, generation),
+            validator.high_rate_payer_class(payer, Some(shell_hash), generation),
             HighRatePayerClass::Upgradeable,
         );
     }
 
     #[test]
-    fn high_rate_class_none_when_impl_slot_is_malformed() {
-        let shell_code = bytes!("60016000");
-        let shell_hash = keccak256(shell_code.as_ref());
-        let impl_hash = keccak256(bytes!("60026000").as_ref());
+    fn commit_classifies_untrusted_impl_as_none() {
+        let shell_hash = keccak256(bytes!("60016000").as_ref());
+        let trusted_impl = Address::repeat_byte(0x42);
+        let untrusted_impl = Address::repeat_byte(0x43);
+        let payer = Address::repeat_byte(0x11);
+
+        let validator = upgradeable_validator(shell_hash, AddressSet::from_iter([trusted_impl]));
+        validator.invalidate_limit_class_cache(&[shell_commit_diff(
+            payer,
+            shell_hash,
+            true,
+            Some(impl_slot_value(untrusted_impl)),
+        )]);
+
+        let generation = validator.limit_class_cache_generation();
+        assert_eq!(
+            validator.high_rate_payer_class(payer, Some(shell_hash), generation),
+            HighRatePayerClass::None,
+        );
+    }
+
+    #[test]
+    fn commit_slot_zero_trusts_baked_default() {
+        let shell_hash = keccak256(bytes!("60016000").as_ref());
+        let payer = Address::repeat_byte(0x11);
+
+        let validator = upgradeable_validator(shell_hash, AddressSet::default());
+        validator.invalidate_limit_class_cache(&[shell_commit_diff(payer, shell_hash, true, None)]);
+
+        let generation = validator.limit_class_cache_generation();
+        assert_eq!(
+            validator.high_rate_payer_class(payer, Some(shell_hash), generation),
+            HighRatePayerClass::Upgradeable,
+        );
+    }
+
+    #[test]
+    fn commit_malformed_slot_is_none() {
+        let shell_hash = keccak256(bytes!("60016000").as_ref());
+        let impl_addr = Address::repeat_byte(0x42);
         let payer = Address::repeat_byte(0x11);
         let malformed = U256::from(1u8) << 200;
 
-        let payer_account = ExtendedAccount::new(0, U256::ZERO)
-            .with_bytecode(shell_code)
-            .extend_storage([(Eip8130Contracts::ERC1967_IMPLEMENTATION_SLOT, malformed)]);
-        let validator = upgradeable_validator(payer, payer_account, &[], shell_hash, impl_hash);
-        let state = validator.client().latest().unwrap();
+        let validator = upgradeable_validator(shell_hash, AddressSet::from_iter([impl_addr]));
+        validator.invalidate_limit_class_cache(&[shell_commit_diff(
+            payer,
+            shell_hash,
+            true,
+            Some(malformed),
+        )]);
+
         let generation = validator.limit_class_cache_generation();
         assert_eq!(
-            validator.high_rate_payer_class(payer, Some(shell_hash), &*state, generation),
+            validator.high_rate_payer_class(payer, Some(shell_hash), generation),
             HighRatePayerClass::None,
         );
     }
 
     #[test]
     fn high_rate_class_immutable_for_canonical_erc1167_clone() {
-        let runtime = Eip8130Contracts::erc1167_proxy_runtime(
+        let code_hash = Eip8130Contracts::erc1167_proxy_code_hash(
             Eip8130Contracts::CANONICAL_HIGH_RATE_PAYER_ACCOUNT,
         );
-        let code_hash = keccak256(runtime);
         let payer = Address::repeat_byte(0x11);
-        let payer_account =
-            ExtendedAccount::new(0, U256::ZERO).with_bytecode(Bytes::copy_from_slice(&runtime));
-        let validator = build_test_validator_with_account(payer, payer_account);
-        let state = validator.client().latest().unwrap();
+        let validator = build_test_validator();
         let generation = validator.limit_class_cache_generation();
         assert_eq!(
-            validator.high_rate_payer_class(payer, Some(code_hash), &*state, generation),
+            validator.high_rate_payer_class(payer, Some(code_hash), generation),
             HighRatePayerClass::Immutable,
         );
     }
@@ -3833,6 +3836,8 @@ mod tests {
             nonce_changed: false,
             code_changed: false,
             changed_slots: vec![Eip8130Contracts::ERC1967_IMPLEMENTATION_SLOT],
+            code_hash: None,
+            erc1967_impl_slot: None,
         }]);
 
         assert!(


### PR DESCRIPTION
Prototype for discussion. Adds a second tier to EIP-8130 high-rate-payer mempool
recognition so a **constrained upgradeable proxy** account can qualify for the
balance-bounded payer book, not just immutable ERC-1167 clones. The two allowlists
default empty, so the new path is dormant and behavior is identical to today until
a shell + implementations are finalized and pinned.

## Problem

Today high-rate trust is single-tier: the payer's own codehash must be the canonical
ERC-1167 clone of a trusted implementation. That is deliberately **free** to check,
the balance/fee check already loaded the payer's `basic_account`, so `bytecode_hash`
is in hand and recognition is an O(1) set lookup with no extra reads. The cost is
rigidity: an upgradeable account can never qualify, and even an immutable one is
frozen to a single implementation forever.

## Design

`high_rate_payer_class` returns `HighRatePayerClass { None, Immutable, Upgradeable }`:

- **Immutable (tier A, unchanged):** codehash is a trusted ERC-1167 clone. Free.
- **Upgradeable (tier B, new):** codehash is a trusted *constrained proxy shell*
  (one that freezes upgrades while locked) whose current ERC-1967 implementation is
  trusted.

**Admission does zero extra state reads** (per review): tier B is a pure in-memory
cache lookup, never an impl-slot `SLOAD`. A cold/unclassified upgradeable payer is
conservatively count-limited, never over-admitted.

**Classification is moved to the once-per-block state-diff path** and computed purely
from data the node already produced for the block (no reads anywhere):

- `AccountStateDiff` carries the account's new `code_hash` and, when the ERC-1967 slot
  changed that block, its new raw value (from the `BundleState` in `collect()`).
- `invalidate_limit_class_cache` classifies trusted shells: slot `0` is the baked
  default (trusted); a well-formed address is checked against the trusted-implementation
  allowlist; a malformed value is untrusted; a code change to a shell is treated as
  creation (baked default). The result is cached and advances the classification
  generation so pending admissions re-evaluate.

Because the diff exposes the implementation only by **address** (the slot value) and the
classifier must not read the implementation account, the inner allowlist is address-keyed
(`trusted_implementation_addresses`) rather than codehash-keyed.

An `Upgradeable` payer additionally watches its ERC-1967 slot (an upgrade demotes
already-admitted txs), and a slot write invalidates/reclassifies its cached class.
EIP-7702-delegated accounts still never qualify.

## Config

`with_trusted_upgradeable_proxies(shell_code_hashes, implementation_addresses)`;
`Eip8130Contracts::ERC1967_IMPLEMENTATION_SLOT` added. Defaults empty (provisional,
like the other Base Sepolia values in `Eip8130Contracts`).

## Known tradeoff

After a cache clear / node restart, an already-locked upgradeable payer with no
subsequent state change stays count-limited until a relevant diff reclassifies it
(safe/conservative). A startup backfill is possible follow-up.

## Testing

`cargo test -p base-execution-txpool --lib` — 205 pass (200+ existing unchanged + new);
`base-common-consensus` 93 pass; clippy + rustfmt clean. New tests: cold-cache is None,
commit classifies trusted then admission trusts, untrusted impl, slot-zero baked default,
malformed slot, immutable tier, impl-slot invalidation.

## Open questions

- Address-based inner allowlist is forced by the no-read constraint (diff carries the
  impl address, not its codehash). Acceptable given CREATE2-deterministic immutable impls?
- Cold-start after restart: acceptable as-is, or add a bounded startup backfill?
- Should the trusted sets be a companion-ERC canonical set (like authenticators) rather
  than node config?
