### PR TITLE
perf(txpool): Reduce overhead of tx parking

### DIFF
--- a/crates/builder/core/Cargo.toml
+++ b/crates/builder/core/Cargo.toml
@@ -240,3 +240,7 @@ test-utils = [
 [[bench]]
 name = "state_root"
 harness = false
+
+[[bench]]
+name = "tx_selection"
+harness = false

--- a/crates/builder/core/benches/tx_selection.rs
+++ b/crates/builder/core/benches/tx_selection.rs
@@ -1,0 +1,237 @@
+//! Benchmarks for transaction selection in the flashblocks payload build loop.
+//!
+//! Transaction construction and EVM execution are excluded. The benchmarks cover the production
+//! non-parking pending-pool iterator, the lane-aware parking adapter used by flashblocks, and the
+//! validity-predicate park/commit/rescan cycle.
+
+use std::{hint::black_box, sync::Arc, time::Instant};
+
+use alloy_consensus::{SignableTransaction, TxEip1559};
+use alloy_eips::eip2718::Encodable2718;
+use alloy_primitives::{Address, Bytes, Signature, TxKind, U256};
+use base_builder_core::{ParkableBestPayloadTransactions, ParkablePayloadTransactions};
+use base_common_consensus::{BaseTransactionSigned, BaseTxEnvelope};
+use base_execution_txpool::{
+    BaseOrdering, BasePooledTransaction, ParkedBestTransactions, ValidityOperator,
+    ValidityPredicate,
+};
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use reth_payload_util::PayloadTransactions;
+use reth_primitives_traits::Recovered;
+use reth_transaction_pool::{
+    BestTransactions, TransactionOrigin, ValidPoolTransaction, identifier::TransactionId,
+    pool::PendingPool,
+};
+use revm::database::InMemoryDB;
+
+type Ordering = BaseOrdering<BasePooledTransaction>;
+type Pool = PendingPool<Ordering>;
+
+const TRANSACTION_COUNTS: &[usize] = &[1_000, 10_000, 100_000];
+const PREDICATE_TRANSACTION_COUNT: usize = 10_000;
+
+fn address(index: usize) -> Address {
+    Address::from_word(U256::from(index + 1).into())
+}
+
+fn predicates(
+    transaction_index: usize,
+    count: usize,
+    unique_state: bool,
+) -> Vec<ValidityPredicate> {
+    (0..count)
+        .map(|predicate_index| ValidityPredicate::Balance {
+            address: address(if unique_state {
+                TRANSACTION_COUNTS[TRANSACTION_COUNTS.len() - 1]
+                    + transaction_index * count
+                    + predicate_index
+            } else {
+                TRANSACTION_COUNTS[TRANSACTION_COUNTS.len() - 1] + predicate_index
+            }),
+            op: ValidityOperator::Equal,
+            value: if predicate_index + 1 == count { U256::ONE } else { U256::ZERO },
+        })
+        .collect()
+}
+
+fn transaction(
+    index: usize,
+    predicate_count: usize,
+    unique_predicate_state: bool,
+) -> Arc<ValidPoolTransaction<BasePooledTransaction>> {
+    let tx = TxEip1559 {
+        chain_id: 1,
+        nonce: 0,
+        gas_limit: 21_000,
+        max_fee_per_gas: 100,
+        max_priority_fee_per_gas: 1,
+        to: TxKind::Call(Address::ZERO),
+        value: U256::from(index),
+        access_list: Default::default(),
+        input: Bytes::new(),
+    };
+    let envelope = BaseTxEnvelope::Eip1559(tx.into_signed(Signature::test_signature()));
+    let encoded_length = envelope.encode_2718_len();
+    let transaction = BasePooledTransaction::new(
+        Recovered::new_unchecked(BaseTransactionSigned::from(envelope), address(index)),
+        encoded_length,
+    )
+    .with_validity_predicates(predicates(index, predicate_count, unique_predicate_state));
+
+    Arc::new(ValidPoolTransaction {
+        transaction_id: TransactionId::new((index as u64).into(), 0),
+        transaction,
+        propagate: true,
+        timestamp: Instant::now(),
+        origin: TransactionOrigin::External,
+        authority_ids: None,
+    })
+}
+
+fn pool(
+    transaction_count: usize,
+    predicate_transactions: usize,
+    predicates_per_transaction: usize,
+    unique_predicate_state: bool,
+) -> Pool {
+    let mut pool = PendingPool::new(Ordering::coinbase_tip());
+    for index in 0..transaction_count {
+        let predicate_count =
+            usize::from(index < predicate_transactions) * predicates_per_transaction;
+        pool.add_transaction(transaction(index, predicate_count, unique_predicate_state), 0);
+    }
+    pool
+}
+
+fn parkable(pool: &Pool) -> ParkableBestPayloadTransactions<BasePooledTransaction> {
+    let mut best = pool.best();
+    best.no_updates();
+    ParkableBestPayloadTransactions::new(Box::new(ParkedBestTransactions::new(
+        best,
+        Ordering::coinbase_tip(),
+        0,
+    )))
+}
+
+fn selection_benches(c: &mut Criterion) {
+    let mut plain = c.benchmark_group("tx_selection/best_transactions");
+    plain.sample_size(10);
+    for &transaction_count in TRANSACTION_COUNTS {
+        let pool = pool(transaction_count, 0, 0, false);
+        plain.throughput(Throughput::Elements(transaction_count as u64));
+        plain.bench_with_input(
+            BenchmarkId::new("transactions", transaction_count),
+            &transaction_count,
+            |b, _| {
+                b.iter(|| {
+                    let mut best = pool.best();
+                    best.no_updates();
+                    let mut selected = 0;
+                    for transaction in best {
+                        black_box(transaction);
+                        selected += 1;
+                    }
+                    assert_eq!(selected, transaction_count);
+                });
+            },
+        );
+    }
+    plain.finish();
+
+    let mut parking = c.benchmark_group("tx_selection/parkable_payload");
+    parking.sample_size(10);
+    for &transaction_count in TRANSACTION_COUNTS {
+        let pool = pool(transaction_count, 0, 0, false);
+        parking.throughput(Throughput::Elements(transaction_count as u64));
+        parking.bench_with_input(
+            BenchmarkId::new("transactions", transaction_count),
+            &transaction_count,
+            |b, _| {
+                b.iter(|| {
+                    let mut best = parkable(&pool);
+                    let mut selected = 0;
+                    while let Some(transaction) = best.next(()) {
+                        black_box(transaction);
+                        best.mark_current_committed();
+                        selected += 1;
+                    }
+                    assert_eq!(selected, transaction_count);
+                });
+            },
+        );
+    }
+    parking.finish();
+}
+
+fn run_predicate_selection(pool: &Pool, db: &mut InMemoryDB) -> usize {
+    let mut best = parkable(pool);
+    let mut selected = 0;
+
+    while let Some(transaction) = best.next(()) {
+        let predicates_match = transaction
+            .validity_predicates()
+            .iter()
+            .all(|predicate| predicate.matches_state(db).expect("in-memory reads cannot fail"));
+        if !predicates_match {
+            assert!(best.park_current());
+            continue;
+        }
+
+        black_box(&transaction);
+        best.mark_current_committed();
+        selected += 1;
+
+        for parked in best.parked_transactions() {
+            let matches =
+                parked.transaction.validity_predicates().iter().all(|predicate| {
+                    predicate.matches_state(db).expect("in-memory reads cannot fail")
+                });
+            if matches {
+                assert!(best.promote(*parked.hash()));
+            }
+        }
+    }
+
+    selected
+}
+
+fn predicate_benches(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tx_selection/predicate_rescan");
+    group.sample_size(10);
+    group.throughput(Throughput::Elements(PREDICATE_TRANSACTION_COUNT as u64));
+
+    for &(predicate_transactions, predicates_per_transaction, unique_state) in &[
+        (10, 1, false),
+        (100, 1, false),
+        (1_000, 1, false),
+        (10, 8, false),
+        (100, 8, false),
+        (1_000, 8, false),
+        (100, 8, true),
+    ] {
+        let pool = pool(
+            PREDICATE_TRANSACTION_COUNT,
+            predicate_transactions,
+            predicates_per_transaction,
+            unique_state,
+        );
+        let name = format!(
+            "transactions={PREDICATE_TRANSACTION_COUNT}/predicate_transactions={predicate_transactions}/predicates={predicates_per_transaction}/state={}",
+            if unique_state { "unique" } else { "shared" }
+        );
+        group.bench_function(name, |b| {
+            b.iter_batched(
+                InMemoryDB::default,
+                |mut db| {
+                    let selected = run_predicate_selection(&pool, &mut db);
+                    assert_eq!(selected, PREDICATE_TRANSACTION_COUNT - predicate_transactions);
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, selection_benches, predicate_benches);
+criterion_main!(benches);

--- a/crates/builder/core/benches/tx_selection.rs
+++ b/crates/builder/core/benches/tx_selection.rs
@@ -56,12 +56,14 @@ fn predicates(
 
 fn transaction(
     index: usize,
+    sender_index: usize,
+    nonce: u64,
     predicate_count: usize,
     unique_predicate_state: bool,
 ) -> Arc<ValidPoolTransaction<BasePooledTransaction>> {
     let tx = TxEip1559 {
         chain_id: 1,
-        nonce: 0,
+        nonce,
         gas_limit: 21_000,
         max_fee_per_gas: 100,
         max_priority_fee_per_gas: 1,
@@ -73,13 +75,13 @@ fn transaction(
     let envelope = BaseTxEnvelope::Eip1559(tx.into_signed(Signature::test_signature()));
     let encoded_length = envelope.encode_2718_len();
     let transaction = BasePooledTransaction::new(
-        Recovered::new_unchecked(BaseTransactionSigned::from(envelope), address(index)),
+        Recovered::new_unchecked(BaseTransactionSigned::from(envelope), address(sender_index)),
         encoded_length,
     )
     .with_validity_predicates(predicates(index, predicate_count, unique_predicate_state));
 
     Arc::new(ValidPoolTransaction {
-        transaction_id: TransactionId::new((index as u64).into(), 0),
+        transaction_id: TransactionId::new((sender_index as u64).into(), nonce),
         transaction,
         propagate: true,
         timestamp: Instant::now(),
@@ -90,15 +92,26 @@ fn transaction(
 
 fn pool(
     transaction_count: usize,
+    sender_count: usize,
     predicate_transactions: usize,
     predicates_per_transaction: usize,
     unique_predicate_state: bool,
 ) -> Pool {
     let mut pool = PendingPool::new(Ordering::coinbase_tip());
     for index in 0..transaction_count {
+        let sender_index = index % sender_count;
         let predicate_count =
             usize::from(index < predicate_transactions) * predicates_per_transaction;
-        pool.add_transaction(transaction(index, predicate_count, unique_predicate_state), 0);
+        pool.add_transaction(
+            transaction(
+                index,
+                sender_index,
+                (index / sender_count) as u64,
+                predicate_count,
+                unique_predicate_state,
+            ),
+            0,
+        );
     }
     pool
 }
@@ -117,10 +130,10 @@ fn selection_benches(c: &mut Criterion) {
     let mut plain = c.benchmark_group("tx_selection/best_transactions");
     plain.sample_size(10);
     for &transaction_count in TRANSACTION_COUNTS {
-        let pool = pool(transaction_count, 0, 0, false);
+        let pool = pool(transaction_count, transaction_count, 0, 0, false);
         plain.throughput(Throughput::Elements(transaction_count as u64));
         plain.bench_with_input(
-            BenchmarkId::new("transactions", transaction_count),
+            BenchmarkId::new("end_to_end", transaction_count),
             &transaction_count,
             |b, _| {
                 b.iter(|| {
@@ -135,13 +148,61 @@ fn selection_benches(c: &mut Criterion) {
                 });
             },
         );
+        plain.bench_with_input(
+            BenchmarkId::new("snapshot", transaction_count),
+            &transaction_count,
+            |b, _| {
+                b.iter(|| {
+                    let mut best = pool.best();
+                    best.no_updates();
+                    black_box(best);
+                });
+            },
+        );
+        plain.bench_with_input(
+            BenchmarkId::new("iterate", transaction_count),
+            &transaction_count,
+            |b, _| {
+                b.iter_batched(
+                    || {
+                        let mut best = pool.best();
+                        best.no_updates();
+                        best
+                    },
+                    |best| {
+                        let mut selected = 0;
+                        for transaction in best {
+                            black_box(transaction);
+                            selected += 1;
+                        }
+                        assert_eq!(selected, transaction_count);
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
     }
     plain.finish();
+
+    let mut chained = c.benchmark_group("tx_selection/best_transactions_chained");
+    chained.sample_size(10);
+    chained.throughput(Throughput::Elements(100_000));
+    for sender_count in [1, 1_000] {
+        let pool = pool(100_000, sender_count, 0, 0, false);
+        chained.bench_function(format!("{sender_count}_senders/100000"), |b| {
+            b.iter(|| {
+                let mut best = pool.best();
+                best.no_updates();
+                assert_eq!(best.by_ref().map(black_box).count(), 100_000);
+            });
+        });
+    }
+    chained.finish();
 
     let mut parking = c.benchmark_group("tx_selection/parkable_payload");
     parking.sample_size(10);
     for &transaction_count in TRANSACTION_COUNTS {
-        let pool = pool(transaction_count, 0, 0, false);
+        let pool = pool(transaction_count, transaction_count, 0, 0, false);
         parking.throughput(Throughput::Elements(transaction_count as u64));
         parking.bench_with_input(
             BenchmarkId::new("transactions", transaction_count),
@@ -210,6 +271,7 @@ fn predicate_benches(c: &mut Criterion) {
         (100, 8, true),
     ] {
         let pool = pool(
+            PREDICATE_TRANSACTION_COUNT,
             PREDICATE_TRANSACTION_COUNT,
             predicate_transactions,
             predicates_per_transaction,

--- a/crates/execution/txpool/src/parking.rs
+++ b/crates/execution/txpool/src/parking.rs
@@ -1,11 +1,14 @@
 //! Lane-aware parking over an existing best-transactions iterator.
 
 use std::{
-    collections::{BinaryHeap, HashMap, VecDeque},
+    collections::{BinaryHeap, VecDeque},
     sync::Arc,
 };
 
-use alloy_primitives::{Address, TxHash, U256};
+use alloy_primitives::{
+    Address, TxHash, U256,
+    map::{HashMap, hash_map::Entry},
+};
 use reth_transaction_pool::{
     BestTransactions, BestTransactionsAttributes, PoolTransaction, TransactionOrdering,
     TransactionPool, ValidPoolTransaction, error::InvalidPoolTransactionError,
@@ -106,7 +109,6 @@ where
     base_fee: u64,
     source_head: Option<Arc<ValidPoolTransaction<T>>>,
     lanes: HashMap<BestTransactionLane, BestTransactionLaneState<T>>,
-    in_flight: HashMap<TxHash, Arc<ValidPoolTransaction<T>>>,
     parked: HashMap<TxHash, Arc<ValidPoolTransaction<T>>>,
     ready: HashMap<TxHash, Arc<ValidPoolTransaction<T>>>,
     ready_heap: BinaryHeap<(BestTransactionPriority<O::PriorityValue>, TxHash)>,
@@ -121,7 +123,6 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ParkedBestTransactions")
             .field("lanes", &self.lanes.len())
-            .field("in_flight", &self.in_flight.len())
             .field("parked", &self.parked.len())
             .field("ready", &self.ready.len())
             .finish_non_exhaustive()
@@ -141,10 +142,9 @@ where
             ordering,
             base_fee,
             source_head: None,
-            lanes: HashMap::new(),
-            in_flight: HashMap::new(),
-            parked: HashMap::new(),
-            ready: HashMap::new(),
+            lanes: HashMap::default(),
+            parked: HashMap::default(),
+            ready: HashMap::default(),
             ready_heap: BinaryHeap::new(),
         }
     }
@@ -170,14 +170,21 @@ where
 
     /// Releases the next buffered transaction in a committed lane.
     pub fn release_lane(&mut self, lane: BestTransactionLane) {
-        let next = match self.lanes.get_mut(&lane) {
-            Some(BestTransactionLaneState::Occupied(buffered)) => buffered.pop_front(),
-            Some(BestTransactionLaneState::Invalid) | None => return,
+        let next = match self.lanes.entry(lane) {
+            Entry::Occupied(mut entry) => match entry.get_mut() {
+                BestTransactionLaneState::Occupied(buffered) => {
+                    let next = buffered.pop_front();
+                    if next.is_none() {
+                        entry.remove();
+                    }
+                    next
+                }
+                BestTransactionLaneState::Invalid => return,
+            },
+            Entry::Vacant(_) => return,
         };
         if let Some(next) = next {
             self.push_ready(next);
-        } else {
-            self.lanes.remove(&lane);
         }
     }
 
@@ -202,9 +209,6 @@ where
             BestTransactionLane::for_transaction(transaction) != Some(lane)
         });
         self.ready_heap.retain(|(_, hash)| self.ready.contains_key(hash));
-        self.in_flight.retain(|_, transaction| {
-            BestTransactionLane::for_transaction(transaction) != Some(lane)
-        });
     }
 
     /// Pulls through blocked descendants until the next source candidate is lane-eligible.
@@ -262,7 +266,6 @@ where
                 .entry(lane)
                 .or_insert_with(|| BestTransactionLaneState::Occupied(VecDeque::new()));
         }
-        self.in_flight.insert(*transaction.hash(), Arc::clone(&transaction));
         transaction
     }
 }
@@ -303,10 +306,6 @@ where
     O: TransactionOrdering<Transaction = T>,
 {
     fn mark_invalid(&mut self, transaction: &Self::Item, kind: InvalidPoolTransactionError) {
-        let hash = *transaction.hash();
-        self.in_flight.remove(&hash);
-        self.parked.remove(&hash);
-        self.ready.remove(&hash);
         if let Some(lane) = BestTransactionLane::for_transaction(transaction) {
             self.invalidate_lane(lane);
         }
@@ -330,9 +329,7 @@ where
 {
     fn park(&mut self, transaction: &Arc<ValidPoolTransaction<T>>) {
         let hash = *transaction.hash();
-        if let Some(transaction) = self.in_flight.remove(&hash) {
-            self.parked.insert(hash, transaction);
-        }
+        self.parked.insert(hash, Arc::clone(transaction));
     }
 
     fn parked_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T>>> {
@@ -363,10 +360,6 @@ where
     }
 
     fn mark_committed(&mut self, transaction: &Arc<ValidPoolTransaction<T>>) {
-        let hash = *transaction.hash();
-        self.in_flight.remove(&hash);
-        self.parked.remove(&hash);
-        self.ready.remove(&hash);
         if let Some(lane) = BestTransactionLane::for_transaction(transaction) {
             self.release_lane(lane);
         }


### PR DESCRIPTION
### Summary

Adds Criterion benchmarks for flashblocks transaction selection and reduces Base’s parking overhead.

### Performance

100k independent transactions, pass-through parking, effectively free execution:

| Benchmark| Before | After | Change |
|------------|--------|------|---------|
| Plain BestTransactions | 29.27ms | 29.27ms | - |
| Parking-enabled selection | 45.47ms | 36.22ms | −20.3% |
| Incremental parking overhead | 16.20ms | 6.95ms | −57.1% |

### Changes

- Use Alloy’s faster hash maps for parking state.
- Remove redundant in-flight transaction tracking.
- Avoid unnecessary map removals on commit/invalidation.
- Release lanes with a single hash-table lookup.
- Add benchmarks covering:
  - snapshot creation versus iteration
  - 1k, 10k, and 100k transactions
  - chained/saturated sender topologies
  - pass-through parking
  - predicate counts, parked transaction counts, and shared versus unique predicate state

The parking lifecycle contract is unchanged: lifecycle methods operate on the transaction most recently yielded by the iterator.