### PR TITLE
docs(batcher): drop reference-batcher comparisons from comments

### DIFF
--- a/bin/batcher/src/cli.rs
+++ b/bin/batcher/src/cli.rs
@@ -171,7 +171,6 @@ pub(crate) struct BatcherArgs {
     ///
     /// Only relevant when `--batch-type=span`. Should be slightly below the
     /// typical observed ratio to avoid creating a small leftover frame.
-    /// Matches the reference batcher's `--approx-compr-ratio` default.
     #[arg(long = "approx-compr-ratio", default_value = "0.6", env = "BATCHER_APPROX_COMPR_RATIO")]
     pub approx_compr_ratio: f64,
 
@@ -198,8 +197,7 @@ pub(crate) struct BatcherArgs {
     /// DA backlog threshold in bytes at which throttling activates.
     ///
     /// When the estimated unsubmitted DA backlog exceeds this value, the batcher
-    /// signals the sequencer to reduce block throughput. Matches the reference batcher's
-    /// `--throttle-threshold` default of 1 MB.
+    /// signals the sequencer to reduce block throughput.
     #[arg(
         long = "throttle-threshold",
         default_value = "1000000",
@@ -209,8 +207,7 @@ pub(crate) struct BatcherArgs {
 
     /// Disable DA throttling.
     ///
-    /// By default throttling is enabled (matching reference batcher behavior). Pass
-    /// this flag to submit batches at full rate regardless of DA backlog.
+    /// Pass this flag to submit batches at full rate regardless of DA backlog.
     #[arg(long = "no-throttle", env = "BATCHER_NO_THROTTLE")]
     pub no_throttle: bool,
 
@@ -234,8 +231,7 @@ pub(crate) struct BatcherArgs {
     /// Maximum serialized size of a single L1 calldata transaction in bytes.
     ///
     /// Safety cap that prevents oversized calldata transactions from being rejected
-    /// by the mempool. No-op for blob DA. Equivalent to the reference batcher's
-    /// `--max-l1-tx-size-bytes` (default 120,000 bytes). Omit to disable the cap.
+    /// by the mempool. No-op for blob DA. Omit to disable the cap.
     #[arg(long = "max-l1-tx-size-bytes", env = "BATCHER_MAX_L1_TX_SIZE_BYTES")]
     pub max_l1_tx_size_bytes: Option<usize>,
 
@@ -284,10 +280,9 @@ pub(crate) struct BatcherArgs {
     ///
     /// By default, when DA-backlog throttling activates, the encoder is forced
     /// to emit blob-typed submissions even if `--data-availability-type=calldata`
-    /// is configured (matching reference batcher behavior, since blobs amortise DA
-    /// cost more efficiently under congestion). Pass this flag to keep the
-    /// configured DA type regardless of throttle state. No-op for blob-configured
-    /// batchers.
+    /// is configured because blobs amortise DA cost more efficiently under congestion.
+    /// Pass this flag to keep the configured DA type regardless of throttle state.
+    /// No-op for blob-configured batchers.
     #[arg(long = "no-force-blobs-when-throttling", env = "BATCHER_NO_FORCE_BLOBS_WHEN_THROTTLING")]
     pub no_force_blobs_when_throttling: bool,
 

--- a/crates/batcher/comp/src/composer.rs
+++ b/crates/batcher/comp/src/composer.rs
@@ -19,9 +19,6 @@ pub enum BatchComposeError {
 }
 
 /// Converts L2 blocks into [`SingleBatch`]es.
-///
-/// This is the Rust equivalent of `BlockToSingularBatch` from the reference batcher's
-/// `channel_out.go`.
 #[derive(Debug)]
 pub struct BatchComposer;
 
@@ -29,7 +26,6 @@ impl BatchComposer {
     /// Convert an L2 [`BaseBlock`] into a [`SingleBatch`] and the decoded
     /// [`L1BlockInfoTx`].
     ///
-    /// Mirrors the reference batcher's `BlockToSingularBatch`:
     /// 1. The first transaction must be a deposit carrying L1 block info calldata.
     /// 2. All deposit transactions are filtered out; remaining user transactions
     ///    are EIP-2718-encoded.

--- a/crates/batcher/comp/src/ratio.rs
+++ b/crates/batcher/comp/src/ratio.rs
@@ -1,6 +1,4 @@
 //! Contains the ratio compressor for Base.
-//!
-//! This is a port of the reference batcher's ratio compressor.
 
 use crate::{CompressorResult, CompressorWriter, Config, VariantCompressor};
 

--- a/crates/batcher/comp/src/shadow.rs
+++ b/crates/batcher/comp/src/shadow.rs
@@ -1,6 +1,4 @@
 //! Contains the shadow compressor for Base.
-//!
-//! This is a port of the reference batcher's shadow compressor.
 
 use alloc::vec::Vec;
 

--- a/crates/batcher/comp/src/types.rs
+++ b/crates/batcher/comp/src/types.rs
@@ -15,8 +15,6 @@ pub enum CompressorError {
 }
 
 /// The type of compressor to use.
-///
-/// Matches the reference batcher's compressor variants.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CompressorType {
     /// The ratio compression.

--- a/crates/batcher/core/README.md
+++ b/crates/batcher/core/README.md
@@ -35,9 +35,9 @@ transaction based on the L1 DA backlog. `ThrottleController` takes a `ThrottleCo
 `ThrottleStrategy` and produces `ThrottleParams` from a raw backlog byte count.
 `ThrottleStrategy::Off` disables throttling entirely. `ThrottleStrategy::Step` applies full
 intensity when the backlog exceeds the configured threshold. `ThrottleStrategy::Linear` grows
-intensity linearly from zero at the threshold to `max_intensity` at twice the threshold, which
-matches the reference batcher implementation. `ThrottleParams` carries a fractional `intensity`
-value and the corresponding `max_block_size` and `max_tx_size` byte limits computed by
+intensity linearly from zero at the threshold to `max_intensity` at twice the threshold.
+`ThrottleParams` carries a fractional `intensity` value and the corresponding
+`max_block_size` and `max_tx_size` byte limits computed by
 interpolating between the upper and lower limits in `ThrottleConfig`. `DaThrottle` wraps a
 `ThrottleController` and a `ThrottleClient` with a last-applied dedup cache so that the
 `miner_setMaxDASize` RPC call is only issued when the computed limits actually change between ticks.

--- a/crates/batcher/core/src/config.rs
+++ b/crates/batcher/core/src/config.rs
@@ -15,8 +15,8 @@ pub struct BatchDriverConfig {
     pub drain_timeout: Duration,
     /// When `true` and DA-backlog throttling is active, force the encoder to
     /// emit blob-typed submissions even when its configured `da_type` is
-    /// calldata. Mirrors reference batcher behavior: blobs amortise DA cost more
-    /// efficiently when the L1 is congested with batcher data.
+    /// calldata. Blobs amortise DA cost more efficiently when the L1 is
+    /// congested with batcher data.
     ///
     /// No-op when the encoder is already configured for blob DA.
     /// Default: `true`.

--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -942,8 +942,7 @@ mod tests {
     }
 
     /// The submission loop must submit each pipeline submission as one L1 tx. The
-    /// pipeline is responsible for choosing the frames that belong in a tx, matching
-    /// op-batcher's `NextTxData` boundary.
+    /// pipeline is responsible for choosing the frames that belong in a transaction.
     #[test]
     fn test_submission_loop_submits_each_pipeline_submission_as_one_tx() {
         Runner::start(Config::seeded(0), |ctx| async move {
@@ -983,8 +982,8 @@ mod tests {
     }
 
     /// A single submission may contain multiple blob-filling frames when
-    /// `target_num_frames > 1`. Matching op-batcher, each frame becomes its own
-    /// blob in the same L1 transaction.
+    /// `target_num_frames > 1`. Each frame becomes its own blob in the same L1
+    /// transaction.
     #[test]
     fn test_multi_frame_blob_submission_maps_frames_to_blobs() {
         Runner::start(Config::seeded(0), |ctx| async move {

--- a/crates/batcher/core/src/submissions.rs
+++ b/crates/batcher/core/src/submissions.rs
@@ -82,7 +82,7 @@ impl<TM: TxManager> SubmissionQueue<TM> {
     ///
     /// For each available semaphore permit (= one L1 transaction), dequeues one
     /// ready submission and encodes it as a blob or calldata transaction. Blob
-    /// submissions map each frame to one blob, matching op-batcher's blob-tx shape.
+    /// submissions map each frame to one blob.
     /// Loops until the semaphore is exhausted, the pipeline has no ready submissions,
     /// or the txpool is blocked.
     ///

--- a/crates/batcher/core/src/throttle.rs
+++ b/crates/batcher/core/src/throttle.rs
@@ -1,9 +1,6 @@
 //! Throttle controller for DA backlog management.
 
 /// Configuration for the throttle controller.
-///
-/// Defaults match the reference batcher implementation:
-/// 1 MB threshold, full intensity, linear strategy.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ThrottleConfig {
     /// Backlog threshold in bytes at which throttling activates.
@@ -28,7 +25,6 @@ pub struct ThrottleConfig {
 
 impl Default for ThrottleConfig {
     fn default() -> Self {
-        // Match the reference batcher defaults.
         Self {
             threshold_bytes: 1_000_000,
             max_intensity: 1.0,

--- a/crates/batcher/encoder/src/config.rs
+++ b/crates/batcher/encoder/src/config.rs
@@ -53,7 +53,6 @@ pub struct EncoderConfig {
     /// Maximum number of L2 blocks to accumulate into one span batch.
     ///
     /// When unset, span batches close only on size and channel-duration thresholds.
-    /// Set this to match the reference batcher's `max-blocks-per-span-batch` behavior.
     ///
     /// Default: `None`.
     pub max_blocks_per_span_batch: Option<usize>,
@@ -83,7 +82,7 @@ pub struct EncoderConfig {
     /// to avoid creating a small leftover frame. Also passed to the `ShadowCompressor`
     /// as the ratio hint used when operating in [`BatchType::Single`] mode.
     ///
-    /// Default: `0.6` (matches the reference batcher's `--approx-compr-ratio` default).
+    /// Default: `0.6`.
     pub approx_compr_ratio: f64,
 
     /// Maximum serialized size of a single L1 calldata transaction in bytes.
@@ -96,7 +95,7 @@ pub struct EncoderConfig {
     /// This is a no-op when [`da_type`] is [`DaType::Blob`], since the blob size is
     /// the binding constraint for blob DA.
     ///
-    /// Default: `None` (no cap; reference batcher equivalent default is 120,000 bytes).
+    /// Default: `None` (no cap).
     ///
     /// [`max_frame_size`]: EncoderConfig::max_frame_size
     /// [`da_type`]: EncoderConfig::da_type

--- a/crates/batcher/encoder/src/encoder.rs
+++ b/crates/batcher/encoder/src/encoder.rs
@@ -627,9 +627,7 @@ impl BatchPipeline for BatchEncoder {
                 }
 
                 // Estimate the compressed size of the accumulated span batch and close
-                // the channel when it would exceed the configured size budget. This mirrors
-                // the reference batcher's `SpanChannelOut`, which triggers closure based on estimated
-                // compressed size rather than waiting for a timeout.
+                // the channel when it would exceed the configured size budget.
                 //
                 // Each block contributes fixed-field overhead plus its raw transaction bytes.
                 // The compressed estimate uses the same ratio as the ShadowCompressor so that

--- a/crates/batcher/service/src/config.rs
+++ b/crates/batcher/service/src/config.rs
@@ -104,8 +104,6 @@ pub struct BatcherConfig {
     pub admin_addr: Option<SocketAddr>,
     /// If `true`, start in a stopped state and defer batch submission until
     /// `admin_startBatcher` is called via the admin API.
-    ///
-    /// Matches the reference batcher's `--stopped` behavior (env: `BATCHER_STOPPED`).
     pub stopped: bool,
     /// If `true`, block startup until the rollup node reports a non-zero
     /// `unsafe_l2` and `current_l1` head via `optimism_syncStatus`.

--- a/crates/batcher/service/src/shadow_parity.rs
+++ b/crates/batcher/service/src/shadow_parity.rs
@@ -33,9 +33,9 @@ pub const MAX_PENDING_BATCH_QUEUE_LEN: usize = 4096;
 /// Runtime configuration for the shadow parity monitor.
 #[derive(Debug, Clone)]
 pub struct ShadowParityMonitorConfig {
-    /// Canonical rollup batch inbox used by the op-batcher.
+    /// Canonical rollup batch inbox.
     pub canonical_inbox: Address,
-    /// Canonical op-batcher sender, if available from the rollup config.
+    /// Canonical batcher sender, if available from the rollup config.
     pub canonical_batcher: Option<Address>,
     /// Shadow batch inbox used by this base-batcher instance.
     pub shadow_inbox: Address,
@@ -69,7 +69,7 @@ pub struct ShadowParityMonitor {
 /// Side of the parity comparison.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ParitySide {
-    /// Canonical op-batcher submissions to the rollup-config inbox.
+    /// Canonical batcher submissions to the rollup-config inbox.
     Canonical,
     /// Shadow base-batcher submissions to the override inbox.
     Shadow,

--- a/crates/batcher/source/src/event.rs
+++ b/crates/batcher/source/src/event.rs
@@ -23,10 +23,8 @@ pub enum L2BlockEvent {
     /// Signal the driver to force-close the current channel and flush pending
     /// frames as submissions without exhausting the source.
     ///
-    /// Analogous to the reference batcher's `forcePublish` signal: the source remains
-    /// open and the driver continues running, but the current channel is
-    /// closed so all accumulated blocks become immediately available for
-    /// submission.
+    /// The source remains open and the driver continues running, but the current
+    /// channel is closed so all accumulated blocks become available for submission.
     Flush {
         /// Fired once the driver's encoding and submission are both fully drained (not just
         /// after the first frame). Delivered through this event — rather than a side channel


### PR DESCRIPTION
## Summary

Remove stale "reference batcher" / op-batcher comparisons from batcher comments
and docs. Comment-only, no functional change.

First of five PRs splitting #4274.