### PR TITLE
perf(consensus): move batches while filtering queue

### DIFF
--- a/crates/consensus/derive/src/stages/batch/batch_queue.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_queue.rs
@@ -132,6 +132,9 @@ where
         // Go over all batches, in order of inclusion, and find the first batch we can accept.
         // Filter in-place by only remembering the batches that may be processed in the future, or
         // any undecided ones.
+        let is_holocene_active = self.cfg.is_holocene_active(origin.timestamp);
+        // Before Holocene, temporarily retain seen batches so a disallowed `Past` result can
+        // restore the queue to its pre-call state. Post-Holocene discards can be dropped eagerly.
         let mut processed = Vec::new();
         let mut batches = core::mem::take(&mut self.batches).into_iter();
         while let Some(batch) = batches.next() {
@@ -142,16 +145,17 @@ where
                     // Drop Future batches post-holocene.
                     //
                     // See: <https://specs.base.org/upgrades/holocene/derivation#batch_queue>
-                    if !self.cfg.is_holocene_active(origin.timestamp) {
+                    if !is_holocene_active {
                         processed.push((batch, true));
                     } else {
-                        processed.push((batch, false));
                         self.prev.flush();
                         warn!(target: "batch_queue", parent_block_num = parent.block_info.number, "[HOLOCENE] Dropping future batch");
                     }
                 }
                 BatchValidity::Drop(reason) => {
-                    processed.push((batch, false));
+                    if !is_holocene_active {
+                        processed.push((batch, false));
+                    }
                     // If we drop a batch, flush previous batches buffered in the BatchStream
                     // stage.
                     self.prev.flush();
@@ -174,7 +178,9 @@ where
                     return Err(PipelineError::Eof.temp());
                 }
                 BatchValidity::Past => {
-                    if !self.cfg.is_holocene_active(origin.timestamp) {
+                    if !is_holocene_active {
+                        // Preserve the pre-call queue on this critical error, including batches
+                        // already classified as `Drop`, matching the previous borrowed iteration.
                         self.batches = processed
                             .into_iter()
                             .map(|(batch, _)| batch)
@@ -185,7 +191,6 @@ where
                         return Err(PipelineError::InvalidBatchValidity.crit());
                     }
 
-                    processed.push((batch, false));
                     warn!(target: "batch_queue", parent_block_num = parent.block_info.number, "[HOLOCENE] Dropping outdated batch");
                     continue;
                 }

--- a/crates/consensus/derive/src/stages/batch/batch_queue.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_queue.rs
@@ -180,6 +180,8 @@ where
                 }
                 BatchValidity::Past => {
                     if !is_holocene_active {
+                        // Preserve the complete pre-call queue on this critical error, matching
+                        // the previous borrowed-iteration behavior; pipeline reset handles it.
                         error!(target: "batch_queue", "BatchValidity::Past is not allowed pre-holocene");
                         return Err(PipelineError::InvalidBatchValidity.crit());
                     }

--- a/crates/consensus/derive/src/stages/batch/batch_queue.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_queue.rs
@@ -124,88 +124,77 @@ where
         // Find the first-seen batch that matches all validity conditions.
         // We may not have sufficient information to proceed filtering, and then we stop.
         // There may be none: in that case we force-create an empty batch
-        let mut next_batch = None;
         let next_timestamp = self.cfg.l2_block_timestamp(parent.block_info.number + 1);
 
         let origin = self.origin.ok_or(PipelineError::MissingOrigin.crit())?;
 
         // Go over all batches, in order of inclusion, and find the first batch we can accept.
-        // Filter in-place by only remembering the batches that may be processed in the future, or
-        // any undecided ones.
+        // Keep the queue intact while validation is pending so cancelling this future does not
+        // discard batches. Apply completed retention decisions synchronously after validation.
         let is_holocene_active = self.cfg.is_holocene_active(origin.timestamp);
-        // Before Holocene, temporarily retain seen batches so a disallowed `Past` result can
-        // restore the queue to its pre-call state. Post-Holocene discards can be dropped eagerly.
-        let mut processed = Vec::new();
-        let mut batches = core::mem::take(&mut self.batches).into_iter();
-        while let Some(batch) = batches.next() {
-            let validity =
-                batch.check_batch(&self.cfg, &self.l1_blocks, parent, &mut self.fetcher).await;
+        let mut retention = Vec::with_capacity(self.batches.len());
+        while retention.len() < self.batches.len() {
+            let index = retention.len();
+            let validity = self.batches[index]
+                .check_batch(&self.cfg, &self.l1_blocks, parent, &mut self.fetcher)
+                .await;
             match validity {
                 BatchValidity::Future => {
                     // Drop Future batches post-holocene.
                     //
                     // See: <https://specs.base.org/upgrades/holocene/derivation#batch_queue>
                     if !is_holocene_active {
-                        processed.push((batch, true));
+                        retention.push(true);
                     } else {
+                        retention.push(false);
                         self.prev.flush();
                         warn!(target: "batch_queue", parent_block_num = parent.block_info.number, "[HOLOCENE] Dropping future batch");
                     }
                 }
                 BatchValidity::Drop(reason) => {
-                    if !is_holocene_active {
-                        processed.push((batch, false));
-                    }
+                    retention.push(false);
                     // If we drop a batch, flush previous batches buffered in the BatchStream
                     // stage.
                     self.prev.flush();
                     warn!(target: "batch_queue", parent_block = %parent.block_info, reason = %reason, "Dropping batch");
-                    continue;
                 }
                 BatchValidity::Accept => {
-                    next_batch = Some(batch);
-                    // Don't keep the current batch in the remaining items since we are processing
-                    // it now, but retain every batch we didn't get to yet.
-                    break;
+                    let next_batch = self.batches.remove(index);
+                    let mut retained_index = 0;
+                    self.batches.retain(|_| {
+                        let keep = retention.get(retained_index).copied().unwrap_or(true);
+                        retained_index += 1;
+                        keep
+                    });
+                    info!(target: "batch_queue", timestamp = next_batch.batch.timestamp(), "Next batch found");
+                    return Ok(next_batch.batch);
                 }
                 BatchValidity::Undecided => {
-                    self.batches = processed
-                        .into_iter()
-                        .filter_map(|(batch, keep)| keep.then_some(batch))
-                        .chain(core::iter::once(batch))
-                        .chain(batches)
-                        .collect();
+                    let mut index = 0;
+                    self.batches.retain(|_| {
+                        let keep = retention.get(index).copied().unwrap_or(true);
+                        index += 1;
+                        keep
+                    });
                     return Err(PipelineError::Eof.temp());
                 }
                 BatchValidity::Past => {
                     if !is_holocene_active {
-                        // Preserve the pre-call queue on this critical error, including batches
-                        // already classified as `Drop`, matching the previous borrowed iteration.
-                        self.batches = processed
-                            .into_iter()
-                            .map(|(batch, _)| batch)
-                            .chain(core::iter::once(batch))
-                            .chain(batches)
-                            .collect();
                         error!(target: "batch_queue", "BatchValidity::Past is not allowed pre-holocene");
                         return Err(PipelineError::InvalidBatchValidity.crit());
                     }
 
+                    retention.push(false);
                     warn!(target: "batch_queue", parent_block_num = parent.block_info.number, "[HOLOCENE] Dropping outdated batch");
-                    continue;
                 }
             }
         }
-        self.batches = processed
-            .into_iter()
-            .filter_map(|(batch, keep)| keep.then_some(batch))
-            .chain(batches)
-            .collect();
-
-        if let Some(nb) = next_batch {
-            info!(target: "batch_queue", timestamp = nb.batch.timestamp(), "Next batch found");
-            return Ok(nb.batch);
-        }
+        let mut index = 0;
+        self.batches.retain(|_| {
+            let keep = retention[index];
+            index += 1;
+            keep
+        });
 
         // If the current epoch is too old compared to the L1 block we are at,
         // i.e. if the sequence window expired, we create empty batches for the current epoch
@@ -502,18 +491,56 @@ where
 #[cfg(test)]
 mod tests {
     use alloc::vec;
+    use core::{
+        future::pending,
+        sync::atomic::{AtomicBool, Ordering},
+        time::Duration,
+    };
 
     use alloy_eips::BlockNumHash;
     use alloy_primitives::{B256, address, b256};
+    use base_common_consensus::BaseBlock;
     use base_common_genesis::{ChainGenesis, RollupConfig, SystemConfig, UpgradeConfig};
-    use base_protocol::{BatchReader, SpanBatch, SpanBatchElement};
+    use base_protocol::{BatchReader, BatchValidationProvider, SpanBatch, SpanBatchElement};
     use tracing::Level;
 
     use super::*;
     use crate::{
         StageReset,
-        test_utils::{TestL2ChainProvider, TestNextBatchProvider},
+        test_utils::{TestL2ChainProvider, TestNextBatchProvider, TestProviderError},
     };
+
+    #[derive(Debug)]
+    struct PendingL2ChainProvider {
+        entered: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl BatchValidationProvider for PendingL2ChainProvider {
+        type Error = TestProviderError;
+
+        async fn l2_block_info_by_number(&mut self, _: u64) -> Result<L2BlockInfo, Self::Error> {
+            self.entered.store(true, Ordering::SeqCst);
+            pending().await
+        }
+
+        async fn block_by_number(&mut self, _: u64) -> Result<BaseBlock, Self::Error> {
+            unreachable!()
+        }
+    }
+
+    #[async_trait]
+    impl L2ChainProvider for PendingL2ChainProvider {
+        type Error = TestProviderError;
+
+        async fn system_config_by_number(
+            &mut self,
+            _: u64,
+            _: Arc<RollupConfig>,
+        ) -> Result<SystemConfig, <Self as L2ChainProvider>::Error> {
+            unreachable!()
+        }
+    }
 
     fn new_batch_reader() -> BatchReader {
         let file_contents =
@@ -901,6 +928,61 @@ mod tests {
         assert_eq!(result, PipelineError::Eof.temp());
         assert!(bq.is_last_in_span());
         assert_eq!(bq.batches.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_derive_next_batch_cancellation_preserves_queue() {
+        let cfg = Arc::new(RollupConfig {
+            upgrades: UpgradeConfig { delta_time: Some(0), ..Default::default() },
+            block_time: 2,
+            genesis: ChainGenesis { l2_time: 0, ..Default::default() },
+            ..Default::default()
+        });
+        let mock = TestNextBatchProvider::new(vec![]);
+        let entered = Arc::new(AtomicBool::new(false));
+        let fetcher = PendingL2ChainProvider { entered: Arc::clone(&entered) };
+        let mut bq = BatchQueue::new(cfg, mock, fetcher);
+        bq.origin = Some(BlockInfo::default());
+        bq.l1_blocks.push(BlockInfo::default());
+        bq.batches.push(BatchWithInclusionBlock {
+            inclusion_block: BlockInfo::default(),
+            batch: Batch::Single(SingleBatch { timestamp: 8, ..Default::default() }),
+        });
+        bq.batches.push(BatchWithInclusionBlock {
+            inclusion_block: BlockInfo::default(),
+            batch: Batch::Single(SingleBatch {
+                parent_hash: B256::repeat_byte(1),
+                timestamp: 6,
+                ..Default::default()
+            }),
+        });
+        bq.batches.push(BatchWithInclusionBlock {
+            inclusion_block: BlockInfo::default(),
+            batch: Batch::Span(SpanBatch {
+                batches: vec![
+                    SpanBatchElement { epoch_num: 0, timestamp: 2, transactions: Vec::new() },
+                    SpanBatchElement { epoch_num: 0, timestamp: 6, transactions: Vec::new() },
+                ],
+                ..Default::default()
+            }),
+        });
+        bq.batches.push(BatchWithInclusionBlock {
+            inclusion_block: BlockInfo::default(),
+            batch: Batch::Single(SingleBatch { timestamp: 10, ..Default::default() }),
+        });
+        let expected = bq.batches.clone();
+        let parent = L2BlockInfo {
+            block_info: BlockInfo { number: 2, timestamp: 4, ..Default::default() },
+            ..Default::default()
+        };
+
+        let result =
+            tokio::time::timeout(Duration::from_millis(10), bq.derive_next_batch(false, parent))
+                .await;
+
+        assert!(result.is_err(), "{result:?}");
+        assert!(entered.load(Ordering::SeqCst));
+        assert_eq!(bq.batches, expected);
     }
 
     #[tokio::test]

--- a/crates/consensus/derive/src/stages/batch/batch_queue.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_queue.rs
@@ -132,9 +132,9 @@ where
         // Go over all batches, in order of inclusion, and find the first batch we can accept.
         // Filter in-place by only remembering the batches that may be processed in the future, or
         // any undecided ones.
-        let mut remaining = Vec::new();
-        for i in 0..self.batches.len() {
-            let batch = &self.batches[i];
+        let mut processed = Vec::new();
+        let mut batches = core::mem::take(&mut self.batches).into_iter();
+        while let Some(batch) = batches.next() {
             let validity =
                 batch.check_batch(&self.cfg, &self.l1_blocks, parent, &mut self.fetcher).await;
             match validity {
@@ -143,13 +143,15 @@ where
                     //
                     // See: <https://specs.base.org/upgrades/holocene/derivation#batch_queue>
                     if !self.cfg.is_holocene_active(origin.timestamp) {
-                        remaining.push(batch.clone());
+                        processed.push((batch, true));
                     } else {
+                        processed.push((batch, false));
                         self.prev.flush();
                         warn!(target: "batch_queue", parent_block_num = parent.block_info.number, "[HOLOCENE] Dropping future batch");
                     }
                 }
                 BatchValidity::Drop(reason) => {
+                    processed.push((batch, false));
                     // If we drop a batch, flush previous batches buffered in the BatchStream
                     // stage.
                     self.prev.flush();
@@ -157,29 +159,43 @@ where
                     continue;
                 }
                 BatchValidity::Accept => {
-                    next_batch = Some(batch.clone());
+                    next_batch = Some(batch);
                     // Don't keep the current batch in the remaining items since we are processing
                     // it now, but retain every batch we didn't get to yet.
-                    remaining.extend_from_slice(&self.batches[i + 1..]);
                     break;
                 }
                 BatchValidity::Undecided => {
-                    remaining.extend_from_slice(&self.batches[i..]);
-                    self.batches = remaining;
+                    self.batches = processed
+                        .into_iter()
+                        .filter_map(|(batch, keep)| keep.then_some(batch))
+                        .chain(core::iter::once(batch))
+                        .chain(batches)
+                        .collect();
                     return Err(PipelineError::Eof.temp());
                 }
                 BatchValidity::Past => {
                     if !self.cfg.is_holocene_active(origin.timestamp) {
+                        self.batches = processed
+                            .into_iter()
+                            .map(|(batch, _)| batch)
+                            .chain(core::iter::once(batch))
+                            .chain(batches)
+                            .collect();
                         error!(target: "batch_queue", "BatchValidity::Past is not allowed pre-holocene");
                         return Err(PipelineError::InvalidBatchValidity.crit());
                     }
 
+                    processed.push((batch, false));
                     warn!(target: "batch_queue", parent_block_num = parent.block_info.number, "[HOLOCENE] Dropping outdated batch");
                     continue;
                 }
             }
         }
-        self.batches = remaining;
+        self.batches = processed
+            .into_iter()
+            .filter_map(|(batch, keep)| keep.then_some(batch))
+            .chain(batches)
+            .collect();
 
         if let Some(nb) = next_batch {
             info!(target: "batch_queue", timestamp = nb.batch.timestamp(), "Next batch found");


### PR DESCRIPTION
## Summary

Move queued batches through derivation filtering instead of cloning retained, accepted, and unvisited batches.

A queued `BatchWithInclusionBlock` can own all transaction bytes for a singular or span batch. Previously, one derivation pass deep-cloned every pre-Holocene future batch, the accepted batch, and every unvisited tail batch. The queue now temporarily owns the input and reconstructs it by moving items; error paths preserve the prior queue behavior.
