### PR TITLE
perf(sequencer): reuse inserted payload for system config

### DIFF
--- a/actions/harness/src/sequencer/attributes.rs
+++ b/actions/harness/src/sequencer/attributes.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::Bytes;
 use async_trait::async_trait;
-use base_common_consensus::BaseTxEnvelope;
+use base_common_consensus::{BaseBlock, BaseTxEnvelope};
 use base_common_rpc_types_engine::BasePayloadAttributes;
 use base_consensus_derive::{
     AttributesBuilder, PipelineError, PipelineResult, StatefulAttributesBuilder,
@@ -41,8 +41,10 @@ impl AttributesBuilder for ActionSequencerAttributesBuilder {
         &mut self,
         l2_parent: L2BlockInfo,
         epoch: alloy_eips::BlockNumHash,
+        parent_block: Option<&BaseBlock>,
     ) -> PipelineResult<BasePayloadAttributes> {
-        let mut attrs = self.inner.prepare_payload_attributes(l2_parent, epoch).await?;
+        let mut attrs =
+            self.inner.prepare_payload_attributes(l2_parent, epoch, parent_block).await?;
         let user_txs = self
             .user_txs
             .lock()

--- a/actions/harness/src/sequencer/attributes.rs
+++ b/actions/harness/src/sequencer/attributes.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use alloy_eips::eip2718::Encodable2718;
-use alloy_primitives::Bytes;
+use alloy_primitives::{Bytes, Sealed};
 use async_trait::async_trait;
 use base_common_consensus::{BaseBlock, BaseTxEnvelope};
 use base_common_rpc_types_engine::BasePayloadAttributes;
@@ -41,7 +41,7 @@ impl AttributesBuilder for ActionSequencerAttributesBuilder {
         &mut self,
         l2_parent: L2BlockInfo,
         epoch: alloy_eips::BlockNumHash,
-        parent_block: Option<&BaseBlock>,
+        parent_block: Option<&Sealed<BaseBlock>>,
     ) -> PipelineResult<BasePayloadAttributes> {
         let mut attrs =
             self.inner.prepare_payload_attributes(l2_parent, epoch, parent_block).await?;

--- a/actions/harness/src/sequencer/driver.rs
+++ b/actions/harness/src/sequencer/driver.rs
@@ -263,6 +263,7 @@ impl<E: SequencerEngineBackend> L2Sequencer<E> {
             attributes_builder: attrs_builder,
             engine_client: Arc::clone(&engine_client),
             origin_selector,
+            last_inserted_block: None,
             recovery_mode: RecoveryModeGuard::new(false),
             rollup_config: Arc::clone(&self.rollup_config),
         };

--- a/crates/common/rpc-types-engine/src/envelope.rs
+++ b/crates/common/rpc-types-engine/src/envelope.rs
@@ -6,7 +6,11 @@
 use alloc::vec::Vec;
 
 use alloy_consensus::{Block, BlockHeader, Sealable, Transaction};
-use alloy_eips::{Encodable2718, eip4895::Withdrawal, eip7685::Requests};
+use alloy_eips::{
+    Decodable2718, Encodable2718, Typed2718,
+    eip4895::Withdrawal,
+    eip7685::{EMPTY_REQUESTS_HASH, Requests},
+};
 use alloy_primitives::{B256, Bytes, Signature, keccak256};
 use alloy_rpc_types_engine::{
     CancunPayloadFields, ExecutionPayloadInputV2, ExecutionPayloadV3, PraguePayloadFields,
@@ -43,6 +47,30 @@ impl BaseExecutionPayloadEnvelope {
         use ssz::Encode;
         let ssz_bytes = self.as_ssz_bytes();
         crate::PayloadHash::from(ssz_bytes.as_slice())
+    }
+
+    /// Converts the envelope into a [`Block`], supplying the sidecar fields carried by the
+    /// envelope (the parent beacon block root) for V3/V4 payloads.
+    pub fn try_into_block<T: Decodable2718 + Typed2718>(
+        self,
+    ) -> Result<Block<T>, crate::BasePayloadError> {
+        let parent_beacon_block_root = self.parent_beacon_block_root.unwrap_or_default();
+        match self.execution_payload {
+            payload @ (BaseExecutionPayload::V1(_) | BaseExecutionPayload::V2(_)) => {
+                payload.try_into_block()
+            }
+            payload @ BaseExecutionPayload::V3(_) => {
+                payload.try_into_block_with_sidecar(&BaseExecutionPayloadSidecar::v3(
+                    CancunPayloadFields::new(parent_beacon_block_root, Vec::new()),
+                ))
+            }
+            payload @ BaseExecutionPayload::V4(_) => {
+                payload.try_into_block_with_sidecar(&BaseExecutionPayloadSidecar::v4(
+                    CancunPayloadFields::new(parent_beacon_block_root, Vec::new()),
+                    PraguePayloadFields::new(EMPTY_REQUESTS_HASH),
+                ))
+            }
+        }
     }
 }
 

--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -1,6 +1,6 @@
 //! The [`AttributesBuilder`] and it's default implementation.
 
-use alloc::{boxed::Box, fmt::Debug, format, string::ToString, sync::Arc, vec, vec::Vec};
+use alloc::{boxed::Box, fmt::Debug, string::ToString, sync::Arc, vec, vec::Vec};
 
 use alloy_consensus::{Eip658Value, Receipt};
 use alloy_eips::{BlockNumHash, eip2718::Encodable2718};
@@ -13,10 +13,7 @@ use base_common_consensus::{BaseBlock, Predeploys};
 use base_common_genesis::RollupConfig;
 use base_common_rpc_types_engine::BasePayloadAttributes;
 use base_consensus_upgrades::{Upgrade, Upgrades};
-use base_protocol::{
-    BaseTimeUpdateTx, BatchValidationProvider, Deposits, L1BlockInfoTx, L2BlockInfo,
-    to_system_config,
-};
+use base_protocol::{BaseTimeUpdateTx, Deposits, L1BlockInfoTx, L2BlockInfo, to_system_config};
 use tracing::warn;
 
 use crate::{
@@ -67,7 +64,6 @@ impl<L1P, L2P> AttributesBuilder for StatefulAttributesBuilder<L1P, L2P>
 where
     L1P: ChainProvider + Debug + Send,
     L2P: L2ChainProvider + Debug + Send,
-    <L2P as BatchValidationProvider>::Error: Into<PipelineErrorKind>,
 {
     async fn prepare_payload_attributes(
         &mut self,
@@ -100,34 +96,11 @@ where
                 }
             }) {
             Some(config) => config,
-            None => {
-                let block = self
-                    .config_fetcher
-                    .block_by_number(l2_parent.block_info.number)
-                    .await
-                    .map_err(Into::into)?;
-                let block_hash = block.header.hash_slow();
-                if block_hash != l2_parent.block_info.hash {
-                    return Err(PipelineErrorKind::Reset(
-                        BuilderError::BlockMismatch(
-                            BlockNumHash {
-                                number: l2_parent.block_info.number,
-                                hash: l2_parent.block_info.hash,
-                            },
-                            BlockNumHash { number: block.header.number, hash: block_hash },
-                        )
-                        .into(),
-                    ));
-                }
-                to_system_config(&block, &self.rollup_cfg).map_err(|err| {
-                    warn!(target: "attributes", error = ?err, number = block.header.number, "Failed to decode system config from parent block");
-                    PipelineError::Provider(format!(
-                        "system config conversion failed for block {}",
-                        block.header.number
-                    ))
-                    .temp()
-                })?
-            }
+            None => self
+                .config_fetcher
+                .system_config_by_number(l2_parent.block_info.number, Arc::clone(&self.rollup_cfg))
+                .await
+                .map_err(Into::into)?,
         };
 
         // If the L1 origin changed in this block, then we are in the first block of the epoch.
@@ -1004,14 +977,11 @@ mod tests {
         Sealed::new_unchecked(block, hash)
     }
 
-    /// Installs a decodable block built from `header` into the fetcher and returns its hash:
-    /// the EL fallback verifies the fetched block's hash against the parent hash, so tests
-    /// exercising it need the parent hash to be a real block hash.
+    /// Registers a fallback [`SystemConfig`] for `header`'s block number and returns the
+    /// header's hash to use as the L2 parent hash.
     fn fallback_parent(fetcher: &mut TestSystemConfigL2Fetcher, header: Header) -> B256 {
-        let block = seedable_block(header);
-        let hash = block.header.hash_slow();
-        fetcher.insert_block(block.header.number, block);
-        hash
+        fetcher.insert(header.number, SystemConfig::default());
+        header.hash_slow()
     }
 
     #[tokio::test]
@@ -1025,14 +995,14 @@ mod tests {
         l2_parent.block_info.hash = parent.hash();
         builder.config_fetcher.clear();
         builder.prepare_payload_attributes(l2_parent, epoch, Some(&parent)).await.unwrap();
-        assert!(builder.config_fetcher.block_calls.is_empty());
+        assert!(builder.config_fetcher.system_config_calls.is_empty());
     }
 
     #[tokio::test]
     async fn test_missing_parent_block_falls_back_to_el() {
         let (mut builder, epoch, l2_parent) = transition_setup();
         builder.prepare_payload_attributes(l2_parent, epoch, None).await.unwrap();
-        assert_eq!(builder.config_fetcher.block_calls, vec![1]);
+        assert_eq!(builder.config_fetcher.system_config_calls, vec![1]);
     }
 
     #[tokio::test]
@@ -1040,24 +1010,7 @@ mod tests {
         let (mut builder, epoch, l2_parent) = transition_setup();
         let other = sealed_block(seedable_block(Header { number: 99, ..Default::default() }));
         builder.prepare_payload_attributes(l2_parent, epoch, Some(&other)).await.unwrap();
-        assert_eq!(builder.config_fetcher.block_calls, vec![1]);
-    }
-
-    /// A fallback read that returns a different block than the parent being built on (e.g. the
-    /// EL reorged between the parent being chosen and the read) must reset instead of using
-    /// another block's config.
-    #[tokio::test]
-    async fn test_fallback_block_hash_mismatch_resets() {
-        let (mut builder, epoch, mut l2_parent) = transition_setup();
-        l2_parent.block_info.hash = B256::left_padding_from(&[0xAA]);
-        let err = builder.prepare_payload_attributes(l2_parent, epoch, None).await.unwrap_err();
-        assert!(matches!(
-            err,
-            PipelineErrorKind::Reset(ResetError::AttributesBuilder(BuilderError::BlockMismatch(
-                _,
-                _
-            )))
-        ));
+        assert_eq!(builder.config_fetcher.system_config_calls, vec![1]);
     }
 
     #[tokio::test]
@@ -1073,7 +1026,7 @@ mod tests {
         let payload =
             builder.prepare_payload_attributes(l2_parent, epoch, Some(&parent)).await.unwrap();
         assert_eq!(payload.gas_limit, Some(40_000_000));
-        assert!(builder.config_fetcher.block_calls.is_empty());
+        assert!(builder.config_fetcher.system_config_calls.is_empty());
     }
 
     #[tokio::test]
@@ -1086,7 +1039,7 @@ mod tests {
         });
         assert_eq!(undecodable.hash(), l2_parent.block_info.hash);
         builder.prepare_payload_attributes(l2_parent, epoch, Some(&undecodable)).await.unwrap();
-        assert_eq!(builder.config_fetcher.block_calls, vec![1]);
+        assert_eq!(builder.config_fetcher.system_config_calls, vec![1]);
     }
 
     /// Crossing a fork that changes the system config encoding (here Holocene, which moves the
@@ -1143,6 +1096,6 @@ mod tests {
             payload.eip_1559_params,
             Some(B64::from_slice(&[250_u32.to_be_bytes(), 6_u32.to_be_bytes()].concat()))
         );
-        assert!(builder.config_fetcher.block_calls.is_empty());
+        assert!(builder.config_fetcher.system_config_calls.is_empty());
     }
 }

--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -11,11 +11,11 @@ use alloy_primitives::{Address, B256, Bytes};
 use alloy_rlp::Encodable;
 use alloy_rpc_types_engine::PayloadAttributes;
 use async_trait::async_trait;
-use base_common_consensus::Predeploys;
-use base_common_genesis::{BaseUpgrade, RollupConfig, SystemConfig};
+use base_common_consensus::{BaseBlock, Predeploys};
+use base_common_genesis::{RollupConfig, SystemConfig};
 use base_common_rpc_types_engine::BasePayloadAttributes;
 use base_consensus_upgrades::{Upgrade, Upgrades};
-use base_protocol::{BaseTimeUpdateTx, Deposits, L1BlockInfoTx, L2BlockInfo};
+use base_protocol::{BaseTimeUpdateTx, Deposits, L1BlockInfoTx, L2BlockInfo, to_system_config};
 use tracing::warn;
 
 use crate::{
@@ -23,7 +23,7 @@ use crate::{
     PipelineError, PipelineErrorKind, PipelineResult,
 };
 
-/// The maximum number of [`SystemConfig`]s cached by L1 origin hash.
+/// The maximum number of [`SystemConfig`]s cached by L2 block hash.
 const MAX_SYSTEM_CONFIG_CACHE_ENTRIES: usize = 8;
 
 /// A stateful implementation of the [`AttributesBuilder`].
@@ -41,7 +41,9 @@ where
     config_fetcher: L2P,
     /// The L1 receipts fetcher.
     receipts_fetcher: L1P,
-    /// Cache of [`SystemConfig`]s keyed by L1 origin hash, most recently used first.
+    /// Cache of [`SystemConfig`]s keyed by the L2 block hash they were decoded from, most
+    /// recently used first. An entry is a pure function of its block, so it can never go stale:
+    /// forks, resets, and reorgs need no invalidation.
     system_configs: VecDeque<(B256, SystemConfig)>,
 }
 
@@ -66,23 +68,23 @@ where
         }
     }
 
-    /// Returns the cached [`SystemConfig`] for the given L1 origin hash, promoting it to most
+    /// Returns the cached [`SystemConfig`] for the given L2 block hash, promoting it to most
     /// recently used.
-    fn cached_system_config(&mut self, origin: &B256) -> Option<SystemConfig> {
-        let index = self.system_configs.iter().position(|(hash, _)| hash == origin)?;
+    fn cached_system_config(&mut self, block_hash: &B256) -> Option<SystemConfig> {
+        let index = self.system_configs.iter().position(|(hash, _)| hash == block_hash)?;
         let entry = self.system_configs.remove(index)?;
         let config = entry.1;
         self.system_configs.push_front(entry);
         Some(config)
     }
 
-    /// Caches the [`SystemConfig`] for the given L1 origin hash, evicting the least recently used
+    /// Caches the [`SystemConfig`] for the given L2 block hash, evicting the least recently used
     /// entries beyond [`MAX_SYSTEM_CONFIG_CACHE_ENTRIES`].
-    fn cache_system_config(&mut self, origin: B256, config: SystemConfig) {
-        if let Some(index) = self.system_configs.iter().position(|(hash, _)| hash == &origin) {
+    fn cache_system_config(&mut self, block_hash: B256, config: SystemConfig) {
+        if let Some(index) = self.system_configs.iter().position(|(hash, _)| hash == &block_hash) {
             self.system_configs.remove(index);
         }
-        self.system_configs.push_front((origin, config));
+        self.system_configs.push_front((block_hash, config));
         self.system_configs.truncate(MAX_SYSTEM_CONFIG_CACHE_ENTRIES);
     }
 }
@@ -105,10 +107,12 @@ where
         let (next_l2_time, next_l2_timestamp_millis_part) =
             self.rollup_cfg.l2_block_timestamp_parts(next_l2_block_number);
 
-        // The system config for the parent's L1 origin: carried forward in memory, read from
-        // the L2 EL only when the origin is unknown (startup, reset, reorg, or immediately after
-        // a network upgrade).
-        let mut sys_config = match self.cached_system_config(&l2_parent.l1_origin.hash) {
+        // The parent block's system config: decoded from the parent itself, either seeded in
+        // memory when the parent was inserted (see [`AttributesBuilder::seed_system_config`]) or
+        // read from the L2 EL on a miss (startup, reset, reorg, or a parent built elsewhere).
+        // ponytail: the miss path fetches by number, not hash, matching the pre-cache behavior;
+        // switch the provider to a by-hash read if non-canonical parents ever need exactness.
+        let mut sys_config = match self.cached_system_config(&l2_parent.block_info.hash) {
             Some(config) => config,
             None => {
                 let config = self
@@ -119,7 +123,7 @@ where
                     )
                     .await
                     .map_err(Into::into)?;
-                self.cache_system_config(l2_parent.l1_origin.hash, config);
+                self.cache_system_config(l2_parent.block_info.hash, config);
                 config
             }
         };
@@ -131,9 +135,6 @@ where
             let header =
                 self.receipts_fetcher.header_by_hash(epoch.hash).await.map_err(Into::into)?;
             if l2_parent.l1_origin.hash != header.parent_hash {
-                // A reset means the carried-forward configs may not match the chain the
-                // pipeline resets to; drop them so the EL is re-read after the reset.
-                self.system_configs.clear();
                 return Err(PipelineErrorKind::Reset(
                     BuilderError::BlockMismatchEpochReset(
                         epoch,
@@ -160,16 +161,10 @@ where
             for err in &errors {
                 warn!(target: "attributes", error = ?err, epoch = epoch.number, "Malformed system config update (skipped)");
             }
-            // Cache the config of the new origin: subsequent blocks in this epoch use it
-            // without consulting the EL.
-            self.cache_system_config(epoch.hash, sys_config);
             l1_header = header;
             deposit_transactions = deposits;
             0
         } else if l2_parent.l1_origin.hash != epoch.hash {
-            // A reset means the carried-forward configs may not match the chain the pipeline
-            // resets to; drop them so the EL is re-read after the reset.
-            self.system_configs.clear();
             return Err(PipelineErrorKind::Reset(
                 BuilderError::BlockMismatch(epoch, l2_parent.l1_origin).into(),
             ));
@@ -181,24 +176,9 @@ where
             l2_parent.seq_num + 1
         };
 
-        // A fork may change which SystemConfig fields can be decoded from an L2 block. Drop the
-        // carried value at every configured fork boundary so the next build decodes the new
-        // format from the EL. Iterating the canonical upgrade list automatically covers future
-        // forks; the extra read happens only once per fork.
-        if BaseUpgrade::VARIANTS.iter().any(|&upgrade| {
-            self.rollup_cfg.upgrade_activation_timestamp(upgrade).is_some_and(|activation| {
-                l2_parent.block_info.timestamp < activation && activation <= next_l2_time
-            })
-        }) {
-            self.system_configs.clear();
-        }
-
         // Sanity check the L1 origin was correctly selected to maintain the time invariant
         // between L1 and L2.
         if next_l2_time < l1_header.timestamp {
-            // A reset means the carried-forward configs may not match the chain the pipeline
-            // resets to; drop them so the EL is re-read after the reset.
-            self.system_configs.clear();
             return Err(PipelineErrorKind::Reset(
                 BuilderError::BrokenTimeInvariant(
                     l2_parent.l1_origin,
@@ -307,6 +287,17 @@ where
                                                                         * set at Jovian */
         })
     }
+
+    fn seed_system_config(&mut self, block: &BaseBlock) {
+        match to_system_config(block, &self.rollup_cfg) {
+            Ok(config) => self.cache_system_config(block.header.hash_slow(), config),
+            // A block that cannot be decoded is simply not seeded: the next build on it falls
+            // back to the EL read.
+            Err(err) => {
+                warn!(target: "attributes", error = ?err, number = block.header.number, "Failed to decode system config from inserted block");
+            }
+        }
+    }
 }
 
 /// Derive deposits as `Vec<Bytes>` for transaction receipts.
@@ -345,15 +336,17 @@ async fn derive_deposits(
 mod tests {
     use alloc::vec;
 
-    use alloy_consensus::Header;
+    use alloy_consensus::{BlockBody, Header};
     use alloy_eips::eip2718::Decodable2718;
-    use alloy_primitives::{B64, B256, Log, LogData, U64, U256, address};
+    use alloy_primitives::{B64, B256, Log, LogData, Sealed, U64, U256, address, bytes};
     use base_common_chains::Sepolia;
-    use base_common_consensus::{BaseTxEnvelope, SystemAddresses};
+    use base_common_consensus::{BaseTxEnvelope, SystemAddresses, TxDeposit};
     use base_common_genesis::{
         BaseUpgradeConfig, ChainGenesis, SystemConfig, SystemConfigUpdate, UpgradeConfig,
     };
-    use base_protocol::{BlockInfo, DepositDecodeError};
+    use base_protocol::{
+        BlockInfo, DepositDecodeError, test_utils::RAW_BEDROCK_INFO_TX,
+    };
 
     use super::*;
     use crate::{
@@ -990,12 +983,13 @@ mod tests {
         (builder, BlockNumHash { hash: epoch_hash, number: 2 }, l2_parent)
     }
 
-    /// Advances to the next L2 parent within the same L1 origin.
+    /// Advances to the next L2 parent within the same L1 origin, giving each block a distinct
+    /// hash.
     fn next_l2_parent(prev: &L2BlockInfo, cfg: &RollupConfig, epoch: BlockNumHash) -> L2BlockInfo {
         let number = prev.block_info.number + 1;
         L2BlockInfo {
             block_info: BlockInfo {
-                hash: B256::ZERO,
+                hash: B256::with_last_byte(number as u8),
                 number,
                 timestamp: cfg.l2_block_timestamp(number),
                 parent_hash: prev.block_info.hash,
@@ -1005,67 +999,82 @@ mod tests {
         }
     }
 
+    /// Builds a minimal decodable L2 block: `to_system_config` requires an L1 info deposit as
+    /// the first transaction.
+    fn seedable_block(header: Header) -> BaseBlock {
+        BaseBlock {
+            header,
+            body: BlockBody {
+                transactions: vec![BaseTxEnvelope::Deposit(Sealed::new(TxDeposit {
+                    input: Bytes::from(&RAW_BEDROCK_INFO_TX),
+                    ..Default::default()
+                }))],
+                ..Default::default()
+            },
+        }
+    }
+
     #[tokio::test]
-    async fn test_system_config_carried_forward_within_epoch() {
+    async fn test_seeded_parent_config_skips_el_read() {
         let (mut builder, epoch, l2_parent) = transition_setup();
 
-        // Epoch transition: reads the EL once for the parent origin's config.
+        // The parent's config was seeded when it was inserted; the EL can no longer serve any
+        // config, so a cache miss would fail the build.
+        builder.cache_system_config(l2_parent.block_info.hash, SystemConfig::default());
+        builder.config_fetcher.clear();
+        builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
+        assert!(builder.config_fetcher.system_config_calls.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_unknown_parent_falls_back_to_el_and_caches() {
+        let (mut builder, epoch, l2_parent) = transition_setup();
+
+        // An unseeded parent (startup, reset, or a block built elsewhere) is read from the EL.
         builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
         assert_eq!(builder.config_fetcher.system_config_calls, vec![1]);
 
-        // Same-epoch blocks reuse the carried-forward config even when the EL can no longer
+        // A rebuild on the same parent is served from the cache even when the EL can no longer
         // serve it.
         builder.config_fetcher.clear();
-        let cfg = Arc::clone(&builder.rollup_cfg);
-        let l2_parent = next_l2_parent(&l2_parent, &cfg, epoch);
-        builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
-        let l2_parent = next_l2_parent(&l2_parent, &cfg, epoch);
         builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
         assert_eq!(builder.config_fetcher.system_config_calls, vec![1]);
     }
 
     #[tokio::test]
-    async fn test_system_config_cache_ignores_stale_el_value() {
+    async fn test_same_origin_different_parent_misses_cache() {
         let (mut builder, epoch, l2_parent) = transition_setup();
-
         builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
-        let cached_gas_limit = SystemConfig::default().gas_limit;
+        assert_eq!(builder.config_fetcher.system_config_calls, vec![1]);
 
-        // The EL now reports a different config for the next block; the carried-forward config
-        // must win because it already includes the new epoch's updates.
-        let stale = SystemConfig { gas_limit: cached_gas_limit + 1, ..Default::default() };
-        builder.config_fetcher.insert(2, stale);
-
+        // The next parent shares the L1 origin but is a different L2 block: entries are keyed
+        // by block hash, so without a seed its config is read from the EL rather than reusing
+        // the previous parent's entry.
         let cfg = Arc::clone(&builder.rollup_cfg);
         let l2_parent = next_l2_parent(&l2_parent, &cfg, epoch);
+        builder.config_fetcher.insert(2, SystemConfig::default());
+        builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
+        assert_eq!(builder.config_fetcher.system_config_calls, vec![1, 2]);
+    }
+
+    #[tokio::test]
+    async fn test_seeded_config_wins_over_el_value() {
+        let (mut builder, epoch, l2_parent) = transition_setup();
+
+        // The seeded entry differs from what the EL reports for the same block number (e.g.
+        // after an L1 reorg changed the canonical block at that height): the exact-hash seed
+        // must win.
+        let seeded_gas_limit = SystemConfig::default().gas_limit + 1;
+        builder.cache_system_config(
+            l2_parent.block_info.hash,
+            SystemConfig { gas_limit: seeded_gas_limit, ..Default::default() },
+        );
         let payload = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
         assert_eq!(
             payload.gas_limit,
-            Some(u64::from_be_bytes(alloy_primitives::U64::from(cached_gas_limit).to_be_bytes()))
+            Some(u64::from_be_bytes(alloy_primitives::U64::from(seeded_gas_limit).to_be_bytes()))
         );
-        assert_eq!(builder.config_fetcher.system_config_calls, vec![1]);
-    }
-
-    #[tokio::test]
-    async fn test_unknown_l1_origin_falls_back_to_el() {
-        let (mut builder, epoch, l2_parent) = transition_setup();
-        builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
-        assert_eq!(builder.config_fetcher.system_config_calls, vec![1]);
-
-        // A reorged L1 origin (same number, unknown hash) is not in the cache: the config is
-        // read from the EL.
-        let reorged_header = Header { number: 2, timestamp: 100, ..Default::default() };
-        let reorged_hash = reorged_header.hash_slow();
-        builder.receipts_fetcher.insert_header(reorged_hash, reorged_header);
-        builder.config_fetcher.insert(2, SystemConfig::default());
-
-        let cfg = Arc::clone(&builder.rollup_cfg);
-        let mut l2_parent =
-            next_l2_parent(&l2_parent, &cfg, BlockNumHash { hash: reorged_hash, number: 2 });
-        l2_parent.l1_origin = BlockNumHash { hash: reorged_hash, number: 2 };
-        let epoch = BlockNumHash { hash: reorged_hash, number: 2 };
-        builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
-        assert_eq!(builder.config_fetcher.system_config_calls, vec![1, 2]);
+        assert!(builder.config_fetcher.system_config_calls.is_empty());
     }
 
     #[test]
@@ -1076,27 +1085,60 @@ mod tests {
             TestSystemConfigL2Fetcher::default(),
             TestChainProvider::default(),
         );
-        let origins: Vec<B256> = (0..10).map(|i| B256::from([i as u8; 32])).collect();
-        for &origin in &origins {
-            builder.cache_system_config(origin, SystemConfig::default());
+        let hashes: Vec<B256> = (0..10).map(|i| B256::from([i as u8; 32])).collect();
+        for &hash in &hashes {
+            builder.cache_system_config(hash, SystemConfig::default());
         }
         assert_eq!(builder.system_configs.len(), MAX_SYSTEM_CONFIG_CACHE_ENTRIES);
-        assert!(builder.cached_system_config(&origins[0]).is_none());
-        assert!(builder.cached_system_config(&origins[9]).is_some());
+        assert!(builder.cached_system_config(&hashes[0]).is_none());
+        assert!(builder.cached_system_config(&hashes[9]).is_some());
 
         // A hit promotes the entry, evicting the next-oldest on the following insert.
-        assert!(builder.cached_system_config(&origins[2]).is_some());
+        assert!(builder.cached_system_config(&hashes[2]).is_some());
         builder.cache_system_config(B256::from([10_u8; 32]), SystemConfig::default());
-        assert!(builder.cached_system_config(&origins[2]).is_some());
-        assert!(builder.cached_system_config(&origins[3]).is_none());
+        assert!(builder.cached_system_config(&hashes[2]).is_some());
+        assert!(builder.cached_system_config(&hashes[3]).is_none());
+    }
+
+    #[test]
+    fn test_seed_system_config_caches_inserted_block() {
+        let mut builder = StatefulAttributesBuilder::new(
+            Arc::new(RollupConfig::default()),
+            Arc::new(Sepolia::l1_config()),
+            TestSystemConfigL2Fetcher::default(),
+            TestChainProvider::default(),
+        );
+        let block =
+            seedable_block(Header { number: 5, gas_limit: 40_000_000, ..Default::default() });
+        builder.seed_system_config(&block);
+        let expected = to_system_config(&block, &builder.rollup_cfg).unwrap();
+        assert_eq!(builder.cached_system_config(&block.header.hash_slow()), Some(expected));
+    }
+
+    #[test]
+    fn test_seed_system_config_undecodable_block_is_skipped() {
+        let mut builder = StatefulAttributesBuilder::new(
+            Arc::new(RollupConfig::default()),
+            Arc::new(Sepolia::l1_config()),
+            TestSystemConfigL2Fetcher::default(),
+            TestChainProvider::default(),
+        );
+        // No transactions: `to_system_config` fails, so nothing is cached and the next build on
+        // this block takes the EL fallback.
+        let block = BaseBlock {
+            header: Header { number: 5, ..Default::default() },
+            body: BlockBody::default(),
+        };
+        builder.seed_system_config(&block);
+        assert!(builder.system_configs.is_empty());
     }
 
     /// Crossing a fork that changes the system config encoding (here Holocene, which moves the
-    /// EIP-1559 parameters into the header's `extra_data`) must force one EL re-read: the
-    /// pre-fork cached config has no EIP-1559 parameters, and carrying it forward would emit
-    /// zeroed params where the EL decodes the persisted values from the parent block.
+    /// EIP-1559 parameters into the header's `extra_data`) needs no EL read: the first
+    /// post-fork block is seeded from its own payload after insertion, so the next build
+    /// decodes the new fields directly from the seed.
     #[tokio::test]
-    async fn test_fork_boundary_forces_el_reseed() {
+    async fn test_fork_transition_seeded_parent_skips_el_read() {
         let block_time = 2_u64;
         // Blocks: 1 -> ts 100 (pre-Holocene), 2 -> ts 102 (first Holocene), 3 -> ts 104.
         let cfg = Arc::new(RollupConfig {
@@ -1106,82 +1148,45 @@ mod tests {
             ..Default::default()
         });
         let l1_cfg = Arc::new(Sepolia::l1_config());
-        let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(1, SystemConfig::default());
         let mut provider = TestChainProvider::default();
         let origin_header = Header { number: 1, timestamp: 100, ..Default::default() };
         let origin_hash = origin_header.hash_slow();
         provider.insert_header(origin_hash, origin_header);
-        let mut builder =
-            StatefulAttributesBuilder::new(Arc::clone(&cfg), l1_cfg, fetcher, provider);
+        let mut builder = StatefulAttributesBuilder::new(
+            Arc::clone(&cfg),
+            l1_cfg,
+            TestSystemConfigL2Fetcher::default(),
+            provider,
+        );
         let epoch = BlockNumHash { hash: origin_hash, number: 1 };
 
-        // Build block 2 (the Holocene transition block) on the pre-fork parent: seeds the
-        // cache from the EL and emits the zeroed transition sentinel.
+        // The sequencer inserted block 2 (the first Holocene block), whose `extra_data`
+        // persists denominator 250 and elasticity 6, and seeded it.
+        let inserted = seedable_block(Header {
+            number: 2,
+            timestamp: 102,
+            extra_data: bytes!("00000000fa00000006"),
+            ..Default::default()
+        });
+        builder.seed_system_config(&inserted);
+
+        // Build block 3 on the seeded post-fork parent: the persisted parameters come from the
+        // seed and the EL is never consulted.
         let l2_parent = L2BlockInfo {
             block_info: BlockInfo {
-                hash: B256::ZERO,
-                number: 1,
-                timestamp: 100,
-                ..Default::default()
+                hash: inserted.header.hash_slow(),
+                number: 2,
+                timestamp: 102,
+                parent_hash: B256::ZERO,
             },
             l1_origin: epoch,
-            seq_num: 0,
+            seq_num: 1,
         };
-        let payload = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
-        assert_eq!(payload.eip_1559_params, Some(B64::ZERO));
-        assert_eq!(builder.config_fetcher.system_config_calls, vec![1]);
-
-        // The EL's view of block 2 decodes the persisted EIP-1559 parameters from its
-        // `extra_data`; the pre-fork cached config has neither.
-        let post_fork = SystemConfig {
-            eip1559_denominator: Some(250),
-            eip1559_elasticity: Some(6),
-            ..Default::default()
-        };
-        builder.config_fetcher.insert(2, post_fork);
-
-        // Build block 3 on the post-fork parent: the transition cleared the cache, so the EL is
-        // re-read, yielding the persisted parameters instead of zeros.
-        let l2_parent = next_l2_parent(&l2_parent, &cfg, epoch);
         let payload = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
         assert_eq!(
             payload.eip_1559_params,
             Some(B64::from_slice(&[250_u32.to_be_bytes(), 6_u32.to_be_bytes()].concat()))
         );
-        assert_eq!(builder.config_fetcher.system_config_calls, vec![1, 2]);
-
-        // Build block 4 without another fork, served from the re-seeded cache.
-        let l2_parent = next_l2_parent(&l2_parent, &cfg, epoch);
-        builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
-        assert_eq!(builder.config_fetcher.system_config_calls, vec![1, 2]);
-    }
-
-    /// A Reset-class error (here a broken time invariant) must clear the carried-forward
-    /// configs: after the pipeline resets, the chain may differ, so the EL is re-read.
-    #[tokio::test]
-    async fn test_reset_error_clears_config_cache() {
-        let (mut builder, _epoch, l2_parent) = transition_setup();
-        let origin = l2_parent.l1_origin;
-
-        // Same-epoch build seeds the cache.
-        builder.prepare_payload_attributes(l2_parent, origin).await.unwrap();
-        assert_eq!(builder.config_fetcher.system_config_calls, vec![1]);
-
-        // An epoch transition to an origin whose timestamp breaks the time invariant returns a
-        // Reset error and clears the cache.
-        let bad_header =
-            Header { number: 2, timestamp: 1_000, parent_hash: origin.hash, ..Default::default() };
-        let bad_hash = bad_header.hash_slow();
-        builder.receipts_fetcher.insert_header(bad_hash, bad_header);
-        builder.receipts_fetcher.insert_receipts(bad_hash, vec![]);
-        let bad_epoch = BlockNumHash { hash: bad_hash, number: 2 };
-        let err = builder.prepare_payload_attributes(l2_parent, bad_epoch).await.unwrap_err();
-        assert!(matches!(err, PipelineErrorKind::Reset(_)));
-        assert!(builder.system_configs.is_empty());
-
-        // The next build re-reads the EL instead of trusting a pre-reset config.
-        builder.prepare_payload_attributes(l2_parent, origin).await.unwrap();
-        assert_eq!(builder.config_fetcher.system_config_calls, vec![1, 1]);
+        assert!(builder.config_fetcher.system_config_calls.is_empty());
     }
 }

--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -1,6 +1,8 @@
 //! The [`AttributesBuilder`] and it's default implementation.
 
-use alloc::{boxed::Box, fmt::Debug, string::ToString, sync::Arc, vec, vec::Vec};
+use alloc::{
+    boxed::Box, collections::VecDeque, fmt::Debug, string::ToString, sync::Arc, vec, vec::Vec,
+};
 
 use alloy_consensus::{Eip658Value, Receipt};
 use alloy_eips::{BlockNumHash, eip2718::Encodable2718};
@@ -10,7 +12,7 @@ use alloy_rlp::Encodable;
 use alloy_rpc_types_engine::PayloadAttributes;
 use async_trait::async_trait;
 use base_common_consensus::Predeploys;
-use base_common_genesis::RollupConfig;
+use base_common_genesis::{BaseUpgrade, RollupConfig, SystemConfig};
 use base_common_rpc_types_engine::BasePayloadAttributes;
 use base_consensus_upgrades::{Upgrade, Upgrades};
 use base_protocol::{BaseTimeUpdateTx, Deposits, L1BlockInfoTx, L2BlockInfo};
@@ -20,6 +22,9 @@ use crate::{
     AttributesBuilder, BuilderError, ChainProvider, L2ChainProvider, PipelineEncodingError,
     PipelineError, PipelineErrorKind, PipelineResult,
 };
+
+/// The maximum number of [`SystemConfig`]s cached by L1 origin hash.
+const MAX_SYSTEM_CONFIG_CACHE_ENTRIES: usize = 8;
 
 /// A stateful implementation of the [`AttributesBuilder`].
 #[derive(Debug, Default)]
@@ -36,6 +41,8 @@ where
     config_fetcher: L2P,
     /// The L1 receipts fetcher.
     receipts_fetcher: L1P,
+    /// Cache of [`SystemConfig`]s keyed by L1 origin hash, most recently used first.
+    system_configs: VecDeque<(B256, SystemConfig)>,
 }
 
 impl<L1P, L2P> StatefulAttributesBuilder<L1P, L2P>
@@ -55,7 +62,28 @@ where
             l1_cfg,
             config_fetcher: sys_cfg_fetcher,
             receipts_fetcher: receipts,
+            system_configs: VecDeque::new(),
         }
+    }
+
+    /// Returns the cached [`SystemConfig`] for the given L1 origin hash, promoting it to most
+    /// recently used.
+    fn cached_system_config(&mut self, origin: &B256) -> Option<SystemConfig> {
+        let index = self.system_configs.iter().position(|(hash, _)| hash == origin)?;
+        let entry = self.system_configs.remove(index)?;
+        let config = entry.1;
+        self.system_configs.push_front(entry);
+        Some(config)
+    }
+
+    /// Caches the [`SystemConfig`] for the given L1 origin hash, evicting the least recently used
+    /// entries beyond [`MAX_SYSTEM_CONFIG_CACHE_ENTRIES`].
+    fn cache_system_config(&mut self, origin: B256, config: SystemConfig) {
+        if let Some(index) = self.system_configs.iter().position(|(hash, _)| hash == &origin) {
+            self.system_configs.remove(index);
+        }
+        self.system_configs.push_front((origin, config));
+        self.system_configs.truncate(MAX_SYSTEM_CONFIG_CACHE_ENTRIES);
     }
 }
 
@@ -73,11 +101,28 @@ where
         let l1_header;
         let deposit_transactions: Vec<Bytes>;
 
-        let mut sys_config = self
-            .config_fetcher
-            .system_config_by_number(l2_parent.block_info.number, Arc::clone(&self.rollup_cfg))
-            .await
-            .map_err(Into::into)?;
+        let next_l2_block_number = l2_parent.block_info.number + 1;
+        let (next_l2_time, next_l2_timestamp_millis_part) =
+            self.rollup_cfg.l2_block_timestamp_parts(next_l2_block_number);
+
+        // The system config for the parent's L1 origin: carried forward in memory, read from
+        // the L2 EL only when the origin is unknown (startup, reset, reorg, or immediately after
+        // a network upgrade).
+        let mut sys_config = match self.cached_system_config(&l2_parent.l1_origin.hash) {
+            Some(config) => config,
+            None => {
+                let config = self
+                    .config_fetcher
+                    .system_config_by_number(
+                        l2_parent.block_info.number,
+                        Arc::clone(&self.rollup_cfg),
+                    )
+                    .await
+                    .map_err(Into::into)?;
+                self.cache_system_config(l2_parent.l1_origin.hash, config);
+                config
+            }
+        };
 
         // If the L1 origin changed in this block, then we are in the first block of the epoch.
         // In this case we need to fetch all transaction receipts from the L1 origin block so
@@ -86,6 +131,9 @@ where
             let header =
                 self.receipts_fetcher.header_by_hash(epoch.hash).await.map_err(Into::into)?;
             if l2_parent.l1_origin.hash != header.parent_hash {
+                // A reset means the carried-forward configs may not match the chain the
+                // pipeline resets to; drop them so the EL is re-read after the reset.
+                self.system_configs.clear();
                 return Err(PipelineErrorKind::Reset(
                     BuilderError::BlockMismatchEpochReset(
                         epoch,
@@ -112,10 +160,16 @@ where
             for err in &errors {
                 warn!(target: "attributes", error = ?err, epoch = epoch.number, "Malformed system config update (skipped)");
             }
+            // Cache the config of the new origin: subsequent blocks in this epoch use it
+            // without consulting the EL.
+            self.cache_system_config(epoch.hash, sys_config);
             l1_header = header;
             deposit_transactions = deposits;
             0
         } else if l2_parent.l1_origin.hash != epoch.hash {
+            // A reset means the carried-forward configs may not match the chain the pipeline
+            // resets to; drop them so the EL is re-read after the reset.
+            self.system_configs.clear();
             return Err(PipelineErrorKind::Reset(
                 BuilderError::BlockMismatch(epoch, l2_parent.l1_origin).into(),
             ));
@@ -127,12 +181,24 @@ where
             l2_parent.seq_num + 1
         };
 
+        // A fork may change which SystemConfig fields can be decoded from an L2 block. Drop the
+        // carried value at every configured fork boundary so the next build decodes the new
+        // format from the EL. Iterating the canonical upgrade list automatically covers future
+        // forks; the extra read happens only once per fork.
+        if BaseUpgrade::VARIANTS.iter().any(|&upgrade| {
+            self.rollup_cfg.upgrade_activation_timestamp(upgrade).is_some_and(|activation| {
+                l2_parent.block_info.timestamp < activation && activation <= next_l2_time
+            })
+        }) {
+            self.system_configs.clear();
+        }
+
         // Sanity check the L1 origin was correctly selected to maintain the time invariant
         // between L1 and L2.
-        let next_l2_block_number = l2_parent.block_info.number + 1;
-        let (next_l2_time, next_l2_timestamp_millis_part) =
-            self.rollup_cfg.l2_block_timestamp_parts(next_l2_block_number);
         if next_l2_time < l1_header.timestamp {
+            // A reset means the carried-forward configs may not match the chain the pipeline
+            // resets to; drop them so the EL is re-read after the reset.
+            self.system_configs.clear();
             return Err(PipelineErrorKind::Reset(
                 BuilderError::BrokenTimeInvariant(
                     l2_parent.l1_origin,
@@ -281,7 +347,7 @@ mod tests {
 
     use alloy_consensus::Header;
     use alloy_eips::eip2718::Decodable2718;
-    use alloy_primitives::{B256, Log, LogData, U64, U256, address};
+    use alloy_primitives::{B64, B256, Log, LogData, U64, U256, address};
     use base_common_chains::Sepolia;
     use base_common_consensus::{BaseTxEnvelope, SystemAddresses};
     use base_common_genesis::{
@@ -879,5 +945,243 @@ mod tests {
 
         // Should succeed despite the malformed system config receipt.
         assert!(builder.prepare_payload_attributes(l2_parent, epoch).await.is_ok());
+    }
+
+    /// Builds a rollup config with the requested block time and no scheduled upgrades.
+    fn cache_test_cfg(block_time: u64, timestamp: u64) -> Arc<RollupConfig> {
+        Arc::new(RollupConfig {
+            block_time,
+            genesis: ChainGenesis {
+                l2_time: timestamp.saturating_sub(block_time),
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+    }
+
+    /// Sets up an L2 parent at block 1 with L1 origin block 1, and the next epoch's origin
+    /// block 2 whose parent hash links back to it. Returns the builder, the epoch block's
+    /// [`BlockNumHash`], and the first L2 parent.
+    fn transition_setup() -> (
+        StatefulAttributesBuilder<TestChainProvider, TestSystemConfigL2Fetcher>,
+        BlockNumHash,
+        L2BlockInfo,
+    ) {
+        let block_time = 2_u64;
+        let timestamp = 100_u64;
+        let cfg = cache_test_cfg(block_time, timestamp);
+        let l1_cfg = Arc::new(Sepolia::l1_config());
+        let mut fetcher = TestSystemConfigL2Fetcher::default();
+        fetcher.insert(1, SystemConfig::default());
+        let mut provider = TestChainProvider::default();
+        let parent_header = Header { number: 1, timestamp, ..Default::default() };
+        let parent_hash = parent_header.hash_slow();
+        let epoch_header = Header { number: 2, timestamp, parent_hash, ..Default::default() };
+        let epoch_hash = epoch_header.hash_slow();
+        provider.insert_header(parent_hash, parent_header);
+        provider.insert_header(epoch_hash, epoch_header);
+        provider.insert_receipts(epoch_hash, vec![]);
+        let builder = StatefulAttributesBuilder::new(cfg, l1_cfg, fetcher, provider);
+        let l2_parent = L2BlockInfo {
+            block_info: BlockInfo { hash: B256::ZERO, number: 1, timestamp, parent_hash },
+            l1_origin: BlockNumHash { hash: parent_hash, number: 1 },
+            seq_num: 0,
+        };
+        (builder, BlockNumHash { hash: epoch_hash, number: 2 }, l2_parent)
+    }
+
+    /// Advances to the next L2 parent within the same L1 origin.
+    fn next_l2_parent(prev: &L2BlockInfo, cfg: &RollupConfig, epoch: BlockNumHash) -> L2BlockInfo {
+        let number = prev.block_info.number + 1;
+        L2BlockInfo {
+            block_info: BlockInfo {
+                hash: B256::ZERO,
+                number,
+                timestamp: cfg.l2_block_timestamp(number),
+                parent_hash: prev.block_info.hash,
+            },
+            l1_origin: epoch,
+            seq_num: prev.seq_num + 1,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_system_config_carried_forward_within_epoch() {
+        let (mut builder, epoch, l2_parent) = transition_setup();
+
+        // Epoch transition: reads the EL once for the parent origin's config.
+        builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
+        assert_eq!(builder.config_fetcher.system_config_calls, vec![1]);
+
+        // Same-epoch blocks reuse the carried-forward config even when the EL can no longer
+        // serve it.
+        builder.config_fetcher.clear();
+        let cfg = Arc::clone(&builder.rollup_cfg);
+        let l2_parent = next_l2_parent(&l2_parent, &cfg, epoch);
+        builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
+        let l2_parent = next_l2_parent(&l2_parent, &cfg, epoch);
+        builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
+        assert_eq!(builder.config_fetcher.system_config_calls, vec![1]);
+    }
+
+    #[tokio::test]
+    async fn test_system_config_cache_ignores_stale_el_value() {
+        let (mut builder, epoch, l2_parent) = transition_setup();
+
+        builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
+        let cached_gas_limit = SystemConfig::default().gas_limit;
+
+        // The EL now reports a different config for the next block; the carried-forward config
+        // must win because it already includes the new epoch's updates.
+        let stale = SystemConfig { gas_limit: cached_gas_limit + 1, ..Default::default() };
+        builder.config_fetcher.insert(2, stale);
+
+        let cfg = Arc::clone(&builder.rollup_cfg);
+        let l2_parent = next_l2_parent(&l2_parent, &cfg, epoch);
+        let payload = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
+        assert_eq!(
+            payload.gas_limit,
+            Some(u64::from_be_bytes(alloy_primitives::U64::from(cached_gas_limit).to_be_bytes()))
+        );
+        assert_eq!(builder.config_fetcher.system_config_calls, vec![1]);
+    }
+
+    #[tokio::test]
+    async fn test_unknown_l1_origin_falls_back_to_el() {
+        let (mut builder, epoch, l2_parent) = transition_setup();
+        builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
+        assert_eq!(builder.config_fetcher.system_config_calls, vec![1]);
+
+        // A reorged L1 origin (same number, unknown hash) is not in the cache: the config is
+        // read from the EL.
+        let reorged_header = Header { number: 2, timestamp: 100, ..Default::default() };
+        let reorged_hash = reorged_header.hash_slow();
+        builder.receipts_fetcher.insert_header(reorged_hash, reorged_header);
+        builder.config_fetcher.insert(2, SystemConfig::default());
+
+        let cfg = Arc::clone(&builder.rollup_cfg);
+        let mut l2_parent =
+            next_l2_parent(&l2_parent, &cfg, BlockNumHash { hash: reorged_hash, number: 2 });
+        l2_parent.l1_origin = BlockNumHash { hash: reorged_hash, number: 2 };
+        let epoch = BlockNumHash { hash: reorged_hash, number: 2 };
+        builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
+        assert_eq!(builder.config_fetcher.system_config_calls, vec![1, 2]);
+    }
+
+    #[test]
+    fn test_system_config_cache_evicts_least_recently_used() {
+        let mut builder = StatefulAttributesBuilder::new(
+            Arc::new(RollupConfig::default()),
+            Arc::new(Sepolia::l1_config()),
+            TestSystemConfigL2Fetcher::default(),
+            TestChainProvider::default(),
+        );
+        let origins: Vec<B256> = (0..10).map(|i| B256::from([i as u8; 32])).collect();
+        for &origin in &origins {
+            builder.cache_system_config(origin, SystemConfig::default());
+        }
+        assert_eq!(builder.system_configs.len(), MAX_SYSTEM_CONFIG_CACHE_ENTRIES);
+        assert!(builder.cached_system_config(&origins[0]).is_none());
+        assert!(builder.cached_system_config(&origins[9]).is_some());
+
+        // A hit promotes the entry, evicting the next-oldest on the following insert.
+        assert!(builder.cached_system_config(&origins[2]).is_some());
+        builder.cache_system_config(B256::from([10_u8; 32]), SystemConfig::default());
+        assert!(builder.cached_system_config(&origins[2]).is_some());
+        assert!(builder.cached_system_config(&origins[3]).is_none());
+    }
+
+    /// Crossing a fork that changes the system config encoding (here Holocene, which moves the
+    /// EIP-1559 parameters into the header's `extra_data`) must force one EL re-read: the
+    /// pre-fork cached config has no EIP-1559 parameters, and carrying it forward would emit
+    /// zeroed params where the EL decodes the persisted values from the parent block.
+    #[tokio::test]
+    async fn test_fork_boundary_forces_el_reseed() {
+        let block_time = 2_u64;
+        // Blocks: 1 -> ts 100 (pre-Holocene), 2 -> ts 102 (first Holocene), 3 -> ts 104.
+        let cfg = Arc::new(RollupConfig {
+            block_time,
+            genesis: ChainGenesis { l2_time: 98, ..Default::default() },
+            upgrades: UpgradeConfig { holocene_time: Some(102), ..Default::default() },
+            ..Default::default()
+        });
+        let l1_cfg = Arc::new(Sepolia::l1_config());
+        let mut fetcher = TestSystemConfigL2Fetcher::default();
+        fetcher.insert(1, SystemConfig::default());
+        let mut provider = TestChainProvider::default();
+        let origin_header = Header { number: 1, timestamp: 100, ..Default::default() };
+        let origin_hash = origin_header.hash_slow();
+        provider.insert_header(origin_hash, origin_header);
+        let mut builder =
+            StatefulAttributesBuilder::new(Arc::clone(&cfg), l1_cfg, fetcher, provider);
+        let epoch = BlockNumHash { hash: origin_hash, number: 1 };
+
+        // Build block 2 (the Holocene transition block) on the pre-fork parent: seeds the
+        // cache from the EL and emits the zeroed transition sentinel.
+        let l2_parent = L2BlockInfo {
+            block_info: BlockInfo {
+                hash: B256::ZERO,
+                number: 1,
+                timestamp: 100,
+                ..Default::default()
+            },
+            l1_origin: epoch,
+            seq_num: 0,
+        };
+        let payload = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
+        assert_eq!(payload.eip_1559_params, Some(B64::ZERO));
+        assert_eq!(builder.config_fetcher.system_config_calls, vec![1]);
+
+        // The EL's view of block 2 decodes the persisted EIP-1559 parameters from its
+        // `extra_data`; the pre-fork cached config has neither.
+        let post_fork = SystemConfig {
+            eip1559_denominator: Some(250),
+            eip1559_elasticity: Some(6),
+            ..Default::default()
+        };
+        builder.config_fetcher.insert(2, post_fork);
+
+        // Build block 3 on the post-fork parent: the transition cleared the cache, so the EL is
+        // re-read, yielding the persisted parameters instead of zeros.
+        let l2_parent = next_l2_parent(&l2_parent, &cfg, epoch);
+        let payload = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
+        assert_eq!(
+            payload.eip_1559_params,
+            Some(B64::from_slice(&[250_u32.to_be_bytes(), 6_u32.to_be_bytes()].concat()))
+        );
+        assert_eq!(builder.config_fetcher.system_config_calls, vec![1, 2]);
+
+        // Build block 4 without another fork, served from the re-seeded cache.
+        let l2_parent = next_l2_parent(&l2_parent, &cfg, epoch);
+        builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
+        assert_eq!(builder.config_fetcher.system_config_calls, vec![1, 2]);
+    }
+
+    /// A Reset-class error (here a broken time invariant) must clear the carried-forward
+    /// configs: after the pipeline resets, the chain may differ, so the EL is re-read.
+    #[tokio::test]
+    async fn test_reset_error_clears_config_cache() {
+        let (mut builder, _epoch, l2_parent) = transition_setup();
+        let origin = l2_parent.l1_origin;
+
+        // Same-epoch build seeds the cache.
+        builder.prepare_payload_attributes(l2_parent, origin).await.unwrap();
+        assert_eq!(builder.config_fetcher.system_config_calls, vec![1]);
+
+        // An epoch transition to an origin whose timestamp breaks the time invariant returns a
+        // Reset error and clears the cache.
+        let bad_header =
+            Header { number: 2, timestamp: 1_000, parent_hash: origin.hash, ..Default::default() };
+        let bad_hash = bad_header.hash_slow();
+        builder.receipts_fetcher.insert_header(bad_hash, bad_header);
+        builder.receipts_fetcher.insert_receipts(bad_hash, vec![]);
+        let bad_epoch = BlockNumHash { hash: bad_hash, number: 2 };
+        let err = builder.prepare_payload_attributes(l2_parent, bad_epoch).await.unwrap_err();
+        assert!(matches!(err, PipelineErrorKind::Reset(_)));
+        assert!(builder.system_configs.is_empty());
+
+        // The next build re-reads the EL instead of trusting a pre-reset config.
+        builder.prepare_payload_attributes(l2_parent, origin).await.unwrap();
+        assert_eq!(builder.config_fetcher.system_config_calls, vec![1, 1]);
     }
 }

--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -1,11 +1,11 @@
 //! The [`AttributesBuilder`] and it's default implementation.
 
-use alloc::{boxed::Box, fmt::Debug, string::ToString, sync::Arc, vec, vec::Vec};
+use alloc::{boxed::Box, fmt::Debug, format, string::ToString, sync::Arc, vec, vec::Vec};
 
 use alloy_consensus::{Eip658Value, Receipt};
 use alloy_eips::{BlockNumHash, eip2718::Encodable2718};
 use alloy_genesis::ChainConfig;
-use alloy_primitives::{Address, B256, Bytes};
+use alloy_primitives::{Address, B256, Bytes, Sealed};
 use alloy_rlp::Encodable;
 use alloy_rpc_types_engine::PayloadAttributes;
 use async_trait::async_trait;
@@ -73,7 +73,7 @@ where
         &mut self,
         l2_parent: L2BlockInfo,
         epoch: BlockNumHash,
-        parent_block: Option<&BaseBlock>,
+        parent_block: Option<&Sealed<BaseBlock>>,
     ) -> PipelineResult<BasePayloadAttributes> {
         let l1_header;
         let deposit_transactions: Vec<Bytes>;
@@ -86,8 +86,8 @@ where
         // Hash must match so a stashed block from before a reorg cannot be used. Decode
         // failure falls through to the EL.
         let mut sys_config = match parent_block
-            .filter(|block| block.header.hash_slow() == l2_parent.block_info.hash)
-            .and_then(|block| match to_system_config(block, &self.rollup_cfg) {
+            .filter(|block| block.hash() == l2_parent.block_info.hash)
+            .and_then(|block| match to_system_config(block.inner(), &self.rollup_cfg) {
                 Ok(config) => Some(config),
                 Err(err) => {
                     warn!(
@@ -121,7 +121,11 @@ where
                 }
                 to_system_config(&block, &self.rollup_cfg).map_err(|err| {
                     warn!(target: "attributes", error = ?err, number = block.header.number, "Failed to decode system config from parent block");
-                    PipelineError::Provider("system config conversion failed".to_string()).temp()
+                    PipelineError::Provider(format!(
+                        "system config conversion failed for block {}",
+                        block.header.number
+                    ))
+                    .temp()
                 })?
             }
         };
@@ -994,6 +998,12 @@ mod tests {
         }
     }
 
+    /// Memoizes a block's header hash for parent-payload tests.
+    fn sealed_block(block: BaseBlock) -> Sealed<BaseBlock> {
+        let hash = block.header.hash_slow();
+        Sealed::new_unchecked(block, hash)
+    }
+
     /// Installs a decodable block built from `header` into the fetcher and returns its hash:
     /// the EL fallback verifies the fetched block's hash against the parent hash, so tests
     /// exercising it need the parent hash to be a real block hash.
@@ -1007,8 +1017,12 @@ mod tests {
     #[tokio::test]
     async fn test_parent_block_skips_el_read() {
         let (mut builder, epoch, mut l2_parent) = transition_setup();
-        let parent = seedable_block(Header { number: 1, timestamp: 100, ..Default::default() });
-        l2_parent.block_info.hash = parent.header.hash_slow();
+        let parent = sealed_block(seedable_block(Header {
+            number: 1,
+            timestamp: 100,
+            ..Default::default()
+        }));
+        l2_parent.block_info.hash = parent.hash();
         builder.config_fetcher.clear();
         builder.prepare_payload_attributes(l2_parent, epoch, Some(&parent)).await.unwrap();
         assert!(builder.config_fetcher.block_calls.is_empty());
@@ -1024,7 +1038,7 @@ mod tests {
     #[tokio::test]
     async fn test_parent_block_hash_mismatch_falls_back_to_el() {
         let (mut builder, epoch, l2_parent) = transition_setup();
-        let other = seedable_block(Header { number: 99, ..Default::default() });
+        let other = sealed_block(seedable_block(Header { number: 99, ..Default::default() }));
         builder.prepare_payload_attributes(l2_parent, epoch, Some(&other)).await.unwrap();
         assert_eq!(builder.config_fetcher.block_calls, vec![1]);
     }
@@ -1049,13 +1063,13 @@ mod tests {
     #[tokio::test]
     async fn test_parent_block_wins_over_el_value() {
         let (mut builder, epoch, mut l2_parent) = transition_setup();
-        let parent = seedable_block(Header {
+        let parent = sealed_block(seedable_block(Header {
             number: 1,
             timestamp: 100,
             gas_limit: 40_000_000,
             ..Default::default()
-        });
-        l2_parent.block_info.hash = parent.header.hash_slow();
+        }));
+        l2_parent.block_info.hash = parent.hash();
         let payload =
             builder.prepare_payload_attributes(l2_parent, epoch, Some(&parent)).await.unwrap();
         assert_eq!(payload.gas_limit, Some(40_000_000));
@@ -1066,11 +1080,11 @@ mod tests {
     async fn test_undecodable_parent_block_falls_back_to_el() {
         let (mut builder, epoch, l2_parent) = transition_setup();
         // Same header hash as the parent, but no L1 info tx, so `to_system_config` fails.
-        let undecodable = BaseBlock {
+        let undecodable = sealed_block(BaseBlock {
             header: Header { number: 1, timestamp: 100, ..Default::default() },
             body: BlockBody::default(),
-        };
-        assert_eq!(undecodable.header.hash_slow(), l2_parent.block_info.hash);
+        });
+        assert_eq!(undecodable.hash(), l2_parent.block_info.hash);
         builder.prepare_payload_attributes(l2_parent, epoch, Some(&undecodable)).await.unwrap();
         assert_eq!(builder.config_fetcher.block_calls, vec![1]);
     }
@@ -1104,18 +1118,18 @@ mod tests {
 
         // The sequencer inserted block 2 (the first Holocene block), whose `extra_data`
         // persists denominator 250 and elasticity 6.
-        let inserted = seedable_block(Header {
+        let inserted = sealed_block(seedable_block(Header {
             number: 2,
             timestamp: 102,
             extra_data: bytes!("00000000fa00000006"),
             ..Default::default()
-        });
+        }));
 
         // Build block 3 on the post-fork parent payload: the persisted parameters come from
         // the payload and the EL is never consulted.
         let l2_parent = L2BlockInfo {
             block_info: BlockInfo {
-                hash: inserted.header.hash_slow(),
+                hash: inserted.hash(),
                 number: 2,
                 timestamp: 102,
                 parent_hash: B256::ZERO,

--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -1,8 +1,6 @@
 //! The [`AttributesBuilder`] and it's default implementation.
 
-use alloc::{
-    boxed::Box, collections::VecDeque, fmt::Debug, string::ToString, sync::Arc, vec, vec::Vec,
-};
+use alloc::{boxed::Box, fmt::Debug, string::ToString, sync::Arc, vec, vec::Vec};
 
 use alloy_consensus::{Eip658Value, Receipt};
 use alloy_eips::{BlockNumHash, eip2718::Encodable2718};
@@ -12,7 +10,7 @@ use alloy_rlp::Encodable;
 use alloy_rpc_types_engine::PayloadAttributes;
 use async_trait::async_trait;
 use base_common_consensus::{BaseBlock, Predeploys};
-use base_common_genesis::{RollupConfig, SystemConfig};
+use base_common_genesis::RollupConfig;
 use base_common_rpc_types_engine::BasePayloadAttributes;
 use base_consensus_upgrades::{Upgrade, Upgrades};
 use base_protocol::{
@@ -25,9 +23,6 @@ use crate::{
     AttributesBuilder, BuilderError, ChainProvider, L2ChainProvider, PipelineEncodingError,
     PipelineError, PipelineErrorKind, PipelineResult,
 };
-
-/// The maximum number of [`SystemConfig`]s cached by L2 block hash.
-const MAX_SYSTEM_CONFIG_CACHE_ENTRIES: usize = 8;
 
 /// A stateful implementation of the [`AttributesBuilder`].
 #[derive(Debug, Default)]
@@ -44,10 +39,6 @@ where
     config_fetcher: L2P,
     /// The L1 receipts fetcher.
     receipts_fetcher: L1P,
-    /// Cache of [`SystemConfig`]s keyed by the L2 block hash they were decoded from, most
-    /// recently used first. An entry is a pure function of its block, so it can never go stale:
-    /// forks, resets, and reorgs need no invalidation.
-    system_configs: VecDeque<(B256, SystemConfig)>,
 }
 
 impl<L1P, L2P> StatefulAttributesBuilder<L1P, L2P>
@@ -67,28 +58,7 @@ where
             l1_cfg,
             config_fetcher: sys_cfg_fetcher,
             receipts_fetcher: receipts,
-            system_configs: VecDeque::new(),
         }
-    }
-
-    /// Returns the cached [`SystemConfig`] for the given L2 block hash, promoting it to most
-    /// recently used.
-    fn cached_system_config(&mut self, block_hash: &B256) -> Option<SystemConfig> {
-        let index = self.system_configs.iter().position(|(hash, _)| hash == block_hash)?;
-        let entry = self.system_configs.remove(index)?;
-        let config = entry.1;
-        self.system_configs.push_front(entry);
-        Some(config)
-    }
-
-    /// Caches the [`SystemConfig`] for the given L2 block hash, evicting the least recently used
-    /// entries beyond [`MAX_SYSTEM_CONFIG_CACHE_ENTRIES`].
-    fn cache_system_config(&mut self, block_hash: B256, config: SystemConfig) {
-        if let Some(index) = self.system_configs.iter().position(|(hash, _)| hash == &block_hash) {
-            self.system_configs.remove(index);
-        }
-        self.system_configs.push_front((block_hash, config));
-        self.system_configs.truncate(MAX_SYSTEM_CONFIG_CACHE_ENTRIES);
     }
 }
 
@@ -103,6 +73,7 @@ where
         &mut self,
         l2_parent: L2BlockInfo,
         epoch: BlockNumHash,
+        parent_block: Option<&BaseBlock>,
     ) -> PipelineResult<BasePayloadAttributes> {
         let l1_header;
         let deposit_transactions: Vec<Bytes>;
@@ -111,12 +82,23 @@ where
         let (next_l2_time, next_l2_timestamp_millis_part) =
             self.rollup_cfg.l2_block_timestamp_parts(next_l2_block_number);
 
-        // The parent block's system config: decoded from the parent itself, either seeded in
-        // memory when the parent was inserted (see [`AttributesBuilder::seed_system_config`]) or
-        // read from the L2 EL on a miss (startup, reset, reorg, or a parent built elsewhere).
-        // The fetched block's hash is verified against the parent hash so that a read racing a
-        // reorg can never cache another block's config under this parent.
-        let mut sys_config = match self.cached_system_config(&l2_parent.block_info.hash) {
+        // Prefer the parent payload the caller already has (the sequencer just built it).
+        // Hash must match so a stashed block from before a reorg cannot be used. Decode
+        // failure falls through to the EL.
+        let mut sys_config = match parent_block
+            .filter(|block| block.header.hash_slow() == l2_parent.block_info.hash)
+            .and_then(|block| match to_system_config(block, &self.rollup_cfg) {
+                Ok(config) => Some(config),
+                Err(err) => {
+                    warn!(
+                        target: "attributes",
+                        error = ?err,
+                        number = block.header.number,
+                        "Failed to decode system config from parent payload"
+                    );
+                    None
+                }
+            }) {
             Some(config) => config,
             None => {
                 let block = self
@@ -137,12 +119,10 @@ where
                         .into(),
                     ));
                 }
-                let config = to_system_config(&block, &self.rollup_cfg).map_err(|err| {
+                to_system_config(&block, &self.rollup_cfg).map_err(|err| {
                     warn!(target: "attributes", error = ?err, number = block.header.number, "Failed to decode system config from parent block");
                     PipelineError::Provider("system config conversion failed".to_string()).temp()
-                })?;
-                self.cache_system_config(l2_parent.block_info.hash, config);
-                config
+                })?
             }
         };
 
@@ -305,17 +285,6 @@ where
                                                                         * set at Jovian */
         })
     }
-
-    fn seed_system_config(&mut self, block: &BaseBlock) {
-        match to_system_config(block, &self.rollup_cfg) {
-            Ok(config) => self.cache_system_config(block.header.hash_slow(), config),
-            // A block that cannot be decoded is simply not seeded: the next build on it falls
-            // back to the EL read.
-            Err(err) => {
-                warn!(target: "attributes", error = ?err, number = block.header.number, "Failed to decode system config from inserted block");
-            }
-        }
-    }
 }
 
 /// Derive deposits as `Vec<Bytes>` for transaction receipts.
@@ -362,9 +331,7 @@ mod tests {
     use base_common_genesis::{
         BaseUpgradeConfig, ChainGenesis, SystemConfig, SystemConfigUpdate, UpgradeConfig,
     };
-    use base_protocol::{
-        BlockInfo, DepositDecodeError, test_utils::RAW_BEDROCK_INFO_TX,
-    };
+    use base_protocol::{BlockInfo, DepositDecodeError, test_utils::RAW_BEDROCK_INFO_TX};
 
     use super::*;
     use crate::{
@@ -494,7 +461,7 @@ mod tests {
         // hash. Here we use the default header whose hash will not equal the custom `l2_hash`.
         let expected =
             BuilderError::BlockMismatchEpochReset(epoch, l2_parent.l1_origin, B256::default());
-        let err = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap_err();
+        let err = builder.prepare_payload_attributes(l2_parent, epoch, None).await.unwrap_err();
         assert_eq!(err, PipelineErrorKind::Reset(expected.into()));
     }
 
@@ -521,7 +488,7 @@ mod tests {
         // This should error because the l2 parent's l1_origin.hash should equal the epoch hash
         // Here the default header is used whose hash will not equal the custom `l2_hash` above.
         let expected = BuilderError::BlockMismatch(epoch, l2_parent.l1_origin);
-        let err = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap_err();
+        let err = builder.prepare_payload_attributes(l2_parent, epoch, None).await.unwrap_err();
         assert_eq!(err, PipelineErrorKind::Reset(ResetError::AttributesBuilder(expected)));
     }
 
@@ -555,7 +522,7 @@ mod tests {
             block_id,
             timestamp,
         );
-        let err = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap_err();
+        let err = builder.prepare_payload_attributes(l2_parent, epoch, None).await.unwrap_err();
         assert_eq!(err, PipelineErrorKind::Reset(ResetError::AttributesBuilder(expected)));
     }
 
@@ -595,7 +562,7 @@ mod tests {
             seq_num: 0,
         };
         let next_l2_time = cfg.l2_block_timestamp(l2_parent.block_info.number + 1);
-        let payload = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
+        let payload = builder.prepare_payload_attributes(l2_parent, epoch, None).await.unwrap();
         let expected = BasePayloadAttributes {
             payload_attributes: PayloadAttributes {
                 timestamp: next_l2_time,
@@ -662,7 +629,7 @@ mod tests {
 
         let next_l2_block_number = l2_parent.block_info.number + 1;
         let (_, expected_millis_part) = cfg.l2_block_timestamp_parts(next_l2_block_number);
-        let payload = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
+        let payload = builder.prepare_payload_attributes(l2_parent, epoch, None).await.unwrap();
         assert_eq!(
             payload.payload_attributes.timestamp,
             cfg.l2_block_timestamp(next_l2_block_number)
@@ -726,7 +693,7 @@ mod tests {
             cfg.l2_block_timestamp_parts(next_l2_block_number);
         assert_eq!(expected_millis_part, 200);
 
-        let payload = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
+        let payload = builder.prepare_payload_attributes(l2_parent, epoch, None).await.unwrap();
         assert_eq!(payload.payload_attributes.timestamp, expected_timestamp);
         let transactions = payload.transactions.unwrap();
         assert_eq!(transactions.len(), 2);
@@ -775,7 +742,7 @@ mod tests {
             seq_num: 0,
         };
         let next_l2_time = cfg.l2_block_timestamp(l2_parent.block_info.number + 1);
-        let payload = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
+        let payload = builder.prepare_payload_attributes(l2_parent, epoch, None).await.unwrap();
         let expected = BasePayloadAttributes {
             payload_attributes: PayloadAttributes {
                 timestamp: next_l2_time,
@@ -836,7 +803,7 @@ mod tests {
             seq_num: 0,
         };
         let next_l2_time = cfg.l2_block_timestamp(l2_parent.block_info.number + 1);
-        let payload = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
+        let payload = builder.prepare_payload_attributes(l2_parent, epoch, None).await.unwrap();
         let expected = BasePayloadAttributes {
             payload_attributes: PayloadAttributes {
                 timestamp: next_l2_time,
@@ -896,7 +863,7 @@ mod tests {
             seq_num: 0,
         };
         let next_l2_time = cfg.l2_block_timestamp(l2_parent.block_info.number + 1);
-        let payload = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
+        let payload = builder.prepare_payload_attributes(l2_parent, epoch, None).await.unwrap();
         let expected = BasePayloadAttributes {
             payload_attributes: PayloadAttributes {
                 timestamp: next_l2_time,
@@ -965,7 +932,7 @@ mod tests {
         };
 
         // Should succeed despite the malformed system config receipt.
-        assert!(builder.prepare_payload_attributes(l2_parent, epoch).await.is_ok());
+        assert!(builder.prepare_payload_attributes(l2_parent, epoch, None).await.is_ok());
     }
 
     /// Builds a rollup config with the requested block time and no scheduled upgrades.
@@ -1038,69 +1005,38 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_seeded_parent_config_skips_el_read() {
-        let (mut builder, epoch, l2_parent) = transition_setup();
-
-        // The parent's config was seeded when it was inserted; the EL can no longer serve any
-        // config, so a cache miss would fail the build.
-        builder.cache_system_config(l2_parent.block_info.hash, SystemConfig::default());
+    async fn test_parent_block_skips_el_read() {
+        let (mut builder, epoch, mut l2_parent) = transition_setup();
+        let parent = seedable_block(Header { number: 1, timestamp: 100, ..Default::default() });
+        l2_parent.block_info.hash = parent.header.hash_slow();
         builder.config_fetcher.clear();
-        builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
+        builder.prepare_payload_attributes(l2_parent, epoch, Some(&parent)).await.unwrap();
         assert!(builder.config_fetcher.block_calls.is_empty());
     }
 
     #[tokio::test]
-    async fn test_unknown_parent_falls_back_to_el_and_caches() {
+    async fn test_missing_parent_block_falls_back_to_el() {
         let (mut builder, epoch, l2_parent) = transition_setup();
-
-        // An unseeded parent (startup, reset, or a block built elsewhere) is read from the EL.
-        builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
-        assert_eq!(builder.config_fetcher.block_calls, vec![1]);
-
-        // A rebuild on the same parent is served from the cache even when the EL can no longer
-        // serve it.
-        builder.config_fetcher.clear();
-        builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
+        builder.prepare_payload_attributes(l2_parent, epoch, None).await.unwrap();
         assert_eq!(builder.config_fetcher.block_calls, vec![1]);
     }
 
     #[tokio::test]
-    async fn test_same_origin_different_parent_misses_cache() {
+    async fn test_parent_block_hash_mismatch_falls_back_to_el() {
         let (mut builder, epoch, l2_parent) = transition_setup();
-        builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
+        let other = seedable_block(Header { number: 99, ..Default::default() });
+        builder.prepare_payload_attributes(l2_parent, epoch, Some(&other)).await.unwrap();
         assert_eq!(builder.config_fetcher.block_calls, vec![1]);
-
-        // The next parent shares the L1 origin but is a different L2 block: entries are keyed
-        // by block hash, so without a seed its config is read from the EL rather than reusing
-        // the previous parent's entry.
-        let cfg = Arc::clone(&builder.rollup_cfg);
-        let timestamp = cfg.l2_block_timestamp(2);
-        let hash = fallback_parent(
-            &mut builder.config_fetcher,
-            Header { number: 2, timestamp, ..Default::default() },
-        );
-        let l2_parent = L2BlockInfo {
-            block_info: BlockInfo {
-                hash,
-                number: 2,
-                timestamp,
-                parent_hash: l2_parent.block_info.hash,
-            },
-            l1_origin: epoch,
-            seq_num: 1,
-        };
-        builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
-        assert_eq!(builder.config_fetcher.block_calls, vec![1, 2]);
     }
 
     /// A fallback read that returns a different block than the parent being built on (e.g. the
-    /// EL reorged between the parent being chosen and the read) must reset instead of caching
-    /// another block's config under the parent hash.
+    /// EL reorged between the parent being chosen and the read) must reset instead of using
+    /// another block's config.
     #[tokio::test]
     async fn test_fallback_block_hash_mismatch_resets() {
         let (mut builder, epoch, mut l2_parent) = transition_setup();
         l2_parent.block_info.hash = B256::left_padding_from(&[0xAA]);
-        let err = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap_err();
+        let err = builder.prepare_payload_attributes(l2_parent, epoch, None).await.unwrap_err();
         assert!(matches!(
             err,
             PipelineErrorKind::Reset(ResetError::AttributesBuilder(BuilderError::BlockMismatch(
@@ -1108,92 +1044,43 @@ mod tests {
                 _
             )))
         ));
-        // Nothing was cached under the mismatched parent hash.
-        assert!(builder.cached_system_config(&l2_parent.block_info.hash).is_none());
     }
 
     #[tokio::test]
-    async fn test_seeded_config_wins_over_el_value() {
-        let (mut builder, epoch, l2_parent) = transition_setup();
-
-        // The seeded entry differs from what the EL reports for the same block number (e.g.
-        // after an L1 reorg changed the canonical block at that height): the exact-hash seed
-        // must win.
-        let seeded_gas_limit = SystemConfig::default().gas_limit + 1;
-        builder.cache_system_config(
-            l2_parent.block_info.hash,
-            SystemConfig { gas_limit: seeded_gas_limit, ..Default::default() },
-        );
-        let payload = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
-        assert_eq!(
-            payload.gas_limit,
-            Some(u64::from_be_bytes(alloy_primitives::U64::from(seeded_gas_limit).to_be_bytes()))
-        );
+    async fn test_parent_block_wins_over_el_value() {
+        let (mut builder, epoch, mut l2_parent) = transition_setup();
+        let parent = seedable_block(Header {
+            number: 1,
+            timestamp: 100,
+            gas_limit: 40_000_000,
+            ..Default::default()
+        });
+        l2_parent.block_info.hash = parent.header.hash_slow();
+        let payload =
+            builder.prepare_payload_attributes(l2_parent, epoch, Some(&parent)).await.unwrap();
+        assert_eq!(payload.gas_limit, Some(40_000_000));
         assert!(builder.config_fetcher.block_calls.is_empty());
     }
 
-    #[test]
-    fn test_system_config_cache_evicts_least_recently_used() {
-        let mut builder = StatefulAttributesBuilder::new(
-            Arc::new(RollupConfig::default()),
-            Arc::new(Sepolia::l1_config()),
-            TestSystemConfigL2Fetcher::default(),
-            TestChainProvider::default(),
-        );
-        let hashes: Vec<B256> = (0..10).map(|i| B256::from([i as u8; 32])).collect();
-        for &hash in &hashes {
-            builder.cache_system_config(hash, SystemConfig::default());
-        }
-        assert_eq!(builder.system_configs.len(), MAX_SYSTEM_CONFIG_CACHE_ENTRIES);
-        assert!(builder.cached_system_config(&hashes[0]).is_none());
-        assert!(builder.cached_system_config(&hashes[9]).is_some());
-
-        // A hit promotes the entry, evicting the next-oldest on the following insert.
-        assert!(builder.cached_system_config(&hashes[2]).is_some());
-        builder.cache_system_config(B256::from([10_u8; 32]), SystemConfig::default());
-        assert!(builder.cached_system_config(&hashes[2]).is_some());
-        assert!(builder.cached_system_config(&hashes[3]).is_none());
-    }
-
-    #[test]
-    fn test_seed_system_config_caches_inserted_block() {
-        let mut builder = StatefulAttributesBuilder::new(
-            Arc::new(RollupConfig::default()),
-            Arc::new(Sepolia::l1_config()),
-            TestSystemConfigL2Fetcher::default(),
-            TestChainProvider::default(),
-        );
-        let block =
-            seedable_block(Header { number: 5, gas_limit: 40_000_000, ..Default::default() });
-        builder.seed_system_config(&block);
-        let expected = to_system_config(&block, &builder.rollup_cfg).unwrap();
-        assert_eq!(builder.cached_system_config(&block.header.hash_slow()), Some(expected));
-    }
-
-    #[test]
-    fn test_seed_system_config_undecodable_block_is_skipped() {
-        let mut builder = StatefulAttributesBuilder::new(
-            Arc::new(RollupConfig::default()),
-            Arc::new(Sepolia::l1_config()),
-            TestSystemConfigL2Fetcher::default(),
-            TestChainProvider::default(),
-        );
-        // No transactions: `to_system_config` fails, so nothing is cached and the next build on
-        // this block takes the EL fallback.
-        let block = BaseBlock {
-            header: Header { number: 5, ..Default::default() },
+    #[tokio::test]
+    async fn test_undecodable_parent_block_falls_back_to_el() {
+        let (mut builder, epoch, l2_parent) = transition_setup();
+        // Same header hash as the parent, but no L1 info tx, so `to_system_config` fails.
+        let undecodable = BaseBlock {
+            header: Header { number: 1, timestamp: 100, ..Default::default() },
             body: BlockBody::default(),
         };
-        builder.seed_system_config(&block);
-        assert!(builder.system_configs.is_empty());
+        assert_eq!(undecodable.header.hash_slow(), l2_parent.block_info.hash);
+        builder.prepare_payload_attributes(l2_parent, epoch, Some(&undecodable)).await.unwrap();
+        assert_eq!(builder.config_fetcher.block_calls, vec![1]);
     }
 
     /// Crossing a fork that changes the system config encoding (here Holocene, which moves the
     /// EIP-1559 parameters into the header's `extra_data`) needs no EL read: the first
-    /// post-fork block is seeded from its own payload after insertion, so the next build
-    /// decodes the new fields directly from the seed.
+    /// post-fork block is passed in as the parent payload, so the next build decodes the new
+    /// fields directly from it.
     #[tokio::test]
-    async fn test_fork_transition_seeded_parent_skips_el_read() {
+    async fn test_fork_transition_parent_block_skips_el_read() {
         let block_time = 2_u64;
         // Blocks: 1 -> ts 100 (pre-Holocene), 2 -> ts 102 (first Holocene), 3 -> ts 104.
         let cfg = Arc::new(RollupConfig {
@@ -1216,17 +1103,16 @@ mod tests {
         let epoch = BlockNumHash { hash: origin_hash, number: 1 };
 
         // The sequencer inserted block 2 (the first Holocene block), whose `extra_data`
-        // persists denominator 250 and elasticity 6, and seeded it.
+        // persists denominator 250 and elasticity 6.
         let inserted = seedable_block(Header {
             number: 2,
             timestamp: 102,
             extra_data: bytes!("00000000fa00000006"),
             ..Default::default()
         });
-        builder.seed_system_config(&inserted);
 
-        // Build block 3 on the seeded post-fork parent: the persisted parameters come from the
-        // seed and the EL is never consulted.
+        // Build block 3 on the post-fork parent payload: the persisted parameters come from
+        // the payload and the EL is never consulted.
         let l2_parent = L2BlockInfo {
             block_info: BlockInfo {
                 hash: inserted.header.hash_slow(),
@@ -1237,7 +1123,8 @@ mod tests {
             l1_origin: epoch,
             seq_num: 1,
         };
-        let payload = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
+        let payload =
+            builder.prepare_payload_attributes(l2_parent, epoch, Some(&inserted)).await.unwrap();
         assert_eq!(
             payload.eip_1559_params,
             Some(B64::from_slice(&[250_u32.to_be_bytes(), 6_u32.to_be_bytes()].concat()))

--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -15,7 +15,10 @@ use base_common_consensus::{BaseBlock, Predeploys};
 use base_common_genesis::{RollupConfig, SystemConfig};
 use base_common_rpc_types_engine::BasePayloadAttributes;
 use base_consensus_upgrades::{Upgrade, Upgrades};
-use base_protocol::{BaseTimeUpdateTx, Deposits, L1BlockInfoTx, L2BlockInfo, to_system_config};
+use base_protocol::{
+    BaseTimeUpdateTx, BatchValidationProvider, Deposits, L1BlockInfoTx, L2BlockInfo,
+    to_system_config,
+};
 use tracing::warn;
 
 use crate::{
@@ -94,6 +97,7 @@ impl<L1P, L2P> AttributesBuilder for StatefulAttributesBuilder<L1P, L2P>
 where
     L1P: ChainProvider + Debug + Send,
     L2P: L2ChainProvider + Debug + Send,
+    <L2P as BatchValidationProvider>::Error: Into<PipelineErrorKind>,
 {
     async fn prepare_payload_attributes(
         &mut self,
@@ -110,19 +114,33 @@ where
         // The parent block's system config: decoded from the parent itself, either seeded in
         // memory when the parent was inserted (see [`AttributesBuilder::seed_system_config`]) or
         // read from the L2 EL on a miss (startup, reset, reorg, or a parent built elsewhere).
-        // ponytail: the miss path fetches by number, not hash, matching the pre-cache behavior;
-        // switch the provider to a by-hash read if non-canonical parents ever need exactness.
+        // The fetched block's hash is verified against the parent hash so that a read racing a
+        // reorg can never cache another block's config under this parent.
         let mut sys_config = match self.cached_system_config(&l2_parent.block_info.hash) {
             Some(config) => config,
             None => {
-                let config = self
+                let block = self
                     .config_fetcher
-                    .system_config_by_number(
-                        l2_parent.block_info.number,
-                        Arc::clone(&self.rollup_cfg),
-                    )
+                    .block_by_number(l2_parent.block_info.number)
                     .await
                     .map_err(Into::into)?;
+                let block_hash = block.header.hash_slow();
+                if block_hash != l2_parent.block_info.hash {
+                    return Err(PipelineErrorKind::Reset(
+                        BuilderError::BlockMismatch(
+                            BlockNumHash {
+                                number: l2_parent.block_info.number,
+                                hash: l2_parent.block_info.hash,
+                            },
+                            BlockNumHash { number: block.header.number, hash: block_hash },
+                        )
+                        .into(),
+                    ));
+                }
+                let config = to_system_config(&block, &self.rollup_cfg).map_err(|err| {
+                    warn!(target: "attributes", error = ?err, number = block.header.number, "Failed to decode system config from parent block");
+                    PipelineError::Provider("system config conversion failed".to_string()).temp()
+                })?;
                 self.cache_system_config(l2_parent.block_info.hash, config);
                 config
             }
@@ -458,7 +476,8 @@ mod tests {
         let l1_cfg = Arc::new(Sepolia::l1_config());
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
+        let l2_parent_hash =
+            fallback_parent(&mut fetcher, Header { number: l2_number, ..Default::default() });
         let mut provider = TestChainProvider::default();
         let header = Header::default();
         let hash = header.hash_slow();
@@ -467,7 +486,7 @@ mod tests {
             StatefulAttributesBuilder::new(Arc::clone(&cfg), l1_cfg, fetcher, provider);
         let epoch = BlockNumHash { hash, number: l2_number };
         let l2_parent = L2BlockInfo {
-            block_info: BlockInfo { hash: B256::ZERO, number: l2_number, ..Default::default() },
+            block_info: BlockInfo { hash: l2_parent_hash, number: l2_number, ..Default::default() },
             l1_origin: BlockNumHash { hash: B256::left_padding_from(&[0xFF]), number: 2 },
             seq_num: 0,
         };
@@ -485,7 +504,8 @@ mod tests {
         let l1_cfg = Arc::new(Sepolia::l1_config());
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
+        let l2_parent_hash =
+            fallback_parent(&mut fetcher, Header { number: l2_number, ..Default::default() });
         let mut provider = TestChainProvider::default();
         let header = Header::default();
         let hash = header.hash_slow();
@@ -494,7 +514,7 @@ mod tests {
             StatefulAttributesBuilder::new(Arc::clone(&cfg), l1_cfg, fetcher, provider);
         let epoch = BlockNumHash { hash, number: l2_number };
         let l2_parent = L2BlockInfo {
-            block_info: BlockInfo { hash: B256::ZERO, number: l2_number, ..Default::default() },
+            block_info: BlockInfo { hash: l2_parent_hash, number: l2_number, ..Default::default() },
             l1_origin: BlockNumHash { hash: B256::ZERO, number: l2_number },
             seq_num: 0,
         };
@@ -513,7 +533,8 @@ mod tests {
         let l1_cfg = Arc::new(Sepolia::l1_config());
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
+        let l2_parent_hash =
+            fallback_parent(&mut fetcher, Header { number: l2_number, ..Default::default() });
         let mut provider = TestChainProvider::default();
         let header = Header { timestamp, ..Default::default() };
         let hash = header.hash_slow();
@@ -522,7 +543,7 @@ mod tests {
             StatefulAttributesBuilder::new(Arc::clone(&cfg), l1_cfg, fetcher, provider);
         let epoch = BlockNumHash { hash, number: l2_number };
         let l2_parent = L2BlockInfo {
-            block_info: BlockInfo { hash: B256::ZERO, number: l2_number, ..Default::default() },
+            block_info: BlockInfo { hash: l2_parent_hash, number: l2_number, ..Default::default() },
             l1_origin: BlockNumHash { hash, number: l2_number },
             seq_num: 0,
         };
@@ -553,7 +574,8 @@ mod tests {
         let l1_cfg = Arc::new(Sepolia::l1_config());
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
+        let l2_parent_hash =
+            fallback_parent(&mut fetcher, Header { number: l2_number, ..Default::default() });
         let mut provider = TestChainProvider::default();
         let header = Header { timestamp, ..Default::default() };
         let prev_randao = header.mix_hash;
@@ -564,7 +586,7 @@ mod tests {
         let epoch = BlockNumHash { hash, number: l2_number };
         let l2_parent = L2BlockInfo {
             block_info: BlockInfo {
-                hash: B256::ZERO,
+                hash: l2_parent_hash,
                 number: l2_number,
                 timestamp,
                 parent_hash: hash,
@@ -618,7 +640,8 @@ mod tests {
         let l1_cfg = Arc::new(Sepolia::l1_config());
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
+        let l2_parent_hash =
+            fallback_parent(&mut fetcher, Header { number: l2_number, ..Default::default() });
         let mut provider = TestChainProvider::default();
         let header = Header { timestamp, ..Default::default() };
         let hash = header.hash_slow();
@@ -628,7 +651,7 @@ mod tests {
         let epoch = BlockNumHash { hash, number: l2_number };
         let l2_parent = L2BlockInfo {
             block_info: BlockInfo {
-                hash: B256::ZERO,
+                hash: l2_parent_hash,
                 number: l2_number,
                 timestamp,
                 parent_hash: hash,
@@ -678,7 +701,8 @@ mod tests {
         let l1_cfg = Arc::new(Sepolia::l1_config());
         let l2_number = 2;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
+        let l2_parent_hash =
+            fallback_parent(&mut fetcher, Header { number: l2_number, ..Default::default() });
         let mut provider = TestChainProvider::default();
         let header = Header { timestamp, ..Default::default() };
         let hash = header.hash_slow();
@@ -688,7 +712,7 @@ mod tests {
         let epoch = BlockNumHash { hash, number: l2_number };
         let l2_parent = L2BlockInfo {
             block_info: BlockInfo {
-                hash: B256::ZERO,
+                hash: l2_parent_hash,
                 number: l2_number,
                 timestamp: 102,
                 parent_hash: hash,
@@ -730,7 +754,8 @@ mod tests {
         let l1_cfg = Arc::new(Sepolia::l1_config());
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
+        let l2_parent_hash =
+            fallback_parent(&mut fetcher, Header { number: l2_number, ..Default::default() });
         let mut provider = TestChainProvider::default();
         let header = Header { timestamp, ..Default::default() };
         let prev_randao = header.mix_hash;
@@ -741,7 +766,7 @@ mod tests {
         let epoch = BlockNumHash { hash, number: l2_number };
         let l2_parent = L2BlockInfo {
             block_info: BlockInfo {
-                hash: B256::ZERO,
+                hash: l2_parent_hash,
                 number: l2_number,
                 timestamp,
                 parent_hash: hash,
@@ -789,7 +814,8 @@ mod tests {
         let l1_cfg = Arc::new(Sepolia::l1_config());
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
+        let l2_parent_hash =
+            fallback_parent(&mut fetcher, Header { number: l2_number, ..Default::default() });
         let mut provider = TestChainProvider::default();
         let header = Header { timestamp, ..Default::default() };
         let parent_beacon_block_root = Some(header.parent_beacon_block_root.unwrap_or_default());
@@ -801,7 +827,7 @@ mod tests {
         let epoch = BlockNumHash { hash, number: l2_number };
         let l2_parent = L2BlockInfo {
             block_info: BlockInfo {
-                hash: B256::ZERO,
+                hash: l2_parent_hash,
                 number: l2_number,
                 timestamp,
                 parent_hash: hash,
@@ -849,7 +875,8 @@ mod tests {
         let l1_cfg = Arc::new(Sepolia::l1_config());
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
+        let l2_parent_hash =
+            fallback_parent(&mut fetcher, Header { number: l2_number, ..Default::default() });
         let mut provider = TestChainProvider::default();
         let header = Header { timestamp, ..Default::default() };
         let prev_randao = header.mix_hash;
@@ -860,7 +887,7 @@ mod tests {
         let epoch = BlockNumHash { hash, number: l2_number };
         let l2_parent = L2BlockInfo {
             block_info: BlockInfo {
-                hash: B256::ZERO,
+                hash: l2_parent_hash,
                 number: l2_number,
                 timestamp,
                 parent_hash: hash,
@@ -904,7 +931,8 @@ mod tests {
         let l1_cfg = Arc::new(Sepolia::l1_config());
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
+        let l2_parent_hash =
+            fallback_parent(&mut fetcher, Header { number: l2_number, ..Default::default() });
         let mut provider = TestChainProvider::default();
 
         // The epoch header's parent_hash must match l2_parent.l1_origin.hash.
@@ -931,7 +959,7 @@ mod tests {
             StatefulAttributesBuilder::new(Arc::clone(&cfg), l1_cfg, fetcher, provider);
         let epoch = BlockNumHash { hash: epoch_hash, number: l2_number + 1 };
         let l2_parent = L2BlockInfo {
-            block_info: BlockInfo { hash: B256::ZERO, number: l2_number, ..Default::default() },
+            block_info: BlockInfo { hash: l2_parent_hash, number: l2_number, ..Default::default() },
             l1_origin: BlockNumHash { hash: origin_hash, number: l2_number },
             seq_num: 0,
         };
@@ -965,7 +993,8 @@ mod tests {
         let cfg = cache_test_cfg(block_time, timestamp);
         let l1_cfg = Arc::new(Sepolia::l1_config());
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(1, SystemConfig::default());
+        let l2_parent_hash =
+            fallback_parent(&mut fetcher, Header { number: 1, timestamp, ..Default::default() });
         let mut provider = TestChainProvider::default();
         let parent_header = Header { number: 1, timestamp, ..Default::default() };
         let parent_hash = parent_header.hash_slow();
@@ -976,27 +1005,11 @@ mod tests {
         provider.insert_receipts(epoch_hash, vec![]);
         let builder = StatefulAttributesBuilder::new(cfg, l1_cfg, fetcher, provider);
         let l2_parent = L2BlockInfo {
-            block_info: BlockInfo { hash: B256::ZERO, number: 1, timestamp, parent_hash },
+            block_info: BlockInfo { hash: l2_parent_hash, number: 1, timestamp, parent_hash },
             l1_origin: BlockNumHash { hash: parent_hash, number: 1 },
             seq_num: 0,
         };
         (builder, BlockNumHash { hash: epoch_hash, number: 2 }, l2_parent)
-    }
-
-    /// Advances to the next L2 parent within the same L1 origin, giving each block a distinct
-    /// hash.
-    fn next_l2_parent(prev: &L2BlockInfo, cfg: &RollupConfig, epoch: BlockNumHash) -> L2BlockInfo {
-        let number = prev.block_info.number + 1;
-        L2BlockInfo {
-            block_info: BlockInfo {
-                hash: B256::with_last_byte(number as u8),
-                number,
-                timestamp: cfg.l2_block_timestamp(number),
-                parent_hash: prev.block_info.hash,
-            },
-            l1_origin: epoch,
-            seq_num: prev.seq_num + 1,
-        }
     }
 
     /// Builds a minimal decodable L2 block: `to_system_config` requires an L1 info deposit as
@@ -1014,6 +1027,16 @@ mod tests {
         }
     }
 
+    /// Installs a decodable block built from `header` into the fetcher and returns its hash:
+    /// the EL fallback verifies the fetched block's hash against the parent hash, so tests
+    /// exercising it need the parent hash to be a real block hash.
+    fn fallback_parent(fetcher: &mut TestSystemConfigL2Fetcher, header: Header) -> B256 {
+        let block = seedable_block(header);
+        let hash = block.header.hash_slow();
+        fetcher.insert_block(block.header.number, block);
+        hash
+    }
+
     #[tokio::test]
     async fn test_seeded_parent_config_skips_el_read() {
         let (mut builder, epoch, l2_parent) = transition_setup();
@@ -1023,7 +1046,7 @@ mod tests {
         builder.cache_system_config(l2_parent.block_info.hash, SystemConfig::default());
         builder.config_fetcher.clear();
         builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
-        assert!(builder.config_fetcher.system_config_calls.is_empty());
+        assert!(builder.config_fetcher.block_calls.is_empty());
     }
 
     #[tokio::test]
@@ -1032,29 +1055,61 @@ mod tests {
 
         // An unseeded parent (startup, reset, or a block built elsewhere) is read from the EL.
         builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
-        assert_eq!(builder.config_fetcher.system_config_calls, vec![1]);
+        assert_eq!(builder.config_fetcher.block_calls, vec![1]);
 
         // A rebuild on the same parent is served from the cache even when the EL can no longer
         // serve it.
         builder.config_fetcher.clear();
         builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
-        assert_eq!(builder.config_fetcher.system_config_calls, vec![1]);
+        assert_eq!(builder.config_fetcher.block_calls, vec![1]);
     }
 
     #[tokio::test]
     async fn test_same_origin_different_parent_misses_cache() {
         let (mut builder, epoch, l2_parent) = transition_setup();
         builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
-        assert_eq!(builder.config_fetcher.system_config_calls, vec![1]);
+        assert_eq!(builder.config_fetcher.block_calls, vec![1]);
 
         // The next parent shares the L1 origin but is a different L2 block: entries are keyed
         // by block hash, so without a seed its config is read from the EL rather than reusing
         // the previous parent's entry.
         let cfg = Arc::clone(&builder.rollup_cfg);
-        let l2_parent = next_l2_parent(&l2_parent, &cfg, epoch);
-        builder.config_fetcher.insert(2, SystemConfig::default());
+        let timestamp = cfg.l2_block_timestamp(2);
+        let hash = fallback_parent(
+            &mut builder.config_fetcher,
+            Header { number: 2, timestamp, ..Default::default() },
+        );
+        let l2_parent = L2BlockInfo {
+            block_info: BlockInfo {
+                hash,
+                number: 2,
+                timestamp,
+                parent_hash: l2_parent.block_info.hash,
+            },
+            l1_origin: epoch,
+            seq_num: 1,
+        };
         builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap();
-        assert_eq!(builder.config_fetcher.system_config_calls, vec![1, 2]);
+        assert_eq!(builder.config_fetcher.block_calls, vec![1, 2]);
+    }
+
+    /// A fallback read that returns a different block than the parent being built on (e.g. the
+    /// EL reorged between the parent being chosen and the read) must reset instead of caching
+    /// another block's config under the parent hash.
+    #[tokio::test]
+    async fn test_fallback_block_hash_mismatch_resets() {
+        let (mut builder, epoch, mut l2_parent) = transition_setup();
+        l2_parent.block_info.hash = B256::left_padding_from(&[0xAA]);
+        let err = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap_err();
+        assert!(matches!(
+            err,
+            PipelineErrorKind::Reset(ResetError::AttributesBuilder(BuilderError::BlockMismatch(
+                _,
+                _
+            )))
+        ));
+        // Nothing was cached under the mismatched parent hash.
+        assert!(builder.cached_system_config(&l2_parent.block_info.hash).is_none());
     }
 
     #[tokio::test]
@@ -1074,7 +1129,7 @@ mod tests {
             payload.gas_limit,
             Some(u64::from_be_bytes(alloy_primitives::U64::from(seeded_gas_limit).to_be_bytes()))
         );
-        assert!(builder.config_fetcher.system_config_calls.is_empty());
+        assert!(builder.config_fetcher.block_calls.is_empty());
     }
 
     #[test]
@@ -1187,6 +1242,6 @@ mod tests {
             payload.eip_1559_params,
             Some(B64::from_slice(&[250_u32.to_be_bytes(), 6_u32.to_be_bytes()].concat()))
         );
-        assert!(builder.config_fetcher.system_config_calls.is_empty());
+        assert!(builder.config_fetcher.block_calls.is_empty());
     }
 }

--- a/crates/consensus/derive/src/stages/attributes_queue.rs
+++ b/crates/consensus/derive/src/stages/attributes_queue.rs
@@ -246,7 +246,7 @@ mod tests {
     ) -> AttributesQueue<TestAttributesProvider, TestAttributesBuilder> {
         let cfg = cfg.unwrap_or_default();
         let mock_batch_queue = new_test_attributes_provider(origin, batches);
-        let mock_attributes_builder = TestAttributesBuilder { attributes };
+        let mock_attributes_builder = TestAttributesBuilder { attributes, ..Default::default() };
         AttributesQueue::new(Arc::new(cfg), mock_batch_queue, mock_attributes_builder)
     }
 
@@ -329,8 +329,10 @@ mod tests {
         let cfg = RollupConfig::default();
         let mock = new_test_attributes_provider(None, vec![]);
         let mut payload_attributes = default_payload_attributes();
-        let mock_builder =
-            TestAttributesBuilder { attributes: vec![Ok(payload_attributes.clone())] };
+        let mock_builder = TestAttributesBuilder {
+            attributes: vec![Ok(payload_attributes.clone())],
+            ..Default::default()
+        };
         let mut aq = AttributesQueue::new(Arc::new(cfg), mock, mock_builder);
         let parent = L2BlockInfo::default();
         let txs = vec![Bytes::default(), Bytes::default()];
@@ -359,7 +361,8 @@ mod tests {
         let mock =
             new_test_attributes_provider(Some(Default::default()), vec![Ok(Default::default())]);
         let mut pa = default_payload_attributes();
-        let mock_builder = TestAttributesBuilder { attributes: vec![Ok(pa.clone())] };
+        let mock_builder =
+            TestAttributesBuilder { attributes: vec![Ok(pa.clone())], ..Default::default() };
         let mut aq = AttributesQueue::new(Arc::new(cfg), mock, mock_builder);
         // If we load the batch, we should get the last in span.
         // But it won't take it so it will be available in the next_attributes call.

--- a/crates/consensus/derive/src/stages/attributes_queue.rs
+++ b/crates/consensus/derive/src/stages/attributes_queue.rs
@@ -115,7 +115,8 @@ where
 
         // Prepare the payload attributes
         let tx_count = batch.transactions.len();
-        let mut attributes = self.builder.prepare_payload_attributes(parent, batch.epoch()).await?;
+        let mut attributes =
+            self.builder.prepare_payload_attributes(parent, batch.epoch(), None).await?;
         attributes.no_tx_pool = Some(true);
         match attributes.transactions {
             Some(ref mut txs) => txs.extend(batch.transactions),
@@ -246,7 +247,7 @@ mod tests {
     ) -> AttributesQueue<TestAttributesProvider, TestAttributesBuilder> {
         let cfg = cfg.unwrap_or_default();
         let mock_batch_queue = new_test_attributes_provider(origin, batches);
-        let mock_attributes_builder = TestAttributesBuilder { attributes, ..Default::default() };
+        let mock_attributes_builder = TestAttributesBuilder { attributes };
         AttributesQueue::new(Arc::new(cfg), mock_batch_queue, mock_attributes_builder)
     }
 
@@ -329,10 +330,8 @@ mod tests {
         let cfg = RollupConfig::default();
         let mock = new_test_attributes_provider(None, vec![]);
         let mut payload_attributes = default_payload_attributes();
-        let mock_builder = TestAttributesBuilder {
-            attributes: vec![Ok(payload_attributes.clone())],
-            ..Default::default()
-        };
+        let mock_builder =
+            TestAttributesBuilder { attributes: vec![Ok(payload_attributes.clone())] };
         let mut aq = AttributesQueue::new(Arc::new(cfg), mock, mock_builder);
         let parent = L2BlockInfo::default();
         let txs = vec![Bytes::default(), Bytes::default()];
@@ -361,8 +360,7 @@ mod tests {
         let mock =
             new_test_attributes_provider(Some(Default::default()), vec![Ok(Default::default())]);
         let mut pa = default_payload_attributes();
-        let mock_builder =
-            TestAttributesBuilder { attributes: vec![Ok(pa.clone())], ..Default::default() };
+        let mock_builder = TestAttributesBuilder { attributes: vec![Ok(pa.clone())] };
         let mut aq = AttributesQueue::new(Arc::new(cfg), mock, mock_builder);
         // If we load the batch, we should get the last in span.
         // But it won't take it so it will be available in the next_attributes call.

--- a/crates/consensus/derive/src/test_utils/attributes_queue.rs
+++ b/crates/consensus/derive/src/test_utils/attributes_queue.rs
@@ -3,7 +3,9 @@
 use alloc::{boxed::Box, vec::Vec};
 
 use alloy_eips::BlockNumHash;
+use alloy_primitives::B256;
 use async_trait::async_trait;
+use base_common_consensus::BaseBlock;
 use base_common_genesis::SystemConfig;
 use base_common_rpc_types_engine::BasePayloadAttributes;
 use base_protocol::{BlockInfo, L2BlockInfo, SingleBatch};
@@ -19,6 +21,8 @@ use crate::{
 pub struct TestAttributesBuilder {
     /// The attributes to return.
     pub attributes: Vec<Result<BasePayloadAttributes, PipelineErrorKind>>,
+    /// Hashes of the blocks passed to [`AttributesBuilder::seed_system_config`], in call order.
+    pub seeded: Vec<B256>,
 }
 
 #[async_trait]
@@ -36,6 +40,10 @@ impl AttributesBuilder for TestAttributesBuilder {
                 "Unexpected call to TestAttributesBuilder::prepare_payload_attributes. Configure the mocked result to return to avoid this error."
             ),
         }
+    }
+
+    fn seed_system_config(&mut self, block: &BaseBlock) {
+        self.seeded.push(block.header.hash_slow());
     }
 }
 

--- a/crates/consensus/derive/src/test_utils/attributes_queue.rs
+++ b/crates/consensus/derive/src/test_utils/attributes_queue.rs
@@ -3,6 +3,7 @@
 use alloc::{boxed::Box, vec::Vec};
 
 use alloy_eips::BlockNumHash;
+use alloy_primitives::Sealed;
 use async_trait::async_trait;
 use base_common_consensus::BaseBlock;
 use base_common_genesis::SystemConfig;
@@ -29,7 +30,7 @@ impl AttributesBuilder for TestAttributesBuilder {
         &mut self,
         _l2_parent: L2BlockInfo,
         _epoch: BlockNumHash,
-        _parent_block: Option<&BaseBlock>,
+        _parent_block: Option<&Sealed<BaseBlock>>,
     ) -> PipelineResult<BasePayloadAttributes> {
         match self.attributes.pop() {
             Some(Ok(attrs)) => Ok(attrs),

--- a/crates/consensus/derive/src/test_utils/attributes_queue.rs
+++ b/crates/consensus/derive/src/test_utils/attributes_queue.rs
@@ -3,7 +3,6 @@
 use alloc::{boxed::Box, vec::Vec};
 
 use alloy_eips::BlockNumHash;
-use alloy_primitives::B256;
 use async_trait::async_trait;
 use base_common_consensus::BaseBlock;
 use base_common_genesis::SystemConfig;
@@ -21,8 +20,6 @@ use crate::{
 pub struct TestAttributesBuilder {
     /// The attributes to return.
     pub attributes: Vec<Result<BasePayloadAttributes, PipelineErrorKind>>,
-    /// Hashes of the blocks passed to [`AttributesBuilder::seed_system_config`], in call order.
-    pub seeded: Vec<B256>,
 }
 
 #[async_trait]
@@ -32,6 +29,7 @@ impl AttributesBuilder for TestAttributesBuilder {
         &mut self,
         _l2_parent: L2BlockInfo,
         _epoch: BlockNumHash,
+        _parent_block: Option<&BaseBlock>,
     ) -> PipelineResult<BasePayloadAttributes> {
         match self.attributes.pop() {
             Some(Ok(attrs)) => Ok(attrs),
@@ -40,10 +38,6 @@ impl AttributesBuilder for TestAttributesBuilder {
                 "Unexpected call to TestAttributesBuilder::prepare_payload_attributes. Configure the mocked result to return to avoid this error."
             ),
         }
-    }
-
-    fn seed_system_config(&mut self, block: &BaseBlock) {
-        self.seeded.push(block.header.hash_slow());
     }
 }
 

--- a/crates/consensus/derive/src/test_utils/sys_config_fetcher.rs
+++ b/crates/consensus/derive/src/test_utils/sys_config_fetcher.rs
@@ -21,10 +21,6 @@ pub struct TestSystemConfigL2Fetcher {
     pub system_configs: HashMap<u64, SystemConfig>,
     /// The block numbers for which the system config was requested, in call order.
     pub system_config_calls: Vec<u64>,
-    /// A map from [u64] block number to a [`BaseBlock`].
-    pub blocks: HashMap<u64, BaseBlock>,
-    /// The block numbers for which a block was requested, in call order.
-    pub block_calls: Vec<u64>,
 }
 
 impl TestSystemConfigL2Fetcher {
@@ -33,15 +29,9 @@ impl TestSystemConfigL2Fetcher {
         self.system_configs.insert(number, config);
     }
 
-    /// Inserts a new block into the mock fetcher with the given block number.
-    pub fn insert_block(&mut self, number: u64, block: BaseBlock) {
-        self.blocks.insert(number, block);
-    }
-
-    /// Clears all system configs and blocks from the mock fetcher.
+    /// Clears all system configs from the mock fetcher.
     pub fn clear(&mut self) {
         self.system_configs.clear();
-        self.blocks.clear();
     }
 }
 
@@ -51,9 +41,6 @@ pub enum TestSystemConfigL2FetcherError {
     /// The system config was not found.
     #[error("system config not found: {0}")]
     NotFound(u64),
-    /// The block was not found.
-    #[error("block not found: {0}")]
-    BlockNotFound(u64),
 }
 
 impl From<TestSystemConfigL2FetcherError> for PipelineErrorKind {
@@ -66,12 +53,8 @@ impl From<TestSystemConfigL2FetcherError> for PipelineErrorKind {
 impl BatchValidationProvider for TestSystemConfigL2Fetcher {
     type Error = TestSystemConfigL2FetcherError;
 
-    async fn block_by_number(&mut self, number: u64) -> Result<BaseBlock, Self::Error> {
-        self.block_calls.push(number);
-        self.blocks
-            .get(&number)
-            .cloned()
-            .ok_or(TestSystemConfigL2FetcherError::BlockNotFound(number))
+    async fn block_by_number(&mut self, _: u64) -> Result<BaseBlock, Self::Error> {
+        unimplemented!()
     }
 
     async fn l2_block_info_by_number(&mut self, _: u64) -> Result<L2BlockInfo, Self::Error> {

--- a/crates/consensus/derive/src/test_utils/sys_config_fetcher.rs
+++ b/crates/consensus/derive/src/test_utils/sys_config_fetcher.rs
@@ -21,6 +21,10 @@ pub struct TestSystemConfigL2Fetcher {
     pub system_configs: HashMap<u64, SystemConfig>,
     /// The block numbers for which the system config was requested, in call order.
     pub system_config_calls: Vec<u64>,
+    /// A map from [u64] block number to a [`BaseBlock`].
+    pub blocks: HashMap<u64, BaseBlock>,
+    /// The block numbers for which a block was requested, in call order.
+    pub block_calls: Vec<u64>,
 }
 
 impl TestSystemConfigL2Fetcher {
@@ -29,9 +33,15 @@ impl TestSystemConfigL2Fetcher {
         self.system_configs.insert(number, config);
     }
 
-    /// Clears all system configs from the mock fetcher.
+    /// Inserts a new block into the mock fetcher with the given block number.
+    pub fn insert_block(&mut self, number: u64, block: BaseBlock) {
+        self.blocks.insert(number, block);
+    }
+
+    /// Clears all system configs and blocks from the mock fetcher.
     pub fn clear(&mut self) {
         self.system_configs.clear();
+        self.blocks.clear();
     }
 }
 
@@ -41,6 +51,9 @@ pub enum TestSystemConfigL2FetcherError {
     /// The system config was not found.
     #[error("system config not found: {0}")]
     NotFound(u64),
+    /// The block was not found.
+    #[error("block not found: {0}")]
+    BlockNotFound(u64),
 }
 
 impl From<TestSystemConfigL2FetcherError> for PipelineErrorKind {
@@ -53,8 +66,12 @@ impl From<TestSystemConfigL2FetcherError> for PipelineErrorKind {
 impl BatchValidationProvider for TestSystemConfigL2Fetcher {
     type Error = TestSystemConfigL2FetcherError;
 
-    async fn block_by_number(&mut self, _: u64) -> Result<BaseBlock, Self::Error> {
-        unimplemented!()
+    async fn block_by_number(&mut self, number: u64) -> Result<BaseBlock, Self::Error> {
+        self.block_calls.push(number);
+        self.blocks
+            .get(&number)
+            .cloned()
+            .ok_or(TestSystemConfigL2FetcherError::BlockNotFound(number))
     }
 
     async fn l2_block_info_by_number(&mut self, _: u64) -> Result<L2BlockInfo, Self::Error> {

--- a/crates/consensus/derive/src/test_utils/sys_config_fetcher.rs
+++ b/crates/consensus/derive/src/test_utils/sys_config_fetcher.rs
@@ -1,6 +1,6 @@
 //! Implements a mock [`L2ChainProvider`] and [`BatchValidationProvider`] for testing.
 
-use alloc::{boxed::Box, string::ToString, sync::Arc};
+use alloc::{boxed::Box, string::ToString, sync::Arc, vec::Vec};
 
 use alloy_primitives::map::HashMap;
 use async_trait::async_trait;
@@ -19,6 +19,8 @@ use crate::{
 pub struct TestSystemConfigL2Fetcher {
     /// A map from [u64] block number to a [`SystemConfig`].
     pub system_configs: HashMap<u64, SystemConfig>,
+    /// The block numbers for which the system config was requested, in call order.
+    pub system_config_calls: Vec<u64>,
 }
 
 impl TestSystemConfigL2Fetcher {
@@ -69,6 +71,7 @@ impl L2ChainProvider for TestSystemConfigL2Fetcher {
         number: u64,
         _: Arc<RollupConfig>,
     ) -> Result<SystemConfig, <Self as L2ChainProvider>::Error> {
+        self.system_config_calls.push(number);
         self.system_configs
             .get(&number)
             .copied()

--- a/crates/consensus/derive/src/traits/attributes.rs
+++ b/crates/consensus/derive/src/traits/attributes.rs
@@ -45,16 +45,16 @@ pub trait AttributesBuilder: Debug + Send {
     /// and no sequencer transactions. The caller has to modify the template to add transactions.
     /// This can be done by either setting the `no_tx_pool` to false as sequencer, or by appending
     /// batch transactions as the verifier.
+    ///
+    /// `parent_block` is the L2 parent payload when the caller already has it (the sequencer
+    /// just built it). When its hash matches `l2_parent`, the parent [`SystemConfig`] is decoded
+    /// from it instead of reading the execution layer.
+    ///
+    /// [`SystemConfig`]: base_common_genesis::SystemConfig
     async fn prepare_payload_attributes(
         &mut self,
         l2_parent: L2BlockInfo,
         epoch: BlockNumHash,
+        parent_block: Option<&BaseBlock>,
     ) -> PipelineResult<BasePayloadAttributes>;
-
-    /// Records a just-inserted L2 block so subsequent attribute builds on top of it can reuse
-    /// its [`SystemConfig`] without consulting the execution layer. Implementations without a
-    /// config cache ignore this.
-    ///
-    /// [`SystemConfig`]: base_common_genesis::SystemConfig
-    fn seed_system_config(&mut self, _block: &BaseBlock) {}
 }

--- a/crates/consensus/derive/src/traits/attributes.rs
+++ b/crates/consensus/derive/src/traits/attributes.rs
@@ -5,6 +5,7 @@ use core::fmt::Debug;
 
 use alloy_eips::BlockNumHash;
 use async_trait::async_trait;
+use base_common_consensus::BaseBlock;
 use base_common_rpc_types_engine::BasePayloadAttributes;
 use base_protocol::{AttributesWithParent, L2BlockInfo, SingleBatch};
 
@@ -49,4 +50,11 @@ pub trait AttributesBuilder: Debug + Send {
         l2_parent: L2BlockInfo,
         epoch: BlockNumHash,
     ) -> PipelineResult<BasePayloadAttributes>;
+
+    /// Records a just-inserted L2 block so subsequent attribute builds on top of it can reuse
+    /// its [`SystemConfig`] without consulting the execution layer. Implementations without a
+    /// config cache ignore this.
+    ///
+    /// [`SystemConfig`]: base_common_genesis::SystemConfig
+    fn seed_system_config(&mut self, _block: &BaseBlock) {}
 }

--- a/crates/consensus/derive/src/traits/attributes.rs
+++ b/crates/consensus/derive/src/traits/attributes.rs
@@ -4,6 +4,7 @@ use alloc::boxed::Box;
 use core::fmt::Debug;
 
 use alloy_eips::BlockNumHash;
+use alloy_primitives::Sealed;
 use async_trait::async_trait;
 use base_common_consensus::BaseBlock;
 use base_common_rpc_types_engine::BasePayloadAttributes;
@@ -46,15 +47,15 @@ pub trait AttributesBuilder: Debug + Send {
     /// This can be done by either setting the `no_tx_pool` to false as sequencer, or by appending
     /// batch transactions as the verifier.
     ///
-    /// `parent_block` is the L2 parent payload when the caller already has it (the sequencer
-    /// just built it). When its hash matches `l2_parent`, the parent [`SystemConfig`] is decoded
-    /// from it instead of reading the execution layer.
+    /// `parent_block` is the sealed L2 parent payload when the caller already has it (the
+    /// sequencer just built it). When its memoized hash matches `l2_parent`, the parent
+    /// [`SystemConfig`] is decoded from it instead of reading the execution layer.
     ///
     /// [`SystemConfig`]: base_common_genesis::SystemConfig
     async fn prepare_payload_attributes(
         &mut self,
         l2_parent: L2BlockInfo,
         epoch: BlockNumHash,
-        parent_block: Option<&BaseBlock>,
+        parent_block: Option<&Sealed<BaseBlock>>,
     ) -> PipelineResult<BasePayloadAttributes>;
 }

--- a/crates/consensus/engine/src/task_queue/tasks/insert/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/insert/task.rs
@@ -2,16 +2,11 @@
 
 use std::{sync::Arc, time::Instant};
 
-use alloy_eips::eip7685::EMPTY_REQUESTS_HASH;
-use alloy_rpc_types_engine::{
-    CancunPayloadFields, ExecutionPayloadInputV2, PayloadStatusEnum, PraguePayloadFields,
-};
+use alloy_rpc_types_engine::{ExecutionPayloadInputV2, PayloadStatusEnum};
 use async_trait::async_trait;
 use base_common_consensus::BaseBlock;
 use base_common_genesis::RollupConfig;
-use base_common_rpc_types_engine::{
-    BaseExecutionPayload, BaseExecutionPayloadEnvelope, BaseExecutionPayloadSidecar,
-};
+use base_common_rpc_types_engine::{BaseExecutionPayload, BaseExecutionPayloadEnvelope};
 use base_protocol::L2BlockInfo;
 use tokio::sync::mpsc;
 
@@ -226,25 +221,8 @@ impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
         // Form a block ref before insertion so stale unsafe payloads can be dropped before import.
         let parent_beacon_block_root = self.envelope.parent_beacon_block_root.unwrap_or_default();
         let execution_payload = self.envelope.execution_payload.clone();
-        let block: BaseBlock = match &execution_payload {
-            BaseExecutionPayload::V1(payload) => BaseExecutionPayload::V1(payload.clone())
-                .try_into_block()
-                .map_err(InsertTaskError::FromBlockError)?,
-            BaseExecutionPayload::V2(payload) => BaseExecutionPayload::V2(payload.clone())
-                .try_into_block()
-                .map_err(InsertTaskError::FromBlockError)?,
-            BaseExecutionPayload::V3(payload) => BaseExecutionPayload::V3(payload.clone())
-                .try_into_block_with_sidecar(&BaseExecutionPayloadSidecar::v3(
-                    CancunPayloadFields::new(parent_beacon_block_root, vec![]),
-                ))
-                .map_err(InsertTaskError::FromBlockError)?,
-            BaseExecutionPayload::V4(payload) => BaseExecutionPayload::V4(payload.clone())
-                .try_into_block_with_sidecar(&BaseExecutionPayloadSidecar::v4(
-                    CancunPayloadFields::new(parent_beacon_block_root, vec![]),
-                    PraguePayloadFields::new(EMPTY_REQUESTS_HASH),
-                ))
-                .map_err(InsertTaskError::FromBlockError)?,
-        };
+        let block: BaseBlock =
+            self.envelope.clone().try_into_block().map_err(InsertTaskError::FromBlockError)?;
 
         let new_block_ref =
             L2BlockInfo::from_block_and_genesis(&block, &self.rollup_config.genesis)

--- a/crates/consensus/service/src/actors/sequencer/actor.rs
+++ b/crates/consensus/service/src/actors/sequencer/actor.rs
@@ -442,14 +442,15 @@ where
 
                 if let Some(sealer) = self.sealer.take() {
                     Metrics::sequencer_seal_pipeline_duration().record(sealer.started_at.elapsed());
-                    // Seed the attributes builder with the just-inserted block so the next build
-                    // on top of it reuses the block's SystemConfig without an EL read.
+                    // Keep the inserted payload so the next build can decode SystemConfig from it
+                    // instead of reading the execution layer.
                     match sealer.envelope.try_into_block() {
                         Ok(block) => {
-                            self.builder.attributes_builder.seed_system_config(&block);
+                            self.builder.last_inserted_block = Some(block);
                         }
                         Err(err) => {
-                            warn!(target: "sequencer", error = ?err, "Failed to decode inserted payload for system config seeding");
+                            warn!(target: "sequencer", error = ?err, "Failed to decode inserted payload as parent block");
+                            self.builder.last_inserted_block = None;
                         }
                     }
                 }

--- a/crates/consensus/service/src/actors/sequencer/actor.rs
+++ b/crates/consensus/service/src/actors/sequencer/actor.rs
@@ -425,7 +425,7 @@ where
     }
 
     /// Handles the outcome of one seal pipeline step.
-    async fn handle_seal_step_result(
+    pub(super) async fn handle_seal_step_result(
         &mut self,
         pipeline: &mut BuildPipelineState,
         shadow: &mut Option<ShadowSequencingState>,
@@ -442,6 +442,16 @@ where
 
                 if let Some(sealer) = self.sealer.take() {
                     Metrics::sequencer_seal_pipeline_duration().record(sealer.started_at.elapsed());
+                    // Seed the attributes builder with the just-inserted block so the next build
+                    // on top of it reuses the block's SystemConfig without an EL read.
+                    match sealer.envelope.try_into_block() {
+                        Ok(block) => {
+                            self.builder.attributes_builder.seed_system_config(&block);
+                        }
+                        Err(err) => {
+                            warn!(target: "sequencer", error = ?err, "Failed to decode inserted payload for system config seeding");
+                        }
+                    }
                 }
 
                 if reconcile {

--- a/crates/consensus/service/src/actors/sequencer/actor.rs
+++ b/crates/consensus/service/src/actors/sequencer/actor.rs
@@ -6,7 +6,7 @@ use std::{
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
-use alloy_primitives::B256;
+use alloy_primitives::{B256, Sealed};
 use async_trait::async_trait;
 use base_common_genesis::RollupConfig;
 use base_consensus_derive::AttributesBuilder;
@@ -215,6 +215,7 @@ where
         &mut self,
         next_payload: &mut Option<UnsealedPayloadHandle>,
     ) -> Result<(), SequencerActorError> {
+        self.builder.last_inserted_block = None;
         loop {
             let engine_client = Arc::clone(&self.engine_client);
             let shadow_cycle_coordinated = self.is_shadow_sequencer();
@@ -283,6 +284,7 @@ where
             shadow_state.abort_reconciliation();
         }
         self.sealer = None;
+        self.builder.last_inserted_block = None;
         pipeline.pending_build_parent = None;
         let canonical_head = self.engine_client.get_unsafe_head().await?;
         *shadow = Some(ShadowSequencingState::new(canonical_head)?);
@@ -364,8 +366,12 @@ where
         let reset_requested =
             self.handle_admin_query(&mut pipeline.next_payload_to_seal, query).await;
 
-        if reset_requested && self.is_shadow_sequencer() {
-            self.reset_shadow_cycle_after_admin(shadow, pipeline, build_ticker).await?;
+        if reset_requested {
+            if self.is_shadow_sequencer() {
+                self.reset_shadow_cycle_after_admin(shadow, pipeline, build_ticker).await?;
+            } else {
+                self.builder.last_inserted_block = None;
+            }
         }
 
         if active_before && !self.is_active {
@@ -442,16 +448,23 @@ where
 
                 if let Some(sealer) = self.sealer.take() {
                     Metrics::sequencer_seal_pipeline_duration().record(sealer.started_at.elapsed());
-                    // Keep the inserted payload so the next build can decode SystemConfig from it
-                    // instead of reading the execution layer.
-                    match sealer.envelope.try_into_block() {
-                        Ok(block) => {
-                            self.builder.last_inserted_block = Some(block);
+                    if self.is_active {
+                        // Keep the inserted payload so the next build can decode SystemConfig from
+                        // it instead of reading the execution layer. Memoize the acknowledged
+                        // inserted hash with the decoded block.
+                        let block_hash = inserted_head.block_info.hash;
+                        match sealer.envelope.try_into_block() {
+                            Ok(block) => {
+                                self.builder.last_inserted_block =
+                                    Some(Sealed::new_unchecked(block, block_hash));
+                            }
+                            Err(err) => {
+                                warn!(target: "sequencer", error = ?err, "Failed to decode inserted payload as parent block");
+                                self.builder.last_inserted_block = None;
+                            }
                         }
-                        Err(err) => {
-                            warn!(target: "sequencer", error = ?err, "Failed to decode inserted payload as parent block");
-                            self.builder.last_inserted_block = None;
-                        }
+                    } else {
+                        self.builder.last_inserted_block = None;
                     }
                 }
 

--- a/crates/consensus/service/src/actors/sequencer/admin_api_impl.rs
+++ b/crates/consensus/service/src/actors/sequencer/admin_api_impl.rs
@@ -199,6 +199,7 @@ where
         // Discard any pre-built payload so a subsequent start_sequencer always builds on a fresh,
         // accurate head.
         next_payload.take();
+        self.builder.last_inserted_block = None;
         self.update_metrics();
 
         if self.sealer.is_some() {

--- a/crates/consensus/service/src/actors/sequencer/build.rs
+++ b/crates/consensus/service/src/actors/sequencer/build.rs
@@ -8,6 +8,7 @@
 use std::{sync::Arc, time::Instant};
 
 use alloy_rpc_types_engine::PayloadId;
+use base_common_consensus::BaseBlock;
 use base_common_genesis::RollupConfig;
 use base_consensus_derive::{AttributesBuilder, PipelineErrorKind};
 use base_protocol::{AttributesWithParent, BlockInfo, L2BlockInfo};
@@ -66,6 +67,9 @@ pub struct PayloadBuilder<A: AttributesBuilder, O: OriginSelector, E: SequencerE
     pub engine_client: Arc<E>,
     /// The origin selector.
     pub origin_selector: O,
+    /// Last L2 block this sequencer inserted, passed into the next
+    /// [`AttributesBuilder::prepare_payload_attributes`] as the parent payload.
+    pub last_inserted_block: Option<BaseBlock>,
     /// Shared recovery mode flag.
     pub recovery_mode: RecoveryModeGuard,
     /// The rollup configuration.
@@ -199,7 +203,11 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
     ) -> Result<Option<AttributesWithParent>, SequencerActorError> {
         let mut attributes = match self
             .attributes_builder
-            .prepare_payload_attributes(unsafe_head, l1_origin.id())
+            .prepare_payload_attributes(
+                unsafe_head,
+                l1_origin.id(),
+                self.last_inserted_block.as_ref(),
+            )
             .await
         {
             Ok(attrs) => attrs,

--- a/crates/consensus/service/src/actors/sequencer/build.rs
+++ b/crates/consensus/service/src/actors/sequencer/build.rs
@@ -7,6 +7,7 @@
 
 use std::{sync::Arc, time::Instant};
 
+use alloy_primitives::Sealed;
 use alloy_rpc_types_engine::PayloadId;
 use base_common_consensus::BaseBlock;
 use base_common_genesis::RollupConfig;
@@ -69,7 +70,7 @@ pub struct PayloadBuilder<A: AttributesBuilder, O: OriginSelector, E: SequencerE
     pub origin_selector: O,
     /// Last L2 block this sequencer inserted, passed into the next
     /// [`AttributesBuilder::prepare_payload_attributes`] as the parent payload.
-    pub last_inserted_block: Option<BaseBlock>,
+    pub last_inserted_block: Option<Sealed<BaseBlock>>,
     /// Shared recovery mode flag.
     pub recovery_mode: RecoveryModeGuard,
     /// The rollup configuration.
@@ -146,6 +147,7 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
                 self.engine_client
                     .reset_engine_forkchoice(ResetReason::L1OriginUnavailable)
                     .await?;
+                self.last_inserted_block = None;
                 return Ok(BuildOutcome::Deferred);
             }
             Err(err @ L1OriginSelectorError::NextL1OriginOrphaned { .. }) => {
@@ -155,6 +157,7 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
                     "Next L1 origin orphaned the accepted current origin, triggering engine reset"
                 );
                 self.engine_client.reset_engine_forkchoice(ResetReason::L1OriginOrphaned).await?;
+                self.last_inserted_block = None;
                 return Ok(BuildOutcome::Deferred);
             }
             Err(err @ L1OriginSelectorError::NotEnoughData(_)) => {
@@ -186,6 +189,7 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
                 "Cannot build new L2 block on inconsistent L1 origin, resetting engine"
             );
             self.engine_client.reset_engine_forkchoice(ResetReason::L1OriginInconsistent).await?;
+            self.last_inserted_block = None;
             return Ok(BuildOutcome::Deferred);
         }
 
@@ -201,6 +205,14 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
         unsafe_head: L2BlockInfo,
         l1_origin: BlockInfo,
     ) -> Result<Option<AttributesWithParent>, SequencerActorError> {
+        if self
+            .last_inserted_block
+            .as_ref()
+            .is_some_and(|block| block.hash() != unsafe_head.block_info.hash)
+        {
+            self.last_inserted_block = None;
+        }
+
         let mut attributes = match self
             .attributes_builder
             .prepare_payload_attributes(
@@ -213,6 +225,7 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
             Ok(attrs) => attrs,
             Err(PipelineErrorKind::Temporary(_)) => return Ok(None),
             Err(PipelineErrorKind::Reset(err)) => {
+                self.last_inserted_block = None;
                 // The attributes builder returned a reset error. These errors fall into two
                 // categories, neither of which requires an engine reset here:
                 //

--- a/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
@@ -10,6 +10,7 @@ use std::{
 use alloy_primitives::B256;
 use alloy_rpc_types_engine::ExecutionPayloadV1;
 use alloy_transport::TransportErrorKind;
+use base_common_consensus::BaseBlock;
 use base_common_genesis::{ChainGenesis, RollupConfig};
 use base_common_rpc_types_engine::{
     BaseExecutionPayload, BaseExecutionPayloadEnvelope, BasePayloadAttributes,
@@ -29,7 +30,7 @@ use crate::{
         MockConductor, MockOriginSelector, MockSequencerEngineClient,
         MockUnsafePayloadGossipClient,
         engine::EngineClientError,
-        sequencer::{PayloadSealer, tests::test_util::test_actor},
+        sequencer::{BuildPipelineState, PayloadSealer, tests::test_util::test_actor},
     },
 };
 
@@ -188,6 +189,7 @@ async fn test_on_time_or_late_insert_starts_child_build_immediately(#[case] seco
             Ok(attributes_at(inserted_timestamp + block_time)),
             Ok(attributes_at(inserted_timestamp)),
         ],
+        ..Default::default()
     };
     actor.builder.engine_client = Arc::clone(&engine_client);
     actor.builder.origin_selector = origin_selector;
@@ -258,6 +260,7 @@ async fn test_early_insert_defers_child_build_until_parent_timestamp() {
             Ok(attributes_at(initial_timestamp + 2 * block_time)),
             Ok(attributes_at(initial_timestamp + block_time)),
         ],
+        ..Default::default()
     };
     actor.builder.engine_client = Arc::clone(&engine_client);
     actor.builder.origin_selector = origin_selector;
@@ -352,6 +355,7 @@ async fn test_stop_discards_queued_parent_and_restart_builds_immediately_on_fres
             Ok(attributes_at(restart_head.block_info.timestamp + block_time)),
             Ok(attributes_at(inserted_head.block_info.timestamp)),
         ],
+        ..Default::default()
     };
     actor.builder.engine_client = Arc::clone(&engine_client);
     actor.builder.origin_selector = origin_selector;
@@ -684,7 +688,8 @@ async fn test_build_unsealed_payload_prepare_payload_attributes_error(
     let mut origin_selector = MockOriginSelector::new();
     origin_selector.expect_next_l1_origin().times(1).return_once(move |_| Ok(l1_origin));
 
-    let attributes_builder = TestAttributesBuilder { attributes: vec![Err(forced_error)] };
+    let attributes_builder =
+        TestAttributesBuilder { attributes: vec![Err(forced_error)], ..Default::default() };
 
     let mut actor = test_actor();
     actor.builder.origin_selector = origin_selector;
@@ -763,6 +768,36 @@ async fn test_seal_payload_failure_propagates() {
     let result = actor.seal_payload(&handle).await;
 
     assert!(result.is_err());
+}
+
+// --- handle_seal_step_result tests ---
+
+#[tokio::test]
+async fn test_inserted_outcome_seeds_attributes_builder() {
+    let mut actor = test_actor();
+    actor.is_active = false;
+    actor.sealer = Some(PayloadSealer::new_private(dummy_envelope()));
+
+    let mut pipeline = BuildPipelineState::default();
+    let mut shadow = None;
+    let mut reconciliation_ticker = tokio::time::interval(Duration::from_secs(2));
+    let mut build_ticker = ScheduledTicker::new(Duration::from_secs(2));
+    actor
+        .handle_seal_step_result(
+            &mut pipeline,
+            &mut shadow,
+            &mut reconciliation_ticker,
+            &mut build_ticker,
+            Ok(SealStepOutcome::Inserted(L2BlockInfo::default())),
+        )
+        .await
+        .unwrap();
+
+    // The inserted payload's block was handed to the attributes builder for seeding, so the
+    // next build on it needs no EL read for the system config.
+    let inserted: BaseBlock = dummy_envelope().try_into_block().unwrap();
+    assert_eq!(actor.builder.attributes_builder.seeded, vec![inserted.header.hash_slow()]);
+    assert!(actor.sealer.is_none());
 }
 
 // --- PayloadSealer::step tests ---

--- a/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
@@ -768,10 +768,13 @@ async fn test_seal_payload_failure_propagates() {
 
 // --- handle_seal_step_result tests ---
 
+#[rstest]
+#[case(true)]
+#[case(false)]
 #[tokio::test]
-async fn test_inserted_outcome_stores_last_block() {
+async fn test_inserted_outcome_caches_last_block_only_while_active(#[case] is_active: bool) {
     let mut actor = test_actor();
-    actor.is_active = false;
+    actor.is_active = is_active;
     actor.sealer = Some(PayloadSealer::new_private(dummy_envelope()));
 
     let mut pipeline = BuildPipelineState::default();
@@ -789,11 +792,14 @@ async fn test_inserted_outcome_stores_last_block() {
         .await
         .unwrap();
 
-    let inserted: BaseBlock = dummy_envelope().try_into_block().unwrap();
-    assert_eq!(
-        actor.builder.last_inserted_block.as_ref().map(|block| block.header.hash_slow()),
-        Some(inserted.header.hash_slow())
-    );
+    if is_active {
+        let inserted: BaseBlock = dummy_envelope().try_into_block().unwrap();
+        let cached = actor.builder.last_inserted_block.as_ref().unwrap();
+        assert_eq!(cached.hash(), B256::ZERO);
+        assert_eq!(cached.inner(), &inserted);
+    } else {
+        assert!(actor.builder.last_inserted_block.is_none());
+    }
     assert!(actor.sealer.is_none());
 }
 

--- a/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
@@ -189,7 +189,6 @@ async fn test_on_time_or_late_insert_starts_child_build_immediately(#[case] seco
             Ok(attributes_at(inserted_timestamp + block_time)),
             Ok(attributes_at(inserted_timestamp)),
         ],
-        ..Default::default()
     };
     actor.builder.engine_client = Arc::clone(&engine_client);
     actor.builder.origin_selector = origin_selector;
@@ -260,7 +259,6 @@ async fn test_early_insert_defers_child_build_until_parent_timestamp() {
             Ok(attributes_at(initial_timestamp + 2 * block_time)),
             Ok(attributes_at(initial_timestamp + block_time)),
         ],
-        ..Default::default()
     };
     actor.builder.engine_client = Arc::clone(&engine_client);
     actor.builder.origin_selector = origin_selector;
@@ -355,7 +353,6 @@ async fn test_stop_discards_queued_parent_and_restart_builds_immediately_on_fres
             Ok(attributes_at(restart_head.block_info.timestamp + block_time)),
             Ok(attributes_at(inserted_head.block_info.timestamp)),
         ],
-        ..Default::default()
     };
     actor.builder.engine_client = Arc::clone(&engine_client);
     actor.builder.origin_selector = origin_selector;
@@ -688,8 +685,7 @@ async fn test_build_unsealed_payload_prepare_payload_attributes_error(
     let mut origin_selector = MockOriginSelector::new();
     origin_selector.expect_next_l1_origin().times(1).return_once(move |_| Ok(l1_origin));
 
-    let attributes_builder =
-        TestAttributesBuilder { attributes: vec![Err(forced_error)], ..Default::default() };
+    let attributes_builder = TestAttributesBuilder { attributes: vec![Err(forced_error)] };
 
     let mut actor = test_actor();
     actor.builder.origin_selector = origin_selector;
@@ -773,7 +769,7 @@ async fn test_seal_payload_failure_propagates() {
 // --- handle_seal_step_result tests ---
 
 #[tokio::test]
-async fn test_inserted_outcome_seeds_attributes_builder() {
+async fn test_inserted_outcome_stores_last_block() {
     let mut actor = test_actor();
     actor.is_active = false;
     actor.sealer = Some(PayloadSealer::new_private(dummy_envelope()));
@@ -793,10 +789,11 @@ async fn test_inserted_outcome_seeds_attributes_builder() {
         .await
         .unwrap();
 
-    // The inserted payload's block was handed to the attributes builder for seeding, so the
-    // next build on it needs no EL read for the system config.
     let inserted: BaseBlock = dummy_envelope().try_into_block().unwrap();
-    assert_eq!(actor.builder.attributes_builder.seeded, vec![inserted.header.hash_slow()]);
+    assert_eq!(
+        actor.builder.last_inserted_block.as_ref().map(|block| block.header.hash_slow()),
+        Some(inserted.header.hash_slow())
+    );
     assert!(actor.sealer.is_none());
 }
 

--- a/crates/consensus/service/src/actors/sequencer/tests/admin_api_impl_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/admin_api_impl_test.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
-use alloy_primitives::B256;
+use alloy_primitives::{B256, Sealed};
+use base_common_consensus::BaseBlock;
 use base_consensus_rpc::SequencerAdminAPIError;
 use base_protocol::{BlockInfo, L2BlockInfo};
 use jsonrpsee::core::ClientError;
@@ -404,6 +405,8 @@ async fn test_stop_sequencer_success(
     let mut actor = test_actor();
     actor.engine_client = Arc::new(client);
     actor.is_active = !already_stopped;
+    actor.builder.last_inserted_block =
+        Some(Sealed::new_unchecked(BaseBlock::default(), B256::ZERO));
 
     // verify starting state
     let result = actor.is_sequencer_active().await;
@@ -426,6 +429,7 @@ async fn test_stop_sequencer_success(
     let result = actor.is_sequencer_active().await;
     assert!(result.is_ok());
     assert!(!result.unwrap());
+    assert!(actor.builder.last_inserted_block.is_none());
 }
 
 #[rstest]

--- a/crates/consensus/service/src/actors/sequencer/tests/test_util.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/test_util.rs
@@ -31,7 +31,7 @@ pub(super) fn test_actor() -> SequencerActor<
     SequencerActor {
         admin_api_rx,
         builder: PayloadBuilder {
-            attributes_builder: TestAttributesBuilder { attributes: vec![] },
+            attributes_builder: TestAttributesBuilder { attributes: vec![], ..Default::default() },
             engine_client: Arc::clone(&engine_client),
             origin_selector: MockOriginSelector::new(),
             recovery_mode: recovery_mode.clone(),

--- a/crates/consensus/service/src/actors/sequencer/tests/test_util.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/test_util.rs
@@ -31,9 +31,10 @@ pub(super) fn test_actor() -> SequencerActor<
     SequencerActor {
         admin_api_rx,
         builder: PayloadBuilder {
-            attributes_builder: TestAttributesBuilder { attributes: vec![], ..Default::default() },
+            attributes_builder: TestAttributesBuilder { attributes: vec![] },
             engine_client: Arc::clone(&engine_client),
             origin_selector: MockOriginSelector::new(),
+            last_inserted_block: None,
             recovery_mode: recovery_mode.clone(),
             rollup_config: Arc::clone(&rollup_config),
         },

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -607,6 +607,7 @@ impl RollupNode {
                         attributes_builder,
                         engine_client: Arc::clone(&engine_client),
                         origin_selector: delayed_origin_selector,
+                        last_inserted_block: None,
                         recovery_mode: recovery_mode.clone(),
                         rollup_config: Arc::clone(&self.config),
                     },

--- a/crates/proof/proof/src/l1/pipeline.rs
+++ b/crates/proof/proof/src/l1/pipeline.rs
@@ -43,7 +43,6 @@ where
     L1: ChainProvider + Send + Sync + Debug + Clone,
     L2: L2ChainProvider + Send + Sync + Debug + Clone,
     DA: DataAvailabilityProvider + Send + Sync + Debug + Clone,
-    <L2 as BatchValidationProvider>::Error: Into<PipelineErrorKind>,
 {
     /// The internal derivation pipeline.
     pub pipeline: ProviderDerivationPipeline<L1, L2, DA>,
@@ -57,7 +56,6 @@ where
     L1: ChainProvider + Send + Sync + Debug + Clone,
     L2: L2ChainProvider + Send + Sync + Debug + Clone,
     DA: DataAvailabilityProvider + Send + Sync + Debug + Clone,
-    <L2 as BatchValidationProvider>::Error: Into<PipelineErrorKind>,
 {
     /// Constructs a new oracle-backed derivation pipeline.
     pub async fn new(
@@ -68,7 +66,10 @@ where
         da_provider: DA,
         chain_provider: L1,
         l2_chain_provider: L2,
-    ) -> PipelineResult<Self> {
+    ) -> PipelineResult<Self>
+    where
+        <L2 as BatchValidationProvider>::Error: Into<PipelineErrorKind>,
+    {
         let attributes = StatefulAttributesBuilder::new(
             Arc::clone(&cfg),
             l1_cfg,
@@ -187,7 +188,6 @@ where
     L1: ChainProvider + Send + Sync + Debug + Clone,
     L2: L2ChainProvider + Send + Sync + Debug + Clone,
     DA: DataAvailabilityProvider + Send + Sync + Debug + Clone,
-    <L2 as BatchValidationProvider>::Error: Into<PipelineErrorKind>,
 {
     /// Returns the optional L1 [`BlockInfo`] origin.
     fn origin(&self) -> Option<BlockInfo> {
@@ -201,7 +201,6 @@ where
     L1: ChainProvider + Send + Sync + Debug + Clone,
     L2: L2ChainProvider + Send + Sync + Debug + Clone,
     DA: DataAvailabilityProvider + Send + Sync + Debug + Clone,
-    <L2 as BatchValidationProvider>::Error: Into<PipelineErrorKind>,
 {
     type Item = AttributesWithParent;
 
@@ -217,7 +216,6 @@ where
     L1: ChainProvider + Send + Sync + Debug + Clone,
     L2: L2ChainProvider + Send + Sync + Debug + Clone,
     DA: DataAvailabilityProvider + Send + Sync + Debug + Clone,
-    <L2 as BatchValidationProvider>::Error: Into<PipelineErrorKind>,
 {
     /// Peeks at the next [`AttributesWithParent`] from the pipeline.
     fn peek(&self) -> Option<&AttributesWithParent> {

--- a/crates/proof/proof/src/l1/pipeline.rs
+++ b/crates/proof/proof/src/l1/pipeline.rs
@@ -43,6 +43,7 @@ where
     L1: ChainProvider + Send + Sync + Debug + Clone,
     L2: L2ChainProvider + Send + Sync + Debug + Clone,
     DA: DataAvailabilityProvider + Send + Sync + Debug + Clone,
+    <L2 as BatchValidationProvider>::Error: Into<PipelineErrorKind>,
 {
     /// The internal derivation pipeline.
     pub pipeline: ProviderDerivationPipeline<L1, L2, DA>,
@@ -56,6 +57,7 @@ where
     L1: ChainProvider + Send + Sync + Debug + Clone,
     L2: L2ChainProvider + Send + Sync + Debug + Clone,
     DA: DataAvailabilityProvider + Send + Sync + Debug + Clone,
+    <L2 as BatchValidationProvider>::Error: Into<PipelineErrorKind>,
 {
     /// Constructs a new oracle-backed derivation pipeline.
     pub async fn new(
@@ -66,10 +68,7 @@ where
         da_provider: DA,
         chain_provider: L1,
         l2_chain_provider: L2,
-    ) -> PipelineResult<Self>
-    where
-        <L2 as BatchValidationProvider>::Error: Into<PipelineErrorKind>,
-    {
+    ) -> PipelineResult<Self> {
         let attributes = StatefulAttributesBuilder::new(
             Arc::clone(&cfg),
             l1_cfg,
@@ -188,6 +187,7 @@ where
     L1: ChainProvider + Send + Sync + Debug + Clone,
     L2: L2ChainProvider + Send + Sync + Debug + Clone,
     DA: DataAvailabilityProvider + Send + Sync + Debug + Clone,
+    <L2 as BatchValidationProvider>::Error: Into<PipelineErrorKind>,
 {
     /// Returns the optional L1 [`BlockInfo`] origin.
     fn origin(&self) -> Option<BlockInfo> {
@@ -201,6 +201,7 @@ where
     L1: ChainProvider + Send + Sync + Debug + Clone,
     L2: L2ChainProvider + Send + Sync + Debug + Clone,
     DA: DataAvailabilityProvider + Send + Sync + Debug + Clone,
+    <L2 as BatchValidationProvider>::Error: Into<PipelineErrorKind>,
 {
     type Item = AttributesWithParent;
 
@@ -216,6 +217,7 @@ where
     L1: ChainProvider + Send + Sync + Debug + Clone,
     L2: L2ChainProvider + Send + Sync + Debug + Clone,
     DA: DataAvailabilityProvider + Send + Sync + Debug + Clone,
+    <L2 as BatchValidationProvider>::Error: Into<PipelineErrorKind>,
 {
     /// Peeks at the next [`AttributesWithParent`] from the pipeline.
     fn peek(&self) -> Option<&AttributesWithParent> {


### PR DESCRIPTION
## Summary

   - Reuse the last inserted payload when building attributes.
   - Decode `SystemConfig` from the payload instead of making a per-block EL read.
   - Safely fall back to the EL on startup, hash mismatch, or decode failure.

   ## Test Plan

   - [x] `cargo fmt --all -- --check`
   - [x] `cargo test -p base-consensus-derive -p base-consensus-node`
   - [x] 508 unit tests and 10 integration tests passed

   ## Breaking Changes

   None.