### PR TITLE
feat(devnet): Enable Validity Txs By Default

### DIFF
--- a/bin/base/src/commands/rpc.rs
+++ b/bin/base/src/commands/rpc.rs
@@ -383,8 +383,8 @@ mod tests {
             launch_config.standard.rpc.rollup_args.sequencer.as_deref(),
             Some("http://localhost:8545")
         );
-        assert!(!launch_config.standard.enable_tx_forwarding);
-        assert!(launch_config.standard.builder_rpc_urls.is_empty());
+        assert!(!launch_config.standard.rpc.enable_tx_forwarding);
+        assert!(launch_config.standard.rpc.builder_rpc_urls.is_empty());
     }
 
     #[test]
@@ -554,12 +554,37 @@ mod tests {
     }
 
     #[test]
-    fn rejects_rpc_tx_forwarding_args() {
+    fn parses_rpc_validity_forwarding_args() {
+        let cli = BaseCli::parse_from(rpc_args(&[
+            "base",
+            "rpc",
+            "--enable-tx-forwarding",
+            "--builder-rpc-urls",
+            "http://localhost:8545",
+            "--enable-experimental-validity-transactions",
+            "--experimental-validity-max-predicates",
+            "8",
+        ]));
+
+        let BaseCommand::Rpc(rpc) = cli.command else {
+            panic!("expected rpc command");
+        };
+
+        let launch_config = rpc.execution.into_launch_config(BaseChainSpec::devnet().into());
+
+        assert!(launch_config.standard.rpc.enable_tx_forwarding);
+        assert!(launch_config.standard.rpc.enable_experimental_validity_transactions);
+        assert_eq!(launch_config.standard.rpc.experimental_validity_max_predicates, 8);
+        assert_eq!(launch_config.standard.rpc.builder_rpc_urls.len(), 1);
+    }
+
+    #[test]
+    fn rpc_tx_forwarding_requires_builder_urls() {
         let err = BaseCli::try_parse_from(rpc_args(&["base", "rpc", "--enable-tx-forwarding"]))
             .unwrap_err();
 
         let rendered = err.to_string();
-        assert!(rendered.contains("--enable-tx-forwarding"));
+        assert!(rendered.contains("--builder-rpc-urls"));
     }
 
     #[test]

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -228,8 +228,10 @@ pub struct RpcStandardNodeArgs {
 
     /// Enable the experimental validity transaction RPC.
     ///
-    /// Validity predicates are forwarded to builders but are not yet enforced.
-    #[arg(long = "enable-experimental-validity-transactions", requires = "enable_tx_forwarding")]
+    /// When transaction forwarding is enabled, validity predicates are forwarded to builders, but
+    /// they are not yet enforced. This can also be enabled on a standalone sequencer (e.g. a local
+    /// devnet) that builds blocks itself, in which case forwarding is not required.
+    #[arg(long = "enable-experimental-validity-transactions")]
     pub enable_experimental_validity_transactions: bool,
 
     /// Maximum validity predicates accepted per experimental transaction.
@@ -534,11 +536,6 @@ impl StandardBaseRethNode {
         runner.install_ext::<BundleExtension>(());
         let tx_forwarding_config: TxForwardingConfig = (&args).into();
         if args.rpc.enable_experimental_validity_transactions {
-            if !tx_forwarding_config.enabled || tx_forwarding_config.builder_urls.is_empty() {
-                eyre::bail!(
-                    "experimental validity transactions require enabled transaction forwarding"
-                );
-            }
             runner.install_ext::<SendRawTransactionValidityExtension>(
                 args.rpc.experimental_validity_max_predicates,
             );
@@ -845,14 +842,15 @@ mod tests {
     }
 
     #[test]
-    fn experimental_validity_transactions_require_forwarding() {
-        let error = CommandParser::<StandardNodeArgs>::try_parse_from([
+    fn experimental_validity_transactions_parse_without_forwarding() {
+        let args = CommandParser::<StandardNodeArgs>::parse_from([
             "base-reth",
             "--enable-experimental-validity-transactions",
         ])
-        .expect_err("validity transactions should require forwarding");
+        .args;
 
-        assert!(error.to_string().contains("--enable-tx-forwarding"));
+        assert!(args.rpc.enable_experimental_validity_transactions);
+        assert!(!args.rpc.enable_tx_forwarding);
     }
 
     #[test]
@@ -875,16 +873,12 @@ mod tests {
     }
 
     #[test]
-    fn programmatic_validity_config_requires_forwarding() {
+    fn programmatic_validity_config_without_forwarding_is_valid() {
         let mut args = StandardNodeArgs::from(default_rpc_standard_node_args());
         args.rpc.enable_experimental_validity_transactions = true;
 
-        let error = match StandardBaseRethNode::runner(args) {
-            Ok(_) => panic!("invalid programmatic validity config should fail"),
-            Err(error) => error,
-        };
-
-        assert!(error.to_string().contains("require enabled transaction forwarding"));
+        StandardBaseRethNode::runner(args)
+            .expect("validity transactions should not require forwarding");
     }
 
     #[test]

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -149,64 +149,6 @@ pub struct StandardNodeArgs {
     /// Shadow indexer `ExEx` arguments.
     #[command(flatten)]
     pub shadow_indexer: ShadowIndexerArgs,
-
-    /// Enable transaction forwarding for mempool nodes to builder RPC endpoints
-    #[arg(
-        long = "enable-tx-forwarding",
-        value_name = "ENABLE_TX_FORWARDING",
-        requires = "builder_rpc_urls"
-    )]
-    pub enable_tx_forwarding: bool,
-
-    /// Enable the experimental validity transaction RPC.
-    ///
-    /// Validity predicates are forwarded to builders but are not yet enforced.
-    #[arg(long = "enable-experimental-validity-transactions", requires = "enable_tx_forwarding")]
-    pub enable_experimental_validity_transactions: bool,
-
-    /// Maximum validity predicates accepted per experimental transaction.
-    #[arg(
-        long = "experimental-validity-max-predicates",
-        default_value_t = DEFAULT_MAX_VALIDITY_PREDICATES,
-        requires = "enable_experimental_validity_transactions"
-    )]
-    pub experimental_validity_max_predicates: usize,
-
-    /// Builder RPC endpoints for transaction forwarding (one forwarder per URL), used by mempool nodes
-    #[arg(
-        long = "builder-rpc-urls",
-        value_name = "BUILDER_RPC_URLS",
-        value_delimiter = ',',
-        requires = "enable_tx_forwarding"
-    )]
-    pub builder_rpc_urls: Vec<Url>,
-
-    /// Resend transactions that haven't been included after this duration in ms (default: 2 blocks)
-    #[arg(
-        long = "tx-forwarding-resend-after-ms",
-        value_name = "TX_FORWARDING_RESEND_AFTER_MS",
-        default_value_t = DEFAULT_RESEND_AFTER_MS,
-        requires = "enable_tx_forwarding"
-    )]
-    pub tx_forwarding_resend_after_ms: u64,
-
-    /// Maximum number of transactions per forwarding batch
-    #[arg(
-        long = "tx-forwarding-batch-size",
-        value_name = "TX_FORWARDING_BATCH_SIZE",
-        default_value_t = DEFAULT_MAX_BATCH_SIZE,
-        requires = "enable_tx_forwarding"
-    )]
-    pub tx_forwarding_batch_size: usize,
-
-    /// Maximum RPC requests per second per forwarder (0 = unlimited).
-    #[arg(
-        long = "tx-forwarding-max-rps",
-        value_name = "TX_FORWARDING_MAX_RPS",
-        default_value_t = DEFAULT_MAX_RPS,
-        requires = "enable_tx_forwarding"
-    )]
-    pub tx_forwarding_max_rps: u32,
 }
 
 /// CLI arguments for a Base execution node embedded by the unified RPC command.
@@ -275,6 +217,64 @@ pub struct RpcStandardNodeArgs {
         requires = "enable_transaction_event_journal"
     )]
     pub transaction_event_journal_path: Option<PathBuf>,
+
+    /// Enable transaction forwarding for mempool nodes to builder RPC endpoints
+    #[arg(
+        long = "enable-tx-forwarding",
+        value_name = "ENABLE_TX_FORWARDING",
+        requires = "builder_rpc_urls"
+    )]
+    pub enable_tx_forwarding: bool,
+
+    /// Enable the experimental validity transaction RPC.
+    ///
+    /// Validity predicates are forwarded to builders but are not yet enforced.
+    #[arg(long = "enable-experimental-validity-transactions", requires = "enable_tx_forwarding")]
+    pub enable_experimental_validity_transactions: bool,
+
+    /// Maximum validity predicates accepted per experimental transaction.
+    #[arg(
+        long = "experimental-validity-max-predicates",
+        default_value_t = DEFAULT_MAX_VALIDITY_PREDICATES,
+        requires = "enable_experimental_validity_transactions"
+    )]
+    pub experimental_validity_max_predicates: usize,
+
+    /// Builder RPC endpoints for transaction forwarding (one forwarder per URL), used by mempool nodes
+    #[arg(
+        long = "builder-rpc-urls",
+        value_name = "BUILDER_RPC_URLS",
+        value_delimiter = ',',
+        requires = "enable_tx_forwarding"
+    )]
+    pub builder_rpc_urls: Vec<Url>,
+
+    /// Resend transactions that haven't been included after this duration in ms (default: 2 blocks)
+    #[arg(
+        long = "tx-forwarding-resend-after-ms",
+        value_name = "TX_FORWARDING_RESEND_AFTER_MS",
+        default_value_t = DEFAULT_RESEND_AFTER_MS,
+        requires = "enable_tx_forwarding"
+    )]
+    pub tx_forwarding_resend_after_ms: u64,
+
+    /// Maximum number of transactions per forwarding batch
+    #[arg(
+        long = "tx-forwarding-batch-size",
+        value_name = "TX_FORWARDING_BATCH_SIZE",
+        default_value_t = DEFAULT_MAX_BATCH_SIZE,
+        requires = "enable_tx_forwarding"
+    )]
+    pub tx_forwarding_batch_size: usize,
+
+    /// Maximum RPC requests per second per forwarder (0 = unlimited).
+    #[arg(
+        long = "tx-forwarding-max-rps",
+        value_name = "TX_FORWARDING_MAX_RPS",
+        default_value_t = DEFAULT_MAX_RPS,
+        requires = "enable_tx_forwarding"
+    )]
+    pub tx_forwarding_max_rps: u32,
 }
 
 impl From<RpcStandardNodeArgs> for StandardNodeArgs {
@@ -287,13 +287,6 @@ impl From<RpcStandardNodeArgs> for StandardNodeArgs {
             rpc: args,
             metering: MeteringArgs::default(),
             shadow_indexer: ShadowIndexerArgs::default(),
-            enable_tx_forwarding: false,
-            enable_experimental_validity_transactions: false,
-            experimental_validity_max_predicates: DEFAULT_MAX_VALIDITY_PREDICATES,
-            builder_rpc_urls: Vec::new(),
-            tx_forwarding_resend_after_ms: DEFAULT_RESEND_AFTER_MS,
-            tx_forwarding_batch_size: DEFAULT_MAX_BATCH_SIZE,
-            tx_forwarding_max_rps: DEFAULT_MAX_RPS,
         }
     }
 }
@@ -356,14 +349,14 @@ impl From<&StandardNodeArgs> for Option<FlashblocksConfig> {
 
 impl From<&StandardNodeArgs> for TxForwardingConfig {
     fn from(args: &StandardNodeArgs) -> Self {
-        if !args.enable_tx_forwarding || args.builder_rpc_urls.is_empty() {
+        if !args.rpc.enable_tx_forwarding || args.rpc.builder_rpc_urls.is_empty() {
             return Self::default();
         }
 
-        Self::new(args.builder_rpc_urls.clone())
-            .with_resend_after_ms(args.tx_forwarding_resend_after_ms)
-            .with_max_batch_size(args.tx_forwarding_batch_size)
-            .with_max_rps(args.tx_forwarding_max_rps)
+        Self::new(args.rpc.builder_rpc_urls.clone())
+            .with_resend_after_ms(args.rpc.tx_forwarding_resend_after_ms)
+            .with_max_batch_size(args.rpc.tx_forwarding_batch_size)
+            .with_max_rps(args.rpc.tx_forwarding_max_rps)
     }
 }
 
@@ -540,14 +533,14 @@ impl StandardBaseRethNode {
         runner.install_ext::<ShadowIndexerExtension>((&args.shadow_indexer).try_into()?);
         runner.install_ext::<BundleExtension>(());
         let tx_forwarding_config: TxForwardingConfig = (&args).into();
-        if args.enable_experimental_validity_transactions {
+        if args.rpc.enable_experimental_validity_transactions {
             if !tx_forwarding_config.enabled || tx_forwarding_config.builder_urls.is_empty() {
                 eyre::bail!(
                     "experimental validity transactions require enabled transaction forwarding"
                 );
             }
             runner.install_ext::<SendRawTransactionValidityExtension>(
-                args.experimental_validity_max_predicates,
+                args.rpc.experimental_validity_max_predicates,
             );
         }
         runner.install_ext::<TxForwardingExtension>(tx_forwarding_config);
@@ -718,6 +711,13 @@ mod tests {
             enable_transaction_tracing_logs: false,
             enable_transaction_event_journal: false,
             transaction_event_journal_path: None,
+            enable_tx_forwarding: false,
+            enable_experimental_validity_transactions: false,
+            experimental_validity_max_predicates: DEFAULT_MAX_VALIDITY_PREDICATES,
+            builder_rpc_urls: Vec::new(),
+            tx_forwarding_resend_after_ms: DEFAULT_RESEND_AFTER_MS,
+            tx_forwarding_batch_size: DEFAULT_MAX_BATCH_SIZE,
+            tx_forwarding_max_rps: DEFAULT_MAX_RPS,
         }
     }
 
@@ -835,9 +835,9 @@ mod tests {
         let config = TxForwardingConfig::from(&standard_args);
 
         assert_eq!(standard_args.rpc.rollup_args.sequencer, None);
-        assert!(!standard_args.enable_experimental_validity_transactions);
+        assert!(!standard_args.rpc.enable_experimental_validity_transactions);
         assert_eq!(
-            standard_args.experimental_validity_max_predicates,
+            standard_args.rpc.experimental_validity_max_predicates,
             DEFAULT_MAX_VALIDITY_PREDICATES
         );
         assert!(!config.enabled);
@@ -868,16 +868,16 @@ mod tests {
         ])
         .args;
 
-        assert!(args.enable_tx_forwarding);
-        assert!(args.enable_experimental_validity_transactions);
-        assert_eq!(args.experimental_validity_max_predicates, 8);
-        assert_eq!(args.builder_rpc_urls.len(), 1);
+        assert!(args.rpc.enable_tx_forwarding);
+        assert!(args.rpc.enable_experimental_validity_transactions);
+        assert_eq!(args.rpc.experimental_validity_max_predicates, 8);
+        assert_eq!(args.rpc.builder_rpc_urls.len(), 1);
     }
 
     #[test]
     fn programmatic_validity_config_requires_forwarding() {
         let mut args = StandardNodeArgs::from(default_rpc_standard_node_args());
-        args.enable_experimental_validity_transactions = true;
+        args.rpc.enable_experimental_validity_transactions = true;
 
         let error = match StandardBaseRethNode::runner(args) {
             Ok(_) => panic!("invalid programmatic validity config should fail"),

--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -238,7 +238,12 @@ _up-devnet compose_profile mode:
     esac
 
     case "$compose_profile" in
-      ha) compose_files=({{ _ha }}) ;;
+      ha)
+        compose_files=({{ _ha }})
+        # Any of the three conductor-managed sequencers can be the leader/builder,
+        # so ingress nodes fan validity (advanced) txs out to all of them.
+        export VALIDITY_BUILDER_RPC_URLS="http://base-builder:${L2_BUILDER_HTTP_PORT},http://base-sequencer-1:${L2_SEQ1_HTTP_PORT},http://base-sequencer-2:${L2_SEQ2_HTTP_PORT}"
+        ;;
       base) compose_files=({{ _base }}) ;;
       *)
         echo "ERROR: compose profile must be 'ha' or 'base' (got '${compose_profile}')" >&2

--- a/etc/docker/devnet-env
+++ b/etc/docker/devnet-env
@@ -70,6 +70,10 @@ L1_CL_P2P_PORT=4900
 L2_EL_BOOTNODE_P2P_PORT=9303
 L2_CL_BOOTNODE_P2P_PORT=9003
 L2_BUILDER_HTTP_PORT=7545
+# Builder RPC endpoint(s) that ingress nodes forward validity (advanced) txs to.
+# Single-sequencer default targets base-builder; the HA `up` recipe overrides
+# this to fan out to all three conductor-managed sequencers.
+VALIDITY_BUILDER_RPC_URLS=http://base-builder:7545
 L2_BUILDER_WS_PORT=7546
 L2_BUILDER_AUTH_PORT=7551
 L2_BUILDER_P2P_PORT=7303

--- a/etc/docker/docker-compose.ha.yml
+++ b/etc/docker/docker-compose.ha.yml
@@ -134,6 +134,7 @@ services:
       - --flashblocks.port=${L2_SEQ1_FLASHBLOCKS_PORT}
       - --flashblocks.block-time=200
       - --rollup.chain-block-time=2000
+      - --builder.enable-experimental-validity-transactions
       - --metrics=0.0.0.0:${L2_SEQ1_METRICS_PORT}
       - --txpool.nolocals
       - --rollup.txpool-max-inflight-delegated-slots=32768
@@ -243,6 +244,7 @@ services:
       - --flashblocks.port=${L2_SEQ2_FLASHBLOCKS_PORT}
       - --flashblocks.block-time=200
       - --rollup.chain-block-time=2000
+      - --builder.enable-experimental-validity-transactions
       - --metrics=0.0.0.0:${L2_SEQ2_METRICS_PORT}
       - --txpool.nolocals
       - --rollup.txpool-max-inflight-delegated-slots=32768

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -308,6 +308,7 @@ services:
       - --rollup.chain-block-time=2000
       - --metrics=0.0.0.0:${L2_BUILDER_METRICS_PORT}
       - --builder.enable-resource-metering
+      - --builder.enable-experimental-validity-transactions
       - --builder.max-rejected-txs-per-block=${BUILDER_MAX_REJECTED_TXS_PER_BLOCK}
       - --txpool.nolocals
       - --rollup.txpool-max-inflight-delegated-slots=32768
@@ -475,6 +476,9 @@ services:
       - --bootnodes=${L2_EL_BOOTNODE_ENODE}
       - --rollup.discovery.v4
       - --rpc.forwarding-endpoint=http://base-builder:${L2_BUILDER_HTTP_PORT}
+      - --enable-tx-forwarding
+      - --builder-rpc-urls=${VALIDITY_BUILDER_RPC_URLS}
+      - --enable-experimental-validity-transactions
       - --enable-transaction-event-journal
       - --enable-metering
       - --metering.gas-limit=${METERING_GAS_LIMIT}
@@ -580,6 +584,9 @@ services:
       - --rpc.eth-proof-window=1209600
       - --bootnodes=${L2_EL_BOOTNODE_ENODE}
       - --rollup.discovery.v4
+      - --enable-tx-forwarding
+      - --builder-rpc-urls=${VALIDITY_BUILDER_RPC_URLS}
+      - --enable-experimental-validity-transactions
       - --l1-eth-rpc
       - http://l1-el:${L1_HTTP_PORT}
       - --l1-beacon


### PR DESCRIPTION
## Summary

Enables experimental validity (advanced) transactions end-to-end on the local devnet by default, and makes the integrated `rpc` node capable of forwarding them. Previously the `rpc` command (base-client and base-rpc) silently forced transaction forwarding and validity ingress off, because those flags lived only on StandardNodeArgs and the RpcStandardNodeArgs conversion hardcoded them to false — so no devnet node could accept base_sendRawTransactionValidity. This moves the forwarding and validity flags onto the shared RpcStandardNodeArgs (which both the `rpc` command and the standalone base-reth-node flatten), so the integrated node can act as a validity-forwarding mempool node, and drops the hardcoded-off block.

The devnet compose files now turn this on out of the box: the builder accepts forwarded validity txs, the ingress nodes expose the validity RPC and forward predicates to the builder, and in the HA profile the ingress fans out to all three conductor-managed sequencers so whichever is leader receives the transaction. The earlier standalone up-validity overlay and BASE_EXTRA_ARGS entrypoint hook were removed in favor of this default-on wiring.

Verified with cargo check on both node binaries, the base-execution-cli and base rpc unit tests, and by rendering the base and HA compose configs to confirm the flags land on the correct services.