### PR TITLE
feat(eip8130): port Keystore.validateSignature to native SignatureVerifier

### DIFF
--- a/crates/common/consensus/src/transaction/eip8130/account_changes.rs
+++ b/crates/common/consensus/src/transaction/eip8130/account_changes.rs
@@ -17,15 +17,17 @@ use crate::transaction::eip8130::constants::Eip8130Constants;
 
 /// Bitmask describing the contexts in which an actor is valid.
 ///
-/// On the wire, `Scope` is encoded as a single RLP-encoded byte (matching the
-/// EIP-8130 `uint8` spec), not as a one-element list. The derived RLP impls
-/// from `alloy_rlp` would wrap the inner byte in a list header, so the
-/// `Encodable`/`Decodable` impls are written by hand.
+/// On the wire, `Scope` is encoded as a minimal RLP-encoded integer (matching
+/// the EIP-8130 `uint16` spec), not as a one-element list. The derived RLP impls
+/// from `alloy_rlp` would wrap the inner value in a list header, so the
+/// `Encodable`/`Decodable` impls are written by hand. RLP integers are
+/// minimal-big-endian, so values `<= 0xff` encode identically to the earlier
+/// `uint8` form.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
-pub struct Scope(pub u8);
+pub struct Scope(pub u16);
 
 impl Encodable for Scope {
     fn encode(&self, out: &mut dyn BufMut) {
@@ -39,7 +41,7 @@ impl Encodable for Scope {
 
 impl Decodable for Scope {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        u8::decode(buf).map(Self)
+        u16::decode(buf).map(Self)
     }
 }
 
@@ -48,7 +50,7 @@ impl Scope {
     pub const UNRESTRICTED: Self = Self(Eip8130Constants::SCOPE_UNRESTRICTED);
 
     /// Returns the raw bitmask.
-    pub const fn bits(&self) -> u8 {
+    pub const fn bits(&self) -> u16 {
         self.0
     }
 
@@ -89,8 +91,9 @@ impl Scope {
 /// (initial actors are always non-expiring, committed as `0`) and a
 /// self-referential `manager = account` (the account address is not known at
 /// commitment time). The field order matches the wire encoding and the
-/// address-derivation commitment (`actorId || authenticator || scope ||
-/// policyData`).
+/// per-actor leaf hashed into the address-derivation commitment
+/// (`keccak256(actorId || authenticator || scope || policyData)`, then the
+/// commitment is `keccak256` over the packed leaves).
 ///
 /// [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
 #[derive(Debug, Clone, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable)]
@@ -102,8 +105,8 @@ pub struct InitialActor {
     pub actor_id: B256,
     /// Address of the authenticator contract (e.g. an ERC-1271 authenticator).
     pub authenticator: Address,
-    /// Scope byte (`0x00` = unrestricted admin), stored verbatim.
-    pub scope: u8,
+    /// Scope bitfield (`uint16`; `0x0000` = unrestricted admin), stored verbatim.
+    pub scope: u16,
     /// Policy data: empty unless `scope` sets `POLICY`, otherwise exactly
     /// `manager (20) || commitment (32)`. Committed to the derived address.
     pub policy_data: Bytes,

--- a/crates/common/consensus/src/transaction/eip8130/constants.rs
+++ b/crates/common/consensus/src/transaction/eip8130/constants.rs
@@ -45,28 +45,30 @@ impl Eip8130Constants {
 
     /// Actor scope bit: ungated `sender_auth` validation context; may originate
     /// transactions to any `call.to`.
-    pub const SCOPE_SENDER: u8 = 0x01;
+    pub const SCOPE_SENDER: u16 = 0x0001;
 
     /// Actor scope bit: policy-gated sender context; may originate transactions
     /// only to the actor's `policy_manager`.
-    pub const SCOPE_POLICY: u8 = 0x02;
+    pub const SCOPE_POLICY: u16 = 0x0002;
 
     /// Actor scope bit: nonce authorization context; permits a restricted actor
     /// to use sequenced `nonce_key`s (otherwise nonceless-only).
-    pub const SCOPE_NONCE: u8 = 0x04;
+    pub const SCOPE_NONCE: u16 = 0x0004;
 
     /// Actor scope bit: self-pay gas; authorizes paying the account's own gas
     /// when `payer == sender`.
-    pub const SCOPE_SELF_PAYER: u8 = 0x08;
+    pub const SCOPE_SELF_PAYER: u16 = 0x0008;
 
     /// Actor scope bit: sponsor gas; authorizes acting as `payer_auth` for a
     /// different sender (`payer != sender`).
-    pub const SCOPE_SPONSOR_PAYER: u8 = 0x10;
+    pub const SCOPE_SPONSOR_PAYER: u16 = 0x0010;
 
     // ERC-1271 signing rides on operational authority (admin `scope == 0x00`, or
     // a SENDER actor without POLICY); it is not its own scope bit, so there is no
-    // `SCOPE_SIGNATURE`. Bits `0x20`, `0x40`, and `0x80` are spare, reserved for
-    // future pure grants.
+    // `SCOPE_SIGNATURE`. The remaining bits of the `uint16` scope are spare,
+    // reserved for future pure grants. The Keystore itself is scope-agnostic
+    // except for `scope == 0` (admin) and the single interpreted `SCOPE_POLICY`
+    // bit; every other bit is stored verbatim and interpreted protocol-side.
 
     /// Domain-separation prefix for the `replay_id` preimage
     /// (`keccak256(REPLAY_ID_TYPE || rlp([...])`).
@@ -80,7 +82,7 @@ impl Eip8130Constants {
     pub const REPLAY_ID_TYPE: [u8; 2] = [0x79, 0x01];
 
     /// Unrestricted scope value (actor is valid in all contexts).
-    pub const SCOPE_UNRESTRICTED: u8 = 0x00;
+    pub const SCOPE_UNRESTRICTED: u16 = 0x0000;
 
     /// [EIP-7702]-style delegation indicator code prefix.
     ///
@@ -259,7 +261,7 @@ mod tests {
             Eip8130Constants::SCOPE_SELF_PAYER,
             Eip8130Constants::SCOPE_SPONSOR_PAYER,
         ];
-        let mut acc: u8 = 0;
+        let mut acc: u16 = 0;
         for b in bits {
             assert_eq!(b.count_ones(), 1, "scope bit must be a single bit");
             assert_eq!(acc & b, 0, "scope bits must be orthogonal");

--- a/crates/common/evm/src/eip8130.rs
+++ b/crates/common/evm/src/eip8130.rs
@@ -2347,8 +2347,8 @@ mod tests {
     sol! {
         struct ActorConfigAbi {
             address authenticator;
-            uint8 scope;
             uint48 expiry;
+            uint16 scope;
         }
     }
 
@@ -2356,14 +2356,14 @@ mod tests {
     /// change (mirrors `AccountChangeApplier`'s decode shape).
     fn authorize_change_data(
         authenticator: Address,
-        scope: u8,
+        scope: u16,
         expiry: u64,
         policy_data: &[u8],
     ) -> Bytes {
         let abi = ActorConfigAbi {
             authenticator,
-            scope,
             expiry: alloy_primitives::aliases::U48::from(expiry),
+            scope,
         };
         Bytes::from((abi, Bytes::copy_from_slice(policy_data)).abi_encode_params())
     }
@@ -2838,11 +2838,12 @@ mod tests {
         assert!(slot0.is_none() || slot0 == Some(U256::ZERO), "phase 1 should have been skipped");
     }
 
-    /// Canonical Solidity packing of an `ActorConfig` word.
-    fn pack_actor(authenticator: Address, scope: u8, expiry: u64) -> U256 {
+    /// Canonical Solidity packing of an `ActorConfig` word (authenticator 0..160,
+    /// expiry 160..208, scope 208..224).
+    fn pack_actor(authenticator: Address, scope: u16, expiry: u64) -> U256 {
         U256::from_be_slice(authenticator.as_slice())
-            | (U256::from(scope) << 160)
-            | (U256::from(expiry) << 168)
+            | (U256::from(expiry) << 160)
+            | (U256::from(scope) << 208)
     }
 
     /// Signs `tx` for a configured sender as `K1_AUTHENTICATOR || sig`.

--- a/crates/execution/eip8130/src/account_config.rs
+++ b/crates/execution/eip8130/src/account_config.rs
@@ -168,10 +168,10 @@ impl AccountConfigurationStorage<'_> {
     /// its still-live implicit default EOA — which bumps `multichain_sequence`
     /// while leaving `local_sequence` at 0. The contract treats that account as
     /// initialized (blocking a later create/import from clobbering the
-    /// multichain-established state), so both counters must be checked.
+    /// multichain-established state), so the local word (`local_sequence` or
+    /// `local_epoch`) and `multichain_sequence` must all be checked.
     pub fn is_initialized(&self, account: Address) -> Result<bool> {
-        let state = self.get_account_state(account)?;
-        Ok(state.local_sequence > 0 || state.multichain_sequence > 0)
+        Ok(self.get_account_state(account)?.is_initialized())
     }
 
     /// Mirrors `AccountConfiguration._isLocked`: not locked unless `FLAG_LOCKED`
@@ -239,15 +239,15 @@ impl AccountConfigurationStorage<'_> {
     }
 }
 
-/// Decoded `AccountConfiguration.ActorConfig` (one packed storage slot).
+/// Decoded `Keystore.ActorConfig` (one packed storage slot).
 ///
-/// Solidity layout `{address authenticator; uint8 scope; uint48 expiry;}` packs
-/// right-aligned in declaration order, lowest-order field
-/// first, into a single 32-byte slot:
+/// Solidity layout `{address authenticator; uint48 expiry; uint16 scope;}` packs
+/// right-aligned in declaration order, lowest-order field first, into a single
+/// 32-byte slot, with the top 4 bytes reserved padding that MUST stay zero:
 ///
 /// ```text
-/// bytes (big-endian):  [0..5) reserved | [5..11) expiry | [11] scope | [12..32) authenticator
-/// bits  (LSB-first):   authenticator 0..160 | scope 160..168 | expiry 168..216 | reserved 216..256
+/// bytes (big-endian):  [0..4) reserved | [4..6) scope | [6..12) expiry | [12..32) authenticator
+/// bits  (LSB-first):   authenticator 0..160 | expiry 160..208 | scope 208..224 | reserved 224..256
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
@@ -255,21 +255,21 @@ pub struct ActorConfig {
     /// Authenticator address bound to the actor (`address(0)` = empty slot,
     /// `address(1)` = native k1/ecrecover, any other = `IAuthenticator` contract).
     pub authenticator: Address,
-    /// Elevated-scope bitfield (`0 = unrestricted`).
-    pub scope: u8,
     /// Unix-seconds expiry; `0 = no expiry`. The actor is invalid once
     /// `block.timestamp > expiry`.
     pub expiry: u64,
+    /// Elevated-scope bitfield (`uint16`; `0 = unrestricted`).
+    pub scope: u16,
 }
 
 impl ActorConfig {
     /// The empty (unset) actor config: a zeroed storage slot.
-    pub const EMPTY: Self = Self { authenticator: Address::ZERO, scope: 0, expiry: 0 };
+    pub const EMPTY: Self = Self { authenticator: Address::ZERO, expiry: 0, scope: 0 };
 
-    /// Returns whether the reserved high 40 bits of a packed word are non-zero.
+    /// Returns whether the reserved high 32 bits of a packed word are non-zero.
     #[must_use]
     pub fn has_nonzero_reserved(word: U256) -> bool {
-        word.to_be_bytes::<32>()[..5].iter().any(|&byte| byte != 0)
+        word.to_be_bytes::<32>()[..4].iter().any(|&byte| byte != 0)
     }
 
     /// Unpacks a raw `ActorConfig` storage word.
@@ -277,11 +277,11 @@ impl ActorConfig {
     pub fn from_word(word: U256) -> Self {
         let b = word.to_be_bytes::<32>();
         let mut expiry = [0u8; 8];
-        expiry[2..].copy_from_slice(&b[5..11]); // uint48: 6 bytes, big-endian
+        expiry[2..].copy_from_slice(&b[6..12]); // uint48: 6 bytes, big-endian
         Self {
             authenticator: Address::from_slice(&b[12..32]),
-            scope: b[11],
             expiry: u64::from_be_bytes(expiry),
+            scope: u16::from_be_bytes([b[4], b[5]]), // uint16: 2 bytes
         }
     }
 
@@ -302,35 +302,40 @@ impl ActorConfig {
         debug_assert!(self.expiry >> 48 == 0, "expiry exceeds uint48 storage width");
         let mut b = [0u8; 32];
         b[12..32].copy_from_slice(self.authenticator.as_slice());
-        b[11] = self.scope;
-        b[5..11].copy_from_slice(&self.expiry.to_be_bytes()[2..]); // uint48: low 6 bytes
+        b[6..12].copy_from_slice(&self.expiry.to_be_bytes()[2..]); // uint48: low 6 bytes
+        b[4..6].copy_from_slice(&self.scope.to_be_bytes()); // uint16: 2 bytes
         U256::from_be_bytes(b)
     }
 }
 
-/// Decoded `AccountConfiguration.AccountState` (one packed storage slot).
+/// Decoded `Keystore.AccountState` (one packed storage slot).
 ///
-/// Solidity layout `{uint64 multichainSequence; uint64 localSequence; uint8
-/// flags; uint40 lockUnion; uint8 defaultEOAScope; uint48 defaultEOAExpiry;}`,
-/// packed right-aligned, lowest-order field first; the top 3 bytes of the slot
-/// are reserved padding that MUST stay zero:
+/// Solidity layout `{uint64 multichainSequence; uint32 localSequence; uint32
+/// localEpoch; uint8 flags; uint48 lockUnion; uint48 defaultEOAExpiry; uint16
+/// defaultEOAScope;}`, packed right-aligned, lowest-order field first; the top
+/// byte of the slot is reserved padding that MUST stay zero:
 ///
 /// ```text
-/// bits (LSB-first): multichain 0..64 | local 64..128 | flags 128..136 | lock_union 136..176 | defaultEOAScope 176..184 | defaultEOAExpiry 184..232 | reserved 232..256
+/// bits (LSB-first): multichain 0..64 | localSequence 64..96 | localEpoch 96..128 | flags 128..136 | lock_union 136..184 | defaultEOAExpiry 184..232 | defaultEOAScope 232..248 | reserved 248..256
 /// ```
 ///
-/// `lock_union` is a `uint40` union field (see [Account Lock] in the spec): while
+/// The local replay counter is split into two adjacent `uint32` fields —
+/// `local_sequence` (low) and `local_epoch` (high) — which occupy the same 8
+/// bytes as, and read identically to, the single `localEpoch(32) ||
+/// localSequence(32)` word committed in a signed batch's `sequence`.
+///
+/// `lock_union` is a `uint48` union field (see [Account Lock] in the spec): while
 /// [`Eip8130Constants::FLAG_UNLOCK_INITIATED`] is clear it holds the configured
 /// `unlock_delay` (seconds, `uint16` range); while set it holds `unlocks_at` (the
 /// timestamp at which a pending unlock takes effect). Lock state is mutated only
-/// through the EVM `applySignedLockChanges` entry point; the native path only
-/// reads it (see [`Self::is_locked`]).
+/// through the EVM signed-change entry point; the native path only reads it (see
+/// [`Self::is_locked`]).
 ///
 /// The `default_eoa_*` fields are the inline home for the account's own
 /// secp256k1 ("self") key: when `DEFAULT_EOA_REVOKED` is unset, a k1 signature
 /// recovering to the account authenticates with this inline config — all-zero
-/// is the implicit full owner, a non-zero scope/policy/expiry is a scoped self
-/// — so the entire self key resolves in a single account-state SLOAD. The
+/// is the implicit full owner, a non-zero scope/expiry is a scoped self — so the
+/// entire self key resolves in a single account-state SLOAD. The
 /// `actor_config(self)` slot is reserved for a *non*-k1 self authenticator
 /// (e.g. a post-quantum verifier returning the self-actorId); the inline k1
 /// self and a non-k1 self are mutually exclusive.
@@ -339,56 +344,64 @@ impl ActorConfig {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct AccountState {
-    /// Sequence for `chain_id == 0` (multichain) signed actor changes. A non-zero
-    /// value also marks the account initialized (see [`Self`] / `is_initialized`).
+    /// Sequence for the multichain (`chain_id == 0`) signed-change channel. A
+    /// non-zero value also marks the account initialized (see [`Self`] /
+    /// `is_initialized`).
     pub multichain_sequence: u64,
-    /// Sequence for local (`chain_id == block.chainid`) changes. Set to 1 at
-    /// bootstrap (create/import); a non-zero value also marks the account
-    /// initialized (see [`Self`] / `is_initialized`).
+    /// Local-channel sequence (`uint32`). Set to 1 at bootstrap (create/import);
+    /// a non-zero value also marks the account initialized. Reset to 0 by an
+    /// `IncrementLocalEpoch` op (which bumps `local_epoch`).
     pub local_sequence: u64,
+    /// Local-channel epoch (`uint32`). Incremented by `IncrementLocalEpoch`,
+    /// invalidating every unlanded local signature at a prior epoch. A non-zero
+    /// value also marks the account initialized.
+    pub local_epoch: u64,
     /// Account flags bitfield: bit 0 ([`Eip8130Constants::DEFAULT_EOA_REVOKED`])
     /// disables the inline secp256k1 self key; bit 1
     /// ([`Eip8130Constants::FLAG_LOCKED`]) freezes actor configuration; bit 2
     /// ([`Eip8130Constants::FLAG_UNLOCK_INITIATED`]) selects the `lock_union`
     /// interpretation.
     pub flags: u8,
-    /// `uint40` lock union: `unlock_delay` (seconds) while `FLAG_UNLOCK_INITIATED`
+    /// `uint48` lock union: `unlock_delay` (seconds) while `FLAG_UNLOCK_INITIATED`
     /// is clear, else `unlocks_at` (Unix-seconds timestamp).
     pub lock_union: u64,
-    /// Inline self-key scope bitfield (`0` = unrestricted full owner). Governs
-    /// only when the self key is live (`!default_eoa_revoked()`).
-    pub default_eoa_scope: u8,
     /// Inline self-key Unix-seconds expiry (`0` = no expiry). The self key is
     /// invalid once `now > default_eoa_expiry`.
     pub default_eoa_expiry: u64,
+    /// Inline self-key scope bitfield (`uint16`; `0` = unrestricted full owner).
+    /// Governs only when the self key is live (`!default_eoa_revoked()`).
+    pub default_eoa_scope: u16,
 }
 
 impl AccountState {
-    /// `type(uint40).max` — the `unlocks_at` value `getLockStatus` synthesizes for
+    /// `type(uint48).max` — the `unlocks_at` value `getLockStatus` synthesizes for
     /// a hard-locked account (`FLAG_LOCKED` set, `FLAG_UNLOCK_INITIATED` clear),
     /// where `lock_union` actually stores the configured delay rather than a
     /// timestamp. Not a stored sentinel.
-    pub const UNLOCKS_AT_MAX: u64 = (1 << 40) - 1;
+    pub const UNLOCKS_AT_MAX: u64 = (1 << 48) - 1;
 
     /// Unpacks a raw `AccountState` storage word.
     #[must_use]
     pub fn from_word(word: U256) -> Self {
         let b = word.to_be_bytes::<32>();
         let mut multichain = [0u8; 8];
-        let mut local = [0u8; 8];
+        let mut local_sequence = [0u8; 8];
+        let mut local_epoch = [0u8; 8];
         let mut lock_union = [0u8; 8];
         let mut default_eoa_expiry = [0u8; 8];
         multichain.copy_from_slice(&b[24..32]); // uint64 at bits 0..64
-        local.copy_from_slice(&b[16..24]); // uint64 at bits 64..128
-        lock_union[3..].copy_from_slice(&b[10..15]); // uint40 at bits 136..176
+        local_sequence[4..].copy_from_slice(&b[20..24]); // uint32 at bits 64..96
+        local_epoch[4..].copy_from_slice(&b[16..20]); // uint32 at bits 96..128
+        lock_union[2..].copy_from_slice(&b[9..15]); // uint48 at bits 136..184
         default_eoa_expiry[2..].copy_from_slice(&b[3..9]); // uint48 at bits 184..232
         Self {
             multichain_sequence: u64::from_be_bytes(multichain),
-            local_sequence: u64::from_be_bytes(local),
+            local_sequence: u64::from_be_bytes(local_sequence),
+            local_epoch: u64::from_be_bytes(local_epoch),
             flags: b[15], // uint8 at bits 128..136
             lock_union: u64::from_be_bytes(lock_union),
-            default_eoa_scope: b[9], // uint8 at bits 176..184
             default_eoa_expiry: u64::from_be_bytes(default_eoa_expiry),
+            default_eoa_scope: u16::from_be_bytes([b[1], b[2]]), // uint16 at bits 232..248
         }
     }
 
@@ -447,27 +460,45 @@ impl AccountState {
         }
     }
 
+    /// Mirrors `AccountConfiguration._isInitialized`: `true` once the account has
+    /// any EIP-8130 state on either channel — a non-zero local word
+    /// (`local_sequence` or `local_epoch`) or a non-zero `multichain_sequence`.
+    /// The single source of truth for the initialized predicate so callers
+    /// (e.g. the create guard in [`AccountChangeApplier::apply_create`]) cannot
+    /// drift from it.
+    #[must_use]
+    pub const fn is_initialized(&self) -> bool {
+        self.local_sequence > 0 || self.local_epoch > 0 || self.multichain_sequence > 0
+    }
+
     /// Packs this state into its raw storage word — the exact inverse of
     /// [`Self::from_word`].
     ///
-    /// `lock_union` must fit in `uint40` and `default_eoa_expiry` in `uint48`
-    /// (their storage field widths); higher bytes are dropped. Values sourced
-    /// from [`Self::from_word`] or ABI decoding always satisfy this, so the
-    /// `debug_assert!`s only guard hand-constructed misuse.
+    /// `local_sequence`/`local_epoch` must fit in `uint32`, `lock_union` and
+    /// `default_eoa_expiry` in `uint48` (their storage field widths); higher
+    /// bytes are dropped. Values sourced from [`Self::from_word`] or ABI decoding
+    /// always satisfy this, so the `debug_assert!`s only guard hand-constructed
+    /// misuse.
     #[must_use]
     pub fn to_word(&self) -> U256 {
-        debug_assert!(self.lock_union >> 40 == 0, "lock_union exceeds uint40 storage width");
+        debug_assert!(
+            self.local_sequence >> 32 == 0,
+            "local_sequence exceeds uint32 storage width"
+        );
+        debug_assert!(self.local_epoch >> 32 == 0, "local_epoch exceeds uint32 storage width");
+        debug_assert!(self.lock_union >> 48 == 0, "lock_union exceeds uint48 storage width");
         debug_assert!(
             self.default_eoa_expiry >> 48 == 0,
             "default_eoa_expiry exceeds uint48 storage width"
         );
         let mut b = [0u8; 32];
         b[24..32].copy_from_slice(&self.multichain_sequence.to_be_bytes());
-        b[16..24].copy_from_slice(&self.local_sequence.to_be_bytes());
+        b[20..24].copy_from_slice(&self.local_sequence.to_be_bytes()[4..]); // uint32: low 4 bytes
+        b[16..20].copy_from_slice(&self.local_epoch.to_be_bytes()[4..]); // uint32: low 4 bytes
         b[15] = self.flags;
-        b[10..15].copy_from_slice(&self.lock_union.to_be_bytes()[3..]); // uint40: low 5 bytes
-        b[9] = self.default_eoa_scope;
-        b[3..9].copy_from_slice(&self.default_eoa_expiry.to_be_bytes()[2..]); // uint48 at bits 184..232
+        b[9..15].copy_from_slice(&self.lock_union.to_be_bytes()[2..]); // uint48: low 6 bytes
+        b[3..9].copy_from_slice(&self.default_eoa_expiry.to_be_bytes()[2..]); // uint48: low 6 bytes
+        b[1..3].copy_from_slice(&self.default_eoa_scope.to_be_bytes()); // uint16: 2 bytes
         U256::from_be_bytes(b)
     }
 }
@@ -502,10 +533,10 @@ mod tests {
     /// Canonical Solidity packing of `ActorConfig` (each field at its bit
     /// offset). Independent of the byte-slice [`ActorConfig::from_word`] decoder,
     /// so agreement cross-checks the layout.
-    fn pack_actor_config(authenticator: Address, scope: u8, expiry: u64) -> U256 {
+    fn pack_actor_config(authenticator: Address, scope: u16, expiry: u64) -> U256 {
         U256::from_be_slice(authenticator.as_slice())
-            | (U256::from(scope) << 160)
-            | (U256::from(expiry) << 168)
+            | (U256::from(expiry) << 160)
+            | (U256::from(scope) << 208)
     }
 
     fn pack_account_state(
@@ -513,15 +544,35 @@ mod tests {
         local: u64,
         flags: u8,
         lock_union: u64,
-        default_eoa_scope: u8,
+        default_eoa_scope: u16,
         default_eoa_expiry: u64,
     ) -> U256 {
         U256::from(multichain)
             | (U256::from(local) << 64)
             | (U256::from(flags) << 128)
             | (U256::from(lock_union) << 136)
-            | (U256::from(default_eoa_scope) << 176)
             | (U256::from(default_eoa_expiry) << 184)
+            | (U256::from(default_eoa_scope) << 232)
+    }
+
+    /// Packs an `AccountState` word with an explicit local epoch (high 32 bits of
+    /// the local word), for tests that exercise the epoch split.
+    fn pack_account_state_epoch(
+        multichain: u64,
+        local_sequence: u64,
+        local_epoch: u64,
+        flags: u8,
+        lock_union: u64,
+        default_eoa_scope: u16,
+        default_eoa_expiry: u64,
+    ) -> U256 {
+        U256::from(multichain)
+            | (U256::from(local_sequence) << 64)
+            | (U256::from(local_epoch) << 96)
+            | (U256::from(flags) << 128)
+            | (U256::from(lock_union) << 136)
+            | (U256::from(default_eoa_expiry) << 184)
+            | (U256::from(default_eoa_scope) << 232)
     }
 
     #[test]
@@ -740,7 +791,7 @@ mod tests {
     #[test]
     fn account_state_unpacks_sequences_and_lock_fields() {
         let expiry = (1u64 << 48) - 1; // full uint48
-        let lock_union = (1u64 << 40) - 1; // full uint40
+        let lock_union = (1u64 << 48) - 1; // full uint48
         let word = pack_account_state(
             7,
             3,
@@ -784,6 +835,14 @@ mod tests {
 
             // Local-only: the bootstrap (create/import) channel.
             acc.account_state.at_mut(&ACCOUNT).write(pack_account_state(0, 1, 0, 0, 0, 0)).unwrap();
+            assert!(acc.is_initialized(ACCOUNT).unwrap());
+
+            // Epoch-only: an IncrementLocalEpoch reset local_sequence to 0 while
+            // bumping local_epoch. A non-zero epoch alone still marks initialized.
+            acc.account_state
+                .at_mut(&ACCOUNT)
+                .write(pack_account_state_epoch(0, 0, 1, 0, 0, 0, 0))
+                .unwrap();
             assert!(acc.is_initialized(ACCOUNT).unwrap());
         });
     }
@@ -847,7 +906,9 @@ mod tests {
 
     #[test]
     fn actor_config_reserved_bits_are_detected_and_cleared_on_write() {
-        let word = pack_actor_config(ACCOUNT, 0xAB, 42) | (U256::from(1) << 216);
+        // Reserved region is the top 4 bytes (bits 224..256), above the uint16
+        // scope (bits 208..224).
+        let word = pack_actor_config(ACCOUNT, 0xAB, 42) | (U256::from(1) << 224);
         assert!(ActorConfig::has_nonzero_reserved(word));
         let config = ActorConfig::from_word(word);
         assert!(!ActorConfig::has_nonzero_reserved(config.to_word()));
@@ -860,13 +921,36 @@ mod tests {
             7,
             3,
             Eip8130Constants::DEFAULT_EOA_REVOKED | Eip8130Constants::FLAG_UNLOCK_INITIATED,
-            (1u64 << 40) - 1,
+            (1u64 << 48) - 1,
             0xAB,
             (1u64 << 48) - 1,
         );
         let state = AccountState::from_word(word);
         assert_eq!(state.to_word(), word);
         assert_eq!(AccountState::from_word(state.to_word()), state);
+    }
+
+    #[test]
+    fn account_state_splits_local_epoch_from_sequence() {
+        // The local word is `localEpoch(32) || localSequence(32)`; each half must
+        // unpack independently, and a full-width uint48 lock union must survive.
+        let lock_union = (1u64 << 48) - 1; // full uint48
+        let word = pack_account_state_epoch(
+            9,
+            0x1234_5678,
+            0x0000_00ab,
+            Eip8130Constants::FLAG_LOCKED | Eip8130Constants::FLAG_UNLOCK_INITIATED,
+            lock_union,
+            Eip8130Constants::SCOPE_POLICY,
+            (1u64 << 48) - 1,
+        );
+        let state = AccountState::from_word(word);
+        assert_eq!(state.multichain_sequence, 9);
+        assert_eq!(state.local_sequence, 0x1234_5678);
+        assert_eq!(state.local_epoch, 0x0000_00ab);
+        assert_eq!(state.lock_union, lock_union);
+        assert_eq!(state.default_eoa_scope, Eip8130Constants::SCOPE_POLICY);
+        assert_eq!(state.to_word(), word);
     }
 
     #[test]

--- a/crates/execution/eip8130/src/apply.rs
+++ b/crates/execution/eip8130/src/apply.rs
@@ -42,8 +42,8 @@ sol! {
     /// for ABI decoding.
     struct ActorConfigAbi {
         address authenticator;
-        uint8 scope;
         uint48 expiry;
+        uint16 scope;
     }
 }
 
@@ -298,8 +298,14 @@ impl AccountChangeApplier {
             state.multichain_sequence =
                 state.multichain_sequence.checked_add(1).ok_or(ApplyError::SequenceOverflow)?;
         } else {
-            state.local_sequence =
-                state.local_sequence.checked_add(1).ok_or(ApplyError::SequenceOverflow)?;
+            // `local_sequence` is a `uint32` in storage (unlike the full-width
+            // `uint64` `multichain_sequence`), so guard the storage ceiling, not
+            // just the `u64` arithmetic one — otherwise `to_word` would silently
+            // truncate the high bytes in release builds.
+            if state.local_sequence >= u64::from(u32::MAX) {
+                return Err(ApplyError::SequenceOverflow);
+            }
+            state.local_sequence += 1;
         }
 
         let mut revoke_discount_slots = 0u32;
@@ -561,13 +567,16 @@ impl AccountChangeApplier {
     ) -> Result<CreatedAccount, ApplyError> {
         let address = Self::compute_address(entry.user_salt, &entry.code, &entry.initial_actors)?;
         // Block re-initialization of an account that already holds EIP-8130 state.
-        // `local_sequence` doubles as the created/imported flag; `multichain_sequence`
-        // additionally guards an account that established state via a global
-        // (chain_id 0) config change without ever being created/imported. This must
-        // be explicit now that `authorize_actor` is an upsert and no longer reverts
-        // on a duplicate initial actor (mirrors `createAccount`'s guard).
+        // `local_sequence` doubles as the created/imported flag; `local_epoch`
+        // covers an account whose sequence was reset to 0 by `IncrementLocalEpoch`;
+        // and `multichain_sequence` guards an account that established state via a
+        // global (chain_id 0) config change without ever being created/imported.
+        // Defer to the shared [`AccountState::is_initialized`] predicate so this
+        // guard can't drift from it. This must be explicit now that
+        // `authorize_actor` is an upsert and no longer reverts on a duplicate
+        // initial actor (mirrors `createAccount`'s guard).
         let mut state = storage.get_account_state(address)?;
-        if state.local_sequence != 0 || state.multichain_sequence != 0 {
+        if state.is_initialized() {
             return Err(ApplyError::AlreadyCreated { account: address });
         }
 
@@ -638,7 +647,7 @@ impl AccountChangeApplier {
     /// `manager(20) || commitment(32)`, written verbatim. Neither field need be
     /// nonzero — a zero `commitment` is a valid "no parameters" value and a zero
     /// `manager` gates the key to `address(0)` (no productive target).
-    pub fn slice_policy(scope: u8, policy_data: &[u8]) -> Result<(Address, B256), ApplyError> {
+    pub fn slice_policy(scope: u16, policy_data: &[u8]) -> Result<(Address, B256), ApplyError> {
         if scope & Eip8130Constants::SCOPE_POLICY == 0 {
             if !policy_data.is_empty() {
                 return Err(ApplyError::MalformedPolicyData);
@@ -680,21 +689,27 @@ impl AccountChangeApplier {
         keccak256(packed)
     }
 
-    /// The packed commitment over the initial actor set. The per-actor
-    /// contribution is `actorId(32) || authenticator(20) || scope(1) ||
-    /// policyData` — 53 bytes for a non-policy actor, 105 bytes when `POLICY`
-    /// is set (appending `manager (20) || commitment (32)`). `expiry` does not
-    /// participate. The per-actor length is fully determined by `scope`, so the
-    /// concatenation is unambiguous. Mirrors `_computeActorsCommitment`.
+    /// The commitment over the initial actor set, using the hash-the-leaves-
+    /// then-hash-the-list scheme shared with the signed digests. Each actor
+    /// hashes to a fixed-width 32-byte leaf
+    /// `keccak256(actorId(32) || authenticator(20) || scope(2) || policyData)`
+    /// (`policyData` is empty for a non-policy actor, or exactly `manager(20) ||
+    /// commitment(32)` when `POLICY` is set; `expiry` does not participate), and
+    /// the commitment is `keccak256(leaf_0 || … || leaf_{n-1})`. Fixed-width
+    /// leaves make the commitment unambiguous by construction and linear in the
+    /// actor count. Mirrors `_computeActorsCommitment`, whose `scope` field is a
+    /// `uint16` packed as 2 big-endian bytes.
     fn actors_commitment(initial_actors: &[InitialActor]) -> B256 {
-        let mut packed = Vec::with_capacity(initial_actors.len() * 53);
+        let mut packed_leaves = Vec::with_capacity(initial_actors.len() * 32);
         for actor in initial_actors {
-            packed.extend_from_slice(actor.actor_id.as_slice());
-            packed.extend_from_slice(actor.authenticator.as_slice());
-            packed.push(actor.scope);
-            packed.extend_from_slice(&actor.policy_data);
+            let mut leaf = Vec::with_capacity(54 + actor.policy_data.len());
+            leaf.extend_from_slice(actor.actor_id.as_slice());
+            leaf.extend_from_slice(actor.authenticator.as_slice());
+            leaf.extend_from_slice(&actor.scope.to_be_bytes());
+            leaf.extend_from_slice(&actor.policy_data);
+            packed_leaves.extend_from_slice(keccak256(&leaf).as_slice());
         }
-        keccak256(packed)
+        keccak256(packed_leaves)
     }
 
     /// Builds an account's deployment code: a 14-byte EVM loader header that
@@ -766,7 +781,7 @@ mod tests {
         Bytes::from((abi, Bytes::copy_from_slice(policy_data)).abi_encode_params())
     }
 
-    fn ungated(authenticator: Address, scope: u8) -> ActorConfig {
+    fn ungated(authenticator: Address, scope: u16) -> ActorConfig {
         ActorConfig { authenticator, scope, expiry: 0 }
     }
 
@@ -1102,6 +1117,32 @@ mod tests {
     }
 
     #[test]
+    fn actors_commitment_hashes_leaves_then_list() {
+        // Golden values cross-checked against the contract's leaves-then-list
+        // scheme (#74) with `cast keccak`: each actor hashes to
+        // `keccak256(actorId(32) || authenticator(20) || scope(2 BE) ||
+        // policyData)` and the commitment is `keccak256(leaf_0 || … ||
+        // leaf_{n-1})`.
+        let auth = address!("0x0000000000000000000000000000000000000001");
+        let a1 = InitialActor::owner(B256::repeat_byte(0x11), auth);
+        assert_eq!(
+            AccountChangeApplier::actors_commitment(std::slice::from_ref(&a1)),
+            b256!("0x072d109643fa2cb02a4727255a5d6f23a248f8e331c5be883d093115dd513ac9"),
+        );
+
+        let a2 = InitialActor {
+            actor_id: B256::repeat_byte(0x22),
+            authenticator: auth,
+            scope: 0x0007,
+            policy_data: Bytes::new(),
+        };
+        assert_eq!(
+            AccountChangeApplier::actors_commitment(&[a1, a2]),
+            b256!("0x7e3212d8f983663f5da75deeced0c37781e972611a5eec67cda3ed154c25affd"),
+        );
+    }
+
+    #[test]
     fn create_initializes_state_actors_and_address() {
         with_storage(|acc| {
             let entry = CreateEntry {
@@ -1164,6 +1205,38 @@ mod tests {
             acc.set_account_state(expected, state).unwrap();
 
             // create must still reject (the guard checks both sequences).
+            assert_eq!(
+                AccountChangeApplier::apply_create(acc, &entry),
+                Err(ApplyError::AlreadyCreated { account: expected })
+            );
+        });
+    }
+
+    #[test]
+    fn create_rejected_when_account_has_only_local_epoch_state() {
+        with_storage(|acc| {
+            let entry = CreateEntry {
+                user_salt: b256!(
+                    "0x4444444444444444444444444444444444444444444444444444444444444444"
+                ),
+                code: Bytes::from_static(&[0x60, 0x00]),
+                initial_actors: vec![InitialActor::owner(NON_SELF, AUTHENTICATOR)],
+            };
+            let expected = AccountChangeApplier::compute_address(
+                entry.user_salt,
+                &entry.code,
+                &entry.initial_actors,
+            )
+            .unwrap();
+
+            // An account whose local sequence was reset to 0 by IncrementLocalEpoch
+            // still holds state: local_sequence == 0 && multichain_sequence == 0 but
+            // local_epoch != 0. The guard must treat it as initialized (mirrors
+            // `AccountState::is_initialized`), not re-creatable.
+            let mut state = acc.get_account_state(expected).unwrap();
+            state.local_epoch = 1;
+            acc.set_account_state(expected, state).unwrap();
+
             assert_eq!(
                 AccountChangeApplier::apply_create(acc, &entry),
                 Err(ApplyError::AlreadyCreated { account: expected })

--- a/crates/execution/eip8130/src/authorize.rs
+++ b/crates/execution/eip8130/src/authorize.rs
@@ -264,18 +264,20 @@ mod tests {
     const NOW: u64 = 1_000;
     const ACCOUNT: Address = address!("0x00000000000000000000000000000000000000a1");
 
-    /// Canonical Solidity packing of `ActorConfig` (each field at its bit offset).
-    fn pack(authenticator: Address, scope: u8, expiry: u64) -> U256 {
+    /// Canonical Solidity packing of `ActorConfig` (each field at its bit offset:
+    /// authenticator 0..160, expiry 160..208, scope 208..224).
+    fn pack(authenticator: Address, scope: u16, expiry: u64) -> U256 {
         U256::from_be_slice(authenticator.as_slice())
-            | (U256::from(scope) << 160)
-            | (U256::from(expiry) << 168)
+            | (U256::from(expiry) << 160)
+            | (U256::from(scope) << 208)
     }
 
     /// Packs an `AccountState` word carrying the inline secp256k1 self config
-    /// (each field at its bit offset; sequences/lock left zero).
-    fn pack_self(scope: u8, expiry: u64, revoked: bool) -> U256 {
+    /// (each field at its bit offset: defaultEOAExpiry 184..232, defaultEOAScope
+    /// 232..248; sequences/lock left zero).
+    fn pack_self(scope: u16, expiry: u64, revoked: bool) -> U256 {
         let flags = if revoked { Eip8130Constants::DEFAULT_EOA_REVOKED } else { 0 };
-        (U256::from(flags) << 128) | (U256::from(scope) << 176) | (U256::from(expiry) << 184)
+        (U256::from(flags) << 128) | (U256::from(expiry) << 184) | (U256::from(scope) << 232)
     }
 
     fn actor_id(address: Address) -> B256 {

--- a/crates/execution/eip8130/src/config.rs
+++ b/crates/execution/eip8130/src/config.rs
@@ -257,20 +257,22 @@ mod tests {
         Bytes::from(out)
     }
 
-    /// Canonical Solidity packing of `ActorConfig`.
-    fn pack(authenticator: Address, scope: u8, expiry: u64) -> U256 {
+    /// Canonical Solidity packing of `ActorConfig` (authenticator 0..160, expiry
+    /// 160..208, scope 208..224).
+    fn pack(authenticator: Address, scope: u16, expiry: u64) -> U256 {
         U256::from_be_slice(authenticator.as_slice())
-            | (U256::from(scope) << 160)
-            | (U256::from(expiry) << 168)
+            | (U256::from(expiry) << 160)
+            | (U256::from(scope) << 208)
     }
 
-    /// Canonical Solidity packing of `AccountState` (sequences + lock fields).
+    /// Canonical Solidity packing of `AccountState` (`local` is the local-channel
+    /// sequence in the low uint32; local epoch left zero).
     fn pack_state(multichain: u64, local: u64, flags: u8, lock_union: u64) -> U256 {
         let mut b = [0u8; 32];
         b[24..32].copy_from_slice(&multichain.to_be_bytes());
-        b[16..24].copy_from_slice(&local.to_be_bytes());
+        b[20..24].copy_from_slice(&local.to_be_bytes()[4..]); // uint32 localSequence
         b[15] = flags;
-        b[10..15].copy_from_slice(&lock_union.to_be_bytes()[3..]);
+        b[9..15].copy_from_slice(&lock_union.to_be_bytes()[2..]); // uint48 lockUnion
         U256::from_be_bytes(b)
     }
 

--- a/crates/execution/eip8130/src/events.rs
+++ b/crates/execution/eip8130/src/events.rs
@@ -42,21 +42,22 @@ pub use IAccountConfigurationEvents::{
 pub struct AccountConfigurationEvents;
 
 impl AccountConfigurationEvents {
-    /// Packs `ActorAuthorized.actorData` as the contract's `_emitActorAuthorized`
-    /// does: `authenticator ‖ scope ‖ expiry ‖ reserved(5 zero bytes)` (32 bytes),
-    /// plus `manager ‖ commitment` when `SCOPE_POLICY` is set (84 bytes total).
-    ///
-    /// This is `abi.encodePacked` order (declaration order, left-to-right) — not
-    /// the right-aligned storage-slot packing of [`ActorConfig::to_word`].
+    /// Packs `ActorAuthorized.actorData` as the finalized Keystore's
+    /// `_emitActorAuthorized` does: `authenticator(20) ‖ expiry(6) ‖ scope(2) ‖
+    /// reserved(4 zero bytes)` (32 bytes), plus `manager(20) ‖ commitment(32)`
+    /// when `SCOPE_POLICY` is set (84 bytes total). This mirrors the right-aligned
+    /// `ActorConfig` storage-slot field order (`authenticator ‖ expiry ‖ scope ‖
+    /// reserved`) packed left-to-right via `abi.encodePacked`.
     #[must_use]
     pub fn pack_actor_data(config: &ActorConfig, manager: Address, commitment: B256) -> Bytes {
         let policy = config.scope & Eip8130Constants::SCOPE_POLICY != 0;
         let mut data = Vec::with_capacity(if policy { 84 } else { 32 });
         data.extend_from_slice(config.authenticator.as_slice());
-        data.push(config.scope);
         // uint48 expiry: low 6 bytes of the big-endian u64.
         data.extend_from_slice(&config.expiry.to_be_bytes()[2..]);
-        data.extend_from_slice(&[0u8; 5]);
+        // uint16 scope: 2 bytes big-endian.
+        data.extend_from_slice(&config.scope.to_be_bytes());
+        data.extend_from_slice(&[0u8; 4]);
         if policy {
             data.extend_from_slice(manager.as_slice());
             data.extend_from_slice(commitment.as_slice());
@@ -150,9 +151,9 @@ mod tests {
         let data = AccountConfigurationEvents::pack_actor_data(&config, Address::ZERO, B256::ZERO);
         assert_eq!(data.len(), 32);
         assert_eq!(&data[..20], config.authenticator.as_slice());
-        assert_eq!(data[20], Eip8130Constants::SCOPE_SENDER);
-        assert_eq!(&data[21..27], &config.expiry.to_be_bytes()[2..]);
-        assert_eq!(&data[27..], &[0u8; 5]);
+        assert_eq!(&data[20..26], &config.expiry.to_be_bytes()[2..]);
+        assert_eq!(&data[26..28], &Eip8130Constants::SCOPE_SENDER.to_be_bytes());
+        assert_eq!(&data[28..], &[0u8; 4]);
     }
 
     #[test]

--- a/crates/execution/eip8130/src/intrinsic.rs
+++ b/crates/execution/eip8130/src/intrinsic.rs
@@ -574,10 +574,12 @@ impl IntrinsicGas {
     }
 
     /// Whether an authorize's ABI-encoded `(ActorConfig, bytes)` `data` carries
-    /// `SCOPE_POLICY`. `ActorConfig` is `(address, uint8 scope, uint48 expiry)`,
-    /// so scope is the second 32-byte word.
+    /// `SCOPE_POLICY`. `ActorConfig` is `(address authenticator, uint48 expiry,
+    /// uint16 scope)`, so scope is the third 32-byte word, right-aligned in its
+    /// low 2 bytes.
     fn authorize_has_policy(data: &[u8]) -> bool {
-        data.len() >= 64 && data[63] & Eip8130Constants::SCOPE_POLICY != 0
+        data.len() >= 96
+            && u16::from_be_bytes([data[94], data[95]]) & Eip8130Constants::SCOPE_POLICY != 0
     }
 }
 
@@ -665,8 +667,8 @@ mod tests {
         // pin the byte offset `authorize_has_policy` reads.
         struct ActorConfigAbi {
             address authenticator;
-            uint8 scope;
             uint48 expiry;
+            uint16 scope;
         }
     }
 
@@ -675,7 +677,8 @@ mod tests {
         use alloy_sol_types::SolValue;
 
         // Drift tripwire: `authorize_has_policy` reads SCOPE_POLICY from the low
-        // byte of the second ABI word.
+        // 2 bytes of the third ABI word (ActorConfig is now `(authenticator,
+        // expiry, scope)`, so scope is the last of the three words).
         let gated = (
             ActorConfigAbi {
                 authenticator: Address::ZERO,
@@ -697,7 +700,7 @@ mod tests {
 
         assert!(IntrinsicGas::authorize_has_policy(&gated));
         assert!(!IntrinsicGas::authorize_has_policy(&ungated));
-        assert_eq!(gated[63], Eip8130Constants::SCOPE_POLICY);
+        assert_eq!(u16::from_be_bytes([gated[94], gated[95]]), Eip8130Constants::SCOPE_POLICY);
     }
 
     #[test]
@@ -879,8 +882,9 @@ mod tests {
             + Eip8130GasSchedule::ACTOR_REVOKE_COST;
         assert_eq!(gas.account_changes, expected);
 
-        // With SCOPE_POLICY, the authorize also writes the two policy slots.
-        authorize_data[63] = Eip8130Constants::SCOPE_POLICY;
+        // With SCOPE_POLICY, the authorize also writes the two policy slots. Scope
+        // is the third ABI word's low 2 bytes (bytes 94..96).
+        authorize_data[94..96].copy_from_slice(&Eip8130Constants::SCOPE_POLICY.to_be_bytes());
         let cc = ConfigChange {
             chain_id: 0,
             sequence: 0,

--- a/crates/execution/eip8130/src/lib.rs
+++ b/crates/execution/eip8130/src/lib.rs
@@ -33,6 +33,9 @@ pub use tx_error::TxAuthError;
 mod verify;
 pub use verify::{ActorTxVerifier, AuthorizedActor, TxActors};
 
+mod signature;
+pub use signature::{SignatureError, SignatureType, SignatureVerifier};
+
 mod config;
 pub use config::ConfigChangeAuthorizer;
 

--- a/crates/execution/eip8130/src/resolved.rs
+++ b/crates/execution/eip8130/src/resolved.rs
@@ -17,8 +17,8 @@ pub struct ResolvedActor {
     /// The resolved actor id (`bytes32(uint256(uint160(address)))`, right-aligned,
     /// for ecrecover/delegate; `keccak256(x‖y)` for P-256/`WebAuthn`).
     pub actor_id: B256,
-    /// The actor's scope bitfield (`0 = unrestricted`).
-    pub scope: u8,
+    /// The actor's scope bitfield (`uint16`; `0 = unrestricted`).
+    pub scope: u16,
     /// The actor's policy gate target (the policy *manager*), or
     /// [`Address::ZERO`] when ungated. Never the signed policy commitment.
     pub policy_target: Address,
@@ -68,7 +68,7 @@ impl ResolvedActor {
 mod tests {
     use super::*;
 
-    fn actor(scope: u8) -> ResolvedActor {
+    fn actor(scope: u16) -> ResolvedActor {
         ResolvedActor { actor_id: B256::ZERO, scope, policy_target: Address::ZERO, expiry: 0 }
     }
 

--- a/crates/execution/eip8130/src/scope.rs
+++ b/crates/execution/eip8130/src/scope.rs
@@ -25,7 +25,7 @@ impl Operation {
     /// The scope bit that grants this operation, or unrestricted scope for
     /// admin-only configuration changes.
     #[must_use]
-    pub const fn required_bit(self) -> u8 {
+    pub const fn required_bit(self) -> u16 {
         match self {
             Self::Sender => Eip8130Constants::SCOPE_SENDER,
             Self::SelfPayer => Eip8130Constants::SCOPE_SELF_PAYER,
@@ -36,7 +36,7 @@ impl Operation {
 
     /// Whether `scope` grants this operation.
     #[must_use]
-    pub const fn is_granted_by(self, scope: u8) -> bool {
+    pub const fn is_granted_by(self, scope: u16) -> bool {
         match self {
             Self::Config => scope == Eip8130Constants::SCOPE_UNRESTRICTED,
             Self::Sender => {

--- a/crates/execution/eip8130/src/signature.rs
+++ b/crates/execution/eip8130/src/signature.rs
@@ -1,0 +1,316 @@
+//! Canonical off-hot-path signature verification: the native port of
+//! `Keystore.validateSignature` / `envelopeDigest` / `replaySafeHash`.
+//!
+//! This is the signature-checking method that supersedes ERC-1271 for EIP-8130
+//! accounts: given an account, an app digest, and a typed signature envelope, it
+//! resolves and authenticates the signing actor and returns its identity and
+//! scope so a consumer can decide authorization without re-deriving the actor.
+//!
+//! The transaction hot path ([`crate::ActorTxVerifier`]) does not use this — it
+//! binds each transaction digest in-struct and calls
+//! [`ActorAuthorizer::authenticate_actor`] directly. This surface exists for
+//! callers that want the contract-parity envelope semantics (an off-8130
+//! consumer reaching parity with the native hot path, or a general app digest
+//! check) and is intentionally not wired into any execution flow today.
+
+use alloy_primitives::{Address, B256, b256, keccak256};
+
+use crate::{AccountConfigurationStorage, ActorAuthorizer, AuthorizeError, ResolvedActor};
+
+/// Precomputed `keccak256` typehash of the replay-safe signed-message struct,
+/// matching `Keystore.SIGNED_MESSAGE_TYPEHASH`:
+/// `keccak256("EIP8130SignedMessage(address account,uint256 chainId,bytes32 hash)")`.
+const SIGNED_MESSAGE_TYPEHASH: B256 =
+    b256!("9d2bc80c29f8a3962243919d898fa1b566a99dc64dd59734f6a10e20be3a7e04");
+
+/// The replay channel a typed signature envelope binds to. Mirrors
+/// `Keystore.SignatureType`: the leading envelope byte is `Local` (`0x01`,
+/// binds a specific chain id) or `Multichain` (`0x02`, binds `chainId == 0` and
+/// is therefore replayable on every chain). `Invalid` (`0x00`) and any
+/// out-of-range byte are rejected by [`SignatureVerifier::validate_signature`].
+///
+/// This is distinct from [`AccountChangeChannel`], which gates the
+/// `SignedAccountChanges` batch and uses different byte values
+/// (`Local = 0x00`, `Multichain = 0x01`).
+///
+/// [`AccountChangeChannel`]: base_common_consensus::AccountChangeChannel
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum SignatureType {
+    /// Binds the caller-supplied chain id (single-chain).
+    Local = 0x01,
+    /// Binds `chainId == 0`; the signature is replayable on every chain.
+    Multichain = 0x02,
+}
+
+impl SignatureType {
+    /// Resolves the leading envelope byte to a [`SignatureType`], returning
+    /// `None` for `Invalid` (`0x00`) and any out-of-range value. Mirrors the
+    /// `sigTypeByte > uint8(type(SignatureType).max)` guard, extended to reject
+    /// the reserved `Invalid` value the way `envelopeDigest` does.
+    #[must_use]
+    pub const fn from_byte(byte: u8) -> Option<Self> {
+        match byte {
+            0x01 => Some(Self::Local),
+            0x02 => Some(Self::Multichain),
+            _ => None,
+        }
+    }
+
+    /// The chain id this envelope type binds, given the local chain id. `Local`
+    /// binds `local_chain_id`; `Multichain` binds `0`.
+    #[must_use]
+    pub const fn bound_chain_id(self, local_chain_id: u64) -> u64 {
+        match self {
+            Self::Local => local_chain_id,
+            Self::Multichain => 0,
+        }
+    }
+}
+
+/// Why a typed signature envelope failed to validate. Mirrors the revert
+/// reasons of `Keystore.validateSignature`.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum SignatureError {
+    /// The envelope was empty (missing its leading `sigType` byte). Mirrors
+    /// `EmptySignatureEnvelope`.
+    #[error("signature envelope is empty (missing its leading sigType byte)")]
+    EmptyEnvelope,
+
+    /// The leading `sigType` byte is not a recognized [`SignatureType`] (it was
+    /// `Invalid` or out of range). Mirrors `UnknownSignatureType`.
+    #[error("unknown signature type byte {0:#04x}")]
+    UnknownSignatureType(u8),
+
+    /// The actor could not be authenticated against the envelope digest (bad
+    /// authenticator length, authentication failure, mismatch, expiry, revoked
+    /// default EOA, or a storage read). Mirrors the `authenticateActor` reverts.
+    #[error("actor authentication failed: {0}")]
+    Authenticate(#[from] AuthorizeError),
+}
+
+/// Contract-parity signature verification over an app digest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct SignatureVerifier;
+
+impl SignatureVerifier {
+    /// The replay-safe digest binding `hash` to `account` and `chain_id`,
+    /// matching `Keystore.replaySafeHash`:
+    /// `keccak256(abi.encode(SIGNED_MESSAGE_TYPEHASH, account, chainId, hash))`.
+    #[must_use]
+    pub fn replay_safe_hash(account: Address, chain_id: u64, hash: B256) -> B256 {
+        // abi.encode(bytes32, address, uint256, bytes32): four right-aligned words.
+        let mut buf = [0u8; 128];
+        buf[..32].copy_from_slice(SIGNED_MESSAGE_TYPEHASH.as_slice());
+        buf[44..64].copy_from_slice(account.as_slice());
+        buf[88..96].copy_from_slice(&chain_id.to_be_bytes());
+        buf[96..128].copy_from_slice(hash.as_slice());
+        keccak256(buf)
+    }
+
+    /// The digest a signer must sign for `hash` to be accepted for `account`
+    /// under `sig_type`, matching `Keystore.envelopeDigest`. `local_chain_id`
+    /// supplies the chain id bound by [`SignatureType::Local`]; `Multichain`
+    /// binds `0`.
+    #[must_use]
+    pub fn envelope_digest(
+        sig_type: SignatureType,
+        account: Address,
+        hash: B256,
+        local_chain_id: u64,
+    ) -> B256 {
+        Self::replay_safe_hash(account, sig_type.bound_chain_id(local_chain_id), hash)
+    }
+
+    /// Validates a typed-envelope signature over app digest `hash` for
+    /// `account`, returning the authenticated actor. Native mirror of
+    /// `Keystore.validateSignature`.
+    ///
+    /// `auth` is `sigType(1) || authenticator(20) || authenticator-specific
+    /// data`. The leading byte selects the [`SignatureType`], the envelope
+    /// digest is resolved against `account`/`local_chain_id`, and the remainder
+    /// is authenticated via [`ActorAuthorizer::authenticate_actor`]. `now` is
+    /// the timestamp used for actor expiry.
+    ///
+    /// Operational gating (which scopes may sign) is left to the caller, which
+    /// reads the returned [`ResolvedActor::scope`].
+    pub fn validate_signature(
+        storage: &AccountConfigurationStorage<'_>,
+        account: Address,
+        hash: B256,
+        auth: &[u8],
+        local_chain_id: u64,
+        now: u64,
+    ) -> Result<ResolvedActor, SignatureError> {
+        let (&sig_type_byte, inner) = auth.split_first().ok_or(SignatureError::EmptyEnvelope)?;
+        let sig_type = SignatureType::from_byte(sig_type_byte)
+            .ok_or(SignatureError::UnknownSignatureType(sig_type_byte))?;
+        let digest = Self::envelope_digest(sig_type, account, hash, local_chain_id);
+        Ok(ActorAuthorizer::authenticate_actor(storage, account, digest, inner, now)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Bytes, U256, address, keccak256};
+    use base_common_consensus::Eip8130Constants;
+    use base_precompile_storage::{Handler, HashMapStorageProvider, StorageCtx};
+    use k256::ecdsa::SigningKey as K256SigningKey;
+
+    use super::*;
+
+    const NOW: u64 = 1_000;
+    const CHAIN_ID: u64 = 8453;
+    const K1: Address = Eip8130Constants::K1_AUTHENTICATOR;
+    const ACCOUNT: Address = address!("0x00000000000000000000000000000000000000aa");
+    const HASH: B256 = B256::repeat_byte(0x42);
+
+    #[test]
+    fn typehash_matches_string() {
+        assert_eq!(
+            SIGNED_MESSAGE_TYPEHASH,
+            keccak256(b"EIP8130SignedMessage(address account,uint256 chainId,bytes32 hash)")
+        );
+    }
+
+    #[test]
+    fn signature_type_byte_roundtrip() {
+        assert_eq!(SignatureType::from_byte(0x00), None);
+        assert_eq!(SignatureType::from_byte(0x01), Some(SignatureType::Local));
+        assert_eq!(SignatureType::from_byte(0x02), Some(SignatureType::Multichain));
+        assert_eq!(SignatureType::from_byte(0x03), None);
+        assert_eq!(SignatureType::Local as u8, 0x01);
+        assert_eq!(SignatureType::Multichain as u8, 0x02);
+    }
+
+    #[test]
+    fn multichain_binds_chain_id_zero() {
+        assert_eq!(SignatureType::Multichain.bound_chain_id(CHAIN_ID), 0);
+        assert_eq!(SignatureType::Local.bound_chain_id(CHAIN_ID), CHAIN_ID);
+        assert_eq!(
+            SignatureVerifier::envelope_digest(SignatureType::Multichain, ACCOUNT, HASH, CHAIN_ID),
+            SignatureVerifier::replay_safe_hash(ACCOUNT, 0, HASH),
+        );
+    }
+
+    fn key(byte: u8) -> K256SigningKey {
+        K256SigningKey::from_slice(&[byte; 32]).unwrap()
+    }
+
+    fn addr(key: &K256SigningKey) -> Address {
+        let point = key.verifying_key().to_encoded_point(false);
+        Address::from_slice(&keccak256(&point.as_bytes()[1..])[12..])
+    }
+
+    /// 65-byte `r || s || v` signature over `hash`, `v` in `{27, 28}`, low-s.
+    fn sig(key: &K256SigningKey, hash: B256) -> Vec<u8> {
+        let (signature, recid) = key.sign_prehash_recoverable(hash.as_slice()).unwrap();
+        let mut out = vec![0u8; 65];
+        out[..64].copy_from_slice(&signature.to_bytes());
+        out[64] = recid.to_byte() + 27;
+        out
+    }
+
+    /// `sigType(1) || authenticator(20) || data`.
+    fn envelope(sig_type: u8, authenticator: Address, data: &[u8]) -> Bytes {
+        let mut out = Vec::with_capacity(1 + 20 + data.len());
+        out.push(sig_type);
+        out.extend_from_slice(authenticator.as_slice());
+        out.extend_from_slice(data);
+        Bytes::from(out)
+    }
+
+    /// Canonical Solidity packing of `ActorConfig` (authenticator 0..160, expiry
+    /// 160..208, scope 208..224).
+    fn pack(authenticator: Address, scope: u16, expiry: u64) -> U256 {
+        U256::from_be_slice(authenticator.as_slice())
+            | (U256::from(expiry) << 160)
+            | (U256::from(scope) << 208)
+    }
+
+    fn with_storage<R>(body: impl FnOnce(&mut AccountConfigurationStorage<'_>) -> R) -> R {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, |ctx| body(&mut AccountConfigurationStorage::new(ctx)))
+    }
+
+    #[test]
+    fn empty_envelope_is_rejected() {
+        with_storage(|acc| {
+            assert_eq!(
+                SignatureVerifier::validate_signature(acc, ACCOUNT, HASH, &[], CHAIN_ID, NOW),
+                Err(SignatureError::EmptyEnvelope),
+            );
+        });
+    }
+
+    #[test]
+    fn invalid_and_out_of_range_sig_type_is_rejected() {
+        with_storage(|acc| {
+            for byte in [0x00u8, 0x03, 0xff] {
+                let auth = envelope(byte, K1, &[]);
+                assert_eq!(
+                    SignatureVerifier::validate_signature(acc, ACCOUNT, HASH, &auth, CHAIN_ID, NOW,),
+                    Err(SignatureError::UnknownSignatureType(byte)),
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn local_envelope_authenticates_bound_actor() {
+        let k = key(0x22);
+        let id = AccountConfigurationStorage::self_actor_id(addr(&k));
+        let scope = Eip8130Constants::SCOPE_SENDER;
+        let digest =
+            SignatureVerifier::envelope_digest(SignatureType::Local, ACCOUNT, HASH, CHAIN_ID);
+        let auth = envelope(SignatureType::Local as u8, K1, &sig(&k, digest));
+        with_storage(|acc| {
+            acc.actor_config.at_mut(&id).at_mut(&ACCOUNT).write(pack(K1, scope, 0)).unwrap();
+            let resolved =
+                SignatureVerifier::validate_signature(acc, ACCOUNT, HASH, &auth, CHAIN_ID, NOW)
+                    .unwrap();
+            assert_eq!(resolved.scope, scope);
+            assert_eq!(resolved.actor_id, id);
+        });
+    }
+
+    #[test]
+    fn multichain_signature_is_chain_independent() {
+        // A Multichain envelope binds chainId == 0, so a signature produced for
+        // one local chain authenticates unchanged under a different local chain.
+        let k = key(0x33);
+        let id = AccountConfigurationStorage::self_actor_id(addr(&k));
+        let digest =
+            SignatureVerifier::envelope_digest(SignatureType::Multichain, ACCOUNT, HASH, CHAIN_ID);
+        let auth = envelope(SignatureType::Multichain as u8, K1, &sig(&k, digest));
+        with_storage(|acc| {
+            acc.actor_config.at_mut(&id).at_mut(&ACCOUNT).write(pack(K1, 0, 0)).unwrap();
+            let other_chain = CHAIN_ID + 1;
+            let resolved =
+                SignatureVerifier::validate_signature(acc, ACCOUNT, HASH, &auth, other_chain, NOW)
+                    .unwrap();
+            assert_eq!(resolved.actor_id, id);
+            assert!(resolved.is_admin());
+        });
+    }
+
+    #[test]
+    fn local_signature_bound_to_other_chain_does_not_authenticate() {
+        // A Local envelope signed for CHAIN_ID must not validate under a
+        // different local chain: the digest binds the chain id.
+        let k = key(0x44);
+        let id = AccountConfigurationStorage::self_actor_id(addr(&k));
+        let digest =
+            SignatureVerifier::envelope_digest(SignatureType::Local, ACCOUNT, HASH, CHAIN_ID);
+        let auth = envelope(SignatureType::Local as u8, K1, &sig(&k, digest));
+        with_storage(|acc| {
+            acc.actor_config.at_mut(&id).at_mut(&ACCOUNT).write(pack(K1, 0, 0)).unwrap();
+            // Recovers a different actor id than the one bound: NotBound.
+            assert!(matches!(
+                SignatureVerifier::validate_signature(acc, ACCOUNT, HASH, &auth, CHAIN_ID + 1, NOW,),
+                Err(SignatureError::Authenticate(AuthorizeError::NotBound { .. })),
+            ));
+        });
+    }
+}

--- a/crates/execution/eip8130/src/transaction.rs
+++ b/crates/execution/eip8130/src/transaction.rs
@@ -276,27 +276,30 @@ mod tests {
         Bytes::from(out)
     }
 
-    /// Canonical Solidity packing of `ActorConfig`.
-    fn pack(authenticator: Address, scope: u8, expiry: u64) -> U256 {
+    /// Canonical Solidity packing of `ActorConfig` (authenticator 0..160, expiry
+    /// 160..208, scope 208..224).
+    fn pack(authenticator: Address, scope: u16, expiry: u64) -> U256 {
         U256::from_be_slice(authenticator.as_slice())
-            | (U256::from(scope) << 160)
-            | (U256::from(expiry) << 168)
+            | (U256::from(expiry) << 160)
+            | (U256::from(scope) << 208)
     }
 
     /// Canonical Solidity packing of `AccountState` (`multichain`, `local`
-    /// sequences, `flags`, and the `lock_union`).
+    /// sequences, `flags`, and the `lock_union`; `local` is the low uint32
+    /// local-channel sequence, local epoch left zero).
     fn pack_state(multichain: u64, local: u64, flags: u8, lock_union: u64) -> U256 {
         let mut b = [0u8; 32];
         b[24..32].copy_from_slice(&multichain.to_be_bytes());
-        b[16..24].copy_from_slice(&local.to_be_bytes());
+        b[20..24].copy_from_slice(&local.to_be_bytes()[4..]); // uint32 localSequence
         b[15] = flags;
-        b[10..15].copy_from_slice(&lock_union.to_be_bytes()[3..]);
+        b[9..15].copy_from_slice(&lock_union.to_be_bytes()[2..]); // uint48 lockUnion
         U256::from_be_bytes(b)
     }
 
-    /// Packs the inline secp256k1 self actor's `default_eoa_scope`.
-    fn pack_default_eoa_scope(scope: u8) -> U256 {
-        U256::from(scope) << 176
+    /// Packs the inline secp256k1 self actor's `default_eoa_scope` (bits
+    /// 232..248).
+    fn pack_default_eoa_scope(scope: u16) -> U256 {
+        U256::from(scope) << 232
     }
 
     /// A [`ConfigChange`] whose `auth` is a fresh signature over its own digest.

--- a/crates/execution/eip8130/src/tx_error.rs
+++ b/crates/execution/eip8130/src/tx_error.rs
@@ -31,7 +31,7 @@ pub enum TxAuthError {
         /// The operation whose scope requirement was not met.
         operation: Operation,
         /// The resolved actor's scope bitfield.
-        scope: u8,
+        scope: u16,
     },
 
     /// A config change or delegation targets a locked account. Both operations

--- a/crates/execution/eip8130/src/verify.rs
+++ b/crates/execution/eip8130/src/verify.rs
@@ -220,11 +220,12 @@ mod tests {
         Bytes::from(out)
     }
 
-    /// Canonical Solidity packing of `ActorConfig`.
-    fn pack(authenticator: Address, scope: u8, expiry: u64) -> U256 {
+    /// Canonical Solidity packing of `ActorConfig` (authenticator 0..160, expiry
+    /// 160..208, scope 208..224).
+    fn pack(authenticator: Address, scope: u16, expiry: u64) -> U256 {
         U256::from_be_slice(authenticator.as_slice())
-            | (U256::from(scope) << 160)
-            | (U256::from(expiry) << 168)
+            | (U256::from(expiry) << 160)
+            | (U256::from(scope) << 208)
     }
 
     fn base_tx(sender: Option<Address>, payer: Option<Address>) -> TxEip8130 {


### PR DESCRIPTION
## Summary
- Adds `SignatureVerifier`, a native mirror of `Keystore.validateSignature` / `envelopeDigest` / `replaySafeHash`: resolves the `sigType(1) || authenticator(20) || data` envelope, builds the replay-safe digest (`Local` binds the local chain, `Multichain` binds `0`), and authenticates the signing actor via `ActorAuthorizer::authenticate_actor`, returning its `ResolvedActor`.
- `SignatureType` (Invalid=0/Local=1/Multichain=2) is distinct from the `AccountChangeChannel` batch enum.
- This is the ERC-1271-superseding check for 8130 accounts. Exposed in the Rust API but intentionally **not wired into any execution flow** today.

## Stack
Base: #4330 (validity window). PR 7 (top) of the EIP-8130 parity stack.

## Test plan
- [x] `cargo test -p base-execution-eip8130` (typehash, envelope, chain-binding, reject paths)
- [x] `cargo clippy` clean