### PR TITLE
ci(fork-tests): pin Cobalt base-std ref to gate composite-policyType → IncompatiblePolicyType (BOP-483)

### DIFF
--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -34,14 +34,10 @@ jobs:
             key: beryl
             base_anvil_ref: 6d744e03224977edd42a36699ba9ff42be25e8cb
             base_std_ref: v1.0.0
-          # Point to the base-std release tag once the Cobalt hardfork is ready; until then, pin the
-          # base-std main SHA that carries the behavior under test.
+          # Point to the base-std release tag once the Cobalt hardfork is ready.
           - fork: Cobalt
             key: cobalt
             base_anvil_ref: ae7557c4f8602caa1da0be33143bb2504c85b0c8
-            # base-std#176 merge commit: createPolicy / createPolicyWithAccounts revert
-            # IncompatiblePolicyType for a composite policyType. The gate runs those tests against
-            # base/base#4210's V2 binary (patched in), regression-locking base/base<->base-std parity.
             base_std_ref: f6522c560e30554a4bf01dccf32a100cbba76eb3
     env:
       FORK_NAME: ${{ matrix.fork }}

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -34,11 +34,15 @@ jobs:
             key: beryl
             base_anvil_ref: 6d744e03224977edd42a36699ba9ff42be25e8cb
             base_std_ref: v1.0.0
-          # Point to the base-std release tag once the Cobalt hardfork is ready.
+          # Point to the base-std release tag once the Cobalt hardfork is ready; until then, pin the
+          # base-std main SHA that carries the behavior under test.
           - fork: Cobalt
             key: cobalt
             base_anvil_ref: ae7557c4f8602caa1da0be33143bb2504c85b0c8
-            base_std_ref: b0a4f048684c4cd279025bf2ba3aa76c45569fa4
+            # base-std#176 merge commit: createPolicy / createPolicyWithAccounts revert
+            # IncompatiblePolicyType for a composite policyType. The gate runs those tests against
+            # base/base#4210's V2 binary (patched in), regression-locking base/base<->base-std parity.
+            base_std_ref: f6522c560e30554a4bf01dccf32a100cbba76eb3
     env:
       FORK_NAME: ${{ matrix.fork }}
       FORK_KEY: ${{ matrix.key }}


### PR DESCRIPTION
## Purpose

Make the **Cobalt fork-conformance gate actually exercise** the fix from #4210 (BOP-476): `createPolicy` / `createPolicyWithAccounts` revert `IncompatiblePolicyType` for a composite `policyType` at V2.

That behavior is currently **unexercised across repos**. The gate `[patch]`es the current base/base into the pinned base-anvil and runs a pinned **base-std** suite against the live Rust precompile — but the Cobalt entry still points at an old base-std (#173) whose `MockPolicyRegistry` has no composite guard and which never sends a composite discriminant to the simple-policy constructors. So #4210's revert has no cross-repo regression lock: a future break in base/base would slip through the Cobalt gate.

## The change

One line in `.github/workflows/base-std-fork-tests.yml` — bump the **Cobalt** `base_std_ref`:

```diff
-            base_std_ref: b0a4f048684c4cd279025bf2ba3aa76c45569fa4   # base-std#173
+            base_std_ref: f6522c560e30554a4bf01dccf32a100cbba76eb3   # base-std#176 (merged)
```

base-std **#176** ("reject composite policyType in createPolicy / createPolicyWithAccounts", merged) adds `test_createPolicy_revert_incompatiblePolicyType` and `test_createPolicyWithAccounts_revert_incompatiblePolicyType` and runs them in the fork profile (no `livePrecompiles` skip). Pinning to it closes the loop and regression-locks base/base ↔ base-std parity for this behavior.

## Why it's safe / minimal

- **CI-only** — no runtime or consensus code touched; a single matrix line + explanatory comments.
- `base_anvil_ref` unchanged — #4210 alters no install surface, and the pinned Cobalt base-anvil already installs policy V2.
- **Beryl untouched** — V1 is frozen; composite discriminants stay `AbiDecodeFailed` there.
- Interim SHA pin; per the file's own comment this becomes a base-std release tag once Cobalt is tagged.

## Preconditions (met)

- #4210 (BOP-476) is on `main`.
- base-std #176 is merged (`f6522c56`), carrying the tests this pin exercises.

## Verification

- [ ] Cobalt job is green and its output shows `test_createPolicy_revert_incompatiblePolicyType` + `test_createPolicyWithAccounts_revert_incompatiblePolicyType` **ran (not skipped)** against the live binary.
- [ ] Beryl job still green.

Closes BOP-483.