### PR TITLE
feat(eip8130): price IncrementLocalEpoch in intrinsic gas

### DIFF
--- a/crates/common/consensus/src/transaction/eip8130/account_changes.rs
+++ b/crates/common/consensus/src/transaction/eip8130/account_changes.rs
@@ -126,9 +126,10 @@ impl InitialActor {
 /// Mirrors the finalized `Keystore.ChangeType` enum. Authority ops
 /// ([`Self::AuthorizeActor`], [`Self::RevokeActor`]) mutate who can act;
 /// environment ops ([`Self::IncrementLocalEpoch`], [`Self::Lock`],
-/// [`Self::Unlock`]) mutate the rules ops are checked against and are valid only
-/// on the [`AccountChangeChannel::Local`] channel (`Lock`/`Unlock` must also be
-/// the batch's only op).
+/// [`Self::Unlock`]) mutate the rules ops are checked against.
+/// [`Self::IncrementLocalEpoch`] is valid on either channel (a Multichain batch
+/// may bump the local epoch); [`Self::Lock`]/[`Self::Unlock`] are valid only on
+/// the [`AccountChangeChannel::Local`] channel and must be the batch's only op.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -137,7 +138,7 @@ pub enum ChangeType {
     AuthorizeActor,
     /// Revoke an actor. Payload: `abi.encode(actorId)`.
     RevokeActor,
-    /// Increment the local epoch (Local only; empty payload).
+    /// Increment the local epoch (either channel; empty payload).
     IncrementLocalEpoch,
     /// Lock the account (Local only; standalone; payload: `abi.encode(uint16 unlockDelay)`).
     Lock,

--- a/crates/common/consensus/src/transaction/eip8130/constants.rs
+++ b/crates/common/consensus/src/transaction/eip8130/constants.rs
@@ -123,8 +123,8 @@ impl Eip8130Constants {
     /// `ChangeType` op byte: revoke an actor. Payload is `abi.encode(bytes32 actorId)`.
     pub const CHANGE_TYPE_REVOKE_ACTOR: u8 = 0x01;
 
-    /// `ChangeType` op byte: increment the local epoch (Local channel only;
-    /// empty payload). Invalidates every unlanded local signature at a prior epoch.
+    /// `ChangeType` op byte: increment the local epoch (either channel; empty
+    /// payload). Invalidates every unlanded local signature at a prior epoch.
     pub const CHANGE_TYPE_INCREMENT_LOCAL_EPOCH: u8 = 0x02;
 
     /// `ChangeType` op byte: lock the account (Local channel only; standalone;

--- a/crates/execution/eip8130/src/apply.rs
+++ b/crates/execution/eip8130/src/apply.rs
@@ -68,10 +68,20 @@ pub enum ApplyError {
     #[error("malformed actor-change revoke data")]
     MalformedRevokeData,
 
-    /// A signed batch carried an environment op (`IncrementLocalEpoch`, `Lock`,
-    /// or `Unlock`) whose apply handler is not yet enshrined. These ops are
-    /// wired into the apply path by a subsequent change; until then a batch
-    /// carrying one is rejected rather than silently ignored.
+    /// An op that requires an empty `payload` (currently `IncrementLocalEpoch`)
+    /// carried a non-empty one. Mirrors `Keystore.InvalidChangePayload`.
+    #[error("account-change op payload must be empty")]
+    InvalidChangePayload,
+
+    /// An `IncrementLocalEpoch` op could not advance because the local epoch is
+    /// at its terminal `u32::MAX` value. Mirrors `Keystore.EpochSaturated`.
+    #[error("local epoch is saturated and cannot be incremented")]
+    EpochSaturated,
+
+    /// A signed batch carried an environment op (`Lock` or `Unlock`) whose apply
+    /// handler is not yet enshrined. These ops are wired into the apply path by a
+    /// subsequent change; until then a batch carrying one is rejected rather than
+    /// silently ignored.
     #[error("unsupported account-change op in the enshrined apply path")]
     UnsupportedChangeType,
 
@@ -355,9 +365,11 @@ impl AccountChangeApplier {
                         Self::revoke_actor_with_account_state(storage, account, actor_id, state)?,
                     );
                 }
-                // Environment ops (IncrementLocalEpoch / Lock / Unlock) are
-                // wired into the apply path by a subsequent change.
-                ChangeType::IncrementLocalEpoch | ChangeType::Lock | ChangeType::Unlock => {
+                ChangeType::IncrementLocalEpoch => {
+                    Self::apply_increment_local_epoch(&change.payload, state)?;
+                }
+                // Lock / Unlock apply handlers are not yet enshrined.
+                ChangeType::Lock | ChangeType::Unlock => {
                     return Err(ApplyError::UnsupportedChangeType);
                 }
             }
@@ -415,6 +427,29 @@ impl AccountChangeApplier {
                     state.multichain_sequence.checked_add(1).ok_or(ApplyError::SequenceOverflow)?;
             }
         }
+        Ok(())
+    }
+
+    /// Applies an `IncrementLocalEpoch` op, mirroring `_applyIncrementLocalEpoch`:
+    /// a strict `local_epoch += 1` (rejecting the terminal `u32::MAX`) that also
+    /// resets `local_sequence` to 0, retiring every unlanded local signature (each
+    /// commits the full 64-bit `localEpoch ‖ localSequence` word). Allowed on
+    /// either channel — a Multichain batch may bump the local epoch without a
+    /// separate Local batch. The payload MUST be empty.
+    fn apply_increment_local_epoch(
+        payload: &[u8],
+        state: &mut AccountState,
+    ) -> Result<(), ApplyError> {
+        if !payload.is_empty() {
+            return Err(ApplyError::InvalidChangePayload);
+        }
+        // `local_epoch` stores a `uint32`; only the terminal value cannot advance
+        // (the epoch half has no reserved sentinel).
+        if state.local_epoch == u64::from(u32::MAX) {
+            return Err(ApplyError::EpochSaturated);
+        }
+        state.local_epoch += 1;
+        state.local_sequence = 0;
         Ok(())
     }
 
@@ -1213,6 +1248,76 @@ mod tests {
             .unwrap();
             assert_eq!(acc.get_change_sequences(ACCOUNT).unwrap(), (1, 1));
         });
+    }
+
+    /// An `IncrementLocalEpoch` op (empty payload).
+    fn increment_epoch_op() -> SignedChange {
+        SignedChange { change_type: ChangeType::IncrementLocalEpoch, payload: Bytes::new() }
+    }
+
+    #[test]
+    fn increment_local_epoch_bumps_epoch_and_resets_sequence() {
+        with_storage(|acc| {
+            // Seed a local sequence of 4; a Local sequenced batch at seq 4 advances
+            // it to 5, and the trailing IncrementLocalEpoch resets it to 0 while
+            // bumping the epoch to 1.
+            let mut state = acc.get_account_state(ACCOUNT).unwrap();
+            state.local_sequence = 4;
+            acc.set_account_state(ACCOUNT, state).unwrap();
+
+            AccountChangeApplier::apply_config_change(
+                acc,
+                ACCOUNT,
+                &[increment_epoch_op()],
+                AccountChangeChannel::Local,
+                4,
+            )
+            .unwrap();
+
+            let state = acc.get_account_state(ACCOUNT).unwrap();
+            assert_eq!(state.local_epoch, 1);
+            assert_eq!(state.local_sequence, 0);
+        });
+    }
+
+    #[test]
+    fn increment_local_epoch_on_multichain_channel_bumps_epoch() {
+        with_storage(|acc| {
+            // A Multichain batch may bump the local epoch; its own counter advances
+            // independently.
+            AccountChangeApplier::apply_config_change(
+                acc,
+                ACCOUNT,
+                &[increment_epoch_op()],
+                AccountChangeChannel::Multichain,
+                0,
+            )
+            .unwrap();
+
+            let state = acc.get_account_state(ACCOUNT).unwrap();
+            assert_eq!(state.local_epoch, 1);
+            assert_eq!(state.multichain_sequence, 1);
+            assert_eq!(state.local_sequence, 0);
+        });
+    }
+
+    #[test]
+    fn increment_local_epoch_rejects_nonempty_payload() {
+        let mut state = AccountState::from_word(alloy_primitives::U256::ZERO);
+        assert_eq!(
+            AccountChangeApplier::apply_increment_local_epoch(&[0xaa], &mut state),
+            Err(ApplyError::InvalidChangePayload),
+        );
+    }
+
+    #[test]
+    fn increment_local_epoch_rejects_saturated_epoch() {
+        let mut state = AccountState::from_word(alloy_primitives::U256::ZERO);
+        state.local_epoch = u64::from(u32::MAX);
+        assert_eq!(
+            AccountChangeApplier::apply_increment_local_epoch(&[], &mut state),
+            Err(ApplyError::EpochSaturated),
+        );
     }
 
     #[test]

--- a/crates/execution/eip8130/src/intrinsic.rs
+++ b/crates/execution/eip8130/src/intrinsic.rs
@@ -571,10 +571,13 @@ impl IntrinsicGas {
                 }
                 cost
             }
-            // Environment ops (IncrementLocalEpoch / Lock / Unlock) carry no
-            // per-actor slot writes; their gas is set when their apply handlers
-            // are enshrined.
-            ChangeType::IncrementLocalEpoch | ChangeType::Lock | ChangeType::Unlock => 0,
+            // IncrementLocalEpoch carries no per-actor slot writes; it rewrites
+            // the packed account-state slot the config change's sequence advance
+            // already touched, priced as a warm dirty SSTORE.
+            ChangeType::IncrementLocalEpoch => Eip8130GasSchedule::INCREMENT_LOCAL_EPOCH_COST,
+            // Lock / Unlock apply handlers are not yet enshrined; priced when
+            // wired in.
+            ChangeType::Lock | ChangeType::Unlock => 0,
         }
     }
 
@@ -939,6 +942,35 @@ mod tests {
             auth_cost
                 + Eip8130GasSchedule::CONFIG_CHANGE_STATE_COST
                 + Eip8130GasSchedule::ACTOR_SLOT_SET_COST * 3
+        );
+    }
+
+    #[test]
+    fn config_change_increment_local_epoch_charges_warm_state_bump() {
+        // A batch carrying a single IncrementLocalEpoch op (empty payload) pays the
+        // auth + first-state cost plus the marginal warm dirty-SSTORE for rewriting
+        // the packed account-state slot, and no per-actor slot writes.
+        let cc = SignedAccountChanges {
+            channel: AccountChangeChannel::Multichain,
+            sequence: 0,
+            changes: vec![SignedChange {
+                change_type: ChangeType::IncrementLocalEpoch,
+                payload: Bytes::new(),
+            }],
+            signature: Bytes::from(configured_auth(K1)),
+        };
+        let tx = TxEip8130 {
+            sender: Some(ACCOUNT),
+            account_changes: vec![AccountChange::ConfigChange(cc)],
+            ..Default::default()
+        };
+        let gas = intrinsic(&signed(tx, configured_auth(K1), vec![]), &EXISTING_KEY);
+        let auth_cost = Eip8130GasSchedule::AUTH_EXEC_K1 + Eip8130GasSchedule::COLD_SLOAD;
+        assert_eq!(
+            gas.account_changes,
+            auth_cost
+                + Eip8130GasSchedule::CONFIG_CHANGE_STATE_COST
+                + Eip8130GasSchedule::INCREMENT_LOCAL_EPOCH_COST
         );
     }
 

--- a/crates/execution/eip8130/src/schedule.rs
+++ b/crates/execution/eip8130/src/schedule.rs
@@ -124,6 +124,17 @@ impl Eip8130GasSchedule {
     /// This is body-derivable (the change's position is known), so estimation and
     /// execution price it identically.
     pub const CONFIG_CHANGE_STATE_COST_SUBSEQUENT: u64 = Self::WARM_SLOAD + Self::SSTORE_DIRTY;
+    /// Marginal cost of an `IncrementLocalEpoch` op. The op rewrites the packed
+    /// account-state slot (`local_epoch ‖ local_sequence`) that the config
+    /// change's own channel-sequence advance already touched and modified earlier
+    /// in the transaction, so the epoch bump is a warm **dirty** `SSTORE`
+    /// (EIP-2200 `original != current`) with no extra SLOAD — the ~100-gas
+    /// already-warm write the contract notes for the trailing increment. In the
+    /// rarer unsequenced-and-initialized case the advance performs no write, but
+    /// the first change's `CONFIG_CHANGE_STATE_COST` conservatively charged a full
+    /// zero-to-nonzero set for that slot, so adding this marginal cost still never
+    /// undercharges.
+    pub const INCREMENT_LOCAL_EPOCH_COST: u64 = Self::SSTORE_DIRTY;
     /// Worst-case revoke cost for the actor config and its two policy slots.
     ///
     /// Policy slots are cleared on every revoke. Charging all three as resets is

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -1517,6 +1517,8 @@ where
             ApplyError::Storage(_) => "EIP-8130 state access failed",
             ApplyError::MalformedAuthorizeData => "actor change authorize data is malformed",
             ApplyError::MalformedRevokeData => "actor change revoke data is malformed",
+            ApplyError::InvalidChangePayload => "account-change op payload must be empty",
+            ApplyError::EpochSaturated => "local epoch is saturated",
             ApplyError::UnsupportedChangeType => "unsupported account-change op",
             ApplyError::InvalidAuthenticator => "actor authenticator is not canonical",
             ApplyError::MalformedPolicyData => "actor policy data is malformed",
@@ -1905,20 +1907,23 @@ where
     ///   `address(0)` empty sentinel) is rejected here.
     /// - `RevokeActor`: `payload = abi.encode(bytes32 actorId)` — exactly the
     ///   32-byte target and nothing more.
-    /// - Environment ops (`IncrementLocalEpoch` / `Lock` / `Unlock`): their apply
-    ///   handlers are not yet enshrined, so a batch carrying one is rejected here
-    ///   rather than admitted and failed later.
+    /// - `IncrementLocalEpoch`: empty payload (mirrors the contract's
+    ///   `payload.length == 0` requirement); it names no actor, so it is not
+    ///   subject to the target-dedup below.
+    /// - `Lock` / `Unlock`: their apply handlers are not yet enshrined, so a batch
+    ///   carrying one is rejected here rather than admitted and failed later.
     fn validate_actor_changes(changes: &[SignedChange]) -> Result<(), InvalidPoolTransactionError> {
         if changes.len() > Eip8130Constants::MAX_ACTOR_CHANGES_PER_CONFIG {
             return Err(InvalidTransactionError::TxTypeNotSupported.into());
         }
         let mut seen = BTreeSet::new();
         for change in changes {
-            // Only `AuthorizeActor`/`RevokeActor` payloads lead with a 32-byte
-            // target `actorId`; extract it per-arm so the duplicate-target check
-            // below is unreachable for environment ops (which carry no actorId and
-            // whose arm returns early). This keeps the `payload[..32]` slice from
-            // ever misreading a non-actorId payload if those ops are enshrined.
+            // Only authority ops (`AuthorizeActor`/`RevokeActor`) lead with a
+            // 32-byte target `actorId`; extract it per-arm so the duplicate-target
+            // check below is unreachable for ops that name no actor
+            // (`IncrementLocalEpoch` skips via `continue`; `Lock`/`Unlock` are
+            // rejected). This keeps the `payload[..32]` slice from ever misreading
+            // a non-actorId payload.
             let actor_id = match change.change_type {
                 ChangeType::AuthorizeActor => {
                     // `payload` = `abi.encode(bytes32 actorId, ActorConfig, bytes)`;
@@ -1945,7 +1950,14 @@ where
                     }
                     B256::from_slice(&change.payload[..32])
                 }
-                ChangeType::IncrementLocalEpoch | ChangeType::Lock | ChangeType::Unlock => {
+                ChangeType::IncrementLocalEpoch => {
+                    if !change.payload.is_empty() {
+                        return Err(InvalidTransactionError::TxTypeNotSupported.into());
+                    }
+                    // Names no actor; skip the target-dedup.
+                    continue;
+                }
+                ChangeType::Lock | ChangeType::Unlock => {
                     return Err(InvalidTransactionError::TxTypeNotSupported.into());
                 }
             };
@@ -2893,14 +2905,51 @@ mod tests {
     }
 
     #[test]
-    fn rejects_eip8130_config_change_with_env_op() {
-        // Environment ops (IncrementLocalEpoch / Lock / Unlock) are not yet
-        // enshrined in the apply path, so a batch carrying one is rejected.
+    fn accepts_eip8130_config_change_with_increment_local_epoch() {
+        // IncrementLocalEpoch carries an empty payload and names no actor; it
+        // passes the structural walk on either channel.
         let cfg = SignedAccountChanges {
             changes: vec![SignedChange {
                 change_type: ChangeType::IncrementLocalEpoch,
                 payload: Bytes::new(),
             }],
+            ..make_valid_config_change()
+        };
+        let tx = TxEip8130 {
+            account_changes: vec![AccountChange::ConfigChange(cfg)],
+            ..minimal_valid_eoa_tx()
+        };
+        assert!(
+            TestValidator::validate_account_changes(&sign_eoa_eip8130(tx), test_chain_id()).is_ok()
+        );
+    }
+
+    #[test]
+    fn rejects_eip8130_config_change_with_nonempty_increment_local_epoch() {
+        // IncrementLocalEpoch must carry an empty payload.
+        let cfg = SignedAccountChanges {
+            changes: vec![SignedChange {
+                change_type: ChangeType::IncrementLocalEpoch,
+                payload: Bytes::from_static(&[0xaa]),
+            }],
+            ..make_valid_config_change()
+        };
+        let tx = TxEip8130 {
+            account_changes: vec![AccountChange::ConfigChange(cfg)],
+            ..minimal_valid_eoa_tx()
+        };
+        assert_unsupported(TestValidator::validate_account_changes(
+            &sign_eoa_eip8130(tx),
+            test_chain_id(),
+        ));
+    }
+
+    #[test]
+    fn rejects_eip8130_config_change_with_lock_op() {
+        // Lock / Unlock apply handlers are not yet enshrined, so a batch carrying
+        // one is rejected structurally.
+        let cfg = SignedAccountChanges {
+            changes: vec![SignedChange { change_type: ChangeType::Lock, payload: Bytes::new() }],
             ..make_valid_config_change()
         };
         let tx = TxEip8130 {


### PR DESCRIPTION
## Summary
- Adds `INCREMENT_LOCAL_EPOCH_COST` to the EIP-8130 gas schedule and charges it from `actor_change_write_cost` for the new op, so intrinsic gas covers the single warm state bump the apply handler performs.

## Stack
Base: #4327 / 4b (IncrementLocalEpoch apply). PR 4c of the EIP-8130 parity stack.

## Test plan
- [x] `cargo test -p base-execution-eip8130` (incl. new warm-state-bump gas test)
- [x] `cargo clippy` clean