### PR TITLE
fix(upgrade-signal): Order Protocol Versions By Semver

### DIFF
--- a/crates/utilities/upgrade-signal/README.md
+++ b/crates/utilities/upgrade-signal/README.md
@@ -63,19 +63,31 @@ ignored while mapping the contract schedule.
 
 ## Protocol Versions
 
-The contract exposes one global `minimumProtocolVersion()` as a packed-semver `uint256`
-(`major << 96 | minor << 64 | patch << 32`), so this crate reads it as `U256` and attaches it to
-every signal in a schedule.
+The contract exposes one global `minimumProtocolVersion()` as a packed-semver `uint256`, so this
+crate reads it as `U256` and attaches it to every signal in a schedule. The highest byte is the
+version-type; for the only defined layout, version-type `0`, the value is
+`version-type || reserved || build || major || minor || patch || pre-release`, where `major`,
+`minor`, `patch`, and `pre-release` are the low four 32-bit fields, `build` occupies the next 64
+bits, and `reserved`/`version-type` occupy the high 64 bits.
+
+Versions are compared by their semver fields rather than as raw integers, via
+[`PackedProtocolVersion`](src/version.rs): an unrecognized version-type (`version-type != 0`) sorts
+above every version-type-`0` value so an unreadable format is rejected (fail-closed); within
+version-type `0` the order is `major`, then `minor`, then `patch`, with a pre-release
+(`pre-release != 0`) sorting below its matching final release (`pre-release == 0`); `build` and the
+reserved bits are ignored.
 
 The node advertises its supported level with
 [`UpgradeSignalDefaults::node_protocol_version()`](src/config/mod.rs), which packs the Cargo
 package semver synced from the `GitHub` release tag on release branches. Development `0.0.0` builds
-advertise `U256::MAX` so contract minimums do not reject untagged local builds. A positive
-activation signal is supported when:
+advertise the maximum version-type-`0` version (`pack(u32::MAX, u32::MAX, u32::MAX, 0)`) so contract
+minimums do not reject untagged local builds; raw `U256::MAX` is unusable as the sentinel because it
+decodes to a pre-release and would rank below its final release. A positive activation signal is
+supported when:
 
 - the contract provides a non-zero minimum protocol version
 - the signaled minimum protocol version is less than or equal to the node's supported protocol
-  version
+  version under the semver ordering above
 
 ## Upgrade Timestamps
 

--- a/crates/utilities/upgrade-signal/src/config/mod.rs
+++ b/crates/utilities/upgrade-signal/src/config/mod.rs
@@ -4,6 +4,8 @@ use core::time::Duration;
 
 use alloy_primitives::U256;
 
+use crate::PackedProtocolVersion;
+
 mod args;
 pub use args::{UpgradeSignalArgs, UpgradeSignalL1RpcArgs, UpgradeSignalStartupConfig};
 
@@ -43,11 +45,13 @@ impl UpgradeSignalDefaults {
         ))
     }
 
-    /// Encodes a `major.minor.patch` version into the packed-semver `uint256` layout used by the
-    /// L1 `ProtocolVersions` contract: `major << 96 | minor << 64 | patch << 32`, with the
-    /// prerelease field left zero.
+    /// Encodes a final-release `major.minor.patch` version into the packed-semver `uint256` layout
+    /// used by the L1 `ProtocolVersions` contract, leaving the prerelease and build fields zero.
+    ///
+    /// See [`PackedProtocolVersion`] for the field layout and the ordering rules that govern
+    /// protocol-version compatibility checks.
     pub const fn packed_protocol_version(major: u32, minor: u32, patch: u32) -> U256 {
-        U256::from_limbs([(patch as u64) << 32, ((major as u64) << 32) | minor as u64, 0, 0])
+        PackedProtocolVersion::pack(major, minor, patch, 0).into_inner()
     }
 
     /// Maps a packed Cargo version to the advertised node protocol version, promoting the

--- a/crates/utilities/upgrade-signal/src/config/mod.rs
+++ b/crates/utilities/upgrade-signal/src/config/mod.rs
@@ -36,7 +36,8 @@ impl UpgradeSignalDefaults {
     ///
     /// Release branches sync the Cargo package version to the `GitHub` release tag, so release
     /// binaries advertise the release semver as their supported protocol version. Dev builds
-    /// (workspace `0.0.0`) advertise `U256::MAX` so no contract minimum rejects them.
+    /// (workspace `0.0.0`) advertise the maximum version-type-`0` version so no contract minimum
+    /// rejects them.
     pub fn node_protocol_version() -> U256 {
         Self::advertised_protocol_version(Self::packed_protocol_version(
             env!("CARGO_PKG_VERSION_MAJOR").parse::<u32>().expect("Cargo package major is numeric"),
@@ -55,9 +56,18 @@ impl UpgradeSignalDefaults {
     }
 
     /// Maps a packed Cargo version to the advertised node protocol version, promoting the
-    /// dev-build `0.0.0` (zero) to `U256::MAX` so no contract minimum can reject a dev build.
+    /// dev-build `0.0.0` (zero) to the maximum version-type-`0` version so no contract minimum can
+    /// reject a dev build.
+    ///
+    /// The sentinel is the top element of [`PackedProtocolVersion`]'s ordering by construction:
+    /// `U256::MAX` is *not* usable here, since it decodes to a pre-release (its pre-release field is
+    /// non-zero) and so ranks below the corresponding final release under the semver ordering.
     pub fn advertised_protocol_version(cargo_version: U256) -> U256 {
-        if cargo_version == U256::ZERO { U256::MAX } else { cargo_version }
+        if cargo_version == U256::ZERO {
+            PackedProtocolVersion::pack(u32::MAX, u32::MAX, u32::MAX, 0).into_inner()
+        } else {
+            cargo_version
+        }
     }
 }
 
@@ -67,9 +77,22 @@ mod tests {
 
     #[test]
     fn dev_build_advertises_max_protocol_version() {
-        // Dev builds (0.0.0 -> zero) must bypass any contract minimum-version check.
+        // Dev builds (0.0.0 -> zero) must bypass any contract minimum-version check, so the
+        // sentinel is the top element of the semver ordering (not the raw `U256::MAX`, which decodes
+        // to a pre-release and ranks below its final release).
         let zero = UpgradeSignalDefaults::packed_protocol_version(0, 0, 0);
-        assert_eq!(UpgradeSignalDefaults::advertised_protocol_version(zero), U256::MAX);
+        let sentinel = UpgradeSignalDefaults::advertised_protocol_version(zero);
+        assert_eq!(
+            sentinel,
+            PackedProtocolVersion::pack(u32::MAX, u32::MAX, u32::MAX, 0).into_inner()
+        );
+
+        // No version-type-`0` minimum can outrank the sentinel.
+        let highest_minimum =
+            UpgradeSignalDefaults::packed_protocol_version(u32::MAX, u32::MAX, u32::MAX);
+        assert!(
+            PackedProtocolVersion::new(highest_minimum) <= PackedProtocolVersion::new(sentinel)
+        );
     }
 
     #[test]

--- a/crates/utilities/upgrade-signal/src/config/schedule.rs
+++ b/crates/utilities/upgrade-signal/src/config/schedule.rs
@@ -7,6 +7,7 @@ use url::Url;
 
 use super::{UpgradeSignalBlockTag, UpgradeSignalDefaults, UpgradeSignalMode};
 use crate::{
+    PackedProtocolVersion,
     contract::AlloyUpgradeSignalReader,
     error::UpgradeSignalError,
     metrics::{UpgradeSignalMetricLayer, UpgradeSignalMetrics},
@@ -49,8 +50,13 @@ impl UpgradeSignalConfig {
     }
 
     /// Returns true if this node supports the minimum protocol version attached to `signal`.
+    ///
+    /// Compatibility compares the packed versions by their OP-Stack semver ordering (see
+    /// [`PackedProtocolVersion`]), not as raw integers: `major.minor.patch` first, with a
+    /// pre-release sorting below its matching release and `build`/reserved bits ignored.
     pub fn supports_signal_protocol_version(&self, signal: &UpgradeSignal) -> bool {
-        signal.protocol_version <= self.node_protocol_version
+        PackedProtocolVersion::new(signal.protocol_version)
+            <= PackedProtocolVersion::new(self.node_protocol_version)
     }
 
     /// Returns an error if a positive activation timestamp omits its minimum protocol version.
@@ -242,11 +248,37 @@ mod tests {
 
     #[test]
     fn rejects_signal_above_node_protocol_version() {
+        // Node supports 1.1.0; a 1.1.1 minimum is genuinely newer.
         let config = supported_config();
-        let minimum_protocol_version = config.node_protocol_version + U256::from(1);
+        let minimum_protocol_version = UpgradeSignalDefaults::packed_protocol_version(1, 1, 1);
 
         assert!(matches!(
             config.validate_signal_protocol_version(&signal(minimum_protocol_version)).unwrap_err(),
+            crate::UpgradeSignalError::UnsupportedProtocolVersion { .. }
+        ));
+    }
+
+    #[test]
+    fn accepts_prerelease_minimum_of_the_node_release() {
+        // Node runs the final 1.2.3; a 1.2.3-rc.1 minimum must be considered sufficient, even
+        // though its raw packed integer is larger than the release's.
+        let mut config = supported_config();
+        config.node_protocol_version = UpgradeSignalDefaults::packed_protocol_version(1, 2, 3);
+
+        let prerelease = PackedProtocolVersion::pack(1, 2, 3, 1).into_inner();
+        assert!(prerelease > config.node_protocol_version);
+        assert!(config.validate_signal_protocol_version(&signal(prerelease)).is_ok());
+    }
+
+    #[test]
+    fn rejects_prerelease_minimum_above_the_node_release() {
+        // A 1.2.4-rc.1 minimum still outranks the node's final 1.2.3.
+        let mut config = supported_config();
+        config.node_protocol_version = UpgradeSignalDefaults::packed_protocol_version(1, 2, 3);
+
+        let prerelease = PackedProtocolVersion::pack(1, 2, 4, 1).into_inner();
+        assert!(matches!(
+            config.validate_signal_protocol_version(&signal(prerelease)).unwrap_err(),
             crate::UpgradeSignalError::UnsupportedProtocolVersion { .. }
         ));
     }
@@ -301,7 +333,7 @@ mod tests {
                 UpgradeSignal {
                     upgrade_id: BaseUpgrade::Beryl,
                     activation_timestamp: 42,
-                    protocol_version: config.node_protocol_version + U256::from(1),
+                    protocol_version: UpgradeSignalDefaults::packed_protocol_version(1, 1, 1),
                 },
             ],
         );

--- a/crates/utilities/upgrade-signal/src/config/schedule.rs
+++ b/crates/utilities/upgrade-signal/src/config/schedule.rs
@@ -51,9 +51,10 @@ impl UpgradeSignalConfig {
 
     /// Returns true if this node supports the minimum protocol version attached to `signal`.
     ///
-    /// Compatibility compares the packed versions by their OP-Stack semver ordering (see
-    /// [`PackedProtocolVersion`]), not as raw integers: `major.minor.patch` first, with a
-    /// pre-release sorting below its matching release and `build`/reserved bits ignored.
+    /// Compatibility compares the packed versions by their semver ordering (see
+    /// [`PackedProtocolVersion`]), not as raw integers: an unrecognized version-type ranks above
+    /// everything (fail-closed), then `major.minor.patch`, with a pre-release sorting below its
+    /// matching release and `build`/reserved bits ignored.
     pub fn supports_signal_protocol_version(&self, signal: &UpgradeSignal) -> bool {
         PackedProtocolVersion::new(signal.protocol_version)
             <= PackedProtocolVersion::new(self.node_protocol_version)
@@ -284,6 +285,21 @@ mod tests {
     }
 
     #[test]
+    fn rejects_signal_with_unrecognized_version_type() {
+        // A non-zero version-type is a format the node cannot interpret. Its semver fields here are
+        // all zero, so ignoring the version-type would decode it as `0.0.0` and wrongly accept it
+        // (fail-open) under the node's 1.1.0; the version-type must instead rank it above the node
+        // so it is rejected (fail-closed).
+        let config = supported_config();
+        let unknown_version_type = U256::from(1) << 248;
+
+        assert!(matches!(
+            config.validate_signal_protocol_version(&signal(unknown_version_type)).unwrap_err(),
+            crate::UpgradeSignalError::UnsupportedProtocolVersion { .. }
+        ));
+    }
+
+    #[test]
     fn rejects_positive_signal_without_protocol_version() {
         let config = UpgradeSignalConfig::new(address!("0000000000000000000000000000000000000001"));
 
@@ -350,13 +366,15 @@ mod tests {
     fn schedule_validation_allows_clear_with_unsupported_protocol_version(
         #[case] upgrade_id: &str,
     ) {
-        let config = UpgradeSignalConfig::new(address!("0000000000000000000000000000000000000001"));
+        // Node supports 1.1.0; a 1.1.1 minimum is genuinely unsupported, yet a clear (activation
+        // timestamp `0`) must still be allowed regardless of the ordering.
+        let config = supported_config();
         let schedule = UpgradeSignalSchedule::new(
             1,
             vec![UpgradeSignal {
                 upgrade_id: upgrade(upgrade_id),
                 activation_timestamp: 0,
-                protocol_version: config.node_protocol_version + U256::from(1),
+                protocol_version: UpgradeSignalDefaults::packed_protocol_version(1, 1, 1),
             }],
         );
 

--- a/crates/utilities/upgrade-signal/src/lib.rs
+++ b/crates/utilities/upgrade-signal/src/lib.rs
@@ -34,3 +34,6 @@ pub use runtime::{
 
 mod state;
 pub use state::{UpgradeSignal, UpgradeSignalMonitor, UpgradeSignalSchedule};
+
+mod version;
+pub use version::PackedProtocolVersion;

--- a/crates/utilities/upgrade-signal/src/runtime/refresher.rs
+++ b/crates/utilities/upgrade-signal/src/runtime/refresher.rs
@@ -105,8 +105,21 @@ mod tests {
         let chain_id = 9_100_002;
         RuntimeUpgradeRegistry::clear_chain(chain_id);
 
-        let unsupported = UpgradeSignalDefaults::node_protocol_version() + U256::from(1);
-        refresher(chain_id).apply(&schedule(BaseUpgrade::Azul, 42, unsupported)).unwrap_err();
+        // Node supports 1.1.0; a 1.1.1 minimum is genuinely newer and must be rejected. Adding
+        // `+ 1` to the dev-build sentinel no longer works: it decodes to a pre-release of the max
+        // release, which now sorts below the release under the semver ordering.
+        let mut config = UpgradeSignalConfig::new(Address::ZERO);
+        config.node_protocol_version = UpgradeSignalDefaults::packed_protocol_version(1, 1, 0);
+        let reader = config.reader("http://127.0.0.1:1".parse().unwrap()).unwrap();
+        let refresher = UpgradeSignalRefresher::new(
+            config,
+            reader,
+            chain_id,
+            UpgradeSignalMetricLayer::Consensus,
+        );
+
+        let unsupported = UpgradeSignalDefaults::packed_protocol_version(1, 1, 1);
+        refresher.apply(&schedule(BaseUpgrade::Azul, 42, unsupported)).unwrap_err();
 
         assert_eq!(RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul), None);
     }

--- a/crates/utilities/upgrade-signal/src/version.rs
+++ b/crates/utilities/upgrade-signal/src/version.rs
@@ -21,8 +21,18 @@ use alloy_primitives::U256;
 /// field holds a larger integer than the release's zero. That inverts the intended order and can
 /// reject a node running a final release under a minimum that is a release candidate of the same
 /// version.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Eq)]
 pub struct PackedProtocolVersion(U256);
+
+impl PartialEq for PackedProtocolVersion {
+    /// Equality mirrors [`Ord`]: two values are equal when their ordered semver fields match, so
+    /// `build` and the reserved/version-type bits are ignored. Deriving `PartialEq` instead would
+    /// compare the raw `U256` bit-for-bit and break the `Ord` contract, under which
+    /// `a.cmp(&b) == Ordering::Equal` must imply `a == b`.
+    fn eq(&self, other: &Self) -> bool {
+        self.ordering_key() == other.ordering_key()
+    }
+}
 
 impl PackedProtocolVersion {
     /// Wraps a packed protocol version read from the L1 `ProtocolVersions` contract.
@@ -138,6 +148,10 @@ mod tests {
         let plain = PackedProtocolVersion::pack(1, 2, 3, 0);
         let with_build = PackedProtocolVersion::new(plain.into_inner() | (U256::from(7) << 128));
 
+        // The raw integers differ, but the ordered fields (and thus both `cmp` and `==`) agree,
+        // keeping the `Ord`/`PartialEq` contract intact.
+        assert_ne!(plain.into_inner(), with_build.into_inner());
         assert_eq!(plain.cmp(&with_build), Ordering::Equal);
+        assert_eq!(plain, with_build);
     }
 }

--- a/crates/utilities/upgrade-signal/src/version.rs
+++ b/crates/utilities/upgrade-signal/src/version.rs
@@ -1,21 +1,26 @@
-//! Ordered comparison of OP-Stack packed-semver protocol versions.
+//! Ordered comparison of packed-semver protocol versions.
 
 use core::cmp::Ordering;
 
 use alloy_primitives::U256;
 
-/// An OP-Stack `ProtocolVersions` packed-semver value ordered by its semver fields.
+/// A `ProtocolVersions` packed-semver value ordered by its semver fields.
 ///
-/// The L1 `ProtocolVersions` contract stores each version as a version-type `0` `uint256`:
-/// `reserved || build || major || minor || patch || pre-release`, where `major`, `minor`, `patch`,
-/// and `pre-release` are the low four 32-bit fields and `build` occupies the next 64 bits.
+/// The L1 `ProtocolVersions` contract stores each version as a `uint256` whose highest byte is the
+/// version-type. For the only defined layout, version-type `0`, the value is
+/// `version-type || reserved || build || major || minor || patch || pre-release`, where `major`,
+/// `minor`, `patch`, and `pre-release` are the low four 32-bit fields, `build` occupies the next 64
+/// bits, and `reserved`/`version-type` occupy the high 64 bits.
 ///
-/// Ordering follows the OP-Stack superchain-upgrade rules rather than the raw integer value:
+/// Ordering follows the protocol-version semver rules rather than the raw integer value:
 ///
-/// * compare `major`, then `minor`, then `patch`;
+/// * an unrecognized version-type (`version-type != 0`) sorts *above* every version-type-`0` value,
+///   so a compatibility check against a version-type-`0` node stays fail-closed for a format the
+///   node cannot interpret;
+/// * within version-type `0`, compare `major`, then `minor`, then `patch`;
 /// * a pre-release (`pre-release != 0`) sorts *below* its matching release (`pre-release == 0`),
 ///   and pre-releases of the same `major.minor.patch` sort by their pre-release counter;
-/// * `build` and the reserved/version-type high bytes are ignored.
+/// * `build` and the reserved high bits are ignored, per spec.
 ///
 /// A raw `U256` comparison instead sorts a pre-release *above* its release, because the pre-release
 /// field holds a larger integer than the release's zero. That inverts the intended order and can
@@ -25,9 +30,9 @@ use alloy_primitives::U256;
 pub struct PackedProtocolVersion(U256);
 
 impl PartialEq for PackedProtocolVersion {
-    /// Equality mirrors [`Ord`]: two values are equal when their ordered semver fields match, so
-    /// `build` and the reserved/version-type bits are ignored. Deriving `PartialEq` instead would
-    /// compare the raw `U256` bit-for-bit and break the `Ord` contract, under which
+    /// Equality mirrors [`Ord`]: two values are equal when their ordered fields (version-type plus
+    /// the semver fields) match, so `build` and the reserved bits are ignored. Deriving `PartialEq`
+    /// instead would compare the raw `U256` bit-for-bit and break the `Ord` contract, under which
     /// `a.cmp(&b) == Ordering::Equal` must imply `a == b`.
     fn eq(&self, other: &Self) -> bool {
         self.ordering_key() == other.ordering_key()
@@ -76,15 +81,24 @@ impl PackedProtocolVersion {
         self.0.as_limbs()[0] as u32
     }
 
-    /// Ordering key that applies the semver pre-release rule.
+    /// Version-type byte (the highest byte of the `uint256`); `0` is the only defined layout.
+    pub const fn version_type(self) -> u8 {
+        (self.0.as_limbs()[3] >> 56) as u8
+    }
+
+    /// Ordering key that applies the version-type and semver pre-release rules.
     ///
-    /// A final release (`prerelease == 0`) is promoted above every pre-release of the same
-    /// `major.minor.patch` by ranking it as [`u64::MAX`], which no 32-bit pre-release counter can
-    /// reach.
-    const fn ordering_key(self) -> (u32, u32, u32, u64) {
+    /// The version-type is the most significant component, so an unrecognized version-type
+    /// (`version_type != 0`) sorts above every version-type-`0` value; a compatibility check against
+    /// a version-type-`0` node therefore rejects a format the node cannot interpret (fail-closed).
+    ///
+    /// Within a version-type, a final release (`prerelease == 0`) is promoted above every
+    /// pre-release of the same `major.minor.patch` by ranking it as [`u64::MAX`], which no 32-bit
+    /// pre-release counter can reach.
+    const fn ordering_key(self) -> (u8, u32, u32, u32, u64) {
         let prerelease_rank =
             if self.prerelease() == 0 { u64::MAX } else { self.prerelease() as u64 };
-        (self.major(), self.minor(), self.patch(), prerelease_rank)
+        (self.version_type(), self.major(), self.minor(), self.patch(), prerelease_rank)
     }
 }
 
@@ -153,5 +167,18 @@ mod tests {
         assert_ne!(plain.into_inner(), with_build.into_inner());
         assert_eq!(plain.cmp(&with_build), Ordering::Equal);
         assert_eq!(plain, with_build);
+    }
+
+    #[test]
+    fn unknown_version_type_sorts_above_every_version_type_zero_value() {
+        // The version-type occupies the highest byte (bits 248..255).
+        let unknown = PackedProtocolVersion::new(U256::from(1) << 248);
+        let highest_type_zero = PackedProtocolVersion::pack(u32::MAX, u32::MAX, u32::MAX, 0);
+
+        assert_eq!(unknown.version_type(), 1);
+        assert_eq!(highest_type_zero.version_type(), 0);
+        // Even the largest possible version-type-0 value ranks below any unknown version-type, so a
+        // version-type-0 node treats an unrecognized format as unsupported (fail-closed).
+        assert!(highest_type_zero < unknown);
     }
 }

--- a/crates/utilities/upgrade-signal/src/version.rs
+++ b/crates/utilities/upgrade-signal/src/version.rs
@@ -1,0 +1,143 @@
+//! Ordered comparison of OP-Stack packed-semver protocol versions.
+
+use core::cmp::Ordering;
+
+use alloy_primitives::U256;
+
+/// An OP-Stack `ProtocolVersions` packed-semver value ordered by its semver fields.
+///
+/// The L1 `ProtocolVersions` contract stores each version as a version-type `0` `uint256`:
+/// `reserved || build || major || minor || patch || pre-release`, where `major`, `minor`, `patch`,
+/// and `pre-release` are the low four 32-bit fields and `build` occupies the next 64 bits.
+///
+/// Ordering follows the OP-Stack superchain-upgrade rules rather than the raw integer value:
+///
+/// * compare `major`, then `minor`, then `patch`;
+/// * a pre-release (`pre-release != 0`) sorts *below* its matching release (`pre-release == 0`),
+///   and pre-releases of the same `major.minor.patch` sort by their pre-release counter;
+/// * `build` and the reserved/version-type high bytes are ignored.
+///
+/// A raw `U256` comparison instead sorts a pre-release *above* its release, because the pre-release
+/// field holds a larger integer than the release's zero. That inverts the intended order and can
+/// reject a node running a final release under a minimum that is a release candidate of the same
+/// version.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PackedProtocolVersion(U256);
+
+impl PackedProtocolVersion {
+    /// Wraps a packed protocol version read from the L1 `ProtocolVersions` contract.
+    pub const fn new(packed: U256) -> Self {
+        Self(packed)
+    }
+
+    /// Packs the ordered semver fields into the version-type `0` layout, leaving `build` and the
+    /// reserved/version-type bytes zero.
+    pub const fn pack(major: u32, minor: u32, patch: u32, prerelease: u32) -> Self {
+        Self(U256::from_limbs([
+            ((patch as u64) << 32) | prerelease as u64,
+            ((major as u64) << 32) | minor as u64,
+            0,
+            0,
+        ]))
+    }
+
+    /// Returns the underlying packed `U256` value.
+    pub const fn into_inner(self) -> U256 {
+        self.0
+    }
+
+    /// Major version field.
+    pub const fn major(self) -> u32 {
+        (self.0.as_limbs()[1] >> 32) as u32
+    }
+
+    /// Minor version field.
+    pub const fn minor(self) -> u32 {
+        self.0.as_limbs()[1] as u32
+    }
+
+    /// Patch version field.
+    pub const fn patch(self) -> u32 {
+        (self.0.as_limbs()[0] >> 32) as u32
+    }
+
+    /// Pre-release counter field; `0` denotes a final release.
+    pub const fn prerelease(self) -> u32 {
+        self.0.as_limbs()[0] as u32
+    }
+
+    /// Ordering key that applies the semver pre-release rule.
+    ///
+    /// A final release (`prerelease == 0`) is promoted above every pre-release of the same
+    /// `major.minor.patch` by ranking it as [`u64::MAX`], which no 32-bit pre-release counter can
+    /// reach.
+    const fn ordering_key(self) -> (u32, u32, u32, u64) {
+        let prerelease_rank =
+            if self.prerelease() == 0 { u64::MAX } else { self.prerelease() as u64 };
+        (self.major(), self.minor(), self.patch(), prerelease_rank)
+    }
+}
+
+impl Ord for PackedProtocolVersion {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.ordering_key().cmp(&other.ordering_key())
+    }
+}
+
+impl PartialOrd for PackedProtocolVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_packed_semver_fields() {
+        let version = PackedProtocolVersion::pack(1, 2, 3, 4);
+
+        assert_eq!(version.major(), 1);
+        assert_eq!(version.minor(), 2);
+        assert_eq!(version.patch(), 3);
+        assert_eq!(version.prerelease(), 4);
+    }
+
+    #[test]
+    fn release_sorts_above_its_prerelease() {
+        let release = PackedProtocolVersion::pack(1, 2, 3, 0);
+        let prerelease = PackedProtocolVersion::pack(1, 2, 3, 1);
+
+        // The raw integers order the prerelease higher; the semver ordering must not.
+        assert!(prerelease.into_inner() > release.into_inner());
+        assert!(prerelease < release);
+    }
+
+    #[test]
+    fn prereleases_sort_by_counter() {
+        let rc1 = PackedProtocolVersion::pack(1, 2, 3, 1);
+        let rc2 = PackedProtocolVersion::pack(1, 2, 3, 2);
+
+        assert!(rc1 < rc2);
+    }
+
+    #[test]
+    fn orders_by_major_then_minor_then_patch() {
+        assert!(PackedProtocolVersion::pack(1, 2, 3, 0) < PackedProtocolVersion::pack(1, 2, 4, 0));
+        assert!(PackedProtocolVersion::pack(1, 2, 3, 0) < PackedProtocolVersion::pack(1, 3, 0, 0));
+        assert!(PackedProtocolVersion::pack(1, 2, 3, 0) < PackedProtocolVersion::pack(2, 0, 0, 0));
+
+        // A higher patch release outranks a lower-patch pre-release regardless of pre-release rank.
+        assert!(PackedProtocolVersion::pack(1, 2, 3, 9) < PackedProtocolVersion::pack(1, 2, 4, 0));
+    }
+
+    #[test]
+    fn build_field_does_not_affect_ordering() {
+        // Set the build field (bits 128..192) on one operand; ordering must ignore it.
+        let plain = PackedProtocolVersion::pack(1, 2, 3, 0);
+        let with_build = PackedProtocolVersion::new(plain.into_inner() | (U256::from(7) << 128));
+
+        assert_eq!(plain.cmp(&with_build), Ordering::Equal);
+    }
+}


### PR DESCRIPTION
## Summary

The minimum protocol version gate compared packed protocol versions as raw U256 integers, which inverts prerelease ordering. A release candidate packs with a nonzero prerelease field in the low bits, so it compares greater than its final release, meaning a node running the final release could be rejected by a minimum that is only a release candidate of the same version. This change introduces a PackedProtocolVersion newtype that decodes the packed semver fields and orders by major.minor.patch with a prerelease sorting below its matching release, ignoring build and reserved bits. The compatibility check and packed_protocol_version helper now use it, and existing tests that relied on raw-integer ordering were corrected.