### PR TITLE
fix(precompiles): restore old-policy-first read order in stablecoin V1 updatePolicy

### DIFF
--- a/crates/common/precompiles/src/b20_stablecoin/logic/v1.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v1.rs
@@ -672,10 +672,12 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> Stablecoin<S, A> for Stableco
 mod tests {
     use alloc::{
         collections::BTreeMap,
+        rc::Rc,
         string::{String, ToString},
         vec,
         vec::Vec,
     };
+    use core::cell::RefCell;
 
     use alloy_primitives::{Address, B256, LogData, U256, keccak256};
     use alloy_sol_types::SolEvent;
@@ -721,6 +723,9 @@ mod tests {
         role_admins: BTreeMap<B256, B256>,
         policy_ids: BTreeMap<B256, u64>,
         events: Vec<LogData>,
+        /// Records storage-access order; shared with [`FakePolicyAccounting`] via
+        /// [`token_with_access_log`] so tests can assert cross-trait read ordering.
+        access_log: Rc<RefCell<Vec<&'static str>>>,
     }
 
     impl FakeAccounting {
@@ -742,6 +747,7 @@ mod tests {
                 role_admins: BTreeMap::new(),
                 policy_ids: BTreeMap::new(),
                 events: Vec::new(),
+                access_log: Rc::new(RefCell::new(Vec::new())),
             }
         }
     }
@@ -842,6 +848,7 @@ mod tests {
             Ok(())
         }
         fn policy_id(&self, policy_scope: B256) -> Result<u64> {
+            self.access_log.borrow_mut().push("old_policy_id");
             Ok(self.policy_ids.get(&policy_scope).copied().unwrap_or(0))
         }
         fn set_policy_id(&mut self, policy_scope: B256, policy_id: u64) -> Result<()> {
@@ -878,6 +885,9 @@ mod tests {
         pending_admins: BTreeMap<u64, Address>,
         next_counter: u64,
         events: Vec<LogData>,
+        /// Records storage-access order; shared with [`FakeAccounting`] via
+        /// [`token_with_access_log`] so tests can assert cross-trait read ordering.
+        access_log: Rc<RefCell<Vec<&'static str>>>,
     }
 
     impl FakePolicyAccounting {
@@ -890,6 +900,7 @@ mod tests {
                 pending_admins: BTreeMap::new(),
                 next_counter: 0,
                 events: Vec::new(),
+                access_log: Rc::new(RefCell::new(Vec::new())),
             }
         }
 
@@ -911,6 +922,7 @@ mod tests {
             self.caller
         }
         fn read_policy_word(&self, policy_id: u64) -> Result<U256> {
+            self.access_log.borrow_mut().push("new_policy_exists");
             Ok(self.policies.get(&policy_id).copied().unwrap_or(U256::ZERO))
         }
         fn write_policy_word(&mut self, policy_id: u64, word: U256) -> Result<()> {
@@ -973,6 +985,16 @@ mod tests {
             FakePolicyAccounting::new(),
             PolicyVersion::V1,
         )
+    }
+
+    /// Builds a token whose accounting and policy fakes share `log`, recording the order in
+    /// which each side's storage is accessed.
+    fn token_with_access_log(log: Rc<RefCell<Vec<&'static str>>>) -> Tok {
+        let mut accounting = FakeAccounting::new();
+        accounting.access_log = Rc::clone(&log);
+        let mut policy = FakePolicyAccounting::new();
+        policy.access_log = log;
+        B20StablecoinToken::with_storage_and_policy(accounting, policy, PolicyVersion::V1)
     }
 
     /// Grants `role` to `account` and keeps the admin member-count consistent.
@@ -1379,6 +1401,19 @@ mod tests {
             .update_policy(&mut tok, ADMIN, B20PolicyType::TransferSender.id(), 99, true)
             .unwrap_err();
         assert_eq!(err, BasePrecompileError::revert(IB20::PolicyNotFound { policyId: 99 }));
+    }
+
+    /// Matches the frozen Beryl reference: the old `policyId` SLOAD must happen before the
+    /// `policyExists(newPolicyId)` check, even on the revert path (BOP-549).
+    #[test]
+    fn update_policy_reads_old_policy_before_checking_new_policy_exists() {
+        let log = Rc::new(RefCell::new(Vec::new()));
+        let mut tok = token_with_access_log(Rc::clone(&log));
+        let err = LOGIC
+            .update_policy(&mut tok, ADMIN, B20PolicyType::TransferSender.id(), 99, true)
+            .unwrap_err();
+        assert_eq!(err, BasePrecompileError::revert(IB20::PolicyNotFound { policyId: 99 }));
+        assert_eq!(*log.borrow(), vec!["old_policy_id", "new_policy_exists"]);
     }
 
     #[test]

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v1.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v1.rs
@@ -672,12 +672,10 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> Stablecoin<S, A> for Stableco
 mod tests {
     use alloc::{
         collections::BTreeMap,
-        rc::Rc,
         string::{String, ToString},
         vec,
         vec::Vec,
     };
-    use core::cell::RefCell;
 
     use alloy_primitives::{Address, B256, LogData, U256, keccak256};
     use alloy_sol_types::SolEvent;
@@ -723,9 +721,6 @@ mod tests {
         role_admins: BTreeMap<B256, B256>,
         policy_ids: BTreeMap<B256, u64>,
         events: Vec<LogData>,
-        /// Records storage-access order; shared with [`FakePolicyAccounting`] via
-        /// [`token_with_access_log`] so tests can assert cross-trait read ordering.
-        access_log: Rc<RefCell<Vec<&'static str>>>,
     }
 
     impl FakeAccounting {
@@ -747,7 +742,6 @@ mod tests {
                 role_admins: BTreeMap::new(),
                 policy_ids: BTreeMap::new(),
                 events: Vec::new(),
-                access_log: Rc::new(RefCell::new(Vec::new())),
             }
         }
     }
@@ -848,7 +842,6 @@ mod tests {
             Ok(())
         }
         fn policy_id(&self, policy_scope: B256) -> Result<u64> {
-            self.access_log.borrow_mut().push("old_policy_id");
             Ok(self.policy_ids.get(&policy_scope).copied().unwrap_or(0))
         }
         fn set_policy_id(&mut self, policy_scope: B256, policy_id: u64) -> Result<()> {
@@ -885,9 +878,6 @@ mod tests {
         pending_admins: BTreeMap<u64, Address>,
         next_counter: u64,
         events: Vec<LogData>,
-        /// Records storage-access order; shared with [`FakeAccounting`] via
-        /// [`token_with_access_log`] so tests can assert cross-trait read ordering.
-        access_log: Rc<RefCell<Vec<&'static str>>>,
     }
 
     impl FakePolicyAccounting {
@@ -900,7 +890,6 @@ mod tests {
                 pending_admins: BTreeMap::new(),
                 next_counter: 0,
                 events: Vec::new(),
-                access_log: Rc::new(RefCell::new(Vec::new())),
             }
         }
 
@@ -922,7 +911,6 @@ mod tests {
             self.caller
         }
         fn read_policy_word(&self, policy_id: u64) -> Result<U256> {
-            self.access_log.borrow_mut().push("new_policy_exists");
             Ok(self.policies.get(&policy_id).copied().unwrap_or(U256::ZERO))
         }
         fn write_policy_word(&mut self, policy_id: u64, word: U256) -> Result<()> {
@@ -985,16 +973,6 @@ mod tests {
             FakePolicyAccounting::new(),
             PolicyVersion::V1,
         )
-    }
-
-    /// Builds a token whose accounting and policy fakes share `log`, recording the order in
-    /// which each side's storage is accessed.
-    fn token_with_access_log(log: Rc<RefCell<Vec<&'static str>>>) -> Tok {
-        let mut accounting = FakeAccounting::new();
-        accounting.access_log = Rc::clone(&log);
-        let mut policy = FakePolicyAccounting::new();
-        policy.access_log = log;
-        B20StablecoinToken::with_storage_and_policy(accounting, policy, PolicyVersion::V1)
     }
 
     /// Grants `role` to `account` and keeps the admin member-count consistent.
@@ -1401,19 +1379,6 @@ mod tests {
             .update_policy(&mut tok, ADMIN, B20PolicyType::TransferSender.id(), 99, true)
             .unwrap_err();
         assert_eq!(err, BasePrecompileError::revert(IB20::PolicyNotFound { policyId: 99 }));
-    }
-
-    /// Matches the frozen Beryl reference: the old `policyId` SLOAD must happen before the
-    /// `policyExists(newPolicyId)` check, even on the revert path (BOP-549).
-    #[test]
-    fn update_policy_reads_old_policy_before_checking_new_policy_exists() {
-        let log = Rc::new(RefCell::new(Vec::new()));
-        let mut tok = token_with_access_log(Rc::clone(&log));
-        let err = LOGIC
-            .update_policy(&mut tok, ADMIN, B20PolicyType::TransferSender.id(), 99, true)
-            .unwrap_err();
-        assert_eq!(err, BasePrecompileError::revert(IB20::PolicyNotFound { policyId: 99 }));
-        assert_eq!(*log.borrow(), vec!["old_policy_id", "new_policy_exists"]);
     }
 
     #[test]

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v1.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v1.rs
@@ -565,12 +565,12 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> Stablecoin<S, A> for Stableco
             B20Guards::ensure_token_role(token, caller, B20TokenRole::DefaultAdmin)?;
         }
         Self::ensure_supported_policy_type(policy_scope)?;
+        let old_policy_id = token.accounting().policy_id(policy_scope)?;
         if !token.policy().policy_exists(token.policy_storage(), new_policy_id)? {
             return Err(BasePrecompileError::revert(IB20::PolicyNotFound {
                 policyId: new_policy_id,
             }));
         }
-        let old_policy_id = token.accounting().policy_id(policy_scope)?;
         token.accounting_mut().set_policy_id(policy_scope, new_policy_id)?;
         token.accounting_mut().emit_event(
             IB20::PolicyUpdated {

--- a/crates/common/precompiles/tests/b20_stablecoin_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_stablecoin_v1_golden.rs
@@ -1894,6 +1894,30 @@ fn gas(
     (s.counter_sload(), s.counter_sstore(), s.counter_keccak256())
 }
 
+/// Like [`gas`], but for calls expected to revert — still counts the storage footprint
+/// incurred before the revert.
+fn gas_reverting(
+    setup: impl FnOnce(&mut B20StablecoinStorage<'_>),
+    caller: Address,
+    policy: FakePolicyAccounting,
+    calldata: Vec<u8>,
+) -> (u64, u64, u64) {
+    let mut s = fresh();
+    seed(&mut s, setup);
+    s.set_caller(caller);
+    s.reset_counters();
+    StorageCtx::enter(&mut s, |ctx| {
+        B20StablecoinToken::with_storage_and_policy(
+            B20StablecoinStorage::from_address(TOKEN, ctx),
+            policy,
+            PolicyVersion::V1,
+        )
+        .route(ctx, &calldata, StablecoinVersion::V1, true, NoopPrecompileCallObserver)
+    })
+    .expect_err("gas-footprint op must revert");
+    (s.counter_sload(), s.counter_sstore(), s.counter_keccak256())
+}
+
 /// An `FakePolicyAccounting` authorizing `who` under the default (0) scope.
 fn allow0(who: Address) -> FakePolicyAccounting {
     let mut p = FakePolicyAccounting::new();
@@ -2069,6 +2093,19 @@ fn golden_gas_footprints() {
                 .abi_encode(),
             ),
         ),
+        (
+            "update_policy_reverts_missing_policy",
+            gas_reverting(
+                |_t| {},
+                ADMIN,
+                FakePolicyAccounting::new(),
+                IB20::updatePolicyCall {
+                    policyScope: B20PolicyType::TransferSender.id(),
+                    newPolicyId: 99,
+                }
+                .abi_encode(),
+            ),
+        ),
     ];
 
     let expected: &[(&str, (u64, u64, u64))] = &[
@@ -2088,6 +2125,11 @@ fn golden_gas_footprints() {
         ("revoke_role", (1, 1, 0)),
         ("set_role_admin", (1, 1, 0)),
         ("update_policy", (2, 1, 0)),
+        // BOP-549: the old policyId SLOAD must still happen even though newPolicyId=99
+        // doesn't exist and the call reverts. A check-new-first regression returns via
+        // `?` before ever reading the old policyId, so its footprint here would be
+        // (0, 0, 0) instead.
+        ("update_policy_reverts_missing_policy", (1, 0, 0)),
     ];
 
     bless_or_assert_gas(&actual, expected);

--- a/crates/common/precompiles/tests/b20_stablecoin_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_stablecoin_v1_golden.rs
@@ -2125,10 +2125,6 @@ fn golden_gas_footprints() {
         ("revoke_role", (1, 1, 0)),
         ("set_role_admin", (1, 1, 0)),
         ("update_policy", (2, 1, 0)),
-        // BOP-549: the old policyId SLOAD must still happen even though newPolicyId=99
-        // doesn't exist and the call reverts. A check-new-first regression returns via
-        // `?` before ever reading the old policyId, so its footprint here would be
-        // (0, 0, 0) instead.
         ("update_policy_reverts_missing_policy", (1, 0, 0)),
     ];
 


### PR DESCRIPTION
## Summary
- Beryl-frozen `b20_stablecoin::logic::v1::StablecoinV1::update_policy` checked `policyExists(newPolicyId)` before reading the old `policyId`, skipping the old-id SLOAD on the invalid-new-ID path.
- The deployed Beryl reference reads old `policyId` first, then validates the new policy — this reimplementation regressed the ordering, causing a caller-visible divergence in gas cost and revert/halt behavior (see BOP-549).
- Verified against the actual frozen Beryl release source: `b20_stablecoin/token.rs` did old-id-first, while `b20_asset/token.rs` at the same commit already did new-first — so this fix is scoped to Stablecoin V1 only. Stablecoin V2 and both Asset versions (V1/V2) are confirmed unchanged and still consistent with each other.
- Added a golden-test regression check: `golden_gas_footprints` (in `b20_stablecoin_v1_golden.rs`) now covers the `updatePolicy` revert-on-missing-policy path, asserting the real storage-access footprint (SLOAD/SSTORE/KECCAK256 counts) still includes the old-`policyId` SLOAD even though the call reverts. This reuses the existing golden-test harness (real `B20StablecoinStorage`, not a fake) and its schedule-independent op-count convention rather than a bespoke unit-test instrumentation.

## Test plan
- [x] `cargo test -p base-common-precompiles` — 658 unit tests pass, including the existing `update_policy_sets_new_id` / `update_policy_reverts_when_policy_missing` for all four implementations
- [x] `cargo test -p base-common-precompiles --features test-utils --test b20_stablecoin_v1_golden` — 84 golden tests pass, including the new `update_policy_reverts_missing_policy` footprint case in `golden_gas_footprints`
- [x] Confirmed the new footprint assertion catches the regression: temporarily reverting the fix drops the footprint from `(1, 0, 0)` to `(0, 0, 0)` (the old-id SLOAD gets skipped), causing `golden_gas_footprints` to fail
- [x] Confirmed `b20_stablecoin/logic/v2.rs`, `b20_asset/logic/v1.rs`, `b20_asset/logic/v2.rs` are unmodified and byte-identical to each other in `update_policy`
- [x] `cargo clippy -p base-common-precompiles --tests --features test-utils` and `cargo +nightly fmt -- --check` clean on touched files

Fixes BOP-549 (Stablecoin V1 portion).