### PR TITLE
feat(builder): enforce hard cutoff on validity-predicate evaluation time

### DIFF
--- a/crates/builder/cli/src/args.rs
+++ b/crates/builder/cli/src/args.rs
@@ -222,6 +222,12 @@ pub struct Args {
     #[arg(long = "builder.metering-wait-duration-ms")]
     pub metering_wait_duration_ms: Option<u64>,
 
+    /// Hard cutoff, in milliseconds, on cumulative validity-predicate evaluation time per
+    /// flashblock build. Once exceeded, further validity-gated transactions are deferred to a
+    /// later flashblock rather than evaluated.
+    #[arg(long = "builder.predicate-eval-hard-cutoff-ms", default_value = "10")]
+    pub predicate_eval_hard_cutoff_ms: u64,
+
     /// URL of the audit-archiver RPC endpoint for forwarding rejected transactions
     #[arg(long = "builder.audit-archiver-url", env = "BUILDER_AUDIT_ARCHIVER_URL")]
     pub audit_archiver_url: Option<String>,
@@ -315,6 +321,7 @@ impl Default for Args {
             shadow_validity_injection_sample_rate_bps: 100,
             max_uncompressed_block_size: None,
             metering_wait_duration_ms: None,
+            predicate_eval_hard_cutoff_ms: 10,
             audit_archiver_url: None,
             rejected_tx_channel_size: 500,
             max_rejected_txs_per_block: 500,
@@ -386,6 +393,7 @@ impl Args {
             execution_metering_mode: self.execution_metering_mode,
             max_uncompressed_block_size: self.max_uncompressed_block_size,
             metering_wait_duration: self.metering_wait_duration_ms.map(Duration::from_millis),
+            predicate_eval_hard_cutoff: Duration::from_millis(self.predicate_eval_hard_cutoff_ms),
             metering_provider,
             rejection_cache: RejectionCache::new(
                 self.rejection_cache_max_capacity,
@@ -580,6 +588,16 @@ mod tests {
         let args = Args { metering_wait_duration_ms: input, ..Default::default() };
         let config = convert(args);
         assert_eq!(config.metering_wait_duration, expected);
+    }
+
+    #[rstest]
+    #[case::default(10, Duration::from_millis(10))]
+    #[case::zero(0, Duration::from_millis(0))]
+    #[case::custom(25, Duration::from_millis(25))]
+    fn predicate_eval_hard_cutoff_maps_correctly(#[case] input: u64, #[case] expected: Duration) {
+        let args = Args { predicate_eval_hard_cutoff_ms: input, ..Default::default() };
+        let config = convert(args);
+        assert_eq!(config.predicate_eval_hard_cutoff, expected);
     }
 
     #[test]

--- a/crates/builder/core/src/config.rs
+++ b/crates/builder/core/src/config.rs
@@ -58,6 +58,12 @@ pub struct BuilderConfig {
     /// Transactions younger than this without metering data will be skipped.
     pub metering_wait_duration: Option<Duration>,
 
+    /// Hard cutoff on cumulative validity-predicate evaluation time per flashblock build.
+    /// Once the cutoff is exceeded, further validity-gated transactions are deferred to a
+    /// later flashblock rather than evaluated. This is the guardrail backing the
+    /// `base_builder_predicate_eval_duration_per_block` metric's P99 SLO.
+    pub predicate_eval_hard_cutoff: Duration,
+
     /// Resource metering provider
     pub metering_provider: SharedMeteringProvider,
 
@@ -108,6 +114,7 @@ impl core::fmt::Debug for BuilderConfig {
             .field("execution_metering_mode", &self.execution_metering_mode)
             .field("max_uncompressed_block_size", &self.max_uncompressed_block_size)
             .field("metering_wait_duration", &self.metering_wait_duration)
+            .field("predicate_eval_hard_cutoff", &self.predicate_eval_hard_cutoff)
             .field("metering_provider", &self.metering_provider)
             .field("rejection_cache_size", &self.rejection_cache.entry_count())
             .field("audit_archiver_url", &self.audit_archiver_url)
@@ -134,6 +141,7 @@ impl Default for BuilderConfig {
             execution_metering_mode: ExecutionMeteringMode::Off,
             max_uncompressed_block_size: None,
             metering_wait_duration: None,
+            predicate_eval_hard_cutoff: Duration::from_millis(10),
             metering_provider: Arc::new(NoopMeteringProvider),
             rejection_cache: RejectionCache::new(100_000, Duration::from_secs(1800)),
             audit_archiver_url: None,
@@ -209,6 +217,13 @@ impl BuilderConfig {
     #[must_use]
     pub const fn with_manifest_precheck_enabled(mut self, enabled: bool) -> Self {
         self.manifest_precheck_enabled = enabled;
+        self
+    }
+
+    /// Sets the validity-predicate evaluation hard cutoff in milliseconds.
+    #[must_use]
+    pub const fn with_predicate_eval_hard_cutoff_ms(mut self, ms: u64) -> Self {
+        self.predicate_eval_hard_cutoff = Duration::from_millis(ms);
         self
     }
 }

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -514,6 +514,20 @@ impl BasePayloadBuilderCtx {
     }
 }
 
+/// The context needed to emit a defer/reject builder-decision event for one candidate.
+pub(crate) struct DecisionContext<'a> {
+    /// Payload identifier used to correlate emitted events.
+    payload_id: &'a str,
+    /// Execution info snapshot read into event budget fields.
+    info: &'a ExecutionInfo,
+    /// Resource limits read into event budget fields.
+    limits: &'a ResourceLimits,
+    /// Machine-readable reason code recorded on the emitted event.
+    reason: &'static str,
+    /// Human-readable detail recorded on the emitted event.
+    detail: &'static str,
+}
+
 impl BasePayloadBuilderCtx {
     /// Constructs a receipt for the given transaction.
     pub fn build_receipt<E: Evm>(
@@ -669,6 +683,45 @@ impl BasePayloadBuilderCtx {
         value
     }
 
+    /// Defers the current validity-gated candidate by parking it for a later flashblock, or, when
+    /// the iterator cannot park it, rejects it and marks it invalid. Emits the matching
+    /// builder-decision event and updates `diag`. Returns `true` when the transaction was parked.
+    fn defer_or_reject_current<B: PayloadTxsBounds>(
+        &self,
+        best_txs: &mut B,
+        diag: &mut FlashblockDiagnostics,
+        cx: &DecisionContext<'_>,
+        tx: &B::Transaction,
+        ordering_position: u64,
+    ) -> bool {
+        if best_txs.park_current() {
+            self.emit_builder_decision_event(
+                cx.payload_id,
+                TransactionEventType::BuilderDeferred,
+                *tx.hash(),
+                Some(ordering_position),
+                || BuilderDeferredEventData::new(cx.reason, cx.detail, cx.info, cx.limits, None),
+            );
+            diag.txs_deferred += 1;
+            true
+        } else {
+            self.emit_builder_decision_event(
+                cx.payload_id,
+                TransactionEventType::BuilderRejected,
+                *tx.hash(),
+                Some(ordering_position),
+                || {
+                    BuilderRejectedEventData::new(
+                        cx.reason, cx.detail, false, cx.info, cx.limits, None,
+                    )
+                },
+            );
+            diag.txs_rejected_other += 1;
+            best_txs.mark_invalid(tx.sender(), tx.nonce());
+            false
+        }
+    }
+
     /// Executes the given best transactions and updates the execution info.
     ///
     /// Returns diagnostics summarizing transaction selection for the flashblock.
@@ -811,6 +864,47 @@ impl BasePayloadBuilderCtx {
 
             let tx_hash = *tx.hash();
             let has_validity_predicates = !tx.validity_predicates().is_empty();
+
+            // Defer without evaluating once this flashblock's predicate-eval time budget is
+            // exhausted, rather than spending more IO on the naive per-transaction loop. The
+            // deferred transaction is never rejected from the pool, so it is picked up as a
+            // fresh candidate next flashblock, when the budget resets.
+            if has_validity_predicates
+                && predicate_eval_total
+                    .is_some_and(|total| total >= self.builder_config.predicate_eval_hard_cutoff)
+            {
+                num_txs_considered += 1;
+                let ordering_position = num_txs_considered;
+                trace!(
+                    target: "payload_builder",
+                    tx_hash = ?tx_hash,
+                    "deferring validity-gated transaction: predicate evaluation budget exhausted for this flashblock"
+                );
+                self.emit_builder_decision_event(
+                    &payload_id,
+                    TransactionEventType::BuilderConsidered,
+                    tx_hash,
+                    Some(ordering_position),
+                    || BuilderConsideredEventData::new(info, limits, None),
+                );
+                BuilderMetrics::validity_predicate_evaluations_total("budget_exhausted")
+                    .increment(1);
+                self.defer_or_reject_current(
+                    best_txs,
+                    &mut diag,
+                    &DecisionContext {
+                        payload_id: &payload_id,
+                        info,
+                        limits,
+                        reason: "predicate_eval_budget_exhausted",
+                        detail: "validity-predicate evaluation time budget exhausted for this flashblock",
+                    },
+                    &tx,
+                    ordering_position,
+                );
+                continue;
+            }
+
             let mut predicate_read_failed = false;
             let blocking_predicate = if has_validity_predicates {
                 match Self::accumulate_elapsed(&mut predicate_eval_total, || {
@@ -917,45 +1011,26 @@ impl BasePayloadBuilderCtx {
                         diag.permanently_rejected_txs.push(tx_hash);
                     }
                     best_txs.mark_invalid(tx.sender(), tx.nonce());
-                } else if let Some(blocking_predicate) = blocking_predicate
-                    && best_txs.park_current()
-                {
-                    self.emit_builder_decision_event(
-                        &payload_id,
-                        TransactionEventType::BuilderDeferred,
-                        tx_hash,
-                        Some(ordering_position),
-                        || {
-                            BuilderDeferredEventData::new(
-                                decision_reason,
-                                decision_detail,
-                                info,
-                                limits,
-                                None,
-                            )
-                        },
-                    );
-                    diag.txs_deferred += 1;
-                    predicate_index.park(tx_hash, tx, blocking_predicate);
                 } else {
-                    self.emit_builder_decision_event(
-                        &payload_id,
-                        TransactionEventType::BuilderRejected,
-                        tx_hash,
-                        Some(ordering_position),
-                        || {
-                            BuilderRejectedEventData::new(
-                                decision_reason,
-                                decision_detail,
-                                false,
-                                info,
-                                limits,
-                                None,
-                            )
+                    // Recoverable state mismatch: park under the current blocker to retry at a
+                    // later position or flashblock, or reject if the iterator cannot park it.
+                    let blocking_predicate = blocking_predicate
+                        .expect("unsatisfied, non-terminal predicate implies a blocking key");
+                    if self.defer_or_reject_current(
+                        best_txs,
+                        &mut diag,
+                        &DecisionContext {
+                            payload_id: &payload_id,
+                            info,
+                            limits,
+                            reason: decision_reason,
+                            detail: decision_detail,
                         },
-                    );
-                    diag.txs_rejected_other += 1;
-                    best_txs.mark_invalid(tx.sender(), tx.nonce());
+                        &tx,
+                        ordering_position,
+                    ) {
+                        predicate_index.park(tx_hash, tx, blocking_predicate);
+                    }
                 }
                 continue;
             }
@@ -1442,7 +1517,22 @@ impl BasePayloadBuilderCtx {
             // Release the committed transaction's lane before promoting predicate-unblocked heads.
             best_txs.mark_current_committed();
             let predicate_rescan_start = Instant::now();
-            for parked_hash in &state_change_effects.affected_transactions {
+            for (rescanned, parked_hash) in
+                state_change_effects.affected_transactions.iter().enumerate()
+            {
+                // Stop rescanning once this flashblock's predicate-eval time budget is
+                // exhausted. Remaining affected transactions stay parked under their current
+                // blocker exactly as they are; they are picked up as fresh candidates next
+                // flashblock, when the budget resets.
+                if predicate_eval_total
+                    .is_some_and(|total| total >= self.builder_config.predicate_eval_hard_cutoff)
+                {
+                    let remaining =
+                        (state_change_effects.affected_transactions.len() - rescanned) as u64;
+                    BuilderMetrics::validity_predicate_evaluations_total("rescan_budget_exhausted")
+                        .increment(remaining);
+                    break;
+                }
                 let mut predicate_read_failed = false;
                 let Some(parked_transaction) = predicate_index.transaction(*parked_hash) else {
                     warn!(

--- a/crates/builder/core/tests/ordering.rs
+++ b/crates/builder/core/tests/ordering.rs
@@ -180,6 +180,109 @@ async fn predicates_delay_priority_without_blocking_nonce_descendants() -> eyre:
     Ok(())
 }
 
+/// Once a flashblock's validity-predicate evaluation time budget is exhausted, further
+/// validity-gated transactions are deferred without evaluation rather than checked, even when
+/// their predicate is already satisfied. An ordinary transaction is unaffected by the cutoff, so
+/// it can be included in the same flashblock ahead of a higher-priority deferred transaction.
+#[tokio::test]
+async fn predicate_eval_hard_cutoff_defers_without_evaluating() -> eyre::Result<()> {
+    let instance =
+        LocalInstanceBuilder::new(BuilderConfig::for_tests().with_predicate_eval_hard_cutoff_ms(0))
+            .install_ext::<BuilderApiExtension>(BuilderApiExtensionConfig::new(
+                true,
+                DEFAULT_MAX_VALIDITY_PREDICATES,
+            ))
+            .build()
+            .await?;
+    let driver = instance.driver().await?;
+    let accounts = driver.fund_accounts(3, ONE_ETH).await?;
+
+    // Trivially satisfied for any real block number: proves deferral is due to the exhausted
+    // budget, not an unsatisfied predicate.
+    let always_satisfied = vec![ValidityPredicate::BlockNumber {
+        op: ValidityOperator::GreaterThanOrEqual,
+        value: U256::ZERO,
+    }];
+
+    let first = driver
+        .create_transaction()
+        .with_signer(&accounts[0])
+        .with_nonce(0)
+        .with_to(Address::random())
+        .with_max_priority_fee_per_gas(100)
+        .build()
+        .await;
+    let first_hash = first.tx_hash();
+    driver
+        .provider()
+        .raw_request::<_, ()>(
+            "base_insertValidatedTransaction".into(),
+            (ValidatedTransaction {
+                sender: accounts[0].address(),
+                raw: first.encoded_2718().into(),
+                min_block_number: None,
+                max_block_number: None,
+                min_timestamp: None,
+                max_timestamp: None,
+                extensions: TransactionValidity { validity: always_satisfied.clone() },
+            },),
+        )
+        .await?;
+
+    let deferred = driver
+        .create_transaction()
+        .with_signer(&accounts[1])
+        .with_nonce(0)
+        .with_to(Address::random())
+        .with_max_priority_fee_per_gas(90)
+        .build()
+        .await;
+    let deferred_hash = deferred.tx_hash();
+    driver
+        .provider()
+        .raw_request::<_, ()>(
+            "base_insertValidatedTransaction".into(),
+            (ValidatedTransaction {
+                sender: accounts[1].address(),
+                raw: deferred.encoded_2718().into(),
+                min_block_number: None,
+                max_block_number: None,
+                min_timestamp: None,
+                max_timestamp: None,
+                extensions: TransactionValidity { validity: always_satisfied },
+            },),
+        )
+        .await?;
+
+    let ordinary_hash = *driver
+        .create_transaction()
+        .with_signer(&accounts[2])
+        .with_nonce(0)
+        .with_to(Address::random())
+        .with_max_priority_fee_per_gas(50)
+        .send()
+        .await?
+        .tx_hash();
+
+    let block = driver.build_new_block().await?;
+    let tracked = [first_hash, deferred_hash, ordinary_hash];
+    let actual = block
+        .transactions
+        .into_transactions()
+        .filter_map(|transaction| {
+            tracked.contains(&transaction.tx_hash()).then(|| transaction.tx_hash())
+        })
+        .collect::<Vec<_>>();
+
+    // `first` is evaluated within budget and included immediately at its natural priority
+    // position. `deferred` has higher priority than `ordinary` but is skipped by the exhausted
+    // budget, so `ordinary` (unaffected by the cutoff) is included ahead of it; `deferred` is
+    // still included overall, just in a later flashblock once the budget resets.
+    assert_eq!(actual, [first_hash, ordinary_hash, deferred_hash]);
+
+    Ok(())
+}
+
 /// Shadow injection adds only builder-local metadata: the original signed transaction executes
 /// with the same hash, encoding, and state transition.
 #[tokio::test]


### PR DESCRIPTION
Stacked on #4511 (reuses its `predicate_eval_total` per-flashblock duration accumulator).

Adds a configurable hard cutoff on cumulative validity-predicate evaluation time per flashblock build — the enforcement side of the guardrail behind the `base_builder_predicate_eval_duration_per_block` metric. Per the BATS TDD, this is "the backstop that makes the naive loop safe."

- `BuilderConfig::predicate_eval_hard_cutoff: Duration`, default **10ms**. CLI: `--builder.predicate-eval-hard-cutoff-ms` (also defaults to 10).
- Enforced at both call sites of `ValidityPredicateKey::first_unsatisfied`:
  - **Main selection loop** — once the budget is exhausted, a net-new validity-gated candidate is deferred without evaluation (`best_txs.park_current()`), rather than checked.
  - **Parked-predicate rescan loop** — once exhausted, remaining affected transactions are left parked under their current blocker rather than rescanned.
- No extra bookkeeping needed for retry: parking never removes a transaction from the pool, and both `predicate_index` and `best_txs`' parked set are rebuilt from scratch every flashblock (`refresh_iterator` re-queries the pool; `execute_best_transactions` creates a fresh `predicate_index`). So anything merely parked reappears as a normal candidate once the budget resets on the next flashblock — no sentinel key or explicit re-queue logic required.
- Reuses the existing `validity_predicate_evaluations_total{outcome=...}` counter with two new outcome values (`budget_exhausted`, `rescan_budget_exhausted`) instead of adding a parallel metric.

New integration test (`predicate_eval_hard_cutoff_defers_without_evaluating` in `tests/ordering.rs`) proves deferral via ordering inversion: with the cutoff set to 0ms, a higher-priority validity-gated transaction evaluated second in a flashblock gets deferred past an ordinary (unaffected) transaction of lower priority, and is still included later once the budget resets — mirroring the existing predicate-delay test's proof technique.

---

**Refactor note:** the two "can't include this validity-gated candidate right now" sites (budget-exhausted, and the pre-existing not-satisfied-but-recoverable case) now share one `defer_or_reject_current` helper — park for a later flashblock, or reject + `mark_invalid` if the iterator can't park. This removed the duplicated park/reject-with-events tail and shrank the core selection loop rather than growing it. The helper takes a small `DecisionContext` bundle (payload_id / info / limits / reason / detail) to stay within the arg-count lint without an `#[allow]`.

A broader refactor of the ~350-line selection loop (introducing a per-flashblock selection-context so state isn't threaded through by hand) is tracked separately and will stack on top of this PR.
