### PR TITLE
fix(upgrade-signal): Fail Closed On Empty L1 Schedule Reads

### DIFF
--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -530,13 +530,16 @@ impl ConsensusNodeArgs {
         signal_config.request_timeout = self.config.l1_rpc_args.l1_rpc_timeout;
         let reader =
             signal_config.reader(self.resolved_upgrade_signal_l1_rpc(upgrade_signal_l1_rpc))?;
-        let schedule = signal_config
-            .read_validated_schedule(
+        let Some(schedule) = signal_config
+            .read_optional_startup_schedule(
                 &reader,
                 "consensus startup",
                 &[UpgradeSignalMetricLayer::Consensus],
             )
-            .await?;
+            .await?
+        else {
+            return Ok(());
+        };
 
         Self::apply_schedule_to_rollup_config(cfg, &schedule);
 

--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -12,8 +12,8 @@ use base_consensus_node::{
     UpgradeSignalBuilderConfig,
 };
 use base_upgrade_signal::{
-    UpgradeSignalArgs, UpgradeSignalConfig, UpgradeSignalMetricLayer, UpgradeSignalRuntimeApplier,
-    UpgradeSignalSchedule, UpgradeSignalStartupMode,
+    UpgradeSignalArgs, UpgradeSignalConfig, UpgradeSignalDefaults, UpgradeSignalMetricLayer,
+    UpgradeSignalRuntimeApplier, UpgradeSignalSchedule, UpgradeSignalStartupMode,
 };
 use clap::Args;
 use eyre::Context;
@@ -535,6 +535,7 @@ impl ConsensusNodeArgs {
                 &reader,
                 "consensus startup",
                 &[UpgradeSignalMetricLayer::Consensus],
+                UpgradeSignalDefaults::STARTUP_SCHEDULE_RETRY_INTERVAL,
             )
             .await?;
 

--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -530,16 +530,13 @@ impl ConsensusNodeArgs {
         signal_config.request_timeout = self.config.l1_rpc_args.l1_rpc_timeout;
         let reader =
             signal_config.reader(self.resolved_upgrade_signal_l1_rpc(upgrade_signal_l1_rpc))?;
-        let Some(schedule) = signal_config
-            .read_optional_startup_schedule(
+        let schedule = signal_config
+            .read_required_startup_schedule(
                 &reader,
                 "consensus startup",
                 &[UpgradeSignalMetricLayer::Consensus],
             )
-            .await?
-        else {
-            return Ok(());
-        };
+            .await?;
 
         Self::apply_schedule_to_rollup_config(cfg, &schedule);
 

--- a/crates/execution/cli/src/upgrade_signal.rs
+++ b/crates/execution/cli/src/upgrade_signal.rs
@@ -3,8 +3,8 @@
 use base_execution_chainspec::BaseChainSpec;
 use base_node_runner::{BaseNodeExtension, BaseRpcContext, FromExtensionConfig, NodeHooks};
 use base_upgrade_signal::{
-    UpgradeSignalApplySummary, UpgradeSignalConfig, UpgradeSignalMetricLayer, UpgradeSignalMonitor,
-    UpgradeSignalRefresher, UpgradeSignalRuntimeApplier, UpgradeSignalSchedule,
+    UpgradeSignalApplySummary, UpgradeSignalConfig, UpgradeSignalDefaults, UpgradeSignalMetricLayer,
+    UpgradeSignalMonitor, UpgradeSignalRefresher, UpgradeSignalRuntimeApplier, UpgradeSignalSchedule,
 };
 use jsonrpsee::{RpcModule, core::RpcResult, types::ErrorObject};
 use reth_chainspec::EthChainSpec;
@@ -38,6 +38,7 @@ impl ExecutionUpgradeSignal {
                 &reader,
                 "execution startup",
                 &[UpgradeSignalMetricLayer::Execution],
+                UpgradeSignalDefaults::STARTUP_SCHEDULE_RETRY_INTERVAL,
             )
             .await?;
 

--- a/crates/execution/cli/src/upgrade_signal.rs
+++ b/crates/execution/cli/src/upgrade_signal.rs
@@ -3,8 +3,9 @@
 use base_execution_chainspec::BaseChainSpec;
 use base_node_runner::{BaseNodeExtension, BaseRpcContext, FromExtensionConfig, NodeHooks};
 use base_upgrade_signal::{
-    UpgradeSignalApplySummary, UpgradeSignalConfig, UpgradeSignalDefaults, UpgradeSignalMetricLayer,
-    UpgradeSignalMonitor, UpgradeSignalRefresher, UpgradeSignalRuntimeApplier, UpgradeSignalSchedule,
+    UpgradeSignalApplySummary, UpgradeSignalConfig, UpgradeSignalDefaults,
+    UpgradeSignalMetricLayer, UpgradeSignalMonitor, UpgradeSignalRefresher,
+    UpgradeSignalRuntimeApplier, UpgradeSignalSchedule,
 };
 use jsonrpsee::{RpcModule, core::RpcResult, types::ErrorObject};
 use reth_chainspec::EthChainSpec;

--- a/crates/execution/cli/src/upgrade_signal.rs
+++ b/crates/execution/cli/src/upgrade_signal.rs
@@ -32,17 +32,14 @@ impl ExecutionUpgradeSignal {
         chain_spec: &mut BaseChainSpec,
     ) -> eyre::Result<()> {
         let reader = config.signal_config.reader(config.l1_rpc.clone())?;
-        let Some(schedule) = config
+        let schedule = config
             .signal_config
-            .read_optional_startup_schedule(
+            .read_required_startup_schedule(
                 &reader,
                 "execution startup",
                 &[UpgradeSignalMetricLayer::Execution],
             )
-            .await?
-        else {
-            return Ok(());
-        };
+            .await?;
 
         Self::apply_schedule_to_chain_spec(chain_spec, &schedule)?;
 

--- a/crates/execution/cli/src/upgrade_signal.rs
+++ b/crates/execution/cli/src/upgrade_signal.rs
@@ -32,14 +32,17 @@ impl ExecutionUpgradeSignal {
         chain_spec: &mut BaseChainSpec,
     ) -> eyre::Result<()> {
         let reader = config.signal_config.reader(config.l1_rpc.clone())?;
-        let schedule = config
+        let Some(schedule) = config
             .signal_config
-            .read_validated_schedule(
+            .read_optional_startup_schedule(
                 &reader,
                 "execution startup",
                 &[UpgradeSignalMetricLayer::Execution],
             )
-            .await?;
+            .await?
+        else {
+            return Ok(());
+        };
 
         Self::apply_schedule_to_chain_spec(chain_spec, &schedule)?;
 

--- a/crates/utilities/upgrade-signal/src/config/mod.rs
+++ b/crates/utilities/upgrade-signal/src/config/mod.rs
@@ -32,6 +32,14 @@ impl UpgradeSignalDefaults {
     /// Maximum jittered backoff between L1 upgrade signal schedule read attempts.
     pub const READ_MAX_BACKOFF: Duration = Duration::from_secs(10);
 
+    /// Fixed interval between fail-closed startup schedule read attempts while the L1 contract has
+    /// not yet returned a valid schedule.
+    ///
+    /// Startup blocks indefinitely on an empty or unreachable contract (see
+    /// [`UpgradeSignalConfig::read_required_startup_schedule`](crate::UpgradeSignalConfig::read_required_startup_schedule)),
+    /// so this is paced to keep the loud retry logs legible rather than to recover quickly.
+    pub const STARTUP_SCHEDULE_RETRY_INTERVAL: Duration = Duration::from_secs(5);
+
     /// Node protocol version supported by this binary for contract-backed upgrade signals.
     ///
     /// Release branches sync the Cargo package version to the `GitHub` release tag, so release

--- a/crates/utilities/upgrade-signal/src/config/schedule.rs
+++ b/crates/utilities/upgrade-signal/src/config/schedule.rs
@@ -1,9 +1,8 @@
 use core::time::Duration;
 
 use alloy_primitives::{Address, U256};
-use backon::Retryable;
+use backon::{ConstantBuilder, Retryable};
 use base_common_genesis::UpgradeActivationSink;
-use base_retry::{DEFAULT_UNBOUNDED_INITIAL_DELAY, DEFAULT_UNBOUNDED_MAX_DELAY, RetryConfig};
 use tracing::{error, info};
 use url::Url;
 
@@ -147,6 +146,7 @@ impl UpgradeSignalConfig {
                 &reader,
                 log_context,
                 &[UpgradeSignalMetricLayer::Execution, UpgradeSignalMetricLayer::Consensus],
+                UpgradeSignalDefaults::STARTUP_SCHEDULE_RETRY_INTERVAL,
             )
             .await?;
 
@@ -223,18 +223,22 @@ impl UpgradeSignalConfig {
     ///
     /// This is the startup counterpart to the manual admin refresh, which instead surfaces an empty
     /// schedule as an error without retrying.
+    ///
+    /// `retry_interval` is the fixed delay between attempts; it is paced for legible retry logs
+    /// rather than fast recovery (see
+    /// [`UpgradeSignalDefaults::STARTUP_SCHEDULE_RETRY_INTERVAL`]).
     pub async fn read_required_startup_schedule(
         &self,
         reader: &AlloyUpgradeSignalReader,
         log_context: &'static str,
         metrics_layers: &[UpgradeSignalMetricLayer],
+        retry_interval: Duration,
     ) -> Result<UpgradeSignalSchedule, UpgradeSignalError> {
         let mut attempt = 1_u64;
-        let retry_config =
-            RetryConfig::unbounded(DEFAULT_UNBOUNDED_INITIAL_DELAY, DEFAULT_UNBOUNDED_MAX_DELAY);
+        let backoff = ConstantBuilder::default().with_delay(retry_interval).without_max_times();
 
         (|| self.read_validated_schedule(reader, log_context, metrics_layers))
-            .retry(retry_config.to_backoff_builder())
+            .retry(backoff)
             .when(|error| {
                 matches!(
                     error,
@@ -306,6 +310,7 @@ mod tests {
                 &reader,
                 "startup",
                 &[UpgradeSignalMetricLayer::Consensus],
+                Duration::from_millis(10),
             )
             .await
             .unwrap();
@@ -337,6 +342,7 @@ mod tests {
                 &reader,
                 "startup",
                 &[UpgradeSignalMetricLayer::Consensus],
+                Duration::from_millis(10),
             ),
             swap,
         );
@@ -360,6 +366,7 @@ mod tests {
                 &reader,
                 "startup",
                 &[UpgradeSignalMetricLayer::Consensus],
+                Duration::from_millis(10),
             )
             .await
             .unwrap_err();

--- a/crates/utilities/upgrade-signal/src/config/schedule.rs
+++ b/crates/utilities/upgrade-signal/src/config/schedule.rs
@@ -1,8 +1,10 @@
 use core::time::Duration;
 
 use alloy_primitives::{Address, U256};
+use backon::Retryable;
 use base_common_genesis::UpgradeActivationSink;
-use tracing::{info, warn};
+use base_retry::{DEFAULT_UNBOUNDED_INITIAL_DELAY, DEFAULT_UNBOUNDED_MAX_DELAY, RetryConfig};
+use tracing::{error, info};
 use url::Url;
 
 use super::{UpgradeSignalBlockTag, UpgradeSignalDefaults, UpgradeSignalMode};
@@ -140,16 +142,13 @@ impl UpgradeSignalConfig {
         CL::Error: std::error::Error + Send + Sync + 'static,
     {
         let reader = self.reader(l1_rpc)?;
-        let Some(schedule) = self
-            .read_optional_startup_schedule(
+        let schedule = self
+            .read_required_startup_schedule(
                 &reader,
                 log_context,
                 &[UpgradeSignalMetricLayer::Execution, UpgradeSignalMetricLayer::Consensus],
             )
-            .await?
-        else {
-            return Ok(());
-        };
+            .await?;
 
         UpgradeSignalRuntimeApplier::apply_schedule_to_sink(chain_id, &schedule, execution_sink)
             .map_err(eyre::Report::new)?
@@ -208,33 +207,52 @@ impl UpgradeSignalConfig {
         Ok(schedule)
     }
 
-    /// Reads the startup schedule via [`Self::read_validated_schedule`], tolerating a contract that
-    /// still reports no schedule after retries.
+    /// Reads the startup schedule via [`Self::read_validated_schedule`], blocking until the L1
+    /// contract returns a valid, non-empty schedule.
     ///
-    /// Empty reads are retried inside [`AlloyUpgradeSignalReader::read_schedule_with_retries`]; a
-    /// schedule that is still empty afterwards yields `Ok(None)` so startup proceeds on the
-    /// genesis/base configuration rather than failing to launch or wiping runtime overrides. All
-    /// other read and validation failures propagate. This is the startup counterpart to the manual
-    /// admin refresh, which instead surfaces an empty schedule as an error.
-    pub async fn read_optional_startup_schedule(
+    /// This is fail-closed by design. A healthy append-only `ProtocolVersions` contract is never
+    /// empty, so an empty read (like a transient provider failure) means the node cannot yet see
+    /// the authoritative activation schedule. Booting on the genesis/base configuration would risk
+    /// activating forks at different times than peers that read a populated contract, forking the
+    /// node — and any blocks it builds — off the network. Rather than take that risk, this retries
+    /// without an attempt limit, logging loudly at `error!` on every failure, until the read
+    /// succeeds. Only unrecoverable errors that waiting cannot fix — malformed contract data
+    /// ([`UpgradeSignalError::Decode`]) or a missing/unsupported protocol version — propagate and
+    /// abort startup. This future is cancellation-safe: dropping it during shutdown cancels the
+    /// in-flight request or retry sleep.
+    ///
+    /// This is the startup counterpart to the manual admin refresh, which instead surfaces an empty
+    /// schedule as an error without retrying.
+    pub async fn read_required_startup_schedule(
         &self,
         reader: &AlloyUpgradeSignalReader,
         log_context: &'static str,
         metrics_layers: &[UpgradeSignalMetricLayer],
-    ) -> Result<Option<UpgradeSignalSchedule>, UpgradeSignalError> {
-        match self.read_validated_schedule(reader, log_context, metrics_layers).await {
-            Ok(schedule) => Ok(Some(schedule)),
-            Err(UpgradeSignalError::EmptySchedule) => {
-                warn!(
+    ) -> Result<UpgradeSignalSchedule, UpgradeSignalError> {
+        let mut attempt = 1_u64;
+        let retry_config =
+            RetryConfig::unbounded(DEFAULT_UNBOUNDED_INITIAL_DELAY, DEFAULT_UNBOUNDED_MAX_DELAY);
+
+        (|| self.read_validated_schedule(reader, log_context, metrics_layers))
+            .retry(retry_config.to_backoff_builder())
+            .when(|error| {
+                matches!(
+                    error,
+                    UpgradeSignalError::EmptySchedule | UpgradeSignalError::Provider { .. }
+                )
+            })
+            .notify(|error, retry_delay| {
+                error!(
                     target: "upgrade_signal",
                     context = log_context,
-                    "L1 upgrade signal contract reported an empty schedule after retries; \
-                     proceeding on the base configuration without applying a schedule"
+                    attempt,
+                    retry_delay_ms = u64::try_from(retry_delay.as_millis()).unwrap_or(u64::MAX),
+                    error = %error,
+                    "refusing to start without an authoritative L1 upgrade schedule; retrying"
                 );
-                Ok(None)
-            }
-            Err(error) => Err(error),
-        }
+                attempt += 1;
+            })
+            .await
     }
 }
 
@@ -261,45 +279,30 @@ mod tests {
         config
     }
 
-    #[tokio::test]
-    async fn startup_read_returns_present_schedule() {
-        // ABI-encode a `uint64[]` with a single zeroed entry (offset, length, one word). A zero
-        // activation needs no protocol version, so the read passes validation without one.
+    /// ABI-encodes a `uint64[]` with a single zeroed entry (offset, length, one word). A zero
+    /// activation needs no protocol version, so the read passes validation without one.
+    fn single_zeroed_entry() -> Vec<u8> {
         let mut single_entry = vec![0_u8; 96];
         single_entry[31] = 32;
         single_entry[63] = 1;
-        let server = MockL1::schedule_server(single_entry).await;
-        let config = UpgradeSignalConfig::new(Address::ZERO);
-        let reader = config.reader(server.url("/").parse().unwrap()).unwrap();
+        single_entry
+    }
 
-        let schedule = config
-            .read_optional_startup_schedule(
-                &reader,
-                "startup",
-                &[UpgradeSignalMetricLayer::Consensus],
-            )
-            .await
-            .unwrap()
-            .expect("a non-empty schedule is present");
-
-        assert_eq!(schedule.signals.len(), 1);
-        assert_eq!(schedule.signals[0].upgrade_id, BaseUpgrade::Regolith);
-        assert_eq!(schedule.signals[0].activation_timestamp, 0);
+    /// ABI-encodes an empty `uint64[]` (offset word, zero length).
+    fn empty_schedule() -> Vec<u8> {
+        let mut empty = vec![0_u8; 64];
+        empty[31] = 32;
+        empty
     }
 
     #[tokio::test]
-    async fn startup_read_tolerates_empty_schedule() {
-        // ABI-encode an empty `uint64[]` (offset word, zero length). The startup path surfaces the
-        // empty read as `EmptySchedule` and tolerates it, yielding `Ok(None)` so the node boots on
-        // the base configuration instead of failing to launch or wiping runtime overrides.
-        let mut empty = vec![0_u8; 64];
-        empty[31] = 32;
-        let server = MockL1::schedule_server(empty).await;
+    async fn startup_read_returns_present_schedule() {
+        let server = MockL1::schedule_server(single_zeroed_entry()).await;
         let config = UpgradeSignalConfig::new(Address::ZERO);
         let reader = config.reader(server.url("/").parse().unwrap()).unwrap();
 
         let schedule = config
-            .read_optional_startup_schedule(
+            .read_required_startup_schedule(
                 &reader,
                 "startup",
                 &[UpgradeSignalMetricLayer::Consensus],
@@ -307,7 +310,61 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(schedule.is_none());
+        assert_eq!(schedule.signals.len(), 1);
+        assert_eq!(schedule.signals[0].upgrade_id, BaseUpgrade::Regolith);
+        assert_eq!(schedule.signals[0].activation_timestamp, 0);
+    }
+
+    #[tokio::test]
+    async fn startup_read_retries_until_schedule_is_present() {
+        // The contract reports an empty schedule at first. Fail-closed startup must not boot on the
+        // base configuration; it retries until the contract returns a real schedule, then applies
+        // it. The mock is swapped from empty to populated once the empty read is observed.
+        let server = MockL1::block_and_min_protocol_server().await;
+        let empty_mock = MockL1::mock_get_schedule(&server, empty_schedule()).await;
+        let config = UpgradeSignalConfig::new(Address::ZERO);
+        let reader = config.reader(server.url("/").parse().unwrap()).unwrap();
+
+        let swap = async {
+            while empty_mock.calls_async().await == 0 {
+                tokio::task::yield_now().await;
+            }
+            empty_mock.delete_async().await;
+            MockL1::mock_get_schedule(&server, single_zeroed_entry()).await;
+        };
+        let (schedule, ()) = tokio::join!(
+            config.read_required_startup_schedule(
+                &reader,
+                "startup",
+                &[UpgradeSignalMetricLayer::Consensus],
+            ),
+            swap,
+        );
+
+        let schedule = schedule.unwrap();
+        assert_eq!(schedule.signals.len(), 1);
+        assert_eq!(schedule.signals[0].upgrade_id, BaseUpgrade::Regolith);
+    }
+
+    #[tokio::test]
+    async fn startup_read_aborts_on_fatal_error() {
+        // A `getSchedule` that returns malformed data (`0x`) is a decode error: waiting cannot fix
+        // it, so fail-closed startup surfaces it immediately instead of looping forever.
+        let server = MockL1::block_and_min_protocol_server().await;
+        MockL1::mock_get_schedule(&server, Vec::new()).await;
+        let config = UpgradeSignalConfig::new(Address::ZERO);
+        let reader = config.reader(server.url("/").parse().unwrap()).unwrap();
+
+        let error = config
+            .read_required_startup_schedule(
+                &reader,
+                "startup",
+                &[UpgradeSignalMetricLayer::Consensus],
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, UpgradeSignalError::Decode { .. }));
     }
 
     #[test]

--- a/crates/utilities/upgrade-signal/src/config/schedule.rs
+++ b/crates/utilities/upgrade-signal/src/config/schedule.rs
@@ -2,7 +2,7 @@ use core::time::Duration;
 
 use alloy_primitives::{Address, U256};
 use base_common_genesis::UpgradeActivationSink;
-use tracing::info;
+use tracing::{info, warn};
 use url::Url;
 
 use super::{UpgradeSignalBlockTag, UpgradeSignalDefaults, UpgradeSignalMode};
@@ -140,13 +140,16 @@ impl UpgradeSignalConfig {
         CL::Error: std::error::Error + Send + Sync + 'static,
     {
         let reader = self.reader(l1_rpc)?;
-        let schedule = self
-            .read_validated_schedule(
+        let Some(schedule) = self
+            .read_optional_startup_schedule(
                 &reader,
                 log_context,
                 &[UpgradeSignalMetricLayer::Execution, UpgradeSignalMetricLayer::Consensus],
             )
-            .await?;
+            .await?
+        else {
+            return Ok(());
+        };
 
         UpgradeSignalRuntimeApplier::apply_schedule_to_sink(chain_id, &schedule, execution_sink)
             .map_err(eyre::Report::new)?
@@ -204,16 +207,51 @@ impl UpgradeSignalConfig {
 
         Ok(schedule)
     }
+
+    /// Reads the startup schedule via [`Self::read_validated_schedule`], tolerating a contract that
+    /// still reports no schedule after retries.
+    ///
+    /// Empty reads are retried inside [`AlloyUpgradeSignalReader::read_schedule_with_retries`]; a
+    /// schedule that is still empty afterwards yields `Ok(None)` so startup proceeds on the
+    /// genesis/base configuration rather than failing to launch or wiping runtime overrides. All
+    /// other read and validation failures propagate. This is the startup counterpart to the manual
+    /// admin refresh, which instead surfaces an empty schedule as an error.
+    pub async fn read_optional_startup_schedule(
+        &self,
+        reader: &AlloyUpgradeSignalReader,
+        log_context: &'static str,
+        metrics_layers: &[UpgradeSignalMetricLayer],
+    ) -> Result<Option<UpgradeSignalSchedule>, UpgradeSignalError> {
+        match self.read_validated_schedule(reader, log_context, metrics_layers).await {
+            Ok(schedule) => Ok(Some(schedule)),
+            Err(UpgradeSignalError::EmptySchedule) => {
+                warn!(
+                    target: "upgrade_signal",
+                    context = log_context,
+                    "L1 upgrade signal contract reported an empty schedule after retries; \
+                     proceeding on the base configuration without applying a schedule"
+                );
+                Ok(None)
+            }
+            Err(error) => Err(error),
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{U256, address};
+    use alloy_primitives::{B256, Bytes, U256, address, hex};
+    use alloy_rpc_types_eth::Block;
+    use alloy_sol_types::SolCall;
     use base_common_genesis::BaseUpgrade;
+    use httpmock::prelude::*;
     use rstest::rstest;
 
     use super::*;
-    use crate::state::{UpgradeSignal, UpgradeSignalSchedule};
+    use crate::{
+        contract::IProtocolVersions,
+        state::{UpgradeSignal, UpgradeSignalSchedule},
+    };
 
     fn upgrade(upgrade_id: &str) -> BaseUpgrade {
         BaseUpgrade::from_contract_fork_name(upgrade_id).unwrap()
@@ -224,6 +262,81 @@ mod tests {
             UpgradeSignalConfig::new(address!("0000000000000000000000000000000000000001"));
         config.node_protocol_version = UpgradeSignalDefaults::packed_protocol_version(1, 1, 0);
         config
+    }
+
+    /// Serves a block plus a `getSchedule` / `minimumProtocolVersion` pair over a mock L1 endpoint.
+    ///
+    /// The two contract calls are matched by ABI selector so a startup read observes the exact
+    /// `getSchedule` return supplied here.
+    async fn schedule_server(getschedule_return: Vec<u8>) -> MockServer {
+        let server = MockServer::start_async().await;
+        let block_hash = B256::repeat_byte(1);
+        let mut block: Block = Block::default();
+        block.header.hash = block_hash;
+        block.header.inner.number = 42;
+        server
+            .mock_async(|when, then| {
+                when.method(POST).path("/").body_includes("eth_getBlockByNumber");
+                then.json_body(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 0,
+                    "result": block,
+                }));
+            })
+            .await;
+        let getschedule_return = Bytes::from(getschedule_return);
+        server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/")
+                    .body_includes(hex::encode(IProtocolVersions::getScheduleCall::SELECTOR));
+                then.json_body(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 0,
+                    "result": getschedule_return,
+                }));
+            })
+            .await;
+        let minimum_protocol_version = Bytes::from(vec![0_u8; 32]);
+        server
+            .mock_async(|when, then| {
+                when.method(POST).path("/").body_includes(hex::encode(
+                    IProtocolVersions::minimumProtocolVersionCall::SELECTOR,
+                ));
+                then.json_body(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 0,
+                    "result": minimum_protocol_version,
+                }));
+            })
+            .await;
+        server
+    }
+
+    #[tokio::test]
+    async fn startup_read_returns_present_schedule() {
+        // ABI-encode a `uint64[]` with a single zeroed entry (offset, length, one word). A zero
+        // activation needs no protocol version, so the read passes validation without one.
+        let mut single_entry = vec![0_u8; 96];
+        single_entry[31] = 32;
+        single_entry[63] = 1;
+        let server = schedule_server(single_entry).await;
+        let config = UpgradeSignalConfig::new(Address::ZERO);
+        let reader = config.reader(server.url("/").parse().unwrap()).unwrap();
+
+        let schedule = config
+            .read_optional_startup_schedule(
+                &reader,
+                "startup",
+                &[UpgradeSignalMetricLayer::Consensus],
+            )
+            .await
+            .unwrap()
+            .expect("a non-empty schedule is present");
+
+        assert_eq!(schedule.signals.len(), 1);
+        assert_eq!(schedule.signals[0].upgrade_id, BaseUpgrade::Regolith);
+        assert_eq!(schedule.signals[0].activation_timestamp, 0);
     }
 
     #[test]

--- a/crates/utilities/upgrade-signal/src/config/schedule.rs
+++ b/crates/utilities/upgrade-signal/src/config/schedule.rs
@@ -240,17 +240,14 @@ impl UpgradeSignalConfig {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{B256, Bytes, U256, address, hex};
-    use alloy_rpc_types_eth::Block;
-    use alloy_sol_types::SolCall;
+    use alloy_primitives::{U256, address};
     use base_common_genesis::BaseUpgrade;
-    use httpmock::prelude::*;
     use rstest::rstest;
 
     use super::*;
     use crate::{
-        contract::IProtocolVersions,
         state::{UpgradeSignal, UpgradeSignalSchedule},
+        test_utils::MockL1,
     };
 
     fn upgrade(upgrade_id: &str) -> BaseUpgrade {
@@ -264,55 +261,6 @@ mod tests {
         config
     }
 
-    /// Serves a block plus a `getSchedule` / `minimumProtocolVersion` pair over a mock L1 endpoint.
-    ///
-    /// The two contract calls are matched by ABI selector so a startup read observes the exact
-    /// `getSchedule` return supplied here.
-    async fn schedule_server(getschedule_return: Vec<u8>) -> MockServer {
-        let server = MockServer::start_async().await;
-        let block_hash = B256::repeat_byte(1);
-        let mut block: Block = Block::default();
-        block.header.hash = block_hash;
-        block.header.inner.number = 42;
-        server
-            .mock_async(|when, then| {
-                when.method(POST).path("/").body_includes("eth_getBlockByNumber");
-                then.json_body(serde_json::json!({
-                    "jsonrpc": "2.0",
-                    "id": 0,
-                    "result": block,
-                }));
-            })
-            .await;
-        let getschedule_return = Bytes::from(getschedule_return);
-        server
-            .mock_async(|when, then| {
-                when.method(POST)
-                    .path("/")
-                    .body_includes(hex::encode(IProtocolVersions::getScheduleCall::SELECTOR));
-                then.json_body(serde_json::json!({
-                    "jsonrpc": "2.0",
-                    "id": 0,
-                    "result": getschedule_return,
-                }));
-            })
-            .await;
-        let minimum_protocol_version = Bytes::from(vec![0_u8; 32]);
-        server
-            .mock_async(|when, then| {
-                when.method(POST).path("/").body_includes(hex::encode(
-                    IProtocolVersions::minimumProtocolVersionCall::SELECTOR,
-                ));
-                then.json_body(serde_json::json!({
-                    "jsonrpc": "2.0",
-                    "id": 0,
-                    "result": minimum_protocol_version,
-                }));
-            })
-            .await;
-        server
-    }
-
     #[tokio::test]
     async fn startup_read_returns_present_schedule() {
         // ABI-encode a `uint64[]` with a single zeroed entry (offset, length, one word). A zero
@@ -320,7 +268,7 @@ mod tests {
         let mut single_entry = vec![0_u8; 96];
         single_entry[31] = 32;
         single_entry[63] = 1;
-        let server = schedule_server(single_entry).await;
+        let server = MockL1::schedule_server(single_entry).await;
         let config = UpgradeSignalConfig::new(Address::ZERO);
         let reader = config.reader(server.url("/").parse().unwrap()).unwrap();
 
@@ -337,6 +285,29 @@ mod tests {
         assert_eq!(schedule.signals.len(), 1);
         assert_eq!(schedule.signals[0].upgrade_id, BaseUpgrade::Regolith);
         assert_eq!(schedule.signals[0].activation_timestamp, 0);
+    }
+
+    #[tokio::test]
+    async fn startup_read_tolerates_empty_schedule() {
+        // ABI-encode an empty `uint64[]` (offset word, zero length). The startup path surfaces the
+        // empty read as `EmptySchedule` and tolerates it, yielding `Ok(None)` so the node boots on
+        // the base configuration instead of failing to launch or wiping runtime overrides.
+        let mut empty = vec![0_u8; 64];
+        empty[31] = 32;
+        let server = MockL1::schedule_server(empty).await;
+        let config = UpgradeSignalConfig::new(Address::ZERO);
+        let reader = config.reader(server.url("/").parse().unwrap()).unwrap();
+
+        let schedule = config
+            .read_optional_startup_schedule(
+                &reader,
+                "startup",
+                &[UpgradeSignalMetricLayer::Consensus],
+            )
+            .await
+            .unwrap();
+
+        assert!(schedule.is_none());
     }
 
     #[test]

--- a/crates/utilities/upgrade-signal/src/contract.rs
+++ b/crates/utilities/upgrade-signal/src/contract.rs
@@ -15,7 +15,7 @@ use base_retry::RetryConfig;
 use futures::future::try_join;
 use reqwest::Client;
 use tower::{ServiceExt, service_fn};
-use tracing::warn;
+use tracing::{debug, warn};
 use url::Url;
 
 use crate::{
@@ -328,18 +328,20 @@ impl AlloyUpgradeSignalReader {
         Ok(schedule)
     }
 
-    /// Reads the schedule, retrying transient failures with bounded exponential jitter before
-    /// giving up.
+    /// Reads the schedule, retrying transient provider failures with bounded exponential jitter
+    /// before giving up.
     ///
     /// Used on the startup path, where a single transient L1 error should not abort node launch
     /// outright; after `max_attempts` failures the last error is returned (fail-fast). This future
     /// is cancellation-safe: dropping it during shutdown cancels an in-flight HTTP request or
     /// retry sleep.
     ///
-    /// [`UpgradeSignalError::EmptySchedule`] is retried alongside provider errors: a freshly
-    /// deployed or just-initialized contract can briefly report an empty schedule at the finalized
-    /// tag, so a few retries let a real schedule settle before callers fall back. Decode and
-    /// protocol-version errors remain fail-fast.
+    /// Only [`UpgradeSignalError::Provider`] errors are retried. An empty schedule is not a
+    /// transient flake at the finalized or safe tags: the tag lags the initializing transaction by
+    /// epochs, far longer than the retry budget, so retrying would only delay startup and multiply
+    /// RPC calls without changing the outcome. Empty reads are surfaced immediately and left for the
+    /// caller to tolerate (startup) or reject (admin refresh). Decode and protocol-version errors
+    /// remain fail-fast.
     pub async fn read_schedule_with_retries(
         &self,
         max_attempts: u32,
@@ -354,12 +356,7 @@ impl AlloyUpgradeSignalReader {
 
         (|| self.read_schedule(metrics_layers))
             .retry(retry_config.to_backoff_builder())
-            .when(|error| {
-                matches!(
-                    error,
-                    UpgradeSignalError::Provider { .. } | UpgradeSignalError::EmptySchedule
-                )
-            })
+            .when(|error| matches!(error, UpgradeSignalError::Provider { .. }))
             // Backon adds jitter after enforcing `max_delay`, so cap the yielded delay too.
             .adjust(|_, retry_delay| retry_delay.map(|delay| delay.min(max_backoff)))
             .notify(|error, retry_delay| {
@@ -378,14 +375,22 @@ impl AlloyUpgradeSignalReader {
 
     /// Reads the schedule, tolerating read failures.
     ///
-    /// Records `l1_read_errors_total` and returns `None` when the read fails. Intended for the live
-    /// metrics poller, which must not abort the node because a schedule read failed.
+    /// Returns `None` when the read fails, recording `l1_read_errors_total`, or when the contract
+    /// reports an empty schedule, which is not a read failure and so records no metric. Intended for
+    /// the live metrics poller, which must not abort the node because a schedule read failed.
     pub async fn read_schedule_tolerant(
         &self,
         metrics_layers: &[UpgradeSignalMetricLayer],
     ) -> Option<UpgradeSignalSchedule> {
         match self.read_schedule(metrics_layers).await {
             Ok(schedule) => Some(schedule),
+            Err(UpgradeSignalError::EmptySchedule) => {
+                debug!(
+                    target: "upgrade_signal",
+                    "L1 upgrade signal contract reported an empty schedule; skipping live apply"
+                );
+                None
+            }
             Err(error) => {
                 warn!(
                     target: "upgrade_signal",
@@ -406,6 +411,7 @@ mod tests {
     use httpmock::prelude::*;
 
     use super::*;
+    use crate::test_utils::MockL1;
 
     fn signals(schedule: &UpgradeSignalSchedule) -> Vec<(BaseUpgrade, u64)> {
         schedule
@@ -560,48 +566,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rejects_empty_schedule_read_without_recording_read_error() {
-        let server = MockServer::start_async().await;
-        let block_hash = B256::repeat_byte(1);
-        let mut block: Block = Block::default();
-        block.header.hash = block_hash;
-        block.header.inner.number = 42;
-        server
-            .mock_async(|when, then| {
-                when.method(POST).path("/").body_includes("eth_getBlockByNumber");
-                then.json_body(serde_json::json!({
-                    "jsonrpc": "2.0",
-                    "id": 0,
-                    "result": block,
-                }));
-            })
-            .await;
-        let empty_schedule = Bytes::from(schedule_abi_header(U256::ZERO));
-        server
-            .mock_async(|when, then| {
-                when.method(POST)
-                    .path("/")
-                    .body_includes(hex::encode(IProtocolVersions::getScheduleCall::SELECTOR));
-                then.json_body(serde_json::json!({
-                    "jsonrpc": "2.0",
-                    "id": 0,
-                    "result": empty_schedule,
-                }));
-            })
-            .await;
-        let minimum_protocol_version = Bytes::from(vec![0_u8; 32]);
-        server
-            .mock_async(|when, then| {
-                when.method(POST).path("/").body_includes(hex::encode(
-                    IProtocolVersions::minimumProtocolVersionCall::SELECTOR,
-                ));
-                then.json_body(serde_json::json!({
-                    "jsonrpc": "2.0",
-                    "id": 0,
-                    "result": minimum_protocol_version,
-                }));
-            })
-            .await;
+    async fn rejects_empty_schedule_read() {
+        let server = MockL1::schedule_server(schedule_abi_header(U256::ZERO)).await;
         let reader = AlloyUpgradeSignalReader::new(
             server.url("/").parse().unwrap(),
             Address::ZERO,
@@ -615,7 +581,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn retries_empty_schedule_reads() {
+    async fn does_not_retry_empty_schedule_reads() {
         let server = MockServer::start_async().await;
         let block_hash = B256::repeat_byte(1);
         let mut block: Block = Block::default();
@@ -669,8 +635,9 @@ mod tests {
             .await
             .unwrap_err();
 
+        // An empty read is surfaced immediately: it is not a transient flake, so it is not retried.
         assert!(matches!(error, UpgradeSignalError::EmptySchedule));
-        schedule_mock.assert_calls_async(3).await;
+        schedule_mock.assert_calls_async(1).await;
     }
 
     #[tokio::test]

--- a/crates/utilities/upgrade-signal/src/contract.rs
+++ b/crates/utilities/upgrade-signal/src/contract.rs
@@ -582,7 +582,8 @@ mod tests {
     #[tokio::test]
     async fn does_not_retry_empty_schedule_reads() {
         let server = MockL1::block_and_min_protocol_server().await;
-        let schedule_mock = MockL1::mock_get_schedule(&server, schedule_abi_header(U256::ZERO)).await;
+        let schedule_mock =
+            MockL1::mock_get_schedule(&server, schedule_abi_header(U256::ZERO)).await;
         let reader = AlloyUpgradeSignalReader::new(
             server.url("/").parse().unwrap(),
             Address::ZERO,

--- a/crates/utilities/upgrade-signal/src/contract.rs
+++ b/crates/utilities/upgrade-signal/src/contract.rs
@@ -405,9 +405,8 @@ impl AlloyUpgradeSignalReader {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{B256, hex};
+    use alloy_primitives::B256;
     use alloy_rpc_types_eth::Block;
-    use alloy_sol_types::SolCall;
     use httpmock::prelude::*;
 
     use super::*;
@@ -582,47 +581,8 @@ mod tests {
 
     #[tokio::test]
     async fn does_not_retry_empty_schedule_reads() {
-        let server = MockServer::start_async().await;
-        let block_hash = B256::repeat_byte(1);
-        let mut block: Block = Block::default();
-        block.header.hash = block_hash;
-        block.header.inner.number = 42;
-        server
-            .mock_async(|when, then| {
-                when.method(POST).path("/").body_includes("eth_getBlockByNumber");
-                then.json_body(serde_json::json!({
-                    "jsonrpc": "2.0",
-                    "id": 0,
-                    "result": block,
-                }));
-            })
-            .await;
-        let empty_schedule = Bytes::from(schedule_abi_header(U256::ZERO));
-        let schedule_mock = server
-            .mock_async(|when, then| {
-                when.method(POST)
-                    .path("/")
-                    .body_includes(hex::encode(IProtocolVersions::getScheduleCall::SELECTOR));
-                then.json_body(serde_json::json!({
-                    "jsonrpc": "2.0",
-                    "id": 0,
-                    "result": empty_schedule,
-                }));
-            })
-            .await;
-        let minimum_protocol_version = Bytes::from(vec![0_u8; 32]);
-        server
-            .mock_async(|when, then| {
-                when.method(POST).path("/").body_includes(hex::encode(
-                    IProtocolVersions::minimumProtocolVersionCall::SELECTOR,
-                ));
-                then.json_body(serde_json::json!({
-                    "jsonrpc": "2.0",
-                    "id": 0,
-                    "result": minimum_protocol_version,
-                }));
-            })
-            .await;
+        let server = MockL1::block_and_min_protocol_server().await;
+        let schedule_mock = MockL1::mock_get_schedule(&server, schedule_abi_header(U256::ZERO)).await;
         let reader = AlloyUpgradeSignalReader::new(
             server.url("/").parse().unwrap(),
             Address::ZERO,

--- a/crates/utilities/upgrade-signal/src/contract.rs
+++ b/crates/utilities/upgrade-signal/src/contract.rs
@@ -290,6 +290,15 @@ impl AlloyUpgradeSignalReader {
     /// Records `l1_read_errors_total` for all contract-backed upgrades when the L1 block fetch or
     /// the schedule read fails; the whole schedule is read with one `getSchedule` call, so
     /// per-upgrade failures no longer exist.
+    ///
+    /// A successful read that yields no signals is rejected with
+    /// [`UpgradeSignalError::EmptySchedule`] rather than mapped to an empty schedule: applying an
+    /// empty schedule would replace every runtime override with base activations and report
+    /// success, silently diverging from the live poller, which ignores empty reads. An empty read
+    /// is not counted as an `l1_read_errors_total` failure, keeping empty success distinct from a
+    /// read failure. Callers decide how to treat it: startup retries then tolerates it (see
+    /// [`read_schedule_with_retries`](Self::read_schedule_with_retries)), while the manual admin
+    /// refresh surfaces it as an error instead of clearing overrides.
     pub async fn read_schedule(
         &self,
         metrics_layers: &[UpgradeSignalMetricLayer],
@@ -311,7 +320,12 @@ impl AlloyUpgradeSignalReader {
                 }
             };
 
-        Ok(Self::map_schedule(&timestamps, minimum_protocol_version, l1_block_number))
+        let schedule = Self::map_schedule(&timestamps, minimum_protocol_version, l1_block_number);
+        if schedule.signals.is_empty() {
+            return Err(UpgradeSignalError::EmptySchedule);
+        }
+
+        Ok(schedule)
     }
 
     /// Reads the schedule, retrying transient failures with bounded exponential jitter before
@@ -321,6 +335,11 @@ impl AlloyUpgradeSignalReader {
     /// outright; after `max_attempts` failures the last error is returned (fail-fast). This future
     /// is cancellation-safe: dropping it during shutdown cancels an in-flight HTTP request or
     /// retry sleep.
+    ///
+    /// [`UpgradeSignalError::EmptySchedule`] is retried alongside provider errors: a freshly
+    /// deployed or just-initialized contract can briefly report an empty schedule at the finalized
+    /// tag, so a few retries let a real schedule settle before callers fall back. Decode and
+    /// protocol-version errors remain fail-fast.
     pub async fn read_schedule_with_retries(
         &self,
         max_attempts: u32,
@@ -335,7 +354,12 @@ impl AlloyUpgradeSignalReader {
 
         (|| self.read_schedule(metrics_layers))
             .retry(retry_config.to_backoff_builder())
-            .when(|error| matches!(error, UpgradeSignalError::Provider { .. }))
+            .when(|error| {
+                matches!(
+                    error,
+                    UpgradeSignalError::Provider { .. } | UpgradeSignalError::EmptySchedule
+                )
+            })
             // Backon adds jitter after enforcing `max_delay`, so cap the yielded delay too.
             .adjust(|_, retry_delay| retry_delay.map(|delay| delay.min(max_backoff)))
             .notify(|error, retry_delay| {
@@ -376,8 +400,9 @@ impl AlloyUpgradeSignalReader {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::B256;
+    use alloy_primitives::{B256, hex};
     use alloy_rpc_types_eth::Block;
+    use alloy_sol_types::SolCall;
     use httpmock::prelude::*;
 
     use super::*;
@@ -532,6 +557,120 @@ mod tests {
 
         assert!(matches!(error, UpgradeSignalError::Provider { .. }));
         mock.assert_calls_async(3).await;
+    }
+
+    #[tokio::test]
+    async fn rejects_empty_schedule_read_without_recording_read_error() {
+        let server = MockServer::start_async().await;
+        let block_hash = B256::repeat_byte(1);
+        let mut block: Block = Block::default();
+        block.header.hash = block_hash;
+        block.header.inner.number = 42;
+        server
+            .mock_async(|when, then| {
+                when.method(POST).path("/").body_includes("eth_getBlockByNumber");
+                then.json_body(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 0,
+                    "result": block,
+                }));
+            })
+            .await;
+        let empty_schedule = Bytes::from(schedule_abi_header(U256::ZERO));
+        server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/")
+                    .body_includes(hex::encode(IProtocolVersions::getScheduleCall::SELECTOR));
+                then.json_body(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 0,
+                    "result": empty_schedule,
+                }));
+            })
+            .await;
+        let minimum_protocol_version = Bytes::from(vec![0_u8; 32]);
+        server
+            .mock_async(|when, then| {
+                when.method(POST).path("/").body_includes(hex::encode(
+                    IProtocolVersions::minimumProtocolVersionCall::SELECTOR,
+                ));
+                then.json_body(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 0,
+                    "result": minimum_protocol_version,
+                }));
+            })
+            .await;
+        let reader = AlloyUpgradeSignalReader::new(
+            server.url("/").parse().unwrap(),
+            Address::ZERO,
+            Duration::from_secs(1),
+        )
+        .unwrap();
+
+        let error = reader.read_schedule(&[]).await.unwrap_err();
+
+        assert!(matches!(error, UpgradeSignalError::EmptySchedule));
+    }
+
+    #[tokio::test]
+    async fn retries_empty_schedule_reads() {
+        let server = MockServer::start_async().await;
+        let block_hash = B256::repeat_byte(1);
+        let mut block: Block = Block::default();
+        block.header.hash = block_hash;
+        block.header.inner.number = 42;
+        server
+            .mock_async(|when, then| {
+                when.method(POST).path("/").body_includes("eth_getBlockByNumber");
+                then.json_body(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 0,
+                    "result": block,
+                }));
+            })
+            .await;
+        let empty_schedule = Bytes::from(schedule_abi_header(U256::ZERO));
+        let schedule_mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/")
+                    .body_includes(hex::encode(IProtocolVersions::getScheduleCall::SELECTOR));
+                then.json_body(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 0,
+                    "result": empty_schedule,
+                }));
+            })
+            .await;
+        let minimum_protocol_version = Bytes::from(vec![0_u8; 32]);
+        server
+            .mock_async(|when, then| {
+                when.method(POST).path("/").body_includes(hex::encode(
+                    IProtocolVersions::minimumProtocolVersionCall::SELECTOR,
+                ));
+                then.json_body(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 0,
+                    "result": minimum_protocol_version,
+                }));
+            })
+            .await;
+        let reader = AlloyUpgradeSignalReader::new(
+            server.url("/").parse().unwrap(),
+            Address::ZERO,
+            Duration::from_secs(1),
+        )
+        .unwrap();
+
+        let error = reader
+            .read_schedule_with_retries(3, Duration::ZERO, Duration::ZERO, &[])
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, UpgradeSignalError::EmptySchedule));
+        schedule_mock.assert_calls_async(3).await;
     }
 
     #[tokio::test]

--- a/crates/utilities/upgrade-signal/src/error.rs
+++ b/crates/utilities/upgrade-signal/src/error.rs
@@ -19,6 +19,14 @@ pub enum UpgradeSignalError {
         /// Decode error string.
         error: String,
     },
+    /// A successful `getSchedule` call returned no schedule entries.
+    ///
+    /// A healthy append-only `ProtocolVersions` contract always reports at least the oldest
+    /// registered upgrade, so an empty read signals a misconfigured, uninitialized, or mock
+    /// contract rather than an authoritative instruction to clear every runtime override. It is
+    /// kept distinct from a read failure so the empty-success case never advances local state.
+    #[error("getSchedule returned an empty schedule from a contract that should be append-only")]
+    EmptySchedule,
     /// A positive activation timestamp was not paired with a minimum node protocol version.
     #[error(
         "upgrade signal for {0} has an activation timestamp but no minimum node protocol version"

--- a/crates/utilities/upgrade-signal/src/lib.rs
+++ b/crates/utilities/upgrade-signal/src/lib.rs
@@ -37,3 +37,6 @@ pub use state::{UpgradeSignal, UpgradeSignalMonitor, UpgradeSignalSchedule};
 
 mod version;
 pub use version::PackedProtocolVersion;
+
+#[cfg(test)]
+pub mod test_utils;

--- a/crates/utilities/upgrade-signal/src/test_utils.rs
+++ b/crates/utilities/upgrade-signal/src/test_utils.rs
@@ -3,7 +3,7 @@
 use alloy_primitives::{B256, Bytes, hex};
 use alloy_rpc_types_eth::Block;
 use alloy_sol_types::SolCall;
-use httpmock::prelude::*;
+use httpmock::{Mock, prelude::*};
 
 use crate::contract::IProtocolVersions;
 
@@ -19,6 +19,17 @@ impl MockL1 {
     /// `getSchedule` return supplied here; `minimumProtocolVersion` returns zero. This is the mock
     /// triple shared across the reader's schedule-read tests.
     pub async fn schedule_server(getschedule_return: Vec<u8>) -> MockServer {
+        let server = Self::block_and_min_protocol_server().await;
+        Self::mock_get_schedule(&server, getschedule_return).await;
+        server
+    }
+
+    /// Serves a finalized block and a zero `minimumProtocolVersion` over a mock L1 endpoint,
+    /// without a `getSchedule` mock.
+    ///
+    /// Register the `getSchedule` response separately with [`Self::mock_get_schedule`] when the
+    /// test needs the mock handle (to assert call counts or swap the response mid-run).
+    pub async fn block_and_min_protocol_server() -> MockServer {
         let server = MockServer::start_async().await;
         let block_hash = B256::repeat_byte(1);
         let mut block: Block = Block::default();
@@ -31,19 +42,6 @@ impl MockL1 {
                     "jsonrpc": "2.0",
                     "id": 0,
                     "result": block,
-                }));
-            })
-            .await;
-        let getschedule_return = Bytes::from(getschedule_return);
-        server
-            .mock_async(|when, then| {
-                when.method(POST)
-                    .path("/")
-                    .body_includes(hex::encode(IProtocolVersions::getScheduleCall::SELECTOR));
-                then.json_body(serde_json::json!({
-                    "jsonrpc": "2.0",
-                    "id": 0,
-                    "result": getschedule_return,
                 }));
             })
             .await;
@@ -61,5 +59,23 @@ impl MockL1 {
             })
             .await;
         server
+    }
+
+    /// Registers a `getSchedule` mock returning `getschedule_return`, matched by ABI selector, and
+    /// returns its handle so tests can assert call counts or swap the response mid-run.
+    pub async fn mock_get_schedule(server: &MockServer, getschedule_return: Vec<u8>) -> Mock<'_> {
+        let getschedule_return = Bytes::from(getschedule_return);
+        server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/")
+                    .body_includes(hex::encode(IProtocolVersions::getScheduleCall::SELECTOR));
+                then.json_body(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 0,
+                    "result": getschedule_return,
+                }));
+            })
+            .await
     }
 }

--- a/crates/utilities/upgrade-signal/src/test_utils.rs
+++ b/crates/utilities/upgrade-signal/src/test_utils.rs
@@ -1,0 +1,65 @@
+//! Shared test utilities for exercising the upgrade signal reader against a mock L1 endpoint.
+
+use alloy_primitives::{B256, Bytes, hex};
+use alloy_rpc_types_eth::Block;
+use alloy_sol_types::SolCall;
+use httpmock::prelude::*;
+
+use crate::contract::IProtocolVersions;
+
+/// Mock L1 JSON-RPC endpoint builders for upgrade signal reads.
+#[derive(Debug)]
+pub struct MockL1;
+
+impl MockL1 {
+    /// Serves a finalized block plus a `getSchedule` / `minimumProtocolVersion` pair over a mock
+    /// L1 endpoint.
+    ///
+    /// The two contract calls are matched by ABI selector so a read observes the exact
+    /// `getSchedule` return supplied here; `minimumProtocolVersion` returns zero. This is the mock
+    /// triple shared across the reader's schedule-read tests.
+    pub async fn schedule_server(getschedule_return: Vec<u8>) -> MockServer {
+        let server = MockServer::start_async().await;
+        let block_hash = B256::repeat_byte(1);
+        let mut block: Block = Block::default();
+        block.header.hash = block_hash;
+        block.header.inner.number = 42;
+        server
+            .mock_async(|when, then| {
+                when.method(POST).path("/").body_includes("eth_getBlockByNumber");
+                then.json_body(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 0,
+                    "result": block,
+                }));
+            })
+            .await;
+        let getschedule_return = Bytes::from(getschedule_return);
+        server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/")
+                    .body_includes(hex::encode(IProtocolVersions::getScheduleCall::SELECTOR));
+                then.json_body(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 0,
+                    "result": getschedule_return,
+                }));
+            })
+            .await;
+        let minimum_protocol_version = Bytes::from(vec![0_u8; 32]);
+        server
+            .mock_async(|when, then| {
+                when.method(POST).path("/").body_includes(hex::encode(
+                    IProtocolVersions::minimumProtocolVersionCall::SELECTOR,
+                ));
+                then.json_body(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 0,
+                    "result": minimum_protocol_version,
+                }));
+            })
+            .await;
+        server
+    }
+}


### PR DESCRIPTION
## Summary

A successful but empty `getSchedule()` read previously mapped to an empty schedule, which the manual admin refresh path would apply as authoritative, silently wiping every runtime upgrade override and returning success while the live poller ignored it. An empty read is now rejected with a typed `EmptySchedule` error instead of being applied, keeping empty-success distinct from a read failure.

Because a healthy append-only `ProtocolVersions` contract is never empty, an empty read means the node cannot yet see the authoritative activation schedule. The three read paths treat that distinctly:

- **Startup (`read_required_startup_schedule`)** — **fail closed**. Booting on the base configuration would risk activating forks at different times than peers reading a populated contract, forking the node — and any blocks it builds — off the network. Instead of proceeding, startup retries without an attempt limit, logging loudly at `error!` on every failure, until the contract returns a valid non-empty schedule. Only unrecoverable errors (malformed contract data, missing/unsupported protocol version) abort startup. The future stays cancellation-safe for shutdown.
- **Admin refresh** — surfaces the empty read as an error immediately (no retry), rather than clearing overrides.
- **Live poller** — logs at `debug` and skips the cycle; empty reads are not counted as `l1_read_errors_total`.

`EmptySchedule` is not part of the bounded transport-level retry predicate: at the finalized/safe tags the empty→populated transition lags by epochs, far past that budget, so retrying there only delayed startup and multiplied RPC. The unbounded startup wait is the mechanism that patiently blocks until L1 is authoritative.