### PR TITLE
perf(builder): optionally distribute predicate blockers by tx hash

### DIFF
--- a/crates/builder/cli/src/args.rs
+++ b/crates/builder/cli/src/args.rs
@@ -242,6 +242,14 @@ pub struct Args {
     )]
     pub manifest_precheck_enabled: bool,
 
+    /// Distribute predicate-parked transactions across unsatisfied predicate state keys.
+    #[arg(
+        long = "builder.hash-rotate-predicate-blockers",
+        env = "BUILDER_HASH_ROTATE_PREDICATE_BLOCKERS",
+        default_value = "false"
+    )]
+    pub hash_rotate_predicate_blockers: bool,
+
     /// Flashblocks configuration
     #[command(flatten)]
     pub flashblocks: FlashblocksArgs,
@@ -298,6 +306,7 @@ impl Default for Args {
             rejection_cache_ttl_secs: 1800,
             sampling_ratio: 100,
             manifest_precheck_enabled: true,
+            hash_rotate_predicate_blockers: false,
             flashblocks: FlashblocksArgs::default(),
             transaction_events: TransactionEventsArgs::default(),
             shadow_indexer: ShadowIndexerArgs::default(),
@@ -351,6 +360,7 @@ impl Args {
             rejected_tx_channel_size: self.rejected_tx_channel_size,
             max_rejected_txs_per_block: self.max_rejected_txs_per_block,
             manifest_precheck_enabled: self.manifest_precheck_enabled,
+            hash_rotate_predicate_blockers: self.hash_rotate_predicate_blockers,
         })
     }
 }
@@ -392,6 +402,7 @@ mod tests {
         assert_eq!(config.block_time, Duration::from_millis(1000));
         assert!(config.max_gas_per_txn.is_none());
         assert!(config.manifest_precheck_enabled);
+        assert!(!config.hash_rotate_predicate_blockers);
     }
 
     #[test]
@@ -417,6 +428,14 @@ mod tests {
         let parsed =
             CommandParser::parse_from(["test", "--builder.eip8130-manifest-precheck=false"]);
         assert!(!parsed.args.manifest_precheck_enabled);
+    }
+
+    #[test]
+    fn hash_rotated_predicate_blockers_require_explicit_opt_in() {
+        let parsed =
+            CommandParser::parse_from(["builder", "--builder.hash-rotate-predicate-blockers"]);
+        assert!(parsed.args.hash_rotate_predicate_blockers);
+        assert!(convert(parsed.args).hash_rotate_predicate_blockers);
     }
 
     #[rstest]

--- a/crates/builder/core/benches/tx_selection.rs
+++ b/crates/builder/core/benches/tx_selection.rs
@@ -2,14 +2,17 @@
 //!
 //! Transaction construction and EVM execution are excluded. The benchmarks cover the production
 //! non-parking pending-pool iterator, the lane-aware parking adapter used by flashblocks, and the
-//! validity-predicate park/commit/rescan cycle.
+//! validity-predicate parking and state-index wakeup cycle.
 
 use std::{hint::black_box, sync::Arc, time::Instant};
 
 use alloy_consensus::{SignableTransaction, TxEip1559};
 use alloy_eips::eip2718::Encodable2718;
-use alloy_primitives::{Address, Bytes, Signature, TxKind, U256};
-use base_builder_core::{ParkableBestPayloadTransactions, ParkablePayloadTransactions};
+use alloy_primitives::{Address, B256, Bytes, Signature, TxKind, U256};
+use base_builder_core::{
+    ParkableBestPayloadTransactions, ParkablePayloadTransactions, ParkedPredicateIndex,
+    ValidityPredicateKey,
+};
 use base_common_consensus::{BaseTransactionSigned, BaseTxEnvelope};
 use base_execution_txpool::{
     BaseOrdering, BasePooledTransaction, ParkedBestTransactions, ValidityOperator,
@@ -19,10 +22,13 @@ use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, 
 use reth_payload_util::PayloadTransactions;
 use reth_primitives_traits::Recovered;
 use reth_transaction_pool::{
-    BestTransactions, TransactionOrigin, ValidPoolTransaction, identifier::TransactionId,
-    pool::PendingPool,
+    BestTransactions, PoolTransaction, TransactionOrigin, ValidPoolTransaction,
+    identifier::TransactionId, pool::PendingPool,
 };
-use revm::database::InMemoryDB;
+use revm::{
+    database::InMemoryDB,
+    state::{Account, EvmState},
+};
 
 type Ordering = BaseOrdering<BasePooledTransaction>;
 type Pool = PendingPool<Ordering>;
@@ -226,31 +232,26 @@ fn selection_benches(c: &mut Criterion) {
 
 fn run_predicate_selection(pool: &Pool, db: &mut InMemoryDB) -> usize {
     let mut best = parkable(pool);
+    let mut predicate_index = ParkedPredicateIndex::default();
     let mut selected = 0;
 
     while let Some(transaction) = best.next(()) {
-        let predicates_match = transaction
+        let blocking_predicate = transaction
             .validity_predicates()
             .iter()
-            .all(|predicate| predicate.matches_state(db).expect("in-memory reads cannot fail"));
-        if !predicates_match {
+            .find(|predicate| !predicate.matches_state(db).expect("in-memory reads cannot fail"))
+            .map(ValidityPredicateKey::for_predicate);
+        if let Some(blocking_predicate) = blocking_predicate {
+            let transaction_hash = *transaction.hash();
             assert!(best.park_current());
+            predicate_index.park(transaction_hash, transaction, blocking_predicate);
             continue;
         }
 
         black_box(&transaction);
         best.mark_current_committed();
         selected += 1;
-
-        for parked in best.parked_transactions() {
-            let matches =
-                parked.transaction.validity_predicates().iter().all(|predicate| {
-                    predicate.matches_state(db).expect("in-memory reads cannot fail")
-                });
-            if matches {
-                assert!(best.promote(*parked.hash()));
-            }
-        }
+        assert!(predicate_index.affected_by_state(&EvmState::default()).is_empty());
     }
 
     selected
@@ -295,5 +296,38 @@ fn predicate_benches(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, selection_benches, predicate_benches);
+fn predicate_index_benches(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tx_selection/predicate_index");
+    group.sample_size(10);
+
+    for parked_transactions in [1_000, 10_000, 100_000] {
+        for shared_state in [false, true] {
+            let shared_address = address(TRANSACTION_COUNTS[TRANSACTION_COUNTS.len() - 1]);
+            let mut index = ParkedPredicateIndex::default();
+            for transaction_index in 0..parked_transactions {
+                let transaction_hash: B256 = U256::from(transaction_index + 1).into();
+                let predicate_address =
+                    if shared_state { shared_address } else { address(transaction_index) };
+                index.park(transaction_hash, (), ValidityPredicateKey::Balance(predicate_address));
+            }
+
+            let changed_address = if shared_state { shared_address } else { address(0) };
+            let mut changed_state = EvmState::default();
+            let mut changed_account = Account::default();
+            changed_account.info.balance = U256::ONE;
+            changed_state.insert(changed_address, changed_account);
+
+            group.bench_function(
+                format!(
+                    "parked={parked_transactions}/state={}",
+                    if shared_state { "shared" } else { "unique" }
+                ),
+                |b| b.iter(|| black_box(index.affected_by_state(&changed_state))),
+            );
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, selection_benches, predicate_benches, predicate_index_benches);
 criterion_main!(benches);

--- a/crates/builder/core/benches/tx_selection.rs
+++ b/crates/builder/core/benches/tx_selection.rs
@@ -28,7 +28,7 @@ use reth_transaction_pool::{
 };
 use revm::{
     database::InMemoryDB,
-    state::{Account, EvmState},
+    state::{Account, AccountInfo, EvmState},
 };
 
 type Ordering = BaseOrdering<BasePooledTransaction>;
@@ -264,7 +264,11 @@ fn selection_benches(c: &mut Criterion) {
     parking.finish();
 }
 
-fn run_predicate_selection(pool: &Pool, db: &mut InMemoryDB, hash_rotated: bool) -> usize {
+fn run_predicate_selection(
+    pool: &Pool,
+    db: &mut InMemoryDB,
+    hash_rotated: bool,
+) -> (usize, ParkedPredicateIndex<BasePooledTransaction>) {
     let mut best = parkable(pool);
     let mut predicate_index = ParkedPredicateIndex::default();
     let mut selected = 0;
@@ -298,7 +302,7 @@ fn run_predicate_selection(pool: &Pool, db: &mut InMemoryDB, hash_rotated: bool)
         assert!(predicate_index.affected_by_state(&EvmState::default()).is_empty());
     }
 
-    selected
+    (selected, predicate_index)
 }
 
 fn predicate_benches(c: &mut Criterion) {
@@ -330,7 +334,7 @@ fn predicate_benches(c: &mut Criterion) {
             b.iter_batched(
                 InMemoryDB::default,
                 |mut db| {
-                    let selected = run_predicate_selection(&pool, &mut db, true);
+                    let (selected, _) = run_predicate_selection(&pool, &mut db, true);
                     assert_eq!(selected, PREDICATE_TRANSACTION_COUNT - predicate_transactions);
                 },
                 BatchSize::SmallInput,
@@ -365,12 +369,76 @@ fn predicate_skew_benches(c: &mut Criterion) {
                         InMemoryDB::default,
                         |mut db| {
                             assert_eq!(
-                                run_predicate_selection(&pool, &mut db, hash_rotated),
+                                run_predicate_selection(&pool, &mut db, hash_rotated).0,
                                 0
                             );
                         },
                         BatchSize::SmallInput,
                     );
+                },
+            );
+        }
+    }
+    group.finish();
+}
+
+fn run_hot_key_cycle(pool: &Pool, hash_rotated: bool) -> usize {
+    let mut db = InMemoryDB::default();
+    let (selected, mut predicate_index) = run_predicate_selection(pool, &mut db, hash_rotated);
+    assert_eq!(selected, 0);
+
+    db.insert_account_info(Address::ZERO, AccountInfo { balance: U256::ONE, ..Default::default() });
+    let mut changed_state = EvmState::default();
+    let mut changed_account = Account::default();
+    changed_account.info.balance = U256::ONE;
+    changed_state.insert(Address::ZERO, changed_account);
+
+    let affected = predicate_index.affected_by_state(&changed_state);
+    for transaction_hash in &affected {
+        let predicates = predicate_index
+            .transaction(*transaction_hash)
+            .expect("affected transaction must remain indexed")
+            .validity_predicates();
+        let blocker = if hash_rotated {
+            ValidityPredicateKey::hash_rotated_scan(predicates, *transaction_hash)
+                .find(|predicate| {
+                    !predicate.matches_state(&mut db).expect("in-memory reads cannot fail")
+                })
+                .map(ValidityPredicateKey::for_predicate)
+        } else {
+            predicates
+                .iter()
+                .find(|predicate| {
+                    !predicate.matches_state(&mut db).expect("in-memory reads cannot fail")
+                })
+                .map(ValidityPredicateKey::for_predicate)
+        }
+        .expect("each transaction retains an unsatisfied unique predicate");
+        assert!(predicate_index.reindex(*transaction_hash, blocker));
+    }
+
+    affected.len()
+}
+
+fn predicate_hot_key_cycle_benches(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tx_selection/predicate_hot_key_cycle");
+    group.sample_size(10);
+    group.throughput(Throughput::Elements(100_000));
+
+    for predicates_per_transaction in [2, 8] {
+        let pool = skewed_pool(100_000, predicates_per_transaction, false);
+        for (policy, hash_rotated) in [("first", false), ("hash_rotated", true)] {
+            group.bench_function(
+                format!("policy={policy}/n=100000/p={predicates_per_transaction}"),
+                |b| {
+                    b.iter(|| {
+                        let affected = run_hot_key_cycle(&pool, hash_rotated);
+                        if hash_rotated {
+                            assert!(affected < 100_000);
+                        } else {
+                            assert_eq!(affected, 100_000);
+                        }
+                    });
                 },
             );
         }
@@ -468,6 +536,7 @@ criterion_group!(
     selection_benches,
     predicate_benches,
     predicate_skew_benches,
+    predicate_hot_key_cycle_benches,
     predicate_index_benches
 );
 criterion_main!(benches);

--- a/crates/builder/core/benches/tx_selection.rs
+++ b/crates/builder/core/benches/tx_selection.rs
@@ -19,6 +19,7 @@ use base_execution_txpool::{
     ValidityPredicate,
 };
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rand::{SeedableRng, rngs::StdRng, seq::SliceRandom};
 use reth_payload_util::PayloadTransactions;
 use reth_primitives_traits::Recovered;
 use reth_transaction_pool::{
@@ -138,13 +139,19 @@ fn skewed_predicates(transaction_index: usize, count: usize) -> Vec<ValidityPred
         .collect()
 }
 
-fn skewed_pool(transaction_count: usize, predicates_per_transaction: usize) -> Pool {
+fn skewed_pool(
+    transaction_count: usize,
+    predicates_per_transaction: usize,
+    shuffle_predicates: bool,
+) -> Pool {
     let mut pool = PendingPool::new(Ordering::coinbase_tip());
+    let mut rng = StdRng::seed_from_u64(0x5eed);
     for index in 0..transaction_count {
-        pool.add_transaction(
-            transaction(index, index, 0, skewed_predicates(index, predicates_per_transaction)),
-            0,
-        );
+        let mut predicates = skewed_predicates(index, predicates_per_transaction);
+        if shuffle_predicates {
+            predicates.shuffle(&mut rng);
+        }
+        pool.add_transaction(transaction(index, index, 0, predicates), 0);
     }
     pool
 }
@@ -257,18 +264,27 @@ fn selection_benches(c: &mut Criterion) {
     parking.finish();
 }
 
-fn run_predicate_selection(pool: &Pool, db: &mut InMemoryDB) -> usize {
+fn run_predicate_selection(pool: &Pool, db: &mut InMemoryDB, hash_rotated: bool) -> usize {
     let mut best = parkable(pool);
     let mut predicate_index = ParkedPredicateIndex::default();
     let mut selected = 0;
 
     while let Some(transaction) = best.next(()) {
-        let blocking_predicate = ValidityPredicateKey::hash_rotated_scan(
-            transaction.validity_predicates(),
-            *transaction.hash(),
-        )
-        .find(|predicate| !predicate.matches_state(db).expect("in-memory reads cannot fail"))
-        .map(ValidityPredicateKey::for_predicate);
+        let predicates = transaction.validity_predicates();
+        let blocking_predicate = if hash_rotated {
+            ValidityPredicateKey::hash_rotated_scan(predicates, *transaction.hash())
+                .find(|predicate| {
+                    !predicate.matches_state(db).expect("in-memory reads cannot fail")
+                })
+                .map(ValidityPredicateKey::for_predicate)
+        } else {
+            predicates
+                .iter()
+                .find(|predicate| {
+                    !predicate.matches_state(db).expect("in-memory reads cannot fail")
+                })
+                .map(ValidityPredicateKey::for_predicate)
+        };
         if let Some(blocking_predicate) = blocking_predicate {
             let transaction_hash = *transaction.hash();
             assert!(best.park_current());
@@ -314,7 +330,7 @@ fn predicate_benches(c: &mut Criterion) {
             b.iter_batched(
                 InMemoryDB::default,
                 |mut db| {
-                    let selected = run_predicate_selection(&pool, &mut db);
+                    let selected = run_predicate_selection(&pool, &mut db, true);
                     assert_eq!(selected, PREDICATE_TRANSACTION_COUNT - predicate_transactions);
                 },
                 BatchSize::SmallInput,
@@ -328,25 +344,36 @@ fn predicate_skew_benches(c: &mut Criterion) {
     let mut group = c.benchmark_group("tx_selection/predicate_skew");
     group.sample_size(10);
 
-    for (transaction_count, predicates_per_transaction) in
-        [(10_000, 2), (10_000, 8), (10_000, 64), (100_000, 2), (100_000, 8)]
-    {
+    for (transaction_count, predicates_per_transaction, order) in [
+        (10_000, 2, "correlated"),
+        (10_000, 8, "correlated"),
+        (10_000, 64, "correlated"),
+        (100_000, 2, "correlated"),
+        (100_000, 8, "correlated"),
+        (100_000, 2, "shuffled"),
+        (100_000, 8, "shuffled"),
+    ] {
         group.throughput(Throughput::Elements(transaction_count as u64));
-        let pool = skewed_pool(transaction_count, predicates_per_transaction);
-        group.bench_function(
-            format!(
-                "park/transactions={transaction_count}/predicates={predicates_per_transaction}"
-            ),
-            |b| {
-                b.iter_batched(
-                    InMemoryDB::default,
-                    |mut db| {
-                        assert_eq!(run_predicate_selection(&pool, &mut db), 0);
-                    },
-                    BatchSize::SmallInput,
-                );
-            },
-        );
+        let pool = skewed_pool(transaction_count, predicates_per_transaction, order == "shuffled");
+        for (policy, hash_rotated) in [("first", false), ("hash_rotated", true)] {
+            group.bench_function(
+                format!(
+                    "drain/order={order}/policy={policy}/n={transaction_count}/p={predicates_per_transaction}"
+                ),
+                |b| {
+                    b.iter_batched(
+                        InMemoryDB::default,
+                        |mut db| {
+                            assert_eq!(
+                                run_predicate_selection(&pool, &mut db, hash_rotated),
+                                0
+                            );
+                        },
+                        BatchSize::SmallInput,
+                    );
+                },
+            );
+        }
     }
     group.finish();
 }

--- a/crates/builder/core/benches/tx_selection.rs
+++ b/crates/builder/core/benches/tx_selection.rs
@@ -64,8 +64,7 @@ fn transaction(
     index: usize,
     sender_index: usize,
     nonce: u64,
-    predicate_count: usize,
-    unique_predicate_state: bool,
+    validity_predicates: Vec<ValidityPredicate>,
 ) -> Arc<ValidPoolTransaction<BasePooledTransaction>> {
     let tx = TxEip1559 {
         chain_id: 1,
@@ -84,7 +83,7 @@ fn transaction(
         Recovered::new_unchecked(BaseTransactionSigned::from(envelope), address(sender_index)),
         encoded_length,
     )
-    .with_validity_predicates(predicates(index, predicate_count, unique_predicate_state));
+    .with_validity_predicates(validity_predicates);
 
     Arc::new(ValidPoolTransaction {
         transaction_id: TransactionId::new((sender_index as u64).into(), nonce),
@@ -113,9 +112,37 @@ fn pool(
                 index,
                 sender_index,
                 (index / sender_count) as u64,
-                predicate_count,
-                unique_predicate_state,
+                predicates(index, predicate_count, unique_predicate_state),
             ),
+            0,
+        );
+    }
+    pool
+}
+
+fn skewed_predicates(transaction_index: usize, count: usize) -> Vec<ValidityPredicate> {
+    (0..count)
+        .map(|predicate_index| ValidityPredicate::Balance {
+            address: if predicate_index == 0 {
+                Address::ZERO
+            } else {
+                address(
+                    TRANSACTION_COUNTS[TRANSACTION_COUNTS.len() - 1]
+                        + transaction_index * count
+                        + predicate_index,
+                )
+            },
+            op: ValidityOperator::Equal,
+            value: U256::ONE,
+        })
+        .collect()
+}
+
+fn skewed_pool(transaction_count: usize, predicates_per_transaction: usize) -> Pool {
+    let mut pool = PendingPool::new(Ordering::coinbase_tip());
+    for index in 0..transaction_count {
+        pool.add_transaction(
+            transaction(index, index, 0, skewed_predicates(index, predicates_per_transaction)),
             0,
         );
     }
@@ -236,11 +263,12 @@ fn run_predicate_selection(pool: &Pool, db: &mut InMemoryDB) -> usize {
     let mut selected = 0;
 
     while let Some(transaction) = best.next(()) {
-        let blocking_predicate = transaction
-            .validity_predicates()
-            .iter()
-            .find(|predicate| !predicate.matches_state(db).expect("in-memory reads cannot fail"))
-            .map(ValidityPredicateKey::for_predicate);
+        let blocking_predicate = ValidityPredicateKey::hash_rotated_scan(
+            transaction.validity_predicates(),
+            *transaction.hash(),
+        )
+        .find(|predicate| !predicate.matches_state(db).expect("in-memory reads cannot fail"))
+        .map(ValidityPredicateKey::for_predicate);
         if let Some(blocking_predicate) = blocking_predicate {
             let transaction_hash = *transaction.hash();
             assert!(best.park_current());
@@ -296,6 +324,57 @@ fn predicate_benches(c: &mut Criterion) {
     group.finish();
 }
 
+fn predicate_skew_benches(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tx_selection/predicate_skew");
+    group.sample_size(10);
+
+    for (transaction_count, predicates_per_transaction) in
+        [(10_000, 2), (10_000, 8), (10_000, 64), (100_000, 2), (100_000, 8)]
+    {
+        group.throughput(Throughput::Elements(transaction_count as u64));
+        let pool = skewed_pool(transaction_count, predicates_per_transaction);
+        group.bench_function(
+            format!(
+                "park/transactions={transaction_count}/predicates={predicates_per_transaction}"
+            ),
+            |b| {
+                b.iter_batched(
+                    InMemoryDB::default,
+                    |mut db| {
+                        assert_eq!(run_predicate_selection(&pool, &mut db), 0);
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn skewed_predicate_index(
+    parked_transactions: usize,
+    predicates_per_transaction: usize,
+    hash_rotated: bool,
+) -> ParkedPredicateIndex<()> {
+    let mut index = ParkedPredicateIndex::default();
+    for transaction_index in 0..parked_transactions {
+        let transaction_hash: B256 = U256::from(transaction_index).into();
+        let predicate_index =
+            if hash_rotated { transaction_index % predicates_per_transaction } else { 0 };
+        let blocker = if predicate_index == 0 {
+            ValidityPredicateKey::Balance(Address::ZERO)
+        } else {
+            ValidityPredicateKey::Balance(address(
+                TRANSACTION_COUNTS[TRANSACTION_COUNTS.len() - 1]
+                    + transaction_index * predicates_per_transaction
+                    + predicate_index,
+            ))
+        };
+        index.park(transaction_hash, (), blocker);
+    }
+    index
+}
+
 fn predicate_index_benches(c: &mut Criterion) {
     let mut group = c.benchmark_group("tx_selection/predicate_index");
     group.sample_size(10);
@@ -326,8 +405,42 @@ fn predicate_index_benches(c: &mut Criterion) {
             );
         }
     }
+
+    let mut hot_state = EvmState::default();
+    let mut hot_account = Account::default();
+    hot_account.info.balance = U256::ONE;
+    hot_state.insert(Address::ZERO, hot_account);
+    for parked_transactions in [10_000, 100_000] {
+        for predicates_per_transaction in [2, 8, 64] {
+            for (policy, hash_rotated) in [("first", false), ("hash_rotated", true)] {
+                let index = skewed_predicate_index(
+                    parked_transactions,
+                    predicates_per_transaction,
+                    hash_rotated,
+                );
+                let expected_affected = if hash_rotated {
+                    parked_transactions.div_ceil(predicates_per_transaction)
+                } else {
+                    parked_transactions
+                };
+                assert_eq!(index.affected_by_state(&hot_state).len(), expected_affected);
+                group.bench_function(
+                    format!(
+                        "skew/parked={parked_transactions}/predicates={predicates_per_transaction}/policy={policy}"
+                    ),
+                    |b| b.iter(|| black_box(index.affected_by_state(&hot_state))),
+                );
+            }
+        }
+    }
     group.finish();
 }
 
-criterion_group!(benches, selection_benches, predicate_benches, predicate_index_benches);
+criterion_group!(
+    benches,
+    selection_benches,
+    predicate_benches,
+    predicate_skew_benches,
+    predicate_index_benches
+);
 criterion_main!(benches);

--- a/crates/builder/core/benches/tx_selection.rs
+++ b/crates/builder/core/benches/tx_selection.rs
@@ -275,20 +275,15 @@ fn run_predicate_selection(
 
     while let Some(transaction) = best.next(()) {
         let predicates = transaction.validity_predicates();
-        let blocking_predicate = if hash_rotated {
-            ValidityPredicateKey::hash_rotated_scan(predicates, *transaction.hash())
-                .find(|predicate| {
-                    !predicate.matches_state(db).expect("in-memory reads cannot fail")
-                })
-                .map(ValidityPredicateKey::for_predicate)
-        } else {
-            predicates
-                .iter()
-                .find(|predicate| {
-                    !predicate.matches_state(db).expect("in-memory reads cannot fail")
-                })
-                .map(ValidityPredicateKey::for_predicate)
-        };
+        let blocking_predicate = ValidityPredicateKey::find_map_in_scan_order(
+            predicates,
+            *transaction.hash(),
+            hash_rotated,
+            |predicate| {
+                (!predicate.matches_state(db).expect("in-memory reads cannot fail"))
+                    .then_some(ValidityPredicateKey::for_predicate(predicate))
+            },
+        );
         if let Some(blocking_predicate) = blocking_predicate {
             let transaction_hash = *transaction.hash();
             assert!(best.park_current());
@@ -399,20 +394,15 @@ fn run_hot_key_cycle(pool: &Pool, hash_rotated: bool) -> usize {
             .transaction(*transaction_hash)
             .expect("affected transaction must remain indexed")
             .validity_predicates();
-        let blocker = if hash_rotated {
-            ValidityPredicateKey::hash_rotated_scan(predicates, *transaction_hash)
-                .find(|predicate| {
-                    !predicate.matches_state(&mut db).expect("in-memory reads cannot fail")
-                })
-                .map(ValidityPredicateKey::for_predicate)
-        } else {
-            predicates
-                .iter()
-                .find(|predicate| {
-                    !predicate.matches_state(&mut db).expect("in-memory reads cannot fail")
-                })
-                .map(ValidityPredicateKey::for_predicate)
-        }
+        let blocker = ValidityPredicateKey::find_map_in_scan_order(
+            predicates,
+            *transaction_hash,
+            hash_rotated,
+            |predicate| {
+                (!predicate.matches_state(&mut db).expect("in-memory reads cannot fail"))
+                    .then_some(ValidityPredicateKey::for_predicate(predicate))
+            },
+        )
         .expect("each transaction retains an unsatisfied unique predicate");
         assert!(predicate_index.reindex(*transaction_hash, blocker));
     }

--- a/crates/builder/core/benches/tx_selection.rs
+++ b/crates/builder/core/benches/tx_selection.rs
@@ -417,6 +417,7 @@ fn run_hot_key_cycle(pool: &Pool, hash_rotated: bool) -> usize {
         assert!(predicate_index.reindex(*transaction_hash, blocker));
     }
 
+    black_box(&predicate_index);
     affected.len()
 }
 

--- a/crates/builder/core/src/config.rs
+++ b/crates/builder/core/src/config.rs
@@ -80,6 +80,10 @@ pub struct BuilderConfig {
     /// Whether to drop EIP-8130 transactions whose captured authorization
     /// predicates are positively stale before executing them.
     pub manifest_precheck_enabled: bool,
+
+    /// Whether to distribute predicate-parked transactions by scanning from a transaction-specific
+    /// predicate offset instead of always selecting the first unsatisfied predicate.
+    pub hash_rotate_predicate_blockers: bool,
 }
 
 impl BuilderConfig {
@@ -114,6 +118,7 @@ impl core::fmt::Debug for BuilderConfig {
             .field("rejected_tx_channel_size", &self.rejected_tx_channel_size)
             .field("max_rejected_txs_per_block", &self.max_rejected_txs_per_block)
             .field("manifest_precheck_enabled", &self.manifest_precheck_enabled)
+            .field("hash_rotate_predicate_blockers", &self.hash_rotate_predicate_blockers)
             .finish()
     }
 }
@@ -140,6 +145,7 @@ impl Default for BuilderConfig {
             rejected_tx_channel_size: 500,
             max_rejected_txs_per_block: 500,
             manifest_precheck_enabled: true,
+            hash_rotate_predicate_blockers: false,
         }
     }
 }

--- a/crates/builder/core/src/flashblocks/best_txs.rs
+++ b/crates/builder/core/src/flashblocks/best_txs.rs
@@ -44,11 +44,6 @@ where
     /// Commits and clears the current transaction, if any.
     fn mark_current_committed(&mut self);
 
-    /// Returns a snapshot of all predicate-parked transactions.
-    ///
-    /// The snapshot permits callers to mutate the underlying iterator while scanning it.
-    fn parked_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
-
     /// Promotes a predicate-parked transaction back into priority competition.
     fn promote(&mut self, transaction_hash: TxHash) -> bool;
 
@@ -66,10 +61,6 @@ where
     }
 
     fn mark_current_committed(&mut self) {}
-
-    fn parked_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
-        Vec::new()
-    }
 
     fn promote(&mut self, _transaction_hash: TxHash) -> bool {
         false
@@ -160,10 +151,6 @@ where
         if let Some(transaction) = self.current.take() {
             self.inner.mark_committed(&transaction);
         }
-    }
-
-    fn parked_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
-        self.inner.parked_transactions()
     }
 
     fn promote(&mut self, transaction_hash: TxHash) -> bool {
@@ -314,10 +301,6 @@ where
         if let Some((transaction_hash, _, _)) = self.current_transaction.take() {
             self.committed_transactions.insert(transaction_hash);
         }
-    }
-
-    fn parked_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
-        self.inner.parked_transactions()
     }
 
     fn promote(&mut self, transaction_hash: TxHash) -> bool {

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -53,6 +53,8 @@ use crate::{
     },
 };
 
+const PREDICATE_COUNT_OVERFLOW_BUCKET: usize = 17;
+
 /// Records the priority fee of a rejected transaction with the given reason as a label.
 fn record_rejected_tx_priority_fee(reason: &TxnExecutionError, priority_fee: f64) {
     BuilderMetrics::rejected_tx_priority_fee(rejection_reason_code(reason)).record(priority_fee);
@@ -678,6 +680,10 @@ impl BasePayloadBuilderCtx {
         let block_timestamp = self.attributes().timestamp();
         let payload_id = self.payload_id().to_string();
         let mut predicate_index = ParkedPredicateIndex::default();
+        let hash_rotate_predicate_blockers = self.builder_config.hash_rotate_predicate_blockers;
+        let predicate_blocker_policy =
+            if hash_rotate_predicate_blockers { "hash_rotated" } else { "first_failing" };
+        let mut parked_by_predicate_count = [0_u64; PREDICATE_COUNT_OVERFLOW_BUCKET + 1];
 
         while let Some(tx) = best_txs.next(()) {
             if tx.is_bundle_expired(block_number, block_timestamp) {
@@ -775,7 +781,10 @@ impl BasePayloadBuilderCtx {
             let mut predicate_read_failed = false;
             let blocking_predicate = {
                 let db = evm.db_mut();
-                ValidityPredicateKey::hash_rotated_scan(tx.validity_predicates(), tx_hash).find_map(
+                ValidityPredicateKey::find_map_in_scan_order(
+                    tx.validity_predicates(),
+                    tx_hash,
+                    hash_rotate_predicate_blockers,
                     |predicate| match predicate.matches_state(db) {
                         Ok(true) => None,
                         Ok(false) => Some(ValidityPredicateKey::for_predicate(predicate)),
@@ -843,6 +852,9 @@ impl BasePayloadBuilderCtx {
                 if predicate_read_failed {
                     best_txs.mark_invalid(tx.sender(), tx.nonce());
                 } else if best_txs.park_current() {
+                    let predicate_count =
+                        tx.validity_predicates().len().min(PREDICATE_COUNT_OVERFLOW_BUCKET);
+                    parked_by_predicate_count[predicate_count] += 1;
                     predicate_index.park(tx_hash, tx, blocking_predicate);
                 } else {
                     best_txs.mark_invalid(tx.sender(), tx.nonce());
@@ -1319,11 +1331,16 @@ impl BasePayloadBuilderCtx {
             };
             info.receipts.push(self.build_receipt(ctx, None));
 
-            let affected_parked = if predicate_index.is_empty() {
+            let had_parked_transactions = !predicate_index.is_empty();
+            let affected_parked = if !had_parked_transactions {
                 Vec::new()
             } else {
                 predicate_index.affected_by_state(&state)
             };
+            if had_parked_transactions {
+                BuilderMetrics::validity_predicate_rescan_transactions(predicate_blocker_policy)
+                    .record(affected_parked.len() as f64);
+            }
 
             // commit changes
             evm.db_mut().commit(state);
@@ -1341,28 +1358,26 @@ impl BasePayloadBuilderCtx {
                     );
                     continue;
                 };
-                let blocking_predicate =
-                    ValidityPredicateKey::hash_rotated_scan(
-                        parked_transaction.validity_predicates(),
-                        *parked_hash,
-                    )
-                    .find_map(
-                        |predicate| match predicate.matches_state(evm.db_mut()) {
-                            Ok(true) => None,
-                            Ok(false) => Some(ValidityPredicateKey::for_predicate(predicate)),
-                            Err(error) => {
-                                warn!(
-                                    target: "payload_builder",
-                                    tx_hash = ?parked_hash,
-                                    predicate = ?predicate,
-                                    error = ?error,
-                                    "failed to re-read validity predicate state"
-                                );
-                                predicate_read_failed = true;
-                                Some(ValidityPredicateKey::for_predicate(predicate))
-                            }
-                        },
-                    );
+                let blocking_predicate = ValidityPredicateKey::find_map_in_scan_order(
+                    parked_transaction.validity_predicates(),
+                    *parked_hash,
+                    hash_rotate_predicate_blockers,
+                    |predicate| match predicate.matches_state(evm.db_mut()) {
+                        Ok(true) => None,
+                        Ok(false) => Some(ValidityPredicateKey::for_predicate(predicate)),
+                        Err(error) => {
+                            warn!(
+                                target: "payload_builder",
+                                tx_hash = ?parked_hash,
+                                predicate = ?predicate,
+                                error = ?error,
+                                "failed to re-read validity predicate state"
+                            );
+                            predicate_read_failed = true;
+                            Some(ValidityPredicateKey::for_predicate(predicate))
+                        }
+                    },
+                );
                 if predicate_read_failed {
                     predicate_index.remove(*parked_hash);
                     best_txs.discard_parked(*parked_hash);
@@ -1374,7 +1389,7 @@ impl BasePayloadBuilderCtx {
                 }
             }
             if !affected_parked.is_empty() {
-                BuilderMetrics::validity_predicate_rescan_duration()
+                BuilderMetrics::validity_predicate_rescan_duration(predicate_blocker_policy)
                     .record(predicate_rescan_start.elapsed().as_secs_f64());
             }
 
@@ -1403,6 +1418,27 @@ impl BasePayloadBuilderCtx {
             info.executed_senders.push(tx.signer());
             info.executed_transactions.push(tx.into_inner());
         }
+
+        for (predicate_count, parked) in parked_by_predicate_count.into_iter().enumerate() {
+            if parked > 0 {
+                let predicate_count = if predicate_count == PREDICATE_COUNT_OVERFLOW_BUCKET {
+                    "17+".to_string()
+                } else {
+                    predicate_count.to_string()
+                };
+                BuilderMetrics::validity_predicate_parked_total(
+                    predicate_blocker_policy,
+                    predicate_count,
+                )
+                .increment(parked);
+            }
+        }
+        BuilderMetrics::validity_predicate_parked_transactions(predicate_blocker_policy)
+            .record(predicate_index.len() as f64);
+        BuilderMetrics::validity_predicate_blocker_keys(predicate_blocker_policy)
+            .record(predicate_index.blocker_key_count() as f64);
+        BuilderMetrics::validity_predicate_max_blocker_bucket_size(predicate_blocker_policy)
+            .record(predicate_index.largest_blocker_bucket_size() as f64);
 
         let payload_transaction_simulation_time = execute_txs_start_time.elapsed();
         BuilderMetrics::set_payload_builder_metrics(

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -775,8 +775,8 @@ impl BasePayloadBuilderCtx {
             let mut predicate_read_failed = false;
             let blocking_predicate = {
                 let db = evm.db_mut();
-                tx.validity_predicates().iter().find_map(|predicate| {
-                    match predicate.matches_state(db) {
+                ValidityPredicateKey::hash_rotated_scan(tx.validity_predicates(), tx_hash).find_map(
+                    |predicate| match predicate.matches_state(db) {
                         Ok(true) => None,
                         Ok(false) => Some(ValidityPredicateKey::for_predicate(predicate)),
                         Err(error) => {
@@ -790,8 +790,8 @@ impl BasePayloadBuilderCtx {
                             predicate_read_failed = true;
                             Some(ValidityPredicateKey::for_predicate(predicate))
                         }
-                    }
-                })
+                    },
+                )
             };
             if let Some(blocking_predicate) = blocking_predicate {
                 num_txs_considered += 1;
@@ -1342,8 +1342,12 @@ impl BasePayloadBuilderCtx {
                     continue;
                 };
                 let blocking_predicate =
-                    parked_transaction.validity_predicates().iter().find_map(|predicate| {
-                        match predicate.matches_state(evm.db_mut()) {
+                    ValidityPredicateKey::hash_rotated_scan(
+                        parked_transaction.validity_predicates(),
+                        *parked_hash,
+                    )
+                    .find_map(
+                        |predicate| match predicate.matches_state(evm.db_mut()) {
                             Ok(true) => None,
                             Ok(false) => Some(ValidityPredicateKey::for_predicate(predicate)),
                             Err(error) => {
@@ -1357,8 +1361,8 @@ impl BasePayloadBuilderCtx {
                                 predicate_read_failed = true;
                                 Some(ValidityPredicateKey::for_predicate(predicate))
                             }
-                        }
-                    });
+                        },
+                    );
                 if predicate_read_failed {
                     predicate_index.remove(*parked_hash);
                     best_txs.discard_parked(*parked_hash);

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -44,8 +44,9 @@ use tokio_util::sync::CancellationToken;
 use tracing::{Level, debug, span, trace, warn};
 
 use crate::{
-    BuilderConfig, BuilderMetrics, ExecutionInfo, ExecutionMeteringLimitExceeded, PayloadTxsBounds,
-    ResourceLimits, TxResources, TxnExecutionError, TxnOutcome,
+    BuilderConfig, BuilderMetrics, ExecutionInfo, ExecutionMeteringLimitExceeded,
+    ParkedPredicateIndex, PayloadTxsBounds, ResourceLimits, TxResources, TxnExecutionError,
+    TxnOutcome, ValidityPredicateKey,
     transaction_events::{
         BuilderAcceptedEventData, BuilderConsideredEventData, BuilderRejectedEventData,
         BuilderTransactionEventContext, emit_builder_transaction_event, rejection_reason_code,
@@ -676,6 +677,7 @@ impl BasePayloadBuilderCtx {
         let block_number = as_u64_saturated!(self.evm_env.block_env.number);
         let block_timestamp = self.attributes().timestamp();
         let payload_id = self.payload_id().to_string();
+        let mut predicate_index = ParkedPredicateIndex::default();
 
         while let Some(tx) = best_txs.next(()) {
             if tx.is_bundle_expired(block_number, block_timestamp) {
@@ -771,23 +773,27 @@ impl BasePayloadBuilderCtx {
 
             let tx_hash = *tx.hash();
             let mut predicate_read_failed = false;
-            let predicates_match = {
+            let blocking_predicate = {
                 let db = evm.db_mut();
-                tx.validity_predicates().iter().all(|predicate| {
-                    predicate.matches_state(db).unwrap_or_else(|error| {
-                        warn!(
-                            target: "payload_builder",
-                            tx_hash = ?tx_hash,
-                            predicate = ?predicate,
-                            error = ?error,
-                            "failed to read validity predicate state"
-                        );
-                        predicate_read_failed = true;
-                        false
-                    })
+                tx.validity_predicates().iter().find_map(|predicate| {
+                    match predicate.matches_state(db) {
+                        Ok(true) => None,
+                        Ok(false) => Some(ValidityPredicateKey::for_predicate(predicate)),
+                        Err(error) => {
+                            warn!(
+                                target: "payload_builder",
+                                tx_hash = ?tx_hash,
+                                predicate = ?predicate,
+                                error = ?error,
+                                "failed to read validity predicate state"
+                            );
+                            predicate_read_failed = true;
+                            Some(ValidityPredicateKey::for_predicate(predicate))
+                        }
+                    }
                 })
             };
-            if !predicates_match {
+            if let Some(blocking_predicate) = blocking_predicate {
                 num_txs_considered += 1;
                 let ordering_position = num_txs_considered;
                 let (rejection_reason, rejection_detail) = if predicate_read_failed {
@@ -834,8 +840,11 @@ impl BasePayloadBuilderCtx {
                 // A read failure cannot be retried at a later ordering position: including the
                 // transaction there could place it behind a lower-priority transaction even though
                 // its predicate may have already been satisfied at its first position.
-                let should_invalidate = predicate_read_failed || !best_txs.park_current();
-                if should_invalidate {
+                if predicate_read_failed {
+                    best_txs.mark_invalid(tx.sender(), tx.nonce());
+                } else if best_txs.park_current() {
+                    predicate_index.park(tx_hash, tx, blocking_predicate);
+                } else {
                     best_txs.mark_invalid(tx.sender(), tx.nonce());
                 }
                 continue;
@@ -1310,21 +1319,29 @@ impl BasePayloadBuilderCtx {
             };
             info.receipts.push(self.build_receipt(ctx, None));
 
+            let affected_parked = if predicate_index.is_empty() {
+                Vec::new()
+            } else {
+                predicate_index.affected_by_state(&state)
+            };
+
             // commit changes
             evm.db_mut().commit(state);
 
-            // The committed state can satisfy transactions that were previously predicate-invalid.
-            // Release the committed transaction's lane first, then naively rescan all parked heads.
+            // Release the committed transaction's lane before promoting predicate-unblocked heads.
             best_txs.mark_current_committed();
             let predicate_rescan_start = Instant::now();
-            let parked_transactions = best_txs.parked_transactions();
-            let rescanned_predicates = !parked_transactions.is_empty();
-            for parked in parked_transactions {
-                let parked_hash = *parked.hash();
+            for parked_hash in &affected_parked {
                 let mut predicate_read_failed = false;
-                let predicates_match =
-                    parked.transaction.validity_predicates().iter().all(|predicate| {
-                        predicate.matches_state(evm.db_mut()).unwrap_or_else(|error| {
+                let blocking_predicate = predicate_index
+                    .transaction(*parked_hash)
+                    .expect("affected transaction must remain indexed")
+                    .validity_predicates()
+                    .iter()
+                    .find_map(|predicate| match predicate.matches_state(evm.db_mut()) {
+                        Ok(true) => None,
+                        Ok(false) => Some(ValidityPredicateKey::for_predicate(predicate)),
+                        Err(error) => {
                             warn!(
                                 target: "payload_builder",
                                 tx_hash = ?parked_hash,
@@ -1333,16 +1350,20 @@ impl BasePayloadBuilderCtx {
                                 "failed to re-read validity predicate state"
                             );
                             predicate_read_failed = true;
-                            false
-                        })
+                            Some(ValidityPredicateKey::for_predicate(predicate))
+                        }
                     });
                 if predicate_read_failed {
-                    best_txs.discard_parked(parked_hash);
-                } else if predicates_match {
-                    best_txs.promote(parked_hash);
+                    predicate_index.remove(*parked_hash);
+                    best_txs.discard_parked(*parked_hash);
+                } else if let Some(blocking_predicate) = blocking_predicate {
+                    predicate_index.reindex(*parked_hash, blocking_predicate);
+                } else {
+                    predicate_index.remove(*parked_hash);
+                    best_txs.promote(*parked_hash);
                 }
             }
-            if rescanned_predicates {
+            if !affected_parked.is_empty() {
                 BuilderMetrics::validity_predicate_rescan_duration()
                     .record(predicate_rescan_start.elapsed().as_secs_f64());
             }

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -1333,24 +1333,30 @@ impl BasePayloadBuilderCtx {
             let predicate_rescan_start = Instant::now();
             for parked_hash in &affected_parked {
                 let mut predicate_read_failed = false;
-                let blocking_predicate = predicate_index
-                    .transaction(*parked_hash)
-                    .expect("affected transaction must remain indexed")
-                    .validity_predicates()
-                    .iter()
-                    .find_map(|predicate| match predicate.matches_state(evm.db_mut()) {
-                        Ok(true) => None,
-                        Ok(false) => Some(ValidityPredicateKey::for_predicate(predicate)),
-                        Err(error) => {
-                            warn!(
-                                target: "payload_builder",
-                                tx_hash = ?parked_hash,
-                                predicate = ?predicate,
-                                error = ?error,
-                                "failed to re-read validity predicate state"
-                            );
-                            predicate_read_failed = true;
-                            Some(ValidityPredicateKey::for_predicate(predicate))
+                let Some(parked_transaction) = predicate_index.transaction(*parked_hash) else {
+                    warn!(
+                        target: "payload_builder",
+                        tx_hash = ?parked_hash,
+                        "affected transaction is no longer predicate-indexed"
+                    );
+                    continue;
+                };
+                let blocking_predicate =
+                    parked_transaction.validity_predicates().iter().find_map(|predicate| {
+                        match predicate.matches_state(evm.db_mut()) {
+                            Ok(true) => None,
+                            Ok(false) => Some(ValidityPredicateKey::for_predicate(predicate)),
+                            Err(error) => {
+                                warn!(
+                                    target: "payload_builder",
+                                    tx_hash = ?parked_hash,
+                                    predicate = ?predicate,
+                                    error = ?error,
+                                    "failed to re-read validity predicate state"
+                                );
+                                predicate_read_failed = true;
+                                Some(ValidityPredicateKey::for_predicate(predicate))
+                            }
                         }
                     });
                 if predicate_read_failed {

--- a/crates/builder/core/src/flashblocks/mod.rs
+++ b/crates/builder/core/src/flashblocks/mod.rs
@@ -6,6 +6,9 @@ pub use best_txs::{
     PayloadTransactionInvalidated,
 };
 
+mod predicate_index;
+pub use predicate_index::{ParkedPredicateIndex, ValidityPredicateKey};
+
 mod deadline;
 pub use deadline::PayloadJobDeadline;
 

--- a/crates/builder/core/src/flashblocks/predicate_index.rs
+++ b/crates/builder/core/src/flashblocks/predicate_index.rs
@@ -44,6 +44,21 @@ impl ValidityPredicateKey {
         };
         predicates[start..].iter().chain(predicates[..start].iter())
     }
+
+    /// Applies a function to predicates in the configured blocker-selection order until it returns
+    /// a value.
+    pub fn find_map_in_scan_order<'a, T>(
+        predicates: &'a [ValidityPredicate],
+        transaction_hash: TxHash,
+        hash_rotated: bool,
+        function: impl FnMut(&'a ValidityPredicate) -> Option<T>,
+    ) -> Option<T> {
+        if hash_rotated {
+            Self::hash_rotated_scan(predicates, transaction_hash).find_map(function)
+        } else {
+            predicates.iter().find_map(function)
+        }
+    }
 }
 
 /// Predicate-parked transactions indexed by one currently unsatisfied state location.
@@ -66,6 +81,21 @@ impl<T> ParkedPredicateIndex<T> {
     /// Returns whether no transactions are indexed.
     pub fn is_empty(&self) -> bool {
         self.transactions.is_empty()
+    }
+
+    /// Returns the number of parked transactions.
+    pub fn len(&self) -> usize {
+        self.transactions.len()
+    }
+
+    /// Returns the number of state keys currently blocking parked transactions.
+    pub fn blocker_key_count(&self) -> usize {
+        self.blockers.len()
+    }
+
+    /// Returns the largest current blocker bucket size.
+    pub fn largest_blocker_bucket_size(&self) -> usize {
+        self.blockers.values().map(HashSet::len).max().unwrap_or_default()
     }
 
     /// Adds a parked transaction under one currently unsatisfied predicate key.
@@ -213,6 +243,47 @@ mod tests {
     }
 
     #[test]
+    fn scan_preserves_original_order_when_hash_rotation_is_disabled() {
+        let predicates = [balance_predicate(0), balance_predicate(1), balance_predicate(2)];
+        let mut keys = Vec::new();
+        ValidityPredicateKey::find_map_in_scan_order(
+            &predicates,
+            B256::with_last_byte(2),
+            false,
+            |predicate| {
+                keys.push(ValidityPredicateKey::for_predicate(predicate));
+                None::<()>
+            },
+        );
+
+        assert_eq!(
+            keys,
+            vec![
+                ValidityPredicateKey::Balance(Address::with_last_byte(0)),
+                ValidityPredicateKey::Balance(Address::with_last_byte(1)),
+                ValidityPredicateKey::Balance(Address::with_last_byte(2)),
+            ]
+        );
+    }
+
+    #[test]
+    fn reports_current_blocker_topology() {
+        let mut index = ParkedPredicateIndex::default();
+        let shared = ValidityPredicateKey::Balance(Address::ZERO);
+        index.park(B256::with_last_byte(1), (), shared);
+        index.park(B256::with_last_byte(2), (), shared);
+        index.park(
+            B256::with_last_byte(3),
+            (),
+            ValidityPredicateKey::Balance(Address::with_last_byte(1)),
+        );
+
+        assert_eq!(index.len(), 3);
+        assert_eq!(index.blocker_key_count(), 2);
+        assert_eq!(index.largest_blocker_bucket_size(), 2);
+    }
+
+    #[test]
     fn indexes_only_transactions_affected_by_changed_state() {
         let balance_address = Address::with_last_byte(1);
         let storage_address = Address::with_last_byte(2);
@@ -221,6 +292,10 @@ mod tests {
         let mut index = ParkedPredicateIndex::default();
         index.park(balance_hash, 1, ValidityPredicateKey::Balance(balance_address));
         index.park(storage_hash, 2, ValidityPredicateKey::Storage(storage_address, U256::from(7)));
+
+        assert_eq!(index.len(), 2);
+        assert_eq!(index.blocker_key_count(), 2);
+        assert_eq!(index.largest_blocker_bucket_size(), 1);
 
         let mut state = EvmState::default();
         let mut account = Account::default();
@@ -246,6 +321,7 @@ mod tests {
         assert_eq!(index.affected_by_state(&state), vec![balance_hash]);
         assert_eq!(index.remove(balance_hash), Some(1));
         assert_eq!(index.transaction(storage_hash), Some(&2));
+        assert_eq!(index.len(), 1);
     }
 
     #[test]

--- a/crates/builder/core/src/flashblocks/predicate_index.rs
+++ b/crates/builder/core/src/flashblocks/predicate_index.rs
@@ -24,6 +24,26 @@ impl ValidityPredicateKey {
             ValidityPredicate::Storage { address, slot, .. } => Self::Storage(*address, *slot),
         }
     }
+
+    /// Iterates predicates circularly from an offset derived from the transaction hash.
+    ///
+    /// This deterministically spreads parked transactions across their unsatisfied state keys when
+    /// predicate lists share the same ordering.
+    pub fn hash_rotated_scan(
+        predicates: &[ValidityPredicate],
+        transaction_hash: TxHash,
+    ) -> impl Iterator<Item = &ValidityPredicate> {
+        let start = if predicates.is_empty() {
+            0
+        } else {
+            let hash = transaction_hash.as_slice();
+            u64::from_be_bytes([
+                hash[24], hash[25], hash[26], hash[27], hash[28], hash[29], hash[30], hash[31],
+            ]) as usize
+                % predicates.len()
+        };
+        predicates[start..].iter().chain(predicates[..start].iter())
+    }
 }
 
 /// Predicate-parked transactions indexed by one currently unsatisfied state location.
@@ -134,9 +154,63 @@ impl<T> ParkedPredicateIndex<T> {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Address, B256, U256};
+    use base_execution_txpool::{ValidityOperator, ValidityPredicate};
     use revm::state::{Account, EvmState, EvmStorageSlot};
 
     use super::{ParkedPredicateIndex, ValidityPredicateKey};
+
+    fn balance_predicate(index: u8) -> ValidityPredicate {
+        ValidityPredicate::Balance {
+            address: Address::with_last_byte(index),
+            op: ValidityOperator::GreaterThan,
+            value: U256::ZERO,
+        }
+    }
+
+    #[test]
+    fn hash_rotated_scan_is_deterministic_and_wraps() {
+        let predicates = [balance_predicate(0), balance_predicate(1), balance_predicate(2)];
+        let transaction_hash = B256::with_last_byte(2);
+
+        let scan = || {
+            ValidityPredicateKey::hash_rotated_scan(&predicates, transaction_hash)
+                .map(ValidityPredicateKey::for_predicate)
+                .collect::<Vec<_>>()
+        };
+
+        assert_eq!(
+            scan(),
+            vec![
+                ValidityPredicateKey::Balance(Address::with_last_byte(2)),
+                ValidityPredicateKey::Balance(Address::with_last_byte(0)),
+                ValidityPredicateKey::Balance(Address::with_last_byte(1)),
+            ]
+        );
+        assert_eq!(scan(), scan());
+    }
+
+    #[test]
+    fn hash_rotated_scan_distributes_starting_predicates() {
+        let predicates = [balance_predicate(0), balance_predicate(1), balance_predicate(2)];
+
+        let starts = (0..3)
+            .map(|index| {
+                ValidityPredicateKey::hash_rotated_scan(&predicates, B256::with_last_byte(index))
+                    .next()
+                    .map(ValidityPredicateKey::for_predicate)
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            starts,
+            vec![
+                Some(ValidityPredicateKey::Balance(Address::with_last_byte(0))),
+                Some(ValidityPredicateKey::Balance(Address::with_last_byte(1))),
+                Some(ValidityPredicateKey::Balance(Address::with_last_byte(2))),
+            ]
+        );
+        assert_eq!(ValidityPredicateKey::hash_rotated_scan(&[], B256::ZERO).next(), None);
+    }
 
     #[test]
     fn indexes_only_transactions_affected_by_changed_state() {

--- a/crates/builder/core/src/flashblocks/predicate_index.rs
+++ b/crates/builder/core/src/flashblocks/predicate_index.rs
@@ -1,0 +1,191 @@
+//! State-key index for predicate-parked payload transactions.
+
+use alloy_primitives::{
+    Address, TxHash, U256,
+    map::{HashMap, HashSet},
+};
+use base_execution_txpool::ValidityPredicate;
+use revm::state::EvmState;
+
+/// State location read by a validity predicate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ValidityPredicateKey {
+    /// Account balance.
+    Balance(Address),
+    /// Contract storage slot.
+    Storage(Address, U256),
+}
+
+impl ValidityPredicateKey {
+    /// Returns the state location read by a predicate.
+    pub const fn for_predicate(predicate: &ValidityPredicate) -> Self {
+        match predicate {
+            ValidityPredicate::Balance { address, .. } => Self::Balance(*address),
+            ValidityPredicate::Storage { address, slot, .. } => Self::Storage(*address, *slot),
+        }
+    }
+}
+
+/// Predicate-parked transactions indexed by one currently unsatisfied state location.
+///
+/// A parked transaction only needs one blocker in the index. When that location changes, callers
+/// re-evaluate all of the transaction's predicates and either promote it or replace its blocker.
+#[derive(Debug)]
+pub struct ParkedPredicateIndex<T> {
+    blockers: HashMap<ValidityPredicateKey, HashSet<TxHash>>,
+    transactions: HashMap<TxHash, (T, ValidityPredicateKey)>,
+}
+
+impl<T> Default for ParkedPredicateIndex<T> {
+    fn default() -> Self {
+        Self { blockers: HashMap::default(), transactions: HashMap::default() }
+    }
+}
+
+impl<T> ParkedPredicateIndex<T> {
+    /// Returns whether no transactions are indexed.
+    pub fn is_empty(&self) -> bool {
+        self.transactions.is_empty()
+    }
+
+    /// Adds a parked transaction under one currently unsatisfied predicate key.
+    pub fn park(
+        &mut self,
+        transaction_hash: TxHash,
+        transaction: T,
+        blocker: ValidityPredicateKey,
+    ) {
+        self.remove(transaction_hash);
+        self.transactions.insert(transaction_hash, (transaction, blocker));
+        self.blockers.entry(blocker).or_default().insert(transaction_hash);
+    }
+
+    /// Returns an indexed parked transaction.
+    pub fn transaction(&self, transaction_hash: TxHash) -> Option<&T> {
+        self.transactions.get(&transaction_hash).map(|(transaction, _)| transaction)
+    }
+
+    /// Replaces a parked transaction's currently unsatisfied predicate key.
+    pub fn reindex(&mut self, transaction_hash: TxHash, blocker: ValidityPredicateKey) -> bool {
+        let Some((_, previous)) = self.transactions.get_mut(&transaction_hash) else {
+            return false;
+        };
+        if *previous == blocker {
+            return true;
+        }
+
+        let previous = core::mem::replace(previous, blocker);
+        if let Some(hashes) = self.blockers.get_mut(&previous) {
+            hashes.remove(&transaction_hash);
+            if hashes.is_empty() {
+                self.blockers.remove(&previous);
+            }
+        }
+        self.blockers.entry(blocker).or_default().insert(transaction_hash);
+        true
+    }
+
+    /// Removes and returns an indexed parked transaction.
+    pub fn remove(&mut self, transaction_hash: TxHash) -> Option<T> {
+        let (transaction, blocker) = self.transactions.remove(&transaction_hash)?;
+        if let Some(hashes) = self.blockers.get_mut(&blocker) {
+            hashes.remove(&transaction_hash);
+            if hashes.is_empty() {
+                self.blockers.remove(&blocker);
+            }
+        }
+        Some(transaction)
+    }
+
+    /// Returns parked transactions whose indexed state may have changed.
+    pub fn affected_by_state(&self, state: &EvmState) -> Vec<TxHash> {
+        let mut affected = Vec::new();
+        for (address, account) in state {
+            if account.info.balance != account.original_info().balance
+                && let Some(hashes) = self.blockers.get(&ValidityPredicateKey::Balance(*address))
+            {
+                affected.extend(hashes.iter().copied());
+            }
+
+            // Selfdestruct can clear slots that were not loaded during this execution. Wake every
+            // storage blocker for the account so those predicates are re-read from committed state.
+            if account.is_selfdestructed() {
+                for (key, hashes) in &self.blockers {
+                    if matches!(key, ValidityPredicateKey::Storage(key_address, _) if key_address == address)
+                    {
+                        affected.extend(hashes.iter().copied());
+                    }
+                }
+            } else {
+                for (slot, value) in &account.storage {
+                    if value.is_changed()
+                        && let Some(hashes) =
+                            self.blockers.get(&ValidityPredicateKey::Storage(*address, *slot))
+                    {
+                        affected.extend(hashes.iter().copied());
+                    }
+                }
+            }
+        }
+        affected
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, B256, U256};
+    use revm::state::{Account, EvmState, EvmStorageSlot};
+
+    use super::{ParkedPredicateIndex, ValidityPredicateKey};
+
+    #[test]
+    fn indexes_only_transactions_affected_by_changed_state() {
+        let balance_address = Address::with_last_byte(1);
+        let storage_address = Address::with_last_byte(2);
+        let balance_hash = B256::with_last_byte(1);
+        let storage_hash = B256::with_last_byte(2);
+        let mut index = ParkedPredicateIndex::default();
+        index.park(balance_hash, 1, ValidityPredicateKey::Balance(balance_address));
+        index.park(storage_hash, 2, ValidityPredicateKey::Storage(storage_address, U256::from(7)));
+
+        let mut state = EvmState::default();
+        let mut account = Account::default();
+        account.info.balance = U256::ONE;
+        state.insert(balance_address, account);
+
+        assert_eq!(index.affected_by_state(&state), vec![balance_hash]);
+
+        assert!(
+            index.reindex(
+                balance_hash,
+                ValidityPredicateKey::Storage(storage_address, U256::from(8))
+            )
+        );
+        let mut account = Account::default();
+        account.storage.insert(
+            U256::from(8),
+            EvmStorageSlot::new_changed(U256::ZERO, U256::ONE, Default::default()),
+        );
+        state.clear();
+        state.insert(storage_address, account);
+
+        assert_eq!(index.affected_by_state(&state), vec![balance_hash]);
+        assert_eq!(index.remove(balance_hash), Some(1));
+        assert_eq!(index.transaction(storage_hash), Some(&2));
+    }
+
+    #[test]
+    fn selfdestruct_wakes_unloaded_storage_blockers() {
+        let address = Address::with_last_byte(1);
+        let hash = B256::with_last_byte(1);
+        let mut index = ParkedPredicateIndex::default();
+        index.park(hash, (), ValidityPredicateKey::Storage(address, U256::from(7)));
+
+        let mut account = Account::default();
+        account.mark_selfdestruct();
+        let mut state = EvmState::default();
+        state.insert(address, account);
+
+        assert_eq!(index.affected_by_state(&state), vec![hash]);
+    }
+}

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -44,8 +44,8 @@ pub use flashblocks::{
     BasePayloadBuilderCtx, BestFlashblocksTxs, BlockPayloadJob, BlockPayloadJobGenerator,
     BuildArguments, FlashblockDiagnostics, FlashblockSelectionOutcome, FlashblocksExtraCtx,
     FlashblocksServiceBuilder, ParkableBestPayloadTransactions, ParkablePayloadTransactions,
-    PayloadBuilder, PayloadHandler, PayloadJobDeadline, PayloadTransactionInvalidated,
-    ResolvePayload,
+    ParkedPredicateIndex, PayloadBuilder, PayloadHandler, PayloadJobDeadline,
+    PayloadTransactionInvalidated, ResolvePayload, ValidityPredicateKey,
 };
 
 mod extension;

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -111,7 +111,24 @@ base_metrics::define_metrics! {
     #[describe("Number of entries in the rejection cache")]
     rejection_cache_size: gauge,
     #[describe("Duration of rescanning parked transaction validity predicates in seconds")]
+    #[label(policy)]
     validity_predicate_rescan_duration: histogram,
+    #[describe("Transactions parked because a validity predicate was unsatisfied")]
+    #[label(policy)]
+    #[label(predicate_count)]
+    validity_predicate_parked_total: counter,
+    #[describe("Parked transactions considered after a state change")]
+    #[label(policy)]
+    validity_predicate_rescan_transactions: histogram,
+    #[describe("Transactions remaining predicate-parked after a selection pass")]
+    #[label(policy)]
+    validity_predicate_parked_transactions: histogram,
+    #[describe("Validity-predicate blocker state keys after a selection pass")]
+    #[label(policy)]
+    validity_predicate_blocker_keys: histogram,
+    #[describe("Largest validity-predicate blocker bucket after a selection pass")]
+    #[label(policy)]
+    validity_predicate_max_blocker_bucket_size: histogram,
     #[describe("Transactions skipped because metering data has not yet arrived")]
     metering_data_pending_skip: counter,
     #[describe("Transactions rejected by per-tx DA size limit")]

--- a/crates/execution/txpool/src/parking.rs
+++ b/crates/execution/txpool/src/parking.rs
@@ -61,12 +61,6 @@ where
     /// Temporarily parks a transaction that was yielded by this iterator.
     fn park(&mut self, transaction: &Arc<ValidPoolTransaction<T>>);
 
-    /// Returns a snapshot of the currently predicate-parked transactions.
-    ///
-    /// The snapshot owns cloned transaction handles so callers can promote or discard entries
-    /// while scanning it without retaining an immutable borrow of the iterator.
-    fn parked_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T>>>;
-
     /// Makes a parked transaction eligible to compete by priority again.
     fn promote(&mut self, transaction_hash: TxHash) -> bool;
 
@@ -330,10 +324,6 @@ where
     fn park(&mut self, transaction: &Arc<ValidPoolTransaction<T>>) {
         let hash = *transaction.hash();
         self.parked.insert(hash, Arc::clone(transaction));
-    }
-
-    fn parked_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T>>> {
-        self.parked.values().cloned().collect()
     }
 
     fn promote(&mut self, transaction_hash: TxHash) -> bool {


### PR DESCRIPTION
## Summary

Optionally prevent predicate ordering from concentrating parked transactions under the same state key.

A transaction can have multiple failing predicates but only needs to be indexed under one of them. Always choosing the first failing predicate can create a large hot bucket when many transactions list the same high-value state first.

This PR adds an opt-in policy that derives a deterministic starting offset from the transaction hash and scans predicates circularly from that position. This distributes parked transactions across their failing predicates without mutating predicate lists, allocating shuffled copies, or introducing nondeterminism. The existing first-failing behavior remains the default.

It also adds metrics for evaluating blocker topology and rescan costs under both policies, plus skewed benchmarks covering up to 100,000 parked transactions.

## Configuration

Hash rotation is disabled by default and can be enabled with either:

- CLI: `--builder.hash-rotate-predicate-blockers`
- Environment: `BUILDER_HASH_ROTATE_PREDICATE_BLOCKERS=true`

The corresponding `BuilderConfig` field is `hash_rotate_predicate_blockers`.

## Metrics

All predicate-parking metrics carry a `policy` label of either `first_failing` or `hash_rotated`:

- `validity_predicate_parked_total` — transactions parked due to an unsatisfied predicate, additionally labeled by `predicate_count` (`17+` is the overflow bucket)
- `validity_predicate_rescan_transactions` — parked transactions considered after each relevant state change
- `validity_predicate_rescan_duration` — predicate rescan duration in seconds
- `validity_predicate_parked_transactions` — transactions remaining predicate-parked after a selection pass
- `validity_predicate_blocker_keys` — distinct blocker state keys after a selection pass
- `validity_predicate_max_blocker_bucket_size` — largest blocker bucket after a selection pass

Together, these expose parking volume, hot-key concentration, state-change fanout, and rescan cost for comparing both policies in production.

## Benchmark topology

The benchmark models an intentionally extreme state-skew scenario:

- every transaction has multiple failing predicates;
- predicate zero reads the same shared “hot” state key;
- the remaining predicates read transaction-specific “cold” keys;
- changing the hot key wakes every transaction indexed under it.

The wakeup benchmark measures only the time to identify affected parked transactions. It excludes subsequent predicate reads, promotion, and re-indexing.

## Hot-key wakeup performance

With first-failing selection, all 100,000 transactions are indexed under the shared predicate. Hash rotation places approximately `1 / P` of them there.

| Predicates per tx | First-failing candidates | First-failing lookup | Rotated candidates | Rotated lookup |
|---:|---:|---:|---:|---:|
| 2 | 100,000 | ~190µs | 50,000 | ~95µs |
| 8 | 100,000 | ~189µs | 12,500 | ~24µs |
| 64 | 100,000 | ~189µs | 1,563 | ~3µs |

Lookup time scales with the number of transactions returned, producing the expected approximately `1 / P` reduction in hot-key fanout.

## Initial parking tradeoff

Distribution is not free. In this benchmark, rotation often starts with a transaction-specific cold key instead of the shared hot key.

| Workload | Blocker policy | Full selection + parking |
|---|---:|---:|
| 100k txs × 2 predicates | Always first failing predicate | ~102ms |
| | Hash-rotated failing predicate | ~130ms |
| 100k txs × 8 predicates | Always first failing predicate | ~110ms |
| | Hash-rotated failing predicate | ~142ms |

This is a roughly 27–29% initial-parking penalty in the deliberately adversarial unique-cold-state topology.

Whether that tradeoff wins in production depends on actual predicate counts, state-key skew, and how frequently hot state changes. The benchmarks establish worst-case boundaries; the new metrics allow production workloads to validate the tradeoff before enabling the policy by default.

## Correctness

Rotation changes only which failing predicate is used as the current blocker.

When its state changes, all predicates are still re-evaluated. The transaction is promoted only when every predicate passes; otherwise, it is re-indexed under another failing predicate. With the flag disabled, predicate scanning preserves the existing order.