### PR TITLE
feat(BOP-441): add seize entrypoints to asset + stablecoin V2

### DIFF
--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -38,7 +38,7 @@ jobs:
           - fork: Cobalt
             key: cobalt
             base_anvil_ref: ae7557c4f8602caa1da0be33143bb2504c85b0c8
-            base_std_ref: b0a4f048684c4cd279025bf2ba3aa76c45569fa4
+            base_std_ref: 9423b2e713affc333e387d7b764b6f50d77056f2
     env:
       FORK_NAME: ${{ matrix.fork }}
       FORK_KEY: ${{ matrix.key }}

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -135,8 +135,12 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
             });
         }
 
-        // Inherited IB20 selectors, decoded against the wire surface frozen for this version so
-        // historical forks see exactly the surface they shipped with.
+        // Fall through to inherited IB20 selectors, decoded against the wire surface frozen for this
+        // version. The seize surface (`transferFromSeizableWithMemo`, `burnBlockedWithMemo`, their
+        // getters) and the `SEIZE` pause feature arrived at Cobalt with `AssetV2`. At an earlier
+        // version the frozen surface neither declares those selectors (so they stay
+        // `UnknownFunctionSelector`) nor accepts the `SEIZE` discriminant in the pause path (so it
+        // fails the enum type check with `AbiDecodeFailed`) — byte-for-byte as before Cobalt.
         let call = version.abi().decode(calldata)?;
         let label = call.as_label();
 
@@ -169,6 +173,9 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
             C::MINT_ROLE(_) => B20TokenRole::Mint.id().abi_encode().into(),
             C::BURN_ROLE(_) => B20TokenRole::Burn.id().abi_encode().into(),
             C::BURN_BLOCKED_ROLE(_) => B20TokenRole::BurnBlocked.id().abi_encode().into(),
+            C::TRANSFER_FROM_SEIZABLE_ROLE(_) => {
+                B20TokenRole::TransferFromSeizable.id().abi_encode().into()
+            }
             C::PAUSE_ROLE(_) => B20TokenRole::Pause.id().abi_encode().into(),
             C::UNPAUSE_ROLE(_) => B20TokenRole::Unpause.id().abi_encode().into(),
             C::METADATA_ROLE(_) => B20TokenRole::Metadata.id().abi_encode().into(),
@@ -182,6 +189,9 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
                 B20PolicyType::TransferExecutor.id().abi_encode().into()
             }
             C::MINT_RECEIVER_POLICY(_) => B20PolicyType::MintReceiver.id().abi_encode().into(),
+            C::SEIZABLE_ACCOUNT_POLICY(_) => {
+                B20PolicyType::SeizableAccount.id().abi_encode().into()
+            }
 
             // --- Role reads ---
             C::hasRole(c) => logic.has_role(self, c.role, c.account)?.abi_encode().into(),
@@ -263,6 +273,16 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
             C::burnBlocked(c) => {
                 logic.burn_blocked(self, caller, c.from, c.amount, privileged)?;
                 Bytes::new()
+            }
+            C::burnBlockedWithMemo(c) => {
+                logic.burn_blocked_with_memo(self, caller, c.from, c.amount, c.memo)?;
+                Bytes::new()
+            }
+            C::transferFromSeizableWithMemo(c) => {
+                logic.transfer_from_seizable_with_memo(
+                    self, caller, c.from, c.to, c.amount, c.memo,
+                )?;
+                true.abi_encode().into()
             }
 
             // --- Pause ---

--- a/crates/common/precompiles/src/b20_asset/logic/interface.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/interface.rs
@@ -72,6 +72,34 @@ pub trait Asset<S: AssetAccounting, A: PolicyAccounting> {
         privileged: bool,
     ) -> Result<()>;
 
+    /// Burn-based seize with a memo (`Transfer` -> `Memo` -> `BurnedBlocked`). Introduced at `AssetV2`.
+    /// An admin op with no factory-privileged path, so the role is always enforced.
+    fn burn_blocked_with_memo(
+        &self,
+        _token: &mut B20AssetToken<S, A>,
+        _caller: Address,
+        _from: Address,
+        _amount: U256,
+        _memo: B256,
+    ) -> Result<()> {
+        reject_frozen_selector!()
+    }
+
+    /// Transfer-based seize: reassigns a blocked `from`'s balance to `to`
+    /// (`Transfer` -> `Memo` -> `TransferredFromSeizable`). Introduced at `AssetV2`.
+    /// An admin op with no factory-privileged path, so the role is always enforced.
+    fn transfer_from_seizable_with_memo(
+        &self,
+        _token: &mut B20AssetToken<S, A>,
+        _caller: Address,
+        _from: Address,
+        _to: Address,
+        _amount: U256,
+        _memo: B256,
+    ) -> Result<()> {
+        reject_frozen_selector!()
+    }
+
     /// Pauses the given features.
     fn pause(
         &self,

--- a/crates/common/precompiles/src/b20_asset/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v2.rs
@@ -1710,6 +1710,23 @@ mod tests {
     }
 
     #[test]
+    fn burn_blocked_with_memo_requires_role() {
+        // Uses BURN_BLOCKED_ROLE (not TRANSFER_FROM_SEIZABLE_ROLE), matching legacy `burnBlocked`.
+        let mut tok = token();
+        make_seizable(&mut tok);
+        let err = LOGIC
+            .burn_blocked_with_memo(&mut tok, ADMIN, ALICE, U256::from(1u64), MEMO)
+            .unwrap_err();
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
+                account: ADMIN,
+                neededRole: B20TokenRole::BurnBlocked.id(),
+            })
+        );
+    }
+
+    #[test]
     fn burn_blocked_with_memo_reverts_when_account_not_seizable() {
         let mut tok = token();
         fund(&mut tok, ALICE, U256::from(100u64));

--- a/crates/common/precompiles/src/b20_asset/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v2.rs
@@ -364,6 +364,49 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
             .emit_event(IB20::BurnedBlocked { caller, from, amount }.encode_log_data())
     }
 
+    fn burn_blocked_with_memo(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        caller: Address,
+        from: Address,
+        amount: U256,
+        memo: B256,
+    ) -> Result<()> {
+        B20Guards::ensure_not_paused(token, IB20::PausableFeature::SEIZE)?;
+        B20Guards::ensure_token_role(token, caller, B20TokenRole::BurnBlocked)?;
+        B20Guards::ensure_seizable(token, from)?;
+        self.burn_inner(token, from, amount)?;
+        // `Memo` must immediately follow the `Transfer` (from `burn_inner`), before `BurnedBlocked`.
+        self.emit_memo(token, caller, memo)?;
+        token
+            .accounting_mut()
+            .emit_event(IB20::BurnedBlocked { caller, from, amount }.encode_log_data())
+    }
+
+    fn transfer_from_seizable_with_memo(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        caller: Address,
+        from: Address,
+        to: Address,
+        amount: U256,
+        memo: B256,
+    ) -> Result<()> {
+        B20Guards::ensure_not_paused(token, IB20::PausableFeature::SEIZE)?;
+        B20Guards::ensure_token_role(token, caller, B20TokenRole::TransferFromSeizable)?;
+        // `to != 0` guards against a disguised burn; `from` is not zero-checked (burn-blocked family).
+        if to == Address::ZERO {
+            return Err(BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }));
+        }
+        B20Guards::ensure_seizable(token, from)?;
+        self.move_balance(token, from, to, amount)?;
+        // `Memo` must immediately follow the `Transfer` (from `move_balance`), before the seize event.
+        self.emit_memo(token, caller, memo)?;
+        token.accounting_mut().emit_event(
+            IB20::TransferredFromSeizable { caller, from, to, amount }.encode_log_data(),
+        )
+    }
+
     fn pause(
         &self,
         token: &mut B20AssetToken<S, A>,
@@ -985,6 +1028,7 @@ mod tests {
     const ADMIN: Address = Address::repeat_byte(0xAD);
     const ALICE: Address = Address::repeat_byte(0xA1);
     const BOB: Address = Address::repeat_byte(0xB0);
+    const MEMO: B256 = B256::repeat_byte(0x77);
     const CHAIN_ID: u64 = 8453;
     const LOGIC: AssetV2 = AssetV2;
 
@@ -1517,6 +1561,179 @@ mod tests {
         LOGIC.burn_blocked(&mut tok, ADMIN, ALICE, U256::from(40u64), true).unwrap();
         assert_eq!(tok.accounting().balance_of(ALICE).unwrap(), U256::from(60u64));
         assert_eq!(last_event_sig(&tok), IB20::BurnedBlocked::SIGNATURE_HASH);
+    }
+
+    // --- seize ---
+
+    /// Points `SEIZABLE_ACCOUNT_POLICY` at the always-block policy, making every account seizable.
+    fn make_seizable(tok: &mut Tok) {
+        tok.accounting_mut()
+            .set_policy_id(
+                B20PolicyType::SeizableAccount.id(),
+                PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+            )
+            .unwrap();
+    }
+
+    fn event_sigs(tok: &Tok) -> Vec<B256> {
+        tok.accounting().events.iter().map(|e| e.topics()[0]).collect()
+    }
+
+    #[test]
+    fn transfer_from_seizable_moves_balance_and_emits_transfer_memo_event() {
+        let mut tok = token();
+        fund(&mut tok, ALICE, U256::from(100u64));
+        make_seizable(&mut tok);
+        grant(&mut tok, B20TokenRole::TransferFromSeizable.id(), ADMIN);
+        let supply = tok.accounting().total_supply().unwrap();
+
+        LOGIC
+            .transfer_from_seizable_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(40u64), MEMO)
+            .unwrap();
+
+        assert_eq!(tok.accounting().balance_of(ALICE).unwrap(), U256::from(60u64));
+        assert_eq!(tok.accounting().balance_of(BOB).unwrap(), U256::from(40u64));
+        assert_eq!(tok.accounting().total_supply().unwrap(), supply, "seize is a transfer");
+        assert_eq!(
+            event_sigs(&tok),
+            vec![
+                IB20::Transfer::SIGNATURE_HASH,
+                IB20::Memo::SIGNATURE_HASH,
+                IB20::TransferredFromSeizable::SIGNATURE_HASH,
+            ]
+        );
+    }
+
+    #[test]
+    fn transfer_from_seizable_reverts_when_account_not_seizable() {
+        let mut tok = token();
+        fund(&mut tok, ALICE, U256::from(100u64));
+        grant(&mut tok, B20TokenRole::TransferFromSeizable.id(), ADMIN);
+        // SEIZABLE_ACCOUNT_POLICY unset => ALWAYS_ALLOW => ALICE authorized => not seizable.
+        let err = LOGIC
+            .transfer_from_seizable_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(1u64), MEMO)
+            .unwrap_err();
+        assert_eq!(err, BasePrecompileError::revert(IB20::AccountNotBlocked { account: ALICE }));
+    }
+
+    #[test]
+    fn transfer_from_seizable_reverts_on_zero_receiver() {
+        let mut tok = token();
+        make_seizable(&mut tok);
+        grant(&mut tok, B20TokenRole::TransferFromSeizable.id(), ADMIN);
+        let err = LOGIC
+            .transfer_from_seizable_with_memo(
+                &mut tok,
+                ADMIN,
+                ALICE,
+                Address::ZERO,
+                U256::from(1u64),
+                MEMO,
+            )
+            .unwrap_err();
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20::InvalidReceiver { receiver: Address::ZERO })
+        );
+    }
+
+    #[test]
+    fn transfer_from_seizable_ignores_receiver_policy_on_to() {
+        let mut tok = token();
+        fund(&mut tok, ALICE, U256::from(50u64));
+        make_seizable(&mut tok);
+        grant(&mut tok, B20TokenRole::TransferFromSeizable.id(), ADMIN);
+        // A normal transfer to BOB would revert on this; seize does not consult it.
+        tok.accounting_mut()
+            .set_policy_id(
+                B20PolicyType::TransferReceiver.id(),
+                PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+            )
+            .unwrap();
+        LOGIC
+            .transfer_from_seizable_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(50u64), MEMO)
+            .unwrap();
+        assert_eq!(tok.accounting().balance_of(BOB).unwrap(), U256::from(50u64));
+    }
+
+    #[test]
+    fn transfer_from_seizable_requires_role() {
+        let mut tok = token();
+        make_seizable(&mut tok);
+        let err = LOGIC
+            .transfer_from_seizable_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(1u64), MEMO)
+            .unwrap_err();
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
+                account: ADMIN,
+                neededRole: B20TokenRole::TransferFromSeizable.id(),
+            })
+        );
+    }
+
+    #[test]
+    fn transfer_from_seizable_reverts_when_seize_paused() {
+        let mut tok = token();
+        make_seizable(&mut tok);
+        LOGIC.pause(&mut tok, ADMIN, vec![IB20::PausableFeature::SEIZE], true).unwrap();
+        let err = LOGIC
+            .transfer_from_seizable_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(1u64), MEMO)
+            .unwrap_err();
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20::ContractPaused {
+                feature: IB20::PausableFeature::SEIZE
+            })
+        );
+    }
+
+    #[test]
+    fn burn_blocked_with_memo_destroys_and_emits_transfer_memo_event() {
+        let mut tok = token();
+        fund(&mut tok, ALICE, U256::from(100u64));
+        make_seizable(&mut tok);
+        grant(&mut tok, B20TokenRole::BurnBlocked.id(), ADMIN);
+
+        LOGIC.burn_blocked_with_memo(&mut tok, ADMIN, ALICE, U256::from(40u64), MEMO).unwrap();
+
+        assert_eq!(tok.accounting().balance_of(ALICE).unwrap(), U256::from(60u64));
+        assert_eq!(tok.accounting().total_supply().unwrap(), U256::from(60u64));
+        assert_eq!(
+            event_sigs(&tok),
+            vec![
+                IB20::Transfer::SIGNATURE_HASH,
+                IB20::Memo::SIGNATURE_HASH,
+                IB20::BurnedBlocked::SIGNATURE_HASH,
+            ]
+        );
+    }
+
+    #[test]
+    fn burn_blocked_with_memo_reverts_when_account_not_seizable() {
+        let mut tok = token();
+        fund(&mut tok, ALICE, U256::from(100u64));
+        grant(&mut tok, B20TokenRole::BurnBlocked.id(), ADMIN);
+        let err = LOGIC
+            .burn_blocked_with_memo(&mut tok, ADMIN, ALICE, U256::from(1u64), MEMO)
+            .unwrap_err();
+        assert_eq!(err, BasePrecompileError::revert(IB20::AccountNotBlocked { account: ALICE }));
+    }
+
+    #[test]
+    fn burn_blocked_with_memo_reverts_when_seize_paused() {
+        let mut tok = token();
+        make_seizable(&mut tok);
+        LOGIC.pause(&mut tok, ADMIN, vec![IB20::PausableFeature::SEIZE], true).unwrap();
+        let err = LOGIC
+            .burn_blocked_with_memo(&mut tok, ADMIN, ALICE, U256::from(1u64), MEMO)
+            .unwrap_err();
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20::ContractPaused {
+                feature: IB20::PausableFeature::SEIZE
+            })
+        );
     }
 
     // --- pause ---

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -118,8 +118,12 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> B20StablecoinToken<S, A> {
             });
         }
 
-        // Inherited IB20 selectors, decoded against the wire surface frozen for this version so
-        // historical forks see exactly the surface they shipped with.
+        // Inherited IB20 selectors, decoded against the wire surface frozen for this version. The
+        // seize surface (`transferFromSeizableWithMemo`, `burnBlockedWithMemo`, their getters) and
+        // the `SEIZE` pause feature arrived at Cobalt with `StablecoinV2`. At an earlier version the
+        // frozen surface neither declares those selectors (so they stay `UnknownFunctionSelector`)
+        // nor accepts the `SEIZE` discriminant in the pause path (so it fails the enum type check
+        // with `AbiDecodeFailed`) — byte-for-byte as before Cobalt.
         let call = version.abi().decode(calldata)?;
         let label = call.as_label();
 
@@ -148,6 +152,9 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> B20StablecoinToken<S, A> {
                 C::MINT_ROLE(_) => B20TokenRole::Mint.id().abi_encode().into(),
                 C::BURN_ROLE(_) => B20TokenRole::Burn.id().abi_encode().into(),
                 C::BURN_BLOCKED_ROLE(_) => B20TokenRole::BurnBlocked.id().abi_encode().into(),
+                C::TRANSFER_FROM_SEIZABLE_ROLE(_) => {
+                    B20TokenRole::TransferFromSeizable.id().abi_encode().into()
+                }
                 C::PAUSE_ROLE(_) => B20TokenRole::Pause.id().abi_encode().into(),
                 C::UNPAUSE_ROLE(_) => B20TokenRole::Unpause.id().abi_encode().into(),
                 C::METADATA_ROLE(_) => B20TokenRole::Metadata.id().abi_encode().into(),
@@ -161,6 +168,9 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> B20StablecoinToken<S, A> {
                     B20PolicyType::TransferExecutor.id().abi_encode().into()
                 }
                 C::MINT_RECEIVER_POLICY(_) => B20PolicyType::MintReceiver.id().abi_encode().into(),
+                C::SEIZABLE_ACCOUNT_POLICY(_) => {
+                    B20PolicyType::SeizableAccount.id().abi_encode().into()
+                }
                 C::hasRole(c) => logic.has_role(self, c.role, c.account)?.abi_encode().into(),
                 C::getRoleAdmin(c) => logic.role_admin(self, c.role)?.abi_encode().into(),
                 C::pausedFeatures(_) => logic.paused_features(self)?.abi_encode().into(),
@@ -242,6 +252,18 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> B20StablecoinToken<S, A> {
                     let caller = ctx.caller();
                     logic.burn_blocked(self, caller, c.from, c.amount, privileged)?;
                     Bytes::new()
+                }
+                C::burnBlockedWithMemo(c) => {
+                    let caller = ctx.caller();
+                    logic.burn_blocked_with_memo(self, caller, c.from, c.amount, c.memo)?;
+                    Bytes::new()
+                }
+                C::transferFromSeizableWithMemo(c) => {
+                    let caller = ctx.caller();
+                    logic.transfer_from_seizable_with_memo(
+                        self, caller, c.from, c.to, c.amount, c.memo,
+                    )?;
+                    true.abi_encode().into()
                 }
 
                 C::pause(c) => {

--- a/crates/common/precompiles/src/b20_stablecoin/logic/interface.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/interface.rs
@@ -82,6 +82,34 @@ pub trait Stablecoin<S: StablecoinAccounting, A: PolicyAccounting> {
         privileged: bool,
     ) -> Result<()>;
 
+    /// Burn-based seize with a memo (`Transfer` -> `Memo` -> `BurnedBlocked`). Introduced at `StablecoinV2`.
+    /// An admin op with no factory-privileged path, so the role is always enforced.
+    fn burn_blocked_with_memo(
+        &self,
+        _token: &mut B20StablecoinToken<S, A>,
+        _caller: Address,
+        _from: Address,
+        _amount: U256,
+        _memo: B256,
+    ) -> Result<()> {
+        reject_frozen_selector!()
+    }
+
+    /// Transfer-based seize: reassigns a blocked `from`'s balance to `to`
+    /// (`Transfer` -> `Memo` -> `TransferredFromSeizable`). Introduced at `StablecoinV2`.
+    /// An admin op with no factory-privileged path, so the role is always enforced.
+    fn transfer_from_seizable_with_memo(
+        &self,
+        _token: &mut B20StablecoinToken<S, A>,
+        _caller: Address,
+        _from: Address,
+        _to: Address,
+        _amount: U256,
+        _memo: B256,
+    ) -> Result<()> {
+        reject_frozen_selector!()
+    }
+
     /// Pauses the given features.
     fn pause(
         &self,

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
@@ -329,6 +329,49 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> Stablecoin<S, A> for Stableco
             .emit_event(IB20::BurnedBlocked { caller, from, amount }.encode_log_data())
     }
 
+    fn burn_blocked_with_memo(
+        &self,
+        token: &mut B20StablecoinToken<S, A>,
+        caller: Address,
+        from: Address,
+        amount: U256,
+        memo: B256,
+    ) -> Result<()> {
+        B20Guards::ensure_not_paused(token, IB20::PausableFeature::SEIZE)?;
+        B20Guards::ensure_token_role(token, caller, B20TokenRole::BurnBlocked)?;
+        B20Guards::ensure_seizable(token, from)?;
+        self.burn_inner(token, from, amount)?;
+        // `Memo` must immediately follow the `Transfer` (from `burn_inner`), before `BurnedBlocked`.
+        self.emit_memo(token, caller, memo)?;
+        token
+            .accounting_mut()
+            .emit_event(IB20::BurnedBlocked { caller, from, amount }.encode_log_data())
+    }
+
+    fn transfer_from_seizable_with_memo(
+        &self,
+        token: &mut B20StablecoinToken<S, A>,
+        caller: Address,
+        from: Address,
+        to: Address,
+        amount: U256,
+        memo: B256,
+    ) -> Result<()> {
+        B20Guards::ensure_not_paused(token, IB20::PausableFeature::SEIZE)?;
+        B20Guards::ensure_token_role(token, caller, B20TokenRole::TransferFromSeizable)?;
+        // `to != 0` guards against a disguised burn; `from` is not zero-checked (burn-blocked family).
+        if to == Address::ZERO {
+            return Err(BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }));
+        }
+        B20Guards::ensure_seizable(token, from)?;
+        self.move_balance(token, from, to, amount)?;
+        // `Memo` must immediately follow the `Transfer` (from `move_balance`), before the seize event.
+        self.emit_memo(token, caller, memo)?;
+        token.accounting_mut().emit_event(
+            IB20::TransferredFromSeizable { caller, from, to, amount }.encode_log_data(),
+        )
+    }
+
     fn pause(
         &self,
         token: &mut B20StablecoinToken<S, A>,
@@ -693,6 +736,7 @@ mod tests {
     const ADMIN: Address = Address::repeat_byte(0xAD);
     const ALICE: Address = Address::repeat_byte(0xA1);
     const BOB: Address = Address::repeat_byte(0xB0);
+    const MEMO: B256 = B256::repeat_byte(0x77);
     const CHAIN_ID: u64 = 8453;
     const LOGIC: StablecoinV2 = StablecoinV2;
 
@@ -1227,6 +1271,177 @@ mod tests {
         // Default ALWAYS_ALLOW authorizes ALICE => not blocked.
         let err = LOGIC.burn_blocked(&mut tok, ADMIN, ALICE, U256::from(1u64), true).unwrap_err();
         assert_eq!(err, BasePrecompileError::revert(IB20::AccountNotBlocked { account: ALICE }));
+    }
+
+    // --- seize ---
+
+    /// Points `SEIZABLE_ACCOUNT_POLICY` at the always-block policy, making every account seizable.
+    fn make_seizable(tok: &mut Tok) {
+        tok.accounting_mut()
+            .set_policy_id(
+                B20PolicyType::SeizableAccount.id(),
+                PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+            )
+            .unwrap();
+    }
+
+    fn event_sigs(tok: &Tok) -> Vec<B256> {
+        tok.accounting().events.iter().map(|e| e.topics()[0]).collect()
+    }
+
+    #[test]
+    fn transfer_from_seizable_moves_balance_and_emits_transfer_memo_event() {
+        let mut tok = token();
+        fund(&mut tok, ALICE, U256::from(100u64));
+        make_seizable(&mut tok);
+        grant(&mut tok, B20TokenRole::TransferFromSeizable.id(), ADMIN);
+        let supply = tok.accounting().total_supply().unwrap();
+
+        LOGIC
+            .transfer_from_seizable_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(40u64), MEMO)
+            .unwrap();
+
+        assert_eq!(tok.accounting().balance_of(ALICE).unwrap(), U256::from(60u64));
+        assert_eq!(tok.accounting().balance_of(BOB).unwrap(), U256::from(40u64));
+        assert_eq!(tok.accounting().total_supply().unwrap(), supply, "seize is a transfer");
+        assert_eq!(
+            event_sigs(&tok),
+            vec![
+                IB20::Transfer::SIGNATURE_HASH,
+                IB20::Memo::SIGNATURE_HASH,
+                IB20::TransferredFromSeizable::SIGNATURE_HASH,
+            ]
+        );
+    }
+
+    #[test]
+    fn transfer_from_seizable_reverts_when_account_not_seizable() {
+        let mut tok = token();
+        fund(&mut tok, ALICE, U256::from(100u64));
+        grant(&mut tok, B20TokenRole::TransferFromSeizable.id(), ADMIN);
+        let err = LOGIC
+            .transfer_from_seizable_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(1u64), MEMO)
+            .unwrap_err();
+        assert_eq!(err, BasePrecompileError::revert(IB20::AccountNotBlocked { account: ALICE }));
+    }
+
+    #[test]
+    fn transfer_from_seizable_reverts_on_zero_receiver() {
+        let mut tok = token();
+        make_seizable(&mut tok);
+        grant(&mut tok, B20TokenRole::TransferFromSeizable.id(), ADMIN);
+        let err = LOGIC
+            .transfer_from_seizable_with_memo(
+                &mut tok,
+                ADMIN,
+                ALICE,
+                Address::ZERO,
+                U256::from(1u64),
+                MEMO,
+            )
+            .unwrap_err();
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20::InvalidReceiver { receiver: Address::ZERO })
+        );
+    }
+
+    #[test]
+    fn transfer_from_seizable_ignores_receiver_policy_on_to() {
+        let mut tok = token();
+        fund(&mut tok, ALICE, U256::from(50u64));
+        make_seizable(&mut tok);
+        grant(&mut tok, B20TokenRole::TransferFromSeizable.id(), ADMIN);
+        tok.accounting_mut()
+            .set_policy_id(
+                B20PolicyType::TransferReceiver.id(),
+                PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+            )
+            .unwrap();
+        LOGIC
+            .transfer_from_seizable_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(50u64), MEMO)
+            .unwrap();
+        assert_eq!(tok.accounting().balance_of(BOB).unwrap(), U256::from(50u64));
+    }
+
+    #[test]
+    fn transfer_from_seizable_requires_role() {
+        let mut tok = token();
+        make_seizable(&mut tok);
+        let err = LOGIC
+            .transfer_from_seizable_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(1u64), MEMO)
+            .unwrap_err();
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
+                account: ADMIN,
+                neededRole: B20TokenRole::TransferFromSeizable.id(),
+            })
+        );
+    }
+
+    #[test]
+    fn transfer_from_seizable_reverts_when_seize_paused() {
+        let mut tok = token();
+        make_seizable(&mut tok);
+        LOGIC.pause(&mut tok, ADMIN, vec![IB20::PausableFeature::SEIZE], true).unwrap();
+        let err = LOGIC
+            .transfer_from_seizable_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(1u64), MEMO)
+            .unwrap_err();
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20::ContractPaused {
+                feature: IB20::PausableFeature::SEIZE
+            })
+        );
+    }
+
+    #[test]
+    fn burn_blocked_with_memo_destroys_and_emits_transfer_memo_event() {
+        let mut tok = token();
+        fund(&mut tok, ALICE, U256::from(100u64));
+        make_seizable(&mut tok);
+        grant(&mut tok, B20TokenRole::BurnBlocked.id(), ADMIN);
+
+        LOGIC.burn_blocked_with_memo(&mut tok, ADMIN, ALICE, U256::from(40u64), MEMO).unwrap();
+
+        assert_eq!(tok.accounting().balance_of(ALICE).unwrap(), U256::from(60u64));
+        assert_eq!(tok.accounting().total_supply().unwrap(), U256::from(60u64));
+        assert_eq!(
+            event_sigs(&tok),
+            vec![
+                IB20::Transfer::SIGNATURE_HASH,
+                IB20::Memo::SIGNATURE_HASH,
+                IB20::BurnedBlocked::SIGNATURE_HASH,
+            ]
+        );
+    }
+
+    #[test]
+    fn burn_blocked_with_memo_reverts_when_account_not_seizable() {
+        let mut tok = token();
+        fund(&mut tok, ALICE, U256::from(100u64));
+        grant(&mut tok, B20TokenRole::BurnBlocked.id(), ADMIN);
+        let err = LOGIC
+            .burn_blocked_with_memo(&mut tok, ADMIN, ALICE, U256::from(1u64), MEMO)
+            .unwrap_err();
+        assert_eq!(err, BasePrecompileError::revert(IB20::AccountNotBlocked { account: ALICE }));
+    }
+
+    #[test]
+    fn burn_blocked_with_memo_reverts_when_seize_paused() {
+        let mut tok = token();
+        make_seizable(&mut tok);
+        LOGIC.pause(&mut tok, ADMIN, vec![IB20::PausableFeature::SEIZE], true).unwrap();
+        let err = LOGIC
+            .burn_blocked_with_memo(&mut tok, ADMIN, ALICE, U256::from(1u64), MEMO)
+            .unwrap_err();
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20::ContractPaused {
+                feature: IB20::PausableFeature::SEIZE
+            })
+        );
     }
 
     // --- pause ---

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
@@ -1418,6 +1418,23 @@ mod tests {
     }
 
     #[test]
+    fn burn_blocked_with_memo_requires_role() {
+        // Uses BURN_BLOCKED_ROLE (not TRANSFER_FROM_SEIZABLE_ROLE), matching legacy `burnBlocked`.
+        let mut tok = token();
+        make_seizable(&mut tok);
+        let err = LOGIC
+            .burn_blocked_with_memo(&mut tok, ADMIN, ALICE, U256::from(1u64), MEMO)
+            .unwrap_err();
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
+                account: ADMIN,
+                neededRole: B20TokenRole::BurnBlocked.id(),
+            })
+        );
+    }
+
+    #[test]
     fn burn_blocked_with_memo_reverts_when_account_not_seizable() {
         let mut tok = token();
         fund(&mut tok, ALICE, U256::from(100u64));

--- a/crates/common/precompiles/src/b20_stablecoin/mod.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/mod.rs
@@ -1,5 +1,25 @@
 //! `B20StablecoinToken` native precompile — stablecoin variant of the B-20 token.
 
+/// Rejects a call as an unknown selector, freezing the observable behavior of every version that
+/// predates the selector.
+///
+/// V2-only selectors (the seize surface) live as **shared trait defaults** on [`Stablecoin`], so
+/// each version inherits these bodies until it explicitly overrides them. A version introduced
+/// *before* a selector existed must reject it exactly as it did at its activation fork; returning
+/// `UnknownFunctionSelector` keeps re-executing a historical block on a newer binary
+/// byte-identical to what the chain already committed.
+///
+/// The `[0u8; 4]` is a placeholder: the dispatcher rejects these selectors on the raw calldata,
+/// before any version method is reached (see the fork gate in `route`), so a reachable call never
+/// actually returns this value. Pinned by `golden_v2_selectors_unknown_at_v1`.
+macro_rules! reject_frozen_selector {
+    () => {
+        ::core::result::Result::Err(
+            ::base_precompile_storage::BasePrecompileError::UnknownFunctionSelector([0u8; 4]),
+        )
+    };
+}
+
 mod abi;
 pub use abi::IB20Stablecoin;
 

--- a/crates/common/precompiles/src/common/abi/mod.rs
+++ b/crates/common/precompiles/src/common/abi/mod.rs
@@ -1,16 +1,17 @@
 //! Versioned wire (ABI) surfaces for the shared `IB20` interface, one per hardfork that moved them.
 //!
 //! `IB20` is shared by the asset and stablecoin B-20 precompiles and is unversioned in Solidity,
-//! but the wire it accepts need not be frozen forever: a hardfork may widen a `sol!` enum or add
-//! selectors. A widened enum is decoded *before* version dispatch, so — unlike a brand-new selector,
-//! which a caller cannot dial until a surface declares it — a new enum discriminant would otherwise
-//! decode against the canonical surface at every historical fork. Freezing the surface each fork
-//! shipped, and decoding calldata against the surface active at the block's fork, keeps historical
-//! behavior byte-for-byte stable.
+//! but the wire it accepts is not: Cobalt widened `PausableFeature` with a `SEIZE` variant and
+//! added the seize functions/getters. Unlike a new selector — which a caller cannot dial before the
+//! surface declares it — a widened `sol!` enum is decoded *before* version dispatch, so at Beryl a
+//! `pause`/`unpause`/`isPaused` carrying the `SEIZE` discriminant would silently decode against the
+//! canonical surface and diverge from the frozen v1 behavior. Freezing the Beryl surface here and
+//! decoding pre-Cobalt calldata against it closes that gap, the same way the selector gate closes it
+//! for the seize functions.
 //!
 //! The latest surface is always named `IB20` in its `vN` module, then re-exported here as both
-//! [`IB20`] (canonical) and the highest `IB20VN`. Older forks keep the same `IB20` Rust name inside
-//! their module so truncated-calldata revert bytes stay stable, and are re-exported as [`IB20V1`].
+//! [`IB20`] (canonical) and [`IB20V2`]. Older forks keep the same `IB20` Rust name inside their
+//! module so truncated-calldata revert bytes stay stable, and are re-exported as [`IB20V1`].
 //!
 //! Both surfaces are reached only through [`B20Abi`], selected per version by the asset/stablecoin
 //! version resolvers (`AssetVersion::abi` / `StablecoinVersion::abi`).
@@ -43,6 +44,7 @@ impl IB20::IB20Calls {
             Self::MINT_ROLE(_) => "precompile-b20-MINT_ROLE",
             Self::BURN_ROLE(_) => "precompile-b20-BURN_ROLE",
             Self::BURN_BLOCKED_ROLE(_) => "precompile-b20-BURN_BLOCKED_ROLE",
+            Self::TRANSFER_FROM_SEIZABLE_ROLE(_) => "precompile-b20-TRANSFER_FROM_SEIZABLE_ROLE",
             Self::PAUSE_ROLE(_) => "precompile-b20-PAUSE_ROLE",
             Self::UNPAUSE_ROLE(_) => "precompile-b20-UNPAUSE_ROLE",
             Self::METADATA_ROLE(_) => "precompile-b20-METADATA_ROLE",
@@ -50,6 +52,7 @@ impl IB20::IB20Calls {
             Self::TRANSFER_RECEIVER_POLICY(_) => "precompile-b20-TRANSFER_RECEIVER_POLICY",
             Self::TRANSFER_EXECUTOR_POLICY(_) => "precompile-b20-TRANSFER_EXECUTOR_POLICY",
             Self::MINT_RECEIVER_POLICY(_) => "precompile-b20-MINT_RECEIVER_POLICY",
+            Self::SEIZABLE_ACCOUNT_POLICY(_) => "precompile-b20-SEIZABLE_ACCOUNT_POLICY",
             Self::hasRole(_) => "precompile-b20-hasRole",
             Self::getRoleAdmin(_) => "precompile-b20-getRoleAdmin",
             Self::pausedFeatures(_) => "precompile-b20-pausedFeatures",
@@ -67,6 +70,8 @@ impl IB20::IB20Calls {
             Self::burn(_) => "precompile-b20-burn",
             Self::burnWithMemo(_) => "precompile-b20-burnWithMemo",
             Self::burnBlocked(_) => "precompile-b20-burnBlocked",
+            Self::burnBlockedWithMemo(_) => "precompile-b20-burnBlockedWithMemo",
+            Self::transferFromSeizableWithMemo(_) => "precompile-b20-transferFromSeizableWithMemo",
             Self::pause(_) => "precompile-b20-pause",
             Self::unpause(_) => "precompile-b20-unpause",
             Self::updateSupplyCap(_) => "precompile-b20-updateSupplyCap",
@@ -88,9 +93,9 @@ impl IB20::IB20Calls {
 /// [`AssetVersion::abi`](crate::AssetVersion) / [`StablecoinVersion::abi`](crate::StablecoinVersion).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum B20Abi {
-    /// Earlier frozen wire surface.
+    /// Wire surface frozen at Beryl (no seize surface; `PausableFeature` has three variants).
     V1,
-    /// Canonical (current) wire surface.
+    /// Wire surface activated at Cobalt (adds the seize surface and the `SEIZE` pause feature).
     V2,
 }
 
@@ -104,8 +109,9 @@ impl B20Abi {
     }
 
     /// Validates `calldata` against this wire surface via alloy's `abi_decode_validate`, discarding
-    /// the decoded call. Decoding against the frozen surface is what keeps an enum discriminant a
-    /// later fork added from being accepted at an earlier fork.
+    /// the decoded call. This is where the frozen V1 surface rejects the `SEIZE` discriminant: its
+    /// `PausableFeature` has no index 3, so the enum type check fails and the call reverts with
+    /// `AbiDecodeFailed` exactly as it did before Cobalt.
     pub fn abi_decode_validate(self, calldata: &[u8], selector: [u8; 4]) -> Result<()> {
         match self {
             Self::V1 => IB20V1::IB20Calls::abi_decode_validate(calldata).map(|_| ()),
@@ -119,9 +125,10 @@ impl B20Abi {
 
     /// Decodes `calldata` into a routable canonical call, gated on this wire surface.
     ///
-    /// A selector absent from this surface returns `UnknownFunctionSelector`; a present selector is
-    /// validated against the frozen surface first and only then re-decoded against the canonical
-    /// surface so the caller matches on one call type across versions.
+    /// A selector absent from this surface (the seize selectors at V1) returns
+    /// `UnknownFunctionSelector`; a present selector is validated against the frozen surface first
+    /// (rejecting e.g. the `SEIZE` discriminant at V1) and only then re-decoded against the
+    /// canonical surface so the caller matches on one call type across versions.
     pub fn decode(self, calldata: &[u8]) -> Result<IB20::IB20Calls> {
         let Some(selector) = calldata.first_chunk::<4>().copied() else {
             return Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]));
@@ -139,10 +146,13 @@ impl B20Abi {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{Address, U256};
-    use alloy_sol_types::SolInterface;
+    use alloc::vec::Vec;
 
-    use super::{IB20, IB20V1, IB20V2};
+    use alloy_primitives::{Address, U256};
+    use alloy_sol_types::{SolCall, SolInterface};
+    use base_precompile_storage::BasePrecompileError;
+
+    use super::{B20Abi, IB20, IB20V1, IB20V2};
 
     #[test]
     fn b20_call_labels_are_stable() {
@@ -162,7 +172,7 @@ mod tests {
 
     /// `SolInterface::NAME` lands in consensus data: the short-calldata branch of
     /// `abi_decode_validate` builds its error from it, and `AbiDecodeFailed` puts that string on the
-    /// wire. Every frozen surface must keep the `IB20` Rust name.
+    /// wire. Both frozen surfaces must keep the `IB20` Rust name.
     #[test]
     fn surface_interface_names_are_frozen() {
         assert_eq!(IB20V1::IB20Calls::NAME, "IB20Calls");
@@ -175,5 +185,62 @@ mod tests {
     #[test]
     fn surfaces_share_a_minimum_calldata_length() {
         assert_eq!(IB20V1::IB20Calls::MIN_DATA_LENGTH, IB20V2::IB20Calls::MIN_DATA_LENGTH);
+    }
+
+    /// The dispatcher re-decodes against the canonical surface after a frozen surface accepts, so
+    /// every V1 selector must exist on canonical. The difference is exactly the seize surface Cobalt
+    /// introduced.
+    #[test]
+    fn v1_selectors_are_a_subset_of_v2() {
+        for selector in IB20V1::IB20Calls::selectors() {
+            assert!(
+                B20Abi::V2.valid_selector(selector),
+                "V1 selector {selector:?} missing from the V2 surface"
+            );
+        }
+
+        let added: Vec<[u8; 4]> = IB20V2::IB20Calls::selectors()
+            .filter(|selector| !B20Abi::V1.valid_selector(*selector))
+            .collect();
+        assert_eq!(added.len(), 4);
+        assert!(added.contains(&IB20::burnBlockedWithMemoCall::SELECTOR));
+        assert!(added.contains(&IB20::transferFromSeizableWithMemoCall::SELECTOR));
+        assert!(added.contains(&IB20::TRANSFER_FROM_SEIZABLE_ROLECall::SELECTOR));
+        assert!(added.contains(&IB20::SEIZABLE_ACCOUNT_POLICYCall::SELECTOR));
+    }
+
+    /// The seize surface was not dialable at Beryl, so the V1 surface must not know its selectors.
+    /// This is what replaces a hand-written fork gate in dispatch.
+    #[test]
+    fn v1_surface_rejects_seize_selectors() {
+        for selector in [
+            IB20::burnBlockedWithMemoCall::SELECTOR,
+            IB20::transferFromSeizableWithMemoCall::SELECTOR,
+            IB20::TRANSFER_FROM_SEIZABLE_ROLECall::SELECTOR,
+            IB20::SEIZABLE_ACCOUNT_POLICYCall::SELECTOR,
+        ] {
+            assert!(!B20Abi::V1.valid_selector(selector));
+            assert!(B20Abi::V2.valid_selector(selector));
+        }
+    }
+
+    /// The bug this module fixes. `pause`/`unpause`/`isPaused` keep their selectors across the
+    /// Cobalt widening, so only decoding against Beryl's own surface rejects the `SEIZE`
+    /// discriminant. At V1 it must fail decode; at V2 it decodes to the `SEIZE` feature.
+    #[test]
+    fn v1_rejects_seize_discriminant_in_pause_path() {
+        let is_paused = IB20::isPausedCall { feature: IB20::PausableFeature::SEIZE }.abi_encode();
+        let pause =
+            IB20::pauseCall { features: alloc::vec![IB20::PausableFeature::SEIZE] }.abi_encode();
+
+        for calldata in [is_paused, pause] {
+            // V1 rejects the discriminant at decode.
+            assert!(matches!(
+                B20Abi::V1.decode(&calldata),
+                Err(BasePrecompileError::AbiDecodeFailed { .. })
+            ));
+            // V2 accepts it and yields a routable canonical call.
+            assert!(B20Abi::V2.decode(&calldata).is_ok());
+        }
     }
 }

--- a/crates/common/precompiles/src/common/abi/v2.rs
+++ b/crates/common/precompiles/src/common/abi/v2.rs
@@ -1,8 +1,9 @@
-//! The shared `IB20` wire surface — the canonical live surface, re-exported unqualified by
-//! [`super`]. This is the surface a caller reaches today.
+//! The shared `IB20` wire surface frozen at Cobalt, which added the seize surface
+//! (`burnBlockedWithMemo`, `transferFromSeizableWithMemo`, their getters, the `SEIZE` pause
+//! feature, and the `TransferredFromSeizable` event). Also the canonical live surface, re-exported
+//! unqualified by [`super`].
 //!
-//! A hardfork that moves the wire freezes the prior surface in a new `abi/vN.rs` and grows this one;
-//! see [`super`].
+//! A new wire surface goes in a new `abi/vN.rs`; see [`super`].
 
 use alloy_sol_types::sol;
 
@@ -15,7 +16,10 @@ sol! {
             /// Mint operations.
             MINT,
             /// Burn operations.
-            BURN
+            BURN,
+            /// Seize operations (`burnBlockedWithMemo`, `transferFromSeizableWithMemo`). Legacy
+            /// `burnBlocked` still gates on `BURN` until it is repointed in a future PR.
+            SEIZE
         }
 
         // Errors
@@ -70,6 +74,7 @@ sol! {
         function MINT_ROLE() external view returns (bytes32);
         function BURN_ROLE() external view returns (bytes32);
         function BURN_BLOCKED_ROLE() external view returns (bytes32);
+        function TRANSFER_FROM_SEIZABLE_ROLE() external view returns (bytes32);
         function PAUSE_ROLE() external view returns (bytes32);
         function UNPAUSE_ROLE() external view returns (bytes32);
         function METADATA_ROLE() external view returns (bytes32);
@@ -79,6 +84,7 @@ sol! {
         function TRANSFER_RECEIVER_POLICY() external view returns (bytes32);
         function TRANSFER_EXECUTOR_POLICY() external view returns (bytes32);
         function MINT_RECEIVER_POLICY() external view returns (bytes32);
+        function SEIZABLE_ACCOUNT_POLICY() external view returns (bytes32);
 
         // ERC-20
         function name() external view returns (string);
@@ -105,6 +111,8 @@ sol! {
         function burn(uint256 amount) external;
         function burnWithMemo(uint256 amount, bytes32 memo) external;
         function burnBlocked(address from, uint256 amount) external;
+        function burnBlockedWithMemo(address from, uint256 amount, bytes32 memo) external;
+        function transferFromSeizableWithMemo(address from, address to, uint256 amount, bytes32 memo) external returns (bool);
 
         // Roles
         function hasRole(bytes32 role, address account) external view returns (bool);
@@ -143,7 +151,7 @@ sol! {
 
 #[cfg(test)]
 mod tests {
-    use alloy_sol_types::{SolEnum, SolInterface};
+    use alloy_sol_types::{SolCall, SolEnum, SolInterface};
 
     use super::IB20;
 
@@ -154,10 +162,20 @@ mod tests {
         assert_eq!(IB20::IB20Calls::NAME, "IB20Calls");
     }
 
-    /// The current `PausableFeature` variant count. A widening fork bumps this in a new surface
-    /// while the frozen surfaces keep their own count.
+    /// Cobalt's `PausableFeature` carries the `SEIZE` variant. A `sol!` enum arg is decoded before
+    /// version dispatch, so this discriminant is exactly what the V1 surface must reject.
     #[test]
-    fn pausable_feature_variant_count() {
-        assert_eq!(IB20::PausableFeature::COUNT, 3);
+    fn pausable_feature_carries_seize() {
+        assert_eq!(IB20::PausableFeature::COUNT, 4);
+        assert_eq!(IB20::PausableFeature::try_from(3u8), Ok(IB20::PausableFeature::SEIZE));
+    }
+
+    /// The seize surface is dialable at Cobalt.
+    #[test]
+    fn seize_selectors_present() {
+        assert!(IB20::IB20Calls::valid_selector(IB20::burnBlockedWithMemoCall::SELECTOR));
+        assert!(IB20::IB20Calls::valid_selector(IB20::transferFromSeizableWithMemoCall::SELECTOR));
+        assert!(IB20::IB20Calls::valid_selector(IB20::TRANSFER_FROM_SEIZABLE_ROLECall::SELECTOR));
+        assert!(IB20::IB20Calls::valid_selector(IB20::SEIZABLE_ACCOUNT_POLICYCall::SELECTOR));
     }
 }

--- a/crates/common/precompiles/src/common/pausable_feature.rs
+++ b/crates/common/precompiles/src/common/pausable_feature.rs
@@ -15,7 +15,8 @@ impl B20PausableFeature {
         match feature {
             IB20::PausableFeature::TRANSFER
             | IB20::PausableFeature::MINT
-            | IB20::PausableFeature::BURN => Ok(()),
+            | IB20::PausableFeature::BURN
+            | IB20::PausableFeature::SEIZE => Ok(()),
             IB20::PausableFeature::__Invalid => Err(BasePrecompileError::enum_conversion_error()),
         }
     }

--- a/crates/common/precompiles/tests/b20_asset_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v1_golden.rs
@@ -24,12 +24,12 @@
 //!    --test b20_asset_v1_golden -- --nocapture` and copy the printed `GOLDEN_ROOT` values.
 
 use alloy_primitives::{Address, B256, Bytes, U256, b256, keccak256};
-use alloy_sol_types::{SolCall, SolError, SolEvent, SolValue};
+use alloy_sol_types::{SolCall, SolError, SolEvent, SolInterface, SolValue};
 use base_common_genesis::BaseUpgrade;
 use base_common_precompiles::{
     Asset, AssetAccounting, AssetV1, AssetVersion, AssetVersions, B20_MAX_SUPPLY_CAP, B20AssetInit,
     B20AssetStorage, B20AssetToken, B20PolicyType, B20TokenRole, FakePolicyAccounting, IB20,
-    IB20Asset, NoopPrecompileCallObserver, PolicyVersion, TokenAccounting,
+    IB20Asset, IB20V1, NoopPrecompileCallObserver, PolicyVersion, TokenAccounting,
 };
 use base_precompile_storage::{BasePrecompileError, HashMapStorageProvider, StorageCtx};
 
@@ -268,6 +268,60 @@ fn golden_v2_selectors_unknown_at_v1() {
         let selector: [u8; 4] = calldata[..4].try_into().unwrap();
         let err = op(&mut s, ALICE, FakePolicyAccounting::new(), calldata).unwrap_err();
         assert_eq!(err, BasePrecompileError::UnknownFunctionSelector(selector));
+    }
+}
+
+/// The seize surface (shared `IB20` selectors) was introduced at V2 (Cobalt); on the frozen V1
+/// (Beryl) these selectors are version-gated and stay unknown.
+#[test]
+fn golden_seize_selectors_unknown_at_v1() {
+    let mut s = fresh();
+    let calls: Vec<Vec<u8>> = vec![
+        IB20::TRANSFER_FROM_SEIZABLE_ROLECall {}.abi_encode(),
+        IB20::SEIZABLE_ACCOUNT_POLICYCall {}.abi_encode(),
+        IB20::burnBlockedWithMemoCall { from: ALICE, amount: u(1), memo: B256::ZERO }.abi_encode(),
+        IB20::transferFromSeizableWithMemoCall {
+            from: ALICE,
+            to: BOB,
+            amount: u(1),
+            memo: B256::ZERO,
+        }
+        .abi_encode(),
+    ];
+    for calldata in calls {
+        let selector: [u8; 4] = calldata[..4].try_into().unwrap();
+        let err = op(&mut s, ALICE, FakePolicyAccounting::new(), calldata).unwrap_err();
+        assert_eq!(err, BasePrecompileError::UnknownFunctionSelector(selector));
+    }
+}
+
+/// Recomputes the frozen V1 revert for `calldata` by decoding it against the pre-seize `IB20`
+/// surface (`IB20V1`). The `SEIZE` pause discriminant (index 3) is out of range there, so the enum
+/// type check fails and the call reverts with `AbiDecodeFailed` — the exact pre-Cobalt behavior.
+fn frozen_v1_seize_discriminant_error(calldata: &[u8]) -> BasePrecompileError {
+    let selector: [u8; 4] = calldata[..4].try_into().unwrap();
+    let Err(error) = IB20V1::IB20Calls::abi_decode_validate(calldata) else {
+        panic!("pre-seize IB20 surface must reject the SEIZE discriminant");
+    };
+    BasePrecompileError::AbiDecodeFailed { selector, error: error.to_string() }
+}
+
+/// The bug this change fixes. `pause`/`unpause`/`isPaused` keep their selectors across the Cobalt
+/// widening of `PausableFeature`, so a `SEIZE` discriminant (index 3) is only rejected by decoding
+/// against Beryl's own surface. At V1 it must fail ABI decoding, exactly as it did before the shared
+/// enum grew — not decode to a live feature and mutate state.
+#[test]
+fn golden_pause_path_rejects_seize_discriminant_at_v1() {
+    let calls: Vec<Vec<u8>> = vec![
+        IB20::pauseCall { features: vec![IB20::PausableFeature::SEIZE] }.abi_encode(),
+        IB20::unpauseCall { features: vec![IB20::PausableFeature::SEIZE] }.abi_encode(),
+        IB20::isPausedCall { feature: IB20::PausableFeature::SEIZE }.abi_encode(),
+    ];
+    for calldata in calls {
+        let mut s = fresh();
+        let err = op(&mut s, ALICE, FakePolicyAccounting::new(), calldata.clone()).unwrap_err();
+        assert_eq!(err, frozen_v1_seize_discriminant_error(&calldata));
+        assert!(matches!(err, BasePrecompileError::AbiDecodeFailed { .. }));
     }
 }
 
@@ -2661,16 +2715,25 @@ fn v1_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Asset::IB20AssetCall
             golden_burn_blocked_unprivileged_requires_role,
         ]),
 
+        // Seize surface (shared IB20 selectors): introduced at V2 (Cobalt). On the frozen V1
+        // (Beryl) these are version-gated and stay unknown.
+        C::burnBlockedWithMemo(_)
+        | C::transferFromSeizableWithMemo(_)
+        | C::TRANSFER_FROM_SEIZABLE_ROLE(_)
+        | C::SEIZABLE_ACCOUNT_POLICY(_) => covered(&[golden_seize_selectors_unknown_at_v1]),
+
         // pause / config / roles / policy / permit
         C::pause(_) => covered(&[
             golden_pause_sets_feature_bit,
             golden_pause_reverts_empty_feature_set,
             golden_pause_unprivileged_requires_role,
+            golden_pause_path_rejects_seize_discriminant_at_v1,
         ]),
         C::unpause(_) => covered(&[
             golden_unpause_clears_feature_bit,
             golden_unpause_reverts_empty_feature_set,
             golden_unpause_unprivileged_requires_role,
+            golden_pause_path_rejects_seize_discriminant_at_v1,
         ]),
         C::updateSupplyCap(_) => covered(&[
             golden_update_supply_cap,
@@ -2724,9 +2787,10 @@ fn v1_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Asset::IB20AssetCall
         ]),
 
         // computed reads
-        C::isPaused(_) | C::pausedFeatures(_) => {
-            covered(&[golden_read_is_paused_and_paused_features])
-        }
+        C::isPaused(_) | C::pausedFeatures(_) => covered(&[
+            golden_read_is_paused_and_paused_features,
+            golden_pause_path_rejects_seize_discriminant_at_v1,
+        ]),
         C::policyId(_) => covered(&[golden_read_policy_id_and_unsupported_scope]),
         C::DOMAIN_SEPARATOR(_) => covered(&[golden_read_domain_separator]),
         C::eip712Domain(_) => covered(&[golden_read_eip712_domain]),

--- a/crates/common/precompiles/tests/b20_stablecoin_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_stablecoin_v1_golden.rs
@@ -20,11 +20,11 @@
 //!    --test b20_stablecoin_v1_golden -- --nocapture` and copy the printed `GOLDEN_ROOT` values.
 
 use alloy_primitives::{Address, B256, Bytes, U256, b256};
-use alloy_sol_types::{SolCall, SolError, SolEvent, SolValue};
+use alloy_sol_types::{SolCall, SolError, SolEvent, SolInterface, SolValue};
 use base_common_genesis::BaseUpgrade;
 use base_common_precompiles::{
     B20_MAX_SUPPLY_CAP, B20PolicyType, B20StablecoinInit, B20StablecoinStorage, B20StablecoinToken,
-    B20TokenRole, FakePolicyAccounting, IB20, IB20Stablecoin, NoopPrecompileCallObserver,
+    B20TokenRole, FakePolicyAccounting, IB20, IB20Stablecoin, IB20V1, NoopPrecompileCallObserver,
     PolicyVersion, Stablecoin, StablecoinV1, StablecoinVersion, StablecoinVersions,
     TokenAccounting,
 };
@@ -2005,6 +2005,60 @@ fn golden_gas_footprints() {
     bless_or_assert_gas(&actual, expected);
 }
 
+/// The seize surface (shared `IB20` selectors) was introduced at V2 (Cobalt); on the frozen V1
+/// (Beryl) these selectors are version-gated and stay unknown.
+#[test]
+fn golden_seize_selectors_unknown_at_v1() {
+    let mut s = fresh();
+    let calls: Vec<Vec<u8>> = vec![
+        IB20::TRANSFER_FROM_SEIZABLE_ROLECall {}.abi_encode(),
+        IB20::SEIZABLE_ACCOUNT_POLICYCall {}.abi_encode(),
+        IB20::burnBlockedWithMemoCall { from: ALICE, amount: u(1), memo: B256::ZERO }.abi_encode(),
+        IB20::transferFromSeizableWithMemoCall {
+            from: ALICE,
+            to: BOB,
+            amount: u(1),
+            memo: B256::ZERO,
+        }
+        .abi_encode(),
+    ];
+    for calldata in calls {
+        let selector: [u8; 4] = calldata[..4].try_into().unwrap();
+        let err = op(&mut s, ALICE, FakePolicyAccounting::new(), calldata).unwrap_err();
+        assert_eq!(err, BasePrecompileError::UnknownFunctionSelector(selector));
+    }
+}
+
+/// Recomputes the frozen V1 revert for `calldata` by decoding it against the pre-seize `IB20`
+/// surface (`IB20V1`). The `SEIZE` pause discriminant (index 3) is out of range there, so the enum
+/// type check fails and the call reverts with `AbiDecodeFailed` — the exact pre-Cobalt behavior.
+fn frozen_v1_seize_discriminant_error(calldata: &[u8]) -> BasePrecompileError {
+    let selector: [u8; 4] = calldata[..4].try_into().unwrap();
+    let Err(error) = IB20V1::IB20Calls::abi_decode_validate(calldata) else {
+        panic!("pre-seize IB20 surface must reject the SEIZE discriminant");
+    };
+    BasePrecompileError::AbiDecodeFailed { selector, error: error.to_string() }
+}
+
+/// The bug this change fixes. `pause`/`unpause`/`isPaused` keep their selectors across the Cobalt
+/// widening of `PausableFeature`, so a `SEIZE` discriminant (index 3) is only rejected by decoding
+/// against Beryl's own surface. At V1 it must fail ABI decoding, exactly as it did before the shared
+/// enum grew — not decode to a live feature and mutate state.
+#[test]
+fn golden_pause_path_rejects_seize_discriminant_at_v1() {
+    let calls: Vec<Vec<u8>> = vec![
+        IB20::pauseCall { features: vec![IB20::PausableFeature::SEIZE] }.abi_encode(),
+        IB20::unpauseCall { features: vec![IB20::PausableFeature::SEIZE] }.abi_encode(),
+        IB20::isPausedCall { feature: IB20::PausableFeature::SEIZE }.abi_encode(),
+    ];
+    for calldata in calls {
+        let mut s = fresh();
+        let err = op(&mut s, ALICE, FakePolicyAccounting::new(), calldata.clone()).unwrap_err();
+        assert_eq!(err, frozen_v1_seize_discriminant_error(&calldata));
+        assert!(matches!(err, BasePrecompileError::AbiDecodeFailed { .. }));
+    }
+}
+
 // ============================================================================
 // meta: op coverage checklist
 // ============================================================================
@@ -2076,16 +2130,25 @@ fn v1_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Stablecoin::IB20Stab
             golden_burn_blocked_unprivileged_requires_role,
         ]),
 
+        // Seize surface (shared IB20 selectors): introduced at V2 (Cobalt). On the frozen V1
+        // (Beryl) these are version-gated and stay unknown.
+        C::burnBlockedWithMemo(_)
+        | C::transferFromSeizableWithMemo(_)
+        | C::TRANSFER_FROM_SEIZABLE_ROLE(_)
+        | C::SEIZABLE_ACCOUNT_POLICY(_) => covered(&[golden_seize_selectors_unknown_at_v1]),
+
         // pause / config / roles / policy / permit
         C::pause(_) => covered(&[
             golden_pause_sets_feature_bit,
             golden_pause_reverts_empty_feature_set,
             golden_pause_unprivileged_requires_role,
+            golden_pause_path_rejects_seize_discriminant_at_v1,
         ]),
         C::unpause(_) => covered(&[
             golden_unpause_clears_feature_bit,
             golden_unpause_reverts_empty_feature_set,
             golden_unpause_unprivileged_requires_role,
+            golden_pause_path_rejects_seize_discriminant_at_v1,
         ]),
         C::updateSupplyCap(_) => covered(&[
             golden_update_supply_cap,
@@ -2139,9 +2202,10 @@ fn v1_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Stablecoin::IB20Stab
         ]),
 
         // computed reads
-        C::isPaused(_) | C::pausedFeatures(_) => {
-            covered(&[golden_read_is_paused_and_paused_features])
-        }
+        C::isPaused(_) | C::pausedFeatures(_) => covered(&[
+            golden_read_is_paused_and_paused_features,
+            golden_pause_path_rejects_seize_discriminant_at_v1,
+        ]),
         C::policyId(_) => covered(&[golden_read_policy_id_and_unsupported_scope]),
         C::DOMAIN_SEPARATOR(_) => covered(&[golden_read_domain_separator]),
         C::eip712Domain(_) => covered(&[golden_read_eip712_domain]),

--- a/etc/systems/src/b20.rs
+++ b/etc/systems/src/b20.rs
@@ -602,8 +602,13 @@ impl<'a> B20PrecompileClient<'a> {
 }
 
 fn pausable_features_from_mask(mask: U256) -> Vec<IB20::PausableFeature> {
-    [IB20::PausableFeature::TRANSFER, IB20::PausableFeature::MINT, IB20::PausableFeature::BURN]
-        .into_iter()
-        .filter(|feature| (mask & B20PausableFeature::mask(*feature)) != U256::ZERO)
-        .collect()
+    [
+        IB20::PausableFeature::TRANSFER,
+        IB20::PausableFeature::MINT,
+        IB20::PausableFeature::BURN,
+        IB20::PausableFeature::SEIZE,
+    ]
+    .into_iter()
+    .filter(|feature| (mask & B20PausableFeature::mask(*feature)) != U256::ZERO)
+    .collect()
 }


### PR DESCRIPTION
## Summary

PR4 of the seize stack (BOP-441). **Makes seize callable** across asset V2 + stablecoin V2, mirroring the base-std reference ([base-std#177](https://github.com/base/base-std/pull/177)). Stacked on #4186 (plumbing); review/merge that first.

New V2-only surface, version-gated so frozen V1 keeps rejecting it byte-for-byte.

## What's included

- **ABI** (`abi.rs`): `SEIZE` `PausableFeature` member; `transferFromSeizableWithMemo` + `burnBlockedWithMemo`; `TRANSFER_FROM_SEIZABLE_ROLE()` / `SEIZABLE_ACCOUNT_POLICY()` getters; `as_label` arms. `SEIZE` also wired into `B20PausableFeature::ensure_valid`.
- **Logic** (asset + stablecoin V2): `transfer_from_seizable_with_memo` and `burn_blocked_with_memo`, overriding `reject_frozen_selector!` defaults on the shared trait (V1 inherits reject). Explicit guard sequence `SEIZE pause -> role -> ensure_seizable(from) -> to != 0 -> balance`, moving balance via the shared `move_balance` (from PR1). Emit order `Transfer -> Memo -> {TransferredFromSeizable | BurnedBlocked}` per the IB20 memo invariant.
- **Dispatch** (asset + stablecoin): handler arms + a **pre-decode fork gate** rejecting the four seize selectors before Cobalt with `UnknownFunctionSelector` (same pattern as the ERC-8056 gate), so pre-Cobalt calldata is byte-identical.
- **Golden** (asset + stablecoin V1): `golden_seize_selectors_unknown_at_v1` + coverage-checklist arms pin that the frozen V1 op surface rejects the new selectors.
- **Unit tests** (asset + stablecoin V2): happy path, event order, revert paths (`AccountNotBlocked`, `InvalidReceiver`, `ContractPaused(SEIZE)`, role), and the decoupling invariants (ignores receiver policy on `to`, no allowance required).
- **etc/systems**: include `SEIZE` in the RPC `unpause`-all helper (mask `0x0f`) so it truly clears every vector.

## Design notes

- **Admin op, explicit skips.** Seize skips allowance and all transfer policies and does not policy-check `to`; it does **not** reuse the factory-bootstrap `privileged` path. The `privileged` param is dropped entirely from the seize methods (they are never factory-called), so the role is always enforced — matching base-std's `onlyRole`.
- **`from` not zero-checked** (only `to != 0`), matching the burn-blocked family.
- **Transient split:** legacy `burnBlocked` still gates on `BURN`/`TRANSFER_SENDER_POLICY`; the new memo variant and `transferFromSeizableWithMemo` gate on `SEIZE`/`SEIZABLE_ACCOUNT_POLICY`. The legacy `burnBlocked` repoint is BOP-471 (PR6), deferred because it changes shipped behavior.
- **Versioning:** the seize scope is recognized globally (matching the reference); per-version gating folds into the in-flight ABI-versioning work.

## Testing

- `cargo test -p base-common-precompiles --features test-utils`: all pass, incl. frozen V1 goldens unchanged (asset 103, stablecoin 81) and 16 new V2 seize unit tests.
- `cargo +nightly fmt --check` and `cargo clippy --all-targets --features test-utils` clean.
- Downstream crates (`etc/systems`, harness) require forge/soldeer contract artifacts to build locally (pre-existing env prerequisite); the `etc/systems` change is a trivial array extension.
