### PR TITLE
fix(builder): do not permanently cache per-tx DA size rejects

### DIFF
--- a/crates/builder/core/src/execution.rs
+++ b/crates/builder/core/src/execution.rs
@@ -159,19 +159,19 @@ pub enum TxnExecutionError {
 
 impl TxnExecutionError {
     /// Returns `true` if this rejection is permanent — the transaction will never be includable
-    /// regardless of block/flashblock cumulative state. Permanent rejections are intrinsic to
-    /// the transaction itself (e.g. its size or predicted execution time exceeds the per-tx limit).
+    /// regardless of block/flashblock cumulative state or operator DA throttle changes.
+    /// Permanent rejections are intrinsic to the transaction itself (e.g. predicted execution
+    /// time exceeds the per-tx limit, or gas usage exceeds the configured maximum).
     ///
-    /// Transient rejections depend on cumulative block state (gas used, DA used, etc.) and may
-    /// succeed in a future block or flashblock with different cumulative values.
+    /// Transient rejections may succeed in a future block or flashblock. This includes cumulative
+    /// block-state limits (gas used, block DA used, etc.) and the per-tx DA size cap
+    /// (`max_da_tx_size`), which is a mutable operator/batcher throttle.
     pub const fn is_permanent(&self) -> bool {
         matches!(
             self,
-            Self::TransactionDASizeExceeded(_, _)
-                | Self::ExecutionMeteringLimitExceeded(
-                    ExecutionMeteringLimitExceeded::TransactionExecutionTime(_, _),
-                )
-                | Self::MaxGasUsageExceeded
+            Self::ExecutionMeteringLimitExceeded(
+                ExecutionMeteringLimitExceeded::TransactionExecutionTime(_, _),
+            ) | Self::MaxGasUsageExceeded
         )
     }
 }
@@ -592,5 +592,82 @@ mod tests {
             TxResources { gas_limit: 21_000, uncompressed_size: 1_000_000, ..Default::default() };
 
         assert!(info.is_tx_over_limits(&tx, &limits).is_ok());
+    }
+
+    // ==================== Permanence Classification ====================
+
+    #[test]
+    fn per_tx_da_size_exceeded_is_not_permanent() {
+        let err = TxnExecutionError::TransactionDASizeExceeded(1001, 1000);
+        assert!(
+            !err.is_permanent(),
+            "max_da_tx_size is a mutable operator throttle; per-tx DA rejects must be re-evaluated"
+        );
+    }
+
+    #[test]
+    fn block_da_size_exceeded_is_not_permanent() {
+        let err = TxnExecutionError::BlockDASizeExceeded {
+            total_da_used: 9500,
+            tx_da_size: 600,
+            block_da_limit: 10_000,
+        };
+        assert!(!err.is_permanent());
+    }
+
+    #[test]
+    fn max_gas_usage_and_execution_time_are_permanent() {
+        assert!(TxnExecutionError::MaxGasUsageExceeded.is_permanent());
+        assert!(
+            TxnExecutionError::ExecutionMeteringLimitExceeded(
+                ExecutionMeteringLimitExceeded::TransactionExecutionTime(1_500_000, 1_000_000),
+            )
+            .is_permanent()
+        );
+    }
+
+    /// A tx that exceeds the current per-tx DA cap is skipped, but after the cap is raised
+    /// the same resource usage is eligible again. This is the `miner_setMaxDASize` retry path.
+    #[test]
+    fn per_tx_da_reject_retries_after_limit_raised() {
+        let info = ExecutionInfo::with_capacity(10);
+        let tx = TxResources { da_size: 1001, gas_limit: 21_000, ..Default::default() };
+
+        let tight = ResourceLimits { tx_data_limit: Some(1000), ..default_limits() };
+        let err = info.is_tx_over_limits(&tx, &tight).expect_err("tx DA should exceed tight cap");
+        assert!(matches!(err, TxnExecutionError::TransactionDASizeExceeded(1001, 1000)));
+        assert!(!err.is_permanent(), "must not enter the cross-block rejection cache");
+
+        let raised = ResourceLimits { tx_data_limit: Some(2000), ..default_limits() };
+        assert!(
+            info.is_tx_over_limits(&tx, &raised).is_ok(),
+            "same tx must pass once max_da_tx_size is raised above its DA size"
+        );
+    }
+
+    /// A tx that does not exceed the per-tx cap but would overflow remaining block DA can
+    /// still be included later when more block DA remains.
+    #[test]
+    fn block_da_reject_retries_with_more_remaining_da() {
+        let tx = TxResources { da_size: 600, gas_limit: 21_000, ..Default::default() };
+        let limits = ResourceLimits {
+            tx_data_limit: Some(10_000),
+            block_data_limit: Some(10_000),
+            ..default_limits()
+        };
+
+        let mut full = ExecutionInfo::with_capacity(10);
+        full.cumulative_da_bytes_used = 9500;
+        let err = full
+            .is_tx_over_limits(&tx, &limits)
+            .expect_err("should overflow remaining block DA without exceeding per-tx cap");
+        assert!(matches!(err, TxnExecutionError::BlockDASizeExceeded { .. }));
+        assert!(!err.is_permanent());
+
+        let empty = ExecutionInfo::with_capacity(10);
+        assert!(
+            empty.is_tx_over_limits(&tx, &limits).is_ok(),
+            "same tx must fit when the block has enough remaining DA"
+        );
     }
 }

--- a/crates/builder/core/src/flashblocks/best_txs.rs
+++ b/crates/builder/core/src/flashblocks/best_txs.rs
@@ -618,6 +618,8 @@ mod tests {
         assert_eq!(seen_hashes.len(), 1, "only non-rejected tx should appear");
     }
 
+    /// A cache hit for a *true* permanent reject (max gas / execution-time metering, not
+    /// the per-tx DA throttle) excludes the sender's later nonces for this iterator.
     #[test]
     fn rejection_cache_hit_excludes_nonce_descendants() {
         let sender = Address::random();
@@ -644,6 +646,53 @@ mod tests {
             std::iter::from_fn(|| iterator.next(())).map(|tx| *tx.hash()).collect();
 
         assert_eq!(yielded_hashes, vec![other_hash]);
+    }
+
+    /// A per-iterator `mark_invalid` (transient skip, e.g. per-tx DA throttle) excludes nonce
+    /// descendants only for the current flashblock. A later iterator with an empty rejection
+    /// cache still yields the head and its descendants, and a different sender still builds.
+    #[test]
+    fn transient_invalidation_does_not_poison_nonce_descendants() {
+        let sender = Address::random();
+        let other_sender = Address::random();
+        let head =
+            MockTransaction::eip1559().with_sender(sender).with_nonce(0).with_priority_fee(3);
+        let descendant =
+            MockTransaction::eip1559().with_sender(sender).with_nonce(1).with_priority_fee(2);
+        let other =
+            MockTransaction::eip1559().with_sender(other_sender).with_nonce(0).with_priority_fee(1);
+        let head_hash = *head.hash();
+        let descendant_hash = *descendant.hash();
+        let other_hash = *other.hash();
+        let mut factory = MockTransactionFactory::default();
+        let mut pool = PendingPool::new(CoinbaseTipOrdering::<MockTransaction>::default());
+        pool.add_transaction(Arc::new(factory.validated(head)), 0);
+        pool.add_transaction(Arc::new(factory.validated(descendant)), 0);
+        pool.add_transaction(Arc::new(factory.validated(other)), 0);
+
+        let mut iter1 =
+            BestFlashblocksTxs::new(BestPayloadTransactions::new(pool.best()), test_rejection_cache());
+        let first = iter1.next(()).unwrap();
+        assert_eq!(*first.hash(), head_hash);
+        iter1.mark_invalid(first.sender(), first.nonce());
+        let yielded_fb1: Vec<_> =
+            std::iter::from_fn(|| iter1.next(())).map(|tx| *tx.hash()).collect();
+        assert_eq!(
+            yielded_fb1,
+            vec![other_hash],
+            "this flashblock skips the sender's later nonce but still includes a different sender"
+        );
+
+        let mut iter2 =
+            BestFlashblocksTxs::new(BestPayloadTransactions::new(pool.best()), test_rejection_cache());
+        let yielded_fb2: Vec<_> =
+            std::iter::from_fn(|| iter2.next(())).map(|tx| *tx.hash()).collect();
+        assert!(yielded_fb2.contains(&head_hash), "head must be re-selected without a cache insert");
+        assert!(
+            yielded_fb2.contains(&descendant_hash),
+            "later nonce must not stay poisoned after a transient skip"
+        );
+        assert!(yielded_fb2.contains(&other_hash));
     }
 
     /// A rejected transaction becomes eligible again after the cache TTL expires.


### PR DESCRIPTION
## Summary
- `TransactionDASizeExceeded` remains the per-tx error (`tx.da_size > tx_data_limit` only). `is_tx_over_limits` is unchanged.
- Stop treating that error as permanent: `max_da_tx_size` is a mutable `miner_setMaxDASize` operator/batcher throttle, so a miss must be re-evaluated instead of entering `RejectionCache` and `mark_invalid`-poisoning later nonces on the sender lane.
- `BlockDASizeExceeded` stays the block-total transient path. True permanent rejects remain `MaxGasUsageExceeded` and per-tx execution-time metering.

## Test plan
- [x] `cargo test -p base-builder-core --lib per_tx_da`
- [x] `cargo test -p base-builder-core --lib block_da`
- [x] `cargo test -p base-builder-core --lib max_gas_usage_and_execution`
- [x] `cargo test -p base-builder-core --lib rejection`
- [x] `cargo test -p base-builder-core --lib transient_invalidation`
- [x] `cargo test -p base-builder-core --lib test_tx_da_limit`