### PR TITLE
test(consensus): Cover Deep Reorg Recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6448,6 +6448,7 @@ dependencies = [
  "alloy-signer-local 2.2.0",
  "alloy-sol-types",
  "async-trait",
+ "axum 0.8.9",
  "base-batcher-encoder",
  "base-batcher-service",
  "base-builder-core",
@@ -6501,6 +6502,7 @@ dependencies = [
  "reth-node-builder",
  "reth-node-core",
  "reth-provider",
+ "reth-rpc-layer",
  "reth-tasks",
  "serde",
  "serde_json",
@@ -6508,6 +6510,7 @@ dependencies = [
  "testcontainers",
  "tokio",
  "tokio-util",
+ "tower 0.5.3",
  "tracing",
  "url",
 ]

--- a/etc/systems/Cargo.toml
+++ b/etc/systems/Cargo.toml
@@ -75,7 +75,10 @@ tokio-util.workspace = true
 tokio = { workspace = true, features = ["full", "rt-multi-thread", "macros"] }
 
 # rpc
+axum = { workspace = true, features = ["http1", "tokio"] }
 jsonrpsee = { workspace = true, features = ["http-client"] }
+reth-rpc-layer.workspace = true
+tower.workspace = true
 
 # p2p
 k256.workspace = true

--- a/etc/systems/src/l1/config.rs
+++ b/etc/systems/src/l1/config.rs
@@ -21,4 +21,7 @@ pub struct L1ContainerConfig {
     /// overlayfs on docker-in-docker CI runners) reject; tmpfs supports it. No effect where the
     /// storage already supports mmap.
     pub tmpfs_datadir: bool,
+    /// If true, supervise Reth so system tests can stop the node process, mutate its database, and
+    /// restart it without replacing the container.
+    pub enable_reorg_control: bool,
 }

--- a/etc/systems/src/l1/lighthouse.rs
+++ b/etc/systems/src/l1/lighthouse.rs
@@ -96,15 +96,18 @@ impl LighthouseBeaconContainer {
     pub fn internal_beacon_url(&self) -> String {
         format!("http://{}:{}", self.name, L1_BEACON_HTTP_PORT)
     }
+
+    /// Stops the beacon node so it cannot overwrite a test-controlled execution forkchoice.
+    pub async fn stop(&self) -> Result<()> {
+        self.container.stop().await?;
+        Ok(())
+    }
 }
 
 /// Lighthouse validator client container wrapper.
 #[derive(Debug)]
 pub struct LighthouseValidatorContainer {
-    #[allow(dead_code)]
     container: ContainerAsync<GenericImage>,
-    #[allow(dead_code)]
-    name: String,
 }
 
 impl LighthouseValidatorContainer {
@@ -148,7 +151,13 @@ impl LighthouseValidatorContainer {
             .start()
             .await?;
 
-        Ok(Self { container, name })
+        Ok(Self { container })
+    }
+
+    /// Stops the validator before its beacon node is stopped for fault injection.
+    pub async fn stop(&self) -> Result<()> {
+        self.container.stop().await?;
+        Ok(())
     }
 }
 

--- a/etc/systems/src/l1/mod.rs
+++ b/etc/systems/src/l1/mod.rs
@@ -8,9 +8,17 @@ pub use config::L1ContainerConfig;
 mod lighthouse;
 pub use lighthouse::{LighthouseBeaconContainer, LighthouseValidatorContainer};
 
+/// Controllable L1 JSON-RPC proxy for fault injection.
+mod rpc_proxy;
+pub use rpc_proxy::L1RpcProxy;
+
 /// Reth execution layer container.
 mod reth;
 pub use reth::RethContainer;
+
+/// Authenticated Engine API driver for replacement L1 branches.
+mod reorg;
+pub use reorg::{L1ReorgDriver, L1ReplacementBranch};
 
 /// L1 stack orchestration.
 mod stack;

--- a/etc/systems/src/l1/reorg.rs
+++ b/etc/systems/src/l1/reorg.rs
@@ -1,0 +1,192 @@
+//! Authenticated Engine API support for constructing replacement L1 branches.
+
+use std::time::Duration;
+
+use alloy_eips::eip1898::BlockNumberOrTag;
+use alloy_network::Ethereum;
+use alloy_primitives::{Address, B256, keccak256};
+use alloy_provider::{Provider, RootProvider};
+use alloy_rpc_types_engine::{
+    ExecutionPayloadEnvelopeV5, ForkchoiceState, ForkchoiceUpdated, JwtSecret, PayloadAttributes,
+    PayloadStatus, PayloadStatusEnum,
+};
+use eyre::{OptionExt, Result, WrapErr, ensure};
+use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
+use reth_rpc_layer::AuthClientLayer;
+use tower::ServiceBuilder;
+use url::Url;
+
+/// Description of a replacement branch installed through the Engine API.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct L1ReplacementBranch {
+    /// Hash of the last block shared with the old canonical branch.
+    pub common_ancestor: B256,
+    /// Hashes of the replacement blocks in ascending block-number order.
+    pub replacement_hashes: Vec<B256>,
+}
+
+impl L1ReplacementBranch {
+    /// Returns the replacement head hash.
+    pub fn head(&self) -> Option<B256> {
+        self.replacement_hashes.last().copied()
+    }
+}
+
+/// Driver for constructing an empty canonical L1 branch through an authenticated Engine API.
+#[derive(Clone, Debug)]
+pub struct L1ReorgDriver {
+    rpc_url: Url,
+    engine_url: Url,
+    jwt_secret: JwtSecret,
+}
+
+impl L1ReorgDriver {
+    /// Creates a replacement-branch driver.
+    pub fn new(rpc_url: Url, engine_url: Url, jwt_secret_hex: &str) -> Result<Self> {
+        let jwt_secret =
+            JwtSecret::from_hex(jwt_secret_hex).wrap_err("Invalid L1 Engine API JWT secret")?;
+        Ok(Self { rpc_url, engine_url, jwt_secret })
+    }
+
+    /// Builds empty replacement blocks from the current head through `target_number`.
+    ///
+    /// Reth must already be unwound to the intended common ancestor, and `first_timestamp` must be
+    /// later than every block timestamp from the branch that was removed.
+    pub async fn build_replacement(
+        &self,
+        target_number: u64,
+        first_timestamp: u64,
+        block_time: u64,
+    ) -> Result<L1ReplacementBranch> {
+        ensure!(block_time > 0, "replacement L1 block time must be nonzero");
+
+        let provider = RootProvider::<Ethereum>::new_http(self.rpc_url.clone());
+        let ancestor = provider
+            .get_block_by_number(BlockNumberOrTag::Latest)
+            .await
+            .wrap_err("Failed to fetch replacement branch ancestor")?
+            .ok_or_eyre("Replacement branch ancestor is missing")?;
+        ensure!(
+            ancestor.header.number < target_number,
+            "replacement target must be above common ancestor"
+        );
+
+        let safe = provider
+            .get_block_by_number(BlockNumberOrTag::Safe)
+            .await
+            .wrap_err("Failed to fetch L1 safe block")?;
+        let finalized = provider
+            .get_block_by_number(BlockNumberOrTag::Finalized)
+            .await
+            .wrap_err("Failed to fetch L1 finalized block")?;
+        ensure!(
+            safe.as_ref().is_none_or(|block| block.header.number <= ancestor.header.number),
+            "cannot replace an L1 branch below the safe block"
+        );
+        ensure!(
+            finalized.as_ref().is_none_or(|block| block.header.number <= ancestor.header.number),
+            "cannot replace an L1 branch below the finalized block"
+        );
+
+        let auth_layer = AuthClientLayer::new(self.jwt_secret);
+        let middleware = ServiceBuilder::new().layer(auth_layer);
+        let client = HttpClientBuilder::default()
+            .request_timeout(Duration::from_secs(15))
+            .set_http_middleware(middleware)
+            .build(self.engine_url.as_str())
+            .wrap_err("Failed to build authenticated L1 Engine API client")?;
+
+        let common_ancestor = ancestor.header.hash;
+        let mut forkchoice = ForkchoiceState {
+            head_block_hash: common_ancestor,
+            safe_block_hash: safe.as_ref().map_or(common_ancestor, |block| block.header.hash),
+            finalized_block_hash: finalized
+                .as_ref()
+                .map_or(common_ancestor, |block| block.header.hash),
+        };
+        let minimum_timestamp = ancestor
+            .header
+            .timestamp
+            .checked_add(block_time)
+            .ok_or_eyre("replacement L1 timestamp overflowed")?;
+        let mut timestamp = first_timestamp.max(minimum_timestamp);
+        let mut replacement_hashes = Vec::with_capacity(
+            usize::try_from(target_number - ancestor.header.number)
+                .wrap_err("Replacement branch length does not fit in memory")?,
+        );
+
+        for number in (ancestor.header.number + 1)..=target_number {
+            let parent_beacon_block_root =
+                keccak256(format!("system-test-replacement-parent-{number}"));
+            let attributes = PayloadAttributes {
+                timestamp,
+                prev_randao: keccak256(format!("system-test-replacement-randao-{number}")),
+                suggested_fee_recipient: Address::ZERO,
+                withdrawals: Some(Vec::new()),
+                parent_beacon_block_root: Some(parent_beacon_block_root),
+                ..Default::default()
+            };
+            let started: ForkchoiceUpdated = client
+                .request("engine_forkchoiceUpdatedV3", rpc_params![forkchoice, attributes])
+                .await
+                .wrap_err_with(|| format!("Failed to start replacement L1 block {number}"))?;
+            Self::ensure_payload_valid(&started.payload_status, number, "start build")?;
+            let payload_id = started.payload_id.ok_or_eyre("Engine did not return a payload ID")?;
+
+            tokio::time::sleep(Duration::from_millis(250)).await;
+            let envelope: ExecutionPayloadEnvelopeV5 = client
+                .request("engine_getPayloadV5", rpc_params![payload_id])
+                .await
+                .wrap_err_with(|| format!("Failed to retrieve replacement L1 block {number}"))?;
+            let payload = envelope.execution_payload;
+            let block_hash = payload.payload_inner.payload_inner.block_hash;
+            let payload_number = payload.payload_inner.payload_inner.block_number;
+            ensure!(payload_number == number, "Engine built unexpected L1 block {payload_number}");
+
+            let status: PayloadStatus = client
+                .request(
+                    "engine_newPayloadV4",
+                    rpc_params![
+                        payload,
+                        Vec::<B256>::new(),
+                        parent_beacon_block_root,
+                        envelope.execution_requests
+                    ],
+                )
+                .await
+                .wrap_err_with(|| format!("Failed to submit replacement L1 block {number}"))?;
+            Self::ensure_payload_valid(&status, number, "submit payload")?;
+
+            forkchoice.head_block_hash = block_hash;
+            let selected: ForkchoiceUpdated = client
+                .request(
+                    "engine_forkchoiceUpdatedV3",
+                    rpc_params![forkchoice, Option::<PayloadAttributes>::None],
+                )
+                .await
+                .wrap_err_with(|| format!("Failed to select replacement L1 block {number}"))?;
+            Self::ensure_payload_valid(&selected.payload_status, number, "select forkchoice")?;
+
+            replacement_hashes.push(block_hash);
+            timestamp = timestamp
+                .checked_add(block_time)
+                .ok_or_eyre("replacement L1 timestamp overflowed")?;
+        }
+
+        Ok(L1ReplacementBranch { common_ancestor, replacement_hashes })
+    }
+
+    /// Requires the Engine API to accept a replacement-branch operation.
+    pub fn ensure_payload_valid(
+        status: &PayloadStatus,
+        number: u64,
+        operation: &str,
+    ) -> Result<()> {
+        ensure!(
+            status.status == PayloadStatusEnum::Valid,
+            "Engine failed to {operation} for L1 block {number}: {:?}",
+            status.status
+        );
+        Ok(())
+    }
+}

--- a/etc/systems/src/l1/reth.rs
+++ b/etc/systems/src/l1/reth.rs
@@ -1,7 +1,9 @@
-use eyre::{Result, WrapErr, eyre};
+use std::time::Duration;
+
+use eyre::{Result, WrapErr, ensure, eyre};
 use testcontainers::{
     ContainerAsync, GenericImage, ImageExt,
-    core::{IntoContainerPort, Mount, WaitFor},
+    core::{CmdWaitFor, ContainerRequest, ExecCommand, IntoContainerPort, Mount, WaitFor},
     runners::AsyncRunner,
 };
 use url::Url;
@@ -18,12 +20,44 @@ const HTTP_PORT: u16 = 8545;
 const ENGINE_PORT: u16 = 8551;
 const GENESIS_PATH: &str = "/genesis/el/genesis.json";
 const JWT_PATH: &str = "/genesis/jwt.hex";
+const RETH_SUPERVISOR: &str = r#"#!/bin/sh
+set -eu
+
+rm -f /tmp/reth-paused /tmp/reth-restart
+child=""
+forward_signal() {
+    if [ -n "$child" ]; then
+        kill -TERM "$child" 2>/dev/null || true
+    fi
+}
+trap forward_signal TERM INT
+
+while true; do
+    /usr/local/bin/reth "$@" &
+    child="$!"
+    echo "$child" > /tmp/reth-child.pid
+    wait "$child" || status="$?"
+    touch /tmp/reth-paused
+
+    while [ -f /tmp/reth-pause ]; do
+        sleep 0.05
+    done
+
+    if [ -f /tmp/reth-restart ]; then
+        rm -f /tmp/reth-restart /tmp/reth-paused
+        unset status
+        continue
+    fi
+    exit "${status:-0}"
+done
+"#;
 
 #[derive(Debug)]
 /// A container running the Reth execution layer.
 pub struct RethContainer {
     container: ContainerAsync<GenericImage>,
     name: String,
+    reorg_control_enabled: bool,
 }
 
 impl RethContainer {
@@ -45,10 +79,22 @@ impl RethContainer {
             RETH_IMAGE.split_once(':').ok_or_else(|| eyre!("Reth image tag is missing"))?;
 
         let image = GenericImage::new(image_name, image_tag)
-            .with_entrypoint("reth")
             .with_exposed_port(HTTP_PORT.tcp())
             .with_exposed_port(ENGINE_PORT.tcp())
             .with_wait_for(WaitFor::message_on_stdout("RPC HTTP server started"));
+        let (image, command) = if config.enable_reorg_control {
+            let image = image
+                .with_entrypoint("sh")
+                .with_copy_to("/reth-supervisor.sh", RETH_SUPERVISOR.as_bytes().to_vec());
+            let command: Vec<String> = std::iter::once("/reth-supervisor.sh".to_string())
+                .chain(reth_args().into_iter().map(str::to_string))
+                .collect();
+            (image, command)
+        } else {
+            let image: ContainerRequest<_> = image.with_entrypoint("reth").into();
+            let command: Vec<String> = reth_args().into_iter().map(str::to_string).collect();
+            (image, command)
+        };
 
         let name = if config.use_stable_names {
             L1_RETH_NAME.to_string()
@@ -60,7 +106,7 @@ impl RethContainer {
         let mut container_builder = image
             .with_container_name(&name)
             .with_network(&network)
-            .with_cmd(reth_args())
+            .with_cmd(command)
             .with_copy_to(GENESIS_PATH, genesis_json.as_ref().to_vec())
             .with_copy_to(JWT_PATH, jwt_secret_hex.as_ref().to_vec());
 
@@ -81,7 +127,7 @@ impl RethContainer {
         let container =
             container_builder.start().await.wrap_err("Failed to start Reth container")?;
 
-        Ok(Self { container, name })
+        Ok(Self { container, name, reorg_control_enabled: config.enable_reorg_control })
     }
 
     /// Returns the public RPC URL of the container.
@@ -112,6 +158,79 @@ impl RethContainer {
             .await
             .wrap_err("Failed to resolve container port")?;
         Url::parse(&format!("http://{host}:{host_port}")).wrap_err("Failed to build container URL")
+    }
+
+    /// Stops the supervised Reth node, unwinds its database to `block_number`, and restarts it.
+    pub async fn unwind_to(&self, block_number: u64) -> Result<()> {
+        ensure!(self.reorg_control_enabled, "Reth reorg control was not enabled for this stack");
+
+        let control_script = format!(
+            "touch /tmp/reth-pause; \
+             kill -TERM \"$(cat /tmp/reth-child.pid)\" 2>/dev/null || true; \
+             attempts=0; \
+             while [ ! -f /tmp/reth-paused ] && [ \"$attempts\" -lt 200 ]; do \
+                 attempts=$((attempts + 1)); sleep 0.05; \
+             done; \
+             if [ ! -f /tmp/reth-paused ]; then \
+                 kill -KILL \"$(cat /tmp/reth-child.pid)\" 2>/dev/null || true; \
+                 attempts=0; \
+                 while [ ! -f /tmp/reth-paused ] && [ \"$attempts\" -lt 200 ]; do \
+                     attempts=$((attempts + 1)); sleep 0.05; \
+                 done; \
+             fi; \
+             if [ ! -f /tmp/reth-paused ]; then rm -f /tmp/reth-pause; exit 1; fi; \
+             /usr/local/bin/reth stage unwind --datadir /data to-block \
+                 --chain {GENESIS_PATH} {block_number}; \
+             status=$?; \
+             touch /tmp/reth-restart; \
+             rm -f /tmp/reth-pause; \
+             exit \"$status\""
+        );
+        self.container
+            .exec(
+                ExecCommand::new(["sh", "-c", &control_script])
+                    .with_cmd_ready_condition(CmdWaitFor::exit_code(0)),
+            )
+            .await
+            .wrap_err("Failed to unwind and restart supervised Reth process")?;
+
+        let rpc_url = self.rpc_url().await?;
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .build()
+            .wrap_err("Failed to build Reth readiness client")?;
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        loop {
+            let response = client
+                .post(rpc_url.clone())
+                .json(&serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "eth_blockNumber",
+                    "params": [],
+                }))
+                .send()
+                .await;
+            let ready = match response {
+                Ok(response) if response.status().is_success() => response
+                    .json::<serde_json::Value>()
+                    .await
+                    .ok()
+                    .and_then(|body| {
+                        body.get("result").and_then(serde_json::Value::as_str).map(str::to_owned)
+                    })
+                    .is_some(),
+                _ => false,
+            };
+            if ready {
+                return Ok(());
+            }
+            ensure!(
+                tokio::time::Instant::now() < deadline,
+                "Reth RPC did not recover after database unwind"
+            );
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
     }
 }
 

--- a/etc/systems/src/l1/rpc_proxy.rs
+++ b/etc/systems/src/l1/rpc_proxy.rs
@@ -1,0 +1,124 @@
+//! Controllable L1 JSON-RPC forwarding for system-test fault injection.
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, AtomicU64, Ordering},
+};
+
+use axum::{
+    Router,
+    body::{Body, Bytes},
+    http::{Response, StatusCode},
+    routing::post,
+};
+use eyre::{Result, WrapErr};
+use tokio::{net::TcpListener, task::JoinHandle};
+use url::Url;
+
+/// An HTTP proxy that can make the configured L1 JSON-RPC endpoint unavailable on demand.
+#[derive(Debug)]
+pub struct L1RpcProxy {
+    url: Url,
+    available: Arc<AtomicBool>,
+    rejected_requests: Arc<AtomicU64>,
+    task: JoinHandle<()>,
+}
+
+impl L1RpcProxy {
+    /// Starts a proxy forwarding JSON-RPC requests to `upstream`.
+    pub async fn start(upstream: Url) -> Result<Self> {
+        let listener =
+            TcpListener::bind("127.0.0.1:0").await.wrap_err("Failed to bind L1 RPC fault proxy")?;
+        let address = listener.local_addr().wrap_err("Failed to read L1 RPC proxy address")?;
+        let url = Url::parse(&format!("http://{address}"))?;
+        let available = Arc::new(AtomicBool::new(true));
+        let handler_available = Arc::clone(&available);
+        let rejected_requests = Arc::new(AtomicU64::new(0));
+        let handler_rejected_requests = Arc::clone(&rejected_requests);
+        let client = reqwest::Client::new();
+
+        let app = Router::new().route(
+            "/",
+            post(move |body: Bytes| {
+                let available = Arc::clone(&handler_available);
+                let rejected_requests = Arc::clone(&handler_rejected_requests);
+                let client = client.clone();
+                let upstream = upstream.clone();
+                async move {
+                    if !available.load(Ordering::Acquire) {
+                        rejected_requests.fetch_add(1, Ordering::Relaxed);
+                        return Response::builder()
+                            .status(StatusCode::SERVICE_UNAVAILABLE)
+                            .body(Body::from("L1 RPC fault injected"))
+                            .expect("static L1 RPC outage response should be valid");
+                    }
+
+                    match client
+                        .post(upstream)
+                        .header("content-type", "application/json")
+                        .body(body)
+                        .send()
+                        .await
+                    {
+                        Ok(response) => {
+                            let status = response.status();
+                            match response.bytes().await {
+                                Ok(body) => Response::builder()
+                                    .status(status)
+                                    .header("content-type", "application/json")
+                                    .body(Body::from(body))
+                                    .expect("forwarded L1 RPC response should be valid"),
+                                Err(error) => Response::builder()
+                                    .status(StatusCode::BAD_GATEWAY)
+                                    .body(Body::from(error.to_string()))
+                                    .expect("L1 RPC body error response should be valid"),
+                            }
+                        }
+                        Err(error) => Response::builder()
+                            .status(StatusCode::BAD_GATEWAY)
+                            .body(Body::from(error.to_string()))
+                            .expect("L1 RPC forwarding error response should be valid"),
+                    }
+                }
+            }),
+        );
+        let task = tokio::spawn(async move {
+            if let Err(error) = axum::serve(listener, app).await {
+                tracing::warn!(error = %error, "L1 RPC fault proxy stopped unexpectedly");
+            }
+        });
+
+        Ok(Self { url, available, rejected_requests, task })
+    }
+
+    /// Returns the proxy URL.
+    pub const fn url(&self) -> &Url {
+        &self.url
+    }
+
+    /// Rejects all subsequent L1 RPC requests.
+    pub fn disable(&self) {
+        self.available.store(false, Ordering::Release);
+    }
+
+    /// Resumes forwarding L1 RPC requests.
+    pub fn enable(&self) {
+        self.available.store(true, Ordering::Release);
+    }
+
+    /// Returns whether requests are currently forwarded.
+    pub fn is_available(&self) -> bool {
+        self.available.load(Ordering::Acquire)
+    }
+
+    /// Returns the number of requests rejected while fault injection was active.
+    pub fn rejected_requests(&self) -> u64 {
+        self.rejected_requests.load(Ordering::Relaxed)
+    }
+}
+
+impl Drop for L1RpcProxy {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}

--- a/etc/systems/src/l1/stack.rs
+++ b/etc/systems/src/l1/stack.rs
@@ -27,7 +27,6 @@ pub struct L1StackConfig {
 pub struct L1Stack {
     reth: RethContainer,
     beacon: LighthouseBeaconContainer,
-    #[allow(dead_code)]
     validator: LighthouseValidatorContainer,
     #[allow(dead_code)]
     jwt_path: PathBuf,
@@ -96,5 +95,12 @@ impl L1Stack {
     /// Returns the public URL of the Lighthouse beacon container.
     pub async fn beacon_url(&self) -> Result<String> {
         self.beacon.beacon_url().await
+    }
+
+    /// Stops the L1 validator and beacon node, leaving the execution layer under test control.
+    pub async fn stop_consensus(&self) -> Result<()> {
+        self.validator.stop().await.wrap_err("Failed to stop L1 validator")?;
+        self.beacon.stop().await.wrap_err("Failed to stop L1 beacon node")?;
+        Ok(())
     }
 }

--- a/etc/systems/src/lib.rs
+++ b/etc/systems/src/lib.rs
@@ -41,8 +41,8 @@ pub use images::{OP_DEPLOYER_IMAGE, RETH_IMAGE};
 
 mod l1;
 pub use l1::{
-    L1ContainerConfig, L1Stack, L1StackConfig, LighthouseBeaconContainer,
-    LighthouseValidatorContainer, RethContainer,
+    L1ContainerConfig, L1ReorgDriver, L1ReplacementBranch, L1RpcProxy, L1Stack, L1StackConfig,
+    LighthouseBeaconContainer, LighthouseValidatorContainer, RethContainer,
 };
 
 mod l2;

--- a/etc/systems/src/smoke.rs
+++ b/etc/systems/src/smoke.rs
@@ -29,7 +29,7 @@ use url::Url;
 use crate::upgrade_signal::{MockProtocolVersionsClient, UpgradeSignalStackOptions};
 use crate::{
     BATCHER, BUILDER, SEQUENCER,
-    l1::{L1ContainerConfig, L1Stack, L1StackConfig},
+    l1::{L1ContainerConfig, L1RpcProxy, L1Stack, L1StackConfig},
     l2::{
         L2ClientConsensusMode, L2ContainerConfig, L2Stack, L2StackConfig, ShadowSequencersConfig,
     },
@@ -107,6 +107,7 @@ pub struct SystemTestStack {
     l2_deployment: L2DeploymentOutput,
     l1_stack: L1Stack,
     l2_stack: L2Stack,
+    l1_rpc_proxy: Option<L1RpcProxy>,
     #[cfg(feature = "upgrade-signal")]
     upgrade_signal: Option<MockProtocolVersionsClient>,
     /// Must be the last field: it clears the runtime registry on drop, so the stacks above
@@ -133,6 +134,11 @@ impl SystemTestStack {
     /// Returns a reference to the L2 stack.
     pub const fn l2_stack(&self) -> &L2Stack {
         &self.l2_stack
+    }
+
+    /// Returns the controllable L1 RPC proxy when fault injection was enabled.
+    pub const fn l1_rpc_proxy(&self) -> Option<&L1RpcProxy> {
+        self.l1_rpc_proxy.as_ref()
     }
 
     /// Returns the public RPC URL of the L1 Reth node.
@@ -288,6 +294,7 @@ pub struct SystemTestStackBuilder {
     shadow_blocks_per_cycle: Option<NonZeroU64>,
     shadow_start_block: Option<u64>,
     tmpfs_datadirs: bool,
+    l1_fault_injection: bool,
     extra_builder_extensions: Vec<Box<dyn BaseNodeExtension>>,
     extra_client_extensions: Vec<Box<dyn BaseNodeExtension>>,
     #[cfg(feature = "upgrade-signal")]
@@ -389,6 +396,12 @@ impl SystemTestStackBuilder {
     /// already supports mmap.
     pub const fn with_tmpfs_datadirs(mut self) -> Self {
         self.tmpfs_datadirs = true;
+        self
+    }
+
+    /// Routes L2 services through a controllable L1 RPC proxy and enables L1 reorg control.
+    pub const fn with_l1_fault_injection(mut self) -> Self {
+        self.l1_fault_injection = true;
         self
     }
 
@@ -534,6 +547,7 @@ impl SystemTestStackBuilder {
                     beacon_http_port: Some(config.ports.l1_cl_http),
                     beacon_p2p_port: Some(config.ports.l1_cl_p2p),
                     tmpfs_datadir: self.tmpfs_datadirs,
+                    enable_reorg_control: self.l1_fault_injection,
                 };
                 let l2_config = L2ContainerConfig {
                     use_stable_names: true,
@@ -559,8 +573,11 @@ impl SystemTestStackBuilder {
 
         // Ensure the tmpfs-datadir request reaches the L1 containers even without a stable config.
         let l1_container_config = l1_container_config.or_else(|| {
-            self.tmpfs_datadirs
-                .then(|| L1ContainerConfig { tmpfs_datadir: true, ..Default::default() })
+            (self.tmpfs_datadirs || self.l1_fault_injection).then(|| L1ContainerConfig {
+                tmpfs_datadir: self.tmpfs_datadirs,
+                enable_reorg_control: self.l1_fault_injection,
+                ..Default::default()
+            })
         });
 
         let l1_config = L1StackConfig {
@@ -636,6 +653,16 @@ impl SystemTestStackBuilder {
         #[cfg(not(feature = "upgrade-signal"))]
         let (l2_upgrade_signal, l2_execution_upgrade_signal) = (None, None);
 
+        let direct_l1_rpc_url = l1_stack.reth().rpc_url().await?;
+        let l1_rpc_proxy = if self.l1_fault_injection {
+            Some(L1RpcProxy::start(direct_l1_rpc_url.clone()).await?)
+        } else {
+            None
+        };
+        let l2_l1_rpc_url = l1_rpc_proxy
+            .as_ref()
+            .map_or_else(|| direct_l1_rpc_url.to_string(), |proxy| proxy.url().to_string());
+
         let l2_config = L2StackConfig {
             l2_genesis: l2_genesis_bytes,
             rollup_config: rollup_config_bytes,
@@ -644,7 +671,7 @@ impl SystemTestStackBuilder {
             p2p_key: BUILDER.private_key,
             sequencer_key: SEQUENCER.private_key,
             batcher_key: BATCHER.private_key,
-            l1_rpc_url: l1_stack.reth().rpc_url().await?.to_string(),
+            l1_rpc_url: l2_l1_rpc_url,
             l1_beacon_url: l1_stack.beacon().beacon_url().await?,
             container_config: l2_container_config,
             tx_forwarding_config: self.tx_forwarding_config,
@@ -669,6 +696,7 @@ impl SystemTestStackBuilder {
             l2_deployment,
             l1_stack,
             l2_stack,
+            l1_rpc_proxy,
             #[cfg(feature = "upgrade-signal")]
             upgrade_signal,
             #[cfg(feature = "upgrade-signal")]

--- a/etc/systems/tests/l1_reorg_recovery.rs
+++ b/etc/systems/tests/l1_reorg_recovery.rs
@@ -1,0 +1,263 @@
+//! System test for sequencer recovery from an L1 outage followed by a deep reorg.
+
+use std::time::Duration;
+
+use alloy_eips::{BlockNumberOrTag, NumHash};
+use alloy_network::Ethereum;
+use alloy_primitives::B256;
+use alloy_provider::{Provider, RootProvider};
+use base_common_genesis::RollupConfig;
+use base_common_network::Base;
+use base_protocol::{L2BlockInfo, SyncStatus};
+use base_system_tests::{
+    L1ReorgDriver, L1RpcProxy, SystemTestProviderExt, SystemTestRpcClient, SystemTestStackBuilder,
+};
+use eyre::{OptionExt, Result, WrapErr, ensure};
+use tokio::time::{sleep, timeout};
+
+const L1_CHAIN_ID: u64 = 1337;
+const L2_CHAIN_ID: u64 = 84538453;
+const L1_BLOCK_TIME: u64 = 4;
+const REORG_DEPTH: u64 = 6;
+const OUTAGE_BLOCKS: u64 = 10;
+const RECOVERY_BLOCKS: u64 = 5;
+const POLL_INTERVAL: Duration = Duration::from_millis(500);
+const ORIGIN_TIMEOUT: Duration = Duration::from_secs(90);
+const RECOVERY_TIMEOUT: Duration = Duration::from_secs(180);
+
+#[tokio::test]
+async fn sequencer_recovers_from_l1_outage_and_deep_reorg() -> Result<()> {
+    base_node_runner::test_utils::init_silenced_tracing();
+    let system = SystemTestStackBuilder::new()
+        .with_l1_chain_id(L1_CHAIN_ID)
+        .with_l2_chain_id(L2_CHAIN_ID)
+        .with_l1_fault_injection()
+        .build()
+        .await?;
+    let urls = system.urls().await?;
+    let rpc = SystemTestRpcClient::new(
+        &urls.l1_rpc,
+        &urls.l2_builder_rpc,
+        &urls.l2_client_rpc,
+        &urls.l2_builder_consensus_rpc,
+        &urls.l2_client_consensus_rpc,
+    )?;
+    let l1_provider = system.l1_provider().await?;
+    let builder = system.l2_builder_provider()?;
+    let client = system.l2_client_provider()?;
+    let rollup_config: RollupConfig =
+        serde_json::from_str(&system.l2_deployment().read_rollup_config()?)?;
+
+    wait_for_reorgable_origin(&rpc, &l1_provider).await?;
+    let proxy = system.l1_rpc_proxy().ok_or_eyre("L1 fault proxy was not configured")?;
+    let l1_head_before_outage = l1_provider.get_block_number().await?;
+    proxy.disable();
+    wait_for_rejected_request(proxy).await?;
+
+    let settling_height = builder.get_block_number().await? + 2;
+    builder.wait_for_block(settling_height, ORIGIN_TIMEOUT).await?;
+    let outage_start = builder.get_block_number().await?;
+    let cached_origin = rpc.l2_builder_sync_status().await?.unsafe_l2.l1_origin;
+    let old_l2_tip = builder.wait_for_block(outage_start + OUTAGE_BLOCKS, ORIGIN_TIMEOUT).await?;
+    ensure!(
+        l1_provider.get_block_number().await? > l1_head_before_outage,
+        "L1 did not advance while its RPC was unavailable to L2 services"
+    );
+    ensure!(
+        rpc.l2_builder_sync_status().await?.unsafe_l2.l1_origin == cached_origin,
+        "sequencer did not continue on one cached L1 origin throughout the outage"
+    );
+    client.wait_for_block(old_l2_tip, ORIGIN_TIMEOUT).await?;
+    client.wait_for_convergence(&builder, old_l2_tip, ORIGIN_TIMEOUT).await?;
+    let mut outage_hashes = Vec::new();
+    for height in (outage_start + 1)..=old_l2_tip {
+        let block = l2_block_info(&builder, height, &rollup_config).await?;
+        ensure!(
+            block.l1_origin == cached_origin,
+            "L2 block {height} did not use the cached L1 origin during the outage"
+        );
+        ensure!(
+            client.block_hash_at(height).await? == Some(block.block_info.hash),
+            "validator did not hold the outage chain at L2 block {height}"
+        );
+        outage_hashes.push((height, block.block_info.hash));
+    }
+
+    system.l1_stack().stop_consensus().await?;
+    let old_l1_head = l1_provider
+        .get_block_by_number(BlockNumberOrTag::Latest)
+        .await?
+        .ok_or_eyre("L1 latest block is missing")?;
+    let old_origin_hash = l1_block_hash(&l1_provider, cached_origin.number).await?;
+    ensure!(
+        old_origin_hash == cached_origin.hash,
+        "the sequencer's cached origin was not canonical before fault injection"
+    );
+    let common_ancestor_number = cached_origin
+        .number
+        .checked_sub(REORG_DEPTH)
+        .ok_or_eyre("cached origin is too early for the configured reorg depth")?;
+    let common_ancestor_hash = l1_block_hash(&l1_provider, common_ancestor_number).await?;
+
+    system.l1_stack().reth().unwind_to(common_ancestor_number).await?;
+    let reorg = L1ReorgDriver::new(
+        system.l1_rpc_url().await?,
+        system.l1_stack().engine_url().await?,
+        &system.l1_genesis().read_jwt_secret()?,
+    )?;
+    let replacement = reorg
+        .build_replacement(
+            old_l1_head.header.number + 2,
+            old_l1_head.header.timestamp + L1_BLOCK_TIME,
+            L1_BLOCK_TIME,
+        )
+        .await?;
+    ensure!(
+        replacement.common_ancestor == common_ancestor_hash,
+        "replacement L1 branch started from an unexpected ancestor"
+    );
+    ensure!(
+        replacement.replacement_hashes.len()
+            == usize::try_from(old_l1_head.header.number + 2 - common_ancestor_number)?,
+        "replacement L1 branch has an unexpected length"
+    );
+    let replacement_origin_hash = l1_block_hash(&l1_provider, cached_origin.number).await?;
+    ensure!(
+        replacement_origin_hash != old_origin_hash,
+        "the replacement L1 branch did not orphan the cached sequencer origin"
+    );
+
+    proxy.enable();
+    for (height, old_hash) in &outage_hashes {
+        wait_for_changed_block(&builder, *height, *old_hash).await?;
+        let rebuilt = l2_block_info(&builder, *height, &rollup_config).await?;
+        ensure!(
+            l1_block_hash(&l1_provider, rebuilt.l1_origin.number).await? == rebuilt.l1_origin.hash,
+            "rebuilt L2 block {height} retained a noncanonical L1 origin"
+        );
+    }
+    let rebuilt_tip =
+        builder.wait_for_block(old_l2_tip + RECOVERY_BLOCKS, RECOVERY_TIMEOUT).await?;
+    wait_for_replacement_origin(
+        &rpc,
+        common_ancestor_number,
+        cached_origin.number,
+        &replacement.replacement_hashes,
+    )
+    .await?;
+
+    let adoption_tip = builder.get_block_number().await?.max(rebuilt_tip);
+    builder.wait_for_block(adoption_tip + RECOVERY_BLOCKS, RECOVERY_TIMEOUT).await?;
+
+    Ok(())
+}
+
+async fn wait_for_rejected_request(proxy: &L1RpcProxy) -> Result<()> {
+    timeout(ORIGIN_TIMEOUT, async {
+        while proxy.rejected_requests() == 0 {
+            sleep(POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .wrap_err("L1 fault proxy did not reject a request after the outage began")
+}
+
+async fn wait_for_reorgable_origin(
+    rpc: &SystemTestRpcClient,
+    l1_provider: &RootProvider<Ethereum>,
+) -> Result<SyncStatus> {
+    timeout(ORIGIN_TIMEOUT, async {
+        loop {
+            let status = rpc.l2_builder_sync_status().await?;
+            let safe = l1_provider
+                .get_block_by_number(BlockNumberOrTag::Safe)
+                .await?
+                .ok_or_eyre("L1 safe block is missing")?;
+            let protected_origin = safe.header.number.max(status.finalized_l2.l1_origin.number);
+            if status.unsafe_l2.l1_origin.number > protected_origin + REORG_DEPTH {
+                return Ok::<_, eyre::Error>(status);
+            }
+            sleep(POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .wrap_err("sequencer did not reach an L1 origin deep enough to reorg")?
+}
+
+async fn wait_for_changed_block(
+    provider: &RootProvider<Base>,
+    height: u64,
+    old_hash: B256,
+) -> Result<B256> {
+    timeout(RECOVERY_TIMEOUT, async {
+        loop {
+            if let Some(hash) = provider.block_hash_at(height).await?
+                && hash != old_hash
+            {
+                return Ok::<_, eyre::Error>(hash);
+            }
+            sleep(POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .wrap_err("sequencer did not automatically replace blocks built on the orphaned L1 origin")?
+}
+
+async fn wait_for_replacement_origin(
+    rpc: &SystemTestRpcClient,
+    common_ancestor_number: u64,
+    minimum_origin_number: u64,
+    replacement_hashes: &[B256],
+) -> Result<()> {
+    timeout(RECOVERY_TIMEOUT, async {
+        loop {
+            let origin = rpc.l2_builder_sync_status().await?.unsafe_l2.l1_origin;
+            if origin.number >= minimum_origin_number
+                && replacement_contains_origin(common_ancestor_number, replacement_hashes, origin)
+            {
+                return Ok::<_, eyre::Error>(());
+            }
+            sleep(POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .wrap_err("sequencer did not adopt an origin from the replacement L1 branch")?
+}
+
+fn replacement_contains_origin(
+    common_ancestor_number: u64,
+    replacement_hashes: &[B256],
+    origin: NumHash,
+) -> bool {
+    origin
+        .number
+        .checked_sub(common_ancestor_number + 1)
+        .and_then(|index| usize::try_from(index).ok())
+        .and_then(|index| replacement_hashes.get(index))
+        == Some(&origin.hash)
+}
+
+async fn l2_block_info(
+    provider: &RootProvider<Base>,
+    number: u64,
+    rollup_config: &RollupConfig,
+) -> Result<L2BlockInfo> {
+    let block = provider
+        .get_block_by_number(BlockNumberOrTag::Number(number))
+        .full()
+        .await?
+        .ok_or_eyre("L2 block is missing at the requested height")?
+        .map_header(|header| header.into_inner())
+        .into_consensus()
+        .map_transactions(|transaction| transaction.inner.inner);
+    L2BlockInfo::from_block_and_genesis(&block, &rollup_config.genesis)
+        .wrap_err("Failed to decode L1 origin from L2 block")
+}
+
+async fn l1_block_hash(provider: &RootProvider<Ethereum>, number: u64) -> Result<B256> {
+    provider
+        .get_block_by_number(BlockNumberOrTag::Number(number))
+        .await?
+        .map(|block| block.header.hash)
+        .ok_or_eyre("L1 block is missing at the requested height")
+}


### PR DESCRIPTION
## Summary

Adds a Docker-backed system test that keeps sequencing on a cached L1 origin during an RPC outage, then replaces L1 deeply enough to orphan that origin. The test verifies automatic L2 rewind and rebuild onto canonical origins, adoption of the replacement L1 branch, and continued sequencing after recovery. It also adds reusable L1 RPC fault injection and replacement-branch controls to the system test stack.