### PR TITLE
fix(system-tests): cap per-node reth runtime thread pools

### DIFF
--- a/etc/systems/Cargo.toml
+++ b/etc/systems/Cargo.toml
@@ -42,13 +42,13 @@ base-common-genesis.workspace = true
 
 # reth
 reth-db.workspace = true
-reth-tasks.workspace = true
 reth-provider.workspace = true
 reth-node-core.workspace = true
 base-node-core.workspace = true
 base-execution-rpc.workspace = true
 base-execution-txpool.workspace = true
 base-execution-chainspec.workspace = true
+reth-tasks = { workspace = true, features = ["rayon"] }
 reth-node-builder = { workspace = true, features = ["test-utils"] }
 
 # alloy

--- a/etc/systems/src/l2/in_process_builder.rs
+++ b/etc/systems/src/l2/in_process_builder.rs
@@ -28,10 +28,11 @@ use reth_node_core::{
     dirs::{DataDirPath, MaybePlatformPath},
     exit::NodeExitFuture,
 };
-use reth_tasks::{Runtime, RuntimeBuilder, RuntimeConfig};
+use reth_tasks::{Runtime, RuntimeBuilder};
 use tracing::warn;
 use url::Url;
 
+use super::TestNodeRuntime;
 use crate::{config::BUILDER, setup::BUILDER_ENODE_ID};
 
 /// Configuration for starting an in-process builder.
@@ -110,7 +111,7 @@ impl InProcessBuilder {
         std::fs::write(&jwt_path, config.jwt_secret.as_bytes().encode_hex().as_bytes())
             .wrap_err("Failed to write JWT secret")?;
 
-        let runtime = RuntimeBuilder::new(RuntimeConfig::default()).build()?;
+        let runtime = RuntimeBuilder::new(TestNodeRuntime::config()).build()?;
 
         let chain_spec = parse_genesis(&config.genesis_json)?;
 

--- a/etc/systems/src/l2/in_process_client.rs
+++ b/etc/systems/src/l2/in_process_client.rs
@@ -30,8 +30,10 @@ use reth_node_core::{
     exit::NodeExitFuture,
 };
 use reth_provider::providers::BlockchainProvider;
-use reth_tasks::{Runtime, RuntimeBuilder, RuntimeConfig};
+use reth_tasks::{Runtime, RuntimeBuilder};
 use url::Url;
+
+use super::TestNodeRuntime;
 
 /// Configuration for starting an in-process client node.
 #[derive(Debug)]
@@ -107,7 +109,7 @@ impl std::fmt::Debug for InProcessClient {
 impl InProcessClient {
     /// Starts an in-process client node with the provided configuration.
     pub async fn start(config: InProcessClientConfig) -> Result<Self> {
-        let runtime = RuntimeBuilder::new(RuntimeConfig::default()).build()?;
+        let runtime = RuntimeBuilder::new(TestNodeRuntime::config()).build()?;
 
         // Parse genesis JSON to chain spec
         let genesis: alloy_genesis::Genesis = serde_json::from_slice(&config.genesis_json)

--- a/etc/systems/src/l2/mod.rs
+++ b/etc/systems/src/l2/mod.rs
@@ -3,6 +3,9 @@
 mod config;
 pub use config::L2ContainerConfig;
 
+mod runtime;
+pub use runtime::TestNodeRuntime;
+
 mod in_process_batcher;
 pub use in_process_batcher::{InProcessBatcher, InProcessBatcherConfig};
 

--- a/etc/systems/src/l2/runtime.rs
+++ b/etc/systems/src/l2/runtime.rs
@@ -1,0 +1,44 @@
+//! Bounded tokio/rayon runtime configuration for in-process test nodes.
+
+use reth_tasks::{RayonConfig, RuntimeConfig, TokioConfig};
+
+/// Small, fixed thread-pool sizing for the reth runtime backing an in-process test node.
+///
+/// reth's [`RuntimeConfig::default`] sizes almost every pool from the host core count: the
+/// tokio worker pool, the rayon cpu/rpc/prewarming/BAL pools, a 16-thread storage pool, and
+/// account/storage proof pools at 2x the core count each. A single system-test stack runs a
+/// builder and a client node (plus a node per shadow sequencer), and the suite runs several
+/// stacks at once on a shared CI runner, so the defaults fan out to hundreds of threads per
+/// node. That starves both RAM (OOM-killing the runner) and CPU (the chain then produces
+/// blocks too slowly and transaction receipts time out).
+///
+/// Test nodes build tiny blocks, so a handful of threads per pool is ample. Capping every
+/// pool keeps each node light enough that concurrent stacks fit on the runner.
+#[derive(Debug, Clone, Copy)]
+pub struct TestNodeRuntime;
+
+impl TestNodeRuntime {
+    /// tokio worker threads per node.
+    const WORKER_THREADS: usize = 2;
+    /// Threads for the rayon cpu, rpc, and storage pools.
+    const POOL_THREADS: usize = 2;
+    /// Threads for the proof, prewarming, BAL streaming, and state-trie overlay worker pools.
+    const WORKER_POOL_THREADS: usize = 1;
+
+    /// Returns a [`RuntimeConfig`] with all tokio and rayon pools bounded to small fixed sizes.
+    pub fn config() -> RuntimeConfig {
+        RuntimeConfig::default()
+            .with_tokio(TokioConfig::with_worker_threads(Self::WORKER_THREADS))
+            .with_rayon(RayonConfig {
+                cpu_threads: Some(Self::POOL_THREADS),
+                rpc_threads: Some(Self::POOL_THREADS),
+                storage_threads: Some(Self::POOL_THREADS),
+                proof_storage_worker_threads: Some(Self::WORKER_POOL_THREADS),
+                proof_account_worker_threads: Some(Self::WORKER_POOL_THREADS),
+                prewarming_threads: Some(Self::WORKER_POOL_THREADS),
+                bal_streaming_threads: Some(Self::WORKER_POOL_THREADS),
+                state_trie_overlay_worker_threads: Some(Self::WORKER_POOL_THREADS),
+                ..Default::default()
+            })
+    }
+}

--- a/etc/systems/src/lib.rs
+++ b/etc/systems/src/lib.rs
@@ -51,7 +51,7 @@ pub use l2::{
     InProcessClient, InProcessClientConfig, InProcessConsensus, InProcessConsensusConfig,
     InProcessFollowConsensus, InProcessFollowConsensusConfig, L2ClientConsensus,
     L2ClientConsensusMode, L2ContainerConfig, L2Stack, L2StackConfig, ShadowSequencer,
-    ShadowSequencerConfig, ShadowSequencersConfig,
+    ShadowSequencerConfig, ShadowSequencersConfig, TestNodeRuntime,
 };
 
 mod network;


### PR DESCRIPTION
## Summary
Stacks onto #4479. Targets the **receipt-timeout** failures (and part of the peak-RAM pressure) rather than parallelism alone.

Each in-process builder/client node builds its reth runtime from `RuntimeConfig::default()`, which sizes nearly every tokio and rayon pool from the host core count — tokio workers, the rayon cpu/rpc/prewarming/BAL pools, a 16-thread storage pool, and the account/storage proof pools at 2× core count each. On a 14-core runner that is **~130 threads per node**.

A stack runs a builder + a client (+ a node per shadow sequencer), and the suite runs several stacks at once, so the defaults fan out to many hundreds of threads. That oversubscribes the runner CPUs → the L2 chain produces blocks too slowly → `... receipt timed out` (the 3 `activation_registry` failures in [run 32079420671](https://github.com/base/base/actions/runs/32079420671/job/95539307376)), and inflates peak RAM toward the SIGKILL.

## Change
- New `TestNodeRuntime` helper returns a `RuntimeConfig` with every tokio + rayon pool bounded to a small fixed size (tokio workers = 2, cpu/rpc/storage = 2, proof/prewarm/BAL/state-overlay = 1).
- `InProcessBuilder` and `InProcessClient` use it. Shadow sequencers reuse the builder, so they're covered too.
- Enables the `rayon` feature on `reth-tasks` in `etc/systems` so `RayonConfig` is available (already on transitively).

Test nodes build tiny blocks, so a handful of threads per pool is ample. This makes each stack far lighter, complementing the serialize-L1 / `max-threads` changes on the base branch: less CPU contention → faster block production → fewer receipt timeouts and lower peak RAM.

## Notes
- The `thread 'tokio-rt' panicked ... RUNTIME_SHUTTING_DOWN` lines in the failing logs are teardown noise (a timer polled while a node runtime shuts down after the test already failed), not a nested-runtime-creation error.

## Test plan
- [ ] `ci / System Tests` runs on this PR and completes without receipt timeouts or SIGKILL

Generated with Claude Code