### PR TITLE
fix(derive): resolve Denim span batches by block number

### DIFF
--- a/crates/consensus/derive/src/stages/batch/batch_stream.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_stream.rs
@@ -1,13 +1,13 @@
 //! This module contains the `BatchStream` stage.
 
-use alloc::{boxed::Box, collections::VecDeque, string::ToString, sync::Arc};
+use alloc::{boxed::Box, collections::VecDeque, string::ToString, sync::Arc, vec::Vec};
 use core::fmt::Debug;
 
 use alloy_eips::BlockNumHash;
 use async_trait::async_trait;
 use base_common_genesis::{RollupConfig, SystemConfig};
 use base_protocol::{
-    Batch, BatchValidity, BatchWithInclusionBlock, BlockInfo, L2BlockInfo, SingleBatch, SpanBatch,
+    Batch, BatchDropReason, BatchValidity, BlockInfo, L2BlockInfo, SingleBatch, SpanBatch,
     SpanBatchError,
 };
 
@@ -45,6 +45,8 @@ where
     pub prev: P,
     /// There can only be a single staged span batch.
     pub span: Option<SpanBatch>,
+    /// Span awaiting contextual resolution and its L1 inclusion block.
+    pub pending_span: Option<(SpanBatch, BlockInfo)>,
     /// A buffer of single batches derived from the [`SpanBatch`].
     pub buffer: VecDeque<SingleBatch>,
     /// A reference to the rollup config, used to check
@@ -61,7 +63,7 @@ where
 {
     /// Create a new [`BatchStream`] stage.
     pub const fn new(prev: P, config: Arc<RollupConfig>, fetcher: BF) -> Self {
-        Self { prev, span: None, buffer: VecDeque::new(), config, fetcher }
+        Self { prev, span: None, pending_span: None, buffer: VecDeque::new(), config, fetcher }
     }
 
     /// Returns if the [`BatchStream`] stage is active based on the
@@ -99,6 +101,71 @@ where
         Metrics::pipeline_batch_mem().set(batch_size);
         Ok(())
     }
+
+    /// Resolves a span's exact first L2 block from the range sharing its header timestamp, using
+    /// span coverage and the parent check.
+    pub async fn resolve_span_start_block(
+        &mut self,
+        span: &SpanBatch,
+        l2_safe_head: L2BlockInfo,
+    ) -> Result<u64, BatchValidity> {
+        let Some(first_batch) = span.batches.first() else {
+            return Err(BatchValidity::Drop(BatchDropReason::SpanBatchMisalignedTimestamp));
+        };
+
+        let next_block_number = l2_safe_head.block_info.number + 1;
+        let Some(timestamp_range) =
+            self.config.l2_block_range_for_header_timestamp(first_batch.timestamp)
+        else {
+            return Err(BatchValidity::Drop(BatchDropReason::SpanBatchMisalignedTimestamp));
+        };
+        let block_count = span.batches.len() as u64;
+        let eligible_starts = timestamp_range
+            .clone()
+            .filter(|start| {
+                *start > self.config.genesis.l2.number
+                    && *start <= next_block_number
+                    && *start + block_count > next_block_number
+            })
+            .collect::<Vec<_>>();
+        if eligible_starts.is_empty() {
+            if *timestamp_range.start() > next_block_number {
+                return Err(BatchValidity::Drop(BatchDropReason::FutureTimestampHolocene));
+            }
+            if *timestamp_range.end() + block_count <= next_block_number {
+                return Err(BatchValidity::Past);
+            }
+            return Err(BatchValidity::Drop(BatchDropReason::SpanBatchMisalignedTimestamp));
+        }
+
+        let mut resolved_start = None;
+        let mut provider_failed = false;
+        for start in eligible_starts {
+            let parent = if start == next_block_number {
+                l2_safe_head
+            } else {
+                let parent_number = start - 1;
+                match self.fetcher.l2_block_info_by_number(parent_number).await {
+                    Ok(parent) => parent,
+                    Err(error) => {
+                        warn!(target: "batch_span", block_number = parent_number, error = %error, "Failed to fetch candidate span parent");
+                        provider_failed = true;
+                        continue;
+                    }
+                }
+            };
+            if span.parent_check.as_slice() == &parent.block_info.hash[..20]
+                && resolved_start.replace(start).is_some()
+            {
+                return Err(BatchValidity::Drop(BatchDropReason::ParentHashMismatch));
+            }
+        }
+
+        if provider_failed {
+            return Err(BatchValidity::Undecided);
+        }
+        resolved_start.ok_or(BatchValidity::Drop(BatchDropReason::ParentHashMismatch))
+    }
 }
 
 #[async_trait]
@@ -111,6 +178,7 @@ where
         if self.is_active().unwrap_or(false) {
             self.prev.flush();
             self.span = None;
+            self.pending_span = None;
             self.buffer.clear();
         }
     }
@@ -133,51 +201,59 @@ where
 
         // If the buffer is empty, attempt to pull a batch from the previous stage.
         if self.buffer.is_empty() {
-            // Safety: bubble up any errors from the batch reader.
-            let batch_with_inclusion = BatchWithInclusionBlock::new(
-                self.origin().ok_or(PipelineError::MissingOrigin.crit())?,
-                self.prev.next_batch().await?,
-            );
+            if self.pending_span.is_none() {
+                let inclusion_block = self.origin().ok_or(PipelineError::MissingOrigin.crit())?;
+                match self.prev.next_batch().await? {
+                    Batch::Single(batch) => return Ok(Batch::Single(batch)),
+                    Batch::Span(span) => self.pending_span = Some((span, inclusion_block)),
+                }
+            }
 
-            // If the next batch is a singular batch, it is immediately
-            // forwarded to the `BatchQueue` stage. Otherwise, we buffer
-            // the span batch in this stage if it passes the validity checks.
-            match batch_with_inclusion.batch {
-                Batch::Single(b) => return Ok(Batch::Single(b)),
-                Batch::Span(b) => {
-                    let (validity, _) =
-                        base_metrics::time!(Metrics::pipeline_check_batch_prefix(), {
-                            b.check_batch_prefix(
-                                self.config.as_ref(),
-                                l1_origins,
-                                parent,
-                                &batch_with_inclusion.inclusion_block,
-                                &mut self.fetcher,
-                            )
-                            .await
-                        });
-                    Metrics::pipeline_batch_validity(validity.to_string()).increment(1.0);
-
-                    match validity {
-                        BatchValidity::Accept => self.span = Some(b),
-                        BatchValidity::Drop(_) => {
-                            // Flush the stage.
-                            self.flush();
-
-                            return Err(PipelineError::NotEnoughData.temp());
-                        }
-                        BatchValidity::Past => {
-                            if !self.is_active()? {
-                                error!(target: "batch_stream", "BatchValidity::Past is not allowed pre-holocene");
-                                return Err(PipelineError::InvalidBatchValidity.crit());
+            let (mut span, inclusion_block) =
+                self.pending_span.take().expect("span must be staged");
+            if self.config.denim_activation_block_number().is_some() {
+                let first_block_number = match self.resolve_span_start_block(&span, parent).await {
+                    Ok(number) => number,
+                    Err(validity) => {
+                        Metrics::pipeline_batch_validity(validity.to_string()).increment(1.0);
+                        match validity {
+                            BatchValidity::Drop(_) => self.flush(),
+                            BatchValidity::Past => {}
+                            BatchValidity::Undecided | BatchValidity::Future => {
+                                self.pending_span = Some((span, inclusion_block));
                             }
-
-                            return Err(PipelineError::NotEnoughData.temp());
+                            BatchValidity::Accept => {
+                                unreachable!("resolution cannot accept directly")
+                            }
                         }
-                        BatchValidity::Undecided | BatchValidity::Future => {
-                            return Err(PipelineError::NotEnoughData.temp());
-                        }
+                        return Err(PipelineError::NotEnoughData.temp());
                     }
+                };
+                span.apply_block_number_timestamps(self.config.as_ref(), first_block_number);
+            }
+
+            let (validity, _) = base_metrics::time!(Metrics::pipeline_check_batch_prefix(), {
+                span.check_batch_prefix(
+                    self.config.as_ref(),
+                    l1_origins,
+                    parent,
+                    &inclusion_block,
+                    &mut self.fetcher,
+                )
+                .await
+            });
+            Metrics::pipeline_batch_validity(validity.to_string()).increment(1.0);
+
+            match validity {
+                BatchValidity::Accept => self.span = Some(span),
+                BatchValidity::Drop(_) => {
+                    self.flush();
+                    return Err(PipelineError::NotEnoughData.temp());
+                }
+                BatchValidity::Past => return Err(PipelineError::NotEnoughData.temp()),
+                BatchValidity::Undecided | BatchValidity::Future => {
+                    self.pending_span = Some((span, inclusion_block));
+                    return Err(PipelineError::NotEnoughData.temp());
                 }
             }
         }
@@ -232,6 +308,7 @@ where
         self.prev.reset(l1_origin, system_config).await?;
         self.buffer.clear();
         self.span = None;
+        self.pending_span = None;
         Ok(())
     }
 
@@ -239,6 +316,7 @@ where
         self.prev.activate().await?;
         self.buffer.clear();
         self.span = None;
+        self.pending_span = None;
         Ok(())
     }
 
@@ -246,6 +324,7 @@ where
         self.prev.flush_channel().await?;
         self.buffer.clear();
         self.span = None;
+        self.pending_span = None;
         Ok(())
     }
 }
@@ -258,7 +337,7 @@ mod tests {
     use alloy_eips::{BlockNumHash, NumHash};
     use alloy_primitives::{FixedBytes, b256};
     use base_common_consensus::BaseBlock;
-    use base_common_genesis::{ChainGenesis, SystemConfig, UpgradeConfig};
+    use base_common_genesis::{BaseUpgradeConfig, ChainGenesis, SystemConfig, UpgradeConfig};
     use base_protocol::{SingleBatch, SpanBatchElement};
 
     use super::*;
@@ -266,6 +345,115 @@ mod tests {
         StageReset,
         test_utils::{TestBatchStreamProvider, TestL2ChainProvider},
     };
+
+    fn denim_config() -> Arc<RollupConfig> {
+        Arc::new(RollupConfig {
+            block_time: 2,
+            seq_window_size: 100,
+            upgrades: UpgradeConfig {
+                delta_time: Some(0),
+                holocene_time: Some(0),
+                base: BaseUpgradeConfig { denim: Some(6), ..Default::default() },
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+    }
+
+    fn span(timestamp: u64, block_count: usize, parent_hash: FixedBytes<32>) -> SpanBatch {
+        SpanBatch {
+            parent_check: FixedBytes::from_slice(&parent_hash[..20]),
+            batches: vec![SpanBatchElement { timestamp, ..Default::default() }; block_count],
+            ..Default::default()
+        }
+    }
+
+    fn l2_block(number: u64, hash: FixedBytes<32>) -> L2BlockInfo {
+        L2BlockInfo {
+            block_info: BlockInfo { number, hash, ..Default::default() },
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn resolves_each_denim_same_second_start_slot() {
+        for start_block in 3..=7 {
+            let parent_hash = FixedBytes::repeat_byte(start_block as u8);
+            let mut stream = BatchStream::new(
+                TestBatchStreamProvider::new(vec![]),
+                denim_config(),
+                TestL2ChainProvider::default(),
+            );
+
+            assert_eq!(
+                stream
+                    .resolve_span_start_block(
+                        &span(6, 1, parent_hash),
+                        l2_block(start_block - 1, parent_hash),
+                    )
+                    .await,
+                Ok(start_block)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn resolves_overlapping_denim_span_by_parent_hash() {
+        let blocks =
+            (2..=4).map(|number| l2_block(number, FixedBytes::repeat_byte(number as u8))).collect();
+        let safe_head = l2_block(5, FixedBytes::repeat_byte(5));
+        let provider = TestL2ChainProvider { blocks, ..Default::default() };
+        let mut stream =
+            BatchStream::new(TestBatchStreamProvider::new(vec![]), denim_config(), provider);
+
+        assert_eq!(
+            stream
+                .resolve_span_start_block(&span(6, 5, FixedBytes::repeat_byte(2)), safe_head)
+                .await,
+            Ok(3)
+        );
+    }
+
+    #[tokio::test]
+    async fn drops_unmatched_or_ambiguous_denim_span_parent() {
+        for parent_hashes in [
+            [FixedBytes::repeat_byte(2), FixedBytes::repeat_byte(3)],
+            [FixedBytes::repeat_byte(2), FixedBytes::repeat_byte(2)],
+        ] {
+            let blocks = vec![l2_block(2, parent_hashes[0]), l2_block(3, parent_hashes[1])];
+            let safe_head = l2_block(4, FixedBytes::repeat_byte(4));
+            let provider = TestL2ChainProvider { blocks, ..Default::default() };
+            let mut stream =
+                BatchStream::new(TestBatchStreamProvider::new(vec![]), denim_config(), provider);
+            let expected_parent = if parent_hashes[0] == parent_hashes[1] {
+                parent_hashes[0]
+            } else {
+                FixedBytes::repeat_byte(9)
+            };
+
+            assert_eq!(
+                stream.resolve_span_start_block(&span(6, 3, expected_parent), safe_head).await,
+                Err(BatchValidity::Drop(BatchDropReason::ParentHashMismatch))
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn keeps_denim_span_undecided_when_candidate_parent_is_unavailable() {
+        let safe_head = l2_block(4, FixedBytes::repeat_byte(4));
+        let mut stream = BatchStream::new(
+            TestBatchStreamProvider::new(vec![]),
+            denim_config(),
+            TestL2ChainProvider::default(),
+        );
+
+        assert_eq!(
+            stream
+                .resolve_span_start_block(&span(6, 3, FixedBytes::repeat_byte(2)), safe_head)
+                .await,
+            Err(BatchValidity::Undecided)
+        );
+    }
 
     #[tokio::test]
     async fn test_batch_stream_flush() {

--- a/crates/consensus/protocol/src/batch/span.rs
+++ b/crates/consensus/protocol/src/batch/span.rs
@@ -311,8 +311,12 @@ impl SpanBatch {
     ) -> Result<Vec<SingleBatch>, SpanBatchError> {
         let mut single_batches = Vec::with_capacity(self.batches.len());
         let mut origin_index = 0;
-        for batch in &self.batches {
-            if batch.timestamp <= l2_safe_head.block_info.timestamp {
+        for (index, batch) in self.batches.iter().enumerate() {
+            let overlaps_safe_head = self.block_number(index).map_or_else(
+                || batch.timestamp <= l2_safe_head.block_info.timestamp,
+                |number| number <= l2_safe_head.block_info.number,
+            );
+            if overlaps_safe_head {
                 continue;
             }
             // Overlapping span batches can pass the prefix checks but then the
@@ -405,7 +409,11 @@ impl SpanBatch {
             let batch_timestamp = batch.timestamp;
             let batch_epoch = batch.epoch_num;
 
-            if batch_timestamp <= l2_safe_head.block_info.timestamp {
+            let overlaps_safe_head = self.block_number(i).map_or_else(
+                || batch_timestamp <= l2_safe_head.block_info.timestamp,
+                |number| number <= l2_safe_head.block_info.number,
+            );
+            if overlaps_safe_head {
                 continue;
             }
             if batch_epoch < l2_safe_head.l1_origin.number {
@@ -535,7 +543,11 @@ impl SpanBatch {
         let parent_num = parent_block.block_info.number;
         let next_timestamp =
             cfg.l2_block_timestamp(l2_safe_head.block_info.number.saturating_add(1));
-        if self.starting_timestamp() < next_timestamp {
+        let overlaps_safe_head = self.start_block_number.map_or_else(
+            || self.starting_timestamp() < next_timestamp,
+            |number| number <= l2_safe_head.block_info.number,
+        );
+        if overlaps_safe_head {
             for i in 0..(l2_safe_head.block_info.number - parent_num) {
                 let safe_block_num = parent_num + i + 1;
                 let safe_block_payload = match fetcher.block_by_number(safe_block_num).await {
@@ -621,8 +633,8 @@ impl SpanBatch {
         }
 
         let epoch = l1_origins[0];
-        let next_timestamp =
-            cfg.l2_block_timestamp(l2_safe_head.block_info.number.saturating_add(1));
+        let next_block_number = l2_safe_head.block_info.number + 1;
+        let next_timestamp = cfg.l2_block_timestamp(next_block_number);
 
         let starting_epoch_num = self.starting_epoch_num();
         let mut batch_origin = epoch;
@@ -647,7 +659,11 @@ impl SpanBatch {
             return (BatchValidity::Drop(BatchDropReason::SpanBatchPreDelta), None);
         }
 
-        if self.starting_timestamp() > next_timestamp {
+        let starts_in_future = self.start_block_number.map_or_else(
+            || self.starting_timestamp() > next_timestamp,
+            |number| number > next_block_number,
+        );
+        if starts_in_future {
             warn!(
                 target: "batch_span",
                 "received out-of-order batch for future processing after next batch ({} > {})",
@@ -663,7 +679,11 @@ impl SpanBatch {
         }
 
         // Drop the batch if it has no new blocks after the safe head.
-        if self.final_timestamp() < next_timestamp {
+        let has_no_new_blocks = self.final_block_number().map_or_else(
+            || self.final_timestamp() < next_timestamp,
+            |number| number < next_block_number,
+        );
+        if has_no_new_blocks {
             warn!(target: "batch_span", "span batch has no new blocks after safe head");
             return if cfg.is_holocene_active(inclusion_block.timestamp) {
                 (BatchValidity::Past, None)
@@ -677,21 +697,36 @@ impl SpanBatch {
         // safe head.
         let mut parent_num = l2_safe_head.block_info.number;
         let mut parent_block = l2_safe_head;
-        if self.starting_timestamp() < next_timestamp {
-            if self.starting_timestamp() > l2_safe_head.block_info.timestamp {
-                // Batch timestamp cannot be between safe head and next timestamp.
-                warn!(target: "batch_span", "batch has misaligned timestamp, block time is too short");
-                return (BatchValidity::Drop(BatchDropReason::SpanBatchMisalignedTimestamp), None);
-            }
-            if !(l2_safe_head.block_info.timestamp - self.starting_timestamp())
-                .is_multiple_of(cfg.block_time)
-            {
-                warn!(target: "batch_span", "batch has misaligned timestamp, not overlapped exactly");
-                return (BatchValidity::Drop(BatchDropReason::SpanBatchNotOverlappedExactly), None);
-            }
-            parent_num = l2_safe_head.block_info.number
-                - (l2_safe_head.block_info.timestamp - self.starting_timestamp()) / cfg.block_time
-                - 1;
+        let overlaps_safe_head = self.start_block_number.map_or_else(
+            || self.starting_timestamp() < next_timestamp,
+            |number| number <= l2_safe_head.block_info.number,
+        );
+        if overlaps_safe_head {
+            parent_num = if let Some(start_block_number) = self.start_block_number {
+                start_block_number - 1
+            } else {
+                if self.starting_timestamp() > l2_safe_head.block_info.timestamp {
+                    // Batch timestamp cannot be between safe head and next timestamp.
+                    warn!(target: "batch_span", "batch has misaligned timestamp, block time is too short");
+                    return (
+                        BatchValidity::Drop(BatchDropReason::SpanBatchMisalignedTimestamp),
+                        None,
+                    );
+                }
+                if !(l2_safe_head.block_info.timestamp - self.starting_timestamp())
+                    .is_multiple_of(cfg.block_time)
+                {
+                    warn!(target: "batch_span", "batch has misaligned timestamp, not overlapped exactly");
+                    return (
+                        BatchValidity::Drop(BatchDropReason::SpanBatchNotOverlappedExactly),
+                        None,
+                    );
+                }
+                l2_safe_head.block_info.number
+                    - (l2_safe_head.block_info.timestamp - self.starting_timestamp())
+                        / cfg.block_time
+                    - 1
+            };
             parent_block = match fetcher.l2_block_info_by_number(parent_num).await {
                 Ok(block) => block,
                 Err(e) => {
@@ -1058,6 +1093,28 @@ mod tests {
         let logs = trace_store.get_by_level(Level::WARN);
         assert_eq!(logs.len(), 1);
         assert!(logs[0].contains("empty span batch, cannot proceed with batch checking"));
+    }
+
+    #[test]
+    fn resolved_span_keeps_new_same_second_blocks_after_safe_head() {
+        let l1_block = BlockInfo { number: 1, timestamp: 0, ..Default::default() };
+        let l2_safe_head = L2BlockInfo {
+            block_info: BlockInfo { number: 5, timestamp: 6, ..Default::default() },
+            l1_origin: l1_block.id(),
+            ..Default::default()
+        };
+        let batch = SpanBatch {
+            start_block_number: Some(3),
+            batches: (0..5)
+                .map(|_| SpanBatchElement { epoch_num: 1, timestamp: 6, ..Default::default() })
+                .collect(),
+            ..Default::default()
+        };
+
+        let singular = batch.get_singular_batches(&[l1_block], l2_safe_head).unwrap();
+
+        assert_eq!(singular.len(), 2);
+        assert_eq!(singular.iter().map(|batch| batch.timestamp).collect::<Vec<_>>(), [6, 6]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- resolve a materialized span's absolute start height from its header timestamp, coverage, and parent check
- re-time Denim span elements from absolute block numbers through `RollupConfig`
- use resolved heights for parent lookup and overlap filtering, including same-second and rollover cases
- keep `Batch` throughout the derivation pipeline and leave the span-batch wire format unchanged

## Stack

3 of 4. Depends on #4587 and is the base for #4589.

The contextual resolution, timestamp application, and overlap changes are kept atomic because none is independently safe under Denim.

## Testing

- `cargo nextest run -p base-protocol -p base-consensus-derive` (451 passed)
- `cargo clippy -p base-protocol -p base-consensus-derive --all-targets -- -D warnings`
- `cargo +nightly fmt --all --check`