### PR TITLE
refactor(consensus): address shadow sequencer review feedback

### DIFF
--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -14,7 +14,7 @@ use tokio::{sync::mpsc, task::JoinHandle};
 
 use crate::{
     CheckpointWriter, EngineActorRequest, EngineClientError, EngineDerivationClient, EngineError,
-    NoopCheckpointWriter, actors::engine::CanonicalReconciliationInputs,
+    NoopCheckpointWriter, actors::sequencer::CanonicalReconciliationInputs,
 };
 
 /// Requires that the implementor handles engine requests via the provided channel.

--- a/crates/consensus/service/src/actors/engine/mod.rs
+++ b/crates/consensus/service/src/actors/engine/mod.rs
@@ -27,10 +27,5 @@ pub use engine_request_processor::{EngineProcessor, EngineRequestReceiver, Reset
 mod validator_engine_request_handler;
 pub use validator_engine_request_handler::ValidatorEngineRequestHandler;
 
-pub use super::sequencer::{
-    CanonicalReconciliationInputs, CanonicalUnsafeCatchup, SequencerEngineState,
-    ShadowReconciliationGate,
-};
-
 mod rpc_request_processor;
 pub use rpc_request_processor::EngineRpcProcessor;

--- a/crates/consensus/service/src/actors/mod.rs
+++ b/crates/consensus/service/src/actors/mod.rs
@@ -15,12 +15,11 @@ mod engine;
 #[cfg(test)]
 pub use engine::MockEngineDerivationClient;
 pub use engine::{
-    BuildRequest, CanonicalReconciliationInputs, CanonicalUnsafeCatchup, EngineActor,
-    EngineActorRequest, EngineClientError, EngineClientResult, EngineConfig,
-    EngineDerivationClient, EngineError, EngineProcessor, EngineRequestReceiver,
+    BuildRequest, EngineActor, EngineActorRequest, EngineClientError, EngineClientResult,
+    EngineConfig, EngineDerivationClient, EngineError, EngineProcessor, EngineRequestReceiver,
     EngineRpcProcessor, EngineRpcRequest, GetPayloadRequest, InsertUnsafePayloadRequest,
     QueuedEngineDerivationClient, ReconcileShadowRequest, ResetOrigin, ResetOutcome, ResetRequest,
-    SequencerEngineState, ShadowReconciliationGate, ValidatorEngineRequestHandler,
+    ValidatorEngineRequestHandler,
 };
 
 mod rpc;
@@ -60,12 +59,13 @@ pub use network::{
 
 mod sequencer;
 pub use sequencer::{
-    Conductor, ConductorClient, ConductorError, DelayedL1OriginSelectorProvider, L1OriginSelector,
-    L1OriginSelectorError, L1OriginSelectorProvider, OriginSelector, PayloadBuilder, PayloadSealer,
-    PendingStopSender, PoolActivation, QueuedSequencerEngineClient, RecoveryModeGuard,
-    ScheduledTicker, SealState, SealStepError, SealStepOutcome, SequencerActor,
-    SequencerActorError, SequencerAdminQuery, SequencerConfig, SequencerEngineClient,
-    SequencerEngineRequestCoordinator, ShadowCycle, ShadowReconciliationTask,
+    CanonicalReconciliationInputs, CanonicalUnsafeCatchup, Conductor, ConductorClient,
+    ConductorError, DelayedL1OriginSelectorProvider, L1OriginSelector, L1OriginSelectorError,
+    L1OriginSelectorProvider, OriginSelector, PayloadBuilder, PayloadSealer, PendingStopSender,
+    PoolActivation, QueuedSequencerEngineClient, RecoveryModeGuard, ScheduledTicker, SealState,
+    SealStepError, SealStepOutcome, SequencerActor, SequencerActorError, SequencerAdminQuery,
+    SequencerConfig, SequencerEngineClient, SequencerEngineRequestCoordinator,
+    SequencerEngineState, ShadowCycle, ShadowReconciliationGate, ShadowReconciliationTask,
     UnsealedPayloadHandle,
 };
 #[cfg(test)]

--- a/crates/consensus/service/src/actors/sequencer/engine_request_coordinator.rs
+++ b/crates/consensus/service/src/actors/sequencer/engine_request_coordinator.rs
@@ -378,11 +378,29 @@ where
                                 if block_gap.is_some_and(|gap| {
                                     gap > 0 && gap <= MAX_SEQUENCER_EXTERNAL_UNSAFE_GAP
                                 }) {
-                                    info!(target: "engine", block_number, block_hash = %envelope.execution_payload.block_hash(), parent_hash = %envelope.execution_payload.parent_hash(), block_gap = ?block_gap, max_external_unsafe_gap = MAX_SEQUENCER_EXTERNAL_UNSAFE_GAP, "Sequencer enqueuing external unsafe payload within gap limit");
+                                    info!(
+                                        target: "engine",
+                                        block_number,
+                                        block_hash = %envelope.execution_payload.block_hash(),
+                                        parent_hash = %envelope.execution_payload.parent_hash(),
+                                        block_gap = ?block_gap,
+                                        max_external_unsafe_gap = MAX_SEQUENCER_EXTERNAL_UNSAFE_GAP,
+                                        "Sequencer enqueuing external unsafe payload within gap limit"
+                                    );
                                     self.processor
                                         .enqueue_unsafe_payload_insert(*envelope, None, false);
                                 } else {
-                                    info!(target: "engine", block_number, block_hash = %envelope.execution_payload.block_hash(), parent_hash = %envelope.execution_payload.parent_hash(), block_gap = ?block_gap, max_external_unsafe_gap = MAX_SEQUENCER_EXTERNAL_UNSAFE_GAP, unsafe_head_number = unsafe_head.block_info.number, unsafe_head_hash = %unsafe_head.block_info.hash, "Sequencer dropped external unsafe payload outside gap limit");
+                                    info!(
+                                        target: "engine",
+                                        block_number,
+                                        block_hash = %envelope.execution_payload.block_hash(),
+                                        parent_hash = %envelope.execution_payload.parent_hash(),
+                                        block_gap = ?block_gap,
+                                        max_external_unsafe_gap = MAX_SEQUENCER_EXTERNAL_UNSAFE_GAP,
+                                        unsafe_head_number = unsafe_head.block_info.number,
+                                        unsafe_head_hash = %unsafe_head.block_info.hash,
+                                        "Sequencer dropped external unsafe payload outside gap limit"
+                                    );
                                 }
                             }
                         }

--- a/etc/systems/Cargo.toml
+++ b/etc/systems/Cargo.toml
@@ -89,6 +89,7 @@ eyre.workspace = true
 nanoid.workspace = true
 reqwest.workspace = true
 tempfile.workspace = true
+async-trait.workspace = true
 tracing = { workspace = true, features = ["std"] }
 serde_json = { workspace = true, features = ["std"] }
 serde = { workspace = true, features = ["derive", "std"] }
@@ -128,7 +129,6 @@ base-prover-service-protocol.workspace = true
 
 # misc
 indicatif.workspace = true
-async-trait.workspace = true
 
 [[bench]]
 name = "b20_zk_proving"

--- a/etc/systems/src/lib.rs
+++ b/etc/systems/src/lib.rs
@@ -58,7 +58,7 @@ mod network;
 pub use network::{ensure_network_exists, ensure_network_exists_with_name, network_name};
 
 mod rpc;
-pub use rpc::SystemTestRpcClient;
+pub use rpc::{SystemTestProviderExt, SystemTestRpcClient};
 
 mod setup;
 pub use setup::{

--- a/etc/systems/src/rpc.rs
+++ b/etc/systems/src/rpc.rs
@@ -1,13 +1,185 @@
-//! RPC client for querying system test nodes.
+//! RPC clients and provider helpers for querying system test nodes.
 
+use std::time::{Duration, Instant};
+
+use alloy_eips::BlockNumberOrTag;
 use alloy_network::Network;
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, B256, U256};
 use alloy_provider::{Provider, RootProvider};
+use async_trait::async_trait;
 use base_common_network::Base;
+use base_common_rpc_types::BaseTransactionReceipt;
 use base_consensus_rpc::SyncStatusApiClient;
 use base_protocol::SyncStatus;
 use eyre::{Result, WrapErr};
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
+use tokio::time::{sleep, timeout};
+
+const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
+const RECEIPT_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const CONVERGENCE_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Polling helpers for Base providers used by system tests.
+#[async_trait]
+pub trait SystemTestProviderExt {
+    /// Waits until the provider reaches at least `min_block`.
+    async fn wait_for_block(&self, min_block: u64, within: Duration) -> Result<u64>;
+
+    /// Waits until `address` has a non-zero balance.
+    async fn wait_for_balance(&self, address: Address, within: Duration) -> Result<()>;
+
+    /// Waits for a transaction receipt.
+    async fn wait_for_receipt(
+        &self,
+        tx_hash: B256,
+        within: Duration,
+    ) -> Result<BaseTransactionReceipt>;
+
+    /// Waits for a transaction to be included above `previous_height`.
+    async fn wait_for_receipt_after(
+        &self,
+        tx_hash: B256,
+        previous_height: u64,
+        within: Duration,
+    ) -> Result<BaseTransactionReceipt>;
+
+    /// Verifies that no transaction receipt appears during `window`.
+    async fn assert_receipt_absent(&self, tx_hash: B256, window: Duration) -> Result<()>;
+
+    /// Returns the block hash at `height`, if the block exists.
+    async fn block_hash_at(&self, height: u64) -> Result<Option<B256>>;
+
+    /// Waits for the block hash at `height` to become available.
+    async fn wait_for_block_hash_at(&self, height: u64, within: Duration) -> Result<B256>;
+
+    /// Waits until this provider and `canonical` agree on the block at `height`.
+    async fn wait_for_convergence(
+        &self,
+        canonical: &RootProvider<Base>,
+        height: u64,
+        within: Duration,
+    ) -> Result<()>;
+}
+
+#[async_trait]
+impl SystemTestProviderExt for RootProvider<Base> {
+    async fn wait_for_block(&self, min_block: u64, within: Duration) -> Result<u64> {
+        timeout(within, async {
+            loop {
+                let block = self.get_block_number().await?;
+                if block >= min_block {
+                    return Ok::<_, eyre::Error>(block);
+                }
+                sleep(BLOCK_POLL_INTERVAL).await;
+            }
+        })
+        .await
+        .wrap_err("block production timed out")?
+    }
+
+    async fn wait_for_balance(&self, address: Address, within: Duration) -> Result<()> {
+        timeout(within, async {
+            loop {
+                if self.get_balance(address).await? > U256::ZERO {
+                    return Ok::<_, eyre::Error>(());
+                }
+                sleep(BLOCK_POLL_INTERVAL).await;
+            }
+        })
+        .await
+        .wrap_err("timed out waiting for a funded account")?
+    }
+
+    async fn wait_for_receipt(
+        &self,
+        tx_hash: B256,
+        within: Duration,
+    ) -> Result<BaseTransactionReceipt> {
+        timeout(within, async {
+            loop {
+                if let Some(receipt) = self.get_transaction_receipt(tx_hash).await? {
+                    return Ok::<_, eyre::Error>(receipt);
+                }
+                sleep(RECEIPT_POLL_INTERVAL).await;
+            }
+        })
+        .await
+        .wrap_err("transaction receipt timed out")?
+    }
+
+    async fn wait_for_receipt_after(
+        &self,
+        tx_hash: B256,
+        previous_height: u64,
+        within: Duration,
+    ) -> Result<BaseTransactionReceipt> {
+        timeout(within, async {
+            loop {
+                if let Some(receipt) = self.get_transaction_receipt(tx_hash).await?
+                    && receipt.inner.block_number.is_some_and(|height| height > previous_height)
+                {
+                    return Ok::<_, eyre::Error>(receipt);
+                }
+                sleep(RECEIPT_POLL_INTERVAL).await;
+            }
+        })
+        .await
+        .wrap_err("transaction was not re-included after reconciliation")?
+    }
+
+    async fn assert_receipt_absent(&self, tx_hash: B256, window: Duration) -> Result<()> {
+        let deadline = Instant::now() + window;
+        while Instant::now() < deadline {
+            if self.get_transaction_receipt(tx_hash).await?.is_some() {
+                eyre::bail!("transaction was included when it should not have been");
+            }
+            sleep(BLOCK_POLL_INTERVAL).await;
+        }
+        Ok(())
+    }
+
+    async fn block_hash_at(&self, height: u64) -> Result<Option<B256>> {
+        Ok(self
+            .get_block_by_number(BlockNumberOrTag::Number(height))
+            .await?
+            .map(|block| block.header.hash))
+    }
+
+    async fn wait_for_block_hash_at(&self, height: u64, within: Duration) -> Result<B256> {
+        timeout(within, async {
+            loop {
+                if let Some(hash) = self.block_hash_at(height).await? {
+                    return Ok::<_, eyre::Error>(hash);
+                }
+                sleep(BLOCK_POLL_INTERVAL).await;
+            }
+        })
+        .await
+        .wrap_err("block at target height not available in time")?
+    }
+
+    async fn wait_for_convergence(
+        &self,
+        canonical: &RootProvider<Base>,
+        height: u64,
+        within: Duration,
+    ) -> Result<()> {
+        timeout(within, async {
+            loop {
+                let canonical_hash = canonical.block_hash_at(height).await?;
+                let local_hash = self.block_hash_at(height).await?;
+                if let (Some(canonical_hash), Some(local_hash)) = (canonical_hash, local_hash)
+                    && canonical_hash == local_hash
+                {
+                    return Ok::<_, eyre::Error>(());
+                }
+                sleep(CONVERGENCE_POLL_INTERVAL).await;
+            }
+        })
+        .await
+        .wrap_err("chain did not converge to canonical at the target height")?
+    }
+}
 
 /// RPC client for querying system test L1 and L2 nodes.
 #[derive(Debug)]

--- a/etc/systems/tests/shadow_sequencer.rs
+++ b/etc/systems/tests/shadow_sequencer.rs
@@ -12,10 +12,7 @@
 //! the canonical chain (adopting canonical blocks and discarding its private
 //! ones).
 
-use std::{
-    num::NonZeroU64,
-    time::{Duration, Instant},
-};
+use std::{num::NonZeroU64, time::Duration};
 
 use alloy_consensus::SignableTransaction;
 use alloy_eips::{BlockNumberOrTag, eip2718::Encodable2718};
@@ -25,15 +22,15 @@ use alloy_provider::{Provider, RootProvider};
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use base_common_network::Base;
-use base_common_rpc_types::{BaseTransactionReceipt, BaseTransactionRequest};
-use base_system_tests::{ANVIL_ACCOUNT_1, ANVIL_ACCOUNT_2, SystemTestStackBuilder};
+use base_common_rpc_types::BaseTransactionRequest;
+use base_system_tests::{
+    ANVIL_ACCOUNT_1, ANVIL_ACCOUNT_2, SystemTestProviderExt, SystemTestStackBuilder,
+};
 use eyre::{Result, WrapErr};
-use tokio::time::{sleep, timeout};
 
 const L1_CHAIN_ID: u64 = 1337;
 const L2_CHAIN_ID: u64 = 84538453;
 const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(30);
-const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(60);
 const BALANCE_SYNC_TIMEOUT: Duration = Duration::from_secs(30);
 const NON_CANONICAL_OBSERVATION_WINDOW: Duration = Duration::from_secs(15);
@@ -58,20 +55,28 @@ async fn shadow_builds_privately_then_reconciles_to_canonical() -> Result<()> {
     let client = system.l2_client_provider()?;
     let shadow_builder = system.l2_shadow_builder_provider(0)?;
 
-    wait_for_block(&active_builder, 2).await.wrap_err("active sequencer did not produce blocks")?;
-    wait_for_block(&shadow_builder, 2).await.wrap_err("shadow sequencer did not produce blocks")?;
+    active_builder
+        .wait_for_block(2, BLOCK_PRODUCTION_TIMEOUT)
+        .await
+        .wrap_err("active sequencer did not produce blocks")?;
+    shadow_builder
+        .wait_for_block(2, BLOCK_PRODUCTION_TIMEOUT)
+        .await
+        .wrap_err("shadow sequencer did not produce blocks")?;
 
     let active_sender = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_1.private_key)
         .wrap_err("failed to parse active-path signer")?;
-    wait_for_balance(&active_builder, active_sender.address()).await?;
-    wait_for_balance(&client, active_sender.address()).await?;
+    active_builder.wait_for_balance(active_sender.address(), BALANCE_SYNC_TIMEOUT).await?;
+    client.wait_for_balance(active_sender.address(), BALANCE_SYNC_TIMEOUT).await?;
     let canonical_nonce = client.get_transaction_count(active_sender.address()).await?;
     let canonical_tx =
         send_transfer(&active_builder, &active_sender, canonical_nonce, dead_address(0x01)).await?;
-    wait_for_receipt(&active_builder, canonical_tx, TX_RECEIPT_TIMEOUT)
+    active_builder
+        .wait_for_receipt(canonical_tx, TX_RECEIPT_TIMEOUT)
         .await
         .wrap_err("canonical tx never landed on the active sequencer")?;
-    wait_for_receipt(&client, canonical_tx, TX_RECEIPT_TIMEOUT)
+    client
+        .wait_for_receipt(canonical_tx, TX_RECEIPT_TIMEOUT)
         .await
         .wrap_err("canonical tx never landed on the client")?;
 
@@ -80,12 +85,13 @@ async fn shadow_builds_privately_then_reconciles_to_canonical() -> Result<()> {
     // active sequencer's mempool.
     let shadow_sender = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_2.private_key)
         .wrap_err("failed to parse shadow-path signer")?;
-    wait_for_balance(&shadow_builder, shadow_sender.address()).await?;
+    shadow_builder.wait_for_balance(shadow_sender.address(), BALANCE_SYNC_TIMEOUT).await?;
     let shadow_nonce = shadow_builder.get_transaction_count(shadow_sender.address()).await?;
     let shadow_tx =
         send_transfer(&shadow_builder, &shadow_sender, shadow_nonce, dead_address(0x02)).await?;
 
-    let shadow_receipt = wait_for_receipt(&shadow_builder, shadow_tx, TX_RECEIPT_TIMEOUT)
+    let shadow_receipt = shadow_builder
+        .wait_for_receipt(shadow_tx, TX_RECEIPT_TIMEOUT)
         .await
         .wrap_err("shadow sequencer failed to build a block containing the shadow-only tx")?;
     let divergence_height = shadow_receipt
@@ -97,20 +103,22 @@ async fn shadow_builds_privately_then_reconciles_to_canonical() -> Result<()> {
         .block_hash
         .ok_or_else(|| eyre::eyre!("shadow receipt should reference a block hash"))?;
 
-    assert_never_included(&active_builder, shadow_tx, NON_CANONICAL_OBSERVATION_WINDOW)
+    active_builder
+        .assert_receipt_absent(shadow_tx, NON_CANONICAL_OBSERVATION_WINDOW)
         .await
         .wrap_err("shadow-only tx unexpectedly appeared on the active sequencer")?;
-    assert_never_included(&client, shadow_tx, NON_CANONICAL_OBSERVATION_WINDOW)
+    client
+        .assert_receipt_absent(shadow_tx, NON_CANONICAL_OBSERVATION_WINDOW)
         .await
         .wrap_err("shadow-only tx unexpectedly appeared on the client")?;
 
     // The shadow built a distinct private block: the canonical chain never saw the
     // shadow-only tx, so its block at `divergence_height` must differ from the
     // shadow's private block that included it.
-    let canonical_hash_at_divergence =
-        wait_for_block_hash_at(&active_builder, divergence_height, BLOCK_PRODUCTION_TIMEOUT)
-            .await
-            .wrap_err("active sequencer did not reach the divergence height")?;
+    let canonical_hash_at_divergence = active_builder
+        .wait_for_block_hash_at(divergence_height, BLOCK_PRODUCTION_TIMEOUT)
+        .await
+        .wrap_err("active sequencer did not reach the divergence height")?;
     assert_ne!(
         shadow_private_hash, canonical_hash_at_divergence,
         "shadow's private block should differ from the canonical block at the same height"
@@ -122,18 +130,15 @@ async fn shadow_builds_privately_then_reconciles_to_canonical() -> Result<()> {
     // shows the private block (and its shadow-only tx) was discarded in favor of
     // canonical state — a robust check that does not race with the shadow-only tx
     // being re-injected into the shadow mempool after the reorg.
-    wait_for_shadow_convergence(
-        &shadow_builder,
-        &active_builder,
-        divergence_height,
-        SHADOW_CONVERGENCE_TIMEOUT,
-    )
-    .await
-    .wrap_err("shadow did not reconcile its private block to the canonical chain")?;
+    shadow_builder
+        .wait_for_convergence(&active_builder, divergence_height, SHADOW_CONVERGENCE_TIMEOUT)
+        .await
+        .wrap_err("shadow did not reconcile its private block to the canonical chain")?;
 
     // Adopting canonical payloads means the shadow now serves the canonical tx it
     // never saw in its own mempool.
-    wait_for_receipt(&shadow_builder, canonical_tx, TX_RECEIPT_TIMEOUT)
+    shadow_builder
+        .wait_for_receipt(canonical_tx, TX_RECEIPT_TIMEOUT)
         .await
         .wrap_err("shadow did not adopt the canonical tx after reconciliation")?;
 
@@ -158,18 +163,15 @@ async fn shadow_reconciles_across_multiple_cycles() -> Result<()> {
     // A height that can only be reached after several reconciliation cycles have
     // advanced the shadow's anchor (3 cycles at 2 blocks/cycle).
     let target_height = blocks_per_cycle.get() * 3;
-    wait_for_block(&active_builder, target_height + 2)
+    active_builder
+        .wait_for_block(target_height + 2, BLOCK_PRODUCTION_TIMEOUT)
         .await
         .wrap_err("active sequencer did not advance far enough")?;
 
-    wait_for_shadow_convergence(
-        &shadow_builder,
-        &active_builder,
-        target_height,
-        SHADOW_CONVERGENCE_TIMEOUT,
-    )
-    .await
-    .wrap_err("shadow did not stay converged to canonical across multiple cycles")?;
+    shadow_builder
+        .wait_for_convergence(&active_builder, target_height, SHADOW_CONVERGENCE_TIMEOUT)
+        .await
+        .wrap_err("shadow did not stay converged to canonical across multiple cycles")?;
 
     Ok(())
 }
@@ -197,18 +199,13 @@ async fn late_shadow_catches_up_then_reconciles_private_blocks() -> Result<()> {
 
     let pre_shadow_height = start_height - 1;
     let canonical_pre_shadow_hash =
-        wait_for_block_hash_at(&active_builder, pre_shadow_height, BLOCK_PRODUCTION_TIMEOUT)
-            .await?;
-    wait_for_shadow_convergence(
-        &shadow_builder,
-        &active_builder,
-        pre_shadow_height,
-        SHADOW_CONVERGENCE_TIMEOUT,
-    )
-    .await
-    .wrap_err("late shadow did not catch up a block produced before it started")?;
+        active_builder.wait_for_block_hash_at(pre_shadow_height, BLOCK_PRODUCTION_TIMEOUT).await?;
+    shadow_builder
+        .wait_for_convergence(&active_builder, pre_shadow_height, SHADOW_CONVERGENCE_TIMEOUT)
+        .await
+        .wrap_err("late shadow did not catch up a block produced before it started")?;
     assert_eq!(
-        block_hash_at(&shadow_builder, pre_shadow_height).await?,
+        shadow_builder.block_hash_at(pre_shadow_height).await?,
         Some(canonical_pre_shadow_hash),
         "late shadow must import pre-start canonical history"
     );
@@ -223,13 +220,9 @@ async fn late_shadow_catches_up_then_reconciles_private_blocks() -> Result<()> {
         "post-start handoff block must still be unsafe: safe={safe_height}, \
          handoff={post_start_height}"
     );
-    let handoff_result = wait_for_shadow_convergence(
-        &shadow_builder,
-        &active_builder,
-        post_start_height,
-        Duration::from_secs(30),
-    )
-    .await;
+    let handoff_result = shadow_builder
+        .wait_for_convergence(&active_builder, post_start_height, Duration::from_secs(30))
+        .await;
     if handoff_result.is_err() {
         let shadow_height = shadow_builder.get_block_number().await?;
         let active_height = active_builder.get_block_number().await?;
@@ -241,11 +234,10 @@ async fn late_shadow_catches_up_then_reconciles_private_blocks() -> Result<()> {
 
     let signer = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_2.private_key)
         .wrap_err("failed to parse late-shadow signer")?;
-    wait_for_balance(&shadow_builder, signer.address()).await?;
+    shadow_builder.wait_for_balance(signer.address(), BALANCE_SYNC_TIMEOUT).await?;
     let nonce = shadow_builder.get_transaction_count(signer.address()).await?;
     let shadow_tx = send_transfer(&shadow_builder, &signer, nonce, dead_address(0x03)).await?;
-    let receipt = match wait_for_receipt(&shadow_builder, shadow_tx, Duration::from_secs(15)).await
-    {
+    let receipt = match shadow_builder.wait_for_receipt(shadow_tx, Duration::from_secs(15)).await {
         Ok(receipt) => receipt,
         Err(error) => {
             let shadow_height = shadow_builder.get_block_number().await?;
@@ -265,22 +257,18 @@ async fn late_shadow_catches_up_then_reconciles_private_blocks() -> Result<()> {
         .block_hash
         .ok_or_else(|| eyre::eyre!("late-shadow receipt should reference a block hash"))?;
     let canonical_hash =
-        wait_for_block_hash_at(&active_builder, private_height, BLOCK_PRODUCTION_TIMEOUT).await?;
+        active_builder.wait_for_block_hash_at(private_height, BLOCK_PRODUCTION_TIMEOUT).await?;
     assert_ne!(private_hash, canonical_hash, "late shadow must enter a private build cycle");
 
-    wait_for_shadow_convergence(
-        &shadow_builder,
-        &active_builder,
-        private_height,
-        SHADOW_CONVERGENCE_TIMEOUT,
-    )
-    .await
-    .wrap_err("late shadow did not reconcile its private cycle to canonical")?;
+    shadow_builder
+        .wait_for_convergence(&active_builder, private_height, SHADOW_CONVERGENCE_TIMEOUT)
+        .await
+        .wrap_err("late shadow did not reconcile its private cycle to canonical")?;
 
-    let second_receipt =
-        wait_for_receipt_after(&shadow_builder, shadow_tx, private_height, TX_RECEIPT_TIMEOUT)
-            .await
-            .wrap_err("shadow-only transaction was not re-included in the next private cycle")?;
+    let second_receipt = shadow_builder
+        .wait_for_receipt_after(shadow_tx, private_height, TX_RECEIPT_TIMEOUT)
+        .await
+        .wrap_err("shadow-only transaction was not re-included in the next private cycle")?;
     let second_private_height = second_receipt
         .inner
         .block_number
@@ -289,22 +277,18 @@ async fn late_shadow_catches_up_then_reconciles_private_blocks() -> Result<()> {
         .inner
         .block_hash
         .ok_or_else(|| eyre::eyre!("second shadow receipt should reference a block hash"))?;
-    let second_canonical_hash =
-        wait_for_block_hash_at(&active_builder, second_private_height, BLOCK_PRODUCTION_TIMEOUT)
-            .await?;
+    let second_canonical_hash = active_builder
+        .wait_for_block_hash_at(second_private_height, BLOCK_PRODUCTION_TIMEOUT)
+        .await?;
     assert_ne!(
         second_private_hash, second_canonical_hash,
         "shadow-only transaction must force divergence in the second private cycle"
     );
 
-    wait_for_shadow_convergence(
-        &shadow_builder,
-        &active_builder,
-        second_private_height,
-        SHADOW_CONVERGENCE_TIMEOUT,
-    )
-    .await
-    .wrap_err("late shadow did not complete its second reconciliation")?;
+    shadow_builder
+        .wait_for_convergence(&active_builder, second_private_height, SHADOW_CONVERGENCE_TIMEOUT)
+        .await
+        .wrap_err("late shadow did not complete its second reconciliation")?;
 
     Ok(())
 }
@@ -341,129 +325,4 @@ async fn send_transfer(
     let pending = provider.send_raw_transaction(&raw_tx).await.wrap_err("failed to send tx")?;
     assert_eq!(*pending.tx_hash(), expected_hash, "transaction hash mismatch");
     Ok(expected_hash)
-}
-
-async fn wait_for_block(provider: &RootProvider<Base>, min_block: u64) -> Result<u64> {
-    timeout(BLOCK_PRODUCTION_TIMEOUT, async {
-        loop {
-            let block = provider.get_block_number().await?;
-            if block >= min_block {
-                return Ok::<_, eyre::Error>(block);
-            }
-            sleep(BLOCK_POLL_INTERVAL).await;
-        }
-    })
-    .await
-    .wrap_err("block production timed out")?
-}
-
-async fn wait_for_balance(provider: &RootProvider<Base>, address: Address) -> Result<()> {
-    timeout(BALANCE_SYNC_TIMEOUT, async {
-        loop {
-            if provider.get_balance(address).await? > U256::ZERO {
-                return Ok::<_, eyre::Error>(());
-            }
-            sleep(BLOCK_POLL_INTERVAL).await;
-        }
-    })
-    .await
-    .wrap_err("timed out waiting for a funded account")?
-}
-
-async fn wait_for_receipt(
-    provider: &RootProvider<Base>,
-    tx_hash: B256,
-    within: Duration,
-) -> Result<BaseTransactionReceipt> {
-    timeout(within, async {
-        loop {
-            if let Some(receipt) = provider.get_transaction_receipt(tx_hash).await? {
-                return Ok::<_, eyre::Error>(receipt);
-            }
-            sleep(Duration::from_millis(100)).await;
-        }
-    })
-    .await
-    .wrap_err("transaction receipt timed out")?
-}
-
-async fn wait_for_receipt_after(
-    provider: &RootProvider<Base>,
-    tx_hash: B256,
-    previous_height: u64,
-    within: Duration,
-) -> Result<BaseTransactionReceipt> {
-    timeout(within, async {
-        loop {
-            if let Some(receipt) = provider.get_transaction_receipt(tx_hash).await?
-                && receipt.inner.block_number.is_some_and(|height| height > previous_height)
-            {
-                return Ok::<_, eyre::Error>(receipt);
-            }
-            sleep(Duration::from_millis(100)).await;
-        }
-    })
-    .await
-    .wrap_err("transaction was not re-included after reconciliation")?
-}
-
-async fn assert_never_included(
-    provider: &RootProvider<Base>,
-    tx_hash: B256,
-    window: Duration,
-) -> Result<()> {
-    let deadline = Instant::now() + window;
-    while Instant::now() < deadline {
-        if provider.get_transaction_receipt(tx_hash).await?.is_some() {
-            eyre::bail!("transaction was included when it should not have been");
-        }
-        sleep(BLOCK_POLL_INTERVAL).await;
-    }
-    Ok(())
-}
-
-async fn block_hash_at(provider: &RootProvider<Base>, height: u64) -> Result<Option<B256>> {
-    Ok(provider
-        .get_block_by_number(BlockNumberOrTag::Number(height))
-        .await?
-        .map(|block| block.header.hash))
-}
-
-async fn wait_for_block_hash_at(
-    provider: &RootProvider<Base>,
-    height: u64,
-    within: Duration,
-) -> Result<B256> {
-    timeout(within, async {
-        loop {
-            if let Some(hash) = block_hash_at(provider, height).await? {
-                return Ok::<_, eyre::Error>(hash);
-            }
-            sleep(BLOCK_POLL_INTERVAL).await;
-        }
-    })
-    .await
-    .wrap_err("block at target height not available in time")?
-}
-
-async fn wait_for_shadow_convergence(
-    shadow: &RootProvider<Base>,
-    canonical: &RootProvider<Base>,
-    height: u64,
-    within: Duration,
-) -> Result<()> {
-    timeout(within, async {
-        loop {
-            let canonical_hash = block_hash_at(canonical, height).await?;
-            let shadow_hash = block_hash_at(shadow, height).await?;
-            if let (Some(canonical_hash), Some(shadow_hash)) = (canonical_hash, shadow_hash)
-                && canonical_hash == shadow_hash
-            {
-                return Ok::<_, eyre::Error>(());
-            }
-            sleep(Duration::from_secs(1)).await;
-        }
-    })
-    .await
-    .wrap_err("shadow chain did not converge to canonical at the target height")?
 }


### PR DESCRIPTION
## Summary

Follow-up to #4139 addressing non-blocking review feedback after the shadow sequencer fix merged.

- move shadow system-test polling behind a typed `SystemTestProviderExt` harness API
- remove the redundant engine-module re-export of sequencer reconciliation types
- format external unsafe payload tracing fields for readability
