### PR TITLE
ci: warm nextest compilation cache

### DIFF
--- a/.github/workflows/ci-main-cache.yml
+++ b/.github/workflows/ci-main-cache.yml
@@ -39,3 +39,29 @@ jobs:
           rust-cache-save: "true"
       - name: Build CI cache
         run: just build::ci
+
+  warm-test-cache:
+    name: Warm Test Cache
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 2
+      - uses: ./.github/actions/setup
+        with:
+          free-disk: "true"
+          native-deps: "true"
+          foundry: "true"
+          sp1: "true"
+          tools: cargo-nextest
+          rust-cache-shared-key: "stable"
+          rust-cache-save: "false"
+      - name: Build CI test cache
+        run: |
+          just build::contracts
+          cargo nextest run -P ci --locked --workspace --all-features \
+            --exclude base-system-tests --cargo-profile ci --no-run


### PR DESCRIPTION
Warm all-feature test artifacts on main so PR test jobs can reuse them.

The current warmer only builds normal targets; sampled PR test compilation had a 30.8% Rust cache hit rate and spent 13m22s compiling. The new warmer runs in parallel and does not change CI coverage.