### PR TITLE
feat(simulation): simBuffer + workers + RPC switch (6/n)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6300,6 +6300,8 @@ dependencies = [
  "base-common-rpc-types",
  "base-execution-chainspec",
  "base-execution-txpool",
+ "base-flashblocks",
+ "base-metering",
  "base-metrics",
  "base-node-runner",
  "base-observability-events",

--- a/crates/common/bundles/src/meter.rs
+++ b/crates/common/bundles/src/meter.rs
@@ -80,6 +80,13 @@ pub struct MeterBundleResponse {
 }
 
 impl MeterBundleResponse {
+    /// Mempool placeholder after a sim timeout or error (`Default`).
+    ///
+    /// A real one-tx `meter_bundle` always has a result and used gas.
+    pub const fn is_placeholder(&self) -> bool {
+        self.results.is_empty() && self.total_gas_used == 0
+    }
+
     /// Heap bytes owned beyond `size_of::<Self>()`: the results buffer, each
     /// `opcode_gas` buffer, and opcode name strings.
     pub fn heap_size(&self) -> usize {
@@ -250,6 +257,13 @@ mod tests {
         assert_eq!(deserialized.state_flashblock_index, None);
         assert_eq!(deserialized.state_block_number, 12345);
         assert_eq!(deserialized.total_gas_used, 21000);
+    }
+
+    #[test]
+    fn default_response_is_the_mempool_placeholder() {
+        assert!(MeterBundleResponse::default().is_placeholder());
+        assert!(!MeterBundleResponse { total_gas_used: 21_000, ..MeterBundleResponse::default() }
+            .is_placeholder());
     }
 
     #[test]

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -307,7 +307,8 @@ pub struct RpcStandardNodeArgs {
 
     /// Deadline for attaching real metering versus `MeterBundleResponse::default`.
     ///
-    /// Does not free the worker: `meter_bundle` still runs to completion.
+    /// Does not free the worker or bound queue drain: `meter_bundle` still runs
+    /// to completion, and the worker joins that blocking task.
     #[arg(
         long = "inline-simulation-timeout-ms",
         value_name = "INLINE_SIMULATION_TIMEOUT_MS",

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -290,6 +290,7 @@ pub struct RpcStandardNodeArgs {
         long = "inline-simulation-workers",
         value_name = "INLINE_SIMULATION_WORKERS",
         default_value_t = DEFAULT_INLINE_SIMULATION_WORKERS,
+        value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..),
         requires = "enable_inline_simulation"
     )]
     pub inline_simulation_workers: usize,
@@ -299,11 +300,14 @@ pub struct RpcStandardNodeArgs {
         long = "inline-simulation-queue-capacity",
         value_name = "INLINE_SIMULATION_QUEUE_CAPACITY",
         default_value_t = DEFAULT_INLINE_SIMULATION_QUEUE_CAPACITY,
+        value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..),
         requires = "enable_inline_simulation"
     )]
     pub inline_simulation_queue_capacity: usize,
 
-    /// Per-transaction meter_bundle timeout in milliseconds.
+    /// Deadline for attaching real metering versus `MeterBundleResponse::default`.
+    ///
+    /// Does not free the worker: `meter_bundle` still runs to completion.
     #[arg(
         long = "inline-simulation-timeout-ms",
         value_name = "INLINE_SIMULATION_TIMEOUT_MS",
@@ -953,6 +957,22 @@ mod tests {
         .expect_err("worker count should require --enable-inline-simulation");
 
         assert!(error.to_string().contains("--enable-inline-simulation"));
+    }
+
+    #[test]
+    fn inline_simulation_rejects_zero_workers() {
+        let error = CommandParser::<StandardNodeArgs>::try_parse_from([
+            "base-reth",
+            "--enable-tx-forwarding",
+            "--builder-rpc-urls",
+            "http://localhost:8545",
+            "--enable-inline-simulation",
+            "--inline-simulation-workers",
+            "0",
+        ])
+        .expect_err("zero workers would install a queue with no consumers");
+
+        assert!(error.to_string().contains("inline-simulation-workers"));
     }
 
     #[test]

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -281,8 +281,11 @@ pub struct RpcStandardNodeArgs {
 
     /// Run meter_bundle on the mempool node before inserting into the forwarding pool.
     ///
-    /// Has no effect until the sim-worker path is wired; keep off in production.
-    #[arg(long = "enable-inline-simulation", requires = "enable_tx_forwarding")]
+    /// Requires `--flashblocks-url` so sims use the live pending state, not an empty default.
+    #[arg(
+        long = "enable-inline-simulation",
+        requires_all = ["enable_tx_forwarding", "flashblocks_url"]
+    )]
     pub enable_inline_simulation: bool,
 
     /// Number of in-process meter_bundle workers.
@@ -588,9 +591,11 @@ impl StandardBaseRethNode {
         runner.install_ext::<BundleExtension>(());
         let mut tx_forwarding_config: TxForwardingConfig = (&args).into();
         if tx_forwarding_config.inline_simulation {
-            tx_forwarding_config = tx_forwarding_config.with_flashblocks_state(
-                flashblocks_config.as_ref().map(|config| Arc::clone(&config.state)),
-            );
+            let Some(flashblocks) = flashblocks_config.as_ref() else {
+                eyre::bail!("--enable-inline-simulation requires --flashblocks-url");
+            };
+            tx_forwarding_config =
+                tx_forwarding_config.with_flashblocks_state(Some(Arc::clone(&flashblocks.state)));
         }
         if args.rpc.enable_experimental_validity_transactions {
             runner.install_ext::<SendRawTransactionValidityExtension>(
@@ -946,6 +951,20 @@ mod tests {
     }
 
     #[test]
+    fn inline_simulation_requires_flashblocks_url() {
+        let error = CommandParser::<StandardNodeArgs>::try_parse_from([
+            "base-reth",
+            "--enable-tx-forwarding",
+            "--builder-rpc-urls",
+            "http://localhost:8545",
+            "--enable-inline-simulation",
+        ])
+        .expect_err("inline simulation should require a flashblocks websocket");
+
+        assert!(error.to_string().contains("--flashblocks-url"));
+    }
+
+    #[test]
     fn inline_simulation_workers_require_enable_flag() {
         let error = CommandParser::<StandardNodeArgs>::try_parse_from([
             "base-reth",
@@ -967,6 +986,8 @@ mod tests {
             "--enable-tx-forwarding",
             "--builder-rpc-urls",
             "http://localhost:8545",
+            "--flashblocks-url",
+            "wss://example.com/ws",
             "--enable-inline-simulation",
             "--inline-simulation-workers",
             "0",
@@ -1004,6 +1025,8 @@ mod tests {
             "--enable-tx-forwarding",
             "--builder-rpc-urls",
             "http://localhost:8545",
+            "--flashblocks-url",
+            "wss://example.com/ws",
             "--enable-inline-simulation",
             "--inline-simulation-workers",
             "8",
@@ -1032,6 +1055,8 @@ mod tests {
             "--enable-tx-forwarding",
             "--builder-rpc-urls",
             "http://localhost:8545",
+            "--flashblocks-url",
+            "wss://example.com/ws",
             "--enable-inline-simulation",
         ])
         .args;
@@ -1075,6 +1100,19 @@ mod tests {
 
         StandardBaseRethNode::runner(args)
             .expect("validity transactions should not require forwarding");
+    }
+
+    #[test]
+    fn runner_rejects_inline_simulation_without_flashblocks() {
+        let mut args = StandardNodeArgs::from(default_rpc_standard_node_args());
+        args.rpc.enable_tx_forwarding = true;
+        args.rpc.builder_rpc_urls = vec!["http://localhost:8545".parse().unwrap()];
+        args.rpc.enable_inline_simulation = true;
+
+        let error = StandardBaseRethNode::runner(args)
+            .expect_err("inline simulation must not start without flashblocks state");
+
+        assert!(error.to_string().contains("--flashblocks-url"));
     }
 
     #[test]

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -581,7 +581,20 @@ impl StandardBaseRethNode {
         runner.install_ext::<MeteringExtension>(metering_config(&args, flashblocks_config.clone())?);
         runner.install_ext::<ShadowIndexerExtension>((&args.shadow_indexer).try_into()?);
         runner.install_ext::<BundleExtension>(());
-        let tx_forwarding_config: TxForwardingConfig = (&args).into();
+        let mut tx_forwarding_config: TxForwardingConfig = (&args).into();
+        if tx_forwarding_config.inline_simulation {
+            let metered_opcodes = if args.metering.metering_metered_opcodes.is_empty() {
+                MeteredOpcodes::default()
+            } else {
+                MeteredOpcodes::parse(&args.metering.metering_metered_opcodes)?
+            }
+            .with_all_precompiles();
+            tx_forwarding_config = tx_forwarding_config
+                .with_flashblocks_state(
+                    flashblocks_config.as_ref().map(|config| Arc::clone(&config.state)),
+                )
+                .with_metered_opcodes(Arc::new(metered_opcodes));
+        }
         if args.rpc.enable_experimental_validity_transactions {
             runner.install_ext::<SendRawTransactionValidityExtension>(
                 args.rpc.experimental_validity_max_predicates,

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -583,17 +583,9 @@ impl StandardBaseRethNode {
         runner.install_ext::<BundleExtension>(());
         let mut tx_forwarding_config: TxForwardingConfig = (&args).into();
         if tx_forwarding_config.inline_simulation {
-            let metered_opcodes = if args.metering.metering_metered_opcodes.is_empty() {
-                MeteredOpcodes::default()
-            } else {
-                MeteredOpcodes::parse(&args.metering.metering_metered_opcodes)?
-            }
-            .with_all_precompiles();
-            tx_forwarding_config = tx_forwarding_config
-                .with_flashblocks_state(
-                    flashblocks_config.as_ref().map(|config| Arc::clone(&config.state)),
-                )
-                .with_metered_opcodes(Arc::new(metered_opcodes));
+            tx_forwarding_config = tx_forwarding_config.with_flashblocks_state(
+                flashblocks_config.as_ref().map(|config| Arc::clone(&config.state)),
+            );
         }
         if args.rpc.enable_experimental_validity_transactions {
             runner.install_ext::<SendRawTransactionValidityExtension>(

--- a/crates/execution/rpc/src/eth/transaction.rs
+++ b/crates/execution/rpc/src/eth/transaction.rs
@@ -34,7 +34,8 @@ use reth_storage_api::{
 };
 use reth_transaction_pool::{
     AddedTransactionOutcome, PoolTransaction, TransactionOrigin, TransactionPool,
-    TransactionValidationOutcome, ValidatingPool, error::PoolError,
+    TransactionValidationOutcome, ValidatingPool,
+    error::{PoolError, PoolErrorKind},
 };
 use tracing::{debug, instrument, warn};
 
@@ -264,7 +265,7 @@ where
     N::Pool: ValidatingPool<Transaction = BasePooledTransaction>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = BaseEthApiError>,
 {
-    /// Cheap-validate, enqueue for meter_bundle workers, and return the hash without waiting.
+    /// Cheap-validate, enqueue for meter_bundle workers, and wait for pool insert.
     async fn send_inline_sim(
         &self,
         origin: TransactionOrigin,
@@ -286,17 +287,20 @@ where
             }
         };
 
-        match InlineSimQueue::try_enqueue(InlineSimJob { origin, transaction: validated }) {
-            Ok(()) => Ok(hash),
-            Err(InlineSimEnqueueError::Full(job)) => {
-                let job = InlineSimQueue::with_default_metering(job, "queue_full");
-                let AddedTransactionOutcome { hash, .. } = self
-                    .pool()
-                    .add_transaction(job.origin, job.transaction)
-                    .await
-                    .map_err(BaseEthApiError::from_eth_err)?;
-                Ok(hash)
-            }
+        let (job, inserted) = InlineSimJob::new(origin, validated);
+        match InlineSimQueue::try_enqueue(job) {
+            Ok(()) => match inserted.await {
+                Ok(Ok(outcome)) => Ok(outcome.hash),
+                Ok(Err(err)) => Err(EthApiError::PoolError(err.into()).into()),
+                Err(_) => Err(EthApiError::PoolError(
+                    PoolError::other(hash, "inline sim worker dropped the insert result").into(),
+                )
+                .into()),
+            },
+            Err(InlineSimEnqueueError::Full(hash)) => Err(EthApiError::PoolError(
+                PoolError::new(hash, PoolErrorKind::DiscardedOnInsert).into(),
+            )
+            .into()),
             Err(InlineSimEnqueueError::Disabled(job)) => {
                 let AddedTransactionOutcome { hash, .. } = self
                     .pool()

--- a/crates/execution/rpc/src/eth/transaction.rs
+++ b/crates/execution/rpc/src/eth/transaction.rs
@@ -288,16 +288,23 @@ where
 
         match InlineSimQueue::try_enqueue(InlineSimJob { origin, transaction: validated }) {
             Ok(()) => Ok(hash),
-            Err(InlineSimEnqueueError::Full) => {
-                Err(EthApiError::PoolError(
-                    reth_rpc_eth_types::error::RpcPoolError::TxPoolOverflow,
-                )
-                .into())
+            Err(InlineSimEnqueueError::Full(job)) => {
+                let job = InlineSimQueue::with_default_metering(job, "queue_full");
+                let AddedTransactionOutcome { hash, .. } = self
+                    .pool()
+                    .add_transaction(job.origin, job.transaction)
+                    .await
+                    .map_err(BaseEthApiError::from_eth_err)?;
+                Ok(hash)
             }
-            Err(InlineSimEnqueueError::Disabled) => Err(EthApiError::PoolError(
-                PoolError::other(hash, "inline sim queue is not installed").into(),
-            )
-            .into()),
+            Err(InlineSimEnqueueError::Disabled(job)) => {
+                let AddedTransactionOutcome { hash, .. } = self
+                    .pool()
+                    .add_transaction(job.origin, job.transaction)
+                    .await
+                    .map_err(BaseEthApiError::from_eth_err)?;
+                Ok(hash)
+            }
         }
     }
 }

--- a/crates/execution/rpc/src/eth/transaction.rs
+++ b/crates/execution/rpc/src/eth/transaction.rs
@@ -14,7 +14,7 @@ use base_common_consensus::{
     BaseTransaction, BaseTransactionInfo, DepositInfo, DepositReceiptExt, EIP8130_TX_TYPE_ID,
 };
 use base_execution_txpool::{
-    BasePooledTransaction, InlineSimEnqueueError, InlineSimJob, InlineSimQueue,
+    BasePooledTransaction, InlineSimEnqueueError, InlineSimJob, InlineSimPool,
 };
 use base_observability_events::{
     TransactionEventProducer, TransactionEventType, transaction_event,
@@ -34,8 +34,7 @@ use reth_storage_api::{
 };
 use reth_transaction_pool::{
     AddedTransactionOutcome, PoolTransaction, TransactionOrigin, TransactionPool,
-    TransactionValidationOutcome, ValidatingPool,
-    error::{PoolError, PoolErrorKind},
+    TransactionValidationOutcome, ValidatingPool, error::PoolError,
 };
 use tracing::{debug, instrument, warn};
 
@@ -46,7 +45,7 @@ impl<N, Rpc> EthTransactions for BaseEthApi<N, Rpc>
 where
     N: RpcNodeCore,
     N::Provider: BlockReaderIdExt + ChainSpecProvider<ChainSpec: Upgrades>,
-    N::Pool: ValidatingPool<Transaction = BasePooledTransaction>,
+    N::Pool: ValidatingPool<Transaction = BasePooledTransaction> + InlineSimPool,
     BaseEthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = BaseEthApiError>,
 {
@@ -105,7 +104,7 @@ where
             return Ok(hash);
         }
 
-        if InlineSimQueue::is_enabled() {
+        if self.pool().is_inline_sim_enabled() {
             return self.send_inline_sim(origin, pool_transaction).await;
         }
 
@@ -262,7 +261,7 @@ where
 impl<N, Rpc> BaseEthApi<N, Rpc>
 where
     N: RpcNodeCore,
-    N::Pool: ValidatingPool<Transaction = BasePooledTransaction>,
+    N::Pool: ValidatingPool<Transaction = BasePooledTransaction> + InlineSimPool,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = BaseEthApiError>,
 {
     /// Cheap-validate, enqueue for meter_bundle workers, and wait for pool insert.
@@ -288,7 +287,7 @@ where
         };
 
         let (job, inserted) = InlineSimJob::new(origin, validated);
-        match InlineSimQueue::try_enqueue(job) {
+        match self.pool().try_enqueue_inline_sim(job) {
             Ok(()) => match inserted.await {
                 Ok(Ok(outcome)) => Ok(outcome.hash),
                 Ok(Err(err)) => Err(EthApiError::PoolError(err.into()).into()),
@@ -297,11 +296,7 @@ where
                 )
                 .into()),
             },
-            Err(InlineSimEnqueueError::Full(hash)) => Err(EthApiError::PoolError(
-                PoolError::new(hash, PoolErrorKind::DiscardedOnInsert).into(),
-            )
-            .into()),
-            Err(InlineSimEnqueueError::Disabled(job)) => {
+            Err(InlineSimEnqueueError::Full(job) | InlineSimEnqueueError::Disabled(job)) => {
                 let AddedTransactionOutcome { hash, .. } = self
                     .pool()
                     .add_transaction(job.origin, job.transaction)

--- a/crates/execution/rpc/src/eth/transaction.rs
+++ b/crates/execution/rpc/src/eth/transaction.rs
@@ -288,6 +288,8 @@ where
 
         let (job, inserted) = InlineSimJob::new(origin, validated);
         match self.pool().try_enqueue_inline_sim(job) {
+            // No oneshot deadline: Ok(hash) is insert. Sim timeout does not
+            // cancel spawn_blocking; the worker joins, so this waits out the EVM.
             Ok(()) => match inserted.await {
                 Ok(Ok(outcome)) => Ok(outcome.hash),
                 Ok(Err(err)) => Err(EthApiError::PoolError(err.into()).into()),

--- a/crates/execution/rpc/src/eth/transaction.rs
+++ b/crates/execution/rpc/src/eth/transaction.rs
@@ -13,6 +13,9 @@ use base_common_chains::Upgrades;
 use base_common_consensus::{
     BaseTransaction, BaseTransactionInfo, DepositInfo, DepositReceiptExt, EIP8130_TX_TYPE_ID,
 };
+use base_execution_txpool::{
+    BasePooledTransaction, InlineSimEnqueueError, InlineSimJob, InlineSimQueue,
+};
 use base_observability_events::{
     TransactionEventProducer, TransactionEventType, transaction_event,
 };
@@ -31,6 +34,7 @@ use reth_storage_api::{
 };
 use reth_transaction_pool::{
     AddedTransactionOutcome, PoolTransaction, TransactionOrigin, TransactionPool,
+    TransactionValidationOutcome, ValidatingPool, error::PoolError,
 };
 use tracing::{debug, instrument, warn};
 
@@ -41,6 +45,7 @@ impl<N, Rpc> EthTransactions for BaseEthApi<N, Rpc>
 where
     N: RpcNodeCore,
     N::Provider: BlockReaderIdExt + ChainSpecProvider<ChainSpec: Upgrades>,
+    N::Pool: ValidatingPool<Transaction = BasePooledTransaction>,
     BaseEthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = BaseEthApiError>,
 {
@@ -97,6 +102,10 @@ where
             });
 
             return Ok(hash);
+        }
+
+        if InlineSimQueue::is_enabled() {
+            return self.send_inline_sim(origin, pool_transaction).await;
         }
 
         // submit the transaction to the pool with the given origin
@@ -246,6 +255,50 @@ where
             return Ok(false);
         };
         Ok(self.provider().chain_spec().is_cobalt_active_at_timestamp(header.timestamp()))
+    }
+}
+
+impl<N, Rpc> BaseEthApi<N, Rpc>
+where
+    N: RpcNodeCore,
+    N::Pool: ValidatingPool<Transaction = BasePooledTransaction>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = BaseEthApiError>,
+{
+    /// Cheap-validate, enqueue for meter_bundle workers, and return the hash without waiting.
+    async fn send_inline_sim(
+        &self,
+        origin: TransactionOrigin,
+        pool_transaction: BasePooledTransaction,
+    ) -> Result<B256, BaseEthApiError> {
+        let hash = *pool_transaction.hash();
+        // Cheap admission before the sim queue so spam does not occupy workers.
+        // `add_transaction` validates again after sim; nonce/balance can change
+        // in between, and validate_one is cheap enough to run twice.
+        let validated = match self.pool().validate(origin, pool_transaction).await {
+            TransactionValidationOutcome::Valid { transaction, .. } => {
+                transaction.into_transaction()
+            }
+            TransactionValidationOutcome::Invalid(tx, err) => {
+                return Err(EthApiError::PoolError(PoolError::new(*tx.hash(), err).into()).into());
+            }
+            TransactionValidationOutcome::Error(hash, err) => {
+                return Err(EthApiError::PoolError(PoolError::other(hash, err).into()).into());
+            }
+        };
+
+        match InlineSimQueue::try_enqueue(InlineSimJob { origin, transaction: validated }) {
+            Ok(()) => Ok(hash),
+            Err(InlineSimEnqueueError::Full) => {
+                Err(EthApiError::PoolError(
+                    reth_rpc_eth_types::error::RpcPoolError::TxPoolOverflow,
+                )
+                .into())
+            }
+            Err(InlineSimEnqueueError::Disabled) => Err(EthApiError::PoolError(
+                PoolError::other(hash, "inline sim queue is not installed").into(),
+            )
+            .into()),
+        }
     }
 }
 

--- a/crates/execution/tx-forwarding/Cargo.toml
+++ b/crates/execution/tx-forwarding/Cargo.toml
@@ -30,6 +30,7 @@ base-observability-events.workspace = true
 
 # misc
 url.workspace = true
+eyre.workspace = true
 serde.workspace = true
 futures.workspace = true
 tracing.workspace = true
@@ -56,7 +57,6 @@ base-execution-chainspec.workspace = true
 base-node-runner = { workspace = true, features = ["test-utils"] }
 
 # misc
-eyre.workspace = true
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 jsonrpsee = { workspace = true, features = ["server"] }

--- a/crates/execution/tx-forwarding/Cargo.toml
+++ b/crates/execution/tx-forwarding/Cargo.toml
@@ -22,6 +22,8 @@ reth-transaction-pool.workspace = true
 
 # workspace
 base-metrics.workspace = true
+base-metering.workspace = true
+base-flashblocks.workspace = true
 base-node-runner.workspace = true
 base-execution-txpool.workspace = true
 base-observability-events.workspace = true

--- a/crates/execution/tx-forwarding/src/config.rs
+++ b/crates/execution/tx-forwarding/src/config.rs
@@ -39,7 +39,7 @@ pub struct TxForwardingConfig {
     pub inline_simulation_workers: usize,
     /// Bounded pre-sim queue capacity.
     pub inline_simulation_queue_capacity: usize,
-    /// Per-transaction meter_bundle timeout in milliseconds.
+    /// Deadline for real vs default metering. Does not free the worker.
     pub inline_simulation_timeout_ms: u64,
     /// Shared flashblocks pending state used by in-process meter_bundle.
     pub flashblocks_state: Option<Arc<FlashblocksState>>,

--- a/crates/execution/tx-forwarding/src/config.rs
+++ b/crates/execution/tx-forwarding/src/config.rs
@@ -1,7 +1,9 @@
 //! Configuration for the transaction forwarding extension.
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
+use base_flashblocks::FlashblocksState;
+use base_metering::MeteredOpcodes;
 use url::Url;
 
 use crate::{forwarder::ForwarderConfig, reader::ReaderConfig};
@@ -33,9 +35,6 @@ pub struct TxForwardingConfig {
     /// Maximum RPC requests per second per forwarder (0 = unlimited).
     pub max_rps: u32,
     /// When true, meter_bundle runs on the mempool node before pool insert.
-    ///
-    /// Stored only until the sim-worker path is wired; forwarding behavior is
-    /// unchanged while this flag is unused.
     pub inline_simulation: bool,
     /// Number of meter_bundle worker tasks.
     pub inline_simulation_workers: usize,
@@ -43,6 +42,10 @@ pub struct TxForwardingConfig {
     pub inline_simulation_queue_capacity: usize,
     /// Per-transaction meter_bundle timeout in milliseconds.
     pub inline_simulation_timeout_ms: u64,
+    /// Shared flashblocks pending state used by in-process meter_bundle.
+    pub flashblocks_state: Option<Arc<FlashblocksState>>,
+    /// Opcodes and precompiles tracked during in-process meter_bundle.
+    pub metered_opcodes: Arc<MeteredOpcodes>,
 }
 
 impl Default for TxForwardingConfig {
@@ -58,6 +61,8 @@ impl Default for TxForwardingConfig {
             inline_simulation_workers: DEFAULT_INLINE_SIMULATION_WORKERS,
             inline_simulation_queue_capacity: DEFAULT_INLINE_SIMULATION_QUEUE_CAPACITY,
             inline_simulation_timeout_ms: DEFAULT_INLINE_SIMULATION_TIMEOUT_MS,
+            flashblocks_state: None,
+            metered_opcodes: Arc::new(MeteredOpcodes::default()),
         }
     }
 }
@@ -112,6 +117,18 @@ impl TxForwardingConfig {
     /// Sets the per-transaction meter_bundle timeout in milliseconds.
     pub const fn with_inline_simulation_timeout_ms(mut self, ms: u64) -> Self {
         self.inline_simulation_timeout_ms = ms;
+        self
+    }
+
+    /// Sets the shared flashblocks pending state used by in-process meter_bundle.
+    pub fn with_flashblocks_state(mut self, state: Option<Arc<FlashblocksState>>) -> Self {
+        self.flashblocks_state = state;
+        self
+    }
+
+    /// Sets opcodes and precompiles tracked during in-process meter_bundle.
+    pub fn with_metered_opcodes(mut self, opcodes: Arc<MeteredOpcodes>) -> Self {
+        self.metered_opcodes = opcodes;
         self
     }
 

--- a/crates/execution/tx-forwarding/src/config.rs
+++ b/crates/execution/tx-forwarding/src/config.rs
@@ -98,15 +98,15 @@ impl TxForwardingConfig {
         self
     }
 
-    /// Sets the number of meter_bundle worker tasks.
+    /// Sets the number of meter_bundle worker tasks. Zero is treated as 1.
     pub const fn with_inline_simulation_workers(mut self, workers: usize) -> Self {
-        self.inline_simulation_workers = workers;
+        self.inline_simulation_workers = if workers == 0 { 1 } else { workers };
         self
     }
 
-    /// Sets the pre-sim queue capacity.
+    /// Sets the pre-sim queue capacity. Zero is treated as 1.
     pub const fn with_inline_simulation_queue_capacity(mut self, capacity: usize) -> Self {
-        self.inline_simulation_queue_capacity = capacity;
+        self.inline_simulation_queue_capacity = if capacity == 0 { 1 } else { capacity };
         self
     }
 
@@ -178,5 +178,15 @@ mod tests {
         assert_eq!(config.inline_simulation_workers, 8);
         assert_eq!(config.inline_simulation_queue_capacity, 32);
         assert_eq!(config.inline_simulation_timeout_ms, 500);
+    }
+
+    #[test]
+    fn zero_workers_or_queue_capacity_clamp_to_one() {
+        let config = TxForwardingConfig::new(vec!["http://builder.test".parse().unwrap()])
+            .with_inline_simulation_workers(0)
+            .with_inline_simulation_queue_capacity(0);
+
+        assert_eq!(config.inline_simulation_workers, 1);
+        assert_eq!(config.inline_simulation_queue_capacity, 1);
     }
 }

--- a/crates/execution/tx-forwarding/src/config.rs
+++ b/crates/execution/tx-forwarding/src/config.rs
@@ -3,7 +3,6 @@
 use std::{sync::Arc, time::Duration};
 
 use base_flashblocks::FlashblocksState;
-use base_metering::MeteredOpcodes;
 use url::Url;
 
 use crate::{forwarder::ForwarderConfig, reader::ReaderConfig};
@@ -44,8 +43,6 @@ pub struct TxForwardingConfig {
     pub inline_simulation_timeout_ms: u64,
     /// Shared flashblocks pending state used by in-process meter_bundle.
     pub flashblocks_state: Option<Arc<FlashblocksState>>,
-    /// Opcodes and precompiles tracked during in-process meter_bundle.
-    pub metered_opcodes: Arc<MeteredOpcodes>,
 }
 
 impl Default for TxForwardingConfig {
@@ -62,7 +59,6 @@ impl Default for TxForwardingConfig {
             inline_simulation_queue_capacity: DEFAULT_INLINE_SIMULATION_QUEUE_CAPACITY,
             inline_simulation_timeout_ms: DEFAULT_INLINE_SIMULATION_TIMEOUT_MS,
             flashblocks_state: None,
-            metered_opcodes: Arc::new(MeteredOpcodes::default()),
         }
     }
 }
@@ -123,12 +119,6 @@ impl TxForwardingConfig {
     /// Sets the shared flashblocks pending state used by in-process meter_bundle.
     pub fn with_flashblocks_state(mut self, state: Option<Arc<FlashblocksState>>) -> Self {
         self.flashblocks_state = state;
-        self
-    }
-
-    /// Sets opcodes and precompiles tracked during in-process meter_bundle.
-    pub fn with_metered_opcodes(mut self, opcodes: Arc<MeteredOpcodes>) -> Self {
-        self.metered_opcodes = opcodes;
         self
     }
 

--- a/crates/execution/tx-forwarding/src/extension.rs
+++ b/crates/execution/tx-forwarding/src/extension.rs
@@ -29,29 +29,22 @@ impl BaseNodeExtension for TxForwardingExtension {
     /// Applies the extension to the supplied hooks.
     fn apply(self: Box<Self>, hooks: NodeHooks) -> NodeHooks {
         let config = self.config;
-        let inline_rx = if config.inline_simulation
+        let inline_chan = if config.inline_simulation
             && config.inline_simulation_workers > 0
             && config.inline_simulation_queue_capacity > 0
         {
-            let (sender, receiver) = mpsc::channel(config.inline_simulation_queue_capacity);
-            InlineSimQueue::install(sender);
-            info!(
-                workers = config.inline_simulation_workers,
-                queue_capacity = config.inline_simulation_queue_capacity,
-                timeout_ms = config.inline_simulation_timeout_ms,
-                "installed inline simulation queue"
-            );
-            Some(receiver)
+            Some(mpsc::channel(config.inline_simulation_queue_capacity))
         } else {
             None
         };
 
-        if (!config.enabled || config.builder_urls.is_empty()) && inline_rx.is_none() {
+        if (!config.enabled || config.builder_urls.is_empty()) && inline_chan.is_none() {
             return hooks;
         }
 
         hooks.add_node_started_hook(move |ctx| {
-            if let Some(receiver) = inline_rx {
+            if let Some((sender, receiver)) = inline_chan {
+                InlineSimQueue::install(sender);
                 let meter = Arc::new(MeteringApiImpl::new(
                     ctx.provider.clone(),
                     config.flashblocks_state.clone().unwrap_or_default(),
@@ -66,6 +59,8 @@ impl BaseNodeExtension for TxForwardingExtension {
                 );
                 info!(
                     workers = config.inline_simulation_workers,
+                    queue_capacity = config.inline_simulation_queue_capacity,
+                    timeout_ms = config.inline_simulation_timeout_ms,
                     "started inline simulation workers"
                 );
             }

--- a/crates/execution/tx-forwarding/src/extension.rs
+++ b/crates/execution/tx-forwarding/src/extension.rs
@@ -6,6 +6,7 @@ use std::{sync::Arc, time::Duration};
 use base_execution_txpool::{InlineSimQueue, TransactionValidity};
 use base_metering::{MeteredOpcodes, MeteringApiImpl};
 use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
+use eyre::eyre;
 use tokio::sync::mpsc;
 use tracing::info;
 
@@ -44,10 +45,15 @@ impl BaseNodeExtension for TxForwardingExtension {
 
         hooks.add_node_started_hook(move |ctx| {
             if let Some((sender, receiver)) = inline_chan {
+                let Some(flashblocks_state) = config.flashblocks_state.clone() else {
+                    return Err(eyre!(
+                        "inline simulation requires flashblocks state; set --flashblocks-url"
+                    ));
+                };
                 InlineSimQueue::install(sender);
                 let meter = Arc::new(MeteringApiImpl::new(
                     ctx.provider.clone(),
-                    config.flashblocks_state.clone().unwrap_or_default(),
+                    flashblocks_state,
                     Arc::new(MeteredOpcodes::default()),
                 ));
                 InlineSimQueue::spawn_workers(

--- a/crates/execution/tx-forwarding/src/extension.rs
+++ b/crates/execution/tx-forwarding/src/extension.rs
@@ -4,7 +4,7 @@
 use std::{sync::Arc, time::Duration};
 
 use base_execution_txpool::{InlineSimQueue, TransactionValidity};
-use base_metering::MeteringApiImpl;
+use base_metering::{MeteredOpcodes, MeteringApiImpl};
 use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
 use tokio::sync::mpsc;
 use tracing::info;
@@ -52,7 +52,7 @@ impl BaseNodeExtension for TxForwardingExtension {
                 let meter = Arc::new(MeteringApiImpl::new(
                     ctx.provider.clone(),
                     config.flashblocks_state.clone().unwrap_or_default(),
-                    Arc::clone(&config.metered_opcodes),
+                    Arc::new(MeteredOpcodes::default()),
                 ));
                 InlineSimQueue::spawn_workers(
                     ctx.pool().clone(),

--- a/crates/execution/tx-forwarding/src/extension.rs
+++ b/crates/execution/tx-forwarding/src/extension.rs
@@ -1,8 +1,12 @@
 //! Contains the [`TxForwardingExtension`] which wires up the transaction
 //! forwarding pipeline on the Base node builder.
 
-use base_execution_txpool::TransactionValidity;
+use std::{sync::Arc, time::Duration};
+
+use base_execution_txpool::{InlineSimQueue, TransactionValidity};
+use base_metering::MeteringApiImpl;
 use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
+use tokio::sync::mpsc;
 use tracing::info;
 
 use crate::{TxForwardingConfig, TxForwardingService};
@@ -24,13 +28,49 @@ impl TxForwardingExtension {
 impl BaseNodeExtension for TxForwardingExtension {
     /// Applies the extension to the supplied hooks.
     fn apply(self: Box<Self>, hooks: NodeHooks) -> NodeHooks {
-        if !self.config.enabled || self.config.builder_urls.is_empty() {
+        let config = self.config;
+        let inline_rx = if config.inline_simulation {
+            let (sender, receiver) = mpsc::channel(config.inline_simulation_queue_capacity);
+            InlineSimQueue::install(sender);
+            info!(
+                workers = config.inline_simulation_workers,
+                queue_capacity = config.inline_simulation_queue_capacity,
+                timeout_ms = config.inline_simulation_timeout_ms,
+                "installed inline simulation queue"
+            );
+            Some(receiver)
+        } else {
+            None
+        };
+
+        if (!config.enabled || config.builder_urls.is_empty()) && inline_rx.is_none() {
             return hooks;
         }
 
-        let config = self.config;
-
         hooks.add_node_started_hook(move |ctx| {
+            if let Some(receiver) = inline_rx {
+                let meter = Arc::new(MeteringApiImpl::new(
+                    ctx.provider.clone(),
+                    config.flashblocks_state.clone().unwrap_or_default(),
+                    Arc::clone(&config.metered_opcodes),
+                ));
+                InlineSimQueue::spawn_workers(
+                    ctx.pool().clone(),
+                    move |tx| meter.meter_transaction(tx).map_err(|error| error.to_string()),
+                    receiver,
+                    config.inline_simulation_workers,
+                    Duration::from_millis(config.inline_simulation_timeout_ms),
+                );
+                info!(
+                    workers = config.inline_simulation_workers,
+                    "started inline simulation workers"
+                );
+            }
+
+            if !config.enabled || config.builder_urls.is_empty() {
+                return Ok(());
+            }
+
             info!(
                 builder_urls = ?config.builder_urls,
                 resend_after_ms = config.resend_after_ms,

--- a/crates/execution/tx-forwarding/src/extension.rs
+++ b/crates/execution/tx-forwarding/src/extension.rs
@@ -50,7 +50,7 @@ impl BaseNodeExtension for TxForwardingExtension {
                         "inline simulation requires flashblocks state; set --flashblocks-url"
                     ));
                 };
-                InlineSimQueue::install(sender);
+                ctx.pool().install_inline_sim(sender);
                 let meter = Arc::new(MeteringApiImpl::new(
                     ctx.provider.clone(),
                     flashblocks_state,

--- a/crates/execution/tx-forwarding/src/extension.rs
+++ b/crates/execution/tx-forwarding/src/extension.rs
@@ -29,7 +29,10 @@ impl BaseNodeExtension for TxForwardingExtension {
     /// Applies the extension to the supplied hooks.
     fn apply(self: Box<Self>, hooks: NodeHooks) -> NodeHooks {
         let config = self.config;
-        let inline_rx = if config.inline_simulation {
+        let inline_rx = if config.inline_simulation
+            && config.inline_simulation_workers > 0
+            && config.inline_simulation_queue_capacity > 0
+        {
             let (sender, receiver) = mpsc::channel(config.inline_simulation_queue_capacity);
             InlineSimQueue::install(sender);
             info!(

--- a/crates/execution/txpool/src/builder/rpc.rs
+++ b/crates/execution/txpool/src/builder/rpc.rs
@@ -154,10 +154,10 @@ where
             tx.min_timestamp,
             tx.max_timestamp,
         );
-        // `MeterBundleResponse::default` is a mempool placeholder after sim
-        // timeout/error. Keep it on the pooled tx; do not treat it as real cache data.
+        // `is_placeholder` is a mempool timeout/error sentinel. Keep it on the
+        // pooled tx; do not treat it as real cache data.
         let pool_tx = match tx.metering {
-            Some(metering) if metering != MeterBundleResponse::default() => {
+            Some(metering) if !metering.is_placeholder() => {
                 if let Some(cache) = &self.metering_cache {
                     cache.insert_metering(tx_hash, metering.clone());
                 }

--- a/crates/execution/txpool/src/builder/rpc.rs
+++ b/crates/execution/txpool/src/builder/rpc.rs
@@ -154,13 +154,16 @@ where
             tx.min_timestamp,
             tx.max_timestamp,
         );
+        // `MeterBundleResponse::default` is a mempool placeholder after sim
+        // timeout/error. Keep it on the pooled tx; do not treat it as real cache data.
         let pool_tx = match tx.metering {
-            Some(metering) => {
+            Some(metering) if metering != MeterBundleResponse::default() => {
                 if let Some(cache) = &self.metering_cache {
                     cache.insert_metering(tx_hash, metering.clone());
                 }
                 pool_tx.with_metering(metering)
             }
+            Some(metering) => pool_tx.with_metering(metering),
             None => pool_tx,
         };
 
@@ -464,6 +467,23 @@ mod tests {
         assert_eq!(inserted.len(), 1, "insert should write metering even if the pool later rejects");
         assert_eq!(inserted[0].0, expected_hash);
         assert_eq!(inserted[0].1, metering);
+    }
+
+    #[tokio::test]
+    async fn insert_skips_default_metering_in_the_builder_cache() {
+        let cache = Arc::new(RecordingMetering::default());
+        let handler = handler().with_metering_cache(Arc::clone(&cache) as Arc<dyn InsertMetering>);
+        let (sender, raw) = create_eip1559_tx();
+        let mut tx = validated_transaction(sender, raw, NoExtensions {});
+        tx.metering = Some(MeterBundleResponse::default());
+
+        let _ = handler.insert_validated_transaction(tx).await;
+
+        let inserted = cache.inserted.lock().expect("recording lock");
+        assert!(
+            inserted.is_empty(),
+            "placeholder MeterBundleResponse::default must not enter the builder cache"
+        );
     }
 
     #[test]

--- a/crates/execution/txpool/src/inline_sim.rs
+++ b/crates/execution/txpool/src/inline_sim.rs
@@ -41,6 +41,8 @@ base_metrics::define_metrics! {
     sim_default_inserts: counter,
     #[describe("Seconds waiting for meter_bundle to finish after the configured timeout fired")]
     sim_timeout_wait_seconds: histogram,
+    #[describe("Enqueued jobs whose pool insert failed after RPC already returned the hash")]
+    sim_insert_failures: counter,
 }
 
 /// Job waiting for an in-process meter_bundle worker.
@@ -143,6 +145,7 @@ impl InlineSimQueue {
                     let job = meter_job(job, Arc::clone(&meter), timeout).await;
                     if let Err(error) = pool.add_transaction(job.origin, job.transaction).await
                     {
+                        InlineSimMetrics::sim_insert_failures().increment(1);
                         debug!(error = %error, "inline sim pool insert failed");
                     }
                     InlineSimMetrics::sim_seconds().record(started.elapsed().as_secs_f64());

--- a/crates/execution/txpool/src/inline_sim.rs
+++ b/crates/execution/txpool/src/inline_sim.rs
@@ -204,8 +204,8 @@ where
             warn!(error = %error, hash = %job.transaction.hash(), "inline sim meter_bundle failed");
             InlineSimQueue::with_default_metering(job, "meter")
         }
-        Either::Left((Err(_), _)) => {
-            warn!(hash = %job.transaction.hash(), "inline sim worker task failed");
+        Either::Left((Err(join_error), _)) => {
+            warn!(error = %join_error, hash = %job.transaction.hash(), "inline sim worker task failed");
             InlineSimQueue::with_default_metering(job, "join")
         }
         Either::Right((_, handle)) => {
@@ -390,6 +390,19 @@ mod tests {
             out.transaction.metering(),
             Some(&MeterBundleResponse::default()),
             "timed-out meter_bundle must still insert with default metering"
+        );
+    }
+
+    #[tokio::test]
+    async fn meter_job_uses_default_metering_when_blocking_task_panics() {
+        let job = InlineSimJob { origin: TransactionOrigin::Local, transaction: pooled_tx() };
+
+        let out = meter_job(job, Arc::new(|_| panic!("meter panic")), Duration::from_secs(1)).await;
+
+        assert_eq!(
+            out.transaction.metering(),
+            Some(&MeterBundleResponse::default()),
+            "a panicked spawn_blocking task must still insert with default metering"
         );
     }
 }

--- a/crates/execution/txpool/src/inline_sim.rs
+++ b/crates/execution/txpool/src/inline_sim.rs
@@ -15,9 +15,10 @@ use std::{
 use alloy_consensus::transaction::Recovered;
 use base_bundles::MeterBundleResponse;
 use base_common_consensus::BaseTxEnvelope;
+use futures::future::{self, Either};
 use parking_lot::RwLock;
 use reth_transaction_pool::{PoolTransaction, TransactionOrigin, TransactionPool};
-use tokio::sync::mpsc;
+use tokio::sync::mpsc::{self, error::TrySendError};
 use tracing::{debug, warn};
 
 use crate::BasePooledTransaction;
@@ -33,9 +34,11 @@ base_metrics::define_metrics! {
     sim_seconds: histogram,
     #[describe("Transactions dropped because the pre-sim queue was full")]
     sim_queue_full: counter,
-    #[describe("meter_bundle failures that skipped pool insert")]
+    #[describe("meter_bundle failures that inserted MeterBundleResponse::default")]
     #[label(name = "reason", default = ["timeout", "meter", "join"])]
     sim_failures: counter,
+    #[describe("Pool inserts that carried MeterBundleResponse::default after a failed or timed-out sim")]
+    sim_default_inserts: counter,
 }
 
 /// Job waiting for an in-process meter_bundle worker.
@@ -82,13 +85,25 @@ impl InlineSimQueue {
         let Some(sender) = QUEUE.read().clone() else {
             return Err(InlineSimEnqueueError::Disabled);
         };
-        sender.try_send(job).map_err(|_| {
-            InlineSimMetrics::sim_queue_full().increment(1);
-            InlineSimEnqueueError::Full
-        })?;
-        let len = QUEUE_LEN.fetch_add(1, Ordering::Relaxed) + 1;
-        InlineSimMetrics::sim_queue_size().set(len as f64);
-        Ok(())
+        match sender.try_send(job) {
+            Ok(()) => {
+                let len = QUEUE_LEN.fetch_add(1, Ordering::Relaxed) + 1;
+                InlineSimMetrics::sim_queue_size().set(len as f64);
+                Ok(())
+            }
+            Err(TrySendError::Full(_)) => {
+                InlineSimMetrics::sim_queue_full().increment(1);
+                Err(InlineSimEnqueueError::Full)
+            }
+            Err(TrySendError::Closed(_)) => {
+                Self::uninstall();
+                Err(InlineSimEnqueueError::Disabled)
+            }
+        }
+    }
+
+    fn uninstall() {
+        *QUEUE.write() = None;
     }
 
     /// Spawns `workers` tasks that meter and insert queued transactions.
@@ -123,9 +138,8 @@ impl InlineSimQueue {
                     InlineSimMetrics::sim_queue_size().set(len as f64);
 
                     let started = Instant::now();
-                    if let Some(job) = meter_job(job, Arc::clone(&meter), timeout).await
-                        && let Err(error) =
-                            pool.add_transaction(job.origin, job.transaction).await
+                    let job = meter_job(job, Arc::clone(&meter), timeout).await;
+                    if let Err(error) = pool.add_transaction(job.origin, job.transaction).await
                     {
                         debug!(error = %error, "inline sim pool insert failed");
                     }
@@ -138,7 +152,7 @@ impl InlineSimQueue {
     /// Drops the enqueue sender so workers exit after draining.
     #[cfg(test)]
     pub fn clear() {
-        *QUEUE.write() = None;
+        Self::uninstall();
         QUEUE_LEN.store(0, Ordering::Relaxed);
         WORKERS_BUSY.store(0, Ordering::Relaxed);
         InlineSimMetrics::sim_queue_size().set(0.0);
@@ -146,7 +160,7 @@ impl InlineSimQueue {
     }
 }
 
-async fn meter_job<F>(job: InlineSimJob, meter: Arc<F>, timeout: Duration) -> Option<InlineSimJob>
+async fn meter_job<F>(job: InlineSimJob, meter: Arc<F>, timeout: Duration) -> InlineSimJob
 where
     F: Fn(Recovered<BaseTxEnvelope>) -> Result<MeterBundleResponse, String> + Send + Sync + 'static,
 {
@@ -154,36 +168,42 @@ where
     let busy = WORKERS_BUSY.fetch_add(1, Ordering::Relaxed) + 1;
     InlineSimMetrics::sim_workers_busy().set(busy as f64);
 
-    // ponytail: spawn_blocking cannot be cancelled; timeout only drops the wait
-    let result = tokio::time::timeout(
-        timeout,
-        tokio::task::spawn_blocking(move || meter(recovered)),
-    )
-    .await;
+    // Timeout must not drop the JoinHandle: spawn_blocking cannot be cancelled,
+    // so the worker joins before taking another job.
+    let handle = tokio::task::spawn_blocking(move || meter(recovered));
+    let job = match future::select(handle, Box::pin(tokio::time::sleep(timeout))).await {
+        Either::Left((Ok(Ok(metering)), _)) => InlineSimJob {
+            origin: job.origin,
+            transaction: job.transaction.with_metering(metering),
+        },
+        Either::Left((Ok(Err(error)), _)) => {
+            warn!(error = %error, hash = %job.transaction.hash(), "inline sim meter_bundle failed");
+            with_default_metering(job, "meter")
+        }
+        Either::Left((Err(_), _)) => {
+            warn!(hash = %job.transaction.hash(), "inline sim worker task failed");
+            with_default_metering(job, "join")
+        }
+        Either::Right((_, handle)) => {
+            warn!(hash = %job.transaction.hash(), "inline sim meter_bundle timed out");
+            let _ = handle.await;
+            with_default_metering(job, "timeout")
+        }
+    };
 
     let busy = WORKERS_BUSY.fetch_sub(1, Ordering::Relaxed).saturating_sub(1);
     InlineSimMetrics::sim_workers_busy().set(busy as f64);
+    job
+}
 
-    match result {
-        Ok(Ok(Ok(metering))) => Some(InlineSimJob {
-            origin: job.origin,
-            transaction: job.transaction.with_metering(metering),
-        }),
-        Ok(Ok(Err(error))) => {
-            InlineSimMetrics::sim_failures("meter").increment(1);
-            warn!(error = %error, hash = %job.transaction.hash(), "inline sim meter_bundle failed");
-            None
-        }
-        Ok(Err(_)) => {
-            InlineSimMetrics::sim_failures("join").increment(1);
-            warn!(hash = %job.transaction.hash(), "inline sim worker task failed");
-            None
-        }
-        Err(_) => {
-            InlineSimMetrics::sim_failures("timeout").increment(1);
-            warn!(hash = %job.transaction.hash(), "inline sim meter_bundle timed out");
-            None
-        }
+/// Sim failed or timed out: still insert so the Consumer can forward.
+/// Builder skips cache write when metering is `Default`.
+fn with_default_metering(job: InlineSimJob, reason: &'static str) -> InlineSimJob {
+    InlineSimMetrics::sim_failures(reason).increment(1);
+    InlineSimMetrics::sim_default_inserts().increment(1);
+    InlineSimJob {
+        origin: job.origin,
+        transaction: job.transaction.with_metering(MeterBundleResponse::default()),
     }
 }
 
@@ -280,6 +300,26 @@ mod tests {
         InlineSimQueue::clear();
     }
 
+    #[test]
+    fn try_enqueue_disables_when_workers_drop_the_queue() {
+        let _guard = TEST_GUARD.lock();
+        InlineSimQueue::clear();
+        let (tx, rx) = mpsc::channel(1);
+        InlineSimQueue::install(tx);
+        drop(rx);
+
+        let err = InlineSimQueue::try_enqueue(InlineSimJob {
+            origin: TransactionOrigin::Local,
+            transaction: pooled_tx(),
+        });
+        assert_eq!(err, Err(InlineSimEnqueueError::Disabled));
+        assert!(
+            !InlineSimQueue::is_enabled(),
+            "a closed worker channel must uninstall the queue"
+        );
+        InlineSimQueue::clear();
+    }
+
     #[tokio::test]
     async fn meter_job_attaches_metering_on_success() {
         let job = InlineSimJob { origin: TransactionOrigin::Local, transaction: pooled_tx() };
@@ -291,24 +331,27 @@ mod tests {
             Arc::new(move |_| Ok(expected_clone.clone())),
             Duration::from_secs(1),
         )
-        .await
-        .expect("successful meter must insert");
+        .await;
 
         assert_eq!(out.transaction.metering(), Some(&expected));
     }
 
     #[tokio::test]
-    async fn meter_job_skips_insert_on_meter_error() {
+    async fn meter_job_uses_default_metering_on_meter_error() {
         let job = InlineSimJob { origin: TransactionOrigin::Local, transaction: pooled_tx() };
 
         let out =
             meter_job(job, Arc::new(|_| Err("boom".to_string())), Duration::from_secs(1)).await;
 
-        assert!(out.is_none(), "failed meter_bundle must not produce an insert");
+        assert_eq!(
+            out.transaction.metering(),
+            Some(&MeterBundleResponse::default()),
+            "failed meter_bundle must still insert with default metering"
+        );
     }
 
     #[tokio::test]
-    async fn meter_job_skips_insert_on_timeout() {
+    async fn meter_job_uses_default_metering_on_timeout() {
         let job = InlineSimJob { origin: TransactionOrigin::Local, transaction: pooled_tx() };
 
         let out = meter_job(
@@ -321,6 +364,10 @@ mod tests {
         )
         .await;
 
-        assert!(out.is_none(), "timed-out meter_bundle must not produce an insert");
+        assert_eq!(
+            out.transaction.metering(),
+            Some(&MeterBundleResponse::default()),
+            "timed-out meter_bundle must still insert with default metering"
+        );
     }
 }

--- a/crates/execution/txpool/src/inline_sim.rs
+++ b/crates/execution/txpool/src/inline_sim.rs
@@ -1,9 +1,10 @@
 //! Pre-sim queue shared by `eth_sendRawTransaction` and mempool meter_bundle workers.
 //!
-//! RPC validates cheaply, then [`InlineSimQueue::try_enqueue`], then waits for the
-//! worker to `meter_bundle` and `add_transaction`. Queue-full returns
-//! [`reth_transaction_pool::error::PoolErrorKind::DiscardedOnInsert`] (`TxPoolOverflow`).
-//! The queue is installed in the node-started hook together with the workers.
+//! RPC validates cheaply, then [`InlineSimPool::try_enqueue_inline_sim`], then
+//! waits for the worker to `meter_bundle` and `add_transaction`. Queue-full and
+//! a dead worker channel fall back to `add_transaction` without metering.
+//! The enqueue sender lives on [`crate::BaseTransactionPool`]; the node-started
+//! hook installs it together with the workers.
 
 use std::{
     sync::Arc,
@@ -11,7 +12,6 @@ use std::{
 };
 
 use alloy_consensus::transaction::Recovered;
-use alloy_primitives::TxHash;
 use base_bundles::MeterBundleResponse;
 use base_common_consensus::BaseTxEnvelope;
 use futures::future::{self, Either};
@@ -38,7 +38,7 @@ base_metrics::define_metrics! {
     sim_workers_alive: gauge,
     #[describe("Wall time in seconds for one sim worker job (meter_bundle plus pool insert)")]
     sim_seconds: histogram,
-    #[describe("Queue-full rejections mapped to TxPoolOverflow")]
+    #[describe("Queue-full events that skipped sim and inserted without metering")]
     sim_queue_full: counter,
     #[describe("meter_bundle failures that inserted MeterBundleResponse::default")]
     #[label(name = "reason", default = ["timeout", "meter", "join"])]
@@ -85,31 +85,43 @@ impl InlineSimJob {
 pub enum InlineSimEnqueueError {
     /// `--enable-inline-simulation` is off, or workers have not installed a queue.
     Disabled(InlineSimJob),
-    /// Bounded pre-sim queue is full. RPC maps this to `TxPoolOverflow`.
-    Full(TxHash),
+    /// Bounded pre-sim queue is full. RPC inserts without metering.
+    Full(InlineSimJob),
 }
 
-static QUEUE: RwLock<Option<mpsc::Sender<InlineSimJob>>> = RwLock::new(None);
+/// Pool that can enqueue cheap-validated txs for in-process `meter_bundle` workers.
+pub trait InlineSimPool {
+    /// Returns true when workers have installed an enqueue sender.
+    fn is_inline_sim_enabled(&self) -> bool;
 
-/// Handle for the mempool pre-sim queue and worker pool.
-#[derive(Debug)]
-pub struct InlineSimQueue;
+    /// Pushes a validated transaction for a sim worker.
+    fn try_enqueue_inline_sim(&self, job: InlineSimJob) -> Result<(), InlineSimEnqueueError>;
+}
+
+/// Per-pool enqueue handle for mempool `meter_bundle` workers.
+///
+/// Clone shares the sender slot, so the node-started hook can install after
+/// RPC already holds a pool clone.
+#[derive(Clone, Debug, Default)]
+pub struct InlineSimQueue {
+    sender: Arc<RwLock<Option<mpsc::Sender<InlineSimJob>>>>,
+}
 
 impl InlineSimQueue {
     /// Installs the enqueue sender used by `eth_sendRawTransaction`.
-    pub fn install(sender: mpsc::Sender<InlineSimJob>) {
+    pub fn install(&self, sender: mpsc::Sender<InlineSimJob>) {
         InlineSimMetrics::sim_queue_size().set(0.0);
-        *QUEUE.write() = Some(sender);
+        *self.sender.write() = Some(sender);
     }
 
     /// Returns true when RPC should validate-then-enqueue instead of `add_transaction`.
-    pub fn is_enabled() -> bool {
-        QUEUE.read().is_some()
+    pub fn is_enabled(&self) -> bool {
+        self.sender.read().is_some()
     }
 
     /// Pushes a validated transaction for a sim worker.
-    pub fn try_enqueue(job: InlineSimJob) -> Result<(), InlineSimEnqueueError> {
-        let Some(sender) = QUEUE.read().clone() else {
+    pub fn try_enqueue(&self, job: InlineSimJob) -> Result<(), InlineSimEnqueueError> {
+        let Some(sender) = self.sender.read().clone() else {
             return Err(InlineSimEnqueueError::Disabled(job));
         };
         match sender.try_send(job) {
@@ -119,17 +131,17 @@ impl InlineSimQueue {
             }
             Err(TrySendError::Full(job)) => {
                 InlineSimMetrics::sim_queue_full().increment(1);
-                Err(InlineSimEnqueueError::Full(*job.transaction.hash()))
+                Err(InlineSimEnqueueError::Full(job))
             }
             Err(TrySendError::Closed(job)) => {
-                Self::uninstall();
+                self.uninstall();
                 Err(InlineSimEnqueueError::Disabled(job))
             }
         }
     }
 
-    fn uninstall() {
-        *QUEUE.write() = None;
+    fn uninstall(&self) {
+        *self.sender.write() = None;
     }
 
     /// Spawns `workers` tasks that meter and insert queued transactions.
@@ -176,15 +188,6 @@ impl InlineSimQueue {
                 }
             });
         }
-    }
-
-    /// Drops the enqueue sender so workers exit after draining.
-    #[cfg(test)]
-    pub fn clear() {
-        Self::uninstall();
-        InlineSimMetrics::sim_queue_size().set(0.0);
-        InlineSimMetrics::sim_workers_busy().set(0.0);
-        InlineSimMetrics::sim_workers_alive().set(0.0);
     }
 
     /// Attaches [`MeterBundleResponse::default`] after a failed or timed-out
@@ -273,13 +276,10 @@ mod tests {
     use alloy_signer_local::PrivateKeySigner;
     use base_bundles::{MeterBundleResponse, TransactionResult};
     use base_common_consensus::BaseTxEnvelope;
-    use parking_lot::Mutex;
     use reth_transaction_pool::TransactionOrigin;
     use tokio::sync::mpsc;
 
     use super::*;
-
-    static TEST_GUARD: Mutex<()> = Mutex::new(());
 
     fn sim_job() -> InlineSimJob {
         InlineSimJob::new(TransactionOrigin::Local, pooled_tx()).0
@@ -326,46 +326,59 @@ mod tests {
 
     #[test]
     fn try_enqueue_reports_disabled_without_install() {
-        let _guard = TEST_GUARD.lock();
-        InlineSimQueue::clear();
+        let queue = InlineSimQueue::default();
 
-        let err = InlineSimQueue::try_enqueue(sim_job());
+        let err = queue.try_enqueue(sim_job());
         assert!(matches!(err, Err(InlineSimEnqueueError::Disabled(_))));
     }
 
     #[test]
     fn try_enqueue_rejects_when_queue_is_full() {
-        let _guard = TEST_GUARD.lock();
-        InlineSimQueue::clear();
+        let queue = InlineSimQueue::default();
         let (tx, _rx) = mpsc::channel(1);
-        InlineSimQueue::install(tx);
+        queue.install(tx);
 
-        let first = InlineSimQueue::try_enqueue(sim_job());
+        let first = queue.try_enqueue(sim_job());
         assert!(first.is_ok(), "first enqueue must succeed");
 
-        let second = InlineSimQueue::try_enqueue(sim_job());
+        let second = queue.try_enqueue(sim_job());
         assert!(
             matches!(second, Err(InlineSimEnqueueError::Full(_))),
-            "full queue must return TxPoolOverflow, not skip-sim insert"
+            "full queue returns the job so RPC can insert without metering"
         );
-        InlineSimQueue::clear();
     }
 
     #[test]
     fn try_enqueue_disables_when_workers_drop_the_queue() {
-        let _guard = TEST_GUARD.lock();
-        InlineSimQueue::clear();
+        let queue = InlineSimQueue::default();
         let (tx, rx) = mpsc::channel(1);
-        InlineSimQueue::install(tx);
+        queue.install(tx);
         drop(rx);
 
-        let err = InlineSimQueue::try_enqueue(sim_job());
+        let err = queue.try_enqueue(sim_job());
         assert!(matches!(err, Err(InlineSimEnqueueError::Disabled(_))));
-        assert!(
-            !InlineSimQueue::is_enabled(),
-            "a closed worker channel must uninstall the queue"
-        );
-        InlineSimQueue::clear();
+        assert!(!queue.is_enabled(), "a closed worker channel must uninstall the queue");
+    }
+
+    #[test]
+    fn queues_do_not_share_the_sender_slot() {
+        let a = InlineSimQueue::default();
+        let b = InlineSimQueue::default();
+        let (tx, _rx) = mpsc::channel(1);
+        a.install(tx);
+
+        assert!(a.is_enabled(), "installed queue must be enabled");
+        assert!(!b.is_enabled(), "a sibling queue must not see another pool's sender");
+    }
+
+    #[test]
+    fn cloned_queue_shares_the_sender_slot() {
+        let a = InlineSimQueue::default();
+        let b = a.clone();
+        let (tx, _rx) = mpsc::channel(1);
+        a.install(tx);
+
+        assert!(b.is_enabled(), "pool clones must see install on the shared slot");
     }
 
     #[tokio::test]

--- a/crates/execution/txpool/src/inline_sim.rs
+++ b/crates/execution/txpool/src/inline_sim.rs
@@ -1,9 +1,9 @@
 //! Pre-sim queue shared by `eth_sendRawTransaction` and mempool meter_bundle workers.
 //!
-//! RPC validates cheaply, then [`InlineSimQueue::try_enqueue`]. Workers pop, run
-//! `meter_bundle`, and insert with [`crate::BasePooledTransaction::with_metering`].
+//! RPC validates cheaply, then [`InlineSimQueue::try_enqueue`], then waits for the
+//! worker to `meter_bundle` and `add_transaction`. Queue-full returns
+//! [`reth_transaction_pool::error::PoolErrorKind::DiscardedOnInsert`] (`TxPoolOverflow`).
 //! The queue is installed in the node-started hook together with the workers.
-//! Queue-full inserts [`MeterBundleResponse::default`] instead of rejecting.
 
 use std::{
     sync::Arc,
@@ -11,13 +11,19 @@ use std::{
 };
 
 use alloy_consensus::transaction::Recovered;
+use alloy_primitives::TxHash;
 use base_bundles::MeterBundleResponse;
 use base_common_consensus::BaseTxEnvelope;
 use futures::future::{self, Either};
 use parking_lot::RwLock;
-use reth_transaction_pool::{PoolTransaction, TransactionOrigin, TransactionPool};
-use tokio::sync::mpsc::{self, error::TrySendError};
-use tracing::{debug, warn};
+use reth_transaction_pool::{
+    AddedTransactionOutcome, PoolTransaction, TransactionOrigin, TransactionPool, error::PoolError,
+};
+use tokio::sync::{
+    mpsc::{self, error::TrySendError},
+    oneshot,
+};
+use tracing::warn;
 
 use crate::BasePooledTransaction;
 
@@ -32,26 +38,46 @@ base_metrics::define_metrics! {
     sim_workers_alive: gauge,
     #[describe("Wall time in seconds for one sim worker job (meter_bundle plus pool insert)")]
     sim_seconds: histogram,
-    #[describe("Queue-full events that inserted MeterBundleResponse::default instead of simulating")]
+    #[describe("Queue-full rejections mapped to TxPoolOverflow")]
     sim_queue_full: counter,
     #[describe("meter_bundle failures that inserted MeterBundleResponse::default")]
-    #[label(name = "reason", default = ["timeout", "meter", "join", "queue_full"])]
+    #[label(name = "reason", default = ["timeout", "meter", "join"])]
     sim_failures: counter,
     #[describe("Pool inserts that carried MeterBundleResponse::default after a failed or timed-out sim")]
     sim_default_inserts: counter,
     #[describe("Seconds waiting for meter_bundle to finish after the configured timeout fired")]
     sim_timeout_wait_seconds: histogram,
-    #[describe("Enqueued jobs whose pool insert failed after RPC already returned the hash")]
+    #[describe("Enqueued jobs whose pool insert failed (RPC receives the same error)")]
     sim_insert_failures: counter,
 }
 
 /// Job waiting for an in-process meter_bundle worker.
-#[derive(Debug)]
 pub struct InlineSimJob {
     /// Origin used when the worker later calls `add_transaction`.
     pub origin: TransactionOrigin,
     /// Transaction that already passed cheap pool validation.
     pub transaction: BasePooledTransaction,
+    inserted: oneshot::Sender<Result<AddedTransactionOutcome, PoolError>>,
+}
+
+impl std::fmt::Debug for InlineSimJob {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InlineSimJob")
+            .field("origin", &self.origin)
+            .field("hash", self.transaction.hash())
+            .finish_non_exhaustive()
+    }
+}
+
+impl InlineSimJob {
+    /// Builds a job and the receiver RPC waits on until pool insert finishes.
+    pub fn new(
+        origin: TransactionOrigin,
+        transaction: BasePooledTransaction,
+    ) -> (Self, oneshot::Receiver<Result<AddedTransactionOutcome, PoolError>>) {
+        let (inserted, rx) = oneshot::channel();
+        (Self { origin, transaction, inserted }, rx)
+    }
 }
 
 /// Why [`InlineSimQueue::try_enqueue`] rejected a job.
@@ -59,8 +85,8 @@ pub struct InlineSimJob {
 pub enum InlineSimEnqueueError {
     /// `--enable-inline-simulation` is off, or workers have not installed a queue.
     Disabled(InlineSimJob),
-    /// Bounded pre-sim queue is full. Caller inserts with default metering.
-    Full(InlineSimJob),
+    /// Bounded pre-sim queue is full. RPC maps this to `TxPoolOverflow`.
+    Full(TxHash),
 }
 
 static QUEUE: RwLock<Option<mpsc::Sender<InlineSimJob>>> = RwLock::new(None);
@@ -93,7 +119,7 @@ impl InlineSimQueue {
             }
             Err(TrySendError::Full(job)) => {
                 InlineSimMetrics::sim_queue_full().increment(1);
-                Err(InlineSimEnqueueError::Full(job))
+                Err(InlineSimEnqueueError::Full(*job.transaction.hash()))
             }
             Err(TrySendError::Closed(job)) => {
                 Self::uninstall();
@@ -143,11 +169,9 @@ impl InlineSimQueue {
 
                     let started = Instant::now();
                     let job = meter_job(job, Arc::clone(&meter), timeout).await;
-                    if let Err(error) = pool.add_transaction(job.origin, job.transaction).await
-                    {
-                        InlineSimMetrics::sim_insert_failures().increment(1);
-                        debug!(error = %error, "inline sim pool insert failed");
-                    }
+                    let InlineSimJob { origin, transaction, inserted } = job;
+                    let result = pool.add_transaction(origin, transaction).await;
+                    notify_insert(inserted, result);
                     InlineSimMetrics::sim_seconds().record(started.elapsed().as_secs_f64());
                 }
             });
@@ -163,14 +187,15 @@ impl InlineSimQueue {
         InlineSimMetrics::sim_workers_alive().set(0.0);
     }
 
-    /// Attaches [`MeterBundleResponse::default`] after a failed, timed-out, or
-    /// queue-full sim so the Consumer can still forward.
+    /// Attaches [`MeterBundleResponse::default`] after a failed or timed-out
+    /// sim so the Consumer can still forward.
     pub fn with_default_metering(job: InlineSimJob, reason: &'static str) -> InlineSimJob {
         InlineSimMetrics::sim_failures(reason).increment(1);
         InlineSimMetrics::sim_default_inserts().increment(1);
         InlineSimJob {
             origin: job.origin,
             transaction: job.transaction.with_metering(MeterBundleResponse::default()),
+            inserted: job.inserted,
         }
     }
 }
@@ -182,6 +207,19 @@ impl Drop for WorkerAlive {
     fn drop(&mut self) {
         InlineSimMetrics::sim_workers_alive().decrement(1.0);
     }
+}
+
+/// Sends the insert result to RPC. Insert already ran; a dropped receiver
+/// (client gone) does not undo it.
+fn notify_insert(
+    inserted: oneshot::Sender<Result<AddedTransactionOutcome, PoolError>>,
+    result: Result<AddedTransactionOutcome, PoolError>,
+) {
+    if let Err(ref error) = result {
+        InlineSimMetrics::sim_insert_failures().increment(1);
+        warn!(error = %error, hash = %error.hash, "inline sim pool insert failed");
+    }
+    let _ = inserted.send(result);
 }
 
 async fn meter_job<F>(job: InlineSimJob, meter: Arc<F>, timeout: Duration) -> InlineSimJob
@@ -199,6 +237,7 @@ where
         Either::Left((Ok(Ok(metering)), _)) => InlineSimJob {
             origin: job.origin,
             transaction: job.transaction.with_metering(metering),
+            inserted: job.inserted,
         },
         Either::Left((Ok(Err(error)), _)) => {
             warn!(error = %error, hash = %job.transaction.hash(), "inline sim meter_bundle failed");
@@ -241,6 +280,10 @@ mod tests {
     use super::*;
 
     static TEST_GUARD: Mutex<()> = Mutex::new(());
+
+    fn sim_job() -> InlineSimJob {
+        InlineSimJob::new(TransactionOrigin::Local, pooled_tx()).0
+    }
 
     fn pooled_tx() -> BasePooledTransaction {
         let signer = PrivateKeySigner::random();
@@ -286,10 +329,7 @@ mod tests {
         let _guard = TEST_GUARD.lock();
         InlineSimQueue::clear();
 
-        let err = InlineSimQueue::try_enqueue(InlineSimJob {
-            origin: TransactionOrigin::Local,
-            transaction: pooled_tx(),
-        });
+        let err = InlineSimQueue::try_enqueue(sim_job());
         assert!(matches!(err, Err(InlineSimEnqueueError::Disabled(_))));
     }
 
@@ -300,24 +340,13 @@ mod tests {
         let (tx, _rx) = mpsc::channel(1);
         InlineSimQueue::install(tx);
 
-        let first = InlineSimQueue::try_enqueue(InlineSimJob {
-            origin: TransactionOrigin::Local,
-            transaction: pooled_tx(),
-        });
+        let first = InlineSimQueue::try_enqueue(sim_job());
         assert!(first.is_ok(), "first enqueue must succeed");
 
-        let second = InlineSimQueue::try_enqueue(InlineSimJob {
-            origin: TransactionOrigin::Local,
-            transaction: pooled_tx(),
-        });
-        let InlineSimEnqueueError::Full(job) = second.expect_err("queue is full") else {
-            panic!("full queue must return the job so RPC can insert default metering");
-        };
-        let job = InlineSimQueue::with_default_metering(job, "queue_full");
-        assert_eq!(
-            job.transaction.metering(),
-            Some(&MeterBundleResponse::default()),
-            "queue-full fallback attaches default metering"
+        let second = InlineSimQueue::try_enqueue(sim_job());
+        assert!(
+            matches!(second, Err(InlineSimEnqueueError::Full(_))),
+            "full queue must return TxPoolOverflow, not skip-sim insert"
         );
         InlineSimQueue::clear();
     }
@@ -330,10 +359,7 @@ mod tests {
         InlineSimQueue::install(tx);
         drop(rx);
 
-        let err = InlineSimQueue::try_enqueue(InlineSimJob {
-            origin: TransactionOrigin::Local,
-            transaction: pooled_tx(),
-        });
+        let err = InlineSimQueue::try_enqueue(sim_job());
         assert!(matches!(err, Err(InlineSimEnqueueError::Disabled(_))));
         assert!(
             !InlineSimQueue::is_enabled(),
@@ -344,7 +370,7 @@ mod tests {
 
     #[tokio::test]
     async fn meter_job_attaches_metering_on_success() {
-        let job = InlineSimJob { origin: TransactionOrigin::Local, transaction: pooled_tx() };
+        let job = sim_job();
         let expected = metering();
         let expected_clone = expected.clone();
 
@@ -360,7 +386,7 @@ mod tests {
 
     #[tokio::test]
     async fn meter_job_uses_default_metering_on_meter_error() {
-        let job = InlineSimJob { origin: TransactionOrigin::Local, transaction: pooled_tx() };
+        let job = sim_job();
 
         let out =
             meter_job(job, Arc::new(|_| Err("boom".to_string())), Duration::from_secs(1)).await;
@@ -374,7 +400,7 @@ mod tests {
 
     #[tokio::test]
     async fn meter_job_uses_default_metering_on_timeout() {
-        let job = InlineSimJob { origin: TransactionOrigin::Local, transaction: pooled_tx() };
+        let job = sim_job();
 
         let out = meter_job(
             job,
@@ -395,7 +421,7 @@ mod tests {
 
     #[tokio::test]
     async fn meter_job_uses_default_metering_when_blocking_task_panics() {
-        let job = InlineSimJob { origin: TransactionOrigin::Local, transaction: pooled_tx() };
+        let job = sim_job();
 
         let out = meter_job(job, Arc::new(|_| panic!("meter panic")), Duration::from_secs(1)).await;
 
@@ -404,5 +430,30 @@ mod tests {
             Some(&MeterBundleResponse::default()),
             "a panicked spawn_blocking task must still insert with default metering"
         );
+    }
+
+    #[test]
+    fn notify_insert_delivers_pool_error_to_rpc() {
+        let (job, rx) = InlineSimJob::new(TransactionOrigin::Local, pooled_tx());
+        let hash = *job.transaction.hash();
+        let err = PoolError::new(hash, reth_transaction_pool::error::PoolErrorKind::AlreadyImported);
+
+        notify_insert(job.inserted, Err(err));
+
+        let got = rx.blocking_recv().expect("RPC waits for insert");
+        assert!(got.is_err(), "insert failure must surface on the oneshot");
+        assert_eq!(got.unwrap_err().hash, hash);
+    }
+
+    #[test]
+    fn notify_insert_still_ok_if_rpc_dropped() {
+        let (job, rx) = InlineSimJob::new(TransactionOrigin::Local, pooled_tx());
+        drop(rx);
+        let err = PoolError::new(
+            *job.transaction.hash(),
+            reth_transaction_pool::error::PoolErrorKind::AlreadyImported,
+        );
+
+        notify_insert(job.inserted, Err(err));
     }
 }

--- a/crates/execution/txpool/src/inline_sim.rs
+++ b/crates/execution/txpool/src/inline_sim.rs
@@ -2,13 +2,11 @@
 //!
 //! RPC validates cheaply, then [`InlineSimQueue::try_enqueue`]. Workers pop, run
 //! `meter_bundle`, and insert with [`crate::BasePooledTransaction::with_metering`].
-//! The queue is installed at node start when `--enable-inline-simulation` is set.
+//! The queue is installed in the node-started hook together with the workers.
+//! Queue-full inserts [`MeterBundleResponse::default`] instead of rejecting.
 
 use std::{
-    sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
-    },
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -30,12 +28,14 @@ base_metrics::define_metrics! {
     sim_queue_size: gauge,
     #[describe("Sim workers currently running meter_bundle")]
     sim_workers_busy: gauge,
+    #[describe("Sim worker tasks still in their recv loop")]
+    sim_workers_alive: gauge,
     #[describe("Wall time in seconds for one sim worker job (meter_bundle plus pool insert)")]
     sim_seconds: histogram,
-    #[describe("Transactions dropped because the pre-sim queue was full")]
+    #[describe("Queue-full events that inserted MeterBundleResponse::default instead of simulating")]
     sim_queue_full: counter,
     #[describe("meter_bundle failures that inserted MeterBundleResponse::default")]
-    #[label(name = "reason", default = ["timeout", "meter", "join"])]
+    #[label(name = "reason", default = ["timeout", "meter", "join", "queue_full"])]
     sim_failures: counter,
     #[describe("Pool inserts that carried MeterBundleResponse::default after a failed or timed-out sim")]
     sim_default_inserts: counter,
@@ -53,16 +53,15 @@ pub struct InlineSimJob {
 }
 
 /// Why [`InlineSimQueue::try_enqueue`] rejected a job.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum InlineSimEnqueueError {
     /// `--enable-inline-simulation` is off, or workers have not installed a queue.
-    Disabled,
-    /// Bounded pre-sim queue is full.
-    Full,
+    Disabled(InlineSimJob),
+    /// Bounded pre-sim queue is full. Caller inserts with default metering.
+    Full(InlineSimJob),
 }
 
 static QUEUE: RwLock<Option<mpsc::Sender<InlineSimJob>>> = RwLock::new(None);
-static QUEUE_LEN: AtomicUsize = AtomicUsize::new(0);
 
 /// Handle for the mempool pre-sim queue and worker pool.
 #[derive(Debug)]
@@ -71,7 +70,6 @@ pub struct InlineSimQueue;
 impl InlineSimQueue {
     /// Installs the enqueue sender used by `eth_sendRawTransaction`.
     pub fn install(sender: mpsc::Sender<InlineSimJob>) {
-        QUEUE_LEN.store(0, Ordering::Relaxed);
         InlineSimMetrics::sim_queue_size().set(0.0);
         *QUEUE.write() = Some(sender);
     }
@@ -84,21 +82,20 @@ impl InlineSimQueue {
     /// Pushes a validated transaction for a sim worker.
     pub fn try_enqueue(job: InlineSimJob) -> Result<(), InlineSimEnqueueError> {
         let Some(sender) = QUEUE.read().clone() else {
-            return Err(InlineSimEnqueueError::Disabled);
+            return Err(InlineSimEnqueueError::Disabled(job));
         };
         match sender.try_send(job) {
             Ok(()) => {
-                let len = QUEUE_LEN.fetch_add(1, Ordering::Relaxed) + 1;
-                InlineSimMetrics::sim_queue_size().set(len as f64);
+                InlineSimMetrics::sim_queue_size().increment(1.0);
                 Ok(())
             }
-            Err(TrySendError::Full(_)) => {
+            Err(TrySendError::Full(job)) => {
                 InlineSimMetrics::sim_queue_full().increment(1);
-                Err(InlineSimEnqueueError::Full)
+                Err(InlineSimEnqueueError::Full(job))
             }
-            Err(TrySendError::Closed(_)) => {
+            Err(TrySendError::Closed(job)) => {
                 Self::uninstall();
-                Err(InlineSimEnqueueError::Disabled)
+                Err(InlineSimEnqueueError::Disabled(job))
             }
         }
     }
@@ -133,13 +130,14 @@ impl InlineSimQueue {
             let rx = Arc::clone(&rx);
             let pool = pool.clone();
             tokio::spawn(async move {
+                InlineSimMetrics::sim_workers_alive().increment(1.0);
+                let _alive = WorkerAlive;
                 loop {
                     let job = rx.lock().await.recv().await;
                     let Some(job) = job else {
                         break;
                     };
-                    let len = QUEUE_LEN.fetch_sub(1, Ordering::Relaxed).saturating_sub(1);
-                    InlineSimMetrics::sim_queue_size().set(len as f64);
+                    InlineSimMetrics::sim_queue_size().decrement(1.0);
 
                     let started = Instant::now();
                     let job = meter_job(job, Arc::clone(&meter), timeout).await;
@@ -157,9 +155,29 @@ impl InlineSimQueue {
     #[cfg(test)]
     pub fn clear() {
         Self::uninstall();
-        QUEUE_LEN.store(0, Ordering::Relaxed);
         InlineSimMetrics::sim_queue_size().set(0.0);
         InlineSimMetrics::sim_workers_busy().set(0.0);
+        InlineSimMetrics::sim_workers_alive().set(0.0);
+    }
+
+    /// Attaches [`MeterBundleResponse::default`] after a failed, timed-out, or
+    /// queue-full sim so the Consumer can still forward.
+    pub fn with_default_metering(job: InlineSimJob, reason: &'static str) -> InlineSimJob {
+        InlineSimMetrics::sim_failures(reason).increment(1);
+        InlineSimMetrics::sim_default_inserts().increment(1);
+        InlineSimJob {
+            origin: job.origin,
+            transaction: job.transaction.with_metering(MeterBundleResponse::default()),
+        }
+    }
+}
+
+/// Decrements [`InlineSimMetrics::sim_workers_alive`] if a worker panics or exits.
+struct WorkerAlive;
+
+impl Drop for WorkerAlive {
+    fn drop(&mut self) {
+        InlineSimMetrics::sim_workers_alive().decrement(1.0);
     }
 }
 
@@ -171,8 +189,8 @@ where
     InlineSimMetrics::sim_workers_busy().increment(1.0);
 
     // `--inline-simulation-timeout-ms` only chooses real vs Default metering.
-    // spawn_blocking cannot be cancelled, so the worker stays busy until EVM
-    // finishes; that is what bounds the blocking pool.
+    // spawn_blocking cannot be cancelled. The worker joins so blocking tasks
+    // stay bounded by worker count and do not pile up.
     let handle = tokio::task::spawn_blocking(move || meter(recovered));
     let job = match future::select(handle, Box::pin(tokio::time::sleep(timeout))).await {
         Either::Left((Ok(Ok(metering)), _)) => InlineSimJob {
@@ -181,34 +199,23 @@ where
         },
         Either::Left((Ok(Err(error)), _)) => {
             warn!(error = %error, hash = %job.transaction.hash(), "inline sim meter_bundle failed");
-            with_default_metering(job, "meter")
+            InlineSimQueue::with_default_metering(job, "meter")
         }
         Either::Left((Err(_), _)) => {
             warn!(hash = %job.transaction.hash(), "inline sim worker task failed");
-            with_default_metering(job, "join")
+            InlineSimQueue::with_default_metering(job, "join")
         }
         Either::Right((_, handle)) => {
             warn!(hash = %job.transaction.hash(), "inline sim meter_bundle timed out");
             let waited = Instant::now();
             let _ = handle.await;
             InlineSimMetrics::sim_timeout_wait_seconds().record(waited.elapsed().as_secs_f64());
-            with_default_metering(job, "timeout")
+            InlineSimQueue::with_default_metering(job, "timeout")
         }
     };
 
     InlineSimMetrics::sim_workers_busy().decrement(1.0);
     job
-}
-
-/// Sim failed or timed out: still insert so the Consumer can forward.
-/// Builder skips cache write when metering is `Default`.
-fn with_default_metering(job: InlineSimJob, reason: &'static str) -> InlineSimJob {
-    InlineSimMetrics::sim_failures(reason).increment(1);
-    InlineSimMetrics::sim_default_inserts().increment(1);
-    InlineSimJob {
-        origin: job.origin,
-        transaction: job.transaction.with_metering(MeterBundleResponse::default()),
-    }
 }
 
 #[cfg(test)]
@@ -280,7 +287,7 @@ mod tests {
             origin: TransactionOrigin::Local,
             transaction: pooled_tx(),
         });
-        assert_eq!(err, Err(InlineSimEnqueueError::Disabled));
+        assert!(matches!(err, Err(InlineSimEnqueueError::Disabled(_))));
     }
 
     #[test]
@@ -294,13 +301,21 @@ mod tests {
             origin: TransactionOrigin::Local,
             transaction: pooled_tx(),
         });
-        assert_eq!(first, Ok(()));
+        assert!(first.is_ok(), "first enqueue must succeed");
 
         let second = InlineSimQueue::try_enqueue(InlineSimJob {
             origin: TransactionOrigin::Local,
             transaction: pooled_tx(),
         });
-        assert_eq!(second, Err(InlineSimEnqueueError::Full));
+        let InlineSimEnqueueError::Full(job) = second.expect_err("queue is full") else {
+            panic!("full queue must return the job so RPC can insert default metering");
+        };
+        let job = InlineSimQueue::with_default_metering(job, "queue_full");
+        assert_eq!(
+            job.transaction.metering(),
+            Some(&MeterBundleResponse::default()),
+            "queue-full fallback attaches default metering"
+        );
         InlineSimQueue::clear();
     }
 
@@ -316,7 +331,7 @@ mod tests {
             origin: TransactionOrigin::Local,
             transaction: pooled_tx(),
         });
-        assert_eq!(err, Err(InlineSimEnqueueError::Disabled));
+        assert!(matches!(err, Err(InlineSimEnqueueError::Disabled(_))));
         assert!(
             !InlineSimQueue::is_enabled(),
             "a closed worker channel must uninstall the queue"

--- a/crates/execution/txpool/src/inline_sim.rs
+++ b/crates/execution/txpool/src/inline_sim.rs
@@ -1,0 +1,326 @@
+//! Pre-sim queue shared by `eth_sendRawTransaction` and mempool meter_bundle workers.
+//!
+//! RPC validates cheaply, then [`InlineSimQueue::try_enqueue`]. Workers pop, run
+//! `meter_bundle`, and insert with [`crate::BasePooledTransaction::with_metering`].
+//! The queue is installed at node start when `--enable-inline-simulation` is set.
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use alloy_consensus::transaction::Recovered;
+use base_bundles::MeterBundleResponse;
+use base_common_consensus::BaseTxEnvelope;
+use parking_lot::RwLock;
+use reth_transaction_pool::{PoolTransaction, TransactionOrigin, TransactionPool};
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+
+use crate::BasePooledTransaction;
+
+base_metrics::define_metrics! {
+    inline_simulation,
+    struct = InlineSimMetrics,
+    #[describe("Transactions waiting in the pre-sim queue")]
+    sim_queue_size: gauge,
+    #[describe("Sim workers currently running meter_bundle")]
+    sim_workers_busy: gauge,
+    #[describe("Wall time in seconds for one sim worker job (meter_bundle plus pool insert)")]
+    sim_seconds: histogram,
+    #[describe("Transactions dropped because the pre-sim queue was full")]
+    sim_queue_full: counter,
+    #[describe("meter_bundle failures that skipped pool insert")]
+    #[label(name = "reason", default = ["timeout", "meter", "join"])]
+    sim_failures: counter,
+}
+
+/// Job waiting for an in-process meter_bundle worker.
+#[derive(Debug)]
+pub struct InlineSimJob {
+    /// Origin used when the worker later calls `add_transaction`.
+    pub origin: TransactionOrigin,
+    /// Transaction that already passed cheap pool validation.
+    pub transaction: BasePooledTransaction,
+}
+
+/// Why [`InlineSimQueue::try_enqueue`] rejected a job.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InlineSimEnqueueError {
+    /// `--enable-inline-simulation` is off, or workers have not installed a queue.
+    Disabled,
+    /// Bounded pre-sim queue is full.
+    Full,
+}
+
+static QUEUE: RwLock<Option<mpsc::Sender<InlineSimJob>>> = RwLock::new(None);
+static QUEUE_LEN: AtomicUsize = AtomicUsize::new(0);
+static WORKERS_BUSY: AtomicUsize = AtomicUsize::new(0);
+
+/// Handle for the mempool pre-sim queue and worker pool.
+#[derive(Debug)]
+pub struct InlineSimQueue;
+
+impl InlineSimQueue {
+    /// Installs the enqueue sender used by `eth_sendRawTransaction`.
+    pub fn install(sender: mpsc::Sender<InlineSimJob>) {
+        QUEUE_LEN.store(0, Ordering::Relaxed);
+        InlineSimMetrics::sim_queue_size().set(0.0);
+        *QUEUE.write() = Some(sender);
+    }
+
+    /// Returns true when RPC should validate-then-enqueue instead of `add_transaction`.
+    pub fn is_enabled() -> bool {
+        QUEUE.read().is_some()
+    }
+
+    /// Pushes a validated transaction for a sim worker.
+    pub fn try_enqueue(job: InlineSimJob) -> Result<(), InlineSimEnqueueError> {
+        let Some(sender) = QUEUE.read().clone() else {
+            return Err(InlineSimEnqueueError::Disabled);
+        };
+        sender.try_send(job).map_err(|_| {
+            InlineSimMetrics::sim_queue_full().increment(1);
+            InlineSimEnqueueError::Full
+        })?;
+        let len = QUEUE_LEN.fetch_add(1, Ordering::Relaxed) + 1;
+        InlineSimMetrics::sim_queue_size().set(len as f64);
+        Ok(())
+    }
+
+    /// Spawns `workers` tasks that meter and insert queued transactions.
+    ///
+    /// ponytail: one mutex on recv; split into per-worker channels if lock contends
+    pub fn spawn_workers<P, F>(
+        pool: P,
+        meter: F,
+        rx: mpsc::Receiver<InlineSimJob>,
+        workers: usize,
+        timeout: Duration,
+    ) where
+        P: TransactionPool<Transaction = BasePooledTransaction> + Clone + Send + 'static,
+        F: Fn(Recovered<BaseTxEnvelope>) -> Result<MeterBundleResponse, String>
+            + Send
+            + Sync
+            + 'static,
+    {
+        let meter = Arc::new(meter);
+        let rx = Arc::new(tokio::sync::Mutex::new(rx));
+        for _ in 0..workers {
+            let meter = Arc::clone(&meter);
+            let rx = Arc::clone(&rx);
+            let pool = pool.clone();
+            tokio::spawn(async move {
+                loop {
+                    let job = rx.lock().await.recv().await;
+                    let Some(job) = job else {
+                        break;
+                    };
+                    let len = QUEUE_LEN.fetch_sub(1, Ordering::Relaxed).saturating_sub(1);
+                    InlineSimMetrics::sim_queue_size().set(len as f64);
+
+                    let started = Instant::now();
+                    if let Some(job) = meter_job(job, Arc::clone(&meter), timeout).await
+                        && let Err(error) =
+                            pool.add_transaction(job.origin, job.transaction).await
+                    {
+                        debug!(error = %error, "inline sim pool insert failed");
+                    }
+                    InlineSimMetrics::sim_seconds().record(started.elapsed().as_secs_f64());
+                }
+            });
+        }
+    }
+
+    /// Drops the enqueue sender so workers exit after draining.
+    #[cfg(test)]
+    pub fn clear() {
+        *QUEUE.write() = None;
+        QUEUE_LEN.store(0, Ordering::Relaxed);
+        WORKERS_BUSY.store(0, Ordering::Relaxed);
+        InlineSimMetrics::sim_queue_size().set(0.0);
+        InlineSimMetrics::sim_workers_busy().set(0.0);
+    }
+}
+
+async fn meter_job<F>(job: InlineSimJob, meter: Arc<F>, timeout: Duration) -> Option<InlineSimJob>
+where
+    F: Fn(Recovered<BaseTxEnvelope>) -> Result<MeterBundleResponse, String> + Send + Sync + 'static,
+{
+    let recovered = job.transaction.clone_into_consensus();
+    let busy = WORKERS_BUSY.fetch_add(1, Ordering::Relaxed) + 1;
+    InlineSimMetrics::sim_workers_busy().set(busy as f64);
+
+    // ponytail: spawn_blocking cannot be cancelled; timeout only drops the wait
+    let result = tokio::time::timeout(
+        timeout,
+        tokio::task::spawn_blocking(move || meter(recovered)),
+    )
+    .await;
+
+    let busy = WORKERS_BUSY.fetch_sub(1, Ordering::Relaxed).saturating_sub(1);
+    InlineSimMetrics::sim_workers_busy().set(busy as f64);
+
+    match result {
+        Ok(Ok(Ok(metering))) => Some(InlineSimJob {
+            origin: job.origin,
+            transaction: job.transaction.with_metering(metering),
+        }),
+        Ok(Ok(Err(error))) => {
+            InlineSimMetrics::sim_failures("meter").increment(1);
+            warn!(error = %error, hash = %job.transaction.hash(), "inline sim meter_bundle failed");
+            None
+        }
+        Ok(Err(_)) => {
+            InlineSimMetrics::sim_failures("join").increment(1);
+            warn!(hash = %job.transaction.hash(), "inline sim worker task failed");
+            None
+        }
+        Err(_) => {
+            InlineSimMetrics::sim_failures("timeout").increment(1);
+            warn!(hash = %job.transaction.hash(), "inline sim meter_bundle timed out");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use std::sync::Arc;
+
+    use alloy_consensus::{SignableTransaction, TxEip1559, transaction::SignerRecoverable};
+    use alloy_eips::eip2718::Encodable2718;
+    use alloy_primitives::{Address, Bytes, TxKind, U256};
+    use alloy_signer::SignerSync;
+    use alloy_signer_local::PrivateKeySigner;
+    use base_bundles::{MeterBundleResponse, TransactionResult};
+    use base_common_consensus::BaseTxEnvelope;
+    use parking_lot::Mutex;
+    use reth_transaction_pool::TransactionOrigin;
+    use tokio::sync::mpsc;
+
+    use super::*;
+
+    static TEST_GUARD: Mutex<()> = Mutex::new(());
+
+    fn pooled_tx() -> BasePooledTransaction {
+        let signer = PrivateKeySigner::random();
+        let tx = TxEip1559 {
+            chain_id: 8453,
+            nonce: 0,
+            gas_limit: 21_000,
+            max_fee_per_gas: 1_000,
+            max_priority_fee_per_gas: 0,
+            to: TxKind::Call(Address::repeat_byte(0xEE)),
+            value: U256::ZERO,
+            access_list: Default::default(),
+            input: Bytes::new(),
+        };
+        let signature = signer.sign_hash_sync(&tx.signature_hash()).unwrap();
+        let envelope = BaseTxEnvelope::Eip1559(tx.into_signed(signature));
+        let recovered = envelope.clone().try_into_recovered().unwrap();
+        BasePooledTransaction::new(recovered, envelope.encode_2718_len())
+    }
+
+    fn metering() -> MeterBundleResponse {
+        MeterBundleResponse {
+            results: vec![TransactionResult {
+                coinbase_diff: U256::ZERO,
+                eth_sent_to_coinbase: U256::ZERO,
+                from_address: Address::ZERO,
+                gas_fees: U256::ZERO,
+                gas_price: U256::ZERO,
+                gas_used: 21_000,
+                to_address: None,
+                tx_hash: Default::default(),
+                value: U256::ZERO,
+                execution_time_us: 1,
+                opcode_gas: Vec::new(),
+            }],
+            total_gas_used: 21_000,
+            ..MeterBundleResponse::default()
+        }
+    }
+
+    #[test]
+    fn try_enqueue_reports_disabled_without_install() {
+        let _guard = TEST_GUARD.lock();
+        InlineSimQueue::clear();
+
+        let err = InlineSimQueue::try_enqueue(InlineSimJob {
+            origin: TransactionOrigin::Local,
+            transaction: pooled_tx(),
+        });
+        assert_eq!(err, Err(InlineSimEnqueueError::Disabled));
+    }
+
+    #[test]
+    fn try_enqueue_rejects_when_queue_is_full() {
+        let _guard = TEST_GUARD.lock();
+        InlineSimQueue::clear();
+        let (tx, _rx) = mpsc::channel(1);
+        InlineSimQueue::install(tx);
+
+        let first = InlineSimQueue::try_enqueue(InlineSimJob {
+            origin: TransactionOrigin::Local,
+            transaction: pooled_tx(),
+        });
+        assert_eq!(first, Ok(()));
+
+        let second = InlineSimQueue::try_enqueue(InlineSimJob {
+            origin: TransactionOrigin::Local,
+            transaction: pooled_tx(),
+        });
+        assert_eq!(second, Err(InlineSimEnqueueError::Full));
+        InlineSimQueue::clear();
+    }
+
+    #[tokio::test]
+    async fn meter_job_attaches_metering_on_success() {
+        let job = InlineSimJob { origin: TransactionOrigin::Local, transaction: pooled_tx() };
+        let expected = metering();
+        let expected_clone = expected.clone();
+
+        let out = meter_job(
+            job,
+            Arc::new(move |_| Ok(expected_clone.clone())),
+            Duration::from_secs(1),
+        )
+        .await
+        .expect("successful meter must insert");
+
+        assert_eq!(out.transaction.metering(), Some(&expected));
+    }
+
+    #[tokio::test]
+    async fn meter_job_skips_insert_on_meter_error() {
+        let job = InlineSimJob { origin: TransactionOrigin::Local, transaction: pooled_tx() };
+
+        let out =
+            meter_job(job, Arc::new(|_| Err("boom".to_string())), Duration::from_secs(1)).await;
+
+        assert!(out.is_none(), "failed meter_bundle must not produce an insert");
+    }
+
+    #[tokio::test]
+    async fn meter_job_skips_insert_on_timeout() {
+        let job = InlineSimJob { origin: TransactionOrigin::Local, transaction: pooled_tx() };
+
+        let out = meter_job(
+            job,
+            Arc::new(|_| {
+                std::thread::sleep(Duration::from_millis(200));
+                Ok(metering())
+            }),
+            Duration::from_millis(10),
+        )
+        .await;
+
+        assert!(out.is_none(), "timed-out meter_bundle must not produce an insert");
+    }
+}

--- a/crates/execution/txpool/src/inline_sim.rs
+++ b/crates/execution/txpool/src/inline_sim.rs
@@ -39,6 +39,8 @@ base_metrics::define_metrics! {
     sim_failures: counter,
     #[describe("Pool inserts that carried MeterBundleResponse::default after a failed or timed-out sim")]
     sim_default_inserts: counter,
+    #[describe("Seconds waiting for meter_bundle to finish after the configured timeout fired")]
+    sim_timeout_wait_seconds: histogram,
 }
 
 /// Job waiting for an in-process meter_bundle worker.
@@ -61,7 +63,6 @@ pub enum InlineSimEnqueueError {
 
 static QUEUE: RwLock<Option<mpsc::Sender<InlineSimJob>>> = RwLock::new(None);
 static QUEUE_LEN: AtomicUsize = AtomicUsize::new(0);
-static WORKERS_BUSY: AtomicUsize = AtomicUsize::new(0);
 
 /// Handle for the mempool pre-sim queue and worker pool.
 #[derive(Debug)]
@@ -122,6 +123,9 @@ impl InlineSimQueue {
             + Sync
             + 'static,
     {
+        if workers == 0 {
+            return;
+        }
         let meter = Arc::new(meter);
         let rx = Arc::new(tokio::sync::Mutex::new(rx));
         for _ in 0..workers {
@@ -154,7 +158,6 @@ impl InlineSimQueue {
     pub fn clear() {
         Self::uninstall();
         QUEUE_LEN.store(0, Ordering::Relaxed);
-        WORKERS_BUSY.store(0, Ordering::Relaxed);
         InlineSimMetrics::sim_queue_size().set(0.0);
         InlineSimMetrics::sim_workers_busy().set(0.0);
     }
@@ -165,11 +168,11 @@ where
     F: Fn(Recovered<BaseTxEnvelope>) -> Result<MeterBundleResponse, String> + Send + Sync + 'static,
 {
     let recovered = job.transaction.clone_into_consensus();
-    let busy = WORKERS_BUSY.fetch_add(1, Ordering::Relaxed) + 1;
-    InlineSimMetrics::sim_workers_busy().set(busy as f64);
+    InlineSimMetrics::sim_workers_busy().increment(1.0);
 
-    // Timeout must not drop the JoinHandle: spawn_blocking cannot be cancelled,
-    // so the worker joins before taking another job.
+    // `--inline-simulation-timeout-ms` only chooses real vs Default metering.
+    // spawn_blocking cannot be cancelled, so the worker stays busy until EVM
+    // finishes; that is what bounds the blocking pool.
     let handle = tokio::task::spawn_blocking(move || meter(recovered));
     let job = match future::select(handle, Box::pin(tokio::time::sleep(timeout))).await {
         Either::Left((Ok(Ok(metering)), _)) => InlineSimJob {
@@ -186,13 +189,14 @@ where
         }
         Either::Right((_, handle)) => {
             warn!(hash = %job.transaction.hash(), "inline sim meter_bundle timed out");
+            let waited = Instant::now();
             let _ = handle.await;
+            InlineSimMetrics::sim_timeout_wait_seconds().record(waited.elapsed().as_secs_f64());
             with_default_metering(job, "timeout")
         }
     };
 
-    let busy = WORKERS_BUSY.fetch_sub(1, Ordering::Relaxed).saturating_sub(1);
-    InlineSimMetrics::sim_workers_busy().set(busy as f64);
+    InlineSimMetrics::sim_workers_busy().decrement(1.0);
     job
 }
 

--- a/crates/execution/txpool/src/lib.rs
+++ b/crates/execution/txpool/src/lib.rs
@@ -43,6 +43,9 @@ pub use transaction::{
     TimestampedTransaction, unix_time_millis,
 };
 
+mod inline_sim;
+pub use inline_sim::{InlineSimEnqueueError, InlineSimJob, InlineSimQueue};
+
 mod ordering;
 pub use ordering::{BaseOrdering, BestTransactionPriority, TimestampOrdering};
 

--- a/crates/execution/txpool/src/lib.rs
+++ b/crates/execution/txpool/src/lib.rs
@@ -44,7 +44,7 @@ pub use transaction::{
 };
 
 mod inline_sim;
-pub use inline_sim::{InlineSimEnqueueError, InlineSimJob, InlineSimQueue};
+pub use inline_sim::{InlineSimEnqueueError, InlineSimJob, InlineSimPool, InlineSimQueue};
 
 mod ordering;
 pub use ordering::{BaseOrdering, BestTransactionPriority, TimestampOrdering};

--- a/crates/execution/txpool/src/pool.rs
+++ b/crates/execution/txpool/src/pool.rs
@@ -26,7 +26,8 @@ use tracing::debug;
 
 use crate::{
     Admission, BasePooledTx, BaseTransactionValidator, GuardLimits, GuardMetrics,
-    InvalidationCause, InvalidationKey, LimitRejection, MempoolGuard, ParkableBestTransactions,
+    InlineSimEnqueueError, InlineSimJob, InlineSimPool, InlineSimQueue, InvalidationCause,
+    InvalidationKey, LimitRejection, MempoolGuard, ParkableBestTransactions,
     ParkableTransactionPool, ParkedBestTransactions, StateDiffInvalidation, ValidityPoolMetrics,
     best::MergeBestTransactions,
     two_d_nonce_pool::{InsertOutcome, TwoDNoncePool},
@@ -99,6 +100,9 @@ pub struct BaseTransactionPool<
     /// concurrent same-nonce replacement cannot leave a stale guard record.
     /// Validation remains outside this lock.
     protocol_admission_lock: Arc<Mutex<()>>,
+    /// Enqueue slot for in-process meter_bundle workers. Empty means the
+    /// flag is off or workers have not installed yet.
+    inline_sim: InlineSimQueue,
 }
 
 impl<Client, S, Evm, T, O> fmt::Debug for BaseTransactionPool<Client, S, Evm, T, O>
@@ -133,6 +137,7 @@ where
             guard: Arc::clone(&self.guard),
             block_expiry: Arc::clone(&self.block_expiry),
             protocol_admission_lock: Arc::clone(&self.protocol_admission_lock),
+            inline_sim: self.inline_sim.clone(),
         }
     }
 }
@@ -175,6 +180,7 @@ where
             guard: Arc::new(RwLock::new(MempoolGuard::unlimited())),
             block_expiry: Arc::new(RwLock::new(crate::BlockExpiryIndex::new())),
             protocol_admission_lock: Arc::new(Mutex::new(())),
+            inline_sim: InlineSimQueue::default(),
         }
     }
 
@@ -183,6 +189,11 @@ where
     pub fn with_guard_limits(self, limits: GuardLimits) -> Self {
         *self.guard.write() = MempoolGuard::new(limits);
         self
+    }
+
+    /// Installs the enqueue sender used by `eth_sendRawTransaction`.
+    pub fn install_inline_sim(&self, sender: mpsc::Sender<InlineSimJob>) {
+        self.inline_sim.install(sender);
     }
 
     /// Builds guard admission metadata carried by a validated EIP-8130 transaction.
@@ -1442,6 +1453,24 @@ where
 
     fn validator(&self) -> &Self::Validator {
         self.protocol_pool.validator()
+    }
+}
+
+impl<Client, S, Evm, T, O> InlineSimPool for BaseTransactionPool<Client, S, Evm, T, O>
+where
+    Client: 'static,
+    Evm: 'static,
+    BaseTransactionValidator<Client, T, Evm>: TransactionValidator<Transaction = T>,
+    T: BasePooledTx + reth_transaction_pool::EthPoolTransaction + 'static,
+    O: reth_transaction_pool::TransactionOrdering<Transaction = T> + Clone,
+    S: BlobStore + Clone,
+{
+    fn is_inline_sim_enabled(&self) -> bool {
+        self.inline_sim.is_enabled()
+    }
+
+    fn try_enqueue_inline_sim(&self, job: InlineSimJob) -> Result<(), InlineSimEnqueueError> {
+        self.inline_sim.try_enqueue(job)
     }
 }
 


### PR DESCRIPTION
## Motivation

Cut over mempool `eth_sendRawTransaction` to validate → bounded sim buffer → in-process `meter_bundle` → `add_transaction(tx.with_metering)` when `--enable-inline-simulation` is set. Flag still defaults off.

## Changes

- `InlineSimQueue` + N workers in `base-execution-txpool`: cheap-validate at RPC, enqueue, workers call in-process `meter_transaction`, then pool insert with metering attached.
- Queue-full returns `TxPoolOverflow`. Sim error/timeout does not insert (RPC already returned the hash).
- `add_transaction` still validates; the pre-queue `validate` is only to keep junk off workers (`validate_one` is cheap enough to run twice).
- Metrics: `sim_queue_size`, `sim_workers_busy`, `sim_seconds` (pickup through insert), plus `sim_queue_full` / `sim_failures`.
- `--enable-inline-simulation` still does not register metering RPC.

## Tests

| Test Name | Description |
| --- | --- |
| `try_enqueue_reports_disabled_without_install` | Enqueue is a no-op until the queue is installed |
| `try_enqueue_rejects_when_queue_is_full` | Bounded queue returns Full instead of growing |
| `meter_job_attaches_metering_on_success` | Successful sim attaches MeterBundleResponse |
| `meter_job_skips_insert_on_meter_error` | Failed meter_bundle does not produce an insert |
| `meter_job_skips_insert_on_timeout` | Timed-out sim does not produce an insert |
| CLI `inline_simulation_*` | Flag still requires forwarding; does not enable metering RPC |

## Test plan

- [ ] `--enable-inline-simulation` off: send path unchanged (`add_transaction`)
- [ ] Flag on: invalid txs fail at pre-queue validate and never occupy workers
- [ ] Flag on: valid txs return hash, then appear in the pool with metering attached
- [ ] Queue full returns txpool overflow to the client
- [ ] Sim timeout/error: hash returned, tx not in pool

Made with [Cursor](https://cursor.com)