### PR TITLE
feat(builder): inject validity predicates in shadow mode

### DIFF
--- a/bin/base/src/commands/sequencer.rs
+++ b/bin/base/src/commands/sequencer.rs
@@ -3,9 +3,7 @@
 use std::sync::Arc;
 
 use base_builder_cli::Args as BuilderArgs;
-use base_builder_core::{
-    BuilderApiExtension, BuilderApiExtensionConfig, FlashblocksServiceBuilder,
-};
+use base_builder_core::{BuilderApiExtension, FlashblocksServiceBuilder};
 use base_builder_metering::MeteringStoreExtension;
 use base_consensus_cli::{
     CliMetrics, ConsensusNodeArgs, ConsensusNodeConfigArgs, ConsensusNodeOverrides,
@@ -70,8 +68,7 @@ impl SequencerCommand {
         let sequencer_rpc = rollup_args.sequencer.clone();
         let metering_provider: base_builder_core::SharedMeteringProvider =
             Arc::new(builder.build_metering_store());
-        let accept_validity_transactions = builder.enable_experimental_validity_transactions;
-        let max_validity_predicates = builder.experimental_validity_max_predicates;
+        let builder_api_config = builder.builder_api_config()?;
         let builder_config = builder.into_builder_config(Arc::clone(&metering_provider))?;
         let da_config = builder_config.da_config.clone();
         let gas_limit_config = builder_config.gas_limit_config.clone();
@@ -110,10 +107,7 @@ impl SequencerCommand {
                 .with_service_builder(FlashblocksServiceBuilder::new(builder_config));
             runner.install_ext::<MeteringStoreExtension>(metering_provider);
             runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig { sequencer_rpc });
-            runner.install_ext::<BuilderApiExtension>(BuilderApiExtensionConfig::new(
-                accept_validity_transactions,
-                max_validity_predicates,
-            ));
+            runner.install_ext::<BuilderApiExtension>(builder_api_config);
             StandardBaseRethNode::install_upgrade_signal_runtime_extension(
                 &mut runner,
                 &rollup_args,

--- a/bin/builder/src/main.rs
+++ b/bin/builder/src/main.rs
@@ -6,9 +6,7 @@
 use std::sync::Arc;
 
 use base_builder_cli::Args;
-use base_builder_core::{
-    BuilderApiExtension, BuilderApiExtensionConfig, FlashblocksServiceBuilder,
-};
+use base_builder_core::{BuilderApiExtension, FlashblocksServiceBuilder};
 use base_builder_metering::MeteringStoreExtension;
 use base_execution_cli::{Cli, StandardBaseRethNode};
 use base_node_runner::BaseNodeRunner;
@@ -40,9 +38,8 @@ fn main() {
             transaction_events_enabled.then(|| builder_args.transaction_events.writer_config()),
         )?;
 
-        let accept_validity_transactions = builder_args.enable_experimental_validity_transactions;
+        let builder_api_config = builder_args.builder_api_config()?;
         let shadow_indexer_config = ShadowIndexerConfig::try_from(&builder_args.shadow_indexer)?;
-        let max_validity_predicates = builder_args.experimental_validity_max_predicates;
         let builder_config = builder_args
             .into_builder_config(Arc::clone(&metering_provider))
             .expect("Failed to convert rollup args to builder config");
@@ -57,10 +54,7 @@ fn main() {
             .with_service_builder(FlashblocksServiceBuilder::new(builder_config));
         runner.install_ext::<MeteringStoreExtension>(metering_provider);
         runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig::default());
-        runner.install_ext::<BuilderApiExtension>(BuilderApiExtensionConfig::new(
-            accept_validity_transactions,
-            max_validity_predicates,
-        ));
+        runner.install_ext::<BuilderApiExtension>(builder_api_config);
         runner.install_ext::<ShadowIndexerExtension>(shadow_indexer_config);
         StandardBaseRethNode::install_upgrade_signal_runtime_extension(&mut runner, &rollup_args)?;
         runner.add_started_callback(|| {

--- a/crates/builder/cli/src/args.rs
+++ b/crates/builder/cli/src/args.rs
@@ -4,8 +4,8 @@ use core::{net::SocketAddr, time::Duration};
 use std::path::PathBuf;
 
 use base_builder_core::{
-    BuilderConfig, DEFAULT_MAX_VALIDITY_PREDICATES, ExecutionMeteringMode, RejectionCache,
-    SharedMeteringProvider,
+    BuilderApiExtensionConfig, BuilderConfig, DEFAULT_MAX_VALIDITY_PREDICATES,
+    ExecutionMeteringMode, RejectionCache, ShadowValidityConfig, SharedMeteringProvider,
 };
 use base_builder_metering::MeteringStore;
 use base_execution_cli::ShadowIndexerArgs;
@@ -187,7 +187,7 @@ pub struct Args {
 
     /// Accept experimental validity-bearing transactions from forwarding nodes.
     ///
-    /// Predicates are preserved but are not yet enforced during block construction.
+    /// Predicates are preserved and enforced during block construction.
     #[arg(long = "builder.enable-experimental-validity-transactions", default_value = "false")]
     pub enable_experimental_validity_transactions: bool,
 
@@ -198,6 +198,20 @@ pub struct Args {
         requires = "enable_experimental_validity_transactions"
     )]
     pub experimental_validity_max_predicates: usize,
+
+    /// Decorate sampled ordinary transactions with a behavior-preserving validity predicate.
+    ///
+    /// This must only be enabled on a shadow builder.
+    #[arg(long = "builder.shadow-validity-injection.enabled", default_value = "false")]
+    pub shadow_validity_injection_enabled: bool,
+
+    /// Sampling rate for shadow validity injection, in basis points.
+    #[arg(
+        long = "builder.shadow-validity-injection.sample-rate-bps",
+        default_value = "100",
+        value_parser = clap::builder::RangedU64ValueParser::<u16>::new().range(1..=10_000)
+    )]
+    pub shadow_validity_injection_sample_rate_bps: u16,
 
     /// Maximum cumulative uncompressed (EIP-2718 encoded) block size in bytes
     #[arg(long = "builder.max-uncompressed-block-size")]
@@ -297,6 +311,8 @@ impl Default for Args {
             enable_resource_metering: false,
             enable_experimental_validity_transactions: false,
             experimental_validity_max_predicates: DEFAULT_MAX_VALIDITY_PREDICATES,
+            shadow_validity_injection_enabled: false,
+            shadow_validity_injection_sample_rate_bps: 100,
             max_uncompressed_block_size: None,
             metering_wait_duration_ms: None,
             audit_archiver_url: None,
@@ -316,6 +332,24 @@ impl Default for Args {
 }
 
 impl Args {
+    /// Builds validated configuration for the builder transaction insertion RPC.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when shadow injection is enabled without validity transaction support.
+    pub fn builder_api_config(&self) -> eyre::Result<BuilderApiExtensionConfig> {
+        let shadow_validity = if self.shadow_validity_injection_enabled {
+            ShadowValidityConfig::enabled(self.shadow_validity_injection_sample_rate_bps)?
+        } else {
+            ShadowValidityConfig::disabled()
+        };
+        Ok(BuilderApiExtensionConfig::new(
+            self.enable_experimental_validity_transactions,
+            self.experimental_validity_max_predicates,
+        )
+        .with_shadow_validity(shadow_validity)?)
+    }
+
     /// Converts these CLI arguments into a [`BuilderConfig`] using the given shared metering
     /// provider. The same provider must also be passed to the RPC extension so that the
     /// building loop and the `base_setMeteringInformation` handler share a single store.
@@ -399,6 +433,9 @@ mod tests {
         let args = Args::default();
         assert!(!args.enable_experimental_validity_transactions);
         assert_eq!(args.experimental_validity_max_predicates, DEFAULT_MAX_VALIDITY_PREDICATES);
+        assert!(!args.shadow_validity_injection_enabled);
+        assert_eq!(args.shadow_validity_injection_sample_rate_bps, 100);
+        assert!(!args.builder_api_config().unwrap().shadow_validity.is_enabled());
         let config = convert(args);
         assert_eq!(config.block_time, Duration::from_millis(1000));
         assert!(config.max_gas_per_txn.is_none());
@@ -416,6 +453,32 @@ mod tests {
 
         assert!(parsed.args.enable_experimental_validity_transactions);
         assert_eq!(parsed.args.experimental_validity_max_predicates, 8);
+    }
+
+    #[test]
+    fn shadow_validity_injection_requires_validity_support() {
+        let args = Args { shadow_validity_injection_enabled: true, ..Default::default() };
+        assert!(args.builder_api_config().is_err());
+
+        let args = Args {
+            enable_experimental_validity_transactions: true,
+            shadow_validity_injection_enabled: true,
+            shadow_validity_injection_sample_rate_bps: 250,
+            ..Default::default()
+        };
+        let config = args.builder_api_config().unwrap();
+        assert!(config.shadow_validity.is_enabled());
+        assert_eq!(config.shadow_validity.sample_rate_basis_points(), 250);
+    }
+
+    #[test]
+    fn shadow_validity_sampling_rate_is_cli_bounded() {
+        let result = CommandParser::try_parse_from([
+            "builder",
+            "--builder.shadow-validity-injection.sample-rate-bps",
+            "10001",
+        ]);
+        assert!(result.is_err());
     }
 
     #[rstest]

--- a/crates/builder/core/src/extension.rs
+++ b/crates/builder/core/src/extension.rs
@@ -1,8 +1,10 @@
 //! Builder API RPC extension for registering the `base_insertValidatedTransaction` endpoint.
 
+use base_execution_txpool::BuilderApiServer;
 pub use base_execution_txpool::DEFAULT_MAX_VALIDITY_PREDICATES;
-use base_execution_txpool::{BuilderApiImpl, BuilderApiServer, TransactionValidity};
 use base_node_runner::{BaseNodeExtension, BaseRpcContext, FromExtensionConfig, NodeHooks};
+
+use crate::{ShadowValidityBuilderApi, ShadowValidityConfig, ShadowValidityConfigError};
 
 /// Builder RPC configuration for experimental validity-bearing transactions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -11,6 +13,8 @@ pub struct BuilderApiExtensionConfig {
     pub accept_experimental_validity_transactions: bool,
     /// Maximum number of validity predicates accepted per transaction.
     pub max_validity_predicates: usize,
+    /// Shadow-only validity injection configuration.
+    pub shadow_validity: ShadowValidityConfig,
 }
 
 impl BuilderApiExtensionConfig {
@@ -19,7 +23,27 @@ impl BuilderApiExtensionConfig {
         accept_experimental_validity_transactions: bool,
         max_validity_predicates: usize,
     ) -> Self {
-        Self { accept_experimental_validity_transactions, max_validity_predicates }
+        Self {
+            accept_experimental_validity_transactions,
+            max_validity_predicates,
+            shadow_validity: ShadowValidityConfig::disabled(),
+        }
+    }
+
+    /// Enables the supplied shadow validity injection configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if injection is enabled while validity extensions are disabled.
+    pub const fn with_shadow_validity(
+        mut self,
+        shadow_validity: ShadowValidityConfig,
+    ) -> Result<Self, ShadowValidityConfigError> {
+        if shadow_validity.is_enabled() && !self.accept_experimental_validity_transactions {
+            return Err(ShadowValidityConfigError::ValidityTransactionsDisabled);
+        }
+        self.shadow_validity = shadow_validity;
+        Ok(self)
     }
 }
 
@@ -31,9 +55,8 @@ impl Default for BuilderApiExtensionConfig {
 
 /// Extension that registers the Builder API RPC module (`base_insertValidatedTransaction`).
 ///
-/// Its configuration controls whether non-empty experimental validity metadata
-/// is accepted and how many predicates a transaction may carry. Ordinary
-/// validated transactions remain available in both modes.
+/// Its configuration controls validity metadata acceptance, predicate limits, and shadow-only
+/// validity injection. Ordinary validated transactions remain available in all modes.
 #[derive(Debug, Default)]
 pub struct BuilderApiExtension {
     config: BuilderApiExtensionConfig,
@@ -41,14 +64,9 @@ pub struct BuilderApiExtension {
 
 impl BaseNodeExtension for BuilderApiExtension {
     fn apply(self: Box<Self>, builder: NodeHooks) -> NodeHooks {
-        let accept_validity = self.config.accept_experimental_validity_transactions;
-        let max_validity_predicates = self.config.max_validity_predicates;
+        let config = self.config;
         builder.add_rpc_module(move |ctx: &mut BaseRpcContext<'_>| {
-            let api = BuilderApiImpl::<_, TransactionValidity>::with_extensions(
-                ctx.pool().clone(),
-                accept_validity,
-                max_validity_predicates,
-            );
+            let api = ShadowValidityBuilderApi::new(ctx.pool().clone(), config);
             ctx.modules.merge_configured(api.into_rpc())?;
             Ok(())
         })

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -774,6 +774,7 @@ impl BasePayloadBuilderCtx {
             }
 
             let tx_hash = *tx.hash();
+            let has_validity_predicates = !tx.validity_predicates().is_empty();
             let mut predicate_read_failed = false;
             let blocking_predicate = match ValidityPredicateKey::first_unsatisfied(
                 tx.validity_predicates(),
@@ -792,6 +793,16 @@ impl BasePayloadBuilderCtx {
                     None
                 }
             };
+            if has_validity_predicates {
+                let outcome = if predicate_read_failed {
+                    "read_error"
+                } else if blocking_predicate.is_some() {
+                    "not_satisfied"
+                } else {
+                    "matched"
+                };
+                BuilderMetrics::validity_predicate_evaluations_total(outcome).increment(1);
+            }
             if predicate_read_failed || blocking_predicate.is_some() {
                 num_txs_considered += 1;
                 let ordering_position = num_txs_considered;
@@ -1382,6 +1393,14 @@ impl BasePayloadBuilderCtx {
                         None
                     }
                 };
+                let outcome = if predicate_read_failed {
+                    "rescan_read_error"
+                } else if blocking_predicate.is_some() {
+                    "rescan_not_satisfied"
+                } else {
+                    "rescan_matched"
+                };
+                BuilderMetrics::validity_predicate_evaluations_total(outcome).increment(1);
                 if predicate_read_failed {
                     predicate_index.remove(*parked_hash);
                     best_txs.discard_parked(*parked_hash);

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -53,6 +53,12 @@ pub use extension::{
     BuilderApiExtension, BuilderApiExtensionConfig, DEFAULT_MAX_VALIDITY_PREDICATES,
 };
 
+mod shadow_validity;
+pub use shadow_validity::{
+    MAX_SHADOW_VALIDITY_SAMPLE_RATE_BPS, ShadowValidityBuilderApi, ShadowValidityConfig,
+    ShadowValidityConfigError,
+};
+
 /// Shared test infrastructure: local node instances, chain drivers, transaction builders, and pool observers.
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -112,6 +112,12 @@ base_metrics::define_metrics! {
     rejection_cache_size: gauge,
     #[describe("Duration of rescanning parked transaction validity predicates in seconds")]
     validity_predicate_rescan_duration: histogram,
+    #[describe("Validity predicate evaluation attempts")]
+    #[label(outcome)]
+    validity_predicate_evaluations_total: counter,
+    #[describe("Shadow validity injection decisions")]
+    #[label(outcome)]
+    shadow_validity_injection_total: counter,
     #[describe("Transactions skipped because metering data has not yet arrived")]
     metering_data_pending_skip: counter,
     #[describe("Transactions rejected by per-tx DA size limit")]

--- a/crates/builder/core/src/shadow_validity.rs
+++ b/crates/builder/core/src/shadow_validity.rs
@@ -1,0 +1,253 @@
+//! Shadow-builder validity predicate injection for forwarded transactions.
+
+use alloy_primitives::{TxHash, U256, keccak256};
+use base_execution_txpool::{
+    BasePooledTransaction, BuilderApiImpl, BuilderApiServer, TransactionValidity,
+    ValidatedTransaction, ValidityOperator, ValidityPredicate,
+};
+use jsonrpsee::core::RpcResult;
+use reth_transaction_pool::TransactionPool;
+use tracing::debug;
+
+use crate::{BuilderApiExtensionConfig, BuilderMetrics};
+
+/// Number of basis points representing a 100% sampling rate.
+pub const MAX_SHADOW_VALIDITY_SAMPLE_RATE_BPS: u16 = 10_000;
+
+/// Invalid shadow validity injection configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum ShadowValidityConfigError {
+    /// The configured sampling rate is zero or exceeds 100%.
+    #[error("shadow validity sample rate must be between 1 and 10000 basis points")]
+    InvalidSampleRate,
+    /// Injection was enabled without enabling validity extensions.
+    #[error("shadow validity injection requires experimental validity transactions to be enabled")]
+    ValidityTransactionsDisabled,
+}
+
+/// Configuration for decorating forwarded transactions with shadow-only validity predicates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ShadowValidityConfig {
+    enabled: bool,
+    sample_rate_basis_points: u16,
+}
+
+impl ShadowValidityConfig {
+    /// Returns disabled shadow validity injection configuration.
+    pub const fn disabled() -> Self {
+        Self { enabled: false, sample_rate_basis_points: 0 }
+    }
+
+    /// Enables shadow validity injection at the supplied basis-point sampling rate.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the rate is zero or greater than 100%.
+    pub const fn enabled(sample_rate_basis_points: u16) -> Result<Self, ShadowValidityConfigError> {
+        if sample_rate_basis_points == 0
+            || sample_rate_basis_points > MAX_SHADOW_VALIDITY_SAMPLE_RATE_BPS
+        {
+            return Err(ShadowValidityConfigError::InvalidSampleRate);
+        }
+        Ok(Self { enabled: true, sample_rate_basis_points })
+    }
+
+    /// Returns whether injection is enabled.
+    pub const fn is_enabled(self) -> bool {
+        self.enabled
+    }
+
+    /// Returns the configured sampling rate in basis points.
+    pub const fn sample_rate_basis_points(self) -> u16 {
+        self.sample_rate_basis_points
+    }
+
+    fn inject(&self, tx: &mut ValidatedTransaction<TransactionValidity>) -> InjectionOutcome {
+        if !self.enabled {
+            return InjectionOutcome::Disabled;
+        }
+        if !tx.extensions.validity.is_empty() {
+            return InjectionOutcome::ExistingValidity;
+        }
+        if tx.min_block_number.is_some()
+            || tx.max_block_number.is_some()
+            || tx.min_timestamp.is_some()
+            || tx.max_timestamp.is_some()
+        {
+            return InjectionOutcome::BundleValidity;
+        }
+        // EIP-1559 transactions use the 0x02 EIP-2718 type byte. The inner RPC handler performs
+        // full decoding and rejects malformed transactions after this inexpensive eligibility
+        // check.
+        if tx.raw.first() != Some(&0x02) {
+            return InjectionOutcome::UnsupportedType;
+        }
+
+        let tx_hash = keccak256(&tx.raw);
+        if !self.samples(tx_hash) {
+            return InjectionOutcome::NotSampled;
+        }
+
+        tx.extensions.validity.push(ValidityPredicate::Balance {
+            address: tx.sender,
+            op: ValidityOperator::GreaterThan,
+            value: U256::ZERO,
+        });
+        InjectionOutcome::Injected(tx_hash)
+    }
+
+    fn samples(&self, tx_hash: TxHash) -> bool {
+        let bytes: [u8; 8] = tx_hash[..8].try_into().expect("transaction hash has eight bytes");
+        u64::from_be_bytes(bytes) % u64::from(MAX_SHADOW_VALIDITY_SAMPLE_RATE_BPS)
+            < u64::from(self.sample_rate_basis_points)
+    }
+}
+
+impl Default for ShadowValidityConfig {
+    fn default() -> Self {
+        Self::disabled()
+    }
+}
+
+/// Builder API that decorates sampled transactions before normal validated insertion.
+#[derive(Debug)]
+pub struct ShadowValidityBuilderApi<P> {
+    inner: BuilderApiImpl<P, TransactionValidity>,
+    config: ShadowValidityConfig,
+}
+
+impl<P> ShadowValidityBuilderApi<P> {
+    /// Creates a builder API using validated configuration.
+    pub const fn new(pool: P, config: BuilderApiExtensionConfig) -> Self {
+        Self {
+            inner: BuilderApiImpl::with_extensions(
+                pool,
+                config.accept_experimental_validity_transactions,
+                config.max_validity_predicates,
+            ),
+            config: config.shadow_validity,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<P> BuilderApiServer<TransactionValidity> for ShadowValidityBuilderApi<P>
+where
+    P: TransactionPool<Transaction = BasePooledTransaction> + Send + Sync + 'static,
+{
+    async fn insert_validated_transaction(
+        &self,
+        mut tx: ValidatedTransaction<TransactionValidity>,
+    ) -> RpcResult<()> {
+        let outcome = self.config.inject(&mut tx);
+        if self.config.is_enabled() {
+            BuilderMetrics::shadow_validity_injection_total(outcome.label()).increment(1);
+        }
+        if let InjectionOutcome::Injected(tx_hash) = outcome {
+            debug!(tx_hash = %tx_hash, sender = %tx.sender, "injected shadow validity predicate");
+        }
+        self.inner.insert_validated_transaction(tx).await
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InjectionOutcome {
+    Disabled,
+    ExistingValidity,
+    BundleValidity,
+    UnsupportedType,
+    NotSampled,
+    Injected(TxHash),
+}
+
+impl InjectionOutcome {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Disabled => "disabled",
+            Self::ExistingValidity => "existing_validity",
+            Self::BundleValidity => "bundle_validity",
+            Self::UnsupportedType => "unsupported_type",
+            Self::NotSampled => "not_sampled",
+            Self::Injected(_) => "injected",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, Bytes};
+
+    use super::*;
+
+    fn transaction(raw: Bytes) -> ValidatedTransaction<TransactionValidity> {
+        ValidatedTransaction {
+            sender: Address::repeat_byte(0x11),
+            raw,
+            min_block_number: None,
+            max_block_number: None,
+            min_timestamp: None,
+            max_timestamp: None,
+            extensions: TransactionValidity::default(),
+        }
+    }
+
+    #[test]
+    fn injects_sender_balance_predicate_without_changing_transaction() {
+        let config = ShadowValidityConfig::enabled(MAX_SHADOW_VALIDITY_SAMPLE_RATE_BPS).unwrap();
+        let mut tx = transaction(Bytes::from_static(&[0x02, 0x01, 0x02]));
+        let original = tx.clone();
+
+        assert!(matches!(config.inject(&mut tx), InjectionOutcome::Injected(_)));
+        assert_eq!(tx.sender, original.sender);
+        assert_eq!(tx.raw, original.raw);
+        assert_eq!(tx.min_block_number, original.min_block_number);
+        assert_eq!(tx.max_block_number, original.max_block_number);
+        assert_eq!(tx.min_timestamp, original.min_timestamp);
+        assert_eq!(tx.max_timestamp, original.max_timestamp);
+        assert_eq!(
+            tx.extensions.validity,
+            vec![ValidityPredicate::Balance {
+                address: original.sender,
+                op: ValidityOperator::GreaterThan,
+                value: U256::ZERO,
+            }]
+        );
+    }
+
+    #[test]
+    fn preserves_existing_validity_and_bundle_bounds() {
+        let config = ShadowValidityConfig::enabled(MAX_SHADOW_VALIDITY_SAMPLE_RATE_BPS).unwrap();
+        let predicate =
+            ValidityPredicate::BlockNumber { op: ValidityOperator::GreaterThan, value: U256::ZERO };
+        let mut existing = transaction(Bytes::from_static(&[0x02, 0x01]));
+        existing.extensions.validity.push(predicate.clone());
+        assert_eq!(config.inject(&mut existing), InjectionOutcome::ExistingValidity);
+        assert_eq!(existing.extensions.validity, vec![predicate]);
+
+        let mut bounded = transaction(Bytes::from_static(&[0x02, 0x01]));
+        bounded.max_block_number = Some(10);
+        assert_eq!(config.inject(&mut bounded), InjectionOutcome::BundleValidity);
+        assert!(bounded.extensions.validity.is_empty());
+    }
+
+    #[test]
+    fn only_samples_eip1559_transactions_deterministically() {
+        let config = ShadowValidityConfig::enabled(1).unwrap();
+        let mut unsupported = transaction(Bytes::from_static(&[0x01, 0x01]));
+        assert_eq!(config.inject(&mut unsupported), InjectionOutcome::UnsupportedType);
+
+        let raw = Bytes::from_static(&[0x02, 0x55]);
+        let first = config.inject(&mut transaction(raw.clone()));
+        let second = config.inject(&mut transaction(raw));
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn configuration_rejects_unsafe_combinations() {
+        assert!(ShadowValidityConfig::enabled(0).is_err());
+        assert!(ShadowValidityConfig::enabled(MAX_SHADOW_VALIDITY_SAMPLE_RATE_BPS + 1).is_err());
+        let shadow = ShadowValidityConfig::enabled(1).unwrap();
+        assert!(BuilderApiExtensionConfig::new(false, 1).with_shadow_validity(shadow).is_err());
+        assert!(BuilderApiExtensionConfig::new(true, 1).with_shadow_validity(shadow).is_ok());
+    }
+}

--- a/crates/builder/core/src/shadow_validity.rs
+++ b/crates/builder/core/src/shadow_validity.rs
@@ -1,13 +1,12 @@
 //! Shadow-builder validity predicate injection for forwarded transactions.
 
-use alloy_primitives::{TxHash, U256, keccak256};
+use alloy_primitives::U256;
 use base_execution_txpool::{
     BasePooledTransaction, BuilderApiImpl, BuilderApiServer, TransactionValidity,
     ValidatedTransaction, ValidityOperator, ValidityPredicate,
 };
 use jsonrpsee::core::RpcResult;
 use reth_transaction_pool::TransactionPool;
-use tracing::debug;
 
 use crate::{BuilderApiExtensionConfig, BuilderMetrics};
 
@@ -83,8 +82,7 @@ impl ShadowValidityConfig {
             return InjectionOutcome::UnsupportedType;
         }
 
-        let tx_hash = keccak256(&tx.raw);
-        if !self.samples(tx_hash) {
+        if !self.samples(&tx.raw) {
             return InjectionOutcome::NotSampled;
         }
 
@@ -93,12 +91,19 @@ impl ShadowValidityConfig {
             op: ValidityOperator::GreaterThan,
             value: U256::ZERO,
         });
-        InjectionOutcome::Injected(tx_hash)
+        InjectionOutcome::Injected
     }
 
-    fn samples(&self, tx_hash: TxHash) -> bool {
-        let bytes: [u8; 8] = tx_hash[..8].try_into().expect("transaction hash has eight bytes");
-        u64::from_be_bytes(bytes) % u64::from(MAX_SHADOW_VALIDITY_SAMPLE_RATE_BPS)
+    fn samples(&self, raw: &[u8]) -> bool {
+        // Signed EIP-1559 transactions end with the signature's `s` scalar. Its low bytes provide
+        // stable per-transaction entropy without hashing bytes that the inner handler hashes after
+        // decoding anyway.
+        let sample = raw
+            .iter()
+            .rev()
+            .take(size_of::<u64>())
+            .fold(0_u64, |sample, byte| (sample << 8) | u64::from(*byte));
+        sample % u64::from(MAX_SHADOW_VALIDITY_SAMPLE_RATE_BPS)
             < u64::from(self.sample_rate_basis_points)
     }
 }
@@ -143,9 +148,6 @@ where
         if self.config.is_enabled() {
             BuilderMetrics::shadow_validity_injection_total(outcome.label()).increment(1);
         }
-        if let InjectionOutcome::Injected(tx_hash) = outcome {
-            debug!(tx_hash = %tx_hash, sender = %tx.sender, "injected shadow validity predicate");
-        }
         self.inner.insert_validated_transaction(tx).await
     }
 }
@@ -157,7 +159,7 @@ enum InjectionOutcome {
     BundleValidity,
     UnsupportedType,
     NotSampled,
-    Injected(TxHash),
+    Injected,
 }
 
 impl InjectionOutcome {
@@ -168,7 +170,7 @@ impl InjectionOutcome {
             Self::BundleValidity => "bundle_validity",
             Self::UnsupportedType => "unsupported_type",
             Self::NotSampled => "not_sampled",
-            Self::Injected(_) => "injected",
+            Self::Injected => "injected",
         }
     }
 }
@@ -197,7 +199,7 @@ mod tests {
         let mut tx = transaction(Bytes::from_static(&[0x02, 0x01, 0x02]));
         let original = tx.clone();
 
-        assert!(matches!(config.inject(&mut tx), InjectionOutcome::Injected(_)));
+        assert_eq!(config.inject(&mut tx), InjectionOutcome::Injected);
         assert_eq!(tx.sender, original.sender);
         assert_eq!(tx.raw, original.raw);
         assert_eq!(tx.min_block_number, original.min_block_number);

--- a/crates/builder/core/tests/ordering.rs
+++ b/crates/builder/core/tests/ordering.rs
@@ -7,6 +7,7 @@ use alloy_primitives::{Address, U256};
 use alloy_provider::Provider;
 use base_builder_core::{
     BuilderApiExtension, BuilderApiExtensionConfig, BuilderConfig, DEFAULT_MAX_VALIDITY_PREDICATES,
+    MAX_SHADOW_VALIDITY_SAMPLE_RATE_BPS, ShadowValidityConfig,
     test_utils::{ChainDriverExt, LocalInstanceBuilder, ONE_ETH, setup_test_instance},
 };
 use base_execution_txpool::{
@@ -174,6 +175,68 @@ async fn predicates_delay_priority_without_blocking_nonce_descendants() -> eyre:
     assert!(
         [50u128, 100, 90, 1].windows(2).any(|fees| fees[0] < fees[1]),
         "predicate-delayed order must intentionally violate descending priority fee order"
+    );
+
+    Ok(())
+}
+
+/// Shadow injection adds only builder-local metadata: the original signed transaction executes
+/// with the same hash, encoding, and state transition.
+#[tokio::test]
+async fn shadow_validity_injection_preserves_forwarded_transaction() -> eyre::Result<()> {
+    let shadow =
+        ShadowValidityConfig::enabled(MAX_SHADOW_VALIDITY_SAMPLE_RATE_BPS).expect("valid rate");
+    let api_config = BuilderApiExtensionConfig::new(true, DEFAULT_MAX_VALIDITY_PREDICATES)
+        .with_shadow_validity(shadow)?;
+    let instance = LocalInstanceBuilder::new(BuilderConfig::for_tests())
+        .install_ext::<BuilderApiExtension>(api_config)
+        .build()
+        .await?;
+    let driver = instance.driver().await?;
+    let accounts = driver.fund_accounts(1, ONE_ETH).await?;
+    let recipient = Address::random();
+    let value = 7;
+    let recipient_balance_before = driver.provider().get_balance(recipient).await?;
+
+    let signed = driver
+        .create_transaction()
+        .with_signer(&accounts[0])
+        .with_to(recipient)
+        .with_value(value)
+        .build()
+        .await;
+    let tx_hash = signed.tx_hash();
+    let raw = signed.encoded_2718();
+    let forwarded = ValidatedTransaction {
+        sender: accounts[0].address(),
+        raw: raw.clone().into(),
+        min_block_number: None,
+        max_block_number: None,
+        min_timestamp: None,
+        max_timestamp: None,
+        extensions: TransactionValidity::default(),
+    };
+    driver
+        .provider()
+        .raw_request::<_, ()>("base_insertValidatedTransaction".into(), (forwarded,))
+        .await?;
+
+    let block = driver.build_new_block().await?;
+    let included = block
+        .transactions
+        .into_transactions()
+        .find(|transaction| transaction.tx_hash() == tx_hash)
+        .expect("forwarded transaction must be included");
+
+    assert_eq!(
+        included.inner.inner.encoded_2718(),
+        raw,
+        "validity metadata must not alter consensus bytes"
+    );
+    assert_eq!(
+        driver.provider().get_balance(recipient).await?,
+        recipient_balance_before + U256::from(value),
+        "the original state transition must execute"
     );
 
     Ok(())

--- a/crates/execution/txpool-rpc/src/rpc.rs
+++ b/crates/execution/txpool-rpc/src/rpc.rs
@@ -38,8 +38,6 @@ pub struct SendRawTransactionValidityRequest {
     /// EIP-2718 encoded signed transaction.
     pub tx: Bytes,
     /// Experimental predicates transported to builders alongside the transaction.
-    ///
-    /// Predicates are not currently evaluated during block construction.
     pub validity: Vec<ValidityPredicate>,
 }
 
@@ -181,7 +179,7 @@ where
             })?;
         let tx_hash = *transaction.hash();
 
-        // Retain the currently unenforced predicates for canonical forwarding to builders.
+        // Retain predicates for canonical forwarding to builders.
         self.pool
             .add_transaction(
                 TransactionOrigin::Private,

--- a/crates/execution/txpool/src/validity.rs
+++ b/crates/execution/txpool/src/validity.rs
@@ -274,9 +274,7 @@ impl ValidityPredicate {
 }
 
 /// Experimental validity predicates carried with a validated transaction.
-///
-/// The builder transport preserves these predicates but does not currently
-/// evaluate them during block construction.
+/// The builder evaluates these predicates against each candidate insertion point.
 #[derive(Clone, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct TransactionValidity {
     /// Predicates intended to control when the transaction is valid for inclusion.


### PR DESCRIPTION
## Summary

- deterministically sample forwarded EIP-1559 transactions in an opt-in shadow-builder mode
- attach a builder-local `balance(sender) > 0` validity predicate without changing signed transaction bytes or hashes
- preserve transactions carrying existing validity metadata or bundle bounds
- add injection/evaluation metrics and configuration safety checks

The feature is disabled by default and requires both `--builder.enable-experimental-validity-transactions` and `--builder.shadow-validity-injection.enabled`. The sampling rate is configured in basis points with `--builder.shadow-validity-injection.sample-rate-bps`.
