### PR TITLE
feat(registrar): union instances across comma-separated target group ARNs

### DIFF
--- a/bin/prover-registrar/README.md
+++ b/bin/prover-registrar/README.md
@@ -2,7 +2,7 @@
 
 Automated TEE prover signer registration service.
 
-Discovers TEE prover instances via an AWS ALB target group, validates their Nitro
+Discovers TEE prover instances via AWS ALB target groups, validates their Nitro
 attestations, generates P-384 inverse hints, and submits certificate-cache and
 signer-registration transactions onchain.
 

--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -31,7 +31,8 @@ pub(crate) struct Cli {
     #[arg(long, env = cli_env!("TEE_PROVER_REGISTRY_ADDRESS"))]
     tee_prover_registry_address: Address,
 
-    /// AWS ALB target group ARN for prover instance discovery.
+    /// AWS ALB target group ARN(s) for prover instance discovery.
+    /// Comma-separated when multiple fleets share one registrar.
     #[arg(long, env = cli_env!("TARGET_GROUP_ARN"))]
     target_group_arn: String,
 
@@ -127,6 +128,11 @@ pub(crate) struct Cli {
 impl Cli {
     pub(crate) fn config(self) -> Result<RegistrarConfig, Box<RegistrarError>> {
         validate_health_port(self.health.port)?;
+        if base_proof_tee_registrar::parse_target_group_arns(&self.target_group_arn).is_empty() {
+            return Err(Box::new(RegistrarError::Config(
+                "target-group-arn must contain at least one ARN".into(),
+            )));
+        }
 
         Ok(RegistrarConfig {
             l1_rpc_url: self.l1_rpc_url,
@@ -179,6 +185,31 @@ mod tests {
             "--private-key",
             "0x0101010101010101010101010101010101010101010101010101010101010101",
         ]
+    }
+
+    #[test]
+    fn comma_separated_target_group_arns_parse() {
+        let mut args = required_args();
+        args[6] = concat!(
+            "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/prover/abc123,",
+            "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/prover-v1/def456"
+        );
+
+        let cli = Cli::try_parse_from(args).unwrap();
+        assert_eq!(
+            base_proof_tee_registrar::parse_target_group_arns(&cli.target_group_arn).len(),
+            2
+        );
+        assert!(cli.config().is_ok());
+    }
+
+    #[test]
+    fn empty_target_group_arn_rejected() {
+        let mut args = required_args();
+        args[6] = " , ";
+
+        let cli = Cli::try_parse_from(args).unwrap();
+        assert!(cli.config().is_err());
     }
 
     #[test]

--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 
 use alloy_primitives::Address;
 use base_proof_tee_registrar::{
-    DEFAULT_MAX_CONCURRENCY, DEFAULT_MAX_TX_RETRIES, DEFAULT_TX_RETRY_DELAY_SECS,
-    INSTANCE_CACHE_TTL_CYCLES, RegistrarConfig, RegistrarError,
+    AwsTargetGroupDiscovery, DEFAULT_MAX_CONCURRENCY, DEFAULT_MAX_TX_RETRIES,
+    DEFAULT_TX_RETRY_DELAY_SECS, INSTANCE_CACHE_TTL_CYCLES, RegistrarConfig, RegistrarError,
 };
 use base_tx_manager::{SignerConfig, TxManagerConfig};
 use clap::Parser;
@@ -128,7 +128,8 @@ pub(crate) struct Cli {
 impl Cli {
     pub(crate) fn config(self) -> Result<RegistrarConfig, Box<RegistrarError>> {
         validate_health_port(self.health.port)?;
-        if base_proof_tee_registrar::parse_target_group_arns(&self.target_group_arn).is_empty() {
+        let target_group_arns = AwsTargetGroupDiscovery::parse_arns(&self.target_group_arn);
+        if target_group_arns.is_empty() {
             return Err(Box::new(RegistrarError::Config(
                 "target-group-arn must contain at least one ARN".into(),
             )));
@@ -137,7 +138,7 @@ impl Cli {
         Ok(RegistrarConfig {
             l1_rpc_url: self.l1_rpc_url,
             tee_prover_registry_address: self.tee_prover_registry_address,
-            target_group_arn: self.target_group_arn,
+            target_group_arns,
             aws_region: self.aws_region,
             prover_port: self.prover_port,
             signing: SignerConfig::try_from(self.signer)
@@ -195,12 +196,8 @@ mod tests {
             "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/prover-v1/def456"
         );
 
-        let cli = Cli::try_parse_from(args).unwrap();
-        assert_eq!(
-            base_proof_tee_registrar::parse_target_group_arns(&cli.target_group_arn).len(),
-            2
-        );
-        assert!(cli.config().is_ok());
+        let config = Cli::try_parse_from(args).unwrap().config().unwrap();
+        assert_eq!(config.target_group_arns.len(), 2);
     }
 
     #[test]

--- a/crates/proof/tee/registrar/src/discovery.rs
+++ b/crates/proof/tee/registrar/src/discovery.rs
@@ -9,25 +9,39 @@ use url::Url;
 
 use crate::{InstanceDiscovery, InstanceHealthStatus, ProverInstance, RegistrarError, Result};
 
+/// Splits a comma-separated target-group ARN list. Empty entries are dropped.
+pub fn parse_target_group_arns(raw: &str) -> Vec<String> {
+    raw.split(',').map(str::trim).filter(|s| !s.is_empty()).map(str::to_string).collect()
+}
+
 /// Discovers prover instances via AWS Elastic Load Balancing target groups.
 ///
-/// Queries `describe_target_health` to enumerate registered targets, then
-/// resolves each EC2 instance's private IP address via `describe_instances`.
-/// Health state is mapped from the ALB target health state.
+/// Queries `describe_target_health` on every configured target group, unions
+/// the instance IDs, then resolves each EC2 instance's private IP via
+/// `describe_instances`. Health state is mapped from the ALB target health
+/// state. A failure against any target group fails the whole discovery cycle so
+/// the driver does not treat unseen fleets as orphans.
 #[derive(Debug)]
 pub struct AwsTargetGroupDiscovery {
     elb_client: ElbClient,
     ec2_client: Ec2Client,
-    target_group_arn: String,
+    target_group_arns: Vec<String>,
     port: u16,
 }
 
 impl AwsTargetGroupDiscovery {
     /// Creates a new `AwsTargetGroupDiscovery` with the given AWS config.
+    ///
+    /// `target_group_arn` is one ARN or a comma-separated list.
     pub fn new(aws_config: &aws_config::SdkConfig, target_group_arn: String, port: u16) -> Self {
         let elb_client = ElbClient::new(aws_config);
         let ec2_client = Ec2Client::new(aws_config);
-        Self { elb_client, ec2_client, target_group_arn, port }
+        Self {
+            elb_client,
+            ec2_client,
+            target_group_arns: parse_target_group_arns(&target_group_arn),
+            port,
+        }
     }
 
     /// Builds prover instances from EC2 reservations and removes matched IDs from `health_map`.
@@ -68,40 +82,49 @@ impl AwsTargetGroupDiscovery {
 
 impl InstanceDiscovery for AwsTargetGroupDiscovery {
     async fn discover_instances(&self) -> Result<Vec<ProverInstance>> {
-        let elb_resp = self
-            .elb_client
-            .describe_target_health()
-            .target_group_arn(&self.target_group_arn)
-            .send()
-            .await
-            .map_err(|e| RegistrarError::Discovery(Box::new(e)))?;
+        if self.target_group_arns.is_empty() {
+            return Err(RegistrarError::Discovery(Box::new(std::io::Error::other(
+                "no target group ARNs configured",
+            ))));
+        }
 
         let mut health_map: HashMap<String, InstanceHealthStatus> = HashMap::new();
-        for desc in elb_resp.target_health_descriptions() {
-            let Some(instance_id) = desc.target().and_then(|t| t.id()) else {
-                warn!("target group entry missing instance ID, skipping");
-                continue;
-            };
-            if !instance_id.starts_with("i-") {
-                warn!(
-                    id = %instance_id,
-                    "target is not an instance-type target (id does not start with \
-                     'i-'); is the target group type set to 'instance'? skipping"
-                );
-                continue;
-            }
-            let health_status = desc
-                .target_health()
-                .and_then(|h| h.state())
-                .map(|s| match s.as_str() {
-                    "initial" => InstanceHealthStatus::Initial,
-                    "healthy" => InstanceHealthStatus::Healthy,
-                    "draining" => InstanceHealthStatus::Draining,
-                    _ => InstanceHealthStatus::Unhealthy,
-                })
-                .unwrap_or(InstanceHealthStatus::Unhealthy);
+        for arn in &self.target_group_arns {
+            let elb_resp = self
+                .elb_client
+                .describe_target_health()
+                .target_group_arn(arn)
+                .send()
+                .await
+                .map_err(|e| RegistrarError::Discovery(Box::new(e)))?;
 
-            health_map.entry(instance_id.to_string()).or_insert(health_status);
+            for desc in elb_resp.target_health_descriptions() {
+                let Some(instance_id) = desc.target().and_then(|t| t.id()) else {
+                    warn!(target_group_arn = %arn, "target group entry missing instance ID, skipping");
+                    continue;
+                };
+                if !instance_id.starts_with("i-") {
+                    warn!(
+                        id = %instance_id,
+                        target_group_arn = %arn,
+                        "target is not an instance-type target (id does not start with \
+                         'i-'); is the target group type set to 'instance'? skipping"
+                    );
+                    continue;
+                }
+                let health_status = desc
+                    .target_health()
+                    .and_then(|h| h.state())
+                    .map(|s| match s.as_str() {
+                        "initial" => InstanceHealthStatus::Initial,
+                        "healthy" => InstanceHealthStatus::Healthy,
+                        "draining" => InstanceHealthStatus::Draining,
+                        _ => InstanceHealthStatus::Unhealthy,
+                    })
+                    .unwrap_or(InstanceHealthStatus::Unhealthy);
+
+                health_map.entry(instance_id.to_string()).or_insert(health_status);
+            }
         }
 
         if health_map.is_empty() {
@@ -141,6 +164,24 @@ mod tests {
     use url::Url;
 
     use super::*;
+
+    #[test]
+    fn parse_target_group_arns_splits_and_trims() {
+        assert_eq!(
+            parse_target_group_arns(
+                " arn:aws:elasticloadbalancing:us-east-1:1:targetgroup/a/abc ,arn:aws:elasticloadbalancing:us-east-1:1:targetgroup/b/def, "
+            ),
+            vec![
+                "arn:aws:elasticloadbalancing:us-east-1:1:targetgroup/a/abc",
+                "arn:aws:elasticloadbalancing:us-east-1:1:targetgroup/b/def",
+            ]
+        );
+        assert!(parse_target_group_arns(" , , ").is_empty());
+        assert_eq!(
+            parse_target_group_arns("arn:aws:elasticloadbalancing:us-east-1:1:targetgroup/a/abc"),
+            vec!["arn:aws:elasticloadbalancing:us-east-1:1:targetgroup/a/abc"]
+        );
+    }
 
     fn reservation(instances: Vec<Instance>) -> Reservation {
         Reservation::builder().set_instances(Some(instances)).build()

--- a/crates/proof/tee/registrar/src/discovery.rs
+++ b/crates/proof/tee/registrar/src/discovery.rs
@@ -1,6 +1,6 @@
 //! AWS ALB target group instance discovery.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, hash_map::Entry};
 
 use aws_sdk_ec2::{Client as Ec2Client, types::Reservation};
 use aws_sdk_elasticloadbalancingv2::Client as ElbClient;
@@ -8,11 +8,6 @@ use tracing::{debug, warn};
 use url::Url;
 
 use crate::{InstanceDiscovery, InstanceHealthStatus, ProverInstance, RegistrarError, Result};
-
-/// Splits a comma-separated target-group ARN list. Empty entries are dropped.
-pub fn parse_target_group_arns(raw: &str) -> Vec<String> {
-    raw.split(',').map(str::trim).filter(|s| !s.is_empty()).map(str::to_string).collect()
-}
 
 /// Discovers prover instances via AWS Elastic Load Balancing target groups.
 ///
@@ -30,17 +25,43 @@ pub struct AwsTargetGroupDiscovery {
 }
 
 impl AwsTargetGroupDiscovery {
+    /// Splits a comma-separated target-group ARN list. Empty entries are dropped.
+    pub fn parse_arns(raw: &str) -> Vec<String> {
+        raw.split(',').map(str::trim).filter(|s| !s.is_empty()).map(str::to_string).collect()
+    }
+
     /// Creates a new `AwsTargetGroupDiscovery` with the given AWS config.
-    ///
-    /// `target_group_arn` is one ARN or a comma-separated list.
-    pub fn new(aws_config: &aws_config::SdkConfig, target_group_arn: String, port: u16) -> Self {
+    pub fn new(
+        aws_config: &aws_config::SdkConfig,
+        target_group_arns: Vec<String>,
+        port: u16,
+    ) -> Self {
         let elb_client = ElbClient::new(aws_config);
         let ec2_client = Ec2Client::new(aws_config);
-        Self {
-            elb_client,
-            ec2_client,
-            target_group_arns: parse_target_group_arns(&target_group_arn),
-            port,
+        Self { elb_client, ec2_client, target_group_arns, port }
+    }
+
+    /// Records target health, keeping the first-seen status when an instance is
+    /// registered in more than one target group.
+    pub fn record_instance_health(
+        health_map: &mut HashMap<String, InstanceHealthStatus>,
+        instance_id: String,
+        health_status: InstanceHealthStatus,
+        target_group_arn: &str,
+    ) {
+        match health_map.entry(instance_id) {
+            Entry::Vacant(entry) => {
+                entry.insert(health_status);
+            }
+            Entry::Occupied(entry) => {
+                warn!(
+                    instance_id = %entry.key(),
+                    target_group_arn = %target_group_arn,
+                    first_health = ?entry.get(),
+                    ignored_health = ?health_status,
+                    "instance appears in multiple target groups; keeping first-seen health"
+                );
+            }
         }
     }
 
@@ -123,7 +144,12 @@ impl InstanceDiscovery for AwsTargetGroupDiscovery {
                     })
                     .unwrap_or(InstanceHealthStatus::Unhealthy);
 
-                health_map.entry(instance_id.to_string()).or_insert(health_status);
+                Self::record_instance_health(
+                    &mut health_map,
+                    instance_id.to_string(),
+                    health_status,
+                    arn,
+                );
             }
         }
 
@@ -166,9 +192,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_target_group_arns_splits_and_trims() {
+    fn parse_arns_splits_and_trims() {
         assert_eq!(
-            parse_target_group_arns(
+            AwsTargetGroupDiscovery::parse_arns(
                 " arn:aws:elasticloadbalancing:us-east-1:1:targetgroup/a/abc ,arn:aws:elasticloadbalancing:us-east-1:1:targetgroup/b/def, "
             ),
             vec![
@@ -176,11 +202,32 @@ mod tests {
                 "arn:aws:elasticloadbalancing:us-east-1:1:targetgroup/b/def",
             ]
         );
-        assert!(parse_target_group_arns(" , , ").is_empty());
+        assert!(AwsTargetGroupDiscovery::parse_arns(" , , ").is_empty());
         assert_eq!(
-            parse_target_group_arns("arn:aws:elasticloadbalancing:us-east-1:1:targetgroup/a/abc"),
+            AwsTargetGroupDiscovery::parse_arns(
+                "arn:aws:elasticloadbalancing:us-east-1:1:targetgroup/a/abc"
+            ),
             vec!["arn:aws:elasticloadbalancing:us-east-1:1:targetgroup/a/abc"]
         );
+    }
+
+    #[test]
+    fn record_instance_health_keeps_first_seen_status() {
+        let mut health_map = HashMap::new();
+        AwsTargetGroupDiscovery::record_instance_health(
+            &mut health_map,
+            "i-001".to_string(),
+            InstanceHealthStatus::Unhealthy,
+            "arn:a",
+        );
+        AwsTargetGroupDiscovery::record_instance_health(
+            &mut health_map,
+            "i-001".to_string(),
+            InstanceHealthStatus::Healthy,
+            "arn:b",
+        );
+
+        assert_eq!(health_map.get("i-001"), Some(&InstanceHealthStatus::Unhealthy));
     }
 
     fn reservation(instances: Vec<Instance>) -> Reservation {

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -8,7 +8,7 @@ mod crl;
 pub use crl::{CertCrlInfo, CrlError, check_chain_against_crls};
 
 mod discovery;
-pub use discovery::AwsTargetGroupDiscovery;
+pub use discovery::{AwsTargetGroupDiscovery, parse_target_group_arns};
 
 mod driver;
 pub use driver::{

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -8,7 +8,7 @@ mod crl;
 pub use crl::{CertCrlInfo, CrlError, check_chain_against_crls};
 
 mod discovery;
-pub use discovery::{AwsTargetGroupDiscovery, parse_target_group_arns};
+pub use discovery::AwsTargetGroupDiscovery;
 
 mod driver;
 pub use driver::{

--- a/crates/proof/tee/registrar/src/service.rs
+++ b/crates/proof/tee/registrar/src/service.rs
@@ -35,7 +35,11 @@ pub struct RegistrarConfig {
     pub l1_rpc_url: Url,
     /// `TEEProverRegistry` contract address on L1.
     pub tee_prover_registry_address: Address,
-    /// AWS ALB target group ARN for prover instance discovery.
+    /// AWS ALB target group ARN(s) for prover instance discovery.
+    ///
+    /// One ARN, or a comma-separated list when multiple fleets (and therefore
+    /// target groups) share one registrar. Discovery unions healthy instances
+    /// across every ARN so orphan cleanup does not deregister a detached fleet.
     pub target_group_arn: String,
     /// AWS region.
     pub aws_region: String,

--- a/crates/proof/tee/registrar/src/service.rs
+++ b/crates/proof/tee/registrar/src/service.rs
@@ -35,12 +35,11 @@ pub struct RegistrarConfig {
     pub l1_rpc_url: Url,
     /// `TEEProverRegistry` contract address on L1.
     pub tee_prover_registry_address: Address,
-    /// AWS ALB target group ARN(s) for prover instance discovery.
+    /// AWS ALB target group ARNs for prover instance discovery.
     ///
-    /// One ARN, or a comma-separated list when multiple fleets (and therefore
-    /// target groups) share one registrar. Discovery unions healthy instances
-    /// across every ARN so orphan cleanup does not deregister a detached fleet.
-    pub target_group_arn: String,
+    /// Discovery unions instances across every ARN so orphan cleanup does not
+    /// deregister a detached fleet.
+    pub target_group_arns: Vec<String>,
     /// AWS region.
     pub aws_region: String,
     /// JSON-RPC port to poll on each prover instance.
@@ -78,7 +77,7 @@ impl fmt::Debug for RegistrarConfig {
         f.debug_struct("RegistrarConfig")
             .field("l1_rpc_url", &self.l1_rpc_url.origin().unicode_serialization())
             .field("tee_prover_registry_address", &self.tee_prover_registry_address)
-            .field("target_group_arn", &self.target_group_arn)
+            .field("target_group_arns", &self.target_group_arns)
             .field("aws_region", &self.aws_region)
             .field("prover_port", &self.prover_port)
             .field("signing", &self.signing)
@@ -178,7 +177,7 @@ impl RegistrarConfig {
             .load()
             .await;
         let discovery =
-            AwsTargetGroupDiscovery::new(&aws_config, self.target_group_arn, self.prover_port);
+            AwsTargetGroupDiscovery::new(&aws_config, self.target_group_arns, self.prover_port);
 
         let registry = TEEProverRegistryContractClient::new(
             self.tee_prover_registry_address,
@@ -274,8 +273,9 @@ mod tests {
         let config = RegistrarConfig {
             l1_rpc_url: Url::parse(&format!("https://mainnet.infura.io/v3/{api_key}")).unwrap(),
             tee_prover_registry_address: TEST_REGISTRY_ADDRESS,
-            target_group_arn: "arn:aws:elasticloadbalancing:us-east-1:123:targetgroup/test/abc"
-                .to_string(),
+            target_group_arns: vec![
+                "arn:aws:elasticloadbalancing:us-east-1:123:targetgroup/test/abc".to_string(),
+            ],
             aws_region: "us-east-1".to_string(),
             prover_port: 8000,
             signing: SignerConfig::local(

--- a/crates/proof/tee/registrar/src/traits.rs
+++ b/crates/proof/tee/registrar/src/traits.rs
@@ -10,7 +10,7 @@ use crate::{ProverInstance, Result};
 ///
 /// The primary implementation is
 /// [`AwsTargetGroupDiscovery`](crate::AwsTargetGroupDiscovery), which queries
-/// an ALB target group via the AWS SDK. Other implementations (e.g., a static
+/// one or more ALB target groups via the AWS SDK. Other implementations (e.g., a static
 /// list for local testing) can be substituted.
 pub trait InstanceDiscovery: Send + Sync {
     /// Return the current set of prover instances with their health status.


### PR DESCRIPTION
## Summary
- Teach registrar discovery to accept a comma-separated `BASE_REGISTRAR_TARGET_GROUP_ARN` list and union instances across every target group.
- A failure against any ARN fails the whole cycle so orphan cleanup does not deregister a fleet whose TG query flaked.
- Needed so extra Nitro fleets can own their own Odin target group instead of sharing the primary TG (Odin rejects two ConfigNames on one TG).

Companion infra: https://coinbase.ghe.com/protocols/base-proofs/pull/445 (creates TG `base-proofs-prover-nitro-v1` and updates metrics-bridge the same way).

## Test plan
- [x] `cargo test -p base-proof-tee-registrar -p base-proof-tee-registrar-bin`
- [ ] After merge, bump `docker/prover-registrar/Dockerfile` `BASE_COMMIT` in base-proofs and rebuild/deploy registrar **before** putting two ARNs in Config Service
- [ ] Confirm a single-ARN Config Service value still discovers the primary fleet
- [ ] After the v1 TG exists, set `target-group-arn` to `primaryArn,v1Arn` and confirm v1 instances are discovered and not orphan-deregistered