### PR TITLE
fix: include block hash in proof host errors

### DIFF
--- a/crates/proof/host/src/error.rs
+++ b/crates/proof/host/src/error.rs
@@ -17,8 +17,8 @@ pub enum HostError {
     #[error("{0}")]
     Custom(String),
     /// Block not found error.
-    #[error("Block not found")]
-    BlockNotFound,
+    #[error("Block not found: {0}")]
+    BlockNotFound(B256),
     /// Invalid hint data length.
     #[error("Invalid hint data length")]
     InvalidHintDataLength,

--- a/crates/proof/host/src/handler.rs
+++ b/crates/proof/host/src/handler.rs
@@ -975,7 +975,7 @@ async fn handle_hint_inner(
                 .get_block_by_hash(hash)
                 .full()
                 .await?
-                .ok_or(HostError::BlockNotFound)?;
+                .ok_or(HostError::BlockNotFound(hash))?;
             let encoded_transactions = transactions
                 .into_transactions()
                 .map(|tx| tx.inner.encoded_2718())
@@ -1094,7 +1094,7 @@ async fn handle_hint_inner(
                 .get_block_by_hash(hash)
                 .full()
                 .await?
-                .ok_or(HostError::BlockNotFound)?;
+                .ok_or(HostError::BlockNotFound(hash))?;
 
             let encoded_transactions = transactions
                 .into_transactions()


### PR DESCRIPTION
## Summary

- Add missing block hash context to `HostError::BlockNotFound`.
- Include the hash when L1 and L2 transaction block lookups fail in the proof host.

## Rationale

A bare `Block not found` error does not identify which transaction lookup failed. The hash is already available at the failure site, so preserving it makes proof host failures easier to diagnose without changing success-path behavior.

## Validation

- `cargo check -p base-proof-host`
- `cargo fmt --check`
- `cargo clippy -p base-proof-host --all-targets -- -D warnings`
