### PR TITLE
refactor(eip8130): align error variant names with finalized Keystore.sol

### DIFF
--- a/crates/common/evm/src/eip8130.rs
+++ b/crates/common/evm/src/eip8130.rs
@@ -3173,7 +3173,7 @@ mod tests {
         // address must authorize and be *included* through the full
         // `Eip8130Executor::execute` pipeline — not just the unit-level
         // `authorize_and_apply`. Before the fix this returned
-        // `BaseTransactionError::Eip8130("...NotBound")` and was rejected at every
+        // `BaseTransactionError::Eip8130("...AuthenticatorMismatch")` and was rejected at every
         // flashblock. Non-empty runtime code mirrors the on-chain account.
         let key = signing_key(0xc1);
         let (derived, signed) = counterfactual_create_signed(&key, bytes!("00"), Vec::new());

--- a/crates/execution/eip8130/src/apply.rs
+++ b/crates/execution/eip8130/src/apply.rs
@@ -505,8 +505,10 @@ impl AccountChangeApplier {
                     sequence, state.multichain_sequence,
                     "multichain sequence must match the account's current multichain sequence",
                 );
-                state.multichain_sequence =
-                    state.multichain_sequence.checked_add(1).ok_or(ApplyError::SequenceSaturated)?;
+                state.multichain_sequence = state
+                    .multichain_sequence
+                    .checked_add(1)
+                    .ok_or(ApplyError::SequenceSaturated)?;
             }
         }
         Ok(())

--- a/crates/execution/eip8130/src/apply.rs
+++ b/crates/execution/eip8130/src/apply.rs
@@ -117,12 +117,12 @@ pub enum ApplyError {
     /// an ungated actor, or not exactly `manager(20) || commitment(32)` for a
     /// gated actor). Mirrors `_slicePolicy`.
     #[error("policy data does not match policy type")]
-    MalformedPolicyData,
+    InvalidPolicyData,
 
     /// Revoking an actor that is not currently authorized. Mirrors
     /// `_revokeActor`'s `require(isActor(...))`.
     #[error("actor {actor_id} is not authorized and cannot be revoked")]
-    NotAnActor {
+    UnknownActor {
         /// The actor id that was not an authorized actor.
         actor_id: B256,
     },
@@ -173,7 +173,7 @@ pub enum ApplyError {
     /// The account targeted by a create entry already has EIP-8130 state. Mirrors
     /// the CREATE2 collision that makes `createAccount` unrepeatable.
     #[error("account {account} is already created")]
-    AlreadyCreated {
+    AlreadyInitialized {
         /// The counterfactual address that already holds state.
         account: Address,
     },
@@ -767,7 +767,7 @@ impl AccountChangeApplier {
             return Ok(0);
         }
         if !is_self || state.default_eoa_revoked() {
-            return Err(ApplyError::NotAnActor { actor_id });
+            return Err(ApplyError::UnknownActor { actor_id });
         }
 
         // The inline self's `actor_config` slot is always empty (a zero-to-zero
@@ -807,7 +807,7 @@ impl AccountChangeApplier {
         config: ActorConfig,
     ) -> Result<(), ApplyError> {
         if config.authenticator == Address::ZERO {
-            return Err(ApplyError::NotAnActor { actor_id });
+            return Err(ApplyError::UnknownActor { actor_id });
         }
         storage.clear_actor_config(account, actor_id)?;
         storage.clear_policy(account, actor_id)?;
@@ -839,7 +839,7 @@ impl AccountChangeApplier {
         // initial actor (mirrors `createAccount`'s guard).
         let mut state = storage.get_account_state(address)?;
         if state.is_initialized() {
-            return Err(ApplyError::AlreadyCreated { account: address });
+            return Err(ApplyError::AlreadyInitialized { account: address });
         }
 
         // Mark initialized and disable the implicit default-EOA path by default
@@ -931,12 +931,12 @@ impl AccountChangeApplier {
     pub fn slice_policy(scope: u16, policy_data: &[u8]) -> Result<(Address, B256), ApplyError> {
         if scope & Eip8130Constants::SCOPE_POLICY == 0 {
             if !policy_data.is_empty() {
-                return Err(ApplyError::MalformedPolicyData);
+                return Err(ApplyError::InvalidPolicyData);
             }
             return Ok((Address::ZERO, B256::ZERO));
         }
         if policy_data.len() != Eip8130Constants::POLICY_DATA_LEN {
-            return Err(ApplyError::MalformedPolicyData);
+            return Err(ApplyError::InvalidPolicyData);
         }
         let manager = Address::from_slice(&policy_data[..20]);
         let commitment = B256::from_slice(&policy_data[20..Eip8130Constants::POLICY_DATA_LEN]);
@@ -1537,7 +1537,7 @@ mod tests {
         );
         assert_eq!(
             AccountChangeApplier::slice_policy(0, &[1]),
-            Err(ApplyError::MalformedPolicyData)
+            Err(ApplyError::InvalidPolicyData)
         );
 
         let mut data = Vec::new();
@@ -1551,7 +1551,7 @@ mod tests {
         // Wrong length rejects.
         assert_eq!(
             AccountChangeApplier::slice_policy(Eip8130Constants::SCOPE_POLICY, &data[..51]),
-            Err(ApplyError::MalformedPolicyData)
+            Err(ApplyError::InvalidPolicyData)
         );
         // Per the frozen rule, neither field need be nonzero: a zero
         // manager/commitment is well-formed (`manager(20) || commitment(32)`).
@@ -1580,7 +1580,7 @@ mod tests {
             assert!(acc.actor_config_slot(ACCOUNT, NON_SELF).unwrap().is_empty());
             assert_eq!(
                 AccountChangeApplier::revoke_actor(acc, ACCOUNT, NON_SELF),
-                Err(ApplyError::NotAnActor { actor_id: NON_SELF })
+                Err(ApplyError::UnknownActor { actor_id: NON_SELF })
             );
         });
     }
@@ -1607,7 +1607,7 @@ mod tests {
             let unrestricted = ActorConfig { authenticator: AUTHENTICATOR, scope: 0, expiry: 0 };
             assert_eq!(
                 AccountChangeApplier::authorize_actor(acc, ACCOUNT, NON_SELF, unrestricted, &data),
-                Err(ApplyError::MalformedPolicyData)
+                Err(ApplyError::InvalidPolicyData)
             );
 
             // SCOPE_POLICY actor accepted; policy slots written.
@@ -2067,7 +2067,7 @@ mod tests {
             // Re-creating the same account is rejected.
             assert_eq!(
                 AccountChangeApplier::apply_create(acc, &entry),
-                Err(ApplyError::AlreadyCreated { account: expected })
+                Err(ApplyError::AlreadyInitialized { account: expected })
             );
         });
     }
@@ -2098,7 +2098,7 @@ mod tests {
             // create must still reject (the guard checks both sequences).
             assert_eq!(
                 AccountChangeApplier::apply_create(acc, &entry),
-                Err(ApplyError::AlreadyCreated { account: expected })
+                Err(ApplyError::AlreadyInitialized { account: expected })
             );
         });
     }
@@ -2130,7 +2130,7 @@ mod tests {
 
             assert_eq!(
                 AccountChangeApplier::apply_create(acc, &entry),
-                Err(ApplyError::AlreadyCreated { account: expected })
+                Err(ApplyError::AlreadyInitialized { account: expected })
             );
         });
     }

--- a/crates/execution/eip8130/src/apply.rs
+++ b/crates/execution/eip8130/src/apply.rs
@@ -78,12 +78,12 @@ pub enum ApplyError {
     #[error("local epoch is saturated and cannot be incremented")]
     EpochSaturated,
 
-    /// A signed batch carried an environment op (`Lock` or `Unlock`) whose apply
-    /// handler is not yet enshrined. These ops are wired into the apply path by a
-    /// subsequent change; until then a batch carrying one is rejected rather than
-    /// silently ignored.
-    #[error("unsupported account-change op in the enshrined apply path")]
-    UnsupportedChangeType,
+    /// A signed batch carried an unrecognized or not-yet-enshrined change type
+    /// (currently `Lock` / `Unlock`, whose apply handlers are wired by a
+    /// subsequent change). Mirrors `Keystore.UnknownChangeType`: rejected rather
+    /// than silently ignored.
+    #[error("unknown account-change op in the enshrined apply path")]
+    UnknownChangeType,
 
     /// The operation is not permitted while the account is locked. Mirrors
     /// `Keystore.AccountIsLocked`.
@@ -215,9 +215,10 @@ pub enum ApplyError {
         account: Address,
     },
 
-    /// A channel sequence would overflow `u64`.
-    #[error("account-change sequence overflow")]
-    SequenceOverflow,
+    /// A channel's sequence counter is at its terminal value and cannot advance.
+    /// Mirrors `Keystore.SequenceSaturated`.
+    #[error("account-change channel sequence is saturated")]
+    SequenceSaturated,
 }
 
 /// A created account's deferred code write: its counterfactual address and the
@@ -459,7 +460,7 @@ impl AccountChangeApplier {
                 }
                 // Lock / Unlock apply handlers are not yet enshrined.
                 ChangeType::Lock | ChangeType::Unlock => {
-                    return Err(ApplyError::UnsupportedChangeType);
+                    return Err(ApplyError::UnknownChangeType);
                 }
             }
         }
@@ -497,7 +498,7 @@ impl AccountChangeApplier {
                 let seq = sequence as u32;
                 if seq != Eip8130Constants::UNSEQUENCED {
                     state.local_sequence =
-                        u64::from(seq).checked_add(1).ok_or(ApplyError::SequenceOverflow)?;
+                        u64::from(seq).checked_add(1).ok_or(ApplyError::SequenceSaturated)?;
                 } else if !state.is_initialized() {
                     state.local_sequence = 1;
                 }
@@ -513,7 +514,7 @@ impl AccountChangeApplier {
                     "multichain sequence must match the account's current multichain sequence",
                 );
                 state.multichain_sequence =
-                    state.multichain_sequence.checked_add(1).ok_or(ApplyError::SequenceOverflow)?;
+                    state.multichain_sequence.checked_add(1).ok_or(ApplyError::SequenceSaturated)?;
             }
         }
         Ok(())

--- a/crates/execution/eip8130/src/apply.rs
+++ b/crates/execution/eip8130/src/apply.rs
@@ -1535,10 +1535,7 @@ mod tests {
             AccountChangeApplier::slice_policy(0, &[]).unwrap(),
             (Address::ZERO, B256::ZERO)
         );
-        assert_eq!(
-            AccountChangeApplier::slice_policy(0, &[1]),
-            Err(ApplyError::InvalidPolicyData)
-        );
+        assert_eq!(AccountChangeApplier::slice_policy(0, &[1]), Err(ApplyError::InvalidPolicyData));
 
         let mut data = Vec::new();
         data.extend_from_slice(MANAGER.as_slice());

--- a/crates/execution/eip8130/src/apply.rs
+++ b/crates/execution/eip8130/src/apply.rs
@@ -164,7 +164,7 @@ pub enum ApplyError {
 
     /// The account targeted by a create entry already has EIP-8130 state. Mirrors
     /// the CREATE2 collision that makes `createAccount` unrepeatable.
-    #[error("account {account} is already created")]
+    #[error("account {account} is already initialized")]
     AlreadyInitialized {
         /// The counterfactual address that already holds state.
         account: Address,

--- a/crates/execution/eip8130/src/apply.rs
+++ b/crates/execution/eip8130/src/apply.rs
@@ -119,14 +119,6 @@ pub enum ApplyError {
     #[error("policy data does not match policy type")]
     InvalidPolicyData,
 
-    /// Revoking an actor that is not currently authorized. Mirrors
-    /// `_revokeActor`'s `require(isActor(...))`.
-    #[error("actor {actor_id} is not authorized and cannot be revoked")]
-    UnknownActor {
-        /// The actor id that was not an authorized actor.
-        actor_id: B256,
-    },
-
     /// A create entry had no initial actors. Mirrors
     /// `require(initialActors.length > 0)`.
     #[error("create entry has no initial actors")]
@@ -736,6 +728,10 @@ impl AccountChangeApplier {
     ///   on how many of its policy slots were written non-zero — a gated actor may
     ///   still carry a zero manager and/or commitment (see [`Self::slice_policy`]),
     ///   which are zero-to-zero no-ops rather than real resets.
+    /// - An **absent** actor revoke is an idempotent no-op (mirrors
+    ///   `_applyRevoke`'s early return, eip-8130 #100) and returns `3`: all three
+    ///   conservatively reset-priced slots are empty, so the whole revoke is
+    ///   discounted.
     ///
     /// The authorize/create paths maintain mutual exclusion between the inline
     /// secp256k1 self key and an explicit non-k1 self actor. This method does not
@@ -768,7 +764,14 @@ impl AccountChangeApplier {
             return Ok(0);
         }
         if !is_self || state.default_eoa_revoked() {
-            return Err(ApplyError::UnknownActor { actor_id });
+            // Idempotent: the actor is already absent — no explicit `actor_config`
+            // entry, and either a non-self id or a self whose inline secp256k1 key
+            // is revoked. Mirrors `_applyRevoke`'s `if (!_isAuthorized(...)) return;`
+            // (eip-8130 #100): no state change and no `ActorRevoked` event. All
+            // three conservatively reset-priced revoke slots (`actor_config` and
+            // both policy slots) are empty for an absent actor, so the whole revoke
+            // is discounted.
+            return Ok(3);
         }
 
         // The inline self's `actor_config` slot is always empty (a zero-to-zero
@@ -808,7 +811,9 @@ impl AccountChangeApplier {
         config: ActorConfig,
     ) -> Result<(), ApplyError> {
         if config.authenticator == Address::ZERO {
-            return Err(ApplyError::UnknownActor { actor_id });
+            // Idempotent: an absent actor is a no-op (no clear, no event), mirroring
+            // `_applyRevoke`'s early return when `!_isAuthorized` (eip-8130 #100).
+            return Ok(());
         }
         storage.clear_actor_config(account, actor_id)?;
         storage.clear_policy(account, actor_id)?;
@@ -1576,11 +1581,30 @@ mod tests {
             // Revoke clears the slot.
             AccountChangeApplier::revoke_actor(acc, ACCOUNT, NON_SELF).unwrap();
             assert!(acc.actor_config_slot(ACCOUNT, NON_SELF).unwrap().is_empty());
-            assert_eq!(
-                AccountChangeApplier::revoke_actor(acc, ACCOUNT, NON_SELF),
-                Err(ApplyError::UnknownActor { actor_id: NON_SELF })
-            );
+            // Revoking an already-absent actor is idempotent: a no-op, not an
+            // error (mirrors `_applyRevoke`'s early return, eip-8130 #100).
+            assert_eq!(AccountChangeApplier::revoke_actor(acc, ACCOUNT, NON_SELF), Ok(()));
+            assert!(acc.actor_config_slot(ACCOUNT, NON_SELF).unwrap().is_empty());
         });
+    }
+
+    #[test]
+    fn revoke_absent_actor_is_idempotent_noop_with_full_discount() {
+        // Revoking an actor that was never authorized mirrors `_applyRevoke`'s
+        // `if (!_isAuthorized(...)) return;` (eip-8130 #100): a no-op that emits
+        // no `ActorRevoked` event and discounts all three conservatively
+        // reset-priced revoke slots (they are all empty for an absent actor).
+        let events = with_storage_events(|acc| {
+            let mut state = acc.get_account_state(ACCOUNT).unwrap();
+            assert_eq!(
+                AccountChangeApplier::revoke_actor_with_account_state(
+                    acc, ACCOUNT, NON_SELF, &mut state
+                ),
+                Ok(3),
+            );
+            assert!(acc.actor_config_slot(ACCOUNT, NON_SELF).unwrap().is_empty());
+        });
+        assert!(events.is_empty(), "a no-op revoke must not emit ActorRevoked");
     }
 
     #[test]

--- a/crates/execution/eip8130/src/authorize.rs
+++ b/crates/execution/eip8130/src/authorize.rs
@@ -806,7 +806,7 @@ mod tests {
     }
 
     #[test]
-    fn delegate_to_zero_address_is_rejected_as_zero_actor() {
+    fn delegate_to_zero_address_is_rejected_as_authentication_failed() {
         // A delegate to address(0) yields an outer actor id of bytes32(0).
         let nested_key = k1_key(0x44);
         let nested_id = actor_id(k1_address(&nested_key));

--- a/crates/execution/eip8130/src/authorize.rs
+++ b/crates/execution/eip8130/src/authorize.rs
@@ -191,7 +191,7 @@ impl ActorAuthorizer {
             }
             // 0 = no expiry; otherwise valid while now <= expiry.
             if state.default_eoa_expiry != 0 && now > state.default_eoa_expiry {
-                return Err(AuthorizeError::Expired {
+                return Err(AuthorizeError::ActorExpired {
                     actor_id: recovered,
                     expiry: state.default_eoa_expiry,
                 });
@@ -226,15 +226,15 @@ impl ActorAuthorizer {
         now: u64,
     ) -> Result<ResolvedActor, AuthorizeError> {
         if actor_id.is_zero() {
-            return Err(AuthorizeError::ZeroActor);
+            return Err(AuthorizeError::AuthenticationFailed);
         }
         let config = storage.actor_config_slot(account, actor_id)?;
         if config.authenticator != authenticator {
-            return Err(AuthorizeError::NotBound { actor_id, authenticator });
+            return Err(AuthorizeError::AuthenticatorMismatch { actor_id, authenticator });
         }
         // 0 = no expiry; otherwise valid while now <= expiry.
         if config.expiry != 0 && now > config.expiry {
-            return Err(AuthorizeError::Expired { actor_id, expiry: config.expiry });
+            return Err(AuthorizeError::ActorExpired { actor_id, expiry: config.expiry });
         }
         // `_resolvePolicyTarget`: address(0) when ungated, else the policy manager
         // (never the signed commitment). Resolved from the `config` already in
@@ -397,7 +397,7 @@ mod tests {
             acc.account_state.at_mut(&account).write(pack_self(0, NOW - 1, false)).unwrap();
             assert_eq!(
                 ActorAuthorizer::authenticate_actor(acc, account, HASH, &auth, NOW),
-                Err(AuthorizeError::Expired { actor_id: actor_id(account), expiry: NOW - 1 }),
+                Err(AuthorizeError::ActorExpired { actor_id: actor_id(account), expiry: NOW - 1 }),
             );
         });
     }
@@ -434,7 +434,7 @@ mod tests {
         with_storage(|acc| {
             assert_eq!(
                 ActorAuthorizer::authenticate_actor(acc, ACCOUNT, HASH, &auth, NOW),
-                Err(AuthorizeError::NotBound {
+                Err(AuthorizeError::AuthenticatorMismatch {
                     actor_id: id,
                     authenticator: Eip8130Constants::K1_AUTHENTICATOR,
                 }),
@@ -475,7 +475,7 @@ mod tests {
         with_storage(|acc| {
             assert_eq!(
                 ActorAuthorizer::authenticate_actor(acc, ACCOUNT, HASH, &auth, NOW),
-                Err(AuthorizeError::NotBound {
+                Err(AuthorizeError::AuthenticatorMismatch {
                     actor_id: id,
                     authenticator: Eip8130Constants::K1_AUTHENTICATOR,
                 }),
@@ -499,7 +499,7 @@ mod tests {
             // Expired once now > expiry.
             assert_eq!(
                 ActorAuthorizer::authenticate_actor(acc, ACCOUNT, HASH, &auth, 501),
-                Err(AuthorizeError::Expired { actor_id: id, expiry: 500 }),
+                Err(AuthorizeError::ActorExpired { actor_id: id, expiry: 500 }),
             );
         });
     }
@@ -675,7 +675,7 @@ mod tests {
                 .unwrap();
             assert_eq!(
                 ActorAuthorizer::authenticate_actor(acc, ACCOUNT, HASH, &auth, NOW),
-                Err(AuthorizeError::NotBound {
+                Err(AuthorizeError::AuthenticatorMismatch {
                     actor_id: nested_id,
                     authenticator: Eip8130Constants::K1_AUTHENTICATOR,
                 }),
@@ -710,7 +710,7 @@ mod tests {
         // EOA as parent: nested k1 recovers to the delegate account itself,
         // with no `actor_config` entry — only the live inline default EOA.
         // `DelegateAuthenticator` → `authenticateActor` must honor that path;
-        // bare `resolve_bound` would incorrectly return NotBound.
+        // bare `resolve_bound` would incorrectly return AuthenticatorMismatch.
         let nested_key = k1_key(0x55);
         let delegate_account = k1_address(&nested_key);
         let outer_id = actor_id(delegate_account);
@@ -797,7 +797,7 @@ mod tests {
                 .unwrap();
             assert_eq!(
                 ActorAuthorizer::authenticate_actor(acc, ACCOUNT, HASH, &auth, NOW),
-                Err(AuthorizeError::NotBound {
+                Err(AuthorizeError::AuthenticatorMismatch {
                     actor_id: outer_id,
                     authenticator: Eip8130Contracts::DELEGATE_AUTHENTICATOR,
                 }),
@@ -821,7 +821,7 @@ mod tests {
                 .unwrap();
             assert_eq!(
                 ActorAuthorizer::authenticate_actor(acc, ACCOUNT, HASH, &auth, NOW),
-                Err(AuthorizeError::ZeroActor),
+                Err(AuthorizeError::AuthenticationFailed),
             );
         });
     }

--- a/crates/execution/eip8130/src/authorize_error.rs
+++ b/crates/execution/eip8130/src/authorize_error.rs
@@ -22,15 +22,16 @@ pub enum AuthorizeError {
     Storage(#[from] BasePrecompileError),
 
     /// The resolved actor id was zero (e.g. a delegate to `address(0)`). Mirrors
-    /// the contract's `require(actorId != bytes32(0))`.
+    /// `Keystore.AuthenticationFailed` (`require(actorId != bytes32(0))`).
     #[error("resolved actor id is zero")]
-    ZeroActor,
+    AuthenticationFailed,
 
     /// The resolved actor is not bound to the authenticator that signed for it on
     /// this account (`actor_config.authenticator != authenticator`), so the actor
-    /// is unknown, revoked, or registered under a different authenticator.
+    /// is unknown, revoked, or registered under a different authenticator. Mirrors
+    /// `Keystore.AuthenticatorMismatch`.
     #[error("actor {actor_id} is not bound to authenticator {authenticator} on the account")]
-    NotBound {
+    AuthenticatorMismatch {
         /// The resolved actor id whose binding check failed.
         actor_id: B256,
         /// The authenticator that signed and was expected to be bound.
@@ -49,8 +50,9 @@ pub enum AuthorizeError {
     },
 
     /// The resolved actor's configured expiry has passed (`now > expiry`).
+    /// Mirrors `Keystore.ActorExpired`.
     #[error("actor {actor_id} expired at {expiry}")]
-    Expired {
+    ActorExpired {
         /// The resolved actor id that is expired.
         actor_id: B256,
         /// The Unix-seconds expiry that was exceeded.

--- a/crates/execution/eip8130/src/config.rs
+++ b/crates/execution/eip8130/src/config.rs
@@ -12,10 +12,10 @@ use crate::{
 /// Precomputed `keccak256` typehash of the `SignedAccountChanges` struct, matching
 /// the one hashed by `Keystore` (the trailing `AccountChange(...)` is the
 /// referenced struct's type, per the EIP-712 encoding rules):
-/// `keccak256("SignedAccountChanges(address account,uint256 chainId,uint64 sequence,AccountChange[] changes)AccountChange(uint8 changeType,bytes payload)")`.
+/// `keccak256("SignedAccountChangeBatch(address account,uint256 chainId,uint64 sequence,AccountChange[] changes)AccountChange(uint8 changeType,bytes payload)")`.
 /// Pinned to its preimage by `typehashes_match_their_preimages`.
 const SIGNED_ACCOUNT_CHANGES_TYPEHASH: B256 =
-    b256!("7f229a23553aa919fdcad551f55a0532adae8076aac7b11fb3b6ac2efe5821ce");
+    b256!("bee0c72c3efba751405b4c241f52736439f7e1e2a804925d36ddc9a6e1aa3614");
 /// Precomputed `keccak256` typehash for the per-change `AccountChange` leaves:
 /// `keccak256("AccountChange(uint8 changeType,bytes payload)")`.
 /// Pinned to its preimage by `typehashes_match_their_preimages`.
@@ -199,7 +199,7 @@ mod tests {
         assert_eq!(
             SIGNED_ACCOUNT_CHANGES_TYPEHASH,
             keccak256(
-                b"SignedAccountChanges(address account,uint256 chainId,uint64 sequence,AccountChange[] changes)AccountChange(uint8 changeType,bytes payload)"
+                b"SignedAccountChangeBatch(address account,uint256 chainId,uint64 sequence,AccountChange[] changes)AccountChange(uint8 changeType,bytes payload)"
             )
         );
         assert_eq!(

--- a/crates/execution/eip8130/src/config.rs
+++ b/crates/execution/eip8130/src/config.rs
@@ -117,7 +117,7 @@ impl ConfigChangeAuthorizer {
                 // must match the account's current local sequence.
                 if seq != Eip8130Constants::UNSEQUENCED {
                     if u64::from(seq) != state.local_sequence {
-                        return Err(TxAuthError::ConfigSequence {
+                        return Err(TxAuthError::BadSequence {
                             expected: state.local_sequence,
                             got: u64::from(seq),
                         });
@@ -129,7 +129,7 @@ impl ConfigChangeAuthorizer {
             }
             AccountChangeChannel::Multichain => {
                 if change.sequence != state.multichain_sequence {
-                    return Err(TxAuthError::ConfigSequence {
+                    return Err(TxAuthError::BadSequence {
                         expected: state.multichain_sequence,
                         got: change.sequence,
                     });
@@ -407,7 +407,7 @@ mod tests {
         with_storage(|acc| {
             assert_eq!(
                 ConfigChangeAuthorizer::authorize(acc, account, LOCAL, &change, NOW),
-                Err(TxAuthError::ConfigSequence { expected: 0, got: 5 }),
+                Err(TxAuthError::BadSequence { expected: 0, got: 5 }),
             );
         });
     }
@@ -463,7 +463,7 @@ mod tests {
             // The recovered signer is not the account and has no registered actor.
             assert_eq!(
                 ConfigChangeAuthorizer::authorize(acc, account, LOCAL, &change, NOW),
-                Err(TxAuthError::Authorize(AuthorizeError::NotBound {
+                Err(TxAuthError::Authorize(AuthorizeError::AuthenticatorMismatch {
                     actor_id: attacker_id,
                     authenticator: Eip8130Constants::K1_AUTHENTICATOR,
                 })),

--- a/crates/execution/eip8130/src/config.rs
+++ b/crates/execution/eip8130/src/config.rs
@@ -9,7 +9,7 @@ use crate::{
     ResolvedActor, TxAuthError,
 };
 
-/// Precomputed `keccak256` typehash of the `SignedAccountChanges` struct, matching
+/// Precomputed `keccak256` typehash of the `SignedAccountChangeBatch` struct, matching
 /// the one hashed by `Keystore` (the trailing `AccountChange(...)` is the
 /// referenced struct's type, per the EIP-712 encoding rules):
 /// `keccak256("SignedAccountChangeBatch(address account,uint256 chainId,uint64 sequence,AccountChange[] changes)AccountChange(uint8 changeType,bytes payload)")`.

--- a/crates/execution/eip8130/src/signature.rs
+++ b/crates/execution/eip8130/src/signature.rs
@@ -75,7 +75,7 @@ pub enum SignatureError {
     /// The envelope was empty (missing its leading `sigType` byte). Mirrors
     /// `EmptySignatureEnvelope`.
     #[error("signature envelope is empty (missing its leading sigType byte)")]
-    EmptyEnvelope,
+    EmptySignatureEnvelope,
 
     /// The leading `sigType` byte is not a recognized [`SignatureType`] (it was
     /// `Invalid` or out of range). Mirrors `UnknownSignatureType`.
@@ -143,7 +143,7 @@ impl SignatureVerifier {
         local_chain_id: u64,
         now: u64,
     ) -> Result<ResolvedActor, SignatureError> {
-        let (&sig_type_byte, inner) = auth.split_first().ok_or(SignatureError::EmptyEnvelope)?;
+        let (&sig_type_byte, inner) = auth.split_first().ok_or(SignatureError::EmptySignatureEnvelope)?;
         let sig_type = SignatureType::from_byte(sig_type_byte)
             .ok_or(SignatureError::UnknownSignatureType(sig_type_byte))?;
         let digest = Self::envelope_digest(sig_type, account, hash, local_chain_id);
@@ -239,7 +239,7 @@ mod tests {
         with_storage(|acc| {
             assert_eq!(
                 SignatureVerifier::validate_signature(acc, ACCOUNT, HASH, &[], CHAIN_ID, NOW),
-                Err(SignatureError::EmptyEnvelope),
+                Err(SignatureError::EmptySignatureEnvelope),
             );
         });
     }
@@ -306,10 +306,10 @@ mod tests {
         let auth = envelope(SignatureType::Local as u8, K1, &sig(&k, digest));
         with_storage(|acc| {
             acc.actor_config.at_mut(&id).at_mut(&ACCOUNT).write(pack(K1, 0, 0)).unwrap();
-            // Recovers a different actor id than the one bound: NotBound.
+            // Recovers a different actor id than the one bound: AuthenticatorMismatch.
             assert!(matches!(
                 SignatureVerifier::validate_signature(acc, ACCOUNT, HASH, &auth, CHAIN_ID + 1, NOW,),
-                Err(SignatureError::Authenticate(AuthorizeError::NotBound { .. })),
+                Err(SignatureError::Authenticate(AuthorizeError::AuthenticatorMismatch { .. })),
             ));
         });
     }

--- a/crates/execution/eip8130/src/signature.rs
+++ b/crates/execution/eip8130/src/signature.rs
@@ -143,7 +143,8 @@ impl SignatureVerifier {
         local_chain_id: u64,
         now: u64,
     ) -> Result<ResolvedActor, SignatureError> {
-        let (&sig_type_byte, inner) = auth.split_first().ok_or(SignatureError::EmptySignatureEnvelope)?;
+        let (&sig_type_byte, inner) =
+            auth.split_first().ok_or(SignatureError::EmptySignatureEnvelope)?;
         let sig_type = SignatureType::from_byte(sig_type_byte)
             .ok_or(SignatureError::UnknownSignatureType(sig_type_byte))?;
         let digest = Self::envelope_digest(sig_type, account, hash, local_chain_id);

--- a/crates/execution/eip8130/src/signature.rs
+++ b/crates/execution/eip8130/src/signature.rs
@@ -19,9 +19,9 @@ use crate::{AccountConfigurationStorage, ActorAuthorizer, AuthorizeError, Resolv
 
 /// Precomputed `keccak256` typehash of the replay-safe signed-message struct,
 /// matching `Keystore.SIGNED_MESSAGE_TYPEHASH`:
-/// `keccak256("EIP8130SignedMessage(address account,uint256 chainId,bytes32 hash)")`.
+/// `keccak256("SignedMessageEnvelope(address account,uint256 chainId,bytes32 hash)")`.
 const SIGNED_MESSAGE_TYPEHASH: B256 =
-    b256!("9d2bc80c29f8a3962243919d898fa1b566a99dc64dd59734f6a10e20be3a7e04");
+    b256!("9bc1b3ab5fdd3e5a2f41b687d0f20e02a512f6f13da58a2f35b2bae1262a050c");
 
 /// The replay channel a typed signature envelope binds to. Mirrors
 /// `Keystore.SignatureType`: the leading envelope byte is `Local` (`0x01`,
@@ -171,7 +171,7 @@ mod tests {
     fn typehash_matches_string() {
         assert_eq!(
             SIGNED_MESSAGE_TYPEHASH,
-            keccak256(b"EIP8130SignedMessage(address account,uint256 chainId,bytes32 hash)")
+            keccak256(b"SignedMessageEnvelope(address account,uint256 chainId,bytes32 hash)")
         );
     }
 

--- a/crates/execution/eip8130/src/transaction.rs
+++ b/crates/execution/eip8130/src/transaction.rs
@@ -224,7 +224,7 @@ impl TransactionAuthorizer {
         sender: &AuthorizedActor,
     ) -> Result<(), TxAuthError> {
         if storage.is_locked(sender.account, now).map_err(AuthorizeError::Storage)? {
-            return Err(TxAuthError::AccountLocked);
+            return Err(TxAuthError::AccountIsLocked);
         }
 
         if !sender.resolved.is_admin() {
@@ -450,7 +450,7 @@ mod tests {
         with_storage(|acc| {
             assert_eq!(
                 TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW),
-                Err(TxAuthError::ConfigSequence { expected: 1, got: 0 }),
+                Err(TxAuthError::BadSequence { expected: 1, got: 0 }),
             );
         });
     }
@@ -656,7 +656,7 @@ mod tests {
                 .unwrap();
             assert_eq!(
                 TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW),
-                Err(TxAuthError::AccountLocked),
+                Err(TxAuthError::AccountIsLocked),
             );
         });
     }
@@ -984,7 +984,7 @@ mod tests {
     fn counterfactual_create_authorizes_on_empty_account() {
         // A counterfactual smart-account CREATE must succeed even though the
         // account does not yet exist in storage (actor_config is empty). Before
-        // the fix this returned `NotBound` because `resolve_bound` ran against
+        // the fix this returned `AuthenticatorMismatch` because `resolve_bound` ran against
         // an empty account before `apply_create` could install `initial_actors`.
         let k = key(0xc1);
         let (derived, signed) = create_tx_and_signed(&k, vec![]);
@@ -1110,7 +1110,7 @@ mod tests {
             assert!(
                 matches!(
                     TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW),
-                    Err(TxAuthError::Authorize(AuthorizeError::NotBound { .. }))
+                    Err(TxAuthError::Authorize(AuthorizeError::AuthenticatorMismatch { .. }))
                 ),
                 "signer not in initial_actors must be rejected"
             );

--- a/crates/execution/eip8130/src/tx_error.rs
+++ b/crates/execution/eip8130/src/tx_error.rs
@@ -39,7 +39,7 @@ pub enum TxAuthError {
     /// is permitted when the grant outlives the unlock floor; see
     /// [`crate::AccountChangeApplier`]. Mirrors `Keystore.AccountIsLocked`.
     #[error("account is locked")]
-    AccountLocked,
+    AccountIsLocked,
 
     /// A delegation was not authorized by an admin (unrestricted) actor on the
     /// unlocked account.
@@ -52,7 +52,7 @@ pub enum TxAuthError {
     /// signed digest would not match the value that will actually be applied).
     /// Mirrors `Keystore.BadSequence`.
     #[error("config change sequence {got} does not match the expected {expected}")]
-    ConfigSequence {
+    BadSequence {
         /// The sequence read from the account's state for the batch's channel.
         expected: u64,
         /// The sequence carried by the signed account-change batch.

--- a/crates/execution/eip8130/src/verify.rs
+++ b/crates/execution/eip8130/src/verify.rs
@@ -447,7 +447,7 @@ mod tests {
             // that is not bound on the payer account.
             assert!(matches!(
                 ActorTxVerifier::verify(&signed, acc, NOW),
-                Err(TxAuthError::Authorize(AuthorizeError::NotBound { .. })),
+                Err(TxAuthError::Authorize(AuthorizeError::AuthenticatorMismatch { .. })),
             ));
         });
     }
@@ -515,7 +515,7 @@ mod tests {
             // No actor seeded: the sender actor is not bound on the account.
             assert!(matches!(
                 ActorTxVerifier::verify(&signed, acc, NOW),
-                Err(TxAuthError::Authorize(AuthorizeError::NotBound { .. })),
+                Err(TxAuthError::Authorize(AuthorizeError::AuthenticatorMismatch { .. })),
             ));
         });
     }

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -1526,7 +1526,9 @@ where
             TxAuthError::Authorize(AuthorizeError::DefaultEoaRevoked { .. }) => {
                 "default EOA actor is revoked"
             }
-            TxAuthError::Authorize(AuthorizeError::ActorExpired { .. }) => "actor credential expired",
+            TxAuthError::Authorize(AuthorizeError::ActorExpired { .. }) => {
+                "actor credential expired"
+            }
             TxAuthError::Authorize(AuthorizeError::NestedSignatureScope { .. }) => {
                 "delegate nested actor lacks SIGNATURE scope"
             }

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -1557,7 +1557,7 @@ where
             ApplyError::MalformedRevokeData => "actor change revoke data is malformed",
             ApplyError::InvalidChangePayload => "account-change op payload must be empty",
             ApplyError::EpochSaturated => "local epoch is saturated",
-            ApplyError::UnsupportedChangeType => "unsupported account-change op",
+            ApplyError::UnknownChangeType => "unknown account-change op",
             ApplyError::AccountIsLocked => "account is locked",
             ApplyError::ExpiryDoesNotOutliveUnlock => {
                 "authorize expiry does not outlive the unlock floor"
@@ -1580,7 +1580,7 @@ where
             ApplyError::MultipleDelegations => "at most one delegation is allowed",
             ApplyError::CreateAndDelegation => "create and delegation may not coexist",
             ApplyError::NonDelegatableCode { .. } => "delegation sender has non-delegation code",
-            ApplyError::SequenceOverflow => "config change sequence overflow",
+            ApplyError::SequenceSaturated => "config change sequence is saturated",
             ApplyError::EmptyChangeSet => "signed account-change batch is empty",
         }
     }

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -1565,7 +1565,6 @@ where
             ApplyError::InvalidActorId => "actor id bytes32(0) is reserved",
             ApplyError::InvalidAuthenticator => "actor authenticator is not canonical",
             ApplyError::InvalidPolicyData => "actor policy data is malformed",
-            ApplyError::UnknownActor { .. } => "revoked actor is not authorized",
             ApplyError::NoInitialActors => "create entry has no initial actors",
             ApplyError::ActorsNotSortedOrDuplicate => {
                 "create initial actors are not strictly ascending"

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -1519,20 +1519,22 @@ where
             TxAuthError::Authorize(AuthorizeError::Storage(_)) => {
                 "account configuration read failed"
             }
-            TxAuthError::Authorize(AuthorizeError::ZeroActor) => "actor id is zero",
-            TxAuthError::Authorize(AuthorizeError::NotBound { .. }) => "actor is not bound",
+            TxAuthError::Authorize(AuthorizeError::AuthenticationFailed) => "actor id is zero",
+            TxAuthError::Authorize(AuthorizeError::AuthenticatorMismatch { .. }) => {
+                "actor is not bound"
+            }
             TxAuthError::Authorize(AuthorizeError::DefaultEoaRevoked { .. }) => {
                 "default EOA actor is revoked"
             }
-            TxAuthError::Authorize(AuthorizeError::Expired { .. }) => "actor credential expired",
+            TxAuthError::Authorize(AuthorizeError::ActorExpired { .. }) => "actor credential expired",
             TxAuthError::Authorize(AuthorizeError::NestedSignatureScope { .. }) => {
                 "delegate nested actor lacks SIGNATURE scope"
             }
             TxAuthError::SenderRecovery => "EOA sender recovery failed",
             TxAuthError::Scope { .. } => "actor scope insufficient",
-            TxAuthError::AccountLocked => "account is locked",
+            TxAuthError::AccountIsLocked => "account is locked",
             TxAuthError::DelegationUnauthorized => "delegation requires admin actor",
-            TxAuthError::ConfigSequence { .. } => "config change sequence mismatch",
+            TxAuthError::BadSequence { .. } => "config change sequence mismatch",
             TxAuthError::StaleEpoch { .. } => "config change local epoch is stale",
             TxAuthError::SequenceSaturated => "config change channel sequence is saturated",
             TxAuthError::Apply(apply) => Self::map_apply_error(apply),
@@ -1560,8 +1562,8 @@ where
             }
             ApplyError::InvalidActorId => "actor id bytes32(0) is reserved",
             ApplyError::InvalidAuthenticator => "actor authenticator is not canonical",
-            ApplyError::MalformedPolicyData => "actor policy data is malformed",
-            ApplyError::NotAnActor { .. } => "revoked actor is not authorized",
+            ApplyError::InvalidPolicyData => "actor policy data is malformed",
+            ApplyError::UnknownActor { .. } => "revoked actor is not authorized",
             ApplyError::NoInitialActors => "create entry has no initial actors",
             ApplyError::ActorsNotSortedOrDuplicate => {
                 "create initial actors are not strictly ascending"
@@ -1570,7 +1572,7 @@ where
             ApplyError::BytecodeTooLarge => "create bytecode exceeds the size limit",
             ApplyError::CreateCodeExceedsMaxSize => "create bytecode exceeds MAX_CODE_SIZE",
             ApplyError::CreateCodeStartsWithEf => "create bytecode begins with 0xEF",
-            ApplyError::AlreadyCreated { .. } => "create account already exists",
+            ApplyError::AlreadyInitialized { .. } => "create account already exists",
             ApplyError::CreateAddressMismatch { .. } => "create address does not match the sender",
             ApplyError::InvalidCreatePosition => "create entry must be the only one, at index 0",
             ApplyError::MultipleDelegations => "at most one delegation is allowed",
@@ -3608,7 +3610,7 @@ mod tests {
     /// freshly-created account's evolving state (the create installs an
     /// unrestricted owner; the config change then advances the multichain
     /// channel from sequence 0). If the overlay did not persist the create's
-    /// storage transitions, the config change would fail with `NotBound`.
+    /// storage transitions, the config change would fail with `AuthenticatorMismatch`.
     #[test]
     fn admits_eip8130_create_then_config_change_via_overlay() {
         let signer = PrivateKeySigner::random();


### PR DESCRIPTION
## Summary

Audit follow-up: aligns the node-side EIP-8130 error variant names with the revert names in the reference [`Keystore.sol`](https://github.com/base/eip-8130/blob/fix/import-confirm-digest/src/Keystore.sol) (tracked against [eip-8130#100](https://github.com/base/eip-8130/pull/100)), so enshrined-path rejection reasons map 1:1 with the contract during the parity audit. Debugging fields (`expected`/`got`, `actor_id`, `authenticator`, `expiry`, `account`) are intentionally kept — they're node-side context and don't affect parity.

### Renames

| Old (Rust) | New (matches Solidity) |
|---|---|
| `ApplyError::MalformedPolicyData` | `InvalidPolicyData` |
| `ApplyError::NotAnActor` | `UnknownActor` |
| `ApplyError::AlreadyCreated` | `AlreadyInitialized` |
| `ApplyError::UnsupportedChangeType` | `UnknownChangeType` |
| `ApplyError::SequenceOverflow` | `SequenceSaturated` |
| `TxAuthError::ConfigSequence` | `BadSequence` |
| `TxAuthError::AccountLocked` | `AccountIsLocked` |
| `AuthorizeError::ZeroActor` | `AuthenticationFailed` |
| `AuthorizeError::NotBound` | `AuthenticatorMismatch` |
| `AuthorizeError::Expired` | `ActorExpired` |
| `SignatureError::EmptyEnvelope` | `EmptySignatureEnvelope` |

`TxAuthError::StaleEpoch` already matched by name and is unchanged.

### Intentionally not mirrored (with PR #100)

- **`InvalidChainId`** — removed from Keystore in #100 with the signature-less `importAccount()` (no `chainId` param). Rust never had a surviving `ConfigChainId`/`InvalidChainId` enshrined-path variant after rebase onto main.
- **`ImportNotConfirmed` / `DelegatedAccountCannotImport`** — contract-call `importAccount` / `confirmImportDigest` surface only. The enshrined path bootstraps via `CreateEntry`, not import.
- **`NoImportActors`** — folded into `NoInitialActors` in #100; Rust already uses `NoInitialActors`.

Variants with no Solidity counterpart (node-specific structural checks, delegation gate, EOA recovery, nested-scope, generic scope wrapper, broader `MalformedAuth`) are left as-is. `Display` message strings were left unchanged (pure debug text).

Canonical CREATE2 address re-pin for the #100 Keystore bytecode is a separate follow-up (P256/WebAuthn unchanged; Keystore / DefaultAccount / high-rate payer / Delegate drift).

## Test plan

- [x] `cargo build -p base-execution-eip8130 -p base-execution-txpool -p base-common-evm`
- [x] `cargo test -p base-execution-eip8130` (204 passed)
- [x] Cross-checked error surface against eip-8130#100 `Keystore.sol`