### PR TITLE
chore(deps): pin reth v2.5.0 plus history-shard and engine-handoff backports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15683,7 +15683,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15710,7 +15710,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15741,7 +15741,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -15761,7 +15761,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -15774,7 +15774,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -15863,7 +15863,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -15873,7 +15873,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -15924,7 +15924,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -15941,7 +15941,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -15955,7 +15955,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15968,7 +15968,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15993,7 +15993,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -16022,7 +16022,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16048,7 +16048,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-genesis",
@@ -16078,7 +16078,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16093,7 +16093,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16118,7 +16118,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16142,7 +16142,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -16166,7 +16166,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16201,7 +16201,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16258,7 +16258,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -16285,7 +16285,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16308,7 +16308,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16335,7 +16335,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -16391,7 +16391,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16421,7 +16421,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16439,7 +16439,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -16455,7 +16455,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16479,7 +16479,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -16490,7 +16490,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -16519,7 +16519,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -16545,7 +16545,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16561,7 +16561,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16577,7 +16577,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks 0.4.7",
@@ -16591,7 +16591,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16621,7 +16621,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16635,7 +16635,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -16645,7 +16645,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -16671,7 +16671,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16691,7 +16691,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -16709,7 +16709,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -16722,7 +16722,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16741,7 +16741,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16779,7 +16779,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-test-utils"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-eips 2.4.1",
  "eyre",
@@ -16811,7 +16811,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16825,7 +16825,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "serde",
  "serde_json",
@@ -16835,7 +16835,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16861,7 +16861,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "bytes",
  "futures",
@@ -16881,7 +16881,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "bitflags 2.13.1",
  "byteorder",
@@ -16898,7 +16898,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -16907,7 +16907,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "futures",
  "libc",
@@ -16921,7 +16921,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -16930,7 +16930,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -16944,7 +16944,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17003,7 +17003,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17028,7 +17028,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -17052,7 +17052,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17067,7 +17067,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -17081,7 +17081,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -17098,7 +17098,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -17122,7 +17122,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17190,7 +17190,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17245,7 +17245,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17294,7 +17294,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17318,7 +17318,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17342,7 +17342,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "bytes",
  "eyre",
@@ -17371,7 +17371,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -17383,7 +17383,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17407,7 +17407,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -17419,7 +17419,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17442,7 +17442,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17452,7 +17452,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-rpc-types-engine",
@@ -17495,7 +17495,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -17544,7 +17544,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17571,7 +17571,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -17587,7 +17587,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17602,7 +17602,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-dyn-abi",
@@ -17678,7 +17678,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-genesis",
@@ -17708,7 +17708,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-network 2.4.1",
  "alloy-provider",
@@ -17751,7 +17751,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-evm",
@@ -17771,7 +17771,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -17802,7 +17802,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-dyn-abi",
@@ -17849,7 +17849,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -17900,7 +17900,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.2",
@@ -17914,7 +17914,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -17945,7 +17945,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17996,7 +17996,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18024,7 +18024,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -18038,7 +18038,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -18058,7 +18058,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -18073,7 +18073,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -18099,7 +18099,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18116,7 +18116,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18143,7 +18143,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -18164,7 +18164,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18180,7 +18180,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -18190,7 +18190,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "clap",
  "eyre",
@@ -18210,7 +18210,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -18229,7 +18229,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18272,7 +18272,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18298,7 +18298,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -18325,7 +18325,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -18341,7 +18341,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -18365,7 +18365,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+source = "git+https://github.com/niran/reth?rev=8371ef894bc8a90ddf9a9495356dfe718e0e0d8d#8371ef894bc8a90ddf9a9495356dfe718e0e0d8d"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -309,71 +309,71 @@ alloy-network-primitives = { version = "2.3.0", default-features = false }
 reth-zstd-compressors = { version = "0.6.0", default-features = false }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
 reth-codecs = { version = "0.6.0", default-features = false, features = ["alloy"] }
-reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-ipc = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-exex = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-ecies = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-discv4 = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-network = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-net-nat = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-eth-wire = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-db-common = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-rpc-layer = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-chain-state = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-payload-util = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-tracing-otlp = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-testing-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-exex-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0", default-features = false }
-reth-stages-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0", default-features = false }
-reth-storage-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0", default-features = false }
-reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0", default-features = false }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0", default-features = false }
-reth-trie-parallel = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
+reth-db = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-cli = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-ipc = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-evm = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-rpc = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-revm = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-trie = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-exex = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-tasks = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-ecies = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-db-api = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-discv4 = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-discv5 = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-trie-db = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-rpc-api = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-network = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-net-nat = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-tracing = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-eth-wire = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-provider = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-cli-util = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-node-api = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-db-common = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-rpc-layer = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-node-core = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-consensus = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-chainspec = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-cli-runner = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-rpc-convert = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-network-p2p = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-storage-api = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-rpc-eth-api = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-chain-state = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-trie-common = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-payload-util = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-node-builder = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-node-metrics = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-cli-commands = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-evm-ethereum = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-tracing-otlp = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-testing-utils = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-rpc-eth-types = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-network-peers = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-node-ethereum = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-rpc-engine-api = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-e2e-test-utils = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-eth-wire-types = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-payload-builder = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-execution-types = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-execution-cache = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-exex-test-utils = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-rpc-server-types = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-transaction-pool = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-execution-errors = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-payload-validator = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-payload-primitives = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-ethereum-primitives = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-basic-payload-builder = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-payload-builder-primitives = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
+reth-prune-types = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d", default-features = false }
+reth-stages-types = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d", default-features = false }
+reth-storage-errors = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d", default-features = false }
+reth-ethereum-forks = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d", default-features = false }
+reth-consensus-common = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d", default-features = false }
+reth-trie-parallel = { git = "https://github.com/niran/reth", rev = "8371ef894bc8a90ddf9a9495356dfe718e0e0d8d" }
 
 # tokio
 tokio = "1.53.1"


### PR DESCRIPTION
## Summary

Plan B for the Sepolia validator lag / storage-v2 persist incident. Plan A was wait for official Reth 2.5.1.

Keep `base/base` `releases/v1.3.0` on Reth **2.5.0**. Pin every Reth git workspace dep to public fork [`niran/reth`](https://github.com/niran/reth) `8371ef894bc8a90ddf9a9495356dfe718e0e0d8d` (`v2.5.0` plus two backports). Do **not** bump Reth to main or to `90ea46d0`. Alloy stays at 2.3.0 / `alloy-hardforks` 0.4.7.

| Piece | Upstream | In this pin |
| --- | --- | --- |
| Live `write_storage_history` last-shard Gets | [reth#25282](https://github.com/paradigmxyz/reth/pull/25282) | Already in Reth 2.5.0 / `v1.3.0-rc.1` |
| Incremental `IndexStorageHistory` last-shard Gets | [reth#26766](https://github.com/paradigmxyz/reth/pull/26766) | Yes (`18cf969`) |
| Engine API liveness during payload leases | [reth#26708](https://github.com/paradigmxyz/reth/pull/26708) | Yes (`8371ef8`) |

Fork compare: [`v2.5.0...8371ef8`](https://github.com/niran/reth/compare/v2.5.0...8371ef894bc8a90ddf9a9495356dfe718e0e0d8d) — two commits (`18cf969` history shards, `8371ef8` engine handoff).

Supersedes [base/base#4530](https://github.com/base/base/pull/4530) (experiment; missing #26708; do not deploy) and is the 1.3.0-line alternative to [base/base#4539](https://github.com/base/base/pull/4539) (`main`; 34 extra Reth commits; missing #26766). Do not merge those PRs for this ship.

Not a sequencer-safety proof. Residual [reth#26710](https://github.com/paradigmxyz/reth/issues/26710). Sequencer fallback remains storage v1 on `base/base` 1.2.1.

Not #4538 / flashblocks lease-ownership.

## Test plan

- [x] `cargo check --locked -p base-reth-node -p base-builder-bin -p base-consensus -p base-consensus-node -p base-builder-cli`
- [x] `cargo test --locked --lib -p base-builder-core -p base-consensus-engine -p base-execution-payload-builder`
- [x] `cargo clippy --locked -D warnings` on the check crates
- [ ] Warm Engine-API / fat-FCU reproduction (Agent 3 if requested)

type=routine
risk=medium
impact=sev5