### PR TITLE
feat(builder): add BUILDER_EXPIRED for terminal builder discards

### DIFF
--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -49,8 +49,8 @@ use crate::{
     TxnOutcome, ValidityPredicateKey,
     transaction_events::{
         BuilderAcceptedEventData, BuilderConsideredEventData, BuilderDeferredEventData,
-        BuilderRejectedEventData, BuilderTransactionEventContext, emit_builder_transaction_event,
-        rejection_reason_code,
+        BuilderExpiredEventData, BuilderRejectedEventData, BuilderTransactionEventContext,
+        emit_builder_transaction_event, rejection_reason_code,
     },
 };
 
@@ -722,14 +722,13 @@ impl BasePayloadBuilderCtx {
                 );
                 self.emit_builder_decision_event(
                     &payload_id,
-                    TransactionEventType::BuilderRejected,
+                    TransactionEventType::BuilderExpired,
                     tx_hash,
                     Some(ordering_position),
                     || {
-                        BuilderRejectedEventData::new(
+                        BuilderExpiredEventData::new(
                             "bundle_expired",
                             "bundle validity window expired",
-                            false,
                             info,
                             limits,
                             None,
@@ -863,12 +862,8 @@ impl BasePayloadBuilderCtx {
                 // its predicate may have already been satisfied at its first position. An expired
                 // position predicate is terminal too — no later position can satisfy it — so both
                 // are dropped rather than parked; only recoverable state mismatches are parked.
-                if predicate_read_failed || predicate_expired {
-                    // A passed position bound can never be satisfied in any later
-                    // block, so an expired predicate is permanently terminal:
-                    // record it for the rejection cache and pool eviction so it is
-                    // not re-evaluated on subsequent flashblock rebuilds. A read
-                    // failure is only terminal for this scan, so it is not cached.
+                if predicate_read_failed {
+                    // A read failure is only terminal for this scan, so it is not cached.
                     self.emit_builder_decision_event(
                         &payload_id,
                         TransactionEventType::BuilderRejected,
@@ -886,9 +881,29 @@ impl BasePayloadBuilderCtx {
                         },
                     );
                     diag.txs_rejected_other += 1;
-                    if predicate_expired {
-                        diag.permanently_rejected_txs.push(tx_hash);
-                    }
+                    best_txs.mark_invalid(tx.sender(), tx.nonce());
+                } else if predicate_expired {
+                    // A passed position bound can never be satisfied in any later
+                    // block, so an expired predicate is permanently terminal:
+                    // record it for the rejection cache and pool eviction so it is
+                    // not re-evaluated on subsequent flashblock rebuilds.
+                    self.emit_builder_decision_event(
+                        &payload_id,
+                        TransactionEventType::BuilderExpired,
+                        tx_hash,
+                        Some(ordering_position),
+                        || {
+                            BuilderExpiredEventData::new(
+                                decision_reason,
+                                decision_detail,
+                                info,
+                                limits,
+                                None,
+                            )
+                        },
+                    );
+                    diag.txs_rejected_other += 1;
+                    diag.permanently_rejected_txs.push(tx_hash);
                     best_txs.mark_invalid(tx.sender(), tx.nonce());
                 } else if let Some(blocking_predicate) = blocking_predicate
                     && best_txs.park_current()

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -733,8 +733,6 @@ impl BasePayloadBuilderCtx {
                             limits,
                             None,
                         )
-                        .with_bundle_block_window(min_block_number, max_block_number)
-                        .with_block_timestamp(block_timestamp)
                     },
                 );
                 best_txs.mark_invalid(tx.sender(), tx.nonce());

--- a/crates/builder/core/src/transaction_events.rs
+++ b/crates/builder/core/src/transaction_events.rs
@@ -315,6 +315,58 @@ impl BuilderDeferredEventData {
     }
 }
 
+/// Fields emitted when the builder discards a transaction that can no longer become valid.
+#[derive(Debug, Serialize)]
+pub(crate) struct BuilderExpiredEventData {
+    #[serde(flatten)]
+    budget: BuilderBudgetFields,
+    expire_reason: &'static str,
+    expire_detail: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bundle_min_block: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bundle_max_block: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    block_timestamp: Option<u64>,
+}
+
+impl BuilderExpiredEventData {
+    /// Creates an expired-event payload with an explicit reason and detail.
+    pub(crate) fn new(
+        expire_reason: &'static str,
+        expire_detail: impl Into<String>,
+        info: &ExecutionInfo,
+        limits: &ResourceLimits,
+        resources: Option<&TxResources>,
+    ) -> Self {
+        Self {
+            budget: BuilderBudgetFields::new(info, limits, resources),
+            expire_reason,
+            expire_detail: expire_detail.into(),
+            bundle_min_block: None,
+            bundle_max_block: None,
+            block_timestamp: None,
+        }
+    }
+
+    /// Adds the block window associated with a bundle transaction.
+    pub(crate) const fn with_bundle_block_window(
+        mut self,
+        min_block_number: Option<u64>,
+        max_block_number: Option<u64>,
+    ) -> Self {
+        self.bundle_min_block = min_block_number;
+        self.bundle_max_block = max_block_number;
+        self
+    }
+
+    /// Adds the block timestamp associated with a bundle expiry.
+    pub(crate) const fn with_block_timestamp(mut self, timestamp: u64) -> Self {
+        self.block_timestamp = Some(timestamp);
+        self
+    }
+}
+
 /// Fields emitted when the builder accepts a transaction.
 #[derive(Debug, Serialize)]
 pub(crate) struct BuilderAcceptedEventData {
@@ -673,6 +725,25 @@ mod tests {
         assert_eq!(data["defer_reason"], "validity_predicate_not_satisfied");
         assert!(data.get("rejection_reason").is_none());
         assert!(data.get("permanent").is_none());
+    }
+
+    #[test]
+    fn expired_event_data_is_distinct_from_rejection() {
+        let data = serialize_builder_event_data(BuilderEventData {
+            context: context().event_data(),
+            event: BuilderExpiredEventData::new(
+                "validity_predicate_expired",
+                "a validity predicate can no longer be satisfied at or after the current build position",
+                &ExecutionInfo { cumulative_gas_used: 21_000, ..Default::default() },
+                &ResourceLimits { block_gas_limit: 30_000_000, ..Default::default() },
+                None,
+            ),
+        });
+
+        assert_eq!(data["expire_reason"], "validity_predicate_expired");
+        assert!(data.get("rejection_reason").is_none());
+        assert!(data.get("permanent").is_none());
+        assert!(data.get("defer_reason").is_none());
     }
 
     #[test]

--- a/crates/builder/core/src/transaction_events.rs
+++ b/crates/builder/core/src/transaction_events.rs
@@ -322,12 +322,6 @@ pub(crate) struct BuilderExpiredEventData {
     budget: BuilderBudgetFields,
     expire_reason: &'static str,
     expire_detail: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    bundle_min_block: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    bundle_max_block: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    block_timestamp: Option<u64>,
 }
 
 impl BuilderExpiredEventData {
@@ -343,27 +337,7 @@ impl BuilderExpiredEventData {
             budget: BuilderBudgetFields::new(info, limits, resources),
             expire_reason,
             expire_detail: expire_detail.into(),
-            bundle_min_block: None,
-            bundle_max_block: None,
-            block_timestamp: None,
         }
-    }
-
-    /// Adds the block window associated with a bundle transaction.
-    pub(crate) const fn with_bundle_block_window(
-        mut self,
-        min_block_number: Option<u64>,
-        max_block_number: Option<u64>,
-    ) -> Self {
-        self.bundle_min_block = min_block_number;
-        self.bundle_max_block = max_block_number;
-        self
-    }
-
-    /// Adds the block timestamp associated with a bundle expiry.
-    pub(crate) const fn with_block_timestamp(mut self, timestamp: u64) -> Self {
-        self.block_timestamp = Some(timestamp);
-        self
     }
 }
 
@@ -707,43 +681,6 @@ mod tests {
         assert_eq!(ctx.payload_id, "0x0102030405060708");
         assert_eq!(data["parent_hash"], format!("{:#x}", B256::repeat_byte(0xaa)));
         assert_eq!(data["transaction_count"], 0);
-    }
-
-    #[test]
-    fn deferred_event_data_is_distinct_from_rejection() {
-        let data = serialize_builder_event_data(BuilderEventData {
-            context: context().event_data(),
-            event: BuilderDeferredEventData::new(
-                "validity_predicate_not_satisfied",
-                "a validity predicate is not satisfied by the current build state",
-                &ExecutionInfo { cumulative_gas_used: 21_000, ..Default::default() },
-                &ResourceLimits { block_gas_limit: 30_000_000, ..Default::default() },
-                None,
-            ),
-        });
-
-        assert_eq!(data["defer_reason"], "validity_predicate_not_satisfied");
-        assert!(data.get("rejection_reason").is_none());
-        assert!(data.get("permanent").is_none());
-    }
-
-    #[test]
-    fn expired_event_data_is_distinct_from_rejection() {
-        let data = serialize_builder_event_data(BuilderEventData {
-            context: context().event_data(),
-            event: BuilderExpiredEventData::new(
-                "validity_predicate_expired",
-                "a validity predicate can no longer be satisfied at or after the current build position",
-                &ExecutionInfo { cumulative_gas_used: 21_000, ..Default::default() },
-                &ResourceLimits { block_gas_limit: 30_000_000, ..Default::default() },
-                None,
-            ),
-        });
-
-        assert_eq!(data["expire_reason"], "validity_predicate_expired");
-        assert!(data.get("rejection_reason").is_none());
-        assert!(data.get("permanent").is_none());
-        assert!(data.get("defer_reason").is_none());
     }
 
     #[test]

--- a/crates/common/observability-events/src/event.rs
+++ b/crates/common/observability-events/src/event.rs
@@ -175,6 +175,9 @@ pub enum TransactionEventType {
     /// The builder deferred a transaction for later re-evaluation during payload construction.
     #[serde(rename = "BUILDER_DEFERRED")]
     BuilderDeferred,
+    /// The builder discarded a transaction that can no longer become valid.
+    #[serde(rename = "BUILDER_EXPIRED")]
+    BuilderExpired,
     /// The builder included a transaction in a finalized payload.
     #[serde(rename = "BUILDER_INCLUDED")]
     BuilderIncluded,
@@ -240,6 +243,7 @@ impl fmt::Display for TransactionEventType {
             Self::BuilderAccepted => "BUILDER_ACCEPTED",
             Self::BuilderRejected => "BUILDER_REJECTED",
             Self::BuilderDeferred => "BUILDER_DEFERRED",
+            Self::BuilderExpired => "BUILDER_EXPIRED",
             Self::BuilderIncluded => "BUILDER_INCLUDED",
             Self::BuilderPayloadFinalized => "BUILDER_PAYLOAD_FINALIZED",
             Self::BuilderFlashblockStarted => "BUILDER_FLASHBLOCK_STARTED",

--- a/crates/infra/audit/migrations/003_transaction_event_expired_rejected_index.sql
+++ b/crates/infra/audit/migrations/003_transaction_event_expired_rejected_index.sql
@@ -1,7 +1,5 @@
 -- no-transaction
--- Include BUILDER_EXPIRED in the rejected-events partial index used by
--- GET /api/rejected.
+-- Drop the rejected-events partial index before recreating it with
+-- BUILDER_EXPIRED. CONCURRENTLY must be the only statement in this
+-- migration; Postgres treats a multi-statement query as a transaction.
 DROP INDEX CONCURRENTLY IF EXISTS transaction_events_rejected_event_time_idx;
-CREATE INDEX CONCURRENTLY IF NOT EXISTS transaction_events_rejected_event_time_idx
-    ON transaction_events (event_type, event_time DESC)
-    WHERE event_type IN ('SIMULATION_FAILED', 'BUILDER_REJECTED', 'BUILDER_EXPIRED');

--- a/crates/infra/audit/migrations/003_transaction_event_expired_rejected_index.sql
+++ b/crates/infra/audit/migrations/003_transaction_event_expired_rejected_index.sql
@@ -1,0 +1,7 @@
+-- no-transaction
+-- Include BUILDER_EXPIRED in the rejected-events partial index used by
+-- GET /api/rejected.
+DROP INDEX CONCURRENTLY IF EXISTS transaction_events_rejected_event_time_idx;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS transaction_events_rejected_event_time_idx
+    ON transaction_events (event_type, event_time DESC)
+    WHERE event_type IN ('SIMULATION_FAILED', 'BUILDER_REJECTED', 'BUILDER_EXPIRED');

--- a/crates/infra/audit/migrations/004_transaction_event_expired_rejected_index.sql
+++ b/crates/infra/audit/migrations/004_transaction_event_expired_rejected_index.sql
@@ -1,0 +1,7 @@
+-- no-transaction
+-- Include BUILDER_EXPIRED in the rejected-events partial index used by
+-- GET /api/rejected. CONCURRENTLY so ingest can continue while the index
+-- builds.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS transaction_events_rejected_event_time_idx
+    ON transaction_events (event_type, event_time DESC)
+    WHERE event_type IN ('SIMULATION_FAILED', 'BUILDER_REJECTED', 'BUILDER_EXPIRED');

--- a/crates/infra/audit/src/transaction_events.rs
+++ b/crates/infra/audit/src/transaction_events.rs
@@ -157,7 +157,8 @@ impl TransactionEventRetentionClass {
             | TransactionEventType::BuilderConsidered
             | TransactionEventType::BuilderAccepted
             | TransactionEventType::BuilderRejected
-            | TransactionEventType::BuilderDeferred => Self::Hot,
+            | TransactionEventType::BuilderDeferred
+            | TransactionEventType::BuilderExpired => Self::Hot,
             TransactionEventType::IngressReceived
             | TransactionEventType::SimulationStarted
             | TransactionEventType::SimulationSucceeded
@@ -834,7 +835,7 @@ impl PgTransactionEventSink {
             "SELECT event_id, schema_version, event_time, ingested_at, producer, event_type, \
              network, tx_hash, block_hash, block_number, payload_id, request_id, data \
              FROM transaction_events \
-             WHERE event_type IN ('SIMULATION_FAILED', 'BUILDER_REJECTED') \
+             WHERE event_type IN ('SIMULATION_FAILED', 'BUILDER_REJECTED', 'BUILDER_EXPIRED') \
                AND ($1::BIGINT IS NULL OR block_number >= $1) \
                AND ($2::BIGINT IS NULL OR block_number <= $2) \
                AND ($3::TIMESTAMPTZ IS NULL OR event_time >= $3) \
@@ -1349,6 +1350,10 @@ mod tests {
         );
         assert_eq!(
             TransactionEventRetentionClass::for_event_type(TransactionEventType::BuilderDeferred),
+            TransactionEventRetentionClass::Hot
+        );
+        assert_eq!(
+            TransactionEventRetentionClass::for_event_type(TransactionEventType::BuilderExpired),
             TransactionEventRetentionClass::Hot
         );
         assert_eq!(

--- a/crates/infra/audit/tests/postgres_transaction_events.rs
+++ b/crates/infra/audit/tests/postgres_transaction_events.rs
@@ -159,6 +159,27 @@ async fn postgres_retention_index_is_applied() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn postgres_rejected_index_includes_builder_expired() -> anyhow::Result<()> {
+    let harness = PostgresHarness::new().await?;
+    PgTransactionEventSink::migrate(&harness.database_url).await?;
+    let pool = PgPoolOptions::new().max_connections(1).connect(&harness.database_url).await?;
+
+    let indexdef: String = sqlx::query_scalar(
+        "SELECT indexdef FROM pg_indexes \
+         WHERE schemaname = 'public' \
+           AND indexname = 'transaction_events_rejected_event_time_idx'",
+    )
+    .fetch_one(&pool)
+    .await?;
+    assert!(
+        indexdef.contains("BUILDER_EXPIRED"),
+        "rejected index should include BUILDER_EXPIRED: {indexdef}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn postgres_sink_chunks_large_direct_inserts() -> anyhow::Result<()> {
     let harness = PostgresHarness::new().await?;
 

--- a/docs/transaction-events/README.md
+++ b/docs/transaction-events/README.md
@@ -225,6 +225,7 @@ Builder:
 - `BUILDER_ACCEPTED`
 - `BUILDER_REJECTED`
 - `BUILDER_DEFERRED`
+- `BUILDER_EXPIRED`
 - `BUILDER_INCLUDED`
 - `BUILDER_PAYLOAD_FINALIZED`
 - `BUILDER_FLASHBLOCK_STARTED`
@@ -232,16 +233,19 @@ Builder:
 - `BUILDER_FLASHBLOCK_BUILD_STOPPED`
 
 Builder caveat: `BUILDER_CONSIDERED`, `BUILDER_ACCEPTED`,
-`BUILDER_REJECTED`, and `BUILDER_DEFERRED` are emitted per payload-building
-attempt and include `payload_id`, `block_number`, and `flashblock_index` when
-applicable. The same transaction can therefore produce multiple decision events
-across flashblocks. `BUILDER_DEFERRED` is emitted each time the builder moves a
-transaction from the selection queue into the parking lot, including after a
-promote-and-repark in the same flashblock. Reindexing an already-parked
-transaction when its blocker changes does not emit another `BUILDER_DEFERRED`.
-`BUILDER_ACCEPTED` and `BUILDER_INCLUDED` are unchanged; correlate a deferral
-with a later accept/include by `tx_hash` within the same `payload_id`/flashblock
-window. A parking-capacity miss stays `BUILDER_REJECTED` with
+`BUILDER_REJECTED`, `BUILDER_DEFERRED`, and `BUILDER_EXPIRED` are emitted per
+payload-building attempt and include `payload_id`, `block_number`, and
+`flashblock_index` when applicable. The same transaction can therefore produce
+multiple decision events across flashblocks. `BUILDER_DEFERRED` is emitted each
+time the builder moves a transaction from the selection queue into the parking
+lot, including after a promote-and-repark in the same flashblock. Reindexing an
+already-parked transaction when its blocker changes does not emit another
+`BUILDER_DEFERRED`. `BUILDER_EXPIRED` is the terminal discard for builder-side
+windows that can never become valid again, such as an expired bundle validity
+window or an expired position predicate. `BUILDER_ACCEPTED` and
+`BUILDER_INCLUDED` are unchanged; correlate a deferral with a later
+accept/include by `tx_hash` within the same `payload_id`/flashblock window. A
+parking-capacity miss stays `BUILDER_REJECTED` with
 `validity_predicate_not_satisfied`.
 `BUILDER_INCLUDED` is emitted when the builder finalizes the payload it can
 serve via `engine_getPayload` and includes


### PR DESCRIPTION
## Summary
- Add a generic `BUILDER_EXPIRED` event for terminal builder-side discards that can never become valid again.
- Emit it for expired bundle validity windows (`bundle_expired`) and expired position predicates (`validity_predicate_expired`).
- Leave scan-only failures, parking-capacity misses, and other execution rejects as `BUILDER_REJECTED`. Include `BUILDER_EXPIRED` in the rejected-events query/index.

Stacked on #4500