### PR TITLE
fix(BOP-506): remove dead TransferredFromSeizable event from frozen IB20V1 ABI

### DIFF
--- a/crates/common/precompiles/src/common/abi/v1.rs
+++ b/crates/common/precompiles/src/common/abi/v1.rs
@@ -54,7 +54,6 @@ sol! {
         event Approval(address indexed owner, address indexed spender, uint256 amount);
         event Memo(address indexed caller, bytes32 indexed memo);
         event BurnedBlocked(address indexed caller, address indexed from, uint256 amount);
-        event TransferredFromSeizable(address indexed caller, address indexed from, address indexed to, uint256 amount);
         event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);
         event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender);
         event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole);

--- a/crates/common/precompiles/src/common/abi/v2.rs
+++ b/crates/common/precompiles/src/common/abi/v2.rs
@@ -235,7 +235,7 @@ mod tests {
     /// `sol!` reorder of `TRANSFER`/`MINT`/`BURN` would silently remap which bit each feature
     /// toggles while leaving every selector, topic0, error selector and `COUNT` identical.
     const V1_ABI_FINGERPRINT: B256 =
-        b256!("106ef4b7c288c9344d6906ba7ef99a740bd9621cdaed89d06b35abd313c13449");
+        b256!("bcece6954307d847db07d6f723438cd1fa93ae40fe0c4c7ee5578779cb502661");
 
     /// Absolute wire fingerprint for Cobalt's (canonical) surface. Diverges from V1: Cobalt adds
     /// the seize surface (`seizeWithMemo`, the `SEIZE_ROLE`/`SEIZE_HOLDER_POLICY`/`SEIZE_RECEIVER_POLICY`


### PR DESCRIPTION
## Summary
- Audit finding I-02 (BlockSec, "Base B20 V2 / PolicyRegistry Precompiles"): the frozen `IB20V1` ABI declared `TransferredFromSeizable`, which was never part of the v1.1.1 / base-std Beryl surface and has no emit site on the V1 path. Seize logging on V2 emits `Seized` instead.
- Removed the dead event from `crates/common/precompiles/src/common/abi/v1.rs`.
- Updated the pinned `V1_ABI_FINGERPRINT` in `crates/common/precompiles/src/common/abi/v2.rs` to match the corrected event set.

Confirmed via grep that `TransferredFromSeizable` had no emit site or decode-path reference anywhere in the crate before removal, so this does not change any historical returndata/log output.

Linear: https://linear.app/coinbase/issue/BOP-506

## Test plan
- [x] `cargo test -p base-common-precompiles --lib` — 648 passed
- [x] `cargo test -p base-common-precompiles --features test-utils --test b20_asset_v1_golden --test b20_stablecoin_v1_golden --test b20_asset_v2_golden --test b20_policy_v1_golden --test b20_factory_v1_golden` — 369 passed
- [x] `cargo clippy -p base-common-precompiles --lib --features test-utils -- -D warnings` — clean