### PR TITLE
fix(batcher): Reanchor Forward Safe Head Reorgs

### DIFF
--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -1,6 +1,6 @@
 //! The async batch driver that orchestrates encoding, block sourcing, and L1 submission.
 
-use std::time::Duration;
+use std::{collections::VecDeque, time::Duration};
 
 use base_batcher_encoder::{BatchPipeline, StepResult};
 use base_batcher_source::{
@@ -53,6 +53,8 @@ where
     l1_head_source: Option<L>,
     /// Last trusted L2 safe head.
     safe_head: Option<BlockInfo>,
+    /// Contiguous accepted chain from the safe head through the latest unsafe block.
+    block_history: VecDeque<BlockInfo>,
     /// Ordered safe-head updates.
     safe_head_rx: Option<mpsc::Receiver<BlockInfo>>,
     /// Maximum wall-clock time to wait for in-flight submissions to settle
@@ -141,6 +143,7 @@ where
     ) -> Self {
         let (l1_head_source, safe_head_feed) = head_sources;
         let (safe_head, safe_head_rx) = safe_head_feed.unzip();
+        let block_history = safe_head.iter().copied().collect();
         Self {
             runtime,
             pipeline,
@@ -153,6 +156,7 @@ where
             throttle,
             l1_head_source: Some(l1_head_source),
             safe_head,
+            block_history,
             safe_head_rx,
             drain_timeout: config.drain_timeout,
             stopped: false,
@@ -166,6 +170,8 @@ where
     #[cfg(any(test, feature = "test-utils"))]
     pub fn with_safe_head_rx(mut self, initial: BlockInfo, rx: mpsc::Receiver<BlockInfo>) -> Self {
         self.safe_head = Some(initial);
+        self.block_history.clear();
+        self.block_history.push_back(initial);
         self.safe_head_rx = Some(rx);
         self
     }
@@ -333,28 +339,42 @@ where
             self.source.reset_catchup(safe_head);
         }
 
+        self.reset_block_history();
         self.discard_pending_flush_acks();
+    }
+
+    /// Retain only the current safe head as the accepted-chain anchor.
+    fn reset_block_history(&mut self) {
+        self.block_history.clear();
+        if let Some(safe_head) = self.safe_head {
+            self.block_history.push_back(safe_head);
+        }
     }
 
     /// Apply an ordered safe-head update.
     fn on_safe_head(&mut self, head: BlockInfo) {
         let previous = self.safe_head.replace(head);
+        let known_index = self
+            .block_history
+            .iter()
+            .position(|block| block.number == head.number && block.hash == head.hash);
 
-        if let Some(previous) = previous.filter(|previous| {
-            head.number < previous.number
-                || (head.number == previous.number && head.hash != previous.hash)
-        }) {
+        let Some(known_index) = known_index else {
             warn!(
-                previous_safe_l2 = %previous.number,
-                previous_safe_hash = %previous.hash,
+                previous_safe_l2 = ?previous.map(|block| block.number),
+                previous_safe_hash = ?previous.map(|block| block.hash),
                 safe_l2 = %head.number,
                 safe_hash = %head.hash,
-                "safe L2 head changed chain, resetting pipeline"
+                "safe L2 head is not on the accepted chain, resetting pipeline"
             );
             self.reset_to_safe_head();
             return;
-        }
+        };
 
+        self.block_history.drain(..known_index);
+        if let Some(anchor) = self.block_history.front_mut() {
+            *anchor = head;
+        }
         self.pipeline.prune_safe(head.number);
         debug!(safe_l2_number = %head.number, "pruned safe L2 blocks");
     }
@@ -391,8 +411,26 @@ where
             return;
         }
 
+        let block_info = BlockInfo::from(block.as_ref());
+        if let Some(tip) = self.block_history.back()
+            && (number != tip.number.saturating_add(1) || block.header.parent_hash != tip.hash)
+        {
+            warn!(
+                block = %number,
+                expected = %tip.number.saturating_add(1),
+                expected_parent = %tip.hash,
+                received_parent = %block.header.parent_hash,
+                "L2 block is not the next child of the accepted chain, resetting pipeline"
+            );
+            self.reset_to_safe_head();
+            return;
+        }
+
         match self.pipeline.add_block(*block) {
             Ok(()) => {
+                if self.safe_head.is_some() {
+                    self.block_history.push_back(block_info);
+                }
                 debug!(block = %number, "added unsafe block to pipeline");
             }
             Err((e, _block)) => {
@@ -445,6 +483,7 @@ where
                         AdminCommand::Pause => {
                             self.submissions.discard();
                             self.pipeline.reset();
+                            self.reset_block_history();
                             self.stopped = true;
                             self.discard_pending_flush_acks();
                             info!(stopped = true, "batcher paused via admin");
@@ -452,6 +491,7 @@ where
                         AdminCommand::Resume => {
                             if let Some(safe_head) = self.safe_head {
                                 self.source.reset_catchup(safe_head);
+                                self.reset_block_history();
                                 info!(
                                     stopped = false,
                                     safe_l2 = %safe_head.number,

--- a/crates/batcher/core/tests/heads.rs
+++ b/crates/batcher/core/tests/heads.rs
@@ -1,11 +1,16 @@
 //! Integration tests for L1 and safe L2 head handling in [`BatchDriver`].
+//!
+//! [`TrackingChannelSource`] is hand-rolled because this integration test needs to coordinate
+//! live block delivery with safe-head updates while retaining a shared log of reset requests.
 
 use std::{
     sync::{Arc, Mutex},
     time::Duration,
 };
 
+use alloy_consensus::Header;
 use alloy_primitives::{Address, B256};
+use async_trait::async_trait;
 use base_batcher_core::{
     BatchDriver, BatchDriverConfig, BatchDriverError, DaThrottle, NoopThrottleClient,
     ThrottleController,
@@ -14,7 +19,10 @@ use base_batcher_core::{
         SubmissionStub, TrackingPipeline, TrackingSource,
     },
 };
-use base_batcher_source::{ChannelL1HeadSource, L1HeadEvent};
+use base_batcher_source::{
+    ChannelL1HeadSource, L1HeadEvent, L2BlockEvent, SourceError, UnsafeBlockSource,
+};
+use base_common_consensus::BaseBlock;
 use base_protocol::BlockInfo;
 use base_runtime::{
     Cancellation, Clock, Spawner,
@@ -22,8 +30,45 @@ use base_runtime::{
 };
 use tokio::sync::mpsc;
 
+#[derive(Debug)]
+struct TrackingChannelSource {
+    rx: mpsc::UnboundedReceiver<L2BlockEvent>,
+    catchup_heads: Arc<Mutex<Vec<BlockInfo>>>,
+}
+
+impl TrackingChannelSource {
+    fn new() -> (Self, mpsc::UnboundedSender<L2BlockEvent>, Arc<Mutex<Vec<BlockInfo>>>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let catchup_heads = Arc::new(Mutex::new(Vec::new()));
+        (Self { rx, catchup_heads: Arc::clone(&catchup_heads) }, tx, catchup_heads)
+    }
+}
+
+#[async_trait]
+impl UnsafeBlockSource for TrackingChannelSource {
+    async fn next(&mut self) -> Result<L2BlockEvent, SourceError> {
+        self.rx.recv().await.ok_or(SourceError::Exhausted)
+    }
+
+    fn reset_catchup(&mut self, safe_head: BlockInfo) {
+        self.catchup_heads.lock().unwrap().push(safe_head);
+    }
+}
+
 fn safe_head(number: u64) -> BlockInfo {
     BlockInfo { hash: B256::with_last_byte(number as u8), number, ..Default::default() }
+}
+
+fn child_block(parent: BlockInfo, number: u64) -> BaseBlock {
+    BaseBlock {
+        header: Header {
+            number,
+            parent_hash: parent.hash,
+            extra_data: vec![number as u8].into(),
+            ..Default::default()
+        },
+        body: Default::default(),
+    }
 }
 
 /// When the L1 head source delivers a new head, the driver must call
@@ -140,15 +185,68 @@ fn test_safe_head_regression_and_chain_mismatch_reset_pipeline() {
             BlockInfo { hash: B256::repeat_byte(0xff), number: 5, ..Default::default() };
         safe_tx.send(regressed).await.unwrap();
         safe_tx.send(replacement).await.unwrap();
-        safe_tx.send(safe_head(10)).await.unwrap();
         ctx.sleep(Duration::from_millis(50)).await;
         ctx.cancel();
 
         assert!(handle.await.unwrap().is_ok());
         let recorded = recorded.lock().unwrap();
         assert_eq!(recorded.resets, 2);
-        assert_eq!(recorded.safe_numbers, vec![10]);
+        assert!(recorded.safe_numbers.is_empty());
         assert_eq!(*catchup_heads.lock().unwrap(), vec![regressed, replacement]);
+    });
+}
+
+#[test]
+fn test_forward_safe_head_replacement_reanchors_to_new_chain() {
+    Runner::start(Config::seeded(0), |ctx| async move {
+        let recorded = Arc::new(Mutex::new(Recorded::default()));
+        let pipeline = TrackingPipeline::new(Arc::clone(&recorded));
+        let (safe_tx, safe_rx) = mpsc::channel(1);
+        let (source, block_tx, catchup_heads) = TrackingChannelSource::new();
+        let initial_safe = safe_head(80);
+
+        let driver = BatchDriver::new(
+            ctx.clone(),
+            pipeline,
+            source,
+            ImmediateConfirmTxManager { l1_block: 1 },
+            BatchDriverConfig {
+                inbox: Address::ZERO,
+                max_pending_transactions: 1,
+                drain_timeout: Duration::from_millis(10),
+                force_blobs_when_throttling: true,
+            },
+            DaThrottle::new(ThrottleController::noop(), Arc::new(NoopThrottleClient)),
+            (PendingL1HeadSource, initial_safe, safe_rx),
+        );
+        let handle = ctx.spawn(driver.run());
+
+        let mut parent = initial_safe;
+        let mut canonical_safe = initial_safe;
+        for number in 81..=100 {
+            let block = child_block(parent, number);
+            parent = BlockInfo::from(&block);
+            if number == 90 {
+                canonical_safe = parent;
+            }
+            block_tx.send(L2BlockEvent::Block(Box::new(block))).unwrap();
+        }
+        ctx.sleep(Duration::from_millis(50)).await;
+
+        safe_tx.send(canonical_safe).await.unwrap();
+        ctx.sleep(Duration::from_millis(50)).await;
+
+        let replacement =
+            BlockInfo { hash: B256::repeat_byte(0xff), number: 95, ..Default::default() };
+        safe_tx.send(replacement).await.unwrap();
+        ctx.sleep(Duration::from_millis(50)).await;
+        ctx.cancel();
+
+        assert!(handle.await.unwrap().is_ok());
+        let recorded = recorded.lock().unwrap();
+        assert_eq!(recorded.safe_numbers, vec![90]);
+        assert_eq!(recorded.resets, 1);
+        assert_eq!(*catchup_heads.lock().unwrap(), vec![replacement]);
     });
 }
 


### PR DESCRIPTION
## Summary

Track the contiguous safe-to-unsafe L2 chain accepted by the batcher driver so sampled forward safe-head replacements are detected by hash. Unknown or conflicting safe heads now reset the pipeline and reanchor ordered polling immediately, while known canonical advances continue to prune without replay. Add deterministic coverage for a numerically forward replacement after normal safe-head advancement.