### PR TITLE
fix(metering): ignore stale flashblock pending vs local tip

### DIFF
--- a/crates/execution/flashblocks/src/lib.rs
+++ b/crates/execution/flashblocks/src/lib.rs
@@ -47,8 +47,9 @@ pub use receipt_builder::{ReceiptBuildError, UnifiedReceiptBuilder};
 
 mod validation;
 pub use validation::{
-    CanonicalBlockReconciler, FlashblockSequenceValidator, ReconciliationStrategy,
-    ReorgDetectionResult, ReorgDetector, SequenceValidationResult,
+    CanonicalBlockReconciler, FlashblockSequenceValidator, PendingWindowStaleReason,
+    ReconciliationStrategy, ReorgDetectionResult, ReorgDetector, SequenceValidationResult,
+    pending_window_is_fresh, pending_window_stale_reason,
 };
 
 mod config;

--- a/crates/execution/flashblocks/src/state.rs
+++ b/crates/execution/flashblocks/src/state.rs
@@ -53,6 +53,11 @@ impl FlashblocksState {
         }
     }
 
+    /// Returns the configured maximum pending-blocks depth.
+    pub const fn max_pending_blocks_depth(&self) -> u64 {
+        self.max_pending_blocks_depth
+    }
+
     /// Starts the flashblocks state processor with the given client.
     ///
     /// This spawns a background task that processes canonical blocks and flashblocks.

--- a/crates/execution/flashblocks/src/validation.rs
+++ b/crates/execution/flashblocks/src/validation.rs
@@ -2,6 +2,7 @@
 //!
 //! Provides stateless validation logic for flashblock sequencing and chain reorg detection.
 
+use alloy_eips::merge::EPOCH_SLOTS;
 use alloy_primitives::B256;
 use base_common_flashblocks::FlashblockId;
 
@@ -206,6 +207,66 @@ impl CanonicalBlockReconciler {
     }
 }
 
+/// Why a pending flashblock window is too stale to overlay for metering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PendingWindowStaleReason {
+    /// Pending latest is at or behind local canonical tip ([`ReconciliationStrategy::CatchUp`]).
+    CatchUp,
+    /// Local tip is more than `max_depth` past pending earliest.
+    DepthLimitExceeded {
+        /// `tip.saturating_sub(earliest)`.
+        depth: u64,
+        /// Configured maximum pending-blocks depth.
+        max_depth: u64,
+    },
+    /// Pending parent is more than [`EPOCH_SLOTS`] behind local tip.
+    HistoricalDistance {
+        /// `tip.saturating_sub(parent)` where `parent = earliest.saturating_sub(1)`.
+        distance: u64,
+    },
+}
+
+/// Returns whether a pending flashblock window is fresh enough to overlay for metering.
+///
+/// `parent < tip` alone is not stale: continue-after-canonical is expected while
+/// `latest > tip` and depth is within `max_depth`.
+pub const fn pending_window_is_fresh(earliest: u64, latest: u64, tip: u64, max_depth: u64) -> bool {
+    pending_window_stale_reason(earliest, latest, tip, max_depth).is_none()
+}
+
+/// Returns why a pending flashblock window should be ignored for metering, if at all.
+///
+/// Reuses [`CanonicalBlockReconciler::reconcile`] with `reorg_detected: false`, then
+/// applies the [`EPOCH_SLOTS`] historical-provider distance backstop against the pending
+/// parent (`earliest - 1`).
+pub const fn pending_window_stale_reason(
+    earliest: u64,
+    latest: u64,
+    tip: u64,
+    max_depth: u64,
+) -> Option<PendingWindowStaleReason> {
+    match CanonicalBlockReconciler::reconcile(Some(earliest), Some(latest), tip, max_depth, false) {
+        ReconciliationStrategy::Continue => {
+            let parent = earliest.saturating_sub(1);
+            let distance = tip.saturating_sub(parent);
+            if distance > EPOCH_SLOTS {
+                Some(PendingWindowStaleReason::HistoricalDistance { distance })
+            } else {
+                None
+            }
+        }
+        ReconciliationStrategy::CatchUp => Some(PendingWindowStaleReason::CatchUp),
+        ReconciliationStrategy::DepthLimitExceeded { depth, max_depth } => {
+            Some(PendingWindowStaleReason::DepthLimitExceeded { depth, max_depth })
+        }
+        // Unreachable with `Some`/`Some` and `reorg_detected: false`. Ignore pending if it
+        // happens so metering never overlays a window that failed reconciliation.
+        ReconciliationStrategy::HandleReorg | ReconciliationStrategy::NoPendingState => {
+            Some(PendingWindowStaleReason::CatchUp)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
@@ -352,5 +413,45 @@ mod tests {
         let result =
             CanonicalBlockReconciler::reconcile(earliest, latest, canonical, max_depth, reorg);
         assert_eq!(result, expected);
+    }
+
+    // ==================== Pending window freshness (metering) ====================
+
+    #[rstest]
+    // Keep: parent == tip - 1 (continue after one canonical)
+    #[case(101, 103, 102, 3, None)]
+    // Keep: parent == tip (fresh window on tip)
+    #[case(101, 103, 100, 3, None)]
+    // Keep: depth exactly at max (`>` not `>=`)
+    #[case(100, 110, 103, 3, None)]
+    // Keep: parent < tip is not sufficient to ignore
+    #[case(101, 104, 102, 3, None)]
+    // Keep: EPOCH_SLOTS distance exactly at the limit
+    #[case(100, 200, 131, 40, None)]
+    // Ignore: latest == tip (CatchUp)
+    #[case(100, 105, 105, 3, Some(PendingWindowStaleReason::CatchUp))]
+    // Ignore: latest < tip (CatchUp)
+    #[case(100, 105, 110, 3, Some(PendingWindowStaleReason::CatchUp))]
+    // Ignore: frozen hours-old / thousands behind
+    #[case(100, 100, 5000, 3, Some(PendingWindowStaleReason::CatchUp))]
+    // Ignore: depth exceeded while still ahead of tip
+    #[case(
+        100,
+        120,
+        104,
+        3,
+        Some(PendingWindowStaleReason::DepthLimitExceeded { depth: 4, max_depth: 3 })
+    )]
+    // Ignore: EPOCH_SLOTS even when max_depth would Keep
+    #[case(100, 200, 132, 40, Some(PendingWindowStaleReason::HistoricalDistance { distance: 33 }))]
+    fn test_pending_window_freshness(
+        #[case] earliest: u64,
+        #[case] latest: u64,
+        #[case] tip: u64,
+        #[case] max_depth: u64,
+        #[case] expected: Option<PendingWindowStaleReason>,
+    ) {
+        assert_eq!(pending_window_stale_reason(earliest, latest, tip, max_depth), expected);
+        assert_eq!(pending_window_is_fresh(earliest, latest, tip, max_depth), expected.is_none());
     }
 }

--- a/crates/execution/metering/src/extension.rs
+++ b/crates/execution/metering/src/extension.rs
@@ -184,6 +184,7 @@ impl BaseNodeExtension for MeteringExtension {
         hooks.add_rpc_module(move |ctx| {
             let fb_state: Arc<FlashblocksState> =
                 flashblocks_config.as_ref().map(|cfg| Arc::clone(&cfg.state)).unwrap_or_default();
+            let max_pending_blocks_depth = fb_state.max_pending_blocks_depth();
 
             let metering_api = if has_estimator {
                 let cache_size = cache_size.expect("estimator configuration validated");
@@ -230,12 +231,18 @@ impl BaseNodeExtension for MeteringExtension {
                 MeteringApiImpl::with_estimator(
                     ctx.provider().clone(),
                     fb_state,
+                    max_pending_blocks_depth,
                     estimator,
                     Arc::clone(&metered_opcodes),
                 )
             } else {
                 info!(message = "Starting Metering RPC (priority fee estimation disabled)");
-                MeteringApiImpl::new(ctx.provider().clone(), fb_state, Arc::clone(&metered_opcodes))
+                MeteringApiImpl::new(
+                    ctx.provider().clone(),
+                    fb_state,
+                    max_pending_blocks_depth,
+                    Arc::clone(&metered_opcodes),
+                )
             };
 
             ctx.modules.merge_configured(metering_api.into_rpc())?;

--- a/crates/execution/metering/src/rpc.rs
+++ b/crates/execution/metering/src/rpc.rs
@@ -11,7 +11,9 @@ use base_common_evm::L1BlockInfo;
 use base_common_flz::flz_compress_len;
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_evm::extract_l1_info_from_tx;
-use base_flashblocks::{FlashblocksAPI, PendingBlocksAPI};
+use base_flashblocks::{
+    FlashblocksAPI, PendingBlocks, PendingWindowStaleReason, pending_window_stale_reason,
+};
 use jsonrpsee::core::{RpcResult, async_trait};
 use reth_primitives_traits::SealedHeader;
 use reth_provider::{
@@ -31,6 +33,8 @@ use crate::{
 pub struct MeteringApiImpl<Provider, FB> {
     provider: Provider,
     flashblocks_api: Arc<FB>,
+    /// Configured `max_pending_blocks_depth` used to ignore stale flashblock pending.
+    max_pending_blocks_depth: u64,
     /// Optional priority fee estimator for `meteredPriorityFeePerGas`.
     priority_fee_estimator: Option<Arc<PriorityFeeEstimator>>,
     /// Opcodes and precompiles to track for gas metering. When non-empty, a
@@ -58,19 +62,101 @@ where
     pub const fn new(
         provider: Provider,
         flashblocks_api: Arc<FB>,
+        max_pending_blocks_depth: u64,
         metered_opcodes: Arc<crate::MeteredOpcodes>,
     ) -> Self {
-        Self { provider, flashblocks_api, priority_fee_estimator: None, metered_opcodes }
+        Self {
+            provider,
+            flashblocks_api,
+            max_pending_blocks_depth,
+            priority_fee_estimator: None,
+            metered_opcodes,
+        }
     }
 
     /// Creates a new instance with priority fee estimation enabled.
     pub const fn with_estimator(
         provider: Provider,
         flashblocks_api: Arc<FB>,
+        max_pending_blocks_depth: u64,
         estimator: Arc<PriorityFeeEstimator>,
         metered_opcodes: Arc<crate::MeteredOpcodes>,
     ) -> Self {
-        Self { provider, flashblocks_api, priority_fee_estimator: Some(estimator), metered_opcodes }
+        Self {
+            provider,
+            flashblocks_api,
+            max_pending_blocks_depth,
+            priority_fee_estimator: Some(estimator),
+            metered_opcodes,
+        }
+    }
+
+    /// Returns pending flashblocks only when the window is fresh versus local canonical tip.
+    ///
+    /// Stale or unreadable pending is treated as absent so metering uses canonical `Latest`
+    /// with no overlay. Never fails the RPC for staleness.
+    fn select_fresh_pending<'a>(
+        &self,
+        pending: Option<&'a PendingBlocks>,
+    ) -> Option<&'a PendingBlocks> {
+        let pending = pending?;
+        let tip = match self.provider.best_block_number() {
+            Ok(tip) => tip,
+            Err(error) => {
+                warn!(
+                    error = %error,
+                    "failed to read canonical tip; ignoring pending flashblocks for metering"
+                );
+                return None;
+            }
+        };
+
+        let earliest = pending.earliest_block_number();
+        let latest = pending.latest_block_number();
+        let parent = earliest.saturating_sub(1);
+        let stale_reason =
+            pending_window_stale_reason(earliest, latest, tip, self.max_pending_blocks_depth);
+        match stale_reason {
+            None => Some(pending),
+            Some(PendingWindowStaleReason::CatchUp) => {
+                warn!(
+                    tip,
+                    earliest,
+                    latest,
+                    parent,
+                    max_depth = self.max_pending_blocks_depth,
+                    reason = "catch_up",
+                    "ignoring stale flashblock pending for metering"
+                );
+                None
+            }
+            Some(PendingWindowStaleReason::DepthLimitExceeded { depth, max_depth }) => {
+                warn!(
+                    tip,
+                    earliest,
+                    latest,
+                    parent,
+                    depth,
+                    max_depth,
+                    reason = "depth_limit_exceeded",
+                    "ignoring stale flashblock pending for metering"
+                );
+                None
+            }
+            Some(PendingWindowStaleReason::HistoricalDistance { distance }) => {
+                warn!(
+                    tip,
+                    earliest,
+                    latest,
+                    parent,
+                    distance,
+                    max_depth = self.max_pending_blocks_depth,
+                    reason = "historical_distance",
+                    "ignoring stale flashblock pending for metering"
+                );
+                None
+            }
+        }
     }
 }
 
@@ -96,56 +182,55 @@ where
             "Starting bundle metering"
         );
 
-        // Get pending blocks from flashblocks API
-        let pending_blocks = self.flashblocks_api.get_pending_blocks();
+        // Get pending blocks from flashblocks API. Stale pending is treated as absent.
+        let pending_guard = self.flashblocks_api.get_pending_blocks();
+        let pending_blocks = self.select_fresh_pending(pending_guard.as_ref().map(AsRef::as_ref));
 
         // Get header and flashblock index from pending blocks
         // If no pending blocks exist, fall back to latest canonical block
-        let (header, flashblock_index, canonical_block_number) =
-            if let Some(pb) = pending_blocks.as_ref() {
-                let latest_header: Sealed<Header> = pb.latest_header();
-                let flashblock_index = pb.latest_flashblock_index();
-                let canonical_block_number = pb.canonical_block_number();
+        let (header, flashblock_index, canonical_block_number) = if let Some(pb) = pending_blocks {
+            let latest_header: Sealed<Header> = pb.latest_header();
+            let flashblock_index = pb.latest_flashblock_index();
+            let canonical_block_number = pb.canonical_block_number();
 
-                debug!(
-                    latest_block = latest_header.number,
-                    canonical_block = %canonical_block_number,
-                    flashblock_index = flashblock_index,
-                    "Using latest flashblock state for metering"
-                );
+            debug!(
+                latest_block = latest_header.number,
+                canonical_block = %canonical_block_number,
+                flashblock_index = flashblock_index,
+                "Using latest flashblock state for metering"
+            );
 
-                // Convert Sealed<Header> to SealedHeader
-                let sealed_header =
-                    SealedHeader::new(latest_header.inner().clone(), latest_header.hash());
-                (sealed_header, flashblock_index, canonical_block_number)
-            } else {
-                // No pending blocks, use latest canonical block
-                let canonical_block_number = pending_blocks.get_canonical_block_number();
-                let header = self
-                    .provider
-                    .sealed_header_by_number_or_tag(canonical_block_number)
-                    .map_err(|e| {
-                        jsonrpsee::types::ErrorObjectOwned::owned(
-                            jsonrpsee::types::ErrorCode::InternalError.code(),
-                            format!("Failed to get canonical block header: {e}"),
-                            None::<()>,
-                        )
-                    })?
-                    .ok_or_else(|| {
-                        jsonrpsee::types::ErrorObjectOwned::owned(
-                            jsonrpsee::types::ErrorCode::InternalError.code(),
-                            "Canonical block not found".to_string(),
-                            None::<()>,
-                        )
-                    })?;
+            // Convert Sealed<Header> to SealedHeader
+            let sealed_header =
+                SealedHeader::new(latest_header.inner().clone(), latest_header.hash());
+            (sealed_header, flashblock_index, canonical_block_number)
+        } else {
+            let canonical_block_number = BlockNumberOrTag::Latest;
+            let header = self
+                .provider
+                .sealed_header_by_number_or_tag(canonical_block_number)
+                .map_err(|e| {
+                    jsonrpsee::types::ErrorObjectOwned::owned(
+                        jsonrpsee::types::ErrorCode::InternalError.code(),
+                        format!("Failed to get canonical block header: {e}"),
+                        None::<()>,
+                    )
+                })?
+                .ok_or_else(|| {
+                    jsonrpsee::types::ErrorObjectOwned::owned(
+                        jsonrpsee::types::ErrorCode::InternalError.code(),
+                        "Canonical block not found".to_string(),
+                        None::<()>,
+                    )
+                })?;
 
-                debug!(
-                    canonical_block = header.number,
-                    "No flashblocks available, using canonical block state for metering"
-                );
+            debug!(
+                canonical_block = header.number,
+                "No flashblocks available, using canonical block state for metering"
+            );
 
-                (header, 0, canonical_block_number)
-            };
+            (header, 0, canonical_block_number)
+        };
 
         let parsed_bundle = ParsedBundle::try_from(bundle).map_err(|e| {
             jsonrpsee::types::ErrorObjectOwned::owned(
@@ -168,12 +253,12 @@ where
 
         // If we have pending blocks, extract the pending state for metering
         let pending_state =
-            pending_blocks.as_ref().map(|pb| PendingState { bundle_state: pb.get_bundle_state() });
+            pending_blocks.map(|pb| PendingState { bundle_state: pb.get_bundle_state() });
 
         // Pending flashblock headers can omit parent_beacon_block_root; prefer the CL-provided
         // value from the flashblock base payload when available, otherwise fall back to the header.
         let parent_beacon_block_root = header.parent_beacon_block_root().or_else(|| {
-            pending_blocks.as_ref().and_then(|pb| {
+            pending_blocks.and_then(|pb| {
                 pb.get_flashblocks()
                     .first()
                     .and_then(|fb| fb.base.as_ref().map(|base| base.parent_beacon_block_root))
@@ -239,7 +324,7 @@ where
             gas_fees: output.total_gas_fees,
             results: output.results,
             state_block_number: header.number,
-            state_flashblock_index: pending_blocks.as_ref().map(|pb| pb.latest_flashblock_index()),
+            state_flashblock_index: pending_blocks.map(|pb| pb.latest_flashblock_index()),
             total_gas_used: output.total_gas_used,
             total_execution_time_us,
         })
@@ -489,7 +574,9 @@ mod tests {
     use base_common_flashblocks::{
         ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, Flashblock, Metadata,
     };
-    use base_flashblocks::{FlashblocksConfig, PendingBlocksBuilder};
+    use base_flashblocks::{
+        FlashblocksConfig, FlashblocksState, PendingBlocks, PendingBlocksBuilder,
+    };
     use base_node_runner::test_utils::{L1_BLOCK_INFO_DEPOSIT_TX, TestHarness};
     use base_test_utils::Account;
     use reth_transaction_pool::test_utils::TransactionBuilder;
@@ -539,6 +626,64 @@ mod tests {
                 .into_encoded()
                 .into_encoded_bytes(),
         ]
+    }
+
+    async fn setup_with_flashblocks(
+        max_pending_blocks_depth: u64,
+    ) -> eyre::Result<(TestHarness, RpcClient, Arc<FlashblocksState>)> {
+        let flashblocks_config = FlashblocksConfig::new(
+            Url::parse("ws://localhost:12345").unwrap(),
+            max_pending_blocks_depth,
+        );
+        let flashblocks_state = Arc::clone(&flashblocks_config.state);
+        let harness = TestHarness::builder()
+            .with_ext::<MeteringExtension>(MeteringConfig::with_flashblocks(flashblocks_config))
+            .build()
+            .await?;
+        let client = harness.rpc_client()?;
+        Ok((harness, client, flashblocks_state))
+    }
+
+    fn pending_blocks_with_numbers(block_numbers: &[u64]) -> eyre::Result<PendingBlocks> {
+        let mut builder = PendingBlocksBuilder::new();
+        for &block_number in block_numbers {
+            let header = Header {
+                number: block_number,
+                timestamp: 1_700_000_000 + block_number,
+                gas_limit: 30_000_000,
+                base_fee_per_gas: Some(1_000_000_000),
+                ..Default::default()
+            };
+            builder.with_header(header.seal(B256::ZERO));
+            builder.with_flashblocks([Flashblock {
+                payload_id: Default::default(),
+                index: 0,
+                base: Some(ExecutionPayloadBaseV1 {
+                    parent_beacon_block_root: B256::ZERO,
+                    parent_hash: B256::ZERO,
+                    fee_recipient: Default::default(),
+                    prev_randao: B256::ZERO,
+                    block_number,
+                    gas_limit: 30_000_000,
+                    timestamp: 1_700_000_000 + block_number,
+                    extra_data: Default::default(),
+                    base_fee_per_gas: alloy_primitives::U256::from(1_000_000_000u64),
+                }),
+                diff: ExecutionPayloadFlashblockDeltaV1 {
+                    state_root: B256::ZERO,
+                    receipts_root: B256::ZERO,
+                    logs_bloom: Bloom::default(),
+                    gas_used: 0,
+                    block_hash: B256::ZERO,
+                    transactions: vec![],
+                    withdrawals: vec![],
+                    withdrawals_root: B256::ZERO,
+                    blob_gas_used: Some(0),
+                },
+                metadata: Metadata::new(block_number),
+            }]);
+        }
+        Ok(builder.build()?)
     }
 
     #[tokio::test]
@@ -869,84 +1014,65 @@ mod tests {
     /// "Block not found: 0x0000000000000000000000000000000000000000000000000000000000000000"
     #[tokio::test]
     async fn test_meter_bundle_with_flashblocks_zero_hash_header() -> eyre::Result<()> {
-        // Create a shared flashblocks state that we can inject pending blocks into
-        let flashblocks_config =
-            FlashblocksConfig::new(Url::parse("ws://localhost:12345").unwrap(), 10);
-        let flashblocks_state = Arc::clone(&flashblocks_config.state);
+        let (harness, client, flashblocks_state) = setup_with_flashblocks(10).await?;
 
-        // Setup harness with flashblocks-enabled metering
-        let harness = TestHarness::builder()
-            .with_ext::<MeteringExtension>(MeteringConfig::with_flashblocks(flashblocks_config))
-            .build()
-            .await?;
-        let client = harness.rpc_client()?;
-
-        // Build a canonical block with L1 block info deposit
         harness
             .build_block_from_transactions(generate_txs_for_block(harness.chain_id()).await)
             .await?;
 
-        // Create a flashblock with a zero-hash header (this is how real flashblocks work)
-        // The header hash is B256::ZERO because the final block hash isn't known yet
-        let flashblock_header = Header {
-            number: 2, // Pending block on top of canonical block 1
-            timestamp: 1_700_000_001,
-            gas_limit: 30_000_000,
-            base_fee_per_gas: Some(1_000_000_000),
-            ..Default::default()
-        };
+        // Fresh pending on tip: earliest=2, latest=2, tip=1, parent==tip. Keep.
+        flashblocks_state.set_pending_blocks_for_testing(Some(pending_blocks_with_numbers(&[2])?));
 
-        // Seal with zero hash (this is what block_assembler.rs does)
-        let sealed_header = flashblock_header.seal(B256::ZERO);
-
-        // Create a minimal flashblock
-        let flashblock = Flashblock {
-            payload_id: Default::default(),
-            index: 0,
-            base: Some(ExecutionPayloadBaseV1 {
-                parent_beacon_block_root: B256::ZERO,
-                parent_hash: B256::ZERO,
-                fee_recipient: Default::default(),
-                prev_randao: B256::ZERO,
-                block_number: 2,
-                gas_limit: 30_000_000,
-                timestamp: 1_700_000_001,
-                extra_data: Default::default(),
-                base_fee_per_gas: alloy_primitives::U256::from(1_000_000_000u64),
-            }),
-            diff: ExecutionPayloadFlashblockDeltaV1 {
-                state_root: B256::ZERO,
-                receipts_root: B256::ZERO,
-                logs_bloom: Bloom::default(),
-                gas_used: 0,
-                block_hash: B256::ZERO,
-                transactions: vec![],
-                withdrawals: vec![],
-                withdrawals_root: B256::ZERO,
-                blob_gas_used: Some(0),
-            },
-            metadata: Metadata::new(2),
-        };
-
-        // Build PendingBlocks with zero-hash header
-        let mut builder = PendingBlocksBuilder::new();
-        builder.with_header(sealed_header);
-        builder.with_flashblocks([flashblock]);
-        let pending_blocks = builder.build()?;
-
-        // Inject the pending blocks into the flashblocks state
-        flashblocks_state.set_pending_blocks_for_testing(Some(pending_blocks));
-
-        // Now call meter_bundle - this should succeed with the fix
-        // Without the fix, it would fail with "Block not found: 0x0000..."
-        // because get_l1_block_info would try to look up block by zero hash
         let bundle = create_bundle(vec![], 0, None);
         let response: MeterBundleResponse = client.request("base_meterBundle", (bundle,)).await?;
 
-        // Verify we got a response and it used the flashblock state
-        // state_block_number should be 2 (the pending block number)
         assert_eq!(response.state_block_number, 2);
-        // state_flashblock_index should be present and be 0
+        assert_eq!(response.state_flashblock_index, Some(0));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_meter_bundle_ignores_stale_flashblock_pending() -> eyre::Result<()> {
+        let (harness, client, flashblocks_state) = setup_with_flashblocks(10).await?;
+
+        // Advance past a pending window at block 2, then land Latest on a block with L1 info.
+        harness.advance_chain(3).await?;
+        harness
+            .build_block_from_transactions(generate_txs_for_block(harness.chain_id()).await)
+            .await?;
+        let tip = harness.latest_block().number;
+        assert!(tip > 2, "harness tip {tip} should be ahead of injected pending latest=2");
+
+        flashblocks_state.set_pending_blocks_for_testing(Some(pending_blocks_with_numbers(&[2])?));
+
+        let bundle = create_bundle(vec![], 0, None);
+        let response: MeterBundleResponse = client.request("base_meterBundle", (bundle,)).await?;
+
+        assert_eq!(response.state_block_number, tip);
+        assert_eq!(response.state_flashblock_index, None);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_meter_bundle_keeps_pending_when_parent_is_one_behind_tip() -> eyre::Result<()> {
+        let (harness, client, flashblocks_state) = setup_with_flashblocks(10).await?;
+
+        harness
+            .build_block_from_transactions(generate_txs_for_block(harness.chain_id()).await)
+            .await?;
+        harness.advance_chain(1).await?;
+        assert_eq!(harness.latest_block().number, 2);
+
+        // earliest=2, latest=3, tip=2 → parent == tip - 1. Keep pending.
+        flashblocks_state
+            .set_pending_blocks_for_testing(Some(pending_blocks_with_numbers(&[2, 3])?));
+
+        let bundle = create_bundle(vec![], 0, None);
+        let response: MeterBundleResponse = client.request("base_meterBundle", (bundle,)).await?;
+
+        assert_eq!(response.state_block_number, 3);
         assert_eq!(response.state_flashblock_index, Some(0));
 
         Ok(())


### PR DESCRIPTION
## Summary

- `base_meterBundle` (and `base_meteredPriorityFeePerGas`, which calls it) no longer overlays flashblock pending that is stale versus the local canonical tip. TIPS ingress fail-opens on metering errors, so correctness only needs the current FB window; stale pending is treated as absent (canonical `Latest`, no overlay, `state_flashblock_index: None`) rather than applied, waited on, or turned into an RPC error.
- Freshness reuses `CanonicalBlockReconciler` (`CatchUp` / `DepthLimitExceeded`, depth at the limit is Keep) plus Reth's `EPOCH_SLOTS` historical-provider backstop against the pending parent. `parent < tip` alone is not stale: continue-after-canonical with `latest > tip` and depth within `max_pending_blocks_depth` still uses pending.
- Depth comes from configured `FlashblocksConfig` / `FlashblocksState` (CLI default 3), not a hardcoded 10 or 3.

Follow-up (not this PR): flashblock-processor catch-up / jump-to-tip when the unbounded Canonical+FB queue lags. Do not overlay stale `BundleState` onto `Latest`.

## Test plan

- [x] `cargo test -p base-flashblocks --lib test_pending_window_freshness`
- [x] `cargo test -p base-metering --lib`
- [ ] Confirm CI `base-metering` / `base-flashblocks` tests pass

type=routine
risk=low
impact=sev5