### PR TITLE
fix(cli-utils): stop logfmt emitting ANSI into the msg field

### DIFF
--- a/crates/utilities/cli/src/tracing.rs
+++ b/crates/utilities/cli/src/tracing.rs
@@ -195,8 +195,9 @@ fn build_stdout_layer<S>(
 where
     S: Subscriber + for<'a> LookupSpan<'a> + Send + Sync,
 {
-    // Log collectors tailing stdout do not strip escape sequences, so the machine-parsed
-    // formats must stay uncolored or the raw `\x1b[..m` bytes are indexed as message text.
+    // `logfmt` renders event fields through the field formatter, which emits escape
+    // sequences when ansi is on, corrupting the `msg="..."` value for log collectors.
+    // The json formatter ignores this flag entirely.
     let colorize =
         matches!(config.format, LogFormat::Full | LogFormat::Compact | LogFormat::Pretty);
 
@@ -208,9 +209,7 @@ where
     match config.format {
         LogFormat::Full => Box::new(base.with_filter(filter)),
         LogFormat::Compact => Box::new(base.compact().with_filter(filter)),
-        // Datadog only reads `message` as a root key; without flattening it stays nested
-        // under `fields` and the whole JSON object is indexed as the log body instead.
-        LogFormat::Json => Box::new(base.json().flatten_event(true).with_filter(filter)),
+        LogFormat::Json => Box::new(base.json().with_filter(filter)),
         LogFormat::Pretty => Box::new(base.pretty().with_filter(filter)),
         LogFormat::Logfmt => Box::new(base.event_format(LogfmtFormatter).with_filter(filter)),
     }
@@ -243,7 +242,7 @@ where
     match config.format {
         LogFormat::Full => Box::new(base.with_filter(filter)),
         LogFormat::Compact => Box::new(base.compact().with_filter(filter)),
-        LogFormat::Json => Box::new(base.json().flatten_event(true).with_filter(filter)),
+        LogFormat::Json => Box::new(base.json().with_filter(filter)),
         LogFormat::Pretty => Box::new(base.pretty().with_filter(filter)),
         LogFormat::Logfmt => Box::new(base.event_format(LogfmtFormatter).with_filter(filter)),
     }

--- a/crates/utilities/cli/src/tracing.rs
+++ b/crates/utilities/cli/src/tracing.rs
@@ -195,15 +195,22 @@ fn build_stdout_layer<S>(
 where
     S: Subscriber + for<'a> LookupSpan<'a> + Send + Sync,
 {
+    // Log collectors tailing stdout do not strip escape sequences, so the machine-parsed
+    // formats must stay uncolored or the raw `\x1b[..m` bytes are indexed as message text.
+    let colorize =
+        matches!(config.format, LogFormat::Full | LogFormat::Compact | LogFormat::Pretty);
+
     let base = tracing_subscriber::fmt::layer()
         .with_writer(io::stdout)
-        .with_ansi(true)
+        .with_ansi(colorize)
         .with_timer(SystemTime);
 
     match config.format {
         LogFormat::Full => Box::new(base.with_filter(filter)),
         LogFormat::Compact => Box::new(base.compact().with_filter(filter)),
-        LogFormat::Json => Box::new(base.json().with_filter(filter)),
+        // Datadog only reads `message` as a root key; without flattening it stays nested
+        // under `fields` and the whole JSON object is indexed as the log body instead.
+        LogFormat::Json => Box::new(base.json().flatten_event(true).with_filter(filter)),
         LogFormat::Pretty => Box::new(base.pretty().with_filter(filter)),
         LogFormat::Logfmt => Box::new(base.event_format(LogfmtFormatter).with_filter(filter)),
     }
@@ -236,7 +243,7 @@ where
     match config.format {
         LogFormat::Full => Box::new(base.with_filter(filter)),
         LogFormat::Compact => Box::new(base.compact().with_filter(filter)),
-        LogFormat::Json => Box::new(base.json().with_filter(filter)),
+        LogFormat::Json => Box::new(base.json().flatten_event(true).with_filter(filter)),
         LogFormat::Pretty => Box::new(base.pretty().with_filter(filter)),
         LogFormat::Logfmt => Box::new(base.event_format(LogfmtFormatter).with_filter(filter)),
     }


### PR DESCRIPTION
## Summary

`build_stdout_layer` hardcoded `.with_ansi(true)` for every `LogFormat`. For `logfmt` that corrupts the output — the field formatter writes escape sequences straight into the `msg="..."` value:

```
time="..." level=INFO target=shadow_metrics msg="Starting shadow-metrics service ^[[3mhttp_addr^[[0m^[[2m=^[[0m0.0.0.0:8080 ..."
```

ANSI is now gated on the human-readable formats. `build_file_layer` already hardcodes `false`; this brings stdout in line for the machine-readable formats only.

## Behavior

Deliberately **not** a behavior change for anything deployed today.

| format | before | after |
|---|---|---|
| `json` | no escapes | no escapes — **byte-identical output** |
| `logfmt` | 28 escapes in a 4-line sample | 0 |
| `full` / `compact` / `pretty` | colored | colored, unchanged |

`json` is unaffected because `tracing-subscriber`'s JSON formatter never consults the ansi flag. That matters because `json` is what's actually in production — `protocols/tips` (ingress-rpc + audit-archiver), `protocols/base`, `base-metal`, `privacy-enclave` and `c3/node-base` all set `<PREFIX>_LOG_FORMAT=json`. Verified by building the binary both ways and diffing stdout: identical.

No deployment currently sets `logfmt`, so this fixes a latent bug rather than changing live output.

`default_value = "full"` is untouched.

### Dropped from the first revision

This branch originally also added `.flatten_event(true)` to the json arm of both layers. That was wrong and has been reverted in the second commit: it would have moved event fields from `data.message.fields.*` to `data.message.*` for every binary already running json, breaking any Datadog query keyed on the old path. It was also unnecessary — the in-house log aggregator already lifts the nested message, which is why tips renders correctly today with `fields.message`.

## Test plan

- [x] `cargo check -p base-cli-utils --all-features`
- [x] `cargo clippy -p base-cli-utils --all-features --all-targets` (no warnings)
- [x] `cargo test -p base-cli-utils --all-features` (10 passed)
- [x] `cargo +nightly fmt -p base-cli-utils -- --check`
- [x] Built `shadow-metrics` from `origin/main` and from this branch, ran under `json`, `logfmt` and `full`, and diffed stdout through `cat -v`: json identical, logfmt escapes gone, full still colored