### PR TITLE
feat(txpool): emit validity transaction pool counters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4566,6 +4566,7 @@ dependencies = [
  "jsonrpsee",
  "lru 0.16.4",
  "metrics",
+ "metrics-util",
  "parking_lot",
  "reth-chainspec",
  "reth-eth-wire-types",

--- a/crates/execution/txpool/Cargo.toml
+++ b/crates/execution/txpool/Cargo.toml
@@ -65,6 +65,7 @@ alloy-signer-local.workspace = true
 reth-tasks.workspace = true
 base-test-utils.workspace = true
 base-execution-chainspec.workspace = true
+metrics-util = { workspace = true, features = ["debugging"] }
 reth-provider = { workspace = true, features = ["test-utils"] }
 reth-transaction-pool = { workspace = true, features = ["test-utils"] }
 tokio = { workspace = true, features = ["time", "rt-multi-thread", "macros"] }

--- a/crates/execution/txpool/src/lib.rs
+++ b/crates/execution/txpool/src/lib.rs
@@ -80,6 +80,6 @@ pub use wire::{
 mod two_d_nonce_pool;
 
 mod metrics;
-pub use metrics::{GuardMetrics, ValidatorMetrics};
+pub use metrics::{GuardMetrics, ValidatorMetrics, ValidityPoolMetrics};
 
 pub mod estimated_da_size;

--- a/crates/execution/txpool/src/metrics.rs
+++ b/crates/execution/txpool/src/metrics.rs
@@ -95,6 +95,25 @@ impl GuardMetrics {
 }
 
 base_metrics::define_metrics! {
+    txpool.validity,
+    struct = ValidityPoolMetrics,
+    #[describe("Validity transactions admitted to the pool, labeled by whether the admission replaced an existing same-sender/nonce transaction or added a new pool entry")]
+    #[label(name = "outcome", default = ["added", "replaced"])]
+    admitted: counter,
+}
+
+impl ValidityPoolMetrics {
+    /// Records a validity-transaction admission, distinguishing a replacement
+    /// (an existing pooled transaction for the same sender/nonce was evicted by
+    /// a fee bump or cancellation) from a net-new pool entry. Together the two
+    /// series decompose lane churn: their sum is total validity admissions and
+    /// `replaced` over that sum is the replacement rate.
+    pub fn record_admission(replaced: bool) {
+        Self::admitted(if replaced { "replaced" } else { "added" }).increment(1);
+    }
+}
+
+base_metrics::define_metrics! {
     txpool.validator,
     struct = ValidatorMetrics,
     #[describe("End-to-end mempool validation wall time by transaction kind")]
@@ -106,4 +125,52 @@ base_metrics::define_metrics! {
     #[describe("EIP-8130 lock-classification account-state resolutions by read source")]
     #[label(name = "source", default = ["cache", "prefetch", "sload"])]
     classification_state_reads: counter,
+}
+
+#[cfg(test)]
+mod tests {
+    use metrics_util::{
+        MetricKind,
+        debugging::{DebugValue, DebuggingRecorder},
+    };
+
+    use super::*;
+
+    type Snapshot = Vec<(
+        metrics_util::CompositeKey,
+        Option<metrics::Unit>,
+        Option<metrics::SharedString>,
+        DebugValue,
+    )>;
+
+    /// Reads the `txpool.validity.admitted` counter value for a given outcome
+    /// label out of a materialized snapshot, or `None` when absent.
+    fn admitted_count(snapshot: &Snapshot, outcome: &str) -> Option<u64> {
+        snapshot.iter().find_map(|(ck, _, _, value)| {
+            let key = ck.key();
+            let matches = ck.kind() == MetricKind::Counter
+                && key.name() == "txpool.validity.admitted"
+                && key.labels().any(|label| label.key() == "outcome" && label.value() == outcome);
+            match (matches, value) {
+                (true, DebugValue::Counter(value)) => Some(*value),
+                _ => None,
+            }
+        })
+    }
+
+    #[test]
+    fn record_admission_splits_added_and_replaced() {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        metrics::with_local_recorder(&recorder, || {
+            ValidityPoolMetrics::record_admission(false);
+            ValidityPoolMetrics::record_admission(false);
+            ValidityPoolMetrics::record_admission(true);
+        });
+
+        // `snapshot()` drains, so materialize once and query the vec.
+        let snapshot = snapshotter.snapshot().into_vec();
+        assert_eq!(admitted_count(&snapshot, "added"), Some(2));
+        assert_eq!(admitted_count(&snapshot, "replaced"), Some(1));
+    }
 }

--- a/crates/execution/txpool/src/pool.rs
+++ b/crates/execution/txpool/src/pool.rs
@@ -27,7 +27,7 @@ use tracing::debug;
 use crate::{
     Admission, BasePooledTx, BaseTransactionValidator, GuardLimits, GuardMetrics,
     InvalidationCause, InvalidationKey, LimitRejection, MempoolGuard, ParkableBestTransactions,
-    ParkableTransactionPool, ParkedBestTransactions, StateDiffInvalidation,
+    ParkableTransactionPool, ParkedBestTransactions, StateDiffInvalidation, ValidityPoolMetrics,
     best::MergeBestTransactions,
     two_d_nonce_pool::{InsertOutcome, TwoDNoncePool},
 };
@@ -399,6 +399,15 @@ where
         }
     }
 
+    /// Returns whether a validated transaction carries validity predicates, for
+    /// lane-churn accounting. Invalid outcomes carry no pooled transaction and
+    /// are never counted.
+    fn has_validity_predicates(validated: &TransactionValidationOutcome<T>) -> bool {
+        validated
+            .as_valid_transaction()
+            .is_some_and(|transaction| !transaction.transaction().validity_predicates().is_empty())
+    }
+
     fn reconcile_guard(&self) {
         let tracked = self.guard.read().tracked_hashes();
         if tracked.is_empty() {
@@ -502,8 +511,10 @@ where
         // tracked replacement bypasses this check and is reaccounted after the
         // protocol pool atomically accepts the fee bump.
         let pre_admitted = self.pre_admit_protocol_transaction(hash, replaced, &validated)?;
-        // Capture the block-expiry bound before `validated` is consumed below.
+        // Capture the block-expiry bound and validity-lane flag before
+        // `validated` is consumed below.
         let block_expiry_bound = Self::validity_block_expiry_bound(&validated);
+        let is_validity = Self::has_validity_predicates(&validated);
         let mut outcomes =
             self.protocol_pool.inner().add_transactions(origin, std::iter::once(validated));
         let outcome = match outcomes.pop() {
@@ -526,6 +537,9 @@ where
         };
         self.gate_protocol_admission(hash, replaced, pre_admitted)?;
         self.register_block_expiry(hash, block_expiry_bound, replaced);
+        if is_validity {
+            ValidityPoolMetrics::record_admission(replaced.is_some());
+        }
         Ok(outcome)
     }
 
@@ -643,6 +657,7 @@ where
                     .limit_class()
                     .map(|class| class.classification_generation);
                 let admission = Self::admission_for(&validated.transaction);
+                let is_validity = !validated.transaction.validity_predicates().is_empty();
                 let outcome = nonce_pool.insert_validated(validated, state_nonce)?;
                 // nonce_pool serializes sidecar replacement. Never acquire it while holding guard.
                 let mut guard = self.guard.write();
@@ -689,6 +704,9 @@ where
                 }
                 drop(guard);
                 listeners.on_inserted(&nonce_pool, &outcome);
+                if is_validity {
+                    ValidityPoolMetrics::record_admission(outcome.replaced.is_some());
+                }
                 Ok(outcome.outcome)
             }
             TransactionValidationOutcome::Invalid(transaction, error) => {
@@ -843,8 +861,10 @@ where
             self.ensure_protocol_classification_current(hash, &validated)?;
             let replaced = self.protocol_replacement_hash(sender, nonce);
             let pre_admitted = self.pre_admit_protocol_transaction(hash, replaced, &validated)?;
-            // Capture the block-expiry bound before `validated` is consumed below.
+            // Capture the block-expiry bound and validity-lane flag before
+            // `validated` is consumed below.
             let block_expiry_bound = Self::validity_block_expiry_bound(&validated);
+            let is_validity = Self::has_validity_predicates(&validated);
             let events =
                 match self.protocol_pool.inner().add_transaction_and_subscribe(origin, validated) {
                     Ok(events) => events,
@@ -857,6 +877,9 @@ where
                 };
             self.gate_protocol_admission(hash, replaced, pre_admitted)?;
             self.register_block_expiry(hash, block_expiry_bound, replaced);
+            if is_validity {
+                ValidityPoolMetrics::record_admission(replaced.is_some());
+            }
             return Ok(events);
         }
 


### PR DESCRIPTION
Add a `txpool.validity.admitted{outcome="added"|"replaced"}` counter that tracks lane churn for validity (advanced) transactions. An admission is counted as `replaced` when it evicts an existing same-sender/nonce transaction (fee bump or cancellation) and `inserted` otherwise, so the two series decompose to total admissions and a replacement rate.

Emission is wired into all three successful-admission paths (protocol add, protocol add-and-subscribe, and the 2D-nonce sidecar), gated so only transactions carrying validity predicates are counted; plain EIP-1559 transactions and every error path are skipped.