### PR TITLE
feat(eip8130): skip expired unsequenced authorize grants

### DIFF
--- a/crates/common/evm/src/eip8130.rs
+++ b/crates/common/evm/src/eip8130.rs
@@ -408,24 +408,41 @@ impl Eip8130Executor {
 
         let ctx = evm.ctx_mut();
         let from = ctx.tx().base.caller;
-        // Estimation prices the happy path: it skips authorization, so it does not
-        // enforce expiry, and the EIP-8130 intrinsic schedule does not depend on
-        // the block timestamp — so no timestamp is read here (unlike `execute`).
+        // Estimation skips authorization (no signature is verified), but it must
+        // still apply account changes exactly as consensus would so the post-change
+        // state the `calls` run against matches inclusion. That includes the
+        // per-change JIT expiry skip, which depends on the block timestamp, so read
+        // it here (in Unix seconds, the same clock as `ActorConfig::expiry`) and
+        // thread it into `apply_account_changes`. Using the estimation block's
+        // timestamp can only over-price a grant that expires before inclusion
+        // (time moves forward, so a grant skipped now stays skipped) — it never
+        // under-estimates.
+        let now: u64 = ctx
+            .block()
+            .timestamp()
+            .try_into()
+            .map_err(|_| BaseTransactionError::eip8130("block timestamp exceeds u64"))?;
         let base_fee: u128 = u128::from(ctx.block().basefee());
         let encoded =
             ctx.tx().enveloped_tx().cloned().ok_or_else(|| {
                 BaseTransactionError::eip8130("missing enveloped transaction bytes")
             })?;
 
-        let outcome =
-            match Self::simulate_resolve(ctx, &signed, &encoded, from, base_fee, acting_actor_hint)
-            {
-                Ok(outcome) => outcome,
-                Err(err) => {
-                    Self::discard_transaction_state(evm);
-                    return Err(err.into());
-                }
-            };
+        let outcome = match Self::simulate_resolve(
+            ctx,
+            &signed,
+            &encoded,
+            from,
+            base_fee,
+            acting_actor_hint,
+            now,
+        ) {
+            Ok(outcome) => outcome,
+            Err(err) => {
+                Self::discard_transaction_state(evm);
+                return Err(err.into());
+            }
+        };
 
         // Dispatch `calls` from the resolved sender so `tx.origin` reads correctly
         // (mirrors `prepay`'s caller overwrite on the execution path).
@@ -727,6 +744,7 @@ impl Eip8130Executor {
         sender: Address,
         base_fee: u128,
         acting_actor_hint: Option<B256>,
+        now: u64,
     ) -> Result<Eip8130Outcome, BaseTransactionError>
     where
         DB: AlloyDatabase,
@@ -772,7 +790,7 @@ impl Eip8130Executor {
             //    calls run against post-change code and create/delegation gas is
             //    priced. Must precede actor/policy resolution so an actor
             //    authorized in this same estimate request is visible.
-            let has_explicit_delegation = Self::apply_account_changes(signed, sctx, sender)?;
+            let has_explicit_delegation = Self::apply_account_changes(signed, sctx, sender, now)?;
 
             // 3. Resolve the acting actor's real policy gate. No signature
             //    recovery: the optional RPC hint names the intended actor (e.g. a
@@ -1611,6 +1629,7 @@ impl Eip8130Executor {
         signed: &base_common_consensus::Eip8130Signed,
         sctx: StorageCtx<'_>,
         sender: Address,
+        now: u64,
     ) -> Result<bool, BaseTransactionError> {
         let mut acc_mut = AccountConfigurationStorage::new(sctx);
         let mut created_effect: Option<(Address, Bytes)> = None;
@@ -1633,13 +1652,18 @@ impl Eip8130Executor {
                 AccountChange::ConfigChange(cc) => {
                     // Estimation prices revokes at the worst-case three-reset cost
                     // (a zero revoke discount is pinned), so the resolved
-                    // empty-slot count is applied but not needed here.
+                    // empty-slot count is applied but not needed here. `now` is the
+                    // block timestamp (Unix seconds) so the JIT expiry skip matches
+                    // consensus: a lapsed unsequenced grant is dropped in both the
+                    // estimate and at inclusion, keeping the post-change state (and
+                    // therefore the simulated `calls`) aligned.
                     AccountChangeApplier::apply_config_change(
                         &mut acc_mut,
                         sender,
                         &cc.changes,
                         cc.channel,
                         cc.sequence,
+                        now,
                     )
                     .map_err(BaseTransactionError::eip8130)?;
                 }

--- a/crates/execution/eip8130/src/apply.rs
+++ b/crates/execution/eip8130/src/apply.rs
@@ -92,6 +92,12 @@ pub enum ApplyError {
     #[error("signed account-change batch is empty")]
     EmptyChangeSet,
 
+    /// The target `actor_id` is `bytes32(0)`, which is reserved for the "no
+    /// actor" sentinel and can never be authorized. Mirrors `_authorizeActor`'s
+    /// `revert InvalidActorId()`.
+    #[error("actor id bytes32(0) is reserved and cannot be authorized")]
+    InvalidActorId,
+
     /// The new actor's authenticator is `address(0)`, below the valid
     /// authenticator namespace. Mirrors `require(config.authenticator >= K1)`.
     #[error("authenticator address(0) is not a valid selector")]
@@ -618,6 +624,14 @@ impl AccountChangeApplier {
         config: ActorConfig,
         policy_data: &[u8],
     ) -> Result<(), ApplyError> {
+        // Zero is reserved for the "no actor" sentinel. Mirrors `_authorizeActor`'s
+        // `revert InvalidActorId()`. A zero `actor_id` only ever reaches the
+        // non-self path (the self id is derived from a nonzero account address),
+        // so guarding here covers every `AuthorizeActor`; the create path already
+        // rejects it earlier via the strictly-ascending `initial_actors` check.
+        if actor_id.is_zero() {
+            return Err(ApplyError::InvalidActorId);
+        }
         if config.authenticator.is_zero() {
             return Err(ApplyError::InvalidAuthenticator);
         }
@@ -1069,6 +1083,26 @@ mod tests {
             )
             .unwrap();
             assert_eq!(acc.actor_config_slot(ACCOUNT, NON_SELF).unwrap(), unauthorized);
+        });
+    }
+
+    #[test]
+    fn authorize_rejects_zero_actor_id() {
+        // `bytes32(0)` is the reserved "no actor" sentinel; authorizing it must
+        // revert `InvalidActorId`, mirroring the contract's `_authorizeActor`.
+        with_storage(|acc| {
+            let zero =
+                [authorize_op(B256::ZERO, &ungated(K1, Eip8130Constants::SCOPE_SENDER), &[])];
+            let err = AccountChangeApplier::apply_config_change(
+                acc,
+                ACCOUNT,
+                &zero,
+                AccountChangeChannel::Local,
+                0,
+                0,
+            )
+            .unwrap_err();
+            assert!(matches!(err, ApplyError::InvalidActorId));
         });
     }
 

--- a/crates/execution/eip8130/src/apply.rs
+++ b/crates/execution/eip8130/src/apply.rs
@@ -331,16 +331,22 @@ impl AccountChangeApplier {
     /// `applySignedAccountChanges`.
     /// Returns the number of empty zero-to-zero revoke slots discounted (see
     /// [`Self::revoke_actor_with_account_state`]), for intrinsic-gas discounting.
+    ///
+    /// `now` is the block timestamp in Unix seconds (the same clock as
+    /// [`ActorConfig::expiry`]), used to skip lapsed replayable JIT grants; see
+    /// [`Self::apply_config_change_with_account_state`]. The read-only estimation
+    /// pipeline passes `0` to price every change without filtering.
     pub fn apply_config_change(
         storage: &mut AccountConfigurationStorage<'_>,
         account: Address,
         changes: &[SignedChange],
         channel: AccountChangeChannel,
         sequence: u64,
+        now: u64,
     ) -> Result<u32, ApplyError> {
         let mut state = storage.get_account_state(account)?;
         let revoke_discount_slots = Self::apply_config_change_with_account_state(
-            storage, account, changes, channel, sequence, &mut state,
+            storage, account, changes, channel, sequence, &mut state, now,
         )?;
         storage.set_account_state(account, state)?;
         Ok(revoke_discount_slots)
@@ -353,6 +359,30 @@ impl AccountChangeApplier {
     /// orchestrator to perform one final packed-state write after all relevant
     /// mutations in this batch.
     ///
+    /// Mirrors Keystore `_applyAuthorize`'s per-change skip of an already-expired
+    /// grant on the replayable unsequenced (JIT) path: a JIT batch — a
+    /// [`AccountChangeChannel::Local`] batch whose low sequence half is
+    /// [`Eip8130Constants::UNSEQUENCED`] — consumes no counter and is replayable
+    /// (last-write-wins on its slot until the epoch is incremented), so an
+    /// `AuthorizeActor` grant whose non-zero expiry is not strictly in the future
+    /// is silently **skipped** (dropped): a lapsed replayable grant can never
+    /// re-land and clobber its slot, and whether a signed change applies never
+    /// depends on onchain time. The skip is per-change — live siblings in the same
+    /// batch still apply — and nothing reverts on expiry. Sequenced batches (local
+    /// sequenced or any multichain) are single-consume and cannot be replayed, so
+    /// an already-expired grant is retained and installs inert — present but dead
+    /// on arrival at authentication — consuming its slot; multichain relies on this
+    /// for cross-chain catch-up. A zero expiry is the "no expiry" sentinel and is
+    /// always applied.
+    ///
+    /// `now` is the block timestamp in Unix seconds (the same clock as
+    /// [`ActorConfig::expiry`]). Both the verifying and read-only estimation
+    /// pipelines pass the real block timestamp so the JIT expiry skip is applied
+    /// identically — the estimate's post-change state matches inclusion. Passing
+    /// `0` disables the skip entirely (`expiry != 0 && expiry <= 0` is never
+    /// true, so every grant is retained); callers that must price every change
+    /// unconditionally, regardless of expiry, can opt into that with a `0` clock.
+    ///
     /// Returns the number of empty zero-to-zero revoke slots discounted (see
     /// [`Self::revoke_actor_with_account_state`]), for intrinsic-gas discounting.
     pub fn apply_config_change_with_account_state(
@@ -362,6 +392,7 @@ impl AccountChangeApplier {
         channel: AccountChangeChannel,
         sequence: u64,
         state: &mut AccountState,
+        now: u64,
     ) -> Result<u32, ApplyError> {
         // Reject an empty batch before advancing the sequence. A no-op batch would
         // otherwise consume the channel's sequence (or initialize a fresh account)
@@ -374,11 +405,25 @@ impl AccountChangeApplier {
 
         Self::advance_channel_sequence(channel, sequence, state)?;
 
+        // A JIT batch (unsequenced Local) is replayable, so a lapsed grant is
+        // skipped rather than installed; every other batch is single-consume and
+        // retains an expired grant inert. Computed once for the whole batch.
+        let is_unsequenced = matches!(channel, AccountChangeChannel::Local)
+            && sequence as u32 == Eip8130Constants::UNSEQUENCED;
+
         let mut revoke_discount_slots = 0u32;
         for change in changes {
             match change.change_type {
                 ChangeType::AuthorizeActor => {
                     let (actor_id, config, policy_data) = Self::decode_authorize(&change.payload)?;
+                    // Skip an already-lapsed grant on the replayable JIT path
+                    // (per-change; live siblings still apply). A `0` clock disables
+                    // the skip via the `expiry != 0 && expiry <= 0` guard; both the
+                    // verifying and estimation pipelines pass the real block
+                    // timestamp so the skip is applied identically.
+                    if is_unsequenced && config.expiry != 0 && config.expiry <= now {
+                        continue;
+                    }
                     Self::authorize_actor_with_account_state(
                         storage,
                         account,
@@ -987,6 +1032,145 @@ mod tests {
         ActorConfig { authenticator, scope, expiry: 0 }
     }
 
+    fn expiring(expiry: u64) -> ActorConfig {
+        ActorConfig { authenticator: AUTHENTICATOR, scope: 0, expiry }
+    }
+
+    #[test]
+    fn apply_skips_lapsed_jit_grant() {
+        let now = 1_000u64;
+        let jit = u64::from(Eip8130Constants::UNSEQUENCED);
+        let unauthorized = ActorConfig { authenticator: Address::ZERO, scope: 0, expiry: 0 };
+        // A strictly-past expiry on the replayable JIT path is skipped (dropped),
+        // not reverted: the grant never lands in its slot.
+        with_storage(|acc| {
+            let past = [authorize_op(NON_SELF, &expiring(now - 1), &[])];
+            AccountChangeApplier::apply_config_change(
+                acc,
+                ACCOUNT,
+                &past,
+                AccountChangeChannel::Local,
+                jit,
+                now,
+            )
+            .unwrap();
+            assert_eq!(acc.actor_config_slot(ACCOUNT, NON_SELF).unwrap(), unauthorized);
+        });
+        // `expiry == now` is not strictly in the future, so it is skipped too.
+        with_storage(|acc| {
+            let at_now = [authorize_op(NON_SELF, &expiring(now), &[])];
+            AccountChangeApplier::apply_config_change(
+                acc,
+                ACCOUNT,
+                &at_now,
+                AccountChangeChannel::Local,
+                jit,
+                now,
+            )
+            .unwrap();
+            assert_eq!(acc.actor_config_slot(ACCOUNT, NON_SELF).unwrap(), unauthorized);
+        });
+    }
+
+    #[test]
+    fn apply_keeps_future_and_zero_expiry_jit_grant() {
+        let now = 1_000u64;
+        let jit = u64::from(Eip8130Constants::UNSEQUENCED);
+        // Strictly-future expiry lands verbatim on the JIT path.
+        with_storage(|acc| {
+            let config = expiring(now + 1);
+            let future = [authorize_op(NON_SELF, &config, &[])];
+            AccountChangeApplier::apply_config_change(
+                acc,
+                ACCOUNT,
+                &future,
+                AccountChangeChannel::Local,
+                jit,
+                now,
+            )
+            .unwrap();
+            assert_eq!(acc.actor_config_slot(ACCOUNT, NON_SELF).unwrap(), config);
+        });
+        // Zero expiry is the "no expiry" sentinel and always lands.
+        with_storage(|acc| {
+            let config = ungated(AUTHENTICATOR, 0);
+            let never = [authorize_op(NON_SELF, &config, &[])];
+            AccountChangeApplier::apply_config_change(
+                acc,
+                ACCOUNT,
+                &never,
+                AccountChangeChannel::Local,
+                jit,
+                now,
+            )
+            .unwrap();
+            assert_eq!(acc.actor_config_slot(ACCOUNT, NON_SELF).unwrap(), config);
+        });
+    }
+
+    #[test]
+    fn apply_jit_applies_live_siblings_only() {
+        let now = 1_000u64;
+        let jit = u64::from(Eip8130Constants::UNSEQUENCED);
+        let other: B256 =
+            b256!("0x00000000000000000000000000000000000000ee000000000000000000000000");
+        let unauthorized = ActorConfig { authenticator: Address::ZERO, scope: 0, expiry: 0 };
+        // A mixed JIT batch: the lapsed grant is skipped per-change; the live
+        // sibling in the same batch still applies.
+        with_storage(|acc| {
+            let live = expiring(now + 1);
+            let batch =
+                [authorize_op(NON_SELF, &expiring(now - 1), &[]), authorize_op(other, &live, &[])];
+            AccountChangeApplier::apply_config_change(
+                acc,
+                ACCOUNT,
+                &batch,
+                AccountChangeChannel::Local,
+                jit,
+                now,
+            )
+            .unwrap();
+            assert_eq!(acc.actor_config_slot(ACCOUNT, NON_SELF).unwrap(), unauthorized);
+            assert_eq!(acc.actor_config_slot(ACCOUNT, other).unwrap(), live);
+        });
+    }
+
+    #[test]
+    fn apply_retains_expired_grant_when_not_jit() {
+        let now = 1_000u64;
+        let config = expiring(now - 1);
+        // Sequenced Local batch (low half != UNSEQUENCED): single-consume, so an
+        // expired grant is retained and installs inert rather than being skipped.
+        with_storage(|acc| {
+            let expired = [authorize_op(NON_SELF, &config, &[])];
+            AccountChangeApplier::apply_config_change(
+                acc,
+                ACCOUNT,
+                &expired,
+                AccountChangeChannel::Local,
+                5,
+                now,
+            )
+            .unwrap();
+            assert_eq!(acc.actor_config_slot(ACCOUNT, NON_SELF).unwrap(), config);
+        });
+        // Multichain is never JIT (needed for cross-chain catch-up), so an expired
+        // grant likewise installs inert instead of being skipped.
+        with_storage(|acc| {
+            let expired = [authorize_op(NON_SELF, &config, &[])];
+            AccountChangeApplier::apply_config_change(
+                acc,
+                ACCOUNT,
+                &expired,
+                AccountChangeChannel::Multichain,
+                0,
+                now,
+            )
+            .unwrap();
+            assert_eq!(acc.actor_config_slot(ACCOUNT, NON_SELF).unwrap(), config);
+        });
+    }
+
     #[test]
     fn slice_policy_matches_contract() {
         assert_eq!(
@@ -1160,6 +1344,7 @@ mod tests {
                 &revoke_self,
                 AccountChangeChannel::Multichain,
                 0,
+                0,
             )
             .unwrap();
             assert_eq!(count, 3);
@@ -1183,6 +1368,7 @@ mod tests {
                 &revoke_self,
                 AccountChangeChannel::Multichain,
                 0,
+                0,
             )
             .unwrap();
             assert_eq!(count, 1);
@@ -1204,6 +1390,7 @@ mod tests {
                 ACCOUNT,
                 &revoke_self,
                 AccountChangeChannel::Multichain,
+                0,
                 0,
             )
             .unwrap();
@@ -1228,6 +1415,7 @@ mod tests {
                 &revoke_self,
                 AccountChangeChannel::Multichain,
                 0,
+                0,
             )
             .unwrap();
             assert_eq!(count, 2);
@@ -1246,6 +1434,7 @@ mod tests {
                 &revoke_self,
                 AccountChangeChannel::Multichain,
                 0,
+                0,
             )
             .unwrap();
             assert_eq!(count, 0);
@@ -1261,6 +1450,7 @@ mod tests {
                 ACCOUNT,
                 &revoke_other,
                 AccountChangeChannel::Multichain,
+                0,
                 0,
             )
             .unwrap();
@@ -1280,6 +1470,7 @@ mod tests {
                 &changes,
                 AccountChangeChannel::Multichain,
                 0,
+                0,
             )
             .unwrap();
             assert_eq!(acc.get_change_sequences(ACCOUNT).unwrap(), (1, 0));
@@ -1295,6 +1486,7 @@ mod tests {
                 ACCOUNT,
                 &local_changes,
                 AccountChangeChannel::Local,
+                0,
                 0,
             )
             .unwrap();
@@ -1323,6 +1515,7 @@ mod tests {
                 &[increment_epoch_op()],
                 AccountChangeChannel::Local,
                 4,
+                0,
             )
             .unwrap();
 
@@ -1342,6 +1535,7 @@ mod tests {
                 ACCOUNT,
                 &[increment_epoch_op()],
                 AccountChangeChannel::Multichain,
+                0,
                 0,
             )
             .unwrap();
@@ -1384,6 +1578,7 @@ mod tests {
                 ACCOUNT,
                 &changes,
                 AccountChangeChannel::Multichain,
+                0,
                 0,
             )
             .unwrap();

--- a/crates/execution/eip8130/src/transaction.rs
+++ b/crates/execution/eip8130/src/transaction.rs
@@ -149,6 +149,12 @@ impl TransactionAuthorizer {
                         &state,
                     )?;
                     config_changes.push(resolved);
+                    // `apply_config_change_with_account_state` silently skips an
+                    // already-expired grant on the replayable unsequenced (JIT)
+                    // Local path (per change, so live siblings still apply);
+                    // sequenced and multichain batches retain such a grant and
+                    // install it inert. Nothing reverts on expiry. `now` (block
+                    // seconds) drives that skip.
                     revoke_discount_slots = revoke_discount_slots.saturating_add(
                         AccountChangeApplier::apply_config_change_with_account_state(
                             storage,
@@ -157,6 +163,7 @@ impl TransactionAuthorizer {
                             cc.channel,
                             cc.sequence,
                             &mut state,
+                            now,
                         )?,
                     );
                     storage

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -1554,6 +1554,7 @@ where
             ApplyError::InvalidChangePayload => "account-change op payload must be empty",
             ApplyError::EpochSaturated => "local epoch is saturated",
             ApplyError::UnsupportedChangeType => "unsupported account-change op",
+            ApplyError::InvalidActorId => "actor id bytes32(0) is reserved",
             ApplyError::InvalidAuthenticator => "actor authenticator is not canonical",
             ApplyError::MalformedPolicyData => "actor policy data is malformed",
             ApplyError::NotAnActor { .. } => "revoked actor is not authorized",
@@ -1985,6 +1986,13 @@ where
                     // the new actor's authenticator is the right-aligned address
                     // in the second word.
                     if change.payload.len() < 64 {
+                        return Err(InvalidTransactionError::TxTypeNotSupported.into());
+                    }
+                    // The target `actorId` is `payload[0..32]`. `bytes32(0)` is the
+                    // reserved "no actor" sentinel and can never be authorized;
+                    // reject it up front to match `_authorizeActor`'s
+                    // `InvalidActorId` (the enshrined apply path rejects it too).
+                    if change.payload[..32].iter().all(|&b| b == 0) {
                         return Err(InvalidTransactionError::TxTypeNotSupported.into());
                     }
                     // The authenticator word is an ABI-encoded `address`: its
@@ -3086,10 +3094,30 @@ mod tests {
         );
     }
 
+    // `bytes32(0)` is the reserved "no actor" sentinel; an `AuthorizeActor`
+    // targeting it is rejected at the gate, matching `_authorizeActor`'s
+    // `InvalidActorId` (and the enshrined apply path).
+    #[test]
+    fn rejects_eip8130_config_change_authorizing_zero_actor_id() {
+        let cfg = SignedAccountChanges {
+            changes: vec![make_authorize_change(B256::ZERO, ok_authenticator())],
+            ..make_valid_config_change()
+        };
+        let tx = TxEip8130 {
+            account_changes: vec![AccountChange::ConfigChange(cfg)],
+            ..minimal_valid_eoa_tx()
+        };
+        assert_unsupported(TestValidator::validate_account_changes(
+            &sign_eoa_eip8130(tx),
+            test_chain_id(),
+        ));
+    }
+
     #[test]
     fn accepts_eip8130_config_change_with_exactly_max_actor_changes() {
+        // Ids start at 1: `bytes32(0)` is the reserved sentinel and rejected.
         let changes = (0..Eip8130Constants::MAX_ACTOR_CHANGES_PER_CONFIG)
-            .map(|i| make_authorize_change(B256::repeat_byte(i as u8), ok_authenticator()))
+            .map(|i| make_authorize_change(B256::repeat_byte(i as u8 + 1), ok_authenticator()))
             .collect();
         let cfg = SignedAccountChanges { changes, ..make_valid_config_change() };
         let tx = TxEip8130 {
@@ -3104,7 +3132,7 @@ mod tests {
     #[test]
     fn rejects_eip8130_config_change_with_too_many_actor_changes() {
         let changes = (0..(Eip8130Constants::MAX_ACTOR_CHANGES_PER_CONFIG + 1))
-            .map(|i| make_authorize_change(B256::repeat_byte(i as u8), ok_authenticator()))
+            .map(|i| make_authorize_change(B256::repeat_byte(i as u8 + 1), ok_authenticator()))
             .collect();
         let cfg = SignedAccountChanges { changes, ..make_valid_config_change() };
         let tx = TxEip8130 {


### PR DESCRIPTION
## Summary
Mirrors [base/eip-8130#79](https://github.com/base/eip-8130/pull/79), which changes the `AuthorizeActor` expiry handling on the replayable unsequenced (JIT) path from a **revert** to a silent **per-change skip**.

- A JIT batch (`Local` channel, low sequence half == `UNSEQUENCED`) consumes no counter and is replayable, so an already-expired grant (non-zero expiry not strictly in the future) is **dropped** rather than applied — a lapsed grant can never re-land and clobber its slot, and whether a signed change applies never depends on onchain time.
- The skip is **per-change**: live siblings in the same batch still apply.
- Sequenced batches (local sequenced or any multichain) are single-consume and cannot be replayed, so an expired grant is **retained and installs inert** (dead on arrival at authentication), consuming its slot — multichain relies on this for cross-chain catch-up.
- **No expiry path reverts.** Removes the now-unused `ApplyError::ExpiredChange` and its txpool mapping.

The consensus authorize-and-apply path filters the batch through `retain_landable_changes` before applying; the read-only estimation pipeline prices every change and does not filter.

## Test plan
- [x] `retain_landable_changes_skips_lapsed_jit_grant`
- [x] `retain_landable_changes_keeps_future_and_zero_expiry`
- [x] `retain_landable_changes_applies_live_siblings_only` (per-change partial application)
- [x] `retain_landable_changes_retains_expired_when_sequenced` (install-inert unchanged)
- [x] `cargo test -p base-execution-eip8130 --lib` (182 pass) + `base-execution-txpool` builds