### PR TITLE
fix(batcher): Recover From Safe Head Regression

### DIFF
--- a/actions/harness/tests/batcher/gap_filling.rs
+++ b/actions/harness/tests/batcher/gap_filling.rs
@@ -235,6 +235,141 @@ async fn batcher_gap_fill_with_safe_head_tracking() {
 }
 
 // ---------------------------------------------------------------------------
+// B2. Gap-filling triggered purely by a safe-head regression (L1 reorg model)
+// ---------------------------------------------------------------------------
+
+/// End-to-end coverage of the safe-head regression recovery path. A regression
+/// on the watch channel, and nothing else, must let the batcher fill a gap and
+/// let the verifier derive through it. There is no [`signal_reorg`] in the
+/// recovery phase, unlike [`batcher_gap_fill_with_safe_head_tracking`].
+///
+/// This exercises the production wiring for the permanent-gap fix. After an L1
+/// reorg drops batches that had advanced the safe head, the rollup node
+/// re-derives a lower safe head, which arrives here as a watch-channel
+/// regression. The driver must react to that regression alone by resetting the
+/// encoder and restarting catchup from `safe_head + 1`, so the re-posted blocks
+/// fill the gap.
+///
+/// Note on discrimination. This test drives the full wired path but is not by
+/// itself a fail-without-fix guarantee, because the action harness prunes
+/// fully-confirmed blocks from the encoder buffer (see
+/// `BatchEncoder::confirm`), which empties it and sidesteps the parent-hash
+/// guard on re-post. The exact regression behavior — reset plus
+/// `reset_catchup(safe_head + 1)`, and never pruning on a regression — is pinned
+/// by the discriminating unit tests `safe_head_regression_resets_and_catches_up`
+/// and `safe_head_advance_prunes_without_reset` in `base-batcher-core`, and by
+/// `poll_propagates_regression` in `base-batcher-service`.
+///
+/// Scenario:
+///
+/// 1. **Phase 1** — Batcher follows a divergent node (safe head 7 via
+///    [`signal_reorg`]) and posts blocks 8-10. They land on L1 but are not
+///    derivable because blocks 6-7 are missing, so the verifier stays at safe
+///    head 5.
+///
+/// 2. **Phase 2** — The batcher's safe head latches at 7, the divergent node's
+///    head. This is the bug precondition: a stale safe head sitting above the
+///    true one.
+///
+/// 3. **Phase 3** — The L1 reorg drops those batches and the rollup node
+///    re-derives the true safe head of 5. It arrives as a watch-channel
+///    **regression** from 7 down to 5, with no [`signal_reorg`]. The driver must
+///    reset the encoder and set `catchup_from = 6` on its own, so the re-posted
+///    blocks 6-10 fill the gap and the verifier derives through to 10.
+///
+/// [`signal_reorg`]: Batcher::signal_reorg
+/// [`batcher_gap_fill_with_safe_head_tracking`]: super::batcher_gap_fill_with_safe_head_tracking
+#[tokio::test]
+async fn batcher_gap_fill_on_safe_head_regression() {
+    let batcher_cfg = BatcherConfig {
+        encoder: EncoderConfig { da_type: DaType::Calldata, ..EncoderConfig::default() },
+        ..BatcherConfig::default()
+    };
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+
+    let mut blocks = Vec::with_capacity(10);
+    for _ in 0..10 {
+        blocks.push(sequencer.build_next_block_with_single_transaction().await);
+    }
+
+    let (mut node, chain) = h.create_test_rollup_node_from_sequencer(
+        &mut sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
+
+    // Wire a safe-head watch channel into the batcher, seeded at 0.
+    let (safe_head_tx, safe_head_rx) = tokio::sync::watch::channel(0u64);
+    let mut batcher = Batcher::with_safe_head_rx(
+        ActionL2Source::new(),
+        &h.rollup_config,
+        batcher_cfg.clone(),
+        safe_head_rx,
+    );
+
+    // Establish the initial safe head at 5 by posting blocks 1-5.
+    for block in &blocks[..5] {
+        batcher.push_block(block.clone());
+    }
+    batcher.advance(&mut h.l1).await;
+    chain.push(h.l1.tip().clone());
+
+    node.initialize().await;
+    let derived = node.run_until_idle().await;
+    assert_eq!(derived, 5, "setup: expected 5 L2 blocks derived");
+    assert_eq!(node.l2_safe_number(), 5, "setup: safe head must be 5");
+    safe_head_tx.send(5).expect("watch channel open");
+    tokio::task::yield_now().await;
+
+    // ----- Phase 1: follow a divergent node, post gap blocks 8-10 -----
+    // signal_reorg models the batcher briefly following a divergent chain
+    // (node B, safe head 7). Blocks 8-10 land on L1 but are not derivable, and
+    // remain buffered in the encoder with the tip at block 10.
+    batcher.signal_reorg(DummyL2Info::at_number(7)).await;
+    for block in &blocks[7..10] {
+        batcher.push_block(block.clone());
+    }
+    batcher.advance(&mut h.l1).await;
+    chain.push(h.l1.tip().clone());
+
+    let derived = node.run_until_idle().await;
+    assert_eq!(node.l2_safe_number(), 5, "Phase 1: safe head must stay at 5 (gap 6-7 missing)");
+    assert_eq!(derived, 0, "Phase 1: no blocks derived");
+
+    // ----- Phase 2: latch the batcher safe head at the divergent head 7 -----
+    // 7 is above blocks 8-10, so this does NOT prune them from the encoder.
+    // They stay buffered with the tip at 10, the stale-forward precondition.
+    safe_head_tx.send(7).expect("watch channel open");
+    tokio::task::yield_now().await;
+
+    // ----- Phase 3: the L1 reorg drops the batches; safe head regresses to 5 -----
+    // No signal_reorg. The regression alone must reset the encoder and set
+    // catchup_from = 6. Yield enough for the driver to process the reset.
+    safe_head_tx.send(5).expect("watch channel open");
+    for _ in 0..4 {
+        tokio::task::yield_now().await;
+    }
+
+    // Post blocks 6-10 from the true safe head to fill the gap.
+    for block in &blocks[5..10] {
+        batcher.push_block(block.clone());
+    }
+    batcher.advance(&mut h.l1).await;
+    chain.push(h.l1.tip().clone());
+
+    let derived = node.run_until_idle().await;
+    assert_eq!(derived, 5, "Phase 3: expected 5 L2 blocks derived (6-10)");
+    assert_eq!(
+        node.l2_safe_number(),
+        10,
+        "Phase 3: safe head must reach 10 after the regression-triggered gap fill"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // C. Gap-filling with separate batcher instances (restart model)
 // ---------------------------------------------------------------------------
 

--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -52,6 +52,14 @@ where
     l1_head_source: Option<L>,
     /// Optional external L2 safe head feed for pruning confirmed blocks.
     safe_head_rx: Option<tokio::sync::watch::Receiver<u64>>,
+    /// Highest safe L2 head observed from [`Self::safe_head_rx`].
+    ///
+    /// Used to detect a safe-head *regression*, which happens when an L1 reorg
+    /// drops already-submitted batches and the rollup node re-derives a lower
+    /// safe head. On regression the driver resets the pipeline and re-fetches
+    /// from the new (lower) safe head so the orphaned block range is re-batched
+    /// instead of skipped forever.
+    last_safe_head: u64,
     /// Maximum wall-clock time to wait for in-flight submissions to settle
     /// when draining on cancellation or source exhaustion.
     drain_timeout: Duration,
@@ -101,6 +109,7 @@ where
             throttle,
             l1_head_source: Some(l1_head_source),
             safe_head_rx: None,
+            last_safe_head: 0,
             drain_timeout: config.drain_timeout,
             stopped: false,
             admin_rx: None,
@@ -110,10 +119,18 @@ where
 
     /// Attach an external L2 safe head watch channel.
     ///
-    /// When the receiver fires, the pipeline's [`prune_safe`](BatchPipeline::prune_safe)
-    /// is called with the new safe L2 block number, allowing the encoder to
-    /// free blocks that are confirmed safe on L2.
+    /// When the receiver fires with a higher value, the pipeline's
+    /// [`prune_safe`](BatchPipeline::prune_safe) is called with the new safe L2
+    /// block number, allowing the encoder to free blocks that are confirmed safe
+    /// on L2. When it fires with a *lower* value (a regression caused by an L1
+    /// reorg dropping already-submitted batches), the driver resets the pipeline
+    /// and restarts catchup from the new safe head so the orphaned range is
+    /// re-batched. See [`Self::last_safe_head`].
+    ///
+    /// The current watch value seeds [`Self::last_safe_head`] so a regression
+    /// relative to the startup safe head is detected on the first update.
     pub fn with_safe_head_rx(mut self, rx: tokio::sync::watch::Receiver<u64>) -> Self {
+        self.last_safe_head = *rx.borrow();
         self.safe_head_rx = Some(rx);
         self
     }
@@ -208,8 +225,28 @@ where
                     debug!(l1_head = %n, "L1 head advanced via source");
                 }
                 DriverEvent::SafeHead(n) => {
-                    self.pipeline.prune_safe(n);
-                    debug!(safe_l2_number = %n, "pruned safe blocks via watch");
+                    if n < self.last_safe_head {
+                        // The safe head moved backward, which means an L1 reorg
+                        // dropped batches that had already advanced it. Recover
+                        // exactly like an L2 reorg: discard in-flight submissions,
+                        // reset the encoder, and restart sequential catchup from
+                        // the new (lower) safe head so the orphaned blocks are
+                        // re-batched instead of skipped forever.
+                        let catchup_from = n + 1;
+                        warn!(
+                            old_safe_head = %self.last_safe_head,
+                            new_safe_head = %n,
+                            catchup_from = %catchup_from,
+                            "safe head regressed after L1 reorg, resetting pipeline and catching up from safe head"
+                        );
+                        self.submissions.discard();
+                        self.pipeline.reset();
+                        self.source.reset_catchup(catchup_from);
+                    } else {
+                        self.pipeline.prune_safe(n);
+                        debug!(safe_l2_number = %n, "pruned safe blocks via watch");
+                    }
+                    self.last_safe_head = n;
                 }
                 DriverEvent::L1SourceClosed => {
                     debug!("L1 head source closed, disabling arm");
@@ -456,7 +493,8 @@ mod tests {
         event::DriverEvent,
         test_utils::{
             DriverFixture, ImmediateConfirmTxManager, ImmediateFailTxManager,
-            NeverConfirmTxManager, Recorded, SubmissionStub, TrackingPipeline,
+            NeverConfirmTxManager, PendingL1HeadSource, Recorded, RecordingSource, SubmissionStub,
+            TrackingPipeline,
         },
     };
 
@@ -778,6 +816,106 @@ mod tests {
 
             let event = driver.next_event().await.expect("next_event should succeed");
             assert!(matches!(event, DriverEvent::SafeHead(7)));
+        });
+    }
+
+    /// A forward safe-head update prunes confirmed blocks and must NOT reset the
+    /// pipeline or restart catchup.
+    #[test]
+    fn safe_head_advance_prunes_without_reset() {
+        Runner::start(Config::seeded(0), |ctx| async move {
+            let recorded = Arc::new(Mutex::new(Recorded::default()));
+            let catchups = Arc::new(Mutex::new(Vec::<u64>::new()));
+            let pipeline = TrackingPipeline::new(Arc::clone(&recorded));
+
+            let (safe_tx, safe_rx) = watch::channel(0u64);
+            let driver = BatchDriver::new(
+                ctx.clone(),
+                pipeline,
+                RecordingSource::new(Arc::clone(&catchups)),
+                NeverConfirmTxManager,
+                BatchDriverConfig {
+                    inbox: Address::ZERO,
+                    max_pending_transactions: 1,
+                    drain_timeout: Duration::from_millis(10),
+                    force_blobs_when_throttling: false,
+                },
+                DaThrottle::new(ThrottleController::noop(), Arc::new(NoopThrottleClient)),
+                PendingL1HeadSource,
+            )
+            .with_safe_head_rx(safe_rx);
+
+            let handle = ctx.spawn(driver.run());
+
+            safe_tx.send(5).expect("driver holds the safe-head receiver");
+            ctx.sleep(Duration::from_millis(50)).await;
+
+            ctx.cancel();
+            assert!(handle.await.unwrap().is_ok(), "driver should exit cleanly on cancellation");
+
+            let recorded = recorded.lock().unwrap();
+            assert_eq!(recorded.safe_numbers, vec![5], "forward safe head must prune at 5");
+            assert_eq!(recorded.resets, 0, "forward safe head must not reset the pipeline");
+            assert!(
+                catchups.lock().unwrap().is_empty(),
+                "forward safe head must not restart catchup"
+            );
+        });
+    }
+
+    /// A safe-head *regression* models an L1 reorg that dropped already-submitted
+    /// batches. The driver must reset the pipeline and restart sequential catchup
+    /// from `regressed_safe_head + 1` so the orphaned block range is re-batched
+    /// instead of skipped forever. A regression must NOT be treated as a prune.
+    #[test]
+    fn safe_head_regression_resets_and_catches_up() {
+        Runner::start(Config::seeded(0), |ctx| async move {
+            let recorded = Arc::new(Mutex::new(Recorded::default()));
+            let catchups = Arc::new(Mutex::new(Vec::<u64>::new()));
+            let pipeline = TrackingPipeline::new(Arc::clone(&recorded));
+
+            let (safe_tx, safe_rx) = watch::channel(0u64);
+            let driver = BatchDriver::new(
+                ctx.clone(),
+                pipeline,
+                RecordingSource::new(Arc::clone(&catchups)),
+                NeverConfirmTxManager,
+                BatchDriverConfig {
+                    inbox: Address::ZERO,
+                    max_pending_transactions: 1,
+                    drain_timeout: Duration::from_millis(10),
+                    force_blobs_when_throttling: false,
+                },
+                DaThrottle::new(ThrottleController::noop(), Arc::new(NoopThrottleClient)),
+                PendingL1HeadSource,
+            )
+            .with_safe_head_rx(safe_rx);
+
+            let handle = ctx.spawn(driver.run());
+
+            // Advance the safe head to 10 (batches confirmed on L1).
+            safe_tx.send(10).expect("driver holds the safe-head receiver");
+            ctx.sleep(Duration::from_millis(50)).await;
+            // An L1 reorg drops those batches; the rollup node re-derives a lower
+            // safe head of 6.
+            safe_tx.send(6).expect("driver holds the safe-head receiver");
+            ctx.sleep(Duration::from_millis(50)).await;
+
+            ctx.cancel();
+            assert!(handle.await.unwrap().is_ok(), "driver should exit cleanly on cancellation");
+
+            let recorded = recorded.lock().unwrap();
+            assert_eq!(
+                recorded.safe_numbers,
+                vec![10],
+                "only the forward update should prune; the regression must not"
+            );
+            assert_eq!(recorded.resets, 1, "the regression must reset the pipeline exactly once");
+            assert_eq!(
+                *catchups.lock().unwrap(),
+                vec![7],
+                "catchup must restart from regressed_safe_head + 1 = 7"
+            );
         });
     }
 

--- a/crates/batcher/core/src/test_utils/mod.rs
+++ b/crates/batcher/core/src/test_utils/mod.rs
@@ -9,7 +9,7 @@ pub use pipeline::{OneReorgPipeline, Recorded, ReorgPipeline, TrackingPipeline};
 #[cfg(any(test, feature = "test-utils"))]
 mod source;
 #[cfg(any(test, feature = "test-utils"))]
-pub use source::{OneBlockSource, PendingL1HeadSource, PendingSource};
+pub use source::{OneBlockSource, PendingL1HeadSource, PendingSource, RecordingSource};
 
 #[cfg(any(test, feature = "test-utils"))]
 mod builder;

--- a/crates/batcher/core/src/test_utils/source.rs
+++ b/crates/batcher/core/src/test_utils/source.rs
@@ -1,9 +1,40 @@
 //! Test [`UnsafeBlockSource`] and [`L1HeadSource`] implementations.
 
+use std::sync::{Arc, Mutex};
+
 use async_trait::async_trait;
 use base_batcher_source::{
     L1HeadEvent, L1HeadSource, L2BlockEvent, SourceError, UnsafeBlockSource,
 };
+
+/// [`UnsafeBlockSource`] that parks the select arm forever but records every
+/// [`reset_catchup`](UnsafeBlockSource::reset_catchup) call.
+///
+/// Use this to assert the block number the driver restarts sequential catchup
+/// from after a reorg or a safe-head regression.
+#[derive(Debug, Clone, Default)]
+pub struct RecordingSource {
+    /// `start_from` values passed to `reset_catchup`, in call order.
+    pub catchups: Arc<Mutex<Vec<u64>>>,
+}
+
+impl RecordingSource {
+    /// Create a new recording source backed by the given shared vector.
+    pub const fn new(catchups: Arc<Mutex<Vec<u64>>>) -> Self {
+        Self { catchups }
+    }
+}
+
+#[async_trait]
+impl UnsafeBlockSource for RecordingSource {
+    async fn next(&mut self) -> Result<L2BlockEvent, SourceError> {
+        std::future::pending().await
+    }
+
+    fn reset_catchup(&mut self, start_from: u64) {
+        self.catchups.lock().unwrap().push(start_from);
+    }
+}
 
 /// [`UnsafeBlockSource`] that parks the select arm forever.
 ///

--- a/crates/batcher/service/src/safe_head_poller.rs
+++ b/crates/batcher/service/src/safe_head_poller.rs
@@ -25,12 +25,15 @@ impl SafeHeadProvider for jsonrpsee::http_client::HttpClient {
     }
 }
 
-/// Polls a [`SafeHeadProvider`] at a fixed interval and advances a watch
-/// channel when the safe L2 head moves forward.
+/// Polls a [`SafeHeadProvider`] at a fixed interval and republishes the safe L2
+/// head into a watch channel whenever it changes.
 ///
 /// The poller waits `poll_interval` before the first call, then loops.
-/// When the safe head advances, it calls [`watch::Sender::send_if_modified`]
-/// so receivers are only woken when the value actually changes.
+/// When the safe head changes in either direction, it calls
+/// [`watch::Sender::send_if_modified`] so receivers are only woken on a real
+/// change. Regressions are published too: an L1 reorg can drop already-submitted
+/// batches and move the safe head backward, and the driver relies on seeing that
+/// to re-batch the orphaned range rather than skipping it.
 ///
 /// Stops cleanly when the runtime passed to [`run`](Self::run) is cancelled.
 /// At most one in-flight RPC call is waited for before exit.
@@ -64,8 +67,14 @@ impl<C: SafeHeadProvider> SafeHeadPoller<C> {
             }
             match self.provider.safe_l2_number().await {
                 Ok(n) => {
+                    // Publish the rollup node's current safe head verbatim,
+                    // including regressions. An L1 reorg can drop batches that
+                    // already advanced the safe head, moving it backward, and the
+                    // driver must observe that to re-batch the orphaned range.
+                    // Only skip the update when the value is unchanged so
+                    // receivers are not woken for no-ops.
                     self.safe_head_tx.send_if_modified(|old| {
-                        if n > *old {
+                        if n != *old {
                             *old = n;
                             true
                         } else {
@@ -121,6 +130,15 @@ mod tests {
     impl SafeHeadProvider for ErrorProvider {
         async fn safe_l2_number(&self) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
             Err("rpc error".into())
+        }
+    }
+
+    /// Always returns the same fixed value.
+    struct ConstantProvider(u64);
+
+    impl SafeHeadProvider for ConstantProvider {
+        async fn safe_l2_number(&self) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
+            Ok(self.0)
         }
     }
 
@@ -181,7 +199,7 @@ mod tests {
         });
     }
 
-    /// When the provider returns the same or lower value, `send_if_modified`
+    /// When the provider keeps returning the current value, `send_if_modified`
     /// must not notify receivers. Check while the poller is still running
     /// (sender alive) so a dropped-sender signal cannot mask a missing change.
     #[test]
@@ -191,20 +209,43 @@ mod tests {
             // Mark the initial value as seen so `changed()` only fires on a new send.
             let _ = rx.borrow_and_update();
 
-            // MockProvider with no queued values returns 0, which is < 10 (initial),
-            // so send_if_modified will always return false.
-            let provider = MockProvider { values: Arc::new(Mutex::new(vec![])) };
-
-            let poller = SafeHeadPoller::new(provider, Duration::from_secs(1), tx);
+            // ConstantProvider always returns 10, equal to the current value, so
+            // send_if_modified always returns false.
+            let poller = SafeHeadPoller::new(ConstantProvider(10), Duration::from_secs(1), tx);
             let handle = ctx.spawn(poller.run(ctx.clone()));
             let timeout_ctx = ctx.clone();
 
             tokio::select! {
                 changed = rx.changed() => {
-                    panic!("watch fired without advancement: {changed:?}");
+                    panic!("watch fired without a value change: {changed:?}");
                 }
                 _ = timeout_ctx.sleep(Duration::from_secs(3)) => {}
             }
+
+            ctx.cancel();
+            handle.await.expect("poller task should stop");
+        });
+    }
+
+    /// When the provider reports a *lower* safe head (an L1 reorg dropped
+    /// already-submitted batches and the rollup node re-derived a lower safe
+    /// head), the poller must publish the regression so the driver can re-batch
+    /// the orphaned range. This is the core of the gap-after-reorg fix.
+    #[test]
+    fn poll_propagates_regression() {
+        Runner::start(Config::seeded(0), |ctx| async move {
+            let (tx, mut rx) = watch::channel(10u64);
+            // Mark the initial value (10) as seen so `changed()` fires on the regression.
+            let _ = rx.borrow_and_update();
+
+            // Provider reports a safe head of 5, below the current 10.
+            let provider = MockProvider { values: Arc::new(Mutex::new(vec![5])) };
+
+            let poller = SafeHeadPoller::new(provider, Duration::from_secs(1), tx);
+            let handle = ctx.spawn(poller.run(ctx.clone()));
+
+            rx.changed().await.expect("sender should still be alive");
+            assert_eq!(*rx.borrow(), 5, "safe head must regress to the lower reported value");
 
             ctx.cancel();
             handle.await.expect("poller task should stop");


### PR DESCRIPTION
## Summary

The batcher's safe head was forward only, so when an L1 reorg dropped already submitted batches and the rollup node re-derived a lower safe head, the batcher never observed the regression and resumed batching above the orphaned range, leaving a permanent gap that stalls verifier derivation. The safe head poller now republishes the rollup node's safe head on any change including regressions, and the driver treats a regression like a reorg by discarding in flight submissions, resetting the encoder, and restarting catchup from the new lower safe head so the orphaned blocks are re-batched. Coverage includes discriminating unit tests in base-batcher-core and base-batcher-service that pin the reset and catchup behavior, plus an end to end action test that drives the full watch to driver to verifier recovery path.