### PR TITLE
feat(txpool): make the builder wire transaction type pluggable

### DIFF
--- a/crates/builder/core/tests/rpc.rs
+++ b/crates/builder/core/tests/rpc.rs
@@ -6,7 +6,7 @@ use alloy_primitives::{Address, Bytes, Signature, TxKind, U256};
 use alloy_rpc_client::RpcClient;
 use base_builder_core::BuilderApiExtension;
 use base_common_consensus::{BaseTransactionSigned, BaseTypedTransaction, TxDeposit};
-use base_execution_txpool::ValidatedTransaction;
+use base_execution_txpool::{NoExtensions, ValidatedTransaction};
 use base_node_runner::test_utils::TestHarness;
 use base_test_utils::Account;
 
@@ -69,6 +69,7 @@ async fn test_insert_validated_deposit_tx() -> eyre::Result<()> {
         max_block_number: None,
         min_timestamp: None,
         max_timestamp: None,
+        extensions: NoExtensions {},
     };
 
     let result: Result<(), _> =
@@ -99,6 +100,7 @@ async fn test_insert_validated_eip1559_tx() -> eyre::Result<()> {
         max_block_number: None,
         min_timestamp: None,
         max_timestamp: None,
+        extensions: NoExtensions {},
     };
 
     // EIP-1559 transactions are supported by the pool
@@ -122,6 +124,7 @@ async fn test_insert_invalid_tx_fails() -> eyre::Result<()> {
         max_block_number: None,
         min_timestamp: None,
         max_timestamp: None,
+        extensions: NoExtensions {},
     };
 
     let result: Result<(), _> =

--- a/crates/execution/txpool/README.md
+++ b/crates/execution/txpool/README.md
@@ -10,6 +10,44 @@ Extends Reth's transaction pool with Base-specific validation and ordering for t
 Also includes a `Consumer` for processing mempool events, a `Forwarder` for relaying transactions,
 and a `BuilderApiImpl` for builder-specific pool management.
 
+### Pluggable builder wire format
+
+`ValidatedTransaction<E>` is the payload of `base_insertValidatedTransaction`, the endpoint mempool
+nodes use to forward transactions to a builder. `E` carries additional wire fields and defaults to
+`NoExtensions`, which encodes to exactly the same bytes as a struct without the field at all — so
+the default is wire-compatible in both directions with peers that predate the parameter.
+
+Downstream node builds substitute their own payload by implementing
+`ValidatedTransactionExtensions<T>`, then registering the generic monomorphizations:
+
+```rust,ignore
+use base_execution_txpool::{
+    BuilderApiImpl, BuilderApiServer, ExtensionError, SpawnedForwarder,
+    ValidatedTransactionExtensions,
+};
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+struct MyExtensions {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    my_field: Option<u64>,
+}
+
+impl ValidatedTransactionExtensions<MyPooledTx> for MyExtensions {
+    fn extract(tx: &ValidPoolTransaction<MyPooledTx>) -> Self { /* ... */ }
+    fn apply(self, tx: MyPooledTx) -> Result<MyPooledTx, ExtensionError> { /* ... */ }
+}
+
+// Builder (ingress) side, in place of the stock `BuilderApiExtension`:
+let api = BuilderApiImpl::<_, MyExtensions>::with_extensions(pool);
+modules.merge_configured(api.into_rpc())?;
+
+// Mempool (egress) side, in place of `SpawnedForwarder::spawn`:
+SpawnedForwarder::spawn_with_extensions::<MyPooledTx, MyExtensions>(sender, config, &executor);
+```
+
+Extension payloads must serialize as a JSON map (a braced struct, not a unit struct) and must avoid
+`u128`/`i128` fields, which `serde_json` cannot represent through `#[serde(flatten)]`.
+
 ## Usage
 
 Add the dependency to your `Cargo.toml`:

--- a/crates/execution/txpool/src/builder/metrics.rs
+++ b/crates/execution/txpool/src/builder/metrics.rs
@@ -6,6 +6,8 @@ base_metrics::define_metrics! {
     txs_inserted: counter,
     #[describe("Transactions that failed to decode")]
     decode_errors: counter,
+    #[describe("Transactions whose wire extension data failed to apply")]
+    extension_errors: counter,
     #[describe("Transactions rejected by the pool")]
     #[label(reason)]
     txs_rejected: counter,

--- a/crates/execution/txpool/src/builder/rpc.rs
+++ b/crates/execution/txpool/src/builder/rpc.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use std::{marker::PhantomData, time::Instant};
 
 use alloy_consensus::transaction::Recovered;
 use alloy_eips::Decodable2718;
@@ -17,11 +17,16 @@ use serde_json::{Map, json};
 use tracing::debug;
 
 use super::metrics::Metrics as BuilderApiMetrics;
-use crate::{BasePooledTransaction, PoolRejectionLabel, ValidatedTransaction};
+use crate::{
+    BasePooledTransaction, NoExtensions, PoolRejectionLabel, ValidatedTransaction,
+    ValidatedTransactionExtensions,
+};
 
 /// RPC interface for submitting pre-validated transactions to a block builder.
+///
+/// `E` is the wire extension payload; see [`ValidatedTransactionExtensions`].
 #[rpc(server, namespace = "base")]
-pub trait BuilderApi {
+pub trait BuilderApi<E> {
     /// Inserts a single pre-validated transaction into the builder's pool.
     ///
     /// The transaction is EIP-2718 encoded with its sender address pre-recovered,
@@ -30,7 +35,7 @@ pub trait BuilderApi {
     /// Returns an error if decoding or pool insertion fails.
     /// Use JSON-RPC batch requests for efficient bulk submission.
     #[method(name = "insertValidatedTransaction")]
-    async fn insert_validated_transaction(&self, tx: ValidatedTransaction) -> RpcResult<()>;
+    async fn insert_validated_transaction(&self, tx: ValidatedTransaction<E>) -> RpcResult<()>;
 }
 
 /// Server implementation of [`BuilderApi`] backed by a transaction pool.
@@ -39,23 +44,40 @@ pub trait BuilderApi {
 /// directly into the pool without re-validating signatures, since the sender
 /// addresses are trusted from the forwarding mempool node.
 #[derive(Debug)]
-pub struct BuilderApiImpl<P> {
+pub struct BuilderApiImpl<P, E = NoExtensions> {
     pool: P,
+    _extensions: PhantomData<E>,
 }
 
-impl<P> BuilderApiImpl<P> {
+impl<P> BuilderApiImpl<P, NoExtensions> {
     /// Creates a new handler backed by the given transaction pool.
+    ///
+    /// This constructor is defined only for [`NoExtensions`] so that
+    /// `BuilderApiImpl::new(pool)` resolves without a type annotation. A single
+    /// constructor on the generic impl would leave `E` unconstrained at every
+    /// call site (`E0282`), because type-parameter defaults do not participate
+    /// in inference for associated-function calls.
     pub const fn new(pool: P) -> Self {
-        Self { pool }
+        Self { pool, _extensions: PhantomData }
+    }
+}
+
+impl<P, E> BuilderApiImpl<P, E> {
+    /// Creates a new handler carrying the wire extension payload `E`.
+    ///
+    /// Use as `BuilderApiImpl::<_, MyExtensions>::with_extensions(pool)`.
+    pub const fn with_extensions(pool: P) -> Self {
+        Self { pool, _extensions: PhantomData }
     }
 }
 
 #[async_trait::async_trait]
-impl<P> BuilderApiServer for BuilderApiImpl<P>
+impl<P, E> BuilderApiServer<E> for BuilderApiImpl<P, E>
 where
     P: TransactionPool<Transaction = BasePooledTransaction> + Send + Sync + 'static,
+    E: ValidatedTransactionExtensions<BasePooledTransaction>,
 {
-    async fn insert_validated_transaction(&self, tx: ValidatedTransaction) -> RpcResult<()> {
+    async fn insert_validated_transaction(&self, tx: ValidatedTransaction<E>) -> RpcResult<()> {
         debug!(
             sender = %tx.sender,
             "rpc::insert_validated_transaction"
@@ -82,6 +104,13 @@ where
             tx.min_timestamp,
             tx.max_timestamp,
         );
+
+        // Attach any extension data carried on the wire. This is a no-op for
+        // `NoExtensions`, the default payload.
+        let pool_tx = tx.extensions.apply(pool_tx).map_err(|e| {
+            BuilderApiMetrics::extension_errors().increment(1);
+            ErrorObjectOwned::owned(ErrorCode::InvalidParams.code(), e.to_string(), None::<()>)
+        })?;
 
         // Insert into the pool
         let start = Instant::now();
@@ -121,7 +150,7 @@ where
     }
 }
 
-impl<P> BuilderApiImpl<P> {
+impl<P, E> BuilderApiImpl<P, E> {
     fn emit_validated_insert_event(
         &self,
         event_type: TransactionEventType,
@@ -152,7 +181,7 @@ mod tests {
     use reth_transaction_pool::noop::NoopTransactionPool;
 
     use super::*;
-    use crate::{BasePooledTransaction, ValidatedTransaction};
+    use crate::{BasePooledTransaction, NoExtensions, ValidatedTransaction};
 
     // ==========================================================================
     // Helper functions for creating test transactions
@@ -201,6 +230,104 @@ mod tests {
     }
 
     // ==========================================================================
+    // Wire extension tests
+    // ==========================================================================
+
+    /// Extension payload that records whether `apply` ran, and can be told to
+    /// fail so the handler's error mapping is observable.
+    #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+    struct TestExtensions {
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        reject: Option<bool>,
+    }
+
+    impl ValidatedTransactionExtensions<BasePooledTransaction> for TestExtensions {
+        fn extract(
+            _tx: &reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>,
+        ) -> Self {
+            Self::default()
+        }
+
+        fn apply(
+            self,
+            tx: BasePooledTransaction,
+        ) -> Result<BasePooledTransaction, crate::ExtensionError> {
+            if self.reject == Some(true) {
+                return Err(crate::ExtensionError("rejected by test extension".to_string()));
+            }
+            Ok(tx)
+        }
+    }
+
+    fn extension_handler()
+    -> BuilderApiImpl<NoopTransactionPool<BasePooledTransaction>, TestExtensions> {
+        BuilderApiImpl::<_, TestExtensions>::with_extensions(NoopTransactionPool::<
+            BasePooledTransaction,
+        >::new())
+    }
+
+    #[tokio::test]
+    async fn extension_apply_failure_returns_invalid_params() {
+        let handler = extension_handler();
+        let (sender, raw) = create_eip1559_tx();
+
+        let tx = ValidatedTransaction {
+            sender,
+            raw,
+            min_block_number: None,
+            max_block_number: None,
+            min_timestamp: None,
+            max_timestamp: None,
+            extensions: TestExtensions { reject: Some(true) },
+        };
+
+        let err = handler.insert_validated_transaction(tx).await.unwrap_err();
+        assert_eq!(
+            err.code(),
+            ErrorCode::InvalidParams.code(),
+            "a failing extension must surface as InvalidParams, not reach the pool"
+        );
+        assert!(
+            err.message().contains("rejected by test extension"),
+            "extension error should be propagated: {}",
+            err.message()
+        );
+    }
+
+    #[tokio::test]
+    async fn extension_apply_success_reaches_the_pool() {
+        let handler = extension_handler();
+        let (sender, raw) = create_eip1559_tx();
+
+        let tx = ValidatedTransaction {
+            sender,
+            raw,
+            min_block_number: None,
+            max_block_number: None,
+            min_timestamp: None,
+            max_timestamp: None,
+            extensions: TestExtensions { reject: None },
+        };
+
+        let err = handler.insert_validated_transaction(tx).await.unwrap_err();
+        // The extension passed, so the request got as far as the noop pool,
+        // which rejects everything with an internal error.
+        assert_eq!(
+            err.code(),
+            ErrorCode::InternalError.code(),
+            "a passing extension must fall through to pool insertion"
+        );
+    }
+
+    #[test]
+    fn both_monomorphizations_build_rpc_modules() {
+        // The stock call-site shape must keep working untouched...
+        let _stock = handler().into_rpc();
+        // ...and a custom extension payload must also produce a module.
+        let _custom = extension_handler().into_rpc();
+    }
+
+    // ==========================================================================
     // Decode error tests
     // ==========================================================================
 
@@ -215,6 +342,7 @@ mod tests {
             max_block_number: None,
             min_timestamp: None,
             max_timestamp: None,
+            extensions: NoExtensions {},
         };
 
         let result = handler.insert_validated_transaction(tx).await;
@@ -244,6 +372,7 @@ mod tests {
             max_block_number: None,
             min_timestamp: None,
             max_timestamp: None,
+            extensions: NoExtensions {},
         };
 
         let result = handler.insert_validated_transaction(tx).await;
@@ -272,6 +401,7 @@ mod tests {
             max_block_number: None,
             min_timestamp: None,
             max_timestamp: None,
+            extensions: NoExtensions {},
         };
 
         let result = handler.insert_validated_transaction(tx).await;
@@ -297,6 +427,7 @@ mod tests {
             max_block_number: None,
             min_timestamp: None,
             max_timestamp: None,
+            extensions: NoExtensions {},
         };
 
         let result = handler.insert_validated_transaction(tx).await;
@@ -317,6 +448,7 @@ mod tests {
             max_block_number: None,
             min_timestamp: None,
             max_timestamp: None,
+            extensions: NoExtensions {},
         };
 
         let result = handler.insert_validated_transaction(tx).await;
@@ -338,6 +470,7 @@ mod tests {
             max_block_number: None,
             min_timestamp: None,
             max_timestamp: None,
+            extensions: NoExtensions {},
         };
 
         let result = handler.insert_validated_transaction(tx).await;
@@ -357,6 +490,7 @@ mod tests {
             max_block_number: None,
             min_timestamp: None,
             max_timestamp: None,
+            extensions: NoExtensions {},
         };
 
         let result = handler.insert_validated_transaction(tx).await;

--- a/crates/execution/txpool/src/forwarder/mod.rs
+++ b/crates/execution/txpool/src/forwarder/mod.rs
@@ -9,7 +9,7 @@ use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
-use crate::transaction::BundleTransaction;
+use crate::{NoExtensions, ValidatedTransactionExtensions, transaction::BundleTransaction};
 
 mod config;
 pub use config::ForwarderConfig;
@@ -34,6 +34,10 @@ pub struct SpawnedForwarder {
 impl SpawnedForwarder {
     /// Spawns one forwarder async task per builder URL, each subscribing to
     /// the given broadcast sender.
+    ///
+    /// Uses the default wire format, without extension fields. Generic
+    /// parameters cannot carry defaults on a function, so the extension-aware
+    /// variant is a separate method: [`Self::spawn_with_extensions`].
     pub fn spawn<T>(
         sender: &broadcast::Sender<Arc<ValidPoolTransaction<T>>>,
         config: ForwarderConfig,
@@ -42,6 +46,21 @@ impl SpawnedForwarder {
     where
         T: PoolTransaction + BundleTransaction + 'static,
         <T as PoolTransaction>::Consensus: alloy_eips::Encodable2718,
+    {
+        Self::spawn_with_extensions::<T, NoExtensions>(sender, config, executor)
+    }
+
+    /// Spawns one forwarder async task per builder URL, each relaying the wire
+    /// extension payload `E` alongside every transaction.
+    pub fn spawn_with_extensions<T, E>(
+        sender: &broadcast::Sender<Arc<ValidPoolTransaction<T>>>,
+        config: ForwarderConfig,
+        executor: &TaskExecutor,
+    ) -> Self
+    where
+        T: PoolTransaction + BundleTransaction + 'static,
+        <T as PoolTransaction>::Consensus: alloy_eips::Encodable2718,
+        E: ValidatedTransactionExtensions<T>,
     {
         let cancel = CancellationToken::new();
         let mut tasks = Vec::with_capacity(config.builder_urls.len());
@@ -64,7 +83,7 @@ impl SpawnedForwarder {
             };
 
             let receiver = sender.subscribe();
-            let forwarder = Forwarder::new(
+            let forwarder = Forwarder::<T, E>::new(
                 url.clone(),
                 client,
                 receiver,

--- a/crates/execution/txpool/src/forwarder/task.rs
+++ b/crates/execution/txpool/src/forwarder/task.rs
@@ -20,7 +20,10 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, trace, warn};
 
 use super::{config::ForwarderConfig, metrics::ForwarderMetrics};
-use crate::{ValidatedTransaction, transaction::BundleTransaction};
+use crate::{
+    NoExtensions, ValidatedTransaction, ValidatedTransactionExtensions,
+    transaction::BundleTransaction,
+};
 
 /// Sliding window rate limiter that tracks request timestamps.
 ///
@@ -84,7 +87,7 @@ impl RateLimiter {
 /// When the sliding window rate limit (`max_rps`) is hit, incoming
 /// transactions buffer and flush as a single batch (capped at
 /// `max_batch_size`) once the window opens.
-pub struct Forwarder<T: PoolTransaction> {
+pub struct Forwarder<T: PoolTransaction, E = NoExtensions> {
     builder_url: url::Url,
     /// Pre-computed URL label shared cheaply across metric emissions.
     url_label: Arc<str>,
@@ -93,18 +96,19 @@ pub struct Forwarder<T: PoolTransaction> {
     config: Arc<ForwarderConfig>,
     cancel: CancellationToken,
     limiter: RateLimiter,
-    buffer: Vec<BufferedTransaction>,
+    buffer: Vec<BufferedTransaction<E>>,
 }
 
-struct BufferedTransaction {
-    transaction: ValidatedTransaction,
+struct BufferedTransaction<E> {
+    transaction: ValidatedTransaction<E>,
     tx_hash: TxHash,
 }
 
-impl<T> Forwarder<T>
+impl<T, E> Forwarder<T, E>
 where
     T: PoolTransaction + BundleTransaction,
     <T as PoolTransaction>::Consensus: Encodable2718,
+    E: ValidatedTransactionExtensions<T>,
 {
     /// Creates a new forwarder for a single builder endpoint.
     pub fn new(
@@ -196,6 +200,7 @@ where
                         max_block_number,
                         min_timestamp,
                         max_timestamp,
+                        extensions: E::extract(&tx),
                     },
                     tx_hash,
                 });
@@ -236,14 +241,14 @@ where
         } else {
             self.buffer.len().min(self.config.max_batch_size)
         };
-        let buffered: Vec<BufferedTransaction> = self.buffer.drain(..batch_size).collect();
+        let buffered: Vec<BufferedTransaction<E>> = self.buffer.drain(..batch_size).collect();
         ForwarderMetrics::buffer_size(Arc::clone(&self.url_label)).set(self.buffer.len() as f64);
 
         if buffered.is_empty() {
             return;
         }
         let tx_hashes: Vec<TxHash> = buffered.iter().map(|tx| tx.tx_hash).collect();
-        let batch: Vec<ValidatedTransaction> =
+        let batch: Vec<ValidatedTransaction<E>> =
             buffered.into_iter().map(|tx| tx.transaction).collect();
 
         trace!(
@@ -257,7 +262,7 @@ where
         self.limiter.record_send();
     }
 
-    async fn send_with_retries(&self, batch: Vec<ValidatedTransaction>, tx_hashes: Vec<TxHash>) {
+    async fn send_with_retries(&self, batch: Vec<ValidatedTransaction<E>>, tx_hashes: Vec<TxHash>) {
         let tx_count = batch.len() as u64;
         let overall_start = Instant::now();
         for attempt in 0..=self.config.max_retries {
@@ -378,7 +383,7 @@ where
 
     async fn send_batch(
         &self,
-        batch: &[ValidatedTransaction],
+        batch: &[ValidatedTransaction<E>],
     ) -> Result<BatchResponse<'_, ()>, ClientError> {
         let mut request = BatchRequestBuilder::new();
         for tx in batch {
@@ -420,7 +425,7 @@ where
     }
 }
 
-impl<T: PoolTransaction> std::fmt::Debug for Forwarder<T> {
+impl<T: PoolTransaction, E> std::fmt::Debug for Forwarder<T, E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Forwarder")
             .field("builder_url", &self.builder_url)

--- a/crates/execution/txpool/src/lib.rs
+++ b/crates/execution/txpool/src/lib.rs
@@ -64,7 +64,9 @@ pub use bundle::{
 };
 
 mod wire;
-pub use wire::ValidatedTransaction;
+pub use wire::{
+    ExtensionError, NoExtensions, ValidatedTransaction, ValidatedTransactionExtensions,
+};
 
 mod two_d_nonce_pool;
 

--- a/crates/execution/txpool/src/wire.rs
+++ b/crates/execution/txpool/src/wire.rs
@@ -1,12 +1,69 @@
+use core::fmt::Debug;
+
 use alloy_primitives::{Address, Bytes};
-use serde::{Deserialize, Serialize};
+use reth_transaction_pool::{PoolTransaction, ValidPoolTransaction};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+
+/// Default extension payload for [`ValidatedTransaction`], contributing no
+/// additional wire fields.
+///
+/// This must remain a braced empty struct. A unit struct (`struct NoExtensions;`)
+/// serializes to `null`, which `#[serde(flatten)]` rejects at runtime rather than
+/// at compile time.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NoExtensions {}
+
+/// Error returned when applying extension data to a pooled transaction fails.
+#[derive(Debug, thiserror::Error)]
+#[error("failed to apply transaction extensions: {0}")]
+pub struct ExtensionError(pub String);
+
+/// Pluggable extension payload carried alongside a [`ValidatedTransaction`].
+///
+/// `T` is the pooled transaction type the extensions decorate. This crate only
+/// ever names [`NoExtensions`]; downstream node builds substitute their own
+/// payload type to carry additional per-transaction data over the builder RPC.
+///
+/// Implementors are constrained by `#[serde(flatten)]`: the payload must
+/// serialize as a JSON map, and it must not use `u128`/`i128` fields, which
+/// `serde_json` cannot represent through flattening.
+pub trait ValidatedTransactionExtensions<T: PoolTransaction>:
+    Serialize + DeserializeOwned + Debug + Clone + Send + Sync + Unpin + 'static
+{
+    /// Extracts extension data from an outbound pooled transaction.
+    ///
+    /// Called by the forwarder for each transaction it relays to a builder.
+    fn extract(tx: &ValidPoolTransaction<T>) -> Self;
+
+    /// Applies extension data to an inbound pooled transaction.
+    ///
+    /// Called by the builder RPC handler before the transaction is inserted
+    /// into the pool.
+    fn apply(self, tx: T) -> Result<T, ExtensionError>;
+}
+
+impl<T: PoolTransaction> ValidatedTransactionExtensions<T> for NoExtensions {
+    fn extract(_tx: &ValidPoolTransaction<T>) -> Self {
+        Self {}
+    }
+
+    fn apply(self, tx: T) -> Result<T, ExtensionError> {
+        Ok(tx)
+    }
+}
 
 /// Pre-validated transaction for the builder RPC wire format.
 ///
 /// Carries the recovered sender address so the builder can skip signer
 /// recovery, and the EIP-2718 encoded transaction envelope.
+///
+/// The `E` parameter carries additional wire fields, flattened into the
+/// top-level JSON object. It defaults to [`NoExtensions`], which serializes to
+/// exactly the same bytes as a struct without the field at all, so the default
+/// instantiation is wire-compatible in both directions with peers that predate
+/// this parameter.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ValidatedTransaction {
+pub struct ValidatedTransaction<E = NoExtensions> {
     /// Recovered signer address.
     pub sender: Address,
     /// EIP-2718 encoded transaction bytes.
@@ -23,4 +80,162 @@ pub struct ValidatedTransaction {
     /// Milliseconds since Unix epoch.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub max_timestamp: Option<u64>,
+    /// Extension fields, inlined into the top-level JSON object.
+    ///
+    /// Deliberately not `#[serde(default)]`: that would force an `E: Default`
+    /// bound onto the generated `Deserialize` impl. Flattening already handles
+    /// an absent payload, since `E` is deserialized from whatever keys remain.
+    #[serde(flatten)]
+    pub extensions: E,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Mirrors the field layout this type had before `extensions` was added, so
+    /// the tests below can assert byte-identical encoding against it.
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+    struct LegacyValidatedTransaction {
+        sender: Address,
+        raw: Bytes,
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        min_block_number: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        max_block_number: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        min_timestamp: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        max_timestamp: Option<u64>,
+    }
+
+    #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+    struct TestExtensions {
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        extra: Option<u64>,
+    }
+
+    fn sender() -> Address {
+        Address::repeat_byte(0x42)
+    }
+
+    fn raw() -> Bytes {
+        Bytes::from_static(&[0x02, 0xff, 0x00])
+    }
+
+    #[test]
+    fn no_extensions_encoding_matches_legacy_layout() {
+        let legacy = LegacyValidatedTransaction {
+            sender: sender(),
+            raw: raw(),
+            min_block_number: Some(u64::MAX),
+            max_block_number: None,
+            min_timestamp: None,
+            max_timestamp: Some(7),
+        };
+        let current = ValidatedTransaction {
+            sender: sender(),
+            raw: raw(),
+            min_block_number: Some(u64::MAX),
+            max_block_number: None,
+            min_timestamp: None,
+            max_timestamp: Some(7),
+            extensions: NoExtensions {},
+        };
+
+        assert_eq!(
+            serde_json::to_string(&legacy).unwrap(),
+            serde_json::to_string(&current).unwrap(),
+            "default instantiation must be byte-identical to the pre-generic layout"
+        );
+    }
+
+    #[test]
+    fn no_extensions_adds_no_json_fields() {
+        let tx = ValidatedTransaction {
+            sender: sender(),
+            raw: raw(),
+            min_block_number: None,
+            max_block_number: None,
+            min_timestamp: None,
+            max_timestamp: None,
+            extensions: NoExtensions {},
+        };
+
+        let json = serde_json::to_string(&tx).unwrap();
+        assert!(!json.contains("extensions"), "flattened marker must not emit a key: {json}");
+        assert_eq!(
+            json,
+            r#"{"sender":"0x4242424242424242424242424242424242424242","raw":"0x02ff00"}"#
+        );
+    }
+
+    #[test]
+    fn extension_fields_inline_at_top_level() {
+        let tx = ValidatedTransaction {
+            sender: sender(),
+            raw: raw(),
+            min_block_number: None,
+            max_block_number: None,
+            min_timestamp: None,
+            max_timestamp: None,
+            extensions: TestExtensions { extra: Some(9) },
+        };
+
+        let json = serde_json::to_string(&tx).unwrap();
+        assert!(json.contains(r#""extra":9"#), "extension field must be inlined: {json}");
+    }
+
+    #[test]
+    fn default_reader_accepts_payload_carrying_extensions() {
+        let extended = ValidatedTransaction {
+            sender: sender(),
+            raw: raw(),
+            min_block_number: Some(3),
+            max_block_number: None,
+            min_timestamp: None,
+            max_timestamp: None,
+            extensions: TestExtensions { extra: Some(9) },
+        };
+        let json = serde_json::to_string(&extended).unwrap();
+
+        let decoded: ValidatedTransaction = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.sender, sender());
+        assert_eq!(decoded.min_block_number, Some(3));
+        assert_eq!(decoded.extensions, NoExtensions {});
+    }
+
+    #[test]
+    fn extension_reader_accepts_payload_without_extensions() {
+        let legacy = LegacyValidatedTransaction {
+            sender: sender(),
+            raw: raw(),
+            min_block_number: None,
+            max_block_number: None,
+            min_timestamp: None,
+            max_timestamp: None,
+        };
+        let json = serde_json::to_string(&legacy).unwrap();
+
+        let decoded: ValidatedTransaction<TestExtensions> = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.sender, sender());
+        assert_eq!(decoded.extensions, TestExtensions { extra: None });
+    }
+
+    #[test]
+    fn large_u64_survives_flatten_buffering() {
+        let tx = ValidatedTransaction {
+            sender: sender(),
+            raw: raw(),
+            min_block_number: Some(u64::MAX),
+            max_block_number: None,
+            min_timestamp: None,
+            max_timestamp: None,
+            extensions: NoExtensions {},
+        };
+        let json = serde_json::to_string(&tx).unwrap();
+
+        let decoded: ValidatedTransaction = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.min_block_number, Some(u64::MAX));
+    }
 }

--- a/etc/systems/tests/tx_forwarding.rs
+++ b/etc/systems/tests/tx_forwarding.rs
@@ -14,7 +14,7 @@ use alloy_rpc_client::RpcClient;
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use base_common_rpc_types::BaseTransactionRequest;
-use base_execution_txpool::ValidatedTransaction;
+use base_execution_txpool::{NoExtensions, ValidatedTransaction};
 use base_system_tests::{
     ANVIL_ACCOUNT_1, ANVIL_ACCOUNT_2, ANVIL_ACCOUNT_3, ANVIL_ACCOUNT_4, SystemTestStackBuilder,
 };
@@ -111,6 +111,7 @@ async fn test_insert_validated_transaction_single() -> Result<()> {
         max_block_number: None,
         min_timestamp: None,
         max_timestamp: None,
+        extensions: NoExtensions {},
     };
 
     // Create RPC client for the builder


### PR DESCRIPTION
## Motivation

`ValidatedTransaction` is the payload of `base_insertValidatedTransaction`, the endpoint mempool nodes use to forward transactions to a builder. Its shape is fixed, so a downstream node build cannot carry additional per-transaction data over that hop without forking the forwarder (~600 lines, since `RateLimiter` and `BufferedTransaction` are private and would drift permanently).

This adds a seam so the payload type is chosen by whoever assembles the node.

## What changed

`ValidatedTransaction<E = NoExtensions>` gains a flattened extension payload. Downstream builds implement `ValidatedTransactionExtensions<T>` — one method per direction, `extract` on the forwarder side and `apply` on the builder side — and register the generic monomorphizations.

Nothing about any specific extension is named in this crate; it only ever mentions `NoExtensions`.

Threaded through `BuilderApi<E>` / `BuilderApiImpl<P, E = NoExtensions>` and `Forwarder<T, E>` / `SpawnedForwarder::spawn_with_extensions`.

This follows the shape already established by `CandidateSource<T>` + `FlashblocksServiceBuilder<S = DefaultCandidateSource>`: seam trait, defaulted type parameter, existing call sites untouched.

## Wire compatibility

`NoExtensions` encodes to **exactly the same bytes** as the previous layout. `no_extensions_encoding_matches_legacy_layout` asserts this against a struct mirroring the old field list. Both compat directions are covered: an old reader accepts a payload carrying extensions, and an extension-aware reader accepts a payload without them.

## Two non-obvious constraints, documented in-place

- **`new` is defined only on the `NoExtensions` monomorphization.** A single generic constructor leaves `E` unconstrained at every call site (`E0282`) — type-parameter defaults do not drive inference through associated-function calls. `with_extensions` covers the generic case.
- **`spawn` delegates to `spawn_with_extensions`.** Generic parameters cannot carry defaults on a function.

Also: the flattened field is deliberately *not* `#[serde(default)]`, which would force an `E: Default` bound onto the generated `Deserialize` impl and break the `#[rpc]` expansion.

## No call sites changed

`crates/builder/core/src/extension.rs:13` and `etc/systems/src/l2/in_process_builder.rs:155` still read `BuilderApiImpl::new(ctx.pool().clone())` verbatim. `ForwarderConfig` is left non-generic, and the batch send is untouched — it addresses the method by name, so only `Serialize` is required of the payload.

## Testing

- `cargo test -p base-execution-txpool --lib` — 16 passed, 0 failed. 6 new wire tests (encoding, both compat directions, `u64::MAX` through flatten buffering) and 3 new RPC tests proving the hook is *invoked*: a failing extension surfaces as `InvalidParams` before reaching the pool, a passing one falls through to insertion, and both monomorphizations build `RpcModule`s.
- `cargo clippy` clean on `base-execution-txpool`, `base-builder-core`, `base-tx-forwarding`.
- `cargo check --all-targets` clean on those three plus `base-system-tests` and `base-builder-bin`.
- Full-workspace check could not complete locally: `risc0-sys` fails its build script with `xcrun: error: unable to find utility "metal"`. Environmental (no full Xcode), pre-existing, unrelated — `base-execution-txpool` checks clean before it.

## Follow-up, not in this PR

This makes the **wire** type pluggable. For extension data to persist into block building, `BasePooledTransaction` also needs a metadata slot — its fields are private and it has no such slot today. That is a separate change to a type used workspace-wide, and it needs an audit of `crates/execution/payload/src/builder.rs:778`, where `into_consensus()` discards the pooled-transaction wrapper inside the build loop.
