### PR TITLE
fix(flashblocks): raise decompressed payload decode cap to 16 MiB

### DIFF
--- a/crates/common/flashblocks/src/block.rs
+++ b/crates/common/flashblocks/src/block.rs
@@ -12,7 +12,13 @@ use super::{
 };
 
 /// Maximum allowed decoded flashblock payload size, in bytes.
-pub const MAX_DECOMPRESSED_FLASHBLOCK_BYTES: usize = 5 * 1024 * 1024;
+///
+/// Flashblock websocket messages JSON-hex-encode transactions (`0x` plus two
+/// characters per byte). A single flashblock can carry nearly a full block's
+/// transactions, and the builder uncompressed-block cap is 5 MiB of EIP-2718
+/// bytes, so the decompressed JSON can exceed 10 MiB. 16 MiB covers that hex
+/// expansion plus envelope and metadata.
+pub const MAX_DECOMPRESSED_FLASHBLOCK_BYTES: usize = 16 * 1024 * 1024;
 
 /// A flashblock containing partial block data.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]


### PR DESCRIPTION
## Summary
- Raise `MAX_DECOMPRESSED_FLASHBLOCK_BYTES` from 5 MiB to 16 MiB.
- Flashblock websocket messages JSON-hex-encode transactions (`0x` + 2 chars/byte). A single flashblock can carry nearly a full block's txs, so a 5 MiB uncompressed (EIP-2718) block produces decompressed JSON that exceeds the old 5 MiB decode cap even though the builder accepted the block.
- 16 MiB covers that ~2x hex expansion plus envelope/metadata. Consumers that hit the cap drop the frame (`flashblock payload too large`) and lose flashblock-latency tracking; the canonical block is unaffected.

## Test plan
- [x] `cargo test -p base-common-flashblocks`
- [ ] Confirm flashblock WS consumers (load tester, rollup-boost subscribers) decode large-calldata flashblocks without `PayloadTooLarge`