### PR TITLE
perf(docker): add base-slim image for faster local/devnet builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -89,7 +89,7 @@ jobs:
   warm-devnet-cache:
     strategy:
       matrix:
-        target: [base, execution, consensus, builder, batcher]
+        target: [base-slim, execution, consensus, builder, batcher]
 
     runs-on: ubuntu-24.04
 

--- a/etc/docker/Dockerfile.rust-services
+++ b/etc/docker/Dockerfile.rust-services
@@ -42,7 +42,7 @@ FROM source AS base-builder
 ARG PROFILE=release
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=base-target,sharing=locked \
+    --mount=type=cache,target=/app/target,id=rust-target,sharing=locked \
     cargo build --profile $PROFILE --package base --bin base && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base /app/base
 
@@ -50,7 +50,7 @@ FROM source AS execution-builder
 ARG PROFILE=release
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=execution-target,sharing=locked \
+    --mount=type=cache,target=/app/target,id=rust-target,sharing=locked \
     cargo build --profile $PROFILE --package base-reth-node --bin base-reth-node && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-reth-node /app/base-reth-node
 
@@ -58,7 +58,7 @@ FROM source AS consensus-builder
 ARG PROFILE=release
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=consensus-target,sharing=locked \
+    --mount=type=cache,target=/app/target,id=rust-target,sharing=locked \
     cargo build --profile $PROFILE --package base-consensus --bin base-consensus && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-consensus /app/base-consensus
 
@@ -66,7 +66,7 @@ FROM source AS builder-builder
 ARG PROFILE=release
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=builder-target,sharing=locked \
+    --mount=type=cache,target=/app/target,id=rust-target,sharing=locked \
     cargo build --profile $PROFILE --package base-builder-bin --bin base-builder && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-builder /app/base-builder
 
@@ -74,7 +74,7 @@ FROM source AS basectl-builder
 ARG PROFILE=release
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=basectl-target,sharing=locked \
+    --mount=type=cache,target=/app/target,id=rust-target,sharing=locked \
     cargo build --profile $PROFILE --package basectl --bin basectl && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/basectl /app/basectl
 
@@ -82,7 +82,7 @@ FROM source AS snapshotter-builder
 ARG PROFILE=release
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=snapshotter-target,sharing=locked \
+    --mount=type=cache,target=/app/target,id=rust-target,sharing=locked \
     cargo build --profile $PROFILE --package base-snapshotter-bin --bin snapshotter && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/snapshotter /app/snapshotter
 
@@ -90,7 +90,7 @@ FROM source AS proposer-builder
 ARG PROFILE=release
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=proposer-target,sharing=locked \
+    --mount=type=cache,target=/app/target,id=rust-target,sharing=locked \
     cargo build --profile $PROFILE --package base-proposer-bin --bin base-proposer && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-proposer /app/base-proposer
 
@@ -98,7 +98,7 @@ FROM source AS websocket-proxy-builder
 ARG PROFILE=release
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=websocket-proxy-target,sharing=locked \
+    --mount=type=cache,target=/app/target,id=rust-target,sharing=locked \
     cargo build --profile $PROFILE --package websocket-proxy-bin --bin websocket-proxy && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/websocket-proxy /app/websocket-proxy
 
@@ -106,7 +106,7 @@ FROM source AS ingress-rpc-builder
 ARG PROFILE=release
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=ingress-rpc-target,sharing=locked \
+    --mount=type=cache,target=/app/target,id=rust-target,sharing=locked \
     cargo build --profile $PROFILE --package ingress-rpc --bin ingress-rpc && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/ingress-rpc /app/ingress-rpc
 
@@ -114,7 +114,7 @@ FROM source AS audit-archiver-builder
 ARG PROFILE=release
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=audit-archiver-target,sharing=locked \
+    --mount=type=cache,target=/app/target,id=rust-target,sharing=locked \
     cargo build --profile $PROFILE --package audit-archiver --bin audit-archiver && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/audit-archiver /app/audit-archiver
 
@@ -122,7 +122,7 @@ FROM source AS batcher-builder
 ARG PROFILE=release
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=batcher-target,sharing=locked \
+    --mount=type=cache,target=/app/target,id=rust-target,sharing=locked \
     cargo build --profile $PROFILE --package base-batcher-bin --bin base-batcher && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-batcher /app/base-batcher
 
@@ -130,7 +130,7 @@ FROM source AS sidecrush-builder
 ARG PROFILE=release
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=sidecrush-target,sharing=locked \
+    --mount=type=cache,target=/app/target,id=rust-target,sharing=locked \
     cargo build --profile $PROFILE --package base-sidecrush-bin --bin sidecrush && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/sidecrush /app/sidecrush
 
@@ -138,7 +138,7 @@ FROM source AS prover-service-builder
 ARG PROFILE=release
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=prover-service-target,sharing=locked \
+    --mount=type=cache,target=/app/target,id=rust-target,sharing=locked \
     cargo build --profile $PROFILE --package base-prover-service-bin --bin base-prover-service && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-prover-service /app/base-prover-service
 
@@ -160,18 +160,23 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
+# Default full multi-bin image (bare metal / published GHCR artifact).
+# Retire split bins here once independent images cover those consumers.
 FROM runtime-base AS base
 COPY --from=base-builder /app/base ./base
 # Compose uses this wrapper to source generated devnet upgrade-signal env before /app/base.
 COPY etc/scripts/devnet/base-entrypoint.sh ./base-entrypoint.sh
 RUN chmod +x ./base-entrypoint.sh
-# Keep split binaries here for now, needed for bare metal work
-# Remove only when there is an alternative available
-# e.g. when we publish independent separate Docker images for each
-# via the CI
 COPY --from=execution-builder /app/base-reth-node ./base-reth-node
 COPY --from=consensus-builder /app/base-consensus ./base-consensus
 COPY --from=snapshotter-builder /app/snapshotter ./snapshotter
+ENTRYPOINT ["./base"]
+
+# Slim local/devnet image: unified binary only. Avoids building split binaries.
+FROM runtime-base AS base-slim
+COPY --from=base-builder /app/base ./base
+COPY etc/scripts/devnet/base-entrypoint.sh ./base-entrypoint.sh
+RUN chmod +x ./base-entrypoint.sh
 ENTRYPOINT ["./base"]
 
 FROM runtime-base AS execution

--- a/etc/docker/README.md
+++ b/etc/docker/README.md
@@ -4,7 +4,10 @@ This directory contains the Dockerfiles and Compose configuration for the Base n
 
 ## Dockerfiles
 
-`Dockerfile.rust-services` is the shared multi-target Dockerfile for the Debian-based Rust services. The local devnet builds the unified `base` image for L2 bootnode, sequencer, and validator/RPC nodes.
+`Dockerfile.rust-services` is the shared multi-target Dockerfile for the Debian-based Rust services.
+
+- `base` (tag `base:local`) is the default multi-bin image (`base` plus `base-reth-node`, `base-consensus`, and `snapshotter`). CI publishes this to `ghcr.io/.../node-reth-dev` for bare-metal consumers.
+- `base-slim` (tag `base-slim:local`) is the slim image with only the unified `base` binary. Local devnet and Compose use this for L2 bootnode, sequencer, and validator/RPC nodes.
 
 `Dockerfile.devnet` builds a utility image containing genesis generation tools (`eth-genesis-state-generator`, `eth2-val-tools`, `op-deployer`) and setup scripts. This image bootstraps L1 and L2 chain configurations for local development.
 
@@ -64,11 +67,13 @@ UPGRADE_SIGNAL_MODE=metrics-only just devnet up
 To build a specific Rust service image directly:
 
 ```bash
-just devnet build-image base release
+just devnet build-image base release        # multi-bin default (bare metal / GHCR)
+just devnet build-image base-slim release   # slim (devnet)
 ```
 
 Plain `docker build` still works if you prefer it:
 
 ```bash
 docker build -t base -f etc/docker/Dockerfile.rust-services --target base .
+docker build -t base-slim -f etc/docker/Dockerfile.rust-services --target base-slim .
 ```

--- a/etc/docker/docker-bake.hcl
+++ b/etc/docker/docker-bake.hcl
@@ -23,11 +23,11 @@ variable "PLATFORM_PAIR" {
 }
 
 variable "DEVNET_TARGETS" {
-  default = ["base", "batcher"]
+  default = ["base-slim", "batcher"]
 }
 
 variable "INGRESS_TARGETS" {
-  default = ["base", "batcher", "ingress-rpc", "audit-archiver"]
+  default = ["base-slim", "batcher", "ingress-rpc", "audit-archiver"]
 }
 
 group "default" {
@@ -37,6 +37,7 @@ group "default" {
 group "rust-services" {
   targets = [
     "base",
+    "base-slim",
     "execution",
     "consensus",
     "builder",
@@ -57,6 +58,10 @@ group "devnet" {
   targets = DEVNET_TARGETS
 }
 
+group "slim" {
+  targets = ["base-slim"]
+}
+
 group "ingress" {
   targets = INGRESS_TARGETS
 }
@@ -75,6 +80,16 @@ target "base" {
   inherits = ["_rust-service-common"]
   target = "base"
   tags = ["base:local"]
+}
+
+target "base-slim" {
+  inherits = ["_rust-service-common"]
+  target = "base-slim"
+  tags = ["base-slim:local"]
+  cache-from = [
+    "type=registry,ref=${REGISTRY_IMAGE}:cache-${PLATFORM_PAIR}",
+    "type=registry,ref=${REGISTRY_IMAGE}:cache-base-slim-${PLATFORM_PAIR}",
+  ]
 }
 
 target "execution" {

--- a/etc/docker/docker-compose.ha.yml
+++ b/etc/docker/docker-compose.ha.yml
@@ -1,11 +1,11 @@
 x-sequencer-base: &sequencer-base
-  image: base:local
+  image: base-slim:local
   build:
     context: ../..
     dockerfile: etc/docker/Dockerfile.rust-services
     args:
       PROFILE: "${CARGO_PROFILE:-dev}"
-    target: base
+    target: base-slim
   entrypoint: /app/base-entrypoint.sh
   depends_on:
     setup-l2:

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -181,10 +181,10 @@ services:
     entrypoint: ["/usr/local/bin/setup-l2.sh"]
 
   base-bootnode:
-    image: base:local
+    image: base-slim:local
     build:
       <<: *rust-service-build
-      target: base
+      target: base-slim
     container_name: base-bootnode
     depends_on:
       setup-l2:
@@ -236,10 +236,10 @@ services:
     restart: unless-stopped
 
   base-builder:
-    image: base:local
+    image: base-slim:local
     build:
       <<: *rust-service-build
-      target: base
+      target: base-slim
     container_name: base-builder
     depends_on:
       setup-l2:
@@ -393,10 +393,10 @@ services:
     restart: unless-stopped
 
   base-client:
-    image: base:local
+    image: base-slim:local
     build:
       <<: *rust-service-build
-      target: base
+      target: base-slim
     container_name: base-client
     depends_on:
       setup-l2:
@@ -512,10 +512,10 @@ services:
     restart: unless-stopped
 
   base-rpc:
-    image: base:local
+    image: base-slim:local
     build:
       <<: *rust-service-build
-      target: base
+      target: base-slim
     container_name: base-rpc
     depends_on:
       setup-l2:


### PR DESCRIPTION
## Summary
- Split the overloaded `base` Docker runtime into default multi-bin `base` (bare metal / GHCR) and explicit `base-slim` (unified binary only).
- Point local/devnet and ingress Compose + bake groups at `base-slim` so cold builds no longer compile unused split binaries (`base-reth-node`, `base-consensus`, `snapshotter`).
- Share a single Cargo `target` cache mount across non-zk builders to avoid recompiling the same dependency graph per binary.

## Test plan
- [ ] `docker buildx bake -f etc/docker/docker-bake.hcl base-slim --load` builds only the unified binary (no execution/consensus/snapshotter builder stages)
- [ ] `docker buildx bake -f etc/docker/docker-bake.hcl base --load` still includes split binaries
- [ ] `just devnet up` (or `just devnet build-image base-slim dev`) tags/runs `base-slim:local` for L2 nodes
- [ ] Confirm CI still publishes full `base` to `node-reth-dev`, and warm-devnet-cache warms `base-slim`


Made with [Cursor](https://cursor.com)