### PR TITLE
refactor(sequencer): Extract L1 Origin Module

### DIFF
--- a/crates/consensus/service/src/actors/sequencer/actor.rs
+++ b/crates/consensus/service/src/actors/sequencer/actor.rs
@@ -30,7 +30,7 @@ use crate::{
             build::{PayloadBuilder, UnsealedPayloadHandle},
             conductor::Conductor,
             error::SequencerActorError,
-            origin_selector::OriginSelector,
+            l1_origin::OriginSelector,
             recovery::RecoveryModeGuard,
             seal::{PayloadSealer, SealStepError, SealStepOutcome},
         },

--- a/crates/consensus/service/src/actors/sequencer/build.rs
+++ b/crates/consensus/service/src/actors/sequencer/build.rs
@@ -18,7 +18,7 @@ use crate::{
         SequencerEngineClient,
         sequencer::{
             error::SequencerActorError,
-            origin_selector::{L1OriginSelectorError, OriginSelector},
+            l1_origin::{L1OriginSelectorError, OriginSelector},
             recovery::RecoveryModeGuard,
         },
     },

--- a/crates/consensus/service/src/actors/sequencer/l1_origin/mod.rs
+++ b/crates/consensus/service/src/actors/sequencer/l1_origin/mod.rs
@@ -1,0 +1,9 @@
+//! L1 origin selection and provider implementations for the sequencer.
+
+mod provider;
+pub use provider::{DelayedL1OriginSelectorProvider, L1OriginSelectorProvider};
+
+mod selector;
+#[cfg(test)]
+pub use selector::MockOriginSelector;
+pub use selector::{L1OriginSelector, L1OriginSelectorError, OriginSelector};

--- a/crates/consensus/service/src/actors/sequencer/l1_origin/provider.rs
+++ b/crates/consensus/service/src/actors/sequencer/l1_origin/provider.rs
@@ -1,0 +1,82 @@
+//! L1 provider interfaces and implementations for origin selection.
+
+use std::fmt::Debug;
+
+use alloy_primitives::B256;
+use alloy_provider::{Provider, RootProvider};
+use async_trait::async_trait;
+use base_protocol::BlockInfo;
+use tokio::sync::watch;
+
+use super::L1OriginSelectorError;
+
+/// L1 [`BlockInfo`] provider interface for the [`super::L1OriginSelector`].
+#[async_trait]
+pub trait L1OriginSelectorProvider: Debug + Sync {
+    /// Returns a [`BlockInfo`] by its hash.
+    async fn get_block_by_hash(
+        &self,
+        hash: B256,
+    ) -> Result<Option<BlockInfo>, L1OriginSelectorError>;
+
+    /// Returns a [`BlockInfo`] by its number.
+    async fn get_block_by_number(
+        &self,
+        number: u64,
+    ) -> Result<Option<BlockInfo>, L1OriginSelectorError>;
+}
+
+/// A wrapper around the [`RootProvider`] that delays the view of the L1 chain by a configurable
+/// amount of blocks.
+#[derive(Debug)]
+pub struct DelayedL1OriginSelectorProvider {
+    /// The inner [`RootProvider`].
+    inner: RootProvider,
+    /// The L1 head watch channel.
+    l1_head: watch::Receiver<Option<BlockInfo>>,
+    /// The confirmation depth to delay the view of the L1 chain.
+    confirmation_depth: u64,
+}
+
+impl DelayedL1OriginSelectorProvider {
+    /// Creates a new [`DelayedL1OriginSelectorProvider`].
+    pub const fn new(
+        inner: RootProvider,
+        l1_head: watch::Receiver<Option<BlockInfo>>,
+        confirmation_depth: u64,
+    ) -> Self {
+        Self { inner, l1_head, confirmation_depth }
+    }
+}
+
+#[async_trait]
+impl L1OriginSelectorProvider for DelayedL1OriginSelectorProvider {
+    async fn get_block_by_hash(
+        &self,
+        hash: B256,
+    ) -> Result<Option<BlockInfo>, L1OriginSelectorError> {
+        // By-hash lookups are not delayed, as they're direct indexes.
+        Ok(Provider::get_block_by_hash(&self.inner, hash).await?.map(Into::into))
+    }
+
+    async fn get_block_by_number(
+        &self,
+        number: u64,
+    ) -> Result<Option<BlockInfo>, L1OriginSelectorError> {
+        let Some(l1_head) = *self.l1_head.borrow() else {
+            // If the L1 head is not available, do not enforce a confirmation delay.
+            return Ok(Provider::get_block_by_number(&self.inner, number.into())
+                .await?
+                .map(Into::into));
+        };
+
+        if number == 0
+            || self.confirmation_depth == 0
+            || number + self.confirmation_depth <= l1_head.number
+        {
+            Ok(Provider::get_block_by_number(&self.inner, number.into()).await?.map(Into::into))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/crates/consensus/service/src/actors/sequencer/l1_origin/selector.rs
+++ b/crates/consensus/service/src/actors/sequencer/l1_origin/selector.rs
@@ -3,12 +3,12 @@
 use std::{fmt::Debug, sync::Arc};
 
 use alloy_primitives::B256;
-use alloy_provider::{Provider, RootProvider};
 use alloy_transport::{RpcError, TransportErrorKind};
 use async_trait::async_trait;
 use base_common_genesis::RollupConfig;
 use base_protocol::{BlockInfo, L2BlockInfo};
-use tokio::sync::watch;
+
+use super::L1OriginSelectorProvider;
 
 /// Trait for selecting the next L1 origin block for sequencing.
 ///
@@ -189,7 +189,7 @@ impl<P: L1OriginSelectorProvider> L1OriginSelector<P> {
 /// An error produced by the [`L1OriginSelector`].
 #[derive(Debug, thiserror::Error)]
 pub enum L1OriginSelectorError {
-    /// An error produced by the [`RootProvider`].
+    /// An error produced by the [`alloy_provider::RootProvider`].
     #[error(transparent)]
     Provider(#[from] RpcError<TransportErrorKind>),
     /// The L1 provider does not have enough data to select the next L1 origin block.
@@ -200,77 +200,6 @@ pub enum L1OriginSelectorError {
     /// The L1 origin block was not found by its hash, e.g. during an L1 reorg or sync lag.
     #[error("L1 origin block not found by hash: {0}")]
     OriginNotFound(B256),
-}
-
-/// L1 [`BlockInfo`] provider interface for the [`L1OriginSelector`].
-#[async_trait]
-pub trait L1OriginSelectorProvider: Debug + Sync {
-    /// Returns a [`BlockInfo`] by its hash.
-    async fn get_block_by_hash(
-        &self,
-        hash: B256,
-    ) -> Result<Option<BlockInfo>, L1OriginSelectorError>;
-
-    /// Returns a [`BlockInfo`] by its number.
-    async fn get_block_by_number(
-        &self,
-        number: u64,
-    ) -> Result<Option<BlockInfo>, L1OriginSelectorError>;
-}
-
-/// A wrapper around the [`RootProvider`] that delays the view of the L1 chain by a configurable
-/// amount of blocks.
-#[derive(Debug)]
-pub struct DelayedL1OriginSelectorProvider {
-    /// The inner [`RootProvider`].
-    inner: RootProvider,
-    /// The L1 head watch channel.
-    l1_head: watch::Receiver<Option<BlockInfo>>,
-    /// The confirmation depth to delay the view of the L1 chain.
-    confirmation_depth: u64,
-}
-
-impl DelayedL1OriginSelectorProvider {
-    /// Creates a new [`DelayedL1OriginSelectorProvider`].
-    pub const fn new(
-        inner: RootProvider,
-        l1_head: watch::Receiver<Option<BlockInfo>>,
-        confirmation_depth: u64,
-    ) -> Self {
-        Self { inner, l1_head, confirmation_depth }
-    }
-}
-
-#[async_trait]
-impl L1OriginSelectorProvider for DelayedL1OriginSelectorProvider {
-    async fn get_block_by_hash(
-        &self,
-        hash: B256,
-    ) -> Result<Option<BlockInfo>, L1OriginSelectorError> {
-        // By-hash lookups are not delayed, as they're direct indexes.
-        Ok(Provider::get_block_by_hash(&self.inner, hash).await?.map(Into::into))
-    }
-
-    async fn get_block_by_number(
-        &self,
-        number: u64,
-    ) -> Result<Option<BlockInfo>, L1OriginSelectorError> {
-        let Some(l1_head) = *self.l1_head.borrow() else {
-            // If the L1 head is not available, do not enforce a confirmation delay.
-            return Ok(Provider::get_block_by_number(&self.inner, number.into())
-                .await?
-                .map(Into::into));
-        };
-
-        if number == 0
-            || self.confirmation_depth == 0
-            || number + self.confirmation_depth <= l1_head.number
-        {
-            Ok(Provider::get_block_by_number(&self.inner, number.into()).await?.map(Into::into))
-        } else {
-            Ok(None)
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/consensus/service/src/actors/sequencer/mod.rs
+++ b/crates/consensus/service/src/actors/sequencer/mod.rs
@@ -6,10 +6,10 @@ pub use build::{PayloadBuilder, UnsealedPayloadHandle};
 mod config;
 pub use config::SequencerConfig;
 
-mod origin_selector;
+mod l1_origin;
 #[cfg(test)]
-pub use origin_selector::MockOriginSelector;
-pub use origin_selector::{
+pub use l1_origin::MockOriginSelector;
+pub use l1_origin::{
     DelayedL1OriginSelectorProvider, L1OriginSelector, L1OriginSelectorError,
     L1OriginSelectorProvider, OriginSelector,
 };


### PR DESCRIPTION
## Summary

Extract the sequencer L1 origin selector into a focused `l1_origin` module with separate selector and provider implementations. This preserves the existing public API, selection behavior, and tests while reducing structural noise for follow-up changes to origin selection. Internal imports now reference the new module layout.