### PR TITLE
feat(batcher): make the receipt query interval configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3283,6 +3283,7 @@ dependencies = [
  "base-tx-manager",
  "clap",
  "eyre",
+ "humantime",
  "serde",
  "tracing",
  "url",

--- a/bin/batcher/Cargo.toml
+++ b/bin/batcher/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 [dependencies]
 url.workspace = true
 eyre.workspace = true
+humantime.workspace = true
 async-trait.workspace = true
 base-alt-da.workspace = true
 base-protocol.workspace = true

--- a/bin/batcher/src/cli.rs
+++ b/bin/batcher/src/cli.rs
@@ -204,6 +204,21 @@ pub(crate) struct BatcherArgs {
     )]
     pub resubmission_timeout_secs: u64,
 
+    /// Interval between receipt query attempts (e.g. "2s").
+    ///
+    /// A submitted transaction is only observed as mined on a poll tick, so
+    /// this also bounds how long an already-mined transaction still looks
+    /// pending. While it stays well above the L1 block time, the fee bump at
+    /// `--resubmission-timeout` can fire against a transaction that is already
+    /// mined, which surfaces as `nonce too low`.
+    #[arg(
+        long = "receipt-query-interval",
+        default_value = "12s",
+        env = "BATCHER_RECEIPT_QUERY_INTERVAL",
+        value_parser = humantime::parse_duration
+    )]
+    pub receipt_query_interval: Duration,
+
     /// DA backlog threshold in bytes at which throttling activates.
     ///
     /// When the estimated unsubmitted DA backlog exceeds this value, the batcher
@@ -372,6 +387,7 @@ impl BatcherArgs {
             max_pending_transactions: self.max_pending_transactions,
             num_confirmations: self.num_confirmations,
             resubmission_timeout: Duration::from_secs(self.resubmission_timeout_secs),
+            receipt_query_interval: self.receipt_query_interval,
             throttle: if self.no_throttle {
                 None
             } else {
@@ -743,6 +759,22 @@ mod tests {
         assert_eq!(config.l1_rpc_url[0].as_str(), "http://localhost:8545/");
         assert_eq!(config.l1_rpc_url[1].as_str(), "http://l1-a:8545/");
         assert_eq!(config.l1_rpc_url[3].as_str(), "http://l1-c:8545/");
+    }
+
+    #[test]
+    fn receipt_query_interval_defaults_to_the_tx_manager_default() {
+        let cli = parse_cli(&[]);
+        let config = cli.args.into_config().expect("config should build");
+
+        assert_eq!(config.receipt_query_interval, Duration::from_secs(12));
+    }
+
+    #[test]
+    fn into_config_accepts_receipt_query_interval() {
+        let cli = parse_cli(&["--receipt-query-interval", "2s"]);
+        let config = cli.args.into_config().expect("config should build");
+
+        assert_eq!(config.receipt_query_interval, Duration::from_secs(2));
     }
 
     #[test]

--- a/crates/batcher/service/src/config.rs
+++ b/crates/batcher/service/src/config.rs
@@ -88,6 +88,8 @@ pub struct BatcherConfig {
     pub num_confirmations: usize,
     /// Timeout before resubmitting a transaction.
     pub resubmission_timeout: Duration,
+    /// Interval between receipt polls for a submitted transaction.
+    pub receipt_query_interval: Duration,
     /// Throttle configuration (optional).
     pub throttle: Option<ThrottleConfig>,
     /// Number of recent L1 blocks to scan on startup for already-submitted batcher frames.
@@ -157,6 +159,7 @@ impl Default for BatcherConfig {
             max_pending_transactions: 1,
             num_confirmations: 1,
             resubmission_timeout: Duration::from_secs(48),
+            receipt_query_interval: Duration::from_secs(12),
             throttle: Some(ThrottleConfig::default()),
             check_recent_txs_depth: 0,
             admin_addr: None,

--- a/crates/batcher/service/src/service.rs
+++ b/crates/batcher/service/src/service.rs
@@ -829,9 +829,11 @@ impl BatcherService {
             .map_err(|e| eyre::eyre!("failed to fetch L1 chain ID: {e}"))?;
         let tx_manager_config = TxManagerConfig {
             resubmission_timeout: self.config.resubmission_timeout,
+            receipt_query_interval: self.config.receipt_query_interval,
             num_confirmations: self.config.num_confirmations as u64,
             ..TxManagerConfig::default()
         };
+        tx_manager_config.validate().map_err(|e| eyre::eyre!("invalid tx manager config: {e}"))?;
         let tx_manager = SimpleTxManager::new(
             l1_provider,
             signer_config,


### PR DESCRIPTION
## Summary

The batcher assembles its `TxManagerConfig` from a struct literal that sets only `resubmission_timeout` and `num_confirmations`:

```rust
let tx_manager_config = TxManagerConfig {
    resubmission_timeout: self.config.resubmission_timeout,
    num_confirmations: self.config.num_confirmations as u64,
    ..TxManagerConfig::default()
};
```

so `receipt_query_interval` silently takes the crate default of **12s** and no operator can change it. The proposer and challenger both get this knob from `define_tx_manager_cli!`; the batcher never wired that macro up and hand-rolls its own transaction arguments instead, so it was simply missed.

Two consequences on a chain with a ~2s block time:

- Every submission is observed as confirmed a full poll interval after it was actually mined. Confirmations land only on multiples of the interval, never between ticks.
- The default `resubmission_timeout` (48s) is an **exact multiple** of the 12s poll, so the fee-bump timer and the fourth receipt poll fire on the same tick. `try_fee_bump` skips the bump only when the poller has *already* recorded the tx on-chain, and at that instant it has not — so the bump goes out against a transaction that is already mined and comes back `nonce too low`. The error is benign (`apply_bump_result_with_suppression` swallows the abort and the original receipt still lands) but it is persistent log noise that looks like a real nonce problem.

This adds `--receipt-query-interval` / `BATCHER_RECEIPT_QUERY_INTERVAL`, **defaulting to `12s` so behaviour is unchanged**, and validates the assembled `TxManagerConfig` so a zero interval or timeout is rejected at startup instead of spinning the poll loop (`resubmission_timeout` was previously unvalidated too).

The value is parsed with `humantime` rather than as bare integer seconds — matching the flag the shared macro generates for the proposer and challenger, so the same `2s` env value works across all three services and a future migration onto `define_tx_manager_cli!` needs no config change.

Deliberately **not** switching the batcher over to `define_tx_manager_cli!` wholesale: that would redefine `BATCHER_RESUBMISSION_TIMEOUT` from bare integer seconds to a humantime string, collide `--num-confirmations` with `--tx-manager.num-confirmations`, and change that default from 1 to 10. Worth doing, but as its own change.

## Test plan

- [x] `cargo test -p base-batcher-bin` — 33 pass, including two new cases asserting the default is still 12s and that `--receipt-query-interval 2s` reaches `BatcherConfig`
- [x] `cargo test -p base-batcher-service` — 37 pass
- [x] `cargo clippy -p base-batcher-bin -p base-batcher-service --all-targets` clean, `cargo fmt --check` clean
- [x] `base-batcher --help` shows the flag with `[env: BATCHER_RECEIPT_QUERY_INTERVAL=]` and `[default: 12s]`

Made with [Cursor](https://cursor.com)