### PR TITLE
feat(batcher): add incremental channel compression

### DIFF
--- a/crates/batcher/comp/README.md
+++ b/crates/batcher/comp/README.md
@@ -6,8 +6,9 @@ Compression types for Base.
 
 Provides channel encoding and compression utilities for the Base derivation pipeline. `ChannelOut`
 encodes batches into compressed frames using a pluggable `VariantCompressor` (Brotli or zlib).
-Supports multiple compression algorithms selectable via `CompressionAlgo`. The `MockCompressor`
-is available under the `test-utils` feature for deterministic testing.
+`CompressionStream` compresses a channel incrementally; `CompressionAlgo::compress_channel`
+compresses one complete channel in a single call. The `MockCompressor` is available under the
+`test-utils` feature for deterministic testing.
 
 ## Usage
 

--- a/crates/batcher/comp/src/lib.rs
+++ b/crates/batcher/comp/src/lib.rs
@@ -20,7 +20,7 @@ mod traits;
 pub use traits::CompressorWriter;
 
 mod types;
-pub use types::{CompressionAlgo, CompressorError, CompressorResult};
+pub use types::{CompressionAlgo, CompressionError, CompressorError, CompressorResult};
 
 mod zlib;
 pub use zlib::ZlibCompressor;
@@ -29,6 +29,11 @@ pub use zlib::ZlibCompressor;
 mod brotli;
 #[cfg(feature = "std")]
 pub use brotli::{BrotliCompressionError, BrotliCompressor, BrotliLevel};
+
+#[cfg(feature = "std")]
+mod stream;
+#[cfg(feature = "std")]
+pub use stream::{CompressionBackend, CompressionStream};
 
 #[cfg(feature = "std")]
 mod variant;

--- a/crates/batcher/comp/src/stream.rs
+++ b/crates/batcher/comp/src/stream.rs
@@ -109,8 +109,10 @@ impl CompressionStream {
                 // miniz `mz_compressBound`.
                 input_size.saturating_add(input_size / 16).saturating_add(67)
             }
-            CompressionBackend::Brotli(_) => BrotliEncoderMaxCompressedSize(input_size)
-                .saturating_add(CompressionAlgo::BROTLI_CHANNEL_VERSION as usize),
+            CompressionBackend::Brotli(_) => {
+                // Channel-version prefix byte.
+                BrotliEncoderMaxCompressedSize(input_size).saturating_add(1)
+            }
         }
     }
 

--- a/crates/batcher/comp/src/stream.rs
+++ b/crates/batcher/comp/src/stream.rs
@@ -1,0 +1,219 @@
+//! Incremental derivation-channel compression.
+
+use alloc::{boxed::Box, vec::Vec};
+use std::{fmt, io::Write};
+
+use brotli::{CompressorWriter, enc::BrotliEncoderMaxCompressedSize};
+use miniz_oxide::{
+    DataFormat,
+    deflate::{
+        CompressionLevel,
+        core::{CompressorOxide, TDEFLFlush, TDEFLStatus, compress_to_output},
+    },
+};
+
+use crate::{CompressionAlgo, CompressionError};
+
+/// Concrete state owned by one [`CompressionStream`].
+pub enum CompressionBackend {
+    /// Streaming zlib encoder and bytes emitted since the last transfer.
+    Zlib {
+        /// Miniz encoder state.
+        compressor: Box<CompressorOxide>,
+        /// Bytes emitted since the last transfer.
+        output: Vec<u8>,
+    },
+    /// Streaming Brotli encoder writing into its transferable output buffer.
+    Brotli(Box<CompressorWriter<Vec<u8>>>),
+}
+
+impl fmt::Debug for CompressionBackend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Zlib { output, .. } => {
+                f.debug_struct("Zlib").field("buffered_bytes", &output.len()).finish()
+            }
+            Self::Brotli(compressor) => f
+                .debug_struct("Brotli")
+                .field("buffered_bytes", &compressor.get_ref().len())
+                .finish(),
+        }
+    }
+}
+
+/// A single incremental compressor for one derivation channel.
+pub struct CompressionStream {
+    backend: CompressionBackend,
+    /// Total bytes returned by prior [`append`](Self::append) calls.
+    output_size: usize,
+}
+
+impl CompressionStream {
+    /// Creates an empty compressor for `algorithm`.
+    pub fn new(algorithm: CompressionAlgo) -> Self {
+        let brotli = |quality| {
+            let mut output = Vec::with_capacity(4096);
+            output.push(CompressionAlgo::BROTLI_CHANNEL_VERSION);
+            CompressionBackend::Brotli(Box::new(CompressorWriter::new(output, 4096, quality, 22)))
+        };
+        let backend = match algorithm {
+            CompressionAlgo::Zlib => CompressionBackend::Zlib {
+                compressor: Box::new(CompressorOxide::with_format_and_level(
+                    DataFormat::Zlib,
+                    CompressionLevel::BestCompression,
+                )),
+                output: Vec::new(),
+            },
+            CompressionAlgo::Brotli9 => brotli(9),
+            CompressionAlgo::Brotli10 => brotli(10),
+            CompressionAlgo::Brotli11 => brotli(11),
+        };
+        Self { backend, output_size: 0 }
+    }
+
+    /// Append input and return newly emitted compressed bytes.
+    pub fn append(&mut self, input: &[u8]) -> Result<Vec<u8>, CompressionError> {
+        // miniz reports consumed input; treat the append as committed only
+        // when every byte was accepted.
+        match &mut self.backend {
+            CompressionBackend::Zlib { compressor, output } => {
+                let (status, consumed) =
+                    compress_to_output(compressor, input, TDEFLFlush::None, |bytes| {
+                        output.extend_from_slice(bytes);
+                        true
+                    });
+                if status != TDEFLStatus::Okay || consumed != input.len() {
+                    return Err(CompressionError::Zlib);
+                }
+            }
+            CompressionBackend::Brotli(compressor) => compressor.write_all(input)?,
+        }
+
+        let output = match &mut self.backend {
+            CompressionBackend::Zlib { output, .. } => core::mem::take(output),
+            CompressionBackend::Brotli(compressor) => core::mem::take(compressor.get_mut()),
+        };
+        self.output_size += output.len();
+        Ok(output)
+    }
+
+    /// Bytes already returned by [`append`](Self::append), excluding any `finish` suffix.
+    pub const fn output_size(&self) -> usize {
+        self.output_size
+    }
+
+    /// Conservative upper bound for a finished stream of `input_size` uncompressed bytes.
+    pub fn max_output_size(&self, input_size: usize) -> usize {
+        match &self.backend {
+            CompressionBackend::Zlib { .. } => {
+                // miniz `mz_compressBound`.
+                input_size.saturating_add(input_size / 16).saturating_add(67)
+            }
+            CompressionBackend::Brotli(_) => BrotliEncoderMaxCompressedSize(input_size)
+                .saturating_add(CompressionAlgo::BROTLI_CHANNEL_VERSION as usize),
+        }
+    }
+
+    /// Finishes the stream and returns compressed bytes not previously transferred.
+    pub fn finish(self) -> Result<Vec<u8>, CompressionError> {
+        match self.backend {
+            CompressionBackend::Zlib { mut compressor, mut output } => {
+                let (status, consumed) =
+                    compress_to_output(&mut compressor, &[], TDEFLFlush::Finish, |bytes| {
+                        output.extend_from_slice(bytes);
+                        true
+                    });
+                if status != TDEFLStatus::Done || consumed != 0 {
+                    return Err(CompressionError::Zlib);
+                }
+                Ok(output)
+            }
+            // Dropping the writer emits Brotli's stream trailer.
+            CompressionBackend::Brotli(compressor) => Ok((*compressor).into_inner()),
+        }
+    }
+}
+
+impl fmt::Debug for CompressionStream {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CompressionStream")
+            .field("backend", &self.backend)
+            .field("output_size", &self.output_size())
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base_common_genesis::RollupConfig;
+    use base_protocol::Brotli;
+    use miniz_oxide::inflate::decompress_to_vec_zlib;
+
+    use super::*;
+
+    const CHUNKS: [&[u8]; 3] = [b"first batch", b"second batch", b"third batch"];
+
+    fn collect(algorithm: CompressionAlgo, chunks: &[&[u8]]) -> Vec<u8> {
+        let mut compressor = CompressionStream::new(algorithm);
+        let mut compressed = Vec::new();
+        for chunk in chunks {
+            compressed.extend(compressor.append(chunk).unwrap());
+        }
+        compressed.extend(compressor.finish().unwrap());
+        compressed
+    }
+
+    #[test]
+    fn zlib_roundtrip_across_appends() {
+        let expected = CHUNKS.concat();
+        let compressed = collect(CompressionAlgo::Zlib, &CHUNKS);
+        assert_eq!(decompress_to_vec_zlib(&compressed).unwrap(), expected);
+    }
+
+    #[test]
+    fn brotli_roundtrip_across_appends() {
+        let expected = CHUNKS.concat();
+        let compressed = collect(CompressionAlgo::Brotli10, &CHUNKS);
+
+        assert_eq!(compressed.first(), Some(&CompressionAlgo::BROTLI_CHANNEL_VERSION));
+        let decompressed = Brotli
+            .decompress(&compressed[1..], RollupConfig::MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize)
+            .unwrap();
+        assert_eq!(decompressed, expected);
+    }
+
+    #[test]
+    fn chunking_does_not_change_the_compressed_stream() {
+        let input = CHUNKS.concat();
+
+        for algorithm in [CompressionAlgo::Zlib, CompressionAlgo::Brotli10] {
+            let chunked = collect(algorithm, &CHUNKS);
+            let single = collect(algorithm, &[input.as_slice()]);
+            assert_eq!(chunked, single);
+        }
+    }
+
+    #[test]
+    fn reported_bounds_cover_incompressible_streams() {
+        let mut state = 1u64;
+        let input: Vec<u8> = (0..100_000)
+            .map(|_| {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                state as u8
+            })
+            .collect();
+
+        for algorithm in [CompressionAlgo::Zlib, CompressionAlgo::Brotli10] {
+            let mut compressor = CompressionStream::new(algorithm);
+            let bound = compressor.max_output_size(input.len());
+            let mut output_size = 0usize;
+            for chunk in input.chunks(7919) {
+                output_size += compressor.append(chunk).unwrap().len();
+            }
+            output_size += compressor.finish().unwrap().len();
+            assert!(output_size <= bound);
+        }
+    }
+}

--- a/crates/batcher/comp/src/stream.rs
+++ b/crates/batcher/comp/src/stream.rs
@@ -1,7 +1,7 @@
 //! Incremental derivation-channel compression.
 
 use alloc::{boxed::Box, vec::Vec};
-use std::{fmt, io::Write};
+use std::io::Write;
 
 use brotli::{CompressorWriter, enc::BrotliEncoderMaxCompressedSize};
 use miniz_oxide::{
@@ -15,49 +15,100 @@ use miniz_oxide::{
 use crate::{CompressionAlgo, CompressionError};
 
 /// Concrete state owned by one [`CompressionStream`].
+#[derive(derive_more::Debug)]
 pub enum CompressionBackend {
     /// Streaming zlib encoder and bytes emitted since the last transfer.
     Zlib {
         /// Miniz encoder state.
+        #[debug(skip)]
         compressor: Box<CompressorOxide>,
         /// Bytes emitted since the last transfer.
+        #[debug(skip)]
         output: Vec<u8>,
     },
     /// Streaming Brotli encoder writing into its transferable output buffer.
-    Brotli(Box<CompressorWriter<Vec<u8>>>),
+    Brotli(#[debug(skip)] Box<CompressorWriter<Vec<u8>>>),
 }
 
-impl fmt::Debug for CompressionBackend {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl CompressionBackend {
+    /// Buffer size used by the Brotli writer.
+    const BROTLI_BUFFER_SIZE: usize = 4096;
+
+    /// Brotli sliding-window exponent (`2^22` bytes).
+    const BROTLI_LGWIN: u32 = 22;
+
+    /// Appends input and returns newly emitted compressed bytes.
+    pub fn append(&mut self, input: &[u8]) -> Result<Vec<u8>, CompressionError> {
         match self {
-            Self::Zlib { output, .. } => {
-                f.debug_struct("Zlib").field("buffered_bytes", &output.len()).finish()
+            Self::Zlib { compressor, output } => {
+                // miniz reports consumed input; treat the append as committed only
+                // when every byte was accepted.
+                let (status, consumed) =
+                    compress_to_output(compressor, input, TDEFLFlush::None, |bytes| {
+                        output.extend_from_slice(bytes);
+                        true
+                    });
+                if status != TDEFLStatus::Okay || consumed != input.len() {
+                    return Err(CompressionError::Zlib);
+                }
+                Ok(core::mem::take(output))
             }
-            Self::Brotli(compressor) => f
-                .debug_struct("Brotli")
-                .field("buffered_bytes", &compressor.get_ref().len())
-                .finish(),
+            Self::Brotli(compressor) => {
+                compressor.write_all(input)?;
+                Ok(core::mem::take(compressor.get_mut()))
+            }
+        }
+    }
+
+    /// Returns a conservative upper bound for a finished stream of `input_size`.
+    pub fn max_output_size(&self, input_size: usize) -> usize {
+        match self {
+            Self::Zlib { .. } => {
+                // miniz `mz_compressBound`.
+                input_size.saturating_add(input_size / 16).saturating_add(67)
+            }
+            Self::Brotli(_) => {
+                // Channel-version prefix byte.
+                BrotliEncoderMaxCompressedSize(input_size).saturating_add(1)
+            }
+        }
+    }
+
+    /// Finishes the stream and returns compressed bytes not previously transferred.
+    pub fn finish(self) -> Result<Vec<u8>, CompressionError> {
+        match self {
+            Self::Zlib { mut compressor, mut output } => {
+                let (status, consumed) =
+                    compress_to_output(&mut compressor, &[], TDEFLFlush::Finish, |bytes| {
+                        output.extend_from_slice(bytes);
+                        true
+                    });
+                if status != TDEFLStatus::Done || consumed != 0 {
+                    return Err(CompressionError::Zlib);
+                }
+                Ok(output)
+            }
+            // Consuming the writer emits Brotli's stream trailer.
+            Self::Brotli(compressor) => Ok((*compressor).into_inner()),
         }
     }
 }
 
-/// A single incremental compressor for one derivation channel.
-pub struct CompressionStream {
-    backend: CompressionBackend,
-    /// Total bytes returned by prior [`append`](Self::append) calls.
-    output_size: usize,
-}
-
-impl CompressionStream {
-    /// Creates an empty compressor for `algorithm`.
-    pub fn new(algorithm: CompressionAlgo) -> Self {
+impl From<CompressionAlgo> for CompressionBackend {
+    fn from(algorithm: CompressionAlgo) -> Self {
         let brotli = |quality| {
-            let mut output = Vec::with_capacity(4096);
+            let mut output = Vec::with_capacity(Self::BROTLI_BUFFER_SIZE);
             output.push(CompressionAlgo::BROTLI_CHANNEL_VERSION);
-            CompressionBackend::Brotli(Box::new(CompressorWriter::new(output, 4096, quality, 22)))
+            Self::Brotli(Box::new(CompressorWriter::new(
+                output,
+                Self::BROTLI_BUFFER_SIZE,
+                quality,
+                Self::BROTLI_LGWIN,
+            )))
         };
-        let backend = match algorithm {
-            CompressionAlgo::Zlib => CompressionBackend::Zlib {
+
+        match algorithm {
+            CompressionAlgo::Zlib => Self::Zlib {
                 compressor: Box::new(CompressorOxide::with_format_and_level(
                     DataFormat::Zlib,
                     CompressionLevel::BestCompression,
@@ -67,32 +118,33 @@ impl CompressionStream {
             CompressionAlgo::Brotli9 => brotli(9),
             CompressionAlgo::Brotli10 => brotli(10),
             CompressionAlgo::Brotli11 => brotli(11),
-        };
-        Self { backend, output_size: 0 }
+        }
+    }
+}
+
+/// A single incremental compressor for one derivation channel.
+#[derive(derive_more::Debug)]
+pub struct CompressionStream {
+    backend: CompressionBackend,
+    /// Total bytes returned by prior [`append`](Self::append) calls.
+    output_size: usize,
+}
+
+impl From<CompressionAlgo> for CompressionStream {
+    fn from(algorithm: CompressionAlgo) -> Self {
+        Self { backend: algorithm.into(), output_size: 0 }
+    }
+}
+
+impl CompressionStream {
+    /// Creates an empty compressor for `algorithm`.
+    pub fn new(algorithm: CompressionAlgo) -> Self {
+        algorithm.into()
     }
 
     /// Append input and return newly emitted compressed bytes.
     pub fn append(&mut self, input: &[u8]) -> Result<Vec<u8>, CompressionError> {
-        // miniz reports consumed input; treat the append as committed only
-        // when every byte was accepted.
-        match &mut self.backend {
-            CompressionBackend::Zlib { compressor, output } => {
-                let (status, consumed) =
-                    compress_to_output(compressor, input, TDEFLFlush::None, |bytes| {
-                        output.extend_from_slice(bytes);
-                        true
-                    });
-                if status != TDEFLStatus::Okay || consumed != input.len() {
-                    return Err(CompressionError::Zlib);
-                }
-            }
-            CompressionBackend::Brotli(compressor) => compressor.write_all(input)?,
-        }
-
-        let output = match &mut self.backend {
-            CompressionBackend::Zlib { output, .. } => core::mem::take(output),
-            CompressionBackend::Brotli(compressor) => core::mem::take(compressor.get_mut()),
-        };
+        let output = self.backend.append(input)?;
         self.output_size += output.len();
         Ok(output)
     }
@@ -104,44 +156,12 @@ impl CompressionStream {
 
     /// Conservative upper bound for a finished stream of `input_size` uncompressed bytes.
     pub fn max_output_size(&self, input_size: usize) -> usize {
-        match &self.backend {
-            CompressionBackend::Zlib { .. } => {
-                // miniz `mz_compressBound`.
-                input_size.saturating_add(input_size / 16).saturating_add(67)
-            }
-            CompressionBackend::Brotli(_) => {
-                // Channel-version prefix byte.
-                BrotliEncoderMaxCompressedSize(input_size).saturating_add(1)
-            }
-        }
+        self.backend.max_output_size(input_size)
     }
 
     /// Finishes the stream and returns compressed bytes not previously transferred.
     pub fn finish(self) -> Result<Vec<u8>, CompressionError> {
-        match self.backend {
-            CompressionBackend::Zlib { mut compressor, mut output } => {
-                let (status, consumed) =
-                    compress_to_output(&mut compressor, &[], TDEFLFlush::Finish, |bytes| {
-                        output.extend_from_slice(bytes);
-                        true
-                    });
-                if status != TDEFLStatus::Done || consumed != 0 {
-                    return Err(CompressionError::Zlib);
-                }
-                Ok(output)
-            }
-            // Dropping the writer emits Brotli's stream trailer.
-            CompressionBackend::Brotli(compressor) => Ok((*compressor).into_inner()),
-        }
-    }
-}
-
-impl fmt::Debug for CompressionStream {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("CompressionStream")
-            .field("backend", &self.backend)
-            .field("output_size", &self.output_size())
-            .finish_non_exhaustive()
+        self.backend.finish()
     }
 }
 

--- a/crates/batcher/comp/src/types.rs
+++ b/crates/batcher/comp/src/types.rs
@@ -1,5 +1,7 @@
 //! Compression types.
 
+use alloc::vec::Vec;
+
 /// The result from compressing data.
 pub type CompressorResult<T> = Result<T, CompressorError>;
 
@@ -12,6 +14,23 @@ pub enum CompressorError {
     /// Brotli compression failed.
     #[error("brotli compression failed")]
     Brotli,
+}
+
+/// Failure from one-shot or streaming channel compression.
+#[derive(Debug, thiserror::Error)]
+pub enum CompressionError {
+    /// Zlib rejected an incremental compression operation.
+    #[cfg(feature = "std")]
+    #[error("zlib compression failed")]
+    Zlib,
+    /// Brotli compression is unavailable without the standard library.
+    #[cfg(not(feature = "std"))]
+    #[error("brotli compression is not supported without the standard library")]
+    BrotliUnavailable,
+    /// Brotli compression failed.
+    #[cfg(feature = "std")]
+    #[error("brotli compression failed: {0}")]
+    Brotli(#[from] std::io::Error),
 }
 
 /// The compression algorithm type.
@@ -29,6 +48,41 @@ pub enum CompressionAlgo {
     Zlib,
 }
 
+impl CompressionAlgo {
+    /// Channel-version byte prepended to Brotli-compressed channels.
+    pub const BROTLI_CHANNEL_VERSION: u8 = 0x01;
+
+    /// Compresses one complete derivation channel.
+    ///
+    /// Brotli output starts with [`BROTLI_CHANNEL_VERSION`](Self::BROTLI_CHANNEL_VERSION);
+    /// zlib is self-identifying.
+    pub fn compress_channel(self, input: &[u8]) -> Result<Vec<u8>, CompressionError> {
+        match self {
+            Self::Zlib => Ok(miniz_oxide::deflate::compress_to_vec_zlib(input, 9)),
+            #[cfg(feature = "std")]
+            brotli => {
+                let compressed = crate::BrotliCompressor::compress(input, brotli.into()).map_err(
+                    |err| match err {
+                        crate::BrotliCompressionError::CompressionError(io) => {
+                            CompressionError::Brotli(io)
+                        }
+                        crate::BrotliCompressionError::NoStd => unreachable!(),
+                    },
+                )?;
+                let mut channel = Vec::with_capacity(compressed.len() + 1);
+                channel.push(Self::BROTLI_CHANNEL_VERSION);
+                channel.extend_from_slice(&compressed);
+                Ok(channel)
+            }
+            #[cfg(not(feature = "std"))]
+            Self::Brotli9 | Self::Brotli10 | Self::Brotli11 => {
+                let _ = input;
+                Err(CompressionError::BrotliUnavailable)
+            }
+        }
+    }
+}
+
 #[cfg(feature = "std")]
 impl<A: alloc::borrow::Borrow<CompressionAlgo>> From<A> for crate::BrotliLevel {
     fn from(algo: A) -> Self {
@@ -37,5 +91,42 @@ impl<A: alloc::borrow::Borrow<CompressionAlgo>> From<A> for crate::BrotliLevel {
             CompressionAlgo::Brotli11 => Self::Brotli11,
             _ => Self::Brotli10,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use miniz_oxide::inflate::decompress_to_vec_zlib;
+
+    use super::*;
+
+    #[cfg(feature = "std")]
+    use base_common_genesis::RollupConfig;
+    #[cfg(feature = "std")]
+    use base_protocol::Brotli;
+
+    #[test]
+    fn zlib_channel_roundtrips() {
+        let input = b"batch channel data";
+        let channel = CompressionAlgo::Zlib.compress_channel(input).unwrap();
+        assert_eq!(decompress_to_vec_zlib(&channel).unwrap(), input);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn brotli_channel_has_version_prefix() {
+        let channel = CompressionAlgo::Brotli10.compress_channel(b"batch channel data").unwrap();
+        assert_eq!(channel.first(), Some(&CompressionAlgo::BROTLI_CHANNEL_VERSION));
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn brotli_channel_roundtrips() {
+        let input = b"batch channel data";
+        let channel = CompressionAlgo::Brotli10.compress_channel(input).unwrap();
+        let decompressed = Brotli
+            .decompress(&channel[1..], RollupConfig::MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize)
+            .unwrap();
+        assert_eq!(decompressed, input);
     }
 }

--- a/crates/batcher/comp/src/types.rs
+++ b/crates/batcher/comp/src/types.rs
@@ -96,14 +96,13 @@ impl<A: alloc::borrow::Borrow<CompressionAlgo>> From<A> for crate::BrotliLevel {
 
 #[cfg(test)]
 mod tests {
-    use miniz_oxide::inflate::decompress_to_vec_zlib;
-
-    use super::*;
-
     #[cfg(feature = "std")]
     use base_common_genesis::RollupConfig;
     #[cfg(feature = "std")]
     use base_protocol::Brotli;
+    use miniz_oxide::inflate::decompress_to_vec_zlib;
+
+    use super::*;
 
     #[test]
     fn zlib_channel_roundtrips() {


### PR DESCRIPTION
## Summary

Add channel compression primitives to `base-comp`:

- `CompressionStream` compresses a derivation channel incrementally as bytes are
  appended.
- `CompressionAlgo::compress_channel` compresses a complete channel in one call.

Brotli channels carry the `0x01` channel-version byte; zlib streams are
self-identifying.

## Testing

- `cargo test -p base-comp --all-features`