### PR TITLE
fix(BOP-501): seizeWithMemo returns void (mirror base-std)

### DIFF
--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -37,7 +37,9 @@ jobs:
           - fork: Cobalt
             key: cobalt
             base_anvil_ref: ae7557c4f8602caa1da0be33143bb2504c85b0c8
-            base_std_ref: 8f88bf3e59dcf7a7396e3e80f6eb02166a46573a
+            # TEMP: base-std branch commit with the void seizeWithMemo + deprecated burnBlocked
+            # interface changes (base-std PR #193). Move to the squash-merge SHA once #193 lands.
+            base_std_ref: 0d2be1ecdac0b720107779660d809efd5a06704e
     env:
       FORK_NAME: ${{ matrix.fork }}
       FORK_KEY: ${{ matrix.key }}

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -37,9 +37,8 @@ jobs:
           - fork: Cobalt
             key: cobalt
             base_anvil_ref: ae7557c4f8602caa1da0be33143bb2504c85b0c8
-            # TEMP: base-std branch commit with the void seizeWithMemo + deprecated burnBlocked
-            # interface changes (base-std PR #193). Move to the squash-merge SHA once #193 lands.
-            base_std_ref: 0d2be1ecdac0b720107779660d809efd5a06704e
+            # base-std #193 squash-merge (void seizeWithMemo + deprecated burnBlocked in IB20).
+            base_std_ref: 5a5605a36bc03449bd0d7540353ce842503042a7
     env:
       FORK_NAME: ${{ matrix.fork }}
       FORK_KEY: ${{ matrix.key }}

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -37,7 +37,6 @@ jobs:
           - fork: Cobalt
             key: cobalt
             base_anvil_ref: ae7557c4f8602caa1da0be33143bb2504c85b0c8
-            # base-std #193 squash-merge (void seizeWithMemo + deprecated burnBlocked in IB20).
             base_std_ref: 5a5605a36bc03449bd0d7540353ce842503042a7
     env:
       FORK_NAME: ${{ matrix.fork }}

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -243,7 +243,7 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
             // --- Seize ---
             C::seizeWithMemo(c) => {
                 logic.seize_with_memo(self, caller, c.from, c.to, c.amount, c.memo)?;
-                true.abi_encode().into()
+                Bytes::new()
             }
 
             // --- Pause ---

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -250,7 +250,7 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> B20StablecoinToken<S, A> {
                 C::seizeWithMemo(c) => {
                     let caller = ctx.caller();
                     logic.seize_with_memo(self, caller, c.from, c.to, c.amount, c.memo)?;
-                    true.abi_encode().into()
+                    Bytes::new()
                 }
 
                 C::pause(c) => {

--- a/crates/common/precompiles/src/common/abi/v2.rs
+++ b/crates/common/precompiles/src/common/abi/v2.rs
@@ -119,7 +119,7 @@ sol! {
         function burnBlocked(address from, uint256 amount) external;
 
         // Seize
-        function seizeWithMemo(address from, address to, uint256 amount, bytes32 memo) external returns (bool);
+        function seizeWithMemo(address from, address to, uint256 amount, bytes32 memo) external;
 
         // Roles
         function hasRole(bytes32 role, address account) external view returns (bool);

--- a/crates/common/precompiles/tests/b20_asset_v2_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v2_golden.rs
@@ -1001,7 +1001,7 @@ fn golden_seize_moves_balance_emits_transfer_memo_seized() {
     )
     .unwrap();
 
-    assert_eq!(out, ok_true());
+    assert!(out.is_empty(), "seizeWithMemo is a void admin op (no bool return)");
     read(&mut s, |t| {
         assert_eq!(t.balance_of(ALICE).unwrap(), u(60));
         assert_eq!(t.balance_of(BOB).unwrap(), u(40));


### PR DESCRIPTION
Mirrors base-std PR https://github.com/base/base-std/pull/193 (source of truth). Part of [BOP-501](https://linear.app/coinbase/issue/BOP-501).

## Change

`seizeWithMemo` becomes a void admin operation, consistent with `burnBlocked`. The always-`true` bool return carried no signal.

- `common/abi/v2.rs`: drop `returns (bool)` from `seizeWithMemo`.
- `b20_asset` + `b20_stablecoin` dispatch: `C::seizeWithMemo` returns `Bytes::new()` instead of `true.abi_encode()`.
- `b20_asset_v2_golden`: assert the seize output is empty instead of `ok_true()`.

The return type is not part of the function selector, so the **V2 ABI fingerprint is unchanged** (the pinned fingerprint test still passes); only the returned bytes change (`true` → empty), which is safe on the not-yet-frozen V2 (Cobalt) surface. State root / event assertions for seize are unaffected.

`burnBlocked` needs no change here — it was never removed from the base/base abi (present on v1/v2) and already returns void. (The base-std side re-adds it to the `IB20` interface with a deprecated natspec; that's an interface-only change.)

## Fork tests

Bumped the Cobalt `base_std_ref` in `.github/workflows/base-std-fork-tests.yml` to the base-std branch commit that carries the matching void-seize interface (otherwise the pinned reference's `IB20` still declares `returns (bool)` and the Solidity return-decode would fail against the empty return).

**Follow-up:** move that ref from the branch SHA to base-std #193's squash-merge SHA once #193 lands.

## Testing

- Full `base-common-precompiles` suite green (1047 passed); clippy + nightly fmt clean.
- V2 ABI fingerprint pin unchanged.