### PR TITLE
feat(reth): retain one month in full preset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6228,6 +6228,7 @@ version = "0.0.0"
 dependencies = [
  "reth-cli-commands",
  "reth-node-core",
+ "reth-prune-types",
 ]
 
 [[package]]

--- a/crates/utilities/reth-cli/Cargo.toml
+++ b/crates/utilities/reth-cli/Cargo.toml
@@ -13,4 +13,5 @@ workspace = true
 
 [dependencies]
 reth-node-core.workspace = true
+reth-prune-types.workspace = true
 reth-cli-commands.workspace = true

--- a/crates/utilities/reth-cli/src/snapshots.rs
+++ b/crates/utilities/reth-cli/src/snapshots.rs
@@ -1,26 +1,28 @@
-//! Reth snapshots initialization utilities
+//! Reth snapshot and pruning-default initialization utilities.
 
 use std::borrow::Cow;
 
 use reth_cli_commands::download::DownloadDefaults;
+use reth_node_core::args::DefaultPruningValues;
+use reth_prune_types::PruneMode;
 
 pub(crate) const DEFAULT_DOWNLOAD_URL: &str = "https://chain.base.org/8453";
 const SNAPSHOT_API_URL: &str = "https://chain.base.org/api/snapshots";
+const FULL_HISTORY_DISTANCE: u64 = 1_339_200;
 
-/// Reth snapshot download URLs initialization for Base execution layer binaries
+/// Reth snapshot and pruning-default initialization for Base execution layer binaries.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct Snapshots;
 
 impl Snapshots {
-    /// Initializes Reth's global download URLs for snapshots
+    /// Initializes Reth's global snapshot download URLs and pruning defaults.
     ///
-    /// This sets up the available snapshots, base download URLs, and
-    /// the snapshot API URL that Reth uses for picking which exact
-    /// uploaded snapshot manifest to follow and download
+    /// This sets up the snapshot sources and makes the full preset retain approximately one month
+    /// of bodies, receipts, and account and storage history.
     ///
     /// ### Panics
     ///
-    /// Panics if unable to initialize download URLs.
+    /// Panics if the download URLs or pruning defaults were already initialized.
     pub fn init_snapshots() {
         let download_defaults = DownloadDefaults {
             available_snapshots: vec![
@@ -35,10 +37,22 @@ impl Snapshots {
         };
 
         download_defaults.try_init().expect("failed to initialize download URLs");
+
+        let mut pruning_defaults = DefaultPruningValues::default();
+        pruning_defaults.full_prune_modes.bodies_history =
+            Some(PruneMode::Distance(FULL_HISTORY_DISTANCE));
+        pruning_defaults.full_prune_modes.receipts =
+            Some(PruneMode::Distance(FULL_HISTORY_DISTANCE));
+        pruning_defaults.full_prune_modes.account_history =
+            Some(PruneMode::Distance(FULL_HISTORY_DISTANCE));
+        pruning_defaults.full_prune_modes.storage_history =
+            Some(PruneMode::Distance(FULL_HISTORY_DISTANCE));
+        pruning_defaults.full_bodies_history_use_pre_merge = false;
+        pruning_defaults.try_init().expect("failed to initialize pruning defaults");
     }
 }
 
-/// Initializes Reth's global download URLs for snapshots
+/// Initializes Reth's global snapshot download URLs and pruning defaults.
 ///
 /// Use this in execution layer binaries (base-node-reth, base-builder) that need
 /// Reth's global download URLs initialized for snapshot downloads
@@ -49,4 +63,22 @@ macro_rules! init_snapshots {
     () => {
         $crate::Snapshots::init_snapshots()
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn full_preset_retains_one_month_of_history() {
+        Snapshots::init_snapshots();
+
+        let defaults = DefaultPruningValues::get_global();
+        let distance = Some(PruneMode::Distance(FULL_HISTORY_DISTANCE));
+        assert_eq!(defaults.full_prune_modes.bodies_history, distance);
+        assert_eq!(defaults.full_prune_modes.receipts, distance);
+        assert_eq!(defaults.full_prune_modes.account_history, distance);
+        assert_eq!(defaults.full_prune_modes.storage_history, distance);
+        assert!(!defaults.full_bodies_history_use_pre_merge);
+    }
 }


### PR DESCRIPTION
## Summary

- configure the Base full preset to retain 1,339,200 blocks of bodies, receipts, account history, and storage history
- disable pre-merge body retention so Base transaction history uses the configured distance
- verify the initialized pruning defaults with a focused unit test

## Testing

- `cargo test -p base-reth-cli`
- `cargo clippy -p base-reth-cli --all-targets -- -D warnings`
- `cargo fmt --check -- crates/utilities/reth-cli/src/snapshots.rs`