### PR TITLE
fix(precompile-storage): checked slot arithmetic for delete and [T; N] (BOP-481)

### DIFF
--- a/crates/common/precompile-macros/src/storable_primitives.rs
+++ b/crates/common/precompile-macros/src/storable_primitives.rs
@@ -353,7 +353,9 @@ fn gen_packed_array_load(array_size: &usize, elem_byte_count: &usize) -> TokenSt
         for i in 0..#array_size {
             let slot_idx = calc_element_slot(i, #elem_byte_count);
             let offset = calc_element_offset(i, #elem_byte_count);
-            let slot_addr = base_slot + ::alloy_primitives::U256::from(slot_idx);
+            let slot_addr = base_slot
+                .checked_add(::alloy_primitives::U256::from(slot_idx))
+                .ok_or(::base_precompile_storage::BasePrecompileError::SlotOverflow)?;
             let slot_value = storage.load(slot_addr)?;
             result[i] = extract_from_word(slot_value, offset, #elem_byte_count)?;
         }
@@ -365,7 +367,9 @@ fn gen_packed_array_store(array_size: &usize, elem_byte_count: &usize) -> TokenS
     quote! {
         let slot_count = ::base_precompile_storage::calc_packed_slot_count(#array_size, #elem_byte_count);
         for slot_idx in 0..slot_count {
-            let slot_addr = base_slot + ::alloy_primitives::U256::from(slot_idx);
+            let slot_addr = base_slot
+                .checked_add(::alloy_primitives::U256::from(slot_idx))
+                .ok_or(::base_precompile_storage::BasePrecompileError::SlotOverflow)?;
             let mut slot_value = ::alloy_primitives::U256::ZERO;
             for i in 0..#array_size {
                 let elem_slot = calc_element_slot(i, #elem_byte_count);
@@ -384,7 +388,9 @@ fn gen_unpacked_array_load(array_size: &usize) -> TokenStream {
     quote! {
         let mut result = [Default::default(); #array_size];
         for i in 0..#array_size {
-            let elem_slot = base_slot + ::alloy_primitives::U256::from(i);
+            let elem_slot = base_slot
+                .checked_add(::alloy_primitives::U256::from(i))
+                .ok_or(::base_precompile_storage::BasePrecompileError::SlotOverflow)?;
             result[i] = ::base_precompile_storage::Storable::load(storage, elem_slot, ::base_precompile_storage::LayoutCtx::FULL)?;
         }
         Ok(result)
@@ -394,7 +400,9 @@ fn gen_unpacked_array_load(array_size: &usize) -> TokenStream {
 fn gen_unpacked_array_store() -> TokenStream {
     quote! {
         for (i, elem) in self.iter().enumerate() {
-            let elem_slot = base_slot + ::alloy_primitives::U256::from(i);
+            let elem_slot = base_slot
+                .checked_add(::alloy_primitives::U256::from(i))
+                .ok_or(::base_precompile_storage::BasePrecompileError::SlotOverflow)?;
             ::base_precompile_storage::Storable::store(elem, storage, elem_slot, ::base_precompile_storage::LayoutCtx::FULL)?;
         }
         Ok(())

--- a/crates/common/precompile-storage/src/provider.rs
+++ b/crates/common/precompile-storage/src/provider.rs
@@ -316,7 +316,10 @@ pub trait Storable: StorableType + Sized {
         match ctx.packed_offset() {
             None => {
                 for offset in 0..Self::SLOTS {
-                    storage.store(slot + U256::from(offset), U256::ZERO)?;
+                    let slot_addr = slot
+                        .checked_add(U256::from(offset))
+                        .ok_or(BasePrecompileError::SlotOverflow)?;
+                    storage.store(slot_addr, U256::ZERO)?;
                 }
                 Ok(())
             }

--- a/crates/common/precompile-storage/src/types/array.rs
+++ b/crates/common/precompile-storage/src/types/array.rs
@@ -142,3 +142,132 @@ where
         self.as_slot().t_delete()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::U256;
+
+    use super::*;
+    use crate::{
+        hashmap::setup_storage, provider::PrecompileStorageProvider, storage_ctx::StorageCtx,
+    };
+
+    const SENTINEL: u64 = 0xDEAD;
+
+    #[test]
+    fn unpacked_array_load_store_succeed_at_boundary() {
+        let (mut storage, address) = setup_storage();
+        let base = U256::MAX - U256::ONE;
+        let value = [U256::from(1u64), U256::from(2u64)];
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut slot = Slot::<[U256; 2]>::new(base, address, ctx);
+            slot.write(value).unwrap();
+            assert_eq!(slot.read().unwrap(), value);
+        });
+    }
+
+    #[test]
+    fn unpacked_array_store_returns_slot_overflow_near_max() {
+        let (mut storage, address) = setup_storage();
+        storage.sstore(address, U256::ZERO, U256::from(SENTINEL)).unwrap();
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut slot = Slot::<[U256; 2]>::new(U256::MAX, address, ctx);
+            let err = slot.write([U256::from(1u64), U256::from(2u64)]).unwrap_err();
+            assert_eq!(err, BasePrecompileError::SlotOverflow);
+        });
+
+        assert_eq!(
+            storage.sload(address, U256::ZERO).unwrap(),
+            U256::from(SENTINEL),
+            "overflow must not wrap-store into slot 0"
+        );
+    }
+
+    #[test]
+    fn unpacked_array_load_returns_slot_overflow_near_max() {
+        let (mut storage, address) = setup_storage();
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let slot = Slot::<[U256; 2]>::new(U256::MAX, address, ctx);
+            let err = slot.read().unwrap_err();
+            assert_eq!(err, BasePrecompileError::SlotOverflow);
+        });
+    }
+
+    #[test]
+    fn packed_array_load_store_succeed_at_boundary() {
+        let (mut storage, address) = setup_storage();
+        // [u16; 32] spans 2 packed slots, so MAX - 1 is the last safe base.
+        let base = U256::MAX - U256::ONE;
+        let value = [7u16; 32];
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut slot = Slot::<[u16; 32]>::new(base, address, ctx);
+            slot.write(value).unwrap();
+            assert_eq!(slot.read().unwrap(), value);
+        });
+    }
+
+    #[test]
+    fn packed_array_store_returns_slot_overflow_near_max() {
+        let (mut storage, address) = setup_storage();
+        storage.sstore(address, U256::ZERO, U256::from(SENTINEL)).unwrap();
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut slot = Slot::<[u16; 32]>::new(U256::MAX, address, ctx);
+            let err = slot.write([9u16; 32]).unwrap_err();
+            assert_eq!(err, BasePrecompileError::SlotOverflow);
+        });
+
+        assert_eq!(
+            storage.sload(address, U256::ZERO).unwrap(),
+            U256::from(SENTINEL),
+            "overflow must not wrap-store into slot 0"
+        );
+    }
+
+    #[test]
+    fn packed_array_load_returns_slot_overflow_near_max() {
+        let (mut storage, address) = setup_storage();
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let slot = Slot::<[u16; 32]>::new(U256::MAX, address, ctx);
+            let err = slot.read().unwrap_err();
+            assert_eq!(err, BasePrecompileError::SlotOverflow);
+        });
+    }
+
+    #[test]
+    fn default_multi_slot_delete_returns_slot_overflow_near_max() {
+        let (mut storage, address) = setup_storage();
+        storage.sstore(address, U256::ZERO, U256::from(SENTINEL)).unwrap();
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            // [U256; 2] uses the default Storable::delete multi-slot loop.
+            let mut slot = Slot::<[U256; 2]>::new(U256::MAX, address, ctx);
+            let err = slot.delete().unwrap_err();
+            assert_eq!(err, BasePrecompileError::SlotOverflow);
+        });
+
+        assert_eq!(
+            storage.sload(address, U256::ZERO).unwrap(),
+            U256::from(SENTINEL),
+            "overflow must not wrap-delete into slot 0"
+        );
+    }
+
+    #[test]
+    fn default_multi_slot_delete_succeeds_at_boundary() {
+        let (mut storage, address) = setup_storage();
+        let base = U256::MAX - U256::ONE;
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut slot = Slot::<[U256; 2]>::new(base, address, ctx);
+            slot.write([U256::from(11u64), U256::from(22u64)]).unwrap();
+            slot.delete().unwrap();
+            assert_eq!(slot.read().unwrap(), [U256::ZERO; 2]);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- Completes Cantina finding #33 follow-up ([BOP-481](https://linear.app/coinbase/issue/BOP-481/33-follow-up-checked-slot-arithmetic-in-storabledelete-and-t)): replace the remaining unchecked `U256` slot additions left after BOP-356 / #3415 / #3427.
- Default `Storable::delete` and primitive `[T; N]` load/store codegen now use `checked_add` and return `BasePrecompileError::SlotOverflow` on overflow, matching existing vec/array-handler/struct-array patterns.
- Adds regression tests for packed/unpacked array load/store and multi-slot delete near `U256::MAX`, including boundary-success cases and asserting no wrap-write to slot `0`.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy -p base-precompile-storage -p base-precompile-macros --all-targets -- -D warnings`
- [x] `cargo nextest run -p base-precompile-storage -p base-precompile-macros --all-features`
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)