### PR TITLE
test(actions): cover Isthmus withdrawals_root across Holocene activation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3304,6 +3304,7 @@ dependencies = [
  "reth-provider",
  "reth-revm",
  "reth-transaction-pool",
+ "reth-trie-common",
  "serde_json",
  "tempfile",
  "thiserror 2.0.19",

--- a/actions/harness/Cargo.toml
+++ b/actions/harness/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 # reth
 reth-node-api.workspace = true
 reth-db-common.workspace = true
+reth-trie-common.workspace = true
 reth-execution-types.workspace = true
 reth-transaction-pool.workspace = true
 reth-primitives-traits.workspace = true

--- a/actions/harness/src/engine.rs
+++ b/actions/harness/src/engine.rs
@@ -9,7 +9,7 @@ use alloy_consensus::{BlockHeader, Header, Sealed};
 use alloy_eips::{BlockId, eip1898::BlockNumberOrTag};
 use alloy_genesis::{Genesis, GenesisAccount};
 use alloy_network::{Ethereum, Network};
-use alloy_primitives::{Address, B256, BlockHash, StorageKey, U256};
+use alloy_primitives::{Address, B256, BlockHash, Bytes, StorageKey, U256, hex};
 use alloy_provider::{EthGetBlock, ProviderCall, RpcWithBlock};
 use alloy_rpc_types_engine::{
     ClientVersionV1, ExecutionPayloadBodiesV1, ExecutionPayloadEnvelopeV2, ExecutionPayloadInputV2,
@@ -21,7 +21,7 @@ use alloy_rpc_types_eth::{
 };
 use alloy_transport::{TransportError, TransportErrorKind, TransportResult};
 use async_trait::async_trait;
-use base_common_consensus::{BaseBlock, BasePrimitives, BaseReceipt};
+use base_common_consensus::{BaseBlock, BasePrimitives, BaseReceipt, Predeploys};
 use base_common_genesis::RollupConfig;
 use base_common_network::{Base, BaseEngineApi};
 use base_common_rpc_types_engine::{
@@ -51,11 +51,12 @@ use reth_payload_primitives::{BuiltPayload, PayloadAttributes};
 use reth_primitives_traits::SealedHeader;
 use reth_provider::{
     BlockWriter, HashedPostStateProvider, LatestStateProviderRef, ProviderFactory, StateProvider,
-    StateProviderFactory, providers::BlockchainProvider,
+    StateProviderFactory, StorageRootProvider, providers::BlockchainProvider,
     test_utils::create_test_provider_factory_with_node_types,
 };
 use reth_revm::{cached::CachedReads, cancelled::CancelOnDrop};
 use reth_transaction_pool::noop::NoopTransactionPool;
+use reth_trie_common::HashedStorage;
 
 use crate::{SharedBlockHashRegistry, SharedL1Chain};
 
@@ -73,6 +74,12 @@ pub type TestPool = NoopTransactionPool<BasePooledTransaction>;
 
 /// Type alias for Base L2 RPC blocks returned by the action engine.
 type ActionL2RpcBlock = <Base as Network>::BlockResponse;
+
+/// Minimal `L2ToL1MessagePasser` stand-in for Isthmus withdrawals-root tests.
+///
+/// Any call increments storage slot 0 so the account storage root — and therefore
+/// the post-Isthmus header `withdrawals_root` — changes when a withdrawal runs.
+const L2_TO_L1_MESSAGE_PASSER_STUB_CODE: [u8; 10] = hex!("60005460010160005500");
 
 /// A payload built in-process during sequencer mode, waiting to be sealed or inserted.
 #[derive(Debug, Clone)]
@@ -152,6 +159,14 @@ impl ActionEngineClient {
         genesis.alloc.insert(
             crate::TEST_ACCOUNT_ADDRESS,
             GenesisAccount::default().with_balance(test_balance),
+        );
+
+        // Harness genesis has no OP predeploys. Without code at this address,
+        // withdrawal calls are no-ops and Isthmus withdrawals_root never moves.
+        genesis.alloc.insert(
+            Predeploys::L2_TO_L1_MESSAGE_PASSER,
+            GenesisAccount::default()
+                .with_code(Some(Bytes::from_static(&L2_TO_L1_MESSAGE_PASSER_STUB_CODE))),
         );
 
         let hf = &rollup_config.upgrades;
@@ -296,6 +311,19 @@ impl ActionEngineClient {
             .expect("failed to read storage")
             .map(alloy_primitives::U256::from)
             .unwrap_or(alloy_primitives::U256::ZERO)
+    }
+
+    /// Storage root of `address` at the latest committed state.
+    ///
+    /// Prefer this over `eth_getProof` in action tests: the engine client's proof
+    /// RPC path is stubbed and always returns a zero storage hash.
+    pub fn account_storage_root(&self, address: Address) -> B256 {
+        let inner = self.inner.lock().expect("engine client lock");
+        let provider =
+            inner.blockchain_provider.latest().expect("failed to get latest state provider");
+        provider
+            .storage_root(address, HashedStorage::default())
+            .expect("failed to compute account storage root")
     }
 
     /// Return receipts for an executed block number.

--- a/actions/harness/tests/upgrade/isthmus.rs
+++ b/actions/harness/tests/upgrade/isthmus.rs
@@ -1,0 +1,253 @@
+//! Action tests for Isthmus `withdrawals_root` header semantics.
+//!
+//! Covers the Holocene → Isthmus boundary: empty withdrawals root before
+//! activation, `L2ToL1MessagePasser` storage root at/after activation, and both
+//! paths with and without a withdrawal transaction.
+
+use alloy_consensus::{TxReceipt, constants::EMPTY_WITHDRAWALS};
+use alloy_eips::eip7685::EMPTY_REQUESTS_HASH;
+use alloy_primitives::{Bytes, TxKind, U256};
+use base_action_harness::{
+    ActionTestHarness, BatcherConfig, L1MinerConfig, L2Sequencer, SharedL1Chain,
+    TestRollupConfigBuilder,
+};
+use base_common_consensus::Predeploys;
+
+const WITHDRAWAL_VALUE: u64 = 500;
+const WITHDRAWAL_GAS_LIMIT: u64 = 100_000;
+
+/// Call the harness `MessagePasser` stub so its storage root (and Isthmus
+/// `withdrawals_root`) can change.
+fn withdrawal_tx(sequencer: &L2Sequencer, chain_id: u64) -> base_common_consensus::BaseTxEnvelope {
+    let account = sequencer.test_account();
+    let mut account = account.lock().expect("test account lock");
+    account.create_tx(
+        chain_id,
+        TxKind::Call(Predeploys::L2_TO_L1_MESSAGE_PASSER),
+        Bytes::new(),
+        U256::from(WITHDRAWAL_VALUE),
+        WITHDRAWAL_GAS_LIMIT,
+    )
+}
+
+fn assert_user_tx_succeeded(sequencer: &L2Sequencer, block_number: u64) {
+    let receipts = sequencer
+        .engine_client()
+        .receipts_at(block_number)
+        .unwrap_or_else(|| panic!("missing receipts for block {block_number}"));
+    let user_receipt =
+        receipts.last().unwrap_or_else(|| panic!("block {block_number} has no receipts"));
+    assert!(user_receipt.status(), "expected successful withdrawal tx in block {block_number}");
+}
+
+fn assert_pre_isthmus_withdrawals_root(block_number: u64, root: Option<alloy_primitives::B256>) {
+    assert_eq!(
+        root,
+        Some(EMPTY_WITHDRAWALS),
+        "block {block_number}: pre-Isthmus withdrawals_root must be EMPTY_WITHDRAWALS"
+    );
+}
+
+fn assert_isthmus_withdrawals_root(
+    sequencer: &L2Sequencer,
+    block_number: u64,
+    root: Option<alloy_primitives::B256>,
+) {
+    let expected =
+        sequencer.engine_client().account_storage_root(Predeploys::L2_TO_L1_MESSAGE_PASSER);
+    assert_eq!(
+        root,
+        Some(expected),
+        "block {block_number}: Isthmus withdrawals_root must equal L2ToL1MessagePasser storage root"
+    );
+}
+
+/// Pre-Isthmus: `withdrawals_root` stays `EMPTY_WITHDRAWALS` even if a withdrawal
+/// executes — the field is not the `MessagePasser` storage root until Isthmus.
+#[tokio::test]
+async fn withdrawals_root_empty_before_isthmus() {
+    let batcher_cfg = BatcherConfig::default();
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).through_holocene().build();
+    let chain_id = rollup_cfg.l2_chain_id.id();
+    let h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+
+    let empty = sequencer.build_empty_block().await;
+    assert_pre_isthmus_withdrawals_root(empty.header.number, empty.header.withdrawals_root);
+    assert!(empty.header.requests_hash.is_none(), "pre-Isthmus blocks must not set requests_hash");
+
+    let with_withdrawal = sequencer
+        .build_next_block_with_transactions(vec![withdrawal_tx(&sequencer, chain_id)])
+        .await;
+    assert_pre_isthmus_withdrawals_root(
+        with_withdrawal.header.number,
+        with_withdrawal.header.withdrawals_root,
+    );
+}
+
+/// Isthmus at genesis: header root matches `MessagePasser` storage, and a
+/// withdrawal must update both.
+#[tokio::test]
+async fn withdrawals_root_matches_message_passer_at_isthmus_genesis() {
+    let batcher_cfg = BatcherConfig::default();
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).through_isthmus().build();
+    let chain_id = rollup_cfg.l2_chain_id.id();
+    let h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+
+    let empty = sequencer.build_empty_block().await;
+    assert_isthmus_withdrawals_root(&sequencer, empty.header.number, empty.header.withdrawals_root);
+    assert_eq!(
+        empty.header.requests_hash,
+        Some(EMPTY_REQUESTS_HASH),
+        "Isthmus blocks must set the empty requests hash"
+    );
+
+    assert!(
+        sequencer.engine_client().has_code(Predeploys::L2_TO_L1_MESSAGE_PASSER),
+        "L2ToL1MessagePasser must be deployed in genesis"
+    );
+
+    let before_withdrawal = empty.header.withdrawals_root.expect("isthmus root present");
+    let with_withdrawal = sequencer
+        .build_next_block_with_transactions(vec![withdrawal_tx(&sequencer, chain_id)])
+        .await;
+    assert_user_tx_succeeded(&sequencer, with_withdrawal.header.number);
+    assert_isthmus_withdrawals_root(
+        &sequencer,
+        with_withdrawal.header.number,
+        with_withdrawal.header.withdrawals_root,
+    );
+    assert_ne!(
+        with_withdrawal.header.withdrawals_root,
+        Some(before_withdrawal),
+        "initiating a withdrawal must change the Isthmus withdrawals_root"
+    );
+}
+
+#[derive(Clone, Copy)]
+struct TransitionCase {
+    name: &'static str,
+    withdrawal_tx: bool,
+    /// 1-indexed L2 block that should include the withdrawal, if any.
+    withdrawal_block: u64,
+    /// With `block_time=2` and Isthmus at ts=6, activation is L2 block 3.
+    total_blocks: u64,
+}
+
+/// Cross Isthmus activation at ts=6 and check roots before / at / after the fork.
+#[tokio::test]
+async fn withdrawals_root_before_at_and_after_isthmus() {
+    const ISTHMUS_TIME: u64 = 6;
+
+    let cases = [
+        TransitionCase {
+            name: "before_isthmus_without_withdrawal",
+            withdrawal_tx: false,
+            withdrawal_block: 0,
+            total_blocks: 1,
+        },
+        TransitionCase {
+            name: "before_isthmus_with_withdrawal",
+            withdrawal_tx: true,
+            withdrawal_block: 1,
+            total_blocks: 1,
+        },
+        TransitionCase {
+            name: "at_isthmus_without_withdrawal",
+            withdrawal_tx: false,
+            withdrawal_block: 0,
+            total_blocks: 3,
+        },
+        TransitionCase {
+            name: "at_isthmus_with_withdrawal",
+            withdrawal_tx: true,
+            withdrawal_block: 3,
+            total_blocks: 3,
+        },
+        TransitionCase {
+            name: "after_isthmus_without_withdrawal",
+            withdrawal_tx: false,
+            withdrawal_block: 0,
+            total_blocks: 4,
+        },
+        TransitionCase {
+            name: "after_isthmus_with_withdrawal",
+            withdrawal_tx: true,
+            withdrawal_block: 4,
+            total_blocks: 4,
+        },
+    ];
+
+    for case in cases {
+        run_transition_case(ISTHMUS_TIME, case).await;
+    }
+}
+
+async fn run_transition_case(isthmus_time: u64, case: TransitionCase) {
+    let batcher_cfg = BatcherConfig::default();
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg)
+        .through_holocene()
+        .with_isthmus_at(isthmus_time)
+        .build();
+    let chain_id = rollup_cfg.l2_chain_id.id();
+    let h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+
+    let mut last_root = None;
+    for block_number in 1..=case.total_blocks {
+        let include_withdrawal = case.withdrawal_tx && case.withdrawal_block == block_number;
+        let block = if include_withdrawal {
+            sequencer
+                .build_next_block_with_transactions(vec![withdrawal_tx(&sequencer, chain_id)])
+                .await
+        } else {
+            sequencer.build_empty_block().await
+        };
+
+        assert_eq!(
+            block.header.number, block_number,
+            "{}: expected L2 block {block_number}",
+            case.name
+        );
+        if include_withdrawal {
+            assert_user_tx_succeeded(&sequencer, block.header.number);
+        }
+
+        let is_isthmus = block.header.timestamp >= isthmus_time;
+        if is_isthmus {
+            assert_isthmus_withdrawals_root(
+                &sequencer,
+                block.header.number,
+                block.header.withdrawals_root,
+            );
+            assert_eq!(
+                block.header.requests_hash,
+                Some(EMPTY_REQUESTS_HASH),
+                "{}: Isthmus block {} must set empty requests_hash",
+                case.name,
+                block.header.number
+            );
+            if include_withdrawal {
+                assert_ne!(
+                    block.header.withdrawals_root, last_root,
+                    "{}: withdrawal in block {} must change withdrawals_root",
+                    case.name, block_number
+                );
+            }
+        } else {
+            assert_pre_isthmus_withdrawals_root(block.header.number, block.header.withdrawals_root);
+            assert!(
+                block.header.requests_hash.is_none(),
+                "{}: pre-Isthmus block {} must not set requests_hash",
+                case.name,
+                block.header.number
+            );
+        }
+
+        last_root = block.header.withdrawals_root;
+    }
+}

--- a/actions/harness/tests/upgrade/main.rs
+++ b/actions/harness/tests/upgrade/main.rs
@@ -3,4 +3,5 @@
 mod activation;
 mod ecotone;
 mod holocene;
+mod isthmus;
 mod operator_fees;


### PR DESCRIPTION
## Summary
Assert empty pre-Isthmus roots, MessagePasser storage roots after activation, and the before/at/after matrix with and without withdrawals.

Made with [Cursor](https://cursor.com)

Linear ticket: CHAIN-3544