### PR TITLE
feat(BOP-441): add seizeWithMemo to asset + stablecoin V2; rename seize surface

### DIFF
--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -34,11 +34,13 @@ jobs:
             key: beryl
             base_anvil_ref: 6d744e03224977edd42a36699ba9ff42be25e8cb
             base_std_ref: v1.0.0
-          # Point to the base-std release tag once the Cobalt hardfork is ready.
+          # Pinned to the base-std seize-surface branch (BOP-440, PR #186) so the Cobalt seize
+          # entrypoints cross-validate against the renamed reference. Move to the base-std release
+          # tag / merge SHA once #186 lands.
           - fork: Cobalt
             key: cobalt
             base_anvil_ref: ae7557c4f8602caa1da0be33143bb2504c85b0c8
-            base_std_ref: b0a4f048684c4cd279025bf2ba3aa76c45569fa4
+            base_std_ref: stephancilliers/bop-440-seize-rename
     env:
       FORK_NAME: ${{ matrix.fork }}
       FORK_KEY: ${{ matrix.key }}

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -34,9 +34,6 @@ jobs:
             key: beryl
             base_anvil_ref: 6d744e03224977edd42a36699ba9ff42be25e8cb
             base_std_ref: v1.0.0
-          # Pinned to the base-std seize-surface merge (BOP-440, #186) so the Cobalt seize
-          # entrypoints cross-validate against the renamed reference. Move to the base-std release
-          # tag once the Cobalt hardfork is ready.
           - fork: Cobalt
             key: cobalt
             base_anvil_ref: ae7557c4f8602caa1da0be33143bb2504c85b0c8

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -34,13 +34,13 @@ jobs:
             key: beryl
             base_anvil_ref: 6d744e03224977edd42a36699ba9ff42be25e8cb
             base_std_ref: v1.0.0
-          # Pinned to the base-std seize-surface branch (BOP-440, PR #186) so the Cobalt seize
+          # Pinned to the base-std seize-surface merge (BOP-440, #186) so the Cobalt seize
           # entrypoints cross-validate against the renamed reference. Move to the base-std release
-          # tag / merge SHA once #186 lands.
+          # tag once the Cobalt hardfork is ready.
           - fork: Cobalt
             key: cobalt
             base_anvil_ref: ae7557c4f8602caa1da0be33143bb2504c85b0c8
-            base_std_ref: stephancilliers/bop-440-seize-rename
+            base_std_ref: 96e96870937fa8c2ef5ad21a8433a9e5bdce07fa
     env:
       FORK_NAME: ${{ matrix.fork }}
       FORK_KEY: ${{ matrix.key }}

--- a/crates/common/precompile-macros/src/accounting.rs
+++ b/crates/common/precompile-macros/src/accounting.rs
@@ -251,7 +251,7 @@ fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
                         self.b20.transfer_executor_policy_id()
                     }
                     crate::B20PolicyType::MintReceiver => self.b20.mint_receiver_policy_id(),
-                    crate::B20PolicyType::SeizableAccount => self.b20.seizable_policy_id(),
+                    crate::B20PolicyType::SeizeHolder => self.b20.seize_holder_policy_id(),
                 }
             }
 
@@ -273,8 +273,8 @@ fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
                     crate::B20PolicyType::MintReceiver => {
                         self.b20.set_mint_receiver_policy_id(policy_id)
                     }
-                    crate::B20PolicyType::SeizableAccount => {
-                        self.b20.set_seizable_policy_id(policy_id)
+                    crate::B20PolicyType::SeizeHolder => {
+                        self.b20.set_seize_holder_policy_id(policy_id)
                     }
                 }
             }

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -141,6 +141,7 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
             C::MINT_ROLE(_) => B20TokenRole::Mint.id().abi_encode().into(),
             C::BURN_ROLE(_) => B20TokenRole::Burn.id().abi_encode().into(),
             C::BURN_BLOCKED_ROLE(_) => B20TokenRole::BurnBlocked.id().abi_encode().into(),
+            C::SEIZE_ROLE(_) => B20TokenRole::Seize.id().abi_encode().into(),
             C::PAUSE_ROLE(_) => B20TokenRole::Pause.id().abi_encode().into(),
             C::UNPAUSE_ROLE(_) => B20TokenRole::Unpause.id().abi_encode().into(),
             C::METADATA_ROLE(_) => B20TokenRole::Metadata.id().abi_encode().into(),
@@ -154,6 +155,7 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
                 B20PolicyType::TransferExecutor.id().abi_encode().into()
             }
             C::MINT_RECEIVER_POLICY(_) => B20PolicyType::MintReceiver.id().abi_encode().into(),
+            C::SEIZE_HOLDER_POLICY(_) => B20PolicyType::SeizeHolder.id().abi_encode().into(),
 
             // --- Role reads ---
             C::hasRole(c) => logic.has_role(self, c.role, c.account)?.abi_encode().into(),
@@ -235,6 +237,12 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
             C::burnBlocked(c) => {
                 logic.burn_blocked(self, caller, c.from, c.amount, privileged)?;
                 Bytes::new()
+            }
+
+            // --- Seize ---
+            C::seizeWithMemo(c) => {
+                logic.seize_with_memo(self, caller, c.from, c.to, c.amount, c.memo)?;
+                true.abi_encode().into()
             }
 
             // --- Pause ---

--- a/crates/common/precompiles/src/b20_asset/logic/interface.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/interface.rs
@@ -73,6 +73,21 @@ pub trait Asset<S: AssetAccounting, A: PolicyAccounting> {
         privileged: bool,
     ) -> Result<()>;
 
+    /// Transfer-based seize: reassigns a seizable `from`'s balance to `to`
+    /// (`Transfer` -> `Memo` -> `Seized`). Introduced at `AssetV2`.
+    /// An admin op with no factory-privileged path, so the role is always enforced.
+    fn seize_with_memo(
+        &self,
+        _token: &mut B20AssetToken<S, A>,
+        _caller: Address,
+        _from: Address,
+        _to: Address,
+        _amount: U256,
+        _memo: B256,
+    ) -> Result<()> {
+        reject_frozen_selector!()
+    }
+
     /// Pauses the given features.
     fn pause(
         &self,

--- a/crates/common/precompiles/src/b20_asset/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v2.rs
@@ -790,6 +790,7 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
             IB20::PausableFeature::TRANSFER,
             IB20::PausableFeature::MINT,
             IB20::PausableFeature::BURN,
+            IB20::PausableFeature::SEIZE,
         ] {
             if (paused & B20PausableFeature::mask(feature)) != U256::ZERO {
                 features.push(feature);
@@ -1661,6 +1662,14 @@ mod tests {
         assert!(LOGIC.is_paused(&tok, IB20::PausableFeature::MINT).unwrap());
         LOGIC.unpause(&mut tok, ADMIN, vec![IB20::PausableFeature::MINT], true).unwrap();
         assert!(!LOGIC.is_paused(&tok, IB20::PausableFeature::MINT).unwrap());
+    }
+
+    #[test]
+    fn paused_features_includes_seize() {
+        let mut tok = token();
+        LOGIC.pause(&mut tok, ADMIN, vec![IB20::PausableFeature::SEIZE], true).unwrap();
+        let features = LOGIC.paused_features(&tok).unwrap();
+        assert_eq!(features, vec![IB20::PausableFeature::SEIZE]);
     }
 
     // --- roles ---

--- a/crates/common/precompiles/src/b20_asset/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v2.rs
@@ -364,6 +364,30 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
             .emit_event(IB20::BurnedBlocked { caller, from, amount }.encode_log_data())
     }
 
+    fn seize_with_memo(
+        &self,
+        token: &mut B20AssetToken<S, A>,
+        caller: Address,
+        from: Address,
+        to: Address,
+        amount: U256,
+        memo: B256,
+    ) -> Result<()> {
+        B20Guards::ensure_not_paused(token, IB20::PausableFeature::SEIZE)?;
+        B20Guards::ensure_token_role(token, caller, B20TokenRole::Seize)?;
+        // `to != 0` guards against a disguised burn; `from` is not zero-checked (burn-blocked family).
+        if to == Address::ZERO {
+            return Err(BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }));
+        }
+        B20Guards::ensure_seizable(token, from)?;
+        self.move_balance(token, from, to, amount)?;
+        // `Memo` must immediately follow the `Transfer` (from `move_balance`), before `Seized`.
+        self.emit_memo(token, caller, memo)?;
+        token
+            .accounting_mut()
+            .emit_event(IB20::Seized { caller, from, to, amount }.encode_log_data())
+    }
+
     fn pause(
         &self,
         token: &mut B20AssetToken<S, A>,
@@ -985,6 +1009,7 @@ mod tests {
     const ADMIN: Address = Address::repeat_byte(0xAD);
     const ALICE: Address = Address::repeat_byte(0xA1);
     const BOB: Address = Address::repeat_byte(0xB0);
+    const MEMO: B256 = B256::repeat_byte(0x77);
     const CHAIN_ID: u64 = 8453;
     const LOGIC: AssetV2 = AssetV2;
 
@@ -1517,6 +1542,114 @@ mod tests {
         LOGIC.burn_blocked(&mut tok, ADMIN, ALICE, U256::from(40u64), true).unwrap();
         assert_eq!(tok.accounting().balance_of(ALICE).unwrap(), U256::from(60u64));
         assert_eq!(last_event_sig(&tok), IB20::BurnedBlocked::SIGNATURE_HASH);
+    }
+
+    // --- seize ---
+
+    /// Points `SEIZE_HOLDER_POLICY` at the always-block policy, making every account seizable.
+    fn make_seizable(tok: &mut Tok) {
+        tok.accounting_mut()
+            .set_policy_id(B20PolicyType::SeizeHolder.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID)
+            .unwrap();
+    }
+
+    fn event_sigs(tok: &Tok) -> Vec<B256> {
+        tok.accounting().events.iter().map(|e| e.topics()[0]).collect()
+    }
+
+    #[test]
+    fn seize_moves_balance_and_emits_transfer_memo_event() {
+        let mut tok = token();
+        fund(&mut tok, ALICE, U256::from(100u64));
+        make_seizable(&mut tok);
+        grant(&mut tok, B20TokenRole::Seize.id(), ADMIN);
+        let supply = tok.accounting().total_supply().unwrap();
+
+        LOGIC.seize_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(40u64), MEMO).unwrap();
+
+        assert_eq!(tok.accounting().balance_of(ALICE).unwrap(), U256::from(60u64));
+        assert_eq!(tok.accounting().balance_of(BOB).unwrap(), U256::from(40u64));
+        assert_eq!(tok.accounting().total_supply().unwrap(), supply, "seize is a transfer");
+        assert_eq!(
+            event_sigs(&tok),
+            vec![
+                IB20::Transfer::SIGNATURE_HASH,
+                IB20::Memo::SIGNATURE_HASH,
+                IB20::Seized::SIGNATURE_HASH,
+            ]
+        );
+    }
+
+    #[test]
+    fn seize_reverts_when_account_not_seizable() {
+        let mut tok = token();
+        fund(&mut tok, ALICE, U256::from(100u64));
+        grant(&mut tok, B20TokenRole::Seize.id(), ADMIN);
+        // SEIZE_HOLDER_POLICY unset => ALWAYS_ALLOW => ALICE authorized => not seizable.
+        let err =
+            LOGIC.seize_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(1u64), MEMO).unwrap_err();
+        assert_eq!(err, BasePrecompileError::revert(IB20::AccountNotSeizable { account: ALICE }));
+    }
+
+    #[test]
+    fn seize_reverts_on_zero_receiver() {
+        let mut tok = token();
+        make_seizable(&mut tok);
+        grant(&mut tok, B20TokenRole::Seize.id(), ADMIN);
+        let err = LOGIC
+            .seize_with_memo(&mut tok, ADMIN, ALICE, Address::ZERO, U256::from(1u64), MEMO)
+            .unwrap_err();
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20::InvalidReceiver { receiver: Address::ZERO })
+        );
+    }
+
+    #[test]
+    fn seize_ignores_receiver_policy_on_to() {
+        let mut tok = token();
+        fund(&mut tok, ALICE, U256::from(50u64));
+        make_seizable(&mut tok);
+        grant(&mut tok, B20TokenRole::Seize.id(), ADMIN);
+        // A normal transfer to BOB would revert on this; seize does not consult it.
+        tok.accounting_mut()
+            .set_policy_id(
+                B20PolicyType::TransferReceiver.id(),
+                PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+            )
+            .unwrap();
+        LOGIC.seize_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(50u64), MEMO).unwrap();
+        assert_eq!(tok.accounting().balance_of(BOB).unwrap(), U256::from(50u64));
+    }
+
+    #[test]
+    fn seize_requires_role() {
+        let mut tok = token();
+        make_seizable(&mut tok);
+        let err =
+            LOGIC.seize_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(1u64), MEMO).unwrap_err();
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
+                account: ADMIN,
+                neededRole: B20TokenRole::Seize.id(),
+            })
+        );
+    }
+
+    #[test]
+    fn seize_reverts_when_seize_paused() {
+        let mut tok = token();
+        make_seizable(&mut tok);
+        LOGIC.pause(&mut tok, ADMIN, vec![IB20::PausableFeature::SEIZE], true).unwrap();
+        let err =
+            LOGIC.seize_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(1u64), MEMO).unwrap_err();
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20::ContractPaused {
+                feature: IB20::PausableFeature::SEIZE
+            })
+        );
     }
 
     // --- pause ---

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -21,7 +21,6 @@ use crate::{
     IB20Stablecoin::{self, IB20StablecoinCalls as SC},
     NoopPrecompileCallObserver, PermitArgs, PolicyAccounting, PrecompileCallObserver,
     StablecoinAccounting, StablecoinV1, StablecoinVersion, StablecoinVersions,
-    macros::decode_precompile_call,
 };
 
 impl<S: StablecoinAccounting, A: PolicyAccounting> B20StablecoinToken<S, A> {
@@ -119,7 +118,7 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> B20StablecoinToken<S, A> {
             });
         }
 
-        let call = decode_precompile_call!(calldata, IB20::IB20Calls);
+        let call = version.common_abi().decode(calldata)?;
         let label = call.as_label();
 
         observer.observe(label, || {
@@ -147,6 +146,7 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> B20StablecoinToken<S, A> {
                 C::MINT_ROLE(_) => B20TokenRole::Mint.id().abi_encode().into(),
                 C::BURN_ROLE(_) => B20TokenRole::Burn.id().abi_encode().into(),
                 C::BURN_BLOCKED_ROLE(_) => B20TokenRole::BurnBlocked.id().abi_encode().into(),
+                C::SEIZE_ROLE(_) => B20TokenRole::Seize.id().abi_encode().into(),
                 C::PAUSE_ROLE(_) => B20TokenRole::Pause.id().abi_encode().into(),
                 C::UNPAUSE_ROLE(_) => B20TokenRole::Unpause.id().abi_encode().into(),
                 C::METADATA_ROLE(_) => B20TokenRole::Metadata.id().abi_encode().into(),
@@ -160,6 +160,7 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> B20StablecoinToken<S, A> {
                     B20PolicyType::TransferExecutor.id().abi_encode().into()
                 }
                 C::MINT_RECEIVER_POLICY(_) => B20PolicyType::MintReceiver.id().abi_encode().into(),
+                C::SEIZE_HOLDER_POLICY(_) => B20PolicyType::SeizeHolder.id().abi_encode().into(),
                 C::hasRole(c) => logic.has_role(self, c.role, c.account)?.abi_encode().into(),
                 C::getRoleAdmin(c) => logic.role_admin(self, c.role)?.abi_encode().into(),
                 C::pausedFeatures(_) => logic.paused_features(self)?.abi_encode().into(),
@@ -241,6 +242,12 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> B20StablecoinToken<S, A> {
                     let caller = ctx.caller();
                     logic.burn_blocked(self, caller, c.from, c.amount, privileged)?;
                     Bytes::new()
+                }
+
+                C::seizeWithMemo(c) => {
+                    let caller = ctx.caller();
+                    logic.seize_with_memo(self, caller, c.from, c.to, c.amount, c.memo)?;
+                    true.abi_encode().into()
                 }
 
                 C::pause(c) => {

--- a/crates/common/precompiles/src/b20_stablecoin/logic/interface.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/interface.rs
@@ -7,7 +7,7 @@ use base_precompile_storage::Result;
 
 use crate::{
     B20StablecoinToken, Eip712Domain, IB20, PermitArgs, PolicyAccounting, StablecoinAccounting,
-    Token,
+    Token, macros::reject_frozen_selector,
 };
 
 /// The stablecoin logic interface.
@@ -81,6 +81,21 @@ pub trait Stablecoin<S: StablecoinAccounting, A: PolicyAccounting> {
         amount: U256,
         privileged: bool,
     ) -> Result<()>;
+
+    /// Transfer-based seize: reassigns a seizable `from`'s balance to `to`
+    /// (`Transfer` -> `Memo` -> `Seized`). Introduced at `StablecoinV2`.
+    /// An admin op with no factory-privileged path, so the role is always enforced.
+    fn seize_with_memo(
+        &self,
+        _token: &mut B20StablecoinToken<S, A>,
+        _caller: Address,
+        _from: Address,
+        _to: Address,
+        _amount: U256,
+        _memo: B256,
+    ) -> Result<()> {
+        reject_frozen_selector!()
+    }
 
     /// Pauses the given features.
     fn pause(

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
@@ -644,6 +644,7 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> Stablecoin<S, A> for Stableco
             IB20::PausableFeature::TRANSFER,
             IB20::PausableFeature::MINT,
             IB20::PausableFeature::BURN,
+            IB20::PausableFeature::SEIZE,
         ] {
             if (paused & B20PausableFeature::mask(feature)) != U256::ZERO {
                 features.push(feature);
@@ -1385,12 +1386,18 @@ mod tests {
             .pause(
                 &mut tok,
                 ADMIN,
-                vec![IB20::PausableFeature::MINT, IB20::PausableFeature::BURN],
+                vec![
+                    IB20::PausableFeature::MINT,
+                    IB20::PausableFeature::BURN,
+                    IB20::PausableFeature::SEIZE,
+                ],
                 true,
             )
             .unwrap();
-        assert_eq!(LOGIC.paused_features(&tok).unwrap().len(), 2);
-        assert!(LOGIC.is_paused(&tok, IB20::PausableFeature::BURN).unwrap());
+        let features = LOGIC.paused_features(&tok).unwrap();
+        assert_eq!(features.len(), 3);
+        assert!(features.contains(&IB20::PausableFeature::SEIZE));
+        assert!(LOGIC.is_paused(&tok, IB20::PausableFeature::SEIZE).unwrap());
     }
 
     // --- config / metadata ---

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
@@ -329,6 +329,30 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> Stablecoin<S, A> for Stableco
             .emit_event(IB20::BurnedBlocked { caller, from, amount }.encode_log_data())
     }
 
+    fn seize_with_memo(
+        &self,
+        token: &mut B20StablecoinToken<S, A>,
+        caller: Address,
+        from: Address,
+        to: Address,
+        amount: U256,
+        memo: B256,
+    ) -> Result<()> {
+        B20Guards::ensure_not_paused(token, IB20::PausableFeature::SEIZE)?;
+        B20Guards::ensure_token_role(token, caller, B20TokenRole::Seize)?;
+        // `to != 0` guards against a disguised burn; `from` is not zero-checked (burn-blocked family).
+        if to == Address::ZERO {
+            return Err(BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }));
+        }
+        B20Guards::ensure_seizable(token, from)?;
+        self.move_balance(token, from, to, amount)?;
+        // `Memo` must immediately follow the `Transfer` (from `move_balance`), before `Seized`.
+        self.emit_memo(token, caller, memo)?;
+        token
+            .accounting_mut()
+            .emit_event(IB20::Seized { caller, from, to, amount }.encode_log_data())
+    }
+
     fn pause(
         &self,
         token: &mut B20StablecoinToken<S, A>,
@@ -693,6 +717,7 @@ mod tests {
     const ADMIN: Address = Address::repeat_byte(0xAD);
     const ALICE: Address = Address::repeat_byte(0xA1);
     const BOB: Address = Address::repeat_byte(0xB0);
+    const MEMO: B256 = B256::repeat_byte(0x77);
     const CHAIN_ID: u64 = 8453;
     const LOGIC: StablecoinV2 = StablecoinV2;
 
@@ -1229,8 +1254,113 @@ mod tests {
         assert_eq!(err, BasePrecompileError::revert(IB20::AccountNotBlocked { account: ALICE }));
     }
 
-    // --- pause ---
+    // --- seize ---
 
+    /// Points `SEIZE_HOLDER_POLICY` at the always-block policy, making every account seizable.
+    fn make_seizable(tok: &mut Tok) {
+        tok.accounting_mut()
+            .set_policy_id(B20PolicyType::SeizeHolder.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID)
+            .unwrap();
+    }
+
+    fn event_sigs(tok: &Tok) -> Vec<B256> {
+        tok.accounting().events.iter().map(|e| e.topics()[0]).collect()
+    }
+
+    #[test]
+    fn seize_moves_balance_and_emits_transfer_memo_event() {
+        let mut tok = token();
+        fund(&mut tok, ALICE, U256::from(100u64));
+        make_seizable(&mut tok);
+        grant(&mut tok, B20TokenRole::Seize.id(), ADMIN);
+        let supply = tok.accounting().total_supply().unwrap();
+
+        LOGIC.seize_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(40u64), MEMO).unwrap();
+
+        assert_eq!(tok.accounting().balance_of(ALICE).unwrap(), U256::from(60u64));
+        assert_eq!(tok.accounting().balance_of(BOB).unwrap(), U256::from(40u64));
+        assert_eq!(tok.accounting().total_supply().unwrap(), supply, "seize is a transfer");
+        assert_eq!(
+            event_sigs(&tok),
+            vec![
+                IB20::Transfer::SIGNATURE_HASH,
+                IB20::Memo::SIGNATURE_HASH,
+                IB20::Seized::SIGNATURE_HASH,
+            ]
+        );
+    }
+
+    #[test]
+    fn seize_reverts_when_account_not_seizable() {
+        let mut tok = token();
+        fund(&mut tok, ALICE, U256::from(100u64));
+        grant(&mut tok, B20TokenRole::Seize.id(), ADMIN);
+        let err =
+            LOGIC.seize_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(1u64), MEMO).unwrap_err();
+        assert_eq!(err, BasePrecompileError::revert(IB20::AccountNotSeizable { account: ALICE }));
+    }
+
+    #[test]
+    fn seize_reverts_on_zero_receiver() {
+        let mut tok = token();
+        make_seizable(&mut tok);
+        grant(&mut tok, B20TokenRole::Seize.id(), ADMIN);
+        let err = LOGIC
+            .seize_with_memo(&mut tok, ADMIN, ALICE, Address::ZERO, U256::from(1u64), MEMO)
+            .unwrap_err();
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20::InvalidReceiver { receiver: Address::ZERO })
+        );
+    }
+
+    #[test]
+    fn seize_ignores_receiver_policy_on_to() {
+        let mut tok = token();
+        fund(&mut tok, ALICE, U256::from(50u64));
+        make_seizable(&mut tok);
+        grant(&mut tok, B20TokenRole::Seize.id(), ADMIN);
+        tok.accounting_mut()
+            .set_policy_id(
+                B20PolicyType::TransferReceiver.id(),
+                PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+            )
+            .unwrap();
+        LOGIC.seize_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(50u64), MEMO).unwrap();
+        assert_eq!(tok.accounting().balance_of(BOB).unwrap(), U256::from(50u64));
+    }
+
+    #[test]
+    fn seize_requires_role() {
+        let mut tok = token();
+        make_seizable(&mut tok);
+        let err =
+            LOGIC.seize_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(1u64), MEMO).unwrap_err();
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
+                account: ADMIN,
+                neededRole: B20TokenRole::Seize.id(),
+            })
+        );
+    }
+
+    #[test]
+    fn seize_reverts_when_seize_paused() {
+        let mut tok = token();
+        make_seizable(&mut tok);
+        LOGIC.pause(&mut tok, ADMIN, vec![IB20::PausableFeature::SEIZE], true).unwrap();
+        let err =
+            LOGIC.seize_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(1u64), MEMO).unwrap_err();
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20::ContractPaused {
+                feature: IB20::PausableFeature::SEIZE
+            })
+        );
+    }
+
+    // --- pause ---
     #[test]
     fn pause_and_unpause_toggle_feature_bit() {
         let mut tok = token();

--- a/crates/common/precompiles/src/b20_stablecoin/versions.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/versions.rs
@@ -9,7 +9,9 @@
 
 use base_common_genesis::BaseUpgrade;
 
-use crate::{PolicyAccounting, Stablecoin, StablecoinAccounting, StablecoinV1, StablecoinV2};
+use crate::{
+    B20Abi, PolicyAccounting, Stablecoin, StablecoinAccounting, StablecoinV1, StablecoinV2,
+};
 
 /// An activated version of the stablecoin B-20 precompile logic.
 ///
@@ -35,6 +37,18 @@ impl StablecoinVersion {
         match self {
             Self::V1 => &V1,
             Self::V2 => &V2,
+        }
+    }
+
+    /// Returns the frozen common [`B20Abi`] wire surface this version decodes against.
+    ///
+    /// Gating the shared surface per version is what freezes V1/Beryl against selectors and enum
+    /// members added to the canonical surface at a later fork (e.g. the Cobalt seize surface and its
+    /// `SEIZE` `PausableFeature` member).
+    pub const fn common_abi(self) -> B20Abi {
+        match self {
+            Self::V1 => B20Abi::V1,
+            Self::V2 => B20Abi::V2,
         }
     }
 }

--- a/crates/common/precompiles/src/common/abi/v2.rs
+++ b/crates/common/precompiles/src/common/abi/v2.rs
@@ -22,7 +22,7 @@ sol! {
             MINT,
             /// Burn operations.
             BURN,
-            /// Seize operations (`seizeWithMemo`). Legacy `burnBlocked` still gates on `BURN`.
+            /// Seize operations (`seizeWithMemo`).
             SEIZE
         }
 

--- a/crates/common/precompiles/src/common/abi/v2.rs
+++ b/crates/common/precompiles/src/common/abi/v2.rs
@@ -21,7 +21,9 @@ sol! {
             /// Mint operations.
             MINT,
             /// Burn operations.
-            BURN
+            BURN,
+            /// Seize operations (`seizeWithMemo`). Legacy `burnBlocked` still gates on `BURN`.
+            SEIZE
         }
 
         // Errors
@@ -46,6 +48,7 @@ sol! {
         error PolicyNotFound(uint64 policyId);
         error UnsupportedPolicyType(bytes32 policyScope);
         error AccountNotBlocked(address account);
+        error AccountNotSeizable(address account);
         error ExpiredSignature(uint256 deadline);
         error InvalidSigner(address signer, address owner);
         error LastAdminCannotRenounce();
@@ -57,7 +60,7 @@ sol! {
         event Approval(address indexed owner, address indexed spender, uint256 amount);
         event Memo(address indexed caller, bytes32 indexed memo);
         event BurnedBlocked(address indexed caller, address indexed from, uint256 amount);
-        event TransferredFromSeizable(address indexed caller, address indexed from, address indexed to, uint256 amount);
+        event Seized(address indexed caller, address indexed from, address indexed to, uint256 amount);
         event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);
         event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender);
         event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole);
@@ -76,6 +79,7 @@ sol! {
         function MINT_ROLE() external view returns (bytes32);
         function BURN_ROLE() external view returns (bytes32);
         function BURN_BLOCKED_ROLE() external view returns (bytes32);
+        function SEIZE_ROLE() external view returns (bytes32);
         function PAUSE_ROLE() external view returns (bytes32);
         function UNPAUSE_ROLE() external view returns (bytes32);
         function METADATA_ROLE() external view returns (bytes32);
@@ -85,6 +89,7 @@ sol! {
         function TRANSFER_RECEIVER_POLICY() external view returns (bytes32);
         function TRANSFER_EXECUTOR_POLICY() external view returns (bytes32);
         function MINT_RECEIVER_POLICY() external view returns (bytes32);
+        function SEIZE_HOLDER_POLICY() external view returns (bytes32);
 
         // ERC-20
         function name() external view returns (string);
@@ -111,6 +116,9 @@ sol! {
         function burn(uint256 amount) external;
         function burnWithMemo(uint256 amount, bytes32 memo) external;
         function burnBlocked(address from, uint256 amount) external;
+
+        // Seize
+        function seizeWithMemo(address from, address to, uint256 amount, bytes32 memo) external returns (bool);
 
         // Roles
         function hasRole(bytes32 role, address account) external view returns (bool);
@@ -164,6 +172,7 @@ impl IB20::IB20Calls {
             Self::MINT_ROLE(_) => "precompile-b20-MINT_ROLE",
             Self::BURN_ROLE(_) => "precompile-b20-BURN_ROLE",
             Self::BURN_BLOCKED_ROLE(_) => "precompile-b20-BURN_BLOCKED_ROLE",
+            Self::SEIZE_ROLE(_) => "precompile-b20-SEIZE_ROLE",
             Self::PAUSE_ROLE(_) => "precompile-b20-PAUSE_ROLE",
             Self::UNPAUSE_ROLE(_) => "precompile-b20-UNPAUSE_ROLE",
             Self::METADATA_ROLE(_) => "precompile-b20-METADATA_ROLE",
@@ -171,6 +180,7 @@ impl IB20::IB20Calls {
             Self::TRANSFER_RECEIVER_POLICY(_) => "precompile-b20-TRANSFER_RECEIVER_POLICY",
             Self::TRANSFER_EXECUTOR_POLICY(_) => "precompile-b20-TRANSFER_EXECUTOR_POLICY",
             Self::MINT_RECEIVER_POLICY(_) => "precompile-b20-MINT_RECEIVER_POLICY",
+            Self::SEIZE_HOLDER_POLICY(_) => "precompile-b20-SEIZE_HOLDER_POLICY",
             Self::hasRole(_) => "precompile-b20-hasRole",
             Self::getRoleAdmin(_) => "precompile-b20-getRoleAdmin",
             Self::pausedFeatures(_) => "precompile-b20-pausedFeatures",
@@ -188,6 +198,7 @@ impl IB20::IB20Calls {
             Self::burn(_) => "precompile-b20-burn",
             Self::burnWithMemo(_) => "precompile-b20-burnWithMemo",
             Self::burnBlocked(_) => "precompile-b20-burnBlocked",
+            Self::seizeWithMemo(_) => "precompile-b20-seizeWithMemo",
             Self::pause(_) => "precompile-b20-pause",
             Self::unpause(_) => "precompile-b20-unpause",
             Self::updateSupplyCap(_) => "precompile-b20-updateSupplyCap",
@@ -224,9 +235,11 @@ mod tests {
     const V1_ABI_FINGERPRINT: B256 =
         b256!("106ef4b7c288c9344d6906ba7ef99a740bd9621cdaed89d06b35abd313c13449");
 
-    /// Absolute wire fingerprint for Cobalt's (canonical) surface. Identical to V1 today.
+    /// Absolute wire fingerprint for Cobalt's (canonical) surface. Diverges from V1: Cobalt adds
+    /// the seize surface (`seizeWithMemo`, the `SEIZE_ROLE`/`SEIZE_HOLDER_POLICY` getters, the
+    /// `Seized` event, the `AccountNotSeizable` error, and the `SEIZE` pause feature).
     const V2_ABI_FINGERPRINT: B256 =
-        b256!("106ef4b7c288c9344d6906ba7ef99a740bd9621cdaed89d06b35abd313c13449");
+        b256!("ff1784b934ecfc840872a07cf0a7716f1818bed4ad1e57dda75ec2a919417be1");
 
     fn v1_abi_fingerprint() -> B256 {
         AbiFingerprint::compute(
@@ -252,6 +265,7 @@ mod tests {
                 IB20::PausableFeature::TRANSFER as u8,
                 IB20::PausableFeature::MINT as u8,
                 IB20::PausableFeature::BURN as u8,
+                IB20::PausableFeature::SEIZE as u8,
             ],
         )
     }

--- a/crates/common/precompiles/src/common/core_storage.rs
+++ b/crates/common/precompiles/src/common/core_storage.rs
@@ -83,7 +83,7 @@ pub struct B20CoreStorage {
     /// Seizable-account policy ID, consulted by the seize operations.
     #[accessor]
     #[mutator]
-    pub seizable_policy_id: u64, // slot 14, offset 0
+    pub seize_holder_policy_id: u64, // slot 14, offset 0
     /// Reserved padding to close slot 14.
     pub seize_reserved: FixedBytes<24>, // slot 14, offset 8
 }
@@ -129,8 +129,8 @@ mod tests {
         assert_eq!(__packing_b20_core_storage::PAUSED_LOC.offset_slots, 11);
         assert_eq!(__packing_b20_core_storage::SUPPLY_CAP_LOC.offset_slots, 12);
         assert_eq!(__packing_b20_core_storage::NONCES_LOC.offset_slots, 13);
-        assert_eq!(__packing_b20_core_storage::SEIZABLE_POLICY_ID_LOC.offset_slots, 14);
-        assert_eq!(__packing_b20_core_storage::SEIZABLE_POLICY_ID_LOC.offset_bytes, 0);
+        assert_eq!(__packing_b20_core_storage::SEIZE_HOLDER_POLICY_ID_LOC.offset_slots, 14);
+        assert_eq!(__packing_b20_core_storage::SEIZE_HOLDER_POLICY_ID_LOC.offset_bytes, 0);
         assert_eq!(__packing_b20_core_storage::SEIZE_RESERVED_LOC.offset_slots, 14);
         assert_eq!(__packing_b20_core_storage::SEIZE_RESERVED_LOC.offset_bytes, 8);
     }

--- a/crates/common/precompiles/src/common/ops/guards.rs
+++ b/crates/common/precompiles/src/common/ops/guards.rs
@@ -84,17 +84,18 @@ impl B20Guards {
         }
     }
 
-    /// Ensures `account` is seizable, i.e. blocked by the current seizable-account policy.
+    /// Ensures `account` is seizable, i.e. a member of the current seize-holder policy.
     ///
-    /// Mirrors [`Self::ensure_blocked`] but consults `SEIZABLE_ACCOUNT_POLICY` instead of the
+    /// Mirrors [`Self::ensure_blocked`] but consults `SEIZE_HOLDER_POLICY` instead of the
     /// transfer-sender policy: an account is seizable only when the configured registry policy does
-    /// not authorize it. Used by the seize operation class. Enforced unconditionally, including in
-    /// the factory bootstrap window.
+    /// not authorize it. Used by `seizeWithMemo`. Enforced unconditionally, including in the factory
+    /// bootstrap window. Reverts `AccountNotSeizable` (distinct from `ensure_blocked`'s
+    /// `AccountNotBlocked`) so the seize path and the deprecated `burnBlocked` report separately.
     pub fn ensure_seizable<T: Token + ?Sized>(token: &T, account: Address) -> Result<()> {
-        let policy_scope = B20PolicyType::SeizableAccount.id();
+        let policy_scope = B20PolicyType::SeizeHolder.id();
         let policy_id = token.accounting().policy_id(policy_scope)?;
         if token.policy().is_authorized(token.policy_storage(), policy_id, account)? {
-            Err(BasePrecompileError::revert(IB20::AccountNotBlocked { account }))
+            Err(BasePrecompileError::revert(IB20::AccountNotSeizable { account }))
         } else {
             Ok(())
         }
@@ -125,7 +126,7 @@ mod tests {
 
     fn token_with_seizable_policy(account: Address) -> TestStablecoinToken {
         let mut accounting = InMemoryTokenAccounting::new(Address::repeat_byte(0x20));
-        accounting.policy_ids.insert(B20PolicyType::SeizableAccount.id(), EXTERNAL_POLICY_ID);
+        accounting.policy_ids.insert(B20PolicyType::SeizeHolder.id(), EXTERNAL_POLICY_ID);
 
         let mut policy = FakePolicyAccounting::new();
         policy.allow(EXTERNAL_POLICY_ID, account);
@@ -173,7 +174,7 @@ mod tests {
         // Authorized (allowed) under the seizable policy => not seizable => reverts.
         assert_eq!(
             B20Guards::ensure_seizable(&token, allowed).unwrap_err(),
-            BasePrecompileError::revert(IB20::AccountNotBlocked { account: allowed })
+            BasePrecompileError::revert(IB20::AccountNotSeizable { account: allowed })
         );
         // Not authorized (denied) => seizable => ok.
         B20Guards::ensure_seizable(&token, denied).unwrap();
@@ -190,14 +191,14 @@ mod tests {
         // `allowed` is authorized by transfer-sender AND by unset seizable (ALWAYS_ALLOW).
         assert_eq!(
             B20Guards::ensure_seizable(&token, allowed).unwrap_err(),
-            BasePrecompileError::revert(IB20::AccountNotBlocked { account: allowed })
+            BasePrecompileError::revert(IB20::AccountNotSeizable { account: allowed })
         );
 
         // `denied` is NOT authorized by transfer-sender, but still not seizable because the
         // seizable policy is unset (ALWAYS_ALLOW) — proving the two scopes are independent.
         assert_eq!(
             B20Guards::ensure_seizable(&token, denied).unwrap_err(),
-            BasePrecompileError::revert(IB20::AccountNotBlocked { account: denied })
+            BasePrecompileError::revert(IB20::AccountNotSeizable { account: denied })
         );
     }
 

--- a/crates/common/precompiles/src/common/ops/roles.rs
+++ b/crates/common/precompiles/src/common/ops/roles.rs
@@ -6,8 +6,7 @@ const MINT_ROLE: B256 = b256!("154c00819833dac601ee5ddded6fda79d9d8b506b911b3dbd
 const BURN_ROLE: B256 = b256!("e97b137254058bd94f28d2f3eb79e2d34074ffb488d042e3bc958e0a57d2fa22");
 const BURN_BLOCKED_ROLE: B256 =
     b256!("7408fdc0d31c7bcb349eab611f5d1168acd4303574993f8cdc98b1cd18c41cae");
-const TRANSFER_FROM_SEIZABLE_ROLE: B256 =
-    b256!("466d0fa97b99b3315998c229880e8a3a6aa5f5586b46f762a35e210facb4ea63");
+const SEIZE_ROLE: B256 = b256!("3469b8b0d89e9604f8510ed143f74a8336d22955d4f83e23bf53d9414e27f432");
 const PAUSE_ROLE: B256 = b256!("139c2898040ef16910dc9f44dc697df79363da767d8bc92f2e310312b816e46d");
 const UNPAUSE_ROLE: B256 =
     b256!("265b220c5a8891efdd9e1b1b7fa72f257bd5169f8d87e319cf3dad6ff52b94ae");
@@ -25,9 +24,9 @@ pub enum B20TokenRole {
     Burn,
     /// Role required for `burnBlocked`; permits burning from blocked accounts without `BURN_ROLE`.
     BurnBlocked,
-    /// Role required for `transferFromSeizableWithMemo`; permits reassigning a blocked account's
+    /// Role required for `seizeWithMemo`; permits reassigning a blocked account's
     /// balance without `TRANSFER_SENDER_POLICY` authorization.
-    TransferFromSeizable,
+    Seize,
     /// Role required for `pause`.
     Pause,
     /// Role required for `unpause`.
@@ -44,7 +43,7 @@ impl B20TokenRole {
             Self::Mint => MINT_ROLE,
             Self::Burn => BURN_ROLE,
             Self::BurnBlocked => BURN_BLOCKED_ROLE,
-            Self::TransferFromSeizable => TRANSFER_FROM_SEIZABLE_ROLE,
+            Self::Seize => SEIZE_ROLE,
             Self::Pause => PAUSE_ROLE,
             Self::Unpause => UNPAUSE_ROLE,
             Self::Metadata => METADATA_ROLE,
@@ -71,10 +70,7 @@ mod tests {
         assert_eq!(B20TokenRole::Mint.id(), keccak256("MINT_ROLE"));
         assert_eq!(B20TokenRole::Burn.id(), keccak256("BURN_ROLE"));
         assert_eq!(B20TokenRole::BurnBlocked.id(), keccak256("BURN_BLOCKED_ROLE"));
-        assert_eq!(
-            B20TokenRole::TransferFromSeizable.id(),
-            keccak256("TRANSFER_FROM_SEIZABLE_ROLE")
-        );
+        assert_eq!(B20TokenRole::Seize.id(), keccak256("SEIZE_ROLE"));
         assert_eq!(B20TokenRole::Pause.id(), keccak256("PAUSE_ROLE"));
         assert_eq!(B20TokenRole::Unpause.id(), keccak256("UNPAUSE_ROLE"));
         assert_eq!(B20TokenRole::Metadata.id(), keccak256("METADATA_ROLE"));

--- a/crates/common/precompiles/src/common/pausable_feature.rs
+++ b/crates/common/precompiles/src/common/pausable_feature.rs
@@ -15,7 +15,8 @@ impl B20PausableFeature {
         match feature {
             IB20::PausableFeature::TRANSFER
             | IB20::PausableFeature::MINT
-            | IB20::PausableFeature::BURN => Ok(()),
+            | IB20::PausableFeature::BURN
+            | IB20::PausableFeature::SEIZE => Ok(()),
             IB20::PausableFeature::__Invalid => Err(BasePrecompileError::enum_conversion_error()),
         }
     }

--- a/crates/common/precompiles/src/common/policy_type.rs
+++ b/crates/common/precompiles/src/common/policy_type.rs
@@ -10,8 +10,8 @@ const TRANSFER_EXECUTOR_POLICY: B256 =
     b256!("10be5173aff2a44e748bd9acd8b19fe34689581398a9db7ba2fb671e786ff7d8");
 const MINT_RECEIVER_POLICY: B256 =
     b256!("a0d5ae037e66a09119acf080a1d807abb9b6d03b6b9130eb19f7c1e6bdb8ffc8");
-const SEIZABLE_ACCOUNT_POLICY: B256 =
-    b256!("3efcaab33335f8757bc9054f42ac0ae92950f9727a52ff4db8681fc9521c9e25");
+const SEIZE_HOLDER_POLICY: B256 =
+    b256!("1497ab2b67ebb0a75dd9cdd6aec9f0e64620e6b87e911af7a088ac12e58d9ef2");
 
 /// Built-in B-20 policy slots.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -26,7 +26,7 @@ pub enum B20PolicyType {
     MintReceiver,
     /// Policy slot consulted against `from` by the seize operations. A `from` is seizable only when
     /// it is NOT authorized by this policy (mirroring the `burnBlocked` "blocked" semantics).
-    SeizableAccount,
+    SeizeHolder,
 }
 
 impl B20PolicyType {
@@ -40,8 +40,8 @@ impl B20PolicyType {
             Some(Self::TransferExecutor)
         } else if id == MINT_RECEIVER_POLICY {
             Some(Self::MintReceiver)
-        } else if id == SEIZABLE_ACCOUNT_POLICY {
-            Some(Self::SeizableAccount)
+        } else if id == SEIZE_HOLDER_POLICY {
+            Some(Self::SeizeHolder)
         } else {
             None
         }
@@ -54,7 +54,7 @@ impl B20PolicyType {
             Self::TransferReceiver => TRANSFER_RECEIVER_POLICY,
             Self::TransferExecutor => TRANSFER_EXECUTOR_POLICY,
             Self::MintReceiver => MINT_RECEIVER_POLICY,
-            Self::SeizableAccount => SEIZABLE_ACCOUNT_POLICY,
+            Self::SeizeHolder => SEIZE_HOLDER_POLICY,
         }
     }
 }
@@ -73,15 +73,15 @@ mod tests {
         assert_eq!(B20PolicyType::TransferReceiver.id(), keccak256("TRANSFER_RECEIVER_POLICY"));
         assert_eq!(B20PolicyType::TransferExecutor.id(), keccak256("TRANSFER_EXECUTOR_POLICY"));
         assert_eq!(B20PolicyType::MintReceiver.id(), keccak256("MINT_RECEIVER_POLICY"));
-        assert_eq!(B20PolicyType::SeizableAccount.id(), keccak256("SEIZABLE_ACCOUNT_POLICY"));
+        assert_eq!(B20PolicyType::SeizeHolder.id(), keccak256("SEIZE_HOLDER_POLICY"));
     }
 
     /// `from_id` is the inverse of `id`, including for the seizable scope.
     #[test]
     fn seizable_scope_round_trips() {
         assert_eq!(
-            B20PolicyType::from_id(B20PolicyType::SeizableAccount.id()),
-            Some(B20PolicyType::SeizableAccount)
+            B20PolicyType::from_id(B20PolicyType::SeizeHolder.id()),
+            Some(B20PolicyType::SeizeHolder)
         );
     }
 }

--- a/crates/common/precompiles/tests/b20_asset_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v1_golden.rs
@@ -275,6 +275,24 @@ fn golden_v2_selectors_unknown_at_v1() {
     }
 }
 
+/// The seize common selectors (`seizeWithMemo` and the `SEIZE_ROLE` / `SEIZE_HOLDER_POLICY`
+/// getters) were introduced at Cobalt (`AssetV2`). At V1 (Beryl) they are absent from the frozen
+/// common `IB20` surface, so `route` rejects them as `UnknownFunctionSelector`.
+#[test]
+fn golden_seize_selectors_unknown_at_v1() {
+    let mut s = fresh();
+    let calls: Vec<Vec<u8>> = vec![
+        IB20::seizeWithMemoCall { from: ALICE, to: BOB, amount: u(1), memo: MEMO }.abi_encode(),
+        IB20::SEIZE_ROLECall {}.abi_encode(),
+        IB20::SEIZE_HOLDER_POLICYCall {}.abi_encode(),
+    ];
+    for calldata in calls {
+        let selector: [u8; 4] = calldata[..4].try_into().unwrap();
+        let err = op(&mut s, ALICE, FakePolicyAccounting::new(), calldata).unwrap_err();
+        assert_eq!(err, BasePrecompileError::UnknownFunctionSelector(selector));
+    }
+}
+
 // ============================================================================
 // transfer
 // ============================================================================
@@ -2664,6 +2682,9 @@ fn v1_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Asset::IB20AssetCall
             golden_burn_blocked_reverts_when_not_blocked,
             golden_burn_blocked_unprivileged_requires_role,
         ]),
+        C::seizeWithMemo(_) | C::SEIZE_ROLE(_) | C::SEIZE_HOLDER_POLICY(_) => {
+            covered(&[golden_seize_selectors_unknown_at_v1])
+        }
 
         // pause / config / roles / policy / permit
         C::pause(_) => covered(&[

--- a/crates/common/precompiles/tests/b20_stablecoin_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_stablecoin_v1_golden.rs
@@ -733,6 +733,24 @@ fn golden_burn_blocked_reverts_when_not_blocked() {
     assert_eq!(err, BasePrecompileError::revert(IB20::AccountNotBlocked { account: ALICE }));
 }
 
+/// The seize common selectors (`seizeWithMemo` and the `SEIZE_ROLE` / `SEIZE_HOLDER_POLICY`
+/// getters) were introduced at Cobalt (`StablecoinV2`). At V1 (Beryl) they are absent from the
+/// frozen common `IB20` surface, so `route` rejects them as `UnknownFunctionSelector`.
+#[test]
+fn golden_seize_selectors_unknown_at_v1() {
+    let mut s = fresh();
+    let calls: Vec<Vec<u8>> = vec![
+        IB20::seizeWithMemoCall { from: ALICE, to: BOB, amount: u(1), memo: MEMO }.abi_encode(),
+        IB20::SEIZE_ROLECall {}.abi_encode(),
+        IB20::SEIZE_HOLDER_POLICYCall {}.abi_encode(),
+    ];
+    for calldata in calls {
+        let selector: [u8; 4] = calldata[..4].try_into().unwrap();
+        let err = op(&mut s, ALICE, FakePolicyAccounting::new(), calldata).unwrap_err();
+        assert_eq!(err, BasePrecompileError::UnknownFunctionSelector(selector));
+    }
+}
+
 // ============================================================================
 // pause / unpause
 // ============================================================================
@@ -2075,6 +2093,9 @@ fn v1_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Stablecoin::IB20Stab
             golden_burn_blocked_reverts_when_not_blocked,
             golden_burn_blocked_unprivileged_requires_role,
         ]),
+        C::seizeWithMemo(_) | C::SEIZE_ROLE(_) | C::SEIZE_HOLDER_POLICY(_) => {
+            covered(&[golden_seize_selectors_unknown_at_v1])
+        }
 
         // pause / config / roles / policy / permit
         C::pause(_) => covered(&[


### PR DESCRIPTION
## Summary

Implements the finalized seize design in the B-20 precompiles, on top of main's versioned-ABI refactor. **Supersedes #4192**, which was built on a now-diverged base (its own abi-versioning commit conflicts head-on with the versioning that has since landed on main). Mirrors the base-std reference PR (BOP-440, base/base-std#186).

Seize activates at **Cobalt (V2)** and is gated out of **Beryl (V1)**.

### Surface
- **New entrypoint** `seizeWithMemo(from, to, amount, memo)` on asset + stablecoin V2. Guard order: `SEIZE` pause → `SEIZE_ROLE` → `ensure_seizable(from)` → `move_balance`; emits `Transfer` → `Memo` → `Seized`. Admin op: skips allowance and all transfer policies, does not policy-check `to`.
- **Renamed** the merged plumbing to the `seize*` names: `SEIZE_HOLDER_POLICY` (`B20PolicyType::SeizeHolder`), `SEIZE_ROLE` (`B20TokenRole::Seize`), `Seized` event, `seize_holder_policy_id` storage. Role/policy keccak ids recomputed to the new strings (parity tests updated).
- **New `AccountNotSeizable` error** for the seize gate, distinct from the deprecated `burnBlocked`'s `AccountNotBlocked`.
- Added the `SEIZE` `PausableFeature` member + the `seizeWithMemo` / `SEIZE_ROLE` / `SEIZE_HOLDER_POLICY` selectors to the canonical (V2) `IB20` wire surface; V2 fingerprint re-pinned (V2 now diverges from V1).

### burnBlocked
Unchanged — keeps `TRANSFER_SENDER_POLICY` + `BURN` pause. **No `burnBlockedWithMemo`.**

### Frozen-V1 correctness
Version-gated the **stablecoin** common decode through `B20Abi` (mirroring asset's `AssetAbiPair`), so Beryl rejects the new seize selectors and `isPaused(SEIZE)` instead of decoding them against the canonical surface. This also resolves the previously-open **V1 `SEIZE`-enum pause-path** gap. Existing V1==V2 common selectors are unaffected.

## Testing

- `cargo test -p base-common-precompiles --features test-utils` — all pass (635 lib + golden + fork-harness units), incl. new seize unit tests (asset + stablecoin V2) and golden coverage (`golden_seize_selectors_unknown_at_v1`).
- `cargo clippy -p base-common-precompiles` (default + `--features test-utils`) — clean.
- `cargo fmt` clean.
- Fork-test Cobalt `base_std_ref` pinned to the base-std seize-surface branch (BOP-440 #186); move to the release tag / merge SHA once #186 lands.