### PR TITLE
refactor(execution): Generalize Upgrade Signal Argument Access

### DIFF
--- a/bin/builder/src/main.rs
+++ b/bin/builder/src/main.rs
@@ -27,11 +27,8 @@ fn main() {
 
     cli.run(|builder, builder_args| async move {
         let rollup_args = builder_args.rollup_args.clone();
-        let builder = StandardBaseRethNode::apply_initial_upgrade_signal_from_rollup_args(
-            builder,
-            &rollup_args,
-        )
-        .await?;
+        let builder =
+            StandardBaseRethNode::apply_initial_upgrade_signal(builder, &builder_args).await?;
 
         let metering_provider: base_builder_core::SharedMeteringProvider =
             Arc::new(builder_args.build_metering_store());

--- a/crates/builder/cli/src/args.rs
+++ b/crates/builder/cli/src/args.rs
@@ -7,7 +7,7 @@ use base_builder_core::{
     BuilderConfig, ExecutionMeteringMode, RejectionCache, SharedMeteringProvider,
 };
 use base_builder_metering::MeteringStore;
-use base_node_core::args::RollupArgs;
+use base_node_core::{HasRollupArgs, RollupArgs};
 use base_observability_events::{
     DEFAULT_MAX_FILE_BYTES, DEFAULT_MAX_FILES, DEFAULT_QUEUE_CAPACITY, TransactionEventProducer,
     TransactionEventWriterConfig,
@@ -244,6 +244,12 @@ pub struct Args {
     pub transaction_events: TransactionEventsArgs,
 }
 
+impl HasRollupArgs for Args {
+    fn rollup_args(&self) -> &RollupArgs {
+        &self.rollup_args
+    }
+}
+
 impl Args {
     /// Creates a [`MeteringStore`] from the CLI arguments.
     pub fn build_metering_store(&self) -> MeteringStore {
@@ -357,6 +363,12 @@ mod tests {
     fn convert(args: Args) -> BuilderConfig {
         let metering_provider: SharedMeteringProvider = Arc::new(NoopMeteringProvider);
         args.into_builder_config(metering_provider).expect("conversion should succeed")
+    }
+
+    #[test]
+    fn builder_args_provides_embedded_rollup_args() {
+        let args = Args::default();
+        assert!(std::ptr::eq(args.rollup_args(), &args.rollup_args));
     }
 
     #[test]

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -7,7 +7,7 @@ use base_execution_eip8130_rpc_node::{Eip8130RpcExtension, Eip8130RpcMode};
 use base_flashblocks::FlashblocksConfig;
 use base_flashblocks_node::FlashblocksExtension;
 use base_metering::{MeteredOpcodes, MeteringConfig, MeteringExtension, MeteringResourceLimits};
-use base_node_core::args::RollupArgs;
+use base_node_core::{HasRollupArgs, RollupArgs};
 use base_node_runner::{BaseNodeBuilder, BaseNodeRunner, LaunchedBaseNode, PayloadServiceBuilder};
 use base_observability_events::{
     DEFAULT_MAX_FILE_BYTES, DEFAULT_MAX_FILES, DEFAULT_QUEUE_CAPACITY,
@@ -225,6 +225,12 @@ impl StandardNodeArgs {
     }
 }
 
+impl HasRollupArgs for StandardNodeArgs {
+    fn rollup_args(&self) -> &RollupArgs {
+        &self.rpc.rollup_args
+    }
+}
+
 impl From<&StandardNodeArgs> for Option<FlashblocksConfig> {
     fn from(args: &StandardNodeArgs) -> Self {
         args.rpc.flashblocks_url.clone().map(|url| {
@@ -253,11 +259,11 @@ pub struct StandardBaseRethNode;
 
 impl StandardBaseRethNode {
     /// Applies a configured L1 upgrade signal to the execution chain spec before startup.
-    pub async fn apply_initial_upgrade_signal(
+    pub async fn apply_initial_upgrade_signal<A: HasRollupArgs + ?Sized>(
         builder: BaseNodeBuilder,
-        args: &StandardNodeArgs,
+        args: &A,
     ) -> eyre::Result<BaseNodeBuilder> {
-        Self::apply_initial_upgrade_signal_from_rollup_args(builder, &args.rpc.rollup_args).await
+        Self::apply_initial_upgrade_signal_from_rollup_args(builder, args.rollup_args()).await
     }
 
     /// Applies a configured L1 upgrade signal from rollup args before startup.
@@ -587,6 +593,12 @@ mod tests {
             enable_transaction_event_journal: false,
             transaction_event_journal_path: None,
         }
+    }
+
+    #[test]
+    fn standard_node_args_provides_embedded_rollup_args() {
+        let args = StandardNodeArgs::from(default_rpc_standard_node_args());
+        assert!(std::ptr::eq(args.rollup_args(), &args.rpc.rollup_args));
     }
 
     #[test]

--- a/crates/execution/node/src/args.rs
+++ b/crates/execution/node/src/args.rs
@@ -318,6 +318,12 @@ fn mib_to_usize(size_mib: u64) -> usize {
     usize::try_from(size_mib.saturating_mul(MIB)).unwrap_or(usize::MAX)
 }
 
+/// Provides access to shared rollup arguments.
+pub trait HasRollupArgs {
+    /// Returns the shared rollup arguments.
+    fn rollup_args(&self) -> &RollupArgs;
+}
+
 /// Parameters for rollup configuration
 #[derive(Debug, Clone, PartialEq, Eq, clap::Args)]
 #[command(next_help_heading = "Rollup")]
@@ -474,6 +480,12 @@ pub struct RollupArgs {
     pub upgrade_signal_l1_rpc: UpgradeSignalL1RpcArgs,
 }
 
+impl HasRollupArgs for RollupArgs {
+    fn rollup_args(&self) -> &RollupArgs {
+        self
+    }
+}
+
 impl Default for RollupArgs {
     fn default() -> Self {
         Self {
@@ -514,6 +526,12 @@ mod tests {
     struct CommandParser<T: Args> {
         #[command(flatten)]
         args: T,
+    }
+
+    #[test]
+    fn rollup_args_provides_itself() {
+        let args = RollupArgs::default();
+        assert!(std::ptr::eq(args.rollup_args(), &args));
     }
 
     #[test]

--- a/crates/execution/node/src/lib.rs
+++ b/crates/execution/node/src/lib.rs
@@ -13,8 +13,8 @@ use reth_db_api as _;
 /// CLI argument parsing for the Base node.
 pub mod args;
 pub use args::{
-    DEFAULT_PROOFS_HISTORY_WINDOW_BLOCKS, ProofsHistoryDbBackend, ProofsHistoryRocksdbArgs,
-    TWELVE_HOURS_IN_BLOCKS, TxpoolOrdering,
+    DEFAULT_PROOFS_HISTORY_WINDOW_BLOCKS, HasRollupArgs, ProofsHistoryDbBackend,
+    ProofsHistoryRocksdbArgs, RollupArgs, TWELVE_HOURS_IN_BLOCKS, TxpoolOrdering,
 };
 
 /// Exports Base-specific implementations of the [`EngineTypes`](reth_node_api::EngineTypes)


### PR DESCRIPTION
## Summary

Introduce a shared HasRollupArgs trait so execution startup can read rollup configuration from either standard node or builder arguments. Generalize the initial upgrade-signal application API around that trait and simplify the builder startup call while preserving the existing rollup-specific methods.