### PR TITLE
fix(proof): validate BaseTime state in stateless execution

### DIFF
--- a/crates/common/consensus/src/transaction/envelope.rs
+++ b/crates/common/consensus/src/transaction/envelope.rs
@@ -2,9 +2,9 @@ use alloy_consensus::{
     Extended, InMemorySize, Sealable, Sealed, SignableTransaction, Signed, TransactionEnvelope,
     TxEip1559, TxEip2930, TxEip7702, TxEnvelope, TxLegacy,
     error::ValueError,
-    transaction::{TransactionInfo, TxHashRef},
+    transaction::{Recovered, TransactionInfo, TxHashRef},
 };
-use alloy_eips::eip2718::Encodable2718;
+use alloy_eips::eip2718::{Encodable2718, WithEncoded};
 #[cfg(feature = "evm")]
 use alloy_evm::{FromRecoveredTx, FromTxWithEncoded};
 #[cfg(feature = "alloy-compat")]
@@ -84,6 +84,34 @@ impl BaseTransaction for BaseTxEnvelope {
 
     fn as_eip8130(&self) -> Option<&Eip8130Signed> {
         self.as_eip8130()
+    }
+}
+
+impl<T: BaseTransaction> BaseTransaction for Recovered<T> {
+    fn is_deposit(&self) -> bool {
+        self.inner().is_deposit()
+    }
+
+    fn as_deposit(&self) -> Option<&Sealed<TxDeposit>> {
+        self.inner().as_deposit()
+    }
+
+    fn as_eip8130(&self) -> Option<&Eip8130Signed> {
+        self.inner().as_eip8130()
+    }
+}
+
+impl<T: BaseTransaction> BaseTransaction for WithEncoded<T> {
+    fn is_deposit(&self) -> bool {
+        self.value().is_deposit()
+    }
+
+    fn as_deposit(&self) -> Option<&Sealed<TxDeposit>> {
+        self.value().as_deposit()
+    }
+
+    fn as_eip8130(&self) -> Option<&Eip8130Signed> {
+        self.value().as_eip8130()
     }
 }
 

--- a/crates/consensus/protocol/src/base_time.rs
+++ b/crates/consensus/protocol/src/base_time.rs
@@ -2,6 +2,7 @@
 
 use alloc::vec::Vec;
 
+use alloy_consensus::TxReceipt;
 use alloy_primitives::{Bytes, Sealable, Sealed, TxKind, U256};
 use base_common_consensus::{
     BaseTimeDepositSource, BaseTransaction, DepositSourceDomain, Predeploys, SystemAddresses,
@@ -90,6 +91,138 @@ impl BaseTimeUpdateTx {
         let base_time = Self::validate_deposit(deposit, block_number)?;
 
         Ok(base_time)
+    }
+
+    /// Returns whether a transaction is a protocol-authorized `BaseTime` setter call.
+    pub fn is_protocol_authorized_setter<T: BaseTransaction>(transaction: &T) -> bool {
+        transaction.as_deposit().is_some_and(|deposit| {
+            deposit.from == SystemAddresses::DEPOSITOR_ACCOUNT
+                && deposit.to == TxKind::Call(Predeploys::BASE_TIME)
+                && deposit.input.starts_with(&Self::SELECTOR)
+        })
+    }
+
+    /// Validates the `BaseTime` transactions for a child block.
+    ///
+    /// Before Denim, protocol-authorized setter deposits are forbidden. At and after Denim, the
+    /// canonical metadata deposit must be at `tx[1]`, and no other protocol-authorized setter may
+    /// appear in the block.
+    pub fn validate_child_transactions<T: BaseTransaction>(
+        transactions: &[T],
+        block_number: u64,
+        denim_active: bool,
+    ) -> Result<Option<Self>, BaseTimeValidationError> {
+        if !denim_active {
+            if let Some(index) = transactions.iter().position(Self::is_protocol_authorized_setter) {
+                return Err(BaseTimeValidationError::ProtocolSetterBeforeDenim { index });
+            }
+            return Ok(None);
+        }
+
+        Self::validate_denim_child_transactions(transactions, block_number).map(Some)
+    }
+
+    /// Validates the canonical metadata and unique protocol writer for a Denim child block.
+    pub fn validate_denim_child_transactions<T: BaseTransaction>(
+        transactions: &[T],
+        block_number: u64,
+    ) -> Result<Self, BaseTimeValidationError> {
+        let base_time = Self::extract_from_transactions(transactions, block_number)?;
+        if let Some(index) = transactions.iter().enumerate().find_map(|(index, transaction)| {
+            (index != 1 && Self::is_protocol_authorized_setter(transaction)).then_some(index)
+        }) {
+            return Err(BaseTimeValidationError::AdditionalProtocolSetter { index });
+        }
+
+        Ok(base_time)
+    }
+
+    /// Validates this update against the configured child timestamp.
+    pub const fn validate_scheduled_timestamp(
+        &self,
+        block_timestamp: u64,
+        expected_timestamp: u64,
+        expected_timestamp_millis_part: u16,
+    ) -> Result<(), BaseTimeValidationError> {
+        if block_timestamp != expected_timestamp
+            || self.timestamp_millis_part != expected_timestamp_millis_part
+        {
+            return Err(BaseTimeValidationError::ScheduledTimestampMismatch {
+                expected_timestamp_ms: expected_timestamp as u128 * 1_000
+                    + expected_timestamp_millis_part as u128,
+                actual_timestamp_ms: block_timestamp as u128 * 1_000
+                    + self.timestamp_millis_part as u128,
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Validates that the first Denim block starts at the `.000` lattice point.
+    pub const fn validate_first_denim_anchor(&self) -> Result<(), BaseTimeValidationError> {
+        if self.timestamp_millis_part != 0 {
+            return Err(BaseTimeValidationError::InvalidFirstDenimAnchor {
+                timestamp_millis_part: self.timestamp_millis_part,
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Validates that this child advances exactly one `BaseTime` slot from an active parent.
+    pub const fn validate_progression(
+        &self,
+        parent_timestamp: u64,
+        parent_timestamp_millis_part: u16,
+        child_timestamp: u64,
+    ) -> Result<(), BaseTimeValidationError> {
+        let parent_timestamp_ms =
+            parent_timestamp as u128 * 1_000 + parent_timestamp_millis_part as u128;
+        let child_timestamp_ms =
+            child_timestamp as u128 * 1_000 + self.timestamp_millis_part as u128;
+        if child_timestamp_ms != parent_timestamp_ms + Self::BLOCK_INTERVAL_MILLIS as u128 {
+            return Err(BaseTimeValidationError::ProgressionMismatch {
+                parent_timestamp_ms,
+                child_timestamp_ms,
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Validates receipt cardinality and successful execution of the metadata transaction.
+    pub fn validate_receipts<R: TxReceipt>(
+        transaction_count: usize,
+        receipts: &[R],
+    ) -> Result<(), BaseTimeValidationError> {
+        if receipts.len() != transaction_count {
+            return Err(BaseTimeValidationError::ReceiptCountMismatch {
+                transaction_count,
+                receipt_count: receipts.len(),
+            });
+        }
+        let receipt = receipts.get(1).ok_or(BaseTimeValidationError::MetadataReceiptMissing)?;
+
+        if !receipt.status() {
+            return Err(BaseTimeValidationError::MetadataExecutionFailed);
+        }
+
+        Ok(())
+    }
+
+    /// Validates the final child `BaseTime` storage value.
+    pub const fn validate_final_state(
+        &self,
+        timestamp_millis_part: u16,
+    ) -> Result<(), BaseTimeValidationError> {
+        if timestamp_millis_part != self.timestamp_millis_part {
+            return Err(BaseTimeValidationError::FinalStateMismatch {
+                expected_timestamp_millis_part: self.timestamp_millis_part,
+                actual_timestamp_millis_part: timestamp_millis_part,
+            });
+        }
+
+        Ok(())
     }
 
     /// Extracts the block timestamp in milliseconds from its transactions and header fields.
@@ -219,6 +352,78 @@ pub enum BaseTimeMetadataError {
     /// The deposit calldata is not a canonical `BaseTime` setter call.
     #[error("invalid BaseTime metadata calldata: {0}")]
     InvalidCalldata(BaseTimeUpdateDecodeError),
+}
+
+/// An error validating a complete `BaseTime` child-state transition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum BaseTimeValidationError {
+    /// The canonical metadata deposit is malformed or missing.
+    #[error(transparent)]
+    Metadata(#[from] BaseTimeMetadataError),
+    /// A protocol-authorized setter deposit appeared before Denim activation.
+    #[error("protocol-authorized BaseTime setter at tx[{index}] before Denim")]
+    ProtocolSetterBeforeDenim {
+        /// The transaction index.
+        index: usize,
+    },
+    /// A protocol-authorized setter appeared outside the canonical `tx[1]` position.
+    #[error("additional protocol-authorized BaseTime setter at tx[{index}]")]
+    AdditionalProtocolSetter {
+        /// The transaction index.
+        index: usize,
+    },
+    /// The child header and metadata do not match the configured schedule.
+    #[error(
+        "BaseTime scheduled timestamp mismatch: expected {expected_timestamp_ms}ms, got {actual_timestamp_ms}ms"
+    )]
+    ScheduledTimestampMismatch {
+        /// The configured child timestamp in milliseconds.
+        expected_timestamp_ms: u128,
+        /// The child header and metadata timestamp in milliseconds.
+        actual_timestamp_ms: u128,
+    },
+    /// The first Denim block does not start at `.000`.
+    #[error("invalid first Denim BaseTime anchor: expected 0ms, got {timestamp_millis_part}ms")]
+    InvalidFirstDenimAnchor {
+        /// The metadata millisecond component.
+        timestamp_millis_part: u16,
+    },
+    /// Consecutive Denim blocks did not advance by exactly one 200ms slot.
+    #[error(
+        "invalid BaseTime progression from {parent_timestamp_ms}ms to {child_timestamp_ms}ms; expected exactly 200ms"
+    )]
+    ProgressionMismatch {
+        /// The parent's full-millisecond timestamp.
+        parent_timestamp_ms: u128,
+        /// The child's full-millisecond timestamp.
+        child_timestamp_ms: u128,
+    },
+    /// Execution produced a different number of receipts than transactions.
+    #[error(
+        "BaseTime receipt count mismatch: {transaction_count} transactions, {receipt_count} receipts"
+    )]
+    ReceiptCountMismatch {
+        /// The block transaction count.
+        transaction_count: usize,
+        /// The execution receipt count.
+        receipt_count: usize,
+    },
+    /// Execution did not produce the metadata receipt at `tx[1]`.
+    #[error("missing BaseTime metadata receipt at tx[1]")]
+    MetadataReceiptMissing,
+    /// The metadata transaction reverted.
+    #[error("BaseTime metadata transaction execution failed")]
+    MetadataExecutionFailed,
+    /// The final `BaseTime` slot does not match the metadata value.
+    #[error(
+        "BaseTime final state mismatch: expected {expected_timestamp_millis_part}ms, got {actual_timestamp_millis_part}ms"
+    )]
+    FinalStateMismatch {
+        /// The millisecond component committed by `tx[1]`.
+        expected_timestamp_millis_part: u16,
+        /// The millisecond component in final child state.
+        actual_timestamp_millis_part: u16,
+    },
 }
 
 #[cfg(test)]

--- a/crates/consensus/protocol/src/lib.rs
+++ b/crates/consensus/protocol/src/lib.rs
@@ -54,6 +54,7 @@ pub use deposits::{DepositDecodeError, Deposits};
 mod base_time;
 pub use base_time::{
     BaseTimeMetadataError, BaseTimeUpdateDecodeError, BaseTimeUpdateError, BaseTimeUpdateTx,
+    BaseTimeValidationError,
 };
 
 mod timing;

--- a/crates/proof/executor/Cargo.toml
+++ b/crates/proof/executor/Cargo.toml
@@ -84,6 +84,7 @@ std = [
 ]
 test-utils = [
 	"base-common-chains?/test-utils",
+	"base-common-genesis/serde",
 	"base-common-genesis/test-utils",
 	"base-protocol/test-utils",
 	"dep:alloy-provider",

--- a/crates/proof/executor/src/builder/core.rs
+++ b/crates/proof/executor/src/builder/core.rs
@@ -10,18 +10,21 @@ use core::fmt::Debug;
 use alloy_consensus::{Header, Sealed, crypto::RecoveryError};
 use alloy_evm::{
     EvmFactory, FromRecoveredTx, FromTxWithEncoded,
-    block::{BlockExecutionResult, BlockExecutor, BlockExecutorFactory},
+    block::{BlockExecutionError, BlockExecutionResult, BlockExecutor, BlockExecutorFactory},
 };
 use base_common_consensus::{BaseReceiptEnvelope, BaseTxEnvelope};
 use base_common_evm::{
-    AlloyReceiptBuilder, BaseBlockExecutionCtx, BaseBlockExecutorFactory, BaseSpecId, BaseTxEnv,
+    AlloyReceiptBuilder, BaseBlockExecutionCtx, BaseBlockExecutorFactory, BaseSpecId, BaseTime,
+    BaseTxEnv,
 };
 use base_common_genesis::RollupConfig;
 use base_common_rpc_types_engine::BasePayloadAttributes;
 use base_proof_mpt::TrieHinter;
+use base_protocol::BaseTimeUpdateTx;
 use revm::{
     context::BlockEnv,
     database::{State, states::bundle_state::BundleRetention},
+    database_interface::bal::EvmDatabaseError,
 };
 
 use crate::{ExecutorError, ExecutorResult, TrieDB, TrieDBError, TrieDBProvider};
@@ -118,6 +121,35 @@ where
         )?;
         let block_env = evm_env.block_env().clone();
         let parent_hash = self.trie_db.parent_block_header().seal();
+        let parent_timestamp = self.trie_db.parent_block_header().timestamp;
+        let block_number = block_env.number.saturating_to::<u64>();
+        let block_timestamp = block_env.timestamp.saturating_to::<u64>();
+        let (expected_timestamp, expected_timestamp_millis_part) =
+            self.config.l2_block_timestamp_parts(block_number);
+        let denim_active = self.config.is_denim_active(expected_timestamp);
+        let parent_denim_active = self.config.is_denim_active(
+            self.config.l2_block_timestamp(self.trie_db.parent_block_header().number),
+        );
+
+        let transactions = attrs
+            .recovered_transactions_with_encoded()
+            .collect::<Result<Vec<_>, RecoveryError>>()
+            .map_err(ExecutorError::Recovery)?;
+        let base_time = BaseTimeUpdateTx::validate_child_transactions(
+            &transactions,
+            block_number,
+            denim_active,
+        )?;
+        if let Some(base_time) = base_time {
+            if !parent_denim_active {
+                base_time.validate_first_denim_anchor()?;
+            }
+            base_time.validate_scheduled_timestamp(
+                block_timestamp,
+                expected_timestamp,
+                expected_timestamp_millis_part,
+            )?;
+        }
 
         // Attempt to send a payload witness hint to the host. This hint instructs the host to
         // populate its preimage store with the preimages required to statelessly execute
@@ -138,8 +170,21 @@ where
         );
 
         // Step 2. Create the executor, using the trie database.
+        let map_state_error = |error| match error {
+            EvmDatabaseError::Database(error) => ExecutorError::TrieDBError(error),
+            EvmDatabaseError::Bal(error) => {
+                ExecutorError::ExecutionError(BlockExecutionError::other(error))
+            }
+        };
         let mut state =
             State::builder().with_database(&mut self.trie_db).with_bundle_update().build();
+        if let Some(base_time) = base_time
+            && parent_denim_active
+        {
+            let parent_millis =
+                BaseTime::fetch_timestamp_millis_part(&mut state).map_err(map_state_error)?;
+            base_time.validate_progression(parent_timestamp, parent_millis, block_timestamp)?;
+        }
         let evm = self.factory.evm_factory().create_evm(&mut state, evm_env);
         let ctx = BaseBlockExecutionCtx {
             parent_hash,
@@ -150,11 +195,14 @@ where
         let executor = self.factory.create_executor(evm, ctx);
 
         // Step 3. Execute the block containing the transactions within the payload attributes.
-        let transactions = attrs
-            .recovered_transactions_with_encoded()
-            .collect::<Result<Vec<_>, RecoveryError>>()
-            .map_err(ExecutorError::Recovery)?;
         let ex_result = executor.execute_block(transactions.iter())?;
+
+        if let Some(base_time) = base_time {
+            BaseTimeUpdateTx::validate_receipts(transactions.len(), &ex_result.receipts)?;
+            let child_millis =
+                BaseTime::fetch_timestamp_millis_part(&mut state).map_err(map_state_error)?;
+            base_time.validate_final_state(child_millis)?;
+        }
 
         info!(
             target: "block_builder",
@@ -199,5 +247,485 @@ impl From<(Sealed<Header>, BlockExecutionResult<BaseReceiptEnvelope>)> for Block
         (header, execution_result): (Sealed<Header>, BlockExecutionResult<BaseReceiptEnvelope>),
     ) -> Self {
         Self { header, execution_result }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::BTreeMap,
+        sync::{Arc, RwLock},
+    };
+
+    use alloy_consensus::{Header, Sealable, SignableTransaction, TxLegacy};
+    use alloy_eips::Encodable2718;
+    use alloy_primitives::{B256, Bytes, Signature, U256, keccak256};
+    use alloy_rlp::{Decodable, Encodable};
+    use alloy_trie::{EMPTY_ROOT_HASH, HashBuilder, Nibbles, TrieAccount, proof::ProofRetainer};
+    use base_common_consensus::{BaseTxEnvelope, Predeploys, SystemAddresses, TxDeposit};
+    use base_common_evm::{BaseEvmFactory, BaseTime};
+    use base_common_genesis::{BaseUpgradeConfig, ChainGenesis, RollupConfig, UpgradeConfig};
+    use base_common_rpc_types_engine::BasePayloadAttributes;
+    use base_proof_mpt::{NoopTrieHinter, TrieNode, TrieProvider};
+    use base_protocol::{BaseTimeMetadataError, BaseTimeUpdateTx, BaseTimeValidationError};
+
+    use crate::{ExecutorError, NoopTrieDBProvider, StatelessL2Builder, TrieDBProvider};
+
+    #[derive(Debug, Clone)]
+    struct MemoryTrieDBProvider {
+        trie_nodes: Arc<RwLock<BTreeMap<B256, Bytes>>>,
+        bytecodes: BTreeMap<B256, Bytes>,
+    }
+
+    impl MemoryTrieDBProvider {
+        fn capture(&self, node: &TrieNode) {
+            match node {
+                TrieNode::Extension { node, .. } => self.capture(node),
+                TrieNode::Branch { stack } => {
+                    for node in stack {
+                        self.capture(node);
+                    }
+                }
+                TrieNode::Empty | TrieNode::Blinded { .. } | TrieNode::Leaf { .. } => {}
+            }
+            if !matches!(node, TrieNode::Empty | TrieNode::Blinded { .. }) {
+                let encoded = rlp(node);
+                self.trie_nodes.write().unwrap().insert(keccak256(&encoded), encoded);
+            }
+        }
+    }
+
+    impl TrieProvider for MemoryTrieDBProvider {
+        type Error = String;
+
+        fn trie_node_by_hash(&self, hash: B256) -> Result<TrieNode, Self::Error> {
+            let bytes = self
+                .trie_nodes
+                .read()
+                .unwrap()
+                .get(&hash)
+                .cloned()
+                .ok_or_else(|| format!("missing trie node {hash}"))?;
+            TrieNode::decode(&mut bytes.as_ref()).map_err(|error| error.to_string())
+        }
+    }
+
+    impl TrieDBProvider for MemoryTrieDBProvider {
+        fn bytecode_by_hash(&self, code_hash: B256) -> Result<Bytes, Self::Error> {
+            self.bytecodes
+                .get(&code_hash)
+                .cloned()
+                .ok_or_else(|| format!("missing bytecode {code_hash}"))
+        }
+
+        fn header_by_hash(&self, hash: B256) -> Result<Header, Self::Error> {
+            Err(format!("missing header {hash}"))
+        }
+    }
+
+    fn trie(mut leaves: Vec<(Nibbles, Bytes)>) -> (B256, BTreeMap<B256, Bytes>) {
+        leaves.sort_by_key(|(path, _)| *path);
+        let paths = leaves.iter().map(|(path, _)| *path).collect();
+        let mut builder = HashBuilder::default().with_proof_retainer(ProofRetainer::new(paths));
+        for (path, value) in leaves {
+            builder.add_leaf(path, &value);
+        }
+        let root = builder.root();
+        let nodes = builder
+            .take_proof_nodes()
+            .into_inner()
+            .into_values()
+            .map(|value| (keccak256(value.as_ref()), value))
+            .collect();
+        (root, nodes)
+    }
+
+    fn rlp(value: &impl Encodable) -> Bytes {
+        let mut encoded = Vec::with_capacity(value.length());
+        value.encode(&mut encoded);
+        encoded.into()
+    }
+
+    fn state(
+        timestamp_millis_part: u16,
+        implementation: Option<Bytes>,
+    ) -> (B256, MemoryTrieDBProvider) {
+        let mut storage = vec![(
+            Nibbles::unpack(keccak256(BaseTime::ADMIN_SLOT.to_be_bytes::<32>())),
+            rlp(&U256::from_be_slice(Predeploys::PROXY_ADMIN.as_slice())),
+        )];
+        if timestamp_millis_part != 0 {
+            storage.push((
+                Nibbles::unpack(keccak256(
+                    BaseTime::TIMESTAMP_MILLIS_PART_SLOT.to_be_bytes::<32>(),
+                )),
+                rlp(&U256::from(timestamp_millis_part)),
+            ));
+        }
+        if implementation.is_some() {
+            storage.push((
+                Nibbles::unpack(keccak256(BaseTime::IMPLEMENTATION_SLOT.to_be_bytes::<32>())),
+                rlp(&U256::from_be_slice(BaseTime::IMPLEMENTATION_ADDRESS.as_slice())),
+            ));
+        }
+        let (storage_root, mut trie_nodes) = trie(storage);
+
+        let proxy = BaseTime::proxy_bytecode();
+        let mut accounts = vec![
+            (
+                Nibbles::unpack(keccak256(Predeploys::BASE_TIME)),
+                rlp(&TrieAccount {
+                    nonce: 1,
+                    storage_root,
+                    code_hash: keccak256(&proxy),
+                    ..Default::default()
+                }),
+            ),
+            (
+                Nibbles::unpack(keccak256(Predeploys::L2_TO_L1_MESSAGE_PASSER)),
+                rlp(&TrieAccount {
+                    nonce: 1,
+                    storage_root: EMPTY_ROOT_HASH,
+                    code_hash: keccak256([]),
+                    ..Default::default()
+                }),
+            ),
+        ];
+        let mut bytecodes = BTreeMap::from([
+            (keccak256(&proxy), proxy),
+            (BaseTime::IMPLEMENTATION_CODE_HASH, BaseTime::implementation_bytecode()),
+        ]);
+        if let Some(implementation) = implementation {
+            let code_hash = keccak256(&implementation);
+            accounts.push((
+                Nibbles::unpack(keccak256(BaseTime::IMPLEMENTATION_ADDRESS)),
+                rlp(&TrieAccount {
+                    storage_root: EMPTY_ROOT_HASH,
+                    code_hash,
+                    ..Default::default()
+                }),
+            ));
+            bytecodes.insert(code_hash, implementation);
+        }
+        let (state_root, state_nodes) = trie(accounts);
+        trie_nodes.extend(state_nodes);
+
+        (
+            state_root,
+            MemoryTrieDBProvider { trie_nodes: Arc::new(RwLock::new(trie_nodes)), bytecodes },
+        )
+    }
+
+    fn config() -> RollupConfig {
+        RollupConfig {
+            genesis: ChainGenesis { l2_time: 10, ..Default::default() },
+            block_time: 2,
+            upgrades: UpgradeConfig {
+                base: BaseUpgradeConfig { denim: Some(14), ..Default::default() },
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    fn encoded(transaction: BaseTxEnvelope) -> Bytes {
+        transaction.encoded_2718().into()
+    }
+
+    fn l1_info() -> Bytes {
+        encoded(
+            TxDeposit {
+                from: SystemAddresses::DEPOSITOR_ACCOUNT,
+                to: Predeploys::L1_BLOCK_INFO.into(),
+                gas_limit: 1_000_000,
+                ..Default::default()
+            }
+            .seal_slow()
+            .into(),
+        )
+    }
+
+    fn base_time(block_number: u64, millis_part: u16) -> Bytes {
+        encoded(BaseTimeUpdateTx::new(millis_part).unwrap().into_deposit_tx(block_number).into())
+    }
+
+    fn user_transaction() -> Bytes {
+        encoded(BaseTxEnvelope::Legacy(
+            TxLegacy::default().into_signed(Signature::test_signature()),
+        ))
+    }
+
+    fn attributes(timestamp: u64, transactions: Vec<Bytes>) -> BasePayloadAttributes {
+        let mut attributes = BasePayloadAttributes::default();
+        attributes.payload_attributes.timestamp = timestamp;
+        attributes.gas_limit = Some(30_000_000);
+        attributes.transactions = Some(transactions);
+        attributes
+    }
+
+    fn builder<'a>(
+        config: &'a RollupConfig,
+        parent_number: u64,
+        parent_timestamp: u64,
+        timestamp_millis_part: u16,
+        implementation: Option<Bytes>,
+    ) -> StatelessL2Builder<'a, MemoryTrieDBProvider, NoopTrieHinter, BaseEvmFactory> {
+        let (state_root, provider) = state(timestamp_millis_part, implementation);
+        let parent = Header {
+            state_root,
+            number: parent_number,
+            timestamp: parent_timestamp,
+            gas_limit: 30_000_000,
+            base_fee_per_gas: Some(1_000_000),
+            ..Default::default()
+        }
+        .seal_slow();
+        StatelessL2Builder::new(config, BaseEvmFactory::default(), provider, NoopTrieHinter, parent)
+    }
+
+    fn assert_rejected(
+        parent_number: u64,
+        parent_timestamp: u64,
+        child_timestamp: u64,
+        transactions: Vec<Bytes>,
+        expected: BaseTimeValidationError,
+    ) {
+        let config = config();
+        let parent = Header {
+            number: parent_number,
+            timestamp: parent_timestamp,
+            gas_limit: 30_000_000,
+            base_fee_per_gas: Some(1_000_000),
+            ..Default::default()
+        }
+        .seal_slow();
+        let parent_hash = parent.hash();
+        let mut builder = StatelessL2Builder::new(
+            &config,
+            BaseEvmFactory::default(),
+            NoopTrieDBProvider,
+            NoopTrieHinter,
+            parent,
+        );
+        let error = builder.build_block(attributes(child_timestamp, transactions)).unwrap_err();
+
+        let ExecutorError::BaseTimeValidation(actual) = error else {
+            panic!("expected BaseTime validation error, got {error:?}");
+        };
+        assert_eq!(actual, expected);
+        assert_eq!(builder.trie_db.parent_block_header().hash(), parent_hash);
+        assert_eq!(builder.trie_db.parent_block_header().number, parent_number);
+    }
+
+    #[test]
+    fn rejects_missing_first_denim_metadata_without_advancing_parent() {
+        assert_rejected(
+            1,
+            12,
+            14,
+            vec![l1_info()],
+            BaseTimeValidationError::Metadata(BaseTimeMetadataError::Missing),
+        );
+    }
+
+    #[test]
+    fn rejects_pre_activation_timestamp_at_first_denim_block_without_advancing_parent() {
+        assert_rejected(
+            1,
+            12,
+            13,
+            vec![l1_info()],
+            BaseTimeValidationError::Metadata(BaseTimeMetadataError::Missing),
+        );
+        assert_rejected(
+            1,
+            12,
+            13,
+            vec![l1_info(), base_time(2, 0)],
+            BaseTimeValidationError::ScheduledTimestampMismatch {
+                expected_timestamp_ms: 14_000,
+                actual_timestamp_ms: 13_000,
+            },
+        );
+    }
+
+    #[test]
+    fn rejects_nonzero_first_denim_anchor_without_advancing_parent() {
+        assert_rejected(
+            1,
+            12,
+            14,
+            vec![l1_info(), base_time(2, 200)],
+            BaseTimeValidationError::InvalidFirstDenimAnchor { timestamp_millis_part: 200 },
+        );
+    }
+
+    #[test]
+    fn rejects_wrong_denim_schedule_without_advancing_parent() {
+        for (child_timestamp, millis_part, actual_timestamp_ms) in
+            [(14, 400, 14_400), (15, 200, 15_200)]
+        {
+            assert_rejected(
+                2,
+                14,
+                child_timestamp,
+                vec![l1_info(), base_time(3, millis_part)],
+                BaseTimeValidationError::ScheduledTimestampMismatch {
+                    expected_timestamp_ms: 14_200,
+                    actual_timestamp_ms,
+                },
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_protocol_metadata_before_denim_without_advancing_parent() {
+        assert_rejected(
+            0,
+            10,
+            12,
+            vec![l1_info(), base_time(1, 0)],
+            BaseTimeValidationError::ProtocolSetterBeforeDenim { index: 1 },
+        );
+    }
+
+    #[test]
+    fn rejects_additional_protocol_setter_without_advancing_parent() {
+        for duplicate_millis_part in [200, 400] {
+            assert_rejected(
+                2,
+                14,
+                14,
+                vec![l1_info(), base_time(3, 200), base_time(3, duplicate_millis_part)],
+                BaseTimeValidationError::AdditionalProtocolSetter { index: 2 },
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_reordered_metadata_without_advancing_parent() {
+        assert_rejected(
+            1,
+            12,
+            14,
+            vec![l1_info(), user_transaction(), base_time(2, 0)],
+            BaseTimeValidationError::Metadata(BaseTimeMetadataError::NotDeposit),
+        );
+    }
+
+    #[test]
+    fn rejection_is_atomic_and_valid_retry_succeeds() {
+        let config = config();
+        let mut builder = builder(&config, 1, 12, 0, None);
+        let parent_hash = builder.trie_db.parent_block_header().hash();
+        let state_root = builder.trie_db.root().blind();
+
+        let error = builder.build_block(attributes(14, vec![l1_info()])).unwrap_err();
+        assert!(matches!(
+            error,
+            ExecutorError::BaseTimeValidation(BaseTimeValidationError::Metadata(
+                BaseTimeMetadataError::Missing
+            ))
+        ));
+        assert_eq!(builder.trie_db.parent_block_header().hash(), parent_hash);
+        assert_eq!(builder.trie_db.root().blind(), state_root);
+
+        let outcome = builder
+            .build_block(attributes(14, vec![l1_info(), base_time(2, 0)]))
+            .expect("valid retry from the original parent should succeed");
+        assert_eq!(outcome.header.number, 2);
+        assert_ne!(outcome.header.hash(), parent_hash);
+    }
+
+    #[test]
+    fn rejects_invalid_parent_progression_without_advancing_parent() {
+        let config = config();
+        let mut builder = builder(&config, 2, 14, 800, None);
+        let parent_hash = builder.trie_db.parent_block_header().hash();
+
+        let error =
+            builder.build_block(attributes(14, vec![l1_info(), base_time(3, 200)])).unwrap_err();
+
+        assert!(matches!(
+            error,
+            ExecutorError::BaseTimeValidation(BaseTimeValidationError::ProgressionMismatch {
+                parent_timestamp_ms: 14_800,
+                child_timestamp_ms: 14_200,
+            })
+        ));
+        assert_eq!(builder.trie_db.parent_block_header().hash(), parent_hash);
+    }
+
+    #[test]
+    fn rejects_failed_metadata_execution_without_advancing_parent() {
+        let config = config();
+        let mut builder =
+            builder(&config, 1, 12, 0, Some(Bytes::from_static(&[0x60, 0x00, 0x60, 0x00, 0xfd])));
+        let parent_hash = builder.trie_db.parent_block_header().hash();
+
+        let error =
+            builder.build_block(attributes(14, vec![l1_info(), base_time(2, 0)])).unwrap_err();
+
+        assert!(matches!(
+            error,
+            ExecutorError::BaseTimeValidation(BaseTimeValidationError::MetadataExecutionFailed)
+        ));
+        assert_eq!(builder.trie_db.parent_block_header().hash(), parent_hash);
+    }
+
+    #[test]
+    fn rejects_stale_final_state_without_advancing_parent() {
+        let config = config();
+        let mut builder = builder(&config, 2, 14, 0, Some(Bytes::from_static(&[0x00])));
+        let parent_hash = builder.trie_db.parent_block_header().hash();
+
+        let error =
+            builder.build_block(attributes(14, vec![l1_info(), base_time(3, 200)])).unwrap_err();
+
+        assert!(matches!(
+            error,
+            ExecutorError::BaseTimeValidation(BaseTimeValidationError::FinalStateMismatch {
+                expected_timestamp_millis_part: 200,
+                actual_timestamp_millis_part: 0,
+            })
+        ));
+        assert_eq!(builder.trie_db.parent_block_header().hash(), parent_hash);
+    }
+
+    #[test]
+    fn executes_six_canonical_base_time_slots() {
+        let config = config();
+        let mut builder = builder(&config, 1, 12, 0, None);
+        let mut parent_hash = builder.trie_db.parent_block_header().hash();
+
+        for (block_number, timestamp, millis_part) in
+            [(2, 14, 0), (3, 14, 200), (4, 14, 400), (5, 14, 600), (6, 14, 800), (7, 15, 0)]
+        {
+            let metadata = base_time(block_number, millis_part);
+            let outcome = builder
+                .build_block(attributes(timestamp, vec![l1_info(), metadata.clone()]))
+                .expect("canonical BaseTime block should execute");
+
+            assert_eq!(outcome.header.number, block_number);
+            assert_eq!(outcome.header.timestamp, timestamp);
+            assert_eq!(outcome.header.parent_hash, parent_hash);
+            assert!(outcome.execution_result.receipts[1].status());
+            assert_eq!(
+                BaseTime::fetch_timestamp_millis_part(&mut builder.trie_db).unwrap(),
+                millis_part
+            );
+            assert_eq!(
+                attributes(timestamp, vec![l1_info(), metadata]).transactions.unwrap()[1],
+                base_time(block_number, millis_part)
+            );
+            assert_eq!(outcome.header.state_root, builder.trie_db.root().blind());
+            assert_ne!(builder.compute_output_root().unwrap(), B256::ZERO);
+
+            builder.trie_db.fetcher.capture(builder.trie_db.root());
+            for storage_root in builder.trie_db.storage_roots().values() {
+                builder.trie_db.fetcher.capture(storage_root);
+            }
+            parent_hash = outcome.header.hash();
+        }
     }
 }

--- a/crates/proof/executor/src/errors.rs
+++ b/crates/proof/executor/src/errors.rs
@@ -9,6 +9,7 @@ use alloc::string::String;
 use alloy_evm::block::BlockExecutionError;
 use base_common_consensus::EIP1559ParamError;
 use base_proof_mpt::TrieNodeError;
+use base_protocol::BaseTimeValidationError;
 use revm::context::DBErrorMarker;
 use thiserror::Error;
 
@@ -150,6 +151,9 @@ pub enum ExecutorError {
     /// - Protocol version mismatches
     #[error("Unsupported transaction type: {0}")]
     UnsupportedTransactionType(u8),
+    /// The child block violates the `BaseTime` transition invariant.
+    #[error("BaseTime validation error: {0}")]
+    BaseTimeValidation(#[from] BaseTimeValidationError),
     /// Trie database operation failed.
     ///
     /// This error wraps [`TrieDBError`] variants that occur during state
@@ -309,6 +313,9 @@ mod tests {
             ExecutorError::MissingEIP1559Params,
             ExecutorError::MissingParentBeaconBlockRoot,
             ExecutorError::InvalidExtraData(Eip1559ValidationError::ZeroDenominator),
+            ExecutorError::BaseTimeValidation(BaseTimeValidationError::InvalidFirstDenimAnchor {
+                timestamp_millis_part: 200,
+            }),
             // Witness-level / prover-influenced — must not trigger silent recovery.
             ExecutorError::TrieDBError(TrieDBError::Provider("missing preimage".to_string())),
             ExecutorError::ExecutionError(BlockExecutionError::Internal(


### PR DESCRIPTION
- Enforce the shared BaseTime invariant before and after stateless execution, deriving Denim activation from the canonical block schedule rather than submitted timestamps.
- Reject malformed metadata, receipts, progression, or storage without advancing the builder parent.