### PR TITLE
feat(proof): emit shared witness metrics from zk host

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5944,6 +5944,8 @@ dependencies = [
  "async-trait",
  "backoff",
  "base-l1-head",
+ "base-metrics",
+ "base-proof-host",
  "base-proof-succinct-client-utils",
  "base-proof-succinct-elfs",
  "base-proof-succinct-host-utils",

--- a/bin/prover/nitro-host/Cargo.toml
+++ b/bin/prover/nitro-host/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 [dependencies]
 # Workspace – Nitro host
 base-common-chains.workspace = true
-base-proof-tee-nitro-host.workspace = true
+base-proof-tee-nitro-host = { workspace = true, features = ["metrics"] }
 base-prover-service-client.workspace = true
 base-proof-host = { workspace = true, features = ["metrics"] }
 base-proof-tee-nitro-enclave = { workspace = true, optional = true }

--- a/crates/proof/host/src/metrics/mod.rs
+++ b/crates/proof/host/src/metrics/mod.rs
@@ -34,7 +34,8 @@ base_metrics::define_metrics! {
     #[describe("Number of preimages captured in the last witness build")]
     preimage_count: gauge,
 
-    #[describe("Size of a witness submitted to a Nitro enclave in bytes")]
+    #[describe("Canonical estimate of range witness data bytes (Nitro: preimage values; SP1: stdin buffer lengths)")]
+    #[label(name = "prover", default = ["sp1", "nitro"])]
     witness_size_bytes: histogram,
 
     #[describe("Latency in seconds for debug_executePayload RPC calls to the L2 proof node")]
@@ -43,7 +44,8 @@ base_metrics::define_metrics! {
     #[describe("End-to-end proof generation duration")]
     proof_duration_seconds: histogram,
 
-    #[describe("Witness build duration")]
+    #[describe("Range witness build duration")]
+    #[label(name = "prover", default = ["sp1", "nitro"])]
     witness_build_duration_seconds: histogram,
 
     #[describe("Backend prover duration")]
@@ -72,6 +74,12 @@ impl Metrics {
 
     /// Future was cancelled (dropped) before completion.
     pub const OUTCOME_DROPPED: &str = "dropped";
+
+    /// SP1 prover label for witness metrics.
+    pub const PROVER_SP1: &str = "sp1";
+
+    /// Nitro TEE prover label for witness metrics.
+    pub const PROVER_NITRO: &str = "nitro";
 }
 
 /// RAII guard for in-flight proof tracking.

--- a/crates/proof/host/src/service.rs
+++ b/crates/proof/host/src/service.rs
@@ -72,11 +72,14 @@ impl<B: ProverBackend> ProverService<B> {
         let l1_header_cache = self.l1_header_cache.get_or_init(L1HeaderCache::new).clone();
         let oracle = self.backend.create_oracle();
 
-        let oracle = base_metrics::time!(Metrics::witness_build_duration_seconds(), {
-            host.build_witness_with_l1_header_cache(oracle, l1_header_cache)
-                .await
-                .map_err(ProverError::Host)?
-        });
+        let witness_timer = base_metrics::timed!(Metrics::witness_build_duration_seconds(
+            self.backend.prover_label()
+        ));
+        let oracle = host
+            .build_witness_with_l1_header_cache(oracle, l1_header_cache)
+            .await
+            .map_err(ProverError::Host)?;
+        drop(witness_timer);
 
         let result = base_metrics::time!(Metrics::prover_duration_seconds(), {
             self.backend.prove(oracle).await.map_err(ProverError::Backend)?
@@ -146,6 +149,10 @@ mod tests {
 
         fn create_oracle(&self) -> Self::Oracle {
             NoopOracle::default()
+        }
+
+        fn prover_label(&self) -> &'static str {
+            "test"
         }
 
         async fn prove(&self, _witness: Self::Oracle) -> Result<ProofResult, Self::Error> {

--- a/crates/proof/primitives/src/prover.rs
+++ b/crates/proof/primitives/src/prover.rs
@@ -24,6 +24,9 @@ pub trait ProverBackend: Send + Sync {
     /// Create a fresh oracle instance for a single proof's witness generation.
     fn create_oracle(&self) -> Self::Oracle;
 
+    /// Metric label for the prover backend (`nitro`, `sp1`, …).
+    fn prover_label(&self) -> &'static str;
+
     /// Execute the proof using the populated witness oracle.
     ///
     /// Called after [`Host::build_witness`] has filled the oracle with preimages

--- a/crates/proof/prover-service/src/lib.rs
+++ b/crates/proof/prover-service/src/lib.rs
@@ -4,10 +4,10 @@ mod metrics;
 pub use metrics::{
     PROOF_REQUEST_DURATION_MS, PROOF_REQUESTS_COMPLETED, PROOF_STATUS_FAILED,
     PROOF_STATUS_SUCCEEDED, ProverMetrics, REQUESTS, RESPONSE_LATENCY_MS, RETRIED_REQUESTS,
-    STUCK_REQUESTS, WITNESS_GENERATION_DURATION_MS, WORKER_JOBS_FAILED, api_proof_type_label,
-    inc_proof_requests_completed, inc_requests, inc_retried_requests, inc_stuck_requests,
-    inc_worker_jobs_failed, inc_worker_requests, proof_type_label, record_proof_request_duration,
-    record_response_latency, record_terminal_proof_job, record_witness_generation_duration,
+    STUCK_REQUESTS, WORKER_JOBS_FAILED, api_proof_type_label, inc_proof_requests_completed,
+    inc_requests, inc_retried_requests, inc_stuck_requests, inc_worker_jobs_failed,
+    inc_worker_requests, proof_type_label, record_proof_request_duration, record_response_latency,
+    record_terminal_proof_job,
 };
 
 mod metadata;

--- a/crates/proof/prover-service/src/metrics.rs
+++ b/crates/proof/prover-service/src/metrics.rs
@@ -15,8 +15,6 @@ use metrics::{counter, describe_counter, describe_histogram, histogram};
 pub const REQUESTS: &str = "prover_service.requests";
 /// RPC response latency in milliseconds. Tags: method, success
 pub const RESPONSE_LATENCY_MS: &str = "prover_service.response_latency_ms";
-/// Time spent in witness generation only. Tags: `proof_type`, success
-pub const WITNESS_GENERATION_DURATION_MS: &str = "prover_service.witness_generation_duration_ms";
 /// End-to-end wall-clock duration from proof request creation to completion.
 /// Tags: `proof_type`, status
 pub const PROOF_REQUEST_DURATION_MS: &str = "prover_service.proof_request_duration_ms";
@@ -48,10 +46,6 @@ impl ProverMetrics {
     pub fn init() {
         describe_counter!(REQUESTS, "Unified RPC request counter");
         describe_histogram!(RESPONSE_LATENCY_MS, "RPC response latency (ms)");
-        describe_histogram!(
-            WITNESS_GENERATION_DURATION_MS,
-            "Time spent in witness generation only (ms)"
-        );
         describe_histogram!(
             PROOF_REQUEST_DURATION_MS,
             "End-to-end wall-clock proof request duration (ms)"
@@ -96,15 +90,6 @@ pub fn inc_worker_requests(method: &str, success: bool, status_code: &str, worke
 pub fn record_response_latency(method: &str, success: bool, duration_ms: f64) {
     histogram!(RESPONSE_LATENCY_MS,
         "method" => method.to_string(),
-        "success" => success.to_string(),
-    )
-    .record(duration_ms);
-}
-
-/// Record witness generation duration in milliseconds.
-pub fn record_witness_generation_duration(proof_type: &str, success: bool, duration_ms: f64) {
-    histogram!(WITNESS_GENERATION_DURATION_MS,
-        "proof_type" => proof_type.to_string(),
         "success" => success.to_string(),
     )
     .record(duration_ms);

--- a/crates/proof/tee/nitro-host/src/backend.rs
+++ b/crates/proof/tee/nitro-host/src/backend.rs
@@ -35,6 +35,10 @@ impl ProverBackend for NitroBackend {
         Oracle::empty()
     }
 
+    fn prover_label(&self) -> &'static str {
+        base_proof_host::Metrics::PROVER_NITRO
+    }
+
     async fn prove(&self, witness: Oracle) -> Result<ProofResult, NitroHostError> {
         let preimages = witness.into_preimages().map_err(NitroHostError::Enclave)?;
         self.transport.prove(preimages).await

--- a/crates/proof/tee/nitro-host/src/transport.rs
+++ b/crates/proof/tee/nitro-host/src/transport.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use alloy_primitives::Address;
 use alloy_signer::utils::public_key_to_address;
+#[cfg(feature = "metrics")]
 use base_proof_host::Metrics;
 use base_proof_preimage::PreimageKey;
 use base_proof_primitives::ProofResult;
@@ -41,7 +42,8 @@ impl NitroTransport {
         &self,
         preimages: Vec<(PreimageKey, Vec<u8>)>,
     ) -> Result<ProofResult, NitroHostError> {
-        Metrics::witness_size_bytes()
+        #[cfg(feature = "metrics")]
+        Metrics::witness_size_bytes(Metrics::PROVER_NITRO)
             .record(preimages.iter().map(|(_, value)| value.len()).sum::<usize>() as f64);
 
         Ok(match self {

--- a/crates/proof/zk/backend/Cargo.toml
+++ b/crates/proof/zk/backend/Cargo.toml
@@ -14,6 +14,8 @@ workspace = true
 [dependencies]
 # base
 base-l1-head.workspace = true
+base-metrics.workspace = true
+base-proof-host.workspace = true
 base-proof-zk-host.workspace = true
 base-proof-succinct-elfs.workspace = true
 base-prover-service-protocol.workspace = true
@@ -52,3 +54,8 @@ tracing.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }
+
+[features]
+default = [ "metrics" ]
+# Declared so `base_metrics::timed!`/`time!` enable real timers in this crate.
+metrics = [ "base-metrics/metrics", "base-proof-host/metrics" ]

--- a/crates/proof/zk/backend/src/succinct/cluster.rs
+++ b/crates/proof/zk/backend/src/succinct/cluster.rs
@@ -599,7 +599,7 @@ impl ClusterZkProver {
         );
 
         let witness_start = std::time::Instant::now();
-        let stdin = self
+        let stdin = match self
             .provider
             .generate_witness(WitnessParams {
                 start_block,
@@ -615,23 +615,25 @@ impl ClusterZkProver {
                 intermediate_root_interval,
             })
             .await
-            .map_err(|e| {
+        {
+            Ok(stdin) => stdin,
+            Err(e) => {
                 error!(
                     start_block = start_block,
                     end_block = end_block,
                     error = %e,
                     "witness generation failed"
                 );
-                backend_error!("witness generation failed: {e}")
-            })?;
-        let witness_gen_duration_ms = witness_start.elapsed().as_secs_f64() * 1000.0;
+                return Err(backend_error!("witness generation failed: {e}"));
+            }
+        };
 
         info!(
             proof_id = %proof_id,
-            witness_gen_duration_ms = witness_gen_duration_ms,
             timeout_secs = self.config.timeout.as_secs(),
             range_cycle_limit = self.config.range_cycle_limit,
             range_gas_limit = self.config.range_gas_limit,
+            witness_gen_duration_ms = witness_start.elapsed().as_millis(),
             "witness generated, submitting range proof to SP1 cluster"
         );
 
@@ -793,8 +795,8 @@ impl ClusterZkProver {
         }
 
         let range_session = ClusterSessionId::parse(range_backend_session_id)?;
-        let witness_start = std::time::Instant::now();
         let range_proof = self.download_cluster_proof(&range_session).await?;
+        let witness_start = std::time::Instant::now();
         let stdin = self
             .provider
             .generate_aggregation_witness(
@@ -804,16 +806,16 @@ impl ClusterZkProver {
             )
             .await
             .map_err(|e| backend_error!("aggregation witness generation failed: {e}"))?;
-        let witness_gen_duration_ms = witness_start.elapsed().as_secs_f64() * 1000.0;
+        let witness_gen_duration_ms = witness_start.elapsed().as_millis();
 
         let session = self.create_cluster_request(proof_id, stdin, ProofMode::Plonk).await?;
         let backend_session_id = session.to_backend_session_id()?;
         info!(
             proof_id = %session.proof_id,
             proof_output_id = %session.proof_output_id,
-            witness_gen_duration_ms = witness_gen_duration_ms,
             cycle_limit = self.config.aggregation_cycle_limit,
             gas_limit = self.config.aggregation_gas_limit,
+            witness_gen_duration_ms = witness_gen_duration_ms,
             "aggregation proof request submitted to SP1 cluster"
         );
 

--- a/crates/proof/zk/backend/src/succinct/dry_run.rs
+++ b/crates/proof/zk/backend/src/succinct/dry_run.rs
@@ -172,7 +172,7 @@ impl DryRunZkProver {
         );
 
         let witness_start = std::time::Instant::now();
-        let stdin = self
+        let stdin = match self
             .provider
             .generate_witness(WitnessParams {
                 start_block,
@@ -188,27 +188,30 @@ impl DryRunZkProver {
                 intermediate_root_interval,
             })
             .await
-            .map_err(|e| {
+        {
+            Ok(stdin) => stdin,
+            Err(e) => {
                 error!(
                     start_block = start_block,
                     end_block = end_block,
                     error = %e,
                     "dry-run witness generation failed"
                 );
-                backend_error!("witness generation failed: {e}")
-            })?;
+                return Err(backend_error!("witness generation failed: {e}"));
+            }
+        };
         let witness_generation_ms =
             u64::try_from(witness_start.elapsed().as_millis()).unwrap_or(u64::MAX);
 
         let mut execution_stats =
             Self::execute_range_program(stdin, self.range_cycle_limit).await?;
+        // Histogram latency is recorded in the provider; this field keeps the dry-run API contract.
         execution_stats.witness_generation_ms = witness_generation_ms;
 
         info!(
             request_session_id = %request_session_id,
             total_instruction_cycles = execution_stats.total_instruction_cycles,
             total_sp1_gas = execution_stats.total_sp1_gas,
-            witness_generation_ms = witness_generation_ms,
             execution_ms = execution_stats.execution_ms,
             tracked_sections = execution_stats.cycle_tracker.len(),
             "dry-run SP1 execution completed"

--- a/crates/proof/zk/backend/src/succinct/network.rs
+++ b/crates/proof/zk/backend/src/succinct/network.rs
@@ -339,7 +339,7 @@ impl NetworkZkProver {
         );
 
         let witness_start = std::time::Instant::now();
-        let stdin = self
+        let stdin = match self
             .provider
             .generate_witness(WitnessParams {
                 start_block,
@@ -355,22 +355,24 @@ impl NetworkZkProver {
                 intermediate_root_interval,
             })
             .await
-            .map_err(|e| {
+        {
+            Ok(stdin) => stdin,
+            Err(e) => {
                 error!(
                     start_block = start_block,
                     end_block = end_block,
                     error = %e,
                     "witness generation failed"
                 );
-                backend_error!("witness generation failed: {e}")
-            })?;
-        let witness_gen_duration_ms = witness_start.elapsed().as_secs_f64() * 1000.0;
+                return Err(backend_error!("witness generation failed: {e}"));
+            }
+        };
 
         info!(
             request_session_id = %request_session_id,
-            witness_gen_duration_ms = witness_gen_duration_ms,
             range_cycle_limit = self.config.range_cycle_limit,
             range_gas_limit = self.config.range_gas_limit,
+            witness_gen_duration_ms = witness_start.elapsed().as_millis(),
             "witness generated, submitting range proof to SP1 Network"
         );
 
@@ -441,13 +443,12 @@ impl NetworkZkProver {
             )
             .await
             .map_err(|e| backend_error!("aggregation witness generation failed: {e}"))?;
-        let witness_gen_duration_ms = witness_start.elapsed().as_secs_f64() * 1000.0;
 
         info!(
             request_session_id = %request_session_id,
-            witness_gen_duration_ms = witness_gen_duration_ms,
             aggregation_cycle_limit = self.config.aggregation_cycle_limit,
             aggregation_gas_limit = self.config.aggregation_gas_limit,
+            witness_gen_duration_ms = witness_start.elapsed().as_millis(),
             "aggregation witness generated, submitting PLONK proof to SP1 Network"
         );
 

--- a/crates/proof/zk/backend/src/succinct/provider.rs
+++ b/crates/proof/zk/backend/src/succinct/provider.rs
@@ -4,6 +4,7 @@ use std::{error::Error as StdError, fmt, sync::Arc};
 
 use alloy_primitives::{Address, B256};
 use base_l1_head::{L1HeadCalculator, L1HeadError};
+use base_proof_host::Metrics;
 use base_proof_succinct_client_utils::boot::BootInfoStruct;
 use base_proof_succinct_host_utils::{
     fetcher::OPSuccinctDataFetcher, get_agg_proof_stdin, host::SuccinctHost,
@@ -154,6 +155,61 @@ impl OpSuccinctWitnessProvider {
         &self,
         params: WitnessParams<'_>,
     ) -> Result<SP1Stdin, WitnessError> {
+        let timer =
+            base_metrics::timed!(Metrics::witness_build_duration_seconds(Metrics::PROVER_SP1));
+        let stdin = self.generate_witness_inner(params).await?;
+        drop(timer);
+        #[cfg(feature = "metrics")]
+        Metrics::witness_size_bytes(Metrics::PROVER_SP1)
+            .record(stdin.buffer.iter().map(Vec::len).sum::<usize>() as f64);
+
+        info!(
+            start_block = params.start_block,
+            end_block = params.end_block,
+            "witness generation completed"
+        );
+
+        Ok(stdin)
+    }
+
+    /// Generate aggregation stdin from a completed compressed range proof.
+    pub async fn generate_aggregation_witness(
+        &self,
+        mut range_proof: SP1ProofWithPublicValues,
+        range_vk: &SP1VerifyingKey,
+        prover_address: Address,
+    ) -> Result<SP1Stdin, WitnessError> {
+        let boot_info: BootInfoStruct = range_proof.public_values.read();
+        let boot_infos = vec![boot_info];
+        let proofs = vec![range_proof.proof];
+
+        let header =
+            self.host.fetcher.get_latest_l1_head_in_batch(&boot_infos).await.map_err(|source| {
+                WitnessError::AggregationL1Head { source: source.into_boxed_dyn_error() }
+            })?;
+        let l1_head_hash = header.hash_slow();
+
+        let headers =
+            self.host.fetcher.get_header_preimages(&boot_infos, l1_head_hash).await.map_err(
+                |source| WitnessError::AggregationHeaders { source: source.into_boxed_dyn_error() },
+            )?;
+
+        info!(
+            l1_head_hash = %l1_head_hash,
+            num_headers = headers.len(),
+            "fetched L1 headers for aggregation proof"
+        );
+
+        get_agg_proof_stdin(proofs, boot_infos, headers, range_vk, l1_head_hash, prover_address)
+            .map_err(|source| WitnessError::AggregationStdin {
+                source: source.into_boxed_dyn_error(),
+            })
+    }
+
+    async fn generate_witness_inner(
+        &self,
+        params: WitnessParams<'_>,
+    ) -> Result<SP1Stdin, WitnessError> {
         let WitnessParams { start_block, end_block, l1_head, intermediate_root_interval } = params;
 
         info!(
@@ -209,48 +265,9 @@ impl OpSuccinctWitnessProvider {
             self.host.run(&host_args).await.map_err(|source| WitnessError::HostRun {
                 source: source.into_boxed_dyn_error(),
             })?;
-        let stdin = self
-            .host
+        self.host
             .witness_generator()
             .get_sp1_stdin(witness)
-            .map_err(|source| WitnessError::Stdin { source: source.into_boxed_dyn_error() })?;
-
-        info!(start_block = start_block, end_block = end_block, "witness generation completed");
-
-        Ok(stdin)
-    }
-
-    /// Generate aggregation stdin from a completed compressed range proof.
-    pub async fn generate_aggregation_witness(
-        &self,
-        mut range_proof: SP1ProofWithPublicValues,
-        range_vk: &SP1VerifyingKey,
-        prover_address: Address,
-    ) -> Result<SP1Stdin, WitnessError> {
-        let boot_info: BootInfoStruct = range_proof.public_values.read();
-        let boot_infos = vec![boot_info];
-        let proofs = vec![range_proof.proof];
-
-        let header =
-            self.host.fetcher.get_latest_l1_head_in_batch(&boot_infos).await.map_err(|source| {
-                WitnessError::AggregationL1Head { source: source.into_boxed_dyn_error() }
-            })?;
-        let l1_head_hash = header.hash_slow();
-
-        let headers =
-            self.host.fetcher.get_header_preimages(&boot_infos, l1_head_hash).await.map_err(
-                |source| WitnessError::AggregationHeaders { source: source.into_boxed_dyn_error() },
-            )?;
-
-        info!(
-            l1_head_hash = %l1_head_hash,
-            num_headers = headers.len(),
-            "fetched L1 headers for aggregation proof"
-        );
-
-        get_agg_proof_stdin(proofs, boot_infos, headers, range_vk, l1_head_hash, prover_address)
-            .map_err(|source| WitnessError::AggregationStdin {
-                source: source.into_boxed_dyn_error(),
-            })
+            .map_err(|source| WitnessError::Stdin { source: source.into_boxed_dyn_error() })
     }
 }

--- a/crates/utilities/metrics/src/timing_macros.rs
+++ b/crates/utilities/metrics/src/timing_macros.rs
@@ -8,7 +8,7 @@
 /// ```ignore
 /// let _timer = base_metrics::timed!(Metrics::proof_duration_seconds());
 ///
-/// let mut timer = base_metrics::timed!(Metrics::witness_build_duration_seconds());
+/// let mut timer = base_metrics::timed!(Metrics::witness_build_duration_seconds("nitro"));
 /// timer.stop();
 /// ```
 #[macro_export]


### PR DESCRIPTION
## Summary
Record base_proof_host witness_build_duration_seconds and witness_size_bytes with prover=sp1|nitro labels, centralize drop-based SP1 witness timing in the provider, and drop the unused prover-service witness generation histogram.