### PR TITLE
feat(BOP-492): mirror SEIZE_RECEIVER_POLICY in the B20 precompile (asset + stablecoin V2)

### DIFF
--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -37,7 +37,7 @@ jobs:
           - fork: Cobalt
             key: cobalt
             base_anvil_ref: ae7557c4f8602caa1da0be33143bb2504c85b0c8
-            base_std_ref: 96e96870937fa8c2ef5ad21a8433a9e5bdce07fa
+            base_std_ref: 8f88bf3e59dcf7a7396e3e80f6eb02166a46573a
     env:
       FORK_NAME: ${{ matrix.fork }}
       FORK_KEY: ${{ matrix.key }}

--- a/crates/common/precompile-macros/src/accounting.rs
+++ b/crates/common/precompile-macros/src/accounting.rs
@@ -252,6 +252,7 @@ fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
                     }
                     crate::B20PolicyType::MintReceiver => self.b20.mint_receiver_policy_id(),
                     crate::B20PolicyType::SeizeHolder => self.b20.seize_holder_policy_id(),
+                    crate::B20PolicyType::SeizeReceiver => self.b20.seize_receiver_policy_id(),
                 }
             }
 
@@ -275,6 +276,9 @@ fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
                     }
                     crate::B20PolicyType::SeizeHolder => {
                         self.b20.set_seize_holder_policy_id(policy_id)
+                    }
+                    crate::B20PolicyType::SeizeReceiver => {
+                        self.b20.set_seize_receiver_policy_id(policy_id)
                     }
                 }
             }

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -156,6 +156,7 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
             }
             C::MINT_RECEIVER_POLICY(_) => B20PolicyType::MintReceiver.id().abi_encode().into(),
             C::SEIZE_HOLDER_POLICY(_) => B20PolicyType::SeizeHolder.id().abi_encode().into(),
+            C::SEIZE_RECEIVER_POLICY(_) => B20PolicyType::SeizeReceiver.id().abi_encode().into(),
 
             // --- Role reads ---
             C::hasRole(c) => logic.has_role(self, c.role, c.account)?.abi_encode().into(),

--- a/crates/common/precompiles/src/b20_asset/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v2.rs
@@ -380,6 +380,9 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
             return Err(BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }));
         }
         B20Guards::ensure_seizable(token, from)?;
+        // Gate the destination like `mint` gates `MintReceiver`: an unset scope is always-allow, so a
+        // treasury need not be allowlisted by default.
+        B20Guards::ensure_policy_type(token, B20PolicyType::SeizeReceiver, to)?;
         self.move_balance(token, from, to, amount)?;
         // `Memo` must immediately follow the `Transfer` (from `move_balance`), before `Seized`.
         self.emit_memo(token, caller, memo)?;
@@ -1621,6 +1624,95 @@ mod tests {
             .unwrap();
         LOGIC.seize_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(50u64), MEMO).unwrap();
         assert_eq!(tok.accounting().balance_of(BOB).unwrap(), U256::from(50u64));
+    }
+
+    #[test]
+    fn seize_reverts_when_receiver_policy_forbids() {
+        let mut tok = token();
+        fund(&mut tok, ALICE, U256::from(50u64));
+        make_seizable(&mut tok);
+        grant(&mut tok, B20TokenRole::Seize.id(), ADMIN);
+        tok.accounting_mut()
+            .set_policy_id(
+                B20PolicyType::SeizeReceiver.id(),
+                PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+            )
+            .unwrap();
+        let err =
+            LOGIC.seize_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(1u64), MEMO).unwrap_err();
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20::PolicyForbids {
+                policyScope: B20PolicyType::SeizeReceiver.id(),
+                policyId: PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+            })
+        );
+    }
+
+    #[test]
+    fn seize_unset_receiver_policy_allows_any_destination() {
+        let mut tok = token();
+        fund(&mut tok, ALICE, U256::from(50u64));
+        make_seizable(&mut tok);
+        grant(&mut tok, B20TokenRole::Seize.id(), ADMIN);
+        // SEIZE_RECEIVER_POLICY left unset => ALWAYS_ALLOW => any destination is allowed.
+        LOGIC.seize_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(50u64), MEMO).unwrap();
+        assert_eq!(tok.accounting().balance_of(BOB).unwrap(), U256::from(50u64));
+    }
+
+    #[test]
+    fn seize_succeeds_with_configured_receiver_policy_allow() {
+        let mut tok = token();
+        fund(&mut tok, ALICE, U256::from(50u64));
+        make_seizable(&mut tok);
+        grant(&mut tok, B20TokenRole::Seize.id(), ADMIN);
+        tok.accounting_mut()
+            .set_policy_id(
+                B20PolicyType::SeizeReceiver.id(),
+                PolicyRegistryStorage::ALWAYS_ALLOW_ID,
+            )
+            .unwrap();
+        LOGIC.seize_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(50u64), MEMO).unwrap();
+        assert_eq!(tok.accounting().balance_of(BOB).unwrap(), U256::from(50u64));
+    }
+
+    #[test]
+    fn seize_holder_policy_beats_receiver_policy() {
+        let mut tok = token();
+        grant(&mut tok, B20TokenRole::Seize.id(), ADMIN);
+        // SEIZE_HOLDER unset => ALICE not seizable; SEIZE_RECEIVER blocks BOB. Holder check fires first.
+        tok.accounting_mut()
+            .set_policy_id(
+                B20PolicyType::SeizeReceiver.id(),
+                PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+            )
+            .unwrap();
+        let err =
+            LOGIC.seize_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(1u64), MEMO).unwrap_err();
+        assert_eq!(err, BasePrecompileError::revert(IB20::AccountNotSeizable { account: ALICE }));
+    }
+
+    #[test]
+    fn seize_receiver_policy_beats_balance() {
+        let mut tok = token();
+        make_seizable(&mut tok);
+        grant(&mut tok, B20TokenRole::Seize.id(), ADMIN);
+        // ALICE is seizable and has zero balance, but the receiver policy forbids BOB first.
+        tok.accounting_mut()
+            .set_policy_id(
+                B20PolicyType::SeizeReceiver.id(),
+                PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+            )
+            .unwrap();
+        let err =
+            LOGIC.seize_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(1u64), MEMO).unwrap_err();
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20::PolicyForbids {
+                policyScope: B20PolicyType::SeizeReceiver.id(),
+                policyId: PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+            })
+        );
     }
 
     #[test]

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -161,6 +161,9 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> B20StablecoinToken<S, A> {
                 }
                 C::MINT_RECEIVER_POLICY(_) => B20PolicyType::MintReceiver.id().abi_encode().into(),
                 C::SEIZE_HOLDER_POLICY(_) => B20PolicyType::SeizeHolder.id().abi_encode().into(),
+                C::SEIZE_RECEIVER_POLICY(_) => {
+                    B20PolicyType::SeizeReceiver.id().abi_encode().into()
+                }
                 C::hasRole(c) => logic.has_role(self, c.role, c.account)?.abi_encode().into(),
                 C::getRoleAdmin(c) => logic.role_admin(self, c.role)?.abi_encode().into(),
                 C::pausedFeatures(_) => logic.paused_features(self)?.abi_encode().into(),

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
@@ -345,6 +345,9 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> Stablecoin<S, A> for Stableco
             return Err(BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }));
         }
         B20Guards::ensure_seizable(token, from)?;
+        // Gate the destination like `mint` gates `MintReceiver`: an unset scope is always-allow, so a
+        // treasury need not be allowlisted by default.
+        B20Guards::ensure_policy_type(token, B20PolicyType::SeizeReceiver, to)?;
         self.move_balance(token, from, to, amount)?;
         // `Memo` must immediately follow the `Transfer` (from `move_balance`), before `Seized`.
         self.emit_memo(token, caller, memo)?;
@@ -1329,6 +1332,95 @@ mod tests {
             .unwrap();
         LOGIC.seize_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(50u64), MEMO).unwrap();
         assert_eq!(tok.accounting().balance_of(BOB).unwrap(), U256::from(50u64));
+    }
+
+    #[test]
+    fn seize_reverts_when_receiver_policy_forbids() {
+        let mut tok = token();
+        fund(&mut tok, ALICE, U256::from(50u64));
+        make_seizable(&mut tok);
+        grant(&mut tok, B20TokenRole::Seize.id(), ADMIN);
+        tok.accounting_mut()
+            .set_policy_id(
+                B20PolicyType::SeizeReceiver.id(),
+                PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+            )
+            .unwrap();
+        let err =
+            LOGIC.seize_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(1u64), MEMO).unwrap_err();
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20::PolicyForbids {
+                policyScope: B20PolicyType::SeizeReceiver.id(),
+                policyId: PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+            })
+        );
+    }
+
+    #[test]
+    fn seize_unset_receiver_policy_allows_any_destination() {
+        let mut tok = token();
+        fund(&mut tok, ALICE, U256::from(50u64));
+        make_seizable(&mut tok);
+        grant(&mut tok, B20TokenRole::Seize.id(), ADMIN);
+        // SEIZE_RECEIVER_POLICY left unset => ALWAYS_ALLOW => any destination is allowed.
+        LOGIC.seize_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(50u64), MEMO).unwrap();
+        assert_eq!(tok.accounting().balance_of(BOB).unwrap(), U256::from(50u64));
+    }
+
+    #[test]
+    fn seize_succeeds_with_configured_receiver_policy_allow() {
+        let mut tok = token();
+        fund(&mut tok, ALICE, U256::from(50u64));
+        make_seizable(&mut tok);
+        grant(&mut tok, B20TokenRole::Seize.id(), ADMIN);
+        tok.accounting_mut()
+            .set_policy_id(
+                B20PolicyType::SeizeReceiver.id(),
+                PolicyRegistryStorage::ALWAYS_ALLOW_ID,
+            )
+            .unwrap();
+        LOGIC.seize_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(50u64), MEMO).unwrap();
+        assert_eq!(tok.accounting().balance_of(BOB).unwrap(), U256::from(50u64));
+    }
+
+    #[test]
+    fn seize_holder_policy_beats_receiver_policy() {
+        let mut tok = token();
+        grant(&mut tok, B20TokenRole::Seize.id(), ADMIN);
+        // SEIZE_HOLDER unset => ALICE not seizable; SEIZE_RECEIVER blocks BOB. Holder check fires first.
+        tok.accounting_mut()
+            .set_policy_id(
+                B20PolicyType::SeizeReceiver.id(),
+                PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+            )
+            .unwrap();
+        let err =
+            LOGIC.seize_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(1u64), MEMO).unwrap_err();
+        assert_eq!(err, BasePrecompileError::revert(IB20::AccountNotSeizable { account: ALICE }));
+    }
+
+    #[test]
+    fn seize_receiver_policy_beats_balance() {
+        let mut tok = token();
+        make_seizable(&mut tok);
+        grant(&mut tok, B20TokenRole::Seize.id(), ADMIN);
+        // ALICE is seizable and has zero balance, but the receiver policy forbids BOB first.
+        tok.accounting_mut()
+            .set_policy_id(
+                B20PolicyType::SeizeReceiver.id(),
+                PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+            )
+            .unwrap();
+        let err =
+            LOGIC.seize_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(1u64), MEMO).unwrap_err();
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20::PolicyForbids {
+                policyScope: B20PolicyType::SeizeReceiver.id(),
+                policyId: PolicyRegistryStorage::ALWAYS_BLOCK_ID,
+            })
+        );
     }
 
     #[test]

--- a/crates/common/precompiles/src/common/abi/v2.rs
+++ b/crates/common/precompiles/src/common/abi/v2.rs
@@ -90,6 +90,7 @@ sol! {
         function TRANSFER_EXECUTOR_POLICY() external view returns (bytes32);
         function MINT_RECEIVER_POLICY() external view returns (bytes32);
         function SEIZE_HOLDER_POLICY() external view returns (bytes32);
+        function SEIZE_RECEIVER_POLICY() external view returns (bytes32);
 
         // ERC-20
         function name() external view returns (string);
@@ -181,6 +182,7 @@ impl IB20::IB20Calls {
             Self::TRANSFER_EXECUTOR_POLICY(_) => "precompile-b20-TRANSFER_EXECUTOR_POLICY",
             Self::MINT_RECEIVER_POLICY(_) => "precompile-b20-MINT_RECEIVER_POLICY",
             Self::SEIZE_HOLDER_POLICY(_) => "precompile-b20-SEIZE_HOLDER_POLICY",
+            Self::SEIZE_RECEIVER_POLICY(_) => "precompile-b20-SEIZE_RECEIVER_POLICY",
             Self::hasRole(_) => "precompile-b20-hasRole",
             Self::getRoleAdmin(_) => "precompile-b20-getRoleAdmin",
             Self::pausedFeatures(_) => "precompile-b20-pausedFeatures",
@@ -236,10 +238,10 @@ mod tests {
         b256!("106ef4b7c288c9344d6906ba7ef99a740bd9621cdaed89d06b35abd313c13449");
 
     /// Absolute wire fingerprint for Cobalt's (canonical) surface. Diverges from V1: Cobalt adds
-    /// the seize surface (`seizeWithMemo`, the `SEIZE_ROLE`/`SEIZE_HOLDER_POLICY` getters, the
-    /// `Seized` event, the `AccountNotSeizable` error, and the `SEIZE` pause feature).
+    /// the seize surface (`seizeWithMemo`, the `SEIZE_ROLE`/`SEIZE_HOLDER_POLICY`/`SEIZE_RECEIVER_POLICY`
+    /// getters, the `Seized` event, the `AccountNotSeizable` error, and the `SEIZE` pause feature).
     const V2_ABI_FINGERPRINT: B256 =
-        b256!("ff1784b934ecfc840872a07cf0a7716f1818bed4ad1e57dda75ec2a919417be1");
+        b256!("ad267d8b4250d41910b7f6cbcea4dcb1ba9273cf75cd27ae97a3e4ba9d9aded8");
 
     fn v1_abi_fingerprint() -> B256 {
         AbiFingerprint::compute(

--- a/crates/common/precompiles/src/common/core_storage.rs
+++ b/crates/common/precompiles/src/common/core_storage.rs
@@ -80,12 +80,16 @@ pub struct B20CoreStorage {
     pub nonces: Mapping<Address, U256>, // offset 13
     // The base-std mock keeps an `initialized` bootstrap flag as its last field; this impl checks
     // factory-init via deployed marker bytecode instead, so it stores no such field.
-    /// Seizable-account policy ID, consulted by the seize operations.
+    /// Seizable-account policy ID, consulted against `from` by the seize operations.
     #[accessor]
     #[mutator]
     pub seize_holder_policy_id: u64, // slot 14, offset 0
+    /// Seize-receiver policy ID, consulted against `to` by the seize operations.
+    #[accessor]
+    #[mutator]
+    pub seize_receiver_policy_id: u64, // slot 14, offset 8
     /// Reserved padding to close slot 14.
-    pub seize_reserved: FixedBytes<24>, // slot 14, offset 8
+    pub seize_reserved: FixedBytes<16>, // slot 14, offset 16
 }
 
 #[cfg(test)]
@@ -131,7 +135,9 @@ mod tests {
         assert_eq!(__packing_b20_core_storage::NONCES_LOC.offset_slots, 13);
         assert_eq!(__packing_b20_core_storage::SEIZE_HOLDER_POLICY_ID_LOC.offset_slots, 14);
         assert_eq!(__packing_b20_core_storage::SEIZE_HOLDER_POLICY_ID_LOC.offset_bytes, 0);
+        assert_eq!(__packing_b20_core_storage::SEIZE_RECEIVER_POLICY_ID_LOC.offset_slots, 14);
+        assert_eq!(__packing_b20_core_storage::SEIZE_RECEIVER_POLICY_ID_LOC.offset_bytes, 8);
         assert_eq!(__packing_b20_core_storage::SEIZE_RESERVED_LOC.offset_slots, 14);
-        assert_eq!(__packing_b20_core_storage::SEIZE_RESERVED_LOC.offset_bytes, 8);
+        assert_eq!(__packing_b20_core_storage::SEIZE_RESERVED_LOC.offset_bytes, 16);
     }
 }

--- a/crates/common/precompiles/src/common/policy_type.rs
+++ b/crates/common/precompiles/src/common/policy_type.rs
@@ -12,6 +12,8 @@ const MINT_RECEIVER_POLICY: B256 =
     b256!("a0d5ae037e66a09119acf080a1d807abb9b6d03b6b9130eb19f7c1e6bdb8ffc8");
 const SEIZE_HOLDER_POLICY: B256 =
     b256!("1497ab2b67ebb0a75dd9cdd6aec9f0e64620e6b87e911af7a088ac12e58d9ef2");
+const SEIZE_RECEIVER_POLICY: B256 =
+    b256!("bf15b19caf5c77422c038bc25f26b8b815c3a14f6d04c6616076b81bcfe07b3d");
 
 /// Built-in B-20 policy slots.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -27,6 +29,10 @@ pub enum B20PolicyType {
     /// Policy slot consulted against `from` by the seize operations. A `from` is seizable only when
     /// it is NOT authorized by this policy (mirroring the `burnBlocked` "blocked" semantics).
     SeizeHolder,
+    /// Policy slot consulted against `to` by the seize operations. Mirrors [`Self::MintReceiver`]:
+    /// the destination must be authorized by this policy. An unset scope reads as always-allow, so
+    /// seize may send anywhere until an issuer configures it.
+    SeizeReceiver,
 }
 
 impl B20PolicyType {
@@ -42,6 +48,8 @@ impl B20PolicyType {
             Some(Self::MintReceiver)
         } else if id == SEIZE_HOLDER_POLICY {
             Some(Self::SeizeHolder)
+        } else if id == SEIZE_RECEIVER_POLICY {
+            Some(Self::SeizeReceiver)
         } else {
             None
         }
@@ -55,6 +63,7 @@ impl B20PolicyType {
             Self::TransferExecutor => TRANSFER_EXECUTOR_POLICY,
             Self::MintReceiver => MINT_RECEIVER_POLICY,
             Self::SeizeHolder => SEIZE_HOLDER_POLICY,
+            Self::SeizeReceiver => SEIZE_RECEIVER_POLICY,
         }
     }
 }
@@ -74,14 +83,19 @@ mod tests {
         assert_eq!(B20PolicyType::TransferExecutor.id(), keccak256("TRANSFER_EXECUTOR_POLICY"));
         assert_eq!(B20PolicyType::MintReceiver.id(), keccak256("MINT_RECEIVER_POLICY"));
         assert_eq!(B20PolicyType::SeizeHolder.id(), keccak256("SEIZE_HOLDER_POLICY"));
+        assert_eq!(B20PolicyType::SeizeReceiver.id(), keccak256("SEIZE_RECEIVER_POLICY"));
     }
 
-    /// `from_id` is the inverse of `id`, including for the seizable scope.
+    /// `from_id` is the inverse of `id`, including for the seize scopes.
     #[test]
     fn seizable_scope_round_trips() {
         assert_eq!(
             B20PolicyType::from_id(B20PolicyType::SeizeHolder.id()),
             Some(B20PolicyType::SeizeHolder)
+        );
+        assert_eq!(
+            B20PolicyType::from_id(B20PolicyType::SeizeReceiver.id()),
+            Some(B20PolicyType::SeizeReceiver)
         );
     }
 }

--- a/crates/common/precompiles/tests/b20_asset_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v1_golden.rs
@@ -275,9 +275,9 @@ fn golden_v2_selectors_unknown_at_v1() {
     }
 }
 
-/// The seize common selectors (`seizeWithMemo` and the `SEIZE_ROLE` / `SEIZE_HOLDER_POLICY`
-/// getters) were introduced at Cobalt (`AssetV2`). At V1 (Beryl) they are absent from the frozen
-/// common `IB20` surface, so `route` rejects them as `UnknownFunctionSelector`.
+/// The seize common selectors (`seizeWithMemo` and the `SEIZE_ROLE` / `SEIZE_HOLDER_POLICY` /
+/// `SEIZE_RECEIVER_POLICY` getters) were introduced at Cobalt (`AssetV2`). At V1 (Beryl) they are
+/// absent from the frozen common `IB20` surface, so `route` rejects them as `UnknownFunctionSelector`.
 #[test]
 fn golden_seize_selectors_unknown_at_v1() {
     let mut s = fresh();
@@ -285,6 +285,7 @@ fn golden_seize_selectors_unknown_at_v1() {
         IB20::seizeWithMemoCall { from: ALICE, to: BOB, amount: u(1), memo: MEMO }.abi_encode(),
         IB20::SEIZE_ROLECall {}.abi_encode(),
         IB20::SEIZE_HOLDER_POLICYCall {}.abi_encode(),
+        IB20::SEIZE_RECEIVER_POLICYCall {}.abi_encode(),
     ];
     for calldata in calls {
         let selector: [u8; 4] = calldata[..4].try_into().unwrap();
@@ -2682,9 +2683,10 @@ fn v1_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Asset::IB20AssetCall
             golden_burn_blocked_reverts_when_not_blocked,
             golden_burn_blocked_unprivileged_requires_role,
         ]),
-        C::seizeWithMemo(_) | C::SEIZE_ROLE(_) | C::SEIZE_HOLDER_POLICY(_) => {
-            covered(&[golden_seize_selectors_unknown_at_v1])
-        }
+        C::seizeWithMemo(_)
+        | C::SEIZE_ROLE(_)
+        | C::SEIZE_HOLDER_POLICY(_)
+        | C::SEIZE_RECEIVER_POLICY(_) => covered(&[golden_seize_selectors_unknown_at_v1]),
 
         // pause / config / roles / policy / permit
         C::pause(_) => covered(&[

--- a/crates/common/precompiles/tests/b20_stablecoin_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_stablecoin_v1_golden.rs
@@ -733,9 +733,9 @@ fn golden_burn_blocked_reverts_when_not_blocked() {
     assert_eq!(err, BasePrecompileError::revert(IB20::AccountNotBlocked { account: ALICE }));
 }
 
-/// The seize common selectors (`seizeWithMemo` and the `SEIZE_ROLE` / `SEIZE_HOLDER_POLICY`
-/// getters) were introduced at Cobalt (`StablecoinV2`). At V1 (Beryl) they are absent from the
-/// frozen common `IB20` surface, so `route` rejects them as `UnknownFunctionSelector`.
+/// The seize common selectors (`seizeWithMemo` and the `SEIZE_ROLE` / `SEIZE_HOLDER_POLICY` /
+/// `SEIZE_RECEIVER_POLICY` getters) were introduced at Cobalt (`StablecoinV2`). At V1 (Beryl) they
+/// are absent from the frozen common `IB20` surface, so `route` rejects them as `UnknownFunctionSelector`.
 #[test]
 fn golden_seize_selectors_unknown_at_v1() {
     let mut s = fresh();
@@ -743,6 +743,7 @@ fn golden_seize_selectors_unknown_at_v1() {
         IB20::seizeWithMemoCall { from: ALICE, to: BOB, amount: u(1), memo: MEMO }.abi_encode(),
         IB20::SEIZE_ROLECall {}.abi_encode(),
         IB20::SEIZE_HOLDER_POLICYCall {}.abi_encode(),
+        IB20::SEIZE_RECEIVER_POLICYCall {}.abi_encode(),
     ];
     for calldata in calls {
         let selector: [u8; 4] = calldata[..4].try_into().unwrap();
@@ -2093,9 +2094,10 @@ fn v1_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Stablecoin::IB20Stab
             golden_burn_blocked_reverts_when_not_blocked,
             golden_burn_blocked_unprivileged_requires_role,
         ]),
-        C::seizeWithMemo(_) | C::SEIZE_ROLE(_) | C::SEIZE_HOLDER_POLICY(_) => {
-            covered(&[golden_seize_selectors_unknown_at_v1])
-        }
+        C::seizeWithMemo(_)
+        | C::SEIZE_ROLE(_)
+        | C::SEIZE_HOLDER_POLICY(_)
+        | C::SEIZE_RECEIVER_POLICY(_) => covered(&[golden_seize_selectors_unknown_at_v1]),
 
         // pause / config / roles / policy / permit
         C::pause(_) => covered(&[


### PR DESCRIPTION
## What

Mirrors base-std [#188](https://github.com/base/base-std/pull/188) (BOP-491) into the Rust B20 precompile: adds a receiver-side seize policy, `SEIZE_RECEIVER_POLICY`, on the **Cobalt (V2)** surface for both asset and stablecoin. `seizeWithMemo` now gates the destination `to` under this policy, in addition to the existing `SEIZE_HOLDER_POLICY` check on `from`.

Mirrors `MINT_RECEIVER_POLICY` exactly: an unset scope reads as `ALWAYS_ALLOW`, so an unconfigured token can still seize to any destination (a treasury need not be allowlisted). Configured, it lets an issuer constrain where seized funds land, derisking a runaway `SEIZE_ROLE`. Beryl/V1 stays byte-frozen.

The new id packs into the **same** seize slot (slot 14) as the seize-holder id — offset 8 — so no new slot and offsets 0..13 are untouched.

## Changes

- `policy_type.rs`: `SEIZE_RECEIVER_POLICY` const (keccak) + `B20PolicyType::SeizeReceiver` + `from_id`/`id` arms + parity/round-trip tests.
- `core_storage.rs`: `seize_receiver_policy_id: u64` at slot 14 offset 8; `seize_reserved` shrunk to `FixedBytes<16>`; offset-pin test updated.
- `precompile-macros/accounting.rs`: `SeizeReceiver` arms in the generated `policy_id`/`set_policy_id`.
- `abi/v2.rs`: `SEIZE_RECEIVER_POLICY()` getter + `as_label`; recomputed `V2_ABI_FINGERPRINT` (V1 unchanged). Beryl rejects the new selector via the existing version-gated common decode.
- `b20_asset`/`b20_stablecoin` `dispatch.rs`: getter arm returning the scope id.
- `b20_asset`/`b20_stablecoin` `logic/v2.rs`: `ensure_policy_type(SeizeReceiver, to)` after the seizable check.
- golden matrices: `SEIZE_RECEIVER_POLICY` covered as unknown-at-V1.
- `.github/workflows/base-std-fork-tests.yml`: Cobalt `base_std_ref` pinned to base-std #188 (`8f88bf3`).

## Guard order (V2 seize)

`SEIZE` pause -> `SEIZE_ROLE` -> `to != 0` -> `AccountNotSeizable(from)` -> `PolicyForbids(SEIZE_RECEIVER_POLICY, to)` -> `InsufficientBalance`.

## Testing

- `cargo test -p base-common-precompiles --features test-utils` — all green (unit 647, asset golden 103, stablecoin golden 81, policy/factory goldens). New: receiver-forbids, unset-allows-any, configured-allow, and two revert-order pairs per variant.
- `cargo clippy ... --features test-utils --tests` clean; `cargo +nightly fmt --check` clean.

Ticket: https://linear.app/coinbase/issue/BOP-492