### PR TITLE
feat(txpool): Validate Validity Predicate Payloads At Ingress

### DIFF
--- a/crates/execution/txpool-rpc/src/rpc.rs
+++ b/crates/execution/txpool-rpc/src/rpc.rs
@@ -162,17 +162,14 @@ where
         &self,
         request: SendRawTransactionValidityRequest,
     ) -> RpcResult<TxHash> {
-        if request.validity.len() > self.max_validity_predicates {
-            return Err(ErrorObjectOwned::owned(
-                ErrorCode::InvalidParams.code(),
-                format!(
-                    "too many validity predicates: {} (maximum {})",
-                    request.validity.len(),
-                    self.max_validity_predicates
-                ),
-                None::<()>,
-            ));
-        }
+        ValidityPredicate::validate_batch(&request.validity, self.max_validity_predicates)
+            .map_err(|error| {
+                ErrorObjectOwned::owned(
+                    ErrorCode::InvalidParams.code(),
+                    error.to_string(),
+                    None::<()>,
+                )
+            })?;
 
         let transaction = BasePooledTransaction::recover_raw_transaction(request.tx.as_ref())
             .map_err(|error| {
@@ -305,6 +302,46 @@ mod tests {
         assert_eq!(error.code(), ErrorCode::InvalidParams.code());
         assert!(error.message().contains("too many validity predicates"));
         assert!(error.message().contains("maximum 2"));
+    }
+
+    #[tokio::test]
+    async fn send_raw_transaction_validity_rejects_empty_predicates() {
+        let rpc = SendRawTransactionValidityApiImpl::new(NoopTransactionPool::<
+            BasePooledTransaction,
+        >::new());
+        let mut request = validity_request(Bytes::from_static(&[0x02]));
+        request.validity.clear();
+
+        let error = rpc
+            .send_raw_transaction_validity(request)
+            .await
+            .expect_err("empty validity should be rejected before transaction decoding");
+
+        assert_eq!(error.code(), ErrorCode::InvalidParams.code());
+        assert!(error.message().contains("must not be empty"));
+    }
+
+    #[tokio::test]
+    async fn send_raw_transaction_validity_rejects_storage_value_outside_mask() {
+        let rpc = SendRawTransactionValidityApiImpl::new(NoopTransactionPool::<
+            BasePooledTransaction,
+        >::new());
+        let mut request = validity_request(Bytes::from_static(&[0x02]));
+        request.validity = vec![ValidityPredicate::Storage {
+            address: Address::repeat_byte(0xab),
+            slot: U256::from(1),
+            mask: U256::from(0xff),
+            op: base_execution_txpool::ValidityOperator::Equal,
+            value: U256::from(0x1ff),
+        }];
+
+        let error = rpc
+            .send_raw_transaction_validity(request)
+            .await
+            .expect_err("storage value outside its mask should be rejected");
+
+        assert_eq!(error.code(), ErrorCode::InvalidParams.code());
+        assert!(error.message().contains("outside its mask"));
     }
 
     #[tokio::test]

--- a/crates/execution/txpool-rpc/src/rpc.rs
+++ b/crates/execution/txpool-rpc/src/rpc.rs
@@ -227,7 +227,6 @@ impl<Pool: TransactionPool + 'static> AdminTxPoolApiServer for AdminTxPoolApiImp
 #[cfg(test)]
 mod tests {
     use alloy_primitives::U256;
-    use base_execution_txpool::MAX_VALIDITY_PREDICATES;
     use httpmock::prelude::*;
     use reth_transaction_pool::{
         PoolTransaction, TransactionOrigin,

--- a/crates/execution/txpool-rpc/src/rpc.rs
+++ b/crates/execution/txpool-rpc/src/rpc.rs
@@ -227,6 +227,7 @@ impl<Pool: TransactionPool + 'static> AdminTxPoolApiServer for AdminTxPoolApiImp
 #[cfg(test)]
 mod tests {
     use alloy_primitives::U256;
+    use base_execution_txpool::MAX_VALIDITY_PREDICATES;
     use httpmock::prelude::*;
     use reth_transaction_pool::{
         PoolTransaction, TransactionOrigin,

--- a/crates/execution/txpool/src/lib.rs
+++ b/crates/execution/txpool/src/lib.rs
@@ -30,7 +30,7 @@ mod best;
 mod validity;
 pub use validity::{
     DEFAULT_MAX_VALIDITY_PREDICATES, PredicateContext, TransactionValidity, ValidityOperator,
-    ValidityPredicate,
+    ValidityPredicate, ValidityPredicateError,
 };
 
 mod transaction;

--- a/crates/execution/txpool/src/validity.rs
+++ b/crates/execution/txpool/src/validity.rs
@@ -147,13 +147,22 @@ impl ValidityPredicate {
         U256::MAX
     }
 
-    /// Returns whether this predicate's parameters are internally consistent.
+    /// Validates that this predicate's parameters are internally consistent.
     ///
     /// A storage predicate's comparison value must not set any bits outside its
-    /// mask, since the loaded value is masked before comparison.
-    #[must_use]
-    pub fn has_valid_params(&self) -> bool {
-        !matches!(self, Self::Storage { mask, value, .. } if (*value & !*mask) != U256::ZERO)
+    /// mask, since the loaded value is masked before comparison. `index` is the
+    /// predicate's position within its submitted batch and is embedded into any
+    /// returned error so callers can report which predicate failed. Returning the
+    /// specific [`ValidityPredicateError`] keeps the diagnosis with the predicate
+    /// itself, so new failure modes surface as distinct errors instead of
+    /// collapsing into a single caller-assigned variant.
+    pub fn validate_params(&self, index: usize) -> Result<(), ValidityPredicateError> {
+        if let Self::Storage { mask, value, .. } = self
+            && (*value & !*mask) != U256::ZERO
+        {
+            return Err(ValidityPredicateError::StorageValueOutsideMask { index });
+        }
+        Ok(())
     }
 
     /// Validates a batch of predicates submitted at ingress.
@@ -168,9 +177,7 @@ impl ValidityPredicate {
             return Err(ValidityPredicateError::TooMany { count: predicates.len(), max });
         }
         for (index, predicate) in predicates.iter().enumerate() {
-            if !predicate.has_valid_params() {
-                return Err(ValidityPredicateError::StorageValueOutsideMask { index });
-            }
+            predicate.validate_params(index)?;
         }
         Ok(())
     }
@@ -247,11 +254,7 @@ impl ValidatedTransactionExtensions<BasePooledTransaction> for TransactionValidi
     /// receives ordinary transactions that carry no predicates.
     fn apply(self, tx: BasePooledTransaction) -> Result<BasePooledTransaction, ExtensionError> {
         for (index, predicate) in self.validity.iter().enumerate() {
-            if !predicate.has_valid_params() {
-                return Err(ExtensionError(format!(
-                    "storage predicate at index {index} has value bits set outside its mask"
-                )));
-            }
+            predicate.validate_params(index).map_err(|e| ExtensionError(e.to_string()))?;
         }
         Ok(tx.with_validity_predicates(self.validity))
     }
@@ -657,7 +660,7 @@ mod tests {
     }
 
     #[test]
-    fn has_valid_params_accepts_storage_value_within_mask() {
+    fn validate_params_accepts_storage_value_within_mask() {
         let predicate = ValidityPredicate::Storage {
             address: Address::repeat_byte(0x11),
             slot: U256::from(1),
@@ -666,11 +669,11 @@ mod tests {
             value: U256::from(0xab),
         };
 
-        assert!(predicate.has_valid_params());
+        assert_eq!(predicate.validate_params(0), Ok(()));
     }
 
     #[test]
-    fn has_valid_params_rejects_storage_value_outside_mask() {
+    fn validate_params_rejects_storage_value_outside_mask_reporting_its_index() {
         let predicate = ValidityPredicate::Storage {
             address: Address::repeat_byte(0x11),
             slot: U256::from(1),
@@ -679,18 +682,21 @@ mod tests {
             value: U256::from(0x1ff),
         };
 
-        assert!(!predicate.has_valid_params());
+        assert_eq!(
+            predicate.validate_params(3),
+            Err(ValidityPredicateError::StorageValueOutsideMask { index: 3 })
+        );
     }
 
     #[test]
-    fn has_valid_params_ignores_mask_for_non_storage_predicates() {
+    fn validate_params_ignores_mask_for_non_storage_predicates() {
         let predicate = ValidityPredicate::Balance {
             address: Address::repeat_byte(0x11),
             op: ValidityOperator::Equal,
             value: U256::MAX,
         };
 
-        assert!(predicate.has_valid_params());
+        assert_eq!(predicate.validate_params(0), Ok(()));
     }
 
     #[test]

--- a/crates/execution/txpool/src/validity.rs
+++ b/crates/execution/txpool/src/validity.rs
@@ -9,6 +9,31 @@ use crate::{BasePooledTransaction, ExtensionError, ValidatedTransactionExtension
 /// Default maximum number of experimental validity predicates carried by one transaction.
 pub const DEFAULT_MAX_VALIDITY_PREDICATES: usize = 64;
 
+/// Error returned when a batch of validity predicates fails ingress validation.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ValidityPredicateError {
+    /// The submission carried no predicates.
+    ///
+    /// A predicate-less submission has no advanced semantics to enforce, so it is
+    /// rejected rather than treated as a plain private transaction.
+    #[error("validity predicates must not be empty")]
+    Empty,
+    /// The submission carried more predicates than the configured maximum.
+    #[error("too many validity predicates: {count} (maximum {max})")]
+    TooMany {
+        /// Number of predicates supplied.
+        count: usize,
+        /// Maximum number of predicates permitted.
+        max: usize,
+    },
+    /// A storage predicate's comparison value has bits set outside its mask.
+    ///
+    /// Because the loaded storage value is masked before comparison, bits set in
+    /// `value` outside `mask` could never match and indicate a malformed request.
+    #[error("storage predicate value has bits set outside its mask")]
+    StorageValueOutsideMask,
+}
+
 /// A comparison used by a [`ValidityPredicate`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub enum ValidityOperator {
@@ -116,6 +141,36 @@ impl ValidityPredicate {
     #[must_use]
     pub const fn default_mask() -> U256 {
         U256::MAX
+    }
+
+    /// Validates that this predicate's parameters are internally consistent.
+    ///
+    /// A storage predicate's comparison value must not set any bits outside its
+    /// mask, since the loaded value is masked before comparison.
+    pub fn validate(&self) -> Result<(), ValidityPredicateError> {
+        if let Self::Storage { mask, value, .. } = self
+            && (*value & !*mask) != U256::ZERO
+        {
+            return Err(ValidityPredicateError::StorageValueOutsideMask);
+        }
+        Ok(())
+    }
+
+    /// Validates a batch of predicates submitted at ingress.
+    ///
+    /// Rejects an empty batch, a batch larger than `max`, and any predicate
+    /// whose parameters are internally inconsistent.
+    pub fn validate_batch(predicates: &[Self], max: usize) -> Result<(), ValidityPredicateError> {
+        if predicates.is_empty() {
+            return Err(ValidityPredicateError::Empty);
+        }
+        if predicates.len() > max {
+            return Err(ValidityPredicateError::TooMany { count: predicates.len(), max });
+        }
+        for predicate in predicates {
+            predicate.validate()?;
+        }
+        Ok(())
     }
 
     /// Returns whether this predicate holds against the current build.
@@ -522,6 +577,108 @@ mod tests {
             serde_json::from_value::<ValidityPredicate>(serde_json::to_value(&predicate).unwrap())
                 .unwrap(),
             predicate
+        );
+    }
+
+    #[test]
+    fn validate_accepts_storage_value_within_mask() {
+        let predicate = ValidityPredicate::Storage {
+            address: Address::repeat_byte(0x11),
+            slot: U256::from(1),
+            mask: U256::from(0xff),
+            op: ValidityOperator::Equal,
+            value: U256::from(0xab),
+        };
+
+        assert_eq!(predicate.validate(), Ok(()));
+    }
+
+    #[test]
+    fn validate_rejects_storage_value_outside_mask() {
+        let predicate = ValidityPredicate::Storage {
+            address: Address::repeat_byte(0x11),
+            slot: U256::from(1),
+            mask: U256::from(0xff),
+            op: ValidityOperator::Equal,
+            value: U256::from(0x1ff),
+        };
+
+        assert_eq!(predicate.validate(), Err(ValidityPredicateError::StorageValueOutsideMask));
+    }
+
+    #[test]
+    fn validate_ignores_mask_for_non_storage_predicates() {
+        let predicate = ValidityPredicate::Balance {
+            address: Address::repeat_byte(0x11),
+            op: ValidityOperator::Equal,
+            value: U256::MAX,
+        };
+
+        assert_eq!(predicate.validate(), Ok(()));
+    }
+
+    #[test]
+    fn validate_batch_rejects_empty() {
+        assert_eq!(
+            ValidityPredicate::validate_batch(&[], DEFAULT_MAX_VALIDITY_PREDICATES),
+            Err(ValidityPredicateError::Empty)
+        );
+    }
+
+    #[test]
+    fn validate_batch_rejects_too_many() {
+        let predicate = ValidityPredicate::Balance {
+            address: Address::ZERO,
+            op: ValidityOperator::Equal,
+            value: U256::ZERO,
+        };
+        let predicates = vec![predicate; DEFAULT_MAX_VALIDITY_PREDICATES + 1];
+
+        assert_eq!(
+            ValidityPredicate::validate_batch(&predicates, DEFAULT_MAX_VALIDITY_PREDICATES),
+            Err(ValidityPredicateError::TooMany {
+                count: DEFAULT_MAX_VALIDITY_PREDICATES + 1,
+                max: DEFAULT_MAX_VALIDITY_PREDICATES,
+            })
+        );
+    }
+
+    #[test]
+    fn validate_batch_accepts_valid_predicates() {
+        let predicates = vec![
+            ValidityPredicate::Balance {
+                address: Address::repeat_byte(0x11),
+                op: ValidityOperator::GreaterThanOrEqual,
+                value: U256::from(1),
+            },
+            ValidityPredicate::Storage {
+                address: Address::repeat_byte(0x22),
+                slot: U256::from(7),
+                mask: U256::from(0xff),
+                op: ValidityOperator::Equal,
+                value: U256::from(0xcd),
+            },
+        ];
+
+        assert_eq!(
+            ValidityPredicate::validate_batch(&predicates, DEFAULT_MAX_VALIDITY_PREDICATES),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn validate_batch_rejects_malformed_predicate() {
+        let predicates = vec![ValidityPredicate::Storage {
+            address: Address::repeat_byte(0x22),
+            slot: U256::from(7),
+            mask: U256::from(0xff),
+            op: ValidityOperator::Equal,
+            value: U256::from(0x100),
+        }];
+
+        assert_eq!(
+            ValidityPredicate::validate_batch(&predicates, DEFAULT_MAX_VALIDITY_PREDICATES),
+            Err(ValidityPredicateError::StorageValueOutsideMask)
         );
     }
 }

--- a/crates/execution/txpool/src/validity.rs
+++ b/crates/execution/txpool/src/validity.rs
@@ -30,8 +30,12 @@ pub enum ValidityPredicateError {
     ///
     /// Because the loaded storage value is masked before comparison, bits set in
     /// `value` outside `mask` could never match and indicate a malformed request.
-    #[error("storage predicate value has bits set outside its mask")]
-    StorageValueOutsideMask,
+    /// `index` is the position of the offending predicate within the batch.
+    #[error("storage predicate at index {index} has value bits set outside its mask")]
+    StorageValueOutsideMask {
+        /// Position of the offending predicate within the batch.
+        index: usize,
+    },
 }
 
 /// A comparison used by a [`ValidityPredicate`].
@@ -143,17 +147,13 @@ impl ValidityPredicate {
         U256::MAX
     }
 
-    /// Validates that this predicate's parameters are internally consistent.
+    /// Returns whether this predicate's parameters are internally consistent.
     ///
     /// A storage predicate's comparison value must not set any bits outside its
     /// mask, since the loaded value is masked before comparison.
-    pub fn validate(&self) -> Result<(), ValidityPredicateError> {
-        if let Self::Storage { mask, value, .. } = self
-            && (*value & !*mask) != U256::ZERO
-        {
-            return Err(ValidityPredicateError::StorageValueOutsideMask);
-        }
-        Ok(())
+    #[must_use]
+    pub fn has_valid_params(&self) -> bool {
+        !matches!(self, Self::Storage { mask, value, .. } if (*value & !*mask) != U256::ZERO)
     }
 
     /// Validates a batch of predicates submitted at ingress.
@@ -167,8 +167,10 @@ impl ValidityPredicate {
         if predicates.len() > max {
             return Err(ValidityPredicateError::TooMany { count: predicates.len(), max });
         }
-        for predicate in predicates {
-            predicate.validate()?;
+        for (index, predicate) in predicates.iter().enumerate() {
+            if !predicate.has_valid_params() {
+                return Err(ValidityPredicateError::StorageValueOutsideMask { index });
+            }
         }
         Ok(())
     }
@@ -235,7 +237,22 @@ impl ValidatedTransactionExtensions<BasePooledTransaction> for TransactionValidi
         Self { validity: tx.transaction.validity_predicates().to_vec() }
     }
 
+    /// Applies the predicates to the builder-inbound transaction.
+    ///
+    /// This is the builder RPC ingress path, distinct from the mempool node's
+    /// `base_sendRawTransactionValidity`. The count bound is enforced separately
+    /// by [`Self::validate`]; here each predicate's parameters are re-checked as
+    /// defense-in-depth against a misbehaving upstream. Unlike the mempool
+    /// ingress, an empty predicate set is not rejected: the builder legitimately
+    /// receives ordinary transactions that carry no predicates.
     fn apply(self, tx: BasePooledTransaction) -> Result<BasePooledTransaction, ExtensionError> {
+        for (index, predicate) in self.validity.iter().enumerate() {
+            if !predicate.has_valid_params() {
+                return Err(ExtensionError(format!(
+                    "storage predicate at index {index} has value bits set outside its mask"
+                )));
+            }
+        }
         Ok(tx.with_validity_predicates(self.validity))
     }
 }
@@ -581,7 +598,66 @@ mod tests {
     }
 
     #[test]
-    fn validate_accepts_storage_value_within_mask() {
+    fn apply_rejects_storage_value_outside_mask() {
+        let signed: BaseTransactionSigned = TxDeposit {
+            source_hash: Default::default(),
+            from: Address::ZERO,
+            to: TxKind::Create,
+            mint: 0,
+            value: U256::ZERO,
+            gas_limit: 21_000,
+            is_system_transaction: false,
+            input: Default::default(),
+        }
+        .into();
+        let encoded_length = signed.encode_2718_len();
+        let transaction = BasePooledTransaction::new(
+            Recovered::new_unchecked(signed, Address::ZERO),
+            encoded_length,
+        );
+        let extension = TransactionValidity {
+            validity: vec![ValidityPredicate::Storage {
+                address: Address::repeat_byte(0x22),
+                slot: U256::from(7),
+                mask: U256::from(0xff),
+                op: ValidityOperator::Equal,
+                value: U256::from(0x100),
+            }],
+        };
+
+        let error = extension.apply(transaction).unwrap_err();
+
+        assert!(error.to_string().contains("outside its mask"));
+    }
+
+    #[test]
+    fn apply_accepts_empty_predicates() {
+        let signed: BaseTransactionSigned = TxDeposit {
+            source_hash: Default::default(),
+            from: Address::ZERO,
+            to: TxKind::Create,
+            mint: 0,
+            value: U256::ZERO,
+            gas_limit: 21_000,
+            is_system_transaction: false,
+            input: Default::default(),
+        }
+        .into();
+        let encoded_length = signed.encode_2718_len();
+        let transaction = BasePooledTransaction::new(
+            Recovered::new_unchecked(signed, Address::ZERO),
+            encoded_length,
+        );
+
+        // The builder path legitimately receives ordinary transactions with no
+        // predicates; unlike the mempool ingress, `apply` must not reject them.
+        let transaction = TransactionValidity::default().apply(transaction).unwrap();
+
+        assert!(transaction.validity_predicates().is_empty());
+    }
+
+    #[test]
+    fn has_valid_params_accepts_storage_value_within_mask() {
         let predicate = ValidityPredicate::Storage {
             address: Address::repeat_byte(0x11),
             slot: U256::from(1),
@@ -590,11 +666,11 @@ mod tests {
             value: U256::from(0xab),
         };
 
-        assert_eq!(predicate.validate(), Ok(()));
+        assert!(predicate.has_valid_params());
     }
 
     #[test]
-    fn validate_rejects_storage_value_outside_mask() {
+    fn has_valid_params_rejects_storage_value_outside_mask() {
         let predicate = ValidityPredicate::Storage {
             address: Address::repeat_byte(0x11),
             slot: U256::from(1),
@@ -603,18 +679,18 @@ mod tests {
             value: U256::from(0x1ff),
         };
 
-        assert_eq!(predicate.validate(), Err(ValidityPredicateError::StorageValueOutsideMask));
+        assert!(!predicate.has_valid_params());
     }
 
     #[test]
-    fn validate_ignores_mask_for_non_storage_predicates() {
+    fn has_valid_params_ignores_mask_for_non_storage_predicates() {
         let predicate = ValidityPredicate::Balance {
             address: Address::repeat_byte(0x11),
             op: ValidityOperator::Equal,
             value: U256::MAX,
         };
 
-        assert_eq!(predicate.validate(), Ok(()));
+        assert!(predicate.has_valid_params());
     }
 
     #[test]
@@ -667,18 +743,24 @@ mod tests {
     }
 
     #[test]
-    fn validate_batch_rejects_malformed_predicate() {
-        let predicates = vec![ValidityPredicate::Storage {
+    fn validate_batch_rejects_malformed_predicate_reporting_its_index() {
+        let valid = ValidityPredicate::Balance {
+            address: Address::repeat_byte(0x11),
+            op: ValidityOperator::Equal,
+            value: U256::ZERO,
+        };
+        let malformed = ValidityPredicate::Storage {
             address: Address::repeat_byte(0x22),
             slot: U256::from(7),
             mask: U256::from(0xff),
             op: ValidityOperator::Equal,
             value: U256::from(0x100),
-        }];
+        };
+        let predicates = vec![valid, malformed];
 
         assert_eq!(
             ValidityPredicate::validate_batch(&predicates, DEFAULT_MAX_VALIDITY_PREDICATES),
-            Err(ValidityPredicateError::StorageValueOutsideMask)
+            Err(ValidityPredicateError::StorageValueOutsideMask { index: 1 })
         );
     }
 }


### PR DESCRIPTION
## Summary

Enforces the validity-predicate payload rules that do not depend on the transaction type at the base_sendRawTransactionValidity ingress. The ingress now rejects an empty validity list (a predicate-less submission has no advanced semantics) and rejects storage predicates whose comparison value has bits set outside its mask, since those bits could never match. The checks live in a reusable ValidityPredicate::validate_batch helper so the same gate can back future ingress paths, and the existing predicate-count bound is folded into it.

Implements BASE-276 (child of BASE-258).