### PR TITLE
backport(prover): batch delete proofs without schedule ID (#4129)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5764,6 +5764,7 @@ dependencies = [
  "alloy-genesis 2.0.5",
  "alloy-primitives",
  "alloy-signer 2.0.5",
+ "alloy-signer-local 2.0.5",
  "async-trait",
  "base-common-genesis",
  "base-health",
@@ -5779,7 +5780,7 @@ dependencies = [
  "jsonrpsee",
  "k256",
  "reqwest 0.13.4",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tokio-vsock",
@@ -6116,7 +6117,9 @@ dependencies = [
 name = "base-prover-service-db"
 version = "0.0.0"
 dependencies = [
+ "alloy-primitives",
  "anyhow",
+ "base-proof-primitives",
  "base-prover-service-protocol",
  "chrono",
  "futures",

--- a/crates/proof/challenge/src/proof_adapter.rs
+++ b/crates/proof/challenge/src/proof_adapter.rs
@@ -271,6 +271,7 @@ mod tests {
             aggregate_proposal: test_proposal(root),
             proposals: Vec::new(),
             tee_kind: TeeKind::AwsNitro,
+            tee_signer: Address::repeat_byte(0x11),
         });
 
         let proof_bytes = ChallengerProofAdapter::tee_dispute_proof_bytes(result, root).unwrap();
@@ -285,6 +286,7 @@ mod tests {
             aggregate_proposal: test_proposal(B256::repeat_byte(0xaa)),
             proposals: Vec::new(),
             tee_kind: TeeKind::AwsNitro,
+            tee_signer: Address::repeat_byte(0x11),
         });
 
         let err = ChallengerProofAdapter::tee_dispute_proof_bytes(result, B256::repeat_byte(0xbb))

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -881,6 +881,13 @@ impl ProofRequesterProvider for MockZkProofProvider {
         Ok(())
     }
 
+    async fn delete_proofs_by_tee_signer(
+        &self,
+        _request: base_prover_service_protocol::DeleteProofsByTeeSignerRequest,
+    ) -> Result<u64, ProverServiceClientError> {
+        unimplemented!("tests do not delete proofs by tee signer")
+    }
+
     async fn list_proofs(
         &self,
         _request: base_prover_service_protocol::ListProofsRequest,

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -146,6 +146,7 @@ const fn tee_api_result(aggregate_proposal: Proposal) -> ApiProofResult {
         aggregate_proposal,
         proposals: Vec::new(),
         tee_kind: TeeKind::AwsNitro,
+        tee_signer: Address::repeat_byte(0x11),
     })
 }
 

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -210,8 +210,8 @@ mod tests {
     use base_proof_contracts::{AnchorStateRegistryClient, DisputeGameFactoryClient};
     use base_prover_service_client::{ProofRequesterProvider, ProverServiceClientError};
     use base_prover_service_protocol::{
-        DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest,
-        ListProofsResponse, ProveBlockRangeRequest, ProveBlockRangeResponse,
+        DeleteProofRequest, DeleteProofsByTeeSignerRequest, GetProofRequest, GetProofResponse,
+        ListProofsRequest, ListProofsResponse, ProveBlockRangeRequest, ProveBlockRangeResponse,
     };
     use tokio_util::sync::CancellationToken;
 
@@ -254,6 +254,13 @@ mod tests {
             &self,
             _request: DeleteProofRequest,
         ) -> Result<(), ProverServiceClientError> {
+            unimplemented!("pipeline tests do not delete proofs")
+        }
+
+        async fn delete_proofs_by_tee_signer(
+            &self,
+            _request: DeleteProofsByTeeSignerRequest,
+        ) -> Result<u64, ProverServiceClientError> {
             unimplemented!("pipeline tests do not delete proofs")
         }
 

--- a/crates/proof/proposer/src/proof_adapter.rs
+++ b/crates/proof/proposer/src/proof_adapter.rs
@@ -1,10 +1,10 @@
 //! Adapters between proposer proof types and the shared prover-service protocol.
 
 use alloy_primitives::B256;
-use base_proof_primitives::{ProofRequest as PrimitiveProofRequest, Proposal};
+use base_proof_primitives::ProofRequest as PrimitiveProofRequest;
 use base_prover_service_protocol::{
     ProofRequest, ProofRequestKind, ProofResult, ProofSessionId, ProveBlockRangeRequest, TeeKind,
-    TeeProofRequest,
+    TeeProofRequest, TeeProofResult,
 };
 
 use crate::ProposerError;
@@ -46,9 +46,7 @@ impl ProposerProofAdapter {
     }
 
     /// Converts a prover-service TEE proof result into proposal parts.
-    pub fn tee_proof_result(
-        result: ProofResult,
-    ) -> Result<(Proposal, Vec<Proposal>), ProposerError> {
+    pub fn tee_proof_result(result: ProofResult) -> Result<TeeProofResult, ProposerError> {
         let result = match result {
             ProofResult::Tee(result) => result,
             ProofResult::Compressed(_) => {
@@ -69,7 +67,7 @@ impl ProposerProofAdapter {
             )));
         }
 
-        Ok((result.aggregate_proposal, result.proposals))
+        Ok(result)
     }
 }
 
@@ -124,11 +122,14 @@ mod tests {
             aggregate_proposal: aggregate.clone(),
             proposals: vec![proposal.clone()],
             tee_kind: TeeKind::AwsNitro,
+            tee_signer: Address::repeat_byte(0x11),
         });
 
         let converted = ProposerProofAdapter::tee_proof_result(result).unwrap();
 
-        assert_eq!(converted, (aggregate, vec![proposal]));
+        assert_eq!(converted.aggregate_proposal, aggregate);
+        assert_eq!(converted.proposals, vec![proposal]);
+        assert_eq!(converted.tee_signer, Address::repeat_byte(0x11));
     }
 
     #[test]

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -3,10 +3,13 @@
 use std::{sync::Arc, time::Duration};
 
 use alloy_primitives::Address;
-use base_proof_primitives::Proposal;
 use base_proof_rpc::RollupProvider;
+use base_proof_submission::ProofSubmissionError;
 use base_prover_service_client::ProofRequesterProvider;
-use base_prover_service_protocol::{DeleteProofRequest, GetProofRequest, ProofStatus};
+use base_prover_service_protocol::{
+    DeleteProofRequest, DeleteProofsByTeeSignerRequest, GetProofRequest, ProofStatus,
+    TeeProofResult,
+};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
@@ -107,7 +110,7 @@ where
             };
 
             let session_id = ProposerProofAdapter::tee_session_id_for_root(claimed_l2_output_root);
-            let (aggregate_proposal, proposals) = match Self::poll_proof(
+            let proof = match Self::poll_proof(
                 self.proof_requester.as_ref(),
                 target_block,
                 &session_id,
@@ -129,14 +132,7 @@ where
             };
 
             match self
-                .submit_proof(
-                    target_block,
-                    &session_id,
-                    aggregate_proposal,
-                    proposals,
-                    current.parent_address,
-                    cancel,
-                )
+                .submit_proof(target_block, &session_id, proof, current.parent_address, cancel)
                 .await
             {
                 SubmitOutcome::Advanced(next) => *current = next,
@@ -151,7 +147,7 @@ where
         target_block: u64,
         session_id: &str,
         request_dispatched: bool,
-    ) -> Result<Option<(Proposal, Vec<Proposal>)>, ProposerError> {
+    ) -> Result<Option<TeeProofResult>, ProposerError> {
         let response = match proof_requester
             .get_proof(GetProofRequest { session_id: session_id.to_owned() })
             .await
@@ -269,19 +265,22 @@ where
         &self,
         target_block: u64,
         session_id: &str,
-        aggregate_proposal: Proposal,
-        proposals: Vec<Proposal>,
+        proof: TeeProofResult,
         parent_address: Address,
         cancel: &CancellationToken,
     ) -> SubmitOutcome {
         info!(target_block, parent_address = %parent_address, "Submitting proof");
 
+        // Bind up front (the field is `Copy`) so the later discard-path match does
+        // not read `proof` after it has been borrowed for submission below.
+        let tee_signer = proof.tee_signer;
+
         let mut submit_timer = base_metrics::timed!(Metrics::proposal_total_duration_seconds());
         let result = match cancel
             .run_until_cancelled(async {
                 let submit = self.submitter.submit(
-                    &aggregate_proposal,
-                    &proposals,
+                    &proof.aggregate_proposal,
+                    &proof.proposals,
                     target_block,
                     parent_address,
                 );
@@ -346,10 +345,21 @@ where
                     error = %error,
                     "Submission discarded, deleting proof request for re-prove"
                 );
-                return if self.delete_proof_request(session_id, target_block).await {
-                    SubmitOutcome::Restart
-                } else {
-                    SubmitOutcome::Idle
+                let deleted = cancel
+                    .run_until_cancelled(async {
+                        if matches!(
+                            error,
+                            ProposerError::Submission(ProofSubmissionError::InvalidSigner)
+                        ) {
+                            self.delete_proofs_by_tee_signer(tee_signer, target_block).await
+                        } else {
+                            self.delete_proof_request(session_id, target_block).await
+                        }
+                    })
+                    .await;
+                return match deleted {
+                    Some(true) => SubmitOutcome::Restart,
+                    Some(false) | None => SubmitOutcome::Idle,
                 };
             }
         }
@@ -382,6 +392,37 @@ where
             }
         }
     }
+
+    async fn delete_proofs_by_tee_signer(&self, tee_signer: Address, target_block: u64) -> bool {
+        match self
+            .proof_requester
+            .delete_proofs_by_tee_signer(DeleteProofsByTeeSignerRequest { tee_signer })
+            .await
+        {
+            Ok(deleted_count) => {
+                info!(
+                    target_block,
+                    tee_signer = %tee_signer,
+                    deleted_count,
+                    "Deleted invalid TEE signer proof requests"
+                );
+                // A zero-row delete means the just-submitted proof was not matched
+                // (e.g. its recorded signer diverged from the reported one). Treat it
+                // as "not deleted" so the caller idles and backs off instead of
+                // immediately re-polling the same still-present proof in a tight loop.
+                deleted_count > 0
+            }
+            Err(error) => {
+                warn!(
+                    target_block,
+                    tee_signer = %tee_signer,
+                    error = %error,
+                    "Failed to delete proof requests by TEE signer"
+                );
+                false
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -394,6 +435,7 @@ mod tests {
     };
     use base_proof_primitives::ProofRequest;
     use base_proof_submission::ProofSubmissionError;
+    use base_prover_service_protocol::TeeKind;
     use tokio_util::sync::CancellationToken;
 
     use super::*;
@@ -602,7 +644,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn tick_deletes_succeeded_proof_when_submission_discards_it() {
+    async fn tick_batch_deletes_proofs_from_invalid_signer() {
         let requester = Arc::new(MockProofRequester::default());
         let target_block = 200;
         let claimed_root = B256::repeat_byte(target_block as u8);
@@ -618,6 +660,18 @@ mod tests {
             .prove_block_range(ProposerProofAdapter::tee_prove_block_range_request(proof_request))
             .await
             .expect("test setup should dispatch root session");
+        let later_root = B256::repeat_byte(0xcc);
+        let later_session_id = ProposerProofAdapter::tee_session_id_for_root(later_root);
+        requester
+            .prove_block_range(ProposerProofAdapter::tee_prove_block_range_request(ProofRequest {
+                claimed_l2_output_root: later_root,
+                claimed_l2_block_number: target_block + BLOCK_INTERVAL,
+                intermediate_block_interval: BLOCK_INTERVAL,
+                l1_head_number: 1000,
+                ..Default::default()
+            }))
+            .await
+            .expect("test setup should dispatch later root session");
         let collector = make_collector(
             Arc::clone(&requester) as Arc<dyn ProofRequesterProvider>,
             rollup_client(target_block, Some(claimed_root)),
@@ -633,6 +687,11 @@ mod tests {
 
         assert!(restart);
         assert!(!requester.requests.lock().unwrap().contains_key(&session_id));
+        assert!(!requester.requests.lock().unwrap().contains_key(&later_session_id));
+        assert_eq!(
+            *requester.deleted_tee_signers.lock().unwrap(),
+            vec![Address::repeat_byte(0x11)]
+        );
     }
 
     #[tokio::test]
@@ -699,8 +758,12 @@ mod tests {
             .submit_proof(
                 target_block,
                 &session_id,
-                aggregate_proposal,
-                vec![],
+                TeeProofResult {
+                    aggregate_proposal,
+                    proposals: vec![],
+                    tee_kind: TeeKind::AwsNitro,
+                    tee_signer: Address::repeat_byte(0x11),
+                },
                 Address::ZERO,
                 &CancellationToken::new(),
             )

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -20,10 +20,11 @@ use base_proof_primitives::Proposal;
 use base_proof_rpc::{BaseBlock, L1Provider, L2Provider, RollupProvider, RpcError, RpcResult};
 use base_prover_service_client::{ProofRequesterProvider, ProverServiceClientError};
 use base_prover_service_protocol::{
-    DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse,
-    PROOF_REQUEST_NOT_FOUND_MESSAGE, ProofRequestIdCollisionMessage,
-    ProofRequestKind as ApiProofRequestKind, ProofResult as ApiProofResult, ProofStatus,
-    ProveBlockRangeRequest, ProveBlockRangeResponse, TeeKind, TeeProofResult,
+    DeleteProofRequest, DeleteProofsByTeeSignerRequest, GetProofRequest, GetProofResponse,
+    ListProofsRequest, ListProofsResponse, PROOF_REQUEST_NOT_FOUND_MESSAGE,
+    ProofRequestIdCollisionMessage, ProofRequestKind as ApiProofRequestKind,
+    ProofResult as ApiProofResult, ProofStatus, ProveBlockRangeRequest, ProveBlockRangeResponse,
+    TeeKind, TeeProofResult,
 };
 use jsonrpsee::{core::client::Error as JsonRpcClientError, types::ErrorObjectOwned};
 
@@ -389,6 +390,8 @@ pub struct MockProofRequester {
     pub requests: Mutex<HashMap<String, ProveBlockRangeRequest>>,
     /// Sessions that should return a terminal failed status from `get_proof`.
     pub failed_sessions: Mutex<HashMap<String, String>>,
+    /// TEE signers passed to batch deletion.
+    pub deleted_tee_signers: Mutex<Vec<Address>>,
     /// Reject every `prove_block_range` call with an L1 head conflict.
     pub reject_l1_head_conflict: bool,
     /// Return a mismatched session id from `prove_block_range`.
@@ -472,6 +475,7 @@ impl ProofRequesterProvider for MockProofRequester {
                 aggregate_proposal,
                 proposals,
                 tee_kind: TeeKind::AwsNitro,
+                tee_signer: Address::repeat_byte(0x11),
             })),
         })
     }
@@ -487,6 +491,19 @@ impl ProofRequesterProvider for MockProofRequester {
         self.requests.lock().unwrap().remove(&request.session_id);
         self.failed_sessions.lock().unwrap().remove(&request.session_id);
         Ok(())
+    }
+
+    async fn delete_proofs_by_tee_signer(
+        &self,
+        request: DeleteProofsByTeeSignerRequest,
+    ) -> Result<u64, ProverServiceClientError> {
+        if self.reject_delete {
+            return Err(ProverServiceClientError::Timeout("simulated delete failure".into()));
+        }
+
+        self.deleted_tee_signers.lock().unwrap().push(request.tee_signer);
+        let deleted_count = self.requests.lock().unwrap().drain().count() as u64;
+        Ok(deleted_count)
     }
 
     async fn list_proofs(

--- a/crates/proof/prover-service/client/src/requester.rs
+++ b/crates/proof/prover-service/client/src/requester.rs
@@ -3,8 +3,9 @@
 use async_trait::async_trait;
 use backon::Retryable;
 use base_prover_service_protocol::{
-    DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse,
-    ProveBlockRangeRequest, ProveBlockRangeResponse, ProverRequesterApiClient,
+    DeleteProofRequest, DeleteProofsByTeeSignerRequest, GetProofRequest, GetProofResponse,
+    ListProofsRequest, ListProofsResponse, ProveBlockRangeRequest, ProveBlockRangeResponse,
+    ProverRequesterApiClient,
 };
 use base_retry::RetryConfig;
 use jsonrpsee::http_client::HttpClient;
@@ -37,6 +38,12 @@ pub trait ProofRequesterProvider: Send + Sync {
         &self,
         request: DeleteProofRequest,
     ) -> Result<(), ProverServiceClientError>;
+
+    /// Delete completed TEE proof requests produced by one signer.
+    async fn delete_proofs_by_tee_signer(
+        &self,
+        request: DeleteProofsByTeeSignerRequest,
+    ) -> Result<u64, ProverServiceClientError>;
 
     /// List submitted proof requests.
     async fn list_proofs(
@@ -168,6 +175,28 @@ impl ProofRequesterClient {
         .await
     }
 
+    /// Delete completed TEE proof requests produced by one signer.
+    pub async fn delete_proofs_by_tee_signer(
+        &self,
+        request: DeleteProofsByTeeSignerRequest,
+    ) -> Result<u64, ProverServiceClientError> {
+        debug!(tee_signer = %request.tee_signer, "deleting proofs by TEE signer");
+        // `request` is `Copy`, so each retry attempt gets its own copy via `async move`
+        // while the outer binding stays available for the `notify` closure below.
+        (|| async move { Ok(self.inner.delete_proofs_by_tee_signer(request).await?) })
+            .retry(self.retry.to_backoff_builder())
+            .when(ProverServiceClientError::is_retryable)
+            .notify(|error, delay| {
+                warn!(
+                    tee_signer = %request.tee_signer,
+                    backoff_ms = delay.as_millis(),
+                    error = %error,
+                    "delete proofs by TEE signer failed; retrying"
+                );
+            })
+            .await
+    }
+
     /// List submitted proof requests.
     pub async fn list_proofs(
         &self,
@@ -219,6 +248,13 @@ impl ProofRequesterProvider for ProofRequesterClient {
         Self::delete_proof_request(self, request).await
     }
 
+    async fn delete_proofs_by_tee_signer(
+        &self,
+        request: DeleteProofsByTeeSignerRequest,
+    ) -> Result<u64, ProverServiceClientError> {
+        Self::delete_proofs_by_tee_signer(self, request).await
+    }
+
     async fn list_proofs(
         &self,
         request: ListProofsRequest,
@@ -241,10 +277,10 @@ mod tests {
 
     use async_trait::async_trait;
     use base_prover_service_protocol::{
-        DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest,
-        ListProofsResponse, ProofRequest, ProofRequestKind, ProofResult, ProofStatus, ProofSummary,
-        ProofType, ProveBlockRangeRequest, ProveBlockRangeResponse, ProverRequesterApiServer,
-        ZkProofRequest, ZkProofResult, ZkVm,
+        DeleteProofRequest, DeleteProofsByTeeSignerRequest, GetProofRequest, GetProofResponse,
+        ListProofsRequest, ListProofsResponse, ProofRequest, ProofRequestKind, ProofResult,
+        ProofStatus, ProofSummary, ProofType, ProveBlockRangeRequest, ProveBlockRangeResponse,
+        ProverRequesterApiServer, ZkProofRequest, ZkProofResult, ZkVm,
     };
     use base_retry::RetryConfig;
     use chrono::Utc;
@@ -284,6 +320,7 @@ mod tests {
         prove_request: Option<ProveBlockRangeRequest>,
         get_request: Option<GetProofRequest>,
         delete_request: Option<DeleteProofRequest>,
+        batch_delete_request: Option<DeleteProofsByTeeSignerRequest>,
         list_request: Option<ListProofsRequest>,
     }
 
@@ -448,6 +485,15 @@ mod tests {
             }
         }
 
+        async fn delete_proofs_by_tee_signer(
+            &self,
+            request: DeleteProofsByTeeSignerRequest,
+        ) -> RpcResult<u64> {
+            self.state.lock().expect("state lock should not be poisoned").batch_delete_request =
+                Some(request);
+            Ok(2)
+        }
+
         async fn list_proofs(&self, request: ListProofsRequest) -> RpcResult<ListProofsResponse> {
             self.state.lock().expect("state lock should not be poisoned").list_request =
                 Some(request);
@@ -514,6 +560,15 @@ mod tests {
             .await
             .expect("delete_proof_request should succeed");
 
+        let batch_delete_request = DeleteProofsByTeeSignerRequest {
+            tee_signer: "0x1111111111111111111111111111111111111111".parse().unwrap(),
+        };
+        let batch_delete_response = provider
+            .delete_proofs_by_tee_signer(batch_delete_request)
+            .await
+            .expect("delete_proofs_by_tee_signer should succeed");
+        assert_eq!(batch_delete_response, 2);
+
         let list_request =
             ListProofsRequest { offset: 7, limit: 25, status_filter: Some(ProofStatus::Succeeded) };
         let list_response =
@@ -527,6 +582,7 @@ mod tests {
             assert_eq!(state.prove_request.as_ref(), Some(&prove_request));
             assert_eq!(state.get_request.as_ref(), Some(&get_request));
             assert_eq!(state.delete_request.as_ref(), Some(&delete_request));
+            assert_eq!(state.batch_delete_request, Some(batch_delete_request));
             assert_eq!(state.list_request, Some(list_request));
         }
 

--- a/crates/proof/prover-service/db/Cargo.toml
+++ b/crates/proof/prover-service/db/Cargo.toml
@@ -29,6 +29,8 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+alloy-primitives.workspace = true
+base-proof-primitives.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]

--- a/crates/proof/prover-service/db/migrations/014_add_zk_backend.sql
+++ b/crates/proof/prover-service/db/migrations/014_add_zk_backend.sql
@@ -1,0 +1,35 @@
+-- Migration 014: Persist the ZK proving backend selected by each request.
+--
+-- Callers choose mock / dry_run / cluster / network per request. Workers claim
+-- jobs whose zk_backend is in their advertised capability list.
+BEGIN;
+
+ALTER TABLE proof_requests ADD COLUMN IF NOT EXISTS zk_backend VARCHAR(32);
+
+-- Preserve historical updated_at values while backfilling.
+ALTER TABLE proof_requests DISABLE TRIGGER update_proof_requests_updated_at;
+
+-- Existing ZK rows were always executed by cluster-configured hosts.
+UPDATE proof_requests
+SET zk_backend = COALESCE(zk_backend, 'cluster')
+WHERE api_proof_type IN ('compressed', 'snark_groth16')
+   OR (api_proof_type IS NULL AND proof_type IS NOT NULL);
+
+ALTER TABLE proof_requests ENABLE TRIGGER update_proof_requests_updated_at;
+
+-- Keep NULL equivalent to the compatibility default while legacy service
+-- binaries may still insert rows during a rolling deployment.
+CREATE INDEX IF NOT EXISTS idx_proof_requests_zk_job_claim
+ON proof_requests(
+    job_status,
+    api_proof_type,
+    zk_vm,
+    (COALESCE(zk_backend, 'cluster')),
+    start_block_number,
+    created_at
+)
+WHERE api_proof_type IN ('compressed', 'snark_groth16');
+
+COMMENT ON COLUMN proof_requests.zk_backend IS 'Protocol ZK proving backend: mock, dry_run, cluster, network.';
+
+COMMIT;

--- a/crates/proof/prover-service/db/migrations/015_rename_snark_groth16_to_plonk.sql
+++ b/crates/proof/prover-service/db/migrations/015_rename_snark_groth16_to_plonk.sql
@@ -1,0 +1,91 @@
+-- Migration 015: Hard-cutover SP1 SNARK proof type from Groth16 to PLONK.
+--
+-- Renames stored proof_type / api_proof_type labels and protocol-native JSON
+-- discriminators. Invalidates historical Groth16 SNARK receipts (bytes are not
+-- convertible) and fails affected SNARK jobs so they are not served as PLONK.
+-- Rebuilds the ZK claim index so workers can find snark_plonk jobs.
+
+BEGIN;
+
+UPDATE proof_requests
+SET proof_type = 'op_succinct_sp1_cluster_snark_plonk'
+WHERE proof_type = 'op_succinct_sp1_cluster_snark_groth16';
+
+-- Rename existing API discriminators and backfill legacy rows that still have
+-- NULL api_proof_type after migration 010 (rolling-deploy inserts). Those rows
+-- already have the renamed backend proof_type above; repository fallback would
+-- otherwise treat them as snark_plonk while leaving Groth16 receipts in place.
+UPDATE proof_requests
+SET api_proof_type = 'snark_plonk'
+WHERE api_proof_type = 'snark_groth16'
+   OR (
+        api_proof_type IS NULL
+        AND proof_type = 'op_succinct_sp1_cluster_snark_plonk'
+   );
+
+-- Rewrite protocol-native request JSON discriminators when present.
+-- jsonb::text is space-normalized (`"proof_type": "…"`), so match that form only.
+UPDATE proof_requests
+SET request_payload = replace(
+        request_payload::text,
+        '"proof_type": "snark_groth16"',
+        '"proof_type": "snark_plonk"'
+    )::jsonb
+WHERE request_payload IS NOT NULL
+  AND request_payload::text LIKE '%snark_groth16%';
+
+-- Clear Groth16 snark receipts / result payloads so nothing serves them as PLONK.
+-- Match both api_proof_type and backend proof_type so any remaining NULL-api
+-- legacy rows are covered even if the backfill above is skipped somehow.
+UPDATE proof_requests
+SET snark_receipt = NULL,
+    result_payload = NULL
+WHERE (
+        api_proof_type = 'snark_plonk'
+        OR proof_type = 'op_succinct_sp1_cluster_snark_plonk'
+    )
+  AND (snark_receipt IS NOT NULL OR result_payload IS NOT NULL);
+
+-- Fail in-flight and previously-succeeded SNARK requests whose Groth16 results
+-- were invalidated above (otherwise SUCCEEDED rows would report success with
+-- no receipt via getProof).
+UPDATE proof_requests
+SET status = 'FAILED',
+    job_status = 'FAILED',
+    error_message = 'invalidated by migration 015: SP1 SNARK hard-cutover from Groth16 to PLONK',
+    completed_at = NOW()
+WHERE (
+        api_proof_type = 'snark_plonk'
+        OR proof_type = 'op_succinct_sp1_cluster_snark_plonk'
+    )
+  AND status IN ('CREATED', 'PENDING', 'RUNNING', 'SUCCEEDED');
+
+UPDATE proof_sessions
+SET status = 'FAILED',
+    error_message = 'invalidated by migration 015: SP1 SNARK hard-cutover from Groth16 to PLONK',
+    completed_at = NOW()
+WHERE status IN ('SUBMITTING', 'RUNNING', 'COMPLETED')
+  AND proof_request_id IN (
+      SELECT id
+      FROM proof_requests
+      WHERE api_proof_type = 'snark_plonk'
+         OR proof_type = 'op_succinct_sp1_cluster_snark_plonk'
+  );
+
+-- Migration 014's claim index predicates on snark_groth16. Recreate it for
+-- snark_plonk so worker claim queries can use the purpose-built index.
+DROP INDEX IF EXISTS idx_proof_requests_zk_job_claim;
+CREATE INDEX IF NOT EXISTS idx_proof_requests_zk_job_claim
+ON proof_requests(
+    job_status,
+    api_proof_type,
+    zk_vm,
+    (COALESCE(zk_backend, 'cluster')),
+    start_block_number,
+    created_at
+)
+WHERE api_proof_type IN ('compressed', 'snark_plonk');
+
+COMMENT ON COLUMN proof_requests.api_proof_type IS 'Protocol proof type: compressed, snark_plonk, tee.';
+
+COMMIT;

--- a/crates/proof/prover-service/db/migrations/016_remove_mock_zk_backend.sql
+++ b/crates/proof/prover-service/db/migrations/016_remove_mock_zk_backend.sql
@@ -1,0 +1,30 @@
+-- Migration 016: Remove mock ZK backend; rewrite stored 'mock' values to dry_run.
+BEGIN;
+
+UPDATE proof_requests
+SET zk_backend = 'dry_run'
+WHERE zk_backend = 'mock';
+
+UPDATE proof_requests
+SET request_payload = jsonb_set(
+    request_payload,
+    '{request,payload,zk_backend}',
+    '"dry_run"'
+)
+WHERE request_payload IS NOT NULL
+  AND request_payload #>> '{request,proof_type}' = 'compressed'
+  AND request_payload #>> '{request,payload,zk_backend}' = 'mock';
+
+UPDATE proof_requests
+SET request_payload = jsonb_set(
+    request_payload,
+    '{request,payload,proof,zk_backend}',
+    '"dry_run"'
+)
+WHERE request_payload IS NOT NULL
+  AND request_payload #>> '{request,proof_type}' = 'snark_plonk'
+  AND request_payload #>> '{request,payload,proof,zk_backend}' = 'mock';
+
+COMMENT ON COLUMN proof_requests.zk_backend IS 'Protocol ZK proving backend: dry_run, cluster, network.';
+
+COMMIT;

--- a/crates/proof/prover-service/db/migrations/017_add_tee_signer.sql
+++ b/crates/proof/prover-service/db/migrations/017_add_tee_signer.sql
@@ -1,0 +1,5 @@
+ALTER TABLE proof_requests ADD COLUMN IF NOT EXISTS tee_signer TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_proof_requests_tee_signer
+ON proof_requests(tee_signer)
+WHERE tee_signer IS NOT NULL AND status = 'SUCCEEDED';

--- a/crates/proof/prover-service/db/src/conversions.rs
+++ b/crates/proof/prover-service/db/src/conversions.rs
@@ -482,7 +482,8 @@ mod tests {
                     "config_hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
                 },
                 "proposals": [],
-                "tee_kind": "aws_nitro"
+                "tee_kind": "aws_nitro",
+                "tee_signer": "0x1111111111111111111111111111111111111111"
             }
         });
         let mut req = proof_request(None);

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -633,17 +633,18 @@ impl ProofJob {
         match result {
             ProtocolProofResult::Compressed(zk) => {
                 self.check_api_proof_type(ApiProofType::Compressed)?;
-                self.check_zk_vm(ZkVmKind::from(zk.zk_vm))
+                self.check_zk_vm(ZkVmKind::from(zk.zk_vm))?;
             }
             ProtocolProofResult::SnarkGroth16(snark) => {
                 self.check_api_proof_type(ApiProofType::SnarkGroth16)?;
-                self.check_zk_vm(ZkVmKind::from(snark.proof.zk_vm))
+                self.check_zk_vm(ZkVmKind::from(snark.proof.zk_vm))?;
             }
             ProtocolProofResult::Tee(tee) => {
                 self.check_api_proof_type(ApiProofType::Tee)?;
-                self.check_tee_kind(TeeKind::from(tee.tee_kind))
+                self.check_tee_kind(TeeKind::from(tee.tee_kind))?;
             }
         }
+        Ok(())
     }
 
     fn check_api_proof_type(&self, expected: ApiProofType) -> Result<(), String> {

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -207,6 +207,7 @@ impl ProofRequestRepo {
                         stark_receipt = NULL,
                         snark_receipt = NULL,
                         result_payload = NULL,
+                        tee_signer = NULL,
                         submitted_by_worker_id = NULL,
                         submitted_lock_id = NULL,
                         completed_at = NULL,
@@ -268,7 +269,6 @@ impl ProofRequestRepo {
         }
 
         let id: Uuid = row.get("id");
-        // Outbox rows do not cascade; proof_sessions rows cascade from proof_requests.
         sqlx::query("DELETE FROM proof_request_outbox WHERE proof_request_id = $1")
             .bind(id)
             .execute(&mut *tx)
@@ -277,6 +277,40 @@ impl ProofRequestRepo {
 
         tx.commit().await?;
         Ok(DeleteProofRequestOutcome::Deleted)
+    }
+
+    /// Delete completed TEE proof requests produced by one reported signer.
+    ///
+    /// The `tee_signer` column is stored as lowercase `0x`-prefixed hex (via
+    /// `format!("{addr:#x}")`). The lookup lowercases its argument to match that
+    /// contract, so a differently-cased caller string still matches stored rows.
+    pub async fn delete_proof_requests_by_tee_signer(&self, tee_signer: &str) -> Result<u64> {
+        let tee_signer = tee_signer.to_lowercase();
+        let mut tx = self.pool.begin().await?;
+        let ids = sqlx::query_scalar::<_, Uuid>(
+            "SELECT id FROM proof_requests \
+             WHERE tee_signer = $1 AND status = 'SUCCEEDED' FOR UPDATE",
+        )
+        .bind(&tee_signer)
+        .fetch_all(&mut *tx)
+        .await?;
+
+        if ids.is_empty() {
+            return Ok(0);
+        }
+
+        sqlx::query("DELETE FROM proof_request_outbox WHERE proof_request_id = ANY($1)")
+            .bind(&ids)
+            .execute(&mut *tx)
+            .await?;
+        let deleted = sqlx::query("DELETE FROM proof_requests WHERE id = ANY($1)")
+            .bind(&ids)
+            .execute(&mut *tx)
+            .await?
+            .rows_affected();
+
+        tx.commit().await?;
+        Ok(deleted)
     }
 
     /// Get a proof request by ID
@@ -720,6 +754,10 @@ impl ProofRequestRepo {
 
         let result_payload =
             serde_json::to_value(&req.result).map_err(|e| sqlx::Error::Encode(Box::new(e)))?;
+        let tee_signer = match &req.result {
+            ProtocolProofResult::Tee(tee) => Some(format!("{:#x}", tee.tee_signer)),
+            _ => None,
+        };
 
         let (stark_receipt, snark_receipt) = compatibility_receipts_for_result(&req.result);
         let submitted_lock_id = req.lock_id.to_string();
@@ -734,6 +772,7 @@ impl ProofRequestRepo {
                 submitted_lock_id = $5,
                 stark_receipt = COALESCE($6, stark_receipt),
                 snark_receipt = COALESCE($7, snark_receipt),
+                tee_signer = $8,
                 error_message = NULL,
                 completed_at = NOW()
             WHERE COALESCE(session_id, id::text) = $1
@@ -753,6 +792,7 @@ impl ProofRequestRepo {
             .bind(&submitted_lock_id)
             .bind(&stark_receipt)
             .bind(&snark_receipt)
+            .bind(&tee_signer)
             .fetch_optional(&self.pool)
             .await?;
 
@@ -943,6 +983,7 @@ impl ProofRequestRepo {
                 stark_receipt = NULL,
                 snark_receipt = NULL,
                 result_payload = NULL,
+                tee_signer = NULL,
                 submitted_by_worker_id = NULL,
                 submitted_lock_id = NULL,
                 completed_at = NULL,

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -15,6 +15,8 @@
 
 use std::time::Duration;
 
+use alloy_primitives::Address;
+use base_proof_primitives::Proposal;
 use base_prover_service_db::{
     ApiProofType, ClaimProofJob, CompleteClaimedProofJob, CreateProofRequest,
     CreateProofRequestError, CreateProofRequestOutcome, CreateProofSession,
@@ -26,7 +28,8 @@ use base_prover_service_db::{
 use base_prover_service_protocol::{
     ProofRequest as ProtocolProofRequest, ProofRequestKind as ProtocolProofRequestKind,
     ProofResult as ProtocolProofResult, SnarkGroth16ProofRequest, SnarkGroth16ProofResult,
-    TeeKind as ProtocolTeeKind, TeeProofRequest, ZkProofRequest, ZkProofResult, ZkVm,
+    TeeKind as ProtocolTeeKind, TeeProofRequest, TeeProofResult, ZkProofRequest, ZkProofResult,
+    ZkVm,
 };
 use sqlx::{PgPool, postgres::PgPoolOptions};
 use uuid::Uuid;
@@ -1864,6 +1867,62 @@ async fn test_complete_claimed_proof_job_guards_and_stores_result() {
         repo.get(id).await.unwrap().unwrap().stark_receipt.as_deref(),
         Some(&[0xca, 0xfe][..])
     );
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_delete_proof_requests_by_tee_signer() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+    let signer = "0x1111111111111111111111111111111111111111";
+    let other_signer = "0x2222222222222222222222222222222222222222";
+
+    drain_claimable_tee_jobs(&repo).await;
+    let mut ids = Vec::new();
+    for submitted_signer in [signer, signer, other_signer] {
+        let id = repo.create(tee_request()).await.unwrap();
+        let claimed = repo
+            .claim_next_proof_job(tee_claim("batch-delete-worker", 3))
+            .await
+            .unwrap()
+            .expect("TEE job should be claimed");
+        assert_eq!(claimed.id, id);
+        let outcome = repo
+            .complete_claimed_proof_job(CompleteClaimedProofJob {
+                session_id: claimed.session_id,
+                lock_id: claimed.lock_id.expect("claimed job has lock"),
+                worker_id: "batch-delete-worker".to_owned(),
+                result: ProtocolProofResult::Tee(TeeProofResult {
+                    aggregate_proposal: Proposal {
+                        output_root: Default::default(),
+                        signature: Default::default(),
+                        l1_origin_hash: Default::default(),
+                        l1_origin_number: 0,
+                        l2_block_number: 0,
+                        prev_output_root: Default::default(),
+                        config_hash: Default::default(),
+                    },
+                    proposals: vec![],
+                    tee_kind: ProtocolTeeKind::AwsNitro,
+                    tee_signer: submitted_signer.parse().unwrap(),
+                }),
+            })
+            .await
+            .unwrap();
+        assert!(matches!(outcome, SubmitProofOutcome::Completed(_)));
+        ids.push(id);
+    }
+
+    assert_eq!(repo.delete_proof_requests_by_tee_signer(signer).await.unwrap(), 2);
+    assert!(repo.get(ids[0]).await.unwrap().is_none());
+    assert!(repo.get(ids[1]).await.unwrap().is_none());
+    let result: ProtocolProofResult =
+        serde_json::from_value(repo.get(ids[2]).await.unwrap().unwrap().result_payload.unwrap())
+            .unwrap();
+    let ProtocolProofResult::Tee(result) = result else { panic!("expected TEE proof") };
+    assert_eq!(result.tee_signer, other_signer.parse::<Address>().unwrap());
+
+    assert_eq!(repo.delete_proof_requests_by_tee_signer(other_signer).await.unwrap(), 1);
 }
 
 #[tokio::test]

--- a/crates/proof/prover-service/protocol/src/api.rs
+++ b/crates/proof/prover-service/protocol/src/api.rs
@@ -3,11 +3,11 @@
 use jsonrpsee::proc_macros::rpc;
 
 use crate::{
-    DeleteProofRequest, GetNextProofRequest, GetNextProofResponse, GetProofRequest,
-    GetProofResponse, GetProofSessionRequest, GetProofSessionResponse, HeartbeatRequest,
-    HeartbeatResponse, ListProofsRequest, ListProofsResponse, ProveBlockRangeRequest,
-    ProveBlockRangeResponse, RecordProofSessionRequest, RecordProofSessionResponse,
-    WorkerSubmitProofRequest, WorkerSubmitProofResponse,
+    DeleteProofRequest, DeleteProofsByTeeSignerRequest, GetNextProofRequest, GetNextProofResponse,
+    GetProofRequest, GetProofResponse, GetProofSessionRequest, GetProofSessionResponse,
+    HeartbeatRequest, HeartbeatResponse, ListProofsRequest, ListProofsResponse,
+    ProveBlockRangeRequest, ProveBlockRangeResponse, RecordProofSessionRequest,
+    RecordProofSessionResponse, WorkerSubmitProofRequest, WorkerSubmitProofResponse,
 };
 
 #[cfg_attr(
@@ -44,6 +44,13 @@ pub trait ProverRequesterApi {
         &self,
         request: DeleteProofRequest,
     ) -> jsonrpsee::core::RpcResult<()>;
+
+    /// Delete completed TEE proof requests produced by one signer.
+    #[method(name = "deleteProofsByTeeSigner")]
+    async fn delete_proofs_by_tee_signer(
+        &self,
+        request: DeleteProofsByTeeSignerRequest,
+    ) -> jsonrpsee::core::RpcResult<u64>;
 
     /// List submitted proof requests.
     #[method(name = "listProofs")]

--- a/crates/proof/prover-service/protocol/src/lib.rs
+++ b/crates/proof/prover-service/protocol/src/lib.rs
@@ -12,13 +12,13 @@ pub use session::ProofSessionId;
 
 mod types;
 pub use types::{
-    BackendSession, BackendSessionState, DeleteProofRequest, ExecutionStats, GetNextProofRequest,
-    GetNextProofResponse, GetProofRequest, GetProofResponse, GetProofSessionRequest,
-    GetProofSessionResponse, HeartbeatRequest, HeartbeatResponse, ListProofsRequest,
-    ListProofsResponse, PROOF_REQUEST_NOT_FOUND_MESSAGE, ProofJob, ProofJobStatus, ProofRequest,
-    ProofRequestIdCollisionMessage, ProofRequestKind, ProofResult, ProofStatus, ProofSummary,
-    ProofType, ProveBlockRangeRequest, ProveBlockRangeResponse, RecordProofSessionRequest,
-    RecordProofSessionResponse, SessionType, SnarkGroth16ProofRequest, SnarkGroth16ProofResult,
-    TeeKind, TeeProofRequest, TeeProofResult, WorkerSubmitProofRequest, WorkerSubmitProofResponse,
-    ZkProofRequest, ZkProofResult, ZkVm,
+    BackendSession, BackendSessionState, DeleteProofRequest, DeleteProofsByTeeSignerRequest,
+    ExecutionStats, GetNextProofRequest, GetNextProofResponse, GetProofRequest, GetProofResponse,
+    GetProofSessionRequest, GetProofSessionResponse, HeartbeatRequest, HeartbeatResponse,
+    ListProofsRequest, ListProofsResponse, PROOF_REQUEST_NOT_FOUND_MESSAGE, ProofJob,
+    ProofJobStatus, ProofRequest, ProofRequestIdCollisionMessage, ProofRequestKind, ProofResult,
+    ProofStatus, ProofSummary, ProofType, ProveBlockRangeRequest, ProveBlockRangeResponse,
+    RecordProofSessionRequest, RecordProofSessionResponse, SessionType, SnarkGroth16ProofRequest,
+    SnarkGroth16ProofResult, TeeKind, TeeProofRequest, TeeProofResult, WorkerSubmitProofRequest,
+    WorkerSubmitProofResponse, ZkProofRequest, ZkProofResult, ZkVm,
 };

--- a/crates/proof/prover-service/protocol/src/types.rs
+++ b/crates/proof/prover-service/protocol/src/types.rs
@@ -98,6 +98,13 @@ pub struct DeleteProofRequest {
     pub session_id: String,
 }
 
+/// Request to delete completed TEE proofs produced by one signer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeleteProofsByTeeSignerRequest {
+    /// TEE signer whose completed proof requests should be deleted.
+    pub tee_signer: Address,
+}
+
 /// Submitted proof request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProofRequest {
@@ -212,6 +219,9 @@ pub struct TeeProofResult {
     pub proposals: Vec<Proposal>,
     /// Trusted execution environment implementation that produced the proof.
     pub tee_kind: TeeKind,
+    /// Signer that produced the proof, recovered host-side from the proof
+    /// signature.
+    pub tee_signer: Address,
 }
 
 /// Request to fetch proof status and result data.
@@ -461,7 +471,7 @@ pub struct RecordProofSessionResponse {
 mod tests {
     use std::collections::HashMap;
 
-    use alloy_primitives::{Bytes, address};
+    use alloy_primitives::{Address, Bytes, address};
     use serde_json::json;
 
     use super::*;
@@ -646,6 +656,7 @@ mod tests {
             aggregate_proposal: aggregate_proposal.clone(),
             proposals: vec![proposal.clone()],
             tee_kind: TeeKind::AwsNitro,
+            tee_signer: Address::repeat_byte(0x11),
         });
 
         let value = serde_json::to_value(result).expect("tee result should serialize");
@@ -765,6 +776,7 @@ mod tests {
             aggregate_proposal: aggregate_proposal.clone(),
             proposals: vec![proposal.clone()],
             tee_kind: TeeKind::AwsNitro,
+            tee_signer: Address::repeat_byte(0x11),
         };
 
         let value = serde_json::to_value(result).expect("tee result payload should serialize");

--- a/crates/proof/prover-service/src/server/delete_proof_request.rs
+++ b/crates/proof/prover-service/src/server/delete_proof_request.rs
@@ -1,5 +1,5 @@
 use base_prover_service_db::{DeleteProofRequestOutcome, canonical_session_id};
-use base_prover_service_protocol::DeleteProofRequest;
+use base_prover_service_protocol::{DeleteProofRequest, DeleteProofsByTeeSignerRequest};
 use jsonrpsee::core::RpcResult;
 use tracing::info;
 
@@ -34,5 +34,33 @@ impl ProverServiceServer {
             }
             Err(e) => Err(internal(format!("Database error: {e}"))),
         }
+    }
+
+    /// Deletes completed TEE proof requests produced by one signer.
+    pub async fn delete_proofs_by_tee_signer_impl(
+        &self,
+        request: DeleteProofsByTeeSignerRequest,
+    ) -> RpcResult<u64> {
+        let start = std::time::Instant::now();
+        let result = self.delete_proofs_by_tee_signer_inner(request).await;
+        record_rpc_result("DeleteProofsByTeeSigner", start, &result);
+        result
+    }
+
+    async fn delete_proofs_by_tee_signer_inner(
+        &self,
+        request: DeleteProofsByTeeSignerRequest,
+    ) -> RpcResult<u64> {
+        if request.tee_signer.is_zero() {
+            return Err(invalid_argument("tee_signer must not be zero"));
+        }
+        let tee_signer = format!("{:#x}", request.tee_signer);
+        let deleted_count = self
+            .repo
+            .delete_proof_requests_by_tee_signer(&tee_signer)
+            .await
+            .map_err(|error| internal(format!("Database error: {error}")))?;
+        info!(tee_signer = %request.tee_signer, deleted_count, "Deleted TEE proofs by signer");
+        Ok(deleted_count)
     }
 }

--- a/crates/proof/prover-service/src/server/get_proof.rs
+++ b/crates/proof/prover-service/src/server/get_proof.rs
@@ -87,7 +87,6 @@ impl ProverServiceServer {
             .map_err(|e| internal(format!("Database error: {e}")))?
             .ok_or_else(|| not_found(PROOF_REQUEST_NOT_FOUND_MESSAGE))?;
         let proof_request_id = proof_req.id;
-
         info!(
             proof_request_id = %proof_request_id,
             session_id = %proof_req.session_id,

--- a/crates/proof/prover-service/src/server/mod.rs
+++ b/crates/proof/prover-service/src/server/mod.rs
@@ -4,8 +4,9 @@ use std::fmt;
 
 use base_prover_service_db::ProofRequestRepo;
 use base_prover_service_protocol::{
-    DeleteProofRequest, GetProofRequest, GetProofResponse, ListProofsRequest, ListProofsResponse,
-    ProveBlockRangeRequest, ProveBlockRangeResponse, ProverRequesterApiServer,
+    DeleteProofRequest, DeleteProofsByTeeSignerRequest, GetProofRequest, GetProofResponse,
+    ListProofsRequest, ListProofsResponse, ProveBlockRangeRequest, ProveBlockRangeResponse,
+    ProverRequesterApiServer,
 };
 use jsonrpsee::{
     core::{RpcResult, async_trait},
@@ -104,6 +105,13 @@ impl ProverRequesterApiServer for ProverServiceServer {
 
     async fn delete_proof_request(&self, request: DeleteProofRequest) -> RpcResult<()> {
         self.delete_proof_request_impl(request).await
+    }
+
+    async fn delete_proofs_by_tee_signer(
+        &self,
+        request: DeleteProofsByTeeSignerRequest,
+    ) -> RpcResult<u64> {
+        self.delete_proofs_by_tee_signer_impl(request).await
     }
 
     async fn list_proofs(&self, request: ListProofsRequest) -> RpcResult<ListProofsResponse> {

--- a/crates/proof/tee/nitro-host/Cargo.toml
+++ b/crates/proof/tee/nitro-host/Cargo.toml
@@ -47,6 +47,7 @@ tokio-vsock.workspace = true
 chrono.workspace = true
 reqwest.workspace = true
 alloy-genesis.workspace = true
+alloy-signer-local.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
 base-common-genesis = { workspace = true, features = ["serde", "std"] }
 

--- a/crates/proof/tee/nitro-host/src/error.rs
+++ b/crates/proof/tee/nitro-host/src/error.rs
@@ -33,6 +33,9 @@ pub enum NitroHostError {
     /// The signer public key returned by the enclave is malformed.
     #[error("invalid signer public key: expected 65-byte uncompressed SEC1 key")]
     InvalidSignerKey,
+    /// A proposal could not be used to recover its signer.
+    #[error("cannot recover signer from proposal: {0}")]
+    SignerRecovery(String),
     /// A response-read timed out (distinct from connect timeout).
     #[error("{operation} timed out")]
     ResponseTimeout {

--- a/crates/proof/tee/nitro-host/src/lib.rs
+++ b/crates/proof/tee/nitro-host/src/lib.rs
@@ -22,6 +22,9 @@ pub use registration::{RegistrationChecker, RegistrationError, ValidSigner};
 mod proof_submitter;
 pub use proof_submitter::{ProofSubmitter, ProofSubmitterError, ProofSubmitterRequest};
 
+mod signer_recovery;
+pub use signer_recovery::TeeSignerRecovery;
+
 mod proof_generator;
 pub use proof_generator::{
     DEFAULT_PROOF_GENERATOR_HEARTBEAT_INTERVAL,

--- a/crates/proof/tee/nitro-host/src/pool.rs
+++ b/crates/proof/tee/nitro-host/src/pool.rs
@@ -207,10 +207,8 @@ mod tests {
     use std::collections::HashMap;
 
     use alloy_genesis::ChainConfig;
-    use alloy_signer::utils::public_key_to_address;
     use base_common_genesis::RollupConfig;
     use base_proof_tee_nitro_enclave::Server as EnclaveServer;
-    use k256::ecdsa::VerifyingKey;
 
     use super::*;
     use crate::test_utils::AddressBasedMockRegistry;
@@ -234,9 +232,7 @@ mod tests {
     }
 
     async fn signer_for(transport: &NitroTransport) -> alloy_primitives::Address {
-        let pk = transport.signer_public_key().await.unwrap();
-        let vk = VerifyingKey::from_sec1_bytes(&pk).unwrap();
-        public_key_to_address(&vk)
+        transport.signer_address().await.unwrap()
     }
 
     #[tokio::test]

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -217,6 +217,8 @@ where
             request.lock_id.clone(),
             request.worker_id.clone(),
             proof,
+            request.proof.proposer,
+            request.proof.image_hash,
         )
         .map_err(|source| ProofGeneratorError::BuildSubmission {
             session_id: request.session_id.clone(),

--- a/crates/proof/tee/nitro-host/src/proof_submitter.rs
+++ b/crates/proof/tee/nitro-host/src/proof_submitter.rs
@@ -1,5 +1,6 @@
 //! Async proof submission task for prover-service worker delivery.
 
+use alloy_primitives::{Address, B256};
 use base_proof_primitives::ProofResult as NitroProofResult;
 use base_prover_service_client::{ProverServiceClientError, ProverWorkerProvider};
 use base_prover_service_protocol::{
@@ -11,12 +12,20 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
+use crate::{NitroHostError, TeeSignerRecovery};
+
 /// Errors raised while preparing or submitting a generated proof.
 #[derive(Debug, Error)]
 pub enum ProofSubmitterError {
     /// Nitro proof submitter only submits TEE proof results.
     #[error("nitro proof submitter only accepts TEE proof results")]
     UnsupportedProofResult,
+    /// A TEE proof result carried no proposals to recover the signer from.
+    #[error("tee proof result contained no proposals")]
+    MissingProposals,
+    /// The enclave signer could not be recovered from the proof signature.
+    #[error(transparent)]
+    SignerRecovery(#[from] NitroHostError),
     /// Proof submission was cancelled before it started.
     #[error("proof submission cancelled before it started")]
     Cancelled,
@@ -31,15 +40,32 @@ pub struct ProofSubmitterRequest;
 
 impl ProofSubmitterRequest {
     /// Builds a worker proof submission request from a generated Nitro TEE proof.
+    ///
+    /// The enclave signer is recovered host-side from the first per-block
+    /// proposal's signature, using `proposer` and `tee_image_hash` from the
+    /// originating proof request to reconstruct the signed journal. This is the
+    /// exact key that signed the proof, so it cannot drift from a concurrent
+    /// enclave restart the way a separate signer query could.
+    ///
+    /// Relies on the invariant that a TEE proof always carries at least one
+    /// per-block proposal (the enclave rejects empty proposal sets); an empty
+    /// set yields [`ProofSubmitterError::MissingProposals`] rather than falling
+    /// back to the aggregate.
     pub fn from_tee_proof(
         session_id: String,
         lock_id: String,
         worker_id: String,
         proof: NitroProofResult,
+        proposer: Address,
+        tee_image_hash: B256,
     ) -> Result<WorkerSubmitProofRequest, ProofSubmitterError> {
         let NitroProofResult::Tee { aggregate_proposal, proposals } = proof else {
             return Err(ProofSubmitterError::UnsupportedProofResult);
         };
+
+        let signer_proposal = proposals.first().ok_or(ProofSubmitterError::MissingProposals)?;
+        let tee_signer =
+            TeeSignerRecovery::recover_from_proposal(signer_proposal, proposer, tee_image_hash)?;
 
         Ok(WorkerSubmitProofRequest {
             session_id,
@@ -49,6 +75,7 @@ impl ProofSubmitterRequest {
                 aggregate_proposal,
                 proposals,
                 tee_kind: TeeKind::AwsNitro,
+                tee_signer,
             }),
         })
     }
@@ -148,9 +175,11 @@ mod tests {
         time::Duration,
     };
 
-    use alloy_primitives::{B256, Bytes};
+    use alloy_primitives::{Address, B256, Bytes, keccak256};
+    use alloy_signer::SignerSync;
+    use alloy_signer_local::PrivateKeySigner;
     use async_trait::async_trait;
-    use base_proof_primitives::{ProofRequest as PrimitiveProofRequest, Proposal};
+    use base_proof_primitives::{ProofJournal, ProofRequest as PrimitiveProofRequest, Proposal};
     use base_prover_service_protocol::{
         GetNextProofRequest, GetNextProofResponse, GetProofSessionRequest, GetProofSessionResponse,
         HeartbeatRequest, HeartbeatResponse, ProofJob, ProofJobStatus, ProofRequest,
@@ -255,22 +284,40 @@ mod tests {
         }
     }
 
-    fn proposal(block: u64) -> Proposal {
-        Proposal {
+    const PROPOSER: Address = Address::repeat_byte(0x22);
+    const TEE_IMAGE_HASH: B256 = B256::repeat_byte(0x33);
+
+    fn proposal(signer: &PrivateKeySigner, block: u64) -> Proposal {
+        let mut proposal = Proposal {
             output_root: B256::repeat_byte(1),
-            signature: Bytes::from(vec![0xab; 65]),
+            signature: Bytes::new(),
             l1_origin_hash: B256::repeat_byte(2),
             l1_origin_number: block.saturating_sub(1),
             l2_block_number: block,
             prev_output_root: B256::repeat_byte(3),
             config_hash: B256::repeat_byte(4),
-        }
+        };
+
+        let journal = ProofJournal {
+            proposer: PROPOSER,
+            l1_origin_hash: proposal.l1_origin_hash,
+            prev_output_root: proposal.prev_output_root,
+            starting_l2_block: block - 1,
+            output_root: proposal.output_root,
+            ending_l2_block: block,
+            intermediate_roots: Vec::new(),
+            config_hash: proposal.config_hash,
+            tee_image_hash: TEE_IMAGE_HASH,
+        };
+        let signature = signer.sign_hash_sync(&keccak256(journal.encode())).unwrap();
+        proposal.signature = Bytes::from(signature.as_rsy().to_vec());
+        proposal
     }
 
-    fn nitro_tee_proof() -> NitroProofResult {
+    fn nitro_tee_proof(signer: &PrivateKeySigner) -> NitroProofResult {
         NitroProofResult::Tee {
-            aggregate_proposal: proposal(10),
-            proposals: vec![proposal(8), proposal(9), proposal(10)],
+            aggregate_proposal: proposal(signer, 10),
+            proposals: vec![proposal(signer, 8), proposal(signer, 9), proposal(signer, 10)],
         }
     }
 
@@ -279,7 +326,9 @@ mod tests {
             "session-1".to_string(),
             "lock-1".to_string(),
             "worker-1".to_string(),
-            nitro_tee_proof(),
+            nitro_tee_proof(&PrivateKeySigner::random()),
+            PROPOSER,
+            TEE_IMAGE_HASH,
         )
         .expect("tee proof should build a submission request")
     }
@@ -319,8 +368,17 @@ mod tests {
     }
 
     #[test]
-    fn tee_proof_request_wraps_nitro_result_for_worker_api() {
-        let request = submit_request();
+    fn tee_proof_request_recovers_signer_from_proposal() {
+        let signer = PrivateKeySigner::random();
+        let request = ProofSubmitterRequest::from_tee_proof(
+            "session-1".to_string(),
+            "lock-1".to_string(),
+            "worker-1".to_string(),
+            nitro_tee_proof(&signer),
+            PROPOSER,
+            TEE_IMAGE_HASH,
+        )
+        .expect("tee proof should build a submission request");
 
         assert_eq!(request.session_id, "session-1");
         assert_eq!(request.lock_id, "lock-1");
@@ -328,6 +386,7 @@ mod tests {
         let ServiceProofResult::Tee(result) = request.result else {
             panic!("expected tee proof result");
         };
+        assert_eq!(result.tee_signer, signer.address());
         assert_eq!(result.tee_kind, TeeKind::AwsNitro);
         assert_eq!(result.aggregate_proposal.l2_block_number, 10);
         assert_eq!(result.proposals.len(), 3);
@@ -340,6 +399,8 @@ mod tests {
             "lock-1".to_string(),
             "worker-1".to_string(),
             NitroProofResult::Zk { proof_bytes: vec![1, 2, 3] },
+            PROPOSER,
+            TEE_IMAGE_HASH,
         );
 
         assert!(matches!(result, Err(ProofSubmitterError::UnsupportedProofResult)));

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -19,9 +19,7 @@
 use std::{sync::Arc, time::Duration};
 
 use alloy_primitives::Address;
-use alloy_signer::utils::public_key_to_address;
 use base_proof_contracts::{TEEProverRegistryClient, TEEProverRegistryContractClient};
-use k256::ecdsa::VerifyingKey;
 use thiserror::Error;
 use tokio::sync::OnceCell;
 use tracing::warn;
@@ -130,13 +128,10 @@ impl RegistrationChecker {
     }
 
     async fn signer_address(transport: &NitroTransport) -> Result<Address, RegistrationError> {
-        let public_key = transport
-            .signer_public_key()
+        transport
+            .signer_address()
             .await
-            .map_err(|e| RegistrationError::Setup(format!("signer public key: {e}")))?;
-        let verifying_key = VerifyingKey::from_sec1_bytes(&public_key)
-            .map_err(|e| RegistrationError::Setup(format!("invalid public key: {e}")))?;
-        Ok(public_key_to_address(&verifying_key))
+            .map_err(|e| RegistrationError::Setup(format!("signer public key: {e}")))
     }
 
     async fn is_valid_signer(&self, signer: Address) -> Result<bool, RegistrationError> {
@@ -301,9 +296,7 @@ mod tests {
     }
 
     async fn transport_signer_address(transport: &NitroTransport) -> Address {
-        let pk = transport.signer_public_key().await.unwrap();
-        let vk = VerifyingKey::from_sec1_bytes(&pk).unwrap();
-        public_key_to_address(&vk)
+        transport.signer_address().await.unwrap()
     }
 
     async fn two_transport_signers(checker: &RegistrationChecker) -> (Address, Address) {

--- a/crates/proof/tee/nitro-host/src/signer_recovery.rs
+++ b/crates/proof/tee/nitro-host/src/signer_recovery.rs
@@ -1,0 +1,180 @@
+//! Host-side recovery of the enclave signer from a generated TEE proof.
+//!
+//! The enclave signs each per-block [`Proposal`] over the keccak256 of its
+//! encoded [`ProofJournal`]. Rather than querying the enclave for its signer in
+//! a separate round-trip (which could observe a different key after a restart),
+//! the host recovers the signer directly from the proof's own signature. The
+//! recovered address is therefore guaranteed to be the exact key that signed
+//! the proof.
+
+use alloy_primitives::{Address, B256, keccak256};
+use alloy_signer::utils::public_key_to_address;
+use base_proof_primitives::{ECDSA_SIGNATURE_LENGTH, ProofJournal, Proposal};
+use k256::ecdsa::{RecoveryId, Signature, VerifyingKey};
+
+use crate::NitroHostError;
+
+/// Recovers the enclave signer address from a signed proposal.
+#[derive(Debug)]
+pub struct TeeSignerRecovery;
+
+impl TeeSignerRecovery {
+    /// Recover the signer of a per-block [`Proposal`].
+    ///
+    /// `proposer` and `tee_image_hash` are the two [`ProofJournal`] fields not
+    /// carried on the proposal; the host supplies them from the originating
+    /// proof request. The proposal must be a per-block proposal (empty
+    /// intermediate roots), matching how the enclave signs each block.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NitroHostError::SignerRecovery`] if the block number is zero,
+    /// the signature is malformed, or the public key cannot be recovered.
+    pub fn recover_from_proposal(
+        proposal: &Proposal,
+        proposer: Address,
+        tee_image_hash: B256,
+    ) -> Result<Address, NitroHostError> {
+        let starting_l2_block = proposal.l2_block_number.checked_sub(1).ok_or_else(|| {
+            NitroHostError::SignerRecovery("proposal l2_block_number is 0".to_owned())
+        })?;
+
+        let journal = ProofJournal {
+            proposer,
+            l1_origin_hash: proposal.l1_origin_hash,
+            prev_output_root: proposal.prev_output_root,
+            starting_l2_block,
+            output_root: proposal.output_root,
+            ending_l2_block: proposal.l2_block_number,
+            intermediate_roots: Vec::new(),
+            config_hash: proposal.config_hash,
+            tee_image_hash,
+        };
+        let digest = keccak256(journal.encode());
+
+        if proposal.signature.len() != ECDSA_SIGNATURE_LENGTH {
+            return Err(NitroHostError::SignerRecovery(format!(
+                "expected {ECDSA_SIGNATURE_LENGTH}-byte signature, got {}",
+                proposal.signature.len()
+            )));
+        }
+        let signature = Signature::from_slice(&proposal.signature[..64])
+            .map_err(|e| NitroHostError::SignerRecovery(format!("invalid signature: {e}")))?;
+        let recovery_id = RecoveryId::from_byte(proposal.signature[64]).ok_or_else(|| {
+            NitroHostError::SignerRecovery(format!(
+                "invalid recovery id {}",
+                proposal.signature[64]
+            ))
+        })?;
+
+        let verifying_key =
+            VerifyingKey::recover_from_prehash(digest.as_slice(), &signature, recovery_id)
+                .map_err(|e| NitroHostError::SignerRecovery(format!("recovery failed: {e}")))?;
+        Ok(public_key_to_address(&verifying_key))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::Bytes;
+    use alloy_signer::SignerSync;
+    use alloy_signer_local::PrivateKeySigner;
+
+    use super::*;
+
+    fn signed_proposal(
+        signer: &PrivateKeySigner,
+        proposer: Address,
+        tee_image_hash: B256,
+    ) -> Proposal {
+        let mut proposal = Proposal {
+            output_root: B256::repeat_byte(0xaa),
+            signature: Bytes::new(),
+            l1_origin_hash: B256::repeat_byte(0xbb),
+            l1_origin_number: 100,
+            l2_block_number: 42,
+            prev_output_root: B256::repeat_byte(0xcc),
+            config_hash: B256::repeat_byte(0xdd),
+        };
+
+        let journal = ProofJournal {
+            proposer,
+            l1_origin_hash: proposal.l1_origin_hash,
+            prev_output_root: proposal.prev_output_root,
+            starting_l2_block: proposal.l2_block_number - 1,
+            output_root: proposal.output_root,
+            ending_l2_block: proposal.l2_block_number,
+            intermediate_roots: Vec::new(),
+            config_hash: proposal.config_hash,
+            tee_image_hash,
+        };
+        let signature = signer.sign_hash_sync(&keccak256(journal.encode())).unwrap();
+        proposal.signature = Bytes::from(signature.as_rsy().to_vec());
+        proposal
+    }
+
+    #[test]
+    fn recovers_the_signing_address() {
+        let signer = PrivateKeySigner::random();
+        let proposer = Address::repeat_byte(0x11);
+        let tee_image_hash = B256::repeat_byte(0x22);
+
+        let proposal = signed_proposal(&signer, proposer, tee_image_hash);
+        let recovered =
+            TeeSignerRecovery::recover_from_proposal(&proposal, proposer, tee_image_hash).unwrap();
+
+        assert_eq!(recovered, signer.address());
+    }
+
+    #[test]
+    fn wrong_context_recovers_a_different_address() {
+        let signer = PrivateKeySigner::random();
+        let proposer = Address::repeat_byte(0x11);
+        let tee_image_hash = B256::repeat_byte(0x22);
+
+        let proposal = signed_proposal(&signer, proposer, tee_image_hash);
+        // Recovering with a mismatched image hash yields some other address, never the signer.
+        let recovered =
+            TeeSignerRecovery::recover_from_proposal(&proposal, proposer, B256::repeat_byte(0x33))
+                .unwrap();
+
+        assert_ne!(recovered, signer.address());
+    }
+
+    #[test]
+    fn malformed_signature_is_rejected() {
+        let proposal = Proposal {
+            output_root: B256::ZERO,
+            signature: Bytes::from(vec![0u8; 10]),
+            l1_origin_hash: B256::ZERO,
+            l1_origin_number: 0,
+            l2_block_number: 1,
+            prev_output_root: B256::ZERO,
+            config_hash: B256::ZERO,
+        };
+
+        assert!(matches!(
+            TeeSignerRecovery::recover_from_proposal(&proposal, Address::ZERO, B256::ZERO),
+            Err(NitroHostError::SignerRecovery(_))
+        ));
+    }
+
+    #[test]
+    fn zero_block_number_is_rejected_with_specific_error() {
+        let proposal = Proposal {
+            output_root: B256::ZERO,
+            signature: Bytes::from(vec![0u8; ECDSA_SIGNATURE_LENGTH]),
+            l1_origin_hash: B256::ZERO,
+            l1_origin_number: 0,
+            l2_block_number: 0,
+            prev_output_root: B256::ZERO,
+            config_hash: B256::ZERO,
+        };
+
+        let err = TeeSignerRecovery::recover_from_proposal(&proposal, Address::ZERO, B256::ZERO)
+            .unwrap_err();
+        assert!(
+            matches!(&err, NitroHostError::SignerRecovery(msg) if msg.contains("l2_block_number is 0"))
+        );
+    }
+}

--- a/crates/proof/tee/nitro-host/src/transport.rs
+++ b/crates/proof/tee/nitro-host/src/transport.rs
@@ -1,9 +1,12 @@
 use std::sync::Arc;
 
+use alloy_primitives::Address;
+use alloy_signer::utils::public_key_to_address;
 use base_proof_host::Metrics;
 use base_proof_preimage::PreimageKey;
 use base_proof_primitives::ProofResult;
 use base_proof_tee_nitro_enclave::Server;
+use k256::ecdsa::VerifyingKey;
 
 #[cfg(target_os = "linux")]
 use super::vsock::VsockTransport;
@@ -55,6 +58,14 @@ impl NitroTransport {
             Self::Vsock(t) => t.signer_public_key().await,
             Self::Local(s) => Ok(s.signer_public_key()),
         }
+    }
+
+    /// Return the Ethereum address of the enclave signer.
+    pub async fn signer_address(&self) -> Result<Address, NitroHostError> {
+        let key = self.signer_public_key().await?;
+        let key =
+            VerifyingKey::from_sec1_bytes(&key).map_err(|_| NitroHostError::InvalidSignerKey)?;
+        Ok(public_key_to_address(&key))
     }
 
     /// Return the raw Nitro attestation document (`COSE_Sign1` bytes) for the enclave signer.

--- a/crates/proof/zk/host/src/proof_submitter.rs
+++ b/crates/proof/zk/host/src/proof_submitter.rs
@@ -80,6 +80,7 @@ mod tests {
             aggregate_proposal: proposal(),
             proposals: vec![proposal()],
             tee_kind: TeeKind::AwsNitro,
+            tee_signer: alloy_primitives::Address::repeat_byte(0x11),
         });
 
         let result = WorkerSubmitProofRequest::try_from(ProofSubmitterRequest {


### PR DESCRIPTION
## What changed?

Cherry-pick of base/base#4129 (`416185dc2064cc487befc563c08b2f02b74202d8`) onto `feat/pre-dynamic-upgrade-nitro-host-new` for the zeronet proposer, prover-service, and nitro-host deploys.

- Adds host-side TEE signer recovery and carries `tee_signer` through prover-service.
- Adds the atomic `deleteProofsByTeeSigner` RPC and proposer batch-delete consumer.
- Intentionally excludes `schedule_id` from proposer, prover-service, shared proof primitives, and nitro-host.
- Keeps the pre-dynamic-upgrade `ProofJournal` format used by this branch:
  `... || configHash || teeImageHash`.
- Keeps this branch's existing `SnarkGroth16` naming; unrelated mainline ZK backend renames remain out of scope.
- Drops the unrelated basectl mock change because that file does not exist on the target branch.

All three services must deploy from this same backport commit. Mixing this branch's nitro-host with schedule-aware mainline proposer/prover-service changes the ECDSA recovery digest and produces mismatched signer addresses.

## Verification

Confirmed there are no `schedule_id` or `scheduleId` references under:

- `crates/proof/proposer`
- `crates/proof/prover-service`
- `crates/proof/tee/nitro-host`
- `crates/proof/primitives`

Passed:

```sh
cargo test --locked \
  -p base-proposer \
  -p base-prover-service \
  -p base-prover-service-db \
  -p base-prover-service-protocol \
  -p base-proof-tee-nitro-host \
  --lib
```

Results: 208 tests passed (69 nitro-host, 58 proposer, 29 prover-service, 33 DB, 19 protocol).

## Change management

type=nonroutine
risk=high
impact=sev3

## Backwards Compatibility

backwards_compatible=false

## automerge

automerge=false
