### PR TITLE
feat(ci): make advisory benchmark comparison reliable

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -18,29 +18,33 @@ permissions:
   pull-requests: write
 
 jobs:
+  # Base and head are benchmarked on the *same* physical runner, back to back, so a
+  # reported delta reflects the code change rather than variance between two hosts.
+  # (Per-benchmark interleaving would tighten this further and is a possible follow-up.)
   bench:
-    name: Run benchmarks (${{ matrix.variant }})
+    name: Benchmarks (advisory)
     runs-on:
       group: BasePerfRunnerGroup
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - variant: base
-            ref: ${{ github.event.pull_request.base.sha }}
-          - variant: head
-            ref: ${{ github.event.pull_request.head.sha }}
+    timeout-minutes: 90
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
-      - name: Checkout ${{ matrix.variant }}
+      # Head is the root checkout so ./.github/actions/setup and the compare script
+      # resolve at the workspace root; base is checked out alongside it into base-src.
+      - name: Checkout head
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ matrix.ref }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 1
+
+      - name: Checkout base
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: base-src
           fetch-depth: 1
 
       - uses: ./.github/actions/setup
@@ -51,8 +55,31 @@ jobs:
           just: "false"
 
       # Advisory only: a bench that fails to compile or run must not fail the job.
-      # The comparison step surfaces whatever results were produced.
-      - name: Run benchmark subset
+      # A bench that runs on base but breaks on head simply produces no head result,
+      # which the comparison step surfaces as lost coverage. The curated subset is the
+      # deterministic, CPU-bound benches; I/O-heavy, async, and multi-threaded benches
+      # are left out because their wall-clock time is too noisy to read per-PR.
+      - name: Run benchmark subset (base)
+        continue-on-error: true
+        working-directory: base-src
+        shell: bash
+        run: |
+          set -uo pipefail
+          run() { echo "::group::$*"; "$@"; echo "::endgroup::"; }
+          run cargo bench -p base-proof-mpt --bench trie_node \
+            -- --save-baseline current --noplot
+          run cargo bench -p base-protocol --bench batch_transaction \
+            -- --save-baseline current --noplot
+          run cargo bench -p base-consensus-derive --bench batch_queue --features test-utils \
+            -- --save-baseline current --noplot
+          run cargo bench -p base-common-precompiles --bench base_precompiles --features test-utils \
+            -- --save-baseline current --noplot
+          run cargo bench -p base-builder-core --bench tx_selection \
+            -- --save-baseline current --noplot
+          run cargo bench -p base-flashblocks-node --bench sender_recovery \
+            -- --save-baseline current sequential --noplot
+
+      - name: Run benchmark subset (head)
         continue-on-error: true
         shell: bash
         run: |
@@ -66,42 +93,15 @@ jobs:
             -- --save-baseline current --noplot
           run cargo bench -p base-common-precompiles --bench base_precompiles --features test-utils \
             -- --save-baseline current --noplot
-
-      - name: Upload benchmark results
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: bench-${{ matrix.variant }}
-          path: target/criterion/**/current/estimates.json
-          if-no-files-found: warn
-
-  comment:
-    name: Benchmarks (advisory)
-    if: always()
-    needs: bench
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - name: Checkout Base
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 1
+          run cargo bench -p base-builder-core --bench tx_selection \
+            -- --save-baseline current --noplot
+          run cargo bench -p base-flashblocks-node --bench sender_recovery \
+            -- --save-baseline current sequential --noplot
 
       - name: Set up Python 3.13
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.13"
-
-      - name: Download benchmark results
-        continue-on-error: true
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: bench-*
-          path: ${{ runner.temp }}/bench-results
 
       - name: Render comparison
         id: render
@@ -111,8 +111,8 @@ jobs:
         run: |
           set -euo pipefail
           python3 etc/scripts/ci/bench_compare.py \
-            --base-dir "$RUNNER_TEMP/bench-results/bench-base" \
-            --head-dir "$RUNNER_TEMP/bench-results/bench-head" \
+            --base-dir base-src/target/criterion \
+            --head-dir target/criterion \
             --output "$RUNNER_TEMP/bench-comment.md" \
             --run-url "$WORKFLOW_RUN_URL" \
             --threshold-pct 10 \
@@ -120,11 +120,12 @@ jobs:
             --github-output "$GITHUB_OUTPUT"
           cat "$RUNNER_TEMP/bench-comment.md" >> "$GITHUB_STEP_SUMMARY"
 
-      # Only comment on a notable regression or improvement, to keep PR noise low. If
-      # a prior run left a comment that a later push has since made unremarkable, delete
-      # it. Skip forked PRs — we don't have permission to comment on them.
+      # Only comment on a notable regression, improvement, or lost coverage, to keep
+      # PR noise low. If a prior run left a comment that a later push has since made
+      # unremarkable, delete it. Skip forked PRs — we can't comment on them.
       - name: Comment or clear benchmark results on PR
         if: >
+          always() &&
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository
         shell: bash

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -150,6 +150,9 @@ jobs:
               gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
                 --field body="$body" > /dev/null
             fi
-          elif [ -n "$existing_id" ]; then
+          elif [ "$SHOULD_COMMENT" = "false" ] && [ -n "$existing_id" ]; then
+            # Only clear a stale comment when the render step explicitly decided this
+            # PR is unremarkable. If render never ran (e.g. it crashed) SHOULD_COMMENT
+            # is empty, and we must not delete a legitimate warning from a prior run.
             gh api "repos/${REPO}/issues/comments/${existing_id}" -X DELETE > /dev/null
           fi

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -56,47 +56,21 @@ jobs:
 
       # Advisory only: a bench that fails to compile or run must not fail the job.
       # A bench that runs on base but breaks on head simply produces no head result,
-      # which the comparison step surfaces as lost coverage. The curated subset is the
-      # deterministic, CPU-bound benches; I/O-heavy, async, and multi-threaded benches
-      # are left out because their wall-clock time is too noisy to read per-PR.
+      # which the comparison step surfaces as lost coverage. The curated subset lives
+      # in run_bench_subset.sh so a single list runs against both trees — see that
+      # script for why these particular benches were chosen. Both steps invoke the
+      # *head* checkout's copy (via GITHUB_WORKSPACE) so the base run cannot use a
+      # stale list from the base commit; only the working directory differs.
       - name: Run benchmark subset (base)
         continue-on-error: true
         working-directory: base-src
         shell: bash
-        run: |
-          set -uo pipefail
-          run() { echo "::group::$*"; "$@"; echo "::endgroup::"; }
-          run cargo bench -p base-proof-mpt --bench trie_node \
-            -- --save-baseline current --noplot
-          run cargo bench -p base-protocol --bench batch_transaction \
-            -- --save-baseline current --noplot
-          run cargo bench -p base-consensus-derive --bench batch_queue --features test-utils \
-            -- --save-baseline current --noplot
-          run cargo bench -p base-common-precompiles --bench base_precompiles --features test-utils \
-            -- --save-baseline current --noplot
-          run cargo bench -p base-builder-core --bench tx_selection \
-            -- --save-baseline current --noplot
-          run cargo bench -p base-flashblocks-node --bench sender_recovery \
-            -- --save-baseline current sequential --noplot
+        run: bash "$GITHUB_WORKSPACE/etc/scripts/ci/run_bench_subset.sh"
 
       - name: Run benchmark subset (head)
         continue-on-error: true
         shell: bash
-        run: |
-          set -uo pipefail
-          run() { echo "::group::$*"; "$@"; echo "::endgroup::"; }
-          run cargo bench -p base-proof-mpt --bench trie_node \
-            -- --save-baseline current --noplot
-          run cargo bench -p base-protocol --bench batch_transaction \
-            -- --save-baseline current --noplot
-          run cargo bench -p base-consensus-derive --bench batch_queue --features test-utils \
-            -- --save-baseline current --noplot
-          run cargo bench -p base-common-precompiles --bench base_precompiles --features test-utils \
-            -- --save-baseline current --noplot
-          run cargo bench -p base-builder-core --bench tx_selection \
-            -- --save-baseline current --noplot
-          run cargo bench -p base-flashblocks-node --bench sender_recovery \
-            -- --save-baseline current sequential --noplot
+        run: bash "$GITHUB_WORKSPACE/etc/scripts/ci/run_bench_subset.sh"
 
       - name: Set up Python 3.13
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/etc/scripts/ci/bench_compare.py
+++ b/etc/scripts/ci/bench_compare.py
@@ -113,6 +113,10 @@ class BenchCompare:
     def render_row(self, bench_id: str, base: Measurement | None, head: Measurement | None) -> str:
         """Render a single Markdown table row for one benchmark."""
         if base is None:
+            # bench_ids is built from set(base) | set(head), so a missing base side
+            # guarantees head is present; assert it so a future refactor can't turn
+            # this into a silent AttributeError.
+            assert head is not None
             return f"| `{bench_id}` | — (new) | {self.humanize_ns(head.median)} | — |"
         if head is None:
             return f"| `{bench_id}` | {self.humanize_ns(base.median)} | — (missing) | — |"

--- a/etc/scripts/ci/bench_compare.py
+++ b/etc/scripts/ci/bench_compare.py
@@ -5,15 +5,31 @@ Reads two trees of criterion output (one benchmarked on the PR base commit, one
 on the PR head commit), matches benchmarks by their criterion id, and emits an
 advisory Markdown table of the median-time delta. This never gates a merge; it is
 visibility only.
+
+A wall-clock delta is only flagged as a regression or improvement when it clears
+the percentage threshold *and* the two medians' confidence intervals do not
+overlap, so ordinary run-to-run noise on a small sample does not trip the alert.
+Benchmarks that produced a result on base but not head (a likely compile/run
+break) are surfaced as a warning rather than silently dropped.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import argparse
 from pathlib import Path
 import json
 
 MARKER = "<!-- bench-pr-results -->"
+
+
+@dataclass
+class Measurement:
+    """A single benchmark's median time and its confidence interval, in ns."""
+
+    median: float
+    lower: float
+    upper: float
 
 
 class BenchCompare:
@@ -24,15 +40,15 @@ class BenchCompare:
         self.improvement_pct = improvement_pct
 
     @staticmethod
-    def collect(root: Path) -> dict[str, float]:
-        """Map criterion benchmark id -> median time in nanoseconds under root.
+    def collect(root: Path) -> dict[str, Measurement]:
+        """Map criterion benchmark id -> Measurement under root.
 
         A criterion result lives at `<root>/<id...>/current/estimates.json`. The id
         is every path component between the artifact root and the `current` baseline
         directory, so ids are identical across the two trees regardless of how the
         upload step stripped any shared path prefix.
         """
-        results: dict[str, float] = {}
+        results: dict[str, Measurement] = {}
         for estimates in root.rglob("current/estimates.json"):
             bench_id = "/".join(estimates.relative_to(root).parts[:-2])
             if not bench_id:
@@ -44,7 +60,13 @@ class BenchCompare:
             point = payload.get("median") or payload.get("mean")
             if not point or "point_estimate" not in point:
                 continue
-            results[bench_id] = float(point["point_estimate"])
+            median = float(point["point_estimate"])
+            # Fall back to a zero-width interval when criterion did not emit one, so
+            # the overlap test degrades to a plain median comparison.
+            interval = point.get("confidence_interval") or {}
+            lower = float(interval.get("lower_bound", median))
+            upper = float(interval.get("upper_bound", median))
+            results[bench_id] = Measurement(median=median, lower=lower, upper=upper)
         return results
 
     @staticmethod
@@ -55,38 +77,62 @@ class BenchCompare:
                 return f"{value / scale:.2f} {unit}"
         return f"{value:.1f} ns"
 
-    def delta_pct(self, base: float | None, head: float | None) -> float | None:
-        """Percent change from base to head, or None if either side is missing."""
-        if base is None or head is None or not base:
+    def delta_pct(self, base: Measurement | None, head: Measurement | None) -> float | None:
+        """Percent change from base to head median, or None if either side is missing."""
+        if base is None or head is None or not base.median:
             return None
-        return (head - base) / base * 100
+        return (head.median - base.median) / base.median * 100
 
-    def is_regression(self, base: float | None, head: float | None) -> bool:
-        """A benchmark regresses when head is slower than base beyond the threshold."""
+    @staticmethod
+    def intervals_overlap(base: Measurement, head: Measurement) -> bool:
+        """Whether the two median confidence intervals overlap.
+
+        Overlapping intervals mean the observed delta is within run-to-run noise, so
+        it must not be flagged even if the median delta clears the threshold.
+        """
+        return base.lower <= head.upper and head.lower <= base.upper
+
+    def is_significant(self, base: Measurement | None, head: Measurement | None) -> bool:
+        """Whether a delta is real signal: both sides present and intervals disjoint."""
+        return base is not None and head is not None and not self.intervals_overlap(base, head)
+
+    def is_regression(self, base: Measurement | None, head: Measurement | None) -> bool:
+        """Regression: head slower than base beyond the threshold, outside the noise band."""
         delta = self.delta_pct(base, head)
-        return delta is not None and delta >= self.threshold_pct
+        return delta is not None and delta >= self.threshold_pct and self.is_significant(base, head)
 
-    def is_improvement(self, base: float | None, head: float | None) -> bool:
-        """A benchmark improves when head is faster than base beyond the threshold."""
+    def is_improvement(self, base: Measurement | None, head: Measurement | None) -> bool:
+        """Improvement: head faster than base beyond the threshold, outside the noise band."""
         delta = self.delta_pct(base, head)
-        return delta is not None and delta <= -self.improvement_pct
+        return (
+            delta is not None
+            and delta <= -self.improvement_pct
+            and self.is_significant(base, head)
+        )
 
-    def render_row(self, bench_id: str, base: float | None, head: float | None) -> str:
+    def render_row(self, bench_id: str, base: Measurement | None, head: Measurement | None) -> str:
         """Render a single Markdown table row for one benchmark."""
         if base is None:
-            return f"| `{bench_id}` | — (new) | {self.humanize_ns(head)} | — |"
+            return f"| `{bench_id}` | — (new) | {self.humanize_ns(head.median)} | — |"
         if head is None:
-            return f"| `{bench_id}` | {self.humanize_ns(base)} | — (removed) | — |"
+            return f"| `{bench_id}` | {self.humanize_ns(base.median)} | — (missing) | — |"
         delta = self.delta_pct(base, head) or 0.0
         flag = ""
         if abs(delta) >= self.threshold_pct:
-            flag = " ⚠️ slower" if delta > 0 else " ✅ faster"
+            if self.is_significant(base, head):
+                flag = " ⚠️ slower" if delta > 0 else " ✅ faster"
+            else:
+                # Threshold cleared, but the confidence intervals overlap, so treat
+                # the move as noise and say so rather than raising a false alarm.
+                flag = " · within noise"
         return (
-            f"| `{bench_id}` | {self.humanize_ns(base)} | {self.humanize_ns(head)} "
+            f"| `{bench_id}` | {self.humanize_ns(base.median)} | {self.humanize_ns(head.median)} "
             f"| {delta:+.1f}%{flag} |"
         )
 
-    def summarize(self, base: dict[str, float], head: dict[str, float], ids: list[str]) -> str:
+    def summarize(
+        self, base: dict[str, Measurement], head: dict[str, Measurement], ids: list[str]
+    ) -> str:
         """Render a `bench (+d%)` list for an alert summary."""
         return ", ".join(f"`{b}` ({self.delta_pct(base[b], head[b]):+.1f}%)" for b in ids)
 
@@ -97,30 +143,44 @@ class BenchCompare:
         bench_ids = sorted(set(base) | set(head))
         regressed = [b for b in bench_ids if self.is_regression(base.get(b), head.get(b))]
         improved = [b for b in bench_ids if self.is_improvement(base.get(b), head.get(b))]
+        # Present on base but not head: the bench likely failed to compile or run on
+        # the PR, which is itself a regression in coverage worth surfacing.
+        dropped = [b for b in bench_ids if b in base and b not in head]
 
         lines = [MARKER, ""]
-        # A regression takes priority over any concurrent improvement in the same PR.
+        # A dropped bench (lost coverage) and a regression are both actionable, so
+        # show each block that applies; an improvement is only highlighted when
+        # nothing regressed or dropped.
+        if dropped:
+            lines += [
+                "> [!WARNING]",
+                f"> {len(dropped)} benchmark(s) produced a result on the base branch "
+                f"but not on this PR — they may have failed to compile or run: "
+                f"{', '.join(f'`{b}`' for b in dropped)}.",
+                "",
+            ]
         if regressed:
             lines += [
                 "> [!CAUTION]",
                 f"> This PR may regress performance. {len(regressed)} benchmark(s) "
-                f"slower by more than {self.threshold_pct:.0f}%: "
+                f"slower by more than {self.threshold_pct:.0f}% beyond the noise band: "
                 f"{self.summarize(base, head, regressed)}.",
                 "",
             ]
-        elif improved:
+        elif improved and not dropped:
             lines += [
                 "> [!TIP]",
                 f"> Nice, this PR improves performance. {len(improved)} benchmark(s) "
-                f"faster by more than {self.improvement_pct:.0f}%: "
+                f"faster by more than {self.improvement_pct:.0f}% beyond the noise band: "
                 f"{self.summarize(base, head, improved)}.",
                 "",
             ]
         lines += [
             "### Benchmark results (advisory)",
             "",
-            f"Median time on the PR head versus the base branch. Wall-clock, so "
-            f"treat small changes as noise. A change flags at ±{self.threshold_pct:.0f}%. "
+            f"Median time on the PR head versus the base branch, measured on the same "
+            f"host. Wall-clock, so a change is only flagged when it clears ±"
+            f"{self.threshold_pct:.0f}% *and* the confidence intervals do not overlap. "
             f"This check never blocks a merge.",
             "",
             "| Benchmark | Base | Head | Δ median |",
@@ -129,9 +189,11 @@ class BenchCompare:
         if not bench_ids:
             lines.append("| _no benchmark results were produced_ | — | — | — |")
         else:
-            lines.extend(self.render_row(b, base.get(b), head.get(b)) for b in bench_ids)
+            lines.extend(
+                self.render_row(b, base.get(b), head.get(b)) for b in bench_ids
+            )
         lines += ["", f"[View run]({run_url}) · [Re-run benchmarks]({run_url})"]
-        return "\n".join(lines) + "\n", bool(regressed or improved)
+        return "\n".join(lines) + "\n", bool(regressed or improved or dropped)
 
 
 def parse_args() -> argparse.Namespace:

--- a/etc/scripts/ci/run_bench_subset.sh
+++ b/etc/scripts/ci/run_bench_subset.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Runs the curated advisory benchmark subset in the current working directory,
+# saving each result under the `current` criterion baseline for base-vs-head
+# comparison.
+#
+# bench-pr.yml invokes this once per side (base and head) from the *head* checkout
+# so a single authoritative list runs against both trees; the only difference is the
+# working directory the caller sets. Keeping the list here removes the drift risk of
+# duplicating it across two workflow steps, where adding or removing a bench in only
+# one block would surface as a spurious "new"/"missing" coverage change.
+#
+# Advisory only: a bench that fails to compile or run must not fail the job, so the
+# caller runs this with continue-on-error. The curated subset is the deterministic,
+# CPU-bound benches; I/O-heavy, async, and multi-threaded benches are left out
+# because their wall-clock time is too noisy to read per-PR.
+set -uo pipefail
+
+run() { echo "::group::$*"; "$@"; echo "::endgroup::"; }
+
+run cargo bench -p base-proof-mpt --bench trie_node \
+  -- --save-baseline current --noplot
+run cargo bench -p base-protocol --bench batch_transaction \
+  -- --save-baseline current --noplot
+run cargo bench -p base-consensus-derive --bench batch_queue --features test-utils \
+  -- --save-baseline current --noplot
+run cargo bench -p base-common-precompiles --bench base_precompiles --features test-utils \
+  -- --save-baseline current --noplot
+run cargo bench -p base-builder-core --bench tx_selection \
+  -- --save-baseline current --noplot
+run cargo bench -p base-flashblocks-node --bench sender_recovery \
+  -- --save-baseline current sequential --noplot


### PR DESCRIPTION
## Summary

Follow-up hardening for the advisory benchmark PR comment shipped in #4462. That workflow is a good start, but the review of it surfaced a few ways the numbers could mislead. This PR makes the advisory signal trustworthy and expands the curated subset. It stays purely advisory — it never fails the build and is not wired into any required check or the merge queue.

This is the first of a small stack:
1. **(this PR)** harness reliability + subset expansion
2. `trie_node` bench-quality fix (clone-in-loop + non-deterministic RNG)
3. first batch of new deterministic micro-benches

### Reliability fixes

- **Same host.** Base and head now run back to back on one `BasePerfRunnerGroup` runner instead of as two separate matrix jobs on (potentially) different machines, so a reported delta reflects the code change rather than cross-machine variance. (Per-benchmark interleaving would tighten this further — noted as a possible follow-up.)
- **Confidence-interval aware comparison.** `bench_compare.py` now flags a delta only when it clears ±10% **and** the two medians' confidence intervals do not overlap. With `sample_size = 10` on most benches, a raw ±10% flag fires on noise; a threshold-clearing but overlapping move now renders as `· within noise` rather than a false alarm.
- **Broken benches are surfaced, not hidden.** A benchmark that produced a result on base but not head (a likely compile/run break, previously rendered as `— (removed)` with the comment silently suppressed and any prior comment deleted) is now reported as a `> [!WARNING]` and does trigger a comment.

### Subset expansion (deterministic, CPU-bound only)

- `base-builder-core / tx_selection` — in-memory pending-pool selection; fully deterministic, pure CPU.
- `base-flashblocks-node / sender_recovery` restricted to the `sequential` filter — sequential ECDSA recovery; the rayon `parallel` variants are excluded because thread scheduling is too noisy for a per-PR wall-clock signal.

Neither new bench requires a `--features` flag (test-utils comes via dev-deps).

## Testing

- `bench_compare.py` self-tested against fabricated criterion output covering: a real regression (disjoint CIs), a +12% move with overlapping CIs (correctly reported `within noise`, not flagged), a small sub-threshold move, an improvement, a dropped bench (WARNING), and a new bench.
- Verified against **real** criterion `estimates.json` from a local `sender_recovery` run: schema matches (`median.confidence_interval.{lower,upper}_bound`), units humanize correctly, identical trees → no comment.
- Confirmed both new subset benches compile with no feature flags, and that the `sequential` filter runs only sequential benches (no `parallel` output) while still writing `current/estimates.json`.