### PR TITLE
feat(registrar): add hinted contract clients

### DIFF
--- a/crates/proof/contracts/src/cert_manager.rs
+++ b/crates/proof/contracts/src/cert_manager.rs
@@ -1,0 +1,326 @@
+//! Hinted `CertManager` contract bindings.
+//!
+//! Cache writes accept caller-supplied P-384 inverse hints. Hint generation and
+//! registration orchestration intentionally remain outside this client.
+
+use alloy_primitives::{Address, B256, Bytes};
+use alloy_provider::RootProvider;
+use alloy_sol_types::{SolCall, SolError, sol};
+use async_trait::async_trait;
+
+use crate::ContractError;
+
+sol! {
+    /// Raw metadata stored for a verified certificate.
+    struct CertManagerVerifiedCert {
+        bool ca;
+        uint64 notAfter;
+        int64 maxPathLen;
+        bytes32 subjectHash;
+        bytes pubKey;
+    }
+
+    /// Registrar subset of the active hinted `CertManager` interface.
+    #[sol(rpc)]
+    interface ICertManager {
+        /// Thrown when an owner-only operation is called by another account.
+        error NotOwner();
+
+        /// Thrown when a non-root revocation is called by another account.
+        error NotRevoker();
+
+        /// Returns the account that controls owner-only operations.
+        function owner() external view returns (address);
+
+        /// Returns the account allowed to revoke non-root certificates.
+        function revoker() external view returns (address);
+
+        /// Verifies and caches a CA certificate using caller-supplied inverse hints.
+        function verifyCACertWithHints(
+            bytes calldata cert,
+            bytes32 parentCertHash,
+            bytes calldata signatureHints
+        ) external returns (bytes32 certHash);
+
+        /// Verifies and caches a leaf certificate using caller-supplied inverse hints.
+        function verifyClientCertWithHints(
+            bytes calldata cert,
+            bytes32 parentCertHash,
+            bytes calldata signatureHints
+        ) external returns (CertManagerVerifiedCert memory verifiedCert);
+
+        /// Returns raw cached metadata, which may be expired or revoked.
+        function loadVerified(bytes32 certHash)
+            external
+            view
+            returns (CertManagerVerifiedCert memory cert);
+
+        /// Returns whether a certificate issuer/serial identity is revoked.
+        function isRevoked(bytes32 certId) external view returns (bool);
+
+        /// Computes the stable issuer/serial identity for a DER certificate.
+        function computeCertId(bytes calldata cert) external pure returns (bytes32 certId);
+
+        /// Revokes a certificate issuer/serial identity.
+        function revokeCert(bytes32 certId) external;
+    }
+}
+
+/// Ergonomic Rust representation of a raw `CertManager` cache entry.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VerifiedCert {
+    /// Whether the cached certificate is a CA certificate.
+    pub ca: bool,
+    /// X.509 `notAfter` timestamp in Unix seconds.
+    pub not_after: u64,
+    /// Remaining CA path length, or `-1` when unconstrained.
+    pub max_path_len: i64,
+    /// Keccak hash of the certificate subject.
+    pub subject_hash: B256,
+    /// Raw P-384 public key bytes.
+    pub public_key: Bytes,
+}
+
+impl From<CertManagerVerifiedCert> for VerifiedCert {
+    fn from(cert: CertManagerVerifiedCert) -> Self {
+        Self {
+            ca: cert.ca,
+            not_after: cert.notAfter,
+            max_path_len: cert.maxPathLen,
+            subject_hash: cert.subjectHash,
+            public_key: cert.pubKey,
+        }
+    }
+}
+
+/// `CertManager` authorization failure decoded from raw revert data.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CertManagerAuthorizationError {
+    /// An owner-only operation was attempted by another account.
+    NotOwner,
+    /// A revoker-only operation was attempted by another account.
+    NotRevoker,
+}
+
+/// Returns the 4-byte selector for `NotOwner()`.
+pub const fn cert_manager_not_owner_selector() -> [u8; 4] {
+    ICertManager::NotOwner::SELECTOR
+}
+
+/// Returns the 4-byte selector for `NotRevoker()`.
+pub const fn cert_manager_not_revoker_selector() -> [u8; 4] {
+    ICertManager::NotRevoker::SELECTOR
+}
+
+/// Classifies a `CertManager` authorization failure from raw revert data.
+pub fn decode_cert_manager_authorization_error(
+    revert_data: &[u8],
+) -> Option<CertManagerAuthorizationError> {
+    let selector = revert_data.get(..4)?;
+    if selector == cert_manager_not_owner_selector() {
+        Some(CertManagerAuthorizationError::NotOwner)
+    } else if selector == cert_manager_not_revoker_selector() {
+        Some(CertManagerAuthorizationError::NotRevoker)
+    } else {
+        None
+    }
+}
+
+/// Reads cache, revocation, identity, and role data from `CertManager`.
+#[async_trait]
+pub trait CertManagerClient: Send + Sync + std::fmt::Debug {
+    /// Returns the `CertManager` address this client is bound to.
+    fn address(&self) -> Address;
+
+    /// Returns raw cached metadata, which may be expired or revoked.
+    async fn load_verified(&self, cert_hash: B256) -> Result<VerifiedCert, ContractError>;
+
+    /// Returns whether a certificate issuer/serial identity is revoked.
+    async fn is_revoked(&self, cert_id: B256) -> Result<bool, ContractError>;
+
+    /// Returns the owner account.
+    async fn owner(&self) -> Result<Address, ContractError>;
+
+    /// Returns the non-root certificate revoker account.
+    async fn revoker(&self) -> Result<Address, ContractError>;
+
+    /// Computes the onchain issuer/serial identity for a DER certificate.
+    async fn compute_cert_id(&self, cert: Bytes) -> Result<B256, ContractError>;
+}
+
+/// Concrete implementation backed by Alloy's sol-generated contract bindings.
+#[derive(Debug)]
+pub struct CertManagerContractClient {
+    contract: ICertManager::ICertManagerInstance<RootProvider>,
+}
+
+impl CertManagerContractClient {
+    /// Creates a client for the `CertManager` returned by `NitroValidator.certManager()`.
+    pub fn new(address: Address, l1_rpc_url: url::Url) -> Self {
+        let provider = RootProvider::new_http(l1_rpc_url);
+        let contract = ICertManager::ICertManagerInstance::new(address, provider);
+        Self { contract }
+    }
+}
+
+#[async_trait]
+impl CertManagerClient for CertManagerContractClient {
+    fn address(&self) -> Address {
+        *self.contract.address()
+    }
+
+    async fn load_verified(&self, cert_hash: B256) -> Result<VerifiedCert, ContractError> {
+        let cert = contract_call!(
+            self.contract.loadVerified(cert_hash).call(),
+            format!("loadVerified({cert_hash})")
+        )?;
+        Ok(cert.into())
+    }
+
+    async fn is_revoked(&self, cert_id: B256) -> Result<bool, ContractError> {
+        contract_call!(self.contract.isRevoked(cert_id).call(), format!("isRevoked({cert_id})"))
+    }
+
+    async fn owner(&self) -> Result<Address, ContractError> {
+        contract_call!(self.contract.owner().call(), "owner()")
+    }
+
+    async fn revoker(&self) -> Result<Address, ContractError> {
+        contract_call!(self.contract.revoker().call(), "revoker()")
+    }
+
+    async fn compute_cert_id(&self, cert: Bytes) -> Result<B256, ContractError> {
+        contract_call!(self.contract.computeCertId(cert).call(), "computeCertId(bytes)")
+    }
+}
+
+/// Encodes a permissionless CA cache transaction using supplied signature hints.
+pub fn encode_verify_ca_cert_with_hints_calldata(
+    cert: Bytes,
+    parent_cert_hash: B256,
+    signature_hints: Bytes,
+) -> Bytes {
+    Bytes::from(
+        ICertManager::verifyCACertWithHintsCall {
+            cert,
+            parentCertHash: parent_cert_hash,
+            signatureHints: signature_hints,
+        }
+        .abi_encode(),
+    )
+}
+
+/// Encodes a permissionless leaf cache transaction using supplied signature hints.
+pub fn encode_verify_client_cert_with_hints_calldata(
+    cert: Bytes,
+    parent_cert_hash: B256,
+    signature_hints: Bytes,
+) -> Bytes {
+    Bytes::from(
+        ICertManager::verifyClientCertWithHintsCall {
+            cert,
+            parentCertHash: parent_cert_hash,
+            signatureHints: signature_hints,
+        }
+        .abi_encode(),
+    )
+}
+
+/// Encodes a revocation transaction for an issuer/serial certificate identity.
+pub fn encode_revoke_cert_calldata(cert_id: B256) -> Bytes {
+    Bytes::from(ICertManager::revokeCertCall { certId: cert_id }.abi_encode())
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_sol_types::SolCall as _;
+
+    use super::*;
+
+    #[test]
+    fn cert_manager_selectors_match_final_contract_abi() {
+        assert_eq!(ICertManager::verifyCACertWithHintsCall::SELECTOR, [0x03, 0x1c, 0xf0, 0x67]);
+        assert_eq!(ICertManager::verifyClientCertWithHintsCall::SELECTOR, [0x77, 0xf2, 0xdd, 0x74]);
+        assert_eq!(ICertManager::loadVerifiedCall::SELECTOR, [0x9c, 0x32, 0x56, 0xed]);
+        assert_eq!(ICertManager::isRevokedCall::SELECTOR, [0x42, 0x94, 0x85, 0x7f]);
+        assert_eq!(ICertManager::computeCertIdCall::SELECTOR, [0xad, 0x1f, 0xd8, 0xbd]);
+        assert_eq!(ICertManager::revokeCertCall::SELECTOR, [0x8c, 0xb5, 0x0c, 0x44]);
+        assert_eq!(ICertManager::ownerCall::SELECTOR, [0x8d, 0xa5, 0xcb, 0x5b]);
+        assert_eq!(ICertManager::revokerCall::SELECTOR, [0x35, 0xde, 0xc5, 0xd1]);
+    }
+
+    #[test]
+    fn cache_transaction_calldata_roundtrips() {
+        let cert = Bytes::from_static(b"certificate-der");
+        let parent_cert_hash = B256::repeat_byte(0x11);
+        let signature_hints = Bytes::from(vec![0x22; 96]);
+
+        let ca_calldata = encode_verify_ca_cert_with_hints_calldata(
+            cert.clone(),
+            parent_cert_hash,
+            signature_hints.clone(),
+        );
+        let ca = ICertManager::verifyCACertWithHintsCall::abi_decode(&ca_calldata)
+            .expect("CA cache calldata should decode");
+        assert_eq!(ca.cert, cert);
+        assert_eq!(ca.parentCertHash, parent_cert_hash);
+        assert_eq!(ca.signatureHints, signature_hints);
+
+        let leaf_calldata = encode_verify_client_cert_with_hints_calldata(
+            ca.cert.clone(),
+            ca.parentCertHash,
+            ca.signatureHints.clone(),
+        );
+        let leaf = ICertManager::verifyClientCertWithHintsCall::abi_decode(&leaf_calldata)
+            .expect("leaf cache calldata should decode");
+        assert_eq!(leaf.cert, ca.cert);
+        assert_eq!(leaf.parentCertHash, ca.parentCertHash);
+        assert_eq!(leaf.signatureHints, ca.signatureHints);
+    }
+
+    #[test]
+    fn cached_metadata_decodes_all_fields() {
+        let raw = CertManagerVerifiedCert {
+            ca: true,
+            notAfter: 2_519_044_085,
+            maxPathLen: -1,
+            subjectHash: B256::repeat_byte(0x33),
+            pubKey: Bytes::from(vec![0x44; 96]),
+        };
+        let encoded = ICertManager::loadVerifiedCall::abi_encode_returns_tuple(&(raw,));
+        let decoded = ICertManager::loadVerifiedCall::abi_decode_returns(&encoded)
+            .expect("cache metadata should decode");
+        let cert = VerifiedCert::from(decoded);
+
+        assert!(cert.ca);
+        assert_eq!(cert.not_after, 2_519_044_085);
+        assert_eq!(cert.max_path_len, -1);
+        assert_eq!(cert.subject_hash, B256::repeat_byte(0x33));
+        assert_eq!(cert.public_key, Bytes::from(vec![0x44; 96]));
+    }
+
+    #[test]
+    fn revocation_calldata_uses_issuer_serial_identity() {
+        let cert_id = B256::repeat_byte(0x55);
+        let calldata = encode_revoke_cert_calldata(cert_id);
+        let decoded = ICertManager::revokeCertCall::abi_decode(&calldata)
+            .expect("revokeCert calldata should decode");
+        assert_eq!(decoded.certId, cert_id);
+    }
+
+    #[test]
+    fn authorization_errors_are_classified_separately() {
+        assert_eq!(cert_manager_not_owner_selector(), [0x30, 0xcd, 0x74, 0x71]);
+        assert_eq!(cert_manager_not_revoker_selector(), [0x2a, 0xd3, 0xd4, 0x4f]);
+        assert_eq!(
+            decode_cert_manager_authorization_error(&cert_manager_not_owner_selector()),
+            Some(CertManagerAuthorizationError::NotOwner)
+        );
+        assert_eq!(
+            decode_cert_manager_authorization_error(&cert_manager_not_revoker_selector()),
+            Some(CertManagerAuthorizationError::NotRevoker)
+        );
+        assert_eq!(decode_cert_manager_authorization_error(&[0xde, 0xad, 0xbe, 0xef]), None);
+        assert_eq!(decode_cert_manager_authorization_error(&[0x30, 0xcd]), None);
+    }
+}

--- a/crates/proof/contracts/src/hinted_tee_prover_registry.rs
+++ b/crates/proof/contracts/src/hinted_tee_prover_registry.rs
@@ -1,0 +1,133 @@
+//! Final hinted `TEEProverRegistry` contract bindings.
+//!
+//! This binding remains separate from the legacy two-argument Registry binding
+//! until the Boundless registration backend is removed.
+
+use alloy_primitives::{Address, Bytes};
+use alloy_provider::RootProvider;
+use alloy_sol_types::{SolCall, sol};
+use async_trait::async_trait;
+
+use crate::ContractError;
+
+sol! {
+    /// Registrar subset of the final hinted `TEEProverRegistry` contract interface.
+    #[sol(rpc)]
+    interface IHintedTEEProverRegistry {
+        /// Thrown when the attestation timestamp is in the future.
+        error AttestationFromFuture();
+
+        /// Thrown when the attestation document is too old.
+        error AttestationTooOld();
+
+        /// Thrown when the attestation's PCR0 is malformed or not trusted.
+        error InvalidPCR0();
+
+        /// Thrown when the attestation's public key is malformed.
+        error InvalidPublicKey();
+
+        /// Thrown when PCR0 is not found in the attestation's PCR list.
+        error PCR0NotFound();
+
+        /// Returns the validator configured immutably on this Registry implementation.
+        function NITRO_VALIDATOR() external view returns (address);
+
+        /// Registers a signer using a hinted AWS Nitro attestation.
+        function registerSigner(
+            bytes calldata attestationTbs,
+            bytes calldata signature,
+            bytes calldata hints
+        ) external;
+    }
+}
+
+/// Reads the immutable validator address from the final hinted Registry implementation.
+#[async_trait]
+pub trait HintedTEEProverRegistryClient: Send + Sync + std::fmt::Debug {
+    /// Returns the Registry address this client is bound to.
+    fn address(&self) -> Address;
+
+    /// Returns the `NitroValidator` address configured on the Registry implementation.
+    async fn nitro_validator(&self) -> Result<Address, ContractError>;
+}
+
+/// Concrete implementation backed by Alloy's sol-generated contract bindings.
+#[derive(Debug)]
+pub struct HintedTEEProverRegistryContractClient {
+    contract: IHintedTEEProverRegistry::IHintedTEEProverRegistryInstance<RootProvider>,
+}
+
+impl HintedTEEProverRegistryContractClient {
+    /// Creates a client for the final hinted Registry ABI.
+    pub fn new(address: Address, l1_rpc_url: url::Url) -> Self {
+        let provider = RootProvider::new_http(l1_rpc_url);
+        let contract =
+            IHintedTEEProverRegistry::IHintedTEEProverRegistryInstance::new(address, provider);
+        Self { contract }
+    }
+}
+
+#[async_trait]
+impl HintedTEEProverRegistryClient for HintedTEEProverRegistryContractClient {
+    fn address(&self) -> Address {
+        *self.contract.address()
+    }
+
+    async fn nitro_validator(&self) -> Result<Address, ContractError> {
+        contract_call!(self.contract.NITRO_VALIDATOR().call(), "NITRO_VALIDATOR()")
+    }
+}
+
+/// Encodes calldata for the final three-argument `registerSigner` call.
+pub fn encode_hinted_register_signer_calldata(
+    attestation_tbs: Bytes,
+    signature: Bytes,
+    hints: Bytes,
+) -> Bytes {
+    Bytes::from(
+        IHintedTEEProverRegistry::registerSignerCall {
+            attestationTbs: attestation_tbs,
+            signature,
+            hints,
+        }
+        .abi_encode(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_sol_types::SolCall as _;
+
+    use super::*;
+
+    #[test]
+    fn hinted_registry_selectors_match_final_contract_abi() {
+        assert_eq!(
+            IHintedTEEProverRegistry::NITRO_VALIDATORCall::SELECTOR,
+            [0x96, 0xce, 0x7e, 0x96]
+        );
+        assert_eq!(
+            IHintedTEEProverRegistry::registerSignerCall::SELECTOR,
+            [0xb3, 0x9d, 0xc0, 0x9d]
+        );
+    }
+
+    #[test]
+    fn hinted_register_signer_calldata_roundtrips() {
+        let attestation_tbs = Bytes::from_static(b"attestation-tbs");
+        let signature = Bytes::from(vec![0x11; 96]);
+        let hints = Bytes::from(vec![0x22; 144]);
+
+        let calldata = encode_hinted_register_signer_calldata(
+            attestation_tbs.clone(),
+            signature.clone(),
+            hints.clone(),
+        );
+        let decoded = IHintedTEEProverRegistry::registerSignerCall::abi_decode(&calldata)
+            .expect("hinted registerSigner calldata should decode");
+
+        assert_eq!(decoded.attestationTbs, attestation_tbs);
+        assert_eq!(decoded.signature, signature);
+        assert_eq!(decoded.hints, hints);
+    }
+}

--- a/crates/proof/contracts/src/lib.rs
+++ b/crates/proof/contracts/src/lib.rs
@@ -38,6 +38,23 @@ pub use tee_prover_registry::{
     ITEEProverRegistry, TEEProverRegistryClient, TEEProverRegistryContractClient,
 };
 
+mod hinted_tee_prover_registry;
+pub use hinted_tee_prover_registry::{
+    HintedTEEProverRegistryClient, HintedTEEProverRegistryContractClient, IHintedTEEProverRegistry,
+    encode_hinted_register_signer_calldata,
+};
+
+mod nitro_validator;
+pub use nitro_validator::{INitroValidator, NitroValidatorClient, NitroValidatorContractClient};
+
+mod cert_manager;
+pub use cert_manager::{
+    CertManagerAuthorizationError, CertManagerClient, CertManagerContractClient, ICertManager,
+    VerifiedCert, cert_manager_not_owner_selector, cert_manager_not_revoker_selector,
+    decode_cert_manager_authorization_error, encode_revoke_cert_calldata,
+    encode_verify_ca_cert_with_hints_calldata, encode_verify_client_cert_with_hints_calldata,
+};
+
 mod nitro_enclave_verifier;
 pub use nitro_enclave_verifier::{
     INitroEnclaveVerifier, NitroEnclaveVerifierClient, NitroEnclaveVerifierContractClient,

--- a/crates/proof/contracts/src/nitro_validator.rs
+++ b/crates/proof/contracts/src/nitro_validator.rs
@@ -1,0 +1,68 @@
+//! `NitroValidator` contract bindings.
+//!
+//! The Registrar discovers `CertManager` through the validator configured on
+//! the Registry instead of accepting an independently configured address.
+
+use alloy_primitives::Address;
+use alloy_provider::RootProvider;
+use alloy_sol_types::sol;
+use async_trait::async_trait;
+
+use crate::ContractError;
+
+sol! {
+    /// `NitroValidator` discovery interface.
+    #[sol(rpc)]
+    interface INitroValidator {
+        /// Returns the `CertManager` configured immutably on this validator.
+        function certManager() external view returns (address);
+    }
+}
+
+/// Discovers `CertManager` from the `NitroValidator` selected by the Registry.
+#[async_trait]
+pub trait NitroValidatorClient: Send + Sync + std::fmt::Debug {
+    /// Returns the validator address this client is bound to.
+    fn address(&self) -> Address;
+
+    /// Returns the `CertManager` address configured on this validator.
+    async fn cert_manager(&self) -> Result<Address, ContractError>;
+}
+
+/// Concrete implementation backed by Alloy's sol-generated contract bindings.
+#[derive(Debug)]
+pub struct NitroValidatorContractClient {
+    contract: INitroValidator::INitroValidatorInstance<RootProvider>,
+}
+
+impl NitroValidatorContractClient {
+    /// Creates a client for the validator returned by the Registry.
+    pub fn new(address: Address, l1_rpc_url: url::Url) -> Self {
+        let provider = RootProvider::new_http(l1_rpc_url);
+        let contract = INitroValidator::INitroValidatorInstance::new(address, provider);
+        Self { contract }
+    }
+}
+
+#[async_trait]
+impl NitroValidatorClient for NitroValidatorContractClient {
+    fn address(&self) -> Address {
+        *self.contract.address()
+    }
+
+    async fn cert_manager(&self) -> Result<Address, ContractError> {
+        contract_call!(self.contract.certManager().call(), "certManager()")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_sol_types::SolCall as _;
+
+    use super::*;
+
+    #[test]
+    fn cert_manager_selector_matches_final_contract_abi() {
+        assert_eq!(INitroValidator::certManagerCall::SELECTOR, [0x73, 0x9e, 0x84, 0x84]);
+    }
+}

--- a/crates/proof/tee/registrar/src/crl.rs
+++ b/crates/proof/tee/registrar/src/crl.rs
@@ -14,6 +14,8 @@ use x509_parser::{
     revocation_list::CertificateRevocationList,
 };
 
+use crate::CertManagerKeys;
+
 const MAX_CRL_RESPONSE_BYTES: usize = 10 * 1024 * 1024;
 const ALLOWED_CRL_HOST_SUFFIX: &str = ".amazonaws.com";
 const ALLOWED_CRL_HOST_KEYWORD: &str = "nitro-enclave";
@@ -28,11 +30,23 @@ pub struct CertCrlInfo {
     /// CRL distribution point URL, if present in the certificate.
     pub crl_url: Option<String>,
     /// Accumulated path digest for this certificate position (for onchain
-    /// `revokeCert` calls).
+    /// legacy `NitroEnclaveVerifier.revokeCert` calls).
     pub path_digest: B256,
+    /// DER bytes retained for lazy final `CertManager` identity derivation.
+    cert_der: Vec<u8>,
 }
 
 impl CertCrlInfo {
+    /// Returns the issuer/serial identity for final `CertManager.revokeCert` calls.
+    ///
+    /// This remains lazy so final `CertManager` parsing requirements cannot change
+    /// the legacy path-digest CRL path before the hinted backend is selected.
+    pub fn revocation_id(&self) -> Result<B256, CrlError> {
+        CertManagerKeys::revocation_id(&self.cert_der).map_err(|e| {
+            CrlError(format!("certificate identity error: certificate {}: {e}", self.index))
+        })
+    }
+
     /// Extracts CRL-relevant information from a DER-encoded chain's intermediate certificates.
     ///
     /// The certificates must be in chain order: root → intermediates → leaf.
@@ -66,7 +80,7 @@ impl CertCrlInfo {
             let serial_number = cert.tbs_certificate.serial.to_bytes_be();
             let crl_url = extract_crl_distribution_point(&cert);
 
-            infos.push(Self { index, serial_number, crl_url, path_digest });
+            infos.push(Self { index, serial_number, crl_url, path_digest, cert_der: der.to_vec() });
         }
 
         Ok(infos)
@@ -230,6 +244,7 @@ pub struct CrlError(
 
 #[cfg(test)]
 mod tests {
+    use alloy_primitives::b256;
     use hex_literal::hex;
 
     use super::*;
@@ -296,6 +311,36 @@ mod tests {
                 "cb286a4a4a09207f8b0c14950dcd6861",
                 "c8925d382506d820d93d2c704a7523c4ba2ddfaa",
             ]
+        );
+        for info in &infos {
+            assert_eq!(
+                info.revocation_id().unwrap(),
+                CertManagerKeys::revocation_id(refs[info.index]).unwrap()
+            );
+            assert_ne!(info.revocation_id().unwrap(), info.path_digest);
+        }
+    }
+
+    #[test]
+    fn crl_identities_match_registration_plan_and_preserve_legacy_digests() {
+        use base_proof_tee_nitro_verifier::AttestationReport;
+
+        use crate::AttestationPlanner;
+
+        let attestation =
+            hex::decode(include_str!("testdata/nitro_attestation.hex").trim()).unwrap();
+        let report = AttestationReport::parse(&attestation).unwrap();
+        let infos = CertCrlInfo::from_chain(&report.cert_chain_der()).unwrap();
+        let plan = AttestationPlanner::prepare_registration_plan(&attestation).unwrap();
+
+        assert_eq!(infos.len(), plan.certs.len() - 1);
+        for (info, cert) in infos.iter().zip(&plan.certs) {
+            assert_eq!(info.revocation_id().unwrap(), cert.revocation_id);
+            assert_ne!(info.path_digest, info.revocation_id().unwrap());
+        }
+        assert_eq!(
+            infos[0].revocation_id().unwrap(),
+            b256!("0xd985a3a751ddd841816eb3d64041272eed9b695a2d61a46408a1950c0bae28e7")
         );
     }
 

--- a/crates/proof/tee/registrar/src/crl.rs
+++ b/crates/proof/tee/registrar/src/crl.rs
@@ -14,8 +14,6 @@ use x509_parser::{
     revocation_list::CertificateRevocationList,
 };
 
-use crate::CertManagerKeys;
-
 const MAX_CRL_RESPONSE_BYTES: usize = 10 * 1024 * 1024;
 const ALLOWED_CRL_HOST_SUFFIX: &str = ".amazonaws.com";
 const ALLOWED_CRL_HOST_KEYWORD: &str = "nitro-enclave";
@@ -30,23 +28,11 @@ pub struct CertCrlInfo {
     /// CRL distribution point URL, if present in the certificate.
     pub crl_url: Option<String>,
     /// Accumulated path digest for this certificate position (for onchain
-    /// legacy `NitroEnclaveVerifier.revokeCert` calls).
+    /// `revokeCert` calls).
     pub path_digest: B256,
-    /// DER bytes retained for lazy final `CertManager` identity derivation.
-    cert_der: Vec<u8>,
 }
 
 impl CertCrlInfo {
-    /// Returns the issuer/serial identity for final `CertManager.revokeCert` calls.
-    ///
-    /// This remains lazy so final `CertManager` parsing requirements cannot change
-    /// the legacy path-digest CRL path before the hinted backend is selected.
-    pub fn revocation_id(&self) -> Result<B256, CrlError> {
-        CertManagerKeys::revocation_id(&self.cert_der).map_err(|e| {
-            CrlError(format!("certificate identity error: certificate {}: {e}", self.index))
-        })
-    }
-
     /// Extracts CRL-relevant information from a DER-encoded chain's intermediate certificates.
     ///
     /// The certificates must be in chain order: root → intermediates → leaf.
@@ -80,7 +66,7 @@ impl CertCrlInfo {
             let serial_number = cert.tbs_certificate.serial.to_bytes_be();
             let crl_url = extract_crl_distribution_point(&cert);
 
-            infos.push(Self { index, serial_number, crl_url, path_digest, cert_der: der.to_vec() });
+            infos.push(Self { index, serial_number, crl_url, path_digest });
         }
 
         Ok(infos)
@@ -244,7 +230,6 @@ pub struct CrlError(
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::b256;
     use hex_literal::hex;
 
     use super::*;
@@ -311,36 +296,6 @@ mod tests {
                 "cb286a4a4a09207f8b0c14950dcd6861",
                 "c8925d382506d820d93d2c704a7523c4ba2ddfaa",
             ]
-        );
-        for info in &infos {
-            assert_eq!(
-                info.revocation_id().unwrap(),
-                CertManagerKeys::revocation_id(refs[info.index]).unwrap()
-            );
-            assert_ne!(info.revocation_id().unwrap(), info.path_digest);
-        }
-    }
-
-    #[test]
-    fn crl_identities_match_registration_plan_and_preserve_legacy_digests() {
-        use base_proof_tee_nitro_verifier::AttestationReport;
-
-        use crate::AttestationPlanner;
-
-        let attestation =
-            hex::decode(include_str!("testdata/nitro_attestation.hex").trim()).unwrap();
-        let report = AttestationReport::parse(&attestation).unwrap();
-        let infos = CertCrlInfo::from_chain(&report.cert_chain_der()).unwrap();
-        let plan = AttestationPlanner::prepare_registration_plan(&attestation).unwrap();
-
-        assert_eq!(infos.len(), plan.certs.len() - 1);
-        for (info, cert) in infos.iter().zip(&plan.certs) {
-            assert_eq!(info.revocation_id().unwrap(), cert.revocation_id);
-            assert_ne!(info.path_digest, info.revocation_id().unwrap());
-        }
-        assert_eq!(
-            infos[0].revocation_id().unwrap(),
-            b256!("0xd985a3a751ddd841816eb3d64041272eed9b695a2d61a46408a1950c0bae28e7")
         );
     }
 


### PR DESCRIPTION
## Summary

- add final-ABI clients for hinted `TEEProverRegistry`, `NitroValidator`, and `CertManager` discovery and reads
- add calldata encoders for three-argument signer registration, CA/leaf certificate caching, and issuer/serial revocation
- add cache metadata decoding and distinct `NotOwner` / `NotRevoker` error classification

## Implementation boundary

- accepts raw hint bytes and does not depend on O2 hint-generation types
- does not wire the clients into `service.rs`, configuration, or the active registration path
- does not add a backend abstraction, runtime selector, configured-address overrides, ABI probing, or mixed-generation fallback
- leaves the legacy CRL model unchanged; O1 already supplies issuer/serial identities and O5 replaces the active path directly
- keeps the final three-argument Registry binding source-isolated until O5 makes it canonical during the direct cutover

## Testing

- `RISC0_SKIP_BUILD_KERNELS=1 cargo test -p base-proof-contracts -p base-proof-tee-registrar`
- `RISC0_SKIP_BUILD_KERNELS=1 cargo clippy -p base-proof-contracts -p base-proof-tee-registrar --all-targets -- -D warnings`
- `cargo fmt --all`
- `git diff --check`

Linear: https://linear.app/coinbase/issue/CHAIN-4837/offchain-registrar-add-hinted-contract-clients