### PR TITLE
perf(providers): prefetch next L1 origin off the attributes build critical path

### DIFF
--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -97,6 +97,10 @@ where
             }
             let receipts =
                 self.receipts_fetcher.receipts_by_hash(epoch.hash).await.map_err(Into::into)?;
+            // This is the first block of a new epoch, so the next epoch's
+            // origin will be needed in roughly one L1 slot. Hint it so the
+            // provider can warm its caches off the critical path.
+            self.receipts_fetcher.hint_block(header.number + 1);
             let deposits =
                 derive_deposits(epoch.hash, &receipts, self.rollup_cfg.deposit_contract_address)
                     .await

--- a/crates/consensus/derive/src/traits/providers.rs
+++ b/crates/consensus/derive/src/traits/providers.rs
@@ -33,6 +33,12 @@ pub trait ChainProvider {
         &mut self,
         hash: B256,
     ) -> Result<(BlockInfo, Vec<TxEnvelope>), Self::Error>;
+
+    /// Hints that the block at `number` is expected to be fetched soon.
+    ///
+    /// Implementations may use this to warm caches in the background. The hint
+    /// is advisory and must not block. The default implementation does nothing.
+    fn hint_block(&mut self, _number: u64) {}
 }
 
 /// Describes the functionality of a data source that fetches safe blocks.

--- a/crates/consensus/providers/Cargo.toml
+++ b/crates/consensus/providers/Cargo.toml
@@ -45,7 +45,7 @@ async-trait.workspace = true
 http-body-util.workspace = true
 serde = { workspace = true, features = ["std"] }
 thiserror = { workspace = true, features = ["std"] }
-tokio = { workspace = true, features = ["time"] }
+tokio = { workspace = true, features = ["rt", "time"] }
 
 c-kzg.workspace = true
 tracing.workspace = true

--- a/crates/consensus/providers/src/chain_provider.rs
+++ b/crates/consensus/providers/src/chain_provider.rs
@@ -14,20 +14,52 @@ use lru::LruCache;
 
 use crate::{L1RpcProvider, Metrics};
 
+/// The result of a background read-ahead task: the resolved block hash with its
+/// header and receipts, or `None` if any fetch failed.
+type ReadAheadResult = Option<(B256, Header, Vec<Receipt>)>;
+
 /// The [`AlloyChainProvider`] is a concrete implementation of the [`ChainProvider`] trait, providing
 /// data over Ethereum JSON-RPC using an alloy provider as the backend.
-#[derive(Debug, Clone)]
+///
+/// [`ChainProvider::hint_block`] spawns a best-effort background task that
+/// fetches the hinted block's header and receipts. The task hands its result
+/// back through a [`tokio::task::JoinHandle`]; the provider absorbs a finished
+/// result into its caches on the next `header_by_hash` or `receipts_by_hash`
+/// call, so the hinted block's fetch becomes a cache hit instead of synchronous
+/// RPC on the critical path. An unfinished read-ahead is never awaited.
+#[derive(Debug)]
 pub struct AlloyChainProvider {
     /// The inner Ethereum JSON-RPC provider.
     pub inner: RootProvider,
     /// Whether to trust the RPC without verification.
     pub trust_rpc: bool,
+    /// The in-flight read-ahead task spawned by [`ChainProvider::hint_block`],
+    /// if any.
+    pending_read_ahead: Option<tokio::task::JoinHandle<ReadAheadResult>>,
     /// `header_by_hash` LRU cache.
     header_by_hash_cache: LruCache<B256, Header>,
     /// `receipts_by_hash_cache` LRU cache.
     receipts_by_hash_cache: LruCache<B256, Vec<Receipt>>,
     /// `block_info_and_transactions_by_hash` LRU cache.
     block_info_and_transactions_by_hash_cache: LruCache<B256, (BlockInfo, Vec<TxEnvelope>)>,
+}
+
+impl Clone for AlloyChainProvider {
+    /// Clones the provider and its caches. The pending read-ahead task is not
+    /// cloned ([`tokio::task::JoinHandle`] is not [`Clone`]); the clone starts
+    /// with no read-ahead in flight.
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            trust_rpc: self.trust_rpc,
+            pending_read_ahead: None,
+            header_by_hash_cache: self.header_by_hash_cache.clone(),
+            receipts_by_hash_cache: self.receipts_by_hash_cache.clone(),
+            block_info_and_transactions_by_hash_cache: self
+                .block_info_and_transactions_by_hash_cache
+                .clone(),
+        }
+    }
 }
 
 impl AlloyChainProvider {
@@ -47,6 +79,7 @@ impl AlloyChainProvider {
         Self {
             inner,
             trust_rpc,
+            pending_read_ahead: None,
             header_by_hash_cache: LruCache::new(NonZeroUsize::new(cache_size).unwrap()),
             receipts_by_hash_cache: LruCache::new(NonZeroUsize::new(cache_size).unwrap()),
             block_info_and_transactions_by_hash_cache: LruCache::new(
@@ -107,6 +140,29 @@ impl AlloyChainProvider {
 
         Ok(())
     }
+
+    /// Absorbs the result of a finished read-ahead task into the caches.
+    ///
+    /// If a read-ahead is still in flight it is left alone — the critical path
+    /// never awaits an unfinished read-ahead. Failed read-aheads are discarded;
+    /// the caller falls back to a synchronous fetch on the next cache miss.
+    async fn absorb_finished_read_ahead(&mut self) {
+        let Some(handle) = self.pending_read_ahead.take() else {
+            return;
+        };
+
+        if !handle.is_finished() {
+            self.pending_read_ahead = Some(handle);
+            return;
+        }
+
+        if let Ok(Some((hash, header, receipts))) = handle.await {
+            self.header_by_hash_cache.put(hash, header);
+            Metrics::cache_entries("header_by_hash").increment(1);
+            self.receipts_by_hash_cache.put(hash, receipts);
+            Metrics::cache_entries("receipts_by_hash").increment(1);
+        }
+    }
 }
 
 /// An error for the [`AlloyChainProvider`].
@@ -155,6 +211,8 @@ impl ChainProvider for AlloyChainProvider {
     type Error = AlloyChainProviderError;
 
     async fn header_by_hash(&mut self, hash: B256) -> Result<Header, Self::Error> {
+        self.absorb_finished_read_ahead().await;
+
         if let Some(header) = self.header_by_hash_cache.get(&hash) {
             Metrics::chain_cache_hits("header_by_hash").increment(1);
             return Ok(header.clone());
@@ -205,6 +263,8 @@ impl ChainProvider for AlloyChainProvider {
     }
 
     async fn receipts_by_hash(&mut self, hash: B256) -> Result<Vec<Receipt>, Self::Error> {
+        self.absorb_finished_read_ahead().await;
+
         if let Some(receipts) = self.receipts_by_hash_cache.get(&hash) {
             Metrics::chain_cache_hits("receipts_by_hash").increment(1);
             return Ok(receipts.clone());
@@ -232,6 +292,68 @@ impl ChainProvider for AlloyChainProvider {
         Metrics::cache_entries("receipts_by_hash").increment(1);
 
         Ok(consensus_receipts)
+    }
+
+    /// Spawns a best-effort background task that fetches the header and
+    /// receipts of the block at `number` and hands them back through
+    /// [`Self::pending_read_ahead`]. The hint is skipped if a read-ahead is
+    /// already pending.
+    ///
+    /// The task uses the (cheaply cloned, `Arc`-backed) RPC client directly:
+    /// the hinted block is new and cannot be cached yet, and the block-by-number
+    /// response already contains the header, so resolving number → hash → header
+    /// through the provider methods would re-fetch the same header. The hash is
+    /// computed from the fetched header, so no `trust_rpc` verification applies.
+    ///
+    /// Failures are ignored: the block may not exist yet, and the caller falls
+    /// back to a synchronous fetch on the next cache miss.
+    ///
+    /// Must be called from within a tokio runtime.
+    fn hint_block(&mut self, number: u64) {
+        if self.pending_read_ahead.is_some() {
+            return;
+        }
+
+        let inner = self.inner.clone();
+        self.pending_read_ahead = Some(tokio::spawn(async move {
+            Metrics::chain_rpc_calls("block_by_number").increment(1);
+            let block = base_metrics::time!(Metrics::request_duration("block_by_number"), {
+                inner.get_block_by_number(number.into()).await
+            })
+            .inspect_err(|err| {
+                Metrics::chain_rpc_errors("block_by_number").increment(1);
+                tracing::debug!(
+                    target: "chain_provider",
+                    error = %err,
+                    number,
+                    "Read-ahead block fetch failed"
+                );
+            })
+            .ok()??;
+            let header = block.header.into_consensus();
+            let hash = header.hash_slow();
+
+            Metrics::chain_rpc_calls("receipts_by_hash").increment(1);
+            let receipts = base_metrics::time!(Metrics::request_duration("receipts_by_hash"), {
+                inner.get_block_receipts(hash.into()).await
+            })
+            .inspect_err(|err| {
+                Metrics::chain_rpc_errors("receipts_by_hash").increment(1);
+                tracing::debug!(
+                    target: "chain_provider",
+                    error = %err,
+                    number,
+                    "Read-ahead receipts fetch failed"
+                );
+            })
+            .ok()??;
+            let receipts = receipts
+                .into_iter()
+                .map(|r| r.inner.into_primitives_receipt().as_receipt().cloned())
+                .collect::<Option<Vec<_>>>()?;
+
+            Some((hash, header, receipts))
+        }));
     }
 
     async fn block_info_and_transactions_by_hash(
@@ -279,9 +401,183 @@ impl ChainProvider for AlloyChainProvider {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+
     use alloy_primitives::B256;
+    use alloy_rpc_types_eth::Block;
+    use httpmock::{HttpMockRequest, HttpMockResponse, Method::POST, MockServer};
+    use serde_json::{Value, json};
 
     use super::*;
+
+    type RecordedCalls = Arc<Mutex<Vec<(String, Value)>>>;
+
+    fn block_json(number: u64) -> Value {
+        json!({
+            "hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "parentHash": "0x2222222222222222222222222222222222222222222222222222222222222222",
+            "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+            "miner": "0x0000000000000000000000000000000000000000",
+            "stateRoot": "0x3333333333333333333333333333333333333333333333333333333333333333",
+            "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+            "receiptsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+            "logsBloom": format!("0x{}", "00".repeat(256)),
+            "difficulty": "0x0",
+            "number": format!("0x{number:x}"),
+            "gasLimit": "0x1c9c380",
+            "gasUsed": "0x0",
+            "timestamp": "0x1",
+            "extraData": "0x",
+            "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "nonce": "0x0000000000000000",
+            "baseFeePerGas": "0x1",
+            "transactions": [],
+            "uncles": [],
+            "withdrawals": [],
+            "blobGasUsed": "0x0",
+            "excessBlobGas": "0x0"
+        })
+    }
+
+    fn json_rpc_response(req: &HttpMockRequest, result: Value) -> String {
+        let id = serde_json::from_slice::<Value>(&req.body_vec())
+            .ok()
+            .and_then(|body| body.get("id").cloned())
+            .unwrap_or(Value::Null);
+        json!({ "jsonrpc": "2.0", "id": id, "result": result }).to_string()
+    }
+
+    /// Mounts a catch-all JSON-RPC dispatcher that serves block 42 (by hash
+    /// `h1`), block 43 (by number and by `next_hash`), and empty receipts for
+    /// any hash, recording every `(method, params)` pair in `calls`.
+    async fn mount_dispatcher(
+        server: &MockServer,
+        h1: B256,
+        next_hash: B256,
+        calls: RecordedCalls,
+    ) {
+        server
+            .mock_async(move |when, then| {
+                when.method(POST).path("/");
+                then.respond_with(move |req| {
+                    let body: Value = serde_json::from_slice(&req.body_vec()).unwrap();
+                    let method = body["method"].as_str().unwrap_or_default().to_string();
+                    let params = body["params"].clone();
+                    calls.lock().unwrap().push((method.clone(), params.clone()));
+                    let result = match method.as_str() {
+                        "eth_getBlockReceipts" => json!([]),
+                        "eth_getBlockByNumber" if params[0] == json!("0x2b") => block_json(43),
+                        "eth_getBlockByHash" if params[0] == json!(format!("{h1:?}")) => {
+                            block_json(42)
+                        }
+                        "eth_getBlockByHash" if params[0] == json!(format!("{next_hash:?}")) => {
+                            block_json(43)
+                        }
+                        _ => Value::Null,
+                    };
+                    HttpMockResponse::builder()
+                        .status(200)
+                        .header("content-type", "application/json")
+                        .body(json_rpc_response(req, result))
+                        .build()
+                });
+            })
+            .await;
+    }
+
+    fn l1_provider(server: &MockServer) -> AlloyChainProvider {
+        AlloyChainProvider::new(RootProvider::new_http(server.url("/").parse().unwrap()), 16)
+    }
+
+    fn count(calls: &RecordedCalls, method: &str) -> usize {
+        calls.lock().unwrap().iter().filter(|(m, _)| m == method).count()
+    }
+
+    /// Waits for the provider's pending read-ahead task to finish, without
+    /// absorbing it.
+    async fn wait_for_read_ahead(provider: &AlloyChainProvider) {
+        let handle = provider.pending_read_ahead.as_ref().expect("no read-ahead pending");
+        for _ in 0..200 {
+            if handle.is_finished() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("read-ahead task never finished");
+    }
+
+    #[tokio::test]
+    async fn test_receipts_by_hash_does_not_prefetch() {
+        let server = MockServer::start_async().await;
+        let calls: RecordedCalls = Arc::default();
+        let h1 = B256::repeat_byte(0xaa);
+        mount_dispatcher(&server, h1, B256::ZERO, Arc::clone(&calls)).await;
+
+        let mut provider = l1_provider(&server);
+        provider.header_by_hash(h1).await.unwrap();
+        provider.receipts_by_hash(h1).await.unwrap();
+
+        assert!(provider.pending_read_ahead.is_none(), "fetches must not spawn read-ahead");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            count(&calls, "eth_getBlockByNumber"),
+            0,
+            "fetches must not trigger background block-by-number lookups"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_hint_block_warms_caches() {
+        let server = MockServer::start_async().await;
+        let calls: RecordedCalls = Arc::default();
+        let h1 = B256::repeat_byte(0xaa);
+        // `block_info_by_number` derives the hash from the fetched header, so
+        // compute the hash the read-ahead task will resolve for block 43.
+        let next_block: Block = serde_json::from_value(block_json(43)).unwrap();
+        let next_hash = next_block.header.inner.hash_slow();
+        mount_dispatcher(&server, h1, next_hash, Arc::clone(&calls)).await;
+
+        let mut provider = l1_provider(&server);
+        provider.hint_block(43);
+        wait_for_read_ahead(&provider).await;
+
+        // Exactly two RPCs: block by number (which includes the header) and
+        // receipts. No header re-fetch by hash, no cascade to block 44.
+        assert_eq!(count(&calls, "eth_getBlockByNumber"), 1);
+        assert_eq!(count(&calls, "eth_getBlockByHash"), 0);
+        assert_eq!(count(&calls, "eth_getBlockReceipts"), 1);
+
+        // The next fetch absorbs the finished read-ahead and serves the hinted
+        // block from cache: no new RPCs.
+        provider.header_by_hash(next_hash).await.unwrap();
+        provider.receipts_by_hash(next_hash).await.unwrap();
+        assert!(provider.pending_read_ahead.is_none(), "finished read-ahead must be absorbed");
+        assert_eq!(count(&calls, "eth_getBlockByHash"), 0, "header must come from the cache");
+        assert_eq!(count(&calls, "eth_getBlockReceipts"), 1, "receipts must come from the cache");
+    }
+
+    #[tokio::test]
+    async fn test_hint_block_skipped_while_pending() {
+        let server = MockServer::start_async().await;
+        let calls: RecordedCalls = Arc::default();
+        let next_block: Block = serde_json::from_value(block_json(43)).unwrap();
+        let next_hash = next_block.header.inner.hash_slow();
+        mount_dispatcher(&server, B256::repeat_byte(0xaa), next_hash, Arc::clone(&calls)).await;
+
+        let mut provider = l1_provider(&server);
+        provider.hint_block(43);
+        provider.hint_block(43);
+        wait_for_read_ahead(&provider).await;
+
+        assert_eq!(
+            count(&calls, "eth_getBlockByNumber"),
+            1,
+            "a hint while one is pending must be dropped"
+        );
+    }
 
     #[test]
     fn test_from_alloy_chain_provider_error() {

--- a/crates/consensus/providers/src/conf_depth.rs
+++ b/crates/consensus/providers/src/conf_depth.rs
@@ -77,6 +77,10 @@ impl ChainProvider for ConfDepthProvider {
         self.inner.receipts_by_hash(hash).await
     }
 
+    fn hint_block(&mut self, number: u64) {
+        self.inner.hint_block(number);
+    }
+
     async fn block_info_and_transactions_by_hash(
         &mut self,
         hash: B256,


### PR DESCRIPTION
Attributes building pays synchronous L1 RPC round trips (block info, header, receipts) at every epoch boundary, showing up as the p99 tail in base_node_sequencer_attributes_build_duration. Since the next epoch origin is always the current origin's successor, the attributes builder now hints the L1 provider after fetching a new epoch's receipts; the provider prefetches the next block's header and receipts in a background task and hands the result back through a JoinHandle, absorbed into its caches on the next fetch — turning the next epoch-boundary fetches into cache hits. The critical path never awaits an in-flight prefetch.