### PR TITLE
feat(telemetry): accept CL p2p multiaddr reachability targets

### DIFF
--- a/bin/base-telemetry/README.md
+++ b/bin/base-telemetry/README.md
@@ -41,11 +41,22 @@ curl https://telemetry.example/v1/p2p/reachability/cl \
   }'
 ```
 
-The signed ENR is returned by the consensus node's `opp2p_self` RPC. It must
-advertise a public literal `IPv4` address and a nonzero TCP port; the service
-probes that address over TCP + Noise + Yamux and verifies the peer identity
-derived from the ENR's secp256k1 key. Both endpoints share the same per-IP
-rate limit and global probe capacity.
+The same endpoint also accepts a public-IPv4 libp2p multiaddr:
+
+```sh
+curl https://telemetry.example/v1/p2p/reachability/cl \
+  --header 'content-type: application/json' \
+  --data '{
+    "multiaddr": "/ip4/YOUR_NODE_IP/tcp/9222/p2p/16Uiu2HAm..."
+  }'
+```
+
+The signed ENR is returned by the consensus node's `opp2p_self` RPC. Either
+form must advertise a public literal `IPv4` address, a nonzero TCP port, and a
+peer identity — derived from the ENR's secp256k1 key, or taken from the
+`/p2p/<peer-id>` component. The service probes that address over TCP + Noise +
+Yamux. Both endpoints share the same per-IP rate limit and global probe
+capacity.
 
 ## Deployment boundary
 

--- a/bin/basectl/README.md
+++ b/bin/basectl/README.md
@@ -122,8 +122,9 @@ consensus layers.
 - `basectl p2p reachability <TARGET>` asks the Base telemetry service to open
   an independent connection to a node's advertised p2p endpoint.
   `enode://...` probes the execution layer (TCP, encrypted identity handshake,
-  and devp2p Hello exchange); `enr:...` probes the consensus layer (TCP, Noise
-  handshake against the ENR identity, and libp2p identify).
+  and devp2p Hello exchange); `enr:...` or `/ip4/.../tcp/.../p2p/<peer-id>`
+  probes the consensus layer (TCP, Noise handshake against the advertised
+  identity, and libp2p identify).
 - `basectl p2p add-peer <TARGET>` connects one peer. `enode://...` routes to
   the execution layer; `enr:...` or `/.../p2p/<peer-id>` routes to the
   consensus layer.
@@ -472,6 +473,9 @@ basectl -c sepolia p2p peers --json | jq '{el: .el | length, cl: .cl | length}'
 
 # Probe an explicit EL enode from the telemetry service's network
 basectl -c sepolia p2p reachability enode://<node-id>@203.0.113.10:30303 --json
+
+# Probe a consensus peer by public-IPv4 libp2p multiaddr
+basectl -c sepolia p2p reachability /ip4/203.0.113.10/tcp/9222/p2p/16Uiu2HAm... --json
 
 # Add an execution-layer peer after confirmation
 basectl -c sepolia p2p add-peer enode://<node-id>@203.0.113.10:30303 --el-rpc https://your-el.example/

--- a/crates/infra/basectl/src/commands/p2p.rs
+++ b/crates/infra/basectl/src/commands/p2p.rs
@@ -32,8 +32,9 @@ pub enum P2pCommands {
     Info(P2pArgs),
     /// Ask the Base telemetry service to probe an execution or consensus peer endpoint.
     Reachability {
-        /// Peer endpoint to probe: an execution-layer `enode://` URL or a
-        /// consensus-layer `enr:` record.
+        /// Peer endpoint to probe: an execution-layer `enode://` URL, a
+        /// consensus-layer `enr:` record, or a public `IPv4`
+        /// `/ip4/.../tcp/.../p2p/<peer-id>` multiaddr.
         #[arg(value_name = "TARGET")]
         target: String,
         /// Emit the telemetry response as JSON.
@@ -138,7 +139,8 @@ impl P2pCommand {
 
 /// Runs `basectl p2p reachability`, exiting non-zero when the probe completed
 /// but the node was not reachable. `enode://` targets route to the
-/// execution-layer endpoint and `enr:` targets route to the consensus layer.
+/// execution-layer endpoint; `enr:` records and `/ip4/.../tcp/.../p2p/<peer-id>`
+/// multiaddrs route to the consensus layer.
 async fn run_reachability(
     config: &MonitoringConfig,
     target: &str,
@@ -148,14 +150,24 @@ async fn run_reachability(
     if target.is_empty() {
         return Err(P2pTargetError::EmptyTarget.into());
     }
-    if !target.starts_with("enode://") && !target.starts_with("enr:") {
+    let is_el = target.starts_with("enode://");
+    let is_cl_multiaddr = target.starts_with("/ip4/");
+    if is_cl_multiaddr {
+        if !target.contains("/p2p/") {
+            return Err(
+                P2pTargetError::MultiaddrMissingPeerId { target: target.to_string() }.into()
+            );
+        }
+    } else if is_el || target.starts_with("enr:") {
+        BootNode::parse_bootnode(target).map_err(|error| P2pTargetError::InvalidBootnode {
+            target: target.to_string(),
+            message: error.to_string(),
+        })?;
+    } else {
         return Err(
             P2pTargetError::ReachabilityTargetUnsupported { target: target.to_string() }.into()
         );
     }
-    let bootnode = BootNode::parse_bootnode(target).map_err(|error| {
-        P2pTargetError::InvalidBootnode { target: target.to_string(), message: error.to_string() }
-    })?;
     let chain_id = fetch_l2_chain_id(&config.rpc).await.with_context(|| {
         format!("could not detect network from selected config RPC {}", config.rpc)
     })?;
@@ -165,9 +177,10 @@ async fn run_reachability(
         )
     })?;
     let client = TelemetryClient::new(telemetry_url)?;
-    let response = match bootnode {
-        BootNode::Enode(_) => client.check_el_reachability(target).await?,
-        BootNode::Enr(_) => client.check_cl_reachability(target).await?,
+    let response = if is_el {
+        client.check_el_reachability(target).await?
+    } else {
+        client.check_cl_reachability(target).await?
     };
     print_reachability(&response, json)?;
     Ok(CommandOutcome::from_failures(response.outcome != ReachabilityOutcome::Reachable))
@@ -945,6 +958,32 @@ mod tests {
             reachability_target_error("enr:!!!").await,
             P2pTargetError::InvalidBootnode { target, .. } if target == "enr:!!!"
         ));
+    }
+
+    #[tokio::test]
+    async fn reachability_rejects_multiaddr_without_peer_id() {
+        assert!(matches!(
+            reachability_target_error("/ip4/8.8.8.8/tcp/9222").await,
+            P2pTargetError::MultiaddrMissingPeerId { target }
+                if target == "/ip4/8.8.8.8/tcp/9222"
+        ));
+    }
+
+    #[tokio::test]
+    async fn reachability_accepts_ip4_multiaddr() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        drop(listener);
+        let mut config = test_config(None);
+        config.rpc = Url::parse(&format!("http://{address}")).unwrap();
+
+        let error = run_reachability(&config, "/ip4/8.8.8.8/tcp/9222/p2p/16Uiu2HAmExample", false)
+            .await
+            .unwrap_err();
+
+        assert!(
+            format!("{error:#}").starts_with("could not detect network from selected config RPC")
+        );
     }
 
     #[test]

--- a/crates/infra/basectl/src/errors.rs
+++ b/crates/infra/basectl/src/errors.rs
@@ -112,9 +112,10 @@ pub enum P2pTargetError {
         /// The target supplied by the caller.
         target: String,
     },
-    /// A reachability target was neither an `enode://` URL nor an `enr:` record.
+    /// A reachability target was not an `enode://` URL, `enr:` record, or
+    /// public `IPv4` `/ip4/.../tcp/.../p2p/<peer-id>` multiaddr.
     #[error(
-        "reachability target `{target}` must be an execution-layer `enode://` URL or a consensus-layer `enr:` record"
+        "reachability target `{target}` must be an execution-layer `enode://` URL, a consensus-layer `enr:` record, or a public-IPv4 `/ip4/.../tcp/.../p2p/<peer-id>` multiaddr"
     )]
     ReachabilityTargetUnsupported {
         /// The target supplied by the caller.

--- a/crates/infra/basectl/src/rpc/telemetry.rs
+++ b/crates/infra/basectl/src/rpc/telemetry.rs
@@ -82,7 +82,7 @@ pub enum TelemetryApiError {
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[non_exhaustive]
 pub enum TelemetryClientError {
-    /// The telemetry service rejected the supplied enode.
+    /// The telemetry service rejected the supplied reachability target.
     #[error("telemetry service rejected the reachability request as invalid")]
     InvalidRequest,
     /// The telemetry service rejected the request body as too large.
@@ -140,7 +140,8 @@ impl TelemetryClient {
         self.check_reachability(EL_REACHABILITY_PATH, &json!({ "enode": enode })).await
     }
 
-    /// Requests an external consensus-layer reachability check for `enr`.
+    /// Requests an external consensus-layer reachability check for an `enr:`
+    /// record or a public `IPv4` `/ip4/.../tcp/.../p2p/<peer-id>` multiaddr.
     pub async fn check_cl_reachability(
         &self,
         enr: &str,

--- a/crates/infra/basectl/src/rpc/telemetry.rs
+++ b/crates/infra/basectl/src/rpc/telemetry.rs
@@ -144,9 +144,14 @@ impl TelemetryClient {
     /// record or a public `IPv4` `/ip4/.../tcp/.../p2p/<peer-id>` multiaddr.
     pub async fn check_cl_reachability(
         &self,
-        enr: &str,
+        target: &str,
     ) -> Result<ReachabilityResponse, TelemetryClientError> {
-        self.check_reachability(CL_REACHABILITY_PATH, &json!({ "enr": enr })).await
+        let body = if target.starts_with('/') {
+            json!({ "multiaddr": target })
+        } else {
+            json!({ "enr": target })
+        };
+        self.check_reachability(CL_REACHABILITY_PATH, &body).await
     }
 
     /// Posts one reachability request and decodes the typed response or error.
@@ -298,6 +303,31 @@ mod tests {
                 client_version: Some("op-node/v1.0.0".to_string()),
             }
         );
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn sends_multiaddr_json_key_for_slash_target() {
+        async fn cl_reachable(Json(request): Json<Value>) -> Json<Value> {
+            assert_eq!(request["multiaddr"], "/ip4/203.0.113.10/tcp/9222/p2p/16Uiu2HAmExample");
+            assert!(request.get("enr").is_none());
+            Json(json!({
+                "outcome": "reachable",
+                "stage": "identify",
+                "observedAddress": "203.0.113.10:9222",
+                "elapsedMs": 42,
+            }))
+        }
+        let router = Router::new().route(CL_REACHABILITY_PATH, post(cl_reachable));
+        let (base_url, handle) = start_server(router).await;
+        let client = TelemetryClient::new(base_url).unwrap();
+
+        let response = client
+            .check_cl_reachability("/ip4/203.0.113.10/tcp/9222/p2p/16Uiu2HAmExample")
+            .await
+            .unwrap();
+
+        assert_eq!(response.outcome, ReachabilityOutcome::Reachable);
         handle.abort();
     }
 

--- a/crates/infra/telemetry/README.md
+++ b/crates/infra/telemetry/README.md
@@ -63,14 +63,15 @@ These limits do not apply to the health routes.
 ## Consensus-layer reachability
 
 The consensus-layer endpoint works the same way for the libp2p network. A
-caller sends the node's signed `enr:` record (as returned by `opp2p_self`),
-then the service opens a separate connection to the public `IPv4` address and
-TCP port advertised by that ENR. The expected libp2p peer identity is derived
-from the ENR's secp256k1 public key. A node is reported as `reachable` only
-after TCP, the Noise handshake against that identity, and stream multiplexer
-negotiation all complete. A node that hangs up right after the connection is
-established (for example because it is at peer capacity) is still `reachable`;
-its response omits `clientVersion`.
+caller sends the node's signed `enr:` record (as returned by `opp2p_self`) or
+a public-IPv4 `/ip4/.../tcp/.../p2p/<peer-id>` multiaddr, then the service
+opens a separate connection to that public `IPv4` address and TCP port. The
+expected libp2p peer identity is derived from the ENR's secp256k1 public key,
+or taken from the multiaddr's `/p2p/<peer-id>` component. A node is reported
+as `reachable` only after TCP, the Noise handshake against that identity, and
+stream multiplexer negotiation all complete. A node that hangs up right after
+the connection is established (for example because it is at peer capacity) is
+still `reachable`; its response omits `clientVersion`.
 
 Request:
 
@@ -80,6 +81,15 @@ Content-Type: application/json
 
 {
   "enr": "enr:-J64QBbwPjPLZ..."
+}
+```
+
+```http
+POST /v1/p2p/reachability/cl
+Content-Type: application/json
+
+{
+  "multiaddr": "/ip4/YOUR_NODE_IP/tcp/9222/p2p/16Uiu2HAm..."
 }
 ```
 
@@ -103,7 +113,8 @@ execution-layer endpoint:
 - `identify`: exchanging libp2p identify information.
 
 Validation, limits, and error responses match the execution-layer endpoint:
-the ENR must advertise a public literal `IPv4` address and a nonzero TCP port.
+the ENR or multiaddr must advertise a public literal `IPv4` address and a
+nonzero TCP port. Multiaddrs must be exactly `/ip4/<addr>/tcp/<port>/p2p/<peer-id>`.
 
 ## Rate limiting
 
@@ -125,6 +136,6 @@ never rate limited.
 ## Target selection
 
 The service probes the exact literal public `IPv4` socket address advertised by
-the enode. `IPv6` and non-public `IPv4` addresses (loopback, private, link-local,
-carrier-grade NAT, multicast, unspecified, and other IANA special-purpose
-ranges) are rejected with `400`.
+the enode, ENR, or multiaddr. `IPv6` and non-public `IPv4` addresses (loopback,
+private, link-local, carrier-grade NAT, multicast, unspecified, and other IANA
+special-purpose ranges) are rejected with `400`.

--- a/crates/infra/telemetry/src/p2p.rs
+++ b/crates/infra/telemetry/src/p2p.rs
@@ -15,7 +15,7 @@ use axum::{
     routing::post,
 };
 use discv5::enr::{CombinedPublicKey, Enr, EnrPublicKey};
-use libp2p::PeerId;
+use libp2p::{Multiaddr, PeerId, multiaddr::Protocol};
 use reth_network_peers::{NodeRecord, id2pk};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
@@ -110,17 +110,25 @@ pub struct ElReachabilityResponse {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ClReachabilityRequest {
-    /// The node's advertised `enr:` record, as returned by `opp2p_self`.
+    /// The node's advertised `enr:` record, as returned by `opp2p_self`, or a
+    /// public `IPv4` `/ip4/.../tcp/.../p2p/<peer-id>` multiaddr.
+    #[serde(alias = "multiaddr")]
     pub enr: String,
 }
 
 impl ClReachabilityRequest {
     /// Validates the request and returns its advertised libp2p target.
     pub fn target(&self) -> Option<Libp2pProbeTarget> {
-        if !self.enr.starts_with("enr:") {
-            return None;
+        if self.enr.starts_with("enr:") {
+            Self::enr_target(&self.enr)
+        } else {
+            Self::multiaddr_target(&self.enr)
         }
-        let enr: Enr<discv5::enr::CombinedKey> = self.enr.parse().ok()?;
+    }
+
+    /// Parses a signed `enr:` record into a public `IPv4` libp2p probe target.
+    fn enr_target(enr: &str) -> Option<Libp2pProbeTarget> {
+        let enr: Enr<discv5::enr::CombinedKey> = enr.parse().ok()?;
         let socket = enr.tcp4_socket()?;
         let address = SocketAddr::from((*socket.ip(), socket.port()));
         if socket.port() == 0 || !ElReachabilityRequest::is_public_ip(address.ip()) {
@@ -133,6 +141,32 @@ impl ClReachabilityRequest {
             libp2p_identity::secp256k1::PublicKey::try_from_bytes(&public_key.encode()).ok()?;
         let peer_id = PeerId::from_public_key(&public_key.into());
         Some(Libp2pProbeTarget { address, peer_id })
+    }
+
+    /// Parses a `/ip4/<addr>/tcp/<port>/p2p/<peer-id>` multiaddr into a public
+    /// `IPv4` libp2p probe target. Extra protocols, `IPv6`, and non-public IPs are
+    /// rejected.
+    fn multiaddr_target(value: &str) -> Option<Libp2pProbeTarget> {
+        let addr: Multiaddr = value.parse().ok()?;
+        let mut protocols = addr.iter();
+        let ip = match protocols.next()? {
+            Protocol::Ip4(ip) => ip,
+            _ => return None,
+        };
+        let port = match protocols.next()? {
+            Protocol::Tcp(port) => port,
+            _ => return None,
+        };
+        let peer_id = match protocols.next()? {
+            Protocol::P2p(peer_id) => peer_id,
+            _ => return None,
+        };
+        if protocols.next().is_some() || port == 0 {
+            return None;
+        }
+        let address = SocketAddr::from((ip, port));
+        ElReachabilityRequest::is_public_ip(address.ip())
+            .then_some(Libp2pProbeTarget { address, peer_id })
     }
 }
 
@@ -388,6 +422,14 @@ mod tests {
 
     fn test_cl_request() -> ClReachabilityRequest {
         ClReachabilityRequest { enr: test_enr([8, 8, 8, 8], 9222) }
+    }
+
+    fn test_peer_id() -> libp2p::PeerId {
+        libp2p::identity::Keypair::generate_secp256k1().public().to_peer_id()
+    }
+
+    fn test_multiaddr(ip: [u8; 4], port: u16, peer_id: libp2p::PeerId) -> String {
+        format!("/ip4/{}.{}.{}.{}/tcp/{port}/p2p/{peer_id}", ip[0], ip[1], ip[2], ip[3])
     }
 
     #[test]
@@ -646,6 +688,50 @@ mod tests {
         assert_eq!(target.peer_id, expected);
     }
 
+    #[test]
+    fn validates_multiaddr_identity_address_and_port() {
+        let peer_id = test_peer_id();
+        let valid = ClReachabilityRequest { enr: test_multiaddr([8, 8, 8, 8], 9222, peer_id) };
+        let target = valid.target().unwrap();
+        assert_eq!(target.address, SocketAddr::from(([8, 8, 8, 8], 9222)));
+        assert_eq!(target.peer_id, peer_id);
+
+        let missing_peer_id = ClReachabilityRequest { enr: "/ip4/8.8.8.8/tcp/9222".to_string() };
+        assert!(missing_peer_id.target().is_none());
+
+        let udp_only =
+            ClReachabilityRequest { enr: format!("/ip4/8.8.8.8/udp/9222/p2p/{peer_id}") };
+        assert!(udp_only.target().is_none());
+
+        let ipv6 =
+            ClReachabilityRequest { enr: format!("/ip6/2001:db8::1/tcp/9222/p2p/{peer_id}") };
+        assert!(ipv6.target().is_none());
+
+        let extra_protocol =
+            ClReachabilityRequest { enr: format!("/ip4/8.8.8.8/tcp/9222/ws/p2p/{peer_id}") };
+        assert!(extra_protocol.target().is_none());
+
+        let zero_port = ClReachabilityRequest { enr: test_multiaddr([8, 8, 8, 8], 0, peer_id) };
+        assert!(zero_port.target().is_none());
+
+        let garbage = ClReachabilityRequest { enr: "/ip4/not-an-ip/tcp/9222/p2p/x".to_string() };
+        assert!(garbage.target().is_none());
+
+        for ip in [
+            [10, 0, 0, 1],
+            [127, 0, 0, 1],
+            [169, 254, 169, 254],
+            [100, 64, 0, 1],
+            [0, 0, 0, 0],
+            [198, 18, 0, 1],
+            [192, 0, 0, 8],
+            [240, 0, 0, 1],
+        ] {
+            let non_public = ClReachabilityRequest { enr: test_multiaddr(ip, 9222, peer_id) };
+            assert!(non_public.target().is_none(), "expected {ip:?} to be rejected");
+        }
+    }
+
     #[tokio::test]
     async fn probes_advertised_enr_address() {
         let request = test_cl_request();
@@ -680,6 +766,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn probes_advertised_multiaddr() {
+        let peer_id = test_peer_id();
+        let request = ClReachabilityRequest { enr: test_multiaddr([8, 8, 8, 8], 9222, peer_id) };
+        let expected = request.target().unwrap();
+        let mut prober = MockClReachabilityProber::new();
+        prober.expect_probe().times(1).withf(move |target| *target == expected).returning(|_| {
+            Libp2pProbeResult {
+                outcome: Libp2pProbeOutcome::Reachable,
+                stage: Libp2pProbeStage::Identify,
+                elapsed: Duration::from_millis(12),
+                client_version: Some("base".to_string()),
+            }
+        });
+        let router =
+            router_with_cl_prober(DEFAULT_P2P_REACHABILITY_MAX_CONCURRENT_PROBES, Arc::new(prober));
+        let (address, handle) = start_test_server(router).await;
+
+        let response = reqwest::Client::new()
+            .post(format!("http://{address}{P2P_REACHABILITY_CL_PATH}"))
+            .json(&std::collections::BTreeMap::from([("multiaddr", request.enr.as_str())]))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let response = response.json::<ClReachabilityResponse>().await.unwrap();
+        assert_eq!(response.outcome, Libp2pProbeOutcome::Reachable);
+        assert_eq!(response.observed_address, SocketAddr::from(([8, 8, 8, 8], 9222)));
+        assert_eq!(response.client_version.as_deref(), Some("base"));
+
+        handle.abort();
+    }
+
+    #[tokio::test]
     async fn rejects_private_cl_target() {
         // No expectations: any probe call panics and fails the status assert.
         let router = router_with_cl_prober(
@@ -688,6 +808,28 @@ mod tests {
         );
         let (address, handle) = start_test_server(router).await;
         let request = ClReachabilityRequest { enr: test_enr([10, 0, 0, 1], 9222) };
+
+        let response = reqwest::Client::new()
+            .post(format!("http://{address}{P2P_REACHABILITY_CL_PATH}"))
+            .json(&request)
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn rejects_private_cl_multiaddr() {
+        // No expectations: any probe call panics and fails the status assert.
+        let router = router_with_cl_prober(
+            DEFAULT_P2P_REACHABILITY_MAX_CONCURRENT_PROBES,
+            Arc::new(MockClReachabilityProber::new()),
+        );
+        let (address, handle) = start_test_server(router).await;
+        let request =
+            ClReachabilityRequest { enr: test_multiaddr([10, 0, 0, 1], 9222, test_peer_id()) };
 
         let response = reqwest::Client::new()
             .post(format!("http://{address}{P2P_REACHABILITY_CL_PATH}"))


### PR DESCRIPTION
## Summary
- Accept a public-IPv4 `/ip4/.../tcp/.../p2p/<peer-id>` multiaddr on `POST /v1/p2p/reachability/cl` (JSON `enr` or `multiaddr`)
- Route the same multiaddr form through `basectl p2p reachability` to the CL probe
- Keep existing `enr:` requests and ENR-derived peer identity checks unchanged

## Test Plan
- [x] `cargo test -p base-telemetry-service --lib p2p::`
- [x] `cargo test -p basectl-cli --lib commands::p2p::`
- [x] `cargo clippy -p base-telemetry-service -p basectl-cli --all-targets --no-deps -- -D warnings`
- [x] Manual: `basectl p2p reachability /ip4/<public-ip>/tcp/<port>/p2p/<peer-id>`
- [x] Manual: `basectl p2p reachability enr:<record>` still works