### PR TITLE
test(precompiles): pin announce inner-Panic system-error classification (BOP-477)

### DIFF
--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -506,7 +506,9 @@ mod tests {
     use alloy_primitives::{Address, Bytes, U256};
     use alloy_sol_types::{SolCall, SolError, SolValue};
     use base_common_genesis::BaseUpgrade;
-    use base_precompile_storage::{HashMapStorageProvider, Result, StorageCtx};
+    use base_precompile_storage::{
+        BasePrecompileError, HashMapStorageProvider, Result, StorageCtx,
+    };
 
     use crate::{
         ActivationAdminConfig, ActivationFeature, ActivationRegistryStorage, AssetAccounting,
@@ -709,6 +711,44 @@ mod tests {
         let err = call_asset(&mut token, ALICE, calldata).unwrap_err();
 
         assert_eq!(err, base_precompile_storage::BasePrecompileError::under_overflow());
+    }
+
+    /// Pins the classification predicate the `announce` inner-call loop keys on: every `Panic`
+    /// kind — including the enum-conversion (`0x21`) and array-out-of-bounds (`0x32`) classes —
+    /// plus `OutOfGas`, `Fatal`, and `SlotOverflow` must be a system error and therefore propagate
+    /// unchanged, whereas an ordinary contract revert (and a strict-decode failure) must not.
+    ///
+    /// The one inner-call system error reachable end-to-end is arithmetic overflow
+    /// (`Panic(UnderOverflow)`), pinned by [`announce_inner_system_error_propagates_unchanged`].
+    /// The enum and array-OOB classes have no inner-call selector that reaches them: strict ABI
+    /// decoding rejects an out-of-range enum as `AbiDecodeFailed` (an ordinary revert) before any
+    /// conversion guard runs, and no reachable path produces an array-OOB. Their propagation is
+    /// therefore pinned here at the `is_system_error()` predicate, guarding against a future change
+    /// that would silently reclassify a `Panic` as a wrappable revert.
+    #[test]
+    fn announce_inner_panic_classes_are_system_errors() {
+        for err in [
+            BasePrecompileError::under_overflow(),
+            BasePrecompileError::enum_conversion_error(),
+            BasePrecompileError::array_oob(),
+            BasePrecompileError::assert_failed(),
+            BasePrecompileError::OutOfGas,
+            BasePrecompileError::SlotOverflow,
+            BasePrecompileError::Fatal(String::from("db failure")),
+        ] {
+            assert!(err.is_system_error(), "{err:?} must propagate unchanged from announce");
+        }
+        // An ordinary contract revert wraps as InternalCallFailed rather than propagating.
+        assert!(
+            !BasePrecompileError::revert(IB20Asset::InternalCallFailed { call: Bytes::new() })
+                .is_system_error()
+        );
+        // A strict-decode failure (what an out-of-range enum inner call actually yields on the
+        // native precompile) is likewise not a system error, so it wraps rather than bubbling.
+        assert!(
+            !BasePrecompileError::AbiDecodeFailed { selector: [0u8; 4], error: String::new() }
+                .is_system_error()
+        );
     }
 
     /// A non-system revert produced by an inner `announce` call must be wrapped as

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -713,18 +713,12 @@ mod tests {
         assert_eq!(err, base_precompile_storage::BasePrecompileError::under_overflow());
     }
 
-    /// Pins the classification predicate the `announce` inner-call loop keys on: every `Panic`
-    /// kind — including the enum-conversion (`0x21`) and array-out-of-bounds (`0x32`) classes —
-    /// plus `OutOfGas`, `Fatal`, and `SlotOverflow` must be a system error and therefore propagate
-    /// unchanged, whereas an ordinary contract revert (and a strict-decode failure) must not.
-    ///
-    /// The one inner-call system error reachable end-to-end is arithmetic overflow
-    /// (`Panic(UnderOverflow)`), pinned by [`announce_inner_system_error_propagates_unchanged`].
-    /// The enum and array-OOB classes have no inner-call selector that reaches them: strict ABI
-    /// decoding rejects an out-of-range enum as `AbiDecodeFailed` (an ordinary revert) before any
-    /// conversion guard runs, and no reachable path produces an array-OOB. Their propagation is
-    /// therefore pinned here at the `is_system_error()` predicate, guarding against a future change
-    /// that would silently reclassify a `Panic` as a wrappable revert.
+    /// Arithmetic overflow (`Panic(UnderOverflow)`) is the one inner-call system error reachable
+    /// end-to-end, pinned by [`announce_inner_system_error_propagates_unchanged`]. The enum (`0x21`)
+    /// and array-OOB (`0x32`) classes have no reachable inner-call selector — strict ABI decode
+    /// rejects an out-of-range enum as `AbiDecodeFailed` first — so this pins their propagation at
+    /// the `is_system_error()` predicate `announce` branches on, guarding against a change that
+    /// silently reclassifies a `Panic` as a wrappable revert.
     #[test]
     fn announce_inner_panic_classes_are_system_errors() {
         for err in [
@@ -743,8 +737,7 @@ mod tests {
             !BasePrecompileError::revert(IB20Asset::InternalCallFailed { call: Bytes::new() })
                 .is_system_error()
         );
-        // A strict-decode failure (what an out-of-range enum inner call actually yields on the
-        // native precompile) is likewise not a system error, so it wraps rather than bubbling.
+        // A strict-decode failure (what an out-of-range enum inner call actually yields) also wraps.
         assert!(
             !BasePrecompileError::AbiDecodeFailed { selector: [0u8; 4], error: String::new() }
                 .is_system_error()


### PR DESCRIPTION
## Summary

Test-only companion to base-std [#185](https://github.com/base/base-std/pull/185) (BOP-477). **No behavior change** — the Rust precompile is authoritative and unchanged.

Extends the b20-asset `announce` self-pin (alongside `announce_inner_system_error_propagates_unchanged`) with `announce_inner_panic_classes_are_system_errors`, which pins that every `Panic` kind — including enum-conversion (`0x21`) and array-out-of-bounds (`0x32`) — plus `OutOfGas`, `Fatal`, and `SlotOverflow` classify as system errors via `is_system_error()`, the predicate the announce inner-call loop branches on to propagate a fault raw rather than wrap it as `InternalCallFailed`. An ordinary revert and a strict-decode failure must not.

## Why pin at the predicate (not end-to-end)

The one inner-call system error reachable end-to-end is arithmetic overflow (`Panic(UnderOverflow)`), already pinned by `announce_inner_system_error_propagates_unchanged`. The enum / array-OOB classes have **no inner-call selector that reaches them**: strict ABI decoding rejects an out-of-range enum as `AbiDecodeFailed` (an ordinary revert) before any conversion guard runs, and no reachable path produces an array-OOB. So their propagation is pinned at the `is_system_error()` classification, guarding against a future change that silently reclassifies a `Panic` as a wrappable revert.

## Test plan

- [x] `cargo test -p base-common-precompiles --features test-utils` (684 + golden suites pass)
- [x] `cargo clippy -p base-common-precompiles --features test-utils --all-targets` clean; `cargo fmt --check` clean
- [x] The base-std mock fix is validated against this precompile's live behavior via fork conformance + smoke on an `anvil --base` (Cobalt) node (see #185).

Made with [Cursor](https://cursor.com)