### PR TITLE
perf(consensus): borrow certificate paths when watching

### DIFF
--- a/crates/consensus/sources/src/signer/remote/cert.rs
+++ b/crates/consensus/sources/src/signer/remote/cert.rs
@@ -98,7 +98,7 @@ impl RemoteSigner {
         &self,
         client: Arc<RwLock<RpcClient>>,
     ) -> Result<Option<RecommendedWatcher>, notify::Error> {
-        let Some(ref client_cert) = self.client_cert.clone() else {
+        let Some(client_cert) = &self.client_cert else {
             return Ok(None);
         };
 


### PR DESCRIPTION
## Summary
- borrow configured mTLS certificate paths while registering filesystem watches
- avoid cloning both `PathBuf`s during remote signer startup

## Validation
- `cargo fmt --check`
- `cargo check -p base-consensus-sources --all-targets`
- `cargo test -p base-consensus-sources`
- `git diff --check`