### PR TITLE
fix(validity): Reject Unsatisfiable Flashblock-Index Predicates

### DIFF
--- a/crates/execution/txpool-rpc/src/rpc.rs
+++ b/crates/execution/txpool-rpc/src/rpc.rs
@@ -440,6 +440,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn send_raw_transaction_validity_rejects_unsatisfiable_flashblock_index() {
+        let rpc = SendRawTransactionValidityApiImpl::new(NoopTransactionPool::<
+            BasePooledTransaction,
+        >::new());
+        let mut request = validity_request(Bytes::from_static(&[0x02]));
+        // A flashblock-index predicate that only holds at index 0, which pooled
+        // transactions never reach, would park forever if admitted.
+        request.validity = vec![ValidityPredicate::FlashblockIndex {
+            op: base_execution_txpool::ValidityOperator::Equal,
+            value: U256::ZERO,
+        }];
+
+        let error = rpc
+            .send_raw_transaction_validity(request)
+            .await
+            .expect_err("an unsatisfiable flashblock-index predicate should be rejected");
+
+        assert_eq!(error.code(), ErrorCode::InvalidParams.code());
+        assert!(error.message().contains("can never be satisfied"));
+    }
+
+    #[tokio::test]
     async fn test_transaction_status() -> eyre::Result<()> {
         let pool = testing_pool();
         let rpc =

--- a/crates/execution/txpool/src/lib.rs
+++ b/crates/execution/txpool/src/lib.rs
@@ -29,8 +29,8 @@ mod best;
 
 mod validity;
 pub use validity::{
-    DEFAULT_MAX_VALIDITY_PREDICATES, PredicateContext, TransactionValidity, ValidityOperator,
-    ValidityPredicate, ValidityPredicateError,
+    DEFAULT_MAX_VALIDITY_PREDICATES, FIRST_POOL_FLASHBLOCK_INDEX, PredicateContext,
+    TransactionValidity, ValidityOperator, ValidityPredicate, ValidityPredicateError,
 };
 
 mod block_expiry;

--- a/crates/execution/txpool/src/validity.rs
+++ b/crates/execution/txpool/src/validity.rs
@@ -53,7 +53,9 @@ pub enum ValidityPredicateError {
     /// index is below that would never be includable and would park indefinitely,
     /// so it is rejected at ingress. `index` is the position of the offending
     /// predicate within the batch.
-    #[error("flashblock-index predicate at index {index} can never be satisfied by a pooled transaction")]
+    #[error(
+        "flashblock-index predicate at index {index} can never be satisfied by a pooled transaction"
+    )]
     UnsatisfiableFlashblockIndex {
         /// Position of the offending predicate within the batch.
         index: usize,
@@ -863,10 +865,10 @@ mod tests {
         // Every shape whose greatest satisfiable index is below the first pool
         // flashblock index (1): pooled transactions never run at index 0.
         let unsatisfiable = [
-            (ValidityOperator::LessThan, U256::ZERO),        // < 0: never holds
-            (ValidityOperator::LessThan, U256::from(1)),     // < 1: only index 0
+            (ValidityOperator::LessThan, U256::ZERO), // < 0: never holds
+            (ValidityOperator::LessThan, U256::from(1)), // < 1: only index 0
             (ValidityOperator::LessThanOrEqual, U256::ZERO), // <= 0: only index 0
-            (ValidityOperator::Equal, U256::ZERO),           // = 0: only index 0
+            (ValidityOperator::Equal, U256::ZERO),    // = 0: only index 0
         ];
         for (op, value) in unsatisfiable {
             let predicate = ValidityPredicate::FlashblockIndex { op, value };
@@ -882,12 +884,12 @@ mod tests {
     fn validate_params_accepts_satisfiable_flashblock_index() {
         // Shapes that some index >= 1 can still satisfy.
         let satisfiable = [
-            (ValidityOperator::LessThan, U256::from(2)),          // < 2: index 1
-            (ValidityOperator::LessThanOrEqual, U256::from(1)),   // <= 1: index 1
-            (ValidityOperator::Equal, U256::from(1)),             // = 1
-            (ValidityOperator::NotEqual, U256::ZERO),             // != 0: any index >= 1
-            (ValidityOperator::GreaterThan, U256::ZERO),          // > 0: index >= 1
-            (ValidityOperator::GreaterThanOrEqual, U256::from(3)),// >= 3
+            (ValidityOperator::LessThan, U256::from(2)), // < 2: index 1
+            (ValidityOperator::LessThanOrEqual, U256::from(1)), // <= 1: index 1
+            (ValidityOperator::Equal, U256::from(1)),    // = 1
+            (ValidityOperator::NotEqual, U256::ZERO),    // != 0: any index >= 1
+            (ValidityOperator::GreaterThan, U256::ZERO), // > 0: index >= 1
+            (ValidityOperator::GreaterThanOrEqual, U256::from(3)), // >= 3
         ];
         for (op, value) in satisfiable {
             let predicate = ValidityPredicate::FlashblockIndex { op, value };

--- a/crates/execution/txpool/src/validity.rs
+++ b/crates/execution/txpool/src/validity.rs
@@ -9,6 +9,15 @@ use crate::{BasePooledTransaction, ExtensionError, ValidatedTransactionExtension
 /// Default maximum number of experimental validity predicates carried by one transaction.
 pub const DEFAULT_MAX_VALIDITY_PREDICATES: usize = 64;
 
+/// The first flashblock index at which pooled transactions are evaluated.
+///
+/// The fallback block published at flashblock index `0` executes only sequencer
+/// (attribute-derived) transactions; pooled transactions are first considered in
+/// the flashblock at index `1`. A [`ValidityPredicate::FlashblockIndex`] whose
+/// greatest satisfiable index is below this can therefore never hold for a pooled
+/// transaction.
+pub const FIRST_POOL_FLASHBLOCK_INDEX: u64 = 1;
+
 /// Error returned when a batch of validity predicates fails ingress validation.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum ValidityPredicateError {
@@ -33,6 +42,19 @@ pub enum ValidityPredicateError {
     /// `index` is the position of the offending predicate within the batch.
     #[error("storage predicate at index {index} has value bits set outside its mask")]
     StorageValueOutsideMask {
+        /// Position of the offending predicate within the batch.
+        index: usize,
+    },
+    /// A flashblock-index predicate can never be satisfied by a pooled transaction.
+    ///
+    /// Pooled transactions are first evaluated at flashblock index
+    /// [`FIRST_POOL_FLASHBLOCK_INDEX`]; the index-`0` fallback block carries only
+    /// sequencer transactions. A predicate whose greatest satisfiable flashblock
+    /// index is below that would never be includable and would park indefinitely,
+    /// so it is rejected at ingress. `index` is the position of the offending
+    /// predicate within the batch.
+    #[error("flashblock-index predicate at index {index} can never be satisfied by a pooled transaction")]
+    UnsatisfiableFlashblockIndex {
         /// Position of the offending predicate within the batch.
         index: usize,
     },
@@ -157,12 +179,33 @@ impl ValidityPredicate {
     /// itself, so new failure modes surface as distinct errors instead of
     /// collapsing into a single caller-assigned variant.
     pub fn validate_params(&self, index: usize) -> Result<(), ValidityPredicateError> {
-        if let Self::Storage { mask, value, .. } = self
-            && (*value & !*mask) != U256::ZERO
-        {
-            return Err(ValidityPredicateError::StorageValueOutsideMask { index });
+        match self {
+            Self::Storage { mask, value, .. } if (*value & !*mask) != U256::ZERO => {
+                Err(ValidityPredicateError::StorageValueOutsideMask { index })
+            }
+            Self::FlashblockIndex { op, value } => {
+                // Pooled transactions are first evaluated at flashblock index
+                // FIRST_POOL_FLASHBLOCK_INDEX (the index-0 fallback block carries
+                // only sequencer transactions), so a predicate whose greatest
+                // satisfiable index is below that can never hold. Upper bounds
+                // (`<`, `<=`, `=`) cap the satisfiable index; lower bounds and
+                // `!=` always leave some index >= 1 satisfiable.
+                let max_satisfiable_index = match op {
+                    ValidityOperator::LessThan => value.checked_sub(U256::from(1)),
+                    ValidityOperator::LessThanOrEqual | ValidityOperator::Equal => Some(*value),
+                    ValidityOperator::NotEqual
+                    | ValidityOperator::GreaterThan
+                    | ValidityOperator::GreaterThanOrEqual => return Ok(()),
+                };
+                if max_satisfiable_index
+                    .is_none_or(|max| max < U256::from(FIRST_POOL_FLASHBLOCK_INDEX))
+                {
+                    return Err(ValidityPredicateError::UnsatisfiableFlashblockIndex { index });
+                }
+                Ok(())
+            }
+            _ => Ok(()),
         }
-        Ok(())
     }
 
     /// Validates a batch of predicates submitted at ingress.
@@ -720,6 +763,36 @@ mod tests {
     }
 
     #[test]
+    fn apply_rejects_unsatisfiable_flashblock_index() {
+        let signed: BaseTransactionSigned = TxDeposit {
+            source_hash: Default::default(),
+            from: Address::ZERO,
+            to: TxKind::Create,
+            mint: 0,
+            value: U256::ZERO,
+            gas_limit: 21_000,
+            is_system_transaction: false,
+            input: Default::default(),
+        }
+        .into();
+        let encoded_length = signed.encode_2718_len();
+        let transaction = BasePooledTransaction::new(
+            Recovered::new_unchecked(signed, Address::ZERO),
+            encoded_length,
+        );
+        let extension = TransactionValidity {
+            validity: vec![ValidityPredicate::FlashblockIndex {
+                op: ValidityOperator::Equal,
+                value: U256::ZERO,
+            }],
+        };
+
+        let error = extension.apply(transaction).unwrap_err();
+
+        assert!(error.to_string().contains("can never be satisfied"));
+    }
+
+    #[test]
     fn apply_accepts_empty_predicates() {
         let signed: BaseTransactionSigned = TxDeposit {
             source_hash: Default::default(),
@@ -783,6 +856,64 @@ mod tests {
         };
 
         assert_eq!(predicate.validate_params(0), Ok(()));
+    }
+
+    #[test]
+    fn validate_params_rejects_flashblock_index_unsatisfiable_for_pooled_transactions() {
+        // Every shape whose greatest satisfiable index is below the first pool
+        // flashblock index (1): pooled transactions never run at index 0.
+        let unsatisfiable = [
+            (ValidityOperator::LessThan, U256::ZERO),        // < 0: never holds
+            (ValidityOperator::LessThan, U256::from(1)),     // < 1: only index 0
+            (ValidityOperator::LessThanOrEqual, U256::ZERO), // <= 0: only index 0
+            (ValidityOperator::Equal, U256::ZERO),           // = 0: only index 0
+        ];
+        for (op, value) in unsatisfiable {
+            let predicate = ValidityPredicate::FlashblockIndex { op, value };
+            assert_eq!(
+                predicate.validate_params(2),
+                Err(ValidityPredicateError::UnsatisfiableFlashblockIndex { index: 2 }),
+                "expected {op:?} {value} to be rejected",
+            );
+        }
+    }
+
+    #[test]
+    fn validate_params_accepts_satisfiable_flashblock_index() {
+        // Shapes that some index >= 1 can still satisfy.
+        let satisfiable = [
+            (ValidityOperator::LessThan, U256::from(2)),          // < 2: index 1
+            (ValidityOperator::LessThanOrEqual, U256::from(1)),   // <= 1: index 1
+            (ValidityOperator::Equal, U256::from(1)),             // = 1
+            (ValidityOperator::NotEqual, U256::ZERO),             // != 0: any index >= 1
+            (ValidityOperator::GreaterThan, U256::ZERO),          // > 0: index >= 1
+            (ValidityOperator::GreaterThanOrEqual, U256::from(3)),// >= 3
+        ];
+        for (op, value) in satisfiable {
+            let predicate = ValidityPredicate::FlashblockIndex { op, value };
+            assert_eq!(
+                predicate.validate_params(0),
+                Ok(()),
+                "expected {op:?} {value} to be accepted",
+            );
+        }
+    }
+
+    #[test]
+    fn validate_batch_rejects_unsatisfiable_flashblock_index_reporting_its_index() {
+        let predicates = vec![
+            ValidityPredicate::Balance {
+                address: Address::repeat_byte(0x11),
+                op: ValidityOperator::GreaterThanOrEqual,
+                value: U256::from(1),
+            },
+            ValidityPredicate::FlashblockIndex { op: ValidityOperator::Equal, value: U256::ZERO },
+        ];
+
+        assert_eq!(
+            ValidityPredicate::validate_batch(&predicates, DEFAULT_MAX_VALIDITY_PREDICATES),
+            Err(ValidityPredicateError::UnsatisfiableFlashblockIndex { index: 1 })
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A FlashblockIndex validity predicate whose greatest satisfiable index is below 1 (for example `= 0`, `< 1`, or `<= 0`) can never hold for a pooled transaction, because pooled transactions are first evaluated at flashblock index 1 while the index-0 fallback block carries only sequencer transactions. Such a predicate was accepted at ingress and then re-evaluated and parked on every flashblock indefinitely, never included and never evicted, wasting pool capacity and builder predicate-evaluation budget. This rejects those predicates at ingress in validate_params, so both the mempool base_sendRawTransactionValidity path and the builder apply path return a clear InvalidParams error instead of admitting a transaction that can never be built. Unit and RPC ingress tests cover the rejected shapes and confirm still-satisfiable shapes such as `>= 1`, `= 1`, and `!= 0` are unaffected.