### PR TITLE
feat(txpool): Add Pluggable Sidecar Pool Seam

### DIFF
--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -28,7 +28,7 @@ use base_execution_rpc::{
 };
 use base_execution_txpool::{
     BaseOrdering, BasePooledTransaction, BasePooledTx, BaseTransactionPool,
-    BaseTransactionValidator, GuardLimits, TimestampedTransaction,
+    BaseTransactionValidator, GuardLimits, SidecarPool, TimestampedTransaction,
     maintain_state_diff_invalidation,
 };
 use reth_chain_state::CanonStateSubscriptions;
@@ -879,6 +879,8 @@ pub struct BasePoolBuilder<T = BasePooledTransaction> {
     pub guard_limits: GuardLimits,
     /// Additional trusted EIP-7702 delegation targets for locked payers.
     pub additional_trusted_delegation_targets: AddressSet,
+    /// Out-of-tree sidecar sub-pools to register on the constructed pool.
+    pub sidecar_pools: Vec<Arc<dyn SidecarPool<T>>>,
     /// Marker for the pooled transaction type.
     _pd: core::marker::PhantomData<T>,
 }
@@ -891,6 +893,7 @@ impl<T> Default for BasePoolBuilder<T> {
             max_inflight_delegated_slots: 4,
             guard_limits: GuardLimits::default(),
             additional_trusted_delegation_targets: AddressSet::default(),
+            sidecar_pools: Vec::new(),
             _pd: Default::default(),
         }
     }
@@ -906,6 +909,7 @@ impl<T> Clone for BasePoolBuilder<T> {
             additional_trusted_delegation_targets: self
                 .additional_trusted_delegation_targets
                 .clone(),
+            sidecar_pools: self.sidecar_pools.clone(),
             _pd: core::marker::PhantomData,
         }
     }
@@ -947,6 +951,13 @@ impl<T> BasePoolBuilder<T> {
         self.additional_trusted_delegation_targets = targets.into_iter().collect();
         self
     }
+
+    /// Registers out-of-tree sidecar sub-pools on the pool this builder constructs.
+    #[must_use]
+    pub fn with_sidecar_pools(mut self, pools: Vec<Arc<dyn SidecarPool<T>>>) -> Self {
+        self.sidecar_pools = pools;
+        self
+    }
 }
 
 impl<Node, T, Evm> PoolBuilder<Node, Evm> for BasePoolBuilder<T>
@@ -968,6 +979,7 @@ where
             max_inflight_delegated_slots,
             guard_limits,
             additional_trusted_delegation_targets,
+            sidecar_pools,
             ..
         } = self;
 
@@ -1005,8 +1017,9 @@ where
             blob_store,
             final_pool_config.clone(),
         );
-        let transaction_pool =
-            BaseTransactionPool::new(transaction_pool, ordering).with_guard_limits(guard_limits);
+        let transaction_pool = BaseTransactionPool::new(transaction_pool, ordering)
+            .with_guard_limits(guard_limits)
+            .with_sidecar_pools(sidecar_pools);
         spawn_maintenance_tasks(ctx, transaction_pool.clone(), &final_pool_config)?;
         let state_diff_events = BroadcastStream::new(ctx.provider().subscribe_to_canonical_state());
         ctx.task_executor().spawn_critical_task(

--- a/crates/execution/runner/src/extension.rs
+++ b/crates/execution/runner/src/extension.rs
@@ -1,6 +1,8 @@
 //! Traits describing node builder extensions.
 
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
+
+use base_execution_txpool::{BasePooledTransaction, SidecarPool};
 
 use crate::NodeHooks;
 
@@ -10,6 +12,15 @@ use crate::NodeHooks;
 pub trait BaseNodeExtension: Send + Sync + Debug {
     /// Applies the extension to the supplied hooks.
     fn apply(self: Box<Self>, hooks: NodeHooks) -> NodeHooks;
+
+    /// Sidecar sub-pools this extension contributes to the transaction pool.
+    ///
+    /// Called by the runner *before* components are built, and therefore before
+    /// [`apply`](Self::apply) consumes the boxed extension. Implementors must construct the pool
+    /// in their constructor and hand out `Arc` clones here.
+    fn sidecar_pools(&self) -> Vec<Arc<dyn SidecarPool<BasePooledTransaction>>> {
+        Vec::new()
+    }
 }
 
 /// An extension that can be built from a config.

--- a/crates/execution/runner/src/node.rs
+++ b/crates/execution/runner/src/node.rs
@@ -1,10 +1,12 @@
 //! Base Node types config.
 
+use std::sync::Arc;
+
 use base_common_consensus::BasePrimitives;
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_payload_builder::config::{BaseDAConfig, GasLimitConfig};
 use base_execution_rpc::eth::BaseEthApiBuilder;
-use base_execution_txpool::GuardLimits;
+use base_execution_txpool::{BasePooledTransaction, GuardLimits, SidecarPool};
 use base_node_core::{
     BaseConsensusBuilder, BaseEngineApiBuilder, BaseEngineTypes, BaseExecutorBuilder,
     BaseNetworkBuilder, BaseNodeComponentBuilder, BaseNodeTypes, BasePayloadValidatorBuilder,
@@ -43,6 +45,8 @@ pub struct BaseNode {
     /// Whether to drop positively stale EIP-8130 transactions using their
     /// captured authorization manifest before execution.
     pub manifest_precheck_enabled: bool,
+    /// Sidecar sub-pools contributed by extensions, installed on the transaction pool.
+    pub sidecar_pools: Vec<Arc<dyn SidecarPool<BasePooledTransaction>>>,
 }
 
 impl Default for BaseNode {
@@ -59,6 +63,7 @@ impl BaseNode {
             da_config: BaseDAConfig::default(),
             gas_limit_config: GasLimitConfig::default(),
             manifest_precheck_enabled: true,
+            sidecar_pools: Vec::new(),
         }
     }
 
@@ -77,6 +82,16 @@ impl BaseNode {
     /// Configure whether EIP-8130 authorization manifests are checked before execution.
     pub const fn with_manifest_precheck_enabled(mut self, enabled: bool) -> Self {
         self.manifest_precheck_enabled = enabled;
+        self
+    }
+
+    /// Registers sidecar sub-pools to install on the transaction pool.
+    #[must_use]
+    pub fn with_sidecar_pools(
+        mut self,
+        pools: Vec<Arc<dyn SidecarPool<BasePooledTransaction>>>,
+    ) -> Self {
+        self.sidecar_pools = pools;
         self
     }
 
@@ -105,7 +120,8 @@ impl BaseNode {
                     })
                     .with_additional_trusted_delegation_targets(
                         self.args.mempool_trusted_delegation_targets.iter().copied(),
-                    ),
+                    )
+                    .with_sidecar_pools(self.sidecar_pools.clone()),
             )
             .executor(BaseExecutorBuilder::default())
             .payload(BasicPayloadServiceBuilder::new(

--- a/crates/execution/runner/src/runner.rs
+++ b/crates/execution/runner/src/runner.rs
@@ -152,6 +152,11 @@ impl<SB: PayloadServiceBuilder> BaseNodeRunner<SB> {
             base_node = base_node.with_gas_limit_config(gas_limit_config);
         }
         base_node = base_node.with_manifest_precheck_enabled(manifest_precheck_enabled);
+        // Collect sidecar sub-pools by reference before the fold below consumes the boxed
+        // extensions, and before `build_components` constructs the pool builder.
+        let sidecar_pools =
+            extensions.iter().flat_map(|ext| ext.sidecar_pools()).collect::<Vec<_>>();
+        base_node = base_node.with_sidecar_pools(sidecar_pools);
         let components = service_builder.build_components(&base_node);
 
         let builder = builder
@@ -171,7 +176,129 @@ impl<SB: PayloadServiceBuilder> BaseNodeRunner<SB> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use base_execution_txpool::{
+        BasePooledTransaction, RemovalReason, SidecarInsert, SidecarPool,
+    };
+
     use super::*;
+
+    /// Stands in for an out-of-tree sidecar pool defined in another crate.
+    #[derive(Debug, Default)]
+    struct ProbePool;
+
+    impl SidecarPool<BasePooledTransaction> for ProbePool {
+        fn name(&self) -> &'static str {
+            "probe"
+        }
+        fn claims(&self, _transaction: &BasePooledTransaction) -> bool {
+            false
+        }
+        fn insert_validated(
+            &self,
+            _origin: reth_transaction_pool::TransactionOrigin,
+            _transaction: reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>,
+            _state_nonce: u64,
+        ) -> reth_transaction_pool::PoolResult<SidecarInsert<BasePooledTransaction>> {
+            unimplemented!()
+        }
+        fn best_transactions(
+            &self,
+            _base_fee: u64,
+        ) -> Box<
+            dyn reth_transaction_pool::BestTransactions<
+                    Item = Arc<
+                        reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>,
+                    >,
+                >,
+        > {
+            unimplemented!()
+        }
+        fn contains(&self, _hash: &alloy_primitives::TxHash) -> bool {
+            false
+        }
+        fn get(
+            &self,
+            _hash: &alloy_primitives::TxHash,
+        ) -> Option<Arc<reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>>>
+        {
+            None
+        }
+        fn all_transactions(
+            &self,
+        ) -> Vec<Arc<reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>>>
+        {
+            Vec::new()
+        }
+        fn pending_transactions(
+            &self,
+        ) -> Vec<Arc<reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>>>
+        {
+            Vec::new()
+        }
+        fn queued_transactions(
+            &self,
+        ) -> Vec<Arc<reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>>>
+        {
+            Vec::new()
+        }
+        fn pending_and_queued_txn_count(&self) -> (usize, usize) {
+            (0, 0)
+        }
+        fn all_hashes(&self) -> Vec<alloy_primitives::TxHash> {
+            Vec::new()
+        }
+        fn remove_transactions(
+            &self,
+            _hashes: &[alloy_primitives::TxHash],
+            _reason: RemovalReason,
+        ) -> Vec<Arc<reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>>>
+        {
+            Vec::new()
+        }
+        fn remove_transactions_by_sender(
+            &self,
+            _sender: alloy_primitives::Address,
+        ) -> Vec<Arc<reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>>>
+        {
+            Vec::new()
+        }
+    }
+
+    #[derive(Debug)]
+    struct ProbeExtension {
+        pool: Arc<ProbePool>,
+    }
+
+    impl BaseNodeExtension for ProbeExtension {
+        fn apply(self: Box<Self>, hooks: NodeHooks) -> NodeHooks {
+            hooks
+        }
+
+        fn sidecar_pools(&self) -> Vec<Arc<dyn SidecarPool<BasePooledTransaction>>> {
+            vec![self.pool.clone()]
+        }
+    }
+
+    #[test]
+    fn extensions_contribute_sidecar_pools_before_boxes_are_consumed() {
+        let extensions: Vec<Box<dyn BaseNodeExtension>> =
+            vec![Box::new(ProbeExtension { pool: Arc::new(ProbePool) })];
+
+        // exactly the lines added to `launch_node`
+        let sidecar_pools =
+            extensions.iter().flat_map(|ext| ext.sidecar_pools()).collect::<Vec<_>>();
+        let base_node =
+            BaseNode::new(RollupArgs::default()).with_sidecar_pools(sidecar_pools.clone());
+
+        assert_eq!(sidecar_pools.len(), 1);
+        assert_eq!(base_node.sidecar_pools.len(), 1);
+        assert_eq!(base_node.sidecar_pools[0].name(), "probe");
+
+        // the fold still consumes the same `extensions` afterwards
+        let _hooks = extensions.into_iter().fold(NodeHooks::new(), |hooks, ext| ext.apply(hooks));
+    }
 
     #[derive(Debug)]
     struct TestPayloadServiceBuilder;

--- a/crates/execution/runner/src/runner.rs
+++ b/crates/execution/runner/src/runner.rs
@@ -178,11 +178,17 @@ impl<SB: PayloadServiceBuilder> BaseNodeRunner<SB> {
 mod tests {
     use std::sync::Arc;
 
-    use base_execution_txpool::{BasePooledTransaction, RemovalReason, SidecarInsert, SidecarPool};
+    use base_execution_txpool::{
+        BasePooledTransaction, RemovalReason, SidecarAdmission, SidecarInsert, SidecarPool,
+    };
 
     use super::*;
 
     /// Stands in for an out-of-tree sidecar pool defined in another crate.
+    ///
+    /// Holds nothing: this test covers registration plumbing only. Behavioural coverage of the
+    /// seam lives in `base-execution-txpool`'s own tests, against a sidecar that actually stores
+    /// transactions.
     #[derive(Debug, Default)]
     struct ProbePool;
 
@@ -193,13 +199,11 @@ mod tests {
         fn claims(&self, _transaction: &BasePooledTransaction) -> bool {
             false
         }
-        fn insert_validated(
+        fn insert(
             &self,
-            _origin: reth_transaction_pool::TransactionOrigin,
-            _transaction: reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>,
-            _state_nonce: u64,
+            _admission: SidecarAdmission<BasePooledTransaction>,
         ) -> reth_transaction_pool::PoolResult<SidecarInsert<BasePooledTransaction>> {
-            unimplemented!()
+            unreachable!("claims() is always false, so nothing is ever routed here")
         }
         fn best_transactions(
             &self,
@@ -209,10 +213,7 @@ mod tests {
                     Item = Arc<reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>>,
                 >,
         > {
-            unimplemented!()
-        }
-        fn contains(&self, _hash: &alloy_primitives::TxHash) -> bool {
-            false
+            Box::new(std::iter::empty())
         }
         fn get(
             &self,
@@ -220,11 +221,6 @@ mod tests {
         ) -> Option<Arc<reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>>>
         {
             None
-        }
-        fn all_transactions(
-            &self,
-        ) -> Vec<Arc<reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>>> {
-            Vec::new()
         }
         fn pending_transactions(
             &self,
@@ -236,22 +232,10 @@ mod tests {
         ) -> Vec<Arc<reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>>> {
             Vec::new()
         }
-        fn pending_and_queued_txn_count(&self) -> (usize, usize) {
-            (0, 0)
-        }
-        fn all_hashes(&self) -> Vec<alloy_primitives::TxHash> {
-            Vec::new()
-        }
         fn remove_transactions(
             &self,
             _hashes: &[alloy_primitives::TxHash],
             _reason: RemovalReason,
-        ) -> Vec<Arc<reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>>> {
-            Vec::new()
-        }
-        fn remove_transactions_by_sender(
-            &self,
-            _sender: alloy_primitives::Address,
         ) -> Vec<Arc<reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>>> {
             Vec::new()
         }

--- a/crates/execution/runner/src/runner.rs
+++ b/crates/execution/runner/src/runner.rs
@@ -268,7 +268,7 @@ mod tests {
         }
 
         fn sidecar_pools(&self) -> Vec<Arc<dyn SidecarPool<BasePooledTransaction>>> {
-            vec![self.pool.clone()]
+            vec![Arc::clone(&self.pool) as Arc<dyn SidecarPool<BasePooledTransaction>>]
         }
     }
 

--- a/crates/execution/runner/src/runner.rs
+++ b/crates/execution/runner/src/runner.rs
@@ -178,9 +178,7 @@ impl<SB: PayloadServiceBuilder> BaseNodeRunner<SB> {
 mod tests {
     use std::sync::Arc;
 
-    use base_execution_txpool::{
-        BasePooledTransaction, RemovalReason, SidecarInsert, SidecarPool,
-    };
+    use base_execution_txpool::{BasePooledTransaction, RemovalReason, SidecarInsert, SidecarPool};
 
     use super::*;
 
@@ -208,9 +206,7 @@ mod tests {
             _base_fee: u64,
         ) -> Box<
             dyn reth_transaction_pool::BestTransactions<
-                    Item = Arc<
-                        reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>,
-                    >,
+                    Item = Arc<reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>>,
                 >,
         > {
             unimplemented!()
@@ -227,20 +223,17 @@ mod tests {
         }
         fn all_transactions(
             &self,
-        ) -> Vec<Arc<reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>>>
-        {
+        ) -> Vec<Arc<reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>>> {
             Vec::new()
         }
         fn pending_transactions(
             &self,
-        ) -> Vec<Arc<reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>>>
-        {
+        ) -> Vec<Arc<reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>>> {
             Vec::new()
         }
         fn queued_transactions(
             &self,
-        ) -> Vec<Arc<reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>>>
-        {
+        ) -> Vec<Arc<reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>>> {
             Vec::new()
         }
         fn pending_and_queued_txn_count(&self) -> (usize, usize) {
@@ -253,15 +246,13 @@ mod tests {
             &self,
             _hashes: &[alloy_primitives::TxHash],
             _reason: RemovalReason,
-        ) -> Vec<Arc<reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>>>
-        {
+        ) -> Vec<Arc<reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>>> {
             Vec::new()
         }
         fn remove_transactions_by_sender(
             &self,
             _sender: alloy_primitives::Address,
-        ) -> Vec<Arc<reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>>>
-        {
+        ) -> Vec<Arc<reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>>> {
             Vec::new()
         }
     }

--- a/crates/execution/txpool/src/best.rs
+++ b/crates/execution/txpool/src/best.rs
@@ -15,6 +15,7 @@ where
 {
     protocol: Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<T>>>>,
     sidecar: Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<T>>>>,
+    owns_sidecar: Box<dyn Fn(&T) -> bool + Send>,
     ordering: O,
     base_fee: u64,
     next_protocol: Option<Arc<ValidPoolTransaction<T>>>,
@@ -32,7 +33,32 @@ where
         ordering: O,
         base_fee: u64,
     ) -> Self {
-        Self { protocol, sidecar, ordering, base_fee, next_protocol: None, next_sidecar: None }
+        Self::with_discriminator(
+            protocol,
+            sidecar,
+            Box::new(T::is_eip8130_sidecar_transaction),
+            ordering,
+            base_fee,
+        )
+    }
+
+    /// Creates a merged iterator with a caller-supplied ownership predicate.
+    pub(crate) fn with_discriminator(
+        protocol: Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<T>>>>,
+        sidecar: Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<T>>>>,
+        owns_sidecar: Box<dyn Fn(&T) -> bool + Send>,
+        ordering: O,
+        base_fee: u64,
+    ) -> Self {
+        Self {
+            protocol,
+            sidecar,
+            owns_sidecar,
+            ordering,
+            base_fee,
+            next_protocol: None,
+            next_sidecar: None,
+        }
     }
 
     fn protocol_is_better(
@@ -108,7 +134,7 @@ where
     O: TransactionOrdering<Transaction = T>,
 {
     fn mark_invalid(&mut self, transaction: &Self::Item, kind: InvalidPoolTransactionError) {
-        if transaction.transaction.is_eip8130_sidecar_transaction() {
+        if (self.owns_sidecar)(&transaction.transaction) {
             self.next_sidecar = None;
             self.sidecar.mark_invalid(transaction, kind);
         } else {
@@ -366,3 +392,328 @@ mod tests {
         assert!(merged.next().is_none());
     }
 }
+
+// ===PROBE-START===
+#[cfg(test)]
+mod nest_probe {
+    use std::{collections::VecDeque, time::Instant};
+
+    use alloy_consensus::{Transaction, transaction::Recovered};
+    use alloy_eips::eip2718::Encodable2718;
+    use alloy_primitives::{Bytes, U256};
+    use alloy_signer::SignerSync;
+    use alloy_signer_local::PrivateKeySigner;
+    use base_common_chains::ChainConfig;
+    use base_common_consensus::{
+        BasePooledTransaction as ConsensusPooledTransaction, Eip8130Signed, TxEip8130,
+    };
+    use reth_transaction_pool::{TransactionOrigin, identifier::TransactionId};
+
+    use super::*;
+    use crate::{BaseOrdering, BasePooledTransaction};
+
+    // ---- PROBE A: does a nested merge coerce, generically? ----
+    fn assert_nests_generic<T: BasePooledTx, O: TransactionOrdering<Transaction = T>>(
+        inner: MergeBestTransactions<T, O>,
+    ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<T>>>> {
+        Box::new(inner)
+    }
+
+    // ---- fixtures (copied from `mod tests`) ----
+    #[derive(Debug)]
+    struct StaticBest<T: BasePooledTx> {
+        transactions: VecDeque<Arc<ValidPoolTransaction<T>>>,
+        marked: Vec<alloy_primitives::TxHash>,
+    }
+
+    impl<T: BasePooledTx> StaticBest<T> {
+        fn new(transactions: Vec<Arc<ValidPoolTransaction<T>>>) -> Self {
+            Self { transactions: transactions.into(), marked: Vec::new() }
+        }
+    }
+
+    impl<T: BasePooledTx> Iterator for StaticBest<T> {
+        type Item = Arc<ValidPoolTransaction<T>>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            self.transactions.pop_front()
+        }
+    }
+
+    impl<T: BasePooledTx> BestTransactions for StaticBest<T> {
+        fn mark_invalid(&mut self, transaction: &Self::Item, _kind: InvalidPoolTransactionError) {
+            self.marked.push(*transaction.hash());
+            self.transactions.retain(|c| c.sender() != transaction.sender());
+        }
+
+        fn no_updates(&mut self) {}
+
+        fn set_skip_blobs(&mut self, _skip_blobs: bool) {}
+    }
+
+    fn signed_tx(
+        signer: &PrivateKeySigner,
+        nonce_key: U256,
+        nonce_sequence: u64,
+        max_priority_fee_per_gas: u128,
+        max_fee_per_gas: u128,
+        received_at: u128,
+    ) -> BasePooledTransaction {
+        let tx = TxEip8130 {
+            chain_id: ChainConfig::mainnet().chain_id,
+            sender: None,
+            nonce_key,
+            nonce_sequence,
+            expiry: 0,
+            max_priority_fee_per_gas,
+            max_fee_per_gas,
+            gas_limit: 50_000,
+            account_changes: Vec::new(),
+            calls: Vec::new(),
+            metadata: Bytes::new(),
+            payer: None,
+        };
+        let signature = signer.sign_hash_sync(&tx.sender_signature_hash()).unwrap();
+        let signed =
+            Eip8130Signed::new(tx, Bytes::from(signature.as_bytes().to_vec()), Bytes::new());
+        let pooled = ConsensusPooledTransaction::Eip8130(signed);
+        let encoded_length = pooled.encode_2718_len();
+        BasePooledTransaction::new_with_received_at(
+            Recovered::new_unchecked(pooled.into(), signer.address()),
+            encoded_length,
+            received_at,
+        )
+    }
+
+    fn vpt(
+        transaction: BasePooledTransaction,
+        timestamp: Instant,
+    ) -> Arc<ValidPoolTransaction<BasePooledTransaction>> {
+        Arc::new(ValidPoolTransaction {
+            transaction_id: TransactionId::new(0u64.into(), transaction.nonce()),
+            transaction,
+            propagate: true,
+            timestamp,
+            origin: TransactionOrigin::External,
+            authority_ids: None,
+        })
+    }
+
+    // ---- PROBE B: concrete 3-way nest, does it run and order correctly? ----
+    #[test]
+    fn probe_nested_three_way_orders_by_priority() {
+        let now = Instant::now();
+        let a = vpt(signed_tx(&PrivateKeySigner::random(), U256::ZERO, 0, 30, 1000, 0), now);
+        let b = vpt(signed_tx(&PrivateKeySigner::random(), U256::from(1), 0, 20, 1000, 0), now);
+        let c = vpt(signed_tx(&PrivateKeySigner::random(), U256::from(2), 0, 40, 1000, 0), now);
+        let (ha, hb, hc) = (*a.hash(), *b.hash(), *c.hash());
+
+        let inner = MergeBestTransactions::new(
+            Box::new(StaticBest::new(vec![a])),
+            Box::new(StaticBest::new(vec![b])),
+            BaseOrdering::coinbase_tip(),
+            10,
+        );
+        let mut outer = MergeBestTransactions::new(
+            Box::new(inner),
+            Box::new(StaticBest::new(vec![c])),
+            BaseOrdering::coinbase_tip(),
+            10,
+        );
+
+        let got: Vec<_> = std::iter::from_fn(|| outer.next()).map(|t| *t.hash()).collect();
+        assert_eq!(got, vec![hc, ha, hb], "expected priority order 40, 30, 20");
+    }
+
+    // ---- PROBE C: nested tie-break: which arm wins an exact tie? ----
+    #[test]
+    fn probe_nested_tie_break_position_dependence() {
+        let now = Instant::now();
+        // three transactions with IDENTICAL priority + identical timestamp; only hashes differ
+        let x = vpt(signed_tx(&PrivateKeySigner::random(), U256::ZERO, 0, 10, 1000, 0), now);
+        let y = vpt(signed_tx(&PrivateKeySigner::random(), U256::from(1), 0, 10, 1000, 0), now);
+        let z = vpt(signed_tx(&PrivateKeySigner::random(), U256::from(2), 0, 10, 1000, 0), now);
+        let mut hashes = [*x.hash(), *y.hash(), *z.hash()];
+        hashes.sort();
+        let max_hash = hashes[2];
+
+        let inner = MergeBestTransactions::new(
+            Box::new(StaticBest::new(vec![x])),
+            Box::new(StaticBest::new(vec![y])),
+            BaseOrdering::coinbase_tip(),
+            10,
+        );
+        let mut outer = MergeBestTransactions::new(
+            Box::new(inner),
+            Box::new(StaticBest::new(vec![z])),
+            BaseOrdering::coinbase_tip(),
+            10,
+        );
+        let first = *outer.next().unwrap().hash();
+        assert_eq!(first, max_hash, "nested merge must still yield global max by hash tiebreak");
+    }
+
+    // ---- PROBE D: nested mark_invalid routing with an explicit discriminator ----
+    #[test]
+    fn probe_nested_mark_invalid_routes_through_inner() {
+        let now = Instant::now();
+        let signer_p = PrivateKeySigner::random();
+        let protocol = vec![
+            vpt(signed_tx(&signer_p, U256::ZERO, 0, 1200, 1200, 0), now),
+            vpt(signed_tx(&signer_p, U256::ZERO, 1, 900, 900, 0), now),
+        ];
+        let sidecar =
+            vec![vpt(signed_tx(&PrivateKeySigner::random(), U256::from(1), 0, 1000, 1000, 0), now)];
+        let extra =
+            vec![vpt(signed_tx(&PrivateKeySigner::random(), U256::from(2), 0, 1100, 1100, 0), now)];
+        let extra_hash = *extra[0].hash();
+
+        let inner = MergeBestTransactions::new(
+            Box::new(StaticBest::new(protocol)),
+            Box::new(StaticBest::new(sidecar)),
+            BaseOrdering::coinbase_tip(),
+            0,
+        );
+        // outer discriminator: "extra" arm owns nonce_key == 2
+        let mut outer = MergeBestTransactions::with_discriminator(
+            Box::new(inner),
+            Box::new(StaticBest::new(extra)),
+            Box::new(|t: &BasePooledTransaction| {
+                t.eip8130_nonce_channel_key() == Some(U256::from(2))
+            }),
+            BaseOrdering::coinbase_tip(),
+            0,
+        );
+
+        // 1200 (protocol, innermost) wins first
+        let first = outer.next().expect("first");
+        assert_eq!(first.transaction.eip8130_nonce_channel_key(), None, "innermost protocol first");
+        assert_eq!(first.nonce(), 0);
+
+        // 1100 (extra, outer arm) next
+        let second = outer.next().expect("second");
+        assert_eq!(*second.hash(), extra_hash, "outer arm second");
+
+        // 1000 (sidecar, inner arm) next
+        let third = outer.next().expect("third");
+        assert_eq!(third.transaction.eip8130_nonce_channel_key(), Some(U256::from(1)));
+
+        // marking the protocol tx invalid must reach the INNERMOST protocol arm and
+        // drain the same-sender descendant (nonce 1 / 900).
+        outer.mark_invalid(&first, InvalidPoolTransactionError::Underpriced);
+        assert!(outer.next().is_none(), "descendant must be drained through two merge levels");
+    }
+
+    // ---- PROBE E: does `max_by_key` pick the FIRST or the LAST maximum? ----
+    #[test]
+    fn probe_max_by_key_returns_last_maximum() {
+        let heads = vec![("protocol", 5u64), ("sidecar", 5u64), ("extra", 5u64)];
+        let picked = heads.iter().max_by_key(|(_, p)| *p).unwrap();
+        assert_eq!(picked.0, "extra", "std max_by_key returns the LAST maximum");
+
+        let picked_first = heads.iter().rev().max_by_key(|(_, p)| *p).unwrap();
+        assert_eq!(picked_first.0, "protocol", "reversing restores first-wins bias");
+    }
+
+    // ---- PROBE F: is the merge key a strict total order (i.e. is `>=` bias reachable)? ----
+    #[test]
+    fn probe_merge_key_is_total_order_so_ge_bias_is_unreachable() {
+        let now = Instant::now();
+        // identical fee, identical timestamp, different senders -> only the hash differs
+        let p = vpt(signed_tx(&PrivateKeySigner::random(), U256::ZERO, 0, 10, 1000, 0), now);
+        let s = vpt(signed_tx(&PrivateKeySigner::random(), U256::ZERO, 0, 10, 1000, 0), now);
+        assert_ne!(*p.hash(), *s.hash());
+
+        let ordering = BaseOrdering::coinbase_tip();
+        let key = |t: &Arc<ValidPoolTransaction<BasePooledTransaction>>| {
+            (ordering.priority(&t.transaction, 10), Reverse(t.timestamp), *t.hash())
+        };
+        assert_ne!(key(&p), key(&s), "hash breaks every tie; exact equality is unreachable");
+    }
+
+    #[allow(dead_code)]
+    fn use_a(x: MergeBestTransactions<BasePooledTransaction, BaseOrdering<BasePooledTransaction>>) {
+        let _ = assert_nests_generic(x);
+    }
+
+    // ---- PROBE G: randomized equivalence, nested-pairwise vs reference N-way max_by_key ----
+    fn reference_nway(
+        mut arms: Vec<VecDeque<Arc<ValidPoolTransaction<BasePooledTransaction>>>>,
+        base_fee: u64,
+    ) -> Vec<alloy_primitives::TxHash> {
+        let ordering = BaseOrdering::coinbase_tip();
+        let mut heads: Vec<Option<Arc<ValidPoolTransaction<BasePooledTransaction>>>> =
+            vec![None; arms.len()];
+        let mut out = Vec::new();
+        loop {
+            for (i, head) in heads.iter_mut().enumerate() {
+                if head.is_none() {
+                    *head = arms[i].pop_front();
+                }
+            }
+            let key = |t: &Arc<ValidPoolTransaction<BasePooledTransaction>>| {
+                (ordering.priority(&t.transaction, base_fee), Reverse(t.timestamp), *t.hash())
+            };
+            let Some(best_idx) = heads
+                .iter()
+                .enumerate()
+                .filter_map(|(i, h)| h.as_ref().map(|t| (i, key(t))))
+                .max_by_key(|(_, k)| k.clone())
+                .map(|(i, _)| i)
+            else {
+                return out;
+            };
+            let tx = heads[best_idx].take().expect("head");
+            if tx.effective_tip_per_gas(base_fee).is_some() {
+                out.push(*tx.hash());
+            }
+        }
+    }
+
+    #[test]
+    fn probe_nested_matches_reference_nway_on_randomized_input() {
+        for seed in 0u128..40 {
+            let now = Instant::now();
+            let mut arms: Vec<Vec<Arc<ValidPoolTransaction<BasePooledTransaction>>>> =
+                vec![Vec::new(), Vec::new(), Vec::new(), Vec::new()];
+            let mut x = seed.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+            for i in 0..24u128 {
+                x = x.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1_442_695_040_888_963_407);
+                let arm = (x >> 33) as usize % 4;
+                let tip = 1 + ((x >> 7) % 60) as u128;
+                let ts = now + std::time::Duration::from_micros(((x >> 17) % 5) as u64);
+                let key = if arm == 0 { U256::ZERO } else { U256::from(arm) };
+                arms[arm].push(vpt(
+                    signed_tx(&PrivateKeySigner::random(), key, i as u64, tip, 1000, 0),
+                    ts,
+                ));
+            }
+
+            let expected = reference_nway(
+                arms.iter().cloned().map(VecDeque::from).collect::<Vec<_>>(),
+                10,
+            );
+
+            let mut merged: Box<
+                dyn BestTransactions<Item = Arc<ValidPoolTransaction<BasePooledTransaction>>>,
+            > = Box::new(MergeBestTransactions::new(
+                Box::new(StaticBest::new(arms[0].clone())),
+                Box::new(StaticBest::new(arms[1].clone())),
+                BaseOrdering::coinbase_tip(),
+                10,
+            ));
+            for arm in arms.iter().skip(2) {
+                merged = Box::new(MergeBestTransactions::with_discriminator(
+                    merged,
+                    Box::new(StaticBest::new(arm.clone())),
+                    Box::new(|_: &BasePooledTransaction| false),
+                    BaseOrdering::coinbase_tip(),
+                    10,
+                ));
+            }
+            let got: Vec<_> = std::iter::from_fn(|| merged.next()).map(|t| *t.hash()).collect();
+            assert_eq!(got, expected, "seed {seed}: nested != reference N-way");
+        }
+    }
+}
+// ===PROBE-END===

--- a/crates/execution/txpool/src/best.rs
+++ b/crates/execution/txpool/src/best.rs
@@ -160,10 +160,16 @@ where
 {
     /// Invalidates `transaction` on the arm that served it.
     ///
-    /// Provenance recorded by [`Self::pop_best`] is authoritative and is what callers exercise:
-    /// the payload builder marks the transaction it just took from `next`. Only a transaction
-    /// this iterator never yielded falls back to `owns_sidecar`, which is the best guess
-    /// available and matches the pre-provenance behaviour.
+    /// Provenance is authoritative **only for the most recently yielded transaction**, which is
+    /// the entire call pattern in practice: both this iterator's own underpriced path and the
+    /// payload builder mark the transaction they just took from `next`. Marking any earlier
+    /// transaction falls back to `owns_sidecar`, which is correct whenever the arms are populated
+    /// consistently with the predicate and is the pre-provenance behaviour otherwise.
+    ///
+    /// Tracking every yielded transaction would remove the caveat, at the cost of a per-yield map
+    /// insertion on the block-building hot path. Not worth it for a case no caller exercises —
+    /// but if a caller ever needs to mark arbitrary earlier transactions, widen this rather than
+    /// letting it silently fall back.
     fn mark_invalid(&mut self, transaction: &Self::Item, kind: InvalidPoolTransactionError) {
         let from = match self.last_yielded {
             Some((hash, from)) if hash == *transaction.hash() => from,

--- a/crates/execution/txpool/src/best.rs
+++ b/crates/execution/txpool/src/best.rs
@@ -678,7 +678,9 @@ mod nest_probe {
                 vec![Vec::new(), Vec::new(), Vec::new(), Vec::new()];
             let mut x = seed.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
             for i in 0..24u128 {
-                x = x.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1_442_695_040_888_963_407);
+                x = x
+                    .wrapping_mul(6_364_136_223_846_793_005)
+                    .wrapping_add(1_442_695_040_888_963_407);
                 let arm = (x >> 33) as usize % 4;
                 let tip = 1 + ((x >> 7) % 60) as u128;
                 let ts = now + std::time::Duration::from_micros(((x >> 17) % 5) as u64);
@@ -689,10 +691,8 @@ mod nest_probe {
                 ));
             }
 
-            let expected = reference_nway(
-                arms.iter().cloned().map(VecDeque::from).collect::<Vec<_>>(),
-                10,
-            );
+            let expected =
+                reference_nway(arms.iter().cloned().map(VecDeque::from).collect::<Vec<_>>(), 10);
 
             let mut merged: Box<
                 dyn BestTransactions<Item = Arc<ValidPoolTransaction<BasePooledTransaction>>>,

--- a/crates/execution/txpool/src/best.rs
+++ b/crates/execution/txpool/src/best.rs
@@ -2,6 +2,7 @@
 
 use std::{cmp::Reverse, sync::Arc};
 
+use alloy_primitives::TxHash;
 use reth_transaction_pool::{
     BestTransactions, TransactionOrdering, ValidPoolTransaction, error::InvalidPoolTransactionError,
 };
@@ -20,6 +21,23 @@ where
     base_fee: u64,
     next_protocol: Option<Arc<ValidPoolTransaction<T>>>,
     next_sidecar: Option<Arc<ValidPoolTransaction<T>>>,
+    /// Which arm produced the most recent [`Self::pop_best`], so [`BestTransactions::mark_invalid`]
+    /// can invalidate the stream a transaction actually came from.
+    ///
+    /// Provenance cannot be re-derived from `owns_sidecar`: the predicate answers "would this
+    /// transaction be routed to the sidecar arm", which coincides with "did it come from the
+    /// sidecar arm" only while every arm is populated consistently with the predicate. Nesting
+    /// breaks that coincidence — an inner merge built by [`Self::new`] discriminates on the
+    /// EIP-8130 transaction *type*, so a sidecar-typed transaction served by its protocol arm
+    /// would be misrouted, clearing the wrong buffered head.
+    last_yielded: Option<(TxHash, YieldedFrom)>,
+}
+
+/// Which arm of a [`MergeBestTransactions`] served a transaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum YieldedFrom {
+    Protocol,
+    Sidecar,
 }
 
 impl<T: BasePooledTx, O> MergeBestTransactions<T, O>
@@ -58,6 +76,7 @@ where
             base_fee,
             next_protocol: None,
             next_sidecar: None,
+            last_yielded: None,
         }
     }
 
@@ -80,18 +99,24 @@ where
     }
 
     fn pop_best(&mut self) -> Option<Arc<ValidPoolTransaction<T>>> {
-        match (&self.next_protocol, &self.next_sidecar) {
+        let from = match (&self.next_protocol, &self.next_sidecar) {
             (Some(protocol), Some(sidecar)) => {
                 if self.protocol_is_better(protocol, sidecar) {
-                    self.next_protocol.take()
+                    YieldedFrom::Protocol
                 } else {
-                    self.next_sidecar.take()
+                    YieldedFrom::Sidecar
                 }
             }
-            (Some(_), None) => self.next_protocol.take(),
-            (None, Some(_)) => self.next_sidecar.take(),
-            (None, None) => None,
-        }
+            (Some(_), None) => YieldedFrom::Protocol,
+            (None, Some(_)) => YieldedFrom::Sidecar,
+            (None, None) => return None,
+        };
+        let transaction = match from {
+            YieldedFrom::Protocol => self.next_protocol.take(),
+            YieldedFrom::Sidecar => self.next_sidecar.take(),
+        }?;
+        self.last_yielded = Some((*transaction.hash(), from));
+        Some(transaction)
     }
 }
 
@@ -133,13 +158,27 @@ impl<T: BasePooledTx, O> BestTransactions for MergeBestTransactions<T, O>
 where
     O: TransactionOrdering<Transaction = T>,
 {
+    /// Invalidates `transaction` on the arm that served it.
+    ///
+    /// Provenance recorded by [`Self::pop_best`] is authoritative and is what callers exercise:
+    /// the payload builder marks the transaction it just took from `next`. Only a transaction
+    /// this iterator never yielded falls back to `owns_sidecar`, which is the best guess
+    /// available and matches the pre-provenance behaviour.
     fn mark_invalid(&mut self, transaction: &Self::Item, kind: InvalidPoolTransactionError) {
-        if (self.owns_sidecar)(&transaction.transaction) {
-            self.next_sidecar = None;
-            self.sidecar.mark_invalid(transaction, kind);
-        } else {
-            self.next_protocol = None;
-            self.protocol.mark_invalid(transaction, kind);
+        let from = match self.last_yielded {
+            Some((hash, from)) if hash == *transaction.hash() => from,
+            _ if (self.owns_sidecar)(&transaction.transaction) => YieldedFrom::Sidecar,
+            _ => YieldedFrom::Protocol,
+        };
+        match from {
+            YieldedFrom::Sidecar => {
+                self.next_sidecar = None;
+                self.sidecar.mark_invalid(transaction, kind);
+            }
+            YieldedFrom::Protocol => {
+                self.next_protocol = None;
+                self.protocol.mark_invalid(transaction, kind);
+            }
         }
     }
 
@@ -393,9 +432,11 @@ mod tests {
     }
 }
 
-// ===PROBE-START===
+/// Tests for nesting one [`MergeBestTransactions`] inside another, which is how more than two
+/// sources are combined. These pin the properties that make nesting equivalent to a flat N-way
+/// merge: priority order, tie-breaking, and `mark_invalid` routing.
 #[cfg(test)]
-mod nest_probe {
+mod nested_merge_tests {
     use std::{collections::VecDeque, time::Instant};
 
     use alloy_consensus::{Transaction, transaction::Recovered};
@@ -412,7 +453,7 @@ mod nest_probe {
     use super::*;
     use crate::{BaseOrdering, BasePooledTransaction};
 
-    // ---- PROBE A: does a nested merge coerce, generically? ----
+    // A nested merge must coerce to the boxed trait object an arm expects.
     fn assert_nests_generic<T: BasePooledTx, O: TransactionOrdering<Transaction = T>>(
         inner: MergeBestTransactions<T, O>,
     ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<T>>>> {
@@ -499,9 +540,9 @@ mod nest_probe {
         })
     }
 
-    // ---- PROBE B: concrete 3-way nest, does it run and order correctly? ----
+    // Three sources, nested pairwise, must come out in priority order.
     #[test]
-    fn probe_nested_three_way_orders_by_priority() {
+    fn nested_three_way_orders_by_priority() {
         let now = Instant::now();
         let a = vpt(signed_tx(&PrivateKeySigner::random(), U256::ZERO, 0, 30, 1000, 0), now);
         let b = vpt(signed_tx(&PrivateKeySigner::random(), U256::from(1), 0, 20, 1000, 0), now);
@@ -525,9 +566,9 @@ mod nest_probe {
         assert_eq!(got, vec![hc, ha, hb], "expected priority order 40, 30, 20");
     }
 
-    // ---- PROBE C: nested tie-break: which arm wins an exact tie? ----
+    // An exact tie must resolve the same way regardless of nesting position.
     #[test]
-    fn probe_nested_tie_break_position_dependence() {
+    fn nested_tie_break_is_position_independent() {
         let now = Instant::now();
         // three transactions with IDENTICAL priority + identical timestamp; only hashes differ
         let x = vpt(signed_tx(&PrivateKeySigner::random(), U256::ZERO, 0, 10, 1000, 0), now);
@@ -553,9 +594,9 @@ mod nest_probe {
         assert_eq!(first, max_hash, "nested merge must still yield global max by hash tiebreak");
     }
 
-    // ---- PROBE D: nested mark_invalid routing with an explicit discriminator ----
+    // mark_invalid must reach the arm that served the transaction, through the nesting.
     #[test]
-    fn probe_nested_mark_invalid_routes_through_inner() {
+    fn nested_mark_invalid_routes_through_inner() {
         let now = Instant::now();
         let signer_p = PrivateKeySigner::random();
         let protocol = vec![
@@ -604,10 +645,10 @@ mod nest_probe {
         assert!(outer.next().is_none(), "descendant must be drained through two merge levels");
     }
 
-    // ---- PROBE E: does `max_by_key` pick the FIRST or the LAST maximum? ----
+    // `max_by_key` returns the LAST maximum, which is why the N-way reference below cannot
     #[test]
-    fn probe_max_by_key_returns_last_maximum() {
-        let heads = vec![("protocol", 5u64), ("sidecar", 5u64), ("extra", 5u64)];
+    fn max_by_key_returns_last_maximum() {
+        let heads = [("protocol", 5u64), ("sidecar", 5u64), ("extra", 5u64)];
         let picked = heads.iter().max_by_key(|(_, p)| *p).unwrap();
         assert_eq!(picked.0, "extra", "std max_by_key returns the LAST maximum");
 
@@ -615,9 +656,9 @@ mod nest_probe {
         assert_eq!(picked_first.0, "protocol", "reversing restores first-wins bias");
     }
 
-    // ---- PROBE F: is the merge key a strict total order (i.e. is `>=` bias reachable)? ----
+    // The merge key ends in the tx hash, so it is a strict total order and the `>=` bias in
     #[test]
-    fn probe_merge_key_is_total_order_so_ge_bias_is_unreachable() {
+    fn merge_key_is_total_order_so_ge_bias_is_unreachable() {
         let now = Instant::now();
         // identical fee, identical timestamp, different senders -> only the hash differs
         let p = vpt(signed_tx(&PrivateKeySigner::random(), U256::ZERO, 0, 10, 1000, 0), now);
@@ -636,7 +677,7 @@ mod nest_probe {
         let _ = assert_nests_generic(x);
     }
 
-    // ---- PROBE G: randomized equivalence, nested-pairwise vs reference N-way max_by_key ----
+    // Randomized differential test: nested pairwise merging must equal a flat N-way merge.
     fn reference_nway(
         mut arms: Vec<VecDeque<Arc<ValidPoolTransaction<BasePooledTransaction>>>>,
         base_fee: u64,
@@ -671,7 +712,7 @@ mod nest_probe {
     }
 
     #[test]
-    fn probe_nested_matches_reference_nway_on_randomized_input() {
+    fn nested_matches_reference_nway_on_randomized_input() {
         for seed in 0u128..40 {
             let now = Instant::now();
             let mut arms: Vec<Vec<Arc<ValidPoolTransaction<BasePooledTransaction>>>> =
@@ -682,7 +723,7 @@ mod nest_probe {
                     .wrapping_mul(6_364_136_223_846_793_005)
                     .wrapping_add(1_442_695_040_888_963_407);
                 let arm = (x >> 33) as usize % 4;
-                let tip = 1 + ((x >> 7) % 60) as u128;
+                let tip = 1 + ((x >> 7) % 60);
                 let ts = now + std::time::Duration::from_micros(((x >> 17) % 5) as u64);
                 let key = if arm == 0 { U256::ZERO } else { U256::from(arm) };
                 arms[arm].push(vpt(
@@ -716,4 +757,3 @@ mod nest_probe {
         }
     }
 }
-// ===PROBE-END===

--- a/crates/execution/txpool/src/lib.rs
+++ b/crates/execution/txpool/src/lib.rs
@@ -68,6 +68,9 @@ pub use wire::ValidatedTransaction;
 
 mod two_d_nonce_pool;
 
+mod sidecar_pool;
+pub use sidecar_pool::{RemovalReason, SidecarInsert, SidecarPool};
+
 mod metrics;
 pub use metrics::{GuardMetrics, ValidatorMetrics};
 

--- a/crates/execution/txpool/src/lib.rs
+++ b/crates/execution/txpool/src/lib.rs
@@ -69,7 +69,7 @@ pub use wire::ValidatedTransaction;
 mod two_d_nonce_pool;
 
 mod sidecar_pool;
-pub use sidecar_pool::{RemovalReason, SidecarInsert, SidecarPool};
+pub use sidecar_pool::{CanonicalStateOutcome, RemovalReason, SidecarInsert, SidecarPool};
 
 mod metrics;
 pub use metrics::{GuardMetrics, ValidatorMetrics};

--- a/crates/execution/txpool/src/lib.rs
+++ b/crates/execution/txpool/src/lib.rs
@@ -69,7 +69,10 @@ pub use wire::ValidatedTransaction;
 mod two_d_nonce_pool;
 
 mod sidecar_pool;
-pub use sidecar_pool::{CanonicalStateOutcome, RemovalReason, SidecarInsert, SidecarPool};
+pub use sidecar_pool::{
+    CanonicalStateOutcome, RemovalReason, SidecarAdmission, SidecarInsert, SidecarPool,
+    SidecarPoolSize,
+};
 
 mod metrics;
 pub use metrics::{GuardMetrics, ValidatorMetrics};

--- a/crates/execution/txpool/src/pool.rs
+++ b/crates/execution/txpool/src/pool.rs
@@ -23,7 +23,6 @@ use reth_transaction_pool::{
     PoolTransaction, PropagatedTransactions, SubPool, TransactionEvents, TransactionListenerKind,
     TransactionOrigin, TransactionPool, TransactionPoolExt, TransactionValidationOutcome,
     TransactionValidationTaskExecutor, TransactionValidator, ValidPoolTransaction,
-    identifier::SenderIdentifiers,
     pool::{AddedTransactionState, TransactionEvent},
 };
 use tokio::{spawn, sync::mpsc};
@@ -33,7 +32,7 @@ use crate::{
     Admission, BasePooledTx, BaseTransactionValidator, GuardLimits, GuardMetrics,
     InvalidationCause, InvalidationKey, LimitRejection, MempoolGuard, StateDiffInvalidation,
     best::MergeBestTransactions,
-    sidecar_pool::{RemovalReason, SidecarInsert, SidecarPool},
+    sidecar_pool::{RemovalReason, SidecarAdmission, SidecarInsert, SidecarPool},
     two_d_nonce_pool::{InsertOutcome, TwoDNoncePool},
 };
 
@@ -94,14 +93,6 @@ pub struct BaseTransactionPool<
     ordering: O,
     nonce_pool: Arc<RwLock<TwoDNoncePool<T>>>,
     sidecars: Arc<Vec<Arc<dyn SidecarPool<T>>>>,
-    /// Sender-ID interner for registered sidecars, kept separate from the 2D nonce pool's.
-    ///
-    /// Sidecar insertions must not allocate out of `nonce_pool`'s interner: those transactions
-    /// never enter the nonce pool, so every one would leave a permanent entry behind in it. The
-    /// two namespaces are independent by design — a [`SidecarPool`] is told to mint its own
-    /// `TransactionId` from the transaction it is handed, and nothing compares a `SenderId`
-    /// across pools.
-    sidecar_senders: Arc<RwLock<SenderIdentifiers>>,
     listeners: Arc<RwLock<SidecarListeners<T>>>,
     /// Shared admission and invalidation ledger for EIP-8130 transactions.
     guard: Arc<RwLock<MempoolGuard>>,
@@ -140,7 +131,6 @@ where
             ordering: self.ordering.clone(),
             nonce_pool: Arc::clone(&self.nonce_pool),
             sidecars: Arc::clone(&self.sidecars),
-            sidecar_senders: Arc::clone(&self.sidecar_senders),
             listeners: Arc::clone(&self.listeners),
             guard: Arc::clone(&self.guard),
             protocol_admission_lock: Arc::clone(&self.protocol_admission_lock),
@@ -183,7 +173,6 @@ where
             ordering,
             nonce_pool: Arc::new(RwLock::new(TwoDNoncePool::new(price_bump_config))),
             sidecars: Arc::new(Vec::new()),
-            sidecar_senders: Arc::new(RwLock::new(SenderIdentifiers::default())),
             listeners: Arc::new(RwLock::new(SidecarListeners::default())),
             guard: Arc::new(RwLock::new(MempoolGuard::unlimited())),
             protocol_admission_lock: Arc::new(Mutex::new(())),
@@ -250,7 +239,39 @@ where
     /// pools, one per node extension, not a per-transaction collection. If that ever stops being
     /// true this wants a hash-to-pool index instead.
     fn sidecar_owning(&self, hash: &TxHash) -> Option<&Arc<dyn SidecarPool<T>>> {
-        self.sidecars.iter().find(|pool| pool.contains(hash))
+        self.sidecars.iter().find(|pool| pool.get(hash).is_some())
+    }
+
+    /// One sidecar's transactions, pending and queued.
+    ///
+    /// Derived rather than a trait method: every implementation would write this same
+    /// concatenation, and the pending/queued split is the only part the pool itself must answer.
+    fn sidecar_all_of(sidecar: &Arc<dyn SidecarPool<T>>) -> Vec<Arc<ValidPoolTransaction<T>>> {
+        let mut all = sidecar.pending_transactions();
+        all.extend(sidecar.queued_transactions());
+        all
+    }
+
+    /// Every transaction held by every registered sidecar.
+    fn sidecar_all_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T>>> {
+        self.sidecars.iter().flat_map(Self::sidecar_all_of).collect()
+    }
+
+    /// Registered-sidecar transactions from `sender`, filtered out of `select`.
+    ///
+    /// Derived rather than asked for: a per-sender view is the same filter for every
+    /// implementation, so the trait does not carry four methods each one would write identically
+    /// — and could quietly get wrong, since the host's callers promise completeness.
+    fn sidecar_by_sender(
+        &self,
+        sender: Address,
+        select: impl Fn(&Arc<dyn SidecarPool<T>>) -> Vec<Arc<ValidPoolTransaction<T>>>,
+    ) -> Vec<Arc<ValidPoolTransaction<T>>> {
+        self.sidecars
+            .iter()
+            .flat_map(select)
+            .filter(|transaction| transaction.sender() == sender)
+            .collect()
     }
 
     /// Splits `hashes` into (registered-sidecar-owned, rest).
@@ -264,7 +285,7 @@ where
         let mut owned = Vec::new();
         let mut rest = Vec::with_capacity(hashes.len());
         for hash in hashes {
-            match self.sidecars.iter().position(|pool| pool.contains(&hash)) {
+            match self.sidecars.iter().position(|pool| pool.get(&hash).is_some()) {
                 Some(index) => owned.push((index, hash)),
                 None => rest.push(hash),
             }
@@ -297,21 +318,18 @@ where
     ) -> PoolResult<AddedTransactionOutcome> {
         let validated = self.validator().validate_transaction(origin, transaction).await;
         match validated {
-            TransactionValidationOutcome::Valid {
-                transaction,
-                propagate,
-                authorities,
-                state_nonce,
-                ..
-            } => {
-                // Deliberately not `validated_pool_transaction`: that interns the sender in the
-                // 2D nonce pool, which this transaction never enters, so every sidecar admission
-                // would leave a permanent entry behind in it.
-                let validated =
-                    self.validated_sidecar_transaction(transaction, origin, propagate, authorities);
-                let admission = Self::admission_for(&validated.transaction);
-                let insert =
-                    self.sidecars[pool_index].insert_validated(origin, validated, state_nonce)?;
+            TransactionValidationOutcome::Valid { transaction, propagate, authorities, .. } => {
+                // The host does not build a `ValidPoolTransaction` here. Minting a
+                // `TransactionId` would need a sender interner, the sidecar is told to mint its
+                // own identifier anyway, and reth's `SenderIdentifiers` has no removal API — so
+                // interning here would accumulate an entry per sender that nothing could free.
+                let admission = Self::admission_for(transaction.transaction());
+                let insert = self.sidecars[pool_index].insert(SidecarAdmission {
+                    origin,
+                    transaction,
+                    propagate,
+                    authorities,
+                })?;
                 let mut listeners = self.listeners.write();
                 let mut guard = self.guard.write();
                 match (&insert.replaced, admission) {
@@ -794,42 +812,6 @@ where
         }
     }
 
-    /// Builds a [`ValidPoolTransaction`] for a registered sidecar, interning the sender in
-    /// [`Self::sidecar_senders`] rather than in the 2D nonce pool.
-    ///
-    /// The `TransactionId` this produces is a starting point only: a [`SidecarPool`] receives the
-    /// transaction by value and is expected to mint whatever identifier its own storage needs.
-    fn validated_sidecar_transaction(
-        &self,
-        transaction: reth_transaction_pool::validate::ValidTransaction<T>,
-        origin: TransactionOrigin,
-        propagate: bool,
-        authorities: Option<Vec<Address>>,
-    ) -> ValidPoolTransaction<T> {
-        let transaction = transaction.into_transaction();
-        let mut senders = self.sidecar_senders.write();
-        let sender_id = senders.sender_id_or_create(transaction.sender());
-        let authority_ids = authorities.map(|authorities| {
-            authorities
-                .into_iter()
-                .map(|authority| senders.sender_id_or_create(authority))
-                .collect()
-        });
-        drop(senders);
-
-        ValidPoolTransaction {
-            transaction_id: reth_transaction_pool::identifier::TransactionId::new(
-                sender_id,
-                transaction.nonce(),
-            ),
-            transaction,
-            propagate,
-            timestamp: std::time::Instant::now(),
-            origin,
-            authority_ids,
-        }
-    }
-
     fn validated_pool_transaction(
         &self,
         transaction: reth_transaction_pool::validate::ValidTransaction<T>,
@@ -979,13 +961,13 @@ where
         size.queued_size += queued_size;
         size.total += pending + queued;
         for sidecar in self.sidecars.iter() {
-            let (p, q) = sidecar.pending_and_queued_txn_count();
+            let sidecar_size = sidecar.size();
+            let (p, q) = (sidecar_size.pending, sidecar_size.queued);
             size.pending += p;
             size.queued += q;
             size.total += p + q;
-            let (pending_size, queued_size) = sidecar.pending_and_queued_size();
-            size.pending_size += pending_size;
-            size.queued_size += queued_size;
+            size.pending_size += sidecar_size.pending_size;
+            size.queued_size += sidecar_size.queued_size;
         }
         size
     }
@@ -1133,8 +1115,7 @@ where
         );
         for sidecar in self.sidecars.iter() {
             hashes.extend(
-                sidecar
-                    .all_transactions()
+                Self::sidecar_all_of(sidecar)
                     .into_iter()
                     .filter(|transaction| transaction.propagate)
                     .map(|transaction| *transaction.hash()),
@@ -1160,7 +1141,7 @@ where
         }
         drop(nonce_pool);
         for sidecar in self.sidecars.iter() {
-            for transaction in sidecar.all_transactions() {
+            for transaction in Self::sidecar_all_of(sidecar) {
                 if transaction.propagate {
                     hashes.push(*transaction.hash());
                     if hashes.len() >= max {
@@ -1182,9 +1163,8 @@ where
                 .filter(|transaction| transaction.propagate),
         );
         for sidecar in self.sidecars.iter() {
-            transactions.extend(
-                sidecar.all_transactions().into_iter().filter(|transaction| transaction.propagate),
-            );
+            transactions
+                .extend(Self::sidecar_all_of(sidecar).into_iter().filter(|tx| tx.propagate));
         }
         transactions
     }
@@ -1209,7 +1189,7 @@ where
         }
         drop(nonce_pool);
         for sidecar in self.sidecars.iter() {
-            for transaction in sidecar.all_transactions() {
+            for transaction in Self::sidecar_all_of(sidecar) {
                 if transaction.propagate {
                     transactions.push(transaction);
                     if transactions.len() >= max {
@@ -1367,7 +1347,8 @@ where
         let mut pending = pending + sidecar_pending;
         let mut queued = queued + sidecar_queued;
         for sidecar in self.sidecars.iter() {
-            let (p, q) = sidecar.pending_and_queued_txn_count();
+            let sidecar_size = sidecar.size();
+            let (p, q) = (sidecar_size.pending, sidecar_size.queued);
             pending += p;
             queued += q;
         }
@@ -1391,7 +1372,7 @@ where
         let mut hashes = self.protocol_pool.all_transaction_hashes();
         hashes.extend(self.nonce_pool.read().all_hashes());
         for sidecar in self.sidecars.iter() {
-            hashes.extend(sidecar.all_hashes());
+            hashes.extend(Self::sidecar_all_of(sidecar).iter().map(|tx| *tx.hash()));
         }
         hashes
     }
@@ -1440,7 +1421,8 @@ where
             let hashes: Vec<_> =
                 registered.iter().filter(|(i, _)| *i == index).map(|(_, h)| *h).collect();
             if !hashes.is_empty() {
-                registered_removed.extend(pool.remove_transactions_and_descendants(&hashes));
+                registered_removed
+                    .extend(pool.remove_transactions(&hashes, RemovalReason::Discarded));
             }
         }
         if !registered_removed.is_empty() {
@@ -1465,7 +1447,15 @@ where
         removed.extend(sidecar_removed);
         let mut registered_removed = Vec::new();
         for pool in self.sidecars.iter() {
-            registered_removed.extend(pool.remove_transactions_by_sender(sender));
+            let hashes = Self::sidecar_all_of(pool)
+                .into_iter()
+                .filter(|transaction| transaction.sender() == sender)
+                .map(|transaction| *transaction.hash())
+                .collect::<Vec<_>>();
+            if !hashes.is_empty() {
+                registered_removed
+                    .extend(pool.remove_transactions(&hashes, RemovalReason::Discarded));
+            }
         }
         if !registered_removed.is_empty() {
             self.listeners.write().on_discarded(&registered_removed);
@@ -1592,9 +1582,7 @@ where
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         let mut transactions = self.protocol_pool.get_transactions_by_sender(sender);
         transactions.extend(self.nonce_pool.read().transactions_by_sender(sender));
-        for sidecar in self.sidecars.iter() {
-            transactions.extend(sidecar.transactions_by_sender(sender));
-        }
+        transactions.extend(self.sidecar_by_sender(sender, Self::sidecar_all_of));
         transactions
     }
 
@@ -1628,9 +1616,8 @@ where
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         let mut transactions = self.protocol_pool.get_pending_transactions_by_sender(sender);
         transactions.extend(self.nonce_pool.read().pending_transactions_by_sender(sender));
-        for sidecar in self.sidecars.iter() {
-            transactions.extend(sidecar.pending_transactions_by_sender(sender));
-        }
+        transactions
+            .extend(self.sidecar_by_sender(sender, |sidecar| sidecar.pending_transactions()));
         transactions
     }
 
@@ -1640,9 +1627,8 @@ where
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         let mut transactions = self.protocol_pool.get_queued_transactions_by_sender(sender);
         transactions.extend(self.nonce_pool.read().queued_transactions_by_sender(sender));
-        for sidecar in self.sidecars.iter() {
-            transactions.extend(sidecar.queued_transactions_by_sender(sender));
-        }
+        transactions
+            .extend(self.sidecar_by_sender(sender, |sidecar| sidecar.queued_transactions()));
         transactions
     }
 
@@ -1683,8 +1669,7 @@ where
         );
         for sidecar in self.sidecars.iter() {
             transactions.extend(
-                sidecar
-                    .all_transactions()
+                Self::sidecar_all_of(sidecar)
                     .into_iter()
                     .filter(|transaction| transaction.origin == origin),
             );
@@ -1720,10 +1705,8 @@ where
         for sender in self.nonce_pool.read().unique_senders() {
             senders.insert(sender);
         }
-        for sidecar in self.sidecars.iter() {
-            for sender in sidecar.unique_senders() {
-                senders.insert(sender);
-            }
+        for transaction in self.sidecar_all_transactions() {
+            senders.insert(transaction.sender());
         }
         senders
     }
@@ -2829,5 +2812,232 @@ mod tests {
         }]);
         assert!(pool.get(&hash).is_none());
         assert!(!pool.guard.read().contains(&hash));
+    }
+
+    // ---- registered sidecar pool: behavioural coverage of the seam ----
+
+    /// A sidecar that actually stores transactions, claiming everything from one sender.
+    ///
+    /// The existing suite only ever ran the empty-`sidecars` path, so none of the host's sidecar
+    /// branches were reachable from a test. This is the minimum second implementation needed to
+    /// exercise them, and it doubles as a check that the trait is implementable without reaching
+    /// into pool internals.
+    #[derive(Debug)]
+    struct TestSidecar {
+        owner: Address,
+        stored: RwLock<Vec<Arc<ValidPoolTransaction<BasePooledTransaction>>>>,
+    }
+
+    impl TestSidecar {
+        fn new(owner: Address) -> Self {
+            Self { owner, stored: RwLock::new(Vec::new()) }
+        }
+    }
+
+    /// Yields a fixed snapshot; the host merges arms by comparing heads, so a sidecar is free to
+    /// hand its transactions over in whatever order it likes.
+    #[derive(Debug)]
+    struct SnapshotBest(std::vec::IntoIter<Arc<ValidPoolTransaction<BasePooledTransaction>>>);
+
+    impl Iterator for SnapshotBest {
+        type Item = Arc<ValidPoolTransaction<BasePooledTransaction>>;
+        fn next(&mut self) -> Option<Self::Item> {
+            self.0.next()
+        }
+    }
+
+    impl BestTransactions for SnapshotBest {
+        fn mark_invalid(
+            &mut self,
+            _tx: &Self::Item,
+            _kind: reth_transaction_pool::error::InvalidPoolTransactionError,
+        ) {
+        }
+        fn no_updates(&mut self) {}
+        fn set_skip_blobs(&mut self, _skip: bool) {}
+    }
+
+    impl SidecarPool<BasePooledTransaction> for TestSidecar {
+        fn name(&self) -> &'static str {
+            "test-sidecar"
+        }
+
+        fn claims(&self, transaction: &BasePooledTransaction) -> bool {
+            transaction.sender() == self.owner
+        }
+
+        fn insert(
+            &self,
+            admission: SidecarAdmission<BasePooledTransaction>,
+        ) -> PoolResult<SidecarInsert<BasePooledTransaction>> {
+            let transaction = admission.transaction.into_transaction();
+            let stored = Arc::new(ValidPoolTransaction {
+                transaction_id: TransactionId::new(0u64.into(), transaction.nonce()),
+                transaction,
+                propagate: admission.propagate,
+                timestamp: Instant::now(),
+                origin: admission.origin,
+                authority_ids: None,
+            });
+            let hash = *stored.hash();
+            self.stored.write().push(Arc::clone(&stored));
+            Ok(SidecarInsert {
+                outcome: AddedTransactionOutcome { hash, state: AddedTransactionState::Pending },
+                replaced: None,
+                promoted: Vec::new(),
+                inserted: stored,
+            })
+        }
+
+        fn best_transactions(
+            &self,
+            _base_fee: u64,
+        ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<BasePooledTransaction>>>>
+        {
+            Box::new(SnapshotBest(self.stored.read().clone().into_iter()))
+        }
+
+        fn get(&self, hash: &TxHash) -> Option<Arc<ValidPoolTransaction<BasePooledTransaction>>> {
+            self.stored.read().iter().find(|tx| tx.hash() == hash).map(Arc::clone)
+        }
+
+        fn pending_transactions(&self) -> Vec<Arc<ValidPoolTransaction<BasePooledTransaction>>> {
+            self.stored.read().clone()
+        }
+
+        fn queued_transactions(&self) -> Vec<Arc<ValidPoolTransaction<BasePooledTransaction>>> {
+            Vec::new()
+        }
+
+        fn remove_transactions(
+            &self,
+            hashes: &[TxHash],
+            _reason: RemovalReason,
+        ) -> Vec<Arc<ValidPoolTransaction<BasePooledTransaction>>> {
+            let mut stored = self.stored.write();
+            let (removed, kept) = stored.iter().cloned().partition(|tx| hashes.contains(tx.hash()));
+            *stored = kept;
+            removed
+        }
+    }
+
+    fn pool_with_sidecar() -> (
+        IntegrationPool,
+        MockEthProvider<BasePrimitives, Arc<BaseChainSpec>>,
+        Arc<TestSidecar>,
+        PrivateKeySigner,
+    ) {
+        let owner = signer();
+        let sidecar = Arc::new(TestSidecar::new(owner.address()));
+        let (pool, client) = build_integration_pool();
+        let pool = pool.with_sidecar_pools(vec![
+            Arc::clone(&sidecar) as Arc<dyn SidecarPool<BasePooledTransaction>>
+        ]);
+        fund(&client, owner.address());
+        (pool, client, sidecar, owner)
+    }
+
+    #[tokio::test]
+    async fn claimed_transaction_is_routed_to_the_sidecar_not_the_protocol_pool() {
+        let (pool, _client, sidecar, owner) = pool_with_sidecar();
+        let transaction = signed_1559(&owner, 0);
+        let hash = *transaction.hash();
+
+        pool.add_transaction(TransactionOrigin::Local, transaction).await.unwrap();
+
+        assert!(sidecar.get(&hash).is_some(), "sidecar must hold the claimed transaction");
+        assert!(pool.protocol_pool.get(&hash).is_none(), "protocol pool must not hold it");
+        // And the host resolves it through the sidecar.
+        assert_eq!(pool.get(&hash).map(|tx| *tx.hash()), Some(hash));
+    }
+
+    #[tokio::test]
+    async fn unclaimed_transaction_still_goes_to_the_protocol_pool() {
+        let (pool, client, sidecar, _owner) = pool_with_sidecar();
+        let other = PrivateKeySigner::random();
+        fund(&client, other.address());
+        let transaction = signed_1559(&other, 0);
+        let hash = *transaction.hash();
+
+        pool.add_transaction(TransactionOrigin::Local, transaction).await.unwrap();
+
+        assert!(sidecar.get(&hash).is_none());
+        assert!(pool.protocol_pool.get(&hash).is_some());
+    }
+
+    #[tokio::test]
+    async fn sidecar_transactions_appear_in_the_merged_best_iterator() {
+        let (pool, client, _sidecar, owner) = pool_with_sidecar();
+        let other = PrivateKeySigner::random();
+        fund(&client, other.address());
+
+        let claimed = signed_1559(&owner, 0);
+        let claimed_hash = *claimed.hash();
+        let unclaimed = signed_1559(&other, 0);
+        let unclaimed_hash = *unclaimed.hash();
+
+        pool.add_transaction(TransactionOrigin::Local, claimed).await.unwrap();
+        pool.add_transaction(TransactionOrigin::Local, unclaimed).await.unwrap();
+
+        let best = pool.best_transactions().map(|tx| *tx.hash()).collect::<Vec<_>>();
+        assert!(best.contains(&claimed_hash), "sidecar transaction missing from merge: {best:?}");
+        assert!(best.contains(&unclaimed_hash), "protocol transaction missing from merge");
+    }
+
+    #[tokio::test]
+    async fn sidecar_transactions_are_visible_to_the_aggregate_queries() {
+        let (pool, _client, _sidecar, owner) = pool_with_sidecar();
+        let transaction = signed_1559(&owner, 0);
+        let hash = *transaction.hash();
+        let encoded_length = transaction.encoded_length();
+
+        pool.add_transaction(TransactionOrigin::Local, transaction).await.unwrap();
+
+        assert!(pool.pending_transactions().iter().any(|tx| *tx.hash() == hash));
+        assert!(pool.all_transactions().pending.iter().any(|tx| *tx.hash() == hash));
+        assert!(pool.pooled_transaction_hashes().contains(&hash));
+        assert!(pool.unique_senders().contains(&owner.address()));
+
+        // Derived per-sender views must include the sidecar, since their callers promise
+        // every transaction from the sender.
+        let by_sender = pool.get_transactions_by_sender(owner.address());
+        assert!(by_sender.iter().any(|tx| *tx.hash() == hash));
+
+        let size = pool.pool_size();
+        assert_eq!(size.pending, 1);
+        assert_eq!(size.pending_size, encoded_length);
+    }
+
+    #[tokio::test]
+    async fn removing_a_sidecar_transaction_drops_it_from_the_sidecar() {
+        let (pool, _client, sidecar, owner) = pool_with_sidecar();
+        let transaction = signed_1559(&owner, 0);
+        let hash = *transaction.hash();
+        pool.add_transaction(TransactionOrigin::Local, transaction).await.unwrap();
+
+        let removed = pool.remove_transactions(vec![hash]);
+
+        assert_eq!(removed.len(), 1);
+        assert!(sidecar.get(&hash).is_none());
+        assert!(pool.get(&hash).is_none());
+    }
+
+    #[tokio::test]
+    async fn removing_by_sender_reaches_sidecar_transactions() {
+        let (pool, _client, sidecar, owner) = pool_with_sidecar();
+        let transaction = signed_1559(&owner, 0);
+        let hash = *transaction.hash();
+        pool.add_transaction(TransactionOrigin::Local, transaction).await.unwrap();
+
+        pool.remove_transactions_by_sender(owner.address());
+
+        assert!(sidecar.get(&hash).is_none(), "by-sender removal must reach the sidecar");
+    }
+
+    #[test]
+    fn a_pool_with_no_registered_sidecars_reports_nothing_for_them() {
+        let (pool, _client) = build_integration_pool();
+        assert!(pool.sidecar_all_transactions().is_empty());
+        assert!(pool.sidecar_owning(&TxHash::repeat_byte(0x11)).is_none());
     }
 }

--- a/crates/execution/txpool/src/pool.rs
+++ b/crates/execution/txpool/src/pool.rs
@@ -330,6 +330,21 @@ where
                 // own identifier anyway, and reth's `SenderIdentifiers` has no removal API — so
                 // interning here would accumulate an entry per sender that nothing could free.
                 let admission = Self::admission_for(transaction.transaction());
+                let generation = transaction
+                    .transaction()
+                    .limit_class()
+                    .map(|class| class.classification_generation);
+
+                // Held across the insert and the guard mutation, as every other guard-mutating
+                // path does. `reconcile_guard` takes this same lock across its recheck *and* its
+                // release; without it here, a reconcile pass can observe the transaction as
+                // absent, then release its guard slot after this path has admitted it. That is
+                // the invariant `reconcile_guard`'s own comment relies on.
+                //
+                // This does mean the serializer — not a pool data lock — is held across the
+                // out-of-tree `insert`. A slow sidecar therefore delays other admissions. It
+                // cannot deadlock: the lock is private and the trait contract forbids reentry.
+                let admission_guard = self.protocol_admission_lock.lock();
                 let insert = self.sidecars[pool_index].insert(SidecarAdmission {
                     origin,
                     transaction,
@@ -339,6 +354,23 @@ where
                 })?;
                 let mut listeners = self.listeners.write();
                 let mut guard = self.guard.write();
+
+                // The limit-class cache can be bumped while validation is awaiting, which would
+                // leave `admission` carrying stale balance and cost figures that `try_admit`
+                // would wrongly accept. The nonce-pool path rolls back for exactly this; so does
+                // this one.
+                let current = generation.is_none_or(|generation| {
+                    generation == self.validator().validator().limit_class_cache_generation()
+                });
+                if !current {
+                    let hash = insert.outcome.hash;
+                    drop(guard);
+                    drop(listeners);
+                    drop(admission_guard);
+                    self.sidecars[pool_index]
+                        .remove_transactions(&[hash], RemovalReason::Discarded);
+                    return Err(Self::stale_classification_error(hash));
+                }
                 match (&insert.replaced, admission) {
                     (Some(replaced), Some(admission)) => {
                         guard.release(replaced.hash());
@@ -349,12 +381,13 @@ where
                     }
                     (None, Some(admission)) => {
                         if let Err(rejection) = guard.try_admit(admission) {
-                            // Both locks go before the rollback: `remove_transactions` is
+                            // Every lock goes before the rollback: `remove_transactions` is
                             // out-of-tree code, and holding `listeners` across it would deadlock
                             // any implementation that reaches back into the pool.
                             let hash = insert.outcome.hash;
                             drop(guard);
                             drop(listeners);
+                            drop(admission_guard);
                             // Rolled back silently, with no `on_discarded`. The insertion was
                             // never announced — `on_sidecar_inserted` is only reached on the
                             // success path below — so a terminal event here would tell every

--- a/crates/execution/txpool/src/pool.rs
+++ b/crates/execution/txpool/src/pool.rs
@@ -318,7 +318,13 @@ where
     ) -> PoolResult<AddedTransactionOutcome> {
         let validated = self.validator().validate_transaction(origin, transaction).await;
         match validated {
-            TransactionValidationOutcome::Valid { transaction, propagate, authorities, .. } => {
+            TransactionValidationOutcome::Valid {
+                transaction,
+                propagate,
+                authorities,
+                state_nonce,
+                ..
+            } => {
                 // The host does not build a `ValidPoolTransaction` here. Minting a
                 // `TransactionId` would need a sender interner, the sidecar is told to mint its
                 // own identifier anyway, and reth's `SenderIdentifiers` has no removal API — so
@@ -329,6 +335,7 @@ where
                     transaction,
                     propagate,
                     authorities,
+                    state_nonce,
                 })?;
                 let mut listeners = self.listeners.write();
                 let mut guard = self.guard.write();
@@ -1421,8 +1428,9 @@ where
             let hashes: Vec<_> =
                 registered.iter().filter(|(i, _)| *i == index).map(|(_, h)| *h).collect();
             if !hashes.is_empty() {
-                registered_removed
-                    .extend(pool.remove_transactions(&hashes, RemovalReason::Discarded));
+                registered_removed.extend(
+                    pool.remove_transactions(&hashes, RemovalReason::DiscardedWithDescendants),
+                );
             }
         }
         if !registered_removed.is_empty() {
@@ -2826,11 +2834,20 @@ mod tests {
     struct TestSidecar {
         owner: Address,
         stored: RwLock<Vec<Arc<ValidPoolTransaction<BasePooledTransaction>>>>,
+        /// Every `reason` the host has passed to `remove_transactions`, in order.
+        reasons: RwLock<Vec<RemovalReason>>,
+        /// Every `state_nonce` the host has passed to `insert`, in order.
+        admitted_state_nonces: RwLock<Vec<u64>>,
     }
 
     impl TestSidecar {
         fn new(owner: Address) -> Self {
-            Self { owner, stored: RwLock::new(Vec::new()) }
+            Self {
+                owner,
+                stored: RwLock::new(Vec::new()),
+                reasons: RwLock::new(Vec::new()),
+                admitted_state_nonces: RwLock::new(Vec::new()),
+            }
         }
     }
 
@@ -2870,6 +2887,7 @@ mod tests {
             &self,
             admission: SidecarAdmission<BasePooledTransaction>,
         ) -> PoolResult<SidecarInsert<BasePooledTransaction>> {
+            self.admitted_state_nonces.write().push(admission.state_nonce);
             let transaction = admission.transaction.into_transaction();
             let stored = Arc::new(ValidPoolTransaction {
                 transaction_id: TransactionId::new(0u64.into(), transaction.nonce()),
@@ -2912,8 +2930,9 @@ mod tests {
         fn remove_transactions(
             &self,
             hashes: &[TxHash],
-            _reason: RemovalReason,
+            reason: RemovalReason,
         ) -> Vec<Arc<ValidPoolTransaction<BasePooledTransaction>>> {
+            self.reasons.write().push(reason);
             let mut stored = self.stored.write();
             let (removed, kept) = stored.iter().cloned().partition(|tx| hashes.contains(tx.hash()));
             *stored = kept;
@@ -3039,5 +3058,49 @@ mod tests {
         let (pool, _client) = build_integration_pool();
         assert!(pool.sidecar_all_transactions().is_empty());
         assert!(pool.sidecar_owning(&TxHash::repeat_byte(0x11)).is_none());
+    }
+
+    #[tokio::test]
+    async fn removal_reason_distinguishes_mined_discarded_and_descendants() {
+        // A pool that sequences per sender advances its cursor only on `Mined`, and must evict
+        // dependents on the descendants variant. Collapsing these — as an earlier revision of the
+        // trait did — is invisible until a nonce-sequencing pool is written against it.
+        let (pool, _client, sidecar, owner) = pool_with_sidecar();
+
+        let mined = signed_1559(&owner, 0);
+        let mined_hash = *mined.hash();
+        pool.add_transaction(TransactionOrigin::Local, mined).await.unwrap();
+        pool.prune_transactions(vec![mined_hash]);
+        assert_eq!(*sidecar.reasons.read().last().unwrap(), RemovalReason::Mined);
+
+        let discarded = signed_1559(&owner, 1);
+        let discarded_hash = *discarded.hash();
+        pool.add_transaction(TransactionOrigin::Local, discarded).await.unwrap();
+        pool.remove_transactions(vec![discarded_hash]);
+        assert_eq!(*sidecar.reasons.read().last().unwrap(), RemovalReason::Discarded);
+
+        let with_descendants = signed_1559(&owner, 2);
+        let with_descendants_hash = *with_descendants.hash();
+        pool.add_transaction(TransactionOrigin::Local, with_descendants).await.unwrap();
+        pool.remove_transactions_and_descendants(vec![with_descendants_hash]);
+        assert_eq!(
+            *sidecar.reasons.read().last().unwrap(),
+            RemovalReason::DiscardedWithDescendants,
+        );
+    }
+
+    #[tokio::test]
+    async fn admission_carries_the_state_nonce_a_sequencing_pool_needs() {
+        // `TwoDNoncePool` anchors its per-sender cursor on this and re-anchors after a reorg, so
+        // a seam that cannot express it cannot host the pool it was extracted from.
+        let (pool, client, sidecar, owner) = pool_with_sidecar();
+        client.add_account(
+            owner.address(),
+            ExtendedAccount::new(7, U256::from(1_000_000_000_000_000_000u64)),
+        );
+
+        pool.add_transaction(TransactionOrigin::Local, signed_1559(&owner, 7)).await.unwrap();
+
+        assert_eq!(*sidecar.admitted_state_nonces.read().last().unwrap(), 7);
     }
 }

--- a/crates/execution/txpool/src/pool.rs
+++ b/crates/execution/txpool/src/pool.rs
@@ -1,6 +1,10 @@
 //! Base transaction-pool wrapper that combines the protocol pool with a 2D nonce sidecar.
 
-use std::{collections::HashMap, fmt, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+    sync::Arc,
+};
 
 use alloy_eips::{
     eip4844::{BlobAndProofV1, BlobAndProofV2, BlobCellsAndProofsV1},
@@ -19,6 +23,7 @@ use reth_transaction_pool::{
     PoolTransaction, PropagatedTransactions, SubPool, TransactionEvents, TransactionListenerKind,
     TransactionOrigin, TransactionPool, TransactionPoolExt, TransactionValidationOutcome,
     TransactionValidationTaskExecutor, TransactionValidator, ValidPoolTransaction,
+    identifier::SenderIdentifiers,
     pool::{AddedTransactionState, TransactionEvent},
 };
 use tokio::{spawn, sync::mpsc};
@@ -89,6 +94,14 @@ pub struct BaseTransactionPool<
     ordering: O,
     nonce_pool: Arc<RwLock<TwoDNoncePool<T>>>,
     sidecars: Arc<Vec<Arc<dyn SidecarPool<T>>>>,
+    /// Sender-ID interner for registered sidecars, kept separate from the 2D nonce pool's.
+    ///
+    /// Sidecar insertions must not allocate out of `nonce_pool`'s interner: those transactions
+    /// never enter the nonce pool, so every one would leave a permanent entry behind in it. The
+    /// two namespaces are independent by design — a [`SidecarPool`] is told to mint its own
+    /// `TransactionId` from the transaction it is handed, and nothing compares a `SenderId`
+    /// across pools.
+    sidecar_senders: Arc<RwLock<SenderIdentifiers>>,
     listeners: Arc<RwLock<SidecarListeners<T>>>,
     /// Shared admission and invalidation ledger for EIP-8130 transactions.
     guard: Arc<RwLock<MempoolGuard>>,
@@ -127,6 +140,7 @@ where
             ordering: self.ordering.clone(),
             nonce_pool: Arc::clone(&self.nonce_pool),
             sidecars: Arc::clone(&self.sidecars),
+            sidecar_senders: Arc::clone(&self.sidecar_senders),
             listeners: Arc::clone(&self.listeners),
             guard: Arc::clone(&self.guard),
             protocol_admission_lock: Arc::clone(&self.protocol_admission_lock),
@@ -169,6 +183,7 @@ where
             ordering,
             nonce_pool: Arc::new(RwLock::new(TwoDNoncePool::new(price_bump_config))),
             sidecars: Arc::new(Vec::new()),
+            sidecar_senders: Arc::new(RwLock::new(SenderIdentifiers::default())),
             listeners: Arc::new(RwLock::new(SidecarListeners::default())),
             guard: Arc::new(RwLock::new(MempoolGuard::unlimited())),
             protocol_admission_lock: Arc::new(Mutex::new(())),
@@ -289,16 +304,11 @@ where
                 state_nonce,
                 ..
             } => {
-                let validated = {
-                    let mut nonce_pool = self.nonce_pool.write();
-                    self.validated_pool_transaction(
-                        transaction,
-                        origin,
-                        propagate,
-                        authorities,
-                        &mut nonce_pool,
-                    )
-                };
+                // Deliberately not `validated_pool_transaction`: that interns the sender in the
+                // 2D nonce pool, which this transaction never enters, so every sidecar admission
+                // would leave a permanent entry behind in it.
+                let validated =
+                    self.validated_sidecar_transaction(transaction, origin, propagate, authorities);
                 let admission = Self::admission_for(&validated.transaction);
                 let insert =
                     self.sidecars[pool_index].insert_validated(origin, validated, state_nonce)?;
@@ -781,6 +791,42 @@ where
             TransactionValidationOutcome::Error(hash, error) => {
                 Err(reth_transaction_pool::error::PoolError::other(hash, error.to_string()))
             }
+        }
+    }
+
+    /// Builds a [`ValidPoolTransaction`] for a registered sidecar, interning the sender in
+    /// [`Self::sidecar_senders`] rather than in the 2D nonce pool.
+    ///
+    /// The `TransactionId` this produces is a starting point only: a [`SidecarPool`] receives the
+    /// transaction by value and is expected to mint whatever identifier its own storage needs.
+    fn validated_sidecar_transaction(
+        &self,
+        transaction: reth_transaction_pool::validate::ValidTransaction<T>,
+        origin: TransactionOrigin,
+        propagate: bool,
+        authorities: Option<Vec<Address>>,
+    ) -> ValidPoolTransaction<T> {
+        let transaction = transaction.into_transaction();
+        let mut senders = self.sidecar_senders.write();
+        let sender_id = senders.sender_id_or_create(transaction.sender());
+        let authority_ids = authorities.map(|authorities| {
+            authorities
+                .into_iter()
+                .map(|authority| senders.sender_id_or_create(authority))
+                .collect()
+        });
+        drop(senders);
+
+        ValidPoolTransaction {
+            transaction_id: reth_transaction_pool::identifier::TransactionId::new(
+                sender_id,
+                transaction.nonce(),
+            ),
+            transaction,
+            propagate,
+            timestamp: std::time::Instant::now(),
+            origin,
+            authority_ids,
         }
     }
 
@@ -1474,12 +1520,27 @@ where
     where
         A: HandleMempoolData,
     {
-        let nonce_pool = self.nonce_pool.read();
-        announcement.retain_by_hash(|hash| {
-            self.protocol_pool.get(hash).is_some()
-                || nonce_pool.contains(hash)
-                || self.sidecar_owning(hash).is_some()
-        });
+        if self.sidecars.is_empty() {
+            let nonce_pool = self.nonce_pool.read();
+            announcement.retain_by_hash(|hash| {
+                self.protocol_pool.get(hash).is_some() || nonce_pool.contains(hash)
+            });
+            return;
+        }
+        // Two passes so no sidecar `contains` runs under `nonce_pool`: note what the in-tree
+        // pools know while the lock is held, then consult the sidecars with nothing held.
+        let mut known = HashSet::new();
+        {
+            let nonce_pool = self.nonce_pool.read();
+            announcement.retain_by_hash(|hash| {
+                if self.protocol_pool.get(hash).is_some() || nonce_pool.contains(hash) {
+                    known.insert(*hash);
+                }
+                true
+            });
+        }
+        announcement
+            .retain_by_hash(|hash| known.contains(hash) || self.sidecar_owning(hash).is_some());
     }
 
     fn get(&self, tx_hash: &TxHash) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>> {
@@ -1490,26 +1551,36 @@ where
     }
 
     fn get_all(&self, txs: Vec<TxHash>) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
-        let nonce_pool = self.nonce_pool.read();
-        txs.into_iter()
-            .filter_map(|tx| {
-                self.protocol_pool
-                    .get(&tx)
-                    .or_else(|| nonce_pool.get(&tx))
-                    .or_else(|| self.sidecar_owning(&tx).and_then(|pool| pool.get(&tx)))
-            })
-            .collect()
+        // In-tree lookups first, under the lock; sidecar lookups afterwards with nothing held,
+        // so no out-of-tree `get` runs while `nonce_pool` is read-locked.
+        let mut resolved = {
+            let nonce_pool = self.nonce_pool.read();
+            txs.into_iter()
+                .map(|tx| (tx, self.protocol_pool.get(&tx).or_else(|| nonce_pool.get(&tx))))
+                .collect::<Vec<_>>()
+        };
+        if !self.sidecars.is_empty() {
+            for (hash, slot) in &mut resolved {
+                if slot.is_none() {
+                    *slot = self.sidecar_owning(hash).and_then(|pool| pool.get(hash));
+                }
+            }
+        }
+        resolved.into_iter().filter_map(|(_, slot)| slot).collect()
     }
 
     fn on_propagated(&self, txs: PropagatedTransactions) {
+        // Sidecar membership first, with no pool lock held.
+        let txs = if self.sidecars.is_empty() {
+            txs
+        } else {
+            PropagatedTransactions(
+                txs.0.into_iter().filter(|(hash, _)| self.sidecar_owning(hash).is_none()).collect(),
+            )
+        };
         let nonce_pool = self.nonce_pool.read();
         let protocol_txs = PropagatedTransactions(
-            txs.0
-                .into_iter()
-                .filter(|(hash, _)| {
-                    !nonce_pool.contains(hash) && self.sidecar_owning(hash).is_none()
-                })
-                .collect(),
+            txs.0.into_iter().filter(|(hash, _)| !nonce_pool.contains(hash)).collect(),
         );
         drop(nonce_pool);
         self.protocol_pool.on_propagated(protocol_txs)

--- a/crates/execution/txpool/src/pool.rs
+++ b/crates/execution/txpool/src/pool.rs
@@ -320,9 +320,15 @@ where
                             let hash = insert.outcome.hash;
                             drop(guard);
                             drop(listeners);
-                            let removed = self.sidecars[pool_index]
+                            // Rolled back silently, with no `on_discarded`. The insertion was
+                            // never announced — `on_sidecar_inserted` is only reached on the
+                            // success path below — so a terminal event here would tell every
+                            // subscriber a hash they never saw enter the pool had just left it.
+                            // The caller learns of the rejection from the returned error, and
+                            // `add_transaction_and_subscribe` drops its hash listener on that
+                            // error path.
+                            self.sidecars[pool_index]
                                 .remove_transactions(&[hash], RemovalReason::Discarded);
-                            self.listeners.write().on_discarded(&removed);
                             return Err(Self::limit_rejection_error(hash, rejection));
                         }
                     }

--- a/crates/execution/txpool/src/pool.rs
+++ b/crates/execution/txpool/src/pool.rs
@@ -28,6 +28,7 @@ use crate::{
     Admission, BasePooledTx, BaseTransactionValidator, GuardLimits, GuardMetrics,
     InvalidationCause, InvalidationKey, LimitRejection, MempoolGuard, StateDiffInvalidation,
     best::MergeBestTransactions,
+    sidecar_pool::{RemovalReason, SidecarInsert, SidecarPool},
     two_d_nonce_pool::{InsertOutcome, TwoDNoncePool},
 };
 
@@ -87,6 +88,7 @@ pub struct BaseTransactionPool<
         Pool<TransactionValidationTaskExecutor<BaseTransactionValidator<Client, T, Evm>>, O, S>,
     ordering: O,
     nonce_pool: Arc<RwLock<TwoDNoncePool<T>>>,
+    sidecars: Arc<Vec<Arc<dyn SidecarPool<T>>>>,
     listeners: Arc<RwLock<SidecarListeners<T>>>,
     /// Shared admission and invalidation ledger for EIP-8130 transactions.
     guard: Arc<RwLock<MempoolGuard>>,
@@ -124,6 +126,7 @@ where
             protocol_pool: self.protocol_pool.clone(),
             ordering: self.ordering.clone(),
             nonce_pool: Arc::clone(&self.nonce_pool),
+            sidecars: Arc::clone(&self.sidecars),
             listeners: Arc::clone(&self.listeners),
             guard: Arc::clone(&self.guard),
             protocol_admission_lock: Arc::clone(&self.protocol_admission_lock),
@@ -165,6 +168,7 @@ where
             protocol_pool,
             ordering,
             nonce_pool: Arc::new(RwLock::new(TwoDNoncePool::new(price_bump_config))),
+            sidecars: Arc::new(Vec::new()),
             listeners: Arc::new(RwLock::new(SidecarListeners::default())),
             guard: Arc::new(RwLock::new(MempoolGuard::unlimited())),
             protocol_admission_lock: Arc::new(Mutex::new(())),
@@ -212,8 +216,121 @@ where
         self.protocol_pool.validator()
     }
 
+    /// Registers out-of-tree sidecar sub-pools. Call before sharing the pool.
+    #[must_use]
+    pub fn with_sidecar_pools(mut self, pools: Vec<Arc<dyn SidecarPool<T>>>) -> Self {
+        self.sidecars = Arc::new(pools);
+        self
+    }
+
     fn is_sidecar_transaction(&self, transaction: &T) -> bool {
         transaction.is_eip8130_sidecar_transaction()
+    }
+
+    fn sidecar_for(&self, transaction: &T) -> Option<&Arc<dyn SidecarPool<T>>> {
+        self.sidecars.iter().find(|pool| pool.claims(transaction))
+    }
+
+    fn sidecar_owning(&self, hash: &TxHash) -> Option<&Arc<dyn SidecarPool<T>>> {
+        self.sidecars.iter().find(|pool| pool.contains(hash))
+    }
+
+    /// Splits `hashes` into (registered-sidecar-owned, rest).
+    fn drain_registered_sidecar_hashes(
+        &self,
+        hashes: Vec<TxHash>,
+    ) -> (Vec<(usize, TxHash)>, Vec<TxHash>) {
+        if self.sidecars.is_empty() {
+            return (Vec::new(), hashes);
+        }
+        let mut owned = Vec::new();
+        let mut rest = Vec::with_capacity(hashes.len());
+        for hash in hashes {
+            match self.sidecars.iter().position(|pool| pool.contains(&hash)) {
+                Some(index) => owned.push((index, hash)),
+                None => rest.push(hash),
+            }
+        }
+        (owned, rest)
+    }
+
+    fn remove_from_registered_sidecars(
+        &self,
+        owned: Vec<(usize, TxHash)>,
+        reason: RemovalReason,
+    ) -> Vec<Arc<ValidPoolTransaction<T>>> {
+        let mut removed = Vec::new();
+        for (index, pool) in self.sidecars.iter().enumerate() {
+            let hashes: Vec<_> =
+                owned.iter().filter(|(i, _)| *i == index).map(|(_, h)| *h).collect();
+            if hashes.is_empty() {
+                continue;
+            }
+            removed.extend(pool.remove_transactions(&hashes, reason));
+        }
+        removed
+    }
+
+    async fn add_registered_sidecar_transaction(
+        &self,
+        pool_index: usize,
+        origin: TransactionOrigin,
+        transaction: T,
+    ) -> PoolResult<AddedTransactionOutcome> {
+        let validated = self.validator().validate_transaction(origin, transaction).await;
+        match validated {
+            TransactionValidationOutcome::Valid {
+                transaction, propagate, authorities, state_nonce, ..
+            } => {
+                let validated = {
+                    let mut nonce_pool = self.nonce_pool.write();
+                    self.validated_pool_transaction(
+                        transaction,
+                        origin,
+                        propagate,
+                        authorities,
+                        &mut nonce_pool,
+                    )
+                };
+                let admission = Self::admission_for(&validated.transaction);
+                let insert =
+                    self.sidecars[pool_index].insert_validated(origin, validated, state_nonce)?;
+                let mut listeners = self.listeners.write();
+                let mut guard = self.guard.write();
+                match (&insert.replaced, admission) {
+                    (Some(replaced), Some(admission)) => {
+                        guard.release(replaced.hash());
+                        guard.insert_forced(admission);
+                    }
+                    (Some(replaced), None) => {
+                        guard.release(replaced.hash());
+                    }
+                    (None, Some(admission)) => {
+                        if let Err(rejection) = guard.try_admit(admission) {
+                            let hash = insert.outcome.hash;
+                            drop(guard);
+                            let removed = self.sidecars[pool_index]
+                                .remove_transactions(&[hash], RemovalReason::Discarded);
+                            listeners.on_discarded(&removed);
+                            return Err(Self::limit_rejection_error(hash, rejection));
+                        }
+                    }
+                    (None, None) => {}
+                }
+                drop(guard);
+                listeners.on_sidecar_inserted(&insert);
+                Ok(insert.outcome)
+            }
+            TransactionValidationOutcome::Invalid(transaction, error) => {
+                Err(reth_transaction_pool::error::PoolError::new(
+                    *transaction.hash(),
+                    reth_transaction_pool::error::PoolErrorKind::InvalidTransaction(error),
+                ))
+            }
+            TransactionValidationOutcome::Error(hash, error) => {
+                Err(reth_transaction_pool::error::PoolError::other(hash, error.to_string()))
+            }
+        }
     }
 
     fn limit_rejection_error(
@@ -284,6 +401,7 @@ where
         if dropped.is_empty() {
             return Vec::new();
         }
+        let (registered, dropped) = self.drain_registered_sidecar_hashes(dropped);
         let (protocol_hashes, sidecar_hashes) = self.partition_hashes_by_pool(dropped);
         let mut removed = if protocol_hashes.is_empty() {
             Vec::new()
@@ -297,6 +415,12 @@ where
             }
             removed.extend(sidecar_removed);
         }
+        let registered_removed =
+            self.remove_from_registered_sidecars(registered, RemovalReason::Discarded);
+        if !registered_removed.is_empty() {
+            self.listeners.write().on_discarded(&registered_removed);
+        }
+        removed.extend(registered_removed);
         removed
     }
 
@@ -342,7 +466,11 @@ where
         let nonce_pool = self.nonce_pool.read();
         let stale: Vec<_> = tracked
             .into_iter()
-            .filter(|hash| self.protocol_pool.get(hash).is_none() && !nonce_pool.contains(hash))
+            .filter(|hash| {
+                self.protocol_pool.get(hash).is_none()
+                    && !nonce_pool.contains(hash)
+                    && self.sidecar_owning(hash).is_none()
+            })
             .collect();
         drop(nonce_pool);
         if stale.is_empty() {
@@ -356,7 +484,11 @@ where
         let nonce_pool = self.nonce_pool.read();
         let stale: Vec<_> = stale
             .into_iter()
-            .filter(|hash| self.protocol_pool.get(hash).is_none() && !nonce_pool.contains(hash))
+            .filter(|hash| {
+                self.protocol_pool.get(hash).is_none()
+                    && !nonce_pool.contains(hash)
+                    && self.sidecar_owning(hash).is_none()
+            })
             .collect();
         drop(nonce_pool);
         if stale.is_empty() {
@@ -669,6 +801,31 @@ where
         }
     }
 
+    fn merged_best(
+        &self,
+        protocol: Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<T>>>>,
+        base_fee: u64,
+    ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<T>>>> {
+        let mut merged: Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<T>>>> =
+            Box::new(MergeBestTransactions::new(
+                protocol,
+                Box::new(self.nonce_pool.read().best_transactions(self.ordering.clone(), base_fee)),
+                self.ordering.clone(),
+                base_fee,
+            ));
+        for sidecar in self.sidecars.iter() {
+            let claims = Arc::clone(sidecar);
+            merged = Box::new(MergeBestTransactions::with_discriminator(
+                merged,
+                sidecar.best_transactions(base_fee),
+                Box::new(move |tx: &T| claims.claims(tx)),
+                self.ordering.clone(),
+                base_fee,
+            ));
+        }
+        merged
+    }
+
     fn merged_pending_listener(&self, kind: TransactionListenerKind) -> mpsc::Receiver<TxHash> {
         let protocol = self.protocol_pool.pending_transactions_listener_for(kind);
         let sidecar = self.listeners.write().subscribe_pending(kind);
@@ -758,6 +915,16 @@ where
         size.queued += queued;
         size.queued_size += queued_size;
         size.total += pending + queued;
+        for sidecar in self.sidecars.iter() {
+            let (p, q) = sidecar.pending_and_queued_txn_count();
+            size.pending += p;
+            size.queued += q;
+            size.total += p + q;
+            size.pending_size +=
+                sidecar.pending_transactions().iter().map(|tx| tx.encoded_length()).sum::<usize>();
+            size.queued_size +=
+                sidecar.queued_transactions().iter().map(|tx| tx.encoded_length()).sum::<usize>();
+        }
         size
     }
 
@@ -770,6 +937,17 @@ where
         origin: TransactionOrigin,
         transaction: Self::Transaction,
     ) -> PoolResult<TransactionEvents> {
+        if let Some(index) = self.sidecars.iter().position(|pool| pool.claims(&transaction)) {
+            let hash = *transaction.hash();
+            let (events, listener) = self.listeners.write().subscribe_hash(hash);
+            if let Err(error) =
+                self.add_registered_sidecar_transaction(index, origin, transaction).await
+            {
+                self.listeners.write().unsubscribe_hash_listener(&hash, &listener);
+                return Err(error);
+            }
+            return Ok(events);
+        }
         if !self.is_sidecar_transaction(&transaction) {
             let hash = *transaction.hash();
             let sender = transaction.sender();
@@ -807,6 +985,9 @@ where
         origin: TransactionOrigin,
         transaction: Self::Transaction,
     ) -> PoolResult<AddedTransactionOutcome> {
+        if let Some(index) = self.sidecars.iter().position(|pool| pool.claims(&transaction)) {
+            return self.add_registered_sidecar_transaction(index, origin, transaction).await;
+        }
         if self.is_sidecar_transaction(&transaction) {
             self.add_sidecar_transaction(origin, transaction).await
         } else {
@@ -842,12 +1023,18 @@ where
     }
 
     fn transaction_event_listener(&self, tx_hash: TxHash) -> Option<TransactionEvents> {
-        self.protocol_pool.transaction_event_listener(tx_hash).or_else(|| {
-            self.nonce_pool
-                .read()
-                .contains(&tx_hash)
-                .then(|| self.listeners.write().subscribe_hash(tx_hash).0)
-        })
+        self.protocol_pool
+            .transaction_event_listener(tx_hash)
+            .or_else(|| {
+                self.nonce_pool
+                    .read()
+                    .contains(&tx_hash)
+                    .then(|| self.listeners.write().subscribe_hash(tx_hash).0)
+            })
+            .or_else(|| {
+                self.sidecar_owning(&tx_hash)
+                    .map(|_| self.listeners.write().subscribe_hash(tx_hash).0)
+            })
     }
 
     fn all_transactions_event_listener(&self) -> AllTransactionsEvents<Self::Transaction> {
@@ -882,6 +1069,15 @@ where
                 .filter(|transaction| transaction.propagate)
                 .map(|transaction| *transaction.hash()),
         );
+        for sidecar in self.sidecars.iter() {
+            hashes.extend(
+                sidecar
+                    .all_transactions()
+                    .into_iter()
+                    .filter(|transaction| transaction.propagate)
+                    .map(|transaction| *transaction.hash()),
+            );
+        }
         hashes
     }
 
@@ -896,7 +1092,18 @@ where
             if transaction.propagate {
                 hashes.push(*transaction.hash());
                 if hashes.len() >= max {
-                    break;
+                    return hashes;
+                }
+            }
+        }
+        drop(nonce_pool);
+        for sidecar in self.sidecars.iter() {
+            for transaction in sidecar.all_transactions() {
+                if transaction.propagate {
+                    hashes.push(*transaction.hash());
+                    if hashes.len() >= max {
+                        return hashes;
+                    }
                 }
             }
         }
@@ -912,6 +1119,11 @@ where
                 .into_iter()
                 .filter(|transaction| transaction.propagate),
         );
+        for sidecar in self.sidecars.iter() {
+            transactions.extend(
+                sidecar.all_transactions().into_iter().filter(|transaction| transaction.propagate),
+            );
+        }
         transactions
     }
 
@@ -929,7 +1141,18 @@ where
             if transaction.propagate {
                 transactions.push(transaction);
                 if transactions.len() >= max {
-                    break;
+                    return transactions;
+                }
+            }
+        }
+        drop(nonce_pool);
+        for sidecar in self.sidecars.iter() {
+            for transaction in sidecar.all_transactions() {
+                if transaction.propagate {
+                    transactions.push(transaction);
+                    if transactions.len() >= max {
+                        return transactions;
+                    }
                 }
             }
         }
@@ -966,7 +1189,12 @@ where
                 continue;
             }
 
-            let Some(transaction) = self.nonce_pool.read().get(hash) else {
+            let Some(transaction) = self
+                .nonce_pool
+                .read()
+                .get(hash)
+                .or_else(|| self.sidecar_owning(hash).and_then(|pool| pool.get(hash)))
+            else {
                 continue;
             };
             let Some((pooled, encoded_length)) = pooled_element(&transaction) else {
@@ -988,6 +1216,7 @@ where
             self.nonce_pool
                 .read()
                 .get(&tx_hash)
+                .or_else(|| self.sidecar_owning(&tx_hash).and_then(|pool| pool.get(&tx_hash)))
                 .and_then(|transaction| transaction.transaction.clone().try_into_pooled().ok())
         })
     }
@@ -1001,12 +1230,10 @@ where
             block_info.pending_blob_fee.map(|fee| u64::try_from(fee).unwrap_or(u64::MAX)),
         );
         let base_fee = best_transactions_attributes.basefee;
-        Box::new(MergeBestTransactions::new(
+        self.merged_best(
             self.protocol_pool.best_transactions_with_attributes(best_transactions_attributes),
-            Box::new(self.nonce_pool.read().best_transactions(self.ordering.clone(), base_fee)),
-            self.ordering.clone(),
             base_fee,
-        ))
+        )
     }
 
     fn best_transactions_with_attributes(
@@ -1014,17 +1241,18 @@ where
         best_transactions_attributes: BestTransactionsAttributes,
     ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<Self::Transaction>>>> {
         let base_fee = best_transactions_attributes.basefee;
-        Box::new(MergeBestTransactions::new(
+        self.merged_best(
             self.protocol_pool.best_transactions_with_attributes(best_transactions_attributes),
-            Box::new(self.nonce_pool.read().best_transactions(self.ordering.clone(), base_fee)),
-            self.ordering.clone(),
             base_fee,
-        ))
+        )
     }
 
     fn pending_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         let mut transactions = self.protocol_pool.pending_transactions();
         transactions.extend(self.nonce_pool.read().pending_transactions());
+        for sidecar in self.sidecars.iter() {
+            transactions.extend(sidecar.pending_transactions());
+        }
         transactions
     }
 
@@ -1051,12 +1279,22 @@ where
         let remaining = max - transactions.len();
         transactions
             .extend(self.nonce_pool.read().pending_transactions().into_iter().take(remaining));
+        for sidecar in self.sidecars.iter() {
+            if transactions.len() >= max {
+                break;
+            }
+            let remaining = max - transactions.len();
+            transactions.extend(sidecar.pending_transactions().into_iter().take(remaining));
+        }
         transactions
     }
 
     fn queued_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         let mut transactions = self.protocol_pool.queued_transactions();
         transactions.extend(self.nonce_pool.read().queued_transactions());
+        for sidecar in self.sidecars.iter() {
+            transactions.extend(sidecar.queued_transactions());
+        }
         transactions
     }
 
@@ -1064,7 +1302,14 @@ where
         let (pending, queued) = self.protocol_pool.pending_and_queued_txn_count();
         let (sidecar_pending, sidecar_queued) =
             self.nonce_pool.read().pending_and_queued_txn_count();
-        (pending + sidecar_pending, queued + sidecar_queued)
+        let mut pending = pending + sidecar_pending;
+        let mut queued = queued + sidecar_queued;
+        for sidecar in self.sidecars.iter() {
+            let (p, q) = sidecar.pending_and_queued_txn_count();
+            pending += p;
+            queued += q;
+        }
+        (pending, queued)
     }
 
     fn all_transactions(&self) -> AllPoolTransactions<Self::Transaction> {
@@ -1072,12 +1317,20 @@ where
         let nonce_pool = self.nonce_pool.read();
         transactions.pending.extend(nonce_pool.pending_transactions());
         transactions.queued.extend(nonce_pool.queued_transactions());
+        drop(nonce_pool);
+        for sidecar in self.sidecars.iter() {
+            transactions.pending.extend(sidecar.pending_transactions());
+            transactions.queued.extend(sidecar.queued_transactions());
+        }
         transactions
     }
 
     fn all_transaction_hashes(&self) -> Vec<TxHash> {
         let mut hashes = self.protocol_pool.all_transaction_hashes();
         hashes.extend(self.nonce_pool.read().all_hashes());
+        for sidecar in self.sidecars.iter() {
+            hashes.extend(sidecar.all_hashes());
+        }
         hashes
     }
 
@@ -1085,6 +1338,7 @@ where
         &self,
         hashes: Vec<TxHash>,
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        let (registered, hashes) = self.drain_registered_sidecar_hashes(hashes);
         let (protocol_hashes, sidecar_hashes) = self.partition_hashes_by_pool(hashes);
         let mut removed = self.protocol_pool.remove_transactions(protocol_hashes);
         self.release_from_guard(&removed);
@@ -1094,6 +1348,13 @@ where
         }
         self.release_from_guard(&sidecar_removed);
         removed.extend(sidecar_removed);
+        let registered_removed =
+            self.remove_from_registered_sidecars(registered, RemovalReason::Discarded);
+        if !registered_removed.is_empty() {
+            self.listeners.write().on_discarded(&registered_removed);
+        }
+        self.release_from_guard(&registered_removed);
+        removed.extend(registered_removed);
         removed
     }
 
@@ -1101,6 +1362,7 @@ where
         &self,
         hashes: Vec<TxHash>,
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        let (registered, hashes) = self.drain_registered_sidecar_hashes(hashes);
         let (protocol_hashes, sidecar_hashes) = self.partition_hashes_by_pool(hashes);
         let mut removed = self.protocol_pool.remove_transactions_and_descendants(protocol_hashes);
         self.release_from_guard(&removed);
@@ -1111,6 +1373,19 @@ where
         }
         self.release_from_guard(&sidecar_removed);
         removed.extend(sidecar_removed);
+        let mut registered_removed = Vec::new();
+        for (index, pool) in self.sidecars.iter().enumerate() {
+            let hashes: Vec<_> =
+                registered.iter().filter(|(i, _)| *i == index).map(|(_, h)| *h).collect();
+            if !hashes.is_empty() {
+                registered_removed.extend(pool.remove_transactions_and_descendants(&hashes));
+            }
+        }
+        if !registered_removed.is_empty() {
+            self.listeners.write().on_discarded(&registered_removed);
+        }
+        self.release_from_guard(&registered_removed);
+        removed.extend(registered_removed);
         removed
     }
 
@@ -1126,6 +1401,15 @@ where
         }
         self.release_from_guard(&sidecar_removed);
         removed.extend(sidecar_removed);
+        let mut registered_removed = Vec::new();
+        for pool in self.sidecars.iter() {
+            registered_removed.extend(pool.remove_transactions_by_sender(sender));
+        }
+        if !registered_removed.is_empty() {
+            self.listeners.write().on_discarded(&registered_removed);
+        }
+        self.release_from_guard(&registered_removed);
+        removed.extend(registered_removed);
         removed
     }
 
@@ -1133,12 +1417,17 @@ where
         &self,
         hashes: Vec<TxHash>,
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        let (registered, hashes) = self.drain_registered_sidecar_hashes(hashes);
         let (protocol_hashes, sidecar_hashes) = self.partition_hashes_by_pool(hashes);
         let mut removed = self.protocol_pool.prune_transactions(protocol_hashes);
         self.release_from_guard(&removed);
         let pruned = self.nonce_pool.write().prune_mined(&sidecar_hashes);
         self.release_from_guard(&pruned.removed);
         removed.extend(pruned.removed);
+        let registered_removed =
+            self.remove_from_registered_sidecars(registered, RemovalReason::Mined);
+        self.release_from_guard(&registered_removed);
+        removed.extend(registered_removed);
         removed
     }
 
@@ -1153,6 +1442,11 @@ where
 
         let nonce_pool = self.nonce_pool.read();
         announcement.retain_by_hash(|hash| !nonce_pool.contains(hash));
+        drop(nonce_pool);
+        if announcement.is_empty() || self.sidecars.is_empty() {
+            return;
+        }
+        announcement.retain_by_hash(|hash| self.sidecar_owning(hash).is_none());
     }
 
     fn retain_contains<A>(&self, announcement: &mut A)
@@ -1161,25 +1455,40 @@ where
     {
         let nonce_pool = self.nonce_pool.read();
         announcement.retain_by_hash(|hash| {
-            self.protocol_pool.get(hash).is_some() || nonce_pool.contains(hash)
+            self.protocol_pool.get(hash).is_some()
+                || nonce_pool.contains(hash)
+                || self.sidecar_owning(hash).is_some()
         });
     }
 
     fn get(&self, tx_hash: &TxHash) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>> {
-        self.protocol_pool.get(tx_hash).or_else(|| self.nonce_pool.read().get(tx_hash))
+        self.protocol_pool
+            .get(tx_hash)
+            .or_else(|| self.nonce_pool.read().get(tx_hash))
+            .or_else(|| self.sidecar_owning(tx_hash).and_then(|pool| pool.get(tx_hash)))
     }
 
     fn get_all(&self, txs: Vec<TxHash>) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         let nonce_pool = self.nonce_pool.read();
         txs.into_iter()
-            .filter_map(|tx| self.protocol_pool.get(&tx).or_else(|| nonce_pool.get(&tx)))
+            .filter_map(|tx| {
+                self.protocol_pool
+                    .get(&tx)
+                    .or_else(|| nonce_pool.get(&tx))
+                    .or_else(|| self.sidecar_owning(&tx).and_then(|pool| pool.get(&tx)))
+            })
             .collect()
     }
 
     fn on_propagated(&self, txs: PropagatedTransactions) {
         let nonce_pool = self.nonce_pool.read();
         let protocol_txs = PropagatedTransactions(
-            txs.0.into_iter().filter(|(hash, _)| !nonce_pool.contains(hash)).collect(),
+            txs.0
+                .into_iter()
+                .filter(|(hash, _)| {
+                    !nonce_pool.contains(hash) && self.sidecar_owning(hash).is_none()
+                })
+                .collect(),
         );
         drop(nonce_pool);
         self.protocol_pool.on_propagated(protocol_txs)
@@ -1191,6 +1500,9 @@ where
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         let mut transactions = self.protocol_pool.get_transactions_by_sender(sender);
         transactions.extend(self.nonce_pool.read().transactions_by_sender(sender));
+        for sidecar in self.sidecars.iter() {
+            transactions.extend(sidecar.transactions_by_sender(sender));
+        }
         transactions
     }
 
@@ -1207,6 +1519,14 @@ where
                 .into_iter()
                 .filter(|transaction| predicate(transaction)),
         );
+        for sidecar in self.sidecars.iter() {
+            transactions.extend(
+                sidecar
+                    .pending_transactions()
+                    .into_iter()
+                    .filter(|transaction| predicate(transaction)),
+            );
+        }
         transactions
     }
 
@@ -1216,6 +1536,9 @@ where
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         let mut transactions = self.protocol_pool.get_pending_transactions_by_sender(sender);
         transactions.extend(self.nonce_pool.read().pending_transactions_by_sender(sender));
+        for sidecar in self.sidecars.iter() {
+            transactions.extend(sidecar.pending_transactions_by_sender(sender));
+        }
         transactions
     }
 
@@ -1225,6 +1548,9 @@ where
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         let mut transactions = self.protocol_pool.get_queued_transactions_by_sender(sender);
         transactions.extend(self.nonce_pool.read().queued_transactions_by_sender(sender));
+        for sidecar in self.sidecars.iter() {
+            transactions.extend(sidecar.queued_transactions_by_sender(sender));
+        }
         transactions
     }
 
@@ -1263,6 +1589,14 @@ where
                 .into_iter()
                 .filter(|transaction| transaction.origin == origin),
         );
+        for sidecar in self.sidecars.iter() {
+            transactions.extend(
+                sidecar
+                    .all_transactions()
+                    .into_iter()
+                    .filter(|transaction| transaction.origin == origin),
+            );
+        }
         transactions
     }
 
@@ -1278,6 +1612,14 @@ where
                 .into_iter()
                 .filter(|transaction| transaction.origin == origin),
         );
+        for sidecar in self.sidecars.iter() {
+            transactions.extend(
+                sidecar
+                    .pending_transactions()
+                    .into_iter()
+                    .filter(|transaction| transaction.origin == origin),
+            );
+        }
         transactions
     }
 
@@ -1285,6 +1627,11 @@ where
         let mut senders = self.protocol_pool.unique_senders();
         for sender in self.nonce_pool.read().unique_senders() {
             senders.insert(sender);
+        }
+        for sidecar in self.sidecars.iter() {
+            for sender in sidecar.unique_senders() {
+                senders.insert(sender);
+            }
         }
         senders
     }
@@ -1402,6 +1749,22 @@ where
             }
             for transaction in &expired {
                 guard.release(transaction.hash());
+            }
+        }
+        if !self.sidecars.is_empty() {
+            let mut listeners = self.listeners.write();
+            let mut guard = self.guard.write();
+            for sidecar in self.sidecars.iter() {
+                let (mined, discarded) = sidecar.on_canonical_state_change(&mined_transactions, now);
+                if !mined.is_empty() {
+                    listeners.on_mined(&mined, block_hash);
+                }
+                if !discarded.is_empty() {
+                    listeners.on_discarded(&discarded);
+                }
+                for transaction in mined.iter().chain(discarded.iter()) {
+                    guard.release(transaction.hash());
+                }
             }
         }
         self.expire_due_buckets(now);
@@ -1561,6 +1924,33 @@ impl<T: BasePooledTx> SidecarListeners<T> {
         }
 
         for promoted in &outcome.promoted {
+            self.broadcast_pending_transaction(promoted);
+        }
+    }
+
+    fn on_sidecar_inserted(&mut self, insert: &SidecarInsert<T>) {
+        let hash = insert.outcome.hash;
+        if let Some(replaced) = &insert.replaced {
+            self.broadcast_hash_event(replaced.hash(), TransactionEvent::Replaced(hash));
+            self.broadcast_all(FullTransactionEvent::Replaced {
+                transaction: Arc::clone(replaced),
+                replaced_by: hash,
+            });
+        }
+        match &insert.outcome.state {
+            AddedTransactionState::Pending => {
+                self.broadcast_pending_transaction(&insert.inserted);
+            }
+            AddedTransactionState::Queued(reason) => {
+                self.broadcast_hash_event(&hash, TransactionEvent::Queued);
+                self.broadcast_all(FullTransactionEvent::Queued(hash, Some(reason.clone())));
+                self.broadcast_new(NewTransactionEvent {
+                    subpool: SubPool::Queued,
+                    transaction: Arc::clone(&insert.inserted),
+                });
+            }
+        }
+        for promoted in &insert.promoted {
             self.broadcast_pending_transaction(promoted);
         }
     }

--- a/crates/execution/txpool/src/pool.rs
+++ b/crates/execution/txpool/src/pool.rs
@@ -227,10 +227,6 @@ where
         transaction.is_eip8130_sidecar_transaction()
     }
 
-    fn sidecar_for(&self, transaction: &T) -> Option<&Arc<dyn SidecarPool<T>>> {
-        self.sidecars.iter().find(|pool| pool.claims(transaction))
-    }
-
     fn sidecar_owning(&self, hash: &TxHash) -> Option<&Arc<dyn SidecarPool<T>>> {
         self.sidecars.iter().find(|pool| pool.contains(hash))
     }
@@ -280,7 +276,11 @@ where
         let validated = self.validator().validate_transaction(origin, transaction).await;
         match validated {
             TransactionValidationOutcome::Valid {
-                transaction, propagate, authorities, state_nonce, ..
+                transaction,
+                propagate,
+                authorities,
+                state_nonce,
+                ..
             } => {
                 let validated = {
                     let mut nonce_pool = self.nonce_pool.write();
@@ -1755,7 +1755,8 @@ where
             let mut listeners = self.listeners.write();
             let mut guard = self.guard.write();
             for sidecar in self.sidecars.iter() {
-                let (mined, discarded) = sidecar.on_canonical_state_change(&mined_transactions, now);
+                let (mined, discarded) =
+                    sidecar.on_canonical_state_change(&mined_transactions, now);
                 if !mined.is_empty() {
                     listeners.on_mined(&mined, block_hash);
                 }

--- a/crates/execution/txpool/src/pool.rs
+++ b/crates/execution/txpool/src/pool.rs
@@ -227,6 +227,13 @@ where
         transaction.is_eip8130_sidecar_transaction()
     }
 
+    /// The registered sidecar holding `hash`, if any.
+    ///
+    /// Linear in the number of registered sidecars, and called from the membership hot paths
+    /// (`get`, `retain_unknown`, `on_propagated`, and once per tracked hash in
+    /// `reconcile_guard`). That is deliberate: sidecars are a handful of statically-registered
+    /// pools, one per node extension, not a per-transaction collection. If that ever stops being
+    /// true this wants a hash-to-pool index instead.
     fn sidecar_owning(&self, hash: &TxHash) -> Option<&Arc<dyn SidecarPool<T>>> {
         self.sidecars.iter().find(|pool| pool.contains(hash))
     }
@@ -307,11 +314,15 @@ where
                     }
                     (None, Some(admission)) => {
                         if let Err(rejection) = guard.try_admit(admission) {
+                            // Both locks go before the rollback: `remove_transactions` is
+                            // out-of-tree code, and holding `listeners` across it would deadlock
+                            // any implementation that reaches back into the pool.
                             let hash = insert.outcome.hash;
                             drop(guard);
+                            drop(listeners);
                             let removed = self.sidecars[pool_index]
                                 .remove_transactions(&[hash], RemovalReason::Discarded);
-                            listeners.on_discarded(&removed);
+                            self.listeners.write().on_discarded(&removed);
                             return Err(Self::limit_rejection_error(hash, rejection));
                         }
                     }
@@ -920,10 +931,9 @@ where
             size.pending += p;
             size.queued += q;
             size.total += p + q;
-            size.pending_size +=
-                sidecar.pending_transactions().iter().map(|tx| tx.encoded_length()).sum::<usize>();
-            size.queued_size +=
-                sidecar.queued_transactions().iter().map(|tx| tx.encoded_length()).sum::<usize>();
+            let (pending_size, queued_size) = sidecar.pending_and_queued_size();
+            size.pending_size += pending_size;
+            size.queued_size += queued_size;
         }
         size
     }
@@ -1427,6 +1437,11 @@ where
         let registered_removed =
             self.remove_from_registered_sidecars(registered, RemovalReason::Mined);
         self.release_from_guard(&registered_removed);
+        // No `on_mined` here, matching the `nonce_pool` line above: `on_mined` needs the block
+        // hash the transactions landed in, and this trait method is not given one. A subscriber
+        // from `add_transaction_and_subscribe` therefore sees no terminal event on this path —
+        // pre-existing for the 2D nonce pool and inherited by sidecars. The normal mined route,
+        // `on_canonical_state_change`, does have the block hash and does fire the event.
         removed.extend(registered_removed);
         removed
     }
@@ -1752,16 +1767,23 @@ where
             }
         }
         if !self.sidecars.is_empty() {
+            // Sidecar implementations are out-of-tree, so their maintenance runs with no pool
+            // lock held: a slow or reentrant one would otherwise stall every reader of
+            // `listeners` and `guard` for the duration of its callback. Results are collected
+            // first, then dispatched under the locks in one pass.
+            let outcomes = self
+                .sidecars
+                .iter()
+                .map(|sidecar| sidecar.on_canonical_state_change(&mined_transactions, now))
+                .collect::<Vec<_>>();
             let mut listeners = self.listeners.write();
             let mut guard = self.guard.write();
-            for sidecar in self.sidecars.iter() {
-                let (mined, discarded) =
-                    sidecar.on_canonical_state_change(&mined_transactions, now);
+            for (mined, discarded) in &outcomes {
                 if !mined.is_empty() {
-                    listeners.on_mined(&mined, block_hash);
+                    listeners.on_mined(mined, block_hash);
                 }
                 if !discarded.is_empty() {
-                    listeners.on_discarded(&discarded);
+                    listeners.on_discarded(discarded);
                 }
                 for transaction in mined.iter().chain(discarded.iter()) {
                     guard.release(transaction.hash());

--- a/crates/execution/txpool/src/sidecar_pool.rs
+++ b/crates/execution/txpool/src/sidecar_pool.rs
@@ -1,0 +1,110 @@
+//! SPIKE ONLY: generic pluggable sidecar sub-pool seam.
+
+use std::sync::Arc;
+
+use alloy_primitives::{Address, TxHash};
+use reth_transaction_pool::{
+    AddedTransactionOutcome, BestTransactions, PoolResult, TransactionOrigin, ValidPoolTransaction,
+};
+
+use crate::BasePooledTx;
+
+/// Why a sidecar pool is being asked to drop transactions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemovalReason {
+    /// The transactions became canonical.
+    Mined,
+    /// The transactions are being discarded.
+    Discarded,
+}
+
+/// Result of a sidecar insertion.
+#[derive(Debug)]
+pub struct SidecarInsert<T: BasePooledTx> {
+    /// reth-shaped outcome (hash + pending/queued state).
+    pub outcome: AddedTransactionOutcome,
+    /// Transaction evicted by a replacement, if any.
+    pub replaced: Option<Arc<ValidPoolTransaction<T>>>,
+    /// Transactions promoted from queued to pending by this insertion.
+    pub promoted: Vec<Arc<ValidPoolTransaction<T>>>,
+    /// The inserted transaction as stored.
+    pub inserted: Arc<ValidPoolTransaction<T>>,
+}
+
+/// An out-of-tree transaction sub-pool that participates in the base pool.
+pub trait SidecarPool<T: BasePooledTx>: Send + Sync + std::fmt::Debug + 'static {
+    /// Stable identifier used for metrics labels.
+    fn name(&self) -> &'static str;
+
+    /// Whether this pool owns `transaction`.
+    fn claims(&self, transaction: &T) -> bool;
+
+    /// Inserts an already-validated transaction. Takes ownership so the pool can
+    /// mint its own `TransactionId`.
+    fn insert_validated(
+        &self,
+        origin: TransactionOrigin,
+        transaction: ValidPoolTransaction<T>,
+        state_nonce: u64,
+    ) -> PoolResult<SidecarInsert<T>>;
+
+    /// Owning snapshot iterator; must not hold an internal lock across yields.
+    fn best_transactions(
+        &self,
+        base_fee: u64,
+    ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<T>>>>;
+
+    fn contains(&self, hash: &TxHash) -> bool;
+    fn get(&self, hash: &TxHash) -> Option<Arc<ValidPoolTransaction<T>>>;
+    fn all_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T>>>;
+    fn pending_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T>>>;
+    fn queued_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T>>>;
+    fn pending_and_queued_txn_count(&self) -> (usize, usize);
+    fn all_hashes(&self) -> Vec<TxHash>;
+
+    fn remove_transactions(
+        &self,
+        hashes: &[TxHash],
+        reason: RemovalReason,
+    ) -> Vec<Arc<ValidPoolTransaction<T>>>;
+
+    fn remove_transactions_and_descendants(
+        &self,
+        hashes: &[TxHash],
+    ) -> Vec<Arc<ValidPoolTransaction<T>>> {
+        self.remove_transactions(hashes, RemovalReason::Discarded)
+    }
+
+    fn remove_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<T>>>;
+
+    /// Per-block maintenance. Returns `(mined, discarded)`.
+    fn on_canonical_state_change(
+        &self,
+        _mined: &[TxHash],
+        _block_timestamp_secs: u64,
+    ) -> (Vec<Arc<ValidPoolTransaction<T>>>, Vec<Arc<ValidPoolTransaction<T>>>) {
+        (Vec::new(), Vec::new())
+    }
+
+    fn transactions_by_sender(&self, _sender: Address) -> Vec<Arc<ValidPoolTransaction<T>>> {
+        Vec::new()
+    }
+    fn pending_transactions_by_sender(
+        &self,
+        _sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<T>>> {
+        Vec::new()
+    }
+    fn queued_transactions_by_sender(
+        &self,
+        _sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<T>>> {
+        Vec::new()
+    }
+    fn unique_senders(&self) -> Vec<Address> {
+        Vec::new()
+    }
+}

--- a/crates/execution/txpool/src/sidecar_pool.rs
+++ b/crates/execution/txpool/src/sidecar_pool.rs
@@ -1,4 +1,20 @@
-//! SPIKE ONLY: generic pluggable sidecar sub-pool seam.
+//! A generic, pluggable sidecar sub-pool seam.
+//!
+//! [`SidecarPool`] lets a crate outside this one contribute an extra sub-pool to
+//! [`BaseTransactionPool`](crate::BaseTransactionPool), alongside the protocol pool and the 2D
+//! nonce pool. The host keeps validation, listener broadcast, and the EIP-8130 admission guard;
+//! the sidecar owns storage and its own internal ordering.
+//!
+//! # Implementor contract
+//!
+//! - **Locking.** Every method is called with no pool lock held, and must not call back into the
+//!   pool that owns it. The host's own order, where it takes more than one, is `nonce_pool` →
+//!   `listeners` → `guard`.
+//! - **Claiming.** [`SidecarPool::claims`] must be stable for a given transaction and must not
+//!   overlap another registered sidecar; the first claimant in registration order wins.
+//! - **Account nonces.** The sender-query methods default to empty. Leave them that way unless
+//!   your transactions genuinely occupy the sender's account-nonce sequence — see
+//!   [`SidecarPool::transactions_by_sender`].
 
 use std::sync::Arc;
 
@@ -70,6 +86,19 @@ pub trait SidecarPool<T: BasePooledTx>: Send + Sync + std::fmt::Debug + 'static 
     fn queued_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T>>>;
     /// `(pending, queued)` counts, for the pool-status RPCs.
     fn pending_and_queued_txn_count(&self) -> (usize, usize);
+
+    /// `(pending, queued)` encoded byte totals, for the pool-status RPCs.
+    ///
+    /// Called from [`TransactionPool::pool_size`](reth_transaction_pool::TransactionPool), which
+    /// serves metrics and RPC, so it runs often. The default materializes both transaction
+    /// vectors just to sum their lengths; override it with a cached or otherwise `O(1)` figure if
+    /// your pool can, and the two allocations disappear from that path.
+    fn pending_and_queued_size(&self) -> (usize, usize) {
+        let pending =
+            self.pending_transactions().iter().map(|tx| tx.encoded_length()).sum::<usize>();
+        let queued = self.queued_transactions().iter().map(|tx| tx.encoded_length()).sum::<usize>();
+        (pending, queued)
+    }
     /// The hashes of every transaction this pool holds.
     fn all_hashes(&self) -> Vec<TxHash>;
 
@@ -98,6 +127,12 @@ pub trait SidecarPool<T: BasePooledTx>: Send + Sync + std::fmt::Debug + 'static 
     fn remove_transactions_by_sender(&self, sender: Address) -> Vec<Arc<ValidPoolTransaction<T>>>;
 
     /// Per-block maintenance. Returns `(mined, discarded)`.
+    ///
+    /// Defaults to evicting nothing, which is only correct for a pool that expires its own
+    /// entries some other way. A pool that returns empty here and never prunes elsewhere grows
+    /// without bound: nothing else drops its transactions when they are mined or go stale.
+    /// The returned transactions are what the host reports to listeners and releases from the
+    /// admission guard, so omitting a transaction here also leaks its guard slot.
     fn on_canonical_state_change(
         &self,
         _mined: &[TxHash],

--- a/crates/execution/txpool/src/sidecar_pool.rs
+++ b/crates/execution/txpool/src/sidecar_pool.rs
@@ -34,9 +34,18 @@ use crate::BasePooledTx;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RemovalReason {
     /// The transactions became canonical.
+    ///
+    /// A pool sequencing transactions per sender should advance its cursor for these, and only
+    /// these — a discard leaves the sequence where it was.
     Mined,
     /// The transactions are being discarded without being mined.
     Discarded,
+    /// As [`Self::Discarded`], and also drop anything their removal leaves un-includable.
+    ///
+    /// A pool whose transactions depend on one another — a per-sender nonce sequence, say — must
+    /// also evict the dependents. A pool with no such dependencies treats this exactly as
+    /// [`Self::Discarded`].
+    DiscardedWithDescendants,
 }
 
 /// A validated transaction being handed to a sidecar for storage.
@@ -55,6 +64,12 @@ pub struct SidecarAdmission<T: BasePooledTx> {
     pub propagate: bool,
     /// EIP-7702 authorities recovered during validation, if any.
     pub authorities: Option<Vec<Address>>,
+    /// The sender's on-chain nonce as of validation.
+    ///
+    /// A pool that sequences transactions per sender needs this to anchor its cursor, and to
+    /// re-anchor it after a reorg moves the account backwards. Pools keyed on anything other than
+    /// account nonces ignore it.
+    pub state_nonce: u64,
 }
 
 /// Result of a sidecar insertion.

--- a/crates/execution/txpool/src/sidecar_pool.rs
+++ b/crates/execution/txpool/src/sidecar_pool.rs
@@ -31,6 +31,10 @@ pub struct SidecarInsert<T: BasePooledTx> {
     pub inserted: Arc<ValidPoolTransaction<T>>,
 }
 
+/// The `(mined, discarded)` split a sidecar pool reports back from per-block maintenance.
+pub type CanonicalStateOutcome<T> =
+    (Vec<Arc<ValidPoolTransaction<T>>>, Vec<Arc<ValidPoolTransaction<T>>>);
+
 /// An out-of-tree transaction sub-pool that participates in the base pool.
 pub trait SidecarPool<T: BasePooledTx>: Send + Sync + std::fmt::Debug + 'static {
     /// Stable identifier used for metrics labels.
@@ -54,20 +58,35 @@ pub trait SidecarPool<T: BasePooledTx>: Send + Sync + std::fmt::Debug + 'static 
         base_fee: u64,
     ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<T>>>>;
 
+    /// Whether this pool holds a transaction with `hash`.
     fn contains(&self, hash: &TxHash) -> bool;
+    /// The transaction with `hash`, if this pool holds it.
     fn get(&self, hash: &TxHash) -> Option<Arc<ValidPoolTransaction<T>>>;
+    /// Every transaction this pool holds, pending and queued alike.
     fn all_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T>>>;
+    /// The transactions currently eligible for inclusion.
     fn pending_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T>>>;
+    /// The transactions held back until some precondition is met.
     fn queued_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T>>>;
+    /// `(pending, queued)` counts, for the pool-status RPCs.
     fn pending_and_queued_txn_count(&self) -> (usize, usize);
+    /// The hashes of every transaction this pool holds.
     fn all_hashes(&self) -> Vec<TxHash>;
 
+    /// Drops the named transactions, returning those actually removed.
+    ///
+    /// `reason` distinguishes inclusion from discard: an implementor tracking a per-sender
+    /// sequence should only advance it for [`RemovalReason::Mined`].
     fn remove_transactions(
         &self,
         hashes: &[TxHash],
         reason: RemovalReason,
     ) -> Vec<Arc<ValidPoolTransaction<T>>>;
 
+    /// Drops the named transactions plus anything their removal leaves un-includable.
+    ///
+    /// Defaults to a plain discard, which is correct for a pool whose transactions carry no
+    /// dependency on one another.
     fn remove_transactions_and_descendants(
         &self,
         hashes: &[TxHash],
@@ -75,35 +94,40 @@ pub trait SidecarPool<T: BasePooledTx>: Send + Sync + std::fmt::Debug + 'static 
         self.remove_transactions(hashes, RemovalReason::Discarded)
     }
 
-    fn remove_transactions_by_sender(
-        &self,
-        sender: Address,
-    ) -> Vec<Arc<ValidPoolTransaction<T>>>;
+    /// Drops every transaction from `sender`, returning those removed.
+    fn remove_transactions_by_sender(&self, sender: Address) -> Vec<Arc<ValidPoolTransaction<T>>>;
 
     /// Per-block maintenance. Returns `(mined, discarded)`.
     fn on_canonical_state_change(
         &self,
         _mined: &[TxHash],
         _block_timestamp_secs: u64,
-    ) -> (Vec<Arc<ValidPoolTransaction<T>>>, Vec<Arc<ValidPoolTransaction<T>>>) {
+    ) -> CanonicalStateOutcome<T> {
         (Vec::new(), Vec::new())
     }
 
+    /// This pool's contribution to the account-nonce query surface for `sender`.
+    ///
+    /// Defaults to empty, which is the safe answer: a pool whose transactions live in a
+    /// namespace disjoint from account nonces must not appear here, or `eth_getTransactionCount`
+    /// will double-count. Override only if your transactions genuinely occupy the sender's
+    /// account-nonce sequence.
     fn transactions_by_sender(&self, _sender: Address) -> Vec<Arc<ValidPoolTransaction<T>>> {
         Vec::new()
     }
+    /// The pending subset of [`transactions_by_sender`](Self::transactions_by_sender).
     fn pending_transactions_by_sender(
         &self,
         _sender: Address,
     ) -> Vec<Arc<ValidPoolTransaction<T>>> {
         Vec::new()
     }
-    fn queued_transactions_by_sender(
-        &self,
-        _sender: Address,
-    ) -> Vec<Arc<ValidPoolTransaction<T>>> {
+    /// The queued subset of [`transactions_by_sender`](Self::transactions_by_sender).
+    fn queued_transactions_by_sender(&self, _sender: Address) -> Vec<Arc<ValidPoolTransaction<T>>> {
         Vec::new()
     }
+    /// Every sender this pool holds a transaction for. Same opt-in caveat as
+    /// [`transactions_by_sender`](Self::transactions_by_sender).
     fn unique_senders(&self) -> Vec<Address> {
         Vec::new()
     }

--- a/crates/execution/txpool/src/sidecar_pool.rs
+++ b/crates/execution/txpool/src/sidecar_pool.rs
@@ -3,7 +3,7 @@
 //! [`SidecarPool`] lets a crate outside this one contribute an extra sub-pool to
 //! [`BaseTransactionPool`](crate::BaseTransactionPool), alongside the protocol pool and the 2D
 //! nonce pool. The host keeps validation, listener broadcast, and the EIP-8130 admission guard;
-//! the sidecar owns storage and its own internal ordering.
+//! the sidecar owns its storage, its identifiers, and its internal ordering.
 //!
 //! # Implementor contract
 //!
@@ -12,15 +12,20 @@
 //!   `listeners` → `guard`.
 //! - **Claiming.** [`SidecarPool::claims`] must be stable for a given transaction and must not
 //!   overlap another registered sidecar; the first claimant in registration order wins.
-//! - **Account nonces.** The sender-query methods default to empty. Leave them that way unless
-//!   your transactions genuinely occupy the sender's account-nonce sequence — see
-//!   [`SidecarPool::transactions_by_sender`].
+//! - **Ordering.** [`SidecarPool::best_transactions`] must yield this pool's own best transaction
+//!   first, respecting whatever internal dependencies it has. The host merges the arms by
+//!   comparing their heads, so a pool orders its own transactions however it likes; it does not
+//!   need to know, and cannot see, the host's ordering.
+//! - **Eviction.** Nothing else drops a sidecar's transactions. A pool that never returns anything
+//!   from [`SidecarPool::on_canonical_state_change`] and never prunes internally grows unbounded,
+//!   and leaks an admission-guard slot per transaction.
 
 use std::sync::Arc;
 
 use alloy_primitives::{Address, TxHash};
 use reth_transaction_pool::{
     AddedTransactionOutcome, BestTransactions, PoolResult, TransactionOrigin, ValidPoolTransaction,
+    validate::ValidTransaction,
 };
 
 use crate::BasePooledTx;
@@ -30,8 +35,26 @@ use crate::BasePooledTx;
 pub enum RemovalReason {
     /// The transactions became canonical.
     Mined,
-    /// The transactions are being discarded.
+    /// The transactions are being discarded without being mined.
     Discarded,
+}
+
+/// A validated transaction being handed to a sidecar for storage.
+///
+/// The host does *not* build a [`ValidPoolTransaction`] first. Doing so would mean minting a
+/// `TransactionId` out of a sender interner the sidecar is then told to ignore — which both
+/// wasted the work and accumulated an entry per sender that nothing could ever free. The sidecar
+/// owns its identifier space, so it builds the stored form itself.
+#[derive(Debug)]
+pub struct SidecarAdmission<T: BasePooledTx> {
+    /// Where the transaction came from.
+    pub origin: TransactionOrigin,
+    /// The validated transaction, still carrying its blob sidecar if it had one.
+    pub transaction: ValidTransaction<T>,
+    /// Whether the transaction may be gossiped.
+    pub propagate: bool,
+    /// EIP-7702 authorities recovered during validation, if any.
+    pub authorities: Option<Vec<Address>>,
 }
 
 /// Result of a sidecar insertion.
@@ -47,60 +70,60 @@ pub struct SidecarInsert<T: BasePooledTx> {
     pub inserted: Arc<ValidPoolTransaction<T>>,
 }
 
+/// A sidecar pool's contribution to [`TransactionPool::pool_size`].
+///
+/// [`TransactionPool::pool_size`]: reth_transaction_pool::TransactionPool::pool_size
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct SidecarPoolSize {
+    /// Number of transactions eligible for inclusion.
+    pub pending: usize,
+    /// Encoded byte total of the pending transactions.
+    pub pending_size: usize,
+    /// Number of transactions held back.
+    pub queued: usize,
+    /// Encoded byte total of the queued transactions.
+    pub queued_size: usize,
+}
+
 /// The `(mined, discarded)` split a sidecar pool reports back from per-block maintenance.
 pub type CanonicalStateOutcome<T> =
     (Vec<Arc<ValidPoolTransaction<T>>>, Vec<Arc<ValidPoolTransaction<T>>>);
 
 /// An out-of-tree transaction sub-pool that participates in the base pool.
+///
+/// Deliberately small. Everything the host can compute from these methods — membership,
+/// enumeration, per-sender views, counts, removal by sender — it computes, rather than asking
+/// each implementor to reimplement it.
 pub trait SidecarPool<T: BasePooledTx>: Send + Sync + std::fmt::Debug + 'static {
-    /// Stable identifier used for metrics labels.
+    /// Stable identifier, used for metrics labels and diagnostics.
     fn name(&self) -> &'static str;
 
     /// Whether this pool owns `transaction`.
+    ///
+    /// Decides routing at admission and is consulted again to attribute a transaction back to
+    /// this pool, so it must not depend on whether the transaction is currently stored.
     fn claims(&self, transaction: &T) -> bool;
 
-    /// Inserts an already-validated transaction. Takes ownership so the pool can
-    /// mint its own `TransactionId`.
-    fn insert_validated(
-        &self,
-        origin: TransactionOrigin,
-        transaction: ValidPoolTransaction<T>,
-        state_nonce: u64,
-    ) -> PoolResult<SidecarInsert<T>>;
+    /// Stores a validated transaction, minting whatever identifier this pool's storage needs.
+    fn insert(&self, admission: SidecarAdmission<T>) -> PoolResult<SidecarInsert<T>>;
 
-    /// Owning snapshot iterator; must not hold an internal lock across yields.
+    /// An owning snapshot of this pool's transactions in its own preferred order, best first.
+    ///
+    /// Must not hold an internal lock across yields. See the ordering note in the module docs:
+    /// the host merges arms by comparing heads, so this pool's order is respected as-is.
     fn best_transactions(
         &self,
         base_fee: u64,
     ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<T>>>>;
 
-    /// Whether this pool holds a transaction with `hash`.
-    fn contains(&self, hash: &TxHash) -> bool;
     /// The transaction with `hash`, if this pool holds it.
     fn get(&self, hash: &TxHash) -> Option<Arc<ValidPoolTransaction<T>>>;
-    /// Every transaction this pool holds, pending and queued alike.
-    fn all_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T>>>;
+
     /// The transactions currently eligible for inclusion.
     fn pending_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T>>>;
+
     /// The transactions held back until some precondition is met.
     fn queued_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T>>>;
-    /// `(pending, queued)` counts, for the pool-status RPCs.
-    fn pending_and_queued_txn_count(&self) -> (usize, usize);
-
-    /// `(pending, queued)` encoded byte totals, for the pool-status RPCs.
-    ///
-    /// Called from [`TransactionPool::pool_size`](reth_transaction_pool::TransactionPool), which
-    /// serves metrics and RPC, so it runs often. The default materializes both transaction
-    /// vectors just to sum their lengths; override it with a cached or otherwise `O(1)` figure if
-    /// your pool can, and the two allocations disappear from that path.
-    fn pending_and_queued_size(&self) -> (usize, usize) {
-        let pending =
-            self.pending_transactions().iter().map(|tx| tx.encoded_length()).sum::<usize>();
-        let queued = self.queued_transactions().iter().map(|tx| tx.encoded_length()).sum::<usize>();
-        (pending, queued)
-    }
-    /// The hashes of every transaction this pool holds.
-    fn all_hashes(&self) -> Vec<TxHash>;
 
     /// Drops the named transactions, returning those actually removed.
     ///
@@ -112,58 +135,31 @@ pub trait SidecarPool<T: BasePooledTx>: Send + Sync + std::fmt::Debug + 'static 
         reason: RemovalReason,
     ) -> Vec<Arc<ValidPoolTransaction<T>>>;
 
-    /// Drops the named transactions plus anything their removal leaves un-includable.
+    /// Counts and byte totals, for the pool-status RPCs and metrics.
     ///
-    /// Defaults to a plain discard, which is correct for a pool whose transactions carry no
-    /// dependency on one another.
-    fn remove_transactions_and_descendants(
-        &self,
-        hashes: &[TxHash],
-    ) -> Vec<Arc<ValidPoolTransaction<T>>> {
-        self.remove_transactions(hashes, RemovalReason::Discarded)
+    /// The default materializes both transaction vectors just to measure them, and runs on a path
+    /// that serves metrics and RPC. Override it if this pool can answer in `O(1)`.
+    fn size(&self) -> SidecarPoolSize {
+        let pending = self.pending_transactions();
+        let queued = self.queued_transactions();
+        SidecarPoolSize {
+            pending: pending.len(),
+            pending_size: pending.iter().map(|tx| tx.encoded_length()).sum(),
+            queued: queued.len(),
+            queued_size: queued.iter().map(|tx| tx.encoded_length()).sum(),
+        }
     }
-
-    /// Drops every transaction from `sender`, returning those removed.
-    fn remove_transactions_by_sender(&self, sender: Address) -> Vec<Arc<ValidPoolTransaction<T>>>;
 
     /// Per-block maintenance. Returns `(mined, discarded)`.
     ///
-    /// Defaults to evicting nothing, which is only correct for a pool that expires its own
-    /// entries some other way. A pool that returns empty here and never prunes elsewhere grows
-    /// without bound: nothing else drops its transactions when they are mined or go stale.
     /// The returned transactions are what the host reports to listeners and releases from the
-    /// admission guard, so omitting a transaction here also leaks its guard slot.
+    /// admission guard, so a transaction dropped internally but omitted here leaks its guard slot.
+    /// Defaulting to empty is only correct for a pool that never needs to evict.
     fn on_canonical_state_change(
         &self,
         _mined: &[TxHash],
         _block_timestamp_secs: u64,
     ) -> CanonicalStateOutcome<T> {
         (Vec::new(), Vec::new())
-    }
-
-    /// This pool's contribution to the account-nonce query surface for `sender`.
-    ///
-    /// Defaults to empty, which is the safe answer: a pool whose transactions live in a
-    /// namespace disjoint from account nonces must not appear here, or `eth_getTransactionCount`
-    /// will double-count. Override only if your transactions genuinely occupy the sender's
-    /// account-nonce sequence.
-    fn transactions_by_sender(&self, _sender: Address) -> Vec<Arc<ValidPoolTransaction<T>>> {
-        Vec::new()
-    }
-    /// The pending subset of [`transactions_by_sender`](Self::transactions_by_sender).
-    fn pending_transactions_by_sender(
-        &self,
-        _sender: Address,
-    ) -> Vec<Arc<ValidPoolTransaction<T>>> {
-        Vec::new()
-    }
-    /// The queued subset of [`transactions_by_sender`](Self::transactions_by_sender).
-    fn queued_transactions_by_sender(&self, _sender: Address) -> Vec<Arc<ValidPoolTransaction<T>>> {
-        Vec::new()
-    }
-    /// Every sender this pool holds a transaction for. Same opt-in caveat as
-    /// [`transactions_by_sender`](Self::transactions_by_sender).
-    fn unique_senders(&self) -> Vec<Address> {
-        Vec::new()
     }
 }


### PR DESCRIPTION
## Summary

This adds a public `SidecarPool<T>` trait so a crate outside `base-execution-txpool` can contribute its own transaction sub-pool to `BaseTransactionPool`, participating in admission, best-transactions ordering, membership queries, removal, and per-block maintenance. The host keeps validation, listener broadcast, and the EIP-8130 admission guard; the sidecar owns its storage, its identifiers, and its internal ordering, and decides which transactions it owns via `claims`. `BaseTransactionPool` gains a `sidecars` field and a `with_sidecar_pools` builder, `MergeBestTransactions` gains a `with_discriminator` constructor so merges nest instead of needing an N-way rewrite, and pools are collected from node extensions before the extension fold consumes them so one registration point covers both the mempool-node and builder roles.

The trait is 8 required methods plus 2 defaulted. Everything the host can derive from those it derives rather than asking each implementor to reimplement: membership from `get`, enumeration and per-sender views by filtering pending/queued, counts and byte totals from a single `size()`, removal-by-sender from a filter plus `remove_transactions`. A sidecar orders its own transactions however it likes — the host merges arms by comparing heads, so it does not need to know the host's ordering.

The seam defaults to an empty `Vec` and every added path is guarded on that, so behaviour is unchanged when nothing is registered. The registered-sidecar admission path takes `protocol_admission_lock` and performs the limit-class staleness recheck, matching every other guard-mutating path, and every trait method is called with no pool *data* lock held so an out-of-tree implementation cannot deadlock the host.

`TwoDNoncePool` is untouched by this PR and continues to run on its own concrete path; nothing about EIP-8130 behaviour changes. The trait is nonetheless sized to be able to host it — `SidecarAdmission::state_nonce` and `RemovalReason::DiscardedWithDescendants` exist because a pool that sequences per sender needs to anchor a cursor and to evict dependents, and a seam that cannot express the pool it was extracted from is not a general seam.

## Tests

213 in `base-execution-txpool`, 3 in `base-node-runner`. Nine of those are new and exercise the seam against `TestSidecar`, a sidecar that actually stores transactions: claim routing, unclaimed passthrough, merged best-transactions, the aggregate and per-sender queries, `pool_size`, removal by hash, removal by sender, the `RemovalReason` distinction, and `state_nonce` delivery. An earlier revision of this PR had no test that constructed a non-empty `sidecars` vector at all, which left every sidecar branch unreachable.

## Still open

Reimplementing `TwoDNoncePool` on top of the trait is the acceptance test that would prove the abstraction mechanically rather than by inspection, and it is not done. Two capability gaps found by inspection during review — the two named above — are exactly what that exercise would have caught on its own.

The limit-class staleness rollback is untested on both the sidecar and the existing nonce-pool path; neither has coverage today.

This deliberately contains no product logic: no advanced-transaction or PRISM-specific behaviour, and no in-tree consumer.