### PR TITLE
feat(builder): Share Execution Cache With Builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3585,6 +3585,7 @@ dependencies = [
  "reth-cli-util",
  "reth-db",
  "reth-evm",
+ "reth-execution-cache",
  "reth-execution-types",
  "reth-ipc",
  "reth-network-peers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -355,6 +355,7 @@ reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "2382
 reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-exex-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }
 reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "2382a2b05a0f15ab5469ea1db152c944f3736f6c" }

--- a/crates/builder/core/Cargo.toml
+++ b/crates/builder/core/Cargo.toml
@@ -47,6 +47,7 @@ reth-rpc-eth-types.workspace = true
 reth-rpc-engine-api.workspace = true
 reth-execution-types.workspace = true
 reth-payload-builder.workspace = true
+reth-execution-cache.workspace = true
 base-execution-txpool.workspace = true
 reth-transaction-pool.workspace = true
 reth-primitives-traits.workspace = true

--- a/crates/builder/core/src/flashblocks/generator.rs
+++ b/crates/builder/core/src/flashblocks/generator.rs
@@ -4,6 +4,7 @@ use alloy_primitives::B256;
 use futures::{Future, FutureExt};
 use parking_lot::Mutex;
 use reth_basic_payload_builder::{HeaderForPayload, PayloadConfig, PrecachedState};
+use reth_execution_cache::SavedCache;
 use reth_node_api::{NodePrimitives, PayloadKind};
 use reth_payload_builder::{
     BuildNewPayload, KeepPayloadJobAlive, PayloadBuilderError, PayloadId, PayloadJob,
@@ -129,6 +130,7 @@ where
 
         // Extract hash before moving parent_header into Arc to avoid cloning
         let parent_hash = parent_header.hash();
+        let execution_cache = input.cache;
         let config = PayloadConfig::new(Arc::new(parent_header), input.attributes, id);
 
         // Create shared mutex for synchronizing cancellation with payload publishing
@@ -144,6 +146,7 @@ where
             publish_guard,
             deadline,
             cached_reads: self.maybe_pre_cached(parent_hash),
+            execution_cache,
         };
 
         job.spawn_build_job();
@@ -214,6 +217,8 @@ where
     /// This is used to avoid reading the same state over and over again when new attempts are
     /// triggered, because during the building process we'll repeatedly execute the transactions.
     pub(crate) cached_reads: Option<CachedReads>,
+    /// Optional execution cache shared with the engine.
+    pub(crate) execution_cache: Option<SavedCache>,
 }
 
 impl<Builder> std::fmt::Debug for BlockPayloadJob<Builder>
@@ -267,6 +272,8 @@ where
 pub struct BuildArguments<Attributes, Payload: BuiltPayload> {
     /// Previously cached disk reads
     pub cached_reads: CachedReads,
+    /// Optional execution cache shared with the engine.
+    pub execution_cache: Option<SavedCache>,
     /// How to configure the payload.
     pub config: PayloadConfig<Attributes, HeaderTy<Payload::Primitives>>,
     /// A marker that can be used to cancel the job.
@@ -293,9 +300,15 @@ where
         let (watch_tx, watch_rx) = watch::channel(None);
         self.payload_rx = Some(watch_rx);
         let cached_reads = self.cached_reads.take().unwrap_or_default();
+        let execution_cache = self.execution_cache.take();
         self.executor.spawn_blocking_task(Box::pin(async move {
-            let args =
-                BuildArguments { cached_reads, config: payload_config, cancel, publish_guard };
+            let args = BuildArguments {
+                cached_reads,
+                execution_cache,
+                config: payload_config,
+                cancel,
+                publish_guard,
+            };
             if let Err(e) = builder.try_build(args, &watch_tx).await {
                 warn!(error = %e, "Payload build task failed");
                 *build_error.lock() = Some(e.to_string());
@@ -392,6 +405,7 @@ mod tests {
     use base_common_consensus::BasePrimitives;
     use base_execution_payload_builder::{BasePayloadBuilderAttributes, PayloadPrimitives};
     use rand::rng;
+    use reth_execution_cache::{ExecutionCache, SavedCache};
     use reth_node_api::{BuiltPayloadExecutedBlock, NodePrimitives};
     use reth_primitives_traits::SealedBlock;
     use reth_provider::test_utils::MockEthProvider;
@@ -455,7 +469,7 @@ mod tests {
 
     #[derive(Debug, PartialEq, Clone)]
     enum BlockEvent {
-        Started,
+        Started(Option<B256>),
         Cancelled,
     }
 
@@ -472,7 +486,9 @@ mod tests {
             args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
             _payload_tx: &watch::Sender<Option<Self::BuiltPayload>>,
         ) -> Result<(), PayloadBuilderError> {
-            self.new_event(BlockEvent::Started);
+            self.new_event(BlockEvent::Started(
+                args.execution_cache.as_ref().map(SavedCache::executed_block_hash),
+            ));
 
             loop {
                 if args.cancel.is_cancelled() {
@@ -530,16 +546,17 @@ mod tests {
             tokio::time::sleep(Duration::from_secs(1)).await;
 
             let events = builder.get_events();
-            assert_eq!(events, vec![BlockEvent::Started, BlockEvent::Cancelled]);
+            assert_eq!(events, vec![BlockEvent::Started(None), BlockEvent::Cancelled]);
         }
 
         {
             // job resolve triggers cancellations from the build task
             let parent_hash = attr.payload_attributes.parent;
+            let cache = SavedCache::new(parent_hash, ExecutionCache::new(1_000));
             let input = BuildNewPayload {
                 attributes: attr.clone(),
                 parent_hash,
-                cache: None,
+                cache: Some(cache.clone()),
                 state_root_handle: None,
             };
             let mut job = generator.new_payload_job(input, attr.payload_id(&parent_hash))?;
@@ -549,7 +566,8 @@ mod tests {
             tokio::time::sleep(Duration::from_secs(1)).await;
 
             let events = builder.get_events();
-            assert_eq!(events, vec![BlockEvent::Started, BlockEvent::Cancelled]);
+            assert_eq!(events, vec![BlockEvent::Started(Some(parent_hash)), BlockEvent::Cancelled]);
+            assert!(cache.is_available(), "builder must release the execution cache after exit");
         }
 
         Ok(())

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -31,6 +31,7 @@ use base_observability_events::{GlobalTransactionEventWriter, TransactionEventTy
 use eyre::WrapErr as _;
 use reth_basic_payload_builder::BuildOutcome;
 use reth_evm::{ConfigureEvm, execute::BlockBuilder};
+use reth_execution_cache::{CachedStateMetrics, CachedStateMetricsSource, CachedStateProvider};
 use reth_execution_types::ChangedAccount;
 use reth_node_api::{Block, BuiltPayloadExecutedBlock, PayloadBuilderError};
 use reth_payload_primitives::PayloadAttributes;
@@ -272,7 +273,13 @@ where
         payload_tx: &watch::Sender<Option<BaseBuiltPayload>>,
     ) -> Result<(), PayloadBuilderError> {
         let block_build_start_time = Instant::now();
-        let BuildArguments { mut cached_reads, config, cancel: block_cancel, publish_guard } = args;
+        let BuildArguments {
+            mut cached_reads,
+            execution_cache,
+            config,
+            cancel: block_cancel,
+            publish_guard,
+        } = args;
 
         // We log only every Nth block based on sampling ratio to reduce usage
         let block_number = config.parent_header.number + 1;
@@ -296,7 +303,14 @@ where
             )
             .map_err(|e| PayloadBuilderError::Other(e.into()))?;
 
-        let state_provider = self.client.state_by_block_hash(ctx.parent().hash())?;
+        let mut state_provider = self.client.state_by_block_hash(ctx.parent().hash())?;
+        if let Some(execution_cache) = execution_cache {
+            state_provider = Box::new(CachedStateProvider::new(
+                state_provider,
+                execution_cache.cache().clone(),
+                Some(CachedStateMetrics::zeroed(CachedStateMetricsSource::Builder)),
+            ));
+        }
         let db = StateProviderDatabase::new(state_provider);
 
         // 1. execute the pre steps and seal an early block with that
@@ -387,6 +401,7 @@ where
         }
 
         if skip_flashblocks_building {
+            drop(state);
             payload_tx.send_replace(Some(payload));
             let total_block_building_time = block_build_start_time.elapsed();
             BuilderMetrics::total_block_built_duration().record(total_block_building_time);
@@ -477,7 +492,7 @@ where
         let mut executed_sender_nonces: HashMap<Address, u64> = HashMap::default();
 
         // Process flashblocks in a blocking loop
-        loop {
+        let final_payload = loop {
             let flashblock_index = ctx.flashblock_index();
             let fb_span = if span.is_none() {
                 tracing::Span::none()
@@ -499,8 +514,7 @@ where
                     &span,
                     "Payload building complete, target flashblock count reached",
                 );
-                self.finalize_payload(&mut state, &ctx, &mut info, payload_tx)?;
-                return Ok(());
+                break self.finalize_payload(&mut state, &ctx, &mut info)?;
             }
 
             // build first flashblock immediately
@@ -526,8 +540,7 @@ where
                         &span,
                         "Payload building complete, job cancelled or target flashblock count reached",
                     );
-                    self.finalize_payload(&mut state, &ctx, &mut info, payload_tx)?;
-                    return Ok(());
+                    break self.finalize_payload(&mut state, &ctx, &mut info)?;
                 }
                 Err(err) => {
                     error!(
@@ -553,11 +566,16 @@ where
                         &span,
                         "Payload building complete, channel closed or job cancelled",
                     );
-                    self.finalize_payload(&mut state, &ctx, &mut info, payload_tx)?;
-                    return Ok(());
+                    break self.finalize_payload(&mut state, &ctx, &mut info)?;
                 }
             }
-        }
+        };
+
+        // Release the state provider's shared-cache handle before waking the payload resolver.
+        drop(state);
+        payload_tx.send_replace(Some(final_payload));
+
+        Ok(())
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -949,14 +967,13 @@ where
         span.record("flashblock_count", ctx.flashblock_index());
     }
 
-    /// Finalize the payload by computing the state root and publishing via the watch channel.
+    /// Finalize the payload by computing the state root.
     fn finalize_payload<DB, P>(
         &self,
         state: &mut State<DB>,
         ctx: &BasePayloadBuilderCtx,
         info: &mut ExecutionInfo,
-        payload_tx: &watch::Sender<Option<BaseBuiltPayload>>,
-    ) -> Result<(), PayloadBuilderError>
+    ) -> Result<BaseBuiltPayload, PayloadBuilderError>
     where
         DB: Database<Error = ProviderError> + AsRef<P>,
         P: StateRootProvider + HashedPostStateProvider + StorageRootProvider,
@@ -978,9 +995,7 @@ where
             "Finalized payload with state root"
         );
 
-        payload_tx.send_replace(Some(final_payload));
-
-        Ok(())
+        Ok(final_payload)
     }
 
     fn emit_final_inclusion_events(
@@ -1386,8 +1401,9 @@ mod tests {
     use base_common_flashblocks::{FlashblockId, Metadata};
     use base_execution_chainspec::BaseChainSpec;
     use reth_chainspec::ChainSpec;
+    use reth_execution_cache::{CachedStateProvider, CachedStatus, ExecutionCache, SavedCache};
     use reth_primitives_traits::SealedHeader;
-    use reth_provider::noop::NoopProvider;
+    use reth_provider::{StateProviderBox, noop::NoopProvider};
     use reth_revm::{State, database::StateProviderDatabase};
 
     use super::{FlashblocksMetadata, build_block};
@@ -1417,6 +1433,40 @@ mod tests {
     fn genesis_header() -> Arc<SealedHeader> {
         let header = Header { gas_limit: 30_000_000, timestamp: 0, ..Default::default() };
         Arc::new(SealedHeader::seal_slow(header))
+    }
+
+    #[test]
+    fn canonical_state_provider_uses_shared_cache_without_filling_misses() {
+        let address = Address::random();
+        let cached_key = B256::random();
+        let uncached_key = B256::random();
+        let cached_value = U256::from(1);
+        let uncached_value = U256::from(2);
+        let cache = SavedCache::new(B256::ZERO, ExecutionCache::new(1_000));
+        cache.cache().insert_storage(address, cached_key, Some(cached_value));
+
+        let state_provider = Box::new(CachedStateProvider::new(
+            Box::new(NoopProvider::default()) as StateProviderBox,
+            cache.cache().clone(),
+            None,
+        )) as StateProviderBox;
+
+        assert!(!cache.is_available(), "provider must hold the shared cache while in use");
+        assert_eq!(state_provider.storage(address, cached_key).unwrap(), Some(cached_value));
+        assert_eq!(state_provider.storage(address, uncached_key).unwrap(), None);
+        assert_eq!(
+            cache
+                .cache()
+                .get_or_try_insert_storage_with(address, uncached_key, || Ok::<_, ()>(
+                    uncached_value
+                ))
+                .unwrap(),
+            CachedStatus::NotCached(uncached_value),
+            "lookup-only canonical reads must not fill cache misses"
+        );
+
+        drop(state_provider);
+        assert!(cache.is_available(), "provider must release the shared cache when dropped");
     }
 
     /// Verify that [`build_block`] produces a valid empty block when called

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -270,8 +270,7 @@ where
     async fn build_payload(
         &self,
         args: BuildArguments<BasePayloadBuilderAttributes<BaseTransactionSigned>, BaseBuiltPayload>,
-        payload_tx: &watch::Sender<Option<BaseBuiltPayload>>,
-    ) -> Result<(), PayloadBuilderError> {
+    ) -> Result<BaseBuiltPayload, PayloadBuilderError> {
         let block_build_start_time = Instant::now();
         let BuildArguments {
             mut cached_reads,
@@ -401,13 +400,11 @@ where
         }
 
         if skip_flashblocks_building {
-            drop(state);
-            payload_tx.send_replace(Some(payload));
             let total_block_building_time = block_build_start_time.elapsed();
             BuilderMetrics::total_block_built_duration().record(total_block_building_time);
             BuilderMetrics::total_block_built_gauge().set(total_block_building_time);
 
-            return Ok(());
+            return Ok(payload);
         }
 
         info!(
@@ -492,7 +489,7 @@ where
         let mut executed_sender_nonces: HashMap<Address, u64> = HashMap::default();
 
         // Process flashblocks in a blocking loop
-        let final_payload = loop {
+        loop {
             let flashblock_index = ctx.flashblock_index();
             let fb_span = if span.is_none() {
                 tracing::Span::none()
@@ -514,7 +511,7 @@ where
                     &span,
                     "Payload building complete, target flashblock count reached",
                 );
-                break self.finalize_payload(&mut state, &ctx, &mut info)?;
+                return self.finalize_payload(&mut state, &ctx, &mut info);
             }
 
             // build first flashblock immediately
@@ -540,7 +537,7 @@ where
                         &span,
                         "Payload building complete, job cancelled or target flashblock count reached",
                     );
-                    break self.finalize_payload(&mut state, &ctx, &mut info)?;
+                    return self.finalize_payload(&mut state, &ctx, &mut info);
                 }
                 Err(err) => {
                     error!(
@@ -566,16 +563,10 @@ where
                         &span,
                         "Payload building complete, channel closed or job cancelled",
                     );
-                    break self.finalize_payload(&mut state, &ctx, &mut info)?;
+                    return self.finalize_payload(&mut state, &ctx, &mut info);
                 }
             }
-        };
-
-        // Release the state provider's shared-cache handle before waking the payload resolver.
-        drop(state);
-        payload_tx.send_replace(Some(final_payload));
-
-        Ok(())
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1106,7 +1097,11 @@ where
         args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
         payload_tx: &watch::Sender<Option<Self::BuiltPayload>>,
     ) -> Result<(), PayloadBuilderError> {
-        self.build_payload(args, payload_tx).await
+        // Keep construction behind this call boundary so its state provider, including any shared
+        // cache handle, is released before publishing wakes the payload resolver.
+        let payload = self.build_payload(args).await?;
+        payload_tx.send_replace(Some(payload));
+        Ok(())
     }
 }
 
@@ -1445,27 +1440,28 @@ mod tests {
         let cache = SavedCache::new(B256::ZERO, ExecutionCache::new(1_000));
         cache.cache().insert_storage(address, cached_key, Some(cached_value));
 
-        let state_provider = Box::new(CachedStateProvider::new(
-            Box::new(NoopProvider::default()) as StateProviderBox,
-            cache.cache().clone(),
-            None,
-        )) as StateProviderBox;
+        {
+            let state_provider = Box::new(CachedStateProvider::new(
+                Box::new(NoopProvider::default()) as StateProviderBox,
+                cache.cache().clone(),
+                None,
+            )) as StateProviderBox;
 
-        assert!(!cache.is_available(), "provider must hold the shared cache while in use");
-        assert_eq!(state_provider.storage(address, cached_key).unwrap(), Some(cached_value));
-        assert_eq!(state_provider.storage(address, uncached_key).unwrap(), None);
-        assert_eq!(
-            cache
-                .cache()
-                .get_or_try_insert_storage_with(address, uncached_key, || Ok::<_, ()>(
-                    uncached_value
-                ))
-                .unwrap(),
-            CachedStatus::NotCached(uncached_value),
-            "lookup-only canonical reads must not fill cache misses"
-        );
+            assert!(!cache.is_available(), "provider must hold the shared cache while in use");
+            assert_eq!(state_provider.storage(address, cached_key).unwrap(), Some(cached_value));
+            assert_eq!(state_provider.storage(address, uncached_key).unwrap(), None);
+            assert_eq!(
+                cache
+                    .cache()
+                    .get_or_try_insert_storage_with(address, uncached_key, || Ok::<_, ()>(
+                        uncached_value
+                    ))
+                    .unwrap(),
+                CachedStatus::NotCached(uncached_value),
+                "lookup-only canonical reads must not fill cache misses"
+            );
+        }
 
-        drop(state_provider);
         assert!(cache.is_available(), "provider must release the shared cache when dropped");
     }
 


### PR DESCRIPTION
## Summary

Preserve Reth's optional engine-owned execution cache through the custom flashblocks payload job, establishing the shared-cache plumbing needed by transaction prewarming without changing transaction selection or block-building behavior.

## What changed

- Carry the optional `SavedCache` from `BuildNewPayload` through `BlockPayloadJob` and `BuildArguments`.
- Wrap the canonical state provider in `CachedStateProvider` so block execution can reuse warmed entries while remaining lookup-only and leaving cache misses unpopulated.
- Separate payload construction from publication: `build_payload` returns the completed payload, allowing its execution state, provider, and shared-cache handles to be released through RAII before `try_build` wakes the payload resolver.
- Use ordinary return paths for flashblock finalization instead of loop-valued `break` expressions or manual `drop(...)` ordering.
- Cover cache propagation, lookup-only behavior, and cache-handle release in unit tests.

## Validation

- `cargo test -p base-builder-core --lib -- --test-threads=1`
- `cargo clippy -p base-builder-core --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
