### PR TITLE
chore: upgrade reth to v2.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6705,7 +6705,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -6725,7 +6725,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -9736,8 +9736,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -10629,7 +10629,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -10665,7 +10665,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.59.0",
 ]
 
 [[package]]
@@ -13148,7 +13148,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -14838,7 +14838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -14871,7 +14871,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -14884,7 +14884,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -14997,7 +14997,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.3",
  "rustls 0.23.43",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -15037,7 +15037,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -15629,8 +15629,8 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15656,8 +15656,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15687,8 +15687,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -15707,8 +15707,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -15720,8 +15720,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -15809,8 +15809,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -15819,8 +15819,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -15870,8 +15870,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -15887,8 +15887,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -15901,8 +15901,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15914,8 +15914,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15939,8 +15939,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -15968,8 +15968,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -15994,8 +15994,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-genesis",
@@ -16024,8 +16024,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16039,8 +16039,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16064,8 +16064,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16088,8 +16088,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -16112,8 +16112,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16147,8 +16147,8 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16204,8 +16204,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -16231,8 +16231,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16254,8 +16254,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16281,8 +16281,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -16337,8 +16337,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16367,8 +16367,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16385,8 +16385,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -16401,8 +16401,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16425,8 +16425,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -16436,8 +16436,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -16465,8 +16465,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -16491,8 +16491,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16507,8 +16507,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16523,8 +16523,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks 0.4.7",
@@ -16537,8 +16537,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16567,8 +16567,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16581,8 +16581,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -16591,8 +16591,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -16617,8 +16617,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16637,8 +16637,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-cache"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -16655,8 +16655,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -16668,8 +16668,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16687,8 +16687,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16725,8 +16725,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-test-utils"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-eips 2.4.1",
  "eyre",
@@ -16757,8 +16757,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16771,8 +16771,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "serde",
  "serde_json",
@@ -16781,8 +16781,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16807,8 +16807,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "bytes",
  "futures",
@@ -16827,8 +16827,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "bitflags 2.13.1",
  "byteorder",
@@ -16844,8 +16844,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -16853,8 +16853,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "futures",
  "libc",
@@ -16867,8 +16867,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -16876,8 +16876,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -16890,8 +16890,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16949,8 +16949,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16974,8 +16974,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -16998,8 +16998,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17013,8 +17013,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -17027,8 +17027,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -17044,8 +17044,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -17068,8 +17068,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17136,8 +17136,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17191,8 +17191,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17240,8 +17240,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17264,8 +17264,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17288,8 +17288,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "bytes",
  "eyre",
@@ -17317,8 +17317,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -17329,8 +17329,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17353,8 +17353,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -17365,8 +17365,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17388,8 +17388,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-util"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17398,8 +17398,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-rpc-types-engine",
@@ -17441,8 +17441,8 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -17490,8 +17490,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17517,8 +17517,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -17533,8 +17533,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17548,8 +17548,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-dyn-abi",
@@ -17624,8 +17624,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-genesis",
@@ -17654,8 +17654,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-network 2.4.1",
  "alloy-provider",
@@ -17697,8 +17697,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-evm",
@@ -17717,8 +17717,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -17748,8 +17748,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-dyn-abi",
@@ -17795,8 +17795,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -17846,8 +17846,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.2",
@@ -17860,8 +17860,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -17891,8 +17891,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17942,8 +17942,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -17970,8 +17970,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -17984,8 +17984,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -18004,8 +18004,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -18019,8 +18019,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -18045,8 +18045,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18062,8 +18062,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-overlay"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18089,8 +18089,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -18110,8 +18110,8 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18126,8 +18126,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -18136,8 +18136,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "clap",
  "eyre",
@@ -18156,8 +18156,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -18175,8 +18175,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18218,8 +18218,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18244,8 +18244,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -18271,8 +18271,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -18287,8 +18287,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -18311,8 +18311,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "2.5.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.0#189c0df32617afc488e0f091dbface1bd72cceb4"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -22758,7 +22758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f7c95348f20c1c913d72157b3c6dee6ea3e30b3d19502c5a7f6d3f160dacbf"
 dependencies = [
  "cc",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -23663,7 +23663,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -307,71 +307,71 @@ alloy-network-primitives = { version = "2.3.0", default-features = false }
 reth-zstd-compressors = { version = "0.6.0", default-features = false }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
 reth-codecs = { version = "0.6.0", default-features = false, features = ["alloy"] }
-reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-ipc = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-exex = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-ecies = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-discv4 = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-network = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-net-nat = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-eth-wire = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-db-common = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-rpc-layer = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-chain-state = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-payload-util = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-tracing-otlp = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-testing-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-exex-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0", default-features = false }
-reth-stages-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0", default-features = false }
-reth-storage-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0", default-features = false }
-reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0", default-features = false }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0", default-features = false }
-reth-trie-parallel = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.0" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-ipc = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-exex = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-ecies = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-discv4 = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-network = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-net-nat = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-eth-wire = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-db-common = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-rpc-layer = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-chain-state = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-payload-util = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-tracing-otlp = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-testing-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-exex-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1", default-features = false }
+reth-stages-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1", default-features = false }
+reth-storage-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1", default-features = false }
+reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1", default-features = false }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1", default-features = false }
+reth-trie-parallel = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
 
 # tokio
 tokio = "1.53.1"


### PR DESCRIPTION
Upgrade all reth Git dependencies and lockfile entries to v2.5.1.