### PR TITLE
feat(load-tests): Submit Fixed-Future Validity Transactions

### DIFF
--- a/crates/infra/load-tests/README.md
+++ b/crates/infra/load-tests/README.md
@@ -360,6 +360,28 @@ The final summary's `by_cohort` breakdown reports confirmed transactions split
 across the `plain` and `validity_pass` cohorts, so plain traffic can be compared
 against validity traffic when the workload is enabled.
 
+##### Delayed (fixed future) validity
+
+Set `future_validity_delay` to make the whole validity cohort become valid at the
+same future block, producing a predictable, precisely-timed sequencer load spike:
+
+```yaml
+validity:
+  ratio: 1.0
+  future_validity_delay: "10s"   # e.g. 10 seconds ahead of run start
+  predicates: []                  # optional; the delay adds its own predicate
+```
+
+At run start the tool reads the current chain tip and freezes one absolute target
+block, `tip + ceil(future_validity_delay / block_time)` (at least one block
+ahead). That single target is attached to every validity transaction as a
+`block_number >= target` predicate, so the whole cohort parks in the pool until
+the target block and then activates together — letting you craft a precise
+transaction pool for a given block. Because one absolute target is shared, the
+cohort stays simultaneous even if `block_time` is approximate (that only shifts
+which wall-clock second the spike lands). The delay consumes one predicate slot,
+requires `ratio > 0`, and may be used with no other predicates configured.
+
 **Required flags for end-to-end evaluation.** For predicates to actually be
 evaluated (not merely transported), the target environment must be configured so
 that:

--- a/crates/infra/load-tests/src/config/test_config.rs
+++ b/crates/infra/load-tests/src/config/test_config.rs
@@ -1380,10 +1380,7 @@ validity:
 "#;
         let config = TestConfig::from_yaml(yaml).unwrap();
         let load_config = config.to_load_config(Some(1337)).unwrap();
-        assert_eq!(
-            load_config.validity_future_delay,
-            Some(std::time::Duration::from_secs(10)),
-        );
+        assert_eq!(load_config.validity_future_delay, Some(std::time::Duration::from_secs(10)),);
         // Delay alone satisfies the "non-empty predicates when enabled" rule.
         assert!(load_config.validity_predicates.is_empty());
     }

--- a/crates/infra/load-tests/src/config/test_config.rs
+++ b/crates/infra/load-tests/src/config/test_config.rs
@@ -666,6 +666,7 @@ impl TestConfig {
             fresh_recipient_ratio: self.fresh_recipient_ratio,
             validity_ratio: self.validity.ratio,
             validity_predicates: self.validity.to_templates()?,
+            validity_future_delay: self.validity.future_delay()?,
         })
     }
 
@@ -1365,6 +1366,26 @@ validity:
         let summary = config.to_summary();
         assert_eq!(summary.validity_ratio, 0.25);
         assert_eq!(summary.validity_predicate_count, 2);
+    }
+
+    #[test]
+    fn validity_future_delay_threads_into_load_config() {
+        let yaml = r#"
+transaction_submission_rpcs: http://localhost:8545
+flashblocks_ws: ws://localhost:7111
+block_time: 2s
+validity:
+  ratio: 1.0
+  future_validity_delay: "10s"
+"#;
+        let config = TestConfig::from_yaml(yaml).unwrap();
+        let load_config = config.to_load_config(Some(1337)).unwrap();
+        assert_eq!(
+            load_config.validity_future_delay,
+            Some(std::time::Duration::from_secs(10)),
+        );
+        // Delay alone satisfies the "non-empty predicates when enabled" rule.
+        assert!(load_config.validity_predicates.is_empty());
     }
 
     #[test]

--- a/crates/infra/load-tests/src/config/validity.rs
+++ b/crates/infra/load-tests/src/config/validity.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use base_execution_txpool::{DEFAULT_MAX_VALIDITY_PREDICATES, ValidityOperator};
 use serde::{Deserialize, Serialize};
 
@@ -24,6 +26,19 @@ pub struct ValidityConfig {
     /// Must be non-empty when `ratio > 0`, and must contain at most
     /// [`DEFAULT_MAX_VALIDITY_PREDICATES`] entries.
     pub predicates: Vec<ValidityPredicateConfig>,
+
+    /// Optional fixed future validity delay (e.g. `"10s"`) applied to the whole
+    /// validity cohort.
+    ///
+    /// When set, one absolute target block is computed at run start
+    /// (`tip + ceil(delay / block_time)`, at least one block ahead) and frozen
+    /// into every validity transaction as a `block_number >= target` predicate,
+    /// so the entire cohort parks until that block and then becomes valid
+    /// simultaneously — a predictable, precisely-timed sequencer load spike.
+    /// Requires `ratio > 0` and consumes one of the
+    /// [`DEFAULT_MAX_VALIDITY_PREDICATES`] predicate slots.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub future_validity_delay: Option<String>,
 }
 
 /// A configured validity predicate template.
@@ -137,20 +152,47 @@ pub enum PredicateSlotConfig {
 }
 
 impl ValidityConfig {
+    /// Parses the configured future validity delay, if any.
+    ///
+    /// Returns `None` when unset or blank. Surfaces a config error for an
+    /// unparseable humantime string.
+    pub fn future_delay(&self) -> Result<Option<Duration>> {
+        self.future_validity_delay
+            .as_deref()
+            .map(str::trim)
+            .filter(|delay| !delay.is_empty())
+            .map(|delay| {
+                humantime::parse_duration(delay).map_err(|e| {
+                    BaselineError::Config(format!(
+                        "invalid validity.future_validity_delay '{delay}': {e}"
+                    ))
+                })
+            })
+            .transpose()
+    }
+
     /// Validates the validity configuration.
     pub fn validate(&self) -> Result<()> {
         if !(0.0..=1.0).contains(&self.ratio) {
             return Err(BaselineError::Config("validity.ratio must be between 0.0 and 1.0".into()));
         }
-        if self.predicates.len() > DEFAULT_MAX_VALIDITY_PREDICATES {
+        // A configured future delay adds one `block_number` predicate to every
+        // validity transaction, so it consumes a predicate slot.
+        let future_delay = self.future_delay()?;
+        let effective_predicates = self.predicates.len() + usize::from(future_delay.is_some());
+        if effective_predicates > DEFAULT_MAX_VALIDITY_PREDICATES {
             return Err(BaselineError::Config(format!(
-                "validity.predicates has {} entries, exceeding the maximum of {DEFAULT_MAX_VALIDITY_PREDICATES}",
-                self.predicates.len()
+                "validity carries {effective_predicates} predicates (including the future-validity target), exceeding the maximum of {DEFAULT_MAX_VALIDITY_PREDICATES}"
             )));
         }
-        if self.ratio > 0.0 && self.predicates.is_empty() {
+        if self.ratio > 0.0 && self.predicates.is_empty() && future_delay.is_none() {
             return Err(BaselineError::Config(
-                "validity.predicates must be non-empty when validity.ratio > 0".into(),
+                "validity.predicates must be non-empty when validity.ratio > 0 (unless validity.future_validity_delay is set)".into(),
+            ));
+        }
+        if future_delay.is_some() && self.ratio <= 0.0 {
+            return Err(BaselineError::Config(
+                "validity.future_validity_delay requires validity.ratio > 0".into(),
             ));
         }
         // Surface parse errors (operators, addresses, values) eagerly.
@@ -381,6 +423,7 @@ mod tests {
         let config = ValidityConfig {
             ratio: 1.0,
             predicates: vec![predicate; DEFAULT_MAX_VALIDITY_PREDICATES + 1],
+            ..Default::default()
         };
         let err = config.validate().unwrap_err();
         assert!(err.to_string().contains("exceeding the maximum"));
@@ -395,7 +438,72 @@ mod tests {
                 op: "==".into(),
                 value: "0".into(),
             }],
+            ..Default::default()
         };
         assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn future_delay_parses_humantime() {
+        let config = ValidityConfig {
+            future_validity_delay: Some("10s".into()),
+            ..Default::default()
+        };
+        assert_eq!(config.future_delay().unwrap(), Some(Duration::from_secs(10)));
+    }
+
+    #[test]
+    fn future_delay_is_none_when_unset_or_blank() {
+        assert_eq!(ValidityConfig::default().future_delay().unwrap(), None);
+        let blank = ValidityConfig { future_validity_delay: Some("  ".into()), ..Default::default() };
+        assert_eq!(blank.future_delay().unwrap(), None);
+    }
+
+    #[test]
+    fn validate_rejects_unparseable_future_delay() {
+        let config = ValidityConfig {
+            ratio: 1.0,
+            predicates: vec![balance_ge_zero()],
+            future_validity_delay: Some("soon".into()),
+        };
+        assert!(config.validate().unwrap_err().to_string().contains("future_validity_delay"));
+    }
+
+    #[test]
+    fn validate_allows_future_delay_without_configured_predicates() {
+        let config = ValidityConfig {
+            ratio: 1.0,
+            predicates: Vec::new(),
+            future_validity_delay: Some("10s".into()),
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_future_delay_without_ratio() {
+        let config = ValidityConfig {
+            ratio: 0.0,
+            predicates: Vec::new(),
+            future_validity_delay: Some("10s".into()),
+        };
+        assert!(config.validate().unwrap_err().to_string().contains("requires validity.ratio > 0"));
+    }
+
+    #[test]
+    fn validate_counts_future_target_against_predicate_maximum() {
+        let config = ValidityConfig {
+            ratio: 1.0,
+            predicates: vec![balance_ge_zero(); DEFAULT_MAX_VALIDITY_PREDICATES],
+            future_validity_delay: Some("10s".into()),
+        };
+        assert!(config.validate().unwrap_err().to_string().contains("exceeding the maximum"));
+    }
+
+    fn balance_ge_zero() -> ValidityPredicateConfig {
+        ValidityPredicateConfig::Balance {
+            address: PredicateAddressConfig::Sender,
+            op: ">=".into(),
+            value: "0".into(),
+        }
     }
 }

--- a/crates/infra/load-tests/src/config/validity.rs
+++ b/crates/infra/load-tests/src/config/validity.rs
@@ -364,7 +364,8 @@ mod tests {
 
     #[test]
     fn block_number_predicate_to_template() {
-        let config = ValidityPredicateConfig::BlockNumber { op: ">=".into(), value: "0x100".into() };
+        let config =
+            ValidityPredicateConfig::BlockNumber { op: ">=".into(), value: "0x100".into() };
         match config.to_template().unwrap() {
             ValidityPredicateTemplate::BlockNumber { op, value } => {
                 assert_eq!(op, ValidityOperator::GreaterThanOrEqual);
@@ -376,8 +377,7 @@ mod tests {
 
     #[test]
     fn flashblock_index_predicate_to_template() {
-        let config =
-            ValidityPredicateConfig::FlashblockIndex { op: "=".into(), value: "2".into() };
+        let config = ValidityPredicateConfig::FlashblockIndex { op: "=".into(), value: "2".into() };
         match config.to_template().unwrap() {
             ValidityPredicateTemplate::FlashblockIndex { op, value } => {
                 assert_eq!(op, ValidityOperator::Equal);
@@ -389,8 +389,7 @@ mod tests {
 
     #[test]
     fn position_predicate_surfaces_bad_operator() {
-        let config =
-            ValidityPredicateConfig::BlockNumber { op: "==".into(), value: "1".into() };
+        let config = ValidityPredicateConfig::BlockNumber { op: "==".into(), value: "1".into() };
         assert!(config.to_template().is_err());
     }
 
@@ -445,17 +444,16 @@ mod tests {
 
     #[test]
     fn future_delay_parses_humantime() {
-        let config = ValidityConfig {
-            future_validity_delay: Some("10s".into()),
-            ..Default::default()
-        };
+        let config =
+            ValidityConfig { future_validity_delay: Some("10s".into()), ..Default::default() };
         assert_eq!(config.future_delay().unwrap(), Some(Duration::from_secs(10)));
     }
 
     #[test]
     fn future_delay_is_none_when_unset_or_blank() {
         assert_eq!(ValidityConfig::default().future_delay().unwrap(), None);
-        let blank = ValidityConfig { future_validity_delay: Some("  ".into()), ..Default::default() };
+        let blank =
+            ValidityConfig { future_validity_delay: Some("  ".into()), ..Default::default() };
         assert_eq!(blank.future_delay().unwrap(), None);
     }
 

--- a/crates/infra/load-tests/src/lib.rs
+++ b/crates/infra/load-tests/src/lib.rs
@@ -21,8 +21,8 @@ pub use utils::{BaselineError, Result};
 mod rpc;
 pub use rpc::{
     BaseFeeExt, BatchRpcClient, BatchSendError, BatchSendResult, JSON_RPC_METHOD_NOT_FOUND,
-    MAX_BATCH_RPC_SIZE, QueryProvider, RPC_TIMEOUT, RpcProviders, RpcResultExt, SubmitItem,
-    TxpoolAdminClient, WalletProvider, create_wallet_provider,
+    LatestBlockExt, MAX_BATCH_RPC_SIZE, QueryProvider, RPC_TIMEOUT, RpcProviders, RpcResultExt,
+    SubmitItem, TxpoolAdminClient, WalletProvider, create_wallet_provider,
 };
 
 mod metrics;

--- a/crates/infra/load-tests/src/rpc/client.rs
+++ b/crates/infra/load-tests/src/rpc/client.rs
@@ -81,6 +81,21 @@ impl BaseFeeExt for QueryProvider {
     }
 }
 
+/// Extension trait for reading the current chain tip from a query provider.
+pub trait LatestBlockExt {
+    /// Returns the number of the latest block.
+    ///
+    /// Used to anchor a future-validity target block against the observed tip at
+    /// run start.
+    fn latest_block_number(&self) -> impl std::future::Future<Output = Result<u64>> + Send;
+}
+
+impl LatestBlockExt for QueryProvider {
+    async fn latest_block_number(&self) -> Result<u64> {
+        self.get_block_number().await.rpc("get latest block number")
+    }
+}
+
 /// Extension trait for converting Alloy RPC results into load-test errors.
 pub trait RpcResultExt<T> {
     /// Converts an RPC result into the load-test result type with context.

--- a/crates/infra/load-tests/src/rpc/mod.rs
+++ b/crates/infra/load-tests/src/rpc/mod.rs
@@ -3,6 +3,6 @@
 mod client;
 pub use client::{
     BaseFeeExt, BatchRpcClient, BatchSendError, BatchSendResult, JSON_RPC_METHOD_NOT_FOUND,
-    MAX_BATCH_RPC_SIZE, QueryProvider, RPC_TIMEOUT, RpcProviders, RpcResultExt, SubmitItem,
-    TxpoolAdminClient, WalletProvider, create_wallet_provider,
+    LatestBlockExt, MAX_BATCH_RPC_SIZE, QueryProvider, RPC_TIMEOUT, RpcProviders, RpcResultExt,
+    SubmitItem, TxpoolAdminClient, WalletProvider, create_wallet_provider,
 };

--- a/crates/infra/load-tests/src/runner/config.rs
+++ b/crates/infra/load-tests/src/runner/config.rs
@@ -252,6 +252,12 @@ pub struct LoadConfig {
     pub validity_ratio: f64,
     /// Predicate templates attached to each validity-bearing transaction.
     pub validity_predicates: Vec<ValidityPredicateTemplate>,
+    /// Optional fixed future validity delay for the validity cohort.
+    ///
+    /// When set, one absolute target block is frozen at run start and attached to
+    /// every validity transaction as a `block_number >= target` predicate, so the
+    /// cohort becomes valid simultaneously at that block.
+    pub validity_future_delay: Option<Duration>,
 }
 
 impl LoadConfig {
@@ -283,6 +289,7 @@ impl LoadConfig {
             fresh_recipient_ratio: 0.0,
             validity_ratio: 0.0,
             validity_predicates: Vec::new(),
+            validity_future_delay: None,
         }
     }
 
@@ -334,15 +341,27 @@ impl LoadConfig {
         if !(0.0..=1.0).contains(&self.validity_ratio) {
             return Err(BaselineError::Config("validity_ratio must be between 0.0 and 1.0".into()));
         }
-        if self.validity_predicates.len() > base_execution_txpool::DEFAULT_MAX_VALIDITY_PREDICATES {
+        // A configured future validity delay adds one `block_number` predicate to
+        // every validity transaction, so it consumes a predicate slot.
+        let effective_predicates =
+            self.validity_predicates.len() + usize::from(self.validity_future_delay.is_some());
+        if effective_predicates > base_execution_txpool::DEFAULT_MAX_VALIDITY_PREDICATES {
             return Err(BaselineError::Config(format!(
-                "validity_predicates exceeds the maximum of {}",
+                "validity_predicates (including the future-validity target) exceeds the maximum of {}",
                 base_execution_txpool::DEFAULT_MAX_VALIDITY_PREDICATES
             )));
         }
-        if self.validity_ratio > 0.0 && self.validity_predicates.is_empty() {
+        if self.validity_ratio > 0.0
+            && self.validity_predicates.is_empty()
+            && self.validity_future_delay.is_none()
+        {
             return Err(BaselineError::Config(
                 "validity_predicates must be non-empty when validity_ratio > 0".into(),
+            ));
+        }
+        if self.validity_future_delay.is_some() && self.validity_ratio <= 0.0 {
+            return Err(BaselineError::Config(
+                "validity_future_delay requires validity_ratio > 0".into(),
             ));
         }
         if self.transactions.is_empty() {

--- a/crates/infra/load-tests/src/runner/pacing.rs
+++ b/crates/infra/load-tests/src/runner/pacing.rs
@@ -36,7 +36,7 @@ use super::{
 use crate::{
     BaselineError, Result,
     metrics::{MetricsCollector, MetricsSummary, PacingCycleObservation, PacingCycleSource},
-    rpc::BaseFeeExt,
+    rpc::{BaseFeeExt, LatestBlockExt},
     workload::{KeyStream, SeededRng, WorkloadGenerator},
 };
 
@@ -405,6 +405,22 @@ impl LoadRunner {
 
         if !self.validity_router.is_disabled() {
             self.probe_validity_endpoint().await?;
+            // Freeze one absolute target block for the whole validity cohort so
+            // every validity transaction carries the same `block_number >= target`
+            // predicate and the cohort becomes valid simultaneously. Done before
+            // the router is cloned into per-sender submission state below.
+            if let Some(delay) = self.config.validity_future_delay {
+                let tip = self.client.latest_block_number().await?;
+                let target =
+                    ValidityRouter::future_target_block(tip, delay, self.config.block_time);
+                self.validity_router.set_target_block(target);
+                info!(
+                    tip,
+                    target_block = target,
+                    delay_secs = delay.as_secs_f64(),
+                    "froze future validity target block"
+                );
+            }
         }
 
         for account in self.accounts.accounts() {

--- a/crates/infra/load-tests/src/runner/validity_router.rs
+++ b/crates/infra/load-tests/src/runner/validity_router.rs
@@ -6,8 +6,10 @@
 //! templates are resolved into concrete [`ValidityPredicate`] values against
 //! each transaction's `from`/`to` at prepare time.
 
+use std::time::Duration;
+
 use alloy_primitives::{Address, B256, U256, keccak256};
-use base_execution_txpool::ValidityPredicate;
+use base_execution_txpool::{ValidityOperator, ValidityPredicate};
 
 use super::{LoadConfig, PredicateAddress, SlotTemplate, SubmitCohort, ValidityPredicateTemplate};
 
@@ -20,6 +22,10 @@ pub struct ValidityRouter {
     ratio: f64,
     predicates: Vec<ValidityPredicateTemplate>,
     seed: u64,
+    /// Absolute block at which the whole validity cohort becomes valid, when a
+    /// future validity delay is configured. Frozen once at run start so every
+    /// cloned router shares the same target and the cohort activates together.
+    target_block: Option<u64>,
 }
 
 impl ValidityRouter {
@@ -29,12 +35,40 @@ impl ValidityRouter {
             ratio: config.validity_ratio,
             predicates: config.validity_predicates.clone(),
             seed: config.seed,
+            target_block: None,
         }
     }
 
     /// Returns true when no transaction will ever be routed to the validity path.
     pub fn is_disabled(&self) -> bool {
         self.ratio <= 0.0
+    }
+
+    /// Computes the absolute target block for a future validity delay.
+    ///
+    /// The delay is rounded up to whole blocks using `block_time` and clamped to
+    /// at least one block ahead of `tip`, so transactions are submitted and
+    /// parked before the target block is built. Block-time inaccuracy only shifts
+    /// which wall-clock second the cohort activates, not its simultaneity: every
+    /// transaction shares this one absolute target.
+    #[must_use]
+    pub fn future_target_block(tip: u64, delay: Duration, block_time: Duration) -> u64 {
+        let block_ms = block_time.as_millis().max(1);
+        let delay_blocks = delay.as_millis().div_ceil(block_ms).max(1);
+        tip.saturating_add(u64::try_from(delay_blocks).unwrap_or(u64::MAX))
+    }
+
+    /// Freezes the absolute block at which the validity cohort becomes valid.
+    ///
+    /// Call before the router is cloned into per-sender submission state so every
+    /// validity transaction carries the same `block_number >= target` predicate.
+    pub const fn set_target_block(&mut self, target_block: u64) {
+        self.target_block = Some(target_block);
+    }
+
+    /// Returns the frozen future-validity target block, if any.
+    pub const fn target_block(&self) -> Option<u64> {
+        self.target_block
     }
 
     /// Determines the submission cohort for a sender.
@@ -61,7 +95,18 @@ impl ValidityRouter {
     ) -> Vec<ValidityPredicate> {
         match cohort {
             SubmitCohort::ValidityPass => {
-                self.predicates.iter().map(|t| Self::resolve(t, from, to)).collect()
+                let mut predicates: Vec<ValidityPredicate> =
+                    self.predicates.iter().map(|t| Self::resolve(t, from, to)).collect();
+                // Every validity transaction shares the frozen future target, so
+                // the whole cohort parks until that block and then activates
+                // together.
+                if let Some(target) = self.target_block {
+                    predicates.push(ValidityPredicate::BlockNumber {
+                        op: ValidityOperator::GreaterThanOrEqual,
+                        value: U256::from(target),
+                    });
+                }
+                predicates
             }
             SubmitCohort::Plain => Vec::new(),
         }
@@ -159,7 +204,7 @@ mod tests {
     use super::*;
 
     fn router(ratio: f64, predicates: Vec<ValidityPredicateTemplate>) -> ValidityRouter {
-        ValidityRouter { ratio, predicates, seed: 12345 }
+        ValidityRouter { ratio, predicates, seed: 12345, target_block: None }
     }
 
     #[test]
@@ -266,6 +311,62 @@ mod tests {
                 },
             ],
         );
+    }
+
+    #[test]
+    fn future_target_block_rounds_up_and_clamps_to_one_block() {
+        let bt = Duration::from_secs(2);
+        // 10s / 2s = 5 blocks ahead.
+        assert_eq!(ValidityRouter::future_target_block(100, Duration::from_secs(10), bt), 105);
+        // 9s / 2s rounds up to 5 blocks.
+        assert_eq!(ValidityRouter::future_target_block(100, Duration::from_secs(9), bt), 105);
+        // A sub-block delay still lands at least one block ahead.
+        assert_eq!(ValidityRouter::future_target_block(100, Duration::from_millis(1), bt), 101);
+        // A zero delay is clamped to one block ahead so txs park before the target.
+        assert_eq!(ValidityRouter::future_target_block(100, Duration::ZERO, bt), 101);
+    }
+
+    #[test]
+    fn frozen_target_appends_block_number_predicate_to_validity_cohort() {
+        let mut r = router(
+            1.0,
+            vec![ValidityPredicateTemplate::Balance {
+                address: PredicateAddress::Sender,
+                op: ValidityOperator::GreaterThanOrEqual,
+                value: U256::ZERO,
+            }],
+        );
+        r.set_target_block(500);
+        assert_eq!(r.target_block(), Some(500));
+
+        let from = Address::repeat_byte(0xaa);
+        let predicates = r.predicates_for(SubmitCohort::ValidityPass, from, None);
+        assert_eq!(predicates.len(), 2, "configured predicate plus the frozen target");
+        assert_eq!(
+            predicates[1],
+            ValidityPredicate::BlockNumber {
+                op: ValidityOperator::GreaterThanOrEqual,
+                value: U256::from(500),
+            },
+        );
+
+        // The plain cohort never carries the target predicate.
+        assert!(r.predicates_for(SubmitCohort::Plain, from, None).is_empty());
+    }
+
+    #[test]
+    fn without_frozen_target_no_extra_predicate_is_added() {
+        let r = router(
+            1.0,
+            vec![ValidityPredicateTemplate::Balance {
+                address: PredicateAddress::Sender,
+                op: ValidityOperator::GreaterThanOrEqual,
+                value: U256::ZERO,
+            }],
+        );
+        let predicates =
+            r.predicates_for(SubmitCohort::ValidityPass, Address::repeat_byte(0xaa), None);
+        assert_eq!(predicates.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements BASE-164: an optional `validity.future_validity_delay` knob that makes the whole validity cohort become valid at the same future block, producing a predictable, precisely-timed sequencer load spike. At run start the tool reads the chain tip and freezes one absolute target block (`tip + ceil(delay / block_time)`, at least one block ahead) into the router before it is cloned per sender, so every validity transaction carries the same `block_number >= target` predicate and the cohort parks until that block and then activates together. This keeps the cohort simultaneous even when block_time is approximate, since one absolute target is shared. The delay threads through the config, LoadConfig, and to_load_config, adds LatestBlockExt::latest_block_number to the RPC client, and is validated to require ratio > 0 and to count its appended predicate against the maximum (a delay alone satisfies the non-empty-predicates rule). Documented in the README with unit tests for target computation, predicate injection, config parsing, and validation.

Stacked on #4614 (position predicates) since it builds on the same router and config; review after that merges. Metrics proving the spike landed at the target follow in a separate PR.