### PR TITLE
fix(flashblocks): rebase pending state on canonical tip

### DIFF
--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -175,6 +175,10 @@ pub struct RpcStandardNodeArgs {
     pub flashblocks_url: Option<Url>,
 
     /// The max pending blocks depth.
+    ///
+    /// Deprecated and ignored. Pending flashblocks are rebased onto the current canonical tip
+    /// instead of retaining a depth-limited historical overlay. Kept so existing deployment
+    /// flags remain accepted.
     #[arg(
         long = "max-pending-blocks-depth",
         value_name = "MAX_PENDING_BLOCKS_DEPTH",

--- a/crates/execution/flashblocks-node/tests/state.rs
+++ b/crates/execution/flashblocks-node/tests/state.rs
@@ -1,11 +1,20 @@
 //! Integration tests that stress Flashblocks state handling.
 
+use std::time::{Duration, Instant};
+
+use alloy_consensus::{Header, Sealed};
 use alloy_network::BlockResponse;
-use alloy_primitives::U256;
-use base_flashblocks::{FlashblocksAPI, PendingBlocksAPI};
+use alloy_primitives::{B256, U256};
+use base_common_flashblocks::{
+    ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, Flashblock, Metadata,
+};
+use base_flashblocks::{
+    FlashblocksAPI, FlashblocksReceiver, PendingBlocks, PendingBlocksAPI, PendingBlocksBuilder,
+};
 use base_flashblocks_node::test_harness::{FlashblockBuilder, FlashblocksBuilderTestHarness};
 use base_test_utils::Account;
 use reth_provider::{AccountReader, StateProviderFactory};
+use tokio::time::sleep;
 
 #[tokio::test]
 async fn test_state_overrides_persisted_across_flashblocks() {
@@ -303,25 +312,9 @@ async fn test_only_current_pending_state_cleared_upon_canonical_block_reorg() {
     )])
     .await;
 
-    let pending = test.flashblocks.get_pending_blocks().get_block(true);
-    assert!(pending.is_some());
-    let pending = pending.unwrap();
-    assert_eq!(pending.transactions.len(), 2);
-
-    let overrides = test
-        .flashblocks
-        .get_pending_blocks()
-        .get_state_overrides()
-        .expect("should be set from txn execution");
-
-    assert!(overrides.contains_key(&Account::Alice.address()));
-    assert_eq!(
-        overrides
-            .get(&Account::Bob.address())
-            .expect("should be set as txn receiver")
-            .balance
-            .expect("should be changed due to receiving funds"),
-        test.expected_pending_balance(Account::Bob, 100_000)
+    assert!(
+        test.flashblocks.get_pending_blocks().get_block(true).is_none(),
+        "overlap mismatch must clear pending instead of rebuilding a suffix from the old overlay"
     );
 }
 
@@ -653,12 +646,11 @@ async fn test_sequential_nonces_across_flashblocks() {
 }
 
 #[tokio::test]
-async fn test_flashblock_cached_and_applied_after_canonical_block() {
+async fn test_cached_wrong_parent_flashblock_is_discarded_after_canonical_advance() {
     let mut test = FlashblocksBuilderTestHarness::new().await;
 
-    // Send a flashblock targeting block 2 (canonical_block_number=1) before
-    // canonical block 1 exists. This triggers MissingCanonicalHeader and should
-    // be cached by the processor.
+    // This cached flashblock was built on the current genesis tip but claims to target block 2.
+    // Once canonical block 1 arrives, its parent hash is no longer valid for the cached payload.
     test.send_flashblock(FlashblockBuilder::new_base(&test).with_canonical_block_number(1).build())
         .await;
 
@@ -667,17 +659,32 @@ async fn test_flashblock_cached_and_applied_after_canonical_block() {
         "pending state should be empty because canonical block 1 does not exist yet"
     );
 
-    // Build canonical block 1 so the processor can replay the cached flashblock.
-    test.new_canonical_block(vec![]).await;
-    assert_eq!(test.node.latest_block().number, 1);
+    let block_one = test.new_canonical_block_without_processing(vec![]).await;
+    let block_one_number = block_one.number;
+    let block_one_hash = block_one.hash();
+    test.flashblocks.on_canonical_block_received(block_one);
 
-    let pending =
-        test.flashblocks.get_pending_blocks().get_block(true).expect("cached flashblock replayed");
-    assert_eq!(pending.header.number, 2, "replayed flashblock should produce pending block 2");
+    let resume = FlashblockBuilder::new_base(&test).build();
+    assert_eq!(resume.metadata.block_number, block_one_number + 1);
+    assert_eq!(resume.base.as_ref().map(|base| base.parent_hash), Some(block_one_hash));
+    test.flashblocks.on_flashblock_received(resume);
+
+    wait_until(
+        Duration::from_secs(5),
+        || {
+            test.flashblocks.get_pending_blocks().as_ref().is_some_and(|pending| {
+                pending.earliest_block_number() == block_one_number + 1
+                    && pending.latest_block_number() == block_one_number + 1
+                    && pending.parent_hash() == block_one_hash
+            })
+        },
+        "cached work from the old fork must be discarded before a matching flashblock resumes",
+    )
+    .await;
 }
 
 #[tokio::test]
-async fn test_cached_flashblock_with_transactions_applied_after_canonical() {
+async fn test_cached_wrong_parent_flashblocks_are_discarded_before_a_fresh_sequence() {
     let mut test = FlashblocksBuilderTestHarness::new().await;
 
     let transfer_amount = 100_000u128;
@@ -701,13 +708,37 @@ async fn test_cached_flashblock_with_transactions_applied_after_canonical() {
     .await;
     assert!(test.flashblocks.get_pending_blocks().is_none());
 
-    // Provide canonical block 1 to unlock the cache.
-    test.new_canonical_block(vec![]).await;
+    let block_one = test.new_canonical_block_without_processing(vec![]).await;
+    let block_one_number = block_one.number;
+    let block_one_hash = block_one.hash();
 
-    let pending =
-        test.flashblocks.get_pending_blocks().get_block(true).expect("cached flashblocks replayed");
-    assert_eq!(pending.header.number, 2);
-    assert_eq!(pending.transactions.len(), 2, "deposit tx from base + Alice->Bob transfer");
+    let resume = FlashblockBuilder::new_base(&test).build();
+    let append = FlashblockBuilder::new(&test, 1)
+        .with_canonical_block_number(block_one_number)
+        .with_transactions(vec![test.build_transaction_to_send_eth(
+            Account::Alice,
+            Account::Bob,
+            transfer_amount,
+        )])
+        .build();
+
+    test.flashblocks.on_canonical_block_received(block_one);
+    test.flashblocks.on_flashblock_received(resume);
+    test.flashblocks.on_flashblock_received(append);
+
+    wait_until(
+        Duration::from_secs(5),
+        || {
+            test.flashblocks.get_pending_blocks().as_ref().is_some_and(|pending| {
+                pending.earliest_block_number() == block_one_number + 1
+                    && pending.latest_block_number() == block_one_number + 1
+                    && pending.parent_hash() == block_one_hash
+                    && pending.pending_transaction_count() == 2
+            })
+        },
+        "cached work from the old fork must not contaminate the fresh flashblock sequence",
+    )
+    .await;
 
     let overrides = test
         .flashblocks
@@ -725,6 +756,91 @@ async fn test_cached_flashblock_with_transactions_applied_after_canonical() {
             .balance
             .expect("balance should be overridden"),
         test.expected_pending_balance(Account::Bob, transfer_amount)
+    );
+}
+
+#[tokio::test]
+async fn test_drops_deltas_after_preserving_tip_aligned_pending_from_a_wrong_parent() {
+    let mut test = FlashblocksBuilderTestHarness::new().await;
+    let old_transfer_amount = 50_000u128;
+    let fresh_transfer_amount = 100_000u128;
+
+    // Cache an old-fork base and delta for block 2 before canonical block 1 is available.
+    test.send_flashblock(FlashblockBuilder::new_base(&test).with_canonical_block_number(1).build())
+        .await;
+    test.send_flashblock(
+        FlashblockBuilder::new(&test, 1)
+            .with_canonical_block_number(1)
+            .with_transactions(vec![test.build_transaction_to_send_eth(
+                Account::Alice,
+                Account::Bob,
+                old_transfer_amount,
+            )])
+            .build(),
+    )
+    .await;
+
+    let block_one = test.new_canonical_block_without_processing(vec![]).await;
+    let block_one_number = block_one.number;
+    let block_one_hash = block_one.hash();
+
+    // Before the canonical notification drains the old cache, a valid current base establishes a
+    // healthy pending window for block 2.
+    test.send_flashblock(FlashblockBuilder::new_base(&test).build()).await;
+    wait_until(
+        Duration::from_secs(5),
+        || {
+            test.flashblocks.get_pending_blocks().as_ref().is_some_and(|pending| {
+                pending.earliest_block_number() == block_one_number + 1
+                    && pending.parent_hash() == block_one_hash
+                    && pending.pending_transaction_count() == 1
+            })
+        },
+        "fresh base flashblock should establish a tip-aligned pending window",
+    )
+    .await;
+
+    let valid_duplicate_base = FlashblockBuilder::new_base(&test).build();
+    let fresh_delta = FlashblockBuilder::new(&test, 1)
+        .with_canonical_block_number(block_one_number)
+        .with_transactions(vec![test.build_transaction_to_send_eth(
+            Account::Charlie,
+            Account::Bob,
+            fresh_transfer_amount,
+        )])
+        .build();
+
+    test.flashblocks.on_canonical_block_received(block_one);
+    // A valid duplicate base clears the single-block quarantine before the fresh delta arrives.
+    test.flashblocks.on_flashblock_received(valid_duplicate_base);
+    test.flashblocks.on_flashblock_received(fresh_delta);
+
+    wait_until(
+        Duration::from_secs(5),
+        || {
+            test.flashblocks.get_pending_blocks().as_ref().is_some_and(|pending| {
+                pending.earliest_block_number() == block_one_number + 1
+                    && pending.latest_block_number() == block_one_number + 1
+                    && pending.parent_hash() == block_one_hash
+                    && pending.pending_transaction_count() == 2
+            })
+        },
+        "old-fork deltas must not extend a pending window preserved after their base is dropped",
+    )
+    .await;
+
+    let overrides = test
+        .flashblocks
+        .get_pending_blocks()
+        .get_state_overrides()
+        .expect("fresh delta should publish state overrides");
+    assert_eq!(
+        overrides
+            .get(&Account::Bob.address())
+            .expect("Bob should have a state override")
+            .balance
+            .expect("Bob balance should be overridden"),
+        test.expected_pending_balance(Account::Bob, fresh_transfer_amount)
     );
 }
 
@@ -850,4 +966,341 @@ async fn test_same_block_append_refreshes_pending_header() {
         after_second_append.header.transactions_root != first_transactions_root,
         "same-block append must publish a fresh header with updated transactions_root"
     );
+}
+
+fn dummy_flashblock(block_number: u64, parent_hash: B256) -> Flashblock {
+    Flashblock {
+        payload_id: Default::default(),
+        index: 0,
+        base: Some(ExecutionPayloadBaseV1 {
+            parent_beacon_block_root: B256::ZERO,
+            parent_hash,
+            fee_recipient: Default::default(),
+            prev_randao: B256::ZERO,
+            block_number,
+            gas_limit: 30_000_000,
+            timestamp: 1_700_000_000 + block_number,
+            extra_data: Default::default(),
+            base_fee_per_gas: U256::from(1_000_000_000u64),
+        }),
+        diff: ExecutionPayloadFlashblockDeltaV1::default(),
+        metadata: Metadata::new(block_number),
+    }
+}
+
+fn pending_spanning(
+    earliest: u64,
+    latest: u64,
+    parent_hash: B256,
+    suffix: Flashblock,
+) -> PendingBlocks {
+    let mut builder = PendingBlocksBuilder::new();
+    builder.with_header(Sealed::new_unchecked(
+        Header { number: earliest, parent_hash, ..Default::default() },
+        B256::ZERO,
+    ));
+    builder.with_header(Sealed::new_unchecked(
+        Header { number: latest, parent_hash: B256::ZERO, ..Default::default() },
+        B256::ZERO,
+    ));
+    builder.with_flashblocks([dummy_flashblock(earliest, parent_hash), suffix]);
+    builder.build().expect("pending snapshot should build")
+}
+
+fn pending_at_block(block_number: u64, parent_hash: B256) -> PendingBlocks {
+    let mut builder = PendingBlocksBuilder::new();
+    builder.with_header(Sealed::new_unchecked(
+        Header { number: block_number, parent_hash, ..Default::default() },
+        B256::ZERO,
+    ));
+    builder.with_flashblocks([dummy_flashblock(block_number, parent_hash)]);
+    builder.build().expect("pending snapshot should build")
+}
+
+async fn wait_until(timeout: Duration, mut check: impl FnMut() -> bool, failure: &str) {
+    let start = Instant::now();
+    loop {
+        if check() {
+            return;
+        }
+        if start.elapsed() > timeout {
+            panic!("{failure}");
+        }
+        sleep(Duration::from_millis(20)).await;
+    }
+}
+
+#[tokio::test]
+async fn test_matching_canonical_rebases_pending_onto_canonical_n() {
+    let mut test = FlashblocksBuilderTestHarness::new().await;
+    let genesis_hash = test.node.latest_block().hash();
+
+    let block_one = test.new_canonical_block_without_processing(vec![]).await;
+    assert!(
+        block_one.body().transactions.is_empty(),
+        "empty canonical block is required so injected pending txs match"
+    );
+
+    let suffix = FlashblockBuilder::new_base(&test).build();
+    assert_eq!(suffix.metadata.block_number, 2);
+
+    test.flashblocks.set_pending_blocks_for_testing(Some(pending_spanning(
+        1,
+        2,
+        genesis_hash,
+        suffix,
+    )));
+
+    test.flashblocks.on_canonical_block_received(block_one.clone());
+    wait_until(
+        Duration::from_secs(5),
+        || {
+            test.flashblocks.get_pending_blocks().as_ref().is_some_and(|pending| {
+                pending.earliest_block_number() == 2 && pending.parent_hash() == block_one.hash()
+            })
+        },
+        "pending snapshot should rebase onto canonical block 1",
+    )
+    .await;
+
+    let pending = test.flashblocks.get_pending_blocks();
+    let pending = pending.as_ref().expect("pending should remain after rebase");
+    assert_eq!(pending.latest_block_number(), 2);
+    assert_eq!(pending.earliest_block_number(), 2);
+}
+
+#[tokio::test]
+async fn test_failed_rebase_clears_pending_and_waits_for_recovery_resume() {
+    let mut test = FlashblocksBuilderTestHarness::new().await;
+    let genesis_hash = test.node.latest_block().hash();
+    let block_one = test.new_canonical_block_without_processing(vec![]).await;
+    let block_one_number = block_one.number;
+    let block_one_hash = block_one.hash();
+
+    // Rebuilding this suffix requires canonical block 2, which the provider does not have. This
+    // models a failed rebase while an old pending snapshot is still published.
+    let suffix = FlashblockBuilder::new_base(&test)
+        .with_canonical_block_number(block_one_number + 1)
+        .build();
+    assert_eq!(suffix.metadata.block_number, block_one_number + 2);
+    test.flashblocks.set_pending_blocks_for_testing(Some(pending_spanning(
+        block_one_number,
+        block_one_number + 2,
+        genesis_hash,
+        suffix,
+    )));
+
+    test.flashblocks.on_canonical_block_received(block_one);
+    wait_until(
+        Duration::from_secs(5),
+        || test.flashblocks.get_pending_blocks().is_none(),
+        "a failed rebase must clear the previously published pending snapshot",
+    )
+    .await;
+
+    let resume = FlashblockBuilder::new_base(&test).build();
+    assert_eq!(resume.metadata.block_number, block_one_number + 1);
+    assert_eq!(resume.base.as_ref().map(|base| base.parent_hash), Some(block_one_hash));
+    test.flashblocks.on_flashblock_received(resume);
+
+    wait_until(
+        Duration::from_secs(5),
+        || {
+            test.flashblocks.get_pending_blocks().as_ref().is_some_and(|pending| {
+                pending.earliest_block_number() == block_one_number + 1
+                    && pending.latest_block_number() == block_one_number + 1
+                    && pending.parent_hash() == block_one_hash
+            })
+        },
+        "the processor must remain in recovery until a matching current flashblock arrives",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_canonical_catch_up_without_future_flashblocks_clears_pending() {
+    let mut test = FlashblocksBuilderTestHarness::new().await;
+    let genesis_hash = test.node.latest_block().hash();
+    let block_one = test.new_canonical_block_without_processing(vec![]).await;
+
+    test.flashblocks.set_pending_blocks_for_testing(Some(pending_at_block(1, genesis_hash)));
+    test.flashblocks.on_canonical_block_received(block_one);
+    wait_until(
+        Duration::from_secs(5),
+        || test.flashblocks.get_pending_blocks().is_none(),
+        "pending should clear when canonical catches up with no future flashblocks",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_canonical_latest_mismatch_waits_for_matching_recovery_resume() {
+    let mut test = FlashblocksBuilderTestHarness::new().await;
+    test.send_flashblock(FlashblockBuilder::new_base(&test).build()).await;
+
+    let block_one = test.new_canonical_block_without_processing(vec![]).await;
+    let block_one_number = block_one.number;
+    let block_one_hash = block_one.hash();
+    test.flashblocks.on_canonical_block_received(block_one);
+    wait_until(
+        Duration::from_secs(5),
+        || test.flashblocks.get_pending_blocks().is_none(),
+        "a latest-block transaction mismatch must clear pending state",
+    )
+    .await;
+
+    let mut wrong_parent = FlashblockBuilder::new_base(&test).build();
+    wrong_parent
+        .base
+        .as_mut()
+        .expect("index-zero flashblock must have a base payload")
+        .parent_hash = B256::repeat_byte(0x24);
+    test.flashblocks.on_flashblock_received(wrong_parent);
+
+    let resume = FlashblockBuilder::new_base(&test).build();
+    assert_eq!(resume.metadata.block_number, block_one_number + 1);
+    assert_eq!(resume.base.as_ref().map(|base| base.parent_hash), Some(block_one_hash));
+    test.flashblocks.on_flashblock_received(resume);
+
+    wait_until(
+        Duration::from_secs(5),
+        || {
+            test.flashblocks.get_pending_blocks().as_ref().is_some_and(|pending| {
+                pending.earliest_block_number() == block_one_number + 1
+                    && pending.latest_block_number() == block_one_number + 1
+                    && pending.parent_hash() == block_one_hash
+            })
+        },
+        "latest-block mismatch recovery must reject a wrong-parent flashblock before resuming",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_untracked_older_canonical_does_not_false_reorg() {
+    let test = FlashblocksBuilderTestHarness::new().await;
+    let genesis = test.node.latest_block();
+    assert_eq!(genesis.number, 0);
+
+    let suffix = FlashblockBuilder::new_base(&test).with_canonical_block_number(2).build();
+    test.flashblocks.set_pending_blocks_for_testing(Some(pending_spanning(
+        2,
+        3,
+        genesis.hash(),
+        suffix,
+    )));
+    assert!(test.flashblocks.get_pending_blocks().as_ref().is_some());
+
+    test.flashblocks.on_canonical_block_received(genesis);
+    sleep(Duration::from_millis(100)).await;
+
+    let pending = test.flashblocks.get_pending_blocks();
+    let pending =
+        pending.as_ref().expect("untracked genesis must not clear pending via empty-vector reorg");
+    assert_eq!(pending.earliest_block_number(), 2);
+    assert_eq!(pending.latest_block_number(), 3);
+}
+
+#[tokio::test]
+async fn test_anchor_hash_mismatch_waits_for_matching_recovery_resume() {
+    let test = FlashblocksBuilderTestHarness::new().await;
+    let genesis = test.node.latest_block();
+    let genesis_number = genesis.number;
+    let genesis_hash = genesis.hash();
+
+    let suffix = FlashblockBuilder::new_base(&test).build();
+    test.flashblocks.set_pending_blocks_for_testing(Some(pending_spanning(
+        1,
+        2,
+        B256::repeat_byte(0x42),
+        suffix,
+    )));
+
+    test.flashblocks.on_canonical_block_received(genesis);
+    wait_until(
+        Duration::from_secs(5),
+        || test.flashblocks.get_pending_blocks().is_none(),
+        "anchor hash mismatch must clear pending",
+    )
+    .await;
+
+    let mut wrong_parent = FlashblockBuilder::new_base(&test).build();
+    wrong_parent
+        .base
+        .as_mut()
+        .expect("index-zero flashblock must have a base payload")
+        .parent_hash = B256::repeat_byte(0x24);
+    test.flashblocks.on_flashblock_received(wrong_parent);
+
+    let resume = FlashblockBuilder::new_base(&test).build();
+    assert_eq!(resume.metadata.block_number, genesis_number + 1);
+    assert_eq!(resume.base.as_ref().map(|base| base.parent_hash), Some(genesis_hash));
+    test.flashblocks.on_flashblock_received(resume);
+
+    wait_until(
+        Duration::from_secs(5),
+        || {
+            test.flashblocks.get_pending_blocks().as_ref().is_some_and(|pending| {
+                pending.earliest_block_number() == genesis_number + 1
+                    && pending.latest_block_number() == genesis_number + 1
+                    && pending.parent_hash() == genesis_hash
+            })
+        },
+        "anchor mismatch recovery must reject a wrong-parent flashblock before accepting a matching resume",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_stale_queue_skips_historical_work_and_resumes_at_current_index_zero() {
+    let mut test = FlashblocksBuilderTestHarness::new().await;
+
+    test.send_flashblock(FlashblockBuilder::new_base(&test).build()).await;
+    assert_eq!(
+        test.flashblocks
+            .get_pending_blocks()
+            .as_ref()
+            .expect("pending after first flashblock")
+            .latest_block_number(),
+        1
+    );
+
+    let mut stale_flashblocks = Vec::new();
+    for parent in 1..8 {
+        stale_flashblocks
+            .push(FlashblockBuilder::new_base(&test).with_canonical_block_number(parent).build());
+    }
+
+    let mut stale_canonicals = Vec::new();
+    for _ in 0..8 {
+        stale_canonicals.push(test.new_canonical_block_without_processing(vec![]).await);
+    }
+    let best = test.node.latest_block();
+    assert_eq!(best.number, 8);
+
+    for block in stale_canonicals {
+        test.flashblocks.on_canonical_block_received(block);
+    }
+    for flashblock in stale_flashblocks {
+        test.flashblocks.on_flashblock_received(flashblock);
+    }
+
+    let resume = FlashblockBuilder::new_base(&test).build();
+    assert_eq!(resume.index, 0);
+    assert_eq!(resume.metadata.block_number, best.number + 1);
+    assert_eq!(resume.base.as_ref().map(|base| base.parent_hash), Some(best.hash()));
+    test.flashblocks.on_flashblock_received(resume);
+
+    wait_until(
+        Duration::from_secs(5),
+        || {
+            test.flashblocks.get_pending_blocks().as_ref().is_some_and(|pending| {
+                pending.latest_block_number() == best.number + 1
+                    && pending.earliest_block_number() == best.number + 1
+                    && pending.parent_hash() == best.hash()
+            })
+        },
+        "processor should skip the stale queue and resume at the current index-0 flashblock",
+    )
+    .await;
 }

--- a/crates/execution/flashblocks/src/cache.rs
+++ b/crates/execution/flashblocks/src/cache.rs
@@ -79,6 +79,11 @@ impl FlashblockCache {
         self.entries.retain(|&bn, _| bn > block_number);
     }
 
+    /// Returns the latest canonical block number observed by this cache.
+    pub const fn latest_canonical_number(&self) -> Option<BlockNumber> {
+        self.latest_canonical
+    }
+
     /// Returns the number of distinct block numbers currently cached.
     pub fn len(&self) -> usize {
         self.entries.len()

--- a/crates/execution/flashblocks/src/config.rs
+++ b/crates/execution/flashblocks/src/config.rs
@@ -9,7 +9,8 @@ use crate::FlashblocksState;
 pub struct FlashblocksConfig {
     /// The websocket endpoint that streams flashblock updates.
     pub websocket_url: Url,
-    /// Maximum number of pending flashblocks to retain in memory.
+    /// Deprecated and ignored. Pending flashblocks are rebased onto the current canonical tip.
+    /// Kept so existing `FlashblocksConfig::new` call sites remain source-compatible.
     pub max_pending_blocks_depth: u64,
     /// Interval between upstream websocket ping frames.
     pub subscriber_ping_interval: Duration,

--- a/crates/execution/flashblocks/src/metrics.rs
+++ b/crates/execution/flashblocks/src/metrics.rs
@@ -20,6 +20,10 @@ base_metrics::define_metrics! {
     pending_clear_catchup: counter,
     #[describe("Number of times pending snapshot was cleared because of reorg")]
     pending_clear_reorg: counter,
+    #[describe("Number of queued flashblock or canonical events skipped as stale versus current tip")]
+    pending_stale_events_skipped: counter,
+    #[describe("Number of times the flashblock processor entered stale-queue recovery")]
+    pending_queue_recovery: counter,
     #[describe("Pending snapshot flashblock index (current)")]
     pending_snapshot_fb_index: gauge,
     #[describe("Pending snapshot block number (current)")]

--- a/crates/execution/flashblocks/src/pending_blocks.rs
+++ b/crates/execution/flashblocks/src/pending_blocks.rs
@@ -428,6 +428,17 @@ impl PendingBlocks {
         BlockNumberOrTag::Number(self.earliest_header.number - 1)
     }
 
+    /// Returns `true` when this snapshot is pending state built directly on canonical `number`/`hash`.
+    ///
+    /// Used by `base_meterBundle` to ignore stale or reorged pending overlays before any historical
+    /// state lookup.
+    #[inline]
+    pub fn is_based_on_canonical(&self, number: BlockNumber, hash: B256) -> bool {
+        matches!(self.canonical_block_number(), BlockNumberOrTag::Number(n) if n == number)
+            && self.parent_hash() == hash
+            && self.latest_block_number() > number
+    }
+
     /// Returns the earliest block number in the pending state.
     #[inline]
     pub fn earliest_block_number(&self) -> BlockNumber {
@@ -1593,5 +1604,22 @@ mod tests {
 
         assert_eq!(txs.len(), 1);
         assert_eq!(txs[0].transaction.tx_hash(), hash_a);
+    }
+
+    #[test]
+    fn is_based_on_canonical_requires_matching_tip_and_future_latest() {
+        let parent = B256::repeat_byte(0x11);
+        let mut builder = PendingBlocksBuilder::new();
+        builder.with_header(Sealed::new_unchecked(
+            Header { number: 2, parent_hash: parent, ..Default::default() },
+            B256::ZERO,
+        ));
+        builder.with_flashblocks([test_flashblock_for_block(2)]);
+        let pending = builder.build().expect("build should succeed");
+
+        assert!(pending.is_based_on_canonical(1, parent));
+        assert!(!pending.is_based_on_canonical(1, B256::repeat_byte(0x22)));
+        assert!(!pending.is_based_on_canonical(0, parent));
+        assert!(!pending.is_based_on_canonical(2, parent));
     }
 }

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -89,15 +89,14 @@ impl StateUpdate {
         }
     }
 
-    fn has_wrong_parent_at_tip(&self, best_number: u64, best_hash: B256) -> bool {
-        match self {
-            Self::Flashblock(flashblock) => {
-                self.pending_anchor_number() == best_number
-                    && flashblock.index == 0
-                    && flashblock.base.as_ref().is_none_or(|base| base.parent_hash != best_hash)
-            }
-            Self::Canonical(_) => false,
-        }
+    fn flashblock_has_wrong_parent_at_tip(
+        flashblock: &Flashblock,
+        best_number: u64,
+        best_hash: B256,
+    ) -> bool {
+        flashblock.metadata.block_number.saturating_sub(1) == best_number
+            && flashblock.index == 0
+            && flashblock.base.as_ref().is_none_or(|base| base.parent_hash != best_hash)
     }
 
     fn is_stale_against(&self, best_number: u64, best_hash: B256) -> bool {
@@ -107,7 +106,9 @@ impl StateUpdate {
 
         match self {
             Self::Canonical(block) => block.number == best_number && block.hash() != best_hash,
-            Self::Flashblock(_) => self.has_wrong_parent_at_tip(best_number, best_hash),
+            Self::Flashblock(flashblock) => {
+                Self::flashblock_has_wrong_parent_at_tip(flashblock, best_number, best_hash)
+            }
         }
     }
 
@@ -123,10 +124,24 @@ impl StateUpdate {
         };
 
         if recovering {
-            return if self.is_recovery_resume(best_number, best_hash) {
-                UpdatePreflight::ResumeRecovery
-            } else {
-                UpdatePreflight::Skip
+            if self.is_recovery_resume(best_number, best_hash) {
+                return UpdatePreflight::ResumeRecovery;
+            }
+
+            return match self {
+                // Canonical notifications are emitted after their tip is visible to the provider.
+                // Process this one to advance and replay the bounded cache.
+                Self::Canonical(block)
+                    if block.number == best_number && block.hash() == best_hash =>
+                {
+                    UpdatePreflight::Process
+                }
+                // A future flashblock cannot execute without its canonical parent, but
+                // `apply_flashblock` stores cacheable payloads until that parent arrives.
+                Self::Flashblock(_) if self.pending_anchor_number() > best_number => {
+                    UpdatePreflight::Process
+                }
+                _ => UpdatePreflight::Skip,
             };
         }
 
@@ -284,8 +299,12 @@ where
             UpdatePreflight::Process => Some((best, false)),
             UpdatePreflight::ResumeRecovery => Some((best, true)),
             UpdatePreflight::Skip => {
-                if update.has_wrong_parent_at_tip(best.number(), best.hash())
-                    && let StateUpdate::Flashblock(flashblock) = update
+                if let StateUpdate::Flashblock(flashblock) = update
+                    && StateUpdate::flashblock_has_wrong_parent_at_tip(
+                        flashblock,
+                        best.number(),
+                        best.hash(),
+                    )
                 {
                     *self
                         .quarantined_flashblock_block
@@ -346,8 +365,7 @@ where
                                         cached_count = cached.len(),
                                     );
                                     for flashblock in cached {
-                                        let cached_update =
-                                            StateUpdate::Flashblock(flashblock.clone());
+                                        let cached_update = StateUpdate::Flashblock(flashblock);
                                         let Some((_, cached_resuming_recovery)) = self
                                             .preflight_update(&cached_update, &mut recovering)
                                             .await
@@ -356,6 +374,10 @@ where
                                                 break;
                                             }
                                             continue;
+                                        };
+                                        let StateUpdate::Flashblock(flashblock) = cached_update
+                                        else {
+                                            unreachable!("cached update is always a flashblock");
                                         };
 
                                         let fb_prev = self.pending_blocks.load_full();
@@ -1115,6 +1137,7 @@ mod tests {
     use base_common_flashblocks::{
         ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, Metadata,
     };
+    use reth_primitives_traits::SealedBlock;
 
     use super::*;
 
@@ -1204,6 +1227,37 @@ mod tests {
         assert_eq!(
             resume.preflight(Some((best, best_hash)), false, false, true),
             UpdatePreflight::ResumeRecovery
+        );
+    }
+
+    #[test]
+    fn recovery_preflight_admits_future_flashblocks_for_caching() {
+        let best = 100;
+        let best_hash = B256::repeat_byte(0xAB);
+        let future = StateUpdate::Flashblock(flashblock(102, 0, B256::repeat_byte(0xCD)));
+
+        assert_eq!(
+            future.preflight(Some((best, best_hash)), false, false, true),
+            UpdatePreflight::Process,
+            "the caller must cache a future flashblock until its parent becomes canonical"
+        );
+    }
+
+    #[test]
+    fn recovery_preflight_processes_current_canonical_for_cache_replay() {
+        let best = 100;
+        let block = BaseBlock {
+            header: Header { number: best, ..Default::default() },
+            body: Default::default(),
+        };
+        let block = RecoveredBlock::new_sealed(SealedBlock::seal_slow(block), Vec::new());
+        let best_hash = block.hash();
+        let update = StateUpdate::Canonical(block);
+
+        assert_eq!(
+            update.preflight(Some((best, best_hash)), false, false, true),
+            UpdatePreflight::Process,
+            "the current canonical event must advance and replay the cache during recovery"
         );
     }
 

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -7,12 +7,12 @@ use std::{
 };
 
 use alloy_consensus::{
-    Block, BlockBody, Header,
+    Block, BlockBody, BlockHeader, Header,
     transaction::{Recovered, SignerRecoverable},
 };
 use alloy_eips::{BlockNumberOrTag, Decodable2718};
 use alloy_network::TransactionResponse;
-use alloy_primitives::{Address, BlockNumber};
+use alloy_primitives::{Address, B256, BlockNumber};
 use alloy_rpc_types_eth::state::StateOverride;
 use arc_swap::ArcSwapOption;
 use base_common_chains::Upgrades;
@@ -22,7 +22,7 @@ use base_execution_evm::{BaseEvmConfig, BaseNextBlockEnvAttributes};
 use rayon::prelude::*;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_evm::ConfigureEvm;
-use reth_primitives_traits::RecoveredBlock;
+use reth_primitives_traits::{RecoveredBlock, SealedHeader};
 use reth_provider::{BlockReaderIdExt, StateProviderBox, StateProviderFactory};
 use reth_revm::{State, database::StateProviderDatabase};
 use revm_database::states::bundle_state::BundleRetention;
@@ -56,16 +56,109 @@ pub enum StateUpdate {
     Flashblock(Flashblock),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UpdatePreflight {
+    /// The update is safe to process.
+    Process,
+    /// The update is a valid recovery-resume flashblock.
+    ResumeRecovery,
+    /// The update cannot be safely processed now.
+    Skip,
+    /// Clear state and wait for a recovery-resume flashblock.
+    EnterRecovery,
+}
+
+impl StateUpdate {
+    /// Canonical block `N` is anchored at `N`; flashblock `B` is anchored at `B - 1`.
+    pub fn pending_anchor_number(&self) -> u64 {
+        match self {
+            Self::Canonical(block) => block.number,
+            Self::Flashblock(flashblock) => flashblock.metadata.block_number.saturating_sub(1),
+        }
+    }
+
+    /// Returns `true` when this is an index-0 flashblock for `best + 1` whose parent matches `best`.
+    pub fn is_recovery_resume(&self, best_number: u64, best_hash: B256) -> bool {
+        match self {
+            Self::Flashblock(flashblock) => {
+                flashblock.index == 0
+                    && flashblock.metadata.block_number == best_number.saturating_add(1)
+                    && flashblock.base.as_ref().is_some_and(|base| base.parent_hash == best_hash)
+            }
+            Self::Canonical(_) => false,
+        }
+    }
+
+    fn has_wrong_parent_at_tip(&self, best_number: u64, best_hash: B256) -> bool {
+        match self {
+            Self::Flashblock(flashblock) => {
+                self.pending_anchor_number() == best_number
+                    && flashblock.index == 0
+                    && flashblock.base.as_ref().is_none_or(|base| base.parent_hash != best_hash)
+            }
+            Self::Canonical(_) => false,
+        }
+    }
+
+    fn is_stale_against(&self, best_number: u64, best_hash: B256) -> bool {
+        if self.pending_anchor_number() < best_number {
+            return true;
+        }
+
+        match self {
+            Self::Canonical(block) => block.number == best_number && block.hash() != best_hash,
+            Self::Flashblock(_) => self.has_wrong_parent_at_tip(best_number, best_hash),
+        }
+    }
+
+    fn preflight(
+        &self,
+        best: Option<(u64, B256)>,
+        has_pending: bool,
+        pending_is_based_on_best: bool,
+        recovering: bool,
+    ) -> UpdatePreflight {
+        let Some((best_number, best_hash)) = best else {
+            return UpdatePreflight::Skip;
+        };
+
+        if recovering {
+            return if self.is_recovery_resume(best_number, best_hash) {
+                UpdatePreflight::ResumeRecovery
+            } else {
+                UpdatePreflight::Skip
+            };
+        }
+
+        // A canonical update at the tip is what rebases pending state. A flashblock cannot safely
+        // extend a snapshot that is not based on the current canonical tip.
+        if matches!(self, Self::Flashblock(_)) && has_pending && !pending_is_based_on_best {
+            return UpdatePreflight::EnterRecovery;
+        }
+
+        if self.is_stale_against(best_number, best_hash) {
+            return if pending_is_based_on_best {
+                // A late event must not wipe a pending window that is already based on the tip.
+                UpdatePreflight::Skip
+            } else {
+                UpdatePreflight::EnterRecovery
+            };
+        }
+
+        UpdatePreflight::Process
+    }
+}
+
 /// Processes flashblocks and canonical blocks to keep pending state updated.
 #[derive(Debug)]
 pub struct StateProcessor<Client> {
     rx: Arc<Mutex<UnboundedReceiver<StateUpdate>>>,
     pending_blocks: Arc<ArcSwapOption<PendingBlocks>>,
-    max_depth: u64,
     client: Client,
     sender: Sender<Arc<PendingBlocks>>,
     cache: Arc<Mutex<FlashblockCache>>,
     live_state: StdMutex<Option<LivePendingState>>,
+    quarantined_flashblock_block: StdMutex<Option<BlockNumber>>,
 }
 
 impl<Client> StateProcessor<Client>
@@ -108,7 +201,6 @@ where
     pub fn new(
         client: Client,
         pending_blocks: Arc<ArcSwapOption<PendingBlocks>>,
-        max_depth: u64,
         rx: Arc<Mutex<UnboundedReceiver<StateUpdate>>>,
         sender: Sender<Arc<PendingBlocks>>,
     ) -> Self {
@@ -119,44 +211,175 @@ where
         Self {
             pending_blocks,
             client,
-            max_depth,
             rx,
             sender,
             cache: Arc::new(Mutex::new(cache)),
             live_state: StdMutex::new(None),
+            quarantined_flashblock_block: StdMutex::new(None),
+        }
+    }
+
+    fn best_canonical_header(&self) -> Option<SealedHeader> {
+        self.client.sealed_header_by_number_or_tag(BlockNumberOrTag::Latest).ok().flatten()
+    }
+
+    async fn enter_recovery(&self, best_number: u64) {
+        warn!(best = best_number, message = "flashblock processor entering recovery");
+        Metrics::pending_queue_recovery().increment(1);
+        self.pending_blocks.swap(None);
+        self.clear_live_state();
+        *self
+            .quarantined_flashblock_block
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+        *self.cache.lock().await = FlashblockCache::new(best_number);
+    }
+
+    fn is_quarantined_flashblock(&self, update: &StateUpdate, best: &SealedHeader) -> bool {
+        let StateUpdate::Flashblock(flashblock) = update else {
+            return false;
+        };
+        let mut quarantined = self
+            .quarantined_flashblock_block
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if *quarantined != Some(flashblock.metadata.block_number) {
+            return false;
+        }
+
+        if update.is_recovery_resume(best.number(), best.hash()) {
+            *quarantined = None;
+            false
+        } else {
+            true
+        }
+    }
+
+    async fn preflight_update(
+        &self,
+        update: &StateUpdate,
+        recovering: &mut bool,
+    ) -> Option<(SealedHeader, bool)> {
+        let Some(best) = self.best_canonical_header() else {
+            Metrics::pending_stale_events_skipped().increment(1);
+            return None;
+        };
+
+        if self.is_quarantined_flashblock(update, &best) {
+            Metrics::pending_stale_events_skipped().increment(1);
+            return None;
+        }
+
+        let pending_blocks = self.pending_blocks.load_full();
+        let preflight = update.preflight(
+            Some((best.number(), best.hash())),
+            pending_blocks.is_some(),
+            pending_blocks
+                .as_ref()
+                .is_some_and(|pending| pending.is_based_on_canonical(best.number(), best.hash())),
+            *recovering,
+        );
+
+        match preflight {
+            UpdatePreflight::Process => Some((best, false)),
+            UpdatePreflight::ResumeRecovery => Some((best, true)),
+            UpdatePreflight::Skip => {
+                if update.has_wrong_parent_at_tip(best.number(), best.hash())
+                    && let StateUpdate::Flashblock(flashblock) = update
+                {
+                    *self
+                        .quarantined_flashblock_block
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner()) =
+                        Some(flashblock.metadata.block_number);
+                }
+                Metrics::pending_stale_events_skipped().increment(1);
+                None
+            }
+            UpdatePreflight::EnterRecovery => {
+                self.enter_recovery(best.number()).await;
+                *recovering = true;
+                Metrics::pending_stale_events_skipped().increment(1);
+                None
+            }
         }
     }
 
     /// Processes updates from the queue until the channel closes.
     pub async fn start(&self) {
+        let mut recovering = false;
         while let Some(update) = self.rx.lock().await.recv().await {
+            let Some((best, resuming_recovery)) =
+                self.preflight_update(&update, &mut recovering).await
+            else {
+                continue;
+            };
+
             let prev_pending_blocks = self.pending_blocks.load_full();
             match update {
                 StateUpdate::Canonical(block) => {
                     debug!(message = "processing canonical block", block_number = block.number);
                     match self.process_canonical_block(prev_pending_blocks, &block) {
-                        Ok(new_pending_blocks) => {
+                        Ok((new_pending_blocks, requires_recovery)) => {
+                            if requires_recovery {
+                                self.enter_recovery(best.number()).await;
+                                recovering = true;
+                                continue;
+                            }
+
                             self.pending_blocks.swap(new_pending_blocks);
 
                             let mut cache = self.cache.lock().await;
-                            cache.update_canonical(block.number);
-                            let cached = cache.drain(block.number + 1);
-                            drop(cache);
+                            let should_advance = cache
+                                .latest_canonical_number()
+                                .is_none_or(|canonical| block.number >= canonical);
+                            if should_advance {
+                                cache.update_canonical(block.number);
+                                let cached = cache.drain(block.number + 1);
+                                drop(cache);
 
-                            if !cached.is_empty() {
-                                debug!(
-                                    message = "replaying cached flashblocks after canonical block",
-                                    canonical_block = block.number,
-                                    cached_count = cached.len(),
-                                );
-                                for flashblock in cached {
-                                    let fb_prev = self.pending_blocks.load_full();
-                                    self.apply_flashblock(fb_prev, flashblock).await;
+                                if !cached.is_empty() {
+                                    debug!(
+                                        message =
+                                            "replaying cached flashblocks after canonical block",
+                                        canonical_block = block.number,
+                                        cached_count = cached.len(),
+                                    );
+                                    for flashblock in cached {
+                                        let cached_update =
+                                            StateUpdate::Flashblock(flashblock.clone());
+                                        let Some((_, cached_resuming_recovery)) = self
+                                            .preflight_update(&cached_update, &mut recovering)
+                                            .await
+                                        else {
+                                            if recovering {
+                                                break;
+                                            }
+                                            continue;
+                                        };
+
+                                        let fb_prev = self.pending_blocks.load_full();
+                                        let applied = self
+                                            .apply_flashblock(
+                                                fb_prev,
+                                                flashblock,
+                                                !cached_resuming_recovery,
+                                            )
+                                            .await;
+                                        if cached_resuming_recovery && applied {
+                                            recovering = false;
+                                        }
+                                        if recovering {
+                                            break;
+                                        }
+                                    }
                                 }
                             }
                         }
                         Err(e) => {
                             error!(message = "could not process canonical block", error = %e);
+                            self.enter_recovery(best.number()).await;
+                            recovering = true;
                         }
                     }
                 }
@@ -166,7 +389,12 @@ where
                         block_number = flashblock.metadata.block_number,
                         flashblock_index = flashblock.index
                     );
-                    self.apply_flashblock(prev_pending_blocks, flashblock).await;
+                    let applied = self
+                        .apply_flashblock(prev_pending_blocks, flashblock, !resuming_recovery)
+                        .await;
+                    if resuming_recovery && applied {
+                        recovering = false;
+                    }
                 }
             }
         }
@@ -176,25 +404,28 @@ where
         &self,
         prev_pending_blocks: Option<Arc<PendingBlocks>>,
         flashblock: Flashblock,
-    ) {
+        cache_on_missing_canonical_header: bool,
+    ) -> bool {
         let start_time = Instant::now();
         match self.process_flashblock(prev_pending_blocks, &flashblock) {
             Ok(new_pending_blocks) => {
+                let applied = new_pending_blocks.is_some();
                 if let Some(ref pb) = new_pending_blocks {
                     _ = self.sender.send(Arc::clone(pb));
                 }
                 self.pending_blocks.swap(new_pending_blocks);
                 Metrics::block_processing_duration().record(start_time.elapsed());
+                applied
             }
             Err(e) => {
                 match e {
                     StateProcessorError::Provider(ProviderError::MissingCanonicalHeader {
                         ..
-                    }) => {
+                    }) if cache_on_missing_canonical_header => {
                         let inserted = self.cache.lock().await.insert(flashblock);
                         if inserted {
                             debug!(message = "cached flashblock pending canonical block", error = %e);
-                            return;
+                            return false;
                         }
                     }
                     StateProcessorError::MissingFirstFlashblock => {
@@ -207,10 +438,10 @@ where
                             )
                             && cache.insert(flashblock)
                         {
-                            return;
+                            return false;
                         }
                         // we should ignore this error since it doesn't necessarily indicate a problem
-                        return;
+                        return false;
                     }
                     _ => {}
                 }
@@ -223,6 +454,7 @@ where
                     error!(message = "could not process Flashblock", error = %e);
                     Metrics::block_processing_error().increment(1);
                 }
+                false
             }
         }
     }
@@ -232,13 +464,13 @@ where
         &self,
         prev_pending_blocks: Option<Arc<PendingBlocks>>,
         block: &RecoveredBlock<BaseBlock>,
-    ) -> Result<Option<Arc<PendingBlocks>>> {
+    ) -> Result<(Option<Arc<PendingBlocks>>, bool)> {
         let pending_blocks = match &prev_pending_blocks {
             Some(pb) => pb,
             None => {
                 debug!(message = "no pending state to update with canonical block, skipping");
                 self.clear_live_state();
-                return Ok(None);
+                return Ok((None, false));
             }
         };
 
@@ -248,28 +480,61 @@ where
         Metrics::flashblocks_in_block().record(num_flashblocks_for_canon as f64);
         Metrics::pending_snapshot_height().set(pending_blocks.latest_block_number() as f64);
 
-        // Check for reorg by comparing transaction sets
-        let tracked_txns = pending_blocks.get_transactions_for_block(block.number);
-        let tracked_txn_hashes: Vec<_> = tracked_txns.map(|tx| tx.tx_hash()).collect();
-        let block_txn_hashes: Vec<_> = block.body().transactions().map(|tx| tx.tx_hash()).collect();
+        let earliest = pending_blocks.earliest_block_number();
+        let latest = pending_blocks.latest_block_number();
+        let anchor = earliest.saturating_sub(1);
+        let in_pending_interval = block.number >= earliest && block.number <= latest;
+        let is_pending_anchor = block.number == anchor;
 
-        let reorg_result = ReorgDetector::detect(&tracked_txn_hashes, &block_txn_hashes);
-        let reorg_detected = reorg_result.is_reorg();
+        // Only compare transaction sets for a block represented in pending. An untracked older
+        // canonical would otherwise compare against an empty vector and look like a reorg.
+        let reorg_detected = if in_pending_interval {
+            let tracked_txn_hashes: Vec<_> = pending_blocks
+                .get_transactions_for_block(block.number)
+                .map(|tx| tx.tx_hash())
+                .collect();
+            let block_txn_hashes: Vec<_> =
+                block.body().transactions().map(|tx| tx.tx_hash()).collect();
+            let reorg_result = ReorgDetector::detect(&tracked_txn_hashes, &block_txn_hashes);
+            if reorg_result.is_reorg() {
+                warn!(
+                    message = "reorg detected, clearing pending flashblocks",
+                    tracked_txn_hashes = ?tracked_txn_hashes,
+                    block_txn_hashes = ?block_txn_hashes,
+                );
+            }
+            reorg_result.is_reorg()
+        } else if is_pending_anchor {
+            let pending_parent = pending_blocks.parent_hash();
+            let canonical_hash = block.hash();
+            if pending_parent != canonical_hash {
+                warn!(
+                    message = "pending anchor hash mismatch, clearing pending flashblocks",
+                    pending_parent_hash = %pending_parent,
+                    canonical_hash = %canonical_hash,
+                    canonical_block = block.number,
+                );
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
 
-        // Determine the reconciliation strategy
         let strategy = CanonicalBlockReconciler::reconcile(
-            Some(pending_blocks.earliest_block_number()),
-            Some(pending_blocks.latest_block_number()),
+            Some(earliest),
+            Some(latest),
             block.number,
-            self.max_depth,
             reorg_detected,
         );
 
-        match strategy {
+        let requires_recovery = matches!(strategy, ReconciliationStrategy::HandleReorg);
+        let pending_blocks = match strategy {
             ReconciliationStrategy::CatchUp => {
                 debug!(
                     message = "pending snapshot cleared because canonical caught up",
-                    latest_pending_block = pending_blocks.latest_block_number(),
+                    latest_pending_block = latest,
                     canonical_block = block.number,
                 );
                 Metrics::pending_clear_catchup().increment(1);
@@ -279,47 +544,44 @@ where
                 Ok(None)
             }
             ReconciliationStrategy::HandleReorg => {
-                warn!(
-                    message = "reorg detected, recomputing pending flashblocks going ahead of reorg",
-                    tracked_txn_hashes = ?tracked_txn_hashes,
-                    block_txn_hashes = ?block_txn_hashes,
-                );
                 Metrics::pending_clear_reorg().increment(1);
-
-                // If there is a reorg, we re-process all future flashblocks without reusing the existing pending state
-                flashblocks.retain(|flashblock| flashblock.metadata.block_number > block.number);
-                self.build_pending_state(None, &flashblocks)
+                self.clear_live_state();
+                Ok(None)
             }
-            ReconciliationStrategy::DepthLimitExceeded { depth, max_depth } => {
-                debug!(
-                    message = "pending blocks depth exceeds max depth, resetting pending blocks",
-                    pending_blocks_depth = depth,
-                    max_depth = max_depth,
-                );
-
+            ReconciliationStrategy::Rebase => {
                 flashblocks.retain(|flashblock| flashblock.metadata.block_number > block.number);
-                self.build_pending_state(None, &flashblocks)
+                if flashblocks.is_empty() {
+                    Metrics::pending_clear_catchup().increment(1);
+                    self.clear_live_state();
+                    Ok(None)
+                } else {
+                    debug!(
+                        message = "rebasing pending flashblocks onto canonical block",
+                        canonical_block = block.number,
+                        remaining_flashblocks = flashblocks.len(),
+                    );
+                    self.clear_live_state();
+                    self.build_pending_state(None, &flashblocks)
+                }
             }
-            ReconciliationStrategy::Continue => {
+            ReconciliationStrategy::VerifyAnchor | ReconciliationStrategy::IgnoreUntracked => {
                 debug!(
-                    message = "canonical block behind latest pending block, continuing with existing pending state",
-                    latest_pending_block = pending_blocks.latest_block_number(),
-                    earliest_pending_block = pending_blocks.earliest_block_number(),
+                    message = "canonical block does not require pending rebuild",
+                    latest_pending_block = latest,
+                    earliest_pending_block = earliest,
                     canonical_block = block.number,
-                    pending_txns_for_block = ?tracked_txn_hashes.len(),
-                    canonical_txns_for_block = ?block_txn_hashes.len(),
+                    strategy = ?strategy,
                 );
-                // If no reorg, we can continue building on top of the existing pending state
-                // NOTE: We do not retain specific flashblocks here to avoid losing track of our "earliest" pending block number
-                self.build_pending_state(prev_pending_blocks, &flashblocks)
+                Ok(prev_pending_blocks)
             }
             ReconciliationStrategy::NoPendingState => {
-                // This case is already handled above, but included for completeness
                 debug!(message = "no pending state to update with canonical block, skipping");
                 self.clear_live_state();
                 Ok(None)
             }
-        }
+        }?;
+
+        Ok((pending_blocks, requires_recovery))
     }
 
     #[instrument(
@@ -843,5 +1105,141 @@ where
         }
 
         self.publish_pending_blocks(pending_blocks_builder, db, state_overrides)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, B256};
+    use alloy_rpc_types_engine::PayloadId;
+    use base_common_flashblocks::{
+        ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, Metadata,
+    };
+
+    use super::*;
+
+    fn flashblock(block_number: u64, index: u64, parent_hash: B256) -> Flashblock {
+        Flashblock {
+            payload_id: PayloadId::default(),
+            index,
+            base: (index == 0).then_some(ExecutionPayloadBaseV1 {
+                parent_beacon_block_root: B256::ZERO,
+                parent_hash,
+                fee_recipient: Address::ZERO,
+                prev_randao: B256::ZERO,
+                block_number,
+                gas_limit: 30_000_000,
+                timestamp: 1_700_000_000,
+                extra_data: Default::default(),
+                base_fee_per_gas: Default::default(),
+            }),
+            diff: ExecutionPayloadFlashblockDeltaV1::default(),
+            metadata: Metadata::new(block_number),
+        }
+    }
+
+    #[test]
+    fn flashblock_anchor_is_parent_block() {
+        let update = StateUpdate::Flashblock(flashblock(101, 0, B256::ZERO));
+        assert_eq!(update.pending_anchor_number(), 100);
+        let genesis = StateUpdate::Flashblock(flashblock(0, 0, B256::ZERO));
+        assert_eq!(genesis.pending_anchor_number(), 0);
+    }
+
+    #[test]
+    fn recovery_resume_requires_index_zero_next_block_and_parent_hash() {
+        let best = 100;
+        let best_hash = B256::repeat_byte(0xAB);
+        let resume = StateUpdate::Flashblock(flashblock(101, 0, best_hash));
+        assert!(resume.is_recovery_resume(best, best_hash));
+        assert!(!resume.is_recovery_resume(best, B256::repeat_byte(0xCD)));
+        assert!(
+            !StateUpdate::Flashblock(flashblock(101, 1, best_hash))
+                .is_recovery_resume(best, best_hash)
+        );
+        assert!(
+            !StateUpdate::Flashblock(flashblock(102, 0, best_hash))
+                .is_recovery_resume(best, best_hash)
+        );
+        assert!(
+            !StateUpdate::Flashblock(flashblock(100, 0, best_hash))
+                .is_recovery_resume(best, best_hash)
+        );
+    }
+
+    #[test]
+    fn preflight_skips_when_the_canonical_tip_is_unavailable() {
+        let update = StateUpdate::Flashblock(flashblock(101, 0, B256::repeat_byte(0xAB)));
+
+        assert_eq!(
+            update.preflight(None, false, false, false),
+            UpdatePreflight::Skip,
+            "the processor must not execute work without a canonical-tip freshness check"
+        );
+    }
+
+    #[test]
+    fn preflight_enters_recovery_for_a_current_flashblock_with_an_old_pending_anchor() {
+        let best = 100;
+        let best_hash = B256::repeat_byte(0xAB);
+        let update = StateUpdate::Flashblock(flashblock(101, 0, best_hash));
+
+        assert_eq!(
+            update.preflight(Some((best, best_hash)), true, false, false),
+            UpdatePreflight::EnterRecovery
+        );
+    }
+
+    #[test]
+    fn recovery_preflight_only_admits_a_matching_resume_flashblock() {
+        let best = 100;
+        let best_hash = B256::repeat_byte(0xAB);
+        let wrong_parent = StateUpdate::Flashblock(flashblock(101, 0, B256::repeat_byte(0xCD)));
+        let resume = StateUpdate::Flashblock(flashblock(101, 0, best_hash));
+
+        assert_eq!(
+            wrong_parent.preflight(Some((best, best_hash)), false, false, true),
+            UpdatePreflight::Skip
+        );
+        assert_eq!(
+            resume.preflight(Some((best, best_hash)), false, false, true),
+            UpdatePreflight::ResumeRecovery
+        );
+    }
+
+    #[test]
+    fn preflight_enters_recovery_for_a_same_height_wrong_parent() {
+        let best = 100;
+        let best_hash = B256::repeat_byte(0xAB);
+        let wrong_parent = StateUpdate::Flashblock(flashblock(101, 0, B256::repeat_byte(0xCD)));
+
+        assert_eq!(
+            wrong_parent.preflight(Some((best, best_hash)), false, false, false),
+            UpdatePreflight::EnterRecovery
+        );
+    }
+
+    #[test]
+    fn preflight_drops_late_events_without_clearing_tip_aligned_pending() {
+        let best = 100;
+        let best_hash = B256::repeat_byte(0xAB);
+        let stale = StateUpdate::Flashblock(flashblock(100, 0, B256::repeat_byte(0xCD)));
+
+        assert_eq!(
+            stale.preflight(Some((best, best_hash)), true, true, false),
+            UpdatePreflight::Skip
+        );
+    }
+
+    #[test]
+    fn preflight_drops_a_same_height_wrong_parent_without_clearing_tip_aligned_pending() {
+        let best = 100;
+        let best_hash = B256::repeat_byte(0xAB);
+        let wrong_parent = StateUpdate::Flashblock(flashblock(101, 0, B256::repeat_byte(0xCD)));
+
+        assert_eq!(
+            wrong_parent.preflight(Some((best, best_hash)), true, true, false),
+            UpdatePreflight::Skip
+        );
     }
 }

--- a/crates/execution/flashblocks/src/state.rs
+++ b/crates/execution/flashblocks/src/state.rs
@@ -31,7 +31,6 @@ pub struct FlashblocksState {
     queue: mpsc::UnboundedSender<StateUpdate>,
     rx: Arc<Mutex<mpsc::UnboundedReceiver<StateUpdate>>>,
     flashblock_sender: Sender<Arc<PendingBlocks>>,
-    max_pending_blocks_depth: u64,
 }
 
 impl FlashblocksState {
@@ -39,18 +38,16 @@ impl FlashblocksState {
     ///
     /// The state is created without a client. Call [`start`](Self::start) with a client
     /// to spawn the state processor after the node is launched.
-    pub fn new(max_pending_blocks_depth: u64) -> Self {
+    ///
+    /// `max_pending_blocks_depth` is accepted for call-site compatibility and ignored: pending
+    /// state is rebased onto the current canonical tip instead of retaining a depth-limited
+    /// historical overlay.
+    pub fn new(_max_pending_blocks_depth: u64) -> Self {
         let (tx, rx) = mpsc::unbounded_channel::<StateUpdate>();
         let pending_blocks: Arc<ArcSwapOption<PendingBlocks>> = Arc::new(ArcSwapOption::new(None));
         let (flashblock_sender, _) = broadcast::channel(BUFFER_SIZE);
 
-        Self {
-            pending_blocks,
-            queue: tx,
-            rx: Arc::new(Mutex::new(rx)),
-            flashblock_sender,
-            max_pending_blocks_depth,
-        }
+        Self { pending_blocks, queue: tx, rx: Arc::new(Mutex::new(rx)), flashblock_sender }
     }
 
     /// Starts the flashblocks state processor with the given client.
@@ -68,7 +65,6 @@ impl FlashblocksState {
         let state_processor = StateProcessor::new(
             client,
             Arc::clone(&self.pending_blocks),
-            self.max_pending_blocks_depth,
             Arc::clone(&self.rx),
             self.flashblock_sender.clone(),
         );

--- a/crates/execution/flashblocks/src/validation.rs
+++ b/crates/execution/flashblocks/src/validation.rs
@@ -149,17 +149,15 @@ impl ReorgDetector {
 pub enum ReconciliationStrategy {
     /// Canonical caught up or passed pending (canonical >= latest pending). Clear pending state.
     CatchUp,
-    /// Reorg detected (tx mismatch). Rebuild pending from canonical.
+    /// Overlap transaction mismatch or pending-anchor hash mismatch. Clear all pending state.
     HandleReorg,
-    /// Pending too far ahead of canonical.
-    DepthLimitExceeded {
-        /// Current depth of pending blocks.
-        depth: u64,
-        /// Configured maximum depth.
-        max_depth: u64,
-    },
-    /// No issues - continue building on pending state.
-    Continue,
+    /// Canonical `N` is represented in pending and is still behind latest. Discard flashblocks at
+    /// or below `N` and rebuild the future suffix from canonical `N`.
+    Rebase,
+    /// Canonical `N` is the pending snapshot's anchor. Hash already verified; keep the snapshot.
+    VerifyAnchor,
+    /// Canonical `N` is older than the pending anchor. Do not treat an empty tx vector as a reorg.
+    IgnoreUntracked,
     /// No pending state exists (startup or after clear).
     NoPendingState,
 }
@@ -171,38 +169,47 @@ pub struct CanonicalBlockReconciler;
 impl CanonicalBlockReconciler {
     /// Returns the appropriate [`ReconciliationStrategy`] based on pending vs canonical state.
     ///
-    /// Priority: `NoPendingState` → `CatchUp` → `HandleReorg` → `DepthLimitExceeded` → `Continue`
+    /// Pending is always rebased onto the current canonical block when that block is represented in
+    /// the snapshot. `max_depth` is intentionally not consulted: cumulative pending spanning
+    /// already-canonicalized blocks is no longer retained.
+    ///
+    /// A reorg is honored only when canonical is the pending anchor or overlaps the pending
+    /// interval. Untracked older canonicals are ignored, and canonicals above the interval catch
+    /// up without consulting a reorg result.
     pub const fn reconcile(
         pending_earliest_block: Option<u64>,
         pending_latest_block: Option<u64>,
         canonical_block_number: u64,
-        max_depth: u64,
         reorg_detected: bool,
     ) -> ReconciliationStrategy {
-        // Check if pending state exists
         let (earliest, latest) = match (pending_earliest_block, pending_latest_block) {
             (Some(e), Some(l)) => (e, l),
             _ => return ReconciliationStrategy::NoPendingState,
         };
 
-        // Check if canonical has caught up or passed pending
-        if latest <= canonical_block_number {
+        let anchor = earliest.saturating_sub(1);
+        if canonical_block_number < anchor {
+            return ReconciliationStrategy::IgnoreUntracked;
+        }
+
+        if canonical_block_number > latest {
             return ReconciliationStrategy::CatchUp;
         }
 
-        // Check for reorg
         if reorg_detected {
             return ReconciliationStrategy::HandleReorg;
         }
 
-        // Check depth limit
-        let depth = canonical_block_number.saturating_sub(earliest);
-        if depth > max_depth {
-            return ReconciliationStrategy::DepthLimitExceeded { depth, max_depth };
+        if canonical_block_number == latest {
+            return ReconciliationStrategy::CatchUp;
         }
 
-        // No issues, continue building
-        ReconciliationStrategy::Continue
+        if canonical_block_number == anchor {
+            return ReconciliationStrategy::VerifyAnchor;
+        }
+
+        // `canonical_block_number` is in `[earliest, latest)`.
+        ReconciliationStrategy::Rebase
     }
 }
 
@@ -321,36 +328,37 @@ mod tests {
 
     #[rstest]
     // NoPendingState
-    #[case(None, None, 100, 10, false, ReconciliationStrategy::NoPendingState)]
-    #[case(Some(100), None, 100, 10, false, ReconciliationStrategy::NoPendingState)]
-    #[case(None, Some(100), 100, 10, false, ReconciliationStrategy::NoPendingState)]
+    #[case(None, None, 100, false, ReconciliationStrategy::NoPendingState)]
+    #[case(Some(100), None, 100, false, ReconciliationStrategy::NoPendingState)]
+    #[case(None, Some(100), 100, false, ReconciliationStrategy::NoPendingState)]
     // CatchUp: canonical >= latest pending
-    #[case(Some(100), Some(105), 105, 10, false, ReconciliationStrategy::CatchUp)]
-    #[case(Some(100), Some(105), 110, 10, false, ReconciliationStrategy::CatchUp)]
-    #[case(Some(100), Some(100), 100, 10, false, ReconciliationStrategy::CatchUp)]
-    #[case(Some(100), Some(105), 105, 10, true, ReconciliationStrategy::CatchUp)] // catchup > reorg priority
-    // HandleReorg
-    #[case(Some(100), Some(110), 102, 10, true, ReconciliationStrategy::HandleReorg)]
-    #[case(Some(100), Some(130), 120, 10, true, ReconciliationStrategy::HandleReorg)] // reorg > depth priority
-    // DepthLimitExceeded
-    #[case(Some(100), Some(120), 115, 10, false, ReconciliationStrategy::DepthLimitExceeded { depth: 15, max_depth: 10 })]
-    #[case(Some(100), Some(105), 101, 0, false, ReconciliationStrategy::DepthLimitExceeded { depth: 1, max_depth: 0 })]
-    // Continue
-    #[case(Some(100), Some(110), 105, 10, false, ReconciliationStrategy::Continue)]
-    #[case(Some(100), Some(120), 110, 10, false, ReconciliationStrategy::Continue)] // depth exactly at limit
-    #[case(Some(100), Some(105), 100, 10, false, ReconciliationStrategy::Continue)]
-    #[case(Some(100), Some(105), 100, 0, false, ReconciliationStrategy::Continue)] // zero depth ok with max_depth=0
-    #[case(Some(100), Some(100), 99, 10, false, ReconciliationStrategy::Continue)] // single pending block
+    #[case(Some(100), Some(105), 105, false, ReconciliationStrategy::CatchUp)]
+    #[case(Some(100), Some(105), 110, false, ReconciliationStrategy::CatchUp)]
+    #[case(Some(100), Some(100), 100, false, ReconciliationStrategy::CatchUp)]
+    #[case(Some(100), Some(105), 105, true, ReconciliationStrategy::HandleReorg)]
+    // Matching canonical N in [earliest, latest) rebases onto N
+    #[case(Some(100), Some(101), 100, false, ReconciliationStrategy::Rebase)]
+    #[case(Some(100), Some(110), 105, false, ReconciliationStrategy::Rebase)]
+    #[case(Some(100), Some(105), 100, false, ReconciliationStrategy::Rebase)]
+    // Untracked older canonical must not honor empty-vector reorg detection
+    #[case(Some(100), Some(105), 50, false, ReconciliationStrategy::IgnoreUntracked)]
+    #[case(Some(100), Some(105), 50, true, ReconciliationStrategy::IgnoreUntracked)]
+    #[case(Some(100), Some(105), 98, false, ReconciliationStrategy::IgnoreUntracked)]
+    // Anchor: N == earliest - 1
+    #[case(Some(100), Some(105), 99, false, ReconciliationStrategy::VerifyAnchor)]
+    #[case(Some(100), Some(100), 99, false, ReconciliationStrategy::VerifyAnchor)]
+    #[case(Some(100), Some(105), 99, true, ReconciliationStrategy::HandleReorg)]
+    // Overlap mismatch clears pending
+    #[case(Some(100), Some(110), 102, true, ReconciliationStrategy::HandleReorg)]
+    #[case(Some(100), Some(101), 100, true, ReconciliationStrategy::HandleReorg)]
     fn test_reconciler(
         #[case] earliest: Option<u64>,
         #[case] latest: Option<u64>,
         #[case] canonical: u64,
-        #[case] max_depth: u64,
         #[case] reorg: bool,
         #[case] expected: ReconciliationStrategy,
     ) {
-        let result =
-            CanonicalBlockReconciler::reconcile(earliest, latest, canonical, max_depth, reorg);
+        let result = CanonicalBlockReconciler::reconcile(earliest, latest, canonical, reorg);
         assert_eq!(result, expected);
     }
 }

--- a/crates/execution/metering/src/rpc.rs
+++ b/crates/execution/metering/src/rpc.rs
@@ -11,7 +11,7 @@ use base_common_evm::L1BlockInfo;
 use base_common_flz::flz_compress_len;
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_evm::extract_l1_info_from_tx;
-use base_flashblocks::{FlashblocksAPI, PendingBlocksAPI};
+use base_flashblocks::FlashblocksAPI;
 use jsonrpsee::core::{RpcResult, async_trait};
 use reth_primitives_traits::SealedHeader;
 use reth_provider::{
@@ -96,13 +96,52 @@ where
             "Starting bundle metering"
         );
 
-        // Get pending blocks from flashblocks API
-        let pending_blocks = self.flashblocks_api.get_pending_blocks();
+        // Take a consistent canonical tip before selecting pending overlay or looking up state.
+        let best = self
+            .provider
+            .sealed_header_by_number_or_tag(BlockNumberOrTag::Latest)
+            .map_err(|e| {
+                jsonrpsee::types::ErrorObjectOwned::owned(
+                    jsonrpsee::types::ErrorCode::InternalError.code(),
+                    format!("Failed to get canonical block header: {e}"),
+                    None::<()>,
+                )
+            })?
+            .ok_or_else(|| {
+                jsonrpsee::types::ErrorObjectOwned::owned(
+                    jsonrpsee::types::ErrorCode::InternalError.code(),
+                    "Canonical block not found".to_string(),
+                    None::<()>,
+                )
+            })?;
+
+        let pending_guard = self.flashblocks_api.get_pending_blocks();
+        let pending_blocks = pending_guard.as_ref().filter(|pb| {
+            let fresh = pb.is_based_on_canonical(best.number(), best.hash());
+            if !fresh {
+                debug!(
+                    tip = best.number(),
+                    tip_hash = %best.hash(),
+                    pending_canonical = %pb.canonical_block_number(),
+                    pending_parent = %pb.parent_hash(),
+                    pending_latest = pb.latest_block_number(),
+                    "ignoring stale flashblock pending for metering"
+                );
+            }
+            fresh
+        });
 
         // Get header and flashblock index from pending blocks
-        // If no pending blocks exist, fall back to latest canonical block
-        let (header, flashblock_index, canonical_block_number) =
-            if let Some(pb) = pending_blocks.as_ref() {
+        // If pending is absent or not based on the current tip, fall back to latest canonical.
+        let (header, flashblock_index, canonical_block_number) = pending_blocks.map_or_else(
+            || {
+                debug!(
+                    canonical_block = best.number(),
+                    "No fresh flashblocks available, using canonical block state for metering"
+                );
+                (best, 0, BlockNumberOrTag::Latest)
+            },
+            |pb| {
                 let latest_header: Sealed<Header> = pb.latest_header();
                 let flashblock_index = pb.latest_flashblock_index();
                 let canonical_block_number = pb.canonical_block_number();
@@ -114,38 +153,11 @@ where
                     "Using latest flashblock state for metering"
                 );
 
-                // Convert Sealed<Header> to SealedHeader
                 let sealed_header =
                     SealedHeader::new(latest_header.inner().clone(), latest_header.hash());
                 (sealed_header, flashblock_index, canonical_block_number)
-            } else {
-                // No pending blocks, use latest canonical block
-                let canonical_block_number = pending_blocks.get_canonical_block_number();
-                let header = self
-                    .provider
-                    .sealed_header_by_number_or_tag(canonical_block_number)
-                    .map_err(|e| {
-                        jsonrpsee::types::ErrorObjectOwned::owned(
-                            jsonrpsee::types::ErrorCode::InternalError.code(),
-                            format!("Failed to get canonical block header: {e}"),
-                            None::<()>,
-                        )
-                    })?
-                    .ok_or_else(|| {
-                        jsonrpsee::types::ErrorObjectOwned::owned(
-                            jsonrpsee::types::ErrorCode::InternalError.code(),
-                            "Canonical block not found".to_string(),
-                            None::<()>,
-                        )
-                    })?;
-
-                debug!(
-                    canonical_block = header.number,
-                    "No flashblocks available, using canonical block state for metering"
-                );
-
-                (header, 0, canonical_block_number)
-            };
+            },
+        );
 
         let parsed_bundle = ParsedBundle::try_from(bundle).map_err(|e| {
             jsonrpsee::types::ErrorObjectOwned::owned(
@@ -168,12 +180,12 @@ where
 
         // If we have pending blocks, extract the pending state for metering
         let pending_state =
-            pending_blocks.as_ref().map(|pb| PendingState { bundle_state: pb.get_bundle_state() });
+            pending_blocks.map(|pb| PendingState { bundle_state: pb.get_bundle_state() });
 
         // Pending flashblock headers can omit parent_beacon_block_root; prefer the CL-provided
         // value from the flashblock base payload when available, otherwise fall back to the header.
         let parent_beacon_block_root = header.parent_beacon_block_root().or_else(|| {
-            pending_blocks.as_ref().and_then(|pb| {
+            pending_blocks.and_then(|pb| {
                 pb.get_flashblocks()
                     .first()
                     .and_then(|fb| fb.base.as_ref().map(|base| base.parent_beacon_block_root))
@@ -239,7 +251,7 @@ where
             gas_fees: output.total_gas_fees,
             results: output.results,
             state_block_number: header.number,
-            state_flashblock_index: pending_blocks.as_ref().map(|pb| pb.latest_flashblock_index()),
+            state_flashblock_index: pending_blocks.map(|pb| pb.latest_flashblock_index()),
             total_gas_used: output.total_gas_used,
             total_execution_time_us,
         })
@@ -489,7 +501,7 @@ mod tests {
     use base_common_flashblocks::{
         ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, Flashblock, Metadata,
     };
-    use base_flashblocks::{FlashblocksConfig, PendingBlocksBuilder};
+    use base_flashblocks::{FlashblocksConfig, FlashblocksState, PendingBlocksBuilder};
     use base_node_runner::test_utils::{L1_BLOCK_INFO_DEPOSIT_TX, TestHarness};
     use base_test_utils::Account;
     use reth_transaction_pool::test_utils::TransactionBuilder;
@@ -539,6 +551,63 @@ mod tests {
                 .into_encoded()
                 .into_encoded_bytes(),
         ]
+    }
+
+    async fn setup_with_flashblocks()
+    -> eyre::Result<(TestHarness, RpcClient, Arc<FlashblocksState>)> {
+        let flashblocks_config =
+            FlashblocksConfig::new(Url::parse("ws://localhost:12345").unwrap(), 10);
+        let flashblocks_state = Arc::clone(&flashblocks_config.state);
+        let harness = TestHarness::builder()
+            .with_ext::<MeteringExtension>(MeteringConfig::with_flashblocks(flashblocks_config))
+            .build()
+            .await?;
+        let client = harness.rpc_client()?;
+        Ok((harness, client, flashblocks_state))
+    }
+
+    fn pending_blocks_on_parent(
+        pending_block_number: u64,
+        parent_hash: B256,
+    ) -> eyre::Result<base_flashblocks::PendingBlocks> {
+        let header = Header {
+            number: pending_block_number,
+            parent_hash,
+            timestamp: 1_700_000_000 + pending_block_number,
+            gas_limit: 30_000_000,
+            base_fee_per_gas: Some(1_000_000_000),
+            ..Default::default()
+        };
+        let mut builder = PendingBlocksBuilder::new();
+        builder.with_header(header.seal(B256::ZERO));
+        builder.with_flashblocks([Flashblock {
+            payload_id: Default::default(),
+            index: 0,
+            base: Some(ExecutionPayloadBaseV1 {
+                parent_beacon_block_root: B256::ZERO,
+                parent_hash,
+                fee_recipient: Default::default(),
+                prev_randao: B256::ZERO,
+                block_number: pending_block_number,
+                gas_limit: 30_000_000,
+                timestamp: 1_700_000_000 + pending_block_number,
+                extra_data: Default::default(),
+                base_fee_per_gas: alloy_primitives::U256::from(1_000_000_000u64),
+            }),
+            diff: ExecutionPayloadFlashblockDeltaV1 {
+                state_root: B256::ZERO,
+                receipts_root: B256::ZERO,
+                logs_bloom: Bloom::default(),
+                gas_used: 0,
+                block_hash: B256::ZERO,
+                transactions: vec![],
+                withdrawals: vec![],
+                withdrawals_root: B256::ZERO,
+                blob_gas_used: Some(0),
+            },
+            metadata: Metadata::new(pending_block_number),
+        }]);
+        Ok(builder.build()?)
     }
 
     #[tokio::test]
@@ -869,86 +938,108 @@ mod tests {
     /// "Block not found: 0x0000000000000000000000000000000000000000000000000000000000000000"
     #[tokio::test]
     async fn test_meter_bundle_with_flashblocks_zero_hash_header() -> eyre::Result<()> {
-        // Create a shared flashblocks state that we can inject pending blocks into
-        let flashblocks_config =
-            FlashblocksConfig::new(Url::parse("ws://localhost:12345").unwrap(), 10);
-        let flashblocks_state = Arc::clone(&flashblocks_config.state);
+        let (harness, client, flashblocks_state) = setup_with_flashblocks().await?;
 
-        // Setup harness with flashblocks-enabled metering
-        let harness = TestHarness::builder()
-            .with_ext::<MeteringExtension>(MeteringConfig::with_flashblocks(flashblocks_config))
-            .build()
-            .await?;
-        let client = harness.rpc_client()?;
-
-        // Build a canonical block with L1 block info deposit
         harness
             .build_block_from_transactions(generate_txs_for_block(harness.chain_id()).await)
             .await?;
+        let tip = harness.latest_block();
 
-        // Create a flashblock with a zero-hash header (this is how real flashblocks work)
-        // The header hash is B256::ZERO because the final block hash isn't known yet
-        let flashblock_header = Header {
-            number: 2, // Pending block on top of canonical block 1
-            timestamp: 1_700_000_001,
-            gas_limit: 30_000_000,
-            base_fee_per_gas: Some(1_000_000_000),
-            ..Default::default()
-        };
+        flashblocks_state.set_pending_blocks_for_testing(Some(pending_blocks_on_parent(
+            tip.number + 1,
+            tip.hash(),
+        )?));
 
-        // Seal with zero hash (this is what block_assembler.rs does)
-        let sealed_header = flashblock_header.seal(B256::ZERO);
-
-        // Create a minimal flashblock
-        let flashblock = Flashblock {
-            payload_id: Default::default(),
-            index: 0,
-            base: Some(ExecutionPayloadBaseV1 {
-                parent_beacon_block_root: B256::ZERO,
-                parent_hash: B256::ZERO,
-                fee_recipient: Default::default(),
-                prev_randao: B256::ZERO,
-                block_number: 2,
-                gas_limit: 30_000_000,
-                timestamp: 1_700_000_001,
-                extra_data: Default::default(),
-                base_fee_per_gas: alloy_primitives::U256::from(1_000_000_000u64),
-            }),
-            diff: ExecutionPayloadFlashblockDeltaV1 {
-                state_root: B256::ZERO,
-                receipts_root: B256::ZERO,
-                logs_bloom: Bloom::default(),
-                gas_used: 0,
-                block_hash: B256::ZERO,
-                transactions: vec![],
-                withdrawals: vec![],
-                withdrawals_root: B256::ZERO,
-                blob_gas_used: Some(0),
-            },
-            metadata: Metadata::new(2),
-        };
-
-        // Build PendingBlocks with zero-hash header
-        let mut builder = PendingBlocksBuilder::new();
-        builder.with_header(sealed_header);
-        builder.with_flashblocks([flashblock]);
-        let pending_blocks = builder.build()?;
-
-        // Inject the pending blocks into the flashblocks state
-        flashblocks_state.set_pending_blocks_for_testing(Some(pending_blocks));
-
-        // Now call meter_bundle - this should succeed with the fix
-        // Without the fix, it would fail with "Block not found: 0x0000..."
-        // because get_l1_block_info would try to look up block by zero hash
         let bundle = create_bundle(vec![], 0, None);
         let response: MeterBundleResponse = client.request("base_meterBundle", (bundle,)).await?;
 
-        // Verify we got a response and it used the flashblock state
-        // state_block_number should be 2 (the pending block number)
-        assert_eq!(response.state_block_number, 2);
-        // state_flashblock_index should be present and be 0
+        assert_eq!(response.state_block_number, tip.number + 1);
         assert_eq!(response.state_flashblock_index, Some(0));
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_meter_bundle_uses_pending_for_exact_tip_hash_anchor() -> eyre::Result<()> {
+        let (harness, client, flashblocks_state) = setup_with_flashblocks().await?;
+        harness
+            .build_block_from_transactions(generate_txs_for_block(harness.chain_id()).await)
+            .await?;
+        let tip = harness.latest_block();
+
+        flashblocks_state.set_pending_blocks_for_testing(Some(pending_blocks_on_parent(
+            tip.number + 1,
+            tip.hash(),
+        )?));
+
+        let response: MeterBundleResponse =
+            client.request("base_meterBundle", (create_bundle(vec![], 0, None),)).await?;
+
+        assert_eq!(response.state_block_number, tip.number + 1);
+        assert_eq!(response.state_flashblock_index, Some(0));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_meter_bundle_falls_back_for_old_pending_anchor() -> eyre::Result<()> {
+        let (harness, client, flashblocks_state) = setup_with_flashblocks().await?;
+        harness
+            .build_block_from_transactions(generate_txs_for_block(harness.chain_id()).await)
+            .await?;
+        let tip = harness.latest_block();
+
+        // Pending canonical parent is 99, not the current tip. Must fall back before overlay.
+        flashblocks_state
+            .set_pending_blocks_for_testing(Some(pending_blocks_on_parent(100, tip.hash())?));
+
+        let response: MeterBundleResponse =
+            client.request("base_meterBundle", (create_bundle(vec![], 0, None),)).await?;
+
+        assert_eq!(response.state_block_number, tip.number);
+        assert_eq!(response.state_flashblock_index, None);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_meter_bundle_falls_back_for_wrong_pending_parent_hash() -> eyre::Result<()> {
+        let (harness, client, flashblocks_state) = setup_with_flashblocks().await?;
+        harness
+            .build_block_from_transactions(generate_txs_for_block(harness.chain_id()).await)
+            .await?;
+        let tip = harness.latest_block();
+
+        flashblocks_state.set_pending_blocks_for_testing(Some(pending_blocks_on_parent(
+            tip.number + 1,
+            B256::repeat_byte(0x42),
+        )?));
+
+        let response: MeterBundleResponse =
+            client.request("base_meterBundle", (create_bundle(vec![], 0, None),)).await?;
+
+        assert_eq!(response.state_block_number, tip.number);
+        assert_eq!(response.state_flashblock_index, None);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_meter_bundle_falls_back_when_pending_latest_is_not_ahead_of_tip()
+    -> eyre::Result<()> {
+        let (harness, client, flashblocks_state) = setup_with_flashblocks().await?;
+        harness
+            .build_block_from_transactions(generate_txs_for_block(harness.chain_id()).await)
+            .await?;
+        let tip = harness.latest_block();
+
+        flashblocks_state.set_pending_blocks_for_testing(Some(pending_blocks_on_parent(
+            tip.number,
+            tip.hash(),
+        )?));
+
+        let response: MeterBundleResponse =
+            client.request("base_meterBundle", (create_bundle(vec![], 0, None),)).await?;
+
+        assert_eq!(response.state_block_number, tip.number);
+        assert_eq!(response.state_flashblock_index, None);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- Rebase Flashblocks pending state on each canonical advance and recover after mismatches or rebuild failures.
- Reject stale queued and cached work against the current canonical tip, including wrong-fork deltas that follow a dropped base.
- Use Flashblocks state in `base_meterBundle` only when it is exactly anchored to the canonical tip.

## Test plan
- [x] `cargo test -p base-flashblocks --lib`
- [x] `cargo test -p base-flashblocks-node --test state -- --test-threads=1`
- [x] `cargo test -p base-metering --lib test_meter_bundle_`
- [x] `cargo clippy -p base-flashblocks -p base-flashblocks-node -p base-metering -p base-execution-cli --tests -- -D warnings`

type=routine
risk=low
impact=sev5