### PR TITLE
fix(proof): Gate Zenith On Claim Timestamp

### DIFF
--- a/crates/proof/proof/src/boot.rs
+++ b/crates/proof/proof/src/boot.rs
@@ -421,9 +421,20 @@ impl BootInfo {
                 schedule_block: schedule_l2_block_number,
             })?;
 
-        // Zenith is not contract-backed, so reject it when active and remove it when future.
+        // The proven range ends at the claimed block, so execution-fork activation must be evaluated
+        // against the claim timestamp, not the (possibly later) schedule pin horizon. A game-wide
+        // schedule block only fixes a shared schedule ID across subranges; it must never make an
+        // upgrade look active for a subrange whose execution never reaches it.
+        let claim_blocks_since_genesis = l2_claim_block - rollup_config.genesis.l2.number;
+        let l2_claim_timestamp = claim_blocks_since_genesis
+            .checked_mul(rollup_config.block_time)
+            .and_then(|offset| rollup_config.genesis.l2_time.checked_add(offset))
+            .ok_or(OracleProviderError::L2ClaimTimestampOverflow { claim_block: l2_claim_block })?;
+
+        // Zenith is not contract-backed, so reject it when active within the proven range and remove
+        // it when it only activates after the claimed block.
         match rollup_config.upgrades.base.zenith {
-            Some(zenith_time) if zenith_time <= l2_schedule_timestamp => {
+            Some(zenith_time) if zenith_time <= l2_claim_timestamp => {
                 return Err(OracleProviderError::UncommittedZenithUpgrade);
             }
             Some(_) => rollup_config.upgrades.base.zenith = None,
@@ -866,6 +877,72 @@ mod tests {
             boot_info.schedule_id,
             ScheduleId::pin(&mut expected_config, schedule_timestamp)
         );
+    }
+
+    #[tokio::test]
+    async fn clears_zenith_activating_after_claim_but_before_schedule_horizon() {
+        // A game-wide schedule block pins the shared schedule ID to the game's final block, which
+        // can sit past a later Zenith activation even when the proven subrange ends before it.
+        // Zenith must be evaluated against the claim timestamp, so this pre-Zenith range still loads.
+        const CLAIM_BLOCK: u64 = 150;
+        const SCHEDULE_BLOCK: u64 = 200;
+
+        let mut rollup_config = BaseChainConfig::MAINNET.rollup_config();
+        rollup_config.genesis.l2.number = 0;
+        rollup_config.genesis.l2_time = 2;
+        rollup_config.block_time = 2;
+        let claim_timestamp =
+            rollup_config.genesis.l2_time + CLAIM_BLOCK * rollup_config.block_time;
+        let schedule_timestamp =
+            rollup_config.genesis.l2_time + SCHEDULE_BLOCK * rollup_config.block_time;
+        let zenith_time = claim_timestamp + 1;
+        assert!(
+            zenith_time <= schedule_timestamp,
+            "premise: Zenith active only at the pin horizon"
+        );
+        rollup_config.upgrades.base.zenith = Some(zenith_time);
+
+        let mut oracle = MockOracle::new();
+        oracle.insert(L1_HEAD_KEY, B256::repeat_byte(0x11).to_vec());
+        oracle.insert(L2_OUTPUT_ROOT_KEY, B256::repeat_byte(0x22).to_vec());
+        oracle.insert(L2_CLAIM_KEY, B256::repeat_byte(0x33).to_vec());
+        oracle.insert(L2_CLAIM_BLOCK_NUMBER_KEY, CLAIM_BLOCK.to_be_bytes().to_vec());
+        oracle.insert(L2_SCHEDULE_BLOCK_NUMBER_KEY, SCHEDULE_BLOCK.to_be_bytes().to_vec());
+        oracle.insert_rollup_config(ORACLE_CHAIN_ID, &rollup_config);
+
+        let boot_info =
+            BootInfo::load(&oracle).await.expect("pre-Zenith subrange should load despite pin");
+
+        assert_eq!(boot_info.rollup_config.upgrades.base.zenith, None);
+    }
+
+    #[tokio::test]
+    async fn rejects_zenith_active_within_claim_range_despite_schedule_override() {
+        // A later schedule pin horizon must not relax the gate: a range that genuinely reaches an
+        // uncommitted Zenith activation still has to be rejected.
+        const CLAIM_BLOCK: u64 = 150;
+        const SCHEDULE_BLOCK: u64 = 200;
+
+        let mut rollup_config = BaseChainConfig::MAINNET.rollup_config();
+        rollup_config.genesis.l2.number = 0;
+        rollup_config.genesis.l2_time = 2;
+        rollup_config.block_time = 2;
+        let claim_timestamp =
+            rollup_config.genesis.l2_time + CLAIM_BLOCK * rollup_config.block_time;
+        rollup_config.upgrades.base.zenith = Some(claim_timestamp);
+
+        let mut oracle = MockOracle::new();
+        oracle.insert(L1_HEAD_KEY, B256::repeat_byte(0x11).to_vec());
+        oracle.insert(L2_OUTPUT_ROOT_KEY, B256::repeat_byte(0x22).to_vec());
+        oracle.insert(L2_CLAIM_KEY, B256::repeat_byte(0x33).to_vec());
+        oracle.insert(L2_CLAIM_BLOCK_NUMBER_KEY, CLAIM_BLOCK.to_be_bytes().to_vec());
+        oracle.insert(L2_SCHEDULE_BLOCK_NUMBER_KEY, SCHEDULE_BLOCK.to_be_bytes().to_vec());
+        oracle.insert_rollup_config(ORACLE_CHAIN_ID, &rollup_config);
+
+        let err = BootInfo::load(&oracle)
+            .await
+            .expect_err("Zenith active within the claim range should fail");
+        assert!(matches!(err, OracleProviderError::UncommittedZenithUpgrade));
     }
 
     #[tokio::test]

--- a/crates/proof/proof/src/errors.rs
+++ b/crates/proof/proof/src/errors.rs
@@ -137,6 +137,12 @@ pub enum OracleProviderError {
         /// The L2 block number used to pin the upgrade schedule.
         schedule_block: u64,
     },
+    /// Computing the claimed L2 block timestamp overflowed `u64`.
+    #[error("L2 claim block timestamp overflow for block {claim_block}")]
+    L2ClaimTimestampOverflow {
+        /// The claimed L2 block number.
+        claim_block: u64,
+    },
     /// The rollup config has a zero L2 block time.
     #[error("L2 block time must be non-zero")]
     InvalidL2BlockTime,


### PR DESCRIPTION
## Summary

The boot loader rejected an uncommitted Zenith upgrade by comparing its activation against the schedule pin timestamp, which is the game-wide horizon (schedule block) and only exists to give every dispute subrange a shared schedule ID. Because that horizon is greater than or equal to the claimed block, a pre-Zenith subrange was rejected purely because the game endpoint was post-Zenith, bricking counter-proofs for every pre-Zenith subrange on chains that configure Zenith in genesis. This changes the check to evaluate Zenith against the claimed block timestamp, which matches the range that is actually proven, while ScheduleId::pin still uses the schedule horizon so cross-subrange schedule IDs remain consistent. A new L2ClaimTimestampOverflow error and two regression tests cover the accept path (a pre-Zenith range past a later pin now loads and clears Zenith) and the reject path (Zenith active within the claim range still fails).