### PR TITLE
fix(eip8130): always surface phaseStatuses on receipts, even when empty

### DIFF
--- a/actions/harness/tests/cobalt/transaction.rs
+++ b/actions/harness/tests/cobalt/transaction.rs
@@ -22,7 +22,7 @@ async fn eip8130_transaction_executes_and_derives_at_cobalt() {
         panic!("expected an EIP-8130 receipt");
     };
     assert!(receipt.inner.status());
-    assert_eq!(receipt.phase_statuses, vec![0x01]);
+    assert_eq!(receipt.phase_statuses, Some(vec![0x01]));
 
     // Send both blocks through the batcher and verifier, asserting the verifier
     // re-derives them with matching state.

--- a/actions/harness/tests/cobalt/transaction.rs
+++ b/actions/harness/tests/cobalt/transaction.rs
@@ -22,7 +22,7 @@ async fn eip8130_transaction_executes_and_derives_at_cobalt() {
         panic!("expected an EIP-8130 receipt");
     };
     assert!(receipt.inner.status());
-    assert_eq!(receipt.phase_statuses, Some(vec![0x01]));
+    assert_eq!(receipt.phase_statuses, vec![0x01]);
 
     // Send both blocks through the batcher and verifier, asserting the verifier
     // re-derives them with matching state.

--- a/crates/common/rpc-types/src/receipt.rs
+++ b/crates/common/rpc-types/src/receipt.rs
@@ -32,10 +32,11 @@ pub struct BaseTransactionReceipt {
     /// Per-phase execution statuses for EIP-8130 transactions.
     ///
     /// Each entry is `0x01` (success) or `0x00` (reverted); phases after a revert are
-    /// not executed and reported as `0x00`. Empty for non-EIP-8130 transactions or when
-    /// the transaction's `calls` was empty.
-    #[serde(default, skip_serializing_if = "Vec::is_empty", with = "alloy_serde::quantity::vec")]
-    pub phase_statuses: Vec<u8>,
+    /// not executed and reported as `0x00`. `None` for non-EIP-8130 transactions (the
+    /// field is omitted from the JSON); `Some([])` for an EIP-8130 transaction whose
+    /// `calls` was empty, which per EIP-8130 must still surface as `"phaseStatuses": []`.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "phase_statuses_serde")]
+    pub phase_statuses: Option<Vec<u8>>,
     /// Opaque transaction metadata for EIP-8130 transactions, committed to by the sender
     /// and payer signatures but otherwise uninterpreted by the protocol.
     ///
@@ -172,6 +173,38 @@ mod l1_fee_scalar_serde {
         }
 
         Ok(None)
+    }
+}
+
+/// Serde for the EIP-8130 `phaseStatuses` field.
+///
+/// Separates applicability from contents: `None` (a non-EIP-8130 receipt) is
+/// omitted from the JSON via `skip_serializing_if`, while `Some(vec)` — including
+/// the empty vector for an EIP-8130 transaction whose `calls` was empty — always
+/// serializes as a (possibly empty) array of `0x00`/`0x01` quantities.
+mod phase_statuses_serde {
+    use alloc::vec::Vec;
+
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub(super) fn serialize<S>(value: &Option<Vec<u8>>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(statuses) => alloy_serde::quantity::vec::serialize(statuses.as_slice(), serializer),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub(super) fn deserialize<'de, D>(deserializer: D) -> Result<Option<Vec<u8>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Wrapper(#[serde(with = "alloy_serde::quantity::vec")] Vec<u8>);
+
+        Ok(Option::<Wrapper>::deserialize(deserializer)?.map(|Wrapper(statuses)| statuses))
     }
 }
 
@@ -350,6 +383,50 @@ mod tests {
         let value = serde_json::to_value(&receipt).unwrap();
         let expected_value = serde_json::from_str::<serde_json::Value>(s).unwrap();
         assert_eq!(value, expected_value);
+    }
+
+    #[test]
+    fn phase_statuses_distinguishes_absent_from_empty() {
+        use alloc::{vec, vec::Vec};
+
+        // The base JSON carries no `phaseStatuses`, so a non-EIP-8130 receipt
+        // deserializes to `None` and re-serializes with the field omitted.
+        let s = r#"{
+            "blockHash": "0x9e6a0fb7e22159d943d760608cc36a0fb596d1ab3c997146f5b7c55c8c718c67",
+            "blockNumber": "0x6cfef89",
+            "contractAddress": null,
+            "cumulativeGasUsed": "0xfa0d",
+            "effectiveGasPrice": "0x0",
+            "from": "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001",
+            "gasUsed": "0xfa0d",
+            "logs": [],
+            "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "status": "0x1",
+            "to": "0x4200000000000000000000000000000000000015",
+            "transactionHash": "0xb7c74afdeb7c89fb9de2c312f49b38cb7a850ba36e064734c5223a477e83fdc9",
+            "transactionIndex": "0x0",
+            "type": "0x79"
+        }"#;
+
+        let mut receipt: BaseTransactionReceipt = serde_json::from_str(s).unwrap();
+        assert_eq!(receipt.phase_statuses, None);
+        let json = serde_json::to_value(&receipt).unwrap();
+        assert!(json.get("phaseStatuses").is_none(), "absent statuses must omit the field");
+
+        // Applicable but empty (EIP-8130 with empty `calls`) must serialize as `[]`,
+        // distinguishable from the omitted field above, and round-trip back to `Some([])`.
+        receipt.phase_statuses = Some(Vec::new());
+        let json = serde_json::to_value(&receipt).unwrap();
+        assert_eq!(json["phaseStatuses"], json!([]));
+        let back: BaseTransactionReceipt = serde_json::from_value(json).unwrap();
+        assert_eq!(back.phase_statuses, Some(Vec::new()));
+
+        // Populated statuses serialize as an array of quantity bytes.
+        receipt.phase_statuses = Some(vec![0x01, 0x00]);
+        let json = serde_json::to_value(&receipt).unwrap();
+        assert_eq!(json["phaseStatuses"], json!(["0x1", "0x0"]));
+        let back: BaseTransactionReceipt = serde_json::from_value(json).unwrap();
+        assert_eq!(back.phase_statuses, Some(vec![0x01, 0x00]));
     }
 
     #[test]

--- a/crates/common/rpc-types/src/receipt.rs
+++ b/crates/common/rpc-types/src/receipt.rs
@@ -192,7 +192,9 @@ mod phase_statuses_serde {
         S: Serializer,
     {
         match value {
-            Some(statuses) => alloy_serde::quantity::vec::serialize(statuses.as_slice(), serializer),
+            Some(statuses) => {
+                alloy_serde::quantity::vec::serialize(statuses.as_slice(), serializer)
+            }
             None => serializer.serialize_none(),
         }
     }

--- a/crates/execution/eip8130-rpc-node/tests/receipt.rs
+++ b/crates/execution/eip8130-rpc-node/tests/receipt.rs
@@ -73,14 +73,17 @@ async fn eip8130_transaction_is_mined_and_has_a_receipt() -> eyre::Result<()> {
     assert!(receipt.block_number().is_some(), "receipt must be mined into a block");
 
     // The EIP-8130 RPC receipt carries the gas payer; for a self-pay transaction
-    // that is the resolved sender. With empty `calls`, `phaseStatuses` is omitted.
+    // that is the resolved sender. With empty `calls`, EIP-8130 requires the
+    // receipt to still carry `phaseStatuses` as an empty array (distinguishing an
+    // applicable-but-empty result from an omitted / lost field).
     let client = harness.rpc_client()?;
     let json: serde_json::Value = client.request("eth_getTransactionReceipt", (tx_hash,)).await?;
     let payer: Address = serde_json::from_value(json["payer"].clone())?;
     assert_eq!(payer, alice.address(), "self-pay receipt payer must be the sender");
-    assert!(
-        json.get("phaseStatuses").is_none_or(|v| v.as_array().is_some_and(|a| a.is_empty())),
-        "empty-calls transaction must not report phase statuses"
+    assert_eq!(
+        json["phaseStatuses"],
+        serde_json::json!([]),
+        "empty-calls EIP-8130 transaction must report an empty phaseStatuses array"
     );
     assert!(
         json.get("metadata").is_none_or(serde_json::Value::is_null),

--- a/crates/execution/flashblocks/src/pending_blocks.rs
+++ b/crates/execution/flashblocks/src/pending_blocks.rs
@@ -989,7 +989,7 @@ mod tests {
             },
             l1_block_info: L1BlockInfo::default(),
             payer: None,
-            phase_statuses: Vec::new(),
+            phase_statuses: None,
             metadata: None,
         }
     }
@@ -1046,7 +1046,7 @@ mod tests {
             },
             l1_block_info: Default::default(),
             payer: None,
-            phase_statuses: Vec::new(),
+            phase_statuses: None,
             metadata: None,
         }
     }
@@ -1329,7 +1329,7 @@ mod tests {
             },
             l1_block_info: Default::default(),
             payer: None,
-            phase_statuses: Vec::new(),
+            phase_statuses: None,
             metadata: None,
         }
     }
@@ -1470,7 +1470,7 @@ mod tests {
             },
             l1_block_info: Default::default(),
             payer: None,
-            phase_statuses: Vec::new(),
+            phase_statuses: None,
             metadata: None,
         };
 

--- a/crates/execution/metering/src/collector.rs
+++ b/crates/execution/metering/src/collector.rs
@@ -359,7 +359,7 @@ mod tests {
                 },
                 l1_block_info: L1BlockInfo::default(),
                 payer: None,
-                phase_statuses: Vec::new(),
+                phase_statuses: None,
                 metadata: None,
             };
 

--- a/crates/execution/rpc/src/eth/receipt.rs
+++ b/crates/execution/rpc/src/eth/receipt.rs
@@ -290,8 +290,9 @@ pub struct BaseReceiptBuilder {
     /// EIP-8130 gas payer (sender for self-pay, specified payer for sponsored). `None` for
     /// non-EIP-8130 transactions.
     pub payer: Option<Address>,
-    /// EIP-8130 per-phase execution statuses. Empty for non-EIP-8130 transactions.
-    pub phase_statuses: Vec<u8>,
+    /// EIP-8130 per-phase execution statuses. `None` for non-EIP-8130 transactions;
+    /// `Some` (possibly empty) for EIP-8130 transactions.
+    pub phase_statuses: Option<Vec<u8>>,
     /// EIP-8130 opaque transaction metadata. `None` for non-EIP-8130 transactions.
     pub metadata: Option<alloy_primitives::Bytes>,
 }
@@ -322,9 +323,12 @@ impl BaseReceiptBuilder {
             .as_eip8130()
             .map(|signed| signed.tx().metadata.clone())
             .filter(|metadata| !metadata.is_empty());
+        // `Some` (possibly empty) marks an EIP-8130 receipt so an empty-`calls`
+        // transaction still surfaces `"phaseStatuses": []`; `None` omits the field
+        // entirely for non-EIP-8130 receipts.
         let phase_statuses = match &input.receipt {
-            BaseReceipt::Eip8130(receipt) => receipt.phase_statuses.clone(),
-            _ => Vec::new(),
+            BaseReceipt::Eip8130(receipt) => Some(receipt.phase_statuses.clone()),
+            _ => None,
         };
 
         let mut core_receipt = build_receipt(input, None, |receipt, next_log_index, meta| {

--- a/crates/execution/rpc/src/eth/receipt.rs
+++ b/crates/execution/rpc/src/eth/receipt.rs
@@ -317,8 +317,9 @@ impl BaseReceiptBuilder {
         let payer = tx_signed
             .as_eip8130()
             .map(|signed| signed.tx().payer.unwrap_or_else(|| input.tx.signer()));
-        // Omit empty metadata rather than serializing it as `"0x"`, matching how
-        // empty `phase_statuses` is skipped — only a non-empty commitment surfaces.
+        // Omit empty metadata rather than serializing it as `"0x"`. Empty
+        // `phase_statuses` is still serialized as `[]` on EIP-8130 receipts;
+        // only metadata is skipped when empty.
         let metadata = tx_signed
             .as_eip8130()
             .map(|signed| signed.tx().metadata.clone())


### PR DESCRIPTION
## Summary

`BaseTransactionReceipt::phase_statuses` was a `Vec<u8>` serialized with `skip_serializing_if = "Vec::is_empty"`. An EIP-8130 transaction with an empty `calls` array correctly produces an empty phase-status vector, but the serializer then **dropped the `phaseStatuses` field entirely**.

EIP-8130 specifies that AA receipts always carry `phaseStatuses`, and that it is `[]` when `calls` was empty:

> `phaseStatuses (uint8[])`: Per-phase status array. Each entry is `0x01` (success) or `0x00` (reverted). Phases after a revert are not executed and reported as `0x00`. **Empty if calls was empty.**

Omitting the field violates the response shape and makes a valid empty result indistinguishable from missing / accidentally-lost node-local metadata. The prior e2e test accepted *either* an absent field or an empty array, so it did not enforce the spec.

## Change

Represent **applicability** separately from **contents**:

- `phase_statuses: Option<Vec<u8>>`
  - `None` → non-EIP-8130 receipt → field omitted (via `skip_serializing_if = "Option::is_none"`).
  - `Some(vec)` → EIP-8130 receipt → always serialized, **including `Some(Vec::new())` → `"phaseStatuses": []`**.
- A dedicated `phase_statuses_serde` module preserves the `0x00`/`0x01` quantity-hex element encoding while honoring the `Option` skip. (`payer` and `metadata` already use this `Option` shape.)
- Builder (`BaseReceiptBuilder`) maps `BaseReceipt::Eip8130 → Some(...)`, everything else → `None`. Non-8130 test constructors updated to `None`.

The consensus `Eip8130Receipt.phase_statuses` (RLP/Compact, non-consensus-JSON) is unchanged — this only touches the RPC receipt shape.

## Tests

- `rpc-types` unit test `phase_statuses_distinguishes_absent_from_empty`: `None` omits the field; `Some([])` serializes as `[]`; populated statuses serialize as quantity hex; each round-trips.
- `eip8130-rpc-node` empty-calls e2e test now requires **exactly** `"phaseStatuses": []` (previously accepted absent-or-empty).
- Cobalt harness assertion updated to `Some(vec![0x01])`.

## Test plan

- [x] `cargo test -p base-common-rpc-types phase_statuses` (new unit test passes)
- [x] `cargo test -p base-execution-eip8130-rpc-node --test receipt` (4/4 pass, incl. empty-calls `[]` and phase-status attribution)
- [x] `cargo clippy -p base-common-rpc-types -p base-execution-rpc` clean
- [x] `cargo build -p base-execution-rpc -p base-flashblocks -p base-metering`
- [ ] `base-flashblocks` / `base-metering` **test** targets: blocked locally by a pre-existing missing forge artifact (`base-test-utils` → `MockProtocolVersions.json`); the edited helpers are trivial `Vec::new() → None` substitutions and the libs build clean.