### PR TITLE
fix(precompiles): remove inaccurate observer comment and dead StablecoinVersion ordering

### DIFF
--- a/crates/common/precompiles/src/b20_stablecoin/versions.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/versions.rs
@@ -15,9 +15,8 @@ use crate::{
 
 /// An activated version of the stablecoin B-20 precompile logic.
 ///
-/// Each variant maps to an immutable implementation via [`Self::implementation`]. Variants are
-/// declared in activation order, so the derived ordering is chronological.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+/// Each variant maps to an immutable implementation via [`Self::implementation`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StablecoinVersion {
     /// Introduced at Beryl, the stablecoin's activation fork.
     V1,

--- a/crates/common/precompiles/src/provider.rs
+++ b/crates/common/precompiles/src/provider.rs
@@ -205,11 +205,6 @@ impl<S: BasePrecompileSpec> BasePrecompiles<S> {
         O: PrecompileCallObserver,
     {
         let mut precompiles = PrecompilesMap::from_static(self.precompiles());
-        // The `observer` only applies to the dynamic, address-derived B-20 token
-        // precompiles resolved at call time via `BerylLookup`. Every directly
-        // installed precompile below — Beryl's factory/registries and Cobalt's
-        // EIP-8130 precompiles alike — uses plain `install`; none is observed, by
-        // design, since metrics are scoped to the B-20 token call path.
         if self.spec.upgrade() >= BaseUpgrade::Beryl {
             B20Factory::install_with_observer(
                 &mut precompiles,


### PR DESCRIPTION
## Summary
- Remove a block comment in `install_with_observer` that incorrectly claimed all directly-installed precompiles use plain `install`; the four Beryl precompiles (`B20Factory`, `BerylLookup`, `PolicyRegistryPrecompile`, `ActivationRegistry`) all call `install_with_observer`
- Drop `PartialOrd`/`Ord` from `StablecoinVersion` and the "derived ordering is chronological" doc sentence — nothing compares version values, and the unused derives made variant reordering silently meaningful; matches `PolicyVersion` and `AssetVersion`

## Test plan
- [ ] Existing tests pass (no behavior change, doc/derive cleanup only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)