### PR TITLE
feat(builder): Activate Parallel Transaction Prewarming

### DIFF
--- a/crates/builder/core/src/flashblocks/generator.rs
+++ b/crates/builder/core/src/flashblocks/generator.rs
@@ -274,6 +274,8 @@ pub struct BuildArguments<Attributes, Payload: BuiltPayload> {
     pub cached_reads: CachedReads,
     /// Optional execution cache shared with the engine.
     pub execution_cache: Option<SavedCache>,
+    /// Executor used for payload-scoped background work.
+    pub executor: Runtime,
     /// How to configure the payload.
     pub config: PayloadConfig<Attributes, HeaderTy<Payload::Primitives>>,
     /// A marker that can be used to cancel the job.
@@ -301,10 +303,12 @@ where
         self.payload_rx = Some(watch_rx);
         let cached_reads = self.cached_reads.take().unwrap_or_default();
         let execution_cache = self.execution_cache.take();
+        let executor = self.executor.clone();
         self.executor.spawn_blocking_task(Box::pin(async move {
             let args = BuildArguments {
                 cached_reads,
                 execution_cache,
+                executor,
                 config: payload_config,
                 cancel,
                 publish_guard,

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -57,8 +57,8 @@ use crate::{
     BuilderConfig, BuilderMetrics, CandidateSource, DefaultCandidateSource, ExecutionInfo,
     PayloadBuilder, ResourceLimits,
     flashblocks::{
-        FlashblocksExtraCtx, best_txs::BestFlashblocksTxs, context::BasePayloadBuilderCtx,
-        generator::BuildArguments,
+        FlashblocksExtraCtx, PrewarmingExecutionContext, TransactionPrewarmer,
+        best_txs::BestFlashblocksTxs, context::BasePayloadBuilderCtx, generator::BuildArguments,
     },
     traits::{ClientBounds, PoolBounds},
     transaction_events::{
@@ -203,7 +203,7 @@ where
 impl<Pool, Client, S> BasePayloadBuilder<Pool, Client, S>
 where
     Pool: PoolBounds,
-    Client: ClientBounds,
+    Client: ClientBounds + 'static,
     S: CandidateSource<Pool::Transaction>,
 {
     fn get_base_payload_builder_ctx(
@@ -275,6 +275,7 @@ where
         let BuildArguments {
             mut cached_reads,
             execution_cache,
+            executor,
             config,
             cancel: block_cancel,
             publish_guard,
@@ -303,7 +304,7 @@ where
             .map_err(|e| PayloadBuilderError::Other(e.into()))?;
 
         let mut state_provider = self.client.state_by_block_hash(ctx.parent().hash())?;
-        if let Some(execution_cache) = execution_cache {
+        if let Some(execution_cache) = execution_cache.as_ref() {
             state_provider = Box::new(CachedStateProvider::new(
                 state_provider,
                 execution_cache.cache().clone(),
@@ -327,6 +328,27 @@ where
             self.calculate_flashblocks(timestamp);
 
         let skip_flashblocks_building = ctx.attributes().no_tx_pool || flashblocks_per_block == 0;
+        let mut prewarmer =
+            execution_cache.filter(|_| !skip_flashblocks_building).map(|execution_cache| {
+                let prewarming_context = PrewarmingExecutionContext::new(
+                    self.client.clone(),
+                    ctx.parent().hash(),
+                    ctx.evm_config.clone(),
+                    ctx.evm_env.clone(),
+                    execution_cache.cache().clone(),
+                );
+                let transactions =
+                    self.pool.best_transactions_with_attributes(ctx.best_transaction_attributes());
+                TransactionPrewarmer::start(&executor, transactions, move |transaction| {
+                    prewarming_context
+                        .prewarm_transactions(std::iter::once(&transaction.transaction))
+                })
+            });
+        let mut release_prewarmer = || {
+            if let Some(prewarmer) = prewarmer.take() {
+                prewarmer.stop_and_wait();
+            }
+        };
 
         let prev_flashblock_id = self.previous_flashblock_id();
         let (payload, fb_payload, state_diff) = build_block(
@@ -511,6 +533,7 @@ where
                     &span,
                     "Payload building complete, target flashblock count reached",
                 );
+                release_prewarmer();
                 return self.finalize_payload(&mut state, &ctx, &mut info);
             }
 
@@ -537,6 +560,7 @@ where
                         &span,
                         "Payload building complete, job cancelled or target flashblock count reached",
                     );
+                    release_prewarmer();
                     return self.finalize_payload(&mut state, &ctx, &mut info);
                 }
                 Err(err) => {
@@ -547,6 +571,7 @@ where
                         ctx.block_number(),
                         err
                     );
+                    release_prewarmer();
                     return Err(PayloadBuilderError::Other(err.into()));
                 }
             };
@@ -563,6 +588,7 @@ where
                         &span,
                         "Payload building complete, channel closed or job cancelled",
                     );
+                    release_prewarmer();
                     return self.finalize_payload(&mut state, &ctx, &mut info);
                 }
             }
@@ -1086,7 +1112,7 @@ where
 impl<Pool, Client, S> PayloadBuilder for BasePayloadBuilder<Pool, Client, S>
 where
     Pool: PoolBounds,
-    Client: ClientBounds,
+    Client: ClientBounds + 'static,
     S: CandidateSource<Pool::Transaction> + Clone + Unpin + 'static,
 {
     type Attributes = BasePayloadBuilderAttributes<BaseTransactionSigned>;

--- a/crates/builder/core/tests/flashblocks.rs
+++ b/crates/builder/core/tests/flashblocks.rs
@@ -6,7 +6,7 @@ use alloy_primitives::{Address, B256, U256};
 use base_builder_core::{
     BuilderConfig,
     test_utils::{
-        TransactionBuilderExt, default_node_config_with_azul, funded_signer,
+        TransactionBuilderExt, default_node_config, default_node_config_with_azul, funded_signer,
         setup_test_instance_with_builder_config, setup_test_instance_with_node_config,
     },
 };
@@ -193,6 +193,25 @@ async fn test_state_root_computed_on_finalize() -> eyre::Result<()> {
     }
 
     flashblocks_listener.stop().await
+}
+
+#[tokio::test]
+async fn transaction_prewarming_builds_payload_with_shared_cache() -> eyre::Result<()> {
+    let config = BuilderConfig::for_tests().with_block_time_ms(2000);
+    let mut node_config = default_node_config();
+    node_config.engine.share_execution_cache_with_payload_builder = true;
+    let rbuilder = setup_test_instance_with_node_config(config, node_config).await?;
+    let driver = rbuilder.driver().await?;
+
+    for _ in 0..3 {
+        let _ = driver.create_transaction().random_valid_transfer().send().await?;
+    }
+
+    let block = driver.build_new_block_with_current_timestamp(None).await?;
+
+    assert_eq!(block.transactions.len(), 4, "block should contain deposit and pool transactions");
+    assert_ne!(block.header.state_root, B256::ZERO, "final payload must have a valid state root");
+    Ok(())
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

This activates transaction prewarming for normal flashblocks payload jobs when Reth supplies a shared execution cache. Each job drains an independent best-transactions iterator onto Reth’s prewarming pool while canonical flashblock construction continues, then stops outstanding work before payload publication so every shared-cache handle is released safely. Prewarming remains disabled for sync-only and late jobs, and an end-to-end test verifies that a shared-cache build still includes pool transactions and produces a valid state root. This PR is stacked on #4282.