### PR TITLE
feat(snapshotter): package and upload proofs DB into run directory

### DIFF
--- a/crates/infra/snapshotter/src/config.rs
+++ b/crates/infra/snapshotter/src/config.rs
@@ -130,4 +130,11 @@ pub struct SnapshotterConfig {
     /// S3 secret access key. Required for `manual` config type.
     #[arg(long, env = "SNAPSHOTTER_S3_SECRET_ACCESS_KEY")]
     pub s3_secret_access_key: Option<String>,
+
+    /// Package and upload the proofs database from `{source_datadir}/proofs`.
+    ///
+    /// Temporary rollout gate while proofs snapshot behavior is validated in
+    /// production. Disabled by default.
+    #[arg(long, env = "SNAPSHOTTER_UPLOAD_PROOFS", default_value_t = false)]
+    pub upload_proofs: bool,
 }

--- a/crates/infra/snapshotter/src/lib.rs
+++ b/crates/infra/snapshotter/src/lib.rs
@@ -24,8 +24,8 @@ pub use tip::{RpcTipChecker, TipChecker, TipStatus};
 
 mod snapshot;
 pub use snapshot::{
-    ChunkFilename, ChunkedArchive, ComponentManifest, OutputFileChecksum, SingleArchive,
-    SnapshotGenerator, SnapshotManifest, SnapshotManifestExt,
+    ChunkFilename, ChunkedArchive, ComponentManifest, ManifestGenerationParams, OutputFileChecksum,
+    SingleArchive, SnapshotGenerator, SnapshotManifest, SnapshotManifestExt,
 };
 
 mod upload;

--- a/crates/infra/snapshotter/src/orchestrator.rs
+++ b/crates/infra/snapshotter/src/orchestrator.rs
@@ -195,6 +195,7 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
         let blocks_per_file = self.config.blocks_per_file;
         let remote_for_gen = remote_static_files;
         let previous_chunk_output_files_for_gen = previous_chunk_output_files;
+        let upload_proofs = self.config.upload_proofs;
 
         let files = tokio::task::spawn_blocking(move || {
             SnapshotGenerator::generate_manifest_with_previous_chunk_output_files(
@@ -205,6 +206,7 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
                 blocks_per_file,
                 &remote_for_gen,
                 &previous_chunk_output_files_for_gen,
+                upload_proofs,
             )
         })
         .await

--- a/crates/infra/snapshotter/src/orchestrator.rs
+++ b/crates/infra/snapshotter/src/orchestrator.rs
@@ -12,7 +12,10 @@ use tracing::{error, info, warn};
 use crate::{
     SnapshotterConfig,
     container::ContainerManager,
-    snapshot::{OutputFileChecksum, SnapshotGenerator, SnapshotManifest, SnapshotManifestExt},
+    snapshot::{
+        ManifestGenerationParams, OutputFileChecksum, SnapshotGenerator, SnapshotManifest,
+        SnapshotManifestExt,
+    },
     tip::TipChecker,
     upload::SnapshotUploader,
 };
@@ -198,16 +201,17 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
         let upload_proofs = self.config.upload_proofs;
 
         let files = tokio::task::spawn_blocking(move || {
-            SnapshotGenerator::generate_manifest_with_previous_chunk_output_files(
-                &source_datadir,
-                &output_dir_for_gen,
+            let params = ManifestGenerationParams {
+                source_datadir: &source_datadir,
+                output_dir: &output_dir_for_gen,
                 chain_id,
                 block,
                 blocks_per_file,
-                &remote_for_gen,
-                &previous_chunk_output_files_for_gen,
+                remote_static_files: &remote_for_gen,
+                previous_chunk_output_files: &previous_chunk_output_files_for_gen,
                 upload_proofs,
-            )
+            };
+            SnapshotGenerator::generate_manifest(&params)
         })
         .await
         .context("snapshot generation task panicked")?

--- a/crates/infra/snapshotter/src/snapshot.rs
+++ b/crates/infra/snapshotter/src/snapshot.rs
@@ -1000,10 +1000,8 @@ mod tests {
         let manifest_content =
             std::fs::read_to_string(output.path().join("manifest.json")).unwrap();
         let manifest: SnapshotManifest = serde_json::from_str(&manifest_content).unwrap();
-        let ComponentManifest::Single(proofs) = manifest
-            .components
-            .get("proofs")
-            .expect("manifest should include proofs component")
+        let ComponentManifest::Single(proofs) =
+            manifest.components.get("proofs").expect("manifest should include proofs component")
         else {
             panic!("proofs component should be a Single archive");
         };

--- a/crates/infra/snapshotter/src/snapshot.rs
+++ b/crates/infra/snapshotter/src/snapshot.rs
@@ -95,6 +95,27 @@ impl SnapshotManifestExt for SnapshotManifest {
     }
 }
 
+/// Inputs for [`SnapshotGenerator::generate_manifest`].
+#[derive(Debug, Clone, Copy)]
+pub struct ManifestGenerationParams<'a> {
+    /// Reth node datadir containing static files, state DB, and optional proofs DB.
+    pub source_datadir: &'a Path,
+    /// Directory where snapshot archives and `manifest.json` are written.
+    pub output_dir: &'a Path,
+    /// Chain ID recorded in the manifest.
+    pub chain_id: u64,
+    /// Snapshot block height. Inferred from header static files when `None`.
+    pub block: Option<u64>,
+    /// Blocks per static-file chunk archive. Defaults to `500_000` when `None`.
+    pub blocks_per_file: Option<u64>,
+    /// Remote static-file chunk filenames and sizes used for skip-range computation.
+    pub remote_static_files: &'a HashMap<String, u64>,
+    /// Prior per-file chunk metadata reused for skipped archives.
+    pub previous_chunk_output_files: &'a HashMap<String, Vec<OutputFileChecksum>>,
+    /// Whether to package `{source_datadir}/proofs` into `proofs.tar.zst`.
+    pub upload_proofs: bool,
+}
+
 /// Generates snapshot archives with selective compression.
 ///
 /// Static file chunks whose block ranges are in `skip_ranges` are not
@@ -103,77 +124,43 @@ impl SnapshotManifestExt for SnapshotManifest {
 pub struct SnapshotGenerator;
 
 impl SnapshotGenerator {
-    /// Generates snapshot archives, skipping compression for chunks in `skip_ranges`.
-    ///
-    /// `skip_ranges` contains `(start, end)` block ranges that already exist
-    /// remotely and don't need to be re-compressed.
+    /// Generates snapshot archives, skipping compression for chunks that already
+    /// exist remotely and reusing prior per-file chunk metadata when available.
     ///
     /// Returns the list of files created in the output directory.
     ///
     /// From <https://github.com/paradigmxyz/reth/blob/420693521fccd1437071a15a4a54a3a98b5492cf/crates/cli/commands/src/download/manifest.rs>
-    pub fn generate_manifest(
-        source_datadir: &Path,
-        output_dir: &Path,
-        chain_id: u64,
-        block: Option<u64>,
-        blocks_per_file: Option<u64>,
-        remote_static_files: &HashMap<String, u64>,
-        upload_proofs: bool,
-    ) -> Result<Vec<PathBuf>> {
-        Self::generate_manifest_with_previous_chunk_output_files(
-            source_datadir,
-            output_dir,
-            chain_id,
-            block,
-            blocks_per_file,
-            remote_static_files,
-            &HashMap::new(),
-            upload_proofs,
-        )
-    }
+    pub fn generate_manifest(params: &ManifestGenerationParams<'_>) -> Result<Vec<PathBuf>> {
+        std::fs::create_dir_all(params.output_dir).with_context(|| {
+            format!("failed to create output dir {}", params.output_dir.display())
+        })?;
 
-    /// Generates snapshot archives while reusing prior per-file chunk metadata when available.
-    ///
-    /// This avoids a long serial pre-pass over finalized chunks: when `previous_chunk_output_files`
-    /// contains a skipped archive's `OutputFileChecksum` entries, the generator can copy those
-    /// manifest rows directly instead of re-hashing local files that will not be re-uploaded.
-    #[allow(clippy::too_many_arguments)]
-    pub fn generate_manifest_with_previous_chunk_output_files(
-        source_datadir: &Path,
-        output_dir: &Path,
-        chain_id: u64,
-        block: Option<u64>,
-        blocks_per_file: Option<u64>,
-        remote_static_files: &HashMap<String, u64>,
-        previous_chunk_output_files: &HashMap<String, Vec<OutputFileChecksum>>,
-        upload_proofs: bool,
-    ) -> Result<Vec<PathBuf>> {
-        std::fs::create_dir_all(output_dir)
-            .with_context(|| format!("failed to create output dir {}", output_dir.display()))?;
-
-        let blocks_per_file = blocks_per_file.unwrap_or(DEFAULT_BLOCKS_PER_FILE);
-        let block = match block {
-            Some(b) => b,
-            None => infer_block_from_headers(source_datadir)?,
+        let blocks_per_file = params.blocks_per_file.unwrap_or(DEFAULT_BLOCKS_PER_FILE);
+        let block = match params.block {
+            Some(block) => block,
+            None => infer_block_from_headers(params.source_datadir)?,
         };
 
         let remote_filenames: HashSet<&str> =
-            remote_static_files.keys().map(String::as_str).collect();
+            params.remote_static_files.keys().map(String::as_str).collect();
         let skip_ranges = Self::compute_skip_ranges(&remote_filenames, block, blocks_per_file)?;
 
         info!(
-            source = %source_datadir.display(),
-            output = %output_dir.display(),
-            chain_id,
+            source = %params.source_datadir.display(),
+            output = %params.output_dir.display(),
+            chain_id = params.chain_id,
             block,
             blocks_per_file,
             skip_count = skip_ranges.len(),
             "generating snapshot archives"
         );
 
-        let static_files_dir = source_datadir.join("static_files");
-        let static_dir =
-            if static_files_dir.exists() { static_files_dir } else { source_datadir.to_path_buf() };
+        let static_files_dir = params.source_datadir.join("static_files");
+        let static_dir = if static_files_dir.exists() {
+            static_files_dir
+        } else {
+            params.source_datadir.to_path_buf()
+        };
         let dir_listing = read_static_dir(&static_dir)?;
 
         let mut components = BTreeMap::new();
@@ -211,19 +198,23 @@ impl SnapshotGenerator {
                 if skip_ranges.contains(&(start, end)) {
                     let archive_name = ChunkFilename::format(key, start, end);
                     chunk_sizes[i as usize] =
-                        remote_static_files.get(&archive_name).copied().ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "missing remote size for skipped archive {archive_name}"
-                            )
-                        })?;
+                        params.remote_static_files.get(&archive_name).copied().ok_or_else(
+                            || {
+                                anyhow::anyhow!(
+                                    "missing remote size for skipped archive {archive_name}"
+                                )
+                            },
+                        )?;
 
-                    if let Some(output_files) = previous_chunk_output_files.get(&archive_name) {
+                    if let Some(output_files) =
+                        params.previous_chunk_output_files.get(&archive_name)
+                    {
                         chunk_decompressed[i as usize] = output_files.iter().map(|f| f.size).sum();
                         chunk_output_files[i as usize] = output_files.clone();
                     } else {
                         planned_hash_only.push(PlannedChunk {
                             chunk_idx: i,
-                            archive_path: output_dir.join(&archive_name),
+                            archive_path: params.output_dir.join(&archive_name),
                             source_files,
                         });
                     }
@@ -232,7 +223,7 @@ impl SnapshotGenerator {
 
                 planned.push(PlannedChunk {
                     chunk_idx: i,
-                    archive_path: output_dir.join(ChunkFilename::format(key, start, end)),
+                    archive_path: params.output_dir.join(ChunkFilename::format(key, start, end)),
                     source_files,
                 });
             }
@@ -307,9 +298,9 @@ impl SnapshotGenerator {
             }
         }
 
-        let state_files = state_source_files(source_datadir)?;
+        let state_files = state_source_files(params.source_datadir)?;
         let (state_size, state_output_files) =
-            package_single_component(output_dir, "state.tar.zst", &state_files)?;
+            package_single_component(params.output_dir, "state.tar.zst", &state_files)?;
         let state_decompressed_size: u64 = state_output_files.iter().map(|f| f.size).sum();
         info!(
             component = "state",
@@ -329,10 +320,13 @@ impl SnapshotGenerator {
             }),
         );
 
-        let rocksdb_files = rocksdb_source_files(source_datadir)?;
+        let rocksdb_files = rocksdb_source_files(params.source_datadir)?;
         if !rocksdb_files.is_empty() {
-            let (rocksdb_size, rocksdb_output_files) =
-                package_single_component(output_dir, "rocksdb_indices.tar.zst", &rocksdb_files)?;
+            let (rocksdb_size, rocksdb_output_files) = package_single_component(
+                params.output_dir,
+                "rocksdb_indices.tar.zst",
+                &rocksdb_files,
+            )?;
             let rocksdb_decompressed_size: u64 = rocksdb_output_files.iter().map(|f| f.size).sum();
             info!(
                 component = "rocksdb_indices",
@@ -353,11 +347,14 @@ impl SnapshotGenerator {
             );
         }
 
-        let proofs_files =
-            if upload_proofs { proofs_source_files(source_datadir)? } else { Vec::new() };
+        let proofs_files = if params.upload_proofs {
+            proofs_source_files(params.source_datadir)?
+        } else {
+            Vec::new()
+        };
         if !proofs_files.is_empty() {
             let (proofs_size, proofs_output_files) =
-                package_single_component(output_dir, "proofs.tar.zst", &proofs_files)?;
+                package_single_component(params.output_dir, "proofs.tar.zst", &proofs_files)?;
             let proofs_decompressed_size: u64 = proofs_output_files.iter().map(|f| f.size).sum();
             info!(
                 component = "proofs",
@@ -385,7 +382,7 @@ impl SnapshotGenerator {
 
         let manifest = SnapshotManifest {
             block,
-            chain_id,
+            chain_id: params.chain_id,
             storage_version: 2,
             timestamp,
             base_url: None,
@@ -393,11 +390,11 @@ impl SnapshotGenerator {
             components,
         };
 
-        let manifest_path = output_dir.join("manifest.json");
+        let manifest_path = params.output_dir.join("manifest.json");
         std::fs::write(&manifest_path, serde_json::to_string_pretty(&manifest)?)?;
         info!(block, components = manifest.components.len(), "manifest written");
 
-        let files = Self::collect_output_files(output_dir)?;
+        let files = Self::collect_output_files(params.output_dir)?;
         info!(file_count = files.len(), "snapshot generation complete");
         Ok(files)
     }
@@ -836,6 +833,26 @@ fn source_files_total_bytes(source_files: &[PathBuf]) -> Result<u64> {
 mod tests {
     use super::*;
 
+    fn test_manifest_params<'a>(
+        source_datadir: &'a Path,
+        output_dir: &'a Path,
+        remote_static_files: &'a HashMap<String, u64>,
+        previous_chunk_output_files: &'a HashMap<String, Vec<OutputFileChecksum>>,
+        block: Option<u64>,
+        upload_proofs: bool,
+    ) -> ManifestGenerationParams<'a> {
+        ManifestGenerationParams {
+            source_datadir,
+            output_dir,
+            chain_id: 8453,
+            block,
+            blocks_per_file: Some(500_000),
+            remote_static_files,
+            previous_chunk_output_files,
+            upload_proofs,
+        }
+    }
+
     #[test]
     fn parse_headers_range_valid() {
         assert_eq!(parse_headers_range("static_file_headers_0_499999"), Some((0, 499_999)));
@@ -948,15 +965,15 @@ mod tests {
         std::fs::write(db_dir.join("mdbx.dat"), b"state-data").unwrap();
 
         let remote = HashMap::new();
-        let files = SnapshotGenerator::generate_manifest(
+        let previous_chunk_output_files = HashMap::new();
+        let files = SnapshotGenerator::generate_manifest(&test_manifest_params(
             source.path(),
             output.path(),
-            8453,
-            Some(0),
-            Some(500_000),
             &remote,
+            &previous_chunk_output_files,
+            Some(0),
             false,
-        )
+        ))
         .unwrap();
 
         assert!(
@@ -988,15 +1005,15 @@ mod tests {
         std::fs::write(proofs_dir.join("000801.log"), b"wal-data").unwrap();
 
         let remote = HashMap::new();
-        let files = SnapshotGenerator::generate_manifest(
+        let previous_chunk_output_files = HashMap::new();
+        let files = SnapshotGenerator::generate_manifest(&test_manifest_params(
             source.path(),
             output.path(),
-            8453,
-            Some(0),
-            Some(500_000),
             &remote,
+            &previous_chunk_output_files,
+            Some(0),
             true,
-        )
+        ))
         .unwrap();
 
         assert!(
@@ -1038,15 +1055,15 @@ mod tests {
         std::fs::write(db_dir.join("mdbx.dat"), b"state-data").unwrap();
 
         let remote = HashMap::new();
-        let files = SnapshotGenerator::generate_manifest(
+        let previous_chunk_output_files = HashMap::new();
+        let files = SnapshotGenerator::generate_manifest(&test_manifest_params(
             source.path(),
             output.path(),
-            8453,
-            Some(0),
-            Some(500_000),
             &remote,
+            &previous_chunk_output_files,
+            Some(0),
             true,
-        )
+        ))
         .unwrap();
 
         assert!(
@@ -1076,15 +1093,15 @@ mod tests {
         std::fs::write(proofs_dir.join("CURRENT"), b"MANIFEST-000014\n").unwrap();
 
         let remote = HashMap::new();
-        let files = SnapshotGenerator::generate_manifest(
+        let previous_chunk_output_files = HashMap::new();
+        let files = SnapshotGenerator::generate_manifest(&test_manifest_params(
             source.path(),
             output.path(),
-            8453,
-            Some(0),
-            Some(500_000),
             &remote,
+            &previous_chunk_output_files,
+            Some(0),
             false,
-        )
+        ))
         .unwrap();
 
         assert!(
@@ -1126,15 +1143,15 @@ mod tests {
             remote.insert(ChunkFilename::format(key, 0, 499_999), 0u64);
         }
 
-        let files = SnapshotGenerator::generate_manifest(
+        let previous_chunk_output_files = HashMap::new();
+        let files = SnapshotGenerator::generate_manifest(&test_manifest_params(
             source.path(),
             output.path(),
-            8453,
-            Some(2_000_000),
-            Some(500_000),
             &remote,
+            &previous_chunk_output_files,
+            Some(2_000_000),
             false,
-        )
+        ))
         .unwrap();
 
         let filenames: Vec<String> = files
@@ -1188,16 +1205,16 @@ mod tests {
             }],
         )]);
 
-        SnapshotGenerator::generate_manifest_with_previous_chunk_output_files(
-            source.path(),
-            output.path(),
-            8453,
-            Some(2_000_000),
-            Some(500_000),
-            &remote,
-            &previous_chunk_output_files,
-            false,
-        )
+        SnapshotGenerator::generate_manifest(&ManifestGenerationParams {
+            source_datadir: source.path(),
+            output_dir: output.path(),
+            chain_id: 8453,
+            block: Some(2_000_000),
+            blocks_per_file: Some(500_000),
+            remote_static_files: &remote,
+            previous_chunk_output_files: &previous_chunk_output_files,
+            upload_proofs: false,
+        })
         .unwrap();
 
         let manifest_content =

--- a/crates/infra/snapshotter/src/snapshot.rs
+++ b/crates/infra/snapshotter/src/snapshot.rs
@@ -118,6 +118,7 @@ impl SnapshotGenerator {
         block: Option<u64>,
         blocks_per_file: Option<u64>,
         remote_static_files: &HashMap<String, u64>,
+        upload_proofs: bool,
     ) -> Result<Vec<PathBuf>> {
         Self::generate_manifest_with_previous_chunk_output_files(
             source_datadir,
@@ -127,6 +128,7 @@ impl SnapshotGenerator {
             blocks_per_file,
             remote_static_files,
             &HashMap::new(),
+            upload_proofs,
         )
     }
 
@@ -135,6 +137,7 @@ impl SnapshotGenerator {
     /// This avoids a long serial pre-pass over finalized chunks: when `previous_chunk_output_files`
     /// contains a skipped archive's `OutputFileChecksum` entries, the generator can copy those
     /// manifest rows directly instead of re-hashing local files that will not be re-uploaded.
+    #[allow(clippy::too_many_arguments)]
     pub fn generate_manifest_with_previous_chunk_output_files(
         source_datadir: &Path,
         output_dir: &Path,
@@ -143,6 +146,7 @@ impl SnapshotGenerator {
         blocks_per_file: Option<u64>,
         remote_static_files: &HashMap<String, u64>,
         previous_chunk_output_files: &HashMap<String, Vec<OutputFileChecksum>>,
+        upload_proofs: bool,
     ) -> Result<Vec<PathBuf>> {
         std::fs::create_dir_all(output_dir)
             .with_context(|| format!("failed to create output dir {}", output_dir.display()))?;
@@ -349,7 +353,8 @@ impl SnapshotGenerator {
             );
         }
 
-        let proofs_files = proofs_source_files(source_datadir)?;
+        let proofs_files =
+            if upload_proofs { proofs_source_files(source_datadir)? } else { Vec::new() };
         if !proofs_files.is_empty() {
             let (proofs_size, proofs_output_files) =
                 package_single_component(output_dir, "proofs.tar.zst", &proofs_files)?;
@@ -950,6 +955,7 @@ mod tests {
             Some(0),
             Some(500_000),
             &remote,
+            false,
         )
         .unwrap();
 
@@ -989,6 +995,7 @@ mod tests {
             Some(0),
             Some(500_000),
             &remote,
+            true,
         )
         .unwrap();
 
@@ -1038,6 +1045,7 @@ mod tests {
             Some(0),
             Some(500_000),
             &remote,
+            true,
         )
         .unwrap();
 
@@ -1052,6 +1060,44 @@ mod tests {
         assert!(
             !manifest.components.contains_key("proofs"),
             "manifest should omit proofs component when proofs/ is missing"
+        );
+    }
+
+    #[test]
+    fn generate_manifest_skips_proofs_when_upload_disabled() {
+        let source = tempfile::tempdir().unwrap();
+        let output = tempfile::tempdir().unwrap();
+        let db_dir = source.path().join("db");
+        std::fs::create_dir_all(&db_dir).unwrap();
+        std::fs::write(db_dir.join("mdbx.dat"), b"state-data").unwrap();
+
+        let proofs_dir = source.path().join("proofs");
+        std::fs::create_dir_all(&proofs_dir).unwrap();
+        std::fs::write(proofs_dir.join("CURRENT"), b"MANIFEST-000014\n").unwrap();
+
+        let remote = HashMap::new();
+        let files = SnapshotGenerator::generate_manifest(
+            source.path(),
+            output.path(),
+            8453,
+            Some(0),
+            Some(500_000),
+            &remote,
+            false,
+        )
+        .unwrap();
+
+        assert!(
+            !files.iter().any(|f| f.file_name().unwrap() == "proofs.tar.zst"),
+            "should not produce proofs.tar.zst when upload_proofs is disabled"
+        );
+
+        let manifest_content =
+            std::fs::read_to_string(output.path().join("manifest.json")).unwrap();
+        let manifest: SnapshotManifest = serde_json::from_str(&manifest_content).unwrap();
+        assert!(
+            !manifest.components.contains_key("proofs"),
+            "manifest should omit proofs component when upload_proofs is disabled"
         );
     }
 
@@ -1087,6 +1133,7 @@ mod tests {
             Some(2_000_000),
             Some(500_000),
             &remote,
+            false,
         )
         .unwrap();
 
@@ -1149,6 +1196,7 @@ mod tests {
             Some(500_000),
             &remote,
             &previous_chunk_output_files,
+            false,
         )
         .unwrap();
 

--- a/crates/infra/snapshotter/src/snapshot.rs
+++ b/crates/infra/snapshotter/src/snapshot.rs
@@ -349,6 +349,30 @@ impl SnapshotGenerator {
             );
         }
 
+        let proofs_files = proofs_source_files(source_datadir)?;
+        if !proofs_files.is_empty() {
+            let (proofs_size, proofs_output_files) =
+                package_single_component(output_dir, "proofs.tar.zst", &proofs_files)?;
+            let proofs_decompressed_size: u64 = proofs_output_files.iter().map(|f| f.size).sum();
+            info!(
+                component = "proofs",
+                compressed_size = proofs_size,
+                decompressed_size = proofs_decompressed_size,
+                file_count = proofs_files.len(),
+                "packaged proofs database"
+            );
+            components.insert(
+                "proofs".to_string(),
+                ComponentManifest::Single(SingleArchive {
+                    file: "proofs.tar.zst".to_string(),
+                    size: proofs_size,
+                    decompressed_size: proofs_decompressed_size,
+                    blake3: None,
+                    output_files: proofs_output_files,
+                }),
+            );
+        }
+
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .context("system clock is before UNIX epoch")?
@@ -548,6 +572,14 @@ fn rocksdb_source_files(source_datadir: &Path) -> Result<Vec<PlannedFile>> {
         return Ok(Vec::new());
     }
     collect_files_recursive(&rocksdb_dir, Path::new("rocksdb"))
+}
+
+fn proofs_source_files(source_datadir: &Path) -> Result<Vec<PlannedFile>> {
+    let proofs_dir = source_datadir.join("proofs");
+    if !proofs_dir.exists() {
+        return Ok(Vec::new());
+    }
+    collect_files_recursive(&proofs_dir, Path::new("proofs"))
 }
 
 fn looks_like_db_dir(path: &Path) -> Result<bool> {
@@ -928,6 +960,100 @@ mod tests {
         assert!(
             files.iter().any(|f| f.file_name().unwrap() == "manifest.json"),
             "should produce manifest.json"
+        );
+    }
+
+    #[test]
+    fn generate_manifest_creates_proofs_archive() {
+        let source = tempfile::tempdir().unwrap();
+        let output = tempfile::tempdir().unwrap();
+        let db_dir = source.path().join("db");
+        std::fs::create_dir_all(&db_dir).unwrap();
+        std::fs::write(db_dir.join("mdbx.dat"), b"state-data").unwrap();
+
+        let proofs_dir = source.path().join("proofs");
+        std::fs::create_dir_all(&proofs_dir).unwrap();
+        std::fs::write(proofs_dir.join("CURRENT"), b"MANIFEST-000014\n").unwrap();
+        std::fs::write(proofs_dir.join("IDENTITY"), b"identity-bytes").unwrap();
+        std::fs::write(proofs_dir.join("LOCK"), b"").unwrap();
+        std::fs::write(proofs_dir.join("MANIFEST-000014"), b"manifest-data").unwrap();
+        std::fs::write(proofs_dir.join("OPTIONS-000007"), b"options-data").unwrap();
+        std::fs::write(proofs_dir.join("000060.sst"), b"sst-data").unwrap();
+        std::fs::write(proofs_dir.join("000801.log"), b"wal-data").unwrap();
+
+        let remote = HashMap::new();
+        let files = SnapshotGenerator::generate_manifest(
+            source.path(),
+            output.path(),
+            8453,
+            Some(0),
+            Some(500_000),
+            &remote,
+        )
+        .unwrap();
+
+        assert!(
+            files.iter().any(|f| f.file_name().unwrap() == "proofs.tar.zst"),
+            "should produce proofs.tar.zst when proofs/ exists"
+        );
+
+        let manifest_content =
+            std::fs::read_to_string(output.path().join("manifest.json")).unwrap();
+        let manifest: SnapshotManifest = serde_json::from_str(&manifest_content).unwrap();
+        let ComponentManifest::Single(proofs) = manifest
+            .components
+            .get("proofs")
+            .expect("manifest should include proofs component")
+        else {
+            panic!("proofs component should be a Single archive");
+        };
+
+        assert_eq!(proofs.file, "proofs.tar.zst", "proofs archive filename");
+        assert_eq!(proofs.output_files.len(), 7, "exactly 7 proofs DB files should be packaged");
+        assert!(
+            proofs.output_files.iter().all(|f| f.path.starts_with("proofs/")),
+            "all proofs output paths should be under proofs/"
+        );
+        assert!(
+            proofs.output_files.iter().any(|f| f.path == "proofs/000060.sst"),
+            "should include SST file under proofs/"
+        );
+        assert!(
+            proofs.output_files.iter().any(|f| f.path == "proofs/CURRENT"),
+            "should include CURRENT under proofs/"
+        );
+    }
+
+    #[test]
+    fn generate_manifest_skips_proofs_when_missing() {
+        let source = tempfile::tempdir().unwrap();
+        let output = tempfile::tempdir().unwrap();
+        let db_dir = source.path().join("db");
+        std::fs::create_dir_all(&db_dir).unwrap();
+        std::fs::write(db_dir.join("mdbx.dat"), b"state-data").unwrap();
+
+        let remote = HashMap::new();
+        let files = SnapshotGenerator::generate_manifest(
+            source.path(),
+            output.path(),
+            8453,
+            Some(0),
+            Some(500_000),
+            &remote,
+        )
+        .unwrap();
+
+        assert!(
+            !files.iter().any(|f| f.file_name().unwrap() == "proofs.tar.zst"),
+            "should not produce proofs.tar.zst when proofs/ is missing"
+        );
+
+        let manifest_content =
+            std::fs::read_to_string(output.path().join("manifest.json")).unwrap();
+        let manifest: SnapshotManifest = serde_json::from_str(&manifest_content).unwrap();
+        assert!(
+            !manifest.components.contains_key("proofs"),
+            "manifest should omit proofs component when proofs/ is missing"
         );
     }
 

--- a/crates/infra/snapshotter/src/upload.rs
+++ b/crates/infra/snapshotter/src/upload.rs
@@ -1117,18 +1117,20 @@ mod tests {
             components,
         };
 
-        let published = build_published_manifest(&local, Some("https://example.com/static_files"), 1_700_000_000)
-            .unwrap();
+        let published = build_published_manifest(
+            &local,
+            Some("https://example.com/static_files"),
+            1_700_000_000,
+        )
+        .unwrap();
         let manifest: serde_json::Value = serde_json::from_slice(&published).unwrap();
 
         assert_eq!(
-            manifest["components"]["state"]["file"],
-            "../1700000000/state.tar.zst",
+            manifest["components"]["state"]["file"], "../1700000000/state.tar.zst",
             "state should be rewritten relative to static_files base_url"
         );
         assert_eq!(
-            manifest["components"]["proofs"]["file"],
-            "proofs.tar.zst",
+            manifest["components"]["proofs"]["file"], "proofs.tar.zst",
             "proofs must remain a sibling of manifest.json for ProofsDownloader"
         );
     }

--- a/crates/infra/snapshotter/src/upload.rs
+++ b/crates/infra/snapshotter/src/upload.rs
@@ -8,8 +8,8 @@
 //!   `manifest.json` against the freshly generated manifest, and skips chunks
 //!   whose hashes match.
 //!
-//! - `{prefix}/{date}/` — per-run directory for mdbx state, rocksdb, and the manifest.
-//!   These are always re-uploaded since they change every snapshot.
+//! - `{prefix}/{date}/` — per-run directory for mdbx state, rocksdb indices, proofs, and the
+//!   manifest. These are always re-uploaded since they change every snapshot.
 
 use std::{
     collections::HashMap,
@@ -65,7 +65,7 @@ pub struct SnapshotRun {
 /// or can be skipped when the remote copy already matches.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UploadStrategy {
-    /// Always upload to the per-run date directory (mdbx, rocksdb, manifest).
+    /// Always upload to the per-run date directory (mdbx, rocksdb, proofs, manifest).
     AlwaysUpload,
     /// Upload to `static_files/`, skipping if the per-file BLAKE3 hashes
     /// recorded in the previous run's manifest match the freshly generated ones.
@@ -79,7 +79,7 @@ impl UploadStrategy {
     /// (e.g. `headers-0-499999.tar.zst`). These are immutable for finalized block
     /// ranges and only the tip chunk changes between snapshots.
     ///
-    /// Everything else (state, rocksdb, manifest) is always uploaded.
+    /// Everything else (state, rocksdb, proofs, manifest) is always uploaded.
     pub fn classify(filename: &str) -> Self {
         if ChunkFilename::parse(filename).is_some() { Self::DiffByHash } else { Self::AlwaysUpload }
     }
@@ -257,7 +257,7 @@ impl SnapshotUploader {
     ///
     /// Static file chunks go to `{prefix}/static_files/` and are skipped when
     /// their per-file BLAKE3 hashes (recorded in `local_manifest`) match those
-    /// from `remote_manifest`. State, rocksdb, and manifest go to
+    /// from `remote_manifest`. State, rocksdb, proofs, and manifest go to
     /// `{prefix}/{timestamp}/` and are always re-uploaded. `manifest.json` is
     /// uploaded last as the "snapshot complete" signal.
     pub async fn upload(
@@ -1010,6 +1010,10 @@ fn retry_delay_secs(attempt: usize) -> u64 {
 /// Chunked archives are served from top-level `static_files/` via `base_url`, while
 /// the always-changing `state` and `rocksdb_indices` archives stay in the timestamped
 /// run directory and are referenced through `../{timestamp}/...` file paths.
+///
+/// `proofs` is also uploaded into the run directory, but its `file` field is left as
+/// a bare filename (`proofs.tar.zst`). The proofs downloader resolves the archive as a
+/// sibling of `manifest.json` and rejects path traversal (`..`).
 fn build_published_manifest(
     local_manifest: &SnapshotManifest,
     public_static_files_base_url: Option<&str>,
@@ -1068,8 +1072,65 @@ mod tests {
             UploadStrategy::classify("rocksdb_indices.tar.zst"),
             UploadStrategy::AlwaysUpload
         );
+        assert_eq!(UploadStrategy::classify("proofs.tar.zst"), UploadStrategy::AlwaysUpload);
         assert_eq!(UploadStrategy::classify("manifest.json"), UploadStrategy::AlwaysUpload);
         assert_eq!(UploadStrategy::classify("random-file.txt"), UploadStrategy::AlwaysUpload);
+    }
+
+    #[test]
+    fn build_published_manifest_leaves_proofs_file_as_sibling() {
+        use std::collections::BTreeMap;
+
+        use reth_cli_commands::download::manifest::{
+            ComponentManifest, SingleArchive, SnapshotManifest,
+        };
+
+        let mut components = BTreeMap::new();
+        components.insert(
+            "state".to_string(),
+            ComponentManifest::Single(SingleArchive {
+                file: "state.tar.zst".to_string(),
+                size: 100,
+                decompressed_size: 200,
+                blake3: None,
+                output_files: vec![],
+            }),
+        );
+        components.insert(
+            "proofs".to_string(),
+            ComponentManifest::Single(SingleArchive {
+                file: "proofs.tar.zst".to_string(),
+                size: 50,
+                decompressed_size: 80,
+                blake3: None,
+                output_files: vec![],
+            }),
+        );
+
+        let local = SnapshotManifest {
+            block: 1,
+            chain_id: 8453,
+            storage_version: 2,
+            timestamp: 1_700_000_000,
+            base_url: None,
+            reth_version: None,
+            components,
+        };
+
+        let published = build_published_manifest(&local, Some("https://example.com/static_files"), 1_700_000_000)
+            .unwrap();
+        let manifest: serde_json::Value = serde_json::from_slice(&published).unwrap();
+
+        assert_eq!(
+            manifest["components"]["state"]["file"],
+            "../1700000000/state.tar.zst",
+            "state should be rewritten relative to static_files base_url"
+        );
+        assert_eq!(
+            manifest["components"]["proofs"]["file"],
+            "proofs.tar.zst",
+            "proofs must remain a sibling of manifest.json for ProofsDownloader"
+        );
     }
 
     #[test]

--- a/crates/infra/snapshotter/tests/e2e_test.rs
+++ b/crates/infra/snapshotter/tests/e2e_test.rs
@@ -14,8 +14,8 @@ use anyhow::Result;
 use async_trait::async_trait;
 use base_snapshotter::{
     ChunkedArchive, ComponentManifest, ContainerManager, DockerContainerManager,
-    OutputFileChecksum, SnapshotGenerator, SnapshotManifest, SnapshotUploader, TipChecker,
-    TipStatus,
+    ManifestGenerationParams, OutputFileChecksum, SnapshotGenerator, SnapshotManifest,
+    SnapshotUploader, TipChecker, TipStatus,
 };
 use bollard::{
     Docker,
@@ -752,15 +752,16 @@ async fn selective_compression_skips_finalized_chunks() -> Result<()> {
     }
 
     let output = tempfile::tempdir()?;
-    let files = SnapshotGenerator::generate_manifest(
-        source.path(),
-        output.path(),
-        8453,
-        Some(2_000_000),
-        Some(500_000),
-        &remote,
-        false,
-    )?;
+    let files = SnapshotGenerator::generate_manifest(&ManifestGenerationParams {
+        source_datadir: source.path(),
+        output_dir: output.path(),
+        chain_id: 8453,
+        block: Some(2_000_000),
+        blocks_per_file: Some(500_000),
+        remote_static_files: &remote,
+        previous_chunk_output_files: &HashMap::new(),
+        upload_proofs: false,
+    })?;
 
     let filenames: Vec<String> = files
         .iter()
@@ -821,15 +822,17 @@ async fn generate_and_upload_proofs_to_minio() -> Result<()> {
     std::fs::write(proofs_dir.join("000801.log"), b"wal-data")?;
 
     let output = tempfile::tempdir()?;
-    let files = SnapshotGenerator::generate_manifest(
-        source.path(),
-        output.path(),
-        8453,
-        Some(0),
-        Some(500_000),
-        &HashMap::new(),
-        true,
-    )?;
+    let empty_remote = HashMap::new();
+    let files = SnapshotGenerator::generate_manifest(&ManifestGenerationParams {
+        source_datadir: source.path(),
+        output_dir: output.path(),
+        chain_id: 8453,
+        block: Some(0),
+        blocks_per_file: Some(500_000),
+        remote_static_files: &empty_remote,
+        previous_chunk_output_files: &HashMap::new(),
+        upload_proofs: true,
+    })?;
 
     assert!(
         files.iter().any(|f| f.file_name().is_some_and(|n| n == "proofs.tar.zst")),

--- a/crates/infra/snapshotter/tests/e2e_test.rs
+++ b/crates/infra/snapshotter/tests/e2e_test.rs
@@ -479,7 +479,6 @@ fn seeded_snapshot(
     std::fs::write(output_dir.join("manifest.json"), serde_json::to_string_pretty(&manifest)?)?;
     std::fs::write(output_dir.join("state.tar.zst"), b"state-data")?;
     std::fs::write(output_dir.join("rocksdb_indices.tar.zst"), b"rocksdb-data")?;
-    std::fs::write(output_dir.join("proofs.tar.zst"), b"proofs-data")?;
 
     let num_chunks = block.div_ceil(blocks_per_file);
     for &component in components {
@@ -845,8 +844,7 @@ async fn generate_and_upload_proofs_to_minio() -> Result<()> {
     let proofs_body = get_object_bytes(s3, bucket, "proofs-gen/1700000000/proofs.tar.zst").await?;
     assert!(!proofs_body.is_empty(), "uploaded proofs archive should not be empty");
 
-    let manifest_body =
-        get_object_bytes(s3, bucket, "proofs-gen/1700000000/manifest.json").await?;
+    let manifest_body = get_object_bytes(s3, bucket, "proofs-gen/1700000000/manifest.json").await?;
     let manifest: serde_json::Value = serde_json::from_slice(&manifest_body)?;
     assert_eq!(
         manifest["components"]["proofs"]["file"], "proofs.tar.zst",
@@ -857,11 +855,9 @@ async fn generate_and_upload_proofs_to_minio() -> Result<()> {
         "state should still use the relative run-dir path"
     );
     assert!(
-        manifest["components"]["proofs"]["output_files"]
-            .as_array()
-            .is_some_and(|files| files.iter().all(|f| {
-                f["path"].as_str().is_some_and(|p| p.starts_with("proofs/"))
-            })),
+        manifest["components"]["proofs"]["output_files"].as_array().is_some_and(|files| files
+            .iter()
+            .all(|f| { f["path"].as_str().is_some_and(|p| p.starts_with("proofs/")) })),
         "proofs output_files paths should all be under proofs/"
     );
     assert_eq!(

--- a/crates/infra/snapshotter/tests/e2e_test.rs
+++ b/crates/infra/snapshotter/tests/e2e_test.rs
@@ -145,6 +145,7 @@ fn test_config(bucket: &str, tmp: &Path) -> base_snapshotter::SnapshotterConfig 
         s3_access_key_id: None,
         s3_secret_access_key: None,
         public_base_url: None,
+        upload_proofs: false,
     }
 }
 
@@ -758,6 +759,7 @@ async fn selective_compression_skips_finalized_chunks() -> Result<()> {
         Some(2_000_000),
         Some(500_000),
         &remote,
+        false,
     )?;
 
     let filenames: Vec<String> = files
@@ -826,6 +828,7 @@ async fn generate_and_upload_proofs_to_minio() -> Result<()> {
         Some(0),
         Some(500_000),
         &HashMap::new(),
+        true,
     )?;
 
     assert!(

--- a/crates/infra/snapshotter/tests/e2e_test.rs
+++ b/crates/infra/snapshotter/tests/e2e_test.rs
@@ -212,6 +212,15 @@ fn create_fake_snapshot(dir: &Path, block: u64) -> Result<Vec<PathBuf>> {
                 "size": 226_377_256_076u64,
                 "decompressed_size": 452_754_512_152u64,
                 "output_files": [{"path": "rocksdb/CURRENT", "size": 16, "blake3": "fake-blake3-rocksdb-current"}]
+            },
+            "proofs": {
+                "file": "proofs.tar.zst",
+                "size": 3_870_192_000u64,
+                "decompressed_size": 3_870_192_000u64,
+                "output_files": [
+                    {"path": "proofs/CURRENT", "size": 16, "blake3": "fake-blake3-proofs-current"},
+                    {"path": "proofs/000060.sst", "size": 9_695_151u64, "blake3": "fake-blake3-proofs-sst"}
+                ]
             }
         }
     });
@@ -226,6 +235,9 @@ fn create_fake_snapshot(dir: &Path, block: u64) -> Result<Vec<PathBuf>> {
 
     std::fs::write(dir.join("rocksdb_indices.tar.zst"), b"fake-rocksdb-archive")?;
     files.push(dir.join("rocksdb_indices.tar.zst"));
+
+    std::fs::write(dir.join("proofs.tar.zst"), b"fake-proofs-archive")?;
+    files.push(dir.join("proofs.tar.zst"));
 
     for component in [
         "headers",
@@ -353,6 +365,9 @@ async fn upload_artifacts_to_minio() -> Result<()> {
         get_object_bytes(s3, bucket, "mainnet/1700000000/rocksdb_indices.tar.zst").await?;
     assert_eq!(rocksdb_body, b"fake-rocksdb-archive", "rocksdb should be in date dir");
 
+    let proofs_body = get_object_bytes(s3, bucket, "mainnet/1700000000/proofs.tar.zst").await?;
+    assert_eq!(proofs_body, b"fake-proofs-archive", "proofs should be in date dir");
+
     let manifest_body = get_object_bytes(s3, bucket, "mainnet/1700000000/manifest.json").await?;
     let manifest: serde_json::Value = serde_json::from_slice(&manifest_body)?;
     assert_eq!(manifest["block"], 1_000_000, "manifest block mismatch");
@@ -365,9 +380,13 @@ async fn upload_artifacts_to_minio() -> Result<()> {
         manifest["components"]["state"]["file"], "../1700000000/state.tar.zst",
         "manifest should point state back to the dated run dir"
     );
+    assert_eq!(
+        manifest["components"]["proofs"]["file"], "proofs.tar.zst",
+        "proofs must remain a sibling of manifest.json for ProofsDownloader"
+    );
 
     let components = manifest["components"].as_object().expect("components should be an object");
-    assert_eq!(components.len(), 8, "should have all 8 component types");
+    assert_eq!(components.len(), 9, "should have all 9 component types");
 
     // Verify static file chunks go to {prefix}/static_files/
     for component in ["headers", "transactions", "receipts"] {
@@ -417,6 +436,9 @@ async fn upload_with_empty_prefix() -> Result<()> {
     let rocksdb_body = get_object_bytes(s3, bucket, "1700000000/rocksdb_indices.tar.zst").await?;
     assert_eq!(rocksdb_body, b"fake-rocksdb-archive", "rocksdb should be in date dir");
 
+    let proofs_body = get_object_bytes(s3, bucket, "1700000000/proofs.tar.zst").await?;
+    assert_eq!(proofs_body, b"fake-proofs-archive", "proofs should be in date dir");
+
     let manifest_body = get_object_bytes(s3, bucket, "1700000000/manifest.json").await?;
     let manifest: serde_json::Value = serde_json::from_slice(&manifest_body)?;
     assert_eq!(manifest["block"], 100, "manifest should be in date dir");
@@ -427,6 +449,10 @@ async fn upload_with_empty_prefix() -> Result<()> {
     assert_eq!(
         manifest["components"]["state"]["file"], "../1700000000/state.tar.zst",
         "manifest should point state back to the dated run dir"
+    );
+    assert_eq!(
+        manifest["components"]["proofs"]["file"], "proofs.tar.zst",
+        "proofs must remain a sibling of manifest.json for ProofsDownloader"
     );
 
     let headers_body =
@@ -453,6 +479,7 @@ fn seeded_snapshot(
     std::fs::write(output_dir.join("manifest.json"), serde_json::to_string_pretty(&manifest)?)?;
     std::fs::write(output_dir.join("state.tar.zst"), b"state-data")?;
     std::fs::write(output_dir.join("rocksdb_indices.tar.zst"), b"rocksdb-data")?;
+    std::fs::write(output_dir.join("proofs.tar.zst"), b"proofs-data")?;
 
     let num_chunks = block.div_ceil(blocks_per_file);
     for &component in components {
@@ -768,7 +795,87 @@ async fn selective_compression_skips_finalized_chunks() -> Result<()> {
 
 #[tokio::test]
 #[serial]
-async fn always_upload_overwrites_existing_state_and_rocksdb() -> Result<()> {
+async fn generate_and_upload_proofs_to_minio() -> Result<()> {
+    let harness = TestHarness::new().await?;
+    let uploader = SnapshotUploader::new(
+        harness.storage_client.clone(),
+        harness.bucket_name.clone(),
+        "proofs-gen".to_string(),
+        Some("https://snapshots.example.com".to_string()),
+    );
+
+    let source = tempfile::tempdir()?;
+    let db_dir = source.path().join("db");
+    std::fs::create_dir_all(&db_dir)?;
+    std::fs::write(db_dir.join("mdbx.dat"), b"state-data")?;
+
+    let proofs_dir = source.path().join("proofs");
+    std::fs::create_dir_all(&proofs_dir)?;
+    std::fs::write(proofs_dir.join("CURRENT"), b"MANIFEST-000014\n")?;
+    std::fs::write(proofs_dir.join("IDENTITY"), b"identity-bytes")?;
+    std::fs::write(proofs_dir.join("LOCK"), b"")?;
+    std::fs::write(proofs_dir.join("MANIFEST-000014"), b"manifest-data")?;
+    std::fs::write(proofs_dir.join("OPTIONS-000007"), b"options-data")?;
+    std::fs::write(proofs_dir.join("000060.sst"), b"sst-data")?;
+    std::fs::write(proofs_dir.join("000801.log"), b"wal-data")?;
+
+    let output = tempfile::tempdir()?;
+    let files = SnapshotGenerator::generate_manifest(
+        source.path(),
+        output.path(),
+        8453,
+        Some(0),
+        Some(500_000),
+        &HashMap::new(),
+    )?;
+
+    assert!(
+        files.iter().any(|f| f.file_name().is_some_and(|n| n == "proofs.tar.zst")),
+        "generator should produce proofs.tar.zst"
+    );
+
+    let local_manifest = parse_local_manifest(output.path())?;
+    let upload_prefix =
+        uploader.upload(output.path(), &files, 1_700_000_000, 100, &local_manifest, None).await?;
+    assert_eq!(upload_prefix, "proofs-gen/1700000000");
+
+    let s3 = &harness.storage_client;
+    let bucket = &harness.bucket_name;
+
+    let proofs_body = get_object_bytes(s3, bucket, "proofs-gen/1700000000/proofs.tar.zst").await?;
+    assert!(!proofs_body.is_empty(), "uploaded proofs archive should not be empty");
+
+    let manifest_body =
+        get_object_bytes(s3, bucket, "proofs-gen/1700000000/manifest.json").await?;
+    let manifest: serde_json::Value = serde_json::from_slice(&manifest_body)?;
+    assert_eq!(
+        manifest["components"]["proofs"]["file"], "proofs.tar.zst",
+        "published proofs file must be a sibling of manifest.json"
+    );
+    assert_eq!(
+        manifest["components"]["state"]["file"], "../1700000000/state.tar.zst",
+        "state should still use the relative run-dir path"
+    );
+    assert!(
+        manifest["components"]["proofs"]["output_files"]
+            .as_array()
+            .is_some_and(|files| files.iter().all(|f| {
+                f["path"].as_str().is_some_and(|p| p.starts_with("proofs/"))
+            })),
+        "proofs output_files paths should all be under proofs/"
+    );
+    assert_eq!(
+        manifest["components"]["proofs"]["output_files"].as_array().map(|a| a.len()),
+        Some(7),
+        "exactly 7 proofs DB files should be recorded in the published manifest"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn always_upload_overwrites_existing_state_rocksdb_and_proofs() -> Result<()> {
     let harness = TestHarness::new().await?;
     let s3 = &harness.storage_client;
     let bucket = &harness.bucket_name;
@@ -780,10 +887,11 @@ async fn always_upload_overwrites_existing_state_and_rocksdb() -> Result<()> {
         None,
     );
 
-    // Simulate a previous run's date dir with old state + rocksdb
+    // Simulate a previous run's date dir with old state + rocksdb + proofs
     let prev_files: &[(&str, &[u8])] = &[
         ("state.tar.zst", b"old-mdbx-from-yesterday"),
         ("rocksdb_indices.tar.zst", b"old-rocksdb-from-yesterday"),
+        ("proofs.tar.zst", b"old-proofs-from-yesterday"),
         ("manifest.json", b"{\"block\":1500000}"),
     ];
     for (name, data) in prev_files {
@@ -805,9 +913,11 @@ async fn always_upload_overwrites_existing_state_and_rocksdb() -> Result<()> {
     std::fs::write(output_dir.join("manifest.json"), serde_json::to_string(&manifest)?)?;
     std::fs::write(output_dir.join("state.tar.zst"), b"fresh-mdbx-state")?;
     std::fs::write(output_dir.join("rocksdb_indices.tar.zst"), b"fresh-rocksdb")?;
+    std::fs::write(output_dir.join("proofs.tar.zst"), b"fresh-proofs")?;
 
     let files = vec![
         output_dir.join("manifest.json"),
+        output_dir.join("proofs.tar.zst"),
         output_dir.join("rocksdb_indices.tar.zst"),
         output_dir.join("state.tar.zst"),
     ];
@@ -827,12 +937,25 @@ async fn always_upload_overwrites_existing_state_and_rocksdb() -> Result<()> {
         get_object_bytes(s3, bucket, "overwrite-test/1700000000/rocksdb_indices.tar.zst").await?;
     assert_eq!(rocksdb_body, b"fresh-rocksdb", "rocksdb should be in new date dir");
 
+    // Verify new proofs in new date dir
+    let proofs_body =
+        get_object_bytes(s3, bucket, "overwrite-test/1700000000/proofs.tar.zst").await?;
+    assert_eq!(proofs_body, b"fresh-proofs", "proofs should be in new date dir");
+
     // Verify previous run's files are untouched
     let old_state = get_object_bytes(s3, bucket, "overwrite-test/1699000000/state.tar.zst").await?;
     assert_eq!(
         old_state.as_slice(),
         b"old-mdbx-from-yesterday",
         "previous run should be untouched"
+    );
+
+    let old_proofs =
+        get_object_bytes(s3, bucket, "overwrite-test/1699000000/proofs.tar.zst").await?;
+    assert_eq!(
+        old_proofs.as_slice(),
+        b"old-proofs-from-yesterday",
+        "previous proofs should be untouched"
     );
 
     Ok(())


### PR DESCRIPTION
- Always upload proofs DB to run timestamp directory
- Packaged into proofs.tar.zst