### PR TITLE
fix(builder): count builder-side validity expiry as block_expiry

### DIFF
--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -929,6 +929,9 @@ impl BasePayloadBuilderCtx {
                     );
                     diag.txs_rejected_other += 1;
                     diag.permanently_rejected_txs.push(tx_hash);
+                    // Same series as the pool-side block eviction: the builder
+                    // drops the tx before the pool sweep sees it.
+                    GuardMetrics::record_block_expiry_invalidations(1);
                     best_txs.mark_invalid(tx.sender(), tx.nonce());
                 } else if let Some(blocking_predicate) = blocking_predicate
                     && best_txs.park_current()


### PR DESCRIPTION
The builder terminally evicts validity-predicate transactions whose monotonic block_number/flashblock_index bounds can no longer be satisfied, removing them from the pool before the pool-side block sweep ever sees them. Report these on the same `invalidated{cause=block_expiry}` series as the pool-side eviction so the counter reflects the true expiry rate rather than only the subset of transactions that expire while never being built against.