### PR TITLE
fix(upgrades): reject stale runtime schedules

### DIFF
--- a/crates/common/genesis/src/chain/mod.rs
+++ b/crates/common/genesis/src/chain/mod.rs
@@ -5,8 +5,8 @@ pub use addresses::AddressList;
 
 mod upgrade;
 pub use upgrade::{
-    BaseUpgrade, BaseUpgradeConfig, RuntimeUpgradeRegistry, UpgradeActivation,
-    UpgradeActivationOverrides, UpgradeActivationSink, UpgradeConfig,
+    BaseUpgrade, BaseUpgradeConfig, RuntimeUpgradeRegistry, RuntimeUpgradeRegistryEntry,
+    UpgradeActivation, UpgradeActivationOverrides, UpgradeActivationSink, UpgradeConfig,
 };
 
 mod roles;

--- a/crates/common/genesis/src/chain/upgrade.rs
+++ b/crates/common/genesis/src/chain/upgrade.rs
@@ -351,8 +351,11 @@ pub trait UpgradeActivationSink {
     ) -> Result<bool, Self::Error>;
 
     /// Finalizes the target after a batch of activations (e.g. recompute derived state).
-    fn finalize(&mut self) -> Result<(), Self::Error> {
-        Ok(())
+    ///
+    /// Returns `true` when the target committed the batch and `false` when it rejected the batch
+    /// without error.
+    fn finalize(&mut self) -> Result<bool, Self::Error> {
+        Ok(true)
     }
 }
 
@@ -405,6 +408,15 @@ impl UpgradeActivationOverrides {
     }
 }
 
+/// Versioned runtime upgrade activation overrides for one chain.
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
+pub struct RuntimeUpgradeRegistryEntry {
+    /// Runtime upgrade activation overrides.
+    pub overrides: UpgradeActivationOverrides,
+    /// Latest L1 block number whose schedule was applied to the overrides.
+    pub last_updated_block_number: Option<u64>,
+}
+
 /// Process-local runtime upgrade activation registry.
 ///
 /// The runtime upgrade signal treats the L1 contract as the authoritative source for these
@@ -418,37 +430,68 @@ pub struct RuntimeUpgradeRegistry;
 
 impl RuntimeUpgradeRegistry {
     /// Returns the global runtime upgrade activation registry.
-    fn registry() -> &'static RwLock<BTreeMap<u64, UpgradeActivationOverrides>> {
-        static REGISTRY: Once<RwLock<BTreeMap<u64, UpgradeActivationOverrides>>> = Once::new();
+    fn registry() -> &'static RwLock<BTreeMap<u64, RuntimeUpgradeRegistryEntry>> {
+        static REGISTRY: Once<RwLock<BTreeMap<u64, RuntimeUpgradeRegistryEntry>>> = Once::new();
         REGISTRY.call_once(|| RwLock::new(BTreeMap::new()))
     }
 
     /// Returns a registry read guard.
-    fn read_registry() -> RwLockReadGuard<'static, BTreeMap<u64, UpgradeActivationOverrides>> {
+    fn read_registry() -> RwLockReadGuard<'static, BTreeMap<u64, RuntimeUpgradeRegistryEntry>> {
         Self::registry().read()
     }
 
     /// Returns a registry write guard.
-    fn write_registry() -> RwLockWriteGuard<'static, BTreeMap<u64, UpgradeActivationOverrides>> {
+    fn write_registry() -> RwLockWriteGuard<'static, BTreeMap<u64, RuntimeUpgradeRegistryEntry>> {
         Self::registry().write()
     }
 
     /// Returns the runtime activation override for a chain and contract upgrade ID.
     pub fn activation(chain_id: u64, upgrade_id: BaseUpgrade) -> Option<UpgradeActivation> {
-        Self::read_registry().get(&chain_id).and_then(|overrides| overrides.activation(upgrade_id))
+        Self::read_registry()
+            .get(&chain_id)
+            .and_then(|entry| entry.overrides.activation(upgrade_id))
     }
 
     /// Returns all runtime activation overrides for a chain.
     pub fn overrides(chain_id: u64) -> Option<UpgradeActivationOverrides> {
-        Self::read_registry().get(&chain_id).cloned()
+        Self::read_registry().get(&chain_id).map(|entry| entry.overrides.clone())
     }
 
-    /// Replaces all runtime activation overrides for a chain.
-    pub fn replace_overrides(chain_id: u64, overrides: UpgradeActivationOverrides) {
-        Self::write_registry().insert(chain_id, overrides);
+    /// Returns the latest L1 block number whose schedule was applied for a chain.
+    pub fn last_updated_block_number(chain_id: u64) -> Option<u64> {
+        Self::read_registry().get(&chain_id).and_then(|entry| entry.last_updated_block_number)
     }
 
-    /// Clears all runtime activation overrides for a chain.
+    /// Replaces all runtime activation overrides unless their L1 block predates stored state.
+    ///
+    /// The ordering check and replacement happen under one write lock so concurrent refreshes
+    /// cannot overwrite a newer schedule with an older one. Returns `true` when the overrides were
+    /// replaced and `false` when a stale schedule was rejected.
+    pub fn replace_overrides(
+        chain_id: u64,
+        l1_block_number: u64,
+        overrides: UpgradeActivationOverrides,
+    ) -> bool {
+        let mut registry = Self::write_registry();
+        if registry
+            .get(&chain_id)
+            .and_then(|entry| entry.last_updated_block_number)
+            .is_some_and(|last_updated| l1_block_number < last_updated)
+        {
+            return false;
+        }
+
+        registry.insert(
+            chain_id,
+            RuntimeUpgradeRegistryEntry {
+                overrides,
+                last_updated_block_number: Some(l1_block_number),
+            },
+        );
+        true
+    }
+
+    /// Clears all runtime activation overrides and their L1 block watermark for a chain.
     pub fn clear_chain(chain_id: u64) {
         Self::write_registry().remove(&chain_id);
     }
@@ -456,18 +499,18 @@ impl RuntimeUpgradeRegistry {
     /// Removes one runtime activation override for a chain and contract upgrade ID.
     pub fn remove_activation_override(chain_id: u64, upgrade_id: BaseUpgrade) -> bool {
         let mut registry = Self::write_registry();
-        let Some(overrides) = registry.get_mut(&chain_id) else {
+        let Some(entry) = registry.get_mut(&chain_id) else {
             return false;
         };
 
-        overrides.remove_activation(upgrade_id)
+        entry.overrides.remove_activation(upgrade_id)
     }
 
     /// Sets one runtime activation override for a chain and contract upgrade ID.
     pub fn set_activation(chain_id: u64, upgrade_id: BaseUpgrade, activation: UpgradeActivation) {
         let mut registry = Self::write_registry();
-        let overrides = registry.entry(chain_id).or_default();
-        overrides.set_activation(upgrade_id, activation)
+        let entry = registry.entry(chain_id).or_default();
+        entry.overrides.set_activation(upgrade_id, activation)
     }
 
     /// Sets one runtime timestamp activation override for a chain and contract upgrade ID.
@@ -489,13 +532,13 @@ impl RuntimeUpgradeRegistry {
         impl Drop for ZenithActivationGuard {
             fn drop(&mut self) {
                 let mut registry = RuntimeUpgradeRegistry::write_registry();
-                let overrides = registry.entry(self.chain_id).or_default();
+                let entry = registry.entry(self.chain_id).or_default();
                 if let Some(previous) = self.previous {
-                    overrides.activations.insert(BaseUpgrade::Zenith, previous);
+                    entry.overrides.activations.insert(BaseUpgrade::Zenith, previous);
                 } else {
-                    overrides.activations.remove(&BaseUpgrade::Zenith);
+                    entry.overrides.activations.remove(&BaseUpgrade::Zenith);
                 }
-                if self.remove_chain_if_empty && overrides.is_empty() {
+                if self.remove_chain_if_empty && entry.overrides.is_empty() {
                     registry.remove(&self.chain_id);
                 }
             }
@@ -503,9 +546,12 @@ impl RuntimeUpgradeRegistry {
 
         let mut registry = Self::write_registry();
         let remove_chain_if_empty = !registry.contains_key(&chain_id);
-        let overrides = registry.entry(chain_id).or_default();
-        let previous = overrides.activation(BaseUpgrade::Zenith);
-        overrides.activations.insert(BaseUpgrade::Zenith, UpgradeActivation::Timestamp(timestamp));
+        let entry = registry.entry(chain_id).or_default();
+        let previous = entry.overrides.activation(BaseUpgrade::Zenith);
+        entry
+            .overrides
+            .activations
+            .insert(BaseUpgrade::Zenith, UpgradeActivation::Timestamp(timestamp));
         ZenithActivationGuard { chain_id, previous, remove_chain_if_empty }
     }
 

--- a/crates/common/genesis/src/lib.rs
+++ b/crates/common/genesis/src/lib.rs
@@ -29,8 +29,9 @@ pub use system::{
 
 mod chain;
 pub use chain::{
-    AddressList, BaseUpgrade, BaseUpgradeConfig, Roles, RuntimeUpgradeRegistry, UpgradeActivation,
-    UpgradeActivationOverrides, UpgradeActivationSink, UpgradeConfig,
+    AddressList, BaseUpgrade, BaseUpgradeConfig, Roles, RuntimeUpgradeRegistry,
+    RuntimeUpgradeRegistryEntry, UpgradeActivation, UpgradeActivationOverrides,
+    UpgradeActivationSink, UpgradeConfig,
 };
 
 mod genesis;

--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -726,13 +726,13 @@ mod tests {
 
     fn upgrade_schedule(signals: &[(BaseUpgrade, u64)]) -> UpgradeSignalSchedule {
         UpgradeSignalSchedule::new(
+            1,
             signals
                 .iter()
                 .map(|(upgrade_id, activation_timestamp)| base_upgrade_signal::UpgradeSignal {
                     upgrade_id: *upgrade_id,
                     activation_timestamp: *activation_timestamp,
                     protocol_version: U256::from(7),
-                    l1_block_number: 1,
                 })
                 .collect(),
         )

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -477,9 +477,9 @@ impl UpgradeActivationSink for BaseChainSpec {
         }
     }
 
-    fn finalize(&mut self) -> Result<(), Self::Error> {
+    fn finalize(&mut self) -> Result<bool, Self::Error> {
         self.refresh_genesis_header();
-        Ok(())
+        Ok(true)
     }
 }
 

--- a/crates/execution/cli/src/upgrade_signal.rs
+++ b/crates/execution/cli/src/upgrade_signal.rs
@@ -223,23 +223,25 @@ mod tests {
         upgrade_id: BaseUpgrade,
         activation_timestamp: u64,
     ) -> UpgradeSignalSchedule {
-        UpgradeSignalSchedule::new(vec![base_upgrade_signal::UpgradeSignal {
-            upgrade_id,
-            activation_timestamp,
-            protocol_version: UpgradeSignalDefaults::node_protocol_version(),
-            l1_block_number: 1,
-        }])
+        UpgradeSignalSchedule::new(
+            1,
+            vec![base_upgrade_signal::UpgradeSignal {
+                upgrade_id,
+                activation_timestamp,
+                protocol_version: UpgradeSignalDefaults::node_protocol_version(),
+            }],
+        )
     }
 
     fn schedule(signals: &[(BaseUpgrade, u64)]) -> UpgradeSignalSchedule {
         UpgradeSignalSchedule::new(
+            1,
             signals
                 .iter()
                 .map(|(upgrade_id, activation_timestamp)| base_upgrade_signal::UpgradeSignal {
                     upgrade_id: *upgrade_id,
                     activation_timestamp: *activation_timestamp,
                     protocol_version: Default::default(),
-                    l1_block_number: 1,
                 })
                 .collect(),
         )

--- a/crates/utilities/upgrade-signal/src/config/schedule.rs
+++ b/crates/utilities/upgrade-signal/src/config/schedule.rs
@@ -171,7 +171,7 @@ impl UpgradeSignalConfig {
                 activation_timestamp = signal.activation_timestamp,
                 minimum_protocol_version = %signal.protocol_version,
                 node_protocol_version = %self.node_protocol_version,
-                l1_block_number = signal.l1_block_number,
+                l1_block_number = schedule.l1_block_number,
                 "read dynamic upgrade signal"
             );
         }
@@ -221,12 +221,7 @@ mod tests {
     }
 
     fn signal(protocol_version: U256) -> UpgradeSignal {
-        UpgradeSignal {
-            upgrade_id: BaseUpgrade::Azul,
-            activation_timestamp: 42,
-            protocol_version,
-            l1_block_number: 1,
-        }
+        UpgradeSignal { upgrade_id: BaseUpgrade::Azul, activation_timestamp: 42, protocol_version }
     }
 
     #[test]
@@ -260,15 +255,17 @@ mod tests {
     }
 
     fn malformed_schedule(config: &UpgradeSignalConfig) -> UpgradeSignalSchedule {
-        UpgradeSignalSchedule::new(vec![
-            signal(config.node_protocol_version),
-            UpgradeSignal {
-                upgrade_id: BaseUpgrade::Beryl,
-                activation_timestamp: 5,
-                protocol_version: U256::ZERO,
-                l1_block_number: 1,
-            },
-        ])
+        UpgradeSignalSchedule::new(
+            1,
+            vec![
+                signal(config.node_protocol_version),
+                UpgradeSignal {
+                    upgrade_id: BaseUpgrade::Beryl,
+                    activation_timestamp: 5,
+                    protocol_version: U256::ZERO,
+                },
+            ],
+        )
     }
 
     #[test]
@@ -286,20 +283,21 @@ mod tests {
     fn schedule_validation_rejects_unsupported_protocol_version() {
         let config = supported_config();
 
-        let schedule = UpgradeSignalSchedule::new(vec![
-            UpgradeSignal {
-                upgrade_id: BaseUpgrade::Azul,
-                activation_timestamp: 42,
-                protocol_version: config.node_protocol_version,
-                l1_block_number: 1,
-            },
-            UpgradeSignal {
-                upgrade_id: BaseUpgrade::Beryl,
-                activation_timestamp: 42,
-                protocol_version: config.node_protocol_version + U256::from(1),
-                l1_block_number: 1,
-            },
-        ]);
+        let schedule = UpgradeSignalSchedule::new(
+            1,
+            vec![
+                UpgradeSignal {
+                    upgrade_id: BaseUpgrade::Azul,
+                    activation_timestamp: 42,
+                    protocol_version: config.node_protocol_version,
+                },
+                UpgradeSignal {
+                    upgrade_id: BaseUpgrade::Beryl,
+                    activation_timestamp: 42,
+                    protocol_version: config.node_protocol_version + U256::from(1),
+                },
+            ],
+        );
 
         assert!(matches!(
             config.validate_schedule_protocol_versions(&schedule).unwrap_err(),
@@ -314,12 +312,14 @@ mod tests {
         #[case] upgrade_id: &str,
     ) {
         let config = UpgradeSignalConfig::new(address!("0000000000000000000000000000000000000001"));
-        let schedule = UpgradeSignalSchedule::new(vec![UpgradeSignal {
-            upgrade_id: upgrade(upgrade_id),
-            activation_timestamp: 0,
-            protocol_version: config.node_protocol_version + U256::from(1),
-            l1_block_number: 1,
-        }]);
+        let schedule = UpgradeSignalSchedule::new(
+            1,
+            vec![UpgradeSignal {
+                upgrade_id: upgrade(upgrade_id),
+                activation_timestamp: 0,
+                protocol_version: config.node_protocol_version + U256::from(1),
+            }],
+        );
 
         assert!(config.validate_schedule_protocol_versions(&schedule).is_ok());
     }

--- a/crates/utilities/upgrade-signal/src/contract.rs
+++ b/crates/utilities/upgrade-signal/src/contract.rs
@@ -158,11 +158,10 @@ impl AlloyUpgradeSignalReader {
                 upgrade_id: *upgrade_id,
                 activation_timestamp: *activation_timestamp,
                 protocol_version: minimum_protocol_version,
-                l1_block_number,
             })
             .collect();
 
-        UpgradeSignalSchedule::new(signals)
+        UpgradeSignalSchedule::new(l1_block_number, signals)
     }
 
     /// Reads the full contract-backed upgrade signal schedule.
@@ -227,21 +226,21 @@ impl AlloyUpgradeSignalReader {
 
     /// Reads the schedule, tolerating read failures.
     ///
-    /// Records `l1_read_errors_total` and returns an empty schedule when the read fails. Intended
-    /// for the live metrics poller, which must not abort the node because a schedule read failed.
+    /// Records `l1_read_errors_total` and returns `None` when the read fails. Intended for the live
+    /// metrics poller, which must not abort the node because a schedule read failed.
     pub async fn read_schedule_tolerant(
         &self,
         metrics_layers: &[UpgradeSignalMetricLayer],
-    ) -> UpgradeSignalSchedule {
+    ) -> Option<UpgradeSignalSchedule> {
         match self.read_schedule(metrics_layers).await {
-            Ok(schedule) => schedule,
+            Ok(schedule) => Some(schedule),
             Err(error) => {
                 warn!(
                     target: "upgrade_signal",
                     error = %error,
                     "failed to read live L1 upgrade signal schedule"
                 );
-                UpgradeSignalSchedule::default()
+                None
             }
         }
     }
@@ -267,13 +266,8 @@ mod tests {
             signals(&schedule),
             vec![(BaseUpgrade::Regolith, 10), (BaseUpgrade::Canyon, 20), (BaseUpgrade::Delta, 0)]
         );
-        assert!(
-            schedule
-                .signals
-                .iter()
-                .all(|signal| signal.protocol_version == U256::from(7)
-                    && signal.l1_block_number == 99)
-        );
+        assert!(schedule.signals.iter().all(|signal| signal.protocol_version == U256::from(7)));
+        assert_eq!(schedule.l1_block_number, 99);
     }
 
     #[test]

--- a/crates/utilities/upgrade-signal/src/metrics.rs
+++ b/crates/utilities/upgrade-signal/src/metrics.rs
@@ -53,7 +53,7 @@ impl UpgradeSignalMetrics {
     pub fn record_schedule(layer: UpgradeSignalMetricLayer, schedule: &UpgradeSignalSchedule) {
         Self::init();
         for signal in &schedule.signals {
-            Self::record_signal(layer, signal);
+            Self::record_signal(layer, schedule.l1_block_number, signal);
         }
     }
 
@@ -69,7 +69,11 @@ impl UpgradeSignalMetrics {
     }
 
     /// Records all metrics derived from a successfully read signal.
-    pub fn record_signal(layer: UpgradeSignalMetricLayer, signal: &UpgradeSignal) {
+    pub fn record_signal(
+        layer: UpgradeSignalMetricLayer,
+        l1_block_number: u64,
+        signal: &UpgradeSignal,
+    ) {
         Self::init();
         let layer = layer.label();
         let upgrade_id = signal.upgrade_id.contract_id().to_string();
@@ -78,7 +82,7 @@ impl UpgradeSignalMetrics {
             .set(signal.activation_timestamp as f64);
         Self::expected_protocol_version(layer, upgrade_id.clone())
             .set(Self::protocol_version_to_f64(signal.protocol_version));
-        Self::last_l1_read_block(layer, upgrade_id).set(signal.l1_block_number as f64);
+        Self::last_l1_read_block(layer, upgrade_id).set(l1_block_number as f64);
     }
 
     /// Records failed L1 reads for all contract-backed upgrades.

--- a/crates/utilities/upgrade-signal/src/runtime/refresher.rs
+++ b/crates/utilities/upgrade-signal/src/runtime/refresher.rs
@@ -1,5 +1,4 @@
 use alloy_provider::RootProvider;
-use tracing::info;
 
 use super::{UpgradeSignalApplySummary, UpgradeSignalRuntimeApplier};
 use crate::{
@@ -42,16 +41,7 @@ impl UpgradeSignalRefresher {
     ) -> Result<UpgradeSignalApplySummary, UpgradeSignalError> {
         self.config.validate_schedule_protocol_versions(schedule)?;
         let summary = UpgradeSignalRuntimeApplier::apply_schedule(self.chain_id, schedule);
-        info!(
-            target: "upgrade_signal",
-            chain_id = summary.chain_id,
-            l1_block_number = ?summary.l1_block_number,
-            applied_upgrades = summary.applied_upgrades,
-            cleared_upgrades = summary.cleared_upgrades,
-            ignored_upgrades = summary.ignored_upgrades,
-            configured_upgrades = summary.configured_upgrades,
-            "applied runtime upgrade signal schedule"
-        );
+        summary.log("runtime registry");
 
         Ok(summary)
     }
@@ -92,12 +82,10 @@ mod tests {
         activation_timestamp: u64,
         protocol_version: U256,
     ) -> UpgradeSignalSchedule {
-        UpgradeSignalSchedule::new(vec![UpgradeSignal {
-            upgrade_id,
-            activation_timestamp,
-            protocol_version,
-            l1_block_number: 1,
-        }])
+        UpgradeSignalSchedule::new(
+            1,
+            vec![UpgradeSignal { upgrade_id, activation_timestamp, protocol_version }],
+        )
     }
 
     #[test]

--- a/crates/utilities/upgrade-signal/src/runtime/sink.rs
+++ b/crates/utilities/upgrade-signal/src/runtime/sink.rs
@@ -94,7 +94,9 @@ impl UpgradeSignalRuntimeApplier {
         }
 
         summary.committed = staged_sink.finalize()?;
-        *sink = staged_sink;
+        if summary.committed {
+            *sink = staged_sink;
+        }
 
         Ok(summary)
     }

--- a/crates/utilities/upgrade-signal/src/runtime/sink.rs
+++ b/crates/utilities/upgrade-signal/src/runtime/sink.rs
@@ -7,18 +7,20 @@ use super::{UpgradeSignalApplyAction, UpgradeSignalApplyChange, UpgradeSignalApp
 use crate::UpgradeSignalSchedule;
 
 /// Upgrade activation sink backed by the process-local runtime registry for one chain.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct RuntimeRegistrySink {
     /// L2 chain ID whose runtime upgrade view is mutated.
     pub chain_id: u64,
+    /// L1 block number used to read the buffered schedule.
+    pub l1_block_number: u64,
     /// Buffered updates to apply to the runtime registry at finalize time.
     pub updates: UpgradeActivationOverrides,
 }
 
 impl RuntimeRegistrySink {
     /// Creates a runtime registry sink for one chain.
-    pub const fn new(chain_id: u64) -> Self {
-        Self { chain_id, updates: UpgradeActivationOverrides::new() }
+    pub const fn new(chain_id: u64, l1_block_number: u64) -> Self {
+        Self { chain_id, l1_block_number, updates: UpgradeActivationOverrides::new() }
     }
 }
 
@@ -38,18 +40,12 @@ impl UpgradeActivationSink for RuntimeRegistrySink {
         Ok(true)
     }
 
-    fn finalize(&mut self) -> Result<(), Self::Error> {
+    fn finalize(&mut self) -> Result<bool, Self::Error> {
         let updates = core::mem::take(&mut self.updates);
 
         // The runtime registry mirrors the latest authoritative L1 schedule for this chain, so a
         // refresh replaces the chain's entire override set instead of merging into prior state.
-        if updates.is_empty() {
-            RuntimeUpgradeRegistry::clear_chain(self.chain_id);
-        } else {
-            RuntimeUpgradeRegistry::replace_overrides(self.chain_id, updates);
-        }
-
-        Ok(())
+        Ok(RuntimeUpgradeRegistry::replace_overrides(self.chain_id, self.l1_block_number, updates))
     }
 }
 
@@ -93,11 +89,11 @@ impl UpgradeSignalRuntimeApplier {
                 action,
                 activation_timestamp: signal.activation_timestamp,
                 minimum_protocol_version: signal.protocol_version.to_string(),
-                l1_block_number: signal.l1_block_number,
+                l1_block_number: schedule.l1_block_number,
             });
         }
 
-        staged_sink.finalize()?;
+        summary.committed = staged_sink.finalize()?;
         *sink = staged_sink;
 
         Ok(summary)
@@ -108,7 +104,7 @@ impl UpgradeSignalRuntimeApplier {
         chain_id: u64,
         schedule: &UpgradeSignalSchedule,
     ) -> UpgradeSignalApplySummary {
-        let mut sink = RuntimeRegistrySink::new(chain_id);
+        let mut sink = RuntimeRegistrySink::new(chain_id, schedule.l1_block_number);
         Self::apply_schedule_to_sink(chain_id, schedule, &mut sink)
             .unwrap_or_else(|never| match never {})
     }
@@ -124,18 +120,22 @@ mod tests {
     use super::{RuntimeRegistrySink, UpgradeSignalRuntimeApplier};
     use crate::{UpgradeSignal, UpgradeSignalSchedule};
 
-    fn schedule(signals: &[(BaseUpgrade, u64)]) -> UpgradeSignalSchedule {
+    fn schedule_at(l1_block_number: u64, signals: &[(BaseUpgrade, u64)]) -> UpgradeSignalSchedule {
         UpgradeSignalSchedule::new(
+            l1_block_number,
             signals
                 .iter()
                 .map(|(upgrade_id, activation_timestamp)| UpgradeSignal {
                     upgrade_id: *upgrade_id,
                     activation_timestamp: *activation_timestamp,
                     protocol_version: U256::from(7),
-                    l1_block_number: 11,
                 })
                 .collect(),
         )
+    }
+
+    fn schedule(signals: &[(BaseUpgrade, u64)]) -> UpgradeSignalSchedule {
+        schedule_at(11, signals)
     }
 
     #[test]
@@ -219,13 +219,13 @@ mod tests {
     fn runtime_registry_sink_only_flushes_in_finalize() {
         let chain_id = 9_000_008;
         RuntimeUpgradeRegistry::clear_chain(chain_id);
-        let mut sink = RuntimeRegistrySink::new(chain_id);
+        let mut sink = RuntimeRegistrySink::new(chain_id, 11);
 
         sink.apply_activation(BaseUpgrade::Azul, UpgradeActivation::Timestamp(42)).unwrap();
 
         assert_eq!(RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul), None);
 
-        sink.finalize().unwrap();
+        assert!(sink.finalize().unwrap());
 
         assert_eq!(
             RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul),
@@ -241,15 +241,91 @@ mod tests {
         RuntimeUpgradeRegistry::clear_chain(chain_id);
         RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Cobalt, 84);
 
-        let mut sink = RuntimeRegistrySink::new(chain_id);
+        let mut sink = RuntimeRegistrySink::new(chain_id, 11);
         sink.apply_activation(BaseUpgrade::Azul, UpgradeActivation::Timestamp(42)).unwrap();
-        sink.finalize().unwrap();
+        assert!(sink.finalize().unwrap());
 
         assert_eq!(
             RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul),
             Some(UpgradeActivation::Timestamp(42))
         );
         assert_eq!(RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Cobalt), None);
+
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+    }
+
+    #[test]
+    fn stale_schedule_does_not_replace_newer_runtime_overrides() {
+        let chain_id = 9_000_010;
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+
+        let newer_summary = UpgradeSignalRuntimeApplier::apply_schedule(
+            chain_id,
+            &schedule_at(101, &[(BaseUpgrade::Jovian, 200)]),
+        );
+        let stale_summary = UpgradeSignalRuntimeApplier::apply_schedule(
+            chain_id,
+            &schedule_at(100, &[(BaseUpgrade::Jovian, 100)]),
+        );
+
+        assert!(newer_summary.committed);
+        assert!(!stale_summary.committed);
+        assert_eq!(RuntimeUpgradeRegistry::last_updated_block_number(chain_id), Some(101));
+        assert_eq!(
+            RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Jovian),
+            Some(UpgradeActivation::Timestamp(200))
+        );
+
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+    }
+
+    #[test]
+    fn newer_schedule_replaces_older_runtime_overrides() {
+        let chain_id = 9_000_011;
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+
+        let older_summary = UpgradeSignalRuntimeApplier::apply_schedule(
+            chain_id,
+            &schedule_at(100, &[(BaseUpgrade::Jovian, 100)]),
+        );
+        let newer_summary = UpgradeSignalRuntimeApplier::apply_schedule(
+            chain_id,
+            &schedule_at(101, &[(BaseUpgrade::Jovian, 200)]),
+        );
+
+        assert!(older_summary.committed);
+        assert!(newer_summary.committed);
+        assert_eq!(RuntimeUpgradeRegistry::last_updated_block_number(chain_id), Some(101));
+        assert_eq!(
+            RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Jovian),
+            Some(UpgradeActivation::Timestamp(200))
+        );
+
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+    }
+
+    #[test]
+    fn empty_schedule_preserves_ordering_watermark() {
+        let chain_id = 9_000_012;
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+
+        UpgradeSignalRuntimeApplier::apply_schedule(
+            chain_id,
+            &schedule_at(100, &[(BaseUpgrade::Jovian, 200)]),
+        );
+        let empty_summary = UpgradeSignalRuntimeApplier::apply_schedule(
+            chain_id,
+            &UpgradeSignalSchedule::new(101, Vec::new()),
+        );
+        let stale_summary = UpgradeSignalRuntimeApplier::apply_schedule(
+            chain_id,
+            &schedule_at(100, &[(BaseUpgrade::Jovian, 100)]),
+        );
+
+        assert!(empty_summary.committed);
+        assert!(!stale_summary.committed);
+        assert_eq!(RuntimeUpgradeRegistry::last_updated_block_number(chain_id), Some(101));
+        assert_eq!(RuntimeUpgradeRegistry::overrides(chain_id), Some(Default::default()));
 
         RuntimeUpgradeRegistry::clear_chain(chain_id);
     }

--- a/crates/utilities/upgrade-signal/src/runtime/summary.rs
+++ b/crates/utilities/upgrade-signal/src/runtime/summary.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::UpgradeSignalSchedule;
 
@@ -35,6 +35,8 @@ pub struct UpgradeSignalApplyChange {
 pub struct UpgradeSignalApplySummary {
     /// L2 chain ID whose runtime upgrade view was updated.
     pub chain_id: u64,
+    /// Whether the destination committed the schedule.
+    pub committed: bool,
     /// L1 block number used for the contract read.
     pub l1_block_number: Option<u64>,
     /// Number of configured upgrade signals read from L1.
@@ -51,10 +53,11 @@ pub struct UpgradeSignalApplySummary {
 
 impl UpgradeSignalApplySummary {
     /// Creates an empty runtime application summary.
-    pub fn new(chain_id: u64, schedule: &UpgradeSignalSchedule) -> Self {
+    pub const fn new(chain_id: u64, schedule: &UpgradeSignalSchedule) -> Self {
         Self {
             chain_id,
-            l1_block_number: schedule.signals.iter().map(|signal| signal.l1_block_number).max(),
+            committed: true,
+            l1_block_number: Some(schedule.l1_block_number),
             configured_upgrades: schedule.signals.len(),
             applied_upgrades: 0,
             cleared_upgrades: 0,
@@ -67,6 +70,17 @@ impl UpgradeSignalApplySummary {
     ///
     /// `target` names the destination the schedule was applied to (e.g. "rollup config").
     pub fn log(&self, target: &'static str) {
+        if !self.committed {
+            warn!(
+                target: "upgrade_signal",
+                destination = target,
+                chain_id = self.chain_id,
+                l1_block_number = ?self.l1_block_number,
+                "ignored stale upgrade signal schedule"
+            );
+            return;
+        }
+
         for change in &self.changes {
             match change.action {
                 UpgradeSignalApplyAction::Applied => info!(

--- a/crates/utilities/upgrade-signal/src/state.rs
+++ b/crates/utilities/upgrade-signal/src/state.rs
@@ -17,8 +17,6 @@ pub struct UpgradeSignal {
     pub activation_timestamp: u64,
     /// Minimum node protocol version announced on L1.
     pub protocol_version: U256,
-    /// L1 block number used for the contract read.
-    pub l1_block_number: u64,
 }
 
 impl UpgradeSignal {
@@ -36,16 +34,18 @@ impl UpgradeSignal {
 }
 
 /// L1 upgrade signal values for a configured upgrade schedule.
-#[derive(Debug, Clone, Default, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct UpgradeSignalSchedule {
+    /// L1 block number used to read the complete schedule.
+    pub l1_block_number: u64,
     /// Signals read from L1.
     pub signals: Vec<UpgradeSignal>,
 }
 
 impl UpgradeSignalSchedule {
     /// Creates a new upgrade signal schedule.
-    pub const fn new(signals: Vec<UpgradeSignal>) -> Self {
-        Self { signals }
+    pub const fn new(l1_block_number: u64, signals: Vec<UpgradeSignal>) -> Self {
+        Self { l1_block_number, signals }
     }
 }
 
@@ -132,7 +132,7 @@ impl UpgradeSignalMonitor {
         reader: &AlloyUpgradeSignalReader,
     ) -> Option<UpgradeSignalSchedule> {
         let metrics_layers = [self.metrics_layer];
-        let schedule = reader.read_schedule_tolerant(&metrics_layers).await;
+        let schedule = reader.read_schedule_tolerant(&metrics_layers).await?;
         let updated_signals = self
             .update_schedule(schedule.clone())
             .iter()
@@ -155,13 +155,21 @@ impl UpgradeSignalMonitor {
         &mut self,
         schedule: UpgradeSignalSchedule,
     ) -> Vec<UpgradeSignalStateUpdate> {
-        schedule.signals.into_iter().map(|signal| self.update_signal(signal)).collect()
+        schedule
+            .signals
+            .into_iter()
+            .map(|signal| self.update_signal(schedule.l1_block_number, signal))
+            .collect()
     }
 
     /// Applies one signal read from L1 and records corresponding live metrics.
-    fn update_signal(&mut self, signal: UpgradeSignal) -> UpgradeSignalStateUpdate {
+    fn update_signal(
+        &mut self,
+        l1_block_number: u64,
+        signal: UpgradeSignal,
+    ) -> UpgradeSignalStateUpdate {
         let upgrade_id = signal.upgrade_id;
-        UpgradeSignalMetrics::record_signal(self.metrics_layer, &signal);
+        UpgradeSignalMetrics::record_signal(self.metrics_layer, l1_block_number, &signal);
 
         let update = self.states.entry(upgrade_id).or_default().update_signal(signal);
         if matches!(update, UpgradeSignalStateUpdate::Changed) {
@@ -183,7 +191,6 @@ mod tests {
             upgrade_id: BaseUpgrade::Azul,
             activation_timestamp: timestamp,
             protocol_version: U256::from(7),
-            l1_block_number: 1,
         }
     }
 
@@ -214,23 +221,12 @@ mod tests {
         assert_eq!(state.update_signal(signal(12)), UpgradeSignalStateUpdate::Changed);
     }
 
-    #[test]
-    fn l1_block_update_does_not_count_as_contract_value_change() {
-        let mut state = UpgradeSignalState::new();
-        let mut updated_signal = signal(10);
-
-        state.update_signal(signal(10));
-        updated_signal.l1_block_number = 2;
-
-        assert_eq!(state.update_signal(updated_signal), UpgradeSignalStateUpdate::Unchanged);
-    }
-
     fn monitor() -> UpgradeSignalMonitor {
         UpgradeSignalMonitor::new(UpgradeSignalMetricLayer::Consensus)
     }
 
     fn schedule(timestamp: u64) -> UpgradeSignalSchedule {
-        UpgradeSignalSchedule::new(vec![signal(timestamp)])
+        UpgradeSignalSchedule::new(1, vec![signal(timestamp)])
     }
 
     #[test]
@@ -257,6 +253,19 @@ mod tests {
 
         assert_eq!(
             monitor.update_schedule(schedule(10)),
+            vec![UpgradeSignalStateUpdate::Unchanged]
+        );
+    }
+
+    #[test]
+    fn monitor_ignores_l1_block_update_with_unchanged_contract_values() {
+        let mut monitor = monitor();
+
+        monitor.update_schedule(schedule(10));
+        let updated_schedule = UpgradeSignalSchedule::new(2, vec![signal(10)]);
+
+        assert_eq!(
+            monitor.update_schedule(updated_schedule),
             vec![UpgradeSignalStateUpdate::Unchanged]
         );
     }


### PR DESCRIPTION
## Summary

  Runtime upgrade-signal reads can complete out of order. Although registry writes are protected by an `RwLock`, a slower read from L1 block 100 could previously replace a schedule already applied from block 101.

  This PR adds a per-chain L1 block-number watermark and performs the ordering check and registry replacement under the same write lock. Schedules from lower L1 blocks are ignored, while equal or newer block numbers are accepted.

  ## Changes

  - Store the source L1 block number once on `UpgradeSignalSchedule`
  - Store `last_updated_block_number` alongside each chain's runtime overrides
  - Atomically reject runtime schedule updates older than the installed schedule
  - Preserve the block-number watermark when a newer empty schedule clears all overrides
  - Return `None` for tolerated L1 read failures instead of representing failures as empty schedules
  - Report stale applications as `committed: false` and emit a structured warning
  - Add regression coverage for stale rejection, forward updates, and empty-schedule watermark preservation


  ## Test plan

  - [x] `cargo test -p base-common-genesis -p base-upgrade-signal`
  - [x] `cargo check -p base-execution-cli -p base-consensus-cli -p base-consensus-node -p base-system-tests`
  - [x] `cargo clippy -p base-common-genesis -p base-upgrade-signal --all-targets --all-features -- -D warnings`
  - [x] `cargo fmt --all`
  - [x] `git diff --check`