### PR TITLE
fix(consensus): detect orphan despite missing receipts

### DIFF
--- a/crates/consensus/service/src/actors/sequencer/build.rs
+++ b/crates/consensus/service/src/actors/sequencer/build.rs
@@ -153,6 +153,15 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
                 self.engine_client.reset_engine_forkchoice(ResetReason::L1OriginOrphaned).await?;
                 return Ok(BuildOutcome::Deferred);
             }
+            Err(err @ L1OriginSelectorError::NextL1OriginOrphaned { .. }) => {
+                warn!(
+                    target: "sequencer",
+                    ?err,
+                    "Next L1 origin orphaned the accepted current origin, triggering engine reset"
+                );
+                self.engine_client.reset_engine_forkchoice().await?;
+                return Ok(BuildOutcome::Deferred);
+            }
             Err(err @ L1OriginSelectorError::NotEnoughData(_)) => {
                 warn!(
                     target: "sequencer",

--- a/crates/consensus/service/src/actors/sequencer/build.rs
+++ b/crates/consensus/service/src/actors/sequencer/build.rs
@@ -153,15 +153,6 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
                 self.engine_client.reset_engine_forkchoice(ResetReason::L1OriginOrphaned).await?;
                 return Ok(BuildOutcome::Deferred);
             }
-            Err(err @ L1OriginSelectorError::NextL1OriginOrphaned { .. }) => {
-                warn!(
-                    target: "sequencer",
-                    ?err,
-                    "Next L1 origin orphaned the accepted current origin, triggering engine reset"
-                );
-                self.engine_client.reset_engine_forkchoice().await?;
-                return Ok(BuildOutcome::Deferred);
-            }
             Err(err @ L1OriginSelectorError::NotEnoughData(_)) => {
                 warn!(
                     target: "sequencer",

--- a/crates/consensus/service/src/actors/sequencer/l1_origin/provider.rs
+++ b/crates/consensus/service/src/actors/sequencer/l1_origin/provider.rs
@@ -50,10 +50,11 @@ pub trait L1OriginSelectorProvider: Debug + Send + Sync + 'static {
         hash: B256,
     ) -> Result<Option<PreparedL1Origin>, L1OriginSelectorError>;
 
-    /// Returns a canonical successor prepared by its number.
+    /// Returns a canonical successor candidate prepared by its number.
     ///
-    /// Unlike [`Self::prepared_by_hash`], this speculative lookup requires receipts before the
-    /// successor can be adopted.
+    /// The candidate may omit receipts when their RPC is unavailable. This lets the selector
+    /// validate successor ancestry immediately, but it must not adopt the successor until receipts
+    /// are present.
     async fn prepared_by_number(
         &self,
         number: u64,
@@ -183,10 +184,19 @@ impl L1OriginSelectorProvider for DelayedL1OriginSelectorProvider {
                 )));
             }
             let hash = header.hash_slow();
-            let Some(receipts) = self.receipts_by_hash(hash).await? else {
-                return Err(L1OriginSelectorError::ReceiptsUnavailable(hash));
+            let receipts = match self.receipts_by_hash(hash).await {
+                Ok(receipts) => receipts.map(Arc::new),
+                Err(error) => {
+                    warn!(
+                        target: "l1_origin_selector",
+                        error = %error,
+                        l1_origin = %hash,
+                        "L1 receipts unavailable while preparing successor origin"
+                    );
+                    None
+                }
             };
-            Ok(Some(PreparedL1Origin { hash, header, receipts: Some(receipts.into()) }))
+            Ok(Some(PreparedL1Origin { hash, header, receipts }))
         } else {
             Ok(None)
         }
@@ -197,8 +207,11 @@ impl L1OriginSelectorProvider for DelayedL1OriginSelectorProvider {
 mod tests {
     use std::time::Duration;
 
+    use alloy_eips::NumHash;
     use alloy_rpc_client::RpcClient;
     use alloy_rpc_types_eth::{Block as RpcBlock, Header as RpcHeader};
+    use base_common_genesis::RollupConfig;
+    use base_protocol::L2BlockInfo;
     use httpmock::prelude::*;
     use metrics_util::{
         CompositeKey, MetricKind,
@@ -207,6 +220,7 @@ mod tests {
     use reqwest::Client;
 
     use super::*;
+    use crate::{L1OriginSelector, OriginSelector};
 
     type SnapshotEntry =
         (CompositeKey, Option<metrics::Unit>, Option<metrics::SharedString>, DebugValue);
@@ -326,7 +340,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn successor_is_not_prepared_without_receipts() {
+    async fn successor_header_is_prepared_without_receipts() {
         let server = MockServer::start_async().await;
         let header = Header { number: 7, ..Default::default() };
         let hash = header.hash_slow();
@@ -353,13 +367,178 @@ mod tests {
             .await;
         let provider = test_provider(&server, Some(BlockInfo { number: 7, ..Default::default() }));
 
-        let error = provider.prepared_by_number(7).await.unwrap_err();
+        let prepared = provider
+            .prepared_by_number(7)
+            .await
+            .unwrap()
+            .expect("successor header should remain available for ancestry validation");
 
-        assert!(
-            matches!(error, L1OriginSelectorError::ReceiptsUnavailable(value) if value == hash)
-        );
+        assert_eq!(prepared.hash, hash);
+        assert!(prepared.receipts.is_none());
         block_mock.assert_calls_async(1).await;
         receipts_mock.assert_calls_async(1).await;
+    }
+
+    #[tokio::test]
+    async fn current_origin_receipt_timeout_is_propagated() {
+        let server = MockServer::start_async().await;
+        let header = Header::default();
+        let hash = header.hash_slow();
+        let block: RpcBlock = RpcBlock::empty(RpcHeader::new(header));
+        let block_mock = server
+            .mock_async(move |when, then| {
+                when.method(POST)
+                    .path("/")
+                    .json_body_includes(r#"{"method":"eth_getBlockByHash"}"#);
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .json_body_obj(&JsonRpcResponse { jsonrpc: "2.0", id: 0, result: block });
+            })
+            .await;
+        let receipts_mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/")
+                    .json_body_includes(r#"{"method":"eth_getBlockReceipts"}"#);
+                then.status(200).delay(RESPONSE_DELAY);
+            })
+            .await;
+        let provider = test_provider(&server, None);
+
+        let result = provider.prepared_by_hash(hash).await;
+
+        assert!(result.is_err());
+        block_mock.assert_calls_async(1).await;
+        receipts_mock.assert_calls_async(1).await;
+    }
+
+    #[tokio::test]
+    async fn successor_header_is_prepared_when_receipts_time_out() {
+        let server = MockServer::start_async().await;
+        let header = Header { number: 7, ..Default::default() };
+        let hash = header.hash_slow();
+        let block: RpcBlock = RpcBlock::empty(RpcHeader::new(header));
+        let block_mock = server
+            .mock_async(move |when, then| {
+                when.method(POST)
+                    .path("/")
+                    .json_body_includes(r#"{"method":"eth_getBlockByNumber"}"#);
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .json_body_obj(&JsonRpcResponse { jsonrpc: "2.0", id: 0, result: block });
+            })
+            .await;
+        let receipts_mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/")
+                    .json_body_includes(r#"{"method":"eth_getBlockReceipts"}"#);
+                then.status(200).delay(RESPONSE_DELAY);
+            })
+            .await;
+        let provider = test_provider(&server, Some(BlockInfo { number: 7, ..Default::default() }));
+
+        let prepared =
+            provider.prepared_by_number(7).await.unwrap().expect(
+                "receipt timeout must preserve the successor header for ancestry validation",
+            );
+
+        assert_eq!(prepared.hash, hash);
+        assert!(prepared.receipts.is_none());
+        block_mock.assert_calls_async(1).await;
+        receipts_mock.assert_calls_async(1).await;
+    }
+
+    #[tokio::test]
+    async fn selector_detects_orphan_when_successor_receipts_time_out() {
+        let server = MockServer::start_async().await;
+        let current_header = Header { number: 4, ..Default::default() };
+        let current_hash = current_header.hash_slow();
+        let successor_header = Header {
+            parent_hash: B256::with_last_byte(99),
+            number: 5,
+            timestamp: 2,
+            ..Default::default()
+        };
+        let successor_hash = successor_header.hash_slow();
+        let current_block: RpcBlock = RpcBlock::empty(RpcHeader::new(current_header.clone()));
+        let successor_block: RpcBlock = RpcBlock::empty(RpcHeader::new(successor_header));
+        server
+            .mock_async(move |when, then| {
+                when.method(POST)
+                    .path("/")
+                    .json_body_includes(r#"{"method":"eth_getBlockByHash"}"#);
+                then.status(200).header("content-type", "application/json").json_body_obj(
+                    &JsonRpcResponse { jsonrpc: "2.0", id: 0, result: current_block },
+                );
+            })
+            .await;
+        server
+            .mock_async(move |when, then| {
+                when.method(POST)
+                    .path("/")
+                    .json_body_includes(r#"{"method":"eth_getBlockByNumber"}"#);
+                then.status(200).header("content-type", "application/json").json_body_obj(
+                    &JsonRpcResponse { jsonrpc: "2.0", id: 0, result: successor_block },
+                );
+            })
+            .await;
+        let current_receipts_mock = server
+            .mock_async(move |when, then| {
+                when.method(POST)
+                    .path("/")
+                    .json_body_includes(r#"{"method":"eth_getBlockReceipts"}"#)
+                    .body_includes(current_hash.to_string());
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .body(r#"{"jsonrpc":"2.0","id":1,"result":[]}"#);
+            })
+            .await;
+        let successor_receipts_mock = server
+            .mock_async(move |when, then| {
+                when.method(POST)
+                    .path("/")
+                    .json_body_includes(r#"{"method":"eth_getBlockReceipts"}"#)
+                    .body_includes(successor_hash.to_string());
+                then.status(200).delay(RESPONSE_DELAY);
+            })
+            .await;
+        let provider = test_provider(
+            &server,
+            Some(BlockInfo { hash: B256::with_last_byte(10), number: 10, ..Default::default() }),
+        );
+        let mut selector = L1OriginSelector::new(
+            Arc::new(RollupConfig {
+                block_time: 2,
+                max_sequencer_drift: 600,
+                ..Default::default()
+            }),
+            provider,
+        );
+        let unsafe_head = L2BlockInfo {
+            l1_origin: NumHash { number: current_header.number, hash: current_hash },
+            ..Default::default()
+        };
+
+        assert_eq!(selector.next_l1_origin(unsafe_head).await.unwrap().hash, current_hash);
+        let error = tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                match selector.next_l1_origin(unsafe_head).await {
+                    Ok(_) => tokio::task::yield_now().await,
+                    Err(error) => break error,
+                }
+            }
+        })
+        .await
+        .expect("selector should detect the orphan after the receipt request times out");
+
+        assert!(matches!(
+            error,
+            L1OriginSelectorError::NextL1OriginOrphaned { current, next }
+                if current == current_hash && next == successor_hash
+        ));
+        current_receipts_mock.assert_calls_async(1).await;
+        successor_receipts_mock.assert_calls_async(1).await;
     }
 
     #[test]

--- a/crates/consensus/service/src/actors/sequencer/l1_origin/selector.rs
+++ b/crates/consensus/service/src/actors/sequencer/l1_origin/selector.rs
@@ -317,6 +317,9 @@ impl<P: L1OriginSelectorProvider> L1OriginSelector<P> {
                 next: block.hash,
             });
         }
+        if block.receipts.is_none() {
+            return Ok(NextSlot::Idle);
+        }
         Ok(NextSlot::Ready { block: Box::new(block), chain_view })
     }
 
@@ -395,9 +398,6 @@ pub enum L1OriginSelectorError {
         /// Hash of its canonical-height successor.
         next: B256,
     },
-    /// The block header exists but its receipts are not available yet.
-    #[error("receipts unavailable for L1 origin: {0}")]
-    ReceiptsUnavailable(B256),
 }
 
 #[cfg(test)]
@@ -419,6 +419,7 @@ mod tests {
         chain_view: Arc<Mutex<Option<B256>>>,
         chain_view_after_number_fetch: Arc<Mutex<Option<B256>>>,
         failed_number_fetches: HashSet<u64>,
+        missing_receipts: Arc<Mutex<HashSet<u64>>>,
         number_delay: Arc<Mutex<Duration>>,
     }
 
@@ -460,6 +461,16 @@ mod tests {
         /// Fails lookups for the given L1 block number.
         fn fail_block_number(&mut self, number: u64) {
             self.failed_number_fetches.insert(number);
+        }
+
+        /// Omits receipts from lookups for the given L1 block number.
+        fn omit_receipts(&self, number: u64) {
+            self.missing_receipts.lock().expect("missing receipts lock poisoned").insert(number);
+        }
+
+        /// Restores receipts for lookups at the given L1 block number.
+        fn restore_receipts(&self, number: u64) {
+            self.missing_receipts.lock().expect("missing receipts lock poisoned").remove(&number);
         }
 
         /// Delays lookups by number.
@@ -512,7 +523,18 @@ mod tests {
             {
                 self.set_chain_view(chain_view);
             }
-            Ok(block.map(prepared))
+            Ok(block.map(|block| {
+                let mut prepared = prepared(block);
+                if self
+                    .missing_receipts
+                    .lock()
+                    .expect("missing receipts lock poisoned")
+                    .contains(&number)
+                {
+                    prepared.receipts = None;
+                }
+                prepared
+            }))
         }
     }
 
@@ -1188,6 +1210,131 @@ mod tests {
             key.key().name() == "base_node.sequencer_l1_origin_orphans_total"
                 && value == &DebugValue::Counter(1)
         }));
+    }
+
+    #[tokio::test]
+    async fn test_wrong_parent_without_receipts_still_reports_orphan() {
+        let cfg = Arc::new(RollupConfig {
+            block_time: 2,
+            max_sequencer_drift: 600,
+            ..Default::default()
+        });
+        let current = BlockInfo { hash: B256::with_last_byte(1), number: 4, ..Default::default() };
+        let orphaning_successor = BlockInfo {
+            hash: B256::with_last_byte(2),
+            parent_hash: B256::with_last_byte(99),
+            number: 5,
+            timestamp: 2,
+        };
+        let provider = MockOriginSelectorProvider::default();
+        provider.with_block(current);
+        provider.with_block(orphaning_successor);
+        provider.omit_receipts(orphaning_successor.number);
+        provider.set_chain_view(B256::with_last_byte(10));
+        let mut selector = L1OriginSelector::new(cfg, provider);
+        let selected_rx = selector.subscribe();
+        let unsafe_head = L2BlockInfo {
+            l1_origin: NumHash { number: current.number, hash: current.hash },
+            ..Default::default()
+        };
+
+        assert_eq!(selector.next_l1_origin(unsafe_head).await.unwrap(), current);
+        selector.wait_for_inflight_completion().await;
+        let error = selector.next_l1_origin(unsafe_head).await.unwrap_err();
+
+        assert!(matches!(
+            error,
+            L1OriginSelectorError::NextL1OriginOrphaned { current: hash, next }
+                if hash == current.hash && next == orphaning_successor.hash
+        ));
+        assert!(selected_rx.borrow().is_none());
+        assert!(selector.next().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_same_height_current_origin_reorg_is_detected_by_canonical_successor() {
+        let cfg = Arc::new(RollupConfig {
+            block_time: 2,
+            max_sequencer_drift: 600,
+            ..Default::default()
+        });
+        let current = BlockInfo { hash: B256::with_last_byte(1), number: 4, ..Default::default() };
+        let replacement = BlockInfo {
+            hash: B256::with_last_byte(2),
+            parent_hash: current.parent_hash,
+            ..current
+        };
+        let canonical_successor = BlockInfo {
+            hash: B256::with_last_byte(3),
+            parent_hash: replacement.hash,
+            number: 5,
+            timestamp: 2,
+        };
+        let provider = MockOriginSelectorProvider::default();
+        provider.with_block(current);
+        let mut selector = L1OriginSelector::new(cfg, provider);
+        let unsafe_head = L2BlockInfo {
+            l1_origin: NumHash { number: current.number, hash: current.hash },
+            ..Default::default()
+        };
+
+        assert_eq!(selector.next_l1_origin(unsafe_head).await.unwrap(), current);
+        selector.await_inflight().await;
+
+        selector.l1.replace_block(replacement);
+        selector.l1.set_chain_view(replacement.hash);
+        assert_eq!(
+            selector.next_l1_origin(unsafe_head).await.unwrap(),
+            current,
+            "without a canonical successor, sequencing may continue on the accepted origin"
+        );
+
+        selector.l1.with_block(canonical_successor);
+        assert_eq!(selector.next_l1_origin(unsafe_head).await.unwrap(), current);
+        selector.wait_for_inflight_completion().await;
+        let error = selector.next_l1_origin(unsafe_head).await.unwrap_err();
+
+        assert!(matches!(
+            error,
+            L1OriginSelectorError::NextL1OriginOrphaned { current: hash, next }
+                if hash == current.hash && next == canonical_successor.hash
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_successor_without_receipts_is_not_adopted() {
+        let cfg = Arc::new(RollupConfig {
+            block_time: 2,
+            max_sequencer_drift: 600,
+            ..Default::default()
+        });
+        let current = BlockInfo { hash: B256::with_last_byte(1), number: 4, ..Default::default() };
+        let successor = BlockInfo {
+            hash: B256::with_last_byte(2),
+            parent_hash: current.hash,
+            number: 5,
+            timestamp: 2,
+        };
+        let provider = MockOriginSelectorProvider::default();
+        provider.with_block(current);
+        provider.with_block(successor);
+        provider.omit_receipts(successor.number);
+        provider.set_chain_view(B256::with_last_byte(10));
+        let mut selector = L1OriginSelector::new(cfg, provider);
+        let unsafe_head = L2BlockInfo {
+            l1_origin: NumHash { number: current.number, hash: current.hash },
+            ..Default::default()
+        };
+
+        assert_eq!(selector.next_l1_origin(unsafe_head).await.unwrap(), current);
+        selector.wait_for_inflight_completion().await;
+        assert_eq!(selector.next_l1_origin(unsafe_head).await.unwrap(), current);
+        assert!(selector.next().is_none());
+
+        selector.l1.restore_receipts(successor.number);
+        selector.wait_for_inflight_completion().await;
+        assert_eq!(selector.next_l1_origin(unsafe_head).await.unwrap(), successor);
+        assert_eq!(selector.next(), Some(successor));
     }
 
     #[tokio::test]

--- a/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
@@ -534,16 +534,21 @@ async fn test_try_seal_handle_non_fatal_seal_error_returns_none() {
 }
 
 #[rstest]
-#[case::awaiting_l1_origin(false)]
-#[case::provider_error(true)]
+#[case::awaiting_l1_origin(false, false)]
+#[case::provider_error(true, false)]
+#[case::repeated_orphan_resets(false, true)]
 #[tokio::test(start_paused = true)]
-async fn test_build_retries_are_paced_after_immediate_budget(#[case] provider_error: bool) {
+async fn test_build_retries_are_paced_after_immediate_budget(
+    #[case] provider_error: bool,
+    #[case] orphaned: bool,
+) {
     let attempts_before_delay = usize::from(ScheduledTicker::MAX_IMMEDIATE_L1_ORIGIN_RETRIES) + 1;
     let expected_attempts = attempts_before_delay + 1;
     let (attempt_tx, mut attempt_rx) = mpsc::unbounded_channel();
 
     let mut client = MockSequencerEngineClient::new();
-    client.expect_reset_engine_forkchoice().times(1).return_once(|_| Ok(()));
+    let expected_resets = if orphaned { expected_attempts + 1 } else { 1 };
+    client.expect_reset_engine_forkchoice().times(expected_resets).returning(|_| Ok(()));
     client
         .expect_get_unsafe_head()
         .times(expected_attempts)
@@ -553,7 +558,12 @@ async fn test_build_retries_are_paced_after_immediate_budget(#[case] provider_er
     let mut origin_selector = MockOriginSelector::new();
     origin_selector.expect_next_l1_origin().times(expected_attempts).returning(move |_| {
         attempt_tx.send(()).unwrap();
-        if provider_error {
+        if orphaned {
+            Err(L1OriginSelectorError::NextL1OriginOrphaned {
+                current: B256::with_last_byte(1),
+                next: B256::with_last_byte(2),
+            })
+        } else if provider_error {
             Err(L1OriginSelectorError::Provider(TransportErrorKind::custom_str(
                 "mock L1 provider failure",
             )))
@@ -619,6 +629,37 @@ async fn test_orphaned_l1_origin_resets_once_without_starting_block_build() {
     actor.builder.engine_client = Arc::new(client);
 
     assert!(matches!(actor.builder.build().await.unwrap(), crate::BuildOutcome::Deferred));
+}
+
+#[tokio::test]
+async fn test_orphaned_l1_origin_propagates_engine_reset_failure() {
+    let unsafe_head = L2BlockInfo::default();
+    let mut client = MockSequencerEngineClient::new();
+    client.expect_get_unsafe_head().times(1).return_once(move || Ok(unsafe_head));
+    client
+        .expect_reset_engine_forkchoice()
+        .with(mockall::predicate::eq(ResetReason::L1OriginOrphaned))
+        .times(1)
+        .return_once(|_| Err(EngineClientError::ResetForkchoiceError("mock reset failure".into())));
+    client.expect_start_build_block().times(0);
+
+    let mut origin_selector = MockOriginSelector::new();
+    origin_selector.expect_next_l1_origin().times(1).return_once(|_| {
+        Err(L1OriginSelectorError::NextL1OriginOrphaned {
+            current: B256::with_last_byte(1),
+            next: B256::with_last_byte(2),
+        })
+    });
+
+    let mut actor = test_actor();
+    actor.builder.origin_selector = origin_selector;
+    actor.builder.engine_client = Arc::new(client);
+
+    assert!(matches!(
+        actor.builder.build().await,
+        Err(SequencerActorError::EngineError(EngineClientError::ResetForkchoiceError(error)))
+            if error == "mock reset failure"
+    ));
 }
 
 #[rstest]


### PR DESCRIPTION
This PR is the first coverage layer on top of #4336. It fixes a case where the background successor lookup discarded a canonical L1 header when its receipt RPC timed out. That header can prove that the currently accepted L1 origin is orphaned even without receipts, so discarding it could let sequencing continue on the orphaned origin.

The selector now validates successor ancestry as soon as the header is available. A receiptless successor can trigger the existing engine reset when its parent does not match, but it cannot be adopted for block building until its receipts are available. Current-origin receipt failures keep their existing error behavior.

The tests cover wrong-parent successors with missing receipts, receipt recovery before adoption, same-height L1 replacements detected through the canonical successor, a real HTTP receipt timeout, current-origin receipt timeouts, bounded retry pacing across repeated orphan resets, and propagation of engine reset failures without starting a block build.

The full base-consensus-node test suite passed with 292 unit tests and 10 integration tests. Clippy passed with warnings denied. Rustfmt and git diff checks also passed.

This PR depends on #4336 and targets its branch. The new GitHub stacked PR feature is not enabled for this repository, so this is represented as a standard stacked PR.