### PR TITLE
fix(genesis): Keep CL/EL Upgrade Activation Consistent

### DIFF
--- a/crates/common/genesis/src/chain/upgrade.rs
+++ b/crates/common/genesis/src/chain/upgrade.rs
@@ -3,6 +3,7 @@
 use alloc::{
     collections::BTreeMap,
     string::{String, ToString},
+    vec::Vec,
 };
 use core::fmt::Display;
 
@@ -204,6 +205,40 @@ impl BaseUpgrade {
             Self::Denim => 12,
             Self::Delta | Self::PectraBlobSchedule | Self::Zenith => return None,
         })
+    }
+
+    /// Returns the upgrade whose activation is *implied* by this one being active, if any.
+    ///
+    /// This is the strictly-ordered cascade chain: a later fork being active implies its
+    /// predecessors are active. It is the single source of that relationship, consumed by the
+    /// `implies` chain in [`RollupConfig`](crate::RollupConfig)'s fork methods,
+    /// [`RollupConfig::ethereum_fork_activation`](crate::RollupConfig::ethereum_fork_activation),
+    /// and cascade-hole normalization. The chain runs the whole activation ladder, from
+    /// [`Regolith`](Self::Regolith) through the Base-specific tail
+    /// [`Azul`](Self::Azul)→[`Beryl`](Self::Beryl)→[`Cobalt`](Self::Cobalt)→[`Denim`](Self::Denim).
+    /// Upgrades outside the chain — block/genesis activated ([`Bedrock`](Self::Bedrock),
+    /// [`Zenith`](Self::Zenith)) and contract-only
+    /// [`PectraBlobSchedule`](Self::PectraBlobSchedule) — return `None`. The match is exhaustive, so
+    /// a new variant cannot be added without deciding where it sits in the cascade.
+    pub const fn cascade_successor(self) -> Option<Self> {
+        match self {
+            Self::Regolith => Some(Self::Canyon),
+            Self::Canyon => Some(Self::Delta),
+            Self::Delta => Some(Self::Ecotone),
+            Self::Ecotone => Some(Self::Fjord),
+            Self::Fjord => Some(Self::Granite),
+            Self::Granite => Some(Self::Holocene),
+            Self::Holocene => Some(Self::Isthmus),
+            Self::Isthmus => Some(Self::Jovian),
+            Self::Jovian => Some(Self::Azul),
+            Self::Azul => Some(Self::Beryl),
+            Self::Beryl => Some(Self::Cobalt),
+            Self::Cobalt => Some(Self::Denim),
+            Self::Denim
+            | Self::Bedrock
+            | Self::PectraBlobSchedule
+            | Self::Zenith => None,
+        }
     }
 
     /// Returns the canonical `snake_case` contract upgrade ID used by the L1 upgrade-signal
@@ -757,7 +792,52 @@ impl UpgradeConfig {
         }
     }
 
+    /// Fills activation "holes" so the cascade chain is monotonic non-decreasing.
+    ///
+    /// A hole is a later upgrade scheduled while one of its predecessors is unscheduled (or
+    /// scheduled later). Because the CL treats a later fork as implying its predecessors are
+    /// active, such a schedule makes cascade-reading consumers (the CL) disagree with
+    /// independent-reading consumers (the EL fork table, [`BaseUpgrade::from_chain_and_timestamp`])
+    /// about whether the predecessor is active. Pulling each predecessor forward to the earliest
+    /// activation of its transitive successors makes the stored schedule match the CL cascade
+    /// semantics, so all consumers agree.
+    ///
+    /// The chain is derived from [`BaseUpgrade::cascade_successor`] (membership) walked in
+    /// [`BaseUpgrade::CONTRACT_VARIANTS`] order (ordering), so it stays in sync with the enum
+    /// without a separate hand-maintained list. Successors always follow their predecessors in
+    /// `CONTRACT_VARIANTS`, so a reverse walk normalizes each successor before the predecessors
+    /// that point at it, letting the earliest downstream activation propagate up the whole chain.
+    ///
+    /// Returns the upgrades whose timestamps were pulled forward, oldest-first, so callers can log
+    /// and record the anomaly. An empty result means the schedule was already a well-formed ladder.
+    pub fn normalize_cascade_ladder(&mut self) -> Vec<(BaseUpgrade, u64)> {
+        let mut filled = Vec::new();
+        for upgrade in BaseUpgrade::CONTRACT_VARIANTS.into_iter().rev() {
+            let Some(successor) = upgrade.cascade_successor() else {
+                continue;
+            };
+            let own = self.activation_timestamp(upgrade);
+            let effective = match (own, self.activation_timestamp(successor)) {
+                (Some(own), Some(successor)) => Some(own.min(successor)),
+                (own, successor) => own.or(successor),
+            };
+            if let Some(effective) = effective
+                && own != Some(effective)
+            {
+                self.set_activation_timestamp(upgrade, effective);
+                filled.push((upgrade, effective));
+            }
+        }
+        filled.reverse();
+        filled
+    }
+
     /// Applies all upgrade activation overrides.
+    ///
+    /// This does not normalize the cascade ladder: the CL reads these overrides through
+    /// cascade-aware fork methods, so a hole cannot cause it to disagree with itself. Independent
+    /// per-fork consumers (the EL fork table) are fed a normalized schedule at ingestion instead
+    /// (see [`normalize_cascade_ladder`](Self::normalize_cascade_ladder)).
     pub fn apply_activation_overrides(&mut self, overrides: &UpgradeActivationOverrides) {
         for (upgrade_id, activation) in &overrides.activations {
             self.set_activation(*upgrade_id, *activation);
@@ -1133,5 +1213,118 @@ mod runtime_tests {
                 Some(BaseUpgrade::Beryl)
             );
         }
+    }
+
+    #[test]
+    fn cascade_successors_follow_predecessors_in_contract_order() {
+        // `normalize_cascade_ladder` relies on every cascade successor appearing after its
+        // predecessor in `CONTRACT_VARIANTS`, so a reverse walk normalizes successors first.
+        let index =
+            |upgrade| BaseUpgrade::CONTRACT_VARIANTS.iter().position(|&variant| variant == upgrade);
+        for upgrade in BaseUpgrade::CONTRACT_VARIANTS {
+            if let Some(successor) = upgrade.cascade_successor() {
+                let upgrade_index = index(upgrade).expect("cascade member is contract-backed");
+                let successor_index =
+                    index(successor).expect("cascade successor is contract-backed");
+                assert!(
+                    upgrade_index < successor_index,
+                    "{upgrade:?} must precede its cascade successor {successor:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn normalize_fills_holes_from_later_scheduled_upgrade() {
+        // A hole: Canyon and Delta cleared while Ecotone stays scheduled at 100.
+        let mut config = UpgradeConfig::default();
+        config.set_activation_timestamp(BaseUpgrade::Regolith, 1);
+        config.set_activation_timestamp(BaseUpgrade::Ecotone, 100);
+
+        let filled = config.normalize_cascade_ladder();
+
+        // Canyon and Delta are pulled forward to Ecotone's timestamp, oldest-first.
+        assert_eq!(filled, alloc::vec![(BaseUpgrade::Canyon, 100), (BaseUpgrade::Delta, 100)]);
+        assert_eq!(config.activation_timestamp(BaseUpgrade::Canyon), Some(100));
+        assert_eq!(config.activation_timestamp(BaseUpgrade::Delta), Some(100));
+        assert_eq!(config.activation_timestamp(BaseUpgrade::Ecotone), Some(100));
+        assert_eq!(config.activation_timestamp(BaseUpgrade::Regolith), Some(1));
+    }
+
+    #[test]
+    fn normalize_clamps_predecessor_scheduled_after_successor() {
+        // A predecessor scheduled later than its successor is pulled back to the successor.
+        let mut config = UpgradeConfig::default();
+        config.set_activation_timestamp(BaseUpgrade::Regolith, 1);
+        config.set_activation_timestamp(BaseUpgrade::Canyon, 200);
+        config.set_activation_timestamp(BaseUpgrade::Ecotone, 100);
+
+        let filled = config.normalize_cascade_ladder();
+
+        // Canyon is clamped back to Ecotone; Delta (unset) is filled to Ecotone too. Regolith
+        // (scheduled earlier at 1) is already valid and left alone.
+        assert_eq!(filled, alloc::vec![(BaseUpgrade::Canyon, 100), (BaseUpgrade::Delta, 100)]);
+        assert_eq!(config.activation_timestamp(BaseUpgrade::Canyon), Some(100));
+        assert_eq!(config.activation_timestamp(BaseUpgrade::Regolith), Some(1));
+    }
+
+    #[test]
+    fn normalize_is_noop_for_wellformed_and_standalone_schedules() {
+        // A fully-scheduled monotonic ladder (through the Base tail) plus a standalone (non-cascade)
+        // Zenith entry is left untouched: there is no hole to fill.
+        let mut config = UpgradeConfig::default();
+        for (upgrade, timestamp) in [
+            (BaseUpgrade::Regolith, 1),
+            (BaseUpgrade::Canyon, 2),
+            (BaseUpgrade::Delta, 3),
+            (BaseUpgrade::Ecotone, 4),
+            (BaseUpgrade::Fjord, 5),
+            (BaseUpgrade::Granite, 6),
+            (BaseUpgrade::Holocene, 7),
+            (BaseUpgrade::Isthmus, 8),
+            (BaseUpgrade::Jovian, 9),
+            (BaseUpgrade::Azul, 10),
+            (BaseUpgrade::Beryl, 11),
+            (BaseUpgrade::Cobalt, 12),
+            (BaseUpgrade::Denim, 13),
+        ] {
+            config.set_activation_timestamp(upgrade, timestamp);
+        }
+        // Zenith is standalone (not in the cascade) and set out of order; it must stay untouched.
+        config.set_activation_timestamp(BaseUpgrade::Zenith, 1);
+        let before = config;
+
+        assert!(config.normalize_cascade_ladder().is_empty());
+        assert_eq!(config, before);
+    }
+
+    #[test]
+    fn normalize_fills_holes_across_the_base_tail() {
+        // Only Denim (the tail) is scheduled: every cascade predecessor is pulled forward to it.
+        let mut config = UpgradeConfig::default();
+        config.set_activation_timestamp(BaseUpgrade::Denim, 500);
+
+        let filled = config.normalize_cascade_ladder();
+
+        for upgrade in [
+            BaseUpgrade::Regolith,
+            BaseUpgrade::Canyon,
+            BaseUpgrade::Delta,
+            BaseUpgrade::Ecotone,
+            BaseUpgrade::Fjord,
+            BaseUpgrade::Granite,
+            BaseUpgrade::Holocene,
+            BaseUpgrade::Isthmus,
+            BaseUpgrade::Jovian,
+            BaseUpgrade::Azul,
+            BaseUpgrade::Beryl,
+            BaseUpgrade::Cobalt,
+        ] {
+            assert_eq!(config.activation_timestamp(upgrade), Some(500), "{upgrade:?} filled");
+        }
+        // 12 predecessors filled; Denim itself was already set.
+        assert_eq!(filled.len(), 12);
+        // PectraBlobSchedule is not part of the cascade and stays unset.
+        assert_eq!(config.activation_timestamp(BaseUpgrade::PectraBlobSchedule), None);
     }
 }

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -115,54 +115,39 @@ impl Default for RollupConfig {
 
 impl EthereumHardforks for RollupConfig {
     fn ethereum_fork_activation(&self, fork: EthereumHardfork) -> ForkCondition {
-        // Helper: cascade through the Base upgrade chain, returning the first set timestamp.
-        let cascade = |starting: &[Option<u64>]| -> ForkCondition {
-            if let Some(ts) = starting.iter().flatten().next() {
-                return ForkCondition::Timestamp(*ts);
-            }
-            ForkCondition::Never
+        // The Base upgrade that first activates this Ethereum fork. The fork then activates at the
+        // earliest scheduled timestamp of that anchor or any of its cascade successors: a later
+        // Base upgrade being scheduled implies the earlier Ethereum fork is active. The successor
+        // chain comes from [`BaseUpgrade::cascade_successor`], the single source of the ladder, so
+        // this stays in sync with the CL fork methods and hole normalization automatically.
+        let anchor = if fork <= EthereumHardfork::Paris {
+            // Pre-Bedrock Ethereum forks and everything through Paris activate at block 0 on Base.
+            return ForkCondition::Block(0);
+        } else if fork <= EthereumHardfork::Shanghai {
+            BaseUpgrade::Canyon
+        } else if fork <= EthereumHardfork::Cancun {
+            BaseUpgrade::Ecotone
+        } else if fork <= EthereumHardfork::Prague {
+            BaseUpgrade::Isthmus
+        } else if fork <= EthereumHardfork::Osaka {
+            BaseUpgrade::Azul
+        } else {
+            return ForkCondition::Never;
         };
 
-        if fork <= EthereumHardfork::Berlin {
-            // Pre-Bedrock Ethereum forks all activate at block 0 on Base chains.
-            ForkCondition::Block(0)
-        } else if fork <= EthereumHardfork::Paris {
-            // Bedrock activates everything from London through Paris at block 0.
-            ForkCondition::Block(0)
-        } else if fork <= EthereumHardfork::Shanghai {
-            // Canyon activates Shanghai; cascade through later Base upgrades if unset.
-            cascade(&[
-                self.upgrade_activation_timestamp(BaseUpgrade::Canyon),
-                self.upgrade_activation_timestamp(BaseUpgrade::Ecotone),
-                self.upgrade_activation_timestamp(BaseUpgrade::Fjord),
-                self.upgrade_activation_timestamp(BaseUpgrade::Granite),
-                self.upgrade_activation_timestamp(BaseUpgrade::Holocene),
-                self.upgrade_activation_timestamp(BaseUpgrade::Isthmus),
-                self.upgrade_activation_timestamp(BaseUpgrade::Jovian),
-            ])
-        } else if fork <= EthereumHardfork::Cancun {
-            // Ecotone activates Cancun; cascade through later Base upgrades if unset.
-            cascade(&[
-                self.upgrade_activation_timestamp(BaseUpgrade::Ecotone),
-                self.upgrade_activation_timestamp(BaseUpgrade::Fjord),
-                self.upgrade_activation_timestamp(BaseUpgrade::Granite),
-                self.upgrade_activation_timestamp(BaseUpgrade::Holocene),
-                self.upgrade_activation_timestamp(BaseUpgrade::Isthmus),
-                self.upgrade_activation_timestamp(BaseUpgrade::Jovian),
-            ])
-        } else if fork <= EthereumHardfork::Prague {
-            // Isthmus activates Prague; cascade through later Base upgrades if unset.
-            cascade(&[
-                self.upgrade_activation_timestamp(BaseUpgrade::Isthmus),
-                self.upgrade_activation_timestamp(BaseUpgrade::Jovian),
-            ])
-        } else if fork <= EthereumHardfork::Osaka {
-            self.upgrade_activation_timestamp(BaseUpgrade::Azul)
-                .map(ForkCondition::Timestamp)
-                .unwrap_or(ForkCondition::Never)
-        } else {
-            ForkCondition::Never
+        let mut upgrade = Some(anchor);
+        while let Some(current) = upgrade {
+            // Only execution-ladder upgrades map to an Ethereum fork. Contract-only upgrades in the
+            // cascade (e.g. Delta, which covers Span Batches, not L1 EIPs) are skipped so they do
+            // not spuriously drive an Ethereum fork's activation.
+            if current.is_execution()
+                && let Some(timestamp) = self.upgrade_activation_timestamp(current)
+            {
+                return ForkCondition::Timestamp(timestamp);
+            }
+            upgrade = current.cascade_successor();
         }
+        ForkCondition::Never
     }
 }
 
@@ -308,22 +293,26 @@ impl RollupConfig {
         is_jovian_active,
         is_first_jovian_block,
         [upgrade_activation_timestamp(BaseUpgrade::Jovian)],
-        "Jovian";
+        "Jovian",
+        implies is_base_azul_active;
 
         is_base_azul_active,
         is_first_base_azul_block,
         [upgrade_activation_timestamp(BaseUpgrade::Azul)],
-        "Base Azul";
+        "Base Azul",
+        implies is_beryl_active;
 
         is_beryl_active,
         is_first_beryl_block,
         [upgrade_activation_timestamp(BaseUpgrade::Beryl)],
-        "Beryl";
+        "Beryl",
+        implies is_cobalt_active;
 
         is_cobalt_active,
         is_first_cobalt_block,
         [upgrade_activation_timestamp(BaseUpgrade::Cobalt)],
-        "Cobalt";
+        "Cobalt",
+        implies is_denim_active;
 
         is_denim_active,
         is_first_denim_block,
@@ -967,7 +956,7 @@ mod tests {
             ForkCondition::Timestamp(600)
         );
 
-        // Osaka↔Azul: azul drives Osaka activation; standalone (not cascaded from Jovian).
+        // Osaka↔Azul: azul drives Osaka activation.
         let mut cfg = RollupConfig::default();
         cfg.upgrades.base = BaseUpgradeConfig {
             azul: Some(700),
@@ -981,7 +970,7 @@ mod tests {
             ForkCondition::Timestamp(700)
         );
 
-        // Beryl follows Azul; Osaka still activates at Azul when both are configured.
+        // Azul set → Osaka activates at Azul even when later Base upgrades are also configured.
         let mut cfg = RollupConfig::default();
         cfg.upgrades.base = BaseUpgradeConfig {
             azul: Some(700),
@@ -997,7 +986,8 @@ mod tests {
         assert!(cfg.is_base_azul_active(800));
         assert!(cfg.is_beryl_active(800));
 
-        // Beryl requires Azul, and does not independently activate Osaka.
+        // Azul unset → Osaka cascades forward through the Base tail to the earliest scheduled
+        // successor (here Beryl). A later Base upgrade being active implies Azul is active.
         let mut cfg = RollupConfig::default();
         cfg.upgrades.base = BaseUpgradeConfig {
             azul: None,
@@ -1006,9 +996,28 @@ mod tests {
             denim: None,
             zenith: None,
         };
-        assert_eq!(cfg.ethereum_fork_activation(EthereumHardfork::Osaka), ForkCondition::Never);
+        assert_eq!(
+            cfg.ethereum_fork_activation(EthereumHardfork::Osaka),
+            ForkCondition::Timestamp(800)
+        );
+        assert!(cfg.is_base_azul_active(800));
 
-        // Jovian set but Azul unset → Osaka is Never.
+        // The cascade reaches all the way to Denim.
+        let mut cfg = RollupConfig::default();
+        cfg.upgrades.base = BaseUpgradeConfig {
+            azul: None,
+            beryl: None,
+            cobalt: None,
+            denim: Some(1000),
+            zenith: None,
+        };
+        assert_eq!(
+            cfg.ethereum_fork_activation(EthereumHardfork::Osaka),
+            ForkCondition::Timestamp(1000)
+        );
+
+        // Jovian set but Azul unset → Osaka is Never: Jovian precedes Azul, so the forward cascade
+        // from Azul never reaches it.
         let mut cfg = RollupConfig::default();
         cfg.upgrades.jovian_time = Some(900);
         assert_eq!(cfg.ethereum_fork_activation(EthereumHardfork::Osaka), ForkCondition::Never);

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -9,7 +9,8 @@ use alloy_primitives::{Address, B256, U256};
 use base_common_chains::{BaseUpgradeExt, ChainConfig, Upgrades};
 use base_common_consensus::Predeploys;
 use base_common_genesis::{
-    BaseUpgrade, RuntimeUpgradeRegistry, UpgradeActivation, UpgradeActivationSink,
+    BaseUpgrade, BaseUpgradeConfig, RuntimeUpgradeRegistry, UpgradeActivation, UpgradeActivationSink,
+    UpgradeConfig,
 };
 use base_protocol::OutputRoot;
 use derive_more::{Constructor, Deref, Into};
@@ -172,29 +173,53 @@ impl BaseChainSpec {
         }
 
         // Time-based upgrades
-        // L1 upgrades are mapped to the activation timestamps of the corresponding Base upgrades
-        let azul_time = genesis_info.base.azul;
-        let beryl_time = genesis_info.base.beryl;
-        let cobalt_time = genesis_info.base.cobalt;
-        let denim_time = genesis_info.base.denim;
+        // L1 upgrades are mapped to the activation timestamps of the corresponding Base upgrades.
+        // Zenith is standalone (not part of the cascade) and applied directly.
         let zenith_time = genesis_info.base.zenith;
+
+        // Fill any cascade "holes" so the EL fork table matches the CL's cascade semantics: a later
+        // fork implies its predecessors are active, across the whole ladder including the
+        // Base-specific tail (Azul→Beryl→Cobalt→Denim). A malformed genesis that schedules a later
+        // fork while leaving a predecessor unscheduled would otherwise make the EL disagree with the
+        // CL. `UpgradeConfig::normalize_cascade_ladder` is the single source of this logic; Delta is
+        // contract-only and absent from the EL fork table, so its filled value is not read back.
+        let mut ladder = UpgradeConfig {
+            regolith_time: genesis_info.regolith_time,
+            canyon_time: genesis_info.canyon_time,
+            ecotone_time: genesis_info.ecotone_time,
+            fjord_time: genesis_info.fjord_time,
+            granite_time: genesis_info.granite_time,
+            holocene_time: genesis_info.holocene_time,
+            isthmus_time: genesis_info.isthmus_time,
+            jovian_time: genesis_info.jovian_time,
+            base: BaseUpgradeConfig {
+                azul: genesis_info.base.azul,
+                beryl: genesis_info.base.beryl,
+                cobalt: genesis_info.base.cobalt,
+                denim: genesis_info.base.denim,
+                zenith: genesis_info.base.zenith,
+            },
+            ..Default::default()
+        };
+        ladder.normalize_cascade_ladder();
+
         let time_upgrade_opts = [
-            (BaseUpgrade::Regolith.boxed(), genesis_info.regolith_time),
-            (EthereumHardfork::Shanghai.boxed(), genesis_info.canyon_time),
-            (BaseUpgrade::Canyon.boxed(), genesis_info.canyon_time),
-            (EthereumHardfork::Cancun.boxed(), genesis_info.ecotone_time),
-            (BaseUpgrade::Ecotone.boxed(), genesis_info.ecotone_time),
-            (BaseUpgrade::Fjord.boxed(), genesis_info.fjord_time),
-            (BaseUpgrade::Granite.boxed(), genesis_info.granite_time),
-            (BaseUpgrade::Holocene.boxed(), genesis_info.holocene_time),
-            (EthereumHardfork::Prague.boxed(), genesis_info.isthmus_time),
-            (BaseUpgrade::Isthmus.boxed(), genesis_info.isthmus_time),
-            (BaseUpgrade::Jovian.boxed(), genesis_info.jovian_time),
-            (EthereumHardfork::Osaka.boxed(), azul_time),
-            (BaseUpgrade::Azul.boxed(), azul_time),
-            (BaseUpgrade::Beryl.boxed(), beryl_time),
-            (BaseUpgrade::Cobalt.boxed(), cobalt_time),
-            (BaseUpgrade::Denim.boxed(), denim_time),
+            (BaseUpgrade::Regolith.boxed(), ladder.regolith_time),
+            (EthereumHardfork::Shanghai.boxed(), ladder.canyon_time),
+            (BaseUpgrade::Canyon.boxed(), ladder.canyon_time),
+            (EthereumHardfork::Cancun.boxed(), ladder.ecotone_time),
+            (BaseUpgrade::Ecotone.boxed(), ladder.ecotone_time),
+            (BaseUpgrade::Fjord.boxed(), ladder.fjord_time),
+            (BaseUpgrade::Granite.boxed(), ladder.granite_time),
+            (BaseUpgrade::Holocene.boxed(), ladder.holocene_time),
+            (EthereumHardfork::Prague.boxed(), ladder.isthmus_time),
+            (BaseUpgrade::Isthmus.boxed(), ladder.isthmus_time),
+            (BaseUpgrade::Jovian.boxed(), ladder.jovian_time),
+            (EthereumHardfork::Osaka.boxed(), ladder.base.azul),
+            (BaseUpgrade::Azul.boxed(), ladder.base.azul),
+            (BaseUpgrade::Beryl.boxed(), ladder.base.beryl),
+            (BaseUpgrade::Cobalt.boxed(), ladder.base.cobalt),
+            (BaseUpgrade::Denim.boxed(), ladder.base.denim),
             (BaseUpgrade::Zenith.boxed(), zenith_time),
         ];
 
@@ -1346,6 +1371,37 @@ mod tests {
         assert!(chain_spec.is_fork_active_at_timestamp(BaseUpgrade::Denim, 900_000));
         assert!(!chain_spec.is_fork_active_at_timestamp(BaseUpgrade::Zenith, 999_999));
         assert!(chain_spec.is_fork_active_at_timestamp(BaseUpgrade::Zenith, 1_000_000));
+    }
+
+    #[test]
+    fn construction_fills_cascade_hole_so_el_matches_cl() {
+        // A malformed genesis: Ecotone is scheduled at 40 while Canyon is left unscheduled — a
+        // cascade "hole". The CL treats Ecotone-active as implying Canyon-active; construction fills
+        // the hole so the EL fork table agrees instead of reporting Canyon inactive.
+        let geth_genesis = r#"
+    {
+      "config": {
+        "bedrockBlock": 0,
+        "ecotoneTime": 40,
+        "activationAdminAddress": "0xcb00000000000000000000000000000000000000",
+        "optimism": {
+          "eip1559Elasticity": 60,
+          "eip1559Denominator": 70
+        }
+      }
+    }
+    "#;
+        let genesis: Genesis = serde_json::from_str(geth_genesis).unwrap();
+        let chain_spec: BaseChainSpec = genesis.into();
+
+        // Ecotone active at 40 now implies its predecessors are active at 40 too.
+        assert!(chain_spec.is_fork_active_at_timestamp(BaseUpgrade::Ecotone, 40));
+        assert!(chain_spec.is_fork_active_at_timestamp(BaseUpgrade::Canyon, 40));
+        assert!(chain_spec.is_fork_active_at_timestamp(BaseUpgrade::Regolith, 40));
+        // The Ethereum fork paired with Canyon (Shanghai) is filled to the same timestamp.
+        assert!(chain_spec.is_fork_active_at_timestamp(EthereumHardfork::Shanghai, 40));
+        // Nothing activates before Ecotone's timestamp.
+        assert!(!chain_spec.is_fork_active_at_timestamp(BaseUpgrade::Canyon, 39));
     }
 
     #[test]

--- a/crates/utilities/upgrade-signal/src/metrics.rs
+++ b/crates/utilities/upgrade-signal/src/metrics.rs
@@ -46,6 +46,9 @@ base_metrics::define_metrics! {
     #[label(layer)]
     #[label(upgrade)]
     signal_updates_total: counter,
+    #[describe("Total upgrade schedule holes filled to keep CL/EL activation consistent")]
+    #[label(upgrade)]
+    schedule_holes_filled_total: counter,
 }
 
 impl UpgradeSignalMetrics {
@@ -107,6 +110,16 @@ impl UpgradeSignalMetrics {
         Self::init();
         Self::signal_updates_total(layer.label(), upgrade_id.contract_id().to_string())
             .increment(1);
+    }
+
+    /// Records a filled cascade-ladder hole for one upgrade ID.
+    ///
+    /// A hole is a malformed schedule where a later upgrade is scheduled while one of its
+    /// predecessors is not; filling it keeps the CL and EL from disagreeing on activation. This is
+    /// schedule-level (not layer-specific), so it carries no layer label.
+    pub fn record_hole_filled(upgrade_id: BaseUpgrade) {
+        Self::init();
+        Self::schedule_holes_filled_total(upgrade_id.contract_id().to_string()).increment(1);
     }
 
     /// Converts a packed-semver protocol version to a compact metric gauge value.

--- a/crates/utilities/upgrade-signal/src/runtime/sink.rs
+++ b/crates/utilities/upgrade-signal/src/runtime/sink.rs
@@ -1,10 +1,11 @@
 use base_common_genesis::{
     BaseUpgrade, RuntimeUpgradeRegistry, UpgradeActivation, UpgradeActivationOverrides,
-    UpgradeActivationSink,
+    UpgradeActivationSink, UpgradeConfig,
 };
+use tracing::warn;
 
 use super::{UpgradeSignalApplyAction, UpgradeSignalApplyChange, UpgradeSignalApplySummary};
-use crate::UpgradeSignalSchedule;
+use crate::{UpgradeSignalMetrics, UpgradeSignalSchedule};
 
 /// Upgrade activation sink backed by the process-local runtime registry for one chain.
 #[derive(Debug, Clone)]
@@ -66,10 +67,38 @@ impl UpgradeSignalRuntimeApplier {
         let mut summary = UpgradeSignalApplySummary::new(chain_id, schedule);
         let mut staged_sink = sink.clone();
 
+        // Normalize the cascade ladder before applying: a later fork always drags its predecessors
+        // with it. Without this, a schedule that clears a predecessor (e.g. Canyon) while a
+        // successor (e.g. Ecotone) stays scheduled would make the EL (independent per-fork) disagree
+        // with the CL (cascading), splitting activation across the two layers. All runtime paths
+        // (execution chain spec, rollup config, runtime registry) flow through this method, so
+        // filling here keeps every consumer consistent. `positive_activation_timestamp` maps an
+        // absent/zero activation to `Never`, so raw signals cleared on L1 stay cleared unless a
+        // scheduled successor pulls them forward.
+        let mut normalized = UpgradeConfig::default();
         for signal in &schedule.signals {
+            normalized.set_activation(
+                signal.upgrade_id,
+                UpgradeActivation::from_timestamp(signal.positive_activation_timestamp()),
+            );
+        }
+        for (upgrade_id, filled_timestamp) in normalized.normalize_cascade_ladder() {
+            warn!(
+                chain_id,
+                upgrade = %upgrade_id.contract_id(),
+                filled_timestamp,
+                "filled upgrade schedule hole to keep CL/EL activation consistent"
+            );
+            UpgradeSignalMetrics::record_hole_filled(upgrade_id);
+        }
+
+        for signal in &schedule.signals {
+            // Report the raw L1 signal in the summary, but apply the normalized (hole-filled)
+            // activation to the sink so the sink's schedule cannot contain a cascade hole.
             let activation =
                 UpgradeActivation::from_timestamp(signal.positive_activation_timestamp());
-            let supported = staged_sink.apply_activation(signal.upgrade_id, activation)?;
+            let applied_activation = normalized.activation(signal.upgrade_id);
+            let supported = staged_sink.apply_activation(signal.upgrade_id, applied_activation)?;
 
             let action = if !supported {
                 UpgradeSignalApplyAction::Ignored
@@ -145,12 +174,14 @@ mod tests {
         let chain_id = 9_000_001;
         RuntimeUpgradeRegistry::clear_chain(chain_id);
 
+        // A well-formed schedule: Azul<Beryl scheduled, Cobalt (the latest of the three) cleared.
+        // Clearing the tail leaves no hole, so normalization is a no-op here.
         let summary = UpgradeSignalRuntimeApplier::apply_schedule(
             chain_id,
             &schedule(&[
                 (BaseUpgrade::Azul, 42),
-                (BaseUpgrade::Beryl, 0),
-                (BaseUpgrade::Cobalt, 10),
+                (BaseUpgrade::Beryl, 84),
+                (BaseUpgrade::Cobalt, 0),
             ]),
         );
 
@@ -163,11 +194,11 @@ mod tests {
         );
         assert_eq!(
             RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Beryl),
-            Some(UpgradeActivation::Never)
+            Some(UpgradeActivation::Timestamp(84))
         );
         assert_eq!(
             RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Cobalt),
-            Some(UpgradeActivation::Timestamp(10))
+            Some(UpgradeActivation::Never)
         );
 
         RuntimeUpgradeRegistry::clear_chain(chain_id);
@@ -215,6 +246,67 @@ mod tests {
 
         assert_eq!(error, RecordingSinkError);
         assert_eq!(sink.applied, vec![(BaseUpgrade::Regolith, UpgradeActivation::Timestamp(1))]);
+    }
+
+    #[test]
+    fn applies_filled_activations_when_schedule_has_a_cascade_hole() {
+        // A hole: Canyon and Delta cleared (timestamp 0 => Never) while Ecotone stays at 100.
+        let mut sink = RecordingSink::default();
+
+        let summary = UpgradeSignalRuntimeApplier::apply_schedule_to_sink(
+            9_000_100,
+            &schedule(&[
+                (BaseUpgrade::Regolith, 1),
+                (BaseUpgrade::Canyon, 0),
+                (BaseUpgrade::Delta, 0),
+                (BaseUpgrade::Ecotone, 100),
+            ]),
+            &mut sink,
+        )
+        .unwrap();
+
+        assert!(summary.committed);
+        // The sink receives Canyon and Delta filled forward to Ecotone, not the raw cleared values,
+        // so an independent-reading sink (the EL fork table) cannot end up with a cascade hole.
+        assert_eq!(
+            sink.applied,
+            vec![
+                (BaseUpgrade::Regolith, UpgradeActivation::Timestamp(1)),
+                (BaseUpgrade::Canyon, UpgradeActivation::Timestamp(100)),
+                (BaseUpgrade::Delta, UpgradeActivation::Timestamp(100)),
+                (BaseUpgrade::Ecotone, UpgradeActivation::Timestamp(100)),
+            ]
+        );
+        // The summary still reports the raw L1 signals: Canyon and Delta were cleared on L1.
+        assert_eq!(summary.cleared_upgrades, 2);
+        assert_eq!(summary.applied_upgrades, 2);
+    }
+
+    #[test]
+    fn leaves_wellformed_schedule_unchanged() {
+        let mut sink = RecordingSink::default();
+
+        UpgradeSignalRuntimeApplier::apply_schedule_to_sink(
+            9_000_101,
+            &schedule(&[
+                (BaseUpgrade::Regolith, 1),
+                (BaseUpgrade::Canyon, 2),
+                (BaseUpgrade::Delta, 3),
+                (BaseUpgrade::Ecotone, 4),
+            ]),
+            &mut sink,
+        )
+        .unwrap();
+
+        assert_eq!(
+            sink.applied,
+            vec![
+                (BaseUpgrade::Regolith, UpgradeActivation::Timestamp(1)),
+                (BaseUpgrade::Canyon, UpgradeActivation::Timestamp(2)),
+                (BaseUpgrade::Delta, UpgradeActivation::Timestamp(3)),
+                (BaseUpgrade::Ecotone, UpgradeActivation::Timestamp(4)),
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The ProtocolVersions schedule can contain a "hole" where a later fork is scheduled while one of its cascade predecessors is unscheduled. The consensus layer treats a later fork as implying its predecessors are active, while the execution layer installs each fork's activation independently, so the two layers could disagree on whether a predecessor is active and split off the canonical chain. This change fills those holes at ingestion so both layers always read the same well-formed ladder.

It introduces `BaseUpgrade::cascade_successor` as the single source of the activation ladder, now spanning the Base-specific tail Azul→Beryl→Cobalt→Denim, and derives the normalizer, the CL `implies` chain, and `ethereum_fork_activation` from it instead of hand-maintained lists. Schedules are normalized at the two ingestion points that feed independent-reading consumers, the upgrade-signal sink and the EL chain-spec construction, emitting a warning and a `schedule_holes_filled_total` metric whenever a hole is filled.