### PR TITLE
perf(consensus): avoid temporary upgrade transaction vectors

### DIFF
--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -148,7 +148,7 @@ where
         if self.rollup_cfg.is_ecotone_active(next_l2_time)
             && !self.rollup_cfg.is_ecotone_active(l2_parent.block_info.timestamp)
         {
-            upgrade_transactions = Upgrades::ECOTONE.txs().collect();
+            upgrade_transactions.extend(Upgrades::ECOTONE.txs());
         }
         if self.rollup_cfg.is_fjord_active(next_l2_time)
             && !self.rollup_cfg.is_fjord_active(l2_parent.block_info.timestamp)

--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -153,17 +153,17 @@ where
         if self.rollup_cfg.is_fjord_active(next_l2_time)
             && !self.rollup_cfg.is_fjord_active(l2_parent.block_info.timestamp)
         {
-            upgrade_transactions.append(&mut Upgrades::FJORD.txs().collect());
+            upgrade_transactions.extend(Upgrades::FJORD.txs());
         }
         if self.rollup_cfg.is_isthmus_active(next_l2_time)
             && !self.rollup_cfg.is_isthmus_active(l2_parent.block_info.timestamp)
         {
-            upgrade_transactions.append(&mut Upgrades::ISTHMUS.txs().collect());
+            upgrade_transactions.extend(Upgrades::ISTHMUS.txs());
         }
         if self.rollup_cfg.is_jovian_active(next_l2_time)
             && !self.rollup_cfg.is_jovian_active(l2_parent.block_info.timestamp)
         {
-            upgrade_transactions.append(&mut Upgrades::JOVIAN.txs().collect());
+            upgrade_transactions.extend(Upgrades::JOVIAN.txs());
         }
 
         // Build and encode the L1 info transaction for the current payload.


### PR DESCRIPTION
## Summary
- extend the payload upgrade transaction vector directly from upgrade iterators
- avoid allocating and immediately draining temporary vectors for Fjord, Isthmus, and Jovian
- preserve upgrade transaction ordering

## Validation
- `cargo fmt --check`
- `cargo test -p base-consensus-derive test_prepare_payload_with_`
- `cargo check -p base-consensus-derive --all-targets`
- `git diff --check`