### PR TITLE
fix(eip8130): mark no_std phase-status clear/take as const fn

### DIFF
--- a/crates/common/evm/Cargo.toml
+++ b/crates/common/evm/Cargo.toml
@@ -52,6 +52,7 @@ sha2 = { workspace = true, default-features = false }
 alloy-hardforks.workspace = true
 alloy-sol-types = { workspace = true, default-features = false }
 alloy-primitives = { workspace = true, default-features = false }
+base-precompile-storage = { workspace = true, features = ["test-utils"] }
 serde_json = { workspace = true, default-features = false, features = ["alloc", "preserve_order"] }
 
 [features]

--- a/crates/common/evm/src/eip8130_phase_statuses.rs
+++ b/crates/common/evm/src/eip8130_phase_statuses.rs
@@ -53,10 +53,17 @@ impl Eip8130PhaseStatuses {
     /// value leaked by an earlier transaction (e.g. a panic caught between a prior
     /// [`Self::set`] and its [`Self::take`]) can never be misattributed to the
     /// current transaction's receipt. No-op in `no_std` builds.
+    #[cfg(feature = "std")]
     pub fn clear() {
-        #[cfg(feature = "std")]
         PHASE_STATUSES.with(|cell| cell.borrow_mut().clear());
     }
+
+    /// Clears any statuses left in the slot, called at the start of `execute` so a
+    /// value leaked by an earlier transaction (e.g. a panic caught between a prior
+    /// [`Self::set`] and its [`Self::take`]) can never be misattributed to the
+    /// current transaction's receipt. No-op in `no_std` builds.
+    #[cfg(not(feature = "std"))]
+    pub const fn clear() {}
 
     /// Records the per-phase statuses of the EIP-8130 transaction just executed
     /// on this thread, to be consumed by the next [`Self::take`] when its receipt
@@ -80,14 +87,15 @@ impl Eip8130PhaseStatuses {
 
     /// Takes (and clears) the per-phase statuses recorded by the most recent
     /// [`Self::set`] on this thread. Returns an empty vector in `no_std` builds.
+    #[cfg(feature = "std")]
     pub fn take() -> Vec<u8> {
-        #[cfg(feature = "std")]
-        {
-            PHASE_STATUSES.with(|cell| core::mem::take(&mut *cell.borrow_mut()))
-        }
-        #[cfg(not(feature = "std"))]
-        {
-            Vec::new()
-        }
+        PHASE_STATUSES.with(|cell| core::mem::take(&mut *cell.borrow_mut()))
+    }
+
+    /// Takes (and clears) the per-phase statuses recorded by the most recent
+    /// [`Self::set`] on this thread. Returns an empty vector in `no_std` builds.
+    #[cfg(not(feature = "std"))]
+    pub const fn take() -> Vec<u8> {
+        Vec::new()
     }
 }


### PR DESCRIPTION
Split Eip8130PhaseStatuses::clear/take on cfg(feature = "std") and mark the no_std versions const fn. Clippy's missing_const_for_fn only fires in the no_std build, where those methods are a no-op / Vec::new(); this unblocks clippy on base-common-evm without std. Behavior is unchanged.