### PR TITLE
feat(rpc): Upgrade Readiness RPC And Command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6631,6 +6631,7 @@ dependencies = [
  "base-prover-service-client",
  "base-prover-service-protocol",
  "base-tx-manager",
+ "base-upgrade-signal",
  "chrono",
  "clap",
  "crossterm",

--- a/crates/consensus/rpc/src/base.rs
+++ b/crates/consensus/rpc/src/base.rs
@@ -1,0 +1,124 @@
+//! Implements the public `base` RPC namespace: read-only, non-admin endpoints for node operators.
+
+use core::str::FromStr;
+
+use async_trait::async_trait;
+use base_consensus_gossip::Metrics;
+use base_upgrade_signal::{
+    AlloyUpgradeSignalReader, PackedProtocolVersion, UpgradeReadiness, UpgradeSignalConfig,
+    UpgradeSignalDefaults, UpgradeSignalError, UpgradeSignalMetricLayer,
+};
+use jsonrpsee::{
+    core::RpcResult,
+    types::{ErrorCode, ErrorObject},
+};
+use tracing::warn;
+
+use crate::BaseApiServer;
+
+/// Server implementation of the public [`crate::BaseApiServer`] (`base` namespace).
+///
+/// Holds the node's upgrade-signal configuration and a contract reader so it can answer readiness
+/// queries with a fresh, authoritative L1 read (which also confirms the node can reach the contract).
+/// It is read-only and never mutates node state, so it is safe to expose on the public RPC.
+#[derive(Debug, Clone)]
+pub struct BaseRpc {
+    /// Upgrade-signal schedule read configuration (carries this node's advertised protocol version).
+    pub upgrade_signal_config: UpgradeSignalConfig,
+    /// Hardened L1 contract reader built from `upgrade_signal_config`.
+    pub upgrade_signal_reader: AlloyUpgradeSignalReader,
+}
+
+impl BaseRpc {
+    /// Creates a new `base`-namespace RPC server from the node's upgrade-signal config and reader.
+    pub const fn new(
+        upgrade_signal_config: UpgradeSignalConfig,
+        upgrade_signal_reader: AlloyUpgradeSignalReader,
+    ) -> Self {
+        Self { upgrade_signal_config, upgrade_signal_reader }
+    }
+
+    /// Parses an optional `major.minor.patch[-rc.N]` target version into a packed value.
+    ///
+    /// Returns an `invalid params` RPC error rather than a generic failure so an operator sees
+    /// exactly what was rejected.
+    fn parse_target_version(
+        target_version: Option<String>,
+    ) -> Result<Option<alloy_primitives::U256>, ErrorObject<'static>> {
+        target_version
+            .map(|version| {
+                PackedProtocolVersion::from_str(&version).map(PackedProtocolVersion::into_inner)
+            })
+            .transpose()
+            .map_err(|error| {
+                ErrorObject::owned(ErrorCode::InvalidParams.code(), error.to_string(), None::<()>)
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base_upgrade_signal::UpgradeSignalDefaults;
+
+    use super::BaseRpc;
+
+    #[test]
+    fn parses_or_rejects_target_version() {
+        assert_eq!(BaseRpc::parse_target_version(None).unwrap(), None);
+        assert_eq!(
+            BaseRpc::parse_target_version(Some("1.2.3".to_string())).unwrap(),
+            Some(UpgradeSignalDefaults::packed_protocol_version(1, 2, 3))
+        );
+
+        let error = BaseRpc::parse_target_version(Some("not-a-version".to_string())).unwrap_err();
+        assert_eq!(error.code(), jsonrpsee::types::ErrorCode::InvalidParams.code());
+    }
+}
+
+#[async_trait]
+impl BaseApiServer for BaseRpc {
+    async fn upgrade_readiness(
+        &self,
+        target_version: Option<String>,
+    ) -> RpcResult<UpgradeReadiness> {
+        Metrics::rpc_calls("base_upgradeReadiness").increment(1.0);
+
+        let target = Self::parse_target_version(target_version)?;
+        let now_secs = UpgradeSignalDefaults::now_secs();
+
+        // Fresh, authoritative read from the same contract and block tag the node uses. An empty
+        // contract is a valid pre-schedule state (the operator is likely checking a `target_version`
+        // ahead of #4), so it is reported as "nothing scheduled" rather than surfaced as an error.
+        match self
+            .upgrade_signal_config
+            .read_schedule(
+                &self.upgrade_signal_reader,
+                "upgrade readiness",
+                &[UpgradeSignalMetricLayer::Consensus],
+            )
+            .await
+        {
+            Ok(schedule) => Ok(self.upgrade_signal_config.evaluate_readiness(
+                &schedule.signals,
+                Some(schedule.l1_block_number),
+                now_secs,
+                target,
+            )),
+            Err(UpgradeSignalError::EmptySchedule) => {
+                Ok(self.upgrade_signal_config.evaluate_readiness(&[], None, now_secs, target))
+            }
+            Err(error) => {
+                warn!(
+                    target: "upgrade_signal",
+                    error = %error,
+                    "failed to read L1 upgrade schedule for readiness query"
+                );
+                Err(ErrorObject::owned(
+                    -32006,
+                    "failed to read L1 upgrade schedule",
+                    Some(error.to_string()),
+                ))
+            }
+        }
+    }
+}

--- a/crates/consensus/rpc/src/base.rs
+++ b/crates/consensus/rpc/src/base.rs
@@ -1,12 +1,16 @@
 //! Implements the public `base` RPC namespace: read-only, non-admin endpoints for node operators.
 
 use core::str::FromStr;
+use std::{
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
 
 use async_trait::async_trait;
 use base_consensus_gossip::Metrics;
 use base_upgrade_signal::{
     AlloyUpgradeSignalReader, PackedProtocolVersion, UpgradeReadiness, UpgradeSignalConfig,
-    UpgradeSignalDefaults, UpgradeSignalError, UpgradeSignalMetricLayer,
+    UpgradeSignalDefaults, UpgradeSignalError, UpgradeSignalMetricLayer, UpgradeSignalSchedule,
 };
 use jsonrpsee::{
     core::RpcResult,
@@ -15,6 +19,15 @@ use jsonrpsee::{
 use tracing::warn;
 
 use crate::BaseApiServer;
+
+/// A cached L1 schedule read, used to collapse bursts of readiness queries into one L1 read.
+#[derive(Debug, Clone)]
+struct CachedSchedule {
+    /// When the read completed.
+    read_at: Instant,
+    /// The schedule read from L1; `None` means the contract had no schedule (empty).
+    schedule: Option<UpgradeSignalSchedule>,
+}
 
 /// Server implementation of the public [`crate::BaseApiServer`] (`base` namespace).
 ///
@@ -27,15 +40,30 @@ pub struct BaseRpc {
     pub upgrade_signal_config: UpgradeSignalConfig,
     /// Hardened L1 contract reader built from `upgrade_signal_config`.
     pub upgrade_signal_reader: AlloyUpgradeSignalReader,
+    /// Short-TTL cache of the last L1 schedule read, shared across all clones of this server.
+    schedule_cache: Arc<Mutex<Option<CachedSchedule>>>,
 }
 
 impl BaseRpc {
+    /// How long a schedule read is reused before the next query reads L1 again.
+    ///
+    /// This endpoint is on the public, unauthenticated RPC and each miss reads the L1 contract (with
+    /// the reader's own retries). A short TTL collapses a burst of queries into a single L1 read,
+    /// bounding the amplification into L1 traffic. It is intentionally short — a few seconds — so it
+    /// only dedups bursts and does not meaningfully stale the answer: the node itself polls L1 far
+    /// less often, and a schedule changes only on a (rare) governance action.
+    const CACHE_TTL: Duration = Duration::from_secs(5);
+
     /// Creates a new `base`-namespace RPC server from the node's upgrade-signal config and reader.
-    pub const fn new(
+    pub fn new(
         upgrade_signal_config: UpgradeSignalConfig,
         upgrade_signal_reader: AlloyUpgradeSignalReader,
     ) -> Self {
-        Self { upgrade_signal_config, upgrade_signal_reader }
+        Self {
+            upgrade_signal_config,
+            upgrade_signal_reader,
+            schedule_cache: Arc::new(Mutex::new(None)),
+        }
     }
 
     /// Parses an optional `major.minor.patch[-rc.N]` target version into a packed value.
@@ -53,6 +81,85 @@ impl BaseRpc {
             .map_err(|error| {
                 ErrorObject::owned(ErrorCode::InvalidParams.code(), error.to_string(), None::<()>)
             })
+    }
+
+    /// Returns the cached schedule when the entry is still within [`Self::CACHE_TTL`].
+    ///
+    /// The outer `Option` distinguishes a cache hit from a miss; the inner `Option` is the cached
+    /// value (`None` = the contract was empty). A poisoned lock degrades to a miss (a fresh read).
+    fn fresh_cached_schedule(&self) -> Option<Option<UpgradeSignalSchedule>> {
+        let guard = self.schedule_cache.lock().ok()?;
+        let cached = guard.as_ref()?;
+        (cached.read_at.elapsed() < Self::CACHE_TTL).then(|| cached.schedule.clone())
+    }
+
+    /// Reads the L1 schedule, serving a recent read from the cache when one is available.
+    ///
+    /// Returns `Ok(None)` for an empty contract (a valid pre-schedule state). Read errors propagate
+    /// and are never cached, so a transient failure is retried by the next query.
+    async fn cached_schedule(&self) -> Result<Option<UpgradeSignalSchedule>, UpgradeSignalError> {
+        if let Some(cached) = self.fresh_cached_schedule() {
+            return Ok(cached);
+        }
+
+        let schedule = match self
+            .upgrade_signal_config
+            .read_schedule(
+                &self.upgrade_signal_reader,
+                "upgrade readiness",
+                &[UpgradeSignalMetricLayer::Consensus],
+            )
+            .await
+        {
+            Ok(schedule) => Some(schedule),
+            Err(UpgradeSignalError::EmptySchedule) => None,
+            Err(error) => return Err(error),
+        };
+
+        if let Ok(mut guard) = self.schedule_cache.lock() {
+            *guard = Some(CachedSchedule { read_at: Instant::now(), schedule: schedule.clone() });
+        }
+
+        Ok(schedule)
+    }
+}
+
+#[async_trait]
+impl BaseApiServer for BaseRpc {
+    async fn upgrade_readiness(
+        &self,
+        target_version: Option<String>,
+    ) -> RpcResult<UpgradeReadiness> {
+        Metrics::rpc_calls("base_upgradeReadiness").increment(1.0);
+
+        let target = Self::parse_target_version(target_version)?;
+        let now_secs = UpgradeSignalDefaults::now_secs();
+
+        // An empty contract is a valid pre-schedule state (the operator is likely checking a
+        // `target_version` ahead of #4), so it is reported as "nothing scheduled" rather than as an
+        // error.
+        let schedule = self.cached_schedule().await.map_err(|error| {
+            warn!(
+                target: "upgrade_signal",
+                error = %error,
+                "failed to read L1 upgrade schedule for readiness query"
+            );
+            ErrorObject::owned(
+                -32006,
+                "failed to read L1 upgrade schedule",
+                Some(error.to_string()),
+            )
+        })?;
+
+        Ok(match schedule {
+            Some(schedule) => self.upgrade_signal_config.evaluate_readiness(
+                &schedule.signals,
+                Some(schedule.l1_block_number),
+                now_secs,
+                target,
+            ),
+            None => self.upgrade_signal_config.evaluate_readiness(&[], None, now_secs, target),
+        })
     }
 }
 
@@ -72,53 +179,5 @@ mod tests {
 
         let error = BaseRpc::parse_target_version(Some("not-a-version".to_string())).unwrap_err();
         assert_eq!(error.code(), jsonrpsee::types::ErrorCode::InvalidParams.code());
-    }
-}
-
-#[async_trait]
-impl BaseApiServer for BaseRpc {
-    async fn upgrade_readiness(
-        &self,
-        target_version: Option<String>,
-    ) -> RpcResult<UpgradeReadiness> {
-        Metrics::rpc_calls("base_upgradeReadiness").increment(1.0);
-
-        let target = Self::parse_target_version(target_version)?;
-        let now_secs = UpgradeSignalDefaults::now_secs();
-
-        // Fresh, authoritative read from the same contract and block tag the node uses. An empty
-        // contract is a valid pre-schedule state (the operator is likely checking a `target_version`
-        // ahead of #4), so it is reported as "nothing scheduled" rather than surfaced as an error.
-        match self
-            .upgrade_signal_config
-            .read_schedule(
-                &self.upgrade_signal_reader,
-                "upgrade readiness",
-                &[UpgradeSignalMetricLayer::Consensus],
-            )
-            .await
-        {
-            Ok(schedule) => Ok(self.upgrade_signal_config.evaluate_readiness(
-                &schedule.signals,
-                Some(schedule.l1_block_number),
-                now_secs,
-                target,
-            )),
-            Err(UpgradeSignalError::EmptySchedule) => {
-                Ok(self.upgrade_signal_config.evaluate_readiness(&[], None, now_secs, target))
-            }
-            Err(error) => {
-                warn!(
-                    target: "upgrade_signal",
-                    error = %error,
-                    "failed to read L1 upgrade schedule for readiness query"
-                );
-                Err(ErrorObject::owned(
-                    -32006,
-                    "failed to read L1 upgrade schedule",
-                    Some(error.to_string()),
-                ))
-            }
-        }
     }
 }

--- a/crates/consensus/rpc/src/base.rs
+++ b/crates/consensus/rpc/src/base.rs
@@ -20,13 +20,21 @@ use tracing::warn;
 
 use crate::BaseApiServer;
 
-/// A cached L1 schedule read, used to collapse bursts of readiness queries into one L1 read.
+/// A cached outcome of an L1 schedule read, used to collapse bursts of readiness queries into a
+/// single read.
+///
+/// Both successes and failures are cached (failures for a shorter window, see
+/// [`BaseRpc::ERROR_CACHE_TTL`]): during an L1 outage a burst of queries would otherwise turn into
+/// one full retrying read per caller, since the refresh lock only serializes them. Caching the
+/// failure lets waiters fail fast off the first caller's result and recover quickly once L1 is
+/// healthy again.
 #[derive(Debug)]
-struct CachedSchedule {
+struct CachedRead {
     /// When the read completed.
     read_at: Instant,
-    /// The schedule read from L1; `None` means the contract had no schedule (empty).
-    schedule: Option<UpgradeSignalSchedule>,
+    /// The outcome of the read: `Ok(None)` = the contract had no schedule (empty), `Ok(Some)` = the
+    /// schedule read from L1, `Err` = the read failed (message retained for server-side logging).
+    outcome: Result<Option<UpgradeSignalSchedule>, String>,
 }
 
 /// Server implementation of the public [`crate::BaseApiServer`] (`base` namespace).
@@ -40,8 +48,8 @@ pub struct BaseRpc {
     pub upgrade_signal_config: UpgradeSignalConfig,
     /// Hardened L1 contract reader built from `upgrade_signal_config`.
     pub upgrade_signal_reader: AlloyUpgradeSignalReader,
-    /// Short-TTL cache of the last L1 schedule read, shared across concurrent RPC requests.
-    schedule_cache: Mutex<Option<CachedSchedule>>,
+    /// Short-TTL cache of the last L1 schedule read outcome, shared across concurrent RPC requests.
+    schedule_cache: Mutex<Option<CachedRead>>,
     /// Serializes L1 schedule refreshes so a burst of cache misses coalesces into one read.
     ///
     /// Unlike [`schedule_cache`](Self::schedule_cache) (only locked to read or write the cached
@@ -60,6 +68,13 @@ impl BaseRpc {
     /// only dedups bursts and does not meaningfully stale the answer: the node itself polls L1 far
     /// less often, and a schedule changes only on a (rare) governance action.
     const CACHE_TTL: Duration = Duration::from_secs(5);
+
+    /// How long a *failed* read is cached before the next query reads L1 again.
+    ///
+    /// Kept shorter than [`Self::CACHE_TTL`] so a burst during an L1 outage collapses into one
+    /// retrying read (rather than one per queued caller) while still recovering quickly once L1 is
+    /// healthy again.
+    const ERROR_CACHE_TTL: Duration = Duration::from_secs(1);
 
     /// Creates a new `base`-namespace RPC server from the node's upgrade-signal config and reader.
     pub const fn new(
@@ -89,23 +104,46 @@ impl BaseRpc {
             .map_err(|error| ErrorObject::owned(ErrorCode::InvalidParams.code(), error, None::<()>))
     }
 
-    /// Returns the cached schedule when the entry is still within [`Self::CACHE_TTL`].
+    /// Whether a cached outcome recorded `elapsed` ago is still fresh.
     ///
-    /// The outer `Option` distinguishes a cache hit from a miss; the inner `Option` is the cached
-    /// value (`None` = the contract was empty). A poisoned lock degrades to a miss (a fresh read).
-    fn fresh_cached_schedule(&self) -> Option<Option<UpgradeSignalSchedule>> {
+    /// Failures expire after the shorter [`Self::ERROR_CACHE_TTL`]; successes after
+    /// [`Self::CACHE_TTL`].
+    const fn outcome_is_fresh(
+        outcome: &Result<Option<UpgradeSignalSchedule>, String>,
+        elapsed: Duration,
+    ) -> bool {
+        let ttl = if outcome.is_ok() { Self::CACHE_TTL } else { Self::ERROR_CACHE_TTL };
+        elapsed.as_nanos() < ttl.as_nanos()
+    }
+
+    /// Returns the cached read outcome when the entry is still within its TTL.
+    ///
+    /// The outer `Option` distinguishes a cache hit from a miss; the inner `Result` is the cached
+    /// outcome — a schedule (`Ok(None)` = empty contract) or a failed read reconstructed as a
+    /// generic error. A poisoned lock degrades to a miss (a fresh read).
+    fn fresh_cached_read(&self) -> Option<Result<Option<UpgradeSignalSchedule>, UpgradeSignalError>> {
         let guard = self.schedule_cache.lock().ok()?;
         let cached = guard.as_ref()?;
-        (cached.read_at.elapsed() < Self::CACHE_TTL).then(|| cached.schedule.clone())
+        if !Self::outcome_is_fresh(&cached.outcome, cached.read_at.elapsed()) {
+            return None;
+        }
+        Some(match &cached.outcome {
+            Ok(schedule) => Ok(schedule.clone()),
+            Err(message) => Err(UpgradeSignalError::provider("cached upgrade readiness", message)),
+        })
     }
 
     /// Reads the L1 schedule, serving a recent read from the cache when one is available.
     ///
-    /// Returns `Ok(None)` for an empty contract (a valid pre-schedule state). Read errors propagate
-    /// and are never cached, so a transient failure is retried by the next query.
+    /// Returns `Ok(None)` for an empty contract. An empty read is *not* an authoritative
+    /// "nothing scheduled" — a healthy append-only contract always carries at least the oldest
+    /// upgrade — but it is cached and surfaced so the readiness evaluator can report it (unready
+    /// unless a `target_version` probe was supplied). Read failures are cached briefly (see
+    /// [`CachedRead`]) so a burst during an L1 outage does not turn into one retrying read per
+    /// caller, then retried once the short error TTL expires.
     async fn cached_schedule(&self) -> Result<Option<UpgradeSignalSchedule>, UpgradeSignalError> {
-        if let Some(cached) = self.fresh_cached_schedule() {
-            return Ok(cached);
+        if let Some(cached) = self.fresh_cached_read() {
+            return cached;
         }
 
         // Coalesce concurrent misses: hold the refresh lock across the L1 read so a burst of
@@ -113,12 +151,12 @@ impl BaseRpc {
         let _refresh = self.refresh_lock.lock().await;
 
         // Re-check under the refresh lock: a caller that held it before us may have just populated
-        // the cache, in which case we skip the L1 read entirely.
-        if let Some(cached) = self.fresh_cached_schedule() {
-            return Ok(cached);
+        // the cache, in which case we skip the L1 read entirely (including a just-cached failure).
+        if let Some(cached) = self.fresh_cached_read() {
+            return cached;
         }
 
-        let schedule = match self
+        let outcome = match self
             .upgrade_signal_config
             .read_schedule(
                 &self.upgrade_signal_reader,
@@ -127,16 +165,24 @@ impl BaseRpc {
             )
             .await
         {
-            Ok(schedule) => Some(schedule),
-            Err(UpgradeSignalError::EmptySchedule) => None,
-            Err(error) => return Err(error),
+            Ok(schedule) => Ok(Some(schedule)),
+            Err(UpgradeSignalError::EmptySchedule) => Ok(None),
+            Err(error) => Err(error),
         };
 
+        // Cache the outcome (success or failure) so the rest of the burst reuses it. The failure is
+        // stored as its message string; waiters get a generic error reconstructed from it.
         if let Ok(mut guard) = self.schedule_cache.lock() {
-            *guard = Some(CachedSchedule { read_at: Instant::now(), schedule: schedule.clone() });
+            *guard = Some(CachedRead {
+                read_at: Instant::now(),
+                outcome: match &outcome {
+                    Ok(schedule) => Ok(schedule.clone()),
+                    Err(error) => Err(error.to_string()),
+                },
+            });
         }
 
-        Ok(schedule)
+        outcome
     }
 }
 
@@ -151,9 +197,10 @@ impl BaseApiServer for BaseRpc {
         let target = Self::parse_target_version(target_version)?;
         let now_secs = UpgradeSignalDefaults::now_secs();
 
-        // An empty contract is a valid pre-schedule state (the operator is likely checking a
-        // `target_version` ahead of the schedule being published on L1), so it is reported as
-        // "nothing scheduled" rather than as an error.
+        // An empty read is surfaced (not errored) so the evaluator can still answer a
+        // `target_version` probe against it — but it is not treated as an authoritative "nothing
+        // scheduled": a healthy append-only contract always carries at least the oldest upgrade, so
+        // without a target the evaluator reports it unready rather than vacuously ready.
         let schedule = self.cached_schedule().await.map_err(|error| {
             // The error string can carry the L1 endpoint URL and upstream response body, and this is
             // the public, unauthenticated namespace — so log the detail server-side and return a
@@ -183,9 +230,29 @@ impl BaseApiServer for BaseRpc {
 
 #[cfg(test)]
 mod tests {
+    use core::time::Duration;
+
     use base_upgrade_signal::UpgradeSignalDefaults;
 
     use super::BaseRpc;
+
+    #[test]
+    fn failed_reads_expire_sooner_than_successful_ones() {
+        // A success stays fresh across the short error window but expires by the success TTL.
+        let success = Ok(None);
+        assert!(BaseRpc::outcome_is_fresh(&success, BaseRpc::ERROR_CACHE_TTL));
+        assert!(BaseRpc::outcome_is_fresh(&success, BaseRpc::CACHE_TTL - Duration::from_millis(1)));
+        assert!(!BaseRpc::outcome_is_fresh(&success, BaseRpc::CACHE_TTL));
+
+        // A failure is only reused within the shorter error TTL, so a burst during an outage
+        // collapses into one retrying read while recovery stays fast.
+        let failure = Err("boom".to_string());
+        assert!(BaseRpc::outcome_is_fresh(
+            &failure,
+            BaseRpc::ERROR_CACHE_TTL - Duration::from_millis(1)
+        ));
+        assert!(!BaseRpc::outcome_is_fresh(&failure, BaseRpc::ERROR_CACHE_TTL));
+    }
 
     #[test]
     fn parses_or_rejects_target_version() {

--- a/crates/consensus/rpc/src/base.rs
+++ b/crates/consensus/rpc/src/base.rs
@@ -50,12 +50,16 @@ pub struct BaseRpc {
     pub upgrade_signal_reader: AlloyUpgradeSignalReader,
     /// Short-TTL cache of the last L1 schedule read outcome, shared across concurrent RPC requests.
     schedule_cache: Mutex<Option<CachedRead>>,
-    /// Serializes L1 schedule refreshes so a burst of cache misses coalesces into one read.
+    /// Single-flights L1 schedule refreshes so a burst of cache misses never queues behind the read.
     ///
     /// Unlike [`schedule_cache`](Self::schedule_cache) (only locked to read or write the cached
-    /// value), this is held across the L1 read. Concurrent missing callers wait here, then re-check
-    /// the cache and serve the value the first caller wrote — so the public endpoint never amplifies
-    /// a burst into one L1 read per caller.
+    /// value), this guards the L1 read itself. Only the caller that wins [`try_lock`] performs the
+    /// read; concurrent missers decline rather than wait, serving the most recent cached value (even
+    /// if past its TTL) or failing fast when none exists. This both keeps the public endpoint from
+    /// amplifying a burst into one L1 read per caller and keeps that burst from tying up the node's
+    /// shared RPC slots on a slow or unavailable L1 read.
+    ///
+    /// [`try_lock`]: tokio::sync::Mutex::try_lock
     refresh_lock: tokio::sync::Mutex<()>,
 }
 
@@ -116,6 +120,19 @@ impl BaseRpc {
         elapsed.as_nanos() < ttl.as_nanos()
     }
 
+    /// Reconstructs the caller-facing outcome from a cached read.
+    ///
+    /// A cached failure is surfaced as a generic provider error rebuilt from the retained message;
+    /// the original error is not stored.
+    fn cached_outcome(
+        cached: &CachedRead,
+    ) -> Result<Option<UpgradeSignalSchedule>, UpgradeSignalError> {
+        match &cached.outcome {
+            Ok(schedule) => Ok(schedule.clone()),
+            Err(message) => Err(UpgradeSignalError::provider("cached upgrade readiness", message)),
+        }
+    }
+
     /// Returns the cached read outcome when the entry is still within its TTL.
     ///
     /// The outer `Option` distinguishes a cache hit from a miss; the inner `Result` is the cached
@@ -126,13 +143,20 @@ impl BaseRpc {
     ) -> Option<Result<Option<UpgradeSignalSchedule>, UpgradeSignalError>> {
         let guard = self.schedule_cache.lock().ok()?;
         let cached = guard.as_ref()?;
-        if !Self::outcome_is_fresh(&cached.outcome, cached.read_at.elapsed()) {
-            return None;
-        }
-        Some(match &cached.outcome {
-            Ok(schedule) => Ok(schedule.clone()),
-            Err(message) => Err(UpgradeSignalError::provider("cached upgrade readiness", message)),
-        })
+        Self::outcome_is_fresh(&cached.outcome, cached.read_at.elapsed())
+            .then(|| Self::cached_outcome(cached))
+    }
+
+    /// Returns the most recent read outcome regardless of its TTL, if any read has completed.
+    ///
+    /// Refresh followers that decline to queue behind an in-flight L1 read serve this (possibly
+    /// stale) value rather than waiting; `None` means no read has ever completed (cold cache). A
+    /// poisoned lock degrades to `None`.
+    fn last_cached_read(
+        &self,
+    ) -> Option<Result<Option<UpgradeSignalSchedule>, UpgradeSignalError>> {
+        let guard = self.schedule_cache.lock().ok()?;
+        guard.as_ref().map(Self::cached_outcome)
     }
 
     /// Reads the L1 schedule, serving a recent read from the cache when one is available.
@@ -143,17 +167,31 @@ impl BaseRpc {
     /// unless a `target_version` probe was supplied). Read failures are cached briefly (see
     /// [`CachedRead`]) so a burst during an L1 outage does not turn into one retrying read per
     /// caller, then retried once the short error TTL expires.
+    ///
+    /// Only one caller reads L1 at a time; concurrent missers decline the refresh and serve the most
+    /// recent cached value (or fail fast on a cold cache) rather than queuing behind the read, so a
+    /// public burst cannot tie up the node's shared RPC slots on a slow or unavailable L1 read.
     async fn cached_schedule(&self) -> Result<Option<UpgradeSignalSchedule>, UpgradeSignalError> {
         if let Some(cached) = self.fresh_cached_read() {
             return cached;
         }
 
-        // Coalesce concurrent misses: hold the refresh lock across the L1 read so a burst of
-        // queries collapses into a single in-flight read rather than one read per caller.
-        let _refresh = self.refresh_lock.lock().await;
+        // Single-flight the refresh without queuing behind the L1 read: only the caller that wins
+        // `try_lock` reads L1. Followers decline instead of awaiting, so a burst can never pile up
+        // on the shared RPC slots while a slow or unavailable L1 read is in flight.
+        let Ok(_refresh) = self.refresh_lock.try_lock() else {
+            // A refresh is already in flight: serve the most recent read (even if past its TTL), or
+            // fail fast when no read has ever completed rather than blocking on L1.
+            return self.last_cached_read().unwrap_or_else(|| {
+                Err(UpgradeSignalError::provider(
+                    "upgrade readiness",
+                    "L1 schedule refresh already in flight",
+                ))
+            });
+        };
 
-        // Re-check under the refresh lock: a caller that held it before us may have just populated
-        // the cache, in which case we skip the L1 read entirely (including a just-cached failure).
+        // Re-check under the refresh lock: the previous holder may have just populated the cache,
+        // in which case we skip the L1 read entirely (including a just-cached failure).
         if let Some(cached) = self.fresh_cached_read() {
             return cached;
         }
@@ -197,7 +235,6 @@ impl BaseApiServer for BaseRpc {
         Metrics::rpc_calls("base_upgradeReadiness").increment(1.0);
 
         let target = Self::parse_target_version(target_version)?;
-        let now_secs = UpgradeSignalDefaults::now_secs();
 
         // An empty read is surfaced (not errored) so the evaluator can still answer a
         // `target_version` probe against it — but it is not treated as an authoritative "nothing
@@ -214,6 +251,10 @@ impl BaseApiServer for BaseRpc {
             );
             ErrorObject::owned(-32006, "failed to read L1 upgrade schedule", None::<()>)
         })?;
+
+        // Sample the clock after the (possibly slow) schedule read, immediately before evaluating,
+        // so a read that spans the halt-lead window cannot report a stale `would_halt`.
+        let now_secs = UpgradeSignalDefaults::now_secs();
 
         // Derive the readiness inputs from the optional schedule so both the scheduled and
         // pre-schedule (empty contract) paths flow through a single `evaluate_readiness` call.

--- a/crates/consensus/rpc/src/base.rs
+++ b/crates/consensus/rpc/src/base.rs
@@ -2,7 +2,7 @@
 
 use core::str::FromStr;
 use std::{
-    sync::{Arc, Mutex},
+    sync::Mutex,
     time::{Duration, Instant},
 };
 
@@ -21,7 +21,7 @@ use tracing::warn;
 use crate::BaseApiServer;
 
 /// A cached L1 schedule read, used to collapse bursts of readiness queries into one L1 read.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct CachedSchedule {
     /// When the read completed.
     read_at: Instant,
@@ -34,14 +34,14 @@ struct CachedSchedule {
 /// Holds the node's upgrade-signal configuration and a contract reader so it can answer readiness
 /// queries with a fresh, authoritative L1 read (which also confirms the node can reach the contract).
 /// It is read-only and never mutates node state, so it is safe to expose on the public RPC.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct BaseRpc {
     /// Upgrade-signal schedule read configuration (carries this node's advertised protocol version).
     pub upgrade_signal_config: UpgradeSignalConfig,
     /// Hardened L1 contract reader built from `upgrade_signal_config`.
     pub upgrade_signal_reader: AlloyUpgradeSignalReader,
-    /// Short-TTL cache of the last L1 schedule read, shared across all clones of this server.
-    schedule_cache: Arc<Mutex<Option<CachedSchedule>>>,
+    /// Short-TTL cache of the last L1 schedule read, shared across concurrent RPC requests.
+    schedule_cache: Mutex<Option<CachedSchedule>>,
 }
 
 impl BaseRpc {
@@ -55,15 +55,11 @@ impl BaseRpc {
     const CACHE_TTL: Duration = Duration::from_secs(5);
 
     /// Creates a new `base`-namespace RPC server from the node's upgrade-signal config and reader.
-    pub fn new(
+    pub const fn new(
         upgrade_signal_config: UpgradeSignalConfig,
         upgrade_signal_reader: AlloyUpgradeSignalReader,
     ) -> Self {
-        Self {
-            upgrade_signal_config,
-            upgrade_signal_reader,
-            schedule_cache: Arc::new(Mutex::new(None)),
-        }
+        Self { upgrade_signal_config, upgrade_signal_reader, schedule_cache: Mutex::new(None) }
     }
 
     /// Parses an optional `major.minor.patch[-rc.N]` target version into a packed value.
@@ -79,7 +75,7 @@ impl BaseRpc {
             })
             .transpose()
             .map_err(|error| {
-                ErrorObject::owned(ErrorCode::InvalidParams.code(), error.to_string(), None::<()>)
+                ErrorObject::owned(ErrorCode::InvalidParams.code(), error, None::<()>)
             })
     }
 
@@ -136,8 +132,8 @@ impl BaseApiServer for BaseRpc {
         let now_secs = UpgradeSignalDefaults::now_secs();
 
         // An empty contract is a valid pre-schedule state (the operator is likely checking a
-        // `target_version` ahead of #4), so it is reported as "nothing scheduled" rather than as an
-        // error.
+        // `target_version` ahead of the schedule being published on L1), so it is reported as
+        // "nothing scheduled" rather than as an error.
         let schedule = self.cached_schedule().await.map_err(|error| {
             warn!(
                 target: "upgrade_signal",
@@ -151,15 +147,18 @@ impl BaseApiServer for BaseRpc {
             )
         })?;
 
-        Ok(match schedule {
-            Some(schedule) => self.upgrade_signal_config.evaluate_readiness(
-                &schedule.signals,
-                Some(schedule.l1_block_number),
-                now_secs,
-                target,
-            ),
-            None => self.upgrade_signal_config.evaluate_readiness(&[], None, now_secs, target),
-        })
+        // Derive the readiness inputs from the optional schedule so both the scheduled and
+        // pre-schedule (empty contract) paths flow through a single `evaluate_readiness` call.
+        let (signals, l1_block_number) = schedule.as_ref().map_or((&[][..], None), |schedule| {
+            (schedule.signals.as_slice(), Some(schedule.l1_block_number))
+        });
+
+        Ok(self.upgrade_signal_config.evaluate_readiness(
+            signals,
+            l1_block_number,
+            now_secs,
+            target,
+        ))
     }
 }
 

--- a/crates/consensus/rpc/src/base.rs
+++ b/crates/consensus/rpc/src/base.rs
@@ -121,7 +121,9 @@ impl BaseRpc {
     /// The outer `Option` distinguishes a cache hit from a miss; the inner `Result` is the cached
     /// outcome — a schedule (`Ok(None)` = empty contract) or a failed read reconstructed as a
     /// generic error. A poisoned lock degrades to a miss (a fresh read).
-    fn fresh_cached_read(&self) -> Option<Result<Option<UpgradeSignalSchedule>, UpgradeSignalError>> {
+    fn fresh_cached_read(
+        &self,
+    ) -> Option<Result<Option<UpgradeSignalSchedule>, UpgradeSignalError>> {
         let guard = self.schedule_cache.lock().ok()?;
         let cached = guard.as_ref()?;
         if !Self::outcome_is_fresh(&cached.outcome, cached.read_at.elapsed()) {

--- a/crates/consensus/rpc/src/base.rs
+++ b/crates/consensus/rpc/src/base.rs
@@ -42,6 +42,13 @@ pub struct BaseRpc {
     pub upgrade_signal_reader: AlloyUpgradeSignalReader,
     /// Short-TTL cache of the last L1 schedule read, shared across concurrent RPC requests.
     schedule_cache: Mutex<Option<CachedSchedule>>,
+    /// Serializes L1 schedule refreshes so a burst of cache misses coalesces into one read.
+    ///
+    /// Unlike [`schedule_cache`](Self::schedule_cache) (only locked to read or write the cached
+    /// value), this is held across the L1 read. Concurrent missing callers wait here, then re-check
+    /// the cache and serve the value the first caller wrote — so the public endpoint never amplifies
+    /// a burst into one L1 read per caller.
+    refresh_lock: tokio::sync::Mutex<()>,
 }
 
 impl BaseRpc {
@@ -59,7 +66,12 @@ impl BaseRpc {
         upgrade_signal_config: UpgradeSignalConfig,
         upgrade_signal_reader: AlloyUpgradeSignalReader,
     ) -> Self {
-        Self { upgrade_signal_config, upgrade_signal_reader, schedule_cache: Mutex::new(None) }
+        Self {
+            upgrade_signal_config,
+            upgrade_signal_reader,
+            schedule_cache: Mutex::new(None),
+            refresh_lock: tokio::sync::Mutex::const_new(()),
+        }
     }
 
     /// Parses an optional `major.minor.patch[-rc.N]` target version into a packed value.
@@ -74,9 +86,7 @@ impl BaseRpc {
                 PackedProtocolVersion::from_str(&version).map(PackedProtocolVersion::into_inner)
             })
             .transpose()
-            .map_err(|error| {
-                ErrorObject::owned(ErrorCode::InvalidParams.code(), error, None::<()>)
-            })
+            .map_err(|error| ErrorObject::owned(ErrorCode::InvalidParams.code(), error, None::<()>))
     }
 
     /// Returns the cached schedule when the entry is still within [`Self::CACHE_TTL`].
@@ -94,6 +104,16 @@ impl BaseRpc {
     /// Returns `Ok(None)` for an empty contract (a valid pre-schedule state). Read errors propagate
     /// and are never cached, so a transient failure is retried by the next query.
     async fn cached_schedule(&self) -> Result<Option<UpgradeSignalSchedule>, UpgradeSignalError> {
+        if let Some(cached) = self.fresh_cached_schedule() {
+            return Ok(cached);
+        }
+
+        // Coalesce concurrent misses: hold the refresh lock across the L1 read so a burst of
+        // queries collapses into a single in-flight read rather than one read per caller.
+        let _refresh = self.refresh_lock.lock().await;
+
+        // Re-check under the refresh lock: a caller that held it before us may have just populated
+        // the cache, in which case we skip the L1 read entirely.
         if let Some(cached) = self.fresh_cached_schedule() {
             return Ok(cached);
         }
@@ -135,16 +155,15 @@ impl BaseApiServer for BaseRpc {
         // `target_version` ahead of the schedule being published on L1), so it is reported as
         // "nothing scheduled" rather than as an error.
         let schedule = self.cached_schedule().await.map_err(|error| {
+            // The error string can carry the L1 endpoint URL and upstream response body, and this is
+            // the public, unauthenticated namespace — so log the detail server-side and return a
+            // generic error with no `data`, matching the redaction in `admin.rs`.
             warn!(
                 target: "upgrade_signal",
                 error = %error,
                 "failed to read L1 upgrade schedule for readiness query"
             );
-            ErrorObject::owned(
-                -32006,
-                "failed to read L1 upgrade schedule",
-                Some(error.to_string()),
-            )
+            ErrorObject::owned(-32006, "failed to read L1 upgrade schedule", None::<()>)
         })?;
 
         // Derive the readiness inputs from the optional schedule so both the scheduled and

--- a/crates/consensus/rpc/src/jsonrpsee.rs
+++ b/crates/consensus/rpc/src/jsonrpsee.rs
@@ -9,7 +9,7 @@ use base_common_rpc_types_engine::BaseExecutionPayloadEnvelope;
 use base_consensus_gossip::{PeerCount, PeerDump, PeerInfo, PeerStats};
 use base_consensus_safedb::SafeHeadResponse;
 use base_protocol::SyncStatus;
-use base_upgrade_signal::UpgradeSignalApplySummary;
+use base_upgrade_signal::{UpgradeReadiness, UpgradeSignalApplySummary};
 #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), allow(unused_imports))]
 use getrandom as _; // required for compiling wasm32-unknown-unknown
 use ipnet::IpNet;
@@ -120,6 +120,32 @@ pub trait RollupNodeApi {
     /// Get the software version.
     #[method(name = "version")]
     async fn version(&self) -> RpcResult<String>;
+}
+
+/// Base-specific node RPC interface (the `base` namespace).
+///
+/// Read-only, non-admin methods intended for node operators — including external operators — so they
+/// are exposed on the public RPC without requiring the (privileged) `admin` namespace to be enabled.
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "base"))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "base"))]
+pub trait BaseApi {
+    /// Reports whether this node is ready for the contract-backed upgrades scheduled on L1.
+    ///
+    /// Reads the live L1 upgrade-signal schedule and compares this node's advertised protocol
+    /// version against each scheduled minimum, returning per-upgrade `supported`/`would_halt` flags
+    /// and an overall `ready`. This is a read-only pre-flight check node operators (internal and
+    /// external) run before an upgrade activates; it never mutates node state.
+    ///
+    /// `target_version`, when supplied, overrides the on-chain minimum for the overall `ready`
+    /// answer so an operator can confirm support for an *announced* upgrade before it is scheduled on
+    /// L1 (the gap between rolling out a release and publishing the schedule). It is plain
+    /// `major.minor.patch` semver, with an optional `-rc.N` pre-release (e.g. `1.2.3` or
+    /// `1.2.3-rc.4`).
+    #[method(name = "upgradeReadiness")]
+    async fn upgrade_readiness(
+        &self,
+        target_version: Option<String>,
+    ) -> RpcResult<UpgradeReadiness>;
 }
 
 /// The opp2p namespace handles peer interactions.
@@ -377,8 +403,9 @@ mod tests {
     use rstest::rstest;
 
     use super::{
-        AdminApiServer, BaseP2PApiServer, ClusterMembership, ConductorApiServer,
-        DevEngineApiServer, HealthzApiServer, RollupNodeApiServer, ServerSuffrage, WsServer,
+        AdminApiServer, BaseApiServer, BaseP2PApiServer, ClusterMembership, ConductorApiServer,
+        DevEngineApiServer, HealthzApiServer, RollupNodeApiServer, ServerSuffrage,
+        UpgradeReadiness, WsServer,
     };
     use crate::{OutputResponse, health::HealthzResponse};
 
@@ -417,6 +444,22 @@ mod tests {
         let module = StubRollupNodeApi.into_rpc();
         let names: Vec<&str> = module.method_names().collect();
         assert!(names.contains(&expected), "missing method {expected}, got: {names:?}");
+    }
+
+    struct StubBaseApi;
+
+    #[async_trait]
+    impl BaseApiServer for StubBaseApi {
+        async fn upgrade_readiness(&self, _: Option<String>) -> RpcResult<UpgradeReadiness> {
+            unimplemented!()
+        }
+    }
+
+    #[test]
+    fn base_api_wire_names() {
+        let module = StubBaseApi.into_rpc();
+        let names: Vec<&str> = module.method_names().collect();
+        assert!(names.contains(&"base_upgradeReadiness"), "missing method, got: {names:?}");
     }
 
     struct StubBaseP2PApi;

--- a/crates/consensus/rpc/src/lib.rs
+++ b/crates/consensus/rpc/src/lib.rs
@@ -13,6 +13,9 @@ extern crate tracing;
 mod admin;
 pub use admin::{AdminRpc, NetworkAdminQuery};
 
+mod base;
+pub use base::BaseRpc;
+
 mod client;
 pub use client::{EngineRpcClient, SequencerAdminAPIClient, SequencerAdminAPIError};
 
@@ -27,11 +30,13 @@ pub use health::{HealthzResponse, HealthzRpc};
 
 mod jsonrpsee;
 #[cfg(feature = "client")]
-pub use jsonrpsee::{AdminApiClient, BaseP2PApiClient, ConductorApiClient, RollupNodeApiClient};
 pub use jsonrpsee::{
-    AdminApiServer, BaseP2PApiServer, ClusterMembership, ConductorApiServer, DevEngineApiServer,
-    HealthzApiServer, RollupNodeApiServer, ServerInfo, ServerSuffrage, UnknownServerSuffrage,
-    WsServer,
+    AdminApiClient, BaseApiClient, BaseP2PApiClient, ConductorApiClient, RollupNodeApiClient,
+};
+pub use jsonrpsee::{
+    AdminApiServer, BaseApiServer, BaseP2PApiServer, ClusterMembership, ConductorApiServer,
+    DevEngineApiServer, HealthzApiServer, RollupNodeApiServer, ServerInfo, ServerSuffrage,
+    UnknownServerSuffrage, WsServer,
 };
 
 mod l1_watcher;

--- a/crates/consensus/service/src/actors/rpc/actor.rs
+++ b/crates/consensus/service/src/actors/rpc/actor.rs
@@ -5,9 +5,10 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use base_consensus_gossip::P2pRpcRequest;
 use base_consensus_rpc::{
-    AdminApiServer, AdminRpc, BaseP2PApiServer, DevEngineApiServer, DevEngineRpc, EngineRpcClient,
-    HealthzApiServer, HealthzRpc, L1WatcherQueries, NetworkAdminQuery, P2pRpc, RollupNodeApiServer,
-    RollupRpc, RpcBuilder, SequencerAdminAPIClient, WsRPC, WsServer,
+    AdminApiServer, AdminRpc, BaseApiServer, BaseP2PApiServer, BaseRpc, DevEngineApiServer,
+    DevEngineRpc, EngineRpcClient, HealthzApiServer, HealthzRpc, L1WatcherQueries,
+    NetworkAdminQuery, P2pRpc, RollupNodeApiServer, RollupRpc, RpcBuilder, SequencerAdminAPIClient,
+    WsRPC, WsServer,
 };
 use base_consensus_safedb::SafeDBReader;
 use base_health::EthHealthCheckLayer;
@@ -38,6 +39,8 @@ where
     sequencer_admin_rpc_client: Option<SequencerAdminApiClient_>,
     safe_db_reader: Arc<dyn SafeDBReader>,
     upgrade_signal_refresher: Option<UpgradeSignalRefresher>,
+    /// Public `base`-namespace RPC server, present when the upgrade signal is configured.
+    base_rpc: Option<BaseRpc>,
 }
 
 /// The communication context used by the RPC actor.
@@ -138,6 +141,12 @@ where
             Arc::clone(&self.safe_db_reader),
         );
         modules.merge(rollup_rpc.into_rpc())?;
+
+        // Public `base` namespace (read-only, non-admin), enabled when the upgrade signal is
+        // configured so operators — including external ones — can query upgrade readiness.
+        if let Some(base_rpc) = self.base_rpc {
+            modules.merge(base_rpc.into_rpc())?;
+        }
 
         // Add development RPC module for engine state introspection if enabled
         if self.config.dev_enabled() {

--- a/crates/consensus/service/src/actors/rpc/actor.rs
+++ b/crates/consensus/service/src/actors/rpc/actor.rs
@@ -17,7 +17,7 @@ use derive_more::Constructor;
 use http::StatusCode;
 use jsonrpsee::{
     RpcModule,
-    server::{Server, ServerHandle, middleware::http::ProxyGetRequestLayer},
+    server::{Server, ServerConfig, ServerHandle, middleware::http::ProxyGetRequestLayer},
 };
 use tokio::sync::mpsc;
 use tokio_util::sync::{CancellationToken, WaitForCancellationFuture};
@@ -84,7 +84,22 @@ pub(crate) async fn launch_rpc_server(
             ProxyGetRequestLayer::new([("/healthz", "healthz")])
                 .expect("Critical: Failed to build GET method proxy"),
         );
-    let server = Server::builder().set_http_middleware(middleware).build(config.socket).await?;
+    // The tower HTTP middleware above (concurrency limit, timeout, load shed) only bounds HTTP
+    // requests — it does not see individual JSON-RPC calls streamed over a WebSocket connection, and
+    // jsonrpsee serves WS by default even when the WS engine module is not merged. So a WS client
+    // could otherwise stream unauthenticated `base_*` calls past those limits. Disable the WS
+    // transport entirely unless it is explicitly enabled, and cap total concurrent connections
+    // (transport-independent) as a backstop.
+    let mut server_config = ServerConfig::builder()
+        .max_connections(u32::try_from(config.max_concurrent_requests.get()).unwrap_or(u32::MAX));
+    if !config.ws_enabled() {
+        server_config = server_config.http_only();
+    }
+    let server = Server::builder()
+        .set_config(server_config.build())
+        .set_http_middleware(middleware)
+        .build(config.socket)
+        .await?;
 
     if let Ok(addr) = server.local_addr() {
         info!(target: "rpc", addr = ?addr, "RPC server bound to address");

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -19,7 +19,7 @@ use base_consensus_providers::{
     AlloyChainProvider, AlloyL2ChainProvider, OnlineBeaconClient, OnlineBlobProvider,
     OnlinePipeline,
 };
-use base_consensus_rpc::RpcBuilder;
+use base_consensus_rpc::{BaseRpc, RpcBuilder};
 use base_consensus_safedb::{DisabledSafeDB, SafeDB, SafeDBReader, SafeHeadListener};
 use base_protocol::L2BlockInfo;
 use tokio::sync::{mpsc, watch};
@@ -633,6 +633,12 @@ impl RollupNode {
         let engine_rpc_actor = rpc_builder
             .as_ref()
             .map(|_| (engine_rpc_processor, (cancellation.clone(), engine_rpc_request_rx)));
+        // Public `base` namespace, available whenever the upgrade signal is configured (any mode),
+        // built from the same config and reader the node uses so readiness reflects reality.
+        let base_rpc = self
+            .upgrade_signal_config
+            .as_ref()
+            .map(|c| BaseRpc::new(c.config.clone(), c.reader.clone()));
         let rpc = rpc_builder.map(|b| {
             RpcActor::new(
                 b,
@@ -640,6 +646,7 @@ impl RollupNode {
                 sequencer_admin_client,
                 safe_db_reader,
                 upgrade_signal_refresher,
+                base_rpc,
             )
         });
 

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -634,7 +634,9 @@ impl RollupNode {
             .as_ref()
             .map(|_| (engine_rpc_processor, (cancellation.clone(), engine_rpc_request_rx)));
         // Public `base` namespace, available whenever the upgrade signal is configured (any mode),
-        // built from the same config and reader the node uses so readiness reflects reality.
+        // built from the same config and reader the node uses. The readiness report accounts for the
+        // configured mode, so a node whose mode does not apply the live schedule is not reported
+        // ready for it.
         let base_rpc = self
             .upgrade_signal_config
             .as_ref()

--- a/crates/infra/basectl/Cargo.toml
+++ b/crates/infra/basectl/Cargo.toml
@@ -23,6 +23,7 @@ alloy-rpc-client = { workspace = true }
 alloy-signer-local = { workspace = true }
 base-common-chains = { workspace = true }
 base-common-network = { workspace = true }
+base-upgrade-signal = { workspace = true }
 base-consensus-peers = { workspace = true }
 base-proof-contracts = { workspace = true }
 alloy-transport-http = { workspace = true }

--- a/crates/infra/basectl/src/commands/cli.rs
+++ b/crates/infra/basectl/src/commands/cli.rs
@@ -6,7 +6,7 @@ use url::Url;
 
 use super::{
     BlockCommand, CommandOutcome, ConductorCommand, DoctorCommand, P2pCommand, ProofsCommand,
-    SequencerCommand, SyncStatusCommand, TxpoolCommand,
+    SequencerCommand, SyncStatusCommand, TxpoolCommand, UpgradeReadinessCommand,
 };
 use crate::{MonitoringConfig, ViewId, run_app, run_flashblocks_json};
 
@@ -48,6 +48,8 @@ pub enum Commands {
     Block(BlockCommand),
     /// Report combined CL `optimism_syncStatus` + EL `eth_syncing`.
     SyncStatus(SyncStatusCommand),
+    /// Check whether this node is ready for the scheduled (or an announced) L1 upgrade.
+    UpgradeReadiness(UpgradeReadinessCommand),
     /// Inspect p2p peers and advertised endpoints.
     P2p(P2pCommand),
     /// Inspect and clear execution-layer txpool contents.
@@ -120,6 +122,7 @@ impl Cli {
             Commands::SyncStatus(command) => {
                 command.run(config).await.map(|()| CommandOutcome::Success)
             }
+            Commands::UpgradeReadiness(command) => command.run(config).await,
             Commands::P2p(command) => command.run(config).await,
             Commands::Txpool(command) => {
                 command.run(config).await.map(|()| CommandOutcome::Success)

--- a/crates/infra/basectl/src/commands/mod.rs
+++ b/crates/infra/basectl/src/commands/mod.rs
@@ -55,3 +55,6 @@ mod txpool;
 pub use txpool::{
     TxpoolClearArgs, TxpoolClearJson, TxpoolCommand, TxpoolCommands, TxpoolReadArgs, TxpoolReadJson,
 };
+
+mod upgrade_readiness;
+pub use upgrade_readiness::UpgradeReadinessCommand;

--- a/crates/infra/basectl/src/commands/upgrade_readiness.rs
+++ b/crates/infra/basectl/src/commands/upgrade_readiness.rs
@@ -65,12 +65,6 @@ fn print_pretty(network: &str, readiness: &UpgradeReadiness) -> Result<()> {
                 .map_or_else(|| "none (no schedule on L1)".to_string(), |block| block.to_string()),
         );
 
-    if let Some(target) = &readiness.target {
-        table
-            .row("target_version", &target.required_protocol_version)
-            .row("target_supported", target.supported.to_string());
-    }
-
     if readiness.upgrades.is_empty() {
         table.row("scheduled_upgrades", "none");
     } else {

--- a/crates/infra/basectl/src/commands/upgrade_readiness.rs
+++ b/crates/infra/basectl/src/commands/upgrade_readiness.rs
@@ -57,6 +57,7 @@ fn print_pretty(network: &str, readiness: &UpgradeReadiness) -> Result<()> {
     table
         .row("network", network)
         .row("ready", readiness.ready.to_string())
+        .row("mode", format!("{:?}", readiness.mode))
         .row("node_protocol_version", &readiness.node_protocol_version)
         .row(
             "l1_block_number",
@@ -65,6 +66,10 @@ fn print_pretty(network: &str, readiness: &UpgradeReadiness) -> Result<()> {
                 .map_or_else(|| "none (no schedule on L1)".to_string(), |block| block.to_string()),
         );
 
+    if let Some(reason) = &readiness.reason {
+        table.row("reason", reason);
+    }
+
     if readiness.upgrades.is_empty() {
         table.row("scheduled_upgrades", "none");
     } else {
@@ -72,10 +77,11 @@ fn print_pretty(network: &str, readiness: &UpgradeReadiness) -> Result<()> {
             table.row(
                 format!("upgrade[{}]", upgrade.upgrade_id),
                 format!(
-                    "required={} activation={} supported={} would_halt={}",
+                    "required={} activation={} supported={} malformed={} would_halt={}",
                     upgrade.required_protocol_version,
                     upgrade.activation_timestamp,
                     upgrade.supported,
+                    upgrade.malformed,
                     upgrade.would_halt,
                 ),
             );

--- a/crates/infra/basectl/src/commands/upgrade_readiness.rs
+++ b/crates/infra/basectl/src/commands/upgrade_readiness.rs
@@ -1,0 +1,93 @@
+//! Implementation of the `basectl upgrade-readiness` subcommand.
+//!
+//! A pre-flight check node operators run to confirm their node will follow an upcoming
+//! contract-backed upgrade rather than fall behind (or fail closed) at activation. It calls the
+//! public `base_upgradeReadiness` RPC and exits non-zero when the node is not ready, so it can gate
+//! a fleet-wide rollout before the upgrade is scheduled on L1.
+
+use anyhow::Result;
+use base_upgrade_signal::UpgradeReadiness;
+use clap::Args;
+use url::Url;
+
+use crate::{CommandOutcome, JsonOutput, KeyValueTable, MonitoringConfig, fetch_upgrade_readiness};
+
+/// Arguments for the upgrade-readiness pre-flight check.
+#[derive(Debug, Args)]
+pub struct UpgradeReadinessCommand {
+    /// Override the consensus-node RPC URL.
+    ///
+    /// Defaults to the chain config's `consensus_node_rpc` field.
+    #[arg(long = "cl-rpc", value_name = "URL")]
+    pub cl_rpc: Option<Url>,
+    /// Announced upgrade version to check support against *before* it is scheduled on L1.
+    ///
+    /// Plain `major.minor.patch` semver, optionally with an `-rc.N` pre-release (e.g. `1.2.3` or
+    /// `1.2.3-rc.4`). Use this in the window between rolling a release out to operators and
+    /// publishing the schedule on L1, when the contract does not yet carry the new minimum: the
+    /// overall `ready` answer is then judged against this version. Omit it once the upgrade is
+    /// scheduled to judge readiness against the on-chain minimum instead.
+    #[arg(long = "target-version", value_name = "SEMVER")]
+    pub target_version: Option<String>,
+    /// Emit JSON instead of the pretty table.
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl UpgradeReadinessCommand {
+    /// Fetches upgrade readiness and renders it, returning a non-zero outcome when not ready.
+    pub async fn run(self, config: MonitoringConfig) -> Result<CommandOutcome> {
+        let cl_rpc = config.resolve_cl_rpc(self.cl_rpc.as_ref(), "upgrade-readiness")?;
+        let readiness = fetch_upgrade_readiness(&cl_rpc, self.target_version).await?;
+
+        if self.json {
+            JsonOutput::print(&readiness)?;
+        } else {
+            print_pretty(&config.name, &readiness)?;
+        }
+
+        // Exit non-zero when the node is not ready so a rollout script can gate on the exit code.
+        Ok(CommandOutcome::from_failures(!readiness.ready))
+    }
+}
+
+/// Renders upgrade readiness as the pretty key-value table.
+fn print_pretty(network: &str, readiness: &UpgradeReadiness) -> Result<()> {
+    let mut table = KeyValueTable::new();
+    table
+        .row("network", network)
+        .row("ready", readiness.ready.to_string())
+        .row("node_protocol_version", &readiness.node_protocol_version)
+        .row(
+            "l1_block_number",
+            readiness
+                .l1_block_number
+                .map_or_else(|| "none (no schedule on L1)".to_string(), |block| block.to_string()),
+        );
+
+    if let Some(target) = &readiness.target {
+        table
+            .row("target_version", &target.required_protocol_version)
+            .row("target_supported", target.supported.to_string());
+    }
+
+    if readiness.upgrades.is_empty() {
+        table.row("scheduled_upgrades", "none");
+    } else {
+        for upgrade in &readiness.upgrades {
+            table.row(
+                format!("upgrade[{}]", upgrade.upgrade_id),
+                format!(
+                    "required={} activation={} supported={} would_halt={}",
+                    upgrade.required_protocol_version,
+                    upgrade.activation_timestamp,
+                    upgrade.supported,
+                    upgrade.would_halt,
+                ),
+            );
+        }
+    }
+
+    table.print()?;
+    Ok(())
+}

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -18,7 +18,7 @@ pub use commands::{
     SequencerNodeActionArgs, SequencerNodeJson, SequencerRole, SequencerStartArgs,
     SequencerStatusArgs, SequencerStatusJson, SyncStatusCommand, SyncStatusJson, TipReferenceJson,
     TipStatus, TxpoolClearArgs, TxpoolClearJson, TxpoolCommand, TxpoolCommands, TxpoolReadArgs,
-    TxpoolReadJson, UnsafeHeadSource, ZkBackendOption,
+    TxpoolReadJson, UnsafeHeadSource, UpgradeReadinessCommand, ZkBackendOption,
 };
 
 mod denim;
@@ -90,12 +90,12 @@ pub use rpc::{
     fetch_full_system_config, fetch_info, fetch_initial_backlog_with_progress,
     fetch_l1_block_number, fetch_l2_block_number, fetch_l2_chain_id, fetch_raw_info,
     fetch_raw_peers, fetch_safe_and_latest, fetch_sequencer_active, fetch_sync_status,
-    list_banned_peers, pause_sequencer_node, remove_peer, restart_conductor_node,
-    run_block_fetcher, run_conductor_poller, run_flashblock_ws, run_flashblock_ws_timestamped,
-    run_l1_blob_watcher, run_pods_poller, run_proofs_poller, run_rollup_config_poller,
-    run_safe_head_poller, run_validator_poller, start_sequencer, start_sequencer_node,
-    stop_sequencer, stop_sequencer_node, transfer_conductor_leader, unban_el_peer, unban_peer,
-    unpause_sequencer_node,
+    fetch_upgrade_readiness, list_banned_peers, pause_sequencer_node, remove_peer,
+    restart_conductor_node, run_block_fetcher, run_conductor_poller, run_flashblock_ws,
+    run_flashblock_ws_timestamped, run_l1_blob_watcher, run_pods_poller, run_proofs_poller,
+    run_rollup_config_poller, run_safe_head_poller, run_validator_poller, start_sequencer,
+    start_sequencer_node, stop_sequencer, stop_sequencer_node, transfer_conductor_leader,
+    unban_el_peer, unban_peer, unpause_sequencer_node,
 };
 
 mod tui;

--- a/crates/infra/basectl/src/rpc/mod.rs
+++ b/crates/infra/basectl/src/rpc/mod.rs
@@ -54,8 +54,8 @@ pub use prover::{ProofProposeRequest, ProofsClient};
 mod rollup;
 pub use rollup::{
     LatestProposal, ProofsSnapshot, SyncStatusReport, ValidatorNodeStatus, fetch_safe_and_latest,
-    fetch_sync_status, run_proofs_poller, run_rollup_config_poller, run_safe_head_poller,
-    run_validator_poller,
+    fetch_sync_status, fetch_upgrade_readiness, run_proofs_poller, run_rollup_config_poller,
+    run_safe_head_poller, run_validator_poller,
 };
 
 mod submit;

--- a/crates/infra/basectl/src/rpc/rollup.rs
+++ b/crates/infra/basectl/src/rpc/rollup.rs
@@ -9,8 +9,9 @@ use alloy_transport_http::Http;
 use anyhow::{Context, Result};
 use base_common_genesis::UpgradeConfig;
 use base_common_network::Base;
-use base_consensus_rpc::{BaseP2PApiClient, RollupNodeApiClient};
+use base_consensus_rpc::{BaseApiClient, BaseP2PApiClient, RollupNodeApiClient};
 use base_protocol::SyncStatus;
+use base_upgrade_signal::UpgradeReadiness;
 use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
 use tokio::sync::mpsc;
 use tracing::warn;
@@ -72,6 +73,24 @@ pub async fn fetch_sync_status(rpc: &Url, cl_rpc: &Url) -> Result<SyncStatusRepo
         },
     )?;
     Ok(SyncStatusReport { cl, el })
+}
+
+/// Fetches this node's upgrade readiness from the consensus-node RPC.
+///
+/// Calls the public `base_upgradeReadiness` method. `target_version`, when set, is an announced
+/// `major.minor.patch[-rc.N]` version to check support against before the upgrade is scheduled on L1;
+/// the node parses and validates it.
+pub async fn fetch_upgrade_readiness(
+    cl_rpc: &Url,
+    target_version: Option<String>,
+) -> Result<UpgradeReadiness> {
+    let cl_client = HttpClientBuilder::default()
+        .request_timeout(Duration::from_secs(30))
+        .build(cl_rpc.as_str())
+        .with_context(|| format!("connecting to consensus node RPC at {cl_rpc}"))?;
+    BaseApiClient::upgrade_readiness(&cl_client, target_version)
+        .await
+        .with_context(|| format!("fetching base_upgradeReadiness from {cl_rpc}"))
 }
 
 /// Fetches the safe and latest L2 block numbers.

--- a/crates/utilities/upgrade-signal/src/config/schedule.rs
+++ b/crates/utilities/upgrade-signal/src/config/schedule.rs
@@ -60,15 +60,23 @@ impl UpgradeSignalConfig {
             .with_block_tag(self.l1_block_tag.block_number_or_tag()))
     }
 
-    /// Returns true if this node supports the minimum protocol version attached to `signal`.
+    /// Returns true if this node's advertised protocol version satisfies `minimum`.
     ///
     /// Compatibility compares the packed versions by their semver ordering (see
     /// [`PackedProtocolVersion`]), not as raw integers: an unrecognized version-type ranks above
     /// everything (fail-closed), then `major.minor.patch`, with a pre-release sorting below its
     /// matching release and `build`/reserved bits ignored.
-    pub fn supports_signal_protocol_version(&self, signal: &UpgradeSignal) -> bool {
-        PackedProtocolVersion::new(signal.protocol_version)
+    pub fn supports_protocol_version(&self, minimum: U256) -> bool {
+        PackedProtocolVersion::new(minimum)
             <= PackedProtocolVersion::new(self.node_protocol_version)
+    }
+
+    /// Returns true if this node supports the minimum protocol version attached to `signal`.
+    ///
+    /// This is the pure version comparison ([`Self::supports_protocol_version`]) independent of the
+    /// signal's activation timing, so it is meaningful even for an upgrade that is not yet scheduled.
+    pub fn supports_signal_protocol_version(&self, signal: &UpgradeSignal) -> bool {
+        self.supports_protocol_version(signal.protocol_version)
     }
 
     /// Returns an error if a positive activation timestamp omits its minimum protocol version.
@@ -164,10 +172,25 @@ impl UpgradeSignalConfig {
         now_secs: u64,
         lead_secs: u64,
     ) -> Option<&'a UpgradeSignal> {
-        schedule.signals.iter().find(|signal| {
-            self.validate_signal_supported_protocol_version(signal).is_err()
-                && now_secs.saturating_add(lead_secs) >= signal.activation_timestamp
-        })
+        schedule.signals.iter().find(|signal| self.signal_fails_closed(signal, now_secs, lead_secs))
+    }
+
+    /// Returns true if `signal` would fail the node closed at `now_secs` given `lead_secs`.
+    ///
+    /// This is the per-signal predicate behind [`Self::fail_closed_upgrade`]: an activation this
+    /// node's protocol version is too old to support whose activation is within `lead_secs` of
+    /// `now_secs` (or already past). A clear (activation `0`) and a malformed zero-version signal are
+    /// both treated as supported by [`Self::validate_signal_supported_protocol_version`], so neither
+    /// fails closed. Sharing this predicate keeps the readiness report (see
+    /// [`Self::evaluate_readiness`]) exactly consistent with the node's actual halt decision.
+    pub fn signal_fails_closed(
+        &self,
+        signal: &UpgradeSignal,
+        now_secs: u64,
+        lead_secs: u64,
+    ) -> bool {
+        self.validate_signal_supported_protocol_version(signal).is_err()
+            && now_secs.saturating_add(lead_secs) >= signal.activation_timestamp
     }
 
     /// Reads the L1 startup schedule and applies it to both sinks.

--- a/crates/utilities/upgrade-signal/src/config/types.rs
+++ b/crates/utilities/upgrade-signal/src/config/types.rs
@@ -32,17 +32,13 @@ impl UpgradeSignalMode {
         matches!(self, Self::StartupApply | Self::RuntimeAdmin)
     }
 
-    /// Returns true if this mode applies live L1 schedule changes after startup (and fails closed
-    /// on an unsupportable one).
-    ///
-    /// Only [`Self::RuntimeAdmin`] tracks the schedule live; the other modes observe it for metrics
-    /// but never apply or halt on a change seen after startup. Upgrade-readiness reporting uses this
-    /// to avoid claiming a node will follow the current L1 schedule when its mode never will.
-    pub const fn applies_live_schedule(self) -> bool {
-        matches!(self, Self::RuntimeAdmin)
-    }
-
     /// Returns true if this mode allows manual runtime schedule refresh.
+    ///
+    /// This is also the predicate for whether the mode applies live L1 schedule changes after
+    /// startup (and fails closed on an unsupportable one): only [`Self::RuntimeAdmin`] tracks the
+    /// schedule live, so the other modes observe it for metrics but never apply or halt on a change
+    /// seen after startup. Upgrade-readiness reporting relies on this to avoid claiming a node will
+    /// follow the current L1 schedule when its mode never will.
     pub const fn allows_runtime_admin(self) -> bool {
         matches!(self, Self::RuntimeAdmin)
     }

--- a/crates/utilities/upgrade-signal/src/config/types.rs
+++ b/crates/utilities/upgrade-signal/src/config/types.rs
@@ -3,7 +3,18 @@ use core::time::Duration;
 use alloy_rpc_types_eth::BlockNumberOrTag;
 
 /// Controls which local schedule mutation paths are enabled for the L1 upgrade signal.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::ValueEnum)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Default,
+    PartialEq,
+    Eq,
+    clap::ValueEnum,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+#[serde(rename_all = "kebab-case")]
 pub enum UpgradeSignalMode {
     /// Do not mutate local upgrade schedules; live L1 metrics are still observed.
     #[default]
@@ -19,6 +30,16 @@ impl UpgradeSignalMode {
     /// Returns true if this mode applies the schedule before node startup.
     pub const fn applies_at_startup(self) -> bool {
         matches!(self, Self::StartupApply | Self::RuntimeAdmin)
+    }
+
+    /// Returns true if this mode applies live L1 schedule changes after startup (and fails closed
+    /// on an unsupportable one).
+    ///
+    /// Only [`Self::RuntimeAdmin`] tracks the schedule live; the other modes observe it for metrics
+    /// but never apply or halt on a change seen after startup. Upgrade-readiness reporting uses this
+    /// to avoid claiming a node will follow the current L1 schedule when its mode never will.
+    pub const fn applies_live_schedule(self) -> bool {
+        matches!(self, Self::RuntimeAdmin)
     }
 
     /// Returns true if this mode allows manual runtime schedule refresh.

--- a/crates/utilities/upgrade-signal/src/lib.rs
+++ b/crates/utilities/upgrade-signal/src/lib.rs
@@ -38,10 +38,10 @@ pub use state::{
 };
 
 mod readiness;
-pub use readiness::{UpgradeReadiness, UpgradeReadinessEntry, UpgradeReadinessTarget};
+pub use readiness::{UpgradeReadiness, UpgradeReadinessEntry};
 
 mod version;
-pub use version::{PackedProtocolVersion, ParseProtocolVersionError};
+pub use version::PackedProtocolVersion;
 
 #[cfg(test)]
 pub mod test_utils;

--- a/crates/utilities/upgrade-signal/src/lib.rs
+++ b/crates/utilities/upgrade-signal/src/lib.rs
@@ -37,8 +37,11 @@ pub use state::{
     UpgradeSignal, UpgradeSignalMonitor, UpgradeSignalPollOutcome, UpgradeSignalSchedule,
 };
 
+mod readiness;
+pub use readiness::{UpgradeReadiness, UpgradeReadinessEntry, UpgradeReadinessTarget};
+
 mod version;
-pub use version::PackedProtocolVersion;
+pub use version::{PackedProtocolVersion, ParseProtocolVersionError};
 
 #[cfg(test)]
 pub mod test_utils;

--- a/crates/utilities/upgrade-signal/src/readiness.rs
+++ b/crates/utilities/upgrade-signal/src/readiness.rs
@@ -14,7 +14,7 @@
 use alloy_primitives::U256;
 use serde::{Deserialize, Serialize};
 
-use crate::{PackedProtocolVersion, UpgradeSignal, UpgradeSignalConfig};
+use crate::{PackedProtocolVersion, UpgradeSignal, UpgradeSignalConfig, UpgradeSignalMode};
 
 /// A node's readiness for the currently scheduled contract-backed upgrades.
 ///
@@ -25,13 +25,28 @@ use crate::{PackedProtocolVersion, UpgradeSignal, UpgradeSignalConfig};
 pub struct UpgradeReadiness {
     /// Whether this node is ready.
     ///
-    /// When a caller-supplied target version was supplied, this is simply whether the node supports
-    /// that version. Otherwise it is whether the node supports every upgrade currently scheduled on
-    /// L1 (vacuously `true` when nothing is scheduled — so a `false` here is always an actionable
-    /// "this node needs upgrading", never "nothing to check").
+    /// When a caller-supplied target version was supplied, this is a pure binary-support check: does
+    /// this node's version satisfy the target, independent of mode.
+    ///
+    /// Otherwise it reflects whether the node will actually follow the upgrades currently scheduled
+    /// on L1, which requires both that the node's [`mode`](Self::mode) applies the live schedule
+    /// *and* that the schedule passes the same validation the apply path runs (every activation has
+    /// a supported, well-formed minimum version). A `false` here is therefore always actionable —
+    /// see [`reason`](Self::reason) — never "nothing to check" (an empty schedule is vacuously
+    /// ready for an applying mode).
     pub ready: bool,
     /// This node's advertised protocol version, rendered as `major.minor.patch` semver.
     pub node_protocol_version: String,
+    /// This node's upgrade-signal mode, which determines whether it applies the live L1 schedule.
+    ///
+    /// Only [`UpgradeSignalMode::RuntimeAdmin`] tracks and applies the schedule after startup, so
+    /// for the other modes the on-chain schedule below is reported for visibility but the node will
+    /// not follow a live change to it (reflected in `ready`).
+    pub mode: UpgradeSignalMode,
+    /// When `ready` is `false`, a human-readable explanation: an unsupported node version, a
+    /// malformed on-chain schedule, or a mode that does not apply the live schedule. `None` when
+    /// ready.
+    pub reason: Option<String>,
     /// L1 block number the schedule was read at, or `None` when the contract has no schedule yet.
     pub l1_block_number: Option<u64>,
     /// Per-upgrade readiness for every activation currently scheduled on L1 (cleared/unscheduled
@@ -53,9 +68,17 @@ pub struct UpgradeReadinessEntry {
     /// This is the pure version comparison, independent of the activation timing, so it stays
     /// meaningful the instant a minimum is published — even before an activation timestamp is set.
     pub supported: bool,
-    /// Whether the node would fail closed (halt) for this upgrade right now: it is unsupported *and*
-    /// the activation is within the halt lead window (or already past). This tracks the node's real
-    /// halt decision exactly, so it only becomes `true` as an unsupported upgrade nears activation.
+    /// Whether this scheduled signal is malformed: it has an activation timestamp but no minimum
+    /// protocol version (see [`UpgradeSignalConfig::validate_signal_has_protocol_version`]).
+    ///
+    /// The node would refuse to apply such a schedule, so a malformed entry makes the overall report
+    /// unready even though its zero minimum version compares as trivially `supported`.
+    pub malformed: bool,
+    /// Whether the node would fail closed (halt) for this upgrade right now: its mode applies the
+    /// live schedule, it is unsupported, *and* the activation is within the halt lead window (or
+    /// already past). This tracks the node's real halt decision exactly — so it stays `false` in a
+    /// mode that never halts live, and otherwise only becomes `true` as an unsupported upgrade nears
+    /// activation.
     pub would_halt: bool,
 }
 
@@ -64,14 +87,17 @@ impl UpgradeSignalConfig {
     ///
     /// `now_secs` is the wall-clock used for the halt-window ([`UpgradeReadinessEntry::would_halt`])
     /// check. `target_version`, when `Some`, overrides the on-chain minimum for the top-level
-    /// [`UpgradeReadiness::ready`] answer: it lets an operator confirm support for an *announced*
-    /// upgrade before it is scheduled on L1 (the gap between rolling out a release and publishing the
-    /// schedule), when the contract does not yet carry the new minimum. When `None`, readiness is
-    /// judged against the upgrades currently scheduled on L1.
+    /// [`UpgradeReadiness::ready`] answer with a pure binary-support check: it lets an operator
+    /// confirm support for an *announced* upgrade before it is scheduled on L1 (the gap between
+    /// rolling out a release and publishing the schedule), independent of this node's mode. When
+    /// `None`, readiness is judged against the upgrades currently scheduled on L1.
     ///
-    /// Only signals with a positive activation timestamp are reported (a clear carries no meaningful
-    /// minimum), and every field is computed with the same predicates the live poller uses so the
-    /// report cannot diverge from the node's actual behavior.
+    /// For that on-chain path, `ready` requires both that this node's [mode](UpgradeSignalConfig)
+    /// applies the live schedule and that the schedule passes the same validation the apply path
+    /// runs ([`Self::validate_signal_protocol_version`]) — so the report can never claim the node
+    /// will follow a schedule it would refuse to apply, or that a non-applying mode will follow one
+    /// at all. Only signals with a positive activation timestamp are itemized (a clear carries no
+    /// meaningful minimum).
     pub fn evaluate_readiness(
         &self,
         signals: &[UpgradeSignal],
@@ -80,6 +106,10 @@ impl UpgradeSignalConfig {
         target_version: Option<U256>,
     ) -> UpgradeReadiness {
         let lead_secs = self.halt_lead_time().as_secs();
+        // Only a live-applying mode actually follows a live schedule change or halts at activation;
+        // in the other modes the node observes the schedule but never applies or halts on it, so the
+        // report must not claim it will.
+        let applies_live = self.mode.applies_live_schedule();
 
         let upgrades: Vec<UpgradeReadinessEntry> = signals
             .iter()
@@ -90,21 +120,47 @@ impl UpgradeSignalConfig {
                     .to_string(),
                 activation_timestamp: signal.activation_timestamp,
                 supported: self.supports_signal_protocol_version(signal),
-                would_halt: self.signal_fails_closed(signal, now_secs, lead_secs),
+                malformed: self.validate_signal_has_protocol_version(signal).is_err(),
+                would_halt: applies_live && self.signal_fails_closed(signal, now_secs, lead_secs),
             })
             .collect();
 
-        // A supplied target is the operator's explicit "am I ready for the announced upgrade?"
-        // question and takes precedence; otherwise fall back to the upgrades currently on L1.
-        let ready = target_version.map_or_else(
-            || upgrades.iter().all(|upgrade| upgrade.supported),
-            |version| self.supports_protocol_version(version),
-        );
+        let (ready, reason) = match target_version {
+            // A supplied target is the operator's explicit "does my binary support the announced
+            // version?" probe used to gate a rollout before the upgrade is scheduled on L1. It is a
+            // pure binary-capability check, independent of this node's apply mode.
+            Some(version) if self.supports_protocol_version(version) => (true, None),
+            Some(version) => (
+                false,
+                Some(format!(
+                    "node protocol version {} does not support target {}",
+                    PackedProtocolVersion::new(self.node_protocol_version),
+                    PackedProtocolVersion::new(version),
+                )),
+            ),
+            // Otherwise judge against the upgrades currently scheduled on L1: the node must be in a
+            // mode that applies the live schedule and pass the same validation the apply path runs.
+            None if !applies_live => (
+                false,
+                Some(
+                    "node's upgrade-signal mode does not apply the live L1 schedule; it will not \
+                     follow a live change to it (per-upgrade `supported` still reflects binary \
+                     capability)"
+                        .to_string(),
+                ),
+            ),
+            None => signals
+                .iter()
+                .find_map(|signal| self.validate_signal_protocol_version(signal).err())
+                .map_or((true, None), |error| (false, Some(error.to_string()))),
+        };
 
         UpgradeReadiness {
             ready,
             node_protocol_version: PackedProtocolVersion::new(self.node_protocol_version)
                 .to_string(),
+            mode: self.mode,
+            reason,
             l1_block_number,
             upgrades,
         }
@@ -119,11 +175,17 @@ mod tests {
     use super::*;
     use crate::UpgradeSignalDefaults;
 
-    fn config() -> UpgradeSignalConfig {
+    fn config_with_mode(mode: UpgradeSignalMode) -> UpgradeSignalConfig {
         let mut config = UpgradeSignalConfig::new(Address::ZERO);
         // Node advertises 1.1.0.
         config.node_protocol_version = UpgradeSignalDefaults::packed_protocol_version(1, 1, 0);
+        config.mode = mode;
         config
+    }
+
+    /// A live-applying node, for which the on-chain readiness verdict is meaningful.
+    fn config() -> UpgradeSignalConfig {
+        config_with_mode(UpgradeSignalMode::RuntimeAdmin)
     }
 
     fn signal(upgrade_id: BaseUpgrade, activation_timestamp: u64, version: U256) -> UpgradeSignal {
@@ -142,6 +204,8 @@ mod tests {
         let readiness = config.evaluate_readiness(&signals, Some(42), 0, None);
 
         assert!(readiness.ready);
+        assert!(readiness.reason.is_none());
+        assert_eq!(readiness.mode, UpgradeSignalMode::RuntimeAdmin);
         assert_eq!(readiness.node_protocol_version, "1.1.0");
         assert_eq!(readiness.l1_block_number, Some(42));
         assert_eq!(readiness.upgrades.len(), 1);
@@ -149,6 +213,7 @@ mod tests {
         assert_eq!(entry.upgrade_id, "azul");
         assert_eq!(entry.required_protocol_version, "1.1.0");
         assert!(entry.supported);
+        assert!(!entry.malformed);
         assert!(!entry.would_halt);
     }
 
@@ -167,6 +232,7 @@ mod tests {
             None,
         );
         assert!(!distant.ready);
+        assert!(distant.reason.is_some());
         assert!(!distant.upgrades[0].supported);
         assert!(!distant.upgrades[0].would_halt);
 
@@ -197,6 +263,48 @@ mod tests {
     }
 
     #[test]
+    fn malformed_scheduled_signal_is_not_ready() {
+        let config = config();
+        // A positive activation with a zero minimum version is malformed: the node would refuse to
+        // apply this schedule, so readiness must be false even though the zero version compares as
+        // trivially supported.
+        let signals = [signal(BaseUpgrade::Azul, 1_000, U256::ZERO)];
+
+        let readiness = config.evaluate_readiness(&signals, Some(1), 0, None);
+
+        assert!(!readiness.ready);
+        assert!(readiness.reason.is_some());
+        let entry = &readiness.upgrades[0];
+        assert!(entry.malformed);
+        // The zero version trivially compares as supported, which is exactly why `malformed` (not
+        // `supported`) is what makes the report unready.
+        assert!(entry.supported);
+        assert!(!entry.would_halt);
+    }
+
+    #[test]
+    fn non_applying_mode_is_not_ready_even_when_supported() {
+        // A supportable, well-formed schedule that a runtime-admin node would follow.
+        let signals = [signal(
+            BaseUpgrade::Azul,
+            1_000,
+            UpgradeSignalDefaults::packed_protocol_version(1, 1, 0),
+        )];
+
+        for mode in [UpgradeSignalMode::MetricsOnly, UpgradeSignalMode::StartupApply] {
+            let readiness = config_with_mode(mode).evaluate_readiness(&signals, Some(1), 0, None);
+
+            // The node's mode never applies a live schedule change, so it cannot be reported ready
+            // for the on-chain schedule, and it never halts live either.
+            assert!(!readiness.ready, "{mode:?} should not be ready for the live schedule");
+            assert!(readiness.reason.is_some());
+            assert_eq!(readiness.mode, mode);
+            assert!(readiness.upgrades[0].supported);
+            assert!(!readiness.upgrades[0].would_halt);
+        }
+    }
+
+    #[test]
     fn target_version_overrides_the_ready_answer_before_anything_is_scheduled() {
         let config = config();
 
@@ -204,6 +312,7 @@ mod tests {
         let supported_target = UpgradeSignalDefaults::packed_protocol_version(1, 0, 0);
         let ready = config.evaluate_readiness(&[], None, 0, Some(supported_target));
         assert!(ready.ready);
+        assert!(ready.reason.is_none());
         assert_eq!(ready.l1_block_number, None);
         assert!(ready.upgrades.is_empty());
 
@@ -211,5 +320,23 @@ mod tests {
         let unsupported_target = UpgradeSignalDefaults::packed_protocol_version(2, 0, 0);
         let not_ready = config.evaluate_readiness(&[], None, 0, Some(unsupported_target));
         assert!(!not_ready.ready);
+        assert!(not_ready.reason.is_some());
+    }
+
+    #[test]
+    fn target_version_check_is_mode_independent() {
+        // The target probe is a pure binary-capability check for gating a rollout, so it answers the
+        // same regardless of whether this node's mode applies the live schedule.
+        let supported_target = UpgradeSignalDefaults::packed_protocol_version(1, 0, 0);
+
+        for mode in [
+            UpgradeSignalMode::MetricsOnly,
+            UpgradeSignalMode::StartupApply,
+            UpgradeSignalMode::RuntimeAdmin,
+        ] {
+            let readiness =
+                config_with_mode(mode).evaluate_readiness(&[], None, 0, Some(supported_target));
+            assert!(readiness.ready, "{mode:?} should support the target version");
+        }
     }
 }

--- a/crates/utilities/upgrade-signal/src/readiness.rs
+++ b/crates/utilities/upgrade-signal/src/readiness.rs
@@ -1,0 +1,239 @@
+//! Upgrade readiness reporting for operator pre-flight checks.
+//!
+//! Between rolling a release out to node operators and scheduling the upgrade on L1, operators need
+//! a way to confirm their node will follow the upgrade rather than fall behind (or, once the
+//! fail-closed poller is active, halt) at activation. [`UpgradeReadiness`] is the machine-readable
+//! answer returned by the public `base_upgradeReadiness` RPC (and rendered by the `basectl
+//! upgrade-readiness` subcommand).
+//!
+//! The report is deliberately built from the *same* predicates the live node uses —
+//! [`UpgradeSignalConfig::supports_signal_protocol_version`] and
+//! [`UpgradeSignalConfig::signal_fails_closed`] — so it can never disagree with what the node
+//! actually does at activation.
+
+use alloy_primitives::U256;
+use serde::{Deserialize, Serialize};
+
+use crate::{PackedProtocolVersion, UpgradeSignal, UpgradeSignalConfig};
+
+/// A node's readiness for the currently scheduled contract-backed upgrades.
+///
+/// `ready` is the single go/no-go answer an operator (or a fleet-wide rollout script) checks before
+/// the upgrade is scheduled on L1. The remaining fields carry the raw inputs so the result is
+/// self-explanatory without a second query.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UpgradeReadiness {
+    /// Whether this node is ready.
+    ///
+    /// When a [`target`](Self::target) version was supplied, this is simply whether the node
+    /// supports that version. Otherwise it is whether the node supports every upgrade currently
+    /// scheduled on L1 (vacuously `true` when nothing is scheduled — so a `false` here is always an
+    /// actionable "this node needs upgrading", never "nothing to check").
+    pub ready: bool,
+    /// This node's advertised protocol version, rendered as `major.minor.patch` semver.
+    pub node_protocol_version: String,
+    /// L1 block number the schedule was read at, or `None` when the contract has no schedule yet.
+    pub l1_block_number: Option<u64>,
+    /// Result of comparing the node against a caller-supplied target version, when one was given.
+    ///
+    /// Operators use this to verify support for an *announced* upgrade before it is scheduled on L1,
+    /// when the contract does not yet carry the new minimum. Absent when no target was supplied.
+    pub target: Option<UpgradeReadinessTarget>,
+    /// Per-upgrade readiness for every activation currently scheduled on L1 (cleared/unscheduled
+    /// entries are omitted).
+    pub upgrades: Vec<UpgradeReadinessEntry>,
+}
+
+/// Readiness against a caller-supplied target protocol version.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UpgradeReadinessTarget {
+    /// The requested target minimum, rendered as `major.minor.patch` semver.
+    pub required_protocol_version: String,
+    /// Whether this node's advertised version satisfies the target.
+    pub supported: bool,
+}
+
+/// A node's readiness for one scheduled contract-backed upgrade.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UpgradeReadinessEntry {
+    /// Contract upgrade identifier (e.g. `azul`).
+    pub upgrade_id: String,
+    /// Minimum node protocol version this upgrade requires on L1, rendered as `major.minor.patch`.
+    pub required_protocol_version: String,
+    /// L2 activation timestamp announced on L1.
+    pub activation_timestamp: u64,
+    /// Whether this node's advertised version satisfies the required minimum.
+    ///
+    /// This is the pure version comparison, independent of the activation timing, so it stays
+    /// meaningful the instant a minimum is published — even before an activation timestamp is set.
+    pub supported: bool,
+    /// Whether the node would fail closed (halt) for this upgrade right now: it is unsupported *and*
+    /// the activation is within the halt lead window (or already past). This tracks the node's real
+    /// halt decision exactly, so it only becomes `true` as an unsupported upgrade nears activation.
+    pub would_halt: bool,
+}
+
+impl UpgradeSignalConfig {
+    /// Builds an [`UpgradeReadiness`] report for `signals` (as read from L1 at `l1_block_number`).
+    ///
+    /// `now_secs` is the wall-clock used for the halt-window ([`UpgradeReadinessEntry::would_halt`])
+    /// check. `target_version`, when `Some`, overrides the on-chain minimum for the top-level
+    /// [`UpgradeReadiness::ready`] answer: it lets an operator confirm support for an *announced*
+    /// upgrade before it is scheduled on L1 (the gap between rolling out a release and publishing the
+    /// schedule), when the contract does not yet carry the new minimum. When `None`, readiness is
+    /// judged against the upgrades currently scheduled on L1.
+    ///
+    /// Only signals with a positive activation timestamp are reported (a clear carries no meaningful
+    /// minimum), and every field is computed with the same predicates the live poller uses so the
+    /// report cannot diverge from the node's actual behavior.
+    pub fn evaluate_readiness(
+        &self,
+        signals: &[UpgradeSignal],
+        l1_block_number: Option<u64>,
+        now_secs: u64,
+        target_version: Option<U256>,
+    ) -> UpgradeReadiness {
+        let lead_secs = self.halt_lead_time().as_secs();
+
+        let upgrades: Vec<UpgradeReadinessEntry> = signals
+            .iter()
+            .filter(|signal| signal.activation_timestamp > 0)
+            .map(|signal| UpgradeReadinessEntry {
+                upgrade_id: signal.upgrade_id.contract_id().to_string(),
+                required_protocol_version: PackedProtocolVersion::new(signal.protocol_version)
+                    .to_string(),
+                activation_timestamp: signal.activation_timestamp,
+                supported: self.supports_signal_protocol_version(signal),
+                would_halt: self.signal_fails_closed(signal, now_secs, lead_secs),
+            })
+            .collect();
+
+        let target = target_version.map(|version| UpgradeReadinessTarget {
+            required_protocol_version: PackedProtocolVersion::new(version).to_string(),
+            supported: self.supports_protocol_version(version),
+        });
+
+        // A supplied target is the operator's explicit "am I ready for the announced upgrade?"
+        // question and takes precedence; otherwise fall back to the upgrades currently on L1.
+        let ready = target.as_ref().map_or_else(
+            || upgrades.iter().all(|upgrade| upgrade.supported),
+            |target| target.supported,
+        );
+
+        UpgradeReadiness {
+            ready,
+            node_protocol_version: PackedProtocolVersion::new(self.node_protocol_version)
+                .to_string(),
+            l1_block_number,
+            target,
+            upgrades,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::Address;
+    use base_common_genesis::BaseUpgrade;
+
+    use super::*;
+    use crate::UpgradeSignalDefaults;
+
+    fn config() -> UpgradeSignalConfig {
+        let mut config = UpgradeSignalConfig::new(Address::ZERO);
+        // Node advertises 1.1.0.
+        config.node_protocol_version = UpgradeSignalDefaults::packed_protocol_version(1, 1, 0);
+        config
+    }
+
+    fn signal(upgrade_id: BaseUpgrade, activation_timestamp: u64, version: U256) -> UpgradeSignal {
+        UpgradeSignal { upgrade_id, activation_timestamp, protocol_version: version }
+    }
+
+    #[test]
+    fn reports_supported_scheduled_upgrade_as_ready() {
+        let config = config();
+        let signals = [signal(
+            BaseUpgrade::Azul,
+            1_000,
+            UpgradeSignalDefaults::packed_protocol_version(1, 1, 0),
+        )];
+
+        let readiness = config.evaluate_readiness(&signals, Some(42), 0, None);
+
+        assert!(readiness.ready);
+        assert_eq!(readiness.node_protocol_version, "1.1.0");
+        assert_eq!(readiness.l1_block_number, Some(42));
+        assert_eq!(readiness.upgrades.len(), 1);
+        let entry = &readiness.upgrades[0];
+        assert_eq!(entry.upgrade_id, "azul");
+        assert_eq!(entry.required_protocol_version, "1.1.0");
+        assert!(entry.supported);
+        assert!(!entry.would_halt);
+    }
+
+    #[test]
+    fn unsupported_upgrade_is_not_ready_and_halts_only_when_imminent() {
+        let config = config();
+        // Requires 1.1.1, which the 1.1.0 node cannot satisfy.
+        let required = UpgradeSignalDefaults::packed_protocol_version(1, 1, 1);
+        let activation = 1_000_000;
+
+        // Far in the future: not ready, but not yet within the halt window.
+        let distant = config.evaluate_readiness(
+            &[signal(BaseUpgrade::Azul, activation, required)],
+            Some(1),
+            0,
+            None,
+        );
+        assert!(!distant.ready);
+        assert!(!distant.upgrades[0].supported);
+        assert!(!distant.upgrades[0].would_halt);
+
+        // Within the halt lead window: would halt.
+        let now = activation - config.halt_lead_time().as_secs() + 1;
+        let imminent = config.evaluate_readiness(
+            &[signal(BaseUpgrade::Azul, activation, required)],
+            Some(1),
+            now,
+            None,
+        );
+        assert!(!imminent.ready);
+        assert!(imminent.upgrades[0].would_halt);
+    }
+
+    #[test]
+    fn cleared_signals_are_omitted() {
+        let config = config();
+        // Activation 0 is a clear and carries no meaningful minimum, even a high one.
+        let signals =
+            [signal(BaseUpgrade::Azul, 0, UpgradeSignalDefaults::packed_protocol_version(9, 9, 9))];
+
+        let readiness = config.evaluate_readiness(&signals, Some(1), 0, None);
+
+        assert!(readiness.upgrades.is_empty());
+        // Nothing scheduled that the node cannot support, so it is ready.
+        assert!(readiness.ready);
+    }
+
+    #[test]
+    fn target_version_overrides_the_ready_answer_before_anything_is_scheduled() {
+        let config = config();
+
+        // Empty contract (pre-schedule): a supported target is ready.
+        let supported_target = UpgradeSignalDefaults::packed_protocol_version(1, 0, 0);
+        let ready = config.evaluate_readiness(&[], None, 0, Some(supported_target));
+        assert!(ready.ready);
+        assert_eq!(ready.l1_block_number, None);
+        assert!(ready.upgrades.is_empty());
+        let target = ready.target.expect("target reported");
+        assert_eq!(target.required_protocol_version, "1.0.0");
+        assert!(target.supported);
+
+        // An unsupported target is not ready, even with nothing scheduled.
+        let unsupported_target = UpgradeSignalDefaults::packed_protocol_version(2, 0, 0);
+        let not_ready = config.evaluate_readiness(&[], None, 0, Some(unsupported_target));
+        assert!(!not_ready.ready);
+        assert!(!not_ready.target.unwrap().supported);
+    }
+}

--- a/crates/utilities/upgrade-signal/src/readiness.rs
+++ b/crates/utilities/upgrade-signal/src/readiness.rs
@@ -32,8 +32,9 @@ pub struct UpgradeReadiness {
     /// on L1, which requires both that the node's [`mode`](Self::mode) applies the live schedule
     /// *and* that the schedule passes the same validation the apply path runs (every activation has
     /// a supported, well-formed minimum version). A `false` here is therefore always actionable —
-    /// see [`reason`](Self::reason) — never "nothing to check" (an empty schedule is vacuously
-    /// ready for an applying mode).
+    /// see [`reason`](Self::reason). An empty read is *not* treated as vacuously ready: an
+    /// append-only contract always carries at least the oldest upgrade, so an empty schedule signals
+    /// a misconfigured, uninitialized, or unreachable contract and is reported unready.
     pub ready: bool,
     /// This node's advertised protocol version, rendered as `major.minor.patch` semver.
     pub node_protocol_version: String,
@@ -108,8 +109,9 @@ impl UpgradeSignalConfig {
         let lead_secs = self.halt_lead_time().as_secs();
         // Only a live-applying mode actually follows a live schedule change or halts at activation;
         // in the other modes the node observes the schedule but never applies or halts on it, so the
-        // report must not claim it will.
-        let applies_live = self.mode.applies_live_schedule();
+        // report must not claim it will. `allows_runtime_admin` is that predicate (only
+        // `RuntimeAdmin` tracks the schedule live).
+        let applies_live = self.mode.allows_runtime_admin();
 
         let upgrades: Vec<UpgradeReadinessEntry> = signals
             .iter()
@@ -146,6 +148,23 @@ impl UpgradeSignalConfig {
                     "node's upgrade-signal mode does not apply the live L1 schedule; it will not \
                      follow a live change to it (per-upgrade `supported` still reflects binary \
                      capability)"
+                        .to_string(),
+                ),
+            ),
+            // No authoritative schedule to judge against. A healthy append-only `ProtocolVersions`
+            // contract always carries at least the oldest registered upgrade, so an empty read is a
+            // misconfigured, uninitialized, or unreachable contract rather than an authoritative
+            // "nothing scheduled" — the node's own apply paths refuse it (startup retries, admin
+            // rejects), so readiness must not vacuously claim the node is ready. An operator
+            // checking an announced upgrade before it is scheduled should pass `target_version`,
+            // which is judged above independently of the schedule.
+            None if signals.is_empty() => (
+                false,
+                Some(
+                    "no upgrade schedule is published on L1 (an append-only ProtocolVersions \
+                     contract always carries at least the oldest upgrade, so an empty read means a \
+                     misconfigured, uninitialized, or unreachable contract); pass a target version \
+                     to check binary support for an announced upgrade"
                         .to_string(),
                 ),
             ),
@@ -301,6 +320,23 @@ mod tests {
             assert_eq!(readiness.mode, mode);
             assert!(readiness.upgrades[0].supported);
             assert!(!readiness.upgrades[0].would_halt);
+        }
+    }
+
+    #[test]
+    fn empty_schedule_without_target_is_not_ready() {
+        // An append-only contract always carries at least the oldest upgrade, so an empty read is a
+        // misconfigured/uninitialized/unreachable contract, not an authoritative "nothing
+        // scheduled". Without a target to check against, the report must not claim readiness.
+        for mode in [
+            UpgradeSignalMode::MetricsOnly,
+            UpgradeSignalMode::StartupApply,
+            UpgradeSignalMode::RuntimeAdmin,
+        ] {
+            let readiness = config_with_mode(mode).evaluate_readiness(&[], None, 0, None);
+            assert!(!readiness.ready, "{mode:?} must not be ready against an empty schedule");
+            assert!(readiness.reason.is_some());
+            assert!(readiness.upgrades.is_empty());
         }
     }
 

--- a/crates/utilities/upgrade-signal/src/readiness.rs
+++ b/crates/utilities/upgrade-signal/src/readiness.rs
@@ -25,32 +25,18 @@ use crate::{PackedProtocolVersion, UpgradeSignal, UpgradeSignalConfig};
 pub struct UpgradeReadiness {
     /// Whether this node is ready.
     ///
-    /// When a [`target`](Self::target) version was supplied, this is simply whether the node
-    /// supports that version. Otherwise it is whether the node supports every upgrade currently
-    /// scheduled on L1 (vacuously `true` when nothing is scheduled — so a `false` here is always an
-    /// actionable "this node needs upgrading", never "nothing to check").
+    /// When a caller-supplied target version was supplied, this is simply whether the node supports
+    /// that version. Otherwise it is whether the node supports every upgrade currently scheduled on
+    /// L1 (vacuously `true` when nothing is scheduled — so a `false` here is always an actionable
+    /// "this node needs upgrading", never "nothing to check").
     pub ready: bool,
     /// This node's advertised protocol version, rendered as `major.minor.patch` semver.
     pub node_protocol_version: String,
     /// L1 block number the schedule was read at, or `None` when the contract has no schedule yet.
     pub l1_block_number: Option<u64>,
-    /// Result of comparing the node against a caller-supplied target version, when one was given.
-    ///
-    /// Operators use this to verify support for an *announced* upgrade before it is scheduled on L1,
-    /// when the contract does not yet carry the new minimum. Absent when no target was supplied.
-    pub target: Option<UpgradeReadinessTarget>,
     /// Per-upgrade readiness for every activation currently scheduled on L1 (cleared/unscheduled
     /// entries are omitted).
     pub upgrades: Vec<UpgradeReadinessEntry>,
-}
-
-/// Readiness against a caller-supplied target protocol version.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct UpgradeReadinessTarget {
-    /// The requested target minimum, rendered as `major.minor.patch` semver.
-    pub required_protocol_version: String,
-    /// Whether this node's advertised version satisfies the target.
-    pub supported: bool,
 }
 
 /// A node's readiness for one scheduled contract-backed upgrade.
@@ -108,16 +94,11 @@ impl UpgradeSignalConfig {
             })
             .collect();
 
-        let target = target_version.map(|version| UpgradeReadinessTarget {
-            required_protocol_version: PackedProtocolVersion::new(version).to_string(),
-            supported: self.supports_protocol_version(version),
-        });
-
         // A supplied target is the operator's explicit "am I ready for the announced upgrade?"
         // question and takes precedence; otherwise fall back to the upgrades currently on L1.
-        let ready = target.as_ref().map_or_else(
+        let ready = target_version.map_or_else(
             || upgrades.iter().all(|upgrade| upgrade.supported),
-            |target| target.supported,
+            |version| self.supports_protocol_version(version),
         );
 
         UpgradeReadiness {
@@ -125,7 +106,6 @@ impl UpgradeSignalConfig {
             node_protocol_version: PackedProtocolVersion::new(self.node_protocol_version)
                 .to_string(),
             l1_block_number,
-            target,
             upgrades,
         }
     }
@@ -226,14 +206,10 @@ mod tests {
         assert!(ready.ready);
         assert_eq!(ready.l1_block_number, None);
         assert!(ready.upgrades.is_empty());
-        let target = ready.target.expect("target reported");
-        assert_eq!(target.required_protocol_version, "1.0.0");
-        assert!(target.supported);
 
         // An unsupported target is not ready, even with nothing scheduled.
         let unsupported_target = UpgradeSignalDefaults::packed_protocol_version(2, 0, 0);
         let not_ready = config.evaluate_readiness(&[], None, 0, Some(unsupported_target));
         assert!(!not_ready.ready);
-        assert!(!not_ready.target.unwrap().supported);
     }
 }

--- a/crates/utilities/upgrade-signal/src/version.rs
+++ b/crates/utilities/upgrade-signal/src/version.rs
@@ -102,6 +102,61 @@ impl PackedProtocolVersion {
     }
 }
 
+/// Error returned when a string cannot be parsed as a `major.minor.patch[-rc.N]` protocol version.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseProtocolVersionError {
+    /// The input that failed to parse.
+    pub input: String,
+}
+
+impl ParseProtocolVersionError {
+    /// Creates a new parse error for `input`.
+    pub fn new(input: impl Into<String>) -> Self {
+        Self { input: input.into() }
+    }
+}
+
+impl core::fmt::Display for ParseProtocolVersionError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "invalid protocol version '{}', expected 'major.minor.patch' with an optional '-rc.N'",
+            self.input
+        )
+    }
+}
+
+impl std::error::Error for ParseProtocolVersionError {}
+
+impl core::str::FromStr for PackedProtocolVersion {
+    type Err = ParseProtocolVersionError;
+
+    /// Parses a human-readable `major.minor.patch` version (with an optional `-rc.N` pre-release)
+    /// into the packed version-type-`0` layout, the inverse of the [`Display`](Self) impl.
+    ///
+    /// This lets operators pass an announced upgrade version as plain semver (e.g. `1.2.3` or
+    /// `1.2.3-rc.4`) rather than the >70-digit packed decimal.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (core, prerelease) = match s.split_once("-rc.") {
+            Some((core, rc)) => {
+                (core, rc.parse::<u32>().map_err(|_| ParseProtocolVersionError::new(s))?)
+            }
+            None => (s, 0),
+        };
+
+        let mut parts = core.splitn(4, '.');
+        let major = parts.next().and_then(|p| p.parse::<u32>().ok());
+        let minor = parts.next().and_then(|p| p.parse::<u32>().ok());
+        let patch = parts.next().and_then(|p| p.parse::<u32>().ok());
+        let extra = parts.next();
+        let (Some(major), Some(minor), Some(patch), None) = (major, minor, patch, extra) else {
+            return Err(ParseProtocolVersionError::new(s));
+        };
+
+        Ok(Self::pack(major, minor, patch, prerelease))
+    }
+}
+
 impl core::fmt::Display for PackedProtocolVersion {
     /// Renders the version as human-readable semver for logs and error messages.
     ///
@@ -155,6 +210,26 @@ mod tests {
             PackedProtocolVersion::new(U256::from(2) << 248).to_string(),
             "unknown-version-type-2"
         );
+    }
+
+    #[test]
+    fn parses_semver_round_trip_and_rejects_garbage() {
+        use core::str::FromStr;
+
+        assert_eq!(
+            PackedProtocolVersion::from_str("1.2.3").unwrap(),
+            PackedProtocolVersion::pack(1, 2, 3, 0)
+        );
+        assert_eq!(
+            PackedProtocolVersion::from_str("1.2.3-rc.4").unwrap(),
+            PackedProtocolVersion::pack(1, 2, 3, 4)
+        );
+        // Round-trips through Display.
+        assert_eq!(PackedProtocolVersion::from_str("10.0.7").unwrap().to_string(), "10.0.7");
+
+        for bad in ["", "1", "1.2", "1.2.3.4", "1.2.x", "1.2.3-rc.", "1.2.3-rc.x", "v1.2.3"] {
+            assert!(PackedProtocolVersion::from_str(bad).is_err(), "expected {bad:?} to fail");
+        }
     }
 
     #[test]

--- a/crates/utilities/upgrade-signal/src/version.rs
+++ b/crates/utilities/upgrade-signal/src/version.rs
@@ -139,7 +139,15 @@ impl core::str::FromStr for PackedProtocolVersion {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (core, prerelease) = match s.split_once("-rc.") {
             Some((core, rc)) => {
-                (core, rc.parse::<u32>().map_err(|_| ParseProtocolVersionError::new(s))?)
+                let prerelease =
+                    rc.parse::<u32>().map_err(|_| ParseProtocolVersionError::new(s))?;
+                // `prerelease == 0` is the sentinel for a final release, so `-rc.0` would silently
+                // round-trip to `major.minor.patch` and drop the suffix. Reject it rather than
+                // accept a pre-release string that means the opposite of what it says.
+                if prerelease == 0 {
+                    return Err(ParseProtocolVersionError::new(s));
+                }
+                (core, prerelease)
             }
             None => (s, 0),
         };
@@ -227,7 +235,9 @@ mod tests {
         // Round-trips through Display.
         assert_eq!(PackedProtocolVersion::from_str("10.0.7").unwrap().to_string(), "10.0.7");
 
-        for bad in ["", "1", "1.2", "1.2.3.4", "1.2.x", "1.2.3-rc.", "1.2.3-rc.x", "v1.2.3"] {
+        for bad in
+            ["", "1", "1.2", "1.2.3.4", "1.2.x", "1.2.3-rc.", "1.2.3-rc.x", "1.2.3-rc.0", "v1.2.3"]
+        {
             assert!(PackedProtocolVersion::from_str(bad).is_err(), "expected {bad:?} to fail");
         }
     }

--- a/crates/utilities/upgrade-signal/src/version.rs
+++ b/crates/utilities/upgrade-signal/src/version.rs
@@ -102,34 +102,10 @@ impl PackedProtocolVersion {
     }
 }
 
-/// Error returned when a string cannot be parsed as a `major.minor.patch[-rc.N]` protocol version.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ParseProtocolVersionError {
-    /// The input that failed to parse.
-    pub input: String,
-}
-
-impl ParseProtocolVersionError {
-    /// Creates a new parse error for `input`.
-    pub fn new(input: impl Into<String>) -> Self {
-        Self { input: input.into() }
-    }
-}
-
-impl core::fmt::Display for ParseProtocolVersionError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(
-            f,
-            "invalid protocol version '{}', expected 'major.minor.patch' with an optional '-rc.N'",
-            self.input
-        )
-    }
-}
-
-impl std::error::Error for ParseProtocolVersionError {}
-
 impl core::str::FromStr for PackedProtocolVersion {
-    type Err = ParseProtocolVersionError;
+    /// A descriptive message naming the rejected input; the parse error carries no structured
+    /// information any caller consumes, so a plain `String` avoids a bespoke public error type.
+    type Err = String;
 
     /// Parses a human-readable `major.minor.patch` version (with an optional `-rc.N` pre-release)
     /// into the packed version-type-`0` layout, the inverse of the [`Display`](Self) impl.
@@ -137,15 +113,20 @@ impl core::str::FromStr for PackedProtocolVersion {
     /// This lets operators pass an announced upgrade version as plain semver (e.g. `1.2.3` or
     /// `1.2.3-rc.4`) rather than the >70-digit packed decimal.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let invalid = || {
+            format!(
+                "invalid protocol version '{s}', expected 'major.minor.patch' with an optional '-rc.N'"
+            )
+        };
+
         let (core, prerelease) = match s.split_once("-rc.") {
             Some((core, rc)) => {
-                let prerelease =
-                    rc.parse::<u32>().map_err(|_| ParseProtocolVersionError::new(s))?;
+                let prerelease = rc.parse::<u32>().map_err(|_| invalid())?;
                 // `prerelease == 0` is the sentinel for a final release, so `-rc.0` would silently
                 // round-trip to `major.minor.patch` and drop the suffix. Reject it rather than
                 // accept a pre-release string that means the opposite of what it says.
                 if prerelease == 0 {
-                    return Err(ParseProtocolVersionError::new(s));
+                    return Err(invalid());
                 }
                 (core, prerelease)
             }
@@ -158,7 +139,7 @@ impl core::str::FromStr for PackedProtocolVersion {
         let patch = parts.next().and_then(|p| p.parse::<u32>().ok());
         let extra = parts.next();
         let (Some(major), Some(minor), Some(patch), None) = (major, minor, patch, extra) else {
-            return Err(ParseProtocolVersionError::new(s));
+            return Err(invalid());
         };
 
         Ok(Self::pack(major, minor, patch, prerelease))


### PR DESCRIPTION
## Summary

Adds a public, read-only `base_upgradeReadiness` JSON-RPC method (in a new `base` namespace, so external node operators can query it without enabling the privileged admin namespace) and a `basectl upgrade-readiness` subcommand that wraps it. It reports whether the node's advertised protocol version satisfies the upgrades scheduled on L1 — returning the node version, each upgrade's required minimum, activation timestamp, and per-upgrade `supported`/`would_halt` flags — so operators can confirm a node will follow an upgrade before it activates. An optional `target_version` (`--target-version` in the CLI) checks readiness against an announced version before it is even scheduled on L1, covering the gap between rolling out a release and publishing the schedule, and the subcommand exits non-zero when the node is not ready so a fleet rollout can gate on it. This is stacked on #4513 (base branch `rf/fix/upgrade-signal-apply-retry`), whose fail-closed predicates the readiness report reuses so it can never disagree with the node's actual halt behavior.