### PR TITLE
feat(builder): emit predicate evaluation time per block

### DIFF
--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 use std::{
     sync::Arc,
-    time::{Instant, SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 use alloy_consensus::{Eip658Value, Transaction};
@@ -658,6 +658,17 @@ impl BasePayloadBuilderCtx {
         Ok(info)
     }
 
+    /// Runs `f`, adding its wall-clock duration to `total`. `total` stays `None`
+    /// until the first call, so a `Some` result also records that at least one
+    /// predicate was evaluated during the build; this gates the per-block
+    /// histogram so blocks without validity transactions emit no observation.
+    fn accumulate_elapsed<T>(total: &mut Option<Duration>, f: impl FnOnce() -> T) -> T {
+        let start = Instant::now();
+        let value = f();
+        *total.get_or_insert(Duration::ZERO) += start.elapsed();
+        value
+    }
+
     /// Executes the given best transactions and updates the execution info.
     ///
     /// Returns diagnostics summarizing transaction selection for the flashblock.
@@ -695,6 +706,12 @@ impl BasePayloadBuilderCtx {
         let mut predicate_index = ParkedPredicateIndex::default();
         let predicate_context =
             PredicateContext { block_number, flashblock_index: self.flashblock_index() };
+
+        // Total validity-predicate evaluation time (inclusive of the state loads each
+        // evaluation performs) across this flashblock build. `None` until the first
+        // evaluation, so it both accumulates and records whether any validity
+        // transaction was seen; emitted once when the loop finishes.
+        let mut predicate_eval_total: Option<Duration> = None;
 
         while let Some(tx) = best_txs.next(()) {
             if tx.is_bundle_expired(block_number, block_timestamp) {
@@ -791,22 +808,28 @@ impl BasePayloadBuilderCtx {
             let tx_hash = *tx.hash();
             let has_validity_predicates = !tx.validity_predicates().is_empty();
             let mut predicate_read_failed = false;
-            let blocking_predicate = match ValidityPredicateKey::first_unsatisfied(
-                tx.validity_predicates(),
-                evm.db_mut(),
-                &predicate_context,
-            ) {
-                Ok(blocking_predicate) => blocking_predicate,
-                Err(error) => {
-                    warn!(
-                        target: "payload_builder",
-                        tx_hash = ?tx_hash,
-                        error = ?error,
-                        "failed to read validity predicate state"
-                    );
-                    predicate_read_failed = true;
-                    None
+            let blocking_predicate = if has_validity_predicates {
+                match Self::accumulate_elapsed(&mut predicate_eval_total, || {
+                    ValidityPredicateKey::first_unsatisfied(
+                        tx.validity_predicates(),
+                        evm.db_mut(),
+                        &predicate_context,
+                    )
+                }) {
+                    Ok(blocking_predicate) => blocking_predicate,
+                    Err(error) => {
+                        warn!(
+                            target: "payload_builder",
+                            tx_hash = ?tx_hash,
+                            error = ?error,
+                            "failed to read validity predicate state"
+                        );
+                        predicate_read_failed = true;
+                        None
+                    }
                 }
+            } else {
+                None
             };
             if has_validity_predicates {
                 let outcome = if predicate_read_failed {
@@ -1424,23 +1447,26 @@ impl BasePayloadBuilderCtx {
                     );
                     continue;
                 };
-                let blocking_predicate = match ValidityPredicateKey::first_unsatisfied(
-                    parked_transaction.validity_predicates(),
-                    evm.db_mut(),
-                    &predicate_context,
-                ) {
-                    Ok(blocking_predicate) => blocking_predicate,
-                    Err(error) => {
-                        warn!(
-                            target: "payload_builder",
-                            tx_hash = ?parked_hash,
-                            error = ?error,
-                            "failed to re-read validity predicate state"
-                        );
-                        predicate_read_failed = true;
-                        None
-                    }
-                };
+                let blocking_predicate =
+                    match Self::accumulate_elapsed(&mut predicate_eval_total, || {
+                        ValidityPredicateKey::first_unsatisfied(
+                            parked_transaction.validity_predicates(),
+                            evm.db_mut(),
+                            &predicate_context,
+                        )
+                    }) {
+                        Ok(blocking_predicate) => blocking_predicate,
+                        Err(error) => {
+                            warn!(
+                                target: "payload_builder",
+                                tx_hash = ?parked_hash,
+                                error = ?error,
+                                "failed to re-read validity predicate state"
+                            );
+                            predicate_read_failed = true;
+                            None
+                        }
+                    };
                 let outcome = if predicate_read_failed {
                     "rescan_read_error"
                 } else if blocking_predicate.is_some() {
@@ -1488,6 +1514,13 @@ impl BasePayloadBuilderCtx {
             // append sender and transaction to the respective lists
             info.executed_senders.push(tx.signer());
             info.executed_transactions.push(tx.into_inner());
+        }
+
+        // Record accumulated validity-predicate evaluation time once per flashblock build.
+        // `None` means no validity transactions were evaluated, so nothing is emitted and
+        // the histogram is not flooded with zero observations.
+        if let Some(predicate_eval_total) = predicate_eval_total {
+            BuilderMetrics::record_predicate_eval_duration(predicate_eval_total);
         }
 
         let payload_transaction_simulation_time = execute_txs_start_time.elapsed();

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -1,5 +1,7 @@
 //! Builder metrics collected during block and flashblock construction.
 
+use std::time::Duration;
+
 use crate::{ExecutionInfo, FlashblockDiagnostics, ResourceLimits};
 
 const PRIORITY_FEE_THRESHOLDS_WEI: [(&str, u64); 3] =
@@ -112,6 +114,10 @@ base_metrics::define_metrics! {
     rejection_cache_size: gauge,
     #[describe("Duration of rescanning parked transaction validity predicates in seconds")]
     validity_predicate_rescan_duration: histogram,
+    #[describe(
+        "Total validity predicate evaluation time per flashblock build, inclusive of state loads, in seconds"
+    )]
+    validity_predicate_eval_duration_per_block: histogram,
     #[describe("Validity predicate evaluation attempts")]
     #[label(outcome)]
     validity_predicate_evaluations_total: counter,
@@ -212,6 +218,12 @@ base_metrics::define_metrics! {
 }
 
 impl BuilderMetrics {
+    /// Records the total validity predicate evaluation time accumulated across a
+    /// single build iteration, inclusive of the state loads each evaluation performs.
+    pub fn record_predicate_eval_duration(duration: Duration) {
+        Self::validity_predicate_eval_duration_per_block().record(duration.as_secs_f64());
+    }
+
     /// Records per-flashblock selection diagnostics as labeled metrics.
     pub fn record_flashblock_diagnostics(
         flashblock_index: u64,
@@ -357,5 +369,26 @@ mod tests {
         assert!(rendered.contains(
             "base_builder_flashblock_min_priority_fee_above_threshold_total{flashblock_index=\"7\",threshold=\"100wei\"} 1"
         ));
+    }
+
+    #[test]
+    fn record_predicate_eval_duration_emits_histogram_in_seconds() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+
+        metrics::with_local_recorder(&recorder, || {
+            // 500ms accumulated across a build iteration -> 0.5 seconds.
+            BuilderMetrics::record_predicate_eval_duration(Duration::from_millis(500));
+        });
+
+        let rendered = handle.render();
+        assert!(
+            rendered.contains("base_builder_validity_predicate_eval_duration_per_block_count 1"),
+            "expected a single observation, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("base_builder_validity_predicate_eval_duration_per_block_sum 0.5"),
+            "expected 0.5s recorded, got: {rendered}"
+        );
     }
 }


### PR DESCRIPTION
Add a `base_builder_validity_predicate_eval_duration_per_block` histogram (seconds) recording total validity-predicate evaluation time per flashblock build, inclusive of the state loads each evaluation performs. This is the observability backstop behind the predicate-eval-time SLO (P99 < 5ms) and a future per-block guardrail.

Timing wraps both `ValidityPredicateKey::first_unsatisfied` call sites (the main selection loop and the parked-transaction rescan), accumulating across the build iteration and recording once when the loop completes, gated so flashblocks with no validity transactions do not emit zero observations.