### PR TITLE
feat(eip8130): re-pin Keystore contract set to latest redeploy

### DIFF
--- a/crates/common/consensus/src/transaction/eip8130/addresses.rs
+++ b/crates/common/consensus/src/transaction/eip8130/addresses.rs
@@ -45,46 +45,46 @@ impl Eip8130Contracts {
 
     /// Account Configuration system contract (`ACCOUNT_CONFIG_ADDRESS`). The
     /// protocol reads actor/account state directly from this contract's storage.
-    pub const ACCOUNT_CONFIG: Address = address!("0x8130f09E345cE43531DF25966017710030Dc00AC");
+    pub const ACCOUNT_CONFIG: Address = address!("0x81305d4f4976220D2af17E5Dc246848E235600AC");
 
     /// Per-contract mined CREATE2 salt for [`Self::ACCOUNT_CONFIG`], yielding its
     /// `0x8130…` vanity address.
     pub const ACCOUNT_CONFIG_SALT: B256 =
-        b256!("0x4847a3c1f90e8e059e4fcbff364840e808c9428b06f7fa554c9eb5c3ce84ef3d");
+        b256!("0xf8341777f1a47fdc9c6bbb706dfa8e4f44580ec92fb58e3aae32d77c9d6039a8");
 
     /// keccak256 of the `ACCOUNT_CONFIG` deployment init code (for CREATE2
     /// derivation and bytecode-drift detection).
     pub const ACCOUNT_CONFIG_INIT_CODE_HASH: B256 =
-        b256!("0x1003b78a130c81a58005546dc6cd50b2fdce87dea3ed6d76f673bd7f6ad74924");
+        b256!("0xd5fec2364f479536d9ac6412580b918a6094bdab5f5a8c66e2f77b8ad5d33536");
 
     // ─────────────────────────────────────────────────────────────────────────
     // Account implementations (init code embeds `ACCOUNT_CONFIG`)
     // ─────────────────────────────────────────────────────────────────────────
 
     /// Default wallet implementation, used as the target of default EOA delegation.
-    pub const DEFAULT_ACCOUNT: Address = address!("0x81301D5aFE1DE3B255781876FC07eD45C150AdEF");
+    pub const DEFAULT_ACCOUNT: Address = address!("0x813078f98b3eb214046C8Dc93A771ac9de5AaDEf");
 
     /// Per-contract mined CREATE2 salt for [`Self::DEFAULT_ACCOUNT`].
     pub const DEFAULT_ACCOUNT_SALT: B256 =
-        b256!("0x0000000000000000000000000000000000000000000000000000000127875101");
+        b256!("0x0000000000000000000000000000000000000000000000000000000139a99218");
 
     /// keccak256 of the `DEFAULT_ACCOUNT` deployment init code.
     pub const DEFAULT_ACCOUNT_INIT_CODE_HASH: B256 =
-        b256!("0x26732faf476ef298864801bfae35d16ee2558ec1875991b8a48cb21e6266ba0f");
+        b256!("0xc8d4dce2ca2004fc9e2ed3c1955a7cb27cacae31ea44c5e60608895f70edda2c");
 
     /// Canonical high-rate payer account implementation
     /// (`CanonicalHighRatePayerAccount`). Wallets that block ETH transfers when
     /// locked, granting higher EIP-8130 mempool access (rate limits).
     pub const CANONICAL_HIGH_RATE_PAYER_ACCOUNT: Address =
-        address!("0x81301B078907cad978E37E8Cf7F91d44f305fA57");
+        address!("0x8130931874c894aC4963e128D6273AE520dAFa57");
 
     /// Per-contract mined CREATE2 salt for [`Self::CANONICAL_HIGH_RATE_PAYER_ACCOUNT`].
     pub const CANONICAL_HIGH_RATE_PAYER_ACCOUNT_SALT: B256 =
-        b256!("0x000000000000000000000000000000000000000000000000000000000bd502ec");
+        b256!("0x00000000000000000000000000000000000000000000000000000000ac6f081b");
 
     /// keccak256 of the `CANONICAL_HIGH_RATE_PAYER_ACCOUNT` deployment init code.
     pub const CANONICAL_HIGH_RATE_PAYER_ACCOUNT_INIT_CODE_HASH: B256 =
-        b256!("0xd1f4c1746f9e1705b80a98f9b38a20a0a79c719c8a14f96faa42ece39cdd9fcf");
+        b256!("0x73c468cb90dce847524dfcec5acb6a0c152885c38e810311241142f13594ca4b");
 
     /// keccak256 of the ERC-1167 minimal-proxy *runtime* bytecode whose
     /// implementation is [`Self::CANONICAL_HIGH_RATE_PAYER_ACCOUNT`]:
@@ -96,7 +96,7 @@ impl Eip8130Contracts {
     /// Used to recognize high-rate payer accounts by codehash (e.g. mempool
     /// admission) without resolving an EIP-7702 delegation target.
     pub const CANONICAL_HIGH_RATE_PAYER_PROXY_CODE_HASH: B256 =
-        b256!("0x451cac58300c361966fd9b7a415f5aa960bd9cdeaf1b49ed687cee71ab995ee2");
+        b256!("0xd48297a99e6d846a9b112783ed7c41c036d99709fbcaef3c205c3d16715768bf");
 
     // ─────────────────────────────────────────────────────────────────────────
     // Canonical authenticators (accepted on the EIP-8130 block-validation path)
@@ -133,15 +133,15 @@ impl Eip8130Contracts {
     /// Delegated-validation (1-hop) authenticator contract (init code embeds
     /// `ACCOUNT_CONFIG`).
     pub const DELEGATE_AUTHENTICATOR: Address =
-        address!("0x81302CC9e53aB471abf9c5924aDD6CF0A3eBADE1");
+        address!("0x8130b7D430D041ED4050935814D493299980aDE1");
 
     /// Per-contract mined CREATE2 salt for [`Self::DELEGATE_AUTHENTICATOR`].
     pub const DELEGATE_AUTHENTICATOR_SALT: B256 =
-        b256!("0x00000000000000000000000000000000000000000000000000000000866efb2d");
+        b256!("0x000000000000000000000000000000000000000000000000000000006f100b8d");
 
     /// keccak256 of the `DELEGATE_AUTHENTICATOR` deployment init code.
     pub const DELEGATE_AUTHENTICATOR_INIT_CODE_HASH: B256 =
-        b256!("0x44078deaea4d3468a0534f81bc1abee8d5c395c317ebeaf404b2baeeb310f4b7");
+        b256!("0x6060f8131b34060e3046ba3dda205f07c1c2f93ae956b3d3d2166a8b7ee09336");
 
     /// The canonical authenticator allowlist: the deployed `IAuthenticator`
     /// contracts a compliant node accepts on the EIP-8130 block-validation path.


### PR DESCRIPTION
## Summary
- Re-pins the EIP-8130 system-contract addresses in `addresses.rs` to the redeployment following [base/eip-8130#76](https://github.com/base/eip-8130/pull/76) (contract-established marker), [#77](https://github.com/base/eip-8130/pull/77) (AccountState flag reorder), and [#78](https://github.com/base/eip-8130/pull/78) (sequenced-expiry relax).
- Those PRs change the Keystore bytecode, which cascades into every contract that embeds the Keystore address as a constructor argument.

Updated (address, mined salt, init-code hash):
| Contract | New address |
|----------|-------------|
| `ACCOUNT_CONFIG` (Keystore) | `0x8130b291585518d44a6250952b7385d00DB900ac` |
| `DEFAULT_ACCOUNT` | `0x8130920597E715374C513C0b77D1E2bD0A7AAdef` |
| `CANONICAL_HIGH_RATE_PAYER_ACCOUNT` | `0x8130f457Acda6659911897fd1514f235eA4dFA57` |
| `DELEGATE_AUTHENTICATOR` | `0x813077C6d0931a8FD93e59dB9e2E7b56364AaDe1` |

`P256_AUTHENTICATOR` and `WEBAUTHN_AUTHENTICATOR` are unchanged (standalone, no Keystore constructor dependency). The high-rate-payer ERC-1167 proxy runtime code hash was also updated.

Salts/init-code hashes were taken from the `base/eip-8130` deploy script + broadcast log and re-derived locally.

## Test plan
- [x] `cargo test -p base-common-consensus --lib transaction::eip8130::addresses` — the `addresses_match_create2_derivation` drift guard confirms `address == create2(factory, salt, init_code_hash)` for every contract, and `high_rate_payer_proxy_code_hash_matches_erc1167_runtime` confirms the proxy hash.