### PR TITLE
fix(eip8130): right-align EOA actor ids to match finalized Keystore

### DIFF
--- a/crates/common/evm/src/eip8130.rs
+++ b/crates/common/evm/src/eip8130.rs
@@ -2777,7 +2777,7 @@ mod tests {
         let owner = eoa_address(key);
         let actor_id = {
             let mut id = [0u8; 32];
-            id[..20].copy_from_slice(owner.as_slice());
+            id[12..].copy_from_slice(owner.as_slice());
             B256::from_slice(&id)
         };
         let initial_actors =

--- a/crates/common/precompiles/src/tx_context/abi.rs
+++ b/crates/common/precompiles/src/tx_context/abi.rs
@@ -10,8 +10,8 @@ sol! {
     /// backing transient slots are unset and the getters fall back to the
     /// ambient origin: `getTransactionSender` and `getTransactionPayer`
     /// return `tx.origin`, and `getTransactionSenderActorId` returns
-    /// `bytes32(bytes20(tx.origin))` (the address left-aligned in the high
-    /// 20 bytes).
+    /// `bytes32(uint256(uint160(tx.origin)))` (the address right-aligned in the
+    /// low 20 bytes).
     interface ITransactionContext {
         /// Precompile cannot be executed via delegatecall or callcode.
         error DelegateCallNotAllowed();

--- a/crates/common/precompiles/src/tx_context/storage.rs
+++ b/crates/common/precompiles/src/tx_context/storage.rs
@@ -13,7 +13,8 @@ use base_precompile_storage::{BasePrecompileError, Result, StorageCtx};
 ///
 /// For any non-EIP-8130 transaction (where nothing is written) each getter falls
 /// back to `tx.origin`: [`Self::sender`] and [`Self::payer`] return the origin
-/// address and [`Self::sender_actor_id`] returns `bytes32(bytes20(tx.origin))`,
+/// address and [`Self::sender_actor_id`] returns
+/// `bytes32(uint256(uint160(tx.origin)))`,
 /// so callers observe the actual transaction originator uniformly across tx types.
 #[derive(Debug)]
 pub struct TxContextStorage<'a> {
@@ -60,8 +61,9 @@ impl<'a> TxContextStorage<'a> {
         Ok(Address::from_word(B256::from(raw.to_be_bytes::<32>())))
     }
 
-    /// Returns the sender actor id, falling back to `bytes32(bytes20(tx.origin))`
-    /// when unset (i.e. outside an EIP-8130 transaction).
+    /// Returns the sender actor id, falling back to
+    /// `bytes32(uint256(uint160(tx.origin)))` when unset (i.e. outside an EIP-8130
+    /// transaction).
     pub fn sender_actor_id(&self) -> Result<B256> {
         let raw = self.storage.tload_unmetered(Self::ADDRESS, Self::SENDER_ACTOR_ID_SLOT)?;
         if raw.is_zero() {
@@ -70,13 +72,13 @@ impl<'a> TxContextStorage<'a> {
         Ok(B256::from(raw.to_be_bytes::<32>()))
     }
 
-    /// Derives the EOA actor id for `addr` as `bytes32(bytes20(addr))`: the 20
-    /// address bytes occupy the high-order bytes of the word, low 12 bytes zero
-    /// (left-aligned, matching the EIP-8130 Solidity cast — distinct from the
-    /// right-aligned EVM address word produced by [`Address::into_word`]).
+    /// Derives the EOA actor id for `addr` as `bytes32(uint256(uint160(addr)))`:
+    /// the 20 address bytes occupy the low-order bytes of the word, high 12 bytes
+    /// zero (right-aligned, matching the finalized `Keystore.ActorId.fromAddress`
+    /// — the same word produced by [`Address::into_word`]).
     fn address_to_actor_id(addr: Address) -> B256 {
         let mut word = [0u8; 32];
-        word[..20].copy_from_slice(addr.as_slice());
+        word[12..].copy_from_slice(addr.as_slice());
         B256::from(word)
     }
 
@@ -158,9 +160,9 @@ mod tests {
     const SENDER_ACTOR_ID: B256 =
         b256!("0x3333333333333333333333333333333333333333333333333333333333333333");
     const ORIGIN: Address = address!("0x9999999999999999999999999999999999999999");
-    /// `bytes32(bytes20(ORIGIN))`: address left-aligned in the high 20 bytes.
+    /// `bytes32(uint256(uint160(ORIGIN)))`: address right-aligned in the low 20 bytes.
     const ORIGIN_ACTOR_ID: B256 =
-        b256!("0x9999999999999999999999999999999999999999000000000000000000000000");
+        b256!("0x0000000000000000000000009999999999999999999999999999999999999999");
 
     #[test]
     fn context_is_zero_when_origin_is_zero() {

--- a/crates/execution/eip8130/src/account_config.rs
+++ b/crates/execution/eip8130/src/account_config.rs
@@ -188,12 +188,13 @@ impl AccountConfigurationStorage<'_> {
         Ok(self.get_account_state(account)?.lock_status(now))
     }
 
-    /// The implicit-EOA self-actor id for `account`: `bytes32(bytes20(account))`,
-    /// i.e. the address left-aligned in the high 20 bytes.
+    /// The implicit-EOA self-actor id for `account`:
+    /// `bytes32(uint256(uint160(account)))`, i.e. the address right-aligned in the
+    /// low 20 bytes (matches the finalized `Keystore.ActorId.fromAddress`).
     #[must_use]
     pub fn self_actor_id(account: Address) -> B256 {
         let mut word = [0u8; 32];
-        word[..20].copy_from_slice(account.as_slice());
+        word[12..].copy_from_slice(account.as_slice());
         B256::from(word)
     }
 
@@ -869,10 +870,10 @@ mod tests {
     }
 
     #[test]
-    fn self_actor_id_left_aligns_the_address() {
+    fn self_actor_id_right_aligns_the_address() {
         let id = AccountConfigurationStorage::self_actor_id(ACCOUNT);
-        assert_eq!(&id.as_slice()[..20], ACCOUNT.as_slice());
-        assert_eq!(&id.as_slice()[20..], &[0u8; 12]);
+        assert_eq!(&id.as_slice()[12..], ACCOUNT.as_slice());
+        assert_eq!(&id.as_slice()[..12], &[0u8; 12]);
     }
 
     /// Packs an `ActorConfig` carrying only an authenticator (scope/expiry/policy

--- a/crates/execution/eip8130/src/authorize.rs
+++ b/crates/execution/eip8130/src/authorize.rs
@@ -104,7 +104,7 @@ impl ActorAuthorizer {
                 // SENDER actor without POLICY): an operational key may sign for
                 // its own account but MUST NOT vouch as a delegate, to preserve
                 // non-escalation. Followed by the outer
-                // `_actorConfig[bytes20(delegate)][account]` binding check.
+                // `_actorConfig[uint256(uint160(delegate))][account]` binding check.
                 //
                 // Independent depth-1 guard: `authenticate_actor` re-enters the
                 // public dispatch, which routes a delegate authenticator straight
@@ -139,7 +139,8 @@ impl ActorAuthorizer {
     /// signer against `account`.
     ///
     /// The account's own key — the **secp256k1 self** (`recovered ==
-    /// bytes32(bytes20(account))`) — resolves entirely from the inline config in
+    /// bytes32(uint256(uint160(account)))`, right-aligned) — resolves entirely from
+    /// the inline config in
     /// the account-state slot, a single SLOAD: a set `DEFAULT_EOA_REVOKED` flag
     /// disables it (revoked, or a non-k1 self is the live self authenticator), an
     /// all-zero inline config is the implicit full owner, and a non-zero inline

--- a/crates/execution/eip8130/src/dispatch.rs
+++ b/crates/execution/eip8130/src/dispatch.rs
@@ -91,16 +91,17 @@ impl AuthenticatorDispatch {
         Err(AuthError::NotCanonical(authenticator))
     }
 
-    /// `actorId = bytes32(bytes20(address))`: the 20 address bytes left-aligned,
-    /// right-padded with zeros.
+    /// `actorId = bytes32(uint256(uint160(address)))`: the 20 address bytes
+    /// right-aligned in the low bytes, high 12 bytes zero (matches the finalized
+    /// `Keystore.ActorId.fromAddress`).
     fn address_actor_id(address: Address) -> B256 {
         let mut id = [0u8; 32];
-        id[..20].copy_from_slice(address.as_slice());
+        id[12..].copy_from_slice(address.as_slice());
         B256::from(id)
     }
 
     /// Native secp256k1 ecrecover for the `K1_AUTHENTICATOR` sentinel, resolving
-    /// `actorId = bytes32(bytes20(recovered))`. Delegates to
+    /// `actorId = bytes32(uint256(uint160(recovered)))`. Delegates to
     /// [`RecoveredActorId::recover_k1`] — the single source of truth for the k1
     /// recovery (`v in {27, 28}`, EIP-2 low-`s`) — so the dispatch path and the
     /// proof-of-recovery token cannot drift from one another or from the
@@ -223,7 +224,7 @@ impl AuthenticatorDispatch {
     /// `nested_auth = nested_authenticator(20) || nested_data`.
     ///
     /// Structural only, mirroring the deployed `DelegateAuthenticator`: it derives
-    /// `actorId = bytes32(bytes20(delegate))`, enforces the single-hop rule
+    /// `actorId = bytes32(uint256(uint160(delegate)))`, enforces the single-hop rule
     /// (`nested_authenticator != DELEGATE_AUTHENTICATOR`), and surfaces a
     /// [`DispatchOutcome::Delegated`] obligation. It does **not** verify the nested
     /// signature or resolve the nested actor — the deployed contract likewise only

--- a/crates/execution/eip8130/src/intrinsic.rs
+++ b/crates/execution/eip8130/src/intrinsic.rs
@@ -993,7 +993,7 @@ mod tests {
         // actor_config slot empty), each empty slot is repriced from a reset to a
         // cold zero-to-zero no-op.
         let mut bytes = [0u8; 32];
-        bytes[..20].copy_from_slice(ACCOUNT.as_slice());
+        bytes[12..].copy_from_slice(ACCOUNT.as_slice());
         let self_id = alloy_primitives::B256::from(bytes);
         let cc = || ConfigChange {
             chain_id: 0,
@@ -1043,7 +1043,7 @@ mod tests {
     )]
     fn excess_revoke_discount_slots_trips_debug_assertion() {
         let mut bytes = [0u8; 32];
-        bytes[..20].copy_from_slice(ACCOUNT.as_slice());
+        bytes[12..].copy_from_slice(ACCOUNT.as_slice());
         let self_id = alloy_primitives::B256::from(bytes);
         let cc = ConfigChange {
             chain_id: 0,
@@ -1086,7 +1086,7 @@ mod tests {
         // same as a non-self change — there is no separate dual-home bump (an
         // earlier over-conservative addition that double-charged account_state).
         let mut bytes = [0u8; 32];
-        bytes[..20].copy_from_slice(ACCOUNT.as_slice());
+        bytes[12..].copy_from_slice(ACCOUNT.as_slice());
         let self_id = alloy_primitives::B256::from(bytes);
         let other_id = alloy_primitives::B256::repeat_byte(0x07);
 

--- a/crates/execution/eip8130/src/outcome.rs
+++ b/crates/execution/eip8130/src/outcome.rs
@@ -25,7 +25,7 @@ pub enum DispatchOutcome {
     /// `ACCOUNT_CONFIGURATION.authenticateActor(delegate, ...)`.
     Delegated {
         /// Outer actor id registered on the originating account:
-        /// `bytes32(bytes20(delegate_account))`.
+        /// `bytes32(uint256(uint160(delegate_account)))` (right-aligned).
         actor_id: B256,
         /// The delegated account (B) whose config the nested actor must be
         /// authorized against via `authenticateActor`.

--- a/crates/execution/eip8130/src/recovered.rs
+++ b/crates/execution/eip8130/src/recovered.rs
@@ -8,7 +8,7 @@ use k256::ecdsa::{RecoveryId, Signature as K256Signature, VerifyingKey as K256Ve
 use crate::AuthError;
 
 /// A recovered secp256k1 signer, carried as its address and resolved `actorId`
-/// (`bytes32(bytes20(address))`).
+/// (`bytes32(uint256(uint160(address)))`, address right-aligned).
 ///
 /// The wrapped address is private and every constructor performs a real
 /// signature recovery, so a value is *evidence* that the signer authenticated
@@ -78,12 +78,13 @@ impl RecoveredActorId {
         self.address
     }
 
-    /// The recovered signer's actor id, `bytes32(bytes20(address))` — the 20
-    /// address bytes left-aligned, right-padded with zeros.
+    /// The recovered signer's actor id, `bytes32(uint256(uint160(address)))` —
+    /// the 20 address bytes right-aligned in the low bytes, high 12 bytes zero
+    /// (matches the finalized `Keystore.ActorId.fromAddress`).
     #[must_use]
     pub fn actor_id(self) -> B256 {
         let mut id = [0u8; 32];
-        id[..20].copy_from_slice(self.address.as_slice());
+        id[12..].copy_from_slice(self.address.as_slice());
         B256::from(id)
     }
 }

--- a/crates/execution/eip8130/src/resolved.rs
+++ b/crates/execution/eip8130/src/resolved.rs
@@ -14,8 +14,8 @@ use base_common_consensus::Eip8130Constants;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct ResolvedActor {
-    /// The resolved actor id (`bytes20(address)` for ecrecover/delegate,
-    /// `keccak256(x‖y)` for P-256/`WebAuthn`).
+    /// The resolved actor id (`bytes32(uint256(uint160(address)))`, right-aligned,
+    /// for ecrecover/delegate; `keccak256(x‖y)` for P-256/`WebAuthn`).
     pub actor_id: B256,
     /// The actor's scope bitfield (`0 = unrestricted`).
     pub scope: u8,

--- a/crates/execution/eip8130/src/transaction.rs
+++ b/crates/execution/eip8130/src/transaction.rs
@@ -628,7 +628,7 @@ mod tests {
         let signer_addr = addr(&k);
         let actor_id_k = B256::from_slice(&{
             let mut id = [0u8; 32];
-            id[..20].copy_from_slice(signer_addr.as_slice());
+            id[12..].copy_from_slice(signer_addr.as_slice());
             id
         });
         let initial_actors = vec![InitialActor::owner(actor_id_k, K1)];
@@ -682,7 +682,7 @@ mod tests {
         let signer_addr = addr(&k);
         let actor_id_k = B256::from_slice(&{
             let mut id = [0u8; 32];
-            id[..20].copy_from_slice(signer_addr.as_slice());
+            id[12..].copy_from_slice(signer_addr.as_slice());
             id
         });
         let initial_actors = vec![InitialActor::owner(actor_id_k, K1)];
@@ -812,7 +812,7 @@ mod tests {
         let signer_addr = addr(signer);
         let actor_id_val = B256::from_slice(&{
             let mut id = [0u8; 32];
-            id[..20].copy_from_slice(signer_addr.as_slice());
+            id[12..].copy_from_slice(signer_addr.as_slice());
             id
         });
         let initial_actors = vec![InitialActor::owner(actor_id_val, K1)];
@@ -883,7 +883,7 @@ mod tests {
         let signer_addr = addr(&k);
         let actor_id_val = B256::from_slice(&{
             let mut id = [0u8; 32];
-            id[..20].copy_from_slice(signer_addr.as_slice());
+            id[12..].copy_from_slice(signer_addr.as_slice());
             id
         });
         let initial_actors = vec![InitialActor::owner(actor_id_val, K1)];
@@ -940,7 +940,7 @@ mod tests {
         let attacker_addr = addr(&attacker);
         let actor_id_val = B256::from_slice(&{
             let mut id = [0u8; 32];
-            id[..20].copy_from_slice(attacker_addr.as_slice());
+            id[12..].copy_from_slice(attacker_addr.as_slice());
             id
         });
         let initial_actors = vec![InitialActor::owner(actor_id_val, K1)];
@@ -993,7 +993,7 @@ mod tests {
         let signer_addr = addr(&k);
         let actor_id_val = B256::from_slice(&{
             let mut id = [0u8; 32];
-            id[..20].copy_from_slice(signer_addr.as_slice());
+            id[12..].copy_from_slice(signer_addr.as_slice());
             id
         });
         let initial_actors = vec![InitialActor::owner(actor_id_val, K1)];

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -3387,7 +3387,7 @@ mod tests {
         let signer_addr = signer.address();
         let actor_id = {
             let mut id = [0u8; 32];
-            id[..20].copy_from_slice(signer_addr.as_slice());
+            id[12..].copy_from_slice(signer_addr.as_slice());
             B256::from_slice(&id)
         };
         let initial_actors =


### PR DESCRIPTION
## Summary
- The finalized Keystore stores addresses **right-aligned** via `ActorId.fromAddress` = `bytes32(uint256(uint160(addr)))` (address in the low 20 bytes).
- Our native EOA actor-id derivations still used the old left-aligned `bytes32(bytes20(addr))` cast (address in the high 20 bytes), so derived actor ids would **not** match keystore entries on-chain.
- This flips every EOA actor-id derivation to right-aligned:
  - `AccountConfigurationStorage::self_actor_id`
  - `AuthenticatorDispatch::address_actor_id`
  - `RecoveredActorId::actor_id`
  - `TxContextStorage::address_to_actor_id` — so the tx-context precompile's `tx.senderActorId` matches keystore actor ids
- Also updates the affected test fixtures/constants and the doc comments that described the old left-aligned cast.

This is a self-contained parity fix against already-merged `main` code, independent of the EIP-8130 stacked PRs.

## Test plan
- [x] `cargo test -p base-common-precompiles -p base-execution-eip8130 -p base-execution-txpool -p base-common-evm` (all pass)
- [ ] Confirm on-chain parity against the deployed Keystore in devnet once available