### PR TITLE
fix(txpool): Preserve Rejected Insertion State

### DIFF
--- a/crates/execution/txpool/src/pool.rs
+++ b/crates/execution/txpool/src/pool.rs
@@ -21,7 +21,10 @@ use reth_transaction_pool::{
     TransactionValidationTaskExecutor, TransactionValidator, ValidPoolTransaction,
     pool::{AddedTransactionState, TransactionEvent},
 };
-use tokio::{spawn, sync::mpsc};
+use tokio::{
+    spawn,
+    sync::mpsc::{self, error::TrySendError},
+};
 use tracing::debug;
 
 use crate::{
@@ -1580,7 +1583,9 @@ impl<T: BasePooledTx> SidecarListeners<T> {
     }
 
     fn broadcast_all(&mut self, event: FullTransactionEvent<T>) {
-        self.all_events.retain(|listener| listener.try_send(event.clone()).is_ok());
+        self.all_events.retain(|listener| {
+            !matches!(listener.try_send(event.clone()), Err(TrySendError::Closed(_)))
+        });
     }
 
     fn broadcast_pending_transaction(&mut self, transaction: &Arc<ValidPoolTransaction<T>>) {
@@ -1592,17 +1597,24 @@ impl<T: BasePooledTx> SidecarListeners<T> {
     }
 
     fn broadcast_pending(&mut self, transaction: &Arc<ValidPoolTransaction<T>>) {
-        self.pending_all.retain(|listener| listener.try_send(*transaction.hash()).is_ok());
+        self.pending_all.retain(|listener| {
+            !matches!(listener.try_send(*transaction.hash()), Err(TrySendError::Closed(_)))
+        });
         if transaction.propagate {
-            self.pending_propagate
-                .retain(|listener| listener.try_send(*transaction.hash()).is_ok());
+            self.pending_propagate.retain(|listener| {
+                !matches!(listener.try_send(*transaction.hash()), Err(TrySendError::Closed(_)))
+            });
         }
     }
 
     fn broadcast_new(&mut self, event: NewTransactionEvent<T>) {
-        self.new_all.retain(|listener| listener.try_send(event.clone()).is_ok());
+        self.new_all.retain(|listener| {
+            !matches!(listener.try_send(event.clone()), Err(TrySendError::Closed(_)))
+        });
         if event.transaction.propagate {
-            self.new_propagate.retain(|listener| listener.try_send(event.clone()).is_ok());
+            self.new_propagate.retain(|listener| {
+                !matches!(listener.try_send(event.clone()), Err(TrySendError::Closed(_)))
+            });
         }
     }
 }
@@ -1882,6 +1894,67 @@ mod tests {
         assert!(matches!(replacement_events.next().await, Some(TransactionEvent::Pending)));
         assert!(nonce_pool.get(&original_hash).is_none());
         assert!(nonce_pool.get(&replacement_hash).is_some());
+    }
+
+    #[test]
+    fn full_sidecar_listener_channels_remain_subscribed() {
+        let signer = signer();
+        let transaction =
+            Arc::new(valid_pool_transaction(signed_channel_tx(&signer, U256::from(3), 0, 1_000)));
+        let hash = *transaction.hash();
+        let mut listeners = SidecarListeners::default();
+
+        let (all_tx, mut all_rx) = mpsc::channel(1);
+        let (pending_all_tx, mut pending_all_rx) = mpsc::channel(1);
+        let (pending_propagate_tx, mut pending_propagate_rx) = mpsc::channel(1);
+        let (new_all_tx, mut new_all_rx) = mpsc::channel(1);
+        let (new_propagate_tx, mut new_propagate_rx) = mpsc::channel(1);
+        listeners.all_events.push(all_tx);
+        listeners.pending_all.push(pending_all_tx);
+        listeners.pending_propagate.push(pending_propagate_tx);
+        listeners.new_all.push(new_all_tx);
+        listeners.new_propagate.push(new_propagate_tx);
+
+        listeners.broadcast_all(FullTransactionEvent::Discarded(hash));
+        listeners.broadcast_all(FullTransactionEvent::Discarded(hash));
+        listeners.broadcast_pending(&transaction);
+        listeners.broadcast_pending(&transaction);
+        let event = NewTransactionEvent::pending(Arc::clone(&transaction));
+        listeners.broadcast_new(event.clone());
+        listeners.broadcast_new(event.clone());
+
+        assert_eq!(listeners.all_events.len(), 1);
+        assert_eq!(listeners.pending_all.len(), 1);
+        assert_eq!(listeners.pending_propagate.len(), 1);
+        assert_eq!(listeners.new_all.len(), 1);
+        assert_eq!(listeners.new_propagate.len(), 1);
+
+        assert!(all_rx.try_recv().is_ok());
+        assert_eq!(pending_all_rx.try_recv(), Ok(hash));
+        assert_eq!(pending_propagate_rx.try_recv(), Ok(hash));
+        assert!(new_all_rx.try_recv().is_ok());
+        assert!(new_propagate_rx.try_recv().is_ok());
+
+        listeners.broadcast_all(FullTransactionEvent::Discarded(hash));
+        listeners.broadcast_pending(&transaction);
+        listeners.broadcast_new(event.clone());
+
+        assert!(all_rx.try_recv().is_ok());
+        assert_eq!(pending_all_rx.try_recv(), Ok(hash));
+        assert_eq!(pending_propagate_rx.try_recv(), Ok(hash));
+        assert!(new_all_rx.try_recv().is_ok());
+        assert!(new_propagate_rx.try_recv().is_ok());
+
+        drop((all_rx, pending_all_rx, pending_propagate_rx, new_all_rx, new_propagate_rx));
+        listeners.broadcast_all(FullTransactionEvent::Discarded(hash));
+        listeners.broadcast_pending(&transaction);
+        listeners.broadcast_new(event);
+
+        assert!(listeners.all_events.is_empty());
+        assert!(listeners.pending_all.is_empty());
+        assert!(listeners.pending_propagate.is_empty());
+        assert!(listeners.new_all.is_empty());
+        assert!(listeners.new_propagate.is_empty());
     }
 
     type IntegrationPool = BaseTransactionPool<

--- a/crates/execution/txpool/src/two_d_nonce_pool.rs
+++ b/crates/execution/txpool/src/two_d_nonce_pool.rs
@@ -250,9 +250,6 @@ impl<T: BasePooledTx> TwoDNoncePool<T> {
         }
 
         if let Some(replay_id) = transaction.transaction.eip8130_replay_id() {
-            let sender_id = self.senders.sender_id_or_create(transaction.sender());
-            transaction.transaction_id = TransactionId::new(sender_id, transaction.nonce());
-            let transaction = Arc::new(transaction);
             let replaced = if let Some(existing) = self.nonce_free.get(&replay_id) {
                 if existing.is_underpriced(&transaction, &self.price_bump_config) {
                     return Err(PoolError::new(hash, PoolErrorKind::ReplacementUnderpriced));
@@ -261,6 +258,9 @@ impl<T: BasePooledTx> TwoDNoncePool<T> {
             } else {
                 None
             };
+            let sender_id = self.senders.sender_id_or_create(transaction.sender());
+            transaction.transaction_id = TransactionId::new(sender_id, transaction.nonce());
+            let transaction = Arc::new(transaction);
             if let Some(existing) = &replaced {
                 self.hashes.remove(existing.hash());
             }
@@ -279,8 +279,28 @@ impl<T: BasePooledTx> TwoDNoncePool<T> {
         })?;
 
         let lane_id = (sender, nonce_key);
-        let sender_id = self.senders.sender_id_or_create(sender);
         let nonce = transaction.nonce();
+        if nonce < state_nonce {
+            return Err(PoolError::new(
+                hash,
+                PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::Consensus(
+                    InvalidTransactionError::NonceNotConsistent { tx: nonce, state: state_nonce },
+                )),
+            ));
+        }
+
+        let replaced = if let Some(existing) =
+            self.lanes.get(&lane_id).and_then(|lane| lane.transactions.get(&nonce))
+        {
+            if existing.is_underpriced(&transaction, &self.price_bump_config) {
+                return Err(PoolError::new(hash, PoolErrorKind::ReplacementUnderpriced));
+            }
+            Some(Arc::clone(existing))
+        } else {
+            None
+        };
+
+        let sender_id = self.senders.sender_id_or_create(sender);
         transaction.transaction_id = TransactionId::new(sender_id, nonce);
         let transaction = Arc::new(transaction);
         let lane = self.lanes.entry(lane_id).or_insert_with(|| NonceLane {
@@ -291,32 +311,8 @@ impl<T: BasePooledTx> TwoDNoncePool<T> {
         // move backward after a reorg lowers the on-chain channel nonce, allowing
         // now-valid transactions to be accepted instead of treating them as
         // already executed under the pre-reorg lane cursor.
-        if state_nonce != lane.next_nonce {
-            lane.next_nonce = state_nonce;
-        }
+        lane.next_nonce = state_nonce;
         let pending_len_before = lane.consecutive_pending_len();
-
-        if nonce < lane.next_nonce {
-            return Err(PoolError::new(
-                hash,
-                PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::Consensus(
-                    InvalidTransactionError::NonceNotConsistent {
-                        tx: nonce,
-                        state: lane.next_nonce,
-                    },
-                )),
-            ));
-        }
-
-        let replaced: Option<Arc<ValidPoolTransaction<T>>> =
-            if let Some(existing) = lane.transactions.get(&nonce) {
-                if existing.is_underpriced(&transaction, &self.price_bump_config) {
-                    return Err(PoolError::new(hash, PoolErrorKind::ReplacementUnderpriced));
-                }
-                Some(Arc::clone(existing))
-            } else {
-                None
-            };
 
         lane.transactions.insert(nonce, Arc::clone(&transaction));
         self.hashes.insert(hash, Arc::clone(&transaction));
@@ -860,6 +856,63 @@ mod tests {
         assert!(pool.get(&original_hash).is_none());
         assert!(pool.get(&replacement_hash).is_some());
         assert_eq!(pool.all_transactions().len(), 1);
+    }
+
+    #[test]
+    fn stale_nonce_rejection_does_not_mutate_lane() {
+        let mut pool = TwoDNoncePool::new(PriceBumpConfig::default());
+        let signer = signer();
+        let nonce_key = U256::from(8);
+        let first = valid_pool_transaction(signed_channel_tx(&signer, nonce_key, 0, 1_000));
+        let second = valid_pool_transaction(signed_channel_tx(&signer, nonce_key, 1, 1_000));
+        pool.insert_validated(first, 0).unwrap();
+        pool.insert_validated(second, 0).unwrap();
+
+        let lane_id = (signer.address(), nonce_key);
+        let hashes_before = pool.all_hashes();
+        let counts_before = pool.pending_and_queued_txn_count();
+        let rejected = valid_pool_transaction(signed_channel_tx(&signer, nonce_key, 0, 1_250));
+
+        assert!(matches!(
+            pool.insert_validated(rejected, 1).unwrap_err().kind,
+            PoolErrorKind::InvalidTransaction(_)
+        ));
+        assert_eq!(pool.lanes.get(&lane_id).map(|lane| lane.next_nonce), Some(0));
+        assert_eq!(pool.all_hashes(), hashes_before);
+        assert_eq!(pool.pending_and_queued_txn_count(), counts_before);
+
+        let new_signer = PrivateKeySigner::random();
+        let new_lane_id = (new_signer.address(), nonce_key);
+        let rejected = valid_pool_transaction(signed_channel_tx(&new_signer, nonce_key, 0, 1_000));
+        assert!(pool.senders.sender_id(&new_signer.address()).is_none());
+
+        assert!(pool.insert_validated(rejected, 1).is_err());
+        assert!(pool.senders.sender_id(&new_signer.address()).is_none());
+        assert!(!pool.lanes.contains_key(&new_lane_id));
+    }
+
+    #[test]
+    fn underpriced_replacement_does_not_mutate_lane() {
+        let mut pool = TwoDNoncePool::new(PriceBumpConfig::default());
+        let signer = signer();
+        let nonce_key = U256::from(9);
+        let first = valid_pool_transaction(signed_channel_tx(&signer, nonce_key, 0, 1_000));
+        let second = valid_pool_transaction(signed_channel_tx(&signer, nonce_key, 1, 1_000));
+        pool.insert_validated(first, 0).unwrap();
+        pool.insert_validated(second, 0).unwrap();
+
+        let lane_id = (signer.address(), nonce_key);
+        let hashes_before = pool.all_hashes();
+        let counts_before = pool.pending_and_queued_txn_count();
+        let rejected = valid_pool_transaction(signed_channel_tx(&signer, nonce_key, 1, 1_050));
+
+        assert!(matches!(
+            pool.insert_validated(rejected, 1).unwrap_err().kind,
+            PoolErrorKind::ReplacementUnderpriced
+        ));
+        assert_eq!(pool.lanes.get(&lane_id).map(|lane| lane.next_nonce), Some(0));
+        assert_eq!(pool.all_hashes(), hashes_before);
+        assert_eq!(pool.pending_and_queued_txn_count(), counts_before);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This makes rejected 2D nonce pool insertions side-effect free by completing stale nonce and replacement-price checks before mutating pool state. It also keeps bounded sidecar listeners subscribed when their channels are temporarily full, while still removing closed listeners. Regression tests cover lane cursors, sender identifiers, pool views, and listener delivery after backpressure.