### PR TITLE
PolicyRegistry: drop ChildPoliciesOutsideOfRange args, add composite child-count getters (BOP-497)

### DIFF
--- a/crates/common/precompiles/src/policy/abi/mod.rs
+++ b/crates/common/precompiles/src/policy/abi/mod.rs
@@ -25,6 +25,8 @@ impl IPolicyRegistry::IPolicyRegistryCalls {
             Self::updateAllowlist(_) => "policy.updateAllowlist",
             Self::updateBlocklist(_) => "policy.updateBlocklist",
             Self::isAuthorized(_) => "policy.isAuthorized",
+            Self::MIN_COMPOSITE_CHILD_POLICIES(_) => "policy.MIN_COMPOSITE_CHILD_POLICIES",
+            Self::MAX_COMPOSITE_CHILD_POLICIES(_) => "policy.MAX_COMPOSITE_CHILD_POLICIES",
             Self::policyExists(_) => "policy.policyExists",
             Self::policyAdmin(_) => "policy.policyAdmin",
             Self::pendingPolicyAdmin(_) => "policy.pendingPolicyAdmin",
@@ -55,7 +57,7 @@ mod tests {
 
     /// Absolute wire fingerprint for Cobalt's (canonical) surface.
     const V2_ABI_FINGERPRINT: B256 =
-        b256!("cc5f508d2cacd9b729ddbd7a7d9ed3788929fdbb237c286e5a9d8961a90cf656");
+        b256!("da3137a81688286fb3af7f0f09a6369ae7c1197c08844a29dbde13f8c036394d");
 
     /// These two surfaces pass no enum ordinals to [`AbiFingerprint`], so the pinned constants
     /// above keep the values they were blessed with. `PolicyType` ordinals *are* load-bearing —

--- a/crates/common/precompiles/src/policy/abi/v2.rs
+++ b/crates/common/precompiles/src/policy/abi/v2.rs
@@ -31,8 +31,9 @@ sol! {
         error NoPendingAdmin();
 
         /// Introduced in V2 (Cobalt). A composite policy was created or updated with a child-policy
-        /// count outside the permitted `[min, max]` range.
-        error ChildPoliciesOutsideOfRange(uint256 min, uint256 max);
+        /// count outside the permitted range. A composite must reference between
+        /// `MIN_COMPOSITE_CHILD_POLICIES` and `MAX_COMPOSITE_CHILD_POLICIES` simple policies, inclusive.
+        error ChildPoliciesOutsideOfRange();
         /// Introduced in V2 (Cobalt). A composite child must be an existing ALLOWLIST or BLOCKLIST
         /// policy — never a built-in sentinel or another composite.
         error InvalidChildPolicy(uint64 childPolicyId);
@@ -51,7 +52,7 @@ sol! {
         function createPolicyWithAccounts(address admin, PolicyType policyType, address[] calldata accounts) external returns (uint64);
         /// Introduced in V2 (Cobalt). Creates a composite policy combining existing simple policies
         /// under a UNION or INTERSECT gate. Children must be simple policies; the child count must
-        /// be in `[2, 4]`.
+        /// be in `[MIN_COMPOSITE_CHILD_POLICIES, MAX_COMPOSITE_CHILD_POLICIES]`.
         function createCompositePolicy(address admin, PolicyType policyType, uint64[] calldata childPolicyIds) external returns (uint64);
         /// Introduced in V2 (Cobalt). Replaces a composite policy's child set in full, re-validated
         /// exactly as at creation. The gate is fixed in the ID and cannot change.
@@ -63,6 +64,12 @@ sol! {
         function updateAllowlist(uint64 policyId, bool allowed, address[] calldata accounts) external;
         function updateBlocklist(uint64 policyId, bool blocked, address[] calldata accounts) external;
         function isAuthorized(uint64 policyId, address account) external view returns (bool);
+        /// Introduced in V2 (Cobalt). Minimum number of child policies a composite must
+        /// reference, inclusive. Never reverts.
+        function MIN_COMPOSITE_CHILD_POLICIES() external view returns (uint256);
+        /// Introduced in V2 (Cobalt). Maximum number of child policies a composite may
+        /// reference, inclusive. Never reverts.
+        function MAX_COMPOSITE_CHILD_POLICIES() external view returns (uint256);
         function policyExists(uint64 policyId) external view returns (bool);
         function policyAdmin(uint64 policyId) external view returns (address);
         function pendingPolicyAdmin(uint64 policyId) external view returns (address);
@@ -116,6 +123,8 @@ mod tests {
             IPolicyRegistry::updateAllowlistCall::SELECTOR,
             IPolicyRegistry::updateBlocklistCall::SELECTOR,
             IPolicyRegistry::isAuthorizedCall::SELECTOR,
+            IPolicyRegistry::MIN_COMPOSITE_CHILD_POLICIESCall::SELECTOR,
+            IPolicyRegistry::MAX_COMPOSITE_CHILD_POLICIESCall::SELECTOR,
             IPolicyRegistry::policyExistsCall::SELECTOR,
             IPolicyRegistry::policyAdminCall::SELECTOR,
             IPolicyRegistry::pendingPolicyAdminCall::SELECTOR,
@@ -123,7 +132,7 @@ mod tests {
         ];
         expected.sort_unstable();
 
-        assert_eq!(selectors.len(), 14);
+        assert_eq!(selectors.len(), 16);
         assert_eq!(selectors, expected);
     }
 }

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::Bytes;
+use alloy_primitives::{Bytes, U256};
 use alloy_sol_types::SolCall;
 use base_common_genesis::BaseUpgrade;
 use base_precompile_storage::{BasePrecompileError, StorageCtx};
@@ -8,8 +8,8 @@ use crate::{
     ActivationFeature, ActivationRegistryStorage, BerylAuxiliaryMetrics, BerylCallRecorder,
     BerylMetricLabels,
     IPolicyRegistry::{self, IPolicyRegistryCalls as C},
-    NoopPrecompileCallObserver, PolicyRegistryStorage, PolicyVersion, PolicyVersions,
-    PrecompileCallObserver,
+    NoopPrecompileCallObserver, PolicyRegistryStorage, PolicyRegistryV2, PolicyVersion,
+    PolicyVersions, PrecompileCallObserver,
 };
 
 impl PolicyRegistryStorage<'_> {
@@ -62,6 +62,8 @@ impl PolicyRegistryStorage<'_> {
             Some(sel)
                 if abi.valid_selector(sel)
                     && (sel == IPolicyRegistry::isAuthorizedCall::SELECTOR
+                        || sel == IPolicyRegistry::MIN_COMPOSITE_CHILD_POLICIESCall::SELECTOR
+                        || sel == IPolicyRegistry::MAX_COMPOSITE_CHILD_POLICIESCall::SELECTOR
                         || sel == IPolicyRegistry::policyExistsCall::SELECTOR
                         || sel == IPolicyRegistry::policyAdminCall::SELECTOR
                         || sel == IPolicyRegistry::pendingPolicyAdminCall::SELECTOR
@@ -146,6 +148,20 @@ impl PolicyRegistryStorage<'_> {
             C::isAuthorized(call) => {
                 let authorized = logic.is_authorized(self, call.policyId, call.account)?;
                 Ok(IPolicyRegistry::isAuthorizedCall::abi_encode_returns(&authorized).into())
+            }
+            // Introduced in V2 (Cobalt). Version-invariant constants, answered without going
+            // through the logic trait.
+            C::MIN_COMPOSITE_CHILD_POLICIES(_) => {
+                Ok(IPolicyRegistry::MIN_COMPOSITE_CHILD_POLICIESCall::abi_encode_returns(
+                    &U256::from(PolicyRegistryV2::MIN_CHILD_POLICIES),
+                )
+                .into())
+            }
+            C::MAX_COMPOSITE_CHILD_POLICIES(_) => {
+                Ok(IPolicyRegistry::MAX_COMPOSITE_CHILD_POLICIESCall::abi_encode_returns(
+                    &U256::from(PolicyRegistryV2::MAX_CHILD_POLICIES),
+                )
+                .into())
             }
             C::policyExists(call) => {
                 let exists = logic.policy_exists(self, call.policyId)?;
@@ -657,6 +673,48 @@ mod tests {
         .abi_encode();
         let out = run(&mut storage, &update_blocklist);
         assert!(!out.is_revert());
+    }
+
+    #[test]
+    fn dispatch_min_max_composite_child_policies() {
+        let mut storage = HashMapStorageProvider::new(1);
+        activate_policy_registry(&mut storage);
+
+        let min_calldata = IPolicyRegistry::MIN_COMPOSITE_CHILD_POLICIESCall {}.abi_encode();
+        let min_out = run_at(&mut storage, &min_calldata, BaseUpgrade::Cobalt);
+        assert!(!min_out.is_revert());
+        assert_eq!(
+            IPolicyRegistry::MIN_COMPOSITE_CHILD_POLICIESCall::abi_decode_returns(&min_out.bytes)
+                .unwrap(),
+            alloy_primitives::U256::from(2)
+        );
+
+        let max_calldata = IPolicyRegistry::MAX_COMPOSITE_CHILD_POLICIESCall {}.abi_encode();
+        let max_out = run_at(&mut storage, &max_calldata, BaseUpgrade::Cobalt);
+        assert!(!max_out.is_revert());
+        assert_eq!(
+            IPolicyRegistry::MAX_COMPOSITE_CHILD_POLICIESCall::abi_decode_returns(&max_out.bytes)
+                .unwrap(),
+            alloy_primitives::U256::from(4)
+        );
+    }
+
+    #[test]
+    fn dispatch_min_max_composite_child_policies_succeed_when_deactivated_and_pre_cobalt() {
+        let mut storage = HashMapStorageProvider::new(1);
+        // Never activated, and dispatched at Beryl where the selectors are unknown — pinning
+        // that pre-Cobalt call sites see `UnknownFunctionSelector`, not a feature-inactive revert.
+        let min_calldata = IPolicyRegistry::MIN_COMPOSITE_CHILD_POLICIESCall {}.abi_encode();
+        let beryl_out = run(&mut storage, &min_calldata);
+        assert!(beryl_out.is_revert());
+        assert_eq!(
+            beryl_out.bytes,
+            Bytes::from(IPolicyRegistry::MIN_COMPOSITE_CHILD_POLICIESCall::SELECTOR.as_ref())
+        );
+
+        // At Cobalt, the same never-activated registry still answers the getter (view bypass).
+        let cobalt_out = run_at(&mut storage, &min_calldata, BaseUpgrade::Cobalt);
+        assert!(!cobalt_out.is_revert(), "getter must not revert when feature is deactivated");
     }
 
     #[test]

--- a/crates/common/precompiles/src/policy/logic/v2.rs
+++ b/crates/common/precompiles/src/policy/logic/v2.rs
@@ -116,15 +116,12 @@ impl PolicyRegistryV2 {
         policy_id == Self::ALWAYS_ALLOW_ID || policy_id == Self::ALWAYS_BLOCK_ID
     }
 
-    /// Reverts `ChildPoliciesOutsideOfRange(2, 4)` when the child count is outside `[2, 4]`.
+    /// Reverts `ChildPoliciesOutsideOfRange` when the child count is outside `[2, 4]`.
     fn require_child_policy_in_range(child_policy_ids: &[u64]) -> Result<()> {
         let count = child_policy_ids.len();
         if !(Self::MIN_CHILD_POLICIES..=Self::MAX_CHILD_POLICIES).contains(&count) {
             return Err(BasePrecompileError::revert(
-                IPolicyRegistry::ChildPoliciesOutsideOfRange {
-                    min: U256::from(Self::MIN_CHILD_POLICIES),
-                    max: U256::from(Self::MAX_CHILD_POLICIES),
-                },
+                IPolicyRegistry::ChildPoliciesOutsideOfRange {},
             ));
         }
         Ok(())
@@ -1466,10 +1463,8 @@ mod tests {
     fn create_composite_child_count_out_of_range_reverts() {
         let mut rt = initialized();
         let ids: Vec<u64> = (0..5).map(|_| create_allowlist(&mut rt)).collect();
-        let range_err = BasePrecompileError::revert(IPolicyRegistry::ChildPoliciesOutsideOfRange {
-            min: U256::from(2),
-            max: U256::from(4),
-        });
+        let range_err =
+            BasePrecompileError::revert(IPolicyRegistry::ChildPoliciesOutsideOfRange {});
         // Too few (1) and too many (5) both revert with the same range error.
         let too_few = LOGIC
             .create_composite_policy(&mut rt, ADMIN, PolicyType::UNION, vec![ids[0]])

--- a/crates/common/precompiles/src/policy/versions.rs
+++ b/crates/common/precompiles/src/policy/versions.rs
@@ -185,21 +185,23 @@ mod tests {
         let added: Vec<[u8; 4]> = IPolicyRegistryV2::IPolicyRegistryCalls::selectors()
             .filter(|selector| !PolicyAbi::V1.valid_selector(*selector))
             .collect();
-        assert_eq!(added.len(), 3);
+        assert_eq!(added.len(), 5);
         assert!(added.contains(&IPolicyRegistry::createCompositePolicyCall::SELECTOR));
         assert!(added.contains(&IPolicyRegistry::updateCompositeCall::SELECTOR));
         assert!(added.contains(&IPolicyRegistry::compositePolicyChildIdsCall::SELECTOR));
+        assert!(added.contains(&IPolicyRegistry::MIN_COMPOSITE_CHILD_POLICIESCall::SELECTOR));
+        assert!(added.contains(&IPolicyRegistry::MAX_COMPOSITE_CHILD_POLICIESCall::SELECTOR));
     }
 
     /// `abi_decode_validate` short-circuits on `len < MIN_DATA_LENGTH + 4` before looking at the
-    /// selector. Equal minimums across surfaces is what makes truncated calldata produce identical
-    /// bytes at every fork, and it is not obvious from the interface definitions.
+    /// selector. Before Cobalt's `MIN_COMPOSITE_CHILD_POLICIES`/`MAX_COMPOSITE_CHILD_POLICIES`
+    /// getters (the first zero-argument calls on either surface), equal minimums across surfaces
+    /// meant truncated calldata produced identical bytes at every fork. V2's minimum is now `0`
+    /// since those two calls take no arguments; V1, which never gained a zero-arg call, keeps `32`.
     #[test]
     fn surfaces_share_a_minimum_calldata_length() {
-        assert_eq!(
-            IPolicyRegistryV1::IPolicyRegistryCalls::MIN_DATA_LENGTH,
-            IPolicyRegistryV2::IPolicyRegistryCalls::MIN_DATA_LENGTH
-        );
+        assert_eq!(IPolicyRegistryV1::IPolicyRegistryCalls::MIN_DATA_LENGTH, 32);
+        assert_eq!(IPolicyRegistryV2::IPolicyRegistryCalls::MIN_DATA_LENGTH, 0);
     }
 
     /// `SolInterface::NAME` lands in consensus data: the short-calldata branch of

--- a/crates/common/precompiles/tests/b20_policy_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_policy_v1_golden.rs
@@ -391,6 +391,35 @@ fn golden_composite_child_ids_selector_unknown_in_v1() {
     assert_eq!(bytes, Bytes::from(IPolicyRegistry::compositePolicyChildIdsCall::SELECTOR.as_ref()));
 }
 
+#[test]
+fn golden_min_max_composite_child_policies_selector_unknown_in_v1() {
+    // MIN_COMPOSITE_CHILD_POLICIES/MAX_COMPOSITE_CHILD_POLICIES are V2-only getters — composite
+    // policies do not exist at Beryl, so their selectors must stay unknown, same as the other
+    // composite selectors above.
+    let mut s = fresh();
+    let (min_rev, min_bytes) = call_policy(
+        &mut s,
+        ADMIN,
+        IPolicyRegistry::MIN_COMPOSITE_CHILD_POLICIESCall {}.abi_encode(),
+    );
+    assert!(min_rev);
+    assert_eq!(
+        min_bytes,
+        Bytes::from(IPolicyRegistry::MIN_COMPOSITE_CHILD_POLICIESCall::SELECTOR.as_ref())
+    );
+
+    let (max_rev, max_bytes) = call_policy(
+        &mut s,
+        ADMIN,
+        IPolicyRegistry::MAX_COMPOSITE_CHILD_POLICIESCall {}.abi_encode(),
+    );
+    assert!(max_rev);
+    assert_eq!(
+        max_bytes,
+        Bytes::from(IPolicyRegistry::MAX_COMPOSITE_CHILD_POLICIESCall::SELECTOR.as_ref())
+    );
+}
+
 fn frozen_v1_abi_decode_failure(calldata: &[u8]) -> Bytes {
     let selector = calldata.first_chunk::<4>().copied().expect("calldata must carry a selector");
     let Err(error) = IPolicyRegistryV1::IPolicyRegistryCalls::abi_decode_validate(calldata) else {
@@ -1022,6 +1051,9 @@ fn v1_op_coverage_checklist(call: IPolicyRegistry::IPolicyRegistryCalls) {
         C::updateComposite(_) => covered(&[golden_update_composite_selector_unknown_in_v1]),
         C::compositePolicyChildIds(_) => {
             covered(&[golden_composite_child_ids_selector_unknown_in_v1])
+        }
+        C::MIN_COMPOSITE_CHILD_POLICIES(_) | C::MAX_COMPOSITE_CHILD_POLICIES(_) => {
+            covered(&[golden_min_max_composite_child_policies_selector_unknown_in_v1])
         }
     }
 }

--- a/crates/common/precompiles/tests/b20_policy_v2_golden.rs
+++ b/crates/common/precompiles/tests/b20_policy_v2_golden.rs
@@ -576,6 +576,84 @@ fn golden_update_composite_reverts_unauthorized() {
 }
 
 #[test]
+fn golden_create_composite_reverts_child_count_outside_of_range() {
+    let mut s = fresh();
+    let a = create(&mut s, ADMIN, ADMIN, PolicyType::ALLOWLIST);
+    let (rev, bytes) = call_policy(
+        &mut s,
+        ADMIN,
+        IPolicyRegistry::createCompositePolicyCall {
+            admin: ADMIN,
+            policyType: PolicyType::UNION,
+            childPolicyIds: vec![a],
+        }
+        .abi_encode(),
+    );
+    assert!(rev);
+    assert_eq!(bytes, Bytes::from(IPolicyRegistry::ChildPoliciesOutsideOfRange {}.abi_encode()));
+}
+
+/// Reads `MIN_COMPOSITE_CHILD_POLICIES()` over the wire.
+fn min_composite_child_policies(storage: &mut HashMapStorageProvider) -> U256 {
+    let (rev, bytes) = call_policy(
+        storage,
+        OUTSIDER,
+        IPolicyRegistry::MIN_COMPOSITE_CHILD_POLICIESCall {}.abi_encode(),
+    );
+    assert!(!rev, "MIN_COMPOSITE_CHILD_POLICIES unexpectedly reverted");
+    IPolicyRegistry::MIN_COMPOSITE_CHILD_POLICIESCall::abi_decode_returns(&bytes).unwrap()
+}
+
+/// Reads `MAX_COMPOSITE_CHILD_POLICIES()` over the wire.
+fn max_composite_child_policies(storage: &mut HashMapStorageProvider) -> U256 {
+    let (rev, bytes) = call_policy(
+        storage,
+        OUTSIDER,
+        IPolicyRegistry::MAX_COMPOSITE_CHILD_POLICIESCall {}.abi_encode(),
+    );
+    assert!(!rev, "MAX_COMPOSITE_CHILD_POLICIES unexpectedly reverted");
+    IPolicyRegistry::MAX_COMPOSITE_CHILD_POLICIESCall::abi_decode_returns(&bytes).unwrap()
+}
+
+#[test]
+fn golden_min_max_composite_child_policies() {
+    let mut s = fresh();
+    assert_eq!(min_composite_child_policies(&mut s), U256::from(2));
+    assert_eq!(max_composite_child_policies(&mut s), U256::from(4));
+}
+
+#[test]
+fn golden_min_max_composite_child_policies_read_before_activation() {
+    // No activation, matching `golden_composite_policy_child_ids_reads_before_activation`.
+    let mut s = HashMapStorageProvider::new(CHAIN_ID);
+    let (min_rev, min_bytes) = call_policy(
+        &mut s,
+        OUTSIDER,
+        IPolicyRegistry::MIN_COMPOSITE_CHILD_POLICIESCall {}.abi_encode(),
+    );
+    assert!(!min_rev, "view must not be gated on activation");
+    assert_eq!(
+        min_bytes,
+        Bytes::from(IPolicyRegistry::MIN_COMPOSITE_CHILD_POLICIESCall::abi_encode_returns(
+            &U256::from(2)
+        ))
+    );
+
+    let (max_rev, max_bytes) = call_policy(
+        &mut s,
+        OUTSIDER,
+        IPolicyRegistry::MAX_COMPOSITE_CHILD_POLICIESCall {}.abi_encode(),
+    );
+    assert!(!max_rev, "view must not be gated on activation");
+    assert_eq!(
+        max_bytes,
+        Bytes::from(IPolicyRegistry::MAX_COMPOSITE_CHILD_POLICIESCall::abi_encode_returns(
+            &U256::from(4)
+        ))
+    );
+}
+
+#[test]
 fn golden_create_with_accounts() {
     let mut s = fresh();
     let (rev, bytes) = call_policy(
@@ -1119,6 +1197,7 @@ fn v2_op_coverage_checklist(call: IPolicyRegistry::IPolicyRegistryCalls) {
         C::createCompositePolicy(_) => covered(&[
             golden_create_composite_union,
             golden_create_composite_reverts_incompatible_type,
+            golden_create_composite_reverts_child_count_outside_of_range,
         ]),
         C::updateComposite(_) => {
             covered(&[golden_update_composite, golden_update_composite_reverts_unauthorized])
@@ -1127,6 +1206,10 @@ fn v2_op_coverage_checklist(call: IPolicyRegistry::IPolicyRegistryCalls) {
             golden_composite_policy_child_ids,
             golden_composite_policy_child_ids_empty_for_non_composites,
             golden_composite_policy_child_ids_reads_before_activation,
+        ]),
+        C::MIN_COMPOSITE_CHILD_POLICIES(_) | C::MAX_COMPOSITE_CHILD_POLICIES(_) => covered(&[
+            golden_min_max_composite_child_policies,
+            golden_min_max_composite_child_policies_read_before_activation,
         ]),
     }
 }


### PR DESCRIPTION
## Summary
- Mirrors [base-std PR #190](https://github.com/base/base-std/pull/190) into the Rust `PolicyRegistry` precompile (`crates/common/precompiles/src/policy/`), which base-std's `MockPolicyRegistry` is written against.
- Drops the `(uint256 min, uint256 max)` args from `ChildPoliciesOutsideOfRange`; it now reverts with no data.
- Adds two new view functions to the Cobalt (V2) wire surface: `MIN_COMPOSITE_CHILD_POLICIES()` and `MAX_COMPOSITE_CHILD_POLICIES()`, both answered directly from `PolicyRegistryV2`'s existing constants (2 and 4) without a new logic-trait method, matching how `b20_asset` answers `WAD_PRECISION()`. Both bypass the activation gate, consistent with the other view functions.
- Cobalt has not activated on any real network (`base.json`/`sepolia_base.json` don't set a `cobalt` timestamp; `zeronet_base.json` sets `"cobalt": null`), so the V2 wire surface and logic were edited in place rather than adding a new `V3`.
- Re-blessed `V2_ABI_FINGERPRINT` and updated the frozen selector-set / cross-surface invariant tests (`abi/v2.rs`, `versions.rs`) for the two new selectors and the error's changed signature.
- Added golden coverage in `b20_policy_v2_golden.rs` (getters, pre-activation reads, argless revert) and `b20_policy_v1_golden.rs` (both getters remain `UnknownFunctionSelector` at Beryl, same as the other composite-only selectors).

## Test plan
- [x] `cargo build -p base-common-precompiles --features test-utils`
- [x] `cargo test -p base-common-precompiles --features test-utils` — 650 lib tests + all golden/integration binaries pass (0 failed)
- [x] `cargo fmt -p base-common-precompiles -- --check`
- [x] `cargo clippy -p base-common-precompiles --features test-utils --all-targets`