### PR TITLE
feat(builder): emit validity-predicate state-load metrics

### DIFF
--- a/crates/builder/core/src/execution.rs
+++ b/crates/builder/core/src/execution.rs
@@ -12,6 +12,8 @@ use base_common_evm::BaseTransactionError;
 use derive_more::Display;
 use thiserror::Error;
 
+use crate::PredicateLoadTracker;
+
 /// Resource limits configuration for transaction and block constraints.
 ///
 /// This struct encapsulates all the resource limit parameters used to determine
@@ -225,6 +227,8 @@ pub struct ExecutionInfo {
     pub da_footprint_scalar: Option<u16>,
     /// Rejected transactions accumulated during block building, flushed after finalization.
     pub rejected_txs: Vec<RejectedTransaction>,
+    /// Validity-predicate state loads accumulated across the block's flashblock builds.
+    pub predicate_loads: PredicateLoadTracker,
 }
 
 impl ExecutionInfo {
@@ -241,6 +245,7 @@ impl ExecutionInfo {
             extra: Default::default(),
             da_footprint_scalar: None,
             rejected_txs: Vec::new(),
+            predicate_loads: PredicateLoadTracker::default(),
         }
     }
 

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -45,8 +45,8 @@ use tracing::{Level, debug, span, trace, warn};
 
 use crate::{
     BuilderConfig, BuilderMetrics, ExecutionInfo, ExecutionMeteringLimitExceeded,
-    ParkedPredicateIndex, PayloadTxsBounds, ResourceLimits, StateChangeEffects, TxResources,
-    TxnExecutionError, TxnOutcome, ValidityPredicateKey,
+    ParkedPredicateIndex, PayloadTxsBounds, PredicateReadRecorder, ResourceLimits,
+    StateChangeEffects, TxResources, TxnExecutionError, TxnOutcome, ValidityPredicateKey,
     transaction_events::{
         BuilderAcceptedEventData, BuilderConsideredEventData, BuilderDeferredEventData,
         BuilderExpiredEventData, BuilderRejectedEventData, BuilderTransactionEventContext,
@@ -905,9 +905,11 @@ impl BasePayloadBuilderCtx {
             let mut predicate_read_failed = false;
             let blocking_predicate = if has_validity_predicates {
                 match Self::accumulate_elapsed(&mut predicate_eval_total, || {
+                    let mut recorder =
+                        PredicateReadRecorder::new(&mut **evm.db_mut(), &mut info.predicate_loads);
                     ValidityPredicateKey::first_unsatisfied(
                         tx.validity_predicates(),
-                        evm.db_mut(),
+                        &mut recorder,
                         &predicate_context,
                     )
                 }) {
@@ -1557,9 +1559,13 @@ impl BasePayloadBuilderCtx {
                 };
                 let blocking_predicate =
                     match Self::accumulate_elapsed(&mut predicate_eval_total, || {
+                        let mut recorder = PredicateReadRecorder::new(
+                            &mut **evm.db_mut(),
+                            &mut info.predicate_loads,
+                        );
                         ValidityPredicateKey::first_unsatisfied(
                             parked_transaction.validity_predicates(),
-                            evm.db_mut(),
+                            &mut recorder,
                             &predicate_context,
                         )
                     }) {

--- a/crates/builder/core/src/flashblocks/mod.rs
+++ b/crates/builder/core/src/flashblocks/mod.rs
@@ -9,6 +9,9 @@ pub use best_txs::{
 mod predicate_index;
 pub use predicate_index::{ParkedPredicateIndex, StateChangeEffects, ValidityPredicateKey};
 
+mod predicate_loads;
+pub use predicate_loads::{PredicateLoadTracker, PredicateReadRecorder};
+
 mod deadline;
 pub use deadline::PayloadJobDeadline;
 

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -931,6 +931,9 @@ where
         // Record cumulative uncompressed block size
         BuilderMetrics::block_uncompressed_size().record(info.cumulative_uncompressed_bytes as f64);
 
+        // Record validity-predicate state loads accumulated across the block's flashblocks.
+        BuilderMetrics::record_predicate_loads(&info.predicate_loads);
+
         debug!(
             target: "payload_builder",
             message = message,

--- a/crates/builder/core/src/flashblocks/predicate_loads.rs
+++ b/crates/builder/core/src/flashblocks/predicate_loads.rs
@@ -1,0 +1,238 @@
+//! Per-block accounting of validity-predicate state loads.
+//!
+//! Evaluating a transaction's validity predicates reads account balances and
+//! contract storage slots from the state the builder is building on. This module
+//! measures the *footprint* of those reads per block — how many accounts and
+//! storage slots predicate evaluation touches, both in total (every read) and
+//! deduplicated (distinct locations).
+//!
+//! It deliberately does **not** classify reads as cache hits vs disk misses.
+//! The read flows through several cache tiers (the per-build revm `State` cache,
+//! reth's cross-block execution cache, then MDBX), and the only tier that
+//! cleanly represents "went to disk" is the execution-cache miss — which is not
+//! observable from here and is already measured, un-scoped, by reth's
+//! `sync.caching` metrics. The footprint counted here is the signal that a
+//! predicate-state prewarmer must cover and that an abusive submitter inflates.
+//!
+//! [`PredicateReadRecorder`] wraps the builder's [`State`] during a predicate
+//! evaluation and records each read into a [`PredicateLoadTracker`] that
+//! accumulates across the whole block build. Because reads flow through the
+//! wrapper as the evaluator issues them, short-circuit evaluation is respected:
+//! only the reads a predicate check actually performs are counted.
+
+use alloy_primitives::{Address, B256, U256, map::HashSet};
+use reth_revm::State;
+use revm::{
+    Database,
+    state::{AccountInfo, Bytecode},
+};
+
+/// Per-block accumulator for validity-predicate state loads.
+///
+/// Totals count every read: a slot re-read (e.g. after it is written, or when a
+/// parked transaction is re-evaluated on a later flashblock) counts again, so
+/// the total captures raw read volume. The unique sets count distinct locations
+/// touched across the block, i.e. the predicate state footprint.
+#[derive(Debug, Default)]
+pub struct PredicateLoadTracker {
+    /// Total account (balance) reads.
+    account_reads: u64,
+    /// Total storage-slot reads.
+    slot_reads: u64,
+    /// Distinct accounts read this block.
+    unique_accounts: HashSet<Address>,
+    /// Distinct storage slots read this block.
+    unique_slots: HashSet<(Address, U256)>,
+}
+
+impl PredicateLoadTracker {
+    /// Records a single account (balance) read.
+    pub fn record_account(&mut self, address: Address) {
+        self.account_reads += 1;
+        self.unique_accounts.insert(address);
+    }
+
+    /// Records a single storage-slot read.
+    pub fn record_slot(&mut self, address: Address, slot: U256) {
+        self.slot_reads += 1;
+        self.unique_slots.insert((address, slot));
+    }
+
+    /// Returns whether any predicate read was recorded this block.
+    ///
+    /// Used to gate metric emission so blocks that carried no validity
+    /// transactions do not flood the per-block histograms with zero observations.
+    pub const fn has_activity(&self) -> bool {
+        self.account_reads > 0 || self.slot_reads > 0
+    }
+
+    /// Total account reads this block.
+    pub const fn account_reads(&self) -> u64 {
+        self.account_reads
+    }
+
+    /// Total storage-slot reads this block.
+    pub const fn slot_reads(&self) -> u64 {
+        self.slot_reads
+    }
+
+    /// Distinct accounts read this block.
+    pub fn unique_accounts(&self) -> u64 {
+        self.unique_accounts.len() as u64
+    }
+
+    /// Distinct storage slots read this block.
+    pub fn unique_slots(&self) -> u64 {
+        self.unique_slots.len() as u64
+    }
+}
+
+/// A [`Database`] wrapper that records validity-predicate state reads.
+///
+/// Wraps the builder's [`State`] for the duration of a predicate evaluation and
+/// records each [`Database::basic`] (account) and [`Database::storage`] (slot)
+/// call into the shared [`PredicateLoadTracker`] before delegating. It does not
+/// inspect any cache — it only counts which locations predicate evaluation
+/// reads, respecting short-circuit evaluation because reads flow through it as
+/// they are issued.
+#[derive(Debug)]
+pub struct PredicateReadRecorder<'a, DB> {
+    state: &'a mut State<DB>,
+    tracker: &'a mut PredicateLoadTracker,
+}
+
+impl<'a, DB> PredicateReadRecorder<'a, DB> {
+    /// Wraps `state`, recording reads into `tracker`.
+    pub const fn new(state: &'a mut State<DB>, tracker: &'a mut PredicateLoadTracker) -> Self {
+        Self { state, tracker }
+    }
+}
+
+impl<DB: Database> Database for PredicateReadRecorder<'_, DB> {
+    type Error = <State<DB> as Database>::Error;
+
+    fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        self.tracker.record_account(address);
+        self.state.basic(address)
+    }
+
+    fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        self.state.code_by_hash(code_hash)
+    }
+
+    fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
+        self.tracker.record_slot(address, index);
+        self.state.storage(address, index)
+    }
+
+    fn block_hash(&mut self, number: u64) -> Result<B256, Self::Error> {
+        self.state.block_hash(number)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, U256};
+    use base_execution_txpool::{PredicateContext, ValidityOperator, ValidityPredicate};
+    use reth_revm::State;
+    use revm::{database::InMemoryDB, state::AccountInfo};
+
+    use super::{PredicateLoadTracker, PredicateReadRecorder};
+    use crate::ValidityPredicateKey;
+
+    fn context() -> PredicateContext {
+        PredicateContext { block_number: 1, flashblock_index: 0 }
+    }
+
+    /// Builds a `State` over an in-memory database seeded with one account that
+    /// has a balance and a single storage slot.
+    fn seeded_state() -> (State<InMemoryDB>, Address, U256) {
+        let address = Address::with_last_byte(0x11);
+        let slot = U256::from(7);
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            address,
+            AccountInfo { balance: U256::from(10), ..Default::default() },
+        );
+        db.insert_account_storage(address, slot, U256::from(3)).unwrap();
+        let state = State::builder().with_database(db).with_bundle_update().build();
+        (state, address, slot)
+    }
+
+    #[test]
+    fn counts_account_and_slot_reads_total_and_unique() {
+        let (mut state, address, slot) = seeded_state();
+        let mut tracker = PredicateLoadTracker::default();
+
+        let balance = ValidityPredicate::Balance {
+            address,
+            op: ValidityOperator::Equal,
+            value: U256::from(10),
+        };
+        let storage = ValidityPredicate::Storage {
+            address,
+            slot,
+            mask: U256::MAX,
+            op: ValidityOperator::Equal,
+            value: U256::from(3),
+        };
+        let predicates = [balance, storage];
+
+        // Evaluate the same batch twice: totals double, unique counts do not.
+        for _ in 0..2 {
+            let mut recorder = PredicateReadRecorder::new(&mut state, &mut tracker);
+            assert_eq!(
+                ValidityPredicateKey::first_unsatisfied(&predicates, &mut recorder, &context())
+                    .unwrap(),
+                None
+            );
+        }
+
+        assert_eq!(tracker.account_reads(), 2);
+        assert_eq!(tracker.slot_reads(), 2);
+        assert_eq!(tracker.unique_accounts(), 1);
+        assert_eq!(tracker.unique_slots(), 1);
+        assert!(tracker.has_activity());
+    }
+
+    #[test]
+    fn short_circuit_skips_reads_after_first_unsatisfied_predicate() {
+        let (mut state, address, slot) = seeded_state();
+        let mut tracker = PredicateLoadTracker::default();
+
+        // The balance predicate fails, so evaluation stops before the storage
+        // predicate is ever read.
+        let failing_balance = ValidityPredicate::Balance {
+            address,
+            op: ValidityOperator::Equal,
+            value: U256::from(999),
+        };
+        let storage = ValidityPredicate::Storage {
+            address,
+            slot,
+            mask: U256::MAX,
+            op: ValidityOperator::Equal,
+            value: U256::from(3),
+        };
+        let predicates = [failing_balance, storage];
+
+        {
+            let mut recorder = PredicateReadRecorder::new(&mut state, &mut tracker);
+            assert_eq!(
+                ValidityPredicateKey::first_unsatisfied(&predicates, &mut recorder, &context())
+                    .unwrap(),
+                Some(ValidityPredicateKey::Balance(address))
+            );
+        }
+
+        assert_eq!(tracker.account_reads(), 1);
+        assert_eq!(tracker.slot_reads(), 0, "storage slot must not be read after short circuit");
+        assert_eq!(tracker.unique_accounts(), 1);
+        assert_eq!(tracker.unique_slots(), 0);
+    }
+
+    #[test]
+    fn empty_tracker_reports_no_activity() {
+        assert!(!PredicateLoadTracker::default().has_activity());
+    }
+}

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -45,7 +45,8 @@ pub use flashblocks::{
     BuildArguments, FlashblockDiagnostics, FlashblockSelectionOutcome, FlashblocksExtraCtx,
     FlashblocksServiceBuilder, ParkableBestPayloadTransactions, ParkablePayloadTransactions,
     ParkedPredicateIndex, PayloadBuilder, PayloadHandler, PayloadJobDeadline,
-    PayloadTransactionInvalidated, ResolvePayload, StateChangeEffects, ValidityPredicateKey,
+    PayloadTransactionInvalidated, PredicateLoadTracker, PredicateReadRecorder, ResolvePayload,
+    StateChangeEffects, ValidityPredicateKey,
 };
 
 mod extension;

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -2,7 +2,10 @@
 
 use std::time::Duration;
 
-use crate::{ExecutionInfo, FlashblockDiagnostics, ParkedPredicateIndex, ResourceLimits};
+use crate::{
+    ExecutionInfo, FlashblockDiagnostics, ParkedPredicateIndex, PredicateLoadTracker,
+    ResourceLimits,
+};
 
 const PRIORITY_FEE_THRESHOLDS_WEI: [(&str, u64); 3] =
     [("100wei", 100), ("100kwei", 100_000), ("1mwei", 1_000_000)];
@@ -126,6 +129,22 @@ base_metrics::define_metrics! {
         "Depth (parked transaction count) of validity-predicate index buckets, sampled once per flashblock build"
     )]
     predicate_bucket_depth: histogram,
+    #[describe(
+        "Accounts read while evaluating validity predicates per block, counting every read"
+    )]
+    predicate_accounts_loaded_total: histogram,
+    #[describe(
+        "Distinct accounts read while evaluating validity predicates per block"
+    )]
+    predicate_accounts_loaded_unique: histogram,
+    #[describe(
+        "Storage slots read while evaluating validity predicates per block, counting every read including re-reads"
+    )]
+    predicate_slots_loaded_total: histogram,
+    #[describe(
+        "Distinct storage slots read while evaluating validity predicates per block (predicate state footprint)"
+    )]
+    predicate_slots_loaded_unique: histogram,
     #[describe("Validity predicate evaluation attempts")]
     #[label(outcome)]
     validity_predicate_evaluations_total: counter,
@@ -289,6 +308,22 @@ impl BuilderMetrics {
         }
     }
 
+    /// Records the block's accumulated validity-predicate state loads as
+    /// per-block histogram observations (total and distinct accounts/slots).
+    ///
+    /// Emits nothing when the block carried no validity transactions, so the
+    /// histograms are not diluted with zero observations from ordinary blocks.
+    pub fn record_predicate_loads(tracker: &PredicateLoadTracker) {
+        if !tracker.has_activity() {
+            return;
+        }
+
+        Self::predicate_accounts_loaded_total().record(tracker.account_reads() as f64);
+        Self::predicate_accounts_loaded_unique().record(tracker.unique_accounts() as f64);
+        Self::predicate_slots_loaded_total().record(tracker.slot_reads() as f64);
+        Self::predicate_slots_loaded_unique().record(tracker.unique_slots() as f64);
+    }
+
     /// Records payload builder metrics.
     pub fn set_payload_builder_metrics(
         payload_transaction_simulation_time: f64,
@@ -322,7 +357,7 @@ impl BuilderMetrics {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{Address, B256};
+    use alloy_primitives::{Address, B256, U256};
     use metrics_exporter_prometheus::PrometheusBuilder;
 
     use super::*;
@@ -439,5 +474,43 @@ mod tests {
         assert!(rendered.contains("base_builder_predicate_bucket_wakeups_sum 3"));
         assert!(rendered.contains("base_builder_predicate_bucket_depth_count 2"));
         assert!(rendered.contains("base_builder_predicate_bucket_depth_sum 3"));
+    }
+
+    #[test]
+    fn record_predicate_loads_emits_total_and_unique_histograms() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+
+        let account = Address::with_last_byte(1);
+        let slot = U256::from(7);
+        let mut tracker = PredicateLoadTracker::default();
+        // Account read twice; slot read three times — one distinct location each.
+        tracker.record_account(account);
+        tracker.record_account(account);
+        tracker.record_slot(account, slot);
+        tracker.record_slot(account, slot);
+        tracker.record_slot(account, slot);
+
+        metrics::with_local_recorder(&recorder, || {
+            BuilderMetrics::record_predicate_loads(&tracker);
+        });
+
+        let rendered = handle.render();
+        assert!(rendered.contains("base_builder_predicate_accounts_loaded_total_sum 2"));
+        assert!(rendered.contains("base_builder_predicate_accounts_loaded_unique_sum 1"));
+        assert!(rendered.contains("base_builder_predicate_slots_loaded_total_sum 3"));
+        assert!(rendered.contains("base_builder_predicate_slots_loaded_unique_sum 1"));
+    }
+
+    #[test]
+    fn record_predicate_loads_emits_nothing_without_activity() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+
+        metrics::with_local_recorder(&recorder, || {
+            BuilderMetrics::record_predicate_loads(&PredicateLoadTracker::default());
+        });
+
+        assert!(!handle.render().contains("predicate_accounts_loaded_total"));
     }
 }


### PR DESCRIPTION
Track the accounts and storage slots read while evaluating validity predicates during a block build, emitted once per block as histograms of total reads (every read, including re-reads across flashblocks and parked-transaction rescans) and distinct locations (the predicate state footprint).

A `PredicateReadRecorder` wraps the builder `State` for the duration of each predicate evaluation and records reads into a per-block `PredicateLoadTracker` carried on `ExecutionInfo`, respecting short-circuit evaluation. This is the footprint signal a predicate-state prewarmer must cover; disk-tier cost is covered separately by reth's `sync.caching` miss metrics and by predicate evaluation time.