### PR TITLE
feat(load-tests): break down confirmed metrics by cohort

### DIFF
--- a/crates/infra/load-tests/src/lib.rs
+++ b/crates/infra/load-tests/src/lib.rs
@@ -27,10 +27,11 @@ pub use rpc::{
 
 mod metrics;
 pub use metrics::{
-    BlockLoadMetrics, BlockRange, ConfigSummary, FlashblocksLatencyMetrics, GasMetrics,
-    LatencyMetrics, MetricsAggregator, MetricsCollector, MetricsSummary, PacingCycleObservation,
-    PacingCycleSource, PacingMetrics, ReceiptCoverage, RollingWindow, SubmissionStats,
-    ThroughputMetrics, ThroughputPercentiles, ThroughputSample, TransactionMetrics,
+    BlockLoadMetrics, BlockRange, CohortMetrics, ConfigSummary, FlashblocksLatencyMetrics,
+    GasMetrics, LatencyMetrics, MetricsAggregator, MetricsCollector, MetricsSummary,
+    PacingCycleObservation, PacingCycleSource, PacingMetrics, ReceiptCoverage, RollingWindow,
+    SubmissionStats, SubmitCohortLabel, ThroughputMetrics, ThroughputPercentiles, ThroughputSample,
+    TransactionMetrics,
 };
 
 mod workload;

--- a/crates/infra/load-tests/src/metrics/aggregator.rs
+++ b/crates/infra/load-tests/src/metrics/aggregator.rs
@@ -3,9 +3,9 @@ use std::{cmp::Reverse, collections::BTreeMap, time::Duration};
 use serde::{Deserialize, Serialize};
 
 use super::{
-    BlockLoadMetrics, BlockRange, ConfigSummary, FlashblocksLatencyMetrics, GasMetrics,
-    LatencyMetrics, PacingMetrics, SubmissionStats, ThroughputMetrics, ThroughputPercentiles,
-    ThroughputSample, TransactionMetrics,
+    BlockLoadMetrics, BlockRange, CohortMetrics, ConfigSummary, FlashblocksLatencyMetrics,
+    GasMetrics, LatencyMetrics, PacingMetrics, SubmissionStats, SubmitCohortLabel,
+    ThroughputMetrics, ThroughputPercentiles, ThroughputSample, TransactionMetrics,
 };
 
 /// Aggregates raw transaction metrics into summary statistics.
@@ -70,7 +70,43 @@ impl<'a> MetricsAggregator<'a> {
             top_failure_reasons,
             receipt_coverage,
             fresh_recipient_count,
+            by_cohort: Self::compute_by_cohort(self.transactions),
         }
+    }
+
+    /// Breaks confirmed transactions down by submission cohort.
+    ///
+    /// Returns an empty vector when every confirmed transaction is
+    /// [`SubmitCohortLabel::Plain`], so the breakdown only appears in the summary
+    /// when validity transactions were actually exercised.
+    fn compute_by_cohort(transactions: &[TransactionMetrics]) -> Vec<CohortMetrics> {
+        if transactions.iter().all(|t| t.cohort == SubmitCohortLabel::Plain) {
+            return Vec::new();
+        }
+
+        let labels = [SubmitCohortLabel::Plain, SubmitCohortLabel::ValidityPass];
+        labels
+            .into_iter()
+            .filter_map(|cohort| {
+                let members: Vec<&TransactionMetrics> =
+                    transactions.iter().filter(|t| t.cohort == cohort).collect();
+                if members.is_empty() {
+                    return None;
+                }
+                let confirmed = members.len() as u64;
+                let reverted = members.iter().filter(|t| t.reverted).count() as u64;
+                let total_gas: u64 = members.iter().map(|t| t.gas_used).sum();
+                let mut latencies: Vec<Duration> =
+                    members.iter().filter_map(|t| t.block_latency).collect();
+                Some(CohortMetrics {
+                    cohort,
+                    confirmed,
+                    reverted,
+                    total_gas,
+                    block_latency: Self::compute_duration_metrics(&mut latencies),
+                })
+            })
+            .collect()
     }
 
     fn compute_block_range<'t>(
@@ -282,6 +318,10 @@ pub struct MetricsSummary {
     /// Number of fresh recipient keys generated during the run.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fresh_recipient_count: Option<u64>,
+    /// Confirmed-transaction metrics broken down by submission cohort. Empty
+    /// unless validity transactions were exercised during the run.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub by_cohort: Vec<CohortMetrics>,
 }
 
 impl MetricsSummary {
@@ -363,5 +403,48 @@ mod tests {
 
     fn unconfirmed_transaction(gas_used: u64) -> TransactionMetrics {
         TransactionMetrics::new(TxHash::ZERO, None, None, gas_used, 0, None)
+    }
+
+    fn cohort_transaction(
+        block_number: u64,
+        gas_used: u64,
+        cohort: SubmitCohortLabel,
+    ) -> TransactionMetrics {
+        let mut transaction = TransactionMetrics::new(
+            TxHash::ZERO,
+            Some(Duration::from_millis(10)),
+            None,
+            gas_used,
+            0,
+            Some(block_number),
+        );
+        transaction.cohort = cohort;
+        transaction
+    }
+
+    #[test]
+    fn by_cohort_is_empty_when_all_plain() {
+        let transactions = [transaction(10, 100), transaction(11, 200)];
+
+        assert!(MetricsAggregator::compute_by_cohort(&transactions).is_empty());
+    }
+
+    #[test]
+    fn by_cohort_splits_confirmed_across_cohorts() {
+        let transactions = [
+            cohort_transaction(10, 100, SubmitCohortLabel::Plain),
+            cohort_transaction(11, 200, SubmitCohortLabel::ValidityPass),
+            cohort_transaction(12, 300, SubmitCohortLabel::ValidityPass),
+        ];
+
+        let by_cohort = MetricsAggregator::compute_by_cohort(&transactions);
+
+        assert_eq!(by_cohort.len(), 2);
+        assert_eq!(by_cohort[0].cohort, SubmitCohortLabel::Plain);
+        assert_eq!(by_cohort[0].confirmed, 1);
+        assert_eq!(by_cohort[0].total_gas, 100);
+        assert_eq!(by_cohort[1].cohort, SubmitCohortLabel::ValidityPass);
+        assert_eq!(by_cohort[1].confirmed, 2);
+        assert_eq!(by_cohort[1].total_gas, 500);
     }
 }

--- a/crates/infra/load-tests/src/metrics/mod.rs
+++ b/crates/infra/load-tests/src/metrics/mod.rs
@@ -2,9 +2,10 @@
 
 mod types;
 pub use types::{
-    BlockLoadMetrics, BlockRange, ConfigSummary, FlashblocksLatencyMetrics, GasMetrics,
-    LatencyMetrics, PacingCycleObservation, PacingCycleSource, PacingMetrics, SubmissionStats,
-    ThroughputMetrics, ThroughputPercentiles, ThroughputSample, TransactionMetrics,
+    BlockLoadMetrics, BlockRange, CohortMetrics, ConfigSummary, FlashblocksLatencyMetrics,
+    GasMetrics, LatencyMetrics, PacingCycleObservation, PacingCycleSource, PacingMetrics,
+    SubmissionStats, SubmitCohortLabel, ThroughputMetrics, ThroughputPercentiles, ThroughputSample,
+    TransactionMetrics,
 };
 
 mod rolling_window;

--- a/crates/infra/load-tests/src/metrics/types.rs
+++ b/crates/infra/load-tests/src/metrics/types.rs
@@ -19,6 +19,17 @@ pub struct SubmissionStats<'a> {
     pub failure_reasons: &'a HashMap<String, u64>,
 }
 
+/// Submission cohort a transaction was routed through, in serialized output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SubmitCohortLabel {
+    /// Plain `eth_sendRawTransaction` submission carrying no predicates.
+    #[default]
+    Plain,
+    /// Validity submission carrying resolved predicates.
+    ValidityPass,
+}
+
 /// Metrics for a single transaction.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TransactionMetrics {
@@ -37,6 +48,9 @@ pub struct TransactionMetrics {
     pub block_number: Option<u64>,
     /// Whether the transaction reverted during execution.
     pub reverted: bool,
+    /// Submission cohort this transaction was routed through.
+    #[serde(default)]
+    pub cohort: SubmitCohortLabel,
     /// When canonical inclusion was observed (used by the rolling window).
     #[serde(skip)]
     pub confirmed_at: Option<Instant>,
@@ -60,6 +74,7 @@ impl TransactionMetrics {
             gas_price,
             block_number,
             reverted: false,
+            cohort: SubmitCohortLabel::Plain,
             confirmed_at: None,
         }
     }
@@ -85,6 +100,21 @@ pub struct LatencyMetrics {
     pub p95: Duration,
     /// 99th percentile latency.
     pub p99: Duration,
+}
+
+/// Confirmed-transaction metrics broken down for a single submission cohort.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CohortMetrics {
+    /// Cohort these metrics summarize.
+    pub cohort: SubmitCohortLabel,
+    /// Confirmed transactions in this cohort.
+    pub confirmed: u64,
+    /// Confirmed transactions in this cohort that reverted during execution.
+    pub reverted: u64,
+    /// Total gas used by confirmed transactions in this cohort.
+    pub total_gas: u64,
+    /// Block landing latency for this cohort's confirmed transactions.
+    pub block_latency: LatencyMetrics,
 }
 
 /// Aggregated throughput metrics.

--- a/crates/infra/load-tests/src/runner/flashblock_watcher.rs
+++ b/crates/infra/load-tests/src/runner/flashblock_watcher.rs
@@ -202,7 +202,7 @@ mod tests {
     use tokio::sync::mpsc;
 
     use super::*;
-    use crate::runner::{InclusionSource, SentTransaction};
+    use crate::runner::{InclusionSource, SentTransaction, SubmitCohort};
 
     #[tokio::test]
     async fn matching_flashblock_publishes_early_refill_pulse() {
@@ -215,6 +215,7 @@ mod tests {
             from: sender,
             estimated_gas: 21_000,
             measured: true,
+            cohort: SubmitCohort::Plain,
         }]);
         let (pulse_tx, mut pulse_rx) = mpsc::channel(1);
         let watcher = FlashblockWatcher::new(

--- a/crates/infra/load-tests/src/runner/results_tracker.rs
+++ b/crates/infra/load-tests/src/runner/results_tracker.rs
@@ -10,7 +10,7 @@ use alloy_primitives::{Address, TxHash};
 use parking_lot::RwLock;
 use tokio::sync::mpsc;
 
-use super::InclusionPulse;
+use super::{InclusionPulse, SubmitCohort};
 use crate::metrics::TransactionMetrics;
 
 /// Maximum flashblock entries retained from recent stream events.
@@ -29,6 +29,8 @@ pub struct SentTransaction {
     pub estimated_gas: u64,
     /// Whether this transaction belongs to the measured cohort.
     pub measured: bool,
+    /// Submission cohort this transaction was routed through.
+    pub cohort: SubmitCohort,
 }
 
 /// A block observed by the block watcher.
@@ -117,6 +119,7 @@ struct PendingTransaction {
     in_flight_released: bool,
     measured: bool,
     estimated_gas: u64,
+    cohort: SubmitCohort,
 }
 
 #[derive(Debug)]
@@ -211,6 +214,7 @@ impl ResultsTracker {
                     in_flight_released: flashblock_observed_at.is_some(),
                     measured,
                     estimated_gas: transaction.estimated_gas,
+                    cohort: transaction.cohort,
                 },
             );
             inner
@@ -551,6 +555,7 @@ impl ResultsTrackerInner {
             0,
             Some(block.number),
         );
+        metrics.cohort = pending.cohort.to_metric_label();
         metrics.confirmed_at = Some(block.observed_at);
         self.unreported_confirmations.push_back(metrics);
 
@@ -594,7 +599,13 @@ mod tests {
     }
 
     fn sent(tx_hash: TxHash, from: Address, measured: bool) -> SentTransaction {
-        SentTransaction { tx_hash, from, estimated_gas: 21_000, measured }
+        SentTransaction {
+            tx_hash,
+            from,
+            estimated_gas: 21_000,
+            measured,
+            cohort: SubmitCohort::Plain,
+        }
     }
 
     #[test]

--- a/crates/infra/load-tests/src/runner/submission.rs
+++ b/crates/infra/load-tests/src/runner/submission.rs
@@ -84,6 +84,14 @@ impl SubmitCohort {
             Self::ValidityPass => "validity_pass",
         }
     }
+
+    /// Maps the cohort to its serializable metrics label.
+    pub const fn to_metric_label(self) -> crate::metrics::SubmitCohortLabel {
+        match self {
+            Self::Plain => crate::metrics::SubmitCohortLabel::Plain,
+            Self::ValidityPass => crate::metrics::SubmitCohortLabel::ValidityPass,
+        }
+    }
 }
 
 /// EIP-1559 fee fields for a transaction.
@@ -1087,6 +1095,7 @@ impl SubmissionPipeline {
             from: signed.from,
             estimated_gas: signed.estimated_gas,
             measured,
+            cohort: signed.cohort,
         }]);
         Self::release_signed(&ctx.submit_event_tx, &signed, true).await;
         let _ = ctx.submit_event_tx.send(SubmitEvent::Submitted(tracked_hash)).await;


### PR DESCRIPTION
Part of BASE-163 (validity/conditional load testing). **Stack 4/5** — base: \`base-163-03-routing\` (#4400).

Attributes confirmed-transaction metrics to their submission cohort so plain, validity-pass, and validity-control lanes can be compared under identical congestion.

- Carry \`SubmitCohort\` on \`SentTransaction\`/\`PendingTransaction\`, joined onto \`TransactionMetrics\` at canonical landing.
- Add \`SubmitCohortLabel\` and a \`CohortMetrics\` breakdown (confirmed count, reverts, gas, block latency) per cohort.
- Surface \`by_cohort\` on \`MetricsSummary\`; stays empty/unserialized unless validity transactions were exercised, so plain runs are unchanged.

The builder emits no validity-specific rejection metric, so the breakdown is over confirmed transactions and inclusion is compared relatively across cohorts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)