### PR TITLE
system-tests: Refactor Setup for Downstream Consumers

### DIFF
--- a/etc/systems/src/l2/in_process_builder.rs
+++ b/etc/systems/src/l2/in_process_builder.rs
@@ -13,7 +13,7 @@ use base_builder_core::{BuilderConfig, FlashblocksServiceBuilder, test_utils::ge
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_txpool::{BasePooledTransaction, BuilderApiImpl, BuilderApiServer};
 use base_node_core::{args::RollupArgs, node::BasePoolBuilder};
-use base_node_runner::BaseNode;
+use base_node_runner::{BaseNode, BaseNodeExtension, NodeHooks};
 use eyre::{Result, WrapErr, eyre};
 use nanoid::nanoid;
 use reth_db::{
@@ -33,7 +33,7 @@ use url::Url;
 use crate::{config::BUILDER, setup::BUILDER_ENODE_ID};
 
 /// Configuration for starting an in-process builder.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct InProcessBuilderConfig {
     /// L2 genesis JSON content.
     pub genesis_json: Vec<u8>,
@@ -49,6 +49,11 @@ pub struct InProcessBuilderConfig {
     pub p2p_port: Option<u16>,
     /// Optional fixed Flashblocks port (uses random if None).
     pub flashblocks_port: Option<u16>,
+    /// Additional node extensions installed after the builder's built-in RPC wiring.
+    ///
+    /// Lets downstream consumers layer their own [`BaseNodeExtension`] onto the standard
+    /// in-process builder wiring without forking this crate.
+    pub extra_extensions: Vec<Box<dyn BaseNodeExtension>>,
 }
 
 /// An in-process builder node that replaces Docker-based `BuilderContainer`.
@@ -157,8 +162,14 @@ impl InProcessBuilder {
                 Ok(())
             });
 
-        let NodeHandle { node: node_handle, node_exit_future } =
-            node_builder.launch().await.wrap_err("Failed to launch builder node")?;
+        let NodeHandle { node: node_handle, node_exit_future } = config
+            .extra_extensions
+            .into_iter()
+            .fold(NodeHooks::new(), |hooks, ext| ext.apply(hooks))
+            .apply_to(node_builder)
+            .launch()
+            .await
+            .wrap_err("Failed to launch builder node")?;
 
         let http_api_addr = node_handle
             .rpc_server_handle()

--- a/etc/systems/src/l2/in_process_client.rs
+++ b/etc/systems/src/l2/in_process_client.rs
@@ -196,8 +196,12 @@ impl InProcessClient {
             .with_add_ons(base_node.add_ons())
             .on_component_initialized(move |_ctx| Ok(()));
 
-        let mut extensions: Vec<Box<dyn BaseNodeExtension>> = Self::build_extensions(&config)?;
+        let (mut extensions, flashblocks_config) = Self::build_extensions(&config)?;
         extensions.extend(config.extra_extensions);
+        // Flashblocks extension must be installed last: it uses `replace_configured`, which
+        // overwrites RPC methods (e.g. `eth_getTransactionCount`, `eth_subscribe`) that
+        // built-in and caller-supplied extensions alike may register.
+        extensions.push(Box::new(FlashblocksExtension::new(Some(flashblocks_config))));
         let NodeHandle { node: node_handle, node_exit_future } = extensions
             .into_iter()
             .fold(NodeHooks::new(), |b, ext| ext.apply(b))
@@ -274,8 +278,13 @@ impl InProcessClient {
         Ok((db, path))
     }
 
-    /// Builds the extensions for the client node.
-    fn build_extensions(config: &InProcessClientConfig) -> Result<Vec<Box<dyn BaseNodeExtension>>> {
+    /// Builds the client node's built-in extensions, excluding [`FlashblocksExtension`].
+    ///
+    /// [`FlashblocksExtension`] must be installed last (see [`Self::start`]), since it uses
+    /// `replace_configured` to overwrite RPC methods that other extensions may register.
+    fn build_extensions(
+        config: &InProcessClientConfig,
+    ) -> Result<(Vec<Box<dyn BaseNodeExtension>>, FlashblocksConfig)> {
         let mut extensions: Vec<Box<dyn BaseNodeExtension>> = Vec::new();
 
         // TxPool extension (tracing disabled for client)
@@ -315,9 +324,6 @@ impl InProcessClient {
             )));
         }
 
-        // Flashblocks extension (must be last - uses replace_configured)
-        extensions.push(Box::new(FlashblocksExtension::new(Some(flashblocks_config))));
-
-        Ok(extensions)
+        Ok((extensions, flashblocks_config))
     }
 }

--- a/etc/systems/src/l2/in_process_client.rs
+++ b/etc/systems/src/l2/in_process_client.rs
@@ -33,7 +33,7 @@ use reth_tasks::{Runtime, RuntimeBuilder, RuntimeConfig};
 use url::Url;
 
 /// Configuration for starting an in-process client node.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct InProcessClientConfig {
     /// L2 genesis JSON content.
     pub genesis_json: Vec<u8>,
@@ -63,6 +63,11 @@ pub struct InProcessClientConfig {
     /// extension is installed for live polling (and, in runtime-admin mode, automatic
     /// re-application of observed L1 changes).
     pub upgrade_signal: Option<ExecutionUpgradeSignalConfig>,
+    /// Additional node extensions installed after Base's built-in client extensions.
+    ///
+    /// Lets downstream consumers layer their own [`BaseNodeExtension`] — such as a custom RPC
+    /// method — onto the standard in-process client wiring without forking this crate.
+    pub extra_extensions: Vec<Box<dyn BaseNodeExtension>>,
 }
 
 /// In-process Base client node that syncs from a builder.
@@ -191,7 +196,8 @@ impl InProcessClient {
             .with_add_ons(base_node.add_ons())
             .on_component_initialized(move |_ctx| Ok(()));
 
-        let extensions: Vec<Box<dyn BaseNodeExtension>> = Self::build_extensions(&config)?;
+        let mut extensions: Vec<Box<dyn BaseNodeExtension>> = Self::build_extensions(&config)?;
+        extensions.extend(config.extra_extensions);
         let NodeHandle { node: node_handle, node_exit_future } = extensions
             .into_iter()
             .fold(NodeHooks::new(), |b, ext| ext.apply(b))

--- a/etc/systems/src/l2/shadow_sequencer.rs
+++ b/etc/systems/src/l2/shadow_sequencer.rs
@@ -86,6 +86,7 @@ impl ShadowSequencer {
             auth_port: None,
             p2p_port: None,
             flashblocks_port: None,
+            extra_extensions: Vec::new(),
         })
         .await
         .wrap_err("Failed to start shadow builder")?;

--- a/etc/systems/src/l2/stack.rs
+++ b/etc/systems/src/l2/stack.rs
@@ -14,6 +14,7 @@ use alloy_rpc_types_engine::JwtSecret;
 use base_common_genesis::RollupConfig;
 use base_consensus_node::NodeMode;
 use base_execution_cli::ExecutionUpgradeSignalConfig;
+use base_node_runner::BaseNodeExtension;
 use base_tx_forwarding::TxForwardingConfig;
 use base_upgrade_signal::UpgradeSignalConfig;
 use eyre::{Result, WrapErr};
@@ -38,7 +39,7 @@ pub enum L2ClientConsensusMode {
 }
 
 /// Configuration for the L2 stack.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct L2StackConfig {
     /// L2 genesis JSON content.
     pub l2_genesis: Vec<u8>,
@@ -74,6 +75,10 @@ pub struct L2StackConfig {
     pub execution_upgrade_signal: Option<ExecutionUpgradeSignalConfig>,
     /// Shadow sequencer configuration. When [`None`], no shadow sequencers are started.
     pub shadow_sequencers: Option<ShadowSequencersConfig>,
+    /// Additional node extensions installed on the builder, after its built-in RPC wiring.
+    pub extra_builder_extensions: Vec<Box<dyn BaseNodeExtension>>,
+    /// Additional node extensions installed on the client, after its built-in extensions.
+    pub extra_client_extensions: Vec<Box<dyn BaseNodeExtension>>,
 }
 
 /// Configuration for the shadow sequencers running alongside the active sequencer.
@@ -176,6 +181,7 @@ impl L2Stack {
             auth_port: container_config.and_then(|c| c.builder_auth_port),
             p2p_port: container_config.and_then(|c| c.builder_p2p_port),
             flashblocks_port: container_config.and_then(|c| c.builder_flashblocks_port),
+            extra_extensions: config.extra_builder_extensions,
         };
         let builder = InProcessBuilder::start(builder_config)
             .await
@@ -245,6 +251,7 @@ impl L2Stack {
             p2p_port: container_config.and_then(|c| c.client_p2p_port),
             tx_forwarding_config,
             upgrade_signal: config.execution_upgrade_signal.clone(),
+            extra_extensions: config.extra_client_extensions,
         };
         let client = InProcessClient::start(client_config)
             .await

--- a/etc/systems/src/setup/container.rs
+++ b/etc/systems/src/setup/container.rs
@@ -1,7 +1,7 @@
 use std::{
     fs,
     io::ErrorKind,
-    path::PathBuf,
+    path::{Path, PathBuf},
     process::Command,
     thread,
     time::{Duration, Instant},
@@ -124,17 +124,23 @@ impl SetupImage {
     }
 
     /// Finds the repository root that contains the setup Dockerfile.
+    ///
+    /// Resolved from this crate's `CARGO_MANIFEST_DIR` (fixed at compile time) rather than the
+    /// process's current directory, so this still finds the Dockerfile when `base-system-tests`
+    /// is compiled as a vendored git dependency from another workspace — where the process's
+    /// current directory is the consuming repo, not this one.
     pub fn find_repo_root() -> Result<PathBuf> {
-        let mut path = std::env::current_dir()?;
-        loop {
-            if path.join("Cargo.toml").exists() && path.join(SETUP_DOCKERFILE_PATH).exists() {
-                return Ok(path);
-            }
-            if !path.pop() {
-                break;
-            }
-        }
-        Err(eyre::eyre!("Could not find repository root with {SETUP_DOCKERFILE_PATH}"))
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(Path::parent)
+            .ok_or_else(|| eyre::eyre!("CARGO_MANIFEST_DIR has no grandparent directory"))?
+            .to_path_buf();
+        ensure!(
+            repo_root.join(SETUP_DOCKERFILE_PATH).exists(),
+            "{SETUP_DOCKERFILE_PATH} not found under {}",
+            repo_root.display()
+        );
+        Ok(repo_root)
     }
 }
 

--- a/etc/systems/src/smoke.rs
+++ b/etc/systems/src/smoke.rs
@@ -17,6 +17,7 @@ use alloy_signer_local::PrivateKeySigner;
 #[cfg(feature = "upgrade-signal")]
 use base_common_genesis::{BaseUpgrade, RollupConfig, RuntimeUpgradeRegistry, UpgradeActivation};
 use base_common_network::Base;
+use base_node_runner::BaseNodeExtension;
 use base_tx_forwarding::TxForwardingConfig;
 #[cfg(feature = "upgrade-signal")]
 use eyre::ensure;
@@ -283,6 +284,8 @@ pub struct SystemTestStackBuilder {
     client_consensus_mode: L2ClientConsensusMode,
     shadow_sequencer_count: usize,
     shadow_blocks_per_cycle: Option<NonZeroU64>,
+    extra_builder_extensions: Vec<Box<dyn BaseNodeExtension>>,
+    extra_client_extensions: Vec<Box<dyn BaseNodeExtension>>,
     #[cfg(feature = "upgrade-signal")]
     upgrade_signal: Option<UpgradeSignalStackOptions>,
 }
@@ -388,6 +391,26 @@ impl SystemTestStackBuilder {
     /// reconciliation cycle. Defaults to [`DEFAULT_SHADOW_BLOCKS_PER_CYCLE`].
     pub const fn with_shadow_blocks_per_cycle(mut self, blocks: NonZeroU64) -> Self {
         self.shadow_blocks_per_cycle = Some(blocks);
+        self
+    }
+
+    /// Registers an additional node extension on the L2 builder, installed after its built-in
+    /// RPC wiring.
+    ///
+    /// Lets downstream consumers layer their own [`BaseNodeExtension`] onto the standard builder
+    /// wiring without forking this crate.
+    pub fn with_builder_extension(mut self, extension: Box<dyn BaseNodeExtension>) -> Self {
+        self.extra_builder_extensions.push(extension);
+        self
+    }
+
+    /// Registers an additional node extension on the L2 client, installed after its built-in
+    /// extensions.
+    ///
+    /// Lets downstream consumers layer their own [`BaseNodeExtension`] — such as a custom RPC
+    /// method — onto the standard client wiring without forking this crate.
+    pub fn with_client_extension(mut self, extension: Box<dyn BaseNodeExtension>) -> Self {
+        self.extra_client_extensions.push(extension);
         self
     }
 
@@ -584,6 +607,8 @@ impl SystemTestStackBuilder {
             upgrade_signal: l2_upgrade_signal,
             execution_upgrade_signal: l2_execution_upgrade_signal,
             shadow_sequencers,
+            extra_builder_extensions: self.extra_builder_extensions,
+            extra_client_extensions: self.extra_client_extensions,
         };
 
         let l2_stack = L2Stack::start(l2_config).await.wrap_err("Failed to start L2 stack")?;


### PR DESCRIPTION
## Summary

Two related fixes to `base-system-tests` (`etc/systems/`) needed to let a downstream repo consume this crate as a git dependency and run the full in-process L1+L2 harness with its own custom builder/node logic:

- `SetupImage::find_repo_root` walked up from the process's current directory looking for `etc/docker/Dockerfile.devnet`. That only resolves when the crate is compiled in-repo — when pulled as a git dependency, cwd is the consuming repo, so the walk never finds the Dockerfile and the setup image (and the full `SystemTestStackBuilder` harness) can never build. Fixed by resolving the repo root from `CARGO_MANIFEST_DIR` instead, which is correct at compile time regardless of where the crate is built from.
- `InProcessBuilder`/`InProcessClient` hardcoded their `BaseNodeExtension` set with no way for a downstream consumer to layer on their own (e.g. a custom RPC method installed on top of the standard node wiring). Added `extra_extensions: Vec<Box<dyn BaseNodeExtension>>` to both configs, threaded through `L2StackConfig` and exposed as `with_builder_extension`/`with_client_extension` on `SystemTestStackBuilder`.

Both changes are additive — no behavior change for in-tree callers (extension lists default to empty, and none of the touched config structs were ever cloned as a whole, so dropping their now-inaccurate `Clone` derive is safe).

## Test plan
- [x] `cargo check -p base-system-tests --all-features`
- [x] `cargo check -p base-system-tests --no-default-features` (the configuration external git-dependency consumers use)
- [x] `cargo clippy -p base-system-tests --all-features --all-targets -- -D warnings`
- [x] `cargo +nightly fmt -p base-system-tests -- --check`
- [x] `just devnet tests` (requires local Docker daemon; not available in this environment — will run in CI's merge-queue system-test job)