### PR TITLE
feat(cli): Configurable Finalized Poll Interval

### DIFF
--- a/crates/consensus/cli/src/follow.rs
+++ b/crates/consensus/cli/src/follow.rs
@@ -275,7 +275,11 @@ impl ConsensusFollowNodeArgs {
                 self.config.l1_rpc_args.l1_eth_rpc.clone(),
                 self.config.l1_rpc_args.l1_rpc_timeout,
             ),
-            finalized_poll_interval: L1Config::default_finalized_poll_interval(cfg.l1_chain_id),
+            finalized_poll_interval: self
+                .config
+                .l1_rpc_args
+                .l1_finalized_poll_interval
+                .unwrap_or_else(|| L1Config::default_finalized_poll_interval(cfg.l1_chain_id)),
             verifier_l1_confs: self.config.l1_rpc_args.l1_verifier_confs,
             da_batcher_sender_override: self.config.l1_rpc_args.l1_da_batcher_sender_override,
         })

--- a/crates/consensus/cli/src/l1.rs
+++ b/crates/consensus/cli/src/l1.rs
@@ -59,6 +59,18 @@ pub struct L1ClientArgs {
     /// the verifier derives from the latest L1 head with no confirmation delay.
     #[arg(long = "l1.verifier-confs", default_value = "0", env = "BASE_NODE_VERIFIER_L1_CONFS")]
     pub l1_verifier_confs: u64,
+    /// Interval, in milliseconds, between polls of the L1 `finalized` block tag. This governs how
+    /// quickly the node observes new L1 finality checkpoints and, in turn, advances its finalized
+    /// L2 head. Controlled via `BASE_NODE_FINALIZED_POLL_INTERVAL_MS`. When unset, a
+    /// chain-specific default is used (one L1 epoch, ~384s, on Ethereum mainnet/Sepolia).
+    #[arg(
+        long = "l1.finalized-poll-interval-ms",
+        env = "BASE_NODE_FINALIZED_POLL_INTERVAL_MS",
+        value_parser = |arg: &str| -> Result<Duration, ParseIntError> {
+            Ok(Duration::from_millis(arg.parse()?))
+        }
+    )]
+    pub l1_finalized_poll_interval: Option<Duration>,
 }
 
 impl Default for L1ClientArgs {
@@ -71,6 +83,7 @@ impl Default for L1ClientArgs {
             l1_slot_duration_override: None,
             l1_da_batcher_sender_override: None,
             l1_verifier_confs: 0,
+            l1_finalized_poll_interval: None,
         }
     }
 }
@@ -108,5 +121,35 @@ mod tests {
         .args;
 
         assert_eq!(args.l1_rpc_timeout, Duration::from_millis(2500));
+    }
+
+    #[test]
+    fn finalized_poll_interval_defaults_to_none() {
+        let args = Command::parse_from([
+            "base-consensus",
+            "--l1-eth-rpc",
+            "http://localhost:8545",
+            "--l1-beacon",
+            "http://localhost:5052",
+        ])
+        .args;
+
+        assert_eq!(args.l1_finalized_poll_interval, None);
+    }
+
+    #[test]
+    fn parses_finalized_poll_interval_in_milliseconds() {
+        let args = Command::parse_from([
+            "base-consensus",
+            "--l1-eth-rpc",
+            "http://localhost:8545",
+            "--l1-beacon",
+            "http://localhost:5052",
+            "--l1.finalized-poll-interval-ms",
+            "60000",
+        ])
+        .args;
+
+        assert_eq!(args.l1_finalized_poll_interval, Some(Duration::from_millis(60000)));
     }
 }

--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -509,6 +509,9 @@ impl ConsensusNodeArgs {
             l1_rpc: upgrade_signal_l1_rpc,
         });
 
+        if let Some(interval) = self.config.l1_rpc_args.l1_finalized_poll_interval {
+            builder = builder.with_finalized_poll_interval(interval);
+        }
         if let Some(path) = self.config.checkpoint_path.clone() {
             builder = builder.with_checkpoint_path(path);
         }


### PR DESCRIPTION
## Summary

Backport of #4593 to `releases/v1.3.0`. Adds a configurable interval for polling the L1 `finalized` block tag, exposed as the `--l1.finalized-poll-interval-ms` CLI flag and the `BASE_NODE_FINALIZED_POLL_INTERVAL_MS` environment variable, wired for both the normal node and follow node paths. When left unset the existing per-chain default (one L1 epoch, ~384s on mainnet/Sepolia) is preserved, so behavior is fully backward compatible. This lets operators shorten the L1 finality poll cadence to narrow the window of cross-node finalized-head divergence.