### PR TITLE
feat(txpool): Add Validated-Transaction Origin Hook

### DIFF
--- a/crates/execution/txpool/src/builder/rpc.rs
+++ b/crates/execution/txpool/src/builder/rpc.rs
@@ -105,6 +105,9 @@ where
             tx.max_timestamp,
         );
 
+        // Read before `apply` consumes `tx.extensions` by value below.
+        let origin = tx.extensions.origin();
+
         // Attach any extension data carried on the wire. This is a no-op for
         // `NoExtensions`, the default payload.
         let pool_tx = tx.extensions.apply(pool_tx).map_err(|e| {
@@ -114,7 +117,7 @@ where
 
         // Insert into the pool
         let start = Instant::now();
-        let result = self.pool.add_external_transaction(pool_tx).await;
+        let result = self.pool.add_transaction(origin, pool_tx).await;
         BuilderApiMetrics::insert_duration().record(start.elapsed().as_secs_f64());
 
         match result {

--- a/crates/execution/txpool/src/wire.rs
+++ b/crates/execution/txpool/src/wire.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 
 use alloy_primitives::{Address, Bytes};
-use reth_transaction_pool::{PoolTransaction, ValidPoolTransaction};
+use reth_transaction_pool::{PoolTransaction, TransactionOrigin, ValidPoolTransaction};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 /// Default extension payload for [`ValidatedTransaction`], contributing no
@@ -40,6 +40,17 @@ pub trait ValidatedTransactionExtensions<T: PoolTransaction>:
     /// Called by the builder RPC handler before the transaction is inserted
     /// into the pool.
     fn apply(self, tx: T) -> Result<T, ExtensionError>;
+
+    /// Pool origin the builder RPC handler should insert the transaction under.
+    ///
+    /// Defaults to [`TransactionOrigin::External`], matching the pool origin the
+    /// handler used before this method existed. An implementation may return a
+    /// different origin per instance (for example, only for the subset of
+    /// payloads that carry its extension data) to give those transactions a
+    /// distinct, queryable partition in the pool.
+    fn origin(&self) -> TransactionOrigin {
+        TransactionOrigin::External
+    }
 }
 
 impl<T: PoolTransaction> ValidatedTransactionExtensions<T> for NoExtensions {
@@ -113,6 +124,14 @@ mod tests {
     struct TestExtensions {
         #[serde(skip_serializing_if = "Option::is_none", default)]
         extra: Option<u64>,
+    }
+
+    #[test]
+    fn no_extensions_origin_defaults_to_external() {
+        let origin = ValidatedTransactionExtensions::<crate::BasePooledTransaction>::origin(
+            &NoExtensions {},
+        );
+        assert_eq!(origin, TransactionOrigin::External);
     }
 
     fn sender() -> Address {


### PR DESCRIPTION
## Summary

Adds a default `origin()` method to `ValidatedTransactionExtensions` so a downstream extension payload can opt the transactions it decorates into `TransactionOrigin::Private` instead of the pool origin `insert_validated_transaction` always used before, `TransactionOrigin::External`. This lets a builder RPC extension give a subset of validated transactions a distinct, queryable partition in the pool without touching the generic insertion path for everyone else. The default preserves today's behavior exactly for `NoExtensions` and any other existing extension type.