### PR TITLE
fix(precompile-storage): enforce LIFO checkpoint commits

### DIFF
--- a/crates/common/precompile-storage/src/evm.rs
+++ b/crates/common/precompile-storage/src/evm.rs
@@ -352,7 +352,7 @@ impl PrecompileStorageProvider for EvmPrecompileStorageProvider<'_> {
         self.internals.checkpoint()
     }
 
-    fn checkpoint_commit(&mut self) {
+    fn commit_latest_checkpoint(&mut self) {
         self.internals.checkpoint_commit();
     }
 

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -295,7 +295,7 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         JournalCheckpoint { log_i: 0, journal_i: idx, selfdestructed_i: 0 }
     }
 
-    fn checkpoint_commit(&mut self) {
+    fn commit_latest_checkpoint(&mut self) {
         assert!(!self.snapshots.is_empty(), "checkpoint_commit called with no active checkpoint");
         self.snapshots.pop();
     }
@@ -660,11 +660,11 @@ mod tests {
     }
 
     #[test]
-    fn checkpoint_commit_does_not_revert_mutations() {
+    fn commit_latest_checkpoint_does_not_revert_mutations() {
         let mut p = HashMapStorageProvider::new(1);
         p.checkpoint();
         p.sstore(ADDR, KEY, U256::from(42u64)).unwrap();
-        p.checkpoint_commit();
+        p.commit_latest_checkpoint();
         assert_eq!(p.sload(ADDR, KEY).unwrap(), U256::from(42u64));
     }
 }

--- a/crates/common/precompile-storage/src/hashmap.rs
+++ b/crates/common/precompile-storage/src/hashmap.rs
@@ -300,6 +300,15 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         self.snapshots.pop();
     }
 
+    fn assert_latest_checkpoint(&self, checkpoint: JournalCheckpoint) {
+        assert!(!self.snapshots.is_empty(), "checkpoint_commit called with no active checkpoint");
+        assert_eq!(
+            checkpoint.journal_i,
+            self.snapshots.len() - 1,
+            "out-of-order checkpoint commit (expected top of stack)"
+        );
+    }
+
     fn checkpoint_revert(&mut self, checkpoint: JournalCheckpoint) {
         assert_eq!(
             checkpoint.journal_i,
@@ -666,5 +675,15 @@ mod tests {
         p.sstore(ADDR, KEY, U256::from(42u64)).unwrap();
         p.commit_latest_checkpoint();
         assert_eq!(p.sload(ADDR, KEY).unwrap(), U256::from(42u64));
+    }
+
+    #[test]
+    #[should_panic(expected = "out-of-order checkpoint commit (expected top of stack)")]
+    fn assert_latest_checkpoint_rejects_out_of_order_checkpoint() {
+        let mut p = HashMapStorageProvider::new(1);
+        let outer = p.checkpoint();
+        p.checkpoint();
+
+        p.assert_latest_checkpoint(outer);
     }
 }

--- a/crates/common/precompile-storage/src/journal.rs
+++ b/crates/common/precompile-storage/src/journal.rs
@@ -220,7 +220,7 @@ impl PrecompileStorageProvider for JournalStorageProvider<'_> {
         self.internals.checkpoint()
     }
 
-    fn checkpoint_commit(&mut self) {
+    fn commit_latest_checkpoint(&mut self) {
         self.internals.checkpoint_commit();
     }
 

--- a/crates/common/precompile-storage/src/provider.rs
+++ b/crates/common/precompile-storage/src/provider.rs
@@ -122,8 +122,11 @@ pub trait PrecompileStorageProvider {
 
     /// Creates a new journal checkpoint for atomic state management.
     fn checkpoint(&mut self) -> JournalCheckpoint;
-    /// Commits all state changes since the last checkpoint.
-    fn checkpoint_commit(&mut self);
+    /// Commits the most recently created active checkpoint.
+    ///
+    /// Keeps all state changes made since that checkpoint was opened. Commit is
+    /// always stack-top / LIFO and does not target an older checkpoint token.
+    fn commit_latest_checkpoint(&mut self);
     /// Reverts all state changes back to the given checkpoint.
     fn checkpoint_revert(&mut self, checkpoint: JournalCheckpoint);
 

--- a/crates/common/precompile-storage/src/provider.rs
+++ b/crates/common/precompile-storage/src/provider.rs
@@ -127,6 +127,12 @@ pub trait PrecompileStorageProvider {
     /// Keeps all state changes made since that checkpoint was opened. Commit is
     /// always stack-top / LIFO and does not target an older checkpoint token.
     fn commit_latest_checkpoint(&mut self);
+    /// Asserts that `checkpoint` is the most recently created active checkpoint.
+    ///
+    /// Test providers use this hook to catch out-of-order guard commits before
+    /// [`Self::commit_latest_checkpoint`] resolves the wrong stack entry.
+    #[cfg(any(test, feature = "test-utils"))]
+    fn assert_latest_checkpoint(&self, _checkpoint: JournalCheckpoint) {}
     /// Reverts all state changes back to the given checkpoint.
     fn checkpoint_revert(&mut self, checkpoint: JournalCheckpoint);
 

--- a/crates/common/precompile-storage/src/storage_ctx.rs
+++ b/crates/common/precompile-storage/src/storage_ctx.rs
@@ -332,7 +332,7 @@ impl CheckpointGuard<'_> {
     /// because `drop` may run during unwinding where a second panic would abort.
     pub fn commit(mut self) {
         if self.checkpoint.take().is_some() {
-            self.storage.with_storage(|s| s.checkpoint_commit());
+            self.storage.with_storage(|s| s.commit_latest_checkpoint());
         }
     }
 }

--- a/crates/common/precompile-storage/src/storage_ctx.rs
+++ b/crates/common/precompile-storage/src/storage_ctx.rs
@@ -331,8 +331,18 @@ impl CheckpointGuard<'_> {
     /// surface loudly. Contrast with `drop` below, which uses `try_borrow_mut`
     /// because `drop` may run during unwinding where a second panic would abort.
     pub fn commit(mut self) {
-        if self.checkpoint.take().is_some() {
-            self.storage.with_storage(|s| s.commit_latest_checkpoint());
+        let checkpoint = self.checkpoint.take();
+        match checkpoint {
+            Some(checkpoint) => {
+                self.storage.with_storage(|storage| {
+                    #[cfg(any(test, feature = "test-utils"))]
+                    storage.assert_latest_checkpoint(checkpoint);
+                    #[cfg(not(any(test, feature = "test-utils")))]
+                    let _ = checkpoint;
+                    storage.commit_latest_checkpoint();
+                });
+            }
+            None => {}
         }
     }
 }
@@ -494,6 +504,19 @@ mod tests {
                 ctx.sstore(addr, key, U256::from(1)).unwrap();
             }
             assert_eq!(ctx.sload(addr, key).unwrap(), U256::from(99));
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "out-of-order checkpoint commit (expected top of stack)")]
+    fn checkpoint_commit_rejects_non_lifo_order() {
+        let mut storage = crate::hashmap::HashMapStorageProvider::new(1);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let outer = ctx.checkpoint();
+            let _inner = ctx.checkpoint();
+
+            outer.commit();
         });
     }
 

--- a/crates/common/precompile-storage/src/storage_ctx.rs
+++ b/crates/common/precompile-storage/src/storage_ctx.rs
@@ -332,17 +332,14 @@ impl CheckpointGuard<'_> {
     /// because `drop` may run during unwinding where a second panic would abort.
     pub fn commit(mut self) {
         let checkpoint = self.checkpoint.take();
-        match checkpoint {
-            Some(checkpoint) => {
-                self.storage.with_storage(|storage| {
-                    #[cfg(any(test, feature = "test-utils"))]
-                    storage.assert_latest_checkpoint(checkpoint);
-                    #[cfg(not(any(test, feature = "test-utils")))]
-                    let _ = checkpoint;
-                    storage.commit_latest_checkpoint();
-                });
-            }
-            None => {}
+        if let Some(checkpoint) = checkpoint {
+            self.storage.with_storage(|storage| {
+                #[cfg(any(test, feature = "test-utils"))]
+                storage.assert_latest_checkpoint(checkpoint);
+                #[cfg(not(any(test, feature = "test-utils")))]
+                let _ = checkpoint;
+                storage.commit_latest_checkpoint();
+            });
         }
     }
 }

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -386,7 +386,7 @@ impl PrecompileStorageProvider for StateProviderPrecompileStorage<'_> {
         JournalCheckpoint::default()
     }
 
-    fn checkpoint_commit(&mut self) {}
+    fn commit_latest_checkpoint(&mut self) {}
 
     fn checkpoint_revert(&mut self, _checkpoint: JournalCheckpoint) {}
 
@@ -615,7 +615,7 @@ impl PrecompileStorageProvider for OverlayPrecompileStorage<'_> {
         JournalCheckpoint::default()
     }
 
-    fn checkpoint_commit(&mut self) {}
+    fn commit_latest_checkpoint(&mut self) {}
 
     // A `checkpoint_revert` would silently leak partial writes (the overlay
     // cannot roll back), so trip loudly in debug/test builds if the admission


### PR DESCRIPTION
## Summary
- rename the low-level commit operation to make its stack-top semantics explicit
- restore test-backend validation that rejects out-of-order `CheckpointGuard` commits
- keep production journal commits tokenless while routing callers through `CheckpointGuard::commit()`

## Test plan
- [x] `cargo test -p base-precompile-storage --lib`
- [x] `cargo check -p base-precompile-storage --features test-utils`
- [x] `cargo check -p base-execution-txpool`
- [x] `cargo clippy -p base-precompile-storage --lib --tests --features test-utils -- -D warnings`

Made with [Cursor](https://cursor.com)