### PR TITLE
feat(eip8130): enshrine IncrementLocalEpoch apply handler + intrinsic gas

### DIFF
--- a/crates/common/consensus/src/transaction/eip8130/account_changes.rs
+++ b/crates/common/consensus/src/transaction/eip8130/account_changes.rs
@@ -126,9 +126,10 @@ impl InitialActor {
 /// Mirrors the finalized `Keystore.ChangeType` enum. Authority ops
 /// ([`Self::AuthorizeActor`], [`Self::RevokeActor`]) mutate who can act;
 /// environment ops ([`Self::IncrementLocalEpoch`], [`Self::Lock`],
-/// [`Self::Unlock`]) mutate the rules ops are checked against and are valid only
-/// on the [`AccountChangeChannel::Local`] channel (`Lock`/`Unlock` must also be
-/// the batch's only op).
+/// [`Self::Unlock`]) mutate the rules ops are checked against.
+/// [`Self::IncrementLocalEpoch`] is valid on either channel (a Multichain batch
+/// may bump the local epoch); [`Self::Lock`]/[`Self::Unlock`] are valid only on
+/// the [`AccountChangeChannel::Local`] channel and must be the batch's only op.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -137,7 +138,7 @@ pub enum ChangeType {
     AuthorizeActor,
     /// Revoke an actor. Payload: `abi.encode(actorId)`.
     RevokeActor,
-    /// Increment the local epoch (Local only; empty payload).
+    /// Increment the local epoch (either channel; empty payload).
     IncrementLocalEpoch,
     /// Lock the account (Local only; standalone; payload: `abi.encode(uint16 unlockDelay)`).
     Lock,

--- a/crates/common/consensus/src/transaction/eip8130/constants.rs
+++ b/crates/common/consensus/src/transaction/eip8130/constants.rs
@@ -123,8 +123,8 @@ impl Eip8130Constants {
     /// `ChangeType` op byte: revoke an actor. Payload is `abi.encode(bytes32 actorId)`.
     pub const CHANGE_TYPE_REVOKE_ACTOR: u8 = 0x01;
 
-    /// `ChangeType` op byte: increment the local epoch (Local channel only;
-    /// empty payload). Invalidates every unlanded local signature at a prior epoch.
+    /// `ChangeType` op byte: increment the local epoch (either channel; empty
+    /// payload). Invalidates every unlanded local signature at a prior epoch.
     pub const CHANGE_TYPE_INCREMENT_LOCAL_EPOCH: u8 = 0x02;
 
     /// `ChangeType` op byte: lock the account (Local channel only; standalone;

--- a/crates/common/consensus/src/transaction/envelope.rs
+++ b/crates/common/consensus/src/transaction/envelope.rs
@@ -671,11 +671,39 @@ pub(super) mod serde_bincode_compat {
         Sealed, Signed,
         transaction::serde_bincode_compat::{TxEip1559, TxEip2930, TxEip7702, TxLegacy},
     };
+    use alloy_eips::eip2718::{Decodable2718, Encodable2718};
     use alloy_primitives::{B256, Signature};
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
     use serde_with::{DeserializeAs, SerializeAs};
 
     use crate::{serde_bincode_compat::TxDeposit, transaction::Eip8130Signed};
+
+    /// Bincode-safe projection of an [`Eip8130Signed`].
+    ///
+    /// The transaction's `account_changes` payload contains
+    /// [`AccountChange`](crate::AccountChange), an internally-tagged `serde`
+    /// enum (`#[serde(tag = "type")]`). `serde` deserializes that shape via
+    /// `deserialize_any`, which non-self-describing formats such as bincode do
+    /// not support (they surface `AnyNotSupported`). Projecting the transaction
+    /// to its self-contained EIP-2718 byte stream sidesteps that path entirely
+    /// while leaving the human-readable JSON/RPC representation untouched.
+    #[derive(Debug)]
+    pub struct Eip8130Bincode(pub Eip8130Signed);
+
+    impl Serialize for Eip8130Bincode {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            self.0.encoded_2718().serialize(serializer)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for Eip8130Bincode {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            let bytes = <Vec<u8>>::deserialize(deserializer)?;
+            let signed = Eip8130Signed::decode_2718(&mut bytes.as_slice())
+                .map_err(serde::de::Error::custom)?;
+            Ok(Self(signed))
+        }
+    }
 
     /// Bincode-compatible representation of an [`BaseTxEnvelope`].
     #[derive(Debug, Serialize, Deserialize)]
@@ -717,13 +745,10 @@ pub(super) mod serde_bincode_compat {
         },
         /// EIP-8130 Account Abstraction variant.
         Eip8130 {
-            /// Owned [`Eip8130Signed`] envelope.
-            ///
-            /// The [`Eip8130Signed`] payload includes variable-length `calls`,
-            /// `account_changes`, and authentication buffers, so we serialize
-            /// it directly instead of borrowing a flattened bincode-friendly
-            /// projection.
-            transaction: Eip8130Signed,
+            /// [`Eip8130Signed`] envelope, projected to its EIP-2718 byte
+            /// stream so the internally-tagged `account_changes` payload stays
+            /// bincode-safe (see [`Eip8130Bincode`]).
+            transaction: Eip8130Bincode,
         },
     }
 
@@ -747,7 +772,7 @@ pub(super) mod serde_bincode_compat {
                     transaction: signed_7702.tx().into(),
                 },
                 super::BaseTxEnvelope::Eip8130(eip8130_signed) => {
-                    Self::Eip8130 { transaction: eip8130_signed.clone() }
+                    Self::Eip8130 { transaction: Eip8130Bincode(eip8130_signed.clone()) }
                 }
                 super::BaseTxEnvelope::Deposit(sealed_deposit) => Self::Deposit {
                     hash: sealed_deposit.seal(),
@@ -772,7 +797,7 @@ pub(super) mod serde_bincode_compat {
                 BaseTxEnvelope::Eip7702 { signature, transaction } => {
                     Self::Eip7702(Signed::new_unhashed(transaction.into(), signature))
                 }
-                BaseTxEnvelope::Eip8130 { transaction } => Self::Eip8130(transaction),
+                BaseTxEnvelope::Eip8130 { transaction } => Self::Eip8130(transaction.0),
                 BaseTxEnvelope::Deposit { hash, transaction } => {
                     Self::Deposit(Sealed::new_unchecked(transaction.into(), hash))
                 }

--- a/crates/execution/eip8130/src/apply.rs
+++ b/crates/execution/eip8130/src/apply.rs
@@ -68,10 +68,20 @@ pub enum ApplyError {
     #[error("malformed actor-change revoke data")]
     MalformedRevokeData,
 
-    /// A signed batch carried an environment op (`IncrementLocalEpoch`, `Lock`,
-    /// or `Unlock`) whose apply handler is not yet enshrined. These ops are
-    /// wired into the apply path by a subsequent change; until then a batch
-    /// carrying one is rejected rather than silently ignored.
+    /// An op that requires an empty `payload` (currently `IncrementLocalEpoch`)
+    /// carried a non-empty one. Mirrors `Keystore.InvalidChangePayload`.
+    #[error("account-change op payload must be empty")]
+    InvalidChangePayload,
+
+    /// An `IncrementLocalEpoch` op could not advance because the local epoch is
+    /// at its terminal `u32::MAX` value. Mirrors `Keystore.EpochSaturated`.
+    #[error("local epoch is saturated and cannot be incremented")]
+    EpochSaturated,
+
+    /// A signed batch carried an environment op (`Lock` or `Unlock`) whose apply
+    /// handler is not yet enshrined. These ops are wired into the apply path by a
+    /// subsequent change; until then a batch carrying one is rejected rather than
+    /// silently ignored.
     #[error("unsupported account-change op in the enshrined apply path")]
     UnsupportedChangeType,
 
@@ -384,9 +394,11 @@ impl AccountChangeApplier {
                         Self::revoke_actor_with_account_state(storage, account, actor_id, state)?,
                     );
                 }
-                // Environment ops (IncrementLocalEpoch / Lock / Unlock) are
-                // wired into the apply path by a subsequent change.
-                ChangeType::IncrementLocalEpoch | ChangeType::Lock | ChangeType::Unlock => {
+                ChangeType::IncrementLocalEpoch => {
+                    Self::apply_increment_local_epoch(&change.payload, state)?;
+                }
+                // Lock / Unlock apply handlers are not yet enshrined.
+                ChangeType::Lock | ChangeType::Unlock => {
                     return Err(ApplyError::UnsupportedChangeType);
                 }
             }
@@ -444,6 +456,29 @@ impl AccountChangeApplier {
                     state.multichain_sequence.checked_add(1).ok_or(ApplyError::SequenceOverflow)?;
             }
         }
+        Ok(())
+    }
+
+    /// Applies an `IncrementLocalEpoch` op, mirroring `_applyIncrementLocalEpoch`:
+    /// a strict `local_epoch += 1` (rejecting the terminal `u32::MAX`) that also
+    /// resets `local_sequence` to 0, retiring every unlanded local signature (each
+    /// commits the full 64-bit `localEpoch ‖ localSequence` word). Allowed on
+    /// either channel — a Multichain batch may bump the local epoch without a
+    /// separate Local batch. The payload MUST be empty.
+    fn apply_increment_local_epoch(
+        payload: &[u8],
+        state: &mut AccountState,
+    ) -> Result<(), ApplyError> {
+        if !payload.is_empty() {
+            return Err(ApplyError::InvalidChangePayload);
+        }
+        // `local_epoch` stores a `uint32`; only the terminal value cannot advance
+        // (the epoch half has no reserved sentinel).
+        if state.local_epoch == u64::from(u32::MAX) {
+            return Err(ApplyError::EpochSaturated);
+        }
+        state.local_epoch += 1;
+        state.local_sequence = 0;
         Ok(())
     }
 
@@ -1265,6 +1300,76 @@ mod tests {
             .unwrap();
             assert_eq!(acc.get_change_sequences(ACCOUNT).unwrap(), (1, 1));
         });
+    }
+
+    /// An `IncrementLocalEpoch` op (empty payload).
+    fn increment_epoch_op() -> SignedChange {
+        SignedChange { change_type: ChangeType::IncrementLocalEpoch, payload: Bytes::new() }
+    }
+
+    #[test]
+    fn increment_local_epoch_bumps_epoch_and_resets_sequence() {
+        with_storage(|acc| {
+            // Seed a local sequence of 4; a Local sequenced batch at seq 4 advances
+            // it to 5, and the trailing IncrementLocalEpoch resets it to 0 while
+            // bumping the epoch to 1.
+            let mut state = acc.get_account_state(ACCOUNT).unwrap();
+            state.local_sequence = 4;
+            acc.set_account_state(ACCOUNT, state).unwrap();
+
+            AccountChangeApplier::apply_config_change(
+                acc,
+                ACCOUNT,
+                &[increment_epoch_op()],
+                AccountChangeChannel::Local,
+                4,
+            )
+            .unwrap();
+
+            let state = acc.get_account_state(ACCOUNT).unwrap();
+            assert_eq!(state.local_epoch, 1);
+            assert_eq!(state.local_sequence, 0);
+        });
+    }
+
+    #[test]
+    fn increment_local_epoch_on_multichain_channel_bumps_epoch() {
+        with_storage(|acc| {
+            // A Multichain batch may bump the local epoch; its own counter advances
+            // independently.
+            AccountChangeApplier::apply_config_change(
+                acc,
+                ACCOUNT,
+                &[increment_epoch_op()],
+                AccountChangeChannel::Multichain,
+                0,
+            )
+            .unwrap();
+
+            let state = acc.get_account_state(ACCOUNT).unwrap();
+            assert_eq!(state.local_epoch, 1);
+            assert_eq!(state.multichain_sequence, 1);
+            assert_eq!(state.local_sequence, 0);
+        });
+    }
+
+    #[test]
+    fn increment_local_epoch_rejects_nonempty_payload() {
+        let mut state = AccountState::from_word(alloy_primitives::U256::ZERO);
+        assert_eq!(
+            AccountChangeApplier::apply_increment_local_epoch(&[0xaa], &mut state),
+            Err(ApplyError::InvalidChangePayload),
+        );
+    }
+
+    #[test]
+    fn increment_local_epoch_rejects_saturated_epoch() {
+        let mut state = AccountState::from_word(alloy_primitives::U256::ZERO);
+        state.local_epoch = u64::from(u32::MAX);
+        assert_eq!(
+            AccountChangeApplier::apply_increment_local_epoch(&[], &mut state),
+            Err(ApplyError::EpochSaturated),
+        );
     }
 
     #[test]

--- a/crates/execution/eip8130/src/intrinsic.rs
+++ b/crates/execution/eip8130/src/intrinsic.rs
@@ -571,10 +571,13 @@ impl IntrinsicGas {
                 }
                 cost
             }
-            // Environment ops (IncrementLocalEpoch / Lock / Unlock) carry no
-            // per-actor slot writes; their gas is set when their apply handlers
-            // are enshrined.
-            ChangeType::IncrementLocalEpoch | ChangeType::Lock | ChangeType::Unlock => 0,
+            // IncrementLocalEpoch carries no per-actor slot writes; it rewrites
+            // the packed account-state slot the config change's sequence advance
+            // already touched, priced as a warm dirty SSTORE.
+            ChangeType::IncrementLocalEpoch => Eip8130GasSchedule::INCREMENT_LOCAL_EPOCH_COST,
+            // Lock / Unlock apply handlers are not yet enshrined; priced when
+            // wired in.
+            ChangeType::Lock | ChangeType::Unlock => 0,
         }
     }
 
@@ -939,6 +942,35 @@ mod tests {
             auth_cost
                 + Eip8130GasSchedule::CONFIG_CHANGE_STATE_COST
                 + Eip8130GasSchedule::ACTOR_SLOT_SET_COST * 3
+        );
+    }
+
+    #[test]
+    fn config_change_increment_local_epoch_charges_warm_state_bump() {
+        // A batch carrying a single IncrementLocalEpoch op (empty payload) pays the
+        // auth + first-state cost plus the marginal warm dirty-SSTORE for rewriting
+        // the packed account-state slot, and no per-actor slot writes.
+        let cc = SignedAccountChanges {
+            channel: AccountChangeChannel::Multichain,
+            sequence: 0,
+            changes: vec![SignedChange {
+                change_type: ChangeType::IncrementLocalEpoch,
+                payload: Bytes::new(),
+            }],
+            signature: Bytes::from(configured_auth(K1)),
+        };
+        let tx = TxEip8130 {
+            sender: Some(ACCOUNT),
+            account_changes: vec![AccountChange::ConfigChange(cc)],
+            ..Default::default()
+        };
+        let gas = intrinsic(&signed(tx, configured_auth(K1), vec![]), &EXISTING_KEY);
+        let auth_cost = Eip8130GasSchedule::AUTH_EXEC_K1 + Eip8130GasSchedule::COLD_SLOAD;
+        assert_eq!(
+            gas.account_changes,
+            auth_cost
+                + Eip8130GasSchedule::CONFIG_CHANGE_STATE_COST
+                + Eip8130GasSchedule::INCREMENT_LOCAL_EPOCH_COST
         );
     }
 

--- a/crates/execution/eip8130/src/schedule.rs
+++ b/crates/execution/eip8130/src/schedule.rs
@@ -124,6 +124,17 @@ impl Eip8130GasSchedule {
     /// This is body-derivable (the change's position is known), so estimation and
     /// execution price it identically.
     pub const CONFIG_CHANGE_STATE_COST_SUBSEQUENT: u64 = Self::WARM_SLOAD + Self::SSTORE_DIRTY;
+    /// Marginal cost of an `IncrementLocalEpoch` op. The op rewrites the packed
+    /// account-state slot (`local_epoch ‖ local_sequence`) that the config
+    /// change's own channel-sequence advance already touched and modified earlier
+    /// in the transaction, so the epoch bump is a warm **dirty** `SSTORE`
+    /// (EIP-2200 `original != current`) with no extra SLOAD — the ~100-gas
+    /// already-warm write the contract notes for the trailing increment. In the
+    /// rarer unsequenced-and-initialized case the advance performs no write, but
+    /// the first change's `CONFIG_CHANGE_STATE_COST` conservatively charged a full
+    /// zero-to-nonzero set for that slot, so adding this marginal cost still never
+    /// undercharges.
+    pub const INCREMENT_LOCAL_EPOCH_COST: u64 = Self::SSTORE_DIRTY;
     /// Worst-case revoke cost for the actor config and its two policy slots.
     ///
     /// Policy slots are cleared on every revoke. Charging all three as resets is

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -1517,6 +1517,8 @@ where
             ApplyError::Storage(_) => "EIP-8130 state access failed",
             ApplyError::MalformedAuthorizeData => "actor change authorize data is malformed",
             ApplyError::MalformedRevokeData => "actor change revoke data is malformed",
+            ApplyError::InvalidChangePayload => "account-change op payload must be empty",
+            ApplyError::EpochSaturated => "local epoch is saturated",
             ApplyError::UnsupportedChangeType => "unsupported account-change op",
             ApplyError::InvalidAuthenticator => "actor authenticator is not canonical",
             ApplyError::MalformedPolicyData => "actor policy data is malformed",
@@ -1919,9 +1921,10 @@ where
     ///   `address(0)` empty sentinel) is rejected here.
     /// - `RevokeActor`: `payload = abi.encode(bytes32 actorId)` — exactly the
     ///   32-byte target and nothing more.
-    /// - Environment ops (`IncrementLocalEpoch` / `Lock` / `Unlock`): their apply
-    ///   handlers are not yet enshrined, so a batch carrying one is rejected here
-    ///   rather than admitted and failed later.
+    /// - `IncrementLocalEpoch`: empty payload (mirrors the contract's
+    ///   `payload.length == 0` requirement); it names no actor.
+    /// - `Lock` / `Unlock`: their apply handlers are not yet enshrined, so a batch
+    ///   carrying one is rejected here rather than admitted and failed later.
     fn validate_actor_changes(changes: &[SignedChange]) -> Result<(), InvalidPoolTransactionError> {
         if changes.len() > Eip8130Constants::MAX_ACTOR_CHANGES_PER_CONFIG {
             return Err(InvalidTransactionError::TxTypeNotSupported.into());
@@ -1957,7 +1960,14 @@ where
                         return Err(InvalidTransactionError::TxTypeNotSupported.into());
                     }
                 }
-                ChangeType::IncrementLocalEpoch | ChangeType::Lock | ChangeType::Unlock => {
+                ChangeType::IncrementLocalEpoch => {
+                    if !change.payload.is_empty() {
+                        return Err(InvalidTransactionError::TxTypeNotSupported.into());
+                    }
+                    // Names no actor; skip the target-dedup.
+                    continue;
+                }
+                ChangeType::Lock | ChangeType::Unlock => {
                     return Err(InvalidTransactionError::TxTypeNotSupported.into());
                 }
             }
@@ -2901,14 +2911,51 @@ mod tests {
     }
 
     #[test]
-    fn rejects_eip8130_config_change_with_env_op() {
-        // Environment ops (IncrementLocalEpoch / Lock / Unlock) are not yet
-        // enshrined in the apply path, so a batch carrying one is rejected.
+    fn accepts_eip8130_config_change_with_increment_local_epoch() {
+        // IncrementLocalEpoch carries an empty payload and names no actor; it
+        // passes the structural walk on either channel.
         let cfg = SignedAccountChanges {
             changes: vec![SignedChange {
                 change_type: ChangeType::IncrementLocalEpoch,
                 payload: Bytes::new(),
             }],
+            ..make_valid_config_change()
+        };
+        let tx = TxEip8130 {
+            account_changes: vec![AccountChange::ConfigChange(cfg)],
+            ..minimal_valid_eoa_tx()
+        };
+        assert!(
+            TestValidator::validate_account_changes(&sign_eoa_eip8130(tx), test_chain_id()).is_ok()
+        );
+    }
+
+    #[test]
+    fn rejects_eip8130_config_change_with_nonempty_increment_local_epoch() {
+        // IncrementLocalEpoch must carry an empty payload.
+        let cfg = SignedAccountChanges {
+            changes: vec![SignedChange {
+                change_type: ChangeType::IncrementLocalEpoch,
+                payload: Bytes::from_static(&[0xaa]),
+            }],
+            ..make_valid_config_change()
+        };
+        let tx = TxEip8130 {
+            account_changes: vec![AccountChange::ConfigChange(cfg)],
+            ..minimal_valid_eoa_tx()
+        };
+        assert_unsupported(TestValidator::validate_account_changes(
+            &sign_eoa_eip8130(tx),
+            test_chain_id(),
+        ));
+    }
+
+    #[test]
+    fn rejects_eip8130_config_change_with_lock_op() {
+        // Lock / Unlock apply handlers are not yet enshrined, so a batch carrying
+        // one is rejected structurally.
+        let cfg = SignedAccountChanges {
+            changes: vec![SignedChange { change_type: ChangeType::Lock, payload: Bytes::new() }],
             ..make_valid_config_change()
         };
         let tx = TxEip8130 {


### PR DESCRIPTION
Wire `IncrementLocalEpoch` into the enshrined apply path, mirroring `_applyIncrementLocalEpoch` in `Keystore.sol`: an empty-payload op that strictly increments the local epoch (rejecting the terminal `u32::MAX`) and resets the local sequence to 0, retiring every unlanded local signature. Allowed on either channel. `Lock`/`Unlock` remain rejected until their handlers are enshrined.

The txpool structural validator now admits `IncrementLocalEpoch` (empty payload, no actor target) and continues to reject `Lock`/`Unlock`.

**Also includes the intrinsic-gas pricing (previously #4329):** adds `INCREMENT_LOCAL_EPOCH_COST` (a warm dirty SSTORE, ~100 gas) charged per `IncrementLocalEpoch` op. The op rewrites the packed account-state slot the config change's own sequence advance already touched, so the epoch bump is an already-warm dirty write; this never undercharges even in the unsequenced, already-initialized case where the first change conservatively priced a full cold set.