### PR TITLE
feat(builder): emit predicate bucket wakeups and depth distribution

### DIFF
--- a/crates/builder/core/benches/tx_selection.rs
+++ b/crates/builder/core/benches/tx_selection.rs
@@ -254,7 +254,12 @@ fn run_predicate_selection(pool: &Pool, db: &mut InMemoryDB) -> usize {
         black_box(&transaction);
         best.mark_current_committed();
         selected += 1;
-        assert!(predicate_index.affected_by_state(&EvmState::default()).is_empty());
+        assert!(
+            predicate_index
+                .affected_by_state(&EvmState::default())
+                .affected_transactions
+                .is_empty()
+        );
     }
 
     selected

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -45,8 +45,8 @@ use tracing::{Level, debug, span, trace, warn};
 
 use crate::{
     BuilderConfig, BuilderMetrics, ExecutionInfo, ExecutionMeteringLimitExceeded,
-    ParkedPredicateIndex, PayloadTxsBounds, ResourceLimits, TxResources, TxnExecutionError,
-    TxnOutcome, ValidityPredicateKey,
+    ParkedPredicateIndex, PayloadTxsBounds, ResourceLimits, StateChangeEffects, TxResources,
+    TxnExecutionError, TxnOutcome, ValidityPredicateKey,
     transaction_events::{
         BuilderAcceptedEventData, BuilderConsideredEventData, BuilderDeferredEventData,
         BuilderRejectedEventData, BuilderTransactionEventContext, emit_builder_transaction_event,
@@ -687,6 +687,10 @@ impl BasePayloadBuilderCtx {
         let mut reverted_gas_used: u64 = 0;
         let base_fee = self.base_fee();
         let mut diag = FlashblockDiagnostics::default();
+
+        // Number of validity-predicate index buckets woken (their watched balance or storage
+        // slot actually changed) across this flashblock build.
+        let mut predicate_bucket_wakeups: u64 = 0;
 
         let min_tx_index = info.executed_transactions.len() as u64;
         let mut evm = self.evm_config.evm_with_env(&mut *db, self.evm_env.clone());
@@ -1425,11 +1429,12 @@ impl BasePayloadBuilderCtx {
             };
             info.receipts.push(self.build_receipt(ctx, None));
 
-            let affected_parked = if predicate_index.is_empty() {
-                Vec::new()
+            let state_change_effects = if predicate_index.is_empty() {
+                StateChangeEffects::default()
             } else {
                 predicate_index.affected_by_state(&state)
             };
+            predicate_bucket_wakeups += state_change_effects.woken_buckets as u64;
 
             // commit changes
             evm.db_mut().commit(state);
@@ -1437,7 +1442,7 @@ impl BasePayloadBuilderCtx {
             // Release the committed transaction's lane before promoting predicate-unblocked heads.
             best_txs.mark_current_committed();
             let predicate_rescan_start = Instant::now();
-            for parked_hash in &affected_parked {
+            for parked_hash in &state_change_effects.affected_transactions {
                 let mut predicate_read_failed = false;
                 let Some(parked_transaction) = predicate_index.transaction(*parked_hash) else {
                     warn!(
@@ -1485,7 +1490,7 @@ impl BasePayloadBuilderCtx {
                     best_txs.promote(*parked_hash);
                 }
             }
-            if !affected_parked.is_empty() {
+            if !state_change_effects.affected_transactions.is_empty() {
                 BuilderMetrics::validity_predicate_rescan_duration()
                     .record(predicate_rescan_start.elapsed().as_secs_f64());
             }
@@ -1531,6 +1536,10 @@ impl BasePayloadBuilderCtx {
             num_txs_simulated_success as f64,
             num_txs_simulated_fail as f64,
             reverted_gas_used as f64,
+        );
+        BuilderMetrics::record_predicate_index_diagnostics(
+            predicate_bucket_wakeups,
+            &predicate_index,
         );
 
         diag.txs_considered = num_txs_considered;

--- a/crates/builder/core/src/flashblocks/mod.rs
+++ b/crates/builder/core/src/flashblocks/mod.rs
@@ -7,7 +7,7 @@ pub use best_txs::{
 };
 
 mod predicate_index;
-pub use predicate_index::{ParkedPredicateIndex, ValidityPredicateKey};
+pub use predicate_index::{ParkedPredicateIndex, StateChangeEffects, ValidityPredicateKey};
 
 mod deadline;
 pub use deadline::PayloadJobDeadline;

--- a/crates/builder/core/src/flashblocks/predicate_index.rs
+++ b/crates/builder/core/src/flashblocks/predicate_index.rs
@@ -127,14 +127,15 @@ impl<T> ParkedPredicateIndex<T> {
         Some(transaction)
     }
 
-    /// Returns parked transactions whose indexed state may have changed.
-    pub fn affected_by_state(&self, state: &EvmState) -> Vec<TxHash> {
-        let mut affected = Vec::new();
+    /// Returns parked transactions and index-bucket wakeups triggered by `state`.
+    pub fn affected_by_state(&self, state: &EvmState) -> StateChangeEffects {
+        let mut effects = StateChangeEffects::default();
         for (address, account) in state {
             if account.info.balance != account.original_info().balance
                 && let Some(hashes) = self.blockers.get(&ValidityPredicateKey::Balance(*address))
             {
-                affected.extend(hashes.iter().copied());
+                effects.affected_transactions.extend(hashes.iter().copied());
+                effects.woken_buckets += 1;
             }
 
             // Selfdestruct can clear slots that were not loaded during this execution. Wake every
@@ -143,7 +144,8 @@ impl<T> ParkedPredicateIndex<T> {
                 for (key, hashes) in &self.blockers {
                     if matches!(key, ValidityPredicateKey::Storage(key_address, _) if key_address == address)
                     {
-                        affected.extend(hashes.iter().copied());
+                        effects.affected_transactions.extend(hashes.iter().copied());
+                        effects.woken_buckets += 1;
                     }
                 }
             } else {
@@ -152,25 +154,45 @@ impl<T> ParkedPredicateIndex<T> {
                         && let Some(hashes) =
                             self.blockers.get(&ValidityPredicateKey::Storage(*address, *slot))
                     {
-                        affected.extend(hashes.iter().copied());
+                        effects.affected_transactions.extend(hashes.iter().copied());
+                        effects.woken_buckets += 1;
                     }
                 }
             }
         }
-        affected
+        effects
     }
+
+    /// Returns the number of parked transactions blocked on each distinct index bucket.
+    pub fn bucket_depths(&self) -> impl Iterator<Item = usize> + '_ {
+        self.blockers.values().map(HashSet::len)
+    }
+}
+
+/// Parked transactions and index-bucket wakeups triggered by one state change.
+///
+/// A bucket is "woken" when the watched [`ValidityPredicateKey`] it indexes actually changed,
+/// counted once per bucket regardless of how many parked transactions block on it. A wakeup
+/// means the bucket's parked transactions are due for re-evaluation — it does not mean their
+/// predicates became satisfied; that outcome is determined separately by the rescan.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct StateChangeEffects {
+    /// Parked transactions whose blocking predicate may have changed and need re-evaluation.
+    pub affected_transactions: Vec<TxHash>,
+    /// Number of distinct index buckets that were woken.
+    pub woken_buckets: usize,
 }
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{Address, B256, U256};
+    use alloy_primitives::{Address, B256, U256, map::HashSet};
     use base_execution_txpool::{PredicateContext, ValidityOperator, ValidityPredicate};
     use revm::{
         database::InMemoryDB,
         state::{Account, EvmState, EvmStorageSlot},
     };
 
-    use super::{ParkedPredicateIndex, ValidityPredicateKey};
+    use super::{ParkedPredicateIndex, StateChangeEffects, ValidityPredicateKey};
 
     fn balance_predicate(address: Address, value: U256) -> ValidityPredicate {
         ValidityPredicate::Balance { address, op: ValidityOperator::Equal, value }
@@ -195,7 +217,10 @@ mod tests {
         account.info.balance = U256::ONE;
         state.insert(balance_address, account);
 
-        assert_eq!(index.affected_by_state(&state), vec![balance_hash]);
+        assert_eq!(
+            index.affected_by_state(&state),
+            StateChangeEffects { affected_transactions: vec![balance_hash], woken_buckets: 1 }
+        );
 
         assert!(
             index.reindex(
@@ -211,7 +236,10 @@ mod tests {
         state.clear();
         state.insert(storage_address, account);
 
-        assert_eq!(index.affected_by_state(&state), vec![balance_hash]);
+        assert_eq!(
+            index.affected_by_state(&state),
+            StateChangeEffects { affected_transactions: vec![balance_hash], woken_buckets: 1 }
+        );
         assert_eq!(index.remove(balance_hash), Some(1));
         assert_eq!(index.transaction(storage_hash), Some(&2));
     }
@@ -228,7 +256,97 @@ mod tests {
         let mut state = EvmState::default();
         state.insert(address, account);
 
-        assert_eq!(index.affected_by_state(&state), vec![hash]);
+        assert_eq!(
+            index.affected_by_state(&state),
+            StateChangeEffects { affected_transactions: vec![hash], woken_buckets: 1 }
+        );
+    }
+
+    #[test]
+    fn selfdestruct_wakes_every_matching_storage_bucket() {
+        let address = Address::with_last_byte(1);
+        let first_hash = B256::with_last_byte(1);
+        let second_hash = B256::with_last_byte(2);
+        let mut index = ParkedPredicateIndex::default();
+        index.park(first_hash, (), ValidityPredicateKey::Storage(address, U256::from(7)));
+        index.park(second_hash, (), ValidityPredicateKey::Storage(address, U256::from(8)));
+
+        let mut account = Account::default();
+        account.mark_selfdestruct();
+        let mut state = EvmState::default();
+        state.insert(address, account);
+
+        let effects = index.affected_by_state(&state);
+        assert_eq!(effects.woken_buckets, 2);
+        assert_eq!(
+            effects.affected_transactions.into_iter().collect::<HashSet<_>>(),
+            HashSet::from_iter([first_hash, second_hash])
+        );
+    }
+
+    #[test]
+    fn distinct_accounts_each_wake_their_own_bucket() {
+        let balance_address = Address::with_last_byte(1);
+        let storage_address = Address::with_last_byte(2);
+        let balance_hash = B256::with_last_byte(1);
+        let storage_hash = B256::with_last_byte(2);
+        let mut index = ParkedPredicateIndex::default();
+        index.park(balance_hash, (), ValidityPredicateKey::Balance(balance_address));
+        index.park(storage_hash, (), ValidityPredicateKey::Storage(storage_address, U256::from(7)));
+
+        let mut state = EvmState::default();
+        let mut changed_balance = Account::default();
+        changed_balance.info.balance = U256::ONE;
+        state.insert(balance_address, changed_balance);
+        let mut changed_storage = Account::default();
+        changed_storage.storage.insert(
+            U256::from(7),
+            EvmStorageSlot::new_changed(U256::ZERO, U256::ONE, Default::default()),
+        );
+        state.insert(storage_address, changed_storage);
+
+        let effects = index.affected_by_state(&state);
+        assert_eq!(effects.woken_buckets, 2);
+        assert_eq!(
+            effects.affected_transactions.into_iter().collect::<HashSet<_>>(),
+            HashSet::from_iter([balance_hash, storage_hash])
+        );
+    }
+
+    #[test]
+    fn shared_bucket_wakes_once_but_affects_every_rider() {
+        let shared_address = Address::with_last_byte(1);
+        let first_hash = B256::with_last_byte(1);
+        let second_hash = B256::with_last_byte(2);
+        let mut index = ParkedPredicateIndex::default();
+        index.park(first_hash, (), ValidityPredicateKey::Balance(shared_address));
+        index.park(second_hash, (), ValidityPredicateKey::Balance(shared_address));
+
+        let mut state = EvmState::default();
+        let mut account = Account::default();
+        account.info.balance = U256::ONE;
+        state.insert(shared_address, account);
+
+        let effects = index.affected_by_state(&state);
+        assert_eq!(effects.woken_buckets, 1);
+        assert_eq!(
+            effects.affected_transactions.into_iter().collect::<HashSet<_>>(),
+            HashSet::from_iter([first_hash, second_hash])
+        );
+    }
+
+    #[test]
+    fn bucket_depths_reflects_parked_transactions_per_bucket() {
+        let shared_address = Address::with_last_byte(1);
+        let unique_address = Address::with_last_byte(2);
+        let mut index = ParkedPredicateIndex::default();
+        index.park(B256::with_last_byte(1), (), ValidityPredicateKey::Balance(shared_address));
+        index.park(B256::with_last_byte(2), (), ValidityPredicateKey::Balance(shared_address));
+        index.park(B256::with_last_byte(3), (), ValidityPredicateKey::Balance(unique_address));
+
+        let mut depths: Vec<usize> = index.bucket_depths().collect();
+        depths.sort_unstable();
+        assert_eq!(depths, vec![1, 2]);
     }
 
     #[test]
@@ -290,6 +408,6 @@ mod tests {
         account.info.balance = U256::ONE;
         state.insert(Address::with_last_byte(1), account);
 
-        assert!(index.affected_by_state(&state).is_empty());
+        assert_eq!(index.affected_by_state(&state), StateChangeEffects::default());
     }
 }

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -45,7 +45,7 @@ pub use flashblocks::{
     BuildArguments, FlashblockDiagnostics, FlashblockSelectionOutcome, FlashblocksExtraCtx,
     FlashblocksServiceBuilder, ParkableBestPayloadTransactions, ParkablePayloadTransactions,
     ParkedPredicateIndex, PayloadBuilder, PayloadHandler, PayloadJobDeadline,
-    PayloadTransactionInvalidated, ResolvePayload, ValidityPredicateKey,
+    PayloadTransactionInvalidated, ResolvePayload, StateChangeEffects, ValidityPredicateKey,
 };
 
 mod extension;

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use crate::{ExecutionInfo, FlashblockDiagnostics, ResourceLimits};
+use crate::{ExecutionInfo, FlashblockDiagnostics, ParkedPredicateIndex, ResourceLimits};
 
 const PRIORITY_FEE_THRESHOLDS_WEI: [(&str, u64); 3] =
     [("100wei", 100), ("100kwei", 100_000), ("1mwei", 1_000_000)];
@@ -118,6 +118,14 @@ base_metrics::define_metrics! {
         "Total validity predicate evaluation time per flashblock build, inclusive of state loads, in seconds"
     )]
     validity_predicate_eval_duration_per_block: histogram,
+    #[describe(
+        "Number of validity-predicate index buckets woken (watched balance or storage slot changed), per flashblock build"
+    )]
+    predicate_bucket_wakeups: histogram,
+    #[describe(
+        "Depth (parked transaction count) of validity-predicate index buckets, sampled once per flashblock build"
+    )]
+    predicate_bucket_depth: histogram,
     #[describe("Validity predicate evaluation attempts")]
     #[label(outcome)]
     validity_predicate_evaluations_total: counter,
@@ -302,13 +310,23 @@ impl BuilderMetrics {
         Self::payload_num_tx_simulated_fail_gauge().set(num_txs_simulated_fail);
         Self::payload_reverted_tx_gas_used().set(reverted_gas_used);
     }
+
+    /// Records validity-predicate index bucket wakeups and depth distribution for one flashblock build.
+    pub fn record_predicate_index_diagnostics<T>(wakeups: u64, index: &ParkedPredicateIndex<T>) {
+        Self::predicate_bucket_wakeups().record(wakeups as f64);
+        for depth in index.bucket_depths() {
+            Self::predicate_bucket_depth().record(depth as f64);
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use alloy_primitives::{Address, B256};
     use metrics_exporter_prometheus::PrometheusBuilder;
 
     use super::*;
+    use crate::ValidityPredicateKey;
 
     #[test]
     fn record_flashblock_diagnostics_emits_labeled_metrics() {
@@ -390,5 +408,36 @@ mod tests {
             rendered.contains("base_builder_validity_predicate_eval_duration_per_block_sum 0.5"),
             "expected 0.5s recorded, got: {rendered}"
         );
+    }
+
+    #[test]
+    fn record_predicate_index_diagnostics_emits_wakeups_and_bucket_depths() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        let mut index = ParkedPredicateIndex::default();
+        index.park(
+            B256::with_last_byte(1),
+            (),
+            ValidityPredicateKey::Balance(Address::with_last_byte(1)),
+        );
+        index.park(
+            B256::with_last_byte(2),
+            (),
+            ValidityPredicateKey::Balance(Address::with_last_byte(1)),
+        );
+        index.park(
+            B256::with_last_byte(3),
+            (),
+            ValidityPredicateKey::Balance(Address::with_last_byte(2)),
+        );
+
+        metrics::with_local_recorder(&recorder, || {
+            BuilderMetrics::record_predicate_index_diagnostics(3, &index);
+        });
+
+        let rendered = handle.render();
+        assert!(rendered.contains("base_builder_predicate_bucket_wakeups_sum 3"));
+        assert!(rendered.contains("base_builder_predicate_bucket_depth_count 2"));
+        assert!(rendered.contains("base_builder_predicate_bucket_depth_sum 3"));
     }
 }


### PR DESCRIPTION
Adds two histograms validating the validity-predicate index cost model:

- `base_builder_predicate_bucket_wakeups` — number of index buckets (watched balances/storage slots) actually woken per flashblock build. A wakeup means the bucket's parked transactions are due for re-evaluation; it does not by itself mean any predicate became satisfied — that outcome is determined separately by the rescan (`validity_predicate_evaluations_total{outcome=...}`).
- `base_builder_predicate_bucket_depth` — depth (parked transaction count) of each index bucket, sampled once per flashblock build.

`ParkedPredicateIndex::affected_by_state` now returns a `StateChangeEffects` struct carrying both the affected transactions and a wakeup count (one per distinct bucket that changed, regardless of how many transactions block on it), computed in the same pass rather than duplicating the state-diff walk. A new `bucket_depths()` iterator exposes each bucket's size directly.

This gives us the data to answer the open question of whether predicates concentrated on the same address/slot (e.g. everyone watching the same WETH/USDC pool) need ordered buckets instead of a flat per-key index.

Scope: instrumentation only.