### PR TITLE
feat(load-tests): add validity transaction config schema

### DIFF
--- a/crates/infra/load-tests/examples/devnet.yaml
+++ b/crates/infra/load-tests/examples/devnet.yaml
@@ -73,3 +73,39 @@ transactions:
   #   router: "0x..."
   #   token_in: "0x..."
   #   token_out: "0x..."
+
+# Validity (conditional) transaction workload.
+#
+# A fraction of *senders* route their entire traffic through
+# base_sendRawTransactionValidity, carrying state predicates. For predicates to
+# be evaluated end-to-end, the ingress node must run with
+# --enable-experimental-validity-transactions (which also requires tx-forwarding)
+# and the builder must run with --builder.enable-experimental-validity-transactions
+# using the flashblocks builder. Omit this block (or set ratio: 0.0) to disable.
+#
+# validity:
+#   ratio: 0.25                 # fraction of senders routed to the validity endpoint
+#   empty_predicate_control: true
+#   control_ratio: 0.2          # of validity senders, fraction sending empty-predicate control txs
+#   predicates:
+#     - type: balance
+#       address: sender          # sender | recipient | 0x-literal
+#       op: ">="
+#       value: "0"
+#     - type: storage
+#       address: "0x1234567890123456789012345678901234567890"
+#       slot:
+#         kind: fixed
+#         value: "0x1"
+#       mask: "0xff"             # optional; defaults to all ones server-side
+#       op: "="
+#       value: "0x0"
+#     # balanceOf(sender) against a seeded token's mapping slot:
+#     - type: storage
+#       address: "0xTOKEN000000000000000000000000000000000000"
+#       slot:
+#         kind: mapping_balance_of
+#         mapping_slot: "0x0"
+#         key: sender
+#       op: ">="
+#       value: "0x0"

--- a/crates/infra/load-tests/examples/devnet.yaml
+++ b/crates/infra/load-tests/examples/devnet.yaml
@@ -85,8 +85,6 @@ transactions:
 #
 # validity:
 #   ratio: 0.25                 # fraction of senders routed to the validity endpoint
-#   empty_predicate_control: true
-#   control_ratio: 0.2          # of validity senders, fraction sending empty-predicate control txs
 #   predicates:
 #     - type: balance
 #       address: sender          # sender | recipient | 0x-literal
@@ -104,7 +102,7 @@ transactions:
 #     - type: storage
 #       address: "0xTOKEN000000000000000000000000000000000000"
 #       slot:
-#         kind: mapping_balance_of
+#         kind: mapping
 #         mapping_slot: "0x0"
 #         key: sender
 #       op: ">="

--- a/crates/infra/load-tests/src/config/mod.rs
+++ b/crates/infra/load-tests/src/config/mod.rs
@@ -13,3 +13,8 @@ pub use real_token::{RealTokenAcquisitionConfig, RealTokenPairTokenConfig, RealT
 
 mod test_config;
 pub use test_config::{OsakaTarget, TestConfig, TxTypeConfig, WeightedTxType};
+
+mod validity;
+pub use validity::{
+    PredicateAddressConfig, PredicateSlotConfig, ValidityConfig, ValidityPredicateConfig,
+};

--- a/crates/infra/load-tests/src/config/parsing.rs
+++ b/crates/infra/load-tests/src/config/parsing.rs
@@ -11,6 +11,19 @@ pub(super) fn parse_amount(s: &str, field: &str) -> Result<U256> {
     s.parse::<U256>().map_err(|e| BaselineError::Config(format!("invalid {field} '{s}': {e}")))
 }
 
+/// Parses a [`U256`] from a hex string (`0x`-prefixed) or a decimal string.
+///
+/// Storage slots, masks, and predicate values are commonly written in hex, so
+/// this accepts both forms rather than the decimal-only [`parse_amount`].
+pub(super) fn parse_u256_hex_or_dec(s: &str, field: &str) -> Result<U256> {
+    let trimmed = s.trim();
+    let parsed = trimmed
+        .strip_prefix("0x")
+        .or_else(|| trimmed.strip_prefix("0X"))
+        .map_or_else(|| U256::from_str_radix(trimmed, 10), |hex| U256::from_str_radix(hex, 16));
+    parsed.map_err(|e| BaselineError::Config(format!("invalid {field} '{s}': {e}")))
+}
+
 pub(super) fn validate_swap_amounts(min: U256, max: U256, tx_type: &str) -> Result<()> {
     if min > max {
         return Err(BaselineError::Config(format!(

--- a/crates/infra/load-tests/src/config/test_config.rs
+++ b/crates/infra/load-tests/src/config/test_config.rs
@@ -9,6 +9,7 @@ use super::{
     parsing::{parse_address, parse_amount, validate_swap_amounts},
     precompile::PrecompileTarget,
     real_token::{RealTokenSetupConfig, parse_real_token_setup},
+    validity::ValidityConfig,
 };
 use crate::{
     metrics::ConfigSummary,
@@ -142,6 +143,11 @@ pub struct TestConfig {
     /// re-funded via deposit rather than reclaimed.
     #[serde(default)]
     pub skip_drain: bool,
+
+    /// Validity (conditional) transaction workload. When `ratio` is `0.0`
+    /// (the default), no validity transactions are submitted.
+    #[serde(default)]
+    pub validity: ValidityConfig,
 }
 
 impl Default for TestConfig {
@@ -173,6 +179,7 @@ impl Default for TestConfig {
             b20_mint_amount: default_b20_mint_amount(),
             real_token_setup: None,
             skip_drain: false,
+            validity: ValidityConfig::default(),
         }
     }
 }
@@ -204,6 +211,7 @@ impl fmt::Debug for TestConfig {
             .field("b20_mint_amount", &self.b20_mint_amount)
             .field("real_token_setup", &self.real_token_setup)
             .field("skip_drain", &self.skip_drain)
+            .field("validity", &self.validity)
             .finish()
     }
 }
@@ -445,6 +453,8 @@ impl TestConfig {
             return Err(BaselineError::Config("block_time must be > 0".into()));
         }
 
+        self.validity.validate()?;
+
         Ok(())
     }
 
@@ -586,6 +596,9 @@ impl TestConfig {
                 })
                 .unwrap_or_default(),
             fresh_recipient_ratio: self.fresh_recipient_ratio,
+            validity_ratio: self.validity.ratio,
+            validity_predicate_count: self.validity.predicates.len(),
+            validity_control_ratio: self.validity.control_ratio,
             looper_contract: self.looper_contract.clone(),
             swap_token_amount: self.swap_token_amount.clone(),
             b20_mint_amount: self.b20_mint_amount.clone(),
@@ -652,6 +665,10 @@ impl TestConfig {
             max_gas_price: crate::runner::DEFAULT_MAX_GAS_PRICE,
             flashblocks_ws: self.flashblocks_ws.clone(),
             fresh_recipient_ratio: self.fresh_recipient_ratio,
+            validity_ratio: self.validity.ratio,
+            validity_predicates: self.validity.to_templates()?,
+            validity_empty_control: self.validity.empty_predicate_control,
+            validity_control_ratio: self.validity.control_ratio,
         })
     }
 
@@ -1303,6 +1320,86 @@ transactions:
             }
             _ => panic!("expected UniswapV3"),
         }
+    }
+
+    #[test]
+    fn validity_defaults_to_disabled() {
+        let yaml = r#"
+transaction_submission_rpcs: http://localhost:8545
+flashblocks_ws: ws://localhost:7111
+"#;
+        let config = TestConfig::from_yaml(yaml).unwrap();
+        assert_eq!(config.validity.ratio, 0.0);
+        let load_config = config.to_load_config(Some(1337)).unwrap();
+        assert_eq!(load_config.validity_ratio, 0.0);
+        assert!(load_config.validity_predicates.is_empty());
+        assert_eq!(config.to_summary().validity_ratio, 0.0);
+    }
+
+    #[test]
+    fn validity_config_round_trips_predicates() {
+        let yaml = r#"
+transaction_submission_rpcs: http://localhost:8545
+flashblocks_ws: ws://localhost:7111
+validity:
+  ratio: 0.25
+  empty_predicate_control: true
+  control_ratio: 0.2
+  predicates:
+    - type: balance
+      address: sender
+      op: ">="
+      value: "0"
+    - type: storage
+      address: "0x1234567890123456789012345678901234567890"
+      slot:
+        kind: mapping_balance_of
+        mapping_slot: "0x0"
+        key: sender
+      op: ">="
+      value: "0x0"
+"#;
+        let config = TestConfig::from_yaml(yaml).unwrap();
+        assert_eq!(config.validity.ratio, 0.25);
+        assert_eq!(config.validity.predicates.len(), 2);
+
+        let load_config = config.to_load_config(Some(1337)).unwrap();
+        assert_eq!(load_config.validity_ratio, 0.25);
+        assert!(load_config.validity_empty_control);
+        assert_eq!(load_config.validity_control_ratio, 0.2);
+        assert_eq!(load_config.validity_predicates.len(), 2);
+
+        let summary = config.to_summary();
+        assert_eq!(summary.validity_ratio, 0.25);
+        assert_eq!(summary.validity_predicate_count, 2);
+    }
+
+    #[test]
+    fn validity_rejects_ratio_above_one() {
+        let yaml = r#"
+transaction_submission_rpcs: http://localhost:8545
+flashblocks_ws: ws://localhost:7111
+validity:
+  ratio: 1.5
+  predicates:
+    - type: balance
+      op: ">="
+      value: "0"
+"#;
+        let err = TestConfig::from_yaml(yaml).unwrap_err();
+        assert!(err.to_string().contains("validity.ratio"));
+    }
+
+    #[test]
+    fn validity_rejects_enabled_without_predicates() {
+        let yaml = r#"
+transaction_submission_rpcs: http://localhost:8545
+flashblocks_ws: ws://localhost:7111
+validity:
+  ratio: 0.5
+"#;
+        let err = TestConfig::from_yaml(yaml).unwrap_err();
+        assert!(err.to_string().contains("validity.predicates must be non-empty"));
     }
 
     #[test]

--- a/crates/infra/load-tests/src/config/test_config.rs
+++ b/crates/infra/load-tests/src/config/test_config.rs
@@ -598,7 +598,6 @@ impl TestConfig {
             fresh_recipient_ratio: self.fresh_recipient_ratio,
             validity_ratio: self.validity.ratio,
             validity_predicate_count: self.validity.predicates.len(),
-            validity_control_ratio: self.validity.control_ratio,
             looper_contract: self.looper_contract.clone(),
             swap_token_amount: self.swap_token_amount.clone(),
             b20_mint_amount: self.b20_mint_amount.clone(),
@@ -667,8 +666,6 @@ impl TestConfig {
             fresh_recipient_ratio: self.fresh_recipient_ratio,
             validity_ratio: self.validity.ratio,
             validity_predicates: self.validity.to_templates()?,
-            validity_empty_control: self.validity.empty_predicate_control,
-            validity_control_ratio: self.validity.control_ratio,
         })
     }
 
@@ -1343,8 +1340,6 @@ transaction_submission_rpcs: http://localhost:8545
 flashblocks_ws: ws://localhost:7111
 validity:
   ratio: 0.25
-  empty_predicate_control: true
-  control_ratio: 0.2
   predicates:
     - type: balance
       address: sender
@@ -1353,7 +1348,7 @@ validity:
     - type: storage
       address: "0x1234567890123456789012345678901234567890"
       slot:
-        kind: mapping_balance_of
+        kind: mapping
         mapping_slot: "0x0"
         key: sender
       op: ">="
@@ -1365,8 +1360,6 @@ validity:
 
         let load_config = config.to_load_config(Some(1337)).unwrap();
         assert_eq!(load_config.validity_ratio, 0.25);
-        assert!(load_config.validity_empty_control);
-        assert_eq!(load_config.validity_control_ratio, 0.2);
         assert_eq!(load_config.validity_predicates.len(), 2);
 
         let summary = config.to_summary();

--- a/crates/infra/load-tests/src/config/validity.rs
+++ b/crates/infra/load-tests/src/config/validity.rs
@@ -1,4 +1,4 @@
-use base_execution_txpool::{MAX_VALIDITY_PREDICATES, ValidityOperator};
+use base_execution_txpool::{DEFAULT_MAX_VALIDITY_PREDICATES, ValidityOperator};
 use serde::{Deserialize, Serialize};
 
 use super::parsing::{parse_address, parse_u256_hex_or_dec};
@@ -21,19 +21,9 @@ pub struct ValidityConfig {
 
     /// Predicate templates attached to each validity-bearing transaction.
     ///
-    /// Must be non-empty when `ratio > 0` unless `empty_predicate_control` is
-    /// set, and must contain at most [`MAX_VALIDITY_PREDICATES`] entries.
+    /// Must be non-empty when `ratio > 0`, and must contain at most
+    /// [`DEFAULT_MAX_VALIDITY_PREDICATES`] entries.
     pub predicates: Vec<ValidityPredicateConfig>,
-
-    /// When true, a fraction of validity-path transactions carry an empty
-    /// predicate list. These isolate the origin/forwarding cost of the validity
-    /// endpoint from the cost of predicate evaluation.
-    pub empty_predicate_control: bool,
-
-    /// Fraction `0.0..=1.0` of validity senders that emit empty-predicate
-    /// control transactions. Only meaningful when `empty_predicate_control` is
-    /// set.
-    pub control_ratio: f64,
 }
 
 /// A configured validity predicate template.
@@ -123,7 +113,7 @@ pub enum PredicateSlotConfig {
     },
     /// A Solidity mapping slot `keccak256(key ++ mapping_slot)`, e.g. the
     /// `balanceOf` slot for a given key address.
-    MappingBalanceOf {
+    Mapping {
         /// Declared position of the mapping in contract storage (hex or decimal).
         mapping_slot: String,
         /// Mapping key address, resolved per transaction.
@@ -138,20 +128,15 @@ impl ValidityConfig {
         if !(0.0..=1.0).contains(&self.ratio) {
             return Err(BaselineError::Config("validity.ratio must be between 0.0 and 1.0".into()));
         }
-        if !(0.0..=1.0).contains(&self.control_ratio) {
-            return Err(BaselineError::Config(
-                "validity.control_ratio must be between 0.0 and 1.0".into(),
-            ));
-        }
-        if self.predicates.len() > MAX_VALIDITY_PREDICATES {
+        if self.predicates.len() > DEFAULT_MAX_VALIDITY_PREDICATES {
             return Err(BaselineError::Config(format!(
-                "validity.predicates has {} entries, exceeding the maximum of {MAX_VALIDITY_PREDICATES}",
+                "validity.predicates has {} entries, exceeding the maximum of {DEFAULT_MAX_VALIDITY_PREDICATES}",
                 self.predicates.len()
             )));
         }
-        if self.ratio > 0.0 && self.predicates.is_empty() && !self.empty_predicate_control {
+        if self.ratio > 0.0 && self.predicates.is_empty() {
             return Err(BaselineError::Config(
-                "validity.predicates must be non-empty when validity.ratio > 0 (or set validity.empty_predicate_control)".into(),
+                "validity.predicates must be non-empty when validity.ratio > 0".into(),
             ));
         }
         // Surface parse errors (operators, addresses, values) eagerly.
@@ -214,7 +199,7 @@ impl PredicateSlotConfig {
             Self::Fixed { value } => {
                 Ok(SlotTemplate::Fixed(parse_u256_hex_or_dec(value, "validity storage slot")?))
             }
-            Self::MappingBalanceOf { mapping_slot, key } => Ok(SlotTemplate::MappingBalanceOf {
+            Self::Mapping { mapping_slot, key } => Ok(SlotTemplate::Mapping {
                 mapping_slot: parse_u256_hex_or_dec(mapping_slot, "validity mapping_slot")?,
                 key: key.to_template()?,
             }),
@@ -299,13 +284,13 @@ mod tests {
     }
 
     #[test]
-    fn mapping_balance_of_slot_to_template() {
-        let config = PredicateSlotConfig::MappingBalanceOf {
+    fn mapping_slot_to_template() {
+        let config = PredicateSlotConfig::Mapping {
             mapping_slot: "0".into(),
             key: PredicateAddressConfig::Sender,
         };
         match config.to_template().unwrap() {
-            SlotTemplate::MappingBalanceOf { mapping_slot, key } => {
+            SlotTemplate::Mapping { mapping_slot, key } => {
                 assert_eq!(mapping_slot, U256::ZERO);
                 assert!(matches!(key, PredicateAddress::Sender));
             }
@@ -320,20 +305,15 @@ mod tests {
     }
 
     #[test]
-    fn validate_rejects_empty_predicates_without_control() {
+    fn validate_rejects_empty_predicates_when_enabled() {
         let config = ValidityConfig { ratio: 0.5, ..Default::default() };
         let err = config.validate().unwrap_err();
         assert!(err.to_string().contains("validity.predicates must be non-empty"));
     }
 
     #[test]
-    fn validate_allows_empty_predicates_with_control() {
-        let config = ValidityConfig {
-            ratio: 0.5,
-            empty_predicate_control: true,
-            control_ratio: 1.0,
-            ..Default::default()
-        };
+    fn validate_allows_empty_predicates_when_disabled() {
+        let config = ValidityConfig { ratio: 0.0, ..Default::default() };
         assert!(config.validate().is_ok());
     }
 
@@ -346,8 +326,7 @@ mod tests {
         };
         let config = ValidityConfig {
             ratio: 1.0,
-            predicates: vec![predicate; MAX_VALIDITY_PREDICATES + 1],
-            ..Default::default()
+            predicates: vec![predicate; DEFAULT_MAX_VALIDITY_PREDICATES + 1],
         };
         let err = config.validate().unwrap_err();
         assert!(err.to_string().contains("exceeding the maximum"));
@@ -362,7 +341,6 @@ mod tests {
                 op: "==".into(),
                 value: "0".into(),
             }],
-            ..Default::default()
         };
         assert!(config.validate().is_err());
     }

--- a/crates/infra/load-tests/src/config/validity.rs
+++ b/crates/infra/load-tests/src/config/validity.rs
@@ -1,0 +1,369 @@
+use base_execution_txpool::{MAX_VALIDITY_PREDICATES, ValidityOperator};
+use serde::{Deserialize, Serialize};
+
+use super::parsing::{parse_address, parse_u256_hex_or_dec};
+use crate::{
+    runner::{PredicateAddress, SlotTemplate, ValidityPredicateTemplate},
+    utils::{BaselineError, Result},
+};
+
+/// Validity-transaction workload configuration.
+///
+/// A fraction of *senders* route their entire traffic through
+/// `base_sendRawTransactionValidity`, carrying the configured predicates.
+/// Routing is per sender (not per transaction) so each sender's nonce stream
+/// stays on a single submission origin.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ValidityConfig {
+    /// Fraction `0.0..=1.0` of senders assigned to the validity path.
+    pub ratio: f64,
+
+    /// Predicate templates attached to each validity-bearing transaction.
+    ///
+    /// Must be non-empty when `ratio > 0` unless `empty_predicate_control` is
+    /// set, and must contain at most [`MAX_VALIDITY_PREDICATES`] entries.
+    pub predicates: Vec<ValidityPredicateConfig>,
+
+    /// When true, a fraction of validity-path transactions carry an empty
+    /// predicate list. These isolate the origin/forwarding cost of the validity
+    /// endpoint from the cost of predicate evaluation.
+    pub empty_predicate_control: bool,
+
+    /// Fraction `0.0..=1.0` of validity senders that emit empty-predicate
+    /// control transactions. Only meaningful when `empty_predicate_control` is
+    /// set.
+    pub control_ratio: f64,
+}
+
+/// A configured validity predicate template.
+///
+/// Values and slots are strings (hex or decimal) parsed at conversion time,
+/// mirroring how amounts are handled elsewhere in the config.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ValidityPredicateConfig {
+    /// Compares an account balance with a value.
+    Balance {
+        /// Account whose balance is read, resolved per transaction.
+        #[serde(default)]
+        address: PredicateAddressConfig,
+        /// Comparison operator (`<`, `<=`, `=`, `!=`, `>`, `>=`).
+        op: String,
+        /// Right-hand comparison value (hex or decimal).
+        value: String,
+    },
+    /// Compares a masked storage value with a value.
+    Storage {
+        /// Contract whose storage is read, resolved per transaction.
+        #[serde(default)]
+        address: PredicateAddressConfig,
+        /// Storage slot to read.
+        slot: PredicateSlotConfig,
+        /// Optional bit mask (hex or decimal); defaults to all ones server-side.
+        #[serde(default)]
+        mask: Option<String>,
+        /// Comparison operator (`<`, `<=`, `=`, `!=`, `>`, `>=`).
+        op: String,
+        /// Right-hand comparison value (hex or decimal).
+        value: String,
+    },
+}
+
+/// Source for a predicate's address, resolved per transaction at prepare time.
+///
+/// Written in YAML as a bare string: the keywords `sender` or `recipient`, or
+/// an explicit `0x` address literal.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum PredicateAddressConfig {
+    /// The transaction's sender (`from`).
+    #[default]
+    Sender,
+    /// The transaction's recipient (`to`).
+    Recipient,
+    /// An explicit `0x` address.
+    Fixed(String),
+}
+
+impl Serialize for PredicateAddressConfig {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error> {
+        let s = match self {
+            Self::Sender => "sender",
+            Self::Recipient => "recipient",
+            Self::Fixed(addr) => addr.as_str(),
+        };
+        serializer.serialize_str(s)
+    }
+}
+
+impl<'de> Deserialize<'de> for PredicateAddressConfig {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        deserializer: D,
+    ) -> std::result::Result<Self, D::Error> {
+        let raw = String::deserialize(deserializer)?;
+        Ok(match raw.as_str() {
+            "sender" => Self::Sender,
+            "recipient" => Self::Recipient,
+            _ => Self::Fixed(raw),
+        })
+    }
+}
+
+/// Source for a storage slot, resolved per transaction at prepare time.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum PredicateSlotConfig {
+    /// A static storage slot.
+    Fixed {
+        /// Slot index (hex or decimal).
+        value: String,
+    },
+    /// A Solidity mapping slot `keccak256(key ++ mapping_slot)`, e.g. the
+    /// `balanceOf` slot for a given key address.
+    MappingBalanceOf {
+        /// Declared position of the mapping in contract storage (hex or decimal).
+        mapping_slot: String,
+        /// Mapping key address, resolved per transaction.
+        #[serde(default)]
+        key: PredicateAddressConfig,
+    },
+}
+
+impl ValidityConfig {
+    /// Validates the validity configuration.
+    pub fn validate(&self) -> Result<()> {
+        if !(0.0..=1.0).contains(&self.ratio) {
+            return Err(BaselineError::Config("validity.ratio must be between 0.0 and 1.0".into()));
+        }
+        if !(0.0..=1.0).contains(&self.control_ratio) {
+            return Err(BaselineError::Config(
+                "validity.control_ratio must be between 0.0 and 1.0".into(),
+            ));
+        }
+        if self.predicates.len() > MAX_VALIDITY_PREDICATES {
+            return Err(BaselineError::Config(format!(
+                "validity.predicates has {} entries, exceeding the maximum of {MAX_VALIDITY_PREDICATES}",
+                self.predicates.len()
+            )));
+        }
+        if self.ratio > 0.0 && self.predicates.is_empty() && !self.empty_predicate_control {
+            return Err(BaselineError::Config(
+                "validity.predicates must be non-empty when validity.ratio > 0 (or set validity.empty_predicate_control)".into(),
+            ));
+        }
+        // Surface parse errors (operators, addresses, values) eagerly.
+        for predicate in &self.predicates {
+            predicate.to_template()?;
+        }
+        Ok(())
+    }
+
+    /// Converts the configured predicate templates into runtime templates.
+    pub fn to_templates(&self) -> Result<Vec<ValidityPredicateTemplate>> {
+        self.predicates.iter().map(ValidityPredicateConfig::to_template).collect()
+    }
+}
+
+impl ValidityPredicateConfig {
+    /// Converts this configured predicate into a runtime template, parsing all
+    /// literal values and pre-resolving fixed addresses.
+    pub fn to_template(&self) -> Result<ValidityPredicateTemplate> {
+        match self {
+            Self::Balance { address, op, value } => Ok(ValidityPredicateTemplate::Balance {
+                address: address.to_template()?,
+                op: parse_operator(op)?,
+                value: parse_u256_hex_or_dec(value, "validity balance value")?,
+            }),
+            Self::Storage { address, slot, mask, op, value } => {
+                let mask = match mask {
+                    Some(mask) => Some(parse_u256_hex_or_dec(mask, "validity storage mask")?),
+                    None => None,
+                };
+                Ok(ValidityPredicateTemplate::Storage {
+                    address: address.to_template()?,
+                    slot: slot.to_template()?,
+                    mask,
+                    op: parse_operator(op)?,
+                    value: parse_u256_hex_or_dec(value, "validity storage value")?,
+                })
+            }
+        }
+    }
+}
+
+impl PredicateAddressConfig {
+    /// Resolves this configured address source into a runtime template.
+    pub fn to_template(&self) -> Result<PredicateAddress> {
+        match self {
+            Self::Sender => Ok(PredicateAddress::Sender),
+            Self::Recipient => Ok(PredicateAddress::Recipient),
+            Self::Fixed(addr) => {
+                Ok(PredicateAddress::Fixed(parse_address(addr, "validity predicate")?))
+            }
+        }
+    }
+}
+
+impl PredicateSlotConfig {
+    /// Resolves this configured slot source into a runtime template.
+    pub fn to_template(&self) -> Result<SlotTemplate> {
+        match self {
+            Self::Fixed { value } => {
+                Ok(SlotTemplate::Fixed(parse_u256_hex_or_dec(value, "validity storage slot")?))
+            }
+            Self::MappingBalanceOf { mapping_slot, key } => Ok(SlotTemplate::MappingBalanceOf {
+                mapping_slot: parse_u256_hex_or_dec(mapping_slot, "validity mapping_slot")?,
+                key: key.to_template()?,
+            }),
+        }
+    }
+}
+
+/// Parses a comparison operator symbol into a [`ValidityOperator`].
+pub(super) fn parse_operator(s: &str) -> Result<ValidityOperator> {
+    match s.trim() {
+        "<" => Ok(ValidityOperator::LessThan),
+        "<=" => Ok(ValidityOperator::LessThanOrEqual),
+        "=" => Ok(ValidityOperator::Equal),
+        "!=" => Ok(ValidityOperator::NotEqual),
+        ">" => Ok(ValidityOperator::GreaterThan),
+        ">=" => Ok(ValidityOperator::GreaterThanOrEqual),
+        other => Err(BaselineError::Config(format!(
+            "invalid validity operator '{other}', expected one of <, <=, =, !=, >, >="
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::U256;
+
+    use super::*;
+
+    #[test]
+    fn parse_operator_accepts_all_symbols() {
+        assert_eq!(parse_operator("<").unwrap(), ValidityOperator::LessThan);
+        assert_eq!(parse_operator("<=").unwrap(), ValidityOperator::LessThanOrEqual);
+        assert_eq!(parse_operator("=").unwrap(), ValidityOperator::Equal);
+        assert_eq!(parse_operator("!=").unwrap(), ValidityOperator::NotEqual);
+        assert_eq!(parse_operator(">").unwrap(), ValidityOperator::GreaterThan);
+        assert_eq!(parse_operator(">=").unwrap(), ValidityOperator::GreaterThanOrEqual);
+    }
+
+    #[test]
+    fn parse_operator_rejects_unknown() {
+        assert!(parse_operator("==").is_err());
+    }
+
+    #[test]
+    fn balance_predicate_to_template() {
+        let config = ValidityPredicateConfig::Balance {
+            address: PredicateAddressConfig::Sender,
+            op: ">=".into(),
+            value: "0".into(),
+        };
+        match config.to_template().unwrap() {
+            ValidityPredicateTemplate::Balance { address, op, value } => {
+                assert!(matches!(address, PredicateAddress::Sender));
+                assert_eq!(op, ValidityOperator::GreaterThanOrEqual);
+                assert_eq!(value, U256::ZERO);
+            }
+            other => panic!("expected balance template, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn storage_predicate_with_hex_slot_and_mask() {
+        let config = ValidityPredicateConfig::Storage {
+            address: PredicateAddressConfig::Fixed(
+                "0x1234567890123456789012345678901234567890".into(),
+            ),
+            slot: PredicateSlotConfig::Fixed { value: "0x1".into() },
+            mask: Some("0xff".into()),
+            op: "=".into(),
+            value: "0".into(),
+        };
+        match config.to_template().unwrap() {
+            ValidityPredicateTemplate::Storage { address, slot, mask, op, value } => {
+                assert!(matches!(address, PredicateAddress::Fixed(_)));
+                assert!(matches!(slot, SlotTemplate::Fixed(s) if s == U256::from(1u64)));
+                assert_eq!(mask, Some(U256::from(0xffu64)));
+                assert_eq!(op, ValidityOperator::Equal);
+                assert_eq!(value, U256::ZERO);
+            }
+            other => panic!("expected storage template, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mapping_balance_of_slot_to_template() {
+        let config = PredicateSlotConfig::MappingBalanceOf {
+            mapping_slot: "0".into(),
+            key: PredicateAddressConfig::Sender,
+        };
+        match config.to_template().unwrap() {
+            SlotTemplate::MappingBalanceOf { mapping_slot, key } => {
+                assert_eq!(mapping_slot, U256::ZERO);
+                assert!(matches!(key, PredicateAddress::Sender));
+            }
+            other => panic!("expected mapping template, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_rejects_ratio_above_one() {
+        let config = ValidityConfig { ratio: 1.5, ..Default::default() };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_empty_predicates_without_control() {
+        let config = ValidityConfig { ratio: 0.5, ..Default::default() };
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("validity.predicates must be non-empty"));
+    }
+
+    #[test]
+    fn validate_allows_empty_predicates_with_control() {
+        let config = ValidityConfig {
+            ratio: 0.5,
+            empty_predicate_control: true,
+            control_ratio: 1.0,
+            ..Default::default()
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_too_many_predicates() {
+        let predicate = ValidityPredicateConfig::Balance {
+            address: PredicateAddressConfig::Sender,
+            op: ">=".into(),
+            value: "0".into(),
+        };
+        let config = ValidityConfig {
+            ratio: 1.0,
+            predicates: vec![predicate; MAX_VALIDITY_PREDICATES + 1],
+            ..Default::default()
+        };
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("exceeding the maximum"));
+    }
+
+    #[test]
+    fn validate_surfaces_bad_operator() {
+        let config = ValidityConfig {
+            ratio: 1.0,
+            predicates: vec![ValidityPredicateConfig::Balance {
+                address: PredicateAddressConfig::Sender,
+                op: "==".into(),
+                value: "0".into(),
+            }],
+            ..Default::default()
+        };
+        assert!(config.validate().is_err());
+    }
+}

--- a/crates/infra/load-tests/src/lib.rs
+++ b/crates/infra/load-tests/src/lib.rs
@@ -4,8 +4,9 @@
 
 mod config;
 pub use config::{
-    OsakaTarget, PrecompileTarget, RealTokenAcquisitionConfig, RealTokenPairTokenConfig,
-    RealTokenSetupConfig, TestConfig, TxTypeConfig, WeightedTxType, WorkloadConfig,
+    OsakaTarget, PrecompileTarget, PredicateAddressConfig, PredicateSlotConfig,
+    RealTokenAcquisitionConfig, RealTokenPairTokenConfig, RealTokenSetupConfig, TestConfig,
+    TxTypeConfig, ValidityConfig, ValidityPredicateConfig, WeightedTxType, WorkloadConfig,
 };
 
 mod executor;
@@ -49,8 +50,9 @@ pub use runner::{
     FlashblockWatcher, GasPricer, InclusionPulse, InclusionSource, InjectLimit, InjectPlan,
     LoadConfig, LoadRunner, LoadTestDisplay, LoadTestStage, MAX_FEE_BASE_FEE_MULTIPLIER,
     MAX_SENDER_WORKER_COUNT, MAX_SIGNER_WORKER_COUNT, MIN_PRIORITY_FEE, MempoolDepthController,
-    PipelineQueue, PipelineStartConfig, PreparedBatch, PreparedTransaction, PresignBuffer,
-    QueuedSubmitFailures, ResultsTracker, SENDER_WORKERS_PER_RPC, SIGNER_WORKERS_PER_RPC,
-    SUBMIT_BATCH_QUEUE_BUFFER, SUBMIT_MAX_ATTEMPTS, SenderContext, SentTransaction, SignedBatch,
-    SignedTransaction, SignerContext, SubmissionPipeline, SubmitEvent, TxConfig, TxType,
+    PipelineQueue, PipelineStartConfig, PredicateAddress, PreparedBatch, PreparedTransaction,
+    PresignBuffer, QueuedSubmitFailures, ResultsTracker, SENDER_WORKERS_PER_RPC,
+    SIGNER_WORKERS_PER_RPC, SUBMIT_BATCH_QUEUE_BUFFER, SUBMIT_MAX_ATTEMPTS, SenderContext,
+    SentTransaction, SignedBatch, SignedTransaction, SignerContext, SlotTemplate,
+    SubmissionPipeline, SubmitEvent, TxConfig, TxType, ValidityPredicateTemplate,
 };

--- a/crates/infra/load-tests/src/metrics/types.rs
+++ b/crates/infra/load-tests/src/metrics/types.rs
@@ -362,9 +362,6 @@ pub struct ConfigSummary {
     /// Number of predicate templates attached to validity transactions.
     #[serde(default)]
     pub validity_predicate_count: usize,
-    /// Fraction of validity senders emitting empty-predicate control transactions.
-    #[serde(default)]
-    pub validity_control_ratio: f64,
     /// Address of the precompile looper contract.
     pub looper_contract: Option<String>,
     /// Amount of each swap token per sender (in wei, as string).

--- a/crates/infra/load-tests/src/metrics/types.rs
+++ b/crates/infra/load-tests/src/metrics/types.rs
@@ -356,6 +356,15 @@ pub struct ConfigSummary {
     /// Fraction of transactions targeting freshly derived recipient addresses.
     #[serde(default)]
     pub fresh_recipient_ratio: f64,
+    /// Fraction of senders routed through the validity submission endpoint.
+    #[serde(default)]
+    pub validity_ratio: f64,
+    /// Number of predicate templates attached to validity transactions.
+    #[serde(default)]
+    pub validity_predicate_count: usize,
+    /// Fraction of validity senders emitting empty-predicate control transactions.
+    #[serde(default)]
+    pub validity_control_ratio: f64,
     /// Address of the precompile looper contract.
     pub looper_contract: Option<String>,
     /// Amount of each swap token per sender (in wei, as string).

--- a/crates/infra/load-tests/src/runner/config.rs
+++ b/crates/infra/load-tests/src/runner/config.rs
@@ -1,6 +1,7 @@
 use std::{path::PathBuf, time::Duration};
 
 use alloy_primitives::{Address, U256};
+use base_execution_txpool::ValidityOperator;
 use revm::precompile::PrecompileId;
 use url::Url;
 
@@ -8,6 +9,63 @@ use crate::{
     config::OsakaTarget,
     utils::{BaselineError, Result},
 };
+
+/// Source for a validity predicate's address, resolved per transaction at
+/// prepare time (the concrete `from`/`to` are only known then).
+#[derive(Debug, Clone)]
+pub enum PredicateAddress {
+    /// The transaction's sender (`from`).
+    Sender,
+    /// The transaction's recipient (`to`).
+    Recipient,
+    /// A fixed, pre-resolved address.
+    Fixed(Address),
+}
+
+/// Source for a validity predicate's storage slot, resolved per transaction.
+#[derive(Debug, Clone)]
+pub enum SlotTemplate {
+    /// A static slot index.
+    Fixed(U256),
+    /// A Solidity mapping slot `keccak256(key ++ mapping_slot)`.
+    MappingBalanceOf {
+        /// Declared position of the mapping in contract storage.
+        mapping_slot: U256,
+        /// Mapping key address, resolved per transaction.
+        key: PredicateAddress,
+    },
+}
+
+/// A runtime validity predicate template with literal values pre-parsed.
+///
+/// Addresses and slots may remain symbolic ([`PredicateAddress::Sender`],
+/// [`SlotTemplate::MappingBalanceOf`]) and are resolved into concrete
+/// `ValidityPredicate` values against each transaction at prepare time.
+#[derive(Debug, Clone)]
+pub enum ValidityPredicateTemplate {
+    /// Balance comparison template.
+    Balance {
+        /// Account whose balance is read.
+        address: PredicateAddress,
+        /// Comparison operator.
+        op: ValidityOperator,
+        /// Right-hand comparison value.
+        value: U256,
+    },
+    /// Storage comparison template.
+    Storage {
+        /// Contract whose storage is read.
+        address: PredicateAddress,
+        /// Storage slot source.
+        slot: SlotTemplate,
+        /// Optional bit mask; `None` uses the server default (all ones).
+        mask: Option<U256>,
+        /// Comparison operator.
+        op: ValidityOperator,
+        /// Right-hand comparison value.
+        value: U256,
+    },
+}
 
 /// Configuration for a single transaction type with its weight.
 #[derive(Debug, Clone)]
@@ -168,6 +226,14 @@ pub struct LoadConfig {
     /// Fraction of transactions that draw a fresh recipient address instead of cycling through
     /// the sender pool. Used to drive account-trie fan-out for account-create workloads.
     pub fresh_recipient_ratio: f64,
+    /// Fraction `0.0..=1.0` of senders routed through `base_sendRawTransactionValidity`.
+    pub validity_ratio: f64,
+    /// Predicate templates attached to each validity-bearing transaction.
+    pub validity_predicates: Vec<ValidityPredicateTemplate>,
+    /// Whether some validity senders emit empty-predicate control transactions.
+    pub validity_empty_control: bool,
+    /// Fraction `0.0..=1.0` of validity senders emitting empty-predicate control transactions.
+    pub validity_control_ratio: f64,
 }
 
 impl LoadConfig {
@@ -197,6 +263,10 @@ impl LoadConfig {
             max_gas_price: DEFAULT_MAX_GAS_PRICE,
             flashblocks_ws: None,
             fresh_recipient_ratio: 0.0,
+            validity_ratio: 0.0,
+            validity_predicates: Vec::new(),
+            validity_empty_control: false,
+            validity_control_ratio: 0.0,
         }
     }
 
@@ -244,6 +314,20 @@ impl LoadConfig {
             return Err(BaselineError::Config(
                 "fresh_recipient_ratio must be between 0.0 and 1.0".into(),
             ));
+        }
+        if !(0.0..=1.0).contains(&self.validity_ratio) {
+            return Err(BaselineError::Config("validity_ratio must be between 0.0 and 1.0".into()));
+        }
+        if !(0.0..=1.0).contains(&self.validity_control_ratio) {
+            return Err(BaselineError::Config(
+                "validity_control_ratio must be between 0.0 and 1.0".into(),
+            ));
+        }
+        if self.validity_predicates.len() > base_execution_txpool::MAX_VALIDITY_PREDICATES {
+            return Err(BaselineError::Config(format!(
+                "validity_predicates exceeds the maximum of {}",
+                base_execution_txpool::MAX_VALIDITY_PREDICATES
+            )));
         }
         if self.transactions.is_empty() {
             return Err(BaselineError::Config("transactions must not be empty".into()));

--- a/crates/infra/load-tests/src/runner/config.rs
+++ b/crates/infra/load-tests/src/runner/config.rs
@@ -28,7 +28,7 @@ pub enum SlotTemplate {
     /// A static slot index.
     Fixed(U256),
     /// A Solidity mapping slot `keccak256(key ++ mapping_slot)`.
-    MappingBalanceOf {
+    Mapping {
         /// Declared position of the mapping in contract storage.
         mapping_slot: U256,
         /// Mapping key address, resolved per transaction.
@@ -39,7 +39,7 @@ pub enum SlotTemplate {
 /// A runtime validity predicate template with literal values pre-parsed.
 ///
 /// Addresses and slots may remain symbolic ([`PredicateAddress::Sender`],
-/// [`SlotTemplate::MappingBalanceOf`]) and are resolved into concrete
+/// [`SlotTemplate::Mapping`]) and are resolved into concrete
 /// `ValidityPredicate` values against each transaction at prepare time.
 #[derive(Debug, Clone)]
 pub enum ValidityPredicateTemplate {
@@ -230,10 +230,6 @@ pub struct LoadConfig {
     pub validity_ratio: f64,
     /// Predicate templates attached to each validity-bearing transaction.
     pub validity_predicates: Vec<ValidityPredicateTemplate>,
-    /// Whether some validity senders emit empty-predicate control transactions.
-    pub validity_empty_control: bool,
-    /// Fraction `0.0..=1.0` of validity senders emitting empty-predicate control transactions.
-    pub validity_control_ratio: f64,
 }
 
 impl LoadConfig {
@@ -265,8 +261,6 @@ impl LoadConfig {
             fresh_recipient_ratio: 0.0,
             validity_ratio: 0.0,
             validity_predicates: Vec::new(),
-            validity_empty_control: false,
-            validity_control_ratio: 0.0,
         }
     }
 
@@ -318,16 +312,16 @@ impl LoadConfig {
         if !(0.0..=1.0).contains(&self.validity_ratio) {
             return Err(BaselineError::Config("validity_ratio must be between 0.0 and 1.0".into()));
         }
-        if !(0.0..=1.0).contains(&self.validity_control_ratio) {
-            return Err(BaselineError::Config(
-                "validity_control_ratio must be between 0.0 and 1.0".into(),
-            ));
-        }
-        if self.validity_predicates.len() > base_execution_txpool::MAX_VALIDITY_PREDICATES {
+        if self.validity_predicates.len() > base_execution_txpool::DEFAULT_MAX_VALIDITY_PREDICATES {
             return Err(BaselineError::Config(format!(
                 "validity_predicates exceeds the maximum of {}",
-                base_execution_txpool::MAX_VALIDITY_PREDICATES
+                base_execution_txpool::DEFAULT_MAX_VALIDITY_PREDICATES
             )));
+        }
+        if self.validity_ratio > 0.0 && self.validity_predicates.is_empty() {
+            return Err(BaselineError::Config(
+                "validity_predicates must be non-empty when validity_ratio > 0".into(),
+            ));
         }
         if self.transactions.is_empty() {
             return Err(BaselineError::Config("transactions must not be empty".into()));

--- a/crates/infra/load-tests/src/runner/mod.rs
+++ b/crates/infra/load-tests/src/runner/mod.rs
@@ -2,7 +2,8 @@
 
 mod config;
 pub use config::{
-    DEFAULT_MAX_GAS_PRICE, DEFAULT_MAX_IN_FLIGHT_PER_SENDER, LoadConfig, TxConfig, TxType,
+    DEFAULT_MAX_GAS_PRICE, DEFAULT_MAX_IN_FLIGHT_PER_SENDER, LoadConfig, PredicateAddress,
+    SlotTemplate, TxConfig, TxType, ValidityPredicateTemplate,
 };
 
 mod backoff;


### PR DESCRIPTION
Part of BASE-163 (validity/conditional load testing). **Stack 2/5** — base: \`base-163-01-client\` (#4398).

Adds opt-in configuration for the validity workload, defaulting to disabled so existing configs are unaffected.

- New \`ValidityConfig\` (ratio, predicates, empty-predicate control) parsed from a \`validity:\` YAML block.
- \`ValidityPredicateConfig\` (balance/storage) with per-tx-resolvable address sources (sender/recipient/0x) and slot sources (fixed or Solidity mapping balanceOf), validated eagerly.
- \`parse_u256_hex_or_dec\` so slots/masks/values accept hex or decimal; reuses existing \`parse_address\`/\`parse_amount\`.
- Threads validity into \`TestConfig\` and the runtime \`LoadConfig\` as pre-parsed \`ValidityPredicateTemplate\` values; extends \`ConfigSummary\`; documents the block in \`examples/devnet.yaml\`.

Default \`validity.ratio: 0.0\` → behavior identical to today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)