### PR TITLE
fix(execution): Restore Default JavaScript Tracer Support

### DIFF
--- a/.config/zepter.yaml
+++ b/.config/zepter.yaml
@@ -9,7 +9,7 @@ workflows:
         # Check that `A` activates the features of `B`.
         "propagate-feature",
         # These are the features to check:
-        "--features=arbitrary,std,serde,test-utils,metrics",
+        "--features=arbitrary,std,serde,test-utils,metrics,js-tracer",
         # Do not try to add a new section into `[features]` of `A` only because `B` exposes that feature. There are edge-cases where this is still needed, but we can add them manually.
         "--left-side-feature-missing=ignore",
         # Ignore the case that `A` is outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.

--- a/bin/base/Cargo.toml
+++ b/bin/base/Cargo.toml
@@ -50,3 +50,7 @@ figment = { workspace = true, features = ["env", "toml"] }
 [dev-dependencies]
 base-common-genesis.workspace = true
 figment = { workspace = true, features = ["test"] }
+
+[features]
+default = [ "js-tracer" ]
+js-tracer = [ "base-execution-cli/js-tracer" ]

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -28,5 +28,6 @@ base-execution-cli = { workspace = true, features = ["otlp"] }
 clap.workspace = true
 
 [features]
-default = [ "jemalloc" ]
+default = [ "jemalloc", "js-tracer" ]
 jemalloc = [ "base-execution-cli/jemalloc", "reth-cli-util/jemalloc" ]
+js-tracer = [ "base-execution-cli/js-tracer" ]

--- a/crates/execution/cli/Cargo.toml
+++ b/crates/execution/cli/Cargo.toml
@@ -106,6 +106,8 @@ jemalloc = [ "reth-node-core/jemalloc", "reth-node-metrics/jemalloc" ]
 jemalloc-prof = [ "jemalloc", "reth-node-metrics/jemalloc-prof" ]
 jemalloc-symbols = [ "jemalloc-prof", "reth-node-metrics/jemalloc-symbols" ]
 
+js-tracer = [ "base-node-core/js-tracer", "reth-node-builder/js-tracer" ]
+
 tracy = [ "reth-node-core/tracy", "reth-tracing/tracy" ]
 
 dev = [

--- a/deny.toml
+++ b/deny.toml
@@ -190,6 +190,12 @@ skip = [
     # reqwest version mismatch: alloy use 0.12.x, newer deps use 0.13.x
     "reqwest",
 
+    # JavaScript tracer version mismatches from boa dependencies
+    "phf",
+    "phf_shared",
+    "rustc_version",
+    "semver",
+
     # quick-error version mismatch: proptest -> rusty-fork uses 1.x, other deps use 2.x
     "quick-error",
 


### PR DESCRIPTION
## Summary

Enable JavaScript tracers by default for both the split execution binary and unified Base binary. Propagate the feature through the execution CLI into Reth's node builder and RPC stack, and include it in Zepter's feature checks to prevent another wiring regression. This was verified by compiling both binaries and successfully executing a JavaScript-based debug_traceCall against a local node.