### PR TITLE
fix(BOP-511): reject from == Address::ZERO in seizeWithMemo (V2)

### DIFF
--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -37,7 +37,7 @@ jobs:
           - fork: Cobalt
             key: cobalt
             base_anvil_ref: ae7557c4f8602caa1da0be33143bb2504c85b0c8
-            base_std_ref: 38567e2082b186c893fab517e2752b8d6a75ea0e
+            base_std_ref: 3f8990095f3316ed9b331a39f5c21a1bb5059c5f
     env:
       FORK_NAME: ${{ matrix.fork }}
       FORK_KEY: ${{ matrix.key }}

--- a/crates/common/precompiles/src/b20_asset/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v2.rs
@@ -394,9 +394,13 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
     ) -> Result<()> {
         B20Guards::ensure_not_paused(token, IB20::PausableFeature::SEIZE)?;
         B20Guards::ensure_token_role(token, caller, B20TokenRole::Seize)?;
-        // `to != 0` guards against a disguised burn; `from` is not zero-checked (burn-blocked family).
+        // `to != 0` guards against a disguised burn; `from != 0` guards against a disguised mint
+        // (`Transfer(0x0, to, ...)`), matching `transfer_inner`.
         if to == Address::ZERO {
             return Err(BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }));
+        }
+        if from == Address::ZERO {
+            return Err(BasePrecompileError::revert(IB20::InvalidSender { sender: from }));
         }
         if from == to {
             return Err(BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }));
@@ -1665,6 +1669,26 @@ mod tests {
         assert_eq!(
             err,
             BasePrecompileError::revert(IB20::InvalidReceiver { receiver: Address::ZERO })
+        );
+    }
+
+    #[test]
+    fn seize_reverts_on_zero_from() {
+        let mut tok = token();
+        // A non-default `SeizeHolder` (here ALWAYS_BLOCK via `make_seizable`) treats the zero
+        // address as seizable, so without the `from != 0` guard a zero-amount seize from the zero
+        // address would emit a misleading `Transfer(0x0, to, 0)` that indexers read as a mint.
+        make_seizable(&mut tok);
+        grant(&mut tok, B20TokenRole::Seize.id(), ADMIN);
+
+        let err = LOGIC
+            .seize_with_memo(&mut tok, ADMIN, Address::ZERO, BOB, U256::ZERO, MEMO)
+            .unwrap_err();
+
+        assert_eq!(err, BasePrecompileError::revert(IB20::InvalidSender { sender: Address::ZERO }));
+        assert!(
+            event_sigs(&tok).is_empty(),
+            "no misleading Transfer/Memo/Seized on a rejected zero-from seize"
         );
     }
 

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
@@ -353,9 +353,13 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> Stablecoin<S, A> for Stableco
     ) -> Result<()> {
         B20Guards::ensure_not_paused(token, IB20::PausableFeature::SEIZE)?;
         B20Guards::ensure_token_role(token, caller, B20TokenRole::Seize)?;
-        // `to != 0` guards against a disguised burn; `from` is not zero-checked (burn-blocked family).
+        // `to != 0` guards against a disguised burn; `from != 0` guards against a disguised mint
+        // (`Transfer(0x0, to, ...)`), matching `transfer_inner`.
         if to == Address::ZERO {
             return Err(BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }));
+        }
+        if from == Address::ZERO {
+            return Err(BasePrecompileError::revert(IB20::InvalidSender { sender: from }));
         }
         if from == to {
             return Err(BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }));
@@ -1358,6 +1362,26 @@ mod tests {
         assert_eq!(
             err,
             BasePrecompileError::revert(IB20::InvalidReceiver { receiver: Address::ZERO })
+        );
+    }
+
+    #[test]
+    fn seize_reverts_on_zero_from() {
+        let mut tok = token();
+        // A non-default `SeizeHolder` (here ALWAYS_BLOCK via `make_seizable`) treats the zero
+        // address as seizable, so without the `from != 0` guard a zero-amount seize from the zero
+        // address would emit a misleading `Transfer(0x0, to, 0)` that indexers read as a mint.
+        make_seizable(&mut tok);
+        grant(&mut tok, B20TokenRole::Seize.id(), ADMIN);
+
+        let err = LOGIC
+            .seize_with_memo(&mut tok, ADMIN, Address::ZERO, BOB, U256::ZERO, MEMO)
+            .unwrap_err();
+
+        assert_eq!(err, BasePrecompileError::revert(IB20::InvalidSender { sender: Address::ZERO }));
+        assert!(
+            event_sigs(&tok).is_empty(),
+            "no misleading Transfer/Memo/Seized on a rejected zero-from seize"
         );
     }
 

--- a/crates/common/precompiles/tests/b20_asset_v2_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v2_golden.rs
@@ -1059,6 +1059,26 @@ fn golden_seize_reverts_zero_receiver() {
 }
 
 #[test]
+fn golden_seize_reverts_zero_from() {
+    let mut s = fresh();
+    seed(&mut s, |t| {
+        give_role(t, B20TokenRole::Seize.id(), ADMIN);
+        // A non-default `SeizeHolder` treats the zero address as seizable; the `from != 0` guard
+        // still rejects a zero-amount seize that would otherwise emit a mint-like Transfer(0x0,..).
+        make_seizable(t);
+    });
+    let err = op(
+        &mut s,
+        ADMIN,
+        FakePolicyAccounting::new(),
+        IB20::seizeWithMemoCall { from: Address::ZERO, to: BOB, amount: u(0), memo: MEMO }
+            .abi_encode(),
+    )
+    .unwrap_err();
+    assert_eq!(err, BasePrecompileError::revert(IB20::InvalidSender { sender: Address::ZERO }));
+}
+
+#[test]
 fn golden_seize_reverts_account_not_seizable() {
     let mut s = fresh();
     seed(&mut s, |t| {


### PR DESCRIPTION
## Summary
- `seizeWithMemo` rejected `to == Address::ZERO` but not `from == Address::ZERO`. With `SEIZE_ROLE` and a non-default `SeizeHolder` that treats the zero address as seizable, a zero-amount seize from `Address::ZERO` could succeed and emit `Transfer(0x0, to, 0)`, which indexers often read as a mint. No onchain inflation, and the default `ALWAYS_ALLOW` `SeizeHolder` already blocks this path.
- Rejects `from == Address::ZERO` with `InvalidSender` in both `b20_asset` and `b20_stablecoin` V2 logic, placed right after the existing zero-receiver check and before `ensure_seizable`/policy checks so it fires unconditionally, matching `transfer_inner`.
- Adds `seize_reverts_on_zero_from` regression tests to both V2 logic modules and a `golden_seize_reverts_zero_from` case to the asset V2 golden suite.

## Linear
[BOP-511](https://linear.app/coinbase/issue/BOP-511/seize-from-addresszero-with-zero-amount-emits-misleading-events) — Cantina finding L-02.

## Test plan
- [x] `cargo test -p base-common-precompiles` — all pass, including new zero-from regression tests in `b20_asset::logic::v2`, `b20_stablecoin::logic::v2`, and the asset V2 golden suite.
- [x] `cargo clippy -p base-common-precompiles --all-targets --all-features` clean.
- [x] `cargo fmt -p base-common-precompiles` clean.

## Note
The Solidity reference mock `MockB20.seizeWithMemo` in [base-std](https://github.com/base/base-std) has the same gap and should get a companion fix (it currently also predates the BOP-510 `from == to` guard).