### PR TITLE
fix(ci): cap system-test parallelism on the nextest CI profile

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -20,6 +20,14 @@ retries = 1
 filter = 'package(base-action-harness)'
 slow-timeout = { period = "90s", terminate-after = 2 }
 
+# Nextest profiles do not inherit default-profile overrides. Without this, CI
+# starts every Docker-backed system test at once and the runner gets OOM-killed.
+[[profile.ci.overrides]]
+filter = 'package(base-system-tests)'
+test-group = 'system-tests'
+retries = 1
+slow-timeout = { period = "120s", terminate-after = 3 }
+
 [[profile.default.overrides]]
 filter = 'test(system_test_)'
 test-group = 'system-test-serial'

--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -178,7 +178,7 @@ tests: _install-nextest _build-contracts
 
 # Runs system tests with ci profile for minimal disk usage
 tests-ci: _install-nextest _build-contracts
-    cargo nextest run -P ci --locked -p base-system-tests --cargo-profile ci
+    cargo nextest run -P ci --locked -p base-system-tests --cargo-profile ci --no-fail-fast
 
 # Runs system test benchmarks
 bench name:


### PR DESCRIPTION
## Summary
- Merge-queue `ci / System Tests` on #4447 was cancelled mid-run (`activation_registry` tests SIGKILL'd at ~105s) after the runner received a shutdown signal. The upgrade-signal unit tests from #4447 had already passed.
- Nextest profiles do not inherit `default` overrides, so `-P ci` never applied the `system-tests` group (`max-threads = 6`) or the 120s slow-timeout. CI started every Docker stack at once.
- Copy those overrides onto `profile.ci`, and run `just devnet tests-ci` with `--no-fail-fast` so one failure does not hide the rest of the suite.

No test-logic speedup in this PR: `activation_registry` tests each need an isolated stack (they mutate admin/activation state), and the harness tears the stack down on drop. Poll timeouts are ceilings, not the 80–100s startup cost.

## Test plan
- [ ] Merge-queue `ci / System Tests` completes without runner shutdown
- [ ] `activation_registry` tests pass under the 6-wide cap
- [ ] Remaining system tests still run after an isolated failure (`--no-fail-fast`)