### PR TITLE
fix(devnet): Display L1 Safe Head

### DIFF
--- a/etc/scripts/devnet/status.sh
+++ b/etc/scripts/devnet/status.sh
@@ -7,8 +7,9 @@ L1_RPC="${1:-$L1_RPC_URL}"
 L2_BUILDER_OP_RPC="${2:-$L2_BUILDER_OP_RPC_URL}"
 L2_CLIENT_OP_RPC="${3:-$L2_CLIENT_OP_RPC_URL}"
 
-# Fetch L1 block number
+# Fetch L1 latest and safe block numbers
 L1_BLOCK=$(cast block-number --rpc-url $L1_RPC 2>/dev/null || echo "N/A")
+L1_SAFE=$(cast block safe --field number --rpc-url $L1_RPC 2>/dev/null || echo "N/A")
 
 # Fetch L2 builder sync status
 BUILDER_STATUS=$(curl -s $L2_BUILDER_OP_RPC -X POST -H "Content-Type: application/json" \
@@ -26,7 +27,7 @@ CLIENT_SAFE=$(echo $CLIENT_STATUS | jq -r '.result.safe_l2.number // "N/A"')
 printf "\n"
 printf "%-12s | %-10s | %-10s\n" "Component" "Unsafe" "Safe"
 printf "%-12s-+-%-10s-+-%-10s\n" "------------" "----------" "----------"
-printf "%-12s | %-10s | %-10s\n" "L1" "$L1_BLOCK" "-"
+printf "%-12s | %-10s | %-10s\n" "L1" "$L1_BLOCK" "$L1_SAFE"
 printf "%-12s | %-10s | %-10s\n" "L2 Builder" "$BUILDER_UNSAFE" "$BUILDER_SAFE"
 printf "%-12s | %-10s | %-10s\n" "L2 Client" "$CLIENT_UNSAFE" "$CLIENT_SAFE"
 


### PR DESCRIPTION
## Summary

Queries the L1 safe block tag in the devnet status command and displays it alongside the latest head. Retains the existing `N/A` fallback when the RPC query is unavailable.