### PR TITLE
fix(trusted-proxy): trim whitespace in comma-separated CIDR lists

### DIFF
--- a/bin/websocket-proxy/src/main.rs
+++ b/bin/websocket-proxy/src/main.rs
@@ -84,6 +84,7 @@ struct Args {
         long,
         env,
         value_delimiter = ',',
+        value_parser = TrustedProxyConfig::parse_cidr,
         help = "Proxy CIDRs trusted when resolving client IPs; include every forwarding hop"
     )]
     trusted_proxy_cidrs: Vec<IpNet>,

--- a/crates/infra/telemetry/src/server.rs
+++ b/crates/infra/telemetry/src/server.rs
@@ -30,7 +30,12 @@ pub struct ServerConfig {
     #[arg(long, env = "BASE_TELEMETRY_LISTEN_ADDR", default_value = "0.0.0.0:8080")]
     pub listen_addr: SocketAddr,
     /// Comma-separated CIDRs of proxies trusted to supply the `X-Forwarded-For` client IP.
-    #[arg(long, env = "BASE_TELEMETRY_TRUSTED_PROXY_CIDRS", value_delimiter = ',')]
+    #[arg(
+        long,
+        env = "BASE_TELEMETRY_TRUSTED_PROXY_CIDRS",
+        value_delimiter = ',',
+        value_parser = TrustedProxyConfig::parse_cidr
+    )]
     pub trusted_proxy_cidrs: Vec<IpNet>,
     /// P2P reachability probe requests allowed per minute for each client IP.
     #[arg(

--- a/crates/utilities/trusted-proxy/src/trusted_proxy.rs
+++ b/crates/utilities/trusted-proxy/src/trusted_proxy.rs
@@ -38,6 +38,11 @@ impl TrustedProxyConfig {
         Self { ip_addr_http_header, trusted_proxy_cidrs }
     }
 
+    /// Parses a CIDR, trimming surrounding whitespace.
+    pub fn parse_cidr(s: &str) -> Result<IpNet, ipnet::AddrParseError> {
+        s.trim().parse()
+    }
+
     /// Returns whether the direct peer belongs to a configured trusted proxy CIDR.
     pub fn is_trusted_proxy(&self, connect_addr: IpAddr) -> bool {
         let connect_addr = connect_addr.to_canonical();


### PR DESCRIPTION
## Summary
Clap splits on commas but does not trim, so values like `10.0.0.0/8,\n192.168.0.0/16` failed to parse. Route entries through TrustedProxyConfig::parse_cidr so surrounding whitespace is ignored.


Made with [Cursor](https://cursor.com)