### PR TITLE
chore(workspace): Simplify Workspace Dependency Manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1437,7 +1437,7 @@ dependencies = [
  "alloy-transport 2.2.0",
  "futures",
  "http 1.4.2",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "serde_json",
  "tokio",
  "tokio-tungstenite 0.28.0",
@@ -2861,7 +2861,7 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -3729,7 +3729,7 @@ dependencies = [
  "metrics",
  "metrics-util",
  "rstest",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "serde",
  "serde_json",
  "sp1-sdk",
@@ -4413,7 +4413,7 @@ dependencies = [
  "base-common-rpc-types-engine",
  "derive_more 2.1.1",
  "notify",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
@@ -5890,7 +5890,7 @@ dependencies = [
  "k256",
  "metrics",
  "reqwest 0.13.4",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "thiserror 2.0.19",
  "tokio",
  "tokio-util",
@@ -6029,7 +6029,7 @@ dependencies = [
  "jsonrpsee",
  "metrics",
  "metrics-util",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
@@ -6780,7 +6780,7 @@ dependencies = [
  "anyhow",
  "basectl-cli",
  "clap",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "tokio",
  "tracing-subscriber 0.3.23",
 ]
@@ -7270,7 +7270,7 @@ dependencies = [
  "num",
  "pin-project-lite",
  "rand 0.9.5",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "rustls-native-certs",
  "rustls-pemfile",
  "rustls-pki-types",
@@ -7807,9 +7807,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.3"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -7817,9 +7817,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -7829,14 +7829,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -10094,7 +10094,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "rustls-pki-types",
 ]
 
@@ -11062,7 +11062,7 @@ dependencies = [
  "hyper 1.11.0",
  "hyper-util",
  "log",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -11925,7 +11925,7 @@ dependencies = [
  "http 1.4.2",
  "jsonrpsee-core",
  "pin-project",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "rustls-pki-types",
  "rustls-platform-verifier 0.5.3",
  "soketto",
@@ -11978,7 +11978,7 @@ dependencies = [
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "rustls-platform-verifier 0.5.3",
  "serde",
  "serde_json",
@@ -12552,7 +12552,7 @@ dependencies = [
  "quinn-proto",
  "rand 0.8.7",
  "ring",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "socket2 0.5.10",
  "thiserror 2.0.19",
  "tokio",
@@ -12634,7 +12634,7 @@ dependencies = [
  "libp2p-identity",
  "rcgen",
  "ring",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "rustls-webpki 0.103.13",
  "thiserror 2.0.19",
  "x509-parser",
@@ -15765,7 +15765,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.3",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "socket2 0.6.5",
  "thiserror 2.0.19",
  "tokio",
@@ -15788,7 +15788,7 @@ dependencies = [
  "rand_pcg",
  "ring",
  "rustc-hash 2.1.3",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.19",
@@ -16315,7 +16315,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -16362,7 +16362,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "rustls-pki-types",
  "rustls-platform-verifier 0.7.0",
  "serde",
@@ -20124,9 +20124,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -20180,7 +20180,7 @@ dependencies = [
  "jni 0.21.1",
  "log",
  "once_cell",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.13",
@@ -20201,7 +20201,7 @@ dependencies = [
  "jni 0.22.4",
  "log",
  "once_cell",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.13",
@@ -21607,7 +21607,7 @@ dependencies = [
  "opentelemetry-otlp 0.16.0",
  "opentelemetry_sdk 0.23.0",
  "prost 0.13.5",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "serde",
  "serde_json",
  "sp1-prover-types",
@@ -22146,7 +22146,7 @@ dependencies = [
  "prost 0.13.5",
  "reqwest 0.12.28",
  "reqwest-middleware",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "serde",
  "sha2 0.10.9",
  "sp1-build",
@@ -23121,9 +23121,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "libc",
@@ -23272,7 +23272,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "tokio",
 ]
 
@@ -23311,7 +23311,7 @@ dependencies = [
  "futures-util",
  "log",
  "native-tls",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -24044,7 +24044,7 @@ dependencies = [
  "log",
  "native-tls",
  "rand 0.9.5",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "rustls-pki-types",
  "sha1 0.10.7",
  "thiserror 2.0.19",
@@ -24340,7 +24340,7 @@ dependencies = [
  "base64 0.22.1",
  "log",
  "percent-encoding",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,62 +9,38 @@ exclude = [".github/"]
 
 [workspace]
 resolver = "2"
-exclude = ["bin/prover", "crates/proof/succinct/programs", "actions/fixtures"]
+exclude = ["actions/fixtures", "crates/proof/succinct/programs"]
 members = [
-  "bin/*",
-  "bin/prover/nitro-host",
-  "bin/prover/nitro-enclave",
-  "bin/prover/zk-host",
-  "bin/prover/service",
-  "crates/proof/mpt",
-  "crates/proof/proof",
-  "crates/proof/driver",
-  "crates/proof/client",
-  "crates/proof/executor",
-  "crates/proof/preimage",
-  "crates/proof/primitives",
-  "crates/proof/host",
-  "crates/proof/prover-service",
-  "crates/proof/prover-service/client",
-  "crates/proof/prover-service/protocol",
-  "crates/proof/prover-service/db",
-  "crates/proof/worker",
-  "crates/proof/tee/nitro-host",
-  "crates/proof/tee/nitro-enclave",
-  "crates/proof/tee/registrar",
-  "crates/proof/tee/nitro-verifier",
-  "crates/proof/tee/nitro-attestation-prover",
-  "crates/proof/zk/host",
-  "crates/proof/zk/backend",
-  "crates/proof/contracts",
-  "crates/proof/submission",
-  "crates/proof/rpc",
-  "crates/proof/proposer",
-  "crates/proof/challenge",
-  "crates/proof/succinct/utils/client",
-  "crates/proof/succinct/utils/host",
-  "crates/proof/succinct/utils/proof",
-  "crates/proof/succinct/utils/elfs",
-  "crates/proof/succinct/scripts",
-
-  "crates/execution/*",
-  "crates/consensus/*",
-  "crates/utilities/*",
+  "actions/*",
+  "bin/[a-o]*",
+  "bin/[q-z]*",
+  "bin/proposer",
+  "bin/prover-*",
+  "bin/prover/*",
   "crates/batcher/*",
   "crates/builder/*",
   "crates/common/*",
+  "crates/consensus/*",
+  "crates/execution/*",
   "crates/infra/*",
+  "crates/proof/[a-r]*",
+  "crates/proof/sub*",
+  "crates/proof/[u-y]*",
+  "crates/proof/prover-service/[a-r]*",
+  "crates/proof/succinct/scripts",
+  "crates/proof/succinct/utils/*",
+  "crates/proof/tee/*",
+  "crates/proof/zk/*",
+  "crates/utilities/*",
   "etc/tools/*",
   "etc/systems",
-  "actions/*",
 ]
 default-members = [
-  "bin/*",
-  "bin/prover/nitro-host",
-  "bin/prover/nitro-enclave",
-  "bin/prover/zk-host",
-  "bin/prover/service",
-  "bin/prover-registrar",
+  "bin/[a-o]*",
+  "bin/[q-z]*",
+  "bin/proposer",
+  "bin/prover-*",
+  "bin/prover/*",
 ]
 
 [workspace.metadata.cargo-udeps.ignore]
@@ -257,13 +233,9 @@ base-proof-tee-nitro-attestation-prover = { path = "crates/proof/tee/nitro-attes
 
 # Succinct (OP Succinct / SP1 proving)
 base-proof-succinct-elfs = { path = "crates/proof/succinct/utils/elfs" }
-base-proof-succinct-scripts = { path = "crates/proof/succinct/scripts" }
 base-proof-succinct-host-utils = { path = "crates/proof/succinct/utils/host" }
 base-proof-succinct-proof-utils = { path = "crates/proof/succinct/utils/proof" }
 base-proof-succinct-client-utils = { path = "crates/proof/succinct/utils/client" }
-
-# Actions
-base-action-harness = { path = "actions/harness" }
 
 # Batcher
 base-blobs = { path = "crates/batcher/blobs" }
@@ -295,16 +267,12 @@ base-runtime = { path = "crates/utilities/runtime", default-features = false }
 revm = { version = "41.0.0", default-features = false }
 revm-bytecode = { version = "41.0.0", default-features = false }
 revm-database = { version = "41.0.0", default-features = false }
-revm-inspectors = { version = "0.41.0", default-features = false }
 revm-precompile = { version = "41.0.0", default-features = false }
-revm-primitives = { version = "41.0.0", default-features = false }
-revm-context-interface = { version = "41.0.0", default-features = false }
 
 # alloy
 alloy-signer = "2.0.5"
 alloy-pubsub = "2.0.5"
 alloy-network = "2.0.5"
-alloy-eip7928 = "0.4.0"
 alloy-provider = "2.0.5"
 alloy-contract = "2.0.5"
 alloy-json-rpc = "2.0.5"
@@ -313,7 +281,6 @@ alloy-rpc-types = "2.0.5"
 alloy-hardforks = "0.4.7"
 alloy-sol-macro = "1.6.0"
 alloy-rpc-client = "2.0.5"
-alloy-signer-gcp = "2.0.5"
 alloy-signer-local = "2.0.5"
 alloy-transport-ws = "2.0.5"
 alloy-node-bindings = "2.0.5"
@@ -338,6 +305,7 @@ alloy-network-primitives = { version = "2.0.5", default-features = false }
 # reth
 reth-zstd-compressors = { version = "0.5.0", default-features = false }
 reth-primitives-traits = { version = "0.5.0", default-features = false }
+reth-codecs = { version = "0.5.0", default-features = false, features = ["alloy"] }
 reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-ipc = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
@@ -348,7 +316,6 @@ reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15
 reth-exex = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-ecies = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-discv4 = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
@@ -366,16 +333,13 @@ reth-rpc-layer = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05
 reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-chain-state = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
-reth-codecs = { version = "0.5.0", default-features = false, features = ["alloy"] }
 reth-payload-util = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
@@ -384,7 +348,6 @@ reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2
 reth-tracing-otlp = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-testing-utils = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
-reth-trie-parallel = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
@@ -397,7 +360,6 @@ reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "23
 reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
@@ -409,24 +371,20 @@ reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", rev = "2382
 reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c", default-features = false }
 
 # tokio
-tokio = "1.48.0"
-tokio-util = "0.7.4"
+tokio = "1.53.1"
+tokio-util = "0.7.19"
 tokio-stream = "0.1.17"
 tokio-tungstenite = "0.28.0"
 
 # async
 futures = "0.3.31"
 reqwest = "0.13.1"
+async-stream = "0.3"
+async-channel = "2.5"
 async-trait = "0.1.83"
 
 # grpc
-prost = "0.14"
 tonic = "0.14"
-tonic-web = "0.14"
-prost-types = "0.14"
-tonic-prost = "0.14"
-tonic-reflection = "0.14"
-tonic-prost-build = "0.14"
 
 # rpc
 jsonrpsee = "0.26.0"
@@ -434,15 +392,29 @@ jsonrpsee-core = "0.26.0"
 jsonrpsee-types = "0.26.0"
 
 # cli
-clap = "4.5.57"
-clap_builder = "4.5.57"
+clap = "4.6.5"
+arboard = "3.6.1"
+ratatui = "0.30.0"
+crossterm = "0.29"
+indicatif = "0.18"
+num-format = "0.4.4"
+human_bytes = "0.4.3"
+clap_builder = "4.6.5"
+tracing-indicatif = "0.3"
 
-# Tracing
+# tracing
 tracing-appender = "0.2.4"
 tracing-subscriber = "0.3.22"
 tracing = { version = "0.1.43", default-features = false }
 
-# Metrics
+# OpenTelemetry
+opentelemetry = "0.32"
+opentelemetry-appender-tracing = "0.32"
+opentelemetry_sdk = { version = "0.32", default-features = false }
+opentelemetry-http = { version = "0.32", default-features = false }
+opentelemetry-otlp = { version = "0.32", default-features = false }
+
+# metrics
 cadence = "1.5"
 ordered-float = "5"
 metrics = { version = "0.24.3", default-features = false }
@@ -475,43 +447,59 @@ sha3 = "0.10"
 k256 = "0.13"
 p256 = "0.13"
 p384 = "0.13"
-ciborium = "0.2"
-rustls = "0.23.35"
+blake3 = "1.8"
+openssl = "0.10"
+getrandom = "0.4"
+rustls = "0.23.43"
 secp256k1 = "0.30"
+hex-literal = "1.1"
 x509-parser = "0.17"
 sha2 = { version = "0.10", default-features = false }
 c-kzg = { version = "2.1.5", default-features = false }
+kzg-rs = { version = "0.2.8", default-features = false }
+ark-ff = { version = "0.5.0", default-features = false }
+ark-bls12-381 = { version = "0.5.0", default-features = false }
 
 # http
+url = "2.5"
 http = "1.4"
 hyper = "1.8"
 tower = "0.5"
 http-body = "1.0"
 hyper-util = "0.1.11"
 http-body-util = "0.1.3"
-axum = { version = "0.8.3", default-features = false }
+axum = { version = "0.8.9", default-features = false }
 tower-http = { version = "0.6", features = ["limit", "timeout"] }
 
 # p2p
+ipnet = "2.11"
 discv5 = "0.10"
 libp2p = "0.56.0"
+multihash = "0.19"
 libp2p-identity = "0.2.12"
+libp2p-stream = "0.4.0-alpha"
+unsigned-varint = { version = "0.8", default-features = false }
 
 # serde
+rkyv = "0.8"
 bincode = "2"
+ciborium = "0.2"
+serde_repr = "0.1"
 serde_bytes = "0.11"
 serde_with = "3.8.1"
+serde_cbor = "0.11.2"
 ethereum_ssz = "0.10"
 serde_yaml = "0.9.34"
 ethereum_ssz_derive = "0.10"
+toml = { version = "1.0", default-features = false }
 serde = { version = "1.0.228", default-features = false }
-serde_json = { version = "1.0.145", default-features = false }
+serde_json = { version = "1.0.151", default-features = false }
 
 # testing
 arbtest = "0.3"
 test-case = "3"
 mockall = "0.14"
-tempfile = "3.20"
+tempfile = "3.27"
 rstest = "0.26.1"
 criterion = "0.8"
 serial_test = "3"
@@ -527,107 +515,87 @@ testcontainers-modules = { version = "0.13", default-features = false }
 bollard = "0.19.4"
 
 # compression
-zstd = "0.13"
-blake3 = "1.8"
-
-# misc
 snap = "1"
-redb = "2"
-hex = "0.4"
-url = "2.5"
-quote = "1"
-libc = "0.2"
-ctor = "0.6"
-eyre = "0.6"
-lru = "0.16"
-rand = "0.9"
-rkyv = "0.8"
-moka = "0.12"
-uuid = "1.21"
-csv = "1.3.0"
-imbl = "7.0.0"
-dirs = "6.0.0"
-log = "0.4.22"
-anyhow = "1.0"
-rayon = "1.11"
-nanoid = "0.4"
+zstd = "0.13"
 tar = "0.4.44"
-backon = "1.6"
-time = "0.3.44"
-base64 = "0.22"
-rlimit = "0.11"
-dashmap = "6.1"
-bytes = "1.11.1"
-proc-macro2 = "1"
-dotenv = "0.15.0"
-arboard = "3.6.1"
-chrono = "0.4.42"
-backoff = "0.4.0"
-humantime = "2.3"
-hostname = "0.4.0"
-ratatui = "0.30.0"
-crossterm = "0.29"
-indicatif = "0.18"
-arc-swap = "1.7.1"
-tokio-vsock = "0.7"
-hex-literal = "1.1"
-auto_impl = "1.2.0"
-shellexpand = "3.1"
-dirs-next = "2.0.0"
-num-format = "0.4.4"
-ambassador = "0.4.2"
-serde_cbor = "0.11.2"
-strum_macros = "0.28"
 miniz_oxide = "0.9.0"
-human_bytes = "0.4.3"
-parking_lot = "0.12.3"
-opentelemetry = "0.32"
-cargo_metadata = "0.18.1"
-tracing-indicatif = "0.3"
-tikv-jemallocator = "0.6"
-modular-bitfield = "0.13.1"
-crossbeam-channel = "0.5.13"
-tracing-opentelemetry = "0.33"
-opentelemetry-appender-tracing = "0.32"
-static_assertions = { version = "1.1.0" }
-rand_08 = { package = "rand", version = "0.8" }
-strum = { version = "0.27", default-features = false }
 brotli = { version = "8.0.2", default-features = false }
-rocksdb = { version = "0.24", default-features = false }
-kzg-rs = { version = "0.2.8", default-features = false }
-thiserror = { version = "2.0", default-features = false }
-either = { version = "1.15.0", default-features = false }
-dotenvy = { version = "0.15.7", default-features = false }
-figment = { version = "0.10.19", default-features = false }
-syn = { version = "2", features = ["full", "extra-traits"] }
-derive_more = { version = "2.1.0", default-features = false }
-lazy_static = { version = "1.5.0", features = ["spin_no_std"] }
-opentelemetry_sdk = { version = "0.32", default-features = false }
-opentelemetry-http = { version = "0.32", default-features = false }
-opentelemetry-otlp = { version = "0.32", default-features = false }
 
 # database
+redb = "2"
 sqlx = { version = "0.8", default-features = false }
+rocksdb = { version = "0.24", default-features = false }
+
+# errors
+eyre = "0.6"
+anyhow = "1.0"
+backtrace = "0.3"
+thiserror = { version = "2.0", default-features = false }
+
+# collections and concurrency
+lru = "0.16"
+moka = "0.12"
+imbl = "7.0.0"
+rayon = "1.11"
+dashmap = "6.1"
+arc-swap = "1.7.1"
+parking_lot = "0.12.3"
+either = { version = "1.15.0", default-features = false }
+
+# configuration
+dirs = "6.0.0"
+dirs-next = "2.0.0"
+dotenvy = { version = "0.15.7", default-features = false }
+figment = { version = "0.10.19", default-features = false }
+
+# encoding
+hex = "0.4"
+base64 = "0.22"
+bytes = "1.12.1"
+
+# identifiers and randomness
+rand = "0.9"
+uuid = "1.24"
+nanoid = "0.4"
+rand_08 = { package = "rand", version = "0.8" }
+
+# time
+time = "0.3.55"
+chrono = "0.4.42"
+humantime = "2.3"
+
+# retry
+backon = "1.6"
+backoff = "0.4.0"
+
+# macros and code generation
+quote = "1"
+ctor = "0.6"
+proc-macro2 = "1"
+auto_impl = "1.2.0"
+ambassador = "0.4.2"
+modular-bitfield = "0.13.1"
+static_assertions = { version = "1.1.0" }
+strum = { version = "0.27", default-features = false }
+syn = { version = "2", features = ["full", "extra-traits"] }
+derive_more = { version = "2.1.0", default-features = false }
+
+# no_std
+spin = "0.10"
+cfg-if = "1.0"
+alloc-no-stdlib = "2.0"
+lazy_static = { version = "1.5.0", features = ["spin_no_std"] }
+
+# system
+libc = "0.2"
+rlimit = "0.11"
+hostname = "0.4.0"
+tokio-vsock = "0.7"
+tikv-jemallocator = "0.6"
+
+# tooling
+notify = "8.2"
+cargo_metadata = "0.18.1"
 
 # rate limiting
 governor = "0.7"
-nonzero_ext = "0.3"
-
-# transitive deps
-spin = "0.10"
-ipnet = "2.11"
-notify = "8.2"
-cfg-if = "1.0"
-openssl = "0.10"
-backtrace = "0.3"
-getrandom = "0.4"
-multihash = "0.19"
-serde_repr = "0.1"
-async-stream = "0.3"
-async-channel = "2.5"
-alloc-no-stdlib = "2.0"
-libp2p-stream = "0.4.0-alpha"
-toml = { version = "1.0", default-features = false }
-ark-ff = { version = "0.5.0", default-features = false }
-unsigned-varint = { version = "0.8", default-features = false }
-ark-bls12-381 = { version = "0.5.0", default-features = false }


### PR DESCRIPTION
## Summary

This simplifies workspace membership with targeted globs and reorganizes shared dependencies into focused domain groups while preserving waterfall ordering. It removes unused dependency declarations and conservatively updates individual crates without changing the Alloy, REVM, Reth, or proving-stack families. The resulting workspace was verified with locked metadata, all-feature and all-target checks and builds, dependency usage auditing, and the workspace test suite.