### PR TITLE
fix(eip8130): canonical sender_auth encodings (tx-hash/gas malleability)

### DIFF
--- a/crates/common/consensus/src/transaction/eip8130/signed.rs
+++ b/crates/common/consensus/src/transaction/eip8130/signed.rs
@@ -366,7 +366,21 @@ impl Eip8130Signed {
         if self.tx.sender.is_some() {
             return Ok(None);
         }
-        let signature = alloy_primitives::Signature::try_from(self.sender_auth.as_ref())
+        // Canonical-encoding guard: the EOA `sender_auth` must be exactly a
+        // 65-byte `r || s || v` blob with `v` in 'Electrum' notation
+        // (`v in {27, 28}`). `sender_auth` cannot be covered by
+        // `sender_signature_hash` (a signature cannot sign over itself), so if we
+        // accepted the alternative `v in {0, 1}` encoding any relayer could flip
+        // that byte to mint a second, equally valid transaction hash for the same
+        // signer without the key (txid malleability). `alloy`'s parser normalizes
+        // `{0, 1, 27, 28}` all to the same parity, so we reject the non-canonical
+        // forms here before parsing, matching the k1 authenticator's strict
+        // `v in {27, 28}` check in `RecoveredActorId::recover_k1`.
+        let raw = self.sender_auth.as_ref();
+        if raw.len() != 65 || !matches!(raw[64], 27 | 28) {
+            return Err(alloy_consensus::crypto::RecoveryError::new());
+        }
+        let signature = alloy_primitives::Signature::try_from(raw)
             .map_err(|_| alloy_consensus::crypto::RecoveryError::new())?;
         let hash = self.tx.sender_signature_hash();
         recover(&signature, hash).map(Some)
@@ -837,6 +851,28 @@ mod tests {
         let signed = Eip8130Signed::new(tx, sender_auth, Bytes::new());
 
         assert_eq!(signed.recover_eoa_sender().unwrap(), Some(expected));
+    }
+
+    #[cfg(feature = "k256")]
+    #[test]
+    fn recover_eoa_sender_rejects_noncanonical_v() {
+        use alloy_signer::SignerSync;
+        use alloy_signer_local::PrivateKeySigner;
+
+        let signer = PrivateKeySigner::random();
+        let mut tx = sample_signed(false).into_tx();
+        tx.sender = None;
+        let signature = signer.sign_hash_sync(&tx.sender_signature_hash()).unwrap();
+        let mut bytes = signature.as_bytes().to_vec();
+        // Honest tooling emits `v` in 'Electrum' notation (`{27, 28}`). Rewrite it
+        // to the `{0, 1}` encoding of the same parity: it recovers the same signer
+        // but is a distinct byte string (txid malleability), so both the checked
+        // and unchecked recovery paths must reject it.
+        assert!(matches!(bytes[64], 27 | 28));
+        bytes[64] -= 27;
+        let signed = Eip8130Signed::new(tx, Bytes::from(bytes), Bytes::new());
+        assert!(signed.recover_eoa_sender().is_err());
+        assert!(signed.recover_eoa_sender_unchecked().is_err());
     }
 
     #[cfg(feature = "k256")]

--- a/crates/execution/eip8130/src/dispatch.rs
+++ b/crates/execution/eip8130/src/dispatch.rs
@@ -158,8 +158,24 @@ impl AuthenticatorDispatch {
     /// `actorId = keccak256(x || y)`. Mirrors `OpenZeppelin` `WebAuthn.verify`
     /// with `requireUV = false` (as the deployed `WebAuthnAuthenticator`).
     fn webauthn(hash: B256, data: &[u8]) -> Result<B256, AuthError> {
-        let (auth, x, y) = <(WebAuthnAuth, B256, B256)>::abi_decode_params(data)
+        let decoded = <(WebAuthnAuth, B256, B256)>::abi_decode_params(data)
             .map_err(|_| AuthError::MalformedAuth)?;
+
+        // Canonical-encoding guard. `data` is un-signed, relay-mutable material —
+        // the WebAuthn signature commits to the challenge and `clientDataJSON`,
+        // not to this outer ABI framing — yet every byte is billed as EIP-2028
+        // payload gas. A non-canonical re-encoding (trailing padding or
+        // non-minimal dynamic offsets) decodes to the same value and still passes
+        // the P-256 check, but changes the transaction hash and inflates
+        // sender-intrinsic gas, letting a relayer shrink the execution-gas budget
+        // without the key. Requiring the input to equal its canonical ABI
+        // re-encoding makes any such mutation invalidate the transaction. Honest
+        // producers (Solidity `abi.encode` / `alloy` `abi_encode_params`) always
+        // emit this canonical form, so this rejects only malleated blobs.
+        if decoded.abi_encode_params() != data {
+            return Err(AuthError::MalformedAuth);
+        }
+        let (auth, x, y) = decoded;
 
         let auth_data = auth.authenticatorData.as_ref();
         let client_json = auth.clientDataJSON.as_bytes();
@@ -459,6 +475,26 @@ mod tests {
                 &data,
             ),
             Err(AuthError::InvalidSignature),
+        );
+    }
+
+    #[test]
+    fn webauthn_rejects_trailing_bytes() {
+        // The blob authenticates HASH; appending an unsigned trailing byte leaves
+        // the decoded value (and thus the P-256 check and resolved actorId)
+        // unchanged, but is non-canonical ABI. It must be rejected so a relayer
+        // cannot malleate the transaction hash or inflate payload gas with bytes
+        // the signer never covered.
+        let key = p256_key();
+        let (mut data, _) = webauthn_blob(&key, HASH);
+        data.push(0xFF);
+        assert_eq!(
+            AuthenticatorDispatch::authenticate(
+                HASH,
+                Eip8130Contracts::WEBAUTHN_AUTHENTICATOR,
+                &data,
+            ),
+            Err(AuthError::MalformedAuth),
         );
     }
 


### PR DESCRIPTION
## Summary

Closes an auth-encoding **malleability + gas-griefing** vector on the EIP-8130 pipeline.

`sender_auth`/`payer_auth` cannot be covered by the sender/payer signature hashes (a signature can't sign over itself), yet every auth byte is billed as EIP-2028 payload gas (`Eip8130IntrinsicGas::payload_cost` folds over the full signed encoding). Because two distinct byte encodings were accepted for the *same* authorization, any relayer could mutate the auth blob to:

- mint a **second valid transaction hash** for the same signer (txid malleability), and
- **inflate sender-intrinsic gas**, shrinking the execution-gas budget so signed call phases OOG-revert after inclusion — nonce consumed, fee paid, earlier phases committed — all without the signing key.

### Root causes fixed

1. **EOA sender `v`** — the empty-`sender` path recovered through `alloy_primitives::Signature::try_from`, whose `normalize_v` maps `{0,1,27,28}` to the same parity. So `v` could be flipped to a non-canonical byte and still recover the same signer. Now enforce a strict 65-byte length and `v ∈ {27,28}` (Electrum notation) before parsing, matching the k1 authenticator's existing `recover_k1` check. Applied in the shared `recover_eoa_sender_with`, so the **checked and unchecked** paths agree (no path can accept a tx another rejects). Honest tooling (`Signature::as_bytes` → `27 + y_parity`) is unaffected.

2. **WebAuthn** — `abi_decode_params` ignores trailing / non-canonical ABI bytes, which decode to the same value and still pass the P-256 check, but change the tx hash and inflate payload gas. Now require the input to equal its canonical ABI re-encoding (`decoded.abi_encode_params() != data → reject`). Covers **sender and payer** auth via the shared dispatch. P-256 already enforced a fixed 129-byte length, so no trailing bytes were possible there.

### Tests

- `recover_eoa_sender_rejects_noncanonical_v`: rewriting `v` from `{27,28}` to the `{0,1}` encoding of the same parity is rejected on both recovery paths.
- `webauthn_rejects_trailing_bytes`: appending an unsigned trailing byte to an otherwise-valid blob is rejected.

## Test plan

- [x] `cargo test -p base-execution-eip8130` (187 passed)
- [x] `cargo test -p base-common-consensus --all-features` (eip8130 suite green; new test passes)
- [x] `cargo clippy -p base-execution-eip8130` clean (default features)
- [ ] Consider follow-up: broader consensus/e2e test asserting mempool↔inclusion symmetry under auth mutation.

## Notes / parity

The tx-level sender/payer signatures and intrinsic-gas accounting are node/protocol concerns, not `Keystore.sol` surface, so there is no contract-parity regression. The WebAuthn canonical-ABI check is intentionally *stricter* than OZ `abi.decode` (which tolerates trailing bytes), but only rejects malleated blobs — honest `abi.encode` output always matches its canonical re-encoding — so no honest transaction is rejected.