### PR TITLE
feat(proof): derive a game's proof capability fingerprint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6884,6 +6884,7 @@ dependencies = [
  "base-consensus-gossip",
  "base-consensus-peers",
  "base-consensus-rpc",
+ "base-proof-contracts",
  "base-protocol",
  "base-prover-service-client",
  "base-prover-service-protocol",

--- a/crates/infra/basectl/Cargo.toml
+++ b/crates/infra/basectl/Cargo.toml
@@ -26,6 +26,7 @@ base-consensus-peers = { workspace = true }
 alloy-transport-http = { workspace = true }
 base-consensus-gossip = { workspace = true }
 alloy-rpc-types-txpool = { workspace = true }
+base-proof-contracts = { workspace = true }
 base-common-precompiles = { workspace = true }
 base-common-flashblocks = { workspace = true }
 base-prover-service-client = { workspace = true }

--- a/crates/infra/basectl/src/commands/mod.rs
+++ b/crates/infra/basectl/src/commands/mod.rs
@@ -34,7 +34,7 @@ mod proofs;
 pub use proofs::{
     ProofOutputStatus, ProofResultJson, ProofStatusFilter, ProofSummaryJson, ProofsCommand,
     ProofsCommands, ProofsFinalizeArgs, ProofsFinalizeJson, ProofsListArgs, ProofsListJson,
-    ProofsStatusArgs, ProofsStatusJson,
+    ProofsProtocolArgs, ProofsStatusArgs, ProofsStatusJson,
 };
 
 mod sequencer;

--- a/crates/infra/basectl/src/commands/proofs.rs
+++ b/crates/infra/basectl/src/commands/proofs.rs
@@ -9,7 +9,7 @@ use alloy_primitives::{Address, B256};
 use anyhow::Result;
 use base_proof_contracts::{
     AggregateVerifierClient, AggregateVerifierContractClient, DisputeGameFactoryClient,
-    DisputeGameFactoryContractClient, ProofProtocolDescriptor, ProofScheduleKind,
+    DisputeGameFactoryContractClient, GameStatus, ProofProtocolDescriptor, ProofScheduleKind,
 };
 use base_prover_service_protocol::{
     GetProofResponse, ListProofsRequest, ProofResult, ProofStatus, ProofSummary, ProofType,
@@ -17,7 +17,7 @@ use base_prover_service_protocol::{
 };
 use clap::{Args, Subcommand, ValueEnum};
 use serde::{Serialize, Serializer};
-use tracing::info;
+use tracing::{info, warn};
 use url::Url;
 
 use crate::{
@@ -316,6 +316,8 @@ struct GameProtocolRow {
     index: Option<u64>,
     /// Game proxy address.
     game: Address,
+    /// Current onchain game status.
+    status: &'static str,
     /// Journal schedule era.
     era: &'static str,
     /// Rollup configuration hash committed by both journal types.
@@ -331,10 +333,20 @@ struct GameProtocolRow {
 }
 
 impl GameProtocolRow {
-    fn new(index: Option<u64>, game: Address, descriptor: &ProofProtocolDescriptor) -> Self {
+    fn new(
+        index: Option<u64>,
+        game: Address,
+        status: GameStatus,
+        descriptor: &ProofProtocolDescriptor,
+    ) -> Self {
         Self {
             index,
             game,
+            status: match status {
+                GameStatus::InProgress => "in-progress",
+                GameStatus::ChallengerWins => "challenger-wins",
+                GameStatus::DefenderWins => "defender-wins",
+            },
             era: match descriptor.schedule_kind {
                 ProofScheduleKind::None => "no-schedule",
                 ProofScheduleKind::Full => "full-schedule",
@@ -362,8 +374,10 @@ async fn run_protocol(args: ProofsProtocolArgs) -> Result<CommandOutcome> {
         info!(factory = %factory_address, from, end, count, "enumerating dispute games");
 
         let mut targets = Vec::new();
-        for index in from..=end.min(count.saturating_sub(1)) {
-            targets.push((Some(index), factory_client.game_at_index(index).await?.proxy));
+        if count > 0 {
+            for index in from..=end.min(count - 1) {
+                targets.push((Some(index), factory_client.game_at_index(index).await?.proxy));
+            }
         }
         targets
     } else {
@@ -371,12 +385,21 @@ async fn run_protocol(args: ProofsProtocolArgs) -> Result<CommandOutcome> {
     };
 
     let mut rows = Vec::with_capacity(targets.len());
+    let mut unreadable = 0;
     for (index, address) in targets {
         // One unreadable game must not hide the rest: an era this build cannot classify is
         // exactly what the operator needs to see.
-        match verifier.proof_protocol_descriptor(address).await {
-            Ok(descriptor) => rows.push(GameProtocolRow::new(index, address, &descriptor)),
-            Err(e) => info!(game = %address, error = %e, "skipping unreadable game"),
+        match futures::try_join!(
+            verifier.status(address),
+            verifier.proof_protocol_descriptor(address)
+        ) {
+            Ok((status, descriptor)) => {
+                rows.push(GameProtocolRow::new(index, address, status, &descriptor));
+            }
+            Err(error) => {
+                unreadable += 1;
+                warn!(game = %address, error = %error, "skipping unreadable game");
+            }
         }
     }
 
@@ -384,6 +407,10 @@ async fn run_protocol(args: ProofsProtocolArgs) -> Result<CommandOutcome> {
         JsonOutput::print(&rows)?;
     } else {
         print_protocol_pretty_to(&mut io::stdout().lock(), &rows)?;
+    }
+
+    if unreadable > 0 {
+        anyhow::bail!("{unreadable} game(s) could not be classified; fingerprint dump incomplete");
     }
 
     Ok(CommandOutcome::Success)
@@ -396,6 +423,7 @@ fn print_protocol_pretty_to(out: &mut impl Write, rows: &[GameProtocolRow]) -> i
             table.row("Index", index.to_string());
         }
         table.row("Game", row.game.to_string());
+        table.row("Status", row.status.to_owned());
         table.row("Era", row.era.to_owned());
         table.row("Config hash", row.config_hash.to_string());
         table.row("TEE image hash", row.tee_image_hash.to_string());
@@ -406,20 +434,24 @@ fn print_protocol_pretty_to(out: &mut impl Write, rows: &[GameProtocolRow]) -> i
         writeln!(out)?;
     }
 
-    // The mapping is per distinct fingerprint, not per game, so collapse before printing the
-    // lines an operator pastes into --proof-protocol-version.
-    let mut distinct: Vec<B256> = rows.iter().map(|row| row.fingerprint).collect();
+    // Resolved games no longer need workers. Build the mapping only from games the challenger may
+    // still need to prove, while keeping resolved rows above as useful history.
+    let mut distinct: Vec<B256> =
+        rows.iter().filter(|row| row.status == "in-progress").map(|row| row.fingerprint).collect();
     distinct.sort_unstable();
     distinct.dedup();
 
     writeln!(
         out,
-        "{} game(s), {} distinct capability fingerprint(s):",
-        rows.len(),
+        "{} in-progress game(s), {} distinct capability fingerprint(s):",
+        rows.iter().filter(|row| row.status == "in-progress").count(),
         distinct.len()
     )?;
     for fingerprint in distinct {
-        let games = rows.iter().filter(|row| row.fingerprint == fingerprint).count();
+        let games = rows
+            .iter()
+            .filter(|row| row.status == "in-progress" && row.fingerprint == fingerprint)
+            .count();
         writeln!(out, "  {fingerprint}  ({games} game(s))  -> assign a version")?;
     }
 
@@ -883,7 +915,7 @@ fn print_list_pretty_to<W: Write>(writer: &mut W, list: &ProofsListJson) -> Resu
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Address, B256};
-    use base_proof_contracts::{ProofProtocolDescriptor, ProofScheduleKind};
+    use base_proof_contracts::{GameStatus, ProofProtocolDescriptor, ProofScheduleKind};
 
     use super::{GameProtocolRow, print_protocol_pretty_to};
 
@@ -902,18 +934,33 @@ mod tests {
     #[test]
     fn protocol_summary_groups_games_by_fingerprint() {
         let rows = vec![
-            GameProtocolRow::new(Some(0), Address::repeat_byte(0xa1), &descriptor(2)),
-            GameProtocolRow::new(Some(1), Address::repeat_byte(0xa2), &descriptor(2)),
-            GameProtocolRow::new(Some(2), Address::repeat_byte(0xa3), &descriptor(9)),
+            GameProtocolRow::new(
+                Some(0),
+                Address::repeat_byte(0xa1),
+                GameStatus::InProgress,
+                &descriptor(2),
+            ),
+            GameProtocolRow::new(
+                Some(1),
+                Address::repeat_byte(0xa2),
+                GameStatus::InProgress,
+                &descriptor(2),
+            ),
+            GameProtocolRow::new(
+                Some(2),
+                Address::repeat_byte(0xa3),
+                GameStatus::DefenderWins,
+                &descriptor(9),
+            ),
         ];
 
         let mut out = Vec::new();
         print_protocol_pretty_to(&mut out, &rows).expect("summary should render");
         let rendered = String::from_utf8(out).expect("summary should be utf8");
 
-        assert!(rendered.contains("3 game(s), 2 distinct capability fingerprint(s)"));
+        assert!(rendered.contains("2 in-progress game(s), 1 distinct capability fingerprint(s)"));
         assert!(rendered.contains("(2 game(s))"), "shared capability should group");
-        assert!(rendered.contains("(1 game(s))"), "differing capability must stay separate");
+        assert!(rendered.contains("defender-wins"), "resolved games should remain visible");
         assert!(rendered.contains("activated-prefix"));
     }
 

--- a/crates/infra/basectl/src/commands/proofs.rs
+++ b/crates/infra/basectl/src/commands/proofs.rs
@@ -16,6 +16,7 @@ use base_prover_service_protocol::{
     TeeKind, ZkVm,
 };
 use clap::{Args, Subcommand, ValueEnum};
+use futures::{StreamExt, TryStreamExt, stream};
 use serde::{Serialize, Serializer};
 use tracing::{info, warn};
 use url::Url;
@@ -362,6 +363,8 @@ impl GameProtocolRow {
 }
 
 async fn run_protocol(args: ProofsProtocolArgs) -> Result<CommandOutcome> {
+    const CONCURRENCY: usize = 32;
+
     let ProofsProtocolArgs { l1_rpc, factory, from, to, game, json } = args;
     let verifier = AggregateVerifierContractClient::new(l1_rpc.clone())?;
 
@@ -373,28 +376,50 @@ async fn run_protocol(args: ProofsProtocolArgs) -> Result<CommandOutcome> {
         let end = to.unwrap_or_else(|| count.saturating_sub(1));
         info!(factory = %factory_address, from, end, count, "enumerating dispute games");
 
-        let mut targets = Vec::new();
-        if count > 0 {
-            for index in from..=end.min(count - 1) {
-                targets.push((Some(index), factory_client.game_at_index(index).await?.proxy));
-            }
-        }
+        let mut targets: Vec<_> = if count == 0 {
+            Vec::new()
+        } else {
+            stream::iter(from..=end.min(count - 1))
+                .map(|index| {
+                    let factory_client = &factory_client;
+                    async move {
+                        Ok::<_, anyhow::Error>((
+                            Some(index),
+                            factory_client.game_at_index(index).await?.proxy,
+                        ))
+                    }
+                })
+                .buffer_unordered(CONCURRENCY)
+                .try_collect()
+                .await?
+        };
+        targets.sort_unstable_by_key(|(index, _)| *index);
         targets
     } else {
         game.into_iter().map(|address| (None, address)).collect()
     };
 
-    let mut rows = Vec::with_capacity(targets.len());
+    let results: Vec<_> = stream::iter(targets)
+        .map(|(index, address)| {
+            let verifier = &verifier;
+            async move {
+                let result = futures::try_join!(
+                    verifier.status(address),
+                    verifier.proof_protocol_descriptor(address)
+                );
+                (index, address, result)
+            }
+        })
+        .buffer_unordered(CONCURRENCY)
+        .collect()
+        .await;
+
+    let mut rows = Vec::with_capacity(results.len());
     let mut unreadable = 0;
-    for (index, address) in targets {
-        // One unreadable game must not hide the rest: an era this build cannot classify is
-        // exactly what the operator needs to see.
-        match futures::try_join!(
-            verifier.status(address),
-            verifier.proof_protocol_descriptor(address)
-        ) {
+    for (index, address, result) in results {
+        match result {
             Ok((status, descriptor)) => {
-                rows.push(GameProtocolRow::new(index, address, status, &descriptor));
+                rows.push(GameProtocolRow::new(index, address, status, &descriptor))
             }
             Err(error) => {
                 unreadable += 1;
@@ -402,6 +427,7 @@ async fn run_protocol(args: ProofsProtocolArgs) -> Result<CommandOutcome> {
             }
         }
     }
+    rows.sort_unstable_by_key(|row| row.index);
 
     if json {
         JsonOutput::print(&rows)?;

--- a/crates/infra/basectl/src/commands/proofs.rs
+++ b/crates/infra/basectl/src/commands/proofs.rs
@@ -45,9 +45,10 @@ pub enum ProofsCommands {
     List(ProofsListArgs),
     /// Print the proof capability fingerprint of historical dispute games.
     ///
-    /// Reads the immutable commitments each game proxy exposes and derives the fingerprint the
-    /// challenger routes on, so `--proof-protocol-version <fingerprint>=<version>` mappings can be
-    /// written from observed state rather than guessed. Read-only.
+    /// Reads each game proxy and fingerprints the prover artifact hashes
+    /// (`TEE_IMAGE_HASH`, `ZK_RANGE_HASH`, `ZK_AGGREGATE_HASH`) so
+    /// `--proof-protocol-version <fingerprint>=<version>` mappings can be written from observed
+    /// state. Read-only.
     Protocol(ProofsProtocolArgs),
 }
 

--- a/crates/infra/basectl/src/commands/proofs.rs
+++ b/crates/infra/basectl/src/commands/proofs.rs
@@ -5,8 +5,12 @@ use std::{
     io::{self, Write},
 };
 
-use alloy_primitives::B256;
+use alloy_primitives::{Address, B256};
 use anyhow::Result;
+use base_proof_contracts::{
+    AggregateVerifierClient, AggregateVerifierContractClient, DisputeGameFactoryClient,
+    DisputeGameFactoryContractClient, ProofProtocolDescriptor, ProofScheduleKind,
+};
 use base_prover_service_protocol::{
     GetProofResponse, ListProofsRequest, ProofResult, ProofStatus, ProofSummary, ProofType,
     TeeKind, ZkVm,
@@ -38,6 +42,35 @@ pub enum ProofsCommands {
     Status(ProofsStatusArgs),
     /// List submitted proof requests.
     List(ProofsListArgs),
+    /// Print the proof capability fingerprint of historical dispute games.
+    ///
+    /// Reads the immutable commitments each game proxy exposes and derives the fingerprint the
+    /// challenger routes on, so `--proof-protocol-version <fingerprint>=<version>` mappings can be
+    /// written from observed state rather than guessed. Read-only.
+    Protocol(ProofsProtocolArgs),
+}
+
+/// Flags for `basectl proofs protocol`.
+#[derive(Debug, Args)]
+pub struct ProofsProtocolArgs {
+    /// L1 RPC endpoint used to read game state.
+    #[arg(long = "l1-rpc", env = "BASECTL_L1_RPC", value_name = "URL")]
+    pub l1_rpc: Url,
+    /// `DisputeGameFactory` address to enumerate games from.
+    #[arg(long = "factory", value_name = "ADDRESS", required_unless_present = "game")]
+    pub factory: Option<Address>,
+    /// First factory index to read. Defaults to 0.
+    #[arg(long = "from", value_name = "INDEX", default_value_t = 0)]
+    pub from: u64,
+    /// Last factory index to read. Defaults to the newest game.
+    #[arg(long = "to", value_name = "INDEX")]
+    pub to: Option<u64>,
+    /// Explicit game proxy address. Repeatable; skips factory enumeration.
+    #[arg(long = "game", value_name = "ADDRESS")]
+    pub game: Vec<Address>,
+    /// Emit JSON instead of a table.
+    #[arg(long = "json")]
+    pub json: bool,
 }
 
 /// Flags for `basectl proofs finalize`.
@@ -152,6 +185,7 @@ impl ProofsCommand {
             ProofsCommands::Finalize(args) => run_finalize(config, args).await,
             ProofsCommands::Status(args) => run_status(config, args).await,
             ProofsCommands::List(args) => run_list(config, args).await,
+            ProofsCommands::Protocol(args) => run_protocol(args).await,
         }
     }
 }
@@ -273,6 +307,123 @@ async fn run_status(config: MonitoringConfig, args: ProofsStatusArgs) -> Result<
         print_status_pretty_to(&mut io::stdout().lock(), &status)?;
     }
     Ok(CommandOutcome::Success)
+}
+
+/// One game's capability descriptor, flattened for display.
+#[derive(Debug, Serialize)]
+struct GameProtocolRow {
+    /// Factory index, absent when the game was named explicitly.
+    index: Option<u64>,
+    /// Game proxy address.
+    game: Address,
+    /// Journal schedule era.
+    era: &'static str,
+    /// Rollup configuration hash committed by both journal types.
+    config_hash: B256,
+    /// Nitro enclave image hash committed by TEE journals.
+    tee_image_hash: B256,
+    /// SP1 range verification key committed by ZK journals.
+    zk_range_hash: B256,
+    /// SP1 aggregation verification key used by the ZK verifier.
+    zk_aggregate_hash: B256,
+    /// Canonical fingerprint the challenger maps to a routing version.
+    fingerprint: B256,
+}
+
+impl GameProtocolRow {
+    fn new(index: Option<u64>, game: Address, descriptor: &ProofProtocolDescriptor) -> Self {
+        Self {
+            index,
+            game,
+            era: match descriptor.schedule_kind {
+                ProofScheduleKind::None => "no-schedule",
+                ProofScheduleKind::Full => "full-schedule",
+                ProofScheduleKind::Activated => "activated-prefix",
+            },
+            config_hash: descriptor.config_hash,
+            tee_image_hash: descriptor.tee_image_hash,
+            zk_range_hash: descriptor.zk_range_hash,
+            zk_aggregate_hash: descriptor.zk_aggregate_hash,
+            fingerprint: descriptor.fingerprint(),
+        }
+    }
+}
+
+async fn run_protocol(args: ProofsProtocolArgs) -> Result<CommandOutcome> {
+    let ProofsProtocolArgs { l1_rpc, factory, from, to, game, json } = args;
+    let verifier = AggregateVerifierContractClient::new(l1_rpc.clone())?;
+
+    let targets: Vec<(Option<u64>, Address)> = if game.is_empty() {
+        let factory_address =
+            factory.ok_or_else(|| anyhow::anyhow!("--factory or --game is required"))?;
+        let factory_client = DisputeGameFactoryContractClient::new(factory_address, l1_rpc)?;
+        let count = factory_client.game_count().await?;
+        let end = to.unwrap_or_else(|| count.saturating_sub(1));
+        info!(factory = %factory_address, from, end, count, "enumerating dispute games");
+
+        let mut targets = Vec::new();
+        for index in from..=end.min(count.saturating_sub(1)) {
+            targets.push((Some(index), factory_client.game_at_index(index).await?.proxy));
+        }
+        targets
+    } else {
+        game.into_iter().map(|address| (None, address)).collect()
+    };
+
+    let mut rows = Vec::with_capacity(targets.len());
+    for (index, address) in targets {
+        // One unreadable game must not hide the rest: an era this build cannot classify is
+        // exactly what the operator needs to see.
+        match verifier.proof_protocol_descriptor(address).await {
+            Ok(descriptor) => rows.push(GameProtocolRow::new(index, address, &descriptor)),
+            Err(e) => info!(game = %address, error = %e, "skipping unreadable game"),
+        }
+    }
+
+    if json {
+        JsonOutput::print(&rows)?;
+    } else {
+        print_protocol_pretty_to(&mut io::stdout().lock(), &rows)?;
+    }
+
+    Ok(CommandOutcome::Success)
+}
+
+fn print_protocol_pretty_to(out: &mut impl Write, rows: &[GameProtocolRow]) -> io::Result<()> {
+    for row in rows {
+        let mut table = KeyValueTable::new();
+        if let Some(index) = row.index {
+            table.row("Index", index.to_string());
+        }
+        table.row("Game", row.game.to_string());
+        table.row("Era", row.era.to_owned());
+        table.row("Config hash", row.config_hash.to_string());
+        table.row("TEE image hash", row.tee_image_hash.to_string());
+        table.row("ZK range hash", row.zk_range_hash.to_string());
+        table.row("ZK aggregate hash", row.zk_aggregate_hash.to_string());
+        table.row("Fingerprint", row.fingerprint.to_string());
+        table.render(out)?;
+        writeln!(out)?;
+    }
+
+    // The mapping is per distinct fingerprint, not per game, so collapse before printing the
+    // lines an operator pastes into --proof-protocol-version.
+    let mut distinct: Vec<B256> = rows.iter().map(|row| row.fingerprint).collect();
+    distinct.sort_unstable();
+    distinct.dedup();
+
+    writeln!(
+        out,
+        "{} game(s), {} distinct capability fingerprint(s):",
+        rows.len(),
+        distinct.len()
+    )?;
+    for fingerprint in distinct {
+        let games = rows.iter().filter(|row| row.fingerprint == fingerprint).count();
+        writeln!(out, "  {fingerprint}  ({games} game(s))  -> assign a version")?;
+    }
+
+    Ok(())
 }
 
 async fn run_list(config: MonitoringConfig, args: ProofsListArgs) -> Result<CommandOutcome> {
@@ -731,6 +882,41 @@ fn print_list_pretty_to<W: Write>(writer: &mut W, list: &ProofsListJson) -> Resu
 
 #[cfg(test)]
 mod tests {
+    use alloy_primitives::{Address, B256};
+    use base_proof_contracts::{ProofProtocolDescriptor, ProofScheduleKind};
+
+    use super::{GameProtocolRow, print_protocol_pretty_to};
+
+    fn descriptor(tee_image_hash: u8) -> ProofProtocolDescriptor {
+        ProofProtocolDescriptor {
+            schedule_kind: ProofScheduleKind::Activated,
+            schedule_id: B256::ZERO,
+            config_hash: B256::repeat_byte(1),
+            tee_image_hash: B256::repeat_byte(tee_image_hash),
+            zk_range_hash: B256::repeat_byte(3),
+            zk_aggregate_hash: B256::repeat_byte(4),
+        }
+    }
+
+    /// Games sharing a capability collapse to one mapping line; a differing commitment does not.
+    #[test]
+    fn protocol_summary_groups_games_by_fingerprint() {
+        let rows = vec![
+            GameProtocolRow::new(Some(0), Address::repeat_byte(0xa1), &descriptor(2)),
+            GameProtocolRow::new(Some(1), Address::repeat_byte(0xa2), &descriptor(2)),
+            GameProtocolRow::new(Some(2), Address::repeat_byte(0xa3), &descriptor(9)),
+        ];
+
+        let mut out = Vec::new();
+        print_protocol_pretty_to(&mut out, &rows).expect("summary should render");
+        let rendered = String::from_utf8(out).expect("summary should be utf8");
+
+        assert!(rendered.contains("3 game(s), 2 distinct capability fingerprint(s)"));
+        assert!(rendered.contains("(2 game(s))"), "shared capability should group");
+        assert!(rendered.contains("(1 game(s))"), "differing capability must stay separate");
+        assert!(rendered.contains("activated-prefix"));
+    }
+
     use base_prover_service_protocol::{
         GetProofResponse, ProofResult, ProofStatus, ProofSummary, ProofType, SnarkPlonkProofResult,
         ZkProofResult, ZkVm,

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -11,12 +11,12 @@ pub use commands::{
     OptionalValue, P2pArgs, P2pCommand, P2pCommands, PausedSummaryJson, PeerAction, PeerActionJson,
     PeerBulkAction, PeerBulkActionResultJson, PeerLayer, PeerTarget, PeersJson, ProofOutputStatus,
     ProofResultJson, ProofStatusFilter, ProofSummaryJson, ProofsCommand, ProofsCommands,
-    ProofsFinalizeArgs, ProofsFinalizeJson, ProofsListArgs, ProofsListJson, ProofsStatusArgs,
-    ProofsStatusJson, SequencerAction, SequencerActionJson, SequencerCommand, SequencerCommands,
-    SequencerNodeActionArgs, SequencerNodeJson, SequencerRole, SequencerStartArgs,
-    SequencerStatusArgs, SequencerStatusJson, SyncStatusCommand, SyncStatusJson, TipReferenceJson,
-    TipStatus, TxpoolClearArgs, TxpoolClearJson, TxpoolCommand, TxpoolCommands, TxpoolReadArgs,
-    TxpoolReadJson, UnsafeHeadSource,
+    ProofsFinalizeArgs, ProofsFinalizeJson, ProofsListArgs, ProofsListJson, ProofsProtocolArgs,
+    ProofsStatusArgs, ProofsStatusJson, SequencerAction, SequencerActionJson, SequencerCommand,
+    SequencerCommands, SequencerNodeActionArgs, SequencerNodeJson, SequencerRole,
+    SequencerStartArgs, SequencerStatusArgs, SequencerStatusJson, SyncStatusCommand,
+    SyncStatusJson, TipReferenceJson, TipStatus, TxpoolClearArgs, TxpoolClearJson, TxpoolCommand,
+    TxpoolCommands, TxpoolReadArgs, TxpoolReadJson, UnsafeHeadSource,
 };
 
 mod zenith;

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -299,6 +299,12 @@ impl MockAggregateVerifier {
 
 #[async_trait]
 impl AggregateVerifierClient for MockAggregateVerifier {
+    async fn proof_protocol_descriptor(
+        &self,
+        _: Address,
+    ) -> Result<base_proof_contracts::ProofProtocolDescriptor, ContractError> {
+        unimplemented!("unused in challenger tests")
+    }
     async fn game_info(&self, game_address: Address) -> Result<GameInfo, ContractError> {
         self.game_info_reads.lock().unwrap().push(game_address);
         self.get(game_address, |s| s.game_info)

--- a/crates/proof/contracts/src/aggregate_verifier.rs
+++ b/crates/proof/contracts/src/aggregate_verifier.rs
@@ -240,7 +240,13 @@ impl ProofProtocolDescriptor {
         let mut bytes = Vec::with_capacity(DOMAIN.len() + 1 + 32 * 5);
         bytes.extend_from_slice(DOMAIN);
         bytes.push(self.schedule_kind as u8);
-        bytes.extend_from_slice(self.schedule_id.as_slice());
+        bytes.extend_from_slice(
+            match self.schedule_kind {
+                ProofScheduleKind::Full => self.schedule_id,
+                ProofScheduleKind::None | ProofScheduleKind::Activated => B256::ZERO,
+            }
+            .as_slice(),
+        );
         bytes.extend_from_slice(self.config_hash.as_slice());
         bytes.extend_from_slice(self.tee_image_hash.as_slice());
         bytes.extend_from_slice(self.zk_range_hash.as_slice());
@@ -985,6 +991,18 @@ mod tests {
             descriptor.fingerprint(),
             ProofProtocolDescriptor { schedule_kind: ProofScheduleKind::Full, ..descriptor }
                 .fingerprint()
+        );
+        assert_eq!(
+            descriptor.fingerprint(),
+            ProofProtocolDescriptor { schedule_id: B256::repeat_byte(9), ..descriptor }
+                .fingerprint(),
+            "activated-prefix fingerprints do not commit the unused full-schedule snapshot"
+        );
+        let full = ProofProtocolDescriptor { schedule_kind: ProofScheduleKind::Full, ..descriptor };
+        assert_ne!(
+            full.fingerprint(),
+            ProofProtocolDescriptor { schedule_id: B256::repeat_byte(9), ..full }.fingerprint(),
+            "full-schedule fingerprints commit the snapshot"
         );
     }
 }

--- a/crates/proof/contracts/src/aggregate_verifier.rs
+++ b/crates/proof/contracts/src/aggregate_verifier.rs
@@ -234,20 +234,15 @@ pub struct ProofProtocolDescriptor {
 
 impl ProofProtocolDescriptor {
     /// Returns the canonical offchain capability fingerprint for routing configuration.
+    ///
+    /// Only prover artifact hashes are committed. Schedule ID is derived by the guest from the
+    /// CL oracle, and `CONFIG_HASH` is chain identity already fixed by deploying one
+    /// prover-service per network.
     #[must_use]
     pub fn fingerprint(&self) -> B256 {
         const DOMAIN: &[u8] = b"base-proof-protocol-v1";
-        let mut bytes = Vec::with_capacity(DOMAIN.len() + 1 + 32 * 5);
+        let mut bytes = Vec::with_capacity(DOMAIN.len() + 32 * 3);
         bytes.extend_from_slice(DOMAIN);
-        bytes.push(self.schedule_kind as u8);
-        bytes.extend_from_slice(
-            match self.schedule_kind {
-                ProofScheduleKind::Full => self.schedule_id,
-                ProofScheduleKind::None | ProofScheduleKind::Activated => B256::ZERO,
-            }
-            .as_slice(),
-        );
-        bytes.extend_from_slice(self.config_hash.as_slice());
         bytes.extend_from_slice(self.tee_image_hash.as_slice());
         bytes.extend_from_slice(self.zk_range_hash.as_slice());
         bytes.extend_from_slice(self.zk_aggregate_hash.as_slice());
@@ -972,7 +967,7 @@ mod tests {
     }
 
     #[test]
-    fn proof_protocol_fingerprint_commits_schedule_kind_and_artifacts() {
+    fn proof_protocol_fingerprint_commits_only_prover_artifacts() {
         let descriptor = ProofProtocolDescriptor {
             schedule_kind: ProofScheduleKind::Activated,
             schedule_id: B256::ZERO,
@@ -989,20 +984,24 @@ mod tests {
         );
         assert_ne!(
             descriptor.fingerprint(),
-            ProofProtocolDescriptor { schedule_kind: ProofScheduleKind::Full, ..descriptor }
+            ProofProtocolDescriptor { zk_range_hash: B256::repeat_byte(6), ..descriptor }
+                .fingerprint()
+        );
+        assert_ne!(
+            descriptor.fingerprint(),
+            ProofProtocolDescriptor { zk_aggregate_hash: B256::repeat_byte(7), ..descriptor }
                 .fingerprint()
         );
         assert_eq!(
             descriptor.fingerprint(),
-            ProofProtocolDescriptor { schedule_id: B256::repeat_byte(9), ..descriptor }
-                .fingerprint(),
-            "activated-prefix fingerprints do not commit the unused full-schedule snapshot"
-        );
-        let full = ProofProtocolDescriptor { schedule_kind: ProofScheduleKind::Full, ..descriptor };
-        assert_ne!(
-            full.fingerprint(),
-            ProofProtocolDescriptor { schedule_id: B256::repeat_byte(9), ..full }.fingerprint(),
-            "full-schedule fingerprints commit the snapshot"
+            ProofProtocolDescriptor {
+                schedule_kind: ProofScheduleKind::Full,
+                schedule_id: B256::repeat_byte(9),
+                config_hash: B256::repeat_byte(8),
+                ..descriptor
+            }
+            .fingerprint(),
+            "schedule and config are not routing keys"
         );
     }
 }

--- a/crates/proof/contracts/src/aggregate_verifier.rs
+++ b/crates/proof/contracts/src/aggregate_verifier.rs
@@ -7,7 +7,7 @@
 //! [`encode_nullify_calldata`] or `challenge` via
 //! [`encode_challenge_calldata`].
 
-use alloy_primitives::{Address, B256, Bytes, U256};
+use alloy_primitives::{Address, B256, Bytes, U256, keccak256};
 use alloy_provider::RootProvider;
 use alloy_sol_types::{SolCall, SolError, sol};
 use async_trait::async_trait;
@@ -45,6 +45,11 @@ sol! {
         /// Returns the current game status. See [`GameStatus`] for values.
         function status() external view returns (uint8);
 
+        /// Returns the upgrade schedule commitment pinned by this game.
+        ///
+        /// Legacy verifier implementations do not expose this getter.
+        function scheduleId() external view returns (bytes32);
+
         /// Returns the address that provided a TEE proof.
         function teeProver() external view returns (address);
 
@@ -59,6 +64,21 @@ sol! {
 
         /// Returns the intermediate block interval for intermediate output root checkpoints.
         function INTERMEDIATE_BLOCK_INTERVAL() external view returns (uint256);
+
+        /// Returns the rollup configuration hash committed by proof journals.
+        function CONFIG_HASH() external view returns (bytes32);
+
+        /// Returns the Nitro enclave image hash committed by TEE journals.
+        function TEE_IMAGE_HASH() external view returns (bytes32);
+
+        /// Returns the SP1 range verification key committed by ZK journals.
+        function ZK_RANGE_HASH() external view returns (bytes32);
+
+        /// Returns the SP1 aggregation verification key used by the ZK verifier.
+        function ZK_AGGREGATE_HASH() external view returns (bytes32);
+
+        /// Returns the L2 block time used by activated-prefix verifiers.
+        function L2_BLOCK_TIME() external view returns (uint64);
 
         /// Returns the game type.
         function gameType() external view returns (uint32);
@@ -183,6 +203,52 @@ pub enum GameStatus {
     DefenderWins = 2,
 }
 
+/// Schedule semantics used by a proof journal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ProofScheduleKind {
+    /// The journal predates schedule commitments.
+    None = 0,
+    /// The journal commits the full schedule snapshotted at game creation.
+    Full = 1,
+    /// The journal commits the schedule prefix activated at the game's L2 block.
+    Activated = 2,
+}
+
+/// Onchain commitments that determine which prover artifacts can satisfy a game.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProofProtocolDescriptor {
+    /// Schedule semantics used by the game.
+    pub schedule_kind: ProofScheduleKind,
+    /// Full schedule snapshot for [`ProofScheduleKind::Full`].
+    pub schedule_id: B256,
+    /// Rollup configuration hash committed by both journal types.
+    pub config_hash: B256,
+    /// Nitro enclave image hash committed by TEE journals.
+    pub tee_image_hash: B256,
+    /// SP1 range verification key committed by ZK journals.
+    pub zk_range_hash: B256,
+    /// SP1 aggregation verification key used to verify ZK proofs.
+    pub zk_aggregate_hash: B256,
+}
+
+impl ProofProtocolDescriptor {
+    /// Returns the canonical offchain capability fingerprint for routing configuration.
+    #[must_use]
+    pub fn fingerprint(&self) -> B256 {
+        const DOMAIN: &[u8] = b"base-proof-protocol-v1";
+        let mut bytes = Vec::with_capacity(DOMAIN.len() + 1 + 32 * 5);
+        bytes.extend_from_slice(DOMAIN);
+        bytes.push(self.schedule_kind as u8);
+        bytes.extend_from_slice(self.schedule_id.as_slice());
+        bytes.extend_from_slice(self.config_hash.as_slice());
+        bytes.extend_from_slice(self.tee_image_hash.as_slice());
+        bytes.extend_from_slice(self.zk_range_hash.as_slice());
+        bytes.extend_from_slice(self.zk_aggregate_hash.as_slice());
+        keccak256(bytes)
+    }
+}
+
 impl std::fmt::Display for GameStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -214,6 +280,12 @@ pub trait AggregateVerifierClient: Send + Sync {
 
     /// Returns the current game status.
     async fn status(&self, game_address: Address) -> Result<GameStatus, ContractError>;
+
+    /// Returns the proof capability descriptor committed by a historical game proxy.
+    async fn proof_protocol_descriptor(
+        &self,
+        game_address: Address,
+    ) -> Result<ProofProtocolDescriptor, ContractError>;
 
     /// Returns the address that provided a ZK proof for the given game.
     async fn zk_prover(&self, game_address: Address) -> Result<Address, ContractError>;
@@ -343,6 +415,27 @@ impl AggregateVerifierContractClient {
         let provider = RootProvider::new_http(l1_rpc_url);
         Ok(Self { provider })
     }
+
+    /// Reports whether a call failed because the contract does not implement the selector.
+    ///
+    /// Calling an absent function on a game proxy reverts with no revert data. Alloy has no typed
+    /// variant for that, so this pairs the structural check (empty revert data) with the message
+    /// match that separates it from other transport failures. Deliberately narrow: an unrecognized
+    /// phrasing falls through to the caller's error arm, which skips the game and retries on the
+    /// next scan, rather than silently misclassifying its proof era.
+    ///
+    /// `Error::ZeroData` is not treated as a missing getter. An empty successful response means the
+    /// address is not a contract or the node is serving a stale state, which is a real error rather
+    /// than evidence about which era the game belongs to.
+    fn is_missing_getter(error: &alloy_contract::Error) -> bool {
+        let alloy_contract::Error::TransportError(error) = error else {
+            return false;
+        };
+        error.as_error_resp().is_some_and(|payload| {
+            payload.message.to_ascii_lowercase().contains("execution reverted")
+                && payload.as_revert_data().is_none_or(|data| data.is_empty())
+        })
+    }
 }
 
 #[async_trait]
@@ -374,6 +467,65 @@ impl AggregateVerifierClient for AggregateVerifierContractClient {
             ContractError::validation(format!(
                 "game {game_address} returned unrecognized status {unknown}"
             ))
+        })
+    }
+
+    async fn proof_protocol_descriptor(
+        &self,
+        game_address: Address,
+    ) -> Result<ProofProtocolDescriptor, ContractError> {
+        let contract =
+            IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
+
+        // All six getters are immutable and independent, so they go out in one round rather than
+        // gating the two era probes behind the hashes. `L2_BLOCK_TIME` is speculative: it is only
+        // read when `scheduleId` succeeds, and the wasted call on a no-schedule game is one
+        // concurrent revert.
+        let (hashes, schedule_id, l2_block_time) = futures::join!(
+            async {
+                futures::try_join!(
+                    async { contract_call!(contract.CONFIG_HASH().call(), "CONFIG_HASH failed") },
+                    async {
+                        contract_call!(contract.TEE_IMAGE_HASH().call(), "TEE_IMAGE_HASH failed")
+                    },
+                    async {
+                        contract_call!(contract.ZK_RANGE_HASH().call(), "ZK_RANGE_HASH failed")
+                    },
+                    async {
+                        contract_call!(
+                            contract.ZK_AGGREGATE_HASH().call(),
+                            "ZK_AGGREGATE_HASH failed"
+                        )
+                    },
+                )
+            },
+            async { contract.scheduleId().call().await },
+            async { contract.L2_BLOCK_TIME().call().await },
+        );
+        let (config_hash, tee_image_hash, zk_range_hash, zk_aggregate_hash) = hashes?;
+
+        let (schedule_kind, schedule_id) = match schedule_id {
+            // Both schedule-aware eras expose `scheduleId`; only the activated-prefix era also
+            // exposes the L2 timestamp anchors it needs. Classify on which getters exist, never
+            // on the returned value: zero is valid for both.
+            Ok(schedule_id) => match l2_block_time {
+                Ok(_) => (ProofScheduleKind::Activated, B256::ZERO),
+                Err(error) if Self::is_missing_getter(&error) => {
+                    (ProofScheduleKind::Full, schedule_id)
+                }
+                Err(error) => return Err(ContractError::call("L2_BLOCK_TIME failed", error)),
+            },
+            Err(error) if Self::is_missing_getter(&error) => (ProofScheduleKind::None, B256::ZERO),
+            Err(error) => return Err(ContractError::call("scheduleId failed", error)),
+        };
+
+        Ok(ProofProtocolDescriptor {
+            schedule_kind,
+            schedule_id,
+            config_hash,
+            tee_image_hash,
+            zk_range_hash,
+            zk_aggregate_hash,
         })
     }
 
@@ -810,6 +962,29 @@ mod tests {
             &resolve[..4],
             &claim[..4],
             "resolve and claimCredit must have different selectors"
+        );
+    }
+
+    #[test]
+    fn proof_protocol_fingerprint_commits_schedule_kind_and_artifacts() {
+        let descriptor = ProofProtocolDescriptor {
+            schedule_kind: ProofScheduleKind::Activated,
+            schedule_id: B256::ZERO,
+            config_hash: B256::repeat_byte(1),
+            tee_image_hash: B256::repeat_byte(2),
+            zk_range_hash: B256::repeat_byte(3),
+            zk_aggregate_hash: B256::repeat_byte(4),
+        };
+
+        assert_ne!(
+            descriptor.fingerprint(),
+            ProofProtocolDescriptor { tee_image_hash: B256::repeat_byte(5), ..descriptor }
+                .fingerprint()
+        );
+        assert_ne!(
+            descriptor.fingerprint(),
+            ProofProtocolDescriptor { schedule_kind: ProofScheduleKind::Full, ..descriptor }
+                .fingerprint()
         );
     }
 }

--- a/crates/proof/contracts/src/lib.rs
+++ b/crates/proof/contracts/src/lib.rs
@@ -12,9 +12,10 @@ mod macros;
 mod aggregate_verifier;
 pub use aggregate_verifier::{
     AggregateVerifierClient, AggregateVerifierContractClient, GameInfo, GameStatus,
-    already_proven_selector, encode_challenge_calldata, encode_claim_credit_calldata,
-    encode_nullify_calldata, encode_resolve_calldata, encode_verify_proposal_proof_calldata,
-    invalid_parent_game_selector, invalid_signer_selector, l1_origin_too_old_selector,
+    ProofProtocolDescriptor, ProofScheduleKind, already_proven_selector, encode_challenge_calldata,
+    encode_claim_credit_calldata, encode_nullify_calldata, encode_resolve_calldata,
+    encode_verify_proposal_proof_calldata, invalid_parent_game_selector, invalid_signer_selector,
+    l1_origin_too_old_selector,
 };
 
 mod delayed_weth;

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -247,6 +247,12 @@ pub struct MockAggregateVerifier {
 
 #[async_trait]
 impl AggregateVerifierClient for MockAggregateVerifier {
+    async fn proof_protocol_descriptor(
+        &self,
+        _: Address,
+    ) -> Result<base_proof_contracts::ProofProtocolDescriptor, ContractError> {
+        unimplemented!("unused in proposer tests")
+    }
     async fn game_info(&self, _: Address) -> Result<GameInfo, ContractError> {
         unimplemented!("unused in proposer tests")
     }


### PR DESCRIPTION
## Summary

First PR in the N-version proof routing stack. Read-only: it adds the ability to *read* what a dispute game requires, and nothing that acts on it.

`ProofProtocolDescriptor` reads the commitments that determine which prover artifacts can satisfy a game — `CONFIG_HASH`, `TEE_IMAGE_HASH`, `ZK_RANGE_HASH`, `ZK_AGGREGATE_HASH`, and the journal schedule era — off the **historical game proxy**, and hashes them under a domain tag into a canonical fingerprint. Only full-schedule descriptors commit `schedule_id`; activated-prefix and no-schedule descriptors canonicalize that unused field to zero.

Two details worth review:

- **The era is classified on which getters exist, not on what they return.** Both schedule-aware eras expose `scheduleId`, and zero is a valid value for both, so truthiness cannot separate them. `is_missing_getter` pairs the structural check (empty revert data) with a message match, and is deliberately narrow: an unrecognized phrasing falls through to the error arm, which skips the game and retries, rather than silently misclassifying its era.
- **All six getters issue in one RPC round, and the CLI inventories games with bounded concurrency.** `L2_BLOCK_TIME` is speculative — only consulted when `scheduleId` succeeds — so a no-schedule game pays one concurrent revert instead of a serial round.

`basectl proofs protocol` prints every descriptor with its onchain status, then groups only in-progress games by fingerprint so `--proof-protocol-version <fingerprint>=<version>` mappings cover the live challenge set rather than resolved history. Any unreadable game is still printed around, but the command exits non-zero so a partial dump cannot be mistaken for a complete inventory. Today nothing can compute a fingerprint, which makes the mapping unwritable — that is what this unblocks.

## Why this is separate

Later PRs in the stack consume the fingerprint to route jobs. This one changes no behavior, so it can be reviewed on correctness of the derivation alone, and the tool it adds is needed *before* any routing is deployed.

## Validation

`cargo test -p basectl-cli` (including an inventory test that resolved games remain visible but do not enter the live mapping), plus targeted check/clippy for `base-proof-contracts`, `base-challenger`, and `base-proposer`. The follow-up also exports `ProofsProtocolArgs`, fixing the `unnameable_types` Clippy failure.

Not yet run against a live chain — that needs a factory address and L1 RPC, and is the first step of the rollout.

