### PR TITLE
feat(payload): finalize Denim payloads on resolve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4396,6 +4396,7 @@ dependencies = [
  "derive_more 2.1.1",
  "reth-basic-payload-builder",
  "reth-chainspec",
+ "reth-ethereum-forks",
  "reth-evm",
  "reth-execution-cache",
  "reth-execution-types",

--- a/crates/execution/payload/Cargo.toml
+++ b/crates/execution/payload/Cargo.toml
@@ -57,4 +57,6 @@ derive_more.workspace = true
 
 [dev-dependencies]
 reth-provider.workspace = true
+reth-ethereum-forks.workspace = true
 base-execution-chainspec.workspace = true
+reth-revm = { workspace = true, features = ["test-utils"] }

--- a/crates/execution/payload/src/builder.rs
+++ b/crates/execution/payload/src/builder.rs
@@ -372,7 +372,7 @@ impl<Txs> Builder<'_, Txs> {
             }
 
             // check if the new payload is even more valuable
-            if !ctx.is_better_payload(info.total_fees) {
+            if !ctx.is_denim_active() && !ctx.is_better_payload(info.total_fees) {
                 // can skip building the block
                 return Ok(BuildOutcomeKind::Aborted { fees: info.total_fees });
             }
@@ -437,10 +437,11 @@ impl<Txs> Builder<'_, Txs> {
             block_access_list.map(|bal| alloy_rlp::encode(bal).into()),
         );
 
-        if no_tx_pool {
+        if no_tx_pool || ctx.is_denim_active() {
             // if `no_tx_pool` is set only transactions from the payload attributes will be included
             // in the payload. In other words, the payload is deterministic and we can
             // freeze it once we've successfully built it.
+            // Denim-active sequencer builds are one-shot, so this payload is also final.
             Ok(BuildOutcomeKind::Freeze(payload))
         } else {
             Ok(BuildOutcomeKind::Better { payload })
@@ -625,6 +626,11 @@ where
         &self.config.attributes
     }
 
+    /// Returns `true` if Denim is active at this payload's timestamp.
+    pub fn is_denim_active(&self) -> bool {
+        self.chain_spec.is_denim_active_at_timestamp(self.attributes().timestamp())
+    }
+
     /// Returns the current fee settings for transactions from the mempool
     pub fn best_transaction_attributes(&self, block_env: impl Block) -> BestTransactionsAttributes {
         BestTransactionsAttributes::new(
@@ -753,6 +759,7 @@ where
         let base_fee = builder.evm_mut().block().basefee();
 
         let block_timestamp = self.attributes().timestamp();
+        let can_finalize_early = self.is_denim_active();
         while let Some(tx) = best_txs.next(()) {
             if self.builder_config.manifest_precheck_enabled
                 && let Some(manifest) = tx.watch_manifest()
@@ -834,9 +841,11 @@ where
                 continue;
             }
 
-            // check if the job was cancelled, if so we can exit early
             if self.cancel.is_cancelled() {
                 return Ok(Some(()));
+            }
+            if can_finalize_early && self.cancel.is_finalization_requested() {
+                break;
             }
 
             let gas_output = match builder.execute_transaction(tx.clone()) {
@@ -867,27 +876,38 @@ where
             info.total_fees += U256::from(miner_fee) * U256::from(gas_output.tx_gas_used());
         }
 
+        if self.cancel.is_cancelled() {
+            return Ok(Some(()));
+        }
+
         Ok(None)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{collections::HashMap, mem::ManuallyDrop, sync::Arc};
 
-    use alloy_consensus::Header;
-    use alloy_primitives::B256;
-    use base_common_consensus::{BasePrimitives, BaseTxEnvelope};
-    use base_execution_chainspec::BaseChainSpec;
+    use alloy_consensus::{Header, SignableTransaction, TxEip1559};
+    use alloy_eips::eip2718::Encodable2718;
+    use alloy_primitives::{Address, B256, Signature, StorageKey, TxKind, U256};
+    use base_common_chains::BaseUpgrade;
+    use base_common_consensus::{BasePrimitives, BaseTxEnvelope, Predeploys};
+    use base_common_evm::BaseTime;
+    use base_execution_chainspec::{BaseChainSpec, BaseChainSpecBuilder};
     use base_execution_evm::BaseEvmConfig;
     use base_execution_txpool::BasePooledTransaction;
     use reth_basic_payload_builder::{BuildOutcomeKind, PayloadConfig};
     use reth_chainspec::ChainSpec;
+    use reth_ethereum_forks::ForkCondition;
     use reth_payload_builder::PayloadId;
-    use reth_payload_util::NoopPayloadTransactions;
-    use reth_primitives_traits::SealedHeader;
+    use reth_payload_util::{NoopPayloadTransactions, PayloadTransactions};
+    use reth_primitives_traits::{Account, SealedHeader, SignedTransaction};
     use reth_provider::noop::NoopProvider;
-    use reth_revm::database::StateProviderDatabase;
+    use reth_revm::{
+        cancelled::CancelOnDrop, database::StateProviderDatabase, test_utils::StateProviderTest,
+    };
+    use reth_transaction_pool::PoolTransaction;
     use reth_trie_common::{HashedPostState, updates::TrieUpdates};
     use reth_trie_parallel::{
         error::StateRootTaskError,
@@ -986,5 +1006,153 @@ mod tests {
     #[test]
     fn parallel_state_root_is_used() {
         assert_eq!(build_empty_payload(state_root_handle()), B256::repeat_byte(0x42));
+    }
+
+    const DENIM_TIMESTAMP: u64 = 1;
+
+    fn pool_payload_context(timestamp: u64) -> BasePayloadBuilderCtx<BaseEvmConfig, BaseChainSpec> {
+        let chain_spec = Arc::new(
+            BaseChainSpecBuilder::base_mainnet()
+                .with_fork(BaseUpgrade::Denim, ForkCondition::Timestamp(DENIM_TIMESTAMP))
+                .build(),
+        );
+        let parent = Arc::new(SealedHeader::seal_slow(Header {
+            gas_limit: 30_000_000,
+            ..Default::default()
+        }));
+        let payload_id = PayloadId::new([0; 8]);
+        let attributes = BasePayloadBuilderAttributes::<BaseTxEnvelope> {
+            payload_attributes: EthPayloadBuilderAttributes {
+                id: payload_id,
+                parent: parent.hash(),
+                timestamp,
+                parent_beacon_block_root: Some(B256::ZERO),
+                ..Default::default()
+            },
+            gas_limit: Some(parent.gas_limit),
+            ..Default::default()
+        };
+        BasePayloadBuilderCtx {
+            evm_config: BaseEvmConfig::<_, BasePrimitives>::base(Arc::clone(&chain_spec)),
+            builder_config: BaseBuilderConfig::default(),
+            chain_spec,
+            config: PayloadConfig::new(parent, attributes, payload_id),
+            cancel: Default::default(),
+            best_payload: None,
+        }
+    }
+
+    fn build_pool_payload<Txs>(
+        ctx: BasePayloadBuilderCtx<BaseEvmConfig, BaseChainSpec>,
+        transactions: Txs,
+    ) -> BuildOutcomeKind<crate::BaseBuiltPayload<BasePrimitives>>
+    where
+        Txs: PayloadTransactions<Transaction = BasePooledTransaction> + Send + Sync,
+    {
+        let mut storage = HashMap::default();
+        storage.insert(
+            StorageKey::from(BaseTime::ADMIN_SLOT.to_be_bytes::<32>()),
+            U256::from_be_slice(Predeploys::PROXY_ADMIN.as_slice()),
+        );
+        let mut provider = StateProviderTest::default();
+        provider.insert_account(
+            Predeploys::BASE_TIME,
+            Account::default(),
+            Some(BaseTime::proxy_bytecode()),
+            storage,
+        );
+        provider.insert_account(
+            pool_transaction(0).sender(),
+            Account { balance: U256::MAX, ..Default::default() },
+            None,
+            HashMap::default(),
+        );
+        Builder::new(|_| transactions)
+            .build(StateProviderDatabase::new(&provider), &provider, Some(state_root_handle()), ctx)
+            .expect("payload must build")
+    }
+
+    fn pool_transaction(nonce: u64) -> BasePooledTransaction {
+        let envelope = BaseTxEnvelope::Eip1559(
+            TxEip1559 {
+                chain_id: 8_453,
+                nonce,
+                gas_limit: 100_000,
+                max_fee_per_gas: 2_000_000_000,
+                max_priority_fee_per_gas: 1,
+                to: TxKind::Call(Address::repeat_byte(0x11)),
+                ..Default::default()
+            }
+            .into_signed(Signature::test_signature()),
+        );
+        let encoded_len = envelope.encode_2718_len();
+        BasePooledTransaction::new(
+            envelope.try_into_recovered().expect("test signature must recover"),
+            encoded_len,
+        )
+    }
+
+    struct FinalizeAfterFirstTransaction {
+        transactions: std::vec::IntoIter<BasePooledTransaction>,
+        calls: usize,
+        // Models the resolver retaining its clone until the finalized payload is returned.
+        cancel: ManuallyDrop<CancelOnDrop>,
+    }
+
+    impl PayloadTransactions for FinalizeAfterFirstTransaction {
+        type Transaction = BasePooledTransaction;
+
+        fn next(&mut self, _ctx: ()) -> Option<Self::Transaction> {
+            self.calls += 1;
+            if self.calls == 2 {
+                self.cancel.request_finalization();
+            }
+            self.transactions.next()
+        }
+
+        fn mark_invalid(&mut self, _sender: Address, _nonce: u64) {}
+    }
+
+    #[test]
+    fn pre_denim_ignores_finalization_requests() {
+        let ctx = pool_payload_context(DENIM_TIMESTAMP - 1);
+        ctx.cancel.request_finalization();
+        let transactions = FinalizeAfterFirstTransaction {
+            transactions: vec![pool_transaction(0)].into_iter(),
+            calls: 0,
+            cancel: ManuallyDrop::new(ctx.cancel.clone()),
+        };
+
+        let BuildOutcomeKind::Better { payload } = build_pool_payload(ctx, transactions) else {
+            panic!("pre-Denim payload must remain eligible for improvement")
+        };
+        assert_eq!(payload.block().body().transactions.len(), 1);
+    }
+
+    #[test]
+    fn denim_finalization_preserves_completed_pool_transactions() {
+        let ctx = pool_payload_context(DENIM_TIMESTAMP);
+        let transactions = FinalizeAfterFirstTransaction {
+            transactions: vec![pool_transaction(0), pool_transaction(1)].into_iter(),
+            calls: 0,
+            cancel: ManuallyDrop::new(ctx.cancel.clone()),
+        };
+
+        let BuildOutcomeKind::Freeze(payload) = build_pool_payload(ctx, transactions) else {
+            panic!("Denim payload must freeze")
+        };
+        assert_eq!(payload.block().body().transactions.len(), 1);
+    }
+
+    #[test]
+    fn cancellation_takes_precedence_over_finalization() {
+        let ctx = pool_payload_context(DENIM_TIMESTAMP);
+        ctx.cancel.request_finalization();
+        drop(ctx.cancel.clone());
+
+        assert!(matches!(
+            build_pool_payload(ctx, NoopPayloadTransactions::<BasePooledTransaction>::default()),
+            BuildOutcomeKind::Cancelled
+        ));
     }
 }

--- a/crates/execution/payload/src/builder.rs
+++ b/crates/execution/payload/src/builder.rs
@@ -761,6 +761,13 @@ where
         let block_timestamp = self.attributes().timestamp();
         let can_finalize_early = self.is_denim_active();
         while let Some(tx) = best_txs.next(()) {
+            if self.cancel.is_cancelled() {
+                return Ok(Some(()));
+            }
+            if can_finalize_early && self.cancel.is_finalization_requested() {
+                break;
+            }
+
             if self.builder_config.manifest_precheck_enabled
                 && let Some(manifest) = tx.watch_manifest()
                 && let Err(stale) = manifest.revalidate(builder.evm_mut().db_mut(), block_timestamp)
@@ -841,13 +848,6 @@ where
                 continue;
             }
 
-            if self.cancel.is_cancelled() {
-                return Ok(Some(()));
-            }
-            if can_finalize_early && self.cancel.is_finalization_requested() {
-                break;
-            }
-
             let gas_output = match builder.execute_transaction(tx.clone()) {
                 Ok(gas_output) => gas_output,
                 Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx {
@@ -876,7 +876,10 @@ where
             info.total_fees += U256::from(miner_fee) * U256::from(gas_output.tx_gas_used());
         }
 
-        if self.cancel.is_cancelled() {
+        // A cancellation that raced the finalization break (or an empty iterator) must still
+        // win, so re-check it before the finalized payload is assembled. Gated on Denim so
+        // pre-Denim control flow is unchanged.
+        if can_finalize_early && self.cancel.is_cancelled() {
             return Ok(Some(()));
         }
 


### PR DESCRIPTION
- Make Denim payload builds one-shot so completed builds freeze instead of being discarded by fee comparison.
- Finalize cooperatively before the next pool transaction while preserving completed transactions and cancellation precedence.
- Keep pre-Denim behavior unchanged and cover finalization and cancellation interactions.