### PR TITLE
feat(runner): make BaseNode and BasePoolBuilder generic over pool extension E

### DIFF
--- a/crates/builder/core/src/flashblocks/service.rs
+++ b/crates/builder/core/src/flashblocks/service.rs
@@ -138,7 +138,7 @@ where
 {
     type ComponentsBuilder = ComponentsBuilder<
         BaseNodeTypes,
-        BasePoolBuilder,
+        BasePoolBuilder<BasePooledTransaction>,
         Self,
         BaseNetworkBuilder,
         BaseExecutorBuilder,

--- a/crates/execution/bundle/src/extension.rs
+++ b/crates/execution/bundle/src/extension.rs
@@ -1,8 +1,11 @@
 //! Wires the `eth_sendBundle` RPC and bundle transaction maintenance task.
 
-use std::sync::{
-    Arc,
-    atomic::{AtomicU64, Ordering},
+use std::{
+    fmt,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
 };
 
 use base_execution_txpool::{SendBundleApiImpl, SendBundleApiServer, maintain_bundle_transactions};
@@ -16,7 +19,10 @@ use tracing::info;
 #[derive(Debug)]
 pub struct BundleExtension;
 
-impl FromExtensionConfig for BundleExtension {
+impl<E> FromExtensionConfig<E> for BundleExtension
+where
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
     type Config = ();
 
     fn from_config(_config: Self::Config) -> Self {
@@ -24,12 +30,15 @@ impl FromExtensionConfig for BundleExtension {
     }
 }
 
-impl BaseNodeExtension for BundleExtension {
-    fn apply(self: Box<Self>, hooks: NodeHooks) -> NodeHooks {
+impl<E> BaseNodeExtension<E> for BundleExtension
+where
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
+    fn apply(self: Box<Self>, hooks: NodeHooks<E>) -> NodeHooks<E> {
         let current_block_number = Arc::new(AtomicU64::new(0));
         let block_number_for_rpc = Arc::clone(&current_block_number);
 
-        let hooks = hooks.add_rpc_module(move |ctx: &mut BaseRpcContext<'_>| {
+        let hooks = hooks.add_rpc_module(move |ctx: &mut BaseRpcContext<'_, E>| {
             let api = SendBundleApiImpl::new(ctx.pool().clone(), true, block_number_for_rpc);
             ctx.modules.merge_configured(api.into_rpc())?;
             info!("eth_sendBundle RPC enabled");

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -1,6 +1,6 @@
 //! Standard Base execution-node arguments and runner wiring.
 
-use std::{env, path::PathBuf, sync::Arc, time::Duration};
+use std::{env, fmt, path::PathBuf, sync::Arc, time::Duration};
 
 use base_bundle_extension::BundleExtension;
 use base_execution_eip8130_rpc_node::{Eip8130RpcExtension, Eip8130RpcMode};
@@ -8,7 +8,10 @@ use base_flashblocks::FlashblocksConfig;
 use base_flashblocks_node::FlashblocksExtension;
 use base_metering::{MeteredOpcodes, MeteringConfig, MeteringExtension, MeteringResourceLimits};
 use base_node_core::{HasRollupArgs, RollupArgs};
-use base_node_runner::{BaseNodeBuilder, BaseNodeRunner, LaunchedBaseNode, PayloadServiceBuilder};
+use base_node_runner::{
+    BaseNodeBuilder, BaseNodeRunner, DefaultPayloadServiceBuilder, LaunchedBaseNode,
+    PayloadServiceBuilder,
+};
 use base_observability_events::{
     DEFAULT_MAX_FILE_BYTES, DEFAULT_MAX_FILES, DEFAULT_QUEUE_CAPACITY,
     GlobalTransactionEventWriter, TransactionEventProducer, TransactionEventWriterConfig,
@@ -299,10 +302,14 @@ impl StandardBaseRethNode {
     }
 
     /// Installs the upgrade signal runtime extension when execution-side live reads are configured.
-    pub fn install_upgrade_signal_runtime_extension<SB: PayloadServiceBuilder>(
-        runner: &mut BaseNodeRunner<SB>,
+    pub fn install_upgrade_signal_runtime_extension<SB, E>(
+        runner: &mut BaseNodeRunner<SB, E>,
         rollup_args: &RollupArgs,
-    ) -> eyre::Result<()> {
+    ) -> eyre::Result<()>
+    where
+        SB: PayloadServiceBuilder<E>,
+        E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+    {
         let Some(config) = Self::upgrade_signal_config(rollup_args)? else {
             return Ok(());
         };
@@ -348,7 +355,10 @@ impl StandardBaseRethNode {
     }
 
     /// Builds a runner with the standard Base execution-node extensions installed.
-    pub fn runner(args: StandardNodeArgs) -> eyre::Result<BaseNodeRunner> {
+    pub fn runner<E>(args: StandardNodeArgs) -> eyre::Result<BaseNodeRunner<DefaultPayloadServiceBuilder, E>>
+    where
+        E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+    {
         let rollup_args = args.rpc.rollup_args.clone();
         // Fail fast on an incomplete upgrade-signal configuration before installing extensions.
         Self::validate_upgrade_signal_args(&rollup_args)?;
@@ -438,8 +448,13 @@ impl StandardBaseRethNode {
     }
 
     /// Builds a standard runner with process version metrics registered on startup.
-    pub fn runner_with_version_metrics(args: StandardNodeArgs) -> eyre::Result<BaseNodeRunner> {
-        let mut runner = Self::runner(args)?;
+    pub fn runner_with_version_metrics<E>(
+        args: StandardNodeArgs,
+    ) -> eyre::Result<BaseNodeRunner<DefaultPayloadServiceBuilder, E>>
+    where
+        E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+    {
+        let mut runner = Self::runner::<E>(args)?;
         runner.add_started_callback(|| {
             base_cli_utils::register_version_metrics!();
             Ok(())
@@ -451,7 +466,7 @@ impl StandardBaseRethNode {
     pub async fn run(builder: BaseNodeBuilder, args: StandardNodeArgs) -> eyre::Result<()> {
         let builder = Self::apply_initial_upgrade_signal(builder, &args).await?;
 
-        Self::runner_with_version_metrics(args)?.run(builder).await
+        Self::runner_with_version_metrics::<()>(args)?.run(builder).await
     }
 
     /// Launches the node and returns immediately with a handle.
@@ -480,7 +495,7 @@ impl StandardBaseRethNode {
         )
         .await?;
 
-        Self::runner_with_version_metrics(args)?.launch(builder).await
+        Self::runner_with_version_metrics::<()>(args)?.launch(builder).await
     }
 }
 

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -355,7 +355,9 @@ impl StandardBaseRethNode {
     }
 
     /// Builds a runner with the standard Base execution-node extensions installed.
-    pub fn runner<E>(args: StandardNodeArgs) -> eyre::Result<BaseNodeRunner<DefaultPayloadServiceBuilder, E>>
+    pub fn runner<E>(
+        args: StandardNodeArgs,
+    ) -> eyre::Result<BaseNodeRunner<DefaultPayloadServiceBuilder, E>>
     where
         E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
     {

--- a/crates/execution/cli/src/upgrade_signal.rs
+++ b/crates/execution/cli/src/upgrade_signal.rs
@@ -1,5 +1,7 @@
 //! Execution-node upgrade signal schedule application.
 
+use std::fmt;
+
 use alloy_provider::RootProvider;
 use base_execution_chainspec::BaseChainSpec;
 use base_node_runner::{BaseNodeExtension, BaseRpcContext, FromExtensionConfig, NodeHooks};
@@ -86,10 +88,13 @@ impl ExecutionUpgradeSignal {
     }
 
     /// Registers the execution admin RPC method for runtime upgrade signal refreshes.
-    pub fn register_runtime_refresh_rpc(
-        ctx: &mut BaseRpcContext<'_>,
+    pub fn register_runtime_refresh_rpc<E>(
+        ctx: &mut BaseRpcContext<'_, E>,
         config: ExecutionUpgradeSignalConfig,
-    ) -> eyre::Result<()> {
+    ) -> eyre::Result<()>
+    where
+        E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+    {
         if !config.signal_config.mode.allows_runtime_admin() {
             return Ok(());
         }
@@ -127,13 +132,16 @@ impl ExecutionUpgradeSignalRuntimeExtension {
     }
 }
 
-impl BaseNodeExtension for ExecutionUpgradeSignalRuntimeExtension {
-    fn apply(self: Box<Self>, hooks: NodeHooks) -> NodeHooks {
+impl<E> BaseNodeExtension<E> for ExecutionUpgradeSignalRuntimeExtension
+where
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
+    fn apply(self: Box<Self>, hooks: NodeHooks<E>) -> NodeHooks<E> {
         let config = self.config;
 
         let hooks = if config.signal_config.mode.allows_runtime_admin() {
             let rpc_config = config.clone();
-            hooks.add_rpc_module(move |ctx: &mut BaseRpcContext<'_>| {
+            hooks.add_rpc_module(move |ctx: &mut BaseRpcContext<'_, E>| {
                 ExecutionUpgradeSignal::register_runtime_refresh_rpc(ctx, rpc_config)
             })
         } else {
@@ -193,7 +201,10 @@ impl BaseNodeExtension for ExecutionUpgradeSignalRuntimeExtension {
     }
 }
 
-impl FromExtensionConfig for ExecutionUpgradeSignalRuntimeExtension {
+impl<E> FromExtensionConfig<E> for ExecutionUpgradeSignalRuntimeExtension
+where
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
     type Config = ExecutionUpgradeSignalConfig;
 
     fn from_config(config: Self::Config) -> Self {

--- a/crates/execution/eip8130-rpc-node/src/extension.rs
+++ b/crates/execution/eip8130-rpc-node/src/extension.rs
@@ -1,6 +1,8 @@
 //! `BaseNodeExtension` that registers the standalone EIP-8130
 //! `eth_getTransactionCount` override when flashblocks is not.
 
+use std::fmt;
+
 use base_execution_eip8130_rpc::{Eip8130EthApiExt, Eip8130EthApiOverrideServer};
 use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
 use tracing::info;
@@ -38,8 +40,11 @@ impl Eip8130RpcExtension {
     }
 }
 
-impl BaseNodeExtension for Eip8130RpcExtension {
-    fn apply(self: Box<Self>, hooks: NodeHooks) -> NodeHooks {
+impl<E> BaseNodeExtension<E> for Eip8130RpcExtension
+where
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
+    fn apply(self: Box<Self>, hooks: NodeHooks<E>) -> NodeHooks<E> {
         match self.mode {
             Eip8130RpcMode::Defer => {
                 info!(message = "EIP-8130 RPC override deferred to flashblocks");
@@ -55,7 +60,10 @@ impl BaseNodeExtension for Eip8130RpcExtension {
     }
 }
 
-impl FromExtensionConfig for Eip8130RpcExtension {
+impl<E> FromExtensionConfig<E> for Eip8130RpcExtension
+where
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
     type Config = Eip8130RpcMode;
 
     fn from_config(mode: Eip8130RpcMode) -> Self {

--- a/crates/execution/flashblocks-node/src/extension.rs
+++ b/crates/execution/flashblocks-node/src/extension.rs
@@ -1,7 +1,7 @@
 //! Contains the [`FlashblocksExtension`] which wires up the flashblocks feature
 //! (canonical block subscription and RPC surface) on the Base node builder.
 
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
 
 use base_flashblocks::{
     EthApiExt, EthApiOverrideServer, EthPubSub, EthPubSubApiServer, FlashblocksConfig,
@@ -26,9 +26,12 @@ impl FlashblocksExtension {
     }
 }
 
-impl BaseNodeExtension for FlashblocksExtension {
+impl<E> BaseNodeExtension<E> for FlashblocksExtension
+where
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
     /// Applies the extension to the supplied hooks.
-    fn apply(self: Box<Self>, hooks: NodeHooks) -> NodeHooks {
+    fn apply(self: Box<Self>, hooks: NodeHooks<E>) -> NodeHooks<E> {
         let Some(cfg) = self.config else {
             info!(message = "flashblocks integration is disabled");
             return hooks;
@@ -91,7 +94,10 @@ impl BaseNodeExtension for FlashblocksExtension {
     }
 }
 
-impl FromExtensionConfig for FlashblocksExtension {
+impl<E> FromExtensionConfig<E> for FlashblocksExtension
+where
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
     type Config = Option<FlashblocksConfig>;
 
     fn from_config(config: Self::Config) -> Self {

--- a/crates/execution/metering/src/extension.rs
+++ b/crates/execution/metering/src/extension.rs
@@ -1,7 +1,7 @@
 //! Contains the [`MeteringExtension`] which wires up the metering RPC surface
 //! on the Base node builder.
 
-use std::{num::NonZeroUsize, sync::Arc};
+use std::{fmt, num::NonZeroUsize, sync::Arc};
 
 use alloy_primitives::U256;
 use base_flashblocks::{FlashblocksAPI, FlashblocksConfig, FlashblocksState};
@@ -163,9 +163,12 @@ impl MeteringExtension {
     }
 }
 
-impl BaseNodeExtension for MeteringExtension {
+impl<E> BaseNodeExtension<E> for MeteringExtension
+where
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
     /// Applies the extension to the supplied hooks.
-    fn apply(self: Box<Self>, hooks: NodeHooks) -> NodeHooks {
+    fn apply(self: Box<Self>, hooks: NodeHooks<E>) -> NodeHooks<E> {
         if !self.enabled {
             return hooks;
         }
@@ -343,7 +346,10 @@ impl MeteringConfig {
     }
 }
 
-impl FromExtensionConfig for MeteringExtension {
+impl<E> FromExtensionConfig<E> for MeteringExtension
+where
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
     type Config = MeteringConfig;
 
     fn from_config(config: Self::Config) -> Self {

--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -879,8 +879,6 @@ pub struct BasePoolBuilder<T = BasePooledTransaction> {
     pub guard_limits: GuardLimits,
     /// Additional trusted EIP-7702 delegation targets for locked payers.
     pub additional_trusted_delegation_targets: AddressSet,
-    /// Marker for the pooled transaction type.
-    _pd: core::marker::PhantomData<T>,
 }
 
 impl<T> Default for BasePoolBuilder<T> {
@@ -891,7 +889,6 @@ impl<T> Default for BasePoolBuilder<T> {
             max_inflight_delegated_slots: 4,
             guard_limits: GuardLimits::default(),
             additional_trusted_delegation_targets: AddressSet::default(),
-            _pd: Default::default(),
         }
     }
 }
@@ -906,7 +903,6 @@ impl<T> Clone for BasePoolBuilder<T> {
             additional_trusted_delegation_targets: self
                 .additional_trusted_delegation_targets
                 .clone(),
-            _pd: core::marker::PhantomData,
         }
     }
 }

--- a/crates/execution/proofs/src/proofs.rs
+++ b/crates/execution/proofs/src/proofs.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::{fmt, sync::Arc, time::Duration};
 
 use base_execution_exex::BaseProofsExEx;
 use base_execution_rpc::{
@@ -33,9 +33,12 @@ impl ProofsHistoryExtension {
     }
 }
 
-impl BaseNodeExtension for ProofsHistoryExtension {
+impl<E> BaseNodeExtension<E> for ProofsHistoryExtension
+where
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
     /// Applies the extension to the supplied hooks.
-    fn apply(self: Box<Self>, mut hooks: NodeHooks) -> NodeHooks {
+    fn apply(self: Box<Self>, mut hooks: NodeHooks<E>) -> NodeHooks<E> {
         // TODO: if NodeHooks exposes the underlying Builder, we can call launch_node_with_proof_history
         let args = self.config;
         let proofs_history_enabled = args.proofs_history;
@@ -123,7 +126,10 @@ impl BaseNodeExtension for ProofsHistoryExtension {
     }
 }
 
-impl FromExtensionConfig for ProofsHistoryExtension {
+impl<E> FromExtensionConfig<E> for ProofsHistoryExtension
+where
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
     type Config = ProofsHistoryConfig;
 
     fn from_config(config: Self::Config) -> Self {
@@ -131,15 +137,16 @@ impl FromExtensionConfig for ProofsHistoryExtension {
     }
 }
 
-fn install_proofs_history<S>(
-    mut hooks: NodeHooks,
+fn install_proofs_history<S, E>(
+    mut hooks: NodeHooks<E>,
     storage_backend: Arc<S>,
     proofs_history_window: u64,
     proofs_history_prune_interval: Duration,
     proofs_history_verification_interval: u64,
-) -> NodeHooks
+) -> NodeHooks<E>
 where
     S: BaseProofsBatchStore + DatabaseMetrics + Send + Sync + 'static,
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
 {
     let storage: BaseProofsStorage<Arc<S>> = Arc::clone(&storage_backend).into();
     let storage_exec = storage.clone();

--- a/crates/execution/runner/src/builder.rs
+++ b/crates/execution/runner/src/builder.rs
@@ -17,36 +17,37 @@ use reth_node_builder::{
 use crate::types::{BaseComponentsBuilder, BaseNodeTypes, ConcreteBaseAddOns};
 
 /// Alias for the default Base components type.
-type BaseComponents = <BaseComponentsBuilder as NodeComponentsBuilder<BaseNodeTypes>>::Components;
+type BaseComponents<E> =
+    <BaseComponentsBuilder<E> as NodeComponentsBuilder<BaseNodeTypes<E>>>::Components;
 
 /// Convenience alias for the Base node adapter type used by the reth builder.
 ///
 /// Because `Components` depends only on pool, network, executor, and consensus builders (not the
 /// payload service builder), this type is identical regardless of which payload service is used.
-pub type BaseNodeAdapter = NodeAdapter<BaseNodeTypes, BaseComponents>;
+pub type BaseNodeAdapter<E = ()> = NodeAdapter<BaseNodeTypes<E>, BaseComponents<E>>;
 
 /// Convenience alias for the Base Eth API type exposed by the reth RPC add-ons.
-type BaseEthApi = <ConcreteBaseAddOns as RethRpcAddOns<BaseNodeAdapter>>::EthApi;
+type BaseEthApi<E> = <ConcreteBaseAddOns<E> as RethRpcAddOns<BaseNodeAdapter<E>>>::EthApi;
 
 /// Convenience alias for the full Base node handle produced after launch.
-type BaseFullNode = FullNode<BaseNodeAdapter, ConcreteBaseAddOns>;
+type BaseFullNode<E> = FullNode<BaseNodeAdapter<E>, ConcreteBaseAddOns<E>>;
 
 /// Alias for the RPC context used by Base extensions.
-pub type BaseRpcContext<'a> = RpcContext<'a, BaseNodeAdapter, BaseEthApi>;
+pub type BaseRpcContext<'a, E = ()> = RpcContext<'a, BaseNodeAdapter<E>, BaseEthApi<E>>;
 
 /// Hook type for extending RPC modules.
-type RpcModuleHook = Box<dyn FnOnce(&mut BaseRpcContext<'_>) -> Result<()> + Send + 'static>;
+type RpcModuleHook<E> = Box<dyn FnOnce(&mut BaseRpcContext<'_, E>) -> Result<()> + Send + 'static>;
 
 /// Hook type for extending add-ons.
-type AddOnsHook = Box<dyn FnOnce(ConcreteBaseAddOns) -> ConcreteBaseAddOns>;
+type AddOnsHook<E> = Box<dyn FnOnce(ConcreteBaseAddOns<E>) -> ConcreteBaseAddOns<E>>;
 
 /// Hook type for node-started callbacks.
-type NodeStartedHook = Box<dyn FnOnce(BaseFullNode) -> Result<()> + Send + 'static>;
+type NodeStartedHook<E> = Box<dyn FnOnce(BaseFullNode<E>) -> Result<()> + Send + 'static>;
 
 /// Type-erased `ExEx` factory.
-type BoxExExFactory = Box<
+type BoxExExFactory<E> = Box<
     dyn FnOnce(
-            ExExContext<BaseNodeAdapter>,
+            ExExContext<BaseNodeAdapter<E>>,
         ) -> BoxFuture<'static, eyre::Result<BoxFuture<'static, eyre::Result<()>>>>
         + Send
         + 'static,
@@ -56,8 +57,8 @@ type BoxExExFactory = Box<
 ///
 /// This is generic over the `NodeComponentsBuilder` (`CB`) so that both the default payload and
 /// the flashblocks payload service can be used interchangeably.
-pub type RethNodeBuilder<CB> =
-    WithLaunchContext<NodeBuilderWithComponents<BaseNodeTypes, CB, ConcreteBaseAddOns>>;
+pub type RethNodeBuilder<CB, E = ()> =
+    WithLaunchContext<NodeBuilderWithComponents<BaseNodeTypes<E>, CB, ConcreteBaseAddOns<E>>>;
 
 /// Pure hook accumulator for the Base node builder.
 ///
@@ -67,14 +68,20 @@ pub type RethNodeBuilder<CB> =
 /// [`apply_to`](Self::apply_to) to drain all hooks onto the concrete configured builder.
 ///
 /// After applying hooks, call [`.launch()`](RethNodeBuilder::launch) on the configured builder.
-pub struct NodeHooks {
-    rpc_hooks: Vec<RpcModuleHook>,
-    node_started_hooks: Vec<NodeStartedHook>,
-    add_ons_hooks: Vec<AddOnsHook>,
-    exex_hooks: Vec<(String, BoxExExFactory)>,
+pub struct NodeHooks<E = ()>
+where
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
+    rpc_hooks: Vec<RpcModuleHook<E>>,
+    node_started_hooks: Vec<NodeStartedHook<E>>,
+    add_ons_hooks: Vec<AddOnsHook<E>>,
+    exex_hooks: Vec<(String, BoxExExFactory<E>)>,
 }
 
-impl NodeHooks {
+impl<E> NodeHooks<E>
+where
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
     /// Create a new, empty `NodeHooks`.
     pub fn new() -> Self {
         Self {
@@ -89,16 +96,16 @@ impl NodeHooks {
     ///
     /// This is generic over `CB` so that it works with any payload service whose component
     /// builder produces the same concrete `Components` type as the default payload builder.
-    pub fn apply_to<CB>(self, mut builder: RethNodeBuilder<CB>) -> RethNodeBuilder<CB>
+    pub fn apply_to<CB>(self, mut builder: RethNodeBuilder<CB, E>) -> RethNodeBuilder<CB, E>
     where
-        CB: NodeComponentsBuilder<BaseNodeTypes, Components = BaseComponents>,
+        CB: NodeComponentsBuilder<BaseNodeTypes<E>, Components = BaseComponents<E>>,
     {
         let Self { rpc_hooks, node_started_hooks, exex_hooks, add_ons_hooks } = self;
 
         // Install ExEx hooks
         for (id, factory) in exex_hooks {
             builder =
-                builder.install_exex(id, move |ctx: ExExContext<BaseNodeAdapter>| factory(ctx));
+                builder.install_exex(id, move |ctx: ExExContext<BaseNodeAdapter<E>>| factory(ctx));
         }
 
         for hook in add_ons_hooks {
@@ -107,7 +114,7 @@ impl NodeHooks {
 
         // Install RPC hooks
         if !rpc_hooks.is_empty() {
-            builder = builder.extend_rpc_modules(move |mut ctx: BaseRpcContext<'_>| {
+            builder = builder.extend_rpc_modules(move |mut ctx: BaseRpcContext<'_, E>| {
                 for hook in rpc_hooks {
                     hook(&mut ctx)?;
                 }
@@ -117,7 +124,7 @@ impl NodeHooks {
 
         // Install node-started hooks
         if !node_started_hooks.is_empty() {
-            builder = builder.on_node_started(move |full_node: BaseFullNode| {
+            builder = builder.on_node_started(move |full_node: BaseFullNode<E>| {
                 for hook in node_started_hooks {
                     hook(full_node.clone())?;
                 }
@@ -131,7 +138,7 @@ impl NodeHooks {
     /// Adds an RPC hook that will run when RPC modules are configured.
     pub fn add_rpc_module<F>(mut self, hook: F) -> Self
     where
-        F: FnOnce(&mut BaseRpcContext<'_>) -> Result<()> + Send + 'static,
+        F: FnOnce(&mut BaseRpcContext<'_, E>) -> Result<()> + Send + 'static,
     {
         self.rpc_hooks.push(Box::new(hook));
         self
@@ -140,7 +147,7 @@ impl NodeHooks {
     /// Adds an add-ons hook that will run when the add-ons are configured.
     pub fn add_add_ons_hook<F>(mut self, hook: F) -> Self
     where
-        F: FnOnce(ConcreteBaseAddOns) -> ConcreteBaseAddOns + Send + 'static,
+        F: FnOnce(ConcreteBaseAddOns<E>) -> ConcreteBaseAddOns<E> + Send + 'static,
     {
         self.add_ons_hooks.push(Box::new(hook));
         self
@@ -149,20 +156,20 @@ impl NodeHooks {
     /// Adds a node-started hook that will run after the node has started.
     pub fn add_node_started_hook<F>(mut self, hook: F) -> Self
     where
-        F: FnOnce(BaseFullNode) -> Result<()> + Send + 'static,
+        F: FnOnce(BaseFullNode<E>) -> Result<()> + Send + 'static,
     {
         self.node_started_hooks.push(Box::new(hook));
         self
     }
 
     /// Installs an `ExEx` extension with the given name and closure.
-    pub fn install_exex<F, R, E>(mut self, exex_id: impl Into<String>, exex: F) -> Self
+    pub fn install_exex<F, R, Fut>(mut self, exex_id: impl Into<String>, exex: F) -> Self
     where
-        F: FnOnce(ExExContext<BaseNodeAdapter>) -> R + Send + 'static,
-        R: Future<Output = eyre::Result<E>> + Send,
-        E: Future<Output = eyre::Result<()>> + Send + 'static,
+        F: FnOnce(ExExContext<BaseNodeAdapter<E>>) -> R + Send + 'static,
+        R: Future<Output = eyre::Result<Fut>> + Send,
+        Fut: Future<Output = eyre::Result<()>> + Send + 'static,
     {
-        let factory: BoxExExFactory = Box::new(move |ctx| {
+        let factory: BoxExExFactory<E> = Box::new(move |ctx| {
             Box::pin(async move {
                 let inner = exex(ctx).await?;
                 Ok(Box::pin(inner) as BoxFuture<'static, eyre::Result<()>>)
@@ -173,13 +180,19 @@ impl NodeHooks {
     }
 }
 
-impl Default for NodeHooks {
+impl<E> Default for NodeHooks<E>
+where
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl fmt::Debug for NodeHooks {
+impl<E> fmt::Debug for NodeHooks<E>
+where
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("NodeHooks").finish_non_exhaustive()
     }

--- a/crates/execution/runner/src/extension.rs
+++ b/crates/execution/runner/src/extension.rs
@@ -1,19 +1,28 @@
 //! Traits describing node builder extensions.
 
-use std::fmt::Debug;
+use std::fmt::{self, Debug};
 
 use crate::NodeHooks;
 
 /// Customizes the node builder before launch.
 ///
+/// Generic over the pool extension type `E` (defaulting to `()`), matching the
+/// [`NodeHooks<E>`] the runner threads through.
+///
 /// Register extensions via [`BaseNodeRunner::install_ext`].
-pub trait BaseNodeExtension: Send + Sync + Debug {
+pub trait BaseNodeExtension<E = ()>: Send + Sync + Debug
+where
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
     /// Applies the extension to the supplied hooks.
-    fn apply(self: Box<Self>, hooks: NodeHooks) -> NodeHooks;
+    fn apply(self: Box<Self>, hooks: NodeHooks<E>) -> NodeHooks<E>;
 }
 
 /// An extension that can be built from a config.
-pub trait FromExtensionConfig: BaseNodeExtension + Sized {
+pub trait FromExtensionConfig<E = ()>: BaseNodeExtension<E> + Sized
+where
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
     /// Configuration type used to construct this extension.
     type Config;
 

--- a/crates/execution/runner/src/lib.rs
+++ b/crates/execution/runner/src/lib.rs
@@ -20,7 +20,9 @@ mod service;
 pub use service::{DefaultPayloadServiceBuilder, PayloadServiceBuilder};
 
 mod types;
-pub use types::{BaseComponentsBuilder, BaseNodeBuilder, BaseNodeTypes, BaseProvider};
+pub use types::{
+    BaseComponentsBuilder, BaseNodeBuilder, BaseNodeComponentsBuilder, BaseNodeTypes, BaseProvider,
+};
 
 mod node;
 pub use node::BaseNode;

--- a/crates/execution/runner/src/node.rs
+++ b/crates/execution/runner/src/node.rs
@@ -1,14 +1,17 @@
 //! Base Node types config.
 
-use base_common_consensus::BasePrimitives;
+use core::marker::PhantomData;
+
+use base_common_consensus::{
+    BasePooledTransaction as ConsensusPooledTransaction, BasePrimitives, BaseTransactionSigned,
+};
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_payload_builder::config::{BaseDAConfig, GasLimitConfig};
 use base_execution_rpc::eth::BaseEthApiBuilder;
-use base_execution_txpool::GuardLimits;
+use base_execution_txpool::{BasePooledTransaction, GuardLimits};
 use base_node_core::{
     BaseConsensusBuilder, BaseEngineApiBuilder, BaseEngineTypes, BaseExecutorBuilder,
-    BaseNetworkBuilder, BaseNodeComponentBuilder, BaseNodeTypes, BasePayloadValidatorBuilder,
-    BaseStorage,
+    BaseNetworkBuilder, BaseNodeTypes, BasePayloadValidatorBuilder, BaseStorage,
     args::RollupArgs,
     node::{BasePayloadBuilder, BasePoolBuilder},
 };
@@ -26,7 +29,7 @@ use crate::{BaseAddOns, BaseAddOnsBuilder};
 /// Type configuration for a regular Base node.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
-pub struct BaseNode {
+pub struct BaseNode<E = ()> {
     /// Additional Base args
     pub args: RollupArgs,
     /// Data availability configuration for the payload builder.
@@ -43,15 +46,17 @@ pub struct BaseNode {
     /// Whether to drop positively stale EIP-8130 transactions using their
     /// captured authorization manifest before execution.
     pub manifest_precheck_enabled: bool,
+    /// Marker for the pool transaction extension type.
+    _pd: PhantomData<E>,
 }
 
-impl Default for BaseNode {
+impl<E> Default for BaseNode<E> {
     fn default() -> Self {
         Self::new(RollupArgs::default())
     }
 }
 
-impl BaseNode {
+impl<E> BaseNode<E> {
     /// Creates a new instance of the Base node type.
     pub fn new(args: RollupArgs) -> Self {
         Self {
@@ -59,6 +64,7 @@ impl BaseNode {
             da_config: BaseDAConfig::default(),
             gas_limit_config: GasLimitConfig::default(),
             manifest_precheck_enabled: true,
+            _pd: PhantomData,
         }
     }
 
@@ -81,9 +87,21 @@ impl BaseNode {
     }
 
     /// Returns the components for the given [`RollupArgs`].
-    pub fn components<Node>(&self) -> BaseNodeComponentBuilder<Node>
+    pub fn components<Node>(
+        &self,
+    ) -> ComponentsBuilder<
+        Node,
+        BasePoolBuilder<
+            BasePooledTransaction<BaseTransactionSigned, ConsensusPooledTransaction, E>,
+        >,
+        BasicPayloadServiceBuilder<BasePayloadBuilder>,
+        BaseNetworkBuilder,
+        BaseExecutorBuilder,
+        BaseConsensusBuilder,
+    >
     where
         Node: FullNodeTypes<Types: BaseNodeTypes>,
+        E: core::fmt::Debug + Clone + Send + Sync + Unpin + 'static,
     {
         let RollupArgs {
             disable_txpool_gossip,
@@ -97,7 +115,9 @@ impl BaseNode {
         ComponentsBuilder::default()
             .node_types::<Node>()
             .pool(
-                BasePoolBuilder::default()
+                BasePoolBuilder::<
+                    BasePooledTransaction<BaseTransactionSigned, ConsensusPooledTransaction, E>,
+                >::default()
                     .with_max_inflight_delegated_slots(max_inflight_delegated_slots)
                     .with_guard_limits(GuardLimits {
                         signature_limit: mempool_sender_limit,
@@ -179,13 +199,16 @@ impl BaseNode {
     }
 }
 
-impl<N> Node<N> for BaseNode
+impl<N, E> Node<N> for BaseNode<E>
 where
     N: FullNodeTypes<Types: BaseNodeTypes>,
+    E: core::fmt::Debug + Clone + Send + Sync + Unpin + 'static,
 {
     type ComponentsBuilder = ComponentsBuilder<
         N,
-        BasePoolBuilder,
+        BasePoolBuilder<
+            BasePooledTransaction<BaseTransactionSigned, ConsensusPooledTransaction, E>,
+        >,
         BasicPayloadServiceBuilder<BasePayloadBuilder>,
         BaseNetworkBuilder,
         BaseExecutorBuilder,
@@ -209,7 +232,10 @@ where
     }
 }
 
-impl NodeTypes for BaseNode {
+impl<E> NodeTypes for BaseNode<E>
+where
+    E: core::fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
     type Primitives = BasePrimitives;
     type ChainSpec = BaseChainSpec;
     type Storage = BaseStorage;

--- a/crates/execution/runner/src/node.rs
+++ b/crates/execution/runner/src/node.rs
@@ -24,7 +24,7 @@ use reth_node_builder::{
 use reth_provider::providers::ProviderFactoryBuilder;
 use reth_rpc_api::eth::RpcTypes;
 
-use crate::{BaseAddOns, BaseAddOnsBuilder};
+use crate::{BaseAddOns, BaseAddOnsBuilder, BaseNodeComponentsBuilder};
 
 /// Type configuration for a regular Base node.
 #[derive(Debug, Clone)]
@@ -87,18 +87,7 @@ impl<E> BaseNode<E> {
     }
 
     /// Returns the components for the given [`RollupArgs`].
-    pub fn components<Node>(
-        &self,
-    ) -> ComponentsBuilder<
-        Node,
-        BasePoolBuilder<
-            BasePooledTransaction<BaseTransactionSigned, ConsensusPooledTransaction, E>,
-        >,
-        BasicPayloadServiceBuilder<BasePayloadBuilder>,
-        BaseNetworkBuilder,
-        BaseExecutorBuilder,
-        BaseConsensusBuilder,
-    >
+    pub fn components<Node>(&self) -> BaseNodeComponentsBuilder<Node, E>
     where
         Node: FullNodeTypes<Types: BaseNodeTypes>,
         E: core::fmt::Debug + Clone + Send + Sync + Unpin + 'static,
@@ -118,14 +107,14 @@ impl<E> BaseNode<E> {
                 BasePoolBuilder::<
                     BasePooledTransaction<BaseTransactionSigned, ConsensusPooledTransaction, E>,
                 >::default()
-                    .with_max_inflight_delegated_slots(max_inflight_delegated_slots)
-                    .with_guard_limits(GuardLimits {
-                        signature_limit: mempool_sender_limit,
-                        payment_limit: mempool_payer_limit,
-                    })
-                    .with_additional_trusted_delegation_targets(
-                        self.args.mempool_trusted_delegation_targets.iter().copied(),
-                    ),
+                .with_max_inflight_delegated_slots(max_inflight_delegated_slots)
+                .with_guard_limits(GuardLimits {
+                    signature_limit: mempool_sender_limit,
+                    payment_limit: mempool_payer_limit,
+                })
+                .with_additional_trusted_delegation_targets(
+                    self.args.mempool_trusted_delegation_targets.iter().copied(),
+                ),
             )
             .executor(BaseExecutorBuilder::default())
             .payload(BasicPayloadServiceBuilder::new(

--- a/crates/execution/runner/src/runner.rs
+++ b/crates/execution/runner/src/runner.rs
@@ -2,6 +2,8 @@
 
 use std::fmt;
 
+use core::marker::PhantomData;
+
 use base_execution_payload_builder::config::{BaseDAConfig, GasLimitConfig};
 use base_node_core::args::RollupArgs;
 use eyre::Result;
@@ -19,17 +21,27 @@ type StartedCallback = Box<dyn FnOnce() -> Result<()> + Send + 'static>;
 
 /// Handle to a launched Base execution node.
 #[derive(Debug)]
-pub struct LaunchedBaseNode {
+pub struct LaunchedBaseNode<E = ()>
+where
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
     /// The underlying reth node handle.
-    pub handle: NodeHandleFor<BaseNode>,
+    pub handle: NodeHandleFor<BaseNode<E>>,
 }
 
 /// Wraps the Base node configuration and orchestrates builder wiring.
-pub struct BaseNodeRunner<SB: PayloadServiceBuilder = DefaultPayloadServiceBuilder> {
+///
+/// Generic over the payload service builder `SB` and the pool extension `E`,
+/// the latter defaulting to `()` (no extension).
+pub struct BaseNodeRunner<SB = DefaultPayloadServiceBuilder, E = ()>
+where
+    SB: PayloadServiceBuilder<E>,
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
     /// Rollup-specific arguments forwarded to the Base node implementation.
     rollup_args: RollupArgs,
     /// Registered builder extensions.
-    extensions: Vec<Box<dyn BaseNodeExtension>>,
+    extensions: Vec<Box<dyn BaseNodeExtension<E>>>,
     /// Payload service builder.
     service_builder: SB,
     /// Shared DA configuration for the node and payload builder.
@@ -41,9 +53,14 @@ pub struct BaseNodeRunner<SB: PayloadServiceBuilder = DefaultPayloadServiceBuild
     manifest_precheck_enabled: bool,
     /// Binary-owned callbacks to run after the node has started.
     started_callbacks: Vec<StartedCallback>,
+    /// Marker for the pool extension type.
+    _pd: PhantomData<E>,
 }
 
-impl BaseNodeRunner<DefaultPayloadServiceBuilder> {
+impl<E> BaseNodeRunner<DefaultPayloadServiceBuilder, E>
+where
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
     /// Creates a new launcher using the provided rollup arguments.
     pub fn new(rollup_args: RollupArgs) -> Self {
         Self {
@@ -54,11 +71,16 @@ impl BaseNodeRunner<DefaultPayloadServiceBuilder> {
             gas_limit_config: None,
             manifest_precheck_enabled: true,
             started_callbacks: Vec::new(),
+            _pd: PhantomData,
         }
     }
 }
 
-impl<SB: PayloadServiceBuilder> fmt::Debug for BaseNodeRunner<SB> {
+impl<SB, E> fmt::Debug for BaseNodeRunner<SB, E>
+where
+    SB: PayloadServiceBuilder<E>,
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("BaseNodeRunner")
             .field("rollup_args", &self.rollup_args)
@@ -71,7 +93,11 @@ impl<SB: PayloadServiceBuilder> fmt::Debug for BaseNodeRunner<SB> {
     }
 }
 
-impl<SB: PayloadServiceBuilder> BaseNodeRunner<SB> {
+impl<SB, E> BaseNodeRunner<SB, E>
+where
+    SB: PayloadServiceBuilder<E>,
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
     /// Sets the shared DA configuration.
     pub fn with_da_config(mut self, da_config: BaseDAConfig) -> Self {
         self.da_config = Some(da_config);
@@ -91,7 +117,10 @@ impl<SB: PayloadServiceBuilder> BaseNodeRunner<SB> {
     }
 
     /// Swap the payload service builder.
-    pub fn with_service_builder<SB2: PayloadServiceBuilder>(self, sb: SB2) -> BaseNodeRunner<SB2> {
+    pub fn with_service_builder<SB2: PayloadServiceBuilder<E>>(
+        self,
+        sb: SB2,
+    ) -> BaseNodeRunner<SB2, E> {
         BaseNodeRunner {
             rollup_args: self.rollup_args,
             extensions: self.extensions,
@@ -100,11 +129,12 @@ impl<SB: PayloadServiceBuilder> BaseNodeRunner<SB> {
             gas_limit_config: self.gas_limit_config,
             manifest_precheck_enabled: self.manifest_precheck_enabled,
             started_callbacks: self.started_callbacks,
+            _pd: PhantomData,
         }
     }
 
     /// Registers a new builder extension.
-    pub fn install_ext<T: FromExtensionConfig + 'static>(&mut self, config: T::Config) {
+    pub fn install_ext<T: FromExtensionConfig<E> + 'static>(&mut self, config: T::Config) {
         self.extensions.push(Box::new(T::from_config(config)));
     }
 
@@ -127,12 +157,12 @@ impl<SB: PayloadServiceBuilder> BaseNodeRunner<SB> {
 
     /// Applies all Base-specific wiring to the supplied builder and returns a launched node
     /// handle without waiting for shutdown.
-    pub async fn launch(self, builder: BaseNodeBuilder) -> Result<LaunchedBaseNode> {
+    pub async fn launch(self, builder: BaseNodeBuilder) -> Result<LaunchedBaseNode<E>> {
         let handle = self.launch_node(builder).await?;
         Ok(LaunchedBaseNode { handle })
     }
 
-    async fn launch_node(self, builder: BaseNodeBuilder) -> Result<NodeHandleFor<BaseNode>> {
+    async fn launch_node(self, builder: BaseNodeBuilder) -> Result<NodeHandleFor<BaseNode<E>>> {
         info!(target: "base-runner", "starting custom Base node");
 
         let Self {
@@ -143,8 +173,9 @@ impl<SB: PayloadServiceBuilder> BaseNodeRunner<SB> {
             gas_limit_config,
             manifest_precheck_enabled,
             started_callbacks,
+            _pd,
         } = self;
-        let mut base_node = BaseNode::new(rollup_args);
+        let mut base_node = BaseNode::<E>::new(rollup_args);
         if let Some(da_config) = da_config {
             base_node = base_node.with_da_config(da_config);
         }
@@ -155,12 +186,13 @@ impl<SB: PayloadServiceBuilder> BaseNodeRunner<SB> {
         let components = service_builder.build_components(&base_node);
 
         let builder = builder
-            .with_types_and_provider::<BaseNode, BlockchainProvider<_>>()
+            .with_types_and_provider::<BaseNode<E>, BlockchainProvider<_>>()
             .with_components(components)
             .with_add_ons(base_node.add_ons())
             .on_component_initialized(move |_ctx| Ok(()));
 
-        let hooks = extensions.into_iter().fold(NodeHooks::new(), |hooks, ext| ext.apply(hooks));
+        let hooks =
+            extensions.into_iter().fold(NodeHooks::<E>::new(), |hooks, ext| ext.apply(hooks));
         let hooks = started_callbacks
             .into_iter()
             .fold(hooks, |hooks, callback| hooks.add_node_started_hook(move |_| callback()));

--- a/crates/execution/runner/src/runner.rs
+++ b/crates/execution/runner/src/runner.rs
@@ -1,8 +1,7 @@
 //! Contains the [`BaseNodeRunner`], which is responsible for configuring and launching a Base node.
 
-use std::fmt;
-
 use core::marker::PhantomData;
+use std::fmt;
 
 use base_execution_payload_builder::config::{BaseDAConfig, GasLimitConfig};
 use base_node_core::args::RollupArgs;

--- a/crates/execution/runner/src/service.rs
+++ b/crates/execution/runner/src/service.rs
@@ -1,5 +1,11 @@
 //! Trait for customizing the payload service used by the node.
 
+use std::fmt;
+
+use base_common_consensus::{
+    BasePooledTransaction as ConsensusPooledTransaction, BaseTransactionSigned,
+};
+use base_execution_txpool::BasePooledTransaction;
 use base_node_core::{
     BaseConsensusBuilder, BaseExecutorBuilder, BaseNetworkBuilder,
     node::{BasePayloadBuilder, BasePoolBuilder},
@@ -21,32 +27,38 @@ use crate::{
 ///
 /// The produced components must have the same concrete `Components` type as the default
 /// so that hooks (RPC, `ExEx`, node-started) remain type-compatible.
-pub trait PayloadServiceBuilder: Send + 'static {
+pub trait PayloadServiceBuilder<E = ()>: Send + 'static
+where
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
     /// The component builder type this produces.
     type ComponentsBuilder: NodeComponentsBuilder<
-            BaseNodeTypes,
-            Components = <BaseComponentsBuilder as NodeComponentsBuilder<BaseNodeTypes>>::Components,
+            BaseNodeTypes<E>,
+            Components = <BaseComponentsBuilder<E> as NodeComponentsBuilder<BaseNodeTypes<E>>>::Components,
         >;
 
     /// Build components using the given [`BaseNode`] configuration.
-    fn build_components(self, base_node: &BaseNode) -> Self::ComponentsBuilder;
+    fn build_components(self, base_node: &BaseNode<E>) -> Self::ComponentsBuilder;
 }
 
 /// Default payload service using the standard Base payload builder.
 #[derive(Debug, Default)]
 pub struct DefaultPayloadServiceBuilder;
 
-impl PayloadServiceBuilder for DefaultPayloadServiceBuilder {
+impl<E> PayloadServiceBuilder<E> for DefaultPayloadServiceBuilder
+where
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
     type ComponentsBuilder = ComponentsBuilder<
-        BaseNodeTypes,
-        BasePoolBuilder,
+        BaseNodeTypes<E>,
+        BasePoolBuilder<BasePooledTransaction<BaseTransactionSigned, ConsensusPooledTransaction, E>>,
         BasicPayloadServiceBuilder<BasePayloadBuilder>,
         BaseNetworkBuilder,
         BaseExecutorBuilder,
         BaseConsensusBuilder,
     >;
 
-    fn build_components(self, base_node: &BaseNode) -> Self::ComponentsBuilder {
+    fn build_components(self, base_node: &BaseNode<E>) -> Self::ComponentsBuilder {
         base_node.components()
     }
 }

--- a/crates/execution/runner/src/service.rs
+++ b/crates/execution/runner/src/service.rs
@@ -51,7 +51,9 @@ where
 {
     type ComponentsBuilder = ComponentsBuilder<
         BaseNodeTypes<E>,
-        BasePoolBuilder<BasePooledTransaction<BaseTransactionSigned, ConsensusPooledTransaction, E>>,
+        BasePoolBuilder<
+            BasePooledTransaction<BaseTransactionSigned, ConsensusPooledTransaction, E>,
+        >,
         BasicPayloadServiceBuilder<BasePayloadBuilder>,
         BaseNetworkBuilder,
         BaseExecutorBuilder,

--- a/crates/execution/runner/src/types.rs
+++ b/crates/execution/runner/src/types.rs
@@ -10,14 +10,14 @@ use reth_provider::providers::BlockchainProvider;
 use crate::node::BaseNode;
 
 /// Alias for the Base node type adapter used by the runner.
-pub type BaseNodeTypes = FullNodeTypesAdapter<BaseNode, DatabaseEnv, BaseProvider>;
+pub type BaseNodeTypes<E = ()> = FullNodeTypesAdapter<BaseNode<E>, DatabaseEnv, BaseProvider<E>>;
 /// Internal alias for the Base node components builder (default payload service).
-pub type BaseComponentsBuilder = <BaseNode as Node<BaseNodeTypes>>::ComponentsBuilder;
+pub type BaseComponentsBuilder<E = ()> = <BaseNode<E> as Node<BaseNodeTypes<E>>>::ComponentsBuilder;
 /// Internal alias for the Base node add-ons (all generics resolved).
-pub(crate) type ConcreteBaseAddOns = <BaseNode as Node<BaseNodeTypes>>::AddOns;
+pub(crate) type ConcreteBaseAddOns<E = ()> = <BaseNode<E> as Node<BaseNodeTypes<E>>>::AddOns;
 
 /// A [`BlockchainProvider`] instance.
-pub type BaseProvider = BlockchainProvider<NodeTypesWithDBAdapter<BaseNode, DatabaseEnv>>;
+pub type BaseProvider<E = ()> = BlockchainProvider<NodeTypesWithDBAdapter<BaseNode<E>, DatabaseEnv>>;
 
 /// Convenience alias for the Base node builder type.
 pub type BaseNodeBuilder = WithLaunchContext<NodeBuilder<DatabaseEnv, BaseChainSpec>>;

--- a/crates/execution/runner/src/types.rs
+++ b/crates/execution/runner/src/types.rs
@@ -1,9 +1,18 @@
 //! Type aliases for the Base node builder.
 
+use base_common_consensus::{
+    BasePooledTransaction as ConsensusPooledTransaction, BaseTransactionSigned,
+};
 use base_execution_chainspec::BaseChainSpec;
+use base_execution_txpool::BasePooledTransaction;
+use base_node_core::{
+    BaseConsensusBuilder, BaseExecutorBuilder, BaseNetworkBuilder,
+    node::{BasePayloadBuilder, BasePoolBuilder},
+};
 use reth_db::DatabaseEnv;
 use reth_node_builder::{
     FullNodeTypesAdapter, Node, NodeBuilder, NodeTypesWithDBAdapter, WithLaunchContext,
+    components::{BasicPayloadServiceBuilder, ComponentsBuilder},
 };
 use reth_provider::providers::BlockchainProvider;
 
@@ -13,11 +22,21 @@ use crate::node::BaseNode;
 pub type BaseNodeTypes<E = ()> = FullNodeTypesAdapter<BaseNode<E>, DatabaseEnv, BaseProvider<E>>;
 /// Internal alias for the Base node components builder (default payload service).
 pub type BaseComponentsBuilder<E = ()> = <BaseNode<E> as Node<BaseNodeTypes<E>>>::ComponentsBuilder;
+/// Alias for the explicit components builder produced by [`BaseNode::components`].
+pub type BaseNodeComponentsBuilder<Node, E = ()> = ComponentsBuilder<
+    Node,
+    BasePoolBuilder<BasePooledTransaction<BaseTransactionSigned, ConsensusPooledTransaction, E>>,
+    BasicPayloadServiceBuilder<BasePayloadBuilder>,
+    BaseNetworkBuilder,
+    BaseExecutorBuilder,
+    BaseConsensusBuilder,
+>;
 /// Internal alias for the Base node add-ons (all generics resolved).
 pub(crate) type ConcreteBaseAddOns<E = ()> = <BaseNode<E> as Node<BaseNodeTypes<E>>>::AddOns;
 
 /// A [`BlockchainProvider`] instance.
-pub type BaseProvider<E = ()> = BlockchainProvider<NodeTypesWithDBAdapter<BaseNode<E>, DatabaseEnv>>;
+pub type BaseProvider<E = ()> =
+    BlockchainProvider<NodeTypesWithDBAdapter<BaseNode<E>, DatabaseEnv>>;
 
 /// Convenience alias for the Base node builder type.
 pub type BaseNodeBuilder = WithLaunchContext<NodeBuilder<DatabaseEnv, BaseChainSpec>>;

--- a/crates/execution/tx-forwarding/src/extension.rs
+++ b/crates/execution/tx-forwarding/src/extension.rs
@@ -1,6 +1,8 @@
 //! Contains the [`TxForwardingExtension`] which wires up the transaction
 //! forwarding pipeline on the Base node builder.
 
+use std::fmt;
+
 use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
 use tracing::info;
 
@@ -20,9 +22,12 @@ impl TxForwardingExtension {
     }
 }
 
-impl BaseNodeExtension for TxForwardingExtension {
+impl<E> BaseNodeExtension<E> for TxForwardingExtension
+where
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
     /// Applies the extension to the supplied hooks.
-    fn apply(self: Box<Self>, hooks: NodeHooks) -> NodeHooks {
+    fn apply(self: Box<Self>, hooks: NodeHooks<E>) -> NodeHooks<E> {
         if !self.config.enabled || self.config.builder_urls.is_empty() {
             return hooks;
         }
@@ -55,7 +60,10 @@ impl BaseNodeExtension for TxForwardingExtension {
     }
 }
 
-impl FromExtensionConfig for TxForwardingExtension {
+impl<E> FromExtensionConfig<E> for TxForwardingExtension
+where
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
     type Config = TxForwardingConfig;
 
     fn from_config(config: Self::Config) -> Self {

--- a/crates/execution/txpool-rpc/src/extension.rs
+++ b/crates/execution/txpool-rpc/src/extension.rs
@@ -1,5 +1,7 @@
 //! `TxPool` RPC extension for registering transaction pool management APIs.
 
+use std::fmt;
+
 use base_node_runner::{BaseNodeExtension, BaseRpcContext, FromExtensionConfig, NodeHooks};
 use reth_rpc_server_types::RethRpcModule;
 
@@ -21,11 +23,14 @@ pub struct TxPoolRpcExtension {
     config: TxPoolRpcConfig,
 }
 
-impl BaseNodeExtension for TxPoolRpcExtension {
-    fn apply(self: Box<Self>, builder: NodeHooks) -> NodeHooks {
+impl<E> BaseNodeExtension<E> for TxPoolRpcExtension
+where
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
+    fn apply(self: Box<Self>, builder: NodeHooks<E>) -> NodeHooks<E> {
         let sequencer_rpc = self.config.sequencer_rpc;
 
-        builder.add_rpc_module(move |ctx: &mut BaseRpcContext<'_>| {
+        builder.add_rpc_module(move |ctx: &mut BaseRpcContext<'_, E>| {
             // Register TransactionStatusApi
             let status_api = TransactionStatusApiImpl::new(sequencer_rpc, ctx.pool().clone())
                 .expect("Failed to create transaction status API");
@@ -41,7 +46,10 @@ impl BaseNodeExtension for TxPoolRpcExtension {
     }
 }
 
-impl FromExtensionConfig for TxPoolRpcExtension {
+impl<E> FromExtensionConfig<E> for TxPoolRpcExtension
+where
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
     type Config = TxPoolRpcConfig;
 
     fn from_config(config: Self::Config) -> Self {

--- a/crates/execution/txpool-tracing/src/extension.rs
+++ b/crates/execution/txpool-tracing/src/extension.rs
@@ -1,7 +1,7 @@
 //! Contains the [`TxPoolExtension`] which wires up the transaction pool tracing
 //! subscription on the Base node builder.
 
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
 
 use base_flashblocks::{FlashblocksConfig, FlashblocksState};
 use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
@@ -38,9 +38,12 @@ impl TxPoolExtension {
     }
 }
 
-impl BaseNodeExtension for TxPoolExtension {
+impl<E> BaseNodeExtension<E> for TxPoolExtension
+where
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
     /// Applies the extension to the supplied builder.
-    fn apply(self: Box<Self>, builder: NodeHooks) -> NodeHooks {
+    fn apply(self: Box<Self>, builder: NodeHooks<E>) -> NodeHooks<E> {
         let config = self.config;
 
         let tracing_enabled = config.tracing_enabled;
@@ -73,7 +76,10 @@ impl BaseNodeExtension for TxPoolExtension {
     }
 }
 
-impl FromExtensionConfig for TxPoolExtension {
+impl<E> FromExtensionConfig<E> for TxPoolExtension
+where
+    E: fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
     type Config = TxpoolConfig;
 
     fn from_config(config: Self::Config) -> Self {

--- a/etc/systems/src/l2/in_process_builder.rs
+++ b/etc/systems/src/l2/in_process_builder.rs
@@ -120,7 +120,7 @@ impl InProcessBuilder {
 
         let rollup_args = RollupArgs::default();
 
-        let base_node = BaseNode::new(rollup_args.clone());
+        let base_node = BaseNode::<()>::new(rollup_args.clone());
 
         let addons: base_node_runner::BaseAddOns<
             _,

--- a/etc/systems/src/l2/in_process_client.rs
+++ b/etc/systems/src/l2/in_process_client.rs
@@ -283,10 +283,12 @@ impl InProcessClient {
         // TxPool RPC extension (management + status APIs)
         let txpool_rpc_config =
             TxPoolRpcConfig { sequencer_rpc: Some(config.builder_rpc_url.clone()) };
-        extensions.push(Box::new(TxPoolRpcExtension::from_config(txpool_rpc_config)));
+        extensions.push(Box::new(<TxPoolRpcExtension as FromExtensionConfig>::from_config(
+            txpool_rpc_config,
+        )));
 
         // Bundle extension (eth_sendBundle RPC + maintenance task)
-        extensions.push(Box::new(BundleExtension::from_config(())));
+        extensions.push(Box::new(<BundleExtension as FromExtensionConfig>::from_config(())));
 
         // TxPool tracing extension (tracing disabled for client)
         let txpool_config = TxpoolConfig {
@@ -299,14 +301,18 @@ impl InProcessClient {
 
         // TxForwarding extension (optional - forwards txs to builder RPC)
         if let Some(ref tx_fwd_config) = config.tx_forwarding_config {
-            extensions.push(Box::new(TxForwardingExtension::from_config(tx_fwd_config.clone())));
+            extensions.push(Box::new(<TxForwardingExtension as FromExtensionConfig>::from_config(
+                tx_fwd_config.clone(),
+            )));
         }
 
         // Upgrade signal runtime extension (optional - live L1 schedule polling)
         if let Some(ref signal_config) = config.upgrade_signal {
-            extensions.push(Box::new(ExecutionUpgradeSignalRuntimeExtension::from_config(
-                signal_config.clone(),
-            )));
+            extensions.push(Box::new(
+                <ExecutionUpgradeSignalRuntimeExtension as FromExtensionConfig>::from_config(
+                    signal_config.clone(),
+                ),
+            ));
         }
 
         // Flashblocks extension (must be last - uses replace_configured)


### PR DESCRIPTION
## Summary

Adds an `E = ()` generic parameter to `BaseNode` and `BasePoolBuilder` so downstream embedders can parameterize the per-transaction extension type without forking the runner.

Stacks on #4215.