### PR TITLE
feat(eip8130): reject codeless create in the enshrined apply path

### DIFF
--- a/crates/common/consensus/src/transaction/eip8130/constants.rs
+++ b/crates/common/consensus/src/transaction/eip8130/constants.rs
@@ -148,6 +148,19 @@ impl Eip8130Constants {
     /// meaningful when [`Self::FLAG_LOCKED`] is set.
     pub const FLAG_UNLOCK_INITIATED: u8 = 0x04;
 
+    /// `AccountState.flags` bit (spec `CONTRACT_ESTABLISHED`): set on every
+    /// account the keystore establishes — `createAccount` (mirrored by the
+    /// node's create path) and `importAccount` — marking it
+    /// "keystore-established, not a proven address key."
+    ///
+    /// Permanent once set and never consulted during authentication. The protocol
+    /// reads it for code-delegation gating: an account may have **empty code yet
+    /// retain EIP-8130 state** (e.g. an EIP-6780 same-transaction `SELFDESTRUCT`),
+    /// so empty code alone must never be read as proof of a known EOA key. The
+    /// node therefore rejects a delegation onto an empty-code account that carries
+    /// this flag (it is not a proven-key EOA and must not be re-delegated as one).
+    pub const FLAG_CONTRACT_ESTABLISHED: u8 = 0x08;
+
     /// Exact byte length of a policy-bearing actor's `policyData`:
     /// `manager (20) || commitment (32)`. Required when `scope & SCOPE_POLICY`
     /// is set; `policyData` MUST be empty otherwise.

--- a/crates/common/evm/src/eip8130.rs
+++ b/crates/common/evm/src/eip8130.rs
@@ -1653,6 +1653,20 @@ impl Eip8130Executor {
             .with_account_info(sender, |info| Ok(info.is_empty_code_hash()))
             .map_err(BaseTransactionError::eip8130)?;
         if is_codeless {
+            // Same guard as an explicit delegation's `DelegationEffect::install`:
+            // empty code on a keystore-established account (e.g. an imported
+            // account whose delegation was later cleared, or an EIP-6780
+            // same-transaction `SELFDESTRUCT`) is not proof of a key-backed EOA,
+            // so it must not be auto-delegated to `DEFAULT_ACCOUNT` as if it were
+            // one. Fail closed, mirroring `ApplyError::ContractEstablishedCodeless`.
+            let contract_established = AccountConfigurationStorage::new(sctx)
+                .is_contract_established(sender)
+                .map_err(BaseTransactionError::eip8130)?;
+            if contract_established {
+                return Err(BaseTransactionError::eip8130(
+                    ApplyError::ContractEstablishedCodeless { account: sender },
+                ));
+            }
             let target = Eip8130Contracts::DEFAULT_ACCOUNT;
             sctx.set_code(sender, Bytecode::new_eip7702(target))
                 .map_err(BaseTransactionError::eip8130)?;
@@ -1709,6 +1723,7 @@ mod tests {
     };
     use base_common_precompiles::INonceManager;
     use base_execution_eip8130::{AccountChangeApplier, DelegationApplied};
+    use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
     use k256::ecdsa::SigningKey;
     use revm::{
         Database,
@@ -1869,6 +1884,36 @@ mod tests {
         // Fees were routed: base fee to the vault, priority tip to the beneficiary.
         assert!(outcome.state.contains_key(&Predeploys::BASE_FEE_VAULT));
         assert!(outcome.state.contains_key(&BENEFICIARY));
+    }
+
+    #[test]
+    fn auto_delegate_skips_contract_established_codeless_sender() {
+        // Auto-delegation carries the same `FLAG_CONTRACT_ESTABLISHED` guard as an
+        // explicit `DelegationEffect::install`: a plain codeless EOA is delegated
+        // to `DEFAULT_ACCOUNT`, but a keystore-established codeless account (e.g.
+        // an imported account whose delegation was cleared) must fail closed.
+        let plain = address!("0x00000000000000000000000000000000000000c1");
+        let established = address!("0x00000000000000000000000000000000000000c2");
+        let mut provider = HashMapStorageProvider::new(CHAIN_ID);
+        StorageCtx::enter(&mut provider, |ctx| {
+            // A non-established codeless sender is auto-delegated.
+            assert!(
+                Eip8130Executor::auto_delegate_codeless_sender(ctx, plain).unwrap(),
+                "plain codeless EOA must be auto-delegated"
+            );
+
+            // Mark a codeless account keystore-established: auto-delegation must
+            // reject it rather than resurrect it as a DEFAULT_ACCOUNT delegate.
+            let mut acc = AccountConfigurationStorage::new(ctx);
+            let mut state = acc.get_account_state(established).unwrap();
+            state.flags = Eip8130Constants::FLAG_CONTRACT_ESTABLISHED;
+            acc.set_account_state(established, state).unwrap();
+            let err = Eip8130Executor::auto_delegate_codeless_sender(ctx, established).unwrap_err();
+            assert!(
+                err.to_string().contains("contract-established"),
+                "expected ContractEstablishedCodeless, got: {err}"
+            );
+        });
     }
 
     #[test]

--- a/crates/execution/eip8130/src/account_config.rs
+++ b/crates/execution/eip8130/src/account_config.rs
@@ -183,6 +183,13 @@ impl AccountConfigurationStorage<'_> {
         Ok(self.get_account_state(account)?.is_locked(now))
     }
 
+    /// Mirrors `AccountConfiguration.isContractEstablished`: `true` once the
+    /// account has been keystore-established (create/import). Used to gate code
+    /// delegation onto an empty-code account (see [`crate::DelegationEffect`]).
+    pub fn is_contract_established(&self, account: Address) -> Result<bool> {
+        Ok(self.get_account_state(account)?.contract_established())
+    }
+
     /// Mirrors `AccountConfiguration.getLockStatus`.
     pub fn get_lock_status(&self, account: Address, now: u64) -> Result<LockStatus> {
         Ok(self.get_account_state(account)?.lock_status(now))
@@ -360,7 +367,10 @@ pub struct AccountState {
     /// disables the inline secp256k1 self key; bit 1
     /// ([`Eip8130Constants::FLAG_LOCKED`]) freezes actor configuration; bit 2
     /// ([`Eip8130Constants::FLAG_UNLOCK_INITIATED`]) selects the `lock_union`
-    /// interpretation.
+    /// interpretation; bit 3
+    /// ([`Eip8130Constants::FLAG_CONTRACT_ESTABLISHED`]) marks a
+    /// keystore-established account (create/import) that must not be treated as a
+    /// proven-key EOA even when its code is empty.
     pub flags: u8,
     /// `uint48` lock union: `unlock_delay` (seconds) while `FLAG_UNLOCK_INITIATED`
     /// is clear, else `unlocks_at` (Unix-seconds timestamp).
@@ -410,6 +420,14 @@ impl AccountState {
     #[must_use]
     pub const fn default_eoa_revoked(&self) -> bool {
         self.flags & Eip8130Constants::DEFAULT_EOA_REVOKED != 0
+    }
+
+    /// `true` when this account was keystore-established (create/import) and so
+    /// must not be treated as a proven-key EOA — even with empty code. Mirrors
+    /// `Keystore.isContractEstablished` (the `FLAG_CONTRACT_ESTABLISHED` bit).
+    #[must_use]
+    pub const fn contract_established(&self) -> bool {
+        self.flags & Eip8130Constants::FLAG_CONTRACT_ESTABLISHED != 0
     }
 
     /// Mirrors `AccountConfiguration._isLocked`: configuration is frozen while

--- a/crates/execution/eip8130/src/apply.rs
+++ b/crates/execution/eip8130/src/apply.rs
@@ -92,10 +92,30 @@ pub enum ApplyError {
     #[error("create initial actors must be strictly ascending by actor id")]
     ActorsNotSortedOrDuplicate,
 
+    /// A create entry's bytecode is empty. Mirrors `_buildDeploymentCode`'s
+    /// `revert EmptyBytecode()`: a codeless create is rejected because an account
+    /// carrying actor config but no runtime code (nor a delegation) would break
+    /// the EOA invariant — a key would exist for an address that is not an EOA.
+    #[error("create bytecode is empty")]
+    EmptyBytecode,
+
     /// A create entry's bytecode exceeds the 0xFFFF deployment limit. Mirrors
     /// `require(n <= 0xFFFF)`.
     #[error("create bytecode exceeds the 65535-byte limit")]
     BytecodeTooLarge,
+
+    /// A create entry's runtime code cannot be deployed. Mirrors `createAccount`'s
+    /// `AccountDeploymentFailed`: on the contract, `CREATE2` returns `address(0)`
+    /// when the runtime code is over the EIP-170 [`Eip8130Constants::MAX_CODE_SIZE`]
+    /// cap or leads with the EIP-3541 reserved `0xEF` byte. The enshrined apply
+    /// path deploys the code directly (`set_code`) rather than via `CREATE2`, so it
+    /// must reject those payloads explicitly — a leading-`0xEF` payload would
+    /// otherwise panic in `Bytecode::new_raw` instead of failing the transaction.
+    #[error("account {account} runtime code is not deployable (EIP-170 size / EIP-3541 prefix)")]
+    AccountDeploymentFailed {
+        /// The counterfactual address whose runtime code cannot be deployed.
+        account: Address,
+    },
 
     /// The account targeted by a create entry already has EIP-8130 state. Mirrors
     /// the CREATE2 collision that makes `createAccount` unrepeatable.
@@ -139,6 +159,18 @@ pub enum ApplyError {
     #[error("delegation cannot replace non-delegation code at account {account}")]
     NonDelegatableCode {
         /// The account whose existing code cannot be replaced by a delegation.
+        account: Address,
+    },
+
+    /// A delegation targeted an empty-code account that is
+    /// [`Eip8130Constants::FLAG_CONTRACT_ESTABLISHED`]. Empty code on a
+    /// keystore-established account (e.g. after an EIP-6780 same-transaction
+    /// `SELFDESTRUCT`) is not proof of a key-backed EOA, so it must not be
+    /// (re)delegated as if it were one — doing so would resurrect a CREATE2
+    /// address that no private key controls.
+    #[error("delegation cannot target empty-code contract-established account {account}")]
+    ContractEstablishedCodeless {
+        /// The keystore-established account whose empty code cannot be delegated.
         account: Address,
     },
 
@@ -192,11 +224,23 @@ impl DelegationEffect {
     /// contract bytecode is left unchanged and rejected with
     /// [`ApplyError::NonDelegatableCode`].
     pub fn install(&self, sctx: StorageCtx<'_>) -> Result<(), ApplyError> {
-        let can_replace = sctx.with_account_code(self.account, |code| {
-            Ok(Self::can_replace_code(code.original_bytes().as_ref()))
+        let (can_replace, code_is_empty) = sctx.with_account_code(self.account, |code| {
+            let bytes = code.original_bytes();
+            let slice = bytes.as_ref();
+            Ok((Self::can_replace_code(slice), slice.is_empty()))
         })?;
         if !can_replace {
             return Err(ApplyError::NonDelegatableCode { account: self.account });
+        }
+
+        // Empty code on a keystore-established account is not proof of a key-backed
+        // EOA (e.g. an EIP-6780 same-transaction SELFDESTRUCT leaves EIP-8130 state
+        // behind empty code), so it must not be (re)delegated as if it were one.
+        // Reading the AccountConfiguration flag mirrors `Keystore.isContractEstablished`.
+        if code_is_empty
+            && AccountConfigurationStorage::new(sctx).is_contract_established(self.account)?
+        {
+            return Err(ApplyError::ContractEstablishedCodeless { account: self.account });
         }
 
         let code = if self.target.is_zero() {
@@ -580,12 +624,29 @@ impl AccountChangeApplier {
             return Err(ApplyError::AlreadyCreated { account: address });
         }
 
-        // Mark initialized and disable the implicit default-EOA path by default
+        // Mirror `createAccount`'s `CREATE2` deploy, which returns `address(0)`
+        // (→ `AccountDeploymentFailed`) for runtime code over the EIP-170 cap or
+        // leading with the EIP-3541 reserved `0xEF` byte. This path deploys via
+        // `set_code(Bytecode::new_raw(..))` instead of `CREATE2`, so it enforces
+        // both here — a leading-`0xEF` payload would otherwise panic in
+        // `Bytecode::new_raw`. Checked after the already-created guard so a
+        // collision still reports `AlreadyCreated` first, and before any state
+        // write so a rejected create leaves no partially-initialized account.
+        if entry.code.len() > Eip8130Constants::MAX_CODE_SIZE || entry.code.first() == Some(&0xEF) {
+            return Err(ApplyError::AccountDeploymentFailed { account: address });
+        }
+
+        // Mark initialized, disable the implicit default-EOA path by default
         // (a created account has contract code, so the recovered==account path is
-        // unreachable). Written before initializing actors so a self-actorId k1
-        // initial actor can re-enable the inline self.
+        // unreachable), and flag the account keystore-established so a later empty-
+        // code state (e.g. an EIP-6780 SELFDESTRUCT) is never mistaken for a
+        // proven-key EOA. Mirrors `createAccount`'s
+        // `flags = FLAG_REVOKE_DEFAULT_EOA | FLAG_CONTRACT_ESTABLISHED`. Written
+        // before initializing actors so a self-actorId k1 initial actor can
+        // re-enable the inline self.
         state.local_sequence = 1;
-        state.flags = Eip8130Constants::DEFAULT_EOA_REVOKED;
+        state.flags =
+            Eip8130Constants::DEFAULT_EOA_REVOKED | Eip8130Constants::FLAG_CONTRACT_ESTABLISHED;
         storage.set_account_state(address, state)?;
 
         Self::initialize_actors(storage, address, &entry.initial_actors)?;
@@ -714,9 +775,14 @@ impl AccountChangeApplier {
 
     /// Builds an account's deployment code: a 14-byte EVM loader header that
     /// returns the trailing `bytecode` as the account's runtime code. Mirrors
-    /// `_buildDeploymentCode`.
+    /// `_buildDeploymentCode`: rejects empty `bytecode` with
+    /// [`ApplyError::EmptyBytecode`] (codeless creates are invalid) and bytecode
+    /// over `0xFFFF` bytes with [`ApplyError::BytecodeTooLarge`].
     pub fn build_deployment_code(bytecode: &[u8]) -> Result<Vec<u8>, ApplyError> {
         let n = bytecode.len();
+        if n == 0 {
+            return Err(ApplyError::EmptyBytecode);
+        }
         if n > 0xFFFF {
             return Err(ApplyError::BytecodeTooLarge);
         }
@@ -738,7 +804,7 @@ impl AccountChangeApplier {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{LogData, address, b256};
+    use alloy_primitives::{LogData, U256, address, b256};
     use alloy_sol_types::SolEvent;
     use base_precompile_storage::{HashMapStorageProvider, PrecompileStorageProvider, StorageCtx};
     use revm::state::Bytecode;
@@ -1113,7 +1179,14 @@ mod tests {
             &[0x61, 0x00, n, 0x60, 0x0E, 0x60, 0x00, 0x39, 0x61, 0x00, n, 0x60, 0x00, 0xF3]
         );
         assert_eq!(&code[14..], &bytecode);
-        assert!(AccountChangeApplier::build_deployment_code(&vec![0u8; 0x10000]).is_err());
+        assert_eq!(
+            AccountChangeApplier::build_deployment_code(&[]),
+            Err(ApplyError::EmptyBytecode)
+        );
+        assert_eq!(
+            AccountChangeApplier::build_deployment_code(&vec![0u8; 0x10000]),
+            Err(ApplyError::BytecodeTooLarge)
+        );
     }
 
     #[test]
@@ -1246,9 +1319,14 @@ mod tests {
 
     #[test]
     fn create_requires_sorted_non_empty_actors() {
+        // Non-empty code so these entries reach the actor-set checks; the
+        // finalized contract builds deployment code (reverting EmptyBytecode)
+        // before `_initializeAccount`, so a codeless entry would fail earlier
+        // (covered by `create_rejects_codeless_account`).
+        let code = Bytes::from_static(&[0x60, 0x01]);
         with_storage(|acc| {
             let empty =
-                CreateEntry { user_salt: B256::ZERO, code: Bytes::new(), initial_actors: vec![] };
+                CreateEntry { user_salt: B256::ZERO, code: code.clone(), initial_actors: vec![] };
             assert_eq!(
                 AccountChangeApplier::apply_create(acc, &empty),
                 Err(ApplyError::NoInitialActors)
@@ -1256,7 +1334,7 @@ mod tests {
 
             let unsorted = CreateEntry {
                 user_salt: B256::ZERO,
-                code: Bytes::new(),
+                code: code.clone(),
                 initial_actors: vec![
                     InitialActor::owner(B256::repeat_byte(2), AUTHENTICATOR),
                     InitialActor::owner(B256::repeat_byte(1), AUTHENTICATOR),
@@ -1266,6 +1344,86 @@ mod tests {
                 AccountChangeApplier::apply_create(acc, &unsorted),
                 Err(ApplyError::ActorsNotSortedOrDuplicate)
             );
+        });
+    }
+
+    #[test]
+    fn create_rejects_codeless_account() {
+        // Codeless creates are invalid: an account with actor config but no
+        // runtime code (nor a delegation) would break the EOA invariant. Mirrors
+        // `_buildDeploymentCode`'s `revert EmptyBytecode()`, which fires before
+        // any actor-set validation, so even a well-formed actor set is rejected.
+        with_storage(|acc| {
+            let entry = CreateEntry {
+                user_salt: B256::ZERO,
+                code: Bytes::new(),
+                initial_actors: vec![InitialActor::owner(B256::repeat_byte(1), AUTHENTICATOR)],
+            };
+            assert_eq!(
+                AccountChangeApplier::apply_create(acc, &entry),
+                Err(ApplyError::EmptyBytecode)
+            );
+        });
+    }
+
+    #[test]
+    fn create_rejects_undeployable_runtime_code() {
+        // The enshrined deploy (`set_code(Bytecode::new_raw(..))`) replaces the
+        // contract's `CREATE2`, so it must reject the same payloads `CREATE2`
+        // would fail with `address(0)`: EIP-3541 (leading `0xEF`) and EIP-170
+        // (over `MAX_CODE_SIZE`). A leading-`0xEF` payload would otherwise panic
+        // in `Bytecode::new_raw`.
+        let actors = vec![InitialActor::owner(B256::repeat_byte(1), AUTHENTICATOR)];
+
+        // EIP-3541: a leading `0xEF` byte is rejected as runtime code.
+        with_storage(|acc| {
+            let entry = CreateEntry {
+                user_salt: B256::ZERO,
+                code: Bytes::from_static(&[0xEF, 0x00]),
+                initial_actors: actors.clone(),
+            };
+            let expected = AccountChangeApplier::compute_address(
+                entry.user_salt,
+                &entry.code,
+                &entry.initial_actors,
+            )
+            .unwrap();
+            assert_eq!(
+                AccountChangeApplier::apply_create(acc, &entry),
+                Err(ApplyError::AccountDeploymentFailed { account: expected })
+            );
+            // No partially-initialized account is left behind on rejection.
+            assert!(!acc.get_account_state(expected).unwrap().is_initialized());
+        });
+
+        // EIP-170: runtime code over `MAX_CODE_SIZE` (but under the 0xFFFF
+        // deployment-code cap) computes an address but is not deployable.
+        with_storage(|acc| {
+            let entry = CreateEntry {
+                user_salt: B256::ZERO,
+                code: Bytes::from(vec![0x00u8; Eip8130Constants::MAX_CODE_SIZE + 1]),
+                initial_actors: actors.clone(),
+            };
+            let expected = AccountChangeApplier::compute_address(
+                entry.user_salt,
+                &entry.code,
+                &entry.initial_actors,
+            )
+            .unwrap();
+            assert_eq!(
+                AccountChangeApplier::apply_create(acc, &entry),
+                Err(ApplyError::AccountDeploymentFailed { account: expected })
+            );
+        });
+
+        // Exactly `MAX_CODE_SIZE` deploys (boundary, non-`0xEF` lead).
+        with_storage(|acc| {
+            let entry = CreateEntry {
+                user_salt: B256::ZERO,
+                code: Bytes::from(vec![0x00u8; Eip8130Constants::MAX_CODE_SIZE]),
+                initial_actors: actors.clone(),
+            };
+            assert!(AccountChangeApplier::apply_create(acc, &entry).is_ok());
         });
     }
 
@@ -1365,6 +1523,106 @@ mod tests {
                 .get_account_info(ACCOUNT)
                 .and_then(|info| info.code.as_ref())
                 .is_some_and(Bytecode::is_empty)
+        );
+    }
+
+    /// Marks `account` keystore-established (`FLAG_CONTRACT_ESTABLISHED`) in the
+    /// `AccountConfiguration` storage, leaving every other state field zero.
+    fn mark_contract_established(storage: &mut HashMapStorageProvider) {
+        StorageCtx::enter(storage, |sctx| {
+            let mut cfg = AccountConfigurationStorage::new(sctx);
+            let mut state = AccountState::from_word(U256::ZERO);
+            state.flags = Eip8130Constants::FLAG_CONTRACT_ESTABLISHED;
+            cfg.set_account_state(ACCOUNT, state).unwrap();
+        });
+    }
+
+    #[test]
+    fn apply_create_flags_account_contract_established() {
+        // A created account is marked keystore-established so a later empty-code
+        // state can never be mistaken for a proven-key EOA. Mirrors
+        // `createAccount`'s `FLAG_REVOKE_DEFAULT_EOA | FLAG_CONTRACT_ESTABLISHED`.
+        let signer = address!("0x00000000000000000000000000000000000000a1");
+        let actor_id = AccountConfigurationStorage::self_actor_id(signer);
+        let entry = CreateEntry {
+            user_salt: B256::ZERO,
+            code: Bytes::from_static(&[0x60, 0x00]),
+            initial_actors: vec![InitialActor::owner(actor_id, Eip8130Constants::K1_AUTHENTICATOR)],
+        };
+        with_storage(|acc| {
+            let created = AccountChangeApplier::apply_create(acc, &entry).unwrap();
+            let state = acc.get_account_state(created.address).unwrap();
+            assert!(state.contract_established(), "create must set FLAG_CONTRACT_ESTABLISHED");
+            assert!(state.default_eoa_revoked(), "create must still revoke the default EOA");
+        });
+    }
+
+    #[test]
+    fn delegation_effect_install_rejects_empty_code_contract_established_account() {
+        // Empty code on a keystore-established account is a self-destructed CREATE2
+        // account, not a proven-key EOA — a delegation onto it is rejected.
+        let target = Address::repeat_byte(0x55);
+        let mut storage = HashMapStorageProvider::new(1);
+        mark_contract_established(&mut storage);
+
+        let error = StorageCtx::enter(&mut storage, |sctx| {
+            DelegationEffect::new(ACCOUNT, target).install(sctx)
+        })
+        .unwrap_err();
+
+        assert_eq!(error, ApplyError::ContractEstablishedCodeless { account: ACCOUNT });
+        // No delegation code was written.
+        assert!(
+            storage
+                .get_account_info(ACCOUNT)
+                .and_then(|info| info.code.as_ref())
+                .and_then(Bytecode::eip7702_address)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn delegation_effect_install_allows_empty_code_non_established_account() {
+        // A genuine (non-established) empty-code EOA may still be delegated: the
+        // guard only fires for keystore-established accounts.
+        let target = Address::repeat_byte(0x56);
+        let mut storage = HashMapStorageProvider::new(1);
+
+        StorageCtx::enter(&mut storage, |sctx| {
+            DelegationEffect::new(ACCOUNT, target).install(sctx)
+        })
+        .unwrap();
+
+        assert_eq!(
+            storage
+                .get_account_info(ACCOUNT)
+                .and_then(|info| info.code.as_ref())
+                .and_then(Bytecode::eip7702_address),
+            Some(target)
+        );
+    }
+
+    #[test]
+    fn delegation_effect_install_allows_redelegation_of_established_delegate() {
+        // An established account that already carries a delegation indicator
+        // (e.g. an imported 7702 delegate — genuinely once an EOA) may be
+        // re-delegated: the codeless guard is scoped to *empty* code only.
+        let target = Address::repeat_byte(0x57);
+        let mut storage = HashMapStorageProvider::new(1);
+        mark_contract_established(&mut storage);
+        storage.set_code(ACCOUNT, Bytecode::new_eip7702(Address::repeat_byte(0x11))).unwrap();
+
+        StorageCtx::enter(&mut storage, |sctx| {
+            DelegationEffect::new(ACCOUNT, target).install(sctx)
+        })
+        .unwrap();
+
+        assert_eq!(
+            storage
+                .get_account_info(ACCOUNT)
+                .and_then(|info| info.code.as_ref())
+                .and_then(Bytecode::eip7702_address),
+            Some(target)
         );
     }
 

--- a/crates/execution/eip8130/src/transaction.rs
+++ b/crates/execution/eip8130/src/transaction.rs
@@ -203,9 +203,14 @@ impl TransactionAuthorizer {
     /// [`DelegationEffect::can_replace_code`], enforced when
     /// [`DelegationEffect::install`] runs in both the mempool overlay and block
     /// execution (ordinary contract code is rejected with
-    /// [`ApplyError::NonDelegatableCode`]). Allowing any admin actor here is
-    /// therefore safe: an admin key can only (re)delegate an EOA-shaped account,
-    /// never repoint a deployed smart account's code.
+    /// [`ApplyError::NonDelegatableCode`]). `install` additionally rejects a
+    /// delegation onto an **empty-code, keystore-established** account
+    /// (`FLAG_CONTRACT_ESTABLISHED`) with
+    /// [`ApplyError::ContractEstablishedCodeless`]: empty code there is a
+    /// self-destructed CREATE2 account, not a proven-key EOA, so it must not be
+    /// re-delegated. Allowing any admin actor here is therefore safe: an admin key
+    /// can only (re)delegate a genuinely EOA-shaped account, never repoint a
+    /// deployed smart account's code nor resurrect a keystore-established one.
     ///
     /// [`DelegationEffect::can_replace_code`]: crate::DelegationEffect::can_replace_code
     /// [`DelegationEffect::install`]: crate::DelegationEffect::install
@@ -975,9 +980,12 @@ mod tests {
             id
         });
         let initial_actors = vec![InitialActor::owner(actor_id_val, K1)];
+        // Non-empty code: codeless creates are rejected by the structural
+        // validator before this path, and `apply_create` now enforces the same
+        // `EmptyBytecode` invariant.
         let create = CreateEntry {
             user_salt: B256::ZERO,
-            code: Bytes::new(),
+            code: Bytes::from_static(&[0x60, 0x00]),
             initial_actors: initial_actors.clone(),
         };
         let derived = AccountChangeApplier::compute_address(
@@ -1034,7 +1042,7 @@ mod tests {
         let initial_actors = vec![InitialActor::owner(actor_id_val, K1)];
         let create = CreateEntry {
             user_salt: B256::ZERO,
-            code: Bytes::new(),
+            code: Bytes::from_static(&[0x60, 0x00]),
             initial_actors: initial_actors.clone(),
         };
         let derived = AccountChangeApplier::compute_address(
@@ -1085,7 +1093,11 @@ mod tests {
             id
         });
         let initial_actors = vec![InitialActor::owner(actor_id_val, K1)];
-        let create = CreateEntry { user_salt: B256::ZERO, code: Bytes::new(), initial_actors };
+        let create = CreateEntry {
+            user_salt: B256::ZERO,
+            code: Bytes::from_static(&[0x60, 0x00]),
+            initial_actors,
+        };
         let tx = TxEip8130 {
             chain_id: LOCAL,
             sender: None, // missing explicit sender

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -1522,13 +1522,20 @@ where
             ApplyError::ActorsNotSortedOrDuplicate => {
                 "create initial actors are not strictly ascending"
             }
+            ApplyError::EmptyBytecode => "create bytecode is empty",
             ApplyError::BytecodeTooLarge => "create bytecode exceeds the size limit",
+            ApplyError::AccountDeploymentFailed { .. } => {
+                "create bytecode is not deployable (size or reserved 0xEF prefix)"
+            }
             ApplyError::AlreadyCreated { .. } => "create account already exists",
             ApplyError::CreateAddressMismatch { .. } => "create address does not match the sender",
             ApplyError::InvalidCreatePosition => "create entry must be the only one, at index 0",
             ApplyError::MultipleDelegations => "at most one delegation is allowed",
             ApplyError::CreateAndDelegation => "create and delegation may not coexist",
             ApplyError::NonDelegatableCode { .. } => "delegation sender has non-delegation code",
+            ApplyError::ContractEstablishedCodeless { .. } => {
+                "delegation target is an empty-code keystore-established account"
+            }
             ApplyError::SequenceOverflow => "config change sequence overflow",
         }
     }
@@ -1798,8 +1805,13 @@ where
                     if create_count > 1 || idx != 0 {
                         return Err(InvalidTransactionError::TxTypeNotSupported.into());
                     }
+                    // Reject at admission the runtime code shapes the enshrined
+                    // deploy (`AccountChangeApplier::apply_create`) refuses:
+                    // EIP-170 oversize and the EIP-3541 reserved leading `0xEF`
+                    // byte (which `CREATE2` would reject with `address(0)`).
                     if create.code.is_empty()
                         || create.code.len() > Eip8130Constants::MAX_CODE_SIZE
+                        || create.code.first() == Some(&0xEF)
                         || create.initial_actors.is_empty()
                     {
                         return Err(InvalidTransactionError::TxTypeNotSupported.into());


### PR DESCRIPTION
## Summary

Mirrors the finalized `Keystore`'s `_buildDeploymentCode` `revert EmptyBytecode()` in the enshrined execution path.

- `build_deployment_code` now rejects empty bytecode with a new `ApplyError::EmptyBytecode` (before the size check), so `apply_create` / `compute_address` refuse a **codeless create**.
- A codeless create would otherwise install actor config at an address with no runtime code (nor a delegation), breaking the invariant that a key-bearing account is either a real EOA or a contract/delegation.
- Ordering matches the contract (deployment code is built before the initial-actor checks), so a codeless entry is rejected even with a well-formed actor set.
- The txpool structural gate already rejects `create.code.is_empty()` at admission; this adds the execution-layer defense-in-depth plus its pool rejection reason.

> Stacked on #4324.

## Test plan

- [x] `cargo test -p base-execution-eip8130` (new `create_rejects_codeless_account` + `build_deployment_code` empty/too-large coverage)
- [x] `cargo test -p base-execution-txpool -p base-common-evm`
- [x] `cargo clippy --all-targets` clean