### PR TITLE
feat(upgrade-signal): derive live poll interval from L1 block tag

### DIFF
--- a/crates/consensus/service/src/actors/upgrade_signal.rs
+++ b/crates/consensus/service/src/actors/upgrade_signal.rs
@@ -1,10 +1,12 @@
 //! Upgrade signal metrics observer actor.
 
+use core::time::Duration;
+
 use alloy_provider::RootProvider;
 use base_consensus_providers::L1RpcProvider;
 use base_upgrade_signal::{
-    AlloyUpgradeSignalReader, UpgradeSignalConfig, UpgradeSignalDefaults, UpgradeSignalError,
-    UpgradeSignalMetricLayer, UpgradeSignalMonitor, UpgradeSignalRefresher,
+    AlloyUpgradeSignalReader, UpgradeSignalConfig, UpgradeSignalError, UpgradeSignalMetricLayer,
+    UpgradeSignalMonitor, UpgradeSignalRefresher,
 };
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
@@ -73,6 +75,8 @@ pub struct UpgradeSignalMetricsActor {
     pub reader: AlloyUpgradeSignalReader,
     /// Live metrics state.
     pub monitor: UpgradeSignalMonitor,
+    /// Interval between live L1 upgrade signal contract reads.
+    pub poll_interval: Duration,
     /// Runtime refresher applied automatically on observed live updates, when enabled.
     pub refresher: Option<UpgradeSignalRefresher>,
     /// Cancellation token shared with the rollup node.
@@ -87,10 +91,11 @@ impl UpgradeSignalMetricsActor {
         refresher: Option<UpgradeSignalRefresher>,
         cancellation: CancellationToken,
     ) -> Self {
+        let poll_interval = config.l1_block_tag.poll_interval();
         let reader = config.reader(l1_provider);
         let monitor = UpgradeSignalMonitor::new(UpgradeSignalMetricLayer::Consensus);
 
-        Self { reader, monitor, refresher, cancellation }
+        Self { reader, monitor, poll_interval, refresher, cancellation }
     }
 
     /// Polls L1 upgrade signal state, records metrics, and auto-applies observed changes when
@@ -118,7 +123,7 @@ impl NodeActor for UpgradeSignalMetricsActor {
 
     async fn start(mut self, _ctx: ()) -> Result<(), Self::Error> {
         let cancellation = self.cancellation.clone();
-        let mut interval = tokio::time::interval(UpgradeSignalDefaults::POLL_INTERVAL);
+        let mut interval = tokio::time::interval(self.poll_interval);
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         loop {

--- a/crates/execution/cli/src/upgrade_signal.rs
+++ b/crates/execution/cli/src/upgrade_signal.rs
@@ -4,9 +4,8 @@ use alloy_provider::RootProvider;
 use base_execution_chainspec::BaseChainSpec;
 use base_node_runner::{BaseNodeExtension, BaseRpcContext, FromExtensionConfig, NodeHooks};
 use base_upgrade_signal::{
-    UpgradeSignalApplySummary, UpgradeSignalConfig, UpgradeSignalDefaults,
-    UpgradeSignalMetricLayer, UpgradeSignalMonitor, UpgradeSignalRefresher,
-    UpgradeSignalRuntimeApplier, UpgradeSignalSchedule,
+    UpgradeSignalApplySummary, UpgradeSignalConfig, UpgradeSignalMetricLayer, UpgradeSignalMonitor,
+    UpgradeSignalRefresher, UpgradeSignalRuntimeApplier, UpgradeSignalSchedule,
 };
 use jsonrpsee::{RpcModule, core::RpcResult, types::ErrorObject};
 use reth_chainspec::EthChainSpec;
@@ -142,6 +141,7 @@ impl BaseNodeExtension for ExecutionUpgradeSignalRuntimeExtension {
 
         hooks.add_node_started_hook(move |ctx| {
             let l1_provider = RootProvider::new_http(config.l1_rpc.clone());
+            let poll_interval = config.signal_config.l1_block_tag.poll_interval();
             let reader = config.signal_config.reader(l1_provider.clone());
             // Live updates are re-applied automatically, matching the manual
             // `admin_refreshUpgradeSignal` path.
@@ -158,7 +158,7 @@ impl BaseNodeExtension for ExecutionUpgradeSignalRuntimeExtension {
 
             executor.spawn_with_graceful_shutdown_signal(|signal| {
                 Box::pin(async move {
-                    let mut interval = tokio::time::interval(UpgradeSignalDefaults::POLL_INTERVAL);
+                    let mut interval = tokio::time::interval(poll_interval);
                     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
                     let mut signal = Box::pin(signal);
 
@@ -205,6 +205,7 @@ impl FromExtensionConfig for ExecutionUpgradeSignalRuntimeExtension {
 mod tests {
     use alloy_primitives::Address;
     use base_common_genesis::{BaseUpgrade, RuntimeUpgradeRegistry, UpgradeActivation};
+    use base_upgrade_signal::UpgradeSignalDefaults;
     use reth_chainspec::{ChainSpec, EthereumHardfork, ForkCondition};
 
     use super::*;

--- a/crates/utilities/upgrade-signal/README.md
+++ b/crates/utilities/upgrade-signal/README.md
@@ -21,7 +21,7 @@ The shared CLI flags are:
 | ---- | ------- | ------- | ----------- |
 | `--upgrade-signal.contract <ADDRESS>` | `BASE_NODE_UPGRADE_SIGNAL_CONTRACT` | unset | Enables L1 schedule reads from the `ProtocolVersions` contract or proxy. The full contract-backed upgrade schedule is always read; application depends on the selected mode. |
 | `--upgrade-signal.mode <metrics-only\|startup-apply\|runtime-admin>` | `BASE_NODE_UPGRADE_SIGNAL_MODE` | `metrics-only` | Selects whether reads are observation-only, startup-applied, or runtime-applied. |
-| `--upgrade-signal.l1-block-tag <finalized\|safe\|latest>` | `BASE_NODE_UPGRADE_SIGNAL_L1_BLOCK_TAG` | `finalized` | Selects the L1 block tag used for contract calls. |
+| `--upgrade-signal.l1-block-tag <finalized\|safe\|latest>` | `BASE_NODE_UPGRADE_SIGNAL_L1_BLOCK_TAG` | `finalized` | Selects the L1 block tag used for contract calls. Also selects the interval between live contract reads: `finalized` 15m, `safe` 6m24s, `latest` 12s. |
 
 Execution-side readers also need `--upgrade-signal.l1-rpc` or
 `BASE_NODE_UPGRADE_SIGNAL_L1_RPC`. Integrated `base rpc` and `base sequencer` commands derive this
@@ -30,10 +30,11 @@ unless an explicit override is supplied.
 
 ## Runtime Behavior
 
-All modes with a configured contract start a live observer. The observer polls L1 every 12 seconds,
-records the latest schedule metrics, and records update counters when a contract-backed signal changes.
-Read failures are metrics-only failures: they are logged and counted, but they do not clear the last
-observed schedule or stop the node.
+All modes with a configured contract start a live observer. The observer polls L1 on an interval
+selected by the configured block tag (see the flag table above), matching how often that tag
+typically advances. It records the latest schedule metrics and update counters when a
+contract-backed signal changes. Read failures are metrics-only failures: they are logged and
+counted, but they do not clear the last observed schedule or stop the node.
 
 `startup-apply` reads and validates the L1 schedule before the node starts serving.
 Execution-side callers apply the schedule to the chain spec, consensus-side callers apply it to the

--- a/crates/utilities/upgrade-signal/src/config/args.rs
+++ b/crates/utilities/upgrade-signal/src/config/args.rs
@@ -16,16 +16,17 @@ pub struct UpgradeSignalArgs {
         long = "upgrade-signal.mode",
         env = "BASE_NODE_UPGRADE_SIGNAL_MODE",
         value_enum,
-        default_value_t = UpgradeSignalMode::MetricsOnly
+        default_value_t = UpgradeSignalMode::default()
     )]
     pub mode: UpgradeSignalMode,
 
-    /// L1 block tag used to read the upgrade signal contract.
+    /// L1 block tag used to read the upgrade signal contract. Also selects the interval between
+    /// live contract reads: 15m for finalized, 6m24s for safe, 12s for latest.
     #[arg(
         long = "upgrade-signal.l1-block-tag",
         env = "BASE_NODE_UPGRADE_SIGNAL_L1_BLOCK_TAG",
         value_enum,
-        default_value_t = UpgradeSignalBlockTag::Finalized
+        default_value_t = UpgradeSignalBlockTag::default()
     )]
     pub l1_block_tag: UpgradeSignalBlockTag,
 }
@@ -38,7 +39,7 @@ impl UpgradeSignalArgs {
         Some(UpgradeSignalConfig {
             contract_address,
             mode: self.mode,
-            l1_block_tag: self.l1_block_tag.block_number_or_tag(),
+            l1_block_tag: self.l1_block_tag,
             node_protocol_version: UpgradeSignalDefaults::node_protocol_version(),
         })
     }
@@ -148,7 +149,6 @@ impl UpgradeSignalL1RpcArgs {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::address;
-    use alloy_rpc_types_eth::BlockNumberOrTag;
 
     use super::*;
 
@@ -179,7 +179,7 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(args.config().unwrap().l1_block_tag, BlockNumberOrTag::Latest);
+        assert_eq!(args.config().unwrap().l1_block_tag, UpgradeSignalBlockTag::Latest);
     }
 
     #[test]

--- a/crates/utilities/upgrade-signal/src/config/mod.rs
+++ b/crates/utilities/upgrade-signal/src/config/mod.rs
@@ -18,9 +18,6 @@ pub use types::{UpgradeSignalBlockTag, UpgradeSignalMode, UpgradeSignalStartupMo
 pub struct UpgradeSignalDefaults;
 
 impl UpgradeSignalDefaults {
-    /// Default wall-clock interval used to check whether another L1 block polling window has elapsed.
-    pub const POLL_INTERVAL: Duration = Duration::from_secs(12);
-
     /// Default number of attempts to read the L1 upgrade signal schedule before failing startup.
     pub const READ_ATTEMPTS: u32 = 3;
 

--- a/crates/utilities/upgrade-signal/src/config/schedule.rs
+++ b/crates/utilities/upgrade-signal/src/config/schedule.rs
@@ -1,11 +1,10 @@
 use alloy_primitives::{Address, U256};
 use alloy_provider::RootProvider;
-use alloy_rpc_types_eth::BlockNumberOrTag;
 use base_common_genesis::UpgradeActivationSink;
 use tracing::info;
 use url::Url;
 
-use super::{UpgradeSignalDefaults, UpgradeSignalMode};
+use super::{UpgradeSignalBlockTag, UpgradeSignalDefaults, UpgradeSignalMode};
 use crate::{
     contract::AlloyUpgradeSignalReader,
     error::UpgradeSignalError,
@@ -21,8 +20,8 @@ pub struct UpgradeSignalConfig {
     pub contract_address: Address,
     /// Local schedule mutation mode.
     pub mode: UpgradeSignalMode,
-    /// L1 block tag used to read the contract.
-    pub l1_block_tag: BlockNumberOrTag,
+    /// L1 block tag used to read the contract. Also selects the live read poll interval.
+    pub l1_block_tag: UpgradeSignalBlockTag,
     /// Node protocol version supported by this binary.
     pub node_protocol_version: U256,
 }
@@ -33,7 +32,7 @@ impl UpgradeSignalConfig {
         Self {
             contract_address,
             mode: UpgradeSignalMode::MetricsOnly,
-            l1_block_tag: BlockNumberOrTag::Finalized,
+            l1_block_tag: UpgradeSignalBlockTag::Finalized,
             node_protocol_version: UpgradeSignalDefaults::node_protocol_version(),
         }
     }
@@ -41,7 +40,7 @@ impl UpgradeSignalConfig {
     /// Creates a contract reader using this configuration's contract address and block tag.
     pub const fn reader(&self, l1_provider: RootProvider) -> AlloyUpgradeSignalReader {
         AlloyUpgradeSignalReader::new(l1_provider, self.contract_address)
-            .with_block_tag(self.l1_block_tag)
+            .with_block_tag(self.l1_block_tag.block_number_or_tag())
     }
 
     /// Returns true if this node supports the minimum protocol version attached to `signal`.
@@ -197,7 +196,6 @@ impl UpgradeSignalConfig {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{U256, address};
-    use alloy_rpc_types_eth::BlockNumberOrTag;
     use base_common_genesis::BaseUpgrade;
     use rstest::rstest;
 
@@ -219,7 +217,7 @@ mod tests {
     fn defaults_to_finalized_block_tag() {
         let config = UpgradeSignalConfig::new(address!("0000000000000000000000000000000000000001"));
 
-        assert_eq!(config.l1_block_tag, BlockNumberOrTag::Finalized);
+        assert_eq!(config.l1_block_tag, UpgradeSignalBlockTag::Finalized);
     }
 
     fn signal(protocol_version: U256) -> UpgradeSignal {

--- a/crates/utilities/upgrade-signal/src/config/types.rs
+++ b/crates/utilities/upgrade-signal/src/config/types.rs
@@ -1,3 +1,5 @@
+use core::time::Duration;
+
 use alloy_rpc_types_eth::BlockNumberOrTag;
 
 /// Controls which local schedule mutation paths are enabled for the L1 upgrade signal.
@@ -46,6 +48,17 @@ impl UpgradeSignalBlockTag {
             Self::Latest => BlockNumberOrTag::Latest,
         }
     }
+
+    /// Interval between live contract reads at this tag, matching how often the tag typically
+    /// advances: one L1 slot for `latest`, one epoch for `safe`, and the two-epoch finality lag
+    /// rounded up for `finalized`.
+    pub const fn poll_interval(self) -> Duration {
+        match self {
+            Self::Finalized => Duration::from_secs(15 * 60),
+            Self::Safe => Duration::from_secs(32 * 12),
+            Self::Latest => Duration::from_secs(12),
+        }
+    }
 }
 
 /// Controls whether a service should perform its own startup signal read.
@@ -62,5 +75,22 @@ impl UpgradeSignalStartupMode {
     /// Returns true if the service should perform its own startup signal read.
     pub const fn reads_and_applies(self) -> bool {
         matches!(self, Self::ReadAndApply)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn poll_interval_grows_with_tag_lag() {
+        assert!(
+            UpgradeSignalBlockTag::Latest.poll_interval()
+                < UpgradeSignalBlockTag::Safe.poll_interval()
+        );
+        assert!(
+            UpgradeSignalBlockTag::Safe.poll_interval()
+                < UpgradeSignalBlockTag::Finalized.poll_interval()
+        );
     }
 }

--- a/etc/systems/src/l2/in_process_follow_consensus.rs
+++ b/etc/systems/src/l2/in_process_follow_consensus.rs
@@ -16,8 +16,8 @@ use base_consensus_node::{EngineConfig, FollowNode, FollowNodeConfig, NodeMode, 
 use base_consensus_providers::L1RpcProvider;
 use base_consensus_rpc::RpcBuilder;
 use base_upgrade_signal::{
-    UpgradeSignalConfig, UpgradeSignalDefaults, UpgradeSignalMetricLayer, UpgradeSignalMonitor,
-    UpgradeSignalRefresher, UpgradeSignalRuntimeApplier,
+    UpgradeSignalConfig, UpgradeSignalMetricLayer, UpgradeSignalMonitor, UpgradeSignalRefresher,
+    UpgradeSignalRuntimeApplier,
 };
 use eyre::{Result, WrapErr};
 use tokio::{
@@ -190,7 +190,7 @@ impl InProcessFollowConsensus {
                 )
             });
             let mut monitor = UpgradeSignalMonitor::new(UpgradeSignalMetricLayer::Consensus);
-            let mut poll_interval = interval(UpgradeSignalDefaults::POLL_INTERVAL);
+            let mut poll_interval = interval(signal_config.l1_block_tag.poll_interval());
             poll_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
             loop {

--- a/etc/systems/src/upgrade_signal.rs
+++ b/etc/systems/src/upgrade_signal.rs
@@ -6,12 +6,13 @@
 use alloy_network::EthereumWallet;
 use alloy_primitives::{Address, U256};
 use alloy_provider::{Provider, ProviderBuilder};
-use alloy_rpc_types_eth::BlockNumberOrTag;
 use alloy_signer_local::PrivateKeySigner;
 use base_common_genesis::{BaseUpgrade, RollupConfig};
 use base_execution_cli::ExecutionUpgradeSignalConfig;
 use base_test_utils::MockProtocolVersions;
-use base_upgrade_signal::{UpgradeSignalConfig, UpgradeSignalDefaults, UpgradeSignalMode};
+use base_upgrade_signal::{
+    UpgradeSignalBlockTag, UpgradeSignalConfig, UpgradeSignalDefaults, UpgradeSignalMode,
+};
 use eyre::{Result, WrapErr};
 use url::Url;
 
@@ -118,7 +119,7 @@ impl UpgradeSignalStackOptions {
         UpgradeSignalConfig {
             contract_address,
             mode,
-            l1_block_tag: BlockNumberOrTag::Latest,
+            l1_block_tag: UpgradeSignalBlockTag::Latest,
             node_protocol_version: UpgradeSignalDefaults::node_protocol_version(),
         }
     }


### PR DESCRIPTION
## Summary
The upgrade signal live observer polled the `ProtocolVersions` contract every 12s regardless of the configured block tag. That cadence only makes sense for `latest` reads; `finalized` only advances every ~2 epochs, so production nodes were making ~75 redundant L1 reads for every one that could observe a change.

The poll interval is now selected by `--upgrade-signal.l1-block-tag`, matching how often each tag advances:

| Tag | Interval |
| --- | --- |
| `finalized` (default) | 15m |
| `safe` | 6m24s (one epoch) |
| `latest` | 12s (one slot) |

There is deliberately no separate poll-interval flag: the tag is the single knob, and the interval follows it. `UpgradeSignalConfig` stores `UpgradeSignalBlockTag` (instead of a raw `BlockNumberOrTag` plus a separate interval field), so the tag and its interval cannot desync — both the contract reader and the poll loops derive from it at the use site.

## Changes

- `UpgradeSignalBlockTag::poll_interval()` — single source of the tag→interval mapping
- Consensus actor and execution runtime extension poll on the tag-derived interval instead of a hardcoded 12s
- Devnet script drops its poll-related env plumbing; it reads `latest`, so the 12s cadence falls out automatically
- Clap defaults for `mode`/`l1-block-tag` now point at the enums' `Default` impls, so CLI and programmatic defaults cannot drift

## Testing

- `cargo test -p base-upgrade-signal` (40 tests), `cargo clippy --tests` clean on `base-upgrade-signal`, `base-consensus-node`, `base-execution-cli`
- New test asserts the interval invariant `latest < safe < finalized`