### PR TITLE
fix(builder): retain payload leases through detached builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.4.5"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b12337f74cbfa451cb04dac173974814a6ff463079e1793aa09600ba8813ab"
+checksum = "3fb59cca9e58f5c624becc3cffb32772dc278f31eeae4606844a88592e8d2672"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -372,7 +372,7 @@ dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
- "alloy-eip7928 0.4.5",
+ "alloy-eip7928 0.4.8",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde 2.4.1",
@@ -397,7 +397,7 @@ checksum = "6b307a52f91f7f3aad56b5cb4f54e5eb17dd0b3f4b2c82823301499fe1c6fdaf"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
- "alloy-hardforks 0.4.7",
+ "alloy-hardforks 0.4.8",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth 2.4.1",
@@ -439,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83ba208044232d14d4adbfa77e57d6329f51bc1acc21f5667bb7db72d88a0831"
+checksum = "865371fb677c005f7cb0ea9c2847a1ba4fdb042caf6428b1769fee20368bbfc7"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -3467,7 +3467,7 @@ dependencies = [
  "alloy-chains",
  "alloy-eips 2.4.1",
  "alloy-genesis",
- "alloy-hardforks 0.4.7",
+ "alloy-hardforks 0.4.8",
  "alloy-primitives",
  "auto_impl",
  "base-common-genesis",
@@ -3513,7 +3513,7 @@ dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
  "alloy-evm",
- "alloy-hardforks 0.4.7",
+ "alloy-hardforks 0.4.8",
  "alloy-primitives",
  "alloy-sol-types",
  "auto_impl",
@@ -3569,7 +3569,7 @@ dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
- "alloy-hardforks 0.4.7",
+ "alloy-hardforks 0.4.8",
  "alloy-primitives",
  "alloy-sol-types",
  "arbitrary",
@@ -4132,7 +4132,7 @@ dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
  "alloy-genesis",
- "alloy-hardforks 0.4.7",
+ "alloy-hardforks 0.4.8",
  "alloy-primitives",
  "base-common-chains",
  "base-common-consensus",
@@ -15686,7 +15686,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15713,7 +15713,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15744,7 +15744,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -15764,7 +15764,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -15777,10 +15777,11 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
+ "alloy-eip7928 0.4.8",
  "alloy-eips 2.4.1",
  "alloy-primitives",
  "alloy-rlp",
@@ -15866,7 +15867,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -15876,7 +15877,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -15927,7 +15928,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -15944,11 +15945,12 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
- "alloy-eip7928 0.4.5",
+ "alloy-eip7928 0.4.8",
  "alloy-primitives",
+ "alloy-rlp",
  "auto_impl",
  "reth-execution-types",
  "reth-primitives-traits",
@@ -15958,7 +15960,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15971,7 +15973,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15996,7 +15998,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -16025,7 +16027,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16051,7 +16053,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-genesis",
@@ -16081,7 +16083,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16096,7 +16098,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16121,7 +16123,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16145,7 +16147,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -16169,7 +16171,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16204,7 +16206,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16261,7 +16263,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -16288,7 +16290,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16311,7 +16313,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16338,10 +16340,10 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
- "alloy-eip7928 0.4.5",
+ "alloy-eip7928 0.4.8",
  "alloy-eips 2.4.1",
  "alloy-evm",
  "alloy-primitives",
@@ -16394,7 +16396,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16424,7 +16426,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16442,7 +16444,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -16458,7 +16460,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16482,7 +16484,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -16493,7 +16495,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -16522,13 +16524,13 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
- "alloy-eip7928 0.4.5",
+ "alloy-eip7928 0.4.8",
  "alloy-eips 2.4.1",
- "alloy-hardforks 0.4.7",
+ "alloy-hardforks 0.4.8",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
@@ -16548,7 +16550,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16564,7 +16566,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16580,10 +16582,10 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-eip2124",
- "alloy-hardforks 0.4.7",
+ "alloy-hardforks 0.4.8",
  "alloy-primitives",
  "arbitrary",
  "auto_impl",
@@ -16594,7 +16596,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16624,7 +16626,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16638,7 +16640,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -16648,10 +16650,10 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
- "alloy-eip7928 0.4.5",
+ "alloy-eip7928 0.4.8",
  "alloy-eips 2.4.1",
  "alloy-evm",
  "alloy-primitives",
@@ -16674,7 +16676,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16694,7 +16696,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -16712,7 +16714,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -16725,7 +16727,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16744,7 +16746,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16782,7 +16784,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-test-utils"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-eips 2.4.1",
  "eyre",
@@ -16814,7 +16816,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16828,7 +16830,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "serde",
  "serde_json",
@@ -16838,7 +16840,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16864,7 +16866,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "bytes",
  "futures",
@@ -16884,7 +16886,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "bitflags 2.13.1",
  "byteorder",
@@ -16901,7 +16903,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -16910,7 +16912,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "futures",
  "libc",
@@ -16924,7 +16926,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -16933,7 +16935,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -16947,7 +16949,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17006,7 +17008,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17031,10 +17033,10 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
- "alloy-eip7928 0.4.5",
+ "alloy-eip7928 0.4.8",
  "alloy-eips 2.4.1",
  "alloy-primitives",
  "auto_impl",
@@ -17055,7 +17057,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17070,7 +17072,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -17084,7 +17086,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -17101,7 +17103,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -17125,7 +17127,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17193,7 +17195,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17248,7 +17250,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17297,7 +17299,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17321,7 +17323,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17345,7 +17347,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "bytes",
  "eyre",
@@ -17374,7 +17376,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -17386,7 +17388,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17410,7 +17412,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -17422,7 +17424,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17445,7 +17447,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17455,7 +17457,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-rpc-types-engine",
@@ -17498,10 +17500,10 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
- "alloy-eip7928 0.4.5",
+ "alloy-eip7928 0.4.8",
  "alloy-eips 2.4.1",
  "alloy-genesis",
  "alloy-primitives",
@@ -17547,7 +17549,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17574,7 +17576,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -17590,7 +17592,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17605,11 +17607,11 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-dyn-abi",
- "alloy-eip7928 0.4.5",
+ "alloy-eip7928 0.4.8",
  "alloy-eips 2.4.1",
  "alloy-evm",
  "alloy-genesis",
@@ -17681,7 +17683,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-genesis",
@@ -17711,7 +17713,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-network 2.4.1",
  "alloy-provider",
@@ -17754,7 +17756,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-evm",
@@ -17774,7 +17776,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -17805,11 +17807,11 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-dyn-abi",
- "alloy-eip7928 0.4.5",
+ "alloy-eip7928 0.4.8",
  "alloy-eips 2.4.1",
  "alloy-evm",
  "alloy-json-rpc 2.4.1",
@@ -17852,11 +17854,11 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
- "alloy-eip7928 0.4.5",
+ "alloy-eip7928 0.4.8",
  "alloy-eips 2.4.1",
  "alloy-evm",
  "alloy-network 2.4.1",
@@ -17903,12 +17905,14 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.2",
+ "http-body-util",
  "jsonrpsee-http-client",
  "pin-project",
+ "tokio",
  "tower 0.5.3",
  "tower-http",
  "tracing",
@@ -17917,7 +17921,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -17948,9 +17952,10 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
+ "alloy-eip7928 0.4.8",
  "alloy-primitives",
  "alloy-rlp",
  "eyre",
@@ -17999,7 +18004,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18027,7 +18032,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -18041,7 +18046,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -18061,7 +18066,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -18076,10 +18081,10 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
- "alloy-eip7928 0.4.5",
+ "alloy-eip7928 0.4.8",
  "alloy-eips 2.4.1",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -18102,7 +18107,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18119,7 +18124,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18146,7 +18151,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -18167,7 +18172,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18183,7 +18188,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -18193,7 +18198,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "clap",
  "eyre",
@@ -18213,7 +18218,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -18232,7 +18237,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18275,7 +18280,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18301,7 +18306,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -18328,7 +18333,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -18344,7 +18349,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -18368,7 +18373,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/paradigmxyz/reth?rev=90ea46d0665408804e5fa24c6f05e06c09b232bb#90ea46d0665408804e5fa24c6f05e06c09b232bb"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -18604,7 +18609,7 @@ version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c4ae66db3abfcb565854dbfc95513bfa440b3dc390ddf8e50b0363d12a6fa79"
 dependencies = [
- "alloy-eip7928 0.4.5",
+ "alloy-eip7928 0.4.8",
  "bitflags 2.13.1",
  "nonmax",
  "revm-bytecode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -273,107 +273,107 @@ revm-database = { version = "42.0.0", default-features = false }
 revm-precompile = { version = "42.0.1", default-features = false }
 
 # alloy
-alloy-signer = "2.3.0"
-alloy-pubsub = "2.3.0"
-alloy-network = "2.3.0"
-alloy-provider = "2.3.0"
-alloy-contract = "2.3.0"
-alloy-json-rpc = "2.3.0"
-alloy-transport = "2.3.0"
-alloy-rpc-types = "2.3.0"
-alloy-hardforks = "0.4.7"
-alloy-rpc-client = "2.3.0"
-alloy-signer-local = "2.3.0"
-alloy-transport-ws = "2.3.0"
-alloy-node-bindings = "2.3.0"
-alloy-transport-http = "2.3.0"
-alloy-rpc-types-beacon = "2.3.0"
+alloy-signer = "2.4.1"
+alloy-pubsub = "2.4.1"
+alloy-network = "2.4.1"
+alloy-provider = "2.4.1"
+alloy-contract = "2.4.1"
+alloy-json-rpc = "2.4.1"
+alloy-transport = "2.4.1"
+alloy-rpc-types = "2.4.1"
+alloy-hardforks = "0.4.8"
+alloy-rpc-client = "2.4.1"
+alloy-signer-local = "2.4.1"
+alloy-transport-ws = "2.4.1"
+alloy-node-bindings = "2.4.1"
+alloy-transport-http = "2.4.1"
+alloy-rpc-types-beacon = "2.4.1"
 alloy-rlp = { version = "0.3.16", default-features = false }
 alloy-trie = { version = "0.9.4", default-features = false }
-alloy-eips = { version = "2.3.0", default-features = false }
+alloy-eips = { version = "2.4.1", default-features = false }
 alloy-evm = { version = "0.38.0", default-features = false }
-alloy-serde = { version = "2.3.0", default-features = false }
+alloy-serde = { version = "2.4.1", default-features = false }
 alloy-chains = { version = "0.2.33", default-features = false }
-alloy-genesis = { version = "2.3.0", default-features = false }
-alloy-consensus = { version = "2.3.0", default-features = false }
+alloy-genesis = { version = "2.4.1", default-features = false }
+alloy-consensus = { version = "2.4.1", default-features = false }
 alloy-sol-types = { version = "1.6.1", default-features = false }
 alloy-primitives = { version = "1.6.1", default-features = false }
 alloy-sol-macro = "1.6.1"
-alloy-rpc-types-eth = { version = "2.3.0", default-features = false }
-alloy-rpc-types-debug = { version = "2.3.0", default-features = false }
-alloy-rpc-types-txpool = { version = "2.3.0", default-features = false }
-alloy-rpc-types-engine = { version = "2.3.0", default-features = false }
-alloy-network-primitives = { version = "2.3.0", default-features = false }
+alloy-rpc-types-eth = { version = "2.4.1", default-features = false }
+alloy-rpc-types-debug = { version = "2.4.1", default-features = false }
+alloy-rpc-types-txpool = { version = "2.4.1", default-features = false }
+alloy-rpc-types-engine = { version = "2.4.1", default-features = false }
+alloy-network-primitives = { version = "2.4.1", default-features = false }
 
 # reth
 reth-zstd-compressors = { version = "0.6.0", default-features = false }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
 reth-codecs = { version = "0.6.0", default-features = false, features = ["alloy"] }
-reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-ipc = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-exex = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-ecies = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-discv4 = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-network = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-net-nat = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-eth-wire = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-db-common = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-rpc-layer = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-chain-state = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-payload-util = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-tracing-otlp = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-testing-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-exex-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0", default-features = false }
-reth-stages-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0", default-features = false }
-reth-storage-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0", default-features = false }
-reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0", default-features = false }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0", default-features = false }
-reth-trie-parallel = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-ipc = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-exex = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-ecies = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-discv4 = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-network = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-net-nat = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-eth-wire = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-db-common = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-rpc-layer = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-chain-state = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-payload-util = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-tracing-otlp = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-testing-utils = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-exex-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb", default-features = false }
+reth-stages-types = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb", default-features = false }
+reth-storage-errors = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb", default-features = false }
+reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb", default-features = false }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb", default-features = false }
+reth-trie-parallel = { git = "https://github.com/paradigmxyz/reth", rev = "90ea46d0665408804e5fa24c6f05e06c09b232bb" }
 
 # tokio
 tokio = "1.53.1"

--- a/crates/builder/core/src/flashblocks/generator.rs
+++ b/crates/builder/core/src/flashblocks/generator.rs
@@ -7,8 +7,8 @@ use reth_basic_payload_builder::{HeaderForPayload, PayloadConfig, PrecachedState
 use reth_execution_cache::SavedCache;
 use reth_node_api::{NodePrimitives, PayloadKind};
 use reth_payload_builder::{
-    BuildNewPayload, KeepPayloadJobAlive, PayloadBuilderError, PayloadId, PayloadJob,
-    PayloadJobGenerator,
+    BuildNewPayload, KeepPayloadJobAlive, PayloadBuilderError, PayloadBuilderLease, PayloadId,
+    PayloadJob, PayloadJobGenerator,
 };
 use reth_payload_primitives::{BuiltPayload, PayloadAttributes};
 use reth_primitives_traits::HeaderTy;
@@ -130,7 +130,7 @@ where
 
         // Extract hash before moving parent_header into Arc to avoid cloning
         let parent_hash = parent_header.hash();
-        let resources = input.resources;
+        let mut resources = input.resources;
         let config = PayloadConfig::new(Arc::new(parent_header), input.attributes, id);
 
         // Create shared mutex for synchronizing cancellation with payload publishing
@@ -146,7 +146,8 @@ where
             publish_guard,
             deadline,
             cached_reads: self.maybe_pre_cached(parent_hash),
-            execution_cache: resources.execution_cache().cloned(),
+            execution_cache: resources.take_execution_cache(),
+            leases: resources.take_leases(),
         };
 
         job.spawn_build_job();
@@ -219,6 +220,8 @@ where
     pub(crate) cached_reads: Option<CachedReads>,
     /// Optional execution cache shared with the engine.
     pub(crate) execution_cache: Option<SavedCache>,
+    /// Lifecycle leases retained until the detached worker finishes using engine resources.
+    pub(crate) leases: Vec<PayloadBuilderLease>,
 }
 
 impl<Builder> std::fmt::Debug for BlockPayloadJob<Builder>
@@ -274,6 +277,8 @@ pub struct BuildArguments<Attributes, Payload: BuiltPayload> {
     pub cached_reads: CachedReads,
     /// Optional execution cache shared with the engine.
     pub execution_cache: Option<SavedCache>,
+    /// Lifecycle leases protecting resources loaned by the engine.
+    pub leases: Vec<PayloadBuilderLease>,
     /// How to configure the payload.
     pub config: PayloadConfig<Attributes, HeaderTy<Payload::Primitives>>,
     /// A marker that can be used to cancel the job.
@@ -301,10 +306,12 @@ where
         self.payload_rx = Some(watch_rx);
         let cached_reads = self.cached_reads.take().unwrap_or_default();
         let execution_cache = self.execution_cache.take();
+        let leases = std::mem::take(&mut self.leases);
         self.executor.spawn_blocking_task(Box::pin(async move {
             let args = BuildArguments {
                 cached_reads,
                 execution_cache,
+                leases,
                 config: payload_config,
                 cancel,
                 publish_guard,
@@ -400,18 +407,30 @@ impl<T> Future for ResolvePayload<T> {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        collections::VecDeque,
+        sync::atomic::{AtomicBool, Ordering},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
     use alloy_eips::eip7685::Requests;
     use alloy_primitives::U256;
-    use base_common_consensus::BasePrimitives;
-    use base_execution_payload_builder::{BasePayloadBuilderAttributes, PayloadPrimitives};
+    use base_common_consensus::{BasePrimitives, BaseTransactionSigned};
+    use base_execution_payload_builder::{
+        BaseBuiltPayload, BasePayloadBuilderAttributes, BasePayloadTypes, PayloadPrimitives,
+    };
+    use futures::stream;
     use rand::rng;
     use reth_execution_cache::{ExecutionCache, SavedCache};
-    use reth_node_api::{BuiltPayloadExecutedBlock, NodePrimitives};
-    use reth_payload_builder::PayloadBuilderResources;
+    use reth_node_api::{BuiltPayloadExecutedBlock, NodePrimitives, PayloadKind};
+    use reth_payload_builder::{
+        PayloadBuilderHandle, PayloadBuilderResources, PayloadBuilderService,
+    };
     use reth_primitives_traits::SealedBlock;
     use reth_provider::test_utils::MockEthProvider;
     use reth_tasks::Runtime;
     use reth_testing_utils::generators::{BlockRangeParams, random_block_range};
+    use tokio::sync::Semaphore;
     use tokio::time::{Duration, sleep, timeout};
 
     use super::*;
@@ -503,6 +522,175 @@ mod tests {
         }
     }
 
+    type TestAttributes = BasePayloadBuilderAttributes<BaseTransactionSigned>;
+
+    #[derive(Debug)]
+    struct LeaseDropProbe {
+        dropped: Arc<AtomicBool>,
+    }
+
+    impl Drop for LeaseDropProbe {
+        fn drop(&mut self) {
+            self.dropped.store(true, Ordering::Release);
+        }
+    }
+
+    #[derive(Debug)]
+    struct BuildControl {
+        started: Semaphore,
+        complete: Semaphore,
+        cancelled: Semaphore,
+        finalizing: Semaphore,
+        finish_finalizing: Semaphore,
+        published: Semaphore,
+    }
+
+    impl Default for BuildControl {
+        fn default() -> Self {
+            Self {
+                started: Semaphore::new(0),
+                complete: Semaphore::new(0),
+                cancelled: Semaphore::new(0),
+                finalizing: Semaphore::new(0),
+                finish_finalizing: Semaphore::new(0),
+                published: Semaphore::new(0),
+            }
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct ControlledBuilder {
+        controls: Arc<Mutex<VecDeque<Arc<BuildControl>>>>,
+    }
+
+    impl ControlledBuilder {
+        fn new(controls: impl IntoIterator<Item = Arc<BuildControl>>) -> Self {
+            Self { controls: Arc::new(Mutex::new(controls.into_iter().collect())) }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl PayloadBuilder for ControlledBuilder {
+        type Attributes = TestAttributes;
+        type BuiltPayload = BaseBuiltPayload;
+
+        async fn try_build(
+            &self,
+            args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
+            payload_tx: &watch::Sender<Option<Self::BuiltPayload>>,
+        ) -> Result<(), PayloadBuilderError> {
+            let control =
+                self.controls.lock().pop_front().expect("missing controlled build configuration");
+            control.started.add_permits(1);
+
+            tokio::select! {
+                permit = control.complete.acquire() => {
+                    permit.expect("complete semaphore closed").forget();
+                }
+                _ = args.cancel.cancelled() => {
+                    control.cancelled.add_permits(1);
+                }
+            }
+
+            control.finalizing.add_permits(1);
+            control
+                .finish_finalizing
+                .acquire()
+                .await
+                .expect("finalization semaphore closed")
+                .forget();
+
+            let payload_id = args.config.payload_id();
+            drop(args);
+            payload_tx.send_replace(Some(BaseBuiltPayload::new(
+                payload_id,
+                Arc::new(SealedBlock::default()),
+                U256::ZERO,
+                None,
+                None,
+            )));
+            control.published.add_permits(1);
+            Ok(())
+        }
+    }
+
+    struct LeaseTest;
+
+    impl LeaseTest {
+        const TIMEOUT: Duration = Duration::from_secs(5);
+
+        fn generator(
+            builder: ControlledBuilder,
+            ensure_only_one_payload: bool,
+            extra_deadline: Duration,
+        ) -> (BlockPayloadJobGenerator<MockEthProvider, ControlledBuilder>, TestAttributes)
+        {
+            let mut rng = rng();
+            let client = MockEthProvider::default();
+            let blocks = random_block_range(
+                &mut rng,
+                1..=1,
+                BlockRangeParams { tx_count: 0..1, ..Default::default() },
+            );
+            client.extend_blocks(blocks.into_iter().map(|block| {
+                let hash = block.hash();
+                (hash, block.unseal())
+            }));
+
+            let mut attributes = TestAttributes::default();
+            attributes.payload_attributes.parent =
+                client.latest_header().expect("latest header query failed").unwrap().hash();
+            attributes.payload_attributes.timestamp =
+                SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() + 60;
+            let generator = BlockPayloadJobGenerator::with_builder(
+                client,
+                Runtime::test(),
+                builder,
+                ensure_only_one_payload,
+                extra_deadline,
+            );
+            (generator, attributes)
+        }
+
+        fn resources(dropped: &Arc<AtomicBool>) -> PayloadBuilderResources {
+            PayloadBuilderResources::default().with_lease(PayloadBuilderLease::new(
+                LeaseDropProbe { dropped: Arc::clone(dropped) },
+            ))
+        }
+
+        fn input(
+            attributes: TestAttributes,
+            dropped: &Arc<AtomicBool>,
+        ) -> BuildNewPayload<TestAttributes> {
+            BuildNewPayload {
+                parent_hash: attributes.payload_attributes.parent,
+                attributes,
+                resources: Self::resources(dropped),
+            }
+        }
+
+        async fn wait(signal: &Semaphore) {
+            timeout(Self::TIMEOUT, signal.acquire())
+                .await
+                .expect("timed out waiting for build signal")
+                .expect("build signal semaphore closed")
+                .forget();
+        }
+
+        async fn wait_until_removed(
+            handle: &PayloadBuilderHandle<BasePayloadTypes>,
+            id: PayloadId,
+        ) {
+            timeout(Self::TIMEOUT, async {
+                while handle.payload_timestamp(id).await.is_some() {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("timed out waiting for payload job removal");
+        }
+    }
+
     #[tokio::test]
     async fn test_payload_generator() -> eyre::Result<()> {
         let mut rng = rng();
@@ -571,6 +759,233 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn normal_get_payload_holds_worker_lease_until_publication() {
+        let control = Arc::new(BuildControl::default());
+        let dropped = Arc::new(AtomicBool::new(false));
+        let (generator, attributes) = LeaseTest::generator(
+            ControlledBuilder::new([Arc::clone(&control)]),
+            false,
+            Duration::from_secs(20),
+        );
+        let parent_hash = attributes.payload_attributes.parent;
+        let mut job = generator
+            .new_payload_job(
+                LeaseTest::input(attributes.clone(), &dropped),
+                attributes.payload_id(&parent_hash),
+            )
+            .expect("payload job creation failed");
+
+        LeaseTest::wait(&control.started).await;
+        assert!(!dropped.load(Ordering::Acquire), "worker must retain the lease while building");
+
+        let (resolved, _) = job.resolve_kind(PayloadKind::Earliest);
+        LeaseTest::wait(&control.cancelled).await;
+        LeaseTest::wait(&control.finalizing).await;
+        assert!(!dropped.load(Ordering::Acquire), "lease must cover cancellation finalization");
+
+        control.finish_finalizing.add_permits(1);
+        let payload = timeout(LeaseTest::TIMEOUT, resolved)
+            .await
+            .expect("timed out resolving payload")
+            .expect("payload resolution failed");
+
+        assert_eq!(payload.id(), attributes.payload_id(&parent_hash));
+        assert!(
+            dropped.load(Ordering::Acquire),
+            "worker lease must drop before publication wakes the resolver"
+        );
+    }
+
+    #[tokio::test]
+    async fn late_get_payload_resolves_after_worker_releases_lease() {
+        let control = Arc::new(BuildControl::default());
+        let dropped = Arc::new(AtomicBool::new(false));
+        let (generator, attributes) = LeaseTest::generator(
+            ControlledBuilder::new([Arc::clone(&control)]),
+            false,
+            Duration::from_secs(20),
+        );
+        let parent_hash = attributes.payload_attributes.parent;
+        let mut job = generator
+            .new_payload_job(
+                LeaseTest::input(attributes.clone(), &dropped),
+                attributes.payload_id(&parent_hash),
+            )
+            .expect("payload job creation failed");
+
+        LeaseTest::wait(&control.started).await;
+        assert!(!dropped.load(Ordering::Acquire), "worker must retain the lease while building");
+        control.complete.add_permits(1);
+        LeaseTest::wait(&control.finalizing).await;
+        assert!(!dropped.load(Ordering::Acquire), "lease must cover finalization");
+        control.finish_finalizing.add_permits(1);
+        LeaseTest::wait(&control.published).await;
+        assert!(
+            dropped.load(Ordering::Acquire),
+            "completed worker must release its lease before a delayed request"
+        );
+
+        let (resolved, _) = job.resolve_kind(PayloadKind::Earliest);
+        let payload = timeout(LeaseTest::TIMEOUT, resolved)
+            .await
+            .expect("timed out resolving delayed payload")
+            .expect("delayed payload resolution failed");
+        assert_eq!(payload.id(), attributes.payload_id(&parent_hash));
+    }
+
+    #[tokio::test]
+    async fn cancelled_resolve_future_keeps_detached_worker_lease() {
+        let control = Arc::new(BuildControl::default());
+        let dropped = Arc::new(AtomicBool::new(false));
+        let (generator, attributes) = LeaseTest::generator(
+            ControlledBuilder::new([Arc::clone(&control)]),
+            false,
+            Duration::from_secs(20),
+        );
+        let (service, handle) = PayloadBuilderService::<_, _, BasePayloadTypes>::new(
+            generator,
+            stream::empty::<CanonStateNotification<BasePrimitives>>(),
+        );
+        let service_task = tokio::spawn(service);
+        let id = handle
+            .send_new_payload(LeaseTest::input(attributes, &dropped))
+            .await
+            .expect("payload service dropped response")
+            .expect("payload job creation failed");
+
+        LeaseTest::wait(&control.started).await;
+        let resolve_handle = handle.clone();
+        let resolve_task =
+            tokio::spawn(
+                async move { resolve_handle.resolve_kind(id, PayloadKind::Earliest).await },
+            );
+        LeaseTest::wait(&control.cancelled).await;
+        LeaseTest::wait(&control.finalizing).await;
+        LeaseTest::wait_until_removed(&handle, id).await;
+
+        resolve_task.abort();
+        let _ = resolve_task.await;
+        tokio::task::yield_now().await;
+        assert!(
+            !dropped.load(Ordering::Acquire),
+            "dropping the service resolver must not release an active worker lease"
+        );
+
+        control.finish_finalizing.add_permits(1);
+        LeaseTest::wait(&control.published).await;
+        assert!(
+            dropped.load(Ordering::Acquire),
+            "worker must release its lease after finalization"
+        );
+        service_task.abort();
+    }
+
+    #[tokio::test]
+    async fn deadline_removal_keeps_detached_worker_lease() {
+        let control = Arc::new(BuildControl::default());
+        let dropped = Arc::new(AtomicBool::new(false));
+        let (generator, mut attributes) = LeaseTest::generator(
+            ControlledBuilder::new([Arc::clone(&control)]),
+            false,
+            Duration::ZERO,
+        );
+        attributes.payload_attributes.timestamp = 0;
+        let (service, handle) = PayloadBuilderService::<_, _, BasePayloadTypes>::new(
+            generator,
+            stream::empty::<CanonStateNotification<BasePrimitives>>(),
+        );
+        let service_task = tokio::spawn(service);
+        let id = handle
+            .send_new_payload(LeaseTest::input(attributes, &dropped))
+            .await
+            .expect("payload service dropped response")
+            .expect("payload job creation failed");
+
+        LeaseTest::wait(&control.started).await;
+        LeaseTest::wait(&control.cancelled).await;
+        LeaseTest::wait(&control.finalizing).await;
+        LeaseTest::wait_until_removed(&handle, id).await;
+        assert!(
+            !dropped.load(Ordering::Acquire),
+            "deadline removal must not release a finalizing worker lease"
+        );
+
+        control.finish_finalizing.add_permits(1);
+        LeaseTest::wait(&control.published).await;
+        assert!(
+            dropped.load(Ordering::Acquire),
+            "worker must release its lease after finalization"
+        );
+        service_task.abort();
+    }
+
+    #[tokio::test]
+    async fn replacement_keeps_cancelled_worker_lease() {
+        let first_control = Arc::new(BuildControl::default());
+        let second_control = Arc::new(BuildControl::default());
+        let first_dropped = Arc::new(AtomicBool::new(false));
+        let second_dropped = Arc::new(AtomicBool::new(false));
+        let builder =
+            ControlledBuilder::new([Arc::clone(&first_control), Arc::clone(&second_control)]);
+        let (generator, first_attributes) =
+            LeaseTest::generator(builder, true, Duration::from_secs(20));
+        let mut second_attributes = first_attributes.clone();
+        second_attributes.payload_attributes.timestamp += 1;
+        let (service, handle) = PayloadBuilderService::<_, _, BasePayloadTypes>::new(
+            generator,
+            stream::empty::<CanonStateNotification<BasePrimitives>>(),
+        );
+        let service_task = tokio::spawn(service);
+
+        let first_id = handle
+            .send_new_payload(LeaseTest::input(first_attributes, &first_dropped))
+            .await
+            .expect("payload service dropped first response")
+            .expect("first payload job creation failed");
+        LeaseTest::wait(&first_control.started).await;
+
+        let second_id = handle
+            .send_new_payload(LeaseTest::input(second_attributes, &second_dropped))
+            .await
+            .expect("payload service dropped second response")
+            .expect("second payload job creation failed");
+        LeaseTest::wait(&second_control.started).await;
+        LeaseTest::wait(&first_control.cancelled).await;
+        LeaseTest::wait(&first_control.finalizing).await;
+        LeaseTest::wait_until_removed(&handle, first_id).await;
+        assert!(
+            !first_dropped.load(Ordering::Acquire),
+            "replacement must not release the cancelled worker's lease during finalization"
+        );
+
+        first_control.finish_finalizing.add_permits(1);
+        LeaseTest::wait(&first_control.published).await;
+        assert!(
+            first_dropped.load(Ordering::Acquire),
+            "replaced worker must release its lease after finalization"
+        );
+
+        second_control.complete.add_permits(1);
+        LeaseTest::wait(&second_control.finalizing).await;
+        second_control.finish_finalizing.add_permits(1);
+        LeaseTest::wait(&second_control.published).await;
+        assert!(
+            !second_dropped.load(Ordering::Acquire),
+            "service intentionally retains its lease for a delayed getPayload"
+        );
+        handle
+            .resolve_kind(second_id, PayloadKind::Earliest)
+            .await
+            .expect("second payload job missing")
+            .expect("second payload resolution failed");
+        assert!(
+            second_dropped.load(Ordering::Acquire),
+            "service lease must release after delayed payload resolution"
+        );
+        service_task.abort();
     }
 
     #[derive(Clone, Debug, Default, PartialEq, Eq)]

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -260,6 +260,7 @@ where
         let BuildArguments {
             mut cached_reads,
             execution_cache,
+            leases: _leases,
             config,
             cancel: block_cancel,
             publish_guard,


### PR DESCRIPTION
## Summary
- pin Reth to `90ea46d0665408804e5fa24c6f05e06c09b232bb`, including the responsive persisted-handoff handling from #26708
- carry payload-builder leases into the detached flashblocks worker through cancellation finalization and synchronous state-root computation
- release worker leases before payload publication and cover normal, late, deadline, cancelled-resolve, and replacement lifecycles with focused tests

## Test plan
- [x] `cargo test -p base-builder-core --lib flashblocks::generator::tests`
- [x] `cargo test -p base-builder-core --test flashblocks -- --test-threads=1`
- [x] `cargo clippy -p base-builder-core --lib --tests --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] warm local devnet smoke test (Docker daemon unavailable)

## Notes
The wall-clock-sensitive flashblocks integration suite passes serially. Concurrent runs intermittently miss one listener observation in cadence-count tests.

Reth issue #26710 remains out of scope: worker retention can extend an active lease through necessary post-cancellation finalization, but this change does not address starvation from continuously overlapping replacement jobs.

type=routine
risk=low
impact=sev5