### PR TITLE
feat(txpool): Configure Validity Predicate Limits

### DIFF
--- a/bin/base/src/commands/sequencer.rs
+++ b/bin/base/src/commands/sequencer.rs
@@ -3,7 +3,9 @@
 use std::sync::Arc;
 
 use base_builder_cli::Args as BuilderArgs;
-use base_builder_core::{BuilderApiExtension, FlashblocksServiceBuilder};
+use base_builder_core::{
+    BuilderApiExtension, BuilderApiExtensionConfig, FlashblocksServiceBuilder,
+};
 use base_builder_metering::MeteringStoreExtension;
 use base_consensus_cli::{
     CliMetrics, ConsensusNodeArgs, ConsensusNodeConfigArgs, ConsensusNodeOverrides,
@@ -69,6 +71,7 @@ impl SequencerCommand {
         let metering_provider: base_builder_core::SharedMeteringProvider =
             Arc::new(builder.build_metering_store());
         let accept_validity_transactions = builder.enable_experimental_validity_transactions;
+        let max_validity_predicates = builder.experimental_validity_max_predicates;
         let builder_config = builder.into_builder_config(Arc::clone(&metering_provider))?;
         let da_config = builder_config.da_config.clone();
         let gas_limit_config = builder_config.gas_limit_config.clone();
@@ -107,7 +110,10 @@ impl SequencerCommand {
                 .with_service_builder(FlashblocksServiceBuilder::new(builder_config));
             runner.install_ext::<MeteringStoreExtension>(metering_provider);
             runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig { sequencer_rpc });
-            runner.install_ext::<BuilderApiExtension>(accept_validity_transactions);
+            runner.install_ext::<BuilderApiExtension>(BuilderApiExtensionConfig::new(
+                accept_validity_transactions,
+                max_validity_predicates,
+            ));
             StandardBaseRethNode::install_upgrade_signal_runtime_extension(
                 &mut runner,
                 &rollup_args,

--- a/bin/builder/src/main.rs
+++ b/bin/builder/src/main.rs
@@ -6,7 +6,9 @@
 use std::sync::Arc;
 
 use base_builder_cli::Args;
-use base_builder_core::{BuilderApiExtension, FlashblocksServiceBuilder};
+use base_builder_core::{
+    BuilderApiExtension, BuilderApiExtensionConfig, FlashblocksServiceBuilder,
+};
 use base_builder_metering::MeteringStoreExtension;
 use base_execution_cli::{Cli, StandardBaseRethNode};
 use base_node_runner::BaseNodeRunner;
@@ -40,6 +42,7 @@ fn main() {
 
         let accept_validity_transactions = builder_args.enable_experimental_validity_transactions;
         let shadow_indexer_config = ShadowIndexerConfig::try_from(&builder_args.shadow_indexer)?;
+        let max_validity_predicates = builder_args.experimental_validity_max_predicates;
         let builder_config = builder_args
             .into_builder_config(Arc::clone(&metering_provider))
             .expect("Failed to convert rollup args to builder config");
@@ -54,7 +57,10 @@ fn main() {
             .with_service_builder(FlashblocksServiceBuilder::new(builder_config));
         runner.install_ext::<MeteringStoreExtension>(metering_provider);
         runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig::default());
-        runner.install_ext::<BuilderApiExtension>(accept_validity_transactions);
+        runner.install_ext::<BuilderApiExtension>(BuilderApiExtensionConfig::new(
+            accept_validity_transactions,
+            max_validity_predicates,
+        ));
         runner.install_ext::<ShadowIndexerExtension>(shadow_indexer_config);
         StandardBaseRethNode::install_upgrade_signal_runtime_extension(&mut runner, &rollup_args)?;
         runner.add_started_callback(|| {

--- a/crates/builder/cli/src/args.rs
+++ b/crates/builder/cli/src/args.rs
@@ -4,7 +4,8 @@ use core::{net::SocketAddr, time::Duration};
 use std::path::PathBuf;
 
 use base_builder_core::{
-    BuilderConfig, ExecutionMeteringMode, RejectionCache, SharedMeteringProvider,
+    BuilderConfig, DEFAULT_MAX_VALIDITY_PREDICATES, ExecutionMeteringMode, RejectionCache,
+    SharedMeteringProvider,
 };
 use base_builder_metering::MeteringStore;
 use base_execution_cli::ShadowIndexerArgs;
@@ -190,6 +191,14 @@ pub struct Args {
     #[arg(long = "builder.enable-experimental-validity-transactions", default_value = "false")]
     pub enable_experimental_validity_transactions: bool,
 
+    /// Maximum validity predicates accepted per experimental transaction.
+    #[arg(
+        long = "builder.experimental-validity-max-predicates",
+        default_value_t = DEFAULT_MAX_VALIDITY_PREDICATES,
+        requires = "enable_experimental_validity_transactions"
+    )]
+    pub experimental_validity_max_predicates: usize,
+
     /// Maximum cumulative uncompressed (EIP-2718 encoded) block size in bytes
     #[arg(long = "builder.max-uncompressed-block-size")]
     pub max_uncompressed_block_size: Option<u64>,
@@ -287,6 +296,7 @@ impl Default for Args {
             extra_block_deadline_secs: 20,
             enable_resource_metering: false,
             enable_experimental_validity_transactions: false,
+            experimental_validity_max_predicates: DEFAULT_MAX_VALIDITY_PREDICATES,
             max_uncompressed_block_size: None,
             metering_wait_duration_ms: None,
             audit_archiver_url: None,
@@ -388,6 +398,7 @@ mod tests {
     fn default_args_produce_valid_config() {
         let args = Args::default();
         assert!(!args.enable_experimental_validity_transactions);
+        assert_eq!(args.experimental_validity_max_predicates, DEFAULT_MAX_VALIDITY_PREDICATES);
         let config = convert(args);
         assert_eq!(config.block_time, Duration::from_millis(1000));
         assert!(config.max_gas_per_txn.is_none());
@@ -399,9 +410,12 @@ mod tests {
         let parsed = CommandParser::parse_from([
             "builder",
             "--builder.enable-experimental-validity-transactions",
+            "--builder.experimental-validity-max-predicates",
+            "8",
         ]);
 
         assert!(parsed.args.enable_experimental_validity_transactions);
+        assert_eq!(parsed.args.experimental_validity_max_predicates, 8);
     }
 
     #[rstest]

--- a/crates/builder/core/src/extension.rs
+++ b/crates/builder/core/src/extension.rs
@@ -1,25 +1,53 @@
 //! Builder API RPC extension for registering the `base_insertValidatedTransaction` endpoint.
 
+pub use base_execution_txpool::DEFAULT_MAX_VALIDITY_PREDICATES;
 use base_execution_txpool::{BuilderApiImpl, BuilderApiServer, TransactionValidity};
 use base_node_runner::{BaseNodeExtension, BaseRpcContext, FromExtensionConfig, NodeHooks};
 
+/// Builder RPC configuration for experimental validity-bearing transactions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BuilderApiExtensionConfig {
+    /// Whether the builder accepts non-empty experimental validity metadata.
+    pub accept_experimental_validity_transactions: bool,
+    /// Maximum number of validity predicates accepted per transaction.
+    pub max_validity_predicates: usize,
+}
+
+impl BuilderApiExtensionConfig {
+    /// Creates a builder RPC configuration.
+    pub const fn new(
+        accept_experimental_validity_transactions: bool,
+        max_validity_predicates: usize,
+    ) -> Self {
+        Self { accept_experimental_validity_transactions, max_validity_predicates }
+    }
+}
+
+impl Default for BuilderApiExtensionConfig {
+    fn default() -> Self {
+        Self::new(false, DEFAULT_MAX_VALIDITY_PREDICATES)
+    }
+}
+
 /// Extension that registers the Builder API RPC module (`base_insertValidatedTransaction`).
 ///
-/// Its boolean configuration controls whether non-empty experimental validity
-/// metadata is accepted. Ordinary validated transactions remain available in
-/// both modes.
+/// Its configuration controls whether non-empty experimental validity metadata
+/// is accepted and how many predicates a transaction may carry. Ordinary
+/// validated transactions remain available in both modes.
 #[derive(Debug, Default)]
 pub struct BuilderApiExtension {
-    accept_experimental_validity_transactions: bool,
+    config: BuilderApiExtensionConfig,
 }
 
 impl BaseNodeExtension for BuilderApiExtension {
     fn apply(self: Box<Self>, builder: NodeHooks) -> NodeHooks {
-        let accept_validity = self.accept_experimental_validity_transactions;
+        let accept_validity = self.config.accept_experimental_validity_transactions;
+        let max_validity_predicates = self.config.max_validity_predicates;
         builder.add_rpc_module(move |ctx: &mut BaseRpcContext<'_>| {
             let api = BuilderApiImpl::<_, TransactionValidity>::with_extensions(
                 ctx.pool().clone(),
                 accept_validity,
+                max_validity_predicates,
             );
             ctx.modules.merge_configured(api.into_rpc())?;
             Ok(())
@@ -28,9 +56,9 @@ impl BaseNodeExtension for BuilderApiExtension {
 }
 
 impl FromExtensionConfig for BuilderApiExtension {
-    type Config = bool;
+    type Config = BuilderApiExtensionConfig;
 
-    fn from_config(accept_experimental_validity_transactions: Self::Config) -> Self {
-        Self { accept_experimental_validity_transactions }
+    fn from_config(config: Self::Config) -> Self {
+        Self { config }
     }
 }

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -49,7 +49,9 @@ pub use flashblocks::{
 };
 
 mod extension;
-pub use extension::BuilderApiExtension;
+pub use extension::{
+    BuilderApiExtension, BuilderApiExtensionConfig, DEFAULT_MAX_VALIDITY_PREDICATES,
+};
 
 /// Shared test infrastructure: local node instances, chain drivers, transaction builders, and pool observers.
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/builder/core/tests/ordering.rs
+++ b/crates/builder/core/tests/ordering.rs
@@ -6,7 +6,7 @@ use alloy_network::TransactionResponse;
 use alloy_primitives::{Address, U256};
 use alloy_provider::Provider;
 use base_builder_core::{
-    BuilderApiExtension, BuilderConfig,
+    BuilderApiExtension, BuilderApiExtensionConfig, BuilderConfig, DEFAULT_MAX_VALIDITY_PREDICATES,
     test_utils::{ChainDriverExt, LocalInstanceBuilder, ONE_ETH, setup_test_instance},
 };
 use base_execution_txpool::{
@@ -94,7 +94,10 @@ async fn fee_priority_ordering() -> eyre::Result<()> {
 #[tokio::test]
 async fn predicates_delay_priority_without_blocking_nonce_descendants() -> eyre::Result<()> {
     let instance = LocalInstanceBuilder::new(BuilderConfig::for_tests())
-        .install_ext::<BuilderApiExtension>(true)
+        .install_ext::<BuilderApiExtension>(BuilderApiExtensionConfig::new(
+            true,
+            DEFAULT_MAX_VALIDITY_PREDICATES,
+        ))
         .build()
         .await?;
     let driver = instance.driver().await?;

--- a/crates/builder/core/tests/rpc.rs
+++ b/crates/builder/core/tests/rpc.rs
@@ -4,18 +4,22 @@ use alloy_consensus::TxEip1559;
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, Bytes, Signature, TxKind, U256};
 use alloy_rpc_client::RpcClient;
-use base_builder_core::BuilderApiExtension;
+use base_builder_core::{BuilderApiExtension, BuilderApiExtensionConfig};
 use base_common_consensus::{BaseTransactionSigned, BaseTypedTransaction, TxDeposit};
 use base_execution_txpool::{
-    NoExtensions, TransactionValidity, ValidatedTransaction, ValidityOperator, ValidityPredicate,
+    DEFAULT_MAX_VALIDITY_PREDICATES, NoExtensions, TransactionValidity, ValidatedTransaction,
+    ValidityOperator, ValidityPredicate,
 };
 use base_node_runner::test_utils::TestHarness;
 use base_test_utils::Account;
 
 /// Sets up a test harness with the `BuilderApiExtension` installed.
-async fn setup(accept_validity: bool) -> eyre::Result<(TestHarness, RpcClient)> {
-    let harness =
-        TestHarness::builder().with_ext::<BuilderApiExtension>(accept_validity).build().await?;
+async fn setup(
+    accept_validity: bool,
+    max_validity_predicates: usize,
+) -> eyre::Result<(TestHarness, RpcClient)> {
+    let config = BuilderApiExtensionConfig::new(accept_validity, max_validity_predicates);
+    let harness = TestHarness::builder().with_ext::<BuilderApiExtension>(config).build().await?;
     let client = harness.rpc_client()?;
     Ok((harness, client))
 }
@@ -62,7 +66,7 @@ fn create_eip1559_tx(chain_id: u64) -> (Address, Bytes) {
 /// The pool doesn't accept deposit transactions, but the RPC should decode it successfully.
 #[tokio::test]
 async fn test_insert_validated_deposit_tx() -> eyre::Result<()> {
-    let (_harness, client) = setup(false).await?;
+    let (_harness, client) = setup(false, DEFAULT_MAX_VALIDITY_PREDICATES).await?;
 
     let (sender, raw) = create_deposit_tx();
     let validated_tx = ValidatedTransaction {
@@ -93,7 +97,7 @@ async fn test_insert_validated_deposit_tx() -> eyre::Result<()> {
 /// The pool should accept this transaction type.
 #[tokio::test]
 async fn test_insert_validated_eip1559_tx() -> eyre::Result<()> {
-    let (harness, client) = setup(false).await?;
+    let (harness, client) = setup(false, DEFAULT_MAX_VALIDITY_PREDICATES).await?;
 
     let (sender, raw) = create_eip1559_tx(harness.chain_id());
     let validated_tx = ValidatedTransaction {
@@ -117,7 +121,7 @@ async fn test_insert_validated_eip1559_tx() -> eyre::Result<()> {
 /// Verifies the RPC endpoint rejects an invalid transaction at the pool insertion stage.
 #[tokio::test]
 async fn test_insert_invalid_tx_fails() -> eyre::Result<()> {
-    let (_harness, client) = setup(false).await?;
+    let (_harness, client) = setup(false, DEFAULT_MAX_VALIDITY_PREDICATES).await?;
 
     // Invalid raw bytes that can't be decoded (0xFF is not a valid tx type)
     let validated_tx = ValidatedTransaction {
@@ -153,7 +157,7 @@ async fn test_validity_transactions_require_explicit_opt_in() -> eyre::Result<()
         }],
     };
 
-    let (disabled_harness, disabled_client) = setup(false).await?;
+    let (disabled_harness, disabled_client) = setup(false, DEFAULT_MAX_VALIDITY_PREDICATES).await?;
     let (sender, raw) = create_eip1559_tx(disabled_harness.chain_id());
     let disabled_tx = ValidatedTransaction {
         sender,
@@ -173,7 +177,7 @@ async fn test_validity_transactions_require_explicit_opt_in() -> eyre::Result<()
             .contains("transaction extensions are disabled")
     );
 
-    let (enabled_harness, enabled_client) = setup(true).await?;
+    let (enabled_harness, enabled_client) = setup(true, DEFAULT_MAX_VALIDITY_PREDICATES).await?;
     let (sender, raw) = create_eip1559_tx(enabled_harness.chain_id());
     let enabled_tx = ValidatedTransaction {
         sender,
@@ -188,5 +192,34 @@ async fn test_validity_transactions_require_explicit_opt_in() -> eyre::Result<()
         enabled_client.request("base_insertValidatedTransaction", (enabled_tx,)).await;
     assert!(enabled.is_ok(), "enabled builder should accept validity: {enabled:?}");
 
+    Ok(())
+}
+
+/// Verifies the builder enforces its configured validity predicate limit.
+#[tokio::test]
+async fn test_validity_transactions_enforce_configured_limit() -> eyre::Result<()> {
+    let (harness, client) = setup(true, 1).await?;
+    let (sender, raw) = create_eip1559_tx(harness.chain_id());
+    let predicate = ValidityPredicate::Balance {
+        address: Account::Alice.address(),
+        op: ValidityOperator::Equal,
+        value: U256::ZERO,
+    };
+    let transaction = ValidatedTransaction {
+        sender,
+        raw,
+        min_block_number: None,
+        max_block_number: None,
+        min_timestamp: None,
+        max_timestamp: None,
+        extensions: TransactionValidity { validity: vec![predicate; 2] },
+    };
+
+    let result: Result<(), _> =
+        client.request("base_insertValidatedTransaction", (transaction,)).await;
+    let error = result.expect_err("builder should reject validity above its configured limit");
+
+    assert!(error.to_string().contains("too many validity predicates"));
+    assert!(error.to_string().contains("maximum 1"));
     Ok(())
 }

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -20,7 +20,10 @@ use base_tx_forwarding::{
     DEFAULT_MAX_BATCH_SIZE, DEFAULT_MAX_RPS, DEFAULT_RESEND_AFTER_MS, TxForwardingConfig,
     TxForwardingExtension,
 };
-use base_txpool_rpc::{SendRawTransactionValidityExtension, TxPoolRpcConfig, TxPoolRpcExtension};
+use base_txpool_rpc::{
+    DEFAULT_MAX_VALIDITY_PREDICATES, SendRawTransactionValidityExtension, TxPoolRpcConfig,
+    TxPoolRpcExtension,
+};
 use base_txpool_tracing::{TxPoolExtension, TxpoolConfig};
 use base_upgrade_signal::UpgradeSignalStartupMode;
 use tracing::warn;
@@ -161,6 +164,14 @@ pub struct StandardNodeArgs {
     #[arg(long = "enable-experimental-validity-transactions", requires = "enable_tx_forwarding")]
     pub enable_experimental_validity_transactions: bool,
 
+    /// Maximum validity predicates accepted per experimental transaction.
+    #[arg(
+        long = "experimental-validity-max-predicates",
+        default_value_t = DEFAULT_MAX_VALIDITY_PREDICATES,
+        requires = "enable_experimental_validity_transactions"
+    )]
+    pub experimental_validity_max_predicates: usize,
+
     /// Builder RPC endpoints for transaction forwarding (one forwarder per URL), used by mempool nodes
     #[arg(
         long = "builder-rpc-urls",
@@ -278,6 +289,7 @@ impl From<RpcStandardNodeArgs> for StandardNodeArgs {
             shadow_indexer: ShadowIndexerArgs::default(),
             enable_tx_forwarding: false,
             enable_experimental_validity_transactions: false,
+            experimental_validity_max_predicates: DEFAULT_MAX_VALIDITY_PREDICATES,
             builder_rpc_urls: Vec::new(),
             tx_forwarding_resend_after_ms: DEFAULT_RESEND_AFTER_MS,
             tx_forwarding_batch_size: DEFAULT_MAX_BATCH_SIZE,
@@ -534,7 +546,9 @@ impl StandardBaseRethNode {
                     "experimental validity transactions require enabled transaction forwarding"
                 );
             }
-            runner.install_ext::<SendRawTransactionValidityExtension>(());
+            runner.install_ext::<SendRawTransactionValidityExtension>(
+                args.experimental_validity_max_predicates,
+            );
         }
         runner.install_ext::<TxForwardingExtension>(tx_forwarding_config);
         runner.install_ext::<ProofsHistoryExtension>(rollup_args.clone());
@@ -822,6 +836,10 @@ mod tests {
 
         assert_eq!(standard_args.rpc.rollup_args.sequencer, None);
         assert!(!standard_args.enable_experimental_validity_transactions);
+        assert_eq!(
+            standard_args.experimental_validity_max_predicates,
+            DEFAULT_MAX_VALIDITY_PREDICATES
+        );
         assert!(!config.enabled);
         assert!(config.builder_urls.is_empty());
     }
@@ -845,11 +863,14 @@ mod tests {
             "--builder-rpc-urls",
             "http://localhost:8545",
             "--enable-experimental-validity-transactions",
+            "--experimental-validity-max-predicates",
+            "8",
         ])
         .args;
 
         assert!(args.enable_tx_forwarding);
         assert!(args.enable_experimental_validity_transactions);
+        assert_eq!(args.experimental_validity_max_predicates, 8);
         assert_eq!(args.builder_rpc_urls.len(), 1);
     }
 

--- a/crates/execution/tx-forwarding/tests/forwarding.rs
+++ b/crates/execution/tx-forwarding/tests/forwarding.rs
@@ -10,7 +10,9 @@ use alloy_provider::Provider;
 use alloy_signer::SignerSync;
 use base_common_rpc_types::BaseTransactionRequest;
 use base_execution_chainspec::BaseChainSpec;
-use base_execution_txpool::{TransactionValidity, ValidatedTransaction};
+use base_execution_txpool::{
+    DEFAULT_MAX_VALIDITY_PREDICATES, TransactionValidity, ValidatedTransaction,
+};
 use base_node_runner::test_utils::TestHarness;
 use base_test_utils::{Account, DEVNET_CHAIN_ID, build_test_genesis};
 use base_tx_forwarding::{TxForwardingConfig, TxForwardingExtension};
@@ -153,7 +155,7 @@ async fn forwards_validity_to_every_builder() -> Result<()> {
     let config = TxForwardingConfig::new(vec![first.url.clone(), second.url.clone()]);
     let chain_spec = Arc::new(BaseChainSpec::from_genesis(build_test_genesis()));
     let harness = TestHarness::builder()
-        .with_ext::<SendRawTransactionValidityExtension>(())
+        .with_ext::<SendRawTransactionValidityExtension>(DEFAULT_MAX_VALIDITY_PREDICATES)
         .with_ext::<TxForwardingExtension>(config)
         .with_chain_spec(chain_spec)
         .build()

--- a/crates/execution/txpool-rpc/src/extension.rs
+++ b/crates/execution/txpool-rpc/src/extension.rs
@@ -1,5 +1,6 @@
 //! `TxPool` RPC extension for registering transaction pool management APIs.
 
+pub use base_execution_txpool::DEFAULT_MAX_VALIDITY_PREDICATES;
 use base_node_runner::{BaseNodeExtension, BaseRpcContext, FromExtensionConfig, NodeHooks};
 use reth_rpc_server_types::RethRpcModule;
 
@@ -43,13 +44,25 @@ impl BaseNodeExtension for TxPoolRpcExtension {
 }
 
 /// Extension registering local validity-bearing transaction ingress.
-#[derive(Debug, Default)]
-pub struct SendRawTransactionValidityExtension;
+#[derive(Debug)]
+pub struct SendRawTransactionValidityExtension {
+    max_validity_predicates: usize,
+}
+
+impl Default for SendRawTransactionValidityExtension {
+    fn default() -> Self {
+        Self { max_validity_predicates: DEFAULT_MAX_VALIDITY_PREDICATES }
+    }
+}
 
 impl BaseNodeExtension for SendRawTransactionValidityExtension {
     fn apply(self: Box<Self>, builder: NodeHooks) -> NodeHooks {
-        builder.add_rpc_module(|ctx: &mut BaseRpcContext<'_>| {
-            let api = SendRawTransactionValidityApiImpl::new(ctx.pool().clone());
+        let max_validity_predicates = self.max_validity_predicates;
+        builder.add_rpc_module(move |ctx: &mut BaseRpcContext<'_>| {
+            let api = SendRawTransactionValidityApiImpl::with_max_validity_predicates(
+                ctx.pool().clone(),
+                max_validity_predicates,
+            );
             ctx.modules.merge_configured(api.into_rpc())?;
             Ok(())
         })
@@ -57,10 +70,10 @@ impl BaseNodeExtension for SendRawTransactionValidityExtension {
 }
 
 impl FromExtensionConfig for SendRawTransactionValidityExtension {
-    type Config = ();
+    type Config = usize;
 
-    fn from_config(_config: Self::Config) -> Self {
-        Self
+    fn from_config(max_validity_predicates: Self::Config) -> Self {
+        Self { max_validity_predicates }
     }
 }
 

--- a/crates/execution/txpool-rpc/src/lib.rs
+++ b/crates/execution/txpool-rpc/src/lib.rs
@@ -15,4 +15,7 @@ pub use rpc::{
 };
 
 mod extension;
-pub use extension::{SendRawTransactionValidityExtension, TxPoolRpcConfig, TxPoolRpcExtension};
+pub use extension::{
+    DEFAULT_MAX_VALIDITY_PREDICATES, SendRawTransactionValidityExtension, TxPoolRpcConfig,
+    TxPoolRpcExtension,
+};

--- a/crates/execution/txpool-rpc/src/rpc.rs
+++ b/crates/execution/txpool-rpc/src/rpc.rs
@@ -1,7 +1,9 @@
 //! RPC implementation for transaction submission, status queries, and pool management.
 
 use alloy_primitives::{Address, Bytes, TxHash};
-use base_execution_txpool::{BasePooledTransaction, MAX_VALIDITY_PREDICATES, ValidityPredicate};
+use base_execution_txpool::{
+    BasePooledTransaction, DEFAULT_MAX_VALIDITY_PREDICATES, ValidityPredicate,
+};
 use jsonrpsee::{
     core::{RpcResult, async_trait, client::ClientT},
     http_client::{HttpClient, HttpClientBuilder},
@@ -86,12 +88,18 @@ pub struct TransactionStatusApiImpl<Pool: TransactionPool> {
 #[derive(Debug, Clone)]
 pub struct SendRawTransactionValidityApiImpl<Pool> {
     pool: Pool,
+    max_validity_predicates: usize,
 }
 
 impl<Pool> SendRawTransactionValidityApiImpl<Pool> {
-    /// Creates a validity transaction ingress backed by the given pool.
+    /// Creates a validity transaction ingress backed by the given pool and default predicate limit.
     pub const fn new(pool: Pool) -> Self {
-        Self { pool }
+        Self { pool, max_validity_predicates: DEFAULT_MAX_VALIDITY_PREDICATES }
+    }
+
+    /// Creates a validity transaction ingress with a predicate limit.
+    pub const fn with_max_validity_predicates(pool: Pool, max_validity_predicates: usize) -> Self {
+        Self { pool, max_validity_predicates }
     }
 }
 
@@ -154,12 +162,13 @@ where
         &self,
         request: SendRawTransactionValidityRequest,
     ) -> RpcResult<TxHash> {
-        if request.validity.len() > MAX_VALIDITY_PREDICATES {
+        if request.validity.len() > self.max_validity_predicates {
             return Err(ErrorObjectOwned::owned(
                 ErrorCode::InvalidParams.code(),
                 format!(
-                    "too many validity predicates: {} (maximum {MAX_VALIDITY_PREDICATES})",
-                    request.validity.len()
+                    "too many validity predicates: {} (maximum {})",
+                    request.validity.len(),
+                    self.max_validity_predicates
                 ),
                 None::<()>,
             ));
@@ -280,12 +289,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_raw_transaction_validity_rejects_too_many_predicates() {
-        let rpc = SendRawTransactionValidityApiImpl::new(NoopTransactionPool::<
-            BasePooledTransaction,
-        >::new());
+    async fn send_raw_transaction_validity_enforces_configured_predicate_limit() {
+        let rpc = SendRawTransactionValidityApiImpl::with_max_validity_predicates(
+            NoopTransactionPool::<BasePooledTransaction>::new(),
+            2,
+        );
         let mut request = validity_request(Bytes::from_static(&[0x02]));
-        request.validity = vec![request.validity[0].clone(); MAX_VALIDITY_PREDICATES + 1];
+        request.validity = vec![request.validity[0].clone(); 3];
 
         let error = rpc
             .send_raw_transaction_validity(request)
@@ -294,6 +304,7 @@ mod tests {
 
         assert_eq!(error.code(), ErrorCode::InvalidParams.code());
         assert!(error.message().contains("too many validity predicates"));
+        assert!(error.message().contains("maximum 2"));
     }
 
     #[tokio::test]

--- a/crates/execution/txpool/src/builder/rpc.rs
+++ b/crates/execution/txpool/src/builder/rpc.rs
@@ -47,6 +47,7 @@ pub trait BuilderApi<E> {
 pub struct BuilderApiImpl<P, E = NoExtensions> {
     pool: P,
     accept_extensions: bool,
+    max_extension_items: usize,
     _extensions: PhantomData<E>,
 }
 
@@ -59,7 +60,7 @@ impl<P> BuilderApiImpl<P, NoExtensions> {
     /// call site (`E0282`), because type-parameter defaults do not participate
     /// in inference for associated-function calls.
     pub const fn new(pool: P) -> Self {
-        Self { pool, accept_extensions: false, _extensions: PhantomData }
+        Self { pool, accept_extensions: false, max_extension_items: 0, _extensions: PhantomData }
     }
 }
 
@@ -67,9 +68,14 @@ impl<P, E> BuilderApiImpl<P, E> {
     /// Creates a new handler carrying the wire extension payload `E`.
     ///
     /// Non-empty extension payloads are rejected unless `accept_extensions` is
-    /// explicitly enabled.
-    pub const fn with_extensions(pool: P, accept_extensions: bool) -> Self {
-        Self { pool, accept_extensions, _extensions: PhantomData }
+    /// explicitly enabled. Extension payloads validate `max_extension_items`
+    /// according to their own item semantics.
+    pub const fn with_extensions(
+        pool: P,
+        accept_extensions: bool,
+        max_extension_items: usize,
+    ) -> Self {
+        Self { pool, accept_extensions, max_extension_items, _extensions: PhantomData }
     }
 }
 
@@ -95,6 +101,11 @@ where
                 None::<()>,
             ));
         }
+
+        tx.extensions.validate(self.max_extension_items).map_err(|e| {
+            BuilderApiMetrics::extension_errors().increment(1);
+            ErrorObjectOwned::owned(ErrorCode::InvalidParams.code(), e.to_string(), None::<()>)
+        })?;
 
         // Decode the EIP-2718 transaction bytes
         let consensus_tx =
@@ -302,6 +313,7 @@ mod tests {
         BuilderApiImpl::<_, TestExtensions>::with_extensions(
             NoopTransactionPool::<BasePooledTransaction>::new(),
             accept_extensions,
+            usize::MAX,
         )
     }
 

--- a/crates/execution/txpool/src/lib.rs
+++ b/crates/execution/txpool/src/lib.rs
@@ -29,7 +29,7 @@ mod best;
 
 mod validity;
 pub use validity::{
-    MAX_VALIDITY_PREDICATES, PredicateContext, TransactionValidity, ValidityOperator,
+    DEFAULT_MAX_VALIDITY_PREDICATES, PredicateContext, TransactionValidity, ValidityOperator,
     ValidityPredicate,
 };
 

--- a/crates/execution/txpool/src/validity.rs
+++ b/crates/execution/txpool/src/validity.rs
@@ -6,8 +6,8 @@ use revm::Database;
 
 use crate::{BasePooledTransaction, ExtensionError, ValidatedTransactionExtensions};
 
-/// Maximum number of experimental validity predicates carried by one transaction.
-pub const MAX_VALIDITY_PREDICATES: usize = 64;
+/// Default maximum number of experimental validity predicates carried by one transaction.
+pub const DEFAULT_MAX_VALIDITY_PREDICATES: usize = 64;
 
 /// A comparison used by a [`ValidityPredicate`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
@@ -166,17 +166,21 @@ impl ValidatedTransactionExtensions<BasePooledTransaction> for TransactionValidi
         self.validity.is_empty()
     }
 
+    fn validate(&self, max_items: usize) -> Result<(), ExtensionError> {
+        if self.validity.len() > max_items {
+            return Err(ExtensionError(format!(
+                "too many validity predicates: {} (maximum {max_items})",
+                self.validity.len()
+            )));
+        }
+        Ok(())
+    }
+
     fn extract(tx: &ValidPoolTransaction<BasePooledTransaction>) -> Self {
         Self { validity: tx.transaction.validity_predicates().to_vec() }
     }
 
     fn apply(self, tx: BasePooledTransaction) -> Result<BasePooledTransaction, ExtensionError> {
-        if self.validity.len() > MAX_VALIDITY_PREDICATES {
-            return Err(ExtensionError(format!(
-                "too many validity predicates: {} (maximum {MAX_VALIDITY_PREDICATES})",
-                self.validity.len()
-            )));
-        }
         Ok(tx.with_validity_predicates(self.validity))
     }
 }
@@ -395,34 +399,18 @@ mod tests {
     }
 
     #[test]
-    fn apply_rejects_too_many_predicates() {
-        let signed: BaseTransactionSigned = TxDeposit {
-            source_hash: Default::default(),
-            from: Address::ZERO,
-            to: TxKind::Create,
-            mint: 0,
-            value: U256::ZERO,
-            gas_limit: 21_000,
-            is_system_transaction: false,
-            input: Default::default(),
-        }
-        .into();
-        let encoded_length = signed.encode_2718_len();
-        let transaction = BasePooledTransaction::new(
-            Recovered::new_unchecked(signed, Address::ZERO),
-            encoded_length,
-        );
+    fn validate_rejects_configured_maximum() {
         let predicate = ValidityPredicate::Balance {
             address: Address::ZERO,
             op: ValidityOperator::Equal,
             value: U256::ZERO,
         };
-        let extension =
-            TransactionValidity { validity: vec![predicate; MAX_VALIDITY_PREDICATES + 1] };
+        let extension = TransactionValidity { validity: vec![predicate; 3] };
 
-        let error = extension.apply(transaction).unwrap_err();
+        let error = extension.validate(2).unwrap_err();
 
         assert!(error.to_string().contains("too many validity predicates"));
+        assert!(error.to_string().contains("maximum 2"));
     }
 
     #[test]

--- a/crates/execution/txpool/src/wire.rs
+++ b/crates/execution/txpool/src/wire.rs
@@ -38,6 +38,14 @@ pub trait ValidatedTransactionExtensions<T: PoolTransaction>:
         false
     }
 
+    /// Validates the payload against the configured maximum number of extension items.
+    ///
+    /// Called by the builder before decoding and applying the payload. Each extension
+    /// type defines what constitutes one item.
+    fn validate(&self, _max_items: usize) -> Result<(), ExtensionError> {
+        Ok(())
+    }
+
     /// Extracts extension data from an outbound pooled transaction.
     ///
     /// Called by the forwarder for each transaction it relays to a builder.

--- a/etc/systems/src/l2/in_process_builder.rs
+++ b/etc/systems/src/l2/in_process_builder.rs
@@ -11,7 +11,9 @@ use alloy_primitives::hex::ToHexExt;
 use alloy_rpc_types_engine::JwtSecret;
 use base_builder_core::{BuilderConfig, FlashblocksServiceBuilder, test_utils::get_available_port};
 use base_execution_chainspec::BaseChainSpec;
-use base_execution_txpool::{BasePooledTransaction, BuilderApiImpl, BuilderApiServer};
+use base_execution_txpool::{
+    BasePooledTransaction, BuilderApiImpl, BuilderApiServer, DEFAULT_MAX_VALIDITY_PREDICATES,
+};
 use base_node_core::{args::RollupArgs, node::BasePoolBuilder};
 use base_node_runner::{BaseNode, BaseNodeExtension, NodeHooks};
 use eyre::{Result, WrapErr, eyre};
@@ -163,6 +165,7 @@ impl InProcessBuilder {
                 let api = BuilderApiImpl::<_, base_execution_txpool::TransactionValidity>::with_extensions(
                     ctx.pool().clone(),
                     accept_validity_transactions,
+                    DEFAULT_MAX_VALIDITY_PREDICATES,
                 );
                 ctx.modules.merge_configured(api.into_rpc())?;
                 Ok(())

--- a/etc/systems/src/l2/in_process_client.rs
+++ b/etc/systems/src/l2/in_process_client.rs
@@ -11,6 +11,7 @@ use base_execution_chainspec::BaseChainSpec;
 use base_execution_cli::{
     ExecutionUpgradeSignal, ExecutionUpgradeSignalConfig, ExecutionUpgradeSignalRuntimeExtension,
 };
+use base_execution_txpool::DEFAULT_MAX_VALIDITY_PREDICATES;
 use base_flashblocks::FlashblocksConfig;
 use base_flashblocks_node::FlashblocksExtension;
 use base_node_core::args::RollupArgs;
@@ -320,7 +321,9 @@ impl InProcessClient {
                 && tx_fwd_config.enabled
                 && !tx_fwd_config.builder_urls.is_empty()
             {
-                extensions.push(Box::new(SendRawTransactionValidityExtension::from_config(())));
+                extensions.push(Box::new(SendRawTransactionValidityExtension::from_config(
+                    DEFAULT_MAX_VALIDITY_PREDICATES,
+                )));
             }
             extensions.push(Box::new(TxForwardingExtension::from_config(tx_fwd_config.clone())));
         }


### PR DESCRIPTION
## Summary

Makes validity predicate limits configurable for both execution-node RPC ingress and builder RPC ingress while preserving the prior default of 64. Adds `--experimental-validity-max-predicates` and `--builder.experimental-validity-max-predicates`, and threads each value into validation at the appropriate boundary. Covers custom limits in RPC, CLI, builder integration, and forwarding tests. This follows up on the post-merge review feedback from #4339.