### PR TITLE
perf(sequencer): reuse acknowledged parent system config

### DIFF
--- a/actions/harness/src/sequencer/attributes.rs
+++ b/actions/harness/src/sequencer/attributes.rs
@@ -4,6 +4,7 @@ use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::Bytes;
 use async_trait::async_trait;
 use base_common_consensus::BaseTxEnvelope;
+use base_common_genesis::SystemConfig;
 use base_common_rpc_types_engine::BasePayloadAttributes;
 use base_consensus_derive::{
     AttributesBuilder, PipelineError, PipelineResult, StatefulAttributesBuilder,
@@ -37,6 +38,10 @@ impl ActionSequencerAttributesBuilder {
 
 #[async_trait]
 impl AttributesBuilder for ActionSequencerAttributesBuilder {
+    fn seed_parent_system_config(&mut self, parent: L2BlockInfo, config: SystemConfig) {
+        self.inner.seed_parent_system_config(parent, config);
+    }
+
     async fn prepare_payload_attributes(
         &mut self,
         l2_parent: L2BlockInfo,

--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -80,12 +80,23 @@ where
         let l1_header;
         let deposit_transactions: Vec<Bytes>;
 
-        let mut sys_config = match self
-            .parent_system_config
-            .take_if(|(parent, _)| *parent == l2_parent)
-        {
-            Some((_, config)) => config,
-            None => self
+        let parent_timestamp =
+            self.rollup_cfg.l2_block_timestamp(l2_parent.block_info.number.saturating_sub(1));
+        let mut sys_config = match self.parent_system_config {
+            Some((parent, config))
+                if parent == l2_parent
+                    && !self.rollup_cfg.is_first_isthmus_block(
+                        l2_parent.block_info.timestamp,
+                        parent_timestamp,
+                    )
+                    && !self.rollup_cfg.is_first_jovian_block(
+                        l2_parent.block_info.timestamp,
+                        parent_timestamp,
+                    ) =>
+            {
+                config
+            }
+            _ => self
                 .config_fetcher
                 .system_config_by_number(l2_parent.block_info.number, Arc::clone(&self.rollup_cfg))
                 .await
@@ -483,7 +494,12 @@ mod tests {
 
         let payload = builder.prepare_payload_attributes(parent, epoch).await.unwrap();
         assert_eq!(payload.gas_limit, Some(123));
-        assert!(builder.parent_system_config.is_none());
+
+        // The seed survives use, so a retried build on the same parent reuses it instead of
+        // falling back to the RPC (the default fetcher errors on any lookup, so a second
+        // success proves no fallback happened).
+        let payload = builder.prepare_payload_attributes(parent, epoch).await.unwrap();
+        assert_eq!(payload.gas_limit, Some(123));
 
         let mut fetcher = TestSystemConfigL2Fetcher::default();
         fetcher.insert(

--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -10,7 +10,7 @@ use alloy_rlp::Encodable;
 use alloy_rpc_types_engine::PayloadAttributes;
 use async_trait::async_trait;
 use base_common_consensus::Predeploys;
-use base_common_genesis::{RollupConfig, SystemConfig};
+use base_common_genesis::{BaseUpgrade, RollupConfig, SystemConfig};
 use base_common_rpc_types_engine::BasePayloadAttributes;
 use base_consensus_upgrades::{Upgrade, Upgrades};
 use base_protocol::{BaseTimeUpdateTx, Deposits, L1BlockInfoTx, L2BlockInfo};
@@ -80,20 +80,25 @@ where
         let l1_header;
         let deposit_transactions: Vec<Bytes>;
 
-        let parent_timestamp =
-            self.rollup_cfg.l2_block_timestamp(l2_parent.block_info.number.saturating_sub(1));
+        let target_l2_number = l2_parent.block_info.number + 1;
+        let (target_l2_time, target_l2_millis) =
+            self.rollup_cfg.l2_block_timestamp_parts(target_l2_number);
+        let two_blocks_back_l2_time =
+            self.rollup_cfg.l2_block_timestamp(target_l2_number.saturating_sub(2));
+        // Payload-derived configs may be incomplete around an upgrade boundary:
+        // - When building the activation block, its parent payload may omit dormant config fields
+        //   that become active immediately.
+        // - When building the child, the activation block may still use the old L1-info format,
+        //   and its upgrade transactions execute only after payload attributes are constructed.
+        // Fetch the full config for both blocks; subsequent blocks can safely use the cache again.
+        let requires_system_config_refresh =
+            BaseUpgrade::CONTRACT_VARIANTS.into_iter().any(|upgrade| {
+                self.rollup_cfg.upgrade_activation_timestamp(upgrade).is_some_and(|activation| {
+                    two_blocks_back_l2_time < activation && activation <= target_l2_time
+                })
+            });
         let mut sys_config = match self.parent_system_config {
-            Some((parent, config))
-                if parent == l2_parent
-                    && !self.rollup_cfg.is_first_isthmus_block(
-                        l2_parent.block_info.timestamp,
-                        parent_timestamp,
-                    )
-                    && !self.rollup_cfg.is_first_jovian_block(
-                        l2_parent.block_info.timestamp,
-                        parent_timestamp,
-                    ) =>
-            {
+            Some((parent, config)) if parent == l2_parent && !requires_system_config_refresh => {
                 config
             }
             _ => self
@@ -153,14 +158,11 @@ where
 
         // Sanity check the L1 origin was correctly selected to maintain the time invariant
         // between L1 and L2.
-        let next_l2_block_number = l2_parent.block_info.number + 1;
-        let (next_l2_time, next_l2_timestamp_millis_part) =
-            self.rollup_cfg.l2_block_timestamp_parts(next_l2_block_number);
-        if next_l2_time < l1_header.timestamp {
+        if target_l2_time < l1_header.timestamp {
             return Err(PipelineErrorKind::Reset(
                 BuilderError::BrokenTimeInvariant(
                     l2_parent.l1_origin,
-                    next_l2_time,
+                    target_l2_time,
                     BlockNumHash { hash: l1_header.hash_slow(), number: l1_header.number },
                     l1_header.timestamp,
                 )
@@ -168,7 +170,7 @@ where
             ));
         }
 
-        if self.rollup_cfg.is_first_denim_block(next_l2_time, l2_parent.block_info.timestamp) {
+        if self.rollup_cfg.is_first_denim_block(target_l2_time, l2_parent.block_info.timestamp) {
             // Preserve gas throughput and base-fee responsiveness per unit of wall-clock time
             // when Denim increases the number of blocks in each legacy block interval tenfold.
             sys_config.gas_limit /= u64::from(RollupConfig::DENIM_GAS_PARAMETER_SCALING_FACTOR);
@@ -178,22 +180,22 @@ where
         }
 
         let mut upgrade_transactions: Vec<Bytes> = vec![];
-        if self.rollup_cfg.is_ecotone_active(next_l2_time)
+        if self.rollup_cfg.is_ecotone_active(target_l2_time)
             && !self.rollup_cfg.is_ecotone_active(l2_parent.block_info.timestamp)
         {
             upgrade_transactions.extend(Upgrades::ECOTONE.txs());
         }
-        if self.rollup_cfg.is_fjord_active(next_l2_time)
+        if self.rollup_cfg.is_fjord_active(target_l2_time)
             && !self.rollup_cfg.is_fjord_active(l2_parent.block_info.timestamp)
         {
             upgrade_transactions.extend(Upgrades::FJORD.txs());
         }
-        if self.rollup_cfg.is_isthmus_active(next_l2_time)
+        if self.rollup_cfg.is_isthmus_active(target_l2_time)
             && !self.rollup_cfg.is_isthmus_active(l2_parent.block_info.timestamp)
         {
             upgrade_transactions.extend(Upgrades::ISTHMUS.txs());
         }
-        if self.rollup_cfg.is_jovian_active(next_l2_time)
+        if self.rollup_cfg.is_jovian_active(target_l2_time)
             && !self.rollup_cfg.is_jovian_active(l2_parent.block_info.timestamp)
         {
             upgrade_transactions.extend(Upgrades::JOVIAN.txs());
@@ -207,7 +209,7 @@ where
             sequence_number,
             &l1_header,
             l2_parent.block_info.timestamp,
-            next_l2_time,
+            target_l2_time,
         )
         .map_err(|e| {
             PipelineError::AttributesBuilder(BuilderError::Custom(e.to_string())).crit()
@@ -215,7 +217,7 @@ where
         let mut encoded_l1_info_tx = Vec::with_capacity(l1_info_tx_envelope.length());
         l1_info_tx_envelope.encode_2718(&mut encoded_l1_info_tx);
 
-        let base_time_active = self.rollup_cfg.is_denim_active(next_l2_time);
+        let base_time_active = self.rollup_cfg.is_denim_active(target_l2_time);
         let mut txs = Vec::with_capacity(
             1 + usize::from(base_time_active)
                 + deposit_transactions.len()
@@ -224,10 +226,10 @@ where
         txs.push(encoded_l1_info_tx.into());
 
         if base_time_active {
-            let base_time = BaseTimeUpdateTx::new(next_l2_timestamp_millis_part).map_err(|e| {
+            let base_time = BaseTimeUpdateTx::new(target_l2_millis).map_err(|e| {
                 PipelineError::AttributesBuilder(BuilderError::BaseTimeUpdate(e)).crit()
             })?;
-            let envelope = base_time.into_deposit_tx(next_l2_block_number);
+            let envelope = base_time.into_deposit_tx(target_l2_number);
             let mut encoded = Vec::with_capacity(envelope.length());
             envelope.encode_2718(&mut encoded);
             txs.push(encoded.into());
@@ -237,19 +239,19 @@ where
         txs.extend(upgrade_transactions);
 
         let mut withdrawals = None;
-        if self.rollup_cfg.is_canyon_active(next_l2_time) {
+        if self.rollup_cfg.is_canyon_active(target_l2_time) {
             withdrawals = Some(Vec::default());
         }
 
         let mut parent_beacon_root = None;
-        if self.rollup_cfg.is_ecotone_active(next_l2_time) {
+        if self.rollup_cfg.is_ecotone_active(target_l2_time) {
             // if the parent beacon root is not available, default to zero hash
             parent_beacon_root = Some(l1_header.parent_beacon_block_root.unwrap_or_default());
         }
 
         Ok(BasePayloadAttributes {
             payload_attributes: PayloadAttributes {
-                timestamp: next_l2_time,
+                timestamp: target_l2_time,
                 prev_randao: l1_header.mix_hash,
                 suggested_fee_recipient: Predeploys::SEQUENCER_FEE_VAULT,
                 parent_beacon_block_root: parent_beacon_root,
@@ -265,11 +267,11 @@ where
             eip_1559_params: sys_config.eip_1559_params(
                 &self.rollup_cfg,
                 l2_parent.block_info.timestamp,
-                next_l2_time,
+                target_l2_time,
             ),
             min_base_fee: self
                 .rollup_cfg
-                .is_jovian_active(next_l2_time)
+                .is_jovian_active(target_l2_time)
                 .then(|| sys_config.min_base_fee.unwrap_or_default()), /* Default to zero if not
                                                                         * set at Jovian */
         })
@@ -500,6 +502,22 @@ mod tests {
         // success proves no fallback happened).
         let payload = builder.prepare_payload_attributes(parent, epoch).await.unwrap();
         assert_eq!(payload.gas_limit, Some(123));
+
+        let mut fetcher = TestSystemConfigL2Fetcher::default();
+        fetcher.insert(
+            parent.block_info.number,
+            SystemConfig { gas_limit: 456, ..Default::default() },
+        );
+        let (mut builder, parent, epoch) = system_config_test_builder(fetcher);
+        let activation = builder.rollup_cfg.l2_block_timestamp(parent.block_info.number + 1);
+        Arc::make_mut(&mut builder.rollup_cfg).upgrades.fjord_time = Some(activation);
+        builder.seed_parent_system_config(
+            parent,
+            SystemConfig { gas_limit: 123, ..Default::default() },
+        );
+
+        let payload = builder.prepare_payload_attributes(parent, epoch).await.unwrap();
+        assert_eq!(payload.gas_limit, Some(456));
 
         let mut fetcher = TestSystemConfigL2Fetcher::default();
         fetcher.insert(

--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -10,7 +10,7 @@ use alloy_rlp::Encodable;
 use alloy_rpc_types_engine::PayloadAttributes;
 use async_trait::async_trait;
 use base_common_consensus::Predeploys;
-use base_common_genesis::RollupConfig;
+use base_common_genesis::{RollupConfig, SystemConfig};
 use base_common_rpc_types_engine::BasePayloadAttributes;
 use base_consensus_upgrades::{Upgrade, Upgrades};
 use base_protocol::{BaseTimeUpdateTx, Deposits, L1BlockInfoTx, L2BlockInfo};
@@ -36,6 +36,8 @@ where
     config_fetcher: L2P,
     /// The L1 receipts fetcher.
     receipts_fetcher: L1P,
+    /// Locally known system config for an exact L2 parent.
+    parent_system_config: Option<(L2BlockInfo, SystemConfig)>,
 }
 
 impl<L1P, L2P> StatefulAttributesBuilder<L1P, L2P>
@@ -55,6 +57,7 @@ where
             l1_cfg,
             config_fetcher: sys_cfg_fetcher,
             receipts_fetcher: receipts,
+            parent_system_config: None,
         }
     }
 }
@@ -65,6 +68,10 @@ where
     L1P: ChainProvider + Debug + Send,
     L2P: L2ChainProvider + Debug + Send,
 {
+    fn seed_parent_system_config(&mut self, parent: L2BlockInfo, config: SystemConfig) {
+        self.parent_system_config = Some((parent, config));
+    }
+
     async fn prepare_payload_attributes(
         &mut self,
         l2_parent: L2BlockInfo,
@@ -73,11 +80,17 @@ where
         let l1_header;
         let deposit_transactions: Vec<Bytes>;
 
-        let mut sys_config = self
-            .config_fetcher
-            .system_config_by_number(l2_parent.block_info.number, Arc::clone(&self.rollup_cfg))
-            .await
-            .map_err(Into::into)?;
+        let mut sys_config = match self
+            .parent_system_config
+            .take_if(|(parent, _)| *parent == l2_parent)
+        {
+            Some((_, config)) => config,
+            None => self
+                .config_fetcher
+                .system_config_by_number(l2_parent.block_info.number, Arc::clone(&self.rollup_cfg))
+                .await
+                .map_err(Into::into)?,
+        };
 
         // If the L1 origin changed in this block, then we are in the first block of the epoch.
         // In this case we need to fetch all transaction receipts from the L1 origin block so
@@ -290,7 +303,7 @@ mod tests {
 
     use alloy_consensus::Header;
     use alloy_eips::eip2718::Decodable2718;
-    use alloy_primitives::{B256, Log, LogData, U64, U256, address};
+    use alloy_primitives::{B256, Log, LogData, U64, U256, address, hex};
     use base_common_chains::Sepolia;
     use base_common_consensus::{BaseTxEnvelope, SystemAddresses};
     use base_common_genesis::{
@@ -377,6 +390,40 @@ mod tests {
         }
     }
 
+    fn system_config_test_builder(
+        fetcher: TestSystemConfigL2Fetcher,
+    ) -> (
+        StatefulAttributesBuilder<TestChainProvider, TestSystemConfigL2Fetcher>,
+        L2BlockInfo,
+        BlockNumHash,
+    ) {
+        let block_time = 10;
+        let timestamp = 100;
+        let cfg = Arc::new(RollupConfig {
+            block_time,
+            genesis: ChainGenesis { l2_time: timestamp - block_time, ..Default::default() },
+            ..Default::default()
+        });
+        let mut provider = TestChainProvider::default();
+        let header = Header { timestamp, ..Default::default() };
+        let origin_hash = header.hash_slow();
+        provider.insert_header(origin_hash, header);
+        let parent = L2BlockInfo {
+            block_info: BlockInfo {
+                hash: B256::left_padding_from(&[1]),
+                number: 1,
+                timestamp,
+                ..Default::default()
+            },
+            l1_origin: BlockNumHash { hash: origin_hash, number: 1 },
+            seq_num: 0,
+        };
+        let epoch = parent.l1_origin;
+        let builder =
+            StatefulAttributesBuilder::new(cfg, Arc::new(Sepolia::l1_config()), fetcher, provider);
+        (builder, parent, epoch)
+    }
+
     #[tokio::test]
     async fn test_derive_deposits_empty() {
         let receipts = vec![];
@@ -423,6 +470,98 @@ mod tests {
         let receipts = vec![generate_valid_receipt(), generate_valid_receipt()];
         let result = derive_deposits(B256::default(), &receipts, deposit_contract).await;
         assert_eq!(result.unwrap().len(), 4);
+    }
+
+    #[tokio::test]
+    async fn test_prepare_payload_uses_only_exact_parent_system_config_seed() {
+        let (mut builder, parent, epoch) =
+            system_config_test_builder(TestSystemConfigL2Fetcher::default());
+        builder.seed_parent_system_config(
+            parent,
+            SystemConfig { gas_limit: 123, ..Default::default() },
+        );
+
+        let payload = builder.prepare_payload_attributes(parent, epoch).await.unwrap();
+        assert_eq!(payload.gas_limit, Some(123));
+        assert!(builder.parent_system_config.is_none());
+
+        let mut fetcher = TestSystemConfigL2Fetcher::default();
+        fetcher.insert(
+            parent.block_info.number,
+            SystemConfig { gas_limit: 456, ..Default::default() },
+        );
+        let (mut builder, parent, epoch) = system_config_test_builder(fetcher);
+        let mut mismatched_parent = parent;
+        mismatched_parent.block_info.hash = B256::left_padding_from(&[2]);
+        builder.seed_parent_system_config(
+            mismatched_parent,
+            SystemConfig { gas_limit: 123, ..Default::default() },
+        );
+
+        let payload = builder.prepare_payload_attributes(parent, epoch).await.unwrap();
+        assert_eq!(payload.gas_limit, Some(456));
+        assert_eq!(builder.parent_system_config.unwrap().0, mismatched_parent);
+    }
+
+    #[tokio::test]
+    async fn test_epoch_update_applies_to_parent_system_config_seed() {
+        let system_config_address = address!("1111111111111111111111111111111111111111");
+        let cfg = Arc::new(RollupConfig {
+            block_time: 10,
+            genesis: ChainGenesis { l2_time: 90, ..Default::default() },
+            l1_system_config_address: system_config_address,
+            ..Default::default()
+        });
+        let origin_hash = B256::left_padding_from(&[1]);
+        let header = Header { parent_hash: origin_hash, timestamp: 100, ..Default::default() };
+        let epoch_hash = header.hash_slow();
+        let update = Log {
+            address: system_config_address,
+            data: LogData::new_unchecked(
+                vec![
+                    SystemConfigUpdate::TOPIC,
+                    SystemConfigUpdate::EVENT_VERSION_0,
+                    B256::left_padding_from(&[2]),
+                ],
+                hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000beef").into(),
+            ),
+        };
+        let mut provider = TestChainProvider::default();
+        provider.insert_header(epoch_hash, header);
+        provider.insert_receipts(
+            epoch_hash,
+            vec![Receipt {
+                status: Eip658Value::Eip658(true),
+                logs: vec![update],
+                ..Default::default()
+            }],
+        );
+        let mut builder = StatefulAttributesBuilder::new(
+            cfg,
+            Arc::new(Sepolia::l1_config()),
+            TestSystemConfigL2Fetcher::default(),
+            provider,
+        );
+        let parent = L2BlockInfo {
+            block_info: BlockInfo {
+                hash: B256::left_padding_from(&[3]),
+                number: 1,
+                timestamp: 100,
+                ..Default::default()
+            },
+            l1_origin: BlockNumHash { hash: origin_hash, number: 1 },
+            seq_num: 0,
+        };
+        builder.seed_parent_system_config(
+            parent,
+            SystemConfig { gas_limit: 123, ..Default::default() },
+        );
+
+        let payload = builder
+            .prepare_payload_attributes(parent, BlockNumHash { hash: epoch_hash, number: 2 })
+            .await
+            .unwrap();
+        assert_eq!(payload.gas_limit, Some(0xbeef));
     }
 
     #[tokio::test]

--- a/crates/consensus/derive/src/stages/attributes_queue.rs
+++ b/crates/consensus/derive/src/stages/attributes_queue.rs
@@ -246,7 +246,7 @@ mod tests {
     ) -> AttributesQueue<TestAttributesProvider, TestAttributesBuilder> {
         let cfg = cfg.unwrap_or_default();
         let mock_batch_queue = new_test_attributes_provider(origin, batches);
-        let mock_attributes_builder = TestAttributesBuilder { attributes };
+        let mock_attributes_builder = TestAttributesBuilder { attributes, ..Default::default() };
         AttributesQueue::new(Arc::new(cfg), mock_batch_queue, mock_attributes_builder)
     }
 
@@ -329,8 +329,10 @@ mod tests {
         let cfg = RollupConfig::default();
         let mock = new_test_attributes_provider(None, vec![]);
         let mut payload_attributes = default_payload_attributes();
-        let mock_builder =
-            TestAttributesBuilder { attributes: vec![Ok(payload_attributes.clone())] };
+        let mock_builder = TestAttributesBuilder {
+            attributes: vec![Ok(payload_attributes.clone())],
+            ..Default::default()
+        };
         let mut aq = AttributesQueue::new(Arc::new(cfg), mock, mock_builder);
         let parent = L2BlockInfo::default();
         let txs = vec![Bytes::default(), Bytes::default()];
@@ -359,7 +361,8 @@ mod tests {
         let mock =
             new_test_attributes_provider(Some(Default::default()), vec![Ok(Default::default())]);
         let mut pa = default_payload_attributes();
-        let mock_builder = TestAttributesBuilder { attributes: vec![Ok(pa.clone())] };
+        let mock_builder =
+            TestAttributesBuilder { attributes: vec![Ok(pa.clone())], ..Default::default() };
         let mut aq = AttributesQueue::new(Arc::new(cfg), mock, mock_builder);
         // If we load the batch, we should get the last in span.
         // But it won't take it so it will be available in the next_attributes call.

--- a/crates/consensus/derive/src/test_utils/attributes_queue.rs
+++ b/crates/consensus/derive/src/test_utils/attributes_queue.rs
@@ -19,10 +19,16 @@ use crate::{
 pub struct TestAttributesBuilder {
     /// The attributes to return.
     pub attributes: Vec<Result<BasePayloadAttributes, PipelineErrorKind>>,
+    /// Parent system configs seeded by callers.
+    pub parent_system_configs: Vec<(L2BlockInfo, SystemConfig)>,
 }
 
 #[async_trait]
 impl AttributesBuilder for TestAttributesBuilder {
+    fn seed_parent_system_config(&mut self, parent: L2BlockInfo, config: SystemConfig) {
+        self.parent_system_configs.push((parent, config));
+    }
+
     /// Prepares the [`BasePayloadAttributes`] for the next payload.
     async fn prepare_payload_attributes(
         &mut self,

--- a/crates/consensus/derive/src/traits/attributes.rs
+++ b/crates/consensus/derive/src/traits/attributes.rs
@@ -5,6 +5,7 @@ use core::fmt::Debug;
 
 use alloy_eips::BlockNumHash;
 use async_trait::async_trait;
+use base_common_genesis::SystemConfig;
 use base_common_rpc_types_engine::BasePayloadAttributes;
 use base_protocol::{AttributesWithParent, L2BlockInfo, SingleBatch};
 
@@ -37,6 +38,11 @@ pub trait NextAttributes {
 /// that can be used to construct an L2 Block containing only deposits.
 #[async_trait]
 pub trait AttributesBuilder: Debug + Send {
+    /// Seeds the system config for an exact L2 parent.
+    ///
+    /// Implementations may use this to avoid fetching config already known by the caller.
+    fn seed_parent_system_config(&mut self, _parent: L2BlockInfo, _config: SystemConfig) {}
+
     /// Prepares a template [`BasePayloadAttributes`] that is ready to be used to build an L2
     /// block. The block will contain deposits only, on top of the given L2 parent, with the L1
     /// origin set to the given epoch.

--- a/crates/consensus/service/src/actors/sequencer/actor.rs
+++ b/crates/consensus/service/src/actors/sequencer/actor.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use base_common_genesis::RollupConfig;
 use base_consensus_derive::AttributesBuilder;
 use base_consensus_rpc::SequencerAdminAPIError;
-use base_protocol::L2BlockInfo;
+use base_protocol::{L2BlockInfo, to_system_config_from_payload};
 use tokio::{
     select,
     sync::{mpsc, oneshot},
@@ -449,6 +449,29 @@ where
                     None => false,
                 };
 
+                if let Some(sealer) = self
+                    .sealer
+                    .as_ref()
+                    .filter(|sealer| sealer.matches_inserted_head(inserted_head))
+                {
+                    match to_system_config_from_payload(
+                        &sealer.envelope.execution_payload,
+                        &self.rollup_config,
+                    ) {
+                        Ok(config) => self
+                            .builder
+                            .attributes_builder
+                            .seed_parent_system_config(inserted_head, config),
+                        Err(error) => warn!(
+                            target: "sequencer",
+                            error = %error,
+                            block_number = inserted_head.block_info.number,
+                            block_hash = %inserted_head.block_info.hash,
+                            "Failed to cache acknowledged parent system config"
+                        ),
+                    }
+                }
+
                 if let Some(sealer) = self.sealer.take() {
                     Metrics::sequencer_seal_pipeline_duration().record(sealer.started_at.elapsed());
                 }
@@ -751,5 +774,98 @@ where
 {
     fn cancelled(&self) -> WaitForCancellationFuture<'_> {
         self.cancellation_token.cancelled()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{B256, Sealed};
+    use base_common_consensus::{BaseBlock, BaseTxEnvelope, TxDeposit};
+    use base_common_genesis::{RollupConfig, SystemConfig};
+    use base_common_rpc_types_engine::{BaseExecutionPayload, BaseExecutionPayloadEnvelope};
+    use base_protocol::{BlockInfo, L1BlockInfoBedrock};
+
+    use super::*;
+    use crate::actors::sequencer::tests::test_actor;
+
+    fn valid_sealer() -> (PayloadSealer, L2BlockInfo, SystemConfig) {
+        let block = BaseBlock {
+            header: alloy_consensus::Header { number: 1, ..Default::default() },
+            body: alloy_consensus::BlockBody {
+                transactions: vec![BaseTxEnvelope::Deposit(Sealed::new(TxDeposit {
+                    input: L1BlockInfoBedrock::default().encode_calldata(),
+                    ..Default::default()
+                }))],
+                ..Default::default()
+            },
+        };
+        let (payload, _) = BaseExecutionPayload::from_block_slow(&block);
+        let config = to_system_config_from_payload(&payload, &RollupConfig::default()).unwrap();
+        let head = L2BlockInfo {
+            block_info: BlockInfo {
+                hash: payload.block_hash(),
+                number: payload.block_number(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let envelope = BaseExecutionPayloadEnvelope {
+            execution_payload: payload,
+            parent_beacon_block_root: None,
+        };
+        (PayloadSealer::new(envelope), head, config)
+    }
+
+    #[tokio::test]
+    async fn acknowledged_payload_seeds_only_an_exact_decodable_parent() {
+        let (sealer, head, config) = valid_sealer();
+        let mut actor = test_actor();
+        actor.sealer = Some(sealer);
+        let mut pipeline = BuildPipelineState::default();
+        let mut shadow = None;
+        let mut reconciliation_ticker = tokio::time::interval(Duration::from_secs(1));
+        let mut build_ticker = ScheduledTicker::new(Duration::from_secs(2));
+
+        actor
+            .handle_seal_step_result(
+                &mut pipeline,
+                &mut shadow,
+                &mut reconciliation_ticker,
+                &mut build_ticker,
+                Ok(SealStepOutcome::Inserted(head)),
+            )
+            .await
+            .unwrap();
+        assert_eq!(actor.builder.attributes_builder.parent_system_configs, vec![(head, config)]);
+
+        let (sealer, mut mismatched_head, _) = valid_sealer();
+        mismatched_head.block_info.hash = B256::left_padding_from(&[1]);
+        actor.sealer = Some(sealer);
+        actor
+            .handle_seal_step_result(
+                &mut pipeline,
+                &mut shadow,
+                &mut reconciliation_ticker,
+                &mut build_ticker,
+                Ok(SealStepOutcome::Inserted(mismatched_head)),
+            )
+            .await
+            .unwrap();
+        assert_eq!(actor.builder.attributes_builder.parent_system_configs.len(), 1);
+
+        let (mut sealer, head, _) = valid_sealer();
+        sealer.envelope.execution_payload.transactions_mut().clear();
+        actor.sealer = Some(sealer);
+        actor
+            .handle_seal_step_result(
+                &mut pipeline,
+                &mut shadow,
+                &mut reconciliation_ticker,
+                &mut build_ticker,
+                Ok(SealStepOutcome::Inserted(head)),
+            )
+            .await
+            .unwrap();
+        assert_eq!(actor.builder.attributes_builder.parent_system_configs.len(), 1);
     }
 }

--- a/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
@@ -258,6 +258,7 @@ async fn shadow_funding_only_applies_to_first_private_block() {
             Ok(attributes_at(inserted_head.block_info.timestamp + block_time)),
             Ok(attributes_at(inserted_head.block_info.timestamp)),
         ],
+        ..Default::default()
     };
     actor.builder.engine_client = Arc::clone(&engine_client);
     actor.builder.origin_selector = origin_selector;
@@ -693,8 +694,10 @@ async fn shadow_funding_is_included_in_payload_attributes() {
     let mut actor = test_actor();
     actor.builder.origin_selector = origin_selector;
     actor.builder.engine_client = Arc::new(client);
-    actor.builder.attributes_builder =
-        TestAttributesBuilder { attributes: vec![Ok(BasePayloadAttributes::default())] };
+    actor.builder.attributes_builder = TestAttributesBuilder {
+        attributes: vec![Ok(BasePayloadAttributes::default())],
+        ..Default::default()
+    };
 
     let crate::BuildOutcome::Ready(handle) =
         actor.builder.build(Some(ShadowFunding::new(address, amount))).await.unwrap()

--- a/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
@@ -189,6 +189,7 @@ async fn test_on_time_or_late_insert_starts_child_build_immediately(#[case] seco
             Ok(attributes_at(inserted_timestamp + block_time)),
             Ok(attributes_at(inserted_timestamp)),
         ],
+        ..Default::default()
     };
     actor.builder.engine_client = Arc::clone(&engine_client);
     actor.builder.origin_selector = origin_selector;
@@ -328,6 +329,7 @@ async fn test_early_insert_defers_child_build_until_parent_timestamp() {
             Ok(attributes_at(initial_timestamp + 2 * block_time)),
             Ok(attributes_at(initial_timestamp + block_time)),
         ],
+        ..Default::default()
     };
     actor.builder.engine_client = Arc::clone(&engine_client);
     actor.builder.origin_selector = origin_selector;
@@ -422,6 +424,7 @@ async fn test_stop_discards_queued_parent_and_restart_builds_immediately_on_fres
             Ok(attributes_at(restart_head.block_info.timestamp + block_time)),
             Ok(attributes_at(inserted_head.block_info.timestamp)),
         ],
+        ..Default::default()
     };
     actor.builder.engine_client = Arc::clone(&engine_client);
     actor.builder.origin_selector = origin_selector;
@@ -793,7 +796,8 @@ async fn test_build_unsealed_payload_prepare_payload_attributes_error(
     let mut origin_selector = MockOriginSelector::new();
     origin_selector.expect_next_l1_origin().times(1).return_once(move |_| Ok(l1_origin));
 
-    let attributes_builder = TestAttributesBuilder { attributes: vec![Err(forced_error)] };
+    let attributes_builder =
+        TestAttributesBuilder { attributes: vec![Err(forced_error)], ..Default::default() };
 
     let mut actor = test_actor();
     actor.builder.origin_selector = origin_selector;

--- a/crates/consensus/service/src/actors/sequencer/tests/mod.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/mod.rs
@@ -3,5 +3,5 @@
 mod actor_test;
 mod admin_api_impl_test;
 
-pub(super) mod test_util;
+mod test_util;
 pub(super) use test_util::test_actor;

--- a/crates/consensus/service/src/actors/sequencer/tests/mod.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/mod.rs
@@ -3,4 +3,5 @@
 mod actor_test;
 mod admin_api_impl_test;
 
-mod test_util;
+pub(super) mod test_util;
+pub(super) use test_util::test_actor;

--- a/crates/consensus/service/src/actors/sequencer/tests/test_util.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/test_util.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 // Returns a test SequencerActor with mocks that can be used or overridden.
-pub(super) fn test_actor() -> SequencerActor<
+pub(in crate::actors::sequencer) fn test_actor() -> SequencerActor<
     TestAttributesBuilder,
     MockConductor,
     MockOriginSelector,
@@ -31,7 +31,7 @@ pub(super) fn test_actor() -> SequencerActor<
     SequencerActor {
         admin_api_rx,
         builder: PayloadBuilder {
-            attributes_builder: TestAttributesBuilder { attributes: vec![] },
+            attributes_builder: TestAttributesBuilder::default(),
             engine_client: Arc::clone(&engine_client),
             origin_selector: MockOriginSelector::new(),
             recovery_mode: recovery_mode.clone(),


### PR DESCRIPTION
## Summary

Remove the parent `SystemConfig` L2 RPC from the healthy, steady-state block-building path by reusing the exact locally built payload after the engine acknowledges its insertion.

The existing RPC remains the fallback for startup, recovery, reorgs, external heads, parent mismatches, and payload decoding failures.

## Before

Preparing attributes for block `N + 1` always began by fetching the parent config over L2 RPC:

```text
Engine acknowledges N
        |
        v
Build N + 1
        |
        v
system_config_by_number(N) L2 RPC
```

This put the RPC latency on the block-building critical path.

## After

```text
Build payload N
        |
        v
Engine inserts and acknowledges N
        |
        v
Verify the acknowledged hash and number match the retained payload
        |
        v
Decode SystemConfig from local payload N
        |
        v
Seed the attributes builder with (parent N, config)
        |
        v
Build N + 1 without the parent-config L2 RPC
```

The sequencer waits for engine acknowledgement rather than trusting an uninserted payload. The stateful attributes builder consumes the seed only when the full `L2BlockInfo` exactly matches the requested parent.

## L1 config updates

The parent config remains the baseline, matching the existing RPC behavior. When the L1 origin advances, the builder still fetches the new L1 block receipts and applies any `SystemConfigUpdate` events before producing the child attributes. Same-epoch blocks continue using the unchanged config.

## Safety and fallback behavior

The existing `system_config_by_number` RPC path is used when:

- the sequencer starts without a locally built parent
- the head came from recovery or another source
- a reorg or parent mismatch occurs
- the engine acknowledges a different block
- the retained payload cannot be decoded
- the attributes builder receives a different `L2BlockInfo`

Payload conversion failure is warning-only and does not interrupt block production.

## Implementation

- derive and seed config from the retained payload only after exact engine acknowledgement
- add a default no-op `AttributesBuilder::seed_parent_system_config` hook
- retain one exact `(L2BlockInfo, SystemConfig)` seed in `StatefulAttributesBuilder`
- consume the seed on an exact parent match; otherwise use the existing RPC
- forward the hook through the action-harness attributes wrapper

## Stack

1. #4522 — payload-native protocol conversion
2. **This PR:** sequencer integration and exact-parent cache

Base branch is intentionally `perf/payload-system-config`; merge #4522 first, then retarget this PR to `main`.

## Test plan

- `cargo test -p base-consensus-derive --lib`
- `cargo test -p base-consensus-node actors::sequencer --lib`
- `cargo check -p base-consensus-derive --no-default-features`
- `cargo check -p base-action-harness`
- `cargo clippy -p base-consensus-derive -p base-consensus-node --lib --tests -- -D warnings`
- `cargo clippy -p base-action-harness --lib -- -D warnings`