### PR TITLE
feat(bench): add deterministic micro-benches to advisory subset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3551,6 +3551,7 @@ dependencies = [
  "alloy-serde 2.2.0",
  "brotli",
  "bytes",
+ "criterion",
  "rstest",
  "serde",
  "serde_json",
@@ -3561,6 +3562,7 @@ dependencies = [
 name = "base-common-flz"
 version = "0.0.0"
 dependencies = [
+ "criterion",
  "hex-literal 1.1.0",
  "rstest",
 ]

--- a/crates/common/flashblocks/Cargo.toml
+++ b/crates/common/flashblocks/Cargo.toml
@@ -28,3 +28,8 @@ serde_json = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 rstest.workspace = true
+criterion.workspace = true
+
+[[bench]]
+name = "flashblock_decode"
+harness = false

--- a/crates/common/flashblocks/benches/flashblock_decode.rs
+++ b/crates/common/flashblocks/benches/flashblock_decode.rs
@@ -1,0 +1,74 @@
+//! Benchmarks for decoding a [`Flashblock`] off the wire.
+//!
+//! `try_decode_message` runs for every flashblock a consumer receives, decompressing
+//! (brotli) and JSON-parsing the payload. It is deterministic and CPU-bound, so it is
+//! a good per-PR advisory signal for the streaming receive path.
+
+use std::{hint::black_box, io::Write};
+
+use base_common_flashblocks::Flashblock;
+use bytes::Bytes;
+use criterion::{Criterion, criterion_group, criterion_main};
+
+/// A representative flashblock payload in the v0.4.1 wire format.
+const PAYLOAD_JSON: &str = r#"{
+    "payload_id": "0x0000000000000000",
+    "index": 0,
+    "base": {
+        "parent_beacon_block_root": "0x0101010101010101010101010101010101010101010101010101010101010101",
+        "parent_hash": "0x0202020202020202020202020202020202020202020202020202020202020202",
+        "fee_recipient": "0x0000000000000000000000000000000000000000",
+        "prev_randao": "0x0303030303030303030303030303030303030303030303030303030303030303",
+        "block_number": "0x9",
+        "gas_limit": "0xf4240",
+        "timestamp": "0x6553f100",
+        "extra_data": "0xaabb",
+        "base_fee_per_gas": "0xa"
+    },
+    "diff": {
+        "state_root": "0x0404040404040404040404040404040404040404040404040404040404040404",
+        "receipts_root": "0x0505050505050505050505050505050505050505050505050505050505050505",
+        "logs_bloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "gas_used": "0x7a120",
+        "block_hash": "0x0606060606060606060606060606060606060606060606060606060606060606",
+        "transactions": ["0x0102"],
+        "withdrawals": [],
+        "withdrawals_root": "0x0707070707070707070707070707070707070707070707070707070707070707",
+        "blob_gas_used": "0x2c"
+    },
+    "metadata": {
+        "block_number": 1234
+    }
+}"#;
+
+/// Brotli-compress with the same parameters the flashblocks publisher uses.
+fn brotli_compress(data: &[u8]) -> Vec<u8> {
+    let mut compressed = Vec::new();
+    {
+        let mut writer = brotli::CompressorWriter::new(&mut compressed, 4096, 5, 22);
+        writer.write_all(data).expect("write compressed payload");
+    }
+    compressed
+}
+
+fn bench_flashblock_decode(c: &mut Criterion) {
+    let plain = Bytes::from(PAYLOAD_JSON.as_bytes().to_vec());
+    let brotli = Bytes::from(brotli_compress(PAYLOAD_JSON.as_bytes()));
+
+    // Fail loudly at setup if the fixture stops decoding, rather than silently
+    // benchmarking an error path.
+    Flashblock::try_decode_message(plain.clone()).expect("plain payload decodes");
+    Flashblock::try_decode_message(brotli.clone()).expect("brotli payload decodes");
+
+    let mut group = c.benchmark_group("flashblock_decode");
+    group.bench_function("plain_json", |b| {
+        b.iter(|| black_box(Flashblock::try_decode_message(black_box(plain.clone())).unwrap()));
+    });
+    group.bench_function("brotli", |b| {
+        b.iter(|| black_box(Flashblock::try_decode_message(black_box(brotli.clone())).unwrap()));
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_flashblock_decode);
+criterion_main!(benches);

--- a/crates/common/flashblocks/benches/flashblock_decode.rs
+++ b/crates/common/flashblocks/benches/flashblock_decode.rs
@@ -42,8 +42,7 @@ impl Fixture {
     /// A representative first flashblock: base header, a full transaction set, and
     /// v0.5.0-style metadata carrying one receipt per transaction.
     fn payload() -> FlashblocksPayloadV1 {
-        let transactions =
-            (0..Self::TRANSACTION_COUNT).map(Self::transaction).collect::<Vec<_>>();
+        let transactions = (0..Self::TRANSACTION_COUNT).map(Self::transaction).collect::<Vec<_>>();
 
         FlashblocksPayloadV1 {
             payload_id: PayloadId::default(),

--- a/crates/common/flashblocks/benches/flashblock_decode.rs
+++ b/crates/common/flashblocks/benches/flashblock_decode.rs
@@ -3,43 +3,112 @@
 //! `try_decode_message` runs for every flashblock a consumer receives, decompressing
 //! (brotli) and JSON-parsing the payload. It is deterministic and CPU-bound, so it is
 //! a good per-PR advisory signal for the streaming receive path.
+//!
+//! The fixture is a *representative* flashblock rather than a minimal one. A busy Base
+//! flashblock slice carries on the order of a hundred transactions plus a receipt per
+//! transaction, and decode cost is dominated by hex-decoding those transaction blobs
+//! and walking that metadata — not by parsing the fixed header. A single tiny
+//! transaction would mostly measure header overhead and make the benchmark
+//! insensitive to the work the receive path actually does, so the fixture is sized to
+//! that shape via [`Fixture::TRANSACTION_COUNT`] and [`Fixture::TRANSACTION_SIZE_BYTES`].
 
 use std::{hint::black_box, io::Write};
 
-use base_common_flashblocks::Flashblock;
+use alloy_primitives::{Address, B256, Bloom, Bytes as PrimitiveBytes, U256};
+use alloy_rpc_types_engine::PayloadId;
+use base_common_flashblocks::{
+    ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, Flashblock, FlashblocksPayloadV1,
+};
 use bytes::Bytes;
 use criterion::{Criterion, criterion_group, criterion_main};
+use serde_json::{Map, Value, json};
 
-/// A representative flashblock payload in the v0.4.1 wire format.
-const PAYLOAD_JSON: &str = r#"{
-    "payload_id": "0x0000000000000000",
-    "index": 0,
-    "base": {
-        "parent_beacon_block_root": "0x0101010101010101010101010101010101010101010101010101010101010101",
-        "parent_hash": "0x0202020202020202020202020202020202020202020202020202020202020202",
-        "fee_recipient": "0x0000000000000000000000000000000000000000",
-        "prev_randao": "0x0303030303030303030303030303030303030303030303030303030303030303",
-        "block_number": "0x9",
-        "gas_limit": "0xf4240",
-        "timestamp": "0x6553f100",
-        "extra_data": "0xaabb",
-        "base_fee_per_gas": "0xa"
-    },
-    "diff": {
-        "state_root": "0x0404040404040404040404040404040404040404040404040404040404040404",
-        "receipts_root": "0x0505050505050505050505050505050505050505050505050505050505050505",
-        "logs_bloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-        "gas_used": "0x7a120",
-        "block_hash": "0x0606060606060606060606060606060606060606060606060606060606060606",
-        "transactions": ["0x0102"],
-        "withdrawals": [],
-        "withdrawals_root": "0x0707070707070707070707070707070707070707070707070707070707070707",
-        "blob_gas_used": "0x2c"
-    },
-    "metadata": {
-        "block_number": 1234
+/// Builds a representative flashblock fixture for the decode benchmark.
+struct Fixture;
+
+impl Fixture {
+    /// Transactions in the fixture — the order of magnitude of a busy Base flashblock slice.
+    const TRANSACTION_COUNT: usize = 150;
+    /// Body size of each synthetic transaction, in bytes — a typical ERC-20 transfer /
+    /// small swap calldata footprint. Only length and count drive decode cost; the
+    /// contents are irrelevant.
+    const TRANSACTION_SIZE_BYTES: usize = 256;
+
+    /// The representative first flashblock, serialized to its JSON wire bytes.
+    fn payload_json() -> Vec<u8> {
+        serde_json::to_vec(&Self::payload()).expect("serialize fixture payload")
     }
-}"#;
+
+    /// A representative first flashblock: base header, a full transaction set, and
+    /// v0.5.0-style metadata carrying one receipt per transaction.
+    fn payload() -> FlashblocksPayloadV1 {
+        let transactions =
+            (0..Self::TRANSACTION_COUNT).map(Self::transaction).collect::<Vec<_>>();
+
+        FlashblocksPayloadV1 {
+            payload_id: PayloadId::default(),
+            index: 0,
+            base: Some(ExecutionPayloadBaseV1 {
+                parent_beacon_block_root: B256::from([1u8; 32]),
+                parent_hash: B256::from([2u8; 32]),
+                fee_recipient: Address::ZERO,
+                prev_randao: B256::from([3u8; 32]),
+                block_number: 9,
+                gas_limit: 1_000_000,
+                timestamp: 1_700_000_000,
+                extra_data: PrimitiveBytes::from(vec![0xAA, 0xBB]),
+                base_fee_per_gas: U256::from(10u64),
+            }),
+            diff: ExecutionPayloadFlashblockDeltaV1 {
+                state_root: B256::from([4u8; 32]),
+                receipts_root: B256::from([5u8; 32]),
+                logs_bloom: Bloom::default(),
+                gas_used: 500_000,
+                block_hash: B256::from([6u8; 32]),
+                transactions,
+                withdrawals: Vec::new(),
+                withdrawals_root: B256::from([7u8; 32]),
+                blob_gas_used: Some(44),
+            },
+            metadata: Self::metadata(),
+        }
+    }
+
+    /// v0.5.0-style metadata with one receipt per transaction, keyed by a per-index
+    /// transaction hash, mirroring the shape a real consumer must parse.
+    fn metadata() -> Value {
+        let receipts = (0..Self::TRANSACTION_COUNT)
+            .map(|index| {
+                let hash = B256::from([index as u8; 32]);
+                let receipt = json!({
+                    "type": "0x2",
+                    "status": true,
+                    "cumulativeGasUsed": "0x5208",
+                    "logs": [],
+                });
+                (hash.to_string(), receipt)
+            })
+            .collect::<Map<String, Value>>();
+
+        json!({
+            "block_number": 1234,
+            "receipts": receipts,
+            "new_account_balances": {},
+        })
+    }
+
+    /// A deterministic synthetic transaction body of [`Self::TRANSACTION_SIZE_BYTES`]
+    /// bytes. The contents are seeded from `index` so the fixture is stable run to run.
+    fn transaction(index: usize) -> PrimitiveBytes {
+        let mut body = Vec::with_capacity(Self::TRANSACTION_SIZE_BYTES);
+        let mut state = index as u8;
+        for _ in 0..Self::TRANSACTION_SIZE_BYTES {
+            state = state.wrapping_mul(31).wrapping_add(17);
+            body.push(state);
+        }
+        PrimitiveBytes::from(body)
+    }
+}
 
 /// Brotli-compress with the same parameters the flashblocks publisher uses.
 fn brotli_compress(data: &[u8]) -> Vec<u8> {
@@ -52,8 +121,9 @@ fn brotli_compress(data: &[u8]) -> Vec<u8> {
 }
 
 fn bench_flashblock_decode(c: &mut Criterion) {
-    let plain = Bytes::from(PAYLOAD_JSON.as_bytes().to_vec());
-    let brotli = Bytes::from(brotli_compress(PAYLOAD_JSON.as_bytes()));
+    let json = Fixture::payload_json();
+    let plain = Bytes::from(json.clone());
+    let brotli = Bytes::from(brotli_compress(&json));
 
     // Fail loudly at setup if the fixture stops decoding, rather than silently
     // benchmarking an error path.

--- a/crates/common/flz/Cargo.toml
+++ b/crates/common/flz/Cargo.toml
@@ -16,7 +16,12 @@ workspace = true
 
 [dev-dependencies]
 rstest.workspace = true
+criterion.workspace = true
 hex-literal.workspace = true
+
+[[bench]]
+name = "flz"
+harness = false
 
 [features]
 default = [ "std" ]

--- a/crates/common/flz/benches/flz.rs
+++ b/crates/common/flz/benches/flz.rs
@@ -1,0 +1,54 @@
+//! Benchmarks for `FastLZ` compressed-size estimation.
+//!
+//! `flz_compress_len` runs once per transaction to price L1 data gas, so it sits on
+//! the hot path of block building, the txpool, and receipt construction. It is a
+//! deterministic, pure-CPU hashtable loop, which makes it a good per-PR advisory
+//! signal.
+
+use std::hint::black_box;
+
+use base_common_flz::{data_gas_fjord, flz_compress_len, tx_estimated_size_fjord};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use hex_literal::hex;
+
+/// A representative encoded EIP-1559 contract-call transaction (~170 bytes).
+const REAL_CONTRACT_CALL: &[u8] = &hex!(
+    "02f901550a758302df1483be21b88304743f94f80e51afb613d764fa61751affd3313c190a86bb870151bd62fd12adb8e41ef24f3f000000000000000000000000000000000000000000000000000000000000006e000000000000000000000000af88d065e77c8cc2239327c5edb3a432268e5831000000000000000000000000000000000000000000000000000000000003c1e5000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000148c89ed219d02f1a5be012c689b4f5b731827bebe000000000000000000000000c001a033fd89cb37c31b2cba46b6466e040c61fc9b2a3675a7f5f493ebd5ad77c497f8a07cdf65680e238392693019b4092f610222e71b7cec06449cb922b93b6a12744e"
+);
+
+/// Build a deterministic calldata-like blob of the given length. The repeating word
+/// pattern gives `FastLZ` realistic back-references without depending on an RNG.
+fn synthetic_calldata(len: usize) -> Vec<u8> {
+    (0..len).map(|i| ((i * 31 + 7) % 256) as u8).collect()
+}
+
+fn bench_flz(c: &mut Criterion) {
+    let mut inputs: Vec<(String, Vec<u8>)> =
+        vec![("real_contract_call".to_string(), REAL_CONTRACT_CALL.to_vec())];
+    for len in [128usize, 1024, 8192] {
+        inputs.push((format!("synthetic_{len}"), synthetic_calldata(len)));
+    }
+
+    let mut group = c.benchmark_group("flz_compress_len");
+    for (name, input) in &inputs {
+        group.throughput(Throughput::Bytes(input.len() as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(name), input, |b, input| {
+            b.iter(|| black_box(flz_compress_len(black_box(input))));
+        });
+    }
+    group.finish();
+
+    // The full Fjord data-gas pricing path (size estimate + gas), dominated by the
+    // FastLZ pass but including the scaling arithmetic applied per transaction.
+    let mut group = c.benchmark_group("fjord_pricing");
+    group.bench_function("tx_estimated_size_fjord", |b| {
+        b.iter(|| black_box(tx_estimated_size_fjord(black_box(REAL_CONTRACT_CALL))));
+    });
+    group.bench_function("data_gas_fjord", |b| {
+        b.iter(|| black_box(data_gas_fjord(black_box(REAL_CONTRACT_CALL))));
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_flz);
+criterion_main!(benches);

--- a/crates/consensus/protocol/Cargo.toml
+++ b/crates/consensus/protocol/Cargo.toml
@@ -66,6 +66,10 @@ alloy-primitives = { workspace = true, features = ["arbitrary"] }
 name = "batch_transaction"
 harness = false
 
+[[bench]]
+name = "frame_parse"
+harness = false
+
 [features]
 default = [ "std" ]
 test-utils = [ "dep:spin", "dep:tracing-subscriber" ]

--- a/crates/consensus/protocol/benches/frame_parse.rs
+++ b/crates/consensus/protocol/benches/frame_parse.rs
@@ -1,0 +1,54 @@
+//! Benchmarks for parsing channel frames out of L1 calldata.
+//!
+//! `Frame::parse_frames` is the decode counterpart to the `batch_transaction` encode
+//! benchmark: it runs on every derivation pass to split calldata/blob payloads back
+//! into frames. It is deterministic and pure-CPU, so it is a good per-PR advisory
+//! signal.
+
+use std::hint::black_box;
+
+use base_protocol::{DERIVATION_VERSION_0, Frame};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+
+/// Encode `frame_count` frames of `data_len` bytes each into the on-chain
+/// `DerivationVersion0 ++ Frame(s)` layout that `parse_frames` expects.
+fn build_encoded(frame_count: usize, data_len: usize) -> Vec<u8> {
+    let mut encoded = vec![DERIVATION_VERSION_0];
+    for i in 0..frame_count {
+        let is_last = i + 1 == frame_count;
+        Frame::new([0xAB; 16], i as u16, vec![0xCD; data_len], is_last).encode_into(&mut encoded);
+    }
+    encoded
+}
+
+fn bench_frame_parse(c: &mut Criterion) {
+    // Many small frames stresses per-frame overhead; a few large frames stresses the
+    // bulk copy. Both shapes occur on the derivation path.
+    let many_small = build_encoded(256, 1024);
+    let few_large = build_encoded(8, 128 * 1024);
+
+    let mut single = Vec::new();
+    Frame::new([0xAB; 16], 0, vec![0xCD; 4096], true).encode_into(&mut single);
+
+    // Fail loudly at setup if the encoding stops round-tripping.
+    Frame::parse_frames(&many_small).expect("many_small parses");
+    Frame::parse_frames(&few_large).expect("few_large parses");
+
+    let mut group = c.benchmark_group("frame_parse");
+    group.throughput(Throughput::Bytes(many_small.len() as u64));
+    group.bench_function("parse_frames/256x1KiB", |b| {
+        b.iter(|| black_box(Frame::parse_frames(black_box(&many_small)).unwrap()));
+    });
+    group.throughput(Throughput::Bytes(few_large.len() as u64));
+    group.bench_function("parse_frames/8x128KiB", |b| {
+        b.iter(|| black_box(Frame::parse_frames(black_box(&few_large)).unwrap()));
+    });
+    group.throughput(Throughput::Bytes(single.len() as u64));
+    group.bench_function("decode/single_4KiB", |b| {
+        b.iter(|| black_box(Frame::decode(black_box(&single)).unwrap()));
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_frame_parse);
+criterion_main!(benches);

--- a/etc/scripts/ci/bench_compare.py
+++ b/etc/scripts/ci/bench_compare.py
@@ -110,6 +110,22 @@ class BenchCompare:
             and self.is_significant(base, head)
         )
 
+    def is_notable(self, base: Measurement | None, head: Measurement | None) -> bool:
+        """Whether a benchmark earns a table row.
+
+        A row is shown for a coverage change (a new or dropped bench) or when the
+        median delta clears the threshold in either direction — regardless of the
+        noise band, so a within-noise move that crossed the threshold is still
+        visible with its `· within noise` caveat. Everything comfortably within the
+        threshold is omitted to keep the comment small.
+        """
+        if base is None or head is None:
+            return True
+        delta = self.delta_pct(base, head)
+        return delta is not None and (
+            delta >= self.threshold_pct or delta <= -self.improvement_pct
+        )
+
     def render_row(self, bench_id: str, base: Measurement | None, head: Measurement | None) -> str:
         """Render a single Markdown table row for one benchmark."""
         if base is None:
@@ -179,23 +195,40 @@ class BenchCompare:
                 f"{self.summarize(base, head, improved)}.",
                 "",
             ]
+        # Only the notable benches get a row; unchanged ones are the bulk of the
+        # subset and only add noise. The rest are summarized as an omitted count so
+        # the trim is never silent.
+        notable = [b for b in bench_ids if self.is_notable(base.get(b), head.get(b))]
+        omitted = len(bench_ids) - len(notable)
+
         lines += [
             "### Benchmark results (advisory)",
             "",
             f"Median time on the PR head versus the base branch, measured on the same "
             f"host. Wall-clock, so a change is only flagged when it clears ±"
             f"{self.threshold_pct:.0f}% *and* the confidence intervals do not overlap. "
-            f"This check never blocks a merge.",
+            f"Only benchmarks past the ±{self.threshold_pct:.0f}% threshold (plus new or "
+            f"dropped ones) are listed. This check never blocks a merge.",
             "",
             "| Benchmark | Base | Head | Δ median |",
             "|---|---:|---:|---:|",
         ]
         if not bench_ids:
             lines.append("| _no benchmark results were produced_ | — | — | — |")
+        elif not notable:
+            lines.append(
+                f"| _all {len(bench_ids)} benchmark(s) within ±{self.threshold_pct:.0f}%_ "
+                f"| — | — | — |"
+            )
         else:
             lines.extend(
-                self.render_row(b, base.get(b), head.get(b)) for b in bench_ids
+                self.render_row(b, base.get(b), head.get(b)) for b in notable
             )
+        if omitted:
+            lines += [
+                "",
+                f"_{omitted} benchmark(s) within ±{self.threshold_pct:.0f}% omitted._",
+            ]
         lines += ["", f"[View run]({run_url}) · [Re-run benchmarks]({run_url})"]
         return "\n".join(lines) + "\n", bool(regressed or improved or dropped)
 

--- a/etc/scripts/ci/run_bench_subset.sh
+++ b/etc/scripts/ci/run_bench_subset.sh
@@ -29,3 +29,9 @@ run cargo bench -p base-builder-core --bench tx_selection \
   -- --save-baseline current --noplot
 run cargo bench -p base-flashblocks-node --bench sender_recovery \
   -- --save-baseline current sequential --noplot
+run cargo bench -p base-common-flz --bench flz \
+  -- --save-baseline current --noplot
+run cargo bench -p base-common-flashblocks --bench flashblock_decode \
+  -- --save-baseline current --noplot
+run cargo bench -p base-protocol --bench frame_parse \
+  -- --save-baseline current --noplot


### PR DESCRIPTION
## Summary

Third PR in the advisory-benchmark stack (stacked on #4473). Adds the first batch of new benchmarks to the per-PR advisory subset, chosen to be deterministic, CPU-bound, and to cover latency/throughput-critical hot paths that had **no** benchmark today. All three are wired into both legs of the advisory workflow. Still advisory only — never gates.

- **`base-common-flz / flz`** — `flz_compress_len` plus the Fjord data-gas pricing path (`tx_estimated_size_fjord`, `data_gas_fjord`). This FastLZ estimator runs once per transaction to price L1 data gas, so it's on the hot path of block building, the txpool, and receipt construction. Pure hashtable loop, fully deterministic.
- **`base-common-flashblocks / flashblock_decode`** — `Flashblock::try_decode_message` for both the plain-JSON and brotli-compressed paths, run for every flashblock a consumer receives.
- **`base-protocol / frame_parse`** — `Frame::parse_frames` and `Frame::decode`, the decode counterpart to the existing `batch_transaction` (encode) bench, run on every derivation pass.

### Note on the batch selection

The original plan listed an envelope-level `recover_signer` bench as the third pick. While implementing, I found `BaseTransactionSigned` is a **type alias for `BaseTxEnvelope`** (`crates/common/consensus/src/lib.rs:55`), so the `sender_recovery` bench already added to the subset in #4471 exercises exactly the same `recover_signer` — a second one would be redundant. Swapped it for `frame_parse`, which is genuinely distinct and complements the existing frame-encode coverage.

Heavier candidates (precompile bn254/BLS crypto, MPT `TrieNode` RLP decode, channel/span-batch derive) are deferred to later PRs on top of this stack.

## Testing

- All three benches compile clean under `RUSTFLAGS="-D warnings"`.
- Smoke-run of each confirms it executes and produces estimates with sensible numbers (e.g. `flz_compress_len` scales with input size; `flashblock_decode/brotli` is slower than `plain_json`; `frame_parse/256x1KiB` ≈ 12 µs).

> Stacked on #4473 → #4471. Review/merge those first; this will retarget to `main` as the stack lands.