### PR TITLE
feat(txpool): Add Validity Transaction Submission RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6602,6 +6602,7 @@ dependencies = [
 name = "base-txpool-rpc"
 version = "0.0.0"
 dependencies = [
+ "alloy-eips 2.2.0",
  "alloy-primitives",
  "base-node-runner",
  "eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6548,6 +6548,7 @@ dependencies = [
  "base-node-runner",
  "base-observability-events",
  "base-test-utils",
+ "base-txpool-rpc",
  "eyre",
  "futures",
  "jsonrpsee",
@@ -6602,12 +6603,13 @@ dependencies = [
 name = "base-txpool-rpc"
 version = "0.0.0"
 dependencies = [
- "alloy-eips 2.2.0",
  "alloy-primitives",
+ "base-execution-txpool",
  "base-node-runner",
  "eyre",
  "httpmock",
  "jsonrpsee",
+ "reth-rpc-eth-types",
  "reth-rpc-server-types",
  "reth-transaction-pool",
  "serde",

--- a/bin/base/src/commands/sequencer.rs
+++ b/bin/base/src/commands/sequencer.rs
@@ -68,6 +68,7 @@ impl SequencerCommand {
         let sequencer_rpc = rollup_args.sequencer.clone();
         let metering_provider: base_builder_core::SharedMeteringProvider =
             Arc::new(builder.build_metering_store());
+        let accept_validity_transactions = builder.enable_experimental_validity_transactions;
         let builder_config = builder.into_builder_config(Arc::clone(&metering_provider))?;
         let da_config = builder_config.da_config.clone();
         let gas_limit_config = builder_config.gas_limit_config.clone();
@@ -106,7 +107,7 @@ impl SequencerCommand {
                 .with_service_builder(FlashblocksServiceBuilder::new(builder_config));
             runner.install_ext::<MeteringStoreExtension>(metering_provider);
             runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig { sequencer_rpc });
-            runner.install_ext::<BuilderApiExtension>(());
+            runner.install_ext::<BuilderApiExtension>(accept_validity_transactions);
             StandardBaseRethNode::install_upgrade_signal_runtime_extension(
                 &mut runner,
                 &rollup_args,

--- a/bin/builder/src/main.rs
+++ b/bin/builder/src/main.rs
@@ -37,6 +37,7 @@ fn main() {
             transaction_events_enabled.then(|| builder_args.transaction_events.writer_config()),
         )?;
 
+        let accept_validity_transactions = builder_args.enable_experimental_validity_transactions;
         let builder_config = builder_args
             .into_builder_config(Arc::clone(&metering_provider))
             .expect("Failed to convert rollup args to builder config");
@@ -51,7 +52,7 @@ fn main() {
             .with_service_builder(FlashblocksServiceBuilder::new(builder_config));
         runner.install_ext::<MeteringStoreExtension>(metering_provider);
         runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig::default());
-        runner.install_ext::<BuilderApiExtension>(());
+        runner.install_ext::<BuilderApiExtension>(accept_validity_transactions);
         StandardBaseRethNode::install_upgrade_signal_runtime_extension(&mut runner, &rollup_args)?;
         runner.add_started_callback(|| {
             base_cli_utils::register_version_metrics!();

--- a/crates/builder/cli/src/args.rs
+++ b/crates/builder/cli/src/args.rs
@@ -183,6 +183,12 @@ pub struct Args {
     #[arg(long = "builder.enable-resource-metering", default_value = "false")]
     pub enable_resource_metering: bool,
 
+    /// Accept experimental validity-bearing transactions from forwarding nodes.
+    ///
+    /// Predicates are preserved but are not yet enforced during block construction.
+    #[arg(long = "builder.enable-experimental-validity-transactions", default_value = "false")]
+    pub enable_experimental_validity_transactions: bool,
+
     /// Maximum cumulative uncompressed (EIP-2718 encoded) block size in bytes
     #[arg(long = "builder.max-uncompressed-block-size")]
     pub max_uncompressed_block_size: Option<u64>,
@@ -275,6 +281,7 @@ impl Default for Args {
             execution_metering_mode: ExecutionMeteringMode::Off,
             extra_block_deadline_secs: 20,
             enable_resource_metering: false,
+            enable_experimental_validity_transactions: false,
             max_uncompressed_block_size: None,
             metering_wait_duration_ms: None,
             audit_archiver_url: None,
@@ -373,10 +380,22 @@ mod tests {
 
     #[test]
     fn default_args_produce_valid_config() {
-        let config = convert(Args::default());
+        let args = Args::default();
+        assert!(!args.enable_experimental_validity_transactions);
+        let config = convert(args);
         assert_eq!(config.block_time, Duration::from_millis(1000));
         assert!(config.max_gas_per_txn.is_none());
         assert!(config.manifest_precheck_enabled);
+    }
+
+    #[test]
+    fn experimental_validity_transactions_require_explicit_opt_in() {
+        let parsed = CommandParser::parse_from([
+            "builder",
+            "--builder.enable-experimental-validity-transactions",
+        ]);
+
+        assert!(parsed.args.enable_experimental_validity_transactions);
     }
 
     #[rstest]

--- a/crates/builder/core/src/extension.rs
+++ b/crates/builder/core/src/extension.rs
@@ -1,6 +1,6 @@
 //! Builder API RPC extension for registering the `base_insertValidatedTransaction` endpoint.
 
-use base_execution_txpool::{BuilderApiImpl, BuilderApiServer};
+use base_execution_txpool::{BuilderApiImpl, BuilderApiServer, TransactionValidity};
 use base_node_runner::{BaseNodeExtension, BaseRpcContext, FromExtensionConfig, NodeHooks};
 
 /// Extension that registers the Builder API RPC module (`base_insertValidatedTransaction`).
@@ -10,7 +10,7 @@ pub struct BuilderApiExtension;
 impl BaseNodeExtension for BuilderApiExtension {
     fn apply(self: Box<Self>, builder: NodeHooks) -> NodeHooks {
         builder.add_rpc_module(move |ctx: &mut BaseRpcContext<'_>| {
-            let api = BuilderApiImpl::new(ctx.pool().clone());
+            let api = BuilderApiImpl::<_, TransactionValidity>::with_extensions(ctx.pool().clone());
             ctx.modules.merge_configured(api.into_rpc())?;
             Ok(())
         })

--- a/crates/builder/core/src/extension.rs
+++ b/crates/builder/core/src/extension.rs
@@ -4,13 +4,23 @@ use base_execution_txpool::{BuilderApiImpl, BuilderApiServer, TransactionValidit
 use base_node_runner::{BaseNodeExtension, BaseRpcContext, FromExtensionConfig, NodeHooks};
 
 /// Extension that registers the Builder API RPC module (`base_insertValidatedTransaction`).
+///
+/// Its boolean configuration controls whether non-empty experimental validity
+/// metadata is accepted. Ordinary validated transactions remain available in
+/// both modes.
 #[derive(Debug, Default)]
-pub struct BuilderApiExtension;
+pub struct BuilderApiExtension {
+    accept_experimental_validity_transactions: bool,
+}
 
 impl BaseNodeExtension for BuilderApiExtension {
     fn apply(self: Box<Self>, builder: NodeHooks) -> NodeHooks {
+        let accept_validity = self.accept_experimental_validity_transactions;
         builder.add_rpc_module(move |ctx: &mut BaseRpcContext<'_>| {
-            let api = BuilderApiImpl::<_, TransactionValidity>::with_extensions(ctx.pool().clone());
+            let api = BuilderApiImpl::<_, TransactionValidity>::with_extensions(
+                ctx.pool().clone(),
+                accept_validity,
+            );
             ctx.modules.merge_configured(api.into_rpc())?;
             Ok(())
         })
@@ -18,9 +28,9 @@ impl BaseNodeExtension for BuilderApiExtension {
 }
 
 impl FromExtensionConfig for BuilderApiExtension {
-    type Config = ();
+    type Config = bool;
 
-    fn from_config(_config: Self::Config) -> Self {
-        Self
+    fn from_config(accept_experimental_validity_transactions: Self::Config) -> Self {
+        Self { accept_experimental_validity_transactions }
     }
 }

--- a/crates/builder/core/tests/rpc.rs
+++ b/crates/builder/core/tests/rpc.rs
@@ -6,13 +6,16 @@ use alloy_primitives::{Address, Bytes, Signature, TxKind, U256};
 use alloy_rpc_client::RpcClient;
 use base_builder_core::BuilderApiExtension;
 use base_common_consensus::{BaseTransactionSigned, BaseTypedTransaction, TxDeposit};
-use base_execution_txpool::{NoExtensions, ValidatedTransaction};
+use base_execution_txpool::{
+    NoExtensions, TransactionValidity, ValidatedTransaction, ValidityOperator, ValidityPredicate,
+};
 use base_node_runner::test_utils::TestHarness;
 use base_test_utils::Account;
 
 /// Sets up a test harness with the `BuilderApiExtension` installed.
-async fn setup() -> eyre::Result<(TestHarness, RpcClient)> {
-    let harness = TestHarness::builder().with_ext::<BuilderApiExtension>(()).build().await?;
+async fn setup(accept_validity: bool) -> eyre::Result<(TestHarness, RpcClient)> {
+    let harness =
+        TestHarness::builder().with_ext::<BuilderApiExtension>(accept_validity).build().await?;
     let client = harness.rpc_client()?;
     Ok((harness, client))
 }
@@ -59,7 +62,7 @@ fn create_eip1559_tx(chain_id: u64) -> (Address, Bytes) {
 /// The pool doesn't accept deposit transactions, but the RPC should decode it successfully.
 #[tokio::test]
 async fn test_insert_validated_deposit_tx() -> eyre::Result<()> {
-    let (_harness, client) = setup().await?;
+    let (_harness, client) = setup(false).await?;
 
     let (sender, raw) = create_deposit_tx();
     let validated_tx = ValidatedTransaction {
@@ -90,7 +93,7 @@ async fn test_insert_validated_deposit_tx() -> eyre::Result<()> {
 /// The pool should accept this transaction type.
 #[tokio::test]
 async fn test_insert_validated_eip1559_tx() -> eyre::Result<()> {
-    let (harness, client) = setup().await?;
+    let (harness, client) = setup(false).await?;
 
     let (sender, raw) = create_eip1559_tx(harness.chain_id());
     let validated_tx = ValidatedTransaction {
@@ -114,7 +117,7 @@ async fn test_insert_validated_eip1559_tx() -> eyre::Result<()> {
 /// Verifies the RPC endpoint rejects an invalid transaction at the pool insertion stage.
 #[tokio::test]
 async fn test_insert_invalid_tx_fails() -> eyre::Result<()> {
-    let (_harness, client) = setup().await?;
+    let (_harness, client) = setup(false).await?;
 
     // Invalid raw bytes that can't be decoded (0xFF is not a valid tx type)
     let validated_tx = ValidatedTransaction {
@@ -136,5 +139,54 @@ async fn test_insert_invalid_tx_fails() -> eyre::Result<()> {
         err_str.contains("-32602") || err_str.contains("failed to decode"),
         "expected InvalidParams for decode failure, got: {err_str}"
     );
+    Ok(())
+}
+
+/// Verifies validity-bearing requests require explicit builder opt-in.
+#[tokio::test]
+async fn test_validity_transactions_require_explicit_opt_in() -> eyre::Result<()> {
+    let validity = TransactionValidity {
+        validity: vec![ValidityPredicate::Balance {
+            address: Account::Alice.address(),
+            op: ValidityOperator::Equal,
+            value: U256::ZERO,
+        }],
+    };
+
+    let (disabled_harness, disabled_client) = setup(false).await?;
+    let (sender, raw) = create_eip1559_tx(disabled_harness.chain_id());
+    let disabled_tx = ValidatedTransaction {
+        sender,
+        raw,
+        min_block_number: None,
+        max_block_number: None,
+        min_timestamp: None,
+        max_timestamp: None,
+        extensions: validity.clone(),
+    };
+    let disabled: Result<(), _> =
+        disabled_client.request("base_insertValidatedTransaction", (disabled_tx,)).await;
+    assert!(
+        disabled
+            .expect_err("disabled builder should reject validity")
+            .to_string()
+            .contains("transaction extensions are disabled")
+    );
+
+    let (enabled_harness, enabled_client) = setup(true).await?;
+    let (sender, raw) = create_eip1559_tx(enabled_harness.chain_id());
+    let enabled_tx = ValidatedTransaction {
+        sender,
+        raw,
+        min_block_number: None,
+        max_block_number: None,
+        min_timestamp: None,
+        max_timestamp: None,
+        extensions: validity,
+    };
+    let enabled: Result<(), _> =
+        enabled_client.request("base_insertValidatedTransaction", (enabled_tx,)).await;
+    assert!(enabled.is_ok(), "enabled builder should accept validity: {enabled:?}");
+
     Ok(())
 }

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -18,7 +18,7 @@ use base_tx_forwarding::{
     DEFAULT_MAX_BATCH_SIZE, DEFAULT_MAX_RPS, DEFAULT_RESEND_AFTER_MS, TxForwardingConfig,
     TxForwardingExtension,
 };
-use base_txpool_rpc::{TxPoolRpcConfig, TxPoolRpcExtension};
+use base_txpool_rpc::{SendRawTransactionValidityExtension, TxPoolRpcConfig, TxPoolRpcExtension};
 use base_txpool_tracing::{TxPoolExtension, TxpoolConfig};
 use base_upgrade_signal::UpgradeSignalStartupMode;
 use tracing::warn;
@@ -424,7 +424,11 @@ impl StandardBaseRethNode {
         };
         runner.install_ext::<MeteringExtension>(metering_config);
         runner.install_ext::<BundleExtension>(());
-        runner.install_ext::<TxForwardingExtension>((&args).into());
+        let tx_forwarding_config: TxForwardingConfig = (&args).into();
+        if tx_forwarding_config.enabled && !tx_forwarding_config.builder_urls.is_empty() {
+            runner.install_ext::<SendRawTransactionValidityExtension>(());
+        }
+        runner.install_ext::<TxForwardingExtension>(tx_forwarding_config);
         runner.install_ext::<ProofsHistoryExtension>(rollup_args.clone());
         Self::install_upgrade_signal_runtime_extension(&mut runner, &rollup_args)?;
         let eip8130_rpc_mode = if flashblocks_config.is_some() {

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -94,6 +94,12 @@ pub struct StandardNodeArgs {
     )]
     pub enable_tx_forwarding: bool,
 
+    /// Enable the experimental validity transaction RPC.
+    ///
+    /// Validity predicates are forwarded to builders but are not yet enforced.
+    #[arg(long = "enable-experimental-validity-transactions", requires = "enable_tx_forwarding")]
+    pub enable_experimental_validity_transactions: bool,
+
     /// Builder RPC endpoints for transaction forwarding (one forwarder per URL), used by mempool nodes
     #[arg(
         long = "builder-rpc-urls",
@@ -209,6 +215,7 @@ impl From<RpcStandardNodeArgs> for StandardNodeArgs {
             rpc: args,
             metering: MeteringArgs::default(),
             enable_tx_forwarding: false,
+            enable_experimental_validity_transactions: false,
             builder_rpc_urls: Vec::new(),
             tx_forwarding_resend_after_ms: DEFAULT_RESEND_AFTER_MS,
             tx_forwarding_batch_size: DEFAULT_MAX_BATCH_SIZE,
@@ -425,7 +432,12 @@ impl StandardBaseRethNode {
         runner.install_ext::<MeteringExtension>(metering_config);
         runner.install_ext::<BundleExtension>(());
         let tx_forwarding_config: TxForwardingConfig = (&args).into();
-        if tx_forwarding_config.enabled && !tx_forwarding_config.builder_urls.is_empty() {
+        if args.enable_experimental_validity_transactions {
+            if !tx_forwarding_config.enabled || tx_forwarding_config.builder_urls.is_empty() {
+                eyre::bail!(
+                    "experimental validity transactions require enabled transaction forwarding"
+                );
+            }
             runner.install_ext::<SendRawTransactionValidityExtension>(());
         }
         runner.install_ext::<TxForwardingExtension>(tx_forwarding_config);
@@ -713,8 +725,49 @@ mod tests {
         let config = TxForwardingConfig::from(&standard_args);
 
         assert_eq!(standard_args.rpc.rollup_args.sequencer, None);
+        assert!(!standard_args.enable_experimental_validity_transactions);
         assert!(!config.enabled);
         assert!(config.builder_urls.is_empty());
+    }
+
+    #[test]
+    fn experimental_validity_transactions_require_forwarding() {
+        let error = CommandParser::<StandardNodeArgs>::try_parse_from([
+            "base-reth",
+            "--enable-experimental-validity-transactions",
+        ])
+        .expect_err("validity transactions should require forwarding");
+
+        assert!(error.to_string().contains("--enable-tx-forwarding"));
+    }
+
+    #[test]
+    fn experimental_validity_transactions_parse_with_forwarding() {
+        let args = CommandParser::<StandardNodeArgs>::parse_from([
+            "base-reth",
+            "--enable-tx-forwarding",
+            "--builder-rpc-urls",
+            "http://localhost:8545",
+            "--enable-experimental-validity-transactions",
+        ])
+        .args;
+
+        assert!(args.enable_tx_forwarding);
+        assert!(args.enable_experimental_validity_transactions);
+        assert_eq!(args.builder_rpc_urls.len(), 1);
+    }
+
+    #[test]
+    fn programmatic_validity_config_requires_forwarding() {
+        let mut args = StandardNodeArgs::from(default_rpc_standard_node_args());
+        args.enable_experimental_validity_transactions = true;
+
+        let error = match StandardBaseRethNode::runner(args) {
+            Ok(_) => panic!("invalid programmatic validity config should fail"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("require enabled transaction forwarding"));
     }
 
     #[test]

--- a/crates/execution/tx-forwarding/Cargo.toml
+++ b/crates/execution/tx-forwarding/Cargo.toml
@@ -47,6 +47,7 @@ alloy-consensus.workspace = true
 
 # workspace
 base-test-utils.workspace = true
+base-txpool-rpc.workspace = true
 base-common-consensus.workspace = true
 base-common-rpc-types.workspace = true
 base-execution-chainspec.workspace = true

--- a/crates/execution/tx-forwarding/src/extension.rs
+++ b/crates/execution/tx-forwarding/src/extension.rs
@@ -1,6 +1,7 @@
 //! Contains the [`TxForwardingExtension`] which wires up the transaction
 //! forwarding pipeline on the Base node builder.
 
+use base_execution_txpool::TransactionValidity;
 use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
 use tracing::info;
 
@@ -40,7 +41,8 @@ impl BaseNodeExtension for TxForwardingExtension {
 
             let pool = ctx.pool().clone();
             let executor = ctx.task_executor;
-            let handle = TxForwardingService::new(config).spawn(pool, &executor);
+            let handle = TxForwardingService::new(config)
+                .spawn_with_extensions::<_, TransactionValidity>(pool, &executor);
 
             executor.spawn_with_graceful_shutdown_signal(|signal| {
                 Box::pin(async move {

--- a/crates/execution/tx-forwarding/tests/forwarding.rs
+++ b/crates/execution/tx-forwarding/tests/forwarding.rs
@@ -10,10 +10,11 @@ use alloy_provider::Provider;
 use alloy_signer::SignerSync;
 use base_common_rpc_types::BaseTransactionRequest;
 use base_execution_chainspec::BaseChainSpec;
-use base_execution_txpool::ValidatedTransaction;
+use base_execution_txpool::{TransactionValidity, ValidatedTransaction};
 use base_node_runner::test_utils::TestHarness;
 use base_test_utils::{Account, DEVNET_CHAIN_ID, build_test_genesis};
 use base_tx_forwarding::{TxForwardingConfig, TxForwardingExtension};
+use base_txpool_rpc::{SendRawTransactionValidityExtension, SendRawTransactionValidityRequest};
 use eyre::{Result, WrapErr};
 use jsonrpsee::{
     RpcModule,
@@ -35,7 +36,7 @@ struct MockBuilder {
 
 impl MockBuilder {
     async fn spawn(
-        received: mpsc::UnboundedSender<ValidatedTransaction>,
+        received: mpsc::UnboundedSender<ValidatedTransaction<TransactionValidity>>,
         entered: Option<Arc<Barrier>>,
         release: Option<Arc<Notify>>,
     ) -> Result<Self> {
@@ -45,7 +46,7 @@ impl MockBuilder {
         module.register_async_method(
             "base_insertValidatedTransaction",
             |params, context, _| async move {
-                let transaction: ValidatedTransaction = params.one()?;
+                let transaction: ValidatedTransaction<TransactionValidity> = params.one()?;
                 context.0.send(transaction).expect("test receiver should remain open");
 
                 if let (Some(entered), Some(release)) = (&context.1, &context.2) {
@@ -123,6 +124,7 @@ async fn forwards_to_healthy_destination_while_another_destination_is_blocked() 
         .ok_or_else(|| eyre::eyre!("healthy destination channel closed"))?;
     assert_eq!(healthy_forwarded.sender, Account::Alice.address());
     assert_eq!(healthy_forwarded.raw, raw);
+    assert!(healthy_forwarded.extensions.validity.is_empty());
 
     slow_release.notify_one();
     let slow_forwarded = timeout(WAIT_TIMEOUT, slow_rx.recv())
@@ -131,6 +133,7 @@ async fn forwards_to_healthy_destination_while_another_destination_is_blocked() 
         .ok_or_else(|| eyre::eyre!("slow destination channel closed"))?;
     assert_eq!(slow_forwarded.sender, Account::Alice.address());
     assert_eq!(slow_forwarded.raw, raw);
+    assert!(slow_forwarded.extensions.validity.is_empty());
 
     assert!(timeout(Duration::from_millis(100), healthy_rx.recv()).await.is_err());
     assert!(timeout(Duration::from_millis(100), slow_rx.recv()).await.is_err());
@@ -138,5 +141,62 @@ async fn forwards_to_healthy_destination_while_another_destination_is_blocked() 
     drop(harness);
     healthy.shutdown().await?;
     slow.shutdown().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn forwards_validity_to_every_builder() -> Result<()> {
+    let (first_tx, mut first_rx) = mpsc::unbounded_channel();
+    let first = MockBuilder::spawn(first_tx, None, None).await?;
+    let (second_tx, mut second_rx) = mpsc::unbounded_channel();
+    let second = MockBuilder::spawn(second_tx, None, None).await?;
+    let config = TxForwardingConfig::new(vec![first.url.clone(), second.url.clone()]);
+    let chain_spec = Arc::new(BaseChainSpec::from_genesis(build_test_genesis()));
+    let harness = TestHarness::builder()
+        .with_ext::<SendRawTransactionValidityExtension>(())
+        .with_ext::<TxForwardingExtension>(config)
+        .with_chain_spec(chain_spec)
+        .build()
+        .await?;
+    let raw = signed_eip1559_transaction();
+    let validity = serde_json::from_value(serde_json::json!({
+        "type": "storage",
+        "params": {
+            "address": Account::Bob.address(),
+            "slot": "0x1",
+            "op": "=",
+            "value": "0x2"
+        }
+    }))?;
+    let expected = vec![validity];
+    let client = harness.rpc_client()?;
+    let _: alloy_primitives::TxHash = client
+        .request(
+            "base_sendRawTransactionValidity",
+            (SendRawTransactionValidityRequest { tx: raw.clone(), validity: expected.clone() },),
+        )
+        .await?;
+
+    let first_forwarded = timeout(WAIT_TIMEOUT, first_rx.recv())
+        .await
+        .wrap_err("first builder was not called")?
+        .ok_or_else(|| eyre::eyre!("first builder channel closed"))?;
+    let second_forwarded = timeout(WAIT_TIMEOUT, second_rx.recv())
+        .await
+        .wrap_err("second builder was not called")?
+        .ok_or_else(|| eyre::eyre!("second builder channel closed"))?;
+    for forwarded in [&first_forwarded, &second_forwarded] {
+        assert_eq!(forwarded.sender, Account::Alice.address());
+        assert_eq!(forwarded.raw, raw);
+        assert_eq!(forwarded.extensions.validity, expected);
+    }
+    assert_eq!(first_forwarded.sender, second_forwarded.sender);
+    assert_eq!(first_forwarded.raw, second_forwarded.raw);
+    assert!(timeout(Duration::from_millis(100), first_rx.recv()).await.is_err());
+    assert!(timeout(Duration::from_millis(100), second_rx.recv()).await.is_err());
+
+    drop(harness);
+    first.shutdown().await?;
+    second.shutdown().await?;
     Ok(())
 }

--- a/crates/execution/txpool-rpc/Cargo.toml
+++ b/crates/execution/txpool-rpc/Cargo.toml
@@ -28,10 +28,11 @@ jsonrpsee.workspace = true
 # misc
 serde.workspace = true
 tracing.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
 eyre.workspace = true
 tokio.workspace = true
 httpmock.workspace = true
-serde_json.workspace = true
+alloy-eips.workspace = true
 reth-transaction-pool = { workspace = true, features = ["test-utils"] }

--- a/crates/execution/txpool-rpc/Cargo.toml
+++ b/crates/execution/txpool-rpc/Cargo.toml
@@ -14,8 +14,10 @@ workspace = true
 [dependencies]
 # workspace
 base-node-runner.workspace = true
+base-execution-txpool.workspace = true
 
 # reth
+reth-rpc-eth-types.workspace = true
 reth-rpc-server-types.workspace = true
 reth-transaction-pool.workspace = true
 
@@ -28,11 +30,10 @@ jsonrpsee.workspace = true
 # misc
 serde.workspace = true
 tracing.workspace = true
-serde_json.workspace = true
 
 [dev-dependencies]
 eyre.workspace = true
 tokio.workspace = true
 httpmock.workspace = true
-alloy-eips.workspace = true
+serde_json.workspace = true
 reth-transaction-pool = { workspace = true, features = ["test-utils"] }

--- a/crates/execution/txpool-rpc/README.md
+++ b/crates/execution/txpool-rpc/README.md
@@ -9,10 +9,10 @@ transaction pool.
 
 Exposes JSON-RPC APIs for transaction pool administration and transaction lifecycle tracking.
 `AdminTxPoolApiImpl` provides admin-level pool management, while `TransactionStatusApiImpl`
-allows clients to query the current status and lifecycle events of individual transactions
-by hash and submit raw transactions through `base_sendRawTransactionValidity`. The validity
-criteria are carried by the request but are not yet enforced. Both implementations use jsonrpsee
-server traits and are registered as node RPC extensions.
+allows clients to query the current status of individual transactions by hash. The separate
+`SendRawTransactionValidityExtension` registers local mempool ingress through
+`base_sendRawTransactionValidity`; typed validity predicates are preserved while forwarding to
+builders, but detailed evaluation remains deferred.
 
 ## Usage
 
@@ -24,10 +24,12 @@ base-txpool-rpc = { workspace = true }
 ```
 
 ```rust,ignore
-use base_txpool_rpc::{AdminTxPoolApiImpl, TransactionStatusApiImpl, TxPoolRpcExtension};
+use base_txpool_rpc::{
+    SendRawTransactionValidityExtension, TxPoolRpcConfig, TxPoolRpcExtension,
+};
 
-let ext = TxPoolRpcExtension::new(pool.clone(), tracker.clone());
-rpc_module.merge(ext.into_rpc())?;
+runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig::default());
+runner.install_ext::<SendRawTransactionValidityExtension>(());
 ```
 
 ## License

--- a/crates/execution/txpool-rpc/README.md
+++ b/crates/execution/txpool-rpc/README.md
@@ -2,14 +2,17 @@
 
 Transaction pool RPC APIs for Base.
 
-Provides RPC endpoints for querying transaction status and managing the transaction pool.
+Provides RPC endpoints for submitting transactions, querying transaction status, and managing the
+transaction pool.
 
 ## Overview
 
 Exposes JSON-RPC APIs for transaction pool administration and transaction lifecycle tracking.
 `AdminTxPoolApiImpl` provides admin-level pool management, while `TransactionStatusApiImpl`
 allows clients to query the current status and lifecycle events of individual transactions
-by hash. Both implement jsonrpsee server traits and are registered as node RPC extensions.
+by hash and submit raw transactions through `base_sendRawTransactionValidity`. The validity
+criteria are carried by the request but are not yet enforced. Both implementations use jsonrpsee
+server traits and are registered as node RPC extensions.
 
 ## Usage
 

--- a/crates/execution/txpool-rpc/README.md
+++ b/crates/execution/txpool-rpc/README.md
@@ -12,7 +12,8 @@ Exposes JSON-RPC APIs for transaction pool administration and transaction lifecy
 allows clients to query the current status of individual transactions by hash. The separate
 `SendRawTransactionValidityExtension` registers local mempool ingress through
 `base_sendRawTransactionValidity`; typed validity predicates are preserved while forwarding to
-builders, but detailed evaluation remains deferred.
+builders. This endpoint is experimental: predicates are not currently evaluated during block
+construction, so callers must not rely on them to prevent transaction inclusion.
 
 ## Usage
 
@@ -29,6 +30,7 @@ use base_txpool_rpc::{
 };
 
 runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig::default());
+// Install only when the node's explicit experimental validity flag is enabled.
 runner.install_ext::<SendRawTransactionValidityExtension>(());
 ```
 

--- a/crates/execution/txpool-rpc/src/extension.rs
+++ b/crates/execution/txpool-rpc/src/extension.rs
@@ -4,7 +4,8 @@ use base_node_runner::{BaseNodeExtension, BaseRpcContext, FromExtensionConfig, N
 use reth_rpc_server_types::RethRpcModule;
 
 use crate::{
-    AdminTxPoolApiImpl, AdminTxPoolApiServer, TransactionStatusApiImpl, TransactionStatusApiServer,
+    AdminTxPoolApiImpl, AdminTxPoolApiServer, SendRawTransactionValidityApiServer,
+    TransactionStatusApiImpl, TransactionStatusApiServer,
 };
 
 /// Configuration for the `TxPool` RPC extension.
@@ -26,10 +27,13 @@ impl BaseNodeExtension for TxPoolRpcExtension {
         let sequencer_rpc = self.config.sequencer_rpc;
 
         builder.add_rpc_module(move |ctx: &mut BaseRpcContext<'_>| {
-            // Register TransactionStatusApi
+            // Register Base transaction pool APIs.
             let status_api = TransactionStatusApiImpl::new(sequencer_rpc, ctx.pool().clone())
                 .expect("Failed to create transaction status API");
-            ctx.modules.merge_configured(status_api.into_rpc())?;
+            ctx.modules
+                .merge_configured(TransactionStatusApiServer::into_rpc(status_api.clone()))?;
+            ctx.modules
+                .merge_configured(SendRawTransactionValidityApiServer::into_rpc(status_api))?;
 
             // Register AdminTxPoolApi
             let admin_txpool_api = AdminTxPoolApiImpl::new(ctx.pool().clone());

--- a/crates/execution/txpool-rpc/src/extension.rs
+++ b/crates/execution/txpool-rpc/src/extension.rs
@@ -4,8 +4,8 @@ use base_node_runner::{BaseNodeExtension, BaseRpcContext, FromExtensionConfig, N
 use reth_rpc_server_types::RethRpcModule;
 
 use crate::{
-    AdminTxPoolApiImpl, AdminTxPoolApiServer, SendRawTransactionValidityApiServer,
-    TransactionStatusApiImpl, TransactionStatusApiServer,
+    AdminTxPoolApiImpl, AdminTxPoolApiServer, SendRawTransactionValidityApiImpl,
+    SendRawTransactionValidityApiServer, TransactionStatusApiImpl, TransactionStatusApiServer,
 };
 
 /// Configuration for the `TxPool` RPC extension.
@@ -30,10 +30,7 @@ impl BaseNodeExtension for TxPoolRpcExtension {
             // Register Base transaction pool APIs.
             let status_api = TransactionStatusApiImpl::new(sequencer_rpc, ctx.pool().clone())
                 .expect("Failed to create transaction status API");
-            ctx.modules
-                .merge_configured(TransactionStatusApiServer::into_rpc(status_api.clone()))?;
-            ctx.modules
-                .merge_configured(SendRawTransactionValidityApiServer::into_rpc(status_api))?;
+            ctx.modules.merge_configured(TransactionStatusApiServer::into_rpc(status_api))?;
 
             // Register AdminTxPoolApi
             let admin_txpool_api = AdminTxPoolApiImpl::new(ctx.pool().clone());
@@ -42,6 +39,28 @@ impl BaseNodeExtension for TxPoolRpcExtension {
 
             Ok(())
         })
+    }
+}
+
+/// Extension registering local validity-bearing transaction ingress.
+#[derive(Debug, Default)]
+pub struct SendRawTransactionValidityExtension;
+
+impl BaseNodeExtension for SendRawTransactionValidityExtension {
+    fn apply(self: Box<Self>, builder: NodeHooks) -> NodeHooks {
+        builder.add_rpc_module(|ctx: &mut BaseRpcContext<'_>| {
+            let api = SendRawTransactionValidityApiImpl::new(ctx.pool().clone());
+            ctx.modules.merge_configured(api.into_rpc())?;
+            Ok(())
+        })
+    }
+}
+
+impl FromExtensionConfig for SendRawTransactionValidityExtension {
+    type Config = ();
+
+    fn from_config(_config: Self::Config) -> Self {
+        Self
     }
 }
 

--- a/crates/execution/txpool-rpc/src/lib.rs
+++ b/crates/execution/txpool-rpc/src/lib.rs
@@ -9,7 +9,8 @@
 
 mod rpc;
 pub use rpc::{
-    AdminTxPoolApiImpl, AdminTxPoolApiServer, Status, TransactionStatusApiImpl,
+    AdminTxPoolApiImpl, AdminTxPoolApiServer, SendRawTransactionValidityApiServer,
+    SendRawTransactionValidityRequest, Status, TransactionStatusApiImpl,
     TransactionStatusApiServer, TransactionStatusResponse,
 };
 

--- a/crates/execution/txpool-rpc/src/lib.rs
+++ b/crates/execution/txpool-rpc/src/lib.rs
@@ -9,10 +9,10 @@
 
 mod rpc;
 pub use rpc::{
-    AdminTxPoolApiImpl, AdminTxPoolApiServer, SendRawTransactionValidityApiServer,
-    SendRawTransactionValidityRequest, Status, TransactionStatusApiImpl,
-    TransactionStatusApiServer, TransactionStatusResponse,
+    AdminTxPoolApiImpl, AdminTxPoolApiServer, SendRawTransactionValidityApiImpl,
+    SendRawTransactionValidityApiServer, SendRawTransactionValidityRequest, Status,
+    TransactionStatusApiImpl, TransactionStatusApiServer, TransactionStatusResponse,
 };
 
 mod extension;
-pub use extension::{TxPoolRpcConfig, TxPoolRpcExtension};
+pub use extension::{SendRawTransactionValidityExtension, TxPoolRpcConfig, TxPoolRpcExtension};

--- a/crates/execution/txpool-rpc/src/rpc.rs
+++ b/crates/execution/txpool-rpc/src/rpc.rs
@@ -1,6 +1,6 @@
-//! RPC implementation for transaction status queries and pool management.
+//! RPC implementation for transaction submission, status queries, and pool management.
 
-use alloy_primitives::{Address, TxHash};
+use alloy_primitives::{Address, Bytes, TxHash};
 use jsonrpsee::{
     core::{RpcResult, async_trait, client::ClientT},
     http_client::{HttpClient, HttpClientBuilder},
@@ -8,7 +8,7 @@ use jsonrpsee::{
     rpc_params,
     types::{ErrorCode, ErrorObjectOwned},
 };
-use reth_transaction_pool::TransactionPool;
+use reth_transaction_pool::{PoolTransaction, TransactionOrigin, TransactionPool};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
 
@@ -28,12 +28,32 @@ pub struct TransactionStatusResponse {
     pub status: Status,
 }
 
+/// Request for `base_sendRawTransactionValidity`.
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
+pub struct SendRawTransactionValidityRequest {
+    /// EIP-2718 encoded signed transaction.
+    pub tx: Bytes,
+    /// Criteria that control when the transaction is valid for inclusion.
+    pub validity: Vec<serde_json::Value>,
+}
+
 /// RPC API for transaction status
 #[rpc(server, namespace = "base")]
 pub trait TransactionStatusApi {
     /// Gets the status of a transaction
     #[method(name = "transactionStatus")]
     async fn transaction_status(&self, tx_hash: TxHash) -> RpcResult<TransactionStatusResponse>;
+}
+
+/// RPC API for submitting a raw transaction with validity criteria.
+#[rpc(server, namespace = "base")]
+pub trait SendRawTransactionValidityApi {
+    /// Submits a raw transaction together with its validity criteria.
+    #[method(name = "sendRawTransactionValidity")]
+    async fn send_raw_transaction_validity(
+        &self,
+        request: SendRawTransactionValidityRequest,
+    ) -> RpcResult<TxHash>;
 }
 
 /// Admin RPC API for transaction pool management operations.
@@ -51,8 +71,8 @@ pub trait AdminTxPoolApi {
     async fn drop_transaction(&self, tx_hash: TxHash) -> RpcResult<bool>;
 }
 
-/// Implementation of the transaction status RPC API.
-#[derive(Debug)]
+/// Implementation of the Base transaction pool RPC APIs.
+#[derive(Debug, Clone)]
 pub struct TransactionStatusApiImpl<Pool: TransactionPool> {
     sequencer_client: Option<HttpClient>,
     pool: Pool,
@@ -61,8 +81,8 @@ pub struct TransactionStatusApiImpl<Pool: TransactionPool> {
 impl<Pool: TransactionPool + 'static> TransactionStatusApiImpl<Pool> {
     /// Creates a new transaction status API instance.
     ///
-    /// If `sequencer_url` is provided, status queries will be forwarded to the sequencer.
-    /// Otherwise, the local transaction pool will be queried.
+    /// If `sequencer_url` is provided, transaction status queries and submissions will be
+    /// forwarded to the sequencer. Otherwise, the local transaction pool will be used.
     pub fn new(
         sequencer_url: Option<String>,
         pool: Pool,
@@ -108,6 +128,54 @@ impl<Pool: TransactionPool + 'static> TransactionStatusApiServer
     }
 }
 
+#[async_trait]
+impl<Pool: TransactionPool + 'static> SendRawTransactionValidityApiServer
+    for TransactionStatusApiImpl<Pool>
+{
+    async fn send_raw_transaction_validity(
+        &self,
+        request: SendRawTransactionValidityRequest,
+    ) -> RpcResult<TxHash> {
+        if let Some(ref sequencer_client) = self.sequencer_client {
+            return sequencer_client
+                .request("base_sendRawTransactionValidity", rpc_params![request])
+                .await
+                .map_err(|error| {
+                    warn!(%error, "failed to submit raw transaction with validity");
+                    ErrorObjectOwned::owned(
+                        ErrorCode::InternalError.code(),
+                        format!("failed to submit raw transaction with validity: {error}"),
+                        None::<()>,
+                    )
+                });
+        }
+
+        let transaction =
+            <Pool::Transaction as PoolTransaction>::recover_raw_transaction(request.tx.as_ref())
+                .map_err(|error| {
+                    ErrorObjectOwned::owned(
+                        ErrorCode::InvalidParams.code(),
+                        format!("failed to decode transaction: {error}"),
+                        None::<()>,
+                    )
+                })?;
+        let tx_hash = *transaction.hash();
+
+        // TODO: Validate and attach `request.validity` before inserting the transaction.
+        self.pool.add_transaction(TransactionOrigin::Local, transaction).await.map_err(
+            |error| {
+                ErrorObjectOwned::owned(
+                    ErrorCode::InternalError.code(),
+                    format!("pool rejected transaction: {error}"),
+                    None::<()>,
+                )
+            },
+        )?;
+
+        Ok(tx_hash)
+    }
+}
+
 /// Implementation of the admin transaction pool management RPC API.
 #[derive(Debug)]
 pub struct AdminTxPoolApiImpl<Pool: TransactionPool> {
@@ -140,6 +208,7 @@ impl<Pool: TransactionPool + 'static> AdminTxPoolApiServer for AdminTxPoolApiImp
 
 #[cfg(test)]
 mod tests {
+    use alloy_eips::eip2718::Encodable2718;
     use httpmock::prelude::*;
     use reth_transaction_pool::{
         PoolTransaction, TransactionOrigin,
@@ -148,6 +217,96 @@ mod tests {
     use serde_json::{self, json};
 
     use super::*;
+
+    fn validity_request(tx: Bytes) -> SendRawTransactionValidityRequest {
+        SendRawTransactionValidityRequest {
+            tx,
+            validity: vec![json!({
+                "type": "storage",
+                "params": {
+                    "address": "0xabc",
+                    "slot": "0x1",
+                    "op": "=",
+                    "value": "0x789"
+                }
+            })],
+        }
+    }
+
+    #[test]
+    fn send_raw_transaction_validity_request_uses_top_level_keys() {
+        let request = validity_request(Bytes::from_static(&[0x02]));
+        let value = serde_json::to_value(request).expect("request should serialize");
+
+        assert_eq!(value["tx"], "0x02");
+        assert_eq!(value["validity"][0]["type"], "storage");
+        assert_eq!(value["validity"][0]["params"]["slot"], "0x1");
+    }
+
+    #[test]
+    fn send_raw_transaction_validity_method_is_registered() {
+        let rpc = TransactionStatusApiImpl::new(None, testing_pool())
+            .expect("should be able to initialize rpc");
+        let module = SendRawTransactionValidityApiServer::into_rpc(rpc);
+
+        assert!(module.method_names().any(|name| name == "base_sendRawTransactionValidity"));
+    }
+
+    #[tokio::test]
+    async fn send_raw_transaction_validity_rejects_malformed_transaction() {
+        let rpc = TransactionStatusApiImpl::new(None, testing_pool())
+            .expect("should be able to initialize rpc");
+
+        let error = rpc
+            .send_raw_transaction_validity(validity_request(Bytes::from_static(&[0xff])))
+            .await
+            .expect_err("malformed transaction should be rejected");
+
+        assert_eq!(error.code(), ErrorCode::InvalidParams.code());
+        assert!(error.message().contains("failed to decode transaction"));
+    }
+
+    #[tokio::test]
+    async fn send_raw_transaction_validity_submits_to_local_pool() {
+        let pool = testing_pool();
+        let rpc = TransactionStatusApiImpl::new(None, pool.clone())
+            .expect("should be able to initialize rpc");
+        let (transaction, _) = MockTransaction::eip1559().into_consensus().into_parts();
+        let request = validity_request(transaction.encoded_2718().into());
+
+        let tx_hash = rpc
+            .send_raw_transaction_validity(request)
+            .await
+            .expect("valid transaction should be submitted");
+
+        assert!(pool.get(&tx_hash).is_some());
+    }
+
+    #[tokio::test]
+    async fn send_raw_transaction_validity_is_forwarded_to_sequencer() -> eyre::Result<()> {
+        let sequencer = MockServer::start();
+        let request = validity_request(Bytes::from_static(&[0x02]));
+        let tx_hash = TxHash::repeat_byte(0x42);
+        let mock = sequencer.mock(|when, then| {
+            when.method(POST).path("/").json_body(json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "method": "base_sendRawTransactionValidity",
+                "params": [request]
+            }));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({"jsonrpc": "2.0", "id": 0, "result": tx_hash}));
+        });
+        let rpc = TransactionStatusApiImpl::new(Some(sequencer.base_url()), testing_pool())
+            .expect("should be able to initialize rpc");
+
+        let result = rpc.send_raw_transaction_validity(request).await?;
+
+        assert_eq!(result, tx_hash);
+        mock.assert();
+        Ok(())
+    }
 
     #[tokio::test]
     async fn test_transaction_status() -> eyre::Result<()> {

--- a/crates/execution/txpool-rpc/src/rpc.rs
+++ b/crates/execution/txpool-rpc/src/rpc.rs
@@ -1,7 +1,7 @@
 //! RPC implementation for transaction submission, status queries, and pool management.
 
 use alloy_primitives::{Address, Bytes, TxHash};
-use base_execution_txpool::{BasePooledTransaction, ValidityPredicate};
+use base_execution_txpool::{BasePooledTransaction, MAX_VALIDITY_PREDICATES, ValidityPredicate};
 use jsonrpsee::{
     core::{RpcResult, async_trait, client::ClientT},
     http_client::{HttpClient, HttpClientBuilder},
@@ -35,7 +35,9 @@ pub struct TransactionStatusResponse {
 pub struct SendRawTransactionValidityRequest {
     /// EIP-2718 encoded signed transaction.
     pub tx: Bytes,
-    /// Predicates that control when the transaction is valid for inclusion.
+    /// Experimental predicates transported to builders alongside the transaction.
+    ///
+    /// Predicates are not currently evaluated during block construction.
     pub validity: Vec<ValidityPredicate>,
 }
 
@@ -47,10 +49,10 @@ pub trait TransactionStatusApi {
     async fn transaction_status(&self, tx_hash: TxHash) -> RpcResult<TransactionStatusResponse>;
 }
 
-/// RPC API for submitting a raw transaction with validity criteria.
+/// Experimental RPC API for submitting a raw transaction with validity criteria.
 #[rpc(server, namespace = "base")]
 pub trait SendRawTransactionValidityApi {
-    /// Submits a raw transaction together with its validity criteria.
+    /// Submits a raw transaction and transports its currently unenforced validity criteria.
     #[method(name = "sendRawTransactionValidity")]
     async fn send_raw_transaction_validity(
         &self,
@@ -152,6 +154,17 @@ where
         &self,
         request: SendRawTransactionValidityRequest,
     ) -> RpcResult<TxHash> {
+        if request.validity.len() > MAX_VALIDITY_PREDICATES {
+            return Err(ErrorObjectOwned::owned(
+                ErrorCode::InvalidParams.code(),
+                format!(
+                    "too many validity predicates: {} (maximum {MAX_VALIDITY_PREDICATES})",
+                    request.validity.len()
+                ),
+                None::<()>,
+            ));
+        }
+
         let transaction = BasePooledTransaction::recover_raw_transaction(request.tx.as_ref())
             .map_err(|error| {
                 ErrorObjectOwned::owned(
@@ -162,7 +175,7 @@ where
             })?;
         let tx_hash = *transaction.hash();
 
-        // Defer validity evaluation, retaining predicates so canonical forwarding carries them to builders.
+        // Retain the currently unenforced predicates for canonical forwarding to builders.
         self.pool
             .add_transaction(
                 TransactionOrigin::Private,
@@ -264,6 +277,23 @@ mod tests {
 
         assert_eq!(error.code(), ErrorCode::InvalidParams.code());
         assert!(error.message().contains("failed to decode transaction"));
+    }
+
+    #[tokio::test]
+    async fn send_raw_transaction_validity_rejects_too_many_predicates() {
+        let rpc = SendRawTransactionValidityApiImpl::new(NoopTransactionPool::<
+            BasePooledTransaction,
+        >::new());
+        let mut request = validity_request(Bytes::from_static(&[0x02]));
+        request.validity = vec![request.validity[0].clone(); MAX_VALIDITY_PREDICATES + 1];
+
+        let error = rpc
+            .send_raw_transaction_validity(request)
+            .await
+            .expect_err("oversized validity should be rejected before transaction decoding");
+
+        assert_eq!(error.code(), ErrorCode::InvalidParams.code());
+        assert!(error.message().contains("too many validity predicates"));
     }
 
     #[tokio::test]

--- a/crates/execution/txpool-rpc/src/rpc.rs
+++ b/crates/execution/txpool-rpc/src/rpc.rs
@@ -1,6 +1,7 @@
 //! RPC implementation for transaction submission, status queries, and pool management.
 
 use alloy_primitives::{Address, Bytes, TxHash};
+use base_execution_txpool::{BasePooledTransaction, ValidityPredicate};
 use jsonrpsee::{
     core::{RpcResult, async_trait, client::ClientT},
     http_client::{HttpClient, HttpClientBuilder},
@@ -8,6 +9,7 @@ use jsonrpsee::{
     rpc_params,
     types::{ErrorCode, ErrorObjectOwned},
 };
+use reth_rpc_eth_types::error::RpcPoolError;
 use reth_transaction_pool::{PoolTransaction, TransactionOrigin, TransactionPool};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
@@ -33,8 +35,8 @@ pub struct TransactionStatusResponse {
 pub struct SendRawTransactionValidityRequest {
     /// EIP-2718 encoded signed transaction.
     pub tx: Bytes,
-    /// Criteria that control when the transaction is valid for inclusion.
-    pub validity: Vec<serde_json::Value>,
+    /// Predicates that control when the transaction is valid for inclusion.
+    pub validity: Vec<ValidityPredicate>,
 }
 
 /// RPC API for transaction status
@@ -78,11 +80,24 @@ pub struct TransactionStatusApiImpl<Pool: TransactionPool> {
     pool: Pool,
 }
 
+/// Local mempool-ingress implementation for validity-bearing transactions.
+#[derive(Debug, Clone)]
+pub struct SendRawTransactionValidityApiImpl<Pool> {
+    pool: Pool,
+}
+
+impl<Pool> SendRawTransactionValidityApiImpl<Pool> {
+    /// Creates a validity transaction ingress backed by the given pool.
+    pub const fn new(pool: Pool) -> Self {
+        Self { pool }
+    }
+}
+
 impl<Pool: TransactionPool + 'static> TransactionStatusApiImpl<Pool> {
     /// Creates a new transaction status API instance.
     ///
-    /// If `sequencer_url` is provided, transaction status queries and submissions will be
-    /// forwarded to the sequencer. Otherwise, the local transaction pool will be used.
+    /// If `sequencer_url` is provided, transaction status queries are forwarded to the
+    /// sequencer. Otherwise, the local transaction pool is used.
     pub fn new(
         sequencer_url: Option<String>,
         pool: Pool,
@@ -129,48 +144,32 @@ impl<Pool: TransactionPool + 'static> TransactionStatusApiServer
 }
 
 #[async_trait]
-impl<Pool: TransactionPool + 'static> SendRawTransactionValidityApiServer
-    for TransactionStatusApiImpl<Pool>
+impl<Pool> SendRawTransactionValidityApiServer for SendRawTransactionValidityApiImpl<Pool>
+where
+    Pool: TransactionPool<Transaction = BasePooledTransaction> + 'static,
 {
     async fn send_raw_transaction_validity(
         &self,
         request: SendRawTransactionValidityRequest,
     ) -> RpcResult<TxHash> {
-        if let Some(ref sequencer_client) = self.sequencer_client {
-            return sequencer_client
-                .request("base_sendRawTransactionValidity", rpc_params![request])
-                .await
-                .map_err(|error| {
-                    warn!(%error, "failed to submit raw transaction with validity");
-                    ErrorObjectOwned::owned(
-                        ErrorCode::InternalError.code(),
-                        format!("failed to submit raw transaction with validity: {error}"),
-                        None::<()>,
-                    )
-                });
-        }
-
-        let transaction =
-            <Pool::Transaction as PoolTransaction>::recover_raw_transaction(request.tx.as_ref())
-                .map_err(|error| {
-                    ErrorObjectOwned::owned(
-                        ErrorCode::InvalidParams.code(),
-                        format!("failed to decode transaction: {error}"),
-                        None::<()>,
-                    )
-                })?;
-        let tx_hash = *transaction.hash();
-
-        // TODO: Validate and attach `request.validity` before inserting the transaction.
-        self.pool.add_transaction(TransactionOrigin::Local, transaction).await.map_err(
-            |error| {
+        let transaction = BasePooledTransaction::recover_raw_transaction(request.tx.as_ref())
+            .map_err(|error| {
                 ErrorObjectOwned::owned(
-                    ErrorCode::InternalError.code(),
-                    format!("pool rejected transaction: {error}"),
+                    ErrorCode::InvalidParams.code(),
+                    format!("failed to decode transaction: {error}"),
                     None::<()>,
                 )
-            },
-        )?;
+            })?;
+        let tx_hash = *transaction.hash();
+
+        // Defer validity evaluation, retaining predicates so canonical forwarding carries them to builders.
+        self.pool
+            .add_transaction(
+                TransactionOrigin::Private,
+                transaction.with_validity_predicates(request.validity),
+            )
+            .await
+            .map_err(|error| ErrorObjectOwned::from(RpcPoolError::from(error)))?;
 
         Ok(tx_hash)
     }
@@ -208,10 +207,11 @@ impl<Pool: TransactionPool + 'static> AdminTxPoolApiServer for AdminTxPoolApiImp
 
 #[cfg(test)]
 mod tests {
-    use alloy_eips::eip2718::Encodable2718;
+    use alloy_primitives::U256;
     use httpmock::prelude::*;
     use reth_transaction_pool::{
         PoolTransaction, TransactionOrigin,
+        noop::NoopTransactionPool,
         test_utils::{MockTransaction, testing_pool},
     };
     use serde_json::{self, json};
@@ -221,15 +221,13 @@ mod tests {
     fn validity_request(tx: Bytes) -> SendRawTransactionValidityRequest {
         SendRawTransactionValidityRequest {
             tx,
-            validity: vec![json!({
-                "type": "storage",
-                "params": {
-                    "address": "0xabc",
-                    "slot": "0x1",
-                    "op": "=",
-                    "value": "0x789"
-                }
-            })],
+            validity: vec![ValidityPredicate::Storage {
+                address: Address::repeat_byte(0xab),
+                slot: U256::from(1),
+                mask: U256::MAX,
+                op: base_execution_txpool::ValidityOperator::Equal,
+                value: U256::from(0x789),
+            }],
         }
     }
 
@@ -245,8 +243,9 @@ mod tests {
 
     #[test]
     fn send_raw_transaction_validity_method_is_registered() {
-        let rpc = TransactionStatusApiImpl::new(None, testing_pool())
-            .expect("should be able to initialize rpc");
+        let rpc = SendRawTransactionValidityApiImpl::new(NoopTransactionPool::<
+            BasePooledTransaction,
+        >::new());
         let module = SendRawTransactionValidityApiServer::into_rpc(rpc);
 
         assert!(module.method_names().any(|name| name == "base_sendRawTransactionValidity"));
@@ -254,8 +253,9 @@ mod tests {
 
     #[tokio::test]
     async fn send_raw_transaction_validity_rejects_malformed_transaction() {
-        let rpc = TransactionStatusApiImpl::new(None, testing_pool())
-            .expect("should be able to initialize rpc");
+        let rpc = SendRawTransactionValidityApiImpl::new(NoopTransactionPool::<
+            BasePooledTransaction,
+        >::new());
 
         let error = rpc
             .send_raw_transaction_validity(validity_request(Bytes::from_static(&[0xff])))
@@ -264,48 +264,6 @@ mod tests {
 
         assert_eq!(error.code(), ErrorCode::InvalidParams.code());
         assert!(error.message().contains("failed to decode transaction"));
-    }
-
-    #[tokio::test]
-    async fn send_raw_transaction_validity_submits_to_local_pool() {
-        let pool = testing_pool();
-        let rpc = TransactionStatusApiImpl::new(None, pool.clone())
-            .expect("should be able to initialize rpc");
-        let (transaction, _) = MockTransaction::eip1559().into_consensus().into_parts();
-        let request = validity_request(transaction.encoded_2718().into());
-
-        let tx_hash = rpc
-            .send_raw_transaction_validity(request)
-            .await
-            .expect("valid transaction should be submitted");
-
-        assert!(pool.get(&tx_hash).is_some());
-    }
-
-    #[tokio::test]
-    async fn send_raw_transaction_validity_is_forwarded_to_sequencer() -> eyre::Result<()> {
-        let sequencer = MockServer::start();
-        let request = validity_request(Bytes::from_static(&[0x02]));
-        let tx_hash = TxHash::repeat_byte(0x42);
-        let mock = sequencer.mock(|when, then| {
-            when.method(POST).path("/").json_body(json!({
-                "jsonrpc": "2.0",
-                "id": 0,
-                "method": "base_sendRawTransactionValidity",
-                "params": [request]
-            }));
-            then.status(200)
-                .header("content-type", "application/json")
-                .json_body(json!({"jsonrpc": "2.0", "id": 0, "result": tx_hash}));
-        });
-        let rpc = TransactionStatusApiImpl::new(Some(sequencer.base_url()), testing_pool())
-            .expect("should be able to initialize rpc");
-
-        let result = rpc.send_raw_transaction_validity(request).await?;
-
-        assert_eq!(result, tx_hash);
-        mock.assert();
-        Ok(())
     }
 
     #[tokio::test]

--- a/crates/execution/txpool/src/builder/rpc.rs
+++ b/crates/execution/txpool/src/builder/rpc.rs
@@ -12,7 +12,7 @@ use jsonrpsee::{
     proc_macros::rpc,
     types::{ErrorCode, ErrorObjectOwned},
 };
-use reth_transaction_pool::TransactionPool;
+use reth_transaction_pool::{TransactionOrigin, TransactionPool};
 use serde_json::{Map, json};
 use tracing::debug;
 
@@ -46,6 +46,7 @@ pub trait BuilderApi<E> {
 #[derive(Debug)]
 pub struct BuilderApiImpl<P, E = NoExtensions> {
     pool: P,
+    accept_extensions: bool,
     _extensions: PhantomData<E>,
 }
 
@@ -58,16 +59,17 @@ impl<P> BuilderApiImpl<P, NoExtensions> {
     /// call site (`E0282`), because type-parameter defaults do not participate
     /// in inference for associated-function calls.
     pub const fn new(pool: P) -> Self {
-        Self { pool, _extensions: PhantomData }
+        Self { pool, accept_extensions: false, _extensions: PhantomData }
     }
 }
 
 impl<P, E> BuilderApiImpl<P, E> {
     /// Creates a new handler carrying the wire extension payload `E`.
     ///
-    /// Use as `BuilderApiImpl::<_, MyExtensions>::with_extensions(pool)`.
-    pub const fn with_extensions(pool: P) -> Self {
-        Self { pool, _extensions: PhantomData }
+    /// Non-empty extension payloads are rejected unless `accept_extensions` is
+    /// explicitly enabled.
+    pub const fn with_extensions(pool: P, accept_extensions: bool) -> Self {
+        Self { pool, accept_extensions, _extensions: PhantomData }
     }
 }
 
@@ -83,6 +85,16 @@ where
             "rpc::insert_validated_transaction"
         );
         let sender = tx.sender;
+        let has_extensions = !tx.extensions.is_empty();
+
+        if has_extensions && !self.accept_extensions {
+            BuilderApiMetrics::extension_errors().increment(1);
+            return Err(ErrorObjectOwned::owned(
+                ErrorCode::InvalidParams.code(),
+                "transaction extensions are disabled",
+                None::<()>,
+            ));
+        }
 
         // Decode the EIP-2718 transaction bytes
         let consensus_tx =
@@ -112,9 +124,14 @@ where
             ErrorObjectOwned::owned(ErrorCode::InvalidParams.code(), e.to_string(), None::<()>)
         })?;
 
-        // Insert into the pool
+        // Extension-bearing transactions remain private so normal P2P gossip
+        // cannot propagate the raw transaction without its extension metadata.
         let start = Instant::now();
-        let result = self.pool.add_external_transaction(pool_tx).await;
+        let result = if has_extensions {
+            self.pool.add_transaction(TransactionOrigin::Private, pool_tx).await
+        } else {
+            self.pool.add_external_transaction(pool_tx).await
+        };
         BuilderApiMetrics::insert_duration().record(start.elapsed().as_secs_f64());
 
         match result {
@@ -258,6 +275,10 @@ mod tests {
     }
 
     impl ValidatedTransactionExtensions<BasePooledTransaction> for TestExtensions {
+        fn is_empty(&self) -> bool {
+            self.reject.is_none()
+        }
+
         fn extract(
             _tx: &reth_transaction_pool::ValidPoolTransaction<BasePooledTransaction>,
         ) -> Self {
@@ -275,16 +296,18 @@ mod tests {
         }
     }
 
-    fn extension_handler()
-    -> BuilderApiImpl<NoopTransactionPool<BasePooledTransaction>, TestExtensions> {
-        BuilderApiImpl::<_, TestExtensions>::with_extensions(NoopTransactionPool::<
-            BasePooledTransaction,
-        >::new())
+    fn extension_handler(
+        accept_extensions: bool,
+    ) -> BuilderApiImpl<NoopTransactionPool<BasePooledTransaction>, TestExtensions> {
+        BuilderApiImpl::<_, TestExtensions>::with_extensions(
+            NoopTransactionPool::<BasePooledTransaction>::new(),
+            accept_extensions,
+        )
     }
 
     #[tokio::test]
     async fn extension_apply_failure_returns_invalid_params() {
-        let handler = extension_handler();
+        let handler = extension_handler(true);
         let (sender, raw) = create_eip1559_tx();
 
         let tx = validated_transaction(sender, raw, TestExtensions { reject: Some(true) });
@@ -304,7 +327,7 @@ mod tests {
 
     #[tokio::test]
     async fn extension_apply_success_reaches_the_pool() {
-        let handler = extension_handler();
+        let handler = extension_handler(true);
         let (sender, raw) = create_eip1559_tx();
 
         let tx = validated_transaction(sender, raw, TestExtensions { reject: None });
@@ -319,12 +342,35 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn disabled_extensions_reject_non_empty_payloads() {
+        let handler = extension_handler(false);
+        let (sender, raw) = create_eip1559_tx();
+        let tx = validated_transaction(sender, raw, TestExtensions { reject: Some(false) });
+
+        let err = handler.insert_validated_transaction(tx).await.unwrap_err();
+
+        assert_eq!(err.code(), ErrorCode::InvalidParams.code());
+        assert_eq!(err.message(), "transaction extensions are disabled");
+    }
+
+    #[tokio::test]
+    async fn disabled_extensions_allow_empty_payloads() {
+        let handler = extension_handler(false);
+        let (sender, raw) = create_eip1559_tx();
+        let tx = validated_transaction(sender, raw, TestExtensions::default());
+
+        let err = handler.insert_validated_transaction(tx).await.unwrap_err();
+
+        assert_eq!(err.code(), ErrorCode::InternalError.code());
+    }
+
     #[test]
     fn both_monomorphizations_build_rpc_modules() {
         // The stock call-site shape must keep working untouched...
         let _stock = handler().into_rpc();
         // ...and a custom extension payload must also produce a module.
-        let _custom = extension_handler().into_rpc();
+        let _custom = extension_handler(true).into_rpc();
     }
 
     // ==========================================================================

--- a/crates/execution/txpool/src/lib.rs
+++ b/crates/execution/txpool/src/lib.rs
@@ -28,7 +28,9 @@ pub use validator::{BaseL1BlockInfo, BaseTransactionValidator, BaseTxPoolError, 
 mod best;
 
 mod validity;
-pub use validity::{TransactionValidity, ValidityOperator, ValidityPredicate};
+pub use validity::{
+    MAX_VALIDITY_PREDICATES, TransactionValidity, ValidityOperator, ValidityPredicate,
+};
 
 mod transaction;
 pub use transaction::{

--- a/crates/execution/txpool/src/lib.rs
+++ b/crates/execution/txpool/src/lib.rs
@@ -28,7 +28,7 @@ pub use validator::{BaseL1BlockInfo, BaseTransactionValidator, BaseTxPoolError, 
 mod best;
 
 mod validity;
-pub use validity::{ValidityOperator, ValidityPredicate};
+pub use validity::{TransactionValidity, ValidityOperator, ValidityPredicate};
 
 mod transaction;
 pub use transaction::{

--- a/crates/execution/txpool/src/validity.rs
+++ b/crates/execution/txpool/src/validity.rs
@@ -1,6 +1,9 @@
 //! State predicates carried by pooled transactions.
 
 use alloy_primitives::{Address, U256};
+use reth_transaction_pool::ValidPoolTransaction;
+
+use crate::{BasePooledTransaction, ExtensionError, ValidatedTransactionExtensions};
 
 /// A comparison used by a [`ValidityPredicate`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
@@ -80,6 +83,24 @@ impl ValidityPredicate {
     #[must_use]
     pub const fn default_mask() -> U256 {
         U256::MAX
+    }
+}
+
+/// Validity predicates carried with a validated transaction.
+#[derive(Clone, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct TransactionValidity {
+    /// Predicates controlling when the transaction is valid for inclusion.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub validity: Vec<ValidityPredicate>,
+}
+
+impl ValidatedTransactionExtensions<BasePooledTransaction> for TransactionValidity {
+    fn extract(tx: &ValidPoolTransaction<BasePooledTransaction>) -> Self {
+        Self { validity: tx.transaction.validity_predicates().to_vec() }
+    }
+
+    fn apply(self, tx: BasePooledTransaction) -> Result<BasePooledTransaction, ExtensionError> {
+        Ok(tx.with_validity_predicates(self.validity))
     }
 }
 
@@ -183,5 +204,35 @@ mod tests {
         ] {
             assert_eq!(op.matches(U256::from(10), U256::from(11)), expected);
         }
+    }
+
+    #[test]
+    fn empty_payload_is_omitted() {
+        assert_eq!(serde_json::to_value(TransactionValidity::default()).unwrap(), json!({}));
+    }
+
+    #[test]
+    fn predicates_round_trip() {
+        let value = json!({
+            "validity": [{
+                "type": "balance",
+                "params": {
+                    "address": "0x1111111111111111111111111111111111111111",
+                    "op": "=",
+                    "value": "0x2"
+                }
+            }]
+        });
+        let payload: TransactionValidity = serde_json::from_value(value.clone()).unwrap();
+
+        assert_eq!(
+            payload.validity,
+            vec![ValidityPredicate::Balance {
+                address: Address::repeat_byte(0x11),
+                op: ValidityOperator::Equal,
+                value: U256::from(2),
+            }]
+        );
+        assert_eq!(serde_json::to_value(payload).unwrap(), value);
     }
 }

--- a/crates/execution/txpool/src/validity.rs
+++ b/crates/execution/txpool/src/validity.rs
@@ -5,6 +5,9 @@ use reth_transaction_pool::ValidPoolTransaction;
 
 use crate::{BasePooledTransaction, ExtensionError, ValidatedTransactionExtensions};
 
+/// Maximum number of experimental validity predicates carried by one transaction.
+pub const MAX_VALIDITY_PREDICATES: usize = 64;
+
 /// A comparison used by a [`ValidityPredicate`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub enum ValidityOperator {
@@ -86,20 +89,33 @@ impl ValidityPredicate {
     }
 }
 
-/// Validity predicates carried with a validated transaction.
+/// Experimental validity predicates carried with a validated transaction.
+///
+/// The builder transport preserves these predicates but does not currently
+/// evaluate them during block construction.
 #[derive(Clone, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct TransactionValidity {
-    /// Predicates controlling when the transaction is valid for inclusion.
+    /// Predicates intended to control when the transaction is valid for inclusion.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub validity: Vec<ValidityPredicate>,
 }
 
 impl ValidatedTransactionExtensions<BasePooledTransaction> for TransactionValidity {
+    fn is_empty(&self) -> bool {
+        self.validity.is_empty()
+    }
+
     fn extract(tx: &ValidPoolTransaction<BasePooledTransaction>) -> Self {
         Self { validity: tx.transaction.validity_predicates().to_vec() }
     }
 
     fn apply(self, tx: BasePooledTransaction) -> Result<BasePooledTransaction, ExtensionError> {
+        if self.validity.len() > MAX_VALIDITY_PREDICATES {
+            return Err(ExtensionError(format!(
+                "too many validity predicates: {} (maximum {MAX_VALIDITY_PREDICATES})",
+                self.validity.len()
+            )));
+        }
         Ok(tx.with_validity_predicates(self.validity))
     }
 }
@@ -270,5 +286,36 @@ mod tests {
         let transaction = extension.apply(transaction).unwrap();
 
         assert_eq!(transaction.validity_predicates(), expected);
+    }
+
+    #[test]
+    fn apply_rejects_too_many_predicates() {
+        let signed: BaseTransactionSigned = TxDeposit {
+            source_hash: Default::default(),
+            from: Address::ZERO,
+            to: TxKind::Create,
+            mint: 0,
+            value: U256::ZERO,
+            gas_limit: 21_000,
+            is_system_transaction: false,
+            input: Default::default(),
+        }
+        .into();
+        let encoded_length = signed.encode_2718_len();
+        let transaction = BasePooledTransaction::new(
+            Recovered::new_unchecked(signed, Address::ZERO),
+            encoded_length,
+        );
+        let predicate = ValidityPredicate::Balance {
+            address: Address::ZERO,
+            op: ValidityOperator::Equal,
+            value: U256::ZERO,
+        };
+        let extension =
+            TransactionValidity { validity: vec![predicate; MAX_VALIDITY_PREDICATES + 1] };
+
+        let error = extension.apply(transaction).unwrap_err();
+
+        assert!(error.to_string().contains("too many validity predicates"));
     }
 }

--- a/crates/execution/txpool/src/validity.rs
+++ b/crates/execution/txpool/src/validity.rs
@@ -106,6 +106,10 @@ impl ValidatedTransactionExtensions<BasePooledTransaction> for TransactionValidi
 
 #[cfg(test)]
 mod tests {
+    use alloy_consensus::transaction::Recovered;
+    use alloy_eips::eip2718::Encodable2718;
+    use alloy_primitives::TxKind;
+    use base_common_consensus::{BaseTransactionSigned, TxDeposit};
     use serde_json::json;
 
     use super::*;
@@ -234,5 +238,37 @@ mod tests {
             }]
         );
         assert_eq!(serde_json::to_value(payload).unwrap(), value);
+    }
+
+    #[test]
+    fn apply_attaches_validity_predicates_to_pooled_transaction() {
+        let signed: BaseTransactionSigned = TxDeposit {
+            source_hash: Default::default(),
+            from: Address::ZERO,
+            to: TxKind::Create,
+            mint: 0,
+            value: U256::ZERO,
+            gas_limit: 21_000,
+            is_system_transaction: false,
+            input: Default::default(),
+        }
+        .into();
+        let encoded_length = signed.encode_2718_len();
+        let transaction = BasePooledTransaction::new(
+            Recovered::new_unchecked(signed, Address::ZERO),
+            encoded_length,
+        );
+        let expected = vec![ValidityPredicate::Storage {
+            address: Address::repeat_byte(0x11),
+            slot: U256::from(1),
+            mask: U256::MAX,
+            op: ValidityOperator::Equal,
+            value: U256::from(2),
+        }];
+        let extension = TransactionValidity { validity: expected.clone() };
+
+        let transaction = extension.apply(transaction).unwrap();
+
+        assert_eq!(transaction.validity_predicates(), expected);
     }
 }

--- a/crates/execution/txpool/src/wire.rs
+++ b/crates/execution/txpool/src/wire.rs
@@ -91,7 +91,10 @@ pub struct ValidatedTransaction<E = NoExtensions> {
 
 #[cfg(test)]
 mod tests {
+    use alloy_primitives::U256;
+
     use super::*;
+    use crate::{TransactionValidity, ValidityOperator, ValidityPredicate};
 
     /// Mirrors the field layout this type had before `extensions` was added, so
     /// the tests below can assert byte-identical encoding against it.
@@ -148,6 +151,58 @@ mod tests {
             serde_json::to_string(&current).unwrap(),
             "default instantiation must be byte-identical to the pre-generic layout"
         );
+    }
+
+    #[test]
+    fn empty_validity_encoding_matches_legacy_layout() {
+        let legacy = LegacyValidatedTransaction {
+            sender: sender(),
+            raw: raw(),
+            min_block_number: Some(3),
+            max_block_number: None,
+            min_timestamp: None,
+            max_timestamp: Some(7),
+        };
+        let current = ValidatedTransaction {
+            sender: sender(),
+            raw: raw(),
+            min_block_number: Some(3),
+            max_block_number: None,
+            min_timestamp: None,
+            max_timestamp: Some(7),
+            extensions: TransactionValidity::default(),
+        };
+
+        assert_eq!(serde_json::to_value(legacy).unwrap(), serde_json::to_value(current).unwrap());
+    }
+
+    #[test]
+    fn storage_validity_is_flattened_and_round_trips() {
+        let predicate = ValidityPredicate::Storage {
+            address: sender(),
+            slot: U256::from(1),
+            mask: U256::MAX,
+            op: ValidityOperator::Equal,
+            value: U256::from(2),
+        };
+        let tx = ValidatedTransaction {
+            sender: sender(),
+            raw: raw(),
+            min_block_number: None,
+            max_block_number: None,
+            min_timestamp: None,
+            max_timestamp: None,
+            extensions: TransactionValidity { validity: vec![predicate.clone()] },
+        };
+
+        let value = serde_json::to_value(&tx).unwrap();
+        assert_eq!(value["validity"][0]["type"], "storage");
+        assert_eq!(value["validity"][0]["params"]["slot"], "0x1");
+        assert!(value.get("extensions").is_none());
+
+        let decoded: ValidatedTransaction<TransactionValidity> =
+            serde_json::from_value(value).unwrap();
+        assert_eq!(decoded.extensions.validity, vec![predicate]);
     }
 
     #[test]

--- a/crates/execution/txpool/src/wire.rs
+++ b/crates/execution/txpool/src/wire.rs
@@ -30,6 +30,14 @@ pub struct ExtensionError(pub String);
 pub trait ValidatedTransactionExtensions<T: PoolTransaction>:
     Serialize + DeserializeOwned + Debug + Clone + Send + Sync + Unpin + 'static
 {
+    /// Returns whether the payload carries no extension data.
+    ///
+    /// Builders use this to preserve legacy transaction handling while rejecting
+    /// or privately inserting non-empty extension payloads.
+    fn is_empty(&self) -> bool {
+        false
+    }
+
     /// Extracts extension data from an outbound pooled transaction.
     ///
     /// Called by the forwarder for each transaction it relays to a builder.
@@ -43,6 +51,10 @@ pub trait ValidatedTransactionExtensions<T: PoolTransaction>:
 }
 
 impl<T: PoolTransaction> ValidatedTransactionExtensions<T> for NoExtensions {
+    fn is_empty(&self) -> bool {
+        true
+    }
+
     fn extract(_tx: &ValidPoolTransaction<T>) -> Self {
         Self {}
     }
@@ -62,6 +74,10 @@ impl<T: PoolTransaction> ValidatedTransactionExtensions<T> for NoExtensions {
 /// exactly the same bytes as a struct without the field at all, so the default
 /// instantiation is wire-compatible in both directions with peers that predate
 /// this parameter.
+///
+/// Legacy [`NoExtensions`] readers silently ignore extension fields. Any future
+/// behavior that relies on extension enforcement must therefore negotiate peer
+/// support instead of relying on this compatibility fallback.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ValidatedTransaction<E = NoExtensions> {
     /// Recovered signer address.

--- a/etc/systems/src/l2/in_process_builder.rs
+++ b/etc/systems/src/l2/in_process_builder.rs
@@ -49,6 +49,8 @@ pub struct InProcessBuilderConfig {
     pub p2p_port: Option<u16>,
     /// Optional fixed Flashblocks port (uses random if None).
     pub flashblocks_port: Option<u16>,
+    /// Whether to accept experimental validity-bearing transactions.
+    pub enable_experimental_validity_transactions: bool,
     /// Additional node extensions installed after the builder's built-in RPC wiring.
     ///
     /// Lets downstream consumers layer their own [`BaseNodeExtension`] onto the standard
@@ -143,6 +145,7 @@ impl InProcessBuilder {
         let node_config = create_node_config(chain_spec, &data_path, &jwt_path, &config)?;
         let p2p_port = node_config.network.port;
 
+        let accept_validity_transactions = config.enable_experimental_validity_transactions;
         let node_builder = NodeBuilder::new(node_config.clone())
             .with_database(db)
             .with_launch_context(runtime.clone())
@@ -156,9 +159,10 @@ impl InProcessBuilder {
             .with_add_ons(addons)
             .on_component_initialized(move |_ctx| Ok(()))
             // Register the builder API RPC module (base_insertValidatedTransaction)
-            .extend_rpc_modules(|ctx| {
+            .extend_rpc_modules(move |ctx| {
                 let api = BuilderApiImpl::<_, base_execution_txpool::TransactionValidity>::with_extensions(
                     ctx.pool().clone(),
+                    accept_validity_transactions,
                 );
                 ctx.modules.merge_configured(api.into_rpc())?;
                 Ok(())

--- a/etc/systems/src/l2/in_process_builder.rs
+++ b/etc/systems/src/l2/in_process_builder.rs
@@ -157,7 +157,9 @@ impl InProcessBuilder {
             .on_component_initialized(move |_ctx| Ok(()))
             // Register the builder API RPC module (base_insertValidatedTransaction)
             .extend_rpc_modules(|ctx| {
-                let api = BuilderApiImpl::new(ctx.pool().clone());
+                let api = BuilderApiImpl::<_, base_execution_txpool::TransactionValidity>::with_extensions(
+                    ctx.pool().clone(),
+                );
                 ctx.modules.merge_configured(api.into_rpc())?;
                 Ok(())
             });

--- a/etc/systems/src/l2/in_process_client.rs
+++ b/etc/systems/src/l2/in_process_client.rs
@@ -56,6 +56,8 @@ pub struct InProcessClientConfig {
     /// Optional transaction forwarding configuration.
     /// When set, the client will forward transactions to builder RPC endpoints.
     pub tx_forwarding_config: Option<TxForwardingConfig>,
+    /// Whether to register the experimental validity transaction RPC.
+    pub enable_experimental_validity_transactions: bool,
     /// Optional L1 upgrade signal configuration.
     ///
     /// When the mode applies at startup, the schedule is read from L1 and applied to the chain
@@ -317,7 +319,9 @@ impl InProcessClient {
             && tx_fwd_config.enabled
             && !tx_fwd_config.builder_urls.is_empty()
         {
-            extensions.push(Box::new(SendRawTransactionValidityExtension::from_config(())));
+            if config.enable_experimental_validity_transactions {
+                extensions.push(Box::new(SendRawTransactionValidityExtension::from_config(())));
+            }
             extensions.push(Box::new(TxForwardingExtension::from_config(tx_fwd_config.clone())));
         }
 

--- a/etc/systems/src/l2/in_process_client.rs
+++ b/etc/systems/src/l2/in_process_client.rs
@@ -16,7 +16,7 @@ use base_flashblocks_node::FlashblocksExtension;
 use base_node_core::args::RollupArgs;
 use base_node_runner::{BaseNode, BaseNodeExtension, FromExtensionConfig, NodeHooks};
 use base_tx_forwarding::{TxForwardingConfig, TxForwardingExtension};
-use base_txpool_rpc::{TxPoolRpcConfig, TxPoolRpcExtension};
+use base_txpool_rpc::{SendRawTransactionValidityExtension, TxPoolRpcConfig, TxPoolRpcExtension};
 use base_txpool_tracing::{TxPoolExtension, TxpoolConfig};
 use eyre::{Context, Result, eyre};
 use reth_db::{
@@ -314,7 +314,11 @@ impl InProcessClient {
 
         // TxForwarding extension (optional - forwards txs to builder RPC)
         if let Some(ref tx_fwd_config) = config.tx_forwarding_config {
-            extensions.push(Box::new(TxForwardingExtension::from_config(tx_fwd_config.clone())));
+            if tx_fwd_config.enabled && !tx_fwd_config.builder_urls.is_empty() {
+                extensions.push(Box::new(SendRawTransactionValidityExtension::from_config(())));
+                extensions
+                    .push(Box::new(TxForwardingExtension::from_config(tx_fwd_config.clone())));
+            }
         }
 
         // Upgrade signal runtime extension (optional - live L1 schedule polling)

--- a/etc/systems/src/l2/in_process_client.rs
+++ b/etc/systems/src/l2/in_process_client.rs
@@ -315,11 +315,11 @@ impl InProcessClient {
         extensions.push(Box::new(TxPoolExtension::new(txpool_config)));
 
         // TxForwarding extension (optional - forwards txs to builder RPC)
-        if let Some(ref tx_fwd_config) = config.tx_forwarding_config
-            && tx_fwd_config.enabled
-            && !tx_fwd_config.builder_urls.is_empty()
-        {
-            if config.enable_experimental_validity_transactions {
+        if let Some(ref tx_fwd_config) = config.tx_forwarding_config {
+            if config.enable_experimental_validity_transactions
+                && tx_fwd_config.enabled
+                && !tx_fwd_config.builder_urls.is_empty()
+            {
                 extensions.push(Box::new(SendRawTransactionValidityExtension::from_config(())));
             }
             extensions.push(Box::new(TxForwardingExtension::from_config(tx_fwd_config.clone())));

--- a/etc/systems/src/l2/in_process_client.rs
+++ b/etc/systems/src/l2/in_process_client.rs
@@ -313,12 +313,12 @@ impl InProcessClient {
         extensions.push(Box::new(TxPoolExtension::new(txpool_config)));
 
         // TxForwarding extension (optional - forwards txs to builder RPC)
-        if let Some(ref tx_fwd_config) = config.tx_forwarding_config {
-            if tx_fwd_config.enabled && !tx_fwd_config.builder_urls.is_empty() {
-                extensions.push(Box::new(SendRawTransactionValidityExtension::from_config(())));
-                extensions
-                    .push(Box::new(TxForwardingExtension::from_config(tx_fwd_config.clone())));
-            }
+        if let Some(ref tx_fwd_config) = config.tx_forwarding_config
+            && tx_fwd_config.enabled
+            && !tx_fwd_config.builder_urls.is_empty()
+        {
+            extensions.push(Box::new(SendRawTransactionValidityExtension::from_config(())));
+            extensions.push(Box::new(TxForwardingExtension::from_config(tx_fwd_config.clone())));
         }
 
         // Upgrade signal runtime extension (optional - live L1 schedule polling)

--- a/etc/systems/src/l2/shadow_sequencer.rs
+++ b/etc/systems/src/l2/shadow_sequencer.rs
@@ -86,6 +86,7 @@ impl ShadowSequencer {
             auth_port: None,
             p2p_port: None,
             flashblocks_port: None,
+            enable_experimental_validity_transactions: false,
             extra_extensions: Vec::new(),
         })
         .await

--- a/etc/systems/src/l2/stack.rs
+++ b/etc/systems/src/l2/stack.rs
@@ -73,6 +73,8 @@ pub struct L2StackConfig {
     /// Optional transaction forwarding configuration for the client node.
     /// When set, the client will forward transactions to builder RPC endpoints.
     pub tx_forwarding_config: Option<TxForwardingConfig>,
+    /// Whether both L2 nodes enable experimental validity transaction transport.
+    pub enable_experimental_validity_transactions: bool,
     /// Number of L1 blocks to keep distance from the L1 head for the client (validator)
     /// consensus node's derivation pipeline.
     pub verifier_l1_confs: u64,
@@ -195,6 +197,8 @@ impl L2Stack {
             auth_port: container_config.and_then(|c| c.builder_auth_port),
             p2p_port: container_config.and_then(|c| c.builder_p2p_port),
             flashblocks_port: container_config.and_then(|c| c.builder_flashblocks_port),
+            enable_experimental_validity_transactions: config
+                .enable_experimental_validity_transactions,
             extra_extensions: config.extra_builder_extensions,
         };
         let builder = InProcessBuilder::start(builder_config)
@@ -273,6 +277,8 @@ impl L2Stack {
             auth_port: container_config.and_then(|c| c.client_auth_port),
             p2p_port: container_config.and_then(|c| c.client_p2p_port),
             tx_forwarding_config,
+            enable_experimental_validity_transactions: config
+                .enable_experimental_validity_transactions,
             upgrade_signal: config.execution_upgrade_signal.clone(),
             extra_extensions: config.extra_client_extensions,
         };

--- a/etc/systems/src/smoke.rs
+++ b/etc/systems/src/smoke.rs
@@ -280,6 +280,7 @@ pub struct SystemTestStackBuilder {
     output_dir: Option<PathBuf>,
     stable_config: Option<StableSystemTestConfig>,
     tx_forwarding_config: Option<TxForwardingConfig>,
+    enable_experimental_validity_transactions: bool,
     verifier_l1_confs: u64,
     client_consensus_mode: L2ClientConsensusMode,
     shadow_sequencer_count: usize,
@@ -363,6 +364,12 @@ impl SystemTestStackBuilder {
     /// the `base_insertValidatedTransaction` RPC endpoint.
     pub fn with_tx_forwarding(mut self, config: TxForwardingConfig) -> Self {
         self.tx_forwarding_config = Some(config);
+        self
+    }
+
+    /// Enables experimental validity transaction ingress and builder acceptance.
+    pub const fn with_experimental_validity_transactions(mut self) -> Self {
+        self.enable_experimental_validity_transactions = true;
         self
     }
 
@@ -630,6 +637,8 @@ impl SystemTestStackBuilder {
             l1_beacon_url: l1_stack.beacon().beacon_url().await?,
             container_config: l2_container_config,
             tx_forwarding_config: self.tx_forwarding_config,
+            enable_experimental_validity_transactions: self
+                .enable_experimental_validity_transactions,
             verifier_l1_confs: self.verifier_l1_confs,
             client_consensus_mode: self.client_consensus_mode,
             upgrade_signal: l2_upgrade_signal,

--- a/etc/systems/tests/tx_forwarding.rs
+++ b/etc/systems/tests/tx_forwarding.rs
@@ -16,9 +16,11 @@ use alloy_signer_local::PrivateKeySigner;
 use base_common_rpc_types::BaseTransactionRequest;
 use base_execution_txpool::{NoExtensions, ValidatedTransaction};
 use base_system_tests::{
-    ANVIL_ACCOUNT_1, ANVIL_ACCOUNT_2, ANVIL_ACCOUNT_3, ANVIL_ACCOUNT_4, SystemTestStackBuilder,
+    ANVIL_ACCOUNT_1, ANVIL_ACCOUNT_2, ANVIL_ACCOUNT_3, ANVIL_ACCOUNT_4, SystemTestProviderExt,
+    SystemTestStackBuilder,
 };
 use base_tx_forwarding::TxForwardingConfig;
+use base_txpool_rpc::SendRawTransactionValidityRequest;
 use eyre::{Result, WrapErr};
 use tokio::time::{sleep, timeout};
 
@@ -248,6 +250,64 @@ async fn test_tx_forwarding_pipeline_system() -> Result<()> {
 
     Ok(())
 }
+
+/// Tests validity-bearing transaction ingress through the production forwarding pipeline.
+#[tokio::test]
+async fn test_validity_tx_forwarding_pipeline_system() -> Result<()> {
+    let system = SystemTestStackBuilder::new()
+        .with_l1_chain_id(L1_CHAIN_ID)
+        .with_l2_chain_id(L2_CHAIN_ID)
+        .with_tx_forwarding(
+            TxForwardingConfig::new(vec![]).with_resend_after_ms(2000).with_max_batch_size(100),
+        )
+        .build()
+        .await?;
+
+    let builder_provider = system.l2_builder_provider()?;
+    let client_provider = system.l2_client_provider()?;
+    builder_provider.wait_for_block(3, Duration::from_secs(15)).await?;
+    client_provider.wait_for_block(3, Duration::from_secs(15)).await?;
+
+    let private_key_hex = format!("0x{}", hex::encode(ANVIL_ACCOUNT_1.private_key.as_slice()));
+    let signer: PrivateKeySigner = private_key_hex.parse()?;
+    let sender = signer.address();
+    client_provider.wait_for_balance(sender, Duration::from_secs(15)).await?;
+
+    let nonce = client_provider.get_transaction_count(sender).await?;
+    let recipient: Address = "0x000000000000000000000000000000000000dEaD".parse()?;
+    let (_, raw_tx, expected_tx_hash) =
+        create_signed_eip1559_tx(&signer, L2_CHAIN_ID, nonce, recipient)?;
+    let validity = serde_json::from_value(serde_json::json!({
+        "type": "storage",
+        "params": {
+            "address": recipient,
+            "slot": "0x1",
+            "op": "=",
+            "value": "0x2"
+        }
+    }))?;
+    let rpc_client = RpcClient::builder().http(system.l2_client_rpc_url()?);
+
+    let tx_hash: alloy_primitives::B256 = rpc_client
+        .request(
+            "base_sendRawTransactionValidity",
+            (SendRawTransactionValidityRequest { tx: raw_tx, validity: vec![validity] },),
+        )
+        .await?;
+
+    assert_eq!(tx_hash, expected_tx_hash, "Transaction hash mismatch");
+
+    // TODO: Update this "transaction landed" assertion when validity transactions are split out
+    // of the builder's regular txpool; the dedicated validity pool will need its own observable.
+    let receipt = builder_provider.wait_for_receipt(expected_tx_hash, TX_RECEIPT_TIMEOUT).await?;
+    assert_eq!(receipt.inner.transaction_hash, expected_tx_hash);
+    assert!(receipt.inner.block_number.is_some(), "Receipt should have block number");
+    assert_eq!(receipt.inner.from, sender);
+    assert_eq!(receipt.inner.to, Some(recipient));
+
+    Ok(())
+}
+
 /// Tests that the forwarding pipeline handles high transaction load under rate limiting.
 ///
 /// Uses all 4 available test accounts (`ANVIL_ACCOUNT_1` through `ANVIL_ACCOUNT_4`) to send

--- a/etc/systems/tests/tx_forwarding.rs
+++ b/etc/systems/tests/tx_forwarding.rs
@@ -260,6 +260,7 @@ async fn test_validity_tx_forwarding_pipeline_system() -> Result<()> {
         .with_tx_forwarding(
             TxForwardingConfig::new(vec![]).with_resend_after_ms(2000).with_max_batch_size(100),
         )
+        .with_experimental_validity_transactions()
         .build()
         .await?;
 


### PR DESCRIPTION
## Summary

Adds the `base_sendRawTransactionValidity` endpoint with top-level `tx` and `validity` request fields. Transactions are submitted to the local pool or forwarded intact to the configured sequencer, while validity criteria remain opaque and intentionally unenforced until their semantics are finalized. Tests cover the request shape, RPC registration, malformed input, local submission, and sequencer forwarding.