### PR TITLE
feat(load-tests): Expose Position Validity Predicates

### DIFF
--- a/crates/infra/load-tests/README.md
+++ b/crates/infra/load-tests/README.md
@@ -360,6 +360,30 @@ The final summary's `by_cohort` breakdown reports confirmed transactions split
 across the `plain` and `validity_pass` cohorts, so plain traffic can be compared
 against validity traffic when the workload is enabled.
 
+##### Delayed (fixed future) validity spike
+
+To make the whole validity cohort become valid at the same future block —
+parking it in the pool until then and releasing it as one predictable spike —
+attach a lower-bound `block_number` predicate targeting a future block:
+
+```yaml
+validity:
+  ratio: 1.0
+  predicates:
+    - type: block_number
+      op: ">="
+      value: "12345"   # a block that is still in the future when submission starts
+```
+
+Every validity transaction carries `block_number >= 12345`, so the builder skips
+them until block 12345 and then includes the accumulated backlog together. Choose
+the target relative to the block height **at which measured submission begins**,
+not run-invocation time: account funding and token setup run first and advance the
+chain by a variable number of blocks, so a target that is too low will already be
+satisfied by the time submission starts (no spike). Pick a value comfortably
+beyond the expected setup duration, and confirm the spike landed via the
+`by_cohort` / `fullest_block` breakdown in the summary.
+
 **Required flags for end-to-end evaluation.** For predicates to actually be
 evaluated (not merely transported), the target environment must be configured so
 that:

--- a/crates/infra/load-tests/README.md
+++ b/crates/infra/load-tests/README.md
@@ -296,11 +296,14 @@ Recipient keys are always positioned with a runtime-random seed/offset (never th
 #### Validity (Conditional) Transactions
 
 A configurable fraction of *senders* can route their entire traffic through the
-`base_sendRawTransactionValidity` endpoint, attaching state-based validity
-predicates (balance and storage conditions) to every transaction they submit.
-This exercises the sequencer and builder under congestion when validity
-predicates are in play. Set `validity.ratio` to `0.0` (the default) to disable
-the workload entirely, in which case behavior is identical to a plain run.
+`base_sendRawTransactionValidity` endpoint, attaching validity predicates to
+every transaction they submit. All four server predicate types are supported:
+the state-based `balance` and `storage` conditions, and the build-position
+`block_number` and `flashblock_index` conditions (compared against the block and
+flashblock currently being built). This exercises the sequencer and builder
+under congestion when validity predicates are in play. Set `validity.ratio` to
+`0.0` (the default) to disable the workload entirely, in which case behavior is
+identical to a plain run.
 
 Routing is deterministic and *per sender* (a hash of `seed + sender`), not per
 transaction, so a given sender's entire nonce stream stays on one submission
@@ -334,14 +337,23 @@ validity:
         key: sender
       op: ">="
       value: "0x0"
+    # build-position predicates carry only an operator and value:
+    - type: block_number
+      op: ">="
+      value: "0x0"
+    - type: flashblock_index
+      op: ">="
+      value: "1"
 ```
 
 Predicate addresses resolve per transaction: `sender` → the tx `from`,
 `recipient` → the tx `to` (falling back to `from` for contract creation), or a
 fixed `0x` address. Storage slots are either a `fixed` slot or a `mapping`
 slot, which computes the Solidity mapping slot `keccak256(key ++ mapping_slot)`
-so `balanceOf(key)` slots are expressible. Values, slots, and masks accept hex
-(`0x...`) or decimal strings. At most 64 predicates may be attached per
+so `balanceOf(key)` slots are expressible. The `block_number` and
+`flashblock_index` predicates carry only an `op` and `value` and read the
+build position rather than any address or slot. Values, slots, and masks accept
+hex (`0x...`) or decimal strings. At most 64 predicates may be attached per
 transaction.
 
 The final summary's `by_cohort` breakdown reports confirmed transactions split

--- a/crates/infra/load-tests/src/config/validity.rs
+++ b/crates/infra/load-tests/src/config/validity.rs
@@ -322,7 +322,8 @@ mod tests {
 
     #[test]
     fn block_number_predicate_to_template() {
-        let config = ValidityPredicateConfig::BlockNumber { op: ">=".into(), value: "0x100".into() };
+        let config =
+            ValidityPredicateConfig::BlockNumber { op: ">=".into(), value: "0x100".into() };
         match config.to_template().unwrap() {
             ValidityPredicateTemplate::BlockNumber { op, value } => {
                 assert_eq!(op, ValidityOperator::GreaterThanOrEqual);
@@ -334,8 +335,7 @@ mod tests {
 
     #[test]
     fn flashblock_index_predicate_to_template() {
-        let config =
-            ValidityPredicateConfig::FlashblockIndex { op: "=".into(), value: "2".into() };
+        let config = ValidityPredicateConfig::FlashblockIndex { op: "=".into(), value: "2".into() };
         match config.to_template().unwrap() {
             ValidityPredicateTemplate::FlashblockIndex { op, value } => {
                 assert_eq!(op, ValidityOperator::Equal);
@@ -347,8 +347,7 @@ mod tests {
 
     #[test]
     fn position_predicate_surfaces_bad_operator() {
-        let config =
-            ValidityPredicateConfig::BlockNumber { op: "==".into(), value: "1".into() };
+        let config = ValidityPredicateConfig::BlockNumber { op: "==".into(), value: "1".into() };
         assert!(config.to_template().is_err());
     }
 

--- a/crates/infra/load-tests/src/config/validity.rs
+++ b/crates/infra/load-tests/src/config/validity.rs
@@ -58,6 +58,20 @@ pub enum ValidityPredicateConfig {
         /// Right-hand comparison value (hex or decimal).
         value: String,
     },
+    /// Compares the number of the block being built with a value.
+    BlockNumber {
+        /// Comparison operator (`<`, `<=`, `=`, `!=`, `>`, `>=`).
+        op: String,
+        /// Right-hand comparison value (hex or decimal).
+        value: String,
+    },
+    /// Compares the index of the flashblock being built with a value.
+    FlashblockIndex {
+        /// Comparison operator (`<`, `<=`, `=`, `!=`, `>`, `>=`).
+        op: String,
+        /// Right-hand comparison value (hex or decimal).
+        value: String,
+    },
 }
 
 /// Source for a predicate's address, resolved per transaction at prepare time.
@@ -175,6 +189,14 @@ impl ValidityPredicateConfig {
                     value: parse_u256_hex_or_dec(value, "validity storage value")?,
                 })
             }
+            Self::BlockNumber { op, value } => Ok(ValidityPredicateTemplate::BlockNumber {
+                op: parse_operator(op)?,
+                value: parse_u256_hex_or_dec(value, "validity block_number value")?,
+            }),
+            Self::FlashblockIndex { op, value } => Ok(ValidityPredicateTemplate::FlashblockIndex {
+                op: parse_operator(op)?,
+                value: parse_u256_hex_or_dec(value, "validity flashblock_index value")?,
+            }),
         }
     }
 }
@@ -296,6 +318,38 @@ mod tests {
             }
             other => panic!("expected mapping template, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn block_number_predicate_to_template() {
+        let config = ValidityPredicateConfig::BlockNumber { op: ">=".into(), value: "0x100".into() };
+        match config.to_template().unwrap() {
+            ValidityPredicateTemplate::BlockNumber { op, value } => {
+                assert_eq!(op, ValidityOperator::GreaterThanOrEqual);
+                assert_eq!(value, U256::from(0x100));
+            }
+            other => panic!("expected block_number template, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn flashblock_index_predicate_to_template() {
+        let config =
+            ValidityPredicateConfig::FlashblockIndex { op: "=".into(), value: "2".into() };
+        match config.to_template().unwrap() {
+            ValidityPredicateTemplate::FlashblockIndex { op, value } => {
+                assert_eq!(op, ValidityOperator::Equal);
+                assert_eq!(value, U256::from(2));
+            }
+            other => panic!("expected flashblock_index template, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn position_predicate_surfaces_bad_operator() {
+        let config =
+            ValidityPredicateConfig::BlockNumber { op: "==".into(), value: "1".into() };
+        assert!(config.to_template().is_err());
     }
 
     #[test]

--- a/crates/infra/load-tests/src/runner/config.rs
+++ b/crates/infra/load-tests/src/runner/config.rs
@@ -65,6 +65,28 @@ pub enum ValidityPredicateTemplate {
         /// Right-hand comparison value.
         value: U256,
     },
+    /// Block-number comparison template.
+    ///
+    /// Carries no address or slot: the block being built is read from the
+    /// builder's context, so this template resolves to the same predicate for
+    /// every transaction.
+    BlockNumber {
+        /// Comparison operator.
+        op: ValidityOperator,
+        /// Right-hand comparison value.
+        value: U256,
+    },
+    /// Flashblock-index comparison template.
+    ///
+    /// Carries no address or slot: the flashblock being built is read from the
+    /// builder's context, so this template resolves to the same predicate for
+    /// every transaction.
+    FlashblockIndex {
+        /// Comparison operator.
+        op: ValidityOperator,
+        /// Right-hand comparison value.
+        value: U256,
+    },
 }
 
 /// Configuration for a single transaction type with its weight.

--- a/crates/infra/load-tests/src/runner/validity_router.rs
+++ b/crates/infra/load-tests/src/runner/validity_router.rs
@@ -90,6 +90,14 @@ impl ValidityRouter {
                     value: *value,
                 }
             }
+            // Position predicates read the build context, not `from`/`to`, so
+            // they resolve identically for every transaction.
+            ValidityPredicateTemplate::BlockNumber { op, value } => {
+                ValidityPredicate::BlockNumber { op: *op, value: *value }
+            }
+            ValidityPredicateTemplate::FlashblockIndex { op, value } => {
+                ValidityPredicate::FlashblockIndex { op: *op, value: *value }
+            }
         }
     }
 }
@@ -225,6 +233,39 @@ mod tests {
             ValidityPredicate::Balance { address, .. } => assert_eq!(*address, to),
             other => panic!("expected balance, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn position_predicates_resolve_independent_of_addresses() {
+        let templates = vec![
+            ValidityPredicateTemplate::BlockNumber {
+                op: ValidityOperator::GreaterThanOrEqual,
+                value: U256::from(100),
+            },
+            ValidityPredicateTemplate::FlashblockIndex {
+                op: ValidityOperator::Equal,
+                value: U256::from(2),
+            },
+        ];
+        let r = router(1.0, templates);
+        let predicates = r.predicates_for(
+            SubmitCohort::ValidityPass,
+            Address::repeat_byte(0xaa),
+            Some(Address::repeat_byte(0xbb)),
+        );
+        assert_eq!(
+            predicates,
+            vec![
+                ValidityPredicate::BlockNumber {
+                    op: ValidityOperator::GreaterThanOrEqual,
+                    value: U256::from(100),
+                },
+                ValidityPredicate::FlashblockIndex {
+                    op: ValidityOperator::Equal,
+                    value: U256::from(2),
+                },
+            ],
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The load-test tooling previously exposed only balance and storage validity predicates, exercising two of the server's four predicate types and leaving the build-position predicates (block_number, flashblock_index) — and the builder expiry/eviction paths they drive — without any load-test coverage. This adds block_number and flashblock_index variants to the validity predicate config, the runtime template, and the router, mirroring the server enum. These predicates carry only an operator and value and read the build context, so they resolve to the same predicate for every transaction regardless of from/to. It also lays the groundwork for BASE-164 delayed-validity transactions, which express a fixed future validity time as a block_number lower bound. The README validity section documents the new types and unit tests cover config parsing and router resolution.