### PR TITLE
perf(BOP-493): single SLOAD for transfer policy ids (V2)

### DIFF
--- a/crates/common/precompile-macros/src/accounting.rs
+++ b/crates/common/precompile-macros/src/accounting.rs
@@ -256,6 +256,13 @@ fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
                 }
             }
 
+            fn transfer_policy_ids(
+                &self,
+            ) -> ::base_precompile_storage::Result<crate::TransferPolicyIds> {
+                // Single SLOAD of the shared transfer-policy slot, extracting all three lanes.
+                self.b20.transfer_policy_ids()
+            }
+
             fn set_policy_id(
                 &mut self,
                 policy_scope: ::alloy_primitives::B256,

--- a/crates/common/precompiles/src/b20_asset/logic/v1.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v1.rs
@@ -793,7 +793,7 @@ mod tests {
     use crate::{
         Asset, AssetAccounting, AssetV1, B20_MAX_SUPPLY_CAP, B20AssetStorage, B20AssetToken,
         B20PolicyType, B20TokenRole, IB20, IB20Asset, PackedPolicy, PermitArgs, PolicyAccounting,
-        PolicyRegistryStorage, PolicyVersion, Token, TokenAccounting,
+        PolicyRegistryStorage, PolicyVersion, Token, TokenAccounting, TransferPolicyIds,
     };
 
     // --- Self-contained in-memory fakes (no dependency on `common::test_utils`, so shared test
@@ -961,6 +961,10 @@ mod tests {
         fn set_policy_id(&mut self, policy_scope: B256, policy_id: u64) -> Result<()> {
             self.policy_ids.insert(policy_scope, policy_id);
             Ok(())
+        }
+
+        fn transfer_policy_ids(&self) -> Result<TransferPolicyIds> {
+            TransferPolicyIds::read_individually(self)
         }
         fn emit_event(&mut self, log: LogData) -> Result<()> {
             self.events.push(log);

--- a/crates/common/precompiles/src/b20_asset/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v2.rs
@@ -21,7 +21,7 @@ use base_precompile_storage::{BasePrecompileError, Result};
 use crate::{
     Asset, AssetAccounting, B20_MAX_SUPPLY_CAP, B20AssetStorage, B20AssetToken, B20Guards,
     B20PausableFeature, B20PolicyType, B20TokenRole, Eip712Domain, IB20, IB20Asset, PermitArgs,
-    PolicyAccounting, Token,
+    PolicyAccounting, Token, TransferPolicyIds,
 };
 
 /// `keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")`
@@ -46,13 +46,16 @@ impl AssetV2 {
         b256!("97667070c54ef182b0f5858b034beac1b6f3089aa2d3188bb1e8929f4fa9b929");
 
     /// Balance-moving core of `transfer`/`transferFrom`, without the pause check.
+    ///
+    /// `policies` carries the sender/receiver ids pre-read from their shared slot by the caller;
+    /// `Some` enforces both (unprivileged path), `None` skips them (factory-privileged path).
     fn transfer_inner<S: AssetAccounting, A: PolicyAccounting>(
         &self,
         token: &mut B20AssetToken<S, A>,
         from: Address,
         to: Address,
         amount: U256,
-        privileged: bool,
+        policies: Option<&TransferPolicyIds>,
     ) -> Result<()> {
         if to == Address::ZERO {
             return Err(BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }));
@@ -60,9 +63,19 @@ impl AssetV2 {
         if from == Address::ZERO {
             return Err(BasePrecompileError::revert(IB20::InvalidSender { sender: from }));
         }
-        if !privileged {
-            B20Guards::ensure_policy_type(token, B20PolicyType::TransferSender, from)?;
-            B20Guards::ensure_policy_type(token, B20PolicyType::TransferReceiver, to)?;
+        if let Some(policies) = policies {
+            B20Guards::ensure_authorized_by_id(
+                token,
+                B20PolicyType::TransferSender.id(),
+                policies.sender,
+                from,
+            )?;
+            B20Guards::ensure_authorized_by_id(
+                token,
+                B20PolicyType::TransferReceiver.id(),
+                policies.receiver,
+                to,
+            )?;
         }
         self.move_balance(token, from, to, amount)
     }
@@ -236,7 +249,10 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
         privileged: bool,
     ) -> Result<()> {
         B20Guards::ensure_not_paused(token, IB20::PausableFeature::TRANSFER)?;
-        self.transfer_inner(token, caller, to, amount, privileged)
+        // One SLOAD fetches all transfer policy ids; skipped entirely on the privileged path.
+        let policies =
+            if privileged { None } else { Some(token.accounting().transfer_policy_ids()?) };
+        self.transfer_inner(token, caller, to, amount, policies.as_ref())
     }
 
     fn transfer_from(
@@ -264,10 +280,21 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
                 needed: amount,
             }));
         }
-        if !privileged && caller != from {
-            B20Guards::ensure_policy_type(token, B20PolicyType::TransferExecutor, caller)?;
+        // One SLOAD fetches all transfer policy ids; reused for the executor and sender/receiver
+        // checks, and skipped entirely on the privileged path.
+        let policies =
+            if privileged { None } else { Some(token.accounting().transfer_policy_ids()?) };
+        if let Some(policies) = &policies
+            && caller != from
+        {
+            B20Guards::ensure_authorized_by_id(
+                token,
+                B20PolicyType::TransferExecutor.id(),
+                policies.executor,
+                caller,
+            )?;
         }
-        self.transfer_inner(token, from, to, amount, privileged)?;
+        self.transfer_inner(token, from, to, amount, policies.as_ref())?;
         if is_infinite {
             return Ok(());
         }

--- a/crates/common/precompiles/src/b20_asset/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v2.rs
@@ -252,7 +252,6 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
         if privileged {
             return self.transfer_inner(token, caller, to, amount, None);
         }
-        // One SLOAD fetches all transfer policy ids for the sender/receiver checks.
         let policies = token.accounting().transfer_policy_ids()?;
         self.transfer_inner(token, caller, to, amount, Some(&policies))
     }

--- a/crates/common/precompiles/src/b20_asset/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v2.rs
@@ -1030,7 +1030,7 @@ mod tests {
     use crate::{
         Asset, AssetAccounting, AssetV2, B20_MAX_SUPPLY_CAP, B20AssetStorage, B20AssetToken,
         B20PolicyType, B20TokenRole, IB20, IB20Asset, PackedPolicy, PermitArgs, PolicyAccounting,
-        PolicyRegistryStorage, PolicyVersion, Token, TokenAccounting,
+        PolicyRegistryStorage, PolicyVersion, Token, TokenAccounting, TransferPolicyIds,
     };
 
     // --- Self-contained in-memory fakes (no dependency on `common::test_utils`, so shared test
@@ -1205,6 +1205,10 @@ mod tests {
         fn set_policy_id(&mut self, policy_scope: B256, policy_id: u64) -> Result<()> {
             self.policy_ids.insert(policy_scope, policy_id);
             Ok(())
+        }
+
+        fn transfer_policy_ids(&self) -> Result<TransferPolicyIds> {
+            TransferPolicyIds::read_individually(self)
         }
         fn emit_event(&mut self, log: LogData) -> Result<()> {
             self.events.push(log);

--- a/crates/common/precompiles/src/b20_asset/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v2.rs
@@ -249,10 +249,12 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
         privileged: bool,
     ) -> Result<()> {
         B20Guards::ensure_not_paused(token, IB20::PausableFeature::TRANSFER)?;
-        // One SLOAD fetches all transfer policy ids; skipped entirely on the privileged path.
-        let policies =
-            if privileged { None } else { Some(token.accounting().transfer_policy_ids()?) };
-        self.transfer_inner(token, caller, to, amount, policies.as_ref())
+        if privileged {
+            return self.transfer_inner(token, caller, to, amount, None);
+        }
+        // One SLOAD fetches all transfer policy ids for the sender/receiver checks.
+        let policies = token.accounting().transfer_policy_ids()?;
+        self.transfer_inner(token, caller, to, amount, Some(&policies))
     }
 
     fn transfer_from(
@@ -280,21 +282,22 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
                 needed: amount,
             }));
         }
-        // One SLOAD fetches all transfer policy ids; reused for the executor and sender/receiver
-        // checks, and skipped entirely on the privileged path.
-        let policies =
-            if privileged { None } else { Some(token.accounting().transfer_policy_ids()?) };
-        if let Some(policies) = &policies
-            && caller != from
-        {
-            B20Guards::ensure_authorized_by_id(
-                token,
-                B20PolicyType::TransferExecutor.id(),
-                policies.executor,
-                caller,
-            )?;
+        if privileged {
+            self.transfer_inner(token, from, to, amount, None)?;
+        } else {
+            // One SLOAD fetches all transfer policy ids, reused for the executor and
+            // sender/receiver checks.
+            let policies = token.accounting().transfer_policy_ids()?;
+            if caller != from {
+                B20Guards::ensure_authorized_by_id(
+                    token,
+                    B20PolicyType::TransferExecutor.id(),
+                    policies.executor,
+                    caller,
+                )?;
+            }
+            self.transfer_inner(token, from, to, amount, Some(&policies))?;
         }
-        self.transfer_inner(token, from, to, amount, policies.as_ref())?;
         if is_infinite {
             return Ok(());
         }

--- a/crates/common/precompiles/src/b20_asset/storage.rs
+++ b/crates/common/precompiles/src/b20_asset/storage.rs
@@ -116,7 +116,10 @@ mod tests {
         __packing_b20_asset_extension_storage, B20AssetExtensionStorage, B20AssetInit,
         B20AssetStorage, slots,
     };
-    use crate::{AssetAccounting, B20CoreStorage, B20TokenRole, TokenAccounting};
+    use crate::{
+        AssetAccounting, B20CoreStorage, B20PolicyType, B20TokenRole, TokenAccounting,
+        TransferPolicyIds,
+    };
 
     const TOKEN: Address = address!("000000000000000000000000000000000000b021");
     const B20_ROOT: U256 =
@@ -231,6 +234,31 @@ mod tests {
                 "clear_pending_multiplier_and_effective_at must write the shared slot exactly once"
             );
             assert_eq!(ctx.sload(TOKEN, pending_slot).unwrap(), reserved);
+        });
+    }
+
+    #[test]
+    fn transfer_policy_ids_reads_shared_slot_once() {
+        let (mut storage, _) = setup_storage();
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut token = B20AssetStorage::from_address(TOKEN, ctx);
+            // Distinct id per lane so a mis-extraction can't accidentally pass.
+            TokenAccounting::set_policy_id(&mut token, B20PolicyType::TransferSender.id(), 11)
+                .unwrap();
+            TokenAccounting::set_policy_id(&mut token, B20PolicyType::TransferReceiver.id(), 22)
+                .unwrap();
+            TokenAccounting::set_policy_id(&mut token, B20PolicyType::TransferExecutor.id(), 33)
+                .unwrap();
+
+            let before = ctx.counter_sload();
+            let ids = TokenAccounting::transfer_policy_ids(&token).unwrap();
+            assert_eq!(
+                ctx.counter_sload() - before,
+                1,
+                "all three transfer policy ids must be fetched in a single SLOAD"
+            );
+            assert_eq!(ids, TransferPolicyIds { sender: 11, receiver: 22, executor: 33 });
         });
     }
 

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v1.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v1.rs
@@ -666,7 +666,7 @@ mod tests {
     use crate::{
         B20_MAX_SUPPLY_CAP, B20PolicyType, B20StablecoinToken, B20TokenRole, IB20, PackedPolicy,
         PermitArgs, PolicyAccounting, PolicyRegistryStorage, PolicyVersion, Stablecoin,
-        StablecoinAccounting, StablecoinV1, Token, TokenAccounting,
+        StablecoinAccounting, StablecoinV1, Token, TokenAccounting, TransferPolicyIds,
     };
 
     // --- Self-contained in-memory fakes (no dependency on `common::test_utils`, so shared test
@@ -828,6 +828,10 @@ mod tests {
         fn set_policy_id(&mut self, policy_scope: B256, policy_id: u64) -> Result<()> {
             self.policy_ids.insert(policy_scope, policy_id);
             Ok(())
+        }
+
+        fn transfer_policy_ids(&self) -> Result<TransferPolicyIds> {
+            TransferPolicyIds::read_individually(self)
         }
         fn emit_event(&mut self, log: LogData) -> Result<()> {
             self.events.push(log);

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
@@ -212,7 +212,6 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> Stablecoin<S, A> for Stableco
         if privileged {
             return self.transfer_inner(token, caller, to, amount, None);
         }
-        // One SLOAD fetches all transfer policy ids for the sender/receiver checks.
         let policies = token.accounting().transfer_policy_ids()?;
         self.transfer_inner(token, caller, to, amount, Some(&policies))
     }

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
@@ -738,7 +738,7 @@ mod tests {
     use crate::{
         B20_MAX_SUPPLY_CAP, B20PolicyType, B20StablecoinToken, B20TokenRole, IB20, PackedPolicy,
         PermitArgs, PolicyAccounting, PolicyRegistryStorage, PolicyVersion, Stablecoin,
-        StablecoinAccounting, StablecoinV2, Token, TokenAccounting,
+        StablecoinAccounting, StablecoinV2, Token, TokenAccounting, TransferPolicyIds,
     };
 
     // --- Self-contained in-memory fakes (no dependency on `common::test_utils`, so shared test
@@ -901,6 +901,10 @@ mod tests {
         fn set_policy_id(&mut self, policy_scope: B256, policy_id: u64) -> Result<()> {
             self.policy_ids.insert(policy_scope, policy_id);
             Ok(())
+        }
+
+        fn transfer_policy_ids(&self) -> Result<TransferPolicyIds> {
+            TransferPolicyIds::read_individually(self)
         }
         fn emit_event(&mut self, log: LogData) -> Result<()> {
             self.events.push(log);

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
@@ -13,7 +13,7 @@ use base_precompile_storage::{BasePrecompileError, Result};
 use crate::{
     B20_MAX_SUPPLY_CAP, B20Guards, B20PausableFeature, B20PolicyType, B20StablecoinToken,
     B20TokenRole, Eip712Domain, IB20, PermitArgs, PolicyAccounting, Stablecoin,
-    StablecoinAccounting, Token,
+    StablecoinAccounting, Token, TransferPolicyIds,
 };
 
 /// `keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")`
@@ -30,13 +30,16 @@ pub struct StablecoinV2;
 
 impl StablecoinV2 {
     /// Balance-moving core of `transfer`/`transferFrom`, without the pause check.
+    ///
+    /// `policies` carries the sender/receiver ids pre-read from their shared slot by the caller;
+    /// `Some` enforces both (unprivileged path), `None` skips them (factory-privileged path).
     fn transfer_inner<S: StablecoinAccounting, A: PolicyAccounting>(
         &self,
         token: &mut B20StablecoinToken<S, A>,
         from: Address,
         to: Address,
         amount: U256,
-        privileged: bool,
+        policies: Option<&TransferPolicyIds>,
     ) -> Result<()> {
         if to == Address::ZERO {
             return Err(BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }));
@@ -44,9 +47,19 @@ impl StablecoinV2 {
         if from == Address::ZERO {
             return Err(BasePrecompileError::revert(IB20::InvalidSender { sender: from }));
         }
-        if !privileged {
-            B20Guards::ensure_policy_type(token, B20PolicyType::TransferSender, from)?;
-            B20Guards::ensure_policy_type(token, B20PolicyType::TransferReceiver, to)?;
+        if let Some(policies) = policies {
+            B20Guards::ensure_authorized_by_id(
+                token,
+                B20PolicyType::TransferSender.id(),
+                policies.sender,
+                from,
+            )?;
+            B20Guards::ensure_authorized_by_id(
+                token,
+                B20PolicyType::TransferReceiver.id(),
+                policies.receiver,
+                to,
+            )?;
         }
         self.move_balance(token, from, to, amount)
     }
@@ -196,7 +209,10 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> Stablecoin<S, A> for Stableco
         privileged: bool,
     ) -> Result<()> {
         B20Guards::ensure_not_paused(token, IB20::PausableFeature::TRANSFER)?;
-        self.transfer_inner(token, caller, to, amount, privileged)
+        // One SLOAD fetches all transfer policy ids; skipped entirely on the privileged path.
+        let policies =
+            if privileged { None } else { Some(token.accounting().transfer_policy_ids()?) };
+        self.transfer_inner(token, caller, to, amount, policies.as_ref())
     }
 
     fn transfer_from(
@@ -224,10 +240,21 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> Stablecoin<S, A> for Stableco
                 needed: amount,
             }));
         }
-        if !privileged && caller != from {
-            B20Guards::ensure_policy_type(token, B20PolicyType::TransferExecutor, caller)?;
+        // One SLOAD fetches all transfer policy ids; reused for the executor and sender/receiver
+        // checks, and skipped entirely on the privileged path.
+        let policies =
+            if privileged { None } else { Some(token.accounting().transfer_policy_ids()?) };
+        if let Some(policies) = &policies
+            && caller != from
+        {
+            B20Guards::ensure_authorized_by_id(
+                token,
+                B20PolicyType::TransferExecutor.id(),
+                policies.executor,
+                caller,
+            )?;
         }
-        self.transfer_inner(token, from, to, amount, privileged)?;
+        self.transfer_inner(token, from, to, amount, policies.as_ref())?;
         if is_infinite {
             return Ok(());
         }

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
@@ -209,10 +209,12 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> Stablecoin<S, A> for Stableco
         privileged: bool,
     ) -> Result<()> {
         B20Guards::ensure_not_paused(token, IB20::PausableFeature::TRANSFER)?;
-        // One SLOAD fetches all transfer policy ids; skipped entirely on the privileged path.
-        let policies =
-            if privileged { None } else { Some(token.accounting().transfer_policy_ids()?) };
-        self.transfer_inner(token, caller, to, amount, policies.as_ref())
+        if privileged {
+            return self.transfer_inner(token, caller, to, amount, None);
+        }
+        // One SLOAD fetches all transfer policy ids for the sender/receiver checks.
+        let policies = token.accounting().transfer_policy_ids()?;
+        self.transfer_inner(token, caller, to, amount, Some(&policies))
     }
 
     fn transfer_from(
@@ -240,21 +242,22 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> Stablecoin<S, A> for Stableco
                 needed: amount,
             }));
         }
-        // One SLOAD fetches all transfer policy ids; reused for the executor and sender/receiver
-        // checks, and skipped entirely on the privileged path.
-        let policies =
-            if privileged { None } else { Some(token.accounting().transfer_policy_ids()?) };
-        if let Some(policies) = &policies
-            && caller != from
-        {
-            B20Guards::ensure_authorized_by_id(
-                token,
-                B20PolicyType::TransferExecutor.id(),
-                policies.executor,
-                caller,
-            )?;
+        if privileged {
+            self.transfer_inner(token, from, to, amount, None)?;
+        } else {
+            // One SLOAD fetches all transfer policy ids, reused for the executor and
+            // sender/receiver checks.
+            let policies = token.accounting().transfer_policy_ids()?;
+            if caller != from {
+                B20Guards::ensure_authorized_by_id(
+                    token,
+                    B20PolicyType::TransferExecutor.id(),
+                    policies.executor,
+                    caller,
+                )?;
+            }
+            self.transfer_inner(token, from, to, amount, Some(&policies))?;
         }
-        self.transfer_inner(token, from, to, amount, policies.as_ref())?;
         if is_infinite {
             return Ok(());
         }

--- a/crates/common/precompiles/src/common/core_storage.rs
+++ b/crates/common/precompiles/src/common/core_storage.rs
@@ -4,7 +4,9 @@ use alloc::string::String;
 
 use alloy_primitives::{Address, B256, FixedBytes, U256};
 use base_precompile_macros::Storable;
-use base_precompile_storage::Mapping;
+use base_precompile_storage::{Mapping, Result, StorageOps, extract_from_word};
+
+use crate::TransferPolicyIds;
 
 /// Core B-20 storage rooted at the `base.b20` ERC-7201 namespace.
 #[derive(Debug, Clone, Storable)]
@@ -90,6 +92,36 @@ pub struct B20CoreStorage {
     pub seize_receiver_policy_id: u64, // slot 14, offset 8
     /// Reserved padding to close slot 14.
     pub seize_reserved: FixedBytes<16>, // slot 14, offset 16
+}
+
+impl B20CoreStorageHandler<'_> {
+    /// Reads the sender/receiver/executor transfer policy ids in a single SLOAD.
+    ///
+    /// The three ids are packed into one storage word (slot 9); loading it once and extracting each
+    /// lane avoids the three separate SLOADs the per-field accessors would incur. Offsets come from
+    /// the generated packing constants, so they track the field layout (also pinned by the
+    /// offset test below).
+    pub fn transfer_policy_ids(&self) -> Result<TransferPolicyIds> {
+        let slot = self.transfer_sender_policy_id.slot();
+        let word = StorageOps::load(&self.transfer_sender_policy_id, slot)?;
+        Ok(TransferPolicyIds {
+            sender: extract_from_word::<u64>(
+                word,
+                __packing_b20_core_storage::TRANSFER_SENDER_POLICY_ID_LOC.offset_bytes,
+                size_of::<u64>(),
+            )?,
+            receiver: extract_from_word::<u64>(
+                word,
+                __packing_b20_core_storage::TRANSFER_RECEIVER_POLICY_ID_LOC.offset_bytes,
+                size_of::<u64>(),
+            )?,
+            executor: extract_from_word::<u64>(
+                word,
+                __packing_b20_core_storage::TRANSFER_EXECUTOR_POLICY_ID_LOC.offset_bytes,
+                size_of::<u64>(),
+            )?,
+        })
+    }
 }
 
 #[cfg(test)]

--- a/crates/common/precompiles/src/common/mod.rs
+++ b/crates/common/precompiles/src/common/mod.rs
@@ -29,4 +29,4 @@ mod token;
 pub use token::Token;
 
 mod token_accounting;
-pub use token_accounting::{B20_MAX_SUPPLY_CAP, TokenAccounting};
+pub use token_accounting::{B20_MAX_SUPPLY_CAP, TokenAccounting, TransferPolicyIds};

--- a/crates/common/precompiles/src/common/ops/guards.rs
+++ b/crates/common/precompiles/src/common/ops/guards.rs
@@ -71,6 +71,28 @@ impl B20Guards {
         }
     }
 
+    /// Ensures `account` is authorized by `policy_scope` using a pre-read `policy_id`.
+    ///
+    /// Identical to [`Self::ensure_policy`] except the caller supplies the id (already loaded, e.g.
+    /// via [`TokenAccounting::transfer_policy_ids`](crate::TokenAccounting::transfer_policy_ids)),
+    /// so a batch of checks against ids from the same slot pays a single SLOAD. Reverts the same
+    /// `PolicyForbids { policyScope, policyId }` as `ensure_policy`.
+    pub fn ensure_authorized_by_id<T: Token + ?Sized>(
+        token: &T,
+        policy_scope: B256,
+        policy_id: u64,
+        account: Address,
+    ) -> Result<()> {
+        if token.policy().is_authorized(token.policy_storage(), policy_id, account)? {
+            Ok(())
+        } else {
+            Err(BasePrecompileError::revert(IB20::PolicyForbids {
+                policyScope: policy_scope,
+                policyId: policy_id,
+            }))
+        }
+    }
+
     /// Ensures `account` is blocked by the current transfer-sender policy.
     ///
     /// Accounts are blocked when the configured registry policy does not authorize them.

--- a/crates/common/precompiles/src/common/test_utils.rs
+++ b/crates/common/precompiles/src/common/test_utils.rs
@@ -12,7 +12,7 @@ use crate::{
     PackedPolicy, PolicyAccounting, PolicyRegistryStorage,
     b20_asset::{AssetAccounting, B20AssetStorage},
     b20_stablecoin::{B20StablecoinToken, StablecoinAccounting},
-    common::{B20_MAX_SUPPLY_CAP, TokenAccounting},
+    common::{B20_MAX_SUPPLY_CAP, TokenAccounting, TransferPolicyIds},
 };
 
 /// Convenience alias: [`B20StablecoinToken`] wired with both in-memory fakes.
@@ -236,6 +236,10 @@ impl TokenAccounting for InMemoryTokenAccounting {
     fn set_policy_id(&mut self, policy_scope: B256, policy_id: u64) -> Result<()> {
         self.policy_ids.insert(policy_scope, policy_id);
         Ok(())
+    }
+
+    fn transfer_policy_ids(&self) -> Result<TransferPolicyIds> {
+        TransferPolicyIds::read_individually(self)
     }
 
     fn emit_event(&mut self, log: LogData) -> Result<()> {

--- a/crates/common/precompiles/src/common/token_accounting.rs
+++ b/crates/common/precompiles/src/common/token_accounting.rs
@@ -21,6 +21,21 @@ pub struct TransferPolicyIds {
     pub executor: u64,
 }
 
+impl TransferPolicyIds {
+    /// Reads each id with a separate [`TokenAccounting::policy_id`] call.
+    ///
+    /// The fallback for adapters that have no packed-slot fast path (e.g. in-memory test doubles);
+    /// EVM-backed adapters implement [`TokenAccounting::transfer_policy_ids`] with a single SLOAD
+    /// instead. Depends only on the port interface, so it never touches EVM storage directly.
+    pub fn read_individually<T: TokenAccounting + ?Sized>(accounting: &T) -> Result<Self> {
+        Ok(Self {
+            sender: accounting.policy_id(crate::B20PolicyType::TransferSender.id())?,
+            receiver: accounting.policy_id(crate::B20PolicyType::TransferReceiver.id())?,
+            executor: accounting.policy_id(crate::B20PolicyType::TransferExecutor.id())?,
+        })
+    }
+}
+
 /// Outbound port: all data reads and writes the core business logic requires.
 ///
 /// Each token variant's `#[contract]` storage struct implements this trait.
@@ -116,16 +131,11 @@ pub trait TokenAccounting {
 
     /// Returns the sender/receiver/executor transfer policy ids together.
     ///
-    /// The three ids share one storage word, so an EVM-backed adapter overrides this with a single
-    /// SLOAD (see the `TokenAccounting` derive). The default reads each id separately and exists for
-    /// in-memory test adapters where SLOAD count is irrelevant; it is behaviorally identical.
-    fn transfer_policy_ids(&self) -> Result<TransferPolicyIds> {
-        Ok(TransferPolicyIds {
-            sender: self.policy_id(crate::B20PolicyType::TransferSender.id())?,
-            receiver: self.policy_id(crate::B20PolicyType::TransferReceiver.id())?,
-            executor: self.policy_id(crate::B20PolicyType::TransferExecutor.id())?,
-        })
-    }
+    /// The three ids share one storage word, so EVM-backed adapters implement this as a single
+    /// SLOAD (see the `TokenAccounting` derive). Adapters without a packed-slot fast path (e.g.
+    /// in-memory test doubles) delegate to [`TransferPolicyIds::read_individually`], which is
+    /// behaviorally identical.
+    fn transfer_policy_ids(&self) -> Result<TransferPolicyIds>;
 
     // --- Event emission ---
 

--- a/crates/common/precompiles/src/common/token_accounting.rs
+++ b/crates/common/precompiles/src/common/token_accounting.rs
@@ -7,6 +7,20 @@ use base_precompile_storage::Result;
 /// Maximum total supply for a B-20 token.
 pub const B20_MAX_SUPPLY_CAP: U256 = U256::from_limbs([u64::MAX, u64::MAX, 0, 0]);
 
+/// The three transfer policy ids read together from their shared packed slot.
+///
+/// The sender/receiver/executor ids all live in one storage word, so a transfer needs only a single
+/// SLOAD to fetch all three. See [`TokenAccounting::transfer_policy_ids`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TransferPolicyIds {
+    /// `TRANSFER_SENDER_POLICY` id.
+    pub sender: u64,
+    /// `TRANSFER_RECEIVER_POLICY` id.
+    pub receiver: u64,
+    /// `TRANSFER_EXECUTOR_POLICY` id.
+    pub executor: u64,
+}
+
 /// Outbound port: all data reads and writes the core business logic requires.
 ///
 /// Each token variant's `#[contract]` storage struct implements this trait.
@@ -99,6 +113,19 @@ pub trait TokenAccounting {
     fn policy_id(&self, policy_scope: B256) -> Result<u64>;
     /// Overwrites the policy ID assigned to `policy_scope`.
     fn set_policy_id(&mut self, policy_scope: B256, policy_id: u64) -> Result<()>;
+
+    /// Returns the sender/receiver/executor transfer policy ids together.
+    ///
+    /// The three ids share one storage word, so an EVM-backed adapter overrides this with a single
+    /// SLOAD (see the `TokenAccounting` derive). The default reads each id separately and exists for
+    /// in-memory test adapters where SLOAD count is irrelevant; it is behaviorally identical.
+    fn transfer_policy_ids(&self) -> Result<TransferPolicyIds> {
+        Ok(TransferPolicyIds {
+            sender: self.policy_id(crate::B20PolicyType::TransferSender.id())?,
+            receiver: self.policy_id(crate::B20PolicyType::TransferReceiver.id())?,
+            executor: self.policy_id(crate::B20PolicyType::TransferExecutor.id())?,
+        })
+    }
 
     // --- Event emission ---
 

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -45,6 +45,7 @@ pub use common::{
 pub use common::{
     B20_MAX_SUPPLY_CAP, B20Abi, B20CoreStorage, B20Guards, B20PausableFeature, B20PolicyType,
     B20TokenRole, Eip712Domain, IB20, IB20V1, IB20V2, PermitArgs, Token, TokenAccounting,
+    TransferPolicyIds,
 };
 
 mod observer;


### PR DESCRIPTION
> **Stacked on #4252 (BOP-492).** Base is the `bop-492` branch so the diff shows only BOP-493; GitHub will retarget this to `main` automatically once #4252 merges. Review/merge #4252 first.

## What

The three transfer policy ids (`TRANSFER_SENDER`/`RECEIVER`/`EXECUTOR`) are packed into one storage word (slot 9), but V2 `transfer`/`transferFrom` currently read it once per policy — 2 SLOADs for `transfer`, 3 for `transferFrom`. This fetches all three in a **single SLOAD**, cutting transfer cost. Behavior-preserving (emitted logs, revert payloads, and revert order all unchanged); base/base only, Cobalt (V2). Beryl/V1 is untouched.

## Changes

- `token_accounting.rs`: add `TransferPolicyIds` and `TokenAccounting::transfer_policy_ids()`. The default impl reads each id separately (for in-memory test fakes where SLOAD count is irrelevant) and is behaviorally identical.
- `core_storage.rs`: `B20CoreStorageHandler::transfer_policy_ids()` does one `StorageOps::load` of the shared slot and extracts each lane using the generated packing offsets (tracked by the existing offset-pin test).
- `precompile-macros/accounting.rs`: the `TokenAccounting` derive overrides `transfer_policy_ids` to delegate to the single-SLOAD handler method for EVM-backed adapters.
- `guards.rs`: `ensure_authorized_by_id` runs `is_authorized` against a pre-read id and reverts the identical `PolicyForbids { policyScope, policyId }` as `ensure_policy`.
- `b20_asset`/`b20_stablecoin` `logic/v2.rs`: `transfer`/`transferFrom` read the snapshot once (skipped entirely on the privileged path) and thread it through `transfer_inner`; the guard *sequence* is preserved, only the redundant SLOADs are removed.

base-std intentionally does **not** mirror this — the Solidity reference still does per-policy reads; the fork harness passes because it compares behavior, not gas/SLOAD counts.

## Testing

- `cargo test -p base-common-precompiles --features test-utils` — all green, incl. the full V2 transfer/transferFrom suites (behavior parity) and all golden matrices.
- New: asset `storage.rs` `transfer_policy_ids_reads_shared_slot_once` asserts exactly one SLOAD via `ctx.counter_sload()` and correct per-lane ids.
- `cargo clippy ... --features test-utils --tests` clean; `cargo +nightly fmt --check` clean.

Ticket: https://linear.app/coinbase/issue/BOP-493