### PR TITLE
chore(ci): Bump Base-Anvil Interface-Test Pins

### DIFF
--- a/.github/workflows/base-anvil-package.yml
+++ b/.github/workflows/base-anvil-package.yml
@@ -9,7 +9,7 @@ on:
       base_anvil_ref:
         description: "base/base-anvil ref to build from"
         required: false
-        default: ae7557c4f8602caa1da0be33143bb2504c85b0c8
+        default: 9df661bc39c6fb96ef28bfd5ff5d345931f133d3
       base_std_ref:
         description: "base/base-std ref to smoke test against"
         required: false
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  BASE_ANVIL_REF: ${{ github.event.inputs.base_anvil_ref || 'ae7557c4f8602caa1da0be33143bb2504c85b0c8' }}
+  BASE_ANVIL_REF: ${{ github.event.inputs.base_anvil_ref || '9df661bc39c6fb96ef28bfd5ff5d345931f133d3' }}
   BASE_STD_REF: ${{ github.event.inputs.base_std_ref || 'main' }}
   CARGO_TERM_COLOR: always
   REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/base-anvil
@@ -355,7 +355,7 @@ jobs:
           primary_tag="sha-$GITHUB_SHA"
           tags=("$REGISTRY_IMAGE:$primary_tag")
 
-          if [[ "$GITHUB_REF_NAME" == "main" && "$BASE_ANVIL_REF" == "ae7557c4f8602caa1da0be33143bb2504c85b0c8" && "$BASE_STD_REF" == "main" ]]; then
+          if [[ "$GITHUB_REF_NAME" == "main" && "$BASE_ANVIL_REF" == "9df661bc39c6fb96ef28bfd5ff5d345931f133d3" && "$BASE_STD_REF" == "main" ]]; then
             tags+=("$REGISTRY_IMAGE:main")
             tags+=("$REGISTRY_IMAGE:main-$commit_date-$short_sha")
           else

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -32,7 +32,7 @@ jobs:
           # recorded in the result artifact and PR comment.
           - fork: Beryl
             key: beryl
-            base_anvil_ref: 9df661bc39c6fb96ef28bfd5ff5d345931f133d3
+            base_anvil_ref: 6d744e03224977edd42a36699ba9ff42be25e8cb
             base_std_ref: v1.0.0
           - fork: Cobalt
             key: cobalt

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -36,8 +36,8 @@ jobs:
             base_std_ref: v1.0.0
           - fork: Cobalt
             key: cobalt
-            base_anvil_ref: ae7557c4f8602caa1da0be33143bb2504c85b0c8
-            base_std_ref: 3f8990095f3316ed9b331a39f5c21a1bb5059c5f
+            base_anvil_ref: 9df661bc39c6fb96ef28bfd5ff5d345931f133d3
+            base_std_ref: e30b34212689186b27acd3d340ba0d75d31495e9
     env:
       FORK_NAME: ${{ matrix.fork }}
       FORK_KEY: ${{ matrix.key }}

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -32,7 +32,7 @@ jobs:
           # recorded in the result artifact and PR comment.
           - fork: Beryl
             key: beryl
-            base_anvil_ref: 6d744e03224977edd42a36699ba9ff42be25e8cb
+            base_anvil_ref: 9df661bc39c6fb96ef28bfd5ff5d345931f133d3
             base_std_ref: v1.0.0
           - fork: Cobalt
             key: cobalt

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -32,7 +32,7 @@ jobs:
           # recorded in the result artifact and PR comment.
           - fork: Beryl
             key: beryl
-            base_anvil_ref: 6d744e03224977edd42a36699ba9ff42be25e8cb
+            base_anvil_ref: 8d0f5b8ae60edd30caa52609bc8677e0b631e2d7
             base_std_ref: v1.0.0
           - fork: Cobalt
             key: cobalt


### PR DESCRIPTION
## Summary

Bumps both interface-test fork pins to base-anvil harnesses that build against current base/base (which moved to alloy-primitives 1.6.1 in #4390). Cobalt moves to base-anvil 9df661bc (main) and base-std e30b3421 (main), and the base-anvil-package.yml default plus its main-tag gating condition move to the same base-anvil commit so the published image and the interface tests stay aligned. Beryl moves to base-anvil 8d0f5b8a, the reth-2.5 dependency backport (base-anvil #70) that bumps the BaseUpgrade::Beryl harness to alloy-primitives 1.6.1 while keeping the Beryl fork gating, tested against its frozen base-std v1.0.0 spec.

Dependency resolution for the Beryl harness against the current precompiles/chains was verified locally to succeed, resolving the alloy-primitives conflict that previously failed the build; CI runs the full build and conformance suite for both forks.