### PR TITLE
fix(policy): short-circuit composite_policy_child_ids on is_well_formed (BOP-507)

### DIFF
--- a/crates/common/precompiles/src/policy/logic/v2.rs
+++ b/crates/common/precompiles/src/policy/logic/v2.rs
@@ -568,6 +568,9 @@ impl<S: PolicyAccounting> PolicyRegistryLogic<S> for PolicyRegistryV2 {
     }
 
     fn composite_policy_child_ids(&self, storage: &S, policy_id: u64) -> Result<Vec<u64>> {
+        if !Self::is_well_formed(policy_id) {
+            return Ok(Vec::new());
+        }
         if !Self::is_composite(policy_id) {
             return Ok(Vec::new());
         }
@@ -1265,6 +1268,13 @@ mod tests {
         let rt = initialized();
         let malformed: u64 = (4u64 << 56) | 42;
         assert_eq!(LOGIC.pending_policy_admin(&rt, malformed).unwrap(), Address::ZERO);
+    }
+
+    #[test]
+    fn composite_policy_child_ids_malformed_policy_id_returns_empty() {
+        let rt = initialized();
+        let malformed: u64 = (4u64 << 56) | 42;
+        assert!(LOGIC.composite_policy_child_ids(&rt, malformed).unwrap().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Addresses BlockSec audit finding **I-03 (Informational)**: `PolicyRegistryV2::composite_policy_child_ids` checked only `is_composite` before reading children, unlike base-std's `MockPolicyRegistry.sol` reference, which short-circuits on `is_well_formed` first.
- Adds the `is_well_formed` short-circuit ahead of `is_composite` so the Rust implementation's structure mirrors the Solidity reference. No behavioral/consensus change — malformed type bytes (> INTERSECT) were already excluded by the `is_composite` check alone, since UNION/INTERSECT are within the well-formed range.

Linear: https://linear.app/coinbase/issue/BOP-507/audit-i-03-composite-policy-child-ids-gates-only-on-is-composite

## Test plan
- [x] Added `composite_policy_child_ids_malformed_policy_id_returns_empty`, matching the existing test style for other read helpers (`get_policy_admin_malformed_policy_id_returns_zero_address`, `pending_policy_admin_malformed_policy_id_returns_zero_address`).
- [x] `cargo test -p base-common-precompiles` passes (unit + golden tests).
- [x] `cargo clippy -p base-common-precompiles --all-targets` is clean.