### PR TITLE
feat(txpool): Evict Expired Validity Txs From Pool

### DIFF
--- a/crates/execution/txpool/src/block_expiry.rs
+++ b/crates/execution/txpool/src/block_expiry.rs
@@ -1,0 +1,153 @@
+//! Block-height expiry index for validity-predicate transactions.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use alloy_primitives::TxHash;
+
+/// Tracks validity-predicate transactions by the last block at which they can
+/// still be included, so the pool can evict them once the chain advances past
+/// that block.
+///
+/// This is the pool-side, block-granular counterpart to the builder's
+/// [`ValidityPredicate::is_batch_expired`](crate::ValidityPredicate::is_batch_expired)
+/// check. Unlike the EIP-8130 invalidation guard it is not gated on transaction
+/// type, so it works for the EIP-1559 transactions used by the beta advanced
+/// submission path.
+#[derive(Debug, Default)]
+pub struct BlockExpiryIndex {
+    /// Maps a transaction's inclusive last-valid block number to the set of
+    /// transactions that expire after it.
+    by_block: BTreeMap<u64, HashSet<TxHash>>,
+    /// Reverse map for removal when a transaction leaves the pool by another
+    /// path (inclusion, replacement, guard eviction).
+    by_hash: HashMap<TxHash, u64>,
+}
+
+impl BlockExpiryIndex {
+    /// Creates an empty index.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registers `hash` as valid only through (and including) `last_valid_block`.
+    ///
+    /// Re-registering a hash replaces its previous bound.
+    pub fn insert(&mut self, hash: TxHash, last_valid_block: u64) {
+        if let Some(previous) = self.by_hash.insert(hash, last_valid_block) {
+            self.remove_from_block(previous, &hash);
+        }
+        self.by_block.entry(last_valid_block).or_default().insert(hash);
+    }
+
+    /// Removes `hash` from the index if present.
+    pub fn remove(&mut self, hash: &TxHash) {
+        if let Some(block) = self.by_hash.remove(hash) {
+            self.remove_from_block(block, hash);
+        }
+    }
+
+    /// Removes and returns every transaction that can no longer be included at
+    /// `current_block` — that is, whose last-valid block is strictly before it.
+    pub fn drain_expired(&mut self, current_block: u64) -> Vec<TxHash> {
+        // Keys `>= current_block` are still valid at `current_block`; keep them.
+        let live = self.by_block.split_off(&current_block);
+        let expired_blocks = std::mem::replace(&mut self.by_block, live);
+        let mut expired = Vec::new();
+        for (_, hashes) in expired_blocks {
+            for hash in hashes {
+                self.by_hash.remove(&hash);
+                expired.push(hash);
+            }
+        }
+        expired
+    }
+
+    /// Returns the number of tracked transactions.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.by_hash.len()
+    }
+
+    /// Returns whether the index tracks no transactions.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.by_hash.is_empty()
+    }
+
+    fn remove_from_block(&mut self, block: u64, hash: &TxHash) {
+        if let Some(hashes) = self.by_block.get_mut(&block) {
+            hashes.remove(hash);
+            if hashes.is_empty() {
+                self.by_block.remove(&block);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hash(byte: u8) -> TxHash {
+        TxHash::repeat_byte(byte)
+    }
+
+    #[test]
+    fn drains_only_blocks_before_current() {
+        let mut index = BlockExpiryIndex::new();
+        index.insert(hash(1), 100);
+        index.insert(hash(2), 101);
+        index.insert(hash(3), 99);
+
+        // At block 100, only the tx valid through 99 is expired.
+        let expired = index.drain_expired(100);
+        assert_eq!(expired, vec![hash(3)]);
+        assert_eq!(index.len(), 2);
+
+        // At block 102, both remaining are expired.
+        let mut expired = index.drain_expired(102);
+        expired.sort();
+        assert_eq!(expired, vec![hash(1), hash(2)]);
+        assert!(index.is_empty());
+    }
+
+    #[test]
+    fn tx_valid_through_current_block_is_not_expired() {
+        let mut index = BlockExpiryIndex::new();
+        index.insert(hash(1), 100);
+
+        assert!(index.drain_expired(100).is_empty());
+        assert_eq!(index.drain_expired(101), vec![hash(1)]);
+    }
+
+    #[test]
+    fn reinsert_replaces_previous_bound() {
+        let mut index = BlockExpiryIndex::new();
+        index.insert(hash(1), 100);
+        index.insert(hash(1), 200);
+
+        assert!(index.drain_expired(150).is_empty());
+        assert_eq!(index.len(), 1);
+        assert_eq!(index.drain_expired(201), vec![hash(1)]);
+    }
+
+    #[test]
+    fn remove_drops_tracking() {
+        let mut index = BlockExpiryIndex::new();
+        index.insert(hash(1), 100);
+        index.insert(hash(2), 100);
+        index.remove(&hash(1));
+
+        assert_eq!(index.len(), 1);
+        assert_eq!(index.drain_expired(101), vec![hash(2)]);
+    }
+
+    #[test]
+    fn remove_of_unknown_hash_is_noop() {
+        let mut index = BlockExpiryIndex::new();
+        index.insert(hash(1), 100);
+        index.remove(&hash(9));
+        assert_eq!(index.len(), 1);
+    }
+}

--- a/crates/execution/txpool/src/lib.rs
+++ b/crates/execution/txpool/src/lib.rs
@@ -33,6 +33,9 @@ pub use validity::{
     ValidityPredicate, ValidityPredicateError,
 };
 
+mod block_expiry;
+pub use block_expiry::BlockExpiryIndex;
+
 mod transaction;
 pub use transaction::{
     BLOCK_TIME_SECS, BasePooledTransaction, BasePooledTx, BundleTransaction,

--- a/crates/execution/txpool/src/metrics.rs
+++ b/crates/execution/txpool/src/metrics.rs
@@ -13,7 +13,15 @@ base_metrics::define_metrics! {
     #[describe("EIP-8130 transactions invalidated and evicted ahead of the builder")]
     #[label(
         name = "cause",
-        default = ["state_diff", "balance_update", "expiry", "reorg", "feed_gap", "reconcile"]
+        default = [
+            "state_diff",
+            "balance_update",
+            "expiry",
+            "block_expiry",
+            "reorg",
+            "feed_gap",
+            "reconcile"
+        ]
     )]
     invalidated: counter,
     #[describe("Occupied expiry buckets fired on canonical state updates")]
@@ -54,6 +62,14 @@ impl GuardMetrics {
     pub fn record_expiry_invalidations(count: usize) {
         if count > 0 {
             Self::invalidated("expiry").increment(count as u64);
+        }
+    }
+
+    /// Records validity-predicate transactions evicted once the chain advanced
+    /// past their last valid block.
+    pub fn record_block_expiry_invalidations(count: usize) {
+        if count > 0 {
+            Self::invalidated("block_expiry").increment(count as u64);
         }
     }
 

--- a/crates/execution/txpool/src/pool.rs
+++ b/crates/execution/txpool/src/pool.rs
@@ -350,10 +350,24 @@ where
         )
     }
 
-    /// Records a transaction's last valid block in the block-expiry index.
-    fn register_block_expiry(&self, hash: TxHash, last_valid_block: Option<u64>) {
+    /// Records a transaction's last valid block in the block-expiry index,
+    /// dropping any replaced transaction's stale entry in the same pass so a
+    /// fee-bump replacement does not orphan the old hash until its expiry block.
+    fn register_block_expiry(
+        &self,
+        hash: TxHash,
+        last_valid_block: Option<u64>,
+        replaced: Option<TxHash>,
+    ) {
+        if last_valid_block.is_none() && replaced.is_none() {
+            return;
+        }
+        let mut block_expiry = self.block_expiry.write();
+        if let Some(replaced) = replaced {
+            block_expiry.remove(&replaced);
+        }
         if let Some(last_valid_block) = last_valid_block {
-            self.block_expiry.write().insert(hash, last_valid_block);
+            block_expiry.insert(hash, last_valid_block);
         }
     }
 
@@ -511,7 +525,7 @@ where
             }
         };
         self.gate_protocol_admission(hash, replaced, pre_admitted)?;
-        self.register_block_expiry(hash, block_expiry_bound);
+        self.register_block_expiry(hash, block_expiry_bound, replaced);
         Ok(outcome)
     }
 
@@ -842,7 +856,7 @@ where
                     }
                 };
             self.gate_protocol_admission(hash, replaced, pre_admitted)?;
-            self.register_block_expiry(hash, block_expiry_bound);
+            self.register_block_expiry(hash, block_expiry_bound, replaced);
             return Ok(events);
         }
 
@@ -2385,5 +2399,40 @@ mod tests {
         }]);
         assert!(pool.get(&hash).is_none());
         assert!(!pool.guard.read().contains(&hash));
+    }
+
+    #[test]
+    fn register_block_expiry_drops_the_replaced_entry() {
+        let (pool, _) = build_integration_pool();
+        let replaced = TxHash::repeat_byte(0x11);
+        let new_hash = TxHash::repeat_byte(0x22);
+
+        // Seed the index with the soon-to-be-replaced transaction.
+        pool.register_block_expiry(replaced, Some(100), None);
+        assert_eq!(pool.block_expiry.read().len(), 1);
+
+        // A fee-bump replacement must evict the stale entry rather than
+        // accumulate it, so the index does not grow per replacement.
+        pool.register_block_expiry(new_hash, Some(200), Some(replaced));
+        assert_eq!(pool.block_expiry.read().len(), 1);
+
+        // Only the new hash remains, tracked at its own bound.
+        let mut index = pool.block_expiry.write();
+        assert!(index.drain_expired(150).is_empty());
+        assert_eq!(index.drain_expired(201), vec![new_hash]);
+    }
+
+    #[test]
+    fn register_block_expiry_drops_a_replaced_entry_without_a_new_bound() {
+        let (pool, _) = build_integration_pool();
+        let replaced = TxHash::repeat_byte(0x33);
+        let new_hash = TxHash::repeat_byte(0x44);
+
+        pool.register_block_expiry(replaced, Some(100), None);
+        assert_eq!(pool.block_expiry.read().len(), 1);
+
+        // An unbounded replacement still clears the replaced hash's stale entry.
+        pool.register_block_expiry(new_hash, None, Some(replaced));
+        assert!(pool.block_expiry.read().is_empty());
     }
 }

--- a/crates/execution/txpool/src/pool.rs
+++ b/crates/execution/txpool/src/pool.rs
@@ -370,6 +370,11 @@ where
         let _admission_guard = self.protocol_admission_lock.lock();
         let expired = self.block_expiry.write().drain_expired(block_number);
         let removed = self.remove_dropped_across_pools(expired);
+        // Release any guard slots directly rather than deferring to the
+        // reconciliation sweep: an EIP-8130 transaction may carry block_number
+        // validity predicates, so an evicted tx can also hold guard capacity.
+        // `release` is a no-op for the common EIP-1559 case that is not tracked.
+        self.release_from_guard(&removed);
         if !removed.is_empty() {
             GuardMetrics::record_block_expiry_invalidations(removed.len());
             debug!(

--- a/crates/execution/txpool/src/pool.rs
+++ b/crates/execution/txpool/src/pool.rs
@@ -91,6 +91,10 @@ pub struct BaseTransactionPool<
     listeners: Arc<RwLock<SidecarListeners<T>>>,
     /// Shared admission and invalidation ledger for EIP-8130 transactions.
     guard: Arc<RwLock<MempoolGuard>>,
+    /// Block-height expiry index for validity-predicate transactions, evicted as
+    /// the chain advances past a transaction's last valid block. Not gated on
+    /// transaction type, so it also covers the EIP-1559 advanced-submission path.
+    block_expiry: Arc<RwLock<crate::BlockExpiryIndex>>,
     /// Serializes the short protocol-pool insertion/admission section so a
     /// concurrent same-nonce replacement cannot leave a stale guard record.
     /// Validation remains outside this lock.
@@ -127,6 +131,7 @@ where
             nonce_pool: Arc::clone(&self.nonce_pool),
             listeners: Arc::clone(&self.listeners),
             guard: Arc::clone(&self.guard),
+            block_expiry: Arc::clone(&self.block_expiry),
             protocol_admission_lock: Arc::clone(&self.protocol_admission_lock),
         }
     }
@@ -168,6 +173,7 @@ where
             nonce_pool: Arc::new(RwLock::new(TwoDNoncePool::new(price_bump_config))),
             listeners: Arc::new(RwLock::new(SidecarListeners::default())),
             guard: Arc::new(RwLock::new(MempoolGuard::unlimited())),
+            block_expiry: Arc::new(RwLock::new(crate::BlockExpiryIndex::new())),
             protocol_admission_lock: Arc::new(Mutex::new(())),
         }
     }
@@ -335,6 +341,45 @@ where
         }
     }
 
+    /// Returns the block-expiry bound for a validated transaction's validity
+    /// predicates, or `None` when they impose no finite block bound.
+    fn validity_block_expiry_bound(validated: &TransactionValidationOutcome<T>) -> Option<u64> {
+        let transaction = validated.as_valid_transaction()?;
+        crate::ValidityPredicate::block_expiry_bound(
+            transaction.transaction().validity_predicates(),
+        )
+    }
+
+    /// Records a transaction's last valid block in the block-expiry index.
+    fn register_block_expiry(&self, hash: TxHash, last_valid_block: Option<u64>) {
+        if let Some(last_valid_block) = last_valid_block {
+            self.block_expiry.write().insert(hash, last_valid_block);
+        }
+    }
+
+    /// Evicts validity-predicate transactions whose last valid block is before
+    /// the newly committed `block_number`.
+    ///
+    /// This is the pool-side, block-granular half of validity expiry (the
+    /// builder enforces the finer flashblock deadline). Driven from
+    /// `on_canonical_state_change`, so eviction rides block cadence. Entries for
+    /// transactions removed by other paths (inclusion, replacement) are cleaned
+    /// up lazily when their own expiry block is reached, bounding index growth to
+    /// the furthest live block bound.
+    fn expire_by_block(&self, block_number: u64) {
+        let _admission_guard = self.protocol_admission_lock.lock();
+        let expired = self.block_expiry.write().drain_expired(block_number);
+        let removed = self.remove_dropped_across_pools(expired);
+        if !removed.is_empty() {
+            GuardMetrics::record_block_expiry_invalidations(removed.len());
+            debug!(
+                count = removed.len(),
+                block = block_number,
+                "validity transactions invalidated by block expiry"
+            );
+        }
+    }
+
     fn reconcile_guard(&self) {
         let tracked = self.guard.read().tracked_hashes();
         if tracked.is_empty() {
@@ -438,6 +483,8 @@ where
         // tracked replacement bypasses this check and is reaccounted after the
         // protocol pool atomically accepts the fee bump.
         let pre_admitted = self.pre_admit_protocol_transaction(hash, replaced, &validated)?;
+        // Capture the block-expiry bound before `validated` is consumed below.
+        let block_expiry_bound = Self::validity_block_expiry_bound(&validated);
         let mut outcomes =
             self.protocol_pool.inner().add_transactions(origin, std::iter::once(validated));
         let outcome = match outcomes.pop() {
@@ -459,6 +506,7 @@ where
             }
         };
         self.gate_protocol_admission(hash, replaced, pre_admitted)?;
+        self.register_block_expiry(hash, block_expiry_bound);
         Ok(outcome)
     }
 
@@ -776,6 +824,8 @@ where
             self.ensure_protocol_classification_current(hash, &validated)?;
             let replaced = self.protocol_replacement_hash(sender, nonce);
             let pre_admitted = self.pre_admit_protocol_transaction(hash, replaced, &validated)?;
+            // Capture the block-expiry bound before `validated` is consumed below.
+            let block_expiry_bound = Self::validity_block_expiry_bound(&validated);
             let events =
                 match self.protocol_pool.inner().add_transaction_and_subscribe(origin, validated) {
                     Ok(events) => events,
@@ -787,6 +837,7 @@ where
                     }
                 };
             self.gate_protocol_admission(hash, replaced, pre_admitted)?;
+            self.register_block_expiry(hash, block_expiry_bound);
             return Ok(events);
         }
 
@@ -1381,6 +1432,7 @@ where
     ) {
         let block_hash = update.hash();
         let now = update.timestamp();
+        let block_number = update.number();
         let mined_transactions = update.mined_transactions.clone();
         // Free mined capacity atomically with admission before the heavier pool
         // maintenance. The transaction is already canonical, so it no longer
@@ -1390,6 +1442,10 @@ where
             let mut guard = self.guard.write();
             for hash in &mined_transactions {
                 guard.release(hash);
+            }
+            let mut block_expiry = self.block_expiry.write();
+            for hash in &mined_transactions {
+                block_expiry.remove(hash);
             }
         }
         self.protocol_pool.on_canonical_state_change(update);
@@ -1416,6 +1472,7 @@ where
             }
         }
         self.expire_due_buckets(now);
+        self.expire_by_block(block_number);
         self.reconcile_guard();
         GuardMetrics::tracked().set(self.guard.read().len() as f64);
     }

--- a/crates/execution/txpool/src/validity.rs
+++ b/crates/execution/txpool/src/validity.rs
@@ -271,6 +271,41 @@ impl ValidityPredicate {
         let pinned_to_current_block = block_upper == Some(current_block);
         pinned_to_current_block && flashblock_upper.is_some_and(|max| max < current_flashblock)
     }
+
+    /// Returns the inclusive last block at which these predicates can still be
+    /// satisfied, when the `block_number` predicates impose a finite upper bound.
+    ///
+    /// Returns `Some(0)` when the block predicates are already unsatisfiable at
+    /// any block (drop as soon as the chain advances), and `None` when no
+    /// `block_number` upper bound applies or the bound exceeds [`u64::MAX`]. This
+    /// is the pool-side, block-granular projection of [`Self::is_batch_expired`];
+    /// the finer flashblock deadline is enforced only by the builder.
+    #[must_use]
+    pub fn block_expiry_bound(predicates: &[Self]) -> Option<u64> {
+        let mut upper: Option<U256> = None;
+        let mut impossible = false;
+        for predicate in predicates {
+            let Self::BlockNumber { op, value } = predicate else { continue };
+            let candidate = match op {
+                ValidityOperator::LessThan => match value.checked_sub(U256::from(1)) {
+                    Some(max) => max,
+                    None => {
+                        impossible = true;
+                        continue;
+                    }
+                },
+                ValidityOperator::LessThanOrEqual | ValidityOperator::Equal => *value,
+                ValidityOperator::NotEqual
+                | ValidityOperator::GreaterThan
+                | ValidityOperator::GreaterThanOrEqual => continue,
+            };
+            upper = Some(upper.map_or(candidate, |current| current.min(candidate)));
+        }
+        if impossible {
+            return Some(0);
+        }
+        upper.and_then(|bound| u64::try_from(bound).ok())
+    }
 }
 
 /// Experimental validity predicates carried with a validated transaction.
@@ -936,5 +971,71 @@ mod tests {
         ];
         assert!(!ValidityPredicate::is_batch_expired(&state_only, &context_at(10_000, 9)));
         assert!(!ValidityPredicate::is_batch_expired(&[], &context_at(10_000, 9)));
+    }
+
+    #[test]
+    fn block_expiry_bound_uses_the_inclusive_upper_bound() {
+        assert_eq!(
+            ValidityPredicate::block_expiry_bound(&[block_number(
+                ValidityOperator::LessThanOrEqual,
+                100
+            )]),
+            Some(100)
+        );
+        assert_eq!(
+            ValidityPredicate::block_expiry_bound(&[block_number(ValidityOperator::Equal, 100)]),
+            Some(100)
+        );
+        // `<` is exclusive, so the last valid block is one lower.
+        assert_eq!(
+            ValidityPredicate::block_expiry_bound(&[block_number(ValidityOperator::LessThan, 100)]),
+            Some(99)
+        );
+    }
+
+    #[test]
+    fn block_expiry_bound_ignores_non_upper_bounds() {
+        for op in [
+            ValidityOperator::GreaterThan,
+            ValidityOperator::GreaterThanOrEqual,
+            ValidityOperator::NotEqual,
+        ] {
+            assert_eq!(ValidityPredicate::block_expiry_bound(&[block_number(op, 100)]), None);
+        }
+        // No block predicate at all.
+        assert_eq!(
+            ValidityPredicate::block_expiry_bound(&[flashblock_index(
+                ValidityOperator::LessThanOrEqual,
+                2
+            )]),
+            None
+        );
+        assert_eq!(ValidityPredicate::block_expiry_bound(&[]), None);
+    }
+
+    #[test]
+    fn block_expiry_bound_takes_the_tightest_bound() {
+        let predicates = [
+            block_number(ValidityOperator::LessThanOrEqual, 200),
+            block_number(ValidityOperator::LessThanOrEqual, 100),
+        ];
+        assert_eq!(ValidityPredicate::block_expiry_bound(&predicates), Some(100));
+    }
+
+    #[test]
+    fn block_expiry_bound_reports_zero_for_unsatisfiable_bounds() {
+        assert_eq!(
+            ValidityPredicate::block_expiry_bound(&[block_number(ValidityOperator::LessThan, 0)]),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn block_expiry_bound_is_none_when_bound_exceeds_u64() {
+        let predicate = ValidityPredicate::BlockNumber {
+            op: ValidityOperator::LessThanOrEqual,
+            value: U256::from(u64::MAX) + U256::from(1),
+        };
+        assert_eq!(ValidityPredicate::block_expiry_bound(&[predicate]), None);
     }
 }

--- a/crates/execution/txpool/src/validity.rs
+++ b/crates/execution/txpool/src/validity.rs
@@ -283,16 +283,13 @@ impl ValidityPredicate {
     #[must_use]
     pub fn block_expiry_bound(predicates: &[Self]) -> Option<u64> {
         let mut upper: Option<U256> = None;
-        let mut impossible = false;
         for predicate in predicates {
             let Self::BlockNumber { op, value } = predicate else { continue };
             let candidate = match op {
                 ValidityOperator::LessThan => match value.checked_sub(U256::from(1)) {
                     Some(max) => max,
-                    None => {
-                        impossible = true;
-                        continue;
-                    }
+                    // `< 0` can never hold, so the batch is permanently expired.
+                    None => return Some(0),
                 },
                 ValidityOperator::LessThanOrEqual | ValidityOperator::Equal => *value,
                 ValidityOperator::NotEqual
@@ -300,9 +297,6 @@ impl ValidityPredicate {
                 | ValidityOperator::GreaterThanOrEqual => continue,
             };
             upper = Some(upper.map_or(candidate, |current| current.min(candidate)));
-        }
-        if impossible {
-            return Some(0);
         }
         upper.and_then(|bound| u64::try_from(bound).ok())
     }


### PR DESCRIPTION
## Summary

Adds the pool-side, cross-block half of beta validity-transaction expiry. The builder half (#4441) skips expired transactions during a build; this evicts them from the mempool node's txpool so they cannot live in the pool forever. Because beta advanced transactions are EIP-1559 rather than EIP-8130, they never enter the existing EIP-8130 admission guard, so this introduces a dedicated, type-agnostic BlockExpiryIndex keyed by each transaction's last valid block number, populated at admission and swept from on_canonical_state_change using the newly committed block number. Pool eviction is block-granular by design; the finer flashblock deadline remains enforced by the builder.

Stacked on #4441. Implements the second half of BASE-280 (child of BASE-258).