### PR TITLE
feat(infra): add shadow-metrics noop mock service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6277,6 +6277,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-shadow-metrics"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "sqlx",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "base-shadow-metrics-bin"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "axum 0.8.9",
+ "base-cli-utils",
+ "base-shadow-metrics",
+ "clap",
+ "dotenvy",
+ "serde",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "base-sidecrush"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,10 +201,9 @@ ingress-rpc-lib = { path = "crates/infra/ingress-rpc" }
 base-snapshotter = { path = "crates/infra/snapshotter" }
 websocket-proxy = { path = "crates/infra/websocket-proxy" }
 base-telemetry-service = { path = "crates/infra/telemetry" }
+base-shadow-metrics = { path = "crates/infra/shadow-metrics" }
 base-zk-benchmarks = { path = "crates/infra/zk-benchmarks" }
 base-zk-fork-dispute = { path = "crates/infra/zk-fork-dispute" }
-base-shadow-metrics = { path = "crates/infra/shadow-metrics" }
-base-shadow-metrics-bin = { path = "bin/shadow-metrics" }
 
 # Proof
 base-proof-rpc = { path = "crates/proof/rpc" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,6 +203,8 @@ websocket-proxy = { path = "crates/infra/websocket-proxy" }
 base-telemetry-service = { path = "crates/infra/telemetry" }
 base-zk-benchmarks = { path = "crates/infra/zk-benchmarks" }
 base-zk-fork-dispute = { path = "crates/infra/zk-fork-dispute" }
+base-shadow-metrics = { path = "crates/infra/shadow-metrics" }
+base-shadow-metrics-bin = { path = "bin/shadow-metrics" }
 
 # Proof
 base-proof-rpc = { path = "crates/proof/rpc" }

--- a/bin/shadow-metrics/Cargo.toml
+++ b/bin/shadow-metrics/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "base-shadow-metrics-bin"
+version.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+
+[[bin]]
+name = "shadow-metrics"
+path = "src/main.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+serde.workspace = true
+tokio.workspace = true
+anyhow.workspace = true
+dotenvy.workspace = true
+base-cli-utils.workspace = true
+base-shadow-metrics.workspace = true
+axum = { workspace = true, features = ["tokio", "http1"] }
+tracing = { workspace = true, features = ["std"] }
+clap = { workspace = true, features = ["derive", "env"] }

--- a/bin/shadow-metrics/Cargo.toml
+++ b/bin/shadow-metrics/Cargo.toml
@@ -16,11 +16,11 @@ workspace = true
 
 [dependencies]
 serde.workspace = true
-tokio.workspace = true
 anyhow.workspace = true
 dotenvy.workspace = true
 base-cli-utils.workspace = true
 base-shadow-metrics.workspace = true
-axum = { workspace = true, features = ["tokio", "http1"] }
 tracing = { workspace = true, features = ["std"] }
 clap = { workspace = true, features = ["derive", "env"] }
+axum = { workspace = true, features = ["tokio", "http1"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "time", "signal"] }

--- a/bin/shadow-metrics/README.md
+++ b/bin/shadow-metrics/README.md
@@ -1,0 +1,33 @@
+# `shadow-metrics`
+
+Noop mock service that connects to Postgres from config and exposes health
+probes. It performs no real metrics work; it is a scaffold that proves
+configuration-driven Postgres connectivity and Kubernetes-style health probes.
+
+## Behavior
+
+- `serve` (default): connects to Postgres when `SHADOW_METRICS_POSTGRES_URL` is
+  set, starts an HTTP health server (`GET /healthz`, `GET /readyz`), and runs an
+  idle heartbeat loop. `/readyz` verifies the Postgres schema is migrated when a
+  connection is configured; otherwise it always reports ready.
+- `migrate up`: runs pending Postgres migrations, then exits.
+
+## Security Model
+
+The health endpoints are unauthenticated internal endpoints. Restrict them to a
+private network; never expose them publicly. The wildcard bind supports
+container networking.
+
+## Configuration
+
+| Env var                              | Default | Description                                  |
+| ------------------------------------ | ------- | -------------------------------------------- |
+| `SHADOW_METRICS_POSTGRES_URL`        | (unset) | Postgres URL. When unset, DB is disabled.    |
+| `SHADOW_METRICS_POSTGRES_MAX_CONNECTIONS` | `10` | Max Postgres pool connections.               |
+| `SHADOW_METRICS_HTTP_PORT`           | `9101`  | Health server port.                          |
+| `SHADOW_METRICS_HEARTBEAT_INTERVAL_SECS` | `30` | Idle heartbeat log interval in seconds.      |
+| `SHADOW_METRICS_METRICS_PORT`        | `9003`  | Prometheus metrics port.                     |
+
+## License
+
+Licensed under the [MIT License](https://github.com/base/base/blob/main/LICENSE).

--- a/bin/shadow-metrics/src/main.rs
+++ b/bin/shadow-metrics/src/main.rs
@@ -136,6 +136,34 @@ async fn run_server(args: Args) -> Result<()> {
         result = http_server => {
             result.map_err(|e| anyhow::anyhow!("shadow-metrics health server stopped unexpectedly: {e}"))
         }
+        () = shutdown_signal() => {
+            info!("Shutdown signal received; stopping shadow-metrics");
+            Ok(())
+        }
+    }
+}
+
+/// Resolves on SIGINT or, on Unix, SIGTERM so the k8s pre-kill SIGTERM unwinds
+/// the runtime and drops the `PgPool` cleanly instead of a hard kill.
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c().await.expect("failed to install SIGINT handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        () = ctrl_c => {},
+        () = terminate => {},
     }
 }
 
@@ -159,11 +187,15 @@ async fn healthz_handler() -> &'static str {
 }
 
 async fn readyz_handler(State(state): State<HealthState>) -> Response {
-    match ShadowMetricsSink::check_optional_schema_ready(state.sink.as_ref()).await {
-        Ok(()) => (StatusCode::OK, "ready\n".to_string()).into_response(),
+    let readiness = match &state.sink {
+        Some(sink) => sink.check_schema_ready().await,
+        None => Ok(()),
+    };
+    match readiness {
+        Ok(()) => (StatusCode::OK, "ready\n").into_response(),
         Err(err) => {
             error!(error = %err, "shadow-metrics readiness check failed");
-            (StatusCode::SERVICE_UNAVAILABLE, "not ready\n".to_string()).into_response()
+            (StatusCode::SERVICE_UNAVAILABLE, "not ready\n").into_response()
         }
     }
 }

--- a/bin/shadow-metrics/src/main.rs
+++ b/bin/shadow-metrics/src/main.rs
@@ -1,0 +1,169 @@
+//! Shadow-metrics noop mock service entry point.
+
+use std::{net::SocketAddr, time::Duration};
+
+use anyhow::Result;
+use axum::{
+    Router,
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::get,
+};
+use base_cli_utils::LogConfig;
+use base_shadow_metrics::ShadowMetricsSink;
+use clap::{Parser, ValueEnum};
+use tokio::net::TcpListener;
+use tracing::{error, info};
+
+base_cli_utils::define_log_args!("SHADOW_METRICS");
+base_cli_utils::define_metrics_args!("SHADOW_METRICS", 9003);
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum Command {
+    Serve,
+    Migrate,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum MigrationDirection {
+    Up,
+}
+
+#[derive(Debug, Clone)]
+struct HealthState {
+    sink: Option<ShadowMetricsSink>,
+}
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    #[arg(value_enum, default_value_t = Command::Serve)]
+    command: Command,
+
+    #[arg(value_enum)]
+    migration_direction: Option<MigrationDirection>,
+
+    #[command(flatten)]
+    log: LogArgs,
+
+    #[command(flatten)]
+    metrics: MetricsArgs,
+
+    /// Postgres connection URL. When unset, Postgres connectivity is disabled
+    /// and `/readyz` always reports ready.
+    #[arg(long, env = "SHADOW_METRICS_POSTGRES_URL")]
+    postgres_url: Option<String>,
+
+    /// Maximum Postgres pool connections.
+    #[arg(long, env = "SHADOW_METRICS_POSTGRES_MAX_CONNECTIONS", default_value = "10")]
+    postgres_max_connections: u32,
+
+    /// Health server port.
+    #[arg(long, env = "SHADOW_METRICS_HTTP_PORT", default_value = "9101")]
+    http_port: u16,
+
+    /// Idle heartbeat log interval in seconds.
+    #[arg(long, env = "SHADOW_METRICS_HEARTBEAT_INTERVAL_SECS", default_value = "30")]
+    heartbeat_interval_secs: u64,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    dotenvy::dotenv().ok();
+
+    let args = Args::parse();
+
+    LogConfig::from(args.log.clone())
+        .init_tracing_subscriber()
+        .expect("Failed to initialize tracing");
+
+    base_cli_utils::MetricsConfig::from(args.metrics.clone())
+        .init()
+        .expect("Failed to install Prometheus exporter");
+
+    if matches!(args.command, Command::Migrate) {
+        run_migrations(&args).await?;
+        return Ok(());
+    }
+
+    run_server(args).await
+}
+
+async fn run_migrations(args: &Args) -> Result<()> {
+    if !matches!(args.migration_direction, Some(MigrationDirection::Up)) {
+        anyhow::bail!("migration command requires an explicit direction: migrate up");
+    }
+
+    let postgres_url = args
+        .postgres_url
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("SHADOW_METRICS_POSTGRES_URL must be set for migrations"))?;
+
+    info!("Running shadow-metrics Postgres migrations");
+    ShadowMetricsSink::migrate(postgres_url).await?;
+    info!("Shadow-metrics Postgres migrations complete");
+    Ok(())
+}
+
+async fn run_server(args: Args) -> Result<()> {
+    let http_addr = SocketAddr::from(([0, 0, 0, 0], args.http_port));
+
+    let sink = if let Some(postgres_url) = &args.postgres_url {
+        Some(ShadowMetricsSink::connect(postgres_url, args.postgres_max_connections).await?)
+    } else {
+        None
+    };
+
+    info!(
+        http_addr = %http_addr,
+        metrics_addr = %args.metrics.addr,
+        metrics_port = args.metrics.port,
+        postgres_enabled = args.postgres_url.is_some(),
+        heartbeat_interval_secs = args.heartbeat_interval_secs,
+        "Starting shadow-metrics noop service"
+    );
+
+    let app = health_router(sink);
+    let http_listener = TcpListener::bind(http_addr).await?;
+    let http_server = axum::serve(http_listener, app);
+    info!(http_addr = %http_addr, "Shadow-metrics health server started");
+
+    let heartbeat = run_heartbeat(Duration::from_secs(args.heartbeat_interval_secs));
+
+    tokio::select! {
+        result = heartbeat => result,
+        result = http_server => {
+            result.map_err(|e| anyhow::anyhow!("shadow-metrics health server stopped unexpectedly: {e}"))
+        }
+    }
+}
+
+async fn run_heartbeat(interval: Duration) -> Result<()> {
+    let mut ticker = tokio::time::interval(interval);
+    loop {
+        ticker.tick().await;
+        info!("shadow-metrics noop heartbeat");
+    }
+}
+
+fn health_router(sink: Option<ShadowMetricsSink>) -> Router {
+    Router::new()
+        .route("/healthz", get(healthz_handler))
+        .route("/readyz", get(readyz_handler))
+        .with_state(HealthState { sink })
+}
+
+async fn healthz_handler() -> &'static str {
+    "ok\n"
+}
+
+async fn readyz_handler(State(state): State<HealthState>) -> Response {
+    match ShadowMetricsSink::check_optional_schema_ready(state.sink.as_ref()).await {
+        Ok(()) => (StatusCode::OK, "ready\n".to_string()).into_response(),
+        Err(err) => {
+            error!(error = %err, "shadow-metrics readiness check failed");
+            (StatusCode::SERVICE_UNAVAILABLE, "not ready\n".to_string()).into_response()
+        }
+    }
+}

--- a/crates/infra/shadow-metrics/Cargo.toml
+++ b/crates/infra/shadow-metrics/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "base-shadow-metrics"
+version.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = { workspace = true, features = ["std"] }
+thiserror = { workspace = true, features = ["std"] }
+sqlx = { workspace = true, features = ["runtime-tokio", "postgres", "migrate", "macros", "tls-native-tls"] }

--- a/crates/infra/shadow-metrics/README.md
+++ b/crates/infra/shadow-metrics/README.md
@@ -1,0 +1,33 @@
+# `base-shadow-metrics`
+
+Postgres connectivity for the shadow-metrics noop mock service.
+
+## Overview
+
+Provides `ShadowMetricsSink`, a thin Postgres handle modeled on the audit
+archiver's transaction-event sink. It establishes an eager `PgPool` from a
+connection URL, embeds sqlx migrations, and exposes a schema-readiness check for
+Kubernetes-style `/readyz` probes. The service itself performs no real work; it
+is a scaffold that proves configuration-driven Postgres connectivity.
+
+## Usage
+
+Add the dependency to your `Cargo.toml`:
+
+```toml
+[dependencies]
+base-shadow-metrics = { workspace = true }
+```
+
+```rust,ignore
+use base_shadow_metrics::ShadowMetricsSink;
+
+// Run migrations, then connect.
+ShadowMetricsSink::migrate(&database_url).await?;
+let sink = ShadowMetricsSink::connect(&database_url, 10).await?;
+sink.check_schema_ready().await?;
+```
+
+## License
+
+Licensed under the [MIT License](https://github.com/base/base/blob/main/LICENSE).

--- a/crates/infra/shadow-metrics/migrations/001_shadow_metrics.sql
+++ b/crates/infra/shadow-metrics/migrations/001_shadow_metrics.sql
@@ -1,0 +1,15 @@
+-- Placeholder schema for the shadow-metrics noop service. The service performs
+-- no real work; this table exists so schema-readiness probes have a relation to
+-- verify and so future metrics storage has a migration to build on.
+CREATE TABLE IF NOT EXISTS shadow_metrics (
+    id BIGSERIAL PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'shadow_metrics') THEN
+        GRANT SELECT ON _sqlx_migrations TO shadow_metrics;
+        GRANT SELECT, INSERT, UPDATE, DELETE ON shadow_metrics TO shadow_metrics;
+    END IF;
+END $$;

--- a/crates/infra/shadow-metrics/migrations/001_shadow_metrics.sql
+++ b/crates/infra/shadow-metrics/migrations/001_shadow_metrics.sql
@@ -30,12 +30,3 @@ CREATE TABLE IF NOT EXISTS shadow_block_transactions(
   PRIMARY KEY(block_hash, tx_index)
 );
 CREATE INDEX IF NOT EXISTS idx_shadow_block_transactions_number ON shadow_block_transactions(block_number, tx_index);
-
-DO $$
-BEGIN
-    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'shadow_metrics') THEN
-        GRANT SELECT ON _sqlx_migrations TO shadow_metrics;
-        GRANT SELECT, INSERT, UPDATE, DELETE ON shadow_blocks TO shadow_metrics;
-        GRANT SELECT, INSERT, UPDATE, DELETE ON shadow_block_transactions TO shadow_metrics;
-    END IF;
-END $$;

--- a/crates/infra/shadow-metrics/migrations/001_shadow_metrics.sql
+++ b/crates/infra/shadow-metrics/migrations/001_shadow_metrics.sql
@@ -1,4 +1,4 @@
-CREATE TABLE shadow_blocks(
+CREATE TABLE IF NOT EXISTS shadow_blocks(
   number BIGINT NOT NULL,
   hash TEXT NOT NULL,
   parent_hash TEXT NOT NULL,
@@ -13,9 +13,9 @@ CREATE TABLE shadow_blocks(
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   PRIMARY KEY(number, hash)
 );
-CREATE INDEX idx_shadow_blocks_number ON shadow_blocks(number DESC);
+CREATE INDEX IF NOT EXISTS idx_shadow_blocks_number ON shadow_blocks(number DESC);
 
-CREATE TABLE shadow_block_transactions(
+CREATE TABLE IF NOT EXISTS shadow_block_transactions(
   block_number BIGINT NOT NULL,
   block_hash TEXT NOT NULL,
   tx_index INT NOT NULL,
@@ -29,7 +29,7 @@ CREATE TABLE shadow_block_transactions(
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   PRIMARY KEY(block_hash, tx_index)
 );
-CREATE INDEX idx_shadow_block_transactions_number ON shadow_block_transactions(block_number, tx_index);
+CREATE INDEX IF NOT EXISTS idx_shadow_block_transactions_number ON shadow_block_transactions(block_number, tx_index);
 
 DO $$
 BEGIN

--- a/crates/infra/shadow-metrics/migrations/001_shadow_metrics.sql
+++ b/crates/infra/shadow-metrics/migrations/001_shadow_metrics.sql
@@ -1,15 +1,41 @@
--- Placeholder schema for the shadow-metrics noop service. The service performs
--- no real work; this table exists so schema-readiness probes have a relation to
--- verify and so future metrics storage has a migration to build on.
-CREATE TABLE IF NOT EXISTS shadow_metrics (
-    id BIGSERIAL PRIMARY KEY,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+CREATE TABLE shadow_blocks(
+  number BIGINT NOT NULL,
+  hash TEXT NOT NULL,
+  parent_hash TEXT NOT NULL,
+  timestamp BIGINT NOT NULL,
+  tx_count INT NOT NULL,
+  gas_used BIGINT NOT NULL,
+  da_bytes BIGINT NOT NULL,
+  state_root TEXT NOT NULL,
+  reorged_out BOOL NOT NULL DEFAULT false,
+  canonical_hash TEXT,
+  builder_version TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY(number, hash)
 );
+CREATE INDEX idx_shadow_blocks_number ON shadow_blocks(number DESC);
+
+CREATE TABLE shadow_block_transactions(
+  block_number BIGINT NOT NULL,
+  block_hash TEXT NOT NULL,
+  tx_index INT NOT NULL,
+  tx_hash TEXT NOT NULL,
+  sender TEXT,
+  tx_type SMALLINT NOT NULL,
+  effective_priority_fee_per_gas TEXT,
+  base_fee_per_gas BIGINT,
+  gas_used BIGINT NOT NULL,
+  reorged_out BOOL NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY(block_hash, tx_index)
+);
+CREATE INDEX idx_shadow_block_transactions_number ON shadow_block_transactions(block_number, tx_index);
 
 DO $$
 BEGIN
     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'shadow_metrics') THEN
         GRANT SELECT ON _sqlx_migrations TO shadow_metrics;
-        GRANT SELECT, INSERT, UPDATE, DELETE ON shadow_metrics TO shadow_metrics;
+        GRANT SELECT, INSERT, UPDATE, DELETE ON shadow_blocks TO shadow_metrics;
+        GRANT SELECT, INSERT, UPDATE, DELETE ON shadow_block_transactions TO shadow_metrics;
     END IF;
 END $$;

--- a/crates/infra/shadow-metrics/migrations/001_shadow_metrics.sql
+++ b/crates/infra/shadow-metrics/migrations/001_shadow_metrics.sql
@@ -25,7 +25,7 @@ CREATE TABLE IF NOT EXISTS shadow_block_transactions(
   effective_priority_fee_per_gas TEXT,
   base_fee_per_gas BIGINT,
   gas_used BIGINT NOT NULL,
-  reorged_out BOOL NOT NULL,
+  reorged_out BOOL NOT NULL DEFAULT false,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   PRIMARY KEY(block_hash, tx_index)
 );

--- a/crates/infra/shadow-metrics/src/lib.rs
+++ b/crates/infra/shadow-metrics/src/lib.rs
@@ -1,0 +1,11 @@
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://avatars.githubusercontent.com/u/16627100?s=200&v=4",
+    html_favicon_url = "https://avatars.githubusercontent.com/u/16627100?s=200&v=4",
+    issue_tracker_base_url = "https://github.com/base/base/issues/"
+)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+mod sink;
+pub use sink::{ShadowMetricsSchemaReadinessError, ShadowMetricsSink};

--- a/crates/infra/shadow-metrics/src/sink.rs
+++ b/crates/infra/shadow-metrics/src/sink.rs
@@ -22,9 +22,9 @@ pub enum ShadowMetricsSchemaReadinessError {
         /// Required sqlx migration version.
         required_version: i64,
     },
-    /// The expected table is missing or not visible to the runtime role.
+    /// An expected table is missing or not visible to the runtime role.
     #[error(
-        "shadow-metrics Postgres schema is not ready: public.shadow_metrics is missing or not visible to the runtime role; run `shadow-metrics migrate up`"
+        "shadow-metrics Postgres schema is not ready: public.shadow_blocks and public.shadow_block_transactions must be present and visible to the runtime role; run `shadow-metrics migrate up`"
     )]
     ShadowMetricsRelationMissing,
     /// A readiness query failed before readiness could be determined.
@@ -96,15 +96,19 @@ impl ShadowMetricsSink {
 
     /// Checks whether shadow-metrics Postgres storage is ready for runtime use.
     pub async fn check_schema_ready(&self) -> Result<(), ShadowMetricsSchemaReadinessError> {
-        let (migration_table_exists, shadow_metrics_relation_exists): (bool, bool) =
-            sqlx::query_as(
-                "SELECT \
+        let (migration_table_exists, shadow_blocks_exists, shadow_block_transactions_exists): (
+            bool,
+            bool,
+            bool,
+        ) = sqlx::query_as(
+            "SELECT \
                     to_regclass('_sqlx_migrations') IS NOT NULL AS migration_table_exists, \
-                    to_regclass('public.shadow_metrics') IS NOT NULL AS shadow_metrics_relation_exists",
-            )
-            .fetch_one(&self.pool)
-            .await
-            .map_err(|source| ShadowMetricsSchemaReadinessError::QueryFailed { source })?;
+                    to_regclass('public.shadow_blocks') IS NOT NULL AS shadow_blocks_exists, \
+                    to_regclass('public.shadow_block_transactions') IS NOT NULL AS shadow_block_transactions_exists",
+        )
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|source| ShadowMetricsSchemaReadinessError::QueryFailed { source })?;
 
         if !migration_table_exists {
             return Err(ShadowMetricsSchemaReadinessError::MigrationTableMissing);
@@ -125,7 +129,7 @@ impl ShadowMetricsSink {
             });
         }
 
-        if !shadow_metrics_relation_exists {
+        if !shadow_blocks_exists || !shadow_block_transactions_exists {
             return Err(ShadowMetricsSchemaReadinessError::ShadowMetricsRelationMissing);
         }
 

--- a/crates/infra/shadow-metrics/src/sink.rs
+++ b/crates/infra/shadow-metrics/src/sink.rs
@@ -131,16 +131,6 @@ impl ShadowMetricsSink {
 
         Ok(())
     }
-
-    /// Checks optional shadow-metrics storage readiness.
-    pub async fn check_optional_schema_ready(
-        sink: Option<&Self>,
-    ) -> Result<(), ShadowMetricsSchemaReadinessError> {
-        match sink {
-            Some(sink) => sink.check_schema_ready().await,
-            None => Ok(()),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/infra/shadow-metrics/src/sink.rs
+++ b/crates/infra/shadow-metrics/src/sink.rs
@@ -1,0 +1,155 @@
+//! Postgres connectivity for the shadow-metrics noop service.
+
+use anyhow::Result;
+use sqlx::{PgPool, migrate::Migrator, postgres::PgPoolOptions};
+
+const REQUIRED_SHADOW_METRICS_MIGRATION_DESCRIPTION: &str = "shadow metrics";
+static SHADOW_METRICS_MIGRATOR: Migrator = sqlx::migrate!("./migrations");
+
+/// Error returned when the shadow-metrics Postgres schema is not ready.
+#[derive(Debug, thiserror::Error)]
+pub enum ShadowMetricsSchemaReadinessError {
+    /// sqlx migration metadata table is missing.
+    #[error(
+        "shadow-metrics Postgres schema is not ready: _sqlx_migrations is missing; run `shadow-metrics migrate up`"
+    )]
+    MigrationTableMissing,
+    /// The required sqlx migration has not been applied successfully.
+    #[error(
+        "shadow-metrics Postgres schema is not ready: required sqlx migration version {required_version} has not been applied successfully; run `shadow-metrics migrate up`"
+    )]
+    RequiredMigrationMissing {
+        /// Required sqlx migration version.
+        required_version: i64,
+    },
+    /// The expected table is missing or not visible to the runtime role.
+    #[error(
+        "shadow-metrics Postgres schema is not ready: public.shadow_metrics is missing or not visible to the runtime role; run `shadow-metrics migrate up`"
+    )]
+    ShadowMetricsRelationMissing,
+    /// A readiness query failed before readiness could be determined.
+    #[error(
+        "shadow-metrics Postgres schema readiness query failed: {source}; verify database connectivity and runtime role privileges"
+    )]
+    QueryFailed {
+        /// Underlying database error.
+        #[source]
+        source: sqlx::Error,
+    },
+    /// The embedded sqlx migration metadata is internally inconsistent.
+    #[error("shadow-metrics Postgres schema readiness metadata is invalid: {reason}")]
+    MigrationMetadataInvalid {
+        /// Static metadata error.
+        reason: &'static str,
+    },
+}
+
+/// Postgres handle for the shadow-metrics noop service.
+#[derive(Debug, Clone)]
+pub struct ShadowMetricsSink {
+    pool: PgPool,
+}
+
+impl ShadowMetricsSink {
+    /// Returns the required sqlx migration version for shadow-metrics storage.
+    pub fn required_migration_version() -> Result<i64, &'static str> {
+        let mut matching_migrations = SHADOW_METRICS_MIGRATOR.iter().filter(|migration| {
+            migration.description.as_ref() == REQUIRED_SHADOW_METRICS_MIGRATION_DESCRIPTION
+        });
+        let migration = matching_migrations.next().ok_or(
+            "shadow-metrics migration 001_shadow_metrics.sql must be embedded in the migrator",
+        )?;
+        if matching_migrations.next().is_some() {
+            return Err("shadow-metrics migration description must be unique");
+        }
+        Ok(migration.version)
+    }
+
+    /// Connects to Postgres without running migrations.
+    ///
+    /// Mirrors the audit archiver pool policy: eagerly opens the full configured
+    /// pool and keeps physical connections open with no lifetime or idle expiry,
+    /// so RDS IAM startup tokens stay valid for the life of the process.
+    pub async fn connect(database_url: &str, max_connections: u32) -> Result<Self> {
+        let max_connections = max_connections.max(1);
+        let pool = PgPoolOptions::new()
+            .max_connections(max_connections)
+            .min_connections(max_connections)
+            .max_lifetime(None)
+            .idle_timeout(None)
+            .connect(database_url)
+            .await?;
+        Ok(Self { pool })
+    }
+
+    /// Runs pending Postgres migrations.
+    pub async fn migrate(database_url: &str) -> Result<()> {
+        let pool = PgPoolOptions::new().max_connections(1).connect(database_url).await?;
+        SHADOW_METRICS_MIGRATOR.run(&pool).await?;
+        Ok(())
+    }
+
+    /// Creates a sink from an existing pool.
+    pub const fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Checks whether shadow-metrics Postgres storage is ready for runtime use.
+    pub async fn check_schema_ready(&self) -> Result<(), ShadowMetricsSchemaReadinessError> {
+        let (migration_table_exists, shadow_metrics_relation_exists): (bool, bool) =
+            sqlx::query_as(
+                "SELECT \
+                    to_regclass('_sqlx_migrations') IS NOT NULL AS migration_table_exists, \
+                    to_regclass('public.shadow_metrics') IS NOT NULL AS shadow_metrics_relation_exists",
+            )
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|source| ShadowMetricsSchemaReadinessError::QueryFailed { source })?;
+
+        if !migration_table_exists {
+            return Err(ShadowMetricsSchemaReadinessError::MigrationTableMissing);
+        }
+
+        let required_version = Self::required_migration_version().map_err(|reason| {
+            ShadowMetricsSchemaReadinessError::MigrationMetadataInvalid { reason }
+        })?;
+        let migration_applied: Option<bool> =
+            sqlx::query_scalar("SELECT success FROM _sqlx_migrations WHERE version = $1")
+                .bind(required_version)
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(|source| ShadowMetricsSchemaReadinessError::QueryFailed { source })?;
+        if !matches!(migration_applied, Some(true)) {
+            return Err(ShadowMetricsSchemaReadinessError::RequiredMigrationMissing {
+                required_version,
+            });
+        }
+
+        if !shadow_metrics_relation_exists {
+            return Err(ShadowMetricsSchemaReadinessError::ShadowMetricsRelationMissing);
+        }
+
+        Ok(())
+    }
+
+    /// Checks optional shadow-metrics storage readiness.
+    pub async fn check_optional_schema_ready(
+        sink: Option<&Self>,
+    ) -> Result<(), ShadowMetricsSchemaReadinessError> {
+        match sink {
+            Some(sink) => sink.check_schema_ready().await,
+            None => Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn required_migration_version_is_resolvable() {
+        let version = ShadowMetricsSink::required_migration_version().unwrap();
+        assert!(version > 0);
+    }
+}

--- a/crates/infra/shadow-metrics/src/sink.rs
+++ b/crates/infra/shadow-metrics/src/sink.rs
@@ -133,6 +133,15 @@ impl ShadowMetricsSink {
             return Err(ShadowMetricsSchemaReadinessError::ShadowMetricsRelationMissing);
         }
 
+        sqlx::query("SELECT 1 FROM shadow_blocks LIMIT 0")
+            .execute(&self.pool)
+            .await
+            .map_err(|source| ShadowMetricsSchemaReadinessError::QueryFailed { source })?;
+        sqlx::query("SELECT 1 FROM shadow_block_transactions LIMIT 0")
+            .execute(&self.pool)
+            .await
+            .map_err(|source| ShadowMetricsSchemaReadinessError::QueryFailed { source })?;
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Adds a new `infra` module `shadow-metrics`, modeled on `infra/audit`, as a **simple noop mock service** that connects to Postgres from config and exposes health probes. It performs no real metrics work — it is a scaffold proving config-driven Postgres connectivity + Kubernetes-style health probes.

## What's included

**Lib `base-shadow-metrics`** (`crates/infra/shadow-metrics/`)
- `ShadowMetricsSink`: wraps a sqlx `PgPool` with `connect(url, max)` / `migrate(url)` / `new(pool)`, plus `check_schema_ready()` + `check_optional_schema_ready()`. Mirrors the audit archiver's eager-pool policy (no lifetime/idle expiry for RDS IAM tokens) and embedded `sqlx::migrate!` pattern.
- `migrations/001_shadow_metrics.sql`: placeholder table + conditional role grant, used as the readiness-probe target.

**Bin `base-shadow-metrics-bin`** (`bin/shadow-metrics/`, executable `shadow-metrics`)
- clap `Args` with `SHADOW_METRICS_*` env vars; `serve` (default) / `migrate up` commands.
- `serve`: connects Postgres only when `SHADOW_METRICS_POSTGRES_URL` is set, runs a `/healthz` + `/readyz` HTTP server (readyz does a live schema check), and an idle heartbeat loop, joined via `tokio::select!`.

**Workspace**: both crates registered in root `Cargo.toml`; auto-globbed as members.

## Deliberate deviations from audit
- Bin package named `base-shadow-metrics-bin` (executable still `shadow-metrics`) per the newer `base-*-bin` convention (`base-sidecrush-bin`, `base-snapshotter-bin`); audit's unprefixed name is legacy.
- Dropped audit's S3/RPC/ingest layers — intentionally a minimal noop.

## Config

| Env var | Default |
| --- | --- |
| `SHADOW_METRICS_POSTGRES_URL` | (unset → DB disabled) |
| `SHADOW_METRICS_POSTGRES_MAX_CONNECTIONS` | `10` |
| `SHADOW_METRICS_HTTP_PORT` | `9101` |
| `SHADOW_METRICS_HEARTBEAT_INTERVAL_SECS` | `30` |
| `SHADOW_METRICS_METRICS_PORT` | `9003` |

## Verification
- `cargo check -p base-shadow-metrics -p base-shadow-metrics-bin` ✓
- `cargo clippy` (strict workspace lints) ✓
- `cargo test -p base-shadow-metrics` ✓ (1 passing)
- CLI `--help` smoke ✓