### PR TITLE
perf(consensus): move payload into gossip queue

### DIFF
--- a/crates/consensus/service/src/actors/network/gossip.rs
+++ b/crates/consensus/service/src/actors/network/gossip.rs
@@ -42,10 +42,10 @@ impl UnsafePayloadGossipClient for QueuedUnsafePayloadGossipClient {
         &self,
         payload: BaseExecutionPayloadEnvelope,
     ) -> Result<(), UnsafePayloadGossipClientError> {
-        self.request_tx
-            .send(payload.clone())
-            .await
-            .map_err(|_| UnsafePayloadGossipClientError::RequestError("request channel closed".to_string()))
-            .inspect_err(|err| error!(target: "gossip_client", ?payload, ?err, "failed to request to gossip payload."))
+        self.request_tx.send(payload).await.map_err(|send_error| {
+            let err = UnsafePayloadGossipClientError::RequestError("request channel closed".to_string());
+            error!(target: "gossip_client", payload = ?send_error.0, ?err, "failed to request to gossip payload.");
+            err
+        })
     }
 }


### PR DESCRIPTION
## Summary
- move unsafe execution payloads directly into the gossip queue
- recover the moved payload from the channel send error for failure logging
- preserve existing queue, error, and logging behavior

## Evidence
The committed sequencer seal path schedules one payload for gossip per block. The queued client previously cloned the full `BaseExecutionPayloadEnvelope` before every send solely to retain it for error logging. Tokio's `SendError` already returns ownership of the payload when the channel is closed, so the clone is unnecessary on both success and failure paths.

## Validation
- `cargo fmt --check`
- `cargo check -p base-consensus-node --all-targets`
- `cargo test -p base-consensus-node` (243 unit, 10 integration passed)
- `git diff --check`