### PR TITLE
refactor(BOP-441): version the shared IB20 ABI per hardfork

### DIFF
--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -23,7 +23,6 @@ use crate::{
     IB20::{self, IB20Calls as C},
     IB20Asset::{self, IB20AssetCalls as SC},
     NoopPrecompileCallObserver, PermitArgs, PolicyAccounting, PrecompileCallObserver,
-    macros::decode_precompile_call,
 };
 
 impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
@@ -136,8 +135,9 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
             });
         }
 
-        // Fall through to inherited IB20 selectors.
-        let call = decode_precompile_call!(calldata, IB20::IB20Calls);
+        // Inherited IB20 selectors, decoded against the wire surface frozen for this version so
+        // historical forks see exactly the surface they shipped with.
+        let call = version.abi().decode(calldata)?;
         let label = call.as_label();
 
         observer.observe(label, || self.handle_b20_call(ctx, call, version, privileged))

--- a/crates/common/precompiles/src/b20_asset/versions.rs
+++ b/crates/common/precompiles/src/b20_asset/versions.rs
@@ -9,7 +9,7 @@
 
 use base_common_genesis::BaseUpgrade;
 
-use crate::{Asset, AssetAccounting, AssetV1, AssetV2, PolicyAccounting};
+use crate::{Asset, AssetAccounting, AssetV1, AssetV2, B20Abi, PolicyAccounting};
 
 /// An activated version of the asset B-20 precompile logic.
 ///
@@ -37,6 +37,14 @@ impl AssetVersion {
         match self {
             Self::V1 => &V1,
             Self::V2 => &V2,
+        }
+    }
+
+    /// Returns the shared `IB20` wire surface frozen for this version.
+    pub const fn abi(self) -> B20Abi {
+        match self {
+            Self::V1 => B20Abi::V1,
+            Self::V2 => B20Abi::V2,
         }
     }
 }

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -21,7 +21,6 @@ use crate::{
     IB20Stablecoin::{self, IB20StablecoinCalls as SC},
     NoopPrecompileCallObserver, PermitArgs, PolicyAccounting, PrecompileCallObserver,
     StablecoinAccounting, StablecoinV1, StablecoinVersion, StablecoinVersions,
-    macros::decode_precompile_call,
 };
 
 impl<S: StablecoinAccounting, A: PolicyAccounting> B20StablecoinToken<S, A> {
@@ -119,7 +118,9 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> B20StablecoinToken<S, A> {
             });
         }
 
-        let call = decode_precompile_call!(calldata, IB20::IB20Calls);
+        // Inherited IB20 selectors, decoded against the wire surface frozen for this version so
+        // historical forks see exactly the surface they shipped with.
+        let call = version.abi().decode(calldata)?;
         let label = call.as_label();
 
         observer.observe(label, || {

--- a/crates/common/precompiles/src/b20_stablecoin/versions.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/versions.rs
@@ -9,7 +9,9 @@
 
 use base_common_genesis::BaseUpgrade;
 
-use crate::{PolicyAccounting, Stablecoin, StablecoinAccounting, StablecoinV1, StablecoinV2};
+use crate::{
+    B20Abi, PolicyAccounting, Stablecoin, StablecoinAccounting, StablecoinV1, StablecoinV2,
+};
 
 /// An activated version of the stablecoin B-20 precompile logic.
 ///
@@ -35,6 +37,18 @@ impl StablecoinVersion {
         match self {
             Self::V1 => &V1,
             Self::V2 => &V2,
+        }
+    }
+
+    /// Returns the shared `IB20` wire surface frozen for this version.
+    ///
+    /// The seize surface — the `SEIZE` pause feature and the seize functions/getters — arrived at
+    /// Cobalt with `V2`. `V1` decodes against the frozen Beryl surface so that discriminant and
+    /// those selectors stay unreachable, matching the pre-Cobalt binary.
+    pub const fn abi(self) -> B20Abi {
+        match self {
+            Self::V1 => B20Abi::V1,
+            Self::V2 => B20Abi::V2,
         }
     }
 }

--- a/crates/common/precompiles/src/common/abi/mod.rs
+++ b/crates/common/precompiles/src/common/abi/mod.rs
@@ -1,0 +1,179 @@
+//! Versioned wire (ABI) surfaces for the shared `IB20` interface, one per hardfork that moved them.
+//!
+//! `IB20` is shared by the asset and stablecoin B-20 precompiles and is unversioned in Solidity,
+//! but the wire it accepts need not be frozen forever: a hardfork may widen a `sol!` enum or add
+//! selectors. A widened enum is decoded *before* version dispatch, so — unlike a brand-new selector,
+//! which a caller cannot dial until a surface declares it — a new enum discriminant would otherwise
+//! decode against the canonical surface at every historical fork. Freezing the surface each fork
+//! shipped, and decoding calldata against the surface active at the block's fork, keeps historical
+//! behavior byte-for-byte stable.
+//!
+//! The latest surface is always named `IB20` in its `vN` module, then re-exported here as both
+//! [`IB20`] (canonical) and the highest `IB20VN`. Older forks keep the same `IB20` Rust name inside
+//! their module so truncated-calldata revert bytes stay stable, and are re-exported as [`IB20V1`].
+//!
+//! Both surfaces are reached only through [`B20Abi`], selected per version by the asset/stablecoin
+//! version resolvers (`AssetVersion::abi` / `StablecoinVersion::abi`).
+
+use alloc::string::ToString;
+
+use alloy_sol_types::SolInterface;
+use base_precompile_storage::{BasePrecompileError, Result};
+
+mod v1;
+pub use v1::IB20 as IB20V1;
+
+mod v2;
+pub use v2::{IB20, IB20 as IB20V2};
+
+impl IB20::IB20Calls {
+    /// Returns the stable label for this decoded B-20 call.
+    pub const fn as_label(&self) -> &'static str {
+        match self {
+            Self::name(_) => "precompile-b20-name",
+            Self::symbol(_) => "precompile-b20-symbol",
+            Self::decimals(_) => "precompile-b20-decimals",
+            Self::totalSupply(_) => "precompile-b20-totalSupply",
+            Self::balanceOf(_) => "precompile-b20-balanceOf",
+            Self::allowance(_) => "precompile-b20-allowance",
+            Self::supplyCap(_) => "precompile-b20-supplyCap",
+            Self::nonces(_) => "precompile-b20-nonces",
+            Self::contractURI(_) => "precompile-b20-contractURI",
+            Self::DEFAULT_ADMIN_ROLE(_) => "precompile-b20-DEFAULT_ADMIN_ROLE",
+            Self::MINT_ROLE(_) => "precompile-b20-MINT_ROLE",
+            Self::BURN_ROLE(_) => "precompile-b20-BURN_ROLE",
+            Self::BURN_BLOCKED_ROLE(_) => "precompile-b20-BURN_BLOCKED_ROLE",
+            Self::PAUSE_ROLE(_) => "precompile-b20-PAUSE_ROLE",
+            Self::UNPAUSE_ROLE(_) => "precompile-b20-UNPAUSE_ROLE",
+            Self::METADATA_ROLE(_) => "precompile-b20-METADATA_ROLE",
+            Self::TRANSFER_SENDER_POLICY(_) => "precompile-b20-TRANSFER_SENDER_POLICY",
+            Self::TRANSFER_RECEIVER_POLICY(_) => "precompile-b20-TRANSFER_RECEIVER_POLICY",
+            Self::TRANSFER_EXECUTOR_POLICY(_) => "precompile-b20-TRANSFER_EXECUTOR_POLICY",
+            Self::MINT_RECEIVER_POLICY(_) => "precompile-b20-MINT_RECEIVER_POLICY",
+            Self::hasRole(_) => "precompile-b20-hasRole",
+            Self::getRoleAdmin(_) => "precompile-b20-getRoleAdmin",
+            Self::pausedFeatures(_) => "precompile-b20-pausedFeatures",
+            Self::policyId(_) => "precompile-b20-policyId",
+            Self::isPaused(_) => "precompile-b20-isPaused",
+            Self::DOMAIN_SEPARATOR(_) => "precompile-b20-DOMAIN_SEPARATOR",
+            Self::eip712Domain(_) => "precompile-b20-eip712Domain",
+            Self::transfer(_) => "precompile-b20-transfer",
+            Self::transferFrom(_) => "precompile-b20-transferFrom",
+            Self::approve(_) => "precompile-b20-approve",
+            Self::transferWithMemo(_) => "precompile-b20-transferWithMemo",
+            Self::transferFromWithMemo(_) => "precompile-b20-transferFromWithMemo",
+            Self::mint(_) => "precompile-b20-mint",
+            Self::mintWithMemo(_) => "precompile-b20-mintWithMemo",
+            Self::burn(_) => "precompile-b20-burn",
+            Self::burnWithMemo(_) => "precompile-b20-burnWithMemo",
+            Self::burnBlocked(_) => "precompile-b20-burnBlocked",
+            Self::pause(_) => "precompile-b20-pause",
+            Self::unpause(_) => "precompile-b20-unpause",
+            Self::updateSupplyCap(_) => "precompile-b20-updateSupplyCap",
+            Self::updateName(_) => "precompile-b20-updateName",
+            Self::updateSymbol(_) => "precompile-b20-updateSymbol",
+            Self::updateContractURI(_) => "precompile-b20-updateContractURI",
+            Self::grantRole(_) => "precompile-b20-grantRole",
+            Self::revokeRole(_) => "precompile-b20-revokeRole",
+            Self::renounceRole(_) => "precompile-b20-renounceRole",
+            Self::renounceLastAdmin(_) => "precompile-b20-renounceLastAdmin",
+            Self::setRoleAdmin(_) => "precompile-b20-setRoleAdmin",
+            Self::updatePolicy(_) => "precompile-b20-updatePolicy",
+            Self::permit(_) => "precompile-b20-permit",
+        }
+    }
+}
+
+/// A frozen wire (ABI) surface of the shared `IB20` interface. Reached only through
+/// [`AssetVersion::abi`](crate::AssetVersion) / [`StablecoinVersion::abi`](crate::StablecoinVersion).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum B20Abi {
+    /// Earlier frozen wire surface.
+    V1,
+    /// Canonical (current) wire surface.
+    V2,
+}
+
+impl B20Abi {
+    /// Returns whether `selector` was dialable on this wire surface.
+    pub fn valid_selector(self, selector: [u8; 4]) -> bool {
+        match self {
+            Self::V1 => IB20V1::IB20Calls::valid_selector(selector),
+            Self::V2 => IB20V2::IB20Calls::valid_selector(selector),
+        }
+    }
+
+    /// Validates `calldata` against this wire surface via alloy's `abi_decode_validate`, discarding
+    /// the decoded call. Decoding against the frozen surface is what keeps an enum discriminant a
+    /// later fork added from being accepted at an earlier fork.
+    pub fn abi_decode_validate(self, calldata: &[u8], selector: [u8; 4]) -> Result<()> {
+        match self {
+            Self::V1 => IB20V1::IB20Calls::abi_decode_validate(calldata).map(|_| ()),
+            Self::V2 => IB20V2::IB20Calls::abi_decode_validate(calldata).map(|_| ()),
+        }
+        .map_err(|error| BasePrecompileError::AbiDecodeFailed {
+            selector,
+            error: error.to_string(),
+        })
+    }
+
+    /// Decodes `calldata` into a routable canonical call, gated on this wire surface.
+    ///
+    /// A selector absent from this surface returns `UnknownFunctionSelector`; a present selector is
+    /// validated against the frozen surface first and only then re-decoded against the canonical
+    /// surface so the caller matches on one call type across versions.
+    pub fn decode(self, calldata: &[u8]) -> Result<IB20::IB20Calls> {
+        let Some(selector) = calldata.first_chunk::<4>().copied() else {
+            return Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]));
+        };
+        if !self.valid_selector(selector) {
+            return Err(BasePrecompileError::UnknownFunctionSelector(selector));
+        }
+        self.abi_decode_validate(calldata, selector)?;
+
+        IB20::IB20Calls::abi_decode_validate(calldata).map_err(|error| {
+            BasePrecompileError::AbiDecodeFailed { selector, error: error.to_string() }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, U256};
+    use alloy_sol_types::SolInterface;
+
+    use super::{IB20, IB20V1, IB20V2};
+
+    #[test]
+    fn b20_call_labels_are_stable() {
+        assert_eq!(
+            IB20::IB20Calls::transfer(IB20::transferCall { to: Address::ZERO, amount: U256::ZERO })
+                .as_label(),
+            "precompile-b20-transfer"
+        );
+        assert_eq!(
+            IB20::IB20Calls::updateSupplyCap(IB20::updateSupplyCapCall {
+                newSupplyCap: U256::ZERO
+            })
+            .as_label(),
+            "precompile-b20-updateSupplyCap"
+        );
+    }
+
+    /// `SolInterface::NAME` lands in consensus data: the short-calldata branch of
+    /// `abi_decode_validate` builds its error from it, and `AbiDecodeFailed` puts that string on the
+    /// wire. Every frozen surface must keep the `IB20` Rust name.
+    #[test]
+    fn surface_interface_names_are_frozen() {
+        assert_eq!(IB20V1::IB20Calls::NAME, "IB20Calls");
+        assert_eq!(IB20V2::IB20Calls::NAME, "IB20Calls");
+    }
+
+    /// `abi_decode_validate` short-circuits on `len < MIN_DATA_LENGTH + 4` before looking at the
+    /// selector. Equal minimums across surfaces is what makes truncated calldata produce identical
+    /// bytes at every fork.
+    #[test]
+    fn surfaces_share_a_minimum_calldata_length() {
+        assert_eq!(IB20V1::IB20Calls::MIN_DATA_LENGTH, IB20V2::IB20Calls::MIN_DATA_LENGTH);
+    }
+}

--- a/crates/common/precompiles/src/common/abi/v1.rs
+++ b/crates/common/precompiles/src/common/abi/v1.rs
@@ -1,4 +1,7 @@
-//! ABI definition for the `IB20` interface.
+//! The shared `IB20` wire surface frozen at Beryl, the fork where the B-20 token precompiles
+//! activate.
+//!
+//! A new wire surface goes in a new `abi/vN.rs`; see [`super`].
 
 use alloy_sol_types::sol;
 
@@ -137,83 +140,26 @@ sol! {
     }
 }
 
-impl IB20::IB20Calls {
-    /// Returns the stable label for this decoded B-20 call.
-    pub const fn as_label(&self) -> &'static str {
-        match self {
-            Self::name(_) => "precompile-b20-name",
-            Self::symbol(_) => "precompile-b20-symbol",
-            Self::decimals(_) => "precompile-b20-decimals",
-            Self::totalSupply(_) => "precompile-b20-totalSupply",
-            Self::balanceOf(_) => "precompile-b20-balanceOf",
-            Self::allowance(_) => "precompile-b20-allowance",
-            Self::supplyCap(_) => "precompile-b20-supplyCap",
-            Self::nonces(_) => "precompile-b20-nonces",
-            Self::contractURI(_) => "precompile-b20-contractURI",
-            Self::DEFAULT_ADMIN_ROLE(_) => "precompile-b20-DEFAULT_ADMIN_ROLE",
-            Self::MINT_ROLE(_) => "precompile-b20-MINT_ROLE",
-            Self::BURN_ROLE(_) => "precompile-b20-BURN_ROLE",
-            Self::BURN_BLOCKED_ROLE(_) => "precompile-b20-BURN_BLOCKED_ROLE",
-            Self::PAUSE_ROLE(_) => "precompile-b20-PAUSE_ROLE",
-            Self::UNPAUSE_ROLE(_) => "precompile-b20-UNPAUSE_ROLE",
-            Self::METADATA_ROLE(_) => "precompile-b20-METADATA_ROLE",
-            Self::TRANSFER_SENDER_POLICY(_) => "precompile-b20-TRANSFER_SENDER_POLICY",
-            Self::TRANSFER_RECEIVER_POLICY(_) => "precompile-b20-TRANSFER_RECEIVER_POLICY",
-            Self::TRANSFER_EXECUTOR_POLICY(_) => "precompile-b20-TRANSFER_EXECUTOR_POLICY",
-            Self::MINT_RECEIVER_POLICY(_) => "precompile-b20-MINT_RECEIVER_POLICY",
-            Self::hasRole(_) => "precompile-b20-hasRole",
-            Self::getRoleAdmin(_) => "precompile-b20-getRoleAdmin",
-            Self::pausedFeatures(_) => "precompile-b20-pausedFeatures",
-            Self::policyId(_) => "precompile-b20-policyId",
-            Self::isPaused(_) => "precompile-b20-isPaused",
-            Self::DOMAIN_SEPARATOR(_) => "precompile-b20-DOMAIN_SEPARATOR",
-            Self::eip712Domain(_) => "precompile-b20-eip712Domain",
-            Self::transfer(_) => "precompile-b20-transfer",
-            Self::transferFrom(_) => "precompile-b20-transferFrom",
-            Self::approve(_) => "precompile-b20-approve",
-            Self::transferWithMemo(_) => "precompile-b20-transferWithMemo",
-            Self::transferFromWithMemo(_) => "precompile-b20-transferFromWithMemo",
-            Self::mint(_) => "precompile-b20-mint",
-            Self::mintWithMemo(_) => "precompile-b20-mintWithMemo",
-            Self::burn(_) => "precompile-b20-burn",
-            Self::burnWithMemo(_) => "precompile-b20-burnWithMemo",
-            Self::burnBlocked(_) => "precompile-b20-burnBlocked",
-            Self::pause(_) => "precompile-b20-pause",
-            Self::unpause(_) => "precompile-b20-unpause",
-            Self::updateSupplyCap(_) => "precompile-b20-updateSupplyCap",
-            Self::updateName(_) => "precompile-b20-updateName",
-            Self::updateSymbol(_) => "precompile-b20-updateSymbol",
-            Self::updateContractURI(_) => "precompile-b20-updateContractURI",
-            Self::grantRole(_) => "precompile-b20-grantRole",
-            Self::revokeRole(_) => "precompile-b20-revokeRole",
-            Self::renounceRole(_) => "precompile-b20-renounceRole",
-            Self::renounceLastAdmin(_) => "precompile-b20-renounceLastAdmin",
-            Self::setRoleAdmin(_) => "precompile-b20-setRoleAdmin",
-            Self::updatePolicy(_) => "precompile-b20-updatePolicy",
-            Self::permit(_) => "precompile-b20-permit",
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{Address, U256};
+    use alloy_sol_types::{SolEnum, SolInterface};
 
-    use crate::IB20;
+    use super::IB20;
 
+    /// See [`super`] — the interface name reaches consensus data via `AbiDecodeFailed` on short
+    /// calldata, so it is pinned rather than left to a future rename. Both surfaces must keep the
+    /// `IB20` Rust name so this string never moves.
     #[test]
-    fn b20_call_labels_are_stable() {
-        assert_eq!(
-            IB20::IB20Calls::transfer(IB20::transferCall { to: Address::ZERO, amount: U256::ZERO })
-                .as_label(),
-            "precompile-b20-transfer"
-        );
-        assert_eq!(
-            IB20::IB20Calls::updateSupplyCap(IB20::updateSupplyCapCall {
-                newSupplyCap: U256::ZERO,
-            })
-            .as_label(),
-            "precompile-b20-updateSupplyCap"
-        );
+    fn interface_name_is_frozen() {
+        assert_eq!(IB20::IB20Calls::NAME, "IB20Calls");
+    }
+
+    /// Beryl's `PausableFeature` has exactly three variants. The `SEIZE` discriminant (index 3)
+    /// must fail to decode here, so `pause`/`unpause`/`isPaused` carrying it revert with
+    /// `AbiDecodeFailed` (type check failed) at Beryl rather than decoding to a live feature.
+    #[test]
+    fn pausable_feature_rejects_seize_discriminant() {
+        assert_eq!(IB20::PausableFeature::COUNT, 3);
+        assert!(IB20::PausableFeature::try_from(3u8).is_err());
     }
 }

--- a/crates/common/precompiles/src/common/abi/v2.rs
+++ b/crates/common/precompiles/src/common/abi/v2.rs
@@ -1,0 +1,163 @@
+//! The shared `IB20` wire surface — the canonical live surface, re-exported unqualified by
+//! [`super`]. This is the surface a caller reaches today.
+//!
+//! A hardfork that moves the wire freezes the prior surface in a new `abi/vN.rs` and grows this one;
+//! see [`super`].
+
+use alloy_sol_types::sol;
+
+sol! {
+    #[derive(Debug, PartialEq, Eq)]
+    interface IB20 {
+        enum PausableFeature {
+            /// Transfer operations.
+            TRANSFER,
+            /// Mint operations.
+            MINT,
+            /// Burn operations.
+            BURN
+        }
+
+        // Errors
+
+        /// ETH was attached to a call targeting a nonpayable token selector.
+        error NonPayable();
+
+        error AccessControlUnauthorizedAccount(address account, bytes32 neededRole);
+        error Unauthorized();
+        error ContractPaused(PausableFeature feature);
+        error InsufficientAllowance(address spender, uint256 allowance, uint256 needed);
+        error InsufficientBalance(address sender, uint256 balance, uint256 needed);
+        error InvalidSender(address sender);
+        error InvalidReceiver(address receiver);
+        error InvalidApprover(address approver);
+        error InvalidSpender(address spender);
+        error InvalidAmount();
+        error EmptyFeatureSet();
+        error InvalidSupplyCap(uint256 currentSupply, uint256 proposedCap);
+        error SupplyCapExceeded(uint256 cap, uint256 attempted);
+        error PolicyForbids(bytes32 policyScope, uint64 policyId);
+        error PolicyNotFound(uint64 policyId);
+        error UnsupportedPolicyType(bytes32 policyScope);
+        error AccountNotBlocked(address account);
+        error ExpiredSignature(uint256 deadline);
+        error InvalidSigner(address signer, address owner);
+        error LastAdminCannotRenounce();
+        error NotSoleAdmin();
+        error AccessControlBadConfirmation();
+
+        // Events
+        event Transfer(address indexed from, address indexed to, uint256 amount);
+        event Approval(address indexed owner, address indexed spender, uint256 amount);
+        event Memo(address indexed caller, bytes32 indexed memo);
+        event BurnedBlocked(address indexed caller, address indexed from, uint256 amount);
+        event TransferredFromSeizable(address indexed caller, address indexed from, address indexed to, uint256 amount);
+        event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);
+        event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender);
+        event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole);
+        event LastAdminRenounced(address indexed previousAdmin);
+        event Paused(address indexed updater, PausableFeature[] features);
+        event Unpaused(address indexed updater, PausableFeature[] features);
+        event PolicyUpdated(bytes32 indexed policyScope, uint64 oldPolicyId, uint64 newPolicyId);
+        event SupplyCapUpdated(address indexed updater, uint256 oldSupplyCap, uint256 newSupplyCap);
+        event ContractURIUpdated();
+        event NameUpdated(address indexed updater, string newName);
+        event SymbolUpdated(address indexed updater, string newSymbol);
+        event EIP712DomainChanged();
+
+        // Role identifiers
+        function DEFAULT_ADMIN_ROLE() external view returns (bytes32);
+        function MINT_ROLE() external view returns (bytes32);
+        function BURN_ROLE() external view returns (bytes32);
+        function BURN_BLOCKED_ROLE() external view returns (bytes32);
+        function PAUSE_ROLE() external view returns (bytes32);
+        function UNPAUSE_ROLE() external view returns (bytes32);
+        function METADATA_ROLE() external view returns (bytes32);
+
+        // Policy type identifiers
+        function TRANSFER_SENDER_POLICY() external view returns (bytes32);
+        function TRANSFER_RECEIVER_POLICY() external view returns (bytes32);
+        function TRANSFER_EXECUTOR_POLICY() external view returns (bytes32);
+        function MINT_RECEIVER_POLICY() external view returns (bytes32);
+
+        // ERC-20
+        function name() external view returns (string);
+        function symbol() external view returns (string);
+        function decimals() external view returns (uint8);
+        function totalSupply() external view returns (uint256);
+        function balanceOf(address account) external view returns (uint256);
+        function allowance(address owner, address spender) external view returns (uint256);
+        function transfer(address to, uint256 amount) external returns (bool);
+        function transferFrom(address from, address to, uint256 amount) external returns (bool);
+        function approve(address spender, uint256 amount) external returns (bool);
+
+        // Metadata updates
+        function updateName(string calldata newName) external;
+        function updateSymbol(string calldata newSymbol) external;
+
+        // Memo transfer variants
+        function transferWithMemo(address to, uint256 amount, bytes32 memo) external returns (bool);
+        function transferFromWithMemo(address from, address to, uint256 amount, bytes32 memo) external returns (bool);
+
+        // Mint / burn
+        function mint(address to, uint256 amount) external;
+        function mintWithMemo(address to, uint256 amount, bytes32 memo) external;
+        function burn(uint256 amount) external;
+        function burnWithMemo(uint256 amount, bytes32 memo) external;
+        function burnBlocked(address from, uint256 amount) external;
+
+        // Roles
+        function hasRole(bytes32 role, address account) external view returns (bool);
+        function getRoleAdmin(bytes32 role) external view returns (bytes32);
+        function grantRole(bytes32 role, address account) external;
+        function revokeRole(bytes32 role, address account) external;
+        function renounceRole(bytes32 role, address callerConfirmation) external;
+        function renounceLastAdmin() external;
+        function setRoleAdmin(bytes32 role, bytes32 newAdminRole) external;
+
+        // Pause
+        function pausedFeatures() external view returns (PausableFeature[] memory);
+        function isPaused(PausableFeature feature) external view returns (bool);
+        function pause(PausableFeature[] calldata features) external;
+        function unpause(PausableFeature[] calldata features) external;
+
+        // Policy
+        function policyId(bytes32 policyScope) external view returns (uint64);
+        function updatePolicy(bytes32 policyScope, uint64 newPolicyId) external;
+
+        // Supply cap
+        function supplyCap() external view returns (uint256);
+        function updateSupplyCap(uint256 newSupplyCap) external;
+
+        // Permit (EIP-2612 + ERC-5267)
+        function DOMAIN_SEPARATOR() external view returns (bytes32);
+        function nonces(address owner) external view returns (uint256);
+        function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
+        function eip712Domain() external view returns (bytes1 fields, string memory name, string memory version, uint256 chainId, address verifyingContract, bytes32 salt, uint256[] memory extensions);
+
+        // Contract URI (ERC-7572)
+        function contractURI() external view returns (string);
+        function updateContractURI(string calldata newURI) external;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_sol_types::{SolEnum, SolInterface};
+
+    use super::IB20;
+
+    /// See [`super`] — the interface name reaches consensus data via `AbiDecodeFailed` on short
+    /// calldata, so it is pinned rather than left to a future rename.
+    #[test]
+    fn interface_name_is_frozen() {
+        assert_eq!(IB20::IB20Calls::NAME, "IB20Calls");
+    }
+
+    /// The current `PausableFeature` variant count. A widening fork bumps this in a new surface
+    /// while the frozen surfaces keep their own count.
+    #[test]
+    fn pausable_feature_variant_count() {
+        assert_eq!(IB20::PausableFeature::COUNT, 3);
+    }
+}

--- a/crates/common/precompiles/src/common/mod.rs
+++ b/crates/common/precompiles/src/common/mod.rs
@@ -1,7 +1,7 @@
 //! Shared business logic for all Base-native token variants.
 
 mod abi;
-pub use abi::IB20;
+pub use abi::{B20Abi, IB20, IB20V1, IB20V2};
 
 mod core_storage;
 pub use core_storage::B20CoreStorage;

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -39,9 +39,9 @@ pub use bls12_381::{
 
 mod common;
 pub use common::{
-    B20_MAX_SUPPLY_CAP, B20CoreStorage, B20Guards, B20PausableFeature, B20PolicyType, B20TokenRole,
-    Burnable, Configurable, Eip712Domain, IB20, Mintable, Pausable, PermitArgs, Permittable,
-    RoleManaged, Token, TokenAccounting, Transferable,
+    B20_MAX_SUPPLY_CAP, B20Abi, B20CoreStorage, B20Guards, B20PausableFeature, B20PolicyType,
+    B20TokenRole, Burnable, Configurable, Eip712Domain, IB20, IB20V1, IB20V2, Mintable, Pausable,
+    PermitArgs, Permittable, RoleManaged, Token, TokenAccounting, Transferable,
 };
 #[cfg(any(test, feature = "test-utils"))]
 pub use common::{FakePolicyAccounting, InMemoryTokenAccounting, TestStablecoinToken, TestToken};


### PR DESCRIPTION
Base of the BOP-441 stack. The seize PR (#4192) is stacked on top of this one.

## Why

`IB20` is shared by the asset and stablecoin B-20 precompiles and is unversioned in Solidity, but the wire it accepts need not be frozen forever. A hardfork may widen a `sol!` enum or add selectors, and a widened enum is decoded **before** version dispatch — so, unlike a brand-new selector (which a caller cannot dial until a surface declares it), a new enum discriminant would otherwise decode against the canonical surface at every historical fork. This introduces a per-fork frozen wire surface so calldata is decoded against the surface active at the block's fork.

This is the general mechanism, mirroring the policy-registry versioning in #4193. The immediate consumer is the seize surface (#4192): once `SEIZE` is added to v2 only, the frozen v1 rejects that discriminant automatically, with no hand-written gate.

## The change

- `common/abi.rs` becomes `common/abi/{mod,v1,v2}.rs`. `v1.rs` is the frozen copy; `v2.rs` is the canonical live surface. **In this PR v1 and v2 are byte-identical** (the currently shipped surface) — the split carries no behavior change on its own.
- Both declare `interface IB20`, so the Rust name (`IB20Calls`) — which reaches consensus data via `AbiDecodeFailed` on short calldata — never moves. Canonical aliases the newest surface; all external `IB20` references are untouched.
- New `B20Abi {V1, V2}` (shared by both precompiles): `valid_selector` / `abi_decode_validate` / `decode` (validates against the frozen surface, then re-decodes canonical so `route` matches one call type). Selected per version via `AssetVersion::abi` / `StablecoinVersion::abi`.
- Both dispatchers decode `IB20` via `version.abi().decode(...)` instead of the shared decode macro.

## Behavior

Behavior-preserving: `v1 == v2`, so every existing golden passes unchanged and no storage root moves.

## Verification

- `cargo test -p base-common-precompiles --features test-utils`: all pass (lib 668, asset 102, stablecoin 80, factory 21, policy 30/32).
- clippy and fmt clean.