### PR TITLE
feat(systems): opt-in tmpfs datadirs for L1 containers

### DIFF
--- a/etc/systems/src/l1/config.rs
+++ b/etc/systems/src/l1/config.rs
@@ -16,4 +16,9 @@ pub struct L1ContainerConfig {
     pub beacon_http_port: Option<u16>,
     /// If set, bind to this specific host port for beacon P2P
     pub beacon_p2p_port: Option<u16>,
+    /// If true, back the container datadir (`/data`) with tmpfs. reth's mdbx and lighthouse's
+    /// database need a writable `MAP_SHARED` mmap, which some container storage backends (e.g.
+    /// overlayfs on docker-in-docker CI runners) reject; tmpfs supports it. No effect where the
+    /// storage already supports mmap.
+    pub tmpfs_datadir: bool,
 }

--- a/etc/systems/src/l1/lighthouse.rs
+++ b/etc/systems/src/l1/lighthouse.rs
@@ -69,6 +69,12 @@ impl LighthouseBeaconContainer {
             .with_mount(Mount::bind_mount(path_for_mount(jwt_path.as_ref()), LIGHTHOUSE_JWT_PATH))
             .with_cmd(command);
 
+        if config.tmpfs_datadir {
+            // Back the beacon datadir with tmpfs so its mmap-backed database works on hosts where
+            // the container's overlayfs upper layer rejects writable mmap (e.g. docker-in-docker CI).
+            container_builder = container_builder.with_mount(Mount::tmpfs_mount("/data"));
+        }
+
         if let Some(port) = config.beacon_http_port {
             container_builder =
                 container_builder.with_mapped_port(port, LIGHTHOUSE_HTTP_PORT.tcp());

--- a/etc/systems/src/l1/reth.rs
+++ b/etc/systems/src/l1/reth.rs
@@ -1,7 +1,7 @@
 use eyre::{Result, WrapErr, eyre};
 use testcontainers::{
     ContainerAsync, GenericImage, ImageExt,
-    core::{IntoContainerPort, WaitFor},
+    core::{IntoContainerPort, Mount, WaitFor},
     runners::AsyncRunner,
 };
 use url::Url;
@@ -63,6 +63,13 @@ impl RethContainer {
             .with_cmd(reth_args())
             .with_copy_to(GENESIS_PATH, genesis_json.as_ref().to_vec())
             .with_copy_to(JWT_PATH, jwt_secret_hex.as_ref().to_vec());
+
+        if config.tmpfs_datadir {
+            // reth's mdbx database needs a writable MAP_SHARED mmap, which the container's overlayfs
+            // upper layer rejects on some hosts (e.g. docker-in-docker CI) with "Remote I/O error
+            // (121)", crashing the node at startup. Back the datadir with tmpfs, which supports it.
+            container_builder = container_builder.with_mount(Mount::tmpfs_mount("/data"));
+        }
 
         if let Some(port) = config.http_port {
             container_builder = container_builder.with_mapped_port(port, HTTP_PORT.tcp());

--- a/etc/systems/src/smoke.rs
+++ b/etc/systems/src/smoke.rs
@@ -285,6 +285,7 @@ pub struct SystemTestStackBuilder {
     shadow_sequencer_count: usize,
     shadow_blocks_per_cycle: Option<NonZeroU64>,
     shadow_start_block: Option<u64>,
+    tmpfs_datadirs: bool,
     extra_builder_extensions: Vec<Box<dyn BaseNodeExtension>>,
     extra_client_extensions: Vec<Box<dyn BaseNodeExtension>>,
     #[cfg(feature = "upgrade-signal")]
@@ -362,6 +363,18 @@ impl SystemTestStackBuilder {
     /// the `base_insertValidatedTransaction` RPC endpoint.
     pub fn with_tx_forwarding(mut self, config: TxForwardingConfig) -> Self {
         self.tx_forwarding_config = Some(config);
+        self
+    }
+
+    /// Backs the L1 container datadirs (reth, lighthouse) with tmpfs.
+    ///
+    /// reth's mdbx and lighthouse's database need a writable `MAP_SHARED` mmap, which some
+    /// container storage backends reject — notably overlayfs on docker-in-docker CI runners, where
+    /// reth exits at startup with "failed to open the database: Remote I/O error (121)". tmpfs
+    /// supports mmap. Enable this to run the stack on such runners; it is a no-op where the storage
+    /// already supports mmap.
+    pub const fn with_tmpfs_datadirs(mut self) -> Self {
+        self.tmpfs_datadirs = true;
         self
     }
 
@@ -502,6 +515,7 @@ impl SystemTestStackBuilder {
                     engine_port: Some(config.ports.l1_auth),
                     beacon_http_port: Some(config.ports.l1_cl_http),
                     beacon_p2p_port: Some(config.ports.l1_cl_p2p),
+                    tmpfs_datadir: self.tmpfs_datadirs,
                 };
                 let l2_config = L2ContainerConfig {
                     use_stable_names: true,
@@ -524,6 +538,12 @@ impl SystemTestStackBuilder {
                 };
                 (Some(l1_config), Some(l2_config))
             });
+
+        // Ensure the tmpfs-datadir request reaches the L1 containers even without a stable config.
+        let l1_container_config = l1_container_config.or_else(|| {
+            self.tmpfs_datadirs
+                .then(|| L1ContainerConfig { tmpfs_datadir: true, ..Default::default() })
+        });
 
         let l1_config = L1StackConfig {
             el_genesis_json,


### PR DESCRIPTION
## Summary

Adds an opt-in `with_tmpfs_datadirs()` on `SystemTestStackBuilder` (backed by a new `L1ContainerConfig::tmpfs_datadir` field) that mounts the L1 reth and lighthouse container datadirs (`/data`) on tmpfs.

reth's mdbx needs a writable `MAP_SHARED` mmap, which some container storage backends reject — notably overlayfs on docker-in-docker CI runners, where reth exits at startup with `failed to open the database: Remote I/O error (121)`. tmpfs supports the mmap; only the small databases live there, images stay on normal storage.

Off by default, so existing runs are unchanged; consumers on such runners opt in.

## Testing

`cargo check -p base-system-tests --no-default-features`.