### PR TITLE
feat(audit): add tiered Postgres retention for transaction events

### DIFF
--- a/bin/audit-archiver/src/main.rs
+++ b/bin/audit-archiver/src/main.rs
@@ -257,7 +257,8 @@ async fn run_server(args: Args) -> Result<()> {
         hot_days: args.transaction_event_hot_retention_days,
         warm_days: args.transaction_event_warm_retention_days,
         cold_days: args.transaction_event_cold_retention_days,
-    };
+    }
+    .validate()?;
     let retention_interval = Duration::from_secs(args.transaction_event_retention_interval_secs);
 
     info!(

--- a/bin/audit-archiver/src/main.rs
+++ b/bin/audit-archiver/src/main.rs
@@ -5,9 +5,12 @@ use std::{net::SocketAddr, sync::Arc, time::Duration};
 use anyhow::Result;
 use audit_archiver_lib::{
     AuditArchiver, AuditArchiverApiServer, AuditArchiverRpc, DEFAULT_TRANSACTION_EVENT_BATCH_PATH,
+    DEFAULT_TRANSACTION_EVENT_COLD_RETENTION_DAYS, DEFAULT_TRANSACTION_EVENT_HOT_RETENTION_DAYS,
     DEFAULT_TRANSACTION_EVENT_MAX_BATCH_SIZE, DEFAULT_TRANSACTION_EVENT_MAX_DATA_BYTES,
     DEFAULT_TRANSACTION_EVENT_MAX_EVENT_BYTES, DEFAULT_TRANSACTION_EVENT_MAX_REQUEST_BYTES,
-    PgTransactionEventSink, RpcEventReader, S3EventReaderWriter, TransactionEventIngestConfig,
+    DEFAULT_TRANSACTION_EVENT_PARTITION_PREMAKE_DAYS,
+    DEFAULT_TRANSACTION_EVENT_WARM_RETENTION_DAYS, Metrics, PgTransactionEventSink, RpcEventReader,
+    S3EventReaderWriter, TransactionEventIngestConfig, TransactionEventRetentionConfig,
 };
 use aws_config::{BehaviorVersion, Region};
 use aws_credential_types::Credentials;
@@ -24,7 +27,11 @@ use base_cli_utils::LogConfig;
 use clap::{Parser, ValueEnum};
 use jsonrpsee::server::{ServerBuilder, stop_channel};
 use moka::{policy::EvictionPolicy, sync::Cache};
-use tokio::{net::TcpListener, sync::mpsc};
+use tokio::{
+    net::TcpListener,
+    sync::mpsc,
+    time::{MissedTickBehavior, interval},
+};
 use tower::ServiceBuilder;
 use tracing::{error, info};
 
@@ -120,6 +127,46 @@ struct Args {
     #[arg(long, env = "TIPS_AUDIT_POSTGRES_MAX_CONNECTIONS", default_value = "10")]
     postgres_max_connections: u32,
 
+    /// Seconds between transaction-event partition maintenance passes.
+    #[arg(
+        long,
+        env = "TIPS_AUDIT_TRANSACTION_EVENT_RETENTION_INTERVAL_SECS",
+        default_value = "3600"
+    )]
+    transaction_event_retention_interval_secs: u64,
+
+    /// Number of upcoming UTC daily partitions to create.
+    #[arg(
+        long,
+        env = "TIPS_AUDIT_TRANSACTION_EVENT_PARTITION_PREMAKE_DAYS",
+        default_value_t = DEFAULT_TRANSACTION_EVENT_PARTITION_PREMAKE_DAYS
+    )]
+    transaction_event_partition_premake_days: u32,
+
+    /// Number of days to retain hot transaction-event families.
+    #[arg(
+        long,
+        env = "TIPS_AUDIT_TRANSACTION_EVENT_HOT_RETENTION_DAYS",
+        default_value_t = DEFAULT_TRANSACTION_EVENT_HOT_RETENTION_DAYS
+    )]
+    transaction_event_hot_retention_days: u32,
+
+    /// Number of days to retain warm transaction-event families.
+    #[arg(
+        long,
+        env = "TIPS_AUDIT_TRANSACTION_EVENT_WARM_RETENTION_DAYS",
+        default_value_t = DEFAULT_TRANSACTION_EVENT_WARM_RETENTION_DAYS
+    )]
+    transaction_event_warm_retention_days: u32,
+
+    /// Number of days to retain cold transaction-event families.
+    #[arg(
+        long,
+        env = "TIPS_AUDIT_TRANSACTION_EVENT_COLD_RETENTION_DAYS",
+        default_value_t = DEFAULT_TRANSACTION_EVENT_COLD_RETENTION_DAYS
+    )]
+    transaction_event_cold_retention_days: u32,
+
     /// HTTP path for Vector transaction-event batch ingest.
     #[arg(
         long,
@@ -205,6 +252,14 @@ async fn run_server(args: Args) -> Result<()> {
         .clone()
         .ok_or_else(|| anyhow::anyhow!("TIPS_AUDIT_S3_BUCKET must be set for serve"))?;
 
+    let retention_config = TransactionEventRetentionConfig {
+        premake_days: args.transaction_event_partition_premake_days,
+        hot_days: args.transaction_event_hot_retention_days,
+        warm_days: args.transaction_event_warm_retention_days,
+        cold_days: args.transaction_event_cold_retention_days,
+    };
+    let retention_interval = Duration::from_secs(args.transaction_event_retention_interval_secs);
+
     info!(
         s3_bucket = %s3_bucket,
         metrics_addr = %args.metrics.addr,
@@ -212,6 +267,11 @@ async fn run_server(args: Args) -> Result<()> {
         rpc_port = args.rpc_port,
         transaction_event_http_path = %args.transaction_event_http_path,
         transaction_event_http_enabled = args.postgres_url.is_some(),
+        transaction_event_partition_premake_days = retention_config.premake_days,
+        transaction_event_hot_retention_days = retention_config.hot_days,
+        transaction_event_warm_retention_days = retention_config.warm_days,
+        transaction_event_cold_retention_days = retention_config.cold_days,
+        transaction_event_retention_interval_secs = retention_interval.as_secs(),
         rpc_cache_capacity = args.rpc_cache_capacity,
         rpc_cache_ttl_secs = args.rpc_cache_ttl_secs,
         channel_buffer_size = args.channel_buffer_size,
@@ -232,7 +292,11 @@ async fn run_server(args: Args) -> Result<()> {
 
     let rpc_addr = SocketAddr::from(([0, 0, 0, 0], args.rpc_port));
     let transaction_event_sink = if let Some(postgres_url) = &args.postgres_url {
-        Some(PgTransactionEventSink::connect(postgres_url, args.postgres_max_connections).await?)
+        let sink =
+            PgTransactionEventSink::connect(postgres_url, args.postgres_max_connections).await?;
+        sink.check_schema_ready().await?;
+        sink.maintain_partitions(retention_config).await?;
+        Some(sink)
     } else {
         None
     };
@@ -258,7 +322,7 @@ async fn run_server(args: Args) -> Result<()> {
         .service(rpc_service);
 
     let health_router = health_router(transaction_event_sink.clone());
-    let http_app = if let Some(sink) = transaction_event_sink {
+    let http_app = if let Some(sink) = transaction_event_sink.clone() {
         let config = TransactionEventIngestConfig {
             path: args.transaction_event_http_path.clone(),
             max_batch_size: args.transaction_event_max_batch_size,
@@ -287,11 +351,55 @@ async fn run_server(args: Args) -> Result<()> {
     );
 
     info!("Audit archiver initialized, starting main loop");
+    let partition_worker =
+        run_partition_worker(transaction_event_sink, retention_config, retention_interval);
 
     tokio::select! {
         result = archiver.run() => result,
         result = http_server => {
             result.map_err(|e| anyhow::anyhow!("audit archiver HTTP server stopped unexpectedly: {e}"))
+        }
+        result = partition_worker => result,
+    }
+}
+
+async fn run_partition_worker(
+    transaction_event_sink: Option<PgTransactionEventSink>,
+    retention_config: TransactionEventRetentionConfig,
+    retention_interval: Duration,
+) -> Result<()> {
+    let Some(sink) = transaction_event_sink else {
+        return std::future::pending().await;
+    };
+
+    if retention_interval.is_zero() {
+        anyhow::bail!("transaction event retention interval must be greater than zero");
+    }
+    let mut ticker = interval(retention_interval);
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    // Startup already performed a synchronous maintenance pass.
+    ticker.tick().await;
+
+    loop {
+        ticker.tick().await;
+        match sink.maintain_partitions(retention_config).await {
+            Ok(outcomes) => {
+                for outcome in outcomes {
+                    if outcome.partitions_created > 0 || outcome.partitions_dropped > 0 {
+                        info!(
+                            retention_class = %outcome.retention_class,
+                            partitions_created = outcome.partitions_created,
+                            partitions_dropped = outcome.partitions_dropped,
+                            oldest_partition_start = ?outcome.oldest_partition_start,
+                            "transaction event partition maintenance complete"
+                        );
+                    }
+                }
+            }
+            Err(err) => {
+                Metrics::transaction_event_partition_maintenance_failures().increment(1);
+                error!(error = %err, "transaction event partition maintenance failed");
+            }
         }
     }
 }

--- a/bin/audit-archiver/src/main.rs
+++ b/bin/audit-archiver/src/main.rs
@@ -390,6 +390,7 @@ async fn run_partition_worker(
                             retention_class = %outcome.retention_class,
                             partitions_created = outcome.partitions_created,
                             partitions_dropped = outcome.partitions_dropped,
+                            partitions_ahead_days = ?outcome.partitions_ahead_days,
                             oldest_partition_start = ?outcome.oldest_partition_start,
                             "transaction event partition maintenance complete"
                         );
@@ -398,6 +399,7 @@ async fn run_partition_worker(
             }
             Err(err) => {
                 Metrics::transaction_event_partition_maintenance_failures().increment(1);
+                sink.record_partition_maintenance_last_success_age();
                 error!(error = %err, "transaction event partition maintenance failed");
             }
         }

--- a/crates/infra/audit/migrations/002_transaction_event_retention.sql
+++ b/crates/infra/audit/migrations/002_transaction_event_retention.sql
@@ -1,0 +1,357 @@
+-- Convert transaction_events to retention-class/list partitions whose leaves are
+-- daily UTC ingested_at ranges. This migration takes an ACCESS EXCLUSIVE lock
+-- while it copies existing rows. Run the documented zeronet-first preflight and
+-- cutover procedure before applying it to a populated environment.
+LOCK TABLE transaction_events IN ACCESS EXCLUSIVE MODE;
+
+ALTER TABLE transaction_events RENAME TO transaction_events_pre_retention;
+
+CREATE TABLE transaction_events (
+    event_id TEXT NOT NULL,
+    retention_class TEXT NOT NULL,
+    schema_version TEXT NOT NULL,
+    event_time TIMESTAMPTZ NOT NULL,
+    ingested_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    producer TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    network TEXT,
+    tx_hash TEXT,
+    block_hash TEXT,
+    block_number BIGINT,
+    payload_id TEXT,
+    request_id TEXT,
+    data JSONB NOT NULL,
+    PRIMARY KEY (event_id, retention_class, ingested_at),
+    CONSTRAINT transaction_events_retention_class_check
+        CHECK (retention_class IN ('hot', 'warm', 'cold'))
+) PARTITION BY LIST (retention_class);
+
+CREATE TABLE transaction_events_hot
+    PARTITION OF transaction_events FOR VALUES IN ('hot')
+    PARTITION BY RANGE (ingested_at);
+CREATE TABLE transaction_events_warm
+    PARTITION OF transaction_events FOR VALUES IN ('warm')
+    PARTITION BY RANGE (ingested_at);
+CREATE TABLE transaction_events_cold
+    PARTITION OF transaction_events FOR VALUES IN ('cold')
+    PARTITION BY RANGE (ingested_at);
+
+CREATE TABLE transaction_event_partition_registry (
+    retention_class TEXT NOT NULL,
+    partition_day DATE NOT NULL,
+    partition_name NAME NOT NULL UNIQUE,
+    PRIMARY KEY (retention_class, partition_day),
+    CONSTRAINT transaction_event_partition_registry_class_check
+        CHECK (retention_class IN ('hot', 'warm', 'cold'))
+);
+
+-- This duplicate of the Rust classification is used only to classify rows that
+-- predate retention_class. New writes are classified by audit-archiver.
+CREATE FUNCTION transaction_event_retention_class_for_backfill(p_event_type TEXT)
+RETURNS TEXT
+LANGUAGE sql
+IMMUTABLE
+STRICT
+AS $$
+    SELECT CASE
+        WHEN p_event_type IN (
+            'PROXY_RECEIVED',
+            'PROXY_VALIDATION_ACCEPTED',
+            'PROXY_ROUTED_TO_BACKEND',
+            'PROXY_BACKEND_SUCCESS',
+            'PROXY_INGRESS_RPC_ATTEMPT',
+            'PROXY_INGRESS_RPC_SUCCESS',
+            'BUILDER_CONSIDERED',
+            'BUILDER_ACCEPTED',
+            'BUILDER_REJECTED'
+        ) THEN 'hot'
+        WHEN p_event_type IN (
+            'PROXY_REJECTED',
+            'PROXY_VALIDATION_REJECTED',
+            'PROXY_BACKEND_FAILURE',
+            'PROXY_INGRESS_RPC_FAILURE',
+            'SIMULATION_FAILED',
+            'INGRESS_TX_FORWARD_FAILURE',
+            'INGRESS_METERING_SEND_FAILURE',
+            'INGRESS_METERING_SEND_DROPPED',
+            'TXPOOL_DROPPED',
+            'TXPOOL_REPLACED',
+            'TXPOOL_TRACKING_OVERFLOWED',
+            'TXPOOL_BLOCK_INCLUDED',
+            'TXPOOL_FLASHBLOCK_INCLUDED',
+            'TXPOOL_BUILDER_FORWARD_FAILURE',
+            'TXPOOL_BUILDER_FORWARD_DROPPED',
+            'TXPOOL_VALIDATED_INSERT_REJECTED',
+            'BUILDER_INCLUDED',
+            'BUILDER_PAYLOAD_FINALIZED',
+            'BUILDER_FLASHBLOCK_STARTED',
+            'BUILDER_FLASHBLOCK_PUBLISHED',
+            'BUILDER_FLASHBLOCK_BUILD_STOPPED'
+        ) THEN 'cold'
+        ELSE 'warm'
+    END
+$$;
+
+CREATE FUNCTION create_transaction_event_partition(
+    p_retention_class TEXT,
+    p_partition_day DATE
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+    parent_name NAME;
+    child_name NAME;
+    child_index_name NAME;
+    lower_bound TIMESTAMPTZ;
+    upper_bound TIMESTAMPTZ;
+BEGIN
+    IF p_retention_class NOT IN ('hot', 'warm', 'cold') THEN
+        RAISE EXCEPTION 'invalid transaction event retention class: %', p_retention_class;
+    END IF;
+
+    parent_name := ('transaction_events_' || p_retention_class)::NAME;
+    child_name :=
+        ('transaction_events_' || p_retention_class || '_' || to_char(p_partition_day, 'YYYYMMDD'))::NAME;
+    child_index_name := (child_name::TEXT || '_event_id_uidx')::NAME;
+    lower_bound := p_partition_day::TIMESTAMP AT TIME ZONE 'UTC';
+    upper_bound := (p_partition_day + 1)::TIMESTAMP AT TIME ZONE 'UTC';
+
+    IF to_regclass('public.' || quote_ident(child_name::TEXT)) IS NOT NULL THEN
+        INSERT INTO public.transaction_event_partition_registry (
+            retention_class,
+            partition_day,
+            partition_name
+        )
+        VALUES (p_retention_class, p_partition_day, child_name)
+        ON CONFLICT (retention_class, partition_day) DO NOTHING;
+        RETURN FALSE;
+    END IF;
+
+    EXECUTE format(
+        'CREATE TABLE public.%I PARTITION OF public.%I FOR VALUES FROM (%L) TO (%L)',
+        child_name,
+        parent_name,
+        lower_bound,
+        upper_bound
+    );
+    -- The parent key cannot enforce event_id uniqueness without both partition
+    -- keys. This leaf index preserves retry dedupe within a UTC ingest day.
+    EXECUTE format(
+        'CREATE UNIQUE INDEX %I ON public.%I (event_id)',
+        child_index_name,
+        child_name
+    );
+    INSERT INTO public.transaction_event_partition_registry (
+        retention_class,
+        partition_day,
+        partition_name
+    )
+    VALUES (p_retention_class, p_partition_day, child_name);
+    RETURN TRUE;
+END
+$$;
+
+DO $$
+DECLARE
+    first_day DATE;
+    last_day DATE;
+    class_name TEXT;
+    partition_day DATE;
+BEGIN
+    SELECT COALESCE(
+        min(ingested_at AT TIME ZONE 'UTC')::DATE,
+        (now() AT TIME ZONE 'UTC')::DATE
+    )
+    INTO first_day
+    FROM transaction_events_pre_retention;
+    last_day := (now() AT TIME ZONE 'UTC')::DATE + 7;
+
+    FOREACH class_name IN ARRAY ARRAY['hot', 'warm', 'cold']
+    LOOP
+        FOR partition_day IN
+            SELECT generate_series(first_day, last_day, INTERVAL '1 day')::DATE
+        LOOP
+            PERFORM create_transaction_event_partition(class_name, partition_day);
+        END LOOP;
+    END LOOP;
+END
+$$;
+
+INSERT INTO transaction_events (
+    event_id,
+    retention_class,
+    schema_version,
+    event_time,
+    ingested_at,
+    producer,
+    event_type,
+    network,
+    tx_hash,
+    block_hash,
+    block_number,
+    payload_id,
+    request_id,
+    data
+)
+SELECT
+    event_id,
+    transaction_event_retention_class_for_backfill(event_type),
+    schema_version,
+    event_time,
+    ingested_at,
+    producer,
+    event_type,
+    network,
+    tx_hash,
+    block_hash,
+    block_number,
+    payload_id,
+    request_id,
+    data
+FROM transaction_events_pre_retention;
+
+CREATE INDEX transaction_events_partitioned_tx_hash_event_time_idx
+    ON transaction_events (tx_hash, event_time)
+    WHERE tx_hash IS NOT NULL;
+CREATE INDEX transaction_events_partitioned_block_number_event_time_idx
+    ON transaction_events (block_number, event_time)
+    WHERE block_number IS NOT NULL;
+CREATE INDEX transaction_events_partitioned_block_hash_event_time_idx
+    ON transaction_events (block_hash, event_time)
+    WHERE block_hash IS NOT NULL;
+CREATE INDEX transaction_events_partitioned_payload_id_event_time_idx
+    ON transaction_events (payload_id, event_time)
+    WHERE payload_id IS NOT NULL;
+CREATE INDEX transaction_events_partitioned_producer_event_type_event_time_idx
+    ON transaction_events (producer, event_type, event_time);
+CREATE INDEX transaction_events_partitioned_rejected_event_time_idx
+    ON transaction_events (event_type, event_time DESC)
+    WHERE event_type IN (
+        'PROXY_REJECTED',
+        'PROXY_VALIDATION_REJECTED',
+        'SIMULATION_FAILED',
+        'TXPOOL_VALIDATED_INSERT_REJECTED',
+        'BUILDER_REJECTED'
+    );
+CREATE INDEX transaction_events_partitioned_bundle_hash_event_time_idx
+    ON transaction_events ((data->>'bundle_hash'), event_time)
+    WHERE data ? 'bundle_hash';
+CREATE INDEX transaction_events_partitioned_bundle_id_event_time_idx
+    ON transaction_events ((data->>'bundle_id'), event_time)
+    WHERE data ? 'bundle_id';
+
+CREATE FUNCTION maintain_transaction_event_partitions(
+    p_now TIMESTAMPTZ,
+    p_premake_days INTEGER,
+    p_hot_days INTEGER,
+    p_warm_days INTEGER,
+    p_cold_days INTEGER
+)
+RETURNS TABLE (
+    retention_class TEXT,
+    partitions_created BIGINT,
+    partitions_dropped BIGINT,
+    oldest_partition_start TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+    class_name TEXT;
+    retention_days INTEGER;
+    day_offset INTEGER;
+    partition_record RECORD;
+BEGIN
+    IF p_premake_days < 1 OR p_premake_days > 31 THEN
+        RAISE EXCEPTION 'premake days must be between 1 and 31';
+    END IF;
+    IF p_hot_days < 1 OR p_warm_days < 1 OR p_cold_days < 1 THEN
+        RAISE EXCEPTION 'retention days must be positive';
+    END IF;
+    IF p_hot_days > p_warm_days OR p_warm_days > p_cold_days THEN
+        RAISE EXCEPTION 'retention days must satisfy hot <= warm <= cold';
+    END IF;
+
+    -- All audit-archiver replicas may run the worker. Only one performs DDL in
+    -- a maintenance transaction; the others safely return no rows.
+    IF NOT pg_try_advisory_xact_lock(744697762131337711) THEN
+        RETURN;
+    END IF;
+
+    FOREACH class_name IN ARRAY ARRAY['hot', 'warm', 'cold']
+    LOOP
+        retention_days := CASE class_name
+            WHEN 'hot' THEN p_hot_days
+            WHEN 'warm' THEN p_warm_days
+            ELSE p_cold_days
+        END;
+        retention_class := class_name;
+        partitions_created := 0;
+        partitions_dropped := 0;
+
+        FOR day_offset IN 0..p_premake_days
+        LOOP
+            IF public.create_transaction_event_partition(
+                class_name,
+                (p_now AT TIME ZONE 'UTC')::DATE + day_offset
+            ) THEN
+                partitions_created := partitions_created + 1;
+            END IF;
+        END LOOP;
+
+        FOR partition_record IN
+            SELECT registry.partition_day, registry.partition_name
+            FROM public.transaction_event_partition_registry AS registry
+            WHERE registry.retention_class = class_name
+              AND (
+                  (registry.partition_day + 1)::TIMESTAMP AT TIME ZONE 'UTC'
+              ) <= p_now - make_interval(days => retention_days)
+            ORDER BY registry.partition_day
+        LOOP
+            EXECUTE format('DROP TABLE public.%I', partition_record.partition_name);
+            DELETE FROM public.transaction_event_partition_registry AS registry
+            WHERE registry.retention_class = class_name
+              AND registry.partition_day = partition_record.partition_day;
+            partitions_dropped := partitions_dropped + 1;
+        END LOOP;
+
+        SELECT
+            min(registry.partition_day)::TIMESTAMP AT TIME ZONE 'UTC'
+        INTO oldest_partition_start
+        FROM public.transaction_event_partition_registry AS registry
+        WHERE registry.retention_class = class_name;
+
+        RETURN NEXT;
+    END LOOP;
+END
+$$;
+
+REVOKE ALL ON FUNCTION create_transaction_event_partition(TEXT, DATE) FROM PUBLIC;
+REVOKE ALL ON FUNCTION maintain_transaction_event_partitions(
+    TIMESTAMPTZ,
+    INTEGER,
+    INTEGER,
+    INTEGER,
+    INTEGER
+) FROM PUBLIC;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'audit_archiver') THEN
+        REVOKE ALL ON transaction_events_pre_retention FROM audit_archiver;
+        GRANT SELECT, INSERT, UPDATE, DELETE ON transaction_events TO audit_archiver;
+        GRANT SELECT ON transaction_event_partition_registry TO audit_archiver;
+        GRANT EXECUTE ON FUNCTION maintain_transaction_event_partitions(
+            TIMESTAMPTZ,
+            INTEGER,
+            INTEGER,
+            INTEGER,
+            INTEGER
+        ) TO audit_archiver;
+    END IF;
+END
+$$;

--- a/crates/infra/audit/migrations/002_transaction_event_retention.sql
+++ b/crates/infra/audit/migrations/002_transaction_event_retention.sql
@@ -1,10 +1,7 @@
--- Convert transaction_events to retention-class/list partitions whose leaves are
--- daily UTC ingested_at ranges. This migration takes an ACCESS EXCLUSIVE lock
--- while it copies existing rows. Run the documented zeronet-first preflight and
--- cutover procedure before applying it to a populated environment.
-LOCK TABLE transaction_events IN ACCESS EXCLUSIVE MODE;
-
-ALTER TABLE transaction_events RENAME TO transaction_events_pre_retention;
+-- Replace the heap transaction_events table with retention-class/list partitions
+-- whose leaves are daily UTC ingested_at ranges. Existing rows are discarded;
+-- pause producers before applying this migration.
+DROP TABLE IF EXISTS transaction_events;
 
 CREATE TABLE transaction_events (
     event_id TEXT NOT NULL,
@@ -44,53 +41,6 @@ CREATE TABLE transaction_event_partition_registry (
     CONSTRAINT transaction_event_partition_registry_class_check
         CHECK (retention_class IN ('hot', 'warm', 'cold'))
 );
-
--- This duplicate of the Rust classification is used only to classify rows that
--- predate retention_class. New writes are classified by audit-archiver.
-CREATE FUNCTION transaction_event_retention_class_for_backfill(p_event_type TEXT)
-RETURNS TEXT
-LANGUAGE sql
-IMMUTABLE
-STRICT
-AS $$
-    SELECT CASE
-        WHEN p_event_type IN (
-            'PROXY_RECEIVED',
-            'PROXY_VALIDATION_ACCEPTED',
-            'PROXY_ROUTED_TO_BACKEND',
-            'PROXY_BACKEND_SUCCESS',
-            'PROXY_INGRESS_RPC_ATTEMPT',
-            'PROXY_INGRESS_RPC_SUCCESS',
-            'BUILDER_CONSIDERED',
-            'BUILDER_ACCEPTED',
-            'BUILDER_REJECTED'
-        ) THEN 'hot'
-        WHEN p_event_type IN (
-            'PROXY_REJECTED',
-            'PROXY_VALIDATION_REJECTED',
-            'PROXY_BACKEND_FAILURE',
-            'PROXY_INGRESS_RPC_FAILURE',
-            'SIMULATION_FAILED',
-            'INGRESS_TX_FORWARD_FAILURE',
-            'INGRESS_METERING_SEND_FAILURE',
-            'INGRESS_METERING_SEND_DROPPED',
-            'TXPOOL_DROPPED',
-            'TXPOOL_REPLACED',
-            'TXPOOL_TRACKING_OVERFLOWED',
-            'TXPOOL_BLOCK_INCLUDED',
-            'TXPOOL_FLASHBLOCK_INCLUDED',
-            'TXPOOL_BUILDER_FORWARD_FAILURE',
-            'TXPOOL_BUILDER_FORWARD_DROPPED',
-            'TXPOOL_VALIDATED_INSERT_REJECTED',
-            'BUILDER_INCLUDED',
-            'BUILDER_PAYLOAD_FINALIZED',
-            'BUILDER_FLASHBLOCK_STARTED',
-            'BUILDER_FLASHBLOCK_PUBLISHED',
-            'BUILDER_FLASHBLOCK_BUILD_STOPPED'
-        ) THEN 'cold'
-        ELSE 'warm'
-    END
-$$;
 
 CREATE FUNCTION create_transaction_event_partition(
     p_retention_class TEXT,
@@ -156,19 +106,11 @@ $$;
 
 DO $$
 DECLARE
-    first_day DATE;
-    last_day DATE;
+    first_day DATE := (now() AT TIME ZONE 'UTC')::DATE;
+    last_day DATE := first_day + 7;
     class_name TEXT;
     partition_day DATE;
 BEGIN
-    SELECT COALESCE(
-        min(ingested_at AT TIME ZONE 'UTC')::DATE,
-        (now() AT TIME ZONE 'UTC')::DATE
-    )
-    INTO first_day
-    FROM transaction_events_pre_retention;
-    last_day := (now() AT TIME ZONE 'UTC')::DATE + 7;
-
     FOREACH class_name IN ARRAY ARRAY['hot', 'warm', 'cold']
     LOOP
         FOR partition_day IN
@@ -179,39 +121,6 @@ BEGIN
     END LOOP;
 END
 $$;
-
-INSERT INTO transaction_events (
-    event_id,
-    retention_class,
-    schema_version,
-    event_time,
-    ingested_at,
-    producer,
-    event_type,
-    network,
-    tx_hash,
-    block_hash,
-    block_number,
-    payload_id,
-    request_id,
-    data
-)
-SELECT
-    event_id,
-    transaction_event_retention_class_for_backfill(event_type),
-    schema_version,
-    event_time,
-    ingested_at,
-    producer,
-    event_type,
-    network,
-    tx_hash,
-    block_hash,
-    block_number,
-    payload_id,
-    request_id,
-    data
-FROM transaction_events_pre_retention;
 
 CREATE INDEX transaction_events_partitioned_tx_hash_event_time_idx
     ON transaction_events (tx_hash, event_time)
@@ -342,7 +251,6 @@ REVOKE ALL ON FUNCTION maintain_transaction_event_partitions(
 DO $$
 BEGIN
     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'audit_archiver') THEN
-        REVOKE ALL ON transaction_events_pre_retention FROM audit_archiver;
         GRANT SELECT, INSERT, UPDATE, DELETE ON transaction_events TO audit_archiver;
         GRANT SELECT ON transaction_event_partition_registry TO audit_archiver;
         GRANT EXECUTE ON FUNCTION maintain_transaction_event_partitions(

--- a/crates/infra/audit/migrations/002_transaction_event_retention.sql
+++ b/crates/infra/audit/migrations/002_transaction_event_retention.sql
@@ -1,9 +1,10 @@
--- Replace the heap transaction_events table with retention-class/list partitions
--- whose leaves are daily UTC ingested_at ranges. Existing rows are discarded;
--- pause producers before applying this migration.
-DROP TABLE IF EXISTS transaction_events;
+-- Add three independent retention tables, each range-partitioned by UTC
+-- ingested_at day. Keep the legacy transaction_events heap intact; a future
+-- migration may drop it and create a union view under that name.
 
-CREATE TABLE transaction_events (
+-- Define the row and index shape once, then copy it into each independent
+-- partitioned parent. LIKE copies definitions only; the template stays empty.
+CREATE TABLE transaction_events_template (
     event_id TEXT NOT NULL,
     retention_class TEXT NOT NULL,
     schema_version TEXT NOT NULL,
@@ -18,29 +19,43 @@ CREATE TABLE transaction_events (
     payload_id TEXT,
     request_id TEXT,
     data JSONB NOT NULL,
-    PRIMARY KEY (event_id, retention_class, ingested_at),
-    CONSTRAINT transaction_events_retention_class_check
-        CHECK (retention_class IN ('hot', 'warm', 'cold'))
-) PARTITION BY LIST (retention_class);
-
-CREATE TABLE transaction_events_hot
-    PARTITION OF transaction_events FOR VALUES IN ('hot')
-    PARTITION BY RANGE (ingested_at);
-CREATE TABLE transaction_events_warm
-    PARTITION OF transaction_events FOR VALUES IN ('warm')
-    PARTITION BY RANGE (ingested_at);
-CREATE TABLE transaction_events_cold
-    PARTITION OF transaction_events FOR VALUES IN ('cold')
-    PARTITION BY RANGE (ingested_at);
-
-CREATE TABLE transaction_event_partition_registry (
-    retention_class TEXT NOT NULL,
-    partition_day DATE NOT NULL,
-    partition_name NAME NOT NULL UNIQUE,
-    PRIMARY KEY (retention_class, partition_day),
-    CONSTRAINT transaction_event_partition_registry_class_check
-        CHECK (retention_class IN ('hot', 'warm', 'cold'))
+    PRIMARY KEY (event_id, ingested_at)
 );
+CREATE INDEX ON transaction_events_template (tx_hash, event_time)
+    WHERE tx_hash IS NOT NULL;
+CREATE INDEX ON transaction_events_template (block_number, event_time)
+    WHERE block_number IS NOT NULL;
+CREATE INDEX ON transaction_events_template (block_hash, event_time)
+    WHERE block_hash IS NOT NULL;
+CREATE INDEX ON transaction_events_template (payload_id, event_time)
+    WHERE payload_id IS NOT NULL;
+CREATE INDEX ON transaction_events_template (producer, event_type, event_time);
+CREATE INDEX ON transaction_events_template (event_type, event_time DESC)
+    WHERE event_type IN (
+        'PROXY_REJECTED',
+        'PROXY_VALIDATION_REJECTED',
+        'SIMULATION_FAILED',
+        'TXPOOL_VALIDATED_INSERT_REJECTED',
+        'BUILDER_REJECTED'
+    );
+CREATE INDEX ON transaction_events_template ((data->>'bundle_hash'), event_time)
+    WHERE data ? 'bundle_hash';
+CREATE INDEX ON transaction_events_template ((data->>'bundle_id'), event_time)
+    WHERE data ? 'bundle_id';
+
+CREATE TABLE transaction_events_hot (
+    LIKE transaction_events_template INCLUDING ALL
+) PARTITION BY RANGE (ingested_at);
+ALTER TABLE transaction_events_hot ADD CHECK (retention_class = 'hot');
+CREATE TABLE transaction_events_warm (
+    LIKE transaction_events_template INCLUDING ALL
+) PARTITION BY RANGE (ingested_at);
+ALTER TABLE transaction_events_warm ADD CHECK (retention_class = 'warm');
+CREATE TABLE transaction_events_cold (
+    LIKE transaction_events_template INCLUDING ALL
+) PARTITION BY RANGE (ingested_at);
+ALTER TABLE transaction_events_cold ADD CHECK (retention_class = 'cold');
+DROP TABLE transaction_events_template;
 
 CREATE FUNCTION create_transaction_event_partition(
     p_retention_class TEXT,
@@ -70,13 +85,6 @@ BEGIN
     upper_bound := (p_partition_day + 1)::TIMESTAMP AT TIME ZONE 'UTC';
 
     IF to_regclass('public.' || quote_ident(child_name::TEXT)) IS NOT NULL THEN
-        INSERT INTO public.transaction_event_partition_registry (
-            retention_class,
-            partition_day,
-            partition_name
-        )
-        VALUES (p_retention_class, p_partition_day, child_name)
-        ON CONFLICT (retention_class, partition_day) DO NOTHING;
         RETURN FALSE;
     END IF;
 
@@ -87,19 +95,13 @@ BEGIN
         lower_bound,
         upper_bound
     );
-    -- The parent key cannot enforce event_id uniqueness without both partition
-    -- keys. This leaf index preserves retry dedupe within a UTC ingest day.
+    -- Parent uniqueness must include ingested_at. Preserve retry dedupe within
+    -- each UTC ingest day with a leaf-local event_id index.
     EXECUTE format(
         'CREATE UNIQUE INDEX %I ON public.%I (event_id)',
         child_index_name,
         child_name
     );
-    INSERT INTO public.transaction_event_partition_registry (
-        retention_class,
-        partition_day,
-        partition_name
-    )
-    VALUES (p_retention_class, p_partition_day, child_name);
     RETURN TRUE;
 END
 $$;
@@ -122,36 +124,6 @@ BEGIN
 END
 $$;
 
-CREATE INDEX transaction_events_partitioned_tx_hash_event_time_idx
-    ON transaction_events (tx_hash, event_time)
-    WHERE tx_hash IS NOT NULL;
-CREATE INDEX transaction_events_partitioned_block_number_event_time_idx
-    ON transaction_events (block_number, event_time)
-    WHERE block_number IS NOT NULL;
-CREATE INDEX transaction_events_partitioned_block_hash_event_time_idx
-    ON transaction_events (block_hash, event_time)
-    WHERE block_hash IS NOT NULL;
-CREATE INDEX transaction_events_partitioned_payload_id_event_time_idx
-    ON transaction_events (payload_id, event_time)
-    WHERE payload_id IS NOT NULL;
-CREATE INDEX transaction_events_partitioned_producer_event_type_event_time_idx
-    ON transaction_events (producer, event_type, event_time);
-CREATE INDEX transaction_events_partitioned_rejected_event_time_idx
-    ON transaction_events (event_type, event_time DESC)
-    WHERE event_type IN (
-        'PROXY_REJECTED',
-        'PROXY_VALIDATION_REJECTED',
-        'SIMULATION_FAILED',
-        'TXPOOL_VALIDATED_INSERT_REJECTED',
-        'BUILDER_REJECTED'
-    );
-CREATE INDEX transaction_events_partitioned_bundle_hash_event_time_idx
-    ON transaction_events ((data->>'bundle_hash'), event_time)
-    WHERE data ? 'bundle_hash';
-CREATE INDEX transaction_events_partitioned_bundle_id_event_time_idx
-    ON transaction_events ((data->>'bundle_id'), event_time)
-    WHERE data ? 'bundle_id';
-
 CREATE FUNCTION maintain_transaction_event_partitions(
     p_now TIMESTAMPTZ,
     p_premake_days INTEGER,
@@ -171,6 +143,7 @@ SET search_path = pg_catalog, public
 AS $$
 DECLARE
     class_name TEXT;
+    parent_name NAME;
     retention_days INTEGER;
     day_offset INTEGER;
     partition_record RECORD;
@@ -185,14 +158,14 @@ BEGIN
         RAISE EXCEPTION 'retention days must satisfy hot <= warm <= cold';
     END IF;
 
-    -- All audit-archiver replicas may run the worker. Only one performs DDL in
-    -- a maintenance transaction; the others safely return no rows.
+    -- Every audit-archiver replica may run the worker. Only one performs DDL.
     IF NOT pg_try_advisory_xact_lock(744697762131337711) THEN
         RETURN;
     END IF;
 
     FOREACH class_name IN ARRAY ARRAY['hot', 'warm', 'cold']
     LOOP
+        parent_name := ('transaction_events_' || class_name)::NAME;
         retention_days := CASE class_name
             WHEN 'hot' THEN p_hot_days
             WHEN 'warm' THEN p_warm_days
@@ -213,26 +186,32 @@ BEGIN
         END LOOP;
 
         FOR partition_record IN
-            SELECT registry.partition_day, registry.partition_name
-            FROM public.transaction_event_partition_registry AS registry
-            WHERE registry.retention_class = class_name
+            SELECT
+                child.relname AS partition_name,
+                to_date(right(child.relname, 8), 'YYYYMMDD') AS partition_day
+            FROM pg_inherits AS inheritance
+            JOIN pg_class AS parent ON parent.oid = inheritance.inhparent
+            JOIN pg_class AS child ON child.oid = inheritance.inhrelid
+            WHERE parent.oid = to_regclass('public.' || quote_ident(parent_name::TEXT))
+              AND child.relname ~ ('^' || parent_name::TEXT || '_[0-9]{8}$')
               AND (
-                  (registry.partition_day + 1)::TIMESTAMP AT TIME ZONE 'UTC'
-              ) <= p_now - make_interval(days => retention_days)
-            ORDER BY registry.partition_day
+                  to_date(right(child.relname, 8), 'YYYYMMDD') + 1
+              )::TIMESTAMP AT TIME ZONE 'UTC'
+                  <= p_now - make_interval(days => retention_days)
+            ORDER BY partition_day
         LOOP
             EXECUTE format('DROP TABLE public.%I', partition_record.partition_name);
-            DELETE FROM public.transaction_event_partition_registry AS registry
-            WHERE registry.retention_class = class_name
-              AND registry.partition_day = partition_record.partition_day;
             partitions_dropped := partitions_dropped + 1;
         END LOOP;
 
         SELECT
-            min(registry.partition_day)::TIMESTAMP AT TIME ZONE 'UTC'
+            min(to_date(right(child.relname, 8), 'YYYYMMDD'))::TIMESTAMP AT TIME ZONE 'UTC'
         INTO oldest_partition_start
-        FROM public.transaction_event_partition_registry AS registry
-        WHERE registry.retention_class = class_name;
+        FROM pg_inherits AS inheritance
+        JOIN pg_class AS parent ON parent.oid = inheritance.inhparent
+        JOIN pg_class AS child ON child.oid = inheritance.inhrelid
+        WHERE parent.oid = to_regclass('public.' || quote_ident(parent_name::TEXT))
+          AND child.relname ~ ('^' || parent_name::TEXT || '_[0-9]{8}$');
 
         RETURN NEXT;
     END LOOP;
@@ -251,8 +230,9 @@ REVOKE ALL ON FUNCTION maintain_transaction_event_partitions(
 DO $$
 BEGIN
     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'audit_archiver') THEN
-        GRANT SELECT, INSERT, UPDATE, DELETE ON transaction_events TO audit_archiver;
-        GRANT SELECT ON transaction_event_partition_registry TO audit_archiver;
+        GRANT SELECT, INSERT, UPDATE, DELETE
+            ON transaction_events_hot, transaction_events_warm, transaction_events_cold
+            TO audit_archiver;
         GRANT EXECUTE ON FUNCTION maintain_transaction_event_partitions(
             TIMESTAMPTZ,
             INTEGER,

--- a/crates/infra/audit/migrations/002_transaction_event_retention.sql
+++ b/crates/infra/audit/migrations/002_transaction_event_retention.sql
@@ -135,7 +135,8 @@ RETURNS TABLE (
     retention_class TEXT,
     partitions_created BIGINT,
     partitions_dropped BIGINT,
-    oldest_partition_start TIMESTAMPTZ
+    oldest_partition_start TIMESTAMPTZ,
+    partitions_ahead_days BIGINT
 )
 LANGUAGE plpgsql
 SECURITY DEFINER
@@ -147,6 +148,8 @@ DECLARE
     retention_days INTEGER;
     day_offset INTEGER;
     partition_record RECORD;
+    today DATE;
+    newest_partition_day DATE;
 BEGIN
     IF p_premake_days < 1 OR p_premake_days > 31 THEN
         RAISE EXCEPTION 'premake days must be between 1 and 31';
@@ -163,6 +166,8 @@ BEGIN
         RETURN;
     END IF;
 
+    today := (p_now AT TIME ZONE 'UTC')::DATE;
+
     FOREACH class_name IN ARRAY ARRAY['hot', 'warm', 'cold']
     LOOP
         parent_name := ('transaction_events_' || class_name)::NAME;
@@ -174,12 +179,14 @@ BEGIN
         retention_class := class_name;
         partitions_created := 0;
         partitions_dropped := 0;
+        partitions_ahead_days := NULL;
+        oldest_partition_start := NULL;
 
         FOR day_offset IN 0..p_premake_days
         LOOP
             IF public.create_transaction_event_partition(
                 class_name,
-                (p_now AT TIME ZONE 'UTC')::DATE + day_offset
+                today + day_offset
             ) THEN
                 partitions_created := partitions_created + 1;
             END IF;
@@ -205,13 +212,18 @@ BEGIN
         END LOOP;
 
         SELECT
-            min(to_date(right(child.relname, 8), 'YYYYMMDD'))::TIMESTAMP AT TIME ZONE 'UTC'
-        INTO oldest_partition_start
+            min(to_date(right(child.relname, 8), 'YYYYMMDD'))::TIMESTAMP AT TIME ZONE 'UTC',
+            max(to_date(right(child.relname, 8), 'YYYYMMDD'))
+        INTO oldest_partition_start, newest_partition_day
         FROM pg_inherits AS inheritance
         JOIN pg_class AS parent ON parent.oid = inheritance.inhparent
         JOIN pg_class AS child ON child.oid = inheritance.inhrelid
         WHERE parent.oid = to_regclass('public.' || quote_ident(parent_name::TEXT))
           AND child.relname ~ ('^' || parent_name::TEXT || '_[0-9]{8}$');
+
+        IF newest_partition_day IS NOT NULL THEN
+            partitions_ahead_days := newest_partition_day - today;
+        END IF;
 
         RETURN NEXT;
     END LOOP;

--- a/crates/infra/audit/migrations/002_transaction_event_retention.sql
+++ b/crates/infra/audit/migrations/002_transaction_event_retention.sql
@@ -106,6 +106,49 @@ BEGIN
 END
 $$;
 
+CREATE FUNCTION drop_transaction_event_partition(
+    p_retention_class TEXT,
+    p_partition_day DATE
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+    parent_name NAME;
+    child_name NAME;
+BEGIN
+    IF p_retention_class NOT IN ('hot', 'warm', 'cold') THEN
+        RAISE EXCEPTION 'invalid transaction event retention class: %', p_retention_class;
+    END IF;
+
+    parent_name := ('transaction_events_' || p_retention_class)::NAME;
+    child_name :=
+        ('transaction_events_' || p_retention_class || '_' || to_char(p_partition_day, 'YYYYMMDD'))::NAME;
+
+    -- Restrict this owner-privileged operation to a partition attached to the
+    -- expected transaction-event parent.
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_inherits AS inheritance
+        JOIN pg_class AS parent ON parent.oid = inheritance.inhparent
+        JOIN pg_namespace AS parent_namespace ON parent_namespace.oid = parent.relnamespace
+        JOIN pg_class AS child ON child.oid = inheritance.inhrelid
+        JOIN pg_namespace AS child_namespace ON child_namespace.oid = child.relnamespace
+        WHERE parent.relname = parent_name
+          AND parent_namespace.nspname = 'public'
+          AND child.relname = child_name
+          AND child_namespace.nspname = 'public'
+    ) THEN
+        RETURN FALSE;
+    END IF;
+
+    EXECUTE format('DROP TABLE public.%I', child_name);
+    RETURN TRUE;
+END
+$$;
+
 DO $$
 DECLARE
     first_day DATE := (now() AT TIME ZONE 'UTC')::DATE;
@@ -124,120 +167,8 @@ BEGIN
 END
 $$;
 
-CREATE FUNCTION maintain_transaction_event_partitions(
-    p_now TIMESTAMPTZ,
-    p_premake_days INTEGER,
-    p_hot_days INTEGER,
-    p_warm_days INTEGER,
-    p_cold_days INTEGER
-)
-RETURNS TABLE (
-    retention_class TEXT,
-    partitions_created BIGINT,
-    partitions_dropped BIGINT,
-    oldest_partition_start TIMESTAMPTZ,
-    partitions_ahead_days BIGINT
-)
-LANGUAGE plpgsql
-SECURITY DEFINER
-SET search_path = pg_catalog, public
-AS $$
-DECLARE
-    class_name TEXT;
-    parent_name NAME;
-    retention_days INTEGER;
-    day_offset INTEGER;
-    partition_record RECORD;
-    today DATE;
-    newest_partition_day DATE;
-BEGIN
-    IF p_premake_days < 1 OR p_premake_days > 31 THEN
-        RAISE EXCEPTION 'premake days must be between 1 and 31';
-    END IF;
-    IF p_hot_days < 1 OR p_warm_days < 1 OR p_cold_days < 1 THEN
-        RAISE EXCEPTION 'retention days must be positive';
-    END IF;
-    IF p_hot_days > p_warm_days OR p_warm_days > p_cold_days THEN
-        RAISE EXCEPTION 'retention days must satisfy hot <= warm <= cold';
-    END IF;
-
-    -- Every audit-archiver replica may run the worker. Only one performs DDL.
-    IF NOT pg_try_advisory_xact_lock(744697762131337711) THEN
-        RETURN;
-    END IF;
-
-    today := (p_now AT TIME ZONE 'UTC')::DATE;
-
-    FOREACH class_name IN ARRAY ARRAY['hot', 'warm', 'cold']
-    LOOP
-        parent_name := ('transaction_events_' || class_name)::NAME;
-        retention_days := CASE class_name
-            WHEN 'hot' THEN p_hot_days
-            WHEN 'warm' THEN p_warm_days
-            ELSE p_cold_days
-        END;
-        retention_class := class_name;
-        partitions_created := 0;
-        partitions_dropped := 0;
-        partitions_ahead_days := NULL;
-        oldest_partition_start := NULL;
-
-        FOR day_offset IN 0..p_premake_days
-        LOOP
-            IF public.create_transaction_event_partition(
-                class_name,
-                today + day_offset
-            ) THEN
-                partitions_created := partitions_created + 1;
-            END IF;
-        END LOOP;
-
-        FOR partition_record IN
-            SELECT
-                child.relname AS partition_name,
-                to_date(right(child.relname, 8), 'YYYYMMDD') AS partition_day
-            FROM pg_inherits AS inheritance
-            JOIN pg_class AS parent ON parent.oid = inheritance.inhparent
-            JOIN pg_class AS child ON child.oid = inheritance.inhrelid
-            WHERE parent.oid = to_regclass('public.' || quote_ident(parent_name::TEXT))
-              AND child.relname ~ ('^' || parent_name::TEXT || '_[0-9]{8}$')
-              AND (
-                  to_date(right(child.relname, 8), 'YYYYMMDD') + 1
-              )::TIMESTAMP AT TIME ZONE 'UTC'
-                  <= p_now - make_interval(days => retention_days)
-            ORDER BY partition_day
-        LOOP
-            EXECUTE format('DROP TABLE public.%I', partition_record.partition_name);
-            partitions_dropped := partitions_dropped + 1;
-        END LOOP;
-
-        SELECT
-            min(to_date(right(child.relname, 8), 'YYYYMMDD'))::TIMESTAMP AT TIME ZONE 'UTC',
-            max(to_date(right(child.relname, 8), 'YYYYMMDD'))
-        INTO oldest_partition_start, newest_partition_day
-        FROM pg_inherits AS inheritance
-        JOIN pg_class AS parent ON parent.oid = inheritance.inhparent
-        JOIN pg_class AS child ON child.oid = inheritance.inhrelid
-        WHERE parent.oid = to_regclass('public.' || quote_ident(parent_name::TEXT))
-          AND child.relname ~ ('^' || parent_name::TEXT || '_[0-9]{8}$');
-
-        IF newest_partition_day IS NOT NULL THEN
-            partitions_ahead_days := newest_partition_day - today;
-        END IF;
-
-        RETURN NEXT;
-    END LOOP;
-END
-$$;
-
 REVOKE ALL ON FUNCTION create_transaction_event_partition(TEXT, DATE) FROM PUBLIC;
-REVOKE ALL ON FUNCTION maintain_transaction_event_partitions(
-    TIMESTAMPTZ,
-    INTEGER,
-    INTEGER,
-    INTEGER,
-    INTEGER
-) FROM PUBLIC;
+REVOKE ALL ON FUNCTION drop_transaction_event_partition(TEXT, DATE) FROM PUBLIC;
 
 DO $$
 BEGIN
@@ -245,13 +176,10 @@ BEGIN
         GRANT SELECT, INSERT, UPDATE, DELETE
             ON transaction_events_hot, transaction_events_warm, transaction_events_cold
             TO audit_archiver;
-        GRANT EXECUTE ON FUNCTION maintain_transaction_event_partitions(
-            TIMESTAMPTZ,
-            INTEGER,
-            INTEGER,
-            INTEGER,
-            INTEGER
-        ) TO audit_archiver;
+        GRANT EXECUTE ON FUNCTION create_transaction_event_partition(TEXT, DATE)
+            TO audit_archiver;
+        GRANT EXECUTE ON FUNCTION drop_transaction_event_partition(TEXT, DATE)
+            TO audit_archiver;
     END IF;
 END
 $$;

--- a/crates/infra/audit/src/lib.rs
+++ b/crates/infra/audit/src/lib.rs
@@ -36,13 +36,17 @@ pub use storage::{
 
 mod transaction_events;
 pub use transaction_events::{
-    DEFAULT_TRANSACTION_EVENT_BATCH_PATH, DEFAULT_TRANSACTION_EVENT_MAX_BATCH_SIZE,
+    DEFAULT_TRANSACTION_EVENT_BATCH_PATH, DEFAULT_TRANSACTION_EVENT_COLD_RETENTION_DAYS,
+    DEFAULT_TRANSACTION_EVENT_HOT_RETENTION_DAYS, DEFAULT_TRANSACTION_EVENT_MAX_BATCH_SIZE,
     DEFAULT_TRANSACTION_EVENT_MAX_DATA_BYTES, DEFAULT_TRANSACTION_EVENT_MAX_EVENT_BYTES,
-    DEFAULT_TRANSACTION_EVENT_MAX_REQUEST_BYTES, DEFAULT_TRANSACTION_EVENT_QUERY_LIMIT,
+    DEFAULT_TRANSACTION_EVENT_MAX_REQUEST_BYTES, DEFAULT_TRANSACTION_EVENT_PARTITION_PREMAKE_DAYS,
+    DEFAULT_TRANSACTION_EVENT_QUERY_LIMIT, DEFAULT_TRANSACTION_EVENT_WARM_RETENTION_DAYS,
     MAX_TRANSACTION_EVENT_INSERT_BATCH_SIZE, MAX_TRANSACTION_EVENT_QUERY_LIMIT,
     PgTransactionEventSink, RejectedTransactionEventQuery, TransactionEventBatchResponse,
     TransactionEventBatchStatus, TransactionEventIngestConfig, TransactionEventInsertOutcome,
-    TransactionEventItemResult, TransactionEventItemStatus, TransactionEventRecord,
+    TransactionEventItemResult, TransactionEventItemStatus,
+    TransactionEventPartitionMaintenanceOutcome, TransactionEventRecord,
+    TransactionEventRetentionClass, TransactionEventRetentionConfig,
     TransactionEventSchemaReadinessError, TransactionEventSink, TransactionEventStorageError,
 };
 

--- a/crates/infra/audit/src/metrics.rs
+++ b/crates/infra/audit/src/metrics.rs
@@ -54,4 +54,15 @@ base_metrics::define_metrics! {
     transaction_event_batch_size: histogram,
     #[describe("Duration of transaction observability Postgres batch writes")]
     transaction_event_batch_write_duration: histogram,
+    #[describe("Transaction observability daily partitions created")]
+    #[label(name = "retention_class", default = ["hot", "warm", "cold"])]
+    transaction_event_partitions_created: counter,
+    #[describe("Expired transaction observability daily partitions dropped")]
+    #[label(name = "retention_class", default = ["hot", "warm", "cold"])]
+    transaction_event_partitions_dropped: counter,
+    #[describe("Age in seconds of the oldest retained transaction observability partition")]
+    #[label(name = "retention_class", default = ["hot", "warm", "cold"])]
+    transaction_event_oldest_partition_age_seconds: gauge,
+    #[describe("Transaction observability partition maintenance failures")]
+    transaction_event_partition_maintenance_failures: counter,
 }

--- a/crates/infra/audit/src/metrics.rs
+++ b/crates/infra/audit/src/metrics.rs
@@ -63,10 +63,10 @@ base_metrics::define_metrics! {
     #[describe("Age in seconds of the oldest retained transaction observability partition")]
     #[label(name = "retention_class", default = ["hot", "warm", "cold"])]
     transaction_event_oldest_partition_age_seconds: gauge,
-    #[describe("UTC days from today to the newest premade transaction observability partition")]
+    #[describe("UTC days from today to the newest premade transaction observability partition; only the advisory-lock winner refreshes this, so alert on max by retention_class (non-winners leave 0)")]
     #[label(name = "retention_class", default = ["hot", "warm", "cold"])]
     transaction_event_partitions_ahead_days: gauge,
-    #[describe("Seconds since this process last completed transaction observability partition maintenance")]
+    #[describe("Seconds since this process last completed a locked transaction observability partition maintenance pass; pods that never won stay at 0, so do not alert on plain min/max across replicas")]
     transaction_event_partition_maintenance_last_success_age_seconds: gauge,
     #[describe("Transaction observability partition maintenance failures")]
     transaction_event_partition_maintenance_failures: counter,

--- a/crates/infra/audit/src/metrics.rs
+++ b/crates/infra/audit/src/metrics.rs
@@ -63,6 +63,11 @@ base_metrics::define_metrics! {
     #[describe("Age in seconds of the oldest retained transaction observability partition")]
     #[label(name = "retention_class", default = ["hot", "warm", "cold"])]
     transaction_event_oldest_partition_age_seconds: gauge,
+    #[describe("UTC days from today to the newest premade transaction observability partition")]
+    #[label(name = "retention_class", default = ["hot", "warm", "cold"])]
+    transaction_event_partitions_ahead_days: gauge,
+    #[describe("Seconds since this process last completed transaction observability partition maintenance")]
+    transaction_event_partition_maintenance_last_success_age_seconds: gauge,
     #[describe("Transaction observability partition maintenance failures")]
     transaction_event_partition_maintenance_failures: counter,
 }

--- a/crates/infra/audit/src/transaction_events.rs
+++ b/crates/infra/audit/src/transaction_events.rs
@@ -1,7 +1,7 @@
 //! HTTP ingest path for transaction observability events.
 
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     fmt,
     sync::{Arc, Mutex},
     time::Instant,
@@ -65,7 +65,7 @@ pub const DEFAULT_TRANSACTION_EVENT_COLD_RETENTION_DAYS: u32 = 90;
 const TRANSACTION_EVENT_PARTITION_MAINTENANCE_LOCK_ID: i64 = 744_697_762_131_337_711;
 
 /// Bounded retention class persisted with every transaction event.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum TransactionEventRetentionClass {
     /// High-volume success-path and repeated builder-decision events.
@@ -97,9 +97,8 @@ impl TransactionEventRetentionClass {
 
     /// Classifies a transaction event at ingest.
     ///
-    /// Event types not explicitly assigned to hot or cold default to warm. This
-    /// makes additions safe by default while keeping exceptional volume and
-    /// diagnostic-value choices visible in this fixed map.
+    /// The match is exhaustive so new `TransactionEventType` variants fail to
+    /// compile until they are assigned a retention class deliberately.
     pub const fn for_event_type(event_type: TransactionEventType) -> Self {
         match event_type {
             TransactionEventType::ProxyReceived
@@ -111,6 +110,19 @@ impl TransactionEventRetentionClass {
             | TransactionEventType::BuilderConsidered
             | TransactionEventType::BuilderAccepted
             | TransactionEventType::BuilderRejected => Self::Hot,
+            TransactionEventType::IngressReceived
+            | TransactionEventType::SimulationStarted
+            | TransactionEventType::SimulationSucceeded
+            | TransactionEventType::IngressMeteringSendAttempt
+            | TransactionEventType::IngressMeteringSendSuccess
+            | TransactionEventType::Pending
+            | TransactionEventType::Queued
+            | TransactionEventType::PendingToQueued
+            | TransactionEventType::QueuedToPending
+            | TransactionEventType::TxpoolBuilderForwardAttempt
+            | TransactionEventType::TxpoolBuilderForwardSuccess
+            | TransactionEventType::TxpoolBuilderConsumed
+            | TransactionEventType::TxpoolValidatedInsertAccepted => Self::Warm,
             TransactionEventType::ProxyRejected
             | TransactionEventType::ProxyValidationRejected
             | TransactionEventType::ProxyBackendFailure
@@ -129,7 +141,6 @@ impl TransactionEventRetentionClass {
             | TransactionEventType::BuilderFlashblockStarted
             | TransactionEventType::BuilderFlashblockPublished
             | TransactionEventType::BuilderFlashblockBuildStopped => Self::Cold,
-            _ => Self::Warm,
         }
     }
 }
@@ -161,6 +172,25 @@ impl Default for TransactionEventRetentionConfig {
             warm_days: DEFAULT_TRANSACTION_EVENT_WARM_RETENTION_DAYS,
             cold_days: DEFAULT_TRANSACTION_EVENT_COLD_RETENTION_DAYS,
         }
+    }
+}
+
+impl TransactionEventRetentionConfig {
+    /// Validates retention and premake bounds before partition maintenance.
+    pub fn validate(self) -> Result<Self> {
+        anyhow::ensure!(
+            (1..=31).contains(&self.premake_days),
+            "transaction event partition premake days must be between 1 and 31"
+        );
+        anyhow::ensure!(
+            self.hot_days > 0 && self.hot_days <= self.warm_days,
+            "transaction event retention days must satisfy 0 < hot <= warm"
+        );
+        anyhow::ensure!(
+            self.warm_days <= self.cold_days,
+            "transaction event retention days must satisfy warm <= cold"
+        );
+        Ok(self)
     }
 }
 
@@ -510,18 +540,7 @@ impl PgTransactionEventSink {
         &self,
         config: TransactionEventRetentionConfig,
     ) -> Result<Vec<TransactionEventPartitionMaintenanceOutcome>> {
-        anyhow::ensure!(
-            (1..=31).contains(&config.premake_days),
-            "transaction event partition premake days must be between 1 and 31"
-        );
-        anyhow::ensure!(
-            config.hot_days > 0 && config.hot_days <= config.warm_days,
-            "transaction event retention days must satisfy 0 < hot <= warm"
-        );
-        anyhow::ensure!(
-            config.warm_days <= config.cold_days,
-            "transaction event retention days must satisfy warm <= cold"
-        );
+        let config = config.validate()?;
 
         let now = Utc::now();
         let today = now.date_naive();
@@ -723,10 +742,11 @@ impl PgTransactionEventSink {
             },
         );
 
+        // Infer the leaf-local UNIQUE (event_id). An explicit ON CONFLICT
+        // (event_id) target is rejected on the partitioned parent because that
+        // uniqueness is not declared on the parent relation. Same-day same-class
+        // retries dedupe; cross-day or cross-class retries do not.
         query_builder.push(" ON CONFLICT DO NOTHING RETURNING event_id");
-        // Leaf partitions carry UNIQUE (event_id). Inference through the parent
-        // is enough for same-day same-class retries; cross-day or cross-class
-        // retries are not covered by this conflict target.
 
         let rows: Vec<(String,)> = query_builder
             .build_query_as()
@@ -739,8 +759,8 @@ impl PgTransactionEventSink {
 
     /// Returns events for one transaction hash sorted by event time.
     ///
-    /// Reads the legacy `transaction_events` relation. Until the later union-view
-    /// cutover, rows written to class tables are not visible here.
+    /// Dual-store window: reads the legacy `transaction_events` heap. Until the
+    /// later union-view cutover, rows written to class tables are not visible.
     pub async fn events_by_transaction_hash(
         &self,
         tx_hash: &str,
@@ -763,6 +783,9 @@ impl PgTransactionEventSink {
     }
 
     /// Returns events for one block number sorted by event time.
+    ///
+    /// Dual-store window: reads the legacy `transaction_events` heap. Until the
+    /// later union-view cutover, rows written to class tables are not visible.
     pub async fn events_by_block_number(
         &self,
         block_number: u64,
@@ -786,6 +809,9 @@ impl PgTransactionEventSink {
     }
 
     /// Returns events for one block hash sorted by event time.
+    ///
+    /// Dual-store window: reads the legacy `transaction_events` heap. Until the
+    /// later union-view cutover, rows written to class tables are not visible.
     pub async fn events_by_block_hash(
         &self,
         block_hash: &str,
@@ -808,6 +834,9 @@ impl PgTransactionEventSink {
     }
 
     /// Returns events for one bundle UUID or bundle hash sorted by event time.
+    ///
+    /// Dual-store window: reads the legacy `transaction_events` heap. Until the
+    /// later union-view cutover, rows written to class tables are not visible.
     pub async fn events_by_bundle(
         &self,
         bundle_key: &str,
@@ -843,6 +872,9 @@ impl PgTransactionEventSink {
     }
 
     /// Returns rejected transaction events sorted newest first for list views.
+    ///
+    /// Dual-store window: reads the legacy `transaction_events` heap. Until the
+    /// later union-view cutover, rows written to class tables are not visible.
     pub async fn rejected_transaction_events(
         &self,
         query: RejectedTransactionEventQuery,
@@ -937,19 +969,17 @@ impl TransactionEventSink for PgTransactionEventSink {
             return Ok(TransactionEventInsertOutcome { inserted_event_ids: HashSet::new() });
         }
 
+        let mut by_class: HashMap<TransactionEventRetentionClass, Vec<&TransactionEvent>> =
+            HashMap::new();
+        for event in events {
+            by_class
+                .entry(TransactionEventRetentionClass::for_event_type(event.event_type))
+                .or_default()
+                .push(event);
+        }
+
         let mut inserted_event_ids = HashSet::new();
-        for retention_class in [
-            TransactionEventRetentionClass::Hot,
-            TransactionEventRetentionClass::Warm,
-            TransactionEventRetentionClass::Cold,
-        ] {
-            let class_events = events
-                .iter()
-                .filter(|event| {
-                    TransactionEventRetentionClass::for_event_type(event.event_type)
-                        == retention_class
-                })
-                .collect::<Vec<_>>();
+        for (retention_class, class_events) in by_class {
             for chunk in class_events.chunks(MAX_TRANSACTION_EVENT_INSERT_BATCH_SIZE) {
                 inserted_event_ids.extend(self.insert_event_chunk(retention_class, chunk).await?);
             }
@@ -1380,6 +1410,21 @@ mod tests {
                 TransactionEventType::BuilderPayloadFinalized
             ),
             TransactionEventRetentionClass::Cold
+        );
+    }
+
+    #[test]
+    fn validates_transaction_event_retention_ordering() {
+        assert!(TransactionEventRetentionConfig::default().validate().is_ok());
+        assert!(
+            TransactionEventRetentionConfig {
+                premake_days: 7,
+                hot_days: 30,
+                warm_days: 7,
+                cold_days: 90,
+            }
+            .validate()
+            .is_err()
         );
     }
 

--- a/crates/infra/audit/src/transaction_events.rs
+++ b/crates/infra/audit/src/transaction_events.rs
@@ -18,7 +18,7 @@ use axum::{
     routing::post,
 };
 use base_observability_events::{TransactionEvent, TransactionEventProducer, TransactionEventType};
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration, NaiveDate, Utc};
 use serde::{
     Deserialize, Serialize,
     de::{
@@ -62,6 +62,7 @@ pub const DEFAULT_TRANSACTION_EVENT_HOT_RETENTION_DAYS: u32 = 7;
 pub const DEFAULT_TRANSACTION_EVENT_WARM_RETENTION_DAYS: u32 = 30;
 /// Default retention for high-value transaction event families.
 pub const DEFAULT_TRANSACTION_EVENT_COLD_RETENTION_DAYS: u32 = 90;
+const TRANSACTION_EVENT_PARTITION_MAINTENANCE_LOCK_ID: i64 = 744_697_762_131_337_711;
 
 /// Bounded retention class persisted with every transaction event.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -343,9 +344,9 @@ pub enum TransactionEventSchemaReadinessError {
         "transaction-event Postgres schema is not ready: hot, warm, and cold transaction event tables must be partitioned; complete the transaction-event retention cutover"
     )]
     TransactionEventsRelationNotPartitioned,
-    /// The application-owned maintenance function is unavailable.
+    /// The owner-privileged partition maintenance functions are unavailable.
     #[error(
-        "transaction-event Postgres schema is not ready: partition maintenance function is missing; run migration 002_transaction_event_retention.sql"
+        "transaction-event Postgres schema is not ready: partition maintenance functions are missing; run migration 002_transaction_event_retention.sql"
     )]
     PartitionMaintenanceFunctionMissing,
     /// The expected table exists but cannot be queried by the runtime role.
@@ -439,7 +440,7 @@ impl PgTransactionEventSink {
             migration_table_exists,
             transaction_events_relation_exists,
             transaction_events_partitioned,
-            maintenance_function_exists,
+            maintenance_functions_exist,
         ): (bool, bool, bool, bool) = sqlx::query_as(
                 "SELECT \
                     to_regclass('_sqlx_migrations') IS NOT NULL AS migration_table_exists, \
@@ -452,8 +453,10 @@ impl PgTransactionEventSink {
                         to_regclass('public.transaction_events_cold') \
                      ) AND relkind = 'p') AS transaction_events_partitioned, \
                     to_regprocedure( \
-                        'public.maintain_transaction_event_partitions(timestamptz,integer,integer,integer,integer)' \
-                    ) IS NOT NULL AS maintenance_function_exists",
+                        'public.create_transaction_event_partition(text,date)' \
+                    ) IS NOT NULL AND to_regprocedure( \
+                        'public.drop_transaction_event_partition(text,date)' \
+                    ) IS NOT NULL AS maintenance_functions_exist",
             )
             .fetch_one(&self.pool)
             .await
@@ -487,7 +490,7 @@ impl PgTransactionEventSink {
                 TransactionEventSchemaReadinessError::TransactionEventsRelationNotPartitioned,
             );
         }
-        if !maintenance_function_exists {
+        if !maintenance_functions_exist {
             return Err(TransactionEventSchemaReadinessError::PartitionMaintenanceFunctionMissing);
         }
 
@@ -502,73 +505,144 @@ impl PgTransactionEventSink {
 
     /// Creates upcoming daily partitions and drops expired partitions.
     ///
-    /// The database function serializes concurrent calls from multiple replicas
-    /// with a transaction-scoped advisory lock. Replicas that lose the lock
-    /// receive no rows; only a locked pass refreshes success and ahead gauges.
+    /// Policy, catalog discovery, and orchestration live here. The database
+    /// exposes only narrowly scoped `SECURITY DEFINER` create/drop primitives,
+    /// because Postgres requires table ownership for partition DDL.
     pub async fn maintain_partitions(
         &self,
         config: TransactionEventRetentionConfig,
     ) -> Result<Vec<TransactionEventPartitionMaintenanceOutcome>> {
-        let premake_days = i32::try_from(config.premake_days)?;
-        let hot_days = i32::try_from(config.hot_days)?;
-        let warm_days = i32::try_from(config.warm_days)?;
-        let cold_days = i32::try_from(config.cold_days)?;
-        let now = Utc::now();
-        let rows = sqlx::query(
-            "SELECT retention_class, partitions_created, partitions_dropped, \
-             oldest_partition_start, partitions_ahead_days \
-             FROM maintain_transaction_event_partitions($1, $2, $3, $4, $5)",
-        )
-        .bind(now)
-        .bind(premake_days)
-        .bind(hot_days)
-        .bind(warm_days)
-        .bind(cold_days)
-        .fetch_all(&self.pool)
-        .await?;
+        anyhow::ensure!(
+            (1..=31).contains(&config.premake_days),
+            "transaction event partition premake days must be between 1 and 31"
+        );
+        anyhow::ensure!(
+            config.hot_days > 0 && config.hot_days <= config.warm_days,
+            "transaction event retention days must satisfy 0 < hot <= warm"
+        );
+        anyhow::ensure!(
+            config.warm_days <= config.cold_days,
+            "transaction event retention days must satisfy warm <= cold"
+        );
 
-        let mut outcomes = Vec::with_capacity(rows.len());
-        for row in rows {
-            let retention_class =
-                parse_transaction_event_retention_class(row.try_get("retention_class")?)?;
-            let partitions_created: i64 = row.try_get("partitions_created")?;
-            let partitions_dropped: i64 = row.try_get("partitions_dropped")?;
-            let oldest_partition_start = row.try_get("oldest_partition_start")?;
-            let partitions_ahead_days: Option<i64> = row.try_get("partitions_ahead_days")?;
+        let now = Utc::now();
+        let today = now.date_naive();
+        let mut transaction = self.pool.begin().await?;
+        let locked: bool = sqlx::query_scalar("SELECT pg_try_advisory_xact_lock($1)")
+            .bind(TRANSACTION_EVENT_PARTITION_MAINTENANCE_LOCK_ID)
+            .fetch_one(&mut *transaction)
+            .await?;
+        if !locked {
+            self.record_partition_maintenance_last_success_age();
+            return Ok(Vec::new());
+        }
+
+        let classes = [
+            (TransactionEventRetentionClass::Hot, config.hot_days),
+            (TransactionEventRetentionClass::Warm, config.warm_days),
+            (TransactionEventRetentionClass::Cold, config.cold_days),
+        ];
+        let mut outcomes = Vec::with_capacity(classes.len());
+        for (retention_class, retention_days) in classes {
+            let mut partitions_created = 0;
+            for day_offset in 0..=config.premake_days {
+                let partition_day = today + Duration::days(i64::from(day_offset));
+                let created: bool =
+                    sqlx::query_scalar("SELECT create_transaction_event_partition($1, $2)")
+                        .bind(retention_class.as_str())
+                        .bind(partition_day)
+                        .fetch_one(&mut *transaction)
+                        .await?;
+                partitions_created += u64::from(created);
+            }
+
+            let parent_name = retention_class.table_name();
+            let partition_name_pattern = format!("^{parent_name}_[0-9]{{8}}$");
+            let partition_days: Vec<NaiveDate> = sqlx::query_scalar(
+                "SELECT to_date(right(child.relname, 8), 'YYYYMMDD') \
+                 FROM pg_inherits AS inheritance \
+                 JOIN pg_class AS parent ON parent.oid = inheritance.inhparent \
+                 JOIN pg_namespace AS parent_namespace \
+                   ON parent_namespace.oid = parent.relnamespace \
+                 JOIN pg_class AS child ON child.oid = inheritance.inhrelid \
+                 JOIN pg_namespace AS child_namespace \
+                   ON child_namespace.oid = child.relnamespace \
+                 WHERE parent.relname = $1 \
+                   AND parent_namespace.nspname = 'public' \
+                   AND child_namespace.nspname = 'public' \
+                   AND child.relname ~ $2 \
+                 ORDER BY 1",
+            )
+            .bind(parent_name)
+            .bind(partition_name_pattern)
+            .fetch_all(&mut *transaction)
+            .await?;
+
+            let cutoff = now - Duration::days(i64::from(retention_days));
+            let mut partitions_dropped = 0;
+            let mut retained_partition_days = Vec::with_capacity(partition_days.len());
+            for partition_day in partition_days {
+                let upper_bound = (partition_day + Duration::days(1))
+                    .and_hms_opt(0, 0, 0)
+                    .expect("UTC partition boundary is a valid timestamp")
+                    .and_utc();
+                if upper_bound <= cutoff {
+                    let dropped: bool =
+                        sqlx::query_scalar("SELECT drop_transaction_event_partition($1, $2)")
+                            .bind(retention_class.as_str())
+                            .bind(partition_day)
+                            .fetch_one(&mut *transaction)
+                            .await?;
+                    partitions_dropped += u64::from(dropped);
+                } else {
+                    retained_partition_days.push(partition_day);
+                }
+            }
+
+            let oldest_partition_start = retained_partition_days.first().map(|day| {
+                day.and_hms_opt(0, 0, 0)
+                    .expect("UTC partition boundary is a valid timestamp")
+                    .and_utc()
+            });
+            let partitions_ahead_days =
+                retained_partition_days.last().map(|newest| (*newest - today).num_days());
             let outcome = TransactionEventPartitionMaintenanceOutcome {
                 retention_class,
-                partitions_created: u64::try_from(partitions_created)?,
-                partitions_dropped: u64::try_from(partitions_dropped)?,
+                partitions_created,
+                partitions_dropped,
                 oldest_partition_start,
                 partitions_ahead_days,
             };
+            outcomes.push(outcome);
+        }
 
-            Metrics::transaction_event_partitions_created(retention_class.as_str())
+        transaction.commit().await?;
+
+        for outcome in &outcomes {
+            Metrics::transaction_event_partitions_created(outcome.retention_class.as_str())
                 .increment(outcome.partitions_created);
-            Metrics::transaction_event_partitions_dropped(retention_class.as_str())
+            Metrics::transaction_event_partitions_dropped(outcome.retention_class.as_str())
                 .increment(outcome.partitions_dropped);
             if let Some(oldest) = outcome.oldest_partition_start {
                 let age_seconds =
                     now.signed_duration_since(oldest).to_std().map_or(0.0, |age| age.as_secs_f64());
-                Metrics::transaction_event_oldest_partition_age_seconds(retention_class.as_str())
-                    .set(age_seconds);
+                Metrics::transaction_event_oldest_partition_age_seconds(
+                    outcome.retention_class.as_str(),
+                )
+                .set(age_seconds);
             }
             if let Some(ahead_days) = outcome.partitions_ahead_days {
-                Metrics::transaction_event_partitions_ahead_days(retention_class.as_str())
+                Metrics::transaction_event_partitions_ahead_days(outcome.retention_class.as_str())
                     .set(ahead_days as f64);
             }
-            outcomes.push(outcome);
         }
-
-        if !outcomes.is_empty() {
-            match self.last_maintenance_success.lock() {
-                Ok(mut last_success) => *last_success = Some(Instant::now()),
-                Err(_) => {
-                    error!(
-                        "transaction event partition maintenance success clock is poisoned; \
-                         freshness gauge will not advance"
-                    );
-                }
+        match self.last_maintenance_success.lock() {
+            Ok(mut last_success) => *last_success = Some(Instant::now()),
+            Err(_) => {
+                error!(
+                    "transaction event partition maintenance success clock is poisoned; \
+                     freshness gauge will not advance"
+                );
             }
         }
         self.record_partition_maintenance_last_success_age();

--- a/crates/infra/audit/src/transaction_events.rs
+++ b/crates/infra/audit/src/transaction_events.rs
@@ -80,6 +80,15 @@ impl TransactionEventRetentionClass {
         }
     }
 
+    /// Class-specific partitioned table used for writes.
+    const fn table_name(self) -> &'static str {
+        match self {
+            Self::Hot => "transaction_events_hot",
+            Self::Warm => "transaction_events_warm",
+            Self::Cold => "transaction_events_cold",
+        }
+    }
+
     /// Classifies a transaction event at ingest.
     ///
     /// Event types not explicitly assigned to hot or cold default to warm. This
@@ -317,14 +326,14 @@ pub enum TransactionEventSchemaReadinessError {
         /// Required sqlx migration version.
         required_version: i64,
     },
-    /// The expected table is missing or not visible to the runtime role.
+    /// The expected read relation or retention tables are missing.
     #[error(
-        "transaction-event Postgres schema is not ready: public.transaction_events is missing or not visible to the runtime role; run `audit-archiver migrate up` or the audit migration WorkflowTemplate before enabling TIPS_AUDIT_POSTGRES_URL"
+        "transaction-event Postgres schema is not ready: public.transaction_events or its retention tables are missing; run `audit-archiver migrate up` or the audit migration WorkflowTemplate before enabling TIPS_AUDIT_POSTGRES_URL"
     )]
     TransactionEventsRelationMissing,
-    /// The table exists but has not been cut over to declarative partitioning.
+    /// One or more class-specific tables are not declaratively partitioned.
     #[error(
-        "transaction-event Postgres schema is not ready: public.transaction_events is not a partitioned table; complete the transaction-event retention cutover"
+        "transaction-event Postgres schema is not ready: hot, warm, and cold transaction event tables must be partitioned; complete the transaction-event retention cutover"
     )]
     TransactionEventsRelationNotPartitioned,
     /// The application-owned maintenance function is unavailable.
@@ -425,11 +434,13 @@ impl PgTransactionEventSink {
                 "SELECT \
                     to_regclass('_sqlx_migrations') IS NOT NULL AS migration_table_exists, \
                     to_regclass('public.transaction_events') IS NOT NULL AS transaction_events_relation_exists, \
-                    COALESCE(( \
-                        SELECT relkind = 'p' \
-                        FROM pg_class \
-                        WHERE oid = to_regclass('public.transaction_events') \
-                    ), FALSE) AS transaction_events_partitioned, \
+                    (SELECT count(*) = 3 \
+                     FROM pg_class \
+                     WHERE oid IN ( \
+                        to_regclass('public.transaction_events_hot'), \
+                        to_regclass('public.transaction_events_warm'), \
+                        to_regclass('public.transaction_events_cold') \
+                     ) AND relkind = 'p') AS transaction_events_partitioned, \
                     to_regprocedure( \
                         'public.maintain_transaction_event_partitions(timestamptz,integer,integer,integer,integer)' \
                     ) IS NOT NULL AS maintenance_function_exists",
@@ -546,7 +557,8 @@ impl PgTransactionEventSink {
 
     async fn insert_event_chunk(
         &self,
-        events: &[TransactionEvent],
+        retention_class: TransactionEventRetentionClass,
+        events: &[&TransactionEvent],
     ) -> std::result::Result<HashSet<String>, TransactionEventStorageError> {
         let ingested_at = Utc::now();
         let block_numbers: Vec<Option<i64>> = events
@@ -560,11 +572,12 @@ impl PgTransactionEventSink {
             })
             .collect::<std::result::Result<_, _>>()?;
 
-        let mut query_builder = QueryBuilder::new(
-            "INSERT INTO transaction_events \
+        let mut query_builder = QueryBuilder::new(format!(
+            "INSERT INTO {} \
              (event_id, retention_class, schema_version, event_time, ingested_at, producer, \
               event_type, network, tx_hash, block_hash, block_number, payload_id, request_id, data) ",
-        );
+            retention_class.table_name()
+        ));
 
         query_builder.push_values(
             events.iter().zip(block_numbers),
@@ -573,12 +586,10 @@ impl PgTransactionEventSink {
                 let block_hash = event.block_hash.map(|hash| hash.to_string());
                 let producer = event.producer.to_string();
                 let event_type = event.event_type.to_string();
-                let retention_class =
-                    TransactionEventRetentionClass::for_event_type(event.event_type).to_string();
                 let data = Value::Object(event.data.clone());
 
                 row.push_bind(&event.event_id)
-                    .push_bind(retention_class)
+                    .push_bind(retention_class.as_str())
                     .push_bind(&event.schema_version)
                     .push_bind(event.event_time)
                     .push_bind(ingested_at)
@@ -814,8 +825,21 @@ impl TransactionEventSink for PgTransactionEventSink {
         }
 
         let mut inserted_event_ids = HashSet::new();
-        for chunk in events.chunks(MAX_TRANSACTION_EVENT_INSERT_BATCH_SIZE) {
-            inserted_event_ids.extend(self.insert_event_chunk(chunk).await?);
+        for retention_class in [
+            TransactionEventRetentionClass::Hot,
+            TransactionEventRetentionClass::Warm,
+            TransactionEventRetentionClass::Cold,
+        ] {
+            let class_events = events
+                .iter()
+                .filter(|event| {
+                    TransactionEventRetentionClass::for_event_type(event.event_type)
+                        == retention_class
+                })
+                .collect::<Vec<_>>();
+            for chunk in class_events.chunks(MAX_TRANSACTION_EVENT_INSERT_BATCH_SIZE) {
+                inserted_event_ids.extend(self.insert_event_chunk(retention_class, chunk).await?);
+            }
         }
 
         Ok(TransactionEventInsertOutcome { inserted_event_ids })

--- a/crates/infra/audit/src/transaction_events.rs
+++ b/crates/infra/audit/src/transaction_events.rs
@@ -1,6 +1,11 @@
 //! HTTP ingest path for transaction observability events.
 
-use std::{collections::HashSet, fmt, sync::Arc, time::Instant};
+use std::{
+    collections::HashSet,
+    fmt,
+    sync::{Arc, Mutex},
+    time::Instant,
+};
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -169,6 +174,8 @@ pub struct TransactionEventPartitionMaintenanceOutcome {
     pub partitions_dropped: u64,
     /// Start of the oldest retained daily partition.
     pub oldest_partition_start: Option<DateTime<Utc>>,
+    /// UTC days from today to the newest retained daily partition.
+    pub partitions_ahead_days: Option<i64>,
 }
 
 /// Configuration for transaction event HTTP ingest.
@@ -381,6 +388,9 @@ pub trait TransactionEventSink: Send + Sync {
 #[derive(Debug, Clone)]
 pub struct PgTransactionEventSink {
     pool: PgPool,
+    /// Shared across clones so every replica process tracks its own last
+    /// successful locked maintenance pass for freshness gauges.
+    last_maintenance_success: Arc<Mutex<Option<Instant>>>,
 }
 
 impl PgTransactionEventSink {
@@ -406,7 +416,7 @@ impl PgTransactionEventSink {
             .idle_timeout(None)
             .connect(database_url)
             .await?;
-        Ok(Self { pool })
+        Ok(Self::new(pool))
     }
 
     /// Runs pending Postgres migrations.
@@ -417,8 +427,8 @@ impl PgTransactionEventSink {
     }
 
     /// Creates a sink from an existing pool.
-    pub const fn new(pool: PgPool) -> Self {
-        Self { pool }
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool, last_maintenance_success: Arc::new(Mutex::new(None)) }
     }
 
     /// Checks whether transaction event Postgres storage is ready for runtime use.
@@ -493,7 +503,8 @@ impl PgTransactionEventSink {
     /// Creates upcoming daily partitions and drops expired partitions.
     ///
     /// The database function serializes concurrent calls from multiple replicas
-    /// with a transaction-scoped advisory lock.
+    /// with a transaction-scoped advisory lock. Replicas that lose the lock
+    /// receive no rows; only a locked pass refreshes success and ahead gauges.
     pub async fn maintain_partitions(
         &self,
         config: TransactionEventRetentionConfig,
@@ -505,7 +516,7 @@ impl PgTransactionEventSink {
         let now = Utc::now();
         let rows = sqlx::query(
             "SELECT retention_class, partitions_created, partitions_dropped, \
-             oldest_partition_start \
+             oldest_partition_start, partitions_ahead_days \
              FROM maintain_transaction_event_partitions($1, $2, $3, $4, $5)",
         )
         .bind(now)
@@ -523,11 +534,13 @@ impl PgTransactionEventSink {
             let partitions_created: i64 = row.try_get("partitions_created")?;
             let partitions_dropped: i64 = row.try_get("partitions_dropped")?;
             let oldest_partition_start = row.try_get("oldest_partition_start")?;
+            let partitions_ahead_days: Option<i64> = row.try_get("partitions_ahead_days")?;
             let outcome = TransactionEventPartitionMaintenanceOutcome {
                 retention_class,
                 partitions_created: u64::try_from(partitions_created)?,
                 partitions_dropped: u64::try_from(partitions_dropped)?,
                 oldest_partition_start,
+                partitions_ahead_days,
             };
 
             Metrics::transaction_event_partitions_created(retention_class.as_str())
@@ -540,9 +553,42 @@ impl PgTransactionEventSink {
                 Metrics::transaction_event_oldest_partition_age_seconds(retention_class.as_str())
                     .set(age_seconds);
             }
+            if let Some(ahead_days) = outcome.partitions_ahead_days {
+                Metrics::transaction_event_partitions_ahead_days(retention_class.as_str())
+                    .set(ahead_days as f64);
+            }
             outcomes.push(outcome);
         }
+
+        if !outcomes.is_empty() {
+            match self.last_maintenance_success.lock() {
+                Ok(mut last_success) => *last_success = Some(Instant::now()),
+                Err(_) => {
+                    error!(
+                        "transaction event partition maintenance success clock is poisoned; \
+                         freshness gauge will not advance"
+                    );
+                }
+            }
+        }
+        self.record_partition_maintenance_last_success_age();
+
         Ok(outcomes)
+    }
+
+    /// Refreshes the last-success age gauge from this process's last locked pass.
+    ///
+    /// Call after a failed maintenance attempt so the age continues to advance
+    /// even when the SQL round-trip errors.
+    pub fn record_partition_maintenance_last_success_age(&self) {
+        let Ok(last_success) = self.last_maintenance_success.lock() else {
+            return;
+        };
+        let Some(last_success) = *last_success else {
+            return;
+        };
+        Metrics::transaction_event_partition_maintenance_last_success_age_seconds()
+            .set(last_success.elapsed().as_secs_f64());
     }
 
     /// Checks optional transaction event storage readiness.

--- a/crates/infra/audit/src/transaction_events.rs
+++ b/crates/infra/audit/src/transaction_events.rs
@@ -281,8 +281,6 @@ pub struct TransactionEventRecord {
     /// Event envelope.
     #[serde(flatten)]
     pub event: TransactionEvent,
-    /// Retention policy selected by audit-archiver at ingest.
-    pub retention_class: TransactionEventRetentionClass,
     /// Time when audit-archiver inserted the event.
     pub ingested_at: DateTime<Utc>,
 }
@@ -744,7 +742,7 @@ impl PgTransactionEventSink {
     ) -> Result<Vec<TransactionEventRecord>> {
         let limit = normalize_limit(limit);
         let rows = sqlx::query(
-            "SELECT event_id, retention_class, schema_version, event_time, ingested_at, producer, event_type, \
+            "SELECT event_id, schema_version, event_time, ingested_at, producer, event_type, \
              network, tx_hash, block_hash, block_number, payload_id, request_id, data \
              FROM transaction_events \
              WHERE tx_hash = $1 \
@@ -767,7 +765,7 @@ impl PgTransactionEventSink {
         let block_number = i64::try_from(block_number)?;
         let limit = normalize_limit(limit);
         let rows = sqlx::query(
-            "SELECT event_id, retention_class, schema_version, event_time, ingested_at, producer, event_type, \
+            "SELECT event_id, schema_version, event_time, ingested_at, producer, event_type, \
              network, tx_hash, block_hash, block_number, payload_id, request_id, data \
              FROM transaction_events \
              WHERE block_number = $1 \
@@ -789,7 +787,7 @@ impl PgTransactionEventSink {
     ) -> Result<Vec<TransactionEventRecord>> {
         let limit = normalize_limit(limit);
         let rows = sqlx::query(
-            "SELECT event_id, retention_class, schema_version, event_time, ingested_at, producer, event_type, \
+            "SELECT event_id, schema_version, event_time, ingested_at, producer, event_type, \
              network, tx_hash, block_hash, block_number, payload_id, request_id, data \
              FROM transaction_events \
              WHERE block_hash = $1 \
@@ -812,12 +810,12 @@ impl PgTransactionEventSink {
         let limit = normalize_limit(limit);
         let rows = sqlx::query(
             "WITH bundle_events AS ( \
-                SELECT event_id, retention_class, schema_version, event_time, ingested_at, producer, event_type, \
+                SELECT event_id, schema_version, event_time, ingested_at, producer, event_type, \
                 network, tx_hash, block_hash, block_number, payload_id, request_id, data \
                 FROM transaction_events \
                 WHERE data ? 'bundle_hash' AND data->>'bundle_hash' = $1 \
                 UNION ALL \
-                SELECT event_id, retention_class, schema_version, event_time, ingested_at, producer, event_type, \
+                SELECT event_id, schema_version, event_time, ingested_at, producer, event_type, \
                 network, tx_hash, block_hash, block_number, payload_id, request_id, data \
                 FROM transaction_events \
                 WHERE data ? 'bundle_id' AND data->>'bundle_id' = $1 \
@@ -825,7 +823,7 @@ impl PgTransactionEventSink {
                 SELECT DISTINCT ON (event_id) * FROM bundle_events \
                 ORDER BY event_id, event_time ASC, ingested_at ASC \
              ) \
-             SELECT event_id, retention_class, schema_version, event_time, ingested_at, producer, event_type, \
+             SELECT event_id, schema_version, event_time, ingested_at, producer, event_type, \
              network, tx_hash, block_hash, block_number, payload_id, request_id, data \
              FROM deduped \
              ORDER BY event_time ASC, ingested_at ASC, event_id ASC \
@@ -848,7 +846,7 @@ impl PgTransactionEventSink {
         let to_block = query.to_block.map(i64::try_from).transpose()?;
 
         let rows = sqlx::query(
-            "SELECT event_id, retention_class, schema_version, event_time, ingested_at, producer, event_type, \
+            "SELECT event_id, schema_version, event_time, ingested_at, producer, event_type, \
              network, tx_hash, block_hash, block_number, payload_id, request_id, data \
              FROM transaction_events \
              WHERE event_type IN ('SIMULATION_FAILED', 'BUILDER_REJECTED') \
@@ -902,11 +900,7 @@ fn record_from_row(row: sqlx::postgres::PgRow) -> Result<TransactionEventRecord>
             .cloned()
             .ok_or_else(|| anyhow::anyhow!("transaction event data column is not a JSON object"))?,
     };
-    Ok(TransactionEventRecord {
-        event,
-        retention_class: parse_transaction_event_retention_class(row.try_get("retention_class")?)?,
-        ingested_at: row.try_get("ingested_at")?,
-    })
+    Ok(TransactionEventRecord { event, ingested_at: row.try_get("ingested_at")? })
 }
 
 fn parse_transaction_event_producer(producer: String) -> Result<TransactionEventProducer> {
@@ -917,13 +911,6 @@ fn parse_transaction_event_producer(producer: String) -> Result<TransactionEvent
 fn parse_transaction_event_type(event_type: String) -> Result<TransactionEventType> {
     let deserializer: StringDeserializer<SerdeValueError> = event_type.into_deserializer();
     Ok(TransactionEventType::deserialize(deserializer)?)
-}
-
-fn parse_transaction_event_retention_class(
-    retention_class: String,
-) -> Result<TransactionEventRetentionClass> {
-    let deserializer: StringDeserializer<SerdeValueError> = retention_class.into_deserializer();
-    Ok(TransactionEventRetentionClass::deserialize(deserializer)?)
 }
 
 fn metric_len_u64(len: usize) -> u64 {

--- a/crates/infra/audit/src/transaction_events.rs
+++ b/crates/infra/audit/src/transaction_events.rs
@@ -349,7 +349,7 @@ pub enum TransactionEventSchemaReadinessError {
     PartitionMaintenanceFunctionMissing,
     /// The expected table exists but cannot be queried by the runtime role.
     #[error(
-        "transaction-event Postgres schema is not ready: runtime role cannot query public.transaction_events; verify audit_archiver privileges from 001_transaction_events.sql"
+        "transaction-event Postgres schema is not ready: runtime role cannot query public.transaction_events; verify audit_archiver privileges from 001_transaction_events.sql and 002_transaction_event_retention.sql"
     )]
     TransactionEventsRelationUnavailable {
         /// Underlying database error.
@@ -724,6 +724,9 @@ impl PgTransactionEventSink {
         );
 
         query_builder.push(" ON CONFLICT DO NOTHING RETURNING event_id");
+        // Leaf partitions carry UNIQUE (event_id). Inference through the parent
+        // is enough for same-day same-class retries; cross-day or cross-class
+        // retries are not covered by this conflict target.
 
         let rows: Vec<(String,)> = query_builder
             .build_query_as()
@@ -735,6 +738,9 @@ impl PgTransactionEventSink {
     }
 
     /// Returns events for one transaction hash sorted by event time.
+    ///
+    /// Reads the legacy `transaction_events` relation. Until the later union-view
+    /// cutover, rows written to class tables are not visible here.
     pub async fn events_by_transaction_hash(
         &self,
         tx_hash: &str,

--- a/crates/infra/audit/src/transaction_events.rs
+++ b/crates/infra/audit/src/transaction_events.rs
@@ -1,6 +1,6 @@
 //! HTTP ingest path for transaction observability events.
 
-use std::{collections::HashSet, sync::Arc, time::Instant};
+use std::{collections::HashSet, fmt, sync::Arc, time::Instant};
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -45,9 +45,122 @@ pub const DEFAULT_TRANSACTION_EVENT_MAX_REQUEST_BYTES: usize = 8 * 1024 * 1024;
 
 /// Maximum events inserted in one Postgres statement.
 ///
-/// Each row uses 12 bind parameters, so this stays below Postgres' 65,535 bind
+/// Each row uses 14 bind parameters, so this stays below Postgres' 65,535 bind
 /// parameter limit with room for future columns.
-pub const MAX_TRANSACTION_EVENT_INSERT_BATCH_SIZE: usize = 5_000;
+pub const MAX_TRANSACTION_EVENT_INSERT_BATCH_SIZE: usize = 4_000;
+
+/// Default number of UTC daily partitions to create ahead of ingest.
+pub const DEFAULT_TRANSACTION_EVENT_PARTITION_PREMAKE_DAYS: u32 = 7;
+/// Default retention for high-volume transaction event families.
+pub const DEFAULT_TRANSACTION_EVENT_HOT_RETENTION_DAYS: u32 = 7;
+/// Default retention for ordinary transaction event families.
+pub const DEFAULT_TRANSACTION_EVENT_WARM_RETENTION_DAYS: u32 = 30;
+/// Default retention for high-value transaction event families.
+pub const DEFAULT_TRANSACTION_EVENT_COLD_RETENTION_DAYS: u32 = 90;
+
+/// Bounded retention class persisted with every transaction event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TransactionEventRetentionClass {
+    /// High-volume success-path and repeated builder-decision events.
+    Hot,
+    /// Default class for ordinary arrival, simulation, and forwarding events.
+    Warm,
+    /// High-value inclusion, finalization, rejection, and drop events.
+    Cold,
+}
+
+impl TransactionEventRetentionClass {
+    /// Stable lowercase value stored in Postgres and used as a bounded metric label.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Hot => "hot",
+            Self::Warm => "warm",
+            Self::Cold => "cold",
+        }
+    }
+
+    /// Classifies a transaction event at ingest.
+    ///
+    /// Event types not explicitly assigned to hot or cold default to warm. This
+    /// makes additions safe by default while keeping exceptional volume and
+    /// diagnostic-value choices visible in this fixed map.
+    pub const fn for_event_type(event_type: TransactionEventType) -> Self {
+        match event_type {
+            TransactionEventType::ProxyReceived
+            | TransactionEventType::ProxyValidationAccepted
+            | TransactionEventType::ProxyRoutedToBackend
+            | TransactionEventType::ProxyBackendSuccess
+            | TransactionEventType::ProxyIngressRpcAttempt
+            | TransactionEventType::ProxyIngressRpcSuccess
+            | TransactionEventType::BuilderConsidered
+            | TransactionEventType::BuilderAccepted
+            | TransactionEventType::BuilderRejected => Self::Hot,
+            TransactionEventType::ProxyRejected
+            | TransactionEventType::ProxyValidationRejected
+            | TransactionEventType::ProxyBackendFailure
+            | TransactionEventType::ProxyIngressRpcFailure
+            | TransactionEventType::SimulationFailed
+            | TransactionEventType::IngressMeteringSendFailure
+            | TransactionEventType::IngressMeteringSendDropped
+            | TransactionEventType::Dropped
+            | TransactionEventType::Replaced
+            | TransactionEventType::Overflowed
+            | TransactionEventType::TxpoolBuilderForwardFailure
+            | TransactionEventType::TxpoolBuilderForwardDropped
+            | TransactionEventType::TxpoolValidatedInsertRejected
+            | TransactionEventType::BuilderIncluded
+            | TransactionEventType::BuilderPayloadFinalized
+            | TransactionEventType::BuilderFlashblockStarted
+            | TransactionEventType::BuilderFlashblockPublished
+            | TransactionEventType::BuilderFlashblockBuildStopped => Self::Cold,
+            _ => Self::Warm,
+        }
+    }
+}
+
+impl fmt::Display for TransactionEventRetentionClass {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Configuration for one transaction event partition-maintenance pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TransactionEventRetentionConfig {
+    /// Number of future UTC daily partitions to create.
+    pub premake_days: u32,
+    /// Hot event retention in days.
+    pub hot_days: u32,
+    /// Warm event retention in days.
+    pub warm_days: u32,
+    /// Cold event retention in days.
+    pub cold_days: u32,
+}
+
+impl Default for TransactionEventRetentionConfig {
+    fn default() -> Self {
+        Self {
+            premake_days: DEFAULT_TRANSACTION_EVENT_PARTITION_PREMAKE_DAYS,
+            hot_days: DEFAULT_TRANSACTION_EVENT_HOT_RETENTION_DAYS,
+            warm_days: DEFAULT_TRANSACTION_EVENT_WARM_RETENTION_DAYS,
+            cold_days: DEFAULT_TRANSACTION_EVENT_COLD_RETENTION_DAYS,
+        }
+    }
+}
+
+/// Result for one retention class from a partition-maintenance pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransactionEventPartitionMaintenanceOutcome {
+    /// Retention class maintained.
+    pub retention_class: TransactionEventRetentionClass,
+    /// Future/current partitions created.
+    pub partitions_created: u64,
+    /// Expired partitions dropped.
+    pub partitions_dropped: u64,
+    /// Start of the oldest retained daily partition.
+    pub oldest_partition_start: Option<DateTime<Utc>>,
+}
 
 /// Configuration for transaction event HTTP ingest.
 #[derive(Debug, Clone)]
@@ -128,7 +241,7 @@ pub struct TransactionEventInsertOutcome {
 pub const DEFAULT_TRANSACTION_EVENT_QUERY_LIMIT: i64 = 500;
 /// Hard maximum query result count for read APIs.
 pub const MAX_TRANSACTION_EVENT_QUERY_LIMIT: i64 = 2_000;
-const REQUIRED_TRANSACTION_EVENT_MIGRATION_DESCRIPTION: &str = "transaction events";
+const REQUIRED_TRANSACTION_EVENT_MIGRATION_DESCRIPTION: &str = "transaction event retention";
 static TRANSACTION_EVENT_MIGRATOR: Migrator = sqlx::migrate!("./migrations");
 
 /// Required sqlx migration version for transaction event storage.
@@ -137,7 +250,7 @@ fn required_transaction_event_migration_version() -> Result<i64, &'static str> {
         migration.description.as_ref() == REQUIRED_TRANSACTION_EVENT_MIGRATION_DESCRIPTION
     });
     let migration = matching_migrations.next().ok_or(
-        "transaction event migration 001_transaction_events.sql must be embedded in audit migrator",
+        "transaction event migration 002_transaction_event_retention.sql must be embedded in audit migrator",
     )?;
     if matching_migrations.next().is_some() {
         return Err("transaction event migration description must be unique");
@@ -151,6 +264,8 @@ pub struct TransactionEventRecord {
     /// Event envelope.
     #[serde(flatten)]
     pub event: TransactionEvent,
+    /// Retention policy selected by audit-archiver at ingest.
+    pub retention_class: TransactionEventRetentionClass,
     /// Time when audit-archiver inserted the event.
     pub ingested_at: DateTime<Utc>,
 }
@@ -196,7 +311,7 @@ pub enum TransactionEventSchemaReadinessError {
     MigrationTableMissing,
     /// The transaction event migration has not completed successfully.
     #[error(
-        "transaction-event Postgres schema is not ready: required sqlx migration version {required_version} for 001_transaction_events.sql has not been applied successfully; run `audit-archiver migrate up` or the audit migration WorkflowTemplate before enabling TIPS_AUDIT_POSTGRES_URL"
+        "transaction-event Postgres schema is not ready: required sqlx migration version {required_version} for 002_transaction_event_retention.sql has not been applied successfully; run `audit-archiver migrate up` or the audit migration WorkflowTemplate before enabling TIPS_AUDIT_POSTGRES_URL"
     )]
     RequiredMigrationMissing {
         /// Required sqlx migration version.
@@ -207,6 +322,16 @@ pub enum TransactionEventSchemaReadinessError {
         "transaction-event Postgres schema is not ready: public.transaction_events is missing or not visible to the runtime role; run `audit-archiver migrate up` or the audit migration WorkflowTemplate before enabling TIPS_AUDIT_POSTGRES_URL"
     )]
     TransactionEventsRelationMissing,
+    /// The table exists but has not been cut over to declarative partitioning.
+    #[error(
+        "transaction-event Postgres schema is not ready: public.transaction_events is not a partitioned table; complete the transaction-event retention cutover"
+    )]
+    TransactionEventsRelationNotPartitioned,
+    /// The application-owned maintenance function is unavailable.
+    #[error(
+        "transaction-event Postgres schema is not ready: partition maintenance function is missing; run migration 002_transaction_event_retention.sql"
+    )]
+    PartitionMaintenanceFunctionMissing,
     /// The expected table exists but cannot be queried by the runtime role.
     #[error(
         "transaction-event Postgres schema is not ready: runtime role cannot query public.transaction_events; verify audit_archiver privileges from 001_transaction_events.sql"
@@ -291,11 +416,23 @@ impl PgTransactionEventSink {
     pub async fn check_schema_ready(
         &self,
     ) -> std::result::Result<(), TransactionEventSchemaReadinessError> {
-        let (migration_table_exists, transaction_events_relation_exists): (bool, bool) =
-            sqlx::query_as(
+        let (
+            migration_table_exists,
+            transaction_events_relation_exists,
+            transaction_events_partitioned,
+            maintenance_function_exists,
+        ): (bool, bool, bool, bool) = sqlx::query_as(
                 "SELECT \
                     to_regclass('_sqlx_migrations') IS NOT NULL AS migration_table_exists, \
-                    to_regclass('public.transaction_events') IS NOT NULL AS transaction_events_relation_exists",
+                    to_regclass('public.transaction_events') IS NOT NULL AS transaction_events_relation_exists, \
+                    COALESCE(( \
+                        SELECT relkind = 'p' \
+                        FROM pg_class \
+                        WHERE oid = to_regclass('public.transaction_events') \
+                    ), FALSE) AS transaction_events_partitioned, \
+                    to_regprocedure( \
+                        'public.maintain_transaction_event_partitions(timestamptz,integer,integer,integer,integer)' \
+                    ) IS NOT NULL AS maintenance_function_exists",
             )
             .fetch_one(&self.pool)
             .await
@@ -324,6 +461,14 @@ impl PgTransactionEventSink {
         if !transaction_events_relation_exists {
             return Err(TransactionEventSchemaReadinessError::TransactionEventsRelationMissing);
         }
+        if !transaction_events_partitioned {
+            return Err(
+                TransactionEventSchemaReadinessError::TransactionEventsRelationNotPartitioned,
+            );
+        }
+        if !maintenance_function_exists {
+            return Err(TransactionEventSchemaReadinessError::PartitionMaintenanceFunctionMissing);
+        }
 
         sqlx::query("SELECT 1 FROM transaction_events LIMIT 0").execute(&self.pool).await.map_err(
             |source| TransactionEventSchemaReadinessError::TransactionEventsRelationUnavailable {
@@ -332,6 +477,61 @@ impl PgTransactionEventSink {
         )?;
 
         Ok(())
+    }
+
+    /// Creates upcoming daily partitions and drops expired partitions.
+    ///
+    /// The database function serializes concurrent calls from multiple replicas
+    /// with a transaction-scoped advisory lock.
+    pub async fn maintain_partitions(
+        &self,
+        config: TransactionEventRetentionConfig,
+    ) -> Result<Vec<TransactionEventPartitionMaintenanceOutcome>> {
+        let premake_days = i32::try_from(config.premake_days)?;
+        let hot_days = i32::try_from(config.hot_days)?;
+        let warm_days = i32::try_from(config.warm_days)?;
+        let cold_days = i32::try_from(config.cold_days)?;
+        let now = Utc::now();
+        let rows = sqlx::query(
+            "SELECT retention_class, partitions_created, partitions_dropped, \
+             oldest_partition_start \
+             FROM maintain_transaction_event_partitions($1, $2, $3, $4, $5)",
+        )
+        .bind(now)
+        .bind(premake_days)
+        .bind(hot_days)
+        .bind(warm_days)
+        .bind(cold_days)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let mut outcomes = Vec::with_capacity(rows.len());
+        for row in rows {
+            let retention_class =
+                parse_transaction_event_retention_class(row.try_get("retention_class")?)?;
+            let partitions_created: i64 = row.try_get("partitions_created")?;
+            let partitions_dropped: i64 = row.try_get("partitions_dropped")?;
+            let oldest_partition_start = row.try_get("oldest_partition_start")?;
+            let outcome = TransactionEventPartitionMaintenanceOutcome {
+                retention_class,
+                partitions_created: u64::try_from(partitions_created)?,
+                partitions_dropped: u64::try_from(partitions_dropped)?,
+                oldest_partition_start,
+            };
+
+            Metrics::transaction_event_partitions_created(retention_class.as_str())
+                .increment(outcome.partitions_created);
+            Metrics::transaction_event_partitions_dropped(retention_class.as_str())
+                .increment(outcome.partitions_dropped);
+            if let Some(oldest) = outcome.oldest_partition_start {
+                let age_seconds =
+                    now.signed_duration_since(oldest).to_std().map_or(0.0, |age| age.as_secs_f64());
+                Metrics::transaction_event_oldest_partition_age_seconds(retention_class.as_str())
+                    .set(age_seconds);
+            }
+            outcomes.push(outcome);
+        }
+        Ok(outcomes)
     }
 
     /// Checks optional transaction event storage readiness.
@@ -348,6 +548,7 @@ impl PgTransactionEventSink {
         &self,
         events: &[TransactionEvent],
     ) -> std::result::Result<HashSet<String>, TransactionEventStorageError> {
+        let ingested_at = Utc::now();
         let block_numbers: Vec<Option<i64>> = events
             .iter()
             .map(|event| {
@@ -361,8 +562,8 @@ impl PgTransactionEventSink {
 
         let mut query_builder = QueryBuilder::new(
             "INSERT INTO transaction_events \
-             (event_id, schema_version, event_time, producer, event_type, network, tx_hash, \
-              block_hash, block_number, payload_id, request_id, data) ",
+             (event_id, retention_class, schema_version, event_time, ingested_at, producer, \
+              event_type, network, tx_hash, block_hash, block_number, payload_id, request_id, data) ",
         );
 
         query_builder.push_values(
@@ -372,11 +573,15 @@ impl PgTransactionEventSink {
                 let block_hash = event.block_hash.map(|hash| hash.to_string());
                 let producer = event.producer.to_string();
                 let event_type = event.event_type.to_string();
+                let retention_class =
+                    TransactionEventRetentionClass::for_event_type(event.event_type).to_string();
                 let data = Value::Object(event.data.clone());
 
                 row.push_bind(&event.event_id)
+                    .push_bind(retention_class)
                     .push_bind(&event.schema_version)
                     .push_bind(event.event_time)
+                    .push_bind(ingested_at)
                     .push_bind(producer)
                     .push_bind(event_type)
                     .push_bind(&event.network)
@@ -389,7 +594,7 @@ impl PgTransactionEventSink {
             },
         );
 
-        query_builder.push(" ON CONFLICT (event_id) DO NOTHING RETURNING event_id");
+        query_builder.push(" ON CONFLICT DO NOTHING RETURNING event_id");
 
         let rows: Vec<(String,)> = query_builder
             .build_query_as()
@@ -408,7 +613,7 @@ impl PgTransactionEventSink {
     ) -> Result<Vec<TransactionEventRecord>> {
         let limit = normalize_limit(limit);
         let rows = sqlx::query(
-            "SELECT event_id, schema_version, event_time, ingested_at, producer, event_type, \
+            "SELECT event_id, retention_class, schema_version, event_time, ingested_at, producer, event_type, \
              network, tx_hash, block_hash, block_number, payload_id, request_id, data \
              FROM transaction_events \
              WHERE tx_hash = $1 \
@@ -431,7 +636,7 @@ impl PgTransactionEventSink {
         let block_number = i64::try_from(block_number)?;
         let limit = normalize_limit(limit);
         let rows = sqlx::query(
-            "SELECT event_id, schema_version, event_time, ingested_at, producer, event_type, \
+            "SELECT event_id, retention_class, schema_version, event_time, ingested_at, producer, event_type, \
              network, tx_hash, block_hash, block_number, payload_id, request_id, data \
              FROM transaction_events \
              WHERE block_number = $1 \
@@ -453,7 +658,7 @@ impl PgTransactionEventSink {
     ) -> Result<Vec<TransactionEventRecord>> {
         let limit = normalize_limit(limit);
         let rows = sqlx::query(
-            "SELECT event_id, schema_version, event_time, ingested_at, producer, event_type, \
+            "SELECT event_id, retention_class, schema_version, event_time, ingested_at, producer, event_type, \
              network, tx_hash, block_hash, block_number, payload_id, request_id, data \
              FROM transaction_events \
              WHERE block_hash = $1 \
@@ -476,12 +681,12 @@ impl PgTransactionEventSink {
         let limit = normalize_limit(limit);
         let rows = sqlx::query(
             "WITH bundle_events AS ( \
-                SELECT event_id, schema_version, event_time, ingested_at, producer, event_type, \
+                SELECT event_id, retention_class, schema_version, event_time, ingested_at, producer, event_type, \
                 network, tx_hash, block_hash, block_number, payload_id, request_id, data \
                 FROM transaction_events \
                 WHERE data ? 'bundle_hash' AND data->>'bundle_hash' = $1 \
                 UNION ALL \
-                SELECT event_id, schema_version, event_time, ingested_at, producer, event_type, \
+                SELECT event_id, retention_class, schema_version, event_time, ingested_at, producer, event_type, \
                 network, tx_hash, block_hash, block_number, payload_id, request_id, data \
                 FROM transaction_events \
                 WHERE data ? 'bundle_id' AND data->>'bundle_id' = $1 \
@@ -489,7 +694,7 @@ impl PgTransactionEventSink {
                 SELECT DISTINCT ON (event_id) * FROM bundle_events \
                 ORDER BY event_id, event_time ASC, ingested_at ASC \
              ) \
-             SELECT event_id, schema_version, event_time, ingested_at, producer, event_type, \
+             SELECT event_id, retention_class, schema_version, event_time, ingested_at, producer, event_type, \
              network, tx_hash, block_hash, block_number, payload_id, request_id, data \
              FROM deduped \
              ORDER BY event_time ASC, ingested_at ASC, event_id ASC \
@@ -512,7 +717,7 @@ impl PgTransactionEventSink {
         let to_block = query.to_block.map(i64::try_from).transpose()?;
 
         let rows = sqlx::query(
-            "SELECT event_id, schema_version, event_time, ingested_at, producer, event_type, \
+            "SELECT event_id, retention_class, schema_version, event_time, ingested_at, producer, event_type, \
              network, tx_hash, block_hash, block_number, payload_id, request_id, data \
              FROM transaction_events \
              WHERE event_type IN ('SIMULATION_FAILED', 'BUILDER_REJECTED') \
@@ -566,7 +771,11 @@ fn record_from_row(row: sqlx::postgres::PgRow) -> Result<TransactionEventRecord>
             .cloned()
             .ok_or_else(|| anyhow::anyhow!("transaction event data column is not a JSON object"))?,
     };
-    Ok(TransactionEventRecord { event, ingested_at: row.try_get("ingested_at")? })
+    Ok(TransactionEventRecord {
+        event,
+        retention_class: parse_transaction_event_retention_class(row.try_get("retention_class")?)?,
+        ingested_at: row.try_get("ingested_at")?,
+    })
 }
 
 fn parse_transaction_event_producer(producer: String) -> Result<TransactionEventProducer> {
@@ -577,6 +786,13 @@ fn parse_transaction_event_producer(producer: String) -> Result<TransactionEvent
 fn parse_transaction_event_type(event_type: String) -> Result<TransactionEventType> {
     let deserializer: StringDeserializer<SerdeValueError> = event_type.into_deserializer();
     Ok(TransactionEventType::deserialize(deserializer)?)
+}
+
+fn parse_transaction_event_retention_class(
+    retention_class: String,
+) -> Result<TransactionEventRetentionClass> {
+    let deserializer: StringDeserializer<SerdeValueError> = retention_class.into_deserializer();
+    Ok(TransactionEventRetentionClass::deserialize(deserializer)?)
 }
 
 fn metric_len_u64(len: usize) -> u64 {
@@ -1000,6 +1216,34 @@ mod tests {
     fn raw_event(value: Value) -> RawTransactionEvent {
         let byte_len = serde_json::to_string(&value).unwrap().len();
         RawTransactionEvent { value, byte_len }
+    }
+
+    #[test]
+    fn classifies_transaction_event_retention() {
+        assert_eq!(
+            TransactionEventRetentionClass::for_event_type(
+                TransactionEventType::ProxyBackendSuccess
+            ),
+            TransactionEventRetentionClass::Hot
+        );
+        assert_eq!(
+            TransactionEventRetentionClass::for_event_type(TransactionEventType::IngressReceived),
+            TransactionEventRetentionClass::Warm
+        );
+        assert_eq!(
+            TransactionEventRetentionClass::for_event_type(TransactionEventType::SimulationFailed),
+            TransactionEventRetentionClass::Cold
+        );
+        assert_eq!(
+            TransactionEventRetentionClass::for_event_type(TransactionEventType::BuilderRejected),
+            TransactionEventRetentionClass::Hot
+        );
+        assert_eq!(
+            TransactionEventRetentionClass::for_event_type(
+                TransactionEventType::BuilderPayloadFinalized
+            ),
+            TransactionEventRetentionClass::Cold
+        );
     }
 
     #[tokio::test]

--- a/crates/infra/audit/tests/postgres_transaction_events.rs
+++ b/crates/infra/audit/tests/postgres_transaction_events.rs
@@ -61,6 +61,9 @@ fn event(event_id: &str) -> TransactionEvent {
 }
 
 async fn cleanup(pool: &PgPool, event_id: &str) {
+    let _ = pool
+        .execute(sqlx::query("DELETE FROM transaction_events WHERE event_id = $1").bind(event_id))
+        .await;
     for table_name in
         ["transaction_events_hot", "transaction_events_warm", "transaction_events_cold"]
     {
@@ -265,6 +268,73 @@ async fn postgres_sink_routes_events_to_class_specific_tables() -> anyhow::Resul
     .await?;
     assert_eq!(combined_count.0, 3);
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn postgres_reads_legacy_heap_and_miss_class_table_writes() -> anyhow::Result<()> {
+    let harness = PostgresHarness::new().await?;
+    PgTransactionEventSink::migrate(&harness.database_url).await?;
+    let sink = PgTransactionEventSink::connect(&harness.database_url, 1).await?;
+    let pool = PgPoolOptions::new().max_connections(1).connect(&harness.database_url).await?;
+
+    let legacy_event_id = unique_event_id();
+    let legacy = event(&legacy_event_id);
+    sqlx::query(
+        "INSERT INTO transaction_events \
+         (event_id, schema_version, event_time, ingested_at, producer, event_type, network, \
+          tx_hash, block_hash, block_number, payload_id, request_id, data) \
+         VALUES ($1, $2, $3, now(), $4, $5, $6, $7, $8, $9, $10, $11, $12)",
+    )
+    .bind(&legacy.event_id)
+    .bind(&legacy.schema_version)
+    .bind(legacy.event_time)
+    .bind(legacy.producer.to_string())
+    .bind(legacy.event_type.to_string())
+    .bind(&legacy.network)
+    .bind(legacy.tx_hash.map(|hash| hash.to_string()))
+    .bind(legacy.block_hash.map(|hash| hash.to_string()))
+    .bind(legacy.block_number.map(i64::try_from).transpose()?)
+    .bind(&legacy.payload_id)
+    .bind(&legacy.request_id)
+    .bind(serde_json::Value::Object(legacy.data.clone()))
+    .execute(&pool)
+    .await?;
+
+    let legacy_rows = sink
+        .events_by_transaction_hash(
+            "0x1111111111111111111111111111111111111111111111111111111111111111",
+            10,
+        )
+        .await?;
+    assert!(
+        legacy_rows.iter().any(|row| row.event.event_id == legacy_event_id),
+        "legacy heap rows must remain readable after migration 002"
+    );
+
+    let class_event_id = unique_event_id();
+    let class_event = event(&class_event_id);
+    sink.insert_events(std::slice::from_ref(&class_event)).await?;
+    let class_count: (i64,) =
+        sqlx::query_as("SELECT count(*) FROM transaction_events_hot WHERE event_id = $1")
+            .bind(&class_event_id)
+            .fetch_one(&pool)
+            .await?;
+    assert_eq!(class_count.0, 1);
+
+    let after_class_write = sink
+        .events_by_transaction_hash(
+            "0x1111111111111111111111111111111111111111111111111111111111111111",
+            50,
+        )
+        .await?;
+    assert!(
+        !after_class_write.iter().any(|row| row.event.event_id == class_event_id),
+        "class-table writes stay invisible on transaction_events until the later view cutover"
+    );
+
+    cleanup(&pool, &legacy_event_id).await;
+    cleanup(&pool, &class_event_id).await;
     Ok(())
 }
 

--- a/crates/infra/audit/tests/postgres_transaction_events.rs
+++ b/crates/infra/audit/tests/postgres_transaction_events.rs
@@ -339,6 +339,30 @@ async fn postgres_reads_legacy_heap_and_miss_class_table_writes() -> anyhow::Res
 }
 
 #[tokio::test]
+async fn postgres_sink_dedupes_same_day_event_id_retries() -> anyhow::Result<()> {
+    let harness = PostgresHarness::new().await?;
+    PgTransactionEventSink::migrate(&harness.database_url).await?;
+    let sink = PgTransactionEventSink::connect(&harness.database_url, 1).await?;
+    let event_id = unique_event_id();
+    let event = event(&event_id);
+
+    let first = sink.insert_events(std::slice::from_ref(&event)).await?;
+    assert!(first.inserted_event_ids.contains(&event_id));
+    let second = sink.insert_events(std::slice::from_ref(&event)).await?;
+    assert!(second.inserted_event_ids.is_empty());
+
+    let pool = PgPoolOptions::new().max_connections(1).connect(&harness.database_url).await?;
+    let count: (i64,) =
+        sqlx::query_as("SELECT count(*) FROM transaction_events_hot WHERE event_id = $1")
+            .bind(&event_id)
+            .fetch_one(&pool)
+            .await?;
+    assert_eq!(count.0, 1);
+    cleanup(&pool, &event_id).await;
+    Ok(())
+}
+
+#[tokio::test]
 async fn postgres_partition_maintenance_creates_and_drops_class_windows() -> anyhow::Result<()> {
     let harness = PostgresHarness::new().await?;
     PgTransactionEventSink::migrate(&harness.database_url).await?;

--- a/crates/infra/audit/tests/postgres_transaction_events.rs
+++ b/crates/infra/audit/tests/postgres_transaction_events.rs
@@ -168,9 +168,8 @@ async fn transaction_events_ready_after_required_migration() -> anyhow::Result<(
             'transaction_events_warm'::regclass, \
             'transaction_events_cold'::regclass \
           ) AND relkind = 'p'), \
-         to_regprocedure( \
-            'maintain_transaction_event_partitions(timestamptz,integer,integer,integer,integer)' \
-         ) IS NOT NULL",
+         to_regprocedure('create_transaction_event_partition(text,date)') IS NOT NULL \
+           AND to_regprocedure('drop_transaction_event_partition(text,date)') IS NOT NULL",
     )
     .fetch_one(&pool)
     .await?;
@@ -328,6 +327,26 @@ async fn postgres_partition_maintenance_creates_and_drops_class_windows() -> any
         assert!(!exists.0, "expired {class} partition was not dropped");
     }
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn postgres_partition_maintenance_skips_when_another_replica_holds_lock() -> anyhow::Result<()>
+{
+    let harness = PostgresHarness::new().await?;
+    PgTransactionEventSink::migrate(&harness.database_url).await?;
+    let sink = PgTransactionEventSink::connect(&harness.database_url, 1).await?;
+    let pool = PgPoolOptions::new().max_connections(1).connect(&harness.database_url).await?;
+    let mut transaction = pool.begin().await?;
+    let locked: bool = sqlx::query_scalar("SELECT pg_try_advisory_xact_lock(744697762131337711)")
+        .fetch_one(&mut *transaction)
+        .await?;
+    assert!(locked);
+
+    let outcomes = sink.maintain_partitions(TransactionEventRetentionConfig::default()).await?;
+    assert!(outcomes.is_empty());
+
+    transaction.rollback().await?;
     Ok(())
 }
 

--- a/crates/infra/audit/tests/postgres_transaction_events.rs
+++ b/crates/infra/audit/tests/postgres_transaction_events.rs
@@ -11,6 +11,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use audit_archiver_lib::{
     MAX_TRANSACTION_EVENT_INSERT_BATCH_SIZE, PgTransactionEventSink,
+    TransactionEventRetentionClass, TransactionEventRetentionConfig,
     TransactionEventSchemaReadinessError, TransactionEventSink,
 };
 use base_observability_events::TransactionEvent;
@@ -99,7 +100,7 @@ async fn transaction_events_unready_when_migration_version_is_missing() -> anyho
             required_version
         } if required_version == expected_version
     ));
-    assert!(err.to_string().contains("001_transaction_events.sql"));
+    assert!(err.to_string().contains("002_transaction_event_retention.sql"));
 
     Ok(())
 }
@@ -108,8 +109,8 @@ async fn transaction_events_unready_when_migration_version_is_missing() -> anyho
 fn transaction_events_migration_version_matches_sqlx_migration_metadata() -> anyhow::Result<()> {
     assert_eq!(
         PgTransactionEventSink::required_migration_version().map_err(anyhow::Error::msg)?,
-        1,
-        "001_transaction_events.sql should resolve to sqlx migration version 1"
+        2,
+        "002_transaction_event_retention.sql should resolve to sqlx migration version 2"
     );
     Ok(())
 }
@@ -124,6 +125,18 @@ async fn transaction_events_ready_after_required_migration() -> anyhow::Result<(
     sink.check_schema_ready().await?;
 
     let pool = PgPoolOptions::new().max_connections(1).connect(&harness.database_url).await?;
+    let schema: (String, bool) = sqlx::query_as(
+        "SELECT c.relkind::TEXT, \
+         to_regprocedure( \
+             'maintain_transaction_event_partitions(timestamptz,integer,integer,integer,integer)' \
+         ) IS NOT NULL \
+         FROM pg_class AS c \
+         WHERE c.oid = 'transaction_events'::regclass",
+    )
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(schema, ("p".to_string(), true));
+
     let applied: (bool,) =
         sqlx::query_as("SELECT success FROM _sqlx_migrations WHERE version = $1")
             .bind(PgTransactionEventSink::required_migration_version().map_err(anyhow::Error::msg)?)
@@ -155,6 +168,48 @@ async fn postgres_sink_chunks_large_direct_inserts() -> anyhow::Result<()> {
             .fetch_one(&pool)
             .await?;
     assert_eq!(count.0, i64::try_from(event_count)?);
+    let placement: (String, String) = sqlx::query_as(
+        "SELECT retention_class, tableoid::regclass::TEXT \
+         FROM transaction_events \
+         WHERE event_id = $1",
+    )
+    .bind(format!("{event_prefix}-0"))
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(placement.0, TransactionEventRetentionClass::Hot.to_string());
+    assert!(placement.1.starts_with("transaction_events_hot_"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn postgres_partition_maintenance_creates_and_drops_class_windows() -> anyhow::Result<()> {
+    let harness = PostgresHarness::new().await?;
+    PgTransactionEventSink::migrate(&harness.database_url).await?;
+    let sink = PgTransactionEventSink::connect(&harness.database_url, 1).await?;
+    let pool = PgPoolOptions::new().max_connections(1).connect(&harness.database_url).await?;
+
+    let outcomes = sink
+        .maintain_partitions(TransactionEventRetentionConfig {
+            premake_days: 2,
+            hot_days: 1,
+            warm_days: 2,
+            cold_days: 3,
+        })
+        .await?;
+    assert_eq!(outcomes.len(), 3);
+
+    let counts: Vec<(String, i64)> = sqlx::query_as(
+        "SELECT retention_class, count(*) \
+         FROM transaction_event_partition_registry \
+         GROUP BY retention_class \
+         ORDER BY retention_class",
+    )
+    .fetch_all(&pool)
+    .await?;
+    assert!(counts.iter().any(|(class, count)| class == "hot" && *count >= 3));
+    assert!(counts.iter().any(|(class, count)| class == "warm" && *count >= 3));
+    assert!(counts.iter().any(|(class, count)| class == "cold" && *count >= 3));
 
     Ok(())
 }

--- a/crates/infra/audit/tests/postgres_transaction_events.rs
+++ b/crates/infra/audit/tests/postgres_transaction_events.rs
@@ -14,7 +14,7 @@ use audit_archiver_lib::{
     TransactionEventRetentionClass, TransactionEventRetentionConfig,
     TransactionEventSchemaReadinessError, TransactionEventSink,
 };
-use base_observability_events::TransactionEvent;
+use base_observability_events::{TransactionEvent, TransactionEventType};
 use chrono::Utc;
 use serde_json::json;
 use sqlx::{Executor, PgPool, postgres::PgPoolOptions};
@@ -61,9 +61,12 @@ fn event(event_id: &str) -> TransactionEvent {
 }
 
 async fn cleanup(pool: &PgPool, event_id: &str) {
-    let _ = pool
-        .execute(sqlx::query("DELETE FROM transaction_events WHERE event_id = $1").bind(event_id))
-        .await;
+    for table_name in
+        ["transaction_events_hot", "transaction_events_warm", "transaction_events_cold"]
+    {
+        let statement = format!("DELETE FROM {table_name} WHERE event_id = $1");
+        let _ = pool.execute(sqlx::query(&statement).bind(event_id)).await;
+    }
 }
 
 #[tokio::test]
@@ -116,6 +119,36 @@ fn transaction_events_migration_version_matches_sqlx_migration_metadata() -> any
 }
 
 #[tokio::test]
+async fn retention_migration_preserves_legacy_transaction_events() -> anyhow::Result<()> {
+    let harness = PostgresHarness::new().await?;
+    let pool = PgPoolOptions::new().max_connections(1).connect(&harness.database_url).await?;
+    let event_id = unique_event_id();
+
+    sqlx::raw_sql(include_str!("../migrations/001_transaction_events.sql")).execute(&pool).await?;
+    sqlx::query(
+        "INSERT INTO transaction_events \
+         (event_id, schema_version, event_time, producer, event_type, data) \
+         VALUES ($1, 'transaction-event/v1', now(), 'base-builder', 'BUILDER_ACCEPTED', '{}')",
+    )
+    .bind(&event_id)
+    .execute(&pool)
+    .await?;
+
+    sqlx::raw_sql(include_str!("../migrations/002_transaction_event_retention.sql"))
+        .execute(&pool)
+        .await?;
+
+    let count: (i64,) =
+        sqlx::query_as("SELECT count(*) FROM transaction_events WHERE event_id = $1")
+            .bind(event_id)
+            .fetch_one(&pool)
+            .await?;
+    assert_eq!(count.0, 1);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn transaction_events_ready_after_required_migration() -> anyhow::Result<()> {
     let harness = PostgresHarness::new().await?;
 
@@ -125,17 +158,23 @@ async fn transaction_events_ready_after_required_migration() -> anyhow::Result<(
     sink.check_schema_ready().await?;
 
     let pool = PgPoolOptions::new().max_connections(1).connect(&harness.database_url).await?;
-    let schema: (String, bool) = sqlx::query_as(
-        "SELECT c.relkind::TEXT, \
+    let schema: (String, i64, bool) = sqlx::query_as(
+        "SELECT \
+         (SELECT relkind::TEXT FROM pg_class \
+          WHERE oid = 'transaction_events'::regclass), \
+         (SELECT count(*) FROM pg_class \
+          WHERE oid IN ( \
+            'transaction_events_hot'::regclass, \
+            'transaction_events_warm'::regclass, \
+            'transaction_events_cold'::regclass \
+          ) AND relkind = 'p'), \
          to_regprocedure( \
-             'maintain_transaction_event_partitions(timestamptz,integer,integer,integer,integer)' \
-         ) IS NOT NULL \
-         FROM pg_class AS c \
-         WHERE c.oid = 'transaction_events'::regclass",
+            'maintain_transaction_event_partitions(timestamptz,integer,integer,integer,integer)' \
+         ) IS NOT NULL",
     )
     .fetch_one(&pool)
     .await?;
-    assert_eq!(schema, ("p".to_string(), true));
+    assert_eq!(schema, ("r".to_string(), 3, true));
 
     let applied: (bool,) =
         sqlx::query_as("SELECT success FROM _sqlx_migrations WHERE version = $1")
@@ -163,14 +202,14 @@ async fn postgres_sink_chunks_large_direct_inserts() -> anyhow::Result<()> {
     assert_eq!(outcome.inserted_event_ids.len(), event_count);
     let pool = PgPoolOptions::new().max_connections(1).connect(&harness.database_url).await?;
     let count: (i64,) =
-        sqlx::query_as("SELECT COUNT(*) FROM transaction_events WHERE event_id LIKE $1")
+        sqlx::query_as("SELECT COUNT(*) FROM transaction_events_hot WHERE event_id LIKE $1")
             .bind(format!("{event_prefix}-%"))
             .fetch_one(&pool)
             .await?;
     assert_eq!(count.0, i64::try_from(event_count)?);
     let placement: (String, String) = sqlx::query_as(
         "SELECT retention_class, tableoid::regclass::TEXT \
-         FROM transaction_events \
+         FROM transaction_events_hot \
          WHERE event_id = $1",
     )
     .bind(format!("{event_prefix}-0"))
@@ -183,11 +222,67 @@ async fn postgres_sink_chunks_large_direct_inserts() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn postgres_sink_routes_events_to_class_specific_tables() -> anyhow::Result<()> {
+    let harness = PostgresHarness::new().await?;
+    PgTransactionEventSink::migrate(&harness.database_url).await?;
+    let sink = PgTransactionEventSink::connect(&harness.database_url, 1).await?;
+    let event_prefix = unique_event_id();
+
+    let mut hot = event(&format!("{event_prefix}-hot"));
+    hot.event_type = TransactionEventType::BuilderAccepted;
+    let mut warm = event(&format!("{event_prefix}-warm"));
+    warm.event_type = TransactionEventType::IngressReceived;
+    let mut cold = event(&format!("{event_prefix}-cold"));
+    cold.event_type = TransactionEventType::SimulationFailed;
+
+    let outcome = sink.insert_events(&[hot, warm, cold]).await?;
+    assert_eq!(outcome.inserted_event_ids.len(), 3);
+
+    let pool = PgPoolOptions::new().max_connections(1).connect(&harness.database_url).await?;
+    for (class, table_name) in [
+        ("hot", "transaction_events_hot"),
+        ("warm", "transaction_events_warm"),
+        ("cold", "transaction_events_cold"),
+    ] {
+        let statement = format!(
+            "SELECT count(*) FROM {table_name} WHERE event_id = $1 AND retention_class = $2"
+        );
+        let count: (i64,) = sqlx::query_as(&statement)
+            .bind(format!("{event_prefix}-{class}"))
+            .bind(class)
+            .fetch_one(&pool)
+            .await?;
+        assert_eq!(count.0, 1, "{class} event was not routed to {table_name}");
+    }
+
+    let combined_count: (i64,) = sqlx::query_as(
+        "SELECT \
+            (SELECT count(*) FROM transaction_events_hot WHERE event_id LIKE $1) + \
+            (SELECT count(*) FROM transaction_events_warm WHERE event_id LIKE $1) + \
+            (SELECT count(*) FROM transaction_events_cold WHERE event_id LIKE $1)",
+    )
+    .bind(format!("{event_prefix}-%"))
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(combined_count.0, 3);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn postgres_partition_maintenance_creates_and_drops_class_windows() -> anyhow::Result<()> {
     let harness = PostgresHarness::new().await?;
     PgTransactionEventSink::migrate(&harness.database_url).await?;
     let sink = PgTransactionEventSink::connect(&harness.database_url, 1).await?;
     let pool = PgPoolOptions::new().max_connections(1).connect(&harness.database_url).await?;
+    let expired_day = Utc::now().date_naive() - chrono::Duration::days(10);
+    for class in ["hot", "warm", "cold"] {
+        sqlx::query("SELECT create_transaction_event_partition($1, $2)")
+            .bind(class)
+            .bind(expired_day)
+            .execute(&pool)
+            .await?;
+    }
 
     let outcomes = sink
         .maintain_partitions(TransactionEventRetentionConfig {
@@ -200,16 +295,31 @@ async fn postgres_partition_maintenance_creates_and_drops_class_windows() -> any
     assert_eq!(outcomes.len(), 3);
 
     let counts: Vec<(String, i64)> = sqlx::query_as(
-        "SELECT retention_class, count(*) \
-         FROM transaction_event_partition_registry \
-         GROUP BY retention_class \
-         ORDER BY retention_class",
+        "SELECT replace(parent.relname, 'transaction_events_', ''), count(*) \
+         FROM pg_inherits AS inheritance \
+         JOIN pg_class AS parent ON parent.oid = inheritance.inhparent \
+         WHERE parent.relname IN ( \
+            'transaction_events_hot', \
+            'transaction_events_warm', \
+            'transaction_events_cold' \
+         ) \
+         GROUP BY parent.relname \
+         ORDER BY parent.relname",
     )
     .fetch_all(&pool)
     .await?;
     assert!(counts.iter().any(|(class, count)| class == "hot" && *count >= 3));
     assert!(counts.iter().any(|(class, count)| class == "warm" && *count >= 3));
     assert!(counts.iter().any(|(class, count)| class == "cold" && *count >= 3));
+    for class in ["hot", "warm", "cold"] {
+        let expired_partition =
+            format!("transaction_events_{class}_{}", expired_day.format("%Y%m%d"));
+        let exists: (bool,) = sqlx::query_as("SELECT to_regclass($1) IS NOT NULL")
+            .bind(expired_partition)
+            .fetch_one(&pool)
+            .await?;
+        assert!(!exists.0, "expired {class} partition was not dropped");
+    }
 
     Ok(())
 }
@@ -233,7 +343,7 @@ async fn postgres_sink_persists_and_dedupes_by_event_id() {
     assert!(second.inserted_event_ids.is_empty());
 
     let count: (i64,) =
-        sqlx::query_as("SELECT COUNT(*) FROM transaction_events WHERE event_id = $1")
+        sqlx::query_as("SELECT COUNT(*) FROM transaction_events_hot WHERE event_id = $1")
             .bind(&event_id)
             .fetch_one(&pool)
             .await

--- a/crates/infra/audit/tests/postgres_transaction_events.rs
+++ b/crates/infra/audit/tests/postgres_transaction_events.rs
@@ -311,6 +311,13 @@ async fn postgres_partition_maintenance_creates_and_drops_class_windows() -> any
     assert!(counts.iter().any(|(class, count)| class == "hot" && *count >= 3));
     assert!(counts.iter().any(|(class, count)| class == "warm" && *count >= 3));
     assert!(counts.iter().any(|(class, count)| class == "cold" && *count >= 3));
+    for outcome in &outcomes {
+        assert!(
+            outcome.partitions_ahead_days.unwrap_or(-1) >= 2,
+            "expected at least two premade future days, got {:?}",
+            outcome.partitions_ahead_days
+        );
+    }
     for class in ["hot", "warm", "cold"] {
         let expired_partition =
             format!("transaction_events_{class}_{}", expired_day.format("%Y%m%d"));

--- a/docs/transaction-events/README.md
+++ b/docs/transaction-events/README.md
@@ -33,6 +33,8 @@ UTC `ingested_at` day. Audit-archiver routes inserts to the matching table and
 continues to read from `transaction_events`. Migration 002 leaves the legacy
 heap untouched, so queries will not see newly written partitioned rows until a
 later migration replaces that heap with a union view of the same name.
+`retention_class` is a write-routing column on the class tables only; read APIs
+do not return it.
 
 An app-owned maintenance worker creates upcoming partitions and drops expired
 ones with `DROP TABLE` rather than row `DELETE`. The migration exposes only

--- a/docs/transaction-events/README.md
+++ b/docs/transaction-events/README.md
@@ -37,8 +37,11 @@ UTC `ingested_at` day. Audit-archiver routes inserts to the matching table and
 continues to read from `transaction_events`. Migration 002 leaves the legacy
 heap untouched, so queries will not see newly written partitioned rows until a
 later migration replaces that heap with a union view of the same name. An
-app-owned maintenance worker creates upcoming partitions and drops expired ones
-with `DROP TABLE` rather than row `DELETE`. The worker emits
+app-owned maintenance worker handles retention policy, partition discovery,
+locking, and metrics, and drops expired partitions with `DROP TABLE` rather
+than row `DELETE`. The migration retains only narrowly scoped
+`SECURITY DEFINER` create/drop functions because Postgres requires table
+ownership for partition DDL. The worker emits
 `tips_audit_transaction_event_partitions_ahead_days` per class and
 `tips_audit_transaction_event_partition_maintenance_last_success_age_seconds`
 after each successful locked maintenance pass; page when ahead days fall below

--- a/docs/transaction-events/README.md
+++ b/docs/transaction-events/README.md
@@ -31,10 +31,14 @@ ingress families can still exceed the current 5 Ti RDS ceiling. Treat the
 windows as tunable and re-check hot/warm GiB/day before locking mainnet
 producer enablement.
 
-The table is list-partitioned by `retention_class` and range-partitioned by UTC
-`ingested_at` day. An app-owned maintenance worker creates upcoming partitions
-and drops expired ones with `DROP TABLE` rather than row `DELETE`. Configure the
-windows with:
+Each retention class has an independent table (`transaction_events_hot`,
+`transaction_events_warm`, or `transaction_events_cold`) range-partitioned by
+UTC `ingested_at` day. Audit-archiver routes inserts to the matching table and
+continues to read from `transaction_events`. Migration 002 leaves the legacy
+heap untouched, so queries will not see newly written partitioned rows until a
+later migration replaces that heap with a union view of the same name. An
+app-owned maintenance worker creates upcoming partitions and drops expired ones
+with `DROP TABLE` rather than row `DELETE`. Configure the windows with:
 
 - `TIPS_AUDIT_TRANSACTION_EVENT_HOT_RETENTION_DAYS`
 - `TIPS_AUDIT_TRANSACTION_EVENT_WARM_RETENTION_DAYS`

--- a/docs/transaction-events/README.md
+++ b/docs/transaction-events/README.md
@@ -15,7 +15,7 @@ one event JSON object per line, not a wrapped JSON batch.
 not the long-term archive. At ingest, the archiver assigns a `retention_class`
 from a fixed event-type map:
 
-| Class | Keep | Families |
+| Class | Default keep | Families |
 | --- | --- | --- |
 | `hot` | 7 days | Proxy success-path hops; `BUILDER_CONSIDERED`, `BUILDER_ACCEPTED`, `BUILDER_REJECTED` |
 | `warm` | 30 days | Default for remaining arrival, simulation, and forwarding events |
@@ -23,36 +23,22 @@ from a fixed event-type map:
 
 Unknown or newly added event types default to `warm`. Prefer changing the map
 deliberately when a new type is high-churn (`hot`) or high-value (`cold`).
-
-At the measured mainnet send rates (ingress sendRaw ≈ 696/s, builder decisions ≈
-272/s, proxyd ≈ 6 events/send), a tiered 7/30/90 policy is roughly an order of
-magnitude smaller than a uniform 90-day TTL, but full enablement of proxy and
-ingress families can still exceed the current 5 Ti RDS ceiling. Treat the
-windows as tunable and re-check hot/warm GiB/day before locking mainnet
-producer enablement.
+Retention windows and create-ahead distance are configurable on
+`audit-archiver`; treat the defaults as a starting point and size storage from
+observed ingest volume before enabling high-churn producers.
 
 Each retention class has an independent table (`transaction_events_hot`,
 `transaction_events_warm`, or `transaction_events_cold`) range-partitioned by
 UTC `ingested_at` day. Audit-archiver routes inserts to the matching table and
 continues to read from `transaction_events`. Migration 002 leaves the legacy
 heap untouched, so queries will not see newly written partitioned rows until a
-later migration replaces that heap with a union view of the same name. An
-app-owned maintenance worker handles retention policy, partition discovery,
-locking, and metrics, and drops expired partitions with `DROP TABLE` rather
-than row `DELETE`. The migration retains only narrowly scoped
-`SECURITY DEFINER` create/drop functions because Postgres requires table
-ownership for partition DDL. The worker emits
-`tips_audit_transaction_event_partitions_ahead_days` per class and
-`tips_audit_transaction_event_partition_maintenance_last_success_age_seconds`
-after each successful locked maintenance pass; page when ahead days fall below
-about two or when last success age exceeds roughly two retention intervals.
-Configure the windows with:
+later migration replaces that heap with a union view of the same name.
 
-- `TIPS_AUDIT_TRANSACTION_EVENT_HOT_RETENTION_DAYS`
-- `TIPS_AUDIT_TRANSACTION_EVENT_WARM_RETENTION_DAYS`
-- `TIPS_AUDIT_TRANSACTION_EVENT_COLD_RETENTION_DAYS`
-- `TIPS_AUDIT_TRANSACTION_EVENT_PARTITION_PREMAKE_DAYS`
-- `TIPS_AUDIT_TRANSACTION_EVENT_RETENTION_INTERVAL_SECS`
+An app-owned maintenance worker creates upcoming partitions and drops expired
+ones with `DROP TABLE` rather than row `DELETE`. The migration exposes only
+narrowly scoped `SECURITY DEFINER` create/drop helpers because Postgres
+requires table ownership for partition DDL; policy, locking, discovery, and
+maintenance metrics live in the application.
 
 ## Configuration Fields
 

--- a/docs/transaction-events/README.md
+++ b/docs/transaction-events/README.md
@@ -153,8 +153,12 @@ just devnet tx-observability-smoke
 
 The smoke test sends one transaction through ingress, waits for Vector to ship
 JSONL events from ingress, proxyd, txpool tracing, and builder producers, and
-verifies `audit-archiver` can read the persisted events back from Postgres by
-transaction hash.
+checks that producers and the collection path are healthy. Until a later
+migration replaces the legacy `transaction_events` heap with a union view of the
+class tables, `audit-archiver` writes to `transaction_events_{hot,warm,cold}`
+while read APIs still query the heap, so the smoke test does **not** verify
+Postgres readback of newly ingested rows. Confirm ingest with class-table row
+counts or the `tips_audit_transaction_events_persisted` metric instead.
 
 For local Vector health, alert or inspect `component_discarded_events_total`.
 `parse_transaction_events` drops malformed JSONL lines, and
@@ -281,8 +285,14 @@ Recommended components:
 - attempt index when applicable
 
 If a source cannot produce an exactly deterministic ID, document why in the
-producer implementation and include enough fields in `data` for
-`audit-archiver` to enforce database-side uniqueness.
+producer implementation and include enough fields in `data` for operators to
+reconcile duplicates offline.
+
+`audit-archiver` enforces uniqueness with a leaf-local `UNIQUE (event_id)` index
+on each UTC daily partition of a retention-class table. Same-day retries of the
+same `event_id` into the same class are deduped; a retry that lands on a later
+UTC day (or into a different retention class after a map change) can insert
+again. Do not rely on a global, forever-unique primary key.
 
 ## proxyd Examples
 

--- a/docs/transaction-events/README.md
+++ b/docs/transaction-events/README.md
@@ -9,6 +9,39 @@ Vector tails these same JSONL files and ships newline-delimited event records to
 `audit-archiver`. The audit HTTP ingest endpoint is collector-facing and expects
 one event JSON object per line, not a wrapped JSON batch.
 
+## Postgres Retention
+
+`audit-archiver` stores events in Postgres for operational queries. Postgres is
+not the long-term archive. At ingest, the archiver assigns a `retention_class`
+from a fixed event-type map:
+
+| Class | Keep | Families |
+| --- | --- | --- |
+| `hot` | 7 days | Proxy success-path hops; `BUILDER_CONSIDERED`, `BUILDER_ACCEPTED`, `BUILDER_REJECTED` |
+| `warm` | 30 days | Default for remaining arrival, simulation, and forwarding events |
+| `cold` | 90 days | Inclusion, finalization, flashblock lifecycle, rejection, and drop events |
+
+Unknown or newly added event types default to `warm`. Prefer changing the map
+deliberately when a new type is high-churn (`hot`) or high-value (`cold`).
+
+At the measured mainnet send rates (ingress sendRaw ≈ 696/s, builder decisions ≈
+272/s, proxyd ≈ 6 events/send), a tiered 7/30/90 policy is roughly an order of
+magnitude smaller than a uniform 90-day TTL, but full enablement of proxy and
+ingress families can still exceed the current 5 Ti RDS ceiling. Treat the
+windows as tunable and re-check hot/warm GiB/day before locking mainnet
+producer enablement.
+
+The table is list-partitioned by `retention_class` and range-partitioned by UTC
+`ingested_at` day. An app-owned maintenance worker creates upcoming partitions
+and drops expired ones with `DROP TABLE` rather than row `DELETE`. Configure the
+windows with:
+
+- `TIPS_AUDIT_TRANSACTION_EVENT_HOT_RETENTION_DAYS`
+- `TIPS_AUDIT_TRANSACTION_EVENT_WARM_RETENTION_DAYS`
+- `TIPS_AUDIT_TRANSACTION_EVENT_COLD_RETENTION_DAYS`
+- `TIPS_AUDIT_TRANSACTION_EVENT_PARTITION_PREMAKE_DAYS`
+- `TIPS_AUDIT_TRANSACTION_EVENT_RETENTION_INTERVAL_SECS`
+
 ## Configuration Fields
 
 Rust producers should expose these config fields directly or with a

--- a/docs/transaction-events/README.md
+++ b/docs/transaction-events/README.md
@@ -38,7 +38,12 @@ continues to read from `transaction_events`. Migration 002 leaves the legacy
 heap untouched, so queries will not see newly written partitioned rows until a
 later migration replaces that heap with a union view of the same name. An
 app-owned maintenance worker creates upcoming partitions and drops expired ones
-with `DROP TABLE` rather than row `DELETE`. Configure the windows with:
+with `DROP TABLE` rather than row `DELETE`. The worker emits
+`tips_audit_transaction_event_partitions_ahead_days` per class and
+`tips_audit_transaction_event_partition_maintenance_last_success_age_seconds`
+after each successful locked maintenance pass; page when ahead days fall below
+about two or when last success age exceeds roughly two retention intervals.
+Configure the windows with:
 
 - `TIPS_AUDIT_TRANSACTION_EVENT_HOT_RETENTION_DAYS`
 - `TIPS_AUDIT_TRANSACTION_EVENT_WARM_RETENTION_DAYS`


### PR DESCRIPTION
## Summary
- Adds migration `002` with three independent `RANGE(ingested_at)` tables (`transaction_events_hot|warm|cold`), leaving the legacy `transaction_events` heap intact for a later view cutover.
- Classifies events at ingest and writes into the matching class table; reads continue from `transaction_events` and do not select `retention_class` (write-routing only).
- Runs an app-owned partition maintenance worker that owns retention policy, locking, discovery, and freshness metrics, calling only narrowly scoped `SECURITY DEFINER` create/drop helpers for ownership-gated DDL.
- Dual-store window is intentional: class-table writes stay invisible on heap reads until a later union-view migration. Smoke docs and event-id guidance match day-local leaf uniqueness.
- Documents the public retention mechanism in `docs/transaction-events`; Coinbase capacity math and paging thresholds live in the private tips rollout docs.

## Test plan
- [x] `cargo test -p audit-archiver-lib --lib`
- [x] `cargo clippy -p audit-archiver-lib --all-targets -- -D warnings`
- [x] `cargo test -p audit-archiver-lib --test postgres_transaction_events` (legacy-heap read, class-write invisibility, same-day dedupe)
- [ ] Deploy migrator on zeronet with producers paused; verify class parents are partitioned and legacy heap remains
- [ ] Bring up new audit image only after 002 succeeds; confirm readiness and freshness gauges
- [ ] Re-enable producers and verify ingest into class tables; accept query gap until view cutover