### PR TITLE
fix(l3): resolve dispute games in ascending index order

### DIFF
--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -157,8 +157,6 @@ impl<C: Clock> BondManager<C> {
     /// Ordering is load-bearing: `resolve()` reverts `ParentGameNotResolved` unless the parent game
     /// has already resolved, so a child processed before its parent is a guaranteed revert. Using
     /// `buffered` rather than `buffer_unordered` keeps the concurrency while preserving that order.
-    /// (`GameScanner` can use `buffer_unordered` because it tuples the index with each result and
-    /// re-sorts downstream; this scan consumes the actions in the order they are returned.)
     async fn bond_actions(
         &self,
         range: std::ops::Range<u64>,

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -899,7 +899,7 @@ mod tests {
                 metrics_enabled: false,
             },
             factory,
-            Arc::new(MockL2Provider::new()),
+            Arc::new(MockL2Provider::default()),
             fixed_clock(1_000),
         );
 

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -152,6 +152,13 @@ impl<C: Clock> BondManager<C> {
             .is_none_or(|last_scan| now.saturating_sub(last_scan) >= self.discovery_interval)
     }
 
+    /// Evaluates the range concurrently but yields actions in **ascending game index order**.
+    ///
+    /// Ordering is load-bearing: `resolve()` reverts `ParentGameNotResolved` unless the parent game
+    /// has already resolved, so a child processed before its parent is a guaranteed revert. Using
+    /// `buffered` rather than `buffer_unordered` keeps the concurrency while preserving that order.
+    /// (`GameScanner` can use `buffer_unordered` because it tuples the index with each result and
+    /// re-sorts downstream; this scan consumes the actions in the order they are returned.)
     async fn bond_actions(
         &self,
         range: std::ops::Range<u64>,
@@ -159,7 +166,7 @@ impl<C: Clock> BondManager<C> {
     ) -> Vec<BondAction> {
         stream::iter(range)
             .map(|i| self.evaluate_game_for_bonds(i, verifier_client))
-            .buffer_unordered(GameScanner::SCAN_CONCURRENCY)
+            .buffered(GameScanner::SCAN_CONCURRENCY)
             .filter_map(std::future::ready)
             .collect()
             .await
@@ -819,5 +826,92 @@ mod tests {
 
         assert_eq!(verifier.delayed_weth_reads.lock().unwrap().len(), 1);
         assert_eq!(tx_manager.recorded_calls().len(), 1);
+    }
+
+    /// Factory whose `game_at_index` completes in reverse index order, reproducing the condition
+    /// under which an unordered scan yields child games before their parents.
+    #[derive(Debug)]
+    struct ReverseLatencyFactory {
+        inner: MockDisputeGameFactory,
+        game_count: u64,
+    }
+
+    #[async_trait::async_trait]
+    impl DisputeGameFactoryClient for ReverseLatencyFactory {
+        async fn game_count(&self) -> Result<u64, base_proof_contracts::ContractError> {
+            self.inner.game_count().await
+        }
+
+        async fn game_at_index(
+            &self,
+            index: u64,
+        ) -> Result<base_proof_contracts::GameAtIndex, base_proof_contracts::ContractError>
+        {
+            let delay = self.game_count.saturating_sub(index).saturating_mul(20);
+            tokio::time::sleep(Duration::from_millis(delay)).await;
+            self.inner.game_at_index(index).await
+        }
+
+        async fn init_bonds(
+            &self,
+            game_type: u32,
+        ) -> Result<alloy_primitives::U256, base_proof_contracts::ContractError> {
+            self.inner.init_bonds(game_type).await
+        }
+
+        async fn game_impls(
+            &self,
+            game_type: u32,
+        ) -> Result<Address, base_proof_contracts::ContractError> {
+            self.inner.game_impls(game_type).await
+        }
+
+        async fn games(
+            &self,
+            game_type: u32,
+            root_claim: B256,
+            extra_data: alloy_primitives::Bytes,
+        ) -> Result<Address, base_proof_contracts::ContractError> {
+            self.inner.games(game_type, root_claim, extra_data).await
+        }
+    }
+
+    /// `resolve()` reverts `ParentGameNotResolved` unless the parent resolved first, so the scan
+    /// must hand back actions in ascending game order even when the reads complete out of order.
+    #[tokio::test]
+    async fn bond_actions_are_ordered_by_game_index() {
+        let claim_addr = claim_addr();
+        let game_count = 5;
+        let games = (0..game_count).map(|i| factory_game(i, 0)).collect::<Vec<_>>();
+        let factory = Arc::new(ReverseLatencyFactory {
+            inner: MockDisputeGameFactory::new(games),
+            game_count,
+        });
+        let states = (0..game_count)
+            .map(|i| (addr(i), game_state(claim_addr, Address::ZERO, 0, false)))
+            .collect::<HashMap<_, _>>();
+        let verifier = MockAggregateVerifier::new(states);
+
+        let mgr = BondManager::new(
+            BondManagerConfig {
+                claim_addresses: vec![claim_addr],
+                l1_rpc_url: url::Url::parse("http://127.0.0.1:1").unwrap(),
+                lookback: 1000,
+                discovery_interval: TEST_DISCOVERY_INTERVAL,
+                metrics_enabled: false,
+            },
+            factory,
+            Arc::new(MockL2Provider::new()),
+            fixed_clock(1_000),
+        );
+
+        let actions = mgr.bond_actions(0..game_count, &verifier).await;
+
+        let ordered = actions.iter().map(|action| action.game_address()).collect::<Vec<_>>();
+        assert_eq!(
+            ordered,
+            (0..game_count).map(addr).collect::<Vec<_>>(),
+            "actions must be ascending by game index so parents resolve before children",
+        );
     }
 }


### PR DESCRIPTION
One-word fix plus a regression test. Ticket **BOP-521**; step 1 of `tickets/l2a-latency-sequence-plan.md`.

## The bug

`bond_actions` collected game evaluations with `buffer_unordered`, so actions arrived in **completion** order, and `discover_claimable_games` then processed them serially in that arbitrary order. `resolve()` reverts `ParentGameNotResolved` unless the parent game has already resolved, so any child processed before its parent is a guaranteed revert.

The idiom was copied from `GameScanner` — the original commit ([#1894](https://github.com/base/base/pull/1894)) said so in a comment:

```rust
// Evaluate all games concurrently using the same pattern as the
// game scanner (`buffer_unordered`).
```

But `GameScanner` is safe precisely because it tuples the index with each result (`|i| async move { (i, …) }`) and rebuilds order downstream in a `BTreeMap`. `bond_actions` dropped the index and consumes the actions in the order returned, so the property that made the pattern correct did not survive the copy. [#3850](https://github.com/base/base/pull/3850) later extracted the helper and carried the primitive across unchanged.

`buffered` keeps the identical concurrency and restores ascending order. `anchor.rs` in the same crate already uses `buffered` for the same reason.

## Why it matters now

It stayed latent because a scan window rarely holds more than one *unresolved* game at `BLOCK_INTERVAL=100` — resolved games yield claim actions, not resolve actions.

A dev run at `BLOCK_INTERVAL=30` (privacy-enclave #844, deployed to `web3-shared-dev` and rolled back) produced **525 `ParentGameNotResolved` reverts against 45 successful resolves**, and the resolve chain stopped advancing entirely — games 82–91 were never resolved and the anchor froze ~48 games behind. Game creation was healthy throughout (0.994 blk/s), so the failure was confined to resolution.

It also affects any deployment independently of the interval: after a challenger outage the rescan (lookback defaults to 1000 games) finds several unresolved games and attempts them in arbitrary order, so recovery advances roughly one game per scan instead of draining in one. The reverts surface from `eth_estimateGas`, so the cost is latency and RPC noise rather than gas.

## Test plan

- [x] `bond_actions_are_ordered_by_game_index` — a factory whose `game_at_index` completes in reverse index order. **Verified it fails on the pre-change code**, returning `[4,3,2,1,0]`, i.e. it reproduces the production failure rather than asserting current behaviour.
- [x] `cargo test -p base-challenger --lib` — 94 passed.
- [x] `cargo clippy -p base-challenger --all-targets -- --deny=warnings` — clean.

## Scope

Deliberately just this. The capacity work that interval 30 also needs (the challenger sends 4 serialised L1 transactions per game) is staged separately so each change can be attributed on its own — `tickets/l2a-latency-sequence-plan.md` has the sequence. A Multicall3 batching implementation is parked on `markusosterlund/bop-521-multicall-batching`.

`origin/main` carries the identical line and the same `ParentGameNotResolved` constraint; a matching PR there is worth opening as a robustness fix.