### PR TITLE
docs: Fix Stale README Crate Names

### DIFF
--- a/bin/load-tester/README.md
+++ b/bin/load-tester/README.md
@@ -1,0 +1,6 @@
+# `base-load-tester-bin`
+
+Load testing and benchmarking binary for Base infrastructure.
+
+Parses CLI arguments and delegates to the `base-load-tests` library, which
+provides the load testing and benchmarking framework for the Base network.

--- a/bin/roxy/README.md
+++ b/bin/roxy/README.md
@@ -1,0 +1,6 @@
+# `base-roxy-bin`
+
+JSON-RPC reverse proxy binary for Base infrastructure.
+
+Parses CLI arguments and delegates to the `base-roxy` library, a Rust-owned
+replacement for the `ProxyD` fork focused on the features run in production.

--- a/bin/sidecrush/README.md
+++ b/bin/sidecrush/README.md
@@ -1,0 +1,6 @@
+# `base-sidecrush-bin`
+
+Block-production health-check sidecar binary for Base.
+
+Parses CLI arguments and delegates to the `base-sidecrush` library, which polls
+an execution-layer node's HTTP RPC endpoint and reports on latest-block age.

--- a/bin/snapshotter/README.md
+++ b/bin/snapshotter/README.md
@@ -1,0 +1,7 @@
+# `base-snapshotter-bin`
+
+Reth snapshot generation and upload sidecar binary for Base.
+
+Parses CLI arguments and delegates to the `base-snapshotter` library, which
+orchestrates periodic snapshot creation and upload to S3-compatible storage
+alongside a Base execution-layer node.

--- a/bin/snark-e2e/README.md
+++ b/bin/snark-e2e/README.md
@@ -1,0 +1,7 @@
+# `base-snark-e2e-bin`
+
+SNARK PLONK end-to-end prover verification binary for Base.
+
+Parses CLI arguments and delegates to the `base-snark-e2e` library, which
+submits a one-block SNARK prove request, polls until completion, and
+cryptographically verifies the receipt. Intended for K8s CronJob execution.

--- a/bin/zk-benchmarks/README.md
+++ b/bin/zk-benchmarks/README.md
@@ -1,0 +1,6 @@
+# `base-zk-benchmarks-bin`
+
+ZK proof benchmarking binary for Base load-test runs.
+
+Parses CLI arguments and delegates to the `base-zk-benchmarks` library, which
+provides ZK proof benchmarking utilities for Base load-test runs.

--- a/crates/execution/evm/src/l1.rs
+++ b/crates/execution/evm/src/l1.rs
@@ -75,7 +75,7 @@ pub fn parse_l1_info(input: &[u8]) -> Result<L1BlockInfo, BaseBlockExecutionErro
 
 /// Parses the calldata of the [`L1BlockInfo`] transaction pre-Ecotone upgrade.
 pub fn parse_l1_info_tx_bedrock(data: &[u8]) -> Result<L1BlockInfo, BaseBlockExecutionError> {
-    // The setL1BlockValues tx calldata must be exactly 260 bytes long, considering that
+    // The setL1BlockValues tx calldata must be exactly 256 bytes long, considering that
     // we already removed the first 4 bytes (the function selector). Detailed breakdown:
     //   32 bytes for the block number
     // + 32 bytes for the block timestamp

--- a/crates/execution/node/README.md
+++ b/crates/execution/node/README.md
@@ -1,4 +1,4 @@
-# `base-execution-node`
+# `base-node-core`
 
 Base execution node implementation.
 
@@ -15,11 +15,11 @@ Add the dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-base-execution-node = { workspace = true }
+base-node-core = { workspace = true }
 ```
 
 ```rust,ignore
-use base_execution_node::{BaseEngineApiBuilder, BaseEngineTypes};
+use base_node_core::{BaseEngineApiBuilder, BaseEngineTypes};
 
 let node = NodeBuilder::new(config)
     .with_types::<BaseEngineTypes>()

--- a/crates/execution/runner/README.md
+++ b/crates/execution/runner/README.md
@@ -1,4 +1,4 @@
-# `base-client-node`
+# `base-node-runner`
 
 <a href="https://github.com/base/base/actions/workflows/ci.yml"><img src="https://github.com/base/base/actions/workflows/ci.yml/badge.svg?label=ci" alt="CI"></a>
 <a href="https://github.com/base/base/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-d1d1f6.svg?label=license&labelColor=2a2f35" alt="MIT License"></a>
@@ -17,7 +17,7 @@ aliases for building modular node extensions.
 
 Configuration types are located in their respective feature crates:
 - **`FlashblocksConfig`**: in `base-flashblocks` crate
-- **`TxpoolConfig`**: in `base-txpool` crate
+- **`TxpoolConfig`**: in `base-txpool-tracing` crate
 
 ## Usage
 
@@ -25,13 +25,13 @@ Add the dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-base-client-node = { git = "https://github.com/base/base" }
+base-node-runner = { git = "https://github.com/base/base" }
 ```
 
 Implement a custom node extension:
 
 ```rust,ignore
-use base_client_node::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
+use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
 use eyre::Result;
 
 #[derive(Debug)]

--- a/crates/execution/tx-forwarding/README.md
+++ b/crates/execution/tx-forwarding/README.md
@@ -62,7 +62,7 @@ than a logged skip, so a caller never silently forwards to fewer destinations th
 Enable transaction forwarding on the Base node CLI:
 
 ```bash
-cargo run -p node --release -- \
+cargo run -p base-reth-node --release -- \
   --enable-tx-forwarding \
   --builder-rpc-urls http://builder1:8545,http://builder2:8545 \
 ```

--- a/crates/execution/txpool-tracing/README.md
+++ b/crates/execution/txpool-tracing/README.md
@@ -1,4 +1,4 @@
-# `base-txpool`
+# `base-txpool-tracing`
 
 <a href="https://github.com/base/base/actions/workflows/ci.yml"><img src="https://github.com/base/base/actions/workflows/ci.yml/badge.svg?label=ci" alt="CI"></a>
 <a href="https://github.com/base/base/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-d1d1f6.svg?label=license&labelColor=2a2f35" alt="MIT License"></a>
@@ -19,7 +19,7 @@ This crate provides:
 Enable transaction tracing on the Base node CLI:
 
 ```bash
-cargo run -p node --release -- \
+cargo run -p base-reth-node --release -- \
   --enable-transaction-tracing \
   --enable-transaction-tracing-logs  # optional: emit per-tx lifecycle logs
 ```
@@ -27,7 +27,7 @@ cargo run -p node --release -- \
 From code, wire the extension into the node builder:
 
 ```rust,ignore
-use base_txpool::{TxpoolConfig, TxPoolExtension};
+use base_txpool_tracing::{TxpoolConfig, TxPoolExtension};
 
 let config = TxpoolConfig {
     tracing_enabled: true,

--- a/crates/execution/txpool/README.md
+++ b/crates/execution/txpool/README.md
@@ -1,4 +1,4 @@
-# `base-txpool`
+# `base-execution-txpool`
 
 Transaction pool for Base.
 
@@ -51,11 +51,11 @@ Add the dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-base-txpool = { workspace = true }
+base-execution-txpool = { workspace = true }
 ```
 
 ```rust,ignore
-use base_txpool::{BaseOrdering, BaseTransactionPool, BaseTransactionValidator};
+use base_execution_txpool::{BaseOrdering, BaseTransactionPool, BaseTransactionValidator};
 
 let pool = Pool::new(
     BaseTransactionValidator::new(client, evm),

--- a/docs/guides/UPGRADES.md
+++ b/docs/guides/UPGRADES.md
@@ -189,7 +189,7 @@ For **cascading** upgrades, replace the previous arm's `unwrap_or(ForkCondition:
 ```rust
 /// Returns `true` if [`Azul`](BaseUpgrade::Azul) is active at given block timestamp.
 fn is_azul_active_at_timestamp(&self, timestamp: u64) -> bool {
-    self.upgrade_activation(BaseUpgrade::Azul).active_at_timestamp(timestamp)
+    self.fork_condition(BaseUpgrade::Azul).active_at_timestamp(timestamp)
 }
 ```
 

--- a/docs/transaction-events/pr-description-note.md
+++ b/docs/transaction-events/pr-description-note.md
@@ -1,6 +1,0 @@
-Transaction observability note:
-
-This change introduces a dedicated transaction event journal path. Producers
-append versioned `transaction-event/v1` JSONL records to a configured file for a
-collector sidecar to tail. This is separate from stdout/stderr application logs,
-which continue to use the normal Kubernetes Datadog path.


### PR DESCRIPTION
## Summary

Several crate READMEs referenced package names and import paths that no longer exist after past crate renames, so this corrects them (base-client-node to base-node-runner, base-execution-node to base-node-core, base-txpool to base-execution-txpool and base-txpool-tracing, and cargo run -p node to cargo run -p base-reth-node). It also fixes two documentation contradictions: the bedrock L1 calldata comment claimed 260 bytes where the code checks 256, and the UPGRADES guide showed upgrade_activation where the real trait method is fork_condition. Finally it removes an orphaned transaction-events PR-description note and adds READMEs for six binaries that previously had none. No code behavior changes.