### PR TITLE
ci: add swap space to release binary builds to fix aarch64 OOM (#4298)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -83,6 +83,20 @@ jobs:
           save-if: ${{ true }}
           cache-targets: "false"
 
+      - name: Add swap space (Linux)
+        # `maxperf` uses fat LTO + codegen-units=1, so the final whole-program link of the
+        # larger binaries (base, base-consensus) needs more headroom than the aarch64 runner's
+        # RAM provides. This has silently OOM'd `build-binaries` for aarch64-unknown-linux-gnu
+        # (base, base-consensus) with no compiler error, just a runner-level shutdown signal
+        # partway through linking — see #4298. x86_64 and macOS builds aren't affected.
+        if: matrix.target.os == 'linux'
+        run: |
+          sudo fallocate -l 12G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          free -h
+
       - name: Build binary
         run: |
           cargo build --locked --profile maxperf --bin "${{ matrix.binary }}"


### PR DESCRIPTION
## What's broken

#4298: the v1.2.0 `Publish Release` run's `build-binaries (aarch64-unknown-linux-gnu)` jobs for `base` and `base-consensus` failed, while `base-reth-node` and `basectl` succeeded on the same runner in the same run, and all four succeeded on `x86_64-unknown-linux-gnu` / `aarch64-apple-darwin`.

## Root cause (from the actual failed-job logs, not just the issue report)

Pulled both failed jobs' full logs (`gh run view --job <id> --log-failed` on run [29948223492](https://github.com/base/base/actions/runs/29948223492)):

- `base` (aarch64): last output is `Compiling base v1.2.0 (bin/base)` at `19:06:56`, then **nothing** until `19:23:56`, when the job dies with `The runner has received a shutdown signal` / exit 143.
- `base-consensus` (aarch64): last output is `Compiling base-consensus v1.2.0 (bin/consensus)` at `19:04:13`, then silence until the runner starts reaping orphan processes (`sccache`) at `19:08:42` — no compiler error surfaces at any point in either log.

Both binaries die during the *final* build step of the top-level binary crate with no rustc error — that's the whole-program LTO/link phase, not a compilation error. `[profile.maxperf]` in `Cargo.toml` sets `lto = "fat", codegen-units = 1`, i.e. the entire dependency graph gets linked in one pass. `base` and `base-consensus` are the two heaviest binaries in the workspace (rocksdb, txpool-tracing, builder, flashblocks, etc. all statically linked in); `base-reth-node` and `basectl` are smaller and complete fine on the same aarch64 runner in the same run. This is consistent with the aarch64 runner running out of memory during that final link, not a genuine cross-compilation regression.

(For reference: `paradigmxyz/reth`'s own `release.yml` uses the identical `maxperf` + `ubuntu-24.04-arm` combination successfully, so this isn't "fat-LTO on arm64 is broken" in general — `base`/`base-consensus` are just heavier than plain `reth`.)

## Fix

Add a swap file before the build step on Linux runners, so the final link has enough headroom to complete. This doesn't touch the `maxperf` profile — shipped-binary performance/optimization is unchanged; it only gives CI more memory to work with.

## Verification

I don't have write access to trigger `Publish Release` on this repo, so I can't confirm green CI on this PR directly — happy for a maintainer to re-run the aarch64 `base`/`base-consensus` matrix legs on this branch, or I can if someone can point me at how release builds get triggered for a fork PR.

## Alternative if swap alone doesn't fully resolve it

A lower-risk fallback (small runtime perf cost, only on aarch64) would be dropping `codegen-units` to something >1 for the aarch64 leg specifically via `CARGO_PROFILE_MAXPERF_CODEGEN_UNITS=4` — happy to add that as a belt-and-suspenders if maintainers want it.