### PR TITLE
feat(rpc-types): add millisecond transaction and log fields

### DIFF
--- a/crates/common/consensus/src/transaction/meta.rs
+++ b/crates/common/consensus/src/transaction/meta.rs
@@ -21,12 +21,14 @@ pub struct BaseTransactionInfo {
     pub inner: TransactionInfo,
     /// Additional metadata for deposit transactions.
     pub deposit_meta: DepositInfo,
+    /// Full block timestamp in milliseconds when `BaseTime` metadata is available.
+    pub block_timestamp_ms: Option<u64>,
 }
 
 impl BaseTransactionInfo {
     /// Creates a new [`BaseTransactionInfo`] with the given [`TransactionInfo`] and
     /// [`DepositInfo`].
     pub const fn new(inner: TransactionInfo, deposit_meta: DepositInfo) -> Self {
-        Self { inner, deposit_meta }
+        Self { inner, deposit_meta, block_timestamp_ms: None }
     }
 }

--- a/crates/common/rpc-types/src/lib.rs
+++ b/crates/common/rpc-types/src/lib.rs
@@ -16,6 +16,9 @@ pub use block::{BaseBlockResponse, BaseHeaderResponse};
 mod genesis;
 pub use genesis::{ChainInfo, FeeInfo, GenesisInfo, UpgradeInfo};
 
+mod log;
+pub use log::BaseLogResponse;
+
 mod receipt;
 pub use receipt::{
     BaseTransactionReceipt, Eip8130ReceiptFields, L1BlockInfo, TransactionReceiptFields,

--- a/crates/common/rpc-types/src/log.rs
+++ b/crates/common/rpc-types/src/log.rs
@@ -1,0 +1,76 @@
+//! Types related to logs for Base chains.
+
+use alloy_primitives::Log as PrimitiveLog;
+use alloy_rpc_types_eth::Log;
+use serde::{Deserialize, Serialize};
+
+/// Base log response with an optional full block timestamp in milliseconds.
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    derive_more::Deref,
+    derive_more::DerefMut,
+)]
+#[serde(rename_all = "camelCase")]
+pub struct BaseLogResponse {
+    /// Standard Ethereum log response.
+    #[deref]
+    #[deref_mut]
+    #[serde(flatten)]
+    pub inner: Log,
+    /// Full Unix timestamp in milliseconds when sub-second timing is available.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    pub block_timestamp_ms: Option<u64>,
+}
+
+impl AsRef<PrimitiveLog> for BaseLogResponse {
+    fn as_ref(&self) -> &PrimitiveLog {
+        self.inner.as_ref()
+    }
+}
+
+impl From<Log> for BaseLogResponse {
+    fn from(inner: Log) -> Self {
+        Self { inner, block_timestamp_ms: None }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn block_timestamp_ms_is_optional_quantity() {
+        let log =
+            BaseLogResponse { block_timestamp_ms: Some(1_700_000_000_200), ..Default::default() };
+
+        let value = serde_json::to_value(&log).unwrap();
+        assert_eq!(value["blockTimestampMs"], "0x18bcfe568c8");
+
+        let round_trip: BaseLogResponse = serde_json::from_value(value).unwrap();
+        assert_eq!(round_trip.block_timestamp_ms, Some(1_700_000_000_200));
+
+        assert_eq!(
+            serde_json::to_value(BaseLogResponse::default()).unwrap(),
+            json!({
+                "address": "0x0000000000000000000000000000000000000000",
+                "topics": [],
+                "data": "0x",
+                "blockHash": null,
+                "blockNumber": null,
+                "transactionHash": null,
+                "transactionIndex": null,
+                "logIndex": null,
+                "removed": false
+            })
+        );
+    }
+}

--- a/crates/common/rpc-types/src/transaction.rs
+++ b/crates/common/rpc-types/src/transaction.rs
@@ -22,6 +22,9 @@ pub struct Transaction {
     #[deref_mut]
     pub inner: alloy_rpc_types_eth::Transaction<BaseTxEnvelope>,
 
+    /// Full block timestamp in milliseconds when sub-second timing is available.
+    pub block_timestamp_ms: Option<u64>,
+
     /// Nonce for deposit transactions. Only present in RPC responses.
     pub deposit_nonce: Option<u64>,
 
@@ -55,6 +58,7 @@ impl Transaction {
                 transaction_index: tx_info.inner.index,
                 effective_gas_price: Some(effective_gas_price),
             },
+            block_timestamp_ms: tx_info.block_timestamp_ms,
             deposit_nonce: tx_info.deposit_meta.deposit_nonce,
             deposit_receipt_version: tx_info.deposit_meta.deposit_receipt_version,
         }
@@ -254,6 +258,12 @@ mod tx_serde {
             skip_serializing_if = "Option::is_none",
             with = "alloy_serde::quantity::opt"
         )]
+        block_timestamp_ms: Option<u64>,
+        #[serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )]
         deposit_receipt_version: Option<u64>,
 
         #[serde(flatten)]
@@ -272,6 +282,7 @@ mod tx_serde {
                         transaction_index,
                         effective_gas_price,
                     },
+                block_timestamp_ms,
                 deposit_receipt_version,
                 deposit_nonce,
             } = value;
@@ -288,6 +299,7 @@ mod tx_serde {
                 block_number,
                 transaction_index,
                 block_timestamp,
+                block_timestamp_ms,
                 deposit_receipt_version,
                 other: OptionalFields { from, effective_gas_price, deposit_nonce },
             }
@@ -304,6 +316,7 @@ mod tx_serde {
                 block_number,
                 transaction_index,
                 block_timestamp,
+                block_timestamp_ms,
                 deposit_receipt_version,
                 other,
             } = value;
@@ -333,6 +346,7 @@ mod tx_serde {
                     transaction_index,
                     effective_gas_price,
                 },
+                block_timestamp_ms,
                 deposit_receipt_version,
                 deposit_nonce,
             })
@@ -408,6 +422,7 @@ mod tests {
                 base_fee: Some(1_000_000_000),
             },
             deposit_meta: Default::default(),
+            block_timestamp_ms: Some(1_700_000_000_200),
         };
         let rpc_tx = Transaction::from_transaction(recovered, tx_info);
 
@@ -422,6 +437,7 @@ mod tests {
         assert_eq!(value["type"], "0x79", "tx type byte exposed in RPC response");
         assert_eq!(value["from"], "0x0000000000000000000000000000000000000011");
         assert_eq!(value["blockNumber"], "0x64");
+        assert_eq!(value["blockTimestampMs"], "0x18bcfe568c8");
         assert_eq!(value["transactionIndex"], "0x0");
 
         let tx_payload = &value["tx"];
@@ -440,5 +456,10 @@ mod tests {
         assert!(value.get("sourceHash").is_none(), "no deposit-only fields leak");
         assert!(value.get("depositReceiptVersion").is_none());
         assert!(value.get("mint").is_none());
+
+        let mut transaction_without_millis = rpc_tx;
+        transaction_without_millis.block_timestamp_ms = None;
+        let value = serde_json::to_value(transaction_without_millis).unwrap();
+        assert!(value.get("blockTimestampMs").is_none());
     }
 }

--- a/crates/consensus/engine/src/sync/mod.rs
+++ b/crates/consensus/engine/src/sync/mod.rs
@@ -305,6 +305,7 @@ mod tests {
                 effective_gas_price: Some(0),
                 transaction_index: Some(0),
             },
+            block_timestamp_ms: None,
             deposit_nonce: None,
             deposit_receipt_version: None,
         }

--- a/crates/consensus/engine/src/task_queue/tasks/consolidate/task_test.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/consolidate/task_test.rs
@@ -44,6 +44,7 @@ fn rpc_transaction(tx: BaseTxEnvelope, block_number: u64) -> BaseTransaction {
             effective_gas_price: Some(0),
             transaction_index: Some(0),
         },
+        block_timestamp_ms: None,
         deposit_nonce: None,
         deposit_receipt_version: None,
     }

--- a/crates/consensus/protocol/src/block.rs
+++ b/crates/consensus/protocol/src/block.rs
@@ -318,6 +318,7 @@ mod tests {
                 transactions: alloy_rpc_types_eth::BlockTransactions::Full(vec![
                     base_common_rpc_types::Transaction {
                         inner: tx_env,
+                        block_timestamp_ms: None,
                         deposit_nonce: None,
                         deposit_receipt_version: None,
                     },

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -1601,6 +1601,7 @@ mod tests {
                 effective_gas_price: Some(0),
                 transaction_index: Some(0),
             },
+            block_timestamp_ms: None,
             deposit_nonce: None,
             deposit_receipt_version: None,
         }

--- a/crates/execution/flashblocks/src/pending_blocks.rs
+++ b/crates/execution/flashblocks/src/pending_blocks.rs
@@ -896,6 +896,7 @@ mod tests {
                 transaction_index: Some(0),
                 effective_gas_price: Some(1_000_000_000),
             },
+            block_timestamp_ms: None,
             deposit_nonce: None,
             deposit_receipt_version: None,
         }
@@ -931,6 +932,7 @@ mod tests {
                 transaction_index: Some(0),
                 effective_gas_price: Some(1_000_000_000),
             },
+            block_timestamp_ms: None,
             deposit_nonce: None,
             deposit_receipt_version: None,
         }
@@ -959,6 +961,7 @@ mod tests {
                 transaction_index: Some(0),
                 effective_gas_price: Some(0),
             },
+            block_timestamp_ms: None,
             deposit_nonce: Some(42),
             deposit_receipt_version: Some(1),
         }

--- a/crates/execution/flashblocks/src/rpc/types.rs
+++ b/crates/execution/flashblocks/src/rpc/types.rs
@@ -144,6 +144,7 @@ mod tests {
                 transaction_index: Some(3),
                 effective_gas_price: Some(1_000_000_000),
             },
+            block_timestamp_ms: None,
             deposit_nonce: None,
             deposit_receipt_version: None,
         };

--- a/crates/execution/flashblocks/src/state_builder.rs
+++ b/crates/execution/flashblocks/src/state_builder.rs
@@ -236,6 +236,7 @@ where
             },
             deposit_nonce,
             deposit_receipt_version,
+            block_timestamp_ms: None,
         };
 
         self.cumulative_gas_used = self
@@ -396,6 +397,7 @@ where
                     },
                     deposit_nonce,
                     deposit_receipt_version,
+                    block_timestamp_ms: None,
                 };
                 self.evm.db_mut().commit(state.clone());
 

--- a/crates/execution/metering/src/collector.rs
+++ b/crates/execution/metering/src/collector.rs
@@ -331,6 +331,7 @@ mod tests {
                     transaction_index: Some(entry.index),
                     effective_gas_price: Some(entry.effective_gas_price),
                 },
+                block_timestamp_ms: None,
                 deposit_nonce: None,
                 deposit_receipt_version: None,
             };

--- a/etc/systems/tests/consensus_pruned_history.rs
+++ b/etc/systems/tests/consensus_pruned_history.rs
@@ -348,6 +348,7 @@ fn l1_info_rpc_transaction(block_number: u64) -> BaseTransaction {
         },
         deposit_nonce: None,
         deposit_receipt_version: None,
+        block_timestamp_ms: None,
     }
 }
 


### PR DESCRIPTION
- Add optional quantity-encoded `blockTimestampMs` fields to Base transaction and log responses.
- Omit the fields when sub-second metadata is unavailable.
- Keep Flashblocks values unset; its only edits are `None` initializers required by the shared transaction type.