### PR TITLE
feat(builder): cut over payload builders at Denim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3333,12 +3333,15 @@ dependencies = [
 name = "base-builder-multiplex"
 version = "0.0.0"
 dependencies = [
- "alloy-eips 2.2.0",
+ "alloy-consensus 2.4.1",
+ "alloy-eips 2.4.1",
  "alloy-primitives",
- "alloy-provider 2.2.0",
+ "alloy-provider",
  "alloy-rpc-types-engine",
  "base-builder-core",
+ "base-common-chains",
  "base-common-consensus",
+ "base-common-genesis",
  "base-common-network",
  "base-common-rpc-types-engine",
  "base-execution-chainspec",
@@ -3353,6 +3356,7 @@ dependencies = [
  "metrics-exporter-prometheus",
  "reth-basic-payload-builder",
  "reth-db",
+ "reth-ethereum-forks",
  "reth-ipc",
  "reth-node-api",
  "reth-node-builder",
@@ -6175,6 +6179,7 @@ dependencies = [
  "base-batcher-encoder",
  "base-batcher-service",
  "base-builder-core",
+ "base-builder-multiplex",
  "base-bundle-extension",
  "base-common-consensus",
  "base-common-genesis",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3155,6 +3155,7 @@ dependencies = [
  "base-builder-cli",
  "base-builder-core",
  "base-builder-metering",
+ "base-builder-multiplex",
  "base-cli-utils",
  "base-execution-cli",
  "base-node-runner",
@@ -3325,6 +3326,44 @@ dependencies = [
  "base-node-runner",
  "jsonrpsee",
  "moka",
+ "tracing",
+]
+
+[[package]]
+name = "base-builder-multiplex"
+version = "0.0.0"
+dependencies = [
+ "alloy-eips 2.2.0",
+ "alloy-primitives",
+ "alloy-provider 2.2.0",
+ "alloy-rpc-types-engine",
+ "base-builder-core",
+ "base-common-consensus",
+ "base-common-network",
+ "base-common-rpc-types-engine",
+ "base-execution-chainspec",
+ "base-execution-evm",
+ "base-execution-payload-builder",
+ "base-execution-rpc",
+ "base-node-core",
+ "base-node-runner",
+ "eyre",
+ "futures",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "reth-basic-payload-builder",
+ "reth-db",
+ "reth-ipc",
+ "reth-node-api",
+ "reth-node-builder",
+ "reth-node-core",
+ "reth-payload-builder",
+ "reth-payload-builder-primitives",
+ "reth-payload-primitives",
+ "reth-provider",
+ "reth-tasks",
+ "thiserror 2.0.19",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,7 @@ base-observability-events = { path = "crates/common/observability-events", defau
 # Builder
 base-builder-cli = { path = "crates/builder/cli" }
 base-builder-core = { path = "crates/builder/core" }
+base-builder-multiplex = { path = "crates/builder/multiplex" }
 base-builder-publish = { path = "crates/builder/publish" }
 base-builder-metering = { path = "crates/builder/metering" }
 

--- a/bin/builder/Cargo.toml
+++ b/bin/builder/Cargo.toml
@@ -23,6 +23,7 @@ base-node-runner.workspace = true
 base-builder-cli.workspace = true
 base-builder-core.workspace = true
 base-shadow-indexer.workspace = true
+base-builder-multiplex.workspace = true
 base-builder-metering.workspace = true
 base-observability-events.workspace = true
 

--- a/bin/builder/src/main.rs
+++ b/bin/builder/src/main.rs
@@ -41,8 +41,9 @@ fn main() {
 
         let builder_api_config = builder_args.builder_api_config()?;
         let shadow_indexer_config = ShadowIndexerConfig::try_from(&builder_args.shadow_indexer)?;
+        let payload_builder_cutover = builder_args.payload_builder_cutover;
+        let basic_payload_builder = builder_args.basic_payload_builder;
         let builder_config = builder_args
-            .clone()
             .into_builder_config(Arc::clone(&metering_provider))
             .expect("Failed to convert rollup args to builder config");
         let da_config = builder_config.da_config.clone();
@@ -55,8 +56,8 @@ fn main() {
             .with_manifest_precheck_enabled(manifest_precheck_enabled)
             .with_service_builder(
                 MultiplexingServiceBuilder::new(builder_config)
-                    .with_cutover_enabled(builder_args.payload_builder_cutover)
-                    .with_basic_only(builder_args.basic_payload_builder),
+                    .with_cutover_enabled(payload_builder_cutover)
+                    .with_basic_only(basic_payload_builder),
             );
         runner.install_ext::<MeteringStoreExtension>(metering_provider);
         runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig::default());

--- a/bin/builder/src/main.rs
+++ b/bin/builder/src/main.rs
@@ -55,8 +55,7 @@ fn main() {
             .with_manifest_precheck_enabled(manifest_precheck_enabled)
             .with_service_builder(
                 MultiplexingServiceBuilder::new(builder_config)
-                    .with_compute_pending_block(rollup_args.compute_pending_block)
-                    .with_dual_builders_enabled(builder_args.dual_payload_builders),
+                    .with_cutover_enabled(builder_args.payload_builder_cutover),
             );
         runner.install_ext::<MeteringStoreExtension>(metering_provider);
         runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig::default());

--- a/bin/builder/src/main.rs
+++ b/bin/builder/src/main.rs
@@ -55,7 +55,8 @@ fn main() {
             .with_manifest_precheck_enabled(manifest_precheck_enabled)
             .with_service_builder(
                 MultiplexingServiceBuilder::new(builder_config)
-                    .with_cutover_enabled(builder_args.payload_builder_cutover),
+                    .with_cutover_enabled(builder_args.payload_builder_cutover)
+                    .with_basic_only(builder_args.basic_payload_builder),
             );
         runner.install_ext::<MeteringStoreExtension>(metering_provider);
         runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig::default());

--- a/bin/builder/src/main.rs
+++ b/bin/builder/src/main.rs
@@ -6,8 +6,9 @@
 use std::sync::Arc;
 
 use base_builder_cli::Args;
-use base_builder_core::{BuilderApiExtension, FlashblocksServiceBuilder};
+use base_builder_core::BuilderApiExtension;
 use base_builder_metering::MeteringStoreExtension;
+use base_builder_multiplex::MultiplexingServiceBuilder;
 use base_execution_cli::{Cli, StandardBaseRethNode};
 use base_node_runner::BaseNodeRunner;
 use base_observability_events::GlobalTransactionEventWriter;
@@ -41,6 +42,7 @@ fn main() {
         let builder_api_config = builder_args.builder_api_config()?;
         let shadow_indexer_config = ShadowIndexerConfig::try_from(&builder_args.shadow_indexer)?;
         let builder_config = builder_args
+            .clone()
             .into_builder_config(Arc::clone(&metering_provider))
             .expect("Failed to convert rollup args to builder config");
         let da_config = builder_config.da_config.clone();
@@ -51,7 +53,11 @@ fn main() {
             .with_da_config(da_config)
             .with_gas_limit_config(gas_limit_config)
             .with_manifest_precheck_enabled(manifest_precheck_enabled)
-            .with_service_builder(FlashblocksServiceBuilder::new(builder_config));
+            .with_service_builder(
+                MultiplexingServiceBuilder::new(builder_config)
+                    .with_compute_pending_block(rollup_args.compute_pending_block)
+                    .with_dual_builders_enabled(builder_args.dual_payload_builders),
+            );
         runner.install_ext::<MeteringStoreExtension>(metering_provider);
         runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig::default());
         runner.install_ext::<BuilderApiExtension>(builder_api_config);

--- a/crates/builder/cli/src/args.rs
+++ b/crates/builder/cli/src/args.rs
@@ -269,7 +269,7 @@ pub struct Args {
     #[command(flatten)]
     pub flashblocks: FlashblocksArgs,
 
-    /// Runs both payload builders and selects the basic builder when Zenith activates.
+    /// Runs both payload builders and selects the basic builder when Denim activates.
     #[arg(
         long = "builder.payload-builder-cutover",
         default_value = "false",

--- a/crates/builder/cli/src/args.rs
+++ b/crates/builder/cli/src/args.rs
@@ -269,6 +269,11 @@ pub struct Args {
     #[command(flatten)]
     pub flashblocks: FlashblocksArgs,
 
+    /// Enables flashblocks + basic dual payload builders for 200ms cutover validation.
+    /// Reads always continue to come from flashblocks.
+    #[arg(long = "builder.dual-payload-builders", default_value = "false")]
+    pub dual_payload_builders: bool,
+
     /// Transaction event journal configuration
     #[command(flatten)]
     pub transaction_events: TransactionEventsArgs,
@@ -325,6 +330,7 @@ impl Default for Args {
             sampling_ratio: 100,
             manifest_precheck_enabled: true,
             flashblocks: FlashblocksArgs::default(),
+            dual_payload_builders: false,
             transaction_events: TransactionEventsArgs::default(),
             shadow_indexer: ShadowIndexerArgs::default(),
         }
@@ -494,6 +500,12 @@ mod tests {
         let parsed =
             CommandParser::parse_from(["test", "--builder.eip8130-manifest-precheck=false"]);
         assert!(!parsed.args.manifest_precheck_enabled);
+    }
+
+    #[test]
+    fn dual_payload_builders_defaults_to_disabled() {
+        let parsed = CommandParser::parse_from(["test"]);
+        assert!(!parsed.args.dual_payload_builders);
     }
 
     #[rstest]

--- a/crates/builder/cli/src/args.rs
+++ b/crates/builder/cli/src/args.rs
@@ -270,8 +270,20 @@ pub struct Args {
     pub flashblocks: FlashblocksArgs,
 
     /// Runs both payload builders and selects the basic builder when Zenith activates.
-    #[arg(long = "builder.payload-builder-cutover", default_value = "false")]
+    #[arg(
+        long = "builder.payload-builder-cutover",
+        default_value = "false",
+        conflicts_with = "basic_payload_builder"
+    )]
     pub payload_builder_cutover: bool,
+
+    /// Runs only the basic payload builder after the cutover is complete.
+    #[arg(
+        long = "builder.basic-payload-builder",
+        default_value = "false",
+        conflicts_with = "payload_builder_cutover"
+    )]
+    pub basic_payload_builder: bool,
 
     /// Transaction event journal configuration
     #[command(flatten)]
@@ -330,6 +342,7 @@ impl Default for Args {
             manifest_precheck_enabled: true,
             flashblocks: FlashblocksArgs::default(),
             payload_builder_cutover: false,
+            basic_payload_builder: false,
             transaction_events: TransactionEventsArgs::default(),
             shadow_indexer: ShadowIndexerArgs::default(),
         }
@@ -505,12 +518,29 @@ mod tests {
     fn payload_builder_cutover_defaults_to_disabled() {
         let parsed = CommandParser::parse_from(["test"]);
         assert!(!parsed.args.payload_builder_cutover);
+        assert!(!parsed.args.basic_payload_builder);
     }
 
     #[test]
     fn payload_builder_cutover_requires_explicit_opt_in() {
         let parsed = CommandParser::parse_from(["test", "--builder.payload-builder-cutover"]);
         assert!(parsed.args.payload_builder_cutover);
+    }
+
+    #[test]
+    fn basic_payload_builder_requires_explicit_opt_in() {
+        let parsed = CommandParser::parse_from(["test", "--builder.basic-payload-builder"]);
+        assert!(parsed.args.basic_payload_builder);
+    }
+
+    #[test]
+    fn payload_builder_modes_are_mutually_exclusive() {
+        let parsed = CommandParser::try_parse_from([
+            "test",
+            "--builder.payload-builder-cutover",
+            "--builder.basic-payload-builder",
+        ]);
+        assert!(parsed.is_err());
     }
 
     #[rstest]

--- a/crates/builder/cli/src/args.rs
+++ b/crates/builder/cli/src/args.rs
@@ -269,10 +269,9 @@ pub struct Args {
     #[command(flatten)]
     pub flashblocks: FlashblocksArgs,
 
-    /// Enables flashblocks + basic dual payload builders for 200ms cutover validation.
-    /// Reads always continue to come from flashblocks.
-    #[arg(long = "builder.dual-payload-builders", default_value = "false")]
-    pub dual_payload_builders: bool,
+    /// Runs both payload builders and selects the basic builder when Zenith activates.
+    #[arg(long = "builder.payload-builder-cutover", default_value = "false")]
+    pub payload_builder_cutover: bool,
 
     /// Transaction event journal configuration
     #[command(flatten)]
@@ -330,7 +329,7 @@ impl Default for Args {
             sampling_ratio: 100,
             manifest_precheck_enabled: true,
             flashblocks: FlashblocksArgs::default(),
-            dual_payload_builders: false,
+            payload_builder_cutover: false,
             transaction_events: TransactionEventsArgs::default(),
             shadow_indexer: ShadowIndexerArgs::default(),
         }
@@ -503,9 +502,15 @@ mod tests {
     }
 
     #[test]
-    fn dual_payload_builders_defaults_to_disabled() {
+    fn payload_builder_cutover_defaults_to_disabled() {
         let parsed = CommandParser::parse_from(["test"]);
-        assert!(!parsed.args.dual_payload_builders);
+        assert!(!parsed.args.payload_builder_cutover);
+    }
+
+    #[test]
+    fn payload_builder_cutover_requires_explicit_opt_in() {
+        let parsed = CommandParser::parse_from(["test", "--builder.payload-builder-cutover"]);
+        assert!(parsed.args.payload_builder_cutover);
     }
 
     #[rstest]

--- a/crates/builder/multiplex/Cargo.toml
+++ b/crates/builder/multiplex/Cargo.toml
@@ -16,7 +16,9 @@ workspace = true
 base-builder-core.workspace = true
 base-node-core.workspace = true
 base-node-runner.workspace = true
+base-common-chains.workspace = true
 base-execution-evm.workspace = true
+base-execution-chainspec.workspace = true
 base-execution-payload-builder.workspace = true
 
 # reth
@@ -39,6 +41,7 @@ tracing.workspace = true
 
 # alloy
 alloy-primitives.workspace = true
+alloy-consensus.workspace = true
 alloy-rpc-types-engine.workspace = true
 
 # metrics
@@ -53,6 +56,7 @@ alloy-provider.workspace = true
 alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-rpc-types-engine.workspace = true
+base-common-genesis.workspace = true
 base-common-consensus = { workspace = true, features = ["reth"] }
 base-common-network.workspace = true
 base-common-rpc-types-engine.workspace = true
@@ -63,4 +67,5 @@ reth-db.workspace = true
 reth-ipc.workspace = true
 reth-node-core.workspace = true
 reth-tasks.workspace = true
+reth-ethereum-forks.workspace = true
 tokio = { workspace = true, features = ["macros"] }

--- a/crates/builder/multiplex/Cargo.toml
+++ b/crates/builder/multiplex/Cargo.toml
@@ -1,0 +1,66 @@
+[package]
+name = "base-builder-multiplex"
+description = "Parallel payload builder multiplexer for Base"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# workspace
+base-builder-core.workspace = true
+base-node-core.workspace = true
+base-node-runner.workspace = true
+base-execution-evm.workspace = true
+base-execution-payload-builder.workspace = true
+
+# reth
+reth-provider.workspace = true
+reth-node-api.workspace = true
+reth-node-builder.workspace = true
+reth-payload-builder.workspace = true
+reth-basic-payload-builder.workspace = true
+reth-payload-builder-primitives.workspace = true
+reth-payload-primitives.workspace = true
+
+# tokio
+tokio.workspace = true
+
+# async
+futures.workspace = true
+
+# tracing
+tracing.workspace = true
+
+# alloy
+alloy-primitives.workspace = true
+alloy-rpc-types-engine.workspace = true
+
+# metrics
+metrics.workspace = true
+
+# misc
+eyre.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+alloy-provider.workspace = true
+alloy-eips.workspace = true
+alloy-primitives.workspace = true
+alloy-rpc-types-engine.workspace = true
+base-common-consensus = { workspace = true, features = ["reth"] }
+base-common-network.workspace = true
+base-common-rpc-types-engine.workspace = true
+base-execution-chainspec.workspace = true
+base-execution-rpc = { workspace = true, features = ["client"] }
+metrics-exporter-prometheus.workspace = true
+reth-db.workspace = true
+reth-ipc.workspace = true
+reth-node-core.workspace = true
+reth-tasks.workspace = true
+tokio = { workspace = true, features = ["macros"] }

--- a/crates/builder/multiplex/README.md
+++ b/crates/builder/multiplex/README.md
@@ -1,12 +1,12 @@
 # `base-builder-multiplex`
 
 Runs Base flashblocks and Base basic payload builders in parallel behind a single routing
-`PayloadBuilderHandle`, cutting the selected builder over when Zenith activates.
+`PayloadBuilderHandle`, cutting the selected builder over when Denim activates.
 
 ## Overview
 
 - with cutover mode enabled, fans out every `BuildNewPayload` request to both builders,
-- selects flashblocks before Zenith and basic at and after Zenith,
+- selects flashblocks before Denim and basic at and after Denim,
 - routes reads (`BestPayload`, `PayloadTimestamp`, `Resolve`, `Subscribe`) to the builder
   selected for each payload,
 - with basic-only mode enabled, starts only the basic payload builder for operation after the

--- a/crates/builder/multiplex/README.md
+++ b/crates/builder/multiplex/README.md
@@ -1,14 +1,13 @@
 # `base-builder-multiplex`
 
 Runs Base flashblocks and Base basic payload builders in parallel behind a single routing
-`PayloadBuilderHandle`.
+`PayloadBuilderHandle`, cutting the selected builder over when Zenith activates.
 
 ## Overview
 
-- with dual mode enabled, fans out every `BuildNewPayload` request to flashblocks (selected)
-  and basic (shadow),
-- always routes reads (`BestPayload`, `PayloadTimestamp`, `Resolve`, `Subscribe`) to
-  flashblocks,
-- keeps basic as validation-only shadow output during 200ms cutover migration,
-- defaults dual mode to disabled so startup behavior is identical to plain
+- with cutover mode enabled, fans out every `BuildNewPayload` request to both builders,
+- selects flashblocks before Zenith and basic at and after Zenith,
+- routes reads (`BestPayload`, `PayloadTimestamp`, `Resolve`, `Subscribe`) to the builder
+  selected for each payload,
+- defaults cutover mode to disabled so startup behavior is identical to plain
   `FlashblocksServiceBuilder`.

--- a/crates/builder/multiplex/README.md
+++ b/crates/builder/multiplex/README.md
@@ -1,0 +1,14 @@
+# `base-builder-multiplex`
+
+Runs Base flashblocks and Base basic payload builders in parallel behind a single routing
+`PayloadBuilderHandle`.
+
+## Overview
+
+- with dual mode enabled, fans out every `BuildNewPayload` request to flashblocks (selected)
+  and basic (shadow),
+- always routes reads (`BestPayload`, `PayloadTimestamp`, `Resolve`, `Subscribe`) to
+  flashblocks,
+- keeps basic as validation-only shadow output during 200ms cutover migration,
+- defaults dual mode to disabled so startup behavior is identical to plain
+  `FlashblocksServiceBuilder`.

--- a/crates/builder/multiplex/README.md
+++ b/crates/builder/multiplex/README.md
@@ -9,5 +9,7 @@ Runs Base flashblocks and Base basic payload builders in parallel behind a singl
 - selects flashblocks before Zenith and basic at and after Zenith,
 - routes reads (`BestPayload`, `PayloadTimestamp`, `Resolve`, `Subscribe`) to the builder
   selected for each payload,
+- with basic-only mode enabled, starts only the basic payload builder for operation after the
+  cutover is complete,
 - defaults cutover mode to disabled so startup behavior is identical to plain
   `FlashblocksServiceBuilder`.

--- a/crates/builder/multiplex/src/config.rs
+++ b/crates/builder/multiplex/src/config.rs
@@ -13,10 +13,7 @@ pub struct RoutingConfig {
 
 impl Default for RoutingConfig {
     fn default() -> Self {
-        Self {
-            dual_builders_enabled: false,
-            getpayload_deadline: Duration::from_secs(5),
-        }
+        Self { dual_builders_enabled: false, getpayload_deadline: Duration::from_secs(5) }
     }
 }
 

--- a/crates/builder/multiplex/src/config.rs
+++ b/crates/builder/multiplex/src/config.rs
@@ -1,20 +1,8 @@
-use std::time::Duration;
-
 /// Runtime routing configuration.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct RoutingConfig {
     /// Enables the Denim payload-builder cutover while running both builders.
     pub cutover_enabled: bool,
-    /// Expected maximum time between a build dispatch and the selected
-    /// builder's `getPayload` resolve completing. Exceeding this records a
-    /// `mux_selected_deadline_miss_total` sample.
-    pub getpayload_deadline: Duration,
-}
-
-impl Default for RoutingConfig {
-    fn default() -> Self {
-        Self { cutover_enabled: false, getpayload_deadline: Duration::from_secs(5) }
-    }
 }
 
 #[cfg(test)]

--- a/crates/builder/multiplex/src/config.rs
+++ b/crates/builder/multiplex/src/config.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 /// Runtime routing configuration.
 #[derive(Debug, Clone)]
 pub struct RoutingConfig {
-    /// Enables dual payload builder mode (flashblocks + shadow basic builder).
-    pub dual_builders_enabled: bool,
+    /// Enables the Zenith payload-builder cutover while running both builders.
+    pub cutover_enabled: bool,
     /// Expected maximum time between a build dispatch and the selected
     /// builder's `getPayload` resolve completing. Exceeding this records a
     /// `mux_selected_deadline_miss_total` sample.
@@ -13,7 +13,7 @@ pub struct RoutingConfig {
 
 impl Default for RoutingConfig {
     fn default() -> Self {
-        Self { dual_builders_enabled: false, getpayload_deadline: Duration::from_secs(5) }
+        Self { cutover_enabled: false, getpayload_deadline: Duration::from_secs(5) }
     }
 }
 
@@ -22,7 +22,7 @@ mod tests {
     use super::RoutingConfig;
 
     #[test]
-    fn dual_builders_default_disabled() {
-        assert!(!RoutingConfig::default().dual_builders_enabled);
+    fn cutover_defaults_to_disabled() {
+        assert!(!RoutingConfig::default().cutover_enabled);
     }
 }

--- a/crates/builder/multiplex/src/config.rs
+++ b/crates/builder/multiplex/src/config.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 /// Runtime routing configuration.
 #[derive(Debug, Clone)]
 pub struct RoutingConfig {
-    /// Enables the Zenith payload-builder cutover while running both builders.
+    /// Enables the Denim payload-builder cutover while running both builders.
     pub cutover_enabled: bool,
     /// Expected maximum time between a build dispatch and the selected
     /// builder's `getPayload` resolve completing. Exceeding this records a

--- a/crates/builder/multiplex/src/config.rs
+++ b/crates/builder/multiplex/src/config.rs
@@ -1,0 +1,31 @@
+use std::time::Duration;
+
+/// Runtime routing configuration.
+#[derive(Debug, Clone)]
+pub struct RoutingConfig {
+    /// Enables dual payload builder mode (flashblocks + shadow basic builder).
+    pub dual_builders_enabled: bool,
+    /// Expected maximum time between a build dispatch and the selected
+    /// builder's `getPayload` resolve completing. Exceeding this records a
+    /// `mux_selected_deadline_miss_total` sample.
+    pub getpayload_deadline: Duration,
+}
+
+impl Default for RoutingConfig {
+    fn default() -> Self {
+        Self {
+            dual_builders_enabled: false,
+            getpayload_deadline: Duration::from_secs(5),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RoutingConfig;
+
+    #[test]
+    fn dual_builders_default_disabled() {
+        assert!(!RoutingConfig::default().dual_builders_enabled);
+    }
+}

--- a/crates/builder/multiplex/src/lib.rs
+++ b/crates/builder/multiplex/src/lib.rs
@@ -1,0 +1,13 @@
+#![doc = include_str!("../README.md")]
+#![doc(issue_tracker_base_url = "https://github.com/base/base/issues/")]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), allow(unused_crate_dependencies))]
+
+mod config;
+pub use config::RoutingConfig;
+
+mod router;
+pub use router::{BuilderUnavailableError, HealthState, MultiplexRouter, ResolveFuture};
+
+mod service_builder;
+pub use service_builder::MultiplexingServiceBuilder;

--- a/crates/builder/multiplex/src/router.rs
+++ b/crates/builder/multiplex/src/router.rs
@@ -420,6 +420,7 @@ impl MultiplexRouter {
             let mut basic_closed = false;
             while !flashblocks_closed || !basic_closed {
                 tokio::select! {
+                    _ = events_tx.closed() => break,
                     result = flashblocks_events.recv(), if !flashblocks_closed => match result {
                         Ok(event) => {
                             if !router.basic_selected_at(Self::event_timestamp(&event)) {
@@ -539,6 +540,8 @@ impl MultiplexRouter {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use alloy_primitives::B256;
     use base_common_genesis::BaseUpgrade;
     use base_execution_chainspec::BaseChainSpecBuilder;
@@ -725,6 +728,12 @@ mod tests {
             MultiplexRouter::event_timestamp(&sub.recv().await.expect("receive basic event")),
             ZENITH_TIMESTAMP
         );
+
+        drop(sub);
+        tokio::time::timeout(Duration::from_secs(1), flash_events_tx.closed())
+            .await
+            .expect("forwarding task should unsubscribe when downstream receiver closes");
+        assert_eq!(basic_events_tx.receiver_count(), 0);
     }
 
     #[tokio::test]

--- a/crates/builder/multiplex/src/router.rs
+++ b/crates/builder/multiplex/src/router.rs
@@ -18,8 +18,6 @@ use reth_payload_primitives::{PayloadAttributes, PayloadKind, PayloadTypes};
 use tokio::sync::{Mutex, broadcast, mpsc};
 use tracing::{error, info, warn};
 
-use crate::RoutingConfig;
-
 const FLASHBLOCKS_BUILDER: &str = "flashblocks";
 const BASIC_BUILDER: &str = "basic";
 const MAX_PAYLOAD_ROUTES: usize = 128;
@@ -89,8 +87,6 @@ pub struct MultiplexRouter {
     pub chain_spec: Arc<BaseChainSpec>,
     /// Whether recent payload IDs are routed to the basic builder, ordered oldest first.
     pub payload_routes: Arc<Mutex<VecDeque<(PayloadId, bool)>>>,
-    /// Deadline used to flag slow selected `getPayload` resolutions.
-    pub getpayload_deadline: std::time::Duration,
 }
 
 impl MultiplexRouter {
@@ -101,7 +97,6 @@ impl MultiplexRouter {
         flashblocks_health: HealthState,
         basic_health: HealthState,
         chain_spec: Arc<BaseChainSpec>,
-        config: RoutingConfig,
     ) -> Self {
         Self {
             flashblocks_handle,
@@ -110,7 +105,6 @@ impl MultiplexRouter {
             basic_health,
             chain_spec,
             payload_routes: Arc::new(Mutex::new(VecDeque::new())),
-            getpayload_deadline: config.getpayload_deadline,
         }
     }
 
@@ -336,7 +330,6 @@ impl MultiplexRouter {
         } else {
             (self.flashblocks_handle.clone(), self.flashblocks_health.clone(), FLASHBLOCKS_BUILDER)
         };
-        let deadline = self.getpayload_deadline;
         let payload_routes = Arc::clone(&self.payload_routes);
         let future = async move {
             let started = Instant::now();
@@ -349,9 +342,6 @@ impl MultiplexRouter {
             drop(routes);
 
             Self::record_selected_getpayload_latency(elapsed.as_secs_f64());
-            if elapsed > deadline {
-                Self::inc_selected_deadline_miss();
-            }
 
             match result {
                 Some(Ok(payload)) => Ok(payload),
@@ -531,11 +521,6 @@ impl MultiplexRouter {
     pub fn record_selected_getpayload_latency(seconds: f64) {
         metrics::histogram!("mux_selected_getpayload_latency_seconds").record(seconds);
     }
-
-    /// Increments selected deadline miss counter.
-    pub fn inc_selected_deadline_miss() {
-        metrics::counter!("mux_selected_deadline_miss_total").increment(1);
-    }
 }
 
 #[cfg(test)]
@@ -571,7 +556,6 @@ mod tests {
                     .with_fork(BaseUpgrade::Denim, ForkCondition::Timestamp(DENIM_TIMESTAMP))
                     .build(),
             ),
-            RoutingConfig::default(),
         );
         (router, flash_rx, basic_rx)
     }

--- a/crates/builder/multiplex/src/router.rs
+++ b/crates/builder/multiplex/src/router.rs
@@ -2,7 +2,7 @@ use std::{
     collections::VecDeque,
     sync::{
         Arc,
-        atomic::{AtomicBool, AtomicU64, Ordering},
+        atomic::{AtomicBool, Ordering},
     },
     time::Instant,
 };
@@ -23,15 +23,6 @@ use crate::RoutingConfig;
 const FLASHBLOCKS_BUILDER: &str = "flashblocks";
 const BASIC_BUILDER: &str = "basic";
 const MAX_PAYLOAD_ROUTES: usize = 128;
-
-#[cfg(debug_assertions)]
-static DEBUG_DISPATCH_FLASHBLOCKS: AtomicU64 = AtomicU64::new(0);
-#[cfg(debug_assertions)]
-static DEBUG_DISPATCH_BASIC: AtomicU64 = AtomicU64::new(0);
-#[cfg(debug_assertions)]
-static DEBUG_SELECTED_FLASHBLOCKS: AtomicU64 = AtomicU64::new(0);
-#[cfg(debug_assertions)]
-static DEBUG_SELECTED_BASIC: AtomicU64 = AtomicU64::new(0);
 
 /// Shared health state for one inner service.
 #[derive(Debug, Clone)]
@@ -507,58 +498,11 @@ impl MultiplexRouter {
 
     /// Increments dispatch metric.
     pub fn inc_dispatch_metric(builder: &'static str) {
-        #[cfg(debug_assertions)]
-        if builder == FLASHBLOCKS_BUILDER {
-            DEBUG_DISPATCH_FLASHBLOCKS.fetch_add(1, Ordering::Relaxed);
-        } else if builder == BASIC_BUILDER {
-            DEBUG_DISPATCH_BASIC.fetch_add(1, Ordering::Relaxed);
-        }
-
         metrics::counter!("mux_builds_dispatched_total", "builder" => builder).increment(1);
-    }
-
-    /// Returns the in-process debug dispatch counter for flashblocks.
-    #[cfg(debug_assertions)]
-    pub fn debug_flashblocks_dispatch_count() -> u64 {
-        DEBUG_DISPATCH_FLASHBLOCKS.load(Ordering::Relaxed)
-    }
-
-    /// Returns the in-process debug dispatch counter for basic.
-    #[cfg(debug_assertions)]
-    pub fn debug_basic_dispatch_count() -> u64 {
-        DEBUG_DISPATCH_BASIC.load(Ordering::Relaxed)
-    }
-
-    /// Returns the in-process debug selected counter for flashblocks.
-    #[cfg(debug_assertions)]
-    pub fn debug_flashblocks_selected_count() -> u64 {
-        DEBUG_SELECTED_FLASHBLOCKS.load(Ordering::Relaxed)
-    }
-
-    /// Returns the in-process debug selected counter for basic.
-    #[cfg(debug_assertions)]
-    pub fn debug_basic_selected_count() -> u64 {
-        DEBUG_SELECTED_BASIC.load(Ordering::Relaxed)
-    }
-
-    /// Resets in-process debug dispatch counters.
-    #[cfg(debug_assertions)]
-    pub fn debug_reset_dispatch_counts() {
-        DEBUG_DISPATCH_FLASHBLOCKS.store(0, Ordering::Relaxed);
-        DEBUG_DISPATCH_BASIC.store(0, Ordering::Relaxed);
-        DEBUG_SELECTED_FLASHBLOCKS.store(0, Ordering::Relaxed);
-        DEBUG_SELECTED_BASIC.store(0, Ordering::Relaxed);
     }
 
     /// Increments selected metric.
     pub fn inc_selected_build_metric(builder: &'static str) {
-        #[cfg(debug_assertions)]
-        if builder == FLASHBLOCKS_BUILDER {
-            DEBUG_SELECTED_FLASHBLOCKS.fetch_add(1, Ordering::Relaxed);
-        } else if builder == BASIC_BUILDER {
-            DEBUG_SELECTED_BASIC.fetch_add(1, Ordering::Relaxed);
-        }
-
         metrics::counter!("mux_selected_builds_total", "builder" => builder).increment(1);
     }
 

--- a/crates/builder/multiplex/src/router.rs
+++ b/crates/builder/multiplex/src/router.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     sync::{
         Arc,
         atomic::{AtomicBool, AtomicU64, Ordering},
@@ -6,12 +7,15 @@ use std::{
     time::Instant,
 };
 
+use alloy_consensus::BlockHeader;
 use alloy_rpc_types_engine::PayloadId;
+use base_common_chains::Upgrades;
+use base_execution_chainspec::BaseChainSpec;
 use base_node_core::BaseEngineTypes;
 use reth_payload_builder::{BuildNewPayload, PayloadBuilderHandle, PayloadServiceCommand};
-use reth_payload_builder_primitives::PayloadBuilderError;
-use reth_payload_primitives::{PayloadKind, PayloadTypes};
-use tokio::sync::mpsc;
+use reth_payload_builder_primitives::{Events, PayloadBuilderError};
+use reth_payload_primitives::{PayloadAttributes, PayloadKind, PayloadTypes};
+use tokio::sync::{Mutex, broadcast, mpsc};
 use tracing::info;
 
 use crate::RoutingConfig;
@@ -23,6 +27,10 @@ const BASIC_BUILDER: &str = "basic";
 static DEBUG_DISPATCH_FLASHBLOCKS: AtomicU64 = AtomicU64::new(0);
 #[cfg(debug_assertions)]
 static DEBUG_DISPATCH_BASIC: AtomicU64 = AtomicU64::new(0);
+#[cfg(debug_assertions)]
+static DEBUG_SELECTED_FLASHBLOCKS: AtomicU64 = AtomicU64::new(0);
+#[cfg(debug_assertions)]
+static DEBUG_SELECTED_BASIC: AtomicU64 = AtomicU64::new(0);
 
 /// Shared health state for one inner service.
 #[derive(Debug, Clone)]
@@ -74,28 +82,33 @@ pub type ResolveFuture = std::pin::Pin<
     >,
 >;
 
-/// Router that multiplexes one outer payload-builder handle over flashblocks + basic shadow.
+/// Router that cuts payload selection from flashblocks to basic when Zenith activates.
 #[derive(Debug, Clone)]
 pub struct MultiplexRouter {
-    /// Flashblocks handle used for all reads and selected build results.
+    /// Flashblocks payload-builder handle.
     pub flashblocks_handle: PayloadBuilderHandle<BaseEngineTypes>,
-    /// Basic handle used only for shadow build fan-out.
+    /// Basic payload-builder handle.
     pub basic_handle: PayloadBuilderHandle<BaseEngineTypes>,
     /// Flashblocks health state.
     pub flashblocks_health: HealthState,
     /// Basic health state.
     pub basic_health: HealthState,
+    /// Chain spec that owns the Zenith activation condition.
+    pub chain_spec: Arc<BaseChainSpec>,
+    /// Whether each active payload ID is routed to the basic builder.
+    pub payload_routes: Arc<Mutex<HashMap<PayloadId, bool>>>,
     /// Deadline used to flag slow selected `getPayload` resolutions.
     pub getpayload_deadline: std::time::Duration,
 }
 
 impl MultiplexRouter {
     /// Creates a new router.
-    pub const fn new(
+    pub fn new(
         flashblocks_handle: PayloadBuilderHandle<BaseEngineTypes>,
         basic_handle: PayloadBuilderHandle<BaseEngineTypes>,
         flashblocks_health: HealthState,
         basic_health: HealthState,
+        chain_spec: Arc<BaseChainSpec>,
         config: RoutingConfig,
     ) -> Self {
         Self {
@@ -103,7 +116,27 @@ impl MultiplexRouter {
             basic_handle,
             flashblocks_health,
             basic_health,
+            chain_spec,
+            payload_routes: Arc::new(Mutex::new(HashMap::new())),
             getpayload_deadline: config.getpayload_deadline,
+        }
+    }
+
+    /// Returns whether Zenith selects the basic builder at `timestamp`.
+    pub fn basic_selected_at(&self, timestamp: u64) -> bool {
+        self.chain_spec.is_zenith_active_at_timestamp(timestamp)
+    }
+
+    /// Returns the recorded route for a payload, defaulting unknown payloads to flashblocks.
+    pub async fn basic_selected_for_payload(&self, payload_id: PayloadId) -> bool {
+        self.payload_routes.lock().await.get(&payload_id).copied().unwrap_or(false)
+    }
+
+    /// Returns the timestamp represented by a payload-builder event.
+    pub fn event_timestamp(event: &Events<BaseEngineTypes>) -> u64 {
+        match event {
+            Events::Attributes(attributes) => attributes.timestamp(),
+            Events::BuiltPayload(payload) => payload.block().timestamp(),
         }
     }
 
@@ -148,38 +181,80 @@ impl MultiplexRouter {
         tx: tokio::sync::oneshot::Sender<Result<PayloadId, PayloadBuilderError>>,
     ) {
         let payload_id = input.payload_id();
+        let selected_basic = self.basic_selected_at(input.attributes.timestamp());
+        self.payload_routes.lock().await.insert(payload_id, selected_basic);
 
-        let basic_input = input;
-        let flashblocks_input = BuildNewPayload {
-            attributes: basic_input.attributes.clone(),
-            parent_hash: basic_input.parent_hash,
-            cache: None,
-            state_root_handle: None,
+        let mut shadow_attributes = input.attributes.clone();
+        shadow_attributes.no_tx_pool = true;
+        let shadow_input = BuildNewPayload {
+            attributes: shadow_attributes,
+            parent_hash: input.parent_hash,
+            resources: Default::default(),
         };
+        let (flashblocks_input, basic_input) =
+            if selected_basic { (shadow_input, input) } else { (input, shadow_input) };
 
         Self::inc_dispatch_metric(FLASHBLOCKS_BUILDER);
         Self::inc_dispatch_metric(BASIC_BUILDER);
-        Self::inc_selected_build_metric(FLASHBLOCKS_BUILDER);
 
         let flashblocks_rx = self.flashblocks_handle.send_new_payload(flashblocks_input);
         let basic_rx = self.basic_handle.send_new_payload(basic_input);
 
-        let (flashblocks_result, basic_result) = tokio::join!(flashblocks_rx, basic_rx);
-        let selected_result = flashblocks_result.unwrap_or_else(|_| {
-            self.flashblocks_health.mark_unavailable();
-            Self::set_service_health_metric(FLASHBLOCKS_BUILDER, false);
-            Err(Self::unavailable_error(FLASHBLOCKS_BUILDER))
-        });
-        let shadow_result = basic_result.unwrap_or_else(|_| {
-            self.basic_health.mark_unavailable();
-            Self::set_service_health_metric(BASIC_BUILDER, false);
-            Err(Self::unavailable_error(BASIC_BUILDER))
+        let (
+            selected_rx,
+            selected_health,
+            selected_builder,
+            shadow_rx,
+            shadow_health,
+            shadow_builder,
+        ) = if selected_basic {
+            (
+                basic_rx,
+                self.basic_health.clone(),
+                BASIC_BUILDER,
+                flashblocks_rx,
+                self.flashblocks_health.clone(),
+                FLASHBLOCKS_BUILDER,
+            )
+        } else {
+            (
+                flashblocks_rx,
+                self.flashblocks_health.clone(),
+                FLASHBLOCKS_BUILDER,
+                basic_rx,
+                self.basic_health.clone(),
+                BASIC_BUILDER,
+            )
+        };
+
+        Self::inc_selected_build_metric(selected_builder);
+        tokio::spawn(async move {
+            let shadow_result = shadow_rx.await.unwrap_or_else(|_| {
+                shadow_health.mark_unavailable();
+                Self::set_service_health_metric(shadow_builder, false);
+                Err(Self::unavailable_error(shadow_builder))
+            });
+            Self::inc_shadow_metric(shadow_builder, shadow_result.is_ok());
+            info!(
+                builder = shadow_builder,
+                payload_id = ?payload_id,
+                selected = false,
+                result = if shadow_result.is_ok() { "ok" } else { "err" },
+                "multiplex shadow build request completed"
+            );
         });
 
-        Self::inc_shadow_metric(BASIC_BUILDER, shadow_result.is_ok());
+        let selected_result = selected_rx.await.unwrap_or_else(|_| {
+            selected_health.mark_unavailable();
+            Self::set_service_health_metric(selected_builder, false);
+            Err(Self::unavailable_error(selected_builder))
+        });
+        if selected_result.is_err() {
+            self.payload_routes.lock().await.remove(&payload_id);
+        }
 
         info!(
-            builder = FLASHBLOCKS_BUILDER,
+            builder = selected_builder,
             payload_id = ?payload_id,
             selected = true,
             result = if selected_result.is_ok() { "ok" } else { "err" },
@@ -197,8 +272,17 @@ impl MultiplexRouter {
             Option<Result<<BaseEngineTypes as PayloadTypes>::BuiltPayload, PayloadBuilderError>>,
         >,
     ) {
-        let result = self.flashblocks_handle.best_payload(payload_id).await;
-        let mapped = self.map_flashblocks_read_result(result);
+        let selected_basic = self.basic_selected_for_payload(payload_id).await;
+        let (result, builder, health) = if selected_basic {
+            (self.basic_handle.best_payload(payload_id).await, BASIC_BUILDER, &self.basic_health)
+        } else {
+            (
+                self.flashblocks_handle.best_payload(payload_id).await,
+                FLASHBLOCKS_BUILDER,
+                &self.flashblocks_health,
+            )
+        };
+        let mapped = self.map_read_result(result, builder, health);
         let _ = tx.send(mapped);
     }
 
@@ -208,8 +292,21 @@ impl MultiplexRouter {
         payload_id: PayloadId,
         tx: tokio::sync::oneshot::Sender<Option<Result<u64, PayloadBuilderError>>>,
     ) {
-        let result = self.flashblocks_handle.payload_timestamp(payload_id).await;
-        let mapped = self.map_flashblocks_read_result(result);
+        let selected_basic = self.basic_selected_for_payload(payload_id).await;
+        let (result, builder, health) = if selected_basic {
+            (
+                self.basic_handle.payload_timestamp(payload_id).await,
+                BASIC_BUILDER,
+                &self.basic_health,
+            )
+        } else {
+            (
+                self.flashblocks_handle.payload_timestamp(payload_id).await,
+                FLASHBLOCKS_BUILDER,
+                &self.flashblocks_health,
+            )
+        };
+        let mapped = self.map_read_result(result, builder, health);
         let _ = tx.send(mapped);
     }
 
@@ -220,13 +317,19 @@ impl MultiplexRouter {
         kind: PayloadKind,
         tx: tokio::sync::oneshot::Sender<Option<ResolveFuture>>,
     ) {
-        let handle = self.flashblocks_handle.clone();
-        let health = self.flashblocks_health.clone();
+        let selected_basic = self.basic_selected_for_payload(payload_id).await;
+        let (handle, health, builder) = if selected_basic {
+            (self.basic_handle.clone(), self.basic_health.clone(), BASIC_BUILDER)
+        } else {
+            (self.flashblocks_handle.clone(), self.flashblocks_health.clone(), FLASHBLOCKS_BUILDER)
+        };
         let deadline = self.getpayload_deadline;
+        let payload_routes = Arc::clone(&self.payload_routes);
         let future = async move {
             let started = Instant::now();
             let result = handle.resolve_kind(payload_id, kind).await;
             let elapsed = started.elapsed();
+            payload_routes.lock().await.remove(&payload_id);
 
             Self::record_selected_getpayload_latency(elapsed.as_secs_f64());
             if elapsed > deadline {
@@ -237,13 +340,13 @@ impl MultiplexRouter {
                 Some(Ok(payload)) => Ok(payload),
                 Some(Err(PayloadBuilderError::ChannelClosed)) => {
                     health.mark_unavailable();
-                    Self::set_service_health_metric(FLASHBLOCKS_BUILDER, false);
-                    Err(Self::unavailable_error(FLASHBLOCKS_BUILDER))
+                    Self::set_service_health_metric(builder, false);
+                    Err(Self::unavailable_error(builder))
                 }
                 Some(Err(err)) => Err(err),
                 None => {
                     if !health.is_healthy() {
-                        Err(Self::unavailable_error(FLASHBLOCKS_BUILDER))
+                        Err(Self::unavailable_error(builder))
                     } else {
                         Err(PayloadBuilderError::MissingPayload)
                     }
@@ -263,37 +366,78 @@ impl MultiplexRouter {
             >,
         >,
     ) {
-        if !self.flashblocks_health.is_healthy() {
+        let mut flashblocks_events = match self.flashblocks_handle.subscribe().await {
+            Ok(events) => events.receiver,
+            Err(_) => {
+                self.flashblocks_health.mark_unavailable();
+                Self::set_service_health_metric(FLASHBLOCKS_BUILDER, false);
+                return;
+            }
+        };
+        let mut basic_events = match self.basic_handle.subscribe().await {
+            Ok(events) => events.receiver,
+            Err(_) => {
+                self.basic_health.mark_unavailable();
+                Self::set_service_health_metric(BASIC_BUILDER, false);
+                return;
+            }
+        };
+        let (events_tx, events_rx) = broadcast::channel(64);
+        if tx.send(events_rx).is_err() {
             return;
         }
 
-        match self.flashblocks_handle.subscribe().await {
-            Ok(events) => {
-                let _ = tx.send(events.receiver);
-            }
-            Err(err) => {
-                if matches!(err, PayloadBuilderError::ChannelClosed) {
-                    self.flashblocks_health.mark_unavailable();
-                    Self::set_service_health_metric(FLASHBLOCKS_BUILDER, false);
+        let router = self.clone();
+        tokio::spawn(async move {
+            let mut flashblocks_closed = false;
+            let mut basic_closed = false;
+            while !flashblocks_closed || !basic_closed {
+                tokio::select! {
+                    result = flashblocks_events.recv(), if !flashblocks_closed => match result {
+                        Ok(event) => {
+                            if !router.basic_selected_at(Self::event_timestamp(&event)) {
+                                let _ = events_tx.send(event);
+                            }
+                        }
+                        Err(broadcast::error::RecvError::Closed) => {
+                            flashblocks_closed = true;
+                            router.flashblocks_health.mark_unavailable();
+                            Self::set_service_health_metric(FLASHBLOCKS_BUILDER, false);
+                        }
+                        Err(broadcast::error::RecvError::Lagged(_)) => {}
+                    },
+                    result = basic_events.recv(), if !basic_closed => match result {
+                        Ok(event) => {
+                            if router.basic_selected_at(Self::event_timestamp(&event)) {
+                                let _ = events_tx.send(event);
+                            }
+                        }
+                        Err(broadcast::error::RecvError::Closed) => {
+                            basic_closed = true;
+                            router.basic_health.mark_unavailable();
+                            Self::set_service_health_metric(BASIC_BUILDER, false);
+                        }
+                        Err(broadcast::error::RecvError::Lagged(_)) => {}
+                    },
                 }
             }
-        }
+        });
     }
 
-    /// Maps flashblocks read results with unavailable conversion.
-    pub fn map_flashblocks_read_result<T>(
+    /// Maps selected-builder read results with unavailable conversion.
+    pub fn map_read_result<T>(
         &self,
         result: Option<Result<T, PayloadBuilderError>>,
+        builder: &'static str,
+        health: &HealthState,
     ) -> Option<Result<T, PayloadBuilderError>> {
         match result {
             Some(Err(PayloadBuilderError::ChannelClosed)) => {
-                self.flashblocks_health.mark_unavailable();
-                Self::set_service_health_metric(FLASHBLOCKS_BUILDER, false);
-                Some(Err(Self::unavailable_error(FLASHBLOCKS_BUILDER)))
+                health.mark_unavailable();
+                Self::set_service_health_metric(builder, false);
+                Some(Err(Self::unavailable_error(builder)))
             }
-            None if !self.flashblocks_health.is_healthy() => {
-                Some(Err(Self::unavailable_error(FLASHBLOCKS_BUILDER)))
-            }
+            None if !health.is_healthy() => Some(Err(Self::unavailable_error(builder))),
             other => other,
         }
     }
@@ -327,15 +471,36 @@ impl MultiplexRouter {
         DEBUG_DISPATCH_BASIC.load(Ordering::Relaxed)
     }
 
+    /// Returns the in-process debug selected counter for flashblocks.
+    #[cfg(debug_assertions)]
+    pub fn debug_flashblocks_selected_count() -> u64 {
+        DEBUG_SELECTED_FLASHBLOCKS.load(Ordering::Relaxed)
+    }
+
+    /// Returns the in-process debug selected counter for basic.
+    #[cfg(debug_assertions)]
+    pub fn debug_basic_selected_count() -> u64 {
+        DEBUG_SELECTED_BASIC.load(Ordering::Relaxed)
+    }
+
     /// Resets in-process debug dispatch counters.
     #[cfg(debug_assertions)]
     pub fn debug_reset_dispatch_counts() {
         DEBUG_DISPATCH_FLASHBLOCKS.store(0, Ordering::Relaxed);
         DEBUG_DISPATCH_BASIC.store(0, Ordering::Relaxed);
+        DEBUG_SELECTED_FLASHBLOCKS.store(0, Ordering::Relaxed);
+        DEBUG_SELECTED_BASIC.store(0, Ordering::Relaxed);
     }
 
     /// Increments selected metric.
     pub fn inc_selected_build_metric(builder: &'static str) {
+        #[cfg(debug_assertions)]
+        if builder == FLASHBLOCKS_BUILDER {
+            DEBUG_SELECTED_FLASHBLOCKS.fetch_add(1, Ordering::Relaxed);
+        } else if builder == BASIC_BUILDER {
+            DEBUG_SELECTED_BASIC.fetch_add(1, Ordering::Relaxed);
+        }
+
         metrics::counter!("mux_selected_builds_total", "builder" => builder).increment(1);
     }
 
@@ -373,11 +538,16 @@ impl MultiplexRouter {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::B256;
+    use base_common_genesis::BaseUpgrade;
+    use base_execution_chainspec::BaseChainSpecBuilder;
+    use reth_ethereum_forks::ForkCondition;
     use reth_payload_builder::PayloadBuilderHandle;
     use reth_payload_builder_primitives::Events;
     use tokio::sync::{broadcast, mpsc};
 
     use super::*;
+
+    const ZENITH_TIMESTAMP: u64 = 10;
 
     fn test_router() -> (
         MultiplexRouter,
@@ -391,76 +561,100 @@ mod tests {
             PayloadBuilderHandle::new(basic_tx),
             HealthState::new(),
             HealthState::new(),
+            Arc::new(
+                BaseChainSpecBuilder::base_mainnet()
+                    .with_fork(BaseUpgrade::Zenith, ForkCondition::Timestamp(ZENITH_TIMESTAMP))
+                    .build(),
+            ),
             RoutingConfig::default(),
         );
         (router, flash_rx, basic_rx)
     }
 
-    fn sample_input() -> BuildNewPayload<<BaseEngineTypes as PayloadTypes>::PayloadAttributes> {
-        BuildNewPayload {
+    fn sample_input(
+        timestamp: u64,
+    ) -> BuildNewPayload<<BaseEngineTypes as PayloadTypes>::PayloadAttributes> {
+        let mut input = BuildNewPayload {
             attributes: base_execution_payload_builder::BasePayloadBuilderAttributes::default(),
             parent_hash: B256::ZERO,
-            cache: None,
-            state_root_handle: None,
-        }
+            resources: Default::default(),
+        };
+        input.attributes.payload_attributes.timestamp = timestamp;
+        input
     }
 
     fn payload_id_from_byte(value: u8) -> PayloadId {
-        let mut input = sample_input();
+        let mut input = sample_input(0);
         input.parent_hash = B256::repeat_byte(value);
         input.payload_id()
     }
 
     #[tokio::test]
-    async fn build_fans_to_both_and_selects_flashblocks() {
-        let (router, mut flash_rx, mut basic_rx) = test_router();
-        let (tx, rx) = tokio::sync::oneshot::channel();
+    async fn build_fans_to_both_and_selects_by_zenith_activation() {
+        for (timestamp, selected_basic) in [(ZENITH_TIMESTAMP - 1, false), (ZENITH_TIMESTAMP, true)]
+        {
+            let (router, mut flash_rx, mut basic_rx) = test_router();
+            let (tx, rx) = tokio::sync::oneshot::channel();
 
-        let input = sample_input();
-        let payload_id = input.payload_id();
-        tokio::spawn(async move {
-            router.handle_build_new_payload(input, tx).await;
-        });
+            let input = sample_input(timestamp);
+            let payload_id = input.payload_id();
+            tokio::spawn(async move {
+                router.handle_build_new_payload(input, tx).await;
+            });
 
-        let flash_cmd = flash_rx.recv().await.expect("flash cmd");
-        let basic_cmd = basic_rx.recv().await.expect("basic cmd");
-        let mut flash_seen = false;
-        let mut basic_seen = false;
+            let flash_cmd = flash_rx.recv().await.expect("flash cmd");
+            let basic_cmd = basic_rx.recv().await.expect("basic cmd");
+            let mut flash_seen = false;
+            let mut basic_seen = false;
 
-        if let PayloadServiceCommand::BuildNewPayload(input, _, tx) = flash_cmd {
-            flash_seen = true;
-            assert_eq!(input.payload_id(), payload_id);
-            assert!(input.cache.is_none());
-            assert!(input.state_root_handle.is_none());
-            tx.send(Ok(payload_id)).expect("flash response");
+            if let PayloadServiceCommand::BuildNewPayload(input, _, tx) = flash_cmd {
+                flash_seen = true;
+                assert_eq!(input.payload_id() == payload_id, !selected_basic);
+                assert_eq!(input.attributes.no_tx_pool, selected_basic);
+                assert!(input.resources.execution_cache().is_none());
+                assert!(input.resources.state_root_handle().is_none());
+                tx.send(if selected_basic {
+                    Err(PayloadBuilderError::MissingPayload)
+                } else {
+                    Ok(payload_id)
+                })
+                .expect("flash response");
+            }
+
+            if let PayloadServiceCommand::BuildNewPayload(input, _, tx) = basic_cmd {
+                basic_seen = true;
+                assert_eq!(input.payload_id() == payload_id, selected_basic);
+                assert_eq!(input.attributes.no_tx_pool, !selected_basic);
+                tx.send(if selected_basic {
+                    Ok(payload_id)
+                } else {
+                    Err(PayloadBuilderError::MissingPayload)
+                })
+                .expect("basic response");
+            }
+
+            assert!(flash_seen);
+            assert!(basic_seen);
+            assert!(rx.await.expect("selected response").is_ok());
         }
-
-        if let PayloadServiceCommand::BuildNewPayload(input, _, tx) = basic_cmd {
-            basic_seen = true;
-            assert_eq!(input.payload_id(), payload_id);
-            tx.send(Err(PayloadBuilderError::MissingPayload)).expect("basic response");
-        }
-
-        assert!(flash_seen);
-        assert!(basic_seen);
-        assert!(rx.await.expect("selected response").is_ok());
     }
 
     #[tokio::test]
-    async fn best_payload_reads_flashblocks_only() {
+    async fn best_payload_reads_recorded_builder() {
         let (router, mut flash_rx, mut basic_rx) = test_router();
         let payload_id = payload_id_from_byte(7);
+        router.payload_routes.lock().await.insert(payload_id, true);
         let (tx, rx) = tokio::sync::oneshot::channel();
 
         tokio::spawn(async move {
             router.handle_best_payload(payload_id, tx).await;
         });
 
-        let flash_cmd = flash_rx.recv().await.expect("flash command");
-        assert!(basic_rx.try_recv().is_err());
-        if let PayloadServiceCommand::BestPayload(inner_payload_id, tx) = flash_cmd {
+        let basic_cmd = basic_rx.recv().await.expect("basic command");
+        assert!(flash_rx.try_recv().is_err());
+        if let PayloadServiceCommand::BestPayload(inner_payload_id, tx) = basic_cmd {
             assert_eq!(inner_payload_id, payload_id);
-            tx.send(None).expect("send flash response");
+            tx.send(None).expect("send basic response");
         } else {
             panic!("expected BestPayload command");
         }
@@ -469,7 +663,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn payload_timestamp_reads_flashblocks_only() {
+    async fn payload_timestamp_defaults_unknown_payload_to_flashblocks() {
         let (router, mut flash_rx, mut basic_rx) = test_router();
         let payload_id = payload_id_from_byte(9);
         let (tx, rx) = tokio::sync::oneshot::channel();
@@ -491,7 +685,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn subscribe_uses_flashblocks_only() {
+    async fn subscribe_forwards_events_from_builder_selected_at_event_timestamp() {
         let (router, mut flash_rx, mut basic_rx) = test_router();
         let (sub_tx, sub_rx) = tokio::sync::oneshot::channel();
 
@@ -499,25 +693,43 @@ mod tests {
             router.handle_subscribe(sub_tx).await;
         });
 
+        let (flash_events_tx, flash_events_rx) = broadcast::channel(2);
+        let (basic_events_tx, basic_events_rx) = broadcast::channel(2);
         let flash_cmd = flash_rx.recv().await.expect("flash subscribe command");
-        assert!(basic_rx.try_recv().is_err());
-        if let PayloadServiceCommand::Subscribe(tx) = flash_cmd {
-            let (events_tx, events_rx) = broadcast::channel(2);
-            tx.send(events_rx).expect("send flash receiver");
-            let mut sub = sub_rx.await.expect("outer subscribe receiver");
-            events_tx
-                .send(Events::Attributes(sample_input().attributes))
-                .expect("send flash event");
-            assert!(sub.recv().await.is_ok());
-        } else {
-            panic!("expected Subscribe command");
-        }
+        let PayloadServiceCommand::Subscribe(flash_tx) = flash_cmd else {
+            panic!("expected flash Subscribe command");
+        };
+        flash_tx.send(flash_events_rx).expect("send flash receiver");
+
+        let basic_cmd = basic_rx.recv().await.expect("basic subscribe command");
+        let PayloadServiceCommand::Subscribe(basic_tx) = basic_cmd else {
+            panic!("expected basic Subscribe command");
+        };
+        basic_tx.send(basic_events_rx).expect("send basic receiver");
+        let mut sub = sub_rx.await.expect("outer subscribe receiver");
+
+        flash_events_tx
+            .send(Events::Attributes(sample_input(ZENITH_TIMESTAMP - 1).attributes))
+            .expect("send pre-Zenith flash event");
+        assert_eq!(
+            MultiplexRouter::event_timestamp(&sub.recv().await.expect("receive flash event")),
+            ZENITH_TIMESTAMP - 1
+        );
+
+        basic_events_tx
+            .send(Events::Attributes(sample_input(ZENITH_TIMESTAMP).attributes))
+            .expect("send post-Zenith basic event");
+        assert_eq!(
+            MultiplexRouter::event_timestamp(&sub.recv().await.expect("receive basic event")),
+            ZENITH_TIMESTAMP
+        );
     }
 
     #[tokio::test]
-    async fn resolve_uses_flashblocks_only() {
+    async fn resolve_uses_recorded_builder() {
         let (router, mut flash_rx, mut basic_rx) = test_router();
         let payload_id = payload_id_from_byte(11);
+        router.payload_routes.lock().await.insert(payload_id, true);
         let (resolve_tx, resolve_rx) = tokio::sync::oneshot::channel();
 
         tokio::spawn(async move {
@@ -529,11 +741,11 @@ mod tests {
 
         let resolve_task = tokio::spawn(future);
 
-        let flash_cmd = flash_rx.recv().await.expect("flash resolve command");
-        assert!(basic_rx.try_recv().is_err());
-        if let PayloadServiceCommand::Resolve(inner_payload_id, _, tx) = flash_cmd {
+        let basic_cmd = basic_rx.recv().await.expect("basic resolve command");
+        assert!(flash_rx.try_recv().is_err());
+        if let PayloadServiceCommand::Resolve(inner_payload_id, _, tx) = basic_cmd {
             assert_eq!(inner_payload_id, payload_id);
-            assert!(tx.send(None).is_ok(), "send flash resolve response");
+            assert!(tx.send(None).is_ok(), "send basic resolve response");
         } else {
             panic!("expected Resolve command");
         }

--- a/crates/builder/multiplex/src/router.rs
+++ b/crates/builder/multiplex/src/router.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::VecDeque,
     sync::{
         Arc,
         atomic::{AtomicBool, AtomicU64, Ordering},
@@ -16,12 +16,13 @@ use reth_payload_builder::{BuildNewPayload, PayloadBuilderHandle, PayloadService
 use reth_payload_builder_primitives::{Events, PayloadBuilderError};
 use reth_payload_primitives::{PayloadAttributes, PayloadKind, PayloadTypes};
 use tokio::sync::{Mutex, broadcast, mpsc};
-use tracing::info;
+use tracing::{error, info, warn};
 
 use crate::RoutingConfig;
 
 const FLASHBLOCKS_BUILDER: &str = "flashblocks";
 const BASIC_BUILDER: &str = "basic";
+const MAX_PAYLOAD_ROUTES: usize = 128;
 
 #[cfg(debug_assertions)]
 static DEBUG_DISPATCH_FLASHBLOCKS: AtomicU64 = AtomicU64::new(0);
@@ -95,8 +96,8 @@ pub struct MultiplexRouter {
     pub basic_health: HealthState,
     /// Chain spec that owns the Zenith activation condition.
     pub chain_spec: Arc<BaseChainSpec>,
-    /// Whether each active payload ID is routed to the basic builder.
-    pub payload_routes: Arc<Mutex<HashMap<PayloadId, bool>>>,
+    /// Whether recent payload IDs are routed to the basic builder, ordered oldest first.
+    pub payload_routes: Arc<Mutex<VecDeque<(PayloadId, bool)>>>,
     /// Deadline used to flag slow selected `getPayload` resolutions.
     pub getpayload_deadline: std::time::Duration,
 }
@@ -117,7 +118,7 @@ impl MultiplexRouter {
             flashblocks_health,
             basic_health,
             chain_spec,
-            payload_routes: Arc::new(Mutex::new(HashMap::new())),
+            payload_routes: Arc::new(Mutex::new(VecDeque::new())),
             getpayload_deadline: config.getpayload_deadline,
         }
     }
@@ -129,7 +130,25 @@ impl MultiplexRouter {
 
     /// Returns the recorded route for a payload, defaulting unknown payloads to flashblocks.
     pub async fn basic_selected_for_payload(&self, payload_id: PayloadId) -> bool {
-        self.payload_routes.lock().await.get(&payload_id).copied().unwrap_or(false)
+        self.payload_routes
+            .lock()
+            .await
+            .iter()
+            .rev()
+            .find_map(|(id, selected_basic)| (*id == payload_id).then_some(*selected_basic))
+            .unwrap_or(false)
+    }
+
+    /// Records a payload route while bounding abandoned payload state.
+    pub async fn record_payload_route(&self, payload_id: PayloadId, selected_basic: bool) {
+        let mut routes = self.payload_routes.lock().await;
+        if let Some(position) = routes.iter().position(|(id, _)| *id == payload_id) {
+            routes.remove(position);
+        }
+        if routes.len() == MAX_PAYLOAD_ROUTES {
+            routes.pop_front();
+        }
+        routes.push_back((payload_id, selected_basic));
     }
 
     /// Returns the timestamp represented by a payload-builder event.
@@ -182,7 +201,7 @@ impl MultiplexRouter {
     ) {
         let payload_id = input.payload_id();
         let selected_basic = self.basic_selected_at(input.attributes.timestamp());
-        self.payload_routes.lock().await.insert(payload_id, selected_basic);
+        self.record_payload_route(payload_id, selected_basic).await;
 
         let mut shadow_attributes = input.attributes.clone();
         shadow_attributes.no_tx_pool = true;
@@ -250,7 +269,10 @@ impl MultiplexRouter {
             Err(Self::unavailable_error(selected_builder))
         });
         if selected_result.is_err() {
-            self.payload_routes.lock().await.remove(&payload_id);
+            let mut routes = self.payload_routes.lock().await;
+            if let Some(position) = routes.iter().position(|(id, _)| *id == payload_id) {
+                routes.remove(position);
+            }
         }
 
         info!(
@@ -329,7 +351,11 @@ impl MultiplexRouter {
             let started = Instant::now();
             let result = handle.resolve_kind(payload_id, kind).await;
             let elapsed = started.elapsed();
-            payload_routes.lock().await.remove(&payload_id);
+            let mut routes = payload_routes.lock().await;
+            if let Some(position) = routes.iter().position(|(id, _)| *id == payload_id) {
+                routes.remove(position);
+            }
+            drop(routes);
 
             Self::record_selected_getpayload_latency(elapsed.as_secs_f64());
             if elapsed > deadline {
@@ -368,17 +394,27 @@ impl MultiplexRouter {
     ) {
         let mut flashblocks_events = match self.flashblocks_handle.subscribe().await {
             Ok(events) => events.receiver,
-            Err(_) => {
+            Err(error) => {
                 self.flashblocks_health.mark_unavailable();
                 Self::set_service_health_metric(FLASHBLOCKS_BUILDER, false);
+                error!(
+                    builder = FLASHBLOCKS_BUILDER,
+                    error = %error,
+                    "failed to subscribe to payload builder events"
+                );
                 return;
             }
         };
         let mut basic_events = match self.basic_handle.subscribe().await {
             Ok(events) => events.receiver,
-            Err(_) => {
+            Err(error) => {
                 self.basic_health.mark_unavailable();
                 Self::set_service_health_metric(BASIC_BUILDER, false);
+                error!(
+                    builder = BASIC_BUILDER,
+                    error = %error,
+                    "failed to subscribe to payload builder events"
+                );
                 return;
             }
         };
@@ -404,7 +440,18 @@ impl MultiplexRouter {
                             router.flashblocks_health.mark_unavailable();
                             Self::set_service_health_metric(FLASHBLOCKS_BUILDER, false);
                         }
-                        Err(broadcast::error::RecvError::Lagged(_)) => {}
+                        Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                            metrics::counter!(
+                                "mux_subscription_lagged_events_total",
+                                "builder" => FLASHBLOCKS_BUILDER
+                            )
+                            .increment(skipped);
+                            warn!(
+                                builder = FLASHBLOCKS_BUILDER,
+                                skipped,
+                                "payload builder event forwarding lagged"
+                            );
+                        }
                     },
                     result = basic_events.recv(), if !basic_closed => match result {
                         Ok(event) => {
@@ -417,7 +464,18 @@ impl MultiplexRouter {
                             router.basic_health.mark_unavailable();
                             Self::set_service_health_metric(BASIC_BUILDER, false);
                         }
-                        Err(broadcast::error::RecvError::Lagged(_)) => {}
+                        Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                            metrics::counter!(
+                                "mux_subscription_lagged_events_total",
+                                "builder" => BASIC_BUILDER
+                            )
+                            .increment(skipped);
+                            warn!(
+                                builder = BASIC_BUILDER,
+                                skipped,
+                                "payload builder event forwarding lagged"
+                            );
+                        }
                     },
                 }
             }
@@ -643,7 +701,7 @@ mod tests {
     async fn best_payload_reads_recorded_builder() {
         let (router, mut flash_rx, mut basic_rx) = test_router();
         let payload_id = payload_id_from_byte(7);
-        router.payload_routes.lock().await.insert(payload_id, true);
+        router.record_payload_route(payload_id, true).await;
         let (tx, rx) = tokio::sync::oneshot::channel();
 
         tokio::spawn(async move {
@@ -729,7 +787,7 @@ mod tests {
     async fn resolve_uses_recorded_builder() {
         let (router, mut flash_rx, mut basic_rx) = test_router();
         let payload_id = payload_id_from_byte(11);
-        router.payload_routes.lock().await.insert(payload_id, true);
+        router.record_payload_route(payload_id, true).await;
         let (resolve_tx, resolve_rx) = tokio::sync::oneshot::channel();
 
         tokio::spawn(async move {
@@ -752,5 +810,19 @@ mod tests {
 
         let resolved = resolve_task.await.expect("resolve task join");
         assert!(matches!(resolved, Err(PayloadBuilderError::MissingPayload)));
+    }
+
+    #[tokio::test]
+    async fn payload_routes_evict_oldest_abandoned_payload() {
+        let (router, _, _) = test_router();
+        for value in 0..=MAX_PAYLOAD_ROUTES {
+            router.record_payload_route(payload_id_from_byte(value as u8), true).await;
+        }
+
+        assert_eq!(router.payload_routes.lock().await.len(), MAX_PAYLOAD_ROUTES);
+        assert!(!router.basic_selected_for_payload(payload_id_from_byte(0)).await);
+        assert!(
+            router.basic_selected_for_payload(payload_id_from_byte(MAX_PAYLOAD_ROUTES as u8)).await
+        );
     }
 }

--- a/crates/builder/multiplex/src/router.rs
+++ b/crates/builder/multiplex/src/router.rs
@@ -66,7 +66,10 @@ pub struct BuilderUnavailableError {
 pub type ResolveFuture = std::pin::Pin<
     Box<
         dyn std::future::Future<
-                Output = Result<<BaseEngineTypes as PayloadTypes>::BuiltPayload, PayloadBuilderError>,
+                Output = Result<
+                    <BaseEngineTypes as PayloadTypes>::BuiltPayload,
+                    PayloadBuilderError,
+                >,
             > + Send,
     >,
 >;
@@ -435,8 +438,7 @@ mod tests {
         if let PayloadServiceCommand::BuildNewPayload(input, _, tx) = basic_cmd {
             basic_seen = true;
             assert_eq!(input.payload_id(), payload_id);
-            tx.send(Err(PayloadBuilderError::MissingPayload))
-                .expect("basic response");
+            tx.send(Err(PayloadBuilderError::MissingPayload)).expect("basic response");
         }
 
         assert!(flash_seen);
@@ -519,15 +521,11 @@ mod tests {
         let (resolve_tx, resolve_rx) = tokio::sync::oneshot::channel();
 
         tokio::spawn(async move {
-            router
-                .handle_resolve(payload_id, PayloadKind::Earliest, resolve_tx)
-                .await;
+            router.handle_resolve(payload_id, PayloadKind::Earliest, resolve_tx).await;
         });
 
-        let future = resolve_rx
-            .await
-            .expect("resolve response")
-            .expect("resolve future should be present");
+        let future =
+            resolve_rx.await.expect("resolve response").expect("resolve future should be present");
 
         let resolve_task = tokio::spawn(future);
 

--- a/crates/builder/multiplex/src/router.rs
+++ b/crates/builder/multiplex/src/router.rs
@@ -74,7 +74,7 @@ pub type ResolveFuture = std::pin::Pin<
     >,
 >;
 
-/// Router that cuts payload selection from flashblocks to basic when Zenith activates.
+/// Router that cuts payload selection from flashblocks to basic when Denim activates.
 #[derive(Debug, Clone)]
 pub struct MultiplexRouter {
     /// Flashblocks payload-builder handle.
@@ -85,7 +85,7 @@ pub struct MultiplexRouter {
     pub flashblocks_health: HealthState,
     /// Basic health state.
     pub basic_health: HealthState,
-    /// Chain spec that owns the Zenith activation condition.
+    /// Chain spec that owns the Denim activation condition.
     pub chain_spec: Arc<BaseChainSpec>,
     /// Whether recent payload IDs are routed to the basic builder, ordered oldest first.
     pub payload_routes: Arc<Mutex<VecDeque<(PayloadId, bool)>>>,
@@ -114,9 +114,9 @@ impl MultiplexRouter {
         }
     }
 
-    /// Returns whether Zenith selects the basic builder at `timestamp`.
+    /// Returns whether Denim selects the basic builder at `timestamp`.
     pub fn basic_selected_at(&self, timestamp: u64) -> bool {
-        self.chain_spec.is_zenith_active_at_timestamp(timestamp)
+        self.chain_spec.is_denim_active_at_timestamp(timestamp)
     }
 
     /// Returns the recorded route for a payload, defaulting unknown payloads to flashblocks.
@@ -552,7 +552,7 @@ mod tests {
 
     use super::*;
 
-    const ZENITH_TIMESTAMP: u64 = 10;
+    const DENIM_TIMESTAMP: u64 = 10;
 
     fn test_router() -> (
         MultiplexRouter,
@@ -568,7 +568,7 @@ mod tests {
             HealthState::new(),
             Arc::new(
                 BaseChainSpecBuilder::base_mainnet()
-                    .with_fork(BaseUpgrade::Zenith, ForkCondition::Timestamp(ZENITH_TIMESTAMP))
+                    .with_fork(BaseUpgrade::Denim, ForkCondition::Timestamp(DENIM_TIMESTAMP))
                     .build(),
             ),
             RoutingConfig::default(),
@@ -595,9 +595,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn build_fans_to_both_and_selects_by_zenith_activation() {
-        for (timestamp, selected_basic) in [(ZENITH_TIMESTAMP - 1, false), (ZENITH_TIMESTAMP, true)]
-        {
+    async fn build_fans_to_both_and_selects_by_denim_activation() {
+        for (timestamp, selected_basic) in [(DENIM_TIMESTAMP - 1, false), (DENIM_TIMESTAMP, true)] {
             let (router, mut flash_rx, mut basic_rx) = test_router();
             let (tx, rx) = tokio::sync::oneshot::channel();
 
@@ -714,19 +713,19 @@ mod tests {
         let mut sub = sub_rx.await.expect("outer subscribe receiver");
 
         flash_events_tx
-            .send(Events::Attributes(sample_input(ZENITH_TIMESTAMP - 1).attributes))
-            .expect("send pre-Zenith flash event");
+            .send(Events::Attributes(sample_input(DENIM_TIMESTAMP - 1).attributes))
+            .expect("send pre-Denim flash event");
         assert_eq!(
             MultiplexRouter::event_timestamp(&sub.recv().await.expect("receive flash event")),
-            ZENITH_TIMESTAMP - 1
+            DENIM_TIMESTAMP - 1
         );
 
         basic_events_tx
-            .send(Events::Attributes(sample_input(ZENITH_TIMESTAMP).attributes))
-            .expect("send post-Zenith basic event");
+            .send(Events::Attributes(sample_input(DENIM_TIMESTAMP).attributes))
+            .expect("send post-Denim basic event");
         assert_eq!(
             MultiplexRouter::event_timestamp(&sub.recv().await.expect("receive basic event")),
-            ZENITH_TIMESTAMP
+            DENIM_TIMESTAMP
         );
 
         drop(sub);

--- a/crates/builder/multiplex/src/router.rs
+++ b/crates/builder/multiplex/src/router.rs
@@ -345,23 +345,19 @@ impl MultiplexRouter {
             Self::record_selected_getpayload_latency(elapsed.as_secs_f64());
 
             let result = match result {
-                Some(Ok(payload)) => Ok(payload),
+                Some(Ok(payload)) => Some(Ok(payload)),
                 Some(Err(PayloadBuilderError::ChannelClosed)) => {
                     health.mark_unavailable();
                     Self::set_service_health_metric(builder, false);
-                    Err(Self::unavailable_error(builder))
+                    Some(Err(Self::unavailable_error(builder)))
                 }
-                Some(Err(err)) => Err(err),
-                None => {
-                    if !health.is_healthy() {
-                        Err(Self::unavailable_error(builder))
-                    } else {
-                        Err(PayloadBuilderError::MissingPayload)
-                    }
-                }
+                Some(Err(err)) => Some(Err(err)),
+                None if !health.is_healthy() => Some(Err(Self::unavailable_error(builder))),
+                None => None,
             };
 
-            let _ = tx.send(Some(Box::pin(async move { result })));
+            let response = result.map(|result| Box::pin(async move { result }) as ResolveFuture);
+            let _ = tx.send(response);
         }
         .boxed()
     }
@@ -763,7 +759,7 @@ mod tests {
             build_rx.await.expect("selected build response").expect("successful build"),
             payload_id
         );
-        assert!(matches!(resolve.await, Some(Err(PayloadBuilderError::MissingPayload))));
+        assert!(resolve.await.is_none());
 
         drop(handle);
         router_task.await.expect("router task");
@@ -825,12 +821,7 @@ mod tests {
                 }
             };
             tokio::join!(response, inner);
-            let future = resolve_rx
-                .await
-                .expect("resolve response")
-                .expect("resolve future should be present");
-            let resolved = future.await;
-            assert!(matches!(resolved, Err(PayloadBuilderError::MissingPayload)));
+            assert!(resolve_rx.await.expect("resolve response").is_none());
         }
 
         assert!(router.basic_selected_for_payload(payload_id));

--- a/crates/builder/multiplex/src/router.rs
+++ b/crates/builder/multiplex/src/router.rs
@@ -12,10 +12,11 @@ use alloy_rpc_types_engine::PayloadId;
 use base_common_chains::Upgrades;
 use base_execution_chainspec::BaseChainSpec;
 use base_node_core::BaseEngineTypes;
+use futures::{FutureExt, StreamExt, future::BoxFuture, stream::FuturesUnordered};
 use reth_payload_builder::{BuildNewPayload, PayloadBuilderHandle, PayloadServiceCommand};
 use reth_payload_builder_primitives::{Events, PayloadBuilderError};
 use reth_payload_primitives::{PayloadAttributes, PayloadKind, PayloadTypes};
-use tokio::sync::{Mutex, broadcast, mpsc};
+use tokio::sync::{broadcast, mpsc};
 use tracing::{error, info, warn};
 
 const FLASHBLOCKS_BUILDER: &str = "flashblocks";
@@ -73,7 +74,7 @@ pub type ResolveFuture = std::pin::Pin<
 >;
 
 /// Router that cuts payload selection from flashblocks to basic when Denim activates.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct MultiplexRouter {
     /// Flashblocks payload-builder handle.
     pub flashblocks_handle: PayloadBuilderHandle<BaseEngineTypes>,
@@ -86,12 +87,12 @@ pub struct MultiplexRouter {
     /// Chain spec that owns the Denim activation condition.
     pub chain_spec: Arc<BaseChainSpec>,
     /// Whether recent payload IDs are routed to the basic builder, ordered oldest first.
-    pub payload_routes: Arc<Mutex<VecDeque<(PayloadId, bool)>>>,
+    pub payload_routes: VecDeque<(PayloadId, bool)>,
 }
 
 impl MultiplexRouter {
     /// Creates a new router.
-    pub fn new(
+    pub const fn new(
         flashblocks_handle: PayloadBuilderHandle<BaseEngineTypes>,
         basic_handle: PayloadBuilderHandle<BaseEngineTypes>,
         flashblocks_health: HealthState,
@@ -104,7 +105,7 @@ impl MultiplexRouter {
             flashblocks_health,
             basic_health,
             chain_spec,
-            payload_routes: Arc::new(Mutex::new(VecDeque::new())),
+            payload_routes: VecDeque::new(),
         }
     }
 
@@ -114,26 +115,23 @@ impl MultiplexRouter {
     }
 
     /// Returns the recorded route for a payload, defaulting unknown payloads to flashblocks.
-    pub async fn basic_selected_for_payload(&self, payload_id: PayloadId) -> bool {
+    pub fn basic_selected_for_payload(&self, payload_id: PayloadId) -> bool {
         self.payload_routes
-            .lock()
-            .await
             .iter()
-            .rev()
             .find_map(|(id, selected_basic)| (*id == payload_id).then_some(*selected_basic))
             .unwrap_or(false)
     }
 
     /// Records a payload route while bounding abandoned payload state.
-    pub async fn record_payload_route(&self, payload_id: PayloadId, selected_basic: bool) {
-        let mut routes = self.payload_routes.lock().await;
-        if let Some(position) = routes.iter().position(|(id, _)| *id == payload_id) {
-            routes.remove(position);
+    pub fn record_payload_route(&mut self, payload_id: PayloadId, selected_basic: bool) {
+        if let Some((_, route)) = self.payload_routes.iter_mut().find(|(id, _)| *id == payload_id) {
+            *route = selected_basic;
+            return;
         }
-        if routes.len() == MAX_PAYLOAD_ROUTES {
-            routes.pop_front();
+        if self.payload_routes.len() == MAX_PAYLOAD_ROUTES {
+            self.payload_routes.pop_front();
         }
-        routes.push_back((payload_id, selected_basic));
+        self.payload_routes.push_back((payload_id, selected_basic));
     }
 
     /// Returns the timestamp represented by a payload-builder event.
@@ -146,47 +144,59 @@ impl MultiplexRouter {
 
     /// Runs the router command loop.
     pub async fn run(
-        self,
+        mut self,
         mut rx: mpsc::UnboundedReceiver<PayloadServiceCommand<BaseEngineTypes>>,
     ) {
-        while let Some(command) = rx.recv().await {
-            let router = self.clone();
-            tokio::spawn(async move {
-                router.handle_command(command).await;
-            });
+        let mut responses: FuturesUnordered<BoxFuture<'static, ()>> = FuturesUnordered::new();
+        loop {
+            // Poll newly queued response work before accepting another command so each inner
+            // service observes commands in the same order as this router.
+            tokio::select! {
+                biased;
+                Some(()) = responses.next(), if !responses.is_empty() => {}
+                command = rx.recv() => match command {
+                    Some(command) => {
+                        if let Some(response) = self.handle_command(command) {
+                            responses.push(response);
+                        }
+                    }
+                    None => break,
+                }
+            }
         }
     }
 
     /// Handles a single command.
-    pub async fn handle_command(&self, command: PayloadServiceCommand<BaseEngineTypes>) {
+    pub fn handle_command(
+        &mut self,
+        command: PayloadServiceCommand<BaseEngineTypes>,
+    ) -> Option<BoxFuture<'static, ()>> {
         match command {
             PayloadServiceCommand::BuildNewPayload(input, _span, tx) => {
-                self.handle_build_new_payload(*input, tx).await;
+                Some(self.handle_build_new_payload(*input, tx))
             }
             PayloadServiceCommand::BestPayload(payload_id, tx) => {
-                self.handle_best_payload(payload_id, tx).await;
+                Some(self.handle_best_payload(payload_id, tx))
             }
             PayloadServiceCommand::PayloadTimestamp(payload_id, tx) => {
-                self.handle_payload_timestamp(payload_id, tx).await;
+                Some(self.handle_payload_timestamp(payload_id, tx))
             }
             PayloadServiceCommand::Resolve(payload_id, kind, tx) => {
-                self.handle_resolve(payload_id, kind, tx).await;
+                Some(self.handle_resolve(payload_id, kind, tx))
             }
-            PayloadServiceCommand::Subscribe(tx) => {
-                self.handle_subscribe(tx).await;
-            }
+            PayloadServiceCommand::Subscribe(tx) => Some(self.handle_subscribe(tx)),
         }
     }
 
     /// Handles build fan-out.
-    pub async fn handle_build_new_payload(
-        &self,
+    pub fn handle_build_new_payload(
+        &mut self,
         input: BuildNewPayload<<BaseEngineTypes as PayloadTypes>::PayloadAttributes>,
         tx: tokio::sync::oneshot::Sender<Result<PayloadId, PayloadBuilderError>>,
-    ) {
+    ) -> BoxFuture<'static, ()> {
         let payload_id = input.payload_id();
         let selected_basic = self.basic_selected_at(input.attributes.timestamp());
-        self.record_payload_route(payload_id, selected_basic).await;
+        self.record_payload_route(payload_id, selected_basic);
 
         let mut shadow_attributes = input.attributes.clone();
         shadow_attributes.no_tx_pool = true;
@@ -232,118 +242,109 @@ impl MultiplexRouter {
         };
 
         Self::inc_selected_build_metric(selected_builder);
-        tokio::spawn(async move {
-            let shadow_result = shadow_rx.await.unwrap_or_else(|_| {
-                shadow_health.mark_unavailable();
-                Self::set_service_health_metric(shadow_builder, false);
-                Err(Self::unavailable_error(shadow_builder))
-            });
-            Self::inc_shadow_metric(shadow_builder, shadow_result.is_ok());
-            info!(
-                builder = shadow_builder,
-                payload_id = ?payload_id,
-                selected = false,
-                result = if shadow_result.is_ok() { "ok" } else { "err" },
-                "multiplex shadow build request completed"
-            );
-        });
-
-        let selected_result = selected_rx.await.unwrap_or_else(|_| {
-            selected_health.mark_unavailable();
-            Self::set_service_health_metric(selected_builder, false);
-            Err(Self::unavailable_error(selected_builder))
-        });
-        if selected_result.is_err() {
-            let mut routes = self.payload_routes.lock().await;
-            if let Some(position) = routes.iter().position(|(id, _)| *id == payload_id) {
-                routes.remove(position);
-            }
+        async move {
+            let selected_response = async move {
+                let selected_result = selected_rx.await.unwrap_or_else(|_| {
+                    selected_health.mark_unavailable();
+                    Self::set_service_health_metric(selected_builder, false);
+                    Err(Self::unavailable_error(selected_builder))
+                });
+                info!(
+                    builder = selected_builder,
+                    payload_id = ?payload_id,
+                    selected = true,
+                    result = if selected_result.is_ok() { "ok" } else { "err" },
+                    "multiplex build request completed"
+                );
+                let _ = tx.send(selected_result);
+            };
+            let shadow_response = async move {
+                let shadow_result = shadow_rx.await.unwrap_or_else(|_| {
+                    shadow_health.mark_unavailable();
+                    Self::set_service_health_metric(shadow_builder, false);
+                    Err(Self::unavailable_error(shadow_builder))
+                });
+                Self::inc_shadow_metric(shadow_builder, shadow_result.is_ok());
+                info!(
+                    builder = shadow_builder,
+                    payload_id = ?payload_id,
+                    selected = false,
+                    result = if shadow_result.is_ok() { "ok" } else { "err" },
+                    "multiplex shadow build request completed"
+                );
+            };
+            futures::join!(selected_response, shadow_response);
         }
-
-        info!(
-            builder = selected_builder,
-            payload_id = ?payload_id,
-            selected = true,
-            result = if selected_result.is_ok() { "ok" } else { "err" },
-            "multiplex build request completed"
-        );
-
-        let _ = tx.send(selected_result);
+        .boxed()
     }
 
     /// Handles best payload lookup.
-    pub async fn handle_best_payload(
+    pub fn handle_best_payload(
         &self,
         payload_id: PayloadId,
         tx: tokio::sync::oneshot::Sender<
             Option<Result<<BaseEngineTypes as PayloadTypes>::BuiltPayload, PayloadBuilderError>>,
         >,
-    ) {
-        let selected_basic = self.basic_selected_for_payload(payload_id).await;
-        let (result, builder, health) = if selected_basic {
-            (self.basic_handle.best_payload(payload_id).await, BASIC_BUILDER, &self.basic_health)
+    ) -> BoxFuture<'static, ()> {
+        let selected_basic = self.basic_selected_for_payload(payload_id);
+        let (handle, builder, health) = if selected_basic {
+            (self.basic_handle.clone(), BASIC_BUILDER, self.basic_health.clone())
         } else {
-            (
-                self.flashblocks_handle.best_payload(payload_id).await,
-                FLASHBLOCKS_BUILDER,
-                &self.flashblocks_health,
-            )
+            (self.flashblocks_handle.clone(), FLASHBLOCKS_BUILDER, self.flashblocks_health.clone())
         };
-        let mapped = self.map_read_result(result, builder, health);
-        let _ = tx.send(mapped);
+        async move {
+            let result = handle.best_payload(payload_id).await;
+            let mapped = Self::map_read_result(result, builder, &health);
+            let _ = tx.send(mapped);
+        }
+        .boxed()
     }
 
     /// Handles payload timestamp lookup.
-    pub async fn handle_payload_timestamp(
+    pub fn handle_payload_timestamp(
         &self,
         payload_id: PayloadId,
         tx: tokio::sync::oneshot::Sender<Option<Result<u64, PayloadBuilderError>>>,
-    ) {
-        let selected_basic = self.basic_selected_for_payload(payload_id).await;
-        let (result, builder, health) = if selected_basic {
-            (
-                self.basic_handle.payload_timestamp(payload_id).await,
-                BASIC_BUILDER,
-                &self.basic_health,
-            )
+    ) -> BoxFuture<'static, ()> {
+        let selected_basic = self.basic_selected_for_payload(payload_id);
+        let (handle, builder, health) = if selected_basic {
+            (self.basic_handle.clone(), BASIC_BUILDER, self.basic_health.clone())
         } else {
-            (
-                self.flashblocks_handle.payload_timestamp(payload_id).await,
-                FLASHBLOCKS_BUILDER,
-                &self.flashblocks_health,
-            )
+            (self.flashblocks_handle.clone(), FLASHBLOCKS_BUILDER, self.flashblocks_health.clone())
         };
-        let mapped = self.map_read_result(result, builder, health);
-        let _ = tx.send(mapped);
+        async move {
+            let result = handle.payload_timestamp(payload_id).await;
+            let mapped = Self::map_read_result(result, builder, &health);
+            let _ = tx.send(mapped);
+        }
+        .boxed()
     }
 
     /// Handles payload resolve.
-    pub async fn handle_resolve(
+    pub fn handle_resolve(
         &self,
         payload_id: PayloadId,
         kind: PayloadKind,
-        tx: tokio::sync::oneshot::Sender<Option<ResolveFuture>>,
-    ) {
-        let selected_basic = self.basic_selected_for_payload(payload_id).await;
+        mut tx: tokio::sync::oneshot::Sender<Option<ResolveFuture>>,
+    ) -> BoxFuture<'static, ()> {
+        let selected_basic = self.basic_selected_for_payload(payload_id);
         let (handle, health, builder) = if selected_basic {
             (self.basic_handle.clone(), self.basic_health.clone(), BASIC_BUILDER)
         } else {
             (self.flashblocks_handle.clone(), self.flashblocks_health.clone(), FLASHBLOCKS_BUILDER)
         };
-        let payload_routes = Arc::clone(&self.payload_routes);
-        let future = async move {
+        async move {
             let started = Instant::now();
-            let result = handle.resolve_kind(payload_id, kind).await;
+            let resolve = handle.resolve_kind(payload_id, kind);
+            tokio::pin!(resolve);
+            let result = tokio::select! {
+                result = &mut resolve => result,
+                _ = tx.closed() => return,
+            };
             let elapsed = started.elapsed();
-            let mut routes = payload_routes.lock().await;
-            if let Some(position) = routes.iter().position(|(id, _)| *id == payload_id) {
-                routes.remove(position);
-            }
-            drop(routes);
-
             Self::record_selected_getpayload_latency(elapsed.as_secs_f64());
 
-            match result {
+            let result = match result {
                 Some(Ok(payload)) => Ok(payload),
                 Some(Err(PayloadBuilderError::ChannelClosed)) => {
                     health.mark_unavailable();
@@ -358,54 +359,59 @@ impl MultiplexRouter {
                         Err(PayloadBuilderError::MissingPayload)
                     }
                 }
-            }
-        };
+            };
 
-        let _ = tx.send(Some(Box::pin(future)));
+            let _ = tx.send(Some(Box::pin(async move { result })));
+        }
+        .boxed()
     }
 
     /// Handles subscriptions.
-    pub async fn handle_subscribe(
+    pub fn handle_subscribe(
         &self,
         tx: tokio::sync::oneshot::Sender<
             tokio::sync::broadcast::Receiver<
                 reth_payload_builder_primitives::Events<BaseEngineTypes>,
             >,
         >,
-    ) {
-        let mut flashblocks_events = match self.flashblocks_handle.subscribe().await {
-            Ok(events) => events.receiver,
-            Err(error) => {
-                self.flashblocks_health.mark_unavailable();
-                Self::set_service_health_metric(FLASHBLOCKS_BUILDER, false);
-                error!(
-                    builder = FLASHBLOCKS_BUILDER,
-                    error = %error,
-                    "failed to subscribe to payload builder events"
-                );
+    ) -> BoxFuture<'static, ()> {
+        let flashblocks_handle = self.flashblocks_handle.clone();
+        let basic_handle = self.basic_handle.clone();
+        let flashblocks_health = self.flashblocks_health.clone();
+        let basic_health = self.basic_health.clone();
+        let chain_spec = Arc::clone(&self.chain_spec);
+        async move {
+            let mut flashblocks_events = match flashblocks_handle.subscribe().await {
+                Ok(events) => events.receiver,
+                Err(error) => {
+                    flashblocks_health.mark_unavailable();
+                    Self::set_service_health_metric(FLASHBLOCKS_BUILDER, false);
+                    error!(
+                        builder = FLASHBLOCKS_BUILDER,
+                        error = %error,
+                        "failed to subscribe to payload builder events"
+                    );
+                    return;
+                }
+            };
+            let mut basic_events = match basic_handle.subscribe().await {
+                Ok(events) => events.receiver,
+                Err(error) => {
+                    basic_health.mark_unavailable();
+                    Self::set_service_health_metric(BASIC_BUILDER, false);
+                    error!(
+                        builder = BASIC_BUILDER,
+                        error = %error,
+                        "failed to subscribe to payload builder events"
+                    );
+                    return;
+                }
+            };
+            let (events_tx, events_rx) = broadcast::channel(64);
+            if tx.send(events_rx).is_err() {
                 return;
             }
-        };
-        let mut basic_events = match self.basic_handle.subscribe().await {
-            Ok(events) => events.receiver,
-            Err(error) => {
-                self.basic_health.mark_unavailable();
-                Self::set_service_health_metric(BASIC_BUILDER, false);
-                error!(
-                    builder = BASIC_BUILDER,
-                    error = %error,
-                    "failed to subscribe to payload builder events"
-                );
-                return;
-            }
-        };
-        let (events_tx, events_rx) = broadcast::channel(64);
-        if tx.send(events_rx).is_err() {
-            return;
-        }
 
-        let router = self.clone();
-        tokio::spawn(async move {
             let mut flashblocks_closed = false;
             let mut basic_closed = false;
             while !flashblocks_closed || !basic_closed {
@@ -413,13 +419,13 @@ impl MultiplexRouter {
                     _ = events_tx.closed() => break,
                     result = flashblocks_events.recv(), if !flashblocks_closed => match result {
                         Ok(event) => {
-                            if !router.basic_selected_at(Self::event_timestamp(&event)) {
+                            if !chain_spec.is_denim_active_at_timestamp(Self::event_timestamp(&event)) {
                                 let _ = events_tx.send(event);
                             }
                         }
                         Err(broadcast::error::RecvError::Closed) => {
                             flashblocks_closed = true;
-                            router.flashblocks_health.mark_unavailable();
+                            flashblocks_health.mark_unavailable();
                             Self::set_service_health_metric(FLASHBLOCKS_BUILDER, false);
                         }
                         Err(broadcast::error::RecvError::Lagged(skipped)) => {
@@ -437,13 +443,13 @@ impl MultiplexRouter {
                     },
                     result = basic_events.recv(), if !basic_closed => match result {
                         Ok(event) => {
-                            if router.basic_selected_at(Self::event_timestamp(&event)) {
+                            if chain_spec.is_denim_active_at_timestamp(Self::event_timestamp(&event)) {
                                 let _ = events_tx.send(event);
                             }
                         }
                         Err(broadcast::error::RecvError::Closed) => {
                             basic_closed = true;
-                            router.basic_health.mark_unavailable();
+                            basic_health.mark_unavailable();
                             Self::set_service_health_metric(BASIC_BUILDER, false);
                         }
                         Err(broadcast::error::RecvError::Lagged(skipped)) => {
@@ -461,12 +467,12 @@ impl MultiplexRouter {
                     },
                 }
             }
-        });
+        }
+        .boxed()
     }
 
     /// Maps selected-builder read results with unavailable conversion.
     pub fn map_read_result<T>(
-        &self,
         result: Option<Result<T, PayloadBuilderError>>,
         builder: &'static str,
         health: &HealthState,
@@ -581,14 +587,12 @@ mod tests {
     #[tokio::test]
     async fn build_fans_to_both_and_selects_by_denim_activation() {
         for (timestamp, selected_basic) in [(DENIM_TIMESTAMP - 1, false), (DENIM_TIMESTAMP, true)] {
-            let (router, mut flash_rx, mut basic_rx) = test_router();
+            let (mut router, mut flash_rx, mut basic_rx) = test_router();
             let (tx, rx) = tokio::sync::oneshot::channel();
 
             let input = sample_input(timestamp);
             let payload_id = input.payload_id();
-            tokio::spawn(async move {
-                router.handle_build_new_payload(input, tx).await;
-            });
+            let response = router.handle_build_new_payload(input, tx);
 
             let flash_cmd = flash_rx.recv().await.expect("flash cmd");
             let basic_cmd = basic_rx.recv().await.expect("basic cmd");
@@ -623,29 +627,30 @@ mod tests {
 
             assert!(flash_seen);
             assert!(basic_seen);
+            response.await;
             assert!(rx.await.expect("selected response").is_ok());
         }
     }
 
     #[tokio::test]
     async fn best_payload_reads_recorded_builder() {
-        let (router, mut flash_rx, mut basic_rx) = test_router();
+        let (mut router, mut flash_rx, mut basic_rx) = test_router();
         let payload_id = payload_id_from_byte(7);
-        router.record_payload_route(payload_id, true).await;
+        router.record_payload_route(payload_id, true);
         let (tx, rx) = tokio::sync::oneshot::channel();
 
-        tokio::spawn(async move {
-            router.handle_best_payload(payload_id, tx).await;
-        });
-
-        let basic_cmd = basic_rx.recv().await.expect("basic command");
-        assert!(flash_rx.try_recv().is_err());
-        if let PayloadServiceCommand::BestPayload(inner_payload_id, tx) = basic_cmd {
-            assert_eq!(inner_payload_id, payload_id);
-            tx.send(None).expect("send basic response");
-        } else {
-            panic!("expected BestPayload command");
-        }
+        let response = router.handle_best_payload(payload_id, tx);
+        let inner = async {
+            let basic_cmd = basic_rx.recv().await.expect("basic command");
+            assert!(flash_rx.try_recv().is_err());
+            if let PayloadServiceCommand::BestPayload(inner_payload_id, tx) = basic_cmd {
+                assert_eq!(inner_payload_id, payload_id);
+                tx.send(None).expect("send basic response");
+            } else {
+                panic!("expected BestPayload command");
+            }
+        };
+        tokio::join!(response, inner);
 
         assert!(rx.await.expect("best response").is_none());
     }
@@ -720,45 +725,128 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_uses_recorded_builder() {
+    async fn run_preserves_build_then_resolve_fifo_order() {
         let (router, mut flash_rx, mut basic_rx) = test_router();
-        let payload_id = payload_id_from_byte(11);
-        router.record_payload_route(payload_id, true).await;
-        let (resolve_tx, resolve_rx) = tokio::sync::oneshot::channel();
+        let (router_tx, router_rx) = mpsc::unbounded_channel();
+        let handle = PayloadBuilderHandle::new(router_tx);
+        let router_task = tokio::spawn(router.run(router_rx));
+        let input = sample_input(DENIM_TIMESTAMP);
+        let payload_id = input.payload_id();
 
-        tokio::spawn(async move {
-            router.handle_resolve(payload_id, PayloadKind::Earliest, resolve_tx).await;
-        });
+        let build_rx = handle.send_new_payload(input);
+        let resolve = handle.resolve_kind(payload_id, PayloadKind::Earliest);
 
-        let future =
-            resolve_rx.await.expect("resolve response").expect("resolve future should be present");
-
-        let resolve_task = tokio::spawn(future);
-
-        let basic_cmd = basic_rx.recv().await.expect("basic resolve command");
+        let flash_cmd = flash_rx.recv().await.expect("flash build command");
+        let PayloadServiceCommand::BuildNewPayload(_, _, flash_build_tx) = flash_cmd else {
+            panic!("expected flash BuildNewPayload command");
+        };
+        let basic_cmd = basic_rx.recv().await.expect("basic build command");
+        let PayloadServiceCommand::BuildNewPayload(_, _, basic_build_tx) = basic_cmd else {
+            panic!("expected basic BuildNewPayload command");
+        };
+        let basic_resolve = tokio::time::timeout(Duration::from_secs(1), basic_rx.recv())
+            .await
+            .expect("resolve should not wait for build responses")
+            .expect("basic resolve command");
+        let PayloadServiceCommand::Resolve(inner_payload_id, _, basic_resolve_tx) = basic_resolve
+        else {
+            panic!("expected basic Resolve command after BuildNewPayload");
+        };
+        assert_eq!(inner_payload_id, payload_id);
         assert!(flash_rx.try_recv().is_err());
-        if let PayloadServiceCommand::Resolve(inner_payload_id, _, tx) = basic_cmd {
-            assert_eq!(inner_payload_id, payload_id);
-            assert!(tx.send(None).is_ok(), "send basic resolve response");
-        } else {
-            panic!("expected Resolve command");
-        }
 
-        let resolved = resolve_task.await.expect("resolve task join");
-        assert!(matches!(resolved, Err(PayloadBuilderError::MissingPayload)));
+        basic_build_tx.send(Ok(payload_id)).expect("basic build response");
+        flash_build_tx.send(Ok(payload_id)).expect("flash build response");
+        assert!(basic_resolve_tx.send(None).is_ok(), "basic resolve response");
+
+        assert_eq!(
+            build_rx.await.expect("selected build response").expect("successful build"),
+            payload_id
+        );
+        assert!(matches!(resolve.await, Some(Err(PayloadBuilderError::MissingPayload))));
+
+        drop(handle);
+        router_task.await.expect("router task");
     }
 
     #[tokio::test]
-    async fn payload_routes_evict_oldest_abandoned_payload() {
-        let (router, _, _) = test_router();
-        for value in 0..=MAX_PAYLOAD_ROUTES {
-            router.record_payload_route(payload_id_from_byte(value as u8), true).await;
+    async fn stalled_shadow_does_not_block_selected_builder() {
+        for (timestamp, selected_basic) in [(DENIM_TIMESTAMP - 1, false), (DENIM_TIMESTAMP, true)] {
+            let (router, mut flash_rx, mut basic_rx) = test_router();
+            let (router_tx, router_rx) = mpsc::unbounded_channel();
+            let handle = PayloadBuilderHandle::new(router_tx);
+            let router_task = tokio::spawn(router.run(router_rx));
+            let input = sample_input(timestamp);
+            let payload_id = input.payload_id();
+            let build_rx = handle.send_new_payload(input);
+
+            let flash_cmd = flash_rx.recv().await.expect("flash build command");
+            let PayloadServiceCommand::BuildNewPayload(_, _, flash_tx) = flash_cmd else {
+                panic!("expected flash BuildNewPayload command");
+            };
+            let basic_cmd = basic_rx.recv().await.expect("basic build command");
+            let PayloadServiceCommand::BuildNewPayload(_, _, basic_tx) = basic_cmd else {
+                panic!("expected basic BuildNewPayload command");
+            };
+            let (selected_tx, stalled_tx) =
+                if selected_basic { (basic_tx, flash_tx) } else { (flash_tx, basic_tx) };
+            selected_tx.send(Ok(payload_id)).expect("selected build response");
+
+            let result = tokio::time::timeout(Duration::from_secs(1), build_rx)
+                .await
+                .expect("selected response should not wait for shadow")
+                .expect("selected response channel")
+                .expect("successful selected response");
+            assert_eq!(result, payload_id);
+
+            drop(stalled_tx);
+            drop(handle);
+            router_task.await.expect("router task");
+        }
+    }
+
+    #[tokio::test]
+    async fn repeated_resolve_uses_recorded_builder() {
+        let (mut router, mut flash_rx, mut basic_rx) = test_router();
+        let payload_id = payload_id_from_byte(11);
+        router.record_payload_route(payload_id, true);
+
+        for _ in 0..2 {
+            let (resolve_tx, resolve_rx) = tokio::sync::oneshot::channel();
+            let response = router.handle_resolve(payload_id, PayloadKind::Earliest, resolve_tx);
+            let inner = async {
+                let basic_cmd = basic_rx.recv().await.expect("basic resolve command");
+                assert!(flash_rx.try_recv().is_err());
+                if let PayloadServiceCommand::Resolve(inner_payload_id, _, tx) = basic_cmd {
+                    assert_eq!(inner_payload_id, payload_id);
+                    assert!(tx.send(None).is_ok(), "send basic resolve response");
+                } else {
+                    panic!("expected Resolve command");
+                }
+            };
+            tokio::join!(response, inner);
+            let future = resolve_rx
+                .await
+                .expect("resolve response")
+                .expect("resolve future should be present");
+            let resolved = future.await;
+            assert!(matches!(resolved, Err(PayloadBuilderError::MissingPayload)));
         }
 
-        assert_eq!(router.payload_routes.lock().await.len(), MAX_PAYLOAD_ROUTES);
-        assert!(!router.basic_selected_for_payload(payload_id_from_byte(0)).await);
-        assert!(
-            router.basic_selected_for_payload(payload_id_from_byte(MAX_PAYLOAD_ROUTES as u8)).await
-        );
+        assert!(router.basic_selected_for_payload(payload_id));
+    }
+
+    #[tokio::test]
+    async fn payload_routes_preserve_fifo_when_rerecorded() {
+        let (mut router, _, _) = test_router();
+        for value in 0..MAX_PAYLOAD_ROUTES {
+            router.record_payload_route(payload_id_from_byte(value as u8), true);
+        }
+        router.record_payload_route(payload_id_from_byte(0), true);
+        router.record_payload_route(payload_id_from_byte(MAX_PAYLOAD_ROUTES as u8), true);
+
+        assert_eq!(router.payload_routes.len(), MAX_PAYLOAD_ROUTES);
+        assert!(!router.basic_selected_for_payload(payload_id_from_byte(0)));
+        assert!(router.basic_selected_for_payload(payload_id_from_byte(MAX_PAYLOAD_ROUTES as u8)));
     }
 }

--- a/crates/builder/multiplex/src/router.rs
+++ b/crates/builder/multiplex/src/router.rs
@@ -1,0 +1,546 @@
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+    time::Instant,
+};
+
+use alloy_rpc_types_engine::PayloadId;
+use base_node_core::BaseEngineTypes;
+use reth_payload_builder::{BuildNewPayload, PayloadBuilderHandle, PayloadServiceCommand};
+use reth_payload_builder_primitives::PayloadBuilderError;
+use reth_payload_primitives::{PayloadKind, PayloadTypes};
+use tokio::sync::mpsc;
+use tracing::info;
+
+use crate::RoutingConfig;
+
+const FLASHBLOCKS_BUILDER: &str = "flashblocks";
+const BASIC_BUILDER: &str = "basic";
+
+#[cfg(debug_assertions)]
+static DEBUG_DISPATCH_FLASHBLOCKS: AtomicU64 = AtomicU64::new(0);
+#[cfg(debug_assertions)]
+static DEBUG_DISPATCH_BASIC: AtomicU64 = AtomicU64::new(0);
+
+/// Shared health state for one inner service.
+#[derive(Debug, Clone)]
+pub struct HealthState {
+    /// True when the service is healthy.
+    pub healthy: Arc<AtomicBool>,
+}
+
+impl Default for HealthState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HealthState {
+    /// Creates a healthy state.
+    pub fn new() -> Self {
+        Self { healthy: Arc::new(AtomicBool::new(true)) }
+    }
+
+    /// Marks the service as unavailable.
+    pub fn mark_unavailable(&self) {
+        self.healthy.store(false, Ordering::Relaxed);
+    }
+
+    /// Returns whether the service is healthy.
+    pub fn is_healthy(&self) -> bool {
+        self.healthy.load(Ordering::Relaxed)
+    }
+}
+
+/// Error used to report selected builder unavailability.
+#[derive(Debug, thiserror::Error)]
+#[error("payload builder unavailable: {builder}")]
+pub struct BuilderUnavailableError {
+    /// Builder label.
+    pub builder: &'static str,
+}
+
+/// Boxed future resolving to a built payload, as returned by `resolve_kind`.
+pub type ResolveFuture = std::pin::Pin<
+    Box<
+        dyn std::future::Future<
+                Output = Result<<BaseEngineTypes as PayloadTypes>::BuiltPayload, PayloadBuilderError>,
+            > + Send,
+    >,
+>;
+
+/// Router that multiplexes one outer payload-builder handle over flashblocks + basic shadow.
+#[derive(Debug, Clone)]
+pub struct MultiplexRouter {
+    /// Flashblocks handle used for all reads and selected build results.
+    pub flashblocks_handle: PayloadBuilderHandle<BaseEngineTypes>,
+    /// Basic handle used only for shadow build fan-out.
+    pub basic_handle: PayloadBuilderHandle<BaseEngineTypes>,
+    /// Flashblocks health state.
+    pub flashblocks_health: HealthState,
+    /// Basic health state.
+    pub basic_health: HealthState,
+    /// Deadline used to flag slow selected `getPayload` resolutions.
+    pub getpayload_deadline: std::time::Duration,
+}
+
+impl MultiplexRouter {
+    /// Creates a new router.
+    pub const fn new(
+        flashblocks_handle: PayloadBuilderHandle<BaseEngineTypes>,
+        basic_handle: PayloadBuilderHandle<BaseEngineTypes>,
+        flashblocks_health: HealthState,
+        basic_health: HealthState,
+        config: RoutingConfig,
+    ) -> Self {
+        Self {
+            flashblocks_handle,
+            basic_handle,
+            flashblocks_health,
+            basic_health,
+            getpayload_deadline: config.getpayload_deadline,
+        }
+    }
+
+    /// Runs the router command loop.
+    pub async fn run(
+        self,
+        mut rx: mpsc::UnboundedReceiver<PayloadServiceCommand<BaseEngineTypes>>,
+    ) {
+        while let Some(command) = rx.recv().await {
+            let router = self.clone();
+            tokio::spawn(async move {
+                router.handle_command(command).await;
+            });
+        }
+    }
+
+    /// Handles a single command.
+    pub async fn handle_command(&self, command: PayloadServiceCommand<BaseEngineTypes>) {
+        match command {
+            PayloadServiceCommand::BuildNewPayload(input, _span, tx) => {
+                self.handle_build_new_payload(*input, tx).await;
+            }
+            PayloadServiceCommand::BestPayload(payload_id, tx) => {
+                self.handle_best_payload(payload_id, tx).await;
+            }
+            PayloadServiceCommand::PayloadTimestamp(payload_id, tx) => {
+                self.handle_payload_timestamp(payload_id, tx).await;
+            }
+            PayloadServiceCommand::Resolve(payload_id, kind, tx) => {
+                self.handle_resolve(payload_id, kind, tx).await;
+            }
+            PayloadServiceCommand::Subscribe(tx) => {
+                self.handle_subscribe(tx).await;
+            }
+        }
+    }
+
+    /// Handles build fan-out.
+    pub async fn handle_build_new_payload(
+        &self,
+        input: BuildNewPayload<<BaseEngineTypes as PayloadTypes>::PayloadAttributes>,
+        tx: tokio::sync::oneshot::Sender<Result<PayloadId, PayloadBuilderError>>,
+    ) {
+        let payload_id = input.payload_id();
+
+        let basic_input = input;
+        let flashblocks_input = BuildNewPayload {
+            attributes: basic_input.attributes.clone(),
+            parent_hash: basic_input.parent_hash,
+            cache: None,
+            state_root_handle: None,
+        };
+
+        Self::inc_dispatch_metric(FLASHBLOCKS_BUILDER);
+        Self::inc_dispatch_metric(BASIC_BUILDER);
+        Self::inc_selected_build_metric(FLASHBLOCKS_BUILDER);
+
+        let flashblocks_rx = self.flashblocks_handle.send_new_payload(flashblocks_input);
+        let basic_rx = self.basic_handle.send_new_payload(basic_input);
+
+        let (flashblocks_result, basic_result) = tokio::join!(flashblocks_rx, basic_rx);
+        let selected_result = flashblocks_result.unwrap_or_else(|_| {
+            self.flashblocks_health.mark_unavailable();
+            Self::set_service_health_metric(FLASHBLOCKS_BUILDER, false);
+            Err(Self::unavailable_error(FLASHBLOCKS_BUILDER))
+        });
+        let shadow_result = basic_result.unwrap_or_else(|_| {
+            self.basic_health.mark_unavailable();
+            Self::set_service_health_metric(BASIC_BUILDER, false);
+            Err(Self::unavailable_error(BASIC_BUILDER))
+        });
+
+        Self::inc_shadow_metric(BASIC_BUILDER, shadow_result.is_ok());
+
+        info!(
+            builder = FLASHBLOCKS_BUILDER,
+            payload_id = ?payload_id,
+            selected = true,
+            result = if selected_result.is_ok() { "ok" } else { "err" },
+            "multiplex build request completed"
+        );
+
+        let _ = tx.send(selected_result);
+    }
+
+    /// Handles best payload lookup.
+    pub async fn handle_best_payload(
+        &self,
+        payload_id: PayloadId,
+        tx: tokio::sync::oneshot::Sender<
+            Option<Result<<BaseEngineTypes as PayloadTypes>::BuiltPayload, PayloadBuilderError>>,
+        >,
+    ) {
+        let result = self.flashblocks_handle.best_payload(payload_id).await;
+        let mapped = self.map_flashblocks_read_result(result);
+        let _ = tx.send(mapped);
+    }
+
+    /// Handles payload timestamp lookup.
+    pub async fn handle_payload_timestamp(
+        &self,
+        payload_id: PayloadId,
+        tx: tokio::sync::oneshot::Sender<Option<Result<u64, PayloadBuilderError>>>,
+    ) {
+        let result = self.flashblocks_handle.payload_timestamp(payload_id).await;
+        let mapped = self.map_flashblocks_read_result(result);
+        let _ = tx.send(mapped);
+    }
+
+    /// Handles payload resolve.
+    pub async fn handle_resolve(
+        &self,
+        payload_id: PayloadId,
+        kind: PayloadKind,
+        tx: tokio::sync::oneshot::Sender<Option<ResolveFuture>>,
+    ) {
+        let handle = self.flashblocks_handle.clone();
+        let health = self.flashblocks_health.clone();
+        let deadline = self.getpayload_deadline;
+        let future = async move {
+            let started = Instant::now();
+            let result = handle.resolve_kind(payload_id, kind).await;
+            let elapsed = started.elapsed();
+
+            Self::record_selected_getpayload_latency(elapsed.as_secs_f64());
+            if elapsed > deadline {
+                Self::inc_selected_deadline_miss();
+            }
+
+            match result {
+                Some(Ok(payload)) => Ok(payload),
+                Some(Err(PayloadBuilderError::ChannelClosed)) => {
+                    health.mark_unavailable();
+                    Self::set_service_health_metric(FLASHBLOCKS_BUILDER, false);
+                    Err(Self::unavailable_error(FLASHBLOCKS_BUILDER))
+                }
+                Some(Err(err)) => Err(err),
+                None => {
+                    if !health.is_healthy() {
+                        Err(Self::unavailable_error(FLASHBLOCKS_BUILDER))
+                    } else {
+                        Err(PayloadBuilderError::MissingPayload)
+                    }
+                }
+            }
+        };
+
+        let _ = tx.send(Some(Box::pin(future)));
+    }
+
+    /// Handles subscriptions.
+    pub async fn handle_subscribe(
+        &self,
+        tx: tokio::sync::oneshot::Sender<
+            tokio::sync::broadcast::Receiver<
+                reth_payload_builder_primitives::Events<BaseEngineTypes>,
+            >,
+        >,
+    ) {
+        if !self.flashblocks_health.is_healthy() {
+            return;
+        }
+
+        match self.flashblocks_handle.subscribe().await {
+            Ok(events) => {
+                let _ = tx.send(events.receiver);
+            }
+            Err(err) => {
+                if matches!(err, PayloadBuilderError::ChannelClosed) {
+                    self.flashblocks_health.mark_unavailable();
+                    Self::set_service_health_metric(FLASHBLOCKS_BUILDER, false);
+                }
+            }
+        }
+    }
+
+    /// Maps flashblocks read results with unavailable conversion.
+    pub fn map_flashblocks_read_result<T>(
+        &self,
+        result: Option<Result<T, PayloadBuilderError>>,
+    ) -> Option<Result<T, PayloadBuilderError>> {
+        match result {
+            Some(Err(PayloadBuilderError::ChannelClosed)) => {
+                self.flashblocks_health.mark_unavailable();
+                Self::set_service_health_metric(FLASHBLOCKS_BUILDER, false);
+                Some(Err(Self::unavailable_error(FLASHBLOCKS_BUILDER)))
+            }
+            None if !self.flashblocks_health.is_healthy() => {
+                Some(Err(Self::unavailable_error(FLASHBLOCKS_BUILDER)))
+            }
+            other => other,
+        }
+    }
+
+    /// Creates unavailable error.
+    pub fn unavailable_error(builder: &'static str) -> PayloadBuilderError {
+        PayloadBuilderError::other(BuilderUnavailableError { builder })
+    }
+
+    /// Increments dispatch metric.
+    pub fn inc_dispatch_metric(builder: &'static str) {
+        #[cfg(debug_assertions)]
+        if builder == FLASHBLOCKS_BUILDER {
+            DEBUG_DISPATCH_FLASHBLOCKS.fetch_add(1, Ordering::Relaxed);
+        } else if builder == BASIC_BUILDER {
+            DEBUG_DISPATCH_BASIC.fetch_add(1, Ordering::Relaxed);
+        }
+
+        metrics::counter!("mux_builds_dispatched_total", "builder" => builder).increment(1);
+    }
+
+    /// Returns the in-process debug dispatch counter for flashblocks.
+    #[cfg(debug_assertions)]
+    pub fn debug_flashblocks_dispatch_count() -> u64 {
+        DEBUG_DISPATCH_FLASHBLOCKS.load(Ordering::Relaxed)
+    }
+
+    /// Returns the in-process debug dispatch counter for basic.
+    #[cfg(debug_assertions)]
+    pub fn debug_basic_dispatch_count() -> u64 {
+        DEBUG_DISPATCH_BASIC.load(Ordering::Relaxed)
+    }
+
+    /// Resets in-process debug dispatch counters.
+    #[cfg(debug_assertions)]
+    pub fn debug_reset_dispatch_counts() {
+        DEBUG_DISPATCH_FLASHBLOCKS.store(0, Ordering::Relaxed);
+        DEBUG_DISPATCH_BASIC.store(0, Ordering::Relaxed);
+    }
+
+    /// Increments selected metric.
+    pub fn inc_selected_build_metric(builder: &'static str) {
+        metrics::counter!("mux_selected_builds_total", "builder" => builder).increment(1);
+    }
+
+    /// Increments shadow outcome metric.
+    pub fn inc_shadow_metric(builder: &'static str, ok: bool) {
+        let result = if ok { "ok" } else { "err" };
+        metrics::counter!(
+            "mux_shadow_outcome_total",
+            "builder" => builder,
+            "result" => result
+        )
+        .increment(1);
+    }
+
+    /// Sets service health gauge.
+    pub fn set_service_health_metric(builder: &'static str, healthy: bool) {
+        metrics::gauge!("mux_service_health", "builder" => builder).set(if healthy {
+            1.0
+        } else {
+            0.0
+        });
+    }
+
+    /// Records getPayload latency for selected route.
+    pub fn record_selected_getpayload_latency(seconds: f64) {
+        metrics::histogram!("mux_selected_getpayload_latency_seconds").record(seconds);
+    }
+
+    /// Increments selected deadline miss counter.
+    pub fn inc_selected_deadline_miss() {
+        metrics::counter!("mux_selected_deadline_miss_total").increment(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::B256;
+    use reth_payload_builder::PayloadBuilderHandle;
+    use reth_payload_builder_primitives::Events;
+    use tokio::sync::{broadcast, mpsc};
+
+    use super::*;
+
+    fn test_router() -> (
+        MultiplexRouter,
+        mpsc::UnboundedReceiver<PayloadServiceCommand<BaseEngineTypes>>,
+        mpsc::UnboundedReceiver<PayloadServiceCommand<BaseEngineTypes>>,
+    ) {
+        let (flash_tx, flash_rx) = mpsc::unbounded_channel();
+        let (basic_tx, basic_rx) = mpsc::unbounded_channel();
+        let router = MultiplexRouter::new(
+            PayloadBuilderHandle::new(flash_tx),
+            PayloadBuilderHandle::new(basic_tx),
+            HealthState::new(),
+            HealthState::new(),
+            RoutingConfig::default(),
+        );
+        (router, flash_rx, basic_rx)
+    }
+
+    fn sample_input() -> BuildNewPayload<<BaseEngineTypes as PayloadTypes>::PayloadAttributes> {
+        BuildNewPayload {
+            attributes: base_execution_payload_builder::BasePayloadBuilderAttributes::default(),
+            parent_hash: B256::ZERO,
+            cache: None,
+            state_root_handle: None,
+        }
+    }
+
+    fn payload_id_from_byte(value: u8) -> PayloadId {
+        let mut input = sample_input();
+        input.parent_hash = B256::repeat_byte(value);
+        input.payload_id()
+    }
+
+    #[tokio::test]
+    async fn build_fans_to_both_and_selects_flashblocks() {
+        let (router, mut flash_rx, mut basic_rx) = test_router();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        let input = sample_input();
+        let payload_id = input.payload_id();
+        tokio::spawn(async move {
+            router.handle_build_new_payload(input, tx).await;
+        });
+
+        let flash_cmd = flash_rx.recv().await.expect("flash cmd");
+        let basic_cmd = basic_rx.recv().await.expect("basic cmd");
+        let mut flash_seen = false;
+        let mut basic_seen = false;
+
+        if let PayloadServiceCommand::BuildNewPayload(input, _, tx) = flash_cmd {
+            flash_seen = true;
+            assert_eq!(input.payload_id(), payload_id);
+            assert!(input.cache.is_none());
+            assert!(input.state_root_handle.is_none());
+            tx.send(Ok(payload_id)).expect("flash response");
+        }
+
+        if let PayloadServiceCommand::BuildNewPayload(input, _, tx) = basic_cmd {
+            basic_seen = true;
+            assert_eq!(input.payload_id(), payload_id);
+            tx.send(Err(PayloadBuilderError::MissingPayload))
+                .expect("basic response");
+        }
+
+        assert!(flash_seen);
+        assert!(basic_seen);
+        assert!(rx.await.expect("selected response").is_ok());
+    }
+
+    #[tokio::test]
+    async fn best_payload_reads_flashblocks_only() {
+        let (router, mut flash_rx, mut basic_rx) = test_router();
+        let payload_id = payload_id_from_byte(7);
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        tokio::spawn(async move {
+            router.handle_best_payload(payload_id, tx).await;
+        });
+
+        let flash_cmd = flash_rx.recv().await.expect("flash command");
+        assert!(basic_rx.try_recv().is_err());
+        if let PayloadServiceCommand::BestPayload(inner_payload_id, tx) = flash_cmd {
+            assert_eq!(inner_payload_id, payload_id);
+            tx.send(None).expect("send flash response");
+        } else {
+            panic!("expected BestPayload command");
+        }
+
+        assert!(rx.await.expect("best response").is_none());
+    }
+
+    #[tokio::test]
+    async fn payload_timestamp_reads_flashblocks_only() {
+        let (router, mut flash_rx, mut basic_rx) = test_router();
+        let payload_id = payload_id_from_byte(9);
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        tokio::spawn(async move {
+            router.handle_payload_timestamp(payload_id, tx).await;
+        });
+
+        let flash_cmd = flash_rx.recv().await.expect("flash command");
+        assert!(basic_rx.try_recv().is_err());
+        if let PayloadServiceCommand::PayloadTimestamp(inner_payload_id, tx) = flash_cmd {
+            assert_eq!(inner_payload_id, payload_id);
+            tx.send(None).expect("send flash response");
+        } else {
+            panic!("expected PayloadTimestamp command");
+        }
+
+        assert!(rx.await.expect("timestamp response").is_none());
+    }
+
+    #[tokio::test]
+    async fn subscribe_uses_flashblocks_only() {
+        let (router, mut flash_rx, mut basic_rx) = test_router();
+        let (sub_tx, sub_rx) = tokio::sync::oneshot::channel();
+
+        tokio::spawn(async move {
+            router.handle_subscribe(sub_tx).await;
+        });
+
+        let flash_cmd = flash_rx.recv().await.expect("flash subscribe command");
+        assert!(basic_rx.try_recv().is_err());
+        if let PayloadServiceCommand::Subscribe(tx) = flash_cmd {
+            let (events_tx, events_rx) = broadcast::channel(2);
+            tx.send(events_rx).expect("send flash receiver");
+            let mut sub = sub_rx.await.expect("outer subscribe receiver");
+            events_tx
+                .send(Events::Attributes(sample_input().attributes))
+                .expect("send flash event");
+            assert!(sub.recv().await.is_ok());
+        } else {
+            panic!("expected Subscribe command");
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_uses_flashblocks_only() {
+        let (router, mut flash_rx, mut basic_rx) = test_router();
+        let payload_id = payload_id_from_byte(11);
+        let (resolve_tx, resolve_rx) = tokio::sync::oneshot::channel();
+
+        tokio::spawn(async move {
+            router
+                .handle_resolve(payload_id, PayloadKind::Earliest, resolve_tx)
+                .await;
+        });
+
+        let future = resolve_rx
+            .await
+            .expect("resolve response")
+            .expect("resolve future should be present");
+
+        let resolve_task = tokio::spawn(future);
+
+        let flash_cmd = flash_rx.recv().await.expect("flash resolve command");
+        assert!(basic_rx.try_recv().is_err());
+        if let PayloadServiceCommand::Resolve(inner_payload_id, _, tx) = flash_cmd {
+            assert_eq!(inner_payload_id, payload_id);
+            assert!(tx.send(None).is_ok(), "send flash resolve response");
+        } else {
+            panic!("expected Resolve command");
+        }
+
+        let resolved = resolve_task.await.expect("resolve task join");
+        assert!(matches!(resolved, Err(PayloadBuilderError::MissingPayload)));
+    }
+}

--- a/crates/builder/multiplex/src/service_builder.rs
+++ b/crates/builder/multiplex/src/service_builder.rs
@@ -120,7 +120,7 @@ where
             return Ok(basic_handle);
         }
 
-        let flashblocks_handle = FlashblocksServiceBuilder::new(self.builder_config.clone())
+        let flashblocks_handle = FlashblocksServiceBuilder::new(self.builder_config)
             .spawn_payload_builder_service(ctx, pool, evm_config)
             .await?;
 

--- a/crates/builder/multiplex/src/service_builder.rs
+++ b/crates/builder/multiplex/src/service_builder.rs
@@ -1,0 +1,170 @@
+use base_builder_core::{BuilderConfig, FlashblocksServiceBuilder, NodeBounds, PoolBounds};
+use base_execution_evm::BaseEvmConfig;
+use base_execution_payload_builder::config::BaseBuilderConfig;
+use base_node_core::{
+    BaseConsensusBuilder, BaseEngineTypes, BaseExecutorBuilder, BaseNetworkBuilder,
+    node::BasePoolBuilder,
+};
+use base_node_runner::{
+    BaseNode, BaseNodeTypes, PayloadServiceBuilder as BasePayloadServiceBuilder,
+};
+use reth_basic_payload_builder::{BasicPayloadJobGenerator, BasicPayloadJobGeneratorConfig};
+use reth_node_api::NodeTypes;
+use reth_node_builder::{
+    BuilderContext,
+    components::{ComponentsBuilder, PayloadServiceBuilder},
+};
+use reth_payload_builder::{PayloadBuilderHandle, PayloadBuilderService};
+use reth_provider::CanonStateSubscriptions;
+use tokio::sync::mpsc;
+use tracing::{error, info};
+
+use crate::{HealthState, MultiplexRouter, RoutingConfig};
+
+/// Spawns flashblocks + basic payload services and returns one routing handle.
+#[derive(Debug, Clone)]
+pub struct MultiplexingServiceBuilder {
+    /// Flashblocks/shared builder config.
+    pub builder_config: BuilderConfig,
+    /// Multiplexer settings.
+    pub routing_config: RoutingConfig,
+    /// Whether to compute pending block in basic builder.
+    pub compute_pending_block: bool,
+}
+
+impl MultiplexingServiceBuilder {
+    /// Creates a new multiplexing service builder.
+    pub fn new(builder_config: BuilderConfig) -> Self {
+        Self {
+            builder_config,
+            routing_config: RoutingConfig::default(),
+            compute_pending_block: false,
+        }
+    }
+
+    /// Configures pending-block computation for the basic payload builder.
+    pub const fn with_compute_pending_block(mut self, compute_pending_block: bool) -> Self {
+        self.compute_pending_block = compute_pending_block;
+        self
+    }
+
+    /// Configures multiplexer runtime config.
+    pub const fn with_routing_config(mut self, routing_config: RoutingConfig) -> Self {
+        self.routing_config = routing_config;
+        self
+    }
+
+    /// Enables or disables dual payload builders mode.
+    pub const fn with_dual_builders_enabled(mut self, dual_builders_enabled: bool) -> Self {
+        self.routing_config.dual_builders_enabled = dual_builders_enabled;
+        self
+    }
+}
+
+impl<Node, Pool> PayloadServiceBuilder<Node, Pool, BaseEvmConfig> for MultiplexingServiceBuilder
+where
+    Node: NodeBounds,
+    Pool: PoolBounds + Clone,
+{
+    async fn spawn_payload_builder_service(
+        self,
+        ctx: &BuilderContext<Node>,
+        pool: Pool,
+        evm_config: BaseEvmConfig,
+    ) -> eyre::Result<PayloadBuilderHandle<<Node::Types as NodeTypes>::Payload>> {
+        if !self.routing_config.dual_builders_enabled {
+            return FlashblocksServiceBuilder::new(self.builder_config)
+                .spawn_payload_builder_service(ctx, pool, evm_config)
+                .await;
+        }
+
+        let flashblocks_handle = FlashblocksServiceBuilder::new(self.builder_config.clone())
+            .spawn_payload_builder_service(ctx, pool.clone(), BaseEvmConfig::base(ctx.chain_spec()))
+            .await?;
+
+        let payload_builder =
+            base_execution_payload_builder::BasePayloadBuilder::with_builder_config(
+                pool,
+                ctx.provider().clone(),
+                evm_config,
+                BaseBuilderConfig {
+                    da_config: self.builder_config.da_config.clone(),
+                    gas_limit_config: self.builder_config.gas_limit_config.clone(),
+                    manifest_precheck_enabled: self.builder_config.manifest_precheck_enabled,
+                },
+            )
+            .set_compute_pending_block(self.compute_pending_block);
+
+        let payload_config = ctx.config().builder.clone();
+        let payload_job_config = BasicPayloadJobGeneratorConfig::default()
+            .interval(payload_config.interval)
+            .deadline(payload_config.deadline)
+            .max_payload_tasks(payload_config.max_payload_tasks)
+            .pre_cache_state(true);
+
+        let payload_generator = BasicPayloadJobGenerator::with_builder(
+            ctx.provider().clone(),
+            ctx.task_executor().clone(),
+            payload_job_config,
+            payload_builder,
+        );
+
+        let (basic_payload_service, basic_handle) =
+            PayloadBuilderService::<_, _, BaseEngineTypes>::new(
+                payload_generator,
+                ctx.provider().canonical_state_stream(),
+            );
+
+        let flashblocks_health = HealthState::new();
+        let basic_health = HealthState::new();
+
+        let basic_health_for_task = basic_health.clone();
+        ctx.task_executor().spawn_critical_task(
+            "multiplex basic payload builder service",
+            Box::pin(async move {
+                basic_payload_service.await;
+                basic_health_for_task.mark_unavailable();
+                MultiplexRouter::set_service_health_metric("basic", false);
+                error!(
+                    builder = "basic",
+                    selected = false,
+                    result = "err",
+                    "basic payload service exited"
+                );
+            }),
+        );
+
+        MultiplexRouter::set_service_health_metric("flashblocks", true);
+        MultiplexRouter::set_service_health_metric("basic", true);
+
+        let router = MultiplexRouter::new(
+            flashblocks_handle,
+            basic_handle,
+            flashblocks_health,
+            basic_health,
+            self.routing_config,
+        );
+
+        let (router_tx, router_rx) = mpsc::unbounded_channel();
+        ctx.task_executor()
+            .spawn_critical_task("payload multiplex router", Box::pin(router.run(router_rx)));
+
+        info!("payload builder multiplex service started");
+        Ok(PayloadBuilderHandle::new(router_tx))
+    }
+}
+
+impl BasePayloadServiceBuilder for MultiplexingServiceBuilder {
+    type ComponentsBuilder = ComponentsBuilder<
+        BaseNodeTypes,
+        BasePoolBuilder,
+        Self,
+        BaseNetworkBuilder,
+        BaseExecutorBuilder,
+        BaseConsensusBuilder,
+    >;
+
+    fn build_components(self, base_node: &BaseNode) -> Self::ComponentsBuilder {
+        base_node.components::<BaseNodeTypes>().payload(self)
+    }
+}

--- a/crates/builder/multiplex/src/service_builder.rs
+++ b/crates/builder/multiplex/src/service_builder.rs
@@ -152,7 +152,6 @@ where
             flashblocks_health,
             basic_health,
             ctx.chain_spec(),
-            self.routing_config,
         );
 
         let (router_tx, router_rx) = mpsc::unbounded_channel();

--- a/crates/builder/multiplex/src/service_builder.rs
+++ b/crates/builder/multiplex/src/service_builder.rs
@@ -28,12 +28,14 @@ pub struct MultiplexingServiceBuilder {
     pub builder_config: BuilderConfig,
     /// Multiplexer settings.
     pub routing_config: RoutingConfig,
+    /// Whether to run only the basic payload builder.
+    pub basic_only: bool,
 }
 
 impl MultiplexingServiceBuilder {
     /// Creates a new multiplexing service builder.
     pub fn new(builder_config: BuilderConfig) -> Self {
-        Self { builder_config, routing_config: RoutingConfig::default() }
+        Self { builder_config, routing_config: RoutingConfig::default(), basic_only: false }
     }
 
     /// Configures multiplexer runtime config.
@@ -45,6 +47,12 @@ impl MultiplexingServiceBuilder {
     /// Enables or disables the Zenith payload-builder cutover.
     pub const fn with_cutover_enabled(mut self, cutover_enabled: bool) -> Self {
         self.routing_config.cutover_enabled = cutover_enabled;
+        self
+    }
+
+    /// Configures the service to run only the basic payload builder.
+    pub const fn with_basic_only(mut self, basic_only: bool) -> Self {
+        self.basic_only = basic_only;
         self
     }
 }
@@ -60,19 +68,15 @@ where
         pool: Pool,
         evm_config: BaseEvmConfig,
     ) -> eyre::Result<PayloadBuilderHandle<<Node::Types as NodeTypes>::Payload>> {
-        if !self.routing_config.cutover_enabled {
+        if !self.routing_config.cutover_enabled && !self.basic_only {
             return FlashblocksServiceBuilder::new(self.builder_config)
                 .spawn_payload_builder_service(ctx, pool, evm_config)
                 .await;
         }
 
-        let flashblocks_handle = FlashblocksServiceBuilder::new(self.builder_config.clone())
-            .spawn_payload_builder_service(ctx, pool.clone(), BaseEvmConfig::base(ctx.chain_spec()))
-            .await?;
-
         let payload_builder =
             base_execution_payload_builder::BasePayloadBuilder::with_builder_config(
-                pool,
+                pool.clone(),
                 ctx.provider().clone(),
                 evm_config,
                 BaseBuilderConfig {
@@ -101,6 +105,19 @@ where
                 payload_generator,
                 ctx.provider().canonical_state_stream(),
             );
+
+        if self.basic_only {
+            ctx.task_executor().spawn_critical_task(
+                "basic payload builder service",
+                Box::pin(basic_payload_service),
+            );
+            info!("basic payload builder service started");
+            return Ok(basic_handle);
+        }
+
+        let flashblocks_handle = FlashblocksServiceBuilder::new(self.builder_config.clone())
+            .spawn_payload_builder_service(ctx, pool, BaseEvmConfig::base(ctx.chain_spec()))
+            .await?;
 
         let flashblocks_health = HealthState::new();
         let basic_health = HealthState::new();

--- a/crates/builder/multiplex/src/service_builder.rs
+++ b/crates/builder/multiplex/src/service_builder.rs
@@ -28,24 +28,12 @@ pub struct MultiplexingServiceBuilder {
     pub builder_config: BuilderConfig,
     /// Multiplexer settings.
     pub routing_config: RoutingConfig,
-    /// Whether to compute pending block in basic builder.
-    pub compute_pending_block: bool,
 }
 
 impl MultiplexingServiceBuilder {
     /// Creates a new multiplexing service builder.
     pub fn new(builder_config: BuilderConfig) -> Self {
-        Self {
-            builder_config,
-            routing_config: RoutingConfig::default(),
-            compute_pending_block: false,
-        }
-    }
-
-    /// Configures pending-block computation for the basic payload builder.
-    pub const fn with_compute_pending_block(mut self, compute_pending_block: bool) -> Self {
-        self.compute_pending_block = compute_pending_block;
-        self
+        Self { builder_config, routing_config: RoutingConfig::default() }
     }
 
     /// Configures multiplexer runtime config.
@@ -54,9 +42,9 @@ impl MultiplexingServiceBuilder {
         self
     }
 
-    /// Enables or disables dual payload builders mode.
-    pub const fn with_dual_builders_enabled(mut self, dual_builders_enabled: bool) -> Self {
-        self.routing_config.dual_builders_enabled = dual_builders_enabled;
+    /// Enables or disables the Zenith payload-builder cutover.
+    pub const fn with_cutover_enabled(mut self, cutover_enabled: bool) -> Self {
+        self.routing_config.cutover_enabled = cutover_enabled;
         self
     }
 }
@@ -72,7 +60,7 @@ where
         pool: Pool,
         evm_config: BaseEvmConfig,
     ) -> eyre::Result<PayloadBuilderHandle<<Node::Types as NodeTypes>::Payload>> {
-        if !self.routing_config.dual_builders_enabled {
+        if !self.routing_config.cutover_enabled {
             return FlashblocksServiceBuilder::new(self.builder_config)
                 .spawn_payload_builder_service(ctx, pool, evm_config)
                 .await;
@@ -92,8 +80,7 @@ where
                     gas_limit_config: self.builder_config.gas_limit_config.clone(),
                     manifest_precheck_enabled: self.builder_config.manifest_precheck_enabled,
                 },
-            )
-            .set_compute_pending_block(self.compute_pending_block);
+            );
 
         let payload_config = ctx.config().builder.clone();
         let payload_job_config = BasicPayloadJobGeneratorConfig::default()
@@ -142,6 +129,7 @@ where
             basic_handle,
             flashblocks_health,
             basic_health,
+            ctx.chain_spec(),
             self.routing_config,
         );
 

--- a/crates/builder/multiplex/src/service_builder.rs
+++ b/crates/builder/multiplex/src/service_builder.rs
@@ -68,6 +68,11 @@ where
         pool: Pool,
         evm_config: BaseEvmConfig,
     ) -> eyre::Result<PayloadBuilderHandle<<Node::Types as NodeTypes>::Payload>> {
+        eyre::ensure!(
+            !(self.routing_config.cutover_enabled && self.basic_only),
+            "payload builder cutover and basic-only modes are mutually exclusive"
+        );
+
         if !self.routing_config.cutover_enabled && !self.basic_only {
             return FlashblocksServiceBuilder::new(self.builder_config)
                 .spawn_payload_builder_service(ctx, pool, evm_config)

--- a/crates/builder/multiplex/src/service_builder.rs
+++ b/crates/builder/multiplex/src/service_builder.rs
@@ -44,7 +44,7 @@ impl MultiplexingServiceBuilder {
         self
     }
 
-    /// Enables or disables the Zenith payload-builder cutover.
+    /// Enables or disables the Denim payload-builder cutover.
     pub const fn with_cutover_enabled(mut self, cutover_enabled: bool) -> Self {
         self.routing_config.cutover_enabled = cutover_enabled;
         self

--- a/crates/builder/multiplex/src/service_builder.rs
+++ b/crates/builder/multiplex/src/service_builder.rs
@@ -78,7 +78,7 @@ where
             base_execution_payload_builder::BasePayloadBuilder::with_builder_config(
                 pool.clone(),
                 ctx.provider().clone(),
-                evm_config,
+                evm_config.clone(),
                 BaseBuilderConfig {
                     da_config: self.builder_config.da_config.clone(),
                     gas_limit_config: self.builder_config.gas_limit_config.clone(),
@@ -116,7 +116,7 @@ where
         }
 
         let flashblocks_handle = FlashblocksServiceBuilder::new(self.builder_config.clone())
-            .spawn_payload_builder_service(ctx, pool, BaseEvmConfig::base(ctx.chain_spec()))
+            .spawn_payload_builder_service(ctx, pool, evm_config)
             .await?;
 
         let flashblocks_health = HealthState::new();

--- a/crates/builder/multiplex/tests/in_process_smoke.rs
+++ b/crates/builder/multiplex/tests/in_process_smoke.rs
@@ -1,0 +1,251 @@
+//! In-process integration smoke test for multiplex payload routing.
+
+use std::{net::TcpListener, time::Duration};
+
+use alloy_eips::BlockNumberOrTag;
+use alloy_primitives::{B64, B256};
+use alloy_provider::{Identity, Provider, ProviderBuilder, RootProvider};
+use alloy_rpc_types_engine::{ForkchoiceState, PayloadAttributes};
+use base_builder_core::{BuilderConfig, FlashblocksServiceBuilder};
+use base_common_consensus::BaseTxEnvelope;
+use base_common_network::Base;
+use base_common_rpc_types_engine::BasePayloadAttributes;
+use base_execution_chainspec::BaseChainSpec;
+use base_execution_payload_builder::BasePayloadBuilderAttributes;
+use base_execution_rpc::BaseEngineApiClient;
+use base_node_core::{BaseEngineTypes, args::RollupArgs};
+use base_node_runner::BaseNodeRunner;
+use reth_node_api::{EngineTypes, PayloadTypes};
+use reth_node_builder::NodeBuilder;
+use reth_payload_builder::PayloadId;
+use reth_tasks::{Runtime, RuntimeBuilder, RuntimeConfig};
+
+use base_builder_multiplex::{MultiplexRouter, MultiplexingServiceBuilder};
+
+#[derive(Debug)]
+struct RunningNode {
+    auth_ipc_path: String,
+    rpc_ipc_path: String,
+    _runtime: Runtime,
+    _handle: base_node_runner::LaunchedBaseNode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct BuiltBlockSummary {
+    hash: B256,
+    state_root: B256,
+    gas_used: u64,
+    tx_count: usize,
+}
+
+impl RunningNode {
+    async fn launch_flashblocks() -> eyre::Result<Self> {
+        Self::launch(FlashblocksServiceBuilder::new(test_builder_config())).await
+    }
+
+    async fn launch_multiplex() -> eyre::Result<Self> {
+        let service_builder = MultiplexingServiceBuilder::new(test_builder_config())
+            .with_dual_builders_enabled(true);
+        Self::launch(service_builder).await
+    }
+
+    async fn launch<SB>(service_builder: SB) -> eyre::Result<Self>
+    where
+        SB: base_node_runner::PayloadServiceBuilder,
+    {
+        let runtime = RuntimeBuilder::new(RuntimeConfig::default()).build()?;
+        let chain_spec = std::sync::Arc::new(BaseChainSpec::mainnet());
+        let mut node_config = reth_node_builder::NodeConfig::new(chain_spec).with_unused_ports();
+        node_config.rpc = reth_node_core::args::RpcServerArgs::default().with_auth_ipc();
+        node_config.rpc.http = false;
+        node_config.rpc.ws = false;
+        node_config.rpc.auth_port = 0;
+
+        let random_id = format!(
+            "{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH)?.as_nanos()
+        );
+        let data_path = std::env::temp_dir().join(format!("mux-test.{random_id}.datadir"));
+        let rocksdb_path = std::env::temp_dir().join(format!("mux-test.{random_id}.rocksdb"));
+        let pprof_path = std::env::temp_dir().join(format!("mux-test.{random_id}.pprof-dumps"));
+        std::fs::create_dir_all(&data_path)?;
+        std::fs::create_dir_all(&rocksdb_path)?;
+        std::fs::create_dir_all(&pprof_path)?;
+        node_config = node_config.with_datadir_args(reth_node_core::args::DatadirArgs {
+            datadir: data_path.to_string_lossy().parse()?,
+            static_files_path: None,
+            rocksdb_path: Some(rocksdb_path),
+            pprof_dumps_path: Some(pprof_path),
+        });
+
+        let db_root = std::env::temp_dir().join(format!(
+            "mux-test-db-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH)?.as_nanos()
+        ));
+        std::fs::create_dir_all(&db_root)?;
+        let db = reth_db::init_db(
+            db_root.as_path(),
+            reth_db::mdbx::DatabaseArguments::new(reth_db::ClientVersion::default()),
+        )?;
+
+        let runner = BaseNodeRunner::new(RollupArgs::default()).with_service_builder(service_builder);
+        let builder = NodeBuilder::new(node_config.clone())
+            .with_database(db)
+            .with_launch_context(runtime.clone());
+        let handle = runner.launch(builder).await?;
+
+        Ok(Self {
+            auth_ipc_path: node_config.rpc.auth_ipc_path,
+            rpc_ipc_path: node_config.rpc.ipcpath,
+            _runtime: runtime,
+            _handle: handle,
+        })
+    }
+
+    async fn provider(&self) -> eyre::Result<RootProvider<Base>> {
+        ProviderBuilder::<Identity, Identity, Base>::default()
+            .connect_ipc(self.rpc_ipc_path.clone().into())
+            .await
+            .map_err(|err| eyre::eyre!("Failed to connect to IPC provider: {err}"))
+    }
+}
+
+fn test_builder_config() -> BuilderConfig {
+    let mut config = BuilderConfig::default();
+    config.flashblocks_ws_addr.set_port(available_port());
+    config
+}
+
+fn available_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("failed to bind random local port")
+        .local_addr()
+        .expect("failed to get local listener addr")
+        .port()
+}
+
+async fn engine_forkchoice_updated(
+    auth_ipc_path: &str,
+    state: ForkchoiceState,
+    attrs: Option<<BaseEngineTypes as PayloadTypes>::PayloadAttributes>,
+) -> eyre::Result<alloy_rpc_types_engine::ForkchoiceUpdated> {
+    let client = reth_ipc::client::IpcClientBuilder::default().build(auth_ipc_path).await?;
+    Ok(BaseEngineApiClient::<BaseEngineTypes>::fork_choice_updated_v3(&client, state, attrs).await?)
+}
+
+async fn engine_get_payload(
+    auth_ipc_path: &str,
+    payload_id: PayloadId,
+) -> eyre::Result<<BaseEngineTypes as EngineTypes>::ExecutionPayloadEnvelopeV3> {
+    let client = reth_ipc::client::IpcClientBuilder::default().build(auth_ipc_path).await?;
+    Ok(BaseEngineApiClient::<BaseEngineTypes>::get_payload_v3(&client, payload_id).await?)
+}
+
+async fn build_new_block(
+    provider: &RootProvider<Base>,
+    auth_ipc_path: &str,
+    block_timestamp: u64,
+) -> eyre::Result<BuiltBlockSummary> {
+    let latest = provider
+        .get_block_by_number(BlockNumberOrTag::Latest)
+        .await?
+        .ok_or_else(|| eyre::eyre!("missing latest block"))?;
+
+    let parent_hash = latest.header.hash;
+    let parent_beacon_block_root = latest.header.parent_beacon_block_root.unwrap_or(B256::ZERO);
+    let eip_1559_params: u64 = ((50_u64) << 32) | 2_u64;
+
+    let payload_attributes = BasePayloadBuilderAttributes::<BaseTxEnvelope>::try_new(
+        parent_hash,
+        BasePayloadAttributes {
+            payload_attributes: PayloadAttributes {
+                timestamp: block_timestamp,
+                parent_beacon_block_root: Some(parent_beacon_block_root),
+                withdrawals: Some(vec![]),
+                slot_number: None,
+                ..Default::default()
+            },
+            transactions: Some(vec![]),
+            gas_limit: Some(10_000_000),
+            no_tx_pool: Some(true),
+            min_base_fee: Some(0),
+            eip_1559_params: Some(B64::from(eip_1559_params)),
+            timestamp_millis_part: None,
+        },
+        3,
+    )?;
+
+    let fcu = engine_forkchoice_updated(
+        auth_ipc_path,
+        ForkchoiceState {
+            head_block_hash: parent_hash,
+            safe_block_hash: parent_hash,
+            finalized_block_hash: parent_hash,
+        },
+        Some(payload_attributes),
+    )
+    .await?;
+
+    let payload_id = fcu
+        .payload_id
+        .ok_or_else(|| eyre::eyre!("fcu did not return payload id"))?;
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let payload = engine_get_payload(auth_ipc_path, payload_id).await?.execution_payload;
+    let payload = payload.payload_inner.payload_inner;
+
+    Ok(BuiltBlockSummary {
+        hash: payload.block_hash,
+        state_root: payload.state_root,
+        gas_used: payload.gas_used,
+        tx_count: payload.transactions.len(),
+    })
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn multiplex_flashblocks_equivalence_and_shadow_dispatch() -> eyre::Result<()> {
+    #[cfg(debug_assertions)]
+    MultiplexRouter::debug_reset_dispatch_counts();
+
+    let baseline = RunningNode::launch_flashblocks().await?;
+    let baseline_provider = baseline.provider().await?;
+
+    let multiplex = RunningNode::launch_multiplex().await?;
+    let multiplex_provider = multiplex.provider().await?;
+
+    let baseline_head = baseline_provider
+        .get_block_by_number(BlockNumberOrTag::Latest)
+        .await?
+        .ok_or_else(|| eyre::eyre!("baseline missing latest block"))?;
+    let multiplex_head = multiplex_provider
+        .get_block_by_number(BlockNumberOrTag::Latest)
+        .await?
+        .ok_or_else(|| eyre::eyre!("multiplex missing latest block"))?;
+
+    assert_eq!(baseline_head.header.hash, multiplex_head.header.hash, "genesis mismatch");
+
+    let wall_clock = std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH)?;
+    let build_timestamp = std::cmp::max(baseline_head.header.timestamp + 2, wall_clock.as_secs() + 2);
+    let baseline_block =
+        build_new_block(&baseline_provider, &baseline.auth_ipc_path, build_timestamp).await?;
+    let multiplex_block =
+        build_new_block(&multiplex_provider, &multiplex.auth_ipc_path, build_timestamp).await?;
+
+    assert_eq!(baseline_block, multiplex_block);
+
+    #[cfg(debug_assertions)]
+    {
+        let flashblocks_dispatches = MultiplexRouter::debug_flashblocks_dispatch_count();
+        let basic_dispatches = MultiplexRouter::debug_basic_dispatch_count();
+        assert!(flashblocks_dispatches >= 1, "expected at least one multiplex dispatch");
+        assert_eq!(flashblocks_dispatches, basic_dispatches);
+    }
+
+    std::mem::forget(baseline);
+    std::mem::forget(multiplex);
+
+    Ok(())
+}

--- a/crates/builder/multiplex/tests/in_process_smoke.rs
+++ b/crates/builder/multiplex/tests/in_process_smoke.rs
@@ -44,7 +44,7 @@ impl RunningNode {
 
     async fn launch_multiplex() -> eyre::Result<Self> {
         let service_builder =
-            MultiplexingServiceBuilder::new(test_builder_config()).with_dual_builders_enabled(true);
+            MultiplexingServiceBuilder::new(test_builder_config()).with_cutover_enabled(true);
         Self::launch(service_builder).await
     }
 
@@ -242,6 +242,8 @@ async fn multiplex_flashblocks_equivalence_and_shadow_dispatch() -> eyre::Result
         let basic_dispatches = MultiplexRouter::debug_basic_dispatch_count();
         assert!(flashblocks_dispatches >= 1, "expected at least one multiplex dispatch");
         assert_eq!(flashblocks_dispatches, basic_dispatches);
+        assert!(MultiplexRouter::debug_flashblocks_selected_count() >= 1);
+        assert_eq!(MultiplexRouter::debug_basic_selected_count(), 0);
     }
 
     std::mem::forget(baseline);

--- a/crates/builder/multiplex/tests/in_process_smoke.rs
+++ b/crates/builder/multiplex/tests/in_process_smoke.rs
@@ -7,7 +7,7 @@ use alloy_primitives::{B64, B256};
 use alloy_provider::{Identity, Provider, ProviderBuilder, RootProvider};
 use alloy_rpc_types_engine::{ForkchoiceState, PayloadAttributes};
 use base_builder_core::{BuilderConfig, FlashblocksServiceBuilder};
-use base_builder_multiplex::{MultiplexRouter, MultiplexingServiceBuilder};
+use base_builder_multiplex::MultiplexingServiceBuilder;
 use base_common_consensus::BaseTxEnvelope;
 use base_common_network::Base;
 use base_common_rpc_types_engine::BasePayloadAttributes;
@@ -40,6 +40,10 @@ struct BuiltBlockSummary {
 impl RunningNode {
     async fn launch_flashblocks() -> eyre::Result<Self> {
         Self::launch(FlashblocksServiceBuilder::new(test_builder_config())).await
+    }
+
+    async fn launch_disabled() -> eyre::Result<Self> {
+        Self::launch(MultiplexingServiceBuilder::new(test_builder_config())).await
     }
 
     async fn launch_multiplex() -> eyre::Result<Self> {
@@ -210,12 +214,12 @@ async fn build_new_block(
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn multiplex_flashblocks_equivalence_and_shadow_dispatch() -> eyre::Result<()> {
-    #[cfg(debug_assertions)]
-    MultiplexRouter::debug_reset_dispatch_counts();
-
+async fn payload_builder_modes_match_flashblocks_baseline() -> eyre::Result<()> {
     let baseline = RunningNode::launch_flashblocks().await?;
     let baseline_provider = baseline.provider().await?;
+
+    let disabled = RunningNode::launch_disabled().await?;
+    let disabled_provider = disabled.provider().await?;
 
     let multiplex = RunningNode::launch_multiplex().await?;
     let multiplex_provider = multiplex.provider().await?;
@@ -237,20 +241,13 @@ async fn multiplex_flashblocks_equivalence_and_shadow_dispatch() -> eyre::Result
         std::cmp::max(baseline_head.header.timestamp + 2, wall_clock.as_secs() + 2);
     let baseline_block =
         build_new_block(&baseline_provider, &baseline.auth_ipc_path, build_timestamp).await?;
+    let disabled_block =
+        build_new_block(&disabled_provider, &disabled.auth_ipc_path, build_timestamp).await?;
     let multiplex_block =
         build_new_block(&multiplex_provider, &multiplex.auth_ipc_path, build_timestamp).await?;
 
+    assert_eq!(baseline_block, disabled_block);
     assert_eq!(baseline_block, multiplex_block);
-
-    #[cfg(debug_assertions)]
-    {
-        let flashblocks_dispatches = MultiplexRouter::debug_flashblocks_dispatch_count();
-        let basic_dispatches = MultiplexRouter::debug_basic_dispatch_count();
-        assert!(flashblocks_dispatches >= 1, "expected at least one multiplex dispatch");
-        assert_eq!(flashblocks_dispatches, basic_dispatches);
-        assert!(MultiplexRouter::debug_flashblocks_selected_count() >= 1);
-        assert_eq!(MultiplexRouter::debug_basic_selected_count(), 0);
-    }
 
     let basic = RunningNode::launch_basic().await?;
     let basic_provider = basic.provider().await?;
@@ -261,6 +258,7 @@ async fn multiplex_flashblocks_equivalence_and_shadow_dispatch() -> eyre::Result
     // Keep the nodes alive until process exit; dropping their independent runtimes can race the
     // remaining providers and database tasks during test teardown.
     std::mem::forget(baseline);
+    std::mem::forget(disabled);
     std::mem::forget(multiplex);
     std::mem::forget(basic);
 

--- a/crates/builder/multiplex/tests/in_process_smoke.rs
+++ b/crates/builder/multiplex/tests/in_process_smoke.rs
@@ -258,6 +258,8 @@ async fn multiplex_flashblocks_equivalence_and_shadow_dispatch() -> eyre::Result
         build_new_block(&basic_provider, &basic.auth_ipc_path, build_timestamp).await?;
     assert_eq!(baseline_block, basic_block);
 
+    // Keep the nodes alive until process exit; dropping their independent runtimes can race the
+    // remaining providers and database tasks during test teardown.
     std::mem::forget(baseline);
     std::mem::forget(multiplex);
     std::mem::forget(basic);

--- a/crates/builder/multiplex/tests/in_process_smoke.rs
+++ b/crates/builder/multiplex/tests/in_process_smoke.rs
@@ -203,6 +203,12 @@ async fn build_new_block(
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     let payload = engine_get_payload(auth_ipc_path, payload_id).await?.execution_payload;
+    let repeated_payload = engine_get_payload(auth_ipc_path, payload_id).await?.execution_payload;
+    assert_eq!(
+        payload.payload_inner.payload_inner.block_hash,
+        repeated_payload.payload_inner.payload_inner.block_hash,
+        "repeated getPayload returned a different block"
+    );
     let payload = payload.payload_inner.payload_inner;
 
     Ok(BuiltBlockSummary {

--- a/crates/builder/multiplex/tests/in_process_smoke.rs
+++ b/crates/builder/multiplex/tests/in_process_smoke.rs
@@ -7,6 +7,7 @@ use alloy_primitives::{B64, B256};
 use alloy_provider::{Identity, Provider, ProviderBuilder, RootProvider};
 use alloy_rpc_types_engine::{ForkchoiceState, PayloadAttributes};
 use base_builder_core::{BuilderConfig, FlashblocksServiceBuilder};
+use base_builder_multiplex::{MultiplexRouter, MultiplexingServiceBuilder};
 use base_common_consensus::BaseTxEnvelope;
 use base_common_network::Base;
 use base_common_rpc_types_engine::BasePayloadAttributes;
@@ -19,8 +20,6 @@ use reth_node_api::{EngineTypes, PayloadTypes};
 use reth_node_builder::NodeBuilder;
 use reth_payload_builder::PayloadId;
 use reth_tasks::{Runtime, RuntimeBuilder, RuntimeConfig};
-
-use base_builder_multiplex::{MultiplexRouter, MultiplexingServiceBuilder};
 
 #[derive(Debug)]
 struct RunningNode {
@@ -44,8 +43,8 @@ impl RunningNode {
     }
 
     async fn launch_multiplex() -> eyre::Result<Self> {
-        let service_builder = MultiplexingServiceBuilder::new(test_builder_config())
-            .with_dual_builders_enabled(true);
+        let service_builder =
+            MultiplexingServiceBuilder::new(test_builder_config()).with_dual_builders_enabled(true);
         Self::launch(service_builder).await
     }
 
@@ -90,7 +89,8 @@ impl RunningNode {
             reth_db::mdbx::DatabaseArguments::new(reth_db::ClientVersion::default()),
         )?;
 
-        let runner = BaseNodeRunner::new(RollupArgs::default()).with_service_builder(service_builder);
+        let runner =
+            BaseNodeRunner::new(RollupArgs::default()).with_service_builder(service_builder);
         let builder = NodeBuilder::new(node_config.clone())
             .with_database(db)
             .with_launch_context(runtime.clone());
@@ -132,7 +132,8 @@ async fn engine_forkchoice_updated(
     attrs: Option<<BaseEngineTypes as PayloadTypes>::PayloadAttributes>,
 ) -> eyre::Result<alloy_rpc_types_engine::ForkchoiceUpdated> {
     let client = reth_ipc::client::IpcClientBuilder::default().build(auth_ipc_path).await?;
-    Ok(BaseEngineApiClient::<BaseEngineTypes>::fork_choice_updated_v3(&client, state, attrs).await?)
+    Ok(BaseEngineApiClient::<BaseEngineTypes>::fork_choice_updated_v3(&client, state, attrs)
+        .await?)
 }
 
 async fn engine_get_payload(
@@ -172,7 +173,6 @@ async fn build_new_block(
             no_tx_pool: Some(true),
             min_base_fee: Some(0),
             eip_1559_params: Some(B64::from(eip_1559_params)),
-            timestamp_millis_part: None,
         },
         3,
     )?;
@@ -188,9 +188,7 @@ async fn build_new_block(
     )
     .await?;
 
-    let payload_id = fcu
-        .payload_id
-        .ok_or_else(|| eyre::eyre!("fcu did not return payload id"))?;
+    let payload_id = fcu.payload_id.ok_or_else(|| eyre::eyre!("fcu did not return payload id"))?;
 
     tokio::time::sleep(Duration::from_secs(1)).await;
 
@@ -227,8 +225,10 @@ async fn multiplex_flashblocks_equivalence_and_shadow_dispatch() -> eyre::Result
 
     assert_eq!(baseline_head.header.hash, multiplex_head.header.hash, "genesis mismatch");
 
-    let wall_clock = std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH)?;
-    let build_timestamp = std::cmp::max(baseline_head.header.timestamp + 2, wall_clock.as_secs() + 2);
+    let wall_clock =
+        std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH)?;
+    let build_timestamp =
+        std::cmp::max(baseline_head.header.timestamp + 2, wall_clock.as_secs() + 2);
     let baseline_block =
         build_new_block(&baseline_provider, &baseline.auth_ipc_path, build_timestamp).await?;
     let multiplex_block =

--- a/crates/builder/multiplex/tests/in_process_smoke.rs
+++ b/crates/builder/multiplex/tests/in_process_smoke.rs
@@ -48,6 +48,12 @@ impl RunningNode {
         Self::launch(service_builder).await
     }
 
+    async fn launch_basic() -> eyre::Result<Self> {
+        let service_builder =
+            MultiplexingServiceBuilder::new(test_builder_config()).with_basic_only(true);
+        Self::launch(service_builder).await
+    }
+
     async fn launch<SB>(service_builder: SB) -> eyre::Result<Self>
     where
         SB: base_node_runner::PayloadServiceBuilder,
@@ -246,8 +252,15 @@ async fn multiplex_flashblocks_equivalence_and_shadow_dispatch() -> eyre::Result
         assert_eq!(MultiplexRouter::debug_basic_selected_count(), 0);
     }
 
+    let basic = RunningNode::launch_basic().await?;
+    let basic_provider = basic.provider().await?;
+    let basic_block =
+        build_new_block(&basic_provider, &basic.auth_ipc_path, build_timestamp).await?;
+    assert_eq!(baseline_block, basic_block);
+
     std::mem::forget(baseline);
     std::mem::forget(multiplex);
+    std::mem::forget(basic);
 
     Ok(())
 }

--- a/etc/systems/Cargo.toml
+++ b/etc/systems/Cargo.toml
@@ -18,6 +18,7 @@ base-test-utils = { workspace = true, optional = true }
 base-txpool-rpc.workspace = true
 base-tx-manager.workspace = true
 base-flashblocks.workspace = true
+base-builder-multiplex.workspace = true
 base-tx-forwarding.workspace = true
 base-execution-cli.workspace = true
 base-txpool-tracing.workspace = true

--- a/etc/systems/src/l2/in_process_builder.rs
+++ b/etc/systems/src/l2/in_process_builder.rs
@@ -9,7 +9,8 @@ use std::{any::Any, path::PathBuf, sync::Arc, time::Duration};
 
 use alloy_primitives::hex::ToHexExt;
 use alloy_rpc_types_engine::JwtSecret;
-use base_builder_core::{BuilderConfig, FlashblocksServiceBuilder, test_utils::get_available_port};
+use base_builder_core::{BuilderConfig, test_utils::get_available_port};
+use base_builder_multiplex::MultiplexingServiceBuilder;
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_txpool::{
     BasePooledTransaction, BuilderApiImpl, BuilderApiServer, DEFAULT_MAX_VALIDITY_PREDICATES,
@@ -53,6 +54,8 @@ pub struct InProcessBuilderConfig {
     pub flashblocks_port: Option<u16>,
     /// Whether to accept experimental validity-bearing transactions.
     pub enable_experimental_validity_transactions: bool,
+    /// Whether to run both payload builders and cut over to basic at Zenith.
+    pub payload_builder_cutover: bool,
     /// Additional node extensions installed after the builder's built-in RPC wiring.
     ///
     /// Lets downstream consumers layer their own [`BaseNodeExtension`] onto the standard
@@ -156,7 +159,10 @@ impl InProcessBuilder {
                 base_node
                     .components()
                     .pool(pool_component(&rollup_args))
-                    .payload(FlashblocksServiceBuilder::new(builder_config)),
+                    .payload(
+                        MultiplexingServiceBuilder::new(builder_config)
+                            .with_cutover_enabled(config.payload_builder_cutover),
+                    ),
             )
             .with_add_ons(addons)
             .on_component_initialized(move |_ctx| Ok(()))

--- a/etc/systems/src/l2/in_process_builder.rs
+++ b/etc/systems/src/l2/in_process_builder.rs
@@ -54,7 +54,7 @@ pub struct InProcessBuilderConfig {
     pub flashblocks_port: Option<u16>,
     /// Whether to accept experimental validity-bearing transactions.
     pub enable_experimental_validity_transactions: bool,
-    /// Whether to run both payload builders and cut over to basic at Zenith.
+    /// Whether to run both payload builders and cut over to basic at Denim.
     pub payload_builder_cutover: bool,
     /// Additional node extensions installed after the builder's built-in RPC wiring.
     ///

--- a/etc/systems/src/l2/shadow_sequencer.rs
+++ b/etc/systems/src/l2/shadow_sequencer.rs
@@ -89,6 +89,7 @@ impl ShadowSequencer {
             p2p_port: None,
             flashblocks_port: None,
             enable_experimental_validity_transactions: false,
+            payload_builder_cutover: false,
             extra_extensions: Vec::new(),
         })
         .await

--- a/etc/systems/src/l2/stack.rs
+++ b/etc/systems/src/l2/stack.rs
@@ -77,7 +77,7 @@ pub struct L2StackConfig {
     pub tx_forwarding_config: Option<TxForwardingConfig>,
     /// Whether both L2 nodes enable experimental validity transaction transport.
     pub enable_experimental_validity_transactions: bool,
-    /// Whether the active builder cuts over from flashblocks to basic at Zenith.
+    /// Whether the active builder cuts over from flashblocks to basic at Denim.
     pub payload_builder_cutover: bool,
     /// Number of L1 blocks to keep distance from the L1 head for the client (validator)
     /// consensus node's derivation pipeline.

--- a/etc/systems/src/l2/stack.rs
+++ b/etc/systems/src/l2/stack.rs
@@ -77,6 +77,8 @@ pub struct L2StackConfig {
     pub tx_forwarding_config: Option<TxForwardingConfig>,
     /// Whether both L2 nodes enable experimental validity transaction transport.
     pub enable_experimental_validity_transactions: bool,
+    /// Whether the active builder cuts over from flashblocks to basic at Zenith.
+    pub payload_builder_cutover: bool,
     /// Number of L1 blocks to keep distance from the L1 head for the client (validator)
     /// consensus node's derivation pipeline.
     pub verifier_l1_confs: u64,
@@ -201,6 +203,7 @@ impl L2Stack {
             flashblocks_port: container_config.and_then(|c| c.builder_flashblocks_port),
             enable_experimental_validity_transactions: config
                 .enable_experimental_validity_transactions,
+            payload_builder_cutover: config.payload_builder_cutover,
             extra_extensions: config.extra_builder_extensions,
         };
         let builder = InProcessBuilder::start(builder_config)

--- a/etc/systems/src/smoke.rs
+++ b/etc/systems/src/smoke.rs
@@ -290,6 +290,7 @@ pub struct SystemTestStackBuilder {
     stable_config: Option<StableSystemTestConfig>,
     tx_forwarding_config: Option<TxForwardingConfig>,
     enable_experimental_validity_transactions: bool,
+    payload_builder_cutover: bool,
     verifier_l1_confs: u64,
     client_consensus_mode: L2ClientConsensusMode,
     shadow_sequencer_count: usize,
@@ -386,6 +387,12 @@ impl SystemTestStackBuilder {
     /// Enables experimental validity transaction ingress and builder acceptance.
     pub const fn with_experimental_validity_transactions(mut self) -> Self {
         self.enable_experimental_validity_transactions = true;
+        self
+    }
+
+    /// Runs both payload builders and cuts selection from flashblocks to basic at Zenith.
+    pub const fn with_payload_builder_cutover(mut self) -> Self {
+        self.payload_builder_cutover = true;
         self
     }
 
@@ -686,6 +693,7 @@ impl SystemTestStackBuilder {
             tx_forwarding_config: self.tx_forwarding_config,
             enable_experimental_validity_transactions: self
                 .enable_experimental_validity_transactions,
+            payload_builder_cutover: self.payload_builder_cutover,
             verifier_l1_confs: self.verifier_l1_confs,
             client_consensus_mode: self.client_consensus_mode,
             upgrade_signal: l2_upgrade_signal,

--- a/etc/systems/src/smoke.rs
+++ b/etc/systems/src/smoke.rs
@@ -390,7 +390,7 @@ impl SystemTestStackBuilder {
         self
     }
 
-    /// Runs both payload builders and cuts selection from flashblocks to basic at Zenith.
+    /// Runs both payload builders and cuts selection from flashblocks to basic at Denim.
     pub const fn with_payload_builder_cutover(mut self) -> Self {
         self.payload_builder_cutover = true;
         self

--- a/etc/systems/tests/builder_cutover.rs
+++ b/etc/systems/tests/builder_cutover.rs
@@ -9,7 +9,6 @@ use alloy_primitives::{Address, Bytes, U256};
 use alloy_provider::{Provider, RootProvider};
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
-use base_builder_multiplex::MultiplexRouter;
 use base_common_network::Base;
 use base_common_rpc_types::BaseTransactionRequest;
 use base_system_tests::{ANVIL_ACCOUNT_1, SystemTestStackBuilder};
@@ -25,8 +24,6 @@ const BLOCK_TIMEOUT: Duration = Duration::from_secs(45);
 #[tokio::test]
 async fn cuts_over_builder_and_block_time_at_zenith() -> Result<()> {
     base_node_runner::test_utils::init_silenced_tracing();
-    #[cfg(debug_assertions)]
-    MultiplexRouter::debug_reset_dispatch_counts();
 
     let system = SystemTestStackBuilder::new()
         .with_l1_chain_id(L1_CHAIN_ID)
@@ -58,16 +55,6 @@ async fn cuts_over_builder_and_block_time_at_zenith() -> Result<()> {
     wait_for_block(&builder, LAST_VERIFIED_BLOCK).await?;
     wait_for_block(&client, LAST_VERIFIED_BLOCK).await?;
     verify_chain_and_cadence(&builder, &client).await?;
-
-    #[cfg(debug_assertions)]
-    {
-        assert!(MultiplexRouter::debug_flashblocks_selected_count() > 0);
-        assert!(MultiplexRouter::debug_basic_selected_count() > 0);
-        assert_eq!(
-            MultiplexRouter::debug_flashblocks_dispatch_count(),
-            MultiplexRouter::debug_basic_dispatch_count()
-        );
-    }
 
     Ok(())
 }

--- a/etc/systems/tests/builder_cutover.rs
+++ b/etc/systems/tests/builder_cutover.rs
@@ -1,0 +1,154 @@
+//! End-to-end test for the Zenith payload-builder and block-time cutover.
+
+use std::time::Duration;
+
+use alloy_consensus::SignableTransaction;
+use alloy_eips::{BlockNumberOrTag, eip2718::Encodable2718};
+use alloy_network::TransactionBuilder;
+use alloy_primitives::{Address, Bytes, U256};
+use alloy_provider::{Provider, RootProvider};
+use alloy_signer::SignerSync;
+use alloy_signer_local::PrivateKeySigner;
+use base_builder_multiplex::MultiplexRouter;
+use base_common_network::Base;
+use base_common_rpc_types::BaseTransactionRequest;
+use base_system_tests::{ANVIL_ACCOUNT_1, SystemTestStackBuilder};
+use eyre::{OptionExt, Result, WrapErr};
+use tokio::time::{sleep, timeout};
+
+const L1_CHAIN_ID: u64 = 1337;
+const L2_CHAIN_ID: u64 = 84538453;
+const ZENITH_ACTIVATION_BLOCK: u64 = 10;
+const LAST_VERIFIED_BLOCK: u64 = ZENITH_ACTIVATION_BLOCK + 4;
+const BLOCK_TIMEOUT: Duration = Duration::from_secs(45);
+
+#[tokio::test]
+async fn cuts_over_builder_and_block_time_at_zenith() -> Result<()> {
+    base_node_runner::test_utils::init_silenced_tracing();
+    #[cfg(debug_assertions)]
+    MultiplexRouter::debug_reset_dispatch_counts();
+
+    let system = SystemTestStackBuilder::new()
+        .with_l1_chain_id(L1_CHAIN_ID)
+        .with_l2_chain_id(L2_CHAIN_ID)
+        .with_base_denim_activation_block(ZENITH_ACTIVATION_BLOCK)
+        .with_base_zenith_activation_block(ZENITH_ACTIVATION_BLOCK)
+        .with_payload_builder_cutover()
+        .build()
+        .await?;
+    let builder = system.l2_builder_provider()?;
+    let client = system.l2_client_provider()?;
+    let signer = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_1.private_key)?;
+
+    let pre_cutover_receipt_block =
+        send_transaction(&builder, &signer).await.wrap_err("pre-cutover transaction failed")?;
+    assert!(
+        pre_cutover_receipt_block < ZENITH_ACTIVATION_BLOCK,
+        "pre-cutover transaction landed at block {pre_cutover_receipt_block}"
+    );
+
+    wait_for_block(&builder, ZENITH_ACTIVATION_BLOCK + 1).await?;
+    let post_cutover_receipt_block =
+        send_transaction(&builder, &signer).await.wrap_err("post-cutover transaction failed")?;
+    assert!(
+        post_cutover_receipt_block > ZENITH_ACTIVATION_BLOCK,
+        "post-cutover transaction landed at block {post_cutover_receipt_block}"
+    );
+
+    wait_for_block(&builder, LAST_VERIFIED_BLOCK).await?;
+    wait_for_block(&client, LAST_VERIFIED_BLOCK).await?;
+    verify_chain_and_cadence(&builder, &client).await?;
+
+    #[cfg(debug_assertions)]
+    {
+        assert!(MultiplexRouter::debug_flashblocks_selected_count() > 0);
+        assert!(MultiplexRouter::debug_basic_selected_count() > 0);
+        assert_eq!(
+            MultiplexRouter::debug_flashblocks_dispatch_count(),
+            MultiplexRouter::debug_basic_dispatch_count()
+        );
+    }
+
+    Ok(())
+}
+
+async fn send_transaction(provider: &RootProvider<Base>, signer: &PrivateKeySigner) -> Result<u64> {
+    let nonce = provider.get_transaction_count(signer.address()).await?;
+    let transaction = BaseTransactionRequest::default()
+        .from(signer.address())
+        .to(Address::repeat_byte(0xfe))
+        .value(U256::from(1))
+        .transaction_type(2)
+        .with_gas_limit(21_000)
+        .with_max_fee_per_gas(2_000_000_000)
+        .with_max_priority_fee_per_gas(1_000_000)
+        .with_chain_id(L2_CHAIN_ID)
+        .with_nonce(nonce)
+        .build_typed_tx()
+        .map_err(|error| eyre::eyre!("invalid transaction: {error:?}"))?;
+    let signature = signer.sign_hash_sync(&transaction.signature_hash())?;
+    let raw_transaction: Bytes = transaction.into_signed(signature).encoded_2718().into();
+    let pending = provider.send_raw_transaction(&raw_transaction).await?;
+    let transaction_hash = *pending.tx_hash();
+    drop(pending);
+
+    timeout(BLOCK_TIMEOUT, async {
+        loop {
+            if let Some(receipt) = provider.get_transaction_receipt(transaction_hash).await? {
+                return receipt.inner.block_number.ok_or_eyre("receipt missing block number");
+            }
+            sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .wrap_err("transaction receipt timed out")?
+}
+
+async fn wait_for_block(provider: &RootProvider<Base>, target: u64) -> Result<()> {
+    timeout(BLOCK_TIMEOUT, async {
+        while provider.get_block_number().await? < target {
+            sleep(Duration::from_millis(100)).await;
+        }
+        Ok::<_, eyre::Error>(())
+    })
+    .await
+    .wrap_err_with(|| format!("timed out waiting for block {target}"))?
+}
+
+async fn verify_chain_and_cadence(
+    builder: &RootProvider<Base>,
+    client: &RootProvider<Base>,
+) -> Result<()> {
+    let mut previous_hash = None;
+    let mut previous_timestamp_ms = None;
+
+    for number in 0..=LAST_VERIFIED_BLOCK {
+        let builder_block = builder
+            .get_block_by_number(BlockNumberOrTag::Number(number))
+            .await?
+            .ok_or_eyre("builder block missing")?;
+        let client_block = client
+            .get_block_by_number(BlockNumberOrTag::Number(number))
+            .await?
+            .ok_or_eyre("client block missing")?;
+        assert_eq!(builder_block.header.hash, client_block.header.hash, "block {number} mismatch");
+
+        if let Some(hash) = previous_hash {
+            assert_eq!(builder_block.header.parent_hash, hash, "non-contiguous block {number}");
+        }
+
+        let timestamp_ms = builder_block
+            .header
+            .timestamp_ms
+            .unwrap_or_else(|| builder_block.header.timestamp.saturating_mul(1_000));
+        if let Some(previous) = previous_timestamp_ms {
+            let expected_delta = if number <= ZENITH_ACTIVATION_BLOCK { 2_000 } else { 200 };
+            assert_eq!(timestamp_ms - previous, expected_delta, "block {number} cadence mismatch");
+        }
+
+        previous_hash = Some(builder_block.header.hash);
+        previous_timestamp_ms = Some(timestamp_ms);
+    }
+
+    Ok(())
+}

--- a/etc/systems/tests/builder_cutover.rs
+++ b/etc/systems/tests/builder_cutover.rs
@@ -1,4 +1,4 @@
-//! End-to-end test for the Zenith payload-builder and block-time cutover.
+//! End-to-end test for the Denim payload-builder and block-time cutover.
 
 use std::time::Duration;
 
@@ -17,19 +17,18 @@ use tokio::time::{sleep, timeout};
 
 const L1_CHAIN_ID: u64 = 1337;
 const L2_CHAIN_ID: u64 = 84538453;
-const ZENITH_ACTIVATION_BLOCK: u64 = 10;
-const LAST_VERIFIED_BLOCK: u64 = ZENITH_ACTIVATION_BLOCK + 4;
+const DENIM_ACTIVATION_BLOCK: u64 = 10;
+const LAST_VERIFIED_BLOCK: u64 = DENIM_ACTIVATION_BLOCK + 4;
 const BLOCK_TIMEOUT: Duration = Duration::from_secs(45);
 
 #[tokio::test]
-async fn cuts_over_builder_and_block_time_at_zenith() -> Result<()> {
+async fn cuts_over_builder_and_block_time_at_denim() -> Result<()> {
     base_node_runner::test_utils::init_silenced_tracing();
 
     let system = SystemTestStackBuilder::new()
         .with_l1_chain_id(L1_CHAIN_ID)
         .with_l2_chain_id(L2_CHAIN_ID)
-        .with_base_denim_activation_block(ZENITH_ACTIVATION_BLOCK)
-        .with_base_zenith_activation_block(ZENITH_ACTIVATION_BLOCK)
+        .with_base_denim_activation_block(DENIM_ACTIVATION_BLOCK)
         .with_payload_builder_cutover()
         .build()
         .await?;
@@ -40,15 +39,15 @@ async fn cuts_over_builder_and_block_time_at_zenith() -> Result<()> {
     let pre_cutover_receipt_block =
         send_transaction(&builder, &signer).await.wrap_err("pre-cutover transaction failed")?;
     assert!(
-        pre_cutover_receipt_block < ZENITH_ACTIVATION_BLOCK,
+        pre_cutover_receipt_block < DENIM_ACTIVATION_BLOCK,
         "pre-cutover transaction landed at block {pre_cutover_receipt_block}"
     );
 
-    wait_for_block(&builder, ZENITH_ACTIVATION_BLOCK + 1).await?;
+    wait_for_block(&builder, DENIM_ACTIVATION_BLOCK + 1).await?;
     let post_cutover_receipt_block =
         send_transaction(&builder, &signer).await.wrap_err("post-cutover transaction failed")?;
     assert!(
-        post_cutover_receipt_block > ZENITH_ACTIVATION_BLOCK,
+        post_cutover_receipt_block > DENIM_ACTIVATION_BLOCK,
         "post-cutover transaction landed at block {post_cutover_receipt_block}"
     );
 
@@ -129,7 +128,7 @@ async fn verify_chain_and_cadence(
             .timestamp_ms
             .unwrap_or_else(|| builder_block.header.timestamp.saturating_mul(1_000));
         if let Some(previous) = previous_timestamp_ms {
-            let expected_delta = if number <= ZENITH_ACTIVATION_BLOCK { 2_000 } else { 200 };
+            let expected_delta = if number <= DENIM_ACTIVATION_BLOCK { 2_000 } else { 200 };
             assert_eq!(timestamp_ms - previous, expected_delta, "block {number} cadence mismatch");
         }
 


### PR DESCRIPTION
## Summary

- add a payload-builder multiplexer that runs the flashblocks and basic builders in parallel
- select flashblocks before Denim and the basic builder at/after Denim while keeping the shadow builder isolated from the transaction pool
- expose temporary cutover mode through `--builder.payload-builder-cutover`
- add `--builder.basic-payload-builder` to run only the basic builder after cutover; the two modes are mutually exclusive
- add an end-to-end system test covering builder selection, transaction inclusion, chain parity, and the Denim 2s-to-200ms cadence transition

## Safety before cutover is enabled

Both new flags default to false. In that configuration, `MultiplexingServiceBuilder` immediately delegates to the existing `FlashblocksServiceBuilder` with the same builder config, pool, and caller-provided EVM config. It does not start the basic builder or router, create an additional command channel, fan out requests, change payload IDs, or introduce the multiplexer’s error mapping. The pre-cutover deployment therefore retains the existing flashblocks payload-building and failure behavior; merely deploying this code with both flags off adds no new payload-path error cases.

The two opt-in modes are mutually exclusive at CLI parsing time and at the service boundary, so an invalid dual-enabled configuration fails at startup rather than changing block production at runtime.

## Cutover sequence

1. **Deploy dormant:** deploy the release with both flags off. The node continues using only the existing flashblocks service as described above.
2. **Enable temporary cutover mode:** restart with `--builder.payload-builder-cutover` before Denim activates. Both builders run, but flashblocks remains selected before Denim. Every build is sent to both services; the selected builder receives the original attributes and resources, while the shadow receives `no_tx_pool = true` and no shared execution resources so it cannot compete for transactions.
3. **Activate Denim:** selection changes by payload timestamp: flashblocks before Denim, basic at and after Denim. Reads and `getPayload` follow the route recorded when that payload ID was created, so in-flight payloads remain attached to their original builder across the boundary. Subscription events are filtered using the same activation rule. There is deliberately no silent failover to the non-selected builder; an unavailable selected service returns an explicit error, and a critical service panic causes the node supervisor restart path.
4. **Remove dual-builder overhead:** after the post-Denim basic-builder path is stable, restart with `--builder.basic-payload-builder`. This starts only the basic builder—no flashblocks service and no multiplexer—so both builders run together only during the short observation window.

Denim controls both the block-time transition to 200ms and payload-builder selection. The system test schedules Denim at one activation block and verifies pre/post-cutover transaction inclusion, 200ms cadence, and builder/client chain parity.

## Validation

- `cargo test -p base-builder-multiplex --lib`
- `cargo test -p base-builder-multiplex --test in_process_smoke`
- `cargo test -p base-system-tests --test builder_cutover`
- `cargo clippy -p base-builder-multiplex -p base-builder-cli -p base-system-tests --tests -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`