### PR TITLE
feat(shadow-indexer): expire shadow blocks after thirty days

### DIFF
--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -14,7 +14,7 @@ use base_observability_events::{
     GlobalTransactionEventWriter, TransactionEventProducer, TransactionEventWriterConfig,
 };
 use base_proofs_extension::ProofsHistoryExtension;
-use base_shadow_indexer::{ShadowIndexerConfig, ShadowIndexerExtension};
+use base_shadow_indexer::{ShadowIndexerConfig, ShadowIndexerExtension, ShadowRetentionConfig};
 use base_shadow_indexer_db::{
     DEFAULT_DATABASE, DEFAULT_PORT, DEFAULT_USERNAME, PgConnectionParams, ShadowDbConfig,
 };
@@ -85,6 +85,10 @@ pub struct MeteringArgs {
 const DEFAULT_SHADOW_INDEXER_MAX_CONNECTIONS: u32 = 5;
 /// Default timeout when acquiring a shadow indexer database connection.
 const DEFAULT_SHADOW_INDEXER_CONNECTION_TIMEOUT: &str = "30s";
+/// Default age at which persisted shadow blocks are deleted.
+const DEFAULT_SHADOW_INDEXER_RETENTION: &str = "30d";
+/// Default delay between shadow block retention sweeps.
+const DEFAULT_SHADOW_INDEXER_RETENTION_INTERVAL: &str = "1h";
 
 /// CLI arguments for the shadow indexer `ExEx` that persists committed execution blocks.
 #[derive(Debug, Clone, PartialEq, Eq, clap::Args)]
@@ -156,6 +160,26 @@ pub struct ShadowIndexerArgs {
         requires = "enable_shadow_indexer"
     )]
     pub shadow_indexer_connection_timeout: Duration,
+
+    /// Age at which persisted shadow blocks are deleted, measured from their last write.
+    #[arg(
+        long = "shadow-indexer.retention",
+        env = "SHADOW_INDEXER_RETENTION",
+        default_value = DEFAULT_SHADOW_INDEXER_RETENTION,
+        value_parser = humantime::parse_duration,
+        requires = "enable_shadow_indexer"
+    )]
+    pub shadow_indexer_retention: Duration,
+
+    /// Delay between shadow block retention sweeps.
+    #[arg(
+        long = "shadow-indexer.retention-interval",
+        env = "SHADOW_INDEXER_RETENTION_INTERVAL",
+        default_value = DEFAULT_SHADOW_INDEXER_RETENTION_INTERVAL,
+        value_parser = humantime::parse_duration,
+        requires = "enable_shadow_indexer"
+    )]
+    pub shadow_indexer_retention_interval: Duration,
 }
 
 impl Default for ShadowIndexerArgs {
@@ -172,6 +196,12 @@ impl Default for ShadowIndexerArgs {
                 DEFAULT_SHADOW_INDEXER_CONNECTION_TIMEOUT,
             )
             .expect("valid default shadow indexer connection timeout"),
+            shadow_indexer_retention: humantime::parse_duration(DEFAULT_SHADOW_INDEXER_RETENTION)
+                .expect("valid default shadow indexer retention"),
+            shadow_indexer_retention_interval: humantime::parse_duration(
+                DEFAULT_SHADOW_INDEXER_RETENTION_INTERVAL,
+            )
+            .expect("valid default shadow indexer retention interval"),
         }
     }
 }
@@ -383,6 +413,20 @@ impl TryFrom<&ShadowIndexerArgs> for ShadowIndexerConfig {
             PgConnectionParams::default()
         };
 
+        if args.enable_shadow_indexer {
+            if args.shadow_indexer_retention.is_zero() {
+                eyre::bail!(
+                    "--shadow-indexer.retention (env SHADOW_INDEXER_RETENTION) must be non-zero"
+                );
+            }
+            if args.shadow_indexer_retention_interval.is_zero() {
+                eyre::bail!(
+                    "--shadow-indexer.retention-interval \
+                     (env SHADOW_INDEXER_RETENTION_INTERVAL) must be non-zero"
+                );
+            }
+        }
+
         Ok(Self {
             enabled: args.enable_shadow_indexer,
             db: ShadowDbConfig {
@@ -391,6 +435,10 @@ impl TryFrom<&ShadowIndexerArgs> for ShadowIndexerConfig {
                 connection_timeout: args.shadow_indexer_connection_timeout,
             },
             builder_version: env!("CARGO_PKG_VERSION").to_string(),
+            retention: ShadowRetentionConfig {
+                period: args.shadow_indexer_retention,
+                interval: args.shadow_indexer_retention_interval,
+            },
         })
     }
 }
@@ -991,6 +1039,10 @@ mod tests {
             "9",
             "--shadow-indexer.connection-timeout",
             "45s",
+            "--shadow-indexer.retention",
+            "3d",
+            "--shadow-indexer.retention-interval",
+            "15m",
         ])
         .args;
 
@@ -1005,6 +1057,65 @@ mod tests {
         assert_eq!(args.shadow_indexer.shadow_indexer_db_user, "writer");
         assert_eq!(args.shadow_indexer.shadow_indexer_max_connections, 9);
         assert_eq!(args.shadow_indexer.shadow_indexer_connection_timeout, Duration::from_secs(45));
+        assert_eq!(
+            args.shadow_indexer.shadow_indexer_retention,
+            Duration::from_secs(3 * 24 * 60 * 60)
+        );
+        assert_eq!(
+            args.shadow_indexer.shadow_indexer_retention_interval,
+            Duration::from_secs(15 * 60)
+        );
+    }
+
+    #[test]
+    fn test_shadow_indexer_retention_defaults_to_thirty_days() {
+        let args = CommandParser::<StandardNodeArgs>::parse_from([
+            "reth",
+            "--enable-shadow-indexer",
+            "--shadow-indexer.db-host",
+            "shadow.example.internal",
+            "--shadow-indexer.db-password",
+            "hunter2",
+        ])
+        .args;
+
+        let config = ShadowIndexerConfig::try_from(&args.shadow_indexer)
+            .expect("enabled shadow indexer config should build");
+
+        assert_eq!(config.retention.period, Duration::from_secs(30 * 24 * 60 * 60));
+        assert_eq!(config.retention.interval, Duration::from_secs(60 * 60));
+    }
+
+    #[test]
+    fn test_shadow_indexer_rejects_zero_retention() {
+        let args = ShadowIndexerArgs {
+            enable_shadow_indexer: true,
+            shadow_indexer_db_host: Some("shadow.example.internal".to_string()),
+            shadow_indexer_db_password: Some("hunter2".to_string()),
+            shadow_indexer_retention: Duration::ZERO,
+            ..ShadowIndexerArgs::default()
+        };
+
+        let error =
+            ShadowIndexerConfig::try_from(&args).expect_err("zero retention should be rejected");
+
+        assert!(error.to_string().contains("--shadow-indexer.retention"));
+    }
+
+    #[test]
+    fn test_shadow_indexer_rejects_zero_retention_interval() {
+        let args = ShadowIndexerArgs {
+            enable_shadow_indexer: true,
+            shadow_indexer_db_host: Some("shadow.example.internal".to_string()),
+            shadow_indexer_db_password: Some("hunter2".to_string()),
+            shadow_indexer_retention_interval: Duration::ZERO,
+            ..ShadowIndexerArgs::default()
+        };
+
+        let error = ShadowIndexerConfig::try_from(&args)
+            .expect_err("zero retention interval should be rejected");
+
+        assert!(error.to_string().contains("--shadow-indexer.retention-interval"));
     }
 
     #[test]

--- a/crates/execution/shadow-indexer-db/src/lib.rs
+++ b/crates/execution/shadow-indexer-db/src/lib.rs
@@ -11,5 +11,8 @@ pub use cursor::{ShadowBlockCursor, ShadowMetricsCursorRepo};
 mod repo;
 pub use repo::{ShadowBlockRepo, ShadowFlushOutcome, ShadowSummaryRow, ShadowUnresolvedBacklog};
 
+mod retention;
+pub use retention::{SHADOW_RETENTION_LOCK_KEY, ShadowRetentionRepo, ShadowRetentionSweep};
+
 mod models;
 pub use models::{ShadowBlockPayload, ShadowBlockRow, ShadowCanonicalRef, ShadowWrite};

--- a/crates/execution/shadow-indexer-db/src/retention.rs
+++ b/crates/execution/shadow-indexer-db/src/retention.rs
@@ -1,0 +1,180 @@
+//! Batched deletion of expired shadow block rows.
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use sqlx::{Connection, PgConnection, PgPool, query, query_scalar};
+use tokio::time::sleep;
+
+/// Fleet-wide advisory lock key for the retention sweep.
+///
+/// Every shadow builder writes to the same database, so the key is a fixed arbitrary constant
+/// rather than anything derived from node identity: they must all contend for the same lock.
+/// Exported so operators can find the holder in `pg_locks`.
+pub const SHADOW_RETENTION_LOCK_KEY: i64 = 0x0053_4841_444f_5701;
+
+/// Rows deleted per transaction.
+const DELETE_BATCH_ROWS: i64 = 2_000;
+
+/// Pause between delete transactions, to leave the writer room against the same database.
+const DELETE_BATCH_PAUSE: Duration = Duration::from_millis(100);
+
+/// Ceiling on a single sweep, roughly a day and a half of ingest at a two-second block cadence.
+///
+/// A sweep that hits this stops early and resumes on the next tick, so a large backlog drains
+/// over several sweeps instead of holding the database busy in one long run.
+const MAX_ROWS_PER_SWEEP: u64 = 100_000;
+
+/// Result of one retention sweep.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ShadowRetentionSweep {
+    /// Rows deleted.
+    pub deleted: u64,
+    /// Delete transactions committed.
+    pub batches: u32,
+    /// Whether the sweep stopped at [`MAX_ROWS_PER_SWEEP`] with rows still expired.
+    pub capped: bool,
+}
+
+/// Deletes shadow block rows that have outlived the retention period.
+#[derive(Debug)]
+pub struct ShadowRetentionRepo {
+    pool: PgPool,
+}
+
+impl ShadowRetentionRepo {
+    /// Creates a repository.
+    #[must_use]
+    pub const fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Resolves the retention cutoff against the database clock.
+    ///
+    /// Read from Postgres rather than the node so a skewed builder clock cannot widen or narrow
+    /// the window.
+    ///
+    /// # Errors
+    /// Returns an error when the period does not fit in seconds or the query fails.
+    pub async fn cutoff(&self, period: Duration) -> Result<DateTime<Utc>> {
+        let seconds = i64::try_from(period.as_secs())
+            .context("shadow retention period does not fit in a signed 64-bit second count")?;
+
+        query_scalar("SELECT now() - ($1::bigint * interval '1 second')")
+            .bind(seconds)
+            .fetch_one(&self.pool)
+            .await
+            .context("failed to resolve the shadow retention cutoff")
+    }
+
+    /// Reports whether expiring rows include reorged blocks the metrics reader never consumed.
+    ///
+    /// Retention is never clamped to the reader: a reader that stops advancing would otherwise
+    /// pin the table and defeat the point of the sweep. Losing unread rows is the deliberate
+    /// trade, so callers surface this as an operational signal instead.
+    ///
+    /// # Errors
+    /// Returns an error when the query fails.
+    pub async fn has_unread_expired(&self, cutoff: DateTime<Utc>) -> Result<bool> {
+        query_scalar(
+            "SELECT EXISTS ( \
+               SELECT 1 FROM shadow_blocks AS blocks \
+               JOIN shadow_metrics_cursor AS cursor_row ON cursor_row.id = 1 \
+               WHERE blocks.updated_at < $1 \
+                 AND (blocks.updated_at, blocks.number) \
+                     > (cursor_row.last_updated_at, cursor_row.last_number) \
+             )",
+        )
+        .bind(cutoff)
+        .fetch_one(&self.pool)
+        .await
+        .context("failed to check the shadow metrics cursor against the retention cutoff")
+    }
+
+    /// Deletes every row last written before `cutoff`, in bounded batches.
+    ///
+    /// Returns `None` when another builder in the fleet already holds the retention lock.
+    ///
+    /// # Errors
+    /// Returns an error when the lock query or any delete batch fails.
+    pub async fn sweep(&self, cutoff: DateTime<Utc>) -> Result<Option<ShadowRetentionSweep>> {
+        let mut conn =
+            self.pool.acquire().await.context("failed to acquire a shadow retention connection")?;
+
+        // The advisory lock is held for the session, so the lock outlives any single statement.
+        // Closing the connection on drop releases it even if a batch below fails midway.
+        conn.close_on_drop();
+
+        let acquired: bool = query_scalar("SELECT pg_try_advisory_lock($1)")
+            .bind(SHADOW_RETENTION_LOCK_KEY)
+            .fetch_one(&mut *conn)
+            .await
+            .context("failed to take the shadow retention advisory lock")?;
+
+        if !acquired {
+            return Ok(None);
+        }
+
+        let mut sweep = ShadowRetentionSweep::default();
+
+        loop {
+            let deleted = Self::delete_batch(&mut conn, cutoff).await?;
+            if deleted == 0 {
+                break;
+            }
+
+            sweep.deleted = sweep.deleted.saturating_add(deleted);
+            sweep.batches = sweep.batches.saturating_add(1);
+
+            if sweep.deleted >= MAX_ROWS_PER_SWEEP {
+                sweep.capped = true;
+                break;
+            }
+
+            sleep(DELETE_BATCH_PAUSE).await;
+        }
+
+        Ok(Some(sweep))
+    }
+
+    async fn delete_batch(conn: &mut PgConnection, cutoff: DateTime<Utc>) -> Result<u64> {
+        let mut tx = conn.begin().await.context("failed to open a shadow retention batch")?;
+
+        // Yield rather than queue behind a writer holding a conflicting lock; the rows are
+        // retried on the next batch.
+        query("SET LOCAL lock_timeout = '2s'")
+            .execute(&mut *tx)
+            .await
+            .context("failed to set the shadow retention lock timeout")?;
+        query("SET LOCAL statement_timeout = '30s'")
+            .execute(&mut *tx)
+            .await
+            .context("failed to set the shadow retention statement timeout")?;
+
+        // `SKIP LOCKED` steps over rows the writer is upserting right now; they expire on a
+        // later sweep. `MATERIALIZED` keeps the limit from being inlined into the delete.
+        let deleted = query(
+            "WITH expired AS MATERIALIZED ( \
+               SELECT number FROM shadow_blocks \
+               WHERE updated_at < $1 \
+               ORDER BY updated_at, number \
+               LIMIT $2 \
+               FOR UPDATE SKIP LOCKED \
+             ) \
+             DELETE FROM shadow_blocks AS blocks \
+             USING expired \
+             WHERE blocks.number = expired.number",
+        )
+        .bind(cutoff)
+        .bind(DELETE_BATCH_ROWS)
+        .execute(&mut *tx)
+        .await
+        .context("failed to delete a batch of expired shadow blocks")?
+        .rows_affected();
+
+        tx.commit().await.context("failed to commit a shadow retention batch")?;
+
+        Ok(deleted)
+    }
+}

--- a/crates/execution/shadow-indexer/src/extension.rs
+++ b/crates/execution/shadow-indexer/src/extension.rs
@@ -2,7 +2,7 @@ use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
 use base_shadow_indexer_db::ShadowDbConfig;
 use tokio::sync::mpsc;
 
-use crate::{ShadowIndexerExEx, ShadowWriter};
+use crate::{ShadowIndexerExEx, ShadowRetention, ShadowRetentionConfig, ShadowWriter};
 
 /// Configuration for the shadow indexer extension.
 #[derive(Clone, Debug)]
@@ -13,6 +13,8 @@ pub struct ShadowIndexerConfig {
     pub db: ShadowDbConfig,
     /// Builder version string to attach to persisted rows.
     pub builder_version: String,
+    /// Retention policy that bounds shadow block table growth.
+    pub retention: ShadowRetentionConfig,
 }
 
 /// Wires the shadow indexer `ExEx` into the Base node.
@@ -37,11 +39,15 @@ impl BaseNodeExtension for ShadowIndexerExtension {
 
         let (tx, rx) = mpsc::channel(1024);
         let db = self.cfg.db.clone();
+        let retention_db = self.cfg.db.clone();
+        let retention = self.cfg.retention;
         let builder_version = self.cfg.builder_version.clone();
 
         hooks
             .add_node_started_hook(move |node| {
-                ShadowWriter::spawn(node.task_executor, rx, db, builder_version);
+                let executor = node.task_executor;
+                ShadowRetention::spawn(&executor, retention_db, retention);
+                ShadowWriter::spawn(executor, rx, db, builder_version);
                 Ok(())
             })
             .install_exex("shadow-indexer", move |ctx| async move {

--- a/crates/execution/shadow-indexer/src/lib.rs
+++ b/crates/execution/shadow-indexer/src/lib.rs
@@ -9,5 +9,8 @@ pub use exex::ShadowIndexerExEx;
 mod metrics;
 pub use metrics::{ShadowExExMetrics, ShadowWriterMetrics};
 
+mod retention;
+pub use retention::{ShadowRetention, ShadowRetentionConfig};
+
 mod writer;
 pub use writer::ShadowWriter;

--- a/crates/execution/shadow-indexer/src/retention.rs
+++ b/crates/execution/shadow-indexer/src/retention.rs
@@ -1,0 +1,125 @@
+//! Periodic retention sweeps that bound shadow block table growth.
+
+use std::time::Duration;
+
+use base_shadow_indexer_db::{ShadowDbConfig, ShadowRetentionRepo};
+use reth_tasks::TaskExecutor;
+use tokio::time::{MissedTickBehavior, interval};
+use tracing::{debug, error, info, warn};
+
+/// Sweeps run one statement at a time, so a single connection is enough.
+const RETENTION_MAX_CONNECTIONS: u32 = 1;
+
+/// Retention policy for persisted shadow blocks.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ShadowRetentionConfig {
+    /// How long a row survives after it was last written.
+    pub period: Duration,
+    /// Delay between sweeps.
+    pub interval: Duration,
+}
+
+/// Shadow block retention task.
+#[derive(Debug)]
+pub struct ShadowRetention {
+    db_config: ShadowDbConfig,
+    config: ShadowRetentionConfig,
+}
+
+impl ShadowRetention {
+    /// Spawns the retention task on the provided executor.
+    pub fn spawn(
+        executor: &TaskExecutor,
+        db_config: ShadowDbConfig,
+        config: ShadowRetentionConfig,
+    ) {
+        let retention = Self {
+            db_config: ShadowDbConfig { max_connections: RETENTION_MAX_CONNECTIONS, ..db_config },
+            config,
+        };
+
+        // Unlike the writer this is not a critical task. Indexing stays correct when a sweep
+        // fails, so a failure retries on the next tick instead of taking the builder down.
+        executor.spawn_task(async move {
+            retention.run().await;
+        });
+    }
+
+    async fn run(self) {
+        info!(
+            target: "base::shadow-indexer",
+            period = ?self.config.period,
+            interval = ?self.config.interval,
+            "Starting shadow block retention"
+        );
+
+        let mut ticker = interval(self.config.interval);
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+        let repo = loop {
+            ticker.tick().await;
+
+            match self.db_config.init_pool().await {
+                Ok(pool) => break ShadowRetentionRepo::new(pool),
+                Err(error) => error!(
+                    target: "base::shadow-indexer",
+                    error = ?error,
+                    "Failed to initialize the shadow retention database pool; \
+                     retrying on the next tick"
+                ),
+            }
+        };
+
+        loop {
+            if let Err(error) = Self::sweep_once(&repo, self.config.period).await {
+                error!(
+                    target: "base::shadow-indexer",
+                    error = ?error,
+                    "Shadow block retention sweep failed"
+                );
+            }
+
+            ticker.tick().await;
+        }
+    }
+
+    async fn sweep_once(repo: &ShadowRetentionRepo, period: Duration) -> anyhow::Result<()> {
+        let cutoff = repo.cutoff(period).await?;
+
+        if repo.has_unread_expired(cutoff).await? {
+            warn!(
+                target: "base::shadow-indexer",
+                %cutoff,
+                "Expiring reorged shadow blocks the metrics reader never consumed"
+            );
+        }
+
+        let Some(sweep) = repo.sweep(cutoff).await? else {
+            debug!(
+                target: "base::shadow-indexer",
+                "Another builder holds the shadow retention lock"
+            );
+            return Ok(());
+        };
+
+        if sweep.capped {
+            warn!(
+                target: "base::shadow-indexer",
+                deleted = sweep.deleted,
+                batches = sweep.batches,
+                %cutoff,
+                "Shadow block retention hit its per-sweep ceiling; backlog resumes next sweep"
+            );
+        } else if sweep.deleted > 0 {
+            info!(
+                target: "base::shadow-indexer",
+                deleted = sweep.deleted,
+                batches = sweep.batches,
+                %cutoff,
+                "Deleted expired shadow blocks"
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/etc/systems/tests/shadow_indexer.rs
+++ b/etc/systems/tests/shadow_indexer.rs
@@ -8,7 +8,7 @@
 use std::time::Duration;
 
 use base_node_runner::FromExtensionConfig;
-use base_shadow_indexer::{ShadowIndexerConfig, ShadowIndexerExtension};
+use base_shadow_indexer::{ShadowIndexerConfig, ShadowIndexerExtension, ShadowRetentionConfig};
 use base_shadow_indexer_db::{PgConnectionParams, ShadowBlockRepo, ShadowDbConfig};
 use base_system_tests::{SystemTestProviderExt, SystemTestStackBuilder};
 use eyre::{Result, WrapErr, ensure};
@@ -26,6 +26,9 @@ const L2_CHAIN_ID: u64 = 84538453;
 const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(60);
 const DB_POLL_TIMEOUT: Duration = Duration::from_secs(20);
 const DB_POLL_INTERVAL: Duration = Duration::from_millis(500);
+/// Long enough that no block this test produces can expire while it runs.
+const RETENTION_PERIOD: Duration = Duration::from_secs(30 * 24 * 60 * 60);
+const RETENTION_INTERVAL: Duration = Duration::from_secs(60 * 60);
 
 #[tokio::test]
 async fn shadow_indexer_persists_no_canonical_blocks() -> Result<()> {
@@ -48,6 +51,7 @@ async fn shadow_indexer_persists_no_canonical_blocks() -> Result<()> {
         enabled: true,
         db: db_config.clone(),
         builder_version: "e2e-test".to_string(),
+        retention: ShadowRetentionConfig { period: RETENTION_PERIOD, interval: RETENTION_INTERVAL },
     }));
 
     let system = SystemTestStackBuilder::new()

--- a/etc/systems/tests/shadow_retention.rs
+++ b/etc/systems/tests/shadow_retention.rs
@@ -1,0 +1,230 @@
+//! Postgres-backed system tests for shadow block retention sweeps.
+
+use std::time::Duration;
+
+use anyhow::Result;
+use base_shadow_indexer_db::{
+    PgConnectionParams, SHADOW_RETENTION_LOCK_KEY, ShadowBlockCursor, ShadowBlockPayload,
+    ShadowBlockRepo, ShadowBlockRow, ShadowDbConfig, ShadowMetricsCursorRepo, ShadowRetentionRepo,
+    ShadowWrite,
+};
+use chrono::{DateTime, Utc};
+use reth_primitives_traits::RecoveredBlock;
+use sqlx::{PgPool, query, query_scalar};
+use testcontainers::{ContainerAsync, ImageExt, runners::AsyncRunner};
+use testcontainers_modules::postgres::Postgres;
+
+const RETENTION_PERIOD: Duration = Duration::from_secs(30 * 24 * 60 * 60);
+
+/// Matches the RDS engine version the shadow builders write to. The module default is Postgres
+/// 11, which predates the `MATERIALIZED` CTE hint the sweep relies on.
+const POSTGRES_TAG: &str = "17-alpine";
+
+struct TestDatabase {
+    _container: ContainerAsync<Postgres>,
+    pool: PgPool,
+}
+
+impl TestDatabase {
+    async fn start() -> Result<Self> {
+        let container = Postgres::default().with_tag(POSTGRES_TAG).start().await?;
+        let port = container.get_host_port_ipv4(5432).await?;
+        let connection = PgConnectionParams {
+            host: "127.0.0.1".to_string(),
+            port,
+            database: "postgres".to_string(),
+            username: "postgres".to_string(),
+            password: "postgres".to_string(),
+        };
+        let pool = ShadowDbConfig {
+            connection,
+            max_connections: 5,
+            connection_timeout: Duration::from_secs(5),
+        }
+        .init_pool()
+        .await?;
+
+        Ok(Self { _container: container, pool })
+    }
+
+    fn retention(&self) -> ShadowRetentionRepo {
+        ShadowRetentionRepo::new(self.pool.clone())
+    }
+
+    async fn insert(&self, rows: Vec<ShadowBlockRow>) -> Result<()> {
+        let writes: Vec<ShadowWrite> =
+            rows.into_iter().map(|row| ShadowWrite::Reorged(Box::new(row))).collect();
+        ShadowBlockRepo::new(self.pool.clone()).flush(&writes).await?;
+
+        Ok(())
+    }
+
+    async fn age_all_rows(&self, age: Duration) -> Result<()> {
+        let seconds = i64::try_from(age.as_secs())?;
+        query("UPDATE shadow_blocks SET updated_at = now() - ($1::bigint * interval '1 second')")
+            .bind(seconds)
+            .execute(&self.pool)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn age_row(&self, number: i64, age: Duration) -> Result<()> {
+        let seconds = i64::try_from(age.as_secs())?;
+        query(
+            "UPDATE shadow_blocks SET updated_at = now() - ($1::bigint * interval '1 second') \
+             WHERE number = $2",
+        )
+        .bind(seconds)
+        .bind(number)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    async fn remaining_numbers(&self) -> Result<Vec<i64>> {
+        let numbers = query_scalar("SELECT number FROM shadow_blocks ORDER BY number")
+            .fetch_all(&self.pool)
+            .await?;
+
+        Ok(numbers)
+    }
+}
+
+fn shadow_row(number: i64) -> ShadowBlockRow {
+    let now = Utc::now();
+
+    ShadowBlockRow {
+        number,
+        hash: number.to_be_bytes().to_vec(),
+        canonical_hash: None,
+        created_at: now,
+        updated_at: now,
+        payload: ShadowBlockPayload {
+            builder_version: "retention-test".to_string(),
+            block: RecoveredBlock::default(),
+            receipts: Vec::new(),
+        },
+    }
+}
+
+const fn days(count: u64) -> Duration {
+    Duration::from_secs(count * 24 * 60 * 60)
+}
+
+#[tokio::test]
+async fn deletes_only_rows_older_than_the_retention_period() -> Result<()> {
+    let database = TestDatabase::start().await?;
+    database.insert(vec![shadow_row(1), shadow_row(2), shadow_row(3)]).await?;
+
+    database.age_row(1, days(31)).await?;
+    database.age_row(2, days(60)).await?;
+
+    let retention = database.retention();
+    let cutoff = retention.cutoff(RETENTION_PERIOD).await?;
+    let sweep = retention.sweep(cutoff).await?.expect("sweep should take the retention lock");
+
+    assert_eq!(sweep.deleted, 2);
+    assert!(!sweep.capped);
+    assert_eq!(database.remaining_numbers().await?, vec![3]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn keeps_every_row_inside_the_retention_period() -> Result<()> {
+    let database = TestDatabase::start().await?;
+    database.insert(vec![shadow_row(1), shadow_row(2)]).await?;
+
+    database.age_all_rows(days(29)).await?;
+
+    let retention = database.retention();
+    let cutoff = retention.cutoff(RETENTION_PERIOD).await?;
+    let sweep = retention.sweep(cutoff).await?.expect("sweep should take the retention lock");
+
+    assert_eq!(sweep.deleted, 0);
+    assert_eq!(sweep.batches, 0);
+    assert_eq!(database.remaining_numbers().await?, vec![1, 2]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn deletes_a_large_backlog_across_several_batches() -> Result<()> {
+    const EXPIRED_ROWS: i64 = 2_500;
+
+    let database = TestDatabase::start().await?;
+    let rows: Vec<ShadowBlockRow> = (1..=EXPIRED_ROWS).map(shadow_row).collect();
+    database.insert(rows).await?;
+    database.age_all_rows(days(31)).await?;
+
+    let retention = database.retention();
+    let cutoff = retention.cutoff(RETENTION_PERIOD).await?;
+    let sweep = retention.sweep(cutoff).await?.expect("sweep should take the retention lock");
+
+    assert_eq!(sweep.deleted, u64::try_from(EXPIRED_ROWS)?);
+    assert!(sweep.batches >= 2, "a backlog past one batch must span several transactions");
+    assert!(database.remaining_numbers().await?.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn yields_when_another_builder_holds_the_retention_lock() -> Result<()> {
+    let database = TestDatabase::start().await?;
+    database.insert(vec![shadow_row(1)]).await?;
+    database.age_all_rows(days(31)).await?;
+
+    let mut holder = database.pool.acquire().await?;
+    holder.close_on_drop();
+    let held: bool = query_scalar("SELECT pg_try_advisory_lock($1)")
+        .bind(SHADOW_RETENTION_LOCK_KEY)
+        .fetch_one(&mut *holder)
+        .await?;
+    assert!(held, "the test must hold the lock before the sweep runs");
+
+    let retention = database.retention();
+    let cutoff = retention.cutoff(RETENTION_PERIOD).await?;
+
+    assert!(retention.sweep(cutoff).await?.is_none());
+    assert_eq!(database.remaining_numbers().await?, vec![1]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn reports_expired_rows_the_metrics_cursor_never_consumed() -> Result<()> {
+    let database = TestDatabase::start().await?;
+    database.insert(vec![shadow_row(1)]).await?;
+    database.age_all_rows(days(31)).await?;
+
+    let retention = database.retention();
+    let cutoff = retention.cutoff(RETENTION_PERIOD).await?;
+
+    assert!(
+        !retention.has_unread_expired(cutoff).await?,
+        "an absent cursor means the reader never ran, which is not an unread-row signal"
+    );
+
+    let cursor = ShadowMetricsCursorRepo::new(database.pool.clone());
+    cursor.store(&ShadowBlockCursor::genesis()).await?;
+
+    assert!(
+        retention.has_unread_expired(cutoff).await?,
+        "a cursor behind the expiring reorged row must be reported"
+    );
+
+    let updated_at =
+        query_scalar::<_, DateTime<Utc>>("SELECT updated_at FROM shadow_blocks WHERE number = 1")
+            .fetch_one(&database.pool)
+            .await?;
+    cursor.store(&ShadowBlockCursor { updated_at, number: 1 }).await?;
+
+    assert!(
+        !retention.has_unread_expired(cutoff).await?,
+        "a cursor level with the expiring row leaves nothing unread"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Nothing ever deleted from `shadow_blocks`, so the shadow builder Postgres grew without bound while each row carries a full block plus receipts as JSONB. This adds an hourly, advisory-locked retention sweep that batch-deletes rows older than `--shadow-indexer.retention` (default 30d), keyed off the already-indexed `updated_at` so no migration is required.

Retention is intentionally not clamped to the shadow metrics cursor — a stalled reader would otherwise pin the table forever — so rows expiring unread are logged instead.