### PR TITLE
perf(bench): Share Build Cache Across Commits

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -20,31 +20,35 @@ permissions:
 jobs:
   # Base and head are benchmarked on the *same* physical runner, back to back, so a
   # reported delta reflects the code change rather than variance between two hosts.
-  # (Per-benchmark interleaving would tighten this further and is a possible follow-up.)
+  #
+  # A single working tree is git-switched between the base and head commits and both
+  # passes build into one shared target dir. Because the tree is at the same path for
+  # both, cargo's fingerprints match for every crate the PR did not touch, so the
+  # second pass is incremental over the first — only the changed crates and the bench
+  # binaries recompile, instead of building the whole dependency graph twice. Base is
+  # built first, so the run ends on the head tree for the compare/comment steps.
+  # (Per-benchmark interleaving would tighten the timing further and is a follow-up.)
   bench:
     name: Benchmarks (advisory)
     runs-on:
       group: BasePerfRunnerGroup
     timeout-minutes: 90
+    env:
+      HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
-      # Head is the root checkout so ./.github/actions/setup and the compare script
-      # resolve at the workspace root; base is checked out alongside it into base-src.
+      # Single checkout at HEAD_SHA. The tree is switched to the base commit for the
+      # first pass and back to head for the second; ./.github/actions/setup and the
+      # compare script resolve at the workspace root either way.
       - name: Checkout head
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 1
-
-      - name: Checkout base
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
-          path: base-src
           fetch-depth: 1
 
       - uses: ./.github/actions/setup
@@ -54,23 +58,42 @@ jobs:
           rust-cache-shared-key: "benchmark"
           just: "false"
 
-      # Advisory only: a bench that fails to compile or run must not fail the job.
-      # A bench that runs on base but breaks on head simply produces no head result,
-      # which the comparison step surfaces as lost coverage. The curated subset lives
-      # in run_bench_subset.sh so a single list runs against both trees — see that
-      # script for why these particular benches were chosen. Both steps invoke the
-      # *head* checkout's copy (via GITHUB_WORKSPACE) so the base run cannot use a
-      # stale list from the base commit; only the working directory differs.
+      # Fetch the base commit so the single tree can be switched to it, and hoist the
+      # head checkout's authoritative bench list out of the tree so both passes run
+      # the *same* list even while the tree is switched to the base commit — the base
+      # run cannot use a stale list from the base commit. See run_bench_subset.sh for
+      # why these particular benches were chosen.
+      - name: Prepare base commit and bench list
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth 1 origin "$BASE_SHA"
+          cp etc/scripts/ci/run_bench_subset.sh "$RUNNER_TEMP/run_bench_subset.sh"
+
+      # Advisory only: a bench that fails to compile or run must not fail the job. A
+      # bench that runs on base but breaks on head simply produces no head result,
+      # which the comparison step surfaces as lost coverage. The tree switches are NOT
+      # continue-on-error: if a checkout fails the whole comparison is invalid, so it
+      # must fail loudly rather than benchmark the wrong commit. --force discards any
+      # tracked-file edits from setup; it never touches the ignored target dir, so the
+      # shared criterion results and build artifacts survive both switches.
+      - name: Switch tree to base commit
+        shell: bash
+        run: git checkout --force --detach "$BASE_SHA"
+
       - name: Run benchmark subset (base)
         continue-on-error: true
-        working-directory: base-src
         shell: bash
-        run: bash "$GITHUB_WORKSPACE/etc/scripts/ci/run_bench_subset.sh"
+        run: bash "$RUNNER_TEMP/run_bench_subset.sh" pr-base
+
+      - name: Switch tree to head commit
+        shell: bash
+        run: git checkout --force --detach "$HEAD_SHA"
 
       - name: Run benchmark subset (head)
         continue-on-error: true
         shell: bash
-        run: bash "$GITHUB_WORKSPACE/etc/scripts/ci/run_bench_subset.sh"
+        run: bash "$RUNNER_TEMP/run_bench_subset.sh" pr-head
 
       - name: Set up Python 3.13
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -85,8 +108,9 @@ jobs:
         run: |
           set -euo pipefail
           python3 etc/scripts/ci/bench_compare.py \
-            --base-dir base-src/target/criterion \
-            --head-dir target/criterion \
+            --criterion-dir target/criterion \
+            --base-baseline pr-base \
+            --head-baseline pr-head \
             --output "$RUNNER_TEMP/bench-comment.md" \
             --run-url "$WORKFLOW_RUN_URL" \
             --threshold-pct 10 \

--- a/etc/scripts/ci/bench_compare.py
+++ b/etc/scripts/ci/bench_compare.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Render a criterion base-vs-head benchmark comparison into a PR comment body.
 
-Reads two trees of criterion output (one benchmarked on the PR base commit, one
-on the PR head commit), matches benchmarks by their criterion id, and emits an
-advisory Markdown table of the median-time delta. This never gates a merge; it is
-visibility only.
+Reads two named baselines from a single criterion tree (one saved on the PR base
+commit, one on the PR head commit — the workflow builds both into one shared target
+dir), matches benchmarks by their criterion id, and emits an advisory Markdown table
+of the median-time delta. This never gates a merge; it is visibility only.
 
 A wall-clock delta is only flagged as a regression or improvement when it clears
 the percentage threshold *and* the two medians' confidence intervals do not
@@ -40,16 +40,18 @@ class BenchCompare:
         self.improvement_pct = improvement_pct
 
     @staticmethod
-    def collect(root: Path) -> dict[str, Measurement]:
-        """Map criterion benchmark id -> Measurement under root.
+    def collect(root: Path, baseline: str) -> dict[str, Measurement]:
+        """Map criterion benchmark id -> Measurement for one baseline under root.
 
-        A criterion result lives at `<root>/<id...>/current/estimates.json`. The id
-        is every path component between the artifact root and the `current` baseline
-        directory, so ids are identical across the two trees regardless of how the
-        upload step stripped any shared path prefix.
+        A criterion result lives at `<root>/<id...>/<baseline>/estimates.json`. The
+        id is every path component between the artifact root and the baseline
+        directory, so ids are identical across the two baselines and the comparison
+        lines up regardless of how deep each bench nests under the tree.
         """
         results: dict[str, Measurement] = {}
-        for estimates in root.rglob("current/estimates.json"):
+        for estimates in root.rglob("estimates.json"):
+            if estimates.parent.name != baseline:
+                continue
             bench_id = "/".join(estimates.relative_to(root).parts[:-2])
             if not bench_id:
                 continue
@@ -156,10 +158,16 @@ class BenchCompare:
         """Render a `bench (+d%)` list for an alert summary."""
         return ", ".join(f"`{b}` ({self.delta_pct(base[b], head[b]):+.1f}%)" for b in ids)
 
-    def render(self, base_dir: Path, head_dir: Path, run_url: str) -> tuple[str, bool]:
+    def render(
+        self,
+        criterion_dir: Path,
+        base_baseline: str,
+        head_baseline: str,
+        run_url: str,
+    ) -> tuple[str, bool]:
         """Render the comment body, returning it and whether it warrants a comment."""
-        base = self.collect(base_dir)
-        head = self.collect(head_dir)
+        base = self.collect(criterion_dir, base_baseline)
+        head = self.collect(criterion_dir, head_baseline)
         bench_ids = sorted(set(base) | set(head))
         regressed = [b for b in bench_ids if self.is_regression(base.get(b), head.get(b))]
         improved = [b for b in bench_ids if self.is_improvement(base.get(b), head.get(b))]
@@ -236,8 +244,9 @@ class BenchCompare:
 def parse_args() -> argparse.Namespace:
     """Parse CLI arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--base-dir", type=Path, required=True)
-    parser.add_argument("--head-dir", type=Path, required=True)
+    parser.add_argument("--criterion-dir", type=Path, required=True)
+    parser.add_argument("--base-baseline", default="pr-base")
+    parser.add_argument("--head-baseline", default="pr-head")
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--run-url", required=True)
     parser.add_argument("--threshold-pct", type=float, default=10.0)
@@ -250,7 +259,7 @@ def main() -> int:
     """Entry point for the benchmark comparison renderer."""
     args = parse_args()
     body, should_comment = BenchCompare(args.threshold_pct, args.improvement_pct).render(
-        args.base_dir, args.head_dir, args.run_url
+        args.criterion_dir, args.base_baseline, args.head_baseline, args.run_url
     )
     args.output.write_text(body, encoding="utf-8")
     if args.github_output is not None:

--- a/etc/scripts/ci/run_bench_subset.sh
+++ b/etc/scripts/ci/run_bench_subset.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
 # Runs the curated advisory benchmark subset in the current working directory,
-# saving each result under the `current` criterion baseline for base-vs-head
-# comparison.
+# saving each result under the criterion baseline named by the first argument
+# (default: `current`) for base-vs-head comparison.
 #
-# bench-pr.yml invokes this once per side (base and head) from the *head* checkout
-# so a single authoritative list runs against both trees; the only difference is the
-# working directory the caller sets. Keeping the list here removes the drift risk of
+# Usage: run_bench_subset.sh [BASELINE]
+#
+# bench-pr.yml invokes this twice from a single checkout — once per commit — after
+# git-switching the working tree between the PR base and head. Both passes share one
+# target dir, so the second build is incremental over the first; passing distinct
+# baseline names ("pr-base" and "pr-head") keeps both results side by side under
+# target/criterion for bench_compare.py to read. The caller runs the *hoisted* copy
+# of this script (outside the tree) for both passes so a single authoritative list
+# runs against both commits: keeping the list here removes the drift risk of
 # duplicating it across two workflow steps, where adding or removing a bench in only
 # one block would surface as a spurious "new"/"missing" coverage change.
 #
@@ -15,23 +21,25 @@
 # because their wall-clock time is too noisy to read per-PR.
 set -uo pipefail
 
+baseline="${1:-current}"
+
 run() { echo "::group::$*"; "$@"; echo "::endgroup::"; }
 
 run cargo bench -p base-proof-mpt --bench trie_node \
-  -- --save-baseline current --noplot
+  -- --save-baseline "$baseline" --noplot
 run cargo bench -p base-protocol --bench batch_transaction \
-  -- --save-baseline current --noplot
+  -- --save-baseline "$baseline" --noplot
 run cargo bench -p base-consensus-derive --bench batch_queue --features test-utils \
-  -- --save-baseline current --noplot
+  -- --save-baseline "$baseline" --noplot
 run cargo bench -p base-common-precompiles --bench base_precompiles --features test-utils \
-  -- --save-baseline current --noplot
+  -- --save-baseline "$baseline" --noplot
 run cargo bench -p base-builder-core --bench tx_selection \
-  -- --save-baseline current --noplot
+  -- --save-baseline "$baseline" --noplot
 run cargo bench -p base-flashblocks-node --bench sender_recovery \
-  -- --save-baseline current sequential --noplot
+  -- --save-baseline "$baseline" sequential --noplot
 run cargo bench -p base-common-flz --bench flz \
-  -- --save-baseline current --noplot
+  -- --save-baseline "$baseline" --noplot
 run cargo bench -p base-common-flashblocks --bench flashblock_decode \
-  -- --save-baseline current --noplot
+  -- --save-baseline "$baseline" --noplot
 run cargo bench -p base-protocol --bench frame_parse \
-  -- --save-baseline current --noplot
+  -- --save-baseline "$baseline" --noplot


### PR DESCRIPTION
## Summary

The advisory benchmark workflow built and ran the base and head commits from two separate checkouts into two separate target directories, which compiled the entire dependency graph twice on every run. This change uses a single checkout and git-switches the working tree between the base and head commits so both passes build into one shared target directory. Because the tree sits at the same path for both passes, cargo's fingerprints match for every crate the PR did not touch, so the second pass only recompiles the changed crates and the bench binaries rather than the whole graph. The two passes save distinct criterion baselines that the comparison script reads from the one tree.
