### PR TITLE
refactor: Group Loose Functions Into Types

### DIFF
--- a/crates/common/precompile-macros/src/storable_primitives.rs
+++ b/crates/common/precompile-macros/src/storable_primitives.rs
@@ -331,7 +331,7 @@ fn gen_array_impl(config: &ArrayConfig) -> TokenStream {
             #[inline]
             fn load<S: ::base_precompile_storage::StorageOps>(storage: &S, slot: ::alloy_primitives::U256, ctx: ::base_precompile_storage::LayoutCtx) -> ::base_precompile_storage::Result<Self> {
                 debug_assert_eq!(ctx, ::base_precompile_storage::LayoutCtx::FULL, "Arrays can only be loaded with LayoutCtx::FULL");
-                use ::base_precompile_storage::{calc_element_slot, calc_element_offset, extract_from_word};
+                use ::base_precompile_storage::{Word, calc_element_slot, calc_element_offset};
                 let base_slot = slot;
                 #load_impl
             }
@@ -339,7 +339,7 @@ fn gen_array_impl(config: &ArrayConfig) -> TokenStream {
             #[inline]
             fn store<S: ::base_precompile_storage::StorageOps>(&self, storage: &mut S, slot: ::alloy_primitives::U256, ctx: ::base_precompile_storage::LayoutCtx) -> ::base_precompile_storage::Result<()> {
                 debug_assert_eq!(ctx, ::base_precompile_storage::LayoutCtx::FULL, "Arrays can only be stored with LayoutCtx::FULL");
-                use ::base_precompile_storage::{calc_element_slot, calc_element_offset, insert_into_word};
+                use ::base_precompile_storage::{Word, calc_element_slot, calc_element_offset};
                 let base_slot = slot;
                 #store_impl
             }
@@ -357,7 +357,7 @@ fn gen_packed_array_load(array_size: &usize, elem_byte_count: &usize) -> TokenSt
                 .checked_add(::alloy_primitives::U256::from(slot_idx))
                 .ok_or(::base_precompile_storage::BasePrecompileError::SlotOverflow)?;
             let slot_value = storage.load(slot_addr)?;
-            result[i] = extract_from_word(slot_value, offset, #elem_byte_count)?;
+            result[i] = Word::extract_from_word(slot_value, offset, #elem_byte_count)?;
         }
         Ok(result)
     }
@@ -375,7 +375,7 @@ fn gen_packed_array_store(array_size: &usize, elem_byte_count: &usize) -> TokenS
                 let elem_slot = calc_element_slot(i, #elem_byte_count);
                 if elem_slot == slot_idx {
                     let offset = calc_element_offset(i, #elem_byte_count);
-                    slot_value = insert_into_word(slot_value, &self[i], offset, #elem_byte_count)?;
+                    slot_value = Word::insert_into_word(slot_value, &self[i], offset, #elem_byte_count)?;
                 }
             }
             storage.store(slot_addr, slot_value)?;

--- a/crates/common/precompile-storage/src/lib.rs
+++ b/crates/common/precompile-storage/src/lib.rs
@@ -10,9 +10,8 @@ pub use error::{BasePrecompileError, DelegateCallNotAllowed, IntoPrecompileResul
 
 mod packing;
 pub use packing::{
-    FieldLocation, PackedSlot, calc_element_loc, calc_element_offset, calc_element_slot,
-    calc_packed_slot_count, create_element_mask, delete_from_word, extract_from_word,
-    insert_into_word,
+    FieldLocation, PackedSlot, Word, calc_element_loc, calc_element_offset, calc_element_slot,
+    calc_packed_slot_count,
 };
 
 mod provider;
@@ -46,5 +45,3 @@ mod hashmap;
 pub use hashmap::HashMapStorageProvider;
 #[cfg(any(test, feature = "test-utils"))]
 pub use hashmap::setup_storage;
-#[cfg(any(test, feature = "test-utils"))]
-pub use packing::gen_word_from;

--- a/crates/common/precompile-storage/src/packing.rs
+++ b/crates/common/precompile-storage/src/packing.rs
@@ -10,7 +10,7 @@
 //!   structs and dynamic types (e.g. `Mapping`, `Vec`), but also fixed-size arrays whose
 //!   element type is small (<=16 bytes). For those arrays `N = calc_packed_slot_count(len,
 //!   elem_bytes)`, and individual elements within each slot are still packed using
-//!   `extract_from_word` / `insert_into_word`.
+//!   `Word::extract_from_word` / `Word::insert_into_word`.
 //!
 //! ## Solidity Compatibility
 //!
@@ -71,88 +71,126 @@ impl FieldLocation {
     }
 }
 
-/// Create a bit mask for a value of the given byte size.
+/// Bit-level operations on a single 32-byte EVM storage word.
 ///
-/// For values less than 32 bytes, returns a mask with the appropriate number of bits set.
-/// For 32-byte values, returns `U256::MAX`.
-#[inline]
-pub fn create_element_mask(byte_count: usize) -> U256 {
-    if byte_count >= 32 { U256::MAX } else { (U256::ONE << (byte_count * 8)) - U256::ONE }
-}
+/// Groups the helpers used to pack and unpack multiple small values within one slot.
+#[derive(Debug)]
+pub struct Word;
 
-/// Extract a packed value from a storage slot at a given byte offset.
-#[inline]
-pub fn extract_from_word<T: FromWord + StorableType>(
-    slot_value: U256,
-    offset: usize,
-    bytes: usize,
-) -> Result<T> {
-    debug_assert!(
-        matches!(T::LAYOUT, Layout::Bytes(..)),
-        "Packing is only supported by primitive types"
-    );
-
-    if offset + bytes > 32 {
-        return Err(crate::error::BasePrecompileError::Fatal(format!(
-            "Value of {} bytes at offset {} would span slot boundary (max offset: {})",
-            bytes,
-            offset,
-            32 - bytes
-        )));
+impl Word {
+    /// Create a bit mask for a value of the given byte size.
+    ///
+    /// For values less than 32 bytes, returns a mask with the appropriate number of bits set.
+    /// For 32-byte values, returns `U256::MAX`.
+    #[inline]
+    pub fn create_element_mask(byte_count: usize) -> U256 {
+        if byte_count >= 32 { U256::MAX } else { (U256::ONE << (byte_count * 8)) - U256::ONE }
     }
 
-    let shift_bits = offset * 8;
-    let mask = create_element_mask(bytes);
+    /// Extract a packed value from a storage slot at a given byte offset.
+    #[inline]
+    pub fn extract_from_word<T: FromWord + StorableType>(
+        slot_value: U256,
+        offset: usize,
+        bytes: usize,
+    ) -> Result<T> {
+        debug_assert!(
+            matches!(T::LAYOUT, Layout::Bytes(..)),
+            "Packing is only supported by primitive types"
+        );
 
-    T::from_word((slot_value >> shift_bits) & mask)
-}
+        if offset + bytes > 32 {
+            return Err(crate::error::BasePrecompileError::Fatal(format!(
+                "Value of {} bytes at offset {} would span slot boundary (max offset: {})",
+                bytes,
+                offset,
+                32 - bytes
+            )));
+        }
 
-/// Insert a packed value into a storage slot at a given byte offset.
-#[inline]
-pub fn insert_into_word<T: FromWord + StorableType>(
-    current: U256,
-    value: &T,
-    offset: usize,
-    bytes: usize,
-) -> Result<U256> {
-    debug_assert!(
-        matches!(T::LAYOUT, Layout::Bytes(..)),
-        "Packing is only supported by primitive types"
-    );
+        let shift_bits = offset * 8;
+        let mask = Self::create_element_mask(bytes);
 
-    if offset + bytes > 32 {
-        return Err(crate::error::BasePrecompileError::Fatal(format!(
-            "Value of {} bytes at offset {} would span slot boundary (max offset: {})",
-            bytes,
-            offset,
-            32 - bytes
-        )));
+        T::from_word((slot_value >> shift_bits) & mask)
     }
 
-    let field_value = value.to_word();
-    let shift_bits = offset * 8;
-    let mask = create_element_mask(bytes);
-    let clear_mask = !(mask << shift_bits);
-    let cleared = current & clear_mask;
-    let positioned = (field_value & mask) << shift_bits;
-    Ok(cleared | positioned)
-}
+    /// Insert a packed value into a storage slot at a given byte offset.
+    #[inline]
+    pub fn insert_into_word<T: FromWord + StorableType>(
+        current: U256,
+        value: &T,
+        offset: usize,
+        bytes: usize,
+    ) -> Result<U256> {
+        debug_assert!(
+            matches!(T::LAYOUT, Layout::Bytes(..)),
+            "Packing is only supported by primitive types"
+        );
 
-/// Zero out a packed value in a storage slot at a given byte offset.
-#[inline]
-pub fn delete_from_word(current: U256, offset: usize, bytes: usize) -> Result<U256> {
-    if offset + bytes > 32 {
-        return Err(crate::error::BasePrecompileError::Fatal(format!(
-            "Value of {} bytes at offset {} would span slot boundary (max offset: {})",
-            bytes,
-            offset,
-            32 - bytes
-        )));
+        if offset + bytes > 32 {
+            return Err(crate::error::BasePrecompileError::Fatal(format!(
+                "Value of {} bytes at offset {} would span slot boundary (max offset: {})",
+                bytes,
+                offset,
+                32 - bytes
+            )));
+        }
+
+        let field_value = value.to_word();
+        let shift_bits = offset * 8;
+        let mask = Self::create_element_mask(bytes);
+        let clear_mask = !(mask << shift_bits);
+        let cleared = current & clear_mask;
+        let positioned = (field_value & mask) << shift_bits;
+        Ok(cleared | positioned)
     }
 
-    let mask = create_element_mask(bytes);
-    let shifted_mask = mask << (offset * 8);
-    Ok(current & !shifted_mask)
+    /// Zero out a packed value in a storage slot at a given byte offset.
+    #[inline]
+    pub fn delete_from_word(current: U256, offset: usize, bytes: usize) -> Result<U256> {
+        if offset + bytes > 32 {
+            return Err(crate::error::BasePrecompileError::Fatal(format!(
+                "Value of {} bytes at offset {} would span slot boundary (max offset: {})",
+                bytes,
+                offset,
+                32 - bytes
+            )));
+        }
+
+        let mask = Self::create_element_mask(bytes);
+        let shifted_mask = mask << (offset * 8);
+        Ok(current & !shifted_mask)
+    }
+
+    /// Test helper: constructs a U256 slot from hex string literals, left-padded to 32 bytes.
+    ///
+    /// Takes an array of hex strings (with or without "0x" prefix), concatenates them
+    /// left-to-right, left-pads with zeros to 32 bytes, and returns a U256.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn gen_word_from(values: &[&str]) -> U256 {
+        let mut bytes = Vec::new();
+
+        for value in values {
+            let hex_str = value.strip_prefix("0x").unwrap_or(value);
+
+            assert!(hex_str.len() % 2 == 0, "Hex string '{value}' has odd length");
+
+            for i in (0..hex_str.len()).step_by(2) {
+                let byte_str = &hex_str[i..i + 2];
+                let byte = u8::from_str_radix(byte_str, 16)
+                    .unwrap_or_else(|e| panic!("Invalid hex in '{value}': {e}"));
+                bytes.push(byte);
+            }
+        }
+
+        assert!(bytes.len() <= 32, "Total bytes ({}) exceed 32-byte slot limit", bytes.len());
+
+        let mut slot_bytes = [0u8; 32];
+        let start_idx = 32 - bytes.len();
+        slot_bytes[start_idx..].copy_from_slice(&bytes);
+
+        U256::from_be_bytes(slot_bytes)
+    }
 }
 
 /// Calculate which slot an array element at index `idx` starts in.
@@ -184,36 +222,6 @@ pub const fn calc_element_loc(idx: usize, elem_bytes: usize) -> FieldLocation {
 pub const fn calc_packed_slot_count(n: usize, elem_bytes: usize) -> usize {
     let elems_per_slot = 32 / elem_bytes;
     n.div_ceil(elems_per_slot)
-}
-
-/// Test helper: constructs a U256 slot from hex string literals, left-padded to 32 bytes.
-///
-/// Takes an array of hex strings (with or without "0x" prefix), concatenates them
-/// left-to-right, left-pads with zeros to 32 bytes, and returns a U256.
-#[cfg(any(test, feature = "test-utils"))]
-pub fn gen_word_from(values: &[&str]) -> U256 {
-    let mut bytes = Vec::new();
-
-    for value in values {
-        let hex_str = value.strip_prefix("0x").unwrap_or(value);
-
-        assert!(hex_str.len() % 2 == 0, "Hex string '{value}' has odd length");
-
-        for i in (0..hex_str.len()).step_by(2) {
-            let byte_str = &hex_str[i..i + 2];
-            let byte = u8::from_str_radix(byte_str, 16)
-                .unwrap_or_else(|e| panic!("Invalid hex in '{value}': {e}"));
-            bytes.push(byte);
-        }
-    }
-
-    assert!(bytes.len() <= 32, "Total bytes ({}) exceed 32-byte slot limit", bytes.len());
-
-    let mut slot_bytes = [0u8; 32];
-    let start_idx = 32 - bytes.len();
-    slot_bytes[start_idx..].copy_from_slice(&bytes);
-
-    U256::from_be_bytes(slot_bytes)
 }
 
 #[cfg(test)]
@@ -314,80 +322,80 @@ mod tests {
 
     #[test]
     fn test_create_element_mask() {
-        assert_eq!(create_element_mask(1), U256::from(0xff));
-        assert_eq!(create_element_mask(2), U256::from(0xffff));
-        assert_eq!(create_element_mask(4), U256::from(0xffffffffu32));
-        assert_eq!(create_element_mask(8), U256::from(u64::MAX));
-        assert_eq!(create_element_mask(16), U256::from(u128::MAX));
-        assert_eq!(create_element_mask(32), U256::MAX);
-        assert_eq!(create_element_mask(64), U256::MAX);
+        assert_eq!(Word::create_element_mask(1), U256::from(0xff));
+        assert_eq!(Word::create_element_mask(2), U256::from(0xffff));
+        assert_eq!(Word::create_element_mask(4), U256::from(0xffffffffu32));
+        assert_eq!(Word::create_element_mask(8), U256::from(u64::MAX));
+        assert_eq!(Word::create_element_mask(16), U256::from(u128::MAX));
+        assert_eq!(Word::create_element_mask(32), U256::MAX);
+        assert_eq!(Word::create_element_mask(64), U256::MAX);
     }
 
     #[test]
     fn test_delete_from_word() {
-        let slot = gen_word_from(&["0xff", "0x56", "0x34", "0x12"]);
+        let slot = Word::gen_word_from(&["0xff", "0x56", "0x34", "0x12"]);
 
-        let cleared = delete_from_word(slot, 1, 1).unwrap();
-        let expected = gen_word_from(&["0xff", "0x56", "0x00", "0x12"]);
+        let cleared = Word::delete_from_word(slot, 1, 1).unwrap();
+        let expected = Word::gen_word_from(&["0xff", "0x56", "0x00", "0x12"]);
         assert_eq!(cleared, expected, "Should zero offset 1");
 
-        let slot = gen_word_from(&["0x5678", "0x1234"]);
-        let cleared = delete_from_word(slot, 0, 2).unwrap();
-        let expected = gen_word_from(&["0x5678", "0x0000"]);
+        let slot = Word::gen_word_from(&["0x5678", "0x1234"]);
+        let cleared = Word::delete_from_word(slot, 0, 2).unwrap();
+        let expected = Word::gen_word_from(&["0x5678", "0x0000"]);
         assert_eq!(cleared, expected, "Should zero u16 at offset 0");
 
-        let slot = gen_word_from(&["0xff"]);
-        let cleared = delete_from_word(slot, 0, 1).unwrap();
+        let slot = Word::gen_word_from(&["0xff"]);
+        let cleared = Word::delete_from_word(slot, 0, 1).unwrap();
         assert_eq!(cleared, U256::ZERO, "Should zero entire slot");
     }
 
     #[test]
     fn test_boundary_validation_rejects_spanning() {
         let addr = Address::random();
-        let result = insert_into_word(U256::ZERO, &addr, 13, 20);
+        let result = Word::insert_into_word(U256::ZERO, &addr, 13, 20);
         assert!(result.is_err(), "Should reject address at offset 13");
 
         let val: u16 = 42;
-        let result = insert_into_word(U256::ZERO, &val, 31, 2);
+        let result = Word::insert_into_word(U256::ZERO, &val, 31, 2);
         assert!(result.is_err(), "Should reject u16 at offset 31");
 
         let val: u32 = 42;
-        let result = insert_into_word(U256::ZERO, &val, 29, 4);
+        let result = Word::insert_into_word(U256::ZERO, &val, 29, 4);
         assert!(result.is_err(), "Should reject u32 at offset 29");
 
-        let result = extract_from_word::<Address>(U256::ZERO, 13, 20);
+        let result = Word::extract_from_word::<Address>(U256::ZERO, 13, 20);
         assert!(result.is_err(), "Should reject extracting address from offset 13");
     }
 
     #[test]
     fn test_boundary_validation_accepts_valid() {
         let addr = Address::random();
-        assert!(insert_into_word(U256::ZERO, &addr, 12, 20).is_ok());
+        assert!(Word::insert_into_word(U256::ZERO, &addr, 12, 20).is_ok());
 
         let val: u16 = 42;
-        assert!(insert_into_word(U256::ZERO, &val, 30, 2).is_ok());
+        assert!(Word::insert_into_word(U256::ZERO, &val, 30, 2).is_ok());
 
         let val: u8 = 42;
-        assert!(insert_into_word(U256::ZERO, &val, 31, 1).is_ok());
+        assert!(Word::insert_into_word(U256::ZERO, &val, 31, 1).is_ok());
 
         let val = U256::from(42);
-        assert!(insert_into_word(U256::ZERO, &val, 0, 32).is_ok());
+        assert!(Word::insert_into_word(U256::ZERO, &val, 0, 32).is_ok());
     }
 
     #[test]
     fn test_bool() {
-        let expected = gen_word_from(&["0x01"]);
-        let slot = insert_into_word(U256::ZERO, &true, 0, 1).unwrap();
+        let expected = Word::gen_word_from(&["0x01"]);
+        let slot = Word::insert_into_word(U256::ZERO, &true, 0, 1).unwrap();
         assert_eq!(slot, expected);
-        assert!(extract_from_word::<bool>(slot, 0, 1).unwrap());
+        assert!(Word::extract_from_word::<bool>(slot, 0, 1).unwrap());
 
-        let expected = gen_word_from(&["0x01", "0x01"]);
+        let expected = Word::gen_word_from(&["0x01", "0x01"]);
         let mut slot = U256::ZERO;
-        slot = insert_into_word(slot, &true, 0, 1).unwrap();
-        slot = insert_into_word(slot, &true, 1, 1).unwrap();
+        slot = Word::insert_into_word(slot, &true, 0, 1).unwrap();
+        slot = Word::insert_into_word(slot, &true, 1, 1).unwrap();
         assert_eq!(slot, expected);
-        assert!(extract_from_word::<bool>(slot, 0, 1).unwrap());
-        assert!(extract_from_word::<bool>(slot, 1, 1).unwrap());
+        assert!(Word::extract_from_word::<bool>(slot, 0, 1).unwrap());
+        assert!(Word::extract_from_word::<bool>(slot, 1, 1).unwrap());
     }
 
     #[test]
@@ -397,19 +405,19 @@ mod tests {
         let v3: u8 = 0x56;
         let v4: u8 = u8::MAX;
 
-        let expected = gen_word_from(&["0xff", "0x56", "0x34", "0x12"]);
+        let expected = Word::gen_word_from(&["0xff", "0x56", "0x34", "0x12"]);
 
         let mut slot = U256::ZERO;
-        slot = insert_into_word(slot, &v1, 0, 1).unwrap();
-        slot = insert_into_word(slot, &v2, 1, 1).unwrap();
-        slot = insert_into_word(slot, &v3, 2, 1).unwrap();
-        slot = insert_into_word(slot, &v4, 3, 1).unwrap();
+        slot = Word::insert_into_word(slot, &v1, 0, 1).unwrap();
+        slot = Word::insert_into_word(slot, &v2, 1, 1).unwrap();
+        slot = Word::insert_into_word(slot, &v3, 2, 1).unwrap();
+        slot = Word::insert_into_word(slot, &v4, 3, 1).unwrap();
 
         assert_eq!(slot, expected);
-        assert_eq!(extract_from_word::<u8>(slot, 0, 1).unwrap(), v1);
-        assert_eq!(extract_from_word::<u8>(slot, 1, 1).unwrap(), v2);
-        assert_eq!(extract_from_word::<u8>(slot, 2, 1).unwrap(), v3);
-        assert_eq!(extract_from_word::<u8>(slot, 3, 1).unwrap(), v4);
+        assert_eq!(Word::extract_from_word::<u8>(slot, 0, 1).unwrap(), v1);
+        assert_eq!(Word::extract_from_word::<u8>(slot, 1, 1).unwrap(), v2);
+        assert_eq!(Word::extract_from_word::<u8>(slot, 2, 1).unwrap(), v3);
+        assert_eq!(Word::extract_from_word::<u8>(slot, 3, 1).unwrap(), v4);
     }
 
     #[test]
@@ -418,17 +426,17 @@ mod tests {
         let v2: u16 = 0x5678;
         let v3: u16 = u16::MAX;
 
-        let expected = gen_word_from(&["0xffff", "0x5678", "0x1234"]);
+        let expected = Word::gen_word_from(&["0xffff", "0x5678", "0x1234"]);
 
         let mut slot = U256::ZERO;
-        slot = insert_into_word(slot, &v1, 0, 2).unwrap();
-        slot = insert_into_word(slot, &v2, 2, 2).unwrap();
-        slot = insert_into_word(slot, &v3, 4, 2).unwrap();
+        slot = Word::insert_into_word(slot, &v1, 0, 2).unwrap();
+        slot = Word::insert_into_word(slot, &v2, 2, 2).unwrap();
+        slot = Word::insert_into_word(slot, &v3, 4, 2).unwrap();
 
         assert_eq!(slot, expected);
-        assert_eq!(extract_from_word::<u16>(slot, 0, 2).unwrap(), v1);
-        assert_eq!(extract_from_word::<u16>(slot, 2, 2).unwrap(), v2);
-        assert_eq!(extract_from_word::<u16>(slot, 4, 2).unwrap(), v3);
+        assert_eq!(Word::extract_from_word::<u16>(slot, 0, 2).unwrap(), v1);
+        assert_eq!(Word::extract_from_word::<u16>(slot, 2, 2).unwrap(), v2);
+        assert_eq!(Word::extract_from_word::<u16>(slot, 4, 2).unwrap(), v3);
     }
 
     #[test]
@@ -436,15 +444,15 @@ mod tests {
         let v1: u32 = 0x12345678;
         let v2: u32 = u32::MAX;
 
-        let expected = gen_word_from(&["0xffffffff", "0x12345678"]);
+        let expected = Word::gen_word_from(&["0xffffffff", "0x12345678"]);
 
         let mut slot = U256::ZERO;
-        slot = insert_into_word(slot, &v1, 0, 4).unwrap();
-        slot = insert_into_word(slot, &v2, 4, 4).unwrap();
+        slot = Word::insert_into_word(slot, &v1, 0, 4).unwrap();
+        slot = Word::insert_into_word(slot, &v2, 4, 4).unwrap();
 
         assert_eq!(slot, expected);
-        assert_eq!(extract_from_word::<u32>(slot, 0, 4).unwrap(), v1);
-        assert_eq!(extract_from_word::<u32>(slot, 4, 4).unwrap(), v2);
+        assert_eq!(Word::extract_from_word::<u32>(slot, 0, 4).unwrap(), v1);
+        assert_eq!(Word::extract_from_word::<u32>(slot, 4, 4).unwrap(), v2);
     }
 
     #[test]
@@ -452,15 +460,15 @@ mod tests {
         let v1: u64 = 0x123456789abcdef0;
         let v2: u64 = u64::MAX;
 
-        let expected = gen_word_from(&["0xffffffffffffffff", "0x123456789abcdef0"]);
+        let expected = Word::gen_word_from(&["0xffffffffffffffff", "0x123456789abcdef0"]);
 
         let mut slot = U256::ZERO;
-        slot = insert_into_word(slot, &v1, 0, 8).unwrap();
-        slot = insert_into_word(slot, &v2, 8, 8).unwrap();
+        slot = Word::insert_into_word(slot, &v1, 0, 8).unwrap();
+        slot = Word::insert_into_word(slot, &v2, 8, 8).unwrap();
 
         assert_eq!(slot, expected);
-        assert_eq!(extract_from_word::<u64>(slot, 0, 8).unwrap(), v1);
-        assert_eq!(extract_from_word::<u64>(slot, 8, 8).unwrap(), v2);
+        assert_eq!(Word::extract_from_word::<u64>(slot, 0, 8).unwrap(), v1);
+        assert_eq!(Word::extract_from_word::<u64>(slot, 8, 8).unwrap(), v2);
     }
 
     #[test]
@@ -468,18 +476,18 @@ mod tests {
         let v1: u128 = 0x123456789abcdef0fedcba9876543210;
         let v2: u128 = u128::MAX;
 
-        let expected = gen_word_from(&[
+        let expected = Word::gen_word_from(&[
             "0xffffffffffffffffffffffffffffffff",
             "0x123456789abcdef0fedcba9876543210",
         ]);
 
         let mut slot = U256::ZERO;
-        slot = insert_into_word(slot, &v1, 0, 16).unwrap();
-        slot = insert_into_word(slot, &v2, 16, 16).unwrap();
+        slot = Word::insert_into_word(slot, &v1, 0, 16).unwrap();
+        slot = Word::insert_into_word(slot, &v2, 16, 16).unwrap();
 
         assert_eq!(slot, expected);
-        assert_eq!(extract_from_word::<u128>(slot, 0, 16).unwrap(), v1);
-        assert_eq!(extract_from_word::<u128>(slot, 16, 16).unwrap(), v2);
+        assert_eq!(Word::extract_from_word::<u128>(slot, 0, 16).unwrap(), v1);
+        assert_eq!(Word::extract_from_word::<u128>(slot, 16, 16).unwrap(), v2);
     }
 
     #[test]
@@ -488,16 +496,16 @@ mod tests {
         let number: u8 = 0x2a;
 
         let expected =
-            gen_word_from(&["0x2a", "0x1111111111111111111111111111111111111111", "0x01"]);
+            Word::gen_word_from(&["0x2a", "0x1111111111111111111111111111111111111111", "0x01"]);
 
         let mut slot = U256::ZERO;
-        slot = insert_into_word(slot, &true, 0, 1).unwrap();
-        slot = insert_into_word(slot, &addr, 1, 20).unwrap();
-        slot = insert_into_word(slot, &number, 21, 1).unwrap();
+        slot = Word::insert_into_word(slot, &true, 0, 1).unwrap();
+        slot = Word::insert_into_word(slot, &addr, 1, 20).unwrap();
+        slot = Word::insert_into_word(slot, &number, 21, 1).unwrap();
         assert_eq!(slot, expected);
-        assert!(extract_from_word::<bool>(slot, 0, 1).unwrap());
-        assert_eq!(extract_from_word::<Address>(slot, 1, 20).unwrap(), addr);
-        assert_eq!(extract_from_word::<u8>(slot, 21, 1).unwrap(), number);
+        assert!(Word::extract_from_word::<bool>(slot, 0, 1).unwrap());
+        assert_eq!(Word::extract_from_word::<Address>(slot, 1, 20).unwrap(), addr);
+        assert_eq!(Word::extract_from_word::<u8>(slot, 21, 1).unwrap(), number);
     }
 
     #[test]
@@ -553,105 +561,105 @@ mod tests {
 
         #[test]
         fn proptest_roundtrip_u8(value: u8, offset in arb_offset(1)) {
-            let slot = insert_into_word(U256::ZERO, &value, offset, 1)?;
-            let extracted: u8 = extract_from_word(slot, offset, 1)?;
+            let slot = Word::insert_into_word(U256::ZERO, &value, offset, 1)?;
+            let extracted: u8 = Word::extract_from_word(slot, offset, 1)?;
             prop_assert_eq!(extracted, value);
         }
 
         #[test]
         fn proptest_roundtrip_u16(value: u16, offset in arb_offset(2)) {
-            let slot = insert_into_word(U256::ZERO, &value, offset, 2)?;
-            let extracted: u16 = extract_from_word(slot, offset, 2)?;
+            let slot = Word::insert_into_word(U256::ZERO, &value, offset, 2)?;
+            let extracted: u16 = Word::extract_from_word(slot, offset, 2)?;
             prop_assert_eq!(extracted, value);
         }
 
         #[test]
         fn proptest_roundtrip_u32(value: u32, offset in arb_offset(4)) {
-            let slot = insert_into_word(U256::ZERO, &value, offset, 4)?;
-            let extracted: u32 = extract_from_word(slot, offset, 4)?;
+            let slot = Word::insert_into_word(U256::ZERO, &value, offset, 4)?;
+            let extracted: u32 = Word::extract_from_word(slot, offset, 4)?;
             prop_assert_eq!(extracted, value);
         }
 
         #[test]
         fn proptest_roundtrip_u64(value: u64, offset in arb_offset(8)) {
-            let slot = insert_into_word(U256::ZERO, &value, offset, 8)?;
-            let extracted: u64 = extract_from_word(slot, offset, 8)?;
+            let slot = Word::insert_into_word(U256::ZERO, &value, offset, 8)?;
+            let extracted: u64 = Word::extract_from_word(slot, offset, 8)?;
             prop_assert_eq!(extracted, value);
         }
 
         #[test]
         fn proptest_roundtrip_u128(value: u128, offset in arb_offset(16)) {
-            let slot = insert_into_word(U256::ZERO, &value, offset, 16)?;
-            let extracted: u128 = extract_from_word(slot, offset, 16)?;
+            let slot = Word::insert_into_word(U256::ZERO, &value, offset, 16)?;
+            let extracted: u128 = Word::extract_from_word(slot, offset, 16)?;
             prop_assert_eq!(extracted, value);
         }
 
         #[test]
         fn proptest_roundtrip_address(addr in arb_address(), offset in arb_offset(20)) {
-            let slot = insert_into_word(U256::ZERO, &addr, offset, 20)?;
-            let extracted: Address = extract_from_word(slot, offset, 20)?;
+            let slot = Word::insert_into_word(U256::ZERO, &addr, offset, 20)?;
+            let extracted: Address = Word::extract_from_word(slot, offset, 20)?;
             prop_assert_eq!(extracted, addr);
         }
 
         #[test]
         fn proptest_roundtrip_u256(value in arb_u256()) {
-            let slot = insert_into_word(U256::ZERO, &value, 0, 32)?;
-            let extracted: U256 = extract_from_word(slot, 0, 32)?;
+            let slot = Word::insert_into_word(U256::ZERO, &value, 0, 32)?;
+            let extracted: U256 = Word::extract_from_word(slot, 0, 32)?;
             prop_assert_eq!(extracted, value);
         }
 
         #[test]
         fn proptest_roundtrip_bool(value: bool, offset in arb_offset(1)) {
-            let slot = insert_into_word(U256::ZERO, &value, offset, 1)?;
-            let extracted: bool = extract_from_word(slot, offset, 1)?;
+            let slot = Word::insert_into_word(U256::ZERO, &value, offset, 1)?;
+            let extracted: bool = Word::extract_from_word(slot, offset, 1)?;
             prop_assert_eq!(extracted, value);
         }
 
         #[test]
         fn proptest_roundtrip_i8(value: i8, offset in arb_offset(1)) {
-            let slot = insert_into_word(U256::ZERO, &value, offset, 1)?;
-            let extracted: i8 = extract_from_word(slot, offset, 1)?;
+            let slot = Word::insert_into_word(U256::ZERO, &value, offset, 1)?;
+            let extracted: i8 = Word::extract_from_word(slot, offset, 1)?;
             prop_assert_eq!(extracted, value);
         }
 
         #[test]
         fn proptest_roundtrip_i16(value: i16, offset in arb_offset(2)) {
-            let slot = insert_into_word(U256::ZERO, &value, offset, 2)?;
-            let extracted: i16 = extract_from_word(slot, offset, 2)?;
+            let slot = Word::insert_into_word(U256::ZERO, &value, offset, 2)?;
+            let extracted: i16 = Word::extract_from_word(slot, offset, 2)?;
             prop_assert_eq!(extracted, value);
         }
 
         #[test]
         fn proptest_roundtrip_i32(value: i32, offset in arb_offset(4)) {
-            let slot = insert_into_word(U256::ZERO, &value, offset, 4)?;
-            let extracted: i32 = extract_from_word(slot, offset, 4)?;
+            let slot = Word::insert_into_word(U256::ZERO, &value, offset, 4)?;
+            let extracted: i32 = Word::extract_from_word(slot, offset, 4)?;
             prop_assert_eq!(extracted, value);
         }
 
         #[test]
         fn proptest_roundtrip_i64(value: i64, offset in arb_offset(8)) {
-            let slot = insert_into_word(U256::ZERO, &value, offset, 8)?;
-            let extracted: i64 = extract_from_word(slot, offset, 8)?;
+            let slot = Word::insert_into_word(U256::ZERO, &value, offset, 8)?;
+            let extracted: i64 = Word::extract_from_word(slot, offset, 8)?;
             prop_assert_eq!(extracted, value);
         }
 
         #[test]
         fn proptest_roundtrip_i128(value: i128, offset in arb_offset(16)) {
-            let slot = insert_into_word(U256::ZERO, &value, offset, 16)?;
-            let extracted: i128 = extract_from_word(slot, offset, 16)?;
+            let slot = Word::insert_into_word(U256::ZERO, &value, offset, 16)?;
+            let extracted: i128 = Word::extract_from_word(slot, offset, 16)?;
             prop_assert_eq!(extracted, value);
         }
 
         #[test]
         fn proptest_multiple_values_no_interference(v1: u8, v2: u16, v3: u32) {
             let mut slot = U256::ZERO;
-            slot = insert_into_word(slot, &v1, 0, 1)?;
-            slot = insert_into_word(slot, &v2, 1, 2)?;
-            slot = insert_into_word(slot, &v3, 3, 4)?;
+            slot = Word::insert_into_word(slot, &v1, 0, 1)?;
+            slot = Word::insert_into_word(slot, &v2, 1, 2)?;
+            slot = Word::insert_into_word(slot, &v3, 3, 4)?;
 
-            let e1: u8 = extract_from_word(slot, 0, 1)?;
-            let e2: u16 = extract_from_word(slot, 1, 2)?;
-            let e3: u32 = extract_from_word(slot, 3, 4)?;
+            let e1: u8 = Word::extract_from_word(slot, 0, 1)?;
+            let e2: u16 = Word::extract_from_word(slot, 1, 2)?;
+            let e3: u32 = Word::extract_from_word(slot, 3, 4)?;
 
             prop_assert_eq!(e1, v1);
             prop_assert_eq!(e2, v2);
@@ -661,12 +669,12 @@ mod tests {
         #[test]
         fn proptest_overwrite_preserves_others(v1: u8, v2: u16, v1_new: u8) {
             let mut slot = U256::ZERO;
-            slot = insert_into_word(slot, &v1, 0, 1)?;
-            slot = insert_into_word(slot, &v2, 1, 2)?;
-            slot = insert_into_word(slot, &v1_new, 0, 1)?;
+            slot = Word::insert_into_word(slot, &v1, 0, 1)?;
+            slot = Word::insert_into_word(slot, &v2, 1, 2)?;
+            slot = Word::insert_into_word(slot, &v1_new, 0, 1)?;
 
-            let e1: u8 = extract_from_word(slot, 0, 1)?;
-            let e2: u16 = extract_from_word(slot, 1, 2)?;
+            let e1: u8 = Word::extract_from_word(slot, 0, 1)?;
+            let e2: u16 = Word::extract_from_word(slot, 1, 2)?;
 
             prop_assert_eq!(e1, v1_new);
             prop_assert_eq!(e2, v2);

--- a/crates/common/precompile-storage/src/provider.rs
+++ b/crates/common/precompile-storage/src/provider.rs
@@ -335,7 +335,7 @@ pub trait Storable: StorableType + Sized {
             Some(offset) => {
                 let bytes = Self::BYTES;
                 let current = storage.load(slot)?;
-                let cleared = crate::packing::delete_from_word(current, offset, bytes)?;
+                let cleared = crate::packing::Word::delete_from_word(current, offset, bytes)?;
                 storage.store(slot, cleared)
             }
         }
@@ -370,7 +370,7 @@ impl<T: Packable> Storable for T {
             None => storage.load(slot).and_then(Self::from_word),
             Some(offset) => {
                 let slot_value = storage.load(slot)?;
-                crate::packing::extract_from_word(slot_value, offset, Self::BYTES)
+                crate::packing::Word::extract_from_word(slot_value, offset, Self::BYTES)
             }
         }
     }
@@ -382,7 +382,8 @@ impl<T: Packable> Storable for T {
             None => storage.store(slot, self.to_word()),
             Some(offset) => {
                 let current = storage.load(slot)?;
-                let updated = crate::packing::insert_into_word(current, self, offset, Self::BYTES)?;
+                let updated =
+                    crate::packing::Word::insert_into_word(current, self, offset, Self::BYTES)?;
                 storage.store(slot, updated)
             }
         }

--- a/crates/common/precompile-storage/src/types/vec.rs
+++ b/crates/common/precompile-storage/src/types/vec.rs
@@ -12,7 +12,7 @@ use alloy_primitives::{Address, U256, keccak256};
 
 use crate::{
     error::{BasePrecompileError, Result},
-    packing::{PackedSlot, calc_element_loc, calc_packed_slot_count, create_element_mask},
+    packing::{PackedSlot, Word, calc_element_loc, calc_packed_slot_count},
     provider::{Handler, Layout, LayoutCtx, Storable, StorableType, StorageOps},
     types::{HandlerCache, Slot},
 };
@@ -313,7 +313,7 @@ where
                 let mut combined_clear_mask = U256::ZERO;
                 for index in new_len..boundary_slot_end {
                     let byte_offset = (index % elems_per_slot) * T::BYTES;
-                    combined_clear_mask |= create_element_mask(T::BYTES) << (byte_offset * 8);
+                    combined_clear_mask |= Word::create_element_mask(T::BYTES) << (byte_offset * 8);
                 }
                 self.storage.sstore(
                     self.address,
@@ -560,9 +560,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        StorageFeatures, hashmap::setup_storage, packing::gen_word_from, storage_ctx::StorageCtx,
-    };
+    use crate::{StorageFeatures, hashmap::setup_storage, packing::Word, storage_ctx::StorageCtx};
 
     #[derive(Debug, Default, Clone, PartialEq, Eq, base_precompile_macros::Storable)]
     struct DynamicRecord {
@@ -609,7 +607,7 @@ mod tests {
 
             let data_start = calc_data_slot(len_slot);
             let slot_data = U256::handle(data_start, LayoutCtx::FULL, address, ctx).read().unwrap();
-            let expected = gen_word_from(&["0x32", "0x28", "0x1e", "0x14", "0x0a"]);
+            let expected = Word::gen_word_from(&["0x32", "0x28", "0x1e", "0x14", "0x0a"]);
             assert_eq!(slot_data, expected, "u8 packing should match Solidity layout");
         });
     }
@@ -745,7 +743,7 @@ mod tests {
                 .read()
                 .unwrap();
             // Only byte 0 (element 32 = 0x20) should survive.
-            let expected = gen_word_from(&["0x20"]);
+            let expected = Word::gen_word_from(&["0x20"]);
             assert_eq!(slot1, expected, "boundary slot must retain element 32 only");
         });
     }
@@ -781,7 +779,7 @@ mod tests {
 
             // slot 0 must be fully intact.
             let slot0 = U256::handle(data_start, LayoutCtx::FULL, address, ctx).read().unwrap();
-            let expected = gen_word_from(&[
+            let expected = Word::gen_word_from(&[
                 "0x1f", "0x1e", "0x1d", "0x1c", "0x1b", "0x1a", "0x19", "0x18", "0x17", "0x16",
                 "0x15", "0x14", "0x13", "0x12", "0x11", "0x10", "0x0f", "0x0e", "0x0d", "0x0c",
                 "0x0b", "0x0a", "0x09", "0x08", "0x07", "0x06", "0x05", "0x04", "0x03", "0x02",

--- a/crates/common/precompiles/src/b20_asset/storage.rs
+++ b/crates/common/precompiles/src/b20_asset/storage.rs
@@ -4,7 +4,7 @@ use alloc::string::String;
 
 use alloy_primitives::{Address, U256};
 use base_precompile_macros::{AssetAccounting, Storable, TokenAccounting, contract};
-use base_precompile_storage::{Handler, Mapping, Result, StorageCtx, StorageOps, insert_into_word};
+use base_precompile_storage::{Handler, Mapping, Result, StorageCtx, StorageOps, Word};
 
 use crate::B20CoreStorage;
 
@@ -94,15 +94,16 @@ impl B20AssetStorage<'_> {
     /// single read-modify-write of the slot they share.
     ///
     /// The two `#[mutator]`-generated setters would each pay a full SLOAD/SSTORE on the same packed
-    /// word; coalescing them halves that to one SLOAD + one SSTORE. `insert_into_word` rewrites only
+    /// word; coalescing them halves that to one SLOAD + one SSTORE. `Word::insert_into_word` rewrites only
     /// each field's own bytes, so the slot's unused upper 8 bytes are preserved untouched.
     fn write_pending(&mut self, multiplier: u128, effective_at: u64) -> Result<()> {
         // `pending_multiplier` (u128) occupies the low 16 bytes; `pending_effective_at` (u64) the
         // next 8. Both share one slot, so writing either field's handle addresses the same word.
         let slot = self.asset.pending_multiplier.slot();
         let current = StorageOps::load(&self.asset.pending_multiplier, slot)?;
-        let word = insert_into_word(current, &multiplier, 0, size_of::<u128>())?;
-        let word = insert_into_word(word, &effective_at, size_of::<u128>(), size_of::<u64>())?;
+        let word = Word::insert_into_word(current, &multiplier, 0, size_of::<u128>())?;
+        let word =
+            Word::insert_into_word(word, &effective_at, size_of::<u128>(), size_of::<u64>())?;
         StorageOps::store(&mut self.asset.pending_multiplier, slot, word)
     }
 }

--- a/crates/common/precompiles/src/common/core_storage.rs
+++ b/crates/common/precompiles/src/common/core_storage.rs
@@ -4,7 +4,7 @@ use alloc::string::String;
 
 use alloy_primitives::{Address, B256, FixedBytes, U256};
 use base_precompile_macros::Storable;
-use base_precompile_storage::{Mapping, Result, StorageOps, extract_from_word};
+use base_precompile_storage::{Mapping, Result, StorageOps, Word};
 
 use crate::TransferPolicyIds;
 
@@ -105,17 +105,17 @@ impl B20CoreStorageHandler<'_> {
         let slot = self.transfer_sender_policy_id.slot();
         let word = StorageOps::load(&self.transfer_sender_policy_id, slot)?;
         Ok(TransferPolicyIds {
-            sender: extract_from_word::<u64>(
+            sender: Word::extract_from_word::<u64>(
                 word,
                 __packing_b20_core_storage::TRANSFER_SENDER_POLICY_ID_LOC.offset_bytes,
                 size_of::<u64>(),
             )?,
-            receiver: extract_from_word::<u64>(
+            receiver: Word::extract_from_word::<u64>(
                 word,
                 __packing_b20_core_storage::TRANSFER_RECEIVER_POLICY_ID_LOC.offset_bytes,
                 size_of::<u64>(),
             )?,
-            executor: extract_from_word::<u64>(
+            executor: Word::extract_from_word::<u64>(
                 word,
                 __packing_b20_core_storage::TRANSFER_EXECUTOR_POLICY_ID_LOC.offset_bytes,
                 size_of::<u64>(),

--- a/crates/consensus/protocol/src/info/variant.rs
+++ b/crates/consensus/protocol/src/info/variant.rs
@@ -621,7 +621,6 @@ mod tests {
 
         let ecotone =
             L1BlockInfoTx::Ecotone(L1BlockInfoEcotone::new_from_blob_base_fee_scalar(456));
-        //dbg!("{}", ecotone);
         assert_eq!(ecotone.blob_base_fee_scalar(), U256::from(456));
 
         let isthmus =

--- a/crates/infra/basectl/src/app/views/command_center.rs
+++ b/crates/infra/basectl/src/app/views/command_center.rs
@@ -15,10 +15,8 @@ use crate::{
     },
     output::{
         COLOR_BASE_BLUE, COLOR_BURN, COLOR_GROWTH, COLOR_ROW_HIGHLIGHTED, COLOR_ROW_SELECTED,
-        L1BlocksTableParams, backlog_size_color, block_color, block_color_bright, build_gas_bar,
-        format_bytes, format_duration, format_gwei, format_rate, render_da_backlog_bar,
-        render_gas_usage_bar, render_l1_blocks_table, target_usage_color, time_diff_color,
-        truncate_block_number,
+        Format, L1BlocksTableParams, build_gas_bar, render_da_backlog_bar, render_gas_usage_bar,
+        render_l1_blocks_table,
     },
     tui::{Keybinding, Toast},
 };
@@ -548,7 +546,7 @@ fn format_gas_value(gas: u64) -> String {
 fn render_stats_panel(f: &mut Frame<'_>, area: Rect, resources: &Resources) {
     let tracker = &resources.da.tracker;
 
-    let backlog_color = backlog_size_color(tracker.da_backlog_bytes);
+    let backlog_color = Format::backlog_size_color(tracker.da_backlog_bytes);
     let growth_rate = tracker.growth_tracker.rate_over(RATE_WINDOW_2M);
     let burn_rate = tracker.burn_tracker.rate_over(RATE_WINDOW_2M);
     let time_since = tracker.last_base_blob_time.map(|t| t.elapsed());
@@ -577,22 +575,23 @@ fn render_stats_panel(f: &mut Frame<'_>, area: Rect, resources: &Resources) {
             ),
             Span::raw("  "),
             Span::styled("↑", Style::default().fg(COLOR_GROWTH)),
-            Span::styled(format_rate(growth_rate), Style::default().fg(COLOR_GROWTH)),
+            Span::styled(Format::rate(growth_rate), Style::default().fg(COLOR_GROWTH)),
             Span::raw(" "),
             Span::styled("↓", Style::default().fg(COLOR_BURN)),
-            Span::styled(format_rate(burn_rate), Style::default().fg(COLOR_BURN)),
+            Span::styled(Format::rate(burn_rate), Style::default().fg(COLOR_BURN)),
         ]),
         Line::from(vec![
             Span::styled("DA: ", Style::default().fg(Color::DarkGray)),
             Span::styled(
-                format_bytes(tracker.da_backlog_bytes),
+                Format::bytes(tracker.da_backlog_bytes),
                 Style::default().fg(backlog_color),
             ),
             Span::raw("  "),
             Span::styled("L1: ", Style::default().fg(Color::DarkGray)),
             Span::styled(
                 target_usage.map_or_else(|| "-".to_string(), |u| format!("{:.0}%", u * 100.0)),
-                Style::default().fg(target_usage.map_or(Color::DarkGray, target_usage_color)),
+                Style::default()
+                    .fg(target_usage.map_or(Color::DarkGray, Format::target_usage_color)),
             ),
             Span::raw("  "),
             Span::styled("Base: ", Style::default().fg(Color::DarkGray)),
@@ -603,7 +602,7 @@ fn render_stats_panel(f: &mut Frame<'_>, area: Rect, resources: &Resources) {
             Span::raw("  "),
             Span::styled("Last: ", Style::default().fg(Color::DarkGray)),
             Span::styled(
-                time_since.map(format_duration).unwrap_or_else(|| "-".to_string()),
+                time_since.map(Format::duration).unwrap_or_else(|| "-".to_string()),
                 Style::default().fg(Color::White),
             ),
         ]),
@@ -670,18 +669,18 @@ fn render_da_panel(
             let block_style = if is_safe {
                 Style::default().fg(Color::DarkGray)
             } else {
-                Style::default().fg(block_color(contrib.block_number))
+                Style::default().fg(Format::block_color(contrib.block_number))
             };
 
             let tx_str =
                 if contrib.tx_count > 0 { contrib.tx_count.to_string() } else { "-".to_string() };
 
             Row::new(vec![
-                Cell::from(truncate_block_number(contrib.block_number, block_col_width))
+                Cell::from(Format::truncate_block_number(contrib.block_number, block_col_width))
                     .style(block_style),
                 Cell::from(tx_str),
-                Cell::from(format_bytes(contrib.da_bytes)),
-                Cell::from(format_duration(Duration::from_secs(contrib.age_seconds()))),
+                Cell::from(Format::bytes(contrib.da_bytes)),
+                Cell::from(Format::duration(Duration::from_secs(contrib.age_seconds()))),
             ])
             .style(style)
         })
@@ -749,7 +748,7 @@ fn render_flash_panel(
             };
 
             let (base_fee_str, base_fee_style) = if entry.index == 0 {
-                let fee_str = entry.base_fee.map(format_gwei).unwrap_or_else(|| "-".to_string());
+                let fee_str = entry.base_fee.map(Format::gwei).unwrap_or_else(|| "-".to_string());
                 let style = match (entry.base_fee, entry.prev_base_fee) {
                     (Some(curr), Some(prev)) if curr > prev => Style::default().fg(Color::Red),
                     (Some(curr), Some(prev)) if curr < prev => Style::default().fg(Color::Green),
@@ -765,19 +764,19 @@ fn render_flash_panel(
 
             let (time_diff_str, time_style) = entry.time_diff_ms.map_or_else(
                 || ("-".to_string(), Style::default().fg(Color::DarkGray)),
-                |ms| (format!("+{ms}ms"), Style::default().fg(time_diff_color(ms))),
+                |ms| (format!("+{ms}ms"), Style::default().fg(Format::time_diff_color(ms))),
             );
 
             let block_style = if entry.index == 0 {
                 Style::default()
-                    .fg(block_color_bright(entry.block_number))
+                    .fg(Format::block_color_bright(entry.block_number))
                     .add_modifier(Modifier::BOLD)
             } else {
-                Style::default().fg(block_color(entry.block_number))
+                Style::default().fg(Format::block_color(entry.block_number))
             };
 
             Row::new(vec![
-                Cell::from(truncate_block_number(entry.block_number, block_col_width))
+                Cell::from(Format::truncate_block_number(entry.block_number, block_col_width))
                     .style(block_style),
                 Cell::from(entry.index.to_string()).style(block_style),
                 Cell::from(entry.tx_count.to_string()).style(block_style),

--- a/crates/infra/basectl/src/app/views/da_monitor.rs
+++ b/crates/infra/basectl/src/app/views/da_monitor.rs
@@ -13,9 +13,8 @@ use crate::{
         Resources, View, views::TransactionPane,
     },
     output::{
-        COLOR_BASE_BLUE, COLOR_BURN, COLOR_GROWTH, COLOR_ROW_SELECTED, L1BlocksTableParams,
-        block_color, format_bytes as fmt_bytes, format_duration as fmt_dur, format_rate,
-        render_da_backlog_bar, render_l1_blocks_table, target_usage_color, truncate_block_number,
+        COLOR_BASE_BLUE, COLOR_BURN, COLOR_GROWTH, COLOR_ROW_SELECTED, Format, L1BlocksTableParams,
+        render_da_backlog_bar, render_l1_blocks_table,
     },
     tui::{Keybinding, Toast},
 };
@@ -348,30 +347,31 @@ fn render_stats_panel(f: &mut Frame<'_>, area: Rect, resources: &Resources, filt
         Line::from(vec![
             Span::styled("Growth:  ", Style::default().fg(Color::DarkGray)),
             Span::styled("30s ", Style::default().fg(Color::DarkGray)),
-            Span::styled(format_rate(growth_30s), Style::default().fg(COLOR_GROWTH)),
+            Span::styled(Format::rate(growth_30s), Style::default().fg(COLOR_GROWTH)),
             Span::raw("  "),
             Span::styled("2m ", Style::default().fg(Color::DarkGray)),
-            Span::styled(format_rate(growth_2m), Style::default().fg(COLOR_GROWTH)),
+            Span::styled(Format::rate(growth_2m), Style::default().fg(COLOR_GROWTH)),
             Span::raw("  "),
             Span::styled("5m ", Style::default().fg(Color::DarkGray)),
-            Span::styled(format_rate(growth_5m), Style::default().fg(COLOR_GROWTH)),
+            Span::styled(Format::rate(growth_5m), Style::default().fg(COLOR_GROWTH)),
         ]),
         Line::from(vec![
             Span::styled("Burn:    ", Style::default().fg(Color::DarkGray)),
             Span::styled("30s ", Style::default().fg(Color::DarkGray)),
-            Span::styled(format_rate(burn_30s), Style::default().fg(COLOR_BURN)),
+            Span::styled(Format::rate(burn_30s), Style::default().fg(COLOR_BURN)),
             Span::raw("  "),
             Span::styled("2m ", Style::default().fg(Color::DarkGray)),
-            Span::styled(format_rate(burn_2m), Style::default().fg(COLOR_BURN)),
+            Span::styled(Format::rate(burn_2m), Style::default().fg(COLOR_BURN)),
             Span::raw("  "),
             Span::styled("5m ", Style::default().fg(Color::DarkGray)),
-            Span::styled(format_rate(burn_5m), Style::default().fg(COLOR_BURN)),
+            Span::styled(Format::rate(burn_5m), Style::default().fg(COLOR_BURN)),
         ]),
         Line::from(vec![
             Span::styled("L1 Target: ", Style::default().fg(Color::DarkGray)),
             Span::styled(
                 format_share(target_usage),
-                Style::default().fg(target_usage.map_or(Color::DarkGray, target_usage_color)),
+                Style::default()
+                    .fg(target_usage.map_or(Color::DarkGray, Format::target_usage_color)),
             ),
             Span::raw("  "),
             Span::styled("Base: ", Style::default().fg(Color::DarkGray)),
@@ -379,7 +379,7 @@ fn render_stats_panel(f: &mut Frame<'_>, area: Rect, resources: &Resources, filt
             Span::raw("  "),
             Span::styled("Last: ", Style::default().fg(Color::DarkGray)),
             Span::styled(
-                time_since.map(fmt_dur).unwrap_or_else(|| "-".to_string()),
+                time_since.map(Format::duration).unwrap_or_else(|| "-".to_string()),
                 Style::default().fg(Color::White),
             ),
             Span::raw("  "),
@@ -447,18 +447,18 @@ fn render_blocks_panel(
             let block_style = if is_safe {
                 Style::default().fg(Color::DarkGray)
             } else {
-                Style::default().fg(block_color(contrib.block_number))
+                Style::default().fg(Format::block_color(contrib.block_number))
             };
 
             let tx_str =
                 if contrib.tx_count > 0 { contrib.tx_count.to_string() } else { "-".to_string() };
 
             Row::new(vec![
-                Cell::from(truncate_block_number(contrib.block_number, block_col_width))
+                Cell::from(Format::truncate_block_number(contrib.block_number, block_col_width))
                     .style(block_style),
                 Cell::from(tx_str),
-                Cell::from(fmt_bytes(contrib.da_bytes)),
-                Cell::from(fmt_dur(Duration::from_secs(contrib.age_seconds()))),
+                Cell::from(Format::bytes(contrib.da_bytes)),
+                Cell::from(Format::duration(Duration::from_secs(contrib.age_seconds()))),
             ])
             .style(style)
         })

--- a/crates/infra/basectl/src/app/views/flashblocks.rs
+++ b/crates/infra/basectl/src/app/views/flashblocks.rs
@@ -9,9 +9,8 @@ use ratatui::{
 use crate::{
     app::{Action, Resources, View, views::TransactionPane},
     output::{
-        COLOR_ACTIVE_BORDER, COLOR_ROW_HIGHLIGHTED, COLOR_ROW_SELECTED, block_color,
-        block_color_bright, build_gas_bar, format_gas, format_gwei, render_gas_usage_bar,
-        time_diff_color, truncate_block_number,
+        COLOR_ACTIVE_BORDER, COLOR_ROW_HIGHLIGHTED, COLOR_ROW_SELECTED, Format, build_gas_bar,
+        render_gas_usage_bar,
     },
     tui::{Keybinding, Toast},
 };
@@ -303,7 +302,7 @@ impl View for FlashblocksView {
 
                 let (base_fee_str, base_fee_style) = if entry.index == 0 {
                     let fee_str =
-                        entry.base_fee.map(format_gwei).unwrap_or_else(|| "-".to_string());
+                        entry.base_fee.map(Format::gwei).unwrap_or_else(|| "-".to_string());
                     let style = match (entry.base_fee, entry.prev_base_fee) {
                         (Some(curr), Some(prev)) if curr > prev => Style::default().fg(Color::Red),
                         (Some(curr), Some(prev)) if curr < prev => {
@@ -341,25 +340,25 @@ impl View for FlashblocksView {
 
                 let (time_diff_str, time_style) = entry.time_diff_ms.map_or_else(
                     || ("-".to_string(), Style::default().fg(Color::DarkGray)),
-                    |ms| (format!("+{ms}ms"), Style::default().fg(time_diff_color(ms))),
+                    |ms| (format!("+{ms}ms"), Style::default().fg(Format::time_diff_color(ms))),
                 );
 
                 let block_style = if entry.index == 0 {
                     Style::default()
-                        .fg(block_color_bright(entry.block_number))
+                        .fg(Format::block_color_bright(entry.block_number))
                         .add_modifier(Modifier::BOLD)
                 } else {
-                    Style::default().fg(block_color(entry.block_number))
+                    Style::default().fg(Format::block_color(entry.block_number))
                 };
 
                 let time_str = entry.timestamp.format("%H:%M:%S").to_string();
 
                 Row::new(vec![
-                    Cell::from(truncate_block_number(entry.block_number, block_col_width))
+                    Cell::from(Format::truncate_block_number(entry.block_number, block_col_width))
                         .style(block_style),
                     Cell::from(entry.index.to_string()).style(block_style),
                     Cell::from(entry.tx_count.to_string()).style(block_style),
-                    Cell::from(format_gas(entry.gas_used)),
+                    Cell::from(Format::gas(entry.gas_used)),
                     Cell::from(base_fee_str).style(base_fee_style),
                     Cell::from(delta_str).style(delta_style),
                     Cell::from(time_diff_str).style(time_style),

--- a/crates/infra/basectl/src/commands/block.rs
+++ b/crates/infra/basectl/src/commands/block.rs
@@ -10,8 +10,8 @@ use clap::Args;
 use serde::Serialize;
 
 use crate::{
-    BlockRefParseError, JsonOutput, KeyValueTable, MonitoringConfig, TimestampJson, fetch_block,
-    format_bytes, format_gas, format_gwei, format_unix_timestamp,
+    BlockRefParseError, Format, JsonOutput, KeyValueTable, MonitoringConfig, TimestampJson,
+    fetch_block,
 };
 
 /// Arguments for inspecting a single L2 block.
@@ -154,24 +154,24 @@ impl BlockSummaryJson {
             .row("parent_hash", format!("{:#x}", header.parent_hash))
             .row(
                 "timestamp",
-                format!("{} ({})", header.timestamp, format_unix_timestamp(header.timestamp)),
+                format!("{} ({})", header.timestamp, Format::unix_timestamp(header.timestamp)),
             )
             .row("transactions", block.transactions.len().to_string())
-            .row("gas_used", format_gas(header.gas_used))
-            .row("gas_limit", format_gas(header.gas_limit));
+            .row("gas_used", Format::gas(header.gas_used))
+            .row("gas_limit", Format::gas(header.gas_limit));
         if let Some(base_fee) = header.base_fee_per_gas {
-            table.row("base_fee_per_gas", format_gwei(u128::from(base_fee)));
+            table.row("base_fee_per_gas", Format::gwei(u128::from(base_fee)));
         }
         if let Some(size) = header.size
             && let Ok(size_u64) = u64::try_from(size)
         {
-            table.row("size", format_bytes(size_u64));
+            table.row("size", Format::bytes(size_u64));
         }
         if let Some(blob_gas_used) = header.blob_gas_used {
-            table.row("blob_gas_used", format_gas(blob_gas_used));
+            table.row("blob_gas_used", Format::gas(blob_gas_used));
         }
         if let Some(excess_blob_gas) = header.excess_blob_gas {
-            table.row("excess_blob_gas", format_gas(excess_blob_gas));
+            table.row("excess_blob_gas", Format::gas(excess_blob_gas));
         }
         if let Some(withdrawals) = block.withdrawals.as_ref() {
             table.row("withdrawals", withdrawals.len().to_string());

--- a/crates/infra/basectl/src/commands/proofs.rs
+++ b/crates/infra/basectl/src/commands/proofs.rs
@@ -21,10 +21,10 @@ use tracing::info;
 use url::Url;
 
 use crate::{
-    CommandOutcome, Confirm, EXPECTED_RESOLUTION_NEVER, GameDetails, GameListFilter, GameStatus,
-    GameSummary, GamesClient, JsonOutput, KeyValueTable, MonitoringConfig, ProofProposeRequest,
-    ProofsClient, ProofsCommandError, ProposalProofSubmitter, SnarkPlonkProofBytes, SubmitterKey,
-    format_unix_timestamp,
+    CommandOutcome, Confirm, EXPECTED_RESOLUTION_NEVER, Format, GameDetails, GameListFilter,
+    GameStatus, GameSummary, GamesClient, JsonOutput, KeyValueTable, MonitoringConfig,
+    ProofProposeRequest, ProofsClient, ProofsCommandError, ProposalProofSubmitter,
+    SnarkPlonkProofBytes, SubmitterKey,
 };
 
 /// How long `--wait` and `finalize` poll the prover service before giving up.
@@ -1350,7 +1350,7 @@ fn nonzero_address(address: Address) -> Option<Address> {
 
 /// Formats an `expectedResolution` timestamp, mapping the unproven sentinel to `None`.
 fn format_expected_resolution(timestamp: u64) -> Option<String> {
-    (timestamp != EXPECTED_RESOLUTION_NEVER).then(|| format_unix_timestamp(timestamp))
+    (timestamp != EXPECTED_RESOLUTION_NEVER).then(|| Format::unix_timestamp(timestamp))
 }
 
 /// Humanized JSON shape for `basectl proofs games` (list mode).
@@ -1430,7 +1430,7 @@ impl GameSummaryJson {
             status: game_status_label(summary.status),
             starting_block: summary.starting_block,
             target_block: summary.target_block,
-            created_at: format_unix_timestamp(summary.created_at),
+            created_at: Format::unix_timestamp(summary.created_at),
             tee_prover: nonzero_address(summary.tee_prover),
             zk_prover: nonzero_address(summary.zk_prover),
             expected_resolution: format_expected_resolution(summary.expected_resolution),
@@ -1506,7 +1506,7 @@ impl GameDetailsJson {
             tee_prover: nonzero_address(details.tee_prover),
             zk_prover: nonzero_address(details.zk_prover),
             proof_count: details.proof_count,
-            created_at: format_unix_timestamp(details.created_at),
+            created_at: Format::unix_timestamp(details.created_at),
             expected_resolution: format_expected_resolution(details.expected_resolution),
             countered_index: details.countered_index,
         }

--- a/crates/infra/basectl/src/commands/sync_status.rs
+++ b/crates/infra/basectl/src/commands/sync_status.rs
@@ -12,8 +12,8 @@ use serde::Serialize;
 use url::Url;
 
 use crate::{
-    JsonOutput, KeyValueTable, MonitoringConfig, SyncStatusReport, TimestampJson, fetch_block,
-    fetch_sync_status, format_duration, format_unix_timestamp,
+    Format, JsonOutput, KeyValueTable, MonitoringConfig, SyncStatusReport, TimestampJson,
+    fetch_block, fetch_sync_status,
 };
 
 /// Arguments for reporting combined consensus- and execution-layer sync status.
@@ -139,7 +139,7 @@ fn print_pretty(
         "safe_lag",
         format!(
             "{} ({} blocks behind unsafe)",
-            format_duration(Duration::from_secs(lag_seconds)),
+            Format::duration(Duration::from_secs(lag_seconds)),
             lag_blocks,
         ),
     );
@@ -186,7 +186,7 @@ fn format_tip_reference(
 
 /// Formats a block number and timestamp for pretty output.
 fn format_block_info(b: &BlockInfo) -> String {
-    format!("#{} ts={} ({})", b.number, b.timestamp, format_unix_timestamp(b.timestamp))
+    format!("#{} ts={} ({})", b.number, b.timestamp, Format::unix_timestamp(b.timestamp))
 }
 
 /// Humanized JSON shape for `basectl sync-status --json`.

--- a/crates/infra/basectl/src/commands/txpool.rs
+++ b/crates/infra/basectl/src/commands/txpool.rs
@@ -10,8 +10,8 @@ use tracing::{debug, info, warn};
 use url::Url;
 
 use crate::{
-    Confirm, JsonOutput, KeyValueTable, MonitoringConfig, TxpoolClient, TxpoolCounts, TxpoolReport,
-    TxpoolScope, TxpoolSenderSummary, TxpoolTransactionRow, format_gas, format_gwei,
+    Confirm, Format, JsonOutput, KeyValueTable, MonitoringConfig, TxpoolClient, TxpoolCounts,
+    TxpoolReport, TxpoolScope, TxpoolSenderSummary, TxpoolTransactionRow,
 };
 
 /// Inspect and clear execution-layer txpool contents.
@@ -423,7 +423,7 @@ fn print_read_pretty_to<W: Write>(
             hash = transaction.hash,
             to = format_destination(transaction.to),
             value_wei = transaction.value_wei,
-            gas = format_gas(transaction.gas_limit),
+            gas = Format::gas(transaction.gas_limit),
             fee = format_transaction_fee(transaction),
             input = transaction.input_bytes,
         )?;
@@ -446,8 +446,8 @@ fn format_destination(to: Option<Address>) -> String {
 
 fn format_transaction_fee(transaction: &TxpoolTransactionRow) -> String {
     let priority_fee =
-        transaction.max_priority_fee_per_gas_wei.map_or_else(|| "n/a".to_string(), format_gwei);
-    format!("max={} priority={priority_fee}", format_gwei(transaction.max_fee_per_gas_wei))
+        transaction.max_priority_fee_per_gas_wei.map_or_else(|| "n/a".to_string(), Format::gwei);
+    format!("max={} priority={priority_fee}", Format::gwei(transaction.max_fee_per_gas_wei))
 }
 
 fn print_clear_action(action: &TxpoolClearJson, json: bool) -> Result<()> {

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -44,12 +44,9 @@ pub use app::{
 mod output;
 pub use output::{
     COLOR_ACTIVE_BORDER, COLOR_BASE_BLUE, COLOR_BURN, COLOR_GAS_FILL, COLOR_GROWTH,
-    COLOR_ROW_HIGHLIGHTED, COLOR_ROW_SELECTED, COLOR_TARGET, JsonOutput, KeyValueTable,
+    COLOR_ROW_HIGHLIGHTED, COLOR_ROW_SELECTED, COLOR_TARGET, Format, JsonOutput, KeyValueTable,
     L1BlocksTableParams, P2pClInfoJson, P2pElInfoJson, P2pInfoJson, P2pInfoTable, TimestampJson,
-    backlog_size_color, block_color, block_color_bright, build_gas_bar, format_bytes,
-    format_duration, format_gas, format_gwei, format_rate, format_unix_timestamp,
-    render_da_backlog_bar, render_gas_usage_bar, render_l1_blocks_table, target_usage_color,
-    time_diff_color, truncate_block_number,
+    build_gas_bar, render_da_backlog_bar, render_gas_usage_bar, render_l1_blocks_table,
 };
 
 mod config;

--- a/crates/infra/basectl/src/output/format.rs
+++ b/crates/infra/basectl/src/output/format.rs
@@ -49,64 +49,6 @@ pub const COLOR_TARGET: Color = Color::Rgb(255, 200, 100);
 /// Color for gas bar fill below target.
 pub const COLOR_GAS_FILL: Color = Color::Rgb(100, 180, 255);
 
-/// Formats a byte count into a human-readable string (e.g. "1.5M").
-pub fn format_bytes(bytes: u64) -> String {
-    if bytes >= 1_000_000_000 {
-        format!("{:.1}G", bytes as f64 / 1_000_000_000.0)
-    } else if bytes >= 1_000_000 {
-        format!("{:.1}M", bytes as f64 / 1_000_000.0)
-    } else if bytes >= 1_000 {
-        format!("{:.0}K", bytes as f64 / 1_000.0)
-    } else {
-        format!("{bytes}B")
-    }
-}
-
-/// Formats a gas value into a human-readable string (e.g. "30.0M").
-pub fn format_gas(gas: u64) -> String {
-    if gas >= 1_000_000 {
-        format!("{:.1}M", gas as f64 / 1_000_000.0)
-    } else if gas >= 1_000 {
-        format!("{:.0}K", gas as f64 / 1_000.0)
-    } else {
-        gas.to_string()
-    }
-}
-
-/// Truncates a block number to fit within `max_width` characters.
-pub fn truncate_block_number(block_number: u64, max_width: usize) -> String {
-    let s = block_number.to_string();
-    if s.len() <= max_width { s } else { format!("…{}", &s[s.len() - (max_width - 1)..]) }
-}
-
-/// Formats a duration into a compact human-readable string (e.g. "2m30s").
-pub fn format_duration(d: Duration) -> String {
-    let secs = d.as_secs();
-    if secs >= 3600 {
-        format!("{}h{}m", secs / 3600, (secs % 3600) / 60)
-    } else if secs >= 60 {
-        format!("{}m{}s", secs / 60, secs % 60)
-    } else {
-        format!("{secs}s")
-    }
-}
-
-/// Formats a byte rate into a human-readable string (e.g. "1.2K/s").
-pub fn format_rate(rate: Option<f64>) -> String {
-    match rate {
-        Some(r) if r >= 1_000_000.0 => format!("{:.1}M/s", r / 1_000_000.0),
-        Some(r) if r >= 1_000.0 => format!("{:.1}K/s", r / 1_000.0),
-        Some(r) => format!("{r:.0}B/s"),
-        None => "-".to_string(),
-    }
-}
-
-/// Formats a wei value as gwei with appropriate precision.
-pub fn format_gwei(wei: u128) -> String {
-    let gwei = wei as f64 / 1_000_000_000.0;
-    if gwei >= 1.0 { format!("{gwei:.2} gwei") } else { format!("{gwei:.4} gwei") }
-}
-
 const BACKLOG_THRESHOLDS: &[(u64, Color)] = &[
     (5_000_000, Color::Rgb(100, 200, 100)),
     (10_000_000, Color::Rgb(150, 220, 100)),
@@ -116,77 +58,141 @@ const BACKLOG_THRESHOLDS: &[(u64, Color)] = &[
     (60_000_000, Color::Rgb(255, 100, 80)),
 ];
 
-/// Returns a color indicating backlog severity based on byte count.
-pub fn backlog_size_color(bytes: u64) -> Color {
-    BACKLOG_THRESHOLDS
-        .iter()
-        .find(|(threshold, _)| bytes < *threshold)
-        .map_or(Color::Rgb(255, 80, 120), |(_, color)| *color)
-}
-
-/// Returns a unique color for the given block number.
-pub const fn block_color(block_number: u64) -> Color {
-    BLOCK_COLORS[(block_number as usize) % BLOCK_COLORS.len()]
-}
-
-/// Returns a brightened version of the block color for emphasis.
-pub const fn block_color_bright(block_number: u64) -> Color {
-    let Color::Rgb(r, g, b) = BLOCK_COLORS[(block_number as usize) % BLOCK_COLORS.len()] else {
-        unreachable!()
-    };
-    Color::Rgb(
-        r.saturating_add((255 - r) / 2),
-        g.saturating_add((255 - g) / 2),
-        b.saturating_add((255 - b) / 2),
-    )
-}
-
 const TARGET_USAGE_MAX: f64 = 1.5;
-
-/// Returns a color representing how close usage is to the target (blue to red).
-pub fn target_usage_color(usage: f64) -> Color {
-    let t = usage.clamp(0.0, TARGET_USAGE_MAX);
-    if t <= 1.0 {
-        lerp_rgb((0, 100, 255), (255, 255, 0), t)
-    } else {
-        lerp_rgb((255, 255, 0), (255, 0, 0), (t - 1.0) / (TARGET_USAGE_MAX - 1.0))
-    }
-}
-
-pub(super) const fn lerp_rgb(a: (u8, u8, u8), b: (u8, u8, u8), t: f64) -> Color {
-    Color::Rgb(
-        (a.0 as f64 + (b.0 as f64 - a.0 as f64) * t) as u8,
-        (a.1 as f64 + (b.1 as f64 - a.1 as f64) * t) as u8,
-        (a.2 as f64 + (b.2 as f64 - a.2 as f64) * t) as u8,
-    )
-}
 
 const FLASHBLOCK_TARGET_MS: i64 = 200;
 const FLASHBLOCK_TOLERANCE_MS: i64 = 50;
 
-/// Returns a color indicating how close a time delta is to the 200ms target.
-pub fn time_diff_color(ms: i64) -> Color {
-    let target = FLASHBLOCK_TARGET_MS;
-    let tol = FLASHBLOCK_TOLERANCE_MS;
-    if (target - tol..=target + tol).contains(&ms) {
-        Color::Green
-    } else if (target - 2 * tol..target - tol).contains(&ms) {
-        Color::Blue
-    } else if ms < target - 2 * tol {
-        Color::Magenta
-    } else if (target + tol..target + 2 * tol).contains(&ms) {
-        Color::Yellow
-    } else {
-        Color::Red
-    }
-}
+/// Formatting and color helpers for basectl output rendering.
+#[derive(Debug)]
+pub struct Format;
 
-/// Formats a Unix timestamp (seconds since epoch) as `YYYY-MM-DD HH:MM:SS UTC`.
-///
-/// Falls back to the raw seconds string when the timestamp is out of range.
-pub fn format_unix_timestamp(secs: u64) -> String {
-    i64::try_from(secs)
-        .ok()
-        .and_then(|s| DateTime::from_timestamp(s, 0))
-        .map_or_else(|| secs.to_string(), |t| t.format("%Y-%m-%d %H:%M:%S UTC").to_string())
+impl Format {
+    /// Formats a byte count into a human-readable string (e.g. "1.5M").
+    pub fn bytes(bytes: u64) -> String {
+        if bytes >= 1_000_000_000 {
+            format!("{:.1}G", bytes as f64 / 1_000_000_000.0)
+        } else if bytes >= 1_000_000 {
+            format!("{:.1}M", bytes as f64 / 1_000_000.0)
+        } else if bytes >= 1_000 {
+            format!("{:.0}K", bytes as f64 / 1_000.0)
+        } else {
+            format!("{bytes}B")
+        }
+    }
+
+    /// Formats a gas value into a human-readable string (e.g. "30.0M").
+    pub fn gas(gas: u64) -> String {
+        if gas >= 1_000_000 {
+            format!("{:.1}M", gas as f64 / 1_000_000.0)
+        } else if gas >= 1_000 {
+            format!("{:.0}K", gas as f64 / 1_000.0)
+        } else {
+            gas.to_string()
+        }
+    }
+
+    /// Truncates a block number to fit within `max_width` characters.
+    pub fn truncate_block_number(block_number: u64, max_width: usize) -> String {
+        let s = block_number.to_string();
+        if s.len() <= max_width { s } else { format!("…{}", &s[s.len() - (max_width - 1)..]) }
+    }
+
+    /// Formats a duration into a compact human-readable string (e.g. "2m30s").
+    pub fn duration(d: Duration) -> String {
+        let secs = d.as_secs();
+        if secs >= 3600 {
+            format!("{}h{}m", secs / 3600, (secs % 3600) / 60)
+        } else if secs >= 60 {
+            format!("{}m{}s", secs / 60, secs % 60)
+        } else {
+            format!("{secs}s")
+        }
+    }
+
+    /// Formats a byte rate into a human-readable string (e.g. "1.2K/s").
+    pub fn rate(rate: Option<f64>) -> String {
+        match rate {
+            Some(r) if r >= 1_000_000.0 => format!("{:.1}M/s", r / 1_000_000.0),
+            Some(r) if r >= 1_000.0 => format!("{:.1}K/s", r / 1_000.0),
+            Some(r) => format!("{r:.0}B/s"),
+            None => "-".to_string(),
+        }
+    }
+
+    /// Formats a wei value as gwei with appropriate precision.
+    pub fn gwei(wei: u128) -> String {
+        let gwei = wei as f64 / 1_000_000_000.0;
+        if gwei >= 1.0 { format!("{gwei:.2} gwei") } else { format!("{gwei:.4} gwei") }
+    }
+
+    /// Returns a color indicating backlog severity based on byte count.
+    pub fn backlog_size_color(bytes: u64) -> Color {
+        BACKLOG_THRESHOLDS
+            .iter()
+            .find(|(threshold, _)| bytes < *threshold)
+            .map_or(Color::Rgb(255, 80, 120), |(_, color)| *color)
+    }
+
+    /// Returns a unique color for the given block number.
+    pub const fn block_color(block_number: u64) -> Color {
+        BLOCK_COLORS[(block_number as usize) % BLOCK_COLORS.len()]
+    }
+
+    /// Returns a brightened version of the block color for emphasis.
+    pub const fn block_color_bright(block_number: u64) -> Color {
+        let Color::Rgb(r, g, b) = BLOCK_COLORS[(block_number as usize) % BLOCK_COLORS.len()] else {
+            unreachable!()
+        };
+        Color::Rgb(
+            r.saturating_add((255 - r) / 2),
+            g.saturating_add((255 - g) / 2),
+            b.saturating_add((255 - b) / 2),
+        )
+    }
+
+    /// Returns a color representing how close usage is to the target (blue to red).
+    pub fn target_usage_color(usage: f64) -> Color {
+        let t = usage.clamp(0.0, TARGET_USAGE_MAX);
+        if t <= 1.0 {
+            Self::lerp_rgb((0, 100, 255), (255, 255, 0), t)
+        } else {
+            Self::lerp_rgb((255, 255, 0), (255, 0, 0), (t - 1.0) / (TARGET_USAGE_MAX - 1.0))
+        }
+    }
+
+    pub(super) const fn lerp_rgb(a: (u8, u8, u8), b: (u8, u8, u8), t: f64) -> Color {
+        Color::Rgb(
+            (a.0 as f64 + (b.0 as f64 - a.0 as f64) * t) as u8,
+            (a.1 as f64 + (b.1 as f64 - a.1 as f64) * t) as u8,
+            (a.2 as f64 + (b.2 as f64 - a.2 as f64) * t) as u8,
+        )
+    }
+
+    /// Returns a color indicating how close a time delta is to the 200ms target.
+    pub fn time_diff_color(ms: i64) -> Color {
+        let target = FLASHBLOCK_TARGET_MS;
+        let tol = FLASHBLOCK_TOLERANCE_MS;
+        if (target - tol..=target + tol).contains(&ms) {
+            Color::Green
+        } else if (target - 2 * tol..target - tol).contains(&ms) {
+            Color::Blue
+        } else if ms < target - 2 * tol {
+            Color::Magenta
+        } else if (target + tol..target + 2 * tol).contains(&ms) {
+            Color::Yellow
+        } else {
+            Color::Red
+        }
+    }
+
+    /// Formats a Unix timestamp (seconds since epoch) as `YYYY-MM-DD HH:MM:SS UTC`.
+    ///
+    /// Falls back to the raw seconds string when the timestamp is out of range.
+    pub fn unix_timestamp(secs: u64) -> String {
+        i64::try_from(secs)
+            .ok()
+            .and_then(|s| DateTime::from_timestamp(s, 0))
+            .map_or_else(|| secs.to_string(), |t| t.format("%Y-%m-%d %H:%M:%S UTC").to_string())
+    }
 }

--- a/crates/infra/basectl/src/output/mod.rs
+++ b/crates/infra/basectl/src/output/mod.rs
@@ -3,9 +3,7 @@
 mod format;
 pub use format::{
     COLOR_ACTIVE_BORDER, COLOR_BASE_BLUE, COLOR_BURN, COLOR_GAS_FILL, COLOR_GROWTH,
-    COLOR_ROW_HIGHLIGHTED, COLOR_ROW_SELECTED, COLOR_TARGET, backlog_size_color, block_color,
-    block_color_bright, format_bytes, format_duration, format_gas, format_gwei, format_rate,
-    format_unix_timestamp, target_usage_color, time_diff_color, truncate_block_number,
+    COLOR_ROW_HIGHLIGHTED, COLOR_ROW_SELECTED, COLOR_TARGET, Format,
 };
 
 mod json;

--- a/crates/infra/basectl/src/output/render.rs
+++ b/crates/infra/basectl/src/output/render.rs
@@ -5,13 +5,9 @@ use ratatui::{
     widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState},
 };
 
-use super::format::lerp_rgb;
 use crate::{
     app::{DaTracker, FlashblockEntry, L1Block, L1BlockFilter, LoadingState},
-    output::{
-        COLOR_BASE_BLUE, COLOR_GAS_FILL, COLOR_ROW_SELECTED, COLOR_TARGET, backlog_size_color,
-        block_color, format_bytes, format_duration, target_usage_color, truncate_block_number,
-    },
+    output::{COLOR_BASE_BLUE, COLOR_GAS_FILL, COLOR_ROW_SELECTED, COLOR_TARGET, Format},
     rpc::L1ConnectionMode,
 };
 
@@ -42,7 +38,7 @@ pub fn build_gas_bar(
 
     let excess_color = |char_idx: usize| -> Color {
         let t = (char_idx - target_char) as f64 / excess_chars as f64;
-        lerp_rgb(GAS_COLOR_WARM, GAS_COLOR_HOT, t.clamp(0.0, 1.0))
+        Format::lerp_rgb(GAS_COLOR_WARM, GAS_COLOR_HOT, t.clamp(0.0, 1.0))
     };
 
     let mut spans = Vec::new();
@@ -167,11 +163,11 @@ pub fn render_l1_blocks_table<'a>(
             };
 
             Row::new(vec![
-                Cell::from(truncate_block_number(l1_block.block_number, l1_col_width)),
+                Cell::from(Format::truncate_block_number(l1_block.block_number, l1_col_width)),
                 Cell::from(l1_block.blobs_display()).style(blobs_style),
                 Cell::from(l1_block.l2_blocks_display()),
                 Cell::from(l1_block.compression_display()),
-                Cell::from(format_duration(Duration::from_secs(l1_block.age_seconds()))),
+                Cell::from(Format::duration(Duration::from_secs(l1_block.age_seconds()))),
             ])
             .style(style)
         })
@@ -247,7 +243,7 @@ pub fn render_da_backlog_bar(
 
     if backlog_blocks.is_empty() || tracker.da_backlog_bytes == 0 {
         let empty_bar = "░".repeat(bar_width);
-        let text = format!("{empty_bar} {:>8}", format_bytes(0));
+        let text = format!("{empty_bar} {:>8}", Format::bytes(0));
         let para = Paragraph::new(text).style(Style::default().fg(Color::DarkGray));
         f.render_widget(para, inner);
         return;
@@ -258,7 +254,7 @@ pub fn render_da_backlog_bar(
     let mut chars_used = 0usize;
 
     for contrib in backlog_blocks.iter().rev() {
-        let color = block_color(contrib.block_number);
+        let color = Format::block_color(contrib.block_number);
         let is_highlighted = highlighted_block == Some(contrib.block_number);
 
         let proportion = contrib.da_bytes as f64 / total_backlog as f64;
@@ -288,9 +284,9 @@ pub fn render_da_backlog_bar(
         ));
     }
 
-    let backlog_color = backlog_size_color(total_backlog);
+    let backlog_color = Format::backlog_size_color(total_backlog);
     spans.push(Span::styled(
-        format!(" {:>8}", format_bytes(total_backlog)),
+        format!(" {:>8}", Format::bytes(total_backlog)),
         Style::default().fg(backlog_color).add_modifier(Modifier::BOLD),
     ));
 
@@ -374,7 +370,7 @@ pub fn render_gas_usage_bar(
             break;
         }
 
-        let color = block_color(block_number);
+        let color = Format::block_color(block_number);
         let is_highlighted = highlighted_block == Some(block_number);
 
         let pos_before = gas_to_chars(cumulative_gas).round() as usize;
@@ -419,7 +415,7 @@ pub fn render_gas_usage_bar(
     let usage_ratio = if total_target > 0 { total_gas as f64 / total_target as f64 } else { 0.0 };
     spans.push(Span::styled(
         format!(" {:>5.0}%", usage_ratio * 100.0),
-        Style::default().fg(target_usage_color(usage_ratio)).add_modifier(Modifier::BOLD),
+        Style::default().fg(Format::target_usage_color(usage_ratio)).add_modifier(Modifier::BOLD),
     ));
 
     let line = Line::from(spans);

--- a/crates/proof/succinct/utils/proof/src/lib.rs
+++ b/crates/proof/succinct/utils/proof/src/lib.rs
@@ -116,7 +116,7 @@ async fn cluster_proof_blocking(
     stdin: SP1Stdin,
     label: &str,
 ) -> Result<SP1ProofWithPublicValues> {
-    tracing::info!("Generating {label} proof via cluster");
+    tracing::info!(label = %label, "Generating proof via cluster");
     let timeout_hours = timeout_secs.div_ceil(3600).max(1);
     let cluster_elf = ClusterElf::NewElf(elf.to_vec());
     let ProofRequestResults { proof, .. } = tokio::time::timeout(


### PR DESCRIPTION
## Summary

This groups loose free functions into namespacing types so the public API exports types rather than bare functions (audit item C2). The basectl output formatting and color helpers move onto a `Format` unit struct, and the precompile-storage word bit-manipulation helpers (mask creation, extract/insert/delete, and the test `gen_word_from`) move onto a `Word` unit struct, with callers in base-common-precompiles and the base-precompile-macros `Storable` derive output updated to match. It also fixes an interpolated tracing message to use structured key=value fields (C4) and removes a commented-out dbg! line (C5). No behavior changes; the workspace builds and clippy is clean.

I intentionally left the basectl RPC-namespace helpers (p2p/el/conductor/admin/rollup) as free functions: those modules mix domain structs with helpers and have no natural receiver type, so a unit-struct namespace would be awkward. Note the C4 line overlaps PR #4484, which relocated that function into a new module, so a trivial conflict is expected when both merge.