### PR TITLE
fix(BOP-508): version-gate pause features with per-version allowlists

### DIFF
--- a/crates/common/precompiles/src/b20_asset/logic/v1.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v1.rs
@@ -28,10 +28,6 @@ const VERSION: &[u8] = b"1";
 pub struct AssetV1;
 
 impl AssetV1 {
-    /// Pausable features dialable on this frozen version.
-    ///
-    /// `SEIZE` was introduced at Cobalt (V2). The Beryl wire already rejects it at `IB20V1` decode;
-    /// this allowlist is the matching logic-layer guard so V1 rejects later features by omission.
     const PAUSABLE_FEATURES: &[IB20::PausableFeature] = &[
         IB20::PausableFeature::TRANSFER,
         IB20::PausableFeature::MINT,

--- a/crates/common/precompiles/src/b20_asset/logic/v1.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v1.rs
@@ -28,6 +28,16 @@ const VERSION: &[u8] = b"1";
 pub struct AssetV1;
 
 impl AssetV1 {
+    /// Pausable features dialable on this frozen version.
+    ///
+    /// `SEIZE` was introduced at Cobalt (V2). The Beryl wire already rejects it at `IB20V1` decode;
+    /// this allowlist is the matching logic-layer guard so V1 rejects later features by omission.
+    const PAUSABLE_FEATURES: &[IB20::PausableFeature] = &[
+        IB20::PausableFeature::TRANSFER,
+        IB20::PausableFeature::MINT,
+        IB20::PausableFeature::BURN,
+    ];
+
     /// Role identifier for asset operators: `keccak256("OPERATOR_ROLE")`.
     ///
     /// Asset-specific (not part of [`B20TokenRole`]); kept inherent to V1 so it stays frozen with
@@ -336,7 +346,7 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV1 {
         privileged: bool,
     ) -> Result<()> {
         for feature in &features {
-            B20PausableFeature::ensure_valid(*feature)?;
+            B20PausableFeature::ensure_one_of(*feature, Self::PAUSABLE_FEATURES)?;
         }
         if !privileged {
             B20Guards::ensure_token_role(token, caller, B20TokenRole::Pause)?;
@@ -362,7 +372,7 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV1 {
         privileged: bool,
     ) -> Result<()> {
         for feature in &features {
-            B20PausableFeature::ensure_valid(*feature)?;
+            B20PausableFeature::ensure_one_of(*feature, Self::PAUSABLE_FEATURES)?;
         }
         if !privileged {
             B20Guards::ensure_token_role(token, caller, B20TokenRole::Unpause)?;
@@ -716,7 +726,7 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV1 {
         token: &B20AssetToken<S, A>,
         feature: IB20::PausableFeature,
     ) -> Result<bool> {
-        B20PausableFeature::ensure_valid(feature)?;
+        B20PausableFeature::ensure_one_of(feature, Self::PAUSABLE_FEATURES)?;
         Ok((token.accounting().paused()? & B20PausableFeature::mask(feature)) != U256::ZERO)
     }
 
@@ -1322,6 +1332,23 @@ mod tests {
         assert!(LOGIC.is_paused(&tok, IB20::PausableFeature::MINT).unwrap());
         LOGIC.unpause(&mut tok, ADMIN, vec![IB20::PausableFeature::MINT], true).unwrap();
         assert!(!LOGIC.is_paused(&tok, IB20::PausableFeature::MINT).unwrap());
+    }
+
+    /// `SEIZE` is Cobalt-only. The Beryl wire rejects it at decode; this pins the matching
+    /// logic-layer allowlist so V1 does not accept it via direct logic calls either.
+    #[test]
+    fn pause_unpause_and_is_paused_reject_seize() {
+        let mut tok = token();
+        let expected = BasePrecompileError::enum_conversion_error();
+        assert_eq!(
+            LOGIC.pause(&mut tok, ADMIN, vec![IB20::PausableFeature::SEIZE], true).unwrap_err(),
+            expected
+        );
+        assert_eq!(
+            LOGIC.unpause(&mut tok, ADMIN, vec![IB20::PausableFeature::SEIZE], true).unwrap_err(),
+            expected
+        );
+        assert_eq!(LOGIC.is_paused(&tok, IB20::PausableFeature::SEIZE).unwrap_err(), expected);
     }
 
     // --- roles ---

--- a/crates/common/precompiles/src/b20_asset/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v2.rs
@@ -38,10 +38,6 @@ const VERSION: &[u8] = b"1";
 pub struct AssetV2;
 
 impl AssetV2 {
-    /// Pausable features dialable on this frozen version.
-    ///
-    /// Extends V1 with `SEIZE` (Cobalt). Later features are rejected by omission until a new
-    /// version adds them to its own allowlist.
     const PAUSABLE_FEATURES: &[IB20::PausableFeature] = &[
         IB20::PausableFeature::TRANSFER,
         IB20::PausableFeature::MINT,

--- a/crates/common/precompiles/src/b20_asset/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v2.rs
@@ -38,6 +38,17 @@ const VERSION: &[u8] = b"1";
 pub struct AssetV2;
 
 impl AssetV2 {
+    /// Pausable features dialable on this frozen version.
+    ///
+    /// Extends V1 with `SEIZE` (Cobalt). Later features are rejected by omission until a new
+    /// version adds them to its own allowlist.
+    const PAUSABLE_FEATURES: &[IB20::PausableFeature] = &[
+        IB20::PausableFeature::TRANSFER,
+        IB20::PausableFeature::MINT,
+        IB20::PausableFeature::BURN,
+        IB20::PausableFeature::SEIZE,
+    ];
+
     /// Role identifier for asset operators: `keccak256("OPERATOR_ROLE")`.
     ///
     /// Asset-specific (not part of [`B20TokenRole`]); kept inherent to V2 so it stays frozen with
@@ -421,7 +432,7 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
         privileged: bool,
     ) -> Result<()> {
         for feature in &features {
-            B20PausableFeature::ensure_valid(*feature)?;
+            B20PausableFeature::ensure_one_of(*feature, Self::PAUSABLE_FEATURES)?;
         }
         if !privileged {
             B20Guards::ensure_token_role(token, caller, B20TokenRole::Pause)?;
@@ -447,7 +458,7 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
         privileged: bool,
     ) -> Result<()> {
         for feature in &features {
-            B20PausableFeature::ensure_valid(*feature)?;
+            B20PausableFeature::ensure_one_of(*feature, Self::PAUSABLE_FEATURES)?;
         }
         if !privileged {
             B20Guards::ensure_token_role(token, caller, B20TokenRole::Unpause)?;
@@ -833,7 +844,7 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
         token: &B20AssetToken<S, A>,
         feature: IB20::PausableFeature,
     ) -> Result<bool> {
-        B20PausableFeature::ensure_valid(feature)?;
+        B20PausableFeature::ensure_one_of(feature, Self::PAUSABLE_FEATURES)?;
         Ok((token.accounting().paused()? & B20PausableFeature::mask(feature)) != U256::ZERO)
     }
 

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v1.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v1.rs
@@ -28,6 +28,16 @@ const VERSION: &[u8] = b"1";
 pub struct StablecoinV1;
 
 impl StablecoinV1 {
+    /// Pausable features dialable on this frozen version.
+    ///
+    /// `SEIZE` was introduced at Cobalt (V2). The Beryl wire already rejects it at `IB20V1` decode;
+    /// this allowlist is the matching logic-layer guard so V1 rejects later features by omission.
+    const PAUSABLE_FEATURES: &[IB20::PausableFeature] = &[
+        IB20::PausableFeature::TRANSFER,
+        IB20::PausableFeature::MINT,
+        IB20::PausableFeature::BURN,
+    ];
+
     /// Balance-moving core of `transfer`/`transferFrom`, without the pause check.
     fn transfer_inner<S: StablecoinAccounting, A: PolicyAccounting>(
         &self,
@@ -310,7 +320,7 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> Stablecoin<S, A> for Stableco
         privileged: bool,
     ) -> Result<()> {
         for feature in &features {
-            B20PausableFeature::ensure_valid(*feature)?;
+            B20PausableFeature::ensure_one_of(*feature, Self::PAUSABLE_FEATURES)?;
         }
         if !privileged {
             B20Guards::ensure_token_role(token, caller, B20TokenRole::Pause)?;
@@ -336,7 +346,7 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> Stablecoin<S, A> for Stableco
         privileged: bool,
     ) -> Result<()> {
         for feature in &features {
-            B20PausableFeature::ensure_valid(*feature)?;
+            B20PausableFeature::ensure_one_of(*feature, Self::PAUSABLE_FEATURES)?;
         }
         if !privileged {
             B20Guards::ensure_token_role(token, caller, B20TokenRole::Unpause)?;
@@ -602,7 +612,7 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> Stablecoin<S, A> for Stableco
         token: &B20StablecoinToken<S, A>,
         feature: IB20::PausableFeature,
     ) -> Result<bool> {
-        B20PausableFeature::ensure_valid(feature)?;
+        B20PausableFeature::ensure_one_of(feature, Self::PAUSABLE_FEATURES)?;
         Ok((token.accounting().paused()? & B20PausableFeature::mask(feature)) != U256::ZERO)
     }
 
@@ -1239,6 +1249,23 @@ mod tests {
         assert!(!LOGIC.is_paused(&tok, IB20::PausableFeature::TRANSFER).unwrap());
         LOGIC.unpause(&mut tok, ADMIN, vec![IB20::PausableFeature::MINT], true).unwrap();
         assert!(!LOGIC.is_paused(&tok, IB20::PausableFeature::MINT).unwrap());
+    }
+
+    /// `SEIZE` is Cobalt-only. The Beryl wire rejects it at decode; this pins the matching
+    /// logic-layer allowlist so V1 does not accept it via direct logic calls either.
+    #[test]
+    fn pause_unpause_and_is_paused_reject_seize() {
+        let mut tok = token();
+        let expected = BasePrecompileError::enum_conversion_error();
+        assert_eq!(
+            LOGIC.pause(&mut tok, ADMIN, vec![IB20::PausableFeature::SEIZE], true).unwrap_err(),
+            expected
+        );
+        assert_eq!(
+            LOGIC.unpause(&mut tok, ADMIN, vec![IB20::PausableFeature::SEIZE], true).unwrap_err(),
+            expected
+        );
+        assert_eq!(LOGIC.is_paused(&tok, IB20::PausableFeature::SEIZE).unwrap_err(), expected);
     }
 
     #[test]

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v1.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v1.rs
@@ -28,10 +28,6 @@ const VERSION: &[u8] = b"1";
 pub struct StablecoinV1;
 
 impl StablecoinV1 {
-    /// Pausable features dialable on this frozen version.
-    ///
-    /// `SEIZE` was introduced at Cobalt (V2). The Beryl wire already rejects it at `IB20V1` decode;
-    /// this allowlist is the matching logic-layer guard so V1 rejects later features by omission.
     const PAUSABLE_FEATURES: &[IB20::PausableFeature] = &[
         IB20::PausableFeature::TRANSFER,
         IB20::PausableFeature::MINT,

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
@@ -29,6 +29,17 @@ const VERSION: &[u8] = b"1";
 pub struct StablecoinV2;
 
 impl StablecoinV2 {
+    /// Pausable features dialable on this frozen version.
+    ///
+    /// Extends V1 with `SEIZE` (Cobalt). Later features are rejected by omission until a new
+    /// version adds them to its own allowlist.
+    const PAUSABLE_FEATURES: &[IB20::PausableFeature] = &[
+        IB20::PausableFeature::TRANSFER,
+        IB20::PausableFeature::MINT,
+        IB20::PausableFeature::BURN,
+        IB20::PausableFeature::SEIZE,
+    ];
+
     /// Balance-moving core of `transfer`/`transferFrom`, without the pause check.
     ///
     /// `policies` carries the sender/receiver ids pre-read from their shared slot by the caller;
@@ -380,7 +391,7 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> Stablecoin<S, A> for Stableco
         privileged: bool,
     ) -> Result<()> {
         for feature in &features {
-            B20PausableFeature::ensure_valid(*feature)?;
+            B20PausableFeature::ensure_one_of(*feature, Self::PAUSABLE_FEATURES)?;
         }
         if !privileged {
             B20Guards::ensure_token_role(token, caller, B20TokenRole::Pause)?;
@@ -406,7 +417,7 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> Stablecoin<S, A> for Stableco
         privileged: bool,
     ) -> Result<()> {
         for feature in &features {
-            B20PausableFeature::ensure_valid(*feature)?;
+            B20PausableFeature::ensure_one_of(*feature, Self::PAUSABLE_FEATURES)?;
         }
         if !privileged {
             B20Guards::ensure_token_role(token, caller, B20TokenRole::Unpause)?;
@@ -672,7 +683,7 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> Stablecoin<S, A> for Stableco
         token: &B20StablecoinToken<S, A>,
         feature: IB20::PausableFeature,
     ) -> Result<bool> {
-        B20PausableFeature::ensure_valid(feature)?;
+        B20PausableFeature::ensure_one_of(feature, Self::PAUSABLE_FEATURES)?;
         Ok((token.accounting().paused()? & B20PausableFeature::mask(feature)) != U256::ZERO)
     }
 

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
@@ -29,10 +29,6 @@ const VERSION: &[u8] = b"1";
 pub struct StablecoinV2;
 
 impl StablecoinV2 {
-    /// Pausable features dialable on this frozen version.
-    ///
-    /// Extends V1 with `SEIZE` (Cobalt). Later features are rejected by omission until a new
-    /// version adds them to its own allowlist.
     const PAUSABLE_FEATURES: &[IB20::PausableFeature] = &[
         IB20::PausableFeature::TRANSFER,
         IB20::PausableFeature::MINT,

--- a/crates/common/precompiles/src/common/pausable_feature.rs
+++ b/crates/common/precompiles/src/common/pausable_feature.rs
@@ -10,14 +10,19 @@ use crate::IB20;
 pub struct B20PausableFeature;
 
 impl B20PausableFeature {
-    /// Returns an enum-conversion panic when `feature` is outside the B-20 pause enum.
-    pub const fn ensure_valid(feature: IB20::PausableFeature) -> Result<()> {
-        match feature {
-            IB20::PausableFeature::TRANSFER
-            | IB20::PausableFeature::MINT
-            | IB20::PausableFeature::BURN
-            | IB20::PausableFeature::SEIZE => Ok(()),
-            IB20::PausableFeature::__Invalid => Err(BasePrecompileError::enum_conversion_error()),
+    /// Returns an enum-conversion error when `feature` is not in `allowed`.
+    ///
+    /// Each frozen version passes its own allowlist so a feature introduced at a later fork is
+    /// rejected by omission on older versions (e.g. V1 allows only TRANSFER/MINT/BURN; V2 adds
+    /// SEIZE). New versions extend their local list; already-shipped versions stay untouched.
+    pub fn ensure_one_of(
+        feature: IB20::PausableFeature,
+        allowed: &[IB20::PausableFeature],
+    ) -> Result<()> {
+        if allowed.contains(&feature) {
+            Ok(())
+        } else {
+            Err(BasePrecompileError::enum_conversion_error())
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace shared `B20PausableFeature::ensure_valid` with `ensure_one_of(feature, allowed)` so each frozen B-20 version owns its pausable-feature surface.
- V1 allowlists only `TRANSFER`/`MINT`/`BURN` (rejecting Cobalt `SEIZE` by omission at the logic layer); V2 extends with `SEIZE`.
- Add unit regressions that call V1 `pause`/`unpause`/`is_paused` with `SEIZE` directly, complementing the existing Beryl ABI-decode golden coverage.

Fixes [BOP-508](https://linear.app/coinbase/issue/BOP-508/audit-i-04-v1-pause-logic-relies-on-ib20v1-abi-gate-rather-than-a).

## Test plan
- [x] `cargo test -p base-common-precompiles --lib pause_unpause_and_is_paused_reject_seize`
- [x] `cargo test -p base-common-precompiles --lib pause_`
- [x] `cargo test -p base-common-precompiles --lib seize_reverts_when_seize_paused`
- [x] `cargo clippy -p base-common-precompiles --all-targets -- -D warnings`
- [ ] Confirm V2 pause/`SEIZE` paths still pass in CI golden suite


Made with [Cursor](https://cursor.com)