### PR TITLE
ci: run workflows on Tenki

### DIFF
--- a/.github/workflows/action-tests.yml
+++ b/.github/workflows/action-tests.yml
@@ -19,8 +19,7 @@ permissions:
 jobs:
   action-tests:
     name: Action Tests
-    runs-on:
-      group: BasePerfRunnerGroup
+    runs-on: tenki-standard-large-plus-16c-32g
     timeout-minutes: 30
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/base-anvil-package.yml
+++ b/.github/workflows/base-anvil-package.yml
@@ -38,10 +38,10 @@ jobs:
       matrix:
         settings:
           - platform: linux/amd64
-            runs-on: ubuntu-24.04
+            runs-on: tenki-standard-medium-4c-8g
             smoke_test: true
           - platform: linux/arm64
-            runs-on: ubuntu-24.04-arm
+            runs-on: tenki-standard-medium-4c-8g
             smoke_test: false
 
     runs-on: ${{ matrix.settings.runs-on }}
@@ -312,7 +312,7 @@ jobs:
   merge:
     name: Publish manifest
     needs: build-and-push
-    runs-on: ubuntu-24.04
+    runs-on: tenki-standard-medium-4c-8g
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -21,8 +21,7 @@ permissions:
 jobs:
   fork-tests:
     name: Base Std Interface Tests (${{ matrix.fork }})
-    runs-on:
-      group: BasePerfRunnerGroup
+    runs-on: tenki-standard-large-plus-16c-32g
     timeout-minutes: 120
     strategy:
       fail-fast: false
@@ -199,7 +198,7 @@ jobs:
     name: Base Std Interface Tests
     if: always()
     needs: fork-tests
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -30,8 +30,7 @@ jobs:
   # (Per-benchmark interleaving would tighten the timing further and is a follow-up.)
   bench:
     name: Benchmarks (advisory)
-    runs-on:
-      group: BasePerfRunnerGroup
+    runs-on: tenki-standard-large-plus-16c-32g
     timeout-minutes: 90
     env:
       HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,7 +21,7 @@ jobs:
   # Build base-reth-node, base-builder, and base-load-test together, cached by source hash
   build-binaries:
     name: Build binaries
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     permissions:
       contents: read
       actions: write
@@ -87,7 +87,7 @@ jobs:
   # Run the benchmark
   benchmark:
     name: Run Benchmark
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     needs: [build-binaries]
     permissions:
       contents: read

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -143,9 +143,9 @@ jobs:
       matrix:
         settings:
           - arch: linux/amd64
-            runs-on: ubuntu-24.04
+            runs-on: tenki-standard-medium-4c-8g
           - arch: linux/arm64
-            runs-on: ubuntu-24.04-arm
+            runs-on: tenki-standard-medium-4c-8g
         image:
           - target: base
             name: node
@@ -225,7 +225,7 @@ jobs:
   find-release-artifacts:
     needs: [build-and-push, build-binaries]
     if: ${{ !cancelled() }}
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     outputs:
       has_digests: ${{ steps.artifacts.outputs.has_digests }}
       has_binaries: ${{ steps.artifacts.outputs.has_binaries }}
@@ -264,7 +264,7 @@ jobs:
   publish:
     needs: [find-release-artifacts]
     if: ${{ !cancelled() && (needs.find-release-artifacts.outputs.has_digests == 'true' || (inputs.is_final && needs.find-release-artifacts.outputs.has_binaries == 'true')) }}
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -44,7 +44,7 @@ permissions:
 jobs:
   changes:
     name: Detect Docker Changes
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     permissions:
       contents: read
       pull-requests: read
@@ -73,7 +73,7 @@ jobs:
 
   metadata-checks:
     name: Metadata Checks
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -96,7 +96,7 @@ jobs:
 
   format:
     name: Format
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -115,8 +115,7 @@ jobs:
 
   build:
     name: Build
-    runs-on:
-      group: BasePerfRunnerGroup
+    runs-on: tenki-standard-large-plus-16c-32g
     env:
       BASE_REF: ${{ inputs.base_ref }}
     steps:
@@ -143,8 +142,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on:
-      group: BasePerfRunnerGroup
+    runs-on: tenki-standard-large-plus-16c-32g
     env:
       BASE_REF: ${{ inputs.base_ref }}
     steps:
@@ -171,8 +169,7 @@ jobs:
 
   test:
     name: Test
-    runs-on:
-      group: BasePerfRunnerGroup
+    runs-on: tenki-standard-large-plus-16c-32g
     env:
       BASE_REF: ${{ inputs.base_ref }}
     steps:
@@ -218,7 +215,7 @@ jobs:
 
   bench:
     name: Benchmarks
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -236,7 +233,7 @@ jobs:
 
   docker:
     name: Docker
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     needs: changes
     if: needs.changes.outputs.docker == 'true'
     permissions:
@@ -266,7 +263,7 @@ jobs:
   test-musl-sigsegv:
     name: Test SIGSEGV (musl)
     if: inputs.run_sigsegv
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -286,8 +283,7 @@ jobs:
   system-tests:
     name: System Tests
     if: inputs.run_system_tests
-    runs-on:
-      group: BasePerfRunnerGroup
+    runs-on: tenki-standard-large-plus-16c-32g
     timeout-minutes: 60
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/ci-main-cache.yml
+++ b/.github/workflows/ci-main-cache.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   warm-stable-cache:
     name: Warm Stable Cache
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -43,7 +43,7 @@ jobs:
 
   warm-test-cache:
     name: Warm Test Cache
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -21,8 +21,7 @@ jobs:
     # It will not work on other runners
     # Skip for external contributor PRs (forks) — secrets and runner group are unavailable
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on:
-      group: BaseRunnerGroup
+    runs-on: tenki-standard-large-plus-16c-32g
     steps:
       - name: Harden the runner (Block unauthorized outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/create-rc.yml
+++ b/.github/workflows/create-rc.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   create-tag:
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     outputs:
       tag: ${{ steps.read-tag.outputs.tag }}
       skip: ${{ steps.version-check.outputs.skip }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,9 +18,9 @@ jobs:
       matrix:
         settings:
           - arch: linux/amd64
-            runs-on: ubuntu-24.04
+            runs-on: tenki-standard-medium-4c-8g
           - arch: linux/arm64
-            runs-on: ubuntu-24.04-arm
+            runs-on: tenki-standard-medium-4c-8g
         image:
           - target: base
             name: node
@@ -101,7 +101,7 @@ jobs:
       matrix:
         target: [base, execution, consensus, builder, batcher]
 
-    runs-on: ubuntu-24.04
+    runs-on: tenki-standard-medium-4c-8g
 
     permissions:
       contents: read
@@ -138,7 +138,7 @@ jobs:
             --set ${{ matrix.target }}.cache-to=type=registry,ref=${{ env.REGISTRY_IMAGE }}:cache-${{ matrix.target }}-linux-amd64,mode=max
 
   merge:
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -25,8 +25,7 @@ permissions:
 jobs:
   fuzz-sync-parity:
     name: Fuzz sync parity
-    runs-on:
-      group: BasePerfRunnerGroup
+    runs-on: tenki-standard-large-plus-16c-32g
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/.github/workflows/generate-succinct-vkeys.yml
+++ b/.github/workflows/generate-succinct-vkeys.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   generate:
     name: Generate Succinct VKeys
-    runs-on: ubuntu-24.04
+    runs-on: tenki-standard-medium-4c-8g
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   lychee-checks:
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     timeout-minutes: 30
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/no-std.yml
+++ b/.github/workflows/no-std.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   check-no-std:
     name: no_std
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     timeout-minutes: 30
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -45,7 +45,7 @@ jobs:
 
   check-no-std-proof:
     name: no_std (proof)
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     timeout-minutes: 30
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   create-tag:
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     outputs:
       tag: ${{ steps.read-tag.outputs.tag }}
 

--- a/.github/workflows/release-branch-ci.yml
+++ b/.github/workflows/release-branch-ci.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   finalized-release:
     name: Finalized Release
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     permissions:
       actions: write
       issues: write

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   start:
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/udeps-report.yml
+++ b/.github/workflows/udeps-report.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   udeps-report:
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     timeout-minutes: 120
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   verify-signatures:
-    runs-on: ubuntu-24.04
+    runs-on: tenki-standard-medium-4c-8g
 
     steps:
       - name: Checkout

--- a/.github/workflows/vouch.yml
+++ b/.github/workflows/vouch.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   check-pr:
     if: github.event_name == 'pull_request_target'
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     permissions:
       contents: read
       pull-requests: write
@@ -39,7 +39,7 @@ jobs:
         contains(github.event.comment.body, 'denounce') ||
         contains(github.event.comment.body, 'unvouch')
       )
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/zepter.yml
+++ b/.github/workflows/zepter.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   zepter:
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4


### PR DESCRIPTION
## Summary

- move hosted Linux workflow jobs to `tenki-standard-medium-4c-8g`
- move Base private/performance runner-group jobs to `tenki-standard-large-plus-16c-32g`
- update matrix runner values used by container builds

This changes runner selection only; no application code or workflow behavior is otherwise modified.

## Validation

- parsed all 25 workflow YAML files
- verified the runner rewrite is idempotent
- verified no hosted Linux or Base runner-group targets remain
- exercised the same runner mappings on the `hashbender/base` mirror across build, test, clippy, no-std, Action Tests, benchmarks, and Base Std jobs
