### PR TITLE
feat(builder): Check validity predicates before including transactions

### DIFF
--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -769,6 +769,72 @@ impl BasePayloadBuilderCtx {
                 continue;
             }
 
+            let tx_hash = *tx.hash();
+            let mut predicate_read_failed = false;
+            let predicates_match = {
+                let db = evm.db_mut();
+                tx.validity_predicates().iter().all(|predicate| {
+                    predicate.matches_state(db).unwrap_or_else(|error| {
+                        trace!(
+                            target: "payload_builder",
+                            tx_hash = ?tx_hash,
+                            predicate = ?predicate,
+                            error = ?error,
+                            "failed to read validity predicate state"
+                        );
+                        predicate_read_failed = true;
+                        false
+                    })
+                })
+            };
+            if !predicates_match {
+                num_txs_considered += 1;
+                let ordering_position = num_txs_considered;
+                let (rejection_reason, rejection_detail) = if predicate_read_failed {
+                    (
+                        "validity_predicate_read_failed",
+                        "failed to read state required by a validity predicate",
+                    )
+                } else {
+                    (
+                        "validity_predicate_not_satisfied",
+                        "a validity predicate is not satisfied by the current build state",
+                    )
+                };
+                trace!(
+                    target: "payload_builder",
+                    tx_hash = ?tx_hash,
+                    rejection_reason,
+                    "skipping transaction with unsatisfied validity predicate"
+                );
+                self.emit_builder_decision_event(
+                    &payload_id,
+                    TransactionEventType::BuilderConsidered,
+                    tx_hash,
+                    Some(ordering_position),
+                    || BuilderConsideredEventData::new(info, limits, None),
+                );
+                self.emit_builder_decision_event(
+                    &payload_id,
+                    TransactionEventType::BuilderRejected,
+                    tx_hash,
+                    Some(ordering_position),
+                    || {
+                        BuilderRejectedEventData::new(
+                            rejection_reason,
+                            rejection_detail,
+                            false,
+                            info,
+                            limits,
+                            None,
+                        )
+                    },
+                );
+                diag.txs_rejected_other += 1;
+                best_txs.mark_invalid(tx.sender(), tx.nonce());
+                continue;
+            }
+
             if self.builder_config.manifest_precheck_enabled
                 && let Some(manifest) = tx.watch_manifest()
                 && let Err(stale) = manifest.revalidate(evm.db_mut(), block_timestamp)

--- a/crates/execution/txpool/src/validity.rs
+++ b/crates/execution/txpool/src/validity.rs
@@ -2,6 +2,7 @@
 
 use alloy_primitives::{Address, U256};
 use reth_transaction_pool::ValidPoolTransaction;
+use revm::Database;
 
 use crate::{BasePooledTransaction, ExtensionError, ValidatedTransactionExtensions};
 
@@ -87,6 +88,24 @@ impl ValidityPredicate {
     pub const fn default_mask() -> U256 {
         U256::MAX
     }
+
+    /// Returns whether this predicate holds against the current database state.
+    ///
+    /// An absent account has a zero balance. Storage values are masked before
+    /// comparison. Callers must treat database errors as an inability to verify
+    /// the predicate rather than as a successful match.
+    pub fn matches_state<DB: Database>(&self, db: &mut DB) -> Result<bool, DB::Error> {
+        match self {
+            Self::Balance { address, op, value } => {
+                let balance = db.basic(*address)?.map_or(U256::ZERO, |account| account.balance);
+                Ok(op.matches(balance, *value))
+            }
+            Self::Storage { address, slot, mask, op, value } => {
+                let storage = db.storage(*address, *slot)? & *mask;
+                Ok(op.matches(storage, *value))
+            }
+        }
+    }
 }
 
 /// Experimental validity predicates carried with a validated transaction.
@@ -126,6 +145,7 @@ mod tests {
     use alloy_eips::eip2718::Encodable2718;
     use alloy_primitives::TxKind;
     use base_common_consensus::{BaseTransactionSigned, TxDeposit};
+    use revm::{database::InMemoryDB, state::AccountInfo};
     use serde_json::json;
 
     use super::*;
@@ -224,6 +244,45 @@ mod tests {
         ] {
             assert_eq!(op.matches(U256::from(10), U256::from(11)), expected);
         }
+    }
+
+    #[test]
+    fn predicates_match_current_state() {
+        let address = Address::repeat_byte(0x11);
+        let slot = U256::from(7);
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            address,
+            AccountInfo { balance: U256::from(10), ..Default::default() },
+        );
+        db.insert_account_storage(address, slot, U256::from(0xabcd)).unwrap();
+
+        let balance = ValidityPredicate::Balance {
+            address,
+            op: ValidityOperator::GreaterThan,
+            value: U256::from(9),
+        };
+        let storage = ValidityPredicate::Storage {
+            address,
+            slot,
+            mask: U256::from(0xff),
+            op: ValidityOperator::Equal,
+            value: U256::from(0xcd),
+        };
+
+        assert!(balance.matches_state(&mut db).unwrap());
+        assert!(storage.matches_state(&mut db).unwrap());
+    }
+
+    #[test]
+    fn absent_accounts_have_zero_balance() {
+        let predicate = ValidityPredicate::Balance {
+            address: Address::repeat_byte(0x11),
+            op: ValidityOperator::Equal,
+            value: U256::ZERO,
+        };
+
+        assert!(predicate.matches_state(&mut InMemoryDB::default()).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
This is a first pass of enforcing validity predicates in the builder. Transactions follow their existing sorting order, and are skipped if their predicates are not satisfied. They may be retried in a future build loop (flashblock and/or block)