### PR TITLE
fix(tx-manager): clear the mempool replacement threshold strictly

### DIFF
--- a/crates/utilities/tx-manager/src/fees.rs
+++ b/crates/utilities/tx-manager/src/fees.rs
@@ -51,17 +51,22 @@ impl FeeCalculator {
         blob_base_fee.saturating_mul(2)
     }
 
-    /// Returns the minimum replacement value that satisfies geth's
-    /// tx-replacement rules.
+    /// Returns the minimum replacement value that clears a mempool's
+    /// tx-replacement rule.
+    ///
+    /// A mempool rejects a replacement whose fee is not **strictly** above
+    /// `x * (100 + bump_percent) / 100`. Because that division truncates, the
+    /// threshold it compares against is exactly `x + x / divisor` — so
+    /// returning that value lands *on* the boundary and is rejected. One extra
+    /// wei clears it.
     ///
     /// * **Regular transactions** (`is_blob = false`): 10 % bump →
-    ///   `x + x / 10`, but always at least `x + 1` when `x > 0`.
-    /// * **Blob transactions** (`is_blob = true`): 100 % bump →
-    ///   `x + x` (i.e. `2 × x`), but always at least `x + 1` when `x > 0`.
+    ///   `x + x / 10 + 1`.
+    /// * **Blob transactions** (`is_blob = true`): 100 % bump → `2x + 1`.
     /// * When `x == 0`, returns `0` (there is no fee to bump).
     ///
-    /// The "at least +1" rule prevents stuck bump loops where
-    /// `x / 10 == 0` for small values.
+    /// The trailing `+ 1` also subsumes the old "at least `x + 1`" rule for
+    /// small `x` where `x / 10` truncates to zero.
     ///
     /// Uses saturating arithmetic — the result is capped at [`u128::MAX`]
     /// rather than panicking on overflow.
@@ -71,16 +76,11 @@ impl FeeCalculator {
             return 0;
         }
 
-        let bump = if is_blob {
-            // 100 % bump: x + x = 2x
-            x
-        } else {
-            // 10 % bump: x / 10, but at least 1
-            let v = x / 10;
-            if v > 0 { v } else { 1 }
-        };
+        // 100 % bump for blobs, 10 % otherwise. `x + x / divisor` is exactly
+        // `floor(x * (100 + bump_percent) / 100)`, i.e. the mempool's threshold.
+        let bump = if is_blob { x } else { x / 10 };
 
-        x.saturating_add(bump)
+        x.saturating_add(bump).saturating_add(1)
     }
 
     /// Selects final `(tip, fee_cap)` values that satisfy geth's replacement
@@ -327,26 +327,50 @@ mod tests {
 
     // ── calc_threshold_value ────────────────────────────────────────────
 
+    // Every expectation is one wei above `x + x / divisor`, which is the
+    // boundary the mempool compares against. Returning the boundary itself is
+    // rejected as `replacement transaction underpriced`.
     #[rstest]
     // Regular (non-blob) cases
     #[case::zero_regular(0, false, 0)]
     #[case::one_regular(1, false, 2)]
     #[case::nine_regular(9, false, 10)]
-    #[case::ten_regular(10, false, 11)]
-    #[case::eleven_regular(11, false, 12)]
-    #[case::hundred_regular(100, false, 110)]
-    #[case::thousand_regular(1000, false, 1100)]
+    #[case::ten_regular(10, false, 12)]
+    #[case::eleven_regular(11, false, 13)]
+    #[case::hundred_regular(100, false, 111)]
+    #[case::thousand_regular(1000, false, 1101)]
     #[case::small_value_ensures_plus_one(5, false, 6)]
     #[case::saturates_regular(u128::MAX, false, u128::MAX)]
     // Blob cases
     #[case::zero_blob(0, true, 0)]
-    #[case::one_blob(1, true, 2)]
-    #[case::ten_blob(10, true, 20)]
-    #[case::hundred_blob(100, true, 200)]
+    #[case::one_blob(1, true, 3)]
+    #[case::ten_blob(10, true, 21)]
+    #[case::hundred_blob(100, true, 201)]
     #[case::saturates_blob(u128::MAX, true, u128::MAX)]
     #[case::half_max_blob(u128::MAX / 2 + 1, true, u128::MAX)]
     fn calc_threshold_value(#[case] x: u128, #[case] is_blob: bool, #[case] expected: u128) {
         assert_eq!(FeeCalculator::calc_threshold_value(x, is_blob), expected);
+    }
+
+    /// The regression this guards: the returned value must be **strictly**
+    /// greater than `floor(x * (100 + bump) / 100)`, the mempool's threshold.
+    /// Equality is what produced the observed `replacement transaction
+    /// underpriced` retry loop against a batcher submission on Base Sepolia.
+    #[rstest]
+    #[case::observed_fee_cap(15_297_156, false)]
+    #[case::observed_tip(1_000_000, false)]
+    #[case::round_number(100, false)]
+    #[case::blob(1_000, true)]
+    fn calc_threshold_value_strictly_clears_mempool_threshold(
+        #[case] x: u128,
+        #[case] is_blob: bool,
+    ) {
+        let mempool_threshold = if is_blob { x * 200 / 100 } else { x * 110 / 100 };
+        assert!(
+            FeeCalculator::calc_threshold_value(x, is_blob) > mempool_threshold,
+            "{x} bumped to {} does not clear threshold {mempool_threshold}",
+            FeeCalculator::calc_threshold_value(x, is_blob),
+        );
     }
 
     // ── update_fees ─────────────────────────────────────────────────────
@@ -355,20 +379,20 @@ mod tests {
     // Case 1: both above threshold → use new values
     #[case::both_above(100, 1000, 200, 500, false, (200, 1200))]
     // Case 2: tip above, fee cap below → new tip + threshold fee cap
-    #[case::tip_above_cap_below(100, 1000, 200, 1, false, (200, 1100))]
+    #[case::tip_above_cap_below(100, 1000, 200, 1, false, (200, 1101))]
     // Case 3: fee cap above, tip below → threshold tip + recalculated fee cap
-    #[case::tip_below_cap_above(100, 1000, 50, 5000, false, (110, 10110))]
+    #[case::tip_below_cap_above(100, 1000, 50, 5000, false, (111, 10111))]
     // Case 4: both below → both threshold values
-    #[case::both_below(100, 1000, 50, 1, false, (110, 1100))]
+    #[case::both_below(100, 1000, 50, 1, false, (111, 1101))]
     // Blob cases — all four arms with 100 % bump thresholds
     #[case::blob_both_above(100, 1000, 300, 1000, true, (300, 2300))]
-    #[case::blob_tip_above_cap_below(100, 1000, 300, 1, true, (300, 2000))]
-    #[case::blob_tip_below_cap_above(100, 1000, 50, 5000, true, (200, 10200))]
-    #[case::blob_both_below(100, 1000, 50, 1, true, (200, 2000))]
+    #[case::blob_tip_above_cap_below(100, 1000, 300, 1, true, (300, 2001))]
+    #[case::blob_tip_below_cap_above(100, 1000, 50, 5000, true, (201, 10201))]
+    #[case::blob_both_below(100, 1000, 50, 1, true, (201, 2001))]
     // Case 2: large old_fee_cap keeps threshold_fee_cap well above new_tip (clamp is no-op)
-    #[case::tip_above_cap_below_large_old_fee_cap(100, 10_000, 150, 1, false, (150, 11_000))]
+    #[case::tip_above_cap_below_large_old_fee_cap(100, 10_000, 150, 1, false, (150, 11_001))]
     // Case 4: old_tip > old_fee_cap → threshold_tip > threshold_fee_cap, clamp applies
-    #[case::both_below_tip_dominates(1_000, 100, 50, 1, false, (1_100, 1_100))]
+    #[case::both_below_tip_dominates(1_000, 100, 50, 1, false, (1_101, 1_101))]
     // Zero starting fees
     #[case::zero_old_fees(0, 0, 10, 100, false, (10, 210))]
     fn update_fees(

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -1151,14 +1151,18 @@ where
 
             // Respond immediately to the bump-fees flag set by
             // process_send_error on retryable errors, rather than waiting
-            // for the next resubmission timer tick. take_bump_fees clears
-            // the flag atomically so a failed bump does not re-trigger.
+            // for the next resubmission timer tick.
             if send_state.take_bump_fees() {
                 if let Some(abort) =
                     self.try_fee_bump(candidate, send_state, &receipt_tx, &mut bump).await
                 {
                     return Err(abort);
                 }
+                // A bump that fails to publish runs through
+                // process_send_error, which re-sets the flag taken above. Drop
+                // it so the retry is timer-driven — what "will retry next tick"
+                // promises — instead of spinning on the same replacement.
+                let _ = send_state.take_bump_fees();
                 // Reset the bump ticker so we get a full interval
                 // before the next timer-driven bump.
                 bump_ticker = self.runtime.interval(self.config.resubmission_timeout);
@@ -1199,6 +1203,9 @@ where
             {
                 return Err(abort);
             }
+            // As above: a bump that failed to publish must not re-fire
+            // immediately off its own error flag.
+            let _ = send_state.take_bump_fees();
             bump_ticker = self.runtime.interval(self.config.resubmission_timeout);
             bump_ticker.next().await;
         }

--- a/crates/utilities/tx-manager/src/send_state.rs
+++ b/crates/utilities/tx-manager/src/send_state.rs
@@ -219,10 +219,11 @@ impl SendState {
     /// Atomically reads and clears the bump-fees flag. Returns `true` if
     /// fees should be bumped.
     ///
-    /// Clearing eagerly prevents a failed bump attempt (e.g. RPC timeout)
-    /// from immediately re-triggering on the next loop iteration. If a new
-    /// retryable error occurs later, [`process_send_error`] will re-set the
-    /// flag.
+    /// Clearing eagerly stops a *stale* flag from re-triggering. It does not
+    /// by itself stop a failed bump from re-firing: that attempt's own publish
+    /// error runs through [`process_send_error`] and re-sets the flag after
+    /// this call, so the send loop takes it a second time after each attempt to
+    /// keep retries on the resubmission timer.
     ///
     /// [`process_send_error`]: Self::process_send_error
     #[must_use]


### PR DESCRIPTION
## Summary

`FeeCalculator::calc_threshold_value` returned `x + x / divisor` as the bumped fee. That value is not *above* the mempool's replacement threshold — it **is** the threshold. For any `x`:

```
floor(x * 110 / 100) == x + floor(x / 10)
```

Mempools require a replacement to be **strictly** greater than that, so every fee bump landed exactly one wei short and was rejected as `replacement transaction underpriced`.

A failed bump does not advance `BumpState`, so the next attempt recomputed the identical value from the identical baseline and was rejected identically. The bump could never succeed; the loop only ended when the original transaction was finally mined by other means.

## Observed in production (Base Sepolia, batcher)

10,704 rejections across two ~2-minute bursts. A 30-second slice:

```
WARN publish failed, will retry            error=replacement transaction underpriced
WARN fee bump failed, will retry next tick error=replacement transaction underpriced
INFO gas price increase computed  old_fee_cap=15297156  bumped_fee_cap=16826871
WARN publish failed, will retry            error=replacement transaction underpriced
INFO gas price increase computed  old_fee_cap=15297156  bumped_fee_cap=16826871
```

253 `publish failed` + 254 byte-identical `gas price increase computed` in 30 s. And `16826871` is exactly `floor(15297156 * 110 / 100)`. The tip legs matched too: `1000000 -> 1100000` is exactly `floor(1000000 * 110 / 100)`. Both legs sat precisely on the boundary, which is why the rejection was deterministic rather than intermittent.

Each burst stalled batch submission for ~56 s against a 20 s cadence, so this has a real latency cost and is not only log noise.

## The fix

**1. Add one wei** so the bump clears the threshold instead of sitting on it. This also subsumes the old "at least `x + 1`" special case for small `x` where `x / 10` truncated to zero, so that branch goes away.

**2. Stop a failed bump from re-firing immediately.** `publish_tx` routes its error through `process_send_error`, which re-sets the `bump_fees` flag that the send loop had just taken — so the loop re-entered the bump path on the very next iteration instead of on the resubmission timer, contradicting its own `will retry next tick` log line and driving retries at ~8/s. The loop now takes the flag again after each attempt.

This second part is defence in depth: with the threshold fixed, our own arithmetic no longer produces a rejection, but a competing sender on the same nonce, or a node configured with a larger price bump, still can — and that should cost one attempt per resubmission interval, not a hot loop.

## Blast radius

`calc_threshold_value` is shared by the batcher, proposer, challenger and prover-registrar. The change makes every fee bump one wei more expensive and makes bumps actually land. Runaway escalation is still bounded by the existing `check_fee_limits` / `fee_limit_multiplier` path, which is untouched.

## Test plan

- [x] `cargo test -p base-tx-manager` — 376 pass. 15 expectations changed, every one of which encoded the old boundary value (`calc_threshold_value` cases plus the `update_fees` cases that derive from them).
- [x] New `calc_threshold_value_strictly_clears_mempool_threshold` asserts the property directly against `floor(x * (100 + bump) / 100)`, using the two fee values observed in the incident. It fails on the previous implementation.
- [x] `cargo clippy -p base-tx-manager --all-targets` and `cargo fmt --check` clean.
- [x] `cargo check -p base-batcher-service -p base-proposer -p base-challenger` — consumers unaffected.
- [ ] **Not covered by an automated test:** the loop-pacing change in part 2. Asserting it needs a full mocked send-loop RPC script under the deterministic runtime, which is brittle relative to the value; the failure mode is noisy retries rather than incorrectness. Called out here rather than papered over.

## Follow-up

Needs a port to `main`, same as base#4442 -> base#4445.

Made with [Cursor](https://cursor.com)