### PR TITLE
fix(basectl): load expected -c devnet chain ID from rollup config

### DIFF
--- a/crates/infra/basectl/src/commands/p2p.rs
+++ b/crates/infra/basectl/src/commands/p2p.rs
@@ -865,6 +865,7 @@ mod tests {
             flashblocks_ws: Url::parse("ws://127.0.0.1:7111").unwrap(),
             l1_rpc: Url::parse("http://127.0.0.1:9545").unwrap(),
             consensus_node_rpc,
+            chain_id: None,
             prover_rpc: None,
             upgrades: None,
             system_config: Address::ZERO,

--- a/crates/infra/basectl/src/config.rs
+++ b/crates/infra/basectl/src/config.rs
@@ -355,6 +355,13 @@ pub struct MonitoringConfig {
     /// Optional Base consensus node JSON-RPC endpoint URL.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub consensus_node_rpc: Option<Url>,
+    /// Expected L2 chain ID for this config, when known.
+    ///
+    /// Fixed for public presets (`mainnet`/`sepolia`/`zeronet`). For `-c
+    /// devnet`, populated from the live `optimism_rollupConfig` so doctor
+    /// compares against whatever chain ID that stack was started with.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chain_id: Option<u64>,
     /// Optional internal prover-service requester JSON-RPC endpoint URL.
     ///
     /// Used by the `basectl proofs` command group. The built-in presets leave
@@ -512,6 +519,7 @@ struct MonitoringConfigOverride {
     flashblocks_ws: Option<Url>,
     l1_rpc: Option<Url>,
     consensus_node_rpc: Option<Url>,
+    chain_id: Option<u64>,
     prover_rpc: Option<Url>,
     #[serde(alias = "hardforks")]
     upgrades: Option<UpgradeConfig>,
@@ -561,6 +569,7 @@ impl MonitoringConfig {
             flashblocks_ws: Url::parse("wss://mainnet.flashblocks.base.org/ws").unwrap(),
             l1_rpc: Url::parse("https://ethereum-rpc.publicnode.com").unwrap(),
             consensus_node_rpc: None,
+            chain_id: Some(8453),
             prover_rpc: None,
             upgrades: Some(rollup.upgrades),
             system_config: rollup.l1_system_config_address,
@@ -586,6 +595,7 @@ impl MonitoringConfig {
             flashblocks_ws: Url::parse("wss://sepolia.flashblocks.base.org/ws").unwrap(),
             l1_rpc: Url::parse("https://ethereum-sepolia-rpc.publicnode.com").unwrap(),
             consensus_node_rpc: None,
+            chain_id: Some(84532),
             prover_rpc: None,
             upgrades: Some(rollup.upgrades),
             system_config: rollup.l1_system_config_address,
@@ -617,6 +627,8 @@ impl MonitoringConfig {
             flashblocks_ws: Url::parse("ws://localhost:7111").unwrap(),
             l1_rpc: Url::parse("http://localhost:4545").unwrap(),
             consensus_node_rpc: Some(Url::parse("http://localhost:7549").unwrap()),
+            // Populated from optimism_rollupConfig in load_devnet.
+            chain_id: None,
             prover_rpc: None,
             upgrades: None,
             // These will be populated by fetch_rollup_config
@@ -765,6 +777,7 @@ impl MonitoringConfig {
         config.system_config = rollup_config.l1_system_config_address;
         config.batcher_address = rollup_config.genesis.system_config.map(|sc| sc.batcher_address);
         config.upgrades = Some(rollup_config.upgrades);
+        config.chain_id = Some(rollup_config.l2_chain_id.id());
 
         Ok(config)
     }
@@ -792,6 +805,7 @@ impl MonitoringConfig {
             flashblocks_ws: overrides.flashblocks_ws.unwrap_or(base.flashblocks_ws),
             l1_rpc: overrides.l1_rpc.unwrap_or(base.l1_rpc),
             consensus_node_rpc: overrides.consensus_node_rpc.or(base.consensus_node_rpc),
+            chain_id: overrides.chain_id.or(base.chain_id),
             prover_rpc: overrides.prover_rpc.or(base.prover_rpc),
             upgrades: overrides.upgrades.or(base.upgrades),
             system_config: overrides.system_config.unwrap_or(base.system_config),
@@ -878,6 +892,7 @@ mod tests {
         assert_eq!(devnet.l1_rpc.as_str(), "http://localhost:4545/");
         assert!(devnet.consensus_node_rpc.is_some());
         assert_eq!(devnet.consensus_node_rpc.unwrap().as_str(), "http://localhost:7549/");
+        assert_eq!(devnet.chain_id, None);
         let validators = devnet.validators.expect("devnet should include validator/RPC node");
         assert_eq!(validators.len(), 2);
         assert_eq!(validators[0].name, "base-client");

--- a/crates/infra/basectl/src/doctor.rs
+++ b/crates/infra/basectl/src/doctor.rs
@@ -436,8 +436,8 @@ impl Doctor {
     }
 
     fn bootnode_check(live_chain_id: Option<&u64>, config: &MonitoringConfig) -> DoctorCheck {
-        let expected = expected_chain_id(&config.name);
-        let chain = bootnode_chain(&config.name, live_chain_id.copied());
+        let expected = expected_chain_id(config);
+        let chain = bootnode_chain(config, live_chain_id.copied());
         let Some(chain) = chain else {
             return DoctorCheck::new(
                 "bootnode_config",
@@ -498,7 +498,7 @@ impl Doctor {
     }
 
     fn declared_network_check(config: &MonitoringConfig, chain_id: &Result<u64>) -> DoctorCheck {
-        let expected = expected_chain_id(&config.name);
+        let expected = expected_chain_id(config);
         match (expected, chain_id) {
             (_, Err(err)) => DoctorCheck::new(
                 "declared_network",
@@ -1084,18 +1084,20 @@ fn worst_status(statuses: impl IntoIterator<Item = DoctorStatus>) -> DoctorStatu
     }
 }
 
-fn expected_chain_id(network: &str) -> Option<u64> {
-    match network {
+fn expected_chain_id(config: &MonitoringConfig) -> Option<u64> {
+    config.chain_id.or(match config.name.as_str() {
         "mainnet" => Some(8453),
         "sepolia" => Some(84532),
-        "devnet" => Some(1337),
         "zeronet" => Some(763360),
         _ => None,
-    }
+    })
 }
 
-fn bootnode_chain(network: &str, live_chain_id: Option<u64>) -> Option<&'static ChainConfig> {
-    expected_chain_id(network)
+fn bootnode_chain(
+    config: &MonitoringConfig,
+    live_chain_id: Option<u64>,
+) -> Option<&'static ChainConfig> {
+    expected_chain_id(config)
         .and_then(ChainConfig::by_chain_id)
         .or_else(|| live_chain_id.and_then(ChainConfig::by_chain_id))
 }
@@ -1138,10 +1140,10 @@ mod tests {
     use super::{
         Doctor, DoctorCheck, DoctorStatus, DoctorSummary, DoctorThresholds, ElInfoReport,
         ElReachabilityOutcome, ElReachabilityResponse, RethLimits, TelemetryClientError,
-        bootnode_addrs, bootnode_chain, bootnode_layer_summary, classify_ip, peer_count_check,
-        worst_status,
+        bootnode_addrs, bootnode_chain, bootnode_layer_summary, classify_ip, expected_chain_id,
+        peer_count_check, worst_status,
     };
-    use crate::{ElNodeIdentity, ElReachabilityStage};
+    use crate::{ElNodeIdentity, ElReachabilityStage, MonitoringConfig};
 
     #[test]
     fn summary_counts_all_statuses() {
@@ -1297,17 +1299,49 @@ mod tests {
     }
 
     #[test]
+    fn expected_chain_id_prefers_config_field_then_known_names() {
+        assert_eq!(expected_chain_id(&named_config("mainnet", None)), Some(8453));
+        assert_eq!(expected_chain_id(&named_config("sepolia", None)), Some(84532));
+        assert_eq!(expected_chain_id(&named_config("zeronet", None)), Some(763360));
+        // Local regenerating nets have no fixed mapping until rollup load sets chain_id.
+        assert_eq!(expected_chain_id(&named_config("devnet", None)), None);
+        assert_eq!(expected_chain_id(&named_config("devnet", Some(84538453))), Some(84538453));
+        assert_eq!(expected_chain_id(&named_config("custom", None)), None);
+    }
+
+    #[test]
     fn bootnode_chain_prefers_declared_config_over_live_chain_id() {
-        let chain = bootnode_chain("mainnet", Some(84532)).unwrap();
+        let chain = bootnode_chain(&named_config("mainnet", None), Some(84532)).unwrap();
 
         assert_eq!(chain.chain_id, 8453);
     }
 
     #[test]
     fn bootnode_chain_falls_back_to_live_chain_for_unknown_config() {
-        let chain = bootnode_chain("custom", Some(84532)).unwrap();
+        let chain = bootnode_chain(&named_config("custom", None), Some(84532)).unwrap();
 
         assert_eq!(chain.chain_id, 84532);
+    }
+
+    fn named_config(name: &str, chain_id: Option<u64>) -> MonitoringConfig {
+        MonitoringConfig {
+            name: name.to_string(),
+            rpc: Url::parse("http://127.0.0.1:8545").unwrap(),
+            flashblocks_ws: Url::parse("ws://127.0.0.1:7111").unwrap(),
+            l1_rpc: Url::parse("http://127.0.0.1:9545").unwrap(),
+            consensus_node_rpc: None,
+            chain_id,
+            prover_rpc: None,
+            upgrades: None,
+            system_config: alloy_primitives::Address::ZERO,
+            batcher_address: None,
+            l1_blob_target: 14,
+            conductors: None,
+            discovery: None,
+            validators: None,
+            proofs: None,
+            pods: None,
+        }
     }
 
     fn check(status: DoctorStatus) -> DoctorCheck {


### PR DESCRIPTION
## Summary
`basectl -c devnet doctor` hardcoded expected chain ID `1337` (local L1), so `declared_network` always failed against the live HA L2.

Load the expected L2 chain ID from `optimism_rollupConfig` instead and compare that to EL `eth_chainId`.