### PR TITLE
fix(upgrade-signal): Fail Closed On Unsupportable Live Upgrades

### DIFF
--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -533,14 +533,22 @@ impl ConsensusNodeArgs {
         signal_config.request_timeout = self.config.l1_rpc_args.l1_rpc_timeout;
         let reader =
             signal_config.reader(self.resolved_upgrade_signal_l1_rpc(upgrade_signal_l1_rpc))?;
-        let schedule = signal_config
-            .read_required_startup_schedule(
+        // Apply the fail-closed startup policy (see `read_startup_schedule`): retry until the L1
+        // contract returns an authoritative schedule, abort startup only for an unsupportable
+        // upgrade nearing activation, but start with a loud alarm (`None`) for one that is still far
+        // off — so a restart is not blocked by a distant upgrade. The live poller fails the node
+        // closed once it nears activation.
+        let Some(schedule) = signal_config
+            .read_startup_schedule(
                 &reader,
                 "consensus startup",
                 &[UpgradeSignalMetricLayer::Consensus],
                 UpgradeSignalDefaults::STARTUP_SCHEDULE_RETRY_INTERVAL,
             )
-            .await?;
+            .await?
+        else {
+            return Ok(());
+        };
 
         Self::apply_schedule_to_rollup_config(cfg, &schedule);
 

--- a/crates/consensus/service/src/actors/upgrade_signal.rs
+++ b/crates/consensus/service/src/actors/upgrade_signal.rs
@@ -3,11 +3,11 @@
 use core::time::Duration;
 
 use base_upgrade_signal::{
-    AlloyUpgradeSignalReader, UpgradeSignalConfig, UpgradeSignalError, UpgradeSignalMetricLayer,
-    UpgradeSignalMonitor, UpgradeSignalRefresher,
+    AlloyUpgradeSignalReader, PackedProtocolVersion, UpgradeSignalConfig, UpgradeSignalError,
+    UpgradeSignalMetricLayer, UpgradeSignalMonitor, UpgradeSignalPollOutcome,
+    UpgradeSignalRefresher,
 };
 use tokio_util::sync::CancellationToken;
-use tracing::warn;
 use url::Url;
 
 use crate::NodeActor;
@@ -95,20 +95,9 @@ impl UpgradeSignalMetricsActor {
     }
 
     /// Polls L1 upgrade signal state, records metrics, and auto-applies observed changes when
-    /// runtime refresh is enabled.
-    pub async fn poll_l1_signal(&mut self) {
-        let Some(schedule) = self.monitor.poll(&self.reader).await else {
-            return;
-        };
-        if let Some(refresher) = &self.refresher
-            && let Err(error) = refresher.apply(&schedule)
-        {
-            warn!(
-                target: "upgrade_signal",
-                error = %error,
-                "failed to auto-apply live upgrade signal update"
-            );
-        }
+    /// runtime refresh is enabled. Returns whether the node must fail closed.
+    pub async fn poll_l1_signal(&mut self) -> UpgradeSignalPollOutcome {
+        self.monitor.poll_and_apply(&self.reader, self.refresher.as_ref()).await
     }
 }
 
@@ -128,9 +117,30 @@ impl NodeActor for UpgradeSignalMetricsActor {
                 _ = interval.tick() => {}
             }
 
-            tokio::select! {
+            let outcome = tokio::select! {
                 _ = cancellation.cancelled() => return Ok(()),
-                _ = self.poll_l1_signal() => {}
+                outcome = self.poll_l1_signal() => outcome,
+            };
+
+            // Fail closed: a scheduled upgrade this node cannot support is activating imminently.
+            // Cancel the shared token so the whole node tears down, then return the fatal error so
+            // the supervisor logs it and the process exits non-zero rather than fork off the chain.
+            if let UpgradeSignalPollOutcome::HaltNode {
+                upgrade_id,
+                activation_timestamp,
+                minimum_protocol_version,
+                node_protocol_version,
+            } = outcome
+            {
+                cancellation.cancel();
+                return Err(UpgradeSignalError::NodeUpgradeRequired {
+                    upgrade_id: upgrade_id.contract_id().to_string(),
+                    activation_timestamp,
+                    minimum_protocol_version: PackedProtocolVersion::new(minimum_protocol_version)
+                        .to_string(),
+                    node_protocol_version: PackedProtocolVersion::new(node_protocol_version)
+                        .to_string(),
+                });
             }
         }
     }

--- a/crates/execution/cli/src/upgrade_signal.rs
+++ b/crates/execution/cli/src/upgrade_signal.rs
@@ -3,9 +3,9 @@
 use base_execution_chainspec::BaseChainSpec;
 use base_node_runner::{BaseNodeExtension, BaseRpcContext, FromExtensionConfig, NodeHooks};
 use base_upgrade_signal::{
-    UpgradeSignalApplySummary, UpgradeSignalConfig, UpgradeSignalDefaults,
-    UpgradeSignalMetricLayer, UpgradeSignalMonitor, UpgradeSignalRefresher,
-    UpgradeSignalRuntimeApplier, UpgradeSignalSchedule,
+    PackedProtocolVersion, UpgradeSignalApplySummary, UpgradeSignalConfig, UpgradeSignalDefaults,
+    UpgradeSignalMetricLayer, UpgradeSignalMetrics, UpgradeSignalMonitor, UpgradeSignalPollOutcome,
+    UpgradeSignalRefresher, UpgradeSignalRuntimeApplier, UpgradeSignalSchedule,
 };
 use jsonrpsee::{RpcModule, core::RpcResult, types::ErrorObject};
 use reth_chainspec::EthChainSpec;
@@ -33,15 +33,18 @@ impl ExecutionUpgradeSignal {
         chain_spec: &mut BaseChainSpec,
     ) -> eyre::Result<()> {
         let reader = config.signal_config.reader(config.l1_rpc.clone())?;
-        let schedule = config
+        let Some(schedule) = config
             .signal_config
-            .read_required_startup_schedule(
+            .read_startup_schedule(
                 &reader,
                 "execution startup",
                 &[UpgradeSignalMetricLayer::Execution],
                 UpgradeSignalDefaults::STARTUP_SCHEDULE_RETRY_INTERVAL,
             )
-            .await?;
+            .await?
+        else {
+            return Ok(());
+        };
 
         Self::apply_schedule_to_chain_spec(chain_spec, &schedule)?;
 
@@ -66,14 +69,21 @@ impl ExecutionUpgradeSignal {
         refresher: &UpgradeSignalRefresher,
     ) -> RpcResult<UpgradeSignalApplySummary> {
         match refresher.read_schedule().await {
-            Ok(schedule) => refresher.apply(&schedule).map_err(|error| {
-                warn!(
-                    target: "upgrade_signal",
-                    error = %error,
-                    "failed to validate execution runtime upgrade signal"
-                );
-                ErrorObject::owned(-32005, "failed to validate upgrade signal", None::<()>)
-            }),
+            Ok(schedule) => match refresher.apply(&schedule) {
+                Ok(summary) => {
+                    UpgradeSignalMetrics::record_apply_success(refresher.metrics_layer, &schedule);
+                    Ok(summary)
+                }
+                Err(error) => {
+                    UpgradeSignalMetrics::record_apply_failure(refresher.metrics_layer, &schedule);
+                    warn!(
+                        target: "upgrade_signal",
+                        error = %error,
+                        "failed to validate execution runtime upgrade signal"
+                    );
+                    Err(ErrorObject::owned(-32005, "failed to validate upgrade signal", None::<()>))
+                }
+            },
             Err(error) => {
                 warn!(
                     target: "upgrade_signal",
@@ -157,36 +167,50 @@ impl BaseNodeExtension for ExecutionUpgradeSignalRuntimeExtension {
             let mut monitor = UpgradeSignalMonitor::new(UpgradeSignalMetricLayer::Execution);
             let executor = ctx.task_executor;
 
-            executor.spawn_with_graceful_shutdown_signal(|signal| {
-                Box::pin(async move {
-                    let mut interval = tokio::time::interval(poll_interval);
-                    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-                    let mut signal = Box::pin(signal);
+            // Spawned as a critical task so a fail-closed panic propagates to reth's TaskManager and
+            // exits the process non-zero, instead of being silently swallowed by a plain spawn.
+            executor.spawn_critical_with_graceful_shutdown_signal(
+                "upgrade-signal-monitor",
+                |signal| {
+                    Box::pin(async move {
+                        let mut interval = tokio::time::interval(poll_interval);
+                        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                        let mut signal = Box::pin(signal);
 
-                    loop {
-                        tokio::select! {
-                            _ = &mut signal => break,
-                            _ = interval.tick() => {
-                                tokio::select! {
-                                    _ = &mut signal => break,
-                                    polled = monitor.poll(&reader) => {
-                                        if let Some(refresher) = &auto_refresher
-                                            && let Some(schedule) = polled
-                                            && let Err(error) = refresher.apply(&schedule)
-                                        {
-                                            warn!(
-                                                target: "upgrade_signal",
-                                                error = %error,
-                                                "failed to auto-apply live upgrade signal update"
-                                            );
-                                        }
+                        loop {
+                            tokio::select! {
+                                _ = &mut signal => break,
+                                _ = interval.tick() => {
+                                    let outcome = tokio::select! {
+                                        _ = &mut signal => break,
+                                        outcome = monitor
+                                            .poll_and_apply(&reader, auto_refresher.as_ref()) =>
+                                            outcome,
+                                    };
+                                    // Fail closed: a scheduled upgrade this node cannot support is
+                                    // activating imminently. Panic so the node exits loudly rather
+                                    // than fork off the network at activation.
+                                    if let UpgradeSignalPollOutcome::HaltNode {
+                                        upgrade_id,
+                                        activation_timestamp,
+                                        minimum_protocol_version,
+                                        node_protocol_version,
+                                    } = outcome
+                                    {
+                                        panic!(
+                                            "upgrade signal fail-closed: upgrade {} activates at {} and requires node protocol version {}, but this binary supports {}; upgrade this node to a supported version",
+                                            upgrade_id.contract_id(),
+                                            activation_timestamp,
+                                            PackedProtocolVersion::new(minimum_protocol_version),
+                                            PackedProtocolVersion::new(node_protocol_version),
+                                        );
                                     }
                                 }
                             }
                         }
-                    }
-                })
-            });
+                    })
+                },
+            );
 
             info!(target: "upgrade_signal", "execution upgrade signal metrics observer spawned");
             Ok(())

--- a/crates/utilities/upgrade-signal/Cargo.toml
+++ b/crates/utilities/upgrade-signal/Cargo.toml
@@ -43,7 +43,7 @@ serde = { workspace = true, features = ["derive", "std"] }
 [dev-dependencies]
 rstest.workspace = true
 httpmock.workspace = true
-tokio = { workspace = true, features = ["macros"] }
+tokio = { workspace = true, features = ["macros", "rt", "time"] }
 
 [features]
 default = []

--- a/crates/utilities/upgrade-signal/src/config/mod.rs
+++ b/crates/utilities/upgrade-signal/src/config/mod.rs
@@ -1,6 +1,7 @@
 //! Upgrade signal configuration and CLI arguments.
 
 use core::time::Duration;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use alloy_primitives::U256;
 
@@ -10,7 +11,7 @@ mod args;
 pub use args::{UpgradeSignalArgs, UpgradeSignalL1RpcArgs, UpgradeSignalStartupConfig};
 
 mod schedule;
-pub use schedule::UpgradeSignalConfig;
+pub use schedule::{StartupScheduleAction, UpgradeSignalConfig};
 
 mod types;
 pub use types::{UpgradeSignalBlockTag, UpgradeSignalMode, UpgradeSignalStartupMode};
@@ -36,9 +37,27 @@ impl UpgradeSignalDefaults {
     /// not yet returned a valid schedule.
     ///
     /// Startup blocks indefinitely on an empty or unreachable contract (see
-    /// [`UpgradeSignalConfig::read_required_startup_schedule`](crate::UpgradeSignalConfig::read_required_startup_schedule)),
+    /// [`UpgradeSignalConfig::read_startup_schedule`](crate::UpgradeSignalConfig::read_startup_schedule)),
     /// so this is paced to keep the loud retry logs legible rather than to recover quickly.
     pub const STARTUP_SCHEDULE_RETRY_INTERVAL: Duration = Duration::from_secs(5);
+
+    /// Current unix time in seconds, used to compare against upgrade activation timestamps.
+    ///
+    /// A backwards clock (before the epoch) is treated as `0`, which only makes the fail-closed
+    /// check more conservative (an upgrade looks nearer), never less.
+    pub fn now_secs() -> u64 {
+        SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0)
+    }
+
+    /// Lead time before an unsupportable upgrade's activation at which the live poller fails the
+    /// node closed.
+    ///
+    /// When the runtime poller (in [`UpgradeSignalMode::RuntimeAdmin`]) observes a scheduled
+    /// upgrade this node's protocol version is too old to apply, it alarms loudly but keeps running
+    /// while the activation is more than this far away, giving the operator time to upgrade the
+    /// node. Once the activation is within this window (or already past), the node halts (fail
+    /// closed) rather than continue and fork off the network at activation.
+    pub const APPLY_HALT_LEAD_TIME: Duration = Duration::from_secs(24 * 60 * 60);
 
     /// Node protocol version supported by this binary for contract-backed upgrade signals.
     ///

--- a/crates/utilities/upgrade-signal/src/config/mod.rs
+++ b/crates/utilities/upgrade-signal/src/config/mod.rs
@@ -49,15 +49,22 @@ impl UpgradeSignalDefaults {
         SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0)
     }
 
-    /// Lead time before an unsupportable upgrade's activation at which the live poller fails the
-    /// node closed.
+    /// Number of L1 read intervals before an unsupportable upgrade's activation at which the node
+    /// fails closed. See [`UpgradeSignalConfig::halt_lead_time`] for the derived window.
     ///
-    /// When the runtime poller (in [`UpgradeSignalMode::RuntimeAdmin`]) observes a scheduled
-    /// upgrade this node's protocol version is too old to apply, it alarms loudly but keeps running
-    /// while the activation is more than this far away, giving the operator time to upgrade the
-    /// node. Once the activation is within this window (or already past), the node halts (fail
-    /// closed) rather than continue and fork off the network at activation.
-    pub const APPLY_HALT_LEAD_TIME: Duration = Duration::from_secs(24 * 60 * 60);
+    /// The node must halt *before* activation to avoid forking, so the halt window has to be wide
+    /// enough that at least one poll reliably lands inside it — hence a small multiple of the poll
+    /// cadence rather than a fixed constant, which also keeps it correct across the `latest`,
+    /// `safe`, and `finalized` block tags.
+    ///
+    /// The window is deliberately short. A large lead would *front-run* the outage: it halts every
+    /// outdated node long before activation, and — worse — before governance could still correct a
+    /// mistakenly scheduled upgrade by clearing or rescheduling the signal (which a running node
+    /// would pick up on its next poll and never halt). Early operator warning does not depend on
+    /// this window: the sticky `apply_failed` alarm is raised on *every* failed apply regardless of
+    /// how far off the activation is. The halt only needs enough margin to stop just ahead of
+    /// activation.
+    pub const HALT_LEAD_POLL_INTERVALS: u32 = 2;
 
     /// Node protocol version supported by this binary for contract-backed upgrade signals.
     ///

--- a/crates/utilities/upgrade-signal/src/config/schedule.rs
+++ b/crates/utilities/upgrade-signal/src/config/schedule.rs
@@ -245,19 +245,6 @@ impl UpgradeSignalConfig {
         Ok(schedule)
     }
 
-    /// Reads the L1 schedule via [`Self::read_schedule`] and validates its protocol versions.
-    pub async fn read_validated_schedule(
-        &self,
-        reader: &AlloyUpgradeSignalReader,
-        log_context: &'static str,
-        metrics_layers: &[UpgradeSignalMetricLayer],
-    ) -> Result<UpgradeSignalSchedule, UpgradeSignalError> {
-        let schedule = self.read_schedule(reader, log_context, metrics_layers).await?;
-        self.validate_schedule_protocol_versions(&schedule)?;
-
-        Ok(schedule)
-    }
-
     /// Reads the startup schedule and applies the fail-closed policy, returning whether it should be
     /// applied.
     ///

--- a/crates/utilities/upgrade-signal/src/config/schedule.rs
+++ b/crates/utilities/upgrade-signal/src/config/schedule.rs
@@ -134,6 +134,20 @@ impl UpgradeSignalConfig {
         Ok(())
     }
 
+    /// Lead time before an unsupportable upgrade's activation at which the node fails closed.
+    ///
+    /// Derived from the configured L1 block tag's poll cadence
+    /// ([`UpgradeSignalDefaults::HALT_LEAD_POLL_INTERVALS`] × the tag's poll interval) rather than a
+    /// fixed constant, so the halt reliably lands one or more polls *before* activation whether the
+    /// node reads `latest`, `safe`, or `finalized`. See
+    /// [`UpgradeSignalDefaults::HALT_LEAD_POLL_INTERVALS`] for why the window is kept short.
+    pub const fn halt_lead_time(&self) -> Duration {
+        Duration::from_secs(
+            self.l1_block_tag.poll_interval().as_secs()
+                * UpgradeSignalDefaults::HALT_LEAD_POLL_INTERVALS as u64,
+        )
+    }
+
     /// Returns the first signal that requires the node to fail closed, if any.
     ///
     /// This is a signal whose activation is positive (an activation, not a clear), whose minimum
@@ -304,7 +318,7 @@ impl UpgradeSignalConfig {
         match self.evaluate_startup_schedule(
             &schedule,
             UpgradeSignalDefaults::now_secs(),
-            UpgradeSignalDefaults::APPLY_HALT_LEAD_TIME.as_secs(),
+            self.halt_lead_time().as_secs(),
             metrics_layers,
         )? {
             StartupScheduleAction::Apply => Ok(Some(schedule)),
@@ -497,6 +511,23 @@ mod tests {
         assert_eq!(config.request_timeout, UpgradeSignalDefaults::REQUEST_TIMEOUT);
     }
 
+    #[rstest]
+    #[case(UpgradeSignalBlockTag::Finalized)]
+    #[case(UpgradeSignalBlockTag::Safe)]
+    #[case(UpgradeSignalBlockTag::Latest)]
+    fn halt_lead_time_is_a_small_multiple_of_the_poll_interval(#[case] tag: UpgradeSignalBlockTag) {
+        // The halt window is derived from the read cadence (never a fixed 24h) so it lands one or
+        // more polls before activation regardless of the block tag, and is short enough not to
+        // front-run the outage.
+        let mut config = supported_config();
+        config.l1_block_tag = tag;
+
+        assert_eq!(
+            config.halt_lead_time(),
+            tag.poll_interval() * UpgradeSignalDefaults::HALT_LEAD_POLL_INTERVALS
+        );
+    }
+
     fn signal(protocol_version: U256) -> UpgradeSignal {
         UpgradeSignal { upgrade_id: BaseUpgrade::Azul, activation_timestamp: 42, protocol_version }
     }
@@ -666,7 +697,7 @@ mod tests {
     #[test]
     fn startup_applies_a_supported_schedule() {
         let config = config_with_mode(UpgradeSignalMode::RuntimeAdmin);
-        let lead = UpgradeSignalDefaults::APPLY_HALT_LEAD_TIME.as_secs();
+        let lead = config.halt_lead_time().as_secs();
         let schedule =
             schedule_at(1_000_000, UpgradeSignalDefaults::packed_protocol_version(1, 1, 0));
 
@@ -679,7 +710,7 @@ mod tests {
     #[test]
     fn startup_aborts_when_an_unsupportable_upgrade_is_imminent() {
         let config = config_with_mode(UpgradeSignalMode::RuntimeAdmin);
-        let lead = UpgradeSignalDefaults::APPLY_HALT_LEAD_TIME.as_secs();
+        let lead = config.halt_lead_time().as_secs();
         let activation = 1_000_000;
         let schedule =
             schedule_at(activation, UpgradeSignalDefaults::packed_protocol_version(1, 1, 1));
@@ -698,7 +729,7 @@ mod tests {
     #[test]
     fn startup_skips_a_distant_unsupportable_upgrade_when_a_live_poller_will_backstop_it() {
         let config = config_with_mode(UpgradeSignalMode::RuntimeAdmin);
-        let lead = UpgradeSignalDefaults::APPLY_HALT_LEAD_TIME.as_secs();
+        let lead = config.halt_lead_time().as_secs();
         let schedule =
             schedule_at(u64::MAX, UpgradeSignalDefaults::packed_protocol_version(1, 1, 1));
 
@@ -711,7 +742,7 @@ mod tests {
     #[test]
     fn startup_stays_strict_for_a_distant_unsupportable_upgrade_without_a_live_poller() {
         let config = config_with_mode(UpgradeSignalMode::StartupApply);
-        let lead = UpgradeSignalDefaults::APPLY_HALT_LEAD_TIME.as_secs();
+        let lead = config.halt_lead_time().as_secs();
         let schedule =
             schedule_at(u64::MAX, UpgradeSignalDefaults::packed_protocol_version(1, 1, 1));
 
@@ -721,7 +752,7 @@ mod tests {
     #[test]
     fn startup_skips_a_malformed_signal_in_runtime_admin_and_never_fails_closed_on_it() {
         let config = config_with_mode(UpgradeSignalMode::RuntimeAdmin);
-        let lead = UpgradeSignalDefaults::APPLY_HALT_LEAD_TIME.as_secs();
+        let lead = config.halt_lead_time().as_secs();
         // A malformed signal (positive activation, no minimum version), even long overdue.
         let schedule = schedule_at(1, U256::ZERO);
 

--- a/crates/utilities/upgrade-signal/src/config/schedule.rs
+++ b/crates/utilities/upgrade-signal/src/config/schedule.rs
@@ -31,6 +31,16 @@ pub struct UpgradeSignalConfig {
     pub request_timeout: Duration,
 }
 
+/// What a node should do with a startup schedule after the fail-closed policy has been applied.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StartupScheduleAction {
+    /// Apply the schedule to the node's configuration.
+    Apply,
+    /// Do not apply the schedule; the node is starting with a loud alarm because it cannot apply an
+    /// upgrade that is still far from activation (a live poller will fail it closed later).
+    Skip,
+}
+
 impl UpgradeSignalConfig {
     /// Creates a new schedule read configuration for the full contract-backed upgrade set.
     pub fn new(contract_address: Address) -> Self {
@@ -93,10 +103,12 @@ impl UpgradeSignalConfig {
             return Ok(());
         }
 
+        // Render both versions as semver (not the raw >70-digit packed decimals) so the error
+        // message states the exact node-vs-contract gap an operator must close.
         Err(UpgradeSignalError::unsupported_protocol_version(
             signal.upgrade_id.contract_id().to_string(),
-            signal.protocol_version,
-            self.node_protocol_version,
+            PackedProtocolVersion::new(signal.protocol_version),
+            PackedProtocolVersion::new(self.node_protocol_version),
         ))
     }
 
@@ -122,6 +134,28 @@ impl UpgradeSignalConfig {
         Ok(())
     }
 
+    /// Returns the first signal that requires the node to fail closed, if any.
+    ///
+    /// This is a signal whose activation is positive (an activation, not a clear), whose minimum
+    /// protocol version this node is too old to support, and whose activation is at most
+    /// `lead_secs` seconds after `now_secs` (or already past). Such an upgrade will fork the network
+    /// at activation and this node cannot follow it, so the node must halt before then.
+    ///
+    /// A malformed signal (a positive activation with a zero minimum version) is deliberately *not*
+    /// returned here: a zero version is trivially supported by the version check, so it is surfaced
+    /// as a non-fatal alarm elsewhere rather than halting the node on an L1 misconfiguration.
+    pub fn fail_closed_upgrade<'a>(
+        &self,
+        schedule: &'a UpgradeSignalSchedule,
+        now_secs: u64,
+        lead_secs: u64,
+    ) -> Option<&'a UpgradeSignal> {
+        schedule.signals.iter().find(|signal| {
+            self.validate_signal_supported_protocol_version(signal).is_err()
+                && now_secs.saturating_add(lead_secs) >= signal.activation_timestamp
+        })
+    }
+
     /// Reads the L1 startup schedule and applies it to both sinks.
     ///
     /// Execution is applied before consensus so an execution-only validation failure leaves the
@@ -141,14 +175,17 @@ impl UpgradeSignalConfig {
         CL::Error: std::error::Error + Send + Sync + 'static,
     {
         let reader = self.reader(l1_rpc)?;
-        let schedule = self
-            .read_required_startup_schedule(
+        let Some(schedule) = self
+            .read_startup_schedule(
                 &reader,
                 log_context,
                 &[UpgradeSignalMetricLayer::Execution, UpgradeSignalMetricLayer::Consensus],
                 UpgradeSignalDefaults::STARTUP_SCHEDULE_RETRY_INTERVAL,
             )
-            .await?;
+            .await?
+        else {
+            return Ok(());
+        };
 
         UpgradeSignalRuntimeApplier::apply_schedule_to_sink(chain_id, &schedule, execution_sink)
             .map_err(eyre::Report::new)?
@@ -207,37 +244,43 @@ impl UpgradeSignalConfig {
         Ok(schedule)
     }
 
-    /// Reads the startup schedule via [`Self::read_validated_schedule`], blocking until the L1
-    /// contract returns a valid, non-empty schedule.
+    /// Reads the startup schedule and applies the fail-closed policy, returning whether it should be
+    /// applied.
     ///
-    /// This is fail-closed by design. A healthy append-only `ProtocolVersions` contract is never
-    /// empty, so an empty read (like a transient provider failure) means the node cannot yet see
-    /// the authoritative activation schedule. Booting on the genesis/base configuration would risk
-    /// activating forks at different times than peers that read a populated contract, forking the
-    /// node — and any blocks it builds — off the network. Rather than take that risk, this retries
-    /// without an attempt limit, logging loudly at `error!` on every failure, until the read
-    /// succeeds. Only unrecoverable errors that waiting cannot fix — malformed contract data
-    /// ([`UpgradeSignalError::Decode`]) or a missing/unsupported protocol version — propagate and
-    /// abort startup. This future is cancellation-safe: dropping it during shutdown cancels the
-    /// in-flight request or retry sleep.
+    /// Two fail-closed behaviors combine here:
     ///
-    /// This is the startup counterpart to the manual admin refresh, which instead surfaces an empty
-    /// schedule as an error without retrying.
+    /// * **Empty or unreachable contract** — a healthy append-only `ProtocolVersions` contract is
+    ///   never empty, so an empty read (like a transient provider failure) means the node cannot yet
+    ///   see the authoritative activation schedule. Booting on the genesis/base configuration would
+    ///   risk activating forks at different times than peers that read a populated contract, forking
+    ///   the node — and any blocks it builds — off the network. Rather than take that risk, the read
+    ///   retries without an attempt limit, logging loudly at `error!` on every failure, until the
+    ///   contract returns a non-empty schedule. Only unrecoverable errors that waiting cannot fix —
+    ///   malformed contract data ([`UpgradeSignalError::Decode`]) — propagate and abort startup.
+    ///   This future is cancellation-safe: dropping it during shutdown cancels the in-flight request
+    ///   or retry sleep.
+    /// * **Unsupportable upgrade** — once a non-empty schedule is read, the lead-time fail-closed
+    ///   policy is applied so a restart is not blocked by an upgrade that is still far off: see
+    ///   [`Self::evaluate_startup_schedule`]. Returns `None` when the schedule must be skipped
+    ///   (started with an alarm), or an error that must abort startup.
     ///
-    /// `retry_interval` is the fixed delay between attempts; it is paced for legible retry logs
-    /// rather than fast recovery (see
+    /// `retry_interval` is the fixed delay between empty/provider retries; it is paced for legible
+    /// retry logs rather than fast recovery (see
     /// [`UpgradeSignalDefaults::STARTUP_SCHEDULE_RETRY_INTERVAL`]).
-    pub async fn read_required_startup_schedule(
+    pub async fn read_startup_schedule(
         &self,
         reader: &AlloyUpgradeSignalReader,
         log_context: &'static str,
         metrics_layers: &[UpgradeSignalMetricLayer],
         retry_interval: Duration,
-    ) -> Result<UpgradeSignalSchedule, UpgradeSignalError> {
+    ) -> Result<Option<UpgradeSignalSchedule>, UpgradeSignalError> {
         let mut attempt = 1_u64;
         let backoff = ConstantBuilder::default().with_delay(retry_interval).without_max_times();
 
-        (|| self.read_validated_schedule(reader, log_context, metrics_layers))
+        // Retry only the raw read until the contract is non-empty and reachable. Validation and the
+        // lead-time policy run once on the resulting schedule (below), so a distant unsupportable
+        // upgrade is deferred to the policy rather than retried forever.
+        let schedule = (|| self.read_schedule(reader, log_context, metrics_layers))
             .retry(backoff)
             .when(|error| {
                 matches!(
@@ -256,7 +299,78 @@ impl UpgradeSignalConfig {
                 );
                 attempt += 1;
             })
-            .await
+            .await?;
+
+        match self.evaluate_startup_schedule(
+            &schedule,
+            UpgradeSignalDefaults::now_secs(),
+            UpgradeSignalDefaults::APPLY_HALT_LEAD_TIME.as_secs(),
+            metrics_layers,
+        )? {
+            StartupScheduleAction::Apply => Ok(Some(schedule)),
+            StartupScheduleAction::Skip => Ok(None),
+        }
+    }
+
+    /// Applies the startup fail-closed policy to an already-read schedule.
+    ///
+    /// This is the startup analogue of the runtime poller's fail-closed handling, so a node that
+    /// applies at startup behaves consistently with one that polls live:
+    ///
+    /// * If an unsupportable upgrade activates within `lead_secs` of `now_secs` (or is overdue), the
+    ///   node must not start only to fork at activation — this returns an error that aborts startup.
+    /// * Otherwise, if the schedule fully validates, it is applied.
+    /// * If validation fails but nothing is imminent (a far-future unsupportable upgrade or a
+    ///   malformed L1 signal), the handling depends on whether a live poller will back-stop it:
+    ///   [`UpgradeSignalMode::RuntimeAdmin`] starts with a loud alarm and skips applying (the poller
+    ///   will fail closed once the upgrade nears activation), while a mode without a live poller
+    ///   stays strict and aborts startup, since nothing would catch the upgrade later.
+    pub fn evaluate_startup_schedule(
+        &self,
+        schedule: &UpgradeSignalSchedule,
+        now_secs: u64,
+        lead_secs: u64,
+        metrics_layers: &[UpgradeSignalMetricLayer],
+    ) -> Result<StartupScheduleAction, UpgradeSignalError> {
+        if let Some(signal) = self.fail_closed_upgrade(schedule, now_secs, lead_secs) {
+            for layer in metrics_layers {
+                UpgradeSignalMetrics::record_fail_closed(*layer, signal);
+            }
+            error!(
+                target: "upgrade_signal",
+                upgrade = %signal.upgrade_id.contract_id(),
+                activation_timestamp = signal.activation_timestamp,
+                node_protocol_version = %PackedProtocolVersion::new(self.node_protocol_version),
+                minimum_protocol_version = %PackedProtocolVersion::new(signal.protocol_version),
+                "refusing to start (fail closed): a scheduled L1 upgrade activates within the halt lead time but this node's protocol version is too old to apply it; upgrade this node to a supported version"
+            );
+            return Err(UpgradeSignalError::NodeUpgradeRequired {
+                upgrade_id: signal.upgrade_id.contract_id().to_string(),
+                activation_timestamp: signal.activation_timestamp,
+                minimum_protocol_version: PackedProtocolVersion::new(signal.protocol_version)
+                    .to_string(),
+                node_protocol_version: PackedProtocolVersion::new(self.node_protocol_version)
+                    .to_string(),
+            });
+        }
+
+        let Err(validation_error) = self.validate_schedule_protocol_versions(schedule) else {
+            return Ok(StartupScheduleAction::Apply);
+        };
+
+        // Validation failed but nothing is imminent. Only a mode with a live poller can safely start
+        // and defer the halt; other modes stay strict.
+        if !self.mode.allows_runtime_admin() {
+            return Err(validation_error);
+        }
+        error!(
+            target: "upgrade_signal",
+            node_protocol_version = %PackedProtocolVersion::new(self.node_protocol_version),
+            contract_protocol_versions = %schedule.required_protocol_versions(),
+            error = %validation_error,
+            "starting despite an L1 upgrade schedule that cannot be applied locally; upgrade this node before the upgrade nears activation or it will fail closed and stop"
+        );
+        Ok(StartupScheduleAction::Skip)
     }
 }
 
@@ -306,14 +420,15 @@ mod tests {
         let reader = config.reader(server.url("/").parse().unwrap()).unwrap();
 
         let schedule = config
-            .read_required_startup_schedule(
+            .read_startup_schedule(
                 &reader,
                 "startup",
                 &[UpgradeSignalMetricLayer::Consensus],
                 Duration::from_millis(10),
             )
             .await
-            .unwrap();
+            .unwrap()
+            .expect("a supported schedule is applied");
 
         assert_eq!(schedule.signals.len(), 1);
         assert_eq!(schedule.signals[0].upgrade_id, BaseUpgrade::Regolith);
@@ -338,7 +453,7 @@ mod tests {
             MockL1::mock_get_schedule(&server, single_zeroed_entry()).await;
         };
         let (schedule, ()) = tokio::join!(
-            config.read_required_startup_schedule(
+            config.read_startup_schedule(
                 &reader,
                 "startup",
                 &[UpgradeSignalMetricLayer::Consensus],
@@ -347,7 +462,7 @@ mod tests {
             swap,
         );
 
-        let schedule = schedule.unwrap();
+        let schedule = schedule.unwrap().expect("a supported schedule is applied");
         assert_eq!(schedule.signals.len(), 1);
         assert_eq!(schedule.signals[0].upgrade_id, BaseUpgrade::Regolith);
     }
@@ -362,7 +477,7 @@ mod tests {
         let reader = config.reader(server.url("/").parse().unwrap()).unwrap();
 
         let error = config
-            .read_required_startup_schedule(
+            .read_startup_schedule(
                 &reader,
                 "startup",
                 &[UpgradeSignalMetricLayer::Consensus],
@@ -527,5 +642,92 @@ mod tests {
         );
 
         assert!(config.validate_schedule_protocol_versions(&schedule).is_ok());
+    }
+
+    const STARTUP_LAYERS: &[UpgradeSignalMetricLayer] = &[UpgradeSignalMetricLayer::Consensus];
+
+    fn config_with_mode(mode: UpgradeSignalMode) -> UpgradeSignalConfig {
+        let mut config = supported_config();
+        config.mode = mode;
+        config
+    }
+
+    fn schedule_at(activation_timestamp: u64, protocol_version: U256) -> UpgradeSignalSchedule {
+        UpgradeSignalSchedule::new(
+            1,
+            vec![UpgradeSignal {
+                upgrade_id: BaseUpgrade::Azul,
+                activation_timestamp,
+                protocol_version,
+            }],
+        )
+    }
+
+    #[test]
+    fn startup_applies_a_supported_schedule() {
+        let config = config_with_mode(UpgradeSignalMode::RuntimeAdmin);
+        let lead = UpgradeSignalDefaults::APPLY_HALT_LEAD_TIME.as_secs();
+        let schedule =
+            schedule_at(1_000_000, UpgradeSignalDefaults::packed_protocol_version(1, 1, 0));
+
+        assert_eq!(
+            config.evaluate_startup_schedule(&schedule, 0, lead, STARTUP_LAYERS).unwrap(),
+            StartupScheduleAction::Apply
+        );
+    }
+
+    #[test]
+    fn startup_aborts_when_an_unsupportable_upgrade_is_imminent() {
+        let config = config_with_mode(UpgradeSignalMode::RuntimeAdmin);
+        let lead = UpgradeSignalDefaults::APPLY_HALT_LEAD_TIME.as_secs();
+        let activation = 1_000_000;
+        let schedule =
+            schedule_at(activation, UpgradeSignalDefaults::packed_protocol_version(1, 1, 1));
+
+        assert!(matches!(
+            config.evaluate_startup_schedule(
+                &schedule,
+                activation - lead + 1,
+                lead,
+                STARTUP_LAYERS
+            ),
+            Err(UpgradeSignalError::NodeUpgradeRequired { .. })
+        ));
+    }
+
+    #[test]
+    fn startup_skips_a_distant_unsupportable_upgrade_when_a_live_poller_will_backstop_it() {
+        let config = config_with_mode(UpgradeSignalMode::RuntimeAdmin);
+        let lead = UpgradeSignalDefaults::APPLY_HALT_LEAD_TIME.as_secs();
+        let schedule =
+            schedule_at(u64::MAX, UpgradeSignalDefaults::packed_protocol_version(1, 1, 1));
+
+        assert_eq!(
+            config.evaluate_startup_schedule(&schedule, 0, lead, STARTUP_LAYERS).unwrap(),
+            StartupScheduleAction::Skip
+        );
+    }
+
+    #[test]
+    fn startup_stays_strict_for_a_distant_unsupportable_upgrade_without_a_live_poller() {
+        let config = config_with_mode(UpgradeSignalMode::StartupApply);
+        let lead = UpgradeSignalDefaults::APPLY_HALT_LEAD_TIME.as_secs();
+        let schedule =
+            schedule_at(u64::MAX, UpgradeSignalDefaults::packed_protocol_version(1, 1, 1));
+
+        assert!(config.evaluate_startup_schedule(&schedule, 0, lead, STARTUP_LAYERS).is_err());
+    }
+
+    #[test]
+    fn startup_skips_a_malformed_signal_in_runtime_admin_and_never_fails_closed_on_it() {
+        let config = config_with_mode(UpgradeSignalMode::RuntimeAdmin);
+        let lead = UpgradeSignalDefaults::APPLY_HALT_LEAD_TIME.as_secs();
+        // A malformed signal (positive activation, no minimum version), even long overdue.
+        let schedule = schedule_at(1, U256::ZERO);
+
+        assert_eq!(
+            config.evaluate_startup_schedule(&schedule, u64::MAX, lead, STARTUP_LAYERS).unwrap(),
+            StartupScheduleAction::Skip
+        );
     }
 }

--- a/crates/utilities/upgrade-signal/src/error.rs
+++ b/crates/utilities/upgrade-signal/src/error.rs
@@ -44,6 +44,21 @@ pub enum UpgradeSignalError {
         /// Node protocol version supported by this binary.
         node_protocol_version: String,
     },
+    /// The node halted (fail closed) because a scheduled upgrade it is too old to support is
+    /// activating imminently; continuing would fork the node off the network.
+    #[error(
+        "node halted (fail closed): upgrade {upgrade_id} activates at {activation_timestamp} and requires node protocol version {minimum_protocol_version} (this binary supports {node_protocol_version}); upgrade this node to a supported version"
+    )]
+    NodeUpgradeRequired {
+        /// Upgrade ID whose activation forced the halt.
+        upgrade_id: String,
+        /// L2 activation timestamp of the unsupportable upgrade.
+        activation_timestamp: u64,
+        /// Minimum node protocol version read from L1.
+        minimum_protocol_version: String,
+        /// Node protocol version supported by this binary.
+        node_protocol_version: String,
+    },
 }
 
 impl UpgradeSignalError {

--- a/crates/utilities/upgrade-signal/src/lib.rs
+++ b/crates/utilities/upgrade-signal/src/lib.rs
@@ -9,8 +9,8 @@
 
 mod config;
 pub use config::{
-    UpgradeSignalArgs, UpgradeSignalBlockTag, UpgradeSignalConfig, UpgradeSignalDefaults,
-    UpgradeSignalL1RpcArgs, UpgradeSignalMode, UpgradeSignalStartupConfig,
+    StartupScheduleAction, UpgradeSignalArgs, UpgradeSignalBlockTag, UpgradeSignalConfig,
+    UpgradeSignalDefaults, UpgradeSignalL1RpcArgs, UpgradeSignalMode, UpgradeSignalStartupConfig,
     UpgradeSignalStartupMode,
 };
 
@@ -33,7 +33,9 @@ pub use runtime::{
 };
 
 mod state;
-pub use state::{UpgradeSignal, UpgradeSignalMonitor, UpgradeSignalSchedule};
+pub use state::{
+    UpgradeSignal, UpgradeSignalMonitor, UpgradeSignalPollOutcome, UpgradeSignalSchedule,
+};
 
 mod version;
 pub use version::PackedProtocolVersion;

--- a/crates/utilities/upgrade-signal/src/metrics.rs
+++ b/crates/utilities/upgrade-signal/src/metrics.rs
@@ -46,6 +46,18 @@ base_metrics::define_metrics! {
     #[label(layer)]
     #[label(upgrade)]
     signal_updates_total: counter,
+    #[describe("Total failed attempts to apply a live upgrade signal schedule")]
+    #[label(layer)]
+    #[label(upgrade)]
+    apply_failures_total: counter,
+    #[describe("1 while the most recent live apply for an upgrade is failing, else 0")]
+    #[label(layer)]
+    #[label(upgrade)]
+    apply_failed: gauge,
+    #[describe("Total times the node failed closed on an unsupportable upgrade nearing activation")]
+    #[label(layer)]
+    #[label(upgrade)]
+    fail_closed_total: counter,
 }
 
 impl UpgradeSignalMetrics {
@@ -109,6 +121,36 @@ impl UpgradeSignalMetrics {
             .increment(1);
     }
 
+    /// Records a failed live apply of a schedule, raising the sticky failure gauge per upgrade.
+    pub fn record_apply_failure(layer: UpgradeSignalMetricLayer, schedule: &UpgradeSignalSchedule) {
+        Self::init();
+        for signal in &schedule.signals {
+            let upgrade_id = signal.upgrade_id.contract_id().to_string();
+            Self::apply_failures_total(layer.label(), upgrade_id.clone()).increment(1);
+            Self::apply_failed(layer.label(), upgrade_id).set(1.0);
+        }
+    }
+
+    /// Records a successful live apply of a schedule, clearing the sticky failure gauge per upgrade.
+    pub fn record_apply_success(layer: UpgradeSignalMetricLayer, schedule: &UpgradeSignalSchedule) {
+        Self::init();
+        for signal in &schedule.signals {
+            Self::apply_failed(layer.label(), signal.upgrade_id.contract_id().to_string()).set(0.0);
+        }
+    }
+
+    /// Records that the node is failing closed because `signal`'s upgrade is unsupportable and its
+    /// activation is within the halt lead time.
+    ///
+    /// Emitted immediately before the node halts, so the sticky `apply_failed` gauge stays raised.
+    /// The counter is best-effort: it may not be scraped before the process exits, so the loud
+    /// fatal log and the non-zero exit remain the primary signals.
+    pub fn record_fail_closed(layer: UpgradeSignalMetricLayer, signal: &UpgradeSignal) {
+        Self::init();
+        Self::fail_closed_total(layer.label(), signal.upgrade_id.contract_id().to_string())
+            .increment(1);
+    }
+
     /// Converts a packed-semver protocol version to a compact metric gauge value.
     ///
     /// Decoded as `major * 1_000_000 + minor * 1_000 + patch` so the gauge stays readable
@@ -132,5 +174,20 @@ mod tests {
     fn converts_packed_semver_protocol_version_to_metric_value() {
         let version = crate::UpgradeSignalDefaults::packed_protocol_version(1, 1, 0);
         assert_eq!(UpgradeSignalMetrics::protocol_version_to_f64(version), 1_001_000.0);
+    }
+
+    #[test]
+    fn records_apply_outcome_without_panicking() {
+        let schedule = UpgradeSignalSchedule::new(
+            1,
+            vec![UpgradeSignal {
+                upgrade_id: BaseUpgrade::Azul,
+                activation_timestamp: 42,
+                protocol_version: U256::from(7),
+            }],
+        );
+
+        UpgradeSignalMetrics::record_apply_failure(UpgradeSignalMetricLayer::Consensus, &schedule);
+        UpgradeSignalMetrics::record_apply_success(UpgradeSignalMetricLayer::Consensus, &schedule);
     }
 }

--- a/crates/utilities/upgrade-signal/src/runtime/refresher.rs
+++ b/crates/utilities/upgrade-signal/src/runtime/refresher.rs
@@ -30,8 +30,11 @@ impl UpgradeSignalRefresher {
 
     /// Validates and applies an already-read schedule without touching L1.
     ///
-    /// Callers do not retry failures: validation failures are deterministic, and failed reads
-    /// never advance the monitor baseline, so changed signals are re-detected next poll.
+    /// This is atomic: the whole schedule is validated before any registry mutation, so a
+    /// validation failure leaves the runtime registry unchanged. The live poller
+    /// ([`crate::UpgradeSignalMonitor::poll_and_apply`]) advances its applied baseline only when
+    /// this call succeeds, so a failed apply leaves the schedule offered for retry on the next
+    /// poll rather than being silently adopted as the baseline.
     pub fn apply(
         &self,
         schedule: &UpgradeSignalSchedule,

--- a/crates/utilities/upgrade-signal/src/state.rs
+++ b/crates/utilities/upgrade-signal/src/state.rs
@@ -4,9 +4,12 @@ use std::collections::BTreeMap;
 
 use alloy_primitives::U256;
 use base_common_genesis::BaseUpgrade;
-use tracing::info;
+use tracing::{debug, error, info};
 
-use crate::{AlloyUpgradeSignalReader, UpgradeSignalMetricLayer, UpgradeSignalMetrics};
+use crate::{
+    AlloyUpgradeSignalReader, PackedProtocolVersion, UpgradeSignalDefaults, UpgradeSignalError,
+    UpgradeSignalMetricLayer, UpgradeSignalMetrics, UpgradeSignalRefresher,
+};
 
 /// L1 upgrade signal values for one contract-backed upgrade.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -47,6 +50,27 @@ impl UpgradeSignalSchedule {
     pub const fn new(l1_block_number: u64, signals: Vec<UpgradeSignal>) -> Self {
         Self { l1_block_number, signals }
     }
+
+    /// Renders the minimum node protocol version each active signal demands as space-separated
+    /// `upgrade=version` pairs, using the semver display of the packed contract value.
+    ///
+    /// Only signals with a positive activation timestamp carry a meaningful minimum (a clear
+    /// carries none), so cleared signals are omitted. Used to log the exact node-vs-contract
+    /// version gap when a live apply fails, so it reads directly rather than as packed decimals.
+    pub fn required_protocol_versions(&self) -> String {
+        self.signals
+            .iter()
+            .filter(|signal| signal.activation_timestamp > 0)
+            .map(|signal| {
+                format!(
+                    "{}={}",
+                    signal.upgrade_id.contract_id(),
+                    PackedProtocolVersion::new(signal.protocol_version)
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
 }
 
 /// Result of applying a live signal read to local metrics state.
@@ -72,22 +96,29 @@ impl UpgradeSignalStateUpdate {
     }
 }
 
-/// Stateful live metrics tracker for one contract-backed upgrade.
+/// Stateful live tracker for one contract-backed upgrade.
+///
+/// Two independent baselines are tracked: `observed` advances on every read and drives metrics and
+/// change detection, while `applied` advances only when a schedule is successfully committed to the
+/// runtime registry. Keeping them separate means a failed apply does not poison the baseline: the
+/// signal keeps being offered for apply until a commit actually succeeds.
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
 struct UpgradeSignalState {
-    /// Last signal read from L1 by the live metrics observer.
-    signal: Option<UpgradeSignal>,
+    /// Last signal read from L1 by the live observer.
+    observed: Option<UpgradeSignal>,
+    /// Last signal a successful apply committed to the runtime registry.
+    applied: Option<UpgradeSignal>,
 }
 
 impl UpgradeSignalState {
     /// Creates an empty upgrade signal state tracker.
     const fn new() -> Self {
-        Self { signal: None }
+        Self { observed: None, applied: None }
     }
 
-    /// Applies a newly read live signal.
+    /// Records a newly read live signal against the observed baseline.
     fn update_signal(&mut self, signal: UpgradeSignal) -> UpgradeSignalStateUpdate {
-        let update = match self.signal.as_ref() {
+        let update = match self.observed.as_ref() {
             Some(previous) if previous.has_same_contract_values(&signal) => {
                 UpgradeSignalStateUpdate::Unchanged
             }
@@ -95,18 +126,55 @@ impl UpgradeSignalState {
             None => UpgradeSignalStateUpdate::Initialized,
         };
 
-        self.signal = Some(signal);
+        self.observed = Some(signal);
         update
+    }
+
+    /// Returns true when `signal` has not yet been successfully applied.
+    fn needs_apply(&self, signal: &UpgradeSignal) -> bool {
+        self.applied.as_ref().is_none_or(|applied| !applied.has_same_contract_values(signal))
+    }
+
+    /// Advances the applied baseline after a successful commit.
+    fn mark_applied(&mut self, signal: &UpgradeSignal) {
+        self.applied = Some(signal.clone());
     }
 }
 
-/// Records live upgrade signal metrics without mutating node configuration.
+/// Outcome of a single live poll, telling the caller whether the node must fail closed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[must_use = "a HaltNode outcome must fail the node closed to avoid forking off the network"]
+pub enum UpgradeSignalPollOutcome {
+    /// The node may keep running.
+    Continue,
+    /// A scheduled upgrade this node is too old to support activates within the halt lead time; the
+    /// node must fail closed (stop) rather than continue and fork off the network at activation.
+    ///
+    /// Carries the offending upgrade so the caller can surface a self-contained fatal error without
+    /// re-reading the log.
+    HaltNode {
+        /// Upgrade whose imminent activation forces the halt.
+        upgrade_id: BaseUpgrade,
+        /// L2 activation timestamp of that upgrade.
+        activation_timestamp: u64,
+        /// Minimum node protocol version the upgrade requires (packed).
+        minimum_protocol_version: U256,
+        /// Node protocol version this binary advertises (packed).
+        node_protocol_version: U256,
+    },
+}
+
+/// Records live upgrade signal metrics and, when a refresher is supplied, auto-applies observed
+/// schedule changes.
 #[derive(Debug, Clone)]
 pub struct UpgradeSignalMonitor {
     /// Metric layer recorded by this monitor.
     pub metrics_layer: UpgradeSignalMetricLayer,
-    /// Live metrics state by contract-backed upgrade.
+    /// Live metrics and apply state by contract-backed upgrade.
     states: BTreeMap<BaseUpgrade, UpgradeSignalState>,
+    /// Contract values of the last schedule that failed to apply, used to page only on the first
+    /// occurrence of a persistent failure rather than on every poll.
+    last_apply_failure: Option<Vec<UpgradeSignal>>,
 }
 
 impl UpgradeSignalMonitor {
@@ -117,37 +185,180 @@ impl UpgradeSignalMonitor {
         for upgrade_id in BaseUpgrade::CONTRACT_VARIANTS {
             states.insert(upgrade_id, UpgradeSignalState::new());
         }
-        Self { metrics_layer, states }
+        Self { metrics_layer, states, last_apply_failure: None }
     }
 
-    /// Tolerantly polls the reader, records live metrics, and returns the schedule that was read
-    /// when any signals updated.
+    /// Tolerantly polls the reader, records live metrics, and — when `refresher` is supplied —
+    /// applies any schedule not yet successfully committed.
     ///
     /// This is the single live-poll routine shared by the consensus actor and the execution
-    /// metrics extension; read failures are recorded but do not abort the poll. See
-    /// [`UpgradeSignalStateUpdate::requires_apply`] for why a first observation counts as an
-    /// update.
-    pub async fn poll(
+    /// metrics extension. Read failures are recorded but do not abort the poll and do not advance
+    /// either baseline; a schedule that reads cleanly but cannot be applied is handled by
+    /// [`Self::apply_and_evaluate`], which may return [`UpgradeSignalPollOutcome::HaltNode`]. The
+    /// caller MUST fail the node closed on `HaltNode`.
+    pub async fn poll_and_apply(
         &mut self,
         reader: &AlloyUpgradeSignalReader,
-    ) -> Option<UpgradeSignalSchedule> {
-        let metrics_layers = [self.metrics_layer];
-        let schedule = reader.read_schedule_tolerant(&metrics_layers).await?;
-        let updated_signals = self
+        refresher: Option<&UpgradeSignalRefresher>,
+    ) -> UpgradeSignalPollOutcome {
+        let Some(schedule) = reader.read_schedule_tolerant(&[self.metrics_layer]).await else {
+            return UpgradeSignalPollOutcome::Continue;
+        };
+
+        let observed_changes = self
             .update_schedule(schedule.clone())
             .iter()
             .filter(|update| update.requires_apply())
             .count();
-        if updated_signals == 0 {
-            return None;
+        if observed_changes > 0 {
+            info!(
+                target: "upgrade_signal",
+                updated_signals = observed_changes,
+                "observed live L1 upgrade signal update"
+            );
         }
 
-        info!(
-            target: "upgrade_signal",
-            updated_signals,
-            "observed live L1 upgrade signal update"
-        );
-        Some(schedule)
+        let Some(refresher) = refresher else {
+            return UpgradeSignalPollOutcome::Continue;
+        };
+        if !self.schedule_needs_apply(&schedule) {
+            return UpgradeSignalPollOutcome::Continue;
+        }
+
+        self.apply_and_evaluate(refresher, &schedule, UpgradeSignalDefaults::now_secs())
+    }
+
+    /// Applies a schedule to the runtime registry, or decides the node must fail closed.
+    ///
+    /// An apply performs no I/O and cannot flake: the L1 read is a separate, earlier step (whose
+    /// failures return before this point) and the runtime registry write is infallible, so every
+    /// failure is a deterministic local validation error — either an outdated node (the schedule
+    /// requires a newer protocol version than this binary advertises) or a malformed L1 signal (a
+    /// scheduled activation with no minimum protocol version). There is therefore nothing to retry.
+    ///
+    /// On failure the applied baseline is deliberately *not* advanced, so the schedule is re-offered
+    /// (and re-evaluated) on every subsequent poll. Handling depends on the cause:
+    ///
+    /// * **Outdated node** — the node cannot follow the upgrade and will fork off the network at its
+    ///   activation, so this is fail-closed. While the activation is more than
+    ///   [`UpgradeSignalDefaults::APPLY_HALT_LEAD_TIME`] away the poller only alarms loudly (giving
+    ///   the operator time to upgrade); once the activation is within that window (or overdue) it
+    ///   returns [`UpgradeSignalPollOutcome::HaltNode`] and the node stops. This escalates
+    ///   automatically: a future-dated upgrade that is ignored becomes fatal as its activation
+    ///   nears.
+    /// * **Malformed L1 signal** — an L1/governance misconfiguration, not a node-version problem, so
+    ///   the node alarms loudly but never halts (halting every node on a governance typo would be a
+    ///   self-inflicted outage).
+    ///
+    /// Failures raise the sticky `apply_failed` gauge and increment `apply_failures_total`; the
+    /// first occurrence of a distinct failure pages at `error`, later re-observations drop to
+    /// `debug` so a weeks-away upgrade does not spam the log every poll.
+    fn apply_and_evaluate(
+        &mut self,
+        refresher: &UpgradeSignalRefresher,
+        schedule: &UpgradeSignalSchedule,
+        now_secs: u64,
+    ) -> UpgradeSignalPollOutcome {
+        let apply_error = match refresher.apply(schedule) {
+            Ok(_) => {
+                self.mark_schedule_applied(schedule);
+                self.last_apply_failure = None;
+                UpgradeSignalMetrics::record_apply_success(self.metrics_layer, schedule);
+                return UpgradeSignalPollOutcome::Continue;
+            }
+            Err(apply_error) => apply_error,
+        };
+
+        UpgradeSignalMetrics::record_apply_failure(self.metrics_layer, schedule);
+        let first_occurrence =
+            self.last_apply_failure.as_deref() != Some(schedule.signals.as_slice());
+        if first_occurrence {
+            self.last_apply_failure = Some(schedule.signals.clone());
+        }
+
+        // Both sides of the protocol-version comparison, logged as semver so an operator reads the
+        // exact gap straight from the line: `node_protocol_version` is what this binary advertises,
+        // `contract_protocol_versions` is what each active upgrade on L1 demands.
+        let node_protocol_version =
+            PackedProtocolVersion::new(refresher.config.node_protocol_version);
+        let contract_protocol_versions = schedule.required_protocol_versions();
+
+        // Fail closed only for an outdated node whose unsupportable upgrade activates within the
+        // lead time. A malformed signal never reaches here (its zero version is trivially supported
+        // by the check), so `fail_closed_upgrade` returning `Some` implies the outdated-node cause.
+        if let Some(signal) = refresher.config.fail_closed_upgrade(
+            schedule,
+            now_secs,
+            UpgradeSignalDefaults::APPLY_HALT_LEAD_TIME.as_secs(),
+        ) {
+            UpgradeSignalMetrics::record_fail_closed(self.metrics_layer, signal);
+            error!(
+                target: "upgrade_signal",
+                upgrade = %signal.upgrade_id.contract_id(),
+                activation_timestamp = signal.activation_timestamp,
+                node_protocol_version = %node_protocol_version,
+                contract_protocol_versions = %contract_protocol_versions,
+                error = %apply_error,
+                "halting node (fail closed): a scheduled L1 upgrade activates within the halt lead time but this node's protocol version is too old to apply it; the node would fork off the network at activation, so it is stopping. Upgrade this node to a supported version"
+            );
+            return UpgradeSignalPollOutcome::HaltNode {
+                upgrade_id: signal.upgrade_id,
+                activation_timestamp: signal.activation_timestamp,
+                minimum_protocol_version: signal.protocol_version,
+                node_protocol_version: refresher.config.node_protocol_version,
+            };
+        }
+
+        // Non-fatal: an outdated node whose upgrade is still far off, or a malformed L1 signal.
+        // Alarm loudly on the first occurrence, then quieten so a weeks-away upgrade does not spam.
+        let node_outdated =
+            matches!(&apply_error, UpgradeSignalError::UnsupportedProtocolVersion { .. });
+        match (node_outdated, first_occurrence) {
+            (true, true) => error!(
+                target: "upgrade_signal",
+                node_protocol_version = %node_protocol_version,
+                contract_protocol_versions = %contract_protocol_versions,
+                error = %apply_error,
+                "an L1 upgrade schedule cannot be applied locally because this node's protocol version is outdated; upgrade this node before the upgrade activates or it will fail closed and stop"
+            ),
+            (true, false) => debug!(
+                target: "upgrade_signal",
+                node_protocol_version = %node_protocol_version,
+                contract_protocol_versions = %contract_protocol_versions,
+                error = %apply_error,
+                "an L1 upgrade schedule still cannot be applied locally because this node's protocol version is outdated; upgrade this node before the upgrade activates or it will fail closed and stop"
+            ),
+            (false, true) => error!(
+                target: "upgrade_signal",
+                node_protocol_version = %node_protocol_version,
+                contract_protocol_versions = %contract_protocol_versions,
+                error = %apply_error,
+                "an L1 upgrade schedule cannot be applied locally because the L1 signal is malformed (a scheduled activation carries no minimum protocol version); fix the L1 upgrade signal"
+            ),
+            (false, false) => debug!(
+                target: "upgrade_signal",
+                node_protocol_version = %node_protocol_version,
+                contract_protocol_versions = %contract_protocol_versions,
+                error = %apply_error,
+                "an L1 upgrade schedule still cannot be applied locally because the L1 signal is malformed (a scheduled activation carries no minimum protocol version); fix the L1 upgrade signal"
+            ),
+        }
+
+        UpgradeSignalPollOutcome::Continue
+    }
+
+    /// Returns true when any signal in `schedule` has not yet been successfully applied.
+    fn schedule_needs_apply(&self, schedule: &UpgradeSignalSchedule) -> bool {
+        schedule.signals.iter().any(|signal| {
+            self.states.get(&signal.upgrade_id).is_none_or(|state| state.needs_apply(signal))
+        })
+    }
+
+    /// Advances the applied baseline for every signal in a successfully committed schedule.
+    fn mark_schedule_applied(&mut self, schedule: &UpgradeSignalSchedule) {
+        for signal in &schedule.signals {
+            self.states.entry(signal.upgrade_id).or_default().mark_applied(signal);
+        }
     }
 
     /// Applies signals read from L1 and records corresponding live metrics.
@@ -182,9 +393,11 @@ impl UpgradeSignalMonitor {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::U256;
+    use alloy_primitives::{Address, U256};
+    use base_common_genesis::{RuntimeUpgradeRegistry, UpgradeActivation};
 
     use super::*;
+    use crate::UpgradeSignalConfig;
 
     fn signal(timestamp: u64) -> UpgradeSignal {
         UpgradeSignal {
@@ -223,6 +436,25 @@ mod tests {
 
     fn monitor() -> UpgradeSignalMonitor {
         UpgradeSignalMonitor::new(UpgradeSignalMetricLayer::Consensus)
+    }
+
+    /// A refresher whose apply succeeds only when `node_version` satisfies the schedule minimum.
+    fn refresher(chain_id: u64, node_version: U256) -> UpgradeSignalRefresher {
+        let mut config = UpgradeSignalConfig::new(Address::ZERO);
+        config.node_protocol_version = node_version;
+        let reader = config.reader("http://127.0.0.1:1".parse().unwrap()).unwrap();
+        UpgradeSignalRefresher::new(config, reader, chain_id, UpgradeSignalMetricLayer::Consensus)
+    }
+
+    fn versioned_schedule(timestamp: u64, protocol_version: U256) -> UpgradeSignalSchedule {
+        UpgradeSignalSchedule::new(
+            1,
+            vec![UpgradeSignal {
+                upgrade_id: BaseUpgrade::Azul,
+                activation_timestamp: timestamp,
+                protocol_version,
+            }],
+        )
     }
 
     fn schedule(timestamp: u64) -> UpgradeSignalSchedule {
@@ -277,5 +509,217 @@ mod tests {
         monitor.update_schedule(schedule(10));
 
         assert_eq!(monitor.update_schedule(schedule(12)), vec![UpgradeSignalStateUpdate::Changed]);
+    }
+
+    #[test]
+    fn state_needs_apply_until_marked_applied() {
+        let mut state = UpgradeSignalState::new();
+        let signal = signal(10);
+
+        // Never applied: needs apply even before it has been observed.
+        assert!(state.needs_apply(&signal));
+
+        // Observing the signal advances the observed baseline but not the applied baseline.
+        state.update_signal(signal.clone());
+        assert!(state.needs_apply(&signal));
+
+        // Only a successful apply advances the applied baseline.
+        state.mark_applied(&signal);
+        assert!(!state.needs_apply(&signal));
+    }
+
+    #[test]
+    fn state_changed_signal_needs_apply_after_previous_applied() {
+        let mut state = UpgradeSignalState::new();
+
+        state.mark_applied(&signal(10));
+
+        assert!(!state.needs_apply(&signal(10)));
+        assert!(state.needs_apply(&signal(12)));
+    }
+
+    #[test]
+    fn failed_apply_keeps_schedule_offered_for_retry() {
+        let mut monitor = monitor();
+        let schedule = schedule(10);
+
+        // Mirror `poll_and_apply`: observe first (advances the observed baseline), then a failed
+        // apply must NOT advance the applied baseline, so the schedule is offered again next poll.
+        monitor.update_schedule(schedule.clone());
+        assert!(
+            monitor.schedule_needs_apply(&schedule),
+            "an unapplied schedule must remain offered for retry"
+        );
+
+        // A subsequent successful apply advances the applied baseline and stops the retries.
+        monitor.mark_schedule_applied(&schedule);
+        assert!(!monitor.schedule_needs_apply(&schedule));
+    }
+
+    #[test]
+    fn l1_change_after_failed_apply_is_offered() {
+        let mut monitor = monitor();
+
+        // Observe v1 and leave it unapplied (apply failed).
+        monitor.update_schedule(schedule(10));
+        assert!(monitor.schedule_needs_apply(&schedule(10)));
+
+        // L1 then changes to v2, which must still be offered for apply.
+        monitor.update_schedule(schedule(12));
+        assert!(monitor.schedule_needs_apply(&schedule(12)));
+    }
+
+    #[test]
+    fn applied_schedule_is_not_reoffered() {
+        let mut monitor = monitor();
+        let schedule = schedule(10);
+
+        monitor.update_schedule(schedule.clone());
+        monitor.mark_schedule_applied(&schedule);
+
+        // The same contract values, even at a new L1 block number, are not re-offered.
+        let same_values_new_block = UpgradeSignalSchedule::new(2, vec![signal(10)]);
+        assert!(!monitor.schedule_needs_apply(&same_values_new_block));
+    }
+
+    #[test]
+    fn required_protocol_versions_renders_active_signals_as_semver() {
+        let schedule = UpgradeSignalSchedule::new(
+            1,
+            vec![
+                UpgradeSignal {
+                    upgrade_id: BaseUpgrade::Azul,
+                    activation_timestamp: 42,
+                    protocol_version: UpgradeSignalDefaults::packed_protocol_version(1, 2, 3),
+                },
+                // A cleared signal (activation 0) carries no meaningful minimum and is omitted.
+                UpgradeSignal {
+                    upgrade_id: BaseUpgrade::Beryl,
+                    activation_timestamp: 0,
+                    protocol_version: UpgradeSignalDefaults::packed_protocol_version(9, 9, 9),
+                },
+            ],
+        );
+
+        assert_eq!(schedule.required_protocol_versions(), "azul=1.2.3");
+    }
+
+    // A far-future activation the fail-closed check will never consider imminent.
+    const FAR_FUTURE: u64 = u64::MAX;
+
+    #[test]
+    fn apply_and_evaluate_commits_a_supported_schedule() {
+        let chain_id = 9_100_010;
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+
+        // A dev-build node version (the sentinel maximum) satisfies any minimum, so the apply
+        // succeeds and the node continues.
+        let refresher = refresher(chain_id, UpgradeSignalDefaults::node_protocol_version());
+        let schedule =
+            versioned_schedule(42, UpgradeSignalDefaults::packed_protocol_version(1, 1, 0));
+
+        let mut monitor = monitor();
+        monitor.update_schedule(schedule.clone());
+        let outcome = monitor.apply_and_evaluate(&refresher, &schedule, 0);
+
+        assert_eq!(outcome, UpgradeSignalPollOutcome::Continue);
+        assert!(!monitor.schedule_needs_apply(&schedule));
+        assert_eq!(
+            RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul),
+            Some(UpgradeActivation::Timestamp(42))
+        );
+
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+    }
+
+    #[test]
+    fn apply_and_evaluate_alarms_but_continues_for_a_distant_unsupportable_upgrade() {
+        let chain_id = 9_100_011;
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+
+        // Node supports 1.1.0; the schedule demands 1.1.1 and activates far in the future.
+        let node_version = UpgradeSignalDefaults::packed_protocol_version(1, 1, 0);
+        let refresher = refresher(chain_id, node_version);
+        let schedule =
+            versioned_schedule(FAR_FUTURE, UpgradeSignalDefaults::packed_protocol_version(1, 1, 1));
+
+        let mut monitor = monitor();
+        monitor.update_schedule(schedule.clone());
+        let outcome = monitor.apply_and_evaluate(&refresher, &schedule, 0);
+
+        // Not yet fatal: the node keeps running, nothing is committed, and the schedule stays
+        // offered (baseline not advanced) so a later poll re-evaluates it.
+        assert_eq!(outcome, UpgradeSignalPollOutcome::Continue);
+        assert!(monitor.schedule_needs_apply(&schedule));
+        assert_eq!(RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul), None);
+
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+    }
+
+    #[test]
+    fn apply_and_evaluate_halts_when_unsupportable_upgrade_is_within_lead_time() {
+        let chain_id = 9_100_012;
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+
+        let node_version = UpgradeSignalDefaults::packed_protocol_version(1, 1, 0);
+        let refresher = refresher(chain_id, node_version);
+        let activation = 1_000_000;
+        let schedule =
+            versioned_schedule(activation, UpgradeSignalDefaults::packed_protocol_version(1, 1, 1));
+
+        let mut monitor = monitor();
+        monitor.update_schedule(schedule.clone());
+        // "Now" is inside the halt lead time before activation.
+        let now = activation - UpgradeSignalDefaults::APPLY_HALT_LEAD_TIME.as_secs() + 1;
+        let outcome = monitor.apply_and_evaluate(&refresher, &schedule, now);
+
+        assert!(matches!(
+            outcome,
+            UpgradeSignalPollOutcome::HaltNode { upgrade_id: BaseUpgrade::Azul, .. }
+        ));
+        assert_eq!(RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul), None);
+
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+    }
+
+    #[test]
+    fn apply_and_evaluate_alarms_but_never_halts_on_a_malformed_signal() {
+        let chain_id = 9_100_013;
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+
+        // A malformed signal: a positive activation (already overdue) with no minimum version.
+        let refresher = refresher(chain_id, UpgradeSignalDefaults::node_protocol_version());
+        let schedule = versioned_schedule(1, U256::ZERO);
+
+        let mut monitor = monitor();
+        monitor.update_schedule(schedule.clone());
+        // Even with "now" well past the activation, a malformed signal never fails the node closed.
+        let outcome = monitor.apply_and_evaluate(&refresher, &schedule, u64::MAX);
+
+        assert_eq!(outcome, UpgradeSignalPollOutcome::Continue);
+
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+    }
+
+    #[test]
+    fn fail_closed_upgrade_only_flags_imminent_unsupportable_activations() {
+        let mut config = UpgradeSignalConfig::new(Address::ZERO);
+        config.node_protocol_version = UpgradeSignalDefaults::packed_protocol_version(1, 1, 0);
+        let lead = UpgradeSignalDefaults::APPLY_HALT_LEAD_TIME.as_secs();
+        let activation = 1_000_000;
+        let unsupported =
+            versioned_schedule(activation, UpgradeSignalDefaults::packed_protocol_version(1, 1, 1));
+
+        // Outside the lead window: not flagged.
+        assert!(config.fail_closed_upgrade(&unsupported, activation - lead - 1, lead).is_none());
+        // Inside the lead window: flagged.
+        assert!(config.fail_closed_upgrade(&unsupported, activation - lead + 1, lead).is_some());
+        // Overdue: flagged.
+        assert!(config.fail_closed_upgrade(&unsupported, activation + 100, lead).is_some());
+
+        // A supported upgrade is never flagged, even when overdue.
+        let supported =
+            versioned_schedule(activation, UpgradeSignalDefaults::packed_protocol_version(1, 1, 0));
+        assert!(config.fail_closed_upgrade(&supported, activation + 100, lead).is_none());
     }
 }

--- a/crates/utilities/upgrade-signal/src/state.rs
+++ b/crates/utilities/upgrade-signal/src/state.rs
@@ -240,8 +240,8 @@ impl UpgradeSignalMonitor {
     /// (and re-evaluated) on every subsequent poll. Handling depends on the cause:
     ///
     /// * **Outdated node** — the node cannot follow the upgrade and will fork off the network at its
-    ///   activation, so this is fail-closed. While the activation is more than
-    ///   [`UpgradeSignalDefaults::APPLY_HALT_LEAD_TIME`] away the poller only alarms loudly (giving
+    ///   activation, so this is fail-closed. While the activation is more than the halt lead time
+    ///   (see [`crate::UpgradeSignalConfig::halt_lead_time`]) away the poller only alarms loudly (giving
     ///   the operator time to upgrade); once the activation is within that window (or overdue) it
     ///   returns [`UpgradeSignalPollOutcome::HaltNode`] and the node stops. This escalates
     ///   automatically: a future-dated upgrade that is ignored becomes fatal as its activation
@@ -289,7 +289,7 @@ impl UpgradeSignalMonitor {
         if let Some(signal) = refresher.config.fail_closed_upgrade(
             schedule,
             now_secs,
-            UpgradeSignalDefaults::APPLY_HALT_LEAD_TIME.as_secs(),
+            refresher.config.halt_lead_time().as_secs(),
         ) {
             UpgradeSignalMetrics::record_fail_closed(self.metrics_layer, signal);
             error!(
@@ -670,7 +670,7 @@ mod tests {
         let mut monitor = monitor();
         monitor.update_schedule(schedule.clone());
         // "Now" is inside the halt lead time before activation.
-        let now = activation - UpgradeSignalDefaults::APPLY_HALT_LEAD_TIME.as_secs() + 1;
+        let now = activation - refresher.config.halt_lead_time().as_secs() + 1;
         let outcome = monitor.apply_and_evaluate(&refresher, &schedule, now);
 
         assert!(matches!(
@@ -705,7 +705,7 @@ mod tests {
     fn fail_closed_upgrade_only_flags_imminent_unsupportable_activations() {
         let mut config = UpgradeSignalConfig::new(Address::ZERO);
         config.node_protocol_version = UpgradeSignalDefaults::packed_protocol_version(1, 1, 0);
-        let lead = UpgradeSignalDefaults::APPLY_HALT_LEAD_TIME.as_secs();
+        let lead = config.halt_lead_time().as_secs();
         let activation = 1_000_000;
         let unsupported =
             versioned_schedule(activation, UpgradeSignalDefaults::packed_protocol_version(1, 1, 1));

--- a/crates/utilities/upgrade-signal/src/version.rs
+++ b/crates/utilities/upgrade-signal/src/version.rs
@@ -102,6 +102,25 @@ impl PackedProtocolVersion {
     }
 }
 
+impl core::fmt::Display for PackedProtocolVersion {
+    /// Renders the version as human-readable semver for logs and error messages.
+    ///
+    /// A raw `U256` prints as a >70-digit decimal that no operator can read; this decodes the
+    /// packed fields to `major.minor.patch` (with a `-rc.N` suffix for a pre-release). An
+    /// unrecognized version-type has no defined semver layout, so it is surfaced verbatim rather
+    /// than mis-decoded as `0.0.0`.
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        if self.version_type() != 0 {
+            return write!(f, "unknown-version-type-{}", self.version_type());
+        }
+        write!(f, "{}.{}.{}", self.major(), self.minor(), self.patch())?;
+        if self.prerelease() != 0 {
+            write!(f, "-rc.{}", self.prerelease())?;
+        }
+        Ok(())
+    }
+}
+
 impl Ord for PackedProtocolVersion {
     fn cmp(&self, other: &Self) -> Ordering {
         self.ordering_key().cmp(&other.ordering_key())
@@ -126,6 +145,16 @@ mod tests {
         assert_eq!(version.minor(), 2);
         assert_eq!(version.patch(), 3);
         assert_eq!(version.prerelease(), 4);
+    }
+
+    #[test]
+    fn displays_semver_with_optional_prerelease_and_unknown_type() {
+        assert_eq!(PackedProtocolVersion::pack(1, 2, 3, 0).to_string(), "1.2.3");
+        assert_eq!(PackedProtocolVersion::pack(1, 2, 3, 4).to_string(), "1.2.3-rc.4");
+        assert_eq!(
+            PackedProtocolVersion::new(U256::from(2) << 248).to_string(),
+            "unknown-version-type-2"
+        );
     }
 
     #[test]

--- a/etc/systems/src/l2/in_process_consensus.rs
+++ b/etc/systems/src/l2/in_process_consensus.rs
@@ -26,7 +26,8 @@ use base_consensus_peers::{PeerScoreLevel, SecretKeyLoader};
 use base_consensus_rpc::{AdminApiClient, BaseP2PApiClient, RollupNodeApiClient, RpcBuilder};
 use base_consensus_sources::BlockSigner;
 use base_upgrade_signal::{
-    UpgradeSignalConfig, UpgradeSignalMetricLayer, UpgradeSignalRuntimeApplier,
+    UpgradeSignalConfig, UpgradeSignalDefaults, UpgradeSignalMetricLayer,
+    UpgradeSignalRuntimeApplier,
 };
 use eyre::{Result, WrapErr};
 use jsonrpsee::http_client::HttpClientBuilder;
@@ -116,27 +117,32 @@ impl InProcessConsensus {
         let mut rollup_config = config.rollup_config;
         let l1_chain_config = config.l1_chain_config;
 
-        // Mirror the standalone consensus CLI: read the validated L1 schedule and apply it to
-        // the rollup config before the node starts.
+        // Mirror the standalone consensus CLI: apply the fail-closed startup policy (see
+        // `read_startup_schedule`) and apply the schedule to the rollup config before the node
+        // starts. A distant unsupportable upgrade yields `None` (start with an alarm); an imminent
+        // one aborts startup.
         if let Some(signal_config) = &config.upgrade_signal
             && signal_config.mode.applies_at_startup()
         {
             let reader = signal_config.reader(config.l1_rpc_url.clone())?;
             let schedule = signal_config
-                .read_validated_schedule(
+                .read_startup_schedule(
                     &reader,
                     "system test consensus startup",
                     &[UpgradeSignalMetricLayer::Consensus],
+                    UpgradeSignalDefaults::STARTUP_SCHEDULE_RETRY_INTERVAL,
                 )
                 .await
                 .wrap_err("Failed to read upgrade signal schedule at startup")?;
-            UpgradeSignalRuntimeApplier::apply_schedule_to_sink(
-                rollup_config.l2_chain_id.id(),
-                &schedule,
-                &mut rollup_config,
-            )
-            .unwrap_or_else(|never| match never {})
-            .log("rollup config");
+            if let Some(schedule) = schedule {
+                UpgradeSignalRuntimeApplier::apply_schedule_to_sink(
+                    rollup_config.l2_chain_id.id(),
+                    &schedule,
+                    &mut rollup_config,
+                )
+                .unwrap_or_else(|never| match never {})
+                .log("rollup config");
+            }
         }
 
         let rpc_port = config.rpc_port.unwrap_or_else(get_available_port);

--- a/etc/systems/src/l2/in_process_follow_consensus.rs
+++ b/etc/systems/src/l2/in_process_follow_consensus.rs
@@ -21,7 +21,7 @@ use base_upgrade_signal::{
 };
 use eyre::{Result, WrapErr};
 use tokio::{
-    task::JoinHandle,
+    task::{AbortHandle, JoinHandle},
     time::{MissedTickBehavior, interval},
 };
 use tracing::{error, info};
@@ -172,7 +172,12 @@ impl InProcessFollowConsensus {
         // clean it up.
         let upgrade_signal_handle = upgrade_signal
             .map(|signal_config| {
-                Self::spawn_upgrade_signal_monitor(signal_config, l1_rpc_url, l2_chain_id)
+                Self::spawn_upgrade_signal_monitor(
+                    signal_config,
+                    l1_rpc_url,
+                    l2_chain_id,
+                    handle.abort_handle(),
+                )
             })
             .transpose()?;
 
@@ -183,6 +188,7 @@ impl InProcessFollowConsensus {
         signal_config: UpgradeSignalConfig,
         l1_rpc_url: Url,
         l2_chain_id: u64,
+        node_abort: AbortHandle,
     ) -> Result<JoinHandle<()>> {
         let reader = signal_config.reader(l1_rpc_url)?;
         Ok(tokio::spawn(async move {
@@ -200,8 +206,11 @@ impl InProcessFollowConsensus {
 
             loop {
                 poll_interval.tick().await;
-                // Mirror production fail-closed: stop the monitor if a scheduled upgrade this node
-                // cannot support is activating imminently, rather than fork off the network.
+                // Mirror production fail-closed: when a scheduled upgrade this node cannot support is
+                // activating imminently, stop the follow node itself rather than fork off the
+                // network. Production cancels the shared token and exits the process; here the
+                // equivalent is aborting the follow node task (not just this monitor loop), so the
+                // node stops following past activation.
                 if let UpgradeSignalPollOutcome::HaltNode {
                     upgrade_id, activation_timestamp, ..
                 } = monitor.poll_and_apply(&reader, refresher.as_ref()).await
@@ -210,8 +219,9 @@ impl InProcessFollowConsensus {
                         target: "upgrade_signal",
                         upgrade = %upgrade_id.contract_id(),
                         activation_timestamp,
-                        "in-process follow node halting upgrade signal monitor (fail closed)"
+                        "in-process follow node failing closed: aborting follow node task"
                     );
+                    node_abort.abort();
                     break;
                 }
             }

--- a/etc/systems/src/l2/in_process_follow_consensus.rs
+++ b/etc/systems/src/l2/in_process_follow_consensus.rs
@@ -16,15 +16,15 @@ use base_consensus_node::{EngineConfig, FollowNode, FollowNodeConfig, NodeMode, 
 use base_consensus_providers::L1RpcProvider;
 use base_consensus_rpc::RpcBuilder;
 use base_upgrade_signal::{
-    UpgradeSignalConfig, UpgradeSignalMetricLayer, UpgradeSignalMonitor, UpgradeSignalRefresher,
-    UpgradeSignalRuntimeApplier,
+    UpgradeSignalConfig, UpgradeSignalDefaults, UpgradeSignalMetricLayer, UpgradeSignalMonitor,
+    UpgradeSignalPollOutcome, UpgradeSignalRefresher, UpgradeSignalRuntimeApplier,
 };
 use eyre::{Result, WrapErr};
 use tokio::{
     task::JoinHandle,
     time::{MissedTickBehavior, interval},
 };
-use tracing::{info, warn};
+use tracing::{error, info};
 use url::Url;
 
 use super::in_process_consensus::wait_for_rpc;
@@ -82,20 +82,23 @@ impl InProcessFollowConsensus {
         {
             let reader = signal_config.reader(l1_rpc_url.clone())?;
             let schedule = signal_config
-                .read_validated_schedule(
+                .read_startup_schedule(
                     &reader,
                     "system test follow consensus startup",
                     &[UpgradeSignalMetricLayer::Consensus],
+                    UpgradeSignalDefaults::STARTUP_SCHEDULE_RETRY_INTERVAL,
                 )
                 .await
                 .wrap_err("Failed to read upgrade signal schedule at follow consensus startup")?;
-            UpgradeSignalRuntimeApplier::apply_schedule_to_sink(
-                l2_chain_id,
-                &schedule,
-                &mut rollup_config,
-            )
-            .unwrap_or_else(|never| match never {})
-            .log("follow rollup config");
+            if let Some(schedule) = schedule {
+                UpgradeSignalRuntimeApplier::apply_schedule_to_sink(
+                    l2_chain_id,
+                    &schedule,
+                    &mut rollup_config,
+                )
+                .unwrap_or_else(|never| match never {})
+                .log("follow rollup config");
+            }
         }
 
         let rollup_config = Arc::new(rollup_config);
@@ -197,17 +200,19 @@ impl InProcessFollowConsensus {
 
             loop {
                 poll_interval.tick().await;
-                let Some(schedule) = monitor.poll(&reader).await else {
-                    continue;
-                };
-                if let Some(refresher) = &refresher
-                    && let Err(error) = refresher.apply(&schedule)
+                // Mirror production fail-closed: stop the monitor if a scheduled upgrade this node
+                // cannot support is activating imminently, rather than fork off the network.
+                if let UpgradeSignalPollOutcome::HaltNode {
+                    upgrade_id, activation_timestamp, ..
+                } = monitor.poll_and_apply(&reader, refresher.as_ref()).await
                 {
-                    warn!(
+                    error!(
                         target: "upgrade_signal",
-                        error = %error,
-                        "failed to auto-apply follow-mode upgrade signal update"
+                        upgrade = %upgrade_id.contract_id(),
+                        activation_timestamp,
+                        "in-process follow node halting upgrade signal monitor (fail closed)"
                     );
+                    break;
                 }
             }
         }))


### PR DESCRIPTION
## Summary

The live upgrade-signal poller used to retry a failed apply and then discard it, leaving an outdated node running on its old config so it would silently fork off the network at activation. This makes the handling fail-closed instead: a node that cannot support an upgrade nearing activation halts with a non-zero exit rather than diverge, while a malformed L1 signal only alarms loudly (halting the fleet on a governance typo would be a self-inflicted outage). The halt window is derived from the L1 poll cadence rather than a fixed 24 hours, so a node stops just before activation without front-running the outage or blocking a restart on a distant upgrade, and the startup and runtime paths across execution and consensus now behave consistently.