### PR TITLE
feat(ci): Add Advisory Benchmark PR Comment

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -1,0 +1,154 @@
+name: Benchmarks (advisory)
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTC_WRAPPER: "sccache"
+  SCCACHE_GHA_ENABLED: "true"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  bench:
+    name: Run benchmarks (${{ matrix.variant }})
+    runs-on:
+      group: BasePerfRunnerGroup
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: base
+            ref: ${{ github.event.pull_request.base.sha }}
+          - variant: head
+            ref: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout ${{ matrix.variant }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ matrix.ref }}
+          fetch-depth: 1
+
+      - uses: ./.github/actions/setup
+        with:
+          foundry: "true"
+          native-deps: "true"
+          rust-cache-shared-key: "benchmark"
+          just: "false"
+
+      # Advisory only: a bench that fails to compile or run must not fail the job.
+      # The comparison step surfaces whatever results were produced.
+      - name: Run benchmark subset
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -uo pipefail
+          run() { echo "::group::$*"; "$@"; echo "::endgroup::"; }
+          run cargo bench -p base-proof-mpt --bench trie_node \
+            -- --save-baseline current --noplot
+          run cargo bench -p base-protocol --bench batch_transaction \
+            -- --save-baseline current --noplot
+          run cargo bench -p base-consensus-derive --bench batch_queue --features test-utils \
+            -- --save-baseline current --noplot
+          run cargo bench -p base-common-precompiles --bench base_precompiles --features test-utils \
+            -- --save-baseline current --noplot
+
+      - name: Upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bench-${{ matrix.variant }}
+          path: target/criterion/**/current/estimates.json
+          if-no-files-found: warn
+
+  comment:
+    name: Benchmarks (advisory)
+    if: always()
+    needs: bench
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout Base
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.13"
+
+      - name: Download benchmark results
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: bench-*
+          path: ${{ runner.temp }}/bench-results
+
+      - name: Render comparison
+        id: render
+        shell: bash
+        env:
+          WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          python3 etc/scripts/ci/bench_compare.py \
+            --base-dir "$RUNNER_TEMP/bench-results/bench-base" \
+            --head-dir "$RUNNER_TEMP/bench-results/bench-head" \
+            --output "$RUNNER_TEMP/bench-comment.md" \
+            --run-url "$WORKFLOW_RUN_URL" \
+            --threshold-pct 10 \
+            --improvement-pct 10 \
+            --github-output "$GITHUB_OUTPUT"
+          cat "$RUNNER_TEMP/bench-comment.md" >> "$GITHUB_STEP_SUMMARY"
+
+      # Only comment on a notable regression or improvement, to keep PR noise low. If
+      # a prior run left a comment that a later push has since made unremarkable, delete
+      # it. Skip forked PRs — we don't have permission to comment on them.
+      - name: Comment or clear benchmark results on PR
+        if: >
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          SHOULD_COMMENT: ${{ steps.render.outputs.should_comment }}
+        run: |
+          set -euo pipefail
+          marker='<!-- bench-pr-results -->'
+          existing_id=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --jq ".[] | select(.body | startswith(\"${marker}\")) | .id" \
+            | head -1)
+
+          if [ "$SHOULD_COMMENT" = "true" ]; then
+            body=$(cat "$RUNNER_TEMP/bench-comment.md")
+            if [ -n "$existing_id" ]; then
+              gh api "repos/${REPO}/issues/comments/${existing_id}" \
+                -X PATCH --field body="$body" > /dev/null
+            else
+              gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+                --field body="$body" > /dev/null
+            fi
+          elif [ -n "$existing_id" ]; then
+            gh api "repos/${REPO}/issues/comments/${existing_id}" -X DELETE > /dev/null
+          fi

--- a/etc/scripts/ci/bench_compare.py
+++ b/etc/scripts/ci/bench_compare.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Render a criterion base-vs-head benchmark comparison into a PR comment body.
+
+Reads two trees of criterion output (one benchmarked on the PR base commit, one
+on the PR head commit), matches benchmarks by their criterion id, and emits an
+advisory Markdown table of the median-time delta. This never gates a merge; it is
+visibility only.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import json
+
+MARKER = "<!-- bench-pr-results -->"
+
+
+class BenchCompare:
+    """Compares two criterion baselines and renders a Markdown comment."""
+
+    def __init__(self, threshold_pct: float, improvement_pct: float) -> None:
+        self.threshold_pct = threshold_pct
+        self.improvement_pct = improvement_pct
+
+    @staticmethod
+    def collect(root: Path) -> dict[str, float]:
+        """Map criterion benchmark id -> median time in nanoseconds under root.
+
+        A criterion result lives at `<root>/<id...>/current/estimates.json`. The id
+        is every path component between the artifact root and the `current` baseline
+        directory, so ids are identical across the two trees regardless of how the
+        upload step stripped any shared path prefix.
+        """
+        results: dict[str, float] = {}
+        for estimates in root.rglob("current/estimates.json"):
+            bench_id = "/".join(estimates.relative_to(root).parts[:-2])
+            if not bench_id:
+                continue
+            try:
+                payload = json.loads(estimates.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                continue
+            point = payload.get("median") or payload.get("mean")
+            if not point or "point_estimate" not in point:
+                continue
+            results[bench_id] = float(point["point_estimate"])
+        return results
+
+    @staticmethod
+    def humanize_ns(value: float) -> str:
+        """Format a nanosecond duration with an appropriate unit."""
+        for unit, scale in (("s", 1e9), ("ms", 1e6), ("µs", 1e3)):
+            if value >= scale:
+                return f"{value / scale:.2f} {unit}"
+        return f"{value:.1f} ns"
+
+    def delta_pct(self, base: float | None, head: float | None) -> float | None:
+        """Percent change from base to head, or None if either side is missing."""
+        if base is None or head is None or not base:
+            return None
+        return (head - base) / base * 100
+
+    def is_regression(self, base: float | None, head: float | None) -> bool:
+        """A benchmark regresses when head is slower than base beyond the threshold."""
+        delta = self.delta_pct(base, head)
+        return delta is not None and delta >= self.threshold_pct
+
+    def is_improvement(self, base: float | None, head: float | None) -> bool:
+        """A benchmark improves when head is faster than base beyond the threshold."""
+        delta = self.delta_pct(base, head)
+        return delta is not None and delta <= -self.improvement_pct
+
+    def render_row(self, bench_id: str, base: float | None, head: float | None) -> str:
+        """Render a single Markdown table row for one benchmark."""
+        if base is None:
+            return f"| `{bench_id}` | — (new) | {self.humanize_ns(head)} | — |"
+        if head is None:
+            return f"| `{bench_id}` | {self.humanize_ns(base)} | — (removed) | — |"
+        delta = self.delta_pct(base, head) or 0.0
+        flag = ""
+        if abs(delta) >= self.threshold_pct:
+            flag = " ⚠️ slower" if delta > 0 else " ✅ faster"
+        return (
+            f"| `{bench_id}` | {self.humanize_ns(base)} | {self.humanize_ns(head)} "
+            f"| {delta:+.1f}%{flag} |"
+        )
+
+    def summarize(self, base: dict[str, float], head: dict[str, float], ids: list[str]) -> str:
+        """Render a `bench (+d%)` list for an alert summary."""
+        return ", ".join(f"`{b}` ({self.delta_pct(base[b], head[b]):+.1f}%)" for b in ids)
+
+    def render(self, base_dir: Path, head_dir: Path, run_url: str) -> tuple[str, bool]:
+        """Render the comment body, returning it and whether it warrants a comment."""
+        base = self.collect(base_dir)
+        head = self.collect(head_dir)
+        bench_ids = sorted(set(base) | set(head))
+        regressed = [b for b in bench_ids if self.is_regression(base.get(b), head.get(b))]
+        improved = [b for b in bench_ids if self.is_improvement(base.get(b), head.get(b))]
+
+        lines = [MARKER, ""]
+        # A regression takes priority over any concurrent improvement in the same PR.
+        if regressed:
+            lines += [
+                "> [!CAUTION]",
+                f"> This PR may regress performance. {len(regressed)} benchmark(s) "
+                f"slower by more than {self.threshold_pct:.0f}%: "
+                f"{self.summarize(base, head, regressed)}.",
+                "",
+            ]
+        elif improved:
+            lines += [
+                "> [!TIP]",
+                f"> Nice, this PR improves performance. {len(improved)} benchmark(s) "
+                f"faster by more than {self.improvement_pct:.0f}%: "
+                f"{self.summarize(base, head, improved)}.",
+                "",
+            ]
+        lines += [
+            "### Benchmark results (advisory)",
+            "",
+            f"Median time on the PR head versus the base branch. Wall-clock, so "
+            f"treat small changes as noise. A change flags at ±{self.threshold_pct:.0f}%. "
+            f"This check never blocks a merge.",
+            "",
+            "| Benchmark | Base | Head | Δ median |",
+            "|---|---:|---:|---:|",
+        ]
+        if not bench_ids:
+            lines.append("| _no benchmark results were produced_ | — | — | — |")
+        else:
+            lines.extend(self.render_row(b, base.get(b), head.get(b)) for b in bench_ids)
+        lines += ["", f"[View run]({run_url}) · [Re-run benchmarks]({run_url})"]
+        return "\n".join(lines) + "\n", bool(regressed or improved)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-dir", type=Path, required=True)
+    parser.add_argument("--head-dir", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--run-url", required=True)
+    parser.add_argument("--threshold-pct", type=float, default=10.0)
+    parser.add_argument("--improvement-pct", type=float, default=10.0)
+    parser.add_argument("--github-output", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Entry point for the benchmark comparison renderer."""
+    args = parse_args()
+    body, should_comment = BenchCompare(args.threshold_pct, args.improvement_pct).render(
+        args.base_dir, args.head_dir, args.run_url
+    )
+    args.output.write_text(body, encoding="utf-8")
+    if args.github_output is not None:
+        with args.github_output.open("a", encoding="utf-8") as handle:
+            handle.write(f"should_comment={'true' if should_comment else 'false'}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This adds an advisory benchmark workflow that runs a small subset of our existing criterion benchmarks on every pull request and posts a comment comparing the PR head against the base branch. The two sides run in parallel on the bare-metal runner group, and a Python script renders the median deltas into a table. To keep pull request noise low it only comments when a benchmark moves past a threshold, flagging a slowdown with a caution alert and a speedup with a tip, and it clears a stale comment when a later push resolves the change. It never fails the build and is not wired into any required check or the merge queue, so it stays purely informational.

An example of this advisory is provided [on a stacked PR](https://github.com/base/base/pull/4465#issuecomment-5318422180).

<img width="881" height="723" alt="Screenshot 2026-08-17 at 2 03 47 PM" src="https://github.com/user-attachments/assets/d27c7f1e-8478-49f8-8505-97eab335f6fb" />
