### PR TITLE
fix(system-tests): cut system-test peak RAM before L2 deploy

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -7,8 +7,11 @@ max-threads = 1
 [test-groups.builder-integration]
 max-threads = 1
 
+# Each stack is a full L1 (reth + lighthouse + validator) plus in-process L2.
+# Six concurrent stacks OOM the 32 GiB BasePerfRunnerGroup even after
+# serializing L2 deploy behind L1 startup (base/base#4479).
 [test-groups.system-tests]
-max-threads = 6
+max-threads = 2
 
 [profile.ci]
 junit = { path = "test-results.xml" }

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -282,7 +282,7 @@ jobs:
     if: inputs.run_system_tests
     runs-on:
       group: BasePerfRunnerGroup
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -24,7 +24,9 @@ jobs:
         just build::affected-ci "origin/${{ github.base_ref || 'main' }}"
       clippy_command: >-
         just check::clippy-affected-ci "origin/${{ github.base_ref || 'main' }}"
-      run_system_tests: false
+      # Temporary: verify system-test peak RAM on this PR before merge queue.
+      # Revert to false before merging.
+      run_system_tests: true
       run_sigsegv: false
       save_rust_cache: false
       test_command: >-

--- a/etc/systems/src/smoke.rs
+++ b/etc/systems/src/smoke.rs
@@ -29,7 +29,7 @@ use url::Url;
 use crate::upgrade_signal::{MockProtocolVersionsClient, UpgradeSignalStackOptions};
 use crate::{
     BATCHER, BUILDER, SEQUENCER,
-    l1::{L1ContainerConfig, L1Execution, L1RpcProxy, L1Stack, L1StackConfig},
+    l1::{L1ContainerConfig, L1RpcProxy, L1Stack, L1StackConfig},
     l2::{
         L2ClientConsensusMode, L2ContainerConfig, L2Stack, L2StackConfig, ShadowSequencersConfig,
     },
@@ -589,20 +589,17 @@ impl SystemTestStackBuilder {
             container_config: l1_container_config,
         };
 
-        // Start Reth first, then overlap live L2 deployment with Lighthouse
-        // startup. `op-deployer apply` only needs the EL RPC; its transactions
-        // sit in the mempool until the validator begins producing blocks.
-        let l1_execution =
-            L1Execution::start(l1_config).await.wrap_err("Failed to start L1 execution layer")?;
-        let l1_internal_rpc_url = l1_execution.reth().internal_rpc_url();
-        let deploy_handle =
-            tokio::task::spawn_blocking(move || setup.deploy_l2_contracts(&l1_internal_rpc_url));
-        let l1_stack =
-            l1_execution.start_consensus().await.wrap_err("Failed to start L1 consensus")?;
-        let l2_deployment = deploy_handle
-            .await
-            .wrap_err("L2 deployment task panicked")?
-            .wrap_err("Failed to deploy L2 contracts")?;
+        // Start the full L1 stack before live L2 deploy. Overlapping
+        // `op-deployer` with Lighthouse made every concurrent stack run reth,
+        // beacon, validator, and the setup container at once and OOM the 32 GiB
+        // CI runner.
+        let l1_stack = L1Stack::start(l1_config).await.wrap_err("Failed to start L1 stack")?;
+        let l1_internal_rpc_url = l1_stack.reth().internal_rpc_url();
+        let l2_deployment =
+            tokio::task::spawn_blocking(move || setup.deploy_l2_contracts(&l1_internal_rpc_url))
+                .await
+                .wrap_err("L2 deployment task panicked")?
+                .wrap_err("Failed to deploy L2 contracts")?;
 
         let jwt_secret = JwtSecret::random();
 


### PR DESCRIPTION
## Summary
- Stop overlapping live `op-deployer` with Lighthouse startup. That made every concurrent stack run reth, beacon, validator, and the setup container at once.
- Overlap revert alone was not enough: [PR run 32079420671](https://github.com/base/base/actions/runs/32079420671/job/95539307376) got 7 passes, then L1 receipt timeouts and a runner SIGKILL at ~257s with 6 stacks still up.
- Cap `[test-groups.system-tests]` at `max-threads = 2` and raise the System Tests job timeout to 90 minutes so ~70 tests can finish on the 32 GiB `BasePerfRunnerGroup` runner.
- **Temporarily** set `run_system_tests: true` on `CI PR` so this can be verified on the PR. Revert that flag to `false` before merge.

## Test plan
- [ ] `ci / System Tests` runs on this PR (not only merge queue) and completes without runner shutdown / SIGKILL
- [ ] Revert `run_system_tests: true` in `.github/workflows/ci-pr.yml` before merging