### PR TITLE
fix(policy): revert IncompatiblePolicyType (not Panic 0x21) for composite policyType at V2 (BOP-476)

### DIFF
--- a/crates/common/precompiles/src/policy/logic/v2.rs
+++ b/crates/common/precompiles/src/policy/logic/v2.rs
@@ -191,11 +191,11 @@ impl PolicyRegistryV2 {
     /// rather than shared with [`super::PolicyRegistryV1`] so that widening the rule for a later
     /// fork cannot reach back and change what that frozen version accepts.
     fn validate_create_policy_inputs(admin: Address, policy_type: PolicyType) -> Result<u8> {
-        if !matches!(policy_type, PolicyType::BLOCKLIST | PolicyType::ALLOWLIST) {
-            return Err(BasePrecompileError::enum_conversion_error());
-        }
         if admin == Address::ZERO {
             return Err(BasePrecompileError::revert(IPolicyRegistry::ZeroAddress {}));
+        }
+        if !matches!(policy_type, PolicyType::BLOCKLIST | PolicyType::ALLOWLIST) {
+            return Err(BasePrecompileError::revert(IPolicyRegistry::IncompatiblePolicyType {}));
         }
         Ok(policy_type.as_discriminant())
     }
@@ -1053,14 +1053,24 @@ mod tests {
         assert_eq!(err, BasePrecompileError::revert(IPolicyRegistry::ZeroAddress {}));
     }
 
+    /// Precedence pin for the shared validator on the `createPolicyWithAccounts` path: a composite
+    /// type is rejected with `IncompatiblePolicyType` before the batch-size guard runs, matching
+    /// base-std's `ZeroAddress` -> `IncompatiblePolicyType` -> `BatchSizeTooLarge` order. Composite
+    /// discriminants (2/3) are the only invalid-type values that decode at V2 and reach the logic;
+    /// out-of-range bytes are rejected earlier at ABI decode (see `dispatch` tests).
     #[test]
-    fn create_policy_with_accounts_invalid_policy_type_precedes_batch_size_revert() {
+    fn create_policy_with_accounts_composite_type_precedes_batch_size_revert() {
         let mut rt = initialized();
         let accounts = many_accounts(PolicyRegistryV2::MAX_ACCOUNTS_PER_BATCH + 1);
-        let err = LOGIC
-            .create_policy_with_accounts(&mut rt, ADMIN, PolicyType::__Invalid, accounts)
-            .unwrap_err();
-        assert_eq!(err, BasePrecompileError::enum_conversion_error());
+        for policy_type in [PolicyType::UNION, PolicyType::INTERSECT] {
+            let err = LOGIC
+                .create_policy_with_accounts(&mut rt, ADMIN, policy_type, accounts.clone())
+                .unwrap_err();
+            assert_eq!(
+                err,
+                BasePrecompileError::revert(IPolicyRegistry::IncompatiblePolicyType {})
+            );
+        }
     }
 
     /// `createPolicy` admits only simple leaf types. `create_composite_policy` is the sole path
@@ -1071,7 +1081,21 @@ mod tests {
         let mut rt = initialized();
         for policy_type in [PolicyType::UNION, PolicyType::INTERSECT] {
             let err = LOGIC.create_policy(&mut rt, ADMIN, policy_type).unwrap_err();
-            assert_eq!(err, BasePrecompileError::enum_conversion_error());
+            assert_eq!(
+                err,
+                BasePrecompileError::revert(IPolicyRegistry::IncompatiblePolicyType {})
+            );
+        }
+    }
+
+    /// Precedence pin: a zero admin is rejected before the composite-type check, matching the
+    /// base-std natspec order (`ZeroAddress` before `IncompatiblePolicyType`).
+    #[test]
+    fn create_policy_zero_admin_precedes_incompatible_type() {
+        let mut rt = initialized();
+        for policy_type in [PolicyType::UNION, PolicyType::INTERSECT] {
+            let err = LOGIC.create_policy(&mut rt, Address::ZERO, policy_type).unwrap_err();
+            assert_eq!(err, BasePrecompileError::revert(IPolicyRegistry::ZeroAddress {}));
         }
     }
 

--- a/crates/common/precompiles/tests/b20_policy_v2_golden.rs
+++ b/crates/common/precompiles/tests/b20_policy_v2_golden.rs
@@ -349,6 +349,22 @@ fn golden_create_reverts_zero_admin() {
     assert_eq!(bytes, Bytes::from(IPolicyRegistry::ZeroAddress {}.abi_encode()));
 }
 
+/// A composite discriminant (UNION/INTERSECT) decodes at V2 (the enum widened at Cobalt) and
+/// reaches the logic, which rejects it with `IncompatiblePolicyType` rather than a `Panic(0x21)`.
+/// The revert body is exactly the 4-byte selector (no args); this is a revert-only path, so no
+/// state-root golden moves.
+#[test]
+fn golden_create_policy_composite_type_is_incompatible_policy_type_in_v2() {
+    for policy_type in [PolicyType::UNION, PolicyType::INTERSECT] {
+        let calldata = IPolicyRegistry::createPolicyCall { admin: ADMIN, policyType: policy_type }
+            .abi_encode();
+        let mut s = fresh();
+        let (rev, bytes) = call_policy(&mut s, ADMIN, calldata);
+        assert!(rev);
+        assert_eq!(bytes, Bytes::from(IPolicyRegistry::IncompatiblePolicyType::SELECTOR.as_ref()));
+    }
+}
+
 // ============================================================================
 // composite policies (V2: UNION / INTERSECT)
 // ============================================================================
@@ -971,6 +987,7 @@ fn v2_op_coverage_checklist(call: IPolicyRegistry::IPolicyRegistryCalls) {
             golden_create_blocklist,
             golden_create_allowlist,
             golden_create_reverts_zero_admin,
+            golden_create_policy_composite_type_is_incompatible_policy_type_in_v2,
         ]),
         C::createPolicyWithAccounts(_) => covered(&[
             golden_create_with_accounts,


### PR DESCRIPTION
## Summary
- At Cobalt the `PolicyType` enum widens to 4 variants, so `createPolicy(admin, 2|3)` and `createPolicyWithAccounts(admin, 2|3, ..)` now decode at V2 and reach the logic layer. A composite (`UNION`/`INTERSECT`) discriminant previously produced an enum-conversion `Panic(0x21)`; this makes both simple-policy constructors revert the typed `IncompatiblePolicyType` instead, per the `IPolicyRegistry` natspec and base-std #176 (composites are minted only via `createCompositePolicy`, which already uses this error for the mirror case).
- Reorders the shared `validate_create_policy_inputs` so the zero-admin check precedes the composite-type check — matching #176's `ZeroAddress` → `IncompatiblePolicyType` (→ `BatchSizeTooLarge` on the with-accounts path). One edit covers both entry points.
- Safe pre-emptively: V1 (Beryl) stays frozen and rejects discriminant 2/3 at ABI-decode with `AbiDecodeFailed`; Cobalt has not shipped, so `Panic(0x21)` was never on-chain. **V1 logic is byte-identical.**
- Tests: updates the V2 composite-rejection unit test, adds a zero-admin precedence test, retargets the with-accounts precedence test at the reachable composite case, and adds a V2 golden byte-pin for the 4-byte `IncompatiblePolicyType` selector. Revert-only path — no storage writes, so **no state-root golden was re-blessed**.

## Hard dependency
Must land in lockstep with base-std #176 (`fix/createpolicy-reject-composite-type`), and the base-std fork pin must be bumped together. The Cobalt fork-conformance gate runs #176's tests against this live Rust binary and expects `IncompatiblePolicyType`; landing one without the other breaks that gate.

## Test plan
- [x] `cargo test -p base-common-precompiles --features test-utils` (unit + golden, incl. the new BOP-476 tests; all existing `assert_root` goldens still pass → no root moved)
- [x] `cargo clippy -p base-common-precompiles --features test-utils --all-targets` (no new allow-lints)
- [x] `cargo fmt --check`
- [ ] Fork conformance: build base-anvil (Cobalt line) with the local `[patch]` at this branch + base-std #176, then `make fork-tests ARGS="--match-path 'test/unit/PolicyRegistry/*'"`
- [ ] Smoke invariants against a Cobalt chain (base-std probe added in the paired branch)

Made with [Cursor](https://cursor.com)