### PR TITLE
fix(validity): Register Sidecar Block-Expiry And Docs

### DIFF
--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -228,9 +228,10 @@ pub struct RpcStandardNodeArgs {
 
     /// Enable the experimental validity transaction RPC.
     ///
-    /// When transaction forwarding is enabled, validity predicates are forwarded to builders, but
-    /// they are not yet enforced. This can also be enabled on a standalone sequencer (e.g. a local
-    /// devnet) that builds blocks itself, in which case forwarding is not required.
+    /// When transaction forwarding is enabled, validity predicates are forwarded to builders, which
+    /// evaluate and enforce them during block construction. This can also be enabled on a standalone
+    /// sequencer (e.g. a local devnet) that builds blocks itself, in which case forwarding is not
+    /// required.
     #[arg(long = "enable-experimental-validity-transactions")]
     pub enable_experimental_validity_transactions: bool,
 

--- a/crates/execution/txpool-rpc/README.md
+++ b/crates/execution/txpool-rpc/README.md
@@ -12,8 +12,9 @@ Exposes JSON-RPC APIs for transaction pool administration and transaction lifecy
 allows clients to query the current status of individual transactions by hash. The separate
 `SendRawTransactionValidityExtension` registers local mempool ingress through
 `base_sendRawTransactionValidity`; typed validity predicates are preserved while forwarding to
-builders. This endpoint is experimental: predicates are not currently evaluated during block
-construction, so callers must not rely on them to prevent transaction inclusion.
+builders. This endpoint is experimental, but predicates are now evaluated and enforced by the
+builder during block construction: a transaction is only included at a point where all of its
+predicates hold, and it is evicted once it can no longer be included.
 
 ## Usage
 
@@ -26,12 +27,14 @@ base-txpool-rpc = { workspace = true }
 
 ```rust,ignore
 use base_txpool_rpc::{
-    SendRawTransactionValidityExtension, TxPoolRpcConfig, TxPoolRpcExtension,
+    DEFAULT_MAX_VALIDITY_PREDICATES, SendRawTransactionValidityExtension, TxPoolRpcConfig,
+    TxPoolRpcExtension,
 };
 
 runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig::default());
 // Install only when the node's explicit experimental validity flag is enabled.
-runner.install_ext::<SendRawTransactionValidityExtension>(());
+// The config is the maximum number of validity predicates accepted per transaction.
+runner.install_ext::<SendRawTransactionValidityExtension>(DEFAULT_MAX_VALIDITY_PREDICATES);
 ```
 
 ## License

--- a/crates/execution/txpool/src/pool.rs
+++ b/crates/execution/txpool/src/pool.rs
@@ -634,6 +634,13 @@ where
         validated: TransactionValidationOutcome<T>,
         origin: TransactionOrigin,
     ) -> PoolResult<AddedTransactionOutcome> {
+        // Capture the block-expiry bound before `validated` is consumed by the
+        // match below, mirroring the protocol admission paths. A sidecar (EIP-8130)
+        // transaction carrying block-number validity predicates must be recorded
+        // in the block-expiry index so it is evicted once its last valid block
+        // passes; a finite 2D-nonce-channel sidecar has no time-based expiry, so
+        // without this it would linger indefinitely.
+        let block_expiry_bound = Self::validity_block_expiry_bound(&validated);
         match validated {
             TransactionValidationOutcome::Valid {
                 transaction,
@@ -707,6 +714,15 @@ where
                 if is_validity {
                     ValidityPoolMetrics::record_admission(outcome.replaced.is_some());
                 }
+                // Record the block-expiry bound after a successful insertion,
+                // dropping the replaced hash's stale entry in the same pass.
+                // Release the sidecar locks first so the block-expiry index is
+                // not acquired while holding the nonce pool.
+                let inserted_hash = outcome.outcome.hash;
+                let replaced_hash = outcome.replaced.as_ref().map(|replaced| *replaced.hash());
+                drop(listeners);
+                drop(nonce_pool);
+                self.register_block_expiry(inserted_hash, block_expiry_bound, replaced_hash);
                 Ok(outcome.outcome)
             }
             TransactionValidationOutcome::Invalid(transaction, error) => {
@@ -2457,5 +2473,34 @@ mod tests {
         // An unbounded replacement still clears the replaced hash's stale entry.
         pool.register_block_expiry(new_hash, None, Some(replaced));
         assert!(pool.block_expiry.read().is_empty());
+    }
+
+    #[tokio::test]
+    async fn sidecar_validity_transaction_registers_block_expiry() {
+        let (pool, client) = build_integration_pool();
+        let signer = signer();
+        fund(&client, signer.address());
+
+        // A finite 2D-nonce-channel EIP-8130 sidecar carrying a block-number
+        // upper-bound predicate. Such a transaction has no time-based expiry, so
+        // block-expiry registration is the only thing that prevents it from
+        // lingering in the pool forever once it can no longer be included.
+        let transaction = self_paid_eoa_8130(&signer, U256::from(1), 0, 0, 1_000)
+            .with_validity_predicates(vec![crate::ValidityPredicate::BlockNumber {
+                op: crate::ValidityOperator::LessThanOrEqual,
+                value: U256::from(100),
+            }]);
+        let hash = *transaction.hash();
+        pool.add_transaction(TransactionOrigin::Local, transaction).await.unwrap();
+
+        // The sidecar admission path must record the tx's last valid block.
+        assert_eq!(pool.block_expiry.read().len(), 1);
+        assert!(pool.get(&hash).is_some());
+
+        // Once the last valid block is behind the tip, block-expiry eviction
+        // removes it and releases any guard capacity it held.
+        pool.expire_by_block(101);
+        assert!(pool.get(&hash).is_none());
+        assert!(!pool.guard.read().contains(&hash));
     }
 }


### PR DESCRIPTION
## Summary

EIP-8130 sidecar transactions carrying block-number validity predicates were admitted without being registered in the block-expiry index, so a finite 2D-nonce-channel sidecar that is never mined could linger in the pool indefinitely and hold guard capacity. This registers the block-expiry bound on the sidecar admission path, mirroring the two protocol admission paths, so such transactions are evicted once their last valid block passes, and adds a regression test covering admission and block-expiry eviction. It also corrects stale documentation that claimed validity predicates are not evaluated during block construction, which is no longer true now that the builder evaluates and enforces them. Finally it fixes a non-compiling install_ext example in the txpool-rpc README so the config argument matches the extension's usize config.