### PR TITLE
[SPIKE] in-process simplex consensus for the Base sequencer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,13 +55,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
 ]
 
@@ -71,9 +81,9 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
- "aead",
+ "aead 0.5.2",
  "aes",
- "cipher",
+ "cipher 0.4.4",
  "ctr",
  "ghash",
  "subtle",
@@ -1173,7 +1183,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "either",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "k256",
  "thiserror 2.0.19",
 ]
@@ -1188,7 +1198,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "either",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "k256",
  "thiserror 2.0.19",
 ]
@@ -1207,7 +1217,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-kms",
  "k256",
- "spki",
+ "spki 0.7.3",
  "thiserror 2.0.19",
  "tracing",
 ]
@@ -2113,6 +2123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 dependencies = [
  "serde",
+ "zeroize",
 ]
 
 [[package]]
@@ -2760,13 +2771,13 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
- "crypto-bigint",
+ "crypto-bigint 0.5.5",
  "form_urlencoded",
  "hex",
  "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.2",
- "p256",
+ "p256 0.13.2",
  "percent-encoding",
  "sha2 0.11.0",
  "subtle",
@@ -3117,6 +3128,7 @@ dependencies = [
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3173,6 +3185,7 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4273,6 +4286,14 @@ dependencies = [
  "base-protocol",
  "base-upgrade-signal",
  "bytes",
+ "commonware-actor",
+ "commonware-codec",
+ "commonware-consensus",
+ "commonware-cryptography",
+ "commonware-p2p",
+ "commonware-parallel",
+ "commonware-runtime",
+ "commonware-utils",
  "derive_more 2.1.1",
  "discv5 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum_ssz",
@@ -4582,7 +4603,7 @@ dependencies = [
  "base-precompile-storage",
  "base64 0.22.1",
  "k256",
- "p256",
+ "p256 0.13.2",
  "revm",
  "sha2 0.10.9",
  "thiserror 2.0.19",
@@ -6544,7 +6565,7 @@ dependencies = [
  "clap",
  "discv5 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
- "governor",
+ "governor 0.7.0",
  "ipnet",
  "libp2p",
  "libp2p-identity",
@@ -6835,6 +6856,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base256emoji"
@@ -7152,6 +7179,7 @@ dependencies = [
  "cfg-if",
  "constant_time_eq",
  "cpufeatures 0.3.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -7194,7 +7222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
 dependencies = [
  "byteorder",
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -7773,7 +7801,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -7822,7 +7850,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
 ]
 
@@ -7833,6 +7861,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
+ "cipher 0.5.2",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
@@ -7843,11 +7872,23 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
- "aead",
+ "aead 0.5.2",
  "chacha20 0.9.1",
- "cipher",
- "poly1305",
+ "cipher 0.4.4",
+ "poly1305 0.8.0",
  "zeroize",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b89e1c441e926b9c82a8d023f6e1b7ae0adcfaa7d621814e4d60789bac751cb"
+dependencies = [
+ "aead 0.6.1",
+ "chacha20 0.10.1",
+ "cipher 0.5.2",
+ "poly1305 0.9.1",
 ]
 
 [[package]]
@@ -7898,8 +7939,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout",
+ "inout 0.1.4",
  "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -8066,6 +8118,372 @@ dependencies = [
  "crossterm",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "commonware-actor"
+version = "2026.7.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=5fde115a25f4eb496d584a725c2c1dedfbe10398#5fde115a25f4eb496d584a725c2c1dedfbe10398"
+dependencies = [
+ "cfg-if",
+ "commonware-macros",
+ "commonware-runtime",
+ "crossbeam-queue",
+ "futures-util",
+ "parking_lot",
+]
+
+[[package]]
+name = "commonware-broadcast"
+version = "2026.7.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=5fde115a25f4eb496d584a725c2c1dedfbe10398#5fde115a25f4eb496d584a725c2c1dedfbe10398"
+dependencies = [
+ "commonware-actor",
+ "commonware-codec",
+ "commonware-cryptography",
+ "commonware-macros",
+ "commonware-p2p",
+ "commonware-runtime",
+ "commonware-utils",
+ "thiserror 2.0.19",
+ "tracing",
+]
+
+[[package]]
+name = "commonware-codec"
+version = "2026.7.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=5fde115a25f4eb496d584a725c2c1dedfbe10398#5fde115a25f4eb496d584a725c2c1dedfbe10398"
+dependencies = [
+ "bytes",
+ "cfg-if",
+ "commonware-codec-macros",
+ "commonware-macros",
+ "paste",
+ "rand_chacha 0.10.0",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "commonware-codec-macros"
+version = "2026.7.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=5fde115a25f4eb496d584a725c2c1dedfbe10398#5fde115a25f4eb496d584a725c2c1dedfbe10398"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "commonware-coding"
+version = "2026.7.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=5fde115a25f4eb496d584a725c2c1dedfbe10398#5fde115a25f4eb496d584a725c2c1dedfbe10398"
+dependencies = [
+ "bytes",
+ "commonware-codec",
+ "commonware-cryptography",
+ "commonware-macros",
+ "commonware-math",
+ "commonware-parallel",
+ "commonware-storage",
+ "commonware-utils",
+ "num-rational",
+ "rayon",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "commonware-consensus"
+version = "2026.7.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=5fde115a25f4eb496d584a725c2c1dedfbe10398#5fde115a25f4eb496d584a725c2c1dedfbe10398"
+dependencies = [
+ "bytes",
+ "cfg-if",
+ "commonware-actor",
+ "commonware-broadcast",
+ "commonware-codec",
+ "commonware-coding",
+ "commonware-cryptography",
+ "commonware-formatting",
+ "commonware-macros",
+ "commonware-math",
+ "commonware-p2p",
+ "commonware-parallel",
+ "commonware-resolver",
+ "commonware-runtime",
+ "commonware-storage",
+ "commonware-utils",
+ "futures",
+ "pin-project",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
+ "rayon",
+ "thiserror 2.0.19",
+ "tracing",
+]
+
+[[package]]
+name = "commonware-cryptography"
+version = "2026.7.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=5fde115a25f4eb496d584a725c2c1dedfbe10398#5fde115a25f4eb496d584a725c2c1dedfbe10398"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "aws-lc-rs",
+ "blake3",
+ "blst",
+ "bytes",
+ "cfg-if",
+ "chacha20poly1305 0.11.0",
+ "commonware-codec",
+ "commonware-formatting",
+ "commonware-macros",
+ "commonware-math",
+ "commonware-parallel",
+ "commonware-utils",
+ "cpufeatures 0.3.0",
+ "crc-fast",
+ "ctutils",
+ "curve25519-dalek 5.0.0",
+ "ecdsa 0.17.0",
+ "fixedbitset 0.5.7",
+ "getrandom 0.2.17",
+ "getrandom 0.4.3",
+ "hashbrown 0.17.1",
+ "num-rational",
+ "num-traits",
+ "once_cell",
+ "p256 0.14.0",
+ "rand 0.10.2",
+ "rand_chacha 0.10.0",
+ "rand_core 0.10.1",
+ "sha2 0.11.0",
+ "thiserror 2.0.19",
+ "x25519-dalek 3.0.0",
+ "zeroize",
+]
+
+[[package]]
+name = "commonware-formatting"
+version = "2026.7.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=5fde115a25f4eb496d584a725c2c1dedfbe10398#5fde115a25f4eb496d584a725c2c1dedfbe10398"
+dependencies = [
+ "commonware-macros",
+ "const-hex",
+]
+
+[[package]]
+name = "commonware-macros"
+version = "2026.7.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=5fde115a25f4eb496d584a725c2c1dedfbe10398#5fde115a25f4eb496d584a725c2c1dedfbe10398"
+dependencies = [
+ "commonware-macros-impl",
+ "tokio",
+]
+
+[[package]]
+name = "commonware-macros-impl"
+version = "2026.7.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=5fde115a25f4eb496d584a725c2c1dedfbe10398#5fde115a25f4eb496d584a725c2c1dedfbe10398"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "toml 1.1.3+spec-1.1.0",
+]
+
+[[package]]
+name = "commonware-math"
+version = "2026.7.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=5fde115a25f4eb496d584a725c2c1dedfbe10398#5fde115a25f4eb496d584a725c2c1dedfbe10398"
+dependencies = [
+ "bytes",
+ "commonware-codec",
+ "commonware-macros",
+ "commonware-parallel",
+ "commonware-utils",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "commonware-p2p"
+version = "2026.7.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=5fde115a25f4eb496d584a725c2c1dedfbe10398#5fde115a25f4eb496d584a725c2c1dedfbe10398"
+dependencies = [
+ "commonware-actor",
+ "commonware-codec",
+ "commonware-cryptography",
+ "commonware-macros",
+ "commonware-parallel",
+ "commonware-runtime",
+ "commonware-stream",
+ "commonware-utils",
+ "either",
+ "futures",
+ "num-bigint 0.4.8",
+ "num-integer",
+ "num-rational",
+ "num-traits",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
+ "rand_distr",
+ "thiserror 2.0.19",
+ "tracing",
+]
+
+[[package]]
+name = "commonware-parallel"
+version = "2026.7.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=5fde115a25f4eb496d584a725c2c1dedfbe10398#5fde115a25f4eb496d584a725c2c1dedfbe10398"
+dependencies = [
+ "cfg-if",
+ "commonware-macros",
+ "dashmap",
+ "futures",
+ "rayon",
+]
+
+[[package]]
+name = "commonware-resolver"
+version = "2026.7.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=5fde115a25f4eb496d584a725c2c1dedfbe10398#5fde115a25f4eb496d584a725c2c1dedfbe10398"
+dependencies = [
+ "bytes",
+ "commonware-actor",
+ "commonware-codec",
+ "commonware-cryptography",
+ "commonware-macros",
+ "commonware-p2p",
+ "commonware-runtime",
+ "commonware-stream",
+ "commonware-utils",
+ "futures",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
+ "thiserror 2.0.19",
+ "tracing",
+]
+
+[[package]]
+name = "commonware-runtime"
+version = "2026.7.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=5fde115a25f4eb496d584a725c2c1dedfbe10398#5fde115a25f4eb496d584a725c2c1dedfbe10398"
+dependencies = [
+ "ahash",
+ "axum 0.8.9",
+ "bytes",
+ "cfg-if",
+ "commonware-codec",
+ "commonware-cryptography",
+ "commonware-formatting",
+ "commonware-macros",
+ "commonware-parallel",
+ "commonware-runtime-macros",
+ "commonware-utils",
+ "criterion",
+ "crossbeam-utils",
+ "futures",
+ "getrandom 0.2.17",
+ "getrandom 0.4.3",
+ "governor 0.10.4",
+ "libc",
+ "opentelemetry 0.32.0",
+ "opentelemetry-otlp 0.32.0",
+ "opentelemetry_sdk 0.32.1",
+ "prometheus-client 0.25.0",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
+ "rayon",
+ "sha2 0.11.0",
+ "sysinfo 0.39.6",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "tracing-opentelemetry 0.33.0",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
+name = "commonware-runtime-macros"
+version = "2026.7.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=5fde115a25f4eb496d584a725c2c1dedfbe10398#5fde115a25f4eb496d584a725c2c1dedfbe10398"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "commonware-storage"
+version = "2026.7.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=5fde115a25f4eb496d584a725c2c1dedfbe10398#5fde115a25f4eb496d584a725c2c1dedfbe10398"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "bytes",
+ "cfg-if",
+ "commonware-codec",
+ "commonware-cryptography",
+ "commonware-formatting",
+ "commonware-macros",
+ "commonware-parallel",
+ "commonware-runtime",
+ "commonware-utils",
+ "futures",
+ "futures-util",
+ "hashbrown 0.17.1",
+ "thiserror 2.0.19",
+ "tracing",
+ "zstd",
+]
+
+[[package]]
+name = "commonware-stream"
+version = "2026.7.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=5fde115a25f4eb496d584a725c2c1dedfbe10398#5fde115a25f4eb496d584a725c2c1dedfbe10398"
+dependencies = [
+ "chacha20poly1305 0.11.0",
+ "commonware-codec",
+ "commonware-cryptography",
+ "commonware-formatting",
+ "commonware-macros",
+ "commonware-runtime",
+ "commonware-utils",
+ "futures",
+ "rand_core 0.10.1",
+ "thiserror 2.0.19",
+ "x25519-dalek 3.0.0",
+ "zeroize",
+]
+
+[[package]]
+name = "commonware-utils"
+version = "2026.7.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=5fde115a25f4eb496d584a725c2c1dedfbe10398#5fde115a25f4eb496d584a725c2c1dedfbe10398"
+dependencies = [
+ "ahash",
+ "bytes",
+ "commonware-codec",
+ "commonware-formatting",
+ "commonware-macros",
+ "futures",
+ "getrandom 0.2.17",
+ "getrandom 0.3.4",
+ "getrandom 0.4.3",
+ "hashbrown 0.17.1",
+ "num-bigint 0.4.8",
+ "num-integer",
+ "num-rational",
+ "num-traits",
+ "parking_lot",
+ "pin-project",
+ "rand 0.10.2",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "zeroize",
 ]
 
 [[package]]
@@ -8262,6 +8680,12 @@ checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -8483,6 +8907,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "getrandom 0.4.3",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8499,7 +8939,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.3",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -8534,7 +8976,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -8544,6 +8986,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+ "subtle",
 ]
 
 [[package]]
@@ -8556,7 +8999,23 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
+ "rustc_version 0.4.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto 0.3.0",
  "rustc_version 0.4.1",
  "subtle",
  "zeroize",
@@ -8866,6 +9325,16 @@ checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
  "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
  "zeroize",
 ]
 
@@ -9344,13 +9813,28 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "serdect",
- "signature",
- "spki",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "serdect 0.2.0",
+ "signature 2.2.0",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
+dependencies = [
+ "der 0.8.1",
+ "digest 0.11.3",
+ "elliptic-curve 0.14.1",
+ "rfc6979 0.6.0",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -9359,8 +9843,8 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "signature",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -9369,7 +9853,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "ed25519",
  "rand_core 0.6.4",
  "serde",
@@ -9411,18 +9895,38 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
- "ff",
+ "ff 0.13.1",
  "generic-array 0.14.7",
- "group",
+ "group 0.13.0",
  "hkdf",
  "pem-rfc7468",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sec1",
- "serdect",
+ "sec1 0.7.3",
+ "serdect 0.2.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
+dependencies = [
+ "base16ct 1.0.0",
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "digest 0.11.3",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sec1 0.8.1",
  "subtle",
  "zeroize",
 ]
@@ -9834,6 +10338,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
+dependencies = [
+ "rand_core 0.10.1",
+ "subtle",
+]
+
+[[package]]
 name = "ff_derive"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9853,6 +10367,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "figment"
@@ -10364,9 +10884,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -10508,13 +11030,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "governor"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.9.5",
+ "smallvec",
+ "spinning_top",
+ "web-time",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
+dependencies = [
+ "ff 0.14.0",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -11082,7 +11638,9 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
+ "subtle",
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -11720,6 +12278,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11749,19 +12316,19 @@ checksum = "e0a77eae781ed6a7709fb15b64862fcca13d886b07c7e2786f5ed34e5e2b9187"
 dependencies = [
  "argon2",
  "bcrypt-pbkdf",
- "ecdsa",
+ "ecdsa 0.16.9",
  "ed25519-dalek",
  "hex",
  "hmac 0.12.1",
- "p256",
+ "p256 0.13.2",
  "p384",
  "p521",
  "rand_core 0.6.4",
  "rsa",
- "sec1",
+ "sec1 0.7.3",
  "sha1 0.10.7",
  "sha2 0.10.9",
- "signature",
+ "signature 2.2.0",
  "ssh-cipher",
  "ssh-encoding",
  "subtle",
@@ -12187,7 +12754,7 @@ dependencies = [
  "pem",
  "serde",
  "serde_json",
- "signature",
+ "signature 2.2.0",
  "simple_asn1",
  "zeroize",
 ]
@@ -12199,12 +12766,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
  "once_cell",
- "serdect",
+ "serdect 0.2.0",
  "sha2 0.10.9",
- "signature",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -12288,7 +12855,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8b4f55c3dedcfaa8668de1dfc8469e7a32d441c28edf225ed1f566fb32977d"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "hex",
  "rkyv",
  "serde",
@@ -12601,7 +13168,7 @@ dependencies = [
  "libp2p-ping",
  "libp2p-swarm",
  "pin-project",
- "prometheus-client",
+ "prometheus-client 0.23.1",
  "web-time",
 ]
 
@@ -12624,7 +13191,7 @@ dependencies = [
  "static_assertions",
  "thiserror 2.0.19",
  "tracing",
- "x25519-dalek",
+ "x25519-dalek 2.0.1",
  "zeroize",
 ]
 
@@ -14112,6 +14679,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14413,6 +14991,8 @@ dependencies = [
  "portable-atomic",
  "rand 0.9.5",
  "thiserror 2.0.19",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -14451,10 +15031,23 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder 0.13.6",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "p256"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
+dependencies = [
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "primefield",
+ "primeorder 0.14.0",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -14491,7 +15084,7 @@ version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2077757c7cb514202ccb5368f521f23f5709c720599e6545c683c66e0a52d2d8"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "num-bigint 0.4.8",
  "p3-field",
  "p3-poseidon2",
@@ -14731,9 +15324,9 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder 0.13.6",
  "sha2 0.10.9",
 ]
 
@@ -14743,10 +15336,10 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
 dependencies = [
- "base16ct",
- "ecdsa",
- "elliptic-curve",
- "primeorder",
+ "base16ct 0.2.0",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder 0.13.6",
  "rand_core 0.6.4",
  "sha2 0.10.9",
 ]
@@ -14784,7 +15377,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
- "group",
+ "group 0.13.0",
 ]
 
 [[package]]
@@ -15197,9 +15790,9 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -15210,11 +15803,11 @@ checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
 dependencies = [
  "aes",
  "cbc",
- "der",
+ "der 0.7.10",
  "pbkdf2",
  "scrypt",
  "sha2 0.10.9",
- "spki",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -15223,10 +15816,20 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
+ "der 0.7.10",
  "pkcs5",
  "rand_core 0.6.4",
- "spki",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -15313,7 +15916,17 @@ checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
+dependencies = [
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -15325,7 +15938,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
 ]
 
 [[package]]
@@ -15452,12 +16065,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "primefield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "ff 0.14.0",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
+dependencies = [
+ "elliptic-curve 0.14.1",
+ "once_cell",
+ "primefield",
+ "serdect 0.4.3",
+ "wnaf",
 ]
 
 [[package]]
@@ -15589,7 +16229,19 @@ dependencies = [
  "dtoa",
  "itoa",
  "parking_lot",
- "prometheus-client-derive-encode",
+ "prometheus-client-derive-encode 0.4.2",
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba70bf887030e45213b4a95c9b08d5a450b157f87c1d63661ed0847a12fa2aad"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "parking_lot",
+ "prometheus-client-derive-encode 0.5.0",
 ]
 
 [[package]]
@@ -15597,6 +16249,17 @@ name = "prometheus-client-derive-encode"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "prometheus-client-derive-encode"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9adf1691c04c0a5ff46ff8f262b58beb07b0dbb61f96f9f54f6cbd82106ed87f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -16000,6 +16663,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16023,6 +16696,16 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_distr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
+dependencies = [
+ "num-traits",
+ "rand 0.10.2",
+]
 
 [[package]]
 name = "rand_pcg"
@@ -17086,7 +17769,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "byteorder",
- "cipher",
+ "cipher 0.4.4",
  "concat-kdf",
  "ctr",
  "digest 0.10.7",
@@ -19366,7 +20049,7 @@ dependencies = [
  "c-kzg",
  "cfg-if",
  "k256",
- "p256",
+ "p256 0.13.2",
  "revm-context-interface",
  "revm-primitives",
  "ripemd",
@@ -19408,6 +20091,16 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac 0.12.1",
  "subtle",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -19734,7 +20427,7 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "digest 0.10.7",
- "ff",
+ "ff 0.13.1",
  "hex",
  "hex-literal 0.4.1",
  "metal",
@@ -19954,11 +20647,11 @@ dependencies = [
  "num-integer",
  "num-traits",
  "pkcs1",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sha2 0.10.9",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -20061,14 +20754,14 @@ dependencies = [
  "bytes",
  "cbc",
  "ctr",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "data-encoding",
  "delegate",
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
- "ecdsa",
+ "ecdsa 0.16.9",
  "ed25519-dalek",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "enum_dispatch",
  "futures",
  "generic-array 0.14.7",
@@ -20076,29 +20769,29 @@ dependencies = [
  "hex-literal 0.4.1",
  "hmac 0.12.1",
  "home",
- "inout",
+ "inout 0.1.4",
  "internal-russh-forked-ssh-key",
  "log",
  "md5",
  "num-bigint 0.4.8",
  "once_cell",
- "p256",
+ "p256 0.13.2",
  "p384",
  "p521",
  "pageant",
  "pbkdf2",
  "pkcs5",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand 0.8.7",
  "rand_core 0.6.4",
  "ring",
  "russh-cryptovec",
  "russh-util",
- "sec1",
+ "sec1 0.7.3",
  "sha1 0.10.7",
  "sha2 0.10.9",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "ssh-encoding",
  "subtle",
  "thiserror 1.0.69",
@@ -20430,7 +21123,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -20549,11 +21242,25 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.10",
  "generic-array 0.14.7",
- "pkcs8",
- "serdect",
+ "pkcs8 0.10.2",
+ "serdect 0.2.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct 1.0.0",
+ "ctutils",
+ "der 0.8.1",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -20857,7 +21564,17 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
  "serde",
 ]
 
@@ -21026,6 +21743,16 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -21219,7 +21946,7 @@ version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea991a652ea2e55f0523649f5c9efbfb32cf9fdcc2bf3b3580b4343a94379503"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "p3-bn254-fr",
  "serde",
  "slop-algebra",
@@ -21593,8 +22320,8 @@ checksum = "850948bee068e713b8ab860fe1adc4d109676ab4c3b621fd8147f06b261f2f85"
 dependencies = [
  "aes-gcm",
  "blake2",
- "chacha20poly1305",
- "curve25519-dalek",
+ "chacha20poly1305 0.10.1",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "ring",
  "rustc_version 0.4.1",
@@ -21871,12 +22598,12 @@ checksum = "93c3a16e1af983f60fb99176d340a401581677e63b7b1439ca034e83ca29476d"
 dependencies = [
  "cfg-if",
  "dashu",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "generic-array 1.1.0",
  "itertools 0.14.0",
  "k256",
  "num",
- "p256",
+ "p256 0.13.2",
  "serde",
  "slop-algebra",
  "snowbridge-amcl",
@@ -22302,8 +23029,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23e41cd36168cc2e51e5d3e35ff0c34b204d945769a65591a76286d04b51e43"
 dependencies = [
  "cfg-if",
- "ff",
- "group",
+ "ff 0.13.1",
+ "group 0.13.0",
  "pairing",
  "rand_core 0.6.4",
  "sp1-lib",
@@ -22344,7 +23071,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
 ]
 
 [[package]]
@@ -22554,9 +23291,9 @@ dependencies = [
  "aes-gcm",
  "cbc",
  "chacha20 0.9.1",
- "cipher",
+ "cipher 0.4.4",
  "ctr",
- "poly1305",
+ "poly1305 0.8.0",
  "ssh-encoding",
  "subtle",
 ]
@@ -22859,6 +23596,21 @@ dependencies = [
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
+ "windows 0.62.2",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.39.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "objc2-open-directory",
  "windows 0.62.2",
 ]
 
@@ -23494,10 +24246,12 @@ version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
 dependencies = [
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
+ "toml_writer",
  "winnow 1.0.4",
 ]
 
@@ -24392,6 +25146,16 @@ checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
  "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -25603,6 +26367,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "wnaf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25665,9 +26440,20 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "rand_core 0.10.1",
  "zeroize",
 ]
 

--- a/bin/consensus/Cargo.toml
+++ b/bin/consensus/Cargo.toml
@@ -22,3 +22,7 @@ base-consensus-cli.workspace = true
 
 # cli
 clap = { workspace = true, features = ["env"] }
+
+[features]
+# Pass-through: enables the in-process simplex consensus actor. Off by default.
+simplex = [ "base-consensus-cli/simplex" ]

--- a/crates/consensus/cli/Cargo.toml
+++ b/crates/consensus/cli/Cargo.toml
@@ -79,3 +79,5 @@ tokio = { workspace = true, features = ["test-util"] }
 [features]
 default = [ "otlp" ]
 otlp = [ "base-cli-utils/otlp", "reth-node-core/otlp" ]
+# Pass-through: enables the in-process simplex consensus actor in the node. Off by default.
+simplex = [ "base-consensus-node/simplex" ]

--- a/crates/consensus/service/Cargo.toml
+++ b/crates/consensus/service/Cargo.toml
@@ -82,6 +82,18 @@ reqwest.workspace = true
 # metrics
 metrics = { workspace = true, optional = true }
 
+# simplex consensus (optional; gated by the `simplex` feature, off by default).
+# Pinned to a git rev on commonware `main` for the stable-leader `Elector`
+# (`Terms::stable`), which the last crates.io release (=2026.7.0) does not have.
+commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo", rev = "5fde115a25f4eb496d584a725c2c1dedfbe10398", optional = true }
+commonware-actor = { git = "https://github.com/commonwarexyz/monorepo", rev = "5fde115a25f4eb496d584a725c2c1dedfbe10398", optional = true }
+commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "5fde115a25f4eb496d584a725c2c1dedfbe10398", optional = true }
+commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "5fde115a25f4eb496d584a725c2c1dedfbe10398", optional = true }
+commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo", rev = "5fde115a25f4eb496d584a725c2c1dedfbe10398", optional = true }
+commonware-parallel = { git = "https://github.com/commonwarexyz/monorepo", rev = "5fde115a25f4eb496d584a725c2c1dedfbe10398", optional = true }
+commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo", rev = "5fde115a25f4eb496d584a725c2c1dedfbe10398", optional = true }
+commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo", rev = "5fde115a25f4eb496d584a725c2c1dedfbe10398", optional = true }
+
 [dev-dependencies]
 rand.workspace = true
 rstest.workspace = true
@@ -103,6 +115,19 @@ alloy-rpc-types-engine = { workspace = true, features = ["arbitrary", "std"] }
 
 [features]
 default = []
+# Enables the in-process simplex consensus actor and pulls in the commonware
+# dependency. Off by default; when disabled the crate carries no commonware code
+# and the actor is never spawned (runtime `simplex_mode` also defaults to Off).
+simplex = [
+	"dep:commonware-consensus",
+	"dep:commonware-cryptography",
+	"dep:commonware-runtime",
+	"dep:commonware-parallel",
+	"dep:commonware-actor",
+	"dep:commonware-codec",
+	"dep:commonware-utils",
+	"dep:commonware-p2p",
+]
 metrics = [
 	"base-consensus-derive/metrics",
 	"base-consensus-disc/metrics",

--- a/crates/consensus/service/src/actors/mod.rs
+++ b/crates/consensus/service/src/actors/mod.rs
@@ -57,6 +57,21 @@ pub use network::{
     UnsafePayloadGossipClient, UnsafePayloadGossipClientError,
 };
 
+mod simplex;
+pub use simplex::{
+    ComparisonOutcome, ConsensusProposer, ConsensusStatus, ConsensusStatusReader, ShadowComparator,
+    SimplexActor, SimplexClient, SimplexError, SimplexMode, SimplexRequest,
+};
+#[cfg(test)]
+pub use simplex::{MockConsensusProposer, MockConsensusStatusReader};
+#[cfg(feature = "simplex")]
+pub use simplex::{
+    PinnedLeaderConfig, PinnedLeaderElector, SIMPLEX_CERTIFICATE_CHANNEL, SIMPLEX_RESOLVER_CHANNEL,
+    SIMPLEX_VOTE_CHANNEL, SimplexActivity, SimplexCertificate, SimplexConfig, SimplexConfigBuilder,
+    SimplexDigest, SimplexNetReceiver, SimplexNetSender, SimplexPublicKey, SimplexRuntimeContext,
+    SimplexScheme, SimplexStrategy, StatusReporter, StubAutomaton, StubBlocker, StubRelay,
+};
+
 mod sequencer;
 pub use sequencer::{
     BuildOutcome, BuildPipelineState, CanonicalReconciliationInputs, CanonicalUnsafeCatchup,

--- a/crates/consensus/service/src/actors/simplex/actor.rs
+++ b/crates/consensus/service/src/actors/simplex/actor.rs
@@ -1,0 +1,220 @@
+//! Simplex consensus actor.
+//!
+//! Phase 1 skeleton: this wires the [`NodeActor`] request/response plumbing and
+//! the read-side status [`watch`] channel, but carries **no consensus logic** —
+//! the commonware simplex engine is integrated in Phase 2. Requests that would
+//! require the engine return [`SimplexError::NotImplemented`].
+
+use async_trait::async_trait;
+use tokio::sync::{mpsc, watch};
+use tokio_util::sync::CancellationToken;
+
+use super::{ConsensusStatus, SimplexError, SimplexRequest};
+use crate::NodeActor;
+
+/// Operating mode for the simplex consensus actor.
+///
+/// Drives the staged rollout. Defaults to [`Off`](SimplexMode::Off). In
+/// `Off`/`Passive`/`Shadow` the actor is **not** authoritative for block
+/// production and must never take the node down (see the isolation invariant on
+/// [`SimplexActor::start`]); only in `Active`/`Primary` is it authoritative.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SimplexMode {
+    /// Actor not participating; no side effects. Shipped default.
+    #[default]
+    Off,
+    /// Joins the consensus mesh and runs views, but its outputs feed nobody.
+    Passive,
+    /// As `Passive`, plus compares decisions against op-conductor for divergence.
+    Shadow,
+    /// Authoritative for block production on this node.
+    Active,
+    /// Authoritative fleet-wide; op-conductor is a monitored standby.
+    Primary,
+}
+
+impl SimplexMode {
+    /// Returns whether the actor is authoritative for block production in this
+    /// mode. Only `Active`/`Primary` are authoritative; a fatal error may
+    /// propagate only in those modes.
+    pub const fn is_authoritative(self) -> bool {
+        matches!(self, Self::Active | Self::Primary)
+    }
+}
+
+/// Actor that owns the simplex consensus engine and drives it from a
+/// `tokio::select!` loop.
+///
+/// Phase 1 is a no-op skeleton; the commonware `Engine` and its `Handle`, plus
+/// the dedicated `commonware-p2p` transport, are added in Phase 2.
+#[derive(Debug)]
+pub struct SimplexActor {
+    mode: SimplexMode,
+    request_rx: mpsc::Receiver<SimplexRequest>,
+    status_tx: watch::Sender<ConsensusStatus>,
+}
+
+impl SimplexActor {
+    /// Creates a new simplex actor.
+    pub const fn new(
+        mode: SimplexMode,
+        request_rx: mpsc::Receiver<SimplexRequest>,
+        status_tx: watch::Sender<ConsensusStatus>,
+    ) -> Self {
+        Self { mode, request_rx, status_tx }
+    }
+
+    /// Handles a single request against the Phase 1 skeleton.
+    ///
+    /// No consensus logic exists yet, so every request resolves to
+    /// [`SimplexError::NotImplemented`]. Responder drops are logged, not fatal.
+    fn handle_request(&self, request: SimplexRequest) {
+        match request {
+            SimplexRequest::Propose { response_tx, .. } => {
+                if response_tx.send(Err(SimplexError::NotImplemented)).is_err() {
+                    debug!(target: "simplex", "propose response receiver dropped");
+                }
+            }
+            SimplexRequest::IsLeader { response_tx } => {
+                if response_tx.send(Err(SimplexError::NotImplemented)).is_err() {
+                    debug!(target: "simplex", "is_leader response receiver dropped");
+                }
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl NodeActor for SimplexActor {
+    type Error = SimplexError;
+    type StartData = CancellationToken;
+
+    /// Runs the no-op select loop until cancellation or request-channel closure.
+    ///
+    /// **Isolation is owned by the framework, not this actor.** The simplex actor
+    /// is spawned in the `non_fatal` group of `spawn_and_wait!` (`service/util.rs`),
+    /// which installs **no** drop guard and swallows any error — so this actor may
+    /// return `Ok` or `Err` freely without cancelling the shared token or
+    /// affecting the live op-conductor path. That lets the loop be a
+    /// straightforward `CheckpointActor`-style select (inlined directly under the
+    /// trait impl, matching `CheckpointActor::start`): return on cancellation, and
+    /// return on request-channel closure (which happens in Phase 1 when no consumer
+    /// holds the client). No per-actor idle-until-cancel workaround is needed.
+    async fn start(mut self, cancellation: Self::StartData) -> Result<(), Self::Error> {
+        // Re-publish the initial status on startup. In Phase 1 this is the only
+        // write to the channel (there is no engine to drive updates yet); Phase 2
+        // replaces it with live notarized/finalized/leadership updates from the
+        // commonware `Reporter`.
+        self.status_tx.send_replace(ConsensusStatus::default());
+
+        loop {
+            tokio::select! {
+                _ = cancellation.cancelled() => {
+                    info!(target: "simplex", mode = ?self.mode, "simplex actor received shutdown signal");
+                    return Ok(());
+                }
+                maybe_request = self.request_rx.recv() => {
+                    let Some(request) = maybe_request else {
+                        debug!(target: "simplex", mode = ?self.mode, "simplex request channel closed; exiting actor (non-fatal)");
+                        return Ok(());
+                    };
+                    self.handle_request(request);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::B256;
+    use alloy_rpc_types_engine::ExecutionPayloadV1;
+    use base_common_rpc_types_engine::{BaseExecutionPayload, BaseExecutionPayloadEnvelope};
+    use tokio::sync::{mpsc, watch};
+
+    use super::*;
+    use crate::actors::simplex::{ConsensusProposer, ConsensusStatusReader, SimplexClient};
+
+    fn test_envelope() -> BaseExecutionPayloadEnvelope {
+        BaseExecutionPayloadEnvelope {
+            parent_beacon_block_root: None,
+            execution_payload: BaseExecutionPayload::V1(ExecutionPayloadV1 {
+                parent_hash: B256::ZERO,
+                fee_recipient: alloy_primitives::Address::ZERO,
+                state_root: B256::ZERO,
+                receipts_root: B256::ZERO,
+                logs_bloom: alloy_primitives::Bloom::ZERO,
+                prev_randao: B256::ZERO,
+                block_number: 0,
+                gas_limit: 0,
+                gas_used: 0,
+                timestamp: 0,
+                extra_data: Default::default(),
+                base_fee_per_gas: Default::default(),
+                block_hash: B256::ZERO,
+                transactions: vec![],
+            }),
+        }
+    }
+
+    fn actor_with_client(mode: SimplexMode) -> (SimplexActor, SimplexClient) {
+        let (request_tx, request_rx) = mpsc::channel(8);
+        let (status_tx, status_rx) = watch::channel(ConsensusStatus::default());
+        let actor = SimplexActor::new(mode, request_rx, status_tx);
+        let client = SimplexClient::new(request_tx, status_rx);
+        (actor, client)
+    }
+
+    #[test]
+    fn only_active_and_primary_are_authoritative() {
+        assert!(!SimplexMode::Off.is_authoritative());
+        assert!(!SimplexMode::Passive.is_authoritative());
+        assert!(!SimplexMode::Shadow.is_authoritative());
+        assert!(SimplexMode::Active.is_authoritative());
+        assert!(SimplexMode::Primary.is_authoritative());
+    }
+
+    #[tokio::test]
+    async fn cancellation_shuts_down_cleanly() {
+        let (actor, _client) = actor_with_client(SimplexMode::Off);
+        let cancellation = CancellationToken::new();
+        let handle = tokio::spawn(actor.start(cancellation.clone()));
+        cancellation.cancel();
+        assert!(handle.await.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn skeleton_requests_return_not_implemented() {
+        let (actor, client) = actor_with_client(SimplexMode::Off);
+        let cancellation = CancellationToken::new();
+        let handle = tokio::spawn(actor.start(cancellation.clone()));
+
+        let propose_err = client.propose(test_envelope()).await.unwrap_err();
+        assert!(matches!(propose_err, SimplexError::NotImplemented));
+
+        let leader_err = client.is_leader().await.unwrap_err();
+        assert!(matches!(leader_err, SimplexError::NotImplemented));
+
+        cancellation.cancel();
+        assert!(handle.await.unwrap().is_ok());
+    }
+
+    /// The actor returns `Ok` on request-channel closure (which happens in Phase
+    /// 1 when no consumer holds the client) without cancelling the shared token.
+    /// Node isolation is now the framework's responsibility: the actor is spawned
+    /// in the `non_fatal` group of `spawn_and_wait!`, which swallows this return —
+    /// so the actor itself no longer needs to idle-until-cancel.
+    #[tokio::test]
+    async fn channel_close_returns_ok_without_cancelling() {
+        let (actor, client) = actor_with_client(SimplexMode::Passive);
+        let cancellation = CancellationToken::new();
+        let handle = tokio::spawn(actor.start(cancellation.clone()));
+
+        drop(client);
+        assert!(handle.await.unwrap().is_ok(), "actor returns Ok on channel close");
+        assert!(
+            !cancellation.is_cancelled(),
+            "actor must not cancel the shared token itself; isolation is the framework's job"
+        );
+    }
+}

--- a/crates/consensus/service/src/actors/simplex/client.rs
+++ b/crates/consensus/service/src/actors/simplex/client.rs
@@ -1,0 +1,198 @@
+//! Simplex consensus actor client.
+//!
+//! Consumers interact with the [`SimplexActor`](super::SimplexActor) only through
+//! the typed [`SimplexClient`] and the two narrow, mockable traits below —
+//! [`ConsensusProposer`] (write side) and [`ConsensusStatusReader`] (read side) —
+//! mirroring the `CheckpointWriter` / `ForkchoiceCheckpointReader` split so
+//! downstream actors depend on the capability they use, not the concrete client.
+//!
+//! The read side is a [`watch`] channel carrying a [`ConsensusStatus`] snapshot:
+//! leadership and the finalized head are continuously-changing state that the
+//! sequencer coordinator samples on its hot loop, so it must not block on an
+//! `mpsc` round-trip. The `mpsc` + `oneshot` path is reserved for the write
+//! ([`SimplexRequest::Propose`]) and for explicit point-in-time queries
+//! ([`SimplexRequest::IsLeader`]).
+
+use async_trait::async_trait;
+use base_common_rpc_types_engine::BaseExecutionPayloadEnvelope;
+use base_protocol::L2BlockInfo;
+use tokio::sync::{mpsc, oneshot, watch};
+
+use super::SimplexError;
+
+/// A point-in-time snapshot of consensus state, published on the read-side
+/// [`watch`] channel.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ConsensusStatus {
+    /// Whether this node is the leader of the current view.
+    pub is_leader: bool,
+    /// The latest finalized unsafe head agreed by consensus, if any.
+    pub finalized_head: Option<L2BlockInfo>,
+    /// The current consensus view number.
+    pub view: u64,
+}
+
+/// Write side of the consensus surface: hand a freshly sealed payload envelope to
+/// consensus to be proposed.
+///
+/// This is the redirect target for the sequencer seal pipeline's op-conductor
+/// commit when the simplex path is authoritative. The acknowledgement means only
+/// that consensus accepted the envelope for proposal — **not** that it was
+/// notarized or finalized; those outcomes are observed on the read side.
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait ConsensusProposer: Send + Sync + std::fmt::Debug {
+    /// Submits a sealed payload envelope to consensus to be proposed.
+    async fn propose(&self, envelope: BaseExecutionPayloadEnvelope) -> Result<(), SimplexError>;
+}
+
+/// Read side of the consensus surface: observe leadership and the finalized head.
+///
+/// [`subscribe`](ConsensusStatusReader::subscribe) hands out a [`watch::Receiver`]
+/// for lock-free, non-blocking sampling on the hot path;
+/// [`is_leader`](ConsensusStatusReader::is_leader) is an explicit point-in-time
+/// query for bootstrap/admin parity with `Conductor::leader`.
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait ConsensusStatusReader: Send + Sync + std::fmt::Debug {
+    /// Subscribes to the consensus status snapshot stream.
+    fn subscribe(&self) -> watch::Receiver<ConsensusStatus>;
+
+    /// Returns whether this node is the leader of the current view.
+    async fn is_leader(&self) -> Result<bool, SimplexError>;
+}
+
+/// Request sent to the [`SimplexActor`](super::SimplexActor).
+#[derive(Debug)]
+pub enum SimplexRequest {
+    /// Leader-only: hand a freshly sealed envelope to consensus to be proposed.
+    ///
+    /// The acknowledgement signals only that consensus accepted the envelope for
+    /// proposal, not that it was notarized or finalized.
+    Propose {
+        /// The sealed payload envelope to propose.
+        envelope: Box<BaseExecutionPayloadEnvelope>,
+        /// Response channel for the proposal acknowledgement.
+        response_tx: oneshot::Sender<Result<(), SimplexError>>,
+    },
+    /// Point-in-time leadership check (bootstrap / admin parity with
+    /// `Conductor::leader`). Steady-state readers should prefer the
+    /// [`watch`] channel from [`ConsensusStatusReader::subscribe`].
+    IsLeader {
+        /// Response channel for the leadership result.
+        response_tx: oneshot::Sender<Result<bool, SimplexError>>,
+    },
+}
+
+/// Client used to communicate with the [`SimplexActor`](super::SimplexActor).
+///
+/// Holds the request sender and a receiver for the consensus status snapshot so
+/// both the write path (`mpsc` + `oneshot`) and the read path (`watch`) are
+/// reachable from one handle.
+#[derive(Debug, Clone)]
+pub struct SimplexClient {
+    request_tx: mpsc::Sender<SimplexRequest>,
+    status_rx: watch::Receiver<ConsensusStatus>,
+}
+
+impl SimplexClient {
+    /// Creates a new simplex client.
+    pub const fn new(
+        request_tx: mpsc::Sender<SimplexRequest>,
+        status_rx: watch::Receiver<ConsensusStatus>,
+    ) -> Self {
+        Self { request_tx, status_rx }
+    }
+
+    async fn send(&self, request: SimplexRequest) -> Result<(), SimplexError> {
+        self.request_tx.send(request).await.map_err(|_| SimplexError::ChannelClosed)
+    }
+}
+
+#[async_trait]
+impl ConsensusProposer for SimplexClient {
+    async fn propose(&self, envelope: BaseExecutionPayloadEnvelope) -> Result<(), SimplexError> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.send(SimplexRequest::Propose { envelope: Box::new(envelope), response_tx }).await?;
+        response_rx.await.map_err(|_| SimplexError::ResponseDropped)?
+    }
+}
+
+#[async_trait]
+impl ConsensusStatusReader for SimplexClient {
+    fn subscribe(&self) -> watch::Receiver<ConsensusStatus> {
+        self.status_rx.clone()
+    }
+
+    async fn is_leader(&self) -> Result<bool, SimplexError> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.send(SimplexRequest::IsLeader { response_tx }).await?;
+        response_rx.await.map_err(|_| SimplexError::ResponseDropped)?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::B256;
+    use alloy_rpc_types_engine::ExecutionPayloadV1;
+    use base_common_rpc_types_engine::BaseExecutionPayload;
+
+    use super::*;
+
+    fn test_envelope() -> BaseExecutionPayloadEnvelope {
+        BaseExecutionPayloadEnvelope {
+            parent_beacon_block_root: None,
+            execution_payload: BaseExecutionPayload::V1(ExecutionPayloadV1 {
+                parent_hash: B256::ZERO,
+                fee_recipient: alloy_primitives::Address::ZERO,
+                state_root: B256::ZERO,
+                receipts_root: B256::ZERO,
+                logs_bloom: alloy_primitives::Bloom::ZERO,
+                prev_randao: B256::ZERO,
+                block_number: 0,
+                gas_limit: 0,
+                gas_used: 0,
+                timestamp: 0,
+                extra_data: Default::default(),
+                base_fee_per_gas: Default::default(),
+                block_hash: B256::ZERO,
+                transactions: vec![],
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn propose_maps_closed_channel_to_error() {
+        let (request_tx, request_rx) = mpsc::channel(1);
+        let (_status_tx, status_rx) = watch::channel(ConsensusStatus::default());
+        let client = SimplexClient::new(request_tx, status_rx);
+        drop(request_rx);
+
+        let err = client.propose(test_envelope()).await.unwrap_err();
+        assert!(matches!(err, SimplexError::ChannelClosed));
+    }
+
+    #[tokio::test]
+    async fn is_leader_maps_closed_channel_to_error() {
+        let (request_tx, request_rx) = mpsc::channel(1);
+        let (_status_tx, status_rx) = watch::channel(ConsensusStatus::default());
+        let client = SimplexClient::new(request_tx, status_rx);
+        drop(request_rx);
+
+        let err = client.is_leader().await.unwrap_err();
+        assert!(matches!(err, SimplexError::ChannelClosed));
+    }
+
+    #[tokio::test]
+    async fn subscribe_observes_published_status() {
+        let (request_tx, _request_rx) = mpsc::channel(1);
+        let (status_tx, status_rx) = watch::channel(ConsensusStatus::default());
+        let client = SimplexClient::new(request_tx, status_rx);
+
+        let mut rx = client.subscribe();
+        status_tx.send_replace(ConsensusStatus { is_leader: true, finalized_head: None, view: 7 });
+        assert!(rx.changed().await.is_ok());
+        assert!(rx.borrow().is_leader);
+        assert_eq!(rx.borrow().view, 7);
+    }
+}

--- a/crates/consensus/service/src/actors/simplex/consensus.rs
+++ b/crates/consensus/service/src/actors/simplex/consensus.rs
@@ -1,0 +1,785 @@
+//! Concrete commonware simplex type choices.
+//!
+//! This module (compiled only under the `simplex` feature) pins the concrete
+//! types for the simplex `Engine`'s cryptographic generics. It carries no live
+//! consensus logic yet — subsequent Phase-2 units add the `Automaton` / `Relay` /
+//! `Reporter` / `Elector` glue and drive the `Engine`.
+//!
+//! **Digest.** commonware's `Digest` is a foreign trait with heavy supertrait
+//! bounds (`Array + Copy + Random`, transitively `Codec`/`Ord`/`Display`/
+//! `Deref<[u8]>`), which Base's `PayloadHash` (an alloy `B256` newtype) does not
+//! implement. Rather than implement the foreign trait on a foreign-ish type, we
+//! reuse commonware's ready-made 32-byte digest, `sha256::Digest`. Its name is
+//! cosmetic — structurally it is a `[u8; 32]` wrapper with `From<[u8; 32]>` — so
+//! the decided value (a `PayloadHash`, per DESIGN.md "What does consensus
+//! decide?") maps into it losslessly via [`SimplexDigest::from`].
+//!
+//! **Scheme.** simplex's `S: Scheme<D>` is the simplex-specific marker trait
+//! `commonware_consensus::simplex::scheme::Scheme` (a blanket impl over
+//! `commonware_cryptography::certificate::Scheme`), **not** a bare cryptography
+//! `Scheme`. For the small fixed sequencer set we use the ed25519 certificate
+//! scheme; bls12381 / `threshold_simplex` remain a Phase-2 revisit for succinct
+//! certificates at larger `n` (see the fault-tolerance design question).
+
+use std::time::Duration;
+
+use commonware_actor::Feedback;
+use commonware_consensus::{
+    Automaton, CertifiableAutomaton, Relay, Reporter, Viewable,
+    simplex::{
+        Plan,
+        config::{Floor, ForwardingPolicy},
+        elector::{Config as ElectorConfig, Elector, Terms},
+        types::Context,
+    },
+    types::{Epoch, Participant, Round, TermLength, ViewDelta},
+};
+use commonware_cryptography::certificate::Verifier;
+use commonware_p2p::Blocker;
+use commonware_runtime::buffer::paged::CacheRef;
+use commonware_utils::{NZU16, NZU32, NZUsize, channel::oneshot, ordered::Set};
+use tokio::sync::watch;
+
+use super::ConsensusStatus;
+
+/// Concrete digest type for the simplex `Engine` (`D: Digest`).
+///
+/// A 32-byte digest wrapper. The decided L2 block's `PayloadHash` (32 bytes) is
+/// converted into this via `SimplexDigest::from(payload_hash.0)`.
+pub type SimplexDigest = commonware_cryptography::sha256::Digest;
+
+/// Concrete signature scheme for the simplex `Engine` (`S: Scheme<D>`).
+///
+/// The ed25519 certificate scheme, keyed over [`SimplexDigest`].
+pub type SimplexScheme = commonware_consensus::simplex::scheme::ed25519::Scheme;
+
+/// The public-key type of [`SimplexScheme`], projected via the scheme's
+/// `Verifier` associated type so it tracks the scheme choice rather than
+/// hardcoding `ed25519::PublicKey`.
+pub type SimplexPublicKey = <SimplexScheme as Verifier>::PublicKey;
+
+/// The certificate type of [`SimplexScheme`] (projected via `Verifier`), as seen
+/// by [`Elector::elect`].
+pub type SimplexCertificate = <SimplexScheme as Verifier>::Certificate;
+
+/// The concrete consensus activity our [`StatusReporter`] receives from the
+/// simplex `Engine` (`F: Reporter<Activity = Activity<S, D>>`).
+pub type SimplexActivity =
+    commonware_consensus::simplex::types::Activity<SimplexScheme, SimplexDigest>;
+
+/// The parallel-execution strategy for the simplex `Engine` (`T: Strategy`).
+///
+/// `Sequential` (single-threaded, deterministic) is the safe default for the
+/// small fixed sequencer set — no thread pool, easiest to reason about. commonware
+/// also provides `Rayon`; revisit for parallel batch signature verification if the
+/// voter set grows enough to warrant it.
+pub type SimplexStrategy = commonware_parallel::Sequential;
+
+/// The runtime environment for the simplex `Engine` (`E`, satisfying
+/// `BufferPooler + Clock + CryptoRng + Spawner + Storage + Metrics`).
+///
+/// A fully-concrete, generic-free type. **Construction constraint:** a `Context`
+/// value is only obtainable inside `commonware_runtime::tokio::Runner::start(|ctx|
+/// ...)` (private fields, no standalone constructor). So `Engine::new(context,
+/// cfg)` must run **inside** that runner closure — the actor drives the engine by
+/// building a `Runner` and constructing/starting the engine within its `start`
+/// closure (wired in a later unit).
+///
+/// `CryptoRng` is satisfied not by a direct impl but via `rand_core` 0.10.1's
+/// blanket `impl CryptoRng for R: TryCryptoRng<Error = Infallible>` (`Context`
+/// impls `TryRng`/`TryCryptoRng`). Both commonware crates pin `rand_core` 0.10.1,
+/// so the bound holds; if those versions ever diverge, this bound breaks — a
+/// coupling to watch at commonware upgrades.
+pub type SimplexRuntimeContext = commonware_runtime::tokio::Context;
+
+/// commonware-p2p channel id for simplex vote traffic (`Engine::start`'s first
+/// channel pair). Channel ids are caller-chosen `u64`s; only distinctness and
+/// cross-peer consistency matter.
+pub const SIMPLEX_VOTE_CHANNEL: commonware_p2p::Channel = 0;
+/// commonware-p2p channel id for simplex certificate traffic (second pair).
+pub const SIMPLEX_CERTIFICATE_CHANNEL: commonware_p2p::Channel = 1;
+/// commonware-p2p channel id for simplex resolver back-fill (third pair).
+pub const SIMPLEX_RESOLVER_CHANNEL: commonware_p2p::Channel = 2;
+
+/// The concrete p2p sender for a simplex channel, from the dedicated
+/// `commonware-p2p::authenticated` transport (the approved Networking decision),
+/// over our runtime env and public key.
+pub type SimplexNetSender =
+    commonware_p2p::authenticated::discovery::Sender<SimplexPublicKey, SimplexRuntimeContext>;
+/// The concrete p2p receiver for a simplex channel (authenticated transport).
+pub type SimplexNetReceiver = commonware_p2p::authenticated::discovery::Receiver<SimplexPublicKey>;
+
+/// The fully-applied simplex `Engine` configuration for our concrete generics.
+///
+/// This alias binds all eight `Config<S, L, B, D, A, R, F, T>` generics to our
+/// concrete types. Note `L` is the elector **config** ([`PinnedLeaderConfig`],
+/// which impls `elector::Config`), not the built [`PinnedLeaderElector`] — the
+/// engine calls `Config::build` internally with the participant set.
+///
+/// A `SimplexConfig` **value** is assembled inside the `Runner::start` closure
+/// (the value-construction unit): every field is a constant, a pinned component,
+/// or a genesis floor, except the page cache, which is built from the live
+/// context via `CacheRef::from_pooler`. The full field list + example values are
+/// captured in `docs/consensus-simplex/DESIGN.md` (In-process integration).
+pub type SimplexConfig = commonware_consensus::simplex::Config<
+    SimplexScheme,
+    PinnedLeaderConfig,
+    StubBlocker,
+    SimplexDigest,
+    StubAutomaton,
+    StubRelay,
+    StatusReporter,
+    SimplexStrategy,
+>;
+
+/// Our read side: a commonware [`Reporter`] that projects consensus activity onto
+/// the [`ConsensusStatus`] watch channel the sequencer coordinator samples.
+///
+/// `Reporter::report` is **synchronous**, takes `&mut self`, returns
+/// [`Feedback`], and the trait requires `Clone + Send + 'static` — the `Engine`
+/// owns the reporter and clones it, so state is shared through the cloneable
+/// [`watch::Sender`].
+///
+/// Phase-2 scope: this updates the consensus `view` from notarization /
+/// finalization certificates (the part fully derivable from `Activity`) and logs
+/// the finalized payload digest. It does **not** yet populate
+/// `finalized_head: Option<L2BlockInfo>` — resolving a [`SimplexDigest`] back to a
+/// full `L2BlockInfo` is the `Relay`/engine's job, wired in Phase 3.
+#[derive(Debug, Clone)]
+pub struct StatusReporter {
+    status_tx: watch::Sender<ConsensusStatus>,
+}
+
+impl StatusReporter {
+    /// Creates a new status reporter over the given status watch sender.
+    pub const fn new(status_tx: watch::Sender<ConsensusStatus>) -> Self {
+        Self { status_tx }
+    }
+
+    /// Advances the reported consensus `view` **monotonically**: a later,
+    /// possibly reordered or late-delivered, lower-view activity can never make
+    /// the observable view regress. Only signals a watch change when the view
+    /// strictly increases.
+    ///
+    /// Monotonicity matters because the sequencer coordinator samples this watch
+    /// on its hot loop to answer leadership; a regressing view (last-write-wins)
+    /// would feed a wrong leadership answer at the precise moment leadership is
+    /// changing during failover.
+    fn advance_view(&self, view: u64) {
+        self.status_tx.send_if_modified(|status| {
+            if view > status.view {
+                status.view = view;
+                true
+            } else {
+                false
+            }
+        });
+    }
+}
+
+impl Reporter for StatusReporter {
+    type Activity = SimplexActivity;
+
+    fn report(&mut self, activity: Self::Activity) -> Feedback {
+        match activity {
+            SimplexActivity::Finalization(finalization) => {
+                let view = finalization.view().get();
+                let digest = finalization.proposal.payload;
+                info!(target: "simplex", view, digest = %digest, "consensus finalized payload");
+                self.advance_view(view);
+            }
+            // A view is *entered* on exactly one 2f+1 event: a **certified**
+            // notarization (commonware advances the view iff the application
+            // certifies the notarization) or a **nullification** certificate (the
+            // leader-timeout skip — this IS the failover primitive, so it must be
+            // observed or the view goes stale exactly during failover). A bare
+            // `Notarization` is a formed certificate that has NOT yet advanced the
+            // view, so it does not move the reported view here (advancing on it
+            // would briefly mis-report an uncertified-then-nullified view).
+            SimplexActivity::Certification(notarization) => {
+                self.advance_view(notarization.view().get());
+            }
+            SimplexActivity::Nullification(nullification) => {
+                self.advance_view(nullification.view().get());
+            }
+            // Per-validator votes, bare notarizations, and fault evidence do not
+            // move the observable status in Phase 2. Fault variants
+            // (ConflictingNotarize/Finalize, NullifyFinalize) feed equivocation
+            // attribution in a later unit (see the review inbox item).
+            _ => {}
+        }
+        Feedback::Ok
+    }
+}
+
+/// Our dissemination side: a commonware [`Relay`] that broadcasts the body
+/// behind a decided digest to peers.
+///
+/// simplex itself moves only digests + votes; the full block body travels via
+/// this `Relay` (see DESIGN.md "What does consensus decide?"). `Relay::broadcast`
+/// is **synchronous** and returns [`Feedback`]; the trait requires
+/// `Clone + Send + 'static`.
+///
+/// Phase-2 scope: a compiling stub that acknowledges (`Feedback::Ok`) without
+/// yet shipping bodies. The real implementation — mapping a [`SimplexDigest`]
+/// back to its `BaseExecutionPayloadEnvelope` and pushing it over the dedicated
+/// commonware-p2p transport — is wired when the `Engine` is constructed (Phase 2)
+/// and the digest↔body store exists (Phase 3).
+#[derive(Debug, Clone, Default)]
+pub struct StubRelay;
+
+impl Relay for StubRelay {
+    type Digest = SimplexDigest;
+    type PublicKey = SimplexPublicKey;
+    type Plan = Plan<SimplexPublicKey>;
+
+    fn broadcast(&mut self, _payload: Self::Digest, _plan: Self::Plan) -> Feedback {
+        Feedback::Ok
+    }
+}
+
+/// Our block-production / verification side: a commonware [`CertifiableAutomaton`]
+/// (supertrait [`Automaton`]).
+///
+/// `propose` is asked for a payload when we lead a view; `verify` validates a
+/// peer's proposal; `certify` gates a *notarized* payload into finalization and
+/// **must be deterministic across honest nodes** (it depends only on the digest +
+/// deterministically-derivable data — never local timing/availability).
+///
+/// Phase-2 scope: a compiling, deliberately **inert** stub. `propose` and
+/// `verify` return a channel whose sender is dropped — no payload proposed, no
+/// verdict rendered — and `certify` keeps commonware's deterministic
+/// always-true default. This stub is **never wired to a live authoritative
+/// `Engine`** in Phase 2. Real block production (`propose` → the sequencer's
+/// built `BaseExecutionPayloadEnvelope`), payload validation (`verify` against the
+/// engine), and a real deterministic `certify` land in Phase 3.
+#[derive(Debug, Clone, Default)]
+pub struct StubAutomaton;
+
+impl Automaton for StubAutomaton {
+    type Context = Context<SimplexDigest, SimplexPublicKey>;
+    type Digest = SimplexDigest;
+
+    async fn propose(&mut self, _context: Self::Context) -> oneshot::Receiver<Self::Digest> {
+        // Inert stub: drop the sender so no payload is proposed (a valid "cannot
+        // generate a payload" per the trait contract). Real proposal is Phase 3.
+        let (_tx, rx) = oneshot::channel();
+        rx
+    }
+
+    async fn verify(
+        &mut self,
+        _context: Self::Context,
+        _payload: Self::Digest,
+    ) -> oneshot::Receiver<bool> {
+        // Inert stub: drop the sender so no verdict is rendered — deliberately
+        // never affirms validity. Real verification against the engine is Phase 3;
+        // this stub must not be wired to a live authoritative Engine.
+        let (_tx, rx) = oneshot::channel();
+        rx
+    }
+}
+
+// `certify` keeps commonware's deterministic always-true default; a real
+// deterministic certify (gating notarized payloads into finalization) is Phase 3.
+impl CertifiableAutomaton for StubAutomaton {}
+
+/// Leader-election config that pins leadership to a **subset** of the voter set.
+///
+/// This realizes the core fault-tolerance decision (see DESIGN.md
+/// "Fault-tolerance target & voter/leader decoupling"): all `n` participants
+/// vote, but only the sequencer subset is ever elected leader. commonware's
+/// built-in `RoundRobin`/`Random` electors spread leadership across **all**
+/// participants, which is not what we want.
+///
+/// `leader_indices` are indices into the ordered participant (voter) set. An
+/// **empty** set — the `Default` required by the `Config` trait — degrades to
+/// "all participants eligible"; production must set the pinned sequencer indices.
+/// Determinism (required by `Elector`) holds: election is a pure function of
+/// `(round, leader set, term policy)`.
+///
+/// `terms` is the **stable-leader** policy: a pinned leader holds across a whole
+/// *term* (a run of `Terms::length()` consecutive views) and rotates only at term
+/// boundaries — or sooner via `stall_timeout` on leader inactivity, which is the
+/// failover primitive. [`PinnedLeaderConfig::new`] uses [`Self::default_terms`]
+/// (Phase-3/4 tuning placeholders); [`PinnedLeaderConfig::with_terms`] takes an
+/// explicit policy (e.g. `Terms::rotating()` for one-leader-per-view).
+#[derive(Clone, Debug)]
+pub struct PinnedLeaderConfig {
+    leader_indices: Vec<usize>,
+    terms: Terms,
+}
+
+impl PinnedLeaderConfig {
+    /// Creates a config pinning leadership to the given participant indices, using
+    /// the [default stable-leader term policy](Self::default_terms).
+    pub const fn new(leader_indices: Vec<usize>) -> Self {
+        Self { leader_indices, terms: Self::default_terms() }
+    }
+
+    /// Creates a config with the given pinned indices and an explicit term policy
+    /// (e.g. `Terms::rotating()` for one leader per view, or a custom stable term).
+    pub const fn with_terms(leader_indices: Vec<usize>, terms: Terms) -> Self {
+        Self { leader_indices, terms }
+    }
+
+    /// The default stable-leader term policy. **Phase-3/4 tuning placeholders:** a
+    /// pinned leader holds for `length` consecutive views before deterministic
+    /// rotation, `stall_timeout` hands off sooner if the leader stalls (the
+    /// failover primitive, analogous to Raft's election timeout), and
+    /// `optimistic_views` disables optimistic look-ahead for now. `stall_timeout`
+    /// must exceed the Engine's `certification_timeout` (an Engine invariant, and
+    /// the config builder uses 2s). Real values (cross-region Δ budget) are a later
+    /// tuning task tracked in the review inbox.
+    const fn default_terms() -> Terms {
+        Terms::stable(TermLength::new(NZU32!(100)), Duration::from_secs(5), ViewDelta::new(0))
+    }
+}
+
+impl Default for PinnedLeaderConfig {
+    fn default() -> Self {
+        Self { leader_indices: Vec::new(), terms: Self::default_terms() }
+    }
+}
+
+impl ElectorConfig<SimplexScheme> for PinnedLeaderConfig {
+    type Elector = PinnedLeaderElector;
+
+    fn build(self, participants: &Set<SimplexPublicKey>) -> PinnedLeaderElector {
+        assert!(!participants.is_empty(), "no participants");
+        let n = participants.len();
+        let leaders: Vec<Participant> = if self.leader_indices.is_empty() {
+            (0..n).map(Participant::from_usize).collect()
+        } else {
+            self.leader_indices
+                .iter()
+                .map(|&index| {
+                    assert!(index < n, "leader index {index} out of range for {n} participants");
+                    Participant::from_usize(index)
+                })
+                .collect()
+        };
+        PinnedLeaderElector { leaders, terms: self.terms }
+    }
+}
+
+/// Initialized elector that keeps a **stable** leader within each term, rotating
+/// only among the pinned subset at term boundaries.
+///
+/// Created via [`PinnedLeaderConfig::build`] (called internally by consensus).
+#[derive(Clone, Debug)]
+pub struct PinnedLeaderElector {
+    leaders: Vec<Participant>,
+    terms: Terms,
+}
+
+impl Elector<SimplexScheme> for PinnedLeaderElector {
+    fn terms(&self) -> Terms {
+        self.terms
+    }
+
+    fn elect(&self, round: Round, _certificate: Option<&SimplexCertificate>) -> Participant {
+        // Stable-leader: the leader is a pure function of the *term index* — a run
+        // of `terms().length()` consecutive views — not the raw view, so one
+        // pinned leader holds across a whole term and rotation happens only at term
+        // boundaries (or sooner via `stall_timeout` on leader inactivity). Mirrors
+        // commonware `RoundRobinElector`'s index math, but over the pinned subset.
+        let term_index = round.view().term_index(self.terms.length());
+        let n = u64::try_from(self.leaders.len()).expect("leader count fits in u64");
+        let index = round.epoch().get().wrapping_add(term_index) % n;
+        self.leaders[usize::try_from(index).expect("leader index fits in usize")]
+    }
+}
+
+/// Peer-blocking hook for the simplex `Engine` (`B: Blocker`).
+///
+/// The `Engine` calls `block` to disconnect and ban a misbehaving peer
+/// (equivocation, invalid signatures). `Blocker::block` is **synchronous** and
+/// returns [`Feedback`]; the trait requires `Clone + Send + 'static`.
+///
+/// Phase-2 scope: a compiling stub that logs the block request and acknowledges.
+/// Real blocking — disconnecting/banning the peer on the dedicated commonware-p2p
+/// transport — is wired when that transport is constructed alongside the `Engine`.
+#[derive(Debug, Clone, Default)]
+pub struct StubBlocker;
+
+impl Blocker for StubBlocker {
+    type PublicKey = SimplexPublicKey;
+
+    fn block(&mut self, peer: Self::PublicKey) -> Feedback {
+        warn!(
+            target: "simplex",
+            peer = %peer,
+            "simplex requested peer block (stub: no-op until the p2p transport is wired)"
+        );
+        Feedback::Ok
+    }
+}
+
+/// Assembler for the [`SimplexConfig`] value the `Engine` consumes.
+///
+/// A unit-struct carrier so the public API exports a type with a `build` method
+/// rather than a loose function (per `CLAUDE.md`); [`SimplexConfig`] is a foreign
+/// type alias, so an inherent `SimplexConfig::build` is not possible.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SimplexConfigBuilder;
+
+impl SimplexConfigBuilder {
+    /// Assembles the [`SimplexConfig`] value for the `Engine`.
+    ///
+    /// The identity-bearing / stateful pieces are passed in — `scheme` (this
+    /// node's signing identity + participant set), `elector` (which participant
+    /// indices may lead), `reporter` (the read-side watch), and the `genesis`
+    /// digest for the `Floor` — while the inert Phase-2 stubs
+    /// (`StubBlocker`/`StubAutomaton`/`StubRelay`) and `Sequential` strategy are
+    /// defaulted, and the timing/buffer scalars use the placeholder constants
+    /// below.
+    ///
+    /// Must be called with a live runtime `context` (only `page_cache` needs it,
+    /// via `CacheRef::from_pooler`). Generic over the pooler so production
+    /// ([`SimplexRuntimeContext`] = tokio) and tests (`deterministic::Context`)
+    /// can both build it — `page_cache` is a concrete `CacheRef` regardless of
+    /// which pooler produced it, and the Engine's `E` is a separate generic. The
+    /// **timeout / buffer / epoch values are Phase-2 placeholders** mirroring
+    /// commonware's own tests — real tuning (cross-region Δ budget, `ViewDelta`
+    /// windows, partition naming, real genesis) is a Phase-3/4 task tracked in the
+    /// review inbox. This does not start consensus; it only builds the config the
+    /// `Engine::new` unit consumes inside a `Runner::start` closure.
+    #[allow(clippy::too_many_arguments)]
+    pub fn build(
+        context: &impl commonware_runtime::BufferPooler,
+        scheme: SimplexScheme,
+        elector: PinnedLeaderConfig,
+        reporter: StatusReporter,
+        partition: String,
+        genesis: SimplexDigest,
+    ) -> SimplexConfig {
+        commonware_consensus::simplex::Config {
+            scheme,
+            elector,
+            blocker: StubBlocker,
+            automaton: StubAutomaton,
+            relay: StubRelay,
+            reporter,
+            // Off by default: extra per-validator historical vote reporting (the
+            // equivocation-attribution path, an open Phase-2/4 verify item).
+            track_historical_votes: false,
+            strategy: SimplexStrategy::default(),
+            partition,
+            mailbox_size: NZUsize!(1024),
+            epoch: Epoch::new(0),
+            floor: Floor::Genesis(genesis),
+            leader_timeout: Duration::from_secs(1),
+            certification_timeout: Duration::from_secs(2),
+            timeout_retry: Duration::from_secs(10),
+            fetch_timeout: Duration::from_secs(1),
+            // On this git rev `skip_timeout` is a `Duration` (was a `ViewDelta` on
+            // =2026.7.0), and `view_retention` (`ViewDelta`) replaces the removed
+            // `activity_timeout`/`fetch_concurrent`. Phase-3/4 tuning placeholders;
+            // Config invariant: `skip_timeout` must exceed BOTH
+            // `certification_timeout` (2s) and `timeout_retry` (10s).
+            skip_timeout: Duration::from_secs(15),
+            view_retention: ViewDelta::new(10),
+            replay_buffer: NZUsize!(1024 * 1024),
+            write_buffer: NZUsize!(1024 * 1024),
+            page_cache: CacheRef::from_pooler(context, NZU16!(1024), NZUsize!(10)),
+            forwarding: ForwardingPolicy::Disabled,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A 32-byte hash (as produced by `BaseExecutionPayloadEnvelope::payload_hash`)
+    /// round-trips losslessly into and out of [`SimplexDigest`], confirming the
+    /// decided-value mapping holds at the type level.
+    #[test]
+    fn payload_hash_bytes_round_trip_through_digest() {
+        let bytes = [7u8; 32];
+        let digest = SimplexDigest::from(bytes);
+        assert_eq!(digest.as_ref(), &bytes[..]);
+    }
+
+    /// The reporter constructs over a status watch and is `Clone` (required by the
+    /// `Reporter` supertrait bound — the `Engine` owns and clones it while state is
+    /// shared through the cloneable `watch::Sender`). Both the reporter and a clone
+    /// observe the same channel.
+    ///
+    /// Note: driving a `Finalization` through `report` to assert the `view`
+    /// projection requires constructing an ed25519 `S::Certificate`, which is only
+    /// practical inside commonware's Engine test harness (or under its `mocks`
+    /// feature); that behavioral test is deferred to the Engine-integration unit.
+    #[test]
+    fn reporter_is_clone_over_shared_status_channel() {
+        let (status_tx, status_rx) = watch::channel(ConsensusStatus::default());
+        let reporter = StatusReporter::new(status_tx);
+        // Cloning yields an independent handle over the SAME channel: drop the
+        // original, and a clone still keeps the receiver alive and observable.
+        let clone = reporter.clone();
+        drop(reporter);
+        assert!(!status_rx.has_changed().unwrap());
+        assert_eq!(status_rx.borrow().view, 0);
+        drop(clone);
+    }
+
+    /// The reporter advances the observed `view` **monotonically**: a reordered
+    /// or late-delivered lower-view activity must never make the reported view
+    /// regress, and an equal view is a no-op. This is the core of the fix for the
+    /// last-write-wins projection that could feed a stale/regressing leadership
+    /// answer during failover.
+    ///
+    /// The projection is exercised through the private `advance_view` helper
+    /// rather than by driving real `Activity` variants through `report`, because
+    /// constructing a `Nullification`/`Certification`/`Finalization` requires a
+    /// signed `S::Certificate` that is only practical to produce inside
+    /// commonware's Engine test harness (same rationale as the reporter clone test
+    /// above); a behavioral Activity-driven test lands with the multi-validator
+    /// Engine tests.
+    #[test]
+    fn reporter_view_is_monotonic() {
+        let (status_tx, status_rx) = watch::channel(ConsensusStatus::default());
+        let reporter = StatusReporter::new(status_tx);
+
+        reporter.advance_view(5);
+        assert_eq!(status_rx.borrow().view, 5);
+
+        // Reordered / late lower-view activity must not regress the view.
+        reporter.advance_view(3);
+        assert_eq!(status_rx.borrow().view, 5, "view must never regress");
+
+        // Equal view is a no-op.
+        reporter.advance_view(5);
+        assert_eq!(status_rx.borrow().view, 5);
+
+        // A strictly higher view advances (e.g. a nullification skip during
+        // failover, which the old projection dropped entirely).
+        reporter.advance_view(9);
+        assert_eq!(status_rx.borrow().view, 9);
+    }
+
+    /// The stub relay accepts a broadcast for a `Propose` plan and acknowledges
+    /// it. Confirms the `Relay` associated types (Digest/PublicKey/Plan) resolve
+    /// against our concrete scheme and that `broadcast` is the synchronous
+    /// `Feedback`-returning shape.
+    #[test]
+    fn stub_relay_broadcast_acknowledges() {
+        use commonware_consensus::types::{Epoch, Round, View};
+
+        let mut relay = StubRelay;
+        let plan = Plan::Propose { round: Round::new(Epoch::new(0), View::new(1)) };
+        let digest = SimplexDigest::from([0u8; 32]);
+        assert!(matches!(relay.broadcast(digest, plan), Feedback::Ok));
+    }
+
+    /// The stub satisfies `CertifiableAutomaton` (and its `Automaton` supertrait,
+    /// which requires `Clone`) — asserted at compile time via the bound below.
+    /// A behavioral `propose`/`verify` test needs a `Context` carrying a real
+    /// leader `PublicKey` (only practical inside the Engine test harness), so it
+    /// is deferred to the Engine-integration unit.
+    #[test]
+    fn stub_automaton_satisfies_certifiable_automaton() {
+        fn assert_certifiable<A: CertifiableAutomaton>(_: &A) {}
+        let automaton = StubAutomaton;
+        assert_certifiable(&automaton);
+        assert_eq!(format!("{automaton:?}"), "StubAutomaton");
+    }
+
+    /// A pinned-leader elector elects **only** from the pinned subset (here, the
+    /// single participant index 1), regardless of round — realizing leader ⊆
+    /// voter. An empty config with `Terms::rotating()` degrades to all
+    /// participants, one leader per view (round-robin over the full set).
+    #[test]
+    fn pinned_leader_elector_rotates_only_over_subset() {
+        use commonware_consensus::types::{Epoch, View};
+        use commonware_cryptography::{Signer, ed25519::PrivateKey};
+
+        // Three voters; deterministic keys via insecure test-only from_seed.
+        let participants: Set<SimplexPublicKey> =
+            Set::from_iter_dedup((0..3u64).map(|seed| PrivateKey::from_seed(seed).public_key()));
+
+        // Pin leadership to participant index 1 only: every round elects it
+        // (single pinned leader ⇒ same leader regardless of the term policy).
+        let pinned = PinnedLeaderConfig::new(vec![1]).build(&participants);
+        for (epoch, view) in [(0u64, 1u64), (0, 2), (1, 5), (7, 3)] {
+            let leader = pinned.elect(Round::new(Epoch::new(epoch), View::new(view)), None);
+            assert_eq!(leader, Participant::from_usize(1), "pinned leader must be index 1");
+        }
+
+        // Empty config + rotating terms degrades to all participants, one leader
+        // per view (round-robin over the full set).
+        let all = PinnedLeaderConfig::with_terms(vec![], Terms::rotating()).build(&participants);
+        assert_eq!(
+            all.elect(Round::new(Epoch::new(0), View::new(0)), None),
+            Participant::from_usize(0)
+        );
+        assert_eq!(
+            all.elect(Round::new(Epoch::new(0), View::new(1)), None),
+            Participant::from_usize(1)
+        );
+        assert_eq!(
+            all.elect(Round::new(Epoch::new(0), View::new(3)), None),
+            Participant::from_usize(0)
+        );
+    }
+
+    /// **Stable-leader**: within a term (a run of `Terms::length()` consecutive
+    /// views) the SAME pinned leader is elected for every view; the leader advances
+    /// to the next pinned candidate only at the term boundary. This is the core
+    /// latency property of the effort — one leader proposing across consecutive
+    /// views on the happy path, not a cross-region hop every view. Uses an explicit
+    /// term length of 3 over k=3 pinned leaders (indices 0,1,2) of a 5-voter set,
+    /// so leadership stability and leader ⊆ voter are both exercised.
+    #[test]
+    fn pinned_leader_elector_is_stable_within_term() {
+        use commonware_consensus::types::{Epoch, View};
+        use commonware_cryptography::{Signer, ed25519::PrivateKey};
+
+        let participants: Set<SimplexPublicKey> =
+            Set::from_iter_dedup((0..5u64).map(|seed| PrivateKey::from_seed(seed).public_key()));
+
+        // Term length 3: a pinned leader holds for 3 consecutive views.
+        let terms =
+            Terms::stable(TermLength::new(NZU32!(3)), Duration::from_secs(10), ViewDelta::new(0));
+        let elector = PinnedLeaderConfig::with_terms(vec![0, 1, 2], terms).build(&participants);
+        let leader = |view: u64| elector.elect(Round::new(Epoch::new(0), View::new(view)), None);
+
+        // Views 1,2,3 are one term ⇒ the SAME leader across all three.
+        let first = leader(1);
+        assert_eq!(first, leader(2), "leader must not rotate within a term");
+        assert_eq!(first, leader(3), "leader must not rotate within a term");
+
+        // View 4 opens the next term ⇒ the leader advances, then stays stable.
+        let second = leader(4);
+        assert_ne!(first, second, "leader must advance at the term boundary");
+        assert_eq!(second, leader(5), "leader must stay stable across the new term");
+        assert_eq!(second, leader(6), "leader must stay stable across the new term");
+
+        // Every elected leader is within the pinned subset {0,1,2}.
+        let pinned = [0usize, 1, 2].map(Participant::from_usize);
+        for view in 1..=9 {
+            assert!(pinned.contains(&leader(view)), "elected leader must be in the pinned subset");
+        }
+    }
+
+    /// The stub blocker acknowledges a block request for a real peer key.
+    #[test]
+    fn stub_blocker_acknowledges_block() {
+        use commonware_cryptography::{Signer, ed25519::PrivateKey};
+
+        let mut blocker = StubBlocker;
+        let peer = PrivateKey::from_seed(0).public_key();
+        assert!(matches!(blocker.block(peer), Feedback::Ok));
+    }
+
+    /// The chosen strategy satisfies commonware's `Strategy` (the Engine's `T`),
+    /// asserted at compile time; `Sequential` constructs trivially.
+    #[test]
+    fn simplex_strategy_satisfies_strategy() {
+        fn assert_strategy<T: commonware_parallel::Strategy>(_: &T) {}
+        let strategy = SimplexStrategy::default();
+        assert_strategy(&strategy);
+    }
+
+    /// The runtime context satisfies the five nameable `commonware_runtime` bounds
+    /// of the Engine's `E` (compile-time). The sixth, `rand_core::CryptoRng`, is
+    /// satisfied via a blanket impl (source-verified) and is checked for real when
+    /// `Engine::new` is written; asserting it here would require adding `rand_core`
+    /// as a direct dep just for a test.
+    #[test]
+    fn simplex_runtime_context_satisfies_runtime_env() {
+        use commonware_runtime::{BufferPooler, Clock, Metrics, Spawner, Storage};
+        fn assert_env<E: BufferPooler + Clock + Spawner + Storage + Metrics>() {}
+        assert_env::<SimplexRuntimeContext>();
+    }
+
+    /// `SimplexConfig` is well-formed — naming it as a concrete type forces the
+    /// compiler to check that all eight `Config<S,L,B,D,A,R,F,T>` where-clause
+    /// bounds hold *together* for our concrete components (e.g.
+    /// `A: CertifiableAutomaton<Context = Context<D, S::PublicKey>>`,
+    /// `F: Reporter<Activity = Activity<S, D>>`, `L: elector::Config<S>`). If the
+    /// eight pieces didn't fit the Engine, this would not compile.
+    #[test]
+    fn simplex_config_type_is_well_formed() {
+        fn assert_well_formed(_: Option<SimplexConfig>) {}
+        assert_well_formed(None);
+    }
+
+    /// The concrete authenticated-transport channel types satisfy exactly what
+    /// `Engine::start` requires for each of its three channel pairs:
+    /// `Sender`/`Receiver` keyed by `SimplexPublicKey`. Compile-time.
+    #[test]
+    fn simplex_net_channel_types_match_engine_start() {
+        fn assert_channel<Se, Re>()
+        where
+            Se: commonware_p2p::Sender<PublicKey = SimplexPublicKey>,
+            Re: commonware_p2p::Receiver<PublicKey = SimplexPublicKey>,
+        {
+        }
+        assert_channel::<SimplexNetSender, SimplexNetReceiver>();
+    }
+
+    /// End-to-end construction: build a real ed25519 scheme + all our glue for a
+    /// single validator, wire a `simulated` network's three channels, assemble the
+    /// config, and `Engine::new` + `engine.start`. Exercises the whole Phase-2
+    /// stack against a REAL commonware Engine on the `deterministic` runtime — the
+    /// payoff that ties every pinned type + impl together at runtime. Uses the
+    /// production `Scheme::signer` ctor (no `mocks` feature) and the `simulated`
+    /// network (no sockets). Asserts construction + start succeed; consensus
+    /// progress itself is exercised by later multi-validator tests.
+    #[test]
+    fn single_validator_engine_constructs_and_starts() {
+        use std::num::NonZeroU32;
+
+        use commonware_cryptography::{Signer, ed25519};
+        use commonware_p2p::simulated;
+        use commonware_runtime::{Quota, Runner as _, Supervisor as _, deterministic};
+
+        let executor = deterministic::Runner::timed(Duration::from_secs(5));
+        executor.start(|context| async move {
+            // One validator: deterministic key, participant set of just itself.
+            let private_key = ed25519::PrivateKey::from_seed(0);
+            let public_key = private_key.public_key();
+            let participants: Set<SimplexPublicKey> = Set::from_iter_dedup([public_key.clone()]);
+            let scheme = SimplexScheme::signer(b"base-simplex-test", participants, private_key)
+                .expect("signer key is in the participant set");
+
+            // Simulated network with a single peer; register the 3 simplex channels.
+            let (network, oracle) = simulated::Network::new_with_peers(
+                context.child("network"),
+                simulated::Config {
+                    max_size: 1024 * 1024,
+                    max_peers_per_set: NZUsize!(1),
+                    disconnect_on_block: true,
+                    tracked_peer_sets: NZUsize!(1),
+                },
+                std::iter::once(public_key.clone()),
+            )
+            .await;
+            network.start();
+            let control = oracle.control(public_key.clone());
+            let quota = Quota::per_second(NonZeroU32::MAX);
+            let vote = control.register(SIMPLEX_VOTE_CHANNEL, quota).await.unwrap();
+            let certificate = control.register(SIMPLEX_CERTIFICATE_CHANNEL, quota).await.unwrap();
+            let resolver = control.register(SIMPLEX_RESOLVER_CHANNEL, quota).await.unwrap();
+
+            // Our glue + config value.
+            let (status_tx, _status_rx) = watch::channel(ConsensusStatus::default());
+            let cfg = SimplexConfigBuilder::build(
+                &context,
+                scheme,
+                PinnedLeaderConfig::new(vec![0]),
+                StatusReporter::new(status_tx),
+                public_key.to_string(),
+                SimplexDigest::from([0u8; 32]),
+            );
+
+            // Construct + start a real Engine, then abort (we assert wiring, not
+            // full consensus progress here).
+            let engine = commonware_consensus::simplex::Engine::new(context.child("engine"), cfg);
+            let handle = engine.start(vote, certificate, resolver);
+            handle.abort();
+        });
+    }
+}

--- a/crates/consensus/service/src/actors/simplex/error.rs
+++ b/crates/consensus/service/src/actors/simplex/error.rs
@@ -1,0 +1,22 @@
+//! Simplex consensus actor error types.
+
+/// Error returned by simplex consensus actor operations.
+#[derive(Debug, thiserror::Error)]
+pub enum SimplexError {
+    /// The simplex actor request channel was closed.
+    #[error("simplex actor channel closed")]
+    ChannelClosed,
+    /// The simplex actor response was dropped before a reply was sent.
+    #[error("simplex actor response dropped")]
+    ResponseDropped,
+    /// The requested operation is not yet implemented.
+    ///
+    /// Returned by the Phase 1 skeleton actor, which wires the request/response
+    /// plumbing but carries no consensus logic yet. Replaced as the commonware
+    /// simplex engine is integrated in Phase 2.
+    #[error("simplex consensus not yet implemented (Phase 1 skeleton)")]
+    NotImplemented,
+    /// A consensus-layer error surfaced from the underlying engine.
+    #[error("simplex consensus error: {0}")]
+    Consensus(String),
+}

--- a/crates/consensus/service/src/actors/simplex/mod.rs
+++ b/crates/consensus/service/src/actors/simplex/mod.rs
@@ -1,0 +1,34 @@
+//! Simplex consensus actor.
+//!
+//! A net-new, feature-flagged consensus actor built on commonware simplex
+//! (stable-leader), running in-process to replace op-conductor's out-of-process
+//! Raft leadership + payload commit on the sequencer hot path. Phase 1 is a no-op
+//! skeleton (request/response plumbing + read-side status watch, no consensus
+//! logic); the commonware engine and its dedicated p2p transport arrive in Phase
+//! 2. See `docs/consensus-simplex/DESIGN.md`.
+
+mod actor;
+pub use actor::{SimplexActor, SimplexMode};
+
+mod client;
+pub use client::{
+    ConsensusProposer, ConsensusStatus, ConsensusStatusReader, SimplexClient, SimplexRequest,
+};
+#[cfg(test)]
+pub use client::{MockConsensusProposer, MockConsensusStatusReader};
+
+mod error;
+pub use error::SimplexError;
+
+mod shadow;
+pub use shadow::{ComparisonOutcome, ShadowComparator};
+
+#[cfg(feature = "simplex")]
+mod consensus;
+#[cfg(feature = "simplex")]
+pub use consensus::{
+    PinnedLeaderConfig, PinnedLeaderElector, SIMPLEX_CERTIFICATE_CHANNEL, SIMPLEX_RESOLVER_CHANNEL,
+    SIMPLEX_VOTE_CHANNEL, SimplexActivity, SimplexCertificate, SimplexConfig, SimplexConfigBuilder,
+    SimplexDigest, SimplexNetReceiver, SimplexNetSender, SimplexPublicKey, SimplexRuntimeContext,
+    SimplexScheme, SimplexStrategy, StatusReporter, StubAutomaton, StubBlocker, StubRelay,
+};

--- a/crates/consensus/service/src/actors/simplex/shadow.rs
+++ b/crates/consensus/service/src/actors/simplex/shadow.rs
@@ -1,0 +1,243 @@
+//! Read-only shadow comparator for the simplex rollout.
+//!
+//! The first step of Phase 3 (sequencer integration): observe the simplex
+//! leadership signal ([`ConsensusStatus`]) and op-conductor's leadership
+//! ([`Conductor::leader`]) side by side, emit divergence metrics, and log
+//! mismatches — while **acting on nothing**. No proposes, no commits, no
+//! forkchoice, and no redirect of any op-conductor authority; op-conductor stays
+//! fully authoritative.
+//!
+//! This deliberately mirrors the shadow-sequencer precedent's discipline
+//! (side-effect-free observation gated by a mode) but at the leadership layer.
+//! The comparator is constructed only when `simplex_mode` is `Shadow` or higher,
+//! and runs in the `non_fatal` spawn group so a comparison failure has zero blast
+//! radius on the live path. It needs no commonware, so it is not feature-gated.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::watch;
+use tokio_util::sync::CancellationToken;
+
+use super::{ConsensusStatus, SimplexError, SimplexMode};
+use crate::{Metrics, NodeActor, actors::sequencer::Conductor};
+
+/// Outcome of a single read-only comparison between the simplex leadership signal
+/// and op-conductor's leadership for this node.
+///
+/// Carries no side effects — [`ShadowComparator::record`] turns it into metrics
+/// and logs — so the comparison logic is unit-testable without the global metrics
+/// facade.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ComparisonOutcome {
+    /// Both systems agree on whether this node is the leader.
+    Agree,
+    /// The two systems disagree on this node's leadership.
+    Diverged {
+        /// simplex's view of this node's leadership.
+        simplex_leader: bool,
+        /// op-conductor's view of this node's leadership.
+        conductor_leader: bool,
+    },
+    /// op-conductor could not be queried (RPC error); no comparison was made.
+    ConductorUnavailable,
+}
+
+/// Read-only comparator that observes simplex vs op-conductor leadership.
+///
+/// **Acts on nothing.** It samples the simplex [`ConsensusStatus`] watch, queries
+/// op-conductor's [`Conductor::leader`], and emits a divergence counter + an
+/// agreement gauge + structured logs. It never proposes, commits, or redirects
+/// any op-conductor authority — the safe first step of the staged rollout.
+///
+/// Runs only in `Shadow` (and higher, once authoritative wiring lands); in
+/// `Off`/`Passive` it is not constructed. If op-conductor is not configured there
+/// is nothing to compare, so it idles until shutdown.
+#[derive(Debug)]
+pub struct ShadowComparator {
+    mode: SimplexMode,
+    status_rx: watch::Receiver<ConsensusStatus>,
+    conductor: Option<Arc<dyn Conductor>>,
+}
+
+impl ShadowComparator {
+    /// Creates a new read-only shadow comparator over the simplex status watch and
+    /// (optionally) an op-conductor leadership source.
+    pub const fn new(
+        mode: SimplexMode,
+        status_rx: watch::Receiver<ConsensusStatus>,
+        conductor: Option<Arc<dyn Conductor>>,
+    ) -> Self {
+        Self { mode, status_rx, conductor }
+    }
+
+    /// Compares one simplex `status` sample against op-conductor's leadership,
+    /// **without acting**. Side effects (metrics/logs) are applied separately by
+    /// [`record`](Self::record), keeping this pure enough to unit-test with a mock
+    /// conductor.
+    async fn compare_once(
+        conductor: &dyn Conductor,
+        status: &ConsensusStatus,
+    ) -> ComparisonOutcome {
+        match conductor.leader().await {
+            Ok(conductor_leader) if conductor_leader == status.is_leader => {
+                ComparisonOutcome::Agree
+            }
+            Ok(conductor_leader) => {
+                ComparisonOutcome::Diverged { simplex_leader: status.is_leader, conductor_leader }
+            }
+            Err(error) => {
+                warn!(target: "simplex", error = %error, "shadow comparator: op-conductor leader() query failed");
+                ComparisonOutcome::ConductorUnavailable
+            }
+        }
+    }
+
+    /// Emits metrics and structured logs for a comparison `outcome`. Read-only.
+    fn record(outcome: ComparisonOutcome, view: u64) {
+        match outcome {
+            ComparisonOutcome::Agree => {
+                Metrics::simplex_conductor_agreement().set(1.0);
+                debug!(target: "simplex", view, "shadow comparator: simplex and op-conductor agree on leadership");
+            }
+            ComparisonOutcome::Diverged { simplex_leader, conductor_leader } => {
+                Metrics::simplex_conductor_agreement().set(0.0);
+                Metrics::leadership_divergence_total("simplex_vs_conductor").increment(1);
+                warn!(
+                    target: "simplex",
+                    view,
+                    simplex_leader,
+                    conductor_leader,
+                    "shadow comparator: leadership divergence between simplex and op-conductor"
+                );
+            }
+            // Already logged in compare_once; no comparison was made, so nothing
+            // to record on the agreement gauge or divergence counter.
+            ComparisonOutcome::ConductorUnavailable => {}
+        }
+    }
+}
+
+#[async_trait]
+impl NodeActor for ShadowComparator {
+    type Error = SimplexError;
+    type StartData = CancellationToken;
+
+    /// Runs the read-only comparison loop until cancellation or until the simplex
+    /// status channel closes. Compares on each simplex status change; acts on
+    /// nothing. Isolation is the framework's job (the `non_fatal` spawn group), so
+    /// returning `Ok`/`Err` here can never cancel the node.
+    async fn start(mut self, cancellation: Self::StartData) -> Result<(), Self::Error> {
+        let Some(conductor) = self.conductor.clone() else {
+            info!(target: "simplex", mode = ?self.mode, "shadow comparator: no op-conductor configured; nothing to compare, idling until shutdown");
+            cancellation.cancelled().await;
+            return Ok(());
+        };
+        info!(target: "simplex", mode = ?self.mode, "shadow comparator started (read-only; acts on nothing)");
+
+        loop {
+            tokio::select! {
+                _ = cancellation.cancelled() => {
+                    info!(target: "simplex", "shadow comparator received shutdown signal");
+                    return Ok(());
+                }
+                changed = self.status_rx.changed() => {
+                    if changed.is_err() {
+                        debug!(target: "simplex", "shadow comparator: simplex status channel closed; exiting (non-fatal)");
+                        return Ok(());
+                    }
+                    let status = self.status_rx.borrow_and_update().clone();
+                    let outcome = Self::compare_once(conductor.as_ref(), &status).await;
+                    Self::record(outcome, status.view);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::actors::sequencer::{ConductorError, MockConductor};
+
+    use super::*;
+
+    fn status(is_leader: bool, view: u64) -> ConsensusStatus {
+        ConsensusStatus { is_leader, finalized_head: None, view }
+    }
+
+    #[tokio::test]
+    async fn compare_once_detects_agreement() {
+        let mut conductor = MockConductor::new();
+        conductor.expect_leader().once().returning(|| Ok(true));
+        let outcome = ShadowComparator::compare_once(&conductor, &status(true, 3)).await;
+        assert_eq!(outcome, ComparisonOutcome::Agree);
+    }
+
+    #[tokio::test]
+    async fn compare_once_detects_divergence() {
+        // simplex says this node leads; op-conductor says it does not.
+        let mut conductor = MockConductor::new();
+        conductor.expect_leader().once().returning(|| Ok(false));
+        let outcome = ShadowComparator::compare_once(&conductor, &status(true, 9)).await;
+        assert_eq!(
+            outcome,
+            ComparisonOutcome::Diverged { simplex_leader: true, conductor_leader: false }
+        );
+    }
+
+    #[tokio::test]
+    async fn compare_once_handles_conductor_error() {
+        let mut conductor = MockConductor::new();
+        conductor.expect_leader().once().returning(|| Err(ConductorError::NotLeader));
+        let outcome = ShadowComparator::compare_once(&conductor, &status(false, 1)).await;
+        assert_eq!(outcome, ComparisonOutcome::ConductorUnavailable);
+    }
+
+    /// With no op-conductor configured there is nothing to compare, so the actor
+    /// idles until cancellation and returns `Ok` — without ever querying anything.
+    #[tokio::test]
+    async fn start_idles_when_no_conductor() {
+        let (_status_tx, status_rx) = watch::channel(ConsensusStatus::default());
+        let comparator = ShadowComparator::new(SimplexMode::Shadow, status_rx, None);
+        let cancellation = CancellationToken::new();
+        let handle = tokio::spawn(comparator.start(cancellation.clone()));
+        cancellation.cancel();
+        assert!(handle.await.unwrap().is_ok());
+    }
+
+    /// A simplex status change drives exactly one read-only comparison (one
+    /// `leader()` query), then cancellation ends the loop cleanly. Uses a call
+    /// counter rather than mock-drop verification so the assertion is timing-robust.
+    #[tokio::test]
+    async fn start_compares_on_status_change() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_in_mock = Arc::clone(&calls);
+        let mut conductor = MockConductor::new();
+        conductor.expect_leader().returning(move || {
+            calls_in_mock.fetch_add(1, Ordering::SeqCst);
+            Ok(true)
+        });
+
+        let (status_tx, status_rx) = watch::channel(ConsensusStatus::default());
+        let comparator =
+            ShadowComparator::new(SimplexMode::Shadow, status_rx, Some(Arc::new(conductor)));
+        let cancellation = CancellationToken::new();
+        let handle = tokio::spawn(comparator.start(cancellation.clone()));
+
+        // Publish a status change; the comparator should query op-conductor once.
+        status_tx.send_replace(status(true, 1));
+        // Yield until the comparison is observed (bounded so a hang fails the test).
+        for _ in 0..100 {
+            if calls.load(Ordering::SeqCst) >= 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(calls.load(Ordering::SeqCst) >= 1, "a status change must drive a leader() query");
+
+        cancellation.cancel();
+        assert!(handle.await.unwrap().is_ok());
+    }
+}

--- a/crates/consensus/service/src/lib.rs
+++ b/crates/consensus/service/src/lib.rs
@@ -24,7 +24,8 @@ pub use actors::{
     AlloyL1BlockFetcher, BlockStream, BuildOutcome, BuildPipelineState, BuildRequest,
     CancellableContext, CanonicalReconciliationInputs, CanonicalUnsafeCatchup, CheckpointActor,
     CheckpointClient, CheckpointDB, CheckpointError, CheckpointRequest, CheckpointWriter,
-    Conductor, ConductorClient, ConductorError, DelayedL1OriginSelectorProvider,
+    ComparisonOutcome, Conductor, ConductorClient, ConductorError, ConsensusProposer,
+    ConsensusStatus, ConsensusStatusReader, DelayedL1OriginSelectorProvider,
     DelegateDerivationActor, DerivationActor, DerivationActorRequest, DerivationClientError,
     DerivationClientResult, DerivationDelegateClient, DerivationDelegateClientError,
     DerivationEngineClient, DerivationError, DerivationState, DerivationStateMachine,
@@ -45,8 +46,9 @@ pub use actors::{
     RecoveryModeGuard, ResetOrigin, ResetOutcome, ResetReason, ResetRequest, ResetRequestOutcome,
     RpcActor, RpcActorError, RpcContext, ScheduledTicker, SealState, SealStepError,
     SealStepOutcome, SequencerActor, SequencerActorError, SequencerAdminQuery, SequencerConfig,
-    SequencerEngineClient, SequencerEngineRequestCoordinator, SequencerEngineState, ShadowCycle,
-    ShadowReconciliationGate, ShadowReconciliationTask, ShadowSequencingState,
+    SequencerEngineClient, SequencerEngineRequestCoordinator, SequencerEngineState,
+    ShadowComparator, ShadowCycle, ShadowReconciliationGate, ShadowReconciliationTask,
+    ShadowSequencingState, SimplexActor, SimplexClient, SimplexError, SimplexMode, SimplexRequest,
     UnsafePayloadGossipClient, UnsafePayloadGossipClientError, UnsealedPayloadHandle,
     UpgradeSignalMetricsActor, UpgradeSignalNodeConfig, ValidatorEngineRequestHandler,
 };
@@ -56,8 +58,15 @@ mod metrics;
 pub mod test_utils;
 #[cfg(test)]
 pub use actors::{
-    MockConductor, MockEngineDerivationClient, MockOriginSelector, MockSequencerEngineClient,
-    MockUnsafePayloadGossipClient,
+    MockConductor, MockConsensusProposer, MockConsensusStatusReader, MockEngineDerivationClient,
+    MockOriginSelector, MockSequencerEngineClient, MockUnsafePayloadGossipClient,
+};
+#[cfg(feature = "simplex")]
+pub use actors::{
+    PinnedLeaderConfig, PinnedLeaderElector, SIMPLEX_CERTIFICATE_CHANNEL, SIMPLEX_RESOLVER_CHANNEL,
+    SIMPLEX_VOTE_CHANNEL, SimplexActivity, SimplexCertificate, SimplexConfig, SimplexConfigBuilder,
+    SimplexDigest, SimplexNetReceiver, SimplexNetSender, SimplexPublicKey, SimplexRuntimeContext,
+    SimplexScheme, SimplexStrategy, StatusReporter, StubAutomaton, StubBlocker, StubRelay,
 };
 #[cfg(test)]
 pub use follow::MockRemoteClient;

--- a/crates/consensus/service/src/metrics/mod.rs
+++ b/crates/consensus/service/src/metrics/mod.rs
@@ -150,6 +150,12 @@ base_metrics::define_metrics! {
     l1_verifier_derivation_head: counter,
     #[describe("Failed attempts to fetch a delayed L1 block for verifier confirmation")]
     l1_verifier_delayed_fetch_errors: counter,
+    #[describe("Leadership decision divergences observed in simplex shadow mode (read-only comparison against op-conductor)")]
+    #[label(name = "source", default = ["simplex_vs_conductor"])]
+    leadership_divergence_total: counter,
+    #[describe("Whether simplex and op-conductor currently agree on this node's leadership in shadow mode (1 = agree, 0 = diverged). No zero-init: absent until the first comparison so a pre-comparison series is not misread as diverged")]
+    #[no_zero]
+    simplex_conductor_agreement: gauge,
 }
 
 impl Metrics {

--- a/crates/consensus/service/src/service/builder.rs
+++ b/crates/consensus/service/src/service/builder.rs
@@ -15,7 +15,7 @@ use base_upgrade_signal::UpgradeSignalConfig;
 use url::Url;
 
 use crate::{
-    EngineConfig, NetworkConfig, RollupNode, SequencerConfig, UpgradeSignalNodeConfig,
+    EngineConfig, NetworkConfig, RollupNode, SequencerConfig, SimplexMode, UpgradeSignalNodeConfig,
     actors::DerivationDelegateClient, service::node::L1Config,
 };
 
@@ -81,6 +81,9 @@ pub struct RollupNodeBuilder {
     pub rpc_config: Option<RpcBuilder>,
     /// The [`SequencerConfig`].
     pub sequencer_config: Option<SequencerConfig>,
+    /// Operating mode for the in-process simplex consensus actor. Defaults to
+    /// [`SimplexMode::Off`] (actor not spawned).
+    pub simplex_mode: SimplexMode,
     /// Optional configuration for Derivation Delegate mode.
     /// When present, the node does not run derivation, instead trusting the configured delegate.
     pub derivation_delegate_config: Option<DerivationDelegateConfig>,
@@ -134,6 +137,7 @@ impl RollupNodeBuilder {
             p2p_config,
             rpc_config,
             sequencer_config: None,
+            simplex_mode: SimplexMode::Off,
             derivation_delegate_config: None,
             finalized_poll_interval: None,
             checkpoint_path: None,
@@ -158,6 +162,12 @@ impl RollupNodeBuilder {
     /// Appends the [`SequencerConfig`] to the builder.
     pub fn with_sequencer_config(self, sequencer_config: SequencerConfig) -> Self {
         Self { sequencer_config: Some(sequencer_config), ..self }
+    }
+
+    /// Sets the [`SimplexMode`] for the in-process simplex consensus actor.
+    /// Defaults to [`SimplexMode::Off`] (actor not spawned) when unset.
+    pub fn with_simplex_mode(self, simplex_mode: SimplexMode) -> Self {
+        Self { simplex_mode, ..self }
     }
 
     /// Overrides the finalized-block poll interval.
@@ -275,6 +285,7 @@ impl RollupNodeBuilder {
             checkpoint_path,
             safedb_path: self.safedb_path,
             upgrade_signal_config,
+            simplex_mode: self.simplex_mode,
         })
     }
 
@@ -370,5 +381,24 @@ mod tests {
             test_builder(Url::parse("ws://127.0.0.1:8551").unwrap()).build().await.unwrap();
 
         assert_eq!(rollup_node.engine_config.l2_url.scheme(), "ws");
+    }
+
+    #[tokio::test]
+    async fn build_defaults_simplex_mode_off() {
+        let rollup_node =
+            test_builder(Url::parse("http://127.0.0.1:8551").unwrap()).build().await.unwrap();
+
+        assert_eq!(rollup_node.simplex_mode, SimplexMode::Off);
+    }
+
+    #[tokio::test]
+    async fn with_simplex_mode_threads_through_build() {
+        let rollup_node = test_builder(Url::parse("http://127.0.0.1:8551").unwrap())
+            .with_simplex_mode(SimplexMode::Shadow)
+            .build()
+            .await
+            .unwrap();
+
+        assert_eq!(rollup_node.simplex_mode, SimplexMode::Shadow);
     }
 }

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -27,16 +27,16 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     AlloyL1BlockFetcher, CheckpointActor, CheckpointClient, CheckpointDB, CheckpointWriter,
-    Conductor, ConductorClient, DelayedL1OriginSelectorProvider, DelegateDerivationActor,
-    DerivationActor, DerivationDelegateClient, DerivationError, EngineActor, EngineActorRequest,
-    EngineConfig, EngineProcessor, EngineRequestReceiver, EngineRpcProcessor, L1OriginSelector,
-    L1WatcherActor, L1WatcherQueryProcessor, NetworkActor, NetworkBuilder, NetworkConfig,
-    NodeActor, NodeMode, PayloadBuilder, PrefetchedChainProvider, PreparedL1Origin,
-    QueuedDerivationEngineClient, QueuedEngineDerivationClient, QueuedEngineRpcClient,
-    QueuedL1WatcherDerivationClient, QueuedNetworkEngineClient, QueuedSequencerAdminAPIClient,
-    QueuedSequencerEngineClient, RecoveryModeGuard, RpcActor, RpcContext, SequencerActor,
-    SequencerConfig, SequencerEngineRequestCoordinator, UpgradeSignalNodeConfig,
-    ValidatorEngineRequestHandler,
+    Conductor, ConductorClient, ConsensusStatus, DelayedL1OriginSelectorProvider,
+    DelegateDerivationActor, DerivationActor, DerivationDelegateClient, DerivationError,
+    EngineActor, EngineActorRequest, EngineConfig, EngineProcessor, EngineRequestReceiver,
+    EngineRpcProcessor, L1OriginSelector, L1WatcherActor, L1WatcherQueryProcessor, NetworkActor,
+    NetworkBuilder, NetworkConfig, NodeActor, NodeMode, PayloadBuilder, PrefetchedChainProvider,
+    PreparedL1Origin, QueuedDerivationEngineClient, QueuedEngineDerivationClient,
+    QueuedEngineRpcClient, QueuedL1WatcherDerivationClient, QueuedNetworkEngineClient,
+    QueuedSequencerAdminAPIClient, QueuedSequencerEngineClient, RecoveryModeGuard, RpcActor,
+    RpcContext, SequencerActor, SequencerConfig, SequencerEngineRequestCoordinator, SimplexActor,
+    SimplexClient, SimplexMode, UpgradeSignalNodeConfig, ValidatorEngineRequestHandler,
     actors::{BlockStream, NetworkInboundData, QueuedUnsafePayloadGossipClient},
 };
 
@@ -145,6 +145,13 @@ pub struct RollupNode {
     pub safedb_path: Option<PathBuf>,
     /// Optional upgrade signal configuration for the consensus node.
     pub upgrade_signal_config: Option<UpgradeSignalNodeConfig>,
+    /// Operating mode for the in-process simplex consensus actor.
+    ///
+    /// Defaults to [`SimplexMode::Off`], in which the actor is not spawned at all
+    /// and the node behaves exactly as before (op-conductor remains the sole
+    /// leadership/commit authority). Non-`Off` modes spawn the experimental
+    /// consensus actor alongside the live path; see `docs/consensus-simplex/`.
+    pub simplex_mode: SimplexMode,
 }
 
 /// A RollupNode-level derivation actor wrapper.
@@ -444,6 +451,34 @@ impl RollupNode {
         let checkpoint_actor = CheckpointActor::new(checkpoint_db, checkpoint_request_rx);
         let checkpoint_client = CheckpointClient::new(checkpoint_request_tx);
 
+        // Optional in-process simplex consensus actor. Built (and spawned) only
+        // when `simplex_mode != Off`; when `Off` this is `None`, so the actor is
+        // never added to the spawn list and the node behaves exactly as before —
+        // op-conductor remains the sole authority. The actor coexists behind this
+        // flag and never touches the live op-conductor path. The client is not yet
+        // consumed (Phase 1 skeleton); dropping it closes the request channel,
+        // which the actor handles by idling in non-authoritative modes.
+        let simplex_mode = self.simplex_mode;
+        // Phase 1 skeleton: no consumer holds the SimplexClient yet, so it is
+        // dropped below. In non-authoritative modes the actor tolerates the
+        // resulting request-channel closure by idling. In authoritative modes
+        // (`Active`/`Primary`) the actor's lifecycle tracks consensus, so a closed
+        // channel would make it return and — via `spawn_and_wait!`'s drop-guard —
+        // cancel the whole node. Those modes are not wired until Phase 3; reject
+        // them fast with a clear error rather than self-terminating at startup.
+        if simplex_mode.is_authoritative() {
+            return Err(format!(
+                "simplex_mode {simplex_mode:?} is not supported yet (authoritative modes land in Phase 3); use Off/Passive/Shadow"
+            ));
+        }
+        let simplex = (simplex_mode != SimplexMode::Off).then(|| {
+            let (simplex_request_tx, simplex_request_rx) = mpsc::channel(1024);
+            let (simplex_status_tx, simplex_status_rx) = watch::channel(ConsensusStatus::default());
+            let actor = SimplexActor::new(simplex_mode, simplex_request_rx, simplex_status_tx);
+            let client = SimplexClient::new(simplex_request_tx, simplex_status_rx);
+            (actor, client)
+        });
+
         // Create the conductor client early — the engine processor needs it for the
         // bootstrap leadership check and the sequencer actor needs it for block building.
         // When `conductor_binary_commit` is set, commit_unsafe_payload uses the
@@ -663,7 +698,11 @@ impl RollupNode {
                 Some((checkpoint_actor, cancellation.clone())),
                 Some((engine_actor, ())),
                 engine_rpc_actor,
-            ]
+            ],
+            // Non-fatal: the experimental simplex actor must have zero blast radius on the live
+            // path. Placed here (no drop guard, errors swallowed) so that in non-authoritative
+            // modes it cannot cancel the node — the framework owns isolation, not the actor.
+            non_fatal = [simplex.map(|(actor, _client)| (actor, cancellation.clone())),]
         );
         Ok(())
     }

--- a/crates/consensus/service/src/service/util.rs
+++ b/crates/consensus/service/src/service/util.rs
@@ -8,17 +8,40 @@ use tracing::info;
 ///
 /// Actors are passed in as optional arguments, in case a given actor is not needed.
 ///
+/// Two actor groups are supported:
+/// - `actors = [...]` — **fatal** actors. Each installs a [`drop_guard`], so if the actor returns
+///   (`Ok` or `Err`) or panics, the shared cancellation token is cancelled and the whole node shuts
+///   down. This is the fail-stop behavior every existing actor relies on (op-conductor sequencer,
+///   engine, derivation, network, …).
+/// - `non_fatal = [...]` — **non-fatal** actors (optional group). These install **no** drop guard and
+///   their errors are logged and swallowed, so an actor in this group completing or erroring does
+///   **not** cancel the shared token or bring down the node. Use this only for experimental /
+///   isolated actors that must have zero blast radius on the live path (e.g. the simplex consensus
+///   actor in non-authoritative modes). Both groups share one [`JoinSet`], so shutdown-signal
+///   handling and abort-on-drop are identical.
+///
 /// This macro also handles OS shutdown signals (SIGTERM, SIGINT) and triggers graceful shutdown
 /// when received.
 ///
 /// [JoinSet]: tokio::task::JoinSet
 /// [NodeActor]: crate::NodeActor
+/// [drop_guard]: tokio_util::sync::CancellationToken::drop_guard
 macro_rules! spawn_and_wait {
+    // Public entry: fatal actors only — forwards to the full form with an empty non-fatal group so
+    // the shutdown/await loop is defined exactly once.
     ($cancellation:expr, actors = [$($actor:expr$(,)?)*]) => {
+        $crate::service::spawn_and_wait!($cancellation, actors = [$($actor,)*], non_fatal = []);
+    };
+    // Public entry: fatal + non-fatal actors.
+    (
+        $cancellation:expr,
+        actors = [$($actor:expr$(,)?)*],
+        non_fatal = [$($non_fatal_actor:expr$(,)?)*]
+    ) => {
         use tracing::{error, info};
         let mut task_handles = tokio::task::JoinSet::new();
 
-        // Check if the actor is present, and spawn it if it is.
+        // Fatal actors: spawn with a drop guard so any return/panic cancels the node.
         $(
             if let Some((actor, context)) = $actor {
                 let cancellation = $cancellation.clone();
@@ -35,6 +58,30 @@ macro_rules! spawn_and_wait {
                         return Err(format!("{e:?}"));
                     }
                     Ok(())
+                });
+            }
+        )*
+
+        // Non-fatal actors: NO drop guard; errors AND panics are caught, logged, and swallowed to
+        // `Ok(())`. All three are load-bearing for zero blast radius: (1) no drop_guard, so a normal
+        // return doesn't cancel the token; (2) `Err` swallowed, so the `Some(Ok(Err(_)))` fatal arm
+        // of the await loop can't fire; (3) `catch_unwind`, so a panic doesn't surface as a
+        // `JoinError` and hit the `Some(Err(_))` fatal arm. Without (3) a panicking non-fatal actor
+        // would still take the whole node (incl. the live op-conductor path) down.
+        $(
+            if let Some((actor, context)) = $non_fatal_actor {
+                task_handles.spawn(async move {
+                    use futures::FutureExt as _;
+                    match std::panic::AssertUnwindSafe(actor.start(context)).catch_unwind().await {
+                        Ok(Ok(())) => {}
+                        Ok(Err(e)) => {
+                            error!(target: "rollup_node", error = ?e, "Non-fatal actor error; ignoring to preserve node isolation");
+                        }
+                        Err(_) => {
+                            error!(target: "rollup_node", "Non-fatal actor panicked; ignoring to preserve node isolation");
+                        }
+                    }
+                    Ok::<(), String>(())
                 });
             }
         )*
@@ -108,5 +155,105 @@ impl ShutdownSignal {
                 info!(target: "rollup_node", "Received SIGTERM");
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use tokio_util::sync::CancellationToken;
+
+    use crate::NodeActor;
+
+    /// Test actor that returns immediately with the configured result.
+    #[derive(Debug)]
+    struct FinishActor(Result<(), String>);
+
+    #[async_trait]
+    impl NodeActor for FinishActor {
+        type Error = String;
+        type StartData = ();
+
+        async fn start(self, _: Self::StartData) -> Result<(), Self::Error> {
+            self.0
+        }
+    }
+
+    /// Test actor that panics, to exercise the non-fatal `catch_unwind`.
+    #[derive(Debug)]
+    struct PanicActor;
+
+    #[async_trait]
+    impl NodeActor for PanicActor {
+        type Error = String;
+        type StartData = ();
+
+        async fn start(self, _: Self::StartData) -> Result<(), Self::Error> {
+            panic!("boom");
+        }
+    }
+
+    /// A non-fatal actor that returns `Err` must NOT cancel the shared token or
+    /// make the node return an error — the whole point of the `non_fatal` slot.
+    async fn run_non_fatal_err(cancellation: CancellationToken) -> Result<(), String> {
+        spawn_and_wait!(
+            cancellation,
+            actors = [],
+            non_fatal = [Some((FinishActor(Err("boom".to_string())), ()))]
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn non_fatal_err_does_not_cancel_token() {
+        let cancellation = CancellationToken::new();
+        assert!(run_non_fatal_err(cancellation.clone()).await.is_ok());
+        assert!(!cancellation.is_cancelled(), "non-fatal Err must not cancel the shared token");
+    }
+
+    /// A non-fatal actor that PANICS must also not cancel the token (caught via
+    /// `catch_unwind`); without the guard the panic would surface as a `JoinError`
+    /// and trip the fatal arm.
+    async fn run_non_fatal_panic(cancellation: CancellationToken) -> Result<(), String> {
+        spawn_and_wait!(cancellation, actors = [], non_fatal = [Some((PanicActor, ()))]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn non_fatal_panic_does_not_cancel_token() {
+        let cancellation = CancellationToken::new();
+        assert!(run_non_fatal_panic(cancellation.clone()).await.is_ok());
+        assert!(!cancellation.is_cancelled(), "non-fatal panic must not cancel the shared token");
+    }
+
+    /// A fatal actor returning `Err` cancels the token and returns the error —
+    /// the existing fail-stop behavior every live actor relies on, unchanged.
+    async fn run_fatal_err(cancellation: CancellationToken) -> Result<(), String> {
+        spawn_and_wait!(cancellation, actors = [Some((FinishActor(Err("boom".to_string())), ()))]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn fatal_err_cancels_token_and_returns_err() {
+        let cancellation = CancellationToken::new();
+        let result = run_fatal_err(cancellation.clone()).await;
+        assert!(result.is_err(), "fatal Err must propagate");
+        assert!(cancellation.is_cancelled(), "fatal Err must cancel the shared token");
+    }
+
+    /// The fatal-only forwarding arm (no `non_fatal` group) must expand and run —
+    /// a fatal actor returning `Ok` still cancels the token via its drop guard.
+    async fn run_fatal_ok_via_forwarding_arm(
+        cancellation: CancellationToken,
+    ) -> Result<(), String> {
+        spawn_and_wait!(cancellation, actors = [Some((FinishActor(Ok(())), ()))]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn fatal_ok_via_forwarding_arm_cancels_token() {
+        let cancellation = CancellationToken::new();
+        assert!(run_fatal_ok_via_forwarding_arm(cancellation.clone()).await.is_ok());
+        assert!(cancellation.is_cancelled(), "fatal actor return fires the drop guard");
     }
 }


### PR DESCRIPTION
**Spike — not for merge.** Exploring replacing op-conductor's out-of-process Raft leadership + payload commit with an **in-process consensus actor built on [commonware](https://github.com/commonwarexyz/monorepo) simplex**, to remove serialization/RPC latency on the sequencer hot path.

Everything is gated behind an off-by-default `simplex` cargo feature + a `simplex_mode` runtime config (default `Off`). **The live op-conductor path is untouched**, and with the feature off the build carries no new dependencies.

### What's in the spike
- Skeleton `SimplexActor` (NodeActor pattern) + typed `SimplexClient` with narrow `ConsensusProposer` (write) / `ConsensusStatusReader` (read/`watch`) traits.
- Full commonware `Engine` glue: all generics pinned + a real `Engine` that constructs and starts in a deterministic behavioral test.
- Stable-leader `PinnedLeaderElector` (leader ⊆ voter, term-based); commonware is pinned to a git rev for the stable-leader `Elector` API.
- Read-only shadow leadership comparator: observes simplex vs op-conductor leadership, emits divergence metrics, and acts on nothing.
- Isolation: the actor runs in a `non_fatal` spawn group so it can never take the node down in non-authoritative modes.

### Status
- Off-by-default; nothing authoritative or wired into the live sequencer path yet.
- Design + rollout/fault-tolerance docs are kept internal — this branch is **code-only** (history squashed to a single commit for that reason).
- Builds + tests pass with and without `--features simplex`.

Open questions (BFT liveness quorum & recovery paths vs op-conductor) are being worked through with the commonware team.