### PR TITLE
fix(batcher): fail channel close instead of publishing a truncated channel

### DIFF
--- a/crates/batcher/comp/src/channel_out.rs
+++ b/crates/batcher/comp/src/channel_out.rs
@@ -9,9 +9,6 @@ use rand::{RngCore, SeedableRng, rngs::SmallRng};
 
 use crate::{ChannelCompressor, CompressorError};
 
-/// The frame overhead.
-const FRAME_V0_OVERHEAD: usize = 23;
-
 /// An error returned by the [`ChannelOut`] when adding single batches.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum ChannelOutError {
@@ -135,13 +132,11 @@ where
     /// Call this repeatedly until [`ready_bytes`] returns 0 to drain all
     /// compressed data into frames. Only the final frame (when no data
     /// remains and the channel is closed) will have `is_last = true`.
+    /// `max_size` must leave room for at least one compressed byte after
+    /// frame metadata and the optional channel-version byte.
     ///
     /// [`ready_bytes`]: ChannelOut::ready_bytes
     pub fn output_frame(&mut self, max_size: usize) -> Result<Frame, ChannelOutError> {
-        if max_size < FRAME_V0_OVERHEAD {
-            return Err(ChannelOutError::MaxFrameSizeTooSmall);
-        }
-
         // The first frame carries the channel version prefix (if any) so that
         // the reader can identify the compression format.  For brotli this is
         // `0x01`; zlib data is self-identifying and needs no prefix.
@@ -149,15 +144,20 @@ where
             if self.frame_number == 0 { self.compressor.channel_version_byte() } else { None };
         let prefix_len = usize::from(version_byte.is_some());
 
-        let max_size = (max_size - FRAME_V0_OVERHEAD - prefix_len).min(self.ready_bytes());
+        let overhead = Frame::ENCODED_OVERHEAD + prefix_len;
+        if max_size <= overhead {
+            return Err(ChannelOutError::MaxFrameSizeTooSmall);
+        }
 
-        let mut data = Vec::with_capacity(prefix_len + max_size);
+        let payload_capacity = max_size - overhead;
+        let payload_size = payload_capacity.min(self.ready_bytes());
+
+        let mut data = Vec::with_capacity(prefix_len + payload_size);
         if let Some(v) = version_byte {
             data.push(v);
         }
 
-        // Read `max_size` bytes from the compressed data.
-        let mut buf = vec![0u8; max_size];
+        let mut buf = vec![0u8; payload_size];
         self.compressor.read(&mut buf).map_err(ChannelOutError::Compression)?;
         data.extend_from_slice(&buf);
 
@@ -184,20 +184,57 @@ mod tests {
 
     #[test]
     fn test_output_frame_max_size_too_small() {
-        let config = RollupConfig::default();
+        let compressor =
+            MockCompressor { compressed: Some(Bytes::from_static(b"x")), ..Default::default() };
         let mut channel =
-            ChannelOut::new(ChannelId::default(), Arc::new(config), MockCompressor::default());
-        assert_eq!(channel.output_frame(0), Err(ChannelOutError::MaxFrameSizeTooSmall));
+            ChannelOut::new(ChannelId::default(), Arc::new(RollupConfig::default()), compressor);
+        channel.close();
+
+        assert_eq!(
+            channel.output_frame(Frame::ENCODED_OVERHEAD),
+            Err(ChannelOutError::MaxFrameSizeTooSmall)
+        );
+
+        let frame =
+            channel.output_frame(Frame::ENCODED_OVERHEAD + 1).expect("one payload byte should fit");
+        assert_eq!(frame.data, Bytes::from_static(b"x"));
     }
 
     #[test]
-    fn test_channel_out_output_frame_no_data() {
+    fn test_output_frame_reserves_channel_version_byte() {
+        let compressor = MockCompressor {
+            compressed: Some(Bytes::from_static(b"x")),
+            version_byte: Some(1),
+            ..Default::default()
+        };
+        let mut channel =
+            ChannelOut::new(ChannelId::default(), Arc::new(RollupConfig::default()), compressor);
+        channel.close();
+
+        assert_eq!(
+            channel.output_frame(Frame::ENCODED_OVERHEAD + 1),
+            Err(ChannelOutError::MaxFrameSizeTooSmall)
+        );
+
+        let frame = channel
+            .output_frame(Frame::ENCODED_OVERHEAD + 2)
+            .expect("version and payload bytes should fit");
+        assert_eq!(frame.data, Bytes::from_static(b"\x01x"));
+    }
+
+    #[test]
+    fn test_output_frame_propagates_compressor_error() {
         let mut channel = ChannelOut::new(
             ChannelId::default(),
             Arc::new(RollupConfig::default()),
-            MockCompressor { read_error: true, compressed: Some(Default::default()) },
+            MockCompressor {
+                compressed: Some(Bytes::from_static(b"x")),
+                read_error: true,
+                ..Default::default()
+            },
         );
-        let err = channel.output_frame(FRAME_V0_OVERHEAD).unwrap_err();
+
+        let err = channel.output_frame(Frame::ENCODED_OVERHEAD + 1).unwrap_err();
         assert_eq!(err, ChannelOutError::Compression(CompressorError::Full));
     }
 
@@ -208,7 +245,7 @@ mod tests {
             Arc::new(RollupConfig::default()),
             MockCompressor { compressed: Some(Default::default()), ..Default::default() },
         );
-        let frame = channel.output_frame(FRAME_V0_OVERHEAD).unwrap();
+        let frame = channel.output_frame(Frame::ENCODED_OVERHEAD + 1).unwrap();
         assert_eq!(frame.id, ChannelId::default());
         assert_eq!(frame.number, 0);
         assert!(!frame.is_last);

--- a/crates/batcher/comp/src/test_utils.rs
+++ b/crates/batcher/comp/src/test_utils.rs
@@ -13,6 +13,8 @@ pub struct MockCompressor {
     pub compressed: Option<Bytes>,
     /// Whether to throw a read error.
     pub read_error: bool,
+    /// Optional channel version prefix.
+    pub version_byte: Option<u8>,
 }
 
 impl CompressorWriter for MockCompressor {
@@ -44,13 +46,19 @@ impl CompressorWriter for MockCompressor {
             return Err(CompressorError::Full);
         }
         let len = self.compressed.as_ref().map(|b: &Bytes| b.len()).unwrap_or(0);
-        buf[..len].copy_from_slice(self.compressed.as_ref().unwrap());
+        buf[..len].copy_from_slice(
+            self.compressed.as_ref().expect("mock compressed output must be configured"),
+        );
         Ok(len)
     }
 }
 
 impl ChannelCompressor for MockCompressor {
     fn get_compressed(&self) -> Vec<u8> {
-        self.compressed.as_ref().unwrap().to_vec()
+        self.compressed.as_ref().expect("mock compressed output must be configured").to_vec()
+    }
+
+    fn channel_version_byte(&self) -> Option<u8> {
+        self.version_byte
     }
 }

--- a/crates/batcher/encoder/src/config.rs
+++ b/crates/batcher/encoder/src/config.rs
@@ -4,7 +4,7 @@ use base_common_genesis::RollupConfig;
 pub use base_comp::CompressionAlgo;
 use base_protocol::{
     BLOB_DERIVATION_PREFIX_SIZE as PROTOCOL_BLOB_DERIVATION_PREFIX_SIZE,
-    BLOB_MAX_DATA_SIZE as PROTOCOL_BLOB_MAX_DATA_SIZE, BatchType,
+    BLOB_MAX_DATA_SIZE as PROTOCOL_BLOB_MAX_DATA_SIZE, BatchType, Frame,
     MAX_BLOB_FRAME_SIZE as PROTOCOL_MAX_BLOB_FRAME_SIZE,
 };
 
@@ -153,20 +153,37 @@ impl EncoderConfig {
                 max_channel_duration: self.max_channel_duration,
             });
         }
+
+        // Every frame must carry at least one compressed byte in addition to
+        // its metadata and the optional Brotli channel-version byte.
+        let channel_version_size =
+            if matches!(self.compression_algo, CompressionAlgo::Zlib) { 0 } else { 1 };
+        let min_frame_size = Frame::ENCODED_OVERHEAD + channel_version_size + 1;
+
+        if self.max_frame_size < min_frame_size {
+            return Err(EncoderConfigError::FrameSizeTooSmall {
+                max_frame_size: self.max_frame_size,
+                min_frame_size,
+            });
+        }
+
         if matches!(self.da_type, DaType::Calldata) && self.target_num_frames != 1 {
             return Err(EncoderConfigError::CalldataRequiresSingleFrame {
                 target_num_frames: self.target_num_frames,
             });
         }
+
         if matches!(self.max_blocks_per_span_batch, Some(0 | 1)) {
             return Err(EncoderConfigError::InvalidMaxBlocksPerSpanBatch);
         }
+
         if matches!(self.da_type, DaType::Blob) && self.max_frame_size > Self::MAX_BLOB_FRAME_SIZE {
             return Err(EncoderConfigError::BlobFrameSizeTooLarge {
                 max_frame_size: self.max_frame_size,
                 max_blob_frame_size: Self::MAX_BLOB_FRAME_SIZE,
             });
         }
+
         if matches!(self.da_type, DaType::Blob)
             && self.target_frame_size > Self::MAX_BLOB_FRAME_SIZE
         {
@@ -175,11 +192,13 @@ impl EncoderConfig {
                 max_blob_frame_size: Self::MAX_BLOB_FRAME_SIZE,
             });
         }
+
         if self.approx_compr_ratio <= 0.0 || self.approx_compr_ratio > 1.0 {
             return Err(EncoderConfigError::InvalidApproxComprRatio {
                 approx_compr_ratio: self.approx_compr_ratio,
             });
         }
+
         Ok(())
     }
 
@@ -205,6 +224,7 @@ impl EncoderConfig {
                 },
             );
         }
+
         if !matches!(self.compression_algo, CompressionAlgo::Zlib)
             && !rollup_config.is_fjord_active(next_l2_timestamp)
         {
@@ -232,6 +252,17 @@ pub enum EncoderConfigError {
         sub_safety_margin: u64,
         /// The configured maximum channel duration.
         max_channel_duration: u64,
+    },
+    /// `max_frame_size` cannot carry one compressed byte and any required channel version.
+    #[error(
+        "max_frame_size ({max_frame_size}) must be at least {min_frame_size} bytes \
+         to carry frame metadata and payload"
+    )]
+    FrameSizeTooSmall {
+        /// The configured maximum frame size.
+        max_frame_size: usize,
+        /// The minimum frame size for the configured compression algorithm.
+        min_frame_size: usize,
     },
     /// `da_type == DaType::Calldata` but `target_num_frames != 1`.
     ///
@@ -362,6 +393,39 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains(&sub_safety_margin.to_string()));
         assert!(msg.contains(&max_channel_duration.to_string()));
+    }
+
+    #[rstest]
+    #[case(CompressionAlgo::Zlib, Frame::ENCODED_OVERHEAD, Frame::ENCODED_OVERHEAD + 1)]
+    #[case(CompressionAlgo::Brotli10, Frame::ENCODED_OVERHEAD + 1, Frame::ENCODED_OVERHEAD + 2)]
+    fn validate_rejects_frame_without_payload_capacity(
+        #[case] compression_algo: CompressionAlgo,
+        #[case] max_frame_size: usize,
+        #[case] min_frame_size: usize,
+    ) {
+        let cfg = EncoderConfig { compression_algo, max_frame_size, ..EncoderConfig::default() };
+
+        let err = cfg.validate().unwrap_err();
+
+        assert!(matches!(
+            err,
+            EncoderConfigError::FrameSizeTooSmall {
+                max_frame_size: actual,
+                min_frame_size: minimum,
+            } if actual == max_frame_size && minimum == min_frame_size
+        ));
+    }
+
+    #[rstest]
+    #[case(CompressionAlgo::Zlib, Frame::ENCODED_OVERHEAD + 1)]
+    #[case(CompressionAlgo::Brotli10, Frame::ENCODED_OVERHEAD + 2)]
+    fn validate_accepts_frame_with_payload_capacity(
+        #[case] compression_algo: CompressionAlgo,
+        #[case] max_frame_size: usize,
+    ) {
+        let cfg = EncoderConfig { compression_algo, max_frame_size, ..EncoderConfig::default() };
+
+        assert!(cfg.validate().is_ok());
     }
 
     #[test]

--- a/crates/batcher/encoder/src/encoder.rs
+++ b/crates/batcher/encoder/src/encoder.rs
@@ -141,9 +141,8 @@ impl BatchEncoder {
     ///
     /// # Errors
     ///
-    /// Returns the first [`StepError`] encountered during encoding. On error the
-    /// encoder state is left as-is; previously ready submissions remain available
-    /// via [`BatchPipeline::next_submission`].
+    /// Returns the first [`StepError`] encountered during encoding. Previously ready
+    /// submissions remain available via [`BatchPipeline::next_submission`].
     pub fn encode_and_drain(&mut self) -> Result<Vec<Arc<Frame>>, StepError> {
         loop {
             match self.step()? {
@@ -243,32 +242,24 @@ impl BatchEncoder {
     }
 
     /// Close the currently open channel, drain its frames, and push it to `ready_channels`.
-    fn close_open_channel(&mut self, close_reason: &'static str) {
+    fn close_open_channel(&mut self, close_reason: &'static str) -> Result<(), StepError> {
         let Some(mut open) = self.current_channel.take() else {
-            return;
+            return Ok(());
         };
 
         // Capture stats before flushing so we can record metrics after draining.
         let input_bytes = open.out.input_bytes();
         let opened_at_l1 = open.opened_at_l1;
         let blocks_added = open.blocks_added;
-
-        // Flush and close the compressor.
-        let _ = open.out.flush();
-        open.out.close();
-
         let channel_id = open.out.id;
 
-        // Drain all frames from the channel.
+        // Build the complete frame list before publishing the ready channel.
+        open.out.flush()?;
+        open.out.close();
+
         let mut frames = Vec::new();
         while open.out.ready_bytes() > 0 {
-            match open.out.output_frame(self.config.max_frame_size) {
-                Ok(frame) => frames.push(Arc::new(frame)),
-                Err(e) => {
-                    warn!(error = %e, "failed to output frame during channel close");
-                    break;
-                }
-            }
+            frames.push(Arc::new(open.out.output_frame(self.config.max_frame_size)?));
         }
 
         let encoded_block_end = open.block_start.saturating_add(blocks_added);
@@ -315,6 +306,8 @@ impl BatchEncoder {
             first_confirmed_l1_block: None,
             last_confirmed_l1_block: None,
         });
+
+        Ok(())
     }
 
     /// Close the current channel, drain its frames, and push it to `ready_channels`.
@@ -330,8 +323,7 @@ impl BatchEncoder {
             return Ok(());
         }
 
-        self.close_open_channel(close_reason);
-        Ok(())
+        self.close_open_channel(close_reason)
     }
 
     /// Flush the span accumulator or close the current channel so the next step can retry.
@@ -341,7 +333,7 @@ impl BatchEncoder {
             return Ok(true);
         }
 
-        self.close_or_discard_after_failed_span_flush(had_open_channel, close_reason);
+        self.close_or_discard_after_failed_span_flush(had_open_channel, close_reason)?;
         Ok(false)
     }
 
@@ -350,13 +342,14 @@ impl BatchEncoder {
         &mut self,
         had_open_channel: bool,
         close_reason: &'static str,
-    ) {
+    ) -> Result<(), StepError> {
         if had_open_channel {
-            self.close_open_channel(close_reason);
+            self.close_open_channel(close_reason)?;
         } else if self.current_channel.is_some() {
             BatcherMetrics::channel_closed_total(BatcherMetrics::REASON_DISCARD).increment(1);
             self.current_channel = None;
         }
+        Ok(())
     }
 
     /// Store a fatal encoding error so the next [`BatchPipeline::step`] reports it.
@@ -1841,6 +1834,26 @@ mod tests {
         // Cursor must still be 0 — the block was not consumed.
         assert_eq!(encoder.block_cursor, 0);
         assert_eq!(encoder.blocks.len(), 1);
+    }
+
+    #[test]
+    fn test_channel_output_failure_does_not_publish_partial_channel() {
+        let config =
+            EncoderConfig { max_frame_size: Frame::ENCODED_OVERHEAD, ..EncoderConfig::default() };
+        let mut encoder = BatchEncoder::new(Arc::new(RollupConfig::default()), config);
+
+        encoder.add_block(make_block(B256::ZERO)).unwrap();
+        assert_eq!(encoder.step().unwrap(), StepResult::BlockEncoded);
+
+        let err =
+            encoder.close_current_channel("force").expect_err("invalid frame size should fail");
+
+        assert!(matches!(
+            err,
+            StepError::ChannelOutputFailed(base_comp::ChannelOutError::MaxFrameSizeTooSmall)
+        ));
+        assert!(encoder.current_channel.is_none());
+        assert!(encoder.ready_channels.is_empty());
     }
 
     // --- Span batch tests ---

--- a/crates/batcher/encoder/src/pipeline.rs
+++ b/crates/batcher/encoder/src/pipeline.rs
@@ -41,8 +41,8 @@ pub trait BatchPipeline: Send {
     /// A step encodes one pending block into the current channel, or closes a full channel
     /// and moves it to the submission queue. Call repeatedly until [`StepResult::Idle`].
     ///
-    /// Returns [`StepError`] if a block cannot be composed into a batch. This is fatal:
-    /// skipping the block would silently break the contiguous L2 block sequence required
+    /// Returns [`StepError`] if batch composition or channel finalization fails. This is
+    /// fatal: continuing could silently break the contiguous L2 block sequence required
     /// by the derivation spec. The caller must not continue and should surface the error.
     fn step(&mut self) -> Result<StepResult, StepError>;
 
@@ -85,6 +85,9 @@ pub trait BatchPipeline: Send {
     ///
     /// Intended for test harnesses that need to flush the current channel without
     /// simulating L1 time progression.
+    ///
+    /// Implementations that encounter a fatal close error surface it from the next
+    /// [`step`](Self::step) call because this method cannot return a result.
     fn force_close_channel(&mut self);
 
     /// Reset buffered encoding and submission state.

--- a/crates/batcher/encoder/src/step.rs
+++ b/crates/batcher/encoder/src/step.rs
@@ -20,10 +20,9 @@ pub enum StepResult {
 /// Returned by [`BatchPipeline::step`](crate::BatchPipeline::step) when a block cannot be
 /// encoded and the pipeline cannot continue.
 ///
-/// Batch composition failure is fatal: a block that cannot be serialised into a
-/// [`SingleBatch`](base_protocol::batch::SingleBatch) would be silently absent
-/// from the submitted data, breaking the contiguous L2 block sequence required by the
-/// derivation spec. The batcher must halt rather than skip such a block.
+/// Encoding failures are fatal. Continuing after a block-composition, span-construction,
+/// or channel-output error could omit part of the contiguous L2 block sequence required
+/// by the derivation spec.
 #[derive(Debug, thiserror::Error)]
 pub enum StepError {
     /// The block could not be converted to a [`SingleBatch`].
@@ -55,4 +54,7 @@ pub enum StepError {
         #[source]
         source: ChannelOutError,
     },
+    /// A channel could not be finalized into frames.
+    #[error("failed to finalize channel: {0}")]
+    ChannelOutputFailed(#[from] ChannelOutError),
 }


### PR DESCRIPTION
## Summary

When closing a channel, the encoder swallowed frame-output errors (`warn!` + `break`)
and published whatever frames it had already drained. A framing failure could
therefore emit a **truncated channel**, silently dropping part of the contiguous
L2 block sequence the derivation spec requires.

Make channel finalization fatal: `close_open_channel` now propagates `flush` and
`output_frame` errors as `StepError`, so a failed close surfaces to the caller and
no partial channel is ever pushed to the ready queue.

## Changes

- Propagate errors from `close_open_channel` (`flush()?` / `output_frame()?`); add
  `StepError::ChannelOutputFailed`. A failed close discards the open channel,
  publishes nothing, and returns a fatal encoder error.
- Fix frame sizing: replace the hardcoded `FRAME_V0_OVERHEAD = 23` with
  `Frame::ENCODED_OVERHEAD`, reserve the Brotli channel-version byte, and require
  room for at least one compressed payload byte.
- Validate `max_frame_size` up front (`EncoderConfigError::FrameSizeTooSmall`) so a
  too-small frame budget fails at config time rather than mid-encode.
- Extend `MockCompressor` (channel version byte) and cover: min frame size, version
  byte reservation, compressor-error propagation, and non-publication of a partial
  channel.

## Testing

- `cargo test -p base-batcher-encoder -p base-comp`