### PR TITLE
fix(trusted-proxy): fall back to outermost trusted hop on unparseable entry

### DIFF
--- a/crates/utilities/trusted-proxy/src/trusted_proxy.rs
+++ b/crates/utilities/trusted-proxy/src/trusted_proxy.rs
@@ -73,12 +73,15 @@ impl TrustedProxyConfig {
                 value: String::from_utf8_lossy(value.as_bytes()).into_owned(),
             })?;
             for entry in value.split(',').rev().map(str::trim).filter(|entry| !entry.is_empty()) {
-                let ip = entry.parse::<IpAddr>().map(|ip| ip.to_canonical()).map_err(|_| {
-                    ForwardedClientIpError::InvalidIp {
+                let Ok(ip) = entry.parse::<IpAddr>().map(|ip| ip.to_canonical()) else {
+                    if let Some(trusted) = outermost_trusted {
+                        return Ok(trusted);
+                    }
+                    return Err(ForwardedClientIpError::InvalidIp {
                         header: header.clone(),
                         value: entry.to_string(),
-                    }
-                })?;
+                    });
+                };
                 if self.is_trusted_proxy(ip) {
                     outermost_trusted = Some(ip);
                     continue;
@@ -313,5 +316,16 @@ mod tests {
 
         headers.insert("x-forwarded-for", HeaderValue::from_static("::ffff:203.0.113.10"));
         assert_eq!(config.client_ip(mapped_proxy, &headers), client);
+    }
+
+    #[test]
+    fn invalid_entry_left_of_trusted_hops_still_uses_outermost() {
+        let config = xff_config(vec!["10.0.0.0/8"]);
+        let outermost = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", HeaderValue::from_static("garbage, 10.0.0.1, 10.0.0.2"));
+
+        assert_eq!(config.forwarded_client_ip(&headers).unwrap(), outermost);
     }
 }


### PR DESCRIPTION
Closes #4352

## What changed? Why?

`forwarded_client_ip` documents that "if every hop is a trusted proxy, the outermost (leftmost) entry is used." While scanning right to left, an entry that fails to parse returned `InvalidIp` immediately, even when `outermost_trusted` had already been resolved and the answer was therefore already determined.

This falls back to the resolved outermost trusted hop on a parse failure, and keeps `InvalidIp` for the case the existing tests cover, where no trusted hop has been resolved yet.

Impact is in `crates/infra/telemetry/src/rate_limit.rs:145`: `PerIpRateLimit::enforce` keys the GCRA bucket on `client_ip`, and a resolution failure collapses every affected request into a single bucket keyed by the proxy address.

## Note on intent

If strict rejection is the intended behavior instead, the fix belongs in the doc comment rather than the code — happy to flip it that way. #4352 has the reasoning for why this reads as unintended: the existing `joins_header_lines_before_peeling_trusted_hops` test already treats an unreachable invalid entry as tolerable.

## How has it been tested?

- `cargo test -p base-trusted-proxy` — 11 passed, 0 failed, no existing test changed
- `cargo fmt` and `cargo clippy --all-targets -- -D warnings` clean
- The new regression test fails on `main`, passes here