### PR TITLE
test(challenger): observe live games after deploy (FORT)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3481,6 +3481,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-challenger-fort"
+version = "0.0.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-provider",
+ "base-challenger",
+ "base-proof-contracts",
+ "base-proof-rpc",
+ "clap",
+ "eyre",
+ "humantime",
+ "reqwest 0.13.4",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "base-challenger-fort-bin"
+version = "0.0.0"
+dependencies = [
+ "base-challenger-fort",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
 name = "base-cli-utils"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,6 +227,7 @@ base-telemetry-service = { path = "crates/infra/telemetry" }
 base-shadow-metrics = { path = "crates/infra/shadow-metrics" }
 base-zk-benchmarks = { path = "crates/infra/zk-benchmarks" }
 base-zk-fork-dispute = { path = "crates/infra/zk-fork-dispute" }
+base-challenger-fort = { path = "crates/infra/challenger-fort" }
 
 # Proof
 base-proof-rpc = { path = "crates/proof/rpc" }

--- a/bin/challenger-fort/Cargo.toml
+++ b/bin/challenger-fort/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "base-challenger-fort-bin"
+description = "Standalone challenger FORT observer for K8s Job execution"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "base-challenger-fort"
+path = "src/main.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+tracing = { workspace = true }
+base-challenger-fort = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tracing-subscriber = { workspace = true, features = ["fmt", "json", "env-filter"] }

--- a/bin/challenger-fort/src/main.rs
+++ b/bin/challenger-fort/src/main.rs
@@ -1,0 +1,17 @@
+//! Standalone challenger FORT observer for K8s Job execution.
+
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt().json().with_env_filter(EnvFilter::from_default_env()).init();
+
+    tracing::info!("starting challenger FORT");
+
+    if let Err(e) = base_challenger_fort::ChallengerFort::run().await {
+        tracing::error!(error = %e, error_debug = ?e, "challenger FORT failed");
+        std::process::exit(1);
+    }
+
+    tracing::info!("challenger FORT passed");
+}

--- a/crates/infra/challenger-fort/Cargo.toml
+++ b/crates/infra/challenger-fort/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "base-challenger-fort"
+description = "Live-chain observer for the challenger after deploy (FORT)"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+eyre.workspace = true
+url.workspace = true
+tracing.workspace = true
+reqwest.workspace = true
+humantime.workspace = true
+alloy-provider.workspace = true
+alloy-primitives.workspace = true
+base-challenger.workspace = true
+base-proof-rpc.workspace = true
+base-proof-contracts.workspace = true
+clap = { workspace = true, features = ["derive", "env"] }
+tokio = { workspace = true, features = ["time"] }

--- a/crates/infra/challenger-fort/README.md
+++ b/crates/infra/challenger-fort/README.md
@@ -1,0 +1,68 @@
+# `base-challenger-fort`
+
+Observer for the live Challenger after deploy.
+
+Talks to the live L1 factory and the live Challenger's Prometheus endpoint.
+It never forks, never plants a game, and never probes `/healthz` or `/readyz`.
+If the factory has no in-progress game of the configured type, FORT exits 0 —
+a Proposer stall is not a Challenger fail.
+
+## What it asserts
+
+Lookback over live factory indices (`CHALLENGER_FORT_GAME_LOOKBACK`, default
+50), same `game_type`, `InProgress`:
+
+1. **No games.** Log skip and exit 0.
+2. **Good game** (intermediate roots match L2 via `OutputValidator`). Pass
+   requires the Challenger to have scanned it (`scan_head` at or past the
+   factory index, or `games_scanned_total > 0` covering it) and left it
+   undisputed. If every observed game is good, `games_invalid_total`,
+   `nullify_tx_submitted_total`, and `challenge_tx_submitted_total` stay flat
+   across the window.
+3. **Bad game** (roots do not match L2). Pass requires it was scanned and
+   disputed on-chain within the window, matching the classifier path:
+   - Path 1 (TEE only): `teeProver == 0` or (`zkProver != 0` and
+     `counteredIndex != 0`)
+   - Path 3 (ZK only): `zkProver == 0`
+   - Path 4 (TEE+ZK, `counteredIndex == 0`): TEE cleared
+   - Path 2 (TEE+ZK, `counteredIndex > 0`): if the original root at the
+     challenged index is correct, ZK is nullified; if that root is wrong,
+     skip (legitimate challenge)
+4. **L2 prune / `BlockNotAvailable`.** Skip that game; it is not a Challenger
+   fail.
+
+The window is `CHALLENGER_FORT_WINDOW` (default 10m). FORT polls until the
+window elapses or the pass conditions hold — it does not fail early just
+because the Challenger has not scanned yet.
+
+## Required environment
+
+`BASE_CHALLENGER_*` is shared with the live Challenger. `CHALLENGER_FORT_*`
+belongs to the observer.
+
+| Variable | Required | Purpose |
+|----------|----------|---------|
+| `BASE_CHALLENGER_L1_ETH_RPC` | Yes | Live L1 RPC |
+| `BASE_CHALLENGER_L2_ETH_RPC` | Yes | Live L2 RPC for canonical output roots |
+| `BASE_CHALLENGER_DISPUTE_GAME_FACTORY_ADDR` | Yes | `DisputeGameFactory` on L1 |
+| `BASE_CHALLENGER_GAME_TYPE` | Yes | `AggregateVerifier` game type |
+| `CHALLENGER_FORT_CHALLENGER_METRICS_URL` | No (default `http://base-challenger:7300/metrics`) | Live Challenger Prometheus endpoint |
+| `CHALLENGER_FORT_GAME_LOOKBACK` | No (default `50`) | Newest factory indices to inspect |
+| `CHALLENGER_FORT_WINDOW` | No (default `10m`) | Observation budget |
+| `CHALLENGER_FORT_POLL_INTERVAL` | No (default `5s`) | Poll interval |
+
+## Usage
+
+```toml
+[dependencies]
+base-challenger-fort = { workspace = true }
+```
+
+```rust,ignore
+use base_challenger_fort::ChallengerFort;
+
+ChallengerFort::run().await?;
+```
+
+The `base-challenger-fort` binary wraps this for K8s Job execution. The Job
+that consumes it lives in `protocols/base-proofs`.

--- a/crates/infra/challenger-fort/src/challenger_fort.rs
+++ b/crates/infra/challenger-fort/src/challenger_fort.rs
@@ -1,0 +1,599 @@
+//! Observes the live Challenger against games that already exist on live L1.
+
+use std::sync::Arc;
+
+use alloy_primitives::Address;
+use alloy_provider::RootProvider;
+use base_challenger::{IntermediateValidationParams, OutputValidator, ValidatorError};
+use base_proof_contracts::{
+    AggregateVerifierClient, AggregateVerifierContractClient, DisputeGameFactoryClient,
+    DisputeGameFactoryContractClient, GameStatus,
+};
+use base_proof_rpc::{L2Client, L2ClientConfig};
+use clap::Parser;
+use eyre::{Context, Result, bail, ensure};
+use tracing::{info, warn};
+
+use crate::{config::Config, metrics::Scrape};
+
+/// Action counters that must stay flat when every observed game is good.
+const ACTION_METRICS: [&str; 3] = [
+    "base_challenger_games_invalid_total",
+    "base_challenger_nullify_tx_submitted_total",
+    "base_challenger_challenge_tx_submitted_total",
+];
+
+/// On-chain prover / countered state used to classify a game and to judge
+/// whether it was later disputed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ProverState {
+    tee: Address,
+    zk: Address,
+    countered: u64,
+}
+
+/// Classifier path that decides what on-chain change counts as a dispute.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Path {
+    /// TEE-only, unchallenged (`tee != 0`, `zk == 0`, `countered == 0`).
+    TeeOnly,
+    /// TEE + ZK, already challenged (`countered > 0`).
+    Challenged,
+    /// ZK-only, unchallenged (`tee == 0`, `zk != 0`, `countered == 0`).
+    ZkOnly,
+    /// TEE + ZK, no challenge (`countered == 0`).
+    Dual,
+}
+
+/// A live in-progress game FORT will assert on.
+#[derive(Debug, Clone, Copy)]
+struct ObservedGame {
+    index: u64,
+    address: Address,
+    path: Path,
+    kind: Kind,
+}
+
+/// Whether the game's claimed roots match L2.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Kind {
+    /// Intermediate roots match L2. The Challenger must leave it alone.
+    Good,
+    /// Intermediate roots do not match L2. The Challenger must dispute it.
+    Bad,
+    /// Path 2: original root at the challenged index is correct. The Challenger
+    /// must nullify the fraudulent ZK challenge.
+    FraudulentChallenge,
+}
+
+/// Live-chain observer for the challenger after deploy.
+///
+/// See the crate README for the full argument. FORT never plants a game and
+/// never forks L1; it only reads the factory and the live Challenger's metrics.
+#[derive(Debug)]
+pub struct ChallengerFort;
+
+impl ChallengerFort {
+    /// Runs the observer to completion. An `Ok` return means pass or skip.
+    pub async fn run() -> Result<()> {
+        let config = Config::parse();
+
+        let l1 = RootProvider::new_http(config.l1_eth_rpc.clone());
+        let factory =
+            DisputeGameFactoryContractClient::new(config.dispute_game_factory_addr, l1.clone());
+        let verifier = AggregateVerifierContractClient::new(l1);
+        let l2 = Arc::new(
+            L2Client::new(L2ClientConfig::new(config.l2_eth_rpc.clone()))
+                .context("failed to build an L2 client")?,
+        );
+        let validator = OutputValidator::new(l2);
+
+        let games = Self::collect_games(&config, &factory, &verifier, &validator).await?;
+        if games.is_empty() {
+            return Ok(());
+        }
+
+        let all_good = games.iter().all(|game| game.kind == Kind::Good);
+        let baseline = Scrape::fetch(&config.challenger_metrics_url).await.ok();
+
+        info!(
+            good = games.iter().filter(|game| game.kind == Kind::Good).count(),
+            bad = games.iter().filter(|game| game.kind == Kind::Bad).count(),
+            fraudulent_challenge =
+                games.iter().filter(|game| game.kind == Kind::FraudulentChallenge).count(),
+            window = ?config.window,
+            "observing the live challenger"
+        );
+
+        Self::await_pass(&config, &verifier, &games, baseline.as_ref(), all_good).await?;
+
+        let addresses: Vec<_> = games.iter().map(|game| game.address).collect();
+        info!(
+            games = games.len(),
+            good = games.iter().filter(|game| game.kind == Kind::Good).count(),
+            bad = games.iter().filter(|game| game.kind == Kind::Bad).count(),
+            ?addresses,
+            "challenger FORT passed"
+        );
+        Ok(())
+    }
+
+    /// Newest in-progress games of the configured type, classified against L2.
+    ///
+    /// Returns an empty vec (and logs skip) when nothing is actionable: no
+    /// matching games, or every candidate was pruned / unvalidatable.
+    async fn collect_games(
+        config: &Config,
+        factory: &DisputeGameFactoryContractClient,
+        verifier: &AggregateVerifierContractClient,
+        validator: &OutputValidator<L2Client>,
+    ) -> Result<Vec<ObservedGame>> {
+        let game_count = factory.game_count().await?;
+        if game_count == 0 {
+            info!(
+                factory = %config.dispute_game_factory_addr,
+                "factory has no games; skipping (proposer stall is not a challenger fail)"
+            );
+            return Ok(Vec::new());
+        }
+
+        let floor = game_count.saturating_sub(config.game_lookback);
+        let mut games = Vec::new();
+        let mut skipped = 0u64;
+        let mut interval = None;
+
+        for index in (floor..game_count).rev() {
+            let factory_game = factory.game_at_index(index).await?;
+            if factory_game.game_type != config.game_type {
+                continue;
+            }
+            if verifier.status(factory_game.proxy).await? != GameStatus::InProgress {
+                continue;
+            }
+
+            let state = Self::prover_state(verifier, factory_game.proxy).await?;
+            let Some(path) = Path::classify(state) else {
+                skipped += 1;
+                continue;
+            };
+
+            let interval = match interval {
+                Some(value) => value,
+                None => {
+                    let resolved =
+                        Self::intermediate_block_interval(factory, verifier, config.game_type)
+                            .await?;
+                    interval = Some(resolved);
+                    resolved
+                }
+            };
+
+            match Self::observe(validator, verifier, factory_game.proxy, index, path, interval)
+                .await?
+            {
+                Some(game) => {
+                    info!(
+                        game = %game.address,
+                        factory_index = game.index,
+                        path = ?game.path,
+                        kind = ?game.kind,
+                        "observing in-progress game"
+                    );
+                    games.push(game);
+                }
+                None => skipped += 1,
+            }
+        }
+
+        if games.is_empty() {
+            info!(
+                lookback = config.game_lookback,
+                game_type = config.game_type,
+                factory = %config.dispute_game_factory_addr,
+                skipped,
+                "no actionable in-progress games; skipping (proposer stall or L2 prune is not a challenger fail)"
+            );
+        }
+
+        Ok(games)
+    }
+
+    async fn intermediate_block_interval(
+        factory: &DisputeGameFactoryContractClient,
+        verifier: &AggregateVerifierContractClient,
+        game_type: u32,
+    ) -> Result<u64> {
+        let impl_address = factory.game_impls(game_type).await?;
+        ensure!(
+            impl_address != Address::ZERO,
+            "no game implementation registered in DisputeGameFactory for game type {game_type}"
+        );
+        let interval = verifier.read_intermediate_block_interval(impl_address).await?;
+        ensure!(interval != 0, "INTERMEDIATE_BLOCK_INTERVAL must be non-zero");
+        Ok(interval)
+    }
+
+    async fn prover_state(
+        verifier: &AggregateVerifierContractClient,
+        game: Address,
+    ) -> Result<ProverState> {
+        let (tee, zk, countered) = tokio::try_join!(
+            verifier.tee_prover(game),
+            verifier.zk_prover(game),
+            verifier.countered_index(game),
+        )?;
+        Ok(ProverState { tee, zk, countered })
+    }
+
+    async fn observe(
+        validator: &OutputValidator<L2Client>,
+        verifier: &AggregateVerifierContractClient,
+        address: Address,
+        index: u64,
+        path: Path,
+        interval: u64,
+    ) -> Result<Option<ObservedGame>> {
+        if path == Path::Challenged {
+            return Self::observe_path2(validator, verifier, address, index, interval).await;
+        }
+
+        let (info, starting_block, intermediate_roots) = tokio::try_join!(
+            verifier.game_info(address),
+            verifier.starting_block_number(address),
+            verifier.intermediate_output_roots(address),
+        )?;
+
+        let params = IntermediateValidationParams {
+            game_address: address,
+            starting_block_number: starting_block,
+            l2_block_number: info.l2_block_number,
+            intermediate_block_interval: interval,
+            claimed_root: info.root_claim,
+            intermediate_roots: &intermediate_roots,
+        };
+
+        match validator.validate_intermediate_roots(params).await {
+            Ok(result) => {
+                let kind = if result.is_valid { Kind::Good } else { Kind::Bad };
+                Ok(Some(ObservedGame { index, address, path, kind }))
+            }
+            Err(error) => {
+                skip_validation(address, index, &error);
+                Ok(None)
+            }
+        }
+    }
+
+    async fn observe_path2(
+        validator: &OutputValidator<L2Client>,
+        verifier: &AggregateVerifierContractClient,
+        address: Address,
+        index: u64,
+        interval: u64,
+    ) -> Result<Option<ObservedGame>> {
+        let state = Self::prover_state(verifier, address).await?;
+        let challenged_index = state.countered.saturating_sub(1);
+        let (on_chain_root, starting_block) = tokio::try_join!(
+            verifier.intermediate_output_root(address, challenged_index),
+            verifier.starting_block_number(address),
+        )?;
+        let Some(checkpoint_block) = checkpoint_block(starting_block, interval, challenged_index)
+        else {
+            warn!(game = %address, challenged_index, "checkpoint arithmetic overflow; skipping");
+            return Ok(None);
+        };
+
+        match validator
+            .validate_claimed_root_at_block(address, checkpoint_block, on_chain_root)
+            .await
+        {
+            Ok(result) if result.is_valid => Ok(Some(ObservedGame {
+                index,
+                address,
+                path: Path::Challenged,
+                kind: Kind::FraudulentChallenge,
+            })),
+            Ok(_) => {
+                info!(
+                    game = %address,
+                    factory_index = index,
+                    challenged_index,
+                    "skipping Path 2 game; original root is wrong (legitimate challenge)"
+                );
+                Ok(None)
+            }
+            Err(error) => {
+                skip_validation(address, index, &error);
+                Ok(None)
+            }
+        }
+    }
+
+    fn evaluate(
+        games: &[ObservedGame],
+        states: &[ProverState],
+        scrape: &Scrape,
+        baseline: Option<&Scrape>,
+        all_good: bool,
+    ) -> Eval {
+        debug_assert_eq!(games.len(), states.len());
+
+        let mut pending = Vec::new();
+        for (game, state) in games.iter().zip(states) {
+            if !game_was_scanned(scrape, game.index) {
+                pending.push(format!("{} not scanned", game.address));
+                continue;
+            }
+            match game.kind {
+                Kind::Good => {
+                    if !state.is_undisputed(game.path) {
+                        return Eval::Fail(eyre::eyre!(
+                            "good game {} was disputed (tee={} zk={} countered={})",
+                            game.address,
+                            state.tee,
+                            state.zk,
+                            state.countered
+                        ));
+                    }
+                }
+                Kind::Bad => {
+                    if !state.is_disputed(game.path) {
+                        pending.push(format!("{} not disputed", game.address));
+                    }
+                }
+                Kind::FraudulentChallenge => {
+                    if state.zk != Address::ZERO {
+                        pending.push(format!(
+                            "{} fraudulent ZK challenge not nullified",
+                            game.address
+                        ));
+                    }
+                }
+            }
+        }
+
+        if !pending.is_empty() {
+            return Eval::Pending(pending);
+        }
+
+        if all_good && let Some(before) = baseline {
+            for metric in ACTION_METRICS {
+                let delta = scrape.sum(metric) - before.sum(metric);
+                if delta != 0.0 {
+                    return Eval::Fail(eyre::eyre!(
+                        "{metric} advanced by {delta} while every observed game was good"
+                    ));
+                }
+            }
+        }
+
+        Eval::Pass
+    }
+
+    /// Polls L1 and metrics until pass, a terminal fail, or the window elapses.
+    ///
+    /// A missing scan is pending, not a fail. Transient RPC/metrics errors are
+    /// retried. A good game that was disputed, or action counters moving on an
+    /// all-good window, fail immediately.
+    async fn await_pass(
+        config: &Config,
+        verifier: &AggregateVerifierContractClient,
+        games: &[ObservedGame],
+        baseline: Option<&Scrape>,
+        all_good: bool,
+    ) -> Result<()> {
+        let mut last_error = None;
+        let mut last_pending = Vec::new();
+        match tokio::time::timeout(config.window, async {
+            loop {
+                match Self::tick(config, verifier, games, baseline, all_good).await {
+                    Ok(Eval::Pass) => return Ok(()),
+                    Ok(Eval::Pending(pending)) => last_pending = pending,
+                    Ok(Eval::Fail(error)) => return Err(error),
+                    Err(error) => {
+                        warn!(error = %error, "poll failed; retrying");
+                        last_error = Some(error);
+                    }
+                }
+                tokio::time::sleep(config.poll_interval).await;
+            }
+        })
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => {
+                let msg = format!(
+                    "timed out after {:?} waiting for the live challenger to satisfy FORT",
+                    config.window
+                );
+                if !last_pending.is_empty() {
+                    bail!("{msg}: {}", last_pending.join("; "));
+                }
+                match last_error {
+                    Some(error) => Err(error.wrap_err(msg)),
+                    None => bail!("{msg}"),
+                }
+            }
+        }
+    }
+
+    async fn tick(
+        config: &Config,
+        verifier: &AggregateVerifierContractClient,
+        games: &[ObservedGame],
+        baseline: Option<&Scrape>,
+        all_good: bool,
+    ) -> Result<Eval> {
+        let scrape = Scrape::fetch(&config.challenger_metrics_url).await?;
+        let mut states = Vec::with_capacity(games.len());
+        for game in games {
+            states.push(Self::prover_state(verifier, game.address).await?);
+        }
+        Ok(Self::evaluate(games, &states, &scrape, baseline, all_good))
+    }
+}
+
+/// Outcome of one evaluation tick.
+#[derive(Debug)]
+enum Eval {
+    Pass,
+    Pending(Vec<String>),
+    Fail(eyre::Report),
+}
+
+impl Path {
+    fn classify(state: ProverState) -> Option<Self> {
+        let has_tee = state.tee != Address::ZERO;
+        let has_zk = state.zk != Address::ZERO;
+        match (has_tee, has_zk, state.countered) {
+            (true, false, 0) => Some(Self::TeeOnly),
+            (true, true, 0) => Some(Self::Dual),
+            (true, true, ci) if ci > 0 => Some(Self::Challenged),
+            (false, true, 0) => Some(Self::ZkOnly),
+            _ => None,
+        }
+    }
+}
+
+impl ProverState {
+    /// Still the undisputed shape for this path.
+    fn is_undisputed(self, path: Path) -> bool {
+        match path {
+            Path::TeeOnly => {
+                self.tee != Address::ZERO && self.zk == Address::ZERO && self.countered == 0
+            }
+            Path::ZkOnly => {
+                self.tee == Address::ZERO && self.zk != Address::ZERO && self.countered == 0
+            }
+            Path::Dual => {
+                self.tee != Address::ZERO && self.zk != Address::ZERO && self.countered == 0
+            }
+            Path::Challenged => false,
+        }
+    }
+
+    /// On-chain dispute matching this path's expected shape.
+    fn is_disputed(self, path: Path) -> bool {
+        match path {
+            Path::TeeOnly => path1_disputed(self.tee, self.zk, self.countered),
+            Path::ZkOnly | Path::Challenged => self.zk == Address::ZERO,
+            Path::Dual => self.tee == Address::ZERO,
+        }
+    }
+}
+
+fn path1_disputed(tee: Address, zk: Address, countered: u64) -> bool {
+    tee == Address::ZERO || (zk != Address::ZERO && countered != 0)
+}
+
+fn game_was_scanned(scrape: &Scrape, index: u64) -> bool {
+    let scanned = scrape.sum("base_challenger_games_scanned_total");
+    if scanned <= 0.0 {
+        return false;
+    }
+    let head = scrape.sum("base_challenger_scan_head");
+    // A finished scan sets `scan_head` to the last factory index. Absent
+    // `scan_head` (sum 0) still counts as coverage when the counter moved:
+    // one scan evaluates the whole post-anchor range, which includes the
+    // lookback tail FORT inspects.
+    head >= index as f64 || head == 0.0
+}
+
+fn skip_validation(address: Address, index: u64, error: &ValidatorError) {
+    match error {
+        ValidatorError::BlockNotAvailable { .. } | ValidatorError::Rpc(_) => {
+            info!(
+                game = %address,
+                factory_index = index,
+                error = %error,
+                "L2 prune or block not available; skipping game"
+            );
+        }
+        _ => {
+            info!(game = %address, factory_index = index, error = %error, "skipping game");
+        }
+    }
+}
+
+fn checkpoint_block(starting_block: u64, interval: u64, challenged_index: u64) -> Option<u64> {
+    let offset = interval.checked_mul(challenged_index.checked_add(1)?)?;
+    starting_block.checked_add(offset)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn addr(byte: u8) -> Address {
+        Address::repeat_byte(byte)
+    }
+
+    #[test]
+    fn path1_disputed_tee_cleared_or_zk_challenge() {
+        assert!(path1_disputed(Address::ZERO, Address::ZERO, 0));
+        assert!(path1_disputed(Address::ZERO, addr(0xCC), 0));
+        assert!(path1_disputed(addr(0xEE), addr(0xCC), 3));
+        assert!(!path1_disputed(addr(0xEE), Address::ZERO, 0));
+    }
+
+    #[test]
+    fn good_path1_stays_undisputed() {
+        let state = ProverState { tee: addr(0xEE), zk: Address::ZERO, countered: 0 };
+        assert!(state.is_undisputed(Path::TeeOnly));
+        assert!(!state.is_disputed(Path::TeeOnly));
+    }
+
+    #[test]
+    fn path3_and_path4_dispute_shapes() {
+        let path3 = ProverState { tee: Address::ZERO, zk: addr(0xCC), countered: 0 };
+        assert!(path3.is_undisputed(Path::ZkOnly));
+        assert!(
+            ProverState { tee: Address::ZERO, zk: Address::ZERO, countered: 0 }
+                .is_disputed(Path::ZkOnly)
+        );
+
+        let path4 = ProverState { tee: addr(0xEE), zk: addr(0xCC), countered: 0 };
+        assert!(path4.is_undisputed(Path::Dual));
+        assert!(
+            ProverState { tee: Address::ZERO, zk: addr(0xCC), countered: 0 }
+                .is_disputed(Path::Dual)
+        );
+    }
+
+    #[test]
+    fn scan_coverage_requires_head_or_counter() {
+        let scrape =
+            Scrape::parse("base_challenger_scan_head 40\nbase_challenger_games_scanned_total 10\n");
+        assert!(game_was_scanned(&scrape, 40));
+        assert!(game_was_scanned(&scrape, 10));
+        assert!(!game_was_scanned(&scrape, 41));
+
+        let counter_only = Scrape::parse("base_challenger_games_scanned_total 3\n");
+        assert!(game_was_scanned(&counter_only, 5));
+    }
+
+    #[test]
+    fn evaluate_pending_until_scanned() {
+        let game =
+            ObservedGame { index: 7, address: addr(0x11), path: Path::TeeOnly, kind: Kind::Good };
+        let state = ProverState { tee: addr(0xEE), zk: Address::ZERO, countered: 0 };
+        let scrape = Scrape::parse("base_challenger_games_scanned_total 0\n");
+        assert!(matches!(
+            ChallengerFort::evaluate(&[game], &[state], &scrape, None, true),
+            Eval::Pending(_)
+        ));
+    }
+
+    #[test]
+    fn evaluate_fails_when_good_game_is_disputed() {
+        let game =
+            ObservedGame { index: 7, address: addr(0x11), path: Path::TeeOnly, kind: Kind::Good };
+        let state = ProverState { tee: Address::ZERO, zk: Address::ZERO, countered: 0 };
+        let scrape =
+            Scrape::parse("base_challenger_scan_head 7\nbase_challenger_games_scanned_total 1\n");
+        assert!(matches!(
+            ChallengerFort::evaluate(&[game], &[state], &scrape, None, true),
+            Eval::Fail(_)
+        ));
+    }
+}

--- a/crates/infra/challenger-fort/src/challenger_fort.rs
+++ b/crates/infra/challenger-fort/src/challenger_fort.rs
@@ -258,7 +258,7 @@ impl ChallengerFort {
                 Ok(Some(ObservedGame { index, address, path, kind }))
             }
             Err(error) => {
-                skip_validation(address, index, &error);
+                skip_or_fail(address, index, error)?;
                 Ok(None)
             }
         }
@@ -303,7 +303,7 @@ impl ChallengerFort {
                 Ok(None)
             }
             Err(error) => {
-                skip_validation(address, index, &error);
+                skip_or_fail(address, index, error)?;
                 Ok(None)
             }
         }
@@ -359,7 +359,7 @@ impl ChallengerFort {
         if all_good && let Some(before) = baseline {
             for metric in ACTION_METRICS {
                 let delta = scrape.sum(metric) - before.sum(metric);
-                if delta != 0.0 {
+                if delta.round() as i64 != 0 {
                     return Eval::Fail(eyre::eyre!(
                         "{metric} advanced by {delta} while every observed game was good"
                     ));
@@ -496,10 +496,12 @@ fn game_was_scanned(scrape: &Scrape, index: u64) -> bool {
     // `scan_head` (sum 0) still counts as coverage when the counter moved:
     // one scan evaluates the whole post-anchor range, which includes the
     // lookback tail FORT inspects.
-    head >= index as f64 || head == 0.0
+    head == 0.0 || head as u64 >= index
 }
 
-fn skip_validation(address: Address, index: u64, error: &ValidatorError) {
+/// Skips only L2 prune / transient RPC. Other validator errors are real
+/// divergence and fail the run.
+fn skip_or_fail(address: Address, index: u64, error: ValidatorError) -> Result<()> {
     match error {
         ValidatorError::BlockNotAvailable { .. } | ValidatorError::Rpc(_) => {
             info!(
@@ -508,10 +510,11 @@ fn skip_validation(address: Address, index: u64, error: &ValidatorError) {
                 error = %error,
                 "L2 prune or block not available; skipping game"
             );
+            Ok(())
         }
-        _ => {
-            info!(game = %address, factory_index = index, error = %error, "skipping game");
-        }
+        other => Err(other).wrap_err(format!(
+            "validation failed for game {address} at factory index {index}"
+        )),
     }
 }
 

--- a/crates/infra/challenger-fort/src/challenger_fort.rs
+++ b/crates/infra/challenger-fort/src/challenger_fort.rs
@@ -512,9 +512,8 @@ fn skip_or_fail(address: Address, index: u64, error: ValidatorError) -> Result<(
             );
             Ok(())
         }
-        other => Err(other).wrap_err(format!(
-            "validation failed for game {address} at factory index {index}"
-        )),
+        other => Err(other)
+            .wrap_err(format!("validation failed for game {address} at factory index {index}")),
     }
 }
 

--- a/crates/infra/challenger-fort/src/config.rs
+++ b/crates/infra/challenger-fort/src/config.rs
@@ -1,0 +1,64 @@
+//! Environment-driven configuration for the challenger FORT observer.
+//!
+//! The `BASE_CHALLENGER_*` variables are shared with the live Challenger —
+//! both source the same config-service mapping — so the observer looks at
+//! exactly the L1 and factory the Challenger is configured against. The
+//! `CHALLENGER_FORT_*` variables belong to the observer alone.
+
+use std::time::Duration;
+
+use alloy_primitives::Address;
+use clap::Parser;
+use url::Url;
+
+/// Runtime configuration for [`crate::ChallengerFort`].
+#[derive(Debug, Parser)]
+#[command(name = "challenger-fort", version, about, long_about = None)]
+pub struct Config {
+    /// Live L1 RPC. Only ever read from.
+    #[arg(long = "l1-eth-rpc", env = "BASE_CHALLENGER_L1_ETH_RPC")]
+    pub l1_eth_rpc: Url,
+
+    /// L2 RPC used to compute canonical output roots.
+    #[arg(long = "l2-eth-rpc", env = "BASE_CHALLENGER_L2_ETH_RPC")]
+    pub l2_eth_rpc: Url,
+
+    /// Address of the `DisputeGameFactory` contract on L1.
+    #[arg(long = "dispute-game-factory-addr", env = "BASE_CHALLENGER_DISPUTE_GAME_FACTORY_ADDR")]
+    pub dispute_game_factory_addr: Address,
+
+    /// Game type ID for `AggregateVerifier` dispute games.
+    #[arg(long = "game-type", env = "BASE_CHALLENGER_GAME_TYPE")]
+    pub game_type: u32,
+
+    /// Prometheus endpoint of the live Challenger.
+    #[arg(
+        long = "challenger-metrics-url",
+        env = "CHALLENGER_FORT_CHALLENGER_METRICS_URL",
+        default_value = "http://base-challenger:7300/metrics"
+    )]
+    pub challenger_metrics_url: Url,
+
+    /// How far back through factory indices to look for in-progress games.
+    #[arg(long = "game-lookback", env = "CHALLENGER_FORT_GAME_LOOKBACK", default_value = "50")]
+    pub game_lookback: u64,
+
+    /// Observation budget. FORT polls until this elapses or the pass
+    /// conditions hold.
+    #[arg(
+        long = "window",
+        env = "CHALLENGER_FORT_WINDOW",
+        default_value = "10m",
+        value_parser = humantime::parse_duration
+    )]
+    pub window: Duration,
+
+    /// Interval between observer polls of L1 and the metrics endpoint.
+    #[arg(
+        long = "poll-interval",
+        env = "CHALLENGER_FORT_POLL_INTERVAL",
+        default_value = "5s",
+        value_parser = humantime::parse_duration
+    )]
+    pub poll_interval: Duration,
+}

--- a/crates/infra/challenger-fort/src/lib.rs
+++ b/crates/infra/challenger-fort/src/lib.rs
@@ -1,0 +1,10 @@
+#![doc = include_str!("../README.md")]
+
+mod config;
+pub use config::Config;
+
+mod metrics;
+pub use metrics::Scrape;
+
+mod challenger_fort;
+pub use challenger_fort::ChallengerFort;

--- a/crates/infra/challenger-fort/src/metrics.rs
+++ b/crates/infra/challenger-fort/src/metrics.rs
@@ -1,0 +1,104 @@
+//! Minimal Prometheus text-exposition scraper for the live challenger.
+
+use eyre::{Context, Result};
+use url::Url;
+
+/// One scrape of a Prometheus `/metrics` endpoint.
+///
+/// Series are kept as `(name, labels, value)` rather than parsed into a typed
+/// model; the observer only ever sums counters and reads gauges.
+#[derive(Debug, Default)]
+pub struct Scrape {
+    series: Vec<(String, String, f64)>,
+}
+
+impl Scrape {
+    /// Fetches and parses the endpoint.
+    pub async fn fetch(url: &Url) -> Result<Self> {
+        let body = reqwest::get(url.clone())
+            .await
+            .with_context(|| format!("failed to scrape {url}"))?
+            .error_for_status()
+            .with_context(|| format!("{url} returned an error status"))?
+            .text()
+            .await
+            .with_context(|| format!("failed to read the response body from {url}"))?;
+        Ok(Self::parse(&body))
+    }
+
+    /// Sum of every series sharing `name`, or `0.0` when the metric is absent.
+    ///
+    /// Absent-as-zero is what makes the assertions readable: a counter that has
+    /// never been incremented is not exported at all, and that is the same
+    /// thing as "it did not happen".
+    pub fn sum(&self, name: &str) -> f64 {
+        self.series
+            .iter()
+            .filter(|(series_name, ..)| series_name == name)
+            .map(|(.., value)| value)
+            .sum()
+    }
+
+    /// Sum of every series sharing `name` whose label set mentions `label`.
+    ///
+    /// A substring match keeps the caller free of label-ordering and quoting
+    /// concerns; label values in this crate's metrics are distinct enough that
+    /// it cannot alias.
+    pub fn label_sum(&self, name: &str, label: &str) -> f64 {
+        self.series
+            .iter()
+            .filter(|(series_name, labels, _)| series_name == name && labels.contains(label))
+            .map(|(.., value)| value)
+            .sum()
+    }
+
+    pub(crate) fn parse(body: &str) -> Self {
+        let series = body
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty() && !line.starts_with('#'))
+            .filter_map(|line| {
+                // Prometheus allows an optional timestamp after the value.
+                let (key, rest) = line.split_once(' ')?;
+                let value = rest.split_whitespace().next()?.parse::<f64>().ok()?;
+                let (name, labels) = key
+                    .split_once('{')
+                    .map_or((key, ""), |(name, labels)| (name, labels.trim_end_matches('}')));
+                Some((name.to_string(), labels.to_string(), value))
+            })
+            .collect();
+        Self { series }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Scrape;
+
+    #[test]
+    fn parses_counters_gauges_and_labels() {
+        let scrape = Scrape::parse(
+            r#"
+            # HELP base_challenger_up Challenger is running
+            # TYPE base_challenger_up gauge
+            base_challenger_up 1
+            base_challenger_games_scanned_total 42
+            base_challenger_nullify_tx_outcome_total{status="success"} 3
+            base_challenger_nullify_tx_outcome_total{status="reverted"} 2
+            "#,
+        );
+
+        assert_eq!(scrape.sum("base_challenger_up"), 1.0);
+        assert_eq!(scrape.sum("base_challenger_games_scanned_total"), 42.0);
+        assert_eq!(scrape.sum("base_challenger_nullify_tx_outcome_total"), 5.0);
+        assert_eq!(scrape.label_sum("base_challenger_nullify_tx_outcome_total", "reverted"), 2.0);
+        // A counter that never fired is not exported, and reads as zero.
+        assert_eq!(scrape.sum("base_challenger_challenge_tx_submitted_total"), 0.0);
+    }
+
+    #[test]
+    fn ignores_optional_prometheus_timestamp() {
+        let scrape = Scrape::parse("base_challenger_up 1 1710000000000\n");
+        assert_eq!(scrape.sum("base_challenger_up"), 1.0);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `base-challenger-fort`, an observer that talks to live L1 and the live Challenger after deploy. It never forks, never plants a game, and never probes `/healthz` or `/readyz`.
- **Good games** (intermediate roots match L2): pass requires scan coverage (`scan_head` or `games_scanned_total > 0`) and the game still undisputed. If every observed game is good, invalid/nullify/challenge counters stay flat.
- **Bad games** (roots do not match L2): pass requires scan plus an on-chain dispute in the Path 1/3/4/2 shape. L2 prune / `BlockNotAvailable` skips that game.
- **No in-progress games** of the right type: log skip and exit 0 (Proposer stall is not a Challenger fail).
- Window is `CHALLENGER_FORT_WINDOW` (default 10m), not a fixed 30 minutes. FORT polls until the window elapses or the pass conditions hold.
- Consumed later by base-proofs as a post-zeronet Job.

## Test plan
- [x] `cargo test -p base-challenger-fort --all-targets`
- [x] `cargo clippy -p base-challenger-fort --all-targets -- -D warnings`
- [ ] Wire the FORT Job in base-proofs against `base-challenger:7300`


Made with [Cursor](https://cursor.com)