### PR TITLE
fix(chains): align built-in configs with Docker devnet

### DIFF
--- a/bin/base/src/config.rs
+++ b/bin/base/src/config.rs
@@ -257,8 +257,8 @@ mod tests {
                 ChainResolver::new(Some(ChainArg::BuiltIn("dev".to_owned()))).resolve().unwrap();
 
             assert_eq!(resolved.name, "dev");
-            assert_eq!(resolved.l2_chain_id, 1337);
-            assert_eq!(resolved.l1_chain_id, 900);
+            assert_eq!(resolved.l2_chain_id, 84538453);
+            assert_eq!(resolved.l1_chain_id, 1337);
             assert_eq!(resolved.source, ResolvedChainSource::BuiltIn("dev".to_owned()));
 
             Ok(())

--- a/crates/common/chains/src/config.rs
+++ b/crates/common/chains/src/config.rs
@@ -153,6 +153,13 @@ pub const SEPOLIA_BERYL_ACTIVATION_ADMIN_ADDRESS: Address =
 pub const ZERONET_BERYL_ACTIVATION_ADMIN_ADDRESS: Address =
     address!("F5969A85a555671EeD766C4ff0C61426AA626b11");
 
+/// Local Docker devnet activation registry admin used by Beryl before Cobalt state-backed storage.
+///
+/// Matches `L2_ACTIVATION_ADMIN_ADDR` in `etc/scripts/devnet/setup-l2.sh`, which defaults to the
+/// deterministic devnet sequencer address.
+pub const DEVNET_BERYL_ACTIVATION_ADMIN_ADDRESS: Address =
+    address!("9965507D1a55bcC2695C58ba16FB37d819B0A4dc");
+
 impl ChainConfig {
     /// CLI chain name for Base Mainnet.
     pub const MAINNET_NAME: &'static str = "base";
@@ -249,7 +256,7 @@ impl ChainConfig {
         match id {
             8453 => Some(&MAINNET),
             84532 => Some(&SEPOLIA),
-            1337 => Some(&DEVNET),
+            84538453 => Some(&DEVNET),
             763360 => Some(&ZERONET),
             _ => None,
         }
@@ -282,6 +289,7 @@ impl ChainConfig {
             8453 => Some(MAINNET_BERYL_ACTIVATION_ADMIN_ADDRESS),
             84532 => Some(SEPOLIA_BERYL_ACTIVATION_ADMIN_ADDRESS),
             763360 => Some(ZERONET_BERYL_ACTIVATION_ADMIN_ADDRESS),
+            84538453 => Some(DEVNET_BERYL_ACTIVATION_ADMIN_ADDRESS),
             _ => None,
         }
     }
@@ -542,8 +550,8 @@ const SEPOLIA: ChainConfig = ChainConfig {
 };
 
 const DEVNET: ChainConfig = ChainConfig {
-    chain_id: 1337,
-    l1_chain_id: 900,
+    chain_id: 84538453,
+    l1_chain_id: 1337,
 
     block_time: 2,
     seq_window_size: 3600,
@@ -754,6 +762,10 @@ mod tests {
         assert_eq!(
             ChainConfig::activation_admin_address_for_upgrade_by_chain_id(84532, BaseUpgrade::Azul),
             None
+        );
+        assert_eq!(
+            ChainConfig::beryl_activation_admin_address_by_chain_id(84538453),
+            Some(DEVNET_BERYL_ACTIVATION_ADMIN_ADDRESS)
         );
     }
 }

--- a/crates/common/chains/src/ethereum/config.rs
+++ b/crates/common/chains/src/ethereum/config.rs
@@ -5,11 +5,12 @@ use alloy_genesis::ChainConfig as GenesisChainConfig;
 use alloy_primitives::map::HashMap;
 use spin::Lazy;
 
-use crate::{Holesky, Hoodi, Mainnet, Sepolia};
+use crate::{Devnet, Holesky, Hoodi, Mainnet, Sepolia};
 
 /// Ethereum L1 chain configurations keyed by chain ID.
 pub static L1_CONFIGS: Lazy<HashMap<u64, GenesisChainConfig>> = Lazy::new(|| {
     let mut map = HashMap::default();
+    map.insert(Devnet::CHAIN_ID, Devnet::l1_config());
     map.insert(NamedChain::Mainnet.into(), Mainnet::l1_config());
     map.insert(NamedChain::Sepolia.into(), Sepolia::l1_config());
     map.insert(NamedChain::Holesky.into(), Holesky::l1_config());
@@ -28,16 +29,26 @@ mod tests {
 
     #[test]
     fn l1_config_all_chains() {
+        let devnet_chain_id = Devnet::CHAIN_ID;
         let mainnet_chain_id = u64::from(NamedChain::Mainnet);
         let sepolia_chain_id = u64::from(NamedChain::Sepolia);
         let holesky_chain_id = u64::from(NamedChain::Holesky);
         let hoodi_chain_id = u64::from(NamedChain::Hoodi);
 
+        assert!(L1_CONFIGS.get(&devnet_chain_id).is_some());
         assert!(L1_CONFIGS.get(&mainnet_chain_id).is_some());
         assert!(L1_CONFIGS.get(&sepolia_chain_id).is_some());
         assert!(L1_CONFIGS.get(&holesky_chain_id).is_some());
         assert!(L1_CONFIGS.get(&hoodi_chain_id).is_some());
         assert!(L1_CONFIGS.get(&99999).is_none());
+    }
+
+    #[test]
+    fn devnet_rollup_l1_config_resolves() {
+        let rollup_config = crate::rollup_config!(crate::ChainConfig::devnet().chain_id).unwrap();
+        let l1_config = L1_CONFIGS.get(&rollup_config.l1_chain_id).unwrap();
+
+        assert_eq!(l1_config.chain_id, Devnet::CHAIN_ID);
     }
 
     #[test]

--- a/crates/common/chains/src/ethereum/devnet.rs
+++ b/crates/common/chains/src/ethereum/devnet.rs
@@ -1,0 +1,74 @@
+//! Ethereum L1 configuration for the local Docker devnet.
+
+use alloy_genesis::ChainConfig;
+use alloy_primitives::U256;
+
+/// Local Docker devnet L1 chain configuration builder.
+#[derive(Debug, Clone, Copy)]
+pub struct Devnet;
+
+impl Devnet {
+    /// Local Docker devnet L1 chain ID.
+    pub const CHAIN_ID: u64 = 1337;
+
+    /// Returns the local Docker devnet L1 [`ChainConfig`].
+    pub fn l1_config() -> ChainConfig {
+        ChainConfig {
+            chain_id: Self::CHAIN_ID,
+            homestead_block: Some(0),
+            dao_fork_block: None,
+            dao_fork_support: false,
+            eip150_block: Some(0),
+            eip155_block: Some(0),
+            eip158_block: Some(0),
+            byzantium_block: Some(0),
+            constantinople_block: Some(0),
+            petersburg_block: Some(0),
+            istanbul_block: Some(0),
+            muir_glacier_block: None,
+            berlin_block: Some(0),
+            london_block: Some(0),
+            arrow_glacier_block: Some(0),
+            gray_glacier_block: Some(0),
+            shanghai_time: Some(0),
+            cancun_time: Some(0),
+            prague_time: Some(0),
+            osaka_time: Some(0),
+            amsterdam_time: None,
+            bpo1_time: Some(0),
+            bpo2_time: Some(0),
+            bpo3_time: None,
+            bpo4_time: None,
+            bpo5_time: None,
+            ethash: None,
+            blob_schedule: super::BlobSchedule::schedule(),
+            merge_netsplit_block: None,
+            terminal_total_difficulty: Some(U256::ZERO),
+            deposit_contract_address: None,
+            clique: None,
+            parlia: None,
+            extra_fields: Default::default(),
+            terminal_total_difficulty_passed: false,
+            _non_exhaustive: (),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_matches_docker_devnet_genesis() {
+        let config = Devnet::l1_config();
+
+        assert_eq!(config.chain_id, Devnet::CHAIN_ID);
+        assert_eq!(config.shanghai_time, Some(0));
+        assert_eq!(config.cancun_time, Some(0));
+        assert_eq!(config.prague_time, Some(0));
+        assert_eq!(config.osaka_time, Some(0));
+        assert_eq!(config.bpo1_time, Some(0));
+        assert_eq!(config.bpo2_time, Some(0));
+        assert_eq!(config.blob_schedule, super::super::BlobSchedule::schedule());
+    }
+}

--- a/crates/common/chains/src/ethereum/mod.rs
+++ b/crates/common/chains/src/ethereum/mod.rs
@@ -7,6 +7,9 @@ use alloc::{
 
 use alloy_eips::eip7840::BlobParams;
 
+mod devnet;
+pub use devnet::Devnet;
+
 mod mainnet;
 pub use mainnet::Mainnet;
 

--- a/crates/common/chains/src/lib.rs
+++ b/crates/common/chains/src/lib.rs
@@ -7,8 +7,9 @@ extern crate alloc;
 
 mod config;
 pub use config::{
-    Bootnodes, ChainConfig, MAINNET_BERYL_ACTIVATION_ADMIN_ADDRESS,
-    SEPOLIA_BERYL_ACTIVATION_ADMIN_ADDRESS, ZERONET_BERYL_ACTIVATION_ADMIN_ADDRESS,
+    Bootnodes, ChainConfig, DEVNET_BERYL_ACTIVATION_ADMIN_ADDRESS,
+    MAINNET_BERYL_ACTIVATION_ADMIN_ADDRESS, SEPOLIA_BERYL_ACTIVATION_ADMIN_ADDRESS,
+    ZERONET_BERYL_ACTIVATION_ADMIN_ADDRESS,
 };
 
 mod upgrade;
@@ -24,7 +25,7 @@ mod macros;
 pub use macros::RollupConfigSource;
 
 mod ethereum;
-pub use ethereum::{Holesky, Hoodi, L1_CONFIGS, Mainnet, Sepolia};
+pub use ethereum::{Devnet, Holesky, Hoodi, L1_CONFIGS, Mainnet, Sepolia};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;

--- a/crates/infra/load-tests/src/runner/config.rs
+++ b/crates/infra/load-tests/src/runner/config.rs
@@ -243,7 +243,7 @@ impl LoadConfig {
             ],
             query_rpc: "http://localhost:8545".parse().expect("valid default query_rpc"),
             txpool_nodes: Vec::new(),
-            chain_id: 1337,
+            chain_id: 84538453,
             account_count: 10,
             seed: 42,
             mnemonic: None,

--- a/crates/proof/tee/nitro-enclave/src/server.rs
+++ b/crates/proof/tee/nitro-enclave/src/server.rs
@@ -344,8 +344,8 @@ mod tests {
             b256!("12e9c45f19f9817c6d4385fad29e7a70c355502cf0883e76a9a7e478a85d1360"),
         );
         assert_eq!(
-            config_hash_for_chain(1337).unwrap(),
-            b256!("1bb15c380e7cf5cfd303807cc1dff6cd5275a6facc7628091d8b3a7ab6d631b1"),
+            config_hash_for_chain(84538453).unwrap(),
+            b256!("846b1fd10a5e22fb7572cc4ac794454d301b382c64ab934091e519486e5200be"),
         );
         assert_eq!(
             config_hash_for_chain(763360).unwrap(),


### PR DESCRIPTION
## Summary

- align the built-in Base devnet identity with the Docker devnet (`L2 84538453` on `L1 1337`)
- register the Docker L1 deterministic execution-fork configuration in `L1_CONFIGS`
- add the Docker devnet Beryl activation admin used before Cobalt state-backed storage
- update the Nitro enclave config-hash golden value and cover devnet L2-to-L1 registry resolution
- update the load-test devnet preset to use L2 chain ID `84538453`

## Context

The Docker devnet already runs Base L2 chain `84538453` on L1 chain `1337`, while the built-in devnet entry still modeled the obsolete `1337`/`900` pairing. Nitro proving resolves both configurations through the compiled chain registries, so the stale identity caused the Docker devnet to be rejected as unsupported.

The L1 fork settings are deterministic in `etc/scripts/devnet/templates/l1-el-genesis.json.template`; only the genesis timestamp and resulting block hash vary, and neither is part of `alloy_genesis::ChainConfig`.

This is the chain-configuration prerequisite for #4378. It supersedes the chain-configuration portion of the closed #4341 implementation.

## Validation

Rebased onto current `main`; the two-commit patch is unchanged according to `git range-diff`.

- `cargo test -p base-common-chains` — 45 passed
- `cargo test -p base-load-tests --lib --locked` — 52 passed
- `cargo clippy -p base-common-chains --all-targets -- -D warnings`
- `cargo test -p base-proof-tee-nitro-enclave config_hash_known_values`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
