### PR TITLE
fix(shadow-indexer): avoid acknowledging shadow blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5965,6 +5965,7 @@ dependencies = [
  "mockall",
  "reth-execution-types",
  "reth-exex",
+ "reth-network-api",
  "reth-node-api",
  "reth-primitives-traits",
  "reth-tasks",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -336,6 +336,7 @@ reth-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
 reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
 reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
 reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
 reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
 reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
 reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }

--- a/crates/execution/shadow-indexer/Cargo.toml
+++ b/crates/execution/shadow-indexer/Cargo.toml
@@ -21,6 +21,7 @@ base-common-consensus = { workspace = true, features = ["reth"] }
 reth-exex.workspace = true
 reth-execution-types.workspace = true
 reth-node-api.workspace = true
+reth-network-api.workspace = true
 reth-primitives-traits.workspace = true
 reth-tasks.workspace = true
 

--- a/crates/execution/shadow-indexer/src/exex.rs
+++ b/crates/execution/shadow-indexer/src/exex.rs
@@ -5,6 +5,7 @@ use eyre::Result;
 use futures::TryStreamExt;
 use reth_execution_types::Chain;
 use reth_exex::{ExExContext, ExExEvent, ExExNotification};
+use reth_network_api::NetworkInfo;
 use reth_node_api::{FullNodeComponents, NodeTypes};
 use reth_primitives_traits::{AlloyBlockHeader, RecoveredBlock};
 use tokio::sync::mpsc;
@@ -29,6 +30,7 @@ impl ShadowIndexerExEx {
         Node::Types: NodeTypes<Primitives = BasePrimitives>,
     {
         while let Some(notification) = ctx.notifications.try_next().await? {
+            let is_syncing = ctx.network().is_syncing();
             let fully_processed = match &notification {
                 ExExNotification::ChainCommitted { new } => {
                     debug!(
@@ -73,7 +75,11 @@ impl ShadowIndexerExEx {
                 break;
             }
 
-            if let Some(committed_chain) = notification.committed_chain() {
+            // Historical commits are canonical, but live commits are speculative shadow blocks.
+            // In live mode only the replacement chain is safe to expose as the WAL watermark.
+            if Self::should_emit_finished_height(&notification, is_syncing)
+                && let Some(committed_chain) = notification.committed_chain()
+            {
                 let tip = committed_chain.tip().num_hash();
                 debug!(
                     target: "base::shadow-indexer",
@@ -86,6 +92,17 @@ impl ShadowIndexerExEx {
         }
 
         Ok(())
+    }
+
+    const fn should_emit_finished_height(
+        notification: &ExExNotification<BasePrimitives>,
+        is_syncing: bool,
+    ) -> bool {
+        match notification {
+            ExExNotification::ChainCommitted { .. } => is_syncing,
+            ExExNotification::ChainReorged { .. } => !is_syncing,
+            ExExNotification::ChainReverted { .. } => false,
+        }
     }
 
     fn build_row(
@@ -200,6 +217,8 @@ impl ShadowIndexerExEx {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use alloy_consensus::Receipt;
     use alloy_primitives::B256;
     use reth_execution_types::{Chain, ExecutionOutcome};
@@ -348,5 +367,22 @@ mod tests {
                 "reverted rows have no replacement canonical hash"
             );
         }
+    }
+
+    #[test]
+    fn finished_height_policy_tracks_sync_and_authoritative_reorgs() {
+        let committed = ExExNotification::ChainCommitted { new: Arc::new(mk_chain(1, 1, 0)) };
+        let reorged = ExExNotification::ChainReorged {
+            old: Arc::new(mk_chain(1, 1, 0)),
+            new: Arc::new(mk_chain(1, 1, NEW_CHAIN_VARIANT)),
+        };
+        let reverted = ExExNotification::ChainReverted { old: Arc::new(mk_chain(1, 1, 0)) };
+
+        assert!(ShadowIndexerExEx::should_emit_finished_height(&committed, true));
+        assert!(!ShadowIndexerExEx::should_emit_finished_height(&committed, false));
+        assert!(!ShadowIndexerExEx::should_emit_finished_height(&reorged, true));
+        assert!(ShadowIndexerExEx::should_emit_finished_height(&reorged, false));
+        assert!(!ShadowIndexerExEx::should_emit_finished_height(&reverted, true));
+        assert!(!ShadowIndexerExEx::should_emit_finished_height(&reverted, false));
     }
 }


### PR DESCRIPTION
## Summary

- use the node network's syncing state to distinguish historical sync notifications from live shadow-building notifications
- emit `FinishedHeight` for canonical `ChainCommitted` notifications only while syncing
- emit `FinishedHeight` for authoritative `ChainReorged` replacements only while live
- keep indexing every notification regardless of acknowledgement policy

## Context

During live shadow building, `ChainCommitted` first contains a speculative shadow block. The canonical block later replaces it through `ChainReorged`. Reporting the speculative hash as the ExEx `FinishedHeight` can leave Reth's acknowledgement watermark on a block that is no longer known when finality advances. Reth then cannot finalize/prune that section of the ExEx WAL, and newer speculative candidates can overwrite valid progress before the next finality-driven pruning attempt.

Historical pipeline sync is different: its `ChainCommitted` notifications are canonical and must still advance the watermark. This change uses the same `NetworkInfo::is_syncing()` state exposed by `eth_syncing` to select between those two modes. A sync-to-live boundary can conservatively skip an acknowledgement; the next live authoritative reorg advances it.

## Testing

- `cargo test -p base-shadow-indexer`
- `cargo clippy -p base-shadow-indexer --all-targets -- -D warnings`
- `cargo fmt --all -- --check`