### PR TITLE
fix(eip8130): enforce CREATE2 deploy rules on enshrined create at inclusion

### DIFF
--- a/crates/common/evm/src/eip8130.rs
+++ b/crates/common/evm/src/eip8130.rs
@@ -990,8 +990,7 @@ impl Eip8130Executor {
             // 2. Install the deferred account-*code* effects (created-account
             //    bytecode, delegation indicator) the apply step surfaced.
             if let Some(created) = &applied_tx.applied.created {
-                sctx.set_code(created.address, Bytecode::new_raw(created.code.clone()))
-                    .map_err(BaseTransactionError::eip8130)?;
+                Self::install_created_code(sctx, created.address, &created.code)?;
             }
             if let Some(delegation) = &applied_tx.applied.delegation {
                 delegation.install(sctx).map_err(BaseTransactionError::eip8130)?;
@@ -1048,7 +1047,15 @@ impl Eip8130Executor {
             //    delegation owner change was supplied. A zero target deliberately
             //    clears the sender's delegation and must not be overwritten with
             //    `DEFAULT_ACCOUNT`.
-            let sender_auto_delegated = if has_explicit_delegation {
+            // A create installs the account's own runtime, so it must never be
+            // auto-delegated to `DEFAULT_ACCOUNT`. `apply_create` rejects empty
+            // runtimes, so a created sender is never code-less here and
+            // `auto_delegate_codeless_sender` would already no-op; gating on the
+            // create explicitly keeps that invariant local rather than relying on
+            // the emptiness check, and matches the `sender_auto_delegated`
+            // intrinsic-gas classifier's own suppression on a create entry.
+            let has_create = applied_tx.applied.created.is_some();
+            let sender_auto_delegated = if has_explicit_delegation || has_create {
                 false
             } else {
                 Self::auto_delegate_codeless_sender(sctx, sender)?
@@ -1678,15 +1685,44 @@ impl Eip8130Executor {
                 }
             }
         }
-        if let Some((address, code)) = created_effect {
-            sctx.set_code(address, Bytecode::new_raw(code))
-                .map_err(BaseTransactionError::eip8130)?;
+        if let Some((address, code)) = &created_effect {
+            Self::install_created_code(sctx, *address, code)?;
         }
         let has_explicit_delegation = delegation_effect.is_some();
         if let Some(delegation) = delegation_effect {
             delegation.install(sctx).map_err(BaseTransactionError::eip8130)?;
         }
         Ok(has_explicit_delegation)
+    }
+
+    /// Installs a created account's runtime code, enforcing the CREATE2 collision
+    /// rule the reference contract gets for free from a real deploy: the
+    /// destination must be empty (no code, zero nonce). The account info is read
+    /// from the real journal (not the config overlay), so block inclusion
+    /// enforces what mempool admission checks separately — an inclusion path that
+    /// bypasses the pool cannot overwrite preexisting third-party code.
+    ///
+    /// The runtime is already validated non-empty, `<= MAX_CODE_SIZE`, and not
+    /// `0xEF`-prefixed by [`AccountChangeApplier::apply_create`], so
+    /// [`Bytecode::new_raw_checked`] never errors here; the fallible constructor
+    /// is used anyway so any future gap surfaces as a validity error rather than
+    /// a panic on transaction-controlled bytes.
+    fn install_created_code(
+        sctx: StorageCtx<'_>,
+        address: Address,
+        code: &Bytes,
+    ) -> Result<(), BaseTransactionError> {
+        let occupied = sctx
+            .with_account_info(address, |info| Ok(!info.is_empty_code_hash() || info.nonce != 0))
+            .map_err(BaseTransactionError::eip8130)?;
+        if occupied {
+            return Err(BaseTransactionError::eip8130(
+                "create destination already has code or a non-zero nonce",
+            ));
+        }
+        let bytecode =
+            Bytecode::new_raw_checked(code.clone()).map_err(BaseTransactionError::eip8130)?;
+        sctx.set_code(address, bytecode).map_err(BaseTransactionError::eip8130)
     }
 
     /// Auto-delegates a code-less sender to [`Eip8130Contracts::DEFAULT_ACCOUNT`]
@@ -3103,6 +3139,73 @@ mod tests {
         assert_eq!(created.info.nonce, 1, "create sender nonce bumped");
         assert!(!created.info.is_empty_code_hash(), "created account has code");
         assert!(created.info.balance < initial_balance, "self-paid create charged");
+    }
+
+    /// Asserts a counterfactual create with `code` is rejected at inclusion with
+    /// an `Eip8130` validity error whose reason contains `reason`, and that no
+    /// balance is charged (the transaction is not included). Never panics — the
+    /// point of the create-safety gate is that transaction-controlled runtimes
+    /// surface as clean rejections rather than executor panics.
+    fn assert_create_rejected(byte: u8, code: Bytes, reason: &str) {
+        let key = signing_key(byte);
+        let (derived, signed) = counterfactual_create_signed(&key, code, Vec::new());
+        let mut evm = evm_with(U256::from(10u64).pow(U256::from(18u64)), derived);
+        let err = evm.transact_raw(into_base_tx(&signed)).unwrap_err();
+        let EVMError::Transaction(BaseTransactionError::Eip8130(got)) = err else {
+            panic!("expected an Eip8130 validity rejection, got {err:?}");
+        };
+        assert!(got.contains(reason), "reason {got:?} does not contain {reason:?}");
+    }
+
+    #[test]
+    fn create_rejects_oversized_runtime() {
+        // EIP-170: a runtime larger than MAX_CODE_SIZE would be rejected by the
+        // reference contract's CREATE2 deploy; the enshrined path must reject it
+        // too rather than install oversized code at inclusion.
+        let code = Bytes::from(vec![0x00u8; Eip8130Constants::MAX_CODE_SIZE + 1]);
+        assert_create_rejected(0xb1, code, "MAX_CODE_SIZE");
+    }
+
+    #[test]
+    fn create_rejects_leading_ef_runtime() {
+        // EIP-3541: deployed code may not begin with 0xEF.
+        assert_create_rejected(0xb2, bytes!("ef00"), "0xEF");
+    }
+
+    #[test]
+    fn create_rejects_malformed_eip7702_runtime() {
+        // The 3-byte 0xEF0100 prefix is a malformed EIP-7702 designator that
+        // previously panicked `Bytecode::new_raw` (InvalidLength) when installed
+        // as create runtime. It must now be a clean EIP-3541 rejection.
+        assert_create_rejected(0xb3, bytes!("ef0100"), "0xEF");
+    }
+
+    #[test]
+    fn create_rejects_full_eip7702_designator_runtime() {
+        // A canonical 23-byte 0xEF0100||target designator must not be accepted as
+        // create runtime (it would silently become an EIP-7702 delegation from a
+        // Create-only transaction); EIP-3541 rejects it.
+        let mut designator = vec![0xEF, 0x01, 0x00];
+        designator.extend_from_slice(Address::repeat_byte(0x42).as_slice());
+        assert_create_rejected(0xb4, Bytes::from(designator), "0xEF");
+    }
+
+    #[test]
+    fn create_rejects_overwriting_existing_code() {
+        // CREATE2 collision: the reference contract's deploy reverts when the
+        // destination already holds code. The enshrined path installs runtime
+        // directly, so it must reject a create whose derived address already has
+        // preexisting (non-8130) bytecode instead of overwriting it.
+        let key = signing_key(0xb5);
+        let (derived, signed) = counterfactual_create_signed(&key, bytes!("6001"), Vec::new());
+        let mut evm = evm_with(U256::from(10u64).pow(U256::from(18u64)), derived);
+        seed_account_code(&mut evm, derived, Bytes::from_static(&[0xfe, 0xfe, 0xfe]));
+
+        let err = evm.transact_raw(into_base_tx(&signed)).unwrap_err();
+        let EVMError::Transaction(BaseTransactionError::Eip8130(got)) = err else {
+            panic!("expected an Eip8130 validity rejection, got {err:?}");
+        };
+        assert!(got.contains("already has code"), "unexpected reason: {got}");
     }
 
     #[test]

--- a/crates/execution/eip8130/src/apply.rs
+++ b/crates/execution/eip8130/src/apply.rs
@@ -135,23 +135,30 @@ pub enum ApplyError {
     #[error("create bytecode is empty")]
     EmptyBytecode,
 
-    /// A create entry's bytecode exceeds the 0xFFFF deployment limit. Mirrors
-    /// `require(n <= 0xFFFF)`.
+    /// A create entry's bytecode exceeds the 0xFFFF deployment-loader limit.
+    /// Mirrors `_buildDeploymentCode`'s `require(n <= 0xFFFF)` (the PUSH2 loader
+    /// bound). The stricter [`Self::CreateCodeExceedsMaxSize`] EIP-170 cap is
+    /// enforced first on the create path.
     #[error("create bytecode exceeds the 65535-byte limit")]
     BytecodeTooLarge,
 
-    /// A create entry's runtime code cannot be deployed. Mirrors `createAccount`'s
-    /// `AccountDeploymentFailed`: on the contract, `CREATE2` returns `address(0)`
-    /// when the runtime code is over the EIP-170 [`Eip8130Constants::MAX_CODE_SIZE`]
-    /// cap or leads with the EIP-3541 reserved `0xEF` byte. The enshrined apply
-    /// path deploys the code directly (`set_code`) rather than via `CREATE2`, so it
-    /// must reject those payloads explicitly — a leading-`0xEF` payload would
-    /// otherwise panic in `Bytecode::new_raw` instead of failing the transaction.
-    #[error("account {account} runtime code is not deployable (EIP-170 size / EIP-3541 prefix)")]
-    AccountDeploymentFailed {
-        /// The counterfactual address whose runtime code cannot be deployed.
-        account: Address,
-    },
+    /// A create entry's runtime bytecode exceeds EIP-170's `MAX_CODE_SIZE`
+    /// (24576). The reference contract deploys the runtime with a real `CREATE2`,
+    /// whose returned code is subject to EIP-170; the enshrined path installs the
+    /// runtime directly with `set_code`, so this bound must be enforced here or
+    /// an inclusion path that bypasses mempool admission would install
+    /// oversized code the reference implementation would reject.
+    #[error("create bytecode exceeds the EIP-170 MAX_CODE_SIZE limit")]
+    CreateCodeExceedsMaxSize,
+
+    /// A create entry's runtime bytecode begins with the `0xEF` byte, which
+    /// EIP-3541 forbids for deployed code. Real `CREATE2` in the reference
+    /// contract rejects such runtimes; the enshrined path installs the runtime
+    /// directly, so it must reject them too. This also prevents a `0xEF01`-
+    /// prefixed runtime from reaching a panicking `Bytecode` constructor or from
+    /// being silently reinterpreted as an EIP-7702 delegation designator.
+    #[error("create bytecode begins with the EIP-3541-forbidden 0xEF byte")]
+    CreateCodeStartsWithEf,
 
     /// The account targeted by a create entry already has EIP-8130 state. Mirrors
     /// the CREATE2 collision that makes `createAccount` unrepeatable.
@@ -769,6 +776,11 @@ impl AccountChangeApplier {
         storage: &mut AccountConfigurationStorage<'_>,
         entry: &CreateEntry,
     ) -> Result<CreatedAccount, ApplyError> {
+        // Validate the runtime before deriving the address so every caller (pool
+        // admission and block inclusion) rejects the same set of malformed
+        // runtimes at the shared choke point, matching the reference contract's
+        // CREATE2 deploy (EIP-170 size, EIP-3541 leading-byte).
+        Self::validate_create_runtime(&entry.code)?;
         let address = Self::compute_address(entry.user_salt, &entry.code, &entry.initial_actors)?;
         // Block re-initialization of an account that already holds EIP-8130 state.
         // `local_sequence` doubles as the created/imported flag; `local_epoch`
@@ -782,18 +794,6 @@ impl AccountChangeApplier {
         let mut state = storage.get_account_state(address)?;
         if state.is_initialized() {
             return Err(ApplyError::AlreadyCreated { account: address });
-        }
-
-        // Mirror `createAccount`'s `CREATE2` deploy, which returns `address(0)`
-        // (→ `AccountDeploymentFailed`) for runtime code over the EIP-170 cap or
-        // leading with the EIP-3541 reserved `0xEF` byte. This path deploys via
-        // `set_code(Bytecode::new_raw(..))` instead of `CREATE2`, so it enforces
-        // both here — a leading-`0xEF` payload would otherwise panic in
-        // `Bytecode::new_raw`. Checked after the already-created guard so a
-        // collision still reports `AlreadyCreated` first, and before any state
-        // write so a rejected create leaves no partially-initialized account.
-        if entry.code.len() > Eip8130Constants::MAX_CODE_SIZE || entry.code.first() == Some(&0xEF) {
-            return Err(ApplyError::AccountDeploymentFailed { account: address });
         }
 
         // Mark initialized, disable the implicit default-EOA path by default
@@ -949,6 +949,31 @@ impl AccountChangeApplier {
             packed_leaves.extend_from_slice(keccak256(&leaf).as_slice());
         }
         keccak256(packed_leaves)
+    }
+
+    /// Validates a create entry's runtime bytecode against the constraints the
+    /// reference contract's real `CREATE2` deploy enforces, which the enshrined
+    /// path — installing the runtime directly with `set_code` rather than
+    /// deploying it — would otherwise skip:
+    ///
+    /// - non-empty ([`ApplyError::EmptyBytecode`]): a codeless create would leave
+    ///   an account with actor config but no code, breaking the EOA invariant.
+    /// - at most EIP-170 `MAX_CODE_SIZE` ([`ApplyError::CreateCodeExceedsMaxSize`]).
+    /// - not `0xEF`-prefixed per EIP-3541 ([`ApplyError::CreateCodeStartsWithEf`]),
+    ///   which also keeps a `0xEF01`-prefixed runtime away from the panicking
+    ///   `Bytecode` designator constructor and from being reinterpreted as an
+    ///   EIP-7702 delegation.
+    pub fn validate_create_runtime(bytecode: &[u8]) -> Result<(), ApplyError> {
+        if bytecode.is_empty() {
+            return Err(ApplyError::EmptyBytecode);
+        }
+        if bytecode.len() > Eip8130Constants::MAX_CODE_SIZE {
+            return Err(ApplyError::CreateCodeExceedsMaxSize);
+        }
+        if bytecode[0] == 0xEF {
+            return Err(ApplyError::CreateCodeStartsWithEf);
+        }
+        Ok(())
     }
 
     /// Builds an account's deployment code: a 14-byte EVM loader header that
@@ -1647,6 +1672,43 @@ mod tests {
     }
 
     #[test]
+    fn validate_create_runtime_enforces_create2_deploy_rules() {
+        // Empty runtime is rejected (codeless create).
+        assert_eq!(
+            AccountChangeApplier::validate_create_runtime(&[]),
+            Err(ApplyError::EmptyBytecode)
+        );
+        // A runtime at exactly MAX_CODE_SIZE is allowed; one byte over is not.
+        assert!(
+            AccountChangeApplier::validate_create_runtime(&vec![
+                0x00u8;
+                Eip8130Constants::MAX_CODE_SIZE
+            ])
+            .is_ok()
+        );
+        assert_eq!(
+            AccountChangeApplier::validate_create_runtime(&vec![
+                0x00u8;
+                Eip8130Constants::MAX_CODE_SIZE + 1
+            ]),
+            Err(ApplyError::CreateCodeExceedsMaxSize)
+        );
+        // EIP-3541: any runtime beginning with 0xEF is rejected, including the
+        // 3-byte 0xEF0100 prefix that would otherwise panic the EIP-7702
+        // designator constructor, and a full 0xEF0100||target designator.
+        assert_eq!(
+            AccountChangeApplier::validate_create_runtime(&[0xEF, 0x00]),
+            Err(ApplyError::CreateCodeStartsWithEf)
+        );
+        assert_eq!(
+            AccountChangeApplier::validate_create_runtime(&[0xEF, 0x01, 0x00]),
+            Err(ApplyError::CreateCodeStartsWithEf)
+        );
+        // An ordinary runtime is accepted.
+        assert!(AccountChangeApplier::validate_create_runtime(&[0x60, 0x00]).is_ok());
+    }
+
+    #[test]
     fn actors_commitment_hashes_leaves_then_list() {
         // Golden values cross-checked against the contract's leaves-then-list
         // scheme (#74) with `cast keccak`: each actor hashes to
@@ -1847,14 +1909,14 @@ mod tests {
             .unwrap();
             assert_eq!(
                 AccountChangeApplier::apply_create(acc, &entry),
-                Err(ApplyError::AccountDeploymentFailed { account: expected })
+                Err(ApplyError::CreateCodeStartsWithEf)
             );
             // No partially-initialized account is left behind on rejection.
             assert!(!acc.get_account_state(expected).unwrap().is_initialized());
         });
 
         // EIP-170: runtime code over `MAX_CODE_SIZE` (but under the 0xFFFF
-        // deployment-code cap) computes an address but is not deployable.
+        // deployment-code cap) is rejected before any state is written.
         with_storage(|acc| {
             let entry = CreateEntry {
                 user_salt: B256::ZERO,
@@ -1869,8 +1931,9 @@ mod tests {
             .unwrap();
             assert_eq!(
                 AccountChangeApplier::apply_create(acc, &entry),
-                Err(ApplyError::AccountDeploymentFailed { account: expected })
+                Err(ApplyError::CreateCodeExceedsMaxSize)
             );
+            assert!(!acc.get_account_state(expected).unwrap().is_initialized());
         });
 
         // Exactly `MAX_CODE_SIZE` deploys (boundary, non-`0xEF` lead).

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -1564,9 +1564,8 @@ where
             }
             ApplyError::EmptyBytecode => "create bytecode is empty",
             ApplyError::BytecodeTooLarge => "create bytecode exceeds the size limit",
-            ApplyError::AccountDeploymentFailed { .. } => {
-                "create bytecode is not deployable (size or reserved 0xEF prefix)"
-            }
+            ApplyError::CreateCodeExceedsMaxSize => "create bytecode exceeds MAX_CODE_SIZE",
+            ApplyError::CreateCodeStartsWithEf => "create bytecode begins with 0xEF",
             ApplyError::AlreadyCreated { .. } => "create account already exists",
             ApplyError::CreateAddressMismatch { .. } => "create address does not match the sender",
             ApplyError::InvalidCreatePosition => "create entry must be the only one, at index 0",


### PR DESCRIPTION
## Summary

The reference contract deploys a created account's runtime with a real `CREATE2`, which enforces **EIP-170** (`MAX_CODE_SIZE`), **EIP-3541** (no leading `0xEF`), and reverts on a **destination that already holds code**. The enshrined path installs the runtime directly with `set_code` (`crates/common/evm/src/eip8130.rs`), so it skipped all of these. Mempool admission (`validator.rs`) re-implements the size/freshness checks, but any inclusion path that bypasses the pool (direct build, Engine delivery, singular-batch derivation) did not — and **no path anywhere** rejected a leading-`0xEF` runtime.

Verified against the code (PoCs run against `Eip8130Executor::execute`): before this change a create at inclusion could

- install runtime larger than `MAX_CODE_SIZE` (24 577 accepted; up to the `0xFFFF` loader bound),
- install an EIP-3541-forbidden `0xEF`-prefixed runtime (`0xef00` installed as legacy code),
- overwrite preexisting non-8130 bytecode at the derived address (nonce 0), and
- **PANIC the executor**: a 3-byte `0xEF0100` runtime reached `Bytecode::new_raw` and panicked on the malformed EIP-7702 designator (`InvalidLength`, `revm-bytecode-41.0.0/.../mod.rs:154`) — a node-crash reachable from the public mempool, which does **not** gate `0xEF`.

Empty-runtime and non-zero-nonce creates were already rejected (via `build_deployment_code`/`EmptyBytecode` and the 2D-nonce check respectively), so those parts of the finding did not reproduce.

## Fixes

- **`AccountChangeApplier::validate_create_runtime`** (shared, `apply.rs`) enforces non-empty, EIP-170 size, and EIP-3541 leading-byte, called at the top of `apply_create` so **pool and inclusion reject the same runtimes at one choke point**. New `ApplyError::CreateCodeExceedsMaxSize` / `CreateCodeStartsWithEf`.
- **`Eip8130Executor::install_created_code`** rejects a create whose derived address already has code or a non-zero nonce (CREATE2 collision), reading the real journal account, and installs via the fallible **`Bytecode::new_raw_checked`** so transaction-controlled bytes can never panic the executor. Used at both the verifying and simulate `set_code` sites.
- Execution **auto-delegation is gated on `applied.created.is_none()`** so a created account is never overwritten by a `DEFAULT_ACCOUNT` delegation (defense-in-depth; empty creates are already rejected).

## Test plan

- [x] `validate_create_runtime_enforces_create2_deploy_rules` (unit): empty / `MAX_CODE_SIZE` boundary / `0xEF00` / `0xEF0100` / ordinary.
- [x] Execution parity tests: `create_rejects_oversized_runtime`, `create_rejects_leading_ef_runtime`, `create_rejects_malformed_eip7702_runtime` (the former panic, now a clean rejection), `create_rejects_full_eip7702_designator_runtime`, `create_rejects_overwriting_existing_code` — all reject with an `Eip8130` validity error and never panic.
- [x] `counterfactual_create_executes_and_is_included` / `..._then_call_...` still pass (fresh create unaffected).
- [x] `cargo test -p base-execution-eip8130` / `-p base-common-evm eip8130::tests::` / `-p base-execution-txpool` green.
- [x] `cargo fmt --check` + `cargo clippy --all-targets` clean on all three crates.