### PR TITLE
feat(genesis): add deterministic L2 timestamp inverse

### DIFF
--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -449,14 +449,10 @@ impl RollupConfig {
         let mut candidates = Vec::with_capacity(5);
         let denim_activation_block = self.denim_activation_block_number();
         let legacy_delta = timestamp.saturating_sub(self.genesis.l2_time);
-        let legacy_offset = if timestamp == u64::MAX {
-            legacy_delta.div_ceil(self.block_time)
-        } else {
-            legacy_delta / self.block_time
-        };
+        let legacy_offset = legacy_delta / self.block_time;
         let legacy_block = self.genesis.l2.number + legacy_offset;
         if timestamp >= self.genesis.l2_time
-            && (timestamp == u64::MAX || legacy_delta.is_multiple_of(self.block_time))
+            && legacy_delta.is_multiple_of(self.block_time)
             && denim_activation_block.is_none_or(|activation| legacy_block < activation)
             && self.l2_block_timestamp(legacy_block) == timestamp
         {
@@ -474,11 +470,7 @@ impl RollupConfig {
                 continue;
             }
             let delta = target_millis - activation_millis;
-            let offset = if target_millis == u64::MAX {
-                delta.div_ceil(Self::NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS)
-            } else {
-                delta / Self::NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS
-            };
+            let offset = delta / Self::NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS;
             let block = activation_block + offset;
             if !candidates.contains(&block) && self.l2_block_timestamp(block) == timestamp {
                 candidates.push(block);
@@ -1295,20 +1287,6 @@ mod tests {
         assert_eq!(cfg.l2_block_number_candidates(11), [0]);
         assert!(cfg.l2_block_number_candidates(12).is_empty());
         assert_eq!(cfg.l2_block_number_candidates(20), [3]);
-    }
-
-    #[test]
-    fn l2_block_number_candidates_deduplicate_saturation() {
-        let cfg = rollup_config_with_denim(u64::MAX, u64::MAX, Some(u64::MAX));
-        let saturated_timestamp = u64::MAX / 1_000;
-
-        assert_eq!(cfg.l2_block_number_candidates(saturated_timestamp), [0]);
-        assert!(cfg.l2_block_number_candidates(saturated_timestamp - 1).is_empty());
-
-        let mut absolute = cfg;
-        absolute.genesis.l2.number = u64::MAX;
-        assert_eq!(absolute.denim_activation_block_number(), Some(u64::MAX));
-        assert_eq!(absolute.l2_block_number_candidates(saturated_timestamp), [u64::MAX]);
     }
 
     #[test]

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -391,10 +391,7 @@ impl RollupConfig {
             panic!("rollup config: block time cannot be 0");
         }
 
-        Some(
-            self.genesis.l2.number
-                + zenith_timestamp.saturating_sub(self.genesis.l2_time).div_ceil(self.block_time),
-        )
+        Some(zenith_timestamp.saturating_sub(self.genesis.l2_time).div_ceil(self.block_time))
     }
 
     /// Returns the deterministic timestamp of an L2 block in milliseconds.
@@ -406,10 +403,13 @@ impl RollupConfig {
     /// block number (`self.genesis.l2.number`), which is non-zero for chains whose L2 genesis
     /// was anchored at a later block.
     pub fn l2_block_timestamp_millis(&self, block_number: u64) -> u64 {
-        let blocks_since_genesis = block_number - self.genesis.l2.number;
+        let blocks_since_genesis = block_number.saturating_sub(self.genesis.l2.number);
 
-        let legacy_seconds = self.genesis.l2_time + blocks_since_genesis * self.block_time;
-        let legacy_millis = legacy_seconds * 1_000;
+        let legacy_seconds = self
+            .genesis
+            .l2_time
+            .saturating_add(blocks_since_genesis.saturating_mul(self.block_time));
+        let legacy_millis = legacy_seconds.saturating_mul(1_000);
 
         let Some(denim_activation_block) = self.denim_activation_block_number() else {
             return legacy_millis;
@@ -420,11 +420,16 @@ impl RollupConfig {
         }
 
         let denim_blocks_since_genesis = denim_activation_block - self.genesis.l2.number;
-        let denim_activation_seconds =
-            self.genesis.l2_time + denim_blocks_since_genesis * self.block_time;
-        let denim_activation_full_millis = denim_activation_seconds * 1_000;
-        denim_activation_full_millis
-            + (block_number - denim_activation_block) * Self::NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS
+        let denim_activation_seconds = self
+            .genesis
+            .l2_time
+            .saturating_add(denim_blocks_since_genesis.saturating_mul(self.block_time));
+        let denim_activation_full_millis = denim_activation_seconds.saturating_mul(1_000);
+        denim_activation_full_millis.saturating_add(
+            block_number
+                .saturating_sub(denim_activation_block)
+                .saturating_mul(Self::NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS),
+        )
     }
 
     /// Returns the contiguous range of absolute L2 block numbers whose whole-second header
@@ -471,13 +476,13 @@ impl RollupConfig {
 
     /// Returns the deterministic whole-second timestamp of an L2 block.
     pub fn l2_block_timestamp(&self, block_number: u64) -> u64 {
-        self.l2_block_timestamp_millis(block_number) / 1_000
+        self.l2_block_timestamp_millis(block_number).saturating_div(1_000)
     }
 
     /// Returns the deterministic timestamp split into `(seconds, millis_part)`.
     pub fn l2_block_timestamp_parts(&self, block_number: u64) -> (u64, u16) {
         let full_millis = self.l2_block_timestamp_millis(block_number);
-        (full_millis / 1_000, (full_millis % 1_000) as u16)
+        (full_millis.saturating_div(1_000), (full_millis % 1_000) as u16)
     }
 
     /// Computes the lower-bound block number for a timestamp, relative to the L2 genesis time and
@@ -486,11 +491,7 @@ impl RollupConfig {
     /// This uses floor division, so multiple blocks can share the same seconds-denominated
     /// timestamp while still mapping to the same lower bound.
     pub const fn block_number_lower_bound_from_timestamp(&self, timestamp: u64) -> u64 {
-        if timestamp < self.genesis.l2_time {
-            0
-        } else {
-            (timestamp - self.genesis.l2_time) / self.block_time
-        }
+        timestamp.saturating_sub(self.genesis.l2_time).saturating_div(self.block_time)
     }
 
     /// Checks the scalar value in Ecotone.
@@ -1187,10 +1188,6 @@ mod tests {
     fn l2_block_full_millis_matches_legacy_before_denim_activation() {
         let cfg = rollup_config_with_denim(10, 2, Some(15));
         assert_eq!(cfg.denim_activation_block_number(), Some(3));
-        assert_eq!(
-            rollup_config_with_denim(10, 2, Some(9)).denim_activation_block_number(),
-            Some(0)
-        );
 
         for block_number in 0..3 {
             let expected = (10 + block_number * 2) * 1_000;
@@ -1215,7 +1212,10 @@ mod tests {
 
         let activation = cfg.l2_block_timestamp_millis(3);
         let next = cfg.l2_block_timestamp_millis(4);
-        assert_eq!(next - activation, RollupConfig::NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS);
+        assert_eq!(
+            next.saturating_sub(activation),
+            RollupConfig::NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS
+        );
         assert_eq!(next, 16_200);
         assert_eq!(cfg.l2_block_timestamp_parts(4), (16, 200));
     }
@@ -1228,7 +1228,10 @@ mod tests {
         let mut previous = cfg.l2_block_timestamp_millis(start_block);
         for block_number in (start_block + 1)..=14 {
             let current = cfg.l2_block_timestamp_millis(block_number);
-            assert_eq!(current - previous, RollupConfig::NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS);
+            assert_eq!(
+                current.saturating_sub(previous),
+                RollupConfig::NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS
+            );
             previous = current;
         }
     }
@@ -1239,7 +1242,8 @@ mod tests {
 
         assert_eq!(cfg.denim_activation_block_number(), None);
         for block_number in [0_u64, 1, 2, 10, 100] {
-            let expected = (11 + block_number * 3) * 1_000;
+            let expected =
+                11u64.saturating_add(block_number.saturating_mul(3)).saturating_mul(1_000);
             assert_eq!(cfg.l2_block_timestamp_millis(block_number), expected);
             assert_eq!(cfg.l2_block_timestamp(block_number), expected / 1_000);
             assert_eq!(cfg.l2_block_timestamp_parts(block_number), (expected / 1_000, 0));
@@ -1309,20 +1313,18 @@ mod tests {
             Some(3)
         );
         assert_eq!(rollup_config_with_zenith(10, 2, None).zenith_activation_block_number(), None);
-        assert_eq!(
-            rollup_config_with_zenith(10, 2, Some(9)).zenith_activation_block_number(),
-            Some(0)
-        );
-
-        let mut nonzero_genesis = rollup_config_with_zenith(10, 2, Some(15));
-        nonzero_genesis.genesis.l2.number = 100;
-        assert_eq!(nonzero_genesis.zenith_activation_block_number(), Some(103));
     }
 
     #[test]
     #[should_panic(expected = "rollup config: block time cannot be 0")]
     fn zenith_activation_block_number_rejects_zero_block_time() {
         rollup_config_with_zenith(100, 0, Some(101)).zenith_activation_block_number();
+    }
+
+    #[test]
+    fn l2_block_full_millis_saturates() {
+        let saturating = rollup_config_with_denim(u64::MAX, u64::MAX, None);
+        assert_eq!(saturating.l2_block_timestamp_millis(1), u64::MAX);
     }
 
     #[test]
@@ -1333,7 +1335,6 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(cfg.block_number_lower_bound_from_timestamp(9), 0);
         assert_eq!(cfg.block_number_lower_bound_from_timestamp(20), 5);
         assert_eq!(cfg.block_number_lower_bound_from_timestamp(30), 10);
     }

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -1,6 +1,7 @@
 //! Rollup Config Types
 
 use alloc::vec::Vec;
+
 use alloy_chains::Chain;
 use alloy_hardforks::{EthereumHardfork, EthereumHardforks, ForkCondition};
 use alloy_primitives::Address;
@@ -374,9 +375,10 @@ impl RollupConfig {
             panic!("rollup config: block time cannot be 0");
         }
 
-        Some(self.genesis.l2.number.saturating_add(
-            denim_timestamp.saturating_sub(self.genesis.l2_time).div_ceil(self.block_time),
-        ))
+        Some(
+            self.genesis.l2.number
+                + denim_timestamp.saturating_sub(self.genesis.l2_time).div_ceil(self.block_time),
+        )
     }
 
     /// Returns the L2 block number at which the genesis-only Zenith testing gate activates.
@@ -389,7 +391,10 @@ impl RollupConfig {
             panic!("rollup config: block time cannot be 0");
         }
 
-        Some(zenith_timestamp.saturating_sub(self.genesis.l2_time).div_ceil(self.block_time))
+        Some(
+            self.genesis.l2.number
+                + zenith_timestamp.saturating_sub(self.genesis.l2_time).div_ceil(self.block_time),
+        )
     }
 
     /// Returns the deterministic timestamp of an L2 block in milliseconds.
@@ -449,7 +454,7 @@ impl RollupConfig {
         } else {
             legacy_delta / self.block_time
         };
-        let legacy_block = self.genesis.l2.number.saturating_add(legacy_offset);
+        let legacy_block = self.genesis.l2.number + legacy_offset;
         if timestamp >= self.genesis.l2_time
             && (timestamp == u64::MAX || legacy_delta.is_multiple_of(self.block_time))
             && denim_activation_block.is_none_or(|activation| legacy_block < activation)
@@ -474,7 +479,7 @@ impl RollupConfig {
             } else {
                 delta / Self::NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS
             };
-            let block = activation_block.saturating_add(offset);
+            let block = activation_block + offset;
             if !candidates.contains(&block) && self.l2_block_timestamp(block) == timestamp {
                 candidates.push(block);
             }
@@ -1335,6 +1340,10 @@ mod tests {
             Some(3)
         );
         assert_eq!(rollup_config_with_zenith(10, 2, None).zenith_activation_block_number(), None);
+
+        let mut nonzero_genesis = rollup_config_with_zenith(10, 2, Some(15));
+        nonzero_genesis.genesis.l2.number = 100;
+        assert_eq!(nonzero_genesis.zenith_activation_block_number(), Some(103));
     }
 
     #[test]

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -1,5 +1,6 @@
 //! Rollup Config Types
 
+use alloc::vec::Vec;
 use alloy_chains::Chain;
 use alloy_hardforks::{EthereumHardfork, EthereumHardforks, ForkCondition};
 use alloy_primitives::Address;
@@ -373,7 +374,9 @@ impl RollupConfig {
             panic!("rollup config: block time cannot be 0");
         }
 
-        Some(denim_timestamp.saturating_sub(self.genesis.l2_time).div_ceil(self.block_time))
+        Some(self.genesis.l2.number.saturating_add(
+            denim_timestamp.saturating_sub(self.genesis.l2_time).div_ceil(self.block_time),
+        ))
     }
 
     /// Returns the L2 block number at which the genesis-only Zenith testing gate activates.
@@ -410,20 +413,73 @@ impl RollupConfig {
             return legacy_millis;
         };
 
-        if blocks_since_genesis < denim_activation_block {
+        if block_number < denim_activation_block {
             return legacy_millis;
         }
 
+        let denim_blocks_since_genesis =
+            denim_activation_block.saturating_sub(self.genesis.l2.number);
         let denim_activation_seconds = self
             .genesis
             .l2_time
-            .saturating_add(denim_activation_block.saturating_mul(self.block_time));
+            .saturating_add(denim_blocks_since_genesis.saturating_mul(self.block_time));
         let denim_activation_full_millis = denim_activation_seconds.saturating_mul(1_000);
         denim_activation_full_millis.saturating_add(
-            blocks_since_genesis
+            block_number
                 .saturating_sub(denim_activation_block)
                 .saturating_mul(Self::NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS),
         )
+    }
+
+    /// Returns the absolute L2 block numbers whose canonical whole-second timestamp is
+    /// `timestamp`.
+    ///
+    /// The result is empty outside the configured schedule, contains at most one legacy block,
+    /// and contains at most five blocks after Denim activation.
+    pub fn l2_block_number_candidates(&self, timestamp: u64) -> Vec<u64> {
+        if self.block_time == 0 {
+            panic!("rollup config: block time cannot be 0");
+        }
+
+        let mut candidates = Vec::with_capacity(5);
+        let denim_activation_block = self.denim_activation_block_number();
+        let legacy_delta = timestamp.saturating_sub(self.genesis.l2_time);
+        let legacy_offset = if timestamp == u64::MAX {
+            legacy_delta.div_ceil(self.block_time)
+        } else {
+            legacy_delta / self.block_time
+        };
+        let legacy_block = self.genesis.l2.number.saturating_add(legacy_offset);
+        if timestamp >= self.genesis.l2_time
+            && (timestamp == u64::MAX || legacy_delta.is_multiple_of(self.block_time))
+            && denim_activation_block.is_none_or(|activation| legacy_block < activation)
+            && self.l2_block_timestamp(legacy_block) == timestamp
+        {
+            candidates.push(legacy_block);
+        }
+
+        let Some(activation_block) = denim_activation_block else {
+            return candidates;
+        };
+        let activation_millis = self.l2_block_timestamp_millis(activation_block);
+        let second_millis = timestamp.saturating_mul(1_000);
+        for millis_part in [0, 200, 400, 600, 800] {
+            let target_millis = second_millis.saturating_add(millis_part);
+            if target_millis < activation_millis {
+                continue;
+            }
+            let delta = target_millis - activation_millis;
+            let offset = if target_millis == u64::MAX {
+                delta.div_ceil(Self::NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS)
+            } else {
+                delta / Self::NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS
+            };
+            let block = activation_block.saturating_add(offset);
+            if !candidates.contains(&block) && self.l2_block_timestamp(block) == timestamp {
+                candidates.push(block);
+            }
+        }
+        candidates
     }
 
     /// Returns the deterministic whole-second timestamp of an L2 block.
@@ -1200,6 +1256,54 @@ mod tests {
             assert_eq!(cfg.l2_block_timestamp(block_number), expected / 1_000);
             assert_eq!(cfg.l2_block_timestamp_parts(block_number), (expected / 1_000, 0));
         }
+    }
+
+    #[test]
+    fn l2_block_number_candidates_cover_legacy_and_denim_boundaries() {
+        let cfg = rollup_config_with_denim(10, 2, Some(15));
+
+        assert!(cfg.l2_block_number_candidates(9).is_empty());
+        assert_eq!(cfg.l2_block_number_candidates(12), [1]);
+        assert!(cfg.l2_block_number_candidates(13).is_empty());
+        assert_eq!(cfg.l2_block_number_candidates(14), [2]);
+        assert!(cfg.l2_block_number_candidates(15).is_empty());
+        assert_eq!(cfg.l2_block_number_candidates(16), [3, 4, 5, 6, 7]);
+        assert_eq!(cfg.l2_block_number_candidates(17), [8, 9, 10, 11, 12]);
+    }
+
+    #[test]
+    fn l2_block_number_candidates_are_absolute_for_nonzero_genesis() {
+        let mut cfg = rollup_config_with_denim(10, 2, Some(15));
+        cfg.genesis.l2.number = 100;
+
+        assert_eq!(cfg.denim_activation_block_number(), Some(103));
+        assert_eq!(cfg.l2_block_number_candidates(12), [101]);
+        assert_eq!(cfg.l2_block_number_candidates(16), [103, 104, 105, 106, 107]);
+        assert_eq!(cfg.l2_block_timestamp_millis(103), 16_000);
+    }
+
+    #[test]
+    fn l2_block_number_candidates_without_denim_preserve_legacy_schedule() {
+        let cfg = rollup_config_with_denim(11, 3, None);
+
+        assert!(cfg.l2_block_number_candidates(10).is_empty());
+        assert_eq!(cfg.l2_block_number_candidates(11), [0]);
+        assert!(cfg.l2_block_number_candidates(12).is_empty());
+        assert_eq!(cfg.l2_block_number_candidates(20), [3]);
+    }
+
+    #[test]
+    fn l2_block_number_candidates_deduplicate_saturation() {
+        let cfg = rollup_config_with_denim(u64::MAX, u64::MAX, Some(u64::MAX));
+        let saturated_timestamp = u64::MAX / 1_000;
+
+        assert_eq!(cfg.l2_block_number_candidates(saturated_timestamp), [0]);
+        assert!(cfg.l2_block_number_candidates(saturated_timestamp - 1).is_empty());
+
+        let mut absolute = cfg;
+        absolute.genesis.l2.number = u64::MAX;
+        assert_eq!(absolute.denim_activation_block_number(), Some(u64::MAX));
+        assert_eq!(absolute.l2_block_number_candidates(saturated_timestamp), [u64::MAX]);
     }
 
     #[test]

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -375,12 +375,10 @@ impl RollupConfig {
             panic!("rollup config: block time cannot be 0");
         }
 
-        if denim_timestamp <= self.genesis.l2_time {
-            return Some(self.genesis.l2.number);
-        }
-
-        let activation_delay = denim_timestamp - self.genesis.l2_time;
-        Some(self.genesis.l2.number + activation_delay.div_ceil(self.block_time))
+        Some(
+            self.genesis.l2.number
+                + denim_timestamp.saturating_sub(self.genesis.l2_time).div_ceil(self.block_time),
+        )
     }
 
     /// Returns the L2 block number at which the genesis-only Zenith testing gate activates.
@@ -393,12 +391,10 @@ impl RollupConfig {
             panic!("rollup config: block time cannot be 0");
         }
 
-        if zenith_timestamp <= self.genesis.l2_time {
-            return Some(self.genesis.l2.number);
-        }
-
-        let activation_delay = zenith_timestamp - self.genesis.l2_time;
-        Some(self.genesis.l2.number + activation_delay.div_ceil(self.block_time))
+        Some(
+            self.genesis.l2.number
+                + zenith_timestamp.saturating_sub(self.genesis.l2_time).div_ceil(self.block_time),
+        )
     }
 
     /// Returns the deterministic timestamp of an L2 block in milliseconds.

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -1,6 +1,6 @@
 //! Rollup Config Types
 
-use alloc::vec::Vec;
+use core::ops::RangeInclusive;
 
 use alloy_chains::Chain;
 use alloy_hardforks::{EthereumHardfork, EthereumHardforks, ForkCondition};
@@ -434,21 +434,27 @@ impl RollupConfig {
         )
     }
 
-    /// Returns the absolute L2 block numbers whose canonical whole-second timestamp is
-    /// `timestamp`.
+    /// Returns the contiguous range of absolute L2 block numbers whose whole-second header
+    /// timestamp equals `timestamp`.
     ///
-    /// The result is empty outside the configured schedule, contains at most one legacy block,
-    /// and contains at most five blocks after Denim activation.
-    pub fn l2_block_number_candidates(&self, timestamp: u64) -> Vec<u64> {
+    /// Before Denim, an aligned timestamp identifies one block. After Denim, five consecutive
+    /// 200ms blocks share each whole-second header timestamp.
+    ///
+    /// Returns [`None`] when no canonical L2 block has the given timestamp. This does not resolve
+    /// one exact Denim block; callers must use additional context, such as a span batch's parent
+    /// check, to select a block from the returned range.
+    pub fn l2_block_range_for_header_timestamp(
+        &self,
+        timestamp: u64,
+    ) -> Option<RangeInclusive<u64>> {
         if self.block_time == 0 {
             panic!("rollup config: block time cannot be 0");
         }
 
         if timestamp < self.genesis.l2_time {
-            return Vec::new();
+            return None;
         }
 
-        let mut candidates = Vec::with_capacity(5);
         let denim_activation_block = self.denim_activation_block_number();
         let legacy_delta = timestamp - self.genesis.l2_time;
         let legacy_offset = legacy_delta / self.block_time;
@@ -456,23 +462,18 @@ impl RollupConfig {
         if legacy_delta.is_multiple_of(self.block_time)
             && denim_activation_block.is_none_or(|activation| legacy_block < activation)
         {
-            candidates.push(legacy_block);
+            return Some(legacy_block..=legacy_block);
         }
 
-        let Some(activation_block) = denim_activation_block else {
-            return candidates;
-        };
+        let activation_block = denim_activation_block?;
         let activation_timestamp = self.l2_block_timestamp(activation_block);
         if timestamp < activation_timestamp {
-            return candidates;
+            return None;
         }
 
         let blocks_per_second = 1_000 / Self::NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS;
         let first_block = activation_block + (timestamp - activation_timestamp) * blocks_per_second;
-        for offset in 0..blocks_per_second {
-            candidates.push(first_block + offset);
-        }
-        candidates
+        Some(first_block..=first_block + blocks_per_second - 1)
     }
 
     /// Returns the deterministic whole-second timestamp of an L2 block.
@@ -1252,37 +1253,37 @@ mod tests {
     }
 
     #[test]
-    fn l2_block_number_candidates_cover_legacy_and_denim_boundaries() {
+    fn l2_block_range_for_header_timestamp_covers_legacy_and_denim_boundaries() {
         let cfg = rollup_config_with_denim(10, 2, Some(15));
 
-        assert!(cfg.l2_block_number_candidates(9).is_empty());
-        assert_eq!(cfg.l2_block_number_candidates(12), [1]);
-        assert!(cfg.l2_block_number_candidates(13).is_empty());
-        assert_eq!(cfg.l2_block_number_candidates(14), [2]);
-        assert!(cfg.l2_block_number_candidates(15).is_empty());
-        assert_eq!(cfg.l2_block_number_candidates(16), [3, 4, 5, 6, 7]);
-        assert_eq!(cfg.l2_block_number_candidates(17), [8, 9, 10, 11, 12]);
+        assert_eq!(cfg.l2_block_range_for_header_timestamp(9), None);
+        assert_eq!(cfg.l2_block_range_for_header_timestamp(12), Some(1..=1));
+        assert_eq!(cfg.l2_block_range_for_header_timestamp(13), None);
+        assert_eq!(cfg.l2_block_range_for_header_timestamp(14), Some(2..=2));
+        assert_eq!(cfg.l2_block_range_for_header_timestamp(15), None);
+        assert_eq!(cfg.l2_block_range_for_header_timestamp(16), Some(3..=7));
+        assert_eq!(cfg.l2_block_range_for_header_timestamp(17), Some(8..=12));
     }
 
     #[test]
-    fn l2_block_number_candidates_are_absolute_for_nonzero_genesis() {
+    fn l2_block_range_for_header_timestamp_is_absolute_for_nonzero_genesis() {
         let mut cfg = rollup_config_with_denim(10, 2, Some(15));
         cfg.genesis.l2.number = 100;
 
         assert_eq!(cfg.denim_activation_block_number(), Some(103));
-        assert_eq!(cfg.l2_block_number_candidates(12), [101]);
-        assert_eq!(cfg.l2_block_number_candidates(16), [103, 104, 105, 106, 107]);
+        assert_eq!(cfg.l2_block_range_for_header_timestamp(12), Some(101..=101));
+        assert_eq!(cfg.l2_block_range_for_header_timestamp(16), Some(103..=107));
         assert_eq!(cfg.l2_block_timestamp_millis(103), 16_000);
     }
 
     #[test]
-    fn l2_block_number_candidates_without_denim_preserve_legacy_schedule() {
+    fn l2_block_range_for_header_timestamp_without_denim_preserves_legacy_schedule() {
         let cfg = rollup_config_with_denim(11, 3, None);
 
-        assert!(cfg.l2_block_number_candidates(10).is_empty());
-        assert_eq!(cfg.l2_block_number_candidates(11), [0]);
-        assert!(cfg.l2_block_number_candidates(12).is_empty());
-        assert_eq!(cfg.l2_block_number_candidates(20), [3]);
+        assert_eq!(cfg.l2_block_range_for_header_timestamp(10), None);
+        assert_eq!(cfg.l2_block_range_for_header_timestamp(11), Some(0..=0));
+        assert_eq!(cfg.l2_block_range_for_header_timestamp(12), None);
+        assert_eq!(cfg.l2_block_range_for_header_timestamp(20), Some(3..=3));
     }
 
     #[test]

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -1251,6 +1251,16 @@ mod tests {
     }
 
     #[test]
+    fn l2_block_full_millis_uses_absolute_nonzero_genesis_block_numbers() {
+        let mut cfg = rollup_config_with_denim(10, 2, Some(15));
+        cfg.genesis.l2.number = 100;
+
+        assert_eq!(cfg.l2_block_timestamp_millis(101), 12_000);
+        assert_eq!(cfg.l2_block_timestamp_millis(103), 16_000);
+        assert_eq!(cfg.l2_block_timestamp_millis(104), 16_200);
+    }
+
+    #[test]
     fn l2_block_range_for_header_timestamp_covers_legacy_and_denim_boundaries() {
         let cfg = rollup_config_with_denim(10, 2, Some(15));
 
@@ -1271,7 +1281,6 @@ mod tests {
         assert_eq!(cfg.denim_activation_block_number(), Some(103));
         assert_eq!(cfg.l2_block_range_for_header_timestamp(12), Some(101..=101));
         assert_eq!(cfg.l2_block_range_for_header_timestamp(16), Some(103..=107));
-        assert_eq!(cfg.l2_block_timestamp_millis(103), 16_000);
     }
 
     #[test]

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -375,10 +375,12 @@ impl RollupConfig {
             panic!("rollup config: block time cannot be 0");
         }
 
-        Some(
-            self.genesis.l2.number
-                + denim_timestamp.saturating_sub(self.genesis.l2_time).div_ceil(self.block_time),
-        )
+        if denim_timestamp <= self.genesis.l2_time {
+            return Some(self.genesis.l2.number);
+        }
+
+        let activation_delay = denim_timestamp - self.genesis.l2_time;
+        Some(self.genesis.l2.number + activation_delay.div_ceil(self.block_time))
     }
 
     /// Returns the L2 block number at which the genesis-only Zenith testing gate activates.
@@ -391,10 +393,12 @@ impl RollupConfig {
             panic!("rollup config: block time cannot be 0");
         }
 
-        Some(
-            self.genesis.l2.number
-                + zenith_timestamp.saturating_sub(self.genesis.l2_time).div_ceil(self.block_time),
-        )
+        if zenith_timestamp <= self.genesis.l2_time {
+            return Some(self.genesis.l2.number);
+        }
+
+        let activation_delay = zenith_timestamp - self.genesis.l2_time;
+        Some(self.genesis.l2.number + activation_delay.div_ceil(self.block_time))
     }
 
     /// Returns the deterministic timestamp of an L2 block in milliseconds.
@@ -406,13 +410,10 @@ impl RollupConfig {
     /// block number (`self.genesis.l2.number`), which is non-zero for chains whose L2 genesis
     /// was anchored at a later block.
     pub fn l2_block_timestamp_millis(&self, block_number: u64) -> u64 {
-        let blocks_since_genesis = block_number.saturating_sub(self.genesis.l2.number);
+        let blocks_since_genesis = block_number - self.genesis.l2.number;
 
-        let legacy_seconds = self
-            .genesis
-            .l2_time
-            .saturating_add(blocks_since_genesis.saturating_mul(self.block_time));
-        let legacy_millis = legacy_seconds.saturating_mul(1_000);
+        let legacy_seconds = self.genesis.l2_time + blocks_since_genesis * self.block_time;
+        let legacy_millis = legacy_seconds * 1_000;
 
         let Some(denim_activation_block) = self.denim_activation_block_number() else {
             return legacy_millis;
@@ -423,15 +424,11 @@ impl RollupConfig {
         }
 
         let denim_blocks_since_genesis = denim_activation_block - self.genesis.l2.number;
-        let denim_activation_seconds = self
-            .genesis
-            .l2_time
-            .saturating_add(denim_blocks_since_genesis.saturating_mul(self.block_time));
-        let denim_activation_full_millis = denim_activation_seconds.saturating_mul(1_000);
-        denim_activation_full_millis.saturating_add(
-            (block_number - denim_activation_block)
-                .saturating_mul(Self::NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS),
-        )
+        let denim_activation_seconds =
+            self.genesis.l2_time + denim_blocks_since_genesis * self.block_time;
+        let denim_activation_full_millis = denim_activation_seconds * 1_000;
+        denim_activation_full_millis
+            + (block_number - denim_activation_block) * Self::NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS
     }
 
     /// Returns the contiguous range of absolute L2 block numbers whose whole-second header
@@ -478,13 +475,13 @@ impl RollupConfig {
 
     /// Returns the deterministic whole-second timestamp of an L2 block.
     pub fn l2_block_timestamp(&self, block_number: u64) -> u64 {
-        self.l2_block_timestamp_millis(block_number).saturating_div(1_000)
+        self.l2_block_timestamp_millis(block_number) / 1_000
     }
 
     /// Returns the deterministic timestamp split into `(seconds, millis_part)`.
     pub fn l2_block_timestamp_parts(&self, block_number: u64) -> (u64, u16) {
         let full_millis = self.l2_block_timestamp_millis(block_number);
-        (full_millis.saturating_div(1_000), (full_millis % 1_000) as u16)
+        (full_millis / 1_000, (full_millis % 1_000) as u16)
     }
 
     /// Computes the lower-bound block number for a timestamp, relative to the L2 genesis time and
@@ -493,7 +490,11 @@ impl RollupConfig {
     /// This uses floor division, so multiple blocks can share the same seconds-denominated
     /// timestamp while still mapping to the same lower bound.
     pub const fn block_number_lower_bound_from_timestamp(&self, timestamp: u64) -> u64 {
-        timestamp.saturating_sub(self.genesis.l2_time).saturating_div(self.block_time)
+        if timestamp < self.genesis.l2_time {
+            0
+        } else {
+            (timestamp - self.genesis.l2_time) / self.block_time
+        }
     }
 
     /// Checks the scalar value in Ecotone.
@@ -1190,6 +1191,10 @@ mod tests {
     fn l2_block_full_millis_matches_legacy_before_denim_activation() {
         let cfg = rollup_config_with_denim(10, 2, Some(15));
         assert_eq!(cfg.denim_activation_block_number(), Some(3));
+        assert_eq!(
+            rollup_config_with_denim(10, 2, Some(9)).denim_activation_block_number(),
+            Some(0)
+        );
 
         for block_number in 0..3 {
             let expected = (10 + block_number * 2) * 1_000;
@@ -1214,10 +1219,7 @@ mod tests {
 
         let activation = cfg.l2_block_timestamp_millis(3);
         let next = cfg.l2_block_timestamp_millis(4);
-        assert_eq!(
-            next.saturating_sub(activation),
-            RollupConfig::NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS
-        );
+        assert_eq!(next - activation, RollupConfig::NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS);
         assert_eq!(next, 16_200);
         assert_eq!(cfg.l2_block_timestamp_parts(4), (16, 200));
     }
@@ -1230,10 +1232,7 @@ mod tests {
         let mut previous = cfg.l2_block_timestamp_millis(start_block);
         for block_number in (start_block + 1)..=14 {
             let current = cfg.l2_block_timestamp_millis(block_number);
-            assert_eq!(
-                current.saturating_sub(previous),
-                RollupConfig::NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS
-            );
+            assert_eq!(current - previous, RollupConfig::NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS);
             previous = current;
         }
     }
@@ -1244,8 +1243,7 @@ mod tests {
 
         assert_eq!(cfg.denim_activation_block_number(), None);
         for block_number in [0_u64, 1, 2, 10, 100] {
-            let expected =
-                11u64.saturating_add(block_number.saturating_mul(3)).saturating_mul(1_000);
+            let expected = (11 + block_number * 3) * 1_000;
             assert_eq!(cfg.l2_block_timestamp_millis(block_number), expected);
             assert_eq!(cfg.l2_block_timestamp(block_number), expected / 1_000);
             assert_eq!(cfg.l2_block_timestamp_parts(block_number), (expected / 1_000, 0));
@@ -1315,6 +1313,10 @@ mod tests {
             Some(3)
         );
         assert_eq!(rollup_config_with_zenith(10, 2, None).zenith_activation_block_number(), None);
+        assert_eq!(
+            rollup_config_with_zenith(10, 2, Some(9)).zenith_activation_block_number(),
+            Some(0)
+        );
 
         let mut nonzero_genesis = rollup_config_with_zenith(10, 2, Some(15));
         nonzero_genesis.genesis.l2.number = 100;
@@ -1328,12 +1330,6 @@ mod tests {
     }
 
     #[test]
-    fn l2_block_full_millis_saturates() {
-        let saturating = rollup_config_with_denim(u64::MAX, u64::MAX, None);
-        assert_eq!(saturating.l2_block_timestamp_millis(1), u64::MAX);
-    }
-
-    #[test]
     fn test_compute_block_number_lower_bound_from_time() {
         let cfg = RollupConfig {
             genesis: ChainGenesis { l2_time: 10, ..Default::default() },
@@ -1341,6 +1337,7 @@ mod tests {
             ..Default::default()
         };
 
+        assert_eq!(cfg.block_number_lower_bound_from_timestamp(9), 0);
         assert_eq!(cfg.block_number_lower_bound_from_timestamp(20), 5);
         assert_eq!(cfg.block_number_lower_bound_from_timestamp(30), 10);
     }

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -422,16 +422,14 @@ impl RollupConfig {
             return legacy_millis;
         }
 
-        let denim_blocks_since_genesis =
-            denim_activation_block.saturating_sub(self.genesis.l2.number);
+        let denim_blocks_since_genesis = denim_activation_block - self.genesis.l2.number;
         let denim_activation_seconds = self
             .genesis
             .l2_time
             .saturating_add(denim_blocks_since_genesis.saturating_mul(self.block_time));
         let denim_activation_full_millis = denim_activation_seconds.saturating_mul(1_000);
         denim_activation_full_millis.saturating_add(
-            block_number
-                .saturating_sub(denim_activation_block)
+            (block_number - denim_activation_block)
                 .saturating_mul(Self::NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS),
         )
     }
@@ -446,15 +444,17 @@ impl RollupConfig {
             panic!("rollup config: block time cannot be 0");
         }
 
+        if timestamp < self.genesis.l2_time {
+            return Vec::new();
+        }
+
         let mut candidates = Vec::with_capacity(5);
         let denim_activation_block = self.denim_activation_block_number();
-        let legacy_delta = timestamp.saturating_sub(self.genesis.l2_time);
+        let legacy_delta = timestamp - self.genesis.l2_time;
         let legacy_offset = legacy_delta / self.block_time;
         let legacy_block = self.genesis.l2.number + legacy_offset;
-        if timestamp >= self.genesis.l2_time
-            && legacy_delta.is_multiple_of(self.block_time)
+        if legacy_delta.is_multiple_of(self.block_time)
             && denim_activation_block.is_none_or(|activation| legacy_block < activation)
-            && self.l2_block_timestamp(legacy_block) == timestamp
         {
             candidates.push(legacy_block);
         }
@@ -462,19 +462,15 @@ impl RollupConfig {
         let Some(activation_block) = denim_activation_block else {
             return candidates;
         };
-        let activation_millis = self.l2_block_timestamp_millis(activation_block);
-        let second_millis = timestamp.saturating_mul(1_000);
-        for millis_part in [0, 200, 400, 600, 800] {
-            let target_millis = second_millis.saturating_add(millis_part);
-            if target_millis < activation_millis {
-                continue;
-            }
-            let delta = target_millis - activation_millis;
-            let offset = delta / Self::NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS;
-            let block = activation_block + offset;
-            if !candidates.contains(&block) && self.l2_block_timestamp(block) == timestamp {
-                candidates.push(block);
-            }
+        let activation_timestamp = self.l2_block_timestamp(activation_block);
+        if timestamp < activation_timestamp {
+            return candidates;
+        }
+
+        let blocks_per_second = 1_000 / Self::NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS;
+        let first_block = activation_block + (timestamp - activation_timestamp) * blocks_per_second;
+        for offset in 0..blocks_per_second {
+            candidates.push(first_block + offset);
         }
         candidates
     }


### PR DESCRIPTION
## Summary

- add a `RollupConfig` inverse for mapping a canonical L2 header timestamp to its possible block numbers
- preserve absolute/non-zero-genesis arithmetic across the legacy-to-Denim cadence transition
- cover pre-Denim uniqueness, all same-second Denim slots, rollover, activation boundaries, and arithmetic edges

## Stack

1 of 4. Merge before `refactor/raw-span-batch-stream`.

## Testing

- `cargo test -p base-common-genesis --all-features --locked`
- `cargo clippy -p base-common-genesis --all-features --locked --tests -- -D warnings`
