### PR TITLE
feat(policy): add compositePolicyChildIds view for composite child sets

### DIFF
--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -38,7 +38,7 @@ jobs:
           - fork: Cobalt
             key: cobalt
             base_anvil_ref: ae7557c4f8602caa1da0be33143bb2504c85b0c8
-            base_std_ref: f6522c560e30554a4bf01dccf32a100cbba76eb3
+            base_std_ref: b0a4f048684c4cd279025bf2ba3aa76c45569fa4
     env:
       FORK_NAME: ${{ matrix.fork }}
       FORK_KEY: ${{ matrix.key }}

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -38,7 +38,7 @@ jobs:
           - fork: Cobalt
             key: cobalt
             base_anvil_ref: ae7557c4f8602caa1da0be33143bb2504c85b0c8
-            base_std_ref: b0a4f048684c4cd279025bf2ba3aa76c45569fa4
+            base_std_ref: f6522c560e30554a4bf01dccf32a100cbba76eb3
     env:
       FORK_NAME: ${{ matrix.fork }}
       FORK_KEY: ${{ matrix.key }}

--- a/crates/common/precompiles/src/b20_asset/accounting.rs
+++ b/crates/common/precompiles/src/b20_asset/accounting.rs
@@ -5,7 +5,7 @@ use alloc::string::String;
 use alloy_primitives::U256;
 use base_precompile_storage::Result;
 
-use crate::TokenAccounting;
+use crate::{TokenAccounting, macros::reject_frozen_selector};
 
 /// Extends [`TokenAccounting`] with asset-token-specific storage slots.
 ///

--- a/crates/common/precompiles/src/b20_asset/logic/interface.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/interface.rs
@@ -7,6 +7,7 @@ use base_precompile_storage::Result;
 
 use crate::{
     AssetAccounting, B20AssetToken, Eip712Domain, IB20, PermitArgs, PolicyAccounting, Token,
+    macros::reject_frozen_selector,
 };
 
 /// The asset logic interface.

--- a/crates/common/precompiles/src/b20_asset/mod.rs
+++ b/crates/common/precompiles/src/b20_asset/mod.rs
@@ -1,27 +1,5 @@
 //! `B20AssetToken` native precompile — asset variant of the B-20 token.
 
-/// Rejects a call as an unknown selector, freezing the observable behavior of every version that
-/// predates the selector.
-///
-/// The ERC-8056 scheduled-multiplier surface lives as **shared trait defaults** on [`Asset`] and
-/// [`AssetAccounting`], so each version inherits these bodies until it explicitly overrides them.
-/// A version introduced *before* a selector existed must reject it exactly as it did at its
-/// activation fork. Returning `UnknownFunctionSelector` rather than an `Ok` or a real value keeps
-/// re-executing a historical block on a newer binary byte-identical to what the chain already
-/// committed; any other default would retroactively change an older version's state transition, i.e.
-/// a silent hardfork.
-///
-/// The `[0u8; 4]` is a placeholder: the dispatcher rejects these selectors on the raw calldata,
-/// before any version method is reached (see the fork gate in `route`), so a reachable call never
-/// actually returns this value. Pinned by `golden_v2_selectors_unknown_at_v1`.
-macro_rules! reject_frozen_selector {
-    () => {
-        ::core::result::Result::Err(
-            ::base_precompile_storage::BasePrecompileError::UnknownFunctionSelector([0u8; 4]),
-        )
-    };
-}
-
 mod abi;
 pub use abi::{ERC165_INTERFACE_ID, ERC8056_INTERFACE_IDS, IB20Asset};
 

--- a/crates/common/precompiles/src/macros.rs
+++ b/crates/common/precompiles/src/macros.rs
@@ -77,6 +77,29 @@ macro_rules! decode_precompile_call {
 
 pub(crate) use decode_precompile_call;
 
+/// Rejects a call as an unknown selector, freezing the observable behavior of every version that
+/// predates the selector.
+///
+/// Selectors added by a later fork live as **shared trait defaults** on the logic and accounting
+/// traits, so each version inherits these bodies until it explicitly overrides them. A version
+/// introduced *before* a selector existed must reject it exactly as it did at its activation fork.
+/// Returning `UnknownFunctionSelector` rather than an `Ok` or a real value keeps re-executing a
+/// historical block on a newer binary byte-identical to what the chain already committed; any other
+/// default would retroactively change an older version's state transition, i.e. a silent hardfork.
+///
+/// The `[0u8; 4]` is a placeholder: the dispatcher rejects these selectors on the raw calldata,
+/// before any version method is reached (see each precompile's fork gate in `route`), so a
+/// reachable call never actually returns this value.
+macro_rules! reject_frozen_selector {
+    () => {
+        ::core::result::Result::Err(
+            ::base_precompile_storage::BasePrecompileError::UnknownFunctionSelector([0u8; 4]),
+        )
+    };
+}
+
+pub(crate) use reject_frozen_selector;
+
 #[cfg(test)]
 mod tests {
     use alloy_sol_types::SolCall;

--- a/crates/common/precompiles/src/macros.rs
+++ b/crates/common/precompiles/src/macros.rs
@@ -79,17 +79,6 @@ pub(crate) use decode_precompile_call;
 
 /// Rejects a call as an unknown selector, freezing the observable behavior of every version that
 /// predates the selector.
-///
-/// Selectors added by a later fork live as **shared trait defaults** on the logic and accounting
-/// traits, so each version inherits these bodies until it explicitly overrides them. A version
-/// introduced *before* a selector existed must reject it exactly as it did at its activation fork.
-/// Returning `UnknownFunctionSelector` rather than an `Ok` or a real value keeps re-executing a
-/// historical block on a newer binary byte-identical to what the chain already committed; any other
-/// default would retroactively change an older version's state transition, i.e. a silent hardfork.
-///
-/// The `[0u8; 4]` is a placeholder: the dispatcher rejects these selectors on the raw calldata,
-/// before any version method is reached (see each precompile's fork gate in `route`), so a
-/// reachable call never actually returns this value.
 macro_rules! reject_frozen_selector {
     () => {
         ::core::result::Result::Err(

--- a/crates/common/precompiles/src/policy/abi/mod.rs
+++ b/crates/common/precompiles/src/policy/abi/mod.rs
@@ -55,10 +55,6 @@ mod tests {
         b256!("1ae189209c8c4875de2caa707322ea74f0d1f3e74a1104ecee6884e8984415da");
 
     /// Absolute wire fingerprint for Cobalt's (canonical) surface.
-    ///
-    /// Re-blessed when `compositePolicyChildIds` joined the surface — legitimate only because
-    /// Cobalt has never activated (`BaseUpgrade::LATEST` is Beryl, every real chain config leaves
-    /// `cobalt` unset). Once Cobalt ships, a change here means a new `abi/v3.rs` instead.
     const V2_ABI_FINGERPRINT: B256 =
         b256!("cc5f508d2cacd9b729ddbd7a7d9ed3788929fdbb237c286e5a9d8961a90cf656");
 

--- a/crates/common/precompiles/src/policy/abi/mod.rs
+++ b/crates/common/precompiles/src/policy/abi/mod.rs
@@ -28,6 +28,7 @@ impl IPolicyRegistry::IPolicyRegistryCalls {
             Self::policyExists(_) => "policy.policyExists",
             Self::policyAdmin(_) => "policy.policyAdmin",
             Self::pendingPolicyAdmin(_) => "policy.pendingPolicyAdmin",
+            Self::compositePolicyChildIds(_) => "policy.compositePolicyChildIds",
         }
     }
 }
@@ -54,8 +55,13 @@ mod tests {
         b256!("1ae189209c8c4875de2caa707322ea74f0d1f3e74a1104ecee6884e8984415da");
 
     /// Absolute wire fingerprint for Cobalt's (canonical) surface.
+    ///
+    /// Re-blessed when `compositePolicyChildIds` joined the surface. Legitimate only because
+    /// Cobalt has never activated on any network (`BaseUpgrade::LATEST` is Beryl, and every real
+    /// chain config leaves `cobalt` unset), so no historical execution depends on the old value.
+    /// Once Cobalt ships, a change here means a new `abi/v3.rs` instead.
     const V2_ABI_FINGERPRINT: B256 =
-        b256!("047d1fceaa9beac82fd473d474bb7f3b6dcd720c9e62c86facc75ef6dd611631");
+        b256!("cc5f508d2cacd9b729ddbd7a7d9ed3788929fdbb237c286e5a9d8961a90cf656");
 
     /// Keccak of sorted call selectors, then sorted event topic0s, then sorted error selectors,
     /// then `PolicyType::COUNT`. Order is fixed so a single pin catches any wire-surface edit.

--- a/crates/common/precompiles/src/policy/abi/mod.rs
+++ b/crates/common/precompiles/src/policy/abi/mod.rs
@@ -56,10 +56,9 @@ mod tests {
 
     /// Absolute wire fingerprint for Cobalt's (canonical) surface.
     ///
-    /// Re-blessed when `compositePolicyChildIds` joined the surface. Legitimate only because
-    /// Cobalt has never activated on any network (`BaseUpgrade::LATEST` is Beryl, and every real
-    /// chain config leaves `cobalt` unset), so no historical execution depends on the old value.
-    /// Once Cobalt ships, a change here means a new `abi/v3.rs` instead.
+    /// Re-blessed when `compositePolicyChildIds` joined the surface — legitimate only because
+    /// Cobalt has never activated (`BaseUpgrade::LATEST` is Beryl, every real chain config leaves
+    /// `cobalt` unset). Once Cobalt ships, a change here means a new `abi/v3.rs` instead.
     const V2_ABI_FINGERPRINT: B256 =
         b256!("cc5f508d2cacd9b729ddbd7a7d9ed3788929fdbb237c286e5a9d8961a90cf656");
 

--- a/crates/common/precompiles/src/policy/abi/v2.rs
+++ b/crates/common/precompiles/src/policy/abi/v2.rs
@@ -66,6 +66,9 @@ sol! {
         function policyExists(uint64 policyId) external view returns (bool);
         function policyAdmin(uint64 policyId) external view returns (address);
         function pendingPolicyAdmin(uint64 policyId) external view returns (address);
+        /// Introduced in V2 (Cobalt). Returns the live child set of a composite policy, or an
+        /// empty array for simple policies, built-in sentinels, unknown IDs, and malformed IDs.
+        function compositePolicyChildIds(uint64 policyId) external view returns (uint64[] memory);
     }
 }
 
@@ -117,10 +120,11 @@ mod tests {
             IPolicyRegistry::policyExistsCall::SELECTOR,
             IPolicyRegistry::policyAdminCall::SELECTOR,
             IPolicyRegistry::pendingPolicyAdminCall::SELECTOR,
+            IPolicyRegistry::compositePolicyChildIdsCall::SELECTOR,
         ];
         expected.sort_unstable();
 
-        assert_eq!(selectors.len(), 13);
+        assert_eq!(selectors.len(), 14);
         assert_eq!(selectors, expected);
     }
 }

--- a/crates/common/precompiles/src/policy/abi/v2.rs
+++ b/crates/common/precompiles/src/policy/abi/v2.rs
@@ -66,8 +66,7 @@ sol! {
         function policyExists(uint64 policyId) external view returns (bool);
         function policyAdmin(uint64 policyId) external view returns (address);
         function pendingPolicyAdmin(uint64 policyId) external view returns (address);
-        /// Introduced in V2 (Cobalt). Returns a composite policy's child set, in the order it
-        /// was last written. Empty for anything else. Never reverts.
+        /// Introduced in V2 (Cobalt). Read function for composite policy child IDs.
         function compositePolicyChildIds(uint64 policyId) external view returns (uint64[] memory);
     }
 }

--- a/crates/common/precompiles/src/policy/abi/v2.rs
+++ b/crates/common/precompiles/src/policy/abi/v2.rs
@@ -66,8 +66,8 @@ sol! {
         function policyExists(uint64 policyId) external view returns (bool);
         function policyAdmin(uint64 policyId) external view returns (address);
         function pendingPolicyAdmin(uint64 policyId) external view returns (address);
-        /// Introduced in V2 (Cobalt). Returns the live child set of a composite policy, or an
-        /// empty array for simple policies, built-in sentinels, unknown IDs, and malformed IDs.
+        /// Introduced in V2 (Cobalt). Returns a composite policy's child set, in the order it
+        /// was last written. Empty for anything else. Never reverts.
         function compositePolicyChildIds(uint64 policyId) external view returns (uint64[] memory);
     }
 }

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -64,7 +64,8 @@ impl PolicyRegistryStorage<'_> {
                     && (sel == IPolicyRegistry::isAuthorizedCall::SELECTOR
                         || sel == IPolicyRegistry::policyExistsCall::SELECTOR
                         || sel == IPolicyRegistry::policyAdminCall::SELECTOR
-                        || sel == IPolicyRegistry::pendingPolicyAdminCall::SELECTOR) =>
+                        || sel == IPolicyRegistry::pendingPolicyAdminCall::SELECTOR
+                        || sel == IPolicyRegistry::compositePolicyChildIdsCall::SELECTOR) =>
             {
                 self.route(calldata, version, &observer)
             }
@@ -172,6 +173,12 @@ impl PolicyRegistryStorage<'_> {
             C::updateComposite(call) => {
                 logic.update_composite(self, call.policyId, call.childPolicyIds)?;
                 Ok(Bytes::new())
+            }
+            // Introduced in V2 (Cobalt).
+            C::compositePolicyChildIds(call) => {
+                let children = logic.composite_policy_child_ids(self, call.policyId)?;
+                Ok(IPolicyRegistry::compositePolicyChildIdsCall::abi_encode_returns(&children)
+                    .into())
             }
         }
     }

--- a/crates/common/precompiles/src/policy/logic/interface.rs
+++ b/crates/common/precompiles/src/policy/logic/interface.rs
@@ -95,9 +95,9 @@ pub trait PolicyRegistryLogic<S: PolicyAccounting> {
     /// Returns the staged pending admin for `policy_id`, or `Address::ZERO` if none.
     fn pending_policy_admin(&self, storage: &S, policy_id: u64) -> Result<Address>;
 
-    /// Returns the live child set of a composite policy, empty for anything else.
-    /// Composite support is a V2 feature; the selector is absent from the V1 wire surface, so
-    /// this default is unreachable and reverts to match the other composite defaults above.
+    /// Returns a composite policy's child set, empty for anything else.
+    /// Composite support is a V2 feature; the V1 surface omits the selector, so this default is
+    /// unreachable and reverts to match the other composite defaults above.
     fn composite_policy_child_ids(&self, _storage: &S, _policy_id: u64) -> Result<Vec<u64>> {
         Err(BasePrecompileError::Revert(Bytes::new()))
     }

--- a/crates/common/precompiles/src/policy/logic/interface.rs
+++ b/crates/common/precompiles/src/policy/logic/interface.rs
@@ -94,4 +94,11 @@ pub trait PolicyRegistryLogic<S: PolicyAccounting> {
 
     /// Returns the staged pending admin for `policy_id`, or `Address::ZERO` if none.
     fn pending_policy_admin(&self, storage: &S, policy_id: u64) -> Result<Address>;
+
+    /// Returns the live child set of a composite policy, empty for anything else.
+    /// Composite support is a V2 feature; the selector is absent from the V1 wire surface, so
+    /// this default is unreachable and reverts to match the other composite defaults above.
+    fn composite_policy_child_ids(&self, _storage: &S, _policy_id: u64) -> Result<Vec<u64>> {
+        Err(BasePrecompileError::Revert(Bytes::new()))
+    }
 }

--- a/crates/common/precompiles/src/policy/logic/interface.rs
+++ b/crates/common/precompiles/src/policy/logic/interface.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 use alloy_primitives::{Address, Bytes};
 use base_precompile_storage::{BasePrecompileError, Result};
 
-use crate::{IPolicyRegistry::PolicyType, PolicyAccounting};
+use crate::{IPolicyRegistry::PolicyType, PolicyAccounting, macros::reject_frozen_selector};
 
 /// The policy-registry logic interface.
 ///
@@ -95,10 +95,8 @@ pub trait PolicyRegistryLogic<S: PolicyAccounting> {
     /// Returns the staged pending admin for `policy_id`, or `Address::ZERO` if none.
     fn pending_policy_admin(&self, storage: &S, policy_id: u64) -> Result<Address>;
 
-    /// Returns a composite policy's child set, empty for anything else.
-    /// Composite support is a V2 feature; the V1 surface omits the selector, so this default is
-    /// unreachable and reverts to match the other composite defaults above.
+    /// (V2) Returns a composite policy's child set, empty for anything else.
     fn composite_policy_child_ids(&self, _storage: &S, _policy_id: u64) -> Result<Vec<u64>> {
-        Err(BasePrecompileError::Revert(Bytes::new()))
+        reject_frozen_selector!()
     }
 }

--- a/crates/common/precompiles/src/policy/logic/interface.rs
+++ b/crates/common/precompiles/src/policy/logic/interface.rs
@@ -2,8 +2,8 @@
 
 use alloc::vec::Vec;
 
-use alloy_primitives::{Address, Bytes};
-use base_precompile_storage::{BasePrecompileError, Result};
+use alloy_primitives::Address;
+use base_precompile_storage::Result;
 
 use crate::{IPolicyRegistry::PolicyType, PolicyAccounting, macros::reject_frozen_selector};
 
@@ -29,8 +29,7 @@ pub trait PolicyRegistryLogic<S: PolicyAccounting> {
         accounts: Vec<Address>,
     ) -> Result<u64>;
 
-    /// Creates a composite (UNION/INTERSECT) policy over existing simple child policies.
-    /// Composite support is a V2 feature;
+    /// (V2) Creates a composite (UNION/INTERSECT) policy over existing simple child policies.
     fn create_composite_policy(
         &self,
         _storage: &mut S,
@@ -38,18 +37,17 @@ pub trait PolicyRegistryLogic<S: PolicyAccounting> {
         _policy_type: PolicyType,
         _child_policy_ids: Vec<u64>,
     ) -> Result<u64> {
-        Err(BasePrecompileError::Revert(Bytes::new()))
+        reject_frozen_selector!()
     }
 
-    /// Replaces a composite policy's child set in full.
-    /// Composite support is a V2 feature;
+    /// (V2) Replaces a composite policy's child set in full.
     fn update_composite(
         &self,
         _storage: &mut S,
         _policy_id: u64,
         _child_policy_ids: Vec<u64>,
     ) -> Result<()> {
-        Err(BasePrecompileError::Revert(Bytes::new()))
+        reject_frozen_selector!()
     }
 
     /// Stages a pending admin transfer for `policy_id`.

--- a/crates/common/precompiles/src/policy/logic/v2.rs
+++ b/crates/common/precompiles/src/policy/logic/v2.rs
@@ -572,10 +572,8 @@ impl<S: PolicyAccounting> PolicyRegistryLogic<S> for PolicyRegistryV2 {
 
     fn composite_policy_child_ids(&self, storage: &S, policy_id: u64) -> Result<Vec<u64>> {
         // Never reverts, matching the rest of the read surface. The gate byte alone decides
-        // whether a child set can exist: `is_composite` is false for the built-in sentinels
-        // (types 0/1), for simple policies, and for malformed IDs (type > INTERSECT), so all of
-        // them collapse to empty without a storage read. A well-formed composite ID that was
-        // never created also reads empty, since only the two write paths populate slot 4.
+        // whether a child set can exist, so built-ins, simple policies, and malformed IDs all
+        // collapse to empty without a storage read.
         if !Self::is_composite(policy_id) {
             return Ok(Vec::new());
         }

--- a/crates/common/precompiles/src/policy/logic/v2.rs
+++ b/crates/common/precompiles/src/policy/logic/v2.rs
@@ -569,6 +569,18 @@ impl<S: PolicyAccounting> PolicyRegistryLogic<S> for PolicyRegistryV2 {
         }
         storage.read_pending_admin(policy_id)
     }
+
+    fn composite_policy_child_ids(&self, storage: &S, policy_id: u64) -> Result<Vec<u64>> {
+        // Never reverts, matching the rest of the read surface. The gate byte alone decides
+        // whether a child set can exist: `is_composite` is false for the built-in sentinels
+        // (types 0/1), for simple policies, and for malformed IDs (type > INTERSECT), so all of
+        // them collapse to empty without a storage read. A well-formed composite ID that was
+        // never created also reads empty, since only the two write paths populate slot 4.
+        if !Self::is_composite(policy_id) {
+            return Ok(Vec::new());
+        }
+        storage.read_children(policy_id)
+    }
 }
 
 #[cfg(test)]
@@ -1347,6 +1359,87 @@ mod tests {
         LOGIC.update_composite(&mut rt, id, vec![b, c]).unwrap();
         assert!(!LOGIC.is_authorized(&rt, id, ALICE).unwrap());
         assert!(LOGIC.is_authorized(&rt, id, BOB).unwrap());
+    }
+
+    #[test]
+    fn composite_policy_child_ids_returns_the_set_in_creation_order() {
+        let mut rt = initialized();
+        let a = create_allowlist(&mut rt);
+        let b = create_allowlist(&mut rt);
+        let c = create_allowlist(&mut rt);
+        let id = create_union(&mut rt, vec![c, a, b]);
+        // Order is preserved verbatim; the registry never sorts or dedupes the child set.
+        assert_eq!(LOGIC.composite_policy_child_ids(&rt, id).unwrap(), vec![c, a, b]);
+    }
+
+    #[test]
+    fn composite_policy_child_ids_tracks_update_composite() {
+        let mut rt = initialized();
+        let a = create_allowlist(&mut rt);
+        let b = create_allowlist(&mut rt);
+        let c = create_allowlist(&mut rt);
+        let id = create_intersect(&mut rt, vec![a, b]);
+        assert_eq!(LOGIC.composite_policy_child_ids(&rt, id).unwrap(), vec![a, b]);
+        set_caller(&mut rt, ADMIN);
+        LOGIC.update_composite(&mut rt, id, vec![b, c]).unwrap();
+        // Full replacement, not a merge — `a` is gone rather than retained as a stale tail.
+        assert_eq!(LOGIC.composite_policy_child_ids(&rt, id).unwrap(), vec![b, c]);
+    }
+
+    /// The view mirrors the event exactly, so indexers reconciling a log against a live read
+    /// never see the two disagree.
+    #[test]
+    fn composite_policy_child_ids_matches_the_emitted_event() {
+        let mut rt = initialized();
+        let a = create_allowlist(&mut rt);
+        let b = create_allowlist(&mut rt);
+        let before = rt.events.len();
+        let id = create_union(&mut rt, vec![a, b]);
+        let emitted =
+            IPolicyRegistry::CompositePolicyUpdated::decode_log_data(&rt.events[before + 2])
+                .unwrap()
+                .childPolicyIds;
+        assert_eq!(LOGIC.composite_policy_child_ids(&rt, id).unwrap(), emitted);
+    }
+
+    /// Every non-composite input collapses to an empty set rather than reverting, matching the
+    /// never-reverts contract the rest of the read surface documents.
+    #[test]
+    fn composite_policy_child_ids_returns_empty_for_non_composites() {
+        let mut rt = initialized();
+        let simple = create_allowlist(&mut rt);
+        let malformed = PolicyRegistryV2::make_id(9, 1);
+        let uncreated_union = PolicyRegistryV2::make_id(PolicyType::UNION as u8, 999);
+
+        for policy_id in [
+            simple,
+            PolicyRegistryV2::ALWAYS_ALLOW_ID,
+            PolicyRegistryV2::ALWAYS_BLOCK_ID,
+            malformed,
+            uncreated_union,
+        ] {
+            assert!(
+                LOGIC.composite_policy_child_ids(&rt, policy_id).unwrap().is_empty(),
+                "expected an empty child set for policy {policy_id}"
+            );
+        }
+    }
+
+    /// A simple policy and a never-created composite are indistinguishable from the return value
+    /// alone. That is safe only because both write paths enforce `MIN_CHILD_POLICIES`, so a
+    /// *created* composite can never hold fewer than two children — empty always means
+    /// "no composite here".
+    #[test]
+    fn created_composites_never_return_an_empty_child_set() {
+        let mut rt = initialized();
+        let a = create_allowlist(&mut rt);
+        let b = create_allowlist(&mut rt);
+        let id = create_union(&mut rt, vec![a, b]);
+        assert!(LOGIC.composite_policy_child_ids(&rt, id).unwrap().len() >= 2);
+        // The only mutation path cannot shrink it below the minimum either.
+        set_caller(&mut rt, ADMIN);
+        LOGIC.update_composite(&mut rt, id, vec![]).unwrap_err();
+        assert_eq!(LOGIC.composite_policy_child_ids(&rt, id).unwrap(), vec![a, b]);
     }
 
     #[test]

--- a/crates/common/precompiles/src/policy/logic/v2.rs
+++ b/crates/common/precompiles/src/policy/logic/v2.rs
@@ -571,9 +571,6 @@ impl<S: PolicyAccounting> PolicyRegistryLogic<S> for PolicyRegistryV2 {
     }
 
     fn composite_policy_child_ids(&self, storage: &S, policy_id: u64) -> Result<Vec<u64>> {
-        // Never reverts, matching the rest of the read surface. The gate byte alone decides
-        // whether a child set can exist, so built-ins, simple policies, and malformed IDs all
-        // collapse to empty without a storage read.
         if !Self::is_composite(policy_id) {
             return Ok(Vec::new());
         }
@@ -1384,8 +1381,6 @@ mod tests {
         assert_eq!(LOGIC.composite_policy_child_ids(&rt, id).unwrap(), vec![b, c]);
     }
 
-    /// The view mirrors the event exactly, so indexers reconciling a log against a live read
-    /// never see the two disagree.
     #[test]
     fn composite_policy_child_ids_matches_the_emitted_event() {
         let mut rt = initialized();
@@ -1400,8 +1395,6 @@ mod tests {
         assert_eq!(LOGIC.composite_policy_child_ids(&rt, id).unwrap(), emitted);
     }
 
-    /// Every non-composite input collapses to an empty set rather than reverting, matching the
-    /// never-reverts contract the rest of the read surface documents.
     #[test]
     fn composite_policy_child_ids_returns_empty_for_non_composites() {
         let mut rt = initialized();
@@ -1421,23 +1414,6 @@ mod tests {
                 "expected an empty child set for policy {policy_id}"
             );
         }
-    }
-
-    /// A simple policy and a never-created composite are indistinguishable from the return value
-    /// alone. That is safe only because both write paths enforce `MIN_CHILD_POLICIES`, so a
-    /// *created* composite can never hold fewer than two children — empty always means
-    /// "no composite here".
-    #[test]
-    fn created_composites_never_return_an_empty_child_set() {
-        let mut rt = initialized();
-        let a = create_allowlist(&mut rt);
-        let b = create_allowlist(&mut rt);
-        let id = create_union(&mut rt, vec![a, b]);
-        assert!(LOGIC.composite_policy_child_ids(&rt, id).unwrap().len() >= 2);
-        // The only mutation path cannot shrink it below the minimum either.
-        set_caller(&mut rt, ADMIN);
-        LOGIC.update_composite(&mut rt, id, vec![]).unwrap_err();
-        assert_eq!(LOGIC.composite_policy_child_ids(&rt, id).unwrap(), vec![a, b]);
     }
 
     #[test]

--- a/crates/common/precompiles/src/policy/versions.rs
+++ b/crates/common/precompiles/src/policy/versions.rs
@@ -163,8 +163,8 @@ mod tests {
     }
 
     /// The dispatcher re-decodes against the canonical surface after a frozen surface accepts, so
-    /// every frozen selector must exist on canonical. The difference is exactly the two composite
-    /// selectors Cobalt introduced.
+    /// every frozen selector must exist on canonical. The difference is exactly the three
+    /// composite selectors Cobalt introduced.
     #[test]
     fn v1_selectors_are_a_subset_of_v2() {
         let v1: Vec<[u8; 4]> = IPolicyRegistryV1::IPolicyRegistryCalls::selectors().collect();
@@ -178,9 +178,10 @@ mod tests {
         let added: Vec<[u8; 4]> = IPolicyRegistryV2::IPolicyRegistryCalls::selectors()
             .filter(|selector| !PolicyAbi::V1.valid_selector(*selector))
             .collect();
-        assert_eq!(added.len(), 2);
+        assert_eq!(added.len(), 3);
         assert!(added.contains(&IPolicyRegistry::createCompositePolicyCall::SELECTOR));
         assert!(added.contains(&IPolicyRegistry::updateCompositeCall::SELECTOR));
+        assert!(added.contains(&IPolicyRegistry::compositePolicyChildIdsCall::SELECTOR));
     }
 
     /// `abi_decode_validate` short-circuits on `len < MIN_DATA_LENGTH + 4` before looking at the
@@ -211,7 +212,13 @@ mod tests {
             !PolicyAbi::V1.valid_selector(IPolicyRegistry::createCompositePolicyCall::SELECTOR)
         );
         assert!(!PolicyAbi::V1.valid_selector(IPolicyRegistry::updateCompositeCall::SELECTOR));
+        assert!(
+            !PolicyAbi::V1.valid_selector(IPolicyRegistry::compositePolicyChildIdsCall::SELECTOR)
+        );
         assert!(PolicyAbi::V2.valid_selector(IPolicyRegistry::createCompositePolicyCall::SELECTOR));
         assert!(PolicyAbi::V2.valid_selector(IPolicyRegistry::updateCompositeCall::SELECTOR));
+        assert!(
+            PolicyAbi::V2.valid_selector(IPolicyRegistry::compositePolicyChildIdsCall::SELECTOR)
+        );
     }
 }

--- a/crates/common/precompiles/tests/b20_policy_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_policy_v1_golden.rs
@@ -377,6 +377,20 @@ fn golden_update_composite_selector_unknown_in_v1() {
     assert_eq!(bytes, Bytes::from(IPolicyRegistry::updateCompositeCall::SELECTOR.as_ref()));
 }
 
+#[test]
+fn golden_composite_child_ids_selector_unknown_in_v1() {
+    // Views bypass the activation gate but NOT the wire gate: the selector is absent from the
+    // frozen V1 surface, so Beryl must reject it as unknown rather than answering the read.
+    let mut s = fresh();
+    let (rev, bytes) = call_policy(
+        &mut s,
+        ADMIN,
+        IPolicyRegistry::compositePolicyChildIdsCall { policyId: BLOCKLIST_ID }.abi_encode(),
+    );
+    assert!(rev);
+    assert_eq!(bytes, Bytes::from(IPolicyRegistry::compositePolicyChildIdsCall::SELECTOR.as_ref()));
+}
+
 fn frozen_v1_abi_decode_failure(calldata: &[u8]) -> Bytes {
     let selector = calldata.first_chunk::<4>().copied().expect("calldata must carry a selector");
     let Err(error) = IPolicyRegistryV1::IPolicyRegistryCalls::abi_decode_validate(calldata) else {
@@ -1006,5 +1020,8 @@ fn v1_op_coverage_checklist(call: IPolicyRegistry::IPolicyRegistryCalls) {
         // V2 ABI; unknown to V1. Goldens pin the UnknownFunctionSelector (old error) behavior.
         C::createCompositePolicy(_) => covered(&[golden_create_composite_selector_unknown_in_v1]),
         C::updateComposite(_) => covered(&[golden_update_composite_selector_unknown_in_v1]),
+        C::compositePolicyChildIds(_) => {
+            covered(&[golden_composite_child_ids_selector_unknown_in_v1])
+        }
     }
 }

--- a/crates/common/precompiles/tests/b20_policy_v2_golden.rs
+++ b/crates/common/precompiles/tests/b20_policy_v2_golden.rs
@@ -439,6 +439,90 @@ fn golden_update_composite() {
     assert_root("update_composite", s, ROOT_UPDATE_COMPOSITE);
 }
 
+/// Reads a composite's child set over the wire, asserting the call never reverts.
+fn composite_child_ids(storage: &mut HashMapStorageProvider, policy_id: u64) -> Vec<u64> {
+    let (rev, bytes) = call_policy(
+        storage,
+        OUTSIDER,
+        IPolicyRegistry::compositePolicyChildIdsCall { policyId: policy_id }.abi_encode(),
+    );
+    assert!(!rev, "compositePolicyChildIds unexpectedly reverted");
+    IPolicyRegistry::compositePolicyChildIdsCall::abi_decode_returns(&bytes).unwrap()
+}
+
+#[test]
+fn golden_composite_policy_child_ids() {
+    let mut s = fresh();
+    let a = create(&mut s, ADMIN, ADMIN, PolicyType::ALLOWLIST);
+    let b = create(&mut s, ADMIN, ADMIN, PolicyType::ALLOWLIST);
+    let c = create(&mut s, ADMIN, ADMIN, PolicyType::ALLOWLIST);
+    let id = create_composite(&mut s, PolicyType::INTERSECT, vec![c, a]);
+
+    // Order is preserved verbatim — the registry neither sorts nor de-dupes.
+    assert_eq!(composite_child_ids(&mut s, id), vec![c, a]);
+
+    // The view tracks a full replacement, leaving no stale tail behind.
+    let (rev, _) = call_policy(
+        &mut s,
+        ADMIN,
+        IPolicyRegistry::updateCompositeCall { policyId: id, childPolicyIds: vec![a, b, c] }
+            .abi_encode(),
+    );
+    assert!(!rev);
+    assert_eq!(composite_child_ids(&mut s, id), vec![a, b, c]);
+
+    // The view agrees with the payload of the event it mirrors.
+    let emitted = IPolicyRegistry::CompositePolicyUpdated::decode_log_data(
+        s.get_events(registry()).last().unwrap(),
+    )
+    .unwrap()
+    .childPolicyIds;
+    assert_eq!(composite_child_ids(&mut s, id), emitted);
+}
+
+/// The view is total: every non-composite input yields an empty array rather than a revert,
+/// matching the never-reverts contract the rest of the read surface documents.
+#[test]
+fn golden_composite_policy_child_ids_empty_for_non_composites() {
+    let mut s = fresh();
+    let simple = create(&mut s, ADMIN, ADMIN, PolicyType::ALLOWLIST);
+    // Type byte above INTERSECT — malformed, and never a valid stored policy.
+    let malformed = (9u64 << 56) | 7;
+    // Well-formed UNION id that was never created.
+    let uncreated = ((PolicyType::UNION as u64) << 56) | 999;
+
+    for policy_id in [
+        simple,
+        PolicyRegistryStorage::ALWAYS_ALLOW_ID,
+        PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+        malformed,
+        uncreated,
+    ] {
+        assert_eq!(
+            composite_child_ids(&mut s, policy_id),
+            Vec::<u64>::new(),
+            "expected an empty child set for policy {policy_id}"
+        );
+    }
+}
+
+/// The view bypasses the activation gate, like every other read on this surface.
+#[test]
+fn golden_composite_policy_child_ids_reads_before_activation() {
+    // No activation, matching `golden_write_reverts_when_not_activated`.
+    let mut s = HashMapStorageProvider::new(CHAIN_ID);
+    let (rev, bytes) = call_policy(
+        &mut s,
+        OUTSIDER,
+        IPolicyRegistry::compositePolicyChildIdsCall { policyId: 999 }.abi_encode(),
+    );
+    assert!(!rev, "view must not be gated on activation");
+    assert_eq!(
+        bytes,
+        Bytes::from(IPolicyRegistry::compositePolicyChildIdsCall::abi_encode_returns(&Vec::new()))
+    );
+}
+
 #[test]
 fn golden_create_composite_reverts_incompatible_type() {
     let mut s = fresh();
@@ -1022,5 +1106,10 @@ fn v2_op_coverage_checklist(call: IPolicyRegistry::IPolicyRegistryCalls) {
         C::updateComposite(_) => {
             covered(&[golden_update_composite, golden_update_composite_reverts_unauthorized])
         }
+        C::compositePolicyChildIds(_) => covered(&[
+            golden_composite_policy_child_ids,
+            golden_composite_policy_child_ids_empty_for_non_composites,
+            golden_composite_policy_child_ids_reads_before_activation,
+        ]),
     }
 }


### PR DESCRIPTION
## Summary

Composite policies (UNION/INTERSECT) shipped in #4159 with no on-chain read path for their child set. The only ways to recover it today are decoding the `CompositePolicyUpdated` event or a raw `eth_getStorageAt` against slot 4. This adds the missing getter to the V2 (Cobalt) wire surface.

```solidity
function compositePolicyChildIds(uint64 policyId) external view returns (uint64[] memory);
```

Spec counterpart (interface + reference mock + tests): **base/base-std#183**.

## Semantics

Total — it never reverts, matching the rest of the read surface. An empty array is the array-typed analogue of `Address::ZERO`:

| Input | Returns |
|---|---|
| Existing composite | Stored child set, in the order last written |
| Simple policy (ALLOWLIST / BLOCKLIST) | `[]` |
| Built-in sentinel | `[]` |
| Well-formed but uncreated ID | `[]` |
| Malformed ID (type byte > INTERSECT) | `[]` |

The gate byte alone decides whether a child set can exist, so `is_composite` short-circuits every non-composite before any storage read. Returning `[]` rather than reverting `IncompatiblePolicyType` is safe because **an empty return is unambiguous in practice**: both write paths reject a set outside `[2, 4]`, and there is no clear-the-list path, so a composite that exists always holds at least two children. Tests pin that invariant on both sides.

## Why this extends V2 in place rather than minting a V3

Adding a selector changes `V2_ABI_FINGERPRINT` (`047d1fce` → `cc5f508d`) and moves the frozen selector count 13 → 14, which normally would mean a new frozen `abi/v3.rs`. That isn't required here: **Cobalt has never activated on any network.** `BaseUpgrade::LATEST` is `Beryl`, and every real chain config leaves `cobalt` unset. No historical execution depends on the old value, and the fingerprint exists to catch *unintended* drift, not to freeze an unactivated fork.

The re-blessing is documented inline at the constant, including the rule that once Cobalt ships, a change here means `abi/v3.rs` instead.

Worth a reviewer's explicit sign-off, since it's the one consensus-relevant judgement call in the PR.

## Fork gating

The V1 surface does not declare the selector, so Beryl rejects it as `UnknownFunctionSelector`. This matters more than usual for a view: views bypass the *activation* gate but not the *wire* gate, and `golden_composite_child_ids_selector_unknown_in_v1` pins that. The `PolicyRegistryLogic` default impl reverts to match its sibling composite methods; it is unreachable for the same reason.

## Independence from #4206

This branches off `main`, not off `feat/factory-abi-versioning`. The `AbiFingerprint` extraction in that PR is behavior-preserving, so `cc5f508d` is identical whether computed by main's local `abi_fingerprint` helper or the extracted `AbiFingerprint::compute` — verified by running the suite green on both bases. The two PRs touch `policy/abi/mod.rs` and will need a trivial merge resolution depending on order, but neither blocks the other.

## Testing

`cargo test -p base-common-precompiles --all-features` — 958 passed, 0 failed. `cargo clippy --all-features --all-targets` clean. `cargo +nightly fmt --check` clean.

New coverage:
- 5 unit tests in `logic/v2.rs`: creation-order readback, `update_composite` tracking, view/event agreement, the four empty cases, and the never-empty invariant.
- 3 V2 golden tests: wire-level readback, empty-for-non-composites, and a read before activation (confirming the view bypasses the activation gate).
- 1 V1 golden test: the selector is unknown at Beryl.
- Both selector-coverage exhaustiveness maps updated.

Generated with Claude Code