### PR TITLE
feat(nitro): select the enclave a game's verifier will accept

### DIFF
--- a/bin/prover/nitro-host/README.md
+++ b/bin/prover/nitro-host/README.md
@@ -15,14 +15,15 @@ Worker mode is the only supported runtime mode:
 cargo build --package base-prover-nitro-host
 ```
 
-It requires `PROVER_SERVICE_ENDPOINT` and claims AWS Nitro TEE jobs through the
-prover-service worker API.
+It requires `PROVER_SERVICE_ENDPOINT` and `PROVER_PROTOCOL_VERSION`, and claims only matching AWS
+Nitro TEE jobs through the prover-service worker API.
 
 For local worker development, enable the `local` feature and use `local`:
 
 ```bash
 cargo run --package base-prover-nitro-host --features local -- local \
   --prover-service-endpoint "$PROVER_SERVICE_ENDPOINT" \
+  --protocol-version "$PROVER_PROTOCOL_VERSION" \
   --l1-eth-url "$L1_ETH_URL" \
   --l2-eth-url "$L2_ETH_URL" \
   --l2-node-url "$L2_NODE_URL" \

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -164,6 +164,14 @@ struct WorkerArgs {
     #[arg(long, env = "PROVER_SERVICE_ENDPOINT")]
     prover_service_endpoint: String,
 
+    /// Proof protocol versions claimed by this worker deployment.
+    ///
+    /// Repeatable or comma-separated. A fleet serves every version its enclaves' registered image
+    /// satisfies, which is usually more than one: the challenger fingerprint mixes TEE and ZK
+    /// commitments, so a ZK-only program rotation mints a new version for an unchanged enclave.
+    #[arg(long, env = "PROVER_PROTOCOL_VERSION", value_delimiter = ',', num_args = 1..)]
+    protocol_version: Vec<u32>,
+
     /// Prover-service JSON-RPC request timeout in seconds.
     #[arg(long, env = "PROVER_SERVICE_REQUEST_TIMEOUT_SECS", default_value_t = 60)]
     prover_service_request_timeout_secs: u64,
@@ -360,6 +368,7 @@ async fn run_worker(
     );
     let worker_id = format!("nitro-host-{}", Uuid::new_v4());
     let host = NitroHost::new(client, Arc::new(pool), worker_id.clone(), heartbeat)
+        .with_protocol_versions(worker.protocol_version.clone())
         .with_poll_interval(Duration::from_millis(worker.job_discovery_poll_interval_ms))
         .with_lock_duration_seconds(worker.job_discovery_lock_duration_seconds)
         .with_max_concurrent_jobs(worker.job_discovery_max_concurrent_jobs);
@@ -381,6 +390,7 @@ async fn run_worker(
         WorkerTransportMode::Vsock => {
             info!(
                 worker_id = %worker_id,
+                protocol_versions = ?worker.protocol_version,
                 prover_service_endpoint = %worker.prover_service_endpoint,
                 enclave_count,
                 "starting nitro prover host worker"
@@ -390,6 +400,7 @@ async fn run_worker(
         WorkerTransportMode::Local => {
             info!(
                 worker_id = %worker_id,
+                protocol_versions = ?worker.protocol_version,
                 prover_service_endpoint = %worker.prover_service_endpoint,
                 enclave_count,
                 "starting nitro prover host worker (local mode)"

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -167,8 +167,8 @@ struct WorkerArgs {
     /// Proof protocol versions claimed by this worker deployment.
     ///
     /// Repeatable or comma-separated. A fleet serves every version its enclaves' registered image
-    /// satisfies, which is usually more than one: the challenger fingerprint mixes TEE and ZK
-    /// commitments, so a ZK-only program rotation mints a new version for an unchanged enclave.
+    /// satisfies. The fingerprint still mixes TEE and ZK hashes, so a ZK-only program rotation
+    /// mints a new version for an unchanged enclave.
     #[arg(long, env = "PROVER_PROTOCOL_VERSION", value_delimiter = ',', num_args = 1..)]
     protocol_version: Vec<u32>,
 

--- a/crates/proof/challenge/src/proof_adapter.rs
+++ b/crates/proof/challenge/src/proof_adapter.rs
@@ -242,6 +242,7 @@ mod tests {
             proposer: Address::repeat_byte(0x04),
             intermediate_block_interval: 300,
             l1_head_number: 1200,
+            image_hash: B256::repeat_byte(0x06),
             schedule_l2_block_number: None,
         };
         let session_id = ChallengerProofAdapter::tee_session_id(game_address, invalid_index);
@@ -272,6 +273,7 @@ mod tests {
             proposer: Address::repeat_byte(0x05),
             intermediate_block_interval: 300,
             l1_head_number: 1200,
+            image_hash: B256::repeat_byte(0x06),
             schedule_l2_block_number: Some(600),
         };
 

--- a/crates/proof/challenge/src/proof_manager.rs
+++ b/crates/proof/challenge/src/proof_manager.rs
@@ -300,9 +300,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
             proposer,
             intermediate_block_interval: candidate.intermediate_block_interval,
             l1_head_number,
-            // `image_hash` is deliberately not set here. `ProofRequest` has no such field on main
-            // (#4321 removed it), and restoring it belongs with the Nitro image-selection change
-            // that reads it. `CandidateGame.tee_image_hash` already carries the value.
+            image_hash: candidate.tee_image_hash,
             schedule_l2_block_number: (candidate.schedule_kind == ProofScheduleKind::Activated)
                 .then_some(candidate.info.l2_block_number),
         })

--- a/crates/proof/contracts/src/tee_prover_registry.rs
+++ b/crates/proof/contracts/src/tee_prover_registry.rs
@@ -3,7 +3,7 @@
 //! Used by the registrar to manage signer registration and deregistration,
 //! and by the proposer to validate signers before on-chain submission.
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256};
 use alloy_provider::RootProvider;
 use alloy_sol_types::sol;
 use async_trait::async_trait;
@@ -54,6 +54,9 @@ sol! {
         /// whether its image hash matches the current expected value.
         function isRegisteredSigner(address signer) external view returns (bool);
 
+        /// Returns the Nitro image hash recorded when the signer registered.
+        function signerImageHash(address signer) external view returns (bytes32);
+
         /// Returns all currently registered signer addresses.
         function getRegisteredSigners() external view returns (address[]);
     }
@@ -69,6 +72,9 @@ pub trait TEEProverRegistryClient: Send + Sync {
     /// Returns `true` if `signer` has been registered, regardless of whether
     /// its image hash matches the current expected value.
     async fn is_registered_signer(&self, signer: Address) -> Result<bool, ContractError>;
+
+    /// Returns the Nitro image hash recorded when the signer registered.
+    async fn signer_image_hash(&self, signer: Address) -> Result<B256, ContractError>;
 
     /// Fetches the complete set of registered signer addresses.
     async fn get_registered_signers(&self) -> Result<Vec<Address>, ContractError>;
@@ -102,6 +108,13 @@ impl TEEProverRegistryClient for TEEProverRegistryContractClient {
         contract_call!(
             self.contract.isRegisteredSigner(signer).call(),
             format!("isRegisteredSigner({signer})")
+        )
+    }
+
+    async fn signer_image_hash(&self, signer: Address) -> Result<B256, ContractError> {
+        contract_call!(
+            self.contract.signerImageHash(signer).call(),
+            format!("signerImageHash({signer})")
         )
     }
 

--- a/crates/proof/primitives/src/proof.rs
+++ b/crates/proof/primitives/src/proof.rs
@@ -72,6 +72,20 @@ pub struct ProofRequest {
     /// L1 head block number without an extra lookup.
     #[cfg_attr(feature = "serde", serde(default))]
     pub l1_head_number: u64,
+    /// Keccak256 hash of the enclave PCR0 measurement this proof must be signed under.
+    ///
+    /// Set from the disputed game's own `TEE_IMAGE_HASH`, so it names the image that game will
+    /// accept rather than whichever image is current. `NitroEnclavePool` selects a registered
+    /// enclave whose on-chain `signerImageHash` matches, and fails the job when none does.
+    ///
+    /// This mirrors `TEEVerifier.verify`, which compares `signerImageHash(signer)` against the
+    /// calling game's `TEE_IMAGE_HASH`: without it, a host holding enclaves of more than one image
+    /// can spend a full proof run before the mismatch surfaces as an on-chain revert.
+    ///
+    /// Zero means "no expectation", which is what proposal proofs send — the proposer creates
+    /// games at the current image, so any registered enclave that can serve them is correct.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub image_hash: B256,
     /// L2 block used to pin the upgrade schedule; defaults to the claimed block.
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub schedule_l2_block_number: Option<u64>,

--- a/crates/proof/proposer/src/proof_adapter.rs
+++ b/crates/proof/proposer/src/proof_adapter.rs
@@ -97,6 +97,7 @@ mod tests {
             proposer: Address::repeat_byte(0x04),
             intermediate_block_interval: 300,
             l1_head_number: 1200,
+            image_hash: B256::ZERO,
             schedule_l2_block_number: None,
         }
     }

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -111,6 +111,10 @@ impl ProofDispatcher {
             proposer: self.config.proposer_address,
             intermediate_block_interval: self.config.intermediate_block_interval,
             l1_head_number: l1_header.number,
+            // Proposals are always created at the current image, so they pin none: any registered
+            // enclave can serve them. Only the challenger, which disputes games created under
+            // possibly-retired images, names one.
+            image_hash: B256::ZERO,
             schedule_l2_block_number: None,
         })
     }

--- a/crates/proof/prover-service/protocol/src/types.rs
+++ b/crates/proof/prover-service/protocol/src/types.rs
@@ -661,6 +661,7 @@ mod tests {
                 proposer: address!("0000000000000000000000000000000000000006"),
                 intermediate_block_interval: 7,
                 l1_head_number: 8,
+                image_hash: B256::repeat_byte(9),
                 schedule_l2_block_number: None,
             },
             tee_kind: TeeKind::AwsNitro,
@@ -680,6 +681,7 @@ mod tests {
                     "proposer": "0x0000000000000000000000000000000000000006",
                     "intermediate_block_interval": 7,
                     "l1_head_number": 8,
+                    "image_hash": format!("{:#x}", B256::repeat_byte(9)),
                 },
                 "tee_kind": "aws_nitro",
             })
@@ -822,6 +824,7 @@ mod tests {
             proposer: address!("0000000000000000000000000000000000000006"),
             intermediate_block_interval: 7,
             l1_head_number: 8,
+            image_hash: B256::repeat_byte(9),
             schedule_l2_block_number: None,
         };
 
@@ -838,6 +841,7 @@ mod tests {
                 "proposer": "0x0000000000000000000000000000000000000006",
                 "intermediate_block_interval": 7,
                 "l1_head_number": 8,
+                "image_hash": format!("{:#x}", B256::repeat_byte(9)),
             })
         );
     }

--- a/crates/proof/succinct/utils/host/src/fetcher.rs
+++ b/crates/proof/succinct/utils/host/src/fetcher.rs
@@ -812,6 +812,8 @@ impl OPSuccinctDataFetcher {
             l1_head_number,
             // We don't need to set the proposer for the range proof zk program
             proposer: Address::ZERO,
+            // ZK range proofs are not enclave-signed, so there is no image to pin.
+            image_hash: B256::ZERO,
             schedule_l2_block_number,
         };
 

--- a/crates/proof/tee/nitro-host/src/host.rs
+++ b/crates/proof/tee/nitro-host/src/host.rs
@@ -41,6 +41,13 @@ impl<Client> NitroHost<Client> {
         self
     }
 
+    /// Sets the proof protocol versions announced by this worker.
+    #[must_use]
+    pub fn with_protocol_versions(mut self, protocol_versions: impl Into<Vec<u32>>) -> Self {
+        self.discovery = self.discovery.with_protocol_versions(protocol_versions);
+        self
+    }
+
     /// Sets the requested claim lock duration in seconds.
     #[must_use]
     pub fn with_lock_duration_seconds(mut self, lock_duration_seconds: u32) -> Self {

--- a/crates/proof/tee/nitro-host/src/pool.rs
+++ b/crates/proof/tee/nitro-host/src/pool.rs
@@ -2,6 +2,7 @@
 
 use std::{fmt, sync::Arc};
 
+use alloy_primitives::B256;
 use base_proof_host::{ProverConfig, ProverError, ProverService};
 use base_proof_primitives::{ProofRequest, ProofResult};
 use thiserror::Error;
@@ -105,7 +106,7 @@ impl NitroEnclavePool {
     /// Proves one request using the busy-enclave policy.
     pub async fn prove(&self, request: ProofRequest) -> Result<ProofResult, NitroEnclavePoolError> {
         let l2_block = request.claimed_l2_block_number;
-        let (enclave, _permit) = self.acquire_enclave(l2_block).await?;
+        let (enclave, _permit) = self.acquire_enclave(l2_block, request.image_hash).await?;
 
         enclave.service.prove_block(request).await.map_err(NitroEnclavePoolError::Prover)
     }
@@ -113,10 +114,11 @@ impl NitroEnclavePool {
     async fn acquire_enclave(
         &self,
         l2_block: u64,
+        image_hash: B256,
     ) -> Result<(&EnclaveService, OwnedSemaphorePermit), NitroEnclavePoolError> {
         let candidate_indices: Vec<usize> = match &self.checker {
             Some(checker) => checker
-                .select_all_valid_enclaves()
+                .select_enclaves_for_image(image_hash)
                 .await
                 .map_err(NitroEnclavePoolError::Registration)?
                 .into_iter()
@@ -256,7 +258,7 @@ mod tests {
     async fn prove_permit_is_released_when_handle_dropped() {
         let pool = test_pool();
 
-        let (_enclave, permit) = pool.acquire_enclave(0).await.unwrap();
+        let (_enclave, permit) = pool.acquire_enclave(0, B256::ZERO).await.unwrap();
         assert_eq!(pool.enclaves[0].prove_permit.available_permits(), 0);
 
         drop(permit);
@@ -311,7 +313,8 @@ mod tests {
 
         let _held = Arc::clone(&pool.enclaves[0].prove_permit).try_acquire_owned().unwrap();
 
-        let (enclave, _permit) = pool.acquire_enclave(0).await.expect("fall-through to enclave[1]");
+        let (enclave, _permit) =
+            pool.acquire_enclave(0, B256::ZERO).await.expect("fall-through to enclave[1]");
         assert!(
             Arc::ptr_eq(&enclave.transport, &pool.enclaves[1].transport),
             "expected enclave[1] selected via fall-through"
@@ -332,7 +335,8 @@ mod tests {
 
         let _held = Arc::clone(&pool.enclaves[0].prove_permit).try_acquire_owned().unwrap();
 
-        let (enclave, _permit) = pool.acquire_enclave(0).await.expect("fall-through to enclave[1]");
+        let (enclave, _permit) =
+            pool.acquire_enclave(0, B256::ZERO).await.expect("fall-through to enclave[1]");
         assert!(
             Arc::ptr_eq(&enclave.transport, &pool.enclaves[1].transport),
             "expected enclave[1] selected via fall-through without registration checker"

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -276,13 +276,14 @@ where
             return true;
         };
 
-        match checker.select_all_valid_enclaves().await {
-            Ok(valid) => {
-                debug!(
-                    valid_signer_count = valid.len(),
-                    "registration gate passed for nitro job claim"
-                );
+        match checker.has_registered_enclave().await {
+            Ok(true) => {
+                debug!("registration gate passed for nitro job claim");
                 true
+            }
+            Ok(false) => {
+                warn!("no registered enclave signer; skipping nitro job claim");
+                false
             }
             Err(error) => {
                 warn!(

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -18,7 +18,7 @@
 
 use std::{sync::Arc, time::Duration};
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256};
 use base_proof_contracts::{TEEProverRegistryClient, TEEProverRegistryContractClient};
 use thiserror::Error;
 use tokio::sync::OnceCell;
@@ -60,6 +60,14 @@ pub enum RegistrationError {
     #[error("no valid signer found among: {signers:?}")]
     NoValidSigner {
         /// The signer addresses that were checked.
+        signers: Vec<Address>,
+    },
+    /// No registered enclave signer matches the proof request's image hash.
+    #[error("no registered signer for image {image_hash} found among: {signers:?}")]
+    NoMatchingImage {
+        /// Image hash required by the proof request.
+        image_hash: B256,
+        /// Enclave signer addresses that were inspected.
         signers: Vec<Address>,
     },
 }
@@ -145,6 +153,89 @@ impl RegistrationChecker {
         }
     }
 
+    /// Returns whether `signer` is registered, independent of the current factory image.
+    pub async fn is_registered_signer(&self, signer: Address) -> Result<bool, RegistrationError> {
+        match tokio::time::timeout(CHECK_TIMEOUT, self.registry.is_registered_signer(signer)).await
+        {
+            Ok(Ok(registered)) => Ok(registered),
+            Ok(Err(e)) => Err(RegistrationError::Rpc { signer, reason: e.to_string() }),
+            Err(_) => Err(RegistrationError::Rpc { signer, reason: "request timed out".into() }),
+        }
+    }
+
+    /// Returns the Nitro image hash recorded for `signer`.
+    pub async fn signer_image_hash(&self, signer: Address) -> Result<B256, RegistrationError> {
+        match tokio::time::timeout(CHECK_TIMEOUT, self.registry.signer_image_hash(signer)).await {
+            Ok(Ok(image_hash)) => Ok(image_hash),
+            Ok(Err(e)) => Err(RegistrationError::Rpc { signer, reason: e.to_string() }),
+            Err(_) => Err(RegistrationError::Rpc { signer, reason: "request timed out".into() }),
+        }
+    }
+
+    /// Returns whether at least one configured enclave signer is registered.
+    pub async fn has_registered_enclave(&self) -> Result<bool, RegistrationError> {
+        for transport in &self.transports {
+            let signer = Self::signer_address(transport).await?;
+            if self.is_registered_signer(signer).await? {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    /// Returns every registered enclave whose attested image matches `image_hash`.
+    ///
+    /// `B256::ZERO` means the request states no expectation and any registered enclave will do.
+    /// Proposal proofs take that path: the proposer creates games at the current image, so it has
+    /// nothing historical to pin. Only the challenger, which disputes games created under images
+    /// that may since have been retired, names one.
+    pub async fn select_enclaves_for_image(
+        &self,
+        image_hash: B256,
+    ) -> Result<Vec<ValidSigner>, RegistrationError> {
+        let mut valid = Vec::new();
+        let mut discovered = Vec::new();
+        let mut first_rpc_error = None;
+
+        for (index, transport) in self.transports.iter().enumerate() {
+            let signer = match Self::signer_address(transport).await {
+                Ok(signer) => signer,
+                Err(error) => {
+                    warn!(error = %error, index, "skipping transport: key fetch failed");
+                    continue;
+                }
+            };
+            discovered.push(signer);
+
+            let matches = async {
+                Ok::<_, RegistrationError>(
+                    self.is_registered_signer(signer).await?
+                        && (image_hash.is_zero()
+                            || self.signer_image_hash(signer).await? == image_hash),
+                )
+            }
+            .await;
+            match matches {
+                Ok(true) => valid.push(ValidSigner { index, signer }),
+                Ok(false) => {
+                    warn!(signer = %signer, index, %image_hash, "signer does not match proof image");
+                }
+                Err(error) => {
+                    warn!(error = %error, signer = %signer, index, "signer image lookup failed");
+                    first_rpc_error.get_or_insert(error);
+                }
+            }
+        }
+
+        if !valid.is_empty() {
+            Ok(valid)
+        } else if let Some(error) = first_rpc_error {
+            Err(error)
+        } else {
+            Err(RegistrationError::NoMatchingImage { image_hash, signers: discovered })
+        }
+    }
+
     async fn fetch_validity(&self) -> Result<bool, RegistrationError> {
         let mut first_rpc_error = None;
 
@@ -157,10 +248,10 @@ impl RegistrationChecker {
                 }
             };
 
-            match self.is_valid_signer(signer).await {
+            match self.is_registered_signer(signer).await {
                 Ok(true) => return Ok(true),
                 Ok(false) => {
-                    warn!(signer = %signer, index, "signer not valid in TEEProverRegistry");
+                    warn!(signer = %signer, index, "signer not registered in TEEProverRegistry");
                 }
                 Err(e) => {
                     first_rpc_error.get_or_insert(e);
@@ -315,6 +406,31 @@ mod tests {
     async fn health_returns_false_when_not_valid() {
         let checker = test_checker_with_mock(MockRegistry::new(false));
         assert!(!checker.check_health().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn image_selection_matches_registered_signer_image() {
+        let image = B256::repeat_byte(7);
+        let checker = test_checker_with_mock(MockRegistry::new(true).with_image_hash(image));
+
+        assert_eq!(checker.select_enclaves_for_image(image).await.unwrap().len(), 1);
+        assert!(
+            matches!(
+                checker.select_enclaves_for_image(B256::repeat_byte(1)).await.unwrap_err(),
+                RegistrationError::NoMatchingImage { .. }
+            ),
+            "an enclave attested under a different image must not serve the request"
+        );
+    }
+
+    /// A zero image hash states no expectation, so any registered enclave serves it. This is the
+    /// proposal-proof path, which pins no historical image.
+    #[tokio::test]
+    async fn image_selection_treats_zero_as_unconstrained() {
+        let checker =
+            test_checker_with_mock(MockRegistry::new(true).with_image_hash(B256::repeat_byte(7)));
+
+        assert_eq!(checker.select_enclaves_for_image(B256::ZERO).await.unwrap().len(), 1);
     }
 
     #[tokio::test]

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -174,6 +174,7 @@ impl RegistrationChecker {
 
     /// Returns whether at least one configured enclave signer is registered.
     pub async fn has_registered_enclave(&self) -> Result<bool, RegistrationError> {
+        let mut first_rpc_error = None;
         for (index, transport) in self.transports.iter().enumerate() {
             let signer = match Self::signer_address(transport).await {
                 Ok(signer) => signer,
@@ -182,11 +183,16 @@ impl RegistrationChecker {
                     continue;
                 }
             };
-            if self.is_registered_signer(signer).await? {
-                return Ok(true);
+            match self.is_registered_signer(signer).await {
+                Ok(true) => return Ok(true),
+                Ok(false) => {}
+                Err(error) => {
+                    warn!(error = %error, signer = %signer, index, "registration check failed");
+                    first_rpc_error.get_or_insert(error);
+                }
             }
         }
-        Ok(false)
+        first_rpc_error.map_or(Ok(false), Err)
     }
 
     /// Returns every registered enclave whose attested image matches `image_hash`.
@@ -224,7 +230,12 @@ impl RegistrationChecker {
             match matches {
                 Ok(true) => valid.push(ValidSigner { index, signer }),
                 Ok(false) => {
-                    warn!(signer = %signer, index, %image_hash, "signer does not match proof image");
+                    warn!(
+                        signer = %signer,
+                        index,
+                        %image_hash,
+                        "signer is unregistered or does not match proof image"
+                    );
                 }
                 Err(error) => {
                     warn!(error = %error, signer = %signer, index, "signer image lookup failed");
@@ -425,6 +436,17 @@ mod tests {
                 .await
                 .unwrap()
         );
+    }
+
+    #[tokio::test]
+    async fn claim_gate_continues_after_one_registry_error() {
+        let registry = AddressBasedMockRegistry::new(HashMap::new());
+        let checker = two_transport_checker(registry.clone());
+        let (first, second) = two_transport_signers(&checker).await;
+        registry.validity_map.lock().expect("validity map poisoned").insert(second, true);
+        registry.fail_signers.lock().expect("fail signers poisoned").insert(first);
+
+        assert!(checker.has_registered_enclave().await.unwrap());
     }
 
     #[tokio::test]

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -174,8 +174,14 @@ impl RegistrationChecker {
 
     /// Returns whether at least one configured enclave signer is registered.
     pub async fn has_registered_enclave(&self) -> Result<bool, RegistrationError> {
-        for transport in &self.transports {
-            let signer = Self::signer_address(transport).await?;
+        for (index, transport) in self.transports.iter().enumerate() {
+            let signer = match Self::signer_address(transport).await {
+                Ok(signer) => signer,
+                Err(error) => {
+                    warn!(error = %error, index, "skipping transport: key fetch failed");
+                    continue;
+                }
+            };
             if self.is_registered_signer(signer).await? {
                 return Ok(true);
             }
@@ -406,6 +412,19 @@ mod tests {
     async fn health_returns_false_when_not_valid() {
         let checker = test_checker_with_mock(MockRegistry::new(false));
         assert!(!checker.check_health().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn claim_gate_requires_a_registered_enclave() {
+        assert!(
+            test_checker_with_mock(MockRegistry::new(true)).has_registered_enclave().await.unwrap()
+        );
+        assert!(
+            !test_checker_with_mock(MockRegistry::new(false))
+                .has_registered_enclave()
+                .await
+                .unwrap()
+        );
     }
 
     #[tokio::test]

--- a/crates/proof/tee/nitro-host/src/test_utils.rs
+++ b/crates/proof/tee/nitro-host/src/test_utils.rs
@@ -8,7 +8,7 @@ use std::{
     },
 };
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256};
 use base_proof_contracts::TEEProverRegistryClient;
 use jsonrpsee::core::async_trait;
 
@@ -23,6 +23,8 @@ pub struct MockRegistry {
     pub call_count: Arc<AtomicUsize>,
     /// When `true`, `is_valid_signer` returns a [`ContractError::Validation`] error.
     pub should_fail: Arc<AtomicBool>,
+    /// Image hash reported by `signer_image_hash` for every signer.
+    pub image_hash: Arc<Mutex<B256>>,
 }
 
 impl MockRegistry {
@@ -32,7 +34,14 @@ impl MockRegistry {
             valid: Arc::new(AtomicBool::new(valid)),
             call_count: Arc::new(AtomicUsize::new(0)),
             should_fail: Arc::new(AtomicBool::new(false)),
+            image_hash: Arc::new(Mutex::new(B256::ZERO)),
         }
+    }
+
+    /// Sets the image hash reported for every signer.
+    pub fn with_image_hash(self, image_hash: B256) -> Self {
+        *self.image_hash.lock().expect("image_hash lock poisoned") = image_hash;
+        self
     }
 }
 
@@ -51,9 +60,16 @@ impl TEEProverRegistryClient for MockRegistry {
 
     async fn is_registered_signer(
         &self,
-        _signer: Address,
+        signer: Address,
     ) -> Result<bool, base_proof_contracts::ContractError> {
-        unimplemented!()
+        self.is_valid_signer(signer).await
+    }
+
+    async fn signer_image_hash(
+        &self,
+        _signer: Address,
+    ) -> Result<B256, base_proof_contracts::ContractError> {
+        Ok(*self.image_hash.lock().expect("image_hash lock poisoned"))
     }
 
     async fn get_registered_signers(
@@ -107,9 +123,16 @@ impl TEEProverRegistryClient for AddressBasedMockRegistry {
 
     async fn is_registered_signer(
         &self,
-        _signer: Address,
+        signer: Address,
     ) -> Result<bool, base_proof_contracts::ContractError> {
-        unimplemented!()
+        self.is_valid_signer(signer).await
+    }
+
+    async fn signer_image_hash(
+        &self,
+        _signer: Address,
+    ) -> Result<B256, base_proof_contracts::ContractError> {
+        Ok(B256::ZERO)
     }
 
     async fn get_registered_signers(

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -733,6 +733,13 @@ mod tests {
             }
         }
 
+        async fn signer_image_hash(
+            &self,
+            _signer: Address,
+        ) -> std::result::Result<B256, base_proof_contracts::ContractError> {
+            Ok(B256::ZERO)
+        }
+
         async fn get_registered_signers(
             &self,
         ) -> std::result::Result<Vec<Address>, base_proof_contracts::ContractError> {


### PR DESCRIPTION
> **Stack 4/4** — base: [#4393](https://github.com/base/base/pull/4393). **Planning only; not for merge yet.**

## Summary

Makes a Nitro host holding enclaves of more than one image prove each job on the enclave *that game* can accept.

`#4321` removed `ProofRequest.image_hash` as having "no production reader." **This is that reader.** The challenger sets it from the disputed game's own `TEE_IMAGE_HASH`, and `select_enclaves_for_image` picks a registered enclave whose on-chain `signerImageHash` matches, failing the job when none does.

That mirrors `TEEVerifier.verify`, which compares exactly that pair against the calling game's `TEE_IMAGE_HASH`. Without it the host spends a full proof run before the mismatch comes back as an on-chain revert.

**Zero means "no expectation"** and matches any registered enclave. Proposals take that path — they create games at the current image, so they pin nothing. Only the challenger, disputing games created under possibly-retired images, names one.

## Two fixes that make old games provable at all

- **The claim gate moves from `is_valid_signer` to `is_registered_signer`.** The former compares against the factory's *current* image, so it would reject a still-registered old-image signer — precisely the one an old game needs.
- **The challenger was sending `image_hash: Default::default()`** (zero) and pinning `schedule_l2_block_number` unconditionally. It now sends the game's real image hash and pins the schedule only for the activated-prefix era.

`--protocol-version` accepts a comma-separated list here, because one enclave image can satisfy several versions: the fingerprint mixes TEE and ZK commitments, so a ZK-only rotation mints a version for an unchanged image.

## Validation

`cargo test` passes across primitives, nitro-host (including image selection, zero-is-unconstrained, and the registered-enclave claim gate), challenger, proposer, and protocol. The claim gate now tries every enclave when signer-key fetches or registry RPCs fail, instead of blocking healthy siblings after the first transient error. `base-proof-tee-registrar` could not be built locally — `risc0-sys` fails on this machine — so its mock update is compile-checked only in CI.

## Blockers before this can deploy

1. **Pairs with [base-proofs#415](https://coinbase.ghe.com/protocols/base-proofs/pull/415)**, which supplies the pinned per-image fleet. Neither is useful alone.
2. **`entrypoint-host.sh` will hard-require `PROVER_PROTOCOL_VERSION` and `L2_NODE_URL`.** Both fleets deploy the same host image, so Config Service needs them for the *primary* fleet too or it crashloops on next promotion.
3. **Untested in reality:** no signer has registered from a pinned fleet, and the registrar's orphan pass has never run with two fleets on one target group.
