### PR TITLE
fix(ingress): populate legacy bundle blockNumber for mixed-version RPC

### DIFF
--- a/crates/common/bundles/src/bundle.rs
+++ b/crates/common/bundles/src/bundle.rs
@@ -133,17 +133,11 @@ mod tests {
     fn test_bundle_serialization_always_includes_legacy_block_number() {
         // Ingress-style payload: only txs / expiry metadata, no block window.
         // Older meterBundle nodes require `blockNumber` and reject otherwise.
-        let bundle = Bundle {
-            txs: vec![],
-            max_timestamp: Some(1_700_000_000),
-            ..Default::default()
-        };
+        let bundle =
+            Bundle { txs: vec![], max_timestamp: Some(1_700_000_000), ..Default::default() };
 
         let json = serde_json::to_string(&bundle).unwrap();
-        assert!(
-            json.contains("\"blockNumber\":\"0x0\""),
-            "expected legacy blockNumber in {json}"
-        );
+        assert!(json.contains("\"blockNumber\":\"0x0\""), "expected legacy blockNumber in {json}");
         assert!(!json.contains("minBlockNumber"));
         assert!(!json.contains("maxBlockNumber"));
     }

--- a/crates/common/bundles/src/bundle.rs
+++ b/crates/common/bundles/src/bundle.rs
@@ -12,12 +12,10 @@ pub struct Bundle {
 
     /// Deprecated single target block number.
     ///
-    /// Always serialized so mixed-version deployments remain compatible with
-    /// older nodes that still require `blockNumber` on bundle RPC params
-    /// (notably `base_meterBundle`). Prefer [`Self::min_block_number`] /
-    /// [`Self::max_block_number`].
-    #[serde(default, with = "alloy_serde::quantity")]
-    pub block_number: u64,
+    /// Retained for mixed-version compatibility with older bundle RPC servers.
+    /// Prefer [`Self::min_block_number`] / [`Self::max_block_number`].
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    pub block_number: Option<u64>,
 
     /// Minimum block number for inclusion.
     #[serde(
@@ -88,7 +86,7 @@ mod tests {
     fn test_bundle_default() {
         let bundle = Bundle::default();
         assert!(bundle.txs.is_empty());
-        assert_eq!(bundle.block_number, 0);
+        assert!(bundle.block_number.is_none());
         assert!(bundle.min_block_number.is_none());
         assert!(bundle.max_block_number.is_none());
         assert!(bundle.flashblock_number_min.is_none());
@@ -104,7 +102,7 @@ mod tests {
     fn test_bundle_serialization() {
         let bundle = Bundle {
             txs: vec![],
-            block_number: 12345,
+            block_number: Some(12345),
             min_block_number: Some(12345),
             max_block_number: Some(12350),
             flashblock_number_min: Some(1),
@@ -130,14 +128,12 @@ mod tests {
     }
 
     #[test]
-    fn test_bundle_serialization_always_includes_legacy_block_number() {
-        // Ingress-style payload: only txs / expiry metadata, no block window.
-        // Older meterBundle nodes require `blockNumber` and reject otherwise.
+    fn test_bundle_serialization_omits_legacy_block_number_when_unset() {
         let bundle =
             Bundle { txs: vec![], max_timestamp: Some(1_700_000_000), ..Default::default() };
 
         let json = serde_json::to_string(&bundle).unwrap();
-        assert!(json.contains("\"blockNumber\":\"0x0\""), "expected legacy blockNumber in {json}");
+        assert!(!json.contains("blockNumber"));
         assert!(!json.contains("minBlockNumber"));
         assert!(!json.contains("maxBlockNumber"));
     }
@@ -151,7 +147,7 @@ mod tests {
         }"#;
 
         let bundle: Bundle = serde_json::from_str(json).unwrap();
-        assert_eq!(bundle.block_number, 0);
+        assert!(bundle.block_number.is_none());
         assert_eq!(bundle.min_block_number, Some(1));
         assert_eq!(bundle.max_block_number, Some(2));
         assert!(bundle.flashblock_number_min.is_none());
@@ -168,7 +164,7 @@ mod tests {
         }"#;
 
         let bundle: Bundle = serde_json::from_str(json).unwrap();
-        assert_eq!(bundle.block_number, 100);
+        assert_eq!(bundle.block_number, Some(100));
         assert!(bundle.min_block_number.is_none());
         assert!(bundle.max_block_number.is_none());
     }

--- a/crates/common/bundles/src/bundle.rs
+++ b/crates/common/bundles/src/bundle.rs
@@ -10,6 +10,15 @@ pub struct Bundle {
     /// The raw transaction bytes in the bundle.
     pub txs: Vec<Bytes>,
 
+    /// Deprecated single target block number.
+    ///
+    /// Always serialized so mixed-version deployments remain compatible with
+    /// older nodes that still require `blockNumber` on bundle RPC params
+    /// (notably `base_meterBundle`). Prefer [`Self::min_block_number`] /
+    /// [`Self::max_block_number`].
+    #[serde(default, with = "alloy_serde::quantity")]
+    pub block_number: u64,
+
     /// Minimum block number for inclusion.
     #[serde(
         default,
@@ -79,6 +88,7 @@ mod tests {
     fn test_bundle_default() {
         let bundle = Bundle::default();
         assert!(bundle.txs.is_empty());
+        assert_eq!(bundle.block_number, 0);
         assert!(bundle.min_block_number.is_none());
         assert!(bundle.max_block_number.is_none());
         assert!(bundle.flashblock_number_min.is_none());
@@ -94,6 +104,7 @@ mod tests {
     fn test_bundle_serialization() {
         let bundle = Bundle {
             txs: vec![],
+            block_number: 12345,
             min_block_number: Some(12345),
             max_block_number: Some(12350),
             flashblock_number_min: Some(1),
@@ -106,6 +117,7 @@ mod tests {
         };
 
         let json = serde_json::to_string(&bundle).unwrap();
+        assert!(json.contains("\"blockNumber\":\"0x3039\""));
         assert!(json.contains("\"minBlockNumber\":12345"));
         assert!(json.contains("\"maxBlockNumber\":12350"));
         // Optional fields serialize as integers, not hex
@@ -118,6 +130,25 @@ mod tests {
     }
 
     #[test]
+    fn test_bundle_serialization_always_includes_legacy_block_number() {
+        // Ingress-style payload: only txs / expiry metadata, no block window.
+        // Older meterBundle nodes require `blockNumber` and reject otherwise.
+        let bundle = Bundle {
+            txs: vec![],
+            max_timestamp: Some(1_700_000_000),
+            ..Default::default()
+        };
+
+        let json = serde_json::to_string(&bundle).unwrap();
+        assert!(
+            json.contains("\"blockNumber\":\"0x0\""),
+            "expected legacy blockNumber in {json}"
+        );
+        assert!(!json.contains("minBlockNumber"));
+        assert!(!json.contains("maxBlockNumber"));
+    }
+
+    #[test]
     fn test_bundle_deserialization_minimal() {
         let json = r#"{
             "txs": [],
@@ -126,12 +157,26 @@ mod tests {
         }"#;
 
         let bundle: Bundle = serde_json::from_str(json).unwrap();
+        assert_eq!(bundle.block_number, 0);
         assert_eq!(bundle.min_block_number, Some(1));
         assert_eq!(bundle.max_block_number, Some(2));
         assert!(bundle.flashblock_number_min.is_none());
         assert!(bundle.flashblock_number_max.is_none());
         assert!(bundle.min_timestamp.is_none());
         assert!(bundle.max_timestamp.is_none());
+    }
+
+    #[test]
+    fn test_bundle_deserialization_legacy_block_number() {
+        let json = r#"{
+            "txs": [],
+            "blockNumber": "0x64"
+        }"#;
+
+        let bundle: Bundle = serde_json::from_str(json).unwrap();
+        assert_eq!(bundle.block_number, 100);
+        assert!(bundle.min_block_number.is_none());
+        assert!(bundle.max_block_number.is_none());
     }
 
     #[test]

--- a/crates/common/bundles/src/parsed.rs
+++ b/crates/common/bundles/src/parsed.rs
@@ -99,9 +99,7 @@ mod tests {
             flashblock_number_max: Some(5),
             min_timestamp: Some(1000),
             max_timestamp: Some(2000),
-            reverting_tx_hashes: vec![],
-            replacement_uuid: None,
-            dropping_tx_hashes: vec![],
+            ..Default::default()
         };
 
         let parsed: ParsedBundle = bundle.try_into().unwrap();

--- a/crates/execution/metering/src/meter.rs
+++ b/crates/execution/metering/src/meter.rs
@@ -844,7 +844,7 @@ mod tests {
 
         let bundle = Bundle {
             txs,
-            block_number: 0,
+            block_number: None,
             min_block_number: None,
             max_block_number: None,
             flashblock_number_min: None,

--- a/crates/execution/metering/src/meter.rs
+++ b/crates/execution/metering/src/meter.rs
@@ -844,6 +844,7 @@ mod tests {
 
         let bundle = Bundle {
             txs,
+            block_number: 0,
             min_block_number: None,
             max_block_number: None,
             flashblock_number_min: None,

--- a/crates/execution/metering/src/rpc.rs
+++ b/crates/execution/metering/src/rpc.rs
@@ -501,6 +501,7 @@ mod tests {
     fn create_bundle(txs: Vec<Bytes>, block_number: u64, min_timestamp: Option<u64>) -> Bundle {
         Bundle {
             txs,
+            block_number,
             min_block_number: Some(block_number),
             max_block_number: Some(block_number),
             flashblock_number_min: None,

--- a/crates/execution/metering/src/rpc.rs
+++ b/crates/execution/metering/src/rpc.rs
@@ -501,7 +501,7 @@ mod tests {
     fn create_bundle(txs: Vec<Bytes>, block_number: u64, min_timestamp: Option<u64>) -> Bundle {
         Bundle {
             txs,
-            block_number,
+            block_number: Some(block_number),
             min_block_number: Some(block_number),
             max_block_number: Some(block_number),
             flashblock_number_min: None,

--- a/crates/infra/ingress-rpc/src/service.rs
+++ b/crates/infra/ingress-rpc/src/service.rs
@@ -103,6 +103,7 @@ impl IngressApiServer for IngressService {
 
         let bundle = Bundle {
             txs: vec![data.clone()],
+            block_number: Some(0),
             max_timestamp: Some(expiry_timestamp),
             reverting_tx_hashes: vec![transaction.tx_hash()],
             ..Default::default()
@@ -611,6 +612,10 @@ mod tests {
 
         let result = service.send_raw_transaction(tx_bytes).await;
         assert!(result.is_ok());
+
+        let requests = simulation_server.received_requests().await.unwrap();
+        let request: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+        assert_eq!(request["params"][0]["blockNumber"], "0x0");
 
         let metering = timeout(Duration::from_secs(1), builder_rx.recv()).await.unwrap().unwrap();
         assert_eq!(metering.response, create_test_meter_bundle_response());


### PR DESCRIPTION
## Summary
- `#4124` replaced required `blockNumber` with optional `min/maxBlockNumber`, so new ingress serialized `base_meterBundle` params without `blockNumber`.
- Older Sepolia simulation nodes still require that field and reject with `-32602 missing field blockNumber`, which zeroed metering known% after the tips pin bump.
- Retain `Bundle.block_number` as an optional compatibility field and explicitly set it to `Some(0)` in ingress. Other bundle callers continue omitting it; there is no semantic promotion into min/max.

## Test plan
- [x] `cargo test -p base-bundles --lib`
- [x] `cargo test -p ingress-rpc-lib test_send_raw_transaction_meters_broadcasts_and_audits`
- [x] Ingress test asserts the outbound `base_meterBundle` request contains `\"blockNumber\":\"0x0\"`
- [ ] Tips Sepolia: pin to this commit, redeploy ingress, confirm metering known% recovers and `Metering failed ... missing field blockNumber` stops
- [ ] Spot-check a proxyd/`sepolia.base.org` submission still meters and reaches the builder