### PR TITLE
feat(consensus): Configure Separate L1 RPC Timeouts

### DIFF
--- a/crates/consensus/cli/src/follow.rs
+++ b/crates/consensus/cli/src/follow.rs
@@ -188,11 +188,15 @@ impl ConsensusFollowNodeArgs {
             l2_url: l2_engine_rpc,
             l2_jwt_secret: jwt_secret,
             l1_url: self.config.l1_rpc_args.l1_eth_rpc.clone(),
+            l1_rpc_timeout: self.config.l1_rpc_args.l1_rpc_timeout,
             mode: NodeMode::Validator,
         };
         let engine_client =
             Arc::new(engine_config.build_engine_client().await.map_err(|e| eyre::eyre!(e))?);
-        let l1_provider = L1RpcProvider::new_http(self.config.l1_rpc_args.l1_eth_rpc.clone());
+        let l1_provider = L1RpcProvider::new_http_with_timeout(
+            self.config.l1_rpc_args.l1_eth_rpc.clone(),
+            self.config.l1_rpc_args.l1_rpc_timeout,
+        );
         let l2_source = RemoteL2Client::new(self.config.source_l2_rpc.clone());
         let rpc_builder = Option::<RpcBuilder>::from(self.config.rpc_flags.clone());
 
@@ -267,7 +271,10 @@ impl ConsensusFollowNodeArgs {
             chain_config: Arc::new(l1_chain_config),
             trust_rpc: self.config.l1_rpc_args.l1_trust_rpc,
             beacon_client: l1_beacon,
-            engine_provider: L1RpcProvider::new_http(self.config.l1_rpc_args.l1_eth_rpc.clone()),
+            engine_provider: L1RpcProvider::new_http_with_timeout(
+                self.config.l1_rpc_args.l1_eth_rpc.clone(),
+                self.config.l1_rpc_args.l1_rpc_timeout,
+            ),
             finalized_poll_interval: L1Config::default_finalized_poll_interval(cfg.l1_chain_id),
             verifier_l1_confs: self.config.l1_rpc_args.l1_verifier_confs,
             da_batcher_sender_override: self.config.l1_rpc_args.l1_da_batcher_sender_override,

--- a/crates/consensus/cli/src/l1.rs
+++ b/crates/consensus/cli/src/l1.rs
@@ -17,7 +17,7 @@ pub struct L1ClientArgs {
     /// Request timeout for general L1 execution JSON-RPC calls.
     #[arg(
         long = "l1.rpc-timeout-ms",
-        default_value = "15000",
+        default_value = L1_RPC_TIMEOUT.as_millis().to_string(),
         env = "BASE_NODE_L1_RPC_TIMEOUT_MS",
         value_parser = |arg: &str| -> Result<Duration, ParseIntError> {
             Ok(Duration::from_millis(arg.parse()?))
@@ -81,7 +81,7 @@ mod tests {
 
     use clap::Parser;
 
-    use super::L1ClientArgs;
+    use super::{L1_RPC_TIMEOUT, L1ClientArgs};
 
     #[derive(Parser)]
     struct Command {
@@ -91,7 +91,7 @@ mod tests {
 
     #[test]
     fn defaults_l1_rpc_timeout_to_fifteen_seconds() {
-        assert_eq!(L1ClientArgs::default().l1_rpc_timeout, Duration::from_secs(15));
+        assert_eq!(L1ClientArgs::default().l1_rpc_timeout, L1_RPC_TIMEOUT);
     }
 
     #[test]

--- a/crates/consensus/cli/src/l1.rs
+++ b/crates/consensus/cli/src/l1.rs
@@ -1,6 +1,9 @@
 //! L1 Client CLI arguments.
 
+use std::{num::ParseIntError, time::Duration};
+
 use alloy_primitives::Address;
+use base_consensus_providers::L1_RPC_TIMEOUT;
 use url::Url;
 
 const DEFAULT_L1_TRUST_RPC: bool = true;
@@ -11,6 +14,16 @@ pub struct L1ClientArgs {
     /// URL of the L1 execution client RPC API.
     #[arg(long, visible_alias = "l1", env = "BASE_NODE_L1_ETH_RPC")]
     pub l1_eth_rpc: Url,
+    /// Request timeout for general L1 execution JSON-RPC calls.
+    #[arg(
+        long = "l1.rpc-timeout-ms",
+        default_value = "15000",
+        env = "BASE_NODE_L1_RPC_TIMEOUT_MS",
+        value_parser = |arg: &str| -> Result<Duration, ParseIntError> {
+            Ok(Duration::from_millis(arg.parse()?))
+        }
+    )]
+    pub l1_rpc_timeout: Duration,
     /// Whether to trust the L1 RPC.
     /// If false, block hash verification is performed for all retrieved blocks.
     #[arg(
@@ -52,11 +65,48 @@ impl Default for L1ClientArgs {
     fn default() -> Self {
         Self {
             l1_eth_rpc: Url::parse("http://localhost:8545").unwrap(),
+            l1_rpc_timeout: L1_RPC_TIMEOUT,
             l1_trust_rpc: DEFAULT_L1_TRUST_RPC,
             l1_beacon: Url::parse("http://localhost:5052").unwrap(),
             l1_slot_duration_override: None,
             l1_da_batcher_sender_override: None,
             l1_verifier_confs: 0,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use clap::Parser;
+
+    use super::L1ClientArgs;
+
+    #[derive(Parser)]
+    struct Command {
+        #[command(flatten)]
+        args: L1ClientArgs,
+    }
+
+    #[test]
+    fn defaults_l1_rpc_timeout_to_fifteen_seconds() {
+        assert_eq!(L1ClientArgs::default().l1_rpc_timeout, Duration::from_secs(15));
+    }
+
+    #[test]
+    fn parses_l1_rpc_timeout_in_milliseconds() {
+        let args = Command::parse_from([
+            "base-consensus",
+            "--l1-eth-rpc",
+            "http://localhost:8545",
+            "--l1-beacon",
+            "http://localhost:5052",
+            "--l1.rpc-timeout-ms",
+            "2500",
+        ])
+        .args;
+
+        assert_eq!(args.l1_rpc_timeout, Duration::from_millis(2500));
     }
 }

--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -455,6 +455,7 @@ impl ConsensusNodeArgs {
             trust_rpc: self.config.l1_rpc_args.l1_trust_rpc,
             beacon: self.config.l1_rpc_args.l1_beacon.clone(),
             rpc_url: self.config.l1_rpc_args.l1_eth_rpc.clone(),
+            rpc_timeout: self.config.l1_rpc_args.l1_rpc_timeout,
             slot_duration_override: self.config.l1_rpc_args.l1_slot_duration_override,
             verifier_l1_confs: self.config.l1_rpc_args.l1_verifier_confs,
             da_batcher_sender_override: self.config.l1_rpc_args.l1_da_batcher_sender_override,
@@ -480,6 +481,7 @@ impl ConsensusNodeArgs {
                 &cfg,
                 self.chain.l2_chain_id.into(),
                 Some(self.config.l1_rpc_args.l1_eth_rpc.clone()),
+                self.config.l1_rpc_args.l1_rpc_timeout,
                 genesis_signer,
             )
             .await?;
@@ -490,6 +492,7 @@ impl ConsensusNodeArgs {
             l2_url: l2_engine_rpc,
             l2_jwt_secret: jwt_secret,
             l1_url: self.config.l1_rpc_args.l1_eth_rpc.clone(),
+            l1_rpc_timeout: self.config.l1_rpc_args.l1_rpc_timeout,
             mode: self.config.node_mode,
         };
 
@@ -524,8 +527,9 @@ impl ConsensusNodeArgs {
         signal_config: &UpgradeSignalConfig,
         upgrade_signal_l1_rpc: Option<&Url>,
     ) -> eyre::Result<()> {
-        let reader = signal_config.reader(L1RpcProvider::new_http(
+        let reader = signal_config.reader(L1RpcProvider::new_http_with_timeout(
             self.resolved_upgrade_signal_l1_rpc(upgrade_signal_l1_rpc),
+            self.config.l1_rpc_args.l1_rpc_timeout,
         ));
         let schedule = signal_config
             .read_validated_schedule(

--- a/crates/consensus/cli/src/p2p.rs
+++ b/crates/consensus/cli/src/p2p.rs
@@ -22,7 +22,7 @@ use base_consensus_gossip::{
 };
 use base_consensus_node::NetworkConfig;
 use base_consensus_peers::{BootNode, BootStoreFile, PeerMonitoring, PeerScoreLevel};
-use base_consensus_providers::AlloyChainProvider;
+use base_consensus_providers::{AlloyChainProvider, L1RpcProvider};
 use base_retry::RetryConfig;
 use clap::Parser;
 use discv5::enr::k256;
@@ -466,6 +466,7 @@ impl P2PArgs {
         l2_chain_id: u64,
         rollup_config: &RollupConfig,
         l1_eth_rpc: Option<Url>,
+        l1_rpc_timeout: Duration,
         genesis_signer: Option<alloy_primitives::Address>,
     ) -> eyre::Result<alloy_primitives::Address> {
         if let Some(l1_eth_rpc) = l1_eth_rpc {
@@ -474,7 +475,10 @@ impl P2PArgs {
             const UNSAFE_BLOCK_SIGNER_ADDRESS_STORAGE_SLOT: B256 =
                 b256!("0x65a7ed542fb37fe237fdfbdd70b31598523fe5b32879e307bae27a0bd9581c08");
 
-            let provider = AlloyChainProvider::new_http(l1_eth_rpc, 1024);
+            let provider = AlloyChainProvider::new(
+                L1RpcProvider::new_http_with_timeout(l1_eth_rpc, l1_rpc_timeout),
+                1024,
+            );
 
             let retry_config = RetryConfig::new(
                 self.unsafe_block_signer_retry_max_attempts,
@@ -624,6 +628,7 @@ impl P2PArgs {
     /// - `config`: The rollup configuration.
     /// - `l2_chain_id`: The L2 chain ID.
     /// - `l1_rpc`: Optional L1 RPC URL for fetching the unsafe block signer.
+    /// - `l1_rpc_timeout`: Request timeout for calls made while fetching the unsafe block signer.
     /// - `genesis_signer`: Optional genesis signer address.
     ///
     /// Errors if the genesis unsafe block signer isn't available for the specified L2 Chain ID.
@@ -632,6 +637,7 @@ impl P2PArgs {
         config: &RollupConfig,
         l2_chain_id: u64,
         l1_rpc: Option<Url>,
+        l1_rpc_timeout: Duration,
         genesis_signer: Option<alloy_primitives::Address>,
     ) -> Result<NetworkConfig, P2PConfigError> {
         // Note: the advertised address is contained in the ENR for external peers from the
@@ -694,8 +700,9 @@ impl P2PArgs {
         let mut gossip_address = libp2p::Multiaddr::from(self.listen_ip);
         gossip_address.push(libp2p::multiaddr::Protocol::Tcp(self.listen_tcp_port));
 
-        let unsafe_block_signer =
-            self.unsafe_block_signer(l2_chain_id, config, l1_rpc, genesis_signer).await?;
+        let unsafe_block_signer = self
+            .unsafe_block_signer(l2_chain_id, config, l1_rpc, l1_rpc_timeout, genesis_signer)
+            .await?;
 
         let bootnodes = self
             .bootnode_strings()?
@@ -803,6 +810,7 @@ mod tests {
     use alloy_primitives::{Address, b256};
     use base_common_genesis::RollupConfig;
     use base_consensus_peers::NodeRecord;
+    use base_consensus_providers::L1_RPC_TIMEOUT;
     use clap::Parser;
     use httpmock::{HttpMockRequest, HttpMockResponse, Method::POST, MockServer};
     use serde_json::{Value, json};
@@ -1017,7 +1025,13 @@ mod tests {
         let args = MockCommand::parse_from(["test"]).p2p;
         let genesis: Address = "0xAf6E19BE0F9cE7f8afd49a1824851023A8249e8a".parse().unwrap();
         let signer = args
-            .unsafe_block_signer(8453, &RollupConfig::default(), None, Some(genesis))
+            .unsafe_block_signer(
+                8453,
+                &RollupConfig::default(),
+                None,
+                L1_RPC_TIMEOUT,
+                Some(genesis),
+            )
             .await
             .unwrap();
         assert_eq!(signer, genesis);
@@ -1032,8 +1046,10 @@ mod tests {
             "0xAf6E19BE0F9cE7f8afd49a1824851023A8249e8a",
         ])
         .p2p;
-        let signer =
-            args.unsafe_block_signer(8453, &RollupConfig::default(), None, None).await.unwrap();
+        let signer = args
+            .unsafe_block_signer(8453, &RollupConfig::default(), None, L1_RPC_TIMEOUT, None)
+            .await
+            .unwrap();
         assert_eq!(signer, expected);
     }
 
@@ -1047,7 +1063,13 @@ mod tests {
         ])
         .p2p;
         let signer = args
-            .unsafe_block_signer(8453, &RollupConfig::default(), None, Some(genesis))
+            .unsafe_block_signer(
+                8453,
+                &RollupConfig::default(),
+                None,
+                L1_RPC_TIMEOUT,
+                Some(genesis),
+            )
             .await
             .unwrap();
         assert_eq!(signer, genesis);
@@ -1057,7 +1079,7 @@ mod tests {
     async fn test_unsafe_block_signer_errors_with_no_fallbacks() {
         let args = MockCommand::parse_from(["test"]).p2p;
         let err = args
-            .unsafe_block_signer(99999, &RollupConfig::default(), None, None)
+            .unsafe_block_signer(99999, &RollupConfig::default(), None, L1_RPC_TIMEOUT, None)
             .await
             .unwrap_err()
             .to_string();
@@ -1199,7 +1221,7 @@ mod tests {
         let args = args_with_retry(3, 1);
         let l1_rpc = server.url("/").parse().unwrap();
         let signer = args
-            .unsafe_block_signer(8453, &RollupConfig::default(), Some(l1_rpc), None)
+            .unsafe_block_signer(8453, &RollupConfig::default(), Some(l1_rpc), L1_RPC_TIMEOUT, None)
             .await
             .unwrap();
 
@@ -1220,7 +1242,7 @@ mod tests {
         let args = args_with_retry(1, 1);
         let l1_rpc = server.url("/").parse().unwrap();
         let err = args
-            .unsafe_block_signer(8453, &RollupConfig::default(), Some(l1_rpc), None)
+            .unsafe_block_signer(8453, &RollupConfig::default(), Some(l1_rpc), L1_RPC_TIMEOUT, None)
             .await
             .unwrap_err();
 
@@ -1235,7 +1257,7 @@ mod tests {
 
         let err = args
             .p2p
-            .config(&RollupConfig::default(), 8453, None, Some(Address::ZERO))
+            .config(&RollupConfig::default(), 8453, None, L1_RPC_TIMEOUT, Some(Address::ZERO))
             .await
             .expect_err("invalid bootnode should fail config")
             .to_string();
@@ -1249,7 +1271,7 @@ mod tests {
 
         let config = args
             .p2p
-            .config(&RollupConfig::default(), 8453, None, Some(Address::ZERO))
+            .config(&RollupConfig::default(), 8453, None, L1_RPC_TIMEOUT, Some(Address::ZERO))
             .await
             .unwrap();
 
@@ -1264,7 +1286,7 @@ mod tests {
 
         let config = args
             .p2p
-            .config(&RollupConfig::default(), 8453, None, Some(Address::ZERO))
+            .config(&RollupConfig::default(), 8453, None, L1_RPC_TIMEOUT, Some(Address::ZERO))
             .await
             .unwrap();
 
@@ -1277,7 +1299,7 @@ mod tests {
 
         let config = args
             .p2p
-            .config(&RollupConfig::default(), 8453, None, Some(Address::ZERO))
+            .config(&RollupConfig::default(), 8453, None, L1_RPC_TIMEOUT, Some(Address::ZERO))
             .await
             .unwrap();
 
@@ -1290,7 +1312,7 @@ mod tests {
 
         let config = args
             .p2p
-            .config(&RollupConfig::default(), 8453, None, Some(Address::ZERO))
+            .config(&RollupConfig::default(), 8453, None, L1_RPC_TIMEOUT, Some(Address::ZERO))
             .await
             .unwrap();
 

--- a/crates/consensus/cli/src/sequencer.rs
+++ b/crates/consensus/cli/src/sequencer.rs
@@ -30,7 +30,7 @@ pub struct SequencerArgs {
     #[arg(
         id = "sequencer_l1_rpc_timeout",
         long = "sequencer.l1-rpc-timeout-ms",
-        default_value = "500",
+        default_value = SequencerConfig::DEFAULT_L1_RPC_TIMEOUT.as_millis().to_string(),
         env = "BASE_NODE_SEQUENCER_L1_RPC_TIMEOUT_MS",
         value_parser = |arg: &str| -> Result<Duration, ParseIntError> {
             Ok(Duration::from_millis(arg.parse()?))
@@ -111,7 +111,7 @@ mod tests {
 
     use clap::Parser;
 
-    use super::SequencerArgs;
+    use super::{SequencerArgs, SequencerConfig};
     use crate::L1ClientArgs;
 
     #[derive(Parser)]
@@ -126,8 +126,8 @@ mod tests {
     fn defaults_l1_rpc_timeout_to_five_hundred_milliseconds() {
         let args = SequencerArgs::default();
 
-        assert_eq!(args.l1_rpc_timeout, Duration::from_millis(500));
-        assert_eq!(args.config().l1_rpc_timeout, Duration::from_millis(500));
+        assert_eq!(args.l1_rpc_timeout, SequencerConfig::DEFAULT_L1_RPC_TIMEOUT);
+        assert_eq!(args.config().l1_rpc_timeout, SequencerConfig::DEFAULT_L1_RPC_TIMEOUT);
     }
 
     #[test]

--- a/crates/consensus/cli/src/sequencer.rs
+++ b/crates/consensus/cli/src/sequencer.rs
@@ -26,6 +26,17 @@ pub struct SequencerArgs {
     #[arg(long = "sequencer.l1-confs", default_value = "4", env = "BASE_NODE_SEQUENCER_L1_CONFS")]
     pub l1_confs: u64,
 
+    /// Request timeout for L1 RPC calls on the sequencer block-production hot path.
+    #[arg(
+        long = "sequencer.l1-rpc-timeout-ms",
+        default_value = "500",
+        env = "BASE_NODE_SEQUENCER_L1_RPC_TIMEOUT_MS",
+        value_parser = |arg: &str| -> Result<Duration, ParseIntError> {
+            Ok(Duration::from_millis(arg.parse()?))
+        }
+    )]
+    pub l1_rpc_timeout: Duration,
+
     /// Force the sequencer to strictly prepare the next L1 origin and create empty L2 blocks.
     #[arg(
         long = "sequencer.recover",
@@ -88,17 +99,35 @@ impl SequencerArgs {
             conductor_binary_commit: self.conductor_binary_commit,
             conductor_rpc_timeout: self.conductor_rpc_timeout,
             l1_conf_delay: self.l1_confs,
+            l1_rpc_timeout: self.l1_rpc_timeout,
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroU64;
+    use std::{num::NonZeroU64, time::Duration};
 
     use clap::Parser;
 
     use super::SequencerArgs;
+
+    #[test]
+    fn defaults_l1_rpc_timeout_to_five_hundred_milliseconds() {
+        let args = SequencerArgs::default();
+
+        assert_eq!(args.l1_rpc_timeout, Duration::from_millis(500));
+        assert_eq!(args.config().l1_rpc_timeout, Duration::from_millis(500));
+    }
+
+    #[test]
+    fn parses_l1_rpc_timeout_in_milliseconds() {
+        let args =
+            SequencerArgs::parse_from(["base-consensus", "--sequencer.l1-rpc-timeout-ms", "750"]);
+
+        assert_eq!(args.l1_rpc_timeout, Duration::from_millis(750));
+        assert_eq!(args.config().l1_rpc_timeout, Duration::from_millis(750));
+    }
 
     #[test]
     fn parses_shadow_blocks_per_cycle() {

--- a/crates/consensus/cli/src/sequencer.rs
+++ b/crates/consensus/cli/src/sequencer.rs
@@ -28,6 +28,7 @@ pub struct SequencerArgs {
 
     /// Request timeout for L1 RPC calls on the sequencer block-production hot path.
     #[arg(
+        id = "sequencer_l1_rpc_timeout",
         long = "sequencer.l1-rpc-timeout-ms",
         default_value = "500",
         env = "BASE_NODE_SEQUENCER_L1_RPC_TIMEOUT_MS",
@@ -111,6 +112,15 @@ mod tests {
     use clap::Parser;
 
     use super::SequencerArgs;
+    use crate::L1ClientArgs;
+
+    #[derive(Parser)]
+    struct Command {
+        #[command(flatten)]
+        l1: L1ClientArgs,
+        #[command(flatten)]
+        sequencer: SequencerArgs,
+    }
 
     #[test]
     fn defaults_l1_rpc_timeout_to_five_hundred_milliseconds() {
@@ -127,6 +137,24 @@ mod tests {
 
         assert_eq!(args.l1_rpc_timeout, Duration::from_millis(750));
         assert_eq!(args.config().l1_rpc_timeout, Duration::from_millis(750));
+    }
+
+    #[test]
+    fn parses_general_and_sequencer_l1_rpc_timeouts_together() {
+        let args = Command::parse_from([
+            "base-consensus",
+            "--l1-eth-rpc",
+            "http://localhost:8545",
+            "--l1-beacon",
+            "http://localhost:5052",
+            "--l1.rpc-timeout-ms",
+            "2500",
+            "--sequencer.l1-rpc-timeout-ms",
+            "750",
+        ]);
+
+        assert_eq!(args.l1.l1_rpc_timeout, Duration::from_millis(2500));
+        assert_eq!(args.sequencer.l1_rpc_timeout, Duration::from_millis(750));
     }
 
     #[test]

--- a/crates/consensus/engine/src/client.rs
+++ b/crates/consensus/engine/src/client.rs
@@ -1,6 +1,6 @@
 //! An Engine API Client.
 
-use std::{future::Future, io, sync::Arc};
+use std::{future::Future, io, sync::Arc, time::Duration};
 
 use alloy_eips::{BlockId, eip1898::BlockNumberOrTag};
 use alloy_network::{Ethereum, Network};
@@ -172,6 +172,8 @@ pub struct EngineClientBuilder {
     pub l2_jwt: JwtSecret,
     /// The L1 RPC URL.
     pub l1_rpc: Url,
+    /// Request timeout for L1 execution JSON-RPC calls.
+    pub l1_rpc_timeout: Duration,
     /// The [`RollupConfig`] for determining Engine API versions based on upgrade activations.
     pub cfg: Arc<RollupConfig>,
 }
@@ -191,7 +193,7 @@ impl EngineClientBuilder {
         )
         .await?;
 
-        let l1_provider = L1RpcProvider::new_http(self.l1_rpc);
+        let l1_provider = L1RpcProvider::new_http_with_timeout(self.l1_rpc, self.l1_rpc_timeout);
 
         Ok(BaseEngineClient { engine, l1_provider, cfg: self.cfg })
     }
@@ -402,6 +404,7 @@ async fn record_call_time<T, Err>(
 #[cfg(test)]
 mod tests {
     use alloy_rpc_types_engine::JwtSecret;
+    use base_consensus_providers::L1_RPC_TIMEOUT;
     use tokio::net::TcpListener;
     use tokio_tungstenite::accept_async;
 
@@ -507,6 +510,7 @@ mod tests {
             l2: "http://127.0.0.1:8551".parse().unwrap(),
             l2_jwt: JwtSecret::random(),
             l1_rpc: "http://127.0.0.1:8545".parse().unwrap(),
+            l1_rpc_timeout: L1_RPC_TIMEOUT,
             cfg: Arc::new(RollupConfig::default()),
         };
         let _client = builder.build().await.unwrap();
@@ -527,6 +531,7 @@ mod tests {
             l2: format!("ws://127.0.0.1:{port}").parse().unwrap(),
             l2_jwt: JwtSecret::random(),
             l1_rpc: "http://127.0.0.1:8545".parse().unwrap(),
+            l1_rpc_timeout: L1_RPC_TIMEOUT,
             cfg: Arc::new(RollupConfig::default()),
         };
         let _client = builder.build().await.unwrap();

--- a/crates/consensus/providers/src/beacon_client.rs
+++ b/crates/consensus/providers/src/beacon_client.rs
@@ -141,7 +141,7 @@ pub struct OnlineBeaconClient {
 impl OnlineBeaconClient {
     /// Creates a new [`OnlineBeaconClient`] from the provided base URL string.
     ///
-    /// Requests use the shared [`crate::L1_RPC_TIMEOUT`] deadline.
+    /// Requests use the default [`crate::L1_RPC_TIMEOUT`] deadline.
     pub fn new_http(base: String) -> Self {
         Self::with_timeout(base, crate::L1_RPC_TIMEOUT)
     }

--- a/crates/consensus/providers/src/chain_provider.rs
+++ b/crates/consensus/providers/src/chain_provider.rs
@@ -57,7 +57,7 @@ impl AlloyChainProvider {
 
     /// Creates a new [`AlloyChainProvider`] from the provided [`url::Url`].
     ///
-    /// The underlying HTTP provider uses the shared [`crate::L1_RPC_TIMEOUT`] deadline.
+    /// The underlying HTTP provider uses the default [`crate::L1_RPC_TIMEOUT`] deadline.
     pub fn new_http(url: url::Url, cache_size: usize) -> Self {
         let inner = L1RpcProvider::new_http(url);
         Self::new(inner, cache_size)

--- a/crates/consensus/providers/src/l1_rpc.rs
+++ b/crates/consensus/providers/src/l1_rpc.rs
@@ -7,10 +7,10 @@ use alloy_rpc_client::RpcClient;
 use reqwest::Client;
 use url::Url;
 
-/// Maximum duration for every HTTP request made by a consensus L1 client.
+/// Default request timeout for consensus L1 HTTP clients.
 ///
-/// This deadline is shared by L1 execution JSON-RPC and Beacon API requests. It is intentionally
-/// not operation-specific: all standard consensus L1 clients use the same transport deadline.
+/// General L1 execution JSON-RPC and Beacon API requests use this deadline unless their caller
+/// supplies an explicit timeout.
 pub const L1_RPC_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Constructs standard consensus L1 HTTP providers.
@@ -18,12 +18,13 @@ pub const L1_RPC_TIMEOUT: Duration = Duration::from_secs(15);
 pub struct L1RpcProvider;
 
 impl L1RpcProvider {
-    /// Creates an L1 execution JSON-RPC provider with the shared request deadline.
+    /// Creates an L1 execution JSON-RPC provider with the default request deadline.
     pub fn new_http(url: Url) -> RootProvider {
-        Self::with_timeout(url, L1_RPC_TIMEOUT)
+        Self::new_http_with_timeout(url, L1_RPC_TIMEOUT)
     }
 
-    fn with_timeout(url: Url, timeout: Duration) -> RootProvider {
+    /// Creates an L1 execution JSON-RPC provider with the provided request deadline.
+    pub fn new_http_with_timeout(url: Url, timeout: Duration) -> RootProvider {
         let client =
             Client::builder().timeout(timeout).build().expect("failed to build L1 RPC HTTP client");
 
@@ -64,7 +65,7 @@ mod tests {
                 then.status(200).delay(TEST_RESPONSE_DELAY);
             })
             .await;
-        let provider = L1RpcProvider::with_timeout(
+        let provider = L1RpcProvider::new_http_with_timeout(
             server.url("/").parse().expect("mock server URL must parse"),
             TEST_REQUEST_TIMEOUT,
         );
@@ -82,6 +83,33 @@ mod tests {
             is_reqwest_timeout(&requests.1),
             "eth_getBlockByNumber should fail with a request timeout"
         );
+        mock.assert_calls_async(2).await;
+    }
+
+    #[tokio::test]
+    async fn execution_providers_can_use_independent_request_timeouts() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path("/");
+                then.status(200).delay(TEST_RESPONSE_DELAY).json_body(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 0,
+                    "result": "0x1"
+                }));
+            })
+            .await;
+        let url: Url = server.url("/").parse().expect("mock server URL must parse");
+        let short_timeout_provider =
+            L1RpcProvider::new_http_with_timeout(url.clone(), TEST_REQUEST_TIMEOUT);
+        let long_timeout_provider =
+            L1RpcProvider::new_http_with_timeout(url, Duration::from_millis(500));
+
+        let short_result = short_timeout_provider.get_block_number().await;
+        let long_result = long_timeout_provider.get_block_number().await;
+
+        assert!(is_reqwest_timeout(&short_result));
+        assert_eq!(long_result.unwrap(), 1);
         mock.assert_calls_async(2).await;
     }
 }

--- a/crates/consensus/service/src/actors/engine/config.rs
+++ b/crates/consensus/service/src/actors/engine/config.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use alloy_provider::RootProvider;
 use alloy_rpc_types_engine::JwtSecret;
@@ -23,6 +23,8 @@ pub struct EngineConfig {
 
     /// The L1 rpc url.
     pub l1_url: Url,
+    /// Request timeout for L1 execution JSON-RPC calls.
+    pub l1_rpc_timeout: Duration,
 
     /// The mode of operation for the node.
     /// When the node is in sequencer mode, the engine actor will receive requests to build blocks
@@ -39,6 +41,7 @@ impl EngineConfig {
             l2: self.l2_url.clone(),
             l2_jwt: self.l2_jwt_secret,
             l1_rpc: self.l1_url.clone(),
+            l1_rpc_timeout: self.l1_rpc_timeout,
             cfg: Arc::clone(&self.config),
         }
         .build()

--- a/crates/consensus/service/src/actors/sequencer/config.rs
+++ b/crates/consensus/service/src/actors/sequencer/config.rs
@@ -37,11 +37,15 @@ pub struct SequencerConfig {
     pub conductor_rpc_timeout: Duration,
     /// The confirmation delay for the sequencer.
     pub l1_conf_delay: u64,
+    /// Request timeout for L1 RPC calls on the sequencer block-production hot path.
+    pub l1_rpc_timeout: Duration,
 }
 
 impl SequencerConfig {
     /// Maximum number of payloads retained for one shadow reconciliation cycle.
     pub const MAX_SHADOW_BLOCKS_PER_CYCLE: u64 = 300;
+    /// Default request timeout for L1 RPC calls on the sequencer block-production hot path.
+    pub const DEFAULT_L1_RPC_TIMEOUT: Duration = Duration::from_millis(500);
 
     /// Returns whether shadow sequencer mode is enabled.
     pub const fn is_shadow_sequencer(&self) -> bool {
@@ -59,6 +63,7 @@ impl Default for SequencerConfig {
             conductor_binary_commit: false,
             conductor_rpc_timeout: DEFAULT_CONDUCTOR_RPC_TIMEOUT,
             l1_conf_delay: 0,
+            l1_rpc_timeout: Self::DEFAULT_L1_RPC_TIMEOUT,
         }
     }
 }

--- a/crates/consensus/service/src/actors/upgrade_signal.rs
+++ b/crates/consensus/service/src/actors/upgrade_signal.rs
@@ -33,10 +33,12 @@ impl UpgradeSignalNodeConfig {
         config: UpgradeSignalConfig,
         l1_rpc: Option<&Url>,
         default_l1_provider: RootProvider,
+        l1_rpc_timeout: Duration,
         chain_id: u64,
     ) -> Self {
-        let l1_provider =
-            l1_rpc.map(|url| L1RpcProvider::new_http(url.clone())).unwrap_or(default_l1_provider);
+        let l1_provider = l1_rpc
+            .map(|url| L1RpcProvider::new_http_with_timeout(url.clone(), l1_rpc_timeout))
+            .unwrap_or(default_l1_provider);
         Self { config, l1_provider, chain_id }
     }
 

--- a/crates/consensus/service/src/service/builder.rs
+++ b/crates/consensus/service/src/service/builder.rs
@@ -53,6 +53,8 @@ pub struct L1ConfigBuilder {
     pub beacon: Url,
     /// The L1 RPC URL.
     pub rpc_url: Url,
+    /// Request timeout for general L1 execution JSON-RPC calls.
+    pub rpc_timeout: Duration,
     /// The duration in seconds of an L1 slot. This can be used to hardcode a fixed slot
     /// duration if the l1-beacon's slot configuration is not available.
     pub slot_duration_override: Option<u64>,
@@ -198,6 +200,7 @@ impl RollupNodeBuilder {
     /// remains lazy during startup. `file://` URLs still connect eagerly because IPC is an
     /// explicit opt-in transport.
     pub async fn build(self) -> TransportResult<RollupNode> {
+        let sequencer_config = self.sequencer_config.unwrap_or_default();
         let mut l1_beacon = OnlineBeaconClient::new_http(self.l1_config_builder.beacon.to_string());
         if let Some(l1_slot_duration) = self.l1_config_builder.slot_duration_override {
             l1_beacon = l1_beacon.with_l1_slot_duration_override(l1_slot_duration);
@@ -211,11 +214,18 @@ impl RollupNodeBuilder {
             chain_config: Arc::new(self.l1_config_builder.chain_config),
             trust_rpc: self.l1_config_builder.trust_rpc,
             beacon_client: l1_beacon,
-            engine_provider: L1RpcProvider::new_http(self.l1_config_builder.rpc_url.clone()),
+            engine_provider: L1RpcProvider::new_http_with_timeout(
+                self.l1_config_builder.rpc_url.clone(),
+                self.l1_config_builder.rpc_timeout,
+            ),
             finalized_poll_interval,
             verifier_l1_confs: self.l1_config_builder.verifier_l1_confs,
             da_batcher_sender_override: self.l1_config_builder.da_batcher_sender_override,
         };
+        let sequencer_l1_provider = L1RpcProvider::new_http_with_timeout(
+            self.l1_config_builder.rpc_url.clone(),
+            sequencer_config.l1_rpc_timeout,
+        );
 
         let l2_provider_url = Self::derivation_l2_provider_url(self.engine_config.l2_url.clone());
         let l2_provider = BaseEngineClient::<RootProvider, RootProvider<Base>>::rpc_client::<Base>(
@@ -230,7 +240,6 @@ impl RollupNodeBuilder {
         });
 
         let p2p_config = self.p2p_config;
-        let sequencer_config = self.sequencer_config.unwrap_or_default();
 
         let derivation_delegate_provider = self.derivation_delegate_config.as_ref().map(|config| {
             DerivationDelegateClient::new(config.l2_cl_url.clone()).expect(
@@ -243,6 +252,7 @@ impl RollupNodeBuilder {
                 config,
                 self.upgrade_signal_config.l1_rpc.as_ref(),
                 l1_config.engine_provider.clone(),
+                self.l1_config_builder.rpc_timeout,
                 rollup_config.l2_chain_id.id(),
             )
         });
@@ -250,6 +260,7 @@ impl RollupNodeBuilder {
         Ok(RollupNode {
             config: rollup_config,
             l1_config,
+            sequencer_l1_provider,
             l2_provider,
             l2_trust_rpc: self.l2_trust_rpc,
             engine_config: self.engine_config,
@@ -296,6 +307,7 @@ mod tests {
             trust_rpc: true,
             beacon: Url::parse("http://127.0.0.1:5052").unwrap(),
             rpc_url: Url::parse("http://127.0.0.1:8545").unwrap(),
+            rpc_timeout: base_consensus_providers::L1_RPC_TIMEOUT,
             slot_duration_override: None,
             verifier_l1_confs: 0,
             da_batcher_sender_override: None,
@@ -305,6 +317,7 @@ mod tests {
             l2_url,
             l2_jwt_secret: JwtSecret::random(),
             l1_url: Url::parse("http://127.0.0.1:8545").unwrap(),
+            l1_rpc_timeout: base_consensus_providers::L1_RPC_TIMEOUT,
             mode: NodeMode::Validator,
         };
         let discovery_listen = LocalNode::new(

--- a/crates/consensus/service/src/service/builder.rs
+++ b/crates/consensus/service/src/service/builder.rs
@@ -222,10 +222,14 @@ impl RollupNodeBuilder {
             verifier_l1_confs: self.l1_config_builder.verifier_l1_confs,
             da_batcher_sender_override: self.l1_config_builder.da_batcher_sender_override,
         };
-        let sequencer_l1_provider = L1RpcProvider::new_http_with_timeout(
-            self.l1_config_builder.rpc_url.clone(),
-            sequencer_config.l1_rpc_timeout,
-        );
+        let sequencer_l1_provider = if self.engine_config.mode.is_sequencer() {
+            L1RpcProvider::new_http_with_timeout(
+                self.l1_config_builder.rpc_url.clone(),
+                sequencer_config.l1_rpc_timeout,
+            )
+        } else {
+            l1_config.engine_provider.clone()
+        };
 
         let l2_provider_url = Self::derivation_l2_provider_url(self.engine_config.l2_url.clone());
         let l2_provider = BaseEngineClient::<RootProvider, RootProvider<Base>>::rpc_client::<Base>(

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -70,7 +70,7 @@ pub struct L1Config {
     pub trust_rpc: bool,
     /// The L1 beacon API client.
     pub beacon_client: OnlineBeaconClient,
-    /// The L1 execution JSON-RPC provider.
+    /// The general L1 execution JSON-RPC provider.
     pub engine_provider: RootProvider,
     /// How frequently to poll L1 for a new finalized block.
     ///
@@ -112,6 +112,8 @@ pub struct RollupNode {
     pub config: Arc<RollupConfig>,
     /// The L1 configuration.
     pub l1_config: L1Config,
+    /// L1 execution JSON-RPC provider dedicated to the sequencer block-production hot path.
+    pub sequencer_l1_provider: RootProvider,
     /// The L2 EL provider.
     pub l2_provider: RootProvider<Base>,
     /// Whether to trust the L2 RPC.
@@ -207,7 +209,7 @@ impl RollupNode {
         &self,
     ) -> StatefulAttributesBuilder<AlloyChainProvider, AlloyL2ChainProvider> {
         let l1_derivation_provider = AlloyChainProvider::new_with_trust(
-            self.l1_config.engine_provider.clone(),
+            self.sequencer_l1_provider.clone(),
             DERIVATION_PROVIDER_CACHE_SIZE,
             self.l1_config.trust_rpc,
         );
@@ -525,7 +527,7 @@ impl RollupNode {
 
         let (l1_head_updates_tx, l1_head_updates_rx) = watch::channel(None);
         let delayed_l1_provider = DelayedL1OriginSelectorProvider::new(
-            self.l1_config.engine_provider.clone(),
+            self.sequencer_l1_provider.clone(),
             l1_head_updates_rx,
             self.sequencer_config.l1_conf_delay,
         );

--- a/etc/systems/src/l2/in_process_consensus.rs
+++ b/etc/systems/src/l2/in_process_consensus.rs
@@ -192,6 +192,7 @@ impl InProcessConsensus {
             trust_rpc: true,
             beacon: config.l1_beacon_url,
             rpc_url: config.l1_rpc_url.clone(),
+            rpc_timeout: base_consensus_providers::L1_RPC_TIMEOUT,
             slot_duration_override: config.l1_slot_duration_override,
             verifier_l1_confs: config.verifier_l1_confs,
             da_batcher_sender_override: None,
@@ -202,6 +203,7 @@ impl InProcessConsensus {
             l2_url: config.l2_engine_url,
             l2_jwt_secret: config.jwt_secret,
             l1_url: config.l1_rpc_url,
+            l1_rpc_timeout: base_consensus_providers::L1_RPC_TIMEOUT,
             mode: config.mode,
         };
 

--- a/etc/systems/src/l2/in_process_follow_consensus.rs
+++ b/etc/systems/src/l2/in_process_follow_consensus.rs
@@ -107,6 +107,7 @@ impl InProcessFollowConsensus {
             l2_url: config.l2_engine_url,
             l2_jwt_secret: config.jwt_secret,
             l1_url: l1_rpc_url.clone(),
+            l1_rpc_timeout: base_consensus_providers::L1_RPC_TIMEOUT,
             mode: NodeMode::Validator,
         };
         let engine_client = Arc::new(


### PR DESCRIPTION
## Summary

Makes general L1 execution RPC timeouts configurable while retaining the 15-second default. Adds a separate provider with a 500 ms default timeout for sequencer origin selection and payload-attribute reads, preventing background L1 traffic from sharing the hot-path deadline. Propagates the general timeout to other consensus L1 execution clients and adds CLI and transport coverage.