### PR TITLE
build: strip debug info from dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,14 @@ string-lit-as-bytes = "warn"
 [profile.dev]
 debug = "line-tables-only"
 
+# Dependencies are rarely stepped into, so strip their debug info. This applies
+# to all dependencies (`*`) but NOT workspace crates, which keep the
+# line-tables-only debug info above. It also disables debug info in C/C++ build
+# scripts (rocksdb, mdbx, jemalloc, ...), which is the single largest consumer
+# of `target` disk.
+[profile.dev.package."*"]
+debug = false
+
 [profile.release]
 opt-level = 3
 lto = "thin"


### PR DESCRIPTION
# Goal

This commit improves build time by roughly 10-20%, and reduces the size of the `target/` directory by 10%.

# Details

Dependencies are rarely stepped into, so disable their debug info via `[profile.dev.package."*"]`. Workspace crates keep their line-tables-only debug info. This also disables debug info in C/C++ build scripts (rocksdb, mdbx, jemalloc, ...), the single largest consumer of `target` disk.

## Benefits

Builds are faster (10-20% faster) and disk usage is lower (> 10% gain).

## Drawbacks

Debugging segmentation faults using `lldb` that affect 3rd-party dependencies (or similar scenarios) becomes harder, and may require manually re-enabling debug symbols. These scenarios should be pretty rare though.