### PR TITLE
feat(proof): route proof jobs by protocol version

### DIFF
--- a/bin/zk-benchmarks/src/cli.rs
+++ b/bin/zk-benchmarks/src/cli.rs
@@ -33,6 +33,10 @@ pub(crate) struct ZkBenchArgs {
     )]
     prover_service_url: url::Url,
 
+    /// Prover-service routing version required by benchmark proof jobs.
+    #[arg(long, env = "PROVER_PROTOCOL_VERSION")]
+    protocol_version: u32,
+
     /// Load test YAML configuration.
     #[arg(value_name = "CONFIG")]
     config: PathBuf,
@@ -70,6 +74,7 @@ async fn run_zk_benchmark(args: ZkBenchArgs) -> Result<()> {
         zk_backend: args.mode.into(),
         rollup_rpc_url: args.rollup_rpc_url,
         prover_url: args.prover_service_url,
+        protocol_version: args.protocol_version,
     };
 
     println!("=== Base ZK Benchmark Runner ===");

--- a/crates/infra/basectl/src/commands/cli.rs
+++ b/crates/infra/basectl/src/commands/cli.rs
@@ -392,7 +392,6 @@ mod tests {
 
     #[test]
     fn proofs_commands_parse() {
-        assert!(try_parse(["basectl", "proofs", "finalize", "100", "5", "--yes"]).is_ok());
         assert!(
             try_parse([
                 "basectl",
@@ -400,6 +399,21 @@ mod tests {
                 "finalize",
                 "100",
                 "5",
+                "--proof-protocol-version",
+                "0",
+                "--yes",
+            ])
+            .is_ok()
+        );
+        assert!(
+            try_parse([
+                "basectl",
+                "proofs",
+                "finalize",
+                "100",
+                "5",
+                "--proof-protocol-version",
+                "1",
                 "--session-id",
                 "custom-session",
                 "--l1-head",
@@ -450,14 +464,49 @@ mod tests {
 
     #[test]
     fn proofs_finalize_rejects_zero_blocks() {
-        assert!(try_parse(["basectl", "proofs", "finalize", "100", "0", "--yes"]).is_err());
+        assert!(
+            try_parse([
+                "basectl",
+                "proofs",
+                "finalize",
+                "100",
+                "0",
+                "--proof-protocol-version",
+                "0",
+                "--yes",
+            ])
+            .is_err()
+        );
     }
 
     #[test]
     fn proofs_finalize_json_requires_yes() {
-        assert!(try_parse(["basectl", "proofs", "finalize", "100", "5", "--json"]).is_err());
         assert!(
-            try_parse(["basectl", "proofs", "finalize", "100", "5", "--yes", "--json"]).is_ok()
+            try_parse([
+                "basectl",
+                "proofs",
+                "finalize",
+                "100",
+                "5",
+                "--proof-protocol-version",
+                "0",
+                "--json",
+            ])
+            .is_err()
+        );
+        assert!(
+            try_parse([
+                "basectl",
+                "proofs",
+                "finalize",
+                "100",
+                "5",
+                "--proof-protocol-version",
+                "0",
+                "--yes",
+                "--json",
+            ])
+            .is_ok()
         );
     }
 

--- a/crates/infra/basectl/src/commands/proofs.rs
+++ b/crates/infra/basectl/src/commands/proofs.rs
@@ -103,6 +103,13 @@ pub struct ProofsFinalizeArgs {
     /// Intermediate output root interval passed to the prover.
     #[arg(long = "intermediate-root-interval", value_name = "N")]
     pub intermediate_root_interval: Option<u64>,
+    /// Prover-service routing version required by this proof job.
+    #[arg(
+        long = "proof-protocol-version",
+        env = "BASECTL_PROOF_PROTOCOL_VERSION",
+        value_name = "VERSION"
+    )]
+    pub protocol_version: u32,
     /// Poll the prover service until the proof succeeds or fails.
     ///
     /// Exits non-zero when the proof fails or does not complete in time.
@@ -212,6 +219,7 @@ async fn run_finalize(
         l1_head,
         sequence_window,
         intermediate_root_interval,
+        protocol_version,
         wait,
         prover_rpc,
         yes,
@@ -225,6 +233,7 @@ async fn run_finalize(
         l1_head,
         sequence_window,
         intermediate_root_interval,
+        protocol_version,
     };
     let request = request.to_prove_request(&config.name);
     let end_block = start_block.saturating_add(num_blocks.saturating_sub(1));

--- a/crates/infra/basectl/src/rpc/prover.rs
+++ b/crates/infra/basectl/src/rpc/prover.rs
@@ -33,6 +33,8 @@ pub struct ProofFinalizeRequest {
     pub sequence_window: Option<u64>,
     /// Optional intermediate output root interval.
     pub intermediate_root_interval: Option<u64>,
+    /// Prover-service routing version required by this proof job.
+    pub protocol_version: u32,
 }
 
 impl ProofFinalizeRequest {
@@ -70,6 +72,7 @@ impl ProofFinalizeRequest {
         ProveBlockRangeRequest {
             proof: ProofRequest {
                 session_id: self.effective_session_id(network),
+                protocol_version: self.protocol_version,
                 request: ProofRequestKind::Compressed(ZkProofRequest {
                     start_block_number: self.start_block,
                     number_of_blocks_to_prove: self.num_blocks,
@@ -246,6 +249,7 @@ mod tests {
             l1_head: None,
             sequence_window: None,
             intermediate_root_interval: None,
+            protocol_version: 1,
         }
     }
 
@@ -288,10 +292,12 @@ mod tests {
             l1_head: Some(alloy_primitives::B256::repeat_byte(0xaa)),
             sequence_window: Some(3600),
             intermediate_root_interval: Some(10),
+            protocol_version: 7,
         };
 
         let prove = request.to_prove_request("devnet");
         assert_eq!(prove.proof.session_id, "session-map");
+        assert_eq!(prove.proof.protocol_version, 7);
         match prove.proof.request {
             ProofRequestKind::Compressed(zk) => {
                 assert_eq!(zk.start_block_number, 100);

--- a/crates/infra/snark-e2e/src/snark_e2e.rs
+++ b/crates/infra/snark-e2e/src/snark_e2e.rs
@@ -99,6 +99,10 @@ impl SnarkE2e {
     /// 6. Verify the SNARK proof with `CpuProver`
     pub async fn run() -> Result<()> {
         let l2_rpc = std::env::var("L2_NODE_ADDRESS").context("L2_NODE_ADDRESS must be set")?;
+        let protocol_version = std::env::var("PROVER_PROTOCOL_VERSION")
+            .context("PROVER_PROTOCOL_VERSION must be set")?
+            .parse()
+            .context("PROVER_PROTOCOL_VERSION must be a u32")?;
 
         // -- 1. Query L2 safe head -----------------------------------------------
         //
@@ -208,6 +212,7 @@ impl SnarkE2e {
             .prove_block_range(ProveBlockRangeRequest {
                 proof: ProofRequest {
                     session_id: session_id.clone(),
+                    protocol_version,
                     request: ProofRequestKind::SnarkPlonk(SnarkPlonkProofRequest {
                         proof: ZkProofRequest {
                             start_block_number: safe_head,

--- a/crates/infra/zk-benchmarks/src/runner.rs
+++ b/crates/infra/zk-benchmarks/src/runner.rs
@@ -114,7 +114,13 @@ impl ZkBenchRunner {
         let client = ProofRequesterClient::connect(&client_config)
             .wrap_err_with(|| format!("failed to connect prover service {}", config.prover_url))?;
         let session_id = format!("zk-benchmarks-{}-{}", zk_backend.as_str(), nanoid!());
-        let request = Self::proof_request(session_id, start_block_number, l1_head, zk_backend);
+        let request = Self::proof_request(
+            session_id,
+            start_block_number,
+            l1_head,
+            zk_backend,
+            config.protocol_version,
+        );
         let proof_started = Instant::now();
         let response =
             client.prove_block_range(request).await.wrap_err("prove-block-range request failed")?;
@@ -144,10 +150,12 @@ impl ZkBenchRunner {
         start_block_number: u64,
         l1_head: B256,
         zk_backend: ZkBackend,
+        protocol_version: u32,
     ) -> ProveBlockRangeRequest {
         ProveBlockRangeRequest {
             proof: ProofRequest {
                 session_id,
+                protocol_version,
                 request: ProofRequestKind::Compressed(ZkProofRequest {
                     start_block_number,
                     number_of_blocks_to_prove: 1,
@@ -272,7 +280,9 @@ mod tests {
             9,
             B256::repeat_byte(0xaa),
             ZkBackend::Cluster,
+            7,
         );
+        assert_eq!(request.proof.protocol_version, 7);
         let ProofRequestKind::Compressed(proof) = request.proof.request else {
             panic!("expected compressed proof request");
         };

--- a/crates/infra/zk-benchmarks/src/types.rs
+++ b/crates/infra/zk-benchmarks/src/types.rs
@@ -36,6 +36,8 @@ pub struct ZkBenchConfig {
     pub rollup_rpc_url: Url,
     /// ZK prover RPC URL.
     pub prover_url: Url,
+    /// Prover-service routing version required by proof jobs.
+    pub protocol_version: u32,
 }
 
 /// The single L2 block selected for proof.

--- a/crates/infra/zk-fork-dispute/src/checkpoint.rs
+++ b/crates/infra/zk-fork-dispute/src/checkpoint.rs
@@ -168,6 +168,7 @@ impl Checkpoint {
             .prove_block_range(ProveBlockRangeRequest {
                 proof: ProofRequest {
                     session_id: session_id.clone(),
+                    protocol_version: config.proof_protocol_version,
                     request: ProofRequestKind::SnarkPlonk(snark_request),
                 },
             })

--- a/crates/infra/zk-fork-dispute/src/cli.rs
+++ b/crates/infra/zk-fork-dispute/src/cli.rs
@@ -48,6 +48,10 @@ pub struct ForkArgs {
     )]
     pub prover_service_url: Url,
 
+    /// Prover-service routing version required by the selected game.
+    #[arg(long = "proof-protocol-version", env = cli_env!("PROOF_PROTOCOL_VERSION"))]
+    pub proof_protocol_version: u32,
+
     /// `DisputeGameFactory` address.
     #[arg(long = "dispute-game-factory", env = cli_env!("DISPUTE_GAME_FACTORY"))]
     pub dispute_game_factory: Address,

--- a/crates/infra/zk-fork-dispute/src/config.rs
+++ b/crates/infra/zk-fork-dispute/src/config.rs
@@ -25,6 +25,8 @@ pub struct Config {
     pub l2_provider: L2HttpProvider,
     /// Prover-service JSON-RPC endpoint.
     pub prover_service_url: Url,
+    /// Prover-service routing version required by the selected game.
+    pub proof_protocol_version: u32,
     /// `DisputeGameFactory` address.
     pub dispute_game_factory: Address,
     /// Selected dispute game proxy.
@@ -69,6 +71,7 @@ impl Config {
             l1_rpc_url: args.l1_rpc_url,
             l2_provider: RootProvider::new_http(args.l2_rpc_url),
             prover_service_url: args.prover_service_url,
+            proof_protocol_version: args.proof_protocol_version,
             dispute_game_factory: args.dispute_game_factory,
             game_address,
             game_type,

--- a/crates/proof/challenge/src/cli.rs
+++ b/crates/proof/challenge/src/cli.rs
@@ -10,6 +10,8 @@ use base_cli_utils::CliStyles;
 use clap::Parser;
 use url::Url;
 
+use crate::ProofProtocolVersion;
+
 base_cli_utils::define_cli_env!("BASE_CHALLENGER");
 base_cli_utils::define_log_args!("BASE_CHALLENGER");
 base_cli_utils::define_metrics_args!("BASE_CHALLENGER", 7300);
@@ -63,6 +65,15 @@ pub struct ChallengerArgs {
     /// Game type ID for `AggregateVerifier` dispute games.
     #[arg(long = "game-type", env = cli_env!("GAME_TYPE"))]
     pub game_type: u32,
+
+    /// Capability fingerprint to prover-service routing version mappings.
+    #[arg(
+        long = "proof-protocol-version",
+        env = cli_env!("PROOF_PROTOCOL_VERSION"),
+        value_delimiter = ',',
+        required = true
+    )]
+    pub proof_protocol_versions: Vec<ProofProtocolVersion>,
 
     /// Polling interval for new dispute games (e.g., "12s", "1m").
     #[arg(

--- a/crates/proof/challenge/src/config.rs
+++ b/crates/proof/challenge/src/config.rs
@@ -1,14 +1,41 @@
 //! Configuration types and validation for the challenger.
 
-use std::{net::SocketAddr, time::Duration};
+use std::{collections::HashMap, net::SocketAddr, str::FromStr, time::Duration};
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256};
 use base_cli_utils::MetricsConfig;
 use base_tx_manager::{SignerConfig, TxManagerConfig};
 use eyre::{Result, WrapErr, ensure};
 use url::Url;
 
 use crate::cli::Cli;
+
+/// Maps a canonical proof capability fingerprint to its prover-service routing version.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProofProtocolVersion {
+    /// Canonical fingerprint returned by `ProofProtocolDescriptor::fingerprint`.
+    pub fingerprint: B256,
+    /// Opaque exact-match routing version stored by prover-service.
+    pub protocol_version: u32,
+}
+
+impl FromStr for ProofProtocolVersion {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let (fingerprint, protocol_version) = value
+            .split_once('=')
+            .ok_or_else(|| "expected <fingerprint>=<protocol_version>".to_owned())?;
+        Ok(Self {
+            fingerprint: fingerprint
+                .parse()
+                .map_err(|error| format!("invalid fingerprint: {error}"))?,
+            protocol_version: protocol_version
+                .parse()
+                .map_err(|error| format!("invalid protocol version: {error}"))?,
+        })
+    }
+}
 
 /// Challenger configuration.
 #[derive(Debug)]
@@ -23,6 +50,8 @@ pub struct ChallengerConfig {
     pub anchor_state_registry_addr: Address,
     /// Game type ID for `AggregateVerifier` dispute games.
     pub game_type: u32,
+    /// Capability fingerprint to prover-service routing version mappings.
+    pub proof_protocol_versions: HashMap<B256, u32>,
     /// Polling interval for new dispute games.
     pub poll_interval: Duration,
     /// URL of the ZK RPC endpoint.
@@ -71,6 +100,16 @@ impl ChallengerConfig {
             "anchor-state-registry-addr must be non-zero"
         );
 
+        let proof_protocol_versions: HashMap<_, _> = challenger
+            .proof_protocol_versions
+            .iter()
+            .map(|mapping| (mapping.fingerprint, mapping.protocol_version))
+            .collect();
+        ensure!(
+            proof_protocol_versions.len() == challenger.proof_protocol_versions.len(),
+            "proof-protocol-version contains duplicate fingerprints"
+        );
+
         for (duration, message) in [
             (challenger.poll_interval, "poll-interval must be greater than 0"),
             (challenger.zk_request_timeout, "zk-request-timeout must be greater than 0"),
@@ -98,6 +137,7 @@ impl ChallengerConfig {
             dispute_game_factory_addr: challenger.dispute_game_factory_addr,
             anchor_state_registry_addr: challenger.anchor_state_registry_addr,
             game_type: challenger.game_type,
+            proof_protocol_versions,
             poll_interval: challenger.poll_interval,
             zk_rpc_url: challenger.zk_rpc_url,
             zk_request_timeout: challenger.zk_request_timeout,
@@ -138,6 +178,8 @@ mod tests {
             "0x2234567890123456789012345678901234567890",
             "--game-type",
             "1",
+            "--proof-protocol-version",
+            "0x0000000000000000000000000000000000000000000000000000000000000001=1",
             "--zk-rpc-url",
             "http://localhost:5000",
             "--private-key",
@@ -159,7 +201,7 @@ mod tests {
 
     #[test]
     fn test_invalid_config_rejected() {
-        let cases: [InvalidConfigCase; 10] = [
+        let cases: [InvalidConfigCase; 11] = [
             (
                 |cli| cli.challenger.poll_interval = Duration::ZERO,
                 "poll-interval must be greater than 0",
@@ -205,6 +247,13 @@ mod tests {
             (
                 |cli| cli.challenger.zk_rpc_url = Url::parse("file:///no/host").unwrap(),
                 "invalid zk-rpc-url URL: missing host",
+            ),
+            (
+                |cli| {
+                    let duplicate = cli.challenger.proof_protocol_versions[0];
+                    cli.challenger.proof_protocol_versions.push(duplicate);
+                },
+                "proof-protocol-version contains duplicate fingerprints",
             ),
         ];
 

--- a/crates/proof/challenge/src/lib.rs
+++ b/crates/proof/challenge/src/lib.rs
@@ -13,7 +13,7 @@ mod anchor;
 pub use anchor::AnchorUpdater;
 
 mod config;
-pub use config::ChallengerConfig;
+pub use config::{ChallengerConfig, ProofProtocolVersion};
 
 mod driver;
 pub use driver::{Driver, DriverComponents};

--- a/crates/proof/challenge/src/metrics.rs
+++ b/crates/proof/challenge/src/metrics.rs
@@ -13,6 +13,23 @@ base_metrics::define_metrics! {
     #[describe("Latest factory index scanned by the game scanner")]
     scan_head: gauge,
 
+    #[describe("In-progress games that may still require proofs, by prover protocol version")]
+    #[label(name = "protocol_version")]
+    open_games: gauge,
+
+    #[describe(
+        "Total games skipped because their capability fingerprint has no configured protocol \
+         version. Non-zero means a deployed verifier is missing from --proof-protocol-version and \
+         its games are going unchallenged."
+    )]
+    unmapped_fingerprint_games_total: counter,
+
+    #[describe(
+        "Total games skipped because they commit a proof schedule this challenger cannot \
+         reproduce. Non-zero means full-schedule-era games are live and going unchallenged."
+    )]
+    unsupported_schedule_games_total: counter,
+
     #[describe("Total number of games found to be invalid during validation")]
     games_invalid_total: counter,
 

--- a/crates/proof/challenge/src/pending.rs
+++ b/crates/proof/challenge/src/pending.rs
@@ -101,6 +101,8 @@ pub struct PendingProof {
     pub tee_submit_retry_count: u32,
     /// The intended on-chain dispute action once the proof is ready.
     pub intent: DisputeIntent,
+    /// Opaque prover-service routing version required for retries.
+    pub protocol_version: u32,
 }
 
 impl PendingProof {
@@ -111,6 +113,7 @@ impl PendingProof {
         expected_root: B256,
         prove_request: SnarkPlonkProofRequest,
         intent: DisputeIntent,
+        protocol_version: u32,
     ) -> Self {
         Self {
             phase: ProofPhase::AwaitingProof { session_id, started_at: Instant::now() },
@@ -120,6 +123,7 @@ impl PendingProof {
             retry_count: 0,
             tee_submit_retry_count: 0,
             intent,
+            protocol_version,
         }
     }
 
@@ -129,6 +133,7 @@ impl PendingProof {
         invalid_index: u64,
         expected_root: B256,
         zk_fallback: Option<(SnarkPlonkProofRequest, DisputeIntent)>,
+        protocol_version: u32,
     ) -> Self {
         Self {
             phase: ProofPhase::AwaitingProof { session_id, started_at: Instant::now() },
@@ -138,6 +143,7 @@ impl PendingProof {
             retry_count: 0,
             tee_submit_retry_count: 0,
             intent: DisputeIntent::Nullify,
+            protocol_version,
         }
     }
 
@@ -148,6 +154,7 @@ impl PendingProof {
         expected_root: B256,
         prove_request: SnarkPlonkProofRequest,
         intent: DisputeIntent,
+        protocol_version: u32,
     ) -> Self {
         Self {
             phase: ProofPhase::ReadyToSubmit { proof_bytes },
@@ -157,6 +164,7 @@ impl PendingProof {
             retry_count: 0,
             tee_submit_retry_count: 0,
             intent,
+            protocol_version,
         }
     }
 }
@@ -382,6 +390,7 @@ mod tests {
             B256::ZERO,
             minimal_prove_request(),
             DisputeIntent::Challenge,
+            1,
         )
     }
 
@@ -509,6 +518,7 @@ mod tests {
                         0,
                         expected_root,
                         Some((minimal_prove_request(), DisputeIntent::Challenge)),
+                        1,
                     ),
                     MockZkProofState {
                         proof_status: ProofStatus::Succeeded,

--- a/crates/proof/challenge/src/proof_adapter.rs
+++ b/crates/proof/challenge/src/proof_adapter.rs
@@ -42,10 +42,15 @@ impl ChallengerProofAdapter {
         game_address: Address,
         invalid_index: u64,
         request: SnarkPlonkProofRequest,
+        protocol_version: u32,
     ) -> ProveBlockRangeRequest {
         let session_id = Self::snark_plonk_session_id(game_address, invalid_index);
         ProveBlockRangeRequest {
-            proof: ProofRequest { session_id, request: ProofRequestKind::SnarkPlonk(request) },
+            proof: ProofRequest {
+                session_id,
+                protocol_version,
+                request: ProofRequestKind::SnarkPlonk(request),
+            },
         }
     }
 
@@ -54,11 +59,13 @@ impl ChallengerProofAdapter {
         game_address: Address,
         invalid_index: u64,
         request: PrimitiveProofRequest,
+        protocol_version: u32,
     ) -> ProveBlockRangeRequest {
         let session_id = Self::tee_session_id(game_address, invalid_index);
         ProveBlockRangeRequest {
             proof: ProofRequest {
                 session_id,
+                protocol_version,
                 request: ProofRequestKind::Tee(TeeProofRequest {
                     proof: request,
                     tee_kind: TeeKind::AwsNitro,
@@ -187,10 +194,38 @@ mod tests {
             game_address,
             invalid_index,
             request.clone(),
+            0,
         );
 
         assert_eq!(wrapped.proof.session_id, session_id);
+        assert_eq!(wrapped.proof.protocol_version, 0);
         assert_eq!(wrapped.proof.request, ProofRequestKind::SnarkPlonk(request));
+    }
+
+    #[test]
+    fn snark_plonk_uses_requested_protocol() {
+        let request = SnarkPlonkProofRequest {
+            proof: ZkProofRequest {
+                start_block_number: 100,
+                number_of_blocks_to_prove: 300,
+                sequence_window: None,
+                l1_head: None,
+                intermediate_root_interval: None,
+                schedule_l2_block_number: Some(600),
+                zk_vm: ZkVm::Sp1,
+                zk_backend: ZkBackend::Cluster,
+            },
+            prover_address: Address::repeat_byte(0x11),
+        };
+
+        let wrapped = ChallengerProofAdapter::snark_plonk_prove_block_range_request(
+            Address::repeat_byte(0xaa),
+            1,
+            request,
+            7,
+        );
+
+        assert_eq!(wrapped.proof.protocol_version, 7);
     }
 
     #[test]
@@ -215,13 +250,39 @@ mod tests {
             game_address,
             invalid_index,
             request.clone(),
+            0,
         );
 
         assert_eq!(wrapped.proof.session_id, session_id);
+        assert_eq!(wrapped.proof.protocol_version, 0);
         assert_eq!(
             wrapped.proof.request,
             ProofRequestKind::Tee(TeeProofRequest { proof: request, tee_kind: TeeKind::AwsNitro })
         );
+    }
+
+    #[test]
+    fn tee_uses_requested_protocol() {
+        let request = ProofRequest {
+            l1_head: B256::repeat_byte(0x01),
+            agreed_l2_head_hash: B256::repeat_byte(0x02),
+            agreed_l2_output_root: B256::repeat_byte(0x03),
+            claimed_l2_output_root: B256::repeat_byte(0x04),
+            claimed_l2_block_number: 600,
+            proposer: Address::repeat_byte(0x05),
+            intermediate_block_interval: 300,
+            l1_head_number: 1200,
+            schedule_l2_block_number: Some(600),
+        };
+
+        let wrapped = ChallengerProofAdapter::tee_prove_block_range_request(
+            Address::repeat_byte(0xaa),
+            1,
+            request,
+            9,
+        );
+
+        assert_eq!(wrapped.proof.protocol_version, 9);
     }
 
     #[test]

--- a/crates/proof/challenge/src/proof_manager.rs
+++ b/crates/proof/challenge/src/proof_manager.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use alloy_primitives::{Address, B256};
-use base_proof_contracts::{AggregateVerifierClient, GameStatus};
+use base_proof_contracts::{AggregateVerifierClient, GameStatus, ProofScheduleKind};
 use base_proof_primitives::ProofRequest as TeeProofRequest;
 use base_proof_rpc::{L1Provider, L2Provider};
 use base_proof_submission::KnownRevert;
@@ -181,6 +181,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
                         game_address,
                         invalid_index,
                         tee_request,
+                        candidate.protocol_version,
                     );
                     match self.proof_requester.prove_block_range(request).await {
                         Ok(response) => {
@@ -197,6 +198,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
                                     invalid_index,
                                     expected_root,
                                     zk_fallback,
+                                    candidate.protocol_version,
                                 ),
                             );
                             return Ok(());
@@ -241,6 +243,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
             game_address,
             invalid_index,
             proof_request.clone(),
+            candidate.protocol_version,
         );
 
         let prove_response = self.proof_requester.prove_block_range(request).await?;
@@ -259,6 +262,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
                 expected_root,
                 proof_request,
                 intent,
+                candidate.protocol_version,
             ),
         );
 
@@ -296,7 +300,11 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
             proposer,
             intermediate_block_interval: candidate.intermediate_block_interval,
             l1_head_number,
-            schedule_l2_block_number: Some(candidate.info.l2_block_number),
+            // `image_hash` is deliberately not set here. `ProofRequest` has no such field on main
+            // (#4321 removed it), and restoring it belongs with the Nitro image-selection change
+            // that reads it. `CandidateGame.tee_image_hash` already carries the value.
+            schedule_l2_block_number: (candidate.schedule_kind == ProofScheduleKind::Activated)
+                .then_some(candidate.info.l2_block_number),
         })
     }
 
@@ -315,7 +323,8 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
                 sequence_window: None,
                 l1_head: Some(candidate.l1_head),
                 intermediate_root_interval: Some(candidate.intermediate_block_interval),
-                schedule_l2_block_number: Some(candidate.info.l2_block_number),
+                schedule_l2_block_number: (candidate.schedule_kind == ProofScheduleKind::Activated)
+                    .then_some(candidate.info.l2_block_number),
                 zk_vm: ZkVm::Sp1,
                 zk_backend: ZkBackend::Cluster,
             },
@@ -541,6 +550,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
 
         let retry_count = pending.retry_count;
         let invalid_index = pending.invalid_index;
+        let protocol_version = pending.protocol_version;
 
         if retry_count > Self::MAX_PROOF_RETRIES {
             warn!(
@@ -585,6 +595,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
             game_address,
             invalid_index,
             request,
+            protocol_version,
         );
 
         match self.proof_requester.prove_block_range(prove_request).await {
@@ -689,6 +700,7 @@ mod tests {
                 B256::repeat_byte(0x22),
                 proof_request(),
                 DisputeIntent::Challenge,
+                1,
             ),
         );
     }
@@ -707,6 +719,7 @@ mod tests {
                 retry_count: 0,
                 tee_submit_retry_count: 0,
                 intent: DisputeIntent::Nullify,
+                protocol_version: 1,
             },
         );
     }

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -33,14 +33,14 @@
 //! provers zero) are skipped.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{Arc, Mutex},
 };
 
 use alloy_primitives::{Address, B256};
 use base_proof_contracts::{
     AggregateVerifierClient, AnchorStateRegistryClient, DisputeGameFactoryClient, GameAtIndex,
-    GameInfo, GameStatus,
+    GameInfo, GameStatus, ProofScheduleKind,
 };
 use eyre::Result;
 use futures::stream::{self, StreamExt};
@@ -102,6 +102,12 @@ pub struct CandidateGame {
     pub intermediate_block_interval: u64,
     /// The L1 head block hash stored at game creation time.
     pub l1_head: B256,
+    /// Opaque prover-service routing version required by this game.
+    pub protocol_version: u32,
+    /// Schedule semantics committed by this game's journal.
+    pub schedule_kind: ProofScheduleKind,
+    /// Nitro image hash expected by this game.
+    pub tee_image_hash: B256,
     /// Address of the TEE prover for this game (`Address::ZERO` if none registered).
     pub tee_prover: Address,
     /// Classification of this candidate and the action the driver should take.
@@ -131,9 +137,8 @@ pub struct GameScanner {
     factory_client: Arc<dyn DisputeGameFactoryClient>,
     verifier_client: Arc<dyn AggregateVerifierClient>,
     anchor_registry_client: Arc<dyn AnchorStateRegistryClient>,
-    /// Cache of `impl_address → intermediate_block_interval` to avoid repeated RPC calls.
-    /// A governance `setImplementation` call changes the address and automatically causes a
-    /// cache miss.
+    protocol_versions: HashMap<B256, u32>,
+    /// Cache of `game_address → intermediate_block_interval` to avoid repeated RPC calls.
     interval_cache: Mutex<HashMap<Address, u64>>,
     /// Cached `(anchor_game, factory_index)` for the current anchor game.
     anchor_index: Option<(Address, u64)>,
@@ -157,11 +162,13 @@ impl GameScanner {
         factory_client: Arc<dyn DisputeGameFactoryClient>,
         verifier_client: Arc<dyn AggregateVerifierClient>,
         anchor_registry_client: Arc<dyn AnchorStateRegistryClient>,
+        protocol_versions: HashMap<B256, u32>,
     ) -> Self {
         Self {
             factory_client,
             verifier_client,
             anchor_registry_client,
+            protocol_versions,
             interval_cache: Mutex::new(HashMap::new()),
             anchor_index: None,
         }
@@ -203,16 +210,45 @@ impl GameScanner {
                 .await;
 
         let mut candidates = Vec::new();
+        let mut evaluated_every_index = true;
 
         for (i, result) in results {
             match result {
                 Ok(Some(candidate)) => candidates.push(candidate),
                 Ok(None) => {}
-                Err(e) => warn!(error = %e, index = i, "game query failed"),
+                Err(e) => {
+                    evaluated_every_index = false;
+                    warn!(error = %e, index = i, "game query failed");
+                }
             }
         }
 
         candidates.sort_unstable_by_key(|c| c.index);
+
+        // Drop cached intervals for games that fell behind the anchor. Keyed by game proxy, the
+        // cache would otherwise grow for the life of the process; live games are re-cached by the
+        // next scan's `evaluate_game`.
+        //
+        // Only a scan that evaluated every index knows the full live set. A game that hit a
+        // transient RPC error is absent from `candidates` despite still being live, so evicting
+        // after a partial scan would discard its interval and re-fetch it next tick. Deferring
+        // eviction to the next clean scan keeps growth bounded without that churn.
+        if evaluated_every_index {
+            let live: HashSet<Address> = candidates.iter().map(|c| c.factory.proxy).collect();
+            self.interval_cache
+                .lock()
+                .expect("interval_cache lock poisoned")
+                .retain(|a, _| live.contains(a));
+        }
+
+        let mut open_games: HashMap<u32, usize> =
+            self.protocol_versions.values().map(|&version| (version, 0)).collect();
+        for candidate in &candidates {
+            *open_games.entry(candidate.protocol_version).or_default() += 1;
+        }
+        for (protocol_version, count) in open_games {
+            ChallengerMetrics::open_games(protocol_version.to_string()).set(count as f64);
+        }
 
         ChallengerMetrics::games_scanned_total().increment(games_to_scan);
         ChallengerMetrics::scan_head().set(end as f64);
@@ -393,17 +429,46 @@ impl GameScanner {
         };
 
         // Fetch remaining fields only for actionable games.
-        let ((info, starting_block_number, l1_head), intermediate_block_interval) = tokio::try_join!(
-            async {
-                tokio::try_join!(
-                    self.verifier_client.game_info(factory.proxy),
-                    self.verifier_client.starting_block_number(factory.proxy),
-                    self.verifier_client.l1_head(factory.proxy),
-                )
-                .map_err(Into::into)
-            },
-            self.resolve_intermediate_block_interval(factory.game_type),
-        )?;
+        let ((info, starting_block_number, l1_head, proof_protocol), intermediate_block_interval) =
+            tokio::try_join!(
+                async {
+                    tokio::try_join!(
+                        self.verifier_client.game_info(factory.proxy),
+                        self.verifier_client.starting_block_number(factory.proxy),
+                        self.verifier_client.l1_head(factory.proxy),
+                        self.verifier_client.proof_protocol_descriptor(factory.proxy),
+                    )
+                    .map_err(Into::into)
+                },
+                self.resolve_intermediate_block_interval(factory.proxy),
+            )?;
+
+        // A full-schedule game commits the whole `ProtocolVersions.scheduleId()` snapshotted at
+        // game creation, which needs the historical rollup-config snapshot that reproduces that
+        // exact value. Nothing here can supply it: both request builders only carry
+        // `schedule_l2_block_number`, so a full-schedule game would be sent as if it pinned
+        // nothing, and the resulting journal would be rejected on-chain. Fail closed instead of
+        // burning a prover job on a proof that cannot verify.
+        if proof_protocol.schedule_kind == ProofScheduleKind::Full {
+            ChallengerMetrics::unsupported_schedule_games_total().increment(1);
+            error!(
+                index = index,
+                "full-schedule game cannot be proven; challenger only supports the \
+                 no-schedule and activated-prefix eras"
+            );
+            return Err(eyre::eyre!("game {index} uses the unsupported full-schedule era"));
+        }
+
+        let fingerprint = proof_protocol.fingerprint();
+        let protocol_version = self.protocol_versions.get(&fingerprint).copied().ok_or_else(|| {
+            // A transient RPC error retries on the next scan; an unmapped fingerprint never will,
+            // so the game goes unchallenged until an operator adds the mapping. The caller logs
+            // the message below; this counter is what an alert can fire on.
+            ChallengerMetrics::unmapped_fingerprint_games_total().increment(1);
+            eyre::eyre!(
+                "no prover protocol version configured for game {index} capability {fingerprint}"
+            )
+        })?;
 
         Ok(Some(CandidateGame {
             index,
@@ -412,6 +477,9 @@ impl GameScanner {
             starting_block_number,
             intermediate_block_interval,
             l1_head,
+            protocol_version,
+            schedule_kind: proof_protocol.schedule_kind,
+            tee_image_hash: proof_protocol.tee_image_hash,
             tee_prover,
             category,
         }))
@@ -487,38 +555,25 @@ impl GameScanner {
         }
     }
 
-    /// Resolves the intermediate block interval for a game type, using a cache
-    /// to avoid repeated RPC calls for the same implementation address.
-    ///
-    /// The impl address is always fetched from the factory so that a governance
-    /// `setImplementation` call (which changes the address) automatically
-    /// invalidates the cached value.
-    async fn resolve_intermediate_block_interval(&self, game_type: u32) -> Result<u64> {
-        let impl_address = self.factory_client.game_impls(game_type).await?;
-        if impl_address == Address::ZERO {
-            return Err(eyre::eyre!(
-                "no game implementation registered in DisputeGameFactory for game type {game_type}"
-            ));
-        }
-
+    /// Resolves the intermediate block interval from the historical game proxy.
+    async fn resolve_intermediate_block_interval(&self, game_address: Address) -> Result<u64> {
         {
             let cache = self.interval_cache.lock().expect("interval_cache lock poisoned");
-            if let Some(&interval) = cache.get(&impl_address) {
+            if let Some(&interval) = cache.get(&game_address) {
                 return Ok(interval);
             }
         }
 
-        let interval = self.verifier_client.read_intermediate_block_interval(impl_address).await?;
+        let interval = self.verifier_client.read_intermediate_block_interval(game_address).await?;
 
         debug!(
-            game_type = game_type,
             interval = interval,
-            impl_address = %impl_address,
+            game_address = %game_address,
             "resolved intermediate block interval"
         );
 
         let mut cache = self.interval_cache.lock().expect("interval_cache lock poisoned");
-        cache.insert(impl_address, interval);
+        cache.insert(game_address, interval);
 
         Ok(interval)
     }
@@ -541,8 +596,16 @@ mod tests {
     use super::*;
     use crate::test_utils::{
         MockAggregateVerifier, MockAnchorStateRegistry, MockDisputeGameFactory, addr, factory_game,
-        mock_anchor_registry, mock_state, mock_state_with_tee,
+        mock_anchor_registry, mock_protocol_versions, mock_state, mock_state_with_tee,
     };
+
+    fn test_scanner(
+        factory: Arc<dyn DisputeGameFactoryClient>,
+        verifier: Arc<dyn AggregateVerifierClient>,
+        anchor: Arc<dyn AnchorStateRegistryClient>,
+    ) -> GameScanner {
+        GameScanner::new(factory, verifier, anchor, mock_protocol_versions())
+    }
 
     /// Mock factory that records queried indices and can return errors for specific indices.
     #[derive(Debug)]
@@ -629,7 +692,7 @@ mod tests {
 
         let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
 
-        let mut scanner = GameScanner::new(
+        let mut scanner = test_scanner(
             factory,
             Arc::clone(&verifier) as Arc<dyn AggregateVerifierClient>,
             mock_anchor_registry(Address::ZERO),
@@ -656,7 +719,7 @@ mod tests {
         assert_eq!(candidates[3].info.l2_block_number, 400);
         assert_eq!(
             verifier.intermediate_block_interval_reads.lock().unwrap().as_slice(),
-            &[Address::repeat_byte(0x11)],
+            &[addr(0), addr(1), addr(3), addr(4)],
         );
     }
 
@@ -681,7 +744,7 @@ mod tests {
 
         let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
 
-        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
+        let mut scanner = test_scanner(factory, verifier, mock_anchor_registry(Address::ZERO));
 
         let candidates = scanner.scan().await.unwrap();
 
@@ -700,7 +763,7 @@ mod tests {
         let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
         let verifier = Arc::new(MockAggregateVerifier::new(HashMap::new()));
 
-        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
+        let mut scanner = test_scanner(factory, verifier, mock_anchor_registry(Address::ZERO));
 
         let candidates = scanner.scan().await.unwrap();
 
@@ -723,7 +786,7 @@ mod tests {
         let factory = Arc::new(MockDisputeGameFactory::new(games));
         let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
 
-        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(addr(96)));
+        let mut scanner = test_scanner(factory, verifier, mock_anchor_registry(addr(96)));
 
         let candidates = scanner.scan().await.unwrap();
 
@@ -744,7 +807,7 @@ mod tests {
         let games = (0..game_count).map(|i| factory_game(i, 1)).collect();
         let factory = Arc::new(RecordingDisputeGameFactory::new(games, vec![error_index]));
         let verifier = Arc::new(MockAggregateVerifier::new(HashMap::new()));
-        let scanner = GameScanner::new(
+        let scanner = test_scanner(
             Arc::clone(&factory) as Arc<dyn DisputeGameFactoryClient>,
             verifier,
             mock_anchor_registry(Address::ZERO),
@@ -776,7 +839,7 @@ mod tests {
 
         let factory = Arc::new(RecordingDisputeGameFactory::new(games, vec![]));
         let verifier = Arc::new(MockAggregateVerifier::new(HashMap::new()));
-        let scanner = GameScanner::new(
+        let scanner = test_scanner(
             Arc::clone(&factory) as Arc<dyn DisputeGameFactoryClient>,
             verifier,
             mock_anchor_registry(Address::ZERO),
@@ -804,7 +867,7 @@ mod tests {
         let factory = Arc::new(MockDisputeGameFactory::new(games));
         let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
         let anchor_registry = Arc::new(MockAnchorStateRegistry::new(addr(2)));
-        let mut scanner = GameScanner::new(
+        let mut scanner = test_scanner(
             factory,
             verifier,
             Arc::clone(&anchor_registry) as Arc<dyn AnchorStateRegistryClient>,
@@ -837,7 +900,7 @@ mod tests {
 
         let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
 
-        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
+        let mut scanner = test_scanner(factory, verifier, mock_anchor_registry(Address::ZERO));
 
         // Index 0 -> candidate. Index 1 errors -> skipped. Index 2 -> candidate.
         let candidates = scanner.scan().await.unwrap();
@@ -870,13 +933,44 @@ mod tests {
 
         let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
 
-        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
+        let mut scanner = test_scanner(factory, verifier, mock_anchor_registry(Address::ZERO));
 
         let candidates = scanner.scan().await.unwrap();
 
         assert_eq!(candidates.len(), 2);
         assert_eq!(candidates[0].index, 0);
         assert_eq!(candidates[1].index, 1);
+    }
+
+    #[tokio::test]
+    async fn test_scan_preserves_legacy_game_protocol() {
+        let factory = Arc::new(MockDisputeGameFactory::new(vec![factory_game(0, 1)]));
+        let mut state = mock_state(GameStatus::InProgress, Address::ZERO, 100);
+        state.proof_protocol = crate::test_utils::mock_proof_protocol(ProofScheduleKind::None);
+        let verifier = Arc::new(MockAggregateVerifier::new(HashMap::from([(addr(0), state)])));
+        let mut scanner = test_scanner(factory, verifier, mock_anchor_registry(Address::ZERO));
+
+        let candidates = scanner.scan().await.unwrap();
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].schedule_kind, ProofScheduleKind::None);
+        assert_eq!(candidates[0].protocol_version, 0);
+    }
+
+    /// A full-schedule game is skipped even though `mock_protocol_versions` maps its fingerprint,
+    /// because the challenger cannot reproduce the snapshotted `scheduleId` its journal commits.
+    #[tokio::test]
+    async fn test_scan_skips_full_schedule_games() {
+        let factory = Arc::new(MockDisputeGameFactory::new(vec![factory_game(0, 1)]));
+        let mut state = mock_state(GameStatus::InProgress, Address::ZERO, 100);
+        state.proof_protocol = crate::test_utils::mock_proof_protocol(ProofScheduleKind::Full);
+        let verifier = Arc::new(MockAggregateVerifier::new(HashMap::from([(addr(0), state)])));
+        let mut scanner = test_scanner(factory, verifier, mock_anchor_registry(Address::ZERO));
+
+        assert!(
+            scanner.scan().await.unwrap().is_empty(),
+            "full-schedule games must not be routed to a prover"
+        );
     }
 
     /// Error at the first index (0) skips that game, rest still returned.
@@ -892,7 +986,7 @@ mod tests {
 
         let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
 
-        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
+        let mut scanner = test_scanner(factory, verifier, mock_anchor_registry(Address::ZERO));
 
         let candidates = scanner.scan().await.unwrap();
 
@@ -915,7 +1009,7 @@ mod tests {
         verifier_games.insert(addr(0), state);
 
         let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
+        let mut scanner = test_scanner(factory, verifier, mock_anchor_registry(Address::ZERO));
 
         let candidates = scanner.scan().await.unwrap();
 
@@ -942,7 +1036,7 @@ mod tests {
         );
 
         let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
+        let mut scanner = test_scanner(factory, verifier, mock_anchor_registry(Address::ZERO));
 
         let candidates = scanner.scan().await.unwrap();
 
@@ -960,7 +1054,7 @@ mod tests {
         verifier_games.insert(addr(0), mock_state(GameStatus::InProgress, Address::ZERO, 100));
 
         let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
+        let mut scanner = test_scanner(factory, verifier, mock_anchor_registry(Address::ZERO));
 
         let candidates = scanner.scan().await.unwrap();
 
@@ -983,7 +1077,7 @@ mod tests {
             .insert(addr(0), mock_state_with_tee(GameStatus::InProgress, zk_addr, tee_addr, 100));
 
         let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
-        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
+        let mut scanner = test_scanner(factory, verifier, mock_anchor_registry(Address::ZERO));
 
         let candidates = scanner.scan().await.unwrap();
 
@@ -1023,7 +1117,7 @@ mod tests {
 
         let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
 
-        let mut scanner = GameScanner::new(factory, verifier, mock_anchor_registry(Address::ZERO));
+        let mut scanner = test_scanner(factory, verifier, mock_anchor_registry(Address::ZERO));
 
         let candidates = scanner.scan().await.unwrap();
 
@@ -1060,7 +1154,7 @@ mod tests {
         );
         let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
 
-        let mut scanner = GameScanner::new(
+        let mut scanner = test_scanner(
             Arc::clone(&factory) as Arc<dyn DisputeGameFactoryClient>,
             Arc::clone(&verifier) as Arc<dyn AggregateVerifierClient>,
             mock_anchor_registry(Address::ZERO),

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -957,7 +957,7 @@ mod tests {
         assert_eq!(candidates[0].protocol_version, 0);
     }
 
-    /// A full-schedule game is skipped even though `mock_protocol_versions` maps its fingerprint,
+    /// A full-schedule game is skipped even though its prover hashes share the mapped fingerprint,
     /// because the challenger cannot reproduce the snapshotted `scheduleId` its journal commits.
     #[tokio::test]
     async fn test_scan_skips_full_schedule_games() {

--- a/crates/proof/challenge/src/service.rs
+++ b/crates/proof/challenge/src/service.rs
@@ -152,6 +152,7 @@ impl ChallengerService {
             Arc::clone(&factory_client),
             Arc::clone(&verifier_client),
             Arc::clone(&anchor_registry_client),
+            config.proof_protocol_versions.clone(),
         );
 
         let anchor_updater = AnchorUpdater::new(

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -20,7 +20,7 @@ use base_common_consensus::Predeploys;
 use base_proof_contracts::{
     AggregateVerifierClient, AnchorPreflight, AnchorRoot, AnchorSnapshot,
     AnchorStateRegistryClient, ContractError, DisputeGameFactoryClient, GameAtIndex, GameInfo,
-    GameStatus,
+    GameStatus, ProofProtocolDescriptor, ProofScheduleKind,
 };
 use base_proof_rpc::{BaseHeader, L1Provider, L2Provider, RpcError, RpcResult};
 use base_prover_service_client::{ProofRequesterProvider, ProverServiceClientError};
@@ -33,6 +33,30 @@ use base_tx_manager::{SendHandle, SendResponse, TxCandidate, TxManager};
 
 /// Discovery interval used in tests (5 minutes).
 pub const TEST_DISCOVERY_INTERVAL: Duration = Duration::from_secs(300);
+
+/// Returns deterministic proof commitments for scanner and driver tests.
+pub fn mock_proof_protocol(schedule_kind: ProofScheduleKind) -> ProofProtocolDescriptor {
+    ProofProtocolDescriptor {
+        schedule_kind,
+        schedule_id: if schedule_kind == ProofScheduleKind::Full {
+            B256::repeat_byte(1)
+        } else {
+            B256::ZERO
+        },
+        config_hash: B256::repeat_byte(2),
+        tee_image_hash: B256::repeat_byte(3),
+        zk_range_hash: B256::repeat_byte(4),
+        zk_aggregate_hash: B256::repeat_byte(5),
+    }
+}
+
+/// Returns routing mappings for every historical schedule mode used in tests.
+pub fn mock_protocol_versions() -> HashMap<B256, u32> {
+    [(ProofScheduleKind::None, 0), (ProofScheduleKind::Full, 2), (ProofScheduleKind::Activated, 1)]
+        .map(|(kind, version)| (mock_proof_protocol(kind).fingerprint(), version))
+        .into_iter()
+        .collect()
+}
 
 /// Per-game state for the mock verifier.
 #[derive(Debug, Clone)]
@@ -49,6 +73,8 @@ pub struct MockGameState {
     pub starting_block_number: u64,
     /// L1 head block hash stored at game creation time.
     pub l1_head: B256,
+    /// Proof commitments exposed by this game.
+    pub proof_protocol: ProofProtocolDescriptor,
     /// Intermediate output roots for this game.
     pub intermediate_output_roots: Vec<B256>,
     /// 1-based index of the challenged intermediate root (`0` = unchallenged).
@@ -86,6 +112,7 @@ impl Default for MockGameState {
             },
             starting_block_number: 0,
             l1_head: B256::ZERO,
+            proof_protocol: mock_proof_protocol(ProofScheduleKind::Activated),
             intermediate_output_roots: vec![],
             countered_index: 0,
             game_over: false,
@@ -299,12 +326,6 @@ impl MockAggregateVerifier {
 
 #[async_trait]
 impl AggregateVerifierClient for MockAggregateVerifier {
-    async fn proof_protocol_descriptor(
-        &self,
-        _: Address,
-    ) -> Result<base_proof_contracts::ProofProtocolDescriptor, ContractError> {
-        unimplemented!("unused in challenger tests")
-    }
     async fn game_info(&self, game_address: Address) -> Result<GameInfo, ContractError> {
         self.game_info_reads.lock().unwrap().push(game_address);
         self.get(game_address, |s| s.game_info)
@@ -313,6 +334,13 @@ impl AggregateVerifierClient for MockAggregateVerifier {
     async fn status(&self, game_address: Address) -> Result<GameStatus, ContractError> {
         self.status_reads.lock().unwrap().push(game_address);
         self.get(game_address, |s| s.status)
+    }
+
+    async fn proof_protocol_descriptor(
+        &self,
+        game_address: Address,
+    ) -> Result<ProofProtocolDescriptor, ContractError> {
+        self.get(game_address, |s| s.proof_protocol)
     }
 
     async fn zk_prover(&self, game_address: Address) -> Result<Address, ContractError> {

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -50,12 +50,9 @@ pub fn mock_proof_protocol(schedule_kind: ProofScheduleKind) -> ProofProtocolDes
     }
 }
 
-/// Returns routing mappings for every historical schedule mode used in tests.
+/// Returns a routing mapping for the mock prover artifacts.
 pub fn mock_protocol_versions() -> HashMap<B256, u32> {
-    [(ProofScheduleKind::None, 0), (ProofScheduleKind::Full, 2), (ProofScheduleKind::Activated, 1)]
-        .map(|(kind, version)| (mock_proof_protocol(kind).fingerprint(), version))
-        .into_iter()
-        .collect()
+    HashMap::from([(mock_proof_protocol(ProofScheduleKind::None).fingerprint(), 0)])
 }
 
 /// Per-game state for the mock verifier.

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -439,7 +439,7 @@ async fn test_step_proof_retry_reuses_deterministic_session_id() {
             expected_session_id.as_str(),
             "challenger must use game-address/invalid-index session_id on initiation",
         );
-        assert_eq!(log[0].proof.protocol_version, 1);
+        assert_eq!(log[0].proof.protocol_version, 0);
         let ProofRequestKind::SnarkPlonk(request) = &log[0].proof.request else {
             panic!("expected SNARK proof request");
         };
@@ -457,7 +457,7 @@ async fn test_step_proof_retry_reuses_deterministic_session_id() {
             expected_session_id.as_str(),
             "retry must reuse the deterministic session_id so the service can requeue",
         );
-        assert_eq!(log[1].proof.protocol_version, 1);
+        assert_eq!(log[1].proof.protocol_version, 0);
     }
 
     let entry = driver
@@ -560,7 +560,7 @@ async fn test_schedule_aware_game_requests_current_prover_protocol() {
 
     let state = zk.state.lock().unwrap();
     let request = state.prove_block_range_log.first().expect("proof should be requested");
-    assert_eq!(request.proof.protocol_version, 1);
+    assert_eq!(request.proof.protocol_version, 0);
     let ProofRequestKind::SnarkPlonk(request) = &request.proof.request else {
         panic!("expected SNARK proof request");
     };
@@ -579,7 +579,7 @@ async fn test_schedule_aware_subrange_pins_game_ending_l2_block() {
 
     let state = zk.state.lock().unwrap();
     let request = state.prove_block_range_log.first().expect("proof should be requested");
-    assert_eq!(request.proof.protocol_version, 1);
+    assert_eq!(request.proof.protocol_version, 0);
     let ProofRequestKind::SnarkPlonk(request) = &request.proof.request else {
         panic!("expected SNARK proof request");
     };

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -14,10 +14,13 @@ use base_challenger::{
         DEFAULT_L1_HEAD, DEFAULT_TEE_PROVER, MockAggregateVerifier, MockDisputeGameFactory,
         MockGameState, MockL1, MockL2Provider, MockTxManager, MockZkProofProvider,
         MockZkProofState, addr, build_test_header_and_account, factory_game, mock_anchor_registry,
-        mock_state, mock_state_with_tee, receipt_with_status,
+        mock_proof_protocol, mock_protocol_versions, mock_state, mock_state_with_tee,
+        receipt_with_status,
     },
 };
-use base_proof_contracts::{AggregateVerifierClient, DisputeGameFactoryClient, GameStatus};
+use base_proof_contracts::{
+    AggregateVerifierClient, DisputeGameFactoryClient, GameStatus, ProofScheduleKind,
+};
 use base_proof_primitives::Proposal;
 use base_proof_rpc::L1Provider;
 use base_proof_submission::test_utils::SnarkReceiptFixture;
@@ -83,6 +86,7 @@ fn test_driver_with_l1_provider(
         Arc::clone(&factory),
         Arc::clone(&verifier) as Arc<dyn AggregateVerifierClient>,
         Arc::clone(&anchor_registry),
+        mock_protocol_versions(),
     );
     let validator = OutputValidator::new(Arc::clone(&l2_provider));
     let submitter = ChallengeSubmitter::new(tx_manager);
@@ -165,6 +169,7 @@ fn default_ready_proof(intent: DisputeIntent) -> PendingProof {
         B256::repeat_byte(0xEE),
         request,
         intent,
+        1,
     )
 }
 
@@ -434,6 +439,11 @@ async fn test_step_proof_retry_reuses_deterministic_session_id() {
             expected_session_id.as_str(),
             "challenger must use game-address/invalid-index session_id on initiation",
         );
+        assert_eq!(log[0].proof.protocol_version, 1);
+        let ProofRequestKind::SnarkPlonk(request) = &log[0].proof.request else {
+            panic!("expected SNARK proof request");
+        };
+        assert_eq!(request.proof.schedule_l2_block_number, Some(20));
     }
 
     // Step 2: poll observes Failed → NeedsRetry → handle_proof_retry must
@@ -447,6 +457,7 @@ async fn test_step_proof_retry_reuses_deterministic_session_id() {
             expected_session_id.as_str(),
             "retry must reuse the deterministic session_id so the service can requeue",
         );
+        assert_eq!(log[1].proof.protocol_version, 1);
     }
 
     let entry = driver
@@ -478,6 +489,105 @@ async fn test_step_proof_retry_reuses_deterministic_session_id() {
         !driver.proof_manager.pending_proofs().contains_key(&addr(0)),
         "entry should be removed after successful retry submission",
     );
+}
+
+#[tokio::test]
+async fn test_legacy_game_requests_legacy_prover_protocol() {
+    let (l2, factory, root_15, _root_20) = base_game_mocks();
+    let verifier = single_game_verifier(MockGameState {
+        tee_prover: DEFAULT_TEE_PROVER,
+        proof_protocol: mock_proof_protocol(ProofScheduleKind::None),
+        intermediate_output_roots: vec![root_15, BOGUS_ROOT],
+        ..game_state(20)
+    });
+    let zk = default_zk_prover();
+    let mut driver = test_driver(factory, verifier, l2, Arc::clone(&zk), default_tx_manager());
+
+    driver.step().await.unwrap();
+
+    let state = zk.state.lock().unwrap();
+    let request = state.prove_block_range_log.first().expect("legacy proof should be requested");
+    assert_eq!(request.proof.protocol_version, 0);
+    let ProofRequestKind::SnarkPlonk(request) = &request.proof.request else {
+        panic!("expected SNARK proof request");
+    };
+    assert_eq!(request.proof.schedule_l2_block_number, None);
+}
+
+/// Builds L2 provider, factory, and output roots for a schedule-aware game
+/// spanning blocks 10–30 with interval 5 (checkpoints at 15, 20, 25, 30).
+/// The root at index 1 (block 20) is bogus, so the challenger proves a
+/// *subrange* (blocks 15–20) while the game's ending L2 block is 30.
+fn subrange_game_mocks()
+-> (Arc<MockL2Provider>, Arc<MockDisputeGameFactory>, Arc<MockAggregateVerifier>) {
+    let (header_15, account_15) = build_test_header_and_account(15, STORAGE_HASH);
+    let root_15 =
+        OutputRoot::from_parts(header_15.state_root, STORAGE_HASH, header_15.hash_slow()).hash();
+    let (header_20, account_20) = build_test_header_and_account(20, STORAGE_HASH);
+    let (header_25, account_25) = build_test_header_and_account(25, STORAGE_HASH);
+    let root_25 =
+        OutputRoot::from_parts(header_25.state_root, STORAGE_HASH, header_25.hash_slow()).hash();
+    let (header_30, account_30) = build_test_header_and_account(30, STORAGE_HASH);
+    let root_30 =
+        OutputRoot::from_parts(header_30.state_root, STORAGE_HASH, header_30.hash_slow()).hash();
+
+    let mut l2 = MockL2Provider::default();
+    l2.insert_block(15, header_15, account_15);
+    l2.insert_block(20, header_20, account_20);
+    l2.insert_block(25, header_25, account_25);
+    l2.insert_block(30, header_30, account_30);
+    let l2 = Arc::new(l2);
+
+    let factory = single_game_factory();
+
+    let verifier = single_game_verifier(MockGameState {
+        tee_prover: DEFAULT_TEE_PROVER,
+        intermediate_output_roots: vec![root_15, BOGUS_ROOT, root_25, root_30],
+        ..game_state(30)
+    });
+
+    (l2, factory, verifier)
+}
+
+#[tokio::test]
+async fn test_schedule_aware_game_requests_current_prover_protocol() {
+    let (l2, factory, verifier) = invalid_game_mocks();
+
+    let zk = default_zk_prover();
+    let mut driver = test_driver(factory, verifier, l2, Arc::clone(&zk), default_tx_manager());
+
+    driver.step().await.unwrap();
+
+    let state = zk.state.lock().unwrap();
+    let request = state.prove_block_range_log.first().expect("proof should be requested");
+    assert_eq!(request.proof.protocol_version, 1);
+    let ProofRequestKind::SnarkPlonk(request) = &request.proof.request else {
+        panic!("expected SNARK proof request");
+    };
+    // schedule_l2_block_number must equal the game's ending L2 block (20).
+    assert_eq!(request.proof.schedule_l2_block_number, Some(20));
+}
+
+#[tokio::test]
+async fn test_schedule_aware_subrange_pins_game_ending_l2_block() {
+    let (l2, factory, verifier) = subrange_game_mocks();
+
+    let zk = default_zk_prover();
+    let mut driver = test_driver(factory, verifier, l2, Arc::clone(&zk), default_tx_manager());
+
+    driver.step().await.unwrap();
+
+    let state = zk.state.lock().unwrap();
+    let request = state.prove_block_range_log.first().expect("proof should be requested");
+    assert_eq!(request.proof.protocol_version, 1);
+    let ProofRequestKind::SnarkPlonk(request) = &request.proof.request else {
+        panic!("expected SNARK proof request");
+    };
+    // The challenger proves a subrange (blocks 15–20) but the schedule must
+    // pin the game's ending L2 block (30), not the subrange end (20).
+    assert_eq!(request.proof.start_block_number, 15);
+    assert_eq!(request.proof.number_of_blocks_to_prove, 5);
+    assert_eq!(request.proof.schedule_l2_block_number, Some(30));
 }
 
 #[tokio::test]
@@ -811,6 +921,7 @@ async fn test_successful_nullify_does_not_track_anchor_update() {
             retry_count: 0,
             tee_submit_retry_count: 0,
             intent: DisputeIntent::Nullify,
+            protocol_version: 1,
         },
     );
 

--- a/crates/proof/proposer/src/cli.rs
+++ b/crates/proof/proposer/src/cli.rs
@@ -84,6 +84,10 @@ pub struct ProposerArgs {
     #[arg(long = "game-type", env = cli_env!("GAME_TYPE"))]
     pub game_type: u32,
 
+    /// Prover-service routing version required by newly proposed games.
+    #[arg(long = "proof-protocol-version", env = cli_env!("PROOF_PROTOCOL_VERSION"))]
+    pub proof_protocol_version: u32,
+
     /// Polling interval for new blocks (e.g., "12s", "1m").
     #[arg(
         long = "poll-interval",
@@ -194,6 +198,8 @@ mod tests {
             "--dispute-game-factory-addr",
             "0x2234567890123456789012345678901234567890",
             "--game-type",
+            "1",
+            "--proof-protocol-version",
             "1",
             "--rollup-rpc",
             "http://localhost:7545",

--- a/crates/proof/proposer/src/config.rs
+++ b/crates/proof/proposer/src/config.rs
@@ -29,6 +29,8 @@ pub struct ProposerConfig {
     pub dispute_game_factory_addr: Address,
     /// Game type ID for `AggregateVerifier` dispute games.
     pub game_type: u32,
+    /// Prover-service routing version required by newly proposed games.
+    pub proof_protocol_version: u32,
     /// Polling interval for new blocks.
     pub poll_interval: Duration,
     /// RPC request timeout.
@@ -123,6 +125,7 @@ impl ProposerConfig {
             anchor_state_registry_addr: proposer.anchor_state_registry_addr,
             dispute_game_factory_addr: proposer.dispute_game_factory_addr,
             game_type: proposer.game_type,
+            proof_protocol_version: proposer.proof_protocol_version,
             poll_interval: proposer.poll_interval,
             rpc_timeout: proposer.rpc_timeout,
             rollup_rpc: proposer.rollup_rpc,
@@ -168,6 +171,8 @@ mod tests {
             "--dispute-game-factory-addr",
             "0x2234567890123456789012345678901234567890",
             "--game-type",
+            "1",
+            "--proof-protocol-version",
             "1",
             "--rollup-rpc",
             "http://localhost:7545",

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -43,6 +43,8 @@ pub struct DriverConfig {
     pub intermediate_block_interval: u64,
     /// Game type ID for `AggregateVerifier` dispute games.
     pub game_type: u32,
+    /// Prover-service routing version required by newly proposed games.
+    pub proof_protocol_version: u32,
     /// Address of the proposer that submits proof transactions onchain.
     /// Included in the proof journal so the enclave signs over the correct `msg.sender`.
     pub proposer_address: Address,
@@ -60,6 +62,7 @@ impl Default for DriverConfig {
             block_interval: 512,
             intermediate_block_interval: 512,
             game_type: 0,
+            proof_protocol_version: 0,
             proposer_address: Address::ZERO,
             anchor_state_registry_address: Address::ZERO,
         }

--- a/crates/proof/proposer/src/proof_adapter.rs
+++ b/crates/proof/proposer/src/proof_adapter.rs
@@ -24,19 +24,24 @@ impl ProposerProofAdapter {
     }
 
     /// Builds a prover-service request for a TEE proposal proof.
-    pub fn tee_prove_block_range_request(request: PrimitiveProofRequest) -> ProveBlockRangeRequest {
+    pub fn tee_prove_block_range_request(
+        request: PrimitiveProofRequest,
+        protocol_version: u32,
+    ) -> ProveBlockRangeRequest {
         let session_id = Self::tee_session_id_for_root(request.claimed_l2_output_root);
-        Self::tee_prove_block_range_request_with_session_id(request, session_id)
+        Self::tee_prove_block_range_request_with_session_id(request, session_id, protocol_version)
     }
 
     /// Builds a prover-service request for a TEE proposal proof with a caller-supplied session id.
     pub const fn tee_prove_block_range_request_with_session_id(
         request: PrimitiveProofRequest,
         session_id: String,
+        protocol_version: u32,
     ) -> ProveBlockRangeRequest {
         ProveBlockRangeRequest {
             proof: ProofRequest {
                 session_id,
+                protocol_version,
                 request: ProofRequestKind::Tee(TeeProofRequest {
                     proof: request,
                     tee_kind: TeeKind::AwsNitro,
@@ -102,9 +107,10 @@ mod tests {
         let request = test_request(root);
         let expected_session_id = ProposerProofAdapter::tee_session_id_for_root(root);
 
-        let wrapped = ProposerProofAdapter::tee_prove_block_range_request(request.clone());
+        let wrapped = ProposerProofAdapter::tee_prove_block_range_request(request.clone(), 7);
 
         assert_eq!(wrapped.proof.session_id, expected_session_id);
+        assert_eq!(wrapped.proof.protocol_version, 7);
         match wrapped.proof.request {
             ProofRequestKind::Tee(tee) => {
                 assert_eq!(tee.proof, request);

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -555,7 +555,10 @@ mod tests {
             ..Default::default()
         };
         requester
-            .prove_block_range(ProposerProofAdapter::tee_prove_block_range_request(proof_request))
+            .prove_block_range(ProposerProofAdapter::tee_prove_block_range_request(
+                proof_request,
+                1,
+            ))
             .await
             .expect("test setup should dispatch root session");
         let collector = make_collector(
@@ -595,6 +598,7 @@ mod tests {
             requester
                 .prove_block_range(ProposerProofAdapter::tee_prove_block_range_request(
                     proof_request,
+                    1,
                 ))
                 .await
                 .expect("test setup should dispatch root session");
@@ -657,19 +661,25 @@ mod tests {
             ..Default::default()
         };
         requester
-            .prove_block_range(ProposerProofAdapter::tee_prove_block_range_request(proof_request))
+            .prove_block_range(ProposerProofAdapter::tee_prove_block_range_request(
+                proof_request,
+                1,
+            ))
             .await
             .expect("test setup should dispatch root session");
         let later_root = B256::repeat_byte(0xcc);
         let later_session_id = ProposerProofAdapter::tee_session_id_for_root(later_root);
         requester
-            .prove_block_range(ProposerProofAdapter::tee_prove_block_range_request(ProofRequest {
-                claimed_l2_output_root: later_root,
-                claimed_l2_block_number: target_block + BLOCK_INTERVAL,
-                intermediate_block_interval: BLOCK_INTERVAL,
-                l1_head_number: 1000,
-                ..Default::default()
-            }))
+            .prove_block_range(ProposerProofAdapter::tee_prove_block_range_request(
+                ProofRequest {
+                    claimed_l2_output_root: later_root,
+                    claimed_l2_block_number: target_block + BLOCK_INTERVAL,
+                    intermediate_block_interval: BLOCK_INTERVAL,
+                    l1_head_number: 1000,
+                    ..Default::default()
+                },
+                1,
+            ))
             .await
             .expect("test setup should dispatch later root session");
         let collector = make_collector(
@@ -708,7 +718,10 @@ mod tests {
             ..Default::default()
         };
         requester
-            .prove_block_range(ProposerProofAdapter::tee_prove_block_range_request(proof_request))
+            .prove_block_range(ProposerProofAdapter::tee_prove_block_range_request(
+                proof_request,
+                1,
+            ))
             .await
             .expect("test setup should dispatch root session");
         let collector = make_collector(
@@ -743,7 +756,10 @@ mod tests {
             ..Default::default()
         };
         requester
-            .prove_block_range(ProposerProofAdapter::tee_prove_block_range_request(proof_request))
+            .prove_block_range(ProposerProofAdapter::tee_prove_block_range_request(
+                proof_request,
+                1,
+            ))
             .await
             .expect("test setup should dispatch stale root session");
         let collector = make_collector(

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -23,6 +23,8 @@ use crate::{
 pub struct ProofDispatcherConfig {
     /// Number of L2 blocks between proof targets.
     pub block_interval: u64,
+    /// Prover-service routing version for proposal jobs.
+    pub protocol_version: u32,
     /// Address of the proposer that will submit the proof onchain.
     pub proposer_address: Address,
     /// Number of L2 blocks between intermediate output root checkpoints.
@@ -33,6 +35,7 @@ impl From<&DriverConfig> for ProofDispatcherConfig {
     fn from(config: &DriverConfig) -> Self {
         Self {
             block_interval: config.block_interval,
+            protocol_version: config.proof_protocol_version,
             proposer_address: config.proposer_address,
             intermediate_block_interval: config.intermediate_block_interval,
         }
@@ -136,7 +139,10 @@ impl ProofDispatcher {
     }
 
     async fn dispatch_request(&self, request: ProofRequest) -> Result<String, ProposerError> {
-        let request = ProposerProofAdapter::tee_prove_block_range_request(request);
+        let request = ProposerProofAdapter::tee_prove_block_range_request(
+            request,
+            self.config.protocol_version,
+        );
         let session_id = request.proof.session_id.clone();
         match self.proof_requester.prove_block_range(request).await {
             Ok(response) if response.session_id == session_id => Ok(response.session_id),
@@ -304,6 +310,7 @@ mod tests {
             }),
             ProofDispatcherConfig {
                 block_interval: 100,
+                protocol_version: 1,
                 proposer_address: Address::repeat_byte(0x04),
                 intermediate_block_interval: 300,
             },

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -222,6 +222,7 @@ impl ProposerService {
             block_interval,
             intermediate_block_interval,
             game_type: config.game_type,
+            proof_protocol_version: config.proof_protocol_version,
             proposer_address: proposer_address.unwrap_or_default(),
             anchor_state_registry_address: config.anchor_state_registry_addr,
         };

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -247,16 +247,16 @@ pub struct MockAggregateVerifier {
 
 #[async_trait]
 impl AggregateVerifierClient for MockAggregateVerifier {
-    async fn proof_protocol_descriptor(
-        &self,
-        _: Address,
-    ) -> Result<base_proof_contracts::ProofProtocolDescriptor, ContractError> {
-        unimplemented!("unused in proposer tests")
-    }
     async fn game_info(&self, _: Address) -> Result<GameInfo, ContractError> {
         unimplemented!("unused in proposer tests")
     }
     async fn status(&self, _: Address) -> Result<GameStatus, ContractError> {
+        unimplemented!("unused in proposer tests")
+    }
+    async fn proof_protocol_descriptor(
+        &self,
+        _: Address,
+    ) -> Result<base_proof_contracts::ProofProtocolDescriptor, ContractError> {
         unimplemented!("unused in proposer tests")
     }
     async fn zk_prover(&self, _: Address) -> Result<Address, ContractError> {

--- a/crates/proof/prover-service/client/src/requester.rs
+++ b/crates/proof/prover-service/client/src/requester.rs
@@ -517,6 +517,7 @@ mod tests {
         ProveBlockRangeRequest {
             proof: ProofRequest {
                 session_id: session_id.to_owned(),
+                protocol_version: 1,
                 request: ProofRequestKind::Compressed(ZkProofRequest {
                     start_block_number: 100,
                     number_of_blocks_to_prove: 5,

--- a/crates/proof/prover-service/client/src/worker.rs
+++ b/crates/proof/prover-service/client/src/worker.rs
@@ -599,6 +599,7 @@ mod tests {
             tee_kinds: Vec::new(),
             zk_vms: vec![ZkVm::Sp1],
             zk_backends: vec![ZkBackend::Cluster],
+            protocol_versions: vec![1],
             lock_duration_seconds: 60,
         }
     }
@@ -667,6 +668,7 @@ mod tests {
     fn proof_request(session_id: impl Into<String>) -> ProofRequest {
         ProofRequest {
             session_id: session_id.into(),
+            protocol_version: 1,
             request: ProofRequestKind::Compressed(ZkProofRequest {
                 start_block_number: 10,
                 number_of_blocks_to_prove: 2,
@@ -699,6 +701,7 @@ mod tests {
             tee_kinds: Vec::new(),
             zk_vms: vec![ZkVm::Sp1],
             zk_backends: vec![ZkBackend::Cluster],
+            protocol_versions: vec![1],
             lock_duration_seconds: 60,
         };
         let provider: &dyn ProverWorkerProvider = &server.client;

--- a/crates/proof/prover-service/db/migrations/018_add_request_protocol_version.sql
+++ b/crates/proof/prover-service/db/migrations/018_add_request_protocol_version.sql
@@ -2,7 +2,7 @@ ALTER TABLE proof_requests
 ADD COLUMN IF NOT EXISTS request_protocol_version BIGINT NOT NULL DEFAULT 0;
 
 COMMENT ON COLUMN proof_requests.request_protocol_version IS
-'Prover protocol required by this job; version 0 is the legacy journal without schedule pinning.';
+'Opaque prover routing version required by this job; 0 is the compatibility default.';
 
 -- Claim queries now match request_protocol_version. Without it in the index, unclaimable rows of
 -- the other protocol sort ahead of claimable ones (ORDER BY start_block_number ASC) and are

--- a/crates/proof/prover-service/db/migrations/018_add_request_protocol_version.sql
+++ b/crates/proof/prover-service/db/migrations/018_add_request_protocol_version.sql
@@ -1,0 +1,36 @@
+ALTER TABLE proof_requests
+ADD COLUMN IF NOT EXISTS request_protocol_version BIGINT NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN proof_requests.request_protocol_version IS
+'Prover protocol required by this job; version 0 is the legacy journal without schedule pinning.';
+
+-- Claim queries now match request_protocol_version. Without it in the index, unclaimable rows of
+-- the other protocol sort ahead of claimable ones (ORDER BY start_block_number ASC) and are
+-- rechecked on every claim, which degrades as drained legacy jobs accumulate.
+--
+-- The replacements are created under new names before the originals are dropped, so no window
+-- exists in which a claim query has no covering index. CREATE INDEX takes a SHARE lock that blocks
+-- writes to proof_requests while it builds; that is a bounded pause on claims rather than the
+-- unbounded sequential scans a drop-then-create would cause.
+CREATE INDEX IF NOT EXISTS idx_proof_requests_job_claim_by_version
+ON proof_requests(
+    job_status,
+    api_proof_type,
+    request_protocol_version,
+    start_block_number,
+    created_at
+);
+DROP INDEX IF EXISTS idx_proof_requests_job_claim;
+
+CREATE INDEX IF NOT EXISTS idx_proof_requests_zk_job_claim_by_version
+ON proof_requests(
+    job_status,
+    api_proof_type,
+    zk_vm,
+    (COALESCE(zk_backend, 'cluster')),
+    request_protocol_version,
+    start_block_number,
+    created_at
+)
+WHERE api_proof_type IN ('compressed', 'snark_plonk');
+DROP INDEX IF EXISTS idx_proof_requests_zk_job_claim;

--- a/crates/proof/prover-service/db/src/conversions.rs
+++ b/crates/proof/prover-service/db/src/conversions.rs
@@ -271,6 +271,7 @@ mod tests {
     fn compressed_payload(session_id: &str) -> serde_json::Value {
         serde_json::to_value(ProtocolProofRequest {
             session_id: session_id.to_owned(),
+            protocol_version: 0,
             request: ProofRequestKind::Compressed(base_prover_service_protocol::ZkProofRequest {
                 start_block_number: 10,
                 number_of_blocks_to_prove: 2,

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -999,6 +999,8 @@ pub struct UpdateReceipt {
 pub struct ClaimProofJob {
     /// Worker identifier acquiring the claim.
     pub worker_id: String,
+    /// Prover protocols implemented by this worker. Empty is treated as `[0]`.
+    pub protocol_versions: Vec<u32>,
     /// Protocol proof type this worker can execute.
     pub api_proof_type: ApiProofType,
     /// TEE implementations this worker can execute (matched for TEE proofs).
@@ -1247,6 +1249,7 @@ mod tests {
     fn compressed_protocol_request(session_id: impl Into<String>) -> ProtocolProofRequest {
         ProtocolProofRequest {
             session_id: session_id.into(),
+            protocol_version: 1,
             request: ProtocolProofRequestKind::Compressed(ZkProofRequest {
                 start_block_number: 100,
                 number_of_blocks_to_prove: 5,

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -2100,10 +2100,9 @@ const PROOF_JOB_RETURNING_COLUMNS: &str = "id, COALESCE(session_id, id::text) AS
 /// so no caller-derived string can ever reach the SQL as a column name. The only
 /// interpolated token is the fixed [`PROOF_JOB_RETURNING_COLUMNS`] constant.
 ///
-/// `request_protocol_version = ANY(...)` lets one worker fleet serve several protocol versions,
-/// which matters because the challenger's capability fingerprint mixes TEE and ZK commitments: a
-/// ZK-only program rotation mints a new version for an otherwise unchanged TEE image, and exact
-/// match would force a whole new Nitro fleet (and a fresh enclave registration) to serve it.
+/// `request_protocol_version = ANY(...)` lets one worker fleet serve several protocol versions.
+/// The fingerprint still mixes TEE and ZK hashes, so a ZK-only program rotation mints a new
+/// version for an otherwise unchanged TEE image; exact match would force a new Nitro fleet.
 ///
 // ponytail: single-element arrays keep the `idx_proof_requests_*_by_version` index scan; multi-
 // element arrays may add a sort for `ORDER BY start_block_number`. Queue depth is small enough

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -37,16 +37,18 @@ impl ProofRequestRepo {
         sqlx::query(
             r#"
             INSERT INTO proof_requests (
-                id, session_id, request_payload, api_proof_type, zk_vm, tee_kind, zk_backend,
+                id, session_id, request_payload, request_protocol_version,
+                api_proof_type, zk_vm, tee_kind, zk_backend,
                 start_block_number, number_of_blocks_to_prove, sequence_window, proof_type, status,
                 prover_address, l1_head, intermediate_root_interval
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
             "#,
         )
         .bind(prepared.id)
         .bind(&prepared.session_id)
         .bind(&prepared.request_payload)
+        .bind(prepared.protocol_version)
         .bind(prepared.api_proof_type.as_str())
         .bind(prepared.zk_vm.map(|zk_vm| zk_vm.as_str()))
         .bind(prepared.tee_kind.map(|tee_kind| tee_kind.as_str()))
@@ -77,17 +79,19 @@ impl ProofRequestRepo {
         let insert_result = sqlx::query(
             r#"
             INSERT INTO proof_requests (
-                id, session_id, request_payload, api_proof_type, zk_vm, tee_kind, zk_backend,
+                id, session_id, request_payload, request_protocol_version,
+                api_proof_type, zk_vm, tee_kind, zk_backend,
                 start_block_number, number_of_blocks_to_prove, sequence_window, proof_type, status,
                 prover_address, l1_head, intermediate_root_interval
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
             ON CONFLICT ((COALESCE(session_id, id::text))) DO NOTHING
             "#,
         )
         .bind(prepared.id)
         .bind(&prepared.session_id)
         .bind(&prepared.request_payload)
+        .bind(prepared.protocol_version)
         .bind(prepared.api_proof_type.as_str())
         .bind(prepared.zk_vm.map(|zk_vm| zk_vm.as_str()))
         .bind(prepared.tee_kind.map(|tee_kind| tee_kind.as_str()))
@@ -112,7 +116,8 @@ impl ProofRequestRepo {
         let row = sqlx::query(
             r#"
             SELECT id, COALESCE(session_id, id::text) AS session_id,
-                   request_payload, api_proof_type, zk_vm, tee_kind, zk_backend,
+                   request_payload, request_protocol_version,
+                   api_proof_type, zk_vm, tee_kind, zk_backend,
                    start_block_number, number_of_blocks_to_prove, sequence_window,
                    proof_type, status, prover_address, l1_head,
                    intermediate_root_interval, retry_count
@@ -135,6 +140,7 @@ impl ProofRequestRepo {
         let existing_id: Uuid = row.get("id");
         let params = CreateRequestParams {
             request_payload: &prepared.request_payload,
+            protocol_version: prepared.protocol_version,
             api_proof_type: prepared.api_proof_type.as_str(),
             zk_vm: prepared.zk_vm.map(|zk_vm| zk_vm.as_str()),
             tee_kind: prepared.tee_kind.map(|tee_kind| tee_kind.as_str()),
@@ -202,8 +208,9 @@ impl ProofRequestRepo {
                     UPDATE proof_requests
                     SET status = $1,
                         request_payload = $2,
-                        l1_head = $3,
-                        zk_backend = $4,
+                        request_protocol_version = $3,
+                        l1_head = $4,
+                        zk_backend = $5,
                         job_status = 'PENDING',
                         retry_count = retry_count + 1,
                         error_message = NULL,
@@ -220,11 +227,12 @@ impl ProofRequestRepo {
                         claimed_at = NULL,
                         last_heartbeat_at = NULL,
                         attempt = 0
-                    WHERE id = $5
+                    WHERE id = $6
                     "#,
                 )
                 .bind(ProofStatus::Created.as_str())
                 .bind(&prepared.request_payload)
+                .bind(prepared.protocol_version)
                 .bind(&prepared.l1_head)
                 .bind(prepared.zk_backend.map(|backend| backend.as_str()))
                 .bind(existing_id)
@@ -574,6 +582,12 @@ impl ProofRequestRepo {
     pub async fn claim_next_proof_job(&self, req: ClaimProofJob) -> Result<Option<ProofJob>> {
         let lock_id = Uuid::new_v4();
         let sql = claim_query(req.api_proof_type);
+        // An empty announcement is a pre-versioning worker, which only ever produced version 0.
+        let protocol_versions: Vec<i64> = if req.protocol_versions.is_empty() {
+            vec![0]
+        } else {
+            req.protocol_versions.iter().copied().map(i64::from).collect()
+        };
 
         let row = match req.api_proof_type {
             ApiProofType::Tee => {
@@ -585,6 +599,7 @@ impl ProofRequestRepo {
                     .bind(i64::from(req.lock_duration_seconds))
                     .bind(req.api_proof_type.as_str())
                     .bind(&tee_kinds)
+                    .bind(&protocol_versions)
                     .bind(i64::from(req.max_attempts))
                     .fetch_optional(&self.pool)
                     .await?
@@ -606,6 +621,7 @@ impl ProofRequestRepo {
                     .bind(req.api_proof_type.as_str())
                     .bind(&zk_vms)
                     .bind(&zk_backends)
+                    .bind(&protocol_versions)
                     .bind(i64::from(req.max_attempts))
                     .fetch_optional(&self.pool)
                     .await?
@@ -1298,6 +1314,26 @@ impl ProofRequestRepo {
         rows.iter().map(row_to_proof_request).collect()
     }
 
+    /// Counts queued (unclaimed) worker jobs grouped by required prover protocol version.
+    /// Feeds the pending-jobs gauge that surfaces jobs stranded at a version no worker claims.
+    pub async fn count_pending_jobs_by_protocol_version(&self) -> Result<Vec<(i64, i64)>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT request_protocol_version,
+                   COUNT(*) FILTER (WHERE job_status = 'PENDING') AS pending_count
+            FROM proof_requests
+            GROUP BY request_protocol_version
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|row| (row.get("request_protocol_version"), row.get("pending_count")))
+            .collect())
+    }
+
     /// Get proof requests that are stuck in PENDING without a running session,
     /// or migration-parked RUNNING requests that were never claimed by a worker.
     /// PENDING requests are likely orphaned due to crashes before session creation.
@@ -1675,6 +1711,7 @@ struct PreparedProofRequest {
     id: Uuid,
     session_id: String,
     request_payload: serde_json::Value,
+    protocol_version: i64,
     api_proof_type: ApiProofType,
     zk_vm: Option<ZkVmKind>,
     tee_kind: Option<TeeKind>,
@@ -1730,6 +1767,7 @@ impl TryFrom<CreateProofRequest> for PreparedProofRequest {
             id,
             session_id,
             request_payload,
+            protocol_version: i64::from(req.request_payload.protocol_version),
             api_proof_type: req.api_proof_type,
             zk_vm: req.zk_vm,
             tee_kind: req.tee_kind,
@@ -2061,6 +2099,16 @@ const PROOF_JOB_RETURNING_COLUMNS: &str = "id, COALESCE(session_id, id::text) AS
 /// hardcoded as literals in each variant rather than interpolated from a value,
 /// so no caller-derived string can ever reach the SQL as a column name. The only
 /// interpolated token is the fixed [`PROOF_JOB_RETURNING_COLUMNS`] constant.
+///
+/// `request_protocol_version = ANY(...)` lets one worker fleet serve several protocol versions,
+/// which matters because the challenger's capability fingerprint mixes TEE and ZK commitments: a
+/// ZK-only program rotation mints a new version for an otherwise unchanged TEE image, and exact
+/// match would force a whole new Nitro fleet (and a fresh enclave registration) to serve it.
+///
+// ponytail: single-element arrays keep the `idx_proof_requests_*_by_version` index scan; multi-
+// element arrays may add a sort for `ORDER BY start_block_number`. Queue depth is small enough
+// that this is not worth optimizing. If it ever is, split into a per-version `UNION ALL` with
+// `LIMIT 1` per branch and take the minimum.
 fn claim_query(api_proof_type: ApiProofType) -> String {
     let columns = PROOF_JOB_RETURNING_COLUMNS;
     match api_proof_type {
@@ -2079,9 +2127,10 @@ fn claim_query(api_proof_type: ApiProofType) -> String {
                 SELECT id FROM proof_requests
                 WHERE api_proof_type = $4
                   AND tee_kind = ANY($5::text[])
+                  AND request_protocol_version = ANY($6::bigint[])
                   AND (
                       job_status = 'PENDING'
-                      OR (job_status = 'CLAIMED' AND lock_expires_at < NOW() AND attempt < $6)
+                      OR (job_status = 'CLAIMED' AND lock_expires_at < NOW() AND attempt < $7)
                   )
                 ORDER BY start_block_number ASC, created_at ASC, id ASC
                 FOR UPDATE SKIP LOCKED
@@ -2106,9 +2155,10 @@ fn claim_query(api_proof_type: ApiProofType) -> String {
                 WHERE api_proof_type = $4
                   AND zk_vm = ANY($5::text[])
                   AND COALESCE(zk_backend, 'cluster') = ANY($6::text[])
+                  AND request_protocol_version = ANY($7::bigint[])
                   AND (
                       job_status = 'PENDING'
-                      OR (job_status = 'CLAIMED' AND lock_expires_at < NOW() AND attempt < $7)
+                      OR (job_status = 'CLAIMED' AND lock_expires_at < NOW() AND attempt < $8)
                   )
                 ORDER BY start_block_number ASC, created_at ASC, id ASC
                 FOR UPDATE SKIP LOCKED
@@ -2181,6 +2231,7 @@ fn row_to_proof_session(row: &sqlx::postgres::PgRow) -> Result<ProofSession> {
 #[derive(Debug, Clone)]
 struct CreateRequestParams<'a> {
     request_payload: &'a serde_json::Value,
+    protocol_version: i64,
     api_proof_type: &'a str,
     zk_vm: Option<&'a str>,
     tee_kind: Option<&'a str>,
@@ -2213,6 +2264,9 @@ impl CreateRequestParams<'_> {
         row: &sqlx::postgres::PgRow,
         mode: RequestMismatchMode,
     ) -> Option<&'static str> {
+        if row.get::<i64, _>("request_protocol_version") != self.protocol_version {
+            return Some("protocol_version");
+        }
         if row.get::<i64, _>("start_block_number") != self.start_block_number {
             return Some("start_block_number");
         }
@@ -2290,6 +2344,11 @@ fn comparable_request_payload(
     mode: RequestMismatchMode,
 ) -> serde_json::Value {
     let mut value = value.clone();
+    if let Some(map) = value.as_object_mut() {
+        // The dedicated request_protocol_version column is compared before the payload. Exclude
+        // this duplicated field so payloads written before protocol versioning compare as v0.
+        map.remove("protocol_version");
+    }
     let zk_backend_path =
         match value.pointer("/request/proof_type").and_then(serde_json::Value::as_str) {
             Some("compressed") => Some("/request/payload"),
@@ -2333,6 +2392,7 @@ mod tests {
         let session_id = Uuid::new_v4();
         let create = CreateProofRequest::new(ProtocolProofRequest {
             session_id: session_id.to_string(),
+            protocol_version: 1,
             request: ProofRequestKind::Compressed(ZkProofRequest {
                 start_block_number: 100,
                 number_of_blocks_to_prove: 5,
@@ -2370,6 +2430,7 @@ mod tests {
     fn prepared_request_omits_absent_optional_protocol_payload_fields() {
         let create = CreateProofRequest::new(ProtocolProofRequest {
             session_id: Uuid::new_v4().to_string(),
+            protocol_version: 0,
             request: ProofRequestKind::Compressed(ZkProofRequest {
                 start_block_number: 100,
                 number_of_blocks_to_prove: 5,
@@ -2435,6 +2496,7 @@ mod tests {
     fn prepared_request_represents_tee_protocol_request() {
         let create = CreateProofRequest::new(ProtocolProofRequest {
             session_id: "tee-session".to_owned(),
+            protocol_version: 1,
             request: ProofRequestKind::Tee(TeeProofRequest {
                 proof: Default::default(),
                 tee_kind: ProtocolTeeKind::AwsNitro,
@@ -2547,9 +2609,25 @@ mod tests {
         }
     }
 
+    #[test]
+    fn legacy_payload_without_protocol_version_matches_v0_payload() {
+        let legacy = serde_json::json!({
+            "session_id": "session",
+            "request": {
+                "proof_type": "compressed",
+                "payload": {"start_block_number": 1, "zk_backend": "cluster"}
+            }
+        });
+        let mut current = legacy.clone();
+        current["protocol_version"] = serde_json::json!(0);
+
+        assert!(request_payload_matches(&legacy, &current, RequestMismatchMode::Strict));
+    }
+
     fn tee_protocol_request(session_id: &str) -> ProtocolProofRequest {
         ProtocolProofRequest {
             session_id: session_id.to_owned(),
+            protocol_version: 1,
             request: ProofRequestKind::Tee(TeeProofRequest {
                 proof: Default::default(),
                 tee_kind: ProtocolTeeKind::AwsNitro,
@@ -2566,6 +2644,7 @@ mod tests {
     fn prepared_request_rejects_unsupported_protocol_combination() {
         let mut create = CreateProofRequest::new(ProtocolProofRequest {
             session_id: "bad-tee-session".to_owned(),
+            protocol_version: 1,
             request: ProofRequestKind::Tee(TeeProofRequest {
                 proof: Default::default(),
                 tee_kind: ProtocolTeeKind::AwsNitro,
@@ -2584,6 +2663,7 @@ mod tests {
     fn prepared_request_rejects_database_range_overflow() {
         let create = CreateProofRequest::new(ProtocolProofRequest {
             session_id: Uuid::new_v4().to_string(),
+            protocol_version: 1,
             request: ProofRequestKind::Compressed(ZkProofRequest {
                 start_block_number: (i64::MAX as u64) + 1,
                 number_of_blocks_to_prove: 5,

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -13,7 +13,7 @@
 //! They run sequentially (`--test-threads=1`) because they share the same database;
 //! each test creates unique UUIDs so they don't collide.
 
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 use alloy_primitives::Address;
 use base_proof_primitives::Proposal;
@@ -68,6 +68,7 @@ fn compressed_request_at_with_backend(
 ) -> CreateProofRequest {
     CreateProofRequest::new(ProtocolProofRequest {
         session_id: Uuid::new_v4().to_string(),
+        protocol_version: 1,
         request: ProtocolProofRequestKind::Compressed(ZkProofRequest {
             start_block_number,
             number_of_blocks_to_prove: 5,
@@ -85,6 +86,7 @@ fn compressed_request_at_with_backend(
 fn compressed_request_with_l1_head(l1_head: &str) -> CreateProofRequest {
     CreateProofRequest::new(ProtocolProofRequest {
         session_id: Uuid::new_v4().to_string(),
+        protocol_version: 1,
         request: ProtocolProofRequestKind::Compressed(ZkProofRequest {
             start_block_number: 100,
             number_of_blocks_to_prove: 5,
@@ -102,6 +104,7 @@ fn compressed_request_with_l1_head(l1_head: &str) -> CreateProofRequest {
 fn snark_request() -> CreateProofRequest {
     CreateProofRequest::new(ProtocolProofRequest {
         session_id: Uuid::new_v4().to_string(),
+        protocol_version: 1,
         request: ProtocolProofRequestKind::SnarkPlonk(SnarkPlonkProofRequest {
             proof: ZkProofRequest {
                 start_block_number: 200,
@@ -128,6 +131,7 @@ fn snark_request() -> CreateProofRequest {
 fn tee_request() -> CreateProofRequest {
     CreateProofRequest::new(ProtocolProofRequest {
         session_id: Uuid::new_v4().to_string(),
+        protocol_version: 1,
         request: ProtocolProofRequestKind::Tee(TeeProofRequest {
             proof: Default::default(),
             tee_kind: ProtocolTeeKind::AwsNitro,
@@ -261,6 +265,7 @@ async fn test_legacy_rollout_request_without_protocol_storage_is_readable_and_re
 
     let explicit_id = Uuid::new_v4();
     let mut req = compressed_request();
+    req.request_payload.protocol_version = 0;
     set_request_session_id(&mut req, explicit_id.to_string());
 
     sqlx::query(
@@ -288,8 +293,9 @@ async fn test_legacy_rollout_request_without_protocol_storage_is_readable_and_re
     let fetched = repo.get(explicit_id).await.unwrap().expect("should synthesize protocol fields");
     assert_eq!(fetched.api_proof_type, ApiProofType::Compressed);
     assert_eq!(fetched.zk_vm, Some(ZkVmKind::Sp1));
-    serde_json::from_value::<ProtocolProofRequest>(fetched.request_payload)
+    let fetched_payload = serde_json::from_value::<ProtocolProofRequest>(fetched.request_payload)
         .expect("synthesized protocol request payload should deserialize");
+    assert_eq!(fetched_payload.protocol_version, 0);
 
     let (proofs, _) = repo
         .list_with_offset(&[ProofStatus::Created], ProofRequestPage::try_new(10_000, 0).unwrap())
@@ -304,6 +310,76 @@ async fn test_legacy_rollout_request_without_protocol_storage_is_readable_and_re
 
     let outcome = repo.create_for_worker_queue(req, TEST_MAX_PROOF_RETRIES).await.unwrap();
     assert_eq!(outcome, CreateProofRequestOutcome::Replayed(explicit_id));
+
+    let mut current = compressed_request();
+    set_request_session_id(&mut current, explicit_id.to_string());
+    let err = repo
+        .create_for_worker_queue(current, TEST_MAX_PROOF_RETRIES)
+        .await
+        .expect_err("current protocol must not replay a legacy row");
+    assert!(matches!(
+        err,
+        CreateProofRequestError::IdCollision { id, field: "protocol_version" }
+            if id == explicit_id
+    ));
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_legacy_rollout_pre_migration_row_claimable_only_by_legacy_worker() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool.clone());
+
+    drain_claimable_compressed_jobs(&repo).await;
+
+    // Insert a row WITHOUT the request_protocol_version column, simulating a
+    // pre-migration row. The migration's DEFAULT 0 ensures it reads as v0.
+    let explicit_id = Uuid::new_v4();
+    let mut req = compressed_request();
+    req.request_payload.protocol_version = 0;
+    set_request_session_id(&mut req, explicit_id.to_string());
+
+    sqlx::query(
+        r#"
+        INSERT INTO proof_requests (
+            id, start_block_number, number_of_blocks_to_prove, sequence_window, proof_type, status,
+            prover_address, l1_head, intermediate_root_interval,
+            api_proof_type, zk_vm, zk_backend
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+        "#,
+    )
+    .bind(explicit_id)
+    .bind(i64::try_from(req.start_block_number).unwrap())
+    .bind(i64::try_from(req.number_of_blocks_to_prove).unwrap())
+    .bind(req.sequence_window.map(|value| i64::try_from(value).unwrap()))
+    .bind(req.proof_type.expect("compressed request has proof_type").as_str())
+    .bind(ProofStatus::Created.as_str())
+    .bind(&req.prover_address)
+    .bind(&req.l1_head)
+    .bind(req.intermediate_root_interval.map(|value| i64::try_from(value).unwrap()))
+    .bind(req.api_proof_type.as_str())
+    .bind(req.zk_vm.expect("compressed request has zk_vm").as_str())
+    .bind(req.zk_backend.as_ref().map(|b| b.as_str()))
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // A v1 (current-protocol) worker must not claim the pre-migration row.
+    assert!(
+        repo.claim_next_proof_job(compressed_claim("current-worker", 3)).await.unwrap().is_none(),
+        "a current-protocol worker must not claim a pre-migration (v0) row"
+    );
+
+    // A v0 (legacy) worker can claim it.
+    let mut legacy = compressed_claim("legacy-worker", 3);
+    legacy.protocol_versions = vec![0];
+    let legacy_job = repo
+        .claim_next_proof_job(legacy)
+        .await
+        .unwrap()
+        .expect("a legacy worker should claim the pre-migration row");
+    assert_eq!(legacy_job.id, explicit_id);
 }
 
 #[tokio::test]
@@ -1526,6 +1602,7 @@ fn claim_job(
 ) -> ClaimProofJob {
     ClaimProofJob {
         worker_id: worker_id.to_owned(),
+        protocol_versions: vec![1],
         api_proof_type,
         tee_kinds,
         zk_vms,
@@ -1554,8 +1631,10 @@ fn compressed_claim(worker_id: &str, max_attempts: u32) -> ClaimProofJob {
 /// an unexpired lock (rather than completing them) keeps this independent of the
 /// worker submit API.
 async fn drain_claimable_tee_jobs(repo: &ProofRequestRepo) {
+    let mut claim = tee_claim("drain-worker", u32::MAX);
+    claim.protocol_versions = vec![0, 1];
     while repo
-        .claim_next_proof_job(tee_claim("drain-worker", u32::MAX))
+        .claim_next_proof_job(claim.clone())
         .await
         .expect("drain claim should not error")
         .is_some()
@@ -1565,8 +1644,10 @@ async fn drain_claimable_tee_jobs(repo: &ProofRequestRepo) {
 /// Drain every currently claimable compressed job for tests that need to claim a
 /// freshly inserted ZK request deterministically.
 async fn drain_claimable_compressed_jobs(repo: &ProofRequestRepo) {
+    let mut claim = compressed_claim("drain-zk-worker", u32::MAX);
+    claim.protocol_versions = vec![0, 1];
     while repo
-        .claim_next_proof_job(compressed_claim("drain-zk-worker", u32::MAX))
+        .claim_next_proof_job(claim.clone())
         .await
         .expect("drain claim should not error")
         .is_some()
@@ -1688,6 +1769,94 @@ async fn test_claim_next_proof_job_orders_by_start_block_number() {
     assert_eq!(job.id, low_block_id);
     assert_ne!(job.id, high_block_id);
     assert_eq!(job.api_proof_type, ApiProofType::Compressed);
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_claim_next_proof_job_matches_request_protocol_version() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    drain_claimable_compressed_jobs(&repo).await;
+    let mut legacy_request = compressed_request();
+    legacy_request.request_payload.protocol_version = 0;
+    let legacy_id = repo.create(legacy_request).await.unwrap();
+    let current_id = repo.create(compressed_request()).await.unwrap();
+
+    let current_job = repo
+        .claim_next_proof_job(compressed_claim("current-worker", 3))
+        .await
+        .unwrap()
+        .expect("a current worker should claim the current-protocol job");
+    assert_eq!(current_job.id, current_id);
+    assert!(
+        repo.claim_next_proof_job(compressed_claim("current-worker", 3)).await.unwrap().is_none(),
+        "a current worker must not claim a legacy request"
+    );
+
+    let mut legacy = compressed_claim("legacy-worker", 3);
+    legacy.protocol_versions = vec![0];
+    let legacy_job = repo
+        .claim_next_proof_job(legacy)
+        .await
+        .unwrap()
+        .expect("a legacy worker should claim the legacy job");
+    assert_eq!(legacy_job.id, legacy_id);
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_claim_next_proof_job_matches_any_announced_protocol_version() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    drain_claimable_compressed_jobs(&repo).await;
+    let mut legacy_request = compressed_request();
+    legacy_request.request_payload.protocol_version = 0;
+    let legacy_id = repo.create(legacy_request).await.unwrap();
+    let current_id = repo.create(compressed_request()).await.unwrap();
+
+    let mut multi = compressed_claim("multi-version-worker", 3);
+    multi.protocol_versions = vec![0, 1];
+
+    let mut claimed = Vec::new();
+    while let Some(job) = repo.claim_next_proof_job(multi.clone()).await.unwrap() {
+        claimed.push(job.id);
+    }
+    claimed.sort();
+
+    let mut expected = vec![legacy_id, current_id];
+    expected.sort();
+    assert_eq!(claimed, expected, "a worker announcing [0, 1] should claim both versions");
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_count_pending_jobs_by_protocol_version() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let baseline: HashMap<i64, i64> =
+        repo.count_pending_jobs_by_protocol_version().await.unwrap().into_iter().collect();
+
+    let mut legacy_request = compressed_request();
+    legacy_request.request_payload.protocol_version = 0;
+    repo.create(legacy_request).await.unwrap();
+    repo.create(compressed_request()).await.unwrap();
+
+    let counts: HashMap<i64, i64> =
+        repo.count_pending_jobs_by_protocol_version().await.unwrap().into_iter().collect();
+    assert_eq!(counts.get(&0).copied().unwrap_or(0), baseline.get(&0).copied().unwrap_or(0) + 1);
+    assert_eq!(counts.get(&1).copied().unwrap_or(0), baseline.get(&1).copied().unwrap_or(0) + 1);
+
+    // Claiming the current-protocol job removes it from the pending counts.
+    repo.claim_next_proof_job(compressed_claim("count-worker", 3))
+        .await
+        .unwrap()
+        .expect("the current-protocol job should be claimable");
+    let after_claim: HashMap<i64, i64> =
+        repo.count_pending_jobs_by_protocol_version().await.unwrap().into_iter().collect();
+    assert_eq!(after_claim.get(&1).copied().unwrap_or(0), baseline.get(&1).copied().unwrap_or(0));
 }
 
 #[tokio::test]

--- a/crates/proof/prover-service/protocol/src/types.rs
+++ b/crates/proof/prover-service/protocol/src/types.rs
@@ -153,7 +153,7 @@ pub struct DeleteProofsByTeeSignerRequest {
 pub struct ProofRequest {
     /// Client-provided idempotency key.
     pub session_id: String,
-    /// Prover protocol required to fulfill this request. Omission defaults to legacy version `0`.
+    /// Opaque prover routing version. Omission defaults to compatibility route `0`.
     #[serde(default)]
     pub protocol_version: u32,
     /// Proof request details.

--- a/crates/proof/prover-service/protocol/src/types.rs
+++ b/crates/proof/prover-service/protocol/src/types.rs
@@ -396,10 +396,9 @@ pub struct GetNextProofRequest {
     pub zk_backends: Vec<ZkBackend>,
     /// Worker protocol versions used to gate incompatible jobs.
     ///
-    /// A worker announces every version it can serve, because one artifact set is usually valid
-    /// for more than one: the challenger's capability fingerprint mixes TEE and ZK commitments, so
-    /// a ZK-only program rotation mints a new version even when the TEE image is unchanged.
-    /// Omission or an empty list means `[0]`, matching pre-versioning workers.
+    /// A worker announces every version it can serve. The fingerprint still mixes TEE and ZK
+    /// hashes, so a ZK-only program rotation mints a new version even when the TEE image is
+    /// unchanged. Omission or an empty list means `[0]`, matching pre-versioning workers.
     #[serde(default)]
     pub protocol_versions: Vec<u32>,
     /// Requested lock duration in seconds. Zero uses the server default.

--- a/crates/proof/prover-service/protocol/src/types.rs
+++ b/crates/proof/prover-service/protocol/src/types.rs
@@ -153,6 +153,9 @@ pub struct DeleteProofsByTeeSignerRequest {
 pub struct ProofRequest {
     /// Client-provided idempotency key.
     pub session_id: String,
+    /// Prover protocol required to fulfill this request. Omission defaults to legacy version `0`.
+    #[serde(default)]
+    pub protocol_version: u32,
     /// Proof request details.
     pub request: ProofRequestKind,
 }
@@ -391,6 +394,14 @@ pub struct GetNextProofRequest {
     /// ZK proving backends this worker can execute for ZK proofs.
     #[serde(default)]
     pub zk_backends: Vec<ZkBackend>,
+    /// Worker protocol versions used to gate incompatible jobs.
+    ///
+    /// A worker announces every version it can serve, because one artifact set is usually valid
+    /// for more than one: the challenger's capability fingerprint mixes TEE and ZK commitments, so
+    /// a ZK-only program rotation mints a new version even when the TEE image is unchanged.
+    /// Omission or an empty list means `[0]`, matching pre-versioning workers.
+    #[serde(default)]
+    pub protocol_versions: Vec<u32>,
     /// Requested lock duration in seconds. Zero uses the server default.
     pub lock_duration_seconds: u32,
 }
@@ -535,6 +546,7 @@ mod tests {
         let request = ProveBlockRangeRequest {
             proof: ProofRequest {
                 session_id: "proof-session".to_owned(),
+                protocol_version: 1,
                 request: ProofRequestKind::Compressed(ZkProofRequest {
                     start_block_number: 10,
                     number_of_blocks_to_prove: 20,
@@ -548,13 +560,14 @@ mod tests {
             },
         };
 
-        let value = serde_json::to_value(request).expect("proof request should serialize");
+        let value = serde_json::to_value(&request).expect("proof request should serialize");
 
         assert_eq!(
             value,
             json!({
                 "proof": {
                     "session_id": "proof-session",
+                    "protocol_version": 1,
                     "request": {
                         "proof_type": "compressed",
                         "payload": {
@@ -569,6 +582,13 @@ mod tests {
                 }
             })
         );
+
+        // A legacy producer omits the field entirely, which must read back as version 0.
+        let mut legacy = value;
+        legacy["proof"].as_object_mut().unwrap().remove("protocol_version");
+        let deserialized: ProveBlockRangeRequest =
+            serde_json::from_value(legacy).expect("legacy proof request should deserialize");
+        assert_eq!(deserialized.proof.protocol_version, 0);
     }
 
     #[test]
@@ -929,6 +949,7 @@ mod tests {
             tee_kinds: Vec::new(),
             zk_vms: vec![ZkVm::Sp1],
             zk_backends: vec![ZkBackend::Cluster, ZkBackend::DryRun],
+            protocol_versions: vec![1, 2],
             lock_duration_seconds: 30,
         };
 
@@ -942,6 +963,7 @@ mod tests {
                 "tee_kinds": [],
                 "zk_vms": ["sp1"],
                 "zk_backends": ["cluster", "dry_run"],
+                "protocol_versions": [1, 2],
                 "lock_duration_seconds": 30
             })
         );
@@ -959,6 +981,7 @@ mod tests {
         assert_eq!(request.tee_kinds, Vec::new());
         assert_eq!(request.zk_vms, Vec::new());
         assert_eq!(request.zk_backends, Vec::new());
+        assert_eq!(request.protocol_versions, Vec::<u32>::new());
     }
 
     #[test]

--- a/crates/proof/prover-service/src/lib.rs
+++ b/crates/proof/prover-service/src/lib.rs
@@ -2,12 +2,12 @@
 
 mod metrics;
 pub use metrics::{
-    PROOF_REQUEST_DURATION_MS, PROOF_REQUESTS_COMPLETED, PROOF_STATUS_FAILED,
+    PENDING_JOBS, PROOF_REQUEST_DURATION_MS, PROOF_REQUESTS_COMPLETED, PROOF_STATUS_FAILED,
     PROOF_STATUS_SUCCEEDED, ProverMetrics, REQUESTS, RESPONSE_LATENCY_MS, RETRIED_REQUESTS,
     STUCK_REQUESTS, WORKER_JOBS_FAILED, api_proof_type_label, inc_proof_requests_completed,
     inc_requests, inc_retried_requests, inc_stuck_requests, inc_worker_jobs_failed,
     inc_worker_requests, proof_type_label, record_proof_request_duration, record_response_latency,
-    record_terminal_proof_job,
+    record_terminal_proof_job, set_pending_jobs,
 };
 
 mod metadata;

--- a/crates/proof/prover-service/src/metrics.rs
+++ b/crates/proof/prover-service/src/metrics.rs
@@ -4,7 +4,7 @@
 //! backend is determined by the binary (e.g. Prometheus, `DogStatsD`).
 
 use base_prover_service_db::{ApiProofType, ProofJob, ProofType};
-use metrics::{counter, describe_counter, describe_histogram, histogram};
+use metrics::{counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram};
 
 // ---------------------------------------------------------------------------
 // Metric name constants
@@ -26,6 +26,9 @@ pub const STUCK_REQUESTS: &str = "prover_service.stuck_requests";
 pub const RETRIED_REQUESTS: &str = "prover_service.retried_requests";
 /// Worker jobs terminally failed by a background reaper. Tags: `reason`, `proof_type`
 pub const WORKER_JOBS_FAILED: &str = "prover_service.worker_jobs_failed";
+/// Queued (unclaimed) worker jobs. Tags: `protocol_version`. Sustained non-zero at a
+/// version no active worker announces means those jobs are stranded.
+pub const PENDING_JOBS: &str = "prover_service.pending_jobs";
 
 /// Terminal success status label.
 pub const PROOF_STATUS_SUCCEEDED: &str = "succeeded";
@@ -57,6 +60,7 @@ impl ProverMetrics {
             WORKER_JOBS_FAILED,
             "Worker jobs terminally failed by a background reaper"
         );
+        describe_gauge!(PENDING_JOBS, "Queued worker jobs awaiting claim, by protocol version");
     }
 }
 
@@ -121,6 +125,11 @@ pub fn inc_stuck_requests(proof_type: &str) {
 /// Increment retried requests counter.
 pub fn inc_retried_requests(proof_type: &str) {
     counter!(RETRIED_REQUESTS, "proof_type" => proof_type.to_string()).increment(1);
+}
+
+/// Set the pending-jobs gauge for one prover protocol version.
+pub fn set_pending_jobs(protocol_version: i64, count: i64) {
+    gauge!(PENDING_JOBS, "protocol_version" => protocol_version.to_string()).set(count as f64);
 }
 
 /// Increment the worker-jobs-failed counter for a reaper outcome.

--- a/crates/proof/prover-service/src/server/prove_block_range.rs
+++ b/crates/proof/prover-service/src/server/prove_block_range.rs
@@ -3,8 +3,7 @@ use base_prover_service_db::{
     canonical_session_id,
 };
 use base_prover_service_protocol::{
-    ProofRequest, ProofRequestIdCollisionMessage, ProofRequestKind, ProveBlockRangeRequest,
-    ProveBlockRangeResponse,
+    ProofRequestIdCollisionMessage, ProveBlockRangeRequest, ProveBlockRangeResponse,
 };
 use jsonrpsee::core::RpcResult;
 use tracing::{info, warn};
@@ -32,7 +31,6 @@ impl ProverServiceServer {
         request: ProveBlockRangeRequest,
     ) -> RpcResult<ProveBlockRangeResponse> {
         let mut proof_request = request.proof;
-        validate_protocol_version(&proof_request)?;
         let session_id = parse_session_id(&proof_request.session_id)?;
         proof_request.session_id = session_id.clone();
 
@@ -120,23 +118,6 @@ fn parse_session_id(session_id: &str) -> RpcResult<String> {
     canonical_session_id(session_id).map_err(|e| invalid_argument(format!("{e}")))
 }
 
-/// Rejects schedule-pinned requests mislabeled as legacy jobs.
-fn validate_protocol_version(request: &ProofRequest) -> RpcResult<()> {
-    let protocol_version = request.protocol_version;
-    let schedule_l2_block_number = match &request.request {
-        ProofRequestKind::Compressed(request) => request.schedule_l2_block_number,
-        ProofRequestKind::SnarkPlonk(request) => request.proof.schedule_l2_block_number,
-        ProofRequestKind::Tee(request) => request.proof.schedule_l2_block_number,
-    };
-    if schedule_l2_block_number.is_some() && protocol_version == 0 {
-        return Err(invalid_argument(
-            "schedule_l2_block_number requires a non-zero protocol_version",
-        ));
-    }
-
-    Ok(())
-}
-
 fn validate_intermediate_root_interval(
     api_proof_type: ApiProofType,
     number_of_blocks_to_prove: u64,
@@ -166,13 +147,9 @@ fn validate_intermediate_root_interval(
 #[cfg(test)]
 mod tests {
     use base_prover_service_db::{ApiProofType, ProofType};
-    use base_prover_service_protocol::{
-        ProofRequest, ProofRequestKind, SnarkPlonkProofRequest, TeeKind, TeeProofRequest,
-        ZkBackend, ZkProofRequest, ZkVm,
-    };
     use uuid::Uuid;
 
-    use super::{parse_session_id, validate_intermediate_root_interval, validate_protocol_version};
+    use super::{parse_session_id, validate_intermediate_root_interval};
     use crate::metrics;
 
     #[test]
@@ -207,39 +184,6 @@ mod tests {
     }
 
     #[test]
-    fn validate_protocol_version_accepts_arbitrary_versions() {
-        for version in [0, 1, 7, u32::MAX] {
-            assert!(validate_protocol_version(&proof_request(version, None)).is_ok());
-        }
-    }
-
-    #[test]
-    fn schedule_pinning_requires_current_protocol_version() {
-        let mut tee_request =
-            TeeProofRequest { proof: Default::default(), tee_kind: TeeKind::AwsNitro };
-        tee_request.proof.schedule_l2_block_number = Some(42);
-        let requests = [
-            ProofRequestKind::Compressed(zk_request(Some(42))),
-            ProofRequestKind::SnarkPlonk(SnarkPlonkProofRequest {
-                proof: zk_request(Some(42)),
-                prover_address: Default::default(),
-            }),
-            ProofRequestKind::Tee(tee_request),
-        ];
-
-        for request in requests {
-            let mut proof_request =
-                ProofRequest { session_id: "session".to_owned(), protocol_version: 0, request };
-            let err = validate_protocol_version(&proof_request)
-                .expect_err("legacy protocol must reject schedule pinning");
-            assert!(err.message().contains("schedule_l2_block_number requires"));
-
-            proof_request.protocol_version = 7;
-            assert!(validate_protocol_version(&proof_request).is_ok());
-        }
-    }
-
-    #[test]
     fn parse_session_id_accepts_uppercase_uuid() {
         let id = Uuid::new_v4();
         let parsed = parse_session_id(&id.to_string().to_uppercase()).unwrap();
@@ -267,26 +211,5 @@ mod tests {
         let result = validate_intermediate_root_interval(ApiProofType::Tee, 1, Some(30));
 
         assert!(result.is_ok());
-    }
-
-    fn proof_request(protocol_version: u32, schedule_l2_block_number: Option<u64>) -> ProofRequest {
-        ProofRequest {
-            session_id: "session".to_owned(),
-            protocol_version,
-            request: ProofRequestKind::Compressed(zk_request(schedule_l2_block_number)),
-        }
-    }
-
-    fn zk_request(schedule_l2_block_number: Option<u64>) -> ZkProofRequest {
-        ZkProofRequest {
-            start_block_number: 1,
-            number_of_blocks_to_prove: 1,
-            sequence_window: None,
-            l1_head: None,
-            intermediate_root_interval: None,
-            schedule_l2_block_number,
-            zk_vm: ZkVm::Sp1,
-            zk_backend: ZkBackend::Cluster,
-        }
     }
 }

--- a/crates/proof/prover-service/src/server/prove_block_range.rs
+++ b/crates/proof/prover-service/src/server/prove_block_range.rs
@@ -3,7 +3,8 @@ use base_prover_service_db::{
     canonical_session_id,
 };
 use base_prover_service_protocol::{
-    ProofRequestIdCollisionMessage, ProveBlockRangeRequest, ProveBlockRangeResponse,
+    ProofRequest, ProofRequestIdCollisionMessage, ProofRequestKind, ProveBlockRangeRequest,
+    ProveBlockRangeResponse,
 };
 use jsonrpsee::core::RpcResult;
 use tracing::{info, warn};
@@ -31,6 +32,7 @@ impl ProverServiceServer {
         request: ProveBlockRangeRequest,
     ) -> RpcResult<ProveBlockRangeResponse> {
         let mut proof_request = request.proof;
+        validate_protocol_version(&proof_request)?;
         let session_id = parse_session_id(&proof_request.session_id)?;
         proof_request.session_id = session_id.clone();
 
@@ -118,6 +120,23 @@ fn parse_session_id(session_id: &str) -> RpcResult<String> {
     canonical_session_id(session_id).map_err(|e| invalid_argument(format!("{e}")))
 }
 
+/// Rejects schedule-pinned requests mislabeled as legacy jobs.
+fn validate_protocol_version(request: &ProofRequest) -> RpcResult<()> {
+    let protocol_version = request.protocol_version;
+    let schedule_l2_block_number = match &request.request {
+        ProofRequestKind::Compressed(request) => request.schedule_l2_block_number,
+        ProofRequestKind::SnarkPlonk(request) => request.proof.schedule_l2_block_number,
+        ProofRequestKind::Tee(request) => request.proof.schedule_l2_block_number,
+    };
+    if schedule_l2_block_number.is_some() && protocol_version == 0 {
+        return Err(invalid_argument(
+            "schedule_l2_block_number requires a non-zero protocol_version",
+        ));
+    }
+
+    Ok(())
+}
+
 fn validate_intermediate_root_interval(
     api_proof_type: ApiProofType,
     number_of_blocks_to_prove: u64,
@@ -147,9 +166,13 @@ fn validate_intermediate_root_interval(
 #[cfg(test)]
 mod tests {
     use base_prover_service_db::{ApiProofType, ProofType};
+    use base_prover_service_protocol::{
+        ProofRequest, ProofRequestKind, SnarkPlonkProofRequest, TeeKind, TeeProofRequest,
+        ZkBackend, ZkProofRequest, ZkVm,
+    };
     use uuid::Uuid;
 
-    use super::{parse_session_id, validate_intermediate_root_interval};
+    use super::{parse_session_id, validate_intermediate_root_interval, validate_protocol_version};
     use crate::metrics;
 
     #[test]
@@ -184,6 +207,39 @@ mod tests {
     }
 
     #[test]
+    fn validate_protocol_version_accepts_arbitrary_versions() {
+        for version in [0, 1, 7, u32::MAX] {
+            assert!(validate_protocol_version(&proof_request(version, None)).is_ok());
+        }
+    }
+
+    #[test]
+    fn schedule_pinning_requires_current_protocol_version() {
+        let mut tee_request =
+            TeeProofRequest { proof: Default::default(), tee_kind: TeeKind::AwsNitro };
+        tee_request.proof.schedule_l2_block_number = Some(42);
+        let requests = [
+            ProofRequestKind::Compressed(zk_request(Some(42))),
+            ProofRequestKind::SnarkPlonk(SnarkPlonkProofRequest {
+                proof: zk_request(Some(42)),
+                prover_address: Default::default(),
+            }),
+            ProofRequestKind::Tee(tee_request),
+        ];
+
+        for request in requests {
+            let mut proof_request =
+                ProofRequest { session_id: "session".to_owned(), protocol_version: 0, request };
+            let err = validate_protocol_version(&proof_request)
+                .expect_err("legacy protocol must reject schedule pinning");
+            assert!(err.message().contains("schedule_l2_block_number requires"));
+
+            proof_request.protocol_version = 7;
+            assert!(validate_protocol_version(&proof_request).is_ok());
+        }
+    }
+
+    #[test]
     fn parse_session_id_accepts_uppercase_uuid() {
         let id = Uuid::new_v4();
         let parsed = parse_session_id(&id.to_string().to_uppercase()).unwrap();
@@ -211,5 +267,26 @@ mod tests {
         let result = validate_intermediate_root_interval(ApiProofType::Tee, 1, Some(30));
 
         assert!(result.is_ok());
+    }
+
+    fn proof_request(protocol_version: u32, schedule_l2_block_number: Option<u64>) -> ProofRequest {
+        ProofRequest {
+            session_id: "session".to_owned(),
+            protocol_version,
+            request: ProofRequestKind::Compressed(zk_request(schedule_l2_block_number)),
+        }
+    }
+
+    fn zk_request(schedule_l2_block_number: Option<u64>) -> ZkProofRequest {
+        ZkProofRequest {
+            start_block_number: 1,
+            number_of_blocks_to_prove: 1,
+            sequence_window: None,
+            l1_head: None,
+            intermediate_root_interval: None,
+            schedule_l2_block_number,
+            zk_vm: ZkVm::Sp1,
+            zk_backend: ZkBackend::Cluster,
+        }
     }
 }

--- a/crates/proof/prover-service/src/server/worker_api.rs
+++ b/crates/proof/prover-service/src/server/worker_api.rs
@@ -68,6 +68,10 @@ impl ProverServiceServer {
     ) -> RpcResult<GetNextProofResponse> {
         let start = std::time::Instant::now();
         let result = self.get_next_proof_inner(request).await;
+        // Deliberately unlabelled by worker. Worker ids are per-process UUIDs, and this is the
+        // highest-frequency worker RPC: labelling it mints a metric series per pod restart that
+        // never retires. Per-version claim behaviour is observable from
+        // `prover_service.pending_jobs{protocol_version}` instead.
         record_rpc_result("GetNextProof", start, &result);
 
         result
@@ -79,6 +83,7 @@ impl ProverServiceServer {
     ) -> RpcResult<GetNextProofResponse> {
         let claim = ClaimProofJob {
             worker_id: request.worker_id,
+            protocol_versions: request.protocol_versions,
             api_proof_type: request.proof_type.into(),
             tee_kinds: request.tee_kinds.into_iter().map(Into::into).collect(),
             zk_vms: request.zk_vms.into_iter().map(Into::into).collect(),

--- a/crates/proof/prover-service/src/worker/status_poller.rs
+++ b/crates/proof/prover-service/src/worker/status_poller.rs
@@ -137,8 +137,31 @@ impl StatusPoller {
         }
 
         self.reap_expired_claims().await;
+        self.record_pending_jobs().await;
 
         Ok(())
+    }
+
+    /// Publish the pending-jobs gauge, grouped by required prover protocol version.
+    ///
+    /// The repository returns every stored version, including zero pending jobs, so drained
+    /// versions do not freeze at their last gauge value. That relies on completed and failed rows
+    /// staying in `proof_requests`: the version is only discoverable while it still has rows. A
+    /// future retention job that prunes them would make a fully pruned version's gauge freeze,
+    /// because this service is deliberately version-agnostic and has no configured version list to
+    /// seed zeros from.
+    async fn record_pending_jobs(&self) {
+        let counts = match self.repo.count_pending_jobs_by_protocol_version().await {
+            Ok(counts) => counts,
+            Err(e) => {
+                error!(error = %e, "Failed to count pending jobs by protocol version");
+                return;
+            }
+        };
+
+        for (protocol_version, count) in counts {
+            metrics::set_pending_jobs(protocol_version, count);
+        }
     }
 
     /// Fail claimed jobs whose lock expired after exhausting the reclaim budget.

--- a/crates/proof/prover-service/tests/idempotency.rs
+++ b/crates/proof/prover-service/tests/idempotency.rs
@@ -16,6 +16,7 @@ fn compressed_request(session_id: &str, start_block_number: u64) -> ProveBlockRa
     ProveBlockRangeRequest {
         proof: ProofRequest {
             session_id: session_id.to_string(),
+            protocol_version: 1,
             request: ProofRequestKind::Compressed(ZkProofRequest {
                 start_block_number,
                 number_of_blocks_to_prove: 1,

--- a/crates/proof/prover-service/tests/worker_api_e2e.rs
+++ b/crates/proof/prover-service/tests/worker_api_e2e.rs
@@ -20,9 +20,9 @@ use base_prover_service_db::{
 };
 use base_prover_service_protocol::{
     GetNextProofRequest, HeartbeatRequest, ProofJobStatus, ProofRequest as ProtocolProofRequest,
-    ProofRequestKind, ProofResult, ProofType, ProverRequesterApiServer, ProverWorkerApiClient,
-    ProverWorkerApiServer, WorkerSubmitProofRequest, ZkBackend, ZkProofRequest, ZkProofResult,
-    ZkVm,
+    ProofRequestKind, ProofResult, ProofType, ProveBlockRangeRequest, ProverRequesterApiClient,
+    ProverRequesterApiServer, ProverWorkerApiClient, ProverWorkerApiServer,
+    WorkerSubmitProofRequest, ZkBackend, ZkProofRequest, ZkProofResult, ZkVm,
 };
 use jsonrpsee::{
     core::client::Error as ClientError,
@@ -103,6 +103,7 @@ impl RunningServer {
 async fn drain_claimable_compressed_jobs(repo: &ProofRequestRepo) {
     let drain = ClaimProofJob {
         worker_id: "worker-api-e2e-drain".to_owned(),
+        protocol_versions: vec![0, 1],
         api_proof_type: ApiProofType::Compressed,
         tee_kinds: Vec::new(),
         zk_vms: vec![ZkVmKind::Sp1],
@@ -122,6 +123,7 @@ async fn drain_claimable_compressed_jobs(repo: &ProofRequestRepo) {
 fn compressed_request(session_id: &str, start_block_number: u64) -> CreateProofRequest {
     CreateProofRequest::new(ProtocolProofRequest {
         session_id: session_id.to_owned(),
+        protocol_version: 1,
         request: ProofRequestKind::Compressed(ZkProofRequest {
             start_block_number,
             number_of_blocks_to_prove: 1,
@@ -144,6 +146,7 @@ fn worker_claim(worker_id: &str) -> GetNextProofRequest {
         zk_vms: vec![ZkVm::Sp1],
         // Omitted by legacy workers; the server defaults this capability to cluster.
         zk_backends: Vec::new(),
+        protocol_versions: vec![1],
         lock_duration_seconds: 60,
     }
 }
@@ -246,6 +249,121 @@ async fn worker_submit_unknown_session_is_not_found() {
         .await
         .expect_err("submitting against an unknown session should fail");
     assert_rpc_error_code(&err, ERROR_NOT_FOUND);
+
+    server.shutdown().await;
+}
+
+fn legacy_prove_request(session_id: &str, start_block_number: u64) -> ProveBlockRangeRequest {
+    ProveBlockRangeRequest {
+        proof: ProtocolProofRequest {
+            session_id: session_id.to_owned(),
+            protocol_version: 0,
+            request: ProofRequestKind::Compressed(ZkProofRequest {
+                start_block_number,
+                number_of_blocks_to_prove: 1,
+                sequence_window: None,
+                l1_head: None,
+                intermediate_root_interval: None,
+                schedule_l2_block_number: None,
+                zk_vm: ZkVm::Sp1,
+                zk_backend: ZkBackend::Cluster,
+            }),
+        },
+    }
+}
+
+fn current_prove_request(session_id: &str, start_block_number: u64) -> ProveBlockRangeRequest {
+    ProveBlockRangeRequest {
+        proof: ProtocolProofRequest {
+            session_id: session_id.to_owned(),
+            protocol_version: 1,
+            request: ProofRequestKind::Compressed(ZkProofRequest {
+                start_block_number,
+                number_of_blocks_to_prove: 1,
+                sequence_window: None,
+                l1_head: None,
+                intermediate_root_interval: None,
+                schedule_l2_block_number: Some(start_block_number),
+                zk_vm: ZkVm::Sp1,
+                zk_backend: ZkBackend::Cluster,
+            }),
+        },
+    }
+}
+
+fn legacy_worker_claim(worker_id: &str) -> GetNextProofRequest {
+    let mut claim = worker_claim(worker_id);
+    claim.protocol_versions = vec![0];
+    claim
+}
+
+/// Protocol v0/v1 isolation across the full requester → HTTP → server → DB →
+/// worker boundary.
+///
+/// A v0 request must only be claimable by a worker claiming protocol version
+/// 0, and a v1 request only by a worker claiming the current protocol
+/// version. Neither protocol can see or claim the other's jobs.
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL)"]
+async fn protocol_version_isolates_request_and_worker_claim() {
+    let repo = test_repo().await;
+    drain_claimable_compressed_jobs(&repo).await;
+
+    let server = RunningServer::spawn(repo.clone()).await;
+
+    let v0_session = Uuid::new_v4().to_string();
+    server
+        .client
+        .prove_block_range(legacy_prove_request(&v0_session, 10))
+        .await
+        .expect("legacy prove_block_range should succeed");
+
+    assert!(
+        server
+            .client
+            .get_next_proof(worker_claim("worker-v1"))
+            .await
+            .expect("get_next_proof should not error")
+            .job
+            .is_none(),
+        "a v1 worker must not claim a v0 request"
+    );
+
+    let v0_job = server
+        .client
+        .get_next_proof(legacy_worker_claim("worker-v0"))
+        .await
+        .expect("legacy get_next_proof should succeed")
+        .job
+        .expect("a v0 worker should claim the v0 request");
+    assert_eq!(v0_job.session_id, v0_session);
+
+    let v1_session = Uuid::new_v4().to_string();
+    server
+        .client
+        .prove_block_range(current_prove_request(&v1_session, 20))
+        .await
+        .expect("v1 prove_block_range should succeed");
+
+    assert!(
+        server
+            .client
+            .get_next_proof(legacy_worker_claim("worker-v0"))
+            .await
+            .expect("legacy get_next_proof should not error")
+            .job
+            .is_none(),
+        "a v0 worker must not claim a v1 request"
+    );
+
+    let v1_job = server
+        .client
+        .get_next_proof(worker_claim("worker-v1"))
+        .await
+        .expect("get_next_proof should succeed")
+        .job
+        .expect("a v1 worker should claim the v1 request");
+    assert_eq!(v1_job.session_id, v1_session);
 
     server.shutdown().await;
 }

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -563,7 +563,7 @@ mod tests {
         ProofJob {
             session_id: session_id.clone(),
             status,
-            request: ProofRequest { session_id, request },
+            request: ProofRequest { session_id, protocol_version: 1, request },
             attempt: 1,
             lock_id,
             worker_id,

--- a/crates/proof/worker/src/job_discovery.rs
+++ b/crates/proof/worker/src/job_discovery.rs
@@ -92,15 +92,22 @@ impl JobClaimFilter {
     pub fn get_next_proof_requests(
         &self,
         worker_id: String,
+        protocol_versions: Vec<u32>,
         lock_duration_seconds: u32,
     ) -> impl Iterator<Item = GetNextProofRequest> {
-        self.get_next_proof_requests_starting_at(worker_id, lock_duration_seconds, 0)
+        self.get_next_proof_requests_starting_at(
+            worker_id,
+            protocol_versions,
+            lock_duration_seconds,
+            0,
+        )
     }
 
     /// Builds the worker claim requests for this filter with a proof-type rotation offset.
     pub fn get_next_proof_requests_starting_at(
         &self,
         worker_id: String,
+        protocol_versions: Vec<u32>,
         lock_duration_seconds: u32,
         proof_type_offset: usize,
     ) -> impl Iterator<Item = GetNextProofRequest> {
@@ -112,6 +119,7 @@ impl JobClaimFilter {
                     tee_kinds: tee_kinds.clone(),
                     zk_vms: Vec::new(),
                     zk_backends: Vec::new(),
+                    protocol_versions,
                     lock_duration_seconds,
                 }),
                 None,
@@ -133,6 +141,7 @@ impl JobClaimFilter {
                         tee_kinds: Vec::new(),
                         zk_vms: zk_vms.clone(),
                         zk_backends: zk_backends.clone(),
+                        protocol_versions: protocol_versions.clone(),
                         lock_duration_seconds,
                     }),
                     Some(GetNextProofRequest {
@@ -141,6 +150,7 @@ impl JobClaimFilter {
                         tee_kinds: Vec::new(),
                         zk_vms,
                         zk_backends,
+                        protocol_versions,
                         lock_duration_seconds,
                     }),
                 ]
@@ -155,6 +165,7 @@ impl JobClaimFilter {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct JobDiscoveryConfig {
     worker_id: String,
+    protocol_versions: Vec<u32>,
     claim_filter: JobClaimFilter,
     poll_interval: Duration,
     lock_duration_seconds: u32,
@@ -180,6 +191,7 @@ impl JobDiscoveryConfig {
     pub fn new(worker_id: impl Into<String>, claim_filter: JobClaimFilter) -> Self {
         Self {
             worker_id: worker_id.into(),
+            protocol_versions: vec![0],
             claim_filter,
             poll_interval: DEFAULT_JOB_DISCOVERY_POLL_INTERVAL,
             lock_duration_seconds: DEFAULT_JOB_DISCOVERY_LOCK_DURATION_SECONDS,
@@ -200,6 +212,26 @@ impl JobDiscoveryConfig {
     /// Returns the requested claim lock duration in seconds.
     pub const fn lock_duration_seconds(&self) -> u32 {
         self.lock_duration_seconds
+    }
+
+    /// Returns the proof protocol versions announced by this worker.
+    pub fn protocol_versions(&self) -> &[u32] {
+        &self.protocol_versions
+    }
+
+    /// Sets the proof protocol versions announced by this worker.
+    ///
+    /// An empty list is normalized to `[0]` so a misconfigured worker claims legacy jobs rather
+    /// than silently claiming everything or nothing.
+    pub fn with_protocol_versions(mut self, protocol_versions: impl Into<Vec<u32>>) -> Self {
+        let mut protocol_versions = protocol_versions.into();
+        protocol_versions.sort_unstable();
+        protocol_versions.dedup();
+        if protocol_versions.is_empty() {
+            protocol_versions.push(0);
+        }
+        self.protocol_versions = protocol_versions;
+        self
     }
 
     /// Sets the delay after empty or failed discovery attempts.
@@ -242,6 +274,7 @@ impl JobDiscoveryConfig {
     ) -> impl Iterator<Item = GetNextProofRequest> {
         self.claim_filter.get_next_proof_requests_starting_at(
             self.worker_id.clone(),
+            self.protocol_versions.clone(),
             self.lock_duration_seconds,
             proof_type_offset,
         )
@@ -640,7 +673,7 @@ mod tests {
         ProofJob {
             session_id: session_id.clone(),
             status: ProofJobStatus::Claimed,
-            request: ProofRequest { session_id, request },
+            request: ProofRequest { session_id, protocol_version: 7, request },
             attempt: 1,
             lock_id: Some("lock-1".to_string()),
             worker_id: Some("worker-1".to_string()),
@@ -667,6 +700,7 @@ mod tests {
             vec![ZkVm::Sp1],
             vec![ZkBackend::Cluster, ZkBackend::Network],
         )
+        .with_protocol_versions(vec![7, 8])
         .with_lock_duration_seconds(30)
         .with_max_concurrent_jobs(0);
 
@@ -674,12 +708,14 @@ mod tests {
 
         assert_eq!(requests.len(), 2);
         assert_eq!(requests[0].worker_id, "worker-a");
+        assert_eq!(requests[0].protocol_versions, vec![7, 8]);
         assert_eq!(requests[0].proof_type, ProofType::Compressed);
         assert!(requests[0].tee_kinds.is_empty());
         assert_eq!(requests[0].zk_vms, vec![ZkVm::Sp1]);
         assert_eq!(requests[0].zk_backends, vec![ZkBackend::Cluster, ZkBackend::Network]);
         assert_eq!(requests[0].lock_duration_seconds, 30);
         assert_eq!(requests[1].worker_id, "worker-a");
+        assert_eq!(requests[1].protocol_versions, vec![7, 8]);
         assert_eq!(requests[1].proof_type, ProofType::SnarkPlonk);
         assert!(requests[1].tee_kinds.is_empty());
         assert_eq!(requests[1].zk_vms, vec![ZkVm::Sp1]);
@@ -691,6 +727,7 @@ mod tests {
     #[test]
     fn config_builds_nitro_claim_request() {
         let config = JobDiscoveryConfig::tee("worker-a", vec![TeeKind::AwsNitro])
+            .with_protocol_versions(vec![9])
             .with_lock_duration_seconds(45);
 
         let requests = config.get_next_proof_requests().collect::<Vec<_>>();
@@ -698,10 +735,28 @@ mod tests {
         let request = &requests[0];
 
         assert_eq!(request.worker_id, "worker-a");
+        assert_eq!(request.protocol_versions, vec![9]);
         assert_eq!(request.proof_type, ProofType::Tee);
         assert_eq!(request.tee_kinds, vec![TeeKind::AwsNitro]);
         assert!(request.zk_vms.is_empty());
         assert_eq!(request.lock_duration_seconds, 45);
+    }
+
+    #[test]
+    fn config_normalizes_announced_protocol_versions() {
+        let config = JobDiscoveryConfig::tee("worker-a", vec![TeeKind::AwsNitro]);
+
+        assert_eq!(config.protocol_versions(), [0], "default announces legacy only");
+        assert_eq!(
+            config.clone().with_protocol_versions(vec![3, 1, 3]).protocol_versions(),
+            [1, 3],
+            "duplicates are collapsed and order is stable"
+        );
+        assert_eq!(
+            config.with_protocol_versions(Vec::new()).protocol_versions(),
+            [0],
+            "an empty list must not claim everything or nothing"
+        );
     }
 
     #[tokio::test]

--- a/crates/proof/worker/src/proof_submitter.rs
+++ b/crates/proof/worker/src/proof_submitter.rs
@@ -441,6 +441,7 @@ mod tests {
             status: ProofJobStatus::Succeeded,
             request: ProofRequest {
                 session_id: request.session_id.clone(),
+                protocol_version: 1,
                 request: ProofRequestKind::Compressed(ZkProofRequest {
                     start_block_number: 1,
                     number_of_blocks_to_prove: 1,

--- a/etc/systems/benches/b20_zk_proving.rs
+++ b/etc/systems/benches/b20_zk_proving.rs
@@ -66,6 +66,9 @@ pub struct B20ZkProvingConfig {
     /// Prover-service requester JSON-RPC URL.
     #[arg(long, default_value = "http://localhost:9000")]
     pub zk_prover_url: Url,
+    /// Prover-service routing version required by the benchmark proof.
+    #[arg(long, env = "PROVER_PROTOCOL_VERSION")]
+    pub protocol_version: u32,
     /// Local benchmark L2 chain ID.
     #[arg(long, default_value_t = 84538453)]
     pub l2_chain_id: u64,
@@ -172,6 +175,7 @@ impl B20ZkProvingBench {
                 safe_l2_poll_interval: config.block_poll_interval,
                 proof_timeout: config.proof_timeout,
                 proof_poll_interval: config.proof_poll_interval,
+                protocol_version: config.protocol_version,
             },
             &display,
         )

--- a/etc/systems/benches/common/zk_proof.rs
+++ b/etc/systems/benches/common/zk_proof.rs
@@ -34,6 +34,8 @@ pub struct ZkProofBenchConfig {
     pub proof_timeout: Duration,
     /// Polling interval while waiting for proof completion.
     pub proof_poll_interval: Duration,
+    /// Prover-service routing version required by the proof job.
+    pub protocol_version: u32,
 }
 
 impl ZkProofBench {
@@ -60,8 +62,7 @@ impl ZkProofBench {
             first_block_number,
             last_block_number,
             l1_head,
-            config.proof_timeout,
-            config.proof_poll_interval,
+            config,
             display,
         )
         .await
@@ -99,8 +100,7 @@ impl ZkProofBench {
         first_block_number: u64,
         last_block_number: u64,
         l1_head: B256,
-        proof_timeout: Duration,
-        poll_interval: Duration,
+        config: ZkProofBenchConfig,
         display: &BenchDisplay,
     ) -> Result<ExecutionStats> {
         ensure!(
@@ -119,6 +119,7 @@ impl ZkProofBench {
             .prove_block_range(ProveBlockRangeRequest {
                 proof: ProofRequest {
                     session_id,
+                    protocol_version: config.protocol_version,
                     request: ProofRequestKind::Compressed(ZkProofRequest {
                         start_block_number,
                         number_of_blocks_to_prove,
@@ -141,8 +142,8 @@ impl ZkProofBench {
         Self::poll_dry_run_stats(
             &client,
             response.session_id,
-            proof_timeout,
-            poll_interval,
+            config.proof_timeout,
+            config.proof_poll_interval,
             display,
         )
         .await


### PR DESCRIPTION
> **Stack 2/4** — base: [#4382](https://github.com/base/base/pull/4382) · then ZK, then Nitro. **Planning only; not for merge yet.**

## Summary

The core of N-version routing. **Every piece is inert until a second version is configured:** routing version `0` remains the compatibility default, workers announce `[0]`, and every live fingerprint initially maps to `0` — so deploying this changes no behaviour.

- **`protocol_version` is opaque.** It does not encode schedule semantics; route `0` may carry activated-prefix jobs. This is what lets old workers continue claiming the inert Phase B deployment.
- **`protocol_version` becomes a claim dimension.** Persisted as `request_protocol_version` (migration `018`); both claim queries match `= ANY($versions)` *inside* the existing atomic `FOR UPDATE SKIP LOCKED`. There is no dispatcher — a worker physically cannot take a job it did not announce.
- **Workers announce a list.** Absent or empty means `[0]`, so a pre-versioning binary keeps working unchanged.
- **The challenger fails closed.** An unmapped fingerprint or a full-schedule-era game is skipped, never routed to a guess, each behind its own counter so an alert can fire.
- **Migration 018 creates its replacement indexes before dropping the originals**, so claim queries never run uncovered.

## Why full-schedule games are skipped rather than routed

They commit a `scheduleId` snapshotted at game creation, which no request field can express — reproducing it needs the historical rollup-config snapshot. Routing one would produce a journal that can only fail on-chain *after* a full proof run. The test fixture maps that fingerprint to a version, so this was reachable, not theoretical.

## Deliberately not here

`ProofRequest.image_hash` does not exist on `main` (removed in #4321 as having "no production reader"). Restoring it belongs with the Nitro change that reads it — PR 4 of this stack. `CandidateGame.tee_image_hash` already carries the value, so that PR is a small wiring change.

## Validation

`cargo test` across challenger, proposer, prover-service, db, protocol, client, worker, contracts, and basectl-cli. The follow-up moved the Nitro test initializer into this PR so this stack layer compiles independently, and removed the incorrect `version 0 => no schedule pin` validation. Postgres integration tests exist for the claim predicate but are `#[ignore]` without a database.

## Blockers before this can deploy

1. **The fingerprint→version mapping must exist.** `--proof-protocol-version` is required; PR 1's `basectl proofs protocol` produces it, and it has not yet been run against a real chain.
2. **Config Service** needs `BASE_CHALLENGER_PROOF_PROTOCOL_VERSION` and `BASE_PROPOSER_PROOF_PROTOCOL_VERSION` before the new binaries roll, or those pods fail to start.