### PR TITLE
fix(upgrades): align execution cascade semantics

### DIFF
--- a/crates/common/chains/src/chain.rs
+++ b/crates/common/chains/src/chain.rs
@@ -74,12 +74,14 @@ impl ChainUpgrades {
 
 impl EthereumHardforks for ChainUpgrades {
     fn ethereum_fork_activation(&self, fork: EthereumHardfork) -> ForkCondition {
-        self[fork]
+        BaseUpgrade::from_ethereum_hardfork(fork)
+            .map(|upgrade| self.fork_condition(upgrade))
+            .unwrap_or(self[fork])
     }
 }
 
 impl Upgrades for ChainUpgrades {
-    fn fork_condition(&self, fork: BaseUpgrade) -> ForkCondition {
+    fn configured_fork_condition(&self, fork: BaseUpgrade) -> ForkCondition {
         self[fork]
     }
 }

--- a/crates/common/chains/src/upgrades.rs
+++ b/crates/common/chains/src/upgrades.rs
@@ -5,9 +5,31 @@ use base_common_genesis::{BaseUpgrade, RollupConfig};
 /// Extends [`EthereumHardforks`] with Base upgrade helper methods.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait Upgrades: EthereumHardforks {
-    /// Retrieves [`ForkCondition`] by a [`BaseUpgrade`]. If `fork` is not present, returns
-    /// [`ForkCondition::Never`].
-    fn fork_condition(&self, fork: BaseUpgrade) -> ForkCondition;
+    /// Retrieves the directly configured [`ForkCondition`] for a [`BaseUpgrade`].
+    ///
+    /// This target-specific lookup does not apply cascading-upgrade semantics.
+    fn configured_fork_condition(&self, fork: BaseUpgrade) -> ForkCondition;
+
+    /// Retrieves the effective [`ForkCondition`] for a [`BaseUpgrade`].
+    ///
+    /// Cascading upgrades imply that their predecessors are active. When both a predecessor and a
+    /// cascading successor have timestamp conditions, the earlier timestamp wins. If `fork` is
+    /// not present, implementations return [`ForkCondition::Never`].
+    fn fork_condition(&self, fork: BaseUpgrade) -> ForkCondition {
+        let configured = self.configured_fork_condition(fork);
+        if !matches!(configured, ForkCondition::Never | ForkCondition::Timestamp(_)) {
+            return configured;
+        }
+
+        fork.cascaded_activation_timestamp(|upgrade| {
+            match self.configured_fork_condition(upgrade) {
+                ForkCondition::Timestamp(timestamp) => Some(timestamp),
+                _ => None,
+            }
+        })
+        .map(ForkCondition::Timestamp)
+        .unwrap_or(ForkCondition::Never)
+    }
 
     /// Returns the activation registry admin address.
     fn activation_admin_address(&self) -> Option<Address> {
@@ -96,74 +118,27 @@ pub trait Upgrades: EthereumHardforks {
 }
 
 impl Upgrades for RollupConfig {
-    fn fork_condition(&self, fork: BaseUpgrade) -> ForkCondition {
-        match fork {
-            BaseUpgrade::Bedrock => ForkCondition::Block(0),
-            BaseUpgrade::Regolith => self
-                .upgrade_activation_timestamp(BaseUpgrade::Regolith)
-                .map(ForkCondition::Timestamp)
-                .unwrap_or_else(|| self.fork_condition(BaseUpgrade::Canyon)),
-            BaseUpgrade::Canyon => self
-                .upgrade_activation_timestamp(BaseUpgrade::Canyon)
-                .map(ForkCondition::Timestamp)
-                .unwrap_or_else(|| self.fork_condition(BaseUpgrade::Ecotone)),
-            BaseUpgrade::Ecotone => self
-                .upgrade_activation_timestamp(BaseUpgrade::Ecotone)
-                .map(ForkCondition::Timestamp)
-                .unwrap_or_else(|| self.fork_condition(BaseUpgrade::Fjord)),
-            BaseUpgrade::Fjord => self
-                .upgrade_activation_timestamp(BaseUpgrade::Fjord)
-                .map(ForkCondition::Timestamp)
-                .unwrap_or_else(|| self.fork_condition(BaseUpgrade::Granite)),
-            BaseUpgrade::Granite => self
-                .upgrade_activation_timestamp(BaseUpgrade::Granite)
-                .map(ForkCondition::Timestamp)
-                .unwrap_or_else(|| self.fork_condition(BaseUpgrade::Holocene)),
-            BaseUpgrade::Holocene => self
-                .upgrade_activation_timestamp(BaseUpgrade::Holocene)
-                .map(ForkCondition::Timestamp)
-                .unwrap_or_else(|| self.fork_condition(BaseUpgrade::Isthmus)),
-            BaseUpgrade::Isthmus => self
-                .upgrade_activation_timestamp(BaseUpgrade::Isthmus)
-                .map(ForkCondition::Timestamp)
-                .unwrap_or_else(|| self.fork_condition(BaseUpgrade::Jovian)),
-            BaseUpgrade::Jovian => self
-                .upgrade_activation_timestamp(BaseUpgrade::Jovian)
-                .map(ForkCondition::Timestamp)
-                .unwrap_or(ForkCondition::Never),
-            BaseUpgrade::Azul => self
-                .upgrade_activation_timestamp(BaseUpgrade::Azul)
-                .map(ForkCondition::Timestamp)
-                .unwrap_or(ForkCondition::Never),
-            BaseUpgrade::Beryl => self
-                .upgrade_activation_timestamp(BaseUpgrade::Beryl)
-                .map(ForkCondition::Timestamp)
-                .unwrap_or(ForkCondition::Never),
-            BaseUpgrade::Cobalt => self
-                .upgrade_activation_timestamp(BaseUpgrade::Cobalt)
-                .map(ForkCondition::Timestamp)
-                .unwrap_or(ForkCondition::Never),
-            BaseUpgrade::Denim => self
-                .upgrade_activation_timestamp(BaseUpgrade::Denim)
-                .map(ForkCondition::Timestamp)
-                .unwrap_or(ForkCondition::Never),
-            // Zenith is the genesis-only gate for future hardfork feature testing: the runtime
-            // registry drops Zenith writes, so only a genesis-configured timestamp can appear
-            // here.
-            BaseUpgrade::Zenith => self
-                .upgrade_activation_timestamp(BaseUpgrade::Zenith)
-                .map(ForkCondition::Timestamp)
-                .unwrap_or(ForkCondition::Never),
-            // Contract-only upgrades (Delta, PectraBlobSchedule) and any future variants are
-            // absent from the execution fork ladder.
-            _ => ForkCondition::Never,
+    fn configured_fork_condition(&self, fork: BaseUpgrade) -> ForkCondition {
+        if fork == BaseUpgrade::Bedrock {
+            return ForkCondition::Block(0);
         }
+
+        // Contract-only upgrades are absent from the execution fork ladder. Zenith is the
+        // genesis-only testing gate and remains readable from rollup genesis configuration.
+        if !fork.is_execution() && fork != BaseUpgrade::Zenith {
+            return ForkCondition::Never;
+        }
+
+        self.upgrade_activation_timestamp(fork)
+            .map(ForkCondition::Timestamp)
+            .unwrap_or(ForkCondition::Never)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ChainUpgrades;
 
     #[test]
     fn rollup_config_upgrade_activation_cascade() {
@@ -184,6 +159,45 @@ mod tests {
         assert_eq!(cfg.fork_condition(BaseUpgrade::Cobalt), ForkCondition::Never);
         assert_eq!(cfg.fork_condition(BaseUpgrade::Denim), ForkCondition::Never);
         assert_eq!(cfg.fork_condition(BaseUpgrade::Zenith), ForkCondition::Never);
+    }
+
+    #[test]
+    fn rollup_config_upgrade_activation_cascade_uses_earliest_timestamp() {
+        let mut cfg = RollupConfig::default();
+        cfg.upgrades.canyon_time = Some(20);
+        cfg.upgrades.ecotone_time = Some(10);
+
+        assert_eq!(cfg.fork_condition(BaseUpgrade::Canyon), ForkCondition::Timestamp(10));
+        assert_eq!(cfg.fork_condition(BaseUpgrade::Ecotone), ForkCondition::Timestamp(10));
+    }
+
+    #[test]
+    fn chain_upgrades_share_rollup_config_cascade_semantics() {
+        let upgrades = ChainUpgrades::new([
+            (BaseUpgrade::Canyon, ForkCondition::Never),
+            (BaseUpgrade::Ecotone, ForkCondition::Timestamp(42)),
+        ]);
+
+        assert_eq!(upgrades[BaseUpgrade::Canyon], ForkCondition::Never);
+        assert_eq!(upgrades.fork_condition(BaseUpgrade::Canyon), ForkCondition::Timestamp(42));
+        assert_eq!(
+            upgrades.ethereum_fork_activation(alloy_hardforks::EthereumHardfork::Shanghai),
+            ForkCondition::Timestamp(42)
+        );
+        assert_eq!(upgrades.fork_condition(BaseUpgrade::Jovian), ForkCondition::Never);
+    }
+
+    #[test]
+    fn pectra_blob_schedule_can_remain_unscheduled_in_cascade() {
+        let mut cfg = RollupConfig::default();
+        cfg.upgrades.isthmus_time = Some(42);
+
+        assert_eq!(cfg.fork_condition(BaseUpgrade::Holocene), ForkCondition::Timestamp(42));
+        assert_eq!(cfg.fork_condition(BaseUpgrade::PectraBlobSchedule), ForkCondition::Never);
+        assert_eq!(cfg.fork_condition(BaseUpgrade::Isthmus), ForkCondition::Timestamp(42));
+        assert!(cfg.is_holocene_active(42));
+        assert!(!cfg.is_pectra_blob_schedule_active(42));
+        assert!(cfg.is_isthmus_active(42));
     }
 
     #[cfg(feature = "std")]

--- a/crates/common/evm/src/base_time.rs
+++ b/crates/common/evm/src/base_time.rs
@@ -415,7 +415,7 @@ mod tests {
     }
 
     impl Upgrades for TestUpgrades {
-        fn fork_condition(&self, fork: BaseUpgrade) -> ForkCondition {
+        fn configured_fork_condition(&self, fork: BaseUpgrade) -> ForkCondition {
             if fork == BaseUpgrade::Denim && self.0 {
                 ForkCondition::Timestamp(100)
             } else {

--- a/crates/common/genesis/src/chain/upgrade.rs
+++ b/crates/common/genesis/src/chain/upgrade.rs
@@ -206,6 +206,48 @@ impl BaseUpgrade {
         })
     }
 
+    /// Returns the next execution upgrade whose activation implies this upgrade is active.
+    ///
+    /// Contract-only upgrades are omitted because they do not enter the execution fork ladder.
+    /// The Base-specific upgrade line beginning with [`Azul`](Self::Azul) is standalone and does
+    /// not cascade from [`Jovian`](Self::Jovian).
+    pub const fn cascading_successor(self) -> Option<Self> {
+        match self {
+            Self::Regolith => Some(Self::Canyon),
+            Self::Canyon => Some(Self::Ecotone),
+            Self::Ecotone => Some(Self::Fjord),
+            Self::Fjord => Some(Self::Granite),
+            Self::Granite => Some(Self::Holocene),
+            Self::Holocene => Some(Self::Isthmus),
+            Self::Isthmus => Some(Self::Jovian),
+            _ => None,
+        }
+    }
+
+    /// Resolves this upgrade's effective activation timestamp across its cascading successors.
+    ///
+    /// A successor's activation implies that every predecessor in the cascade is active. If more
+    /// than one upgrade in the cascade has a timestamp, the earliest timestamp is effective.
+    pub fn cascaded_activation_timestamp(
+        self,
+        mut activation_timestamp: impl FnMut(Self) -> Option<u64>,
+    ) -> Option<u64> {
+        let mut effective_timestamp = None;
+        let mut upgrade = Some(self);
+
+        while let Some(current) = upgrade {
+            if let Some(timestamp) = activation_timestamp(current) {
+                effective_timestamp = Some(
+                    effective_timestamp
+                        .map_or(timestamp, |effective: u64| effective.min(timestamp)),
+                );
+            }
+            upgrade = current.cascading_successor();
+        }
+
+        effective_timestamp
+    }
+
     /// Returns the canonical `snake_case` contract upgrade ID used by the L1 upgrade-signal
     /// contract and metrics.
     ///

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -115,12 +115,11 @@ impl Default for RollupConfig {
 
 impl EthereumHardforks for RollupConfig {
     fn ethereum_fork_activation(&self, fork: EthereumHardfork) -> ForkCondition {
-        // Helper: cascade through the Base upgrade chain, returning the first set timestamp.
-        let cascade = |starting: &[Option<u64>]| -> ForkCondition {
-            if let Some(ts) = starting.iter().flatten().next() {
-                return ForkCondition::Timestamp(*ts);
-            }
-            ForkCondition::Never
+        let cascade = |upgrade: BaseUpgrade| {
+            upgrade
+                .cascaded_activation_timestamp(|current| self.upgrade_activation_timestamp(current))
+                .map(ForkCondition::Timestamp)
+                .unwrap_or(ForkCondition::Never)
         };
 
         if fork <= EthereumHardfork::Berlin {
@@ -131,35 +130,15 @@ impl EthereumHardforks for RollupConfig {
             ForkCondition::Block(0)
         } else if fork <= EthereumHardfork::Shanghai {
             // Canyon activates Shanghai; cascade through later Base upgrades if unset.
-            cascade(&[
-                self.upgrade_activation_timestamp(BaseUpgrade::Canyon),
-                self.upgrade_activation_timestamp(BaseUpgrade::Ecotone),
-                self.upgrade_activation_timestamp(BaseUpgrade::Fjord),
-                self.upgrade_activation_timestamp(BaseUpgrade::Granite),
-                self.upgrade_activation_timestamp(BaseUpgrade::Holocene),
-                self.upgrade_activation_timestamp(BaseUpgrade::Isthmus),
-                self.upgrade_activation_timestamp(BaseUpgrade::Jovian),
-            ])
+            cascade(BaseUpgrade::Canyon)
         } else if fork <= EthereumHardfork::Cancun {
             // Ecotone activates Cancun; cascade through later Base upgrades if unset.
-            cascade(&[
-                self.upgrade_activation_timestamp(BaseUpgrade::Ecotone),
-                self.upgrade_activation_timestamp(BaseUpgrade::Fjord),
-                self.upgrade_activation_timestamp(BaseUpgrade::Granite),
-                self.upgrade_activation_timestamp(BaseUpgrade::Holocene),
-                self.upgrade_activation_timestamp(BaseUpgrade::Isthmus),
-                self.upgrade_activation_timestamp(BaseUpgrade::Jovian),
-            ])
+            cascade(BaseUpgrade::Ecotone)
         } else if fork <= EthereumHardfork::Prague {
             // Isthmus activates Prague; cascade through later Base upgrades if unset.
-            cascade(&[
-                self.upgrade_activation_timestamp(BaseUpgrade::Isthmus),
-                self.upgrade_activation_timestamp(BaseUpgrade::Jovian),
-            ])
+            cascade(BaseUpgrade::Isthmus)
         } else if fork <= EthereumHardfork::Osaka {
-            self.upgrade_activation_timestamp(BaseUpgrade::Azul)
-                .map(ForkCondition::Timestamp)
-                .unwrap_or(ForkCondition::Never)
+            cascade(BaseUpgrade::Azul)
         } else {
             ForkCondition::Never
         }

--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -629,6 +629,7 @@ mod tests {
 
     use alloy_chains::Chain;
     use alloy_primitives::{B256, U256, address};
+    use base_common_chains::Upgrades;
     use base_common_genesis::BaseUpgrade;
     use clap::{Args, Parser};
     use rstest::rstest;
@@ -750,6 +751,22 @@ mod tests {
         assert_eq!(applied, 2);
         assert_eq!(cfg.upgrades.activation_timestamp(BaseUpgrade::Delta), Some(40));
         assert_eq!(cfg.upgrades.activation_timestamp(BaseUpgrade::Azul), Some(42));
+    }
+
+    #[test]
+    fn cascades_later_upgrade_to_consensus_predecessors() {
+        let mut cfg = RollupConfig::default();
+
+        let applied = ConsensusNodeArgs::apply_schedule_to_rollup_config(
+            &mut cfg,
+            &upgrade_schedule(&[(BaseUpgrade::Canyon, 0), (BaseUpgrade::Ecotone, 42)]),
+        );
+
+        assert_eq!(applied, 1);
+        assert_eq!(cfg.upgrades.activation_timestamp(BaseUpgrade::Canyon), None);
+        assert!(!cfg.fork_condition(BaseUpgrade::Canyon).active_at_timestamp(41));
+        assert!(cfg.fork_condition(BaseUpgrade::Canyon).active_at_timestamp(42));
+        assert!(cfg.fork_condition(BaseUpgrade::Ecotone).active_at_timestamp(42));
     }
 
     #[test]

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -314,9 +314,18 @@ impl BaseChainSpec {
         self.inner.hardforks.insert(fork, condition);
     }
 
-    /// Returns the runtime-aware activation condition for a hardfork.
-    pub fn fork<H: Hardfork>(&self, fork: H) -> ForkCondition {
+    /// Returns the directly configured, runtime-aware activation condition for a hardfork.
+    pub fn configured_fork<H: Hardfork>(&self, fork: H) -> ForkCondition {
         self.runtime_fork_condition(&fork).unwrap_or_else(|| self.inner.fork(fork))
+    }
+
+    /// Returns the effective, runtime-aware activation condition for a hardfork.
+    pub fn fork<H: Hardfork>(&self, fork: H) -> ForkCondition {
+        if let Some(upgrade) = BaseUpgrade::from_contract_fork_name(fork.name()) {
+            return Upgrades::fork_condition(self, upgrade);
+        }
+
+        self.configured_fork(fork)
     }
 
     /// Returns a runtime upgrade override for an execution fork condition.
@@ -333,14 +342,16 @@ impl BaseChainSpec {
     /// Returns hardforks with runtime overrides materialized into the schedule.
     pub fn runtime_hardforks(&self) -> ChainHardforks {
         let mut hardforks = self.inner.hardforks.clone();
-        if let Some(overrides) = RuntimeUpgradeRegistry::overrides(self.chain().id()) {
-            for (hardfork_id, activation) in overrides.activations {
-                let condition = match activation {
-                    UpgradeActivation::Never => ForkCondition::Never,
-                    UpgradeActivation::Timestamp(timestamp) => ForkCondition::Timestamp(timestamp),
-                };
-                Self::set_hardfork_activation_condition_for(&mut hardforks, hardfork_id, condition);
+        for hardfork_id in BaseUpgrade::EXECUTION_VARIANTS {
+            let condition = Upgrades::fork_condition(self, hardfork_id);
+            if matches!(condition, ForkCondition::Never) {
+                if let Some(execution_hardfork) = hardfork_id.execution_hardfork() {
+                    hardforks.remove(&execution_hardfork);
+                }
+                hardforks.remove(&hardfork_id);
+                continue;
             }
+            Self::set_hardfork_activation_condition_for(&mut hardforks, hardfork_id, condition);
         }
 
         hardforks
@@ -356,7 +367,9 @@ impl BaseChainSpec {
     /// Get an iterator of all hardforks with runtime-aware activation conditions.
     pub fn forks_iter(&self) -> impl Iterator<Item = (&dyn Hardfork, ForkCondition)> {
         self.inner.forks_iter().map(|(fork, condition)| {
-            let condition = self.runtime_fork_condition(fork).unwrap_or(condition);
+            let condition = BaseUpgrade::from_contract_fork_name(fork.name())
+                .map(|upgrade| Upgrades::fork_condition(self, upgrade))
+                .unwrap_or_else(|| self.runtime_fork_condition(fork).unwrap_or(condition));
             (fork, condition)
         })
     }
@@ -652,8 +665,8 @@ impl EthereumHardforks for BaseChainSpec {
 }
 
 impl Upgrades for BaseChainSpec {
-    fn fork_condition(&self, fork: BaseUpgrade) -> ForkCondition {
-        self.fork(fork)
+    fn configured_fork_condition(&self, fork: BaseUpgrade) -> ForkCondition {
+        self.configured_fork(fork)
     }
 
     fn activation_admin_address(&self) -> Option<Address> {

--- a/crates/execution/chainspec/src/upgrades.rs
+++ b/crates/execution/chainspec/src/upgrades.rs
@@ -1,7 +1,7 @@
 use alloc::{boxed::Box, vec};
 
 use alloy_primitives::U256;
-use base_common_chains::ChainUpgrades;
+use base_common_chains::{ChainUpgrades, Upgrades};
 use base_common_genesis::BaseUpgrade;
 use reth_ethereum_forks::{ChainHardforks, EthereumHardfork, ForkCondition, Hardfork};
 
@@ -41,44 +41,44 @@ impl ChainUpgradesExt for ChainUpgrades {
             ),
         ];
 
-        forks.push((BaseUpgrade::Bedrock.boxed(), self[BaseUpgrade::Bedrock]));
-        forks.push((BaseUpgrade::Regolith.boxed(), self[BaseUpgrade::Regolith]));
+        forks.push((BaseUpgrade::Bedrock.boxed(), self.fork_condition(BaseUpgrade::Bedrock)));
+        forks.push((BaseUpgrade::Regolith.boxed(), self.fork_condition(BaseUpgrade::Regolith)));
 
-        let canyon = self[BaseUpgrade::Canyon];
+        let canyon = self.fork_condition(BaseUpgrade::Canyon);
         forks.push((EthereumHardfork::Shanghai.boxed(), canyon));
         forks.push((BaseUpgrade::Canyon.boxed(), canyon));
 
-        let ecotone = self[BaseUpgrade::Ecotone];
+        let ecotone = self.fork_condition(BaseUpgrade::Ecotone);
         forks.push((EthereumHardfork::Cancun.boxed(), ecotone));
         forks.push((BaseUpgrade::Ecotone.boxed(), ecotone));
 
-        forks.push((BaseUpgrade::Fjord.boxed(), self[BaseUpgrade::Fjord]));
-        forks.push((BaseUpgrade::Granite.boxed(), self[BaseUpgrade::Granite]));
-        forks.push((BaseUpgrade::Holocene.boxed(), self[BaseUpgrade::Holocene]));
+        forks.push((BaseUpgrade::Fjord.boxed(), self.fork_condition(BaseUpgrade::Fjord)));
+        forks.push((BaseUpgrade::Granite.boxed(), self.fork_condition(BaseUpgrade::Granite)));
+        forks.push((BaseUpgrade::Holocene.boxed(), self.fork_condition(BaseUpgrade::Holocene)));
 
-        let isthmus = self[BaseUpgrade::Isthmus];
+        let isthmus = self.fork_condition(BaseUpgrade::Isthmus);
         if !matches!(isthmus, ForkCondition::Never) {
             forks.push((EthereumHardfork::Prague.boxed(), isthmus));
             forks.push((BaseUpgrade::Isthmus.boxed(), isthmus));
         }
 
-        let jovian = self[BaseUpgrade::Jovian];
+        let jovian = self.fork_condition(BaseUpgrade::Jovian);
         if !matches!(jovian, ForkCondition::Never) {
             forks.push((BaseUpgrade::Jovian.boxed(), jovian));
         }
 
-        let azul = self[BaseUpgrade::Azul];
+        let azul = self.fork_condition(BaseUpgrade::Azul);
         if !matches!(azul, ForkCondition::Never) {
             forks.push((EthereumHardfork::Osaka.boxed(), azul));
             forks.push((BaseUpgrade::Azul.boxed(), azul));
         }
 
-        let beryl = self[BaseUpgrade::Beryl];
+        let beryl = self.fork_condition(BaseUpgrade::Beryl);
         if !matches!(beryl, ForkCondition::Never) {
             forks.push((BaseUpgrade::Beryl.boxed(), beryl));
         }
 
-        let cobalt = self[BaseUpgrade::Cobalt];
+        let cobalt = self.fork_condition(BaseUpgrade::Cobalt);
         if !matches!(cobalt, ForkCondition::Never) {
             forks.push((BaseUpgrade::Cobalt.boxed(), cobalt));
         }

--- a/crates/execution/cli/src/upgrade_signal.rs
+++ b/crates/execution/cli/src/upgrade_signal.rs
@@ -263,10 +263,31 @@ mod tests {
         .unwrap();
 
         assert_eq!(applied, 2);
-        assert_eq!(chain_spec.fork(EthereumHardfork::Shanghai), ForkCondition::Timestamp(40));
-        assert_eq!(chain_spec.fork(BaseUpgrade::Canyon), ForkCondition::Timestamp(40));
+        assert_eq!(
+            chain_spec.configured_fork(EthereumHardfork::Shanghai),
+            ForkCondition::Timestamp(40)
+        );
+        assert_eq!(chain_spec.configured_fork(BaseUpgrade::Canyon), ForkCondition::Timestamp(40));
         assert_eq!(chain_spec.fork(EthereumHardfork::Osaka), ForkCondition::Timestamp(42));
         assert_eq!(chain_spec.fork(BaseUpgrade::Azul), ForkCondition::Timestamp(42));
+    }
+
+    #[test]
+    fn cascades_later_upgrade_to_execution_predecessors() {
+        let mut chain_spec = BaseChainSpec::from(ChainSpec::default());
+
+        let applied = ExecutionUpgradeSignal::apply_schedule_to_chain_spec(
+            &mut chain_spec,
+            &schedule(&[(BaseUpgrade::Canyon, 0), (BaseUpgrade::Ecotone, 42)]),
+        )
+        .unwrap();
+
+        assert_eq!(applied, 1);
+        assert_eq!(chain_spec.configured_fork(BaseUpgrade::Canyon), ForkCondition::Never);
+        assert_eq!(chain_spec.fork(EthereumHardfork::Shanghai), ForkCondition::Timestamp(42));
+        assert_eq!(chain_spec.fork(BaseUpgrade::Canyon), ForkCondition::Timestamp(42));
+        assert_eq!(chain_spec.fork(EthereumHardfork::Cancun), ForkCondition::Timestamp(42));
+        assert_eq!(chain_spec.fork(BaseUpgrade::Ecotone), ForkCondition::Timestamp(42));
     }
 
     #[test]
@@ -285,8 +306,11 @@ mod tests {
         .unwrap();
 
         assert_eq!(applied, 0);
-        assert_eq!(chain_spec.fork(EthereumHardfork::Shanghai), ForkCondition::Timestamp(40));
-        assert_eq!(chain_spec.fork(BaseUpgrade::Canyon), ForkCondition::Timestamp(40));
+        assert_eq!(
+            chain_spec.configured_fork(EthereumHardfork::Shanghai),
+            ForkCondition::Timestamp(40)
+        );
+        assert_eq!(chain_spec.configured_fork(BaseUpgrade::Canyon), ForkCondition::Timestamp(40));
         assert_eq!(chain_spec.fork(EthereumHardfork::Osaka), ForkCondition::Never);
         assert_eq!(chain_spec.fork(BaseUpgrade::Azul), ForkCondition::Never);
     }


### PR DESCRIPTION
## Summary

  The consensus layer treats later cascading upgrades as implicitly activating their predecessors, while the execution layer previously used only each fork’s directly configured condition. A sparse schedule could therefore produce different effective fork rules between CL and EL.

  This PR centralizes cascade resolution and applies it consistently to rollup configs, execution chain specs, paired Ethereum forks, and runtime hardfork materialization.

  For example, if Canyon is unscheduled and Ecotone activates at timestamp `42`, both layers now treat Canyon, Shanghai, Ecotone, and Cancun as active at `42`.

  ## Changes

  - Define the cascading execution-upgrade relationships once on `BaseUpgrade`
  - Add shared earliest-effective-timestamp resolution
  - Move cascade handling into the default `Upgrades::fork_condition` implementation
  - Require implementations to provide only their directly configured fork condition
  - Apply effective conditions to paired Ethereum forks and reth hardfork schedules
  - Preserve access to the EL’s directly configured condition separately from its effective condition
  - Remove never-active entries when materializing runtime hardforks so fork-ID calculation remains valid
  - Keep contract-only and standalone upgrades, including Pectra Blob Schedule, outside the execution cascade
  - Add regression coverage for sparse schedules, non-monotonic timestamps, CL/EL parity, paired Ethereum forks, and optional Pectra holes

  ## Compatibility

  - Existing complete chain schedules retain the same effective activation boundaries
  - Bedrock activation behavior is unchanged
  - Direct L1 schedule values and application summaries are unchanged
  - Pectra Blob Schedule can remain unscheduled while later cascading upgrades activate
  - Azul and later standalone Base upgrades remain non-cascading
  - Sparse schedules now produce consistent effective fork conditions across CL and EL

  ## Testing

  - `cargo test -p base-common-chains --all-features`
  - `cargo test -p base-execution-chainspec`
  - `cargo test -p base-execution-cli upgrade_signal`
  - `cargo test -p base-consensus-cli cascades_later_upgrade_to_consensus_predecessors`
  - `cargo clippy -p base-common-chains -p base-execution-chainspec -p base-execution-cli -p base-consensus-cli --all-targets -- -D warnings`
  - `cargo fmt --all`
  - `git diff --check`