### PR TITLE
chore(execution): remove compute pending block option

### DIFF
--- a/crates/execution/node/src/args.rs
+++ b/crates/execution/node/src/args.rs
@@ -349,17 +349,6 @@ pub struct RollupArgs {
     #[arg(long = "rollup.disable-tx-pool-gossip")]
     pub disable_txpool_gossip: bool,
 
-    /// By default the pending block equals the latest block
-    /// to save resources and not leak txs from the tx-pool,
-    /// this flag enables computing of the pending block
-    /// from the tx-pool instead.
-    ///
-    /// If `compute_pending_block` is not enabled, the payload builder
-    /// will use the payload attributes from the latest block. Note
-    /// that this flag is not yet functional.
-    #[arg(long = "rollup.compute-pending-block")]
-    pub compute_pending_block: bool,
-
     /// enables discovery v4 if provided
     #[arg(long = "rollup.discovery.v4", default_value = "false")]
     pub discovery_v4: bool,
@@ -517,7 +506,6 @@ impl Default for RollupArgs {
         Self {
             sequencer: None,
             disable_txpool_gossip: false,
-            compute_pending_block: false,
             discovery_v4: false,
             sequencer_headers: Vec::new(),
             min_suggested_priority_fee: 1_000_000,
@@ -568,15 +556,6 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_rollup_compute_pending_block_args() {
-        let expected_args = RollupArgs { compute_pending_block: true, ..Default::default() };
-        let args =
-            CommandParser::<RollupArgs>::parse_from(["reth", "--rollup.compute-pending-block"])
-                .args;
-        assert_eq!(args, expected_args);
-    }
-
-    #[test]
     fn test_parse_rollup_discovery_v4_args() {
         let expected_args = RollupArgs { discovery_v4: true, ..Default::default() };
         let args = CommandParser::<RollupArgs>::parse_from(["reth", "--rollup.discovery.v4"]).args;
@@ -609,14 +588,12 @@ mod tests {
     fn test_parse_rollup_many_args() {
         let expected_args = RollupArgs {
             disable_txpool_gossip: true,
-            compute_pending_block: true,
             sequencer: Some("http://host:port".into()),
             ..Default::default()
         };
         let args = CommandParser::<RollupArgs>::parse_from([
             "reth",
             "--rollup.disable-tx-pool-gossip",
-            "--rollup.compute-pending-block",
             "--rollup.sequencer-http",
             "http://host:port",
         ])

--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -1136,12 +1136,12 @@ where
                 ctx.provider().clone(),
                 evm_config,
                 BaseBuilderConfig {
-                    da_config: self.da_config.clone(),
-                    gas_limit_config: self.gas_limit_config.clone(),
+                    da_config: self.da_config,
+                    gas_limit_config: self.gas_limit_config,
                     manifest_precheck_enabled: self.manifest_precheck_enabled,
                 },
             )
-            .with_transactions(self.best_transactions.clone());
+            .with_transactions(self.best_transactions);
         Ok(payload_builder)
     }
 }

--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -247,7 +247,6 @@ impl BaseNode {
     {
         let RollupArgs {
             disable_txpool_gossip,
-            compute_pending_block,
             discovery_v4,
             txpool_ordering,
             max_inflight_delegated_slots,
@@ -275,7 +274,7 @@ impl BaseNode {
                     ),
             )
             .payload(BasicPayloadServiceBuilder::new(
-                BasePayloadBuilder::new(compute_pending_block)
+                BasePayloadBuilder::new()
                     .with_da_config(self.da_config.clone())
                     .with_gas_limit_config(self.gas_limit_config.clone()),
             ))
@@ -1029,15 +1028,6 @@ where
 /// A basic Base payload service builder
 #[derive(Debug, Clone)]
 pub struct BasePayloadBuilder<Txs = ()> {
-    /// By default the pending block equals the latest block
-    /// to save resources and not leak txs from the tx-pool,
-    /// this flag enables computing of the pending block
-    /// from the tx-pool instead.
-    ///
-    /// If `compute_pending_block` is not enabled, the payload builder
-    /// will use the payload attributes from the latest block. Note
-    /// that this flag is not yet functional.
-    pub compute_pending_block: bool,
     /// The type responsible for yielding the best transactions for the payload if mempool
     /// transactions are allowed.
     pub best_transactions: Txs,
@@ -1055,7 +1045,6 @@ pub struct BasePayloadBuilder<Txs = ()> {
 impl<Txs: Default> Default for BasePayloadBuilder<Txs> {
     fn default() -> Self {
         Self {
-            compute_pending_block: false,
             best_transactions: Txs::default(),
             da_config: BaseDAConfig::default(),
             gas_limit_config: GasLimitConfig::default(),
@@ -1065,11 +1054,9 @@ impl<Txs: Default> Default for BasePayloadBuilder<Txs> {
 }
 
 impl BasePayloadBuilder {
-    /// Create a new instance with the given `compute_pending_block` flag and data availability
-    /// config.
-    pub fn new(compute_pending_block: bool) -> Self {
+    /// Create a new instance with the default configuration.
+    pub fn new() -> Self {
         Self {
-            compute_pending_block,
             best_transactions: (),
             da_config: BaseDAConfig::default(),
             gas_limit_config: GasLimitConfig::default(),
@@ -1100,19 +1087,11 @@ impl<Txs> BasePayloadBuilder<Txs> {
     /// Configures the type responsible for yielding the transactions that should be included in the
     /// payload.
     pub fn with_transactions<T>(self, best_transactions: T) -> BasePayloadBuilder<T> {
-        let Self {
-            compute_pending_block,
-            da_config,
-            gas_limit_config,
-            manifest_precheck_enabled,
-            ..
-        } = self;
         BasePayloadBuilder {
-            compute_pending_block,
             best_transactions,
-            da_config,
-            gas_limit_config,
-            manifest_precheck_enabled,
+            da_config: self.da_config,
+            gas_limit_config: self.gas_limit_config,
+            manifest_precheck_enabled: self.manifest_precheck_enabled,
         }
     }
 }
@@ -1162,8 +1141,7 @@ where
                     manifest_precheck_enabled: self.manifest_precheck_enabled,
                 },
             )
-            .with_transactions(self.best_transactions.clone())
-            .set_compute_pending_block(self.compute_pending_block);
+            .with_transactions(self.best_transactions.clone());
         Ok(payload_builder)
     }
 }
@@ -1459,9 +1437,8 @@ mod tests {
 
     #[test]
     fn payload_builder_preserves_manifest_precheck_setting() {
-        let builder = BasePayloadBuilder::new(false)
-            .with_manifest_precheck_enabled(false)
-            .with_transactions(());
+        let builder =
+            BasePayloadBuilder::new().with_manifest_precheck_enabled(false).with_transactions(());
 
         assert!(!builder.manifest_precheck_enabled);
         assert!(BasePayloadBuilder::<()>::default().manifest_precheck_enabled);

--- a/crates/execution/node/src/proof_history.rs
+++ b/crates/execution/node/src/proof_history.rs
@@ -47,7 +47,6 @@ pub async fn launch_node_with_proof_history(
     let RollupArgs {
         sequencer,
         disable_txpool_gossip,
-        compute_pending_block,
         discovery_v4,
         sequencer_headers,
         min_suggested_priority_fee,
@@ -72,7 +71,6 @@ pub async fn launch_node_with_proof_history(
     let mut node_builder = builder.node(BaseNode::new(RollupArgs {
         sequencer,
         disable_txpool_gossip,
-        compute_pending_block,
         discovery_v4,
         sequencer_headers,
         min_suggested_priority_fee,

--- a/crates/execution/node/tests/it/priority.rs
+++ b/crates/execution/node/tests/it/priority.rs
@@ -93,15 +93,13 @@ fn build_components<Node>(
 where
     Node: FullNodeTypes<Types: BaseNodeTypes>,
 {
-    let RollupArgs { disable_txpool_gossip, compute_pending_block, discovery_v4, .. } =
-        RollupArgs::default();
+    let RollupArgs { disable_txpool_gossip, discovery_v4, .. } = RollupArgs::default();
     ComponentsBuilder::default()
         .node_types::<Node>()
         .pool(BasePoolBuilder::default())
         .executor(BaseExecutorBuilder::default())
         .payload(BasicPayloadServiceBuilder::new(
-            BasePayloadBuilder::new(compute_pending_block)
-                .with_transactions(CustomTxPriority { chain_id }),
+            BasePayloadBuilder::new().with_transactions(CustomTxPriority { chain_id }),
         ))
         .network(BaseNetworkBuilder::new(disable_txpool_gossip, !discovery_v4))
         .consensus(BaseConsensusBuilder::default())

--- a/crates/execution/payload/src/builder.rs
+++ b/crates/execution/payload/src/builder.rs
@@ -53,8 +53,6 @@ pub struct BasePayloadBuilder<
     Txs = (),
     Attrs = BasePayloadBuilderAttributes<TxTy<<Evm as ConfigureEvm>::Primitives>>,
 > {
-    /// The rollup's compute pending block configuration option.
-    pub compute_pending_block: bool,
     /// The type responsible for creating the evm.
     pub evm_config: Evm,
     /// Transaction pool.
@@ -84,7 +82,6 @@ where
             client: self.client.clone(),
             config: self.config.clone(),
             best_transactions: self.best_transactions.clone(),
-            compute_pending_block: self.compute_pending_block,
             _pd: PhantomData,
         }
     }
@@ -105,51 +102,25 @@ impl<Pool, Client, Evm, Attrs> BasePayloadBuilder<Pool, Client, Evm, (), Attrs> 
         evm_config: Evm,
         config: BaseBuilderConfig,
     ) -> Self {
-        Self {
-            pool,
-            client,
-            compute_pending_block: true,
-            evm_config,
-            config,
-            best_transactions: (),
-            _pd: PhantomData,
-        }
+        Self { pool, client, evm_config, config, best_transactions: (), _pd: PhantomData }
     }
 }
 
 impl<Pool, Client, Evm, Txs, Attrs> BasePayloadBuilder<Pool, Client, Evm, Txs, Attrs> {
-    /// Sets the rollup's compute pending block configuration option.
-    pub const fn set_compute_pending_block(mut self, compute_pending_block: bool) -> Self {
-        self.compute_pending_block = compute_pending_block;
-        self
-    }
-
     /// Configures the type responsible for yielding the transactions that should be included in the
     /// payload.
     pub fn with_transactions<T>(
         self,
         best_transactions: T,
     ) -> BasePayloadBuilder<Pool, Client, Evm, T, Attrs> {
-        let Self { pool, client, compute_pending_block, evm_config, config, .. } = self;
         BasePayloadBuilder {
-            pool,
-            client,
-            compute_pending_block,
-            evm_config,
+            pool: self.pool,
+            client: self.client,
+            evm_config: self.evm_config,
             best_transactions,
-            config,
+            config: self.config,
             _pd: PhantomData,
         }
-    }
-
-    /// Enables the rollup's compute pending block configuration option.
-    pub const fn compute_pending_block(self) -> Self {
-        self.set_compute_pending_block(true)
-    }
-
-    /// Returns the rollup's compute pending block configuration option.
-    pub const fn is_compute_pending_block(&self) -> bool {
-        self.compute_pending_block
     }
 }
 

--- a/crates/execution/runner/src/node.rs
+++ b/crates/execution/runner/src/node.rs
@@ -87,7 +87,6 @@ impl BaseNode {
     {
         let RollupArgs {
             disable_txpool_gossip,
-            compute_pending_block,
             discovery_v4,
             max_inflight_delegated_slots,
             mempool_sender_limit,
@@ -109,7 +108,7 @@ impl BaseNode {
             )
             .executor(BaseExecutorBuilder::default())
             .payload(BasicPayloadServiceBuilder::new(
-                BasePayloadBuilder::new(compute_pending_block)
+                BasePayloadBuilder::new()
                     .with_da_config(self.da_config.clone())
                     .with_gas_limit_config(self.gas_limit_config.clone())
                     .with_manifest_precheck_enabled(self.manifest_precheck_enabled),


### PR DESCRIPTION
Removes the non-functional compute pending block setting from the CLI and payload builder APIs. The option was only stored and forwarded and never affected pending block construction.