### PR TITLE
fix(BOP-500): add failed-path SLOAD testing + restore asset updatePolicy ordering

### DIFF
--- a/crates/common/precompiles/src/b20_asset/logic/v1.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v1.rs
@@ -586,11 +586,6 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV1 {
         if !privileged {
             B20Guards::ensure_token_role(token, caller, B20TokenRole::DefaultAdmin)?;
         }
-        // Frozen Beryl ordering (see `token.rs` at v1.1.0/v1.2.0): validate the scope (pure), then
-        // the existence check, and only read the old id on the success path. Reading the old id
-        // before `policy_exists` would add an SLOAD on the `PolicyNotFound` revert path, changing
-        // gas — a consensus divergence from the frozen asset surface. (Stablecoin reads before the
-        // check; that difference is itself frozen, so the two variants intentionally differ here.)
         Self::ensure_supported_policy_type(policy_scope)?;
         if !token.policy().policy_exists(token.policy_storage(), new_policy_id)? {
             return Err(BasePrecompileError::revert(IB20::PolicyNotFound {

--- a/crates/common/precompiles/src/b20_asset/logic/v1.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v1.rs
@@ -586,12 +586,18 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV1 {
         if !privileged {
             B20Guards::ensure_token_role(token, caller, B20TokenRole::DefaultAdmin)?;
         }
-        let old_policy_id = self.policy_id(token, policy_scope)?;
+        // Frozen Beryl ordering (see `token.rs` at v1.1.0/v1.2.0): validate the scope (pure), then
+        // the existence check, and only read the old id on the success path. Reading the old id
+        // before `policy_exists` would add an SLOAD on the `PolicyNotFound` revert path, changing
+        // gas — a consensus divergence from the frozen asset surface. (Stablecoin reads before the
+        // check; that difference is itself frozen, so the two variants intentionally differ here.)
+        Self::ensure_supported_policy_type(policy_scope)?;
         if !token.policy().policy_exists(token.policy_storage(), new_policy_id)? {
             return Err(BasePrecompileError::revert(IB20::PolicyNotFound {
                 policyId: new_policy_id,
             }));
         }
+        let old_policy_id = token.accounting().policy_id(policy_scope)?;
         token.accounting_mut().set_policy_id(policy_scope, new_policy_id)?;
         token.accounting_mut().emit_event(
             IB20::PolicyUpdated {

--- a/crates/common/precompiles/src/b20_asset/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v2.rs
@@ -662,12 +662,17 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
         if !privileged {
             B20Guards::ensure_token_role(token, caller, B20TokenRole::DefaultAdmin)?;
         }
-        let old_policy_id = self.policy_id(token, policy_scope)?;
+        // Preserve asset's frozen Beryl `update_policy` ordering into Cobalt: validate the scope
+        // (pure) and run the existence check before reading the old id, so the `PolicyNotFound`
+        // revert path does no old-id SLOAD (matches AssetV1 / `token.rs`). Keeps asset's gas
+        // profile unchanged across the Beryl->Cobalt boundary.
+        Self::ensure_supported_policy_type(policy_scope)?;
         if !token.policy().policy_exists(token.policy_storage(), new_policy_id)? {
             return Err(BasePrecompileError::revert(IB20::PolicyNotFound {
                 policyId: new_policy_id,
             }));
         }
+        let old_policy_id = token.accounting().policy_id(policy_scope)?;
         token.accounting_mut().set_policy_id(policy_scope, new_policy_id)?;
         token.accounting_mut().emit_event(
             IB20::PolicyUpdated {

--- a/crates/common/precompiles/src/b20_asset/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v2.rs
@@ -662,10 +662,6 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
         if !privileged {
             B20Guards::ensure_token_role(token, caller, B20TokenRole::DefaultAdmin)?;
         }
-        // Preserve asset's frozen Beryl `update_policy` ordering into Cobalt: validate the scope
-        // (pure) and run the existence check before reading the old id, so the `PolicyNotFound`
-        // revert path does no old-id SLOAD (matches AssetV1 / `token.rs`). Keeps asset's gas
-        // profile unchanged across the Beryl->Cobalt boundary.
         Self::ensure_supported_policy_type(policy_scope)?;
         if !token.policy().policy_exists(token.policy_storage(), new_policy_id)? {
             return Err(BasePrecompileError::revert(IB20::PolicyNotFound {

--- a/crates/common/precompiles/tests/b20_asset_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v1_golden.rs
@@ -1214,6 +1214,32 @@ fn golden_update_policy_reverts_missing_policy() {
     assert_eq!(err, BasePrecompileError::revert(IB20::PolicyNotFound { policyId: 99 }));
 }
 
+/// Consensus gas pin: on the `PolicyNotFound` revert path, asset `updatePolicy` must NOT read the
+/// old policy id, so the path performs zero SLOADs. This is the frozen asset ordering (`token.rs` at
+/// v1.1.0/v1.2.0: `ensure_supported` -> `policy_exists` -> read old only on success). Reading the
+/// old id before the existence check adds an SLOAD and changes gas — a consensus divergence that
+/// `golden_gas_footprints` (success path only) does not catch. Stablecoin intentionally reads before
+/// the check; its suite pins the opposite count.
+#[test]
+fn golden_update_policy_notfound_does_not_read_old_id() {
+    let mut s = fresh();
+    let before = s.counter_sload();
+    let err = op_privileged(
+        &mut s,
+        ADMIN,
+        FakePolicyAccounting::new(),
+        IB20::updatePolicyCall { policyScope: B20PolicyType::TransferSender.id(), newPolicyId: 99 }
+            .abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(err, BasePrecompileError::revert(IB20::PolicyNotFound { policyId: 99 }));
+    assert_eq!(
+        s.counter_sload() - before,
+        0,
+        "PolicyNotFound path must not read the old policy id (frozen asset ordering)"
+    );
+}
+
 // ============================================================================
 // permit
 // ============================================================================
@@ -2813,6 +2839,7 @@ fn v1_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Asset::IB20AssetCall
             golden_update_policy_reverts_missing_policy,
             golden_update_policy_unprivileged_requires_role,
             golden_update_policy_rejects_seize_scopes_at_v1,
+            golden_update_policy_notfound_does_not_read_old_id,
         ]),
         C::permit(_) => covered(&[
             golden_permit_sets_allowance_and_increments_nonce,

--- a/crates/common/precompiles/tests/b20_asset_v2_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v2_golden.rs
@@ -1790,6 +1790,29 @@ fn golden_update_policy_reverts_missing_policy() {
     assert_eq!(err, BasePrecompileError::revert(IB20::PolicyNotFound { policyId: 99 }));
 }
 
+/// Consensus gas pin (mirrors AssetV1): the `PolicyNotFound` revert path reads no old policy id, so
+/// it performs zero SLOADs. `AssetV2` preserves asset's frozen Beryl `update_policy` ordering into
+/// Cobalt, so asset's gas profile does not change across the fork boundary.
+#[test]
+fn golden_update_policy_notfound_does_not_read_old_id() {
+    let mut s = fresh();
+    let before = s.counter_sload();
+    let err = op_privileged(
+        &mut s,
+        ADMIN,
+        FakePolicyAccounting::new(),
+        IB20::updatePolicyCall { policyScope: B20PolicyType::TransferSender.id(), newPolicyId: 99 }
+            .abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(err, BasePrecompileError::revert(IB20::PolicyNotFound { policyId: 99 }));
+    assert_eq!(
+        s.counter_sload() - before,
+        0,
+        "PolicyNotFound path must not read the old policy id (frozen asset ordering)"
+    );
+}
+
 #[test]
 fn golden_update_policy_unprivileged_requires_role() {
     assert_unprivileged_requires_role(
@@ -3481,6 +3504,7 @@ fn v2_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Asset::IB20AssetCall
             golden_update_policy,
             golden_update_policy_reverts_missing_policy,
             golden_update_policy_unprivileged_requires_role,
+            golden_update_policy_notfound_does_not_read_old_id,
         ]),
         C::permit(_) => covered(&[
             golden_permit_sets_allowance_and_increments_nonce,

--- a/crates/common/precompiles/tests/b20_stablecoin_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_stablecoin_v1_golden.rs
@@ -1166,6 +1166,30 @@ fn golden_update_policy_reverts_missing_policy() {
     assert_eq!(err, BasePrecompileError::revert(IB20::PolicyNotFound { policyId: 99 }));
 }
 
+/// Consensus gas pin: stablecoin `updatePolicy` reads the old policy id BEFORE the existence check,
+/// so the `PolicyNotFound` revert path performs exactly one SLOAD. This is the frozen stablecoin
+/// ordering (`token.rs` at v1.1.0/v1.2.0), and it intentionally differs from asset (which reads
+/// after the check, zero SLOADs). Pinned so the two variants are not accidentally unified.
+#[test]
+fn golden_update_policy_notfound_reads_old_id() {
+    let mut s = fresh();
+    let before = s.counter_sload();
+    let err = op_privileged(
+        &mut s,
+        ADMIN,
+        FakePolicyAccounting::new(),
+        IB20::updatePolicyCall { policyScope: B20PolicyType::TransferSender.id(), newPolicyId: 99 }
+            .abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(err, BasePrecompileError::revert(IB20::PolicyNotFound { policyId: 99 }));
+    assert_eq!(
+        s.counter_sload() - before,
+        1,
+        "frozen stablecoin ordering reads the old policy id before the existence check"
+    );
+}
+
 // ============================================================================
 // permit
 // ============================================================================
@@ -2225,6 +2249,7 @@ fn v1_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Stablecoin::IB20Stab
             golden_update_policy_reverts_missing_policy,
             golden_update_policy_unprivileged_requires_role,
             golden_update_policy_rejects_seize_scopes_at_v1,
+            golden_update_policy_notfound_reads_old_id,
         ]),
         C::permit(_) => covered(&[
             golden_permit_sets_allowance_and_increments_nonce,


### PR DESCRIPTION
Stacked on #4289 (BOP-498). Review/merge that first; this PR's base is the BOP-498 branch, so the diff here is only the BOP-500 delta.

## Motivation ([BOP-500](https://linear.app/coinbase/issue/BOP-500))

Golden gas-footprint coverage (`golden_gas_footprints`) only exercises **success** paths. So a divergence in the **revert-path** storage-access footprint (SLOAD count = gas = consensus) is invisible to the existing suite and to the fork harness (which compares logs/reverts, not gas). This PR adds failed-path SLOAD testing and fixes the divergence it surfaces.

## The divergence

The unreleased `logic/` refactor changed **asset** `updatePolicy` to read the old policy id **before** the `policy_exists` check. The frozen asset surface (base-base `token.rs` at v1.1.0/v1.2.0) reads it **after**, only on the success path — so the `PolicyNotFound` revert path does **zero** old-id SLOADs. Reading before the check adds an SLOAD on that reachable revert path = gas/consensus divergence from frozen Beryl.

Per-variant (verified against the frozen tags):

| Variant | Frozen v1.1.0/v1.2.0 | main before | main after |
| --- | --- | --- | --- |
| Asset | read-after (0 SLOAD on PolicyNotFound) | read-before (1) | read-after (0) |
| Stablecoin | read-before (1 SLOAD) | read-before (1) | read-before (1) |

## Change

- Restore asset V1 `update_policy` to read-after (frozen Beryl ordering); mirror in asset V2 so asset's gas profile is unchanged across Beryl→Cobalt.
- **Stablecoin is intentionally left unchanged** — it reads before the check on both the frozen surface and main; the two variants legitimately differ, and that difference is itself frozen.

## Tests (the BOP-500 deliverable)

Failed-path SLOAD pins on the `PolicyNotFound` revert path:
- asset V1/V2 assert **0** old-id SLOADs;
- stablecoin V1 asserts **1**, locking each variant's frozen ordering so they can't be accidentally unified.

Full `base-common-precompiles` suite green; clippy + nightly fmt clean.

## Reviewer notes

- The refactor that introduced this is unreleased, so no live chain is affected — but it must land before Cobalt.
- base-std reads-before for asset (disagrees with frozen base-base asset, which reads-after); harmless for cross-validation (fork harness ignores gas), but worth reconciling.
- Follow-up worth considering: extend failed-path SLOAD/SSTORE footprint checks to every op (not just `updatePolicy`), since the refactor could have introduced other revert-path gas divergences.