### PR TITLE
perf(protocol): encode batch frames in place

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6070,6 +6070,7 @@ dependencies = [
  "base-common-rpc-types",
  "base-common-rpc-types-engine",
  "brotli",
+ "criterion",
  "derive_more 2.1.1",
  "miniz_oxide 0.9.1",
  "proptest",

--- a/crates/consensus/protocol/Cargo.toml
+++ b/crates/consensus/protocol/Cargo.toml
@@ -51,6 +51,7 @@ tracing-subscriber = { workspace = true, features = ["fmt"], optional = true }
 spin.workspace = true
 rstest.workspace = true
 proptest.workspace = true
+criterion.workspace = true
 serde_json.workspace = true
 base-common-chains.workspace = true
 base-common-rpc-types.workspace = true
@@ -60,6 +61,10 @@ arbitrary = { workspace = true, features = ["derive"] }
 rand = { workspace = true, features = ["std", "std_rng"] }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 alloy-primitives = { workspace = true, features = ["arbitrary"] }
+
+[[bench]]
+name = "batch_transaction"
+harness = false
 
 [features]
 default = [ "std" ]

--- a/crates/consensus/protocol/benches/batch_transaction.rs
+++ b/crates/consensus/protocol/benches/batch_transaction.rs
@@ -1,0 +1,42 @@
+//! Benchmarks for batch transaction frame encoding.
+
+use std::hint::black_box;
+
+use alloy_primitives::Bytes;
+use base_protocol::{BatchTransaction, Frame};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+
+const FRAME_COUNT: usize = 32;
+const FRAME_DATA_LEN: usize = 128 * 1024;
+
+fn encode_with_temporary_buffers(batch: &BatchTransaction) -> Bytes {
+    batch
+        .frames
+        .iter()
+        .fold(Vec::new(), |mut encoded, frame| {
+            encoded.append(&mut frame.encode());
+            encoded
+        })
+        .into()
+}
+
+fn bench_batch_transaction_encoding(c: &mut Criterion) {
+    let frame = Frame::new([0xFF; 16], 0, vec![0xDD; FRAME_DATA_LEN], false);
+    let batch = BatchTransaction {
+        frames: vec![frame; FRAME_COUNT],
+        size: FRAME_COUNT * (FRAME_DATA_LEN + Frame::ENCODED_OVERHEAD),
+    };
+
+    let mut group = c.benchmark_group("batch_transaction_encoding");
+    group.throughput(Throughput::Bytes(batch.size() as u64));
+    group.bench_function("temporary_frame_buffers", |b| {
+        b.iter(|| black_box(encode_with_temporary_buffers(black_box(&batch))));
+    });
+    group.bench_function("encode_in_place", |b| {
+        b.iter(|| black_box(black_box(&batch).to_bytes()));
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_batch_transaction_encoding);
+criterion_main!(benches);

--- a/crates/consensus/protocol/src/batch/tx.rs
+++ b/crates/consensus/protocol/src/batch/tx.rs
@@ -29,13 +29,12 @@ impl BatchTransaction {
 
     /// Returns the [`BatchTransaction`] as a [`Bytes`].
     pub fn to_bytes(&self) -> Bytes {
-        self.frames
-            .iter()
-            .fold(Vec::new(), |mut acc, frame| {
-                acc.append(&mut frame.encode());
-                acc
-            })
-            .into()
+        let capacity = self.frames.iter().map(Frame::encoded_len).sum();
+        let mut encoded = Vec::with_capacity(capacity);
+        for frame in &self.frames {
+            frame.encode_into(&mut encoded);
+        }
+        encoded.into()
     }
 }
 

--- a/crates/consensus/protocol/src/frame.rs
+++ b/crates/consensus/protocol/src/frame.rs
@@ -166,7 +166,8 @@ pub struct Frame {
 }
 
 impl Frame {
-    /// Number of metadata bytes in an encoded frame.
+    /// Number of metadata bytes in an encoded frame: 16-byte channel ID, 2-byte frame number,
+    /// 4-byte payload length, and 1-byte final-frame flag.
     pub const ENCODED_OVERHEAD: usize = 16 + 2 + 4 + 1;
 
     /// Overhead estimation for frame metadata and tagging information.

--- a/crates/consensus/protocol/src/frame.rs
+++ b/crates/consensus/protocol/src/frame.rs
@@ -166,6 +166,9 @@ pub struct Frame {
 }
 
 impl Frame {
+    /// Number of metadata bytes in an encoded frame.
+    pub const ENCODED_OVERHEAD: usize = 16 + 2 + 4 + 1;
+
     /// Overhead estimation for frame metadata and tagging information.
     ///
     /// This constant provides an estimate of the additional bytes required
@@ -193,13 +196,23 @@ impl Frame {
 
     /// Encode the frame into a byte vector.
     pub fn encode(&self) -> Vec<u8> {
-        let mut encoded = Vec::with_capacity(16 + 2 + 4 + self.data.len() + 1);
+        let mut encoded = Vec::with_capacity(self.encoded_len());
+        self.encode_into(&mut encoded);
+        encoded
+    }
+
+    /// Returns the encoded length of the frame.
+    pub const fn encoded_len(&self) -> usize {
+        Self::ENCODED_OVERHEAD + self.data.len()
+    }
+
+    /// Appends the encoded frame to an existing byte vector.
+    pub fn encode_into(&self, encoded: &mut Vec<u8>) {
         encoded.extend_from_slice(&self.id);
         encoded.extend_from_slice(&self.number.to_be_bytes());
         encoded.extend_from_slice(&(self.data.len() as u32).to_be_bytes());
         encoded.extend_from_slice(&self.data);
         encoded.push(self.is_last as u8);
-        encoded
     }
 
     /// Decode a frame from a byte vector.

--- a/crates/consensus/protocol/src/frame.rs
+++ b/crates/consensus/protocol/src/frame.rs
@@ -217,9 +217,7 @@ impl Frame {
 
     /// Decode a frame from a byte vector.
     pub fn decode(encoded: &[u8]) -> Result<(usize, Self), FrameDecodingError> {
-        const BASE_FRAME_LEN: usize = 16 + 2 + 4 + 1;
-
-        if encoded.len() < BASE_FRAME_LEN {
+        if encoded.len() < Self::ENCODED_OVERHEAD {
             return Err(FrameDecodingError::DataTooShort(encoded.len()));
         }
 
@@ -231,13 +229,13 @@ impl Frame {
             encoded[18..22].try_into().map_err(|_| FrameDecodingError::InvalidDataLength)?,
         ) as usize;
 
-        if data_len > Self::MAX_LEN || data_len >= encoded.len() - (BASE_FRAME_LEN - 1) {
+        if data_len > Self::MAX_LEN || data_len >= encoded.len() - (Self::ENCODED_OVERHEAD - 1) {
             return Err(FrameDecodingError::DataTooLarge(data_len));
         }
 
         let data = encoded[22..22 + data_len].to_vec();
         let is_last = encoded[22 + data_len] == 1;
-        Ok((BASE_FRAME_LEN + data_len, Self { id, number, data, is_last }))
+        Ok((Self::ENCODED_OVERHEAD + data_len, Self { id, number, data, is_last }))
     }
 
     /// Parses a single frame from the given data at the given starting position,


### PR DESCRIPTION
## Summary
- add non-allocating frame encoding into an existing buffer
- pre-size batch transaction output exactly and encode every frame directly into it
- preserve the existing allocating `Frame::encode` API

## Evidence
Previously `BatchTransaction::to_bytes` allocated one temporary vector per frame, then copied each temporary into a separately growing accumulator. The new path performs one exact-size allocation for the complete batch, eliminating N temporary allocations and accumulator growth for N frames.

## Validation
- `cargo fmt --check`
- `cargo test -p base-protocol batch::tx`
- `cargo check -p base-protocol --all-targets`
- `git diff --check`