### PR TITLE
feat(builder): throttle fresh storage slot bursts

### DIFF
--- a/crates/builder/cli/src/args.rs
+++ b/crates/builder/cli/src/args.rs
@@ -87,6 +87,22 @@ pub struct Args {
     #[arg(long = "builder.execution-metering-mode", value_enum, default_value = "off")]
     pub execution_metering_mode: ExecutionMeteringMode,
 
+    /// Maximum cumulative fresh storage slots created by txpool transactions per block
+    #[arg(
+        long = "builder.max-new-storage-slots-per-block",
+        env = "BUILDER_MAX_NEW_STORAGE_SLOTS_PER_BLOCK"
+    )]
+    pub max_new_storage_slots_per_block: Option<u64>,
+
+    /// Fresh storage slot throttle mode: off, dry-run, or enforce
+    #[arg(
+        long = "builder.new-storage-slot-throttle-mode",
+        env = "BUILDER_NEW_STORAGE_SLOT_THROTTLE_MODE",
+        value_enum,
+        default_value = "off"
+    )]
+    pub new_storage_slot_throttle_mode: ExecutionMeteringMode,
+
     /// How much extra time to wait for the block building job to complete and not get garbage collected
     #[arg(long = "builder.extra-block-deadline-secs", default_value = "20")]
     pub extra_block_deadline_secs: u64,
@@ -165,6 +181,8 @@ impl Default for Args {
             state_root_gas_coefficient: 0.02,
             state_root_gas_anchor_us: 5000,
             execution_metering_mode: ExecutionMeteringMode::Off,
+            max_new_storage_slots_per_block: None,
+            new_storage_slot_throttle_mode: ExecutionMeteringMode::Off,
             extra_block_deadline_secs: 20,
             enable_resource_metering: false,
             max_uncompressed_block_size: None,
@@ -213,6 +231,8 @@ impl Args {
             state_root_gas_coefficient: self.state_root_gas_coefficient,
             state_root_gas_anchor_us: self.state_root_gas_anchor_us,
             execution_metering_mode: self.execution_metering_mode,
+            max_new_storage_slots_per_block: self.max_new_storage_slots_per_block,
+            new_storage_slot_throttle_mode: self.new_storage_slot_throttle_mode,
             max_uncompressed_block_size: self.max_uncompressed_block_size,
             metering_wait_duration: self.metering_wait_duration_ms.map(Duration::from_millis),
             metering_provider,
@@ -229,14 +249,21 @@ impl Args {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{ffi::OsStr, sync::Arc};
 
     use alloy_primitives::{B256, TxHash, U256};
     use base_builder_core::{MeteringProvider, NoopMeteringProvider};
     use base_bundles::MeterBundleResponse;
+    use clap::{CommandFactory, Parser};
     use rstest::rstest;
 
     use super::*;
+
+    #[derive(clap::Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        args: Args,
+    }
 
     fn convert(args: Args) -> BuilderConfig {
         let metering_provider: SharedMeteringProvider = Arc::new(NoopMeteringProvider);
@@ -268,6 +295,48 @@ mod tests {
         let args = Args { max_gas_per_txn: input, ..Default::default() };
         let config = convert(args);
         assert_eq!(config.max_gas_per_txn, expected);
+    }
+
+    #[test]
+    fn new_storage_slot_throttle_maps_correctly() {
+        let args = Args {
+            max_new_storage_slots_per_block: Some(10_000),
+            new_storage_slot_throttle_mode: ExecutionMeteringMode::DryRun,
+            ..Default::default()
+        };
+        let config = convert(args);
+
+        assert_eq!(config.max_new_storage_slots_per_block, Some(10_000));
+        assert_eq!(config.new_storage_slot_throttle_mode, ExecutionMeteringMode::DryRun);
+    }
+
+    #[test]
+    fn new_storage_slot_throttle_has_direct_environment_bindings() {
+        let parsed = TestCli::parse_from([
+            "test",
+            "--builder.max-new-storage-slots-per-block",
+            "123",
+            "--builder.new-storage-slot-throttle-mode",
+            "enforce",
+        ]);
+        assert_eq!(parsed.args.max_new_storage_slots_per_block, Some(123));
+        assert_eq!(parsed.args.new_storage_slot_throttle_mode, ExecutionMeteringMode::Enforce);
+
+        let command = TestCli::command();
+        let max_slots = command
+            .get_arguments()
+            .find(|arg| arg.get_long() == Some("builder.max-new-storage-slots-per-block"))
+            .expect("max slots argument should exist");
+        assert_eq!(
+            max_slots.get_env(),
+            Some(OsStr::new("BUILDER_MAX_NEW_STORAGE_SLOTS_PER_BLOCK"))
+        );
+
+        let mode = command
+            .get_arguments()
+            .find(|arg| arg.get_long() == Some("builder.new-storage-slot-throttle-mode"))
+            .expect("throttle mode argument should exist");
+        assert_eq!(mode.get_env(), Some(OsStr::new("BUILDER_NEW_STORAGE_SLOT_THROTTLE_MODE")));
     }
 
     #[rstest]

--- a/crates/builder/core/src/config.rs
+++ b/crates/builder/core/src/config.rs
@@ -70,6 +70,12 @@ pub struct BuilderConfig {
     /// Execution metering mode: off, dry-run, or enforce.
     pub execution_metering_mode: ExecutionMeteringMode,
 
+    /// Maximum cumulative fresh storage slots created by txpool transactions per block.
+    pub max_new_storage_slots_per_block: Option<u64>,
+
+    /// Fresh storage slot throttle mode: off, dry-run, or enforce.
+    pub new_storage_slot_throttle_mode: ExecutionMeteringMode,
+
     /// Maximum cumulative uncompressed (EIP-2718 encoded) block size in bytes.
     pub max_uncompressed_block_size: Option<u64>,
 
@@ -125,6 +131,8 @@ impl core::fmt::Debug for BuilderConfig {
             .field("state_root_gas_coefficient", &self.state_root_gas_coefficient)
             .field("state_root_gas_anchor_us", &self.state_root_gas_anchor_us)
             .field("execution_metering_mode", &self.execution_metering_mode)
+            .field("max_new_storage_slots_per_block", &self.max_new_storage_slots_per_block)
+            .field("new_storage_slot_throttle_mode", &self.new_storage_slot_throttle_mode)
             .field("max_uncompressed_block_size", &self.max_uncompressed_block_size)
             .field("metering_wait_duration", &self.metering_wait_duration)
             .field("metering_provider", &self.metering_provider)
@@ -154,6 +162,8 @@ impl Default for BuilderConfig {
             state_root_gas_coefficient: 0.02,
             state_root_gas_anchor_us: 5_000,
             execution_metering_mode: ExecutionMeteringMode::Off,
+            max_new_storage_slots_per_block: None,
+            new_storage_slot_throttle_mode: ExecutionMeteringMode::Off,
             max_uncompressed_block_size: None,
             metering_wait_duration: None,
             metering_provider: Arc::new(NoopMeteringProvider),

--- a/crates/builder/core/src/execution.rs
+++ b/crates/builder/core/src/execution.rs
@@ -333,7 +333,7 @@ impl ExecutionInfo {
     }
 
     /// Checks whether adding a transaction's fresh storage slots would exceed the block limit.
-    pub fn check_new_storage_slots(
+    pub const fn check_new_storage_slots(
         &self,
         tx_new_slots: u64,
         block_limit: u64,

--- a/crates/builder/core/src/execution.rs
+++ b/crates/builder/core/src/execution.rs
@@ -12,6 +12,7 @@ use base_bundles::RejectedTransaction;
 use base_common_consensus::{BaseReceipt, BaseTransactionSigned};
 use base_common_evm::BaseTransactionError;
 use derive_more::Display;
+use revm::state::EvmState;
 use thiserror::Error;
 
 /// Resource limits configuration for transaction and block constraints.
@@ -46,6 +47,8 @@ pub struct ResourceLimits {
     pub block_state_root_gas_limit: Option<u64>,
     /// Maximum cumulative uncompressed (EIP-2718 encoded) block size in bytes (optional).
     pub block_uncompressed_size_limit: Option<u64>,
+    /// Maximum cumulative fresh storage slots created by txpool transactions per block (optional).
+    pub block_new_storage_slots_limit: Option<u64>,
 }
 
 /// Resource usage for a single transaction.
@@ -144,6 +147,19 @@ pub enum TxnExecutionError {
         block_limit: u64,
     },
 
+    /// Block fresh storage slot limit exceeded.
+    #[error(
+        "block new storage slots exceeded: cumulative={cumulative} tx_new_slots={tx_new_slots} block_limit={block_limit}"
+    )]
+    BlockNewStorageSlotsExceeded {
+        /// Fresh storage slots created by previously included txpool transactions.
+        cumulative: u64,
+        /// Fresh storage slots created by this transaction.
+        tx_new_slots: u64,
+        /// Block fresh storage slot limit.
+        block_limit: u64,
+    },
+
     // Execution metering limits (optionally enforced, depend on metering service predictions)
     /// Execution metering limit exceeded (execution time or state root time).
     #[error("{0}")]
@@ -176,6 +192,35 @@ pub enum TxnExecutionError {
 }
 
 impl TxnExecutionError {
+    /// Returns the stable machine-readable rejection code used by logs and metrics.
+    pub const fn rejection_code(&self) -> &'static str {
+        match self {
+            Self::TransactionDASizeExceeded(_, _) => "tx_da_size_exceeded",
+            Self::BlockDASizeExceeded { .. } => "block_da_size_exceeded",
+            Self::DAFootprintLimitExceeded { .. } => "da_footprint_limit_exceeded",
+            Self::TransactionGasLimitExceeded { .. } => "transaction_gas_limit_exceeded",
+            Self::BlockUncompressedSizeExceeded { .. } => "block_uncompressed_size_exceeded",
+            Self::BlockNewStorageSlotsExceeded { .. } => "block_new_storage_slots_exceeded",
+            Self::ExecutionMeteringLimitExceeded(inner) => match inner {
+                ExecutionMeteringLimitExceeded::TransactionExecutionTime(_, _) => {
+                    "tx_execution_time_exceeded"
+                }
+                ExecutionMeteringLimitExceeded::FlashblockExecutionTime(_, _, _) => {
+                    "flashblock_execution_time_exceeded"
+                }
+                ExecutionMeteringLimitExceeded::BlockStateRootGas(_, _, _) => {
+                    "block_state_root_gas_exceeded"
+                }
+            },
+            Self::SequencerTransaction => "sequencer_transaction",
+            Self::NonceTooLow => "nonce_too_low",
+            Self::InternalError(_) => "internal_error",
+            Self::EvmError => "evm_error",
+            Self::MaxGasUsageExceeded => "max_gas_usage_exceeded",
+            Self::MeteringDataPending => "metering_data_pending",
+        }
+    }
+
     /// Returns `true` if this rejection is permanent — the transaction will never be includable
     /// regardless of block/flashblock cumulative state. Permanent rejections are intrinsic to
     /// the transaction itself (e.g. its size or predicted execution time exceeds the per-tx limit).
@@ -241,6 +286,8 @@ pub struct ExecutionInfo {
     pub cumulative_state_root_gas: u64,
     /// Cumulative uncompressed (EIP-2718 encoded) bytes used in the block
     pub cumulative_uncompressed_bytes: u64,
+    /// Cumulative fresh storage slots created by txpool transactions in the block.
+    pub cumulative_new_storage_slots: u64,
     /// Tracks fees from executed mempool transactions
     pub total_fees: U256,
     /// Extra execution information for the Flashblocks builder
@@ -263,6 +310,7 @@ impl ExecutionInfo {
             flashblock_execution_time_us: 0,
             cumulative_state_root_gas: 0,
             cumulative_uncompressed_bytes: 0,
+            cumulative_new_storage_slots: 0,
             total_fees: U256::ZERO,
             extra: Default::default(),
             da_footprint_scalar: None,
@@ -273,6 +321,39 @@ impl ExecutionInfo {
     /// Reset the flashblock-scoped execution time budget for a new flashblock.
     pub const fn reset_flashblock_execution_time(&mut self) {
         self.flashblock_execution_time_us = 0;
+    }
+
+    /// Counts changed storage slots whose value transitions from zero to non-zero.
+    pub fn count_new_storage_slots(state: &EvmState) -> u64 {
+        state
+            .values()
+            .flat_map(|account| account.storage.values())
+            .filter(|slot| slot.original_value().is_zero() && !slot.present_value().is_zero())
+            .fold(0, |count, _| count.saturating_add(1))
+    }
+
+    /// Checks whether adding a transaction's fresh storage slots would exceed the block limit.
+    pub fn check_new_storage_slots(
+        &self,
+        tx_new_slots: u64,
+        block_limit: u64,
+    ) -> Result<(), TxnExecutionError> {
+        if tx_new_slots > 0
+            && self.cumulative_new_storage_slots.saturating_add(tx_new_slots) > block_limit
+        {
+            return Err(TxnExecutionError::BlockNewStorageSlotsExceeded {
+                cumulative: self.cumulative_new_storage_slots,
+                tx_new_slots,
+                block_limit,
+            });
+        }
+        Ok(())
+    }
+
+    /// Adds a committed transaction's fresh storage slots to the block total.
+    pub const fn record_new_storage_slots(&mut self, tx_new_slots: u64) {
+        self.cumulative_new_storage_slots =
+            self.cumulative_new_storage_slots.saturating_add(tx_new_slots);
     }
 
     /// Returns true if the transaction would exceed the block limits:
@@ -387,11 +468,26 @@ impl ExecutionInfo {
 
 #[cfg(test)]
 mod tests {
+    use revm::state::{Account, EvmStorageSlot, TransactionId};
+
     use super::*;
 
     /// Helper to create default limits with block gas limit set
     fn default_limits() -> ResourceLimits {
         ResourceLimits { block_gas_limit: 30_000_000, ..Default::default() }
+    }
+
+    fn state_with_slots(slots: &[(U256, U256, U256)]) -> EvmState {
+        let mut account = Account::default();
+        for (key, original, present) in slots {
+            account.storage.insert(
+                *key,
+                EvmStorageSlot::new_changed(*original, *present, TransactionId::ZERO),
+            );
+        }
+        let mut state = EvmState::default();
+        state.insert(Address::ZERO, account);
+        state
     }
 
     // ==================== Basic Limit Tests ====================
@@ -828,5 +924,91 @@ mod tests {
             TxResources { gas_limit: 21_000, uncompressed_size: 1_000_000, ..Default::default() };
 
         assert!(info.is_tx_over_limits(&tx, &limits).is_ok());
+    }
+
+    #[test]
+    fn counts_only_zero_to_nonzero_storage_transitions() {
+        let state = state_with_slots(&[
+            (U256::from(1), U256::ZERO, U256::from(10)),
+            (U256::from(2), U256::from(5), U256::from(10)),
+            (U256::from(3), U256::from(5), U256::ZERO),
+            (U256::from(4), U256::ZERO, U256::ZERO),
+        ]);
+
+        assert_eq!(ExecutionInfo::count_new_storage_slots(&state), 1);
+    }
+
+    #[test]
+    fn duplicate_writes_to_one_fresh_slot_count_once() {
+        let mut state = state_with_slots(&[(U256::from(1), U256::ZERO, U256::from(10))]);
+        let account = state.get_mut(&Address::ZERO).expect("account exists");
+        account.storage.insert(
+            U256::from(1),
+            EvmStorageSlot::new_changed(U256::ZERO, U256::from(20), TransactionId::ZERO),
+        );
+
+        assert_eq!(ExecutionInfo::count_new_storage_slots(&state), 1);
+    }
+
+    #[test]
+    fn reverted_state_consumes_no_fresh_storage_slots() {
+        assert_eq!(ExecutionInfo::count_new_storage_slots(&EvmState::default()), 0);
+    }
+
+    #[test]
+    fn fresh_storage_slot_limit_allows_exact_limit() {
+        let mut info = ExecutionInfo::with_capacity(1);
+        info.cumulative_new_storage_slots = 8;
+
+        assert!(info.check_new_storage_slots(2, 10).is_ok());
+    }
+
+    #[test]
+    fn fresh_storage_slot_limit_does_not_reject_zero_slot_transactions_after_dry_run_excess() {
+        let mut info = ExecutionInfo::with_capacity(1);
+        info.cumulative_new_storage_slots = 11;
+
+        assert!(info.check_new_storage_slots(0, 10).is_ok());
+    }
+
+    #[test]
+    fn fresh_storage_slot_limit_is_transient_and_reports_usage() {
+        let mut info = ExecutionInfo::with_capacity(1);
+        info.cumulative_new_storage_slots = 8;
+
+        let err = info.check_new_storage_slots(3, 10).expect_err("limit should be exceeded");
+        assert!(matches!(
+            err,
+            TxnExecutionError::BlockNewStorageSlotsExceeded {
+                cumulative: 8,
+                tx_new_slots: 3,
+                block_limit: 10,
+            }
+        ));
+        assert_eq!(err.rejection_code(), "block_new_storage_slots_exceeded");
+        assert!(!err.is_permanent());
+    }
+
+    #[test]
+    fn fresh_storage_slot_accumulation_saturates() {
+        let mut info = ExecutionInfo::with_capacity(1);
+        info.cumulative_new_storage_slots = u64::MAX - 1;
+
+        info.record_new_storage_slots(10);
+
+        assert_eq!(info.cumulative_new_storage_slots, u64::MAX);
+        assert!(info.check_new_storage_slots(1, u64::MAX).is_ok());
+    }
+
+    #[test]
+    fn fresh_storage_slots_accumulate_across_flashblocks() {
+        let mut info = ExecutionInfo::with_capacity(2);
+        info.record_new_storage_slots(4);
+        info.reset_flashblock_execution_time();
+        info.record_new_storage_slots(5);
+
+        assert_eq!(info.cumulative_new_storage_slots, 9);
+        assert!(info.check_new_storage_slots(1, 10).is_ok());
+        assert!(info.check_new_storage_slots(2, 10).is_err());
     }
 }

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -46,33 +46,7 @@ use crate::{
 
 /// Records the priority fee of a rejected transaction with the given reason as a label.
 fn record_rejected_tx_priority_fee(reason: &TxnExecutionError, priority_fee: f64) {
-    let r = match reason {
-        TxnExecutionError::TransactionDASizeExceeded(_, _) => "tx_da_size_exceeded",
-        TxnExecutionError::BlockDASizeExceeded { .. } => "block_da_size_exceeded",
-        TxnExecutionError::DAFootprintLimitExceeded { .. } => "da_footprint_limit_exceeded",
-        TxnExecutionError::TransactionGasLimitExceeded { .. } => "transaction_gas_limit_exceeded",
-        TxnExecutionError::BlockUncompressedSizeExceeded { .. } => {
-            "block_uncompressed_size_exceeded"
-        }
-        TxnExecutionError::MeteringDataPending => "metering_data_pending",
-        TxnExecutionError::ExecutionMeteringLimitExceeded(inner) => match inner {
-            ExecutionMeteringLimitExceeded::TransactionExecutionTime(_, _) => {
-                "tx_execution_time_exceeded"
-            }
-            ExecutionMeteringLimitExceeded::FlashblockExecutionTime(_, _, _) => {
-                "flashblock_execution_time_exceeded"
-            }
-            ExecutionMeteringLimitExceeded::BlockStateRootGas(_, _, _) => {
-                "block_state_root_gas_exceeded"
-            }
-        },
-        TxnExecutionError::SequencerTransaction => "sequencer_transaction",
-        TxnExecutionError::NonceTooLow => "nonce_too_low",
-        TxnExecutionError::InternalError(_) => "internal_error",
-        TxnExecutionError::EvmError => "evm_error",
-        TxnExecutionError::MaxGasUsageExceeded => "max_gas_usage_exceeded",
-    };
-    BuilderMetrics::rejected_tx_priority_fee(r).record(priority_fee);
+    BuilderMetrics::rejected_tx_priority_fee(reason.rejection_code()).record(priority_fee);
 }
 
 /// Diagnostics captured during a single flashblock's transaction execution.
@@ -121,6 +95,8 @@ pub struct FlashblockDiagnostics {
     pub txs_rejected_state_root_time: u64,
     /// Number rejected by uncompressed size limit.
     pub txs_rejected_uncompressed_size: u64,
+    /// Number rejected by the block fresh storage slot limit.
+    pub txs_rejected_new_storage_slots: u64,
     /// Number skipped because metering data has not yet arrived.
     pub txs_rejected_metering_data_pending: u64,
     /// Number rejected or skipped for other reasons.
@@ -144,7 +120,7 @@ impl FlashblockDiagnostics {
     }
 
     /// Returns the rejection counts keyed by their metric/log reason labels.
-    pub const fn rejection_counts(&self) -> [(&'static str, u64); 8] {
+    pub const fn rejection_counts(&self) -> [(&'static str, u64); 9] {
         [
             ("gas_limit", self.txs_rejected_gas),
             ("da_size", self.txs_rejected_da),
@@ -152,6 +128,7 @@ impl FlashblockDiagnostics {
             ("execution_time", self.txs_rejected_execution_time),
             ("state_root_time", self.txs_rejected_state_root_time),
             ("uncompressed_size", self.txs_rejected_uncompressed_size),
+            ("new_storage_slots", self.txs_rejected_new_storage_slots),
             ("metering_data_pending", self.txs_rejected_metering_data_pending),
             ("other", self.txs_rejected_other),
         ]
@@ -173,6 +150,7 @@ impl FlashblockDiagnostics {
             + self.txs_rejected_execution_time
             + self.txs_rejected_state_root_time
             + self.txs_rejected_uncompressed_size
+            + self.txs_rejected_new_storage_slots
             + self.txs_rejected_metering_data_pending
             + self.txs_rejected_other
     }
@@ -192,6 +170,9 @@ impl FlashblockDiagnostics {
             }
             TxnExecutionError::BlockUncompressedSizeExceeded { .. } => {
                 self.txs_rejected_uncompressed_size += 1;
+            }
+            TxnExecutionError::BlockNewStorageSlotsExceeded { .. } => {
+                self.txs_rejected_new_storage_slots += 1;
             }
             TxnExecutionError::ExecutionMeteringLimitExceeded(inner) => match inner {
                 ExecutionMeteringLimitExceeded::TransactionExecutionTime(_, _)
@@ -674,6 +655,8 @@ impl BasePayloadBuilderCtx {
             flashblock_execution_time_limit_us = ?limits.flashblock_execution_time_limit_us,
             block_state_root_gas_limit = ?limits.block_state_root_gas_limit,
             execution_metering_mode = ?self.builder_config.execution_metering_mode,
+            block_new_storage_slots_limit = ?limits.block_new_storage_slots_limit,
+            new_storage_slot_throttle_mode = ?self.builder_config.new_storage_slot_throttle_mode,
         );
 
         let block_number = as_u64_saturated!(self.evm_env.block_env.number);
@@ -941,8 +924,49 @@ impl BasePayloadBuilderCtx {
             // Record state modification counts (trie work proxy)
             let accounts_modified = state.len();
             let storage_slots_modified: usize = state.values().map(|a| a.storage.len()).sum();
+            let new_storage_slots = ExecutionInfo::count_new_storage_slots(&state);
             BuilderMetrics::tx_accounts_modified().record(accounts_modified as f64);
             BuilderMetrics::tx_storage_slots_modified().record(storage_slots_modified as f64);
+            BuilderMetrics::tx_new_storage_slots().record(new_storage_slots as f64);
+
+            if self.builder_config.new_storage_slot_throttle_mode.is_enabled()
+                && let Some(block_limit) = limits.block_new_storage_slots_limit
+                && let Err(err) = info.check_new_storage_slots(new_storage_slots, block_limit)
+            {
+                BuilderMetrics::new_storage_slot_throttle_would_reject_total().increment(1);
+                let dry_run = self.builder_config.new_storage_slot_throttle_mode.is_dry_run();
+                let priority_fee = tx.effective_tip_per_gas(base_fee).unwrap_or(0) as f64;
+
+                debug!(
+                    target: "payload_builder",
+                    rejection_code = err.rejection_code(),
+                    cumulative_new_storage_slots = info.cumulative_new_storage_slots,
+                    tx_new_storage_slots = new_storage_slots,
+                    block_limit,
+                    priority_fee,
+                    dry_run,
+                    "Fresh storage slot throttle exceeded"
+                );
+
+                if !dry_run {
+                    BuilderMetrics::new_storage_slot_throttle_rejected_total().increment(1);
+                    diag.record_rejection(&err);
+                    record_rejected_tx_priority_fee(&err, priority_fee);
+                    self.record_rejected_tx(
+                        info,
+                        tx_hash,
+                        RejectionReason::NewStorageSlotsExceeded {
+                            cumulative: info.cumulative_new_storage_slots,
+                            tx_new_slots: new_storage_slots,
+                            block_limit,
+                        },
+                        resource_usage.unwrap_or_default(),
+                    );
+                    log_txn(Err(err));
+                    best_txs.mark_invalid(tx.signer(), tx.nonce());
+                    continue;
+                }
+            }
 
             // Record execution time for unmetered transactions (race condition indicator)
             if resource_usage.is_none() {
@@ -991,6 +1015,8 @@ impl BasePayloadBuilderCtx {
             info.cumulative_da_bytes_used += tx_da_size;
             // record uncompressed tx size
             info.cumulative_uncompressed_bytes += tx_uncompressed_size;
+            // record fresh storage slots created by committed txpool transactions
+            info.record_new_storage_slots(new_storage_slots);
             // record execution time (only from predictions; unmetered txs count as zero)
             if let Some(execution_time) = predicted_execution_time_us {
                 info.flashblock_execution_time_us += execution_time;
@@ -1228,6 +1254,7 @@ mod tests {
                 ("execution_time", 0),
                 ("state_root_time", 1),
                 ("uncompressed_size", 0),
+                ("new_storage_slots", 0),
                 ("metering_data_pending", 0),
                 ("other", 0),
             ]
@@ -1245,6 +1272,19 @@ mod tests {
         assert_eq!(diag.txs_rejected_metering_data_pending, 1);
         assert_eq!(diag.txs_rejected_other, 3);
         assert_eq!(diag.txs_rejected_total(), 4);
+    }
+
+    #[test]
+    fn diagnostics_bucket_new_storage_slot_rejections() {
+        let mut diag = FlashblockDiagnostics::default();
+        diag.record_rejection(&TxnExecutionError::BlockNewStorageSlotsExceeded {
+            cumulative: 8,
+            tx_new_slots: 3,
+            block_limit: 10,
+        });
+
+        assert_eq!(diag.txs_rejected_new_storage_slots, 1);
+        assert_eq!(diag.rejection_reasons(), vec!["new_storage_slots"]);
     }
 
     #[test]

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -627,6 +627,7 @@ where
             flashblock_execution_time_limit_us,
             block_state_root_gas_limit: target_state_root_gas_for_batch,
             block_uncompressed_size_limit: ctx.builder_config.max_uncompressed_block_size,
+            block_new_storage_slots_limit: ctx.builder_config.max_new_storage_slots_per_block,
         };
         let diag = ctx
             .execute_best_transactions(info, state, best_txs, &limits)
@@ -847,6 +848,7 @@ where
 
         // Record cumulative uncompressed block size
         BuilderMetrics::block_uncompressed_size().record(info.cumulative_uncompressed_bytes as f64);
+        BuilderMetrics::block_new_storage_slots().record(info.cumulative_new_storage_slots as f64);
 
         debug!(
             target: "payload_builder",

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -209,6 +209,14 @@ base_metrics::define_metrics! {
     tx_accounts_modified: histogram,
     #[describe("Number of storage slots modified by a transaction (from EVM post-state)")]
     tx_storage_slots_modified: histogram,
+    #[describe("Number of fresh storage slots created by a transaction (from EVM post-state)")]
+    tx_new_storage_slots: histogram,
+    #[describe("Cumulative fresh storage slots created by txpool transactions per block")]
+    block_new_storage_slots: histogram,
+    #[describe("Transactions that would exceed the block fresh storage slot limit")]
+    new_storage_slot_throttle_would_reject_total: counter,
+    #[describe("Transactions rejected by the block fresh storage slot throttle")]
+    new_storage_slot_throttle_rejected_total: counter,
     #[describe("Rejected transaction batch drops due to full forwarding channel")]
     rejected_tx_channel_drops: counter,
     #[describe("Rejected transaction drops due to per-block accumulation limit")]
@@ -353,6 +361,10 @@ mod tests {
 
         metrics::with_local_recorder(&recorder, || {
             BuilderMetrics::record_flashblock_diagnostics(7, &diag, &info, &limits);
+            BuilderMetrics::tx_new_storage_slots().record(2.0);
+            BuilderMetrics::block_new_storage_slots().record(9.0);
+            BuilderMetrics::new_storage_slot_throttle_would_reject_total().increment(1);
+            BuilderMetrics::new_storage_slot_throttle_rejected_total().increment(1);
         });
 
         let rendered = handle.render();
@@ -382,5 +394,9 @@ mod tests {
         assert!(rendered.contains(
             "base_builder_flashblock_min_priority_fee_above_threshold_total{flashblock_index=\"7\",threshold=\"100wei\"} 1"
         ));
+        assert!(rendered.contains("base_builder_tx_new_storage_slots"));
+        assert!(rendered.contains("base_builder_block_new_storage_slots"));
+        assert!(rendered.contains("base_builder_new_storage_slot_throttle_would_reject_total 1"));
+        assert!(rendered.contains("base_builder_new_storage_slot_throttle_rejected_total 1"));
     }
 }

--- a/crates/builder/core/tests/flashblocks.rs
+++ b/crates/builder/core/tests/flashblocks.rs
@@ -4,12 +4,14 @@ use std::time::Duration;
 
 use alloy_primitives::{Address, B256, U256};
 use base_builder_core::{
-    BuilderConfig,
+    BuilderConfig, ExecutionMeteringMode,
     test_utils::{
-        TransactionBuilderExt, default_node_config_with_azul, funded_signer,
-        setup_test_instance_with_builder_config, setup_test_instance_with_node_config,
+        BlockTransactionsExt, ChainDriverExt, ONE_ETH, TransactionBuilderExt,
+        default_node_config_with_azul, funded_signer, setup_test_instance_with_builder_config,
+        setup_test_instance_with_node_config,
     },
 };
+use base_test_utils::DoubleCounter;
 
 /// Verify that pre-Base-Azul flashblock metadata contains `new_account_balances`
 /// and `receipts` (but no `access_list`).
@@ -149,6 +151,98 @@ async fn test_flashblock_metadata_post_base_azul() -> eyre::Result<()> {
     }
 
     flashblocks_listener.stop().await
+}
+
+/// Dry-run mode observes a block-level fresh-slot excess without excluding any transaction.
+#[tokio::test]
+async fn new_storage_slot_throttle_dry_run_includes_excess_transaction() -> eyre::Result<()> {
+    let mut config = BuilderConfig::for_tests();
+    config.max_new_storage_slots_per_block = Some(2);
+    config.new_storage_slot_throttle_mode = ExecutionMeteringMode::DryRun;
+    let rbuilder = setup_test_instance_with_builder_config(config).await?;
+    let driver = rbuilder.driver().await?;
+    let signers = driver.fund_accounts(3, ONE_ETH).await?;
+
+    let deployment_a = driver
+        .create_transaction()
+        .with_signer(&signers[0])
+        .with_create()
+        .with_input(DoubleCounter::BYTECODE.clone())
+        .with_gas_limit(500_000)
+        .with_max_priority_fee_per_gas(100)
+        .send()
+        .await?;
+    let deployment_b = driver
+        .create_transaction()
+        .with_signer(&signers[1])
+        .with_create()
+        .with_input(DoubleCounter::BYTECODE.clone())
+        .with_gas_limit(500_000)
+        .with_max_priority_fee_per_gas(90)
+        .send()
+        .await?;
+    let ordinary_transfer = driver
+        .create_transaction()
+        .with_signer(&signers[2])
+        .with_to(Address::repeat_byte(0x11))
+        .with_value(1)
+        .with_max_priority_fee_per_gas(80)
+        .send()
+        .await?;
+
+    let block = driver.build_new_block_with_current_timestamp(None).await?;
+
+    assert!(block.includes(deployment_a.tx_hash()));
+    assert!(block.includes(deployment_b.tx_hash()));
+    assert!(block.includes(ordinary_transfer.tx_hash()));
+    Ok(())
+}
+
+/// Enforce mode skips before commit, leaves ordinary transactions unaffected, and retries next block.
+#[tokio::test]
+async fn new_storage_slot_throttle_enforces_per_block_and_retries() -> eyre::Result<()> {
+    let mut config = BuilderConfig::for_tests();
+    config.max_new_storage_slots_per_block = Some(2);
+    config.new_storage_slot_throttle_mode = ExecutionMeteringMode::Enforce;
+    let rbuilder = setup_test_instance_with_builder_config(config).await?;
+    let driver = rbuilder.driver().await?;
+    let signers = driver.fund_accounts(3, ONE_ETH).await?;
+
+    let deployment_a = driver
+        .create_transaction()
+        .with_signer(&signers[0])
+        .with_create()
+        .with_input(DoubleCounter::BYTECODE.clone())
+        .with_gas_limit(500_000)
+        .with_max_priority_fee_per_gas(100)
+        .send()
+        .await?;
+    let deployment_b = driver
+        .create_transaction()
+        .with_signer(&signers[1])
+        .with_create()
+        .with_input(DoubleCounter::BYTECODE.clone())
+        .with_gas_limit(500_000)
+        .with_max_priority_fee_per_gas(90)
+        .send()
+        .await?;
+    let ordinary_transfer = driver
+        .create_transaction()
+        .with_signer(&signers[2])
+        .with_to(Address::repeat_byte(0x22))
+        .with_value(1)
+        .with_max_priority_fee_per_gas(80)
+        .send()
+        .await?;
+
+    let block_one = driver.build_new_block_with_current_timestamp(None).await?;
+    assert!(block_one.includes(deployment_a.tx_hash()));
+    assert!(!block_one.includes(deployment_b.tx_hash()));
+    assert!(block_one.includes(ordinary_transfer.tx_hash()));
+
+    let block_two = driver.build_new_block_with_current_timestamp(None).await?;
+    assert!(block_two.includes(deployment_b.tx_hash()));
+    Ok(())
 }
 
 /// Test that state root is computed on finalization:

--- a/crates/common/bundles/src/rejected.rs
+++ b/crates/common/bundles/src/rejected.rs
@@ -16,6 +16,15 @@ pub enum RejectionReason {
         /// Per-transaction limit in microseconds.
         limit_us: u128,
     },
+    /// A transaction would cause the block to exceed its fresh storage slot limit.
+    NewStorageSlotsExceeded {
+        /// Fresh storage slots created by previously included txpool transactions.
+        cumulative: u64,
+        /// Fresh storage slots created by this transaction.
+        tx_new_slots: u64,
+        /// Block fresh storage slot limit.
+        block_limit: u64,
+    },
 }
 
 /// A transaction that was rejected during block building.
@@ -32,4 +41,31 @@ pub struct RejectedTransaction {
     pub timestamp: u64,
     /// The metering simulation response that informed the rejection decision.
     pub metering: MeterBundleResponse,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn new_storage_slots_rejection_serializes_with_stable_fields() {
+        let reason = RejectionReason::NewStorageSlotsExceeded {
+            cumulative: 100,
+            tx_new_slots: 20,
+            block_limit: 110,
+        };
+
+        assert_eq!(
+            serde_json::to_value(reason).expect("reason should serialize"),
+            json!({
+                "newStorageSlotsExceeded": {
+                    "cumulative": 100,
+                    "tx_new_slots": 20,
+                    "block_limit": 110
+                }
+            })
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- add an independent, default-off block budget for fresh storage slots with direct CLI and environment configuration
- count authoritative zero-to-nonzero post-EVM storage transitions and support dry-run or transient enforcement before receipt construction and state commit
- add low-cardinality metrics, structured rejection reporting, and focused unit/in-process coverage without changing `MeterBundleResponse`

## Test plan
- [x] `cargo test -p base-bundles new_storage_slots_rejection_serializes_with_stable_fields`
- [x] `cargo test -p base-builder-core --lib execution::tests` (31 tests passed before the final zero-slot dry-run guard was added)
- [x] replay three `mineFlip()` transactions from Base Sepolia block 45622453 with `prestateTracer`; each created 292 fresh storage slots
- [ ] rerun focused builder core/CLI tests and the new builder-loop dry-run/enforce tests (local disk is full)
- [ ] run builder core/CLI clippy after disk space is available

## Rollout
1. Deploy with `BUILDER_NEW_STORAGE_SLOT_THROTTLE_MODE=off`.
2. Set a provisional `BUILDER_MAX_NEW_STORAGE_SLOTS_PER_BLOCK` and switch to `dry-run` to establish the mainnet distribution.
3. Select the limit from observed fresh-slot metrics, then switch only the mode to `enforce`.

type=routine
risk=low
impact=sev5