### PR TITLE
fix(sequencer): Reuse Prefetched L1 Origin Data

### DIFF
--- a/actions/harness/src/engine.rs
+++ b/actions/harness/src/engine.rs
@@ -30,7 +30,9 @@ use base_common_rpc_types_engine::{
     BasePayloadAttributes,
 };
 use base_consensus_engine::{EngineClient, EngineClientError};
-use base_consensus_node::{EngineClientError as NodeEngineClientError, SequencerEngineClient};
+use base_consensus_node::{
+    EngineClientError as NodeEngineClientError, ResetReason, SequencerEngineClient,
+};
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_evm::BaseEvmConfig;
 use base_execution_payload_builder::{
@@ -925,7 +927,10 @@ impl BaseEngineApi for ActionEngineClient {
 
 #[async_trait]
 impl SequencerEngineClient for ActionEngineClient {
-    async fn reset_engine_forkchoice(&self) -> Result<(), NodeEngineClientError> {
+    async fn reset_engine_forkchoice(
+        &self,
+        _reason: ResetReason,
+    ) -> Result<(), NodeEngineClientError> {
         // No-op in action tests — FCU to current head is the default.
         Ok(())
     }

--- a/actions/harness/src/l1/provider.rs
+++ b/actions/harness/src/l1/provider.rs
@@ -4,7 +4,7 @@ use alloy_consensus::{Header, Receipt};
 use alloy_primitives::B256;
 use async_trait::async_trait;
 use base_consensus_derive::{ChainProvider, PipelineError, PipelineErrorKind};
-use base_consensus_node::{L1OriginSelectorError, L1OriginSelectorProvider};
+use base_consensus_node::{L1OriginSelectorError, L1OriginSelectorProvider, PreparedL1Origin};
 use base_protocol::BlockInfo;
 
 use crate::{L1Block, block_info_from};
@@ -62,18 +62,26 @@ impl L1OriginSelectorProvider for SharedL1Chain {
         self.tip().map(|block| block.hash())
     }
 
-    async fn get_block_by_hash(
+    async fn prepared_by_hash(
         &self,
         hash: B256,
-    ) -> Result<Option<BlockInfo>, L1OriginSelectorError> {
-        Ok(self.block_by_hash(hash).map(|b| block_info_from(&b)))
+    ) -> Result<Option<PreparedL1Origin>, L1OriginSelectorError> {
+        Ok(self.block_by_hash(hash).map(prepared_from))
     }
 
-    async fn get_block_by_number(
+    async fn prepared_by_number(
         &self,
         number: u64,
-    ) -> Result<Option<BlockInfo>, L1OriginSelectorError> {
-        Ok(self.get_block(number).map(|b| block_info_from(&b)))
+    ) -> Result<Option<PreparedL1Origin>, L1OriginSelectorError> {
+        Ok(self.get_block(number).map(prepared_from))
+    }
+}
+
+fn prepared_from(block: L1Block) -> PreparedL1Origin {
+    PreparedL1Origin {
+        hash: block.hash(),
+        header: block.header,
+        receipts: Arc::new(block.receipts),
     }
 }
 

--- a/actions/harness/src/l1/provider.rs
+++ b/actions/harness/src/l1/provider.rs
@@ -81,7 +81,7 @@ fn prepared_from(block: L1Block) -> PreparedL1Origin {
     PreparedL1Origin {
         hash: block.hash(),
         header: block.header,
-        receipts: Arc::new(block.receipts),
+        receipts: Some(Arc::new(block.receipts)),
     }
 }
 

--- a/actions/harness/src/sequencer/builder_backend.rs
+++ b/actions/harness/src/sequencer/builder_backend.rs
@@ -35,7 +35,9 @@ use base_common_genesis::RollupConfig;
 use base_common_network::Base;
 use base_common_rpc_types_engine::{BaseExecutionPayload, BaseExecutionPayloadEnvelope};
 use base_consensus_engine::EngineGetPayloadVersion;
-use base_consensus_node::{EngineClientError, EngineClientResult, SequencerEngineClient};
+use base_consensus_node::{
+    EngineClientError, EngineClientResult, ResetReason, SequencerEngineClient,
+};
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_payload_builder::BasePayloadBuilderAttributes;
 use base_execution_txpool::BasePooledTransaction;
@@ -158,7 +160,7 @@ impl BuilderBackedEngineClient {
 /// `newPayload` + canonical `forkchoiceUpdated` to import it.
 #[async_trait]
 impl SequencerEngineClient for BuilderBackedEngineClient {
-    async fn reset_engine_forkchoice(&self) -> EngineClientResult<()> {
+    async fn reset_engine_forkchoice(&self, _reason: ResetReason) -> EngineClientResult<()> {
         let head = self.head.lock().expect("head lock").block_info.hash;
         self.engine()
             .update_forkchoice(head, head, None)

--- a/actions/harness/src/sequencer/engine_client.rs
+++ b/actions/harness/src/sequencer/engine_client.rs
@@ -4,7 +4,7 @@ use alloy_rpc_types_engine::PayloadId;
 use async_trait::async_trait;
 use base_common_consensus::BaseBlock;
 use base_common_rpc_types_engine::BaseExecutionPayloadEnvelope;
-use base_consensus_node::SequencerEngineClient;
+use base_consensus_node::{ResetReason, SequencerEngineClient};
 use base_protocol::{AttributesWithParent, L2BlockInfo};
 use tokio::sync::mpsc;
 
@@ -40,8 +40,11 @@ impl ActionSequencerEngineClient {
 
 #[async_trait]
 impl SequencerEngineClient for ActionSequencerEngineClient {
-    async fn reset_engine_forkchoice(&self) -> Result<(), base_consensus_node::EngineClientError> {
-        self.inner.reset_engine_forkchoice().await
+    async fn reset_engine_forkchoice(
+        &self,
+        reason: ResetReason,
+    ) -> Result<(), base_consensus_node::EngineClientError> {
+        self.inner.reset_engine_forkchoice(reason).await
     }
 
     async fn start_build_block(

--- a/actions/harness/src/sequencer/origin.rs
+++ b/actions/harness/src/sequencer/origin.rs
@@ -28,11 +28,10 @@ impl OriginSelector for ActionOriginSelector {
     async fn next_l1_origin(
         &mut self,
         unsafe_head: L2BlockInfo,
-        is_recovery_mode: bool,
     ) -> Result<BlockInfo, base_consensus_node::L1OriginSelectorError> {
         if let Some(pin) = *self.pin.lock().expect("L1 origin pin lock poisoned") {
             return Ok(pin);
         }
-        self.inner.next_l1_origin(unsafe_head, is_recovery_mode).await
+        self.inner.next_l1_origin(unsafe_head).await
     }
 }

--- a/crates/consensus/engine/src/metrics/mod.rs
+++ b/crates/consensus/engine/src/metrics/mod.rs
@@ -45,6 +45,12 @@ base_metrics::define_metrics! {
     engine_method_request_duration: histogram,
     #[describe("Engine reset count")]
     engine_reset_count: counter,
+    #[describe("L2 blocks walked backward while discovering reset forkchoice")]
+    #[label(name = "phase", default = ["unsafe", "safe"])]
+    engine_reset_forkchoice_walked_blocks: histogram,
+    #[describe("Wall-clock duration of reset forkchoice discovery walks")]
+    #[label(name = "phase", default = ["unsafe", "safe"])]
+    engine_reset_forkchoice_walk_duration_seconds: histogram,
     #[describe("Payloads dropped because unsafe head changed between build and seal")]
     sequencer_unsafe_head_changed_total: counter,
     #[describe("Total duration of the finalize task in seconds")]

--- a/crates/consensus/engine/src/sync/error.rs
+++ b/crates/consensus/engine/src/sync/error.rs
@@ -34,6 +34,9 @@ pub enum SyncStartError {
     /// Finalized block mismatch
     #[error("Finalized block mismatch. Expected {0}, Got {1}")]
     MismatchedFinalizedBlock(B256, B256),
+    /// A reset would have to reorg the finalized L2 block because its L1 origin is noncanonical.
+    #[error("Cannot reorg finalized L2 block {0} with a noncanonical L1 origin")]
+    FinalizedL1OriginNotCanonical(B256),
     /// L1 origin mismatch.
     #[error("L1 origin mismatch")]
     L1OriginMismatch,

--- a/crates/consensus/engine/src/sync/error.rs
+++ b/crates/consensus/engine/src/sync/error.rs
@@ -37,6 +37,16 @@ pub enum SyncStartError {
     /// A reset would have to reorg the finalized L2 block because its L1 origin is noncanonical.
     #[error("Cannot reorg finalized L2 block {0} with a noncanonical L1 origin")]
     FinalizedL1OriginNotCanonical(B256),
+    /// The recovered unsafe head would exceed the maximum supported L1 reorg depth.
+    #[error(
+        "L1 reorg is too deep: previous unsafe origin {previous_unsafe_origin}, walked origin {walked_origin}"
+    )]
+    TooDeepReorg {
+        /// L1 origin number of the previous unsafe L2 head.
+        previous_unsafe_origin: u64,
+        /// L1 origin number reached by the backward walk.
+        walked_origin: u64,
+    },
     /// L1 origin mismatch.
     #[error("L1 origin mismatch")]
     L1OriginMismatch,

--- a/crates/consensus/engine/src/sync/mod.rs
+++ b/crates/consensus/engine/src/sync/mod.rs
@@ -71,6 +71,15 @@ pub async fn find_starting_forkchoice_with_checkpoint_reader<
     let mut unsafe_walked_blocks = 0_u64;
     let unsafe_walk_result = async {
         loop {
+            if current_fc.un_safe.block_info.number <= current_fc.finalized.block_info.number
+                && current_fc.un_safe.block_info.hash != current_fc.finalized.block_info.hash
+            {
+                break Err(SyncStartError::MismatchedFinalizedBlock(
+                    current_fc.finalized.block_info.hash,
+                    current_fc.un_safe.block_info.hash,
+                ));
+            }
+
             let origin = current_fc.un_safe.l1_origin;
             let canonical_l1 =
                 engine_client.get_l1_block(BlockNumberOrTag::Number(origin.number).into()).await?;
@@ -102,6 +111,12 @@ pub async fn find_starting_forkchoice_with_checkpoint_reader<
                     "Found L2 unsafe block with canonical L1 origin"
                 );
                 break Ok::<(), SyncStartError>(());
+            }
+
+            if current_fc.un_safe.block_info.number <= current_fc.finalized.block_info.number {
+                break Err(SyncStartError::FinalizedL1OriginNotCanonical(
+                    current_fc.finalized.block_info.hash,
+                ));
             }
 
             let l2_parent_hash = current_fc.un_safe.block_info.parent_hash.into();
@@ -422,6 +437,53 @@ mod tests {
                 "base_node_engine_reset_forkchoice_walk_duration_seconds_count{phase=\"safe\"} 1"
             ));
         }
+    }
+
+    #[tokio::test]
+    async fn reset_does_not_rewind_below_finalized_with_orphaned_l1_origin() {
+        let genesis_hash =
+            b256!("2020202020202020202020202020202020202020202020202020202020202020");
+        let genesis_origin = BlockNumHash {
+            number: 10,
+            hash: b256!("1010101010101010101010101010101010101010101010101010101010101010"),
+        };
+        let orphan_origin = BlockNumHash {
+            number: 11,
+            hash: b256!("1111111111111111111111111111111111111111111111111111111111111111"),
+        };
+        let rollup_config = base_common_genesis::RollupConfig {
+            genesis: ChainGenesis {
+                l1: genesis_origin,
+                l2: BlockNumHash { number: 0, hash: genesis_hash },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let finalized = l2_block_with_l1_info(1, genesis_hash, orphan_origin);
+        let finalized_hash = finalized.clone().into_consensus().hash_slow();
+        let unsafe_head = l2_block_with_l1_info(2, finalized_hash, orphan_origin);
+        let mut canonical_l1 = RpcBlock::<EthTransaction>::default();
+        canonical_l1.header.hash =
+            b256!("1212121212121212121212121212121212121212121212121212121212121212");
+        canonical_l1.header.inner.number = orphan_origin.number;
+
+        let client = test_engine_client_builder()
+            .with_l2_block(BlockNumberOrTag::Latest.into(), unsafe_head)
+            .with_l2_block(BlockNumberOrTag::Finalized.into(), finalized.clone())
+            .with_l2_block(finalized_hash.into(), finalized)
+            .with_l1_block(BlockNumberOrTag::Number(orphan_origin.number).into(), canonical_l1)
+            .build();
+
+        let error = super::find_starting_forkchoice(&rollup_config, &client)
+            .await
+            .expect_err("reset must not walk below the finalized L2 head");
+
+        assert!(matches!(
+            error,
+            super::SyncStartError::FinalizedL1OriginNotCanonical(hash)
+                if hash == finalized_hash
+        ));
     }
 
     #[tokio::test]

--- a/crates/consensus/engine/src/sync/mod.rs
+++ b/crates/consensus/engine/src/sync/mod.rs
@@ -1,5 +1,6 @@
 //! Sync start algorithm for the Base rollup node.
 
+use alloy_eips::BlockNumberOrTag;
 use base_common_genesis::RollupConfig;
 use base_protocol::L2BlockInfo;
 
@@ -63,44 +64,54 @@ pub async fn find_starting_forkchoice_with_checkpoint_reader<
         "Loaded current L2 EL forkchoice state"
     );
 
-    // Search for the highest `unsafe` block, relative to the initial `unsafe` block's L1 origin,
+    // Search for the highest `unsafe` block, relative to the initial `unsafe` block's L1 origin.
     loop {
-        let l1_origin =
-            engine_client.get_l1_block(current_fc.un_safe.l1_origin.hash.into()).await?;
+        let origin = current_fc.un_safe.l1_origin;
+        let canonical_l1 =
+            engine_client.get_l1_block(BlockNumberOrTag::Number(origin.number).into()).await?;
         info!(
             target: "sync_start",
-            l1_origin = %current_fc.un_safe.l1_origin.number,
+            l1_origin = origin.number,
             l2_unsafe = %current_fc.un_safe.block_info.number,
             "Searching for L2 unsafe block with canonical L1 origin"
         );
 
-        match l1_origin {
-            Some(_) => {
-                // Unsafe block has existing L1 origin. Continue with this head.
-                info!(
-                    target: "sync_start",
-                    l2_unsafe = %current_fc.un_safe.block_info.number,
-                    "Found L2 unsafe block with canonical L1 origin"
-                );
-                break;
-            }
+        let origin_is_plausible = match canonical_l1 {
+            Some(block) => block.header.hash == origin.hash,
             None => {
-                let l2_parent_hash = current_fc.un_safe.block_info.parent_hash.into();
-                let l2_parent = engine_client
-                    .get_l2_block(l2_parent_hash)
-                    .full()
+                // A missing block by number is only plausible when the L2 origin is ahead of the
+                // L1 view. A missing block at or below the visible L1 head is noncanonical.
+                let l1_head = engine_client
+                    .get_l1_block(BlockNumberOrTag::Latest.into())
                     .await?
-                    .ok_or(SyncStartError::BlockNotFound(l2_parent_hash))?;
-
-                current_fc.un_safe = L2BlockInfo::from_block_and_genesis(
-                    &l2_parent
-                        .map_header(|header| header.into_inner())
-                        .into_consensus()
-                        .map_transactions(|tx| tx.inner.inner.into_inner()),
-                    &cfg.genesis,
-                )?;
+                    .ok_or(SyncStartError::BlockNotFound(BlockNumberOrTag::Latest.into()))?;
+                origin.number > l1_head.header.number
             }
+        };
+
+        if origin_is_plausible {
+            info!(
+                target: "sync_start",
+                l2_unsafe = %current_fc.un_safe.block_info.number,
+                "Found L2 unsafe block with canonical L1 origin"
+            );
+            break;
         }
+
+        let l2_parent_hash = current_fc.un_safe.block_info.parent_hash.into();
+        let l2_parent = engine_client
+            .get_l2_block(l2_parent_hash)
+            .full()
+            .await?
+            .ok_or(SyncStartError::BlockNotFound(l2_parent_hash))?;
+
+        current_fc.un_safe = L2BlockInfo::from_block_and_genesis(
+            &l2_parent
+                .map_header(|header| header.into_inner())
+                .into_consensus()
+                .map_transactions(|tx| tx.inner.inner.into_inner()),
+            &cfg.genesis,
+        )?;
     }
 
     // Search for the highest `safe` block that's L1 origin is at least older than the sequencing
@@ -174,7 +185,7 @@ mod tests {
     use base_common_rpc_types::Transaction as BaseTransaction;
     use base_protocol::{BlockInfo, L1BlockInfoBedrock, L2BlockInfo};
 
-    use crate::test_utils::test_engine_client_builder;
+    use crate::{EngineClient, test_utils::test_engine_client_builder};
 
     const BASE_SEPOLIA_GENESIS_HASH: B256 =
         b256!("0dcc9e089e30b90ddfc55be9a37dd15bc551aeee999d2e2b51414c54eaf934e4");
@@ -205,10 +216,14 @@ mod tests {
         assert_eq!(rpc_reported_hash, l2_block_info.block_info.hash);
     }
 
-    fn l1_info_rpc_transaction(block_number: u64) -> BaseTransaction {
+    fn l1_info_rpc_transaction(origin: BlockNumHash, block_number: u64) -> BaseTransaction {
         let envelope = BaseTxEnvelope::Deposit(Sealed::new_unchecked(
             TxDeposit {
-                input: L1BlockInfoBedrock::default().encode_calldata(),
+                input: L1BlockInfoBedrock::new_from_number_and_block_hash(
+                    origin.number,
+                    origin.hash,
+                )
+                .encode_calldata(),
                 ..Default::default()
             },
             B256::ZERO,
@@ -227,12 +242,16 @@ mod tests {
         }
     }
 
-    fn l2_block_with_l1_info(number: u64, parent_hash: B256) -> RpcBlock<BaseTransaction> {
+    fn l2_block_with_l1_info(
+        number: u64,
+        parent_hash: B256,
+        origin: BlockNumHash,
+    ) -> RpcBlock<BaseTransaction> {
         let mut block = RpcBlock::<BaseTransaction>::default();
         block.header.inner.number = number;
         block.header.inner.parent_hash = parent_hash;
         block.header.inner.timestamp = number;
-        block.transactions = BlockTransactions::Full(vec![l1_info_rpc_transaction(number)]);
+        block.transactions = BlockTransactions::Full(vec![l1_info_rpc_transaction(origin, number)]);
         block
     }
 
@@ -253,11 +272,15 @@ mod tests {
             },
             ..Default::default()
         };
-        let latest = l2_block_with_l1_info(1, rollup_config.genesis.l2.hash);
+        let latest =
+            l2_block_with_l1_info(1, rollup_config.genesis.l2.hash, BlockNumHash::default());
         let latest_hash = latest.clone().into_consensus().hash_slow();
         let client = test_engine_client_builder()
             .with_l2_block(BlockId::Number(BlockNumberOrTag::Latest), latest)
-            .with_l1_block(BlockId::from(B256::ZERO), RpcBlock::<EthTransaction>::default())
+            .with_l1_block(
+                BlockId::Number(BlockNumberOrTag::Number(0)),
+                RpcBlock::<EthTransaction>::default(),
+            )
             .build();
 
         let forkchoice = super::find_starting_forkchoice(&rollup_config, &client)
@@ -278,5 +301,110 @@ mod tests {
         assert_eq!(forkchoice.un_safe.block_info.hash, latest_hash);
         assert_eq!(forkchoice.safe, expected_genesis);
         assert_eq!(forkchoice.finalized, expected_genesis);
+    }
+
+    #[tokio::test]
+    async fn reset_rewinds_orphaned_l1_origin_and_preserves_finalized() {
+        let canonical_parent_origin = BlockNumHash {
+            number: 10,
+            hash: b256!("1010101010101010101010101010101010101010101010101010101010101010"),
+        };
+        let orphan_origin = BlockNumHash {
+            number: 11,
+            hash: b256!("1111111111111111111111111111111111111111111111111111111111111111"),
+        };
+        let canonical_origin_hash =
+            b256!("1212121212121212121212121212121212121212121212121212121212121212");
+        let genesis_hash =
+            b256!("2020202020202020202020202020202020202020202020202020202020202020");
+        let rollup_config = base_common_genesis::RollupConfig {
+            genesis: ChainGenesis {
+                l1: canonical_parent_origin,
+                l2: BlockNumHash { number: 0, hash: genesis_hash },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let parent = l2_block_with_l1_info(1, genesis_hash, canonical_parent_origin);
+        let parent_hash = parent.clone().into_consensus().hash_slow();
+        let unsafe_head = l2_block_with_l1_info(2, parent_hash, orphan_origin);
+
+        let mut canonical_parent_l1 = RpcBlock::<EthTransaction>::default();
+        canonical_parent_l1.header.hash = canonical_parent_origin.hash;
+        canonical_parent_l1.header.inner.number = canonical_parent_origin.number;
+        let mut canonical_l1 = RpcBlock::<EthTransaction>::default();
+        canonical_l1.header.hash = canonical_origin_hash;
+        canonical_l1.header.inner.number = orphan_origin.number;
+        let mut orphan_l1 = RpcBlock::<EthTransaction>::default();
+        orphan_l1.header.hash = orphan_origin.hash;
+        orphan_l1.header.inner.number = orphan_origin.number;
+
+        let client = test_engine_client_builder()
+            .with_l2_block(BlockNumberOrTag::Latest.into(), unsafe_head)
+            .with_l2_block(BlockNumberOrTag::Safe.into(), parent.clone())
+            .with_l2_block(BlockNumberOrTag::Finalized.into(), parent.clone())
+            .with_l2_block(parent_hash.into(), parent)
+            .with_l1_block(BlockNumberOrTag::Number(10).into(), canonical_parent_l1)
+            .with_l1_block(BlockNumberOrTag::Number(11).into(), canonical_l1)
+            // The orphan remains available by hash, as is common after an L1 reorg.
+            .with_l1_block(orphan_origin.hash.into(), orphan_l1)
+            .build();
+
+        assert!(
+            client
+                .get_l1_block(orphan_origin.hash.into())
+                .await
+                .expect("orphan lookup should succeed")
+                .is_some(),
+            "orphan must remain retrievable by hash"
+        );
+
+        let forkchoice = super::find_starting_forkchoice(&rollup_config, &client)
+            .await
+            .expect("reset should find the canonical parent");
+
+        assert_eq!(forkchoice.un_safe.block_info.hash, parent_hash);
+        assert_eq!(forkchoice.un_safe.l1_origin, canonical_parent_origin);
+        assert_eq!(forkchoice.safe.block_info.hash, parent_hash);
+        assert_eq!(forkchoice.finalized.block_info.hash, parent_hash);
+        assert_eq!(forkchoice.safe, forkchoice.finalized);
+    }
+
+    #[tokio::test]
+    async fn reset_preserves_unsafe_origin_ahead_of_visible_l1() {
+        let genesis_hash =
+            b256!("2020202020202020202020202020202020202020202020202020202020202020");
+        let ahead_origin = BlockNumHash {
+            number: 12,
+            hash: b256!("1212121212121212121212121212121212121212121212121212121212121212"),
+        };
+        let rollup_config = base_common_genesis::RollupConfig {
+            genesis: ChainGenesis {
+                l1: BlockNumHash {
+                    number: 10,
+                    hash: b256!("1010101010101010101010101010101010101010101010101010101010101010"),
+                },
+                l2: BlockNumHash { number: 0, hash: genesis_hash },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let unsafe_head = l2_block_with_l1_info(1, genesis_hash, ahead_origin);
+        let unsafe_hash = unsafe_head.clone().into_consensus().hash_slow();
+        let mut visible_l1_head = RpcBlock::<EthTransaction>::default();
+        visible_l1_head.header.inner.number = 11;
+
+        let client = test_engine_client_builder()
+            .with_l2_block(BlockNumberOrTag::Latest.into(), unsafe_head)
+            .with_l1_block(BlockNumberOrTag::Latest.into(), visible_l1_head)
+            .build();
+
+        let forkchoice = super::find_starting_forkchoice(&rollup_config, &client)
+            .await
+            .expect("an origin ahead of the visible L1 head should remain plausible");
+
+        assert_eq!(forkchoice.un_safe.block_info.hash, unsafe_hash);
+        assert_eq!(forkchoice.un_safe.l1_origin, ahead_origin);
     }
 }

--- a/crates/consensus/engine/src/sync/mod.rs
+++ b/crates/consensus/engine/src/sync/mod.rs
@@ -67,6 +67,9 @@ pub async fn find_starting_forkchoice_with_checkpoint_reader<
     );
 
     // Search for the highest `unsafe` block, relative to the initial `unsafe` block's L1 origin.
+    // The finalized L2 head is the correctness boundary for this walk. Do not impose a smaller
+    // iteration cap: a reset must be able to recover every unfinalized block invalidated by a
+    // legitimate deep L1 reorg, and failing at a fixed depth would retry from the same unsafe head.
     let unsafe_walk_started = Instant::now();
     let mut unsafe_walked_blocks = 0_u64;
     let mut visible_l1_head_number = None;

--- a/crates/consensus/engine/src/sync/mod.rs
+++ b/crates/consensus/engine/src/sync/mod.rs
@@ -69,6 +69,7 @@ pub async fn find_starting_forkchoice_with_checkpoint_reader<
     // Search for the highest `unsafe` block, relative to the initial `unsafe` block's L1 origin.
     let unsafe_walk_started = Instant::now();
     let mut unsafe_walked_blocks = 0_u64;
+    let mut visible_l1_head_number = None;
     let unsafe_walk_result = async {
         loop {
             if current_fc.un_safe.block_info.number <= current_fc.finalized.block_info.number
@@ -95,12 +96,24 @@ pub async fn find_starting_forkchoice_with_checkpoint_reader<
                 None => {
                     // A missing block by number is only plausible when the L2 origin is ahead of
                     // the L1 view. A missing block at or below the visible L1 head is
-                    // noncanonical.
-                    let l1_head = engine_client
-                        .get_l1_block(BlockNumberOrTag::Latest.into())
-                        .await?
-                        .ok_or(SyncStartError::BlockNotFound(BlockNumberOrTag::Latest.into()))?;
-                    origin.number > l1_head.header.number
+                    // noncanonical. Keep one head snapshot for a coherent reset walk and to avoid
+                    // repeating the same latest-head RPC for each missing origin.
+                    let l1_head_number = match visible_l1_head_number {
+                        Some(number) => number,
+                        None => {
+                            let number = engine_client
+                                .get_l1_block(BlockNumberOrTag::Latest.into())
+                                .await?
+                                .ok_or(SyncStartError::BlockNotFound(
+                                    BlockNumberOrTag::Latest.into(),
+                                ))?
+                                .header
+                                .number;
+                            visible_l1_head_number = Some(number);
+                            number
+                        }
+                    };
+                    origin.number > l1_head_number
                 }
             };
 
@@ -521,5 +534,61 @@ mod tests {
 
         assert_eq!(forkchoice.un_safe.block_info.hash, unsafe_hash);
         assert_eq!(forkchoice.un_safe.l1_origin, ahead_origin);
+    }
+
+    #[tokio::test]
+    async fn reset_fetches_visible_l1_head_once_while_walking_missing_origins() {
+        let genesis_origin = BlockNumHash {
+            number: 10,
+            hash: b256!("1010101010101010101010101010101010101010101010101010101010101010"),
+        };
+        let parent_origin = BlockNumHash {
+            number: 11,
+            hash: b256!("1111111111111111111111111111111111111111111111111111111111111111"),
+        };
+        let unsafe_origin = BlockNumHash {
+            number: 12,
+            hash: b256!("1212121212121212121212121212121212121212121212121212121212121212"),
+        };
+
+        let genesis = l2_block_with_l1_info(0, B256::ZERO, genesis_origin);
+        let genesis_hash = genesis.clone().into_consensus().hash_slow();
+        let parent = l2_block_with_l1_info(1, genesis_hash, parent_origin);
+        let parent_hash = parent.clone().into_consensus().hash_slow();
+        let unsafe_head = l2_block_with_l1_info(2, parent_hash, unsafe_origin);
+        let rollup_config = base_common_genesis::RollupConfig {
+            genesis: ChainGenesis {
+                l1: genesis_origin,
+                l2: BlockNumHash { number: 0, hash: genesis_hash },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let mut canonical_genesis_l1 = RpcBlock::<EthTransaction>::default();
+        canonical_genesis_l1.header.hash = genesis_origin.hash;
+        canonical_genesis_l1.header.inner.number = genesis_origin.number;
+        let mut visible_l1_head = RpcBlock::<EthTransaction>::default();
+        visible_l1_head.header.inner.number = unsafe_origin.number;
+
+        let client = test_engine_client_builder()
+            .with_l2_block(BlockNumberOrTag::Latest.into(), unsafe_head)
+            .with_l2_block(parent_hash.into(), parent)
+            .with_l2_block(genesis_hash.into(), genesis)
+            .with_l1_block(
+                BlockNumberOrTag::Number(genesis_origin.number).into(),
+                canonical_genesis_l1,
+            )
+            .with_l1_block(BlockNumberOrTag::Latest.into(), visible_l1_head)
+            .build();
+
+        let forkchoice = super::find_starting_forkchoice(&rollup_config, &client)
+            .await
+            .expect("reset should walk both missing origins to the canonical genesis origin");
+
+        assert_eq!(forkchoice.un_safe.block_info.hash, genesis_hash);
+        let storage = client.storage();
+        let storage = storage.read().await;
+        assert_eq!(storage.l1_block_calls_by_id.get("number:latest"), Some(&1));
     }
 }

--- a/crates/consensus/engine/src/sync/mod.rs
+++ b/crates/consensus/engine/src/sync/mod.rs
@@ -21,6 +21,9 @@ pub use checkpoint::{
 
 use crate::{EngineClient, Metrics};
 
+/// Maximum supported L1 reorg depth, expressed as sequencing windows to match op-node.
+const MAX_REORG_SEQ_WINDOWS: u64 = 5;
+
 /// Searches for the latest [`L2ForkchoiceState`] that we can use to start the sync process with.
 ///
 ///   - The *unsafe L2 block*: This is the highest L2 block whose L1 origin is a *plausible*
@@ -67,9 +70,10 @@ pub async fn find_starting_forkchoice_with_checkpoint_reader<
     );
 
     // Search for the highest `unsafe` block, relative to the initial `unsafe` block's L1 origin.
-    // The finalized L2 head is the correctness boundary for this walk. Do not impose a smaller
-    // iteration cap: a reset must be able to recover every unfinalized block invalidated by a
-    // legitimate deep L1 reorg, and failing at a fixed depth would retry from the same unsafe head.
+    // Finalized is the lower correctness boundary. The L1-origin depth guard matches op-node's
+    // operational bound without imposing an arbitrary L2-block limit inside a sequencing epoch.
+    let previous_unsafe_origin = current_fc.un_safe.l1_origin.number;
+    let max_reorg_depth = cfg.seq_window_size.saturating_mul(MAX_REORG_SEQ_WINDOWS);
     let unsafe_walk_started = Instant::now();
     let mut unsafe_walked_blocks = 0_u64;
     let mut visible_l1_head_number = None;
@@ -85,6 +89,12 @@ pub async fn find_starting_forkchoice_with_checkpoint_reader<
             }
 
             let origin = current_fc.un_safe.l1_origin;
+            if origin.number.saturating_add(max_reorg_depth) < previous_unsafe_origin {
+                break Err(SyncStartError::TooDeepReorg {
+                    previous_unsafe_origin,
+                    walked_origin: origin.number,
+                });
+            }
             let canonical_l1 =
                 engine_client.get_l1_block(BlockNumberOrTag::Number(origin.number).into()).await?;
             info!(
@@ -388,6 +398,7 @@ mod tests {
                 l2: BlockNumHash { number: 0, hash: genesis_hash },
                 ..Default::default()
             },
+            seq_window_size: 1,
             ..Default::default()
         };
 
@@ -503,6 +514,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn reset_rejects_reorg_deeper_than_five_sequencing_windows() {
+        let canonical_origin = BlockNumHash {
+            number: 10,
+            hash: b256!("1010101010101010101010101010101010101010101010101010101010101010"),
+        };
+        let orphan_origin = BlockNumHash {
+            number: 16,
+            hash: b256!("1616161616161616161616161616161616161616161616161616161616161616"),
+        };
+        let genesis_hash =
+            b256!("2020202020202020202020202020202020202020202020202020202020202020");
+        let rollup_config = base_common_genesis::RollupConfig {
+            genesis: ChainGenesis {
+                l1: canonical_origin,
+                l2: BlockNumHash { number: 0, hash: genesis_hash },
+                ..Default::default()
+            },
+            seq_window_size: 1,
+            ..Default::default()
+        };
+
+        let parent = l2_block_with_l1_info(1, genesis_hash, canonical_origin);
+        let parent_hash = parent.clone().into_consensus().hash_slow();
+        let unsafe_head = l2_block_with_l1_info(2, parent_hash, orphan_origin);
+        let mut canonical_parent_l1 = RpcBlock::<EthTransaction>::default();
+        canonical_parent_l1.header.hash = canonical_origin.hash;
+        canonical_parent_l1.header.inner.number = canonical_origin.number;
+        let mut replacement_l1 = RpcBlock::<EthTransaction>::default();
+        replacement_l1.header.hash = B256::with_last_byte(17);
+        replacement_l1.header.inner.number = orphan_origin.number;
+
+        let client = test_engine_client_builder()
+            .with_l2_block(BlockNumberOrTag::Latest.into(), unsafe_head)
+            .with_l2_block(BlockNumberOrTag::Safe.into(), parent.clone())
+            .with_l2_block(BlockNumberOrTag::Finalized.into(), parent.clone())
+            .with_l2_block(parent_hash.into(), parent)
+            .with_l1_block(BlockNumberOrTag::Number(10).into(), canonical_parent_l1)
+            .with_l1_block(BlockNumberOrTag::Number(16).into(), replacement_l1)
+            .build();
+
+        let error = super::find_starting_forkchoice(&rollup_config, &client)
+            .await
+            .expect_err("reset must reject a reorg deeper than five sequencing windows");
+
+        assert!(matches!(
+            error,
+            super::SyncStartError::TooDeepReorg { previous_unsafe_origin: 16, walked_origin: 10 }
+        ));
+        let storage = client.storage();
+        let storage = storage.read().await;
+        assert_eq!(storage.l1_block_calls_by_id.get("number:10"), None);
+    }
+
+    #[tokio::test]
     async fn reset_preserves_unsafe_origin_ahead_of_visible_l1() {
         let genesis_hash =
             b256!("2020202020202020202020202020202020202020202020202020202020202020");
@@ -565,6 +630,7 @@ mod tests {
                 l2: BlockNumHash { number: 0, hash: genesis_hash },
                 ..Default::default()
             },
+            seq_window_size: 1,
             ..Default::default()
         };
 

--- a/crates/consensus/engine/src/sync/mod.rs
+++ b/crates/consensus/engine/src/sync/mod.rs
@@ -1,5 +1,7 @@
 //! Sync start algorithm for the Base rollup node.
 
+use std::time::Instant;
+
 use alloy_eips::BlockNumberOrTag;
 use base_common_genesis::RollupConfig;
 use base_protocol::L2BlockInfo;
@@ -17,7 +19,7 @@ pub use checkpoint::{
     NoopForkchoiceCheckpointReader,
 };
 
-use crate::EngineClient;
+use crate::{EngineClient, Metrics};
 
 /// Searches for the latest [`L2ForkchoiceState`] that we can use to start the sync process with.
 ///
@@ -65,106 +67,129 @@ pub async fn find_starting_forkchoice_with_checkpoint_reader<
     );
 
     // Search for the highest `unsafe` block, relative to the initial `unsafe` block's L1 origin.
-    loop {
-        let origin = current_fc.un_safe.l1_origin;
-        let canonical_l1 =
-            engine_client.get_l1_block(BlockNumberOrTag::Number(origin.number).into()).await?;
-        info!(
-            target: "sync_start",
-            l1_origin = origin.number,
-            l2_unsafe = %current_fc.un_safe.block_info.number,
-            "Searching for L2 unsafe block with canonical L1 origin"
-        );
-
-        let origin_is_plausible = match canonical_l1 {
-            Some(block) => block.header.hash == origin.hash,
-            None => {
-                // A missing block by number is only plausible when the L2 origin is ahead of the
-                // L1 view. A missing block at or below the visible L1 head is noncanonical.
-                let l1_head = engine_client
-                    .get_l1_block(BlockNumberOrTag::Latest.into())
-                    .await?
-                    .ok_or(SyncStartError::BlockNotFound(BlockNumberOrTag::Latest.into()))?;
-                origin.number > l1_head.header.number
-            }
-        };
-
-        if origin_is_plausible {
+    let unsafe_walk_started = Instant::now();
+    let mut unsafe_walked_blocks = 0_u64;
+    let unsafe_walk_result = async {
+        loop {
+            let origin = current_fc.un_safe.l1_origin;
+            let canonical_l1 =
+                engine_client.get_l1_block(BlockNumberOrTag::Number(origin.number).into()).await?;
             info!(
                 target: "sync_start",
+                l1_origin = origin.number,
                 l2_unsafe = %current_fc.un_safe.block_info.number,
-                "Found L2 unsafe block with canonical L1 origin"
+                "Searching for L2 unsafe block with canonical L1 origin"
             );
-            break;
+
+            let origin_is_plausible = match canonical_l1 {
+                Some(block) => block.header.hash == origin.hash,
+                None => {
+                    // A missing block by number is only plausible when the L2 origin is ahead of
+                    // the L1 view. A missing block at or below the visible L1 head is
+                    // noncanonical.
+                    let l1_head = engine_client
+                        .get_l1_block(BlockNumberOrTag::Latest.into())
+                        .await?
+                        .ok_or(SyncStartError::BlockNotFound(BlockNumberOrTag::Latest.into()))?;
+                    origin.number > l1_head.header.number
+                }
+            };
+
+            if origin_is_plausible {
+                info!(
+                    target: "sync_start",
+                    l2_unsafe = %current_fc.un_safe.block_info.number,
+                    "Found L2 unsafe block with canonical L1 origin"
+                );
+                break Ok::<(), SyncStartError>(());
+            }
+
+            let l2_parent_hash = current_fc.un_safe.block_info.parent_hash.into();
+            let l2_parent = engine_client
+                .get_l2_block(l2_parent_hash)
+                .full()
+                .await?
+                .ok_or(SyncStartError::BlockNotFound(l2_parent_hash))?;
+
+            current_fc.un_safe = L2BlockInfo::from_block_and_genesis(
+                &l2_parent
+                    .map_header(|header| header.into_inner())
+                    .into_consensus()
+                    .map_transactions(|tx| tx.inner.inner.into_inner()),
+                &cfg.genesis,
+            )?;
+            unsafe_walked_blocks = unsafe_walked_blocks.saturating_add(1);
         }
-
-        let l2_parent_hash = current_fc.un_safe.block_info.parent_hash.into();
-        let l2_parent = engine_client
-            .get_l2_block(l2_parent_hash)
-            .full()
-            .await?
-            .ok_or(SyncStartError::BlockNotFound(l2_parent_hash))?;
-
-        current_fc.un_safe = L2BlockInfo::from_block_and_genesis(
-            &l2_parent
-                .map_header(|header| header.into_inner())
-                .into_consensus()
-                .map_transactions(|tx| tx.inner.inner.into_inner()),
-            &cfg.genesis,
-        )?;
     }
+    .await;
+    Metrics::engine_reset_forkchoice_walked_blocks("unsafe").record(unsafe_walked_blocks as f64);
+    Metrics::engine_reset_forkchoice_walk_duration_seconds("unsafe")
+        .record(unsafe_walk_started.elapsed());
+    unsafe_walk_result?;
 
     // Search for the highest `safe` block that's L1 origin is at least older than the sequencing
     // window, relative to the L1 origin of the `unsafe` block.
     let mut safe_cursor = current_fc.un_safe;
-    loop {
-        info!(
-            target: "sync_start",
-            l1_origin = %safe_cursor.l1_origin.number,
-            l2_safe = %safe_cursor.block_info.number,
-            "Searching for L2 safe block beyond sequencing window"
-        );
-
-        let is_behind_sequence_window =
-            current_fc.un_safe.l1_origin.number.saturating_sub(cfg.seq_window_size)
-                > safe_cursor.l1_origin.number;
-        let is_labeled_safe = safe_cursor.block_info.hash == current_fc.safe.block_info.hash;
-        let is_finalized = safe_cursor.block_info.hash == current_fc.finalized.block_info.hash;
-        let is_genesis = safe_cursor.block_info.hash == cfg.genesis.l2.hash;
-        if is_behind_sequence_window || is_labeled_safe || is_finalized || is_genesis {
+    let safe_walk_started = Instant::now();
+    let mut safe_walked_blocks = 0_u64;
+    let safe_walk_result = async {
+        loop {
             info!(
                 target: "sync_start",
+                l1_origin = %safe_cursor.l1_origin.number,
                 l2_safe = %safe_cursor.block_info.number,
-                is_behind_sequence_window,
-                is_labeled_safe,
-                is_finalized,
-                is_genesis,
-                "Found suitable L2 safe block"
+                "Searching for L2 safe block beyond sequencing window"
             );
-            current_fc.safe = safe_cursor;
-            break;
+
+            let is_behind_sequence_window =
+                current_fc.un_safe.l1_origin.number.saturating_sub(cfg.seq_window_size)
+                    > safe_cursor.l1_origin.number;
+            let is_labeled_safe = safe_cursor.block_info.hash == current_fc.safe.block_info.hash;
+            let is_finalized = safe_cursor.block_info.hash == current_fc.finalized.block_info.hash;
+            let is_genesis = safe_cursor.block_info.hash == cfg.genesis.l2.hash;
+            if is_behind_sequence_window || is_labeled_safe || is_finalized || is_genesis {
+                info!(
+                    target: "sync_start",
+                    l2_safe = %safe_cursor.block_info.number,
+                    is_behind_sequence_window,
+                    is_labeled_safe,
+                    is_finalized,
+                    is_genesis,
+                    "Found suitable L2 safe block"
+                );
+                current_fc.safe = safe_cursor;
+                break Ok::<(), SyncStartError>(());
+            }
+            if safe_cursor.block_info.parent_hash == current_fc.safe.block_info.hash {
+                safe_cursor = current_fc.safe;
+                safe_walked_blocks = safe_walked_blocks.saturating_add(1);
+                continue;
+            }
+            if safe_cursor.block_info.parent_hash == current_fc.finalized.block_info.hash {
+                safe_cursor = current_fc.finalized;
+                safe_walked_blocks = safe_walked_blocks.saturating_add(1);
+                continue;
+            }
+            let block = engine_client
+                .get_l2_block(safe_cursor.block_info.parent_hash.into())
+                .full()
+                .await?
+                .ok_or(SyncStartError::BlockNotFound(safe_cursor.block_info.parent_hash.into()))?;
+            safe_cursor = L2BlockInfo::from_block_and_genesis(
+                &block
+                    .map_header(|header| header.into_inner())
+                    .into_consensus()
+                    .map_transactions(|tx| tx.inner.inner.into_inner()),
+                &cfg.genesis,
+            )?;
+            safe_walked_blocks = safe_walked_blocks.saturating_add(1);
         }
-        if safe_cursor.block_info.parent_hash == current_fc.safe.block_info.hash {
-            safe_cursor = current_fc.safe;
-            continue;
-        }
-        if safe_cursor.block_info.parent_hash == current_fc.finalized.block_info.hash {
-            safe_cursor = current_fc.finalized;
-            continue;
-        }
-        let block = engine_client
-            .get_l2_block(safe_cursor.block_info.parent_hash.into())
-            .full()
-            .await?
-            .ok_or(SyncStartError::BlockNotFound(safe_cursor.block_info.parent_hash.into()))?;
-        safe_cursor = L2BlockInfo::from_block_and_genesis(
-            &block
-                .map_header(|header| header.into_inner())
-                .into_consensus()
-                .map_transactions(|tx| tx.inner.inner.into_inner()),
-            &cfg.genesis,
-        )?;
     }
+    .await;
+    Metrics::engine_reset_forkchoice_walked_blocks("safe").record(safe_walked_blocks as f64);
+    Metrics::engine_reset_forkchoice_walk_duration_seconds("safe")
+        .record(safe_walk_started.elapsed());
+    safe_walk_result?;
 
     // Leave the finalized block as-is, and return the current forkchoice.
     Ok(current_fc)
@@ -184,6 +209,8 @@ mod tests {
     use base_common_network::Base;
     use base_common_rpc_types::Transaction as BaseTransaction;
     use base_protocol::{BlockInfo, L1BlockInfoBedrock, L2BlockInfo};
+    #[cfg(feature = "metrics")]
+    use metrics_exporter_prometheus::PrometheusBuilder;
 
     use crate::{EngineClient, test_utils::test_engine_client_builder};
 
@@ -305,6 +332,13 @@ mod tests {
 
     #[tokio::test]
     async fn reset_rewinds_orphaned_l1_origin_and_preserves_finalized() {
+        #[cfg(feature = "metrics")]
+        let recorder = PrometheusBuilder::new().build_recorder();
+        #[cfg(feature = "metrics")]
+        let metrics_handle = recorder.handle();
+        #[cfg(feature = "metrics")]
+        let _metrics_guard = metrics::set_default_local_recorder(&recorder);
+
         let canonical_parent_origin = BlockNumHash {
             number: 10,
             hash: b256!("1010101010101010101010101010101010101010101010101010101010101010"),
@@ -369,6 +403,25 @@ mod tests {
         assert_eq!(forkchoice.safe.block_info.hash, parent_hash);
         assert_eq!(forkchoice.finalized.block_info.hash, parent_hash);
         assert_eq!(forkchoice.safe, forkchoice.finalized);
+
+        #[cfg(feature = "metrics")]
+        {
+            let rendered = metrics_handle.render();
+            assert!(rendered.contains(
+                "base_node_engine_reset_forkchoice_walked_blocks_sum{phase=\"unsafe\"} 1"
+            ));
+            assert!(
+                rendered.contains(
+                    "base_node_engine_reset_forkchoice_walked_blocks_sum{phase=\"safe\"} 0"
+                )
+            );
+            assert!(rendered.contains(
+                "base_node_engine_reset_forkchoice_walk_duration_seconds_count{phase=\"unsafe\"} 1"
+            ));
+            assert!(rendered.contains(
+                "base_node_engine_reset_forkchoice_walk_duration_seconds_count{phase=\"safe\"} 1"
+            ));
+        }
     }
 
     #[tokio::test]

--- a/crates/consensus/engine/src/test_utils/engine_client.rs
+++ b/crates/consensus/engine/src/test_utils/engine_client.rs
@@ -111,6 +111,8 @@ pub struct MockEngineStorage {
     /// Storage for L1 blocks by stringified `BlockId`.
     /// L1 blocks use standard Ethereum transactions.
     pub l1_blocks_by_id: HashMap<String, Block<EthTransaction>>,
+    /// Number of executed L1 block requests by stringified `BlockId`.
+    pub l1_block_calls_by_id: HashMap<String, u64>,
     /// Storage for L2 blocks by stringified `BlockId`.
     /// L2 blocks use Base transactions.
     pub l2_blocks_by_id: HashMap<String, L2RpcBlock>,
@@ -489,7 +491,8 @@ impl EngineClient for MockEngineClient {
                 let block_key = block_key.clone();
 
                 ProviderCall::BoxedFuture(Box::pin(async move {
-                    let storage_guard = storage.read().await;
+                    let mut storage_guard = storage.write().await;
+                    *storage_guard.l1_block_calls_by_id.entry(block_key.clone()).or_default() += 1;
                     Ok(storage_guard.l1_blocks_by_id.get(&block_key).cloned())
                 }))
             }),

--- a/crates/consensus/service/src/actors/derivation/actor.rs
+++ b/crates/consensus/service/src/actors/derivation/actor.rs
@@ -20,7 +20,7 @@ use tokio_util::sync::{CancellationToken, WaitForCancellationFuture};
 use crate::{
     CancellableContext, DerivationActorRequest, DerivationEngineClient, DerivationState,
     DerivationStateMachine, DerivationStateTransitionError, DerivationStateUpdate, Metrics,
-    NodeActor, actors::derivation::L2Finalizer,
+    NodeActor, ResetReason, actors::derivation::L2Finalizer,
 };
 
 /// The [`NodeActor`] for the derivation sub-routine.
@@ -210,6 +210,11 @@ where
                                     )
                                     .await?;
                             } else {
+                                let reason = if matches!(&e, ResetError::ReorgDetected(..)) {
+                                    ResetReason::DerivationL1Reorg
+                                } else {
+                                    ResetReason::DerivationPipeline
+                                };
                                 if let ResetError::ReorgDetected(expected, new) = e {
                                     warn!(
                                         target: "derivation",
@@ -218,10 +223,13 @@ where
 
                                     Metrics::l1_reorg_count().increment(1);
                                 }
-                                self.engine_client.reset_engine_forkchoice().await.map_err(|e| {
-                                    error!(target: "derivation", ?e, "Failed to send reset request");
-                                    DerivationError::Sender(Box::new(e))
-                                })?;
+                                self.engine_client
+                                    .reset_engine_forkchoice(reason)
+                                    .await
+                                    .map_err(|e| {
+                                        error!(target: "derivation", ?e, "Failed to send reset request");
+                                        DerivationError::Sender(Box::new(e))
+                                    })?;
                                 self.derivation_state_machine
                                     .update(&DerivationStateUpdate::SignalNeeded)?;
                                 return Err(DerivationError::Yield);

--- a/crates/consensus/service/src/actors/derivation/actor.rs
+++ b/crates/consensus/service/src/actors/derivation/actor.rs
@@ -218,7 +218,9 @@ where
                                 if let ResetError::ReorgDetected(expected, new) = e {
                                     warn!(
                                         target: "derivation",
-                                        "L1 reorg detected! Expected: {expected} | New: {new}"
+                                        %expected,
+                                        %new,
+                                        "L1 reorg detected"
                                     );
 
                                     Metrics::l1_reorg_count().increment(1);

--- a/crates/consensus/service/src/actors/derivation/engine_client.rs
+++ b/crates/consensus/service/src/actors/derivation/engine_client.rs
@@ -5,14 +5,17 @@ use base_consensus_engine::ConsolidateInput;
 use derive_more::Constructor;
 use tokio::sync::mpsc;
 
-use crate::{EngineActorRequest, EngineClientError, EngineClientResult, ResetOrigin, ResetRequest};
+use crate::{
+    EngineActorRequest, EngineClientError, EngineClientResult, ResetOrigin, ResetReason,
+    ResetRequest,
+};
 
 /// Client to use to interact with the engine.
 #[cfg_attr(test, mockall::automock(type SafeL2Signal = AttributesWithParent;))]
 #[async_trait]
 pub trait DerivationEngineClient: Debug + Send + Sync {
     /// Resets the engine's forkchoice.
-    async fn reset_engine_forkchoice(&self) -> EngineClientResult<()>;
+    async fn reset_engine_forkchoice(&self, reason: ResetReason) -> EngineClientResult<()>;
 
     /// Sends a request to finalize the L2 block at the provided block number.
     /// Note: This does not wait for the engine to process it.
@@ -37,7 +40,7 @@ pub struct QueuedDerivationEngineClient {
 
 #[async_trait]
 impl DerivationEngineClient for QueuedDerivationEngineClient {
-    async fn reset_engine_forkchoice(&self) -> EngineClientResult<()> {
+    async fn reset_engine_forkchoice(&self, reason: ResetReason) -> EngineClientResult<()> {
         let (result_tx, mut result_rx) = mpsc::channel(1);
 
         info!(target: "derivation", "Sending reset request to engine.");
@@ -45,6 +48,7 @@ impl DerivationEngineClient for QueuedDerivationEngineClient {
             .send(EngineActorRequest::ResetRequest(Box::new(ResetRequest {
                 result_tx,
                 origin: ResetOrigin::Derivation,
+                reason,
             })))
             .await
             .map_err(|_| EngineClientError::RequestError("request channel closed.".to_string()))?;

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -640,7 +640,9 @@ mod tests {
     use alloy_rpc_types_engine::{
         ExecutionPayloadV1, ForkchoiceUpdated, PayloadId, PayloadStatus, PayloadStatusEnum,
     };
-    use alloy_rpc_types_eth::{Block as RpcBlock, BlockTransactions};
+    use alloy_rpc_types_eth::{
+        Block as RpcBlock, BlockTransactions, Transaction as EthTransaction,
+    };
     use async_trait::async_trait;
     use base_common_consensus::{BaseTxEnvelope, TxDeposit};
     use base_common_genesis::{ChainGenesis, RollupConfig, SystemConfig};
@@ -648,8 +650,8 @@ mod tests {
     use base_common_rpc_types_engine::{BaseExecutionPayload, BaseExecutionPayloadEnvelope};
     use base_consensus_derive::Signal;
     use base_consensus_engine::{
-        Engine, EngineState, EngineTaskError, EngineTaskErrorSeverity, ForkchoiceCheckpointError,
-        ForkchoiceCheckpointLabel, ForkchoiceCheckpointReader,
+        Engine, EngineClient, EngineState, EngineTaskError, EngineTaskErrorSeverity,
+        ForkchoiceCheckpointError, ForkchoiceCheckpointLabel, ForkchoiceCheckpointReader,
         test_utils::{
             TestAttributesBuilder, TestEngineStateBuilder, test_block_info,
             test_engine_client_builder,
@@ -1576,10 +1578,14 @@ mod tests {
         block
     }
 
-    fn l1_info_rpc_transaction(block_number: u64) -> BaseTransaction {
+    fn l1_info_rpc_transaction(block_number: u64, l1_origin: BlockNumHash) -> BaseTransaction {
         let envelope = BaseTxEnvelope::Deposit(Sealed::new_unchecked(
             TxDeposit {
-                input: L1BlockInfoBedrock::default().encode_calldata(),
+                input: L1BlockInfoBedrock::new_from_number_and_block_hash(
+                    l1_origin.number,
+                    l1_origin.hash,
+                )
+                .encode_calldata(),
                 ..Default::default()
             },
             B256::ZERO,
@@ -1601,12 +1607,14 @@ mod tests {
     fn full_reth_l2_block_with_l1_info(
         number: u64,
         parent_hash: B256,
+        l1_origin: BlockNumHash,
     ) -> RpcBlock<BaseTransaction> {
         let mut block = RpcBlock::<BaseTransaction>::default();
         block.header.inner.number = number;
         block.header.inner.parent_hash = parent_hash;
         block.header.inner.timestamp = number;
-        block.transactions = BlockTransactions::Full(vec![l1_info_rpc_transaction(number)]);
+        block.transactions =
+            BlockTransactions::Full(vec![l1_info_rpc_transaction(number, l1_origin)]);
         block
     }
 
@@ -1655,6 +1663,7 @@ mod tests {
         let full_latest = full_reth_l2_block_with_l1_info(
             reth_latest.block_info.number + 1,
             reth_latest.block_info.hash,
+            BlockNumHash::default(),
         );
 
         let client = Arc::new(
@@ -1664,6 +1673,7 @@ mod tests {
                 .with_l2_block(BlockId::Number(BlockNumberOrTag::Safe), pruned_safe)
                 .with_l2_block(BlockId::Number(BlockNumberOrTag::Latest), full_latest)
                 .with_l1_block(BlockId::from(B256::ZERO), RpcBlock::default())
+                .with_l1_block(BlockId::from(0u64), RpcBlock::default())
                 .with_new_payload_v2_response(PayloadStatus {
                     status: PayloadStatusEnum::Valid,
                     latest_valid_hash: Some(next_hash),
@@ -1701,6 +1711,133 @@ mod tests {
             .drain()
             .await
             .expect("validator restart must not crash when reth pruned historical block bodies");
+    }
+
+    /// Verifies the engine actor reset boundary rejects an orphaned L1 origin even when the
+    /// orphan remains retrievable by hash, and rewinds only to the finalized canonical parent.
+    #[tokio::test]
+    async fn reset_request_rewinds_hash_retrievable_l1_orphan_and_preserves_finalized() {
+        let genesis_hash = B256::with_last_byte(0x50);
+        let canonical_parent_origin = BlockNumHash { number: 10, hash: B256::with_last_byte(0x10) };
+        let orphan_origin = BlockNumHash { number: 11, hash: B256::with_last_byte(0x11) };
+        let canonical_origin_hash = B256::with_last_byte(0x21);
+        let cfg = Arc::new(RollupConfig {
+            genesis: ChainGenesis {
+                l1: canonical_parent_origin,
+                l2: BlockNumHash { number: 0, hash: genesis_hash },
+                system_config: Some(SystemConfig::default()),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let finalized = full_reth_l2_block_with_l1_info(1, genesis_hash, canonical_parent_origin);
+        let finalized_hash = finalized.clone().into_consensus().hash_slow();
+        let unsafe_head = full_reth_l2_block_with_l1_info(2, finalized_hash, orphan_origin);
+        let unsafe_hash = unsafe_head.clone().into_consensus().hash_slow();
+        let finalized_info = L2BlockInfo {
+            block_info: BlockInfo {
+                number: 1,
+                hash: finalized_hash,
+                parent_hash: genesis_hash,
+                timestamp: 1,
+            },
+            l1_origin: canonical_parent_origin,
+            seq_num: 0,
+        };
+        let unsafe_info = L2BlockInfo {
+            block_info: BlockInfo {
+                number: 2,
+                hash: unsafe_hash,
+                parent_hash: finalized_hash,
+                timestamp: 2,
+            },
+            l1_origin: orphan_origin,
+            seq_num: 0,
+        };
+
+        let mut canonical_parent_l1 = RpcBlock::<EthTransaction>::default();
+        canonical_parent_l1.header.hash = canonical_parent_origin.hash;
+        canonical_parent_l1.header.inner.number = canonical_parent_origin.number;
+        let mut canonical_l1 = RpcBlock::<EthTransaction>::default();
+        canonical_l1.header.hash = canonical_origin_hash;
+        canonical_l1.header.inner.number = orphan_origin.number;
+        let mut orphan_l1 = RpcBlock::<EthTransaction>::default();
+        orphan_l1.header.hash = orphan_origin.hash;
+        orphan_l1.header.inner.number = orphan_origin.number;
+
+        let client = Arc::new(
+            test_engine_client_builder()
+                .with_config(Arc::clone(&cfg))
+                .with_l2_block(BlockNumberOrTag::Finalized.into(), finalized.clone())
+                .with_l2_block(BlockNumberOrTag::Safe.into(), finalized.clone())
+                .with_l2_block(BlockNumberOrTag::Latest.into(), unsafe_head)
+                .with_l2_block(finalized_hash.into(), finalized)
+                .with_l1_block(canonical_parent_origin.number.into(), canonical_parent_l1)
+                .with_l1_block(orphan_origin.number.into(), canonical_l1)
+                .with_l1_block(orphan_origin.hash.into(), orphan_l1)
+                .with_fork_choice_updated_v3_response(valid_fcu())
+                .build(),
+        );
+        assert!(
+            client
+                .get_l1_block(orphan_origin.hash.into())
+                .await
+                .expect("orphan lookup should succeed")
+                .is_some(),
+            "test precondition failed: orphan must remain retrievable by hash"
+        );
+
+        let mut mock_derivation = MockEngineDerivationClient::new();
+        mock_derivation.expect_send_signal().times(1).returning(|_| Ok(()));
+        mock_derivation.expect_send_new_engine_safe_head().times(1).returning(|_| Ok(()));
+        mock_derivation.expect_notify_sync_completed().times(1).returning(|_| Ok(()));
+
+        let initial_state = TestEngineStateBuilder::new()
+            .with_unsafe_head(unsafe_info)
+            .with_safe_head(finalized_info)
+            .with_finalized_head(finalized_info)
+            .with_el_sync_finished(true)
+            .build();
+        let (state_tx, state_rx) = watch::channel(initial_state);
+        let (queue_tx, _) = watch::channel(0usize);
+        let engine = Engine::new(initial_state, state_tx, queue_tx);
+        let processor =
+            EngineProcessor::new(Arc::clone(&client), Arc::clone(&cfg), mock_derivation, engine);
+        let (request_tx, request_rx) = mpsc::channel(1);
+        let handle = ValidatorEngineRequestHandler::new(processor).start(request_rx);
+
+        let (result_tx, mut result_rx) = mpsc::channel(1);
+        request_tx
+            .send(EngineActorRequest::ResetRequest(Box::new(ResetRequest {
+                result_tx,
+                origin: crate::ResetOrigin::Derivation,
+            })))
+            .await
+            .expect("failed to send reset request");
+        tokio::time::timeout(std::time::Duration::from_secs(5), result_rx.recv())
+            .await
+            .expect("timed out waiting for reset response")
+            .expect("reset response channel closed")
+            .expect("reset should succeed");
+
+        let state = *state_rx.borrow();
+        assert_eq!(state.sync_state.unsafe_head(), finalized_info);
+        assert_eq!(state.sync_state.safe_head(), finalized_info);
+        assert_eq!(state.sync_state.finalized_head(), finalized_info);
+
+        let storage = client.storage();
+        let storage = storage.read().await;
+        assert_eq!(storage.fork_choice_updated_v3_requests.len(), 1);
+        let reset_forkchoice = storage.fork_choice_updated_v3_requests[0].0;
+        assert_eq!(reset_forkchoice.head_block_hash, finalized_hash);
+        assert_eq!(reset_forkchoice.safe_block_hash, finalized_hash);
+        assert_eq!(reset_forkchoice.finalized_block_hash, finalized_hash);
+        drop(storage);
+
+        drop(request_tx);
+        let result = handle.await.expect("engine handler panicked");
+        assert!(matches!(result, Err(crate::EngineError::ChannelClosed)));
     }
 
     /// Regression test: when a `Build` request fails with an `InvalidPayload` (the EL rejects

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -1043,6 +1043,7 @@ mod tests {
             .send(EngineActorRequest::ResetRequest(Box::new(ResetRequest {
                 result_tx,
                 origin: crate::ResetOrigin::Derivation,
+                reason: crate::ResetReason::DerivationPipeline,
             })))
             .await
             .expect("failed to send reset request");
@@ -1276,6 +1277,7 @@ mod tests {
             .send(EngineActorRequest::ResetRequest(Box::new(ResetRequest {
                 result_tx,
                 origin: crate::ResetOrigin::Derivation,
+                reason: crate::ResetReason::DerivationPipeline,
             })))
             .await
             .expect("failed to send reset during private build");
@@ -1812,6 +1814,7 @@ mod tests {
             .send(EngineActorRequest::ResetRequest(Box::new(ResetRequest {
                 result_tx,
                 origin: crate::ResetOrigin::Derivation,
+                reason: crate::ResetReason::DerivationPipeline,
             })))
             .await
             .expect("failed to send reset request");

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -1730,6 +1730,7 @@ mod tests {
                 system_config: Some(SystemConfig::default()),
                 ..Default::default()
             },
+            seq_window_size: 1,
             ..Default::default()
         });
 

--- a/crates/consensus/service/src/actors/engine/mod.rs
+++ b/crates/consensus/service/src/actors/engine/mod.rs
@@ -16,7 +16,7 @@ mod request;
 pub use request::{
     BuildRequest, EngineActorRequest, EngineClientError, EngineClientResult, EngineRpcRequest,
     GetPayloadRequest, InsertUnsafePayloadRequest, ReconcileShadowRequest, ResetOrigin,
-    ResetRequest,
+    ResetReason, ResetRequest, ResetRequestOutcome,
 };
 
 mod engine_request_processor;

--- a/crates/consensus/service/src/actors/engine/request.rs
+++ b/crates/consensus/service/src/actors/engine/request.rs
@@ -121,6 +121,8 @@ pub struct ResetRequest {
     pub result_tx: mpsc::Sender<EngineClientResult<()>>,
     /// The subsystem and coordination path that requested the reset.
     pub origin: ResetOrigin,
+    /// The condition that caused the reset request.
+    pub reason: ResetReason,
 }
 
 /// Identifies the state owner coordinating an engine reset.
@@ -132,6 +134,90 @@ pub enum ResetOrigin {
     Sequencer,
     /// The shadow sequencer coordinated initial activation or its private-cycle reset.
     ShadowCycleCoordinated,
+}
+
+impl ResetOrigin {
+    /// Returns the bounded metrics label for this reset origin.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Derivation => "derivation",
+            Self::Sequencer => "sequencer",
+            Self::ShadowCycleCoordinated => "shadow_cycle_coordinated",
+        }
+    }
+}
+
+/// Identifies the condition that caused an engine reset request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResetReason {
+    /// The derivation pipeline encountered a generic reset condition.
+    DerivationPipeline,
+    /// Derivation detected an L1 reorganization.
+    DerivationL1Reorg,
+    /// The accepted L1 origin could not be fetched.
+    L1OriginUnavailable,
+    /// The canonical L1 successor does not extend the accepted origin.
+    L1OriginOrphaned,
+    /// The selected L1 origin is inconsistent with the unsafe L2 head.
+    L1OriginInconsistent,
+    /// The sequencer is performing its initial engine reset.
+    SequencerStartup,
+    /// An administrator explicitly requested a reset.
+    Admin,
+    /// A shadow sequencer is beginning a new private production cycle.
+    ShadowCycle,
+}
+
+impl ResetReason {
+    /// Returns the bounded metrics label for this reset reason.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::DerivationPipeline => "derivation_pipeline",
+            Self::DerivationL1Reorg => "derivation_l1_reorg",
+            Self::L1OriginUnavailable => "l1_origin_unavailable",
+            Self::L1OriginOrphaned => "l1_origin_orphaned",
+            Self::L1OriginInconsistent => "l1_origin_inconsistent",
+            Self::SequencerStartup => "sequencer_startup",
+            Self::Admin => "admin",
+            Self::ShadowCycle => "shadow_cycle",
+        }
+    }
+}
+
+/// Terminal outcome of a logical engine reset request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResetRequestOutcome {
+    /// The reset completed without changing the unsafe L2 head.
+    Unchanged,
+    /// The reset changed the unsafe L2 head.
+    Rewound,
+    /// The reset was deferred until engine synchronization completes.
+    Deferred,
+    /// The reset failed.
+    Failed,
+}
+
+impl ResetRequestOutcome {
+    /// Classifies a successful reset from its unsafe heads before and after processing.
+    pub fn from_unsafe_heads(before: L2BlockInfo, after: L2BlockInfo) -> Self {
+        if before.block_info.number == after.block_info.number
+            && before.block_info.hash == after.block_info.hash
+        {
+            Self::Unchanged
+        } else {
+            Self::Rewound
+        }
+    }
+
+    /// Returns the bounded metrics label for this reset outcome.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Unchanged => "unchanged",
+            Self::Rewound => "rewound",
+            Self::Deferred => "deferred",
+            Self::Failed => "failed",
+        }
+    }
 }
 
 /// A request to insert a local unsafe payload.

--- a/crates/consensus/service/src/actors/engine/request.rs
+++ b/crates/consensus/service/src/actors/engine/request.rs
@@ -184,7 +184,7 @@ impl ResetReason {
     }
 }
 
-/// Terminal outcome of a logical engine reset request.
+/// Outcome of one engine reset request handling attempt.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResetRequestOutcome {
     /// The reset completed without changing the unsafe L2 head.
@@ -193,7 +193,9 @@ pub enum ResetRequestOutcome {
     Rewound,
     /// The reset was deferred until engine synchronization completes.
     Deferred,
-    /// The reset failed.
+    /// The engine reset completed, but derivation could not be notified.
+    DerivationNotificationFailed,
+    /// The engine reset did not complete.
     Failed,
 }
 
@@ -215,6 +217,7 @@ impl ResetRequestOutcome {
             Self::Unchanged => "unchanged",
             Self::Rewound => "rewound",
             Self::Deferred => "deferred",
+            Self::DerivationNotificationFailed => "derivation_notification_failed",
             Self::Failed => "failed",
         }
     }

--- a/crates/consensus/service/src/actors/engine/validator_engine_request_handler.rs
+++ b/crates/consensus/service/src/actors/engine/validator_engine_request_handler.rs
@@ -195,7 +195,7 @@ where
                                         unsafe_after,
                                     )
                                 } else {
-                                    ResetRequestOutcome::Failed
+                                    ResetRequestOutcome::DerivationNotificationFailed
                                 };
                                 Metrics::record_engine_reset(
                                     origin,

--- a/crates/consensus/service/src/actors/engine/validator_engine_request_handler.rs
+++ b/crates/consensus/service/src/actors/engine/validator_engine_request_handler.rs
@@ -1,6 +1,6 @@
 //! Validator engine request routing.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Instant};
 
 use alloy_eips::BlockNumberOrTag;
 use base_consensus_engine::{
@@ -13,8 +13,8 @@ use tracing::{error, warn};
 
 use crate::{
     BuildRequest, EngineActorRequest, EngineClientError, EngineDerivationClient, EngineError,
-    EngineProcessor, EngineRequestReceiver, GetPayloadRequest, InsertUnsafePayloadRequest,
-    ReconcileShadowRequest, ResetRequest,
+    EngineProcessor, EngineRequestReceiver, GetPayloadRequest, InsertUnsafePayloadRequest, Metrics,
+    ReconcileShadowRequest, ResetRequest, ResetRequestOutcome,
 };
 
 /// Receives validator engine requests without carrying sequencer configuration.
@@ -158,9 +158,19 @@ where
                         }
                     }
                     EngineActorRequest::ResetRequest(request) => {
-                        let ResetRequest { result_tx, .. } = *request;
+                        let reset_started = Instant::now();
+                        let ResetRequest { result_tx, origin, reason } = *request;
+                        let unsafe_before = self.processor.engine_state().sync_state.unsafe_head();
                         if !self.processor.engine_state().el_sync_finished {
                             warn!(target: "engine", "Deferring engine reset: EL sync not yet complete");
+                            Metrics::record_engine_reset(
+                                origin,
+                                reason,
+                                ResetRequestOutcome::Deferred,
+                                reset_started.elapsed(),
+                                unsafe_before,
+                                self.processor.engine_state().sync_state.unsafe_head(),
+                            );
                             if result_tx.send(Err(EngineClientError::ELSyncing)).await.is_err() {
                                 warn!(target: "engine", "Sending ELSyncing response failed");
                             }
@@ -177,11 +187,37 @@ where
                                     .map_err(|error| {
                                         EngineClientError::ResetForkchoiceError(error.to_string())
                                     });
+                                let unsafe_after =
+                                    self.processor.engine_state().sync_state.unsafe_head();
+                                let outcome = if response.is_ok() {
+                                    ResetRequestOutcome::from_unsafe_heads(
+                                        unsafe_before,
+                                        unsafe_after,
+                                    )
+                                } else {
+                                    ResetRequestOutcome::Failed
+                                };
+                                Metrics::record_engine_reset(
+                                    origin,
+                                    reason,
+                                    outcome,
+                                    reset_started.elapsed(),
+                                    unsafe_before,
+                                    unsafe_after,
+                                );
                                 if result_tx.send(response).await.is_err() {
                                     warn!(target: "engine", "Sending reset response failed");
                                 }
                             }
                             Err(error) => {
+                                Metrics::record_engine_reset(
+                                    origin,
+                                    reason,
+                                    ResetRequestOutcome::Failed,
+                                    reset_started.elapsed(),
+                                    unsafe_before,
+                                    self.processor.engine_state().sync_state.unsafe_head(),
+                                );
                                 let response =
                                     Err(EngineClientError::ResetForkchoiceError(error.to_string()));
                                 if result_tx.send(response).await.is_err() {

--- a/crates/consensus/service/src/actors/mod.rs
+++ b/crates/consensus/service/src/actors/mod.rs
@@ -62,11 +62,12 @@ pub use sequencer::{
     BuildOutcome, BuildPipelineState, CanonicalReconciliationInputs, CanonicalUnsafeCatchup,
     Conductor, ConductorClient, ConductorError, DelayedL1OriginSelectorProvider, L1OriginSelector,
     L1OriginSelectorError, L1OriginSelectorProvider, OriginSelector, PayloadBuilder, PayloadSealer,
-    PendingStopSender, PoolActivation, QueuedSequencerEngineClient, RecoveryModeGuard,
-    ScheduledTicker, SealState, SealStepError, SealStepOutcome, SequencerActor,
-    SequencerActorError, SequencerAdminQuery, SequencerConfig, SequencerEngineClient,
-    SequencerEngineRequestCoordinator, SequencerEngineState, ShadowCycle, ShadowReconciliationGate,
-    ShadowReconciliationTask, ShadowSequencingState, UnsealedPayloadHandle,
+    PendingStopSender, PoolActivation, PrefetchedChainProvider, PrefetchedChainProviderError,
+    PreparedL1Origin, QueuedSequencerEngineClient, RecoveryModeGuard, ScheduledTicker, SealState,
+    SealStepError, SealStepOutcome, SequencerActor, SequencerActorError, SequencerAdminQuery,
+    SequencerConfig, SequencerEngineClient, SequencerEngineRequestCoordinator,
+    SequencerEngineState, ShadowCycle, ShadowReconciliationGate, ShadowReconciliationTask,
+    ShadowSequencingState, UnsealedPayloadHandle,
 };
 #[cfg(test)]
 pub use sequencer::{MockConductor, MockOriginSelector, MockSequencerEngineClient};

--- a/crates/consensus/service/src/actors/mod.rs
+++ b/crates/consensus/service/src/actors/mod.rs
@@ -18,8 +18,8 @@ pub use engine::{
     BuildRequest, EngineActor, EngineActorRequest, EngineClientError, EngineClientResult,
     EngineConfig, EngineDerivationClient, EngineError, EngineProcessor, EngineRequestReceiver,
     EngineRpcProcessor, EngineRpcRequest, GetPayloadRequest, InsertUnsafePayloadRequest,
-    QueuedEngineDerivationClient, ReconcileShadowRequest, ResetOrigin, ResetOutcome, ResetRequest,
-    ValidatorEngineRequestHandler,
+    QueuedEngineDerivationClient, ReconcileShadowRequest, ResetOrigin, ResetOutcome, ResetReason,
+    ResetRequest, ResetRequestOutcome, ValidatorEngineRequestHandler,
 };
 
 mod rpc;

--- a/crates/consensus/service/src/actors/sequencer/actor.rs
+++ b/crates/consensus/service/src/actors/sequencer/actor.rs
@@ -491,12 +491,7 @@ where
                 build_ticker.reset_l1_origin_retry_budget();
                 pipeline.next_payload_to_seal = Some(payload);
             }
-            BuildOutcome::Deferred => {
-                build_ticker.reset_l1_origin_retry_budget();
-                pipeline.next_payload_to_seal = None;
-                build_ticker.reset_immediately();
-            }
-            BuildOutcome::AwaitingL1Origin => {
+            BuildOutcome::Deferred | BuildOutcome::AwaitingL1Origin => {
                 pipeline.next_payload_to_seal = None;
                 build_ticker.schedule_l1_origin_retry();
             }
@@ -518,12 +513,7 @@ where
                 pipeline.next_payload_to_seal = Some(payload);
                 build_ticker.schedule_after_build(Some(target));
             }
-            BuildOutcome::Deferred => {
-                build_ticker.reset_l1_origin_retry_budget();
-                pipeline.next_payload_to_seal = None;
-                build_ticker.schedule_after_build(None);
-            }
-            BuildOutcome::AwaitingL1Origin => {
+            BuildOutcome::Deferred | BuildOutcome::AwaitingL1Origin => {
                 pipeline.next_payload_to_seal = None;
                 build_ticker.schedule_l1_origin_retry();
             }

--- a/crates/consensus/service/src/actors/sequencer/actor.rs
+++ b/crates/consensus/service/src/actors/sequencer/actor.rs
@@ -21,7 +21,8 @@ use tokio::{
 use tokio_util::sync::{CancellationToken, WaitForCancellationFuture};
 
 use crate::{
-    CancellableContext, Metrics, NodeActor, SequencerAdminQuery, UnsafePayloadGossipClient,
+    CancellableContext, Metrics, NodeActor, ResetReason, SequencerAdminQuery,
+    UnsafePayloadGossipClient,
     actors::{
         SequencerEngineClient,
         engine::{EngineClientError, EngineClientResult},
@@ -225,9 +226,13 @@ where
                 }
                 result = async {
                     if shadow_cycle_coordinated {
-                        engine_client.reset_engine_forkchoice_coordinated().await
+                        engine_client
+                            .reset_engine_forkchoice_coordinated(ResetReason::ShadowCycle)
+                            .await
                     } else {
-                        engine_client.reset_engine_forkchoice().await
+                        engine_client
+                            .reset_engine_forkchoice(ResetReason::SequencerStartup)
+                            .await
                     }
                 } => match result {
                     Ok(()) => return Ok(()),

--- a/crates/consensus/service/src/actors/sequencer/admin_api_impl.rs
+++ b/crates/consensus/service/src/actors/sequencer/admin_api_impl.rs
@@ -4,7 +4,10 @@ use base_consensus_rpc::SequencerAdminAPIError;
 use tokio::sync::oneshot;
 
 use super::{SequencerActor, build::UnsealedPayloadHandle};
-use crate::{Conductor, Metrics, OriginSelector, SequencerEngineClient, UnsafePayloadGossipClient};
+use crate::{
+    Conductor, Metrics, OriginSelector, ResetReason, SequencerEngineClient,
+    UnsafePayloadGossipClient,
+};
 
 /// The query types to the sequencer actor for the admin api.
 #[derive(Debug)]
@@ -258,9 +261,9 @@ where
     pub(super) async fn reset_derivation_pipeline(&self) -> Result<(), SequencerAdminAPIError> {
         info!(target: "sequencer", "Resetting derivation pipeline");
         let result = if self.is_shadow_sequencer() {
-            self.engine_client.reset_engine_forkchoice_coordinated().await
+            self.engine_client.reset_engine_forkchoice_coordinated(ResetReason::Admin).await
         } else {
-            self.engine_client.reset_engine_forkchoice().await
+            self.engine_client.reset_engine_forkchoice(ResetReason::Admin).await
         };
         result.map_err(|e| {
             error!(target: "sequencer", err=?e, "Failed to reset engine forkchoice");

--- a/crates/consensus/service/src/actors/sequencer/build.rs
+++ b/crates/consensus/service/src/actors/sequencer/build.rs
@@ -146,6 +146,15 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
                 self.engine_client.reset_engine_forkchoice().await?;
                 return Ok(BuildOutcome::Deferred);
             }
+            Err(err @ L1OriginSelectorError::NextL1OriginOrphaned { .. }) => {
+                warn!(
+                    target: "sequencer",
+                    ?err,
+                    "Next L1 origin orphaned the accepted current origin, triggering engine reset"
+                );
+                self.engine_client.reset_engine_forkchoice().await?;
+                return Ok(BuildOutcome::Deferred);
+            }
             Err(err @ L1OriginSelectorError::NotEnoughData(_)) => {
                 warn!(
                     target: "sequencer",

--- a/crates/consensus/service/src/actors/sequencer/build.rs
+++ b/crates/consensus/service/src/actors/sequencer/build.rs
@@ -131,11 +131,7 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
         &mut self,
         unsafe_head: L2BlockInfo,
     ) -> Result<BuildOutcome<BlockInfo>, SequencerActorError> {
-        let l1_origin = match self
-            .origin_selector
-            .next_l1_origin(unsafe_head, self.recovery_mode.get())
-            .await
-        {
+        let l1_origin = match self.origin_selector.next_l1_origin(unsafe_head).await {
             Ok(l1_origin) => l1_origin,
             Err(L1OriginSelectorError::OriginNotFound(hash)) => {
                 warn!(

--- a/crates/consensus/service/src/actors/sequencer/build.rs
+++ b/crates/consensus/service/src/actors/sequencer/build.rs
@@ -14,7 +14,7 @@ use base_protocol::{AttributesWithParent, BlockInfo, L2BlockInfo};
 use tracing::instrument;
 
 use crate::{
-    Metrics, PoolActivation,
+    Metrics, PoolActivation, ResetReason,
     actors::{
         SequencerEngineClient,
         sequencer::{
@@ -143,7 +143,9 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
                     hash = %hash,
                     "L1 origin block not found (reorg or sync lag), triggering engine reset"
                 );
-                self.engine_client.reset_engine_forkchoice().await?;
+                self.engine_client
+                    .reset_engine_forkchoice(ResetReason::L1OriginUnavailable)
+                    .await?;
                 return Ok(BuildOutcome::Deferred);
             }
             Err(err @ L1OriginSelectorError::NextL1OriginOrphaned { .. }) => {
@@ -152,7 +154,7 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
                     ?err,
                     "Next L1 origin orphaned the accepted current origin, triggering engine reset"
                 );
-                self.engine_client.reset_engine_forkchoice().await?;
+                self.engine_client.reset_engine_forkchoice(ResetReason::L1OriginOrphaned).await?;
                 return Ok(BuildOutcome::Deferred);
             }
             Err(err @ L1OriginSelectorError::NotEnoughData(_)) => {
@@ -183,7 +185,7 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
                 unsafe_head_l1_origin = ?unsafe_head.l1_origin,
                 "Cannot build new L2 block on inconsistent L1 origin, resetting engine"
             );
-            self.engine_client.reset_engine_forkchoice().await?;
+            self.engine_client.reset_engine_forkchoice(ResetReason::L1OriginInconsistent).await?;
             return Ok(BuildOutcome::Deferred);
         }
 

--- a/crates/consensus/service/src/actors/sequencer/build.rs
+++ b/crates/consensus/service/src/actors/sequencer/build.rs
@@ -153,14 +153,11 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
                 self.engine_client.reset_engine_forkchoice(ResetReason::L1OriginOrphaned).await?;
                 return Ok(BuildOutcome::Deferred);
             }
-            Err(
-                err @ (L1OriginSelectorError::NotEnoughData(_)
-                | L1OriginSelectorError::ChainViewUnavailable),
-            ) => {
+            Err(err @ L1OriginSelectorError::NotEnoughData(_)) => {
                 warn!(
                     target: "sequencer",
                     ?err,
-                    "L1 state is not ready for origin selection; deferring block build"
+                    "Next L1 origin is not ready after sequencer drift; deferring block build"
                 );
                 return Ok(BuildOutcome::AwaitingL1Origin);
             }

--- a/crates/consensus/service/src/actors/sequencer/build.rs
+++ b/crates/consensus/service/src/actors/sequencer/build.rs
@@ -153,11 +153,14 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
                 self.engine_client.reset_engine_forkchoice(ResetReason::L1OriginOrphaned).await?;
                 return Ok(BuildOutcome::Deferred);
             }
-            Err(err @ L1OriginSelectorError::NotEnoughData(_)) => {
+            Err(
+                err @ (L1OriginSelectorError::NotEnoughData(_)
+                | L1OriginSelectorError::ChainViewUnavailable),
+            ) => {
                 warn!(
                     target: "sequencer",
                     ?err,
-                    "Next L1 origin is not ready after sequencer drift; deferring block build"
+                    "L1 state is not ready for origin selection; deferring block build"
                 );
                 return Ok(BuildOutcome::AwaitingL1Origin);
             }

--- a/crates/consensus/service/src/actors/sequencer/engine_client.rs
+++ b/crates/consensus/service/src/actors/sequencer/engine_client.rs
@@ -12,7 +12,7 @@ use crate::{
     EngineClientError, EngineClientResult,
     actors::engine::{
         BuildRequest, EngineActorRequest, GetPayloadRequest, InsertUnsafePayloadRequest,
-        ReconcileShadowRequest, ResetOrigin, ResetRequest,
+        ReconcileShadowRequest, ResetOrigin, ResetReason, ResetRequest,
     },
 };
 
@@ -23,14 +23,17 @@ use crate::{
 pub trait SequencerEngineClient: Debug + Send + Sync {
     /// Resets the engine's forkchoice, awaiting confirmation that it succeeded or returning the
     /// error in performing the reset.
-    async fn reset_engine_forkchoice(&self) -> EngineClientResult<()>;
+    async fn reset_engine_forkchoice(&self, reason: ResetReason) -> EngineClientResult<()>;
 
     /// Coordinates the engine boundary for a shadow cycle that the caller will explicitly rebuild.
     ///
     /// During initial catch-up, success activates shadow production after catch-up has already
     /// advanced the engine. Once shadow production is active, this performs an actual reset.
-    async fn reset_engine_forkchoice_coordinated(&self) -> EngineClientResult<()> {
-        self.reset_engine_forkchoice().await
+    async fn reset_engine_forkchoice_coordinated(
+        &self,
+        reason: ResetReason,
+    ) -> EngineClientResult<()> {
+        self.reset_engine_forkchoice(reason).await
     }
 
     /// Starts building a block with the provided attributes.
@@ -79,12 +82,15 @@ pub trait SequencerEngineClient: Debug + Send + Sync {
 /// methods without any additional wrapping.
 #[async_trait]
 impl<T: SequencerEngineClient> SequencerEngineClient for Arc<T> {
-    async fn reset_engine_forkchoice(&self) -> EngineClientResult<()> {
-        (**self).reset_engine_forkchoice().await
+    async fn reset_engine_forkchoice(&self, reason: ResetReason) -> EngineClientResult<()> {
+        (**self).reset_engine_forkchoice(reason).await
     }
 
-    async fn reset_engine_forkchoice_coordinated(&self) -> EngineClientResult<()> {
-        (**self).reset_engine_forkchoice_coordinated().await
+    async fn reset_engine_forkchoice_coordinated(
+        &self,
+        reason: ResetReason,
+    ) -> EngineClientResult<()> {
+        (**self).reset_engine_forkchoice_coordinated(reason).await
     }
 
     async fn start_build_block(
@@ -138,12 +144,16 @@ pub struct QueuedSequencerEngineClient {
 }
 
 impl QueuedSequencerEngineClient {
-    async fn send_reset(&self, origin: ResetOrigin) -> EngineClientResult<()> {
+    async fn send_reset(&self, origin: ResetOrigin, reason: ResetReason) -> EngineClientResult<()> {
         let (result_tx, mut result_rx) = mpsc::channel(1);
 
         info!(target: "sequencer", "Sending reset request to engine.");
         self.engine_actor_request_tx
-            .send(EngineActorRequest::ResetRequest(Box::new(ResetRequest { result_tx, origin })))
+            .send(EngineActorRequest::ResetRequest(Box::new(ResetRequest {
+                result_tx,
+                origin,
+                reason,
+            })))
             .await
             .map_err(|_| EngineClientError::RequestError("request channel closed.".to_string()))?;
 
@@ -185,12 +195,15 @@ impl SequencerEngineClient for QueuedSequencerEngineClient {
         })?
     }
 
-    async fn reset_engine_forkchoice(&self) -> EngineClientResult<()> {
-        self.send_reset(ResetOrigin::Sequencer).await
+    async fn reset_engine_forkchoice(&self, reason: ResetReason) -> EngineClientResult<()> {
+        self.send_reset(ResetOrigin::Sequencer, reason).await
     }
 
-    async fn reset_engine_forkchoice_coordinated(&self) -> EngineClientResult<()> {
-        self.send_reset(ResetOrigin::ShadowCycleCoordinated).await
+    async fn reset_engine_forkchoice_coordinated(
+        &self,
+        reason: ResetReason,
+    ) -> EngineClientResult<()> {
+        self.send_reset(ResetOrigin::ShadowCycleCoordinated, reason).await
     }
 
     async fn start_build_block(

--- a/crates/consensus/service/src/actors/sequencer/engine_request_coordinator.rs
+++ b/crates/consensus/service/src/actors/sequencer/engine_request_coordinator.rs
@@ -1,6 +1,6 @@
 //! Sequencer ownership and serialized routing of engine requests.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Instant};
 
 use alloy_eips::BlockNumberOrTag;
 use base_consensus_engine::{
@@ -17,8 +17,9 @@ use tracing::{debug, error, info, warn};
 use super::{CanonicalUnsafeCatchup, Conductor, SequencerEngineState, ShadowReconciliationGate};
 use crate::{
     BuildRequest, EngineActorRequest, EngineClientError, EngineDerivationClient, EngineError,
-    EngineProcessor, EngineRequestReceiver, GetPayloadRequest, InsertUnsafePayloadRequest,
-    ReconcileShadowRequest, ResetOrigin, ResetRequest, actors::engine::ResetOutcome,
+    EngineProcessor, EngineRequestReceiver, GetPayloadRequest, InsertUnsafePayloadRequest, Metrics,
+    ReconcileShadowRequest, ResetOrigin, ResetRequest, ResetRequestOutcome,
+    actors::engine::ResetOutcome,
 };
 
 const MAX_SEQUENCER_EXTERNAL_UNSAFE_GAP: u64 = 300;
@@ -456,9 +457,11 @@ where
                         }
                     }
                     EngineActorRequest::ResetRequest(reset_request) => {
-                        let ResetRequest { result_tx, origin } = *reset_request;
+                        let reset_started = Instant::now();
+                        let ResetRequest { result_tx, origin, reason } = *reset_request;
                         let sync_state = self.processor.engine_state().sync_state;
                         let head = sync_state.unsafe_head();
+                        let unsafe_before = head;
                         if origin != ResetOrigin::Derivation
                             && let SequencerEngineState::CatchingUp { shadow, catchup } =
                                 &self.sequencer_state
@@ -466,6 +469,14 @@ where
                             let shadow = *shadow;
                             if catchup.is_faulted() {
                                 error!(target: "engine", "Canonical catch-up payload buffer is faulted");
+                                Metrics::record_engine_reset(
+                                    origin,
+                                    reason,
+                                    ResetRequestOutcome::Failed,
+                                    reset_started.elapsed(),
+                                    unsafe_before,
+                                    self.processor.engine_state().sync_state.unsafe_head(),
+                                );
                                 if result_tx
                                     .send(Err(EngineClientError::ShadowBufferFaulted))
                                     .await
@@ -477,6 +488,14 @@ where
                             }
                             if !catchup.is_complete(head, sync_state.safe_head()) {
                                 warn!(target: "engine", "Deferring sequencer reset until canonical catch-up completes");
+                                Metrics::record_engine_reset(
+                                    origin,
+                                    reason,
+                                    ResetRequestOutcome::Deferred,
+                                    reset_started.elapsed(),
+                                    unsafe_before,
+                                    self.processor.engine_state().sync_state.unsafe_head(),
+                                );
                                 if result_tx.send(Err(EngineClientError::ELSyncing)).await.is_err()
                                 {
                                     warn!(target: "engine", "Sending ELSyncing response failed");
@@ -485,6 +504,14 @@ where
                             }
                             if shadow {
                                 if origin != ResetOrigin::ShadowCycleCoordinated {
+                                    Metrics::record_engine_reset(
+                                        origin,
+                                        reason,
+                                        ResetRequestOutcome::Failed,
+                                        reset_started.elapsed(),
+                                        unsafe_before,
+                                        self.processor.engine_state().sync_state.unsafe_head(),
+                                    );
                                     if result_tx
                                         .send(Err(EngineClientError::ShadowReconciliationDisabled))
                                         .await
@@ -507,6 +534,14 @@ where
                                     Box::new(ShadowReconciliationGate::new(head)),
                                 );
                                 self.unsafe_head_tx.send_replace(head);
+                                Metrics::record_engine_reset(
+                                    origin,
+                                    reason,
+                                    ResetRequestOutcome::from_unsafe_heads(unsafe_before, head),
+                                    reset_started.elapsed(),
+                                    unsafe_before,
+                                    head,
+                                );
                                 if result_tx.send(Ok(())).await.is_err() {
                                     warn!(target: "engine", "Sending shadow activation response failed");
                                 }
@@ -526,6 +561,14 @@ where
                         // aborting any in-progress snap sync. Defer until el_sync_finished=true.
                         if !self.processor.engine_state().el_sync_finished {
                             warn!(target: "engine", "Deferring engine reset: EL sync not yet complete");
+                            Metrics::record_engine_reset(
+                                origin,
+                                reason,
+                                ResetRequestOutcome::Deferred,
+                                reset_started.elapsed(),
+                                unsafe_before,
+                                self.processor.engine_state().sync_state.unsafe_head(),
+                            );
                             if result_tx.send(Err(EngineClientError::ELSyncing)).await.is_err() {
                                 warn!(target: "engine", "Sending ELSyncing response failed");
                             }
@@ -548,6 +591,14 @@ where
                             if let Err(error) =
                                 self.processor.notify_derivation_of_reset(*safe_head).await
                             {
+                                Metrics::record_engine_reset(
+                                    origin,
+                                    reason,
+                                    ResetRequestOutcome::Failed,
+                                    reset_started.elapsed(),
+                                    unsafe_before,
+                                    self.processor.engine_state().sync_state.unsafe_head(),
+                                );
                                 if result_tx
                                     .send(Err(EngineClientError::ResetForkchoiceError(
                                         error.to_string(),
@@ -563,6 +614,21 @@ where
                                 continue;
                             }
                         }
+
+                        let unsafe_after = self.processor.engine_state().sync_state.unsafe_head();
+                        let reset_outcome = if reset_res.is_ok() {
+                            ResetRequestOutcome::from_unsafe_heads(unsafe_before, unsafe_after)
+                        } else {
+                            ResetRequestOutcome::Failed
+                        };
+                        Metrics::record_engine_reset(
+                            origin,
+                            reason,
+                            reset_outcome,
+                            reset_started.elapsed(),
+                            unsafe_before,
+                            unsafe_after,
+                        );
 
                         // Send the result.
                         let response_payload = reset_res

--- a/crates/consensus/service/src/actors/sequencer/engine_request_coordinator.rs
+++ b/crates/consensus/service/src/actors/sequencer/engine_request_coordinator.rs
@@ -594,7 +594,7 @@ where
                                 Metrics::record_engine_reset(
                                     origin,
                                     reason,
-                                    ResetRequestOutcome::Failed,
+                                    ResetRequestOutcome::DerivationNotificationFailed,
                                     reset_started.elapsed(),
                                     unsafe_before,
                                     self.processor.engine_state().sync_state.unsafe_head(),

--- a/crates/consensus/service/src/actors/sequencer/l1_origin/mod.rs
+++ b/crates/consensus/service/src/actors/sequencer/l1_origin/mod.rs
@@ -1,5 +1,8 @@
 //! L1 origin selection and provider implementations for the sequencer.
 
+mod prepared;
+pub use prepared::PreparedL1Origin;
+
 mod provider;
 pub use provider::{DelayedL1OriginSelectorProvider, L1OriginSelectorProvider};
 
@@ -7,3 +10,6 @@ mod selector;
 #[cfg(test)]
 pub use selector::MockOriginSelector;
 pub use selector::{L1OriginSelector, L1OriginSelectorError, OriginSelector};
+
+mod prefetched_chain_provider;
+pub use prefetched_chain_provider::{PrefetchedChainProvider, PrefetchedChainProviderError};

--- a/crates/consensus/service/src/actors/sequencer/l1_origin/prefetched_chain_provider.rs
+++ b/crates/consensus/service/src/actors/sequencer/l1_origin/prefetched_chain_provider.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use alloy_consensus::{Header, Receipt, TxEnvelope};
 use alloy_primitives::B256;
 use async_trait::async_trait;
-use base_consensus_derive::{ChainProvider, PipelineError, PipelineErrorKind};
+use base_consensus_derive::{ChainProvider, PipelineErrorKind};
 use base_consensus_providers::{AlloyChainProvider, AlloyChainProviderError};
 use base_protocol::BlockInfo;
 use tokio::sync::watch;
@@ -62,23 +62,13 @@ impl ChainProvider for PrefetchedChainProvider {
             .borrow()
             .as_ref()
             .filter(|origin| origin.hash == hash)
-            .map(|origin| Arc::clone(&origin.receipts));
+            .and_then(|origin| origin.receipts.as_ref().map(Arc::clone));
         if let Some(receipts) = receipts {
             Metrics::sequencer_l1_origin_buffer_hits_total("receipts").increment(1);
             return Ok((*receipts).clone());
         }
         Metrics::sequencer_l1_origin_buffer_misses_total("receipts").increment(1);
-        match self
-            .fallback
-            .receipts_by_hash(hash)
-            .await
-            .map_err(PrefetchedChainProviderError::Fallback)
-        {
-            Err(PrefetchedChainProviderError::Fallback(
-                AlloyChainProviderError::BlockNotFound(_),
-            )) => Err(PrefetchedChainProviderError::ReceiptsUnavailable(hash)),
-            result => result,
-        }
+        self.fallback.receipts_by_hash(hash).await.map_err(PrefetchedChainProviderError::Fallback)
     }
 
     async fn block_info_and_transactions_by_hash(
@@ -98,18 +88,12 @@ pub enum PrefetchedChainProviderError {
     /// The RPC fallback failed.
     #[error(transparent)]
     Fallback(#[from] AlloyChainProviderError),
-    /// The requested block exists but its receipts are not available yet.
-    #[error("receipts unavailable for L1 origin: {0}")]
-    ReceiptsUnavailable(B256),
 }
 
 impl From<PrefetchedChainProviderError> for PipelineErrorKind {
     fn from(error: PrefetchedChainProviderError) -> Self {
         match error {
             PrefetchedChainProviderError::Fallback(error) => error.into(),
-            PrefetchedChainProviderError::ReceiptsUnavailable(hash) => Self::Temporary(
-                PipelineError::Provider(format!("L1 origin receipts unavailable: {hash}")),
-            ),
         }
     }
 }
@@ -117,14 +101,12 @@ impl From<PrefetchedChainProviderError> for PipelineErrorKind {
 #[cfg(test)]
 mod tests {
     use alloy_provider::RootProvider;
+    use httpmock::prelude::*;
 
     use super::*;
 
-    fn fallback() -> AlloyChainProvider {
-        AlloyChainProvider::new(
-            RootProvider::new_http("http://localhost:1".parse().expect("valid URL")),
-            1,
-        )
+    fn fallback(url: &str) -> AlloyChainProvider {
+        AlloyChainProvider::new(RootProvider::new_http(url.parse().expect("valid URL")), 1)
     }
 
     #[tokio::test]
@@ -135,19 +117,60 @@ mod tests {
         let (_tx, rx) = watch::channel(Some(PreparedL1Origin {
             hash,
             header: header.clone(),
-            receipts: Arc::clone(&receipts),
+            receipts: Some(Arc::clone(&receipts)),
         }));
-        let mut provider = PrefetchedChainProvider::new(rx, fallback());
+        let mut provider = PrefetchedChainProvider::new(rx, fallback("http://localhost:1"));
 
         assert_eq!(provider.header_by_hash(hash).await.unwrap(), header);
         assert_eq!(provider.receipts_by_hash(hash).await.unwrap(), *receipts);
     }
 
-    #[test]
-    fn test_missing_fallback_receipts_are_temporary() {
-        let kind: PipelineErrorKind =
-            PrefetchedChainProviderError::ReceiptsUnavailable(B256::ZERO).into();
+    #[tokio::test]
+    async fn test_origin_without_receipts_uses_fallback() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/")
+                    .json_body_includes(r#"{"method":"eth_getBlockReceipts"}"#);
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .body(r#"{"jsonrpc":"2.0","id":0,"result":[]}"#);
+            })
+            .await;
+        let header = Header::default();
+        let hash = header.hash_slow();
+        let (_tx, rx) = watch::channel(Some(PreparedL1Origin { hash, header, receipts: None }));
+        let mut provider = PrefetchedChainProvider::new(rx, fallback(&server.url("/")));
 
-        assert!(matches!(kind, PipelineErrorKind::Temporary(_)));
+        assert!(provider.receipts_by_hash(hash).await.unwrap().is_empty());
+        mock.assert_calls_async(1).await;
+    }
+
+    #[tokio::test]
+    async fn test_missing_fallback_receipts_remain_block_not_found() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/")
+                    .json_body_includes(r#"{"method":"eth_getBlockReceipts"}"#);
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .body(r#"{"jsonrpc":"2.0","id":0,"result":null}"#);
+            })
+            .await;
+        let (_tx, rx) = watch::channel(None);
+        let mut provider = PrefetchedChainProvider::new(rx, fallback(&server.url("/")));
+
+        let error = provider.receipts_by_hash(B256::ZERO).await.unwrap_err();
+        assert!(matches!(
+            &error,
+            PrefetchedChainProviderError::Fallback(AlloyChainProviderError::BlockNotFound(_))
+        ));
+        let kind: PipelineErrorKind = error.into();
+
+        assert!(matches!(kind, PipelineErrorKind::Reset(_)));
+        mock.assert_calls_async(1).await;
     }
 }

--- a/crates/consensus/service/src/actors/sequencer/l1_origin/prefetched_chain_provider.rs
+++ b/crates/consensus/service/src/actors/sequencer/l1_origin/prefetched_chain_provider.rs
@@ -1,0 +1,153 @@
+//! Watch-backed chain provider for prefetched sequencer origins.
+
+use std::sync::Arc;
+
+use alloy_consensus::{Header, Receipt, TxEnvelope};
+use alloy_primitives::B256;
+use async_trait::async_trait;
+use base_consensus_derive::{ChainProvider, PipelineError, PipelineErrorKind};
+use base_consensus_providers::{AlloyChainProvider, AlloyChainProviderError};
+use base_protocol::BlockInfo;
+use tokio::sync::watch;
+
+use super::PreparedL1Origin;
+use crate::Metrics;
+
+/// Serves matching header and receipt requests from the selected prepared origin.
+#[derive(Debug)]
+pub struct PrefetchedChainProvider {
+    origin: watch::Receiver<Option<PreparedL1Origin>>,
+    fallback: AlloyChainProvider,
+}
+
+impl PrefetchedChainProvider {
+    /// Creates a provider with an RPC fallback.
+    pub const fn new(
+        origin: watch::Receiver<Option<PreparedL1Origin>>,
+        fallback: AlloyChainProvider,
+    ) -> Self {
+        Self { origin, fallback }
+    }
+}
+
+#[async_trait]
+impl ChainProvider for PrefetchedChainProvider {
+    type Error = PrefetchedChainProviderError;
+
+    async fn header_by_hash(&mut self, hash: B256) -> Result<Header, Self::Error> {
+        let header = self
+            .origin
+            .borrow()
+            .as_ref()
+            .filter(|origin| origin.hash == hash)
+            .map(|origin| origin.header.clone());
+        if let Some(header) = header {
+            Metrics::sequencer_l1_origin_buffer_hits_total("header").increment(1);
+            return Ok(header);
+        }
+        Metrics::sequencer_l1_origin_buffer_misses_total("header").increment(1);
+        self.fallback.header_by_hash(hash).await.map_err(PrefetchedChainProviderError::Fallback)
+    }
+
+    async fn block_info_by_number(&mut self, number: u64) -> Result<BlockInfo, Self::Error> {
+        self.fallback
+            .block_info_by_number(number)
+            .await
+            .map_err(PrefetchedChainProviderError::Fallback)
+    }
+
+    async fn receipts_by_hash(&mut self, hash: B256) -> Result<Vec<Receipt>, Self::Error> {
+        let receipts = self
+            .origin
+            .borrow()
+            .as_ref()
+            .filter(|origin| origin.hash == hash)
+            .map(|origin| Arc::clone(&origin.receipts));
+        if let Some(receipts) = receipts {
+            Metrics::sequencer_l1_origin_buffer_hits_total("receipts").increment(1);
+            return Ok((*receipts).clone());
+        }
+        Metrics::sequencer_l1_origin_buffer_misses_total("receipts").increment(1);
+        match self
+            .fallback
+            .receipts_by_hash(hash)
+            .await
+            .map_err(PrefetchedChainProviderError::Fallback)
+        {
+            Err(PrefetchedChainProviderError::Fallback(
+                AlloyChainProviderError::BlockNotFound(_),
+            )) => Err(PrefetchedChainProviderError::ReceiptsUnavailable(hash)),
+            result => result,
+        }
+    }
+
+    async fn block_info_and_transactions_by_hash(
+        &mut self,
+        hash: B256,
+    ) -> Result<(BlockInfo, Vec<TxEnvelope>), Self::Error> {
+        self.fallback
+            .block_info_and_transactions_by_hash(hash)
+            .await
+            .map_err(PrefetchedChainProviderError::Fallback)
+    }
+}
+
+/// Error returned by [`PrefetchedChainProvider`].
+#[derive(Debug, thiserror::Error)]
+pub enum PrefetchedChainProviderError {
+    /// The RPC fallback failed.
+    #[error(transparent)]
+    Fallback(#[from] AlloyChainProviderError),
+    /// The requested block exists but its receipts are not available yet.
+    #[error("receipts unavailable for L1 origin: {0}")]
+    ReceiptsUnavailable(B256),
+}
+
+impl From<PrefetchedChainProviderError> for PipelineErrorKind {
+    fn from(error: PrefetchedChainProviderError) -> Self {
+        match error {
+            PrefetchedChainProviderError::Fallback(error) => error.into(),
+            PrefetchedChainProviderError::ReceiptsUnavailable(hash) => Self::Temporary(
+                PipelineError::Provider(format!("L1 origin receipts unavailable: {hash}")),
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_provider::RootProvider;
+
+    use super::*;
+
+    fn fallback() -> AlloyChainProvider {
+        AlloyChainProvider::new(
+            RootProvider::new_http("http://localhost:1".parse().expect("valid URL")),
+            1,
+        )
+    }
+
+    #[tokio::test]
+    async fn test_matching_origin_serves_header_and_receipts() {
+        let header = Header { number: 7, timestamp: 84, ..Default::default() };
+        let hash = header.hash_slow();
+        let receipts = Arc::new(vec![Receipt::default()]);
+        let (_tx, rx) = watch::channel(Some(PreparedL1Origin {
+            hash,
+            header: header.clone(),
+            receipts: Arc::clone(&receipts),
+        }));
+        let mut provider = PrefetchedChainProvider::new(rx, fallback());
+
+        assert_eq!(provider.header_by_hash(hash).await.unwrap(), header);
+        assert_eq!(provider.receipts_by_hash(hash).await.unwrap(), *receipts);
+    }
+
+    #[test]
+    fn test_missing_fallback_receipts_are_temporary() {
+        let kind: PipelineErrorKind =
+            PrefetchedChainProviderError::ReceiptsUnavailable(B256::ZERO).into();
+
+        assert!(matches!(kind, PipelineErrorKind::Temporary(_)));
+    }
+}

--- a/crates/consensus/service/src/actors/sequencer/l1_origin/prefetched_chain_provider.rs
+++ b/crates/consensus/service/src/actors/sequencer/l1_origin/prefetched_chain_provider.rs
@@ -14,6 +14,9 @@ use super::PreparedL1Origin;
 use crate::Metrics;
 
 /// Serves matching header and receipt requests from the selected prepared origin.
+///
+/// Requests that do not match the buffered origin fall back to L1 RPC. This preserves cold-start,
+/// stale-buffer, and missing-receipts behavior without making RPC the normal block-building path.
 #[derive(Debug)]
 pub struct PrefetchedChainProvider {
     origin: watch::Receiver<Option<PreparedL1Origin>>,
@@ -21,7 +24,7 @@ pub struct PrefetchedChainProvider {
 }
 
 impl PrefetchedChainProvider {
-    /// Creates a provider with an RPC fallback.
+    /// Creates a provider with an RPC fallback for requests the buffered origin cannot serve.
     pub const fn new(
         origin: watch::Receiver<Option<PreparedL1Origin>>,
         fallback: AlloyChainProvider,

--- a/crates/consensus/service/src/actors/sequencer/l1_origin/prepared.rs
+++ b/crates/consensus/service/src/actors/sequencer/l1_origin/prepared.rs
@@ -6,10 +6,13 @@ use alloy_consensus::{Header, Receipt};
 use alloy_primitives::B256;
 use base_protocol::BlockInfo;
 
-/// An L1 origin with a verified header and any receipts available during preparation.
+/// A hash-addressed L1 origin and any receipts available during preparation.
+///
+/// The header is checked against [`Self::hash`], but exact-hash preparation alone does not prove
+/// the origin is canonical.
 #[derive(Debug, Clone)]
 pub struct PreparedL1Origin {
-    /// The verified origin block hash.
+    /// The exact origin block hash.
     pub hash: B256,
     /// The full L1 block header.
     pub header: Header,

--- a/crates/consensus/service/src/actors/sequencer/l1_origin/prepared.rs
+++ b/crates/consensus/service/src/actors/sequencer/l1_origin/prepared.rs
@@ -6,15 +6,15 @@ use alloy_consensus::{Header, Receipt};
 use alloy_primitives::B256;
 use base_protocol::BlockInfo;
 
-/// An L1 origin with the header and receipts needed to build payload attributes.
+/// An L1 origin with a verified header and any receipts available during preparation.
 #[derive(Debug, Clone)]
 pub struct PreparedL1Origin {
     /// The verified origin block hash.
     pub hash: B256,
     /// The full L1 block header.
     pub header: Header,
-    /// The L1 block receipts.
-    pub receipts: Arc<Vec<Receipt>>,
+    /// The L1 block receipts, if they were available during preparation.
+    pub receipts: Option<Arc<Vec<Receipt>>>,
 }
 
 impl PreparedL1Origin {

--- a/crates/consensus/service/src/actors/sequencer/l1_origin/prepared.rs
+++ b/crates/consensus/service/src/actors/sequencer/l1_origin/prepared.rs
@@ -1,0 +1,30 @@
+//! Prepared L1 origin state shared by selection and attributes building.
+
+use std::sync::Arc;
+
+use alloy_consensus::{Header, Receipt};
+use alloy_primitives::B256;
+use base_protocol::BlockInfo;
+
+/// An L1 origin with the header and receipts needed to build payload attributes.
+#[derive(Debug, Clone)]
+pub struct PreparedL1Origin {
+    /// The verified origin block hash.
+    pub hash: B256,
+    /// The full L1 block header.
+    pub header: Header,
+    /// The L1 block receipts.
+    pub receipts: Arc<Vec<Receipt>>,
+}
+
+impl PreparedL1Origin {
+    /// Returns the lightweight block information for this origin.
+    pub const fn block_info(&self) -> BlockInfo {
+        BlockInfo {
+            hash: self.hash,
+            number: self.header.number,
+            parent_hash: self.header.parent_hash,
+            timestamp: self.header.timestamp,
+        }
+    }
+}

--- a/crates/consensus/service/src/actors/sequencer/l1_origin/provider.rs
+++ b/crates/consensus/service/src/actors/sequencer/l1_origin/provider.rs
@@ -38,7 +38,11 @@ pub trait L1OriginSelectorProvider: Debug + Send + Sync + 'static {
     /// Returns the latest observed L1 head hash, used to identify the canonical chain view.
     fn chain_view(&self) -> Option<B256>;
 
-    /// Returns a prepared origin by its hash.
+    /// Returns the origin addressed by the exact `hash`, if available.
+    ///
+    /// This lookup verifies that the returned header hashes to `hash`, but does not establish that
+    /// the block is canonical. Successor canonicality is established separately by a by-number
+    /// lookup tied to [`Self::chain_view`].
     async fn prepared_by_hash(
         &self,
         hash: B256,

--- a/crates/consensus/service/src/actors/sequencer/l1_origin/provider.rs
+++ b/crates/consensus/service/src/actors/sequencer/l1_origin/provider.rs
@@ -1,6 +1,6 @@
 //! L1 provider interfaces and implementations for origin selection.
 
-use std::{fmt::Debug, time::Instant};
+use std::{fmt::Debug, sync::Arc, time::Instant};
 
 use alloy_consensus::{Header, Receipt};
 use alloy_primitives::B256;
@@ -141,10 +141,8 @@ impl L1OriginSelectorProvider for DelayedL1OriginSelectorProvider {
             warn!(target: "l1_origin_selector", requested = %hash, returned = %returned_hash, "L1 RPC returned a mismatched header hash");
             return Ok(None);
         }
-        let Some(receipts) = self.receipts_by_hash(hash).await? else {
-            return Err(L1OriginSelectorError::ReceiptsUnavailable(hash));
-        };
-        Ok(Some(PreparedL1Origin { hash, header, receipts: receipts.into() }))
+        let receipts = self.receipts_by_hash(hash).await?.map(Arc::new);
+        Ok(Some(PreparedL1Origin { hash, header, receipts }))
     }
 
     async fn prepared_by_number(
@@ -179,7 +177,7 @@ impl L1OriginSelectorProvider for DelayedL1OriginSelectorProvider {
             let Some(receipts) = self.receipts_by_hash(hash).await? else {
                 return Err(L1OriginSelectorError::ReceiptsUnavailable(hash));
             };
-            Ok(Some(PreparedL1Origin { hash, header, receipts: receipts.into() }))
+            Ok(Some(PreparedL1Origin { hash, header, receipts: Some(receipts.into()) }))
         } else {
             Ok(None)
         }
@@ -191,6 +189,7 @@ mod tests {
     use std::time::Duration;
 
     use alloy_rpc_client::RpcClient;
+    use alloy_rpc_types_eth::{Block as RpcBlock, Header as RpcHeader};
     use httpmock::prelude::*;
     use metrics_util::{
         CompositeKey, MetricKind,
@@ -202,6 +201,13 @@ mod tests {
 
     type SnapshotEntry =
         (CompositeKey, Option<metrics::Unit>, Option<metrics::SharedString>, DebugValue);
+
+    #[derive(serde::Serialize)]
+    struct JsonRpcResponse<T> {
+        jsonrpc: &'static str,
+        id: u64,
+        result: T,
+    }
 
     const REQUEST_TIMEOUT: Duration = Duration::from_millis(25);
     const RESPONSE_DELAY: Duration = Duration::from_millis(250);
@@ -268,6 +274,83 @@ mod tests {
             }
             value => panic!("expected one duration observation, got {value:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn current_origin_can_be_prepared_without_receipts() {
+        let server = MockServer::start_async().await;
+        let header = Header::default();
+        let hash = header.hash_slow();
+        let block: RpcBlock = RpcBlock::empty(RpcHeader::new(header.clone()));
+        let block_mock = server
+            .mock_async(move |when, then| {
+                when.method(POST)
+                    .path("/")
+                    .json_body_includes(r#"{"method":"eth_getBlockByHash"}"#);
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .json_body_obj(&JsonRpcResponse { jsonrpc: "2.0", id: 0, result: block });
+            })
+            .await;
+        let receipts_mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/")
+                    .json_body_includes(r#"{"method":"eth_getBlockReceipts"}"#);
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .body(r#"{"jsonrpc":"2.0","id":1,"result":null}"#);
+            })
+            .await;
+        let provider = test_provider(&server, None);
+
+        let prepared = provider
+            .prepared_by_hash(hash)
+            .await
+            .unwrap()
+            .expect("header should prepare the current origin");
+
+        assert_eq!(prepared.header, header);
+        assert!(prepared.receipts.is_none());
+        block_mock.assert_calls_async(1).await;
+        receipts_mock.assert_calls_async(1).await;
+    }
+
+    #[tokio::test]
+    async fn successor_is_not_prepared_without_receipts() {
+        let server = MockServer::start_async().await;
+        let header = Header { number: 7, ..Default::default() };
+        let hash = header.hash_slow();
+        let block: RpcBlock = RpcBlock::empty(RpcHeader::new(header));
+        let block_mock = server
+            .mock_async(move |when, then| {
+                when.method(POST)
+                    .path("/")
+                    .json_body_includes(r#"{"method":"eth_getBlockByNumber"}"#);
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .json_body_obj(&JsonRpcResponse { jsonrpc: "2.0", id: 0, result: block });
+            })
+            .await;
+        let receipts_mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/")
+                    .json_body_includes(r#"{"method":"eth_getBlockReceipts"}"#);
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .body(r#"{"jsonrpc":"2.0","id":1,"result":null}"#);
+            })
+            .await;
+        let provider = test_provider(&server, Some(BlockInfo { number: 7, ..Default::default() }));
+
+        let error = provider.prepared_by_number(7).await.unwrap_err();
+
+        assert!(
+            matches!(error, L1OriginSelectorError::ReceiptsUnavailable(value) if value == hash)
+        );
+        block_mock.assert_calls_async(1).await;
+        receipts_mock.assert_calls_async(1).await;
     }
 
     #[test]

--- a/crates/consensus/service/src/actors/sequencer/l1_origin/provider.rs
+++ b/crates/consensus/service/src/actors/sequencer/l1_origin/provider.rs
@@ -42,13 +42,18 @@ pub trait L1OriginSelectorProvider: Debug + Send + Sync + 'static {
     ///
     /// This lookup verifies that the returned header hashes to `hash`, but does not establish that
     /// the block is canonical. Successor canonicality is established separately by a by-number
-    /// lookup tied to [`Self::chain_view`].
+    /// lookup tied to [`Self::chain_view`]. Missing receipts do not make an exact-hash current
+    /// origin unavailable; the returned origin may omit them so the attributes provider can use
+    /// its RPC fallback.
     async fn prepared_by_hash(
         &self,
         hash: B256,
     ) -> Result<Option<PreparedL1Origin>, L1OriginSelectorError>;
 
-    /// Returns a prepared origin by its number.
+    /// Returns a canonical successor prepared by its number.
+    ///
+    /// Unlike [`Self::prepared_by_hash`], this speculative lookup requires receipts before the
+    /// successor can be adopted.
     async fn prepared_by_number(
         &self,
         number: u64,

--- a/crates/consensus/service/src/actors/sequencer/l1_origin/provider.rs
+++ b/crates/consensus/service/src/actors/sequencer/l1_origin/provider.rs
@@ -2,13 +2,15 @@
 
 use std::{fmt::Debug, time::Instant};
 
+use alloy_consensus::{Header, Receipt};
 use alloy_primitives::B256;
 use alloy_provider::{Provider, RootProvider};
+use alloy_transport::TransportErrorKind;
 use async_trait::async_trait;
 use base_protocol::BlockInfo;
 use tokio::sync::watch;
 
-use super::L1OriginSelectorError;
+use super::{L1OriginSelectorError, PreparedL1Origin};
 use crate::Metrics;
 
 macro_rules! rpc_outcome {
@@ -30,23 +32,23 @@ macro_rules! rpc_outcome {
     };
 }
 
-/// L1 [`BlockInfo`] provider interface for the [`super::L1OriginSelector`].
+/// Prepared L1 origin provider interface for the [`super::L1OriginSelector`].
 #[async_trait]
 pub trait L1OriginSelectorProvider: Debug + Send + Sync + 'static {
     /// Returns the latest observed L1 head hash, used to identify the canonical chain view.
     fn chain_view(&self) -> Option<B256>;
 
-    /// Returns a [`BlockInfo`] by its hash.
-    async fn get_block_by_hash(
+    /// Returns a prepared origin by its hash.
+    async fn prepared_by_hash(
         &self,
         hash: B256,
-    ) -> Result<Option<BlockInfo>, L1OriginSelectorError>;
+    ) -> Result<Option<PreparedL1Origin>, L1OriginSelectorError>;
 
-    /// Returns a [`BlockInfo`] by its number.
-    async fn get_block_by_number(
+    /// Returns a prepared origin by its number.
+    async fn prepared_by_number(
         &self,
         number: u64,
-    ) -> Result<Option<BlockInfo>, L1OriginSelectorError>;
+    ) -> Result<Option<PreparedL1Origin>, L1OriginSelectorError>;
 }
 
 /// A wrapper around the [`RootProvider`] that delays the view of the L1 chain by a configurable
@@ -70,6 +72,54 @@ impl DelayedL1OriginSelectorProvider {
     ) -> Self {
         Self { inner, l1_head, confirmation_depth }
     }
+
+    async fn header_by_hash(&self, hash: B256) -> Result<Option<Header>, L1OriginSelectorError> {
+        let start = Instant::now();
+        let result = Provider::get_block_by_hash(&self.inner, hash).await;
+        let outcome = rpc_outcome!(&result);
+        Metrics::sequencer_l1_origin_rpc_duration_seconds("block_by_hash", outcome)
+            .record(start.elapsed());
+        Metrics::sequencer_l1_origin_rpc_calls_total("block_by_hash", outcome).increment(1);
+
+        Ok(result?.map(|block| block.header.into_consensus()))
+    }
+
+    async fn header_by_number(&self, number: u64) -> Result<Option<Header>, L1OriginSelectorError> {
+        let start = Instant::now();
+        let result = Provider::get_block_by_number(&self.inner, number.into()).await;
+        let outcome = rpc_outcome!(&result);
+        Metrics::sequencer_l1_origin_rpc_duration_seconds("block_by_number", outcome)
+            .record(start.elapsed());
+        Metrics::sequencer_l1_origin_rpc_calls_total("block_by_number", outcome).increment(1);
+
+        Ok(result?.map(|block| block.header.into_consensus()))
+    }
+
+    async fn receipts_by_hash(
+        &self,
+        hash: B256,
+    ) -> Result<Option<Vec<Receipt>>, L1OriginSelectorError> {
+        let start = Instant::now();
+        let result = Provider::get_block_receipts(&self.inner, hash.into()).await;
+        let outcome = rpc_outcome!(&result);
+        Metrics::sequencer_l1_origin_rpc_duration_seconds("block_receipts", outcome)
+            .record(start.elapsed());
+        Metrics::sequencer_l1_origin_rpc_calls_total("block_receipts", outcome).increment(1);
+
+        let Some(receipts) = result? else {
+            return Ok(None);
+        };
+        receipts
+            .into_iter()
+            .map(|receipt| receipt.inner.into_primitives_receipt().as_receipt().cloned())
+            .collect::<Option<Vec<_>>>()
+            .map(Some)
+            .ok_or_else(|| {
+                L1OriginSelectorError::Provider(TransportErrorKind::custom_str(
+                    "failed to convert RPC receipts",
+                ))
+            })
+    }
 }
 
 #[async_trait]
@@ -78,25 +128,29 @@ impl L1OriginSelectorProvider for DelayedL1OriginSelectorProvider {
         self.l1_head.borrow().as_ref().map(|head| head.hash)
     }
 
-    async fn get_block_by_hash(
+    async fn prepared_by_hash(
         &self,
         hash: B256,
-    ) -> Result<Option<BlockInfo>, L1OriginSelectorError> {
+    ) -> Result<Option<PreparedL1Origin>, L1OriginSelectorError> {
         // By-hash lookups are not delayed, as they're direct indexes.
-        let start = Instant::now();
-        let result = Provider::get_block_by_hash(&self.inner, hash).await;
-        let outcome = rpc_outcome!(&result);
-        Metrics::sequencer_l1_origin_rpc_duration_seconds("block_by_hash", outcome)
-            .record(start.elapsed());
-        Metrics::sequencer_l1_origin_rpc_calls_total("block_by_hash", outcome).increment(1);
-
-        Ok(result?.map(Into::into))
+        let Some(header) = self.header_by_hash(hash).await? else {
+            return Ok(None);
+        };
+        let returned_hash = header.hash_slow();
+        if returned_hash != hash {
+            warn!(target: "l1_origin_selector", requested = %hash, returned = %returned_hash, "L1 RPC returned a mismatched header hash");
+            return Ok(None);
+        }
+        let Some(receipts) = self.receipts_by_hash(hash).await? else {
+            return Err(L1OriginSelectorError::ReceiptsUnavailable(hash));
+        };
+        Ok(Some(PreparedL1Origin { hash, header, receipts: receipts.into() }))
     }
 
-    async fn get_block_by_number(
+    async fn prepared_by_number(
         &self,
         number: u64,
-    ) -> Result<Option<BlockInfo>, L1OriginSelectorError> {
+    ) -> Result<Option<PreparedL1Origin>, L1OriginSelectorError> {
         let Some(l1_head) = *self.l1_head.borrow() else {
             // Without an observed head, a by-number result cannot be tied to a canonical chain
             // view or checked against the confirmation delay.
@@ -105,16 +159,27 @@ impl L1OriginSelectorProvider for DelayedL1OriginSelectorProvider {
 
         if number == 0
             || self.confirmation_depth == 0
-            || number + self.confirmation_depth <= l1_head.number
+            || number.saturating_add(self.confirmation_depth) <= l1_head.number
         {
-            let start = Instant::now();
-            let result = Provider::get_block_by_number(&self.inner, number.into()).await;
-            let outcome = rpc_outcome!(&result);
-            Metrics::sequencer_l1_origin_rpc_duration_seconds("block_by_number", outcome)
-                .record(start.elapsed());
-            Metrics::sequencer_l1_origin_rpc_calls_total("block_by_number", outcome).increment(1);
-
-            Ok(result?.map(Into::into))
+            let Some(header) = self.header_by_number(number).await? else {
+                return Ok(None);
+            };
+            if header.number != number {
+                warn!(
+                    target: "l1_origin_selector",
+                    requested = number,
+                    returned = header.number,
+                    "L1 RPC returned a header at the wrong block number"
+                );
+                return Err(L1OriginSelectorError::Provider(TransportErrorKind::custom_str(
+                    "L1 RPC returned a header at the wrong block number",
+                )));
+            }
+            let hash = header.hash_slow();
+            let Some(receipts) = self.receipts_by_hash(hash).await? else {
+                return Err(L1OriginSelectorError::ReceiptsUnavailable(hash));
+            };
+            Ok(Some(PreparedL1Origin { hash, header, receipts: receipts.into() }))
         } else {
             Ok(None)
         }
@@ -225,7 +290,7 @@ mod tests {
                         .await;
                     let provider = test_provider(&server, None);
 
-                    assert!(provider.get_block_by_hash(B256::ZERO).await.is_err());
+                    assert!(provider.prepared_by_hash(B256::ZERO).await.is_err());
                     mock.assert_calls_async(1).await;
                 });
         });
@@ -256,7 +321,7 @@ mod tests {
                         Some(BlockInfo { number: 10, ..Default::default() }),
                     );
 
-                    assert!(provider.get_block_by_number(1).await.is_err());
+                    assert!(provider.prepared_by_number(1).await.is_err());
                     mock.assert_calls_async(1).await;
                 });
         });
@@ -286,7 +351,7 @@ mod tests {
                         .await;
                     let provider = test_provider(&server, None);
 
-                    assert_eq!(provider.get_block_by_hash(B256::ZERO).await.unwrap(), None);
+                    assert!(provider.prepared_by_hash(B256::ZERO).await.unwrap().is_none());
                 });
         });
 
@@ -307,7 +372,7 @@ mod tests {
                     let server = MockServer::start_async().await;
                     let provider = test_provider(&server, None);
 
-                    assert_eq!(provider.get_block_by_number(1).await.unwrap(), None);
+                    assert!(provider.prepared_by_number(1).await.unwrap().is_none());
                 });
         });
 

--- a/crates/consensus/service/src/actors/sequencer/l1_origin/selector.rs
+++ b/crates/consensus/service/src/actors/sequencer/l1_origin/selector.rs
@@ -7,9 +7,10 @@ use alloy_transport::{RpcError, TransportErrorKind};
 use async_trait::async_trait;
 use base_common_genesis::RollupConfig;
 use base_protocol::{BlockInfo, L2BlockInfo};
+use tokio::sync::watch;
 use tokio_util::task::AbortOnDropHandle;
 
-use super::L1OriginSelectorProvider;
+use super::{L1OriginSelectorProvider, PreparedL1Origin};
 
 /// The speculative successor to `current` and any in-flight work to obtain it.
 #[derive(Debug, Default)]
@@ -24,12 +25,12 @@ enum NextSlot {
         /// The observed L1 head hash under which the fetch started.
         chain_view: B256,
         /// The self-aborting background fetch.
-        handle: AbortOnDropHandle<Option<BlockInfo>>,
+        handle: AbortOnDropHandle<Option<PreparedL1Origin>>,
     },
     /// A successor verified against its parent and observed L1 chain view.
     Ready {
         /// The prepared next origin.
-        block: BlockInfo,
+        block: Box<PreparedL1Origin>,
         /// The observed L1 head hash under which the origin was fetched.
         chain_view: B256,
     },
@@ -72,9 +73,11 @@ pub struct L1OriginSelector<P: L1OriginSelectorProvider> {
     /// The [`L1OriginSelectorProvider`], shared with the background fetch.
     l1: Arc<P>,
     /// The current L1 origin.
-    current: Option<BlockInfo>,
+    current: Option<PreparedL1Origin>,
     /// The next L1 origin and any in-flight work to obtain it.
     next: NextSlot,
+    /// Publishes the prepared origin selected for the next payload.
+    selected_tx: watch::Sender<Option<PreparedL1Origin>>,
 }
 
 #[async_trait]
@@ -92,39 +95,55 @@ impl<P: L1OriginSelectorProvider + Send + Sync> OriginSelector for L1OriginSelec
         is_recovery_mode: bool,
     ) -> Result<BlockInfo, L1OriginSelectorError> {
         self.select_origins(&unsafe_head, is_recovery_mode).await?;
-        self.choose_origin(&unsafe_head)
+        let selected = self.choose_origin(&unsafe_head)?;
+        self.selected_tx.send_replace(Some(selected.clone()));
+        Ok(selected.block_info())
     }
 }
 
 impl<P: L1OriginSelectorProvider> L1OriginSelector<P> {
     /// Creates a new [`L1OriginSelector`].
     pub fn new(cfg: Arc<RollupConfig>, l1: P) -> Self {
-        Self { cfg, l1: Arc::new(l1), current: None, next: NextSlot::Idle }
+        Self {
+            cfg,
+            l1: Arc::new(l1),
+            current: None,
+            next: NextSlot::Idle,
+            selected_tx: watch::Sender::new(None),
+        }
+    }
+
+    /// Subscribes to the prepared origin selected for payload building.
+    pub fn subscribe(&self) -> watch::Receiver<Option<PreparedL1Origin>> {
+        self.selected_tx.subscribe()
     }
 
     /// Returns the current L1 origin.
-    pub const fn current(&self) -> Option<&BlockInfo> {
-        self.current.as_ref()
+    pub fn current(&self) -> Option<BlockInfo> {
+        self.current.as_ref().map(PreparedL1Origin::block_info)
     }
 
     /// Returns the next L1 origin if its background fetch has completed and been adopted.
-    pub const fn next(&self) -> Option<&BlockInfo> {
-        self.next_ready()
+    pub fn next(&self) -> Option<BlockInfo> {
+        self.next_ready().map(PreparedL1Origin::block_info)
     }
 
     /// Returns the ready successor, if any.
-    const fn next_ready(&self) -> Option<&BlockInfo> {
+    fn next_ready(&self) -> Option<&PreparedL1Origin> {
         match &self.next {
-            NextSlot::Ready { block, .. } => Some(block),
+            NextSlot::Ready { block, .. } => Some(block.as_ref()),
             _ => None,
         }
     }
 
     /// Selects the origin to build on from the current selector state without performing I/O.
-    fn choose_origin(&self, unsafe_head: &L2BlockInfo) -> Result<BlockInfo, L1OriginSelectorError> {
+    fn choose_origin(
+        &self,
+        unsafe_head: &L2BlockInfo,
+    ) -> Result<PreparedL1Origin, L1OriginSelectorError> {
         let next_l2_timestamp =
             self.cfg.l2_block_timestamp(unsafe_head.block_info.number.saturating_add(1));
-        let Some(current) = self.current else {
+        let Some(current) = self.current.as_ref() else {
             return Err(L1OriginSelectorError::OriginNotFound(unsafe_head.l1_origin.hash));
         };
         let next = self.next_ready();
@@ -132,32 +151,33 @@ impl<P: L1OriginSelectorProvider> L1OriginSelector<P> {
         // Start building on the next L1 origin block if the next L2 block's timestamp is
         // greater than or equal to the next L1 origin's timestamp.
         if let Some(next) = next
-            && next_l2_timestamp >= next.timestamp
+            && next_l2_timestamp >= next.header.timestamp
         {
-            return Ok(*next);
+            return Ok(next.clone());
         }
 
-        let max_seq_drift = self.cfg.max_sequencer_drift(current.timestamp);
-        let past_seq_drift = next_l2_timestamp.saturating_sub(current.timestamp) > max_seq_drift;
+        let max_seq_drift = self.cfg.max_sequencer_drift(current.header.timestamp);
+        let past_seq_drift =
+            next_l2_timestamp.saturating_sub(current.header.timestamp) > max_seq_drift;
 
         // If the sequencer drift has not been exceeded, return the current L1 origin.
         if !past_seq_drift {
-            return Ok(current);
+            return Ok(current.clone());
         }
 
         warn!(
             target: "l1_origin_selector",
-            current_origin_time = current.timestamp,
+            current_origin_time = current.header.timestamp,
             unsafe_head_time = unsafe_head.block_info.timestamp,
             next_l2_time = next_l2_timestamp,
             max_seq_drift,
             "Next L2 block time is past the sequencer drift"
         );
 
-        if next.map(|next| next_l2_timestamp < next.timestamp).unwrap_or(false) {
+        if next.map(|next| next_l2_timestamp < next.header.timestamp).unwrap_or(false) {
             // If the next L1 origin is ahead of the next L2 block's timestamp, return the current
             // origin.
-            return Ok(current);
+            return Ok(current.clone());
         }
 
         // Any ready successor was already handled above: a successor at or behind the next L2
@@ -166,7 +186,7 @@ impl<P: L1OriginSelectorProvider> L1OriginSelector<P> {
         // limit the caller must defer the build until the verified successor becomes ready rather
         // than continue building on an expired origin.
         debug_assert!(next.is_none(), "a ready successor must be handled before the drift path");
-        Err(L1OriginSelectorError::NotEnoughData(current))
+        Err(L1OriginSelectorError::NotEnoughData(current.block_info()))
     }
 
     /// Selects the current origin and drives the background next-origin state machine.
@@ -179,22 +199,22 @@ impl<P: L1OriginSelectorProvider> L1OriginSelector<P> {
 
         if in_recovery_mode {
             self.invalidate_next(origin_hash);
-            self.current = self.l1.get_block_by_hash(origin_hash).await?;
+            self.current = self.l1.prepared_by_hash(origin_hash).await?;
         } else {
             self.invalidate_next_if_chain_view_changed();
-            if self.current.is_some_and(|current| current.hash == origin_hash) {
+            if self.current.as_ref().is_some_and(|current| current.hash == origin_hash) {
                 // The next L2 block remains in the current sequencing epoch.
             } else if let Some(promoted) = self.take_ready_if(origin_hash) {
                 self.current = Some(promoted);
             } else {
                 // Cold start, multi-epoch jump, or reorg: resolve the required current origin.
                 self.next = NextSlot::Idle;
-                self.current = self.l1.get_block_by_hash(origin_hash).await?;
+                self.current = self.l1.prepared_by_hash(origin_hash).await?;
             }
         }
 
-        if let Some(current) = self.current {
-            self.poll_next(current.hash, current.number).await;
+        if let Some(current) = self.current.as_ref() {
+            self.poll_next(current.hash, current.header.number).await;
         }
         Ok(())
     }
@@ -204,7 +224,7 @@ impl<P: L1OriginSelectorProvider> L1OriginSelector<P> {
         self.invalidate_next_if_chain_view_changed();
         let stored_parent = match &self.next {
             NextSlot::InFlight { parent_hash, .. } => *parent_hash,
-            NextSlot::Ready { block, .. } => block.parent_hash,
+            NextSlot::Ready { block, .. } => block.header.parent_hash,
             NextSlot::Idle => return,
         };
         if stored_parent != parent_hash {
@@ -213,10 +233,10 @@ impl<P: L1OriginSelectorProvider> L1OriginSelector<P> {
     }
 
     /// Takes a ready successor if it matches `hash`.
-    fn take_ready_if(&mut self, hash: B256) -> Option<BlockInfo> {
+    fn take_ready_if(&mut self, hash: B256) -> Option<PreparedL1Origin> {
         if matches!(&self.next, NextSlot::Ready { block, .. } if block.hash == hash) {
             match std::mem::take(&mut self.next) {
-                NextSlot::Ready { block, .. } => Some(block),
+                NextSlot::Ready { block, .. } => Some(*block),
                 _ => None,
             }
         } else {
@@ -246,10 +266,10 @@ impl<P: L1OriginSelectorProvider> L1OriginSelector<P> {
         };
 
         self.next = match std::mem::take(&mut self.next) {
-            ready @ NextSlot::Ready { block, chain_view: ready_view }
-                if block.parent_hash == current_hash && ready_view == chain_view =>
+            NextSlot::Ready { block, chain_view: ready_view }
+                if block.header.parent_hash == current_hash && ready_view == chain_view =>
             {
-                ready
+                NextSlot::Ready { block, chain_view: ready_view }
             }
             NextSlot::InFlight { parent_hash, chain_view: fetch_view, .. }
                 if parent_hash != current_hash || fetch_view != chain_view =>
@@ -291,13 +311,13 @@ impl<P: L1OriginSelectorProvider> L1OriginSelector<P> {
         &self,
         current_hash: B256,
         chain_view: B256,
-        fetched: Option<BlockInfo>,
+        fetched: Option<PreparedL1Origin>,
     ) -> NextSlot {
         fetched
             .filter(|next| {
-                next.parent_hash == current_hash && self.l1.chain_view() == Some(chain_view)
+                next.header.parent_hash == current_hash && self.l1.chain_view() == Some(chain_view)
             })
-            .map_or(NextSlot::Idle, |block| NextSlot::Ready { block, chain_view })
+            .map_or(NextSlot::Idle, |block| NextSlot::Ready { block: Box::new(block), chain_view })
     }
 
     /// Starts a background lookup for the origin following `current_number`.
@@ -305,7 +325,7 @@ impl<P: L1OriginSelectorProvider> L1OriginSelector<P> {
         let l1 = Arc::clone(&self.l1);
         let number = current_number.saturating_add(1);
         let handle = AbortOnDropHandle::new(tokio::spawn(async move {
-            match l1.get_block_by_number(number).await {
+            match l1.prepared_by_number(number).await {
                 Ok(next) => next,
                 Err(error) => {
                     warn!(
@@ -324,7 +344,7 @@ impl<P: L1OriginSelectorProvider> L1OriginSelector<P> {
     /// Test-only helper that settles an in-flight fetch through the production adoption path.
     #[cfg(test)]
     async fn await_inflight(&mut self) {
-        let Some(current_hash) = self.current.map(|current| current.hash) else {
+        let Some(current_hash) = self.current.as_ref().map(|current| current.hash) else {
             return;
         };
         self.next = match std::mem::take(&mut self.next) {
@@ -366,6 +386,9 @@ pub enum L1OriginSelectorError {
     /// The L1 origin block was not found by its hash, e.g. during an L1 reorg or sync lag.
     #[error("L1 origin block not found by hash: {0}")]
     OriginNotFound(B256),
+    /// The block header exists but its receipts are not available yet.
+    #[error("receipts unavailable for L1 origin: {0}")]
+    ReceiptsUnavailable(B256),
 }
 
 #[cfg(test)]
@@ -440,23 +463,24 @@ mod tests {
             *self.chain_view.lock().expect("chain view lock poisoned")
         }
 
-        async fn get_block_by_hash(
+        async fn prepared_by_hash(
             &self,
             hash: B256,
-        ) -> Result<Option<BlockInfo>, L1OriginSelectorError> {
+        ) -> Result<Option<PreparedL1Origin>, L1OriginSelectorError> {
             Ok(self
                 .blocks
                 .lock()
                 .expect("blocks lock poisoned")
                 .iter()
                 .find(|block| block.hash == hash)
-                .copied())
+                .copied()
+                .map(prepared))
         }
 
-        async fn get_block_by_number(
+        async fn prepared_by_number(
             &self,
             number: u64,
-        ) -> Result<Option<BlockInfo>, L1OriginSelectorError> {
+        ) -> Result<Option<PreparedL1Origin>, L1OriginSelectorError> {
             let delay = *self.number_delay.lock().expect("number delay lock poisoned");
             tokio::time::sleep(delay).await;
             if self.failed_number_fetches.contains(&number) {
@@ -477,7 +501,20 @@ mod tests {
             {
                 self.set_chain_view(chain_view);
             }
-            Ok(block)
+            Ok(block.map(prepared))
+        }
+    }
+
+    fn prepared(block: BlockInfo) -> PreparedL1Origin {
+        PreparedL1Origin {
+            hash: block.hash,
+            header: alloy_consensus::Header {
+                parent_hash: block.parent_hash,
+                number: block.number,
+                timestamp: block.timestamp,
+                ..Default::default()
+            },
+            receipts: Arc::new(Vec::new()),
         }
     }
 
@@ -613,7 +650,7 @@ mod tests {
         let selected = selector.next_l1_origin(unsafe_head, false).await.unwrap();
         assert_eq!(selected, current);
         selector.await_inflight().await;
-        assert_eq!(selector.next(), Some(&next_a));
+        assert_eq!(selector.next(), Some(next_a));
 
         selector.l1.replace_block(next_b);
         selector.l1.set_chain_view(B256::with_last_byte(11));
@@ -625,7 +662,7 @@ mod tests {
         selector.await_inflight().await;
         let selected = selector.next_l1_origin(unsafe_head, false).await.unwrap();
         assert_eq!(selected, next_b);
-        assert_eq!(selector.next(), Some(&next_b));
+        assert_eq!(selector.next(), Some(next_b));
     }
 
     #[tokio::test]
@@ -668,7 +705,7 @@ mod tests {
         selector.await_inflight().await;
         let selected = selector.next_l1_origin(unsafe_head, false).await.unwrap();
         assert_eq!(selected, next);
-        assert_eq!(selector.next(), Some(&next));
+        assert_eq!(selector.next(), Some(next));
     }
 
     #[tokio::test]
@@ -715,7 +752,7 @@ mod tests {
         selector.await_inflight().await;
         let selected = selector.next_l1_origin(unsafe_head, false).await.unwrap();
         assert_eq!(selected, next_b);
-        assert_eq!(selector.next(), Some(&next_b));
+        assert_eq!(selector.next(), Some(next_b));
     }
 
     #[tokio::test]
@@ -814,7 +851,7 @@ mod tests {
         let next = selector.next_l1_origin(unsafe_head, false).await.unwrap();
 
         assert_eq!(next, current);
-        assert_eq!(selector.current(), Some(&current));
+        assert_eq!(selector.current(), Some(current));
         assert_eq!(selector.next(), None);
     }
 
@@ -849,7 +886,7 @@ mod tests {
         let next = selector.next_l1_origin(unsafe_head, true).await.unwrap();
 
         assert_eq!(next, current);
-        assert_eq!(selector.current(), Some(&current));
+        assert_eq!(selector.current(), Some(current));
         assert_eq!(selector.next(), None);
     }
 
@@ -884,7 +921,7 @@ mod tests {
         let err = selector.next_l1_origin(unsafe_head, false).await.unwrap_err();
 
         assert!(matches!(err, L1OriginSelectorError::NotEnoughData(block) if block == current));
-        assert_eq!(selector.current(), Some(&current));
+        assert_eq!(selector.current(), Some(current));
         assert_eq!(selector.next(), None);
     }
 
@@ -1008,7 +1045,7 @@ mod tests {
         assert_eq!(selected, current);
 
         selector.await_inflight().await;
-        assert_eq!(selector.next(), Some(&next));
+        assert_eq!(selector.next(), Some(next));
     }
 
     #[tokio::test]
@@ -1051,7 +1088,7 @@ mod tests {
         let selected = selector.next_l1_origin(unsafe_head, false).await.unwrap();
         assert_eq!(selected, current);
         selector.await_inflight().await;
-        assert_eq!(selector.next(), Some(&next_b));
+        assert_eq!(selector.next(), Some(next_b));
     }
 
     #[tokio::test]
@@ -1085,7 +1122,35 @@ mod tests {
         assert_eq!(selector.next_l1_origin(unsafe_head, true).await.unwrap(), current);
         selector.wait_for_inflight_completion().await;
         assert_eq!(selector.next_l1_origin(unsafe_head, true).await.unwrap(), next);
-        assert_eq!(selector.next(), Some(&next));
+        assert_eq!(selector.next(), Some(next));
+    }
+
+    #[tokio::test]
+    async fn test_selected_origin_is_published() {
+        let cfg = Arc::new(RollupConfig {
+            block_time: 2,
+            max_sequencer_drift: 600,
+            ..Default::default()
+        });
+        let current = BlockInfo {
+            hash: B256::with_last_byte(1),
+            number: 0,
+            timestamp: 0,
+            ..Default::default()
+        };
+        let provider = MockOriginSelectorProvider::default();
+        provider.with_block(current);
+        let mut selector = L1OriginSelector::new(cfg, provider);
+        let selected_rx = selector.subscribe();
+        let unsafe_head = L2BlockInfo {
+            l1_origin: NumHash { number: current.number, hash: current.hash },
+            ..Default::default()
+        };
+
+        assert_eq!(selector.next_l1_origin(unsafe_head, false).await.unwrap(), current);
+        let published = selected_rx.borrow().clone().expect("selected origin published");
+        assert_eq!(published.block_info(), current);
+        assert!(published.receipts.is_empty());
     }
 
     #[tokio::test]
@@ -1118,7 +1183,7 @@ mod tests {
 
         assert_eq!(selector.next_l1_origin(unsafe_head, false).await.unwrap(), current);
         selector.await_inflight().await;
-        assert_eq!(selector.next(), Some(&next));
+        assert_eq!(selector.next(), Some(next));
         selector.l1.remove_block(current.hash);
 
         let error = selector.next_l1_origin(unsafe_head, true).await.unwrap_err();

--- a/crates/consensus/service/src/actors/sequencer/l1_origin/selector.rs
+++ b/crates/consensus/service/src/actors/sequencer/l1_origin/selector.rs
@@ -96,8 +96,9 @@ impl<P: L1OriginSelectorProvider + Send + Sync> OriginSelector for L1OriginSelec
     ) -> Result<BlockInfo, L1OriginSelectorError> {
         self.select_origins(&unsafe_head).await?;
         let selected = self.choose_origin(&unsafe_head)?;
-        self.selected_tx.send_replace(Some(selected.clone()));
-        Ok(selected.block_info())
+        let block_info = selected.block_info();
+        self.selected_tx.send_replace(Some(selected));
+        Ok(block_info)
     }
 }
 
@@ -483,7 +484,7 @@ mod tests {
                 timestamp: block.timestamp,
                 ..Default::default()
             },
-            receipts: Arc::new(Vec::new()),
+            receipts: Some(Arc::new(Vec::new())),
         }
     }
 
@@ -1119,7 +1120,7 @@ mod tests {
         assert_eq!(selector.next_l1_origin(unsafe_head, false).await.unwrap(), current);
         let published = selected_rx.borrow().clone().expect("selected origin published");
         assert_eq!(published.block_info(), current);
-        assert!(published.receipts.is_empty());
+        assert!(published.receipts.as_ref().is_some_and(|receipts| receipts.is_empty()));
     }
 
     #[tokio::test]

--- a/crates/consensus/service/src/actors/sequencer/l1_origin/selector.rs
+++ b/crates/consensus/service/src/actors/sequencer/l1_origin/selector.rs
@@ -64,11 +64,11 @@ pub trait OriginSelector: Debug + Send + Sync {
 /// extend the current origin under the same observed L1 chain view. While sequencer drift permits,
 /// an unfinished lookup does not prevent building on the current origin. Once drift is exceeded,
 /// selection returns [`L1OriginSelectorError::NotEnoughData`] until the lookup is ready rather than
-/// awaiting speculative work on the build path. Selection remains disabled until an observed L1
-/// head is available because successor canonicality cannot otherwise be established. An L1 reorg
-/// that orphans the current origin is therefore detected when the background successor lookup
-/// completes its parent check, after which the sequencer requests an engine reset to rewind any
-/// affected unsafe L2 blocks.
+/// awaiting speculative work on the build path. Before the first observed L1 head, the selector may
+/// reuse the exact-hash current origin accepted by the engine reset, but it cannot prepare or advance
+/// to a successor. An L1 reorg that orphans the current origin is therefore detected when the
+/// background successor lookup completes its parent check, after which the sequencer requests an
+/// engine reset to rewind any affected unsafe L2 blocks.
 #[derive(Debug)]
 pub struct L1OriginSelector<P: L1OriginSelectorProvider> {
     /// The [`RollupConfig`].
@@ -247,7 +247,7 @@ impl<P: L1OriginSelectorProvider> L1OriginSelector<P> {
     ) -> Result<(), L1OriginSelectorError> {
         let Some(chain_view) = self.l1.chain_view() else {
             self.next = NextSlot::Idle;
-            return Err(L1OriginSelectorError::ChainViewUnavailable);
+            return Ok(());
         };
 
         // Taking the slot first intentionally leaves it idle if successor adoption proves the
@@ -384,9 +384,6 @@ pub enum L1OriginSelectorError {
         "Waiting for more L1 data to be available to select the next L1 origin block. Current L1 origin: {0:?}"
     )]
     NotEnoughData(BlockInfo),
-    /// No observed L1 head is available to establish successor canonicality.
-    #[error("L1 chain view unavailable")]
-    ChainViewUnavailable,
     /// The L1 origin block was not found by its hash, e.g. during an L1 reorg or sync lag.
     #[error("L1 origin block not found by hash: {0}")]
     OriginNotFound(B256),
@@ -680,7 +677,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_next_l1_origin_refuses_to_build_without_chain_view() {
+    async fn test_next_l1_origin_waits_for_chain_view() {
         let cfg = Arc::new(RollupConfig {
             block_time: 2,
             max_sequencer_drift: 600,
@@ -709,8 +706,8 @@ mod tests {
             seq_num: 0,
         };
 
-        let error = selector.next_l1_origin(unsafe_head).await.unwrap_err();
-        assert!(matches!(error, L1OriginSelectorError::ChainViewUnavailable));
+        let selected = selector.next_l1_origin(unsafe_head).await.unwrap();
+        assert_eq!(selected, current);
         assert_eq!(selector.next(), None);
 
         selector.l1.set_chain_view(B256::with_last_byte(10));

--- a/crates/consensus/service/src/actors/sequencer/l1_origin/selector.rs
+++ b/crates/consensus/service/src/actors/sequencer/l1_origin/selector.rs
@@ -248,6 +248,9 @@ impl<P: L1OriginSelectorProvider> L1OriginSelector<P> {
             return Ok(());
         };
 
+        // Taking the slot first intentionally leaves it idle if successor adoption proves the
+        // current origin was orphaned and returns an error. Stale speculative state must not
+        // survive that error path.
         self.next = match std::mem::take(&mut self.next) {
             NextSlot::Ready { block, chain_view: ready_view }
                 if block.header.parent_hash == current_hash && ready_view == chain_view =>

--- a/crates/consensus/service/src/actors/sequencer/l1_origin/selector.rs
+++ b/crates/consensus/service/src/actors/sequencer/l1_origin/selector.rs
@@ -48,14 +48,12 @@ pub trait OriginSelector: Debug + Send + Sync {
     ///
     /// # Arguments
     /// * `unsafe_head` - The current unsafe head of the L2 chain
-    /// * `is_recovery_mode` - Whether the sequencer is in recovery mode
     ///
     /// # Returns
     /// The selected L1 origin block information, or an error if selection failed.
     async fn next_l1_origin(
         &mut self,
         unsafe_head: L2BlockInfo,
-        is_recovery_mode: bool,
     ) -> Result<BlockInfo, L1OriginSelectorError>;
 }
 
@@ -66,7 +64,9 @@ pub trait OriginSelector: Debug + Send + Sync {
 /// extend the current origin under the same observed L1 chain view. While sequencer drift permits,
 /// an unfinished lookup does not prevent building on the current origin. Once drift is exceeded,
 /// selection returns [`L1OriginSelectorError::NotEnoughData`] until the lookup is ready rather than
-/// awaiting speculative work on the build path.
+/// awaiting speculative work on the build path. An L1 reorg that orphans the current origin is
+/// therefore detected when the background successor lookup completes its parent check, after which
+/// the sequencer requests an engine reset to rewind any affected unsafe L2 blocks.
 #[derive(Debug)]
 pub struct L1OriginSelector<P: L1OriginSelectorProvider> {
     /// The [`RollupConfig`].
@@ -93,7 +93,6 @@ impl<P: L1OriginSelectorProvider + Send + Sync> OriginSelector for L1OriginSelec
     async fn next_l1_origin(
         &mut self,
         unsafe_head: L2BlockInfo,
-        _is_recovery_mode: bool,
     ) -> Result<BlockInfo, L1OriginSelectorError> {
         if let Err(error) = self.select_origins(&unsafe_head).await {
             self.selected_tx.send_replace(None);
@@ -574,10 +573,10 @@ mod tests {
                 },
                 seq_num: 0,
             };
-            let _ = selector.next_l1_origin(unsafe_head, false).await;
+            let _ = selector.next_l1_origin(unsafe_head).await;
             selector.await_inflight().await;
             assert!(selector.next().is_some(), "next origin not ready at L2 block {i}");
-            let next = selector.next_l1_origin(unsafe_head, false).await.unwrap();
+            let next = selector.next_l1_origin(unsafe_head).await.unwrap();
 
             // The expected L1 origin block is the one corresponding to the epoch of the current L2
             // block.
@@ -616,7 +615,7 @@ mod tests {
             seq_num: 0,
         };
 
-        let err = selector.next_l1_origin(unsafe_head, false).await.unwrap_err();
+        let err = selector.next_l1_origin(unsafe_head).await.unwrap_err();
         assert!(
             matches!(err, L1OriginSelectorError::OriginNotFound(h) if h == B256::with_last_byte(42))
         );
@@ -654,7 +653,7 @@ mod tests {
             seq_num: 0,
         };
 
-        let selected = selector.next_l1_origin(unsafe_head, false).await.unwrap();
+        let selected = selector.next_l1_origin(unsafe_head).await.unwrap();
         assert_eq!(selected, current);
         selector.await_inflight().await;
         assert_eq!(selector.next(), Some(next_a));
@@ -664,10 +663,10 @@ mod tests {
         unsafe_head.block_info.number = 5;
         unsafe_head.block_info.timestamp = 10;
 
-        let selected = selector.next_l1_origin(unsafe_head, false).await.unwrap();
+        let selected = selector.next_l1_origin(unsafe_head).await.unwrap();
         assert_eq!(selected, current);
         selector.await_inflight().await;
-        let selected = selector.next_l1_origin(unsafe_head, false).await.unwrap();
+        let selected = selector.next_l1_origin(unsafe_head).await.unwrap();
         assert_eq!(selected, next_b);
         assert_eq!(selector.next(), Some(next_b));
     }
@@ -702,15 +701,15 @@ mod tests {
             seq_num: 0,
         };
 
-        let selected = selector.next_l1_origin(unsafe_head, false).await.unwrap();
+        let selected = selector.next_l1_origin(unsafe_head).await.unwrap();
         assert_eq!(selected, current);
         assert_eq!(selector.next(), None);
 
         selector.l1.set_chain_view(B256::with_last_byte(10));
-        let selected = selector.next_l1_origin(unsafe_head, false).await.unwrap();
+        let selected = selector.next_l1_origin(unsafe_head).await.unwrap();
         assert_eq!(selected, current);
         selector.await_inflight().await;
-        let selected = selector.next_l1_origin(unsafe_head, false).await.unwrap();
+        let selected = selector.next_l1_origin(unsafe_head).await.unwrap();
         assert_eq!(selected, next);
         assert_eq!(selector.next(), Some(next));
     }
@@ -754,17 +753,17 @@ mod tests {
             seq_num: 0,
         };
 
-        let selected = selector.next_l1_origin(unsafe_head, false).await.unwrap();
+        let selected = selector.next_l1_origin(unsafe_head).await.unwrap();
         assert_eq!(selected, current);
         selector.await_inflight().await;
         assert_eq!(selector.next(), None);
 
         selector.l1.replace_block(next_b);
         selector.l1.change_chain_view_after_number_fetch(None);
-        let selected = selector.next_l1_origin(unsafe_head, false).await.unwrap();
+        let selected = selector.next_l1_origin(unsafe_head).await.unwrap();
         assert_eq!(selected, current);
         selector.await_inflight().await;
-        let selected = selector.next_l1_origin(unsafe_head, false).await.unwrap();
+        let selected = selector.next_l1_origin(unsafe_head).await.unwrap();
         assert_eq!(selected, next_b);
         assert_eq!(selector.next(), Some(next_b));
 
@@ -825,9 +824,9 @@ mod tests {
             },
             seq_num: 0,
         };
-        let _ = selector.next_l1_origin(unsafe_head, false).await;
+        let _ = selector.next_l1_origin(unsafe_head).await;
         selector.await_inflight().await;
-        let next = selector.next_l1_origin(unsafe_head, false).await.unwrap();
+        let next = selector.next_l1_origin(unsafe_head).await.unwrap();
 
         // The expected L1 origin block is the one corresponding to the epoch of the current L2
         // block. Assuming the next L1 origin block is not available from the eyes of the
@@ -867,42 +866,7 @@ mod tests {
             seq_num: 0,
         };
 
-        let next = selector.next_l1_origin(unsafe_head, false).await.unwrap();
-
-        assert_eq!(next, current);
-        assert_eq!(selector.current(), Some(current));
-        assert_eq!(selector.next(), None);
-    }
-
-    #[tokio::test]
-    async fn test_recovery_mode_reuses_current_on_next_fetch_error_before_seq_drift() {
-        const L2_BLOCK_TIME: u64 = 2;
-        const MAX_SEQUENCER_DRIFT: u64 = 30 * 60;
-
-        let cfg = Arc::new(RollupConfig {
-            block_time: L2_BLOCK_TIME,
-            max_sequencer_drift: MAX_SEQUENCER_DRIFT,
-            ..Default::default()
-        });
-
-        let current =
-            BlockInfo { parent_hash: B256::ZERO, hash: B256::ZERO, number: 0, timestamp: 0 };
-        let mut provider = MockOriginSelectorProvider::default();
-        provider.with_block(current);
-        provider.fail_block_number(current.number + 1);
-
-        let mut selector = L1OriginSelector::new(Arc::clone(&cfg), provider);
-        let unsafe_head = L2BlockInfo {
-            block_info: BlockInfo {
-                number: (MAX_SEQUENCER_DRIFT - cfg.block_time) / cfg.block_time,
-                timestamp: MAX_SEQUENCER_DRIFT - cfg.block_time,
-                ..Default::default()
-            },
-            l1_origin: NumHash { number: current.number, hash: current.hash },
-            seq_num: 0,
-        };
-
-        let next = selector.next_l1_origin(unsafe_head, true).await.unwrap();
+        let next = selector.next_l1_origin(unsafe_head).await.unwrap();
 
         assert_eq!(next, current);
         assert_eq!(selector.current(), Some(current));
@@ -937,7 +901,7 @@ mod tests {
             seq_num: 0,
         };
 
-        let err = selector.next_l1_origin(unsafe_head, false).await.unwrap_err();
+        let err = selector.next_l1_origin(unsafe_head).await.unwrap_err();
 
         assert!(matches!(err, L1OriginSelectorError::NotEnoughData(block) if block == current));
         assert_eq!(selector.current(), Some(current));
@@ -1004,9 +968,9 @@ mod tests {
         };
 
         if next_available {
-            let _ = selector.next_l1_origin(unsafe_head, false).await;
+            let _ = selector.next_l1_origin(unsafe_head).await;
             selector.await_inflight().await;
-            let next = selector.next_l1_origin(unsafe_head, false).await.unwrap();
+            let next = selector.next_l1_origin(unsafe_head).await.unwrap();
             if next_ahead_of_unsafe {
                 // If the next L1 origin is available and ahead of the unsafe head, the L1 origin
                 // should not change.
@@ -1022,7 +986,7 @@ mod tests {
             // If we're past the sequencer drift, and the next L1 block is not available, a
             // `NotEnoughData` error should be returned signifying that we cannot
             // proceed with the next L1 origin until the block is present.
-            let next_err = selector.next_l1_origin(unsafe_head, false).await.unwrap_err();
+            let next_err = selector.next_l1_origin(unsafe_head).await.unwrap_err();
             assert!(matches!(next_err, L1OriginSelectorError::NotEnoughData(_)));
         }
     }
@@ -1056,11 +1020,10 @@ mod tests {
             ..Default::default()
         };
 
-        let selected =
-            timeout(Duration::from_millis(20), selector.next_l1_origin(unsafe_head, false))
-                .await
-                .expect("background lookup must not block selection")
-                .unwrap();
+        let selected = timeout(Duration::from_millis(20), selector.next_l1_origin(unsafe_head))
+            .await
+            .expect("background lookup must not block selection")
+            .unwrap();
         assert_eq!(selected, current);
 
         selector.await_inflight().await;
@@ -1098,20 +1061,20 @@ mod tests {
             ..Default::default()
         };
 
-        let selected = selector.next_l1_origin(unsafe_head, false).await.unwrap();
+        let selected = selector.next_l1_origin(unsafe_head).await.unwrap();
         assert_eq!(selected, current);
 
         selector.l1.replace_block(next_b);
         selector.l1.set_chain_view(B256::with_last_byte(11));
         selector.l1.set_number_delay(Duration::ZERO);
-        let selected = selector.next_l1_origin(unsafe_head, false).await.unwrap();
+        let selected = selector.next_l1_origin(unsafe_head).await.unwrap();
         assert_eq!(selected, current);
         selector.await_inflight().await;
         assert_eq!(selector.next(), Some(next_b));
     }
 
     #[tokio::test]
-    async fn test_recovery_mode_adopts_completed_fetch() {
+    async fn test_adopts_completed_fetch() {
         let cfg = Arc::new(RollupConfig {
             block_time: 2,
             max_sequencer_drift: 600,
@@ -1138,9 +1101,9 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(selector.next_l1_origin(unsafe_head, true).await.unwrap(), current);
+        assert_eq!(selector.next_l1_origin(unsafe_head).await.unwrap(), current);
         selector.wait_for_inflight_completion().await;
-        assert_eq!(selector.next_l1_origin(unsafe_head, true).await.unwrap(), next);
+        assert_eq!(selector.next_l1_origin(unsafe_head).await.unwrap(), next);
         assert_eq!(selector.next(), Some(next));
     }
 
@@ -1166,7 +1129,7 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(selector.next_l1_origin(unsafe_head, false).await.unwrap(), current);
+        assert_eq!(selector.next_l1_origin(unsafe_head).await.unwrap(), current);
         let published = selected_rx.borrow().clone().expect("selected origin published");
         assert_eq!(published.block_info(), current);
         assert!(published.receipts.as_ref().is_some_and(|receipts| receipts.is_empty()));
@@ -1204,9 +1167,9 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(selector.next_l1_origin(unsafe_head, false).await.unwrap(), current);
+        assert_eq!(selector.next_l1_origin(unsafe_head).await.unwrap(), current);
         selector.wait_for_inflight_completion().await;
-        let error = selector.next_l1_origin(unsafe_head, false).await.unwrap_err();
+        let error = selector.next_l1_origin(unsafe_head).await.unwrap_err();
 
         assert!(matches!(
             error,
@@ -1223,7 +1186,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_recovery_mode_reuses_prepared_current() {
+    async fn test_reuses_prepared_current_when_provider_loses_current() {
         let cfg = Arc::new(RollupConfig {
             block_time: 2,
             max_sequencer_drift: 600,
@@ -1243,20 +1206,15 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(selector.next_l1_origin(unsafe_head, false).await.unwrap(), current);
+        assert_eq!(selector.next_l1_origin(unsafe_head).await.unwrap(), current);
         selector.l1.remove_block(current.hash);
 
-        assert_eq!(selector.next_l1_origin(unsafe_head, true).await.unwrap(), current);
+        assert_eq!(selector.next_l1_origin(unsafe_head).await.unwrap(), current);
         assert_eq!(selector.current(), Some(current));
     }
 
     #[tokio::test]
-    #[rstest]
-    #[case::normal(false)]
-    #[case::recovery(true)]
-    async fn test_accepted_head_promotes_ready_origin_after_chain_view_advances(
-        #[case] recovery_mode: bool,
-    ) {
+    async fn test_accepted_head_promotes_ready_origin_after_chain_view_advances() {
         let cfg = Arc::new(RollupConfig {
             block_time: 2,
             max_sequencer_drift: 600,
@@ -1283,7 +1241,7 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(selector.next_l1_origin(current_head, false).await.unwrap(), current);
+        assert_eq!(selector.next_l1_origin(current_head).await.unwrap(), current);
         selector.await_inflight().await;
         assert_eq!(selector.next(), Some(next));
 
@@ -1297,7 +1255,7 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(selector.next_l1_origin(accepted_head, recovery_mode).await.unwrap(), next);
+        assert_eq!(selector.next_l1_origin(accepted_head).await.unwrap(), next);
         assert_eq!(selector.current(), Some(next));
     }
 
@@ -1332,9 +1290,9 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(selector.next_l1_origin(unsafe_head, false).await.unwrap(), current);
+        assert_eq!(selector.next_l1_origin(unsafe_head).await.unwrap(), current);
         selector.wait_for_inflight_completion().await;
-        assert_eq!(selector.next_l1_origin(unsafe_head, false).await.unwrap(), current);
+        assert_eq!(selector.next_l1_origin(unsafe_head).await.unwrap(), current);
         assert!(matches!(
             &selector.next,
             NextSlot::InFlight { chain_view, .. } if *chain_view == latest_view
@@ -1342,6 +1300,6 @@ mod tests {
 
         selector.l1.change_chain_view_after_number_fetch(None);
         selector.wait_for_inflight_completion().await;
-        assert_eq!(selector.next_l1_origin(unsafe_head, false).await.unwrap(), next);
+        assert_eq!(selector.next_l1_origin(unsafe_head).await.unwrap(), next);
     }
 }

--- a/crates/consensus/service/src/actors/sequencer/l1_origin/selector.rs
+++ b/crates/consensus/service/src/actors/sequencer/l1_origin/selector.rs
@@ -11,6 +11,7 @@ use tokio::sync::watch;
 use tokio_util::task::AbortOnDropHandle;
 
 use super::{L1OriginSelectorProvider, PreparedL1Origin};
+use crate::Metrics;
 
 /// The speculative successor to `current` and any in-flight work to obtain it.
 #[derive(Debug, Default)]
@@ -306,6 +307,7 @@ impl<P: L1OriginSelectorProvider> L1OriginSelector<P> {
             return Ok(NextSlot::Idle);
         }
         if block.header.parent_hash != current_hash {
+            Metrics::sequencer_l1_origin_orphans_total().increment(1);
             return Err(L1OriginSelectorError::NextL1OriginOrphaned {
                 current: current_hash,
                 next: block.hash,
@@ -399,6 +401,8 @@ mod tests {
     use std::{collections::HashSet, sync::Mutex, time::Duration};
 
     use alloy_eips::NumHash;
+    #[cfg(feature = "metrics")]
+    use metrics_util::debugging::{DebugValue, DebuggingRecorder};
     use rstest::rstest;
     use tokio::time::timeout;
 
@@ -713,6 +717,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_next_l1_origin_discards_result_when_chain_view_changes_during_fetch() {
+        #[cfg(feature = "metrics")]
+        let recorder = DebuggingRecorder::new();
+        #[cfg(feature = "metrics")]
+        let snapshotter = recorder.snapshotter();
+        #[cfg(feature = "metrics")]
+        let _metrics_guard = metrics::set_default_local_recorder(&recorder);
+
         let cfg = Arc::new(RollupConfig {
             block_time: 2,
             max_sequencer_drift: 600,
@@ -756,6 +767,11 @@ mod tests {
         let selected = selector.next_l1_origin(unsafe_head, false).await.unwrap();
         assert_eq!(selected, next_b);
         assert_eq!(selector.next(), Some(next_b));
+
+        #[cfg(feature = "metrics")]
+        assert!(snapshotter.snapshot().into_vec().iter().all(|(key, _, _, _)| {
+            key.key().name() != "base_node.sequencer_l1_origin_orphans_total"
+        }));
     }
 
     #[tokio::test]
@@ -1158,6 +1174,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_canonical_successor_with_wrong_parent_reports_orphan_and_clears_selection() {
+        #[cfg(feature = "metrics")]
+        let recorder = DebuggingRecorder::new();
+        #[cfg(feature = "metrics")]
+        let snapshotter = recorder.snapshotter();
+        #[cfg(feature = "metrics")]
+        let _metrics_guard = metrics::set_default_local_recorder(&recorder);
+
         let cfg = Arc::new(RollupConfig {
             block_time: 2,
             max_sequencer_drift: 600,
@@ -1192,6 +1215,11 @@ mod tests {
         ));
         assert!(selected_rx.borrow().is_none());
         assert!(selector.next().is_none());
+        #[cfg(feature = "metrics")]
+        assert!(snapshotter.snapshot().into_vec().iter().any(|(key, _, _, value)| {
+            key.key().name() == "base_node.sequencer_l1_origin_orphans_total"
+                && value == &DebugValue::Counter(1)
+        }));
     }
 
     #[tokio::test]

--- a/crates/consensus/service/src/actors/sequencer/l1_origin/selector.rs
+++ b/crates/consensus/service/src/actors/sequencer/l1_origin/selector.rs
@@ -94,8 +94,17 @@ impl<P: L1OriginSelectorProvider + Send + Sync> OriginSelector for L1OriginSelec
         unsafe_head: L2BlockInfo,
         _is_recovery_mode: bool,
     ) -> Result<BlockInfo, L1OriginSelectorError> {
-        self.select_origins(&unsafe_head).await?;
-        let selected = self.choose_origin(&unsafe_head)?;
+        if let Err(error) = self.select_origins(&unsafe_head).await {
+            self.selected_tx.send_replace(None);
+            return Err(error);
+        }
+        let selected = match self.choose_origin(&unsafe_head) {
+            Ok(selected) => selected,
+            Err(error) => {
+                self.selected_tx.send_replace(None);
+                return Err(error);
+            }
+        };
         let block_info = selected.block_info();
         self.selected_tx.send_replace(Some(selected));
         Ok(block_info)
@@ -211,7 +220,7 @@ impl<P: L1OriginSelectorProvider> L1OriginSelector<P> {
         }
 
         if let Some(current) = self.current.as_ref() {
-            self.poll_next(current.hash, current.header.number).await;
+            self.poll_next(current.hash, current.header.number).await?;
         }
         Ok(())
     }
@@ -229,10 +238,14 @@ impl<P: L1OriginSelectorProvider> L1OriginSelector<P> {
     }
 
     /// Advances the next-origin state machine without awaiting an unfinished fetch.
-    async fn poll_next(&mut self, current_hash: B256, current_number: u64) {
+    async fn poll_next(
+        &mut self,
+        current_hash: B256,
+        current_number: u64,
+    ) -> Result<(), L1OriginSelectorError> {
         let Some(chain_view) = self.l1.chain_view() else {
             self.next = NextSlot::Idle;
-            return;
+            return Ok(());
         };
 
         self.next = match std::mem::take(&mut self.next) {
@@ -258,7 +271,7 @@ impl<P: L1OriginSelectorProvider> L1OriginSelector<P> {
                         None
                     }
                 };
-                match self.adopt_next(current_hash, chain_view, fetched) {
+                match self.adopt_next(current_hash, chain_view, fetched)? {
                     NextSlot::Idle => self.l1.chain_view().map_or(NextSlot::Idle, |live_view| {
                         self.spawn_next(current_hash, current_number, live_view)
                     }),
@@ -274,6 +287,7 @@ impl<P: L1OriginSelectorProvider> L1OriginSelector<P> {
                 self.spawn_next(current_hash, current_number, chain_view)
             }
         };
+        Ok(())
     }
 
     /// Adopts a fetched successor only if its parent and observed chain view are still current.
@@ -282,12 +296,22 @@ impl<P: L1OriginSelectorProvider> L1OriginSelector<P> {
         current_hash: B256,
         chain_view: B256,
         fetched: Option<PreparedL1Origin>,
-    ) -> NextSlot {
-        fetched
-            .filter(|next| {
-                next.header.parent_hash == current_hash && self.l1.chain_view() == Some(chain_view)
-            })
-            .map_or(NextSlot::Idle, |block| NextSlot::Ready { block: Box::new(block), chain_view })
+    ) -> Result<NextSlot, L1OriginSelectorError> {
+        let Some(block) = fetched else {
+            return Ok(NextSlot::Idle);
+        };
+        // A result fetched against an obsolete observed head says nothing about the live canonical
+        // successor. Discard it before checking ancestry so it cannot be mistaken for a reorg.
+        if self.l1.chain_view() != Some(chain_view) {
+            return Ok(NextSlot::Idle);
+        }
+        if block.header.parent_hash != current_hash {
+            return Err(L1OriginSelectorError::NextL1OriginOrphaned {
+                current: current_hash,
+                next: block.hash,
+            });
+        }
+        Ok(NextSlot::Ready { block: Box::new(block), chain_view })
     }
 
     /// Starts a background lookup for the origin following `current_number`.
@@ -321,6 +345,7 @@ impl<P: L1OriginSelectorProvider> L1OriginSelector<P> {
             NextSlot::InFlight { chain_view, handle, .. } => {
                 let fetched = handle.await.ok().flatten();
                 self.adopt_next(current_hash, chain_view, fetched)
+                    .expect("test fetch must extend the current origin")
             }
             slot => slot,
         };
@@ -356,6 +381,14 @@ pub enum L1OriginSelectorError {
     /// The L1 origin block was not found by its hash, e.g. during an L1 reorg or sync lag.
     #[error("L1 origin block not found by hash: {0}")]
     OriginNotFound(B256),
+    /// The canonical successor no longer extends the accepted current L1 origin.
+    #[error("next L1 origin {next} does not extend current L1 origin {current}")]
+    NextL1OriginOrphaned {
+        /// Hash of the accepted current L1 origin.
+        current: B256,
+        /// Hash of its canonical-height successor.
+        next: B256,
+    },
     /// The block header exists but its receipts are not available yet.
     #[error("receipts unavailable for L1 origin: {0}")]
     ReceiptsUnavailable(B256),
@@ -1121,6 +1154,44 @@ mod tests {
         let published = selected_rx.borrow().clone().expect("selected origin published");
         assert_eq!(published.block_info(), current);
         assert!(published.receipts.as_ref().is_some_and(|receipts| receipts.is_empty()));
+    }
+
+    #[tokio::test]
+    async fn test_canonical_successor_with_wrong_parent_reports_orphan_and_clears_selection() {
+        let cfg = Arc::new(RollupConfig {
+            block_time: 2,
+            max_sequencer_drift: 600,
+            ..Default::default()
+        });
+        let current = BlockInfo { hash: B256::with_last_byte(1), number: 4, ..Default::default() };
+        let orphaning_successor = BlockInfo {
+            hash: B256::with_last_byte(2),
+            parent_hash: B256::with_last_byte(99),
+            number: 5,
+            timestamp: 2,
+        };
+        let provider = MockOriginSelectorProvider::default();
+        provider.with_block(current);
+        provider.with_block(orphaning_successor);
+        provider.set_chain_view(B256::with_last_byte(10));
+        let mut selector = L1OriginSelector::new(cfg, provider);
+        let selected_rx = selector.subscribe();
+        let unsafe_head = L2BlockInfo {
+            l1_origin: NumHash { number: current.number, hash: current.hash },
+            ..Default::default()
+        };
+
+        assert_eq!(selector.next_l1_origin(unsafe_head, false).await.unwrap(), current);
+        selector.wait_for_inflight_completion().await;
+        let error = selector.next_l1_origin(unsafe_head, false).await.unwrap_err();
+
+        assert!(matches!(
+            error,
+            L1OriginSelectorError::NextL1OriginOrphaned { current: hash, next }
+                if hash == current.hash && next == orphaning_successor.hash
+        ));
+        assert!(selected_rx.borrow().is_none());
+        assert!(selector.next().is_none());
     }
 
     #[tokio::test]

--- a/crates/consensus/service/src/actors/sequencer/l1_origin/selector.rs
+++ b/crates/consensus/service/src/actors/sequencer/l1_origin/selector.rs
@@ -92,9 +92,9 @@ impl<P: L1OriginSelectorProvider + Send + Sync> OriginSelector for L1OriginSelec
     async fn next_l1_origin(
         &mut self,
         unsafe_head: L2BlockInfo,
-        is_recovery_mode: bool,
+        _is_recovery_mode: bool,
     ) -> Result<BlockInfo, L1OriginSelectorError> {
-        self.select_origins(&unsafe_head, is_recovery_mode).await?;
+        self.select_origins(&unsafe_head).await?;
         let selected = self.choose_origin(&unsafe_head)?;
         self.selected_tx.send_replace(Some(selected.clone()));
         Ok(selected.block_info())
@@ -193,43 +193,26 @@ impl<P: L1OriginSelectorProvider> L1OriginSelector<P> {
     async fn select_origins(
         &mut self,
         unsafe_head: &L2BlockInfo,
-        in_recovery_mode: bool,
     ) -> Result<(), L1OriginSelectorError> {
         let origin_hash = unsafe_head.l1_origin.hash;
 
-        if in_recovery_mode {
-            self.invalidate_next(origin_hash);
-            self.current = self.l1.prepared_by_hash(origin_hash).await?;
+        if self.current.as_ref().is_some_and(|current| current.hash == origin_hash) {
+            // The next L2 block remains in the current sequencing epoch.
+        } else if let Some(promoted) = self.take_ready_if(origin_hash) {
+            // The accepted unsafe head confirms that the prepared successor was used. Promote it
+            // before applying speculative chain-view invalidation so a normal L1 head advance
+            // cannot discard the exact origin required by the accepted L2 parent.
+            self.current = Some(promoted);
         } else {
-            self.invalidate_next_if_chain_view_changed();
-            if self.current.as_ref().is_some_and(|current| current.hash == origin_hash) {
-                // The next L2 block remains in the current sequencing epoch.
-            } else if let Some(promoted) = self.take_ready_if(origin_hash) {
-                self.current = Some(promoted);
-            } else {
-                // Cold start, multi-epoch jump, or reorg: resolve the required current origin.
-                self.next = NextSlot::Idle;
-                self.current = self.l1.prepared_by_hash(origin_hash).await?;
-            }
+            // Cold start, multi-epoch jump, or reorg: resolve the required current origin.
+            self.next = NextSlot::Idle;
+            self.current = self.l1.prepared_by_hash(origin_hash).await?;
         }
 
         if let Some(current) = self.current.as_ref() {
             self.poll_next(current.hash, current.header.number).await;
         }
         Ok(())
-    }
-
-    /// Drops speculative state that cannot extend `parent_hash` in the live L1 chain view.
-    fn invalidate_next(&mut self, parent_hash: B256) {
-        self.invalidate_next_if_chain_view_changed();
-        let stored_parent = match &self.next {
-            NextSlot::InFlight { parent_hash, .. } => *parent_hash,
-            NextSlot::Ready { block, .. } => block.header.parent_hash,
-            NextSlot::Idle => return,
-        };
-        if stored_parent != parent_hash {
-            self.next = NextSlot::Idle;
-        }
     }
 
     /// Takes a ready successor if it matches `hash`.
@@ -241,20 +224,6 @@ impl<P: L1OriginSelectorProvider> L1OriginSelector<P> {
             }
         } else {
             None
-        }
-    }
-
-    /// Drops speculative state when its observed L1 chain view is no longer current.
-    fn invalidate_next_if_chain_view_changed(&mut self) {
-        let live_view = self.l1.chain_view();
-        let stored_view = match &self.next {
-            NextSlot::InFlight { chain_view, .. } | NextSlot::Ready { chain_view, .. } => {
-                *chain_view
-            }
-            NextSlot::Idle => return,
-        };
-        if Some(stored_view) != live_view {
-            self.next = NextSlot::Idle;
         }
     }
 
@@ -1154,7 +1123,40 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_recovery_mode_does_not_use_ready_next_when_current_is_missing() {
+    async fn test_recovery_mode_reuses_prepared_current() {
+        let cfg = Arc::new(RollupConfig {
+            block_time: 2,
+            max_sequencer_drift: 600,
+            ..Default::default()
+        });
+        let current = BlockInfo {
+            hash: B256::with_last_byte(1),
+            number: 0,
+            timestamp: 0,
+            ..Default::default()
+        };
+        let provider = MockOriginSelectorProvider::default();
+        provider.with_block(current);
+        let mut selector = L1OriginSelector::new(cfg, provider);
+        let unsafe_head = L2BlockInfo {
+            l1_origin: NumHash { number: current.number, hash: current.hash },
+            ..Default::default()
+        };
+
+        assert_eq!(selector.next_l1_origin(unsafe_head, false).await.unwrap(), current);
+        selector.l1.remove_block(current.hash);
+
+        assert_eq!(selector.next_l1_origin(unsafe_head, true).await.unwrap(), current);
+        assert_eq!(selector.current(), Some(current));
+    }
+
+    #[tokio::test]
+    #[rstest]
+    #[case::normal(false)]
+    #[case::recovery(true)]
+    async fn test_accepted_head_promotes_ready_origin_after_chain_view_advances(
+        #[case] recovery_mode: bool,
+    ) {
         let cfg = Arc::new(RollupConfig {
             block_time: 2,
             max_sequencer_drift: 600,
@@ -1176,20 +1178,27 @@ mod tests {
         provider.with_block(current);
         provider.with_block(next);
         let mut selector = L1OriginSelector::new(cfg, provider);
-        let unsafe_head = L2BlockInfo {
+        let current_head = L2BlockInfo {
             l1_origin: NumHash { number: current.number, hash: current.hash },
             ..Default::default()
         };
 
-        assert_eq!(selector.next_l1_origin(unsafe_head, false).await.unwrap(), current);
+        assert_eq!(selector.next_l1_origin(current_head, false).await.unwrap(), current);
         selector.await_inflight().await;
         assert_eq!(selector.next(), Some(next));
-        selector.l1.remove_block(current.hash);
 
-        let error = selector.next_l1_origin(unsafe_head, true).await.unwrap_err();
-        assert!(
-            matches!(error, L1OriginSelectorError::OriginNotFound(hash) if hash == current.hash)
-        );
+        // Simulate the next origin being selected and accepted, followed by an ordinary L1 head
+        // advance and an L1 RPC outage before the child build starts.
+        selector.l1.set_chain_view(B256::with_last_byte(3));
+        selector.l1.remove_block(next.hash);
+        let accepted_head = L2BlockInfo {
+            block_info: BlockInfo { number: 1, timestamp: 2, ..Default::default() },
+            l1_origin: NumHash { number: next.number, hash: next.hash },
+            ..Default::default()
+        };
+
+        assert_eq!(selector.next_l1_origin(accepted_head, recovery_mode).await.unwrap(), next);
+        assert_eq!(selector.current(), Some(next));
     }
 
     #[tokio::test]

--- a/crates/consensus/service/src/actors/sequencer/l1_origin/selector.rs
+++ b/crates/consensus/service/src/actors/sequencer/l1_origin/selector.rs
@@ -64,9 +64,11 @@ pub trait OriginSelector: Debug + Send + Sync {
 /// extend the current origin under the same observed L1 chain view. While sequencer drift permits,
 /// an unfinished lookup does not prevent building on the current origin. Once drift is exceeded,
 /// selection returns [`L1OriginSelectorError::NotEnoughData`] until the lookup is ready rather than
-/// awaiting speculative work on the build path. An L1 reorg that orphans the current origin is
-/// therefore detected when the background successor lookup completes its parent check, after which
-/// the sequencer requests an engine reset to rewind any affected unsafe L2 blocks.
+/// awaiting speculative work on the build path. Selection remains disabled until an observed L1
+/// head is available because successor canonicality cannot otherwise be established. An L1 reorg
+/// that orphans the current origin is therefore detected when the background successor lookup
+/// completes its parent check, after which the sequencer requests an engine reset to rewind any
+/// affected unsafe L2 blocks.
 #[derive(Debug)]
 pub struct L1OriginSelector<P: L1OriginSelectorProvider> {
     /// The [`RollupConfig`].
@@ -245,7 +247,7 @@ impl<P: L1OriginSelectorProvider> L1OriginSelector<P> {
     ) -> Result<(), L1OriginSelectorError> {
         let Some(chain_view) = self.l1.chain_view() else {
             self.next = NextSlot::Idle;
-            return Ok(());
+            return Err(L1OriginSelectorError::ChainViewUnavailable);
         };
 
         // Taking the slot first intentionally leaves it idle if successor adoption proves the
@@ -382,6 +384,9 @@ pub enum L1OriginSelectorError {
         "Waiting for more L1 data to be available to select the next L1 origin block. Current L1 origin: {0:?}"
     )]
     NotEnoughData(BlockInfo),
+    /// No observed L1 head is available to establish successor canonicality.
+    #[error("L1 chain view unavailable")]
+    ChainViewUnavailable,
     /// The L1 origin block was not found by its hash, e.g. during an L1 reorg or sync lag.
     #[error("L1 origin block not found by hash: {0}")]
     OriginNotFound(B256),
@@ -675,7 +680,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_next_l1_origin_waits_for_chain_view() {
+    async fn test_next_l1_origin_refuses_to_build_without_chain_view() {
         let cfg = Arc::new(RollupConfig {
             block_time: 2,
             max_sequencer_drift: 600,
@@ -704,8 +709,8 @@ mod tests {
             seq_num: 0,
         };
 
-        let selected = selector.next_l1_origin(unsafe_head).await.unwrap();
-        assert_eq!(selected, current);
+        let error = selector.next_l1_origin(unsafe_head).await.unwrap_err();
+        assert!(matches!(error, L1OriginSelectorError::ChainViewUnavailable));
         assert_eq!(selector.next(), None);
 
         selector.l1.set_chain_view(B256::with_last_byte(10));

--- a/crates/consensus/service/src/actors/sequencer/mod.rs
+++ b/crates/consensus/service/src/actors/sequencer/mod.rs
@@ -11,7 +11,8 @@ mod l1_origin;
 pub use l1_origin::MockOriginSelector;
 pub use l1_origin::{
     DelayedL1OriginSelectorProvider, L1OriginSelector, L1OriginSelectorError,
-    L1OriginSelectorProvider, OriginSelector,
+    L1OriginSelectorProvider, OriginSelector, PrefetchedChainProvider,
+    PrefetchedChainProviderError, PreparedL1Origin,
 };
 
 mod recovery;

--- a/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
@@ -164,7 +164,7 @@ async fn test_on_time_or_late_insert_starts_child_build_immediately(#[case] seco
     client.expect_insert_unsafe_payload().times(1).return_once(move |_| Ok(inserted_head));
 
     let mut origin_selector = MockOriginSelector::new();
-    origin_selector.expect_next_l1_origin().times(2).returning(|_, _| Ok(BlockInfo::default()));
+    origin_selector.expect_next_l1_origin().times(2).returning(|_| Ok(BlockInfo::default()));
 
     let mut gossip = MockUnsafePayloadGossipClient::new();
     gossip.expect_schedule_execution_payload_gossip().times(1).return_once(|_| Ok(()));
@@ -234,7 +234,7 @@ async fn test_early_insert_defers_child_build_until_parent_timestamp() {
     });
 
     let mut origin_selector = MockOriginSelector::new();
-    origin_selector.expect_next_l1_origin().times(2).returning(|_, _| Ok(BlockInfo::default()));
+    origin_selector.expect_next_l1_origin().times(2).returning(|_| Ok(BlockInfo::default()));
 
     let mut gossip = MockUnsafePayloadGossipClient::new();
     gossip.expect_schedule_execution_payload_gossip().times(1).return_once(|_| Ok(()));
@@ -326,7 +326,7 @@ async fn test_stop_discards_queued_parent_and_restart_builds_immediately_on_fres
     });
 
     let mut origin_selector = MockOriginSelector::new();
-    origin_selector.expect_next_l1_origin().times(2).returning(|_, _| Ok(BlockInfo::default()));
+    origin_selector.expect_next_l1_origin().times(2).returning(|_| Ok(BlockInfo::default()));
 
     let mut gossip = MockUnsafePayloadGossipClient::new();
     gossip.expect_schedule_execution_payload_gossip().times(1).return_once(|_| Ok(()));
@@ -551,7 +551,7 @@ async fn test_build_retries_are_paced_after_immediate_budget(#[case] provider_er
     client.expect_start_build_block().times(0);
 
     let mut origin_selector = MockOriginSelector::new();
-    origin_selector.expect_next_l1_origin().times(expected_attempts).returning(move |_, _| {
+    origin_selector.expect_next_l1_origin().times(expected_attempts).returning(move |_| {
         attempt_tx.send(()).unwrap();
         if provider_error {
             Err(L1OriginSelectorError::Provider(TransportErrorKind::custom_str(
@@ -607,7 +607,7 @@ async fn test_orphaned_l1_origin_resets_once_without_starting_block_build() {
     client.expect_start_build_block().times(0);
 
     let mut origin_selector = MockOriginSelector::new();
-    origin_selector.expect_next_l1_origin().times(1).return_once(|_, _| {
+    origin_selector.expect_next_l1_origin().times(1).return_once(|_| {
         Err(L1OriginSelectorError::NextL1OriginOrphaned {
             current: B256::with_last_byte(1),
             next: B256::with_last_byte(2),
@@ -641,7 +641,7 @@ async fn test_build_unsealed_payload_prepare_payload_attributes_error(
 
     let l1_origin = BlockInfo::default();
     let mut origin_selector = MockOriginSelector::new();
-    origin_selector.expect_next_l1_origin().times(1).return_once(move |_, _| Ok(l1_origin));
+    origin_selector.expect_next_l1_origin().times(1).return_once(move |_| Ok(l1_origin));
 
     let attributes_builder = TestAttributesBuilder { attributes: vec![Err(forced_error)] };
 

--- a/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
@@ -621,6 +621,27 @@ async fn test_orphaned_l1_origin_resets_once_without_starting_block_build() {
     assert!(matches!(actor.builder.build().await.unwrap(), crate::BuildOutcome::Deferred));
 }
 
+#[tokio::test]
+async fn test_missing_l1_chain_view_defers_without_starting_block_build() {
+    let unsafe_head = L2BlockInfo::default();
+    let mut client = MockSequencerEngineClient::new();
+    client.expect_get_unsafe_head().times(1).return_once(move || Ok(unsafe_head));
+    client.expect_reset_engine_forkchoice().times(0);
+    client.expect_start_build_block().times(0);
+
+    let mut origin_selector = MockOriginSelector::new();
+    origin_selector
+        .expect_next_l1_origin()
+        .times(1)
+        .return_once(|_| Err(L1OriginSelectorError::ChainViewUnavailable));
+
+    let mut actor = test_actor();
+    actor.builder.origin_selector = origin_selector;
+    actor.builder.engine_client = Arc::new(client);
+
+    assert!(matches!(actor.builder.build().await.unwrap(), crate::BuildOutcome::AwaitingL1Origin));
+}
+
 #[rstest]
 #[case::temp(PipelineErrorKind::Temporary(BuilderError::Custom(String::new()).into()), false)]
 #[case::reset(PipelineErrorKind::Reset(BuilderError::Custom(String::new()).into()), false)]

--- a/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
@@ -9,6 +9,7 @@ use std::{
 
 use alloy_primitives::B256;
 use alloy_rpc_types_engine::ExecutionPayloadV1;
+use alloy_transport::TransportErrorKind;
 use base_common_genesis::{ChainGenesis, RollupConfig};
 use base_common_rpc_types_engine::{
     BaseExecutionPayload, BaseExecutionPayloadEnvelope, BasePayloadAttributes,
@@ -532,8 +533,11 @@ async fn test_try_seal_handle_non_fatal_seal_error_returns_none() {
     assert!(!actor.cancellation_token.is_cancelled());
 }
 
+#[rstest]
+#[case::awaiting_l1_origin(false)]
+#[case::provider_error(true)]
 #[tokio::test(start_paused = true)]
-async fn test_l1_origin_retries_are_paced_after_immediate_budget() {
+async fn test_build_retries_are_paced_after_immediate_budget(#[case] provider_error: bool) {
     let attempts_before_delay = usize::from(ScheduledTicker::MAX_IMMEDIATE_L1_ORIGIN_RETRIES) + 1;
     let expected_attempts = attempts_before_delay + 1;
     let (attempt_tx, mut attempt_rx) = mpsc::unbounded_channel();
@@ -549,7 +553,13 @@ async fn test_l1_origin_retries_are_paced_after_immediate_budget() {
     let mut origin_selector = MockOriginSelector::new();
     origin_selector.expect_next_l1_origin().times(expected_attempts).returning(move |_, _| {
         attempt_tx.send(()).unwrap();
-        Err(L1OriginSelectorError::NotEnoughData(BlockInfo::default()))
+        if provider_error {
+            Err(L1OriginSelectorError::Provider(TransportErrorKind::custom_str(
+                "mock L1 provider failure",
+            )))
+        } else {
+            Err(L1OriginSelectorError::NotEnoughData(BlockInfo::default()))
+        }
     });
 
     let engine_client = Arc::new(client);

--- a/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
@@ -594,6 +594,29 @@ async fn test_build_retries_are_paced_after_immediate_budget(#[case] provider_er
 
 // --- build tests ---
 
+#[tokio::test]
+async fn test_orphaned_l1_origin_resets_once_without_starting_block_build() {
+    let unsafe_head = L2BlockInfo::default();
+    let mut client = MockSequencerEngineClient::new();
+    client.expect_get_unsafe_head().times(1).return_once(move || Ok(unsafe_head));
+    client.expect_reset_engine_forkchoice().times(1).return_once(|| Ok(()));
+    client.expect_start_build_block().times(0);
+
+    let mut origin_selector = MockOriginSelector::new();
+    origin_selector.expect_next_l1_origin().times(1).return_once(|_, _| {
+        Err(L1OriginSelectorError::NextL1OriginOrphaned {
+            current: B256::with_last_byte(1),
+            next: B256::with_last_byte(2),
+        })
+    });
+
+    let mut actor = test_actor();
+    actor.builder.origin_selector = origin_selector;
+    actor.builder.engine_client = Arc::new(client);
+
+    assert!(matches!(actor.builder.build().await.unwrap(), crate::BuildOutcome::Deferred));
+}
+
 #[rstest]
 #[case::temp(PipelineErrorKind::Temporary(BuilderError::Custom(String::new()).into()), false)]
 #[case::reset(PipelineErrorKind::Reset(BuilderError::Custom(String::new()).into()), false)]

--- a/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
@@ -22,9 +22,9 @@ use rstest::rstest;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::{
-    ConductorError, L1OriginSelectorError, NodeActor, ScheduledTicker, SealState, SealStepError,
-    SealStepOutcome, SequencerActorError, SequencerAdminQuery, UnsafePayloadGossipClientError,
-    UnsealedPayloadHandle,
+    ConductorError, L1OriginSelectorError, NodeActor, ResetReason, ScheduledTicker, SealState,
+    SealStepError, SealStepOutcome, SequencerActorError, SequencerAdminQuery,
+    UnsafePayloadGossipClientError, UnsealedPayloadHandle,
     actors::{
         MockConductor, MockOriginSelector, MockSequencerEngineClient,
         MockUnsafePayloadGossipClient,
@@ -154,7 +154,7 @@ async fn test_on_time_or_late_insert_starts_child_build_immediately(#[case] seco
     let (build_tx, mut build_rx) = mpsc::unbounded_channel();
 
     let mut client = MockSequencerEngineClient::new();
-    client.expect_reset_engine_forkchoice().times(1).return_once(|| Ok(()));
+    client.expect_reset_engine_forkchoice().times(1).return_once(|_| Ok(()));
     client.expect_get_unsafe_head().times(2).returning(move || Ok(initial_head));
     client.expect_start_build_block().times(2).returning(move |attributes| {
         build_tx.send(attributes.parent().block_info.number).unwrap();
@@ -221,7 +221,7 @@ async fn test_early_insert_defers_child_build_until_parent_timestamp() {
     let (insert_tx, mut insert_rx) = mpsc::unbounded_channel();
 
     let mut client = MockSequencerEngineClient::new();
-    client.expect_reset_engine_forkchoice().times(1).return_once(|| Ok(()));
+    client.expect_reset_engine_forkchoice().times(1).return_once(|_| Ok(()));
     client.expect_get_unsafe_head().times(2).returning(move || Ok(initial_head));
     client.expect_start_build_block().times(2).returning(move |attributes| {
         build_tx.send(attributes.parent().block_info.number).unwrap();
@@ -303,7 +303,7 @@ async fn test_stop_discards_queued_parent_and_restart_builds_immediately_on_fres
     let get_head_calls = Arc::new(AtomicUsize::new(0));
 
     let mut client = MockSequencerEngineClient::new();
-    client.expect_reset_engine_forkchoice().times(1).return_once(|| Ok(()));
+    client.expect_reset_engine_forkchoice().times(1).return_once(|_| Ok(()));
     client.expect_get_unsafe_head().times(5).returning({
         let get_head_calls = Arc::clone(&get_head_calls);
         move || {
@@ -399,7 +399,7 @@ async fn shadow_cycle_reconciles_after_configured_private_block_count() {
     let cancellation_token = tokio_util::sync::CancellationToken::new();
     let cancel_after_reconciliation = cancellation_token.clone();
     let mut client = MockSequencerEngineClient::new();
-    client.expect_reset_engine_forkchoice_coordinated().times(1).return_once(|| Ok(()));
+    client.expect_reset_engine_forkchoice_coordinated().times(1).return_once(|_| Ok(()));
     client.expect_get_unsafe_head().times(1).return_once(move || Ok(cycle_start));
     client.expect_insert_unsafe_payload().times(1).return_once(move |_| Ok(private_head));
     client
@@ -543,7 +543,7 @@ async fn test_build_retries_are_paced_after_immediate_budget(#[case] provider_er
     let (attempt_tx, mut attempt_rx) = mpsc::unbounded_channel();
 
     let mut client = MockSequencerEngineClient::new();
-    client.expect_reset_engine_forkchoice().times(1).return_once(|| Ok(()));
+    client.expect_reset_engine_forkchoice().times(1).return_once(|_| Ok(()));
     client
         .expect_get_unsafe_head()
         .times(expected_attempts)
@@ -599,7 +599,11 @@ async fn test_orphaned_l1_origin_resets_once_without_starting_block_build() {
     let unsafe_head = L2BlockInfo::default();
     let mut client = MockSequencerEngineClient::new();
     client.expect_get_unsafe_head().times(1).return_once(move || Ok(unsafe_head));
-    client.expect_reset_engine_forkchoice().times(1).return_once(|| Ok(()));
+    client
+        .expect_reset_engine_forkchoice()
+        .with(mockall::predicate::eq(ResetReason::L1OriginOrphaned))
+        .times(1)
+        .return_once(|_| Ok(()));
     client.expect_start_build_block().times(0);
 
     let mut origin_selector = MockOriginSelector::new();

--- a/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
@@ -621,27 +621,6 @@ async fn test_orphaned_l1_origin_resets_once_without_starting_block_build() {
     assert!(matches!(actor.builder.build().await.unwrap(), crate::BuildOutcome::Deferred));
 }
 
-#[tokio::test]
-async fn test_missing_l1_chain_view_defers_without_starting_block_build() {
-    let unsafe_head = L2BlockInfo::default();
-    let mut client = MockSequencerEngineClient::new();
-    client.expect_get_unsafe_head().times(1).return_once(move || Ok(unsafe_head));
-    client.expect_reset_engine_forkchoice().times(0);
-    client.expect_start_build_block().times(0);
-
-    let mut origin_selector = MockOriginSelector::new();
-    origin_selector
-        .expect_next_l1_origin()
-        .times(1)
-        .return_once(|_| Err(L1OriginSelectorError::ChainViewUnavailable));
-
-    let mut actor = test_actor();
-    actor.builder.origin_selector = origin_selector;
-    actor.builder.engine_client = Arc::new(client);
-
-    assert!(matches!(actor.builder.build().await.unwrap(), crate::BuildOutcome::AwaitingL1Origin));
-}
-
 #[rstest]
 #[case::temp(PipelineErrorKind::Temporary(BuilderError::Custom(String::new()).into()), false)]
 #[case::reset(PipelineErrorKind::Reset(BuilderError::Custom(String::new()).into()), false)]

--- a/crates/consensus/service/src/actors/sequencer/tests/admin_api_impl_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/admin_api_impl_test.rs
@@ -8,7 +8,7 @@ use rstest::rstest;
 use tokio::sync::oneshot;
 
 use crate::{
-    ConductorError, EngineClientError, SequencerAdminQuery,
+    ConductorError, EngineClientError, ResetReason, SequencerAdminQuery,
     actors::{MockConductor, MockSequencerEngineClient, sequencer::tests::test_util::test_actor},
 };
 
@@ -558,7 +558,11 @@ async fn test_override_leader(
 #[tokio::test]
 async fn test_reset_derivation_pipeline_success(#[values(true, false)] via_channel: bool) {
     let mut client = MockSequencerEngineClient::new();
-    client.expect_reset_engine_forkchoice().times(1).return_once(|| Ok(()));
+    client
+        .expect_reset_engine_forkchoice()
+        .with(mockall::predicate::eq(ResetReason::Admin))
+        .times(1)
+        .return_once(|_| Ok(()));
 
     let mut actor = test_actor();
     actor.engine_client = Arc::new(client);
@@ -588,7 +592,7 @@ async fn test_reset_derivation_pipeline_error(#[values(true, false)] via_channel
     client
         .expect_reset_engine_forkchoice()
         .times(1)
-        .return_once(|| Err(EngineClientError::RequestError("reset failed".to_string())));
+        .return_once(|_| Err(EngineClientError::RequestError("reset failed".to_string())));
 
     let mut actor = test_actor();
     actor.engine_client = Arc::new(client);
@@ -624,7 +628,7 @@ async fn test_handle_admin_query_resilient_to_dropped_receiver() {
     };
     let mut client = MockSequencerEngineClient::new();
     client.expect_get_unsafe_head().times(1).returning(move || Ok(unsafe_head));
-    client.expect_reset_engine_forkchoice().times(1).returning(|| Ok(()));
+    client.expect_reset_engine_forkchoice().times(1).returning(|_| Ok(()));
 
     let mut actor = test_actor();
     actor.conductor = Some(conductor);

--- a/crates/consensus/service/src/actors/sequencer/ticker.rs
+++ b/crates/consensus/service/src/actors/sequencer/ticker.rs
@@ -87,11 +87,14 @@ impl ScheduledTicker {
     }
 
     /// Resets the immediate retry budget after a build succeeds.
+    ///
+    /// Reset-triggered and other deferrals intentionally preserve the budget so persistent L1
+    /// provider lag or repeated engine resets cannot hot-loop the sequencer.
     pub const fn reset_l1_origin_retry_budget(&mut self) {
         self.immediate_l1_origin_retries = 0;
     }
 
-    /// Schedules a retry after a non-fatal build deferral.
+    /// Schedules a retry after a non-fatal build deferral or while awaiting a prefetched origin.
     ///
     /// A short burst handles races where the background fetch is about to complete. Once the
     /// budget is exhausted, subsequent retries are spaced by [`Self::L1_ORIGIN_RETRY_DELAY`] so

--- a/crates/consensus/service/src/actors/sequencer/ticker.rs
+++ b/crates/consensus/service/src/actors/sequencer/ticker.rs
@@ -86,12 +86,12 @@ impl ScheduledTicker {
         }
     }
 
-    /// Resets the immediate retry budget after origin selection advances past the drift wait.
+    /// Resets the immediate retry budget after a build succeeds.
     pub const fn reset_l1_origin_retry_budget(&mut self) {
         self.immediate_l1_origin_retries = 0;
     }
 
-    /// Schedules a build retry while drift requires a next L1 origin that is not ready yet.
+    /// Schedules a retry after a non-fatal build deferral.
     ///
     /// A short burst handles races where the background fetch is about to complete. Once the
     /// budget is exhausted, subsequent retries are spaced by [`Self::L1_ORIGIN_RETRY_DELAY`] so

--- a/crates/consensus/service/src/lib.rs
+++ b/crates/consensus/service/src/lib.rs
@@ -38,6 +38,7 @@ pub use actors::{
     NetworkBuilder, NetworkBuilderError, NetworkConfig, NetworkDriver, NetworkDriverError,
     NetworkEngineClient, NetworkHandler, NetworkInboundData, NodeActor, NoopCheckpointWriter,
     OriginSelector, PayloadBuilder, PayloadSealer, PendingStopSender, PoolActivation,
+    PrefetchedChainProvider, PrefetchedChainProviderError, PreparedL1Origin,
     QueuedDerivationEngineClient, QueuedEngineDerivationClient, QueuedEngineRpcClient,
     QueuedL1WatcherDerivationClient, QueuedNetworkEngineClient, QueuedSequencerAdminAPIClient,
     QueuedSequencerEngineClient, QueuedUnsafePayloadGossipClient, ReconcileShadowRequest,

--- a/crates/consensus/service/src/lib.rs
+++ b/crates/consensus/service/src/lib.rs
@@ -42,13 +42,13 @@ pub use actors::{
     QueuedDerivationEngineClient, QueuedEngineDerivationClient, QueuedEngineRpcClient,
     QueuedL1WatcherDerivationClient, QueuedNetworkEngineClient, QueuedSequencerAdminAPIClient,
     QueuedSequencerEngineClient, QueuedUnsafePayloadGossipClient, ReconcileShadowRequest,
-    RecoveryModeGuard, ResetOrigin, ResetOutcome, ResetRequest, RpcActor, RpcActorError,
-    RpcContext, ScheduledTicker, SealState, SealStepError, SealStepOutcome, SequencerActor,
-    SequencerActorError, SequencerAdminQuery, SequencerConfig, SequencerEngineClient,
-    SequencerEngineRequestCoordinator, SequencerEngineState, ShadowCycle, ShadowReconciliationGate,
-    ShadowReconciliationTask, ShadowSequencingState, UnsafePayloadGossipClient,
-    UnsafePayloadGossipClientError, UnsealedPayloadHandle, UpgradeSignalMetricsActor,
-    UpgradeSignalNodeConfig, ValidatorEngineRequestHandler,
+    RecoveryModeGuard, ResetOrigin, ResetOutcome, ResetReason, ResetRequest, ResetRequestOutcome,
+    RpcActor, RpcActorError, RpcContext, ScheduledTicker, SealState, SealStepError,
+    SealStepOutcome, SequencerActor, SequencerActorError, SequencerAdminQuery, SequencerConfig,
+    SequencerEngineClient, SequencerEngineRequestCoordinator, SequencerEngineState, ShadowCycle,
+    ShadowReconciliationGate, ShadowReconciliationTask, ShadowSequencingState,
+    UnsafePayloadGossipClient, UnsafePayloadGossipClientError, UnsealedPayloadHandle,
+    UpgradeSignalMetricsActor, UpgradeSignalNodeConfig, ValidatorEngineRequestHandler,
 };
 
 mod metrics;

--- a/crates/consensus/service/src/metrics/mod.rs
+++ b/crates/consensus/service/src/metrics/mod.rs
@@ -70,7 +70,7 @@ base_metrics::define_metrics! {
         ]
     )]
     engine_reset_unsafe_rewind_depth_blocks: histogram,
-    #[describe("Wall-clock duration of a logical engine reset request")]
+    #[describe("Wall-clock duration of one engine reset request handling attempt")]
     #[label(
         name = "reason",
         default = [
@@ -135,7 +135,7 @@ base_metrics::define_metrics! {
 }
 
 impl Metrics {
-    /// Records one terminal logical engine reset request and any resulting unsafe-head rewind.
+    /// Records one engine reset handling attempt and any resulting unsafe-head rewind.
     pub fn record_engine_reset(
         origin: ResetOrigin,
         reason: ResetReason,

--- a/crates/consensus/service/src/metrics/mod.rs
+++ b/crates/consensus/service/src/metrics/mod.rs
@@ -20,11 +20,11 @@ base_metrics::define_metrics! {
     #[label(recovery)]
     sequencer_state: gauge,
     #[describe("Sequencer L1 origin RPC calls by method and outcome")]
-    #[label(name = "method", default = ["block_by_hash", "block_by_number"])]
+    #[label(name = "method", default = ["block_by_hash", "block_by_number", "block_receipts"])]
     #[label(name = "outcome", default = ["success", "not_found", "timeout", "error"])]
     sequencer_l1_origin_rpc_calls_total: counter,
     #[describe("Wall-clock duration of sequencer L1 origin RPC calls in seconds")]
-    #[label(name = "method", default = ["block_by_hash", "block_by_number"])]
+    #[label(name = "method", default = ["block_by_hash", "block_by_number", "block_receipts"])]
     #[label(name = "outcome", default = ["success", "not_found", "timeout", "error"])]
     sequencer_l1_origin_rpc_duration_seconds: histogram,
     #[describe("Duration of the sequencer attributes builder")]
@@ -59,6 +59,12 @@ base_metrics::define_metrics! {
     sequencer_recovery_mode_blocks_total: counter,
     #[describe("Empty blocks produced due to sequencer drift threshold")]
     sequencer_drift_empty_blocks_total: counter,
+    #[describe("L1 origin lookups served from the selected-origin slot")]
+    #[label(name = "kind", default = ["header", "receipts"])]
+    sequencer_l1_origin_buffer_hits_total: counter,
+    #[describe("L1 origin lookups that missed the selected-origin slot")]
+    #[label(name = "kind", default = ["header", "receipts"])]
+    sequencer_l1_origin_buffer_misses_total: counter,
     #[describe("Pre-built payloads discarded because the unsafe head advanced past their parent")]
     sequencer_stale_build_discarded_total: counter,
     #[describe("Configured verifier L1 confirmation depth")]

--- a/crates/consensus/service/src/metrics/mod.rs
+++ b/crates/consensus/service/src/metrics/mod.rs
@@ -35,7 +35,7 @@ base_metrics::define_metrics! {
     sequencer_l1_origin_rpc_duration_seconds: histogram,
     #[describe("Canonical L1 successors that do not extend the accepted sequencer origin")]
     sequencer_l1_origin_orphans_total: counter,
-    #[describe("Terminal engine reset requests by caller, cause, and outcome")]
+    #[describe("Engine reset handling attempts by caller, cause, and outcome")]
     #[label(
         name = "origin",
         default = ["derivation", "sequencer", "shadow_cycle_coordinated"]
@@ -53,7 +53,16 @@ base_metrics::define_metrics! {
             "shadow_cycle"
         ]
     )]
-    #[label(name = "outcome", default = ["unchanged", "rewound", "deferred", "failed"])]
+    #[label(
+        name = "outcome",
+        default = [
+            "unchanged",
+            "rewound",
+            "deferred",
+            "derivation_notification_failed",
+            "failed"
+        ]
+    )]
     engine_reset_outcomes_total: counter,
     #[describe("Unsafe L2 head rewind depth caused by an engine reset")]
     #[label(
@@ -84,7 +93,16 @@ base_metrics::define_metrics! {
             "shadow_cycle"
         ]
     )]
-    #[label(name = "outcome", default = ["unchanged", "rewound", "deferred", "failed"])]
+    #[label(
+        name = "outcome",
+        default = [
+            "unchanged",
+            "rewound",
+            "deferred",
+            "derivation_notification_failed",
+            "failed"
+        ]
+    )]
     engine_reset_duration_seconds: histogram,
     #[describe("Duration of the sequencer attributes builder")]
     sequencer_attributes_build_duration: histogram,
@@ -244,15 +262,29 @@ mod tests {
             Metrics::record_engine_reset(
                 ResetOrigin::Sequencer,
                 ResetReason::L1OriginOrphaned,
-                ResetRequestOutcome::Failed,
+                ResetRequestOutcome::DerivationNotificationFailed,
                 Duration::from_millis(5),
+                head(10, 1),
+                head(8, 2),
+            );
+            Metrics::record_engine_reset(
+                ResetOrigin::Sequencer,
+                ResetReason::L1OriginOrphaned,
+                ResetRequestOutcome::Failed,
+                Duration::from_millis(6),
                 head(10, 1),
                 head(10, 1),
             );
         });
 
         let snapshot = snapshotter.snapshot().into_vec();
-        for (outcome, count) in [("unchanged", 1), ("rewound", 2), ("deferred", 1), ("failed", 1)] {
+        for (outcome, count) in [
+            ("unchanged", 1),
+            ("rewound", 2),
+            ("deferred", 1),
+            ("derivation_notification_failed", 1),
+            ("failed", 1),
+        ] {
             assert_eq!(
                 metric(
                     &snapshot,
@@ -277,13 +309,15 @@ mod tests {
             Some(DebugValue::Histogram(values)) => {
                 assert_eq!(
                     values.iter().map(|value| value.into_inner()).collect::<Vec<_>>(),
-                    [3.0, 0.0]
+                    [3.0, 0.0, 2.0]
                 );
             }
             value => panic!("expected rewind-depth observations, got {value:?}"),
         }
 
-        for outcome in ["unchanged", "rewound", "deferred", "failed"] {
+        for outcome in
+            ["unchanged", "rewound", "deferred", "derivation_notification_failed", "failed"]
+        {
             assert!(matches!(
                 metric(
                     &snapshot,

--- a/crates/consensus/service/src/metrics/mod.rs
+++ b/crates/consensus/service/src/metrics/mod.rs
@@ -1,5 +1,11 @@
 //! Metrics for the node service
 
+use std::time::Duration;
+
+use base_protocol::L2BlockInfo;
+
+use crate::{ResetOrigin, ResetReason, ResetRequestOutcome};
+
 base_metrics::define_metrics! {
     base_node
     #[describe("L1 reorg count")]
@@ -27,6 +33,59 @@ base_metrics::define_metrics! {
     #[label(name = "method", default = ["block_by_hash", "block_by_number", "block_receipts"])]
     #[label(name = "outcome", default = ["success", "not_found", "timeout", "error"])]
     sequencer_l1_origin_rpc_duration_seconds: histogram,
+    #[describe("Canonical L1 successors that do not extend the accepted sequencer origin")]
+    sequencer_l1_origin_orphans_total: counter,
+    #[describe("Terminal engine reset requests by caller, cause, and outcome")]
+    #[label(
+        name = "origin",
+        default = ["derivation", "sequencer", "shadow_cycle_coordinated"]
+    )]
+    #[label(
+        name = "reason",
+        default = [
+            "derivation_pipeline",
+            "derivation_l1_reorg",
+            "l1_origin_unavailable",
+            "l1_origin_orphaned",
+            "l1_origin_inconsistent",
+            "sequencer_startup",
+            "admin",
+            "shadow_cycle"
+        ]
+    )]
+    #[label(name = "outcome", default = ["unchanged", "rewound", "deferred", "failed"])]
+    engine_reset_outcomes_total: counter,
+    #[describe("Unsafe L2 head rewind depth caused by an engine reset")]
+    #[label(
+        name = "reason",
+        default = [
+            "derivation_pipeline",
+            "derivation_l1_reorg",
+            "l1_origin_unavailable",
+            "l1_origin_orphaned",
+            "l1_origin_inconsistent",
+            "sequencer_startup",
+            "admin",
+            "shadow_cycle"
+        ]
+    )]
+    engine_reset_unsafe_rewind_depth_blocks: histogram,
+    #[describe("Wall-clock duration of a logical engine reset request")]
+    #[label(
+        name = "reason",
+        default = [
+            "derivation_pipeline",
+            "derivation_l1_reorg",
+            "l1_origin_unavailable",
+            "l1_origin_orphaned",
+            "l1_origin_inconsistent",
+            "sequencer_startup",
+            "admin",
+            "shadow_cycle"
+        ]
+    )]
+    #[label(name = "outcome", default = ["unchanged", "rewound", "deferred", "failed"])]
+    engine_reset_duration_seconds: histogram,
     #[describe("Duration of the sequencer attributes builder")]
     sequencer_attributes_build_duration: histogram,
     #[describe("Duration of the sequencer block building start task")]
@@ -73,4 +132,167 @@ base_metrics::define_metrics! {
     l1_verifier_derivation_head: counter,
     #[describe("Failed attempts to fetch a delayed L1 block for verifier confirmation")]
     l1_verifier_delayed_fetch_errors: counter,
+}
+
+impl Metrics {
+    /// Records one terminal logical engine reset request and any resulting unsafe-head rewind.
+    pub fn record_engine_reset(
+        origin: ResetOrigin,
+        reason: ResetReason,
+        outcome: ResetRequestOutcome,
+        duration: Duration,
+        unsafe_before: L2BlockInfo,
+        unsafe_after: L2BlockInfo,
+    ) {
+        Self::engine_reset_outcomes_total(origin.as_str(), reason.as_str(), outcome.as_str())
+            .increment(1);
+        Self::engine_reset_duration_seconds(reason.as_str(), outcome.as_str()).record(duration);
+        if unsafe_before.block_info.number != unsafe_after.block_info.number
+            || unsafe_before.block_info.hash != unsafe_after.block_info.hash
+        {
+            Self::engine_reset_unsafe_rewind_depth_blocks(reason.as_str()).record(
+                unsafe_before.block_info.number.saturating_sub(unsafe_after.block_info.number)
+                    as f64,
+            );
+        }
+    }
+}
+
+#[cfg(all(test, feature = "metrics"))]
+mod tests {
+    use alloy_primitives::B256;
+    use base_protocol::{BlockInfo, L2BlockInfo};
+    use metrics_util::{
+        CompositeKey, MetricKind,
+        debugging::{DebugValue, DebuggingRecorder},
+    };
+
+    use super::*;
+
+    type SnapshotEntry =
+        (CompositeKey, Option<metrics::Unit>, Option<metrics::SharedString>, DebugValue);
+
+    fn metric<'a>(
+        snapshot: &'a [SnapshotEntry],
+        kind: MetricKind,
+        name: &str,
+        labels: &[(&str, &str)],
+    ) -> Option<&'a DebugValue> {
+        snapshot
+            .iter()
+            .find(|(key, _, _, _)| {
+                key.kind() == kind
+                    && key.key().name() == name
+                    && labels.iter().all(|(expected_key, expected_value)| {
+                        key.key().labels().any(|label| {
+                            label.key() == *expected_key && label.value() == *expected_value
+                        })
+                    })
+            })
+            .map(|(_, _, _, value)| value)
+    }
+
+    fn head(number: u64, hash: u8) -> L2BlockInfo {
+        L2BlockInfo {
+            block_info: BlockInfo {
+                number,
+                hash: B256::with_last_byte(hash),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn records_reset_outcomes_and_rewind_depths() {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+
+        metrics::with_local_recorder(&recorder, || {
+            Metrics::record_engine_reset(
+                ResetOrigin::Sequencer,
+                ResetReason::L1OriginOrphaned,
+                ResetRequestOutcome::from_unsafe_heads(head(10, 1), head(10, 1)),
+                Duration::from_millis(1),
+                head(10, 1),
+                head(10, 1),
+            );
+            Metrics::record_engine_reset(
+                ResetOrigin::Sequencer,
+                ResetReason::L1OriginOrphaned,
+                ResetRequestOutcome::from_unsafe_heads(head(10, 1), head(7, 2)),
+                Duration::from_millis(2),
+                head(10, 1),
+                head(7, 2),
+            );
+            Metrics::record_engine_reset(
+                ResetOrigin::Sequencer,
+                ResetReason::L1OriginOrphaned,
+                ResetRequestOutcome::from_unsafe_heads(head(10, 1), head(10, 2)),
+                Duration::from_millis(3),
+                head(10, 1),
+                head(10, 2),
+            );
+            Metrics::record_engine_reset(
+                ResetOrigin::Sequencer,
+                ResetReason::L1OriginOrphaned,
+                ResetRequestOutcome::Deferred,
+                Duration::from_millis(4),
+                head(10, 1),
+                head(10, 1),
+            );
+            Metrics::record_engine_reset(
+                ResetOrigin::Sequencer,
+                ResetReason::L1OriginOrphaned,
+                ResetRequestOutcome::Failed,
+                Duration::from_millis(5),
+                head(10, 1),
+                head(10, 1),
+            );
+        });
+
+        let snapshot = snapshotter.snapshot().into_vec();
+        for (outcome, count) in [("unchanged", 1), ("rewound", 2), ("deferred", 1), ("failed", 1)] {
+            assert_eq!(
+                metric(
+                    &snapshot,
+                    MetricKind::Counter,
+                    "base_node.engine_reset_outcomes_total",
+                    &[
+                        ("origin", "sequencer"),
+                        ("reason", "l1_origin_orphaned"),
+                        ("outcome", outcome),
+                    ],
+                ),
+                Some(&DebugValue::Counter(count)),
+            );
+        }
+
+        match metric(
+            &snapshot,
+            MetricKind::Histogram,
+            "base_node.engine_reset_unsafe_rewind_depth_blocks",
+            &[("reason", "l1_origin_orphaned")],
+        ) {
+            Some(DebugValue::Histogram(values)) => {
+                assert_eq!(
+                    values.iter().map(|value| value.into_inner()).collect::<Vec<_>>(),
+                    [3.0, 0.0]
+                );
+            }
+            value => panic!("expected rewind-depth observations, got {value:?}"),
+        }
+
+        for outcome in ["unchanged", "rewound", "deferred", "failed"] {
+            assert!(matches!(
+                metric(
+                    &snapshot,
+                    MetricKind::Histogram,
+                    "base_node.engine_reset_duration_seconds",
+                    &[("reason", "l1_origin_orphaned"), ("outcome", outcome)],
+                ),
+                Some(DebugValue::Histogram(values)) if !values.is_empty()
+            ));
+        }
+    }
 }

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -31,11 +31,12 @@ use crate::{
     DerivationActor, DerivationDelegateClient, DerivationError, EngineActor, EngineActorRequest,
     EngineConfig, EngineProcessor, EngineRequestReceiver, EngineRpcProcessor, L1OriginSelector,
     L1WatcherActor, L1WatcherQueryProcessor, NetworkActor, NetworkBuilder, NetworkConfig,
-    NodeActor, NodeMode, PayloadBuilder, QueuedDerivationEngineClient,
-    QueuedEngineDerivationClient, QueuedEngineRpcClient, QueuedL1WatcherDerivationClient,
-    QueuedNetworkEngineClient, QueuedSequencerAdminAPIClient, QueuedSequencerEngineClient,
-    RecoveryModeGuard, RpcActor, RpcContext, SequencerActor, SequencerConfig,
-    SequencerEngineRequestCoordinator, UpgradeSignalNodeConfig, ValidatorEngineRequestHandler,
+    NodeActor, NodeMode, PayloadBuilder, PrefetchedChainProvider, PreparedL1Origin,
+    QueuedDerivationEngineClient, QueuedEngineDerivationClient, QueuedEngineRpcClient,
+    QueuedL1WatcherDerivationClient, QueuedNetworkEngineClient, QueuedSequencerAdminAPIClient,
+    QueuedSequencerEngineClient, RecoveryModeGuard, RpcActor, RpcContext, SequencerActor,
+    SequencerConfig, SequencerEngineRequestCoordinator, UpgradeSignalNodeConfig,
+    ValidatorEngineRequestHandler,
     actors::{BlockStream, NetworkInboundData, QueuedUnsafePayloadGossipClient},
 };
 
@@ -204,15 +205,17 @@ impl RollupNode {
         self.rpc_builder.clone()
     }
 
-    /// Returns the sequencer builder for the node.
+    /// Returns the sequencer attributes builder for the node.
     fn create_attributes_builder(
         &self,
-    ) -> StatefulAttributesBuilder<AlloyChainProvider, AlloyL2ChainProvider> {
-        let l1_derivation_provider = AlloyChainProvider::new_with_trust(
+        origin_rx: watch::Receiver<Option<PreparedL1Origin>>,
+    ) -> StatefulAttributesBuilder<PrefetchedChainProvider, AlloyL2ChainProvider> {
+        let l1_fallback_provider = AlloyChainProvider::new_with_trust(
             self.sequencer_l1_provider.clone(),
             DERIVATION_PROVIDER_CACHE_SIZE,
             self.l1_config.trust_rpc,
         );
+        let l1_derivation_provider = PrefetchedChainProvider::new(origin_rx, l1_fallback_provider);
         let l2_derivation_provider = AlloyL2ChainProvider::new_with_trust(
             self.l2_provider.clone(),
             Arc::clone(&self.config),
@@ -526,14 +529,6 @@ impl RollupNode {
         .map_err(|e| format!("Failed to start network actor: {e}"))?;
 
         let (l1_head_updates_tx, l1_head_updates_rx) = watch::channel(None);
-        let delayed_l1_provider = DelayedL1OriginSelectorProvider::new(
-            self.sequencer_l1_provider.clone(),
-            l1_head_updates_rx,
-            self.sequencer_config.l1_conf_delay,
-        );
-
-        let delayed_origin_selector =
-            L1OriginSelector::new(Arc::clone(&self.config), delayed_l1_provider);
 
         // Create the L1 Watcher actor
 
@@ -582,6 +577,15 @@ impl RollupNode {
         let node_mode = self.mode();
         // Create the sequencer if needed
         let (sequencer_actor, sequencer_admin_client) = if node_mode.is_sequencer() {
+            let delayed_l1_provider = DelayedL1OriginSelectorProvider::new(
+                self.sequencer_l1_provider.clone(),
+                l1_head_updates_rx,
+                self.sequencer_config.l1_conf_delay,
+            );
+            let delayed_origin_selector =
+                L1OriginSelector::new(Arc::clone(&self.config), delayed_l1_provider);
+            let attributes_builder =
+                self.create_attributes_builder(delayed_origin_selector.subscribe());
             let sequencer_engine_client = QueuedSequencerEngineClient {
                 engine_actor_request_tx: engine_actor_request_tx.clone(),
                 unsafe_head_rx,
@@ -600,7 +604,7 @@ impl RollupNode {
                 Some(SequencerActor {
                     admin_api_rx: sequencer_admin_api_rx,
                     builder: PayloadBuilder {
-                        attributes_builder: self.create_attributes_builder(),
+                        attributes_builder,
                         engine_client: Arc::clone(&engine_client),
                         origin_selector: delayed_origin_selector,
                         recovery_mode: recovery_mode.clone(),


### PR DESCRIPTION
This PR moves L1 origin RPC work off the sequencer block production path. The origin selector prefetches hash checked headers and receipts in the background, then publishes the selected data to the attributes builder. The sequencer can keep building on its accepted origin during temporary L1 RPC outages while drift permits and never waits for an unfinished successor fetch. A current origin may use the RPC fallback for missing receipts, but a successor is not adopted until its receipts are available.

Prefetches are tied to the accepted origin and observed L1 chain view. If a canonical successor no longer extends the accepted origin, the sequencer requests an engine reset. Reset validates the origin of each unsafe L2 block against the canonical L1 block at the same height, walks backward without crossing finalized L2, applies the corrected forkchoice, and resets derivation. Origins ahead of the visible L1 head remain plausible and do not cause a false rewind.

Metrics report L1 origin RPC outcomes and latency, orphaned origins, reset outcomes, derivation notification failures, unsafe rewind depth, reset duration, and forkchoice walk cost.

Tests cover prefetched origin reuse, temporary L1 outages, missing receipts, stale chain view invalidation, nonblocking selection, drift retry pacing, same height L1 replacements, orphan resets, finalized boundary enforcement, and derivation recovery. The consensus node, engine, action harness, formatting, and clippy checks pass.
