### PR TITLE
feat(roxy): JSON-RPC passthrough to a named backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6274,6 +6274,7 @@ dependencies = [
  "base-health",
  "clap",
  "reqwest 0.13.4",
+ "serde",
  "serde_json",
  "tokio",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6274,9 +6274,12 @@ dependencies = [
  "base-health",
  "clap",
  "reqwest 0.13.4",
+ "serde_json",
  "tokio",
  "tokio-util",
  "tracing",
+ "url",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/infra/roxy/Cargo.toml
+++ b/crates/infra/roxy/Cargo.toml
@@ -17,11 +17,12 @@ tokio-util.workspace = true
 tokio = { workspace = true, features = ["net"] }
 anyhow = { workspace = true, features = ["std"] }
 tracing = { workspace = true, features = ["std"] }
-reqwest = { workspace = true, features = ["json", "stream"] }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
-axum = { workspace = true, features = ["tokio", "http1", "json"] }
+reqwest = { workspace = true, features = ["json", "stream"] }
 base-health = { workspace = true, features = ["axum-server"] }
 clap = { workspace = true, features = ["derive", "env", "std"] }
+axum = { workspace = true, features = ["tokio", "http1", "json"] }
 
 [dev-dependencies]
 wiremock.workspace = true

--- a/crates/infra/roxy/Cargo.toml
+++ b/crates/infra/roxy/Cargo.toml
@@ -18,12 +18,13 @@ tokio = { workspace = true, features = ["net"] }
 anyhow = { workspace = true, features = ["std"] }
 tracing = { workspace = true, features = ["std"] }
 serde = { workspace = true, features = ["derive"] }
+reqwest = { workspace = true, features = ["stream"] }
 serde_json = { workspace = true, features = ["std"] }
-reqwest = { workspace = true, features = ["json", "stream"] }
 base-health = { workspace = true, features = ["axum-server"] }
 clap = { workspace = true, features = ["derive", "env", "std"] }
 axum = { workspace = true, features = ["tokio", "http1", "json"] }
 
 [dev-dependencies]
 wiremock.workspace = true
+reqwest = { workspace = true, features = ["json"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/infra/roxy/Cargo.toml
+++ b/crates/infra/roxy/Cargo.toml
@@ -12,14 +12,18 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
+url.workspace = true
 tokio-util.workspace = true
 tokio = { workspace = true, features = ["net"] }
 anyhow = { workspace = true, features = ["std"] }
 tracing = { workspace = true, features = ["std"] }
-axum = { workspace = true, features = ["tokio", "http1"] }
+reqwest = { workspace = true, features = ["json"] }
+serde_json = { workspace = true, features = ["std"] }
+axum = { workspace = true, features = ["tokio", "http1", "json"] }
 base-health = { workspace = true, features = ["axum-server"] }
 clap = { workspace = true, features = ["derive", "env", "std"] }
 
 [dev-dependencies]
+wiremock.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/infra/roxy/Cargo.toml
+++ b/crates/infra/roxy/Cargo.toml
@@ -17,7 +17,7 @@ tokio-util.workspace = true
 tokio = { workspace = true, features = ["net"] }
 anyhow = { workspace = true, features = ["std"] }
 tracing = { workspace = true, features = ["std"] }
-reqwest = { workspace = true, features = ["json"] }
+reqwest = { workspace = true, features = ["json", "stream"] }
 serde_json = { workspace = true, features = ["std"] }
 axum = { workspace = true, features = ["tokio", "http1", "json"] }
 base-health = { workspace = true, features = ["axum-server"] }
@@ -25,5 +25,4 @@ clap = { workspace = true, features = ["derive", "env", "std"] }
 
 [dev-dependencies]
 wiremock.workspace = true
-reqwest = { workspace = true, features = ["json"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/infra/roxy/README.md
+++ b/crates/infra/roxy/README.md
@@ -3,8 +3,8 @@
 JSON-RPC reverse proxy for Base infrastructure. Replaces the `ProxyD` fork with a
 Rust service we own, focused on the features we actually run in production.
 
-> **Status:** single-backend JSON-RPC passthrough. Batch, whitelist, and
-> multi-backend routing come in follow-up PRs.
+> **Status:** JSON-RPC passthrough. Batch, whitelist, and multi-backend routing
+> come in follow-up PRs.
 
 ## Usage
 
@@ -14,8 +14,8 @@ roxy \
   --backend rpcs=http://127.0.0.1:8545,http://127.0.0.1:8546
 ```
 
-Exactly one `--backend` is required. Extra URLs on that backend are accepted and
-stored; traffic currently uses the first URL.
+At least one `--backend` is required (names must be unique). Traffic currently
+uses the first URL of the first backend; multi-backend routing comes later.
 
 `POST /` accepts a single JSON-RPC request object and forwards it to the
 backend. Batch arrays are rejected. `GET /healthz` is liveness; `GET /readyz`

--- a/crates/infra/roxy/README.md
+++ b/crates/infra/roxy/README.md
@@ -18,8 +18,9 @@ At least one `--backend` is required (names must be unique). Traffic currently
 uses the first URL of the first backend; multi-backend routing comes later.
 
 `POST /` accepts a single JSON-RPC request object and forwards it to the
-backend. Batch arrays are rejected. `GET /healthz` is liveness; `GET /readyz`
-is readiness.
+backend. Batch arrays are rejected. Upstream response body and `Content-Type`
+are preserved; the client always receives HTTP 200 for forwarded responses.
+`GET /healthz` is liveness; `GET /readyz` is readiness.
 
 Run `roxy --help` for the full flag list. Every flag also accepts an env var
 (see `--help`).

--- a/crates/infra/roxy/README.md
+++ b/crates/infra/roxy/README.md
@@ -3,15 +3,23 @@
 JSON-RPC reverse proxy for Base infrastructure. Replaces the `ProxyD` fork with a
 Rust service we own, focused on the features we actually run in production.
 
-> **Status:** scaffolding only. No proxying yet.
+> **Status:** single-backend JSON-RPC passthrough. Batch, whitelist, and
+> multi-backend routing come in follow-up PRs.
 
 ## Usage
 
 ```bash
-roxy --listen-addr 0.0.0.0:8545
+roxy \
+  --listen-addr 0.0.0.0:8545 \
+  --backend rpcs=http://127.0.0.1:8545,http://127.0.0.1:8546
 ```
 
-`GET /healthz` is the liveness probe. `GET /readyz` is the readiness probe.
+Exactly one `--backend` is required. Extra URLs on that backend are accepted and
+stored; traffic currently uses the first URL.
+
+`POST /` accepts a single JSON-RPC request object and forwards it to the
+backend. Batch arrays are rejected. `GET /healthz` is liveness; `GET /readyz`
+is readiness.
 
 Run `roxy --help` for the full flag list. Every flag also accepts an env var
 (see `--help`).

--- a/crates/infra/roxy/src/backend.rs
+++ b/crates/infra/roxy/src/backend.rs
@@ -31,6 +31,14 @@ impl Backend {
             }
             let url = Url::parse(part)
                 .map_err(|error| format!("invalid --backend URL '{part}' in '{raw}': {error}"))?;
+            match url.scheme() {
+                "http" | "https" => {}
+                scheme => {
+                    return Err(format!(
+                        "invalid --backend URL '{part}' in '{raw}': unsupported scheme '{scheme}' (expected http or https)"
+                    ));
+                }
+            }
             urls.push(url);
         }
 
@@ -74,5 +82,14 @@ mod tests {
     fn parse_rejects_empty_urls() {
         let error = Backend::parse("rpcs=").expect_err("empty urls");
         assert!(error.contains("at least one URL"), "error={error}");
+    }
+
+    #[test]
+    fn parse_rejects_non_http_schemes() {
+        let error = Backend::parse("rpcs=file:///tmp/rpc").expect_err("file scheme");
+        assert!(error.contains("unsupported scheme 'file'"), "error={error}");
+
+        let error = Backend::parse("rpcs=ftp://example.com/rpc").expect_err("ftp scheme");
+        assert!(error.contains("unsupported scheme 'ftp'"), "error={error}");
     }
 }

--- a/crates/infra/roxy/src/backend.rs
+++ b/crates/infra/roxy/src/backend.rs
@@ -1,0 +1,78 @@
+//! Named backend definitions for Roxy.
+
+use url::Url;
+
+/// A named backend: one or more RPC target URLs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Backend {
+    /// Backend name (unique among configured backends).
+    pub name: String,
+    /// Target URLs for this backend (non-empty).
+    pub urls: Vec<Url>,
+}
+
+impl Backend {
+    /// Parses `name=url[,url...]`.
+    pub fn parse(raw: &str) -> Result<Self, String> {
+        let (name, urls_part) = raw.split_once('=').ok_or_else(|| {
+            format!("invalid --backend value '{raw}': expected name=url[,url...]")
+        })?;
+
+        let name = name.trim();
+        if name.is_empty() {
+            return Err(format!("invalid --backend value '{raw}': backend name is empty"));
+        }
+
+        let mut urls = Vec::new();
+        for part in urls_part.split(',') {
+            let part = part.trim();
+            if part.is_empty() {
+                continue;
+            }
+            let url = Url::parse(part)
+                .map_err(|error| format!("invalid --backend URL '{part}' in '{raw}': {error}"))?;
+            urls.push(url);
+        }
+
+        if urls.is_empty() {
+            return Err(format!("invalid --backend value '{raw}': at least one URL is required"));
+        }
+
+        Ok(Self { name: name.to_owned(), urls })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_single_url() {
+        let backend = Backend::parse("rpcs=http://127.0.0.1:8545").expect("parse");
+        assert_eq!(backend.name, "rpcs");
+        assert_eq!(backend.urls.len(), 1, "exactly one URL");
+        assert_eq!(backend.urls[0].as_str(), "http://127.0.0.1:8545/");
+    }
+
+    #[test]
+    fn parse_multiple_urls() {
+        let backend =
+            Backend::parse("rpcs=http://127.0.0.1:8545,http://127.0.0.1:8546").expect("parse");
+        assert_eq!(backend.name, "rpcs");
+        assert_eq!(backend.urls.len(), 2, "exactly two URLs");
+        assert_eq!(backend.urls[0].as_str(), "http://127.0.0.1:8545/");
+        assert_eq!(backend.urls[1].as_str(), "http://127.0.0.1:8546/");
+    }
+
+    #[test]
+    fn parse_rejects_missing_equals() {
+        let error = Backend::parse("rpcs").expect_err("missing '='");
+        assert!(error.contains("expected name=url"), "error={error}");
+    }
+
+    #[test]
+    fn parse_rejects_empty_urls() {
+        let error = Backend::parse("rpcs=").expect_err("empty urls");
+        assert!(error.contains("at least one URL"), "error={error}");
+    }
+}

--- a/crates/infra/roxy/src/config.rs
+++ b/crates/infra/roxy/src/config.rs
@@ -1,8 +1,8 @@
 //! CLI / env configuration for the Roxy HTTP server.
 
-use std::net::SocketAddr;
+use std::{collections::HashSet, net::SocketAddr};
 
-use anyhow::ensure;
+use anyhow::{bail, ensure};
 use clap::Args;
 
 use crate::Backend;
@@ -14,7 +14,7 @@ pub struct Config {
     #[arg(long, env = "ROXY_LISTEN_ADDR", default_value = "0.0.0.0:8545")]
     pub listen_addr: SocketAddr,
 
-    /// Named backend: `name=url[,url...]`. Exactly one backend is required for now.
+    /// Named backend: `name=url[,url...]`. At least one is required.
     #[arg(
         long = "backend",
         env = "ROXY_BACKEND",
@@ -25,19 +25,25 @@ pub struct Config {
 }
 
 impl Config {
-    /// Validates config and returns the single configured backend.
-    pub fn backend(&self) -> anyhow::Result<&Backend> {
+    /// Validates backends and returns them.
+    ///
+    /// Requires at least one backend and unique names. Request routing across
+    /// multiple backends is not implemented yet; callers currently use the first
+    /// entry for forwarding.
+    pub fn backends(&self) -> anyhow::Result<&[Backend]> {
         ensure!(
             !self.backends.is_empty(),
-            "exactly one --backend is required (e.g. --backend rpcs=http://127.0.0.1:8545)"
-        );
-        ensure!(
-            self.backends.len() == 1,
-            "exactly one --backend is required for now, found {}",
-            self.backends.len()
+            "at least one --backend is required (e.g. --backend rpcs=http://127.0.0.1:8545)"
         );
 
-        Ok(&self.backends[0])
+        let mut seen = HashSet::new();
+        for backend in &self.backends {
+            if !seen.insert(backend.name.as_str()) {
+                bail!("duplicate backend name '{}'", backend.name);
+            }
+        }
+
+        Ok(&self.backends)
     }
 }
 
@@ -50,24 +56,31 @@ mod tests {
     }
 
     #[test]
-    fn backend_requires_exactly_one() {
+    fn backends_requires_at_least_one() {
         let empty = config_with(vec![]);
-        let error = empty.backend().expect_err("empty");
-        assert!(error.to_string().contains("exactly one --backend"), "error={error}");
-
-        let two = config_with(vec![
-            Backend::parse("a=http://127.0.0.1:1").expect("parse"),
-            Backend::parse("b=http://127.0.0.1:2").expect("parse"),
-        ]);
-        let error = two.backend().expect_err("two backends");
-        assert!(error.to_string().contains("exactly one --backend"), "error={error}");
+        let error = empty.backends().expect_err("empty");
+        assert!(error.to_string().contains("at least one --backend"), "error={error}");
     }
 
     #[test]
-    fn backend_returns_the_only_entry() {
-        let config =
-            config_with(vec![Backend::parse("rpcs=http://127.0.0.1:8545").expect("parse")]);
-        let backend = config.backend().expect("one backend");
-        assert_eq!(backend.name, "rpcs");
+    fn backends_allows_multiple_unique_names() {
+        let config = config_with(vec![
+            Backend::parse("rpcs=http://127.0.0.1:1").expect("parse"),
+            Backend::parse("flashblocks=http://127.0.0.1:2").expect("parse"),
+        ]);
+        let backends = config.backends().expect("two backends");
+        assert_eq!(backends.len(), 2, "both backends retained");
+        assert_eq!(backends[0].name, "rpcs");
+        assert_eq!(backends[1].name, "flashblocks");
+    }
+
+    #[test]
+    fn backends_rejects_duplicate_names() {
+        let config = config_with(vec![
+            Backend::parse("rpcs=http://127.0.0.1:1").expect("parse"),
+            Backend::parse("rpcs=http://127.0.0.1:2").expect("parse"),
+        ]);
+        let error = config.backends().expect_err("duplicate name");
+        assert!(error.to_string().contains("duplicate backend name 'rpcs'"), "error={error}");
     }
 }

--- a/crates/infra/roxy/src/config.rs
+++ b/crates/infra/roxy/src/config.rs
@@ -1,8 +1,11 @@
 //! CLI / env configuration for the Roxy HTTP server.
 
-use std::net::SocketAddr;
+use std::{collections::HashSet, net::SocketAddr};
 
+use anyhow::{bail, ensure};
 use clap::Args;
+
+use crate::Backend;
 
 /// Configuration for the Roxy HTTP server.
 #[derive(Args, Debug, Clone)]
@@ -10,4 +13,68 @@ pub struct Config {
     /// Socket address to bind the HTTP server to.
     #[arg(long, env = "ROXY_LISTEN_ADDR", default_value = "0.0.0.0:8545")]
     pub listen_addr: SocketAddr,
+
+    /// Named backend: `name=url[,url...]`. Exactly one backend is required for now.
+    #[arg(
+        long = "backend",
+        env = "ROXY_BACKEND",
+        value_name = "NAME=URL[,URL...]",
+        value_parser = Backend::parse
+    )]
+    pub backends: Vec<Backend>,
+}
+
+impl Config {
+    /// Validates config and returns the single configured backend.
+    pub fn backend(&self) -> anyhow::Result<&Backend> {
+        ensure!(
+            !self.backends.is_empty(),
+            "exactly one --backend is required (e.g. --backend rpcs=http://127.0.0.1:8545)"
+        );
+        ensure!(
+            self.backends.len() == 1,
+            "exactly one --backend is required for now, found {}",
+            self.backends.len()
+        );
+
+        let mut seen = HashSet::new();
+        for backend in &self.backends {
+            if !seen.insert(backend.name.as_str()) {
+                bail!("duplicate backend name '{}'", backend.name);
+            }
+        }
+
+        Ok(&self.backends[0])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config_with(backends: Vec<Backend>) -> Config {
+        Config { listen_addr: "127.0.0.1:0".parse().expect("addr"), backends }
+    }
+
+    #[test]
+    fn backend_requires_exactly_one() {
+        let empty = config_with(vec![]);
+        let error = empty.backend().expect_err("empty");
+        assert!(error.to_string().contains("exactly one --backend"), "error={error}");
+
+        let two = config_with(vec![
+            Backend::parse("a=http://127.0.0.1:1").expect("parse"),
+            Backend::parse("b=http://127.0.0.1:2").expect("parse"),
+        ]);
+        let error = two.backend().expect_err("two backends");
+        assert!(error.to_string().contains("exactly one --backend"), "error={error}");
+    }
+
+    #[test]
+    fn backend_returns_the_only_entry() {
+        let config =
+            config_with(vec![Backend::parse("rpcs=http://127.0.0.1:8545").expect("parse")]);
+        let backend = config.backend().expect("one backend");
+        assert_eq!(backend.name, "rpcs");
+    }
 }

--- a/crates/infra/roxy/src/config.rs
+++ b/crates/infra/roxy/src/config.rs
@@ -1,8 +1,8 @@
 //! CLI / env configuration for the Roxy HTTP server.
 
-use std::{collections::HashSet, net::SocketAddr};
+use std::net::SocketAddr;
 
-use anyhow::{bail, ensure};
+use anyhow::ensure;
 use clap::Args;
 
 use crate::Backend;
@@ -36,13 +36,6 @@ impl Config {
             "exactly one --backend is required for now, found {}",
             self.backends.len()
         );
-
-        let mut seen = HashSet::new();
-        for backend in &self.backends {
-            if !seen.insert(backend.name.as_str()) {
-                bail!("duplicate backend name '{}'", backend.name);
-            }
-        }
 
         Ok(&self.backends[0])
     }

--- a/crates/infra/roxy/src/lib.rs
+++ b/crates/infra/roxy/src/lib.rs
@@ -1,7 +1,13 @@
 #![doc = include_str!("../README.md")]
 
+mod backend;
+pub use backend::Backend;
+
 mod config;
 pub use config::Config;
+
+mod proxy;
+pub use proxy::ProxyState;
 
 mod server;
 pub use server::Server;

--- a/crates/infra/roxy/src/lib.rs
+++ b/crates/infra/roxy/src/lib.rs
@@ -7,7 +7,7 @@ mod config;
 pub use config::Config;
 
 mod proxy;
-pub use proxy::ProxyState;
+pub use proxy::{MAX_REQUEST_BODY_BYTES, MAX_RESPONSE_BODY_BYTES, ProxyState};
 
 mod server;
 pub use server::Server;

--- a/crates/infra/roxy/src/proxy.rs
+++ b/crates/infra/roxy/src/proxy.rs
@@ -6,12 +6,12 @@ use axum::{
     Json, Router,
     body::Bytes,
     extract::{DefaultBodyLimit, State},
-    http::StatusCode,
+    http::{HeaderValue, StatusCode, header::CONTENT_TYPE},
     response::{IntoResponse, Response},
     routing::post,
 };
 use reqwest::Client;
-use serde::{Deserialize, de::IgnoredAny};
+use serde::Deserialize;
 use serde_json::{Value, json};
 use tracing::{error, warn};
 use url::Url;
@@ -62,7 +62,7 @@ impl ProxyState {
     }
 
     async fn handle_rpc(State(state): State<Self>, body: Bytes) -> Response {
-        // Avoid full `Value` materialization (heap amplification on crafted payloads).
+        // Only classify the envelope here; the backend owns full JSON-RPC validation.
         match first_non_whitespace(&body) {
             Some(b'[') => {
                 return jsonrpc_error(Value::Null, -32600, "batch requests are not supported");
@@ -71,19 +71,8 @@ impl ProxyState {
             Some(_) | None => return jsonrpc_error(Value::Null, -32600, "invalid request"),
         }
 
-        // Validate JSON without building a `Value` tree; unused fields are skipped.
-        if let Err(error) = serde_json::from_slice::<IgnoredAny>(&body) {
-            warn!(error = %error, "invalid JSON-RPC request body");
-            return jsonrpc_error(Value::Null, -32700, "parse error");
-        }
-
         match state.forward(&body).await {
-            Ok(response_body) => (
-                StatusCode::OK,
-                [(axum::http::header::CONTENT_TYPE, "application/json")],
-                response_body,
-            )
-                .into_response(),
+            Ok(upstream) => upstream.into_client_response(),
             Err(ForwardError::ResponseTooLarge) => {
                 warn!(
                     backend = %state.backend_name,
@@ -105,27 +94,28 @@ impl ProxyState {
         }
     }
 
-    async fn forward(&self, body: &Bytes) -> Result<Bytes, ForwardError> {
+    async fn forward(&self, body: &Bytes) -> Result<UpstreamResponse, ForwardError> {
         let mut response = self
             .client
             .post(self.backend_url.as_str())
-            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .header(CONTENT_TYPE, "application/json")
             .body(body.clone())
             .send()
             .await
             .map_err(ForwardError::Transport)?;
 
-        let status = response.status();
-        if !status.is_success() {
-            // Keep the body: some backends put JSON-RPC errors on non-2xx HTTP statuses.
+        // Forward body regardless of HTTP status (e.g. 429 with a JSON-RPC error).
+        // Client still gets HTTP 200; only body + Content-Type are preserved.
+        if !response.status().is_success() {
             warn!(
                 backend = %self.backend_name,
                 url = %self.backend_url,
-                status = %status.as_u16(),
+                status = %response.status().as_u16(),
                 "backend returned non-success HTTP status"
             );
         }
 
+        let content_type = response.headers().get(CONTENT_TYPE).cloned();
         let content_length = response.content_length();
         if let Some(content_length) = content_length
             && content_length > MAX_RESPONSE_BODY_BYTES as u64
@@ -142,7 +132,27 @@ impl ProxyState {
             buf.extend_from_slice(&chunk);
         }
 
-        Ok(Bytes::from(buf))
+        Ok(UpstreamResponse { content_type, body: Bytes::from(buf) })
+    }
+}
+
+/// Proxied backend response body fields preserved for the client.
+#[derive(Debug)]
+struct UpstreamResponse {
+    /// Upstream `Content-Type`, if present.
+    content_type: Option<HeaderValue>,
+    /// Upstream response body.
+    body: Bytes,
+}
+
+impl UpstreamResponse {
+    /// Builds the client response: HTTP 200 with upstream body and Content-Type.
+    fn into_client_response(self) -> Response {
+        let mut response = (StatusCode::OK, self.body).into_response();
+        if let Some(content_type) = self.content_type {
+            response.headers_mut().insert(CONTENT_TYPE, content_type);
+        }
+        response
     }
 }
 

--- a/crates/infra/roxy/src/proxy.rs
+++ b/crates/infra/roxy/src/proxy.rs
@@ -11,6 +11,7 @@ use axum::{
     routing::post,
 };
 use reqwest::Client;
+use serde::{Deserialize, de::IgnoredAny};
 use serde_json::{Value, json};
 use tracing::{error, warn};
 use url::Url;
@@ -61,23 +62,20 @@ impl ProxyState {
     }
 
     async fn handle_rpc(State(state): State<Self>, body: Bytes) -> Response {
-        let parsed: Value = match serde_json::from_slice(&body) {
-            Ok(value) => value,
-            Err(error) => {
-                warn!(error = %error, "invalid JSON-RPC request body");
-                return jsonrpc_error(Value::Null, -32700, "parse error");
+        // Avoid full `Value` materialization (heap amplification on crafted payloads).
+        match first_non_whitespace(&body) {
+            Some(b'[') => {
+                return jsonrpc_error(Value::Null, -32600, "batch requests are not supported");
             }
-        };
-
-        if parsed.is_array() {
-            return jsonrpc_error(Value::Null, -32600, "batch requests are not supported");
+            Some(b'{') => {}
+            Some(_) | None => return jsonrpc_error(Value::Null, -32600, "invalid request"),
         }
 
-        if !parsed.is_object() {
-            return jsonrpc_error(Value::Null, -32600, "invalid request");
+        // Validate JSON without building a `Value` tree; unused fields are skipped.
+        if let Err(error) = serde_json::from_slice::<IgnoredAny>(&body) {
+            warn!(error = %error, "invalid JSON-RPC request body");
+            return jsonrpc_error(Value::Null, -32700, "parse error");
         }
-
-        let id = parsed.get("id").cloned().unwrap_or(Value::Null);
 
         match state.forward(&body).await {
             Ok(response_body) => (
@@ -93,7 +91,7 @@ impl ProxyState {
                     max_bytes = MAX_RESPONSE_BODY_BYTES,
                     "backend response exceeded size limit"
                 );
-                jsonrpc_error(id, -32000, "backend response too large")
+                jsonrpc_error(request_id(&body), -32000, "backend response too large")
             }
             Err(ForwardError::Transport(error)) => {
                 error!(
@@ -102,7 +100,7 @@ impl ProxyState {
                     url = %state.backend_url,
                     "backend request failed"
                 );
-                jsonrpc_error(id, -32000, "backend request failed")
+                jsonrpc_error(request_id(&body), -32000, "backend request failed")
             }
         }
     }
@@ -157,6 +155,27 @@ enum ForwardError {
     ResponseTooLarge,
 }
 
+/// Minimal request view used only when building proxy-generated JSON-RPC errors.
+#[derive(Debug, Deserialize)]
+struct IdOnly {
+    /// JSON-RPC request id, if present.
+    #[serde(default)]
+    id: Option<Value>,
+}
+
+/// Returns the first non-ASCII-whitespace byte in `body`, if any.
+fn first_non_whitespace(body: &[u8]) -> Option<u8> {
+    body.iter().copied().find(|byte| !byte.is_ascii_whitespace())
+}
+
+/// Extracts `id` without materializing the rest of the request as a [`Value`] tree.
+fn request_id(body: &[u8]) -> Value {
+    serde_json::from_slice::<IdOnly>(body)
+        .ok()
+        .and_then(|request| request.id)
+        .unwrap_or(Value::Null)
+}
+
 fn jsonrpc_error(id: Value, code: i64, message: &str) -> Response {
     let body = json!({
         "jsonrpc": "2.0",
@@ -167,4 +186,25 @@ fn jsonrpc_error(id: Value, code: i64, message: &str) -> Response {
         }
     });
     (StatusCode::OK, Json(body)).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_non_whitespace_skips_leading_space() {
+        assert_eq!(first_non_whitespace(b"  \n{"), Some(b'{'));
+        assert_eq!(first_non_whitespace(b"\t["), Some(b'['));
+        assert_eq!(first_non_whitespace(b"   "), None);
+    }
+
+    #[test]
+    fn request_id_reads_only_id_field() {
+        let body = br#"{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":42}"#;
+        assert_eq!(request_id(body), json!(42));
+
+        let body = br#"{"jsonrpc":"2.0","method":"eth_chainId"}"#;
+        assert_eq!(request_id(body), Value::Null);
+    }
 }

--- a/crates/infra/roxy/src/proxy.rs
+++ b/crates/infra/roxy/src/proxy.rs
@@ -37,13 +37,13 @@ pub struct ProxyState {
     /// Configured backend name (for logs).
     backend_name: Arc<str>,
     /// URL used for forwarding (first URL of the backend for now).
-    backend_url: Url,
+    backend_url: Arc<Url>,
 }
 
 impl ProxyState {
     /// Builds proxy state from a validated backend.
     pub fn from_backend(backend: &Backend) -> Self {
-        let backend_url = backend.urls[0].clone();
+        let backend_url = Arc::new(backend.urls[0].clone());
         let client = Client::builder()
             .connect_timeout(BACKEND_CONNECT_TIMEOUT)
             .timeout(BACKEND_REQUEST_TIMEOUT)
@@ -110,7 +110,7 @@ impl ProxyState {
     async fn forward(&self, body: &Bytes) -> Result<Bytes, ForwardError> {
         let mut response = self
             .client
-            .post(self.backend_url.clone())
+            .post(self.backend_url.as_ref().clone())
             .header(reqwest::header::CONTENT_TYPE, "application/json")
             .body(body.clone())
             .send()

--- a/crates/infra/roxy/src/proxy.rs
+++ b/crates/infra/roxy/src/proxy.rs
@@ -1,0 +1,105 @@
+//! JSON-RPC reverse-proxy handlers.
+
+use std::sync::Arc;
+
+use axum::{
+    Json, Router,
+    body::Bytes,
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::post,
+};
+use reqwest::Client;
+use serde_json::{Value, json};
+use tracing::{error, warn};
+use url::Url;
+
+use crate::Backend;
+
+/// Shared state for JSON-RPC proxy routes.
+#[derive(Debug, Clone)]
+pub struct ProxyState {
+    /// HTTP client used to call backend URLs.
+    client: Client,
+    /// Configured backend name (for logs).
+    backend_name: Arc<str>,
+    /// URL used for forwarding (first URL of the backend for now).
+    backend_url: Url,
+}
+
+impl ProxyState {
+    /// Builds proxy state from a validated backend.
+    pub fn from_backend(backend: &Backend) -> Self {
+        let backend_url = backend.urls[0].clone();
+        Self { client: Client::new(), backend_name: Arc::from(backend.name.as_str()), backend_url }
+    }
+
+    /// Returns the JSON-RPC proxy router (`POST /`).
+    pub fn router(self) -> Router {
+        Router::new().route("/", post(Self::handle_rpc)).with_state(self)
+    }
+
+    async fn handle_rpc(State(state): State<Self>, body: Bytes) -> Response {
+        let parsed: Value = match serde_json::from_slice(&body) {
+            Ok(value) => value,
+            Err(error) => {
+                warn!(error = %error, "invalid JSON-RPC request body");
+                return jsonrpc_error(Value::Null, -32700, "parse error");
+            }
+        };
+
+        if parsed.is_array() {
+            return jsonrpc_error(Value::Null, -32600, "batch requests are not supported");
+        }
+
+        if !parsed.is_object() {
+            return jsonrpc_error(Value::Null, -32600, "invalid request");
+        }
+
+        let id = parsed.get("id").cloned().unwrap_or(Value::Null);
+
+        match state.forward(&body).await {
+            Ok(response_body) => (
+                StatusCode::OK,
+                [(axum::http::header::CONTENT_TYPE, "application/json")],
+                response_body,
+            )
+                .into_response(),
+            Err(error) => {
+                error!(
+                    error = %error,
+                    backend = %state.backend_name,
+                    url = %state.backend_url,
+                    "backend request failed"
+                );
+                jsonrpc_error(id, -32000, "backend request failed")
+            }
+        }
+    }
+
+    async fn forward(&self, body: &Bytes) -> Result<Bytes, reqwest::Error> {
+        let response = self
+            .client
+            .post(self.backend_url.clone())
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body.clone())
+            .send()
+            .await?
+            .error_for_status()?;
+        let bytes = response.bytes().await?;
+        Ok(bytes)
+    }
+}
+
+fn jsonrpc_error(id: Value, code: i64, message: &str) -> Response {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+            "code": code,
+            "message": message,
+        }
+    });
+    (StatusCode::OK, Json(body)).into_response()
+}

--- a/crates/infra/roxy/src/proxy.rs
+++ b/crates/infra/roxy/src/proxy.rs
@@ -1,6 +1,6 @@
 //! JSON-RPC reverse-proxy handlers.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use axum::{
     Json, Router,
@@ -23,6 +23,12 @@ pub(crate) const MAX_REQUEST_BODY_BYTES: usize = 2 * 1024 * 1024;
 /// Maximum accepted backend response body size (`2 MiB`).
 pub(crate) const MAX_RESPONSE_BODY_BYTES: usize = 2 * 1024 * 1024;
 
+/// TCP connect timeout for backend requests.
+const BACKEND_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Overall timeout for a backend request (connect + headers + body).
+const BACKEND_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Shared state for JSON-RPC proxy routes.
 #[derive(Debug, Clone)]
 pub struct ProxyState {
@@ -38,7 +44,12 @@ impl ProxyState {
     /// Builds proxy state from a validated backend.
     pub fn from_backend(backend: &Backend) -> Self {
         let backend_url = backend.urls[0].clone();
-        Self { client: Client::new(), backend_name: Arc::from(backend.name.as_str()), backend_url }
+        let client = Client::builder()
+            .connect_timeout(BACKEND_CONNECT_TIMEOUT)
+            .timeout(BACKEND_REQUEST_TIMEOUT)
+            .build()
+            .expect("failed to build reqwest client");
+        Self { client, backend_name: Arc::from(backend.name.as_str()), backend_url }
     }
 
     /// Returns the JSON-RPC proxy router (`POST /`).
@@ -104,9 +115,18 @@ impl ProxyState {
             .body(body.clone())
             .send()
             .await
-            .map_err(ForwardError::Transport)?
-            .error_for_status()
             .map_err(ForwardError::Transport)?;
+
+        let status = response.status();
+        if !status.is_success() {
+            // Keep the body: some backends put JSON-RPC errors on non-2xx HTTP statuses.
+            warn!(
+                backend = %self.backend_name,
+                url = %self.backend_url,
+                status = %status.as_u16(),
+                "backend returned non-success HTTP status"
+            );
+        }
 
         if let Some(content_length) = response.content_length()
             && content_length > MAX_RESPONSE_BODY_BYTES as u64

--- a/crates/infra/roxy/src/proxy.rs
+++ b/crates/infra/roxy/src/proxy.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use axum::{
     Json, Router,
     body::Bytes,
-    extract::State,
+    extract::{DefaultBodyLimit, State},
     http::StatusCode,
     response::{IntoResponse, Response},
     routing::post,
@@ -16,6 +16,12 @@ use tracing::{error, warn};
 use url::Url;
 
 use crate::Backend;
+
+/// Maximum accepted inbound JSON-RPC request body size (`2 MiB`).
+pub(crate) const MAX_REQUEST_BODY_BYTES: usize = 2 * 1024 * 1024;
+
+/// Maximum accepted backend response body size (`2 MiB`).
+pub(crate) const MAX_RESPONSE_BODY_BYTES: usize = 2 * 1024 * 1024;
 
 /// Shared state for JSON-RPC proxy routes.
 #[derive(Debug, Clone)]
@@ -37,7 +43,10 @@ impl ProxyState {
 
     /// Returns the JSON-RPC proxy router (`POST /`).
     pub fn router(self) -> Router {
-        Router::new().route("/", post(Self::handle_rpc)).with_state(self)
+        Router::new()
+            .route("/", post(Self::handle_rpc))
+            .layer(DefaultBodyLimit::max(MAX_REQUEST_BODY_BYTES))
+            .with_state(self)
     }
 
     async fn handle_rpc(State(state): State<Self>, body: Bytes) -> Response {
@@ -66,7 +75,16 @@ impl ProxyState {
                 response_body,
             )
                 .into_response(),
-            Err(error) => {
+            Err(ForwardError::ResponseTooLarge) => {
+                warn!(
+                    backend = %state.backend_name,
+                    url = %state.backend_url,
+                    max_bytes = MAX_RESPONSE_BODY_BYTES,
+                    "backend response exceeded size limit"
+                );
+                jsonrpc_error(id, -32000, "backend response too large")
+            }
+            Err(ForwardError::Transport(error)) => {
                 error!(
                     error = %error,
                     backend = %state.backend_name,
@@ -78,18 +96,44 @@ impl ProxyState {
         }
     }
 
-    async fn forward(&self, body: &Bytes) -> Result<Bytes, reqwest::Error> {
-        let response = self
+    async fn forward(&self, body: &Bytes) -> Result<Bytes, ForwardError> {
+        let mut response = self
             .client
             .post(self.backend_url.clone())
             .header(reqwest::header::CONTENT_TYPE, "application/json")
             .body(body.clone())
             .send()
-            .await?
-            .error_for_status()?;
-        let bytes = response.bytes().await?;
-        Ok(bytes)
+            .await
+            .map_err(ForwardError::Transport)?
+            .error_for_status()
+            .map_err(ForwardError::Transport)?;
+
+        if let Some(content_length) = response.content_length()
+            && content_length > MAX_RESPONSE_BODY_BYTES as u64
+        {
+            return Err(ForwardError::ResponseTooLarge);
+        }
+
+        let mut buf = Vec::new();
+        while let Some(chunk) = response.chunk().await.map_err(ForwardError::Transport)? {
+            let next_len = buf.len().saturating_add(chunk.len());
+            if next_len > MAX_RESPONSE_BODY_BYTES {
+                return Err(ForwardError::ResponseTooLarge);
+            }
+            buf.extend_from_slice(&chunk);
+        }
+
+        Ok(Bytes::from(buf))
     }
+}
+
+/// Failure while forwarding a request to a backend.
+#[derive(Debug)]
+enum ForwardError {
+    /// HTTP client / transport failure.
+    Transport(reqwest::Error),
+    /// Backend response exceeded [`MAX_RESPONSE_BODY_BYTES`].
+    ResponseTooLarge,
 }
 
 fn jsonrpc_error(id: Value, code: i64, message: &str) -> Response {

--- a/crates/infra/roxy/src/proxy.rs
+++ b/crates/infra/roxy/src/proxy.rs
@@ -18,10 +18,10 @@ use url::Url;
 use crate::Backend;
 
 /// Maximum accepted inbound JSON-RPC request body size (`2 MiB`).
-pub(crate) const MAX_REQUEST_BODY_BYTES: usize = 2 * 1024 * 1024;
+pub const MAX_REQUEST_BODY_BYTES: usize = 2 * 1024 * 1024;
 
 /// Maximum accepted backend response body size (`2 MiB`).
-pub(crate) const MAX_RESPONSE_BODY_BYTES: usize = 2 * 1024 * 1024;
+pub const MAX_RESPONSE_BODY_BYTES: usize = 2 * 1024 * 1024;
 
 /// TCP connect timeout for backend requests.
 const BACKEND_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
@@ -110,7 +110,7 @@ impl ProxyState {
     async fn forward(&self, body: &Bytes) -> Result<Bytes, ForwardError> {
         let mut response = self
             .client
-            .post(self.backend_url.as_ref().clone())
+            .post(self.backend_url.as_str())
             .header(reqwest::header::CONTENT_TYPE, "application/json")
             .body(body.clone())
             .send()
@@ -128,13 +128,14 @@ impl ProxyState {
             );
         }
 
-        if let Some(content_length) = response.content_length()
+        let content_length = response.content_length();
+        if let Some(content_length) = content_length
             && content_length > MAX_RESPONSE_BODY_BYTES as u64
         {
             return Err(ForwardError::ResponseTooLarge);
         }
 
-        let mut buf = Vec::new();
+        let mut buf = content_length.map_or_else(Vec::new, |len| Vec::with_capacity(len as usize));
         while let Some(chunk) = response.chunk().await.map_err(ForwardError::Transport)? {
             let next_len = buf.len().saturating_add(chunk.len());
             if next_len > MAX_RESPONSE_BODY_BYTES {

--- a/crates/infra/roxy/src/server.rs
+++ b/crates/infra/roxy/src/server.rs
@@ -10,7 +10,7 @@ use axum::Router;
 use base_health::HealthServer;
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::{Config, ProxyState};
 
@@ -27,8 +27,22 @@ impl Server {
     /// Starts the Roxy HTTP server with the provided configuration.
     pub async fn serve(config: Config, cancel: CancellationToken) -> anyhow::Result<()> {
         let backends = config.backends()?;
-        let backend = backends[0].clone();
-        let proxy = ProxyState::from_backend(&backend);
+        if backends.len() > 1 {
+            warn!(
+                backend_count = backends.len(),
+                active_backend = %backends[0].name,
+                "multiple backends configured; only the first is used until routing lands"
+            );
+        }
+        if backends[0].urls.len() > 1 {
+            warn!(
+                backend = %backends[0].name,
+                url_count = backends[0].urls.len(),
+                active_url = %backends[0].urls[0],
+                "multiple URLs configured for backend; only the first is used until pooling lands"
+            );
+        }
+        let proxy = ProxyState::from_backend(&backends[0]);
 
         let listen_addr = config.listen_addr;
         let ready = Arc::new(AtomicBool::new(false));
@@ -41,9 +55,9 @@ impl Server {
 
         info!(
             %listen_addr,
-            backend = %backend.name,
-            url = %backend.urls[0],
-            url_count = backend.urls.len(),
+            backend = %backends[0].name,
+            url = %backends[0].urls[0],
+            url_count = backends[0].urls.len(),
             "roxy server started"
         );
 
@@ -325,6 +339,44 @@ mod tests {
             body["error"]["message"],
             json!("rate limited"),
             "backend error message must be preserved"
+        );
+
+        cancel.cancel();
+    }
+
+    #[tokio::test]
+    async fn preserves_backend_content_type() {
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(
+                ResponseTemplate::new(502).set_body_raw("<html>bad gateway</html>", "text/html"),
+            )
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let backend = Backend::parse(&format!("rpcs={}", mock.uri())).expect("parse backend");
+        let ready = Arc::new(AtomicBool::new(true));
+        let (addr, _handle, cancel) =
+            start_test_server(ready, ProxyState::from_backend(&backend)).await;
+
+        let response = reqwest::Client::new()
+            .post(format!("http://{addr}/"))
+            .body(r#"{"jsonrpc":"2.0","method":"eth_chainId","id":1}"#)
+            .send()
+            .await
+            .expect("proxy request");
+
+        assert_eq!(response.status().as_u16(), 200, "client still sees HTTP 200");
+        assert_eq!(
+            response.headers().get(reqwest::header::CONTENT_TYPE),
+            Some(&reqwest::header::HeaderValue::from_static("text/html")),
+            "backend content type must be preserved"
+        );
+        assert_eq!(
+            response.text().await.expect("response body"),
+            "<html>bad gateway</html>",
+            "backend body must be preserved"
         );
 
         cancel.cancel();

--- a/crates/infra/roxy/src/server.rs
+++ b/crates/infra/roxy/src/server.rs
@@ -26,7 +26,8 @@ impl Server {
 
     /// Starts the Roxy HTTP server with the provided configuration.
     pub async fn serve(config: Config, cancel: CancellationToken) -> anyhow::Result<()> {
-        let backend = config.backend()?.clone();
+        let backends = config.backends()?;
+        let backend = backends[0].clone();
         let proxy = ProxyState::from_backend(&backend);
 
         let listen_addr = config.listen_addr;

--- a/crates/infra/roxy/src/server.rs
+++ b/crates/infra/roxy/src/server.rs
@@ -249,7 +249,7 @@ mod tests {
     #[tokio::test]
     async fn returns_jsonrpc_error_when_backend_response_too_large() {
         let mock = MockServer::start().await;
-        let oversized = vec![b'x'; crate::proxy::MAX_RESPONSE_BODY_BYTES + 1];
+        let oversized = vec![b'x'; crate::MAX_RESPONSE_BODY_BYTES + 1];
         Mock::given(method("POST"))
             .respond_with(ResponseTemplate::new(200).set_body_bytes(oversized))
             .expect(1)

--- a/crates/infra/roxy/src/server.rs
+++ b/crates/infra/roxy/src/server.rs
@@ -285,4 +285,47 @@ mod tests {
 
         cancel.cancel();
     }
+
+    #[tokio::test]
+    async fn forwards_backend_error_body_on_non_success_status() {
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(429).set_body_json(json!({
+                "jsonrpc": "2.0",
+                "id": 9,
+                "error": { "code": -32005, "message": "rate limited" }
+            })))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let backend = Backend::parse(&format!("rpcs={}", mock.uri())).expect("parse backend");
+        let ready = Arc::new(AtomicBool::new(true));
+        let (addr, _handle, cancel) =
+            start_test_server(ready, ProxyState::from_backend(&backend)).await;
+
+        let response = reqwest::Client::new()
+            .post(format!("http://{addr}/"))
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "method": "eth_sendRawTransaction",
+                "params": ["0xdead"],
+                "id": 9
+            }))
+            .send()
+            .await
+            .expect("proxy request");
+
+        assert_eq!(response.status().as_u16(), 200, "client still sees HTTP 200");
+        let body: serde_json::Value = response.json().await.expect("response json");
+        assert_eq!(body["id"], json!(9), "id must match backend payload");
+        assert_eq!(body["error"]["code"], json!(-32005), "backend error code must be preserved");
+        assert_eq!(
+            body["error"]["message"],
+            json!("rate limited"),
+            "backend error message must be preserved"
+        );
+
+        cancel.cancel();
+    }
 }

--- a/crates/infra/roxy/src/server.rs
+++ b/crates/infra/roxy/src/server.rs
@@ -245,4 +245,44 @@ mod tests {
 
         cancel.cancel();
     }
+
+    #[tokio::test]
+    async fn returns_jsonrpc_error_when_backend_response_too_large() {
+        let mock = MockServer::start().await;
+        let oversized = vec![b'x'; crate::proxy::MAX_RESPONSE_BODY_BYTES + 1];
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(oversized))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let backend = Backend::parse(&format!("rpcs={}", mock.uri())).expect("parse backend");
+        let ready = Arc::new(AtomicBool::new(true));
+        let (addr, _handle, cancel) =
+            start_test_server(ready, ProxyState::from_backend(&backend)).await;
+
+        let response = reqwest::Client::new()
+            .post(format!("http://{addr}/"))
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "method": "eth_chainId",
+                "params": [],
+                "id": 3
+            }))
+            .send()
+            .await
+            .expect("proxy request");
+
+        assert_eq!(response.status().as_u16(), 200, "JSON-RPC errors use HTTP 200");
+        let body: serde_json::Value = response.json().await.expect("response json");
+        assert_eq!(body["id"], json!(3), "id must be preserved");
+        assert_eq!(body["error"]["code"], json!(-32000), "server error code");
+        assert_eq!(
+            body["error"]["message"],
+            json!("backend response too large"),
+            "oversized backend responses must be rejected"
+        );
+
+        cancel.cancel();
+    }
 }

--- a/crates/infra/roxy/src/server.rs
+++ b/crates/infra/roxy/src/server.rs
@@ -1,4 +1,4 @@
-//! HTTP server scaffold for Roxy.
+//! HTTP server for Roxy.
 
 use std::sync::{
     Arc,
@@ -12,33 +12,39 @@ use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
-use crate::Config;
+use crate::{Config, ProxyState};
 
 /// Roxy HTTP server.
-///
-/// Scaffold serves liveness and readiness probes. Proxy routes land in later
-/// PRs on the same listener.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Server;
 
 impl Server {
-    /// Returns the application router.
-    pub fn router(ready: Arc<AtomicBool>) -> Router {
-        HealthServer::router(ready)
+    /// Returns the application router (health probes + JSON-RPC proxy).
+    pub fn router(ready: Arc<AtomicBool>, proxy: ProxyState) -> Router {
+        HealthServer::router(ready).merge(proxy.router())
     }
 
     /// Starts the Roxy HTTP server with the provided configuration.
     pub async fn serve(config: Config, cancel: CancellationToken) -> anyhow::Result<()> {
+        let backend = config.backend()?.clone();
+        let proxy = ProxyState::from_backend(&backend);
+
         let listen_addr = config.listen_addr;
         let ready = Arc::new(AtomicBool::new(false));
-        let app = Self::router(Arc::clone(&ready));
+        let app = Self::router(Arc::clone(&ready), proxy);
 
         let listener = TcpListener::bind(listen_addr)
             .await
             .with_context(|| format!("failed to bind roxy server to {listen_addr}"))?;
         let listen_addr = listener.local_addr().context("failed to read roxy listen address")?;
 
-        info!(%listen_addr, "roxy server started");
+        info!(
+            %listen_addr,
+            backend = %backend.name,
+            url = %backend.urls[0],
+            url_count = backend.urls.len(),
+            "roxy server started"
+        );
 
         // Marked ready before `serve` is first polled. The listener is already bound, so the
         // kernel accept backlog queues any connections that arrive in the gap; they are served
@@ -65,18 +71,25 @@ mod tests {
         },
     };
 
+    use serde_json::json;
     use tokio::net::TcpListener;
     use tokio_util::sync::CancellationToken;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{body_partial_json, method, path},
+    };
 
     use super::*;
+    use crate::Backend;
 
     /// Starts the server on an ephemeral port for tests.
     async fn start_test_server(
         ready: Arc<AtomicBool>,
+        proxy: ProxyState,
     ) -> (SocketAddr, tokio::task::JoinHandle<()>, CancellationToken) {
         let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind ephemeral port");
         let addr = listener.local_addr().expect("local addr");
-        let app = Server::router(ready);
+        let app = Server::router(ready, proxy);
         let cancel = CancellationToken::new();
         let cancel_for_shutdown = cancel.clone();
 
@@ -90,10 +103,15 @@ mod tests {
         (addr, handle, cancel)
     }
 
+    fn dummy_proxy() -> ProxyState {
+        let backend = Backend::parse("dummy=http://127.0.0.1:1").expect("parse backend");
+        ProxyState::from_backend(&backend)
+    }
+
     #[tokio::test]
     async fn healthz_returns_ok_when_not_ready() {
         let ready = Arc::new(AtomicBool::new(false));
-        let (addr, _handle, cancel) = start_test_server(ready).await;
+        let (addr, _handle, cancel) = start_test_server(ready, dummy_proxy()).await;
 
         let response =
             reqwest::get(format!("http://{addr}/healthz")).await.expect("healthz request");
@@ -105,7 +123,7 @@ mod tests {
     #[tokio::test]
     async fn readyz_reflects_ready_flag() {
         let ready = Arc::new(AtomicBool::new(false));
-        let (addr, _handle, cancel) = start_test_server(Arc::clone(&ready)).await;
+        let (addr, _handle, cancel) = start_test_server(Arc::clone(&ready), dummy_proxy()).await;
 
         let response = reqwest::get(format!("http://{addr}/readyz"))
             .await
@@ -118,6 +136,112 @@ mod tests {
             .await
             .expect("readyz request while ready");
         assert_eq!(response.status().as_u16(), 200, "readiness must return 200 after ready");
+
+        cancel.cancel();
+    }
+
+    #[tokio::test]
+    async fn proxies_single_jsonrpc_request_to_backend() {
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_partial_json(json!({
+                "jsonrpc": "2.0",
+                "method": "eth_chainId",
+                "id": 1
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": "0x2105"
+            })))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let backend = Backend::parse(&format!("rpcs={}", mock.uri())).expect("parse backend");
+        let ready = Arc::new(AtomicBool::new(true));
+        let (addr, _handle, cancel) =
+            start_test_server(ready, ProxyState::from_backend(&backend)).await;
+
+        let response = reqwest::Client::new()
+            .post(format!("http://{addr}/"))
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "method": "eth_chainId",
+                "params": [],
+                "id": 1
+            }))
+            .send()
+            .await
+            .expect("proxy request");
+
+        assert_eq!(response.status().as_u16(), 200, "proxy must return HTTP 200");
+        let body: serde_json::Value = response.json().await.expect("response json");
+        assert_eq!(body["result"], json!("0x2105"), "result must match mocked backend");
+        assert_eq!(body["id"], json!(1), "id must be preserved");
+
+        cancel.cancel();
+    }
+
+    #[tokio::test]
+    async fn rejects_batch_requests() {
+        let mock = MockServer::start().await;
+        let backend = Backend::parse(&format!("rpcs={}", mock.uri())).expect("parse backend");
+        let ready = Arc::new(AtomicBool::new(true));
+        let (addr, _handle, cancel) =
+            start_test_server(ready, ProxyState::from_backend(&backend)).await;
+
+        let response = reqwest::Client::new()
+            .post(format!("http://{addr}/"))
+            .json(&json!([
+                {"jsonrpc": "2.0", "method": "eth_chainId", "id": 1},
+                {"jsonrpc": "2.0", "method": "eth_blockNumber", "id": 2}
+            ]))
+            .send()
+            .await
+            .expect("batch request");
+
+        assert_eq!(response.status().as_u16(), 200, "JSON-RPC errors use HTTP 200");
+        let body: serde_json::Value = response.json().await.expect("response json");
+        assert_eq!(body["error"]["code"], json!(-32600), "invalid request code");
+        assert_eq!(
+            body["error"]["message"],
+            json!("batch requests are not supported"),
+            "batch must be rejected"
+        );
+        assert_eq!(
+            mock.received_requests().await.expect("request log").len(),
+            0,
+            "backend must not be called"
+        );
+
+        cancel.cancel();
+    }
+
+    #[tokio::test]
+    async fn returns_jsonrpc_error_when_backend_is_down() {
+        let backend = Backend::parse("rpcs=http://127.0.0.1:1").expect("parse backend");
+        let ready = Arc::new(AtomicBool::new(true));
+        let (addr, _handle, cancel) =
+            start_test_server(ready, ProxyState::from_backend(&backend)).await;
+
+        let response = reqwest::Client::new()
+            .post(format!("http://{addr}/"))
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "method": "eth_chainId",
+                "params": [],
+                "id": 7
+            }))
+            .send()
+            .await
+            .expect("proxy request");
+
+        assert_eq!(response.status().as_u16(), 200, "JSON-RPC errors use HTTP 200");
+        let body: serde_json::Value = response.json().await.expect("response json");
+        assert_eq!(body["id"], json!(7), "id must be preserved on backend failure");
+        assert_eq!(body["error"]["code"], json!(-32000), "server error code");
 
         cancel.cancel();
     }


### PR DESCRIPTION
## Motivation

PR1 only served health probes. This adds the first real proxy path: accept a single JSON-RPC request and forward it to a configured named backend.

## Changes

- Add `Backend { name, urls }` parsed from `--backend name=url[,url...]` (unique name, non-empty URL list)
- Require exactly one `--backend` for now (no default flag, no method routing)
- `POST /` forwards a single JSON-RPC object to the backend's first URL
- Reject batch arrays with a JSON-RPC error; map backend transport failures to JSON-RPC `-32000`
- Keep `/healthz` and `/readyz` on the same listener
- Update README with usage

## Tests

| Test Name | Description |
| --- | --- |
| `parse_single_url` / `parse_multiple_urls` | Backend CLI value parsing |
| `parse_rejects_*` | Invalid backend strings |
| `backend_requires_exactly_one` | Config accepts only one backend |
| `proxies_single_jsonrpc_request_to_backend` | wiremock end-to-end passthrough |
| `rejects_batch_requests` | Batch arrays are not forwarded |
| `returns_jsonrpc_error_when_backend_is_down` | Transport failure → JSON-RPC error |

## Test plan

- [x] `cargo test -p base-roxy`
- [x] `cargo clippy -p base-roxy -p base-roxy-bin --all-targets -- -D warnings`
- [ ] Spot-check: `roxy --backend rpcs=http://127.0.0.1:8545` against a local RPC


Made with [Cursor](https://cursor.com)