### PR TITLE
chore: delete vestigial l3 configuration

### DIFF
--- a/crates/proof/proposer/src/cli.rs
+++ b/crates/proof/proposer/src/cli.rs
@@ -153,16 +153,6 @@ pub struct ProposerArgs {
     )]
     pub recovery_scan_concurrency: NonZeroUsize,
 
-    /// Use `ProverClient::prove` (synchronous `prover_prove` JSON-RPC) directly
-    /// instead of the async dispatch+collect pattern via `ProofRequesterProver`.
-    /// Required when the prover endpoint is `nitro-local` rather than prover-service.
-    #[arg(
-        long = "direct-prover-rpc",
-        env = cli_env!("DIRECT_PROVER_RPC"),
-        default_value = "false"
-    )]
-    pub direct_prover_rpc: bool,
-
     /// Transaction manager configuration.
     #[command(flatten)]
     pub tx_manager: TxManagerCli,

--- a/crates/proof/proposer/src/config.rs
+++ b/crates/proof/proposer/src/config.rs
@@ -59,10 +59,6 @@ pub struct ProposerConfig {
     pub tx_manager: Option<base_tx_manager::TxManagerConfig>,
     /// Maximum number of concurrent RPC calls during the recovery scan.
     pub recovery_scan_concurrency: usize,
-    /// Use `ProverClient::prove` directly instead of the async dispatch+collect
-    /// pattern via `ProofRequesterProver`. Required when the prover endpoint is
-    /// `nitro-local` rather than prover-service.
-    pub direct_prover_rpc: bool,
 }
 
 impl ProposerConfig {
@@ -151,7 +147,6 @@ impl ProposerConfig {
             signing,
             tx_manager,
             recovery_scan_concurrency: proposer.recovery_scan_concurrency.get(),
-            direct_prover_rpc: proposer.direct_prover_rpc,
         })
     }
 }
@@ -214,7 +209,6 @@ mod tests {
         assert_eq!(config.admin_addr.unwrap().port(), 8545);
         assert!(matches!(config.signing, Some(base_tx_manager::SignerConfig::Local { .. })));
         assert!(config.tx_manager.is_some());
-        assert!(!config.direct_prover_rpc);
     }
 
     #[test]

--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -5,8 +5,7 @@ _ha := "-f etc/docker/docker-compose.yml -f etc/docker/docker-compose.ha.yml"
 _base := "-f etc/docker/docker-compose.yml"
 _env := "--env-file etc/docker/devnet-env"
 _yaml_to_env := "etc/scripts/yaml-to-compose-env.py"
-_eth := "--profile eth-l1"
-_all_profiles := "--profile eth-l1 --profile profiling"
+_all_profiles := "--profile profiling"
 
 # Show devnet commands
 default:
@@ -22,7 +21,7 @@ up-single zk='dry-run':
 
 # Stops devnet, deletes data, and starts fresh with profiling (Pyroscope + optimized builds)
 profiling: down _build-setup-image (_build-rust-images "devnet" "profiling")
-    docker compose {{ _env }} {{ _ha }} {{ _eth }} --profile profiling up -d --no-build
+    docker compose {{ _env }} {{ _ha }} --profile profiling up -d --no-build
 
 # Stops devnet and deletes all data
 down:
@@ -90,9 +89,9 @@ transfer-leader to='':
 conductor:
     cargo run --quiet -p basectl -- -c devnet monitor conductor
 
-# Stops devnet+ingress, deletes data, and starts fresh with full ingress stack (eth-l1)
+# Stops devnet+ingress, deletes data, and starts fresh with full ingress stack
 ingress: ingress-down _build-setup-image (_build-rust-images "ingress" "dev")
-    docker compose {{ _env }} {{ _base }} -f etc/docker/docker-compose.ingress.yml {{ _eth }} up -d --no-build
+    docker compose {{ _env }} {{ _base }} -f etc/docker/docker-compose.ingress.yml up -d --no-build
 
 # Stops devnet+ingress and deletes all data
 ingress-down:
@@ -193,14 +192,12 @@ _up-devnet compose_profile zk:
     esac
 
     env_files=({{ _env }})
-    l1_profile=({{ _eth }})
-
     case "$zk_mode" in
       dry-run)
         just --justfile {{ source_file() }} down
         just --justfile {{ source_file() }} _build-setup-image
         just --justfile {{ source_file() }} _build-rust-images "devnet" "dev"
-        docker compose "${env_files[@]}" "${compose_files[@]}" "${l1_profile[@]}" up -d --no-build --remove-orphans
+        docker compose "${env_files[@]}" "${compose_files[@]}" up -d --no-build --remove-orphans
         ;;
       cluster)
         if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
@@ -247,7 +244,7 @@ _up-devnet compose_profile zk:
         just --justfile {{ source_file() }} down
         just --justfile {{ source_file() }} _build-setup-image
         just --justfile {{ source_file() }} _build-rust-images "devnet" "dev"
-        docker compose "${env_files[@]}" --env-file "$cluster_env" "${compose_files[@]}" "${l1_profile[@]}" up -d --no-build --remove-orphans
+        docker compose "${env_files[@]}" --env-file "$cluster_env" "${compose_files[@]}" up -d --no-build --remove-orphans
         ;;
       *)
         echo "ERROR: zk must be 'dry-run' or 'cluster' (got '${zk_mode}')" >&2

--- a/etc/docker/docker-bake.hcl
+++ b/etc/docker/docker-bake.hcl
@@ -56,7 +56,7 @@ group "rust-services" {
 }
 
 group "devnet" {
-  targets = concat(DEVNET_TARGETS, ["da-server"])
+  targets = DEVNET_TARGETS
 }
 
 group "ingress" {

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -39,12 +39,11 @@ services:
       - L1_DATA_DIR=/data
     entrypoint: ["/usr/local/bin/setup-l1.sh"]
 
-  # --- L1 parent chain: Ethereum (reth + lighthouse), eth-l1 profile ---------------------
+  # --- L1 parent chain: Ethereum (reth + lighthouse) -------------------------------------
 
   l1-el:
     image: ghcr.io/paradigmxyz/reth:v1.11.4
     container_name: l1-el
-    profiles: ["eth-l1"]
     depends_on:
       setup-l1:
         condition: service_completed_successfully
@@ -89,7 +88,6 @@ services:
   l1-cl:
     image: sigp/lighthouse:v8.0.1
     container_name: l1-cl
-    profiles: ["eth-l1"]
     depends_on:
       setup-l1:
         condition: service_completed_successfully
@@ -135,7 +133,6 @@ services:
   l1-vc:
     image: sigp/lighthouse:v8.0.1
     container_name: l1-vc
-    profiles: ["eth-l1"]
     depends_on:
       l1-cl:
         condition: service_healthy


### PR DESCRIPTION
## Summary

- Remove the unused `--direct-prover-rpc` proposer option.
- Start L1 services without the obsolete `eth-l1` Compose profile.
- Stop the `devnet` bake group from building `da-server`; keep its standalone target.

## Testing

- `cargo fmt --check`
- `cargo check -p base-proposer`
- `cargo test -p base-proposer config::tests`
- `cargo clippy -p base-proposer --all-targets -- -D warnings`
- Parse the Justfile, Compose config, and Bake targets.