### PR TITLE
fix(precompiles): resolve active token version for factory bootstrap init calls

### DIFF
--- a/crates/common/precompiles/src/b20_factory/logic/v1.rs
+++ b/crates/common/precompiles/src/b20_factory/logic/v1.rs
@@ -9,10 +9,10 @@ use base_precompile_storage::{BasePrecompileError, ContractStorage, Result};
 use revm::state::Bytecode;
 
 use crate::{
-    ActivationRegistryStorage, AssetVersion, B20AssetInit, B20AssetStorage, B20AssetToken,
+    ActivationRegistryStorage, AssetVersions, B20AssetInit, B20AssetStorage, B20AssetToken,
     B20FactoryStorage, B20StablecoinInit, B20StablecoinStorage, B20StablecoinToken, B20TokenRole,
     B20Variant, Factory, IB20Factory, NoopPrecompileCallObserver, PolicyRegistryStorage,
-    PolicyVersions, StablecoinVersion, Token,
+    PolicyVersions, StablecoinVersions, Token,
 };
 
 /// Version byte for `B20StablecoinEventParams` inside `B20Created.variantParams`.
@@ -81,14 +81,15 @@ impl FactoryV1 {
             )?;
         }
 
-        // Pinned to V1: factory-init setup calls run before any later fork can be relevant.
+        let stablecoin_version = StablecoinVersions::from_base_upgrade(upgrade)
+            .ok_or_else(|| BasePrecompileError::Revert(Bytes::new()))?;
         storage.storage().with_caller(B20FactoryStorage::ADDRESS, || {
             for (index, calldata) in init_calls.into_iter().enumerate() {
                 token
                     .route(
                         storage.storage(),
                         &calldata,
-                        StablecoinVersion::V1,
+                        stablecoin_version,
                         true,
                         NoopPrecompileCallObserver,
                     )
@@ -140,14 +141,15 @@ impl FactoryV1 {
             )?;
         }
 
-        // Pinned to V1: factory-init setup calls run before any later fork can be relevant.
+        let asset_version = AssetVersions::from_base_upgrade(upgrade)
+            .ok_or_else(|| BasePrecompileError::Revert(Bytes::new()))?;
         storage.storage().with_caller(B20FactoryStorage::ADDRESS, || {
             for (index, calldata) in init_calls.into_iter().enumerate() {
                 token
                     .route(
                         storage.storage(),
                         &calldata,
-                        AssetVersion::V1,
+                        asset_version,
                         true,
                         NoopPrecompileCallObserver,
                     )

--- a/crates/common/precompiles/tests/b20_factory_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_factory_v1_golden.rs
@@ -24,9 +24,9 @@ use alloy_sol_types::{SolCall, SolError, SolEvent, SolValue};
 use base_common_genesis::BaseUpgrade;
 use base_common_precompiles::{
     ActivationAdminConfig, ActivationFeature, ActivationRegistryStorage, AssetAccounting,
-    B20AssetStorage, B20FactoryStorage, B20StablecoinStorage, B20TokenRole, B20Variant,
-    FactoryVersion, FactoryVersions, IActivationRegistry, IB20, IB20Factory, StablecoinAccounting,
-    TokenAccounting,
+    B20AssetStorage, B20FactoryStorage, B20PolicyType, B20StablecoinStorage, B20TokenRole,
+    B20Variant, FactoryVersion, FactoryVersions, IActivationRegistry, IB20, IB20Factory,
+    IPolicyRegistry, PolicyRegistryStorage, StablecoinAccounting, TokenAccounting,
 };
 use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
 
@@ -675,6 +675,204 @@ fn golden_create_reverts_when_not_activated() {
 }
 
 // ============================================================================
+// createB20 — Cobalt bootstrap resolves the active token version (BOP-550)
+// ============================================================================
+
+/// Drives one factory call through `dispatch` at `upgrade`, returning `(is_revert, bytes)`.
+///
+/// `call_factory` is pinned to Beryl; this variant exercises the Cobalt path so bootstrap init
+/// calls resolve the *active* token version rather than the frozen V1.
+fn call_factory_at(
+    storage: &mut HashMapStorageProvider,
+    caller: Address,
+    calldata: Vec<u8>,
+    upgrade: BaseUpgrade,
+) -> (bool, Bytes) {
+    storage.set_caller(caller);
+    StorageCtx::enter(storage, |ctx| B20FactoryStorage::new(ctx).dispatch(ctx, &calldata, upgrade))
+        .map(|out| (out.is_revert(), out.bytes))
+        .expect("dispatch must not fatally error")
+}
+
+/// Creates a simple policy as `ADMIN` on the live registry (dispatched at Cobalt), returning its id.
+fn create_policy(s: &mut HashMapStorageProvider, policy_type: IPolicyRegistry::PolicyType) -> u64 {
+    s.set_caller(ADMIN);
+    let out = StorageCtx::enter(s, |ctx| {
+        PolicyRegistryStorage::new(ctx).dispatch(
+            ctx,
+            &IPolicyRegistry::createPolicyCall { admin: ADMIN, policyType: policy_type }
+                .abi_encode(),
+            BaseUpgrade::Cobalt,
+        )
+    })
+    .expect("dispatch must not fatally error");
+    assert!(!out.is_revert(), "createPolicy reverted");
+    IPolicyRegistry::createPolicyCall::abi_decode_returns(&out.bytes).unwrap()
+}
+
+/// Seeds a UNION composite over two simple ALLOWLIST children on the live registry, returning its
+/// id. Composites are a Cobalt-only (V2) policy feature; the bootstrap init call points
+/// `SEIZE_HOLDER_POLICY` at this id, and `updatePolicy` checks `policy_exists` against the registry,
+/// so the composite must genuinely exist.
+fn seed_union_composite(s: &mut HashMapStorageProvider) -> u64 {
+    s.set_caller(ACTIVATION_ADMIN);
+    StorageCtx::enter(s, |ctx| {
+        ActivationRegistryStorage::new(ctx)
+            .activate(
+                ActivationFeature::PolicyRegistry.id(),
+                ActivationAdminConfig::static_fallback(Some(ACTIVATION_ADMIN)),
+            )
+            .unwrap();
+    });
+    let child_a = create_policy(s, IPolicyRegistry::PolicyType::ALLOWLIST);
+    let child_b = create_policy(s, IPolicyRegistry::PolicyType::ALLOWLIST);
+    s.set_caller(ADMIN);
+    let out = StorageCtx::enter(s, |ctx| {
+        PolicyRegistryStorage::new(ctx).dispatch(
+            ctx,
+            &IPolicyRegistry::createCompositePolicyCall {
+                admin: ADMIN,
+                policyType: IPolicyRegistry::PolicyType::UNION,
+                childPolicyIds: vec![child_a, child_b],
+            }
+            .abi_encode(),
+            BaseUpgrade::Cobalt,
+        )
+    })
+    .expect("dispatch must not fatally error");
+    assert!(!out.is_revert(), "createCompositePolicy reverted");
+    IPolicyRegistry::createCompositePolicyCall::abi_decode_returns(&out.bytes).unwrap()
+}
+
+#[test]
+fn golden_cobalt_bootstrap_routes_asset_seize_holder_policy_init_call() {
+    // BOP-550: an adminless Asset created at Cobalt whose init call points SEIZE_HOLDER_POLICY (a
+    // V2-only scope) at a UNION composite must succeed. The factory must route the init call through
+    // the Cobalt-active AssetVersion::V2; the frozen V1 rejects the seize scope with
+    // UnsupportedPolicyType, which would roll the whole creation back.
+    let mut s = fresh();
+    let composite = seed_union_composite(&mut s);
+    let token = asset_addr(CREATOR, SALT);
+
+    let update = IB20::updatePolicyCall {
+        policyScope: B20PolicyType::SeizeHolder.id(),
+        newPolicyId: composite,
+    }
+    .abi_encode();
+    let (rev, bytes) = call_factory_at(
+        &mut s,
+        CREATOR,
+        create_call(
+            IB20Factory::B20Variant::ASSET,
+            SALT,
+            asset_params(Address::ZERO, ASSET_DECIMALS), // adminless: relies on bootstrap privilege
+            vec![Bytes::from(update)],
+        ),
+        BaseUpgrade::Cobalt,
+    );
+
+    assert!(!rev, "Cobalt bootstrap must not revert; got {bytes:?}");
+    assert_eq!(bytes, Bytes::from(IB20Factory::createB20Call::abi_encode_returns(&token)));
+    read_asset(&mut s, token, |t| {
+        assert_eq!(t.policy_id(B20PolicyType::SeizeHolder.id()).unwrap(), composite);
+    });
+}
+
+#[test]
+fn golden_cobalt_bootstrap_routes_stablecoin_seize_holder_policy_init_call() {
+    // BOP-550 (stablecoin path): the same Cobalt bootstrap must succeed for a Stablecoin, routed
+    // through StablecoinVersion::V2. Exercises `init_stablecoin`'s version resolution independently
+    // of the asset path, since the fix touches both.
+    let mut s = fresh();
+    let composite = seed_union_composite(&mut s);
+    let token = stablecoin_addr(CREATOR, SALT);
+
+    let update = IB20::updatePolicyCall {
+        policyScope: B20PolicyType::SeizeHolder.id(),
+        newPolicyId: composite,
+    }
+    .abi_encode();
+    let (rev, bytes) = call_factory_at(
+        &mut s,
+        CREATOR,
+        create_call(
+            IB20Factory::B20Variant::STABLECOIN,
+            SALT,
+            stablecoin_params(Address::ZERO, CURRENCY), // adminless: relies on bootstrap privilege
+            vec![Bytes::from(update)],
+        ),
+        BaseUpgrade::Cobalt,
+    );
+
+    assert!(!rev, "Cobalt bootstrap must not revert; got {bytes:?}");
+    assert_eq!(bytes, Bytes::from(IB20Factory::createB20Call::abi_encode_returns(&token)));
+    read_stablecoin(&mut s, token, |t| {
+        assert_eq!(t.policy_id(B20PolicyType::SeizeHolder.id()).unwrap(), composite);
+    });
+}
+
+#[test]
+fn golden_beryl_bootstrap_rejects_asset_seize_holder_policy_init_call() {
+    // The fix is upgrade-gated, not a blanket widening of V1: the same init call at Beryl must still
+    // revert UnsupportedPolicyType, because the seize scope is not part of the frozen V1 surface.
+    // The seize-scope check precedes the policy-existence check, so no policy need exist here.
+    let mut s = fresh();
+    let update =
+        IB20::updatePolicyCall { policyScope: B20PolicyType::SeizeHolder.id(), newPolicyId: 2 }
+            .abi_encode();
+    let (rev, bytes) = call_factory_at(
+        &mut s,
+        CREATOR,
+        create_call(
+            IB20Factory::B20Variant::ASSET,
+            SALT,
+            asset_params(Address::ZERO, ASSET_DECIMALS),
+            vec![Bytes::from(update)],
+        ),
+        BaseUpgrade::Beryl,
+    );
+
+    assert!(rev);
+    assert_eq!(
+        bytes,
+        Bytes::from(
+            IB20::UnsupportedPolicyType { policyScope: B20PolicyType::SeizeHolder.id() }
+                .abi_encode()
+        )
+    );
+}
+
+#[test]
+fn golden_beryl_bootstrap_rejects_stablecoin_seize_holder_policy_init_call() {
+    // Stablecoin counterpart: Beryl bootstrap must still reject the V2-only seize scope, pinning
+    // that the stablecoin fix is upgrade-gated too.
+    let mut s = fresh();
+    let update =
+        IB20::updatePolicyCall { policyScope: B20PolicyType::SeizeHolder.id(), newPolicyId: 2 }
+            .abi_encode();
+    let (rev, bytes) = call_factory_at(
+        &mut s,
+        CREATOR,
+        create_call(
+            IB20Factory::B20Variant::STABLECOIN,
+            SALT,
+            stablecoin_params(Address::ZERO, CURRENCY),
+            vec![Bytes::from(update)],
+        ),
+        BaseUpgrade::Beryl,
+    );
+
+    assert!(rev);
+    assert_eq!(
+        bytes,
+        Bytes::from(
+            IB20::UnsupportedPolicyType { policyScope: B20PolicyType::SeizeHolder.id() }
+                .abi_encode()
+        )
+    );
+}
+
+// ============================================================================
 // gas: storage-access footprint per op
 // ============================================================================
 
@@ -783,6 +981,10 @@ fn v1_op_coverage_checklist(call: IB20Factory::IB20FactoryCalls) {
             golden_create_reverts_when_not_activated,
             golden_create_propagates_typed_init_call_revert,
             golden_create_reverts_malformed_params,
+            golden_cobalt_bootstrap_routes_asset_seize_holder_policy_init_call,
+            golden_cobalt_bootstrap_routes_stablecoin_seize_holder_policy_init_call,
+            golden_beryl_bootstrap_rejects_asset_seize_holder_policy_init_call,
+            golden_beryl_bootstrap_rejects_stablecoin_seize_holder_policy_init_call,
         ]),
         C::getB20Address(_) => covered(&[golden_get_b20_address]),
         C::isB20(_) => covered(&[golden_is_b20]),

--- a/crates/common/precompiles/tests/b20_factory_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_factory_v1_golden.rs
@@ -679,9 +679,6 @@ fn golden_create_reverts_when_not_activated() {
 // ============================================================================
 
 /// Drives one factory call through `dispatch` at `upgrade`, returning `(is_revert, bytes)`.
-///
-/// `call_factory` is pinned to Beryl; this variant exercises the Cobalt path so bootstrap init
-/// calls resolve the *active* token version rather than the frozen V1.
 fn call_factory_at(
     storage: &mut HashMapStorageProvider,
     caller: Address,
@@ -710,10 +707,7 @@ fn create_policy(s: &mut HashMapStorageProvider, policy_type: IPolicyRegistry::P
     IPolicyRegistry::createPolicyCall::abi_decode_returns(&out.bytes).unwrap()
 }
 
-/// Seeds a UNION composite over two simple ALLOWLIST children on the live registry, returning its
-/// id. Composites are a Cobalt-only (V2) policy feature; the bootstrap init call points
-/// `SEIZE_HOLDER_POLICY` at this id, and `updatePolicy` checks `policy_exists` against the registry,
-/// so the composite must genuinely exist.
+/// Seeds a UNION composite over two simple ALLOWLIST children on the live registry, returning its id.
 fn seed_union_composite(s: &mut HashMapStorageProvider) -> u64 {
     s.set_caller(ACTIVATION_ADMIN);
     StorageCtx::enter(s, |ctx| {
@@ -746,10 +740,6 @@ fn seed_union_composite(s: &mut HashMapStorageProvider) -> u64 {
 
 #[test]
 fn golden_cobalt_bootstrap_routes_asset_seize_holder_policy_init_call() {
-    // BOP-550: an adminless Asset created at Cobalt whose init call points SEIZE_HOLDER_POLICY (a
-    // V2-only scope) at a UNION composite must succeed. The factory must route the init call through
-    // the Cobalt-active AssetVersion::V2; the frozen V1 rejects the seize scope with
-    // UnsupportedPolicyType, which would roll the whole creation back.
     let mut s = fresh();
     let composite = seed_union_composite(&mut s);
     let token = asset_addr(CREATOR, SALT);
@@ -765,7 +755,7 @@ fn golden_cobalt_bootstrap_routes_asset_seize_holder_policy_init_call() {
         create_call(
             IB20Factory::B20Variant::ASSET,
             SALT,
-            asset_params(Address::ZERO, ASSET_DECIMALS), // adminless: relies on bootstrap privilege
+            asset_params(Address::ZERO, ASSET_DECIMALS),
             vec![Bytes::from(update)],
         ),
         BaseUpgrade::Cobalt,
@@ -780,9 +770,6 @@ fn golden_cobalt_bootstrap_routes_asset_seize_holder_policy_init_call() {
 
 #[test]
 fn golden_cobalt_bootstrap_routes_stablecoin_seize_holder_policy_init_call() {
-    // BOP-550 (stablecoin path): the same Cobalt bootstrap must succeed for a Stablecoin, routed
-    // through StablecoinVersion::V2. Exercises `init_stablecoin`'s version resolution independently
-    // of the asset path, since the fix touches both.
     let mut s = fresh();
     let composite = seed_union_composite(&mut s);
     let token = stablecoin_addr(CREATOR, SALT);
@@ -798,7 +785,7 @@ fn golden_cobalt_bootstrap_routes_stablecoin_seize_holder_policy_init_call() {
         create_call(
             IB20Factory::B20Variant::STABLECOIN,
             SALT,
-            stablecoin_params(Address::ZERO, CURRENCY), // adminless: relies on bootstrap privilege
+            stablecoin_params(Address::ZERO, CURRENCY),
             vec![Bytes::from(update)],
         ),
         BaseUpgrade::Cobalt,
@@ -813,9 +800,6 @@ fn golden_cobalt_bootstrap_routes_stablecoin_seize_holder_policy_init_call() {
 
 #[test]
 fn golden_beryl_bootstrap_rejects_asset_seize_holder_policy_init_call() {
-    // The fix is upgrade-gated, not a blanket widening of V1: the same init call at Beryl must still
-    // revert UnsupportedPolicyType, because the seize scope is not part of the frozen V1 surface.
-    // The seize-scope check precedes the policy-existence check, so no policy need exist here.
     let mut s = fresh();
     let update =
         IB20::updatePolicyCall { policyScope: B20PolicyType::SeizeHolder.id(), newPolicyId: 2 }
@@ -844,8 +828,6 @@ fn golden_beryl_bootstrap_rejects_asset_seize_holder_policy_init_call() {
 
 #[test]
 fn golden_beryl_bootstrap_rejects_stablecoin_seize_holder_policy_init_call() {
-    // Stablecoin counterpart: Beryl bootstrap must still reject the V2-only seize scope, pinning
-    // that the stablecoin fix is upgrade-gated too.
     let mut s = fresh();
     let update =
         IB20::updatePolicyCall { policyScope: B20PolicyType::SeizeHolder.id(), newPolicyId: 2 }

--- a/crates/common/precompiles/tests/b20_factory_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_factory_v1_golden.rs
@@ -675,7 +675,7 @@ fn golden_create_reverts_when_not_activated() {
 }
 
 // ============================================================================
-// createB20 — Cobalt bootstrap resolves the active token version (BOP-550)
+// createB20 — test correct base upgrade logic is used when creating
 // ============================================================================
 
 /// Drives one factory call through `dispatch` at `upgrade`, returning `(is_revert, bytes)`.

--- a/crates/common/precompiles/tests/b20_factory_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_factory_v1_golden.rs
@@ -801,9 +801,12 @@ fn golden_cobalt_bootstrap_routes_stablecoin_seize_holder_policy_init_call() {
 #[test]
 fn golden_beryl_bootstrap_rejects_asset_seize_holder_policy_init_call() {
     let mut s = fresh();
-    let update =
-        IB20::updatePolicyCall { policyScope: B20PolicyType::SeizeHolder.id(), newPolicyId: 2 }
-            .abi_encode();
+    let composite = seed_union_composite(&mut s);
+    let update = IB20::updatePolicyCall {
+        policyScope: B20PolicyType::SeizeHolder.id(),
+        newPolicyId: composite,
+    }
+    .abi_encode();
     let (rev, bytes) = call_factory_at(
         &mut s,
         CREATOR,
@@ -829,9 +832,12 @@ fn golden_beryl_bootstrap_rejects_asset_seize_holder_policy_init_call() {
 #[test]
 fn golden_beryl_bootstrap_rejects_stablecoin_seize_holder_policy_init_call() {
     let mut s = fresh();
-    let update =
-        IB20::updatePolicyCall { policyScope: B20PolicyType::SeizeHolder.id(), newPolicyId: 2 }
-            .abi_encode();
+    let composite = seed_union_composite(&mut s);
+    let update = IB20::updatePolicyCall {
+        policyScope: B20PolicyType::SeizeHolder.id(),
+        newPolicyId: composite,
+    }
+    .abi_encode();
     let (rev, bytes) = call_factory_at(
         &mut s,
         CREATOR,


### PR DESCRIPTION
## Summary

Fixes **BOP-550**: at Cobalt, the B-20 token factory's bootstrap path dispatched Asset and Stablecoin `initCalls` through token **V1** instead of the active token version.

`FactoryV1::init_asset_token` and `init_stablecoin` resolved the *policy* version from the block's upgrade but hardcoded the *token* version (`AssetVersion::V1` / `StablecoinVersion::V1`) when routing caller-supplied `initCalls`. A valid Cobalt bootstrap whose init call depends on a V2-only scope — e.g. `updatePolicy(SEIZE_HOLDER_POLICY, compositeId)` — was routed through token V1, rejected with `UnsupportedPolicyType`, and rolled the whole `createB20` back.

## Fix

Resolve the active token version from the block's upgrade via `AssetVersions` / `StablecoinVersions::from_base_upgrade(upgrade)`, mirroring the `policy_version` resolution already present two lines above in each method, and drop the stale "pinned to V1" comment.

- The bootstrap privilege (`route`'s `privileged=true`) is preserved unchanged.
- No changes to `b20_asset` / `b20_stablecoin` V2 logic — both already exist and are tested; the factory just wasn't reaching them.
- `FactoryVersion` itself legitimately stays V1: the factory's own dispatch/ABI surface didn't change at Cobalt; only the downstream token version it routes into must track the upgrade. (The `versions.rs` line cited in the ticket is not the bug site.)

## Tests

Adds Cobalt-vs-Beryl golden regression tests for **both** asset and stablecoin bootstrap paths (reproducing the ticket's exact scenario — simple ALLOWLIST policies + a UNION composite → adminless token → `updatePolicy(SEIZE_HOLDER_POLICY, compositeId)`):

- **Cobalt**: the seize-scope init call succeeds, routed through token V2, and the policy id is written.
- **Beryl**: the same init call still reverts `UnsupportedPolicyType`, pinning that the fix is upgrade-gated, not a blanket widening of V1.

Each was verified to fail against the pre-fix (hardcoded-V1) code.

### Verification
- `cargo test -p base-common-precompiles --features test-utils` — all suites green (25 factory golden tests, including the 4 new ones).
- `cargo clippy -p base-common-precompiles --features test-utils --all-targets` — clean.

Linear: https://linear.app/coinbase/issue/BOP-550