### PR TITLE
fix(BOP-498): version-gate B20 seize policy scope validation to Cobalt (V2)

### DIFF
--- a/crates/common/precompiles/src/b20_asset/logic/v1.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v1.rs
@@ -170,7 +170,12 @@ impl AssetV1 {
     /// The seize scopes (`SEIZE_HOLDER_POLICY` / `SEIZE_RECEIVER_POLICY`) were introduced at Cobalt
     /// (V2), so they are rejected here — matching the base-std `v1.0.0` reference. This is what keeps
     /// the common `updatePolicy` / `policyId` selectors (dialable on V1) from reaching a V2-only
-    /// scope. The wildcard arm also freezes V1 against any scope added to `B20PolicyType` later.
+    /// scope.
+    ///
+    /// The match is exhaustive by design (no `_` arm): every `B20PolicyType` variant is named, so a
+    /// scope added for a future fork fails to compile here until an engineer explicitly places it in
+    /// the supported or rejected arm, reconciling V1 against the base-std `v1.0.0` reference. A
+    /// wildcard would silently reject a newly added scope that should be valid at V1.
     fn ensure_supported_policy_type(policy_scope: B256) -> Result<()> {
         match B20PolicyType::from_id(policy_scope) {
             Some(
@@ -179,9 +184,12 @@ impl AssetV1 {
                 | B20PolicyType::TransferExecutor
                 | B20PolicyType::MintReceiver,
             ) => Ok(()),
-            _ => Err(BasePrecompileError::revert(IB20::UnsupportedPolicyType {
-                policyScope: policy_scope,
-            })),
+            // Cobalt (V2)-only scopes, and any unrecognized id, are not part of the frozen V1 surface.
+            Some(B20PolicyType::SeizeHolder | B20PolicyType::SeizeReceiver) | None => {
+                Err(BasePrecompileError::revert(IB20::UnsupportedPolicyType {
+                    policyScope: policy_scope,
+                }))
+            }
         }
     }
 

--- a/crates/common/precompiles/src/b20_asset/logic/v1.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v1.rs
@@ -164,14 +164,24 @@ impl AssetV1 {
         Ok(())
     }
 
-    /// Ensures `policy_scope` names a built-in B-20 policy slot.
+    /// Ensures `policy_scope` names a built-in B-20 policy slot available on the frozen V1 (Beryl)
+    /// common surface.
+    ///
+    /// The seize scopes (`SEIZE_HOLDER_POLICY` / `SEIZE_RECEIVER_POLICY`) were introduced at Cobalt
+    /// (V2), so they are rejected here — matching the base-std `v1.0.0` reference. This is what keeps
+    /// the common `updatePolicy` / `policyId` selectors (dialable on V1) from reaching a V2-only
+    /// scope. The wildcard arm also freezes V1 against any scope added to `B20PolicyType` later.
     fn ensure_supported_policy_type(policy_scope: B256) -> Result<()> {
-        if B20PolicyType::from_id(policy_scope).is_some() {
-            Ok(())
-        } else {
-            Err(BasePrecompileError::revert(IB20::UnsupportedPolicyType {
+        match B20PolicyType::from_id(policy_scope) {
+            Some(
+                B20PolicyType::TransferSender
+                | B20PolicyType::TransferReceiver
+                | B20PolicyType::TransferExecutor
+                | B20PolicyType::MintReceiver,
+            ) => Ok(()),
+            _ => Err(BasePrecompileError::revert(IB20::UnsupportedPolicyType {
                 policyScope: policy_scope,
-            }))
+            })),
         }
     }
 

--- a/crates/common/precompiles/src/b20_asset/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v2.rs
@@ -203,14 +203,26 @@ impl AssetV2 {
         Ok(())
     }
 
-    /// Ensures `policy_scope` names a built-in B-20 policy slot.
+    /// Ensures `policy_scope` names a built-in B-20 policy slot available on the V2 (Cobalt) common
+    /// surface, which adds the seize scopes (`SEIZE_HOLDER_POLICY` / `SEIZE_RECEIVER_POLICY`) on top
+    /// of V1.
+    ///
+    /// The match is exhaustive on purpose: a policy scope added to `B20PolicyType` for a future fork
+    /// must not silently widen this frozen V2 surface — it should fail to compile until V2's stance
+    /// on it is decided explicitly.
     fn ensure_supported_policy_type(policy_scope: B256) -> Result<()> {
-        if B20PolicyType::from_id(policy_scope).is_some() {
-            Ok(())
-        } else {
-            Err(BasePrecompileError::revert(IB20::UnsupportedPolicyType {
+        match B20PolicyType::from_id(policy_scope) {
+            Some(
+                B20PolicyType::TransferSender
+                | B20PolicyType::TransferReceiver
+                | B20PolicyType::TransferExecutor
+                | B20PolicyType::MintReceiver
+                | B20PolicyType::SeizeHolder
+                | B20PolicyType::SeizeReceiver,
+            ) => Ok(()),
+            None => Err(BasePrecompileError::revert(IB20::UnsupportedPolicyType {
                 policyScope: policy_scope,
-            }))
+            })),
         }
     }
 

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v1.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v1.rs
@@ -157,14 +157,24 @@ impl StablecoinV1 {
         Ok(())
     }
 
-    /// Ensures `policy_scope` names a built-in B-20 policy slot.
+    /// Ensures `policy_scope` names a built-in B-20 policy slot available on the frozen V1 (Beryl)
+    /// common surface.
+    ///
+    /// The seize scopes (`SEIZE_HOLDER_POLICY` / `SEIZE_RECEIVER_POLICY`) were introduced at Cobalt
+    /// (V2), so they are rejected here — matching the base-std `v1.0.0` reference. This is what keeps
+    /// the common `updatePolicy` / `policyId` selectors (dialable on V1) from reaching a V2-only
+    /// scope. The wildcard arm also freezes V1 against any scope added to `B20PolicyType` later.
     fn ensure_supported_policy_type(policy_scope: B256) -> Result<()> {
-        if B20PolicyType::from_id(policy_scope).is_some() {
-            Ok(())
-        } else {
-            Err(BasePrecompileError::revert(IB20::UnsupportedPolicyType {
+        match B20PolicyType::from_id(policy_scope) {
+            Some(
+                B20PolicyType::TransferSender
+                | B20PolicyType::TransferReceiver
+                | B20PolicyType::TransferExecutor
+                | B20PolicyType::MintReceiver,
+            ) => Ok(()),
+            _ => Err(BasePrecompileError::revert(IB20::UnsupportedPolicyType {
                 policyScope: policy_scope,
-            }))
+            })),
         }
     }
 }

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v1.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v1.rs
@@ -163,7 +163,12 @@ impl StablecoinV1 {
     /// The seize scopes (`SEIZE_HOLDER_POLICY` / `SEIZE_RECEIVER_POLICY`) were introduced at Cobalt
     /// (V2), so they are rejected here — matching the base-std `v1.0.0` reference. This is what keeps
     /// the common `updatePolicy` / `policyId` selectors (dialable on V1) from reaching a V2-only
-    /// scope. The wildcard arm also freezes V1 against any scope added to `B20PolicyType` later.
+    /// scope.
+    ///
+    /// The match is exhaustive by design (no `_` arm): every `B20PolicyType` variant is named, so a
+    /// scope added for a future fork fails to compile here until an engineer explicitly places it in
+    /// the supported or rejected arm, reconciling V1 against the base-std `v1.0.0` reference. A
+    /// wildcard would silently reject a newly added scope that should be valid at V1.
     fn ensure_supported_policy_type(policy_scope: B256) -> Result<()> {
         match B20PolicyType::from_id(policy_scope) {
             Some(
@@ -172,9 +177,12 @@ impl StablecoinV1 {
                 | B20PolicyType::TransferExecutor
                 | B20PolicyType::MintReceiver,
             ) => Ok(()),
-            _ => Err(BasePrecompileError::revert(IB20::UnsupportedPolicyType {
-                policyScope: policy_scope,
-            })),
+            // Cobalt (V2)-only scopes, and any unrecognized id, are not part of the frozen V1 surface.
+            Some(B20PolicyType::SeizeHolder | B20PolicyType::SeizeReceiver) | None => {
+                Err(BasePrecompileError::revert(IB20::UnsupportedPolicyType {
+                    policyScope: policy_scope,
+                }))
+            }
         }
     }
 }

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
@@ -188,13 +188,26 @@ impl StablecoinV2 {
     }
 
     /// Ensures `policy_scope` names a built-in B-20 policy slot.
+    /// Ensures `policy_scope` names a built-in B-20 policy slot available on the V2 (Cobalt) common
+    /// surface, which adds the seize scopes (`SEIZE_HOLDER_POLICY` / `SEIZE_RECEIVER_POLICY`) on top
+    /// of V1.
+    ///
+    /// The match is exhaustive on purpose: a policy scope added to `B20PolicyType` for a future fork
+    /// must not silently widen this frozen V2 surface — it should fail to compile until V2's stance
+    /// on it is decided explicitly.
     fn ensure_supported_policy_type(policy_scope: B256) -> Result<()> {
-        if B20PolicyType::from_id(policy_scope).is_some() {
-            Ok(())
-        } else {
-            Err(BasePrecompileError::revert(IB20::UnsupportedPolicyType {
+        match B20PolicyType::from_id(policy_scope) {
+            Some(
+                B20PolicyType::TransferSender
+                | B20PolicyType::TransferReceiver
+                | B20PolicyType::TransferExecutor
+                | B20PolicyType::MintReceiver
+                | B20PolicyType::SeizeHolder
+                | B20PolicyType::SeizeReceiver,
+            ) => Ok(()),
+            None => Err(BasePrecompileError::revert(IB20::UnsupportedPolicyType {
                 policyScope: policy_scope,
-            }))
+            })),
         }
     }
 }

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
@@ -187,7 +187,6 @@ impl StablecoinV2 {
         Ok(())
     }
 
-    /// Ensures `policy_scope` names a built-in B-20 policy slot.
     /// Ensures `policy_scope` names a built-in B-20 policy slot available on the V2 (Cobalt) common
     /// surface, which adds the seize scopes (`SEIZE_HOLDER_POLICY` / `SEIZE_RECEIVER_POLICY`) on top
     /// of V1.

--- a/crates/common/precompiles/tests/b20_asset_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v1_golden.rs
@@ -294,6 +294,50 @@ fn golden_seize_selectors_unknown_at_v1() {
     }
 }
 
+/// The seize policy scopes were introduced at Cobalt (`AssetV2`). Although the `SEIZE_HOLDER_POLICY()`
+/// / `SEIZE_RECEIVER_POLICY()` getter selectors are absent from V1, the scope *values* must also not
+/// leak through the common `updatePolicy` selector, which is dialable on V1: V1 rejects them with
+/// `UnsupportedPolicyType`, matching the base-std `v1.0.0` reference.
+#[test]
+fn golden_update_policy_rejects_seize_scopes_at_v1() {
+    for scope in [B20PolicyType::SeizeHolder.id(), B20PolicyType::SeizeReceiver.id()] {
+        let mut s = fresh();
+        let mut policy = FakePolicyAccounting::new();
+        policy.create_existing_policy(7);
+        let err = op_privileged(
+            &mut s,
+            ADMIN,
+            policy,
+            IB20::updatePolicyCall { policyScope: scope, newPolicyId: 7 }.abi_encode(),
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20::UnsupportedPolicyType { policyScope: scope })
+        );
+    }
+}
+
+/// Companion to [`golden_update_policy_rejects_seize_scopes_at_v1`] on the read path: the common
+/// `policyId` selector is dialable on V1 but must reject the V2-only seize scopes.
+#[test]
+fn golden_policy_id_rejects_seize_scopes_at_v1() {
+    for scope in [B20PolicyType::SeizeHolder.id(), B20PolicyType::SeizeReceiver.id()] {
+        let mut s = fresh();
+        let err = op(
+            &mut s,
+            ALICE,
+            FakePolicyAccounting::new(),
+            IB20::policyIdCall { policyScope: scope }.abi_encode(),
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20::UnsupportedPolicyType { policyScope: scope })
+        );
+    }
+}
+
 // ============================================================================
 // transfer
 // ============================================================================
@@ -842,6 +886,28 @@ fn golden_unpause_clears_feature_bit() {
     assert!(out.is_empty());
     assert_eq!(last_topic0(&s), IB20::Unpaused::SIGNATURE_HASH);
     assert_root("unpause", s, ROOT_UNPAUSE);
+}
+
+/// The `SEIZE` pause feature was introduced at Cobalt (`AssetV2`) as enum member 3. On the frozen V1
+/// (Beryl) common wire the `PausableFeature` enum has only three members, so `pause`/`unpause`/
+/// `isPaused` carrying `SEIZE` fail to decode (`AbiDecodeFailed`) before any shared validation runs.
+/// Unlike the `bytes32` policy scope, the enum argument is range-checked by the wire decode itself.
+#[test]
+fn golden_seize_pause_feature_unknown_at_v1() {
+    let calls: Vec<Vec<u8>> = vec![
+        IB20::pauseCall { features: vec![IB20::PausableFeature::SEIZE] }.abi_encode(),
+        IB20::unpauseCall { features: vec![IB20::PausableFeature::SEIZE] }.abi_encode(),
+        IB20::isPausedCall { feature: IB20::PausableFeature::SEIZE }.abi_encode(),
+    ];
+    for calldata in calls {
+        let mut s = fresh();
+        let selector: [u8; 4] = calldata[..4].try_into().unwrap();
+        let err = op_privileged(&mut s, ADMIN, FakePolicyAccounting::new(), calldata).unwrap_err();
+        assert!(
+            matches!(err, BasePrecompileError::AbiDecodeFailed { selector: s, .. } if s == selector),
+            "expected AbiDecodeFailed for selector {selector:?}, got {err:?}"
+        );
+    }
 }
 
 #[test]
@@ -2693,11 +2759,13 @@ fn v1_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Asset::IB20AssetCall
             golden_pause_sets_feature_bit,
             golden_pause_reverts_empty_feature_set,
             golden_pause_unprivileged_requires_role,
+            golden_seize_pause_feature_unknown_at_v1,
         ]),
         C::unpause(_) => covered(&[
             golden_unpause_clears_feature_bit,
             golden_unpause_reverts_empty_feature_set,
             golden_unpause_unprivileged_requires_role,
+            golden_seize_pause_feature_unknown_at_v1,
         ]),
         C::updateSupplyCap(_) => covered(&[
             golden_update_supply_cap,
@@ -2744,6 +2812,7 @@ fn v1_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Asset::IB20AssetCall
             golden_update_policy,
             golden_update_policy_reverts_missing_policy,
             golden_update_policy_unprivileged_requires_role,
+            golden_update_policy_rejects_seize_scopes_at_v1,
         ]),
         C::permit(_) => covered(&[
             golden_permit_sets_allowance_and_increments_nonce,
@@ -2752,9 +2821,15 @@ fn v1_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Asset::IB20AssetCall
 
         // computed reads
         C::isPaused(_) | C::pausedFeatures(_) => {
-            covered(&[golden_read_is_paused_and_paused_features])
+            covered(&[
+                golden_read_is_paused_and_paused_features,
+                golden_seize_pause_feature_unknown_at_v1,
+            ])
         }
-        C::policyId(_) => covered(&[golden_read_policy_id_and_unsupported_scope]),
+        C::policyId(_) => covered(&[
+            golden_read_policy_id_and_unsupported_scope,
+            golden_policy_id_rejects_seize_scopes_at_v1,
+        ]),
         C::DOMAIN_SEPARATOR(_) => covered(&[golden_read_domain_separator]),
         C::eip712Domain(_) => covered(&[golden_read_eip712_domain]),
 

--- a/crates/common/precompiles/tests/b20_asset_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v1_golden.rs
@@ -2820,12 +2820,10 @@ fn v1_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Asset::IB20AssetCall
         ]),
 
         // computed reads
-        C::isPaused(_) | C::pausedFeatures(_) => {
-            covered(&[
-                golden_read_is_paused_and_paused_features,
-                golden_seize_pause_feature_unknown_at_v1,
-            ])
-        }
+        C::isPaused(_) | C::pausedFeatures(_) => covered(&[
+            golden_read_is_paused_and_paused_features,
+            golden_seize_pause_feature_unknown_at_v1,
+        ]),
         C::policyId(_) => covered(&[
             golden_read_policy_id_and_unsupported_scope,
             golden_policy_id_rejects_seize_scopes_at_v1,

--- a/crates/common/precompiles/tests/b20_stablecoin_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_stablecoin_v1_golden.rs
@@ -752,6 +752,50 @@ fn golden_seize_selectors_unknown_at_v1() {
     }
 }
 
+/// The seize policy scopes were introduced at Cobalt (`StablecoinV2`). Although the
+/// `SEIZE_HOLDER_POLICY()` / `SEIZE_RECEIVER_POLICY()` getter selectors are absent from V1, the scope
+/// *values* must also not leak through the common `updatePolicy` selector, which is dialable on V1:
+/// V1 rejects them with `UnsupportedPolicyType`, matching the base-std `v1.0.0` reference.
+#[test]
+fn golden_update_policy_rejects_seize_scopes_at_v1() {
+    for scope in [B20PolicyType::SeizeHolder.id(), B20PolicyType::SeizeReceiver.id()] {
+        let mut s = fresh();
+        let mut policy = FakePolicyAccounting::new();
+        policy.create_existing_policy(7);
+        let err = op_privileged(
+            &mut s,
+            ADMIN,
+            policy,
+            IB20::updatePolicyCall { policyScope: scope, newPolicyId: 7 }.abi_encode(),
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20::UnsupportedPolicyType { policyScope: scope })
+        );
+    }
+}
+
+/// Companion to [`golden_update_policy_rejects_seize_scopes_at_v1`] on the read path: the common
+/// `policyId` selector is dialable on V1 but must reject the V2-only seize scopes.
+#[test]
+fn golden_policy_id_rejects_seize_scopes_at_v1() {
+    for scope in [B20PolicyType::SeizeHolder.id(), B20PolicyType::SeizeReceiver.id()] {
+        let mut s = fresh();
+        let err = op(
+            &mut s,
+            ALICE,
+            FakePolicyAccounting::new(),
+            IB20::policyIdCall { policyScope: scope }.abi_encode(),
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20::UnsupportedPolicyType { policyScope: scope })
+        );
+    }
+}
+
 // ============================================================================
 // pause / unpause
 // ============================================================================
@@ -793,6 +837,29 @@ fn golden_unpause_clears_feature_bit() {
     assert!(out.is_empty());
     assert_eq!(last_topic0(&s), IB20::Unpaused::SIGNATURE_HASH);
     assert_root("unpause", s, ROOT_UNPAUSE);
+}
+
+/// The `SEIZE` pause feature was introduced at Cobalt (`StablecoinV2`) as enum member 3. On the
+/// frozen V1 (Beryl) common wire the `PausableFeature` enum has only three members, so `pause`/
+/// `unpause`/`isPaused` carrying `SEIZE` fail to decode (`AbiDecodeFailed`) before any shared
+/// validation runs. Unlike the `bytes32` policy scope, the enum argument is range-checked by the
+/// wire decode itself.
+#[test]
+fn golden_seize_pause_feature_unknown_at_v1() {
+    let calls: Vec<Vec<u8>> = vec![
+        IB20::pauseCall { features: vec![IB20::PausableFeature::SEIZE] }.abi_encode(),
+        IB20::unpauseCall { features: vec![IB20::PausableFeature::SEIZE] }.abi_encode(),
+        IB20::isPausedCall { feature: IB20::PausableFeature::SEIZE }.abi_encode(),
+    ];
+    for calldata in calls {
+        let mut s = fresh();
+        let selector: [u8; 4] = calldata[..4].try_into().unwrap();
+        let err = op_privileged(&mut s, ADMIN, FakePolicyAccounting::new(), calldata).unwrap_err();
+        assert!(
+            matches!(err, BasePrecompileError::AbiDecodeFailed { selector: s, .. } if s == selector),
+            "expected AbiDecodeFailed for selector {selector:?}, got {err:?}"
+        );
+    }
 }
 
 #[test]
@@ -2104,11 +2171,13 @@ fn v1_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Stablecoin::IB20Stab
             golden_pause_sets_feature_bit,
             golden_pause_reverts_empty_feature_set,
             golden_pause_unprivileged_requires_role,
+            golden_seize_pause_feature_unknown_at_v1,
         ]),
         C::unpause(_) => covered(&[
             golden_unpause_clears_feature_bit,
             golden_unpause_reverts_empty_feature_set,
             golden_unpause_unprivileged_requires_role,
+            golden_seize_pause_feature_unknown_at_v1,
         ]),
         C::updateSupplyCap(_) => covered(&[
             golden_update_supply_cap,
@@ -2155,6 +2224,7 @@ fn v1_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Stablecoin::IB20Stab
             golden_update_policy,
             golden_update_policy_reverts_missing_policy,
             golden_update_policy_unprivileged_requires_role,
+            golden_update_policy_rejects_seize_scopes_at_v1,
         ]),
         C::permit(_) => covered(&[
             golden_permit_sets_allowance_and_increments_nonce,
@@ -2163,9 +2233,15 @@ fn v1_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Stablecoin::IB20Stab
 
         // computed reads
         C::isPaused(_) | C::pausedFeatures(_) => {
-            covered(&[golden_read_is_paused_and_paused_features])
+            covered(&[
+                golden_read_is_paused_and_paused_features,
+                golden_seize_pause_feature_unknown_at_v1,
+            ])
         }
-        C::policyId(_) => covered(&[golden_read_policy_id_and_unsupported_scope]),
+        C::policyId(_) => covered(&[
+            golden_read_policy_id_and_unsupported_scope,
+            golden_policy_id_rejects_seize_scopes_at_v1,
+        ]),
         C::DOMAIN_SEPARATOR(_) => covered(&[golden_read_domain_separator]),
         C::eip712Domain(_) => covered(&[golden_read_eip712_domain]),
 

--- a/crates/common/precompiles/tests/b20_stablecoin_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_stablecoin_v1_golden.rs
@@ -2232,12 +2232,10 @@ fn v1_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Stablecoin::IB20Stab
         ]),
 
         // computed reads
-        C::isPaused(_) | C::pausedFeatures(_) => {
-            covered(&[
-                golden_read_is_paused_and_paused_features,
-                golden_seize_pause_feature_unknown_at_v1,
-            ])
-        }
+        C::isPaused(_) | C::pausedFeatures(_) => covered(&[
+            golden_read_is_paused_and_paused_features,
+            golden_seize_pause_feature_unknown_at_v1,
+        ]),
         C::policyId(_) => covered(&[
             golden_read_policy_id_and_unsupported_scope,
             golden_policy_id_rejects_seize_scopes_at_v1,


### PR DESCRIPTION
## Summary

Audit ([BOP-498](https://linear.app/coinbase/issue/BOP-498)) found that **B20 V1 (Beryl) incorrectly accepts the seize policy scopes**.

The seize scopes (`SEIZE_HOLDER_POLICY` / `SEIZE_RECEIVER_POLICY`) were introduced at Cobalt (V2). But the `updatePolicy(bytes32,uint64)` and `policyId(bytes32)` selectors are **common** (dialable on V1), and their scope validation routed through the shared, un-versioned `B20PolicyType::from_id`, which recognizes all six scopes. Because a `bytes32` argument is not range-checked by ABI decode, V1 accepted the V2-only seize scopes and wrote/read the seize storage slot, instead of reverting `UnsupportedPolicyType`. At the frozen base-base tags (v1.1.0/v1.2.0), `B20PolicyType` has only the four pre-Cobalt scopes, confirming the correct V1 behavior is to reject.

No live seize on V1 (the `seizeWithMemo` entrypoint stays V2-only), so a stored value is dormant. But it is a frozen-surface divergence, and the fork harness missed it because it never exercises `updatePolicy`/`policyId` with the seize scope args.

Contrast: the enum-typed sibling (`SEIZE` pause feature) is already safe — `pause`/`isPaused` take a `PausableFeature` enum, so the V1 wire decode (`IB20V1`, three variants) rejects `SEIZE`=3 before any shared code runs.

## Change

Move the supported-scope decision into each version's `ensure_supported_policy_type` (asset + stablecoin):
- **V1**: accept only `TransferSender`/`TransferReceiver`/`TransferExecutor`/`MintReceiver`; wildcard-reject everything else (so any scope added to `B20PolicyType` later stays frozen out of V1 automatically).
- **V2**: exhaustive match over all six scopes — a future scope will fail to compile until V2's stance is decided explicitly, closing this class of silent widening going forward.

## Tests

- `golden_update_policy_rejects_seize_scopes_at_v1` / `golden_policy_id_rejects_seize_scopes_at_v1` (asset + stablecoin) — the fixed leak.
- `golden_seize_pause_feature_unknown_at_v1` (asset + stablecoin) — defense-in-depth regression pinning that `pause`/`unpause`/`isPaused` reject `SEIZE` on V1 via wire decode.
- Registered in the exhaustive `covered(&[...])` matrices. Full `base-common-precompiles` suite green; clippy + nightly fmt clean.

## Notes

- Verified against the frozen base-base tags (v1.1.0/v1.2.0): `B20PolicyType` there has only the four pre-Cobalt scopes, so rejecting is the frozen-correct V1 behavior.
- A stacked PR ([BOP-500](https://linear.app/coinbase/issue/BOP-500)) builds on this branch: it adds failed-path SLOAD testing and fixes an asset `updatePolicy` revert-path SLOAD divergence surfaced during the same audit.