### PR TITLE
feat(load-tests): route and submit validity transactions

### DIFF
--- a/crates/infra/load-tests/src/lib.rs
+++ b/crates/infra/load-tests/src/lib.rs
@@ -54,5 +54,6 @@ pub use runner::{
     PresignBuffer, QueuedSubmitFailures, ResultsTracker, SENDER_WORKERS_PER_RPC,
     SIGNER_WORKERS_PER_RPC, SUBMIT_BATCH_QUEUE_BUFFER, SUBMIT_MAX_ATTEMPTS, SenderContext,
     SentTransaction, SignedBatch, SignedTransaction, SignerContext, SlotTemplate,
-    SubmissionPipeline, SubmitEvent, TxConfig, TxType, ValidityPredicateTemplate,
+    SubmissionPipeline, SubmitCohort, SubmitEvent, TxConfig, TxType, ValidityPredicateTemplate,
+    ValidityRouter,
 };

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -12,25 +12,26 @@ use std::{
 };
 
 use alloy_network::{Ethereum, EthereumWallet, TransactionBuilder};
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::{Address, B256, TxHash, U256};
 use alloy_provider::{Provider, RootProvider};
 use alloy_signer_local::PrivateKeySigner;
 use base_tx_manager::NonceManager;
 use rand::Rng;
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
-use tracing::{info, instrument};
+use tracing::{debug, info, instrument};
 
 use super::{
     DisplaySnapshot, LoadConfig, LoadTestDisplay, LoadTestStage, SubmissionPipeline, TxType,
+    ValidityRouter,
 };
 use crate::{
     BaselineError, Result,
     config::WorkloadConfig,
     metrics::{ConfigSummary, MetricsCollector, MetricsSummary},
     rpc::{
-        BaseFeeExt, BatchRpcClient, QueryProvider, RpcProviders, RpcResultExt,
-        create_wallet_provider,
+        BaseFeeExt, BatchRpcClient, JSON_RPC_METHOD_NOT_FOUND, QueryProvider, RpcProviders,
+        RpcResultExt, create_wallet_provider,
     },
     workload::{
         AccountPool, ChainPrepContext, KeyStream, PREP_CONCURRENCY, RealTokenRecoverySummary,
@@ -55,6 +56,7 @@ pub struct LoadRunner {
     pub(super) nonce_managers: Arc<HashMap<Address, NonceManager<RootProvider<Ethereum>>>>,
     pub(super) signers: Arc<HashMap<Address, PrivateKeySigner>>,
     pub(super) submission_batch_rpcs: Arc<Vec<BatchRpcClient>>,
+    pub(super) validity_router: ValidityRouter,
     pub(super) base_fee: u128,
     pub(super) display: Option<LoadTestDisplay>,
     pub(super) snapshot_tx: Option<watch::Sender<DisplaySnapshot>>,
@@ -156,6 +158,7 @@ impl LoadRunner {
             None
         };
         let recipient_rng = SeededRng::new(config.seed.wrapping_add(FRESH_RECIPIENT_RNG_SALT));
+        let validity_router = ValidityRouter::new(&config);
 
         Ok(Self {
             config,
@@ -169,6 +172,7 @@ impl LoadRunner {
             nonce_managers: Arc::new(HashMap::new()),
             signers,
             submission_batch_rpcs,
+            validity_router,
             base_fee: 0,
             display: None,
             snapshot_tx: None,
@@ -206,6 +210,37 @@ impl LoadRunner {
 
     pub(super) fn build_signers(accounts: &AccountPool) -> HashMap<Address, PrivateKeySigner> {
         accounts.accounts().iter().map(|a| (a.address, a.signer.clone())).collect()
+    }
+
+    /// Probes each submission endpoint for validity-transaction support.
+    ///
+    /// Sends a throwaway `base_sendRawTransactionValidity` request; a
+    /// method-not-found response means the node was not started with validity
+    /// transactions enabled, so the run aborts loudly rather than silently
+    /// degrading to plain submission. Any other response (including a rejection
+    /// of the throwaway payload) confirms the method is served.
+    pub(super) async fn probe_validity_endpoint(&self) -> Result<()> {
+        for url in &self.config.transaction_submission_rpcs {
+            let provider = RpcProviders::query(url.clone())?;
+            let result: std::result::Result<TxHash, _> = provider
+                .client()
+                .request(
+                    "base_sendRawTransactionValidity",
+                    (serde_json::json!({ "tx": "0x", "validity": [] }),),
+                )
+                .await;
+            if let Err(err) = &result
+                && let Some(payload) = err.as_error_resp()
+                && payload.code == JSON_RPC_METHOD_NOT_FOUND
+            {
+                return Err(BaselineError::Config(format!(
+                    "submission endpoint {url} does not serve base_sendRawTransactionValidity; \
+                     start the node with --enable-experimental-validity-transactions"
+                )));
+            }
+            debug!(url = %url, "validity endpoint capability probe passed");
+        }
+        Ok(())
     }
 
     pub(super) async fn calibrate_avg_gas(&self) -> Result<u64> {

--- a/crates/infra/load-tests/src/runner/mod.rs
+++ b/crates/infra/load-tests/src/runner/mod.rs
@@ -31,8 +31,11 @@ pub use submission::{
     MIN_PRIORITY_FEE, PipelineQueue, PipelineStartConfig, PreparedBatch, PreparedTransaction,
     QueuedSubmitFailures, SENDER_WORKERS_PER_RPC, SIGNER_WORKERS_PER_RPC,
     SUBMIT_BATCH_QUEUE_BUFFER, SUBMIT_MAX_ATTEMPTS, SenderContext, SignedBatch, SignedTransaction,
-    SignerContext, SubmissionPipeline, SubmitEvent,
+    SignerContext, SubmissionPipeline, SubmitCohort, SubmitEvent,
 };
+
+mod validity_router;
+pub use validity_router::ValidityRouter;
 
 mod status;
 pub use status::{DisplaySnapshot, LoadTestDisplay, LoadTestStage};

--- a/crates/infra/load-tests/src/runner/pacing.rs
+++ b/crates/infra/load-tests/src/runner/pacing.rs
@@ -31,7 +31,7 @@ use super::{
     BlockWatcher, DisplaySnapshot, FlashblockWatcher, InclusionPulse, InclusionSource, LoadRunner,
     LoadTestDisplay, LoadTestStage, MIN_PRIORITY_FEE, PipelineStartConfig, PreparedTransaction,
     PresignBuffer, QueuedSubmitFailures, ResultsTracker, SignedBatch, SignedTransaction,
-    SubmissionPipeline, SubmitEvent, TxType,
+    SubmissionPipeline, SubmitEvent, TxType, ValidityRouter,
 };
 use crate::{
     BaselineError, Result,
@@ -96,6 +96,7 @@ struct PresignConfig {
     estimated_gas: u64,
     fresh_recipient_ratio: f64,
     signed_chunk_tx: mpsc::Sender<Vec<Vec<SignedTransaction>>>,
+    validity_router: ValidityRouter,
 }
 
 struct EnqueueProgress {
@@ -402,6 +403,10 @@ impl LoadRunner {
         self.base_fee = self.client.get_base_fee().await?;
         info!(base_fee = self.base_fee, "fetched current base fee");
 
+        if !self.validity_router.is_disabled() {
+            self.probe_validity_endpoint().await?;
+        }
+
         for account in self.accounts.accounts() {
             if !self.nonce_managers.contains_key(&account.address) {
                 let provider = RootProvider::<Ethereum>::new_http(self.config.query_rpc.clone());
@@ -626,6 +631,7 @@ impl LoadRunner {
                 estimated_gas: initial_avg_gas,
                 fresh_recipient_ratio: self.config.fresh_recipient_ratio,
                 signed_chunk_tx,
+                validity_router: self.validity_router.clone(),
             },
         ));
 
@@ -1175,6 +1181,7 @@ impl LoadRunner {
         let mut sender_jobs = Vec::with_capacity(sender_count);
         for (sender_index, from) in config.sender_addresses.iter().copied().enumerate() {
             let sender_pool_recipient = config.sender_addresses[(sender_index + 1) % sender_count];
+            let cohort = config.validity_router.cohort_for_sender(from);
             let mut prepared_txs = Vec::with_capacity(txs_per_sender);
             for _ in 0..txs_per_sender {
                 let payload = generator.select_payload()?;
@@ -1194,6 +1201,7 @@ impl LoadRunner {
                 let value = tx_request.value.unwrap_or(U256::ZERO);
                 let data = tx_request.input.input().cloned().unwrap_or_default();
                 let gas_limit = tx_request.gas.unwrap_or(21_000);
+                let validity = config.validity_router.predicates_for(cohort, from, to_addr);
 
                 prepared_txs.push(PreparedTransaction {
                     from,
@@ -1202,6 +1210,8 @@ impl LoadRunner {
                     data,
                     gas_limit,
                     estimated_gas: config.estimated_gas,
+                    validity,
+                    cohort,
                 });
             }
 
@@ -1388,6 +1398,8 @@ impl LoadRunner {
                 nonce,
                 gas_limit: prepared.gas_limit,
                 estimated_gas: prepared.estimated_gas,
+                validity: prepared.validity,
+                cohort: prepared.cohort,
             });
         }
 
@@ -1918,7 +1930,7 @@ mod tests {
         metrics::MetricsCollector,
         runner::{
             PipelineStartConfig, ResultsTracker, SUBMIT_BATCH_QUEUE_BUFFER, SignedBatch,
-            SignedTransaction, SubmissionPipeline, SubmitEvent,
+            SignedTransaction, SubmissionPipeline, SubmitCohort, SubmitEvent,
         },
     };
     #[test]
@@ -1940,6 +1952,8 @@ mod tests {
                 nonce: id,
                 gas_limit: 21_000,
                 estimated_gas: 21_000,
+                validity: Vec::new(),
+                cohort: SubmitCohort::Plain,
             }],
         }
     }

--- a/crates/infra/load-tests/src/runner/presign_buffer.rs
+++ b/crates/infra/load-tests/src/runner/presign_buffer.rs
@@ -140,7 +140,7 @@ impl PresignBuffer {
 mod tests {
     use alloy_primitives::{Address, Bytes, TxHash};
 
-    use super::*;
+    use super::{super::SubmitCohort, *};
 
     fn tx(sender: u8, nonce: u64, gas_limit: u64) -> SignedTransaction {
         tx_with_estimated_gas(sender, nonce, gas_limit, gas_limit)
@@ -159,6 +159,8 @@ mod tests {
             nonce,
             gas_limit,
             estimated_gas,
+            validity: Vec::new(),
+            cohort: SubmitCohort::Plain,
         }
     }
 

--- a/crates/infra/load-tests/src/runner/submission.rs
+++ b/crates/infra/load-tests/src/runner/submission.rs
@@ -18,6 +18,7 @@ use alloy_provider::RootProvider;
 use alloy_rpc_types::TransactionRequest;
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
+use base_execution_txpool::ValidityPredicate;
 use base_tx_manager::NonceManager;
 use tokio::{
     sync::{Mutex, Semaphore, mpsc},
@@ -56,6 +57,34 @@ pub const MIN_PRIORITY_FEE: u128 = 1;
 /// Ensures the rate-limit warning is only logged once per process, since a
 /// saturated RPC can otherwise report it on every batch under sustained load.
 static RATE_LIMIT_WARNED: AtomicBool = AtomicBool::new(false);
+
+/// Submission cohort a transaction is routed to.
+///
+/// A sender's cohort is assigned deterministically so its entire nonce stream
+/// flows through a single submission origin, keeping nonces contiguous.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SubmitCohort {
+    /// Plain `eth_sendRawTransaction` submission carrying no predicates.
+    #[default]
+    Plain,
+    /// Validity submission carrying resolved predicates.
+    ValidityPass,
+}
+
+impl SubmitCohort {
+    /// Returns true when the cohort submits via the validity path.
+    pub const fn is_validity(&self) -> bool {
+        !matches!(self, Self::Plain)
+    }
+
+    /// Returns a stable label for the cohort.
+    pub const fn label(&self) -> &'static str {
+        match self {
+            Self::Plain => "plain",
+            Self::ValidityPass => "validity_pass",
+        }
+    }
+}
 
 /// EIP-1559 fee fields for a transaction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -143,6 +172,11 @@ pub struct PreparedTransaction {
     pub gas_limit: u64,
     /// Calibrated execution gas used for pacing.
     pub estimated_gas: u64,
+    /// Resolved validity predicates transported with the transaction. Empty for
+    /// the plain cohort.
+    pub validity: Vec<ValidityPredicate>,
+    /// Submission cohort this transaction is routed to.
+    pub cohort: SubmitCohort,
 }
 
 /// Submission events emitted by signer and sender stages.
@@ -209,6 +243,11 @@ pub struct SignedTransaction {
     pub gas_limit: u64,
     /// Calibrated execution gas used for pacing.
     pub estimated_gas: u64,
+    /// Resolved validity predicates transported with the transaction. Empty for
+    /// the plain cohort.
+    pub validity: Vec<ValidityPredicate>,
+    /// Submission cohort this transaction is routed to.
+    pub cohort: SubmitCohort,
 }
 
 /// A batch of prepared transactions.
@@ -725,6 +764,8 @@ impl SubmissionPipeline {
             nonce,
             gas_limit: prepared.gas_limit,
             estimated_gas: prepared.estimated_gas,
+            validity: prepared.validity.clone(),
+            cohort: prepared.cohort,
         })
     }
 
@@ -826,8 +867,11 @@ impl SubmissionPipeline {
             }
 
             let attempt = batch.attempt;
-            let submit_items: Vec<SubmitItem> =
-                batch.txs.iter().map(|s| SubmitItem::plain(s.raw.clone())).collect();
+            let submit_items: Vec<SubmitItem> = batch
+                .txs
+                .iter()
+                .map(|s| SubmitItem::with_validity(s.raw.clone(), s.validity.clone()))
+                .collect();
             let rpc_index = batch_id as usize % ctx.submission_batch_rpcs.len();
             let batch_results = match ctx.submission_batch_rpcs[rpc_index]
                 .send_raw_transactions(&submit_items, ctx.submit_request_limiter.as_deref())
@@ -1202,7 +1246,7 @@ mod tests {
     use super::{
         BatchTxError, Fees, GasPricer, MAX_FEE_BASE_FEE_MULTIPLIER, MIN_PRIORITY_FEE,
         PipelineQueue, PreparedBatch, PreparedTransaction, SignedBatch, SignedTransaction,
-        SubmissionPipeline, SubmitEvent,
+        SubmissionPipeline, SubmitCohort, SubmitEvent,
     };
 
     #[test]
@@ -1348,6 +1392,8 @@ mod tests {
             data: Bytes::new(),
             gas_limit: 21_000,
             estimated_gas: 12_345,
+            validity: Vec::new(),
+            cohort: SubmitCohort::Plain,
         };
         let fees = Fees { max_fee: 100, priority_fee: 10 };
 
@@ -1385,6 +1431,8 @@ mod tests {
                     data: Bytes::new(),
                     gas_limit: 21_000,
                     estimated_gas: 21_000,
+                    validity: Vec::new(),
+                    cohort: SubmitCohort::Plain,
                 }],
             })
             .await
@@ -1406,6 +1454,8 @@ mod tests {
                     nonce: 0,
                     gas_limit: 21_000,
                     estimated_gas: 21_000,
+                    validity: Vec::new(),
+                    cohort: SubmitCohort::Plain,
                 }],
             })
             .await

--- a/crates/infra/load-tests/src/runner/validity_router.rs
+++ b/crates/infra/load-tests/src/runner/validity_router.rs
@@ -1,0 +1,288 @@
+//! Per-sender routing and predicate resolution for validity transactions.
+//!
+//! Cohort assignment is deterministic per sender: a sender's entire nonce
+//! stream flows through a single submission origin (plain vs. validity), which
+//! keeps nonces contiguous and single-origin under congestion. Predicate
+//! templates are resolved into concrete [`ValidityPredicate`] values against
+//! each transaction's `from`/`to` at prepare time.
+
+use alloy_primitives::{Address, B256, U256, keccak256};
+use base_execution_txpool::ValidityPredicate;
+
+use super::{LoadConfig, PredicateAddress, SlotTemplate, SubmitCohort, ValidityPredicateTemplate};
+
+/// Salt mixed into the per-sender validity routing hash.
+const VALIDITY_SENDER_SALT: u64 = 0x7661_6c69_6469_7479; // "validity"
+
+/// Routes transactions onto submission cohorts and resolves validity predicates.
+#[derive(Debug, Clone)]
+pub struct ValidityRouter {
+    ratio: f64,
+    predicates: Vec<ValidityPredicateTemplate>,
+    seed: u64,
+}
+
+impl ValidityRouter {
+    /// Builds a router from the runtime load configuration.
+    pub fn new(config: &LoadConfig) -> Self {
+        Self {
+            ratio: config.validity_ratio,
+            predicates: config.validity_predicates.clone(),
+            seed: config.seed,
+        }
+    }
+
+    /// Returns true when no transaction will ever be routed to the validity path.
+    pub fn is_disabled(&self) -> bool {
+        self.ratio <= 0.0
+    }
+
+    /// Determines the submission cohort for a sender.
+    ///
+    /// The decision is deterministic in `(seed, sender)` so a sender's entire
+    /// nonce stream shares one origin across the run.
+    pub fn cohort_for_sender(&self, sender: Address) -> SubmitCohort {
+        if self.is_disabled()
+            || !sender_in_fraction(sender, self.seed, VALIDITY_SENDER_SALT, self.ratio)
+        {
+            return SubmitCohort::Plain;
+        }
+        SubmitCohort::ValidityPass
+    }
+
+    /// Resolves the configured predicate templates into concrete predicates for
+    /// a transaction. Returns an empty vector for the plain cohort, which carries
+    /// no predicates.
+    pub fn predicates_for(
+        &self,
+        cohort: SubmitCohort,
+        from: Address,
+        to: Option<Address>,
+    ) -> Vec<ValidityPredicate> {
+        match cohort {
+            SubmitCohort::ValidityPass => {
+                self.predicates.iter().map(|t| Self::resolve(t, from, to)).collect()
+            }
+            SubmitCohort::Plain => Vec::new(),
+        }
+    }
+
+    /// Resolves a single template into a concrete predicate.
+    fn resolve(
+        template: &ValidityPredicateTemplate,
+        from: Address,
+        to: Option<Address>,
+    ) -> ValidityPredicate {
+        match template {
+            ValidityPredicateTemplate::Balance { address, op, value } => {
+                ValidityPredicate::Balance {
+                    address: resolve_address(address, from, to),
+                    op: *op,
+                    value: *value,
+                }
+            }
+            ValidityPredicateTemplate::Storage { address, slot, mask, op, value } => {
+                ValidityPredicate::Storage {
+                    address: resolve_address(address, from, to),
+                    slot: resolve_slot(slot, from, to),
+                    mask: mask.unwrap_or_else(ValidityPredicate::default_mask),
+                    op: *op,
+                    value: *value,
+                }
+            }
+        }
+    }
+}
+
+/// Resolves a predicate address source against a transaction's `from`/`to`.
+///
+/// A contract-creation transaction (no `to`) falls back to the sender.
+fn resolve_address(source: &PredicateAddress, from: Address, to: Option<Address>) -> Address {
+    match source {
+        PredicateAddress::Sender => from,
+        PredicateAddress::Recipient => to.unwrap_or(from),
+        PredicateAddress::Fixed(addr) => *addr,
+    }
+}
+
+/// Resolves a storage slot source, computing the Solidity mapping slot when
+/// required.
+fn resolve_slot(slot: &SlotTemplate, from: Address, to: Option<Address>) -> U256 {
+    match slot {
+        SlotTemplate::Fixed(value) => *value,
+        SlotTemplate::Mapping { mapping_slot, key } => {
+            mapping_slot_for(resolve_address(key, from, to), *mapping_slot)
+        }
+    }
+}
+
+/// Computes the Solidity mapping storage slot `keccak256(key ++ mapping_slot)`
+/// for a 20-byte address key left-padded to 32 bytes.
+fn mapping_slot_for(key: Address, mapping_slot: U256) -> U256 {
+    let mut preimage = [0u8; 64];
+    preimage[12..32].copy_from_slice(key.as_slice());
+    preimage[32..64].copy_from_slice(&mapping_slot.to_be_bytes::<32>());
+    U256::from_be_bytes::<32>(keccak256(preimage).0)
+}
+
+/// Returns true when a sender falls within `fraction` of the sender space for a
+/// given salt, using a deterministic hash of `(seed, salt, sender)`.
+fn sender_in_fraction(sender: Address, seed: u64, salt: u64, fraction: f64) -> bool {
+    if fraction <= 0.0 {
+        return false;
+    }
+    if fraction >= 1.0 {
+        return true;
+    }
+    let mut preimage = [0u8; 36];
+    preimage[..8].copy_from_slice(&seed.to_be_bytes());
+    preimage[8..16].copy_from_slice(&salt.to_be_bytes());
+    preimage[16..36].copy_from_slice(sender.as_slice());
+    let digest: B256 = keccak256(preimage);
+    // Map the leading 8 bytes to a uniform [0, 1) value.
+    let bucket = u64::from_be_bytes(digest.0[..8].try_into().expect("8 bytes"));
+    (bucket as f64) / (u64::MAX as f64) < fraction
+}
+
+#[cfg(test)]
+mod tests {
+    use base_execution_txpool::ValidityOperator;
+
+    use super::*;
+
+    fn router(ratio: f64, predicates: Vec<ValidityPredicateTemplate>) -> ValidityRouter {
+        ValidityRouter { ratio, predicates, seed: 12345 }
+    }
+
+    #[test]
+    fn disabled_router_routes_everything_plain() {
+        let r = router(0.0, Vec::new());
+        assert!(r.is_disabled());
+        assert_eq!(r.cohort_for_sender(Address::repeat_byte(0x11)), SubmitCohort::Plain);
+    }
+
+    #[test]
+    fn full_ratio_routes_all_senders_to_validity() {
+        let r = router(1.0, Vec::new());
+        for i in 0..50u8 {
+            assert_eq!(
+                r.cohort_for_sender(Address::repeat_byte(i)),
+                SubmitCohort::ValidityPass,
+                "sender {i} must route to validity at ratio 1.0"
+            );
+        }
+    }
+
+    #[test]
+    fn cohort_is_stable_per_sender() {
+        let r = router(0.5, Vec::new());
+        let sender = Address::repeat_byte(0x22);
+        let first = r.cohort_for_sender(sender);
+        for _ in 0..10 {
+            assert_eq!(r.cohort_for_sender(sender), first);
+        }
+    }
+
+    #[test]
+    fn ratio_selects_roughly_the_configured_fraction() {
+        let r = router(0.3, Vec::new());
+        let total = 2_000u32;
+        let validity = (0..total)
+            .filter(|i| {
+                let mut bytes = [0u8; 20];
+                bytes[..4].copy_from_slice(&i.to_be_bytes());
+                r.cohort_for_sender(Address::from(bytes)).is_validity()
+            })
+            .count();
+        let fraction = validity as f64 / total as f64;
+        assert!((fraction - 0.3).abs() < 0.05, "fraction {fraction} should be near 0.3");
+    }
+
+    #[test]
+    fn pass_cohort_resolves_sender_and_recipient_addresses() {
+        let templates = vec![
+            ValidityPredicateTemplate::Balance {
+                address: PredicateAddress::Sender,
+                op: ValidityOperator::GreaterThanOrEqual,
+                value: U256::ZERO,
+            },
+            ValidityPredicateTemplate::Balance {
+                address: PredicateAddress::Recipient,
+                op: ValidityOperator::LessThanOrEqual,
+                value: U256::MAX,
+            },
+        ];
+        let r = router(1.0, templates);
+        let from = Address::repeat_byte(0xaa);
+        let to = Address::repeat_byte(0xbb);
+        let predicates = r.predicates_for(SubmitCohort::ValidityPass, from, Some(to));
+        assert_eq!(predicates.len(), 2);
+        match &predicates[0] {
+            ValidityPredicate::Balance { address, .. } => assert_eq!(*address, from),
+            other => panic!("expected balance, got {other:?}"),
+        }
+        match &predicates[1] {
+            ValidityPredicate::Balance { address, .. } => assert_eq!(*address, to),
+            other => panic!("expected balance, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plain_cohort_carries_no_predicates() {
+        let templates = vec![ValidityPredicateTemplate::Balance {
+            address: PredicateAddress::Sender,
+            op: ValidityOperator::GreaterThanOrEqual,
+            value: U256::ZERO,
+        }];
+        let r = router(1.0, templates);
+        let from = Address::repeat_byte(0xaa);
+        assert!(r.predicates_for(SubmitCohort::Plain, from, None).is_empty());
+    }
+
+    #[test]
+    fn recipient_address_falls_back_to_sender_on_create() {
+        let templates = vec![ValidityPredicateTemplate::Balance {
+            address: PredicateAddress::Recipient,
+            op: ValidityOperator::GreaterThanOrEqual,
+            value: U256::ZERO,
+        }];
+        let r = router(1.0, templates);
+        let from = Address::repeat_byte(0xaa);
+        let predicates = r.predicates_for(SubmitCohort::ValidityPass, from, None);
+        match &predicates[0] {
+            ValidityPredicate::Balance { address, .. } => assert_eq!(*address, from),
+            other => panic!("expected balance, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mapping_slot_matches_solidity_layout() {
+        // keccak256(pad32(key) ++ pad32(slot)) is the canonical mapping slot.
+        let key = Address::repeat_byte(0x01);
+        let templates = vec![ValidityPredicateTemplate::Storage {
+            address: PredicateAddress::Fixed(Address::repeat_byte(0x99)),
+            slot: SlotTemplate::Mapping {
+                mapping_slot: U256::ZERO,
+                key: PredicateAddress::Fixed(key),
+            },
+            mask: None,
+            op: ValidityOperator::GreaterThanOrEqual,
+            value: U256::ZERO,
+        }];
+        let r = router(1.0, templates);
+        let predicates = r.predicates_for(SubmitCohort::ValidityPass, Address::ZERO, None);
+        let expected = {
+            let mut preimage = [0u8; 64];
+            preimage[12..32].copy_from_slice(key.as_slice());
+            // mapping_slot 0 => all zero high half
+            U256::from_be_bytes::<32>(keccak256(preimage).0)
+        };
+        match &predicates[0] {
+            ValidityPredicate::Storage { slot, mask, .. } => {
+                assert_eq!(*slot, expected);
+                assert_eq!(*mask, ValidityPredicate::default_mask());
+            }
+            other => panic!("expected storage, got {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
Part of BASE-163 (validity/conditional load testing). **Stack 3/5** — base: \`base-163-02-config\`.

Wires config through the submission pipeline so a configurable fraction of senders submit conditional transactions.

- \`SubmitCohort\` (plain, validity pass/control) carried plus resolved predicates on Prepared/Signed transactions.
- \`ValidityRouter\`: deterministic per-sender gate (hash of seed+salt+sender) so a sender's whole nonce stream stays single-origin, avoiding cross-origin nonce gaps under congestion. Resolves predicate templates (sender/recipient/fixed addresses, fixed and mapping-balanceOf slots) at prepare time.
- Mixed-batch submission via \`send_transactions\`, method chosen per element.
- Fail-loud: startup probe of \`base_sendRawTransactionValidity\` hard-fails when the workload is enabled but the endpoint is unserved; in-flight -32601 treated as a non-nonce-returning failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)