### PR TITLE
feat(load-tests): Report Validity Spike Metrics

### DIFF
--- a/crates/infra/load-tests/README.md
+++ b/crates/infra/load-tests/README.md
@@ -382,6 +382,13 @@ cohort stays simultaneous even if `block_time` is approximate (that only shifts
 which wall-clock second the spike lands). The delay consumes one predicate slot,
 requires `ratio > 0`, and may be used with no other predicates configured.
 
+When a delay is set, the summary reports the resolved `validity_target_block` in
+its config block and a `validity_spike` section quantifying how the cohort
+landed: the first block a `validity_pass` transaction confirmed in, its delta
+from the target (`0` = landed exactly at the target), and counts of transactions
+confirming at/after versus before the target (a non-zero "before" count means the
+predicate was not enforced).
+
 **Required flags for end-to-end evaluation.** For predicates to actually be
 evaluated (not merely transported), the target environment must be configured so
 that:

--- a/crates/infra/load-tests/src/config/test_config.rs
+++ b/crates/infra/load-tests/src/config/test_config.rs
@@ -598,6 +598,9 @@ impl TestConfig {
             fresh_recipient_ratio: self.fresh_recipient_ratio,
             validity_ratio: self.validity.ratio,
             validity_predicate_count: self.validity.predicates.len(),
+            validity_future_delay: self.validity.future_validity_delay.clone(),
+            // Resolved at run start from the observed tip; unknown at config time.
+            validity_target_block: None,
             looper_contract: self.looper_contract.clone(),
             swap_token_amount: self.swap_token_amount.clone(),
             b20_mint_amount: self.b20_mint_amount.clone(),

--- a/crates/infra/load-tests/src/lib.rs
+++ b/crates/infra/load-tests/src/lib.rs
@@ -31,7 +31,7 @@ pub use metrics::{
     GasMetrics, LatencyMetrics, MetricsAggregator, MetricsCollector, MetricsSummary,
     PacingCycleObservation, PacingCycleSource, PacingMetrics, ReceiptCoverage, RollingWindow,
     SubmissionStats, SubmitCohortLabel, ThroughputMetrics, ThroughputPercentiles, ThroughputSample,
-    TransactionMetrics,
+    TransactionMetrics, ValiditySpikeMetrics,
 };
 
 mod workload;

--- a/crates/infra/load-tests/src/metrics/aggregator.rs
+++ b/crates/infra/load-tests/src/metrics/aggregator.rs
@@ -104,8 +104,10 @@ impl<'a> MetricsAggregator<'a> {
                 confirmed_before_target += 1;
             }
         }
-        let first_block_delta = first_confirmed_block
-            .map(|block| i64::try_from(block).unwrap_or(i64::MAX) - i64::try_from(target_block).unwrap_or(i64::MAX));
+        let first_block_delta = first_confirmed_block.map(|block| {
+            i64::try_from(block).unwrap_or(i64::MAX)
+                - i64::try_from(target_block).unwrap_or(i64::MAX)
+        });
         ValiditySpikeMetrics {
             target_block,
             first_confirmed_block,

--- a/crates/infra/load-tests/src/metrics/aggregator.rs
+++ b/crates/infra/load-tests/src/metrics/aggregator.rs
@@ -6,6 +6,7 @@ use super::{
     BlockLoadMetrics, BlockRange, CohortMetrics, ConfigSummary, FlashblocksLatencyMetrics,
     GasMetrics, LatencyMetrics, PacingMetrics, SubmissionStats, SubmitCohortLabel,
     ThroughputMetrics, ThroughputPercentiles, ThroughputSample, TransactionMetrics,
+    ValiditySpikeMetrics,
 };
 
 /// Aggregates raw transaction metrics into summary statistics.
@@ -50,6 +51,12 @@ impl<'a> MetricsAggregator<'a> {
         let throughput_duration =
             block_range.block_time_duration(block_time).unwrap_or(wall_clock_duration);
 
+        // Only computed when a future-validity target was frozen for the run.
+        let validity_spike = config
+            .as_ref()
+            .and_then(|config| config.validity_target_block)
+            .map(|target| Self::compute_validity_spike(self.transactions, target));
+
         MetricsSummary {
             config,
             error: None,
@@ -71,6 +78,40 @@ impl<'a> MetricsAggregator<'a> {
             receipt_coverage,
             fresh_recipient_count,
             by_cohort: Self::compute_by_cohort(self.transactions),
+            validity_spike,
+        }
+    }
+
+    /// Summarizes how the `validity_pass` cohort landed relative to a frozen
+    /// future-validity `target_block`, to confirm the intended load spike landed.
+    pub fn compute_validity_spike(
+        transactions: &[TransactionMetrics],
+        target_block: u64,
+    ) -> ValiditySpikeMetrics {
+        let mut first_confirmed_block: Option<u64> = None;
+        let mut confirmed_at_or_after_target = 0u64;
+        let mut confirmed_before_target = 0u64;
+        for transaction in transactions
+            .iter()
+            .filter(|transaction| transaction.cohort == SubmitCohortLabel::ValidityPass)
+        {
+            let Some(block) = transaction.block_number else { continue };
+            first_confirmed_block =
+                Some(first_confirmed_block.map_or(block, |current| current.min(block)));
+            if block >= target_block {
+                confirmed_at_or_after_target += 1;
+            } else {
+                confirmed_before_target += 1;
+            }
+        }
+        let first_block_delta = first_confirmed_block
+            .map(|block| i64::try_from(block).unwrap_or(i64::MAX) - i64::try_from(target_block).unwrap_or(i64::MAX));
+        ValiditySpikeMetrics {
+            target_block,
+            first_confirmed_block,
+            confirmed_at_or_after_target,
+            confirmed_before_target,
+            first_block_delta,
         }
     }
 
@@ -322,6 +363,10 @@ pub struct MetricsSummary {
     /// unless validity transactions were exercised during the run.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub by_cohort: Vec<CohortMetrics>,
+    /// How the delayed-validity cohort landed relative to its frozen target
+    /// block. Present only when a `future_validity_delay` froze a target block.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub validity_spike: Option<ValiditySpikeMetrics>,
 }
 
 impl MetricsSummary {
@@ -446,5 +491,55 @@ mod tests {
         assert_eq!(by_cohort[1].cohort, SubmitCohortLabel::ValidityPass);
         assert_eq!(by_cohort[1].confirmed, 2);
         assert_eq!(by_cohort[1].total_gas, 500);
+    }
+
+    #[test]
+    fn validity_spike_measures_landing_relative_to_target() {
+        // Target block 105. Two validity txs land at 105 and 106; a plain tx at
+        // 104 must be ignored.
+        let transactions = [
+            cohort_transaction(105, 100, SubmitCohortLabel::ValidityPass),
+            cohort_transaction(106, 100, SubmitCohortLabel::ValidityPass),
+            cohort_transaction(104, 100, SubmitCohortLabel::Plain),
+        ];
+
+        let spike = MetricsAggregator::compute_validity_spike(&transactions, 105);
+
+        assert_eq!(spike.target_block, 105);
+        assert_eq!(spike.first_confirmed_block, Some(105));
+        assert_eq!(spike.confirmed_at_or_after_target, 2);
+        assert_eq!(spike.confirmed_before_target, 0);
+        assert_eq!(spike.first_block_delta, Some(0));
+    }
+
+    #[test]
+    fn validity_spike_flags_transactions_landing_before_target() {
+        // A validity tx landing before the target signals the predicate was not
+        // enforced; the delta is negative.
+        let transactions = [
+            cohort_transaction(103, 100, SubmitCohortLabel::ValidityPass),
+            cohort_transaction(107, 100, SubmitCohortLabel::ValidityPass),
+        ];
+
+        let spike = MetricsAggregator::compute_validity_spike(&transactions, 105);
+
+        assert_eq!(spike.first_confirmed_block, Some(103));
+        assert_eq!(spike.confirmed_at_or_after_target, 1);
+        assert_eq!(spike.confirmed_before_target, 1);
+        assert_eq!(spike.first_block_delta, Some(-2));
+    }
+
+    #[test]
+    fn validity_spike_is_none_without_a_target_block() {
+        let transactions = [cohort_transaction(10, 100, SubmitCohortLabel::ValidityPass)];
+        let summary = MetricsAggregator::new(&transactions).summarize(
+            Duration::from_secs(1),
+            SubmissionStats { submitted: 1, failed: 0, failure_reasons: &Default::default() },
+            &[],
+            None,
+            ReceiptCoverage::default(),
+            None,
+        );
+        assert!(summary.validity_spike.is_none());
     }
 }

--- a/crates/infra/load-tests/src/metrics/mod.rs
+++ b/crates/infra/load-tests/src/metrics/mod.rs
@@ -5,7 +5,7 @@ pub use types::{
     BlockLoadMetrics, BlockRange, CohortMetrics, ConfigSummary, FlashblocksLatencyMetrics,
     GasMetrics, LatencyMetrics, PacingCycleObservation, PacingCycleSource, PacingMetrics,
     SubmissionStats, SubmitCohortLabel, ThroughputMetrics, ThroughputPercentiles, ThroughputSample,
-    TransactionMetrics,
+    TransactionMetrics, ValiditySpikeMetrics,
 };
 
 mod rolling_window;

--- a/crates/infra/load-tests/src/metrics/types.rs
+++ b/crates/infra/load-tests/src/metrics/types.rs
@@ -117,6 +117,31 @@ pub struct CohortMetrics {
     pub block_latency: LatencyMetrics,
 }
 
+/// How the delayed-validity cohort landed relative to its frozen target block.
+///
+/// Only produced when a `future_validity_delay` froze a target block, this
+/// quantifies whether the intended load spike landed at the target: the whole
+/// `validity_pass` cohort should first confirm at or after `target_block`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ValiditySpikeMetrics {
+    /// The absolute block the cohort was frozen to activate at.
+    pub target_block: u64,
+    /// First block containing a confirmed `validity_pass` transaction.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_confirmed_block: Option<u64>,
+    /// Confirmed `validity_pass` transactions that landed at or after the target.
+    pub confirmed_at_or_after_target: u64,
+    /// Confirmed `validity_pass` transactions that landed before the target.
+    ///
+    /// Should be zero: the `block_number >= target` predicate forbids earlier
+    /// inclusion, so a non-zero count signals the predicate was not enforced.
+    pub confirmed_before_target: u64,
+    /// `first_confirmed_block - target_block`: `0` means the cohort landed
+    /// exactly at the target, positive means later. `None` when nothing confirmed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_block_delta: Option<i64>,
+}
+
 /// Aggregated throughput metrics.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ThroughputMetrics {
@@ -392,6 +417,13 @@ pub struct ConfigSummary {
     /// Number of predicate templates attached to validity transactions.
     #[serde(default)]
     pub validity_predicate_count: usize,
+    /// Configured fixed future validity delay (e.g. `"10s"`), when set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub validity_future_delay: Option<String>,
+    /// Absolute block the validity cohort was frozen to activate at, resolved at
+    /// run start from the observed tip and `validity_future_delay`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub validity_target_block: Option<u64>,
     /// Address of the precompile looper contract.
     pub looper_contract: Option<String>,
     /// Amount of each swap token per sender (in wei, as string).

--- a/crates/infra/load-tests/src/runner/pacing.rs
+++ b/crates/infra/load-tests/src/runner/pacing.rs
@@ -414,6 +414,11 @@ impl LoadRunner {
                 let target =
                     ValidityRouter::future_target_block(tip, delay, self.config.block_time);
                 self.validity_router.set_target_block(target);
+                // Record the resolved target so the summary can report how the
+                // cohort landed relative to it.
+                if let Some(summary) = self.config_summary.as_mut() {
+                    summary.validity_target_block = Some(target);
+                }
                 info!(
                     tip,
                     target_block = target,


### PR DESCRIPTION
## Summary

Completes BASE-164's observability: surfaces whether the delayed-validity load spike actually landed at its target block. The resolved target block is recorded on the config summary at run start, and a new `validity_spike` summary section reports, over the `validity_pass` cohort, the first block a validity transaction confirmed in, its delta from the target (`0` means it landed exactly at the target), and counts of transactions confirming at/after versus before the target. A non-zero before-target count signals the `block_number` predicate was not enforced. Adds `validity_future_delay` and `validity_target_block` to the config summary, documents the section in the README, and covers the aggregation with unit tests.

Stacked on #4617 (the delayed-validity mechanism), which resolves the target block this measures; review after that merges.