### PR TITLE
feat(protocol): attach block numbers to span batches

### DIFF
--- a/crates/consensus/protocol/src/batch/span.rs
+++ b/crates/consensus/protocol/src/batch/span.rs
@@ -165,6 +165,7 @@ impl SpanBatch {
 
     /// Returns the absolute L2 block number for the element at `index`, when resolved.
     pub fn block_number(&self, index: usize) -> Option<u64> {
+        self.batches.get(index)?;
         self.start_block_number.map(|number| number + index as u64)
     }
 
@@ -812,6 +813,7 @@ mod tests {
 
         assert_eq!(batch.start_block_number, Some(1));
         assert_eq!(batch.block_number(3), Some(4));
+        assert_eq!(batch.block_number(8), None);
         assert_eq!(batch.final_block_number(), Some(8));
         assert_eq!(
             batch.batches.iter().map(|batch| batch.timestamp).collect::<Vec<_>>(),

--- a/crates/consensus/protocol/src/batch/span.rs
+++ b/crates/consensus/protocol/src/batch/span.rs
@@ -809,15 +809,68 @@ mod tests {
         let mut batch =
             SpanBatch { batches: vec![SpanBatchElement::default(); 8], ..Default::default() };
 
+        assert_eq!(batch.block_number(0), None);
+        assert_eq!(batch.final_block_number(), None);
+
         batch.apply_block_number_timestamps(&cfg, 1);
 
         assert_eq!(batch.start_block_number, Some(1));
+        assert_eq!(batch.block_number(0), Some(1));
         assert_eq!(batch.block_number(3), Some(4));
+        assert_eq!(batch.block_number(7), Some(8));
         assert_eq!(batch.block_number(8), None);
         assert_eq!(batch.final_block_number(), Some(8));
         assert_eq!(
             batch.batches.iter().map(|batch| batch.timestamp).collect::<Vec<_>>(),
             [2, 4, 6, 6, 6, 6, 6, 7]
+        );
+    }
+
+    #[test]
+    fn apply_block_number_timestamps_without_denim_uses_legacy_schedule() {
+        let cfg = RollupConfig {
+            genesis: ChainGenesis { l2_time: 10, ..Default::default() },
+            block_time: 2,
+            ..Default::default()
+        };
+        let mut batch =
+            SpanBatch { batches: vec![SpanBatchElement::default(); 3], ..Default::default() };
+
+        batch.apply_block_number_timestamps(&cfg, 2);
+
+        assert_eq!(batch.start_block_number, Some(2));
+        assert_eq!(batch.final_block_number(), Some(4));
+        assert_eq!(
+            batch.batches.iter().map(|batch| batch.timestamp).collect::<Vec<_>>(),
+            [14, 16, 18]
+        );
+    }
+
+    #[test]
+    fn apply_block_number_timestamps_uses_absolute_nonzero_genesis_numbers() {
+        let cfg = RollupConfig {
+            genesis: ChainGenesis {
+                l2: BlockNumHash { number: 100, ..Default::default() },
+                l2_time: 10,
+                ..Default::default()
+            },
+            block_time: 2,
+            upgrades: UpgradeConfig {
+                base: BaseUpgradeConfig { denim: Some(15), ..Default::default() },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut batch =
+            SpanBatch { batches: vec![SpanBatchElement::default(); 4], ..Default::default() };
+
+        batch.apply_block_number_timestamps(&cfg, 101);
+
+        assert_eq!(batch.start_block_number, Some(101));
+        assert_eq!(batch.final_block_number(), Some(104));
+        assert_eq!(
+            batch.batches.iter().map(|batch| batch.timestamp).collect::<Vec<_>>(),
+            [12, 14, 16, 16]
         );
     }
 

--- a/crates/consensus/protocol/src/batch/span.rs
+++ b/crates/consensus/protocol/src/batch/span.rs
@@ -156,7 +156,7 @@ impl SpanBatch {
     }
 
     /// Applies the deterministic timestamp schedule from the given first L2 block number.
-    pub fn set_start_block_number(&mut self, cfg: &RollupConfig, block_number: u64) {
+    pub fn apply_block_number_timestamps(&mut self, cfg: &RollupConfig, block_number: u64) {
         self.start_block_number = Some(block_number);
         for (index, batch) in self.batches.iter_mut().enumerate() {
             batch.timestamp = cfg.l2_block_timestamp(block_number + index as u64);
@@ -796,7 +796,7 @@ mod tests {
     }
 
     #[test]
-    fn set_start_block_number_applies_denim_timestamps() {
+    fn apply_block_number_timestamps_uses_denim_schedule() {
         let cfg = RollupConfig {
             block_time: 2,
             upgrades: UpgradeConfig {
@@ -808,7 +808,7 @@ mod tests {
         let mut batch =
             SpanBatch { batches: vec![SpanBatchElement::default(); 8], ..Default::default() };
 
-        batch.set_start_block_number(&cfg, 1);
+        batch.apply_block_number_timestamps(&cfg, 1);
 
         assert_eq!(batch.start_block_number, Some(1));
         assert_eq!(batch.block_number(3), Some(4));

--- a/crates/consensus/protocol/src/batch/span.rs
+++ b/crates/consensus/protocol/src/batch/span.rs
@@ -65,6 +65,10 @@ use crate::{
 /// - **Bit field consistency**: Ensures origin bits match block count
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct SpanBatch {
+    /// Absolute L2 block number of the first element when resolved by the derivation pipeline.
+    ///
+    /// This is in-memory context and is not encoded in the span-batch wire format.
+    pub start_block_number: Option<u64>,
     /// First 20 bytes of the parent hash of the first block in the span.
     ///
     /// This field provides a collision-resistant check to ensure the span batch
@@ -149,6 +153,24 @@ impl SpanBatch {
     /// temporal ranges and fits within L1 derivation windows.
     pub fn final_timestamp(&self) -> u64 {
         self.batches[self.batches.len() - 1].timestamp
+    }
+
+    /// Applies the deterministic timestamp schedule from the given first L2 block number.
+    pub fn set_start_block_number(&mut self, cfg: &RollupConfig, block_number: u64) {
+        self.start_block_number = Some(block_number);
+        for (index, batch) in self.batches.iter_mut().enumerate() {
+            batch.timestamp = cfg.l2_block_timestamp(block_number + index as u64);
+        }
+    }
+
+    /// Returns the absolute L2 block number for the element at `index`, when resolved.
+    pub fn block_number(&self, index: usize) -> Option<u64> {
+        self.start_block_number.map(|number| number + index as u64)
+    }
+
+    /// Returns the absolute L2 block number of the last element, when resolved.
+    pub fn final_block_number(&self) -> Option<u64> {
+        self.batches.len().checked_sub(1).and_then(|index| self.block_number(index))
     }
 
     /// Returns the L1 epoch number for the first batch in the span.
@@ -771,6 +793,30 @@ mod tests {
                 ..Default::default()
             })
             .collect()
+    }
+
+    #[test]
+    fn set_start_block_number_applies_denim_timestamps() {
+        let cfg = RollupConfig {
+            block_time: 2,
+            upgrades: UpgradeConfig {
+                base: BaseUpgradeConfig { denim: Some(6), ..Default::default() },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut batch =
+            SpanBatch { batches: vec![SpanBatchElement::default(); 8], ..Default::default() };
+
+        batch.set_start_block_number(&cfg, 1);
+
+        assert_eq!(batch.start_block_number, Some(1));
+        assert_eq!(batch.block_number(3), Some(4));
+        assert_eq!(batch.final_block_number(), Some(8));
+        assert_eq!(
+            batch.batches.iter().map(|batch| batch.timestamp).collect::<Vec<_>>(),
+            [2, 4, 6, 6, 6, 6, 6, 7]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- attach an optional absolute start block number to materialized `SpanBatch` values
- apply the deterministic timestamp schedule from that resolved block number
- expose bounds-checked element and final block-number helpers for downstream validation
- keep `Batch`, `BatchReader`, and `ChannelReader` unchanged; no wire-format change

## Stack

2 of 4. Depends on #4586 and is the base for #4588.

This PR only adds in-memory span context and timing helpers. Contextual resolution remains in the next PR.

## Testing

- `cargo nextest run -p base-protocol` (239 passed)
- `cargo +nightly fmt --all --check`
- covered by the combined protocol/derivation suite in #4588