### PR TITLE
fix(consensus): survive cold-start reset on shadow sequencer

### DIFF
--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -23,6 +23,7 @@ use crate::{
     NoopCheckpointWriter, ResetRequest,
     actors::engine::{
         CanonicalReconciliationInputs, ReconcileShadowRequest, ShadowReconciliationGate,
+        ShadowResetPolicy,
     },
 };
 
@@ -1059,6 +1060,10 @@ where
 
                         warn!(target: "engine", "Received reset request");
 
+                        let private_branch_in_flight = self.shadow_gate.as_ref().is_some_and(|gate| {
+                            self.processor.engine.state().sync_state.unsafe_head() != gate.anchor()
+                        });
+
                         let reset_res = self.processor.reset_engine_state().await;
                         if let Ok(safe_head) = &reset_res {
                             let anchor = self.processor.engine.state().sync_state.unsafe_head();
@@ -1099,10 +1104,12 @@ where
                             // return the error.
                             reset_res?;
                         }
-                        if reset_succeeded
-                            && self.shadow_gate.is_some()
-                            && !shadow_cycle_coordinated
-                        {
+                        if ShadowResetPolicy::is_fatal_reset(
+                            reset_succeeded,
+                            self.shadow_gate.is_some(),
+                            shadow_cycle_coordinated,
+                            private_branch_in_flight,
+                        ) {
                             return Err(EngineError::ShadowInternalReset);
                         }
                     }
@@ -1696,6 +1703,80 @@ mod tests {
             !matches!(result, Err(super::EngineError::ShadowInternalReset)),
             "shadow node must survive the initial EL-sync reset, got: {result:?}"
         );
+    }
+
+    /// Regression test for the shadow-sequencer cold-start crash on the explicit `ResetRequest`
+    /// path: an uncoordinated successful reset whose engine unsafe head still equals the gate
+    /// anchor (no private shadow branch in flight, e.g. the derivation pipeline's mandatory
+    /// cold-start reset) must NOT terminate with [`EngineError::ShadowInternalReset`].
+    ///
+    /// Before the fix, any uncoordinated reset on a shadow sequencer was fatal, so the node
+    /// crash-looped on every startup. The fix gates the fatal return on the unsafe head having
+    /// diverged from the anchor.
+    #[tokio::test]
+    async fn shadow_gate_survives_uncoordinated_reset_without_private_branch() {
+        let head = test_block_info(100);
+
+        let client = Arc::new(
+            test_engine_client_builder()
+                .with_block_info_by_tag(BlockNumberOrTag::Latest, head)
+                .with_fork_choice_updated_v3_response(valid_fcu())
+                .build(),
+        );
+
+        let mut mock_derivation = MockEngineDerivationClient::new();
+        mock_derivation.expect_send_new_engine_safe_head().returning(|_| Ok(()));
+        mock_derivation.expect_notify_sync_completed().returning(|_| Ok(()));
+        mock_derivation.expect_send_signal().returning(|_| Ok(()));
+
+        let mut mock_conductor = MockConductor::new();
+        mock_conductor.expect_leader().returning(|| Ok(false));
+
+        let (state_tx, _state_rx) = watch::channel(EngineState::default());
+        let (queue_tx, _) = watch::channel(0usize);
+        let engine = Engine::new(EngineState::default(), state_tx, queue_tx);
+
+        let (unsafe_head_tx, _) = watch::channel(L2BlockInfo::default());
+
+        let processor = EngineProcessor::new(
+            Arc::clone(&client),
+            Arc::new(RollupConfig::default()),
+            mock_derivation,
+            engine,
+            EngineProcessorOptions {
+                node_mode: NodeMode::Sequencer,
+                unsafe_head_tx: Some(unsafe_head_tx),
+                conductor: Some(Arc::new(mock_conductor)),
+                sequencer_stopped: false,
+            },
+        );
+
+        // A present gate marks this node as a shadow sequencer, arming the fatal-reset guard.
+        // Gate anchor equals the default unsafe head, so no private branch is in flight. The
+        // exhaustive fatal-reset decision matrix lives in ShadowResetPolicy's unit tests; this
+        // integration case guards the wired call path: an armed-gate sequencer that observes an
+        // uncoordinated reset must not surface EngineError::ShadowInternalReset.
+        let gate = super::ShadowReconciliationGate::new(L2BlockInfo::default());
+
+        let (req_tx, req_rx) = mpsc::channel(8);
+        let handle = EngineRequestHandler::new(processor, Some(gate)).start(req_rx);
+
+        let (result_tx, result_rx) = mpsc::channel(1);
+        req_tx
+            .send(EngineActorRequest::ResetRequest(Box::new(ResetRequest {
+                result_tx,
+                shadow_cycle_coordinated: false,
+            })))
+            .await
+            .expect("failed to send reset request");
+
+        drop(req_tx);
+        let result = handle.await.expect("engine task panicked");
+        assert!(
+            !matches!(result, Err(super::EngineError::ShadowInternalReset)),
+            "cold-start reset with no private branch must be survivable, got: {result:?}"
+        );
+        let _ = result_rx;
     }
 
     /// Regression test: demonstrates that a validator node (`unsafe_head_tx` = None) was

--- a/crates/consensus/service/src/actors/engine/error.rs
+++ b/crates/consensus/service/src/actors/engine/error.rs
@@ -21,7 +21,7 @@ pub enum EngineError {
     /// A critical engine task error was already forwarded to the request caller.
     #[error("critical engine task error: {0}")]
     CriticalEngineTask(String),
-    /// An automatic processor reset invalidated shadow reconciliation state.
+    /// An uncoordinated processor reset orphaned an in-flight private shadow branch.
     #[error(
         "engine performed an internal reset while shadow sequencing; terminating to avoid a stale reconciliation gate"
     )]

--- a/crates/consensus/service/src/actors/engine/mod.rs
+++ b/crates/consensus/service/src/actors/engine/mod.rs
@@ -27,7 +27,9 @@ pub use engine_request_processor::{
 };
 
 mod shadow_reconciliation_gate;
-pub use shadow_reconciliation_gate::{CanonicalReconciliationInputs, ShadowReconciliationGate};
+pub use shadow_reconciliation_gate::{
+    CanonicalReconciliationInputs, ShadowReconciliationGate, ShadowResetPolicy,
+};
 
 mod rpc_request_processor;
 pub use rpc_request_processor::EngineRpcProcessor;

--- a/crates/consensus/service/src/actors/engine/request.rs
+++ b/crates/consensus/service/src/actors/engine/request.rs
@@ -120,7 +120,9 @@ pub struct ResetRequest {
     /// response will be sent to this channel, if `Some`.
     pub result_tx: mpsc::Sender<EngineClientResult<()>>,
     /// Whether the caller coordinates rebuilding its shadow-cycle state around this reset.
-    /// Uncoordinated successful resets terminate an active shadow handler after responding.
+    /// An uncoordinated successful reset terminates an active shadow handler only when a private
+    /// shadow branch was in flight (unsafe head diverged from the gate anchor); a reset with no
+    /// private branch outstanding (e.g. the derivation pipeline's cold-start reset) is survivable.
     pub shadow_cycle_coordinated: bool,
 }
 

--- a/crates/consensus/service/src/actors/engine/shadow_reconciliation_gate.rs
+++ b/crates/consensus/service/src/actors/engine/shadow_reconciliation_gate.rs
@@ -154,6 +154,31 @@ impl ShadowReconciliationGate {
         self.clear();
         self.anchor = anchor;
     }
+
+    /// The current canonical anchor. Equals the engine's unsafe head unless a private shadow
+    /// branch is in flight.
+    pub const fn anchor(&self) -> L2BlockInfo {
+        self.anchor
+    }
+}
+
+/// Policy for deciding whether a completed engine reset invalidates shadow reconciliation state.
+#[derive(Debug)]
+pub struct ShadowResetPolicy;
+
+impl ShadowResetPolicy {
+    /// A completed engine reset is fatal for a shadow sequencer only when it actually happened, a
+    /// shadow gate is armed, the cycle was not coordinated, and a private branch was outstanding
+    /// (the engine unsafe head had diverged from the gate anchor). A reset with no private branch
+    /// in flight — e.g. the derivation pipeline's mandatory cold-start reset — is survivable.
+    pub const fn is_fatal_reset(
+        reset_succeeded: bool,
+        shadow_present: bool,
+        coordinated: bool,
+        private_branch_in_flight: bool,
+    ) -> bool {
+        reset_succeeded && shadow_present && !coordinated && private_branch_in_flight
+    }
 }
 
 #[cfg(test)]
@@ -164,7 +189,7 @@ mod tests {
     use base_consensus_engine::ConsolidateInput;
     use base_protocol::{BlockInfo, L2BlockInfo};
 
-    use super::ShadowReconciliationGate;
+    use super::{ShadowReconciliationGate, ShadowResetPolicy};
     use crate::EngineClientError;
 
     fn head(number: u64, hash: B256) -> L2BlockInfo {
@@ -282,5 +307,57 @@ mod tests {
         assert!(gate.payloads.is_empty());
         assert_eq!(gate.anchor, anchor);
         assert!(!gate.faulted);
+    }
+
+    #[test]
+    fn anchor_accessor_tracks_constructor_commit_and_reanchor() {
+        let genesis = head(10, B256::with_last_byte(10));
+        let mut gate = ShadowReconciliationGate::new(genesis);
+        assert_eq!(gate.anchor(), genesis);
+
+        let committed = head(11, B256::with_last_byte(11));
+        gate.commit(committed);
+        assert_eq!(gate.anchor(), committed);
+
+        let reanchored = head(20, B256::with_last_byte(20));
+        gate.reanchor(reanchored);
+        assert_eq!(gate.anchor(), reanchored);
+    }
+
+    #[test]
+    fn fatal_reset_only_when_uncoordinated_private_branch_after_successful_reset() {
+        for reset_succeeded in [false, true] {
+            for shadow_present in [false, true] {
+                for coordinated in [false, true] {
+                    for private_branch_in_flight in [false, true] {
+                        let expected = reset_succeeded
+                            && shadow_present
+                            && !coordinated
+                            && private_branch_in_flight;
+                        assert_eq!(
+                            ShadowResetPolicy::is_fatal_reset(
+                                reset_succeeded,
+                                shadow_present,
+                                coordinated,
+                                private_branch_in_flight,
+                            ),
+                            expected,
+                            "reset_succeeded={reset_succeeded} shadow_present={shadow_present} \
+                             coordinated={coordinated} private_branch={private_branch_in_flight}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn cold_start_reset_without_private_branch_is_survivable() {
+        assert!(!ShadowResetPolicy::is_fatal_reset(true, true, false, false));
+    }
+
+    #[test]
+    fn uncoordinated_reset_with_private_branch_is_fatal() {
+        assert!(ShadowResetPolicy::is_fatal_reset(true, true, false, true));
     }
 }

--- a/crates/consensus/service/src/actors/mod.rs
+++ b/crates/consensus/service/src/actors/mod.rs
@@ -20,6 +20,7 @@ pub use engine::{
     EngineProcessor, EngineProcessorOptions, EngineRequestHandler, EngineRequestReceiver,
     EngineRpcProcessor, EngineRpcRequest, GetPayloadRequest, InsertUnsafePayloadRequest,
     QueuedEngineDerivationClient, ReconcileShadowRequest, ResetRequest, ShadowReconciliationGate,
+    ShadowResetPolicy,
 };
 
 mod rpc;

--- a/crates/consensus/service/src/lib.rs
+++ b/crates/consensus/service/src/lib.rs
@@ -44,7 +44,7 @@ pub use actors::{
     RecoveryModeGuard, ResetRequest, RpcActor, RpcActorError, RpcContext, ScheduledTicker,
     SealState, SealStepError, SealStepOutcome, SequencerActor, SequencerActorError,
     SequencerAdminQuery, SequencerConfig, SequencerEngineClient, ShadowCycle,
-    ShadowReconciliationGate, ShadowReconciliationTask, UnsafePayloadGossipClient,
+    ShadowReconciliationGate, ShadowReconciliationTask, ShadowResetPolicy, UnsafePayloadGossipClient,
     UnsafePayloadGossipClientError, UnsealedPayloadHandle, UpgradeSignalMetricsActor,
     UpgradeSignalNodeConfig,
 };


### PR DESCRIPTION
## Problem

Shadow builder (`base-public-3`) crash-loops every cold start (docker `RestartCount` 1500+). A shadow sequencer (armed `shadow_gate`) treats the derivation pipeline's mandatory cold-start `ResetRequest { shadow_cycle_coordinated: false }` as fatal `ShadowInternalReset`, exits 1, and is restarted forever.

## Root cause

The fatal-reset guard fired on **any** uncoordinated reset while a gate was armed. That path is only meant to catch a coordinated cycle torn down **while a private shadow branch is in flight** — which a cold-start reset never has (engine unsafe head still equals the gate anchor).

## Fix

Gate the fatal return on the private branch being in flight (`unsafe_head != gate.anchor()`), captured **before** the reset mutates state. Extracted to a pure, unit-testable `ShadowResetPolicy::is_fatal_reset`:

```rust
reset_succeeded && shadow_present && !coordinated && private_branch_in_flight
```

Cold start → `unsafe == anchor` → survives. Genuine teardown with an outstanding branch → still fatal. Other 3 reset-fatal sites (drain, `BuildRequest`, `GetPayloadRequest`) unchanged.

## Tests

`ShadowResetPolicy` exhaustive truth table + `anchor()` accessor + call-path integration guard. `cargo test --lib shadow` → 18 passed; clippy clean.