### PR TITLE
feat(consensus): Expose Engine Sync Status

### DIFF
--- a/actions/harness/src/engine.rs
+++ b/actions/harness/src/engine.rs
@@ -986,4 +986,9 @@ impl SequencerEngineClient for ActionEngineClient {
         let guard = self.inner.lock().expect("action engine inner lock poisoned");
         Ok(guard.canonical_head)
     }
+
+    async fn el_sync_finished(&self) -> Result<bool, NodeEngineClientError> {
+        // The action engine executes synchronously and does not model background EL sync.
+        Ok(true)
+    }
 }

--- a/actions/harness/src/sequencer/engine_client.rs
+++ b/actions/harness/src/sequencer/engine_client.rs
@@ -63,4 +63,8 @@ impl SequencerEngineClient for ActionSequencerEngineClient {
     async fn get_unsafe_head(&self) -> Result<L2BlockInfo, base_consensus_node::EngineClientError> {
         self.inner.get_unsafe_head().await
     }
+
+    async fn el_sync_finished(&self) -> Result<bool, base_consensus_node::EngineClientError> {
+        self.inner.el_sync_finished().await
+    }
 }

--- a/crates/consensus/service/src/actors/sequencer/engine_client.rs
+++ b/crates/consensus/service/src/actors/sequencer/engine_client.rs
@@ -3,6 +3,7 @@ use std::{fmt::Debug, sync::Arc};
 use alloy_rpc_types_engine::PayloadId;
 use async_trait::async_trait;
 use base_common_rpc_types_engine::BaseExecutionPayloadEnvelope;
+use base_consensus_engine::EngineState;
 use base_protocol::{AttributesWithParent, L2BlockInfo};
 use derive_more::Constructor;
 use tokio::sync::{mpsc, watch};
@@ -63,6 +64,9 @@ pub trait SequencerEngineClient: Debug + Send + Sync {
         let _ = shadow_head;
         Err(EngineClientError::ShadowReconciliationDisabled)
     }
+
+    /// Returns whether the engine has completed execution-layer sync.
+    async fn el_sync_finished(&self) -> EngineClientResult<bool>;
 }
 
 /// Blanket implementation so [`Arc<T>`] can be used wherever `T: SequencerEngineClient`.
@@ -112,6 +116,10 @@ impl<T: SequencerEngineClient> SequencerEngineClient for Arc<T> {
     ) -> EngineClientResult<Option<L2BlockInfo>> {
         (**self).reconcile_shadow(shadow_head).await
     }
+
+    async fn el_sync_finished(&self) -> EngineClientResult<bool> {
+        (**self).el_sync_finished().await
+    }
 }
 
 /// Queue-based implementation of the [`SequencerEngineClient`] trait. This handles all
@@ -122,6 +130,8 @@ pub struct QueuedSequencerEngineClient {
     pub engine_actor_request_tx: mpsc::Sender<EngineActorRequest>,
     /// A channel to receive the latest unsafe head [`L2BlockInfo`].
     pub unsafe_head_rx: watch::Receiver<L2BlockInfo>,
+    /// A channel to receive the latest engine state.
+    pub engine_state_rx: watch::Receiver<EngineState>,
 }
 
 impl QueuedSequencerEngineClient {
@@ -152,6 +162,10 @@ impl QueuedSequencerEngineClient {
 impl SequencerEngineClient for QueuedSequencerEngineClient {
     async fn get_unsafe_head(&self) -> EngineClientResult<L2BlockInfo> {
         Ok(*self.unsafe_head_rx.borrow())
+    }
+
+    async fn el_sync_finished(&self) -> EngineClientResult<bool> {
+        Ok(self.engine_state_rx.borrow().el_sync_finished)
     }
 
     async fn reconcile_shadow(
@@ -297,6 +311,7 @@ mod tests {
     use alloy_primitives::{Address, B256, Bloom, U256};
     use alloy_rpc_types_engine::ExecutionPayloadV1;
     use base_common_rpc_types_engine::{BaseExecutionPayload, BaseExecutionPayloadEnvelope};
+    use base_consensus_engine::EngineState;
     use base_protocol::{BlockInfo, L2BlockInfo};
     use tokio::sync::{mpsc, watch};
 
@@ -333,11 +348,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn el_sync_finished_tracks_engine_state() {
+        let (request_tx, _request_rx) = mpsc::channel(1);
+        let (_, unsafe_head_rx) = watch::channel(L2BlockInfo::default());
+        let (engine_state_tx, engine_state_rx) = watch::channel(EngineState::default());
+        let client = QueuedSequencerEngineClient::new(request_tx, unsafe_head_rx, engine_state_rx);
+
+        assert!(!client.el_sync_finished().await.expect("read engine state"));
+
+        engine_state_tx.send_replace(EngineState { el_sync_finished: true, ..Default::default() });
+
+        assert!(client.el_sync_finished().await.expect("read updated engine state"));
+    }
+
+    #[tokio::test]
     async fn insert_unsafe_payload_returns_engine_ack() {
         let (request_tx, mut request_rx) = mpsc::channel(1);
         let (_, unsafe_head_rx) = watch::channel(L2BlockInfo::default());
+        let (_, engine_state_rx) = watch::channel(EngineState::default());
         let inserted_head = l2_head(1);
-        let client = QueuedSequencerEngineClient::new(request_tx, unsafe_head_rx);
+        let client = QueuedSequencerEngineClient::new(request_tx, unsafe_head_rx, engine_state_rx);
 
         let insert_handle =
             tokio::spawn(async move { client.insert_unsafe_payload(dummy_envelope()).await });
@@ -358,9 +388,10 @@ mod tests {
     async fn reconcile_shadow_returns_engine_ack() {
         let (request_tx, mut request_rx) = mpsc::channel(1);
         let (_, unsafe_head_rx) = watch::channel(L2BlockInfo::default());
+        let (_, engine_state_rx) = watch::channel(EngineState::default());
         let shadow_head = l2_head(12);
         let reconciled_head = l2_head(12);
-        let client = QueuedSequencerEngineClient::new(request_tx, unsafe_head_rx);
+        let client = QueuedSequencerEngineClient::new(request_tx, unsafe_head_rx, engine_state_rx);
 
         let reconcile_handle =
             tokio::spawn(async move { client.reconcile_shadow(shadow_head).await });

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -247,10 +247,14 @@ impl RollupNode {
         unsafe_head_tx: watch::Sender<L2BlockInfo>,
         conductor: Option<Arc<dyn Conductor>>,
         checkpoint_client: CheckpointClient,
-    ) -> (EngineActor<EngineRequestHandler<E, QueuedEngineDerivationClient>>, EngineRpcProcessor<E>)
-    {
+    ) -> (
+        EngineActor<EngineRequestHandler<E, QueuedEngineDerivationClient>>,
+        EngineRpcProcessor<E>,
+        watch::Receiver<EngineState>,
+    ) {
         let engine_state = EngineState::default();
         let (engine_state_tx, engine_state_rx) = watch::channel(engine_state);
+        let sequencer_engine_state_rx = engine_state_rx.clone();
         let (engine_queue_length_tx, engine_queue_length_rx) = watch::channel(0);
         let engine = Engine::new(engine_state, engine_state_tx, engine_queue_length_tx);
 
@@ -286,7 +290,7 @@ impl RollupNode {
         let engine_handler = EngineRequestHandler::new(engine_processor, shadow_gate);
         let engine_actor = EngineActor::new(cancellation_token, engine_request_rx, engine_handler);
 
-        (engine_actor, engine_rpc_processor)
+        (engine_actor, engine_rpc_processor, sequencer_engine_state_rx)
     }
 
     /// Starts the rollup node service.
@@ -437,15 +441,16 @@ impl RollupNode {
         let engine_conductor: Option<Arc<dyn Conductor>> =
             conductor.clone().map(|c| Arc::new(c) as Arc<dyn Conductor>);
 
-        let (engine_actor, engine_rpc_processor) = self.create_engine_actor(
-            engine_client,
-            cancellation.clone(),
-            engine_actor_request_rx,
-            QueuedEngineDerivationClient::new(derivation_actor_request_tx.clone()),
-            unsafe_head_tx,
-            engine_conductor,
-            checkpoint_client,
-        );
+        let (engine_actor, engine_rpc_processor, sequencer_engine_state_rx) = self
+            .create_engine_actor(
+                engine_client,
+                cancellation.clone(),
+                engine_actor_request_rx,
+                QueuedEngineDerivationClient::new(derivation_actor_request_tx.clone()),
+                unsafe_head_tx,
+                engine_conductor,
+                checkpoint_client,
+            );
 
         // Select the concrete derivation actor implementation based on
         // RollupNode configuration.
@@ -556,6 +561,7 @@ impl RollupNode {
             let sequencer_engine_client = QueuedSequencerEngineClient {
                 engine_actor_request_tx: engine_actor_request_tx.clone(),
                 unsafe_head_rx,
+                engine_state_rx: sequencer_engine_state_rx,
             };
 
             // Create the admin API channel


### PR DESCRIPTION
## Summary

A sequencer should only activate once its execution layer is ready; otherwise it can begin producing before the engine has finished syncing. Today the engine owns and broadcasts that readiness state, but the sequencer cannot observe it.

Pass the existing engine-state watch receiver into the sequencer client so follow-up activation policy can use the authoritative signal without polling, adding another actor request, or duplicating sync state. This PR only exposes the signal; it does not change sequencer behavior yet.