### PR TITLE
fix(bench): make trie_node measure the operation, not setup

### DIFF
--- a/crates/proof/mpt/benches/trie_node.rs
+++ b/crates/proof/mpt/benches/trie_node.rs
@@ -1,16 +1,18 @@
-#![allow(missing_docs)]
 //! Benchmarks for the [`TrieNode`].
 
 use alloy_trie::Nibbles;
 use base_proof_mpt::{NoopTrieProvider, TrieNode};
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use rand::{Rng, SeedableRng, rngs::StdRng, seq::IteratorRandom};
+use std::hint::black_box;
 
 fn trie(c: &mut Criterion) {
     let mut g = c.benchmark_group("execution");
     g.sample_size(10);
 
-    // Use pseudo-randomness for reproducibility
+    // Use pseudo-randomness for reproducibility. Both the key set and the deleted /
+    // retrieved subsets are drawn from this seeded generator so a base-vs-head
+    // comparison exercises the identical workload on each side.
     let mut rng = StdRng::seed_from_u64(42);
 
     g.bench_function("Insertion - 4096 nodes", |b| {
@@ -43,58 +45,62 @@ fn trie(c: &mut Criterion) {
         let keys = (0..2usize.pow(12))
             .map(|_| Nibbles::unpack(rng.random::<[u8; 32]>()))
             .collect::<Vec<_>>();
+        let keys_to_delete = keys.iter().cloned().choose_multiple(&mut rng, 16);
+
         let mut trie = TrieNode::Empty;
-
-        let rng = &mut rand::rng();
-        let keys_to_delete = keys.clone().into_iter().choose_multiple(rng, 16);
-
         for key in &keys {
             trie.insert(key, key.to_vec().into(), &NoopTrieProvider).unwrap();
         }
 
-        b.iter(|| {
-            let trie = &mut trie.clone();
-            for key in &keys_to_delete {
-                trie.delete(key, &NoopTrieProvider).unwrap();
-            }
-        });
+        // Clone the populated trie in the setup closure so the deep-clone cost is
+        // excluded from the measured deletion work.
+        b.iter_batched(
+            || trie.clone(),
+            |mut trie| {
+                for key in &keys_to_delete {
+                    trie.delete(key, &NoopTrieProvider).unwrap();
+                }
+            },
+            BatchSize::LargeInput,
+        );
     });
 
     g.bench_function("Delete 16 nodes - 65,536 nodes", |b| {
         let keys = (0..2usize.pow(16))
             .map(|_| Nibbles::unpack(rng.random::<[u8; 32]>()))
             .collect::<Vec<_>>();
+        let keys_to_delete = keys.iter().cloned().choose_multiple(&mut rng, 16);
+
         let mut trie = TrieNode::Empty;
         for key in &keys {
             trie.insert(key, key.to_vec().into(), &NoopTrieProvider).unwrap();
         }
 
-        let rng = &mut rand::rng();
-        let keys_to_delete = keys.into_iter().choose_multiple(rng, 16);
-
-        b.iter(|| {
-            let trie = &mut trie.clone();
-            for key in &keys_to_delete {
-                trie.delete(key, &NoopTrieProvider).unwrap();
-            }
-        });
+        b.iter_batched(
+            || trie.clone(),
+            |mut trie| {
+                for key in &keys_to_delete {
+                    trie.delete(key, &NoopTrieProvider).unwrap();
+                }
+            },
+            BatchSize::LargeInput,
+        );
     });
 
     g.bench_function("Open 1024 nodes - 4096 nodes", |b| {
         let keys = (0..2usize.pow(12))
             .map(|_| Nibbles::unpack(rng.random::<[u8; 32]>()))
             .collect::<Vec<_>>();
+        let keys_to_retrieve = keys.iter().cloned().choose_multiple(&mut rng, 1024);
+
         let mut trie = TrieNode::Empty;
         for key in &keys {
             trie.insert(key, key.to_vec().into(), &NoopTrieProvider).unwrap();
         }
 
-        let rng = &mut rand::rng();
-        let keys_to_retrieve = keys.into_iter().choose_multiple(rng, 1024);
-
         b.iter(|| {
             for key in &keys_to_retrieve {
-                trie.open(key, &NoopTrieProvider).unwrap();
+                black_box(trie.open(key, &NoopTrieProvider).unwrap());
             }
         });
     });
@@ -103,17 +109,16 @@ fn trie(c: &mut Criterion) {
         let keys = (0..2usize.pow(16))
             .map(|_| Nibbles::unpack(rng.random::<[u8; 32]>()))
             .collect::<Vec<_>>();
+        let keys_to_retrieve = keys.iter().cloned().choose_multiple(&mut rng, 1024);
+
         let mut trie = TrieNode::Empty;
         for key in &keys {
             trie.insert(key, key.to_vec().into(), &NoopTrieProvider).unwrap();
         }
 
-        let rng = &mut rand::rng();
-        let keys_to_retrieve = keys.into_iter().choose_multiple(rng, 1024);
-
         b.iter(|| {
             for key in &keys_to_retrieve {
-                trie.open(key, &NoopTrieProvider).unwrap();
+                black_box(trie.open(key, &NoopTrieProvider).unwrap());
             }
         });
     });
@@ -127,9 +132,10 @@ fn trie(c: &mut Criterion) {
             trie.insert(key, key.to_vec().into(), &NoopTrieProvider).unwrap();
         }
 
+        // `blind` takes `&self` and returns the root hash, so no clone is needed;
+        // black-box the result so the computation is not optimized away.
         b.iter(|| {
-            let trie = &mut trie.clone();
-            trie.blind();
+            black_box(trie.blind());
         });
     });
 
@@ -143,8 +149,7 @@ fn trie(c: &mut Criterion) {
         }
 
         b.iter(|| {
-            let trie = &mut trie.clone();
-            trie.blind();
+            black_box(trie.blind());
         });
     });
 }

--- a/crates/proof/mpt/benches/trie_node.rs
+++ b/crates/proof/mpt/benches/trie_node.rs
@@ -1,10 +1,11 @@
 //! Benchmarks for the [`TrieNode`].
 
+use std::hint::black_box;
+
 use alloy_trie::Nibbles;
 use base_proof_mpt::{NoopTrieProvider, TrieNode};
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use rand::{Rng, SeedableRng, rngs::StdRng, seq::IteratorRandom};
-use std::hint::black_box;
 
 fn trie(c: &mut Criterion) {
     let mut g = c.benchmark_group("execution");
@@ -45,7 +46,7 @@ fn trie(c: &mut Criterion) {
         let keys = (0..2usize.pow(12))
             .map(|_| Nibbles::unpack(rng.random::<[u8; 32]>()))
             .collect::<Vec<_>>();
-        let keys_to_delete = keys.iter().cloned().choose_multiple(&mut rng, 16);
+        let keys_to_delete = keys.iter().copied().choose_multiple(&mut rng, 16);
 
         let mut trie = TrieNode::Empty;
         for key in &keys {
@@ -69,7 +70,7 @@ fn trie(c: &mut Criterion) {
         let keys = (0..2usize.pow(16))
             .map(|_| Nibbles::unpack(rng.random::<[u8; 32]>()))
             .collect::<Vec<_>>();
-        let keys_to_delete = keys.iter().cloned().choose_multiple(&mut rng, 16);
+        let keys_to_delete = keys.iter().copied().choose_multiple(&mut rng, 16);
 
         let mut trie = TrieNode::Empty;
         for key in &keys {
@@ -91,7 +92,7 @@ fn trie(c: &mut Criterion) {
         let keys = (0..2usize.pow(12))
             .map(|_| Nibbles::unpack(rng.random::<[u8; 32]>()))
             .collect::<Vec<_>>();
-        let keys_to_retrieve = keys.iter().cloned().choose_multiple(&mut rng, 1024);
+        let keys_to_retrieve = keys.iter().copied().choose_multiple(&mut rng, 1024);
 
         let mut trie = TrieNode::Empty;
         for key in &keys {
@@ -109,7 +110,7 @@ fn trie(c: &mut Criterion) {
         let keys = (0..2usize.pow(16))
             .map(|_| Nibbles::unpack(rng.random::<[u8; 32]>()))
             .collect::<Vec<_>>();
-        let keys_to_retrieve = keys.iter().cloned().choose_multiple(&mut rng, 1024);
+        let keys_to_retrieve = keys.iter().copied().choose_multiple(&mut rng, 1024);
 
         let mut trie = TrieNode::Empty;
         for key in &keys {


### PR DESCRIPTION
## Summary

Second PR in the advisory-benchmark stack (stacked on #4471). `trie_node` is one of the benches in the per-PR advisory subset, so its numbers need to be stable and actually reflect the operation under test. The review of the subset found three ways this bench was misleading:

- **Deep clone inside the measured loop.** The delete benchmarks did `trie.clone()` of a trie of up to 65,536 nodes *inside* `b.iter`, so the clone allocation dominated the timing rather than the deletion. Moved into an `iter_batched` setup closure. (Local smoke run: `Delete 16 nodes - 65,536 nodes` now measures ~1.7 ms of actual deletion instead of the clone.)
- **Unnecessary clone before `blind`.** The "compute root" benchmarks cloned before calling `blind`, but `blind(&self)` returns the root hash and does not mutate — so the clone was pure overhead. Dropped it and `black_box` the returned hash instead.
- **Non-deterministic workload.** The deleted / retrieved key subsets were drawn from a thread-local RNG (`rand::rng()`), so every run — including base vs head in the advisory comparison — used a different set of keys. They now come from the existing seeded `StdRng`, so the comparison is apples to apples.

Also `black_box` the `open` results, and drop the file-level `#![allow(missing_docs)]` per the repo lint policy.

No behavior change to any shipping code — this only touches the benchmark.

## Testing

- Compiles clean under `RUSTFLAGS="-D warnings"`.
- Smoke-run of the full bench target confirms every group still runs and produces estimates.

> Stacked on #4471 — review/merge that first. This targets `rf/ci/bench-advisory-reliability`; it'll retarget to `main` automatically once the base merges.