### PR TITLE
fix(systems): Restore In-Process Sequencer Block Production

### DIFF
--- a/etc/systems/src/l2/in_process_consensus.rs
+++ b/etc/systems/src/l2/in_process_consensus.rs
@@ -243,6 +243,7 @@ impl InProcessConsensus {
             builder = builder.with_sequencer_config(SequencerConfig {
                 sequencer_stopped: config.sequencer_stopped,
                 shadow_blocks_per_cycle: config.shadow_blocks_per_cycle,
+                l1_rpc_timeout: base_consensus_providers::L1_RPC_TIMEOUT,
                 ..Default::default()
             });
         }


### PR DESCRIPTION
## Summary

The B-20 precompile system tests were failing in CI with "receipt timed out" errors because L2 transactions were never being mined. PR #4354 introduced a 500ms `SequencerConfig::DEFAULT_L1_RPC_TIMEOUT` for L1 RPC calls on the sequencer block-production hot path, but the in-process consensus stack used by every system test left `SequencerConfig` at `..Default::default()`, so its L1 origin provider silently fell back to that aggressive 500ms timeout while the L1 and engine configs correctly used the 15s `L1_RPC_TIMEOUT`. Under CI load the in-process L1 responds slower than 500ms, so L1-origin fetches time out, block production stalls, and transactions never receive receipts. This sets the sequencer `l1_rpc_timeout` to `L1_RPC_TIMEOUT` to match the L1 and engine configs, restoring block production for the in-process sequencer.