### PR TITLE
ci: one sccache writer, all-features Build, default-features check

### DIFF
--- a/.github/actions/sccache-report/action.yml
+++ b/.github/actions/sccache-report/action.yml
@@ -1,0 +1,9 @@
+name: Report sccache
+description: Classify sccache write failures and publish stats to the job summary
+
+runs:
+  using: composite
+  steps:
+    - name: Report sccache stats
+      shell: bash
+      run: ./etc/scripts/ci/sccache-report.sh

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -41,11 +41,6 @@ inputs:
       so only designated writers (CI Test, main cache warmer) compete for the
       200 uploads/min repo limit.
     default: "false"
-  sccache-log:
-    description: >
-      Write SCCACHE_LOG=info into SCCACHE_ERROR_LOG. Enable on the writer and
-      one reader so write-error reasons are attributable without flooding every job.
-    default: "false"
 
 runs:
   using: composite
@@ -120,7 +115,6 @@ runs:
       shell: bash
       env:
         SCCACHE_WRITE: ${{ inputs.sccache-write }}
-        SCCACHE_LOG_ENABLED: ${{ inputs.sccache-log }}
       run: |
         error_log="${RUNNER_TEMP}/sccache-error.log"
         : > "$error_log"
@@ -132,17 +126,12 @@ runs:
           echo "SCCACHE_GHA_RW_MODE=READ_ONLY" >> "$GITHUB_ENV"
           echo "sccache mode: READ_ONLY"
         fi
-        if [ "$SCCACHE_LOG_ENABLED" = "true" ]; then
-          echo "SCCACHE_LOG=info" >> "$GITHUB_ENV"
-          echo "sccache log: info -> $error_log"
-        fi
 
     - name: Setup sccache
       uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       env:
         SCCACHE_GHA_RW_MODE: ${{ inputs.sccache-write == 'true' && 'READ_WRITE' || 'READ_ONLY' }}
         SCCACHE_ERROR_LOG: ${{ runner.temp }}/sccache-error.log
-        SCCACHE_LOG: ${{ inputs.sccache-log == 'true' && 'info' || '' }}
 
     - name: Rust cache
       if: inputs.rust-cache-shared-key != ''

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -41,6 +41,11 @@ inputs:
       so only designated writers (CI Test, main cache warmer) compete for the
       200 uploads/min repo limit.
     default: "false"
+  sccache-log:
+    description: >
+      Write SCCACHE_LOG=info into SCCACHE_ERROR_LOG. Enable on the writer and
+      one reader so write-error reasons are attributable without flooding every job.
+    default: "false"
 
 runs:
   using: composite
@@ -115,6 +120,7 @@ runs:
       shell: bash
       env:
         SCCACHE_WRITE: ${{ inputs.sccache-write }}
+        SCCACHE_LOG_ENABLED: ${{ inputs.sccache-log }}
       run: |
         error_log="${RUNNER_TEMP}/sccache-error.log"
         : > "$error_log"
@@ -126,12 +132,17 @@ runs:
           echo "SCCACHE_GHA_RW_MODE=READ_ONLY" >> "$GITHUB_ENV"
           echo "sccache mode: READ_ONLY"
         fi
+        if [ "$SCCACHE_LOG_ENABLED" = "true" ]; then
+          echo "SCCACHE_LOG=info" >> "$GITHUB_ENV"
+          echo "sccache log: info -> $error_log"
+        fi
 
     - name: Setup sccache
       uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       env:
         SCCACHE_GHA_RW_MODE: ${{ inputs.sccache-write == 'true' && 'READ_WRITE' || 'READ_ONLY' }}
         SCCACHE_ERROR_LOG: ${{ runner.temp }}/sccache-error.log
+        SCCACHE_LOG: ${{ inputs.sccache-log == 'true' && 'info' || '' }}
 
     - name: Rust cache
       if: inputs.rust-cache-shared-key != ''

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -35,6 +35,12 @@ inputs:
   just:
     description: Install just
     default: "true"
+  sccache-write:
+    description: >
+      Whether this job may write to the shared GHA sccache. Default is read-only
+      so only designated writers (CI Test, main cache warmer) compete for the
+      200 uploads/min repo limit.
+    default: "false"
 
 runs:
   using: composite
@@ -105,8 +111,27 @@ runs:
       with:
         components: ${{ inputs.components }}
 
+    - name: Configure sccache
+      shell: bash
+      env:
+        SCCACHE_WRITE: ${{ inputs.sccache-write }}
+      run: |
+        error_log="${RUNNER_TEMP}/sccache-error.log"
+        : > "$error_log"
+        echo "SCCACHE_ERROR_LOG=$error_log" >> "$GITHUB_ENV"
+        if [ "$SCCACHE_WRITE" = "true" ]; then
+          echo "SCCACHE_GHA_RW_MODE=READ_WRITE" >> "$GITHUB_ENV"
+          echo "sccache mode: READ_WRITE (designated writer)"
+        else
+          echo "SCCACHE_GHA_RW_MODE=READ_ONLY" >> "$GITHUB_ENV"
+          echo "sccache mode: READ_ONLY"
+        fi
+
     - name: Setup sccache
       uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      env:
+        SCCACHE_GHA_RW_MODE: ${{ inputs.sccache-write == 'true' && 'READ_WRITE' || 'READ_ONLY' }}
+        SCCACHE_ERROR_LOG: ${{ runner.temp }}/sccache-error.log
 
     - name: Rust cache
       if: inputs.rust-cache-shared-key != ''

--- a/.github/workflows/action-tests.yml
+++ b/.github/workflows/action-tests.yml
@@ -44,3 +44,6 @@ jobs:
         run: just actions::lint-ci
       - name: Run action tests
         run: just actions::test-ci
+      - name: Report sccache stats
+        if: always()
+        uses: ./.github/actions/sccache-report

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -16,6 +16,9 @@ on:
       clippy_command:
         required: true
         type: string
+      check_command:
+        required: true
+        type: string
       run_sigsegv:
         required: false
         type: boolean
@@ -132,7 +135,6 @@ jobs:
           sp1: "true"
           rust-cache-shared-key: "stable"
           rust-cache-save: ${{ inputs.save_rust_cache }}
-          sccache-log: "true"
       - name: Run build
         run: ${{ inputs.build_command }}
       - name: Report sccache stats
@@ -197,7 +199,6 @@ jobs:
           rust-cache-shared-key: "stable"
           rust-cache-save: ${{ inputs.save_rust_cache }}
           sccache-write: "true"
-          sccache-log: "true"
       - name: Clear prior JUnit report
         run: rm -f target/nextest/ci/test-results.xml
       - name: Run tests
@@ -224,6 +225,8 @@ jobs:
   default-features-check:
     name: Check (default features)
     runs-on: ubuntu-latest
+    env:
+      BASE_REF: ${{ inputs.base_ref }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -231,15 +234,19 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 1
+          fetch-depth: ${{ inputs.base_ref != '' && 0 || 1 }}
+      - name: Fetch base branch
+        if: inputs.base_ref != ''
+        run: git fetch origin "$BASE_REF":refs/remotes/origin/"$BASE_REF"
       - uses: ./.github/actions/setup
         with:
           free-disk: "true"
           native-deps: "true"
           foundry: "true"
           rust-cache-shared-key: "stable"
+          rust-cache-save: ${{ inputs.save_rust_cache }}
       - name: Check default features
-        run: just check::default-features-ci
+        run: ${{ inputs.check_command }}
       - name: Report sccache stats
         if: always()
         uses: ./.github/actions/sccache-report

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -134,6 +134,9 @@ jobs:
           rust-cache-save: ${{ inputs.save_rust_cache }}
       - name: Run build
         run: ${{ inputs.build_command }}
+      - name: Report sccache stats
+        if: always()
+        uses: ./.github/actions/sccache-report
 
   clippy:
     name: Clippy
@@ -162,6 +165,9 @@ jobs:
           rust-cache-save: ${{ inputs.save_rust_cache }}
       - name: Run clippy
         run: ${{ inputs.clippy_command }}
+      - name: Report sccache stats
+        if: always()
+        uses: ./.github/actions/sccache-report
 
   test:
     name: Test
@@ -189,6 +195,7 @@ jobs:
           tools: cargo-nextest
           rust-cache-shared-key: "stable"
           rust-cache-save: ${{ inputs.save_rust_cache }}
+          sccache-write: "true"
       - name: Clear prior JUnit report
         run: rm -f target/nextest/ci/test-results.xml
       - name: Run tests
@@ -208,6 +215,32 @@ jobs:
         uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6.4.0
         with:
           report_paths: target/nextest/ci/test-results.xml
+      - name: Report sccache stats
+        if: always()
+        uses: ./.github/actions/sccache-report
+
+  default-features-check:
+    name: Check (default features)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+      - uses: ./.github/actions/setup
+        with:
+          free-disk: "true"
+          native-deps: "true"
+          foundry: "true"
+          rust-cache-shared-key: "stable"
+      - name: Check default features
+        run: just check::default-features-ci
+      - name: Report sccache stats
+        if: always()
+        uses: ./.github/actions/sccache-report
 
   bench:
     name: Benchmarks
@@ -226,6 +259,9 @@ jobs:
           native-deps: "true"
           rust-cache-shared-key: "stable"
       - run: cargo bench --locked -p base-proof-mpt --bench trie_node -- --test
+      - name: Report sccache stats
+        if: always()
+        uses: ./.github/actions/sccache-report
 
   docker:
     name: Docker
@@ -321,3 +357,6 @@ jobs:
         uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6.4.0
         with:
           report_paths: target/nextest/ci/test-results.xml
+      - name: Report sccache stats
+        if: always()
+        uses: ./.github/actions/sccache-report

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -132,6 +132,7 @@ jobs:
           sp1: "true"
           rust-cache-shared-key: "stable"
           rust-cache-save: ${{ inputs.save_rust_cache }}
+          sccache-log: "true"
       - name: Run build
         run: ${{ inputs.build_command }}
       - name: Report sccache stats
@@ -196,6 +197,7 @@ jobs:
           rust-cache-shared-key: "stable"
           rust-cache-save: ${{ inputs.save_rust_cache }}
           sccache-write: "true"
+          sccache-log: "true"
       - name: Clear prior JUnit report
         run: rm -f target/nextest/ci/test-results.xml
       - name: Run tests

--- a/.github/workflows/ci-main-cache.yml
+++ b/.github/workflows/ci-main-cache.yml
@@ -40,6 +40,8 @@ jobs:
           sccache-write: "true"
       - name: Build CI cache
         run: just build::ci
+      - name: Warm default-features check cache
+        run: just check::default-features-ci
       - name: Report sccache stats
         if: always()
         uses: ./.github/actions/sccache-report

--- a/.github/workflows/ci-main-cache.yml
+++ b/.github/workflows/ci-main-cache.yml
@@ -37,8 +37,12 @@ jobs:
           sp1: "true"
           rust-cache-shared-key: "stable"
           rust-cache-save: "true"
+          sccache-write: "true"
       - name: Build CI cache
         run: just build::ci
+      - name: Report sccache stats
+        if: always()
+        uses: ./.github/actions/sccache-report
 
   warm-test-cache:
     name: Warm Test Cache
@@ -65,3 +69,6 @@ jobs:
           just build::contracts
           cargo nextest run -P ci --locked --workspace --all-features \
             --exclude base-system-tests --cargo-profile ci --no-run
+      - name: Report sccache stats
+        if: always()
+        uses: ./.github/actions/sccache-report

--- a/.github/workflows/ci-merge-queue.yml
+++ b/.github/workflows/ci-merge-queue.yml
@@ -22,6 +22,7 @@ jobs:
       base_ref: ""
       build_command: just build::ci
       clippy_command: just check::clippy-ci
+      check_command: just check::default-features-ci
       run_system_tests: true
       run_sigsegv: false
       save_rust_cache: false

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -24,6 +24,8 @@ jobs:
         just build::affected-ci "origin/${{ github.base_ref || 'main' }}"
       clippy_command: >-
         just check::clippy-affected-ci "origin/${{ github.base_ref || 'main' }}"
+      check_command: >-
+        just check::default-features-affected-ci "origin/${{ github.base_ref || 'main' }}"
       run_system_tests: false
       run_sigsegv: false
       save_rust_cache: false

--- a/etc/just/build.just
+++ b/etc/just/build.just
@@ -12,7 +12,7 @@ all-targets: contracts elfs
 
 # Builds all targets with ci profile
 ci: contracts
-    cargo build --locked --workspace --all-targets --profile ci
+    cargo build --locked --workspace --all-targets --all-features --profile ci
 
 # Builds only affected packages with ci profile
 affected-ci base="main": contracts
@@ -28,7 +28,7 @@ affected-ci base="main": contracts
         exit 0
     fi
     echo "Building affected crates:${pkg_args[*]}"
-    cargo build --locked --all-targets --profile ci "${pkg_args[@]}"
+    cargo build --locked --all-targets --all-features --profile ci "${pkg_args[@]}"
 
 elfs:
     just succinct build-elfs

--- a/etc/just/check.just
+++ b/etc/just/check.just
@@ -58,6 +58,14 @@ no-std-proof:
 crate-deps:
     {{justfile_directory()}}/etc/scripts/ci/check-crate-deps.sh
 
+# Typechecks the default feature set for all targets (no --all-features)
+default-features: _build-contracts
+    {{_skip_kernels}} {{_elf_stub}} cargo check --workspace --all-targets
+
+# Typechecks the default feature set with the ci profile
+default-features-ci: _build-contracts
+    {{_skip_kernels}} {{_elf_stub}} cargo check --locked --workspace --all-targets --profile ci
+
 [private]
 _build-contracts:
     cd {{justfile_directory()}}/crates/utilities/test-utils/contracts && forge soldeer install && forge build

--- a/etc/just/check.just
+++ b/etc/just/check.just
@@ -66,6 +66,22 @@ default-features: _build-contracts
 default-features-ci: _build-contracts
     {{_skip_kernels}} {{_elf_stub}} cargo check --locked --workspace --all-targets --profile ci
 
+# Typechecks the default feature set for only affected packages with ci profile
+default-features-affected-ci base="main": _build-contracts
+    #!/usr/bin/env bash
+    set -euo pipefail
+    pkg_args_output="$(python3 {{justfile_directory()}}/etc/scripts/local/affected-crates.py {{ base }} --cargo-args)"
+    pkg_args=()
+    while IFS= read -r line; do
+        [ -n "$line" ] && pkg_args+=("$line")
+    done <<< "$pkg_args_output"
+    if [ "${#pkg_args[@]}" -eq 0 ]; then
+        echo "No affected crates to check."
+        exit 0
+    fi
+    echo "Checking affected crates:${pkg_args[*]}"
+    {{_skip_kernels}} {{_elf_stub}} cargo check --locked --all-targets --profile ci "${pkg_args[@]}"
+
 [private]
 _build-contracts:
     cd {{justfile_directory()}}/crates/utilities/test-utils/contracts && forge soldeer install && forge build

--- a/etc/scripts/ci/sccache-report.sh
+++ b/etc/scripts/ci/sccache-report.sh
@@ -26,16 +26,26 @@ stat_field() {
 
 write_errors="$(stat_field "Cache write errors")"
 write_errors="${write_errors:-0}"
+misses="$(stat_field "Cache misses")"
+misses="${misses:-0}"
 hit_rate="$(stat_field "Cache hits rate")"
 rust_hits="$(stat_field "Cache hits (Rust)")"
 rust_misses="$(stat_field "Cache misses (Rust)")"
 cxx_hits="$(stat_field "Cache hits (C/C++)")"
 cxx_misses="$(stat_field "Cache misses (C/C++)")"
+writes_stuck=0
+if [[ "$misses" =~ ^[0-9]+$ && "$write_errors" =~ ^[0-9]+$ ]]; then
+  writes_stuck=$((misses - write_errors))
+  if (( writes_stuck < 0 )); then
+    writes_stuck=0
+  fi
+fi
 
 rate_limited=0
 cache_full=0
 auth=0
 timeout=0
+readonly_skip=0
 other=0
 classified_lines=0
 
@@ -51,6 +61,8 @@ classify_line() {
     auth=$((auth + 1))
   elif [[ "$lower" == *timeout* || "$lower" == *"timed out"* || "$lower" == *deadline* ]]; then
     timeout=$((timeout + 1))
+  elif [[ "$lower" == *read.only* || "$lower" == *readonly* || "$lower" == *"not writable"* || "$lower" == *"skipping write"* ]]; then
+    readonly_skip=$((readonly_skip + 1))
   else
     other=$((other + 1))
   fi
@@ -73,20 +85,23 @@ summary="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
   echo "| Cache hits rate | ${hit_rate:-n/a} |"
   echo "| Rust hits / misses | ${rust_hits:-n/a} / ${rust_misses:-n/a} |"
   echo "| C/C++ hits / misses | ${cxx_hits:-n/a} / ${cxx_misses:-n/a} |"
+  echo "| Cache misses | \`$misses\` |"
   echo "| Cache write errors (stats) | \`$write_errors\` |"
+  echo "| Writes that stuck | \`$writes_stuck\` |"
   echo "| Error-log lines | \`$classified_lines\` |"
   echo "| Rate limited | \`$rate_limited\` |"
   echo "| Cache full / quota | \`$cache_full\` |"
   echo "| Auth | \`$auth\` |"
   echo "| Timeout | \`$timeout\` |"
-  echo "| Other errors | \`$other\` |"
+  echo "| Read-only skip | \`$readonly_skip\` |"
+  echo "| Other log lines | \`$other\` |"
   echo
-  if [[ "$mode" == "READ_ONLY" && "$write_errors" != "0" ]]; then
-    echo "Write errors on a read-only job are unexpected; the GHA backend may have opened read-write before \`SCCACHE_GHA_RW_MODE\` was applied."
+  if [[ "$mode" == "READ_ONLY" && "$write_errors" == "$misses" && "$misses" != "0" ]]; then
+    echo "Read-only job: write errors equal misses. That is consistent with sccache counting skipped writes rather than GHA upload failures. Confirm from the log sample below (look for PUT/429 vs read-only skip)."
     echo
   fi
   if [[ "$write_errors" != "0" && "$classified_lines" -eq 0 ]]; then
-    echo "Stats reported write errors but \`SCCACHE_ERROR_LOG\` was empty. The usual cause on this repo is the GitHub Actions cache upload rate limit (200/min/repo); sccache increments the counter without always logging a line."
+    echo "Stats reported write errors but \`SCCACHE_ERROR_LOG\` was empty. Enable \`sccache-log: true\` on this job, or the GHA backend is incrementing the counter without logging (typical for 200/min rate limits)."
     echo
   fi
   echo "<details><summary>sccache --show-stats</summary>"
@@ -98,14 +113,14 @@ summary="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
   echo "</details>"
   if [[ -s "$error_log" ]]; then
     echo
-    echo "<details><summary>SCCACHE_ERROR_LOG (last 80 lines)</summary>"
+    echo "<details><summary>SCCACHE_ERROR_LOG (last 120 lines)</summary>"
     echo
     echo '```'
-    tail -n 80 "$error_log"
+    tail -n 120 "$error_log"
     echo '```'
     echo
     echo "</details>"
   fi
 } >> "$summary"
 
-echo "sccache mode=$mode write_errors=$write_errors rate_limited=$rate_limited cache_full=$cache_full auth=$auth timeout=$timeout other=$other"
+echo "sccache mode=$mode misses=$misses write_errors=$write_errors writes_stuck=$writes_stuck rate_limited=$rate_limited cache_full=$cache_full auth=$auth timeout=$timeout readonly_skip=$readonly_skip other=$other"

--- a/etc/scripts/ci/sccache-report.sh
+++ b/etc/scripts/ci/sccache-report.sh
@@ -101,7 +101,7 @@ summary="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
     echo
   fi
   if [[ "$write_errors" != "0" && "$classified_lines" -eq 0 ]]; then
-    echo "Stats reported write errors but \`SCCACHE_ERROR_LOG\` was empty. Enable \`sccache-log: true\` on this job, or the GHA backend is incrementing the counter without logging (typical for 200/min rate limits)."
+    echo "Stats reported write errors but \`SCCACHE_ERROR_LOG\` was empty. Typical for the GHA 200 uploads/min rate limit, and for read-only jobs that count skipped writes as errors."
     echo
   fi
   echo "<details><summary>sccache --show-stats</summary>"

--- a/etc/scripts/ci/sccache-report.sh
+++ b/etc/scripts/ci/sccache-report.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Publishes sccache hit/miss/write-error stats to the GitHub job summary and
+# classifies SCCACHE_ERROR_LOG lines so write failures are attributable
+# (GHA 200 uploads/min rate limit vs quota vs auth vs timeout).
+
+if ! command -v sccache >/dev/null 2>&1; then
+  echo "sccache not installed; skipping report"
+  exit 0
+fi
+
+stats="$(sccache --show-stats 2>&1 || true)"
+error_log="${SCCACHE_ERROR_LOG:-${RUNNER_TEMP:-/tmp}/sccache-error.log}"
+mode="${SCCACHE_GHA_RW_MODE:-unknown}"
+
+stat_field() {
+  local label="$1"
+  printf '%s\n' "$stats" | awk -v label="$label" '
+    index($0, label) == 1 {
+      print $NF
+      exit
+    }
+  '
+}
+
+write_errors="$(stat_field "Cache write errors")"
+write_errors="${write_errors:-0}"
+hit_rate="$(stat_field "Cache hits rate")"
+rust_hits="$(stat_field "Cache hits (Rust)")"
+rust_misses="$(stat_field "Cache misses (Rust)")"
+cxx_hits="$(stat_field "Cache hits (C/C++)")"
+cxx_misses="$(stat_field "Cache misses (C/C++)")"
+
+rate_limited=0
+cache_full=0
+auth=0
+timeout=0
+other=0
+classified_lines=0
+
+classify_line() {
+  local lower
+  lower="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  classified_lines=$((classified_lines + 1))
+  if [[ "$lower" == *429* || "$lower" == *ratelimit* || "$lower" == *"rate limit"* || "$lower" == *"too many requests"* ]]; then
+    rate_limited=$((rate_limited + 1))
+  elif [[ "$lower" == *quota* || "$lower" == *"no space"* || "$lower" == *"insufficient storage"* || "$lower" == *"cache too large"* || "$lower" == *"cache full"* ]]; then
+    cache_full=$((cache_full + 1))
+  elif [[ "$lower" == *401* || "$lower" == *403* || "$lower" == *unauthorized* || "$lower" == *forbidden* || "$lower" == *permission* || "$lower" == *unauthenticated* ]]; then
+    auth=$((auth + 1))
+  elif [[ "$lower" == *timeout* || "$lower" == *"timed out"* || "$lower" == *deadline* ]]; then
+    timeout=$((timeout + 1))
+  else
+    other=$((other + 1))
+  fi
+}
+
+if [[ -s "$error_log" ]]; then
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ -z "${line// /}" ]] && continue
+    classify_line "$line"
+  done < "$error_log"
+fi
+
+summary="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+{
+  echo "### sccache"
+  echo
+  echo "| Field | Value |"
+  echo "|---|---|"
+  echo "| Mode | \`$mode\` |"
+  echo "| Cache hits rate | ${hit_rate:-n/a} |"
+  echo "| Rust hits / misses | ${rust_hits:-n/a} / ${rust_misses:-n/a} |"
+  echo "| C/C++ hits / misses | ${cxx_hits:-n/a} / ${cxx_misses:-n/a} |"
+  echo "| Cache write errors (stats) | \`$write_errors\` |"
+  echo "| Error-log lines | \`$classified_lines\` |"
+  echo "| Rate limited | \`$rate_limited\` |"
+  echo "| Cache full / quota | \`$cache_full\` |"
+  echo "| Auth | \`$auth\` |"
+  echo "| Timeout | \`$timeout\` |"
+  echo "| Other errors | \`$other\` |"
+  echo
+  if [[ "$mode" == "READ_ONLY" && "$write_errors" != "0" ]]; then
+    echo "Write errors on a read-only job are unexpected; the GHA backend may have opened read-write before \`SCCACHE_GHA_RW_MODE\` was applied."
+    echo
+  fi
+  if [[ "$write_errors" != "0" && "$classified_lines" -eq 0 ]]; then
+    echo "Stats reported write errors but \`SCCACHE_ERROR_LOG\` was empty. The usual cause on this repo is the GitHub Actions cache upload rate limit (200/min/repo); sccache increments the counter without always logging a line."
+    echo
+  fi
+  echo "<details><summary>sccache --show-stats</summary>"
+  echo
+  echo '```'
+  printf '%s\n' "$stats"
+  echo '```'
+  echo
+  echo "</details>"
+  if [[ -s "$error_log" ]]; then
+    echo
+    echo "<details><summary>SCCACHE_ERROR_LOG (last 80 lines)</summary>"
+    echo
+    echo '```'
+    tail -n 80 "$error_log"
+    echo '```'
+    echo
+    echo "</details>"
+  fi
+} >> "$summary"
+
+echo "sccache mode=$mode write_errors=$write_errors rate_limited=$rate_limited cache_full=$cache_full auth=$auth timeout=$timeout other=$other"


### PR DESCRIPTION
## Summary
- Make **Test** (PR/MQ) and the **main cache warmer** the only sccache writers; every other setup job is `SCCACHE_GHA_RW_MODE=READ_ONLY` so we stop seven compile jobs racing the GHA 200 uploads/min limit.
- Switch `just build::ci` / `build::affected-ci` to `--all-features` so Build shares rustc cache keys with Test/Clippy instead of writing a parallel default-features graph.
- Add a concurrent `Check (default features)` job (`cargo check --workspace --all-targets`, no `--all-features`) as the cheap default-feature gate.
- Publish classified sccache stats to each compile job summary (hit rate, write errors, rate-limit / quota / auth / timeout) so we can see *why* writes fail.

## What to look for in this PR's CI
- **Test** job summary: `Mode: READ_WRITE`, write-error count and classification (empty log + nonzero writes ≈ GHA rate limit).
- **Build / Clippy / Action Tests / Check**: `Mode: READ_ONLY`, write errors should be 0.
- **Build** wall clock vs recent MQ (~12 min) now that it is all-features (may be a bit slower individually; should hit more of Test's keys on later runs).
- **Check (default features)** duration and whether default-feature typecheck stays off the critical path.

## Test plan
- [ ] Confirm Test is the only `READ_WRITE` job on this PR
- [ ] Compare sccache write-error counts on Test vs Build/Clippy
- [ ] Confirm `Check (default features)` is green and not the wall-clock ceiling
- [ ] Confirm Build still compiles (`--all-features --all-targets`)


Made with [Cursor](https://cursor.com)