### PR TITLE
feat(txpool): add revert protection to the pooled transaction shape

### DIFF
--- a/crates/builder/core/src/execution.rs
+++ b/crates/builder/core/src/execution.rs
@@ -152,6 +152,10 @@ pub enum TxnExecutionError {
     #[error("max gas usage exceeded")]
     MaxGasUsageExceeded,
 
+    /// Transaction reverted despite requiring revert protection.
+    #[error("revert-protected transaction reverted")]
+    RevertProtected,
+
     /// Metering data has not yet arrived for this transaction.
     #[error("metering data pending")]
     MeteringDataPending,
@@ -164,6 +168,7 @@ impl TxnExecutionError {
     ///
     /// Transient rejections depend on cumulative block state (gas used, DA used, etc.) and may
     /// succeed in a future block or flashblock with different cumulative values.
+    /// A revert-protected transaction is transient because its execution result depends on state.
     pub const fn is_permanent(&self) -> bool {
         matches!(
             self,

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -182,7 +182,8 @@ impl FlashblockDiagnostics {
             | TxnExecutionError::NonceTooLow
             | TxnExecutionError::InternalError(_)
             | TxnExecutionError::EvmError
-            | TxnExecutionError::MaxGasUsageExceeded => {
+            | TxnExecutionError::MaxGasUsageExceeded
+            | TxnExecutionError::RevertProtected => {
                 self.txs_rejected_other += 1;
             }
         }
@@ -819,6 +820,7 @@ impl BasePayloadBuilderCtx {
 
             let tx_da_size = tx.estimated_da_size();
             let tx_received_at_ms = tx.received_at();
+            let allow_revert = tx.allow_revert();
 
             // EIP-8130 meters payer authentication gas on top of the declared gas limit, so it must
             // be reserved against the block gas budget in addition to `gas_limit`. Reserve a
@@ -1174,15 +1176,43 @@ impl BasePayloadBuilderCtx {
 
             let gas_used = result.tx_gas_used();
             let is_success = result.is_success();
+            let exclude_revert = !is_success && allow_revert == Some(false);
             if is_success {
                 log_txn(Ok(TxnOutcome::Success));
                 num_txs_simulated_success += 1;
                 BuilderMetrics::successful_tx_gas_used().record(gas_used as f64);
             } else {
-                log_txn(Ok(TxnOutcome::Reverted));
+                log_txn(Ok(if exclude_revert {
+                    TxnOutcome::RevertedAndExcluded
+                } else {
+                    TxnOutcome::Reverted
+                }));
                 num_txs_simulated_fail += 1;
                 reverted_gas_used += gas_used;
                 BuilderMetrics::reverted_tx_gas_used().record(gas_used as f64);
+            }
+
+            if exclude_revert {
+                let err = TxnExecutionError::RevertProtected;
+                diag.record_rejection(&err);
+                let priority_fee = tx.effective_tip_per_gas(base_fee).unwrap_or(0) as f64;
+                record_rejected_tx_priority_fee(&err, priority_fee);
+                self.emit_builder_decision_event(
+                    &payload_id,
+                    TransactionEventType::BuilderRejected,
+                    tx_hash,
+                    Some(ordering_position),
+                    || {
+                        BuilderRejectedEventData::from_error(
+                            &err,
+                            info,
+                            limits,
+                            Some(&tx_resources),
+                        )
+                    },
+                );
+                best_txs.mark_invalid(tx.signer(), tx.nonce());
+                continue;
             }
 
             // add gas used by the transaction to cumulative gas used, before creating the

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -658,6 +658,7 @@ impl BasePayloadBuilderCtx {
         let mut num_txs_simulated = 0;
         let mut num_txs_simulated_success = 0;
         let mut num_txs_simulated_fail = 0;
+        let mut num_txs_reverted_and_excluded = 0;
         let mut reverted_gas_used: u64 = 0;
         let base_fee = self.base_fee();
         let mut diag = FlashblockDiagnostics::default();
@@ -1177,22 +1178,15 @@ impl BasePayloadBuilderCtx {
             let gas_used = result.tx_gas_used();
             let is_success = result.is_success();
             let exclude_revert = !is_success && allow_revert == Some(false);
-            if is_success {
-                log_txn(Ok(TxnOutcome::Success));
-                num_txs_simulated_success += 1;
-                BuilderMetrics::successful_tx_gas_used().record(gas_used as f64);
-            } else {
-                log_txn(Ok(if exclude_revert {
-                    TxnOutcome::RevertedAndExcluded
-                } else {
-                    TxnOutcome::Reverted
-                }));
-                num_txs_simulated_fail += 1;
-                reverted_gas_used += gas_used;
-                BuilderMetrics::reverted_tx_gas_used().record(gas_used as f64);
-            }
 
+            // Accounted separately, and before the reverted totals below: an excluded transaction
+            // contributes no gas to the sealed block, so folding it into `reverted_gas_used` would
+            // report gas the block never used.
             if exclude_revert {
+                log_txn(Ok(TxnOutcome::RevertedAndExcluded));
+                num_txs_reverted_and_excluded += 1;
+                BuilderMetrics::excluded_revert_tx_gas_used().record(gas_used as f64);
+
                 let err = TxnExecutionError::RevertProtected;
                 diag.record_rejection(&err);
                 let priority_fee = tx.effective_tip_per_gas(base_fee).unwrap_or(0) as f64;
@@ -1213,6 +1207,17 @@ impl BasePayloadBuilderCtx {
                 );
                 best_txs.mark_invalid(tx.signer(), tx.nonce());
                 continue;
+            }
+
+            if is_success {
+                log_txn(Ok(TxnOutcome::Success));
+                num_txs_simulated_success += 1;
+                BuilderMetrics::successful_tx_gas_used().record(gas_used as f64);
+            } else {
+                log_txn(Ok(TxnOutcome::Reverted));
+                num_txs_simulated_fail += 1;
+                reverted_gas_used += gas_used;
+                BuilderMetrics::reverted_tx_gas_used().record(gas_used as f64);
             }
 
             // add gas used by the transaction to cumulative gas used, before creating the
@@ -1314,6 +1319,7 @@ impl BasePayloadBuilderCtx {
             num_txs_simulated_success as f64,
             num_txs_simulated_fail as f64,
             reverted_gas_used as f64,
+            num_txs_reverted_and_excluded as f64,
         );
 
         diag.txs_considered = num_txs_considered;

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -80,6 +80,12 @@ base_metrics::define_metrics! {
     reverted_tx_gas_used: histogram,
     #[describe("Gas used by reverted transactions in the latest block")]
     payload_reverted_tx_gas_used: gauge,
+    #[describe("Histogram of gas used by reverted transactions excluded from the block")]
+    excluded_revert_tx_gas_used: histogram,
+    #[describe("Histogram of reverted transactions excluded from the payload")]
+    payload_num_tx_reverted_and_excluded: histogram,
+    #[describe("Latest number of reverted transactions excluded from the payload")]
+    payload_num_tx_reverted_and_excluded_gauge: gauge,
     #[describe(
         "Histogram of local builder EVM transaction execution/simulation duration in seconds"
     )]
@@ -265,6 +271,7 @@ impl BuilderMetrics {
         num_txs_simulated_success: f64,
         num_txs_simulated_fail: f64,
         reverted_gas_used: f64,
+        num_txs_reverted_and_excluded: f64,
     ) {
         Self::payload_transaction_simulation_duration().record(payload_transaction_simulation_time);
         Self::payload_transaction_simulation_gauge().set(payload_transaction_simulation_time);
@@ -277,6 +284,8 @@ impl BuilderMetrics {
         Self::payload_num_tx_simulated_fail().record(num_txs_simulated_fail);
         Self::payload_num_tx_simulated_fail_gauge().set(num_txs_simulated_fail);
         Self::payload_reverted_tx_gas_used().set(reverted_gas_used);
+        Self::payload_num_tx_reverted_and_excluded().record(num_txs_reverted_and_excluded);
+        Self::payload_num_tx_reverted_and_excluded_gauge().set(num_txs_reverted_and_excluded);
     }
 }
 

--- a/crates/builder/core/src/transaction_events.rs
+++ b/crates/builder/core/src/transaction_events.rs
@@ -442,6 +442,7 @@ pub(crate) const fn rejection_reason_code(err: &TxnExecutionError) -> &'static s
         TxnExecutionError::InternalError(_) => "internal_error",
         TxnExecutionError::EvmError => "evm_error",
         TxnExecutionError::MaxGasUsageExceeded => "max_gas_usage_exceeded",
+        TxnExecutionError::RevertProtected => "revert_protected",
         TxnExecutionError::MeteringDataPending => "metering_data_pending",
     }
 }
@@ -647,5 +648,6 @@ mod tests {
             )),
             "tx_execution_time_exceeded"
         );
+        assert_eq!(rejection_reason_code(&TxnExecutionError::RevertProtected), "revert_protected");
     }
 }

--- a/crates/builder/core/tests/bundles.rs
+++ b/crates/builder/core/tests/bundles.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::TxHash;
+use alloy_provider::Provider;
 use alloy_signer_local::PrivateKeySigner;
 use base_builder_core::test_utils::{
     ChainDriver, ChainDriverExt, ExternalTransactionPool, ONE_ETH, Protocol, TransactionBuilderExt,
@@ -52,6 +53,28 @@ async fn insert_bundle_transaction_with_nonce<P: Protocol>(
         timestamps.0,
         timestamps.1,
     );
+
+    pool.add_external_transaction(pool_tx).await?;
+
+    Ok(tx_hash)
+}
+
+async fn insert_reverting_transaction<P: Protocol>(
+    pool: &Arc<dyn ExternalTransactionPool>,
+    driver: &ChainDriver<P>,
+    signer: &PrivateKeySigner,
+    allow_revert: Option<bool>,
+) -> eyre::Result<TxHash> {
+    let recovered = driver
+        .create_transaction()
+        .with_signer(signer)
+        .random_reverting_transaction()
+        .build()
+        .await;
+    let tx_hash = TxHash::from(*recovered.tx_hash());
+    let encoded_len = recovered.encode_2718_len();
+    let pool_tx =
+        BasePooledTransaction::new(recovered, encoded_len).with_allow_revert(allow_revert);
 
     pool.add_external_transaction(pool_tx).await?;
 
@@ -248,6 +271,54 @@ async fn expired_bundle_excluded_while_valid_bundle_included_for_same_sender() -
         block.transactions.hashes().all(|hash| hash != expired_tx_hash),
         "expired bundle tx should be excluded"
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn revert_protected_transaction_is_excluded_without_committing_state() -> eyre::Result<()> {
+    let rbuilder = setup_test_instance().await?;
+    let driver = rbuilder.driver().await?;
+    let signer = driver.fund_accounts(1, ONE_ETH).await?.remove(0);
+    let pool = rbuilder.pool_handle();
+    let nonce_before = driver.provider().get_transaction_count(signer.address()).await?;
+    let tx_hash = insert_reverting_transaction(&pool, &driver, &signer, Some(false)).await?;
+
+    let block = driver.build_new_block_with_current_timestamp(None).await?;
+    let nonce_after = driver.provider().get_transaction_count(signer.address()).await?;
+
+    assert!(block.transactions.hashes().all(|hash| hash != tx_hash));
+    assert_eq!(nonce_after, nonce_before, "excluded transaction state must not be committed");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn explicitly_allowed_reverting_transaction_is_included() -> eyre::Result<()> {
+    let rbuilder = setup_test_instance().await?;
+    let driver = rbuilder.driver().await?;
+    let signer = driver.fund_accounts(1, ONE_ETH).await?.remove(0);
+    let pool = rbuilder.pool_handle();
+    let tx_hash = insert_reverting_transaction(&pool, &driver, &signer, Some(true)).await?;
+
+    let block = driver.build_new_block_with_current_timestamp(None).await?;
+
+    assert!(block.transactions.hashes().any(|hash| hash == tx_hash));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn reverting_transaction_without_policy_is_included() -> eyre::Result<()> {
+    let rbuilder = setup_test_instance().await?;
+    let driver = rbuilder.driver().await?;
+    let signer = driver.fund_accounts(1, ONE_ETH).await?.remove(0);
+    let pool = rbuilder.pool_handle();
+    let tx_hash = insert_reverting_transaction(&pool, &driver, &signer, None).await?;
+
+    let block = driver.build_new_block_with_current_timestamp(None).await?;
+
+    assert!(block.transactions.hashes().any(|hash| hash == tx_hash));
 
     Ok(())
 }

--- a/crates/builder/core/tests/rpc.rs
+++ b/crates/builder/core/tests/rpc.rs
@@ -69,6 +69,7 @@ async fn test_insert_validated_deposit_tx() -> eyre::Result<()> {
         max_block_number: None,
         min_timestamp: None,
         max_timestamp: None,
+        allow_revert: None,
         extensions: NoExtensions {},
     };
 
@@ -100,6 +101,7 @@ async fn test_insert_validated_eip1559_tx() -> eyre::Result<()> {
         max_block_number: None,
         min_timestamp: None,
         max_timestamp: None,
+        allow_revert: None,
         extensions: NoExtensions {},
     };
 
@@ -124,6 +126,7 @@ async fn test_insert_invalid_tx_fails() -> eyre::Result<()> {
         max_block_number: None,
         min_timestamp: None,
         max_timestamp: None,
+        allow_revert: None,
         extensions: NoExtensions {},
     };
 

--- a/crates/execution/tx-forwarding/src/forwarder/request.rs
+++ b/crates/execution/tx-forwarding/src/forwarder/request.rs
@@ -85,6 +85,7 @@ mod tests {
                 max_block_number: Some(42),
                 min_timestamp: None,
                 max_timestamp: None,
+                allow_revert: None,
                 extensions: NoExtensions {},
             },
             tx_hash,

--- a/crates/execution/tx-forwarding/src/forwarder/task.rs
+++ b/crates/execution/tx-forwarding/src/forwarder/task.rs
@@ -420,6 +420,7 @@ mod tests {
                 max_block_number: None,
                 min_timestamp: None,
                 max_timestamp: None,
+                allow_revert: None,
                 extensions: E::default(),
             },
             tx_hash: B256::with_last_byte(nonce as u8),

--- a/crates/execution/tx-forwarding/src/reader/task.rs
+++ b/crates/execution/tx-forwarding/src/reader/task.rs
@@ -156,6 +156,7 @@ where
                 max_block_number: transaction.transaction.max_block_number(),
                 min_timestamp: transaction.transaction.min_timestamp_millis(),
                 max_timestamp: transaction.transaction.max_timestamp_millis(),
+                allow_revert: transaction.transaction.allow_revert(),
                 extensions: E::extract(transaction),
             },
             tx_hash: *transaction.transaction.hash(),
@@ -219,7 +220,8 @@ mod tests {
             input: Default::default(),
         }
         .into();
-        let transaction = BasePooledTransaction::new(Recovered::new_unchecked(signed, sender), 128);
+        let transaction = BasePooledTransaction::new(Recovered::new_unchecked(signed, sender), 128)
+            .with_allow_revert(Some(false));
         Arc::new(ValidPoolTransaction {
             transaction_id: TransactionId::new(0u64.into(), nonce),
             transaction,
@@ -265,6 +267,7 @@ mod tests {
         assert_eq!(converted.tx_hash, *transaction.hash());
         assert_eq!(converted.transaction.sender, *transaction.sender_ref());
         assert!(!converted.transaction.raw.is_empty(), "the envelope must be encoded");
+        assert_eq!(converted.transaction.allow_revert, Some(false));
     }
 
     #[test]

--- a/crates/execution/tx-forwarding/src/service.rs
+++ b/crates/execution/tx-forwarding/src/service.rs
@@ -285,6 +285,7 @@ mod tests {
                 max_block_number: None,
                 min_timestamp: None,
                 max_timestamp: None,
+                allow_revert: None,
                 extensions: Default::default(),
             },
             tx_hash: B256::repeat_byte(byte),

--- a/crates/execution/txpool/src/builder/rpc.rs
+++ b/crates/execution/txpool/src/builder/rpc.rs
@@ -98,12 +98,14 @@ where
         let encoded_len = tx.raw.len();
 
         let recovered = Recovered::new_unchecked(consensus_tx, sender);
-        let pool_tx = BasePooledTransaction::new(recovered, encoded_len).with_bundle_metadata(
-            tx.min_block_number,
-            tx.max_block_number,
-            tx.min_timestamp,
-            tx.max_timestamp,
-        );
+        let pool_tx = BasePooledTransaction::new(recovered, encoded_len)
+            .with_bundle_metadata(
+                tx.min_block_number,
+                tx.max_block_number,
+                tx.min_timestamp,
+                tx.max_timestamp,
+            )
+            .with_allow_revert(tx.allow_revert);
 
         // Attach any extension data carried on the wire. This is a no-op for
         // `NoExtensions`, the default payload.
@@ -241,6 +243,7 @@ mod tests {
             max_block_number: None,
             min_timestamp: None,
             max_timestamp: None,
+            allow_revert: None,
             extensions,
         }
     }

--- a/crates/execution/txpool/src/transaction.rs
+++ b/crates/execution/txpool/src/transaction.rs
@@ -75,6 +75,8 @@ pub struct BasePooledTransaction<
     /// Optional maximum timestamp (millis since Unix epoch) from bundle submission.
     /// The transaction should be evicted after this time.
     max_timestamp: Option<u64>,
+    /// Whether the transaction may revert, if specified.
+    allow_revert: Option<bool>,
     /// The set of on-chain state surfaces whose change invalidates this
     /// transaction, computed once during validation and consumed by the pool's
     /// invalidation index. Empty until set; see [`crate::WatchSet`].
@@ -114,6 +116,7 @@ impl<Cons: SignedTransaction, Pooled> BasePooledTransaction<Cons, Pooled> {
             max_block_number: None,
             min_timestamp: None,
             max_timestamp: None,
+            allow_revert: None,
             watch_set: OnceLock::new(),
             limit_class: OnceLock::new(),
             watch_manifest: OnceLock::new(),
@@ -132,6 +135,12 @@ impl<Cons: SignedTransaction, Pooled> BasePooledTransaction<Cons, Pooled> {
         self.max_block_number = max_block_number;
         self.min_timestamp = min_timestamp;
         self.max_timestamp = max_timestamp;
+        self
+    }
+
+    /// Sets whether this transaction may revert, returning the modified instance.
+    pub const fn with_allow_revert(mut self, allow_revert: Option<bool>) -> Self {
+        self.allow_revert = allow_revert;
         self
     }
 
@@ -232,6 +241,7 @@ impl<Cons: InMemorySize, Pooled> InMemorySize for BasePooledTransaction<Cons, Po
         self.inner.size()
             + core::mem::size_of::<u128>()
             + core::mem::size_of::<Option<u64>>() * 4
+            + core::mem::size_of::<Option<bool>>()
             + core::mem::size_of::<OnceLock<crate::WatchSet>>()
             + watch_keys_size
             + core::mem::size_of::<OnceLock<crate::LimitClass>>()
@@ -507,6 +517,9 @@ pub trait BundleTransaction {
     /// Returns the maximum timestamp in milliseconds.
     fn max_timestamp_millis(&self) -> Option<u64>;
 
+    /// Returns whether the transaction may revert, if specified.
+    fn allow_revert(&self) -> Option<bool>;
+
     /// Returns `true` if this transaction's bundle constraints have expired
     /// relative to the given block number and block timestamp (in seconds).
     fn is_bundle_expired(&self, block_number: u64, block_timestamp_secs: u64) -> bool {
@@ -568,6 +581,10 @@ where
     fn max_timestamp_millis(&self) -> Option<u64> {
         self.max_timestamp
     }
+
+    fn allow_revert(&self) -> Option<bool> {
+        self.allow_revert
+    }
 }
 
 #[cfg(test)]
@@ -594,8 +611,8 @@ mod tests {
     };
 
     use crate::{
-        BasePooledTransaction, BasePooledTx, BaseTransactionValidator, ConfigSlot, InvalidationKey,
-        WatchManifest, WatchSet,
+        BasePooledTransaction, BasePooledTx, BaseTransactionValidator, BundleTransaction,
+        ConfigSlot, InvalidationKey, WatchManifest, WatchSet,
     };
 
     fn signer() -> PrivateKeySigner {
@@ -668,6 +685,13 @@ mod tests {
         assert!(eip8130_pooled(U256::ZERO).requires_nonce_check());
         assert!(!eip8130_pooled(U256::from(1)).requires_nonce_check());
         assert!(!eip8130_pooled(Eip8130Constants::NONCE_KEY_MAX).requires_nonce_check());
+    }
+
+    #[test]
+    fn allow_revert_builder_is_exposed_through_bundle_transaction() {
+        let transaction = eip8130_pooled(U256::ZERO).with_allow_revert(Some(false));
+
+        assert_eq!(transaction.allow_revert(), Some(false));
     }
 
     #[test]

--- a/crates/execution/txpool/src/wire.rs
+++ b/crates/execution/txpool/src/wire.rs
@@ -80,6 +80,9 @@ pub struct ValidatedTransaction<E = NoExtensions> {
     /// Milliseconds since Unix epoch.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub max_timestamp: Option<u64>,
+    /// Whether the transaction may revert. `None` leaves the builder's default behavior.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub allow_revert: Option<bool>,
     /// Extension fields, inlined into the top-level JSON object.
     ///
     /// Deliberately not `#[serde(default)]`: that would force an `E: Default`
@@ -140,6 +143,7 @@ mod tests {
             max_block_number: None,
             min_timestamp: None,
             max_timestamp: Some(7),
+            allow_revert: None,
             extensions: NoExtensions {},
         };
 
@@ -159,6 +163,7 @@ mod tests {
             max_block_number: None,
             min_timestamp: None,
             max_timestamp: None,
+            allow_revert: None,
             extensions: NoExtensions {},
         };
 
@@ -179,6 +184,7 @@ mod tests {
             max_block_number: None,
             min_timestamp: None,
             max_timestamp: None,
+            allow_revert: None,
             extensions: TestExtensions { extra: Some(9) },
         };
 
@@ -195,6 +201,7 @@ mod tests {
             max_block_number: None,
             min_timestamp: None,
             max_timestamp: None,
+            allow_revert: None,
             extensions: TestExtensions { extra: Some(9) },
         };
         let json = serde_json::to_string(&extended).unwrap();
@@ -231,11 +238,41 @@ mod tests {
             max_block_number: None,
             min_timestamp: None,
             max_timestamp: None,
+            allow_revert: None,
             extensions: NoExtensions {},
         };
         let json = serde_json::to_string(&tx).unwrap();
 
         let decoded: ValidatedTransaction = serde_json::from_str(&json).unwrap();
         assert_eq!(decoded.min_block_number, Some(u64::MAX));
+    }
+
+    #[test]
+    fn allow_revert_round_trips_and_defaults_when_absent() {
+        let tx = ValidatedTransaction {
+            sender: sender(),
+            raw: raw(),
+            min_block_number: None,
+            max_block_number: None,
+            min_timestamp: None,
+            max_timestamp: None,
+            allow_revert: Some(false),
+            extensions: NoExtensions {},
+        };
+        let json = serde_json::to_string(&tx).unwrap();
+        let decoded: ValidatedTransaction = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.allow_revert, Some(false));
+
+        let legacy = LegacyValidatedTransaction {
+            sender: sender(),
+            raw: raw(),
+            min_block_number: None,
+            max_block_number: None,
+            min_timestamp: None,
+            max_timestamp: None,
+        };
+        let json = serde_json::to_string(&legacy).unwrap();
+        let decoded: ValidatedTransaction = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.allow_revert, None);
     }
 }

--- a/etc/systems/tests/tx_forwarding.rs
+++ b/etc/systems/tests/tx_forwarding.rs
@@ -111,6 +111,7 @@ async fn test_insert_validated_transaction_single() -> Result<()> {
         max_block_number: None,
         min_timestamp: None,
         max_timestamp: None,
+        allow_revert: None,
         extensions: NoExtensions {},
     };
 


### PR DESCRIPTION
A forwarded transaction can now say whether it may revert, alongside the bundle validity windows it already carries. When `allow_revert` is `Some(false)` and the transaction reverts during block building, the builder excludes it instead of sealing a reverting transaction into the block.

`TxnOutcome::RevertedAndExcluded` already described this outcome but nothing produced it; this is what produces it.

The field is populated only by the forwarding path, like the validity windows, and is absent by default: `None` and `Some(true)` both keep today's behavior, so transactions that predate the field are unaffected and the wire form stays compatible in both directions.

`RevertProtected` is deliberately not permanent. A revert is state-dependent, so marking it permanent would cache the hash in the cross-block rejection cache and the transaction could never land, even once it would succeed.

On exclusion the loop skips gas and DA accounting, the acceptance event, the receipt, the state commit, fee accounting, metering metrics, and the executed transaction lists, then invalidates the sender's later nonces for this payload — excluding nonce n leaves n+1 unexecutable.