### PR TITLE
fix(b20-asset): version-gate announce inner-call error handling — wrap Panic as InternalCallFailed at AssetV2 (Cobalt), keep AssetV1 (Beryl) raw

### DIFF
--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -461,17 +461,8 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
             if call_bytes[..4] == IB20Asset::announceCall::SELECTOR {
                 return Err(BasePrecompileError::revert(IB20Asset::AnnouncementInProgress {}));
             }
-            self.route(ctx, call_bytes, version, privileged, NoopPrecompileCallObserver).map_err(
-                |err| {
-                    if err.is_system_error() {
-                        err
-                    } else {
-                        BasePrecompileError::revert(IB20Asset::InternalCallFailed {
-                            call: call.clone(),
-                        })
-                    }
-                },
-            )?;
+            self.route(ctx, call_bytes, version, privileged, NoopPrecompileCallObserver)
+                .map_err(|err| logic.map_announce_internal_error(call, err))?;
         }
 
         logic.end_announce(self, id)
@@ -709,6 +700,35 @@ mod tests {
         .abi_encode();
 
         let err = call_asset(&mut token, ALICE, calldata).unwrap_err();
+
+        assert_eq!(
+            err,
+            base_precompile_storage::BasePrecompileError::revert(IB20Asset::InternalCallFailed {
+                call: inner_call
+            })
+        );
+    }
+
+    /// At V2 (Cobalt) an inner-call `Panic` is remapped to `InternalCallFailed`
+    #[test]
+    fn announce_inner_panic_wraps_as_internal_call_failed_at_v2() {
+        let mut token = make_token();
+        // Any balance > 1 overflows when multiplied by this multiplier.
+        token.accounting_mut().multiplier = U256::MAX / U256::from(2u64) + U256::ONE;
+        token.accounting_mut().roles.insert((AssetV1::OPERATOR_ROLE, ALICE), true);
+
+        let inner_call = Bytes::from(
+            IB20Asset::toScaledBalanceCall { rawBalance: U256::from(2u64) }.abi_encode(),
+        );
+        let calldata = IB20Asset::announceCall {
+            internalCalls: alloc::vec![inner_call.clone()],
+            id: String::from("test-v2-panic"),
+            description: String::from("test"),
+            uri: String::new(),
+        }
+        .abi_encode();
+
+        let err = call_asset_v2_at(&mut token, ALICE, U256::from(1u64), calldata).unwrap_err();
 
         assert_eq!(
             err,

--- a/crates/common/precompiles/src/b20_asset/logic/interface.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/interface.rs
@@ -2,8 +2,8 @@
 
 use alloc::{string::String, vec::Vec};
 
-use alloy_primitives::{Address, B256, FixedBytes, U256};
-use base_precompile_storage::Result;
+use alloy_primitives::{Address, B256, Bytes, FixedBytes, U256};
+use base_precompile_storage::{BasePrecompileError, Result};
 
 use crate::{
     AssetAccounting, B20AssetToken, Eip712Domain, IB20, PermitArgs, PolicyAccounting, Token,
@@ -252,6 +252,21 @@ pub trait Asset<S: AssetAccounting, A: PolicyAccounting> {
 
     /// Closes an announcement after its internal calls have executed: emits `EndAnnouncement`.
     fn end_announce(&self, token: &mut B20AssetToken<S, A>, id: String) -> Result<()>;
+
+    /// Maps a failure from an `announce` internal call to the error this version surfaces.
+    ///
+    /// The dispatcher runs each `internalCalls` entry through `route` and hands any failure here.
+    /// The classification is consensus-frozen per fork, so it lives on the version: `AssetV1`
+    /// (Beryl) propagates system errors (`Panic` / `OutOfGas` / `Fatal` / `SlotOverflow`) raw and
+    /// wraps only ordinary reverts as `InternalCallFailed`; `AssetV2` (Cobalt) additionally remaps
+    /// `Panic` to `InternalCallFailed`, while still propagating `OutOfGas` / `Fatal` /
+    /// `SlotOverflow` raw (converting those would break EVM gas semantics or mask unrecoverable
+    /// faults).
+    fn map_announce_internal_error(
+        &self,
+        call: &Bytes,
+        err: BasePrecompileError,
+    ) -> BasePrecompileError;
 
     // --- Direct reads: version-invariant pass-throughs to the storage port, so the
     //     dispatcher never touches token storage directly. Defaulted here and shared by

--- a/crates/common/precompiles/src/b20_asset/logic/interface.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/interface.rs
@@ -254,14 +254,6 @@ pub trait Asset<S: AssetAccounting, A: PolicyAccounting> {
     fn end_announce(&self, token: &mut B20AssetToken<S, A>, id: String) -> Result<()>;
 
     /// Maps a failure from an `announce` internal call to the error this version surfaces.
-    ///
-    /// The dispatcher runs each `internalCalls` entry through `route` and hands any failure here.
-    /// The classification is consensus-frozen per fork, so it lives on the version: `AssetV1`
-    /// (Beryl) propagates system errors (`Panic` / `OutOfGas` / `Fatal` / `SlotOverflow`) raw and
-    /// wraps only ordinary reverts as `InternalCallFailed`; `AssetV2` (Cobalt) additionally remaps
-    /// `Panic` to `InternalCallFailed`, while still propagating `OutOfGas` / `Fatal` /
-    /// `SlotOverflow` raw (converting those would break EVM gas semantics or mask unrecoverable
-    /// faults).
     fn map_announce_internal_error(
         &self,
         call: &Bytes,

--- a/crates/common/precompiles/src/b20_asset/logic/v1.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v1.rs
@@ -6,7 +6,7 @@ use alloc::{
     vec::Vec,
 };
 
-use alloy_primitives::{Address, B256, FixedBytes, U256, b256, keccak256};
+use alloy_primitives::{Address, B256, Bytes, FixedBytes, U256, b256, keccak256};
 use alloy_sol_types::{SolEvent, SolValue};
 use base_precompile_storage::{BasePrecompileError, Result};
 
@@ -694,6 +694,20 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV1 {
 
     fn end_announce(&self, token: &mut B20AssetToken<S, A>, id: String) -> Result<()> {
         token.accounting_mut().emit_event(IB20Asset::EndAnnouncement { id }.encode_log_data())
+    }
+
+    fn map_announce_internal_error(
+        &self,
+        call: &Bytes,
+        err: BasePrecompileError,
+    ) -> BasePrecompileError {
+        // Frozen at Beryl: every system error (Panic / OutOfGas / Fatal / SlotOverflow) propagates
+        // raw; only ordinary reverts are wrapped. Byte-identical to the pre-BOP-485 inline mapping.
+        if err.is_system_error() {
+            err
+        } else {
+            BasePrecompileError::revert(IB20Asset::InternalCallFailed { call: call.clone() })
+        }
     }
 
     // --- Computed reads ---
@@ -1616,6 +1630,36 @@ mod tests {
         let mut tok = token();
         LOGIC.end_announce(&mut tok, "id".to_string()).unwrap();
         assert_eq!(last_event_sig(&tok), IB20Asset::EndAnnouncement::SIGNATURE_HASH);
+    }
+
+    /// Frozen at Beryl: every system error — including `Panic` — propagates raw from an inner
+    /// `announce` call; only ordinary reverts are wrapped. Pins the classification against
+    /// `AssetV2`'s Panic-wrapping divergence (BOP-485).
+    #[test]
+    fn map_announce_internal_error_keeps_system_errors_raw() {
+        let call = alloy_primitives::Bytes::from(vec![1u8, 2, 3, 4]);
+        let map = |err| {
+            <AssetV1 as Asset<FakeAccounting, FakePolicyAccounting>>::map_announce_internal_error(
+                &LOGIC, &call, err,
+            )
+        };
+        // Panic stays raw at V1 (the pre-Cobalt behavior).
+        assert_eq!(
+            map(BasePrecompileError::under_overflow()),
+            BasePrecompileError::under_overflow()
+        );
+        // The other system errors also stay raw.
+        assert_eq!(map(BasePrecompileError::OutOfGas), BasePrecompileError::OutOfGas);
+        assert_eq!(
+            map(BasePrecompileError::Fatal("db".to_string())),
+            BasePrecompileError::Fatal("db".to_string())
+        );
+        assert_eq!(map(BasePrecompileError::SlotOverflow), BasePrecompileError::SlotOverflow);
+        // An ordinary revert is wrapped as InternalCallFailed.
+        assert_eq!(
+            map(BasePrecompileError::revert(IB20::EmptyFeatureSet {})),
+            BasePrecompileError::revert(IB20Asset::InternalCallFailed { call: call.clone() })
+        );
     }
 
     // --- reads ---

--- a/crates/common/precompiles/src/b20_asset/logic/v1.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v1.rs
@@ -701,8 +701,7 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV1 {
         call: &Bytes,
         err: BasePrecompileError,
     ) -> BasePrecompileError {
-        // Frozen at Beryl: every system error (Panic / OutOfGas / Fatal / SlotOverflow) propagates
-        // raw; only ordinary reverts are wrapped. Byte-identical to the pre-BOP-485 inline mapping.
+        // Frozen at Beryl: every system error propagates raw; only ordinary reverts are wrapped
         if err.is_system_error() {
             err
         } else {
@@ -1632,9 +1631,6 @@ mod tests {
         assert_eq!(last_event_sig(&tok), IB20Asset::EndAnnouncement::SIGNATURE_HASH);
     }
 
-    /// Frozen at Beryl: every system error — including `Panic` — propagates raw from an inner
-    /// `announce` call; only ordinary reverts are wrapped. Pins the classification against
-    /// `AssetV2`'s Panic-wrapping divergence (BOP-485).
     #[test]
     fn map_announce_internal_error_keeps_system_errors_raw() {
         let call = alloy_primitives::Bytes::from(vec![1u8, 2, 3, 4]);

--- a/crates/common/precompiles/src/b20_asset/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v2.rs
@@ -14,7 +14,7 @@ use alloc::{
     vec::Vec,
 };
 
-use alloy_primitives::{Address, B256, FixedBytes, U256, b256, keccak256};
+use alloy_primitives::{Address, B256, Bytes, FixedBytes, U256, b256, keccak256};
 use alloy_sol_types::{SolEvent, SolValue};
 use base_precompile_storage::{BasePrecompileError, Result};
 
@@ -770,6 +770,22 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
 
     fn end_announce(&self, token: &mut B20AssetToken<S, A>, id: String) -> Result<()> {
         token.accounting_mut().emit_event(IB20Asset::EndAnnouncement { id }.encode_log_data())
+    }
+
+    fn map_announce_internal_error(
+        &self,
+        call: &Bytes,
+        err: BasePrecompileError,
+    ) -> BasePrecompileError {
+        // Cobalt remaps an inner-call Panic (Solidity 0x11/0x21/0x32) to the dedicated typed revert
+        // so the reference and binary agree, but still propagates OutOfGas / Fatal / SlotOverflow
+        // raw: converting OutOfGas to a catchable revert would break EVM gas semantics, and masking
+        // the hard faults would hide unrecoverable failures.
+        if matches!(err, BasePrecompileError::Panic(_)) || !err.is_system_error() {
+            BasePrecompileError::revert(IB20Asset::InternalCallFailed { call: call.clone() })
+        } else {
+            err
+        }
     }
 
     // --- Computed reads ---
@@ -1982,6 +1998,36 @@ mod tests {
         let mut tok = token();
         LOGIC.end_announce(&mut tok, "id".to_string()).unwrap();
         assert_eq!(last_event_sig(&tok), IB20Asset::EndAnnouncement::SIGNATURE_HASH);
+    }
+
+    /// Cobalt (BOP-485): an inner-call `Panic` and ordinary reverts both become
+    /// `InternalCallFailed`, but `OutOfGas` / `Fatal` / `SlotOverflow` still propagate raw. The
+    /// hard-fault arm is the security-relevant scope — converting `OutOfGas` into a catchable
+    /// revert would break EVM gas semantics, and masking `Fatal` / `SlotOverflow` would hide
+    /// unrecoverable faults.
+    #[test]
+    fn map_announce_internal_error_wraps_panic_keeps_hard_faults_raw() {
+        let call = alloy_primitives::Bytes::from(vec![1u8, 2, 3, 4]);
+        let map = |err| {
+            <AssetV2 as Asset<FakeAccounting, FakePolicyAccounting>>::map_announce_internal_error(
+                &LOGIC, &call, err,
+            )
+        };
+        let wrapped =
+            BasePrecompileError::revert(IB20Asset::InternalCallFailed { call: call.clone() });
+        // Every Panic kind is remapped to the typed revert (the V2 divergence from V1).
+        assert_eq!(map(BasePrecompileError::under_overflow()), wrapped);
+        assert_eq!(map(BasePrecompileError::enum_conversion_error()), wrapped);
+        assert_eq!(map(BasePrecompileError::array_oob()), wrapped);
+        // An ordinary revert is wrapped, unchanged from V1.
+        assert_eq!(map(BasePrecompileError::revert(IB20::EmptyFeatureSet {})), wrapped);
+        // The hard faults must still propagate raw.
+        assert_eq!(map(BasePrecompileError::OutOfGas), BasePrecompileError::OutOfGas);
+        assert_eq!(
+            map(BasePrecompileError::Fatal("db".to_string())),
+            BasePrecompileError::Fatal("db".to_string())
+        );
+        assert_eq!(map(BasePrecompileError::SlotOverflow), BasePrecompileError::SlotOverflow);
     }
 
     // --- reads ---

--- a/crates/common/precompiles/src/b20_asset/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v2.rs
@@ -777,10 +777,7 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
         call: &Bytes,
         err: BasePrecompileError,
     ) -> BasePrecompileError {
-        // Cobalt remaps an inner-call Panic (Solidity 0x11/0x21/0x32) to the dedicated typed revert
-        // so the reference and binary agree, but still propagates OutOfGas / Fatal / SlotOverflow
-        // raw: converting OutOfGas to a catchable revert would break EVM gas semantics, and masking
-        // the hard faults would hide unrecoverable failures.
+        // Cobalt remaps an inner-call Panic to the dedicated typed revert
         if matches!(err, BasePrecompileError::Panic(_)) || !err.is_system_error() {
             BasePrecompileError::revert(IB20Asset::InternalCallFailed { call: call.clone() })
         } else {
@@ -2000,11 +1997,7 @@ mod tests {
         assert_eq!(last_event_sig(&tok), IB20Asset::EndAnnouncement::SIGNATURE_HASH);
     }
 
-    /// Cobalt (BOP-485): an inner-call `Panic` and ordinary reverts both become
-    /// `InternalCallFailed`, but `OutOfGas` / `Fatal` / `SlotOverflow` still propagate raw. The
-    /// hard-fault arm is the security-relevant scope — converting `OutOfGas` into a catchable
-    /// revert would break EVM gas semantics, and masking `Fatal` / `SlotOverflow` would hide
-    /// unrecoverable faults.
+    /// Cobalt: inner-call `Panic` and ordinary reverts both become `InternalCallFailed`
     #[test]
     fn map_announce_internal_error_wraps_panic_keeps_hard_faults_raw() {
         let call = alloy_primitives::Bytes::from(vec![1u8, 2, 3, 4]);


### PR DESCRIPTION
## Summary

Resolves the `announce` inner-call error-handling divergence from BOP-477 by changing the **Rust precompile** at **Cobalt (AssetV2)** to remap an inner-call `Panic` to the dedicated `InternalCallFailed` typed revert, matching the base-std mock and `IB20Asset.announce` natspec. **AssetV1 (Beryl) is consensus-frozen and unchanged** — it keeps propagating system errors raw, byte-for-byte (the `v1.1.1` Beryl-launch tag already ships that behavior, so it cannot change).

Must land before Cobalt freezes `AssetV2` (AssetV2 already exists and is still mutable, so this rides it — no new version needed).

## What changed

- New `Asset` trait method `map_announce_internal_error(&self, call: &Bytes, err) -> BasePrecompileError`, mirroring the existing version-specific `begin_announce`/`end_announce`. It's **required (no default)**, so any future version is forced to declare its own inner-call classification (same "force a choice" spirit as #4229's exhaustive match).
  - **AssetV1** (`logic/v1.rs`, FROZEN): `if err.is_system_error() { err } else { InternalCallFailed }` — byte-identical to the previous inline mapping.
  - **AssetV2** (`logic/v2.rs`): `Panic` **and** ordinary reverts → `InternalCallFailed`; `OutOfGas` / `Fatal` / `SlotOverflow` still propagate **raw**.
- The dispatcher's `announce` loop (`dispatch.rs`) now calls `logic.map_announce_internal_error(call, err)` instead of the inline closure — the mapping moves onto the version axis, no hand-written fork gate.

## Scoping (security-relevant)

Only `Panic` (Solidity `0x11`/`0x21`/`0x32`) is remapped. `OutOfGas` **must** halt — converting it to a catchable typed revert would let a caller swallow OOG and continue, breaking EVM gas semantics. `Fatal`/`SlotOverflow` are unrecoverable internal faults that must not be masked. Both are kept raw at **both** versions and pinned by test.

## Tests

- **V1 (kept):** `announce_inner_system_error_propagates_unchanged` — inner overflow → raw `Panic(0x11)`.
- **V2 (new, end-to-end):** `announce_inner_panic_wraps_as_internal_call_failed_at_v2` — same overflowing `toScaledBalance` inner call → `InternalCallFailed`.
- **V1/V2 mapper units (new):** `map_announce_internal_error_*` pin the full classification, including that `OutOfGas`/`Fatal`/`SlotOverflow` stay raw at V2 (guards against over-wrapping the hard faults).

The `announce` wire surface (selectors/events/errors) is unchanged, so no frozen-surface/fingerprint pins move and there is **no golden re-bless** (revert-only paths).

## Verification

- `cargo test -p base-common-precompiles --features test-utils` — all pass (636+ lib + integration + goldens), 0 failures, 0 golden re-bless.
- `cargo clippy -p base-common-precompiles --all-targets --features test-utils` clean; `cargo +nightly fmt --check` clean.

## Follow-up (separate, base-std repo)

The per-fork base-std reference work is **not** in this PR (different repo): fix the `IB20Asset.announce` natspec (Panic → `InternalCallFailed` at Cobalt; OOG halts), verify/fix the Beryl-line mock to propagate raw `Panic`, and add fork + smoke pins for the inner-Panic case on both fork lines. Tracked under BOP-485 / BOP-477.

Linear: BOP-485

Made with [Cursor](https://cursor.com)