### PR TITLE
refactor(txpool): Simplify Transaction Pool Internals

### DIFF
--- a/crates/execution/txpool/src/builder/rpc.rs
+++ b/crates/execution/txpool/src/builder/rpc.rs
@@ -229,6 +229,22 @@ mod tests {
         BuilderApiImpl::new(NoopTransactionPool::<BasePooledTransaction>::new())
     }
 
+    fn validated_transaction<E>(
+        sender: Address,
+        raw: Bytes,
+        extensions: E,
+    ) -> ValidatedTransaction<E> {
+        ValidatedTransaction {
+            sender,
+            raw,
+            min_block_number: None,
+            max_block_number: None,
+            min_timestamp: None,
+            max_timestamp: None,
+            extensions,
+        }
+    }
+
     // ==========================================================================
     // Wire extension tests
     // ==========================================================================
@@ -271,15 +287,7 @@ mod tests {
         let handler = extension_handler();
         let (sender, raw) = create_eip1559_tx();
 
-        let tx = ValidatedTransaction {
-            sender,
-            raw,
-            min_block_number: None,
-            max_block_number: None,
-            min_timestamp: None,
-            max_timestamp: None,
-            extensions: TestExtensions { reject: Some(true) },
-        };
+        let tx = validated_transaction(sender, raw, TestExtensions { reject: Some(true) });
 
         let err = handler.insert_validated_transaction(tx).await.unwrap_err();
         assert_eq!(
@@ -299,15 +307,7 @@ mod tests {
         let handler = extension_handler();
         let (sender, raw) = create_eip1559_tx();
 
-        let tx = ValidatedTransaction {
-            sender,
-            raw,
-            min_block_number: None,
-            max_block_number: None,
-            min_timestamp: None,
-            max_timestamp: None,
-            extensions: TestExtensions { reject: None },
-        };
+        let tx = validated_transaction(sender, raw, TestExtensions { reject: None });
 
         let err = handler.insert_validated_transaction(tx).await.unwrap_err();
         // The extension passed, so the request got as far as the noop pool,
@@ -335,15 +335,11 @@ mod tests {
     async fn decode_invalid_bytes_returns_invalid_params() {
         let handler = handler();
 
-        let tx = ValidatedTransaction {
-            sender: Address::repeat_byte(0x01),
-            raw: Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]),
-            min_block_number: None,
-            max_block_number: None,
-            min_timestamp: None,
-            max_timestamp: None,
-            extensions: NoExtensions {},
-        };
+        let tx = validated_transaction(
+            Address::repeat_byte(0x01),
+            Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]),
+            NoExtensions {},
+        );
 
         let result = handler.insert_validated_transaction(tx).await;
         assert!(result.is_err(), "expected decode error for invalid bytes");
@@ -365,15 +361,7 @@ mod tests {
     async fn decode_empty_bytes_returns_invalid_params() {
         let handler = handler();
 
-        let tx = ValidatedTransaction {
-            sender: Address::ZERO,
-            raw: Bytes::new(),
-            min_block_number: None,
-            max_block_number: None,
-            min_timestamp: None,
-            max_timestamp: None,
-            extensions: NoExtensions {},
-        };
+        let tx = validated_transaction(Address::ZERO, Bytes::new(), NoExtensions {});
 
         let result = handler.insert_validated_transaction(tx).await;
         assert!(result.is_err(), "expected decode error for empty bytes");
@@ -394,15 +382,7 @@ mod tests {
         let (sender, full_raw) = create_deposit_tx();
         let truncated = Bytes::from(full_raw[..full_raw.len() / 2].to_vec());
 
-        let tx = ValidatedTransaction {
-            sender,
-            raw: truncated,
-            min_block_number: None,
-            max_block_number: None,
-            min_timestamp: None,
-            max_timestamp: None,
-            extensions: NoExtensions {},
-        };
+        let tx = validated_transaction(sender, truncated, NoExtensions {});
 
         let result = handler.insert_validated_transaction(tx).await;
         assert!(result.is_err(), "expected decode error for truncated tx");
@@ -420,15 +400,11 @@ mod tests {
         let handler = handler();
 
         // Type byte 0xFF is not a valid EIP-2718 tx type
-        let tx = ValidatedTransaction {
-            sender: Address::repeat_byte(0x01),
-            raw: Bytes::from_static(&[0xFF, 0x01, 0x02, 0x03]),
-            min_block_number: None,
-            max_block_number: None,
-            min_timestamp: None,
-            max_timestamp: None,
-            extensions: NoExtensions {},
-        };
+        let tx = validated_transaction(
+            Address::repeat_byte(0x01),
+            Bytes::from_static(&[0xFF, 0x01, 0x02, 0x03]),
+            NoExtensions {},
+        );
 
         let result = handler.insert_validated_transaction(tx).await;
         assert!(result.is_err(), "expected decode error for invalid type byte");
@@ -441,15 +417,8 @@ mod tests {
     async fn decode_single_byte_returns_invalid_params() {
         let handler = handler();
 
-        let tx = ValidatedTransaction {
-            sender: Address::ZERO,
-            raw: Bytes::from_static(&[0x02]), // Just type byte, no payload
-            min_block_number: None,
-            max_block_number: None,
-            min_timestamp: None,
-            max_timestamp: None,
-            extensions: NoExtensions {},
-        };
+        // Just the type byte, without a payload.
+        let tx = validated_transaction(Address::ZERO, Bytes::from_static(&[0x02]), NoExtensions {});
 
         let result = handler.insert_validated_transaction(tx).await;
         assert!(result.is_err());
@@ -463,15 +432,11 @@ mod tests {
         let handler = handler();
 
         // Legacy tx (type 0x00) followed by invalid RLP
-        let tx = ValidatedTransaction {
-            sender: Address::ZERO,
-            raw: Bytes::from_static(&[0x00, 0x01, 0x02]),
-            min_block_number: None,
-            max_block_number: None,
-            min_timestamp: None,
-            max_timestamp: None,
-            extensions: NoExtensions {},
-        };
+        let tx = validated_transaction(
+            Address::ZERO,
+            Bytes::from_static(&[0x00, 0x01, 0x02]),
+            NoExtensions {},
+        );
 
         let result = handler.insert_validated_transaction(tx).await;
         let err = result.unwrap_err();
@@ -483,15 +448,7 @@ mod tests {
         let handler = handler();
 
         let (sender, raw) = create_eip1559_tx();
-        let tx = ValidatedTransaction {
-            sender,
-            raw,
-            min_block_number: None,
-            max_block_number: None,
-            min_timestamp: None,
-            max_timestamp: None,
-            extensions: NoExtensions {},
-        };
+        let tx = validated_transaction(sender, raw, NoExtensions {});
 
         let result = handler.insert_validated_transaction(tx).await;
         let err = result.unwrap_err();

--- a/crates/execution/txpool/src/bundle/rpc.rs
+++ b/crates/execution/txpool/src/bundle/rpc.rs
@@ -270,10 +270,9 @@ mod tests {
         )
     }
 
-    #[test]
-    fn rejects_empty_txs() {
-        let req = SendBundleRequest {
-            txs: vec![],
+    fn request(txs: Vec<Bytes>) -> SendBundleRequest {
+        SendBundleRequest {
+            txs,
             min_block_number: None,
             max_block_number: None,
             min_timestamp: None,
@@ -281,166 +280,92 @@ mod tests {
             reverting_tx_hashes: None,
             replacement_uuid: None,
             builders: None,
-        };
+        }
+    }
+
+    #[test]
+    fn rejects_empty_txs() {
+        let req = request(vec![]);
         let err = validate_bundle_request(&req, 100).unwrap_err();
         assert!(err.message().contains("exactly 1 transaction"));
     }
 
     #[test]
     fn rejects_multiple_txs() {
-        let req = SendBundleRequest {
-            txs: vec![Bytes::from_static(b"a"), Bytes::from_static(b"b")],
-            min_block_number: None,
-            max_block_number: None,
-            min_timestamp: None,
-            max_timestamp: None,
-            reverting_tx_hashes: None,
-            replacement_uuid: None,
-            builders: None,
-        };
+        let req = request(vec![Bytes::from_static(b"a"), Bytes::from_static(b"b")]);
         let err = validate_bundle_request(&req, 100).unwrap_err();
         assert!(err.message().contains("exactly 1 transaction"));
     }
 
     #[test]
     fn rejects_min_block_number_too_far_ahead() {
-        let req = SendBundleRequest {
-            txs: vec![Bytes::from_static(b"tx")],
-            min_block_number: Some(200),
-            max_block_number: None,
-            min_timestamp: None,
-            max_timestamp: None,
-            reverting_tx_hashes: None,
-            replacement_uuid: None,
-            builders: None,
-        };
+        let mut req = request(vec![Bytes::from_static(b"tx")]);
+        req.min_block_number = Some(200);
         let err = validate_bundle_request(&req, 100).unwrap_err();
         assert!(err.message().contains("too far ahead"));
     }
 
     #[test]
     fn accepts_block_window_within_range() {
-        let req = SendBundleRequest {
-            txs: vec![Bytes::from_static(b"tx")],
-            min_block_number: Some(120),
-            max_block_number: Some(130),
-            min_timestamp: None,
-            max_timestamp: None,
-            reverting_tx_hashes: None,
-            replacement_uuid: None,
-            builders: None,
-        };
+        let mut req = request(vec![Bytes::from_static(b"tx")]);
+        req.min_block_number = Some(120);
+        req.max_block_number = Some(130);
         assert!(validate_bundle_request(&req, 100).is_ok());
     }
 
     #[test]
     fn rejects_max_block_number_in_the_past() {
-        let req = SendBundleRequest {
-            txs: vec![Bytes::from_static(b"tx")],
-            min_block_number: None,
-            max_block_number: Some(50),
-            min_timestamp: None,
-            max_timestamp: None,
-            reverting_tx_hashes: None,
-            replacement_uuid: None,
-            builders: None,
-        };
+        let mut req = request(vec![Bytes::from_static(b"tx")]);
+        req.max_block_number = Some(50);
         let err = validate_bundle_request(&req, 100).unwrap_err();
         assert!(err.message().contains("in the past"));
     }
 
     #[test]
     fn rejects_min_block_number_after_max_block_number() {
-        let req = SendBundleRequest {
-            txs: vec![Bytes::from_static(b"tx")],
-            min_block_number: Some(120),
-            max_block_number: Some(110),
-            min_timestamp: None,
-            max_timestamp: None,
-            reverting_tx_hashes: None,
-            replacement_uuid: None,
-            builders: None,
-        };
+        let mut req = request(vec![Bytes::from_static(b"tx")]);
+        req.min_block_number = Some(120);
+        req.max_block_number = Some(110);
         let err = validate_bundle_request(&req, 100).unwrap_err();
         assert!(err.message().contains("after maxBlockNumber"));
     }
 
     #[test]
     fn rejects_reverting_tx_hashes() {
-        let req = SendBundleRequest {
-            txs: vec![Bytes::from_static(b"tx")],
-            min_block_number: None,
-            max_block_number: None,
-            min_timestamp: None,
-            max_timestamp: None,
-            reverting_tx_hashes: Some(vec![TxHash::ZERO]),
-            replacement_uuid: None,
-            builders: None,
-        };
+        let mut req = request(vec![Bytes::from_static(b"tx")]);
+        req.reverting_tx_hashes = Some(vec![TxHash::ZERO]);
         let err = validate_bundle_request(&req, 100).unwrap_err();
         assert!(err.message().contains("revertingTxHashes"));
     }
 
     #[test]
     fn rejects_replacement_uuid() {
-        let req = SendBundleRequest {
-            txs: vec![Bytes::from_static(b"tx")],
-            min_block_number: None,
-            max_block_number: None,
-            min_timestamp: None,
-            max_timestamp: None,
-            reverting_tx_hashes: None,
-            replacement_uuid: Some("abc".to_string()),
-            builders: None,
-        };
+        let mut req = request(vec![Bytes::from_static(b"tx")]);
+        req.replacement_uuid = Some("abc".to_string());
         let err = validate_bundle_request(&req, 100).unwrap_err();
         assert!(err.message().contains("replacementUuid"));
     }
 
     #[test]
     fn rejects_builders() {
-        let req = SendBundleRequest {
-            txs: vec![Bytes::from_static(b"tx")],
-            min_block_number: None,
-            max_block_number: None,
-            min_timestamp: None,
-            max_timestamp: None,
-            reverting_tx_hashes: None,
-            replacement_uuid: None,
-            builders: Some(vec!["builder1".to_string()]),
-        };
+        let mut req = request(vec![Bytes::from_static(b"tx")]);
+        req.builders = Some(vec!["builder1".to_string()]);
         let err = validate_bundle_request(&req, 100).unwrap_err();
         assert!(err.message().contains("builders"));
     }
 
     #[test]
     fn rejects_min_block_number_in_the_past() {
-        let req = SendBundleRequest {
-            txs: vec![Bytes::from_static(b"tx")],
-            min_block_number: Some(50),
-            max_block_number: None,
-            min_timestamp: None,
-            max_timestamp: None,
-            reverting_tx_hashes: None,
-            replacement_uuid: None,
-            builders: None,
-        };
+        let mut req = request(vec![Bytes::from_static(b"tx")]);
+        req.min_block_number = Some(50);
         let err = validate_bundle_request(&req, 100).unwrap_err();
         assert!(err.message().contains("in the past"));
     }
 
     #[test]
     fn rejects_max_timestamp_in_the_past() {
-        let req = SendBundleRequest {
-            txs: vec![Bytes::from_static(b"tx")],
-            min_block_number: None,
-            max_block_number: None,
-            min_timestamp: None,
-            max_timestamp: Some(1),
-            reverting_tx_hashes: None,
-            replacement_uuid: None,
-            builders: None,
-        };
+        let mut req = request(vec![Bytes::from_static(b"tx")]);
+        req.max_timestamp = Some(1);
         let err = validate_bundle_request(&req, 100).unwrap_err();
         assert!(err.message().contains("in the past"));
     }
@@ -448,48 +373,23 @@ mod tests {
     #[test]
     fn rejects_min_after_max_timestamp() {
         let now = crate::transaction::unix_time_millis() as u64;
-        let req = SendBundleRequest {
-            txs: vec![Bytes::from_static(b"tx")],
-            min_block_number: None,
-            max_block_number: None,
-            min_timestamp: Some(now + 30_000),
-            max_timestamp: Some(now + 10_000),
-            reverting_tx_hashes: None,
-            replacement_uuid: None,
-            builders: None,
-        };
+        let mut req = request(vec![Bytes::from_static(b"tx")]);
+        req.min_timestamp = Some(now + 30_000);
+        req.max_timestamp = Some(now + 10_000);
         let err = validate_bundle_request(&req, 100).unwrap_err();
         assert!(err.message().contains("after maxTimestamp"));
     }
 
     #[test]
     fn accepts_minimal_valid_request() {
-        let req = SendBundleRequest {
-            txs: vec![Bytes::from_static(b"tx")],
-            min_block_number: None,
-            max_block_number: None,
-            min_timestamp: None,
-            max_timestamp: None,
-            reverting_tx_hashes: None,
-            replacement_uuid: None,
-            builders: None,
-        };
+        let req = request(vec![Bytes::from_static(b"tx")]);
         assert!(validate_bundle_request(&req, 100).is_ok());
     }
 
     #[tokio::test]
     async fn send_bundle_rejects_empty_bundle() {
         let handler = handler(100);
-        let req = SendBundleRequest {
-            txs: vec![],
-            min_block_number: None,
-            max_block_number: None,
-            min_timestamp: None,
-            max_timestamp: None,
-            reverting_tx_hashes: None,
-            replacement_uuid: None,
-            builders: None,
-        };
+        let req = request(vec![]);
 
         let err = handler.send_bundle(req).await.unwrap_err();
         assert_eq!(err.code(), ErrorCode::InvalidParams.code());
@@ -499,16 +399,8 @@ mod tests {
     #[tokio::test]
     async fn send_bundle_rejects_min_block_number_too_far_ahead() {
         let handler = handler(100);
-        let req = SendBundleRequest {
-            txs: vec![Bytes::from_static(b"tx")],
-            min_block_number: Some(200),
-            max_block_number: None,
-            min_timestamp: None,
-            max_timestamp: None,
-            reverting_tx_hashes: None,
-            replacement_uuid: None,
-            builders: None,
-        };
+        let mut req = request(vec![Bytes::from_static(b"tx")]);
+        req.min_block_number = Some(200);
 
         let err = handler.send_bundle(req).await.unwrap_err();
         assert_eq!(err.code(), ErrorCode::InvalidParams.code());

--- a/crates/execution/txpool/src/forwarder/task.rs
+++ b/crates/execution/txpool/src/forwarder/task.rs
@@ -37,18 +37,13 @@ struct RateLimiter {
 
 impl RateLimiter {
     fn new(max_rps: u32) -> Self {
-        let capacity = if max_rps == 0 { 0 } else { max_rps as usize };
-        Self { timestamps: VecDeque::with_capacity(capacity), max_rps }
+        Self { timestamps: VecDeque::with_capacity(max_rps as usize), max_rps }
     }
 
     fn prune(&mut self, now: Instant) {
         let window = std::time::Duration::from_secs(1);
-        while let Some(&front) = self.timestamps.front() {
-            if now.duration_since(front) >= window {
-                self.timestamps.pop_front();
-            } else {
-                break;
-            }
+        while self.timestamps.front().is_some_and(|front| now.duration_since(*front) >= window) {
+            self.timestamps.pop_front();
         }
     }
 
@@ -67,10 +62,9 @@ impl RateLimiter {
             return None;
         }
 
-        let oldest = self.timestamps.front().expect("non-empty after prune");
-        let window = std::time::Duration::from_secs(1);
-        let elapsed = now.duration_since(*oldest);
-        Some(window.saturating_sub(elapsed))
+        Some(std::time::Duration::from_secs(1).saturating_sub(
+            now.duration_since(*self.timestamps.front().expect("non-empty after prune")),
+        ))
     }
 
     fn record_send(&mut self) {
@@ -247,9 +241,8 @@ where
         if buffered.is_empty() {
             return;
         }
-        let tx_hashes: Vec<TxHash> = buffered.iter().map(|tx| tx.tx_hash).collect();
-        let batch: Vec<ValidatedTransaction<E>> =
-            buffered.into_iter().map(|tx| tx.transaction).collect();
+        let (tx_hashes, batch): (Vec<TxHash>, Vec<ValidatedTransaction<E>>) =
+            buffered.into_iter().map(|tx| (tx.tx_hash, tx.transaction)).unzip();
 
         trace!(
             builder_url = %self.builder_url,

--- a/crates/execution/txpool/src/limits.rs
+++ b/crates/execution/txpool/src/limits.rs
@@ -183,13 +183,10 @@ impl PayerBook {
         self.balance = balance;
         let mut evicted = Vec::new();
         while self.reserved > self.balance {
-            let Some((&(priority, hash), &max_cost)) = self.by_priority.iter().next() else {
+            let Some(&(_, hash)) = self.by_priority.keys().next() else {
                 break;
             };
-            self.by_priority.remove(&(priority, hash));
-            self.entries.remove(&hash);
-            debug_assert!(self.reserved >= max_cost, "reserved balance accounting underflow");
-            self.reserved = self.reserved.saturating_sub(max_cost);
+            assert!(self.remove(&hash), "priority index must reference an existing reservation");
             evicted.push(hash);
         }
         evicted

--- a/crates/execution/txpool/src/manifest.rs
+++ b/crates/execution/txpool/src/manifest.rs
@@ -169,6 +169,12 @@ impl ManifestStale {
 
 #[cfg(test)]
 mod tests {
+    //! Manifest unit tests.
+    //!
+    //! [`FailingDatabase`] is hand-written because [`revm::Database`] is an external trait and
+    //! every read must return the same custom associated error type; `automock` cannot be attached
+    //! to that trait.
+
     use alloy_primitives::B256;
     use revm::{
         Database,

--- a/crates/execution/txpool/src/manifest.rs
+++ b/crates/execution/txpool/src/manifest.rs
@@ -169,12 +169,6 @@ impl ManifestStale {
 
 #[cfg(test)]
 mod tests {
-    //! Manifest unit tests.
-    //!
-    //! [`FailingDatabase`] is hand-written because [`revm::Database`] is an external trait and
-    //! every read must return the same custom associated error type; `automock` cannot be attached
-    //! to that trait.
-
     use alloy_primitives::B256;
     use revm::{
         Database,

--- a/crates/execution/txpool/src/pool.rs
+++ b/crates/execution/txpool/src/pool.rs
@@ -954,19 +954,7 @@ where
     ) {
         let mut current_size = 0;
         for hash in tx_hashes {
-            if let Some(transaction) = self.protocol_pool.get(hash) {
-                let Some((pooled, encoded_length)) = pooled_element(&transaction) else {
-                    continue;
-                };
-                current_size += encoded_length;
-                if limit.exceeds(current_size) {
-                    break;
-                }
-                out.push(pooled);
-                continue;
-            }
-
-            let Some(transaction) = self.nonce_pool.read().get(hash) else {
+            let Some(transaction) = self.get(hash) else {
                 continue;
             };
             let Some((pooled, encoded_length)) = pooled_element(&transaction) else {
@@ -1614,9 +1602,7 @@ impl<T: BasePooledTx> SidecarListeners<T> {
     fn broadcast_new(&mut self, event: NewTransactionEvent<T>) {
         self.new_all.retain(|listener| listener.try_send(event.clone()).is_ok());
         if event.transaction.propagate {
-            let propagate_event = event.clone();
-            self.new_propagate
-                .retain(|listener| listener.try_send(propagate_event.clone()).is_ok());
+            self.new_propagate.retain(|listener| listener.try_send(event.clone()).is_ok());
         }
     }
 }
@@ -1656,14 +1642,13 @@ fn merge_receivers<T: Send + 'static>(
 fn pooled_element<T: BasePooledTx>(
     transaction: &Arc<ValidPoolTransaction<T>>,
 ) -> Option<(<T as PoolTransaction>::Pooled, usize)> {
-    let encoded_length = transaction.encoded_length();
     transaction
         .transaction
         .clone()
         .try_into_pooled()
         .ok()
         .map(|recovered| recovered.into_parts().0)
-        .map(|pooled| (pooled, encoded_length))
+        .map(|pooled| (pooled, transaction.encoded_length()))
 }
 
 #[cfg(test)]
@@ -1757,15 +1742,26 @@ mod tests {
         nonce_sequence: u64,
         max_fee_per_gas: u128,
     ) -> BasePooledTransaction {
+        signed_8130(signer, nonce_key, nonce_sequence, 0, max_fee_per_gas, 50_000)
+    }
+
+    fn signed_8130(
+        signer: &PrivateKeySigner,
+        nonce_key: U256,
+        nonce_sequence: u64,
+        expiry: u64,
+        max_fee_per_gas: u128,
+        gas_limit: u64,
+    ) -> BasePooledTransaction {
         let tx = TxEip8130 {
             chain_id: test_chain_id(),
             sender: None,
             nonce_key,
             nonce_sequence,
-            expiry: 0,
+            expiry,
             max_priority_fee_per_gas: 0,
             max_fee_per_gas,
-            gas_limit: 50_000,
+            gas_limit,
             account_changes: Vec::new(),
             calls: Vec::new(),
             metadata: Bytes::new(),
@@ -1783,25 +1779,7 @@ mod tests {
         expiry: u64,
         max_fee_per_gas: u128,
     ) -> BasePooledTransaction {
-        let tx = TxEip8130 {
-            chain_id: test_chain_id(),
-            sender: None,
-            nonce_key: Eip8130Constants::NONCE_KEY_MAX,
-            nonce_sequence: 0,
-            expiry,
-            max_priority_fee_per_gas: 0,
-            max_fee_per_gas,
-            gas_limit: 50_000,
-            account_changes: Vec::new(),
-            calls: Vec::new(),
-            metadata: Bytes::new(),
-            payer: None,
-        };
-        let signature = signer.sign_hash_sync(&tx.sender_signature_hash()).unwrap();
-        let signed =
-            Eip8130Signed::new(tx, Bytes::from(signature.as_bytes().to_vec()), Bytes::new());
-        let pooled = ConsensusPooledTransaction::Eip8130(signed);
-        BasePooledTransaction::from_pooled(Recovered::new_unchecked(pooled, signer.address()))
+        signed_8130(signer, Eip8130Constants::NONCE_KEY_MAX, 0, expiry, max_fee_per_gas, 50_000)
     }
 
     fn valid_pool_transaction(
@@ -1965,25 +1943,7 @@ mod tests {
         expiry: u64,
         max_fee_per_gas: u128,
     ) -> BasePooledTransaction {
-        let tx = TxEip8130 {
-            chain_id: test_chain_id(),
-            sender: None,
-            nonce_key,
-            nonce_sequence,
-            expiry,
-            max_priority_fee_per_gas: 0,
-            max_fee_per_gas,
-            gas_limit: 1_000_000,
-            account_changes: Vec::new(),
-            calls: Vec::new(),
-            metadata: Bytes::new(),
-            payer: None,
-        };
-        let signature = signer.sign_hash_sync(&tx.sender_signature_hash()).unwrap();
-        let signed =
-            Eip8130Signed::new(tx, Bytes::from(signature.as_bytes().to_vec()), Bytes::new());
-        let pooled = ConsensusPooledTransaction::Eip8130(signed);
-        BasePooledTransaction::from_pooled(Recovered::new_unchecked(pooled, signer.address()))
+        signed_8130(signer, nonce_key, nonce_sequence, expiry, max_fee_per_gas, 1_000_000)
     }
 
     #[tokio::test]

--- a/crates/execution/txpool/src/transaction.rs
+++ b/crates/execution/txpool/src/transaction.rs
@@ -93,20 +93,7 @@ pub struct BasePooledTransaction<
 impl<Cons: SignedTransaction, Pooled> BasePooledTransaction<Cons, Pooled> {
     /// Create new instance of [Self].
     pub fn new(transaction: Recovered<Cons>, encoded_length: usize) -> Self {
-        Self {
-            inner: EthPooledTransaction::new(transaction, encoded_length),
-            estimated_tx_compressed_size: Default::default(),
-            _pd: core::marker::PhantomData,
-            encoded_2718: Default::default(),
-            received_at: unix_time_millis(),
-            min_block_number: None,
-            max_block_number: None,
-            min_timestamp: None,
-            max_timestamp: None,
-            watch_set: OnceLock::new(),
-            limit_class: OnceLock::new(),
-            watch_manifest: OnceLock::new(),
-        }
+        Self::new_with_received_at(transaction, encoded_length, unix_time_millis())
     }
 
     /// Create new instance with an explicit `received_at` timestamp (millis since Unix epoch).
@@ -161,11 +148,6 @@ impl<Cons: SignedTransaction, Pooled> BasePooledTransaction<Cons, Pooled> {
     /// Returns lazily computed EIP-2718 encoded bytes of the transaction.
     pub fn encoded_2718(&self) -> &Bytes {
         self.encoded_2718.get_or_init(|| self.inner.transaction().encoded_2718().into())
-    }
-
-    /// Returns the timestamp (millis since Unix epoch) when this transaction was received.
-    const fn inner_received_at(&self) -> u128 {
-        self.received_at
     }
 }
 
@@ -504,7 +486,7 @@ where
     Pooled: Send + Sync + 'static,
 {
     fn received_at(&self) -> u128 {
-        self.inner_received_at()
+        self.received_at
     }
 }
 

--- a/crates/execution/txpool/src/two_d_nonce_pool.rs
+++ b/crates/execution/txpool/src/two_d_nonce_pool.rs
@@ -673,12 +673,23 @@ mod tests {
         max_priority_fee_per_gas: u128,
         max_fee_per_gas: u128,
     ) -> BasePooledTransaction {
+        signed_tx(signer, nonce_key, nonce_sequence, 0, max_priority_fee_per_gas, max_fee_per_gas)
+    }
+
+    fn signed_tx(
+        signer: &PrivateKeySigner,
+        nonce_key: U256,
+        nonce_sequence: u64,
+        expiry: u64,
+        max_priority_fee_per_gas: u128,
+        max_fee_per_gas: u128,
+    ) -> BasePooledTransaction {
         let tx = TxEip8130 {
             chain_id: test_chain_id(),
             sender: None,
             nonce_key,
             nonce_sequence,
-            expiry: 0,
+            expiry,
             max_priority_fee_per_gas,
             max_fee_per_gas,
             gas_limit: 50_000,
@@ -700,27 +711,14 @@ mod tests {
         max_priority_fee_per_gas: u128,
         max_fee_per_gas: u128,
     ) -> BasePooledTransaction {
-        let tx = TxEip8130 {
-            chain_id: test_chain_id(),
-            sender: None,
-            nonce_key: Eip8130Constants::NONCE_KEY_MAX,
-            nonce_sequence: 0,
+        signed_tx(
+            signer,
+            Eip8130Constants::NONCE_KEY_MAX,
+            0,
             expiry,
             max_priority_fee_per_gas,
             max_fee_per_gas,
-            gas_limit: 50_000,
-            account_changes: Vec::new(),
-            calls: Vec::new(),
-            metadata: Bytes::new(),
-            payer: None,
-        };
-        let signature = signer.sign_hash_sync(&tx.sender_signature_hash()).unwrap();
-        let signed =
-            Eip8130Signed::new(tx, Bytes::from(signature.as_bytes().to_vec()), Bytes::new());
-        BasePooledTransaction::from_pooled(Recovered::new_unchecked(
-            ConsensusPooledTransaction::Eip8130(signed),
-            signer.address(),
-        ))
+        )
     }
 
     fn valid_pool_transaction(


### PR DESCRIPTION
## Summary

This refactor removes duplicated transaction and RPC test fixtures across the execution txpool crate. It also simplifies pooled transaction lookup, forwarding batches, payer reservation eviction, and transaction construction while preserving existing behavior and public APIs. The result removes 215 net lines and retains the full txpool test and clippy coverage.