### PR TITLE
feat(batcher): add Channel and DA egress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3083,6 +3083,7 @@ dependencies = [
  "base-metrics",
  "base-protocol",
  "clap",
+ "derive_more 2.1.1",
  "metrics",
  "rand 0.9.5",
  "rstest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3076,6 +3076,7 @@ dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
  "alloy-primitives",
+ "alloy-rlp",
  "base-common-consensus",
  "base-common-genesis",
  "base-comp",

--- a/bin/batcher/src/cli.rs
+++ b/bin/batcher/src/cli.rs
@@ -302,6 +302,8 @@ impl BatcherArgs {
             // The batcher binary only targets post-Fjord chains, so it always uses Brotli.
             compression_algo: base_batcher_encoder::CompressionAlgo::Brotli10,
             max_l1_tx_size_bytes: self.max_l1_tx_size_bytes,
+            compressed_size_target: None,
+            max_blobs_per_tx: base_batcher_encoder::EncoderConfig::MAX_BLOBS_PER_TX,
         };
         encoder_config.validate()?;
         let tx_manager = TxManagerConfig {
@@ -461,6 +463,11 @@ mod tests {
         let config = cli.args.into_config().expect("config should build");
 
         assert_eq!(config.encoder_config.da_type, base_batcher_encoder::DaType::Blob);
+        assert_eq!(config.encoder_config.compressed_size_target, None);
+        assert_eq!(
+            config.encoder_config.max_blobs_per_tx,
+            base_batcher_encoder::EncoderConfig::MAX_BLOBS_PER_TX
+        );
     }
 
     #[test]

--- a/crates/batcher/encoder/Cargo.toml
+++ b/crates/batcher/encoder/Cargo.toml
@@ -12,6 +12,7 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
+alloy-rlp.workspace = true
 base-metrics.workspace = true
 metrics = { workspace = true, optional = true }
 tracing = { workspace = true, features = ["std"] }

--- a/crates/batcher/encoder/Cargo.toml
+++ b/crates/batcher/encoder/Cargo.toml
@@ -20,6 +20,7 @@ base-comp = { workspace = true, features = ["std"] }
 thiserror = { workspace = true, features = ["std"] }
 alloy-eips = { workspace = true, features = ["std"] }
 base-protocol = { workspace = true, features = ["std"] }
+derive_more = { workspace = true, features = ["debug"] }
 alloy-primitives = { workspace = true, features = ["std"] }
 rand = { workspace = true, features = ["std", "small_rng"] }
 base-common-consensus = { workspace = true, features = ["std"] }

--- a/crates/batcher/encoder/src/artifact.rs
+++ b/crates/batcher/encoder/src/artifact.rs
@@ -303,3 +303,151 @@ impl<'a> IntoIterator for &'a DaArtifacts {
         self.artifacts.iter()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::DaType;
+
+    const FIRST: ChannelId = [1; 16];
+    const SECOND: ChannelId = [2; 16];
+
+    fn frame(channel_id: ChannelId) -> Arc<Frame> {
+        Arc::new(Frame { id: channel_id, number: 0, data: Vec::new(), is_last: true })
+    }
+
+    fn blob(channel_id: ChannelId, frames: usize) -> DaArtifactPayload {
+        DaArtifactPayload::Blob(BlobPayload::new((0..frames).map(|_| frame(channel_id)).collect()))
+    }
+
+    fn calldata(channel_id: ChannelId) -> DaArtifactPayload {
+        DaArtifactPayload::Calldata(frame(channel_id))
+    }
+
+    #[test]
+    fn push_appends_ready_artifacts_in_creation_order() {
+        let mut artifacts = DaArtifacts::new();
+
+        let first = artifacts.push(blob(FIRST, 1), vec![FIRST]);
+        let second = artifacts.push(calldata(SECOND), vec![SECOND]);
+
+        assert_eq!(artifacts.len(), 2);
+        assert_eq!(artifacts.iter().map(DaArtifact::id).collect::<Vec<_>>(), [first, second]);
+        assert!(artifacts.iter().all(|artifact| artifact.state() == ArtifactState::Ready));
+    }
+
+    #[test]
+    fn clear_preserves_monotonic_identifiers() {
+        let mut artifacts = DaArtifacts::new();
+        let first = artifacts.push(calldata(FIRST), vec![FIRST]);
+
+        artifacts.clear();
+        let second = artifacts.push(calldata(FIRST), vec![FIRST]);
+
+        assert_eq!(artifacts.len(), 1);
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn lease_packs_consecutive_ready_blobs_up_to_the_maximum() {
+        let mut artifacts = DaArtifacts::new();
+        for _ in 0..3 {
+            artifacts.push(blob(FIRST, 2), vec![FIRST]);
+        }
+
+        let (submission, leased) = artifacts.lease(SubmissionId(0), 2).expect("blob lease");
+
+        assert_eq!(leased.len(), 2);
+        assert_eq!(submission.blob_count(), 2);
+        assert_eq!(submission.frame_count(), 4);
+        assert!(artifacts.all_pending(&leased));
+        assert_eq!(artifacts.ready_blob_count(), 1);
+    }
+
+    #[test]
+    fn lease_stops_at_the_first_calldata_artifact() {
+        let mut artifacts = DaArtifacts::new();
+        artifacts.push(blob(FIRST, 1), vec![FIRST]);
+        artifacts.push(calldata(FIRST), vec![FIRST]);
+        artifacts.push(blob(FIRST, 1), vec![FIRST]);
+
+        let (blobs, _) = artifacts.lease(SubmissionId(0), 6).expect("blob lease");
+        let (frame, leased) = artifacts.lease(SubmissionId(1), 6).expect("calldata lease");
+
+        assert_eq!(blobs.blob_count(), 1);
+        assert_eq!(frame.da_type(), DaType::Calldata);
+        assert_eq!(leased.len(), 1);
+    }
+
+    #[test]
+    fn lease_requires_a_ready_artifact() {
+        let mut artifacts = DaArtifacts::new();
+        assert!(artifacts.lease(SubmissionId(0), 6).is_none());
+
+        artifacts.push(calldata(FIRST), vec![FIRST]);
+        artifacts.lease(SubmissionId(0), 6).expect("calldata lease");
+
+        assert!(artifacts.lease(SubmissionId(1), 6).is_none());
+    }
+
+    #[test]
+    fn confirm_reports_each_contributing_channel_once() {
+        let mut artifacts = DaArtifacts::new();
+        artifacts.push(blob(FIRST, 2), vec![FIRST, SECOND]);
+        artifacts.push(blob(SECOND, 1), vec![SECOND]);
+        let (_, leased) = artifacts.lease(SubmissionId(0), 6).expect("blob lease");
+
+        assert_eq!(artifacts.confirm(&leased), [FIRST, SECOND]);
+        assert!(!artifacts.all_pending(&leased));
+    }
+
+    #[test]
+    fn requeue_returns_leased_frames_to_ready() {
+        let mut artifacts = DaArtifacts::new();
+        artifacts.push(blob(FIRST, 3), vec![FIRST]);
+        let (_, leased) = artifacts.lease(SubmissionId(0), 6).expect("blob lease");
+        assert_eq!(artifacts.ready_frame_count(), 0);
+
+        assert_eq!(artifacts.requeue(&leased), 3);
+        assert_eq!(artifacts.ready_frame_count(), 3);
+    }
+
+    #[test]
+    fn a_channel_without_artifacts_is_never_fully_confirmed() {
+        let mut artifacts = DaArtifacts::new();
+        assert!(!artifacts.all_confirmed_for(FIRST));
+
+        artifacts.push(blob(FIRST, 1), vec![FIRST]);
+        assert!(!artifacts.all_confirmed_for(FIRST));
+
+        let (_, leased) = artifacts.lease(SubmissionId(0), 6).expect("blob lease");
+        artifacts.confirm(&leased);
+
+        assert!(artifacts.all_confirmed_for(FIRST));
+    }
+
+    #[test]
+    fn prune_channels_drops_artifacts_left_without_a_channel() {
+        let mut artifacts = DaArtifacts::new();
+        let shared = artifacts.push(blob(FIRST, 1), vec![FIRST, SECOND]);
+        let single = artifacts.push(blob(FIRST, 1), vec![FIRST]);
+
+        artifacts.prune_channels(&[FIRST]);
+
+        assert!(artifacts.contains(shared));
+        assert!(!artifacts.contains(single));
+        assert_eq!(artifacts.iter().next().expect("retained artifact").channel_ids(), [SECOND]);
+    }
+
+    #[test]
+    fn invalidate_removes_only_the_listed_artifacts() {
+        let mut artifacts = DaArtifacts::new();
+        let first = artifacts.push(calldata(FIRST), vec![FIRST]);
+        let second = artifacts.push(calldata(SECOND), vec![SECOND]);
+
+        artifacts.invalidate(&[first]);
+
+        assert!(!artifacts.contains(first));
+        assert!(artifacts.contains(second));
+    }
+}

--- a/crates/batcher/encoder/src/artifact.rs
+++ b/crates/batcher/encoder/src/artifact.rs
@@ -1,0 +1,305 @@
+//! Immutable DA artifacts and the ledger tracking their submission state.
+
+use std::{
+    collections::{VecDeque, vec_deque},
+    sync::Arc,
+};
+
+use base_protocol::{ChannelId, Frame};
+
+use crate::{BatchSubmission, BlobPayload, SubmissionId};
+
+/// Stable identifier for one immutable DA artifact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ArtifactId(u64);
+
+/// Submission state of one immutable DA artifact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArtifactState {
+    /// Available for a new L1 submission.
+    Ready,
+    /// Leased to one in-flight submission.
+    Pending,
+    /// Confirmed on L1.
+    Confirmed,
+}
+
+/// Immutable payload carried by one DA artifact.
+#[derive(Debug)]
+pub enum DaArtifactPayload {
+    /// One complete EIP-4844 blob payload.
+    Blob(BlobPayload),
+    /// One derivation frame carried by calldata.
+    Calldata(Arc<Frame>),
+}
+
+impl DaArtifactPayload {
+    /// Returns the number of derivation frames carried by this payload.
+    pub fn frame_count(&self) -> usize {
+        match self {
+            Self::Blob(payload) => payload.frames().len(),
+            // A calldata transaction carries exactly one frame by construction.
+            Self::Calldata(_) => 1,
+        }
+    }
+}
+
+/// One immutable artifact retained through submission retries and confirmation.
+#[derive(Debug)]
+pub struct DaArtifact {
+    /// Stable artifact identifier.
+    id: ArtifactId,
+    /// Artifact payload.
+    payload: DaArtifactPayload,
+    /// Channels contributing frames to this artifact.
+    channel_ids: Vec<ChannelId>,
+    /// Current submission state.
+    state: ArtifactState,
+}
+
+impl DaArtifact {
+    /// Returns the artifact identifier.
+    pub const fn id(&self) -> ArtifactId {
+        self.id
+    }
+
+    /// Returns the artifact payload.
+    pub const fn payload(&self) -> &DaArtifactPayload {
+        &self.payload
+    }
+
+    /// Returns contributing channel identifiers.
+    pub fn channel_ids(&self) -> &[ChannelId] {
+        &self.channel_ids
+    }
+
+    /// Returns the current submission state.
+    pub const fn state(&self) -> ArtifactState {
+        self.state
+    }
+}
+
+/// Ledger of immutable DA artifacts, in creation order.
+///
+/// Artifacts are appended [`ArtifactState::Ready`], leased to one in-flight
+/// submission at a time, and retained until the channels they carry are safe.
+#[derive(Debug, Default)]
+pub struct DaArtifacts {
+    /// Artifacts in creation order.
+    artifacts: VecDeque<DaArtifact>,
+    /// Next stable artifact identifier.
+    next_id: u64,
+}
+
+impl DaArtifacts {
+    /// Creates an empty ledger.
+    pub const fn new() -> Self {
+        Self { artifacts: VecDeque::new(), next_id: 0 }
+    }
+
+    /// Returns the number of retained artifacts.
+    pub fn len(&self) -> usize {
+        self.artifacts.len()
+    }
+
+    /// Returns whether no artifact is retained.
+    pub fn is_empty(&self) -> bool {
+        self.artifacts.is_empty()
+    }
+
+    /// Returns every retained artifact in creation order.
+    pub fn iter(&self) -> vec_deque::Iter<'_, DaArtifact> {
+        self.artifacts.iter()
+    }
+
+    /// Appends one immutable ready artifact.
+    pub fn push(&mut self, payload: DaArtifactPayload, channel_ids: Vec<ChannelId>) -> ArtifactId {
+        let id = ArtifactId(self.next_id);
+        self.next_id += 1;
+        self.artifacts.push_back(DaArtifact {
+            id,
+            payload,
+            channel_ids,
+            state: ArtifactState::Ready,
+        });
+        id
+    }
+
+    /// Returns whether any artifact is available for a new submission.
+    pub fn has_ready(&self) -> bool {
+        self.artifacts.iter().any(|artifact| artifact.state == ArtifactState::Ready)
+    }
+
+    /// Returns the number of ready blob artifacts.
+    pub fn ready_blob_count(&self) -> usize {
+        self.ready()
+            .filter(|artifact| matches!(artifact.payload, DaArtifactPayload::Blob(_)))
+            .count()
+    }
+
+    /// Returns the number of frames currently available for submission.
+    pub fn ready_frame_count(&self) -> usize {
+        self.ready().map(|artifact| artifact.payload.frame_count()).sum()
+    }
+
+    /// Leases the next ready artifacts as one transaction-sized submission.
+    ///
+    /// Consecutive ready blobs are packed into one transaction, up to
+    /// `max_blobs`. A calldata artifact is always leased on its own.
+    pub fn lease(
+        &mut self,
+        submission_id: SubmissionId,
+        max_blobs: usize,
+    ) -> Option<(BatchSubmission, Vec<ArtifactId>)> {
+        let first_ready =
+            self.artifacts.iter().position(|artifact| artifact.state == ArtifactState::Ready)?;
+
+        Some(match self.artifacts[first_ready].payload {
+            DaArtifactPayload::Blob(_) => self.lease_blobs(first_ready, max_blobs, submission_id),
+            DaArtifactPayload::Calldata(_) => self.lease_calldata(first_ready, submission_id),
+        })
+    }
+
+    /// Returns whether every listed artifact is still leased to a submission.
+    pub fn all_pending(&self, artifact_ids: &[ArtifactId]) -> bool {
+        artifact_ids.iter().all(|id| {
+            self.artifacts
+                .iter()
+                .any(|artifact| artifact.id == *id && artifact.state == ArtifactState::Pending)
+        })
+    }
+
+    /// Confirms the listed artifacts and returns their contributing channels.
+    pub fn confirm(&mut self, artifact_ids: &[ArtifactId]) -> Vec<ChannelId> {
+        let mut channel_ids = Vec::new();
+
+        for artifact in self.select_mut(artifact_ids) {
+            artifact.state = ArtifactState::Confirmed;
+            for channel_id in &artifact.channel_ids {
+                if !channel_ids.contains(channel_id) {
+                    channel_ids.push(*channel_id);
+                }
+            }
+        }
+
+        channel_ids
+    }
+
+    /// Returns the listed artifacts to ready state, and their total frame count.
+    pub fn requeue(&mut self, artifact_ids: &[ArtifactId]) -> usize {
+        let mut frame_count = 0;
+
+        for artifact in self.select_mut(artifact_ids) {
+            frame_count += artifact.payload.frame_count();
+            artifact.state = ArtifactState::Ready;
+        }
+
+        frame_count
+    }
+
+    /// Returns whether `channel_id` has artifacts and all of them are confirmed.
+    pub fn all_confirmed_for(&self, channel_id: ChannelId) -> bool {
+        let mut artifacts =
+            self.artifacts.iter().filter(|artifact| artifact.channel_ids.contains(&channel_id));
+
+        artifacts.next().is_some_and(|first| {
+            first.state == ArtifactState::Confirmed
+                && artifacts.all(|artifact| artifact.state == ArtifactState::Confirmed)
+        })
+    }
+
+    /// Drops safe channel references, and artifacts left without any channel.
+    pub fn prune_channels(&mut self, channel_ids: &[ChannelId]) {
+        for artifact in &mut self.artifacts {
+            artifact.channel_ids.retain(|id| !channel_ids.contains(id));
+        }
+        self.artifacts.retain(|artifact| !artifact.channel_ids.is_empty());
+    }
+
+    /// Removes the listed artifacts.
+    pub fn invalidate(&mut self, artifact_ids: &[ArtifactId]) {
+        self.artifacts.retain(|artifact| !artifact_ids.contains(&artifact.id));
+    }
+
+    /// Returns whether `artifact_id` is still retained.
+    pub fn contains(&self, artifact_id: ArtifactId) -> bool {
+        self.artifacts.iter().any(|artifact| artifact.id == artifact_id)
+    }
+
+    /// Clears every artifact while preserving monotonic artifact identifiers.
+    pub fn clear(&mut self) {
+        self.artifacts.clear();
+    }
+
+    /// Returns every artifact available for a new submission.
+    fn ready(&self) -> impl Iterator<Item = &DaArtifact> {
+        self.artifacts.iter().filter(|artifact| artifact.state == ArtifactState::Ready)
+    }
+
+    /// Returns the listed artifacts, in creation order.
+    fn select_mut(&mut self, artifact_ids: &[ArtifactId]) -> impl Iterator<Item = &mut DaArtifact> {
+        self.artifacts.iter_mut().filter(|artifact| artifact_ids.contains(&artifact.id))
+    }
+
+    /// Leases consecutive ready blobs as one transaction.
+    fn lease_blobs(
+        &mut self,
+        first_ready: usize,
+        maximum: usize,
+        submission_id: SubmissionId,
+    ) -> (BatchSubmission, Vec<ArtifactId>) {
+        let indexes: Vec<_> = self
+            .artifacts
+            .iter()
+            .enumerate()
+            .skip(first_ready)
+            .filter(|(_, artifact)| artifact.state == ArtifactState::Ready)
+            .take_while(|(_, artifact)| matches!(artifact.payload, DaArtifactPayload::Blob(_)))
+            .take(maximum)
+            .map(|(index, _)| index)
+            .collect();
+
+        let payloads = indexes
+            .iter()
+            .map(|index| match &self.artifacts[*index].payload {
+                DaArtifactPayload::Blob(payload) => payload.clone(),
+                DaArtifactPayload::Calldata(_) => {
+                    unreachable!("blob lease contains only blob artifacts")
+                }
+            })
+            .collect();
+        let artifact_ids = indexes.iter().map(|index| self.artifacts[*index].id).collect();
+
+        for index in indexes {
+            self.artifacts[index].state = ArtifactState::Pending;
+        }
+
+        (BatchSubmission::blobs(submission_id, payloads), artifact_ids)
+    }
+
+    /// Leases one ready calldata frame as one transaction.
+    fn lease_calldata(
+        &mut self,
+        index: usize,
+        submission_id: SubmissionId,
+    ) -> (BatchSubmission, Vec<ArtifactId>) {
+        let DaArtifactPayload::Calldata(frame) = &self.artifacts[index].payload else {
+            unreachable!("calldata lease requires a calldata artifact");
+        };
+        let frame = Arc::clone(frame);
+        let artifact_id = self.artifacts[index].id;
+
+        self.artifacts[index].state = ArtifactState::Pending;
+
+        (BatchSubmission::calldata(submission_id, frame), vec![artifact_id])
+    }
+}
+
+impl<'a> IntoIterator for &'a DaArtifacts {
+    type Item = &'a DaArtifact;
+    type IntoIter = vec_deque::Iter<'a, DaArtifact>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.artifacts.iter()
+    }
+}

--- a/crates/batcher/encoder/src/config.rs
+++ b/crates/batcher/encoder/src/config.rs
@@ -88,6 +88,19 @@ pub struct EncoderConfig {
     /// [`max_frame_size`]: EncoderConfig::max_frame_size
     /// [`da_type`]: EncoderConfig::da_type
     pub max_l1_tx_size_bytes: Option<usize>,
+
+    /// Optional soft compressed-byte target. The reaching batch stays, then the
+    /// channel closes. `None` closes on duration, flush, or protocol limits.
+    ///
+    /// Default: `None`.
+    pub compressed_size_target: Option<usize>,
+
+    /// Maximum number of blobs packed into one L1 transaction.
+    ///
+    /// Blob DA rejects values above [`Self::MAX_BLOBS_PER_TX`].
+    ///
+    /// Default: 6.
+    pub max_blobs_per_tx: usize,
 }
 
 impl Default for EncoderConfig {
@@ -101,6 +114,8 @@ impl Default for EncoderConfig {
             da_type: DaType::Blob,
             compression_algo: CompressionAlgo::Brotli10,
             max_l1_tx_size_bytes: None,
+            compressed_size_target: None,
+            max_blobs_per_tx: Self::MAX_BLOBS_PER_TX,
         }
     }
 }
@@ -166,6 +181,21 @@ impl EncoderConfig {
         if matches!(self.da_type, DaType::Blob) && self.target_num_frames > Self::MAX_BLOBS_PER_TX {
             return Err(EncoderConfigError::TooManyBlobFramesPerTx {
                 target_num_frames: self.target_num_frames,
+                maximum: Self::MAX_BLOBS_PER_TX,
+            });
+        }
+
+        if matches!(self.compressed_size_target, Some(0)) {
+            return Err(EncoderConfigError::CompressedTargetZero);
+        }
+
+        if self.max_blobs_per_tx == 0 {
+            return Err(EncoderConfigError::MaxBlobsPerTxZero);
+        }
+
+        if self.max_blobs_per_tx > Self::MAX_BLOBS_PER_TX {
+            return Err(EncoderConfigError::TooManyBlobsPerTx {
+                configured: self.max_blobs_per_tx,
                 maximum: Self::MAX_BLOBS_PER_TX,
             });
         }
@@ -271,6 +301,20 @@ pub enum EncoderConfigError {
         /// Protocol maximum blobs per transaction.
         maximum: usize,
     },
+    /// `compressed_size_target == Some(0)`.
+    #[error("compressed_size_target must be greater than zero when configured")]
+    CompressedTargetZero,
+    /// `max_blobs_per_tx == 0`.
+    #[error("max_blobs_per_tx must be greater than zero")]
+    MaxBlobsPerTxZero,
+    /// `max_blobs_per_tx` exceeds the protocol transaction limit.
+    #[error("max_blobs_per_tx ({configured}) must be at most {maximum}")]
+    TooManyBlobsPerTx {
+        /// Configured blob count.
+        configured: usize,
+        /// Protocol maximum blob count.
+        maximum: usize,
+    },
     /// `da_type == DaType::Blob` but `max_frame_size` leaves no room for the
     /// derivation-version prefix.
     #[error(
@@ -323,6 +367,8 @@ mod tests {
 
         assert_eq!(cfg.target_frame_size, EncoderConfig::MAX_BLOB_FRAME_SIZE);
         assert_eq!(cfg.max_frame_size, EncoderConfig::MAX_BLOB_FRAME_SIZE);
+        assert_eq!(cfg.compressed_size_target, None);
+        assert_eq!(cfg.max_blobs_per_tx, EncoderConfig::MAX_BLOBS_PER_TX);
         assert_eq!(
             cfg.max_frame_size + EncoderConfig::BLOB_DERIVATION_PREFIX_SIZE,
             EncoderConfig::BLOB_MAX_DATA_SIZE
@@ -428,6 +474,37 @@ mod tests {
                 target_num_frames,
                 maximum,
             } if target_num_frames == EncoderConfig::MAX_BLOBS_PER_TX + 1
+                && maximum == EncoderConfig::MAX_BLOBS_PER_TX
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_zero_compressed_size_target() {
+        let cfg = EncoderConfig { compressed_size_target: Some(0), ..EncoderConfig::default() };
+
+        assert!(matches!(cfg.validate().unwrap_err(), EncoderConfigError::CompressedTargetZero));
+    }
+
+    #[test]
+    fn validate_rejects_zero_max_blobs_per_tx() {
+        let cfg = EncoderConfig { max_blobs_per_tx: 0, ..EncoderConfig::default() };
+
+        assert!(matches!(cfg.validate().unwrap_err(), EncoderConfigError::MaxBlobsPerTxZero));
+    }
+
+    #[test]
+    fn validate_rejects_max_blobs_per_tx_above_limit() {
+        let cfg = EncoderConfig {
+            max_blobs_per_tx: EncoderConfig::MAX_BLOBS_PER_TX + 1,
+            ..EncoderConfig::default()
+        };
+
+        assert!(matches!(
+            cfg.validate().unwrap_err(),
+            EncoderConfigError::TooManyBlobsPerTx {
+                configured,
+                maximum,
+            } if configured == EncoderConfig::MAX_BLOBS_PER_TX + 1
                 && maximum == EncoderConfig::MAX_BLOBS_PER_TX
         ));
     }

--- a/crates/batcher/encoder/src/egress.rs
+++ b/crates/batcher/encoder/src/egress.rs
@@ -540,8 +540,7 @@ mod tests {
             max_channel_duration: duration,
             ..EncoderConfig::default()
         };
-        Channel::new(id, Arc::new(RollupConfig::default()), &config, 0, opened_l1_block)
-            .unwrap()
+        Channel::new(id, Arc::new(RollupConfig::default()), &config, 0, opened_l1_block).unwrap()
     }
 
     fn incompressible_batch(transaction_len: usize) -> SingleBatch {

--- a/crates/batcher/encoder/src/egress.rs
+++ b/crates/batcher/encoder/src/egress.rs
@@ -7,7 +7,7 @@ use std::{
 
 use base_protocol::{BLOB_DERIVATION_PREFIX_SIZE, BLOB_MAX_DATA_SIZE, ChannelId, Frame};
 
-use crate::{BatchSubmission, BlobPayload, DaType, SubmissionId, record::ChannelRecord};
+use crate::{BatchSubmission, BlobPayload, DaType, SubmissionId, record::Channel};
 
 /// Stable identifier for one immutable DA artifact.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -98,7 +98,7 @@ impl DaEgress {
 
     /// Plans one full or deadline-released blob without mutating channels.
     fn plan_blob(
-        channels: &VecDeque<ChannelRecord>,
+        channels: &VecDeque<Channel>,
         l1_head: u64,
     ) -> Option<Vec<(ChannelId, usize, bool)>> {
         let mut frames = Vec::new();
@@ -135,7 +135,7 @@ impl DaEgress {
     ///
     /// `true` after the terminal frame, so the planner may continue to the next channel.
     fn plan_channel_frames(
-        channel: &ChannelRecord,
+        channel: &Channel,
         remaining: &mut usize,
         frames: &mut Vec<(ChannelId, usize, bool)>,
     ) -> bool {
@@ -173,7 +173,7 @@ impl DaEgress {
     /// Returns whether an immutable ready artifact or buildable payload exists.
     pub fn has_ready_submission(
         &self,
-        channels: &VecDeque<ChannelRecord>,
+        channels: &VecDeque<Channel>,
         da_type: DaType,
         l1_head: u64,
     ) -> bool {
@@ -190,7 +190,7 @@ impl DaEgress {
     /// Builds and leases one transaction-sized submission.
     pub fn next_submission(
         &mut self,
-        channels: &mut VecDeque<ChannelRecord>,
+        channels: &mut VecDeque<Channel>,
         da_type: DaType,
         l1_head: u64,
         max_blobs_per_tx: usize,
@@ -215,7 +215,7 @@ impl DaEgress {
     /// Materializes ready artifacts only when no retry is already waiting.
     fn build_ready_artifacts(
         &mut self,
-        channels: &mut VecDeque<ChannelRecord>,
+        channels: &mut VecDeque<Channel>,
         da_type: DaType,
         l1_head: u64,
         max_blobs: usize,
@@ -343,7 +343,7 @@ impl DaEgress {
     }
 
     /// Returns whether all artifacts from a fully framed channel are confirmed.
-    pub fn channel_fully_confirmed(&self, channel: &ChannelRecord) -> bool {
+    pub fn channel_fully_confirmed(&self, channel: &Channel) -> bool {
         if !channel.framing_complete() {
             return false;
         }
@@ -405,7 +405,7 @@ impl DaEgress {
     }
 
     /// Plans one calldata frame without mutating channel output.
-    fn plan_calldata(channels: &VecDeque<ChannelRecord>) -> Option<(ChannelId, usize, bool)> {
+    fn plan_calldata(channels: &VecDeque<Channel>) -> Option<(ChannelId, usize, bool)> {
         // Preserve FIFO ordering: only the first unfinished channel may emit.
         for channel in channels {
             if channel.framing_complete() {
@@ -436,7 +436,7 @@ impl DaEgress {
     /// Commits a validated blob plan into one immutable ready artifact.
     fn commit_blob(
         &mut self,
-        channels: &mut VecDeque<ChannelRecord>,
+        channels: &mut VecDeque<Channel>,
         plan: Vec<(ChannelId, usize, bool)>,
     ) -> ArtifactId {
         let mut frames = Vec::with_capacity(plan.len());
@@ -464,7 +464,7 @@ impl DaEgress {
     /// Commits one calldata frame into an immutable ready artifact.
     fn commit_calldata(
         &mut self,
-        channels: &mut VecDeque<ChannelRecord>,
+        channels: &mut VecDeque<Channel>,
         plan: (ChannelId, usize, bool),
     ) -> ArtifactId {
         let (channel_id, data_len, is_last) = plan;
@@ -534,13 +534,13 @@ mod tests {
     use super::*;
     use crate::{CompressionAlgo, EncoderConfig, record::ChannelAddOutcome};
 
-    fn channel(id: ChannelId, opened_l1_block: u64, duration: u64) -> ChannelRecord {
+    fn channel(id: ChannelId, opened_l1_block: u64, duration: u64) -> Channel {
         let config = EncoderConfig {
             compression_algo: CompressionAlgo::Zlib,
             max_channel_duration: duration,
             ..EncoderConfig::default()
         };
-        ChannelRecord::new(id, Arc::new(RollupConfig::default()), &config, 0, opened_l1_block)
+        Channel::new(id, Arc::new(RollupConfig::default()), &config, 0, opened_l1_block)
             .unwrap()
     }
 
@@ -563,7 +563,7 @@ mod tests {
         }
     }
 
-    fn append_accepted(channel: &mut ChannelRecord, transaction_len: usize) {
+    fn append_accepted(channel: &mut Channel, transaction_len: usize) {
         assert_eq!(
             channel
                 .add_batch(incompressible_batch(transaction_len), transaction_len as u64)
@@ -572,7 +572,7 @@ mod tests {
         );
     }
 
-    fn fill_open_channel(channel: &mut ChannelRecord, min_output: usize) {
+    fn fill_open_channel(channel: &mut Channel, min_output: usize) {
         let mut transaction_len = 4_096;
         while channel.available_output() < min_output {
             append_accepted(channel, transaction_len);

--- a/crates/batcher/encoder/src/egress.rs
+++ b/crates/batcher/encoder/src/egress.rs
@@ -1,0 +1,647 @@
+//! Immutable DA artifacts built from streaming channel output.
+
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::Arc,
+};
+
+use base_protocol::{BLOB_DERIVATION_PREFIX_SIZE, BLOB_MAX_DATA_SIZE, ChannelId, Frame};
+
+use crate::{BatchSubmission, BlobPayload, DaType, SubmissionId, record::ChannelRecord};
+
+/// Stable identifier for one immutable DA artifact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ArtifactId(u64);
+
+/// Submission state of one immutable DA artifact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArtifactState {
+    /// Available for a new L1 submission.
+    Ready,
+    /// Leased to one in-flight submission.
+    Pending,
+    /// Confirmed on L1.
+    Confirmed,
+}
+
+/// Immutable payload carried by one DA artifact.
+#[derive(Debug)]
+pub enum DaArtifactPayload {
+    /// One complete EIP-4844 blob payload.
+    Blob(BlobPayload),
+    /// One derivation frame carried by calldata.
+    Calldata(Arc<Frame>),
+}
+
+/// One immutable artifact retained through submission retries and confirmation.
+#[derive(Debug)]
+pub struct DaArtifact {
+    /// Stable artifact identifier.
+    id: ArtifactId,
+    /// Artifact payload.
+    payload: DaArtifactPayload,
+    /// Channels contributing frames to this artifact.
+    channel_ids: Vec<ChannelId>,
+    /// Current submission state.
+    state: ArtifactState,
+}
+
+impl DaArtifact {
+    /// Returns the artifact identifier.
+    pub const fn id(&self) -> ArtifactId {
+        self.id
+    }
+
+    /// Returns contributing channel identifiers.
+    pub fn channel_ids(&self) -> &[ChannelId] {
+        &self.channel_ids
+    }
+
+    /// Returns the current submission state.
+    pub const fn state(&self) -> ArtifactState {
+        self.state
+    }
+
+    /// Returns the number of frames carried by this artifact.
+    pub fn frame_count(&self) -> usize {
+        match &self.payload {
+            DaArtifactPayload::Blob(payload) => payload.frames().len(),
+            DaArtifactPayload::Calldata(_) => 1,
+        }
+    }
+}
+
+/// Stateful DA egress and immutable artifact ledger.
+#[derive(Debug, Default)]
+pub struct DaEgress {
+    /// Artifacts in creation order.
+    artifacts: VecDeque<DaArtifact>,
+    /// In-flight submissions and their immutable artifacts.
+    pending: HashMap<SubmissionId, Vec<ArtifactId>>,
+    /// Next stable artifact identifier.
+    next_artifact_id: u64,
+}
+
+impl DaEgress {
+    /// Number of frame bytes available in one blob after its version prefix.
+    pub const BLOB_CAPACITY: usize = BLOB_MAX_DATA_SIZE - BLOB_DERIVATION_PREFIX_SIZE;
+
+    /// Creates an empty DA egress.
+    pub fn new() -> Self {
+        Self { artifacts: VecDeque::new(), pending: HashMap::new(), next_artifact_id: 0 }
+    }
+
+    /// Returns all retained artifacts in creation order.
+    pub const fn artifacts(&self) -> &VecDeque<DaArtifact> {
+        &self.artifacts
+    }
+
+    /// Plans one full or deadline-released blob without mutating channels.
+    fn plan_blob(
+        channels: &VecDeque<ChannelRecord>,
+        l1_head: u64,
+    ) -> Option<Vec<(ChannelId, usize, bool)>> {
+        let mut frames = Vec::new();
+        let mut remaining = Self::BLOB_CAPACITY;
+        let mut release_due = false;
+
+        for channel in channels {
+            if channel.framing_complete() {
+                continue;
+            }
+
+            let first_frame = frames.len();
+            let channel_complete = Self::plan_channel_frames(channel, &mut remaining, &mut frames);
+
+            if frames.len() > first_frame && !channel.is_open() {
+                release_due |= channel.deadline_due(l1_head);
+            }
+
+            // Open output, or a closed tail that does not fit, stops the walk.
+            if !channel_complete {
+                break;
+            }
+        }
+
+        if frames.is_empty() {
+            return None;
+        }
+
+        let saturated = remaining < Frame::ENCODED_OVERHEAD + 1;
+        if saturated || release_due { Some(frames) } else { None }
+    }
+
+    /// Append frames from one channel that fit in the current blob.
+    ///
+    /// `true` after the terminal frame, so the planner may continue to the next channel.
+    fn plan_channel_frames(
+        channel: &ChannelRecord,
+        remaining: &mut usize,
+        frames: &mut Vec<(ChannelId, usize, bool)>,
+    ) -> bool {
+        let mut available = channel.available_output();
+        let mut terminal_pending = channel.terminal_pending();
+
+        // Every emitted data frame consumes a stable compressed prefix.
+        while available > 0 && *remaining > Frame::ENCODED_OVERHEAD {
+            let data_capacity =
+                (*remaining - Frame::ENCODED_OVERHEAD).min(channel.max_frame_data());
+            let data_len = available.min(data_capacity);
+            let is_last = data_len == available && terminal_pending;
+            frames.push((channel.id(), data_len, is_last));
+
+            available -= data_len;
+            *remaining -= Frame::ENCODED_OVERHEAD + data_len;
+
+            if is_last {
+                terminal_pending = false;
+                break;
+            }
+        }
+
+        // An empty compressed stream still needs one terminal frame.
+        if available == 0 && terminal_pending && *remaining >= Frame::ENCODED_OVERHEAD {
+            frames.push((channel.id(), 0, true));
+
+            *remaining -= Frame::ENCODED_OVERHEAD;
+            terminal_pending = false;
+        }
+
+        !channel.is_open() && available == 0 && !terminal_pending
+    }
+
+    /// Returns whether an immutable ready artifact or buildable payload exists.
+    pub fn has_ready_submission(
+        &self,
+        channels: &VecDeque<ChannelRecord>,
+        da_type: DaType,
+        l1_head: u64,
+    ) -> bool {
+        if self.artifacts.iter().any(|artifact| artifact.state == ArtifactState::Ready) {
+            return true;
+        }
+
+        match da_type {
+            DaType::Blob => Self::plan_blob(channels, l1_head).is_some(),
+            DaType::Calldata => Self::plan_calldata(channels).is_some(),
+        }
+    }
+
+    /// Builds and leases one transaction-sized submission.
+    pub fn next_submission(
+        &mut self,
+        channels: &mut VecDeque<ChannelRecord>,
+        da_type: DaType,
+        l1_head: u64,
+        max_blobs_per_tx: usize,
+        id: SubmissionId,
+    ) -> Option<BatchSubmission> {
+        if !self.artifacts.iter().any(|artifact| artifact.state == ArtifactState::Ready) {
+            self.build_ready_artifacts(channels, da_type, l1_head, max_blobs_per_tx);
+        }
+
+        let first_ready =
+            self.artifacts.iter().position(|artifact| artifact.state == ArtifactState::Ready)?;
+
+        let (submission, artifact_ids) = match &self.artifacts[first_ready].payload {
+            DaArtifactPayload::Blob(_) => self.lease_blobs(first_ready, max_blobs_per_tx, id),
+            DaArtifactPayload::Calldata(_) => self.lease_calldata(first_ready, id),
+        };
+        self.pending.insert(id, artifact_ids);
+
+        Some(submission)
+    }
+
+    /// Materializes ready artifacts only when no retry is already waiting.
+    fn build_ready_artifacts(
+        &mut self,
+        channels: &mut VecDeque<ChannelRecord>,
+        da_type: DaType,
+        l1_head: u64,
+        max_blobs: usize,
+    ) {
+        match da_type {
+            DaType::Blob => {
+                while self
+                    .artifacts
+                    .iter()
+                    .filter(|artifact| {
+                        artifact.state == ArtifactState::Ready
+                            && matches!(artifact.payload, DaArtifactPayload::Blob(_))
+                    })
+                    .count()
+                    < max_blobs
+                {
+                    let Some(plan) = Self::plan_blob(channels, l1_head) else {
+                        break;
+                    };
+                    self.commit_blob(channels, plan);
+                }
+            }
+            DaType::Calldata => {
+                if let Some(plan) = Self::plan_calldata(channels) {
+                    self.commit_calldata(channels, plan);
+                }
+            }
+        }
+    }
+
+    /// Leases consecutive ready blobs as one transaction.
+    fn lease_blobs(
+        &mut self,
+        first_ready: usize,
+        maximum: usize,
+        submission_id: SubmissionId,
+    ) -> (BatchSubmission, Vec<ArtifactId>) {
+        let indexes: Vec<_> = self
+            .artifacts
+            .iter()
+            .enumerate()
+            .skip(first_ready)
+            .filter(|(_, artifact)| artifact.state == ArtifactState::Ready)
+            .take_while(|(_, artifact)| matches!(artifact.payload, DaArtifactPayload::Blob(_)))
+            .take(maximum)
+            .map(|(index, _)| index)
+            .collect();
+
+        let payloads = indexes
+            .iter()
+            .map(|index| match &self.artifacts[*index].payload {
+                DaArtifactPayload::Blob(payload) => payload.clone(),
+                DaArtifactPayload::Calldata(_) => {
+                    unreachable!("blob lease contains only blob artifacts")
+                }
+            })
+            .collect();
+        let artifact_ids = indexes.iter().map(|index| self.artifacts[*index].id).collect();
+
+        for index in indexes {
+            self.artifacts[index].state = ArtifactState::Pending;
+        }
+
+        (BatchSubmission::blobs(submission_id, payloads), artifact_ids)
+    }
+
+    /// Leases one ready calldata frame as one transaction.
+    fn lease_calldata(
+        &mut self,
+        index: usize,
+        submission_id: SubmissionId,
+    ) -> (BatchSubmission, Vec<ArtifactId>) {
+        let DaArtifactPayload::Calldata(frame) = &self.artifacts[index].payload else {
+            unreachable!("calldata lease requires a calldata artifact");
+        };
+        let frame = Arc::clone(frame);
+        let artifact_id = self.artifacts[index].id;
+
+        self.artifacts[index].state = ArtifactState::Pending;
+
+        (BatchSubmission::calldata(submission_id, frame), vec![artifact_id])
+    }
+
+    /// Confirms every artifact leased to `submission_id`.
+    pub fn confirm(&mut self, submission_id: SubmissionId) -> Option<Vec<ChannelId>> {
+        let artifact_ids = self.pending.remove(&submission_id)?;
+        if !self.lease_matches(&artifact_ids) {
+            return None;
+        }
+
+        let mut channel_ids = Vec::new();
+
+        for artifact in &mut self.artifacts {
+            if !artifact_ids.contains(&artifact.id) {
+                continue;
+            }
+
+            artifact.state = ArtifactState::Confirmed;
+            for channel_id in &artifact.channel_ids {
+                if !channel_ids.contains(channel_id) {
+                    channel_ids.push(*channel_id);
+                }
+            }
+        }
+
+        Some(channel_ids)
+    }
+
+    /// Returns every artifact leased to `submission_id` to ready state.
+    pub fn requeue(&mut self, submission_id: SubmissionId) -> Option<usize> {
+        let artifact_ids = self.pending.remove(&submission_id)?;
+        if !self.lease_matches(&artifact_ids) {
+            return None;
+        }
+
+        let mut frame_count = 0;
+        for artifact in &mut self.artifacts {
+            if artifact_ids.contains(&artifact.id) {
+                frame_count += artifact.frame_count();
+                artifact.state = ArtifactState::Ready;
+            }
+        }
+
+        Some(frame_count)
+    }
+
+    /// Returns whether all artifacts from a fully framed channel are confirmed.
+    pub fn channel_fully_confirmed(&self, channel: &ChannelRecord) -> bool {
+        if !channel.framing_complete() {
+            return false;
+        }
+
+        let mut found = false;
+        for artifact in &self.artifacts {
+            if !artifact.channel_ids.contains(&channel.id()) {
+                continue;
+            }
+            found = true;
+            if artifact.state != ArtifactState::Confirmed {
+                return false;
+            }
+        }
+        found
+    }
+
+    /// Removes safe channel references and artifacts no longer tracking any channel.
+    pub fn prune_channels(&mut self, channel_ids: &[ChannelId]) {
+        for artifact in &mut self.artifacts {
+            artifact.channel_ids.retain(|id| !channel_ids.contains(id));
+        }
+        self.artifacts.retain(|artifact| !artifact.channel_ids.is_empty());
+        self.retain_existing_pending_artifacts();
+    }
+
+    /// Removes artifacts invalidated by deterministic replay closure.
+    pub fn invalidate_artifacts(&mut self, artifact_ids: &[ArtifactId]) {
+        self.artifacts.retain(|artifact| !artifact_ids.contains(&artifact.id));
+        self.pending.retain(|_, pending| !pending.iter().any(|id| artifact_ids.contains(id)));
+    }
+
+    /// Adds every artifact sharing an in-flight submission with `affected`.
+    pub fn extend_with_submission_artifacts(&self, affected: &mut Vec<ArtifactId>) {
+        for artifact_ids in self.pending.values() {
+            if artifact_ids.iter().any(|id| affected.contains(id)) {
+                for id in artifact_ids {
+                    if !affected.contains(id) {
+                        affected.push(*id);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Returns the number of frames currently available for submission.
+    pub fn ready_frame_count(&self) -> usize {
+        self.artifacts
+            .iter()
+            .filter(|artifact| artifact.state == ArtifactState::Ready)
+            .map(DaArtifact::frame_count)
+            .sum()
+    }
+
+    /// Clears every artifact while preserving monotonic artifact identifiers.
+    pub fn reset(&mut self) {
+        self.artifacts.clear();
+        self.pending.clear();
+    }
+
+    /// Plans one calldata frame without mutating channel output.
+    fn plan_calldata(channels: &VecDeque<ChannelRecord>) -> Option<(ChannelId, usize, bool)> {
+        // Preserve FIFO ordering: only the first unfinished channel may emit.
+        for channel in channels {
+            if channel.framing_complete() {
+                continue;
+            }
+
+            let available = channel.available_output();
+
+            // Full frames may stream before the channel closes.
+            if available >= channel.max_frame_data() {
+                let data_len = channel.max_frame_data();
+                let is_last = data_len == available && channel.terminal_pending();
+                return Some((channel.id(), data_len, is_last));
+            }
+
+            // A closed channel releases its final, possibly empty, frame.
+            if channel.terminal_pending() {
+                return Some((channel.id(), available, true));
+            }
+
+            // Partial output from an open channel remains buffered.
+            return None;
+        }
+
+        None
+    }
+
+    /// Commits a validated blob plan into one immutable ready artifact.
+    fn commit_blob(
+        &mut self,
+        channels: &mut VecDeque<ChannelRecord>,
+        plan: Vec<(ChannelId, usize, bool)>,
+    ) -> ArtifactId {
+        let mut frames = Vec::with_capacity(plan.len());
+        let mut channel_ids = Vec::new();
+
+        for (channel_id, data_len, is_last) in plan {
+            let channel = channels
+                .iter_mut()
+                .find(|channel| channel.id() == channel_id)
+                .expect("planned channel remains in the encoder FIFO");
+            let frame = Arc::new(
+                channel.take_frame(data_len, is_last).expect("blob plan satisfies channel limits"),
+            );
+
+            if !channel_ids.contains(&channel.id()) {
+                channel_ids.push(channel.id());
+            }
+            frames.push(frame);
+        }
+
+        let payload = BlobPayload::new(frames);
+        self.push_artifact(DaArtifactPayload::Blob(payload), channel_ids)
+    }
+
+    /// Commits one calldata frame into an immutable ready artifact.
+    fn commit_calldata(
+        &mut self,
+        channels: &mut VecDeque<ChannelRecord>,
+        plan: (ChannelId, usize, bool),
+    ) -> ArtifactId {
+        let (channel_id, data_len, is_last) = plan;
+        let channel = channels
+            .iter_mut()
+            .find(|channel| channel.id() == channel_id)
+            .expect("planned channel remains in the encoder FIFO");
+        let frame = Arc::new(
+            channel.take_frame(data_len, is_last).expect("calldata plan satisfies channel limits"),
+        );
+
+        self.push_artifact(DaArtifactPayload::Calldata(frame), vec![channel_id])
+    }
+
+    /// Appends one immutable ready artifact.
+    fn push_artifact(
+        &mut self,
+        payload: DaArtifactPayload,
+        channel_ids: Vec<ChannelId>,
+    ) -> ArtifactId {
+        let id = ArtifactId(self.next_artifact_id);
+        self.next_artifact_id += 1;
+        self.artifacts.push_back(DaArtifact {
+            id,
+            payload,
+            channel_ids,
+            state: ArtifactState::Ready,
+        });
+        id
+    }
+
+    /// Returns whether every artifact in a lease remains pending.
+    fn lease_matches(&self, artifact_ids: &[ArtifactId]) -> bool {
+        artifact_ids.iter().all(|id| {
+            self.artifacts
+                .iter()
+                .any(|artifact| artifact.id == *id && artifact.state == ArtifactState::Pending)
+        })
+    }
+
+    /// Removes pruned artifact identifiers from pending submissions.
+    fn retain_existing_pending_artifacts(&mut self) {
+        let artifacts = &self.artifacts;
+        self.pending.retain(|_, pending| {
+            pending.retain(|id| artifacts.iter().any(|artifact| artifact.id == *id));
+            !pending.is_empty()
+        });
+    }
+
+    /// Returns artifacts leased to `submission_id`.
+    pub fn pending_artifacts(&self, submission_id: SubmissionId) -> Option<&[ArtifactId]> {
+        self.pending.get(&submission_id).map(Vec::as_slice)
+    }
+
+    /// Returns the number of in-flight submissions.
+    pub fn pending_submission_count(&self) -> usize {
+        self.pending.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{B256, Bytes};
+    use base_common_genesis::RollupConfig;
+    use base_protocol::SingleBatch;
+
+    use super::*;
+    use crate::{CompressionAlgo, EncoderConfig, record::ChannelAddOutcome};
+
+    fn channel(id: ChannelId, opened_l1_block: u64, duration: u64) -> ChannelRecord {
+        let config = EncoderConfig {
+            compression_algo: CompressionAlgo::Zlib,
+            max_channel_duration: duration,
+            ..EncoderConfig::default()
+        };
+        ChannelRecord::new(id, Arc::new(RollupConfig::default()), &config, 0, opened_l1_block)
+            .unwrap()
+    }
+
+    fn incompressible_batch(transaction_len: usize) -> SingleBatch {
+        let mut state = 1u64;
+        let transaction = (0..transaction_len)
+            .map(|_| {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                state as u8
+            })
+            .collect::<Vec<_>>();
+        SingleBatch {
+            parent_hash: B256::ZERO,
+            epoch_num: 0,
+            epoch_hash: B256::ZERO,
+            timestamp: 0,
+            transactions: vec![Bytes::from(transaction)],
+        }
+    }
+
+    fn append_accepted(channel: &mut ChannelRecord, transaction_len: usize) {
+        assert_eq!(
+            channel
+                .add_batch(incompressible_batch(transaction_len), transaction_len as u64)
+                .unwrap(),
+            ChannelAddOutcome::Accepted
+        );
+    }
+
+    fn fill_open_channel(channel: &mut ChannelRecord, min_output: usize) {
+        let mut transaction_len = 4_096;
+        while channel.available_output() < min_output {
+            append_accepted(channel, transaction_len);
+            transaction_len = (transaction_len * 2).min(200_000);
+        }
+        assert!(channel.is_open());
+    }
+
+    #[test]
+    fn full_blob_is_ready_from_open_channel_output() {
+        let mut channel = channel([1; 16], 0, 10);
+        fill_open_channel(&mut channel, DaEgress::BLOB_CAPACITY - Frame::ENCODED_OVERHEAD);
+        let channels = VecDeque::from([channel]);
+
+        let plan = DaEgress::plan_blob(&channels, 0).expect("full blob");
+        let (_, _, is_last) = plan[0];
+
+        assert_eq!(plan.len(), 1);
+        assert!(!is_last);
+    }
+
+    #[test]
+    fn open_channel_timeout_does_not_release_non_terminal_partial_data() {
+        let mut channel = channel([1; 16], 0, 1);
+        append_accepted(&mut channel, 50_000);
+        assert!(channel.available_output() > 0);
+        assert!(channel.available_output() < DaEgress::BLOB_CAPACITY - Frame::ENCODED_OVERHEAD);
+        let channels = VecDeque::from([channel]);
+
+        assert!(DaEgress::plan_blob(&channels, 1).is_none());
+    }
+
+    #[test]
+    fn closed_channel_timeout_releases_partial_tail() {
+        let mut channel = channel([1; 16], 0, 2);
+        append_accepted(&mut channel, 50_000);
+        channel.close().unwrap();
+        assert!(channel.available_output() > 0);
+        assert!(channel.available_output() < DaEgress::BLOB_CAPACITY - Frame::ENCODED_OVERHEAD);
+        let channels = VecDeque::from([channel]);
+
+        assert!(DaEgress::plan_blob(&channels, 1).is_none());
+        let plan = DaEgress::plan_blob(&channels, 2).expect("timeout-released tail");
+        assert!(plan.last().is_some_and(|(_, _, is_last)| *is_last));
+    }
+
+    #[test]
+    fn plan_crosses_closed_channel_boundary_without_mutation() {
+        let mut first = channel([1; 16], 0, 10);
+        append_accepted(&mut first, 50_000);
+        first.close().unwrap();
+        let first_bytes = first.available_output();
+        assert!(first_bytes > 0);
+        assert!(first_bytes < DaEgress::BLOB_CAPACITY - Frame::ENCODED_OVERHEAD);
+
+        let mut second = channel([2; 16], 0, 10);
+        fill_open_channel(&mut second, DaEgress::BLOB_CAPACITY);
+        let second_bytes = second.available_output();
+        let channels = VecDeque::from([first, second]);
+
+        let plan = DaEgress::plan_blob(&channels, 0).expect("cross-channel blob");
+        let (first_id, _, first_is_last) = plan[0];
+        let (second_id, _, second_is_last) = plan[1];
+
+        assert_eq!(first_id, [1; 16]);
+        assert!(first_is_last);
+        assert_eq!(second_id, [2; 16]);
+        assert!(!second_is_last);
+        assert_eq!(channels[0].available_output(), first_bytes);
+        assert_eq!(channels[1].available_output(), second_bytes);
+    }
+}

--- a/crates/batcher/encoder/src/egress.rs
+++ b/crates/batcher/encoder/src/egress.rs
@@ -416,6 +416,40 @@ mod tests {
     }
 
     #[test]
+    fn calldata_plan_emits_a_full_frame_before_close() {
+        let mut channel = channel([1; 16], 0, 10);
+        let max_frame_data = channel.max_frame_data();
+        fill_open_channel(&mut channel, max_frame_data);
+        let channels = VecDeque::from([channel]);
+
+        assert_eq!(DaEgress::plan_calldata(&channels), Some(([1; 16], max_frame_data, false)));
+    }
+
+    #[test]
+    fn calldata_plan_buffers_partial_open_output() {
+        let mut channel = channel([1; 16], 0, 10);
+        append_accepted(&mut channel, 50_000);
+        let buffered = channel.available_output();
+        assert!(buffered > 0 && buffered < channel.max_frame_data());
+        let channels = VecDeque::from([channel]);
+
+        assert!(DaEgress::plan_calldata(&channels).is_none());
+        assert_eq!(channels[0].available_output(), buffered);
+    }
+
+    #[test]
+    fn calldata_plan_releases_the_closed_tail() {
+        let mut channel = channel([1; 16], 0, 10);
+        append_accepted(&mut channel, 50_000);
+        channel.close().unwrap();
+        let tail = channel.available_output();
+        assert!(tail > 0 && tail < channel.max_frame_data());
+        let channels = VecDeque::from([channel]);
+
+        assert_eq!(DaEgress::plan_calldata(&channels), Some(([1; 16], tail, true)));
+    }
+
+    #[test]
     fn plan_crosses_closed_channel_boundary_without_mutation() {
         let mut first = channel([1; 16], 0, 10);
         append_accepted(&mut first, 50_000);
@@ -439,5 +473,131 @@ mod tests {
         assert!(!second_is_last);
         assert_eq!(channels[0].available_output(), first_bytes);
         assert_eq!(channels[1].available_output(), second_bytes);
+    }
+
+    /// Returns an egress and one channel holding `blobs` worth of output.
+    fn egress_with_output(blobs: usize) -> (DaEgress, VecDeque<Channel>) {
+        let mut channel = channel([1; 16], 0, 10);
+        fill_open_channel(&mut channel, DaEgress::BLOB_CAPACITY * blobs);
+
+        (DaEgress::new(), VecDeque::from([channel]))
+    }
+
+    #[test]
+    fn submission_confirms_the_contributing_channel() {
+        let (mut egress, mut channels) = egress_with_output(1);
+
+        let submission = egress
+            .next_submission(&mut channels, DaType::Blob, 0, 6, SubmissionId(0))
+            .expect("blob submission");
+
+        assert_eq!(egress.pending_submission_count(), 1);
+        assert!(!egress.channel_fully_confirmed(&channels[0]));
+
+        assert_eq!(egress.confirm(submission.id), Some(vec![[1; 16]]));
+        assert_eq!(egress.pending_submission_count(), 0);
+        assert!(egress.confirm(submission.id).is_none());
+
+        // The channel keeps producing frames, so confirmed artifacts are not enough.
+        assert!(!egress.channel_fully_confirmed(&channels[0]));
+    }
+
+    #[test]
+    fn a_requeued_submission_is_leased_again_before_new_output() {
+        let (mut egress, mut channels) = egress_with_output(2);
+        let first = egress
+            .next_submission(&mut channels, DaType::Blob, 0, 1, SubmissionId(0))
+            .expect("blob submission");
+        let leased = egress.pending_artifacts(first.id).expect("in-flight submission").to_vec();
+
+        assert_eq!(egress.requeue(first.id), Some(first.frame_count()));
+        assert_eq!(egress.artifacts().ready_frame_count(), first.frame_count());
+        assert_eq!(egress.pending_submission_count(), 0);
+        assert!(egress.requeue(first.id).is_none());
+
+        // The channel still holds output, but a retry takes priority over new blobs.
+        let retry = egress
+            .next_submission(&mut channels, DaType::Blob, 0, 2, SubmissionId(1))
+            .expect("retry submission");
+
+        assert_eq!(egress.pending_artifacts(retry.id), Some(leased.as_slice()));
+        assert_eq!(egress.artifacts().len(), 1);
+    }
+
+    #[test]
+    fn blob_submissions_are_capped_by_max_blobs_per_tx() {
+        let (mut egress, mut channels) = egress_with_output(3);
+
+        let submission = egress
+            .next_submission(&mut channels, DaType::Blob, 0, 2, SubmissionId(0))
+            .expect("blob submission");
+
+        assert_eq!(submission.blob_count(), 2);
+        assert_eq!(egress.artifacts().len(), 2);
+    }
+
+    #[test]
+    fn co_submitted_artifacts_extend_the_replay_closure() {
+        let (mut egress, mut channels) = egress_with_output(2);
+        let submission = egress
+            .next_submission(&mut channels, DaType::Blob, 0, 2, SubmissionId(0))
+            .expect("blob submission");
+        let leased =
+            egress.pending_artifacts(submission.id).expect("in-flight submission").to_vec();
+        assert_eq!(leased.len(), 2);
+
+        let mut affected = vec![leased[0]];
+        egress.extend_with_submission_artifacts(&mut affected);
+
+        assert_eq!(affected, leased);
+    }
+
+    #[test]
+    fn invalidating_a_leased_artifact_drops_its_submission() {
+        let (mut egress, mut channels) = egress_with_output(1);
+        let submission = egress
+            .next_submission(&mut channels, DaType::Blob, 0, 6, SubmissionId(0))
+            .expect("blob submission");
+        let leased =
+            egress.pending_artifacts(submission.id).expect("in-flight submission").to_vec();
+
+        egress.invalidate_artifacts(&leased);
+
+        assert!(egress.artifacts().is_empty());
+        assert_eq!(egress.pending_submission_count(), 0);
+        assert!(egress.pending_artifacts(submission.id).is_none());
+    }
+
+    #[test]
+    fn pruning_a_safe_channel_drops_its_confirmed_artifacts() {
+        let (mut egress, mut channels) = egress_with_output(1);
+        let submission = egress
+            .next_submission(&mut channels, DaType::Blob, 0, 6, SubmissionId(0))
+            .expect("blob submission");
+        egress.confirm(submission.id).expect("confirmed submission");
+
+        egress.prune_channels(&[[1; 16]]);
+
+        assert!(egress.artifacts().is_empty());
+    }
+
+    #[test]
+    fn reset_clears_artifacts_without_reusing_identifiers() {
+        let (mut egress, mut channels) = egress_with_output(2);
+        let submission = egress
+            .next_submission(&mut channels, DaType::Blob, 0, 1, SubmissionId(0))
+            .expect("blob submission");
+        let leased =
+            egress.pending_artifacts(submission.id).expect("in-flight submission").to_vec();
+
+        egress.reset();
+        assert!(egress.artifacts().is_empty());
+        assert_eq!(egress.pending_submission_count(), 0);
+
+        let rebuilt = egress
+            .next_submission(&mut channels, DaType::Blob, 0, 1, SubmissionId(1))
+            .expect("submission after reset");
+
+        assert_ne!(egress.pending_artifacts(rebuilt.id), Some(leased.as_slice()));
     }
 }

--- a/crates/batcher/encoder/src/egress.rs
+++ b/crates/batcher/encoder/src/egress.rs
@@ -362,7 +362,7 @@ mod tests {
     fn append_accepted(channel: &mut Channel, transaction_len: usize) {
         assert_eq!(
             channel
-                .add_batch(incompressible_batch(transaction_len), transaction_len as u64)
+                .add_batch(&incompressible_batch(transaction_len), transaction_len as u64)
                 .unwrap(),
             ChannelAddOutcome::Accepted
         );

--- a/crates/batcher/encoder/src/egress.rs
+++ b/crates/batcher/encoder/src/egress.rs
@@ -7,79 +7,19 @@ use std::{
 
 use base_protocol::{BLOB_DERIVATION_PREFIX_SIZE, BLOB_MAX_DATA_SIZE, ChannelId, Frame};
 
-use crate::{BatchSubmission, BlobPayload, DaType, SubmissionId, record::Channel};
+use crate::{
+    BatchSubmission, BlobPayload, DaType, SubmissionId,
+    artifact::{ArtifactId, DaArtifactPayload, DaArtifacts},
+    record::Channel,
+};
 
-/// Stable identifier for one immutable DA artifact.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ArtifactId(u64);
-
-/// Submission state of one immutable DA artifact.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ArtifactState {
-    /// Available for a new L1 submission.
-    Ready,
-    /// Leased to one in-flight submission.
-    Pending,
-    /// Confirmed on L1.
-    Confirmed,
-}
-
-/// Immutable payload carried by one DA artifact.
-#[derive(Debug)]
-pub enum DaArtifactPayload {
-    /// One complete EIP-4844 blob payload.
-    Blob(BlobPayload),
-    /// One derivation frame carried by calldata.
-    Calldata(Arc<Frame>),
-}
-
-/// One immutable artifact retained through submission retries and confirmation.
-#[derive(Debug)]
-pub struct DaArtifact {
-    /// Stable artifact identifier.
-    id: ArtifactId,
-    /// Artifact payload.
-    payload: DaArtifactPayload,
-    /// Channels contributing frames to this artifact.
-    channel_ids: Vec<ChannelId>,
-    /// Current submission state.
-    state: ArtifactState,
-}
-
-impl DaArtifact {
-    /// Returns the artifact identifier.
-    pub const fn id(&self) -> ArtifactId {
-        self.id
-    }
-
-    /// Returns contributing channel identifiers.
-    pub fn channel_ids(&self) -> &[ChannelId] {
-        &self.channel_ids
-    }
-
-    /// Returns the current submission state.
-    pub const fn state(&self) -> ArtifactState {
-        self.state
-    }
-
-    /// Returns the number of frames carried by this artifact.
-    pub fn frame_count(&self) -> usize {
-        match &self.payload {
-            DaArtifactPayload::Blob(payload) => payload.frames().len(),
-            DaArtifactPayload::Calldata(_) => 1,
-        }
-    }
-}
-
-/// Stateful DA egress and immutable artifact ledger.
+/// Stateful DA egress over an immutable artifact ledger.
 #[derive(Debug, Default)]
 pub struct DaEgress {
-    /// Artifacts in creation order.
-    artifacts: VecDeque<DaArtifact>,
+    /// Immutable artifacts and their submission state.
+    artifacts: DaArtifacts,
     /// In-flight submissions and their immutable artifacts.
     pending: HashMap<SubmissionId, Vec<ArtifactId>>,
-    /// Next stable artifact identifier.
-    next_artifact_id: u64,
 }
 
 impl DaEgress {
@@ -88,11 +28,11 @@ impl DaEgress {
 
     /// Creates an empty DA egress.
     pub fn new() -> Self {
-        Self { artifacts: VecDeque::new(), pending: HashMap::new(), next_artifact_id: 0 }
+        Self { artifacts: DaArtifacts::new(), pending: HashMap::new() }
     }
 
-    /// Returns all retained artifacts in creation order.
-    pub const fn artifacts(&self) -> &VecDeque<DaArtifact> {
+    /// Returns the immutable artifact ledger.
+    pub const fn artifacts(&self) -> &DaArtifacts {
         &self.artifacts
     }
 
@@ -177,7 +117,7 @@ impl DaEgress {
         da_type: DaType,
         l1_head: u64,
     ) -> bool {
-        if self.artifacts.iter().any(|artifact| artifact.state == ArtifactState::Ready) {
+        if self.artifacts.has_ready() {
             return true;
         }
 
@@ -196,17 +136,11 @@ impl DaEgress {
         max_blobs_per_tx: usize,
         id: SubmissionId,
     ) -> Option<BatchSubmission> {
-        if !self.artifacts.iter().any(|artifact| artifact.state == ArtifactState::Ready) {
+        if !self.artifacts.has_ready() {
             self.build_ready_artifacts(channels, da_type, l1_head, max_blobs_per_tx);
         }
 
-        let first_ready =
-            self.artifacts.iter().position(|artifact| artifact.state == ArtifactState::Ready)?;
-
-        let (submission, artifact_ids) = match &self.artifacts[first_ready].payload {
-            DaArtifactPayload::Blob(_) => self.lease_blobs(first_ready, max_blobs_per_tx, id),
-            DaArtifactPayload::Calldata(_) => self.lease_calldata(first_ready, id),
-        };
+        let (submission, artifact_ids) = self.artifacts.lease(id, max_blobs_per_tx)?;
         self.pending.insert(id, artifact_ids);
 
         Some(submission)
@@ -222,16 +156,7 @@ impl DaEgress {
     ) {
         match da_type {
             DaType::Blob => {
-                while self
-                    .artifacts
-                    .iter()
-                    .filter(|artifact| {
-                        artifact.state == ArtifactState::Ready
-                            && matches!(artifact.payload, DaArtifactPayload::Blob(_))
-                    })
-                    .count()
-                    < max_blobs
-                {
+                while self.artifacts.ready_blob_count() < max_blobs {
                     let Some(plan) = Self::plan_blob(channels, l1_head) else {
                         break;
                     };
@@ -246,133 +171,40 @@ impl DaEgress {
         }
     }
 
-    /// Leases consecutive ready blobs as one transaction.
-    fn lease_blobs(
-        &mut self,
-        first_ready: usize,
-        maximum: usize,
-        submission_id: SubmissionId,
-    ) -> (BatchSubmission, Vec<ArtifactId>) {
-        let indexes: Vec<_> = self
-            .artifacts
-            .iter()
-            .enumerate()
-            .skip(first_ready)
-            .filter(|(_, artifact)| artifact.state == ArtifactState::Ready)
-            .take_while(|(_, artifact)| matches!(artifact.payload, DaArtifactPayload::Blob(_)))
-            .take(maximum)
-            .map(|(index, _)| index)
-            .collect();
-
-        let payloads = indexes
-            .iter()
-            .map(|index| match &self.artifacts[*index].payload {
-                DaArtifactPayload::Blob(payload) => payload.clone(),
-                DaArtifactPayload::Calldata(_) => {
-                    unreachable!("blob lease contains only blob artifacts")
-                }
-            })
-            .collect();
-        let artifact_ids = indexes.iter().map(|index| self.artifacts[*index].id).collect();
-
-        for index in indexes {
-            self.artifacts[index].state = ArtifactState::Pending;
-        }
-
-        (BatchSubmission::blobs(submission_id, payloads), artifact_ids)
-    }
-
-    /// Leases one ready calldata frame as one transaction.
-    fn lease_calldata(
-        &mut self,
-        index: usize,
-        submission_id: SubmissionId,
-    ) -> (BatchSubmission, Vec<ArtifactId>) {
-        let DaArtifactPayload::Calldata(frame) = &self.artifacts[index].payload else {
-            unreachable!("calldata lease requires a calldata artifact");
-        };
-        let frame = Arc::clone(frame);
-        let artifact_id = self.artifacts[index].id;
-
-        self.artifacts[index].state = ArtifactState::Pending;
-
-        (BatchSubmission::calldata(submission_id, frame), vec![artifact_id])
-    }
-
     /// Confirms every artifact leased to `submission_id`.
     pub fn confirm(&mut self, submission_id: SubmissionId) -> Option<Vec<ChannelId>> {
         let artifact_ids = self.pending.remove(&submission_id)?;
-        if !self.lease_matches(&artifact_ids) {
+        if !self.artifacts.all_pending(&artifact_ids) {
             return None;
         }
 
-        let mut channel_ids = Vec::new();
-
-        for artifact in &mut self.artifacts {
-            if !artifact_ids.contains(&artifact.id) {
-                continue;
-            }
-
-            artifact.state = ArtifactState::Confirmed;
-            for channel_id in &artifact.channel_ids {
-                if !channel_ids.contains(channel_id) {
-                    channel_ids.push(*channel_id);
-                }
-            }
-        }
-
-        Some(channel_ids)
+        Some(self.artifacts.confirm(&artifact_ids))
     }
 
     /// Returns every artifact leased to `submission_id` to ready state.
     pub fn requeue(&mut self, submission_id: SubmissionId) -> Option<usize> {
         let artifact_ids = self.pending.remove(&submission_id)?;
-        if !self.lease_matches(&artifact_ids) {
+        if !self.artifacts.all_pending(&artifact_ids) {
             return None;
         }
 
-        let mut frame_count = 0;
-        for artifact in &mut self.artifacts {
-            if artifact_ids.contains(&artifact.id) {
-                frame_count += artifact.frame_count();
-                artifact.state = ArtifactState::Ready;
-            }
-        }
-
-        Some(frame_count)
+        Some(self.artifacts.requeue(&artifact_ids))
     }
 
     /// Returns whether all artifacts from a fully framed channel are confirmed.
     pub fn channel_fully_confirmed(&self, channel: &Channel) -> bool {
-        if !channel.framing_complete() {
-            return false;
-        }
-
-        let mut found = false;
-        for artifact in &self.artifacts {
-            if !artifact.channel_ids.contains(&channel.id()) {
-                continue;
-            }
-            found = true;
-            if artifact.state != ArtifactState::Confirmed {
-                return false;
-            }
-        }
-        found
+        channel.framing_complete() && self.artifacts.all_confirmed_for(channel.id())
     }
 
     /// Removes safe channel references and artifacts no longer tracking any channel.
     pub fn prune_channels(&mut self, channel_ids: &[ChannelId]) {
-        for artifact in &mut self.artifacts {
-            artifact.channel_ids.retain(|id| !channel_ids.contains(id));
-        }
-        self.artifacts.retain(|artifact| !artifact.channel_ids.is_empty());
+        self.artifacts.prune_channels(channel_ids);
         self.retain_existing_pending_artifacts();
     }
 
     /// Removes artifacts invalidated by deterministic replay closure.
     pub fn invalidate_artifacts(&mut self, artifact_ids: &[ArtifactId]) {
-        self.artifacts.retain(|artifact| !artifact_ids.contains(&artifact.id));
+        self.artifacts.invalidate(artifact_ids);
         self.pending.retain(|_, pending| !pending.iter().any(|id| artifact_ids.contains(id)));
     }
 
@@ -387,15 +219,6 @@ impl DaEgress {
                 }
             }
         }
-    }
-
-    /// Returns the number of frames currently available for submission.
-    pub fn ready_frame_count(&self) -> usize {
-        self.artifacts
-            .iter()
-            .filter(|artifact| artifact.state == ArtifactState::Ready)
-            .map(DaArtifact::frame_count)
-            .sum()
     }
 
     /// Clears every artifact while preserving monotonic artifact identifiers.
@@ -458,7 +281,7 @@ impl DaEgress {
         }
 
         let payload = BlobPayload::new(frames);
-        self.push_artifact(DaArtifactPayload::Blob(payload), channel_ids)
+        self.artifacts.push(DaArtifactPayload::Blob(payload), channel_ids)
     }
 
     /// Commits one calldata frame into an immutable ready artifact.
@@ -476,40 +299,14 @@ impl DaEgress {
             channel.take_frame(data_len, is_last).expect("calldata plan satisfies channel limits"),
         );
 
-        self.push_artifact(DaArtifactPayload::Calldata(frame), vec![channel_id])
-    }
-
-    /// Appends one immutable ready artifact.
-    fn push_artifact(
-        &mut self,
-        payload: DaArtifactPayload,
-        channel_ids: Vec<ChannelId>,
-    ) -> ArtifactId {
-        let id = ArtifactId(self.next_artifact_id);
-        self.next_artifact_id += 1;
-        self.artifacts.push_back(DaArtifact {
-            id,
-            payload,
-            channel_ids,
-            state: ArtifactState::Ready,
-        });
-        id
-    }
-
-    /// Returns whether every artifact in a lease remains pending.
-    fn lease_matches(&self, artifact_ids: &[ArtifactId]) -> bool {
-        artifact_ids.iter().all(|id| {
-            self.artifacts
-                .iter()
-                .any(|artifact| artifact.id == *id && artifact.state == ArtifactState::Pending)
-        })
+        self.artifacts.push(DaArtifactPayload::Calldata(frame), vec![channel_id])
     }
 
     /// Removes pruned artifact identifiers from pending submissions.
     fn retain_existing_pending_artifacts(&mut self) {
         let artifacts = &self.artifacts;
         self.pending.retain(|_, pending| {
-            pending.retain(|id| artifacts.iter().any(|artifact| artifact.id == *id));
+            pending.retain(|id| artifacts.contains(*id));
             !pending.is_empty()
         });
     }

--- a/crates/batcher/encoder/src/lib.rs
+++ b/crates/batcher/encoder/src/lib.rs
@@ -24,6 +24,11 @@ pub use channel::{
     ReadyChannel,
 };
 
+#[allow(dead_code, unreachable_pub, unnameable_types)]
+mod egress;
+#[allow(dead_code, unreachable_pub, unnameable_types)]
+mod record;
+
 mod encoder;
 pub use encoder::BatchEncoder;
 

--- a/crates/batcher/encoder/src/lib.rs
+++ b/crates/batcher/encoder/src/lib.rs
@@ -25,6 +25,8 @@ pub use channel::{
 };
 
 #[allow(dead_code, unreachable_pub, unnameable_types)]
+mod artifact;
+#[allow(dead_code, unreachable_pub, unnameable_types)]
 mod egress;
 #[allow(dead_code, unreachable_pub, unnameable_types)]
 mod record;

--- a/crates/batcher/encoder/src/metrics.rs
+++ b/crates/batcher/encoder/src/metrics.rs
@@ -50,11 +50,20 @@ impl BatcherMetrics {
     /// Channel closed because the compressed frame data reached the target size.
     pub const REASON_SIZE_FULL: &'static str = "size_full";
 
+    /// Channel closed because the optional compressed-size target was reached.
+    pub const REASON_SOFT_TARGET: &'static str = "soft_target";
+
+    /// Channel closed because the next batch would exceed a hard derivation limit.
+    pub const REASON_PROTOCOL_LIMIT: &'static str = "protocol_limit";
+
     /// Channel closed because it reached `max_channel_duration` L1 blocks.
     pub const REASON_TIMEOUT: &'static str = "timeout";
 
     /// Channel closed by an explicit force-flush signal.
     pub const REASON_FORCE: &'static str = "force";
+
+    /// Channel closed by an administrative flush.
+    pub const REASON_FLUSH: &'static str = "flush";
 
     /// Channel discarded because its first block exceeded channel limits.
     pub const REASON_DISCARD: &'static str = "discard";

--- a/crates/batcher/encoder/src/record.rs
+++ b/crates/batcher/encoder/src/record.rs
@@ -1,0 +1,562 @@
+//! One derivation channel and its admission / close types.
+
+use std::{collections::VecDeque, fmt, sync::Arc};
+
+use alloy_primitives::Bytes;
+use alloy_rlp::{Encodable, Header};
+use base_common_genesis::RollupConfig;
+use base_comp::{CompressionError, CompressionStream};
+use base_protocol::{
+    BLOB_DERIVATION_PREFIX_SIZE, BLOB_MAX_DATA_SIZE, BatchType, ChannelId, Frame, SingleBatch,
+};
+
+use crate::{BatcherMetrics, EncoderConfig, EncoderConfigError};
+
+/// Result of appending one complete `SingleBatch` to a channel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChannelAddOutcome {
+    /// The batch was committed and the channel remains below its soft target.
+    Accepted,
+    /// The batch was committed and reached the optional soft target.
+    TargetReached,
+    /// The batch was not committed because a hard channel limit would be exceeded.
+    Rejected(ChannelLimit),
+}
+
+/// Hard derivation limit preventing one batch from joining a channel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum ChannelLimit {
+    /// Uncompressed channel RLP bytes exceed the fork-specific decoder limit.
+    #[error("channel RLP requires {required} bytes, maximum is {maximum}")]
+    RlpBytes {
+        /// Required bytes after appending the candidate batch.
+        required: usize,
+        /// Fork-specific maximum.
+        maximum: usize,
+    },
+    /// The finished channel cannot be represented by sequential `u16` frame numbers.
+    #[error("channel requires {required} frames, maximum is {maximum}")]
+    FrameCount {
+        /// Conservatively required frames.
+        required: usize,
+        /// Maximum representable frame count.
+        maximum: usize,
+    },
+    /// Compressed bytes and frame storage exceed the assembled-channel limit.
+    #[error("assembled channel may require {required} bytes, maximum is {maximum}")]
+    AssembledBytes {
+        /// Conservative assembled size.
+        required: usize,
+        /// Fork-specific maximum.
+        maximum: usize,
+    },
+}
+
+/// Why a writable channel stopped accepting batches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChannelCloseReason {
+    /// The optional compressed-size target was reached.
+    SoftTarget,
+    /// The next batch would exceed a hard derivation limit.
+    ProtocolLimit,
+    /// The channel reached its operational L1 block timeout.
+    Timeout,
+    /// The caller explicitly requested an administrative flush.
+    Flush,
+}
+
+impl ChannelCloseReason {
+    /// Returns the bounded metric label for this reason.
+    pub const fn metric_label(self) -> &'static str {
+        match self {
+            Self::SoftTarget => BatcherMetrics::REASON_SOFT_TARGET,
+            Self::ProtocolLimit => BatcherMetrics::REASON_PROTOCOL_LIMIT,
+            Self::Timeout => BatcherMetrics::REASON_TIMEOUT,
+            Self::Flush => BatcherMetrics::REASON_FLUSH,
+        }
+    }
+}
+
+/// Error returned by a channel state transition.
+#[derive(Debug, thiserror::Error)]
+pub enum ChannelError {
+    /// Compression failed.
+    #[error(transparent)]
+    Compression(#[from] CompressionError),
+    /// A batch was appended after the channel closed.
+    #[error("cannot append a batch to a closed channel")]
+    Closed,
+    /// A frame requests compressed bytes not present in the channel output.
+    #[error("frame requires {requested} bytes, but only {available} are available")]
+    OutputUnderflow {
+        /// Requested compressed bytes.
+        requested: usize,
+        /// Available compressed bytes.
+        available: usize,
+    },
+    /// The finished channel cannot be represented by sequential `u16` frame numbers.
+    #[error("channel requires {frame_count} frames, exceeding the maximum {maximum}")]
+    TooManyFrames {
+        /// Number of frames required for the channel.
+        frame_count: usize,
+        /// Maximum representable frame count.
+        maximum: usize,
+    },
+    /// A terminal frame was requested before the closed channel tail was complete.
+    #[error("terminal frame does not consume the complete closed channel tail")]
+    InvalidTerminalTransition,
+}
+
+/// One encoding channel, from first batch until the safe head covers it.
+pub struct ChannelRecord {
+    /// Unique derivation channel identifier.
+    id: ChannelId,
+    /// Rollup rules used for timestamp-dependent protocol limits.
+    rollup_config: Arc<RollupConfig>,
+    /// Compressor present only while the channel accepts batches.
+    compressor: Option<CompressionStream>,
+    /// Compressed bytes emitted but not yet assigned to immutable DA artifacts.
+    output: VecDeque<Bytes>,
+    /// Number of bytes currently available in `output`.
+    available_output: usize,
+    /// Total compressed bytes emitted by this channel.
+    compressed_bytes: usize,
+    /// Maximum serialized frame size.
+    max_frame_size: usize,
+    /// Optional soft compressed-size target.
+    compressed_size_target: Option<usize>,
+    /// Number of accepted uncompressed RLP bytes.
+    input_bytes: usize,
+    /// Reused buffer for one encoded `SingleBatch` wire value.
+    candidate_scratch: Vec<u8>,
+    /// Index of the first buffered L2 block encoded into the channel.
+    block_start: usize,
+    /// Number of buffered L2 blocks encoded into the channel.
+    blocks_added: usize,
+    /// Estimated DA bytes represented by the accepted L2 blocks.
+    da_backlog_bytes: u64,
+    /// L1 block observed when the channel opened.
+    opened_l1_block: u64,
+    /// Absolute L1 deadline for closure, then partial-tail release.
+    deadline_l1_block: u64,
+    /// Next frame number assigned by DA egress.
+    next_frame_number: usize,
+    /// Whether the terminal frame still needs to be emitted.
+    terminal_pending: bool,
+    /// Earliest L1 inclusion block among confirmed artifacts.
+    first_confirmed_l1_block: Option<u64>,
+    /// Latest L1 inclusion block among confirmed artifacts.
+    last_confirmed_l1_block: Option<u64>,
+}
+
+impl fmt::Debug for ChannelRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ChannelRecord")
+            .field("id", &self.id)
+            .field("block_start", &self.block_start)
+            .field("blocks_added", &self.blocks_added)
+            .field("available_output", &self.available_output)
+            .field("compressed_bytes", &self.compressed_bytes)
+            .field("opened_l1_block", &self.opened_l1_block)
+            .field("deadline_l1_block", &self.deadline_l1_block)
+            .field("next_frame_number", &self.next_frame_number)
+            .field("terminal_pending", &self.terminal_pending)
+            .finish()
+    }
+}
+
+impl ChannelRecord {
+    /// Max frames per channel. Derivation cannot reassemble frame number `u16::MAX`.
+    pub const MAX_FRAMES: usize = u16::MAX as usize;
+
+    /// Creates an empty writable channel at the tail of the FIFO.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EncoderConfigError`] when `config` violates an encoder limit.
+    pub fn new(
+        id: ChannelId,
+        rollup_config: Arc<RollupConfig>,
+        config: &EncoderConfig,
+        block_start: usize,
+        opened_l1_block: u64,
+    ) -> Result<Self, EncoderConfigError> {
+        config.validate()?;
+
+        let duration_blocks = config.max_channel_duration - config.sub_safety_margin;
+        Ok(Self {
+            id,
+            rollup_config,
+            compressor: Some(CompressionStream::new(config.compression_algo)),
+            output: VecDeque::new(),
+            available_output: 0,
+            compressed_bytes: 0,
+            max_frame_size: config.max_frame_size,
+            compressed_size_target: config.compressed_size_target,
+            input_bytes: 0,
+            candidate_scratch: Vec::new(),
+            block_start,
+            blocks_added: 0,
+            da_backlog_bytes: 0,
+            opened_l1_block,
+            deadline_l1_block: opened_l1_block + duration_blocks,
+            next_frame_number: 0,
+            terminal_pending: false,
+            first_confirmed_l1_block: None,
+            last_confirmed_l1_block: None,
+        })
+    }
+
+    /// Returns the channel identifier.
+    pub const fn id(&self) -> ChannelId {
+        self.id
+    }
+
+    /// Returns whether the channel still accepts batches.
+    pub const fn is_open(&self) -> bool {
+        self.compressor.is_some()
+    }
+
+    /// Returns whether no batch has been accepted.
+    pub const fn is_empty(&self) -> bool {
+        self.blocks_added == 0
+    }
+
+    /// Returns the number of accepted uncompressed RLP bytes.
+    pub fn input_bytes(&self) -> u64 {
+        u64::try_from(self.input_bytes).unwrap_or(u64::MAX)
+    }
+
+    /// Returns the total compressed stream bytes emitted so far.
+    pub fn compressed_bytes(&self) -> u64 {
+        u64::try_from(self.compressed_bytes).unwrap_or(u64::MAX)
+    }
+
+    /// Returns compressed bytes not yet assigned to a DA artifact.
+    pub const fn available_output(&self) -> usize {
+        self.available_output
+    }
+
+    /// Returns the maximum data bytes carried by one frame.
+    pub const fn max_frame_data(&self) -> usize {
+        self.max_frame_size - Frame::ENCODED_OVERHEAD
+    }
+
+    /// Returns the L1 block observed when the channel opened.
+    pub const fn opened_l1_block(&self) -> u64 {
+        self.opened_l1_block
+    }
+
+    /// Whether `l1_head` has reached the channel deadline.
+    pub const fn deadline_due(&self, l1_head: u64) -> bool {
+        l1_head >= self.deadline_l1_block
+    }
+
+    /// Make a closed partial tail eligible at `l1_head` without postponing the deadline.
+    pub fn release_at(&mut self, l1_head: u64) {
+        self.deadline_l1_block = self.deadline_l1_block.min(l1_head);
+    }
+
+    /// Returns the accepted buffered block range.
+    pub const fn block_range(&self) -> std::ops::Range<usize> {
+        self.block_start..self.block_start + self.blocks_added
+    }
+
+    /// Returns the number of accepted L2 blocks.
+    pub const fn blocks_added(&self) -> usize {
+        self.blocks_added
+    }
+
+    /// Returns the estimated DA backlog represented by accepted blocks.
+    pub const fn da_backlog_bytes(&self) -> u64 {
+        self.da_backlog_bytes
+    }
+
+    /// Returns whether the terminal frame has been emitted.
+    pub const fn framing_complete(&self) -> bool {
+        self.compressor.is_none() && !self.terminal_pending
+    }
+
+    /// Returns whether a terminal frame remains after the available output.
+    pub const fn terminal_pending(&self) -> bool {
+        self.terminal_pending
+    }
+
+    /// Returns the number of frames assigned so far.
+    pub const fn frame_count(&self) -> usize {
+        self.next_frame_number
+    }
+
+    /// Append `batch` if hard limits hold; otherwise reject without mutating the stream.
+    pub fn add_batch(
+        &mut self,
+        batch: SingleBatch,
+        da_backlog_bytes: u64,
+    ) -> Result<ChannelAddOutcome, ChannelError> {
+        let timestamp = batch.timestamp;
+
+        // Wire form of one Single batch: RLP string header, type byte, payload.
+        self.candidate_scratch.clear();
+        Header { list: false, payload_length: 1 + batch.length() }
+            .encode(&mut self.candidate_scratch);
+        self.candidate_scratch.push(BatchType::Single as u8);
+        batch.encode(&mut self.candidate_scratch);
+
+        let next_input_bytes = self.input_bytes.saturating_add(self.candidate_scratch.len());
+        let max_channel_bytes =
+            usize::try_from(self.rollup_config.max_rlp_bytes_per_channel(timestamp))
+                .unwrap_or(usize::MAX);
+        let max_frame_data = self.max_frame_data();
+        let Some(compressor) = self.compressor.as_mut() else {
+            return Err(ChannelError::Closed);
+        };
+
+        // Worst-case compressed size of the finished channel, including this batch.
+        let max_compressed_bytes = compressor.max_output_size(next_input_bytes);
+        let max_frame_count = max_compressed_bytes.div_ceil(max_frame_data);
+
+        // Blob packing can split output at blob boundaries, so a channel may
+        // need more frames than `max_frame_size` packing alone would suggest.
+        let blob_payload_capacity = BLOB_MAX_DATA_SIZE - BLOB_DERIVATION_PREFIX_SIZE;
+        let max_blob_boundary_frames = max_compressed_bytes
+            .div_ceil(blob_payload_capacity - Frame::ENCODED_OVERHEAD)
+            .saturating_add(1);
+        let max_total_frames = max_frame_count.saturating_add(max_blob_boundary_frames);
+        let max_assembled_bytes =
+            max_compressed_bytes.saturating_add(max_total_frames.saturating_mul(Frame::OVERHEAD));
+
+        // Reject against projected limits before mutating the stream.
+        if next_input_bytes > max_channel_bytes {
+            return Ok(ChannelAddOutcome::Rejected(ChannelLimit::RlpBytes {
+                required: next_input_bytes,
+                maximum: max_channel_bytes,
+            }));
+        }
+        if max_total_frames > Self::MAX_FRAMES {
+            return Ok(ChannelAddOutcome::Rejected(ChannelLimit::FrameCount {
+                required: max_total_frames,
+                maximum: Self::MAX_FRAMES,
+            }));
+        }
+        if max_assembled_bytes > max_channel_bytes {
+            return Ok(ChannelAddOutcome::Rejected(ChannelLimit::AssembledBytes {
+                required: max_assembled_bytes,
+                maximum: max_channel_bytes,
+            }));
+        }
+
+        // Commit once. Newly stable bytes go into the FIFO.
+        let output = compressor.append(&self.candidate_scratch)?;
+        let total_output = compressor.output_size();
+
+        self.push_output(output);
+        self.input_bytes = next_input_bytes;
+        self.blocks_added += 1;
+        self.da_backlog_bytes += da_backlog_bytes;
+
+        if self.compressed_size_target.is_some_and(|target| total_output >= target) {
+            Ok(ChannelAddOutcome::TargetReached)
+        } else {
+            Ok(ChannelAddOutcome::Accepted)
+        }
+    }
+
+    /// Stop accepting batches and finish the compressor.
+    pub fn close(&mut self) -> Result<(), ChannelError> {
+        let Some(compressor) = self.compressor.take() else {
+            return Ok(());
+        };
+
+        self.push_output(compressor.finish()?);
+        self.candidate_scratch = Vec::new();
+        self.terminal_pending = true;
+        Ok(())
+    }
+
+    /// Cut the next numbered frame from the compressed FIFO.
+    pub fn take_frame(&mut self, data_len: usize, is_last: bool) -> Result<Frame, ChannelError> {
+        if data_len > self.available_output {
+            return Err(ChannelError::OutputUnderflow {
+                requested: data_len,
+                available: self.available_output,
+            });
+        }
+        if self.next_frame_number >= Self::MAX_FRAMES {
+            return Err(ChannelError::TooManyFrames {
+                frame_count: self.next_frame_number + 1,
+                maximum: Self::MAX_FRAMES,
+            });
+        }
+
+        // `is_last` is valid only after close, on the exact remaining tail.
+        if is_last
+            && (self.compressor.is_some()
+                || data_len != self.available_output
+                || !self.terminal_pending)
+        {
+            return Err(ChannelError::InvalidTerminalTransition);
+        }
+
+        let number = self.next_frame_number as u16;
+        let data = self.take_output(data_len);
+
+        self.next_frame_number += 1;
+        if is_last {
+            self.terminal_pending = false;
+        }
+
+        Ok(Frame { id: self.id, number, data, is_last })
+    }
+
+    /// Drain `len` bytes from the compressed FIFO.
+    fn take_output(&mut self, len: usize) -> Vec<u8> {
+        debug_assert!(len <= self.available_output);
+        debug_assert_eq!(
+            self.available_output,
+            self.output.iter().map(|chunk| chunk.len()).sum::<usize>()
+        );
+
+        let mut remaining = len;
+        let mut output = Vec::with_capacity(len);
+        while remaining > 0 {
+            let chunk = self.output.pop_front().expect("output length validated before mutation");
+            let consumed = remaining.min(chunk.len());
+            output.extend_from_slice(&chunk[..consumed]);
+            remaining -= consumed;
+
+            if consumed < chunk.len() {
+                self.output.push_front(chunk.slice(consumed..));
+            }
+        }
+
+        self.available_output -= len;
+        output
+    }
+
+    /// Record L1 inclusion for timeout/replay (min/max over artifacts).
+    pub fn record_confirmation(&mut self, l1_block: u64) {
+        self.first_confirmed_l1_block =
+            Some(self.first_confirmed_l1_block.map_or(l1_block, |first| first.min(l1_block)));
+        self.last_confirmed_l1_block =
+            Some(self.last_confirmed_l1_block.map_or(l1_block, |last| last.max(l1_block)));
+    }
+
+    /// Returns the earliest confirmed artifact inclusion block.
+    pub const fn first_confirmed_l1_block(&self) -> Option<u64> {
+        self.first_confirmed_l1_block
+    }
+
+    /// Returns the latest confirmed artifact inclusion block.
+    pub const fn last_confirmed_l1_block(&self) -> Option<u64> {
+        self.last_confirmed_l1_block
+    }
+
+    /// Shifts `block_start` after the encoder drops a safe prefix of `blocks`.
+    pub const fn rebase_after_prune(&mut self, prune_count: usize) {
+        let old_end = self.block_start + self.blocks_added;
+        self.block_start = self.block_start.saturating_sub(prune_count);
+        self.blocks_added = old_end.saturating_sub(prune_count).saturating_sub(self.block_start);
+    }
+
+    /// Enqueues newly transferred compressor bytes for later framing.
+    fn push_output(&mut self, output: Vec<u8>) {
+        if output.is_empty() {
+            return;
+        }
+        self.available_output += output.len();
+        self.compressed_bytes += output.len();
+        self.output.push_back(Bytes::from(output));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::B256;
+
+    use super::*;
+    use crate::CompressionAlgo;
+
+    fn batch(transaction_len: usize) -> SingleBatch {
+        let mut state = 1u64;
+        let transaction = (0..transaction_len)
+            .map(|_| {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                state as u8
+            })
+            .collect::<Vec<_>>();
+        SingleBatch {
+            parent_hash: B256::ZERO,
+            epoch_num: 0,
+            epoch_hash: B256::ZERO,
+            timestamp: 0,
+            transactions: vec![Bytes::from(transaction)],
+        }
+    }
+
+    fn channel(config: EncoderConfig) -> ChannelRecord {
+        ChannelRecord::new(ChannelId::default(), Arc::new(RollupConfig::default()), &config, 0, 0)
+            .unwrap()
+    }
+
+    #[test]
+    fn output_fifo_preserves_transferred_stream_order() {
+        let mut channel = channel(EncoderConfig::default());
+        channel.push_output(vec![1, 2]);
+        channel.push_output(vec![3, 4, 5]);
+
+        assert_eq!(channel.take_output(4), vec![1, 2, 3, 4]);
+        assert_eq!(channel.take_output(1), vec![5]);
+        assert_eq!(channel.available_output(), 0);
+    }
+
+    #[test]
+    fn soft_target_accepts_complete_batch_before_closing() {
+        let config = EncoderConfig {
+            compression_algo: CompressionAlgo::Zlib,
+            compressed_size_target: Some(1),
+            ..EncoderConfig::default()
+        };
+        let mut channel = channel(config);
+
+        assert_eq!(
+            channel.add_batch(batch(100_000), 100_000).unwrap(),
+            ChannelAddOutcome::TargetReached
+        );
+        assert_eq!(channel.blocks_added(), 1);
+        assert!(channel.input_bytes() > 0);
+    }
+
+    #[test]
+    fn cumulative_rlp_limit_rejects_without_mutating_stream() {
+        let mut channel = channel(EncoderConfig::default());
+        let maximum = channel.rollup_config.max_rlp_bytes_per_channel(0) as usize;
+        channel.input_bytes = maximum;
+
+        assert!(matches!(
+            channel.add_batch(batch(1), 1).unwrap(),
+            ChannelAddOutcome::Rejected(ChannelLimit::RlpBytes { .. })
+        ));
+        assert_eq!(channel.input_bytes, maximum);
+        assert_eq!(channel.blocks_added(), 0);
+        assert_eq!(channel.compressed_bytes(), 0);
+    }
+
+    #[test]
+    fn frame_number_limit_rejects_without_mutating_stream() {
+        let config = EncoderConfig {
+            compression_algo: CompressionAlgo::Zlib,
+            max_frame_size: Frame::ENCODED_OVERHEAD + 1,
+            ..EncoderConfig::default()
+        };
+        let mut channel = channel(config);
+
+        assert!(matches!(
+            channel.add_batch(batch(ChannelRecord::MAX_FRAMES + 1), 1).unwrap(),
+            ChannelAddOutcome::Rejected(ChannelLimit::FrameCount { .. })
+        ));
+        assert!(channel.is_empty());
+        assert_eq!(channel.compressed_bytes(), 0);
+    }
+}

--- a/crates/batcher/encoder/src/record.rs
+++ b/crates/batcher/encoder/src/record.rs
@@ -108,7 +108,7 @@ pub enum ChannelError {
 }
 
 /// One encoding channel, from first batch until the safe head covers it.
-pub struct ChannelRecord {
+pub struct Channel {
     /// Unique derivation channel identifier.
     id: ChannelId,
     /// Rollup rules used for timestamp-dependent protocol limits.
@@ -149,9 +149,9 @@ pub struct ChannelRecord {
     last_confirmed_l1_block: Option<u64>,
 }
 
-impl fmt::Debug for ChannelRecord {
+impl fmt::Debug for Channel {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ChannelRecord")
+        f.debug_struct("Channel")
             .field("id", &self.id)
             .field("block_start", &self.block_start)
             .field("blocks_added", &self.blocks_added)
@@ -165,7 +165,7 @@ impl fmt::Debug for ChannelRecord {
     }
 }
 
-impl ChannelRecord {
+impl Channel {
     /// Max frames per channel. Derivation cannot reassemble frame number `u16::MAX`.
     pub const MAX_FRAMES: usize = u16::MAX as usize;
 
@@ -495,8 +495,8 @@ mod tests {
         }
     }
 
-    fn channel(config: EncoderConfig) -> ChannelRecord {
-        ChannelRecord::new(ChannelId::default(), Arc::new(RollupConfig::default()), &config, 0, 0)
+    fn channel(config: EncoderConfig) -> Channel {
+        Channel::new(ChannelId::default(), Arc::new(RollupConfig::default()), &config, 0, 0)
             .unwrap()
     }
 
@@ -553,7 +553,7 @@ mod tests {
         let mut channel = channel(config);
 
         assert!(matches!(
-            channel.add_batch(batch(ChannelRecord::MAX_FRAMES + 1), 1).unwrap(),
+            channel.add_batch(batch(Channel::MAX_FRAMES + 1), 1).unwrap(),
             ChannelAddOutcome::Rejected(ChannelLimit::FrameCount { .. })
         ));
         assert!(channel.is_empty());

--- a/crates/batcher/encoder/src/record.rs
+++ b/crates/batcher/encoder/src/record.rs
@@ -1,9 +1,9 @@
 //! One derivation channel and its admission / close types.
 
-use std::{collections::VecDeque, fmt, sync::Arc};
+use std::{collections::VecDeque, sync::Arc};
 
 use alloy_primitives::Bytes;
-use alloy_rlp::{Encodable, Header};
+use alloy_rlp::Encodable;
 use base_common_genesis::RollupConfig;
 use base_comp::{CompressionError, CompressionStream};
 use base_protocol::{
@@ -30,9 +30,9 @@ pub enum ChannelLimit {
     #[error("channel RLP requires {required} bytes, maximum is {maximum}")]
     RlpBytes {
         /// Required bytes after appending the candidate batch.
-        required: usize,
+        required: u64,
         /// Fork-specific maximum.
-        maximum: usize,
+        maximum: u64,
     },
     /// The finished channel cannot be represented by sequential `u16` frame numbers.
     #[error("channel requires {required} frames, maximum is {maximum}")]
@@ -46,9 +46,9 @@ pub enum ChannelLimit {
     #[error("assembled channel may require {required} bytes, maximum is {maximum}")]
     AssembledBytes {
         /// Conservative assembled size.
-        required: usize,
+        required: u64,
         /// Fork-specific maximum.
-        maximum: usize,
+        maximum: u64,
     },
 }
 
@@ -108,26 +108,31 @@ pub enum ChannelError {
 }
 
 /// One encoding channel, from first batch until the safe head covers it.
+#[derive(derive_more::Debug)]
 pub struct Channel {
     /// Unique derivation channel identifier.
     id: ChannelId,
     /// Rollup rules used for timestamp-dependent protocol limits.
+    #[debug(skip)]
     rollup_config: Arc<RollupConfig>,
     /// Compressor present only while the channel accepts batches.
+    #[debug(skip)]
     compressor: Option<CompressionStream>,
     /// Compressed bytes emitted but not yet assigned to immutable DA artifacts.
+    #[debug(skip)]
     output: VecDeque<Bytes>,
     /// Number of bytes currently available in `output`.
     available_output: usize,
     /// Total compressed bytes emitted by this channel.
-    compressed_bytes: usize,
+    compressed_bytes: u64,
     /// Maximum serialized frame size.
     max_frame_size: usize,
     /// Optional soft compressed-size target.
     compressed_size_target: Option<usize>,
     /// Number of accepted uncompressed RLP bytes.
-    input_bytes: usize,
+    input_bytes: u64,
     /// Reused buffer for one encoded `SingleBatch` wire value.
+    #[debug(skip)]
     candidate_scratch: Vec<u8>,
     /// Index of the first buffered L2 block encoded into the channel.
     block_start: usize,
@@ -149,22 +154,6 @@ pub struct Channel {
     last_confirmed_l1_block: Option<u64>,
 }
 
-impl fmt::Debug for Channel {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Channel")
-            .field("id", &self.id)
-            .field("block_start", &self.block_start)
-            .field("blocks_added", &self.blocks_added)
-            .field("available_output", &self.available_output)
-            .field("compressed_bytes", &self.compressed_bytes)
-            .field("opened_l1_block", &self.opened_l1_block)
-            .field("deadline_l1_block", &self.deadline_l1_block)
-            .field("next_frame_number", &self.next_frame_number)
-            .field("terminal_pending", &self.terminal_pending)
-            .finish()
-    }
-}
-
 impl Channel {
     /// Max frames per channel. Derivation cannot reassemble frame number `u16::MAX`.
     pub const MAX_FRAMES: usize = u16::MAX as usize;
@@ -183,7 +172,7 @@ impl Channel {
     ) -> Result<Self, EncoderConfigError> {
         config.validate()?;
 
-        let duration_blocks = config.max_channel_duration - config.sub_safety_margin;
+        let duration_blocks = config.max_channel_duration.saturating_sub(config.sub_safety_margin);
         Ok(Self {
             id,
             rollup_config,
@@ -199,7 +188,7 @@ impl Channel {
             blocks_added: 0,
             da_backlog_bytes: 0,
             opened_l1_block,
-            deadline_l1_block: opened_l1_block + duration_blocks,
+            deadline_l1_block: opened_l1_block.saturating_add(duration_blocks),
             next_frame_number: 0,
             terminal_pending: false,
             first_confirmed_l1_block: None,
@@ -223,13 +212,13 @@ impl Channel {
     }
 
     /// Returns the number of accepted uncompressed RLP bytes.
-    pub fn input_bytes(&self) -> u64 {
-        u64::try_from(self.input_bytes).unwrap_or(u64::MAX)
+    pub const fn input_bytes(&self) -> u64 {
+        self.input_bytes
     }
 
     /// Returns the total compressed stream bytes emitted so far.
-    pub fn compressed_bytes(&self) -> u64 {
-        u64::try_from(self.compressed_bytes).unwrap_or(u64::MAX)
+    pub const fn compressed_bytes(&self) -> u64 {
+        self.compressed_bytes
     }
 
     /// Returns compressed bytes not yet assigned to a DA artifact.
@@ -293,26 +282,30 @@ impl Channel {
         batch: SingleBatch,
         da_backlog_bytes: u64,
     ) -> Result<ChannelAddOutcome, ChannelError> {
-        let timestamp = batch.timestamp;
-
-        // Wire form of one Single batch: RLP string header, type byte, payload.
-        self.candidate_scratch.clear();
-        Header { list: false, payload_length: 1 + batch.length() }
-            .encode(&mut self.candidate_scratch);
-        self.candidate_scratch.push(BatchType::Single as u8);
-        batch.encode(&mut self.candidate_scratch);
-
-        let next_input_bytes = self.input_bytes.saturating_add(self.candidate_scratch.len());
-        let max_channel_bytes =
-            usize::try_from(self.rollup_config.max_rlp_bytes_per_channel(timestamp))
-                .unwrap_or(usize::MAX);
+        let max_channel_bytes = self.rollup_config.max_rlp_bytes_per_channel(batch.timestamp);
         let max_frame_data = self.max_frame_data();
         let Some(compressor) = self.compressor.as_mut() else {
             return Err(ChannelError::Closed);
         };
 
+        // Wire form of one Single batch: RLP string header, type byte, payload.
+        self.candidate_scratch.clear();
+        batch.rlp_header().encode(&mut self.candidate_scratch);
+        self.candidate_scratch.push(BatchType::Single as u8);
+        batch.encode(&mut self.candidate_scratch);
+
+        // Reject on the cumulative RLP limit first. Every projection below then
+        // starts from an input size the protocol bounds well inside memory.
+        let next_input_bytes = self.input_bytes.saturating_add(self.candidate_scratch.len() as u64);
+        if next_input_bytes > max_channel_bytes {
+            return Ok(ChannelAddOutcome::Rejected(ChannelLimit::RlpBytes {
+                required: next_input_bytes,
+                maximum: max_channel_bytes,
+            }));
+        }
+
         // Worst-case compressed size of the finished channel, including this batch.
-        let max_compressed_bytes = compressor.max_output_size(next_input_bytes);
+        let max_compressed_bytes = compressor.max_output_size(next_input_bytes as usize);
         let max_frame_count = max_compressed_bytes.div_ceil(max_frame_data);
 
         // Blob packing can split output at blob boundaries, so a channel may
@@ -322,16 +315,11 @@ impl Channel {
             .div_ceil(blob_payload_capacity - Frame::ENCODED_OVERHEAD)
             .saturating_add(1);
         let max_total_frames = max_frame_count.saturating_add(max_blob_boundary_frames);
-        let max_assembled_bytes =
-            max_compressed_bytes.saturating_add(max_total_frames.saturating_mul(Frame::OVERHEAD));
+        let max_assembled_bytes = max_compressed_bytes
+            .saturating_add(max_total_frames.saturating_mul(Frame::OVERHEAD))
+            as u64;
 
         // Reject against projected limits before mutating the stream.
-        if next_input_bytes > max_channel_bytes {
-            return Ok(ChannelAddOutcome::Rejected(ChannelLimit::RlpBytes {
-                required: next_input_bytes,
-                maximum: max_channel_bytes,
-            }));
-        }
         if max_total_frames > Self::MAX_FRAMES {
             return Ok(ChannelAddOutcome::Rejected(ChannelLimit::FrameCount {
                 required: max_total_frames,
@@ -464,7 +452,7 @@ impl Channel {
             return;
         }
         self.available_output += output.len();
-        self.compressed_bytes += output.len();
+        self.compressed_bytes += output.len() as u64;
         self.output.push_back(Bytes::from(output));
     }
 }
@@ -531,7 +519,7 @@ mod tests {
     #[test]
     fn cumulative_rlp_limit_rejects_without_mutating_stream() {
         let mut channel = channel(EncoderConfig::default());
-        let maximum = channel.rollup_config.max_rlp_bytes_per_channel(0) as usize;
+        let maximum = channel.rollup_config.max_rlp_bytes_per_channel(0);
         channel.input_bytes = maximum;
 
         assert!(matches!(

--- a/crates/batcher/encoder/src/record.rs
+++ b/crates/batcher/encoder/src/record.rs
@@ -279,7 +279,7 @@ impl Channel {
     /// Append `batch` if hard limits hold; otherwise reject without mutating the stream.
     pub fn add_batch(
         &mut self,
-        batch: SingleBatch,
+        batch: &SingleBatch,
         da_backlog_bytes: u64,
     ) -> Result<ChannelAddOutcome, ChannelError> {
         let max_channel_bytes = self.rollup_config.max_rlp_bytes_per_channel(batch.timestamp);
@@ -355,9 +355,12 @@ impl Channel {
             return Ok(());
         };
 
-        self.push_output(compressor.finish()?);
-        self.candidate_scratch = Vec::new();
+        // Marked before finishing: a failed finish loses the compressed tail, and
+        // must not leave a channel reporting complete framing without a terminal frame.
         self.terminal_pending = true;
+        self.candidate_scratch = Vec::new();
+        self.push_output(compressor.finish()?);
+
         Ok(())
     }
 
@@ -509,7 +512,7 @@ mod tests {
         let mut channel = channel(config);
 
         assert_eq!(
-            channel.add_batch(batch(100_000), 100_000).unwrap(),
+            channel.add_batch(&batch(100_000), 100_000).unwrap(),
             ChannelAddOutcome::TargetReached
         );
         assert_eq!(channel.blocks_added(), 1);
@@ -523,7 +526,7 @@ mod tests {
         channel.input_bytes = maximum;
 
         assert!(matches!(
-            channel.add_batch(batch(1), 1).unwrap(),
+            channel.add_batch(&batch(1), 1).unwrap(),
             ChannelAddOutcome::Rejected(ChannelLimit::RlpBytes { .. })
         ));
         assert_eq!(channel.input_bytes, maximum);
@@ -541,7 +544,7 @@ mod tests {
         let mut channel = channel(config);
 
         assert!(matches!(
-            channel.add_batch(batch(Channel::MAX_FRAMES + 1), 1).unwrap(),
+            channel.add_batch(&batch(Channel::MAX_FRAMES + 1), 1).unwrap(),
             ChannelAddOutcome::Rejected(ChannelLimit::FrameCount { .. })
         ));
         assert!(channel.is_empty());

--- a/crates/consensus/protocol/src/batch/single.rs
+++ b/crates/consensus/protocol/src/batch/single.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{BlockHash, Bytes};
-use alloy_rlp::{RlpDecodable, RlpEncodable};
+use alloy_rlp::{Encodable, Header, RlpDecodable, RlpEncodable};
 use base_common_consensus::OpTxType;
 use base_common_genesis::RollupConfig;
 use tracing::warn;
@@ -28,6 +28,14 @@ pub struct SingleBatch {
 }
 
 impl SingleBatch {
+    /// Returns the RLP string header wrapping this batch inside a channel.
+    ///
+    /// A channel entry is an RLP byte string holding the batch type byte
+    /// followed by the encoded batch.
+    pub fn rlp_header(&self) -> Header {
+        Header { list: false, payload_length: 1 + self.length() }
+    }
+
     /// Returns the [`BlockNumHash`] of the batch.
     pub const fn epoch(&self) -> BlockNumHash {
         BlockNumHash { number: self.epoch_num, hash: self.epoch_hash }


### PR DESCRIPTION
## Summary

- `Channel` (`record.rs`): batch admission, `take_frame`, and close/deadline handling for a channel.
- `DaEgress` (`egress.rs`): plans and commits blob and calldata submissions, with lease / confirm / requeue.

Encoder config gains `compressed_size_target` (soft compressed-byte target, default none) and `max_blobs_per_tx` (default 6), both validated. Adds `REASON_SOFT_TARGET` / `REASON_PROTOCOL_LIMIT` / `REASON_FLUSH` close-reason metrics.

## Testing

- `cargo test -p base-batcher-encoder -p base-batcher-core --all-features`