### PR TITLE
fix(batcher): select the L1 node-sync target from batcher nonce history

### DIFF
--- a/bin/batcher/src/cli.rs
+++ b/bin/batcher/src/cli.rs
@@ -171,7 +171,6 @@ pub(crate) struct BatcherArgs {
     ///
     /// Only relevant when `--batch-type=span`. Should be slightly below the
     /// typical observed ratio to avoid creating a small leftover frame.
-    /// Matches the reference batcher's `--approx-compr-ratio` default.
     #[arg(long = "approx-compr-ratio", default_value = "0.6", env = "BATCHER_APPROX_COMPR_RATIO")]
     pub approx_compr_ratio: f64,
 
@@ -198,8 +197,7 @@ pub(crate) struct BatcherArgs {
     /// DA backlog threshold in bytes at which throttling activates.
     ///
     /// When the estimated unsubmitted DA backlog exceeds this value, the batcher
-    /// signals the sequencer to reduce block throughput. Matches the reference batcher's
-    /// `--throttle-threshold` default of 1 MB.
+    /// signals the sequencer to reduce block throughput.
     #[arg(
         long = "throttle-threshold",
         default_value = "1000000",
@@ -209,8 +207,7 @@ pub(crate) struct BatcherArgs {
 
     /// Disable DA throttling.
     ///
-    /// By default throttling is enabled (matching reference batcher behavior). Pass
-    /// this flag to submit batches at full rate regardless of DA backlog.
+    /// Pass this flag to submit batches at full rate regardless of DA backlog.
     #[arg(long = "no-throttle", env = "BATCHER_NO_THROTTLE")]
     pub no_throttle: bool,
 
@@ -234,8 +231,7 @@ pub(crate) struct BatcherArgs {
     /// Maximum serialized size of a single L1 calldata transaction in bytes.
     ///
     /// Safety cap that prevents oversized calldata transactions from being rejected
-    /// by the mempool. No-op for blob DA. Equivalent to the reference batcher's
-    /// `--max-l1-tx-size-bytes` (default 120,000 bytes). Omit to disable the cap.
+    /// by the mempool. No-op for blob DA. Omit to disable the cap.
     #[arg(long = "max-l1-tx-size-bytes", env = "BATCHER_MAX_L1_TX_SIZE_BYTES")]
     pub max_l1_tx_size_bytes: Option<usize>,
 
@@ -284,10 +280,9 @@ pub(crate) struct BatcherArgs {
     ///
     /// By default, when DA-backlog throttling activates, the encoder is forced
     /// to emit blob-typed submissions even if `--data-availability-type=calldata`
-    /// is configured (matching reference batcher behavior, since blobs amortise DA
-    /// cost more efficiently under congestion). Pass this flag to keep the
-    /// configured DA type regardless of throttle state. No-op for blob-configured
-    /// batchers.
+    /// is configured because blobs amortise DA cost more efficiently under congestion.
+    /// Pass this flag to keep the configured DA type regardless of throttle state.
+    /// No-op for blob-configured batchers.
     #[arg(long = "no-force-blobs-when-throttling", env = "BATCHER_NO_FORCE_BLOBS_WHEN_THROTTLING")]
     pub no_force_blobs_when_throttling: bool,
 

--- a/bin/batcher/src/cli.rs
+++ b/bin/batcher/src/cli.rs
@@ -211,15 +211,14 @@ pub(crate) struct BatcherArgs {
     #[arg(long = "no-throttle", env = "BATCHER_NO_THROTTLE")]
     pub no_throttle: bool,
 
-    /// Number of recent L1 blocks to scan on startup for already-submitted batcher frames.
+    /// Number of recent L1 blocks to inspect for a confirmed batcher transaction.
     ///
-    /// When set to a nonzero value N, the batcher walks back N L1 blocks from the
-    /// current head on startup, decodes any calldata batcher frames it finds, and
-    /// advances the L2 block cursor past data already pending on L1. This avoids
-    /// re-submitting frames after an unclean shutdown. Maximum value is 128.
+    /// With `--wait-node-sync`, recent nonce activity selects the L1 synchronization
+    /// target within this window.
+    /// It does not decode batches or change the L2 backfill cursor. A non-zero
+    /// value requires `--wait-node-sync`.
     ///
-    /// A value of 0 (default) disables the scan. Matches the reference batcher's
-    /// `--check-recent-txs-depth` flag.
+    /// A value of 0 (default) disables the scan.
     #[arg(
         long = "check-recent-txs-depth",
         default_value = "0",
@@ -257,12 +256,10 @@ pub(crate) struct BatcherArgs {
     #[arg(long = "stopped", env = "BATCHER_STOPPED")]
     pub stopped: bool,
 
-    /// Block startup until the rollup node reports a non-zero sync status.
+    /// Block startup until the rollup node has processed the selected L1 target.
     ///
-    /// Polls `optimism_syncStatus` on the poll interval until both `current_l1`
-    /// and `unsafe_l2` heads are non-zero. Useful when the batcher is started
-    /// alongside a fresh node so it does not race the node's initial sync.
-    /// Matches the reference batcher's `--wait-node-sync`.
+    /// By default the target is the current L1 head. `--check-recent-txs-depth`
+    /// may select an earlier target from the configured window.
     #[arg(long = "wait-node-sync", env = "BATCHER_WAIT_NODE_SYNC")]
     pub wait_node_sync: bool,
 

--- a/crates/batcher/comp/src/composer.rs
+++ b/crates/batcher/comp/src/composer.rs
@@ -19,9 +19,6 @@ pub enum BatchComposeError {
 }
 
 /// Converts L2 blocks into [`SingleBatch`]es.
-///
-/// This is the Rust equivalent of `BlockToSingularBatch` from the reference batcher's
-/// `channel_out.go`.
 #[derive(Debug)]
 pub struct BatchComposer;
 
@@ -29,7 +26,6 @@ impl BatchComposer {
     /// Convert an L2 [`BaseBlock`] into a [`SingleBatch`] and the decoded
     /// [`L1BlockInfoTx`].
     ///
-    /// Mirrors the reference batcher's `BlockToSingularBatch`:
     /// 1. The first transaction must be a deposit carrying L1 block info calldata.
     /// 2. All deposit transactions are filtered out; remaining user transactions
     ///    are EIP-2718-encoded.

--- a/crates/batcher/comp/src/ratio.rs
+++ b/crates/batcher/comp/src/ratio.rs
@@ -1,6 +1,4 @@
 //! Contains the ratio compressor for Base.
-//!
-//! This is a port of the reference batcher's ratio compressor.
 
 use crate::{CompressorResult, CompressorWriter, Config, VariantCompressor};
 

--- a/crates/batcher/comp/src/shadow.rs
+++ b/crates/batcher/comp/src/shadow.rs
@@ -1,6 +1,4 @@
 //! Contains the shadow compressor for Base.
-//!
-//! This is a port of the reference batcher's shadow compressor.
 
 use alloc::vec::Vec;
 

--- a/crates/batcher/comp/src/types.rs
+++ b/crates/batcher/comp/src/types.rs
@@ -15,8 +15,6 @@ pub enum CompressorError {
 }
 
 /// The type of compressor to use.
-///
-/// Matches the reference batcher's compressor variants.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CompressorType {
     /// The ratio compression.

--- a/crates/batcher/core/README.md
+++ b/crates/batcher/core/README.md
@@ -35,9 +35,9 @@ transaction based on the L1 DA backlog. `ThrottleController` takes a `ThrottleCo
 `ThrottleStrategy` and produces `ThrottleParams` from a raw backlog byte count.
 `ThrottleStrategy::Off` disables throttling entirely. `ThrottleStrategy::Step` applies full
 intensity when the backlog exceeds the configured threshold. `ThrottleStrategy::Linear` grows
-intensity linearly from zero at the threshold to `max_intensity` at twice the threshold, which
-matches the reference batcher implementation. `ThrottleParams` carries a fractional `intensity`
-value and the corresponding `max_block_size` and `max_tx_size` byte limits computed by
+intensity linearly from zero at the threshold to `max_intensity` at twice the threshold.
+`ThrottleParams` carries a fractional `intensity` value and the corresponding
+`max_block_size` and `max_tx_size` byte limits computed by
 interpolating between the upper and lower limits in `ThrottleConfig`. `DaThrottle` wraps a
 `ThrottleController` and a `ThrottleClient` with a last-applied dedup cache so that the
 `miner_setMaxDASize` RPC call is only issued when the computed limits actually change between ticks.

--- a/crates/batcher/core/src/config.rs
+++ b/crates/batcher/core/src/config.rs
@@ -15,8 +15,8 @@ pub struct BatchDriverConfig {
     pub drain_timeout: Duration,
     /// When `true` and DA-backlog throttling is active, force the encoder to
     /// emit blob-typed submissions even when its configured `da_type` is
-    /// calldata. Mirrors reference batcher behavior: blobs amortise DA cost more
-    /// efficiently when the L1 is congested with batcher data.
+    /// calldata. Blobs amortise DA cost more efficiently when the L1 is
+    /// congested with batcher data.
     ///
     /// No-op when the encoder is already configured for blob DA.
     /// Default: `true`.

--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -942,8 +942,7 @@ mod tests {
     }
 
     /// The submission loop must submit each pipeline submission as one L1 tx. The
-    /// pipeline is responsible for choosing the frames that belong in a tx, matching
-    /// op-batcher's `NextTxData` boundary.
+    /// pipeline is responsible for choosing the frames that belong in a transaction.
     #[test]
     fn test_submission_loop_submits_each_pipeline_submission_as_one_tx() {
         Runner::start(Config::seeded(0), |ctx| async move {
@@ -983,8 +982,8 @@ mod tests {
     }
 
     /// A single submission may contain multiple blob-filling frames when
-    /// `target_num_frames > 1`. Matching op-batcher, each frame becomes its own
-    /// blob in the same L1 transaction.
+    /// `target_num_frames > 1`. Each frame becomes its own blob in the same L1
+    /// transaction.
     #[test]
     fn test_multi_frame_blob_submission_maps_frames_to_blobs() {
         Runner::start(Config::seeded(0), |ctx| async move {

--- a/crates/batcher/core/src/submissions.rs
+++ b/crates/batcher/core/src/submissions.rs
@@ -82,7 +82,7 @@ impl<TM: TxManager> SubmissionQueue<TM> {
     ///
     /// For each available semaphore permit (= one L1 transaction), dequeues one
     /// ready submission and encodes it as a blob or calldata transaction. Blob
-    /// submissions map each frame to one blob, matching op-batcher's blob-tx shape.
+    /// submissions map each frame to one blob.
     /// Loops until the semaphore is exhausted, the pipeline has no ready submissions,
     /// or the txpool is blocked.
     ///

--- a/crates/batcher/core/src/throttle.rs
+++ b/crates/batcher/core/src/throttle.rs
@@ -1,9 +1,6 @@
 //! Throttle controller for DA backlog management.
 
 /// Configuration for the throttle controller.
-///
-/// Defaults match the reference batcher implementation:
-/// 1 MB threshold, full intensity, linear strategy.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ThrottleConfig {
     /// Backlog threshold in bytes at which throttling activates.
@@ -28,7 +25,6 @@ pub struct ThrottleConfig {
 
 impl Default for ThrottleConfig {
     fn default() -> Self {
-        // Match the reference batcher defaults.
         Self {
             threshold_bytes: 1_000_000,
             max_intensity: 1.0,

--- a/crates/batcher/encoder/src/config.rs
+++ b/crates/batcher/encoder/src/config.rs
@@ -53,7 +53,6 @@ pub struct EncoderConfig {
     /// Maximum number of L2 blocks to accumulate into one span batch.
     ///
     /// When unset, span batches close only on size and channel-duration thresholds.
-    /// Set this to match the reference batcher's `max-blocks-per-span-batch` behavior.
     ///
     /// Default: `None`.
     pub max_blocks_per_span_batch: Option<usize>,
@@ -83,7 +82,7 @@ pub struct EncoderConfig {
     /// to avoid creating a small leftover frame. Also passed to the `ShadowCompressor`
     /// as the ratio hint used when operating in [`BatchType::Single`] mode.
     ///
-    /// Default: `0.6` (matches the reference batcher's `--approx-compr-ratio` default).
+    /// Default: `0.6`.
     pub approx_compr_ratio: f64,
 
     /// Maximum serialized size of a single L1 calldata transaction in bytes.
@@ -96,7 +95,7 @@ pub struct EncoderConfig {
     /// This is a no-op when [`da_type`] is [`DaType::Blob`], since the blob size is
     /// the binding constraint for blob DA.
     ///
-    /// Default: `None` (no cap; reference batcher equivalent default is 120,000 bytes).
+    /// Default: `None` (no cap).
     ///
     /// [`max_frame_size`]: EncoderConfig::max_frame_size
     /// [`da_type`]: EncoderConfig::da_type

--- a/crates/batcher/encoder/src/encoder.rs
+++ b/crates/batcher/encoder/src/encoder.rs
@@ -627,9 +627,7 @@ impl BatchPipeline for BatchEncoder {
                 }
 
                 // Estimate the compressed size of the accumulated span batch and close
-                // the channel when it would exceed the configured size budget. This mirrors
-                // the reference batcher's `SpanChannelOut`, which triggers closure based on estimated
-                // compressed size rather than waiting for a timeout.
+                // the channel when it would exceed the configured size budget.
                 //
                 // Each block contributes fixed-field overhead plus its raw transaction bytes.
                 // The compressed estimate uses the same ratio as the ShadowCompressor so that

--- a/crates/batcher/service/src/config.rs
+++ b/crates/batcher/service/src/config.rs
@@ -104,8 +104,6 @@ pub struct BatcherConfig {
     pub admin_addr: Option<SocketAddr>,
     /// If `true`, start in a stopped state and defer batch submission until
     /// `admin_startBatcher` is called via the admin API.
-    ///
-    /// Matches the reference batcher's `--stopped` behavior (env: `BATCHER_STOPPED`).
     pub stopped: bool,
     /// If `true`, block startup until the rollup node reports a non-zero
     /// `unsafe_l2` and `current_l1` head via `optimism_syncStatus`.

--- a/crates/batcher/service/src/config.rs
+++ b/crates/batcher/service/src/config.rs
@@ -87,13 +87,13 @@ pub struct BatcherConfig {
     pub resubmission_timeout: Duration,
     /// Throttle configuration (optional).
     pub throttle: Option<ThrottleConfig>,
-    /// Number of recent L1 blocks to scan on startup for already-submitted batcher frames.
+    /// Number of recent L1 blocks to inspect for a confirmed batcher transaction.
     ///
-    /// When nonzero, the service walks back this many blocks from the current L1 head
-    /// on startup, decodes any calldata batcher frames it finds, and advances the L2
-    /// block cursor past data already pending on L1. This avoids re-submitting frames
-    /// that were posted but not yet reflected in the safe head after an unclean shutdown.
+    /// When [`wait_node_sync`](Self::wait_node_sync) is enabled, recent batcher
+    /// account nonce activity selects the L1 synchronization target in this window.
+    /// This never changes the L2 backfill cursor.
     ///
+    /// Must be zero unless [`wait_node_sync`](Self::wait_node_sync) is enabled.
     /// Must be at most [`MAX_CHECK_RECENT_TXS_DEPTH`](crate::MAX_CHECK_RECENT_TXS_DEPTH)
     /// (128). A value of 0 disables the scan (default).
     pub check_recent_txs_depth: u64,
@@ -105,13 +105,12 @@ pub struct BatcherConfig {
     /// If `true`, start in a stopped state and defer batch submission until
     /// `admin_startBatcher` is called via the admin API.
     pub stopped: bool,
-    /// If `true`, block startup until the rollup node reports a non-zero
-    /// `unsafe_l2` and `current_l1` head via `optimism_syncStatus`.
+    /// If `true`, block startup until the rollup node has processed the selected
+    /// L1 synchronization target.
     ///
     /// Useful when the batcher is started before the node has finished its
     /// initial sync — without this gate the initial backfill would race the
     /// node's derivation pipeline and could submit redundant data.
-    /// Matches the reference batcher's `--wait-node-sync` flag.
     pub wait_node_sync: bool,
     /// Maximum time to wait for the rollup node to report sync when
     /// [`wait_node_sync`](Self::wait_node_sync) is set.

--- a/crates/batcher/service/src/lib.rs
+++ b/crates/batcher/service/src/lib.rs
@@ -25,7 +25,7 @@ mod parity_normalizer;
 pub use parity_normalizer::{ParityComparator, ParityNormalizer};
 
 mod recent_txs;
-pub use recent_txs::{MAX_CHECK_RECENT_TXS_DEPTH, RecentTxScanner, SCAN_FETCH_CONCURRENCY};
+pub use recent_txs::{MAX_CHECK_RECENT_TXS_DEPTH, recent_tx_sync_target};
 
 mod source;
 pub use source::RpcPollingSource;

--- a/crates/batcher/service/src/lib.rs
+++ b/crates/batcher/service/src/lib.rs
@@ -25,7 +25,7 @@ mod parity_normalizer;
 pub use parity_normalizer::{ParityComparator, ParityNormalizer};
 
 mod recent_txs;
-pub use recent_txs::{MAX_CHECK_RECENT_TXS_DEPTH, recent_tx_sync_target};
+pub use recent_txs::{MAX_CHECK_RECENT_TXS_DEPTH, RecentTxSyncTarget};
 
 mod source;
 pub use source::RpcPollingSource;

--- a/crates/batcher/service/src/recent_txs.rs
+++ b/crates/batcher/service/src/recent_txs.rs
@@ -8,67 +8,70 @@ use tracing::{info, warn};
 /// Maximum depth allowed for the recent-transaction startup scan.
 pub const MAX_CHECK_RECENT_TXS_DEPTH: u64 = 128;
 
-/// Returns an L1 synchronization target based on recent batcher transactions.
-///
-/// The result never changes the L2 backfill cursor.
-pub async fn recent_tx_sync_target(
-    l1_provider: &RootProvider,
-    batcher_address: Address,
-    depth: u64,
-) -> eyre::Result<u64> {
-    let current_l1 = l1_provider
-        .get_block_number()
-        .await
-        .map_err(|e| eyre::eyre!("failed to fetch L1 head for recent tx scan: {e}"))?;
-    let oldest_l1 = current_l1.saturating_sub(depth);
+/// Selects the L1 synchronization target from recent batcher transactions.
+#[derive(Debug)]
+pub struct RecentTxSyncTarget;
 
-    let current_nonce = nonce_at(l1_provider, batcher_address, current_l1).await?;
-    let oldest_nonce = nonce_at(l1_provider, batcher_address, oldest_l1).await?;
+impl RecentTxSyncTarget {
+    /// Returns an L1 synchronization target based on recent batcher transactions.
+    ///
+    /// The result never changes the L2 backfill cursor.
+    pub async fn find(
+        l1_provider: &RootProvider,
+        batcher_address: Address,
+        depth: u64,
+    ) -> eyre::Result<u64> {
+        let current_l1 = l1_provider
+            .get_block_number()
+            .await
+            .map_err(|e| eyre::eyre!("failed to fetch L1 head for recent tx scan: {e}"))?;
+        let oldest_l1 = current_l1.saturating_sub(depth);
+        let nonce_at = |block_number| async move {
+            l1_provider
+                .get_transaction_count(batcher_address)
+                .block_id(BlockNumberOrTag::Number(block_number).into())
+                .await
+                .map_err(|e| {
+                    eyre::eyre!("failed to fetch batcher nonce at L1 block {block_number}: {e}")
+                })
+        };
 
-    if oldest_nonce > current_nonce {
-        warn!(target_l1 = %current_l1, "L1 changed during recent transaction scan");
-        return Ok(current_l1);
-    }
+        let current_nonce = nonce_at(current_l1).await?;
+        let oldest_nonce = nonce_at(oldest_l1).await?;
 
-    if oldest_nonce == current_nonce {
-        info!(
-            scan_start = %oldest_l1,
-            scan_end = %current_l1,
-            "no recent batcher transaction found on L1"
-        );
-        return Ok(oldest_l1);
-    }
-
-    let mut low = oldest_l1.saturating_add(1);
-    let mut high = current_l1;
-    while low < high {
-        let mid = low + (high - low) / 2;
-        let nonce = nonce_at(l1_provider, batcher_address, mid).await?;
-        if nonce > current_nonce {
+        if oldest_nonce > current_nonce {
             warn!(target_l1 = %current_l1, "L1 changed during recent transaction scan");
             return Ok(current_l1);
         }
-        if nonce == current_nonce {
-            high = mid;
-        } else {
-            low = mid.saturating_add(1);
+
+        if oldest_nonce == current_nonce {
+            info!(
+                scan_start = %oldest_l1,
+                scan_end = %current_l1,
+                "no recent batcher transaction found on L1"
+            );
+            return Ok(oldest_l1);
         }
+
+        let mut low = oldest_l1.saturating_add(1);
+        let mut high = current_l1;
+        while low < high {
+            let mid = low + (high - low) / 2;
+            let nonce = nonce_at(mid).await?;
+            if nonce > current_nonce {
+                warn!(target_l1 = %current_l1, "L1 changed during recent transaction scan");
+                return Ok(current_l1);
+            }
+            if nonce == current_nonce {
+                high = mid;
+            } else {
+                low = mid.saturating_add(1);
+            }
+        }
+
+        info!(l1_block = %low, "found latest batcher transaction in recent L1 window");
+        Ok(low)
     }
-
-    info!(l1_block = %low, "found latest batcher transaction in recent L1 window");
-    Ok(low)
-}
-
-async fn nonce_at(
-    l1_provider: &RootProvider,
-    batcher_address: Address,
-    block_number: u64,
-) -> eyre::Result<u64> {
-    l1_provider
-        .get_transaction_count(batcher_address)
-        .block_id(BlockNumberOrTag::Number(block_number).into())
-        .await
-        .map_err(|e| eyre::eyre!("failed to fetch batcher nonce at L1 block {block_number}: {e}"))
 }
 
 #[cfg(test)]
@@ -77,7 +80,7 @@ mod tests {
     use alloy_provider::RootProvider;
     use httpmock::prelude::*;
 
-    use super::recent_tx_sync_target;
+    use super::RecentTxSyncTarget;
 
     async fn mock_rpc(server: &MockServer, request: String, id: u64, result: &str) {
         let response = format!(r#"{{"jsonrpc":"2.0","id":{id},"result":"{result}"}}"#);
@@ -89,28 +92,63 @@ mod tests {
             .await;
     }
 
+    fn nonce_request(address: &str, block: &str) -> String {
+        format!(r#"{{"method":"eth_getTransactionCount","params":["{address}","{block}"]}}"#)
+    }
+
     #[tokio::test]
     async fn finds_block_where_current_nonce_was_reached() {
         let server = MockServer::start_async().await;
-        let address = Address::ZERO;
-        let address = format!("{address:#x}");
+        let address = format!("{:#x}", Address::ZERO);
 
         mock_rpc(&server, r#"{"method":"eth_blockNumber"}"#.into(), 0, "0xa").await;
         for (id, block, nonce) in
             [(1, "0xa", "0x3"), (2, "0x5", "0x1"), (3, "0x8", "0x2"), (4, "0x9", "0x3")]
         {
-            mock_rpc(
-                &server,
-                format!(
-                    r#"{{"method":"eth_getTransactionCount","params":["{address}","{block}"]}}"#
-                ),
-                id,
-                nonce,
-            )
-            .await;
+            mock_rpc(&server, nonce_request(&address, block), id, nonce).await;
         }
 
         let provider = RootProvider::new_http(server.url("/").parse().unwrap());
-        assert_eq!(recent_tx_sync_target(&provider, Address::ZERO, 5).await.unwrap(), 9);
+        assert_eq!(RecentTxSyncTarget::find(&provider, Address::ZERO, 5).await.unwrap(), 9);
+    }
+
+    #[tokio::test]
+    async fn uses_oldest_block_when_no_recent_transaction_exists() {
+        let server = MockServer::start_async().await;
+        let address = format!("{:#x}", Address::ZERO);
+
+        mock_rpc(&server, r#"{"method":"eth_blockNumber"}"#.into(), 0, "0xa").await;
+        mock_rpc(&server, nonce_request(&address, "0xa"), 1, "0x3").await;
+        mock_rpc(&server, nonce_request(&address, "0x5"), 2, "0x3").await;
+
+        let provider = RootProvider::new_http(server.url("/").parse().unwrap());
+        assert_eq!(RecentTxSyncTarget::find(&provider, Address::ZERO, 5).await.unwrap(), 5);
+    }
+
+    #[tokio::test]
+    async fn uses_head_when_endpoint_nonces_are_inconsistent() {
+        let server = MockServer::start_async().await;
+        let address = format!("{:#x}", Address::ZERO);
+
+        mock_rpc(&server, r#"{"method":"eth_blockNumber"}"#.into(), 0, "0xa").await;
+        mock_rpc(&server, nonce_request(&address, "0xa"), 1, "0x2").await;
+        mock_rpc(&server, nonce_request(&address, "0x5"), 2, "0x3").await;
+
+        let provider = RootProvider::new_http(server.url("/").parse().unwrap());
+        assert_eq!(RecentTxSyncTarget::find(&provider, Address::ZERO, 5).await.unwrap(), 10);
+    }
+
+    #[tokio::test]
+    async fn uses_head_when_binary_search_nonce_is_inconsistent() {
+        let server = MockServer::start_async().await;
+        let address = format!("{:#x}", Address::ZERO);
+
+        mock_rpc(&server, r#"{"method":"eth_blockNumber"}"#.into(), 0, "0xa").await;
+        mock_rpc(&server, nonce_request(&address, "0xa"), 1, "0x3").await;
+        mock_rpc(&server, nonce_request(&address, "0x5"), 2, "0x1").await;
+        mock_rpc(&server, nonce_request(&address, "0x8"), 3, "0x4").await;
+
+        let provider = RootProvider::new_http(server.url("/").parse().unwrap());
+        assert_eq!(RecentTxSyncTarget::find(&provider, Address::ZERO, 5).await.unwrap(), 10);
     }
 }

--- a/crates/batcher/service/src/recent_txs.rs
+++ b/crates/batcher/service/src/recent_txs.rs
@@ -26,6 +26,13 @@ impl RecentTxSyncTarget {
             .await
             .map_err(|e| eyre::eyre!("failed to fetch L1 head for recent tx scan: {e}"))?;
         let oldest_l1 = current_l1.saturating_sub(depth);
+        info!(
+            depth = %depth,
+            scan_start = %oldest_l1,
+            scan_end = %current_l1,
+            batcher = %batcher_address,
+            "scanning recent L1 blocks for batcher nonce activity"
+        );
         let nonce_at = |block_number| async move {
             l1_provider
                 .get_transaction_count(batcher_address)

--- a/crates/batcher/service/src/recent_txs.rs
+++ b/crates/batcher/service/src/recent_txs.rs
@@ -1,329 +1,116 @@
-//! Startup scan of recent L1 blocks for submitted batcher frames.
-
-use std::collections::HashMap;
+//! Startup scan for recent L1 transactions from the batcher account.
 
 use alloy_primitives::Address;
 use alloy_provider::{Provider, RootProvider};
-use alloy_rpc_types_eth::{BlockNumberOrTag, TransactionTrait};
-use base_common_genesis::RollupConfig;
-use base_protocol::{Batch, BatchReader, BlockInfo, Channel, ChannelId, Frame};
-use futures::StreamExt;
-use tracing::{debug, info};
+use alloy_rpc_types_eth::BlockNumberOrTag;
+use tracing::{info, warn};
 
 /// Maximum depth allowed for the recent-transaction startup scan.
-///
-/// Matches the limit used by the reference batcher's `--check-recent-txs-depth` flag.
 pub const MAX_CHECK_RECENT_TXS_DEPTH: u64 = 128;
 
-/// Maximum number of L1 block fetches in flight during the startup scan.
+/// Returns an L1 synchronization target based on recent batcher transactions.
 ///
-/// Bounds peak memory to roughly this many full L1 blocks while still
-/// achieving significant speedup over sequential fetching.
-pub const SCAN_FETCH_CONCURRENCY: usize = 16;
+/// The result never changes the L2 backfill cursor.
+pub async fn recent_tx_sync_target(
+    l1_provider: &RootProvider,
+    batcher_address: Address,
+    depth: u64,
+) -> eyre::Result<u64> {
+    let current_l1 = l1_provider
+        .get_block_number()
+        .await
+        .map_err(|e| eyre::eyre!("failed to fetch L1 head for recent tx scan: {e}"))?;
+    let oldest_l1 = current_l1.saturating_sub(depth);
 
-/// Scans recent L1 blocks on startup to find the highest submitted L2 block.
-///
-/// When the batcher restarts after an unclean shutdown, in-memory channel state
-/// is lost. `RecentTxScanner` compensates by reading the last N L1 blocks and
-/// decoding any calldata batcher frames sent from the batcher address to the
-/// batch inbox. Complete channels are decoded to determine the highest L2 block
-/// number already submitted but not yet reflected in the safe head, allowing
-/// the block cursor to be advanced accordingly and preventing re-submissions.
-#[derive(Debug)]
-pub struct RecentTxScanner;
+    let current_nonce = nonce_at(l1_provider, batcher_address, current_l1).await?;
+    let oldest_nonce = nonce_at(l1_provider, batcher_address, oldest_l1).await?;
 
-impl RecentTxScanner {
-    /// Scans the last `depth` L1 blocks for batcher transactions and returns
-    /// the highest L2 block number covered, or `None` if no complete batcher
-    /// channels were found.
-    ///
-    /// Only calldata transactions are decoded (those beginning with
-    /// `DERIVATION_VERSION_0`). Blob transactions are identified by their
-    /// empty calldata and skipped — their frame data resides in KZG sidecars
-    /// that would require a separate fetch not supported by this scanner.
-    ///
-    /// **Limitation:** channels whose opening frame falls before the scan window
-    /// are never completed and will be silently missed. The caller should treat
-    /// the result as a best-effort lower bound, not a guarantee.
-    pub async fn highest_submitted_l2_block(
-        l1_provider: &RootProvider,
-        batcher_address: Address,
-        batch_inbox: Address,
-        depth: u64,
-        rollup_config: &RollupConfig,
-    ) -> eyre::Result<Option<u64>> {
-        let current_l1 = l1_provider
-            .get_block_number()
-            .await
-            .map_err(|e| eyre::eyre!("failed to fetch L1 head for recent tx scan: {e}"))?;
-        let scan_start = current_l1.saturating_sub(depth.saturating_sub(1));
+    if oldest_nonce > current_nonce {
+        warn!(target_l1 = %current_l1, "L1 changed during recent transaction scan");
+        return Ok(current_l1);
+    }
 
+    if oldest_nonce == current_nonce {
         info!(
-            depth = %depth,
-            scan_start = %scan_start,
+            scan_start = %oldest_l1,
             scan_end = %current_l1,
-            batcher = %batcher_address,
-            inbox = %batch_inbox,
-            "scanning recent L1 blocks for submitted batcher frames"
+            "no recent batcher transaction found on L1"
         );
+        return Ok(oldest_l1);
+    }
 
-        let mut channels: HashMap<ChannelId, Channel> = HashMap::new();
-        let mut highest_l2: Option<u64> = None;
-
-        // Fetch blocks in parallel with bounded concurrency, preserving L1 order.
-        // Blocks are processed as the stream yields them so peak memory is
-        // bounded by the concurrency limit (~16 blocks) rather than the full
-        // scan depth (~128 blocks).
-        let block_stream = futures::stream::iter(scan_start..=current_l1)
-            .map(|block_num| {
-                let provider = l1_provider.clone();
-                async move {
-                    let block = provider
-                        .get_block_by_number(BlockNumberOrTag::Number(block_num))
-                        .full()
-                        .await
-                        .map_err(|e| eyre::eyre!("failed to fetch L1 block {block_num}: {e}"))?;
-                    eyre::Ok((block_num, block))
-                }
-            })
-            .buffered(SCAN_FETCH_CONCURRENCY);
-        futures::pin_mut!(block_stream);
-
-        while let Some(result) = block_stream.next().await {
-            let (block_num, block) = result?;
-            let block = match block {
-                Some(b) => b,
-                None => {
-                    debug!(block = %block_num, "L1 block not found during recent tx scan");
-                    continue;
-                }
-            };
-
-            let block_info = BlockInfo {
-                hash: block.header.hash,
-                number: block_num,
-                parent_hash: block.header.inner.parent_hash,
-                timestamp: block.header.inner.timestamp,
-            };
-
-            for tx in block.transactions.txns() {
-                if tx.inner.signer() != batcher_address {
-                    continue;
-                }
-                if tx.inner.to() != Some(batch_inbox) {
-                    continue;
-                }
-
-                // Only parse calldata (version-0) frames. Blob transactions have
-                // empty or absent calldata and will fail parse_frames gracefully.
-                let frames = match Frame::parse_frames(tx.inner.input()) {
-                    Ok(f) => f,
-                    Err(_) => continue,
-                };
-
-                for frame in frames {
-                    let channel = channels
-                        .entry(frame.id)
-                        .or_insert_with(|| Channel::new(frame.id, block_info));
-                    if let Err(e) = channel.add_frame(frame, block_info) {
-                        debug!(error = %e, "ignoring rejected batcher frame during recent tx scan");
-                    }
-                }
-            }
-
-            // Drain channels that became complete within this block.
-            let complete_ids: Vec<ChannelId> =
-                channels.iter().filter(|(_, ch)| ch.is_ready()).map(|(id, _)| *id).collect();
-            for id in complete_ids {
-                if let Some(ch) = channels.remove(&id) {
-                    Self::decode_channel(&ch, block_info.timestamp, rollup_config, &mut highest_l2);
-                }
-            }
+    let mut low = oldest_l1.saturating_add(1);
+    let mut high = current_l1;
+    while low < high {
+        let mid = low + (high - low) / 2;
+        let nonce = nonce_at(l1_provider, batcher_address, mid).await?;
+        if nonce > current_nonce {
+            warn!(target_l1 = %current_l1, "L1 changed during recent transaction scan");
+            return Ok(current_l1);
         }
-
-        if let Some(block) = highest_l2 {
-            info!(highest_l2 = %block, "recent tx scan found highest submitted L2 block");
+        if nonce == current_nonce {
+            high = mid;
         } else {
-            info!("recent tx scan found no submitted batcher frames");
-        }
-
-        Ok(highest_l2)
-    }
-
-    /// Decodes all batches from a complete channel and updates `highest_l2` with
-    /// the maximum L2 block number found.
-    fn decode_channel(
-        channel: &Channel,
-        inclusion_timestamp: u64,
-        rollup_config: &RollupConfig,
-        highest_l2: &mut Option<u64>,
-    ) {
-        let Some(data) = channel.frame_data() else { return };
-        let max_rlp = rollup_config.max_rlp_bytes_per_channel(inclusion_timestamp) as usize;
-        let brotli_supported = rollup_config.is_fjord_active(inclusion_timestamp);
-        let mut reader = BatchReader::new(data.to_vec(), max_rlp, brotli_supported);
-        while let Some(batch) = reader.next_batch(rollup_config) {
-            let last_timestamp = match &batch {
-                Batch::Single(sb) => sb.timestamp,
-                Batch::Span(sb) => sb.final_timestamp(),
-            };
-            let relative = rollup_config.block_number_lower_bound_from_timestamp(last_timestamp);
-            let l2_block = rollup_config.genesis.l2.number + relative;
-            *highest_l2 = Some(highest_l2.map_or(l2_block, |h| h.max(l2_block)));
+            low = mid.saturating_add(1);
         }
     }
+
+    info!(l1_block = %low, "found latest batcher transaction in recent L1 window");
+    Ok(low)
+}
+
+async fn nonce_at(
+    l1_provider: &RootProvider,
+    batcher_address: Address,
+    block_number: u64,
+) -> eyre::Result<u64> {
+    l1_provider
+        .get_transaction_count(batcher_address)
+        .block_id(BlockNumberOrTag::Number(block_number).into())
+        .await
+        .map_err(|e| eyre::eyre!("failed to fetch batcher nonce at L1 block {block_number}: {e}"))
 }
 
 #[cfg(test)]
 mod tests {
-    use alloy_eips::eip1898::BlockNumHash;
-    use alloy_primitives::B256;
-    use alloy_rlp::Encodable;
-    use base_common_genesis::{ChainGenesis, RollupConfig};
-    use base_protocol::{Batch, BlockInfo, Channel, ChannelId, Frame, SingleBatch};
+    use alloy_primitives::Address;
+    use alloy_provider::RootProvider;
+    use httpmock::prelude::*;
 
-    use super::RecentTxScanner;
+    use super::recent_tx_sync_target;
 
-    /// Build a [`RollupConfig`] with controllable genesis parameters for tests.
-    fn test_rollup_config(
-        genesis_l2_number: u64,
-        genesis_l2_time: u64,
-        block_time: u64,
-    ) -> RollupConfig {
-        RollupConfig {
-            genesis: ChainGenesis {
-                l2: BlockNumHash { number: genesis_l2_number, hash: B256::ZERO },
-                l2_time: genesis_l2_time,
-                ..Default::default()
-            },
-            block_time,
-            ..Default::default()
+    async fn mock_rpc(server: &MockServer, request: String, id: u64, result: &str) {
+        let response = format!(r#"{{"jsonrpc":"2.0","id":{id},"result":"{result}"}}"#);
+        server
+            .mock_async(move |when, then| {
+                when.method(POST).path("/").json_body_includes(request.as_str());
+                then.status(200).header("content-type", "application/json").body(response);
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn finds_block_where_current_nonce_was_reached() {
+        let server = MockServer::start_async().await;
+        let address = Address::ZERO;
+        let address = format!("{address:#x}");
+
+        mock_rpc(&server, r#"{"method":"eth_blockNumber"}"#.into(), 0, "0xa").await;
+        for (id, block, nonce) in
+            [(1, "0xa", "0x3"), (2, "0x5", "0x1"), (3, "0x8", "0x2"), (4, "0x9", "0x3")]
+        {
+            mock_rpc(
+                &server,
+                format!(
+                    r#"{{"method":"eth_getTransactionCount","params":["{address}","{block}"]}}"#
+                ),
+                id,
+                nonce,
+            )
+            .await;
         }
-    }
 
-    /// Encode a `SingleBatch` into the zlib-compressed channel frame data format
-    /// that `BatchReader` expects:
-    ///   `zlib_compress`( `rlp_bytes`( `batch_type_byte` ++ `rlp_encode(SingleBatch)` ) )
-    fn encode_single_batch(batch: &SingleBatch) -> Vec<u8> {
-        // Batch-level encoding: type byte + RLP body.
-        let typed_batch = Batch::Single(batch.clone());
-        let mut batch_bytes = Vec::new();
-        typed_batch.encode(&mut batch_bytes).expect("batch must encode");
-
-        // Wrap as RLP byte string (how ChannelOut wraps it before compressing).
-        let mut rlp_buf = Vec::new();
-        batch_bytes.as_slice().encode(&mut rlp_buf);
-
-        // Compress with zlib (produces a stream whose first byte has lower nibble 0x8,
-        // matching the ZLIB_DEFLATE_COMPRESSION_METHOD check in BatchReader::decompress).
-        miniz_oxide::deflate::compress_to_vec_zlib(&rlp_buf, 6)
-    }
-
-    /// Create a single-frame channel whose frame data is `payload`.
-    fn single_frame_channel(id: ChannelId, payload: Vec<u8>) -> Channel {
-        let block_info = BlockInfo::default();
-        let mut channel = Channel::new(id, block_info);
-        let frame = Frame { id, number: 0, data: payload, is_last: true };
-        channel.add_frame(frame, block_info).expect("frame must be accepted");
-        channel
-    }
-
-    // ── decode_channel tests ─────────────────────────────────────────────────
-
-    /// A channel with no frame data (empty, non-ready channel) must produce no
-    /// output and not panic.
-    #[test]
-    fn decode_channel_no_frame_data_is_noop() {
-        let cfg = test_rollup_config(1000, 1000, 2);
-        // A channel with no frames has frame_data() == None.
-        let channel = Channel::new([0u8; 16], BlockInfo::default());
-        let mut highest = None;
-        RecentTxScanner::decode_channel(&channel, 0, &cfg, &mut highest);
-        assert_eq!(highest, None);
-    }
-
-    /// A channel containing one `SingleBatch` with a known timestamp must yield
-    /// the correct L2 block number.
-    #[test]
-    fn decode_channel_single_batch_computes_correct_l2_block() {
-        // genesis at L2 block 1000, timestamp 1000, 2-second blocks.
-        // batch timestamp 1010 → relative block 5 → L2 block 1005.
-        let cfg = test_rollup_config(1000, 1000, 2);
-        let batch = SingleBatch { timestamp: 1010, ..Default::default() };
-
-        let id: ChannelId = [1u8; 16];
-        let channel = single_frame_channel(id, encode_single_batch(&batch));
-
-        let mut highest = None;
-        RecentTxScanner::decode_channel(&channel, 0, &cfg, &mut highest);
-        assert_eq!(highest, Some(1005));
-    }
-
-    /// When the channel contains multiple batches, `decode_channel` must track
-    /// the maximum L2 block across all of them.
-    #[test]
-    fn decode_channel_multiple_batches_returns_highest() {
-        let cfg = test_rollup_config(1000, 1000, 2);
-
-        // Encode two batches into the same compressed payload.
-        // batch A: timestamp 1010 → block 1005
-        // batch B: timestamp 1020 → block 1010
-        let batch_a = SingleBatch { timestamp: 1010, ..Default::default() };
-        let batch_b = SingleBatch { timestamp: 1020, ..Default::default() };
-
-        // Encode both into a single byte stream the way ChannelOut would:
-        // rlp_bytes(batchA) ++ rlp_bytes(batchB), then zlib-compress.
-        let mut combined = Vec::new();
-        let mut a_encoded = Vec::new();
-        Batch::Single(batch_a).encode(&mut a_encoded).unwrap();
-        a_encoded.as_slice().encode(&mut combined);
-
-        let mut b_encoded = Vec::new();
-        Batch::Single(batch_b).encode(&mut b_encoded).unwrap();
-        b_encoded.as_slice().encode(&mut combined);
-
-        let compressed = miniz_oxide::deflate::compress_to_vec_zlib(&combined, 6);
-
-        let id: ChannelId = [2u8; 16];
-        let channel = single_frame_channel(id, compressed);
-
-        let mut highest = None;
-        RecentTxScanner::decode_channel(&channel, 0, &cfg, &mut highest);
-        assert_eq!(highest, Some(1010));
-    }
-
-    /// `decode_channel` must not update `highest_l2` when the channel data is
-    /// corrupted and `BatchReader` fails to produce any batches.
-    #[test]
-    fn decode_channel_corrupted_data_is_silently_skipped() {
-        let cfg = test_rollup_config(1000, 1000, 2);
-
-        // Craft a payload whose first byte looks like zlib (0x78) but whose body
-        // is garbage, so decompression fails and next_batch returns None.
-        let junk = vec![0x78u8, 0x9c, 0xde, 0xad, 0xbe, 0xef];
-
-        let id: ChannelId = [3u8; 16];
-        let channel = single_frame_channel(id, junk);
-
-        let mut highest = Some(42);
-        RecentTxScanner::decode_channel(&channel, 0, &cfg, &mut highest);
-        // The existing value must be preserved — no panics, no reset.
-        assert_eq!(highest, Some(42));
-    }
-
-    /// `decode_channel` must not lower an existing `highest_l2` value: when a
-    /// channel yields a block number below the current maximum, the maximum wins.
-    #[test]
-    fn decode_channel_does_not_lower_existing_highest() {
-        let cfg = test_rollup_config(1000, 1000, 2);
-        let batch = SingleBatch { timestamp: 1010, ..Default::default() };
-
-        let id: ChannelId = [4u8; 16];
-        let channel = single_frame_channel(id, encode_single_batch(&batch));
-
-        // Pre-seed with a higher block number (2000 > 1005).
-        let mut highest = Some(2000u64);
-        RecentTxScanner::decode_channel(&channel, 0, &cfg, &mut highest);
-        assert_eq!(highest, Some(2000));
+        let provider = RootProvider::new_http(server.url("/").parse().unwrap());
+        assert_eq!(recent_tx_sync_target(&provider, Address::ZERO, 5).await.unwrap(), 9);
     }
 }

--- a/crates/batcher/service/src/service.rs
+++ b/crates/batcher/service/src/service.rs
@@ -30,12 +30,13 @@ use url::Url;
 
 use crate::{
     BatcherConfig, L2BlockParityMonitor, L2BlockParityMonitorConfig, MAX_CHECK_RECENT_TXS_DEPTH,
-    NullL1HeadSubscription, NullSubscription, RecentTxScanner, RpcL1HeadPollingSource,
-    RpcL2BlockProvider, RpcPollingSource, RpcThrottleClient, SafeHeadPoller, ShadowParityMonitor,
-    ShadowParityMonitorConfig, WsBlockSubscription, WsL1HeadSubscription,
+    NullL1HeadSubscription, NullSubscription, RpcL1HeadPollingSource, RpcL2BlockProvider,
+    RpcPollingSource, RpcThrottleClient, SafeHeadPoller, ShadowParityMonitor,
+    ShadowParityMonitorConfig, WsBlockSubscription, WsL1HeadSubscription, recent_tx_sync_target,
 };
 
 const WEI_PER_ETHER: f64 = 1_000_000_000_000_000_000.0;
+const MAX_SHADOW_PARITY_START_DEPTH: u64 = 128;
 
 /// Service-internal throttle client variant: either a no-op or an RPC client.
 ///
@@ -349,90 +350,59 @@ impl BatcherService {
         ))
     }
 
-    /// Block until the rollup node reports a non-zero sync status, or until
-    /// `timeout` elapses.
+    /// Block until the rollup node has processed `target_l1`, or until `timeout` elapses.
     ///
-    /// Polls `optimism_syncStatus` on `poll_interval` and returns once both
-    /// `current_l1.number` and `unsafe_l2.block_info.number` are non-zero.
-    /// RPC errors are logged and retried with exponential backoff (capped at
-    /// 30 seconds) so a permanently-broken endpoint is not hammered at the
-    /// poll cadence. Returns an error when `timeout` is exceeded so operators
-    /// see an explicit failure rather than a silent hang.
+    /// RPC errors use exponential backoff capped at 30 seconds.
     async fn wait_for_node_sync(
         rollup_client: &HttpClient,
+        target_l1: u64,
         poll_interval: std::time::Duration,
         timeout: std::time::Duration,
     ) -> eyre::Result<()> {
-        // Cap RPC-error backoff so a broken endpoint backs off but eventually
-        // recovers within a reasonable window.
         const MAX_ERROR_BACKOFF: std::time::Duration = std::time::Duration::from_secs(30);
 
         info!(
+            target_l1 = %target_l1,
             timeout_secs = %timeout.as_secs(),
-            "waiting for rollup node to report a non-zero sync status"
+            "waiting for rollup node to process L1 target"
         );
-        let deadline = std::time::Instant::now() + timeout;
-        let mut error_backoff = poll_interval;
-        loop {
-            match rollup_client.sync_status().await {
-                Ok(status)
-                    if status.current_l1.number > 0 && status.unsafe_l2.block_info.number > 0 =>
-                {
-                    info!(
-                        current_l1 = %status.current_l1.number,
-                        unsafe_l2 = %status.unsafe_l2.block_info.number,
-                        safe_l2 = %status.safe_l2.block_info.number,
-                        "rollup node reports sync, proceeding with batcher startup"
-                    );
-                    return Ok(());
-                }
-                Ok(status) => {
-                    // Reset error backoff: the RPC is responsive, the node
-                    // just hasn't produced/derived blocks yet.
-                    error_backoff = poll_interval;
-                    info!(
-                        current_l1 = %status.current_l1.number,
-                        unsafe_l2 = %status.unsafe_l2.block_info.number,
-                        "rollup node not yet synced, waiting"
-                    );
-                    Self::sleep_or_timeout(poll_interval, deadline).await?;
-                }
-                Err(e) => {
-                    warn!(
-                        error = %e,
-                        backoff_secs = %error_backoff.as_secs(),
-                        "optimism_syncStatus RPC failed during wait, backing off"
-                    );
-                    Self::sleep_or_timeout(error_backoff, deadline).await?;
-                    error_backoff = (error_backoff * 2).min(MAX_ERROR_BACKOFF);
+        let wait = async {
+            let mut error_backoff = poll_interval;
+            loop {
+                match rollup_client.sync_status().await {
+                    Ok(status) if status.current_l1.number >= target_l1 => {
+                        info!(
+                            current_l1 = %status.current_l1.number,
+                            unsafe_l2 = %status.unsafe_l2.block_info.number,
+                            safe_l2 = %status.safe_l2.block_info.number,
+                            "rollup node reports sync, proceeding with batcher startup"
+                        );
+                        return;
+                    }
+                    Ok(status) => {
+                        error_backoff = poll_interval;
+                        info!(
+                            target_l1 = %target_l1,
+                            current_l1 = %status.current_l1.number,
+                            "rollup node not yet synced, waiting"
+                        );
+                        tokio::time::sleep(poll_interval).await;
+                    }
+                    Err(error) => {
+                        warn!(
+                            error = %error,
+                            backoff_secs = %error_backoff.as_secs(),
+                            "optimism_syncStatus RPC failed during wait, backing off"
+                        );
+                        tokio::time::sleep(error_backoff).await;
+                        error_backoff = (error_backoff * 2).min(MAX_ERROR_BACKOFF);
+                    }
                 }
             }
-        }
-    }
-
-    /// Sleep for `dur` or until `deadline`, whichever is sooner.
-    ///
-    /// Returns `Err` if the deadline is reached before or during the sleep so
-    /// callers surface a single timeout error rather than silently looping
-    /// past the deadline.
-    async fn sleep_or_timeout(
-        dur: std::time::Duration,
-        deadline: std::time::Instant,
-    ) -> eyre::Result<()> {
-        let now = std::time::Instant::now();
-        if now >= deadline {
-            return Err(eyre::eyre!(
-                "wait_for_node_sync timed out before the rollup node reported a non-zero sync status"
-            ));
-        }
-        let remaining = deadline - now;
-        tokio::time::sleep(dur.min(remaining)).await;
-        if std::time::Instant::now() >= deadline {
-            return Err(eyre::eyre!(
-                "wait_for_node_sync timed out before the rollup node reported a non-zero sync status"
-            ));
-        }
-        Ok(())
+        };
+        tokio::time::timeout(timeout, wait)
+            .await
+            .map_err(|_| eyre::eyre!("wait_for_node_sync timed out"))
     }
 
     /// Initialise all batcher components and return a [`ReadyBatcher`].
@@ -463,6 +433,16 @@ impl BatcherService {
         }
         if self.config.rollup_rpc_url.is_empty() {
             eyre::bail!("at least one rollup RPC endpoint is required");
+        }
+        if self.config.check_recent_txs_depth > MAX_CHECK_RECENT_TXS_DEPTH {
+            eyre::bail!(
+                "check_recent_txs_depth {} exceeds maximum of {}",
+                self.config.check_recent_txs_depth,
+                MAX_CHECK_RECENT_TXS_DEPTH,
+            );
+        }
+        if self.config.check_recent_txs_depth > 0 && !self.config.wait_node_sync {
+            eyre::bail!("check_recent_txs_depth requires wait_node_sync");
         }
 
         let signer_config = self
@@ -549,11 +529,35 @@ impl BatcherService {
             );
         }
 
-        // Optionally block startup until the rollup node reports a non-zero
-        // sync status. Mirrors the reference batcher's `--wait-node-sync`.
+        // Connect to L1 before the optional node-sync gate.
+        let l1_provider: RootProvider =
+            Self::connect_first(&self.config.l1_rpc_url, "l1-rpc", |url| {
+                let url = url.clone();
+                async move {
+                    ProviderBuilder::new().disable_recommended_fillers().connect(url.as_str()).await
+                }
+            })
+            .await?;
+
+        // Recent transactions only select an L1 synchronization target.
+        // They never advance the L2 backfill cursor.
         if self.config.wait_node_sync {
+            let target_l1 = if self.config.check_recent_txs_depth > 0 {
+                recent_tx_sync_target(
+                    &l1_provider,
+                    signer_address,
+                    self.config.check_recent_txs_depth,
+                )
+                .await?
+            } else {
+                l1_provider
+                    .get_block_number()
+                    .await
+                    .map_err(|e| eyre::eyre!("failed to fetch L1 sync target: {e}"))?
+            };
             Self::wait_for_node_sync(
                 &rollup_client,
+                target_l1,
                 self.config.poll_interval,
                 self.config.wait_node_sync_timeout,
             )
@@ -570,26 +574,6 @@ impl BatcherService {
             sync_status.safe_l2.block_info.timestamp.saturating_add(rollup_config.block_time);
         self.config.encoder_config.validate_for_rollup_config(&rollup_config, next_l2_timestamp)?;
         info!(safe_l2 = %safe_l2_number, "fetched safe L2 head");
-
-        // Validate the recent-tx scan depth against the maximum. Do this early so
-        // the error surfaces before any network I/O for the scan.
-        if self.config.check_recent_txs_depth > MAX_CHECK_RECENT_TXS_DEPTH {
-            return Err(eyre::eyre!(
-                "check_recent_txs_depth {} exceeds maximum of {}",
-                self.config.check_recent_txs_depth,
-                MAX_CHECK_RECENT_TXS_DEPTH,
-            ));
-        }
-
-        // Connect to L1 early so it is available for the optional recent-tx scan.
-        let l1_provider: RootProvider =
-            Self::connect_first(&self.config.l1_rpc_url, "l1-rpc", |url| {
-                let url = url.clone();
-                async move {
-                    ProviderBuilder::new().disable_recommended_fillers().connect(url.as_str()).await
-                }
-            })
-            .await?;
 
         if self.config.metrics_enabled {
             let (layer, mut balance_rx) = BalanceMonitorLayer::new(
@@ -633,11 +617,7 @@ impl BatcherService {
                 );
             } else {
                 let channel_timeout_depth = rollup_config.channel_timeout(next_l2_timestamp);
-                let start_depth = self
-                    .config
-                    .check_recent_txs_depth
-                    .max(channel_timeout_depth)
-                    .clamp(1, MAX_CHECK_RECENT_TXS_DEPTH);
+                let start_depth = channel_timeout_depth.clamp(1, MAX_SHADOW_PARITY_START_DEPTH);
                 let monitor_config = ShadowParityMonitorConfig {
                     canonical_inbox: rollup_config.batch_inbox_address,
                     canonical_batcher: rollup_config
@@ -720,44 +700,21 @@ impl BatcherService {
             }
         }
 
-        // Optionally scan recent L1 blocks to find the highest L2 block already
-        // submitted but not yet reflected in the safe head, preventing re-submissions
-        // after an unclean restart. Peek at the batcher address from the private key
-        // (without consuming it) only when the scan is requested.
-        let scanned_highest = if self.config.check_recent_txs_depth > 0 {
-            let batcher_address = signer_address;
-            RecentTxScanner::highest_submitted_l2_block(
-                &l1_provider,
-                batcher_address,
-                effective_batch_inbox,
-                self.config.check_recent_txs_depth,
-                &rollup_config,
-            )
-            .await?
-        } else {
-            None
-        };
-
         // Get the current L2 latest block to decide whether historical backfill is needed.
         let latest_l2 = l2_provider
             .get_block_number()
             .await
             .map_err(|e| eyre::eyre!("failed to fetch L2 latest block number: {e}"))?;
 
-        // Advance the cursor past any L2 blocks that are already on L1 but not yet safe.
-        // Use the higher of the safe head and the scan result as the backfill start.
-        let cursor_start = safe_l2_number.max(scanned_highest.unwrap_or(0));
-
-        // Build the L2 polling source. If blocks between cursor_start+1 and latest
+        // Build the L2 polling source. If blocks between the safe head and latest
         // were not yet submitted, use sequential catchup mode to avoid skipping them.
-        let poller = if cursor_start < latest_l2 {
+        let poller = if safe_l2_number < latest_l2 {
             info!(
                 safe_l2 = %safe_l2_number,
-                cursor_start = %cursor_start,
                 latest_l2 = %latest_l2,
-                "starting sequential backfill from cursor"
+                "starting sequential backfill from safe head"
             );
-            RpcPollingSource::new_from(Arc::clone(&l2_provider), cursor_start + 1)
+            RpcPollingSource::new_from(Arc::clone(&l2_provider), safe_l2_number.saturating_add(1))
         } else {
             RpcPollingSource::new(Arc::clone(&l2_provider))
         };

--- a/crates/batcher/service/src/service.rs
+++ b/crates/batcher/service/src/service.rs
@@ -30,9 +30,9 @@ use url::Url;
 
 use crate::{
     BatcherConfig, L2BlockParityMonitor, L2BlockParityMonitorConfig, MAX_CHECK_RECENT_TXS_DEPTH,
-    NullL1HeadSubscription, NullSubscription, RpcL1HeadPollingSource, RpcL2BlockProvider,
-    RpcPollingSource, RpcThrottleClient, SafeHeadPoller, ShadowParityMonitor,
-    ShadowParityMonitorConfig, WsBlockSubscription, WsL1HeadSubscription, recent_tx_sync_target,
+    NullL1HeadSubscription, NullSubscription, RecentTxSyncTarget, RpcL1HeadPollingSource,
+    RpcL2BlockProvider, RpcPollingSource, RpcThrottleClient, SafeHeadPoller, ShadowParityMonitor,
+    ShadowParityMonitorConfig, WsBlockSubscription, WsL1HeadSubscription,
 };
 
 const WEI_PER_ETHER: f64 = 1_000_000_000_000_000_000.0;
@@ -543,7 +543,7 @@ impl BatcherService {
         // They never advance the L2 backfill cursor.
         if self.config.wait_node_sync {
             let target_l1 = if self.config.check_recent_txs_depth > 0 {
-                recent_tx_sync_target(
+                RecentTxSyncTarget::find(
                     &l1_provider,
                     signer_address,
                     self.config.check_recent_txs_depth,

--- a/crates/batcher/service/src/shadow_parity.rs
+++ b/crates/batcher/service/src/shadow_parity.rs
@@ -33,9 +33,9 @@ pub const MAX_PENDING_BATCH_QUEUE_LEN: usize = 4096;
 /// Runtime configuration for the shadow parity monitor.
 #[derive(Debug, Clone)]
 pub struct ShadowParityMonitorConfig {
-    /// Canonical rollup batch inbox used by the op-batcher.
+    /// Canonical rollup batch inbox.
     pub canonical_inbox: Address,
-    /// Canonical op-batcher sender, if available from the rollup config.
+    /// Canonical batcher sender, if available from the rollup config.
     pub canonical_batcher: Option<Address>,
     /// Shadow batch inbox used by this base-batcher instance.
     pub shadow_inbox: Address,
@@ -69,7 +69,7 @@ pub struct ShadowParityMonitor {
 /// Side of the parity comparison.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ParitySide {
-    /// Canonical op-batcher submissions to the rollup-config inbox.
+    /// Canonical batcher submissions to the rollup-config inbox.
     Canonical,
     /// Shadow base-batcher submissions to the override inbox.
     Shadow,

--- a/crates/batcher/source/src/event.rs
+++ b/crates/batcher/source/src/event.rs
@@ -23,10 +23,8 @@ pub enum L2BlockEvent {
     /// Signal the driver to force-close the current channel and flush pending
     /// frames as submissions without exhausting the source.
     ///
-    /// Analogous to the reference batcher's `forcePublish` signal: the source remains
-    /// open and the driver continues running, but the current channel is
-    /// closed so all accumulated blocks become immediately available for
-    /// submission.
+    /// The source remains open and the driver continues running, but the current
+    /// channel is closed so all accumulated blocks become available for submission.
     Flush {
         /// Fired once the driver's encoding and submission are both fully drained (not just
         /// after the first frame). Delivered through this event — rather than a side channel


### PR DESCRIPTION
## Summary

On restart the batcher decoded recent L1 calldata frames to guess the highest
already-submitted L2 block and advanced the L2 backfill cursor past it — a
heuristic that silently missed blob transactions and channels opened before the
scan window.

Replace it with a nonce-based scan that only picks an **L1 synchronization
target** for `--wait-node-sync` and never touches the L2 cursor. Startup catch-up
now always begins at `safe_head + 1`.

## Changes

- Rewrite `recent_txs.rs` around `recent_tx_sync_target`: binary-search the
  batcher account nonce over the recent L1 window to find the block holding its
  latest transaction. Drop the frame/RLP decoding, `RecentTxScanner` and
  `SCAN_FETCH_CONCURRENCY`.
- `service.rs`: connect L1 before the sync gate, pick the target by nonce (or the
  current head), rewrite `wait_for_node_sync` around a single timeout, validate
  the flags up front, and decouple shadow-parity start depth from
  `check_recent_txs_depth`.
- `--check-recent-txs-depth` now requires `--wait-node-sync`; update the CLI and
  config docs and the crate exports accordingly.

## Testing

- `cargo test -p base-batcher-service`

Second of five PRs splitting #4274.