### PR TITLE
refactor(BOP-495): align internal multiplier fn names with the ERC-8056 wire vocabulary

### DIFF
--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -383,7 +383,7 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
                 Bytes::new()
             }
             SC::updateUIMultiplier(c) => {
-                logic.set_ui_multiplier(
+                logic.update_ui_multiplier(
                     self,
                     caller,
                     c.newMultiplier,
@@ -393,7 +393,7 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
                 Bytes::new()
             }
             SC::cancelUIMultiplierUpdate(_) => {
-                logic.cancel_scheduled_multiplier(self, caller, privileged)?;
+                logic.cancel_ui_multiplier_update(self, caller, privileged)?;
                 Bytes::new()
             }
 

--- a/crates/common/precompiles/src/b20_asset/logic/interface.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/interface.rs
@@ -415,7 +415,7 @@ pub trait Asset<S: AssetAccounting, A: PolicyAccounting> {
     }
 
     /// Schedules a multiplier update.
-    fn set_ui_multiplier(
+    fn update_ui_multiplier(
         &self,
         _token: &mut B20AssetToken<S, A>,
         _caller: Address,
@@ -427,7 +427,7 @@ pub trait Asset<S: AssetAccounting, A: PolicyAccounting> {
     }
 
     /// Cancels a scheduled multiplier update.
-    fn cancel_scheduled_multiplier(
+    fn cancel_ui_multiplier_update(
         &self,
         _token: &mut B20AssetToken<S, A>,
         _caller: Address,

--- a/crates/common/precompiles/src/b20_asset/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v2.rs
@@ -955,7 +955,7 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
         Ok(product / B20AssetStorage::WAD)
     }
 
-    fn set_ui_multiplier(
+    fn update_ui_multiplier(
         &self,
         token: &mut B20AssetToken<S, A>,
         caller: Address,
@@ -1007,7 +1007,7 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
         )
     }
 
-    fn cancel_scheduled_multiplier(
+    fn cancel_ui_multiplier_update(
         &self,
         token: &mut B20AssetToken<S, A>,
         caller: Address,
@@ -2196,7 +2196,7 @@ mod tests {
         let target = wad() * U256::from(3u64);
         let effective_at = U256::from(100u64);
         set_now(&mut tok, U256::from(10u64));
-        LOGIC.set_ui_multiplier(&mut tok, ALICE, target, effective_at, true).unwrap();
+        LOGIC.update_ui_multiplier(&mut tok, ALICE, target, effective_at, true).unwrap();
 
         // T-1: still the old (current) multiplier.
         set_now(&mut tok, U256::from(99u64));
@@ -2212,12 +2212,12 @@ mod tests {
     }
 
     #[test]
-    fn set_ui_multiplier_emits_event_and_records_pending() {
+    fn update_ui_multiplier_emits_event_and_records_pending() {
         let mut tok = token();
         let target = wad() * U256::from(2u64);
         let effective_at = U256::from(500u64);
         set_now(&mut tok, U256::from(1u64));
-        LOGIC.set_ui_multiplier(&mut tok, ALICE, target, effective_at, true).unwrap();
+        LOGIC.update_ui_multiplier(&mut tok, ALICE, target, effective_at, true).unwrap();
 
         assert_eq!(
             last_event(&tok),
@@ -2233,11 +2233,12 @@ mod tests {
     }
 
     #[test]
-    fn set_ui_multiplier_requires_operator_role() {
+    fn update_ui_multiplier_requires_operator_role() {
         let mut tok = token();
         set_now(&mut tok, U256::from(1u64));
-        let err =
-            LOGIC.set_ui_multiplier(&mut tok, ALICE, wad(), U256::from(2u64), false).unwrap_err();
+        let err = LOGIC
+            .update_ui_multiplier(&mut tok, ALICE, wad(), U256::from(2u64), false)
+            .unwrap_err();
         assert_eq!(
             err,
             BasePrecompileError::revert(IB20::AccessControlUnauthorizedAccount {
@@ -2247,38 +2248,39 @@ mod tests {
         );
         // Once granted, the same call succeeds.
         grant(&mut tok, AssetV2::OPERATOR_ROLE, ALICE);
-        LOGIC.set_ui_multiplier(&mut tok, ALICE, wad(), U256::from(2u64), false).unwrap();
+        LOGIC.update_ui_multiplier(&mut tok, ALICE, wad(), U256::from(2u64), false).unwrap();
     }
 
     #[test]
-    fn set_ui_multiplier_rejects_zero_and_above_uint128() {
+    fn update_ui_multiplier_rejects_zero_and_above_uint128() {
         let mut tok = token();
         set_now(&mut tok, U256::from(1u64));
         let zero = LOGIC
-            .set_ui_multiplier(&mut tok, ALICE, U256::ZERO, U256::from(2u64), true)
+            .update_ui_multiplier(&mut tok, ALICE, U256::ZERO, U256::from(2u64), true)
             .unwrap_err();
         assert_eq!(zero, BasePrecompileError::revert(IB20Asset::InvalidMultiplier {}));
 
         let too_big = U256::from(u128::MAX) + U256::ONE;
-        let over =
-            LOGIC.set_ui_multiplier(&mut tok, ALICE, too_big, U256::from(2u64), true).unwrap_err();
+        let over = LOGIC
+            .update_ui_multiplier(&mut tok, ALICE, too_big, U256::from(2u64), true)
+            .unwrap_err();
         assert_eq!(over, BasePrecompileError::revert(IB20Asset::InvalidMultiplier {}));
     }
 
     #[test]
-    fn set_ui_multiplier_rejects_effective_at_in_past_and_too_far() {
+    fn update_ui_multiplier_rejects_effective_at_in_past_and_too_far() {
         let mut tok = token();
         let now = U256::from(100u64);
         set_now(&mut tok, now);
         // effectiveAt == now is not in the future.
-        let past = LOGIC.set_ui_multiplier(&mut tok, ALICE, wad(), now, true).unwrap_err();
+        let past = LOGIC.update_ui_multiplier(&mut tok, ALICE, wad(), now, true).unwrap_err();
         assert_eq!(
             past,
             BasePrecompileError::revert(IB20Asset::EffectiveAtInPast { effectiveAt: now })
         );
 
         let too_far = U256::from(u64::MAX) + U256::ONE;
-        let far = LOGIC.set_ui_multiplier(&mut tok, ALICE, wad(), too_far, true).unwrap_err();
+        let far = LOGIC.update_ui_multiplier(&mut tok, ALICE, wad(), too_far, true).unwrap_err();
         assert_eq!(
             far,
             BasePrecompileError::revert(IB20Asset::EffectiveAtTooFar { effectiveAt: too_far })
@@ -2286,15 +2288,21 @@ mod tests {
     }
 
     #[test]
-    fn set_ui_multiplier_reverts_on_live_overlap() {
+    fn update_ui_multiplier_reverts_on_live_overlap() {
         let mut tok = token();
         let first_effective_at = U256::from(1_000u64);
         set_now(&mut tok, U256::from(1u64));
         LOGIC
-            .set_ui_multiplier(&mut tok, ALICE, wad() * U256::from(2u64), first_effective_at, true)
+            .update_ui_multiplier(
+                &mut tok,
+                ALICE,
+                wad() * U256::from(2u64),
+                first_effective_at,
+                true,
+            )
             .unwrap();
         let err = LOGIC
-            .set_ui_multiplier(
+            .update_ui_multiplier(
                 &mut tok,
                 ALICE,
                 wad() * U256::from(3u64),
@@ -2311,12 +2319,12 @@ mod tests {
     }
 
     #[test]
-    fn set_ui_multiplier_materializes_matured_pending() {
+    fn update_ui_multiplier_materializes_matured_pending() {
         let mut tok = token();
         let first = wad() * U256::from(2u64);
         let first_effective_at = U256::from(100u64);
         set_now(&mut tok, U256::from(1u64));
-        LOGIC.set_ui_multiplier(&mut tok, ALICE, first, first_effective_at, true).unwrap();
+        LOGIC.update_ui_multiplier(&mut tok, ALICE, first, first_effective_at, true).unwrap();
 
         // After maturity, schedule a second: the matured first must fold into the current slot.
         let now = U256::from(150u64);
@@ -2324,7 +2332,7 @@ mod tests {
         assert_eq!(LOGIC.multiplier(&tok).unwrap(), first, "first has matured");
         let second = wad() * U256::from(3u64);
         let second_effective_at = U256::from(300u64);
-        LOGIC.set_ui_multiplier(&mut tok, ALICE, second, second_effective_at, true).unwrap();
+        LOGIC.update_ui_multiplier(&mut tok, ALICE, second, second_effective_at, true).unwrap();
 
         // `old` in the emitted event is the folded (matured) value, not the pre-fold WAD.
         assert_eq!(
@@ -2350,9 +2358,9 @@ mod tests {
         let target = wad() * U256::from(2u64);
         let effective_at = U256::from(1_000u64);
         set_now(&mut tok, U256::from(1u64));
-        LOGIC.set_ui_multiplier(&mut tok, ALICE, target, effective_at, true).unwrap();
+        LOGIC.update_ui_multiplier(&mut tok, ALICE, target, effective_at, true).unwrap();
 
-        LOGIC.cancel_scheduled_multiplier(&mut tok, ALICE, true).unwrap();
+        LOGIC.cancel_ui_multiplier_update(&mut tok, ALICE, true).unwrap();
 
         assert_eq!(
             last_event(&tok),
@@ -2371,15 +2379,21 @@ mod tests {
     fn cancel_reverts_without_live_pending() {
         let mut tok = token();
         set_now(&mut tok, U256::from(1u64));
-        let none = LOGIC.cancel_scheduled_multiplier(&mut tok, ALICE, true).unwrap_err();
+        let none = LOGIC.cancel_ui_multiplier_update(&mut tok, ALICE, true).unwrap_err();
         assert_eq!(none, BasePrecompileError::revert(IB20Asset::UIMultiplierUpdateDoesNotExist {}));
 
         // A matured pending is no longer "live", so cancel still reverts.
         LOGIC
-            .set_ui_multiplier(&mut tok, ALICE, wad() * U256::from(2u64), U256::from(100u64), true)
+            .update_ui_multiplier(
+                &mut tok,
+                ALICE,
+                wad() * U256::from(2u64),
+                U256::from(100u64),
+                true,
+            )
             .unwrap();
         set_now(&mut tok, U256::from(100u64));
-        let matured = LOGIC.cancel_scheduled_multiplier(&mut tok, ALICE, true).unwrap_err();
+        let matured = LOGIC.cancel_ui_multiplier_update(&mut tok, ALICE, true).unwrap_err();
         assert_eq!(
             matured,
             BasePrecompileError::revert(IB20Asset::UIMultiplierUpdateDoesNotExist {})
@@ -2411,7 +2425,7 @@ mod tests {
         let pending = wad() * U256::from(2u64);
         let pending_effective_at = U256::from(1_000u64);
         set_now(&mut tok, U256::from(1u64));
-        LOGIC.set_ui_multiplier(&mut tok, ALICE, pending, pending_effective_at, true).unwrap();
+        LOGIC.update_ui_multiplier(&mut tok, ALICE, pending, pending_effective_at, true).unwrap();
 
         let now = U256::from(10u64);
         let instant = wad() * U256::from(5u64);
@@ -2449,7 +2463,7 @@ mod tests {
         let mut tok = token();
         let matured = wad() * U256::from(2u64);
         set_now(&mut tok, U256::from(1u64));
-        LOGIC.set_ui_multiplier(&mut tok, ALICE, matured, U256::from(100u64), true).unwrap();
+        LOGIC.update_ui_multiplier(&mut tok, ALICE, matured, U256::from(100u64), true).unwrap();
 
         let now = U256::from(150u64); // matured
         let instant = wad() * U256::from(5u64);
@@ -2496,7 +2510,7 @@ mod tests {
         let target = wad() * U256::from(2u64);
         let effective_at = U256::from(100u64);
         set_now(&mut tok, U256::from(1u64));
-        LOGIC.set_ui_multiplier(&mut tok, ALICE, target, effective_at, true).unwrap();
+        LOGIC.update_ui_multiplier(&mut tok, ALICE, target, effective_at, true).unwrap();
 
         let now = U256::from(150u64);
         set_now(&mut tok, now);
@@ -2514,7 +2528,7 @@ mod tests {
         let target = wad() * U256::from(2u64);
         let effective_at = U256::from(100u64);
         set_now(&mut tok, U256::from(1u64));
-        LOGIC.set_ui_multiplier(&mut tok, ALICE, target, effective_at, true).unwrap();
+        LOGIC.update_ui_multiplier(&mut tok, ALICE, target, effective_at, true).unwrap();
 
         // Before maturity: 1:1.
         set_now(&mut tok, U256::from(50u64));

--- a/crates/common/precompiles/tests/b20_asset_v2_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v2_golden.rs
@@ -135,11 +135,11 @@ const ROOT_UPDATE_MULTIPLIER_V2: B256 =
     b256!("fedb235aa7953b3224856747a42ef936f814559763791f14126249a05f5f9a6b");
 const ROOT_UPDATE_MULTIPLIER_CLEARS_PENDING: B256 =
     b256!("1bcd7dd7a84d36e144d3f9a4547acda2eb80f6622ed7eec9a8cd6ad3a021f0ba");
-const ROOT_SET_UI_MULTIPLIER: B256 =
+const ROOT_UPDATE_UI_MULTIPLIER: B256 =
     b256!("f75ebc45a2ee2e3e1027ac80d1245ba8a4f594c69e4ab73be9a213f25a2f0a9f");
-const ROOT_SET_UI_MULTIPLIER_FOLDS_MATURED: B256 =
+const ROOT_UPDATE_UI_MULTIPLIER_FOLDS_MATURED: B256 =
     b256!("a0942971f4c3b38bd0d2ebd19730bda7585f517774ffaf8d7c5ba21c5cf63475");
-const ROOT_CANCEL_SCHEDULED_MULTIPLIER: B256 =
+const ROOT_CANCEL_UI_MULTIPLIER_UPDATE: B256 =
     b256!("63ac7df12f8dc4e2af852b1a6545c284a98a65fa604b6671c39293de9bcc967b");
 const ROOT_SEIZE: B256 = b256!("3b853f2d0f2ed769695b5577e4df3e8e8ecac537d4f26c29da283a724a426301");
 const ROOT_ANNOUNCE_V2: B256 =
@@ -2335,7 +2335,7 @@ fn golden_update_multiplier_clears_live_pending_and_emits_cancellation() {
 // ============================================================================
 
 #[test]
-fn golden_set_ui_multiplier_schedules_pending() {
+fn golden_update_ui_multiplier_schedules_pending() {
     let mut s = fresh();
     seed(&mut s, |t| give_role(t, operator_role(), ALICE));
     warp(&mut s, u(1));
@@ -2366,7 +2366,7 @@ fn golden_set_ui_multiplier_schedules_pending() {
         }
         .encode_log_data()
     );
-    assert_root("set_ui_multiplier", s, ROOT_SET_UI_MULTIPLIER);
+    assert_root("update_ui_multiplier", s, ROOT_UPDATE_UI_MULTIPLIER);
 }
 
 #[test]
@@ -2507,7 +2507,7 @@ fn golden_balance_of_ui_and_total_supply_ui_scale_by_effective_multiplier() {
 }
 
 #[test]
-fn golden_set_ui_multiplier_reverts_invalid_multiplier() {
+fn golden_update_ui_multiplier_reverts_invalid_multiplier() {
     let mut s = fresh();
     seed(&mut s, |t| give_role(t, operator_role(), ALICE));
     warp(&mut s, u(1));
@@ -2523,7 +2523,7 @@ fn golden_set_ui_multiplier_reverts_invalid_multiplier() {
 }
 
 #[test]
-fn golden_set_ui_multiplier_reverts_effective_at_in_past() {
+fn golden_update_ui_multiplier_reverts_effective_at_in_past() {
     let mut s = fresh();
     seed(&mut s, |t| give_role(t, operator_role(), ALICE));
     warp(&mut s, u(1_000));
@@ -2545,7 +2545,7 @@ fn golden_set_ui_multiplier_reverts_effective_at_in_past() {
 }
 
 #[test]
-fn golden_set_ui_multiplier_reverts_effective_at_too_far() {
+fn golden_update_ui_multiplier_reverts_effective_at_too_far() {
     let mut s = fresh();
     seed(&mut s, |t| give_role(t, operator_role(), ALICE));
     warp(&mut s, u(1));
@@ -2568,7 +2568,7 @@ fn golden_set_ui_multiplier_reverts_effective_at_too_far() {
 }
 
 #[test]
-fn golden_set_ui_multiplier_reverts_schedule_overlap() {
+fn golden_update_ui_multiplier_reverts_schedule_overlap() {
     let mut s = fresh();
     seed(&mut s, |t| give_role(t, operator_role(), ALICE));
     warp(&mut s, u(1));
@@ -2602,7 +2602,7 @@ fn golden_set_ui_multiplier_reverts_schedule_overlap() {
 }
 
 #[test]
-fn golden_set_ui_multiplier_folds_matured_pending_before_rescheduling() {
+fn golden_update_ui_multiplier_folds_matured_pending_before_rescheduling() {
     let mut s = fresh();
     seed(&mut s, |t| give_role(t, operator_role(), ALICE));
     warp(&mut s, u(1));
@@ -2648,11 +2648,11 @@ fn golden_set_ui_multiplier_folds_matured_pending_before_rescheduling() {
         }
         .encode_log_data()
     );
-    assert_root("set_ui_multiplier_folds_matured", s, ROOT_SET_UI_MULTIPLIER_FOLDS_MATURED);
+    assert_root("update_ui_multiplier_folds_matured", s, ROOT_UPDATE_UI_MULTIPLIER_FOLDS_MATURED);
 }
 
 #[test]
-fn golden_set_ui_multiplier_unprivileged_requires_role() {
+fn golden_update_ui_multiplier_unprivileged_requires_role() {
     let mut s = fresh();
     let err = op(
         &mut s,
@@ -2675,7 +2675,7 @@ fn golden_set_ui_multiplier_unprivileged_requires_role() {
 }
 
 #[test]
-fn golden_cancel_scheduled_multiplier() {
+fn golden_cancel_ui_multiplier_update() {
     let mut s = fresh();
     seed(&mut s, |t| give_role(t, operator_role(), ALICE));
     warp(&mut s, u(1));
@@ -2713,11 +2713,11 @@ fn golden_cancel_scheduled_multiplier() {
         }
         .encode_log_data()
     );
-    assert_root("cancel_scheduled_multiplier", s, ROOT_CANCEL_SCHEDULED_MULTIPLIER);
+    assert_root("cancel_ui_multiplier_update", s, ROOT_CANCEL_UI_MULTIPLIER_UPDATE);
 }
 
 #[test]
-fn golden_cancel_scheduled_multiplier_reverts_when_none() {
+fn golden_cancel_ui_multiplier_update_reverts_when_none() {
     let mut s = fresh();
     seed(&mut s, |t| give_role(t, operator_role(), ALICE));
     let err = op(
@@ -2731,7 +2731,7 @@ fn golden_cancel_scheduled_multiplier_reverts_when_none() {
 }
 
 #[test]
-fn golden_cancel_scheduled_multiplier_reverts_when_already_matured() {
+fn golden_cancel_ui_multiplier_update_reverts_when_already_matured() {
     let mut s = fresh();
     seed(&mut s, |t| give_role(t, operator_role(), ALICE));
     warp(&mut s, u(1));
@@ -2759,7 +2759,7 @@ fn golden_cancel_scheduled_multiplier_reverts_when_already_matured() {
 }
 
 #[test]
-fn golden_cancel_scheduled_multiplier_unprivileged_requires_role() {
+fn golden_cancel_ui_multiplier_update_unprivileged_requires_role() {
     let mut s = fresh();
     let err = op(
         &mut s,
@@ -3288,7 +3288,7 @@ fn golden_gas_footprints() {
             ),
         ),
         (
-            "set_ui_multiplier",
+            "update_ui_multiplier",
             gas(
                 |_t| {},
                 ADMIN,
@@ -3301,7 +3301,7 @@ fn golden_gas_footprints() {
             ),
         ),
         (
-            "cancel_scheduled_multiplier",
+            "cancel_ui_multiplier_update",
             gas(
                 |t| {
                     t.set_pending_and_effective_at(
@@ -3382,8 +3382,8 @@ fn golden_gas_footprints() {
         ("set_role_admin", (1, 1, 0)),
         ("update_policy", (2, 1, 0)),
         ("update_multiplier", (4, 1, 0)),
-        ("set_ui_multiplier", (3, 1, 0)),
-        ("cancel_scheduled_multiplier", (3, 1, 0)),
+        ("update_ui_multiplier", (3, 1, 0)),
+        ("cancel_ui_multiplier_update", (3, 1, 0)),
         ("batch_mint", (11, 4, 0)),
         ("announce", (1, 1, 0)),
         ("update_extra_metadata", (0, 1, 0)),
@@ -3629,19 +3629,19 @@ fn v2_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Asset::IB20AssetCall
             covered(&[golden_balance_of_ui_and_total_supply_ui_scale_by_effective_multiplier])
         }
         SC::updateUIMultiplier(_) => covered(&[
-            golden_set_ui_multiplier_schedules_pending,
-            golden_set_ui_multiplier_reverts_invalid_multiplier,
-            golden_set_ui_multiplier_reverts_effective_at_in_past,
-            golden_set_ui_multiplier_reverts_effective_at_too_far,
-            golden_set_ui_multiplier_reverts_schedule_overlap,
-            golden_set_ui_multiplier_folds_matured_pending_before_rescheduling,
-            golden_set_ui_multiplier_unprivileged_requires_role,
+            golden_update_ui_multiplier_schedules_pending,
+            golden_update_ui_multiplier_reverts_invalid_multiplier,
+            golden_update_ui_multiplier_reverts_effective_at_in_past,
+            golden_update_ui_multiplier_reverts_effective_at_too_far,
+            golden_update_ui_multiplier_reverts_schedule_overlap,
+            golden_update_ui_multiplier_folds_matured_pending_before_rescheduling,
+            golden_update_ui_multiplier_unprivileged_requires_role,
         ]),
         SC::cancelUIMultiplierUpdate(_) => covered(&[
-            golden_cancel_scheduled_multiplier,
-            golden_cancel_scheduled_multiplier_reverts_when_none,
-            golden_cancel_scheduled_multiplier_reverts_when_already_matured,
-            golden_cancel_scheduled_multiplier_unprivileged_requires_role,
+            golden_cancel_ui_multiplier_update,
+            golden_cancel_ui_multiplier_update_reverts_when_none,
+            golden_cancel_ui_multiplier_update_reverts_when_already_matured,
+            golden_cancel_ui_multiplier_update_unprivileged_requires_role,
         ]),
         SC::supportsInterface(_) => covered(&[
             golden_supports_interface_true_for_erc165_and_erc8056_ids,


### PR DESCRIPTION
## Summary
Follow-up to #4285 (and base-std #192). Those PRs renamed the Cobalt wire surface to the ERC-8056
canonical `updateUIMultiplier` (scheduled setter) and `cancelUIMultiplierUpdate`, but the **V2-only
Rust logic method names** kept their pre-rename dev names whose wire counterparts no longer exist. This aligns the internal identifiers with the wire vocabulary they implement:

- `set_ui_multiplier` → `update_ui_multiplier` (wire `updateUIMultiplier`, the scheduled setter)
- `cancel_scheduled_multiplier` → `cancel_ui_multiplier_update` (wire `cancelUIMultiplierUpdate`)
- matching golden-root const names (`ROOT_SET_UI_MULTIPLIER*` → `ROOT_UPDATE_UI_MULTIPLIER*`,
  `ROOT_CANCEL_SCHEDULED_MULTIPLIER` → `ROOT_CANCEL_UI_MULTIPLIER_UPDATE`)

**Internal-only, zero behavioral/wire change:**
- no function selector / ABI / event / error / interface-id change (V2 ABI fingerprint unchanged)
- golden root *values* unchanged (pure identifier rename); no re-bless
- both methods are V2-only — **frozen `v1.rs` is untouched**
- no base-std change and no fork-test pin change (the wire is identical)

## Test plan
- [x] `cargo test -p base-common-precompiles --features test-utils` — 654 lib + 106/127 golden green
- [x] `cargo clippy -p base-common-precompiles --all-targets --features test-utils` — clean
- [x] `cargo +nightly fmt --check` — clean

Made with [Cursor](https://cursor.com)