### PR TITLE
feat(roxy): add backend configuration options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6279,6 +6279,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/bin/roxy/src/main.rs
+++ b/bin/roxy/src/main.rs
@@ -20,6 +20,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     let cli = Cli::parse();
+    cli.config.validate()?;
 
     LogConfig::default().init_tracing_subscriber().expect("failed to initialize tracing");
 

--- a/crates/infra/roxy/Cargo.toml
+++ b/crates/infra/roxy/Cargo.toml
@@ -12,6 +12,7 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
+url.workspace = true
 tokio-util.workspace = true
 tokio = { workspace = true, features = ["net"] }
 anyhow = { workspace = true, features = ["std"] }

--- a/crates/infra/roxy/README.md
+++ b/crates/infra/roxy/README.md
@@ -8,8 +8,20 @@ Rust service we own, focused on the features we actually run in production.
 ## Usage
 
 ```bash
-roxy --listen-addr 0.0.0.0:8545
+roxy \
+  --listen-addr 0.0.0.0:8545 \
+  --backend rpcs=http://127.0.0.1:8545,http://127.0.0.1:8546 \
+  --backend flashblocks=http://127.0.0.1:9545
 ```
+
+Backend flags use `name=url[,url...]` and may be repeated. The equivalent
+environment variable uses semicolons between backends:
+
+```bash
+ROXY_BACKENDS='rpcs=http://127.0.0.1:8545,http://127.0.0.1:8546;flashblocks=http://127.0.0.1:9545'
+```
+
+Literal commas and semicolons in URLs must be percent-encoded.
 
 `GET /healthz` is the liveness probe. `GET /readyz` is the readiness probe.
 

--- a/crates/infra/roxy/src/backend.rs
+++ b/crates/infra/roxy/src/backend.rs
@@ -1,0 +1,91 @@
+//! Named backend configuration.
+
+use url::Url;
+
+/// A named backend with one or more RPC URLs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Backend {
+    /// Backend name.
+    pub name: String,
+    /// RPC URLs assigned to the backend.
+    pub urls: Vec<Url>,
+}
+
+impl Backend {
+    /// Parses a backend in `name=url[,url...]` format.
+    pub fn parse(raw: &str) -> Result<Self, String> {
+        if raw.trim().is_empty() {
+            return Err("invalid backend: entry is empty".to_owned());
+        }
+
+        let (name, raw_urls) = raw
+            .split_once('=')
+            .ok_or_else(|| format!("invalid backend '{raw}': expected name=url[,url...]"))?;
+        let name = name.trim();
+        if name.is_empty() {
+            return Err(format!("invalid backend '{raw}': backend name is empty"));
+        }
+        if raw_urls.trim().is_empty() {
+            return Err(format!("invalid backend '{raw}': at least one URL is required"));
+        }
+
+        let urls = raw_urls
+            .split(',')
+            .map(|raw_url| {
+                let raw_url = raw_url.trim();
+                let url = Url::parse(raw_url)
+                    .map_err(|error| format!("invalid backend URL '{raw_url}': {error}"))?;
+                match url.scheme() {
+                    "http" | "https" => Ok(url),
+                    scheme => Err(format!(
+                        "invalid backend URL '{raw_url}': unsupported scheme '{scheme}'"
+                    )),
+                }
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Self { name: name.to_owned(), urls })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_named_backend_urls() {
+        let backend = Backend::parse("rpcs=http://127.0.0.1:8545,https://rpc.example.com")
+            .expect("valid backend");
+
+        assert_eq!(backend.name, "rpcs", "backend name must be preserved");
+        assert_eq!(backend.urls.len(), 2, "both URLs must be parsed");
+        assert_eq!(
+            backend.urls[0].as_str(),
+            "http://127.0.0.1:8545/",
+            "first URL must be preserved"
+        );
+        assert_eq!(
+            backend.urls[1].as_str(),
+            "https://rpc.example.com/",
+            "second URL must be preserved"
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_backend_values() {
+        for (raw, expected) in [
+            ("", "entry is empty"),
+            ("rpcs", "expected name=url"),
+            ("=http://127.0.0.1:8545", "backend name is empty"),
+            ("rpcs=", "at least one URL is required"),
+            ("rpcs= ", "at least one URL is required"),
+            ("rpcs=file:///tmp/rpc", "unsupported scheme 'file'"),
+        ] {
+            let error = Backend::parse(raw).expect_err("invalid backend");
+            assert!(
+                error.contains(expected),
+                "error '{error}' must contain '{expected}' for '{raw}'"
+            );
+        }
+    }
+}

--- a/crates/infra/roxy/src/config.rs
+++ b/crates/infra/roxy/src/config.rs
@@ -1,8 +1,11 @@
 //! CLI / env configuration for the Roxy HTTP server.
 
-use std::net::SocketAddr;
+use std::{collections::HashSet, net::SocketAddr};
 
+use anyhow::ensure;
 use clap::Args;
+
+use crate::Backend;
 
 /// Configuration for the Roxy HTTP server.
 #[derive(Args, Debug, Clone)]
@@ -10,4 +13,129 @@ pub struct Config {
     /// Socket address to bind the HTTP server to.
     #[arg(long, env = "ROXY_LISTEN_ADDR", default_value = "0.0.0.0:8545")]
     pub listen_addr: SocketAddr,
+
+    /// Named backend in `name=url[,url...]` format. May be repeated.
+    #[arg(
+        long = "backend",
+        env = "ROXY_BACKENDS",
+        value_name = "NAME=URL[,URL...]",
+        value_delimiter = ';',
+        required = true,
+        value_parser = Backend::parse
+    )]
+    pub backends: Vec<Backend>,
+}
+
+impl Config {
+    /// Validates relationships between configured options.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        let mut names = HashSet::new();
+        for backend in &self.backends {
+            ensure!(
+                names.insert(backend.name.as_str()),
+                "duplicate backend name '{}'",
+                backend.name
+            );
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{env, ffi::OsStr, process::Command as ProcessCommand};
+
+    use clap::{Command, FromArgMatches};
+
+    use super::*;
+
+    #[test]
+    fn parses_repeated_backend_flags() {
+        let matches = Config::augment_args(Command::new("roxy"))
+            .try_get_matches_from([
+                "roxy",
+                "--backend",
+                "rpcs=http://127.0.0.1:8545",
+                "--backend",
+                "flashblocks=http://127.0.0.1:8546",
+            ])
+            .expect("valid repeated backend flags");
+        let config = Config::from_arg_matches(&matches).expect("backend config");
+
+        assert_eq!(config.backends.len(), 2, "both backend flags must be parsed");
+        assert_eq!(config.backends[0].name, "rpcs", "first backend must be preserved");
+        assert_eq!(config.backends[1].name, "flashblocks", "second backend must be preserved");
+    }
+
+    #[test]
+    fn configures_plural_semicolon_delimited_env() {
+        if env::var_os("ROXY_ENV_TEST_CHILD").is_some() {
+            let matches = Config::augment_args(Command::new("roxy"))
+                .try_get_matches_from(["roxy"])
+                .expect("valid environment backends");
+            let config = Config::from_arg_matches(&matches).expect("backend config");
+
+            assert_eq!(config.backends.len(), 2, "both environment backends must be parsed");
+            assert_eq!(config.backends[0].name, "rpcs", "first backend must be preserved");
+            assert_eq!(config.backends[1].name, "flashblocks", "second backend must be preserved");
+            return;
+        }
+
+        let command = Config::augment_args(Command::new("roxy"));
+        let argument = command
+            .get_arguments()
+            .find(|argument| argument.get_id() == "backends")
+            .expect("backends argument");
+
+        assert_eq!(
+            argument.get_env(),
+            Some(OsStr::new("ROXY_BACKENDS")),
+            "backend environment variable must be plural"
+        );
+        assert_eq!(
+            argument.get_value_delimiter(),
+            Some(';'),
+            "environment entries must be semicolon-delimited"
+        );
+
+        let status = ProcessCommand::new(env::current_exe().expect("current test executable"))
+            .args(["--exact", "config::tests::configures_plural_semicolon_delimited_env"])
+            .env("ROXY_ENV_TEST_CHILD", "1")
+            .env("ROXY_BACKENDS", "rpcs=http://127.0.0.1:8545;flashblocks=http://127.0.0.1:8546")
+            .status()
+            .expect("run environment parsing subprocess");
+        assert!(status.success(), "environment parsing subprocess must pass");
+    }
+
+    #[test]
+    fn rejects_duplicate_backend_names() {
+        let matches = Config::augment_args(Command::new("roxy"))
+            .try_get_matches_from([
+                "roxy",
+                "--backend",
+                "rpcs=http://127.0.0.1:8545",
+                "--backend",
+                "rpcs=http://127.0.0.1:8546",
+            ])
+            .expect("individually valid backends");
+        let config = Config::from_arg_matches(&matches).expect("backend config");
+
+        let error = config.validate().expect_err("duplicate backend name");
+        assert!(
+            error.to_string().contains("duplicate backend name 'rpcs'"),
+            "error must identify the duplicate name: {error}"
+        );
+    }
+
+    #[test]
+    fn rejects_empty_delimited_backend_entries() {
+        let error = Config::augment_args(Command::new("roxy"))
+            .try_get_matches_from(["roxy", "--backend", "rpcs=http://127.0.0.1:8545;"])
+            .expect_err("empty backend entry");
+
+        assert!(
+            error.to_string().contains("entry is empty"),
+            "error must identify the empty backend entry: {error}"
+        );
+    }
 }

--- a/crates/infra/roxy/src/lib.rs
+++ b/crates/infra/roxy/src/lib.rs
@@ -1,5 +1,8 @@
 #![doc = include_str!("../README.md")]
 
+mod backend;
+pub use backend::Backend;
+
 mod config;
 pub use config::Config;
 


### PR DESCRIPTION
## Motivation

Roxy needs backend configuration before proxy routing can be added. The CLI and environment variable must represent multiple named backends consistently.

## Changes

- Add repeated `--backend name=url[,url...]` options with HTTP(S) URL validation.
- Add semicolon-delimited `ROXY_BACKENDS` support and reject duplicate names or empty entries.
- Document CLI and environment variable syntax.

## Tests

| Test Name | Description |
|---|---|
| `cargo test -p base-roxy -p base-roxy-bin` | Verifies backend parsing, repeated flags, real environment parsing, validation, and existing health endpoints. |
| `cargo fmt --check -p base-roxy -p base-roxy-bin` | Verifies formatting. |

Made with [Cursor](https://cursor.com)