### PR TITLE
feat(builder): add generic InclusionPolicy hook seam to block builder

### DIFF
--- a/crates/builder/core/src/execution.rs
+++ b/crates/builder/core/src/execution.rs
@@ -155,6 +155,10 @@ pub enum TxnExecutionError {
     /// Metering data has not yet arrived for this transaction.
     #[error("metering data pending")]
     MeteringDataPending,
+
+    /// Inclusion policy skipped this transaction.
+    #[error("policy rejected")]
+    PolicyRejected,
 }
 
 impl TxnExecutionError {

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -44,8 +44,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::{Level, debug, span, trace, warn};
 
 use crate::{
-    BuilderConfig, BuilderMetrics, ExecutionInfo, ExecutionMeteringLimitExceeded, PayloadTxsBounds,
-    ResourceLimits, TxResources, TxnExecutionError, TxnOutcome,
+    BuilderConfig, BuilderMetrics, ExecutionInfo, ExecutionMeteringLimitExceeded, InclusionPolicy,
+    PayloadTxsBounds, ResourceLimits, TxResources, TxnExecutionError, TxnOutcome,
     transaction_events::{
         BuilderAcceptedEventData, BuilderConsideredEventData, BuilderRejectedEventData,
         BuilderTransactionEventContext, emit_builder_transaction_event, rejection_reason_code,
@@ -182,7 +182,8 @@ impl FlashblockDiagnostics {
             | TxnExecutionError::NonceTooLow
             | TxnExecutionError::InternalError(_)
             | TxnExecutionError::EvmError
-            | TxnExecutionError::MaxGasUsageExceeded => {
+            | TxnExecutionError::MaxGasUsageExceeded
+            | TxnExecutionError::PolicyRejected => {
                 self.txs_rejected_other += 1;
             }
         }
@@ -645,13 +646,18 @@ impl BasePayloadBuilderCtx {
     /// Executes the given best transactions and updates the execution info.
     ///
     /// Returns diagnostics summarizing transaction selection for the flashblock.
-    pub(super) fn execute_best_transactions(
+    pub(super) fn execute_best_transactions<Txs, P>(
         &self,
         info: &mut ExecutionInfo,
         db: &mut State<impl Database>,
-        best_txs: &mut impl PayloadTxsBounds,
+        best_txs: &mut Txs,
         limits: &ResourceLimits,
-    ) -> Result<FlashblockDiagnostics, PayloadBuilderError> {
+        inclusion_policy: &P,
+    ) -> Result<FlashblockDiagnostics, PayloadBuilderError>
+    where
+        Txs: PayloadTxsBounds,
+        P: InclusionPolicy<Txs::Transaction>,
+    {
         let execute_txs_start_time = Instant::now();
         let mut num_txs_considered = 0;
         let mut num_txs_simulated = 0;
@@ -845,7 +851,8 @@ impl BasePayloadBuilderCtx {
                 None => 0,
             };
 
-            let tx = tx.into_consensus();
+            let pooled_tx = tx;
+            let tx = pooled_tx.clone_into_consensus();
             let tx_hash = tx.tx_hash();
             let tx_uncompressed_size = tx.encode_2718_len() as u64;
 
@@ -1183,6 +1190,33 @@ impl BasePayloadBuilderCtx {
                 num_txs_simulated_fail += 1;
                 reverted_gas_used += gas_used;
                 BuilderMetrics::reverted_tx_gas_used().record(gas_used as f64);
+            }
+
+            if !inclusion_policy.should_include(&pooled_tx, is_success) {
+                let err = TxnExecutionError::PolicyRejected;
+                diag.record_rejection(&err);
+                let priority_fee = tx.effective_tip_per_gas(base_fee).unwrap_or(0) as f64;
+                record_rejected_tx_priority_fee(&err, priority_fee);
+                if err.is_permanent() {
+                    diag.permanently_rejected_txs.push(tx_hash);
+                }
+                self.emit_builder_decision_event(
+                    &payload_id,
+                    TransactionEventType::BuilderRejected,
+                    tx_hash,
+                    Some(ordering_position),
+                    || {
+                        BuilderRejectedEventData::from_error(
+                            &err,
+                            info,
+                            limits,
+                            Some(&tx_resources),
+                        )
+                    },
+                );
+                log_txn(Err(err));
+                best_txs.mark_invalid(tx.signer(), tx.nonce());
+                continue;
             }
 
             // add gas used by the transaction to cumulative gas used, before creating the

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -53,8 +53,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, metadata::Level, span, warn};
 
 use crate::{
-    BuilderConfig, BuilderMetrics, CandidateSource, DefaultCandidateSource, ExecutionInfo,
-    PayloadBuilder, ResourceLimits,
+    BuilderConfig, BuilderMetrics, CandidateSource, DefaultCandidateSource, DefaultInclusionPolicy,
+    ExecutionInfo, InclusionPolicy, PayloadBuilder, ResourceLimits,
     flashblocks::{
         FlashblocksExtraCtx, best_txs::BestFlashblocksTxs, context::BasePayloadBuilderCtx,
         generator::BuildArguments,
@@ -119,7 +119,12 @@ pub(super) struct BuilderOutputs {
 
 /// Base payload builder
 #[derive(Debug, Clone)]
-pub(super) struct BasePayloadBuilder<Pool, Client, S = DefaultCandidateSource> {
+pub(super) struct BasePayloadBuilder<
+    Pool,
+    Client,
+    S = DefaultCandidateSource,
+    P = DefaultInclusionPolicy,
+> {
     /// The type responsible for creating the evm.
     pub evm_config: BaseEvmConfig,
     /// The transaction pool
@@ -135,9 +140,11 @@ pub(super) struct BasePayloadBuilder<Pool, Client, S = DefaultCandidateSource> {
     last_emitted_flashblock_id: Arc<LastEmittedFlashblockId>,
     /// Transforms the candidate transaction stream drained by the build loop.
     candidate_source: S,
+    /// Decides whether executed candidate transactions should be included.
+    inclusion_policy: P,
 }
 
-impl<Pool, Client, S> BasePayloadBuilder<Pool, Client, S> {
+impl<Pool, Client, S, P> BasePayloadBuilder<Pool, Client, S, P> {
     /// `BasePayloadBuilder` constructor.
     pub(super) fn new(
         evm_config: BaseEvmConfig,
@@ -146,6 +153,7 @@ impl<Pool, Client, S> BasePayloadBuilder<Pool, Client, S> {
         config: BuilderConfig,
         outputs: BuilderOutputs,
         candidate_source: S,
+        inclusion_policy: P,
     ) -> Self {
         Self {
             evm_config,
@@ -155,6 +163,7 @@ impl<Pool, Client, S> BasePayloadBuilder<Pool, Client, S> {
             outputs,
             last_emitted_flashblock_id: Arc::default(),
             candidate_source,
+            inclusion_policy,
         }
     }
 
@@ -167,12 +176,13 @@ impl<Pool, Client, S> BasePayloadBuilder<Pool, Client, S> {
     }
 }
 
-impl<Pool, Client, S> reth_basic_payload_builder::PayloadBuilder
-    for BasePayloadBuilder<Pool, Client, S>
+impl<Pool, Client, S, P> reth_basic_payload_builder::PayloadBuilder
+    for BasePayloadBuilder<Pool, Client, S, P>
 where
     Pool: Clone + Send + Sync,
     Client: Clone + Send + Sync,
     S: Clone + Send + Sync,
+    P: Clone + Send + Sync,
 {
     type Attributes = BasePayloadBuilderAttributes<BaseTransactionSigned>;
     type BuiltPayload = BaseBuiltPayload;
@@ -199,11 +209,12 @@ where
     }
 }
 
-impl<Pool, Client, S> BasePayloadBuilder<Pool, Client, S>
+impl<Pool, Client, S, P> BasePayloadBuilder<Pool, Client, S, P>
 where
     Pool: PoolBounds,
     Client: ClientBounds,
     S: CandidateSource<Pool::Transaction>,
+    P: InclusionPolicy<Pool::Transaction>,
 {
     fn get_base_payload_builder_ctx(
         &self,
@@ -562,8 +573,8 @@ where
 
     #[allow(clippy::too_many_arguments)]
     async fn build_next_flashblock<
-        DB: Database<Error = ProviderError> + std::fmt::Debug + AsRef<P> + revm::Database,
-        P: StateRootProvider + HashedPostStateProvider + StorageRootProvider,
+        DB: Database<Error = ProviderError> + std::fmt::Debug + AsRef<Provider> + revm::Database,
+        Provider: StateRootProvider + HashedPostStateProvider + StorageRootProvider,
     >(
         &self,
         ctx: &BasePayloadBuilderCtx,
@@ -655,7 +666,7 @@ where
             block_uncompressed_size_limit: ctx.builder_config.max_uncompressed_block_size,
         };
         let diag = ctx
-            .execute_best_transactions(info, state, best_txs, &limits)
+            .execute_best_transactions(info, state, best_txs, &limits, &self.inclusion_policy)
             .wrap_err("failed to execute best transactions")?;
 
         // Evict permanently rejected transactions from the iterator and pool.
@@ -950,7 +961,7 @@ where
     }
 
     /// Finalize the payload by computing the state root and publishing via the watch channel.
-    fn finalize_payload<DB, P>(
+    fn finalize_payload<DB, Provider>(
         &self,
         state: &mut State<DB>,
         ctx: &BasePayloadBuilderCtx,
@@ -958,8 +969,8 @@ where
         payload_tx: &watch::Sender<Option<BaseBuiltPayload>>,
     ) -> Result<(), PayloadBuilderError>
     where
-        DB: Database<Error = ProviderError> + AsRef<P>,
-        P: StateRootProvider + HashedPostStateProvider + StorageRootProvider,
+        DB: Database<Error = ProviderError> + AsRef<Provider>,
+        Provider: StateRootProvider + HashedPostStateProvider + StorageRootProvider,
     {
         let start_time = Instant::now();
 
@@ -1077,11 +1088,12 @@ where
 }
 
 #[async_trait::async_trait]
-impl<Pool, Client, S> PayloadBuilder for BasePayloadBuilder<Pool, Client, S>
+impl<Pool, Client, S, P> PayloadBuilder for BasePayloadBuilder<Pool, Client, S, P>
 where
     Pool: PoolBounds,
     Client: ClientBounds,
     S: CandidateSource<Pool::Transaction> + Clone + Unpin + 'static,
+    P: InclusionPolicy<Pool::Transaction> + Clone + Unpin + 'static,
 {
     type Attributes = BasePayloadBuilderAttributes<BaseTransactionSigned>;
     type BuiltPayload = BaseBuiltPayload;

--- a/crates/builder/core/src/flashblocks/service.rs
+++ b/crates/builder/core/src/flashblocks/service.rs
@@ -138,7 +138,7 @@ where
 {
     type ComponentsBuilder = ComponentsBuilder<
         BaseNodeTypes,
-        BasePoolBuilder,
+        BasePoolBuilder<BasePooledTransaction>,
         Self,
         BaseNetworkBuilder,
         BaseExecutorBuilder,

--- a/crates/builder/core/src/flashblocks/service.rs
+++ b/crates/builder/core/src/flashblocks/service.rs
@@ -25,37 +25,64 @@ use super::{
     payload::{BasePayloadBuilder, BuilderOutputs},
 };
 use crate::{
-    BuilderConfig, CandidateSource, DefaultCandidateSource, RejectedTxForwarder,
+    BuilderConfig, CandidateSource, DefaultCandidateSource, DefaultInclusionPolicy,
+    InclusionPolicy, RejectedTxForwarder,
     traits::{NodeBounds, PoolBounds},
 };
 
 /// Builder for the flashblocks payload service.
 ///
-/// Holds a [`BuilderConfig`] and a [`CandidateSource`], and implements
+/// Holds a [`BuilderConfig`], a [`CandidateSource`], and an [`InclusionPolicy`], and implements
 /// [`BasePayloadServiceBuilder`] to spawn the flashblocks payload builder service, which produces
 /// sub-block chunks (flashblocks) at sub-second intervals during block construction.
 ///
-/// The candidate source defaults to [`DefaultCandidateSource`] (the pool's best transactions,
-/// unchanged); use [`FlashblocksServiceBuilder::with_candidate_source`] to supply an alternative.
+/// The injectable seams default to [`DefaultCandidateSource`] and [`DefaultInclusionPolicy`]; use
+/// [`FlashblocksServiceBuilder::with_candidate_source`] and
+/// [`FlashblocksServiceBuilder::with_inclusion_policy`] to supply alternatives.
 #[derive(Debug)]
-pub struct FlashblocksServiceBuilder<S = DefaultCandidateSource> {
+pub struct FlashblocksServiceBuilder<S = DefaultCandidateSource, P = DefaultInclusionPolicy> {
     config: BuilderConfig,
     candidate_source: S,
+    inclusion_policy: P,
 }
 
 impl FlashblocksServiceBuilder {
     /// Create a service builder that uses the default candidate source
     /// (the pool's priority-ordered best transactions, unchanged).
     pub const fn new(config: BuilderConfig) -> Self {
-        Self { config, candidate_source: DefaultCandidateSource }
+        Self {
+            config,
+            candidate_source: DefaultCandidateSource,
+            inclusion_policy: DefaultInclusionPolicy,
+        }
     }
 }
 
-impl<S> FlashblocksServiceBuilder<S> {
+impl<S, P> FlashblocksServiceBuilder<S, P> {
     /// Replace the candidate transaction source used by the flashblocks build loop.
     #[must_use]
-    pub fn with_candidate_source<S2>(self, candidate_source: S2) -> FlashblocksServiceBuilder<S2> {
-        FlashblocksServiceBuilder { config: self.config, candidate_source }
+    pub fn with_candidate_source<S2>(
+        self,
+        candidate_source: S2,
+    ) -> FlashblocksServiceBuilder<S2, P> {
+        FlashblocksServiceBuilder {
+            config: self.config,
+            candidate_source,
+            inclusion_policy: self.inclusion_policy,
+        }
+    }
+
+    /// Replace the inclusion policy used by the flashblocks build loop.
+    #[must_use]
+    pub fn with_inclusion_policy<P2>(
+        self,
+        inclusion_policy: P2,
+    ) -> FlashblocksServiceBuilder<S, P2> {
+        FlashblocksServiceBuilder {
+            config: self.config,
+            candidate_source: self.candidate_source,
+            inclusion_policy,
+        }
     }
 
     fn spawn_payload_builder_service<Node, Pool>(
@@ -67,6 +94,7 @@ impl<S> FlashblocksServiceBuilder<S> {
         Node: NodeBounds,
         Pool: PoolBounds,
         S: CandidateSource<Pool::Transaction> + Clone + Unpin + 'static,
+        P: InclusionPolicy<Pool::Transaction> + Clone + Unpin + 'static,
     {
         let (built_payload_tx, built_payload_rx) = tokio::sync::mpsc::channel(16);
 
@@ -90,6 +118,7 @@ impl<S> FlashblocksServiceBuilder<S> {
             self.config.clone(),
             BuilderOutputs { payload_tx: built_payload_tx, ws_pub, rejected_tx_sender },
             self.candidate_source.clone(),
+            self.inclusion_policy.clone(),
         );
         let payload_generator = BlockPayloadJobGenerator::with_builder(
             ctx.provider().clone(),
@@ -115,12 +144,13 @@ impl<S> FlashblocksServiceBuilder<S> {
     }
 }
 
-impl<Node, Pool, S> PayloadServiceBuilder<Node, Pool, BaseEvmConfig>
-    for FlashblocksServiceBuilder<S>
+impl<Node, Pool, S, P> PayloadServiceBuilder<Node, Pool, BaseEvmConfig>
+    for FlashblocksServiceBuilder<S, P>
 where
     Node: NodeBounds,
     Pool: PoolBounds,
     S: CandidateSource<Pool::Transaction> + Clone + Unpin + 'static,
+    P: InclusionPolicy<Pool::Transaction> + Clone + Unpin + 'static,
 {
     async fn spawn_payload_builder_service(
         self,
@@ -132,9 +162,10 @@ where
     }
 }
 
-impl<S> BasePayloadServiceBuilder for FlashblocksServiceBuilder<S>
+impl<S, P> BasePayloadServiceBuilder for FlashblocksServiceBuilder<S, P>
 where
     S: CandidateSource<BasePooledTransaction> + Clone + Unpin + 'static,
+    P: InclusionPolicy<BasePooledTransaction> + Clone + Unpin + 'static,
 {
     type ComponentsBuilder = ComponentsBuilder<
         BaseNodeTypes,

--- a/crates/builder/core/src/inclusion_policy.rs
+++ b/crates/builder/core/src/inclusion_policy.rs
@@ -1,0 +1,107 @@
+//! Pluggable transaction inclusion policy for the flashblocks build loop.
+//!
+//! When building a (flash)block the builder executes each candidate transaction before committing
+//! its state changes. [`InclusionPolicy`] lets that post-execution decision be customized — using
+//! the original pooled transaction plus the execution success flag — without forking the build loop.
+//!
+//! [`DefaultInclusionPolicy`] is the default and includes every executed transaction, reproducing
+//! prior behavior byte-for-byte.
+
+use base_execution_txpool::BasePooledTx;
+
+/// The boxed inclusion policy used when callers need dynamic dispatch.
+pub type BoxedInclusionPolicy<T> = Box<dyn InclusionPolicy<T>>;
+
+/// Decides whether an executed candidate transaction should be included in the current payload.
+///
+/// The builder calls [`InclusionPolicy::should_include`] after execution has produced an outcome
+/// and before state changes are committed. Implementations receive the original pooled transaction
+/// so any admission-time extension data can be inspected while it is still available.
+pub trait InclusionPolicy<T>: Send + Sync + std::fmt::Debug + 'static
+where
+    T: BasePooledTx,
+{
+    /// Returns `true` when the transaction should be included in the payload.
+    fn should_include(&self, tx: &T, is_success: bool) -> bool;
+}
+
+impl<T> InclusionPolicy<T> for BoxedInclusionPolicy<T>
+where
+    T: BasePooledTx,
+{
+    fn should_include(&self, tx: &T, is_success: bool) -> bool {
+        self.as_ref().should_include(tx, is_success)
+    }
+}
+
+/// The default inclusion policy: include every executed transaction.
+///
+/// This reproduces prior behavior byte-for-byte — every candidate that reaches the post-execution
+/// decision point is included.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DefaultInclusionPolicy;
+
+impl<T> InclusionPolicy<T> for DefaultInclusionPolicy
+where
+    T: BasePooledTx,
+{
+    fn should_include(&self, _tx: &T, _is_success: bool) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_eips::eip2718::Encodable2718;
+    use base_common_consensus::BaseTransactionSigned;
+    use base_execution_txpool::BasePooledTransaction;
+    use base_test_utils::Account;
+    use reth_primitives_traits::Recovered;
+    use reth_transaction_pool::test_utils::TransactionBuilder;
+
+    use super::*;
+    use crate::TxnExecutionError;
+
+    #[derive(Debug)]
+    struct AlwaysSkip;
+
+    impl InclusionPolicy<BasePooledTransaction> for AlwaysSkip {
+        fn should_include(&self, _tx: &BasePooledTransaction, _is_success: bool) -> bool {
+            false
+        }
+    }
+
+    fn test_tx() -> BasePooledTransaction {
+        let alice = Account::Alice;
+        let bob = Account::Bob;
+
+        let signed_tx = TransactionBuilder::default()
+            .signer(alice.signer_b256())
+            .chain_id(1)
+            .nonce(0)
+            .to(bob.address())
+            .value(1_000)
+            .gas_limit(21_000)
+            .max_fee_per_gas(10)
+            .max_priority_fee_per_gas(1)
+            .into_eip1559();
+        let tx = BaseTransactionSigned::Eip1559(
+            signed_tx.as_eip1559().expect("eip1559 transaction").clone(),
+        );
+
+        let recovered = Recovered::new_unchecked(tx, alice.address());
+        let len = recovered.encode_2718_len();
+        BasePooledTransaction::new(recovered, len)
+    }
+
+    #[test]
+    fn default_policy_includes_non_successful_outcome() {
+        assert!(DefaultInclusionPolicy.should_include(&test_tx(), false));
+    }
+
+    #[test]
+    fn skip_policy_excludes_and_policy_error_is_not_permanent() {
+        assert!(!AlwaysSkip.should_include(&test_tx(), true));
+        assert!(!TxnExecutionError::PolicyRejected.is_permanent());
+    }
+}

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -10,6 +10,9 @@
 mod candidate_source;
 pub use candidate_source::{BoxedBestTransactions, CandidateSource, DefaultCandidateSource};
 
+mod inclusion_policy;
+pub use inclusion_policy::{BoxedInclusionPolicy, DefaultInclusionPolicy, InclusionPolicy};
+
 mod config;
 pub use config::BuilderConfig;
 

--- a/crates/builder/core/src/transaction_events.rs
+++ b/crates/builder/core/src/transaction_events.rs
@@ -443,6 +443,7 @@ pub(crate) const fn rejection_reason_code(err: &TxnExecutionError) -> &'static s
         TxnExecutionError::EvmError => "evm_error",
         TxnExecutionError::MaxGasUsageExceeded => "max_gas_usage_exceeded",
         TxnExecutionError::MeteringDataPending => "metering_data_pending",
+        TxnExecutionError::PolicyRejected => "policy_rejected",
     }
 }
 

--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -879,8 +879,6 @@ pub struct BasePoolBuilder<T = BasePooledTransaction> {
     pub guard_limits: GuardLimits,
     /// Additional trusted EIP-7702 delegation targets for locked payers.
     pub additional_trusted_delegation_targets: AddressSet,
-    /// Marker for the pooled transaction type.
-    _pd: core::marker::PhantomData<T>,
 }
 
 impl<T> Default for BasePoolBuilder<T> {
@@ -891,7 +889,6 @@ impl<T> Default for BasePoolBuilder<T> {
             max_inflight_delegated_slots: 4,
             guard_limits: GuardLimits::default(),
             additional_trusted_delegation_targets: AddressSet::default(),
-            _pd: Default::default(),
         }
     }
 }
@@ -906,7 +903,6 @@ impl<T> Clone for BasePoolBuilder<T> {
             additional_trusted_delegation_targets: self
                 .additional_trusted_delegation_targets
                 .clone(),
-            _pd: core::marker::PhantomData,
         }
     }
 }

--- a/crates/execution/runner/src/node.rs
+++ b/crates/execution/runner/src/node.rs
@@ -1,14 +1,17 @@
 //! Base Node types config.
 
-use base_common_consensus::BasePrimitives;
+use core::marker::PhantomData;
+
+use base_common_consensus::{
+    BasePooledTransaction as ConsensusPooledTransaction, BasePrimitives, BaseTransactionSigned,
+};
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_payload_builder::config::{BaseDAConfig, GasLimitConfig};
 use base_execution_rpc::eth::BaseEthApiBuilder;
-use base_execution_txpool::GuardLimits;
+use base_execution_txpool::{BasePooledTransaction, GuardLimits};
 use base_node_core::{
     BaseConsensusBuilder, BaseEngineApiBuilder, BaseEngineTypes, BaseExecutorBuilder,
-    BaseNetworkBuilder, BaseNodeComponentBuilder, BaseNodeTypes, BasePayloadValidatorBuilder,
-    BaseStorage,
+    BaseNetworkBuilder, BaseNodeTypes, BasePayloadValidatorBuilder, BaseStorage,
     args::RollupArgs,
     node::{BasePayloadBuilder, BasePoolBuilder},
 };
@@ -26,7 +29,7 @@ use crate::{BaseAddOns, BaseAddOnsBuilder};
 /// Type configuration for a regular Base node.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
-pub struct BaseNode {
+pub struct BaseNode<E = ()> {
     /// Additional Base args
     pub args: RollupArgs,
     /// Data availability configuration for the payload builder.
@@ -43,15 +46,17 @@ pub struct BaseNode {
     /// Whether to drop positively stale EIP-8130 transactions using their
     /// captured authorization manifest before execution.
     pub manifest_precheck_enabled: bool,
+    /// Marker for the pool transaction extension type.
+    _pd: PhantomData<E>,
 }
 
-impl Default for BaseNode {
+impl<E> Default for BaseNode<E> {
     fn default() -> Self {
         Self::new(RollupArgs::default())
     }
 }
 
-impl BaseNode {
+impl<E> BaseNode<E> {
     /// Creates a new instance of the Base node type.
     pub fn new(args: RollupArgs) -> Self {
         Self {
@@ -59,6 +64,7 @@ impl BaseNode {
             da_config: BaseDAConfig::default(),
             gas_limit_config: GasLimitConfig::default(),
             manifest_precheck_enabled: true,
+            _pd: PhantomData,
         }
     }
 
@@ -81,9 +87,21 @@ impl BaseNode {
     }
 
     /// Returns the components for the given [`RollupArgs`].
-    pub fn components<Node>(&self) -> BaseNodeComponentBuilder<Node>
+    pub fn components<Node>(
+        &self,
+    ) -> ComponentsBuilder<
+        Node,
+        BasePoolBuilder<
+            BasePooledTransaction<BaseTransactionSigned, ConsensusPooledTransaction, E>,
+        >,
+        BasicPayloadServiceBuilder<BasePayloadBuilder>,
+        BaseNetworkBuilder,
+        BaseExecutorBuilder,
+        BaseConsensusBuilder,
+    >
     where
         Node: FullNodeTypes<Types: BaseNodeTypes>,
+        E: core::fmt::Debug + Clone + Send + Sync + Unpin + 'static,
     {
         let RollupArgs {
             disable_txpool_gossip,
@@ -97,7 +115,9 @@ impl BaseNode {
         ComponentsBuilder::default()
             .node_types::<Node>()
             .pool(
-                BasePoolBuilder::default()
+                BasePoolBuilder::<
+                    BasePooledTransaction<BaseTransactionSigned, ConsensusPooledTransaction, E>,
+                >::default()
                     .with_max_inflight_delegated_slots(max_inflight_delegated_slots)
                     .with_guard_limits(GuardLimits {
                         signature_limit: mempool_sender_limit,
@@ -179,13 +199,16 @@ impl BaseNode {
     }
 }
 
-impl<N> Node<N> for BaseNode
+impl<N, E> Node<N> for BaseNode<E>
 where
     N: FullNodeTypes<Types: BaseNodeTypes>,
+    E: core::fmt::Debug + Clone + Send + Sync + Unpin + 'static,
 {
     type ComponentsBuilder = ComponentsBuilder<
         N,
-        BasePoolBuilder,
+        BasePoolBuilder<
+            BasePooledTransaction<BaseTransactionSigned, ConsensusPooledTransaction, E>,
+        >,
         BasicPayloadServiceBuilder<BasePayloadBuilder>,
         BaseNetworkBuilder,
         BaseExecutorBuilder,
@@ -209,7 +232,10 @@ where
     }
 }
 
-impl NodeTypes for BaseNode {
+impl<E> NodeTypes for BaseNode<E>
+where
+    E: core::fmt::Debug + Clone + Send + Sync + Unpin + 'static,
+{
     type Primitives = BasePrimitives;
     type ChainSpec = BaseChainSpec;
     type Storage = BaseStorage;

--- a/crates/execution/runner/src/types.rs
+++ b/crates/execution/runner/src/types.rs
@@ -10,14 +10,14 @@ use reth_provider::providers::BlockchainProvider;
 use crate::node::BaseNode;
 
 /// Alias for the Base node type adapter used by the runner.
-pub type BaseNodeTypes = FullNodeTypesAdapter<BaseNode, DatabaseEnv, BaseProvider>;
+pub type BaseNodeTypes = FullNodeTypesAdapter<BaseNode<()>, DatabaseEnv, BaseProvider>;
 /// Internal alias for the Base node components builder (default payload service).
-pub type BaseComponentsBuilder = <BaseNode as Node<BaseNodeTypes>>::ComponentsBuilder;
+pub type BaseComponentsBuilder = <BaseNode<()> as Node<BaseNodeTypes>>::ComponentsBuilder;
 /// Internal alias for the Base node add-ons (all generics resolved).
-pub(crate) type ConcreteBaseAddOns = <BaseNode as Node<BaseNodeTypes>>::AddOns;
+pub(crate) type ConcreteBaseAddOns = <BaseNode<()> as Node<BaseNodeTypes>>::AddOns;
 
 /// A [`BlockchainProvider`] instance.
-pub type BaseProvider = BlockchainProvider<NodeTypesWithDBAdapter<BaseNode, DatabaseEnv>>;
+pub type BaseProvider = BlockchainProvider<NodeTypesWithDBAdapter<BaseNode<()>, DatabaseEnv>>;
 
 /// Convenience alias for the Base node builder type.
 pub type BaseNodeBuilder = WithLaunchContext<NodeBuilder<DatabaseEnv, BaseChainSpec>>;


### PR DESCRIPTION
## Summary

Adds a pluggable `InclusionPolicy<T>` seam to the block builder's post-execution window. After each transaction is executed (outcome known), the policy decides whether to include or skip it. The default (`DefaultInclusionPolicy`) always includes, reproducing current behavior byte-for-byte.

Mirrors the existing `CandidateSource` injectable seam pattern.

Stacks on #4264 (G2 runner generics).