### PR TITLE
fix(basectl): default mainnet and sepolia to local RPCs

### DIFF
--- a/bin/basectl/README.md
+++ b/bin/basectl/README.md
@@ -32,6 +32,10 @@ RPC flags or a config override to target different endpoints.
 ### `basectl monitor`
 
 Opens the interactive TUI. With no subcommand, opens the Home view.
+The top-right badge shows the active EL and CL endpoints. Press `e` from any
+non-input view to switch the EL between the configured `rpc` and `public_rpc`;
+the CL endpoint is unchanged. Switching rebuilds the active monitors so their
+background requests reconnect to the selected EL endpoint.
 
 | Command                  | Alias | Description                                      |
 | ------------------------ | ----- | ------------------------------------------------ |

--- a/bin/basectl/README.md
+++ b/bin/basectl/README.md
@@ -20,6 +20,13 @@ Global options:
 | `-c, --config <CONFIG>` | `mainnet` | Chain config: `mainnet`, `sepolia`, `devnet`, or a path to a config file                                                                                                                                                                                                    |
 | `--conductor-rpc <URL>` |           | Bootstrap conductor JSON-RPC URL for runtime cluster discovery when the chain config has no hardcoded conductor list. Used by `basectl conductor` and `basectl sequencer`. If omitted, basectl uses `discovery.bootstrap_rpc` from config. Set via `BASECTL_CONDUCTOR_RPC`. |
 
+The built-in mainnet and Sepolia configs target a local node at
+`http://127.0.0.1:8545` (EL) and `http://127.0.0.1:9545` (CL). Their
+`public_rpc` values retain the hosted endpoints for network-reference reads,
+including tip comparisons and upgrade monitoring. Local-node commands do not
+silently fall back when the local node is unavailable. Use the command-specific
+RPC flags or a config override to target different endpoints.
+
 ## Commands
 
 ### `basectl monitor`
@@ -94,8 +101,8 @@ is one of `caught_up` (within ±N blocks of the reference, where N is the
 
 | Flag                       | Description                                                                                                                                                                                                                                                                                           |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--el-rpc <URL>`           | Override the execution-layer RPC URL. Defaults to the chain config's `rpc` field.                                                                                                                                                                                                                     |
-| `--cl-rpc <URL>`           | Override the consensus-node RPC URL. The mainnet and sepolia presets ship `consensus_node_rpc` unset, so non-devnet users must pass this flag (or set the field in their YAML config).                                                                                                                |
+| `--el-rpc <URL>`           | Override the execution-layer RPC URL. Defaults to the chain config's local `rpc` field.                                                                                                                                                                                                              |
+| `--cl-rpc <URL>`           | Override the consensus-node RPC URL. Defaults to the chain config's `consensus_node_rpc` field.                                                                                                                                                                                                       |
 | `--tip-tolerance <BLOCKS>` | Block tolerance for the tip-reference `caught_up` classification. Within ±this many blocks of the public reference, the local node is reported as `caught_up`; otherwise `behind` or `ahead`. Default `5` ≈ ~10s at Base's 2s block time. Use `0` for strict alerting, larger values to dampen noise. |
 | `--json`                   | Emit humanized JSON (decoded numeric values, ISO + local timestamps, precomputed `safeLag*`, `tipReference` object, `elSyncInfo` with `processedBlocks` / `remainingBlocks`) instead of the key-value table.                                                                                          |
 | `--raw`                    | With `--json`, emit the alloy-typed `optimism_syncStatus` wire format instead of the humanized form. Errors at parse time if used without `--json`.                                                                                                                                                   |
@@ -131,8 +138,8 @@ Read-only p2p commands and single-peer actions support:
 
 | Flag             | Description                                                                                                                                                                            |
 | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--el-rpc <URL>` | Override the execution-layer RPC URL. Defaults to the chain config's `rpc` field.                                                                                                      |
-| `--cl-rpc <URL>` | Override the consensus-node RPC URL. The mainnet and sepolia presets ship `consensus_node_rpc` unset, so non-devnet users must pass this flag (or set the field in their YAML config). |
+| `--el-rpc <URL>` | Override the execution-layer RPC URL. Defaults to the chain config's local `rpc` field.             |
+| `--cl-rpc <URL>` | Override the consensus-node RPC URL. Defaults to the chain config's `consensus_node_rpc` field.    |
 
 Read-only p2p commands also support:
 
@@ -311,7 +318,7 @@ Doctor reads the selected config the same way as the other non-TUI commands:
 built-in preset, optional YAML override, or explicit config path through global
 `-c/--config`. By default it uses the config's `rpc`, `l1_rpc`, and
 `consensus_node_rpc` values. Pass `--el-rpc` and `--cl-rpc` to point at a
-specific node when the config points at shared/public endpoints.
+different node.
 
 Checks include declared network vs. live chain ID, p2p endpoint context,
 canonical bootnode config context, advertised endpoint sanity,
@@ -440,21 +447,21 @@ basectl -c mainnet block --json --raw finalized | jq '{number, gasUsed, baseFeeP
 # Sync status against a devnet (consensus_node_rpc is set in the devnet preset)
 basectl -c devnet sync-status
 
-# Sync status against a public chain — requires explicit --cl-rpc since mainnet/sepolia presets ship without one
-basectl -c sepolia sync-status --cl-rpc https://your-rollup-node.example/
+# Sync status against a local Sepolia node
+basectl -c sepolia sync-status
 
 # Humanized JSON shows precomputed safe-head lag for downstream tooling
-basectl -c sepolia sync-status --cl-rpc https://your-rollup-node.example/ --json | jq '{safeLagSeconds, safeLagBlocks, elActivelySyncing}'
+basectl -c sepolia sync-status --json | jq '{safeLagSeconds, safeLagBlocks, elActivelySyncing}'
 ```
 
 ### `basectl p2p`
 
 ```sh
 # P2P endpoint summary for a node
-basectl -c sepolia p2p info --el-rpc https://your-el.example/ --cl-rpc https://your-cl.example/
+basectl -c sepolia p2p info
 
 # P2P peers as JSON
-basectl -c sepolia p2p peers --el-rpc https://your-el.example/ --cl-rpc https://your-cl.example/ --json | jq '{el: .el | length, cl: .cl | length}'
+basectl -c sepolia p2p peers --json | jq '{el: .el | length, cl: .cl | length}'
 
 # Probe an explicit EL enode from the telemetry service's network
 basectl -c sepolia p2p reachability enode://<node-id>@203.0.113.10:30303 --json

--- a/crates/infra/basectl/src/app/core.rs
+++ b/crates/infra/basectl/src/app/core.rs
@@ -52,6 +52,8 @@ pub struct App {
     /// Bootstrap conductor RPC URL from `--conductor-rpc`. Forwarded to background
     /// services on every network switch so discovery survives the rebuild.
     conductor_rpc: Option<Url>,
+    /// Whether the active EL endpoint is the configured public RPC.
+    using_public_rpc: bool,
 }
 
 impl fmt::Debug for App {
@@ -63,6 +65,7 @@ impl fmt::Debug for App {
             .field("view_cache", &format_args!("({} views)", self.view_cache.len()))
             .field("network_picker", &self.network_picker.as_ref().map(|_| ".."))
             .field("pending_network", &self.pending_network.is_some())
+            .field("using_public_rpc", &self.using_public_rpc)
             .finish()
     }
 }
@@ -78,6 +81,7 @@ impl App {
             network_picker: None,
             pending_network: None,
             conductor_rpc,
+            using_public_rpc: false,
         }
     }
 
@@ -131,19 +135,17 @@ impl App {
                 break;
             }
 
-            // Show `[…]` in the badge while a network switch is in progress.
-            // Use ASCII "..." so badge.len() == display width (avoids multi-byte
-            // width miscalculation from the 3-byte U+2026 HORIZONTAL ELLIPSIS).
-            let badge_name = if self.pending_network.is_some() {
-                "...".to_string()
-            } else {
-                self.resources.chain_name().to_string()
-            };
-
             terminal.draw(|frame| {
                 let layout = AppFrame::split_layout(frame.area(), self.show_help);
                 current_view.render(frame, layout.content, &self.resources);
-                AppFrame::render(frame, &layout, &badge_name, current_view.keybindings());
+                AppFrame::render(
+                    frame,
+                    &layout,
+                    &self.resources.config,
+                    self.using_public_rpc,
+                    self.pending_network.is_some(),
+                    current_view.keybindings(),
+                );
                 // Network picker overlays the entire frame, above the view.
                 if let Some(ref picker) = self.network_picker {
                     render_network_picker(frame, frame.area(), picker, self.resources.chain_name());
@@ -176,6 +178,13 @@ impl App {
                         {
                             self.show_help = false;
                             self.network_picker = Some(NetworkPicker::new());
+                            Action::None
+                        }
+                        KeyCode::Char('e')
+                            if self.pending_network.is_none()
+                                && !current_view.captures_char_input() =>
+                        {
+                            self.toggle_rpc(&mut current_view, view_factory);
                             Action::None
                         }
                         KeyCode::Char('q') => {
@@ -309,8 +318,8 @@ impl App {
         F: FnMut(ViewId) -> Box<dyn View>,
     {
         let name = new_config.name.clone();
-        // Replace resources entirely — dropping old receivers causes background
-        // tasks from the previous network to exit naturally on their next send.
+        self.using_public_rpc = false;
+        // Replacing resources aborts the previous network's background tasks.
         self.resources = Resources::new(new_config.clone());
         start_background_services(&new_config, &mut self.resources, self.conductor_rpc.clone());
         // Discard all cached view state so views re-initialise for the new network.
@@ -318,6 +327,35 @@ impl App {
         self.router = Router::new(ViewId::Home);
         *current_view = view_factory(ViewId::Home);
         self.resources.toasts.push(Toast::info(format!("Connected to {name}")));
+    }
+
+    fn toggle_rpc<F>(&mut self, current_view: &mut Box<dyn View>, view_factory: &mut F)
+    where
+        F: FnMut(ViewId) -> Box<dyn View>,
+    {
+        let (rpc, using_public_rpc, label) = if self.using_public_rpc {
+            (self.resources.configured_rpc.clone(), false, "configured")
+        } else {
+            let Some(rpc) = self.resources.config.public_rpc.clone() else {
+                self.resources
+                    .toasts
+                    .push(Toast::warning("No public EL RPC configured".to_string()));
+                return;
+            };
+            (rpc, true, "public")
+        };
+        let configured_rpc = self.resources.configured_rpc.clone();
+        let mut config = self.resources.config.clone();
+        config.rpc = rpc.clone();
+        self.resources = Resources::new(config.clone());
+        self.resources.configured_rpc = configured_rpc;
+        start_background_services(&config, &mut self.resources, self.conductor_rpc.clone());
+        self.view_cache.clear();
+        *current_view = view_factory(self.router.current());
+        self.using_public_rpc = using_public_rpc;
+        self.resources
+            .toasts
+            .push(Toast::info(format!("Using {label} EL RPC: {}", AppFrame::endpoint_label(&rpc))));
     }
 
     // -----------------------------------------------------------------------
@@ -416,4 +454,25 @@ fn render_network_picker(
     lines.push(Line::from(vec![Span::styled("  ↑/↓ move  Enter confirm  Esc cancel", hint_style)]));
 
     frame.render_widget(Paragraph::new(lines), inner);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::views::create_view;
+
+    #[tokio::test]
+    async fn rpc_toggle_switches_between_public_and_configured_endpoints() {
+        let resources = Resources::new(MonitoringConfig::mainnet());
+        let mut app = App::new(resources, ViewId::Home, None);
+        let mut current_view = create_view(ViewId::Home);
+        let mut view_factory = create_view;
+
+        app.toggle_rpc(&mut current_view, &mut view_factory);
+        assert_eq!(app.resources.config.rpc.as_str(), "https://mainnet.base.org/");
+        assert_eq!(app.resources.configured_rpc.as_str(), "http://127.0.0.1:8545/");
+
+        app.toggle_rpc(&mut current_view, &mut view_factory);
+        assert_eq!(app.resources.config.rpc.as_str(), "http://127.0.0.1:8545/");
+    }
 }

--- a/crates/infra/basectl/src/app/resources.rs
+++ b/crates/infra/basectl/src/app/resources.rs
@@ -7,7 +7,10 @@ use std::{
 use base_common_flashblocks::Flashblock;
 use base_common_genesis::{SystemConfig, UpgradeConfig};
 use base_consensus_rpc::ClusterMembership;
-use tokio::sync::{mpsc, watch};
+use tokio::{
+    sync::{mpsc, watch},
+    task::AbortHandle,
+};
 use url::Url;
 
 use crate::{
@@ -220,6 +223,9 @@ impl PodsState {
 pub struct Resources {
     /// Active chain configuration.
     pub config: MonitoringConfig,
+    /// Configured execution-layer RPC retained while the TUI uses the public RPC.
+    pub configured_rpc: Url,
+    background_tasks: Vec<AbortHandle>,
     /// Data availability monitoring state.
     pub da: DaState,
     /// Flashblock stream state.
@@ -287,8 +293,11 @@ pub struct FlashState {
 impl Resources {
     /// Creates new resources with the given chain configuration.
     pub fn new(config: MonitoringConfig) -> Self {
+        let configured_rpc = config.rpc.clone();
         Self {
             config,
+            configured_rpc,
+            background_tasks: Vec::new(),
             da: DaState::new(),
             flash: FlashState::new(),
             toasts: ToastState::new(),
@@ -305,6 +314,11 @@ impl Resources {
     /// Returns the configured chain name.
     pub fn chain_name(&self) -> &str {
         &self.config.name
+    }
+
+    /// Replaces the task set aborted when these resources are dropped.
+    pub fn set_background_tasks(&mut self, background_tasks: Vec<AbortHandle>) {
+        self.background_tasks = background_tasks;
     }
 
     /// Sets the channel for receiving L1 system config updates.
@@ -332,6 +346,14 @@ impl Resources {
             while let Ok(upgrades) = rx.try_recv() {
                 self.config.upgrades = Some(upgrades);
             }
+        }
+    }
+}
+
+impl Drop for Resources {
+    fn drop(&mut self) {
+        for task in &self.background_tasks {
+            task.abort();
         }
     }
 }
@@ -698,10 +720,26 @@ impl FlashState {
 
 #[cfg(test)]
 mod tests {
+    use std::future;
+
     use tokio::sync::mpsc;
 
-    use super::DaState;
-    use crate::rpc::{BacklogFetchResult, BlockDaInfo, L1BlockInfo};
+    use super::{DaState, Resources};
+    use crate::{
+        MonitoringConfig,
+        rpc::{BacklogFetchResult, BlockDaInfo, L1BlockInfo},
+    };
+
+    #[tokio::test]
+    async fn dropping_resources_aborts_background_tasks() {
+        let task = tokio::spawn(future::pending::<()>());
+        let mut resources = Resources::new(MonitoringConfig::mainnet());
+        resources.set_background_tasks(vec![task.abort_handle()]);
+
+        drop(resources);
+
+        assert!(task.await.unwrap_err().is_cancelled());
+    }
 
     #[test]
     fn records_l1_blocks_before_backlog_load_completes() {

--- a/crates/infra/basectl/src/app/runner.rs
+++ b/crates/infra/basectl/src/app/runner.rs
@@ -56,6 +56,7 @@ pub fn start_background_services(
     resources: &mut Resources,
     conductor_rpc: Option<Url>,
 ) {
+    let mut background_tasks = Vec::new();
     let (fb_tx, fb_rx) = mpsc::channel::<TimestampedFlashblock>(100);
     let (da_fb_tx, da_fb_rx) = mpsc::channel::<Flashblock>(100);
     let (sync_tx, sync_rx) = mpsc::channel::<u64>(10);
@@ -89,50 +90,73 @@ pub fn start_background_services(
     );
     resources.toasts.set_channel(toast_rx);
 
-    tokio::spawn(run_flashblock_ws_timestamped(fb_url_rx.clone(), fb_tx, toast_tx.clone()));
-    tokio::spawn(run_flashblock_ws(fb_url_rx, da_fb_tx, toast_tx.clone()));
+    background_tasks.push(
+        tokio::spawn(run_flashblock_ws_timestamped(fb_url_rx.clone(), fb_tx, toast_tx.clone()))
+            .abort_handle(),
+    );
+    background_tasks.push(
+        tokio::spawn(run_flashblock_ws(fb_url_rx, da_fb_tx, toast_tx.clone())).abort_handle(),
+    );
 
-    tokio::spawn(run_block_fetcher(
-        config.rpc.to_string(),
-        block_req_rx,
-        block_res_tx,
-        toast_tx.clone(),
-    ));
+    background_tasks.push(
+        tokio::spawn(run_block_fetcher(
+            config.rpc.to_string(),
+            block_req_rx,
+            block_res_tx,
+            toast_tx.clone(),
+        ))
+        .abort_handle(),
+    );
 
     if let Some(batcher_addr) = config.batcher_address {
         let (l1_mode_tx, l1_mode_rx) = mpsc::channel::<L1ConnectionMode>(1);
         resources.da.set_l1_mode_channel(l1_mode_rx);
-        tokio::spawn(run_l1_blob_watcher(
-            config.l1_rpc.to_string(),
-            batcher_addr,
-            l1_block_tx,
-            l1_mode_tx,
-            toast_tx.clone(),
-        ));
+        background_tasks.push(
+            tokio::spawn(run_l1_blob_watcher(
+                config.l1_rpc.to_string(),
+                batcher_addr,
+                l1_block_tx,
+                l1_mode_tx,
+                toast_tx.clone(),
+            ))
+            .abort_handle(),
+        );
     }
 
-    tokio::spawn(fetch_initial_backlog_with_progress(config.rpc.to_string(), backlog_tx));
+    background_tasks.push(
+        tokio::spawn(fetch_initial_backlog_with_progress(config.rpc.to_string(), backlog_tx))
+            .abort_handle(),
+    );
 
     let proofs_toast_tx = toast_tx.clone();
 
     if let Some(consensus_rpc) = config.consensus_node_rpc.clone() {
         let (upgrades_tx, upgrades_rx) = mpsc::channel(1);
         resources.set_upgrades_channel(upgrades_rx);
-        tokio::spawn(run_rollup_config_poller(consensus_rpc, upgrades_tx, toast_tx.clone()));
+        background_tasks.push(
+            tokio::spawn(run_rollup_config_poller(consensus_rpc, upgrades_tx, toast_tx.clone()))
+                .abort_handle(),
+        );
     }
 
-    tokio::spawn(run_safe_head_poller(config.rpc.to_string(), sync_tx, toast_tx));
+    background_tasks.push(
+        tokio::spawn(run_safe_head_poller(config.rpc.to_string(), sync_tx, toast_tx))
+            .abort_handle(),
+    );
 
     let (sys_config_tx, sys_config_rx) = mpsc::channel::<SystemConfig>(1);
     resources.set_sys_config_channel(sys_config_rx);
 
     let l1_rpc = config.l1_rpc.to_string();
     let system_config_addr = config.system_config;
-    tokio::spawn(async move {
-        if let Ok(cfg) = fetch_full_system_config(&l1_rpc, system_config_addr).await {
-            let _ = sys_config_tx.send(cfg).await;
-        }
-    });
+    background_tasks.push(
+        tokio::spawn(async move {
+            if let Ok(cfg) = fetch_full_system_config(&l1_rpc, system_config_addr).await {
+                let _ = sys_config_tx.send(cfg).await;
+            }
+        })
+        .abort_handle(),
+    );
 
     if let Some(source) = config.conductor_source(conductor_rpc) {
         let (conductor_tx, conductor_rx) = mpsc::channel::<ConductorPollUpdate>(8);
@@ -163,32 +187,39 @@ pub fn start_background_services(
                 }
             }
         }
-        tokio::spawn(run_conductor_poller(source, conductor_tx));
+        background_tasks
+            .push(tokio::spawn(run_conductor_poller(source, conductor_tx)).abort_handle());
     }
 
     if let Some(validator_nodes) = config.validators.clone() {
         let (validator_tx, validator_rx) = mpsc::channel::<Vec<ValidatorNodeStatus>>(4);
         resources.validators.set_channel(validator_rx);
-        tokio::spawn(run_validator_poller(validator_nodes, validator_tx));
+        background_tasks
+            .push(tokio::spawn(run_validator_poller(validator_nodes, validator_tx)).abort_handle());
     }
 
     if let Some(proofs_config) = config.proofs.clone() {
         let (proofs_tx, proofs_rx) = mpsc::channel::<ProofsSnapshot>(4);
         resources.proofs.set_channel(proofs_rx);
-        tokio::spawn(run_proofs_poller(
-            proofs_config,
-            config.l1_rpc.clone(),
-            config.rpc.clone(),
-            proofs_tx,
-            proofs_toast_tx,
-        ));
+        background_tasks.push(
+            tokio::spawn(run_proofs_poller(
+                proofs_config,
+                config.l1_rpc.clone(),
+                config.rpc.clone(),
+                proofs_tx,
+                proofs_toast_tx,
+            ))
+            .abort_handle(),
+        );
     }
 
     if let Some(pods_config) = config.pods.clone() {
         let (pods_tx, pods_rx) = mpsc::channel::<PodsSnapshot>(4);
         resources.pods.set_channel(pods_rx);
-        tokio::spawn(run_pods_poller(pods_config, pods_tx));
+        background_tasks.push(tokio::spawn(run_pods_poller(pods_config, pods_tx)).abort_handle());
     }
+
+    resources.set_background_tasks(background_tasks);
 }
 
 /// Streams flashblocks as JSON lines to stdout.

--- a/crates/infra/basectl/src/app/views/config.rs
+++ b/crates/infra/basectl/src/app/views/config.rs
@@ -84,6 +84,7 @@ fn render_chain_config(f: &mut Frame<'_>, area: Rect, resources: &Resources) {
 
     let fields: &[(&str, &str)] = &[
         ("RPC", config.rpc.as_str()),
+        ("Public RPC", config.public_rpc.as_ref().unwrap_or(&config.rpc).as_str()),
         ("Flashblocks WS", config.flashblocks_ws.as_str()),
         ("L1 RPC", config.l1_rpc.as_str()),
         (

--- a/crates/infra/basectl/src/app/views/config.rs
+++ b/crates/infra/basectl/src/app/views/config.rs
@@ -83,8 +83,9 @@ fn render_chain_config(f: &mut Frame<'_>, area: Rect, resources: &Resources) {
     ];
 
     let fields: &[(&str, &str)] = &[
-        ("RPC", config.rpc.as_str()),
-        ("Public RPC", config.public_rpc.as_ref().unwrap_or(&config.rpc).as_str()),
+        ("Active EL RPC", config.rpc.as_str()),
+        ("Configured EL RPC", resources.configured_rpc.as_str()),
+        ("Public EL RPC", config.public_rpc.as_ref().map_or("-", |url| url.as_str())),
         ("Flashblocks WS", config.flashblocks_ws.as_str()),
         ("L1 RPC", config.l1_rpc.as_str()),
         (

--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -792,7 +792,7 @@ impl UpgradesView {
     fn rpc_for_selected(&self, resources: &Resources) -> Option<String> {
         let chain = &self.chains[self.selected_chain];
         if chain_name_matches_loaded(chain.display_name, &resources.config.name) {
-            Some(resources.config.rpc.to_string())
+            Some(resources.config.public_rpc.as_ref().unwrap_or(&resources.config.rpc).to_string())
         } else {
             chain.rpc.clone()
         }
@@ -2843,6 +2843,19 @@ mod tests {
 
         view.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE), &mut resources);
         assert_eq!(view.selected_check_upgrade(100), Some("Beryl"));
+    }
+
+    #[test]
+    fn loaded_chain_upgrade_rpc_prefers_public_with_local_fallback() {
+        let mut view = UpgradesView::new();
+        view.selected_chain = 3; // Mainnet
+        let mut resources = Resources::new(MonitoringConfig::mainnet());
+
+        assert_eq!(view.rpc_for_selected(&resources).as_deref(), Some("https://mainnet.base.org/"));
+
+        resources.config.public_rpc = None;
+
+        assert_eq!(view.rpc_for_selected(&resources).as_deref(), Some("http://127.0.0.1:8545/"));
     }
 
     #[test]

--- a/crates/infra/basectl/src/commands/doctor.rs
+++ b/crates/infra/basectl/src/commands/doctor.rs
@@ -26,14 +26,13 @@ const ANSI_RESET: &str = "\x1b[0m";
 pub struct DoctorCommand {
     /// Override the execution-layer RPC URL.
     ///
-    /// Defaults to the chain config's `rpc` field. Pass this flag to diagnose
-    /// a specific node instead of a public preset RPC.
+    /// Defaults to the chain config's local `rpc` field.
     #[arg(long = "el-rpc", value_name = "URL")]
     pub el_rpc: Option<Url>,
     /// Override the consensus-node RPC URL.
     ///
-    /// If omitted and the selected config has no `consensus_node_rpc`, CL
-    /// checks are skipped with hints while EL/L1/config checks still run.
+    /// Defaults to the chain config's `consensus_node_rpc` field. If neither
+    /// is set, CL checks are skipped with hints while EL/L1/config checks run.
     #[arg(long = "cl-rpc", value_name = "URL")]
     pub cl_rpc: Option<Url>,
     /// Path to the local `reth.toml` file.

--- a/crates/infra/basectl/src/commands/p2p.rs
+++ b/crates/infra/basectl/src/commands/p2p.rs
@@ -56,16 +56,12 @@ pub enum P2pCommands {
 pub struct P2pArgs {
     /// Override the execution-layer RPC URL.
     ///
-    /// Defaults to the chain config's `rpc` field, which on the
-    /// `mainnet` and `sepolia` presets resolves to the public proxyd
-    /// fleet. Pass this flag to query a single node directly.
+    /// Defaults to the chain config's local `rpc` field.
     #[arg(long = "el-rpc", value_name = "URL")]
     pub el_rpc: Option<Url>,
     /// Override the consensus-node RPC URL.
     ///
-    /// The mainnet and sepolia presets ship `consensus_node_rpc` unset,
-    /// so non-devnet users must pass this flag (or set the field in
-    /// their YAML config).
+    /// Defaults to the chain config's `consensus_node_rpc` field.
     #[arg(long = "cl-rpc", value_name = "URL")]
     pub cl_rpc: Option<Url>,
     /// Emit JSON instead of the pretty table output.
@@ -84,16 +80,12 @@ pub struct DestructivePeerArgs {
     pub target: String,
     /// Override the execution-layer RPC URL.
     ///
-    /// Defaults to the chain config's `rpc` field, which on the
-    /// `mainnet` and `sepolia` presets resolves to the public proxyd
-    /// fleet. Pass this flag to query a single node directly.
+    /// Defaults to the chain config's local `rpc` field.
     #[arg(long = "el-rpc", value_name = "URL")]
     pub el_rpc: Option<Url>,
     /// Override the consensus-node RPC URL.
     ///
-    /// The mainnet and sepolia presets ship `consensus_node_rpc` unset,
-    /// so non-devnet users must pass this flag (or set the field in
-    /// their YAML config).
+    /// Defaults to the chain config's `consensus_node_rpc` field.
     #[arg(long = "cl-rpc", value_name = "URL")]
     pub cl_rpc: Option<Url>,
     /// Skip the interactive confirmation prompt.
@@ -109,9 +101,7 @@ pub struct DestructivePeerArgs {
 pub struct DestructiveClBulkArgs {
     /// Override the consensus-node RPC URL.
     ///
-    /// The mainnet and sepolia presets ship `consensus_node_rpc` unset,
-    /// so non-devnet users must pass this flag (or set the field in
-    /// their YAML config).
+    /// Defaults to the chain config's `consensus_node_rpc` field.
     #[arg(long = "cl-rpc", value_name = "URL")]
     pub cl_rpc: Option<Url>,
     /// Skip the interactive confirmation prompt.
@@ -862,6 +852,7 @@ mod tests {
         MonitoringConfig {
             name: "devnet".to_string(),
             rpc: Url::parse("http://127.0.0.1:8545").unwrap(),
+            public_rpc: None,
             flashblocks_ws: Url::parse("ws://127.0.0.1:7111").unwrap(),
             l1_rpc: Url::parse("http://127.0.0.1:9545").unwrap(),
             consensus_node_rpc,

--- a/crates/infra/basectl/src/commands/sync_status.rs
+++ b/crates/infra/basectl/src/commands/sync_status.rs
@@ -21,18 +21,12 @@ use crate::{
 pub struct SyncStatusCommand {
     /// Override the execution-layer RPC URL.
     ///
-    /// Defaults to the chain config's `rpc` field, which on the
-    /// `mainnet` and `sepolia` presets resolves to the public proxyd
-    /// fleet — `eth_syncing` against that always reports "not syncing"
-    /// because proxyd routes only-healthy backends. Pass this flag to
-    /// point at a single node.
+    /// Defaults to the chain config's local `rpc` field.
     #[arg(long = "el-rpc", value_name = "URL")]
     pub el_rpc: Option<Url>,
     /// Override the consensus-node RPC URL.
     ///
-    /// The mainnet and sepolia presets ship `consensus_node_rpc` unset, so
-    /// non-devnet users must pass this flag (or set the field in their YAML
-    /// config).
+    /// Defaults to the chain config's `consensus_node_rpc` field.
     #[arg(long = "cl-rpc", value_name = "URL")]
     pub cl_rpc: Option<Url>,
     /// Block tolerance for the tip-reference `caught_up` classification.
@@ -59,16 +53,17 @@ impl SyncStatusCommand {
     pub async fn run(self, config: MonitoringConfig) -> Result<()> {
         let el_rpc = self.el_rpc.unwrap_or_else(|| config.rpc.clone());
         let cl_rpc = config.resolve_cl_rpc(self.cl_rpc.as_ref(), "sync-status")?;
+        let public_rpc = config.public_rpc.as_ref().unwrap_or(&config.rpc);
         // Public tip reference is best-effort — failure marks the row unavailable
         // rather than failing the whole command. Run in parallel with the local
         // sync fetch.
         let (sync_result, tip_result) = tokio::join!(
             fetch_sync_status(&el_rpc, &cl_rpc),
-            fetch_block(&config.rpc, BlockId::Number(BlockNumberOrTag::Latest)),
+            fetch_block(public_rpc, BlockId::Number(BlockNumberOrTag::Latest)),
         );
         let report = sync_result?;
         let public_tip_block = tip_result.ok().map(|b| b.header.number);
-        let tip_url = config.rpc.as_str();
+        let tip_url = public_rpc.as_str();
 
         match (self.json, self.raw) {
             (true, true) => JsonOutput::print(&report.cl)?,
@@ -308,14 +303,14 @@ pub struct ElSyncInfoJson {
     pub remaining_blocks: u64,
 }
 
-/// Comparison of the local node's unsafe L2 head against a public-RPC
-/// reference (`config.rpc` for the active preset). Best-effort — when the
-/// public fetch fails, `block_number` and `delta_blocks` are `None` and
-/// `status` is `unavailable`.
+/// Comparison of the local node's unsafe L2 head against the configured public
+/// RPC, falling back to `config.rpc` when `config.public_rpc` is unset.
+/// Best-effort — when the fetch fails, `block_number` and `delta_blocks` are
+/// `None` and `status` is `unavailable`.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TipReferenceJson {
-    /// The public-RPC URL queried (the preset's `config.rpc`).
+    /// The effective public-reference RPC URL queried.
     pub url: String,
     /// Latest block number reported by the public RPC. `None` if the call failed.
     pub block_number: Option<u64>,

--- a/crates/infra/basectl/src/commands/sync_status.rs
+++ b/crates/infra/basectl/src/commands/sync_status.rs
@@ -53,17 +53,19 @@ impl SyncStatusCommand {
     pub async fn run(self, config: MonitoringConfig) -> Result<()> {
         let el_rpc = self.el_rpc.unwrap_or_else(|| config.rpc.clone());
         let cl_rpc = config.resolve_cl_rpc(self.cl_rpc.as_ref(), "sync-status")?;
-        let public_rpc = config.public_rpc.as_ref().unwrap_or(&config.rpc);
+        let public_rpc = config.public_rpc.as_ref().filter(|url| *url != &el_rpc);
+        let tip_url = public_rpc.map_or(el_rpc.as_str(), Url::as_str);
         // Public tip reference is best-effort — failure marks the row unavailable
         // rather than failing the whole command. Run in parallel with the local
         // sync fetch.
-        let (sync_result, tip_result) = tokio::join!(
-            fetch_sync_status(&el_rpc, &cl_rpc),
-            fetch_block(public_rpc, BlockId::Number(BlockNumberOrTag::Latest)),
-        );
+        let (sync_result, tip_result) = tokio::join!(fetch_sync_status(&el_rpc, &cl_rpc), async {
+            match public_rpc {
+                Some(url) => fetch_block(url, BlockId::Number(BlockNumberOrTag::Latest)).await.ok(),
+                None => None,
+            }
+        },);
         let report = sync_result?;
-        let public_tip_block = tip_result.ok().map(|b| b.header.number);
-        let tip_url = public_rpc.as_str();
+        let public_tip_block = tip_result.map(|block| block.header.number);
 
         match (self.json, self.raw) {
             (true, true) => JsonOutput::print(&report.cl)?,
@@ -78,7 +80,14 @@ impl SyncStatusCommand {
                 JsonOutput::print(&summary)?;
             }
             (false, _) => {
-                print_pretty(&config.name, &report, tip_url, public_tip_block, self.tip_tolerance)?;
+                print_pretty(
+                    &config.name,
+                    &report,
+                    tip_url,
+                    public_rpc.is_some(),
+                    public_tip_block,
+                    self.tip_tolerance,
+                )?;
             }
         }
         Ok(())
@@ -90,6 +99,7 @@ fn print_pretty(
     network: &str,
     report: &SyncStatusReport,
     tip_url: &str,
+    has_tip_reference: bool,
     public_tip_block: Option<u64>,
     tip_tolerance: u64,
 ) -> Result<()> {
@@ -143,6 +153,7 @@ fn print_pretty(
         "tip_reference",
         format_tip_reference(
             tip_url,
+            has_tip_reference,
             cl.unsafe_l2.block_info.number,
             public_tip_block,
             tip_tolerance,
@@ -154,7 +165,16 @@ fn print_pretty(
 }
 
 /// Formats the public-tip comparison row.
-fn format_tip_reference(url: &str, local: u64, public: Option<u64>, tolerance: u64) -> String {
+fn format_tip_reference(
+    url: &str,
+    has_reference: bool,
+    local: u64,
+    public: Option<u64>,
+    tolerance: u64,
+) -> String {
+    if !has_reference {
+        return "unavailable (no independent public RPC configured)".to_string();
+    }
     let tip = TipReferenceJson::from_local_and_public(url, local, public, tolerance);
     match (tip.block_number, tip.delta_blocks) {
         (Some(block), Some(delta)) => {
@@ -303,8 +323,8 @@ pub struct ElSyncInfoJson {
     pub remaining_blocks: u64,
 }
 
-/// Comparison of the local node's unsafe L2 head against the configured public
-/// RPC, falling back to `config.rpc` when `config.public_rpc` is unset.
+/// Comparison of the local node's unsafe L2 head against an independent public
+/// RPC reference.
 /// Best-effort — when the fetch fails, `block_number` and `delta_blocks` are
 /// `None` and `status` is `unavailable`.
 #[derive(Debug, Clone, Serialize)]
@@ -390,7 +410,7 @@ mod tests {
     use alloy_primitives::{B256, U256};
     use base_protocol::{BlockInfo, L2BlockInfo, SyncStatus};
 
-    use super::SyncStatusJson;
+    use super::{SyncStatusJson, format_tip_reference};
     use crate::SyncStatusReport;
 
     fn sample_l2(block: u64, ts: u64) -> L2BlockInfo {
@@ -515,6 +535,14 @@ mod tests {
         assert!(value["tipReference"]["deltaBlocks"].is_null());
         assert_eq!(value["tipReference"]["status"], "unavailable");
         assert_eq!(value["tipReference"]["url"], "https://mainnet.base.org/");
+    }
+
+    #[test]
+    fn tip_reference_is_unavailable_without_independent_public_rpc() {
+        assert_eq!(
+            format_tip_reference("http://127.0.0.1:8545/", false, 100, Some(100), 5),
+            "unavailable (no independent public RPC configured)"
+        );
     }
 
     #[test]

--- a/crates/infra/basectl/src/config.rs
+++ b/crates/infra/basectl/src/config.rs
@@ -346,8 +346,11 @@ fn peer_url(bootstrap: &Url, host: &str, port: u16) -> Url {
 pub struct MonitoringConfig {
     /// Human-readable chain name (e.g. "mainnet", "sepolia").
     pub name: String,
-    /// L2 JSON-RPC endpoint URL.
+    /// Local L2 execution-layer JSON-RPC endpoint URL.
     pub rpc: Url,
+    /// Optional public L2 JSON-RPC endpoint used for network-reference reads.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public_rpc: Option<Url>,
     /// Flashblocks WebSocket endpoint URL.
     pub flashblocks_ws: Url,
     /// L1 Ethereum JSON-RPC endpoint URL.
@@ -516,6 +519,7 @@ const fn default_blob_target() -> u64 {
 struct MonitoringConfigOverride {
     name: Option<String>,
     rpc: Option<Url>,
+    public_rpc: Option<Url>,
     flashblocks_ws: Option<Url>,
     l1_rpc: Option<Url>,
     consensus_node_rpc: Option<Url>,
@@ -565,10 +569,11 @@ impl MonitoringConfig {
         let rollup = rollup_config!(ChainConfig::MAINNET);
         Self {
             name: "mainnet".to_string(),
-            rpc: Url::parse("https://mainnet.base.org").unwrap(),
+            rpc: Url::parse("http://127.0.0.1:8545").unwrap(),
+            public_rpc: Some(Url::parse("https://mainnet.base.org").unwrap()),
             flashblocks_ws: Url::parse("wss://mainnet.flashblocks.base.org/ws").unwrap(),
             l1_rpc: Url::parse("https://ethereum-rpc.publicnode.com").unwrap(),
-            consensus_node_rpc: None,
+            consensus_node_rpc: Some(Url::parse("http://127.0.0.1:9545").unwrap()),
             chain_id: Some(8453),
             prover_rpc: None,
             upgrades: Some(rollup.upgrades),
@@ -591,10 +596,11 @@ impl MonitoringConfig {
         let rollup = rollup_config!(ChainConfig::SEPOLIA);
         Self {
             name: "sepolia".to_string(),
-            rpc: Url::parse("https://sepolia.base.org").unwrap(),
+            rpc: Url::parse("http://127.0.0.1:8545").unwrap(),
+            public_rpc: Some(Url::parse("https://sepolia.base.org").unwrap()),
             flashblocks_ws: Url::parse("wss://sepolia.flashblocks.base.org/ws").unwrap(),
             l1_rpc: Url::parse("https://ethereum-sepolia-rpc.publicnode.com").unwrap(),
-            consensus_node_rpc: None,
+            consensus_node_rpc: Some(Url::parse("http://127.0.0.1:9545").unwrap()),
             chain_id: Some(84532),
             prover_rpc: None,
             upgrades: Some(rollup.upgrades),
@@ -624,6 +630,7 @@ impl MonitoringConfig {
         Self {
             name: "devnet".to_string(),
             rpc: Url::parse("http://localhost:7545").unwrap(),
+            public_rpc: None,
             flashblocks_ws: Url::parse("ws://localhost:7111").unwrap(),
             l1_rpc: Url::parse("http://localhost:4545").unwrap(),
             consensus_node_rpc: Some(Url::parse("http://localhost:7549").unwrap()),
@@ -802,6 +809,7 @@ impl MonitoringConfig {
         Ok(Self {
             name: overrides.name.unwrap_or(base.name),
             rpc: overrides.rpc.unwrap_or(base.rpc),
+            public_rpc: overrides.public_rpc.or(base.public_rpc),
             flashblocks_ws: overrides.flashblocks_ws.unwrap_or(base.flashblocks_ws),
             l1_rpc: overrides.l1_rpc.unwrap_or(base.l1_rpc),
             consensus_node_rpc: overrides.consensus_node_rpc.or(base.consensus_node_rpc),
@@ -854,15 +862,16 @@ mod tests {
 
     #[test]
     fn resolve_cl_rpc_falls_back_to_config() {
-        let config = MonitoringConfig::devnet_base();
-        let expected = config.consensus_node_rpc.clone().expect("devnet sets consensus_node_rpc");
+        let config = MonitoringConfig::mainnet();
+        let expected = config.consensus_node_rpc.clone().expect("mainnet sets consensus_node_rpc");
 
         assert_eq!(config.resolve_cl_rpc(None, "p2p info").unwrap(), expected);
     }
 
     #[test]
     fn resolve_cl_rpc_errors_without_config() {
-        let config = MonitoringConfig::mainnet();
+        let mut config = MonitoringConfig::mainnet();
+        config.consensus_node_rpc = None;
 
         let error = config.resolve_cl_rpc(None, "sync-status").unwrap_err();
 
@@ -870,15 +879,19 @@ mod tests {
         assert_eq!(error.config_name, "mainnet");
     }
 
-    #[tokio::test]
-    async fn test_builtin_configs() {
-        let mainnet = MonitoringConfig::load("mainnet").await.unwrap();
+    #[test]
+    fn test_builtin_configs() {
+        let mainnet = MonitoringConfig::mainnet();
         assert_eq!(mainnet.name, "mainnet");
-        assert!(mainnet.rpc.as_str().contains("mainnet"));
+        assert_eq!(mainnet.rpc.as_str(), "http://127.0.0.1:8545/");
+        assert_eq!(mainnet.public_rpc.as_ref().unwrap().as_str(), "https://mainnet.base.org/");
+        assert_eq!(mainnet.consensus_node_rpc.as_ref().unwrap().as_str(), "http://127.0.0.1:9545/");
 
-        let sepolia = MonitoringConfig::load("sepolia").await.unwrap();
+        let sepolia = MonitoringConfig::sepolia();
         assert_eq!(sepolia.name, "sepolia");
-        assert!(sepolia.rpc.as_str().contains("sepolia"));
+        assert_eq!(sepolia.rpc.as_str(), "http://127.0.0.1:8545/");
+        assert_eq!(sepolia.public_rpc.as_ref().unwrap().as_str(), "https://sepolia.base.org/");
+        assert_eq!(sepolia.consensus_node_rpc.as_ref().unwrap().as_str(), "http://127.0.0.1:9545/");
     }
 
     #[test]
@@ -886,11 +899,10 @@ mod tests {
         // Test the base devnet config structure (without RPC call)
         let devnet = MonitoringConfig::devnet_base();
         assert_eq!(devnet.name, "devnet");
-        assert!(devnet.rpc.as_str().contains("localhost"));
         assert_eq!(devnet.rpc.as_str(), "http://localhost:7545/");
+        assert!(devnet.public_rpc.is_none());
         assert_eq!(devnet.flashblocks_ws.as_str(), "ws://localhost:7111/");
         assert_eq!(devnet.l1_rpc.as_str(), "http://localhost:4545/");
-        assert!(devnet.consensus_node_rpc.is_some());
         assert_eq!(devnet.consensus_node_rpc.unwrap().as_str(), "http://localhost:7549/");
         assert_eq!(devnet.chain_id, None);
         let validators = devnet.validators.expect("devnet should include validator/RPC node");

--- a/crates/infra/basectl/src/doctor.rs
+++ b/crates/infra/basectl/src/doctor.rs
@@ -214,6 +214,7 @@ impl Doctor {
     /// Runs doctor checks and returns a complete report.
     pub async fn run(config: MonitoringConfig, options: DoctorOptions) -> DoctorReport {
         let el_rpc = options.el_rpc.clone();
+        let public_tip_rpc = config.public_rpc.as_ref().unwrap_or(&config.rpc);
         let (
             (el_info, chain_id, telemetry_url, el_reachability),
             cl_info,
@@ -246,7 +247,7 @@ impl Doctor {
                 }
             },
             fetch_l2_block_number(&options.el_rpc),
-            fetch_l2_block_number(&config.rpc),
+            fetch_l2_block_number(public_tip_rpc),
             async {
                 match &options.cl_rpc {
                     Some(cl_rpc) => Some(fetch_sync_status(&options.el_rpc, cl_rpc).await),
@@ -260,7 +261,7 @@ impl Doctor {
             el_rpc: options.el_rpc.clone(),
             cl_rpc: options.cl_rpc.clone(),
             l1_rpc: config.l1_rpc.clone(),
-            public_tip_rpc: config.rpc.clone(),
+            public_tip_rpc: public_tip_rpc.clone(),
             reth_config: options.reth_config.clone(),
             telemetry_url: telemetry_url.clone(),
         };
@@ -328,7 +329,7 @@ impl Doctor {
                 &public_head,
                 &options.thresholds,
                 &options.el_rpc,
-                &config.rpc,
+                public_tip_rpc,
             ),
             Self::safe_head_recency_check(sync_status.as_ref(), &options.thresholds),
             Self::l1_reachability_check(&l1_head, &config.l1_rpc),
@@ -1327,6 +1328,7 @@ mod tests {
         MonitoringConfig {
             name: name.to_string(),
             rpc: Url::parse("http://127.0.0.1:8545").unwrap(),
+            public_rpc: None,
             flashblocks_ws: Url::parse("ws://127.0.0.1:7111").unwrap(),
             l1_rpc: Url::parse("http://127.0.0.1:9545").unwrap(),
             consensus_node_rpc: None,

--- a/crates/infra/basectl/src/tui/app_frame.rs
+++ b/crates/infra/basectl/src/tui/app_frame.rs
@@ -3,9 +3,10 @@ use ratatui::{
     prelude::*,
     widgets::{Block, Borders, Paragraph},
 };
+use url::Url;
 
 use super::Keybinding;
-use crate::output::COLOR_BASE_BLUE;
+use crate::{config::MonitoringConfig, output::COLOR_BASE_BLUE};
 
 const HELP_SIDEBAR_WIDTH: u16 = 30;
 
@@ -41,22 +42,65 @@ impl AppFrame {
     pub fn render(
         f: &mut Frame<'_>,
         layout: &AppLayout,
-        config_name: &str,
+        config: &MonitoringConfig,
+        using_public_rpc: bool,
+        pending_network: bool,
         keybindings: &[Keybinding],
     ) {
-        render_network_badge(f, config_name);
+        render_network_badge(f, layout.content, config, using_public_rpc, pending_network);
         if let Some(sidebar) = layout.sidebar {
-            render_help_sidebar(f, sidebar, config_name, keybindings);
+            render_help_sidebar(f, sidebar, &config.name, keybindings);
         }
+    }
+
+    /// Returns a compact host-and-port label for an RPC URL.
+    pub fn endpoint_label(url: &Url) -> String {
+        let origin = url.origin().ascii_serialization();
+        origin
+            .strip_prefix("http://")
+            .or_else(|| origin.strip_prefix("https://"))
+            .unwrap_or(&origin)
+            .to_string()
     }
 }
 
-/// Renders a `[network]` badge pinned to the top-right corner of the full frame.
-fn render_network_badge(f: &mut Frame<'_>, config_name: &str) {
-    let badge = format!(" [{config_name}] ");
-    let badge_width = badge.len() as u16;
-    let area = f.area();
-    if area.width < badge_width || area.height == 0 {
+/// Renders active RPC endpoints in a badge pinned to the top-right corner.
+fn render_network_badge(
+    f: &mut Frame<'_>,
+    area: Rect,
+    config: &MonitoringConfig,
+    using_public_rpc: bool,
+    pending_network: bool,
+) {
+    let mode = if using_public_rpc { "pub" } else { "cfg" };
+    let toggle = if config.public_rpc.is_some() {
+        if using_public_rpc { " | e:cfg" } else { " | e:pub" }
+    } else {
+        ""
+    };
+    let short_badge = format!(" [{} | EL {mode}{toggle}] ", config.name);
+    let badge = if pending_network {
+        " [...] ".to_string()
+    } else {
+        let el = AppFrame::endpoint_label(&config.rpc);
+        let cl = config
+            .consensus_node_rpc
+            .as_ref()
+            .map(AppFrame::endpoint_label)
+            .unwrap_or_else(|| "-".to_string());
+        format!(" [{} | EL {mode} {el} | CL {cl}{toggle}] ", config.name)
+    };
+    let badge_width = Line::from(badge.as_str()).width() as u16;
+    if area.height == 0 {
+        return;
+    }
+    let badge = if !pending_network && area.width < badge_width.saturating_add(20) {
+        short_badge
+    } else {
+        badge
+    };
+    let badge_width = Line::from(badge.as_str()).width() as u16;
+    if area.width < badge_width {
         return;
     }
     let badge_area =
@@ -100,6 +144,11 @@ fn render_help_sidebar(
         Span::styled("Switch network", Style::default().fg(Color::White)),
     ]));
     lines.push(Line::from(vec![
+        Span::styled("           e", Style::default().fg(Color::Yellow)),
+        Span::raw("  "),
+        Span::styled("Toggle configured/public EL", Style::default().fg(Color::White)),
+    ]));
+    lines.push(Line::from(vec![
         Span::styled("           ?", Style::default().fg(Color::Yellow)),
         Span::raw("  "),
         Span::styled("Close help", Style::default().fg(Color::White)),
@@ -107,4 +156,17 @@ fn render_help_sidebar(
 
     let para = Paragraph::new(lines);
     f.render_widget(para, inner);
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::text::Line;
+
+    #[test]
+    fn unicode_badge_width_uses_display_columns() {
+        let badge = " [网络 | EL cfg] ";
+
+        assert_eq!(Line::from(badge).width(), 17);
+        assert_ne!(Line::from(badge).width(), badge.len());
+    }
 }


### PR DESCRIPTION
## Summary
  - Default mainnet and Sepolia EL/CL endpoints to local node ports
  - Preserve hosted RPCs for tip comparisons and upgrade monitoring
  - Update configuration docs, CLI guidance, and tests
  - Add a global TUI `e` hotkey to switch EL monitoring between configured and public RPCs, with active EL/CL endpoints shown in the badge.

  ## Test Plan
  - [x] `cargo test -p basectl-cli --lib` — 208 passed
  - [x] `cargo clippy -p basectl-cli --all-targets`
  - [x] `git diff --check`