### PR TITLE
fix(devnet): Disable Denim By Default

### DIFF
--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -223,10 +223,10 @@ _up-devnet compose_profile mode:
     compose_profile={{ quote(compose_profile) }}
     devnet_mode={{ quote(mode) }}
 
-    # Denim is activated by default. The zenith mode additionally schedules the genesis-only
-    # Zenith gate used for future hardfork feature testing.
+    # Default mode leaves Denim opt-in through L2_BASE_DENIM_BLOCK. The zenith mode schedules
+    # Denim and the genesis-only Zenith gate used for future hardfork feature testing.
     case "$devnet_mode" in
-      default) export L2_BASE_DENIM_BLOCK="${L2_BASE_DENIM_BLOCK-23}" ;;
+      default) ;;
       zenith)
         export L2_BASE_DENIM_BLOCK="${L2_BASE_DENIM_BLOCK-23}"
         export L2_BASE_ZENITH_BLOCK="${L2_BASE_ZENITH_BLOCK:-50}"

--- a/etc/docker/README.md
+++ b/etc/docker/README.md
@@ -70,16 +70,15 @@ Anvil mines one block every four seconds. Do not use timestamp-warp RPCs in
 this variant: Base derives Beacon slots from L1 timestamps, so arbitrary time
 jumps would break the one-slot-per-execution-block mapping used to fetch blobs.
 
-Denim is activated at block 23 by default, switching the sequencer to its 200ms cadence. To
-start a pre-Denim devnet, set `L2_BASE_DENIM_BLOCK` to an empty value:
+Denim is disabled in the default mode. To activate it at block 23 and switch the sequencer to
+its 200ms cadence, set `L2_BASE_DENIM_BLOCK` explicitly:
 
 ```bash
-L2_BASE_DENIM_BLOCK= just devnet up
+L2_BASE_DENIM_BLOCK=23 just devnet up
 ```
 
 Zenith is the permanently unscheduled, genesis-only gate for future hardfork feature testing.
-To additionally activate it at block 50 (after Denim, so it does not conflict with earlier
-activations), start with:
+Zenith mode activates Denim at block 23 and Zenith at block 50:
 
 ```bash
 just devnet up zenith

--- a/etc/docker/devnet-env
+++ b/etc/docker/devnet-env
@@ -196,11 +196,10 @@ L2_BASE_BERYL_BLOCK=21
 # Leave unset to avoid setting base.cobalt during genesis generation.
 L2_BASE_COBALT_BLOCK=22
 # Optional: set to a non-negative block number to schedule Base Denim in devnet.
-# `just devnet up` defaults this to 23; set it to an empty value to leave base.denim unset.
+# Default mode leaves this unset; `just devnet up zenith` defaults it to 23.
 # L2_BASE_DENIM_BLOCK=23
 # Optional: set to a non-negative block number to schedule the genesis-only Base Zenith gate
-# used for future hardfork feature testing. `just devnet up zenith` defaults this to 50,
-# after the Denim default so it does not conflict with earlier activations.
+# used for future hardfork feature testing. `just devnet up zenith` defaults this to 50.
 # Leave unset to avoid setting base.zenith during genesis generation.
 # L2_BASE_ZENITH_BLOCK=50
 


### PR DESCRIPTION
## Summary

This backports #4527 to releases/v1.3.0. It leaves Denim disabled in the default local devnet mode while retaining explicit opt-in and Zenith-mode activation.