### PR TITLE
feat(devnet): add single-Anvil no-Nitro proof stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4460,6 +4460,7 @@ dependencies = [
  "base-common-consensus",
  "base-common-genesis",
  "base-common-rpc-types",
+ "base-protocol",
  "derive_more 2.1.1",
  "reth-chainspec",
  "reth-ethereum-forks",

--- a/Justfile
+++ b/Justfile
@@ -22,6 +22,8 @@ mod build 'etc/just/build.just'
 mod succinct 'etc/just/succinct.just'
 # Standalone user-funded prover stack (user RPCs + Succinct Network key)
 mod prover 'etc/just/prover.just'
+# Local no-Nitro proof stack for the single-Anvil L1 devnet
+mod anvil-no-nitro 'etc/just/anvil-no-nitro.just'
 # Prover-service JSON-RPC request helpers
 mod zk-prover 'etc/just/zk-prover.just'
 # Challenge / dispute helpers

--- a/bin/base/src/commands/reth.rs
+++ b/bin/base/src/commands/reth.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_cli::{
     chainspec::BaseChainSpecParser,
-    commands::{init_state, p2p},
+    commands::{GenesisOutputRootCommand, init_state, p2p},
 };
 use base_execution_consensus::BaseBeaconConsensus;
 use base_execution_evm::BaseExecutorProvider;
@@ -44,6 +44,9 @@ pub(crate) enum RethSubcommand {
     /// Dump genesis block JSON configuration to stdout.
     #[command(name = "dump-genesis")]
     DumpGenesis(dump_genesis::DumpGenesisCommand<BaseChainSpecParser>),
+    /// Print the OP Stack output root for an L2 genesis configuration.
+    #[command(name = "genesis-output-root")]
+    GenesisOutputRoot(GenesisOutputRootCommand),
     /// Manipulate individual stages.
     #[command(name = "stage")]
     Stage(Box<stage::Command<BaseChainSpecParser>>),
@@ -81,6 +84,10 @@ impl RethSubcommand {
             Self::DumpGenesis(command) => {
                 let runner = CliRunner::try_default_runtime()?;
                 runner.run_blocking_until_ctrl_c(command.execute())
+            }
+            Self::GenesisOutputRoot(command) => {
+                command.execute();
+                Ok(())
             }
             Self::Stage(command) => {
                 let runner = CliRunner::try_default_runtime()?;

--- a/bin/base/src/config.rs
+++ b/bin/base/src/config.rs
@@ -257,8 +257,8 @@ mod tests {
                 ChainResolver::new(Some(ChainArg::BuiltIn("dev".to_owned()))).resolve().unwrap();
 
             assert_eq!(resolved.name, "dev");
-            assert_eq!(resolved.l2_chain_id, 1337);
-            assert_eq!(resolved.l1_chain_id, 900);
+            assert_eq!(resolved.l2_chain_id, 84538453);
+            assert_eq!(resolved.l1_chain_id, 1337);
             assert_eq!(resolved.source, ResolvedChainSource::BuiltIn("dev".to_owned()));
 
             Ok(())

--- a/crates/common/chains/src/config.rs
+++ b/crates/common/chains/src/config.rs
@@ -153,6 +153,13 @@ pub const SEPOLIA_BERYL_ACTIVATION_ADMIN_ADDRESS: Address =
 pub const ZERONET_BERYL_ACTIVATION_ADMIN_ADDRESS: Address =
     address!("F5969A85a555671EeD766C4ff0C61426AA626b11");
 
+/// Local Docker devnet activation registry admin used by Beryl before Cobalt state-backed storage.
+///
+/// Matches `L2_ACTIVATION_ADMIN_ADDR` in `etc/scripts/devnet/setup-l2.sh`, which defaults to the
+/// deterministic devnet sequencer address.
+pub const DEVNET_BERYL_ACTIVATION_ADMIN_ADDRESS: Address =
+    address!("9965507D1a55bcC2695C58ba16FB37d819B0A4dc");
+
 impl ChainConfig {
     /// CLI chain name for Base Mainnet.
     pub const MAINNET_NAME: &'static str = "base";
@@ -249,7 +256,7 @@ impl ChainConfig {
         match id {
             8453 => Some(&MAINNET),
             84532 => Some(&SEPOLIA),
-            1337 => Some(&DEVNET),
+            84538453 => Some(&DEVNET),
             763360 => Some(&ZERONET),
             _ => None,
         }
@@ -282,6 +289,7 @@ impl ChainConfig {
             8453 => Some(MAINNET_BERYL_ACTIVATION_ADMIN_ADDRESS),
             84532 => Some(SEPOLIA_BERYL_ACTIVATION_ADMIN_ADDRESS),
             763360 => Some(ZERONET_BERYL_ACTIVATION_ADMIN_ADDRESS),
+            84538453 => Some(DEVNET_BERYL_ACTIVATION_ADMIN_ADDRESS),
             _ => None,
         }
     }
@@ -542,8 +550,8 @@ const SEPOLIA: ChainConfig = ChainConfig {
 };
 
 const DEVNET: ChainConfig = ChainConfig {
-    chain_id: 1337,
-    l1_chain_id: 900,
+    chain_id: 84538453,
+    l1_chain_id: 1337,
 
     block_time: 2,
     seq_window_size: 3600,
@@ -754,6 +762,10 @@ mod tests {
         assert_eq!(
             ChainConfig::activation_admin_address_for_upgrade_by_chain_id(84532, BaseUpgrade::Azul),
             None
+        );
+        assert_eq!(
+            ChainConfig::beryl_activation_admin_address_by_chain_id(84538453),
+            Some(DEVNET_BERYL_ACTIVATION_ADMIN_ADDRESS)
         );
     }
 }

--- a/crates/common/chains/src/ethereum/config.rs
+++ b/crates/common/chains/src/ethereum/config.rs
@@ -5,11 +5,12 @@ use alloy_genesis::ChainConfig as GenesisChainConfig;
 use alloy_primitives::map::HashMap;
 use spin::Lazy;
 
-use crate::{Holesky, Hoodi, Mainnet, Sepolia};
+use crate::{Devnet, Holesky, Hoodi, Mainnet, Sepolia};
 
 /// Ethereum L1 chain configurations keyed by chain ID.
 pub static L1_CONFIGS: Lazy<HashMap<u64, GenesisChainConfig>> = Lazy::new(|| {
     let mut map = HashMap::default();
+    map.insert(Devnet::CHAIN_ID, Devnet::l1_config());
     map.insert(NamedChain::Mainnet.into(), Mainnet::l1_config());
     map.insert(NamedChain::Sepolia.into(), Sepolia::l1_config());
     map.insert(NamedChain::Holesky.into(), Holesky::l1_config());
@@ -28,16 +29,26 @@ mod tests {
 
     #[test]
     fn l1_config_all_chains() {
+        let devnet_chain_id = Devnet::CHAIN_ID;
         let mainnet_chain_id = u64::from(NamedChain::Mainnet);
         let sepolia_chain_id = u64::from(NamedChain::Sepolia);
         let holesky_chain_id = u64::from(NamedChain::Holesky);
         let hoodi_chain_id = u64::from(NamedChain::Hoodi);
 
+        assert!(L1_CONFIGS.get(&devnet_chain_id).is_some());
         assert!(L1_CONFIGS.get(&mainnet_chain_id).is_some());
         assert!(L1_CONFIGS.get(&sepolia_chain_id).is_some());
         assert!(L1_CONFIGS.get(&holesky_chain_id).is_some());
         assert!(L1_CONFIGS.get(&hoodi_chain_id).is_some());
         assert!(L1_CONFIGS.get(&99999).is_none());
+    }
+
+    #[test]
+    fn devnet_rollup_l1_config_resolves() {
+        let rollup_config = crate::rollup_config!(crate::ChainConfig::devnet().chain_id).unwrap();
+        let l1_config = L1_CONFIGS.get(&rollup_config.l1_chain_id).unwrap();
+
+        assert_eq!(l1_config.chain_id, Devnet::CHAIN_ID);
     }
 
     #[test]

--- a/crates/common/chains/src/ethereum/devnet.rs
+++ b/crates/common/chains/src/ethereum/devnet.rs
@@ -1,0 +1,74 @@
+//! Ethereum L1 configuration for the local Docker devnet.
+
+use alloy_genesis::ChainConfig;
+use alloy_primitives::U256;
+
+/// Local Docker devnet L1 chain configuration builder.
+#[derive(Debug, Clone, Copy)]
+pub struct Devnet;
+
+impl Devnet {
+    /// Local Docker devnet L1 chain ID.
+    pub const CHAIN_ID: u64 = 1337;
+
+    /// Returns the local Docker devnet L1 [`ChainConfig`].
+    pub fn l1_config() -> ChainConfig {
+        ChainConfig {
+            chain_id: Self::CHAIN_ID,
+            homestead_block: Some(0),
+            dao_fork_block: None,
+            dao_fork_support: false,
+            eip150_block: Some(0),
+            eip155_block: Some(0),
+            eip158_block: Some(0),
+            byzantium_block: Some(0),
+            constantinople_block: Some(0),
+            petersburg_block: Some(0),
+            istanbul_block: Some(0),
+            muir_glacier_block: None,
+            berlin_block: Some(0),
+            london_block: Some(0),
+            arrow_glacier_block: Some(0),
+            gray_glacier_block: Some(0),
+            shanghai_time: Some(0),
+            cancun_time: Some(0),
+            prague_time: Some(0),
+            osaka_time: Some(0),
+            amsterdam_time: None,
+            bpo1_time: Some(0),
+            bpo2_time: Some(0),
+            bpo3_time: None,
+            bpo4_time: None,
+            bpo5_time: None,
+            ethash: None,
+            blob_schedule: super::BlobSchedule::schedule(),
+            merge_netsplit_block: None,
+            terminal_total_difficulty: Some(U256::ZERO),
+            deposit_contract_address: None,
+            clique: None,
+            parlia: None,
+            extra_fields: Default::default(),
+            terminal_total_difficulty_passed: false,
+            _non_exhaustive: (),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_matches_docker_devnet_genesis() {
+        let config = Devnet::l1_config();
+
+        assert_eq!(config.chain_id, Devnet::CHAIN_ID);
+        assert_eq!(config.shanghai_time, Some(0));
+        assert_eq!(config.cancun_time, Some(0));
+        assert_eq!(config.prague_time, Some(0));
+        assert_eq!(config.osaka_time, Some(0));
+        assert_eq!(config.bpo1_time, Some(0));
+        assert_eq!(config.bpo2_time, Some(0));
+        assert_eq!(config.blob_schedule, super::super::BlobSchedule::schedule());
+    }
+}

--- a/crates/common/chains/src/ethereum/mod.rs
+++ b/crates/common/chains/src/ethereum/mod.rs
@@ -7,6 +7,9 @@ use alloc::{
 
 use alloy_eips::eip7840::BlobParams;
 
+mod devnet;
+pub use devnet::Devnet;
+
 mod mainnet;
 pub use mainnet::Mainnet;
 

--- a/crates/common/chains/src/lib.rs
+++ b/crates/common/chains/src/lib.rs
@@ -7,8 +7,9 @@ extern crate alloc;
 
 mod config;
 pub use config::{
-    Bootnodes, ChainConfig, MAINNET_BERYL_ACTIVATION_ADMIN_ADDRESS,
-    SEPOLIA_BERYL_ACTIVATION_ADMIN_ADDRESS, ZERONET_BERYL_ACTIVATION_ADMIN_ADDRESS,
+    Bootnodes, ChainConfig, DEVNET_BERYL_ACTIVATION_ADMIN_ADDRESS,
+    MAINNET_BERYL_ACTIVATION_ADMIN_ADDRESS, SEPOLIA_BERYL_ACTIVATION_ADMIN_ADDRESS,
+    ZERONET_BERYL_ACTIVATION_ADMIN_ADDRESS,
 };
 
 mod upgrade;
@@ -24,7 +25,7 @@ mod macros;
 pub use macros::RollupConfigSource;
 
 mod ethereum;
-pub use ethereum::{Holesky, Hoodi, L1_CONFIGS, Mainnet, Sepolia};
+pub use ethereum::{Devnet, Holesky, Hoodi, L1_CONFIGS, Mainnet, Sepolia};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;

--- a/crates/execution/chainspec/Cargo.toml
+++ b/crates/execution/chainspec/Cargo.toml
@@ -30,6 +30,7 @@ alloy-hardforks.workspace = true
 alloy-primitives.workspace = true
 
 # op
+base-protocol.workspace = true
 base-common-rpc-types.workspace = true
 base-common-genesis = { workspace = true, features = ["std"] }
 
@@ -56,6 +57,7 @@ std = [
 	"base-common-consensus/std",
 	"base-common-genesis/std",
 	"base-common-rpc-types/std",
+	"base-protocol/std",
 	"derive_more/std",
 	"reth-chainspec/std",
 	"reth-ethereum-forks/std",

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -1,7 +1,7 @@
 use alloc::{boxed::Box, sync::Arc, vec, vec::Vec};
 
 use alloy_chains::Chain;
-use alloy_consensus::{BlockHeader, Header, proofs::storage_root_unhashed};
+use alloy_consensus::{BlockHeader, EMPTY_ROOT_HASH, Header, proofs::storage_root_unhashed};
 use alloy_eips::eip7840::BlobParams;
 use alloy_genesis::Genesis;
 use alloy_hardforks::Hardfork;
@@ -11,6 +11,7 @@ use base_common_consensus::Predeploys;
 use base_common_genesis::{
     BaseUpgrade, RuntimeUpgradeRegistry, UpgradeActivation, UpgradeActivationSink,
 };
+use base_protocol::OutputRoot;
 use derive_more::{Constructor, Deref, Into};
 use reth_chainspec::{
     BaseFeeParams, BaseFeeParamsKind, ChainSpec, DepositContract, DisplayHardforks, EthChainSpec,
@@ -266,16 +267,38 @@ impl BaseChainSpec {
         let mut header = reth_chainspec::make_genesis_header(genesis, upgrades);
 
         if upgrades.fork(BaseUpgrade::Isthmus).active_at_timestamp(header.timestamp)
-            && let Some(predeploy) = genesis.alloc.get(&Predeploys::L2_TO_L1_MESSAGE_PASSER)
-            && let Some(storage) = &predeploy.storage
+            && let Some(storage_root) = Self::l2_to_l1_message_passer_storage_root(genesis)
         {
-            header.withdrawals_root =
-                Some(storage_root_unhashed(storage.iter().filter_map(|(k, v)| {
-                    if v.is_zero() { None } else { Some((*k, (*v).into())) }
-                })));
+            header.withdrawals_root = Some(storage_root);
         }
 
         header
+    }
+
+    /// Computes the storage root of the genesis `L2ToL1MessagePasser`, if configured.
+    pub fn l2_to_l1_message_passer_storage_root(genesis: &Genesis) -> Option<B256> {
+        genesis
+            .alloc
+            .get(&Predeploys::L2_TO_L1_MESSAGE_PASSER)
+            .and_then(|account| account.storage.as_ref())
+            .map(|storage| {
+                storage_root_unhashed(storage.iter().filter_map(|(key, value)| {
+                    if value.is_zero() { None } else { Some((*key, (*value).into())) }
+                }))
+            })
+    }
+
+    /// Computes the V0 output root for this chain's genesis block.
+    pub fn genesis_output_root(&self) -> B256 {
+        let bridge_storage_root =
+            Self::l2_to_l1_message_passer_storage_root(&self.genesis).unwrap_or(EMPTY_ROOT_HASH);
+
+        OutputRoot::from_parts(
+            self.genesis_header().state_root,
+            bridge_storage_root,
+            self.genesis_hash(),
+        )
+        .hash()
     }
 
     /// Parses a chain name into an [`BaseChainSpec`], if recognized.
@@ -709,6 +732,14 @@ mod tests {
         assert_ne!(root_origin, root_fix);
         assert_eq!(root_origin, origin_root);
         assert_eq!(root_fix, expected_root);
+    }
+
+    #[test]
+    fn devnet_genesis_output_root() {
+        assert_eq!(
+            BaseChainSpec::devnet().genesis_output_root(),
+            b256!("14dabde8a7b90e1c258c03b239c69567baf19bad7eccf4e59c6c720e6787e7fe")
+        );
     }
 
     #[test]

--- a/crates/execution/cli/src/commands/genesis_output_root.rs
+++ b/crates/execution/cli/src/commands/genesis_output_root.rs
@@ -1,0 +1,23 @@
+//! Command that prints the OP Stack output root for an L2 genesis configuration.
+
+use std::sync::Arc;
+
+use base_execution_chainspec::BaseChainSpec;
+use clap::Parser;
+
+use crate::chainspec::chain_value_parser;
+
+/// Prints the V0 output root for a Base genesis configuration.
+#[derive(Debug, Parser)]
+pub struct GenesisOutputRootCommand {
+    /// Built-in chain name or path to a genesis JSON file.
+    #[arg(long, value_parser = chain_value_parser)]
+    pub chain: Arc<BaseChainSpec>,
+}
+
+impl GenesisOutputRootCommand {
+    /// Computes and prints the genesis output root.
+    pub fn execute(self) {
+        println!("{}", self.chain.genesis_output_root());
+    }
+}

--- a/crates/execution/cli/src/commands/mod.rs
+++ b/crates/execution/cli/src/commands/mod.rs
@@ -16,6 +16,8 @@ use crate::chainspec::BaseChainSpecParser;
 
 pub mod base_proofs;
 pub mod download;
+mod genesis_output_root;
+pub use genesis_output_root::GenesisOutputRootCommand;
 pub mod init_state;
 pub mod p2p;
 

--- a/crates/infra/load-tests/src/runner/config.rs
+++ b/crates/infra/load-tests/src/runner/config.rs
@@ -243,7 +243,7 @@ impl LoadConfig {
             ],
             query_rpc: "http://localhost:8545".parse().expect("valid default query_rpc"),
             txpool_nodes: Vec::new(),
-            chain_id: 1337,
+            chain_id: 84538453,
             account_count: 10,
             seed: 42,
             mnemonic: None,

--- a/crates/proof/tee/nitro-enclave/src/server.rs
+++ b/crates/proof/tee/nitro-enclave/src/server.rs
@@ -344,8 +344,8 @@ mod tests {
             b256!("12e9c45f19f9817c6d4385fad29e7a70c355502cf0883e76a9a7e478a85d1360"),
         );
         assert_eq!(
-            config_hash_for_chain(1337).unwrap(),
-            b256!("1bb15c380e7cf5cfd303807cc1dff6cd5275a6facc7628091d8b3a7ab6d631b1"),
+            config_hash_for_chain(84538453).unwrap(),
+            b256!("846b1fd10a5e22fb7572cc4ac794454d301b382c64ab934091e519486e5200be"),
         );
         assert_eq!(
             config_hash_for_chain(763360).unwrap(),

--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -3,6 +3,7 @@ set working-directory := '../..'
 
 _ha := "-f etc/docker/docker-compose.yml -f etc/docker/docker-compose.ha.yml"
 _base := "-f etc/docker/docker-compose.yml"
+_anvil := "-f etc/docker/docker-compose.yml -f etc/docker/docker-compose.anvil-l1.yml"
 _env := "--env-file etc/docker/devnet-env"
 
 # Show devnet commands
@@ -16,6 +17,53 @@ up mode='default':
 # Stops devnet, deletes data, and starts fresh with a single sequencer (no conductor)
 up-single mode='default':
     just --justfile {{ source_file() }} _up-devnet "base" {{ quote(mode) }}
+
+# Starts the single-Anvil L1 devnet and its two-worker local no-Nitro proof stack
+up-anvil-no-nitro: down-anvil _build-setup-image (_build-rust-images "devnet" "dev")
+    #!/usr/bin/env bash
+    set -euo pipefail
+    l1_rpc_url="http://l1-el:${L1_HTTP_PORT}"
+    export L1_CONTAINER_BEACON_URL="$l1_rpc_url"
+    compose_cmd=(docker compose {{ _env }} {{ _anvil }})
+
+    "${compose_cmd[@]}" up -d --no-build --remove-orphans setup-l1 l1-el
+    until cast block-number --rpc-url "$L1_RPC_URL" >/dev/null 2>&1; do
+      sleep 0.25
+    done
+    cast rpc --rpc-url "$L1_RPC_URL" anvil_setBlockTimestampInterval 4 >/dev/null
+    cast rpc --rpc-url "$L1_RPC_URL" anvil_setIntervalMining 4 >/dev/null
+    mkdir -p .devnet/l2/configs
+    "${compose_cmd[@]}" up -d --no-build --remove-orphans setup-l2
+    setup_l2_status="$(docker wait setup-l2)"
+    if [ "$setup_l2_status" != "0" ]; then
+      docker logs setup-l2 >&2 || true
+      exit "$setup_l2_status"
+    fi
+
+    UPGRADE_SIGNAL_CONTAINER_L1_RPC="$l1_rpc_url" \
+      ./etc/scripts/devnet/anvil-no-nitro.sh bootstrap
+    "${compose_cmd[@]}" up -d --no-build --remove-orphans
+    # base-client/base-rpc/base-builder read upgrade-signal.env once at container
+    # start. If any of them were already running (e.g. left over from a prior
+    # partial run), the `up` above leaves them untouched with whatever value
+    # they booted with, which can predate the file bootstrap just wrote.
+    # Force-recreate them so they always boot off the final file.
+    "${compose_cmd[@]}" up -d --no-build --force-recreate base-client base-rpc base-builder
+    ./etc/scripts/devnet/anvil-no-nitro.sh up
+
+# Stops the single-Anvil L1 devnet, proof workers, and all of their data
+down-anvil:
+    -./etc/scripts/devnet/anvil-no-nitro.sh down
+    -docker compose {{ _env }} {{ _anvil }} --profile profiling down
+    -docker run --rm -v "$(pwd)/.devnet:/devnet" alpine sh -c 'rm -rf /devnet/*'
+
+# Builds the latest Base-Anvil default branch used by the no-Nitro devnet
+build-anvil-image source='https://github.com/base/base-anvil.git':
+    docker buildx build --load \
+      --tag base-anvil:prover-single-l1 \
+      --build-arg RUST_PROFILE=release \
+      --build-arg RUST_FEATURES=anvil/cli \
+      {{ quote(source) }}
 
 # Stops devnet, deletes data, and starts fresh with profiling (Pyroscope + optimized builds)
 profiling: down _build-setup-image (_build-rust-images "devnet" "profiling")

--- a/etc/docker/README.md
+++ b/etc/docker/README.md
@@ -37,6 +37,38 @@ just devnet logs   # Stream logs from all containers
 just devnet status # Check block numbers and sync status
 ```
 
+### Single-Anvil L1 no-Nitro proving
+
+The optional single-Anvil variant replaces the Reth execution node and both
+Lighthouse processes with one Base-Anvil process. It keeps the L2 and batcher
+unchanged, and uses the same Anvil endpoint for L1 execution, Beacon blob
+fetching, proof inputs, and proof contracts.
+
+First build the latest Base-Anvil default branch, then start the complete stack:
+
+```bash
+just devnet build-anvil-image
+just devnet up-anvil-no-nitro
+```
+
+The second command generates the L2 genesis, computes its output root offline,
+then clones the latest base/contracts default branch and deploys the development
+no-Nitro contracts before any L2 node starts. The Base nodes and proof verifier
+therefore use the same real `ProtocolVersions` contract from genesis; this path
+does not deploy the normal devnet's mock upgrade-signal contract. It then starts
+a fresh prover database, registers and starts two Nitro workers in local mode,
+and starts the proposer. Inspect or stop it with:
+
+```bash
+just anvil-no-nitro status
+just anvil-no-nitro logs
+just devnet down-anvil
+```
+
+Anvil mines one block every four seconds. Do not use timestamp-warp RPCs in
+this variant: Base derives Beacon slots from L1 timestamps, so arbitrary time
+jumps would break the one-slot-per-execution-block mapping used to fetch blobs.
+
 Denim is activated at block 23 by default, switching the sequencer to its 200ms cadence. To
 start a pre-Denim devnet, set `L2_BASE_DENIM_BLOCK` to an empty value:
 

--- a/etc/docker/devnet-env
+++ b/etc/docker/devnet-env
@@ -143,6 +143,7 @@ SEQ2_P2P_KEY=47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a
 L1_RPC_URL=http://localhost:4545
 L1_WS_URL=ws://localhost:4546
 L1_BEACON_URL=http://localhost:4052
+L1_CONTAINER_BEACON_URL=http://l1-cl:4052
 L2_BUILDER_RPC_URL=http://localhost:7545
 L2_BUILDER_WS_URL=ws://localhost:7546
 L2_BUILDER_OP_RPC_URL=http://localhost:7549

--- a/etc/docker/docker-compose.anvil-l1.yml
+++ b/etc/docker/docker-compose.anvil-l1.yml
@@ -1,0 +1,33 @@
+services:
+  # Reuse the l1-el service name so setup-l2 keeps its existing dependency and
+  # all execution RPC callers share one endpoint. This Anvil also serves the
+  # Beacon REST API used for blob derivation.
+  l1-el:
+    image: ${BASE_ANVIL_IMAGE:-base-anvil:prover-single-l1}
+    entrypoint: ["/usr/local/bin/anvil"]
+    command:
+      - --host=0.0.0.0
+      - --port=${L1_HTTP_PORT}
+      - --init=/genesis/el/genesis.json
+      - --no-mining
+      - --slots-in-an-epoch=1
+    ports: !override
+      - "${L1_HTTP_PORT}:${L1_HTTP_PORT}"
+      - "${L1_WS_PORT}:${L1_HTTP_PORT}"
+      - "${L1_CL_HTTP_PORT}:${L1_HTTP_PORT}"
+    volumes: !override
+      - ../../.devnet/l1/configs:/genesis:ro
+
+  # These services remain available in the normal devnet but are omitted from
+  # the single-Anvil variant unless explicitly enabled.
+  l1-cl:
+    profiles: ["lighthouse-l1"]
+
+  l1-vc:
+    profiles: ["lighthouse-l1"]
+
+  # Compose starts completed dependencies again when the remaining services
+  # come up. Keep the genesis used by pre-L2 no-Nitro contract deployment.
+  setup-l2:
+    environment:
+      - SETUP_L2_SKIP_IF_CONFIGURED=true

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -324,7 +324,7 @@ services:
       - --l1-eth-rpc
       - http://l1-el:${L1_HTTP_PORT}
       - --l1-beacon
-      - http://l1-cl:${L1_CL_HTTP_PORT}
+      - ${L1_CONTAINER_BEACON_URL}
       - --l2-config-file
       - /genesis/l2/rollup.json
       - --l1-config-file
@@ -483,7 +483,7 @@ services:
       - --l1-eth-rpc
       - http://l1-el:${L1_HTTP_PORT}
       - --l1-beacon
-      - http://l1-cl:${L1_CL_HTTP_PORT}
+      - ${L1_CONTAINER_BEACON_URL}
       - --l2-config-file
       - /genesis/l2/rollup.json
       - --l1-config-file
@@ -583,7 +583,7 @@ services:
       - --l1-eth-rpc
       - http://l1-el:${L1_HTTP_PORT}
       - --l1-beacon
-      - http://l1-cl:${L1_CL_HTTP_PORT}
+      - ${L1_CONTAINER_BEACON_URL}
       - --l2-config-file
       - /genesis/l2/rollup.json
       - --l1-config-file

--- a/etc/just/anvil-no-nitro.just
+++ b/etc/just/anvil-no-nitro.just
@@ -1,0 +1,22 @@
+set positional-arguments := true
+set working-directory := '../..'
+
+# Show local no-Nitro proof-stack commands
+default:
+    @just --justfile {{ source_file() }} --list --list-prefix '  anvil-no-nitro::'
+
+# Starts a fresh single-Anvil devnet with no-Nitro contracts, workers, and proposer
+up:
+    just devnet up-anvil-no-nitro
+
+# Stops proof daemons and removes their fresh Postgres container
+down:
+    ./etc/scripts/devnet/anvil-no-nitro.sh down
+
+# Prints contract, signer, worker, L2-finality, and latest-game status
+status:
+    ./etc/scripts/devnet/anvil-no-nitro.sh status
+
+# Tails prover-service, Nitro worker, and proposer logs
+logs:
+    ./etc/scripts/devnet/anvil-no-nitro.sh logs

--- a/etc/scripts/devnet/anvil-no-nitro.sh
+++ b/etc/scripts/devnet/anvil-no-nitro.sh
@@ -1,0 +1,629 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+set -a
+# shellcheck source=../../docker/devnet-env
+# shellcheck disable=SC1091
+source "$REPO_ROOT/etc/docker/devnet-env"
+set +a
+
+STATE_DIR="$REPO_ROOT/.devnet/anvil-no-nitro"
+LOG_DIR="$STATE_DIR/logs"
+PID_DIR="$STATE_DIR/pids"
+ADDRESSES_FILE="$STATE_DIR/addresses.json"
+ROLLUP_CONFIG="$STATE_DIR/rollup.json"
+L2_CONFIG_DIR="$REPO_ROOT/.devnet/l2/configs"
+L2_GENESIS="$L2_CONFIG_DIR/genesis.json"
+GENERATED_ROLLUP_CONFIG="$L2_CONFIG_DIR/rollup.json"
+UPGRADE_SIGNAL_ENV="$L2_CONFIG_DIR/upgrade-signal.env"
+
+L1_RPC="$L1_RPC_URL"
+L1_BEACON_RPC="$L1_BEACON_URL"
+L2_ETH_RPC="$L2_BASE_RPC_URL"
+L2_NODE_RPC="$L2_BASE_RPC_OP_RPC_URL"
+L1_CHAIN_ID_VALUE="$L1_CHAIN_ID"
+L2_CHAIN_ID_VALUE="$L2_CHAIN_ID"
+CONTAINER_L1_RPC="${UPGRADE_SIGNAL_CONTAINER_L1_RPC:-http://l1-el:$L1_HTTP_PORT}"
+MIN_PROTOCOL_VERSION="${UPGRADE_SIGNAL_MIN_PROTOCOL_VERSION:-4294967296}"
+
+CONTRACTS_REPO="https://github.com/base/contracts.git"
+CONTRACTS_DIR="$STATE_DIR/contracts"
+GAME_TYPE="621"
+TEE_IMAGE_HASH="0x0000000000000000000000000000000000000000000000000000000000000000"
+NO_NITRO_CONFIG_HASH="0x846b1fd10a5e22fb7572cc4ac794454d301b382c64ab934091e519486e5200be"
+NITRO_PROVERS="2"
+
+POSTGRES_CONTAINER="anvil-no-nitro-postgres"
+POSTGRES_PORT="15433"
+PROVER_SERVICE_RPC_PORT="19000"
+PROVER_SERVICE_WORKER_RPC_PORT="19001"
+PROPOSER_HEALTH_PORT="18080"
+PROVER_SERVICE_RPC="http://localhost:$PROVER_SERVICE_RPC_PORT"
+PROVER_SERVICE_WORKER_RPC="http://localhost:$PROVER_SERVICE_WORKER_RPC_PORT"
+
+OWNER_ADDR="$DEPLOYER_ADDR"
+OWNER_KEY="$DEPLOYER_KEY"
+TEE_PROPOSER_KEY="$PROPOSER_KEY"
+TEE_PROPOSER_ADDR="$PROPOSER_ADDR"
+TEE_CHALLENGER_ADDR="$CHALLENGER_ADDR"
+
+DAEMON_NAMES=()
+FORK_NAMES=()
+
+usage() {
+  cat <<'EOF'
+Usage: anvil-no-nitro.sh <bootstrap|up|down|status|logs>
+
+Runs the no-Nitro contract and proof stack against the Docker devnet whose
+execution and Beacon L1 APIs are both served by one Base-Anvil process.
+
+The devnet startup calls bootstrap before starting L2 nodes, then calls up
+after the L2 is available. Use `just devnet up-anvil-no-nitro` to run both.
+EOF
+}
+
+require_tools() {
+  local tool
+  for tool in "$@"; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      echo "ERROR: '$tool' is required" >&2
+      exit 1
+    fi
+  done
+}
+
+first_word() {
+  awk 'NR == 1 { gsub(/[(),]/, "", $1); print $1 }'
+}
+
+call_first() {
+  cast call "$@" --rpc-url "$L1_RPC" | first_word
+}
+
+owner_send() {
+  local receipt
+  receipt=$(cast send --private-key "$OWNER_KEY" --rpc-url "$L1_RPC" --json "$@")
+  if ! jq -e '.status == "0x1" or .status == "1" or .status == 1' <<<"$receipt" >/dev/null; then
+    jq -r '"ERROR: transaction \(.transactionHash) reverted with status \(.status)"' \
+      <<<"$receipt" >&2
+    return 1
+  fi
+  jq -r '"tx: \(.transactionHash) block=\(.blockNumber) status=\(.status)"' <<<"$receipt"
+}
+
+address_value() {
+  local key="$1" value
+  value=$(jq -r --arg key "$key" '.[$key] // empty' "$ADDRESSES_FILE")
+  if [ -z "$value" ]; then
+    echo "ERROR: missing $key in $ADDRESSES_FILE" >&2
+    exit 1
+  fi
+  echo "$value"
+}
+
+prover_signer_key() {
+  printf '0x%064x' "$1"
+}
+
+prover_signer_address() {
+  cast wallet address --private-key "$(prover_signer_key "$1")"
+}
+
+cargo_native_env() {
+  local lz4_prefix cpath="${CPATH:-}" library_path="${LIBRARY_PATH:-}"
+  if command -v brew >/dev/null 2>&1; then
+    lz4_prefix=$(brew --prefix lz4 2>/dev/null || true)
+    if [ -n "$lz4_prefix" ] && [ -f "$lz4_prefix/include/lz4.h" ]; then
+      cpath="${cpath:+$cpath:}$lz4_prefix/include"
+      library_path="${library_path:+$library_path:}$lz4_prefix/lib"
+    fi
+  fi
+  printf 'CPATH=%s\nLIBRARY_PATH=%s\n' "$cpath" "$library_path"
+}
+
+run_with_native_env() {
+  local item env_args=()
+  while IFS= read -r item; do
+    env_args+=("$item")
+  done < <(cargo_native_env)
+  env "${env_args[@]}" "$@"
+}
+
+preflight_l1() {
+  local chain_id seconds_per_slot genesis_time latest_block block_number_hex block_timestamp_hex
+  local block_number block_timestamp slot
+  chain_id=$(cast chain-id --rpc-url "$L1_RPC")
+  if [ "$chain_id" != "$L1_CHAIN_ID_VALUE" ]; then
+    echo "ERROR: L1 chain ID is $chain_id, expected $L1_CHAIN_ID_VALUE" >&2
+    exit 1
+  fi
+
+  seconds_per_slot=$(curl -fsS "$L1_BEACON_RPC/eth/v1/config/spec" | jq -r '.data.SECONDS_PER_SLOT')
+  if [ "$seconds_per_slot" != "4" ]; then
+    echo "ERROR: Base-Anvil reports SECONDS_PER_SLOT=$seconds_per_slot, expected 4" >&2
+    exit 1
+  fi
+
+  genesis_time=$(curl -fsS "$L1_BEACON_RPC/eth/v1/beacon/genesis" |
+    jq -er '.data.genesis_time')
+  latest_block=$(cast rpc --rpc-url "$L1_RPC" eth_getBlockByNumber latest false)
+  block_number_hex=$(jq -er '.number' <<<"$latest_block")
+  block_timestamp_hex=$(jq -er '.timestamp' <<<"$latest_block")
+  block_number=$((block_number_hex))
+  block_timestamp=$((block_timestamp_hex))
+  slot=$(((block_timestamp - genesis_time) / seconds_per_slot))
+  if [ "$slot" != "$block_number" ]; then
+    echo "ERROR: L1 block $block_number maps to Beacon slot $slot; expected identical values" >&2
+    echo "       start the devnet with 'just devnet up-anvil-no-nitro'" >&2
+    exit 1
+  fi
+
+  cast rpc --rpc-url "$L1_RPC" debug_getRawHeader latest | jq -e 'type == "string"' >/dev/null
+  cast rpc --rpc-url "$L1_RPC" debug_getRawReceipts latest | jq -e 'type == "array"' >/dev/null
+}
+
+wait_for_l2() {
+  local deadline=$((SECONDS + 120))
+  until cast rpc optimism_syncStatus --rpc-url "$L2_NODE_RPC" >/dev/null 2>&1; do
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      echo "ERROR: L2 rollup RPC is unavailable at $L2_NODE_RPC" >&2
+      exit 1
+    fi
+    sleep 1
+  done
+}
+
+load_rollup_config() {
+  if [ ! -f "$GENERATED_ROLLUP_CONFIG" ]; then
+    echo "ERROR: generated rollup config not found: $GENERATED_ROLLUP_CONFIG" >&2
+    exit 1
+  fi
+  cp "$GENERATED_ROLLUP_CONFIG" "$ROLLUP_CONFIG"
+
+  local rollup_l1_chain_id
+  rollup_l1_chain_id=$(jq -r '.l1_chain_id' "$ROLLUP_CONFIG")
+  if [ "$rollup_l1_chain_id" != "$L1_CHAIN_ID_VALUE" ]; then
+    echo "ERROR: rollup L1 chain ID is $rollup_l1_chain_id, expected $L1_CHAIN_ID_VALUE" >&2
+    exit 1
+  fi
+}
+
+genesis_output_root() {
+  local root
+  if [ ! -f "$L2_GENESIS" ]; then
+    echo "ERROR: generated L2 genesis not found: $L2_GENESIS" >&2
+    exit 1
+  fi
+  root=$(docker run --rm \
+    -v "$L2_CONFIG_DIR:/config:ro" \
+    base:local reth genesis-output-root --chain /config/genesis.json)
+  if ! [[ "$root" =~ ^0x[0-9a-fA-F]{64}$ ]]; then
+    echo "ERROR: invalid L2 genesis output root: $root" >&2
+    exit 1
+  fi
+  echo "$root"
+}
+
+prepare_contracts() {
+  echo "Fetching the latest base/contracts default branch ..."
+  git clone --depth 1 --quiet "$CONTRACTS_REPO" "$CONTRACTS_DIR"
+
+  echo "Installing contract dependencies ..."
+  # Foundry 1.7 breaks nested submodules when --no-git removes each dependency's Git metadata.
+  sed -i.bak 's/forge install --no-git/forge install/' "$CONTRACTS_DIR/justfile"
+  (cd "$CONTRACTS_DIR" && just deps)
+  mv "$CONTRACTS_DIR/justfile.bak" "$CONTRACTS_DIR/justfile"
+}
+
+write_deploy_config() {
+  local anchor_block="$1" anchor_root="$2"
+  local source="$CONTRACTS_DIR/deploy-config/local.json"
+  local destination="$CONTRACTS_DIR/deploy-config/anvil-no-nitro.json"
+  local l2_block_time l2_genesis_block l2_genesis_time
+
+  l2_block_time=$(jq -er '.block_time' "$ROLLUP_CONFIG")
+  l2_genesis_block=$(jq -er '.genesis.l2.number' "$ROLLUP_CONFIG")
+  l2_genesis_time=$(jq -er '.genesis.l2_time' "$ROLLUP_CONFIG")
+
+  jq \
+    --arg owner "$OWNER_ADDR" \
+    --arg proposer "$TEE_PROPOSER_ADDR" \
+    --arg challenger "$TEE_CHALLENGER_ADDR" \
+    --arg anchorRoot "$anchor_root" \
+    --arg teeImageHash "$TEE_IMAGE_HASH" \
+    --arg configHash "$NO_NITRO_CONFIG_HASH" \
+    --argjson l2ChainId "$L2_CHAIN_ID_VALUE" \
+    --argjson gameType "$GAME_TYPE" \
+    --argjson anchorBlock "$anchor_block" \
+    --argjson l2BlockTime "$l2_block_time" \
+    --argjson l2GenesisBlockNumber "$l2_genesis_block" \
+    --argjson l2GenesisTimestamp "$l2_genesis_time" \
+    '.finalSystemOwner = $owner
+      | .teeProposer = $proposer
+      | .teeChallenger = $challenger
+      | .l2ChainId = $l2ChainId
+      | .multiproofGameType = $gameType
+      | .multiproofConfigHash = $configHash
+      | .multiproofGenesisBlockNumber = $anchorBlock
+      | .multiproofGenesisOutputRoot = $anchorRoot
+      | .teeImageHash = $teeImageHash
+      | .l2BlockTime = $l2BlockTime
+      | .l2GenesisBlockNumber = $l2GenesisBlockNumber
+      | .l2GenesisTimestamp = $l2GenesisTimestamp' \
+    "$source" >"$destination"
+}
+
+deploy_contracts() {
+  local anchor_block=0 anchor_root deployment verifier protocol_versions
+  anchor_root=$(genesis_output_root)
+  write_deploy_config "$anchor_block" "$anchor_root"
+  mkdir -p "$CONTRACTS_DIR/deployments"
+
+  echo "Deploying no-Nitro contracts at L2 anchor block $anchor_block ..."
+  (
+    cd "$CONTRACTS_DIR"
+    DEPLOY_CONFIG_PATH="$CONTRACTS_DIR/deploy-config/anvil-no-nitro.json" \
+      forge script scripts/multiproof/DeployDevNoNitro.s.sol \
+      --rpc-url "$L1_RPC" \
+      --broadcast \
+      --private-key "$OWNER_KEY"
+  )
+
+  deployment="$CONTRACTS_DIR/deployments/${L1_CHAIN_ID_VALUE}-dev-no-nitro.json"
+  test -f "$deployment"
+  verifier=$(jq -r '.AggregateVerifier' "$deployment")
+  protocol_versions=$(call_first "$verifier" "PROTOCOL_VERSIONS()(address)")
+  jq \
+    --arg protocolVersions "$protocol_versions" \
+    --arg anchorRoot "$anchor_root" \
+    --argjson gameType "$GAME_TYPE" \
+    --argjson anchorBlock "$anchor_block" \
+    '. + {
+      ProtocolVersions: $protocolVersions,
+      gameType: $gameType,
+      anchorBlock: $anchorBlock,
+      anchorRoot: $anchorRoot
+    }' "$deployment" >"$ADDRESSES_FILE"
+}
+
+load_fork_names() {
+  local names
+  names=$(cd "$REPO_ROOT" && cargo run --quiet -p base-upgrade-signal --bin contract_upgrade_ids)
+  IFS=, read -r -a FORK_NAMES <<<"$names"
+}
+
+rollup_timestamp() {
+  local name="$1" path
+  case "$name" in
+    azul | beryl | cobalt) path=".base.${name}" ;;
+    *) path=".${name}_time" ;;
+  esac
+  jq -r --arg path "$path" '
+    (getpath($path | ltrimstr(".") | split("."))) as $ts
+    | if $ts == null then 0
+      elif $ts == 0 then .genesis.l2_time
+      else $ts end' "$ROLLUP_CONFIG"
+}
+
+seed_protocol_versions() {
+  load_fork_names
+  local registry schedule id timestamp minimum actual_minimum
+  registry=$(address_value ProtocolVersions)
+  schedule=$(cast call --json "$registry" "getSchedule()(uint64[])" --rpc-url "$L1_RPC" |
+    jq -r '.[0] | length')
+  if [ "$schedule" != "0" ]; then
+    echo "ERROR: newly deployed ProtocolVersions schedule is not empty" >&2
+    exit 1
+  fi
+
+  echo "Registering ${#FORK_NAMES[@]} protocol upgrades ..."
+  for ((id = 0; id < ${#FORK_NAMES[@]}; id++)); do
+    timestamp=$(rollup_timestamp "${FORK_NAMES[$id]}")
+    minimum=0
+    [ "$id" -eq 0 ] && minimum="$MIN_PROTOCOL_VERSION"
+    owner_send "$registry" "registerUpgrade(uint64,uint256)" "$timestamp" "$minimum" >/dev/null
+    echo "  $id ${FORK_NAMES[$id]}=$timestamp"
+  done
+
+  actual_minimum=$(call_first "$registry" "minimumProtocolVersion()(uint256)")
+  if [ "$actual_minimum" != "$MIN_PROTOCOL_VERSION" ]; then
+    echo "ERROR: minimum protocol version is $actual_minimum, expected $MIN_PROTOCOL_VERSION" >&2
+    exit 1
+  fi
+}
+
+write_upgrade_signal_env() {
+  local registry
+  registry=$(address_value ProtocolVersions)
+  cat >"$UPGRADE_SIGNAL_ENV" <<EOF
+BASE_NODE_UPGRADE_SIGNAL_CONTRACT=$registry
+BASE_NODE_UPGRADE_SIGNAL_L1_RPC=$CONTAINER_L1_RPC
+BASE_NODE_UPGRADE_SIGNAL_MODE=runtime-admin
+BASE_NODE_UPGRADE_SIGNAL_L1_BLOCK_TAG=latest
+EOF
+}
+
+fresh_postgres() {
+  docker rm -f "$POSTGRES_CONTAINER" >/dev/null 2>&1 || true
+  docker run -d --name "$POSTGRES_CONTAINER" \
+    -p "$POSTGRES_PORT:5432" \
+    -e POSTGRES_DB=prover \
+    -e POSTGRES_USER=prover \
+    -e POSTGRES_PASSWORD=prover \
+    -v "$REPO_ROOT/crates/proof/prover-service/db/migrations:/docker-entrypoint-initdb.d:ro" \
+    postgres:17-alpine >/dev/null
+
+  local deadline=$((SECONDS + 60))
+  until docker exec "$POSTGRES_CONTAINER" pg_isready -U prover -d prover >/dev/null 2>&1; do
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      docker logs "$POSTGRES_CONTAINER" >&2
+      exit 1
+    fi
+    sleep 1
+  done
+}
+
+wait_for_prover_service() {
+  local deadline=$((SECONDS + 30))
+  until curl -sf -m 2 -X POST -H 'content-type: application/json' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"health","params":[]}' \
+    "$PROVER_SERVICE_RPC" | jq -e '.jsonrpc' >/dev/null 2>&1; do
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      echo "ERROR: prover-service did not start; see $LOG_DIR/prover-service.log" >&2
+      exit 1
+    fi
+    sleep 1
+  done
+}
+
+register_signer() {
+  local number="$1" registry signer
+  registry=$(address_value TEEProverRegistry)
+  signer=$(prover_signer_address "$number")
+  echo "Registering local Nitro signer $number: $signer"
+  owner_send "$registry" "addDevSigner(address,bytes32)" "$signer" "$TEE_IMAGE_HASH" >/dev/null
+}
+
+run_prover_service() {
+  exec env \
+    POSTGRES_HOST=localhost \
+    POSTGRES_PORT="$POSTGRES_PORT" \
+    POSTGRES_DB=prover \
+    POSTGRES_USER=prover \
+    POSTGRES_PASSWORD=prover \
+    POSTGRES_SSLMODE=disable \
+    "$REPO_ROOT/target/debug/base-prover-service" \
+    --rpc-listen-addr "127.0.0.1:$PROVER_SERVICE_RPC_PORT" \
+    --worker-rpc-listen-addr "127.0.0.1:$PROVER_SERVICE_WORKER_RPC_PORT"
+}
+
+run_nitro_local() {
+  local number="$1"
+  exec env BASE_ENCLAVE_SIGNER_KEY="$(prover_signer_key "$number")" \
+    "$REPO_ROOT/target/debug/base-prover-nitro-host" local \
+    --l1-eth-url "$L1_RPC" \
+    --l2-eth-url "$L2_ETH_RPC" \
+    --l2-node-url "$L2_NODE_RPC" \
+    --l1-beacon-url "$L1_BEACON_RPC" \
+    --l2-chain-id "$L2_CHAIN_ID_VALUE" \
+    --tee-prover-registry-address "$(address_value TEEProverRegistry)" \
+    --prover-service-endpoint "$PROVER_SERVICE_WORKER_RPC"
+}
+
+run_proposer() {
+  exec "$REPO_ROOT/target/debug/base-proposer" \
+    --prover-rpc "$PROVER_SERVICE_RPC" \
+    --l1-eth-rpc "$L1_RPC" \
+    --l2-eth-rpc "$L2_ETH_RPC" \
+    --rollup-rpc "$L2_NODE_RPC" \
+    --anchor-state-registry-addr "$(address_value AnchorStateRegistry)" \
+    --dispute-game-factory-addr "$(address_value DisputeGameFactory)" \
+    --game-type "$GAME_TYPE" \
+    --health.port "$PROPOSER_HEALTH_PORT" \
+    --private-key "$TEE_PROPOSER_KEY"
+}
+
+start_daemon() {
+  local name="$1"
+  shift
+  mkdir -p "$LOG_DIR" "$PID_DIR"
+  echo "Starting $name; log: $LOG_DIR/$name.log"
+  python3 -c 'import os, sys; os.setsid(); os.execv(sys.argv[1], sys.argv[1:])' \
+    "$SCRIPT_DIR/anvil-no-nitro.sh" "$@" >"$LOG_DIR/$name.log" 2>&1 &
+  echo $! >"$PID_DIR/$name.pid"
+}
+
+daemon_names() {
+  DAEMON_NAMES=()
+  local path
+  for path in "$PID_DIR"/*.pid; do
+    [ -f "$path" ] || continue
+    DAEMON_NAMES+=("$(basename "$path" .pid)")
+  done
+}
+
+stop_daemons() {
+  daemon_names
+  [ "${#DAEMON_NAMES[@]}" -gt 0 ] || return 0
+  local name pid
+  for name in "${DAEMON_NAMES[@]}"; do
+    pid=$(cat "$PID_DIR/$name.pid")
+    kill -TERM "-$pid" >/dev/null 2>&1 || kill -TERM "$pid" >/dev/null 2>&1 || true
+  done
+  sleep 2
+  for name in "${DAEMON_NAMES[@]}"; do
+    pid=$(cat "$PID_DIR/$name.pid")
+    kill -KILL "-$pid" >/dev/null 2>&1 || kill -KILL "$pid" >/dev/null 2>&1 || true
+    rm -f "$PID_DIR/$name.pid"
+  done
+}
+
+wait_for_proposal_target() {
+  local anchor target deadline block
+  anchor=$(jq -r '.anchorBlock' "$ADDRESSES_FILE")
+  target=$((anchor + 100))
+  deadline=$((SECONDS + 900))
+  echo "Waiting for finalized L2 block $target before starting proposer ..."
+  while true; do
+    block=$(cast rpc optimism_syncStatus --rpc-url "$L2_NODE_RPC" |
+      jq -r '.finalized_l2.number // .finalizedL2.number // 0')
+    if [[ "$block" =~ ^[0-9]+$ ]] && [ "$block" -ge "$target" ]; then
+      return
+    fi
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      echo "ERROR: finalized L2 did not reach $target within 15 minutes" >&2
+      exit 1
+    fi
+    sleep 2
+  done
+}
+
+cmd_bootstrap() {
+  require_tools cast forge jq git just docker cargo curl
+  stop_daemons
+  rm -rf "$STATE_DIR"
+  mkdir -p "$STATE_DIR"
+
+  preflight_l1
+  load_rollup_config
+  prepare_contracts
+  deploy_contracts
+  seed_protocol_versions
+  write_upgrade_signal_env
+
+  echo "No-Nitro contracts are anchored at L2 genesis."
+  echo "  ProtocolVersions: $(address_value ProtocolVersions)"
+  echo "  L2 output root:   $(address_value anchorRoot)"
+}
+
+cmd_up() {
+  require_tools cast jq docker cargo curl python3
+  if [ ! -f "$ADDRESSES_FILE" ] || [ ! -f "$ROLLUP_CONFIG" ] || [ ! -f "$UPGRADE_SIGNAL_ENV" ]; then
+    echo "ERROR: no bootstrapped no-Nitro devnet; run 'just devnet up-anvil-no-nitro'" >&2
+    exit 1
+  fi
+
+  preflight_l1
+  wait_for_l2
+
+  echo "Building local prover binaries ..."
+  run_with_native_env cargo build -p base-prover-service-bin --bin base-prover-service
+  run_with_native_env cargo build \
+    -p base-prover-nitro-host --bin base-prover-nitro-host --features local
+  run_with_native_env cargo build -p base-proposer-bin --bin base-proposer
+
+  fresh_postgres
+  start_daemon prover-service _prover-service
+  wait_for_prover_service
+
+  local number
+  for ((number = 1; number <= NITRO_PROVERS; number++)); do
+    register_signer "$number"
+  done
+  for ((number = 1; number <= NITRO_PROVERS; number++)); do
+    start_daemon "nitro-prover-$number" _nitro-local "$number"
+  done
+
+  wait_for_proposal_target
+  start_daemon proposer _proposer
+
+  echo ""
+  echo "Single-L1 no-Nitro stack is running."
+  echo "  L1 execution + Beacon: $L1_RPC / $L1_BEACON_RPC (chain $L1_CHAIN_ID_VALUE)"
+  echo "  L2 execution + rollup: $L2_ETH_RPC / $L2_NODE_RPC (chain $L2_CHAIN_ID_VALUE)"
+  echo "  TEE registry:           $(address_value TEEProverRegistry)"
+  echo "  Dispute game factory:   $(address_value DisputeGameFactory)"
+  echo "  Logs:                   $LOG_DIR"
+}
+
+cmd_down() {
+  stop_daemons
+  docker rm -f "$POSTGRES_CONTAINER" >/dev/null 2>&1 || true
+  echo "No-Nitro proof stack stopped."
+}
+
+cmd_status() {
+  echo "Daemons"
+  daemon_names
+  local name pid state number signer registry
+  if [ "${#DAEMON_NAMES[@]}" -eq 0 ]; then
+    echo "  none"
+  else
+    for name in "${DAEMON_NAMES[@]}"; do
+      pid=$(cat "$PID_DIR/$name.pid")
+      state=dead
+      kill -0 "$pid" >/dev/null 2>&1 && state=running
+      echo "  $name: $state (pid $pid)"
+    done
+  fi
+
+  echo ""
+  echo "L2 sync"
+  cast rpc optimism_syncStatus --rpc-url "$L2_NODE_RPC" |
+    jq '{unsafe_l2: .unsafe_l2.number, safe_l2: .safe_l2.number, finalized_l2: .finalized_l2.number}'
+
+  if [ ! -f "$ADDRESSES_FILE" ]; then
+    echo "No no-Nitro deployment found."
+    return
+  fi
+
+  echo ""
+  echo "Contracts"
+  jq -r 'to_entries[] | select(.value | type == "string") | "  \(.key): \(.value)"' \
+    "$ADDRESSES_FILE"
+
+  registry=$(address_value TEEProverRegistry)
+  echo ""
+  echo "Nitro signers"
+  for ((number = 1; number <= NITRO_PROVERS; number++)); do
+    signer=$(prover_signer_address "$number")
+    echo "  $signer registered=$(call_first "$registry" "isRegisteredSigner(address)(bool)" "$signer")"
+  done
+
+  local factory count
+  factory=$(address_value DisputeGameFactory)
+  count=$(call_first "$factory" "gameCount()(uint256)")
+  echo ""
+  echo "Dispute games: $count"
+  if [ "$count" -gt 0 ]; then
+    local latest_game
+    latest_game=$(cast call "$factory" "gameAtIndex(uint256)(uint32,uint64,address)" \
+      "$((count - 1))" --rpc-url "$L1_RPC" | awk 'NR == 3 { print $1 }')
+    echo "  latest: $latest_game"
+    echo "  target L2 block: $(call_first "$latest_game" "l2SequenceNumber()(uint256)")"
+    echo "  accepted proofs: $(call_first "$latest_game" "proofCount()(uint8)")"
+    echo "  TEE proposer: $(call_first "$latest_game" "teeProver()(address)")"
+  fi
+}
+
+cmd_logs() {
+  daemon_names
+  if [ "${#DAEMON_NAMES[@]}" -eq 0 ]; then
+    echo "No proof-stack logs found." >&2
+    exit 1
+  fi
+  local name files=()
+  for name in "${DAEMON_NAMES[@]}"; do
+    [ -f "$LOG_DIR/$name.log" ] && files+=("$LOG_DIR/$name.log")
+  done
+  if [ "${#files[@]}" -eq 0 ]; then
+    echo "No proof-stack logs found." >&2
+    exit 1
+  fi
+  exec tail -n 50 -F "${files[@]}"
+}
+
+case "${1:-}" in
+  bootstrap) cmd_bootstrap ;;
+  up) cmd_up ;;
+  down) cmd_down ;;
+  status) cmd_status ;;
+  logs) cmd_logs ;;
+  _prover-service) run_prover_service ;;
+  _nitro-local) run_nitro_local "${2:?prover number required}" ;;
+  _proposer) run_proposer ;;
+  *) usage >&2; exit 1 ;;
+esac

--- a/etc/scripts/devnet/setup-l2.sh
+++ b/etc/scripts/devnet/setup-l2.sh
@@ -20,6 +20,11 @@ L2_EL_BOOTNODE_ENODE="${L2_EL_BOOTNODE_ENODE:-enode://4f355bdcb7cc0af728ef3cceb9
 L2_CL_BOOTNODE_P2P_KEY="${L2_CL_BOOTNODE_P2P_KEY:-2222222222222222222222222222222222222222222222222222222222222222}"
 L2_CL_BOOTNODE_ENR_PATH="${L2_CL_BOOTNODE_ENR_PATH:-/bootnodes/cl-bootnode.enr}"
 
+if [ "${SETUP_L2_SKIP_IF_CONFIGURED:-}" = "true" ] && [ -f "$OUTPUT_DIR/.setup-complete" ]; then
+  echo "L2 configuration already generated; reusing $OUTPUT_DIR"
+  exit 0
+fi
+
 replace_output_file() {
   local source_file="$1"
   local destination_file="$2"
@@ -468,6 +473,9 @@ echo "Sequencer-2 P2P key written to $OUTPUT_DIR/sequencer-2-p2p-key.txt"
 
 # Cleanup
 rm -rf "$OP_DEPLOYER_WORKDIR"
+if [ "${SETUP_L2_SKIP_IF_CONFIGURED:-}" = "true" ]; then
+  touch "$OUTPUT_DIR/.setup-complete"
+fi
 
 echo ""
 echo "=== L2 Genesis Generation Complete ==="


### PR DESCRIPTION
## Summary

Add one opt-in command that starts Jack's minimum local no-Nitro proving environment:

```bash
just devnet build-anvil-image
just devnet up-anvil-no-nitro
```

The command uses one Base-Anvil process as the complete L1 execution and Beacon endpoint, while retaining the normal Base L2 nodes and batcher. Normal `just devnet up` and `up-single` behavior is unchanged.

## Startup order

1. Generate the normal L1 genesis and start Base-Anvil.
2. Generate the L2 genesis and compute its canonical V0 output root offline.
3. Clone the current base/contracts default branch and deploy `DeployDevNoNitro` on L1, anchored at L2 block zero.
4. Seed the complete real `ProtocolVersions` schedule.
5. Start all L2 nodes already pointing at that same `ProtocolVersions` contract.
6. Start a fresh prover-service database, register two local Nitro signers, start both workers, and start the proposer after the first proof target finalizes.

This avoids deploying a separate mock upgrade-signal contract and removes the previous contract-address switch after node startup.

## Dependencies

- Stacked on #4342 for the deterministic Docker devnet chain configuration; both branches are rebased onto current `main`.
- `just devnet build-anvil-image` builds the current Base-Anvil default branch.
- Bootstrap shallow-clones the current base/contracts default branch.
- Supersedes the standalone/forked-Anvil architecture in the closed #4341.

## Validation

The no-Nitro architecture completed a fresh end-to-end run with:

- L1 chain ID `1337` and L2 chain ID `84538453`
- identical offline, deployed-anchor, and live L2 block-zero output roots
- the same real `ProtocolVersions` address in `AggregateVerifier` and the PID 1 environment of builder, client, and RPC node
- all 14 schedule entries from current main, including unscheduled Denim, and minimum protocol version `4294967296`
- two registered local Nitro signers
- proof DB result `SUCCEEDED` for the `0 -> 100` proof, crossing the configured Azul, Beryl, and Cobalt activations
- proposer receipt status `1`
- target L2 block `100` and `proofCount = 1`
- matching proof, game, and activated schedule IDs
- a full schedule ID that additionally commits to the unscheduled Denim entry

The final dependency-resolution change was checked against both repositories' live default branches. Base-Anvil's Git build context and the base/contracts shallow clone both resolved their current default-branch HEADs. The current-head E2E retry reached those sources successfully; the Docker image rebuild then exhausted the Docker VM filesystem while compiling RocksDB, and a follow-up contract dependency download was interrupted by the GitHub connection. These were environmental failures rather than source or test failures.

Local checks completed on the final rebased commit:

```text
cargo check -p base --bin base --locked
cargo test -p base-execution-chainspec devnet_genesis_output_root --locked
cargo test -p base-common-chains
cargo test -p base-proof-tee-nitro-enclave config_hash_known_values
cargo fmt --all -- --check
shellcheck etc/scripts/devnet/anvil-no-nitro.sh
bash -n etc/scripts/devnet/anvil-no-nitro.sh
bash -n etc/scripts/devnet/setup-l2.sh
docker compose ... config --quiet
just --justfile etc/docker/Justfile --list
git diff --check origin/main...HEAD
```
