### PR TITLE
fix(deps): Relax Alloy-Core Pins To 1.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -296,9 +296,9 @@ alloy-serde = { version = "2.3.0", default-features = false }
 alloy-chains = { version = "0.2.33", default-features = false }
 alloy-genesis = { version = "2.3.0", default-features = false }
 alloy-consensus = { version = "2.3.0", default-features = false }
-alloy-sol-types = { version = "1.6.1", default-features = false }
-alloy-primitives = { version = "1.6.1", default-features = false }
-alloy-sol-macro = "1.6.1"
+alloy-sol-types = { version = "1.6.0", default-features = false }
+alloy-primitives = { version = "1.6.0", default-features = false }
+alloy-sol-macro = "1.6.0"
 alloy-rpc-types-eth = { version = "2.3.0", default-features = false }
 alloy-rpc-types-debug = { version = "2.3.0", default-features = false }
 alloy-rpc-types-txpool = { version = "2.3.0", default-features = false }


### PR DESCRIPTION
## Summary

The reth 2.5.0 upgrade bumped the alloy-primitives, alloy-sol-types, and alloy-sol-macro workspace pins to 1.6.1, which broke the Base Std interface fork tests. Those tests build base-anvil (a foundry fork that patches the alloy-core suite to 1.6.0) with base-common-chains and base-common-precompiles patched in from base HEAD, so the patched crates demanded ^1.6.1 and dependency resolution failed against base-anvil's 1.6.0. This relaxes the three pins back to 1.6.0 so the standalone base-common-* crates accept 1.6.0. Base's own build still resolves to 1.6.1 transitively through reth 2.5.0 and alloy-dyn-abi, so Cargo.lock is unchanged.