### PR TITLE
fix(devnet): load setup image under Podman buildx

### DIFF
--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -130,7 +130,7 @@ build-image target='base' profile='dev':
 
 # Prepares Docker images needed for system tests
 pull-images:
-    docker build -t devnet-setup:local -f etc/docker/Dockerfile.devnet .
+    docker build --load -t devnet-setup:local -f etc/docker/Dockerfile.devnet .
     docker pull ghcr.io/paradigmxyz/reth:v1.11.4
     docker pull sigp/lighthouse:v8.0.1
 
@@ -157,7 +157,7 @@ _install-nextest:
 
 [private]
 _build-setup-image:
-    docker build -t devnet-setup:local -f etc/docker/Dockerfile.devnet .
+    docker build --load -t devnet-setup:local -f etc/docker/Dockerfile.devnet .
 
 [private]
 _build-rust-images group profile='dev':


### PR DESCRIPTION
Podman's buildx docker-container driver doesn't put docker build results into the local image store unless --load is set, so compose couldn't find devnet-setup:local.

Add `--load` to the setup-image builds.