### PR TITLE
feat(consensus): Add EL Sync Probes

### DIFF
--- a/actions/harness/src/engine.rs
+++ b/actions/harness/src/engine.rs
@@ -759,6 +759,10 @@ impl EngineClient for ActionEngineClient {
         };
         Ok(info)
     }
+
+    async fn el_syncing(&self) -> Result<bool, EngineClientError> {
+        Ok(false)
+    }
 }
 
 #[async_trait]

--- a/crates/consensus/engine/src/client.rs
+++ b/crates/consensus/engine/src/client.rs
@@ -11,7 +11,7 @@ use alloy_rpc_types_engine::{
     ClientVersionV1, ExecutionPayloadBodiesV1, ExecutionPayloadEnvelopeV2, ExecutionPayloadInputV2,
     ExecutionPayloadV3, ForkchoiceState, ForkchoiceUpdated, JwtSecret, PayloadId, PayloadStatus,
 };
-use alloy_rpc_types_eth::EIP1186AccountProofResponse;
+use alloy_rpc_types_eth::{EIP1186AccountProofResponse, SyncStatus as EthSyncStatus};
 use alloy_transport::{RpcError, TransportErrorKind, TransportResult};
 use alloy_transport_http::{
     AuthLayer, Http, HyperClient,
@@ -79,6 +79,9 @@ pub trait EngineClient: BaseEngineApi + Send + Sync {
         &self,
         numtag: BlockNumberOrTag,
     ) -> Result<Option<L2BlockInfo>, EngineClientError>;
+
+    /// Returns whether the execution layer reports an active sync.
+    async fn el_syncing(&self) -> Result<bool, EngineClientError>;
 }
 
 /// An Engine API client that provides authenticated HTTP communication with an execution layer.
@@ -239,6 +242,10 @@ where
             &block.map_header(|header| header.into_inner()).into_consensus(),
             &self.cfg.genesis,
         )?))
+    }
+
+    async fn el_syncing(&self) -> Result<bool, EngineClientError> {
+        Ok(matches!(self.engine.syncing().await?, EthSyncStatus::Info(_)))
     }
 }
 

--- a/crates/consensus/engine/src/task_queue/core.rs
+++ b/crates/consensus/engine/src/task_queue/core.rs
@@ -536,17 +536,15 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
     /// - `Err(_)` — transport or protocol error; the caller should treat this the same
     ///   as `Syncing` (pessimistic fallback).
     ///
-    /// **Precondition**: call this while `state.sync_state == Default::default()`.
-    /// If [`Engine::seed_state`] has already been called with the same `update`,
-    /// [`SynchronizeTask`] will detect an identical state and skip the FCU silently,
-    /// leaving `el_sync_finished = false`. Always probe before seeding.
+    /// The probe always sends the FCU, even when `update` matches the current state. The EL may
+    /// transition from `Syncing` to `Valid` without its forkchoice changing.
     pub async fn probe_el_sync(
         &mut self,
         client: Arc<EngineClient_>,
         config: Arc<RollupConfig>,
         update: EngineSyncStateUpdate,
     ) -> Result<bool, SynchronizeTaskError> {
-        SynchronizeTask::new(client, config, update).execute(&mut self.state).await?;
+        SynchronizeTask::new_forced(client, config, update).execute(&mut self.state).await?;
         self.state_sender.send_replace(self.state);
         Ok(self.state.el_sync_finished)
     }
@@ -864,11 +862,8 @@ mod tests {
         );
     }
 
-    /// Documents the "probe before `seed_state`" invariant: if `seed_state` is called first with
-    /// the same update, `SynchronizeTask`'s early-exit guard fires and the FCU is never sent,
-    /// leaving `el_sync_finished` = false even when the EL would respond Valid.
     #[tokio::test]
-    async fn probe_el_sync_after_seed_state_silently_skips_fcu() {
+    async fn probe_el_sync_after_seed_state_rechecks_same_forkchoice() {
         let head = test_block_info(100);
 
         let (state_tx, _) = watch::channel(EngineState::default());
@@ -880,17 +875,16 @@ mod tests {
         let update = EngineSyncStateUpdate { unsafe_head: Some(head), ..Default::default() };
 
         let mut engine = Engine::new(EngineState::default(), state_tx, queue_tx);
-        engine.seed_state(update); // seed first — the wrong order
+        engine.seed_state(update);
 
         let confirmed = engine
-            .probe_el_sync(Arc::clone(&client), Arc::new(RollupConfig::default()), update)
+            .probe_el_sync(client, Arc::new(RollupConfig::default()), update)
             .await
-            .expect("should not error");
+            .expect("forced probe should not error");
 
-        // SynchronizeTask short-circuits because state.sync_state == new_sync_state.
-        // el_sync_finished stays false despite Valid being configured.
-        assert!(!confirmed, "probe after seed short-circuits — documents the invariant");
-        assert!(!engine.state().el_sync_finished);
+        assert!(confirmed, "probe must re-check the same forkchoice");
+        assert!(engine.state().el_sync_finished);
+        assert_eq!(engine.state().sync_state.unsafe_head(), head);
     }
 
     /// Regression test: an attr-bearing FCU that returns `PayloadStatusEnum::Invalid` must

--- a/crates/consensus/engine/src/test_utils/engine_client.rs
+++ b/crates/consensus/engine/src/test_utils/engine_client.rs
@@ -56,6 +56,8 @@ pub struct MockEngineStorage {
     pub l2_blocks_by_label: HashMap<BlockNumberOrTag, L2RpcBlock>,
     /// Storage for block info responses by tag.
     pub block_info_by_tag: HashMap<BlockNumberOrTag, L2BlockInfo>,
+    /// Whether the EL is actively syncing.
+    pub el_syncing: bool,
 
     // Version-specific new_payload responses
     /// Storage for `new_payload_v2` responses.
@@ -171,6 +173,12 @@ impl MockEngineClientBuilder {
     /// Sets a block info response for a specific tag.
     pub fn with_block_info_by_tag(mut self, tag: BlockNumberOrTag, info: L2BlockInfo) -> Self {
         self.storage.block_info_by_tag.insert(tag, info);
+        self
+    }
+
+    /// Sets the `eth_syncing` response.
+    pub const fn with_el_syncing(mut self, syncing: bool) -> Self {
+        self.storage.el_syncing = syncing;
         self
     }
 
@@ -557,6 +565,10 @@ impl EngineClient for MockEngineClient {
     ) -> Result<Option<L2BlockInfo>, EngineClientError> {
         let storage = self.storage.read().await;
         Ok(storage.block_info_by_tag.get(&numtag).copied())
+    }
+
+    async fn el_syncing(&self) -> Result<bool, EngineClientError> {
+        Ok(self.storage.read().await.el_syncing)
     }
 }
 

--- a/crates/consensus/service/src/test_utils/fake_engine_client.rs
+++ b/crates/consensus/service/src/test_utils/fake_engine_client.rs
@@ -207,6 +207,10 @@ impl EngineClient for FakeEngineClient {
         self.cfg.as_ref()
     }
 
+    async fn el_syncing(&self) -> Result<bool, EngineClientError> {
+        Ok(false)
+    }
+
     fn get_l1_block(&self, block: BlockId) -> EthGetBlock<<Ethereum as Network>::BlockResponse> {
         EthGetBlock::new_provider(
             block,


### PR DESCRIPTION
## Summary

Sequencer startup cannot safely rely on reth's latest head alone: at genesis that head may mean either an idle node or an active snap sync, and a premature forkchoice update can disrupt the sync. It also needs to retry the exact same forkchoice because reth can move from Syncing to Valid without the head changing; same-state deduplication otherwise leaves startup stuck. This exposes eth_syncing and makes EL probes always reach reth, establishing the engine primitives for the sequencer startup flow.