### PR TITLE
feat(txpool): add validity predicates to BasePooledTransaction

### DIFF
--- a/crates/execution/txpool/src/lib.rs
+++ b/crates/execution/txpool/src/lib.rs
@@ -27,6 +27,9 @@ pub use validator::{BaseL1BlockInfo, BaseTransactionValidator, BaseTxPoolError, 
 
 mod best;
 
+mod validity;
+pub use validity::{ValidityOperator, ValidityPredicate};
+
 mod transaction;
 pub use transaction::{
     BLOCK_TIME_SECS, BasePooledTransaction, BasePooledTx, BundleTransaction,

--- a/crates/execution/txpool/src/transaction.rs
+++ b/crates/execution/txpool/src/transaction.rs
@@ -75,6 +75,9 @@ pub struct BasePooledTransaction<
     /// Optional maximum timestamp (millis since Unix epoch) from bundle submission.
     /// The transaction should be evicted after this time.
     max_timestamp: Option<u64>,
+    /// State predicates that must hold before this transaction is eligible for
+    /// inclusion.
+    validity_predicates: Vec<crate::ValidityPredicate>,
     /// The set of on-chain state surfaces whose change invalidates this
     /// transaction, computed once during validation and consumed by the pool's
     /// invalidation index. Empty until set; see [`crate::WatchSet`].
@@ -114,6 +117,7 @@ impl<Cons: SignedTransaction, Pooled> BasePooledTransaction<Cons, Pooled> {
             max_block_number: None,
             min_timestamp: None,
             max_timestamp: None,
+            validity_predicates: Vec::new(),
             watch_set: OnceLock::new(),
             limit_class: OnceLock::new(),
             watch_manifest: OnceLock::new(),
@@ -133,6 +137,22 @@ impl<Cons: SignedTransaction, Pooled> BasePooledTransaction<Cons, Pooled> {
         self.min_timestamp = min_timestamp;
         self.max_timestamp = max_timestamp;
         self
+    }
+
+    /// Sets the state predicates required for this transaction's inclusion.
+    #[must_use]
+    pub fn with_validity_predicates(
+        mut self,
+        validity_predicates: Vec<crate::ValidityPredicate>,
+    ) -> Self {
+        self.validity_predicates = validity_predicates;
+        self
+    }
+
+    /// Returns the state predicates required for this transaction's inclusion.
+    #[must_use]
+    pub fn validity_predicates(&self) -> &[crate::ValidityPredicate] {
+        &self.validity_predicates
     }
 
     /// Returns the estimated compressed size of a transaction in bytes.
@@ -229,14 +249,17 @@ impl<Cons: InMemorySize, Pooled> InMemorySize for BasePooledTransaction<Cons, Po
             .watch_manifest
             .get()
             .map_or(0, |manifest| core::mem::size_of_val(manifest.config_slots()));
+        let validity_predicates_size = core::mem::size_of_val(self.validity_predicates.as_slice());
         self.inner.size()
             + core::mem::size_of::<u128>()
             + core::mem::size_of::<Option<u64>>() * 4
+            + core::mem::size_of::<Vec<crate::ValidityPredicate>>()
             + core::mem::size_of::<OnceLock<crate::WatchSet>>()
             + watch_keys_size
             + core::mem::size_of::<OnceLock<crate::LimitClass>>()
             + core::mem::size_of::<OnceLock<crate::WatchManifest>>()
             + manifest_slots_size
+            + validity_predicates_size
     }
 }
 
@@ -353,6 +376,14 @@ pub trait BasePooledTx: PoolTransaction + DataAvailabilitySized {
     /// Returns the EIP-2718 encoded bytes of the transaction.
     fn encoded_2718(&self) -> Cow<'_, Bytes>;
 
+    /// Returns state predicates required for this transaction's inclusion.
+    ///
+    /// Defaults to an empty slice for transaction types that do not carry
+    /// validity predicates.
+    fn validity_predicates(&self) -> &[crate::ValidityPredicate] {
+        &[]
+    }
+
     /// Returns the signed EIP-8130 payload when this transaction carries one.
     ///
     /// Required for the mempool validator's structural admission checks; the
@@ -423,6 +454,10 @@ where
 {
     fn encoded_2718(&self) -> Cow<'_, Bytes> {
         Cow::Borrowed(self.encoded_2718())
+    }
+
+    fn validity_predicates(&self) -> &[crate::ValidityPredicate] {
+        &self.validity_predicates
     }
 
     fn as_eip8130(&self) -> Option<&Eip8130Signed> {
@@ -595,7 +630,7 @@ mod tests {
 
     use crate::{
         BasePooledTransaction, BasePooledTx, BaseTransactionValidator, ConfigSlot, InvalidationKey,
-        WatchManifest, WatchSet,
+        ValidityOperator, ValidityPredicate, WatchManifest, WatchSet,
     };
 
     fn signer() -> PrivateKeySigner {
@@ -706,5 +741,22 @@ mod tests {
         transaction.set_watch_manifest(manifest);
 
         assert_eq!(transaction.size(), size_without_slots + slots_size);
+    }
+
+    #[test]
+    fn retains_validity_predicates() {
+        let predicate = ValidityPredicate::Balance {
+            address: Address::repeat_byte(1),
+            op: ValidityOperator::GreaterThanOrEqual,
+            value: U256::from(1),
+        };
+        let transaction =
+            eip8130_pooled(U256::ZERO).with_validity_predicates(vec![predicate.clone()]);
+
+        assert_eq!(transaction.validity_predicates(), core::slice::from_ref(&predicate));
+        assert_eq!(
+            BasePooledTx::validity_predicates(&transaction),
+            core::slice::from_ref(&predicate)
+        );
     }
 }

--- a/crates/execution/txpool/src/validity.rs
+++ b/crates/execution/txpool/src/validity.rs
@@ -1,0 +1,187 @@
+//! State predicates carried by pooled transactions.
+
+use alloy_primitives::{Address, U256};
+
+/// A comparison used by a [`ValidityPredicate`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub enum ValidityOperator {
+    /// Less than.
+    #[serde(rename = "<")]
+    LessThan,
+    /// Less than or equal to.
+    #[serde(rename = "<=")]
+    LessThanOrEqual,
+    /// Equal to.
+    #[serde(rename = "=")]
+    Equal,
+    /// Not equal to.
+    #[serde(rename = "!=")]
+    NotEqual,
+    /// Greater than.
+    #[serde(rename = ">")]
+    GreaterThan,
+    /// Greater than or equal to.
+    #[serde(rename = ">=")]
+    GreaterThanOrEqual,
+}
+
+impl ValidityOperator {
+    /// Returns whether `left op right` holds.
+    #[must_use]
+    pub fn matches(self, left: U256, right: U256) -> bool {
+        match self {
+            Self::LessThan => left < right,
+            Self::LessThanOrEqual => left <= right,
+            Self::Equal => left == right,
+            Self::NotEqual => left != right,
+            Self::GreaterThan => left > right,
+            Self::GreaterThanOrEqual => left >= right,
+        }
+    }
+}
+
+/// A declared state condition for a transaction.
+///
+/// The JSON representation uses a `type` tag and a `params` object, accepting
+/// either `balance` or `storage`. A `storage` predicate compares
+/// `storage(address, slot) & mask` with `value`; omitted masks default to
+/// [`U256::MAX`]. A `balance` predicate has the same comparison fields but
+/// does not accept `slot` or `mask`.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(tag = "type", content = "params", rename_all = "lowercase", deny_unknown_fields)]
+pub enum ValidityPredicate {
+    /// Compares an account balance with a value.
+    Balance {
+        /// Account whose balance is read.
+        address: Address,
+        /// Comparison to apply to the account balance.
+        op: ValidityOperator,
+        /// Right-hand comparison value.
+        value: U256,
+    },
+    /// Compares a masked storage value with a value.
+    Storage {
+        /// Contract whose storage is read.
+        address: Address,
+        /// Storage slot to read.
+        slot: U256,
+        /// Bit mask applied to the loaded storage value.
+        #[serde(default = "ValidityPredicate::default_mask")]
+        mask: U256,
+        /// Comparison to apply to the masked storage value.
+        op: ValidityOperator,
+        /// Right-hand comparison value.
+        value: U256,
+    },
+}
+
+impl ValidityPredicate {
+    /// Returns the default mask for storage predicates.
+    #[must_use]
+    pub const fn default_mask() -> U256 {
+        U256::MAX
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn deserializes_storage_predicate_with_default_mask() {
+        let predicate: ValidityPredicate = serde_json::from_str(
+            r#"{"type":"storage","params":{"address":"0x1111111111111111111111111111111111111111","slot":"0x7","op":"=","value":"0x12ab"}}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            predicate,
+            ValidityPredicate::Storage {
+                address: Address::repeat_byte(0x11),
+                slot: U256::from(7),
+                mask: U256::MAX,
+                op: ValidityOperator::Equal,
+                value: U256::from(0x12ab),
+            }
+        );
+    }
+
+    #[test]
+    fn predicate_json_rejects_fields_not_supported_by_its_type() {
+        let balance_with_slot = r#"{"type":"balance","params":{"address":"0x1111111111111111111111111111111111111111","slot":"0x7","op":"=","value":"0x0"}}"#;
+        let storage_without_slot = r#"{"type":"storage","params":{"address":"0x1111111111111111111111111111111111111111","op":"=","value":"0x0"}}"#;
+
+        assert!(serde_json::from_str::<ValidityPredicate>(balance_with_slot).is_err());
+        assert!(serde_json::from_str::<ValidityPredicate>(storage_without_slot).is_err());
+    }
+
+    #[test]
+    fn predicate_json_rejects_flattened_parameters() {
+        let flattened = r#"{"type":"balance","address":"0x1111111111111111111111111111111111111111","op":"=","value":"0x0"}"#;
+
+        assert!(serde_json::from_str::<ValidityPredicate>(flattened).is_err());
+    }
+
+    #[test]
+    fn serializes_predicate_parameters_under_params() {
+        let predicate = ValidityPredicate::Balance {
+            address: Address::repeat_byte(0x11),
+            op: ValidityOperator::GreaterThanOrEqual,
+            value: U256::from(1),
+        };
+
+        assert_eq!(
+            serde_json::to_value(predicate).unwrap(),
+            json!({
+                "type": "balance",
+                "params": {
+                    "address": "0x1111111111111111111111111111111111111111",
+                    "op": ">=",
+                    "value": "0x1",
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn deserializes_every_comparison_operator() {
+        for (op, expected) in [
+            ("<", ValidityOperator::LessThan),
+            ("<=", ValidityOperator::LessThanOrEqual),
+            ("=", ValidityOperator::Equal),
+            ("!=", ValidityOperator::NotEqual),
+            (">", ValidityOperator::GreaterThan),
+            (">=", ValidityOperator::GreaterThanOrEqual),
+        ] {
+            let predicate: ValidityPredicate = serde_json::from_str(&format!(
+                r#"{{"type":"balance","params":{{"address":"0x1111111111111111111111111111111111111111","op":"{op}","value":"0x0"}}}}"#
+            ))
+            .unwrap();
+
+            assert_eq!(
+                predicate,
+                ValidityPredicate::Balance {
+                    address: Address::repeat_byte(0x11),
+                    op: expected,
+                    value: U256::ZERO,
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn comparison_operators_match_expected_values() {
+        for (op, expected) in [
+            (ValidityOperator::LessThan, true),
+            (ValidityOperator::LessThanOrEqual, true),
+            (ValidityOperator::Equal, false),
+            (ValidityOperator::NotEqual, true),
+            (ValidityOperator::GreaterThan, false),
+            (ValidityOperator::GreaterThanOrEqual, false),
+        ] {
+            assert_eq!(op.matches(U256::from(10), U256::from(11)), expected);
+        }
+    }
+}


### PR DESCRIPTION
Add predicates for `balance` and `storage`, operators for (`<`, `<=`, `=`, `!=`, `>`, `>=`)