### PR TITLE
feat(audit): classify validity tx events and cover emission paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6368,7 +6368,11 @@ dependencies = [
 name = "base-txpool-rpc"
 version = "0.0.0"
 dependencies = [
+ "alloy-consensus 2.4.1",
+ "alloy-eips 2.4.1",
  "alloy-primitives",
+ "alloy-signer 2.4.1",
+ "alloy-signer-local 2.4.1",
  "base-execution-txpool",
  "base-node-runner",
  "base-observability-events",

--- a/crates/builder/core/Cargo.toml
+++ b/crates/builder/core/Cargo.toml
@@ -216,6 +216,7 @@ test-utils = [
 	"base-execution-rpc/client",
 	"base-node-core/test-utils",
 	"base-node-runner/test-utils",
+	"base-observability-events/test-utils",
 	"ctor",
 	"http-body-util",
 	"hyper",

--- a/crates/builder/core/src/flashblocks/best_txs.rs
+++ b/crates/builder/core/src/flashblocks/best_txs.rs
@@ -326,7 +326,10 @@ mod tests {
         test_utils::{MockTransaction, MockTransactionFactory},
     };
 
-    use crate::{RejectionCache, flashblocks::best_txs::BestFlashblocksTxs};
+    use crate::{
+        RejectionCache,
+        flashblocks::best_txs::{BestFlashblocksTxs, ParkablePayloadTransactions},
+    };
 
     fn test_rejection_cache() -> RejectionCache {
         RejectionCache::new(1000, Duration::from_secs(60))
@@ -377,6 +380,23 @@ mod tests {
         iterator.refresh_iterator(BestPayloadTransactions::new(pool.best()));
         // Check that it's empty
         assert!(iterator.next(()).is_none(), "Iterator should be empty");
+    }
+
+    #[test]
+    fn non_parkable_iterator_reports_parking_capacity_miss() {
+        let mut pool = PendingPool::new(CoinbaseTipOrdering::<MockTransaction>::default());
+        let mut f = MockTransactionFactory::default();
+        pool.add_transaction(Arc::new(f.create_eip1559()), 0);
+
+        let mut iterator = BestFlashblocksTxs::new(
+            BestPayloadTransactions::new(pool.best()),
+            test_rejection_cache(),
+        );
+        assert!(iterator.next(()).is_some());
+        assert!(
+            !iterator.park_current(),
+            "BestPayloadTransactions cannot park, so the builder must emit BUILDER_REJECTED"
+        );
     }
 
     /// This test simulates the nonce-chain gating fix across flashblock boundaries.

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -895,7 +895,7 @@ where
         D: Serialize,
         F: FnOnce() -> D,
     {
-        if GlobalTransactionEventWriter::get().is_none() {
+        if !GlobalTransactionEventWriter::is_recording() {
             return;
         }
         let event_ctx = BuilderTransactionEventContext {
@@ -980,7 +980,7 @@ where
         ctx: &BasePayloadBuilderCtx,
         final_payload: &BaseBuiltPayload,
     ) {
-        if GlobalTransactionEventWriter::get().is_none() {
+        if !GlobalTransactionEventWriter::is_recording() {
             return;
         }
 

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -895,7 +895,7 @@ where
         D: Serialize,
         F: FnOnce() -> D,
     {
-        if !GlobalTransactionEventWriter::is_recording() {
+        if GlobalTransactionEventWriter::get().is_none() {
             return;
         }
         let event_ctx = BuilderTransactionEventContext {
@@ -980,7 +980,7 @@ where
         ctx: &BasePayloadBuilderCtx,
         final_payload: &BaseBuiltPayload,
     ) {
-        if !GlobalTransactionEventWriter::is_recording() {
+        if GlobalTransactionEventWriter::get().is_none() {
             return;
         }
 

--- a/crates/builder/core/src/transaction_events.rs
+++ b/crates/builder/core/src/transaction_events.rs
@@ -510,7 +510,7 @@ pub(crate) fn emit_builder_transaction_event<D, F>(
     D: Serialize,
     F: FnOnce() -> D,
 {
-    if !GlobalTransactionEventWriter::is_recording() {
+    if GlobalTransactionEventWriter::get().is_none() {
         return;
     }
 
@@ -560,7 +560,7 @@ pub(crate) fn emit_builder_payload_event<D, F>(
     D: Serialize,
     F: FnOnce() -> D,
 {
-    if !GlobalTransactionEventWriter::is_recording() {
+    if GlobalTransactionEventWriter::get().is_none() {
         return;
     }
 

--- a/crates/builder/core/src/transaction_events.rs
+++ b/crates/builder/core/src/transaction_events.rs
@@ -510,7 +510,7 @@ pub(crate) fn emit_builder_transaction_event<D, F>(
     D: Serialize,
     F: FnOnce() -> D,
 {
-    if GlobalTransactionEventWriter::get().is_none() {
+    if !GlobalTransactionEventWriter::is_recording() {
         return;
     }
 
@@ -560,7 +560,7 @@ pub(crate) fn emit_builder_payload_event<D, F>(
     D: Serialize,
     F: FnOnce() -> D,
 {
-    if GlobalTransactionEventWriter::get().is_none() {
+    if !GlobalTransactionEventWriter::is_recording() {
         return;
     }
 
@@ -606,6 +606,11 @@ fn serialize_builder_event_data<T: Serialize>(data: BuilderEventData<T>) -> Map<
 
 #[cfg(test)]
 mod tests {
+    use alloy_primitives::{B256, TxHash};
+    use base_observability_events::{
+        TransactionEventBuilder, TransactionEventProducer, TransactionEventType,
+    };
+
     use super::*;
 
     fn context() -> BuilderTransactionEventContext {
@@ -698,6 +703,86 @@ mod tests {
                 ExecutionMeteringLimitExceeded::TransactionExecutionTime(1, 2),
             )),
             "tx_execution_time_exceeded"
+        );
+    }
+
+    #[test]
+    fn deferred_rejected_and_expired_event_payloads_are_distinguishable() {
+        let info = ExecutionInfo::default();
+        let limits = ResourceLimits::default();
+        let deferred = serde_json::to_value(BuilderDeferredEventData::new(
+            "validity_predicate_not_satisfied",
+            "a validity predicate is not satisfied by the current build state",
+            &info,
+            &limits,
+            None,
+        ))
+        .unwrap();
+        let rejected = serde_json::to_value(BuilderRejectedEventData::new(
+            "validity_predicate_not_satisfied",
+            "a validity predicate is not satisfied by the current build state",
+            false,
+            &info,
+            &limits,
+            None,
+        ))
+        .unwrap();
+        let expired = serde_json::to_value(BuilderExpiredEventData::new(
+            "validity_predicate_expired",
+            "a validity predicate can no longer be satisfied at or after the current build position",
+            &info,
+            &limits,
+            None,
+        ))
+        .unwrap();
+
+        assert_eq!(deferred["defer_reason"], "validity_predicate_not_satisfied");
+        assert!(deferred.get("rejection_reason").is_none());
+        assert!(deferred.get("expire_reason").is_none());
+        assert!(!deferred.as_object().unwrap().contains_key("validity_predicates"));
+
+        assert_eq!(rejected["rejection_reason"], "validity_predicate_not_satisfied");
+        assert!(rejected.get("defer_reason").is_none());
+        assert!(rejected.get("expire_reason").is_none());
+        assert!(!rejected.as_object().unwrap().contains_key("validity_predicates"));
+
+        assert_eq!(expired["expire_reason"], "validity_predicate_expired");
+        assert!(expired.get("defer_reason").is_none());
+        assert!(expired.get("rejection_reason").is_none());
+        assert!(!expired.as_object().unwrap().contains_key("validity_predicates"));
+    }
+
+    #[test]
+    fn repark_in_the_same_flashblock_uses_a_distinct_deferred_event_id() {
+        let tx_hash = TxHash::repeat_byte(0x33);
+        let first = TransactionEventBuilder::new(
+            TransactionEventProducer::BaseBuilder,
+            TransactionEventType::BuilderDeferred,
+        )
+        .tx_hash(tx_hash)
+        .payload_id("0x0102030405060708")
+        .id_part("flashblock_index", 2)
+        .id_part("ordering_position", 1)
+        .data_field("defer_reason", serde_json::json!("validity_predicate_not_satisfied"))
+        .build_with_network("base-devnet");
+        let second = TransactionEventBuilder::new(
+            TransactionEventProducer::BaseBuilder,
+            TransactionEventType::BuilderDeferred,
+        )
+        .tx_hash(tx_hash)
+        .payload_id("0x0102030405060708")
+        .id_part("flashblock_index", 2)
+        .id_part("ordering_position", 4)
+        .data_field("defer_reason", serde_json::json!("validity_predicate_not_satisfied"))
+        .build_with_network("base-devnet");
+
+        first.validate().expect("first deferred event should be valid");
+        second.validate().expect("second deferred event should be valid");
+        assert_eq!(first.tx_hash, second.tx_hash);
+        assert_eq!(first.payload_id, second.payload_id);
+        assert_ne!(
+            first.event_id, second.event_id,
+            "promote-and-repark in the same flashblock must emit a second BUILDER_DEFERRED with its own event_id"
         );
     }
 }

--- a/crates/builder/core/src/transaction_events.rs
+++ b/crates/builder/core/src/transaction_events.rs
@@ -606,10 +606,7 @@ fn serialize_builder_event_data<T: Serialize>(data: BuilderEventData<T>) -> Map<
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{B256, TxHash};
-    use base_observability_events::{
-        TransactionEventBuilder, TransactionEventProducer, TransactionEventType,
-    };
+    use alloy_primitives::B256;
 
     use super::*;
 
@@ -750,39 +747,5 @@ mod tests {
         assert!(expired.get("defer_reason").is_none());
         assert!(expired.get("rejection_reason").is_none());
         assert!(!expired.as_object().unwrap().contains_key("validity_predicates"));
-    }
-
-    #[test]
-    fn repark_in_the_same_flashblock_uses_a_distinct_deferred_event_id() {
-        let tx_hash = TxHash::repeat_byte(0x33);
-        let first = TransactionEventBuilder::new(
-            TransactionEventProducer::BaseBuilder,
-            TransactionEventType::BuilderDeferred,
-        )
-        .tx_hash(tx_hash)
-        .payload_id("0x0102030405060708")
-        .id_part("flashblock_index", 2)
-        .id_part("ordering_position", 1)
-        .data_field("defer_reason", serde_json::json!("validity_predicate_not_satisfied"))
-        .build_with_network("base-devnet");
-        let second = TransactionEventBuilder::new(
-            TransactionEventProducer::BaseBuilder,
-            TransactionEventType::BuilderDeferred,
-        )
-        .tx_hash(tx_hash)
-        .payload_id("0x0102030405060708")
-        .id_part("flashblock_index", 2)
-        .id_part("ordering_position", 4)
-        .data_field("defer_reason", serde_json::json!("validity_predicate_not_satisfied"))
-        .build_with_network("base-devnet");
-
-        first.validate().expect("first deferred event should be valid");
-        second.validate().expect("second deferred event should be valid");
-        assert_eq!(first.tx_hash, second.tx_hash);
-        assert_eq!(first.payload_id, second.payload_id);
-        assert_ne!(
-            first.event_id, second.event_id,
-            "promote-and-repark in the same flashblock must emit a second BUILDER_DEFERRED with its own event_id"
-        );
     }
 }

--- a/crates/builder/core/tests/transaction_events.rs
+++ b/crates/builder/core/tests/transaction_events.rs
@@ -1,0 +1,176 @@
+//! Integration tests for AT builder audit-event emission.
+
+#![allow(missing_docs)]
+
+use alloy_eips::eip2718::Encodable2718;
+use alloy_network::TransactionResponse;
+use alloy_primitives::{Address, U256};
+use alloy_provider::Provider;
+use base_builder_core::{
+    BuilderApiExtension, BuilderApiExtensionConfig, BuilderConfig, DEFAULT_MAX_VALIDITY_PREDICATES,
+    test_utils::{ChainDriverExt, LocalInstanceBuilder, ONE_ETH},
+};
+use base_execution_txpool::{
+    TransactionValidity, ValidatedTransaction, ValidityOperator, ValidityPredicate,
+};
+use base_observability_events::{TransactionEventCapture, TransactionEventType};
+
+fn validity_instance() -> LocalInstanceBuilder {
+    LocalInstanceBuilder::new(BuilderConfig::for_tests()).install_ext::<BuilderApiExtension>(
+        BuilderApiExtensionConfig::new(true, DEFAULT_MAX_VALIDITY_PREDICATES),
+    )
+}
+
+#[tokio::test]
+async fn recoverable_predicate_emits_builder_deferred() -> eyre::Result<()> {
+    let capture = TransactionEventCapture::install();
+    let instance = validity_instance().build().await?;
+    let driver = instance.driver().await?;
+    let accounts = driver.fund_accounts(2, ONE_ETH).await?;
+    let watched = Address::random();
+
+    let gated = driver
+        .create_transaction()
+        .with_signer(&accounts[0])
+        .with_nonce(0)
+        .with_to(Address::random())
+        .with_max_priority_fee_per_gas(100)
+        .build()
+        .await;
+    let gated_hash = gated.tx_hash();
+    driver
+        .provider()
+        .raw_request::<_, ()>(
+            "base_insertValidatedTransaction".into(),
+            (ValidatedTransaction {
+                sender: accounts[0].address(),
+                raw: gated.encoded_2718().into(),
+                min_block_number: None,
+                max_block_number: None,
+                min_timestamp: None,
+                max_timestamp: None,
+                extensions: TransactionValidity {
+                    validity: vec![ValidityPredicate::Balance {
+                        address: watched,
+                        op: ValidityOperator::Equal,
+                        value: U256::from_limbs([1, 0, 0, 0]),
+                    }],
+                },
+            },),
+        )
+        .await?;
+
+    let trigger_hash = *driver
+        .create_transaction()
+        .with_signer(&accounts[1])
+        .with_to(watched)
+        .with_value(1)
+        .with_max_priority_fee_per_gas(50)
+        .send()
+        .await?
+        .tx_hash();
+
+    let block = driver.build_new_block().await?;
+    let included: Vec<_> = block
+        .transactions
+        .into_transactions()
+        .filter_map(|transaction| {
+            [gated_hash, trigger_hash]
+                .contains(&transaction.tx_hash())
+                .then(|| transaction.tx_hash())
+        })
+        .collect();
+    assert_eq!(included, [trigger_hash, gated_hash]);
+
+    let gated_types: Vec<_> = capture
+        .events()
+        .into_iter()
+        .filter(|event| event.tx_hash == Some(gated_hash))
+        .map(|event| event.event_type)
+        .collect();
+    assert!(
+        gated_types.contains(&TransactionEventType::BuilderDeferred),
+        "recoverable predicate must emit BUILDER_DEFERRED, got {gated_types:?}"
+    );
+    assert!(
+        !gated_types.contains(&TransactionEventType::BuilderRejected),
+        "parked transactions must not be labeled BUILDER_REJECTED, got {gated_types:?}"
+    );
+    assert!(
+        !gated_types.contains(&TransactionEventType::BuilderExpired),
+        "recoverable predicates must not emit BUILDER_EXPIRED, got {gated_types:?}"
+    );
+    assert!(
+        capture
+            .events()
+            .iter()
+            .filter(|event| event.tx_hash == Some(gated_hash))
+            .all(|event| !event.data.contains_key("validity_predicates")),
+        "downstream builder events must not repeat validity_predicates"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn expired_position_predicate_emits_builder_expired() -> eyre::Result<()> {
+    let capture = TransactionEventCapture::install();
+    let instance = validity_instance().build().await?;
+    let driver = instance.driver().await?;
+    let accounts = driver.fund_accounts(1, ONE_ETH).await?;
+
+    let expired = driver
+        .create_transaction()
+        .with_signer(&accounts[0])
+        .with_nonce(0)
+        .with_to(Address::random())
+        .build()
+        .await;
+    let expired_hash = expired.tx_hash();
+    driver
+        .provider()
+        .raw_request::<_, ()>(
+            "base_insertValidatedTransaction".into(),
+            (ValidatedTransaction {
+                sender: accounts[0].address(),
+                raw: expired.encoded_2718().into(),
+                min_block_number: None,
+                max_block_number: None,
+                min_timestamp: None,
+                max_timestamp: None,
+                extensions: TransactionValidity {
+                    validity: vec![ValidityPredicate::FlashblockIndex {
+                        op: ValidityOperator::LessThan,
+                        value: U256::ZERO,
+                    }],
+                },
+            },),
+        )
+        .await?;
+
+    let block = driver.build_new_block().await?;
+    assert!(
+        !block
+            .transactions
+            .into_transactions()
+            .any(|transaction| transaction.tx_hash() == expired_hash),
+        "expired position predicates must never be included"
+    );
+
+    let expired_types: Vec<_> = capture
+        .events()
+        .into_iter()
+        .filter(|event| event.tx_hash == Some(expired_hash))
+        .map(|event| event.event_type)
+        .collect();
+    assert!(
+        expired_types.contains(&TransactionEventType::BuilderExpired),
+        "terminal position predicates must emit BUILDER_EXPIRED, got {expired_types:?}"
+    );
+    assert!(
+        !expired_types.contains(&TransactionEventType::BuilderDeferred),
+        "expired transactions must not be parked, got {expired_types:?}"
+    );
+
+    Ok(())
+}

--- a/crates/builder/core/tests/transaction_events.rs
+++ b/crates/builder/core/tests/transaction_events.rs
@@ -119,6 +119,10 @@ async fn expired_position_predicate_emits_builder_expired() -> eyre::Result<()> 
     let driver = instance.driver().await?;
     let accounts = driver.fund_accounts(1, ONE_ETH).await?;
 
+    // Pooled transactions never run at flashblock index 0, so a flashblock-index
+    // bound below that is rejected at ingress. A block-number upper bound on the
+    // already-mined head is admitted, then terminal on the next payload build.
+    let latest = driver.latest().await?;
     let expired = driver
         .create_transaction()
         .with_signer(&accounts[0])
@@ -139,9 +143,9 @@ async fn expired_position_predicate_emits_builder_expired() -> eyre::Result<()> 
                 min_timestamp: None,
                 max_timestamp: None,
                 extensions: TransactionValidity {
-                    validity: vec![ValidityPredicate::FlashblockIndex {
-                        op: ValidityOperator::LessThan,
-                        value: U256::ZERO,
+                    validity: vec![ValidityPredicate::BlockNumber {
+                        op: ValidityOperator::LessThanOrEqual,
+                        value: U256::from(latest.header.number),
                     }],
                 },
             },),

--- a/crates/builder/core/tests/transaction_events.rs
+++ b/crates/builder/core/tests/transaction_events.rs
@@ -175,6 +175,10 @@ async fn expired_position_predicate_emits_builder_expired() -> eyre::Result<()> 
         !expired_types.contains(&TransactionEventType::BuilderDeferred),
         "expired transactions must not be parked, got {expired_types:?}"
     );
+    assert!(
+        !expired_types.contains(&TransactionEventType::BuilderRejected),
+        "expired transactions must not be labeled BUILDER_REJECTED, got {expired_types:?}"
+    );
 
     Ok(())
 }

--- a/crates/common/observability-events/Cargo.toml
+++ b/crates/common/observability-events/Cargo.toml
@@ -32,3 +32,4 @@ tempfile.workspace = true
 [features]
 default = [ "metrics" ]
 metrics = [ "base-metrics/metrics", "dep:metrics" ]
+test-utils = []

--- a/crates/common/observability-events/src/emit.rs
+++ b/crates/common/observability-events/src/emit.rs
@@ -1,6 +1,6 @@
 //! Transaction event emission helpers and process-global writer access.
 
-use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::sync::{Mutex, OnceLock};
 
 use alloy_primitives::{B256, TxHash};
 use chrono::Utc;
@@ -14,8 +14,6 @@ use crate::{
 
 static GLOBAL_TRANSACTION_EVENT_WRITER: OnceLock<TransactionEventWriter> = OnceLock::new();
 static GLOBAL_TRANSACTION_EVENT_WRITER_INIT_LOCK: Mutex<()> = Mutex::new(());
-static TEST_CAPTURE_SERIAL: Mutex<()> = Mutex::new(());
-static TEST_CAPTURE_EVENTS: Mutex<Option<Vec<TransactionEvent>>> = Mutex::new(None);
 
 /// Result of initializing the process-global transaction event writer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -70,55 +68,14 @@ impl GlobalTransactionEventWriter {
     }
 
     /// Returns the process-global transaction event writer, if configured.
-    pub fn get() -> Option<&'static TransactionEventWriter> {
-        GLOBAL_TRANSACTION_EVENT_WRITER.get()
-    }
-
-    /// Returns true when a configured writer or an installed test capture would record events.
-    pub fn is_recording() -> bool {
-        Self::get().is_some() || TransactionEventCapture::is_active()
-    }
-}
-
-/// Process-global capture of emitted transaction events for tests.
-///
-/// Installing a capture serializes other capture-using tests so parallel crates do not
-/// interleave recorded events. Production emission is unaffected until a capture is installed.
-#[derive(Debug)]
-pub struct TransactionEventCapture {
-    _serial: MutexGuard<'static, ()>,
-}
-
-impl TransactionEventCapture {
-    /// Installs a process-global event capture, replacing any previously recorded events.
-    pub fn install() -> Self {
-        let serial = TEST_CAPTURE_SERIAL.lock().unwrap_or_else(|err| err.into_inner());
-        *TEST_CAPTURE_EVENTS.lock().unwrap_or_else(|err| err.into_inner()) = Some(Vec::new());
-        Self { _serial: serial }
-    }
-
-    /// Returns true when a test capture is currently installed.
-    pub fn is_active() -> bool {
-        TEST_CAPTURE_EVENTS.lock().map(|guard| guard.is_some()).unwrap_or(false)
-    }
-
-    /// Returns a snapshot of events recorded since this capture was installed.
-    pub fn events(&self) -> Vec<TransactionEvent> {
-        TEST_CAPTURE_EVENTS.lock().ok().and_then(|guard| guard.clone()).unwrap_or_default()
-    }
-
-    fn record(event: &TransactionEvent) {
-        if let Ok(mut guard) = TEST_CAPTURE_EVENTS.lock()
-            && let Some(events) = guard.as_mut()
+    pub fn get() -> Option<TransactionEventWriter> {
+        #[cfg(any(test, feature = "test-utils"))]
         {
-            events.push(event.clone());
+            if let Some(writer) = crate::TransactionEventCapture::installed_writer() {
+                return Some(writer);
+            }
         }
-    }
-}
-
-impl Drop for TransactionEventCapture {
-    fn drop(&mut self) {
-        *TEST_CAPTURE_EVENTS.lock().unwrap_or_else(|err| err.into_inner()) = None;
+        GLOBAL_TRANSACTION_EVENT_WRITER.get().cloned()
     }
 }
 
@@ -272,23 +229,10 @@ impl TransactionEventBuilder {
 
     /// Emits the event through the process-global writer, if configured.
     pub fn emit_global(self) -> Result<TransactionEventEmitOutcome, WriteEventError> {
-        if let Some(writer) = GlobalTransactionEventWriter::get() {
-            let event = self.build(writer);
-            TransactionEventCapture::record(&event);
-            let result = writer.try_write(&event);
-            if let Err(err) = &result {
-                debug!(error = %err, event_type = %event.event_type, "transaction event not written");
-            }
-            return result.map(|()| TransactionEventEmitOutcome::Emitted);
-        }
-
-        if TransactionEventCapture::is_active() {
-            let event = self.build_with_network("test");
-            TransactionEventCapture::record(&event);
-            return Ok(TransactionEventEmitOutcome::Emitted);
-        }
-
-        Ok(TransactionEventEmitOutcome::NotConfigured)
+        let Some(writer) = GlobalTransactionEventWriter::get() else {
+            return Ok(TransactionEventEmitOutcome::NotConfigured);
+        };
+        self.emit_to(&writer)
     }
 }
 
@@ -497,6 +441,7 @@ mod tests {
 
     #[test]
     fn builder_none_writer_is_noop() {
+        let _serial = crate::TransactionEventCapture::hold_serial();
         let result = TransactionEventBuilder::new(
             TransactionEventProducer::BaseRethNode,
             TransactionEventType::Pending,
@@ -560,7 +505,7 @@ mod tests {
 
     #[test]
     fn capture_records_global_emits_without_a_writer() {
-        let capture = super::TransactionEventCapture::install();
+        let capture = crate::TransactionEventCapture::install();
         let tx_hash = TxHash::repeat_byte(0x42);
 
         let result = transaction_event!(

--- a/crates/common/observability-events/src/emit.rs
+++ b/crates/common/observability-events/src/emit.rs
@@ -1,6 +1,6 @@
 //! Transaction event emission helpers and process-global writer access.
 
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Mutex, MutexGuard, OnceLock};
 
 use alloy_primitives::{B256, TxHash};
 use chrono::Utc;
@@ -14,6 +14,8 @@ use crate::{
 
 static GLOBAL_TRANSACTION_EVENT_WRITER: OnceLock<TransactionEventWriter> = OnceLock::new();
 static GLOBAL_TRANSACTION_EVENT_WRITER_INIT_LOCK: Mutex<()> = Mutex::new(());
+static TEST_CAPTURE_SERIAL: Mutex<()> = Mutex::new(());
+static TEST_CAPTURE_EVENTS: Mutex<Option<Vec<TransactionEvent>>> = Mutex::new(None);
 
 /// Result of initializing the process-global transaction event writer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -70,6 +72,53 @@ impl GlobalTransactionEventWriter {
     /// Returns the process-global transaction event writer, if configured.
     pub fn get() -> Option<&'static TransactionEventWriter> {
         GLOBAL_TRANSACTION_EVENT_WRITER.get()
+    }
+
+    /// Returns true when a configured writer or an installed test capture would record events.
+    pub fn is_recording() -> bool {
+        Self::get().is_some() || TransactionEventCapture::is_active()
+    }
+}
+
+/// Process-global capture of emitted transaction events for tests.
+///
+/// Installing a capture serializes other capture-using tests so parallel crates do not
+/// interleave recorded events. Production emission is unaffected until a capture is installed.
+#[derive(Debug)]
+pub struct TransactionEventCapture {
+    _serial: MutexGuard<'static, ()>,
+}
+
+impl TransactionEventCapture {
+    /// Installs a process-global event capture, replacing any previously recorded events.
+    pub fn install() -> Self {
+        let serial = TEST_CAPTURE_SERIAL.lock().unwrap_or_else(|err| err.into_inner());
+        *TEST_CAPTURE_EVENTS.lock().unwrap_or_else(|err| err.into_inner()) = Some(Vec::new());
+        Self { _serial: serial }
+    }
+
+    /// Returns true when a test capture is currently installed.
+    pub fn is_active() -> bool {
+        TEST_CAPTURE_EVENTS.lock().map(|guard| guard.is_some()).unwrap_or(false)
+    }
+
+    /// Returns a snapshot of events recorded since this capture was installed.
+    pub fn events(&self) -> Vec<TransactionEvent> {
+        TEST_CAPTURE_EVENTS.lock().ok().and_then(|guard| guard.clone()).unwrap_or_default()
+    }
+
+    fn record(event: &TransactionEvent) {
+        if let Ok(mut guard) = TEST_CAPTURE_EVENTS.lock()
+            && let Some(events) = guard.as_mut()
+        {
+            events.push(event.clone());
+        }
+    }
+}
+
+impl Drop for TransactionEventCapture {
+    fn drop(&mut self) {
+        *TEST_CAPTURE_EVENTS.lock().unwrap_or_else(|err| err.into_inner()) = None;
     }
 }
 
@@ -223,11 +272,23 @@ impl TransactionEventBuilder {
 
     /// Emits the event through the process-global writer, if configured.
     pub fn emit_global(self) -> Result<TransactionEventEmitOutcome, WriteEventError> {
-        let Some(writer) = GlobalTransactionEventWriter::get() else {
-            return Ok(TransactionEventEmitOutcome::NotConfigured);
-        };
+        if let Some(writer) = GlobalTransactionEventWriter::get() {
+            let event = self.build(writer);
+            TransactionEventCapture::record(&event);
+            let result = writer.try_write(&event);
+            if let Err(err) = &result {
+                debug!(error = %err, event_type = %event.event_type, "transaction event not written");
+            }
+            return result.map(|()| TransactionEventEmitOutcome::Emitted);
+        }
 
-        self.emit_to(writer)
+        if TransactionEventCapture::is_active() {
+            let event = self.build_with_network("test");
+            TransactionEventCapture::record(&event);
+            return Ok(TransactionEventEmitOutcome::Emitted);
+        }
+
+        Ok(TransactionEventEmitOutcome::NotConfigured)
     }
 }
 
@@ -485,6 +546,7 @@ mod tests {
     #[test]
     fn macro_noops_when_global_writer_is_not_configured() {
         let result = transaction_event!(
+            writer: Option::<&TransactionEventWriter>::None,
             producer: TransactionEventProducer::BaseRethNode,
             event_type: TransactionEventType::Pending,
             tx_hash: TxHash::repeat_byte(0x11),
@@ -494,5 +556,27 @@ mod tests {
         );
 
         assert_eq!(result.unwrap(), TransactionEventEmitOutcome::NotConfigured);
+    }
+
+    #[test]
+    fn capture_records_global_emits_without_a_writer() {
+        let capture = super::TransactionEventCapture::install();
+        let tx_hash = TxHash::repeat_byte(0x42);
+
+        let result = transaction_event!(
+            producer: TransactionEventProducer::BaseRethNode,
+            event_type: TransactionEventType::TxpoolSendRawTransactionValidity,
+            tx_hash: tx_hash,
+            data: {
+                "rpc_method" => "base_sendRawTransactionValidity",
+            },
+        );
+
+        assert_eq!(result.unwrap(), TransactionEventEmitOutcome::Emitted);
+        let events = capture.events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type, TransactionEventType::TxpoolSendRawTransactionValidity);
+        assert_eq!(events[0].tx_hash, Some(tx_hash));
+        assert_eq!(events[0].data["rpc_method"], "base_sendRawTransactionValidity");
     }
 }

--- a/crates/common/observability-events/src/emit.rs
+++ b/crates/common/observability-events/src/emit.rs
@@ -63,19 +63,20 @@ impl GlobalTransactionEventWriter {
         }
 
         let writer = TransactionEventWriter::from_config(config)?;
-        let _ = GLOBAL_TRANSACTION_EVENT_WRITER.set(writer);
-        Ok(GlobalTransactionEventWriterInitStatus::Initialized)
+        match GLOBAL_TRANSACTION_EVENT_WRITER.set(writer) {
+            Ok(()) => Ok(GlobalTransactionEventWriterInitStatus::Initialized),
+            Err(_) => Ok(GlobalTransactionEventWriterInitStatus::AlreadyInitialized),
+        }
     }
 
     /// Returns the process-global transaction event writer, if configured.
-    pub fn get() -> Option<TransactionEventWriter> {
-        #[cfg(any(test, feature = "test-utils"))]
-        {
-            if let Some(writer) = crate::TransactionEventCapture::installed_writer() {
-                return Some(writer);
-            }
-        }
-        GLOBAL_TRANSACTION_EVENT_WRITER.get().cloned()
+    pub fn get() -> Option<&'static TransactionEventWriter> {
+        GLOBAL_TRANSACTION_EVENT_WRITER.get()
+    }
+
+    /// Returns the process-global writer, storing `writer` if the slot is empty.
+    pub fn get_or_init(writer: TransactionEventWriter) -> &'static TransactionEventWriter {
+        GLOBAL_TRANSACTION_EVENT_WRITER.get_or_init(|| writer)
     }
 }
 
@@ -232,7 +233,7 @@ impl TransactionEventBuilder {
         let Some(writer) = GlobalTransactionEventWriter::get() else {
             return Ok(TransactionEventEmitOutcome::NotConfigured);
         };
-        self.emit_to(&writer)
+        self.emit_to(writer)
     }
 }
 
@@ -440,18 +441,6 @@ mod tests {
     }
 
     #[test]
-    fn builder_none_writer_is_noop() {
-        let _serial = crate::TransactionEventCapture::hold_serial();
-        let result = TransactionEventBuilder::new(
-            TransactionEventProducer::BaseRethNode,
-            TransactionEventType::Pending,
-        )
-        .emit_global();
-
-        assert_eq!(result.unwrap(), TransactionEventEmitOutcome::NotConfigured);
-    }
-
-    #[test]
     fn macro_emits_inline_data_fields() {
         let writer = disabled_writer();
 
@@ -523,5 +512,25 @@ mod tests {
         assert_eq!(events[0].event_type, TransactionEventType::TxpoolSendRawTransactionValidity);
         assert_eq!(events[0].tx_hash, Some(tx_hash));
         assert_eq!(events[0].data["rpc_method"], "base_sendRawTransactionValidity");
+    }
+
+    #[test]
+    fn capture_clears_events_between_installs() {
+        {
+            let capture = crate::TransactionEventCapture::install();
+            let result = transaction_event!(
+                producer: TransactionEventProducer::BaseRethNode,
+                event_type: TransactionEventType::Pending,
+                tx_hash: TxHash::repeat_byte(0x43),
+            );
+            assert_eq!(result.unwrap(), TransactionEventEmitOutcome::Emitted);
+            assert_eq!(capture.events().len(), 1);
+        }
+
+        let capture = crate::TransactionEventCapture::install();
+        assert!(
+            capture.events().is_empty(),
+            "a later capture should not see events from the previous install"
+        );
     }
 }

--- a/crates/common/observability-events/src/emit.rs
+++ b/crates/common/observability-events/src/emit.rs
@@ -75,6 +75,7 @@ impl GlobalTransactionEventWriter {
     }
 
     /// Returns the process-global writer, storing `writer` if the slot is empty.
+    #[cfg(any(test, feature = "test-utils"))]
     pub fn get_or_init(writer: TransactionEventWriter) -> &'static TransactionEventWriter {
         GLOBAL_TRANSACTION_EVENT_WRITER.get_or_init(|| writer)
     }

--- a/crates/common/observability-events/src/lib.rs
+++ b/crates/common/observability-events/src/lib.rs
@@ -13,8 +13,13 @@ pub use event::*;
 mod emit;
 pub use emit::{
     GlobalTransactionEventWriter, GlobalTransactionEventWriterInitStatus, TransactionEventBuilder,
-    TransactionEventCapture, TransactionEventEmitOutcome,
+    TransactionEventEmitOutcome,
 };
+
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils;
+#[cfg(any(test, feature = "test-utils"))]
+pub use test_utils::TransactionEventCapture;
 
 mod id;
 pub use id::EventIdBuilder;

--- a/crates/common/observability-events/src/lib.rs
+++ b/crates/common/observability-events/src/lib.rs
@@ -28,7 +28,9 @@ mod metrics;
 pub use metrics::Metrics;
 
 mod writer;
-pub use writer::{TransactionEventWriter, TransactionEventWriterConfig, WriteEventError};
+pub use writer::{
+    TransactionEventRecorder, TransactionEventWriter, TransactionEventWriterConfig, WriteEventError,
+};
 
 #[doc(hidden)]
 pub mod __private {

--- a/crates/common/observability-events/src/lib.rs
+++ b/crates/common/observability-events/src/lib.rs
@@ -13,7 +13,7 @@ pub use event::*;
 mod emit;
 pub use emit::{
     GlobalTransactionEventWriter, GlobalTransactionEventWriterInitStatus, TransactionEventBuilder,
-    TransactionEventEmitOutcome,
+    TransactionEventCapture, TransactionEventEmitOutcome,
 };
 
 mod id;

--- a/crates/common/observability-events/src/lib.rs
+++ b/crates/common/observability-events/src/lib.rs
@@ -28,9 +28,9 @@ mod metrics;
 pub use metrics::Metrics;
 
 mod writer;
-pub use writer::{
-    TransactionEventRecorder, TransactionEventWriter, TransactionEventWriterConfig, WriteEventError,
-};
+#[cfg(any(test, feature = "test-utils"))]
+pub use writer::TransactionEventRecorder;
+pub use writer::{TransactionEventWriter, TransactionEventWriterConfig, WriteEventError};
 
 #[doc(hidden)]
 pub mod __private {

--- a/crates/common/observability-events/src/test_utils.rs
+++ b/crates/common/observability-events/src/test_utils.rs
@@ -1,34 +1,42 @@
 //! Records globally emitted transaction events for tests.
 //!
 //! [`TransactionEventCapture::install`] registers an in-memory writer in the
-//! process-global slot when it is empty, clears any events already recorded
-//! there, and holds a lock so concurrent capture tests do not interleave.
+//! process-global slot when it is empty, using a shared
+//! [`TransactionEventRecorder`]. Each install clears that recorder and holds a
+//! lock so concurrent capture tests do not interleave.
 
-use std::sync::{Mutex, MutexGuard};
+use std::sync::{Mutex, MutexGuard, OnceLock};
 
-use crate::{GlobalTransactionEventWriter, TransactionEvent, TransactionEventWriter};
+use crate::{
+    GlobalTransactionEventWriter, TransactionEvent, TransactionEventRecorder,
+    TransactionEventWriter,
+};
 
 static TEST_CAPTURE_SERIAL: Mutex<()> = Mutex::new(());
+static TEST_RECORDER: OnceLock<TransactionEventRecorder> = OnceLock::new();
 
 /// Process-global capture of emitted transaction events for tests.
 #[derive(Debug)]
 pub struct TransactionEventCapture {
     _serial: MutexGuard<'static, ()>,
-    writer: &'static TransactionEventWriter,
+    recorder: TransactionEventRecorder,
 }
 
 impl TransactionEventCapture {
     /// Installs a process-global in-memory writer and starts a fresh recording window.
     pub fn install() -> Self {
         let serial = TEST_CAPTURE_SERIAL.lock().unwrap_or_else(|err| err.into_inner());
-        let writer =
-            GlobalTransactionEventWriter::get_or_init(TransactionEventWriter::in_memory("test"));
-        writer.clear_recorded_events();
-        Self { _serial: serial, writer }
+        let recorder = TEST_RECORDER.get_or_init(TransactionEventRecorder::new).clone();
+        let _ = GlobalTransactionEventWriter::get_or_init(TransactionEventWriter::in_memory(
+            "test",
+            recorder.clone(),
+        ));
+        recorder.clear();
+        Self { _serial: serial, recorder }
     }
 
     /// Returns a snapshot of events recorded since this capture was installed.
     pub fn events(&self) -> Vec<TransactionEvent> {
-        self.writer.recorded_events()
+        self.recorder.events()
     }
 }

--- a/crates/common/observability-events/src/test_utils.rs
+++ b/crates/common/observability-events/src/test_utils.rs
@@ -1,52 +1,34 @@
-//! In-memory transaction event capture for tests.
+//! Records globally emitted transaction events for tests.
 //!
-//! Installing a capture registers an in-memory [`TransactionEventWriter`] as a
-//! process-global overlay so production emission stays on the normal writer path.
-//! The overlay is cleared when the capture is dropped. Installing a capture
-//! serializes other capture-using tests so parallel crates do not interleave
-//! recorded events.
+//! [`TransactionEventCapture::install`] registers an in-memory writer in the
+//! process-global slot when it is empty, clears any events already recorded
+//! there, and holds a lock so concurrent capture tests do not interleave.
 
 use std::sync::{Mutex, MutexGuard};
 
-use crate::{TransactionEvent, TransactionEventWriter};
+use crate::{GlobalTransactionEventWriter, TransactionEvent, TransactionEventWriter};
 
 static TEST_CAPTURE_SERIAL: Mutex<()> = Mutex::new(());
-static TEST_WRITER_OVERLAY: Mutex<Option<TransactionEventWriter>> = Mutex::new(None);
 
 /// Process-global capture of emitted transaction events for tests.
 #[derive(Debug)]
 pub struct TransactionEventCapture {
     _serial: MutexGuard<'static, ()>,
-    writer: TransactionEventWriter,
+    writer: &'static TransactionEventWriter,
 }
 
 impl TransactionEventCapture {
-    /// Installs a process-global in-memory writer, replacing any previously recorded events.
+    /// Installs a process-global in-memory writer and starts a fresh recording window.
     pub fn install() -> Self {
-        let serial = Self::hold_serial();
-        let writer = TransactionEventWriter::in_memory("test");
-        *TEST_WRITER_OVERLAY.lock().unwrap_or_else(|err| err.into_inner()) = Some(writer.clone());
+        let serial = TEST_CAPTURE_SERIAL.lock().unwrap_or_else(|err| err.into_inner());
+        let writer =
+            GlobalTransactionEventWriter::get_or_init(TransactionEventWriter::in_memory("test"));
+        writer.clear_recorded_events();
         Self { _serial: serial, writer }
     }
 
     /// Returns a snapshot of events recorded since this capture was installed.
     pub fn events(&self) -> Vec<TransactionEvent> {
         self.writer.recorded_events()
-    }
-
-    /// Returns the in-memory writer installed by an active capture.
-    pub fn installed_writer() -> Option<TransactionEventWriter> {
-        TEST_WRITER_OVERLAY.lock().unwrap_or_else(|err| err.into_inner()).clone()
-    }
-
-    /// Holds the capture serial lock without installing a writer.
-    pub fn hold_serial() -> MutexGuard<'static, ()> {
-        TEST_CAPTURE_SERIAL.lock().unwrap_or_else(|err| err.into_inner())
-    }
-}
-
-impl Drop for TransactionEventCapture {
-    fn drop(&mut self) {
-        *TEST_WRITER_OVERLAY.lock().unwrap_or_else(|err| err.into_inner()) = None;
     }
 }

--- a/crates/common/observability-events/src/test_utils.rs
+++ b/crates/common/observability-events/src/test_utils.rs
@@ -1,0 +1,52 @@
+//! In-memory transaction event capture for tests.
+//!
+//! Installing a capture registers an in-memory [`TransactionEventWriter`] as a
+//! process-global overlay so production emission stays on the normal writer path.
+//! The overlay is cleared when the capture is dropped. Installing a capture
+//! serializes other capture-using tests so parallel crates do not interleave
+//! recorded events.
+
+use std::sync::{Mutex, MutexGuard};
+
+use crate::{TransactionEvent, TransactionEventWriter};
+
+static TEST_CAPTURE_SERIAL: Mutex<()> = Mutex::new(());
+static TEST_WRITER_OVERLAY: Mutex<Option<TransactionEventWriter>> = Mutex::new(None);
+
+/// Process-global capture of emitted transaction events for tests.
+#[derive(Debug)]
+pub struct TransactionEventCapture {
+    _serial: MutexGuard<'static, ()>,
+    writer: TransactionEventWriter,
+}
+
+impl TransactionEventCapture {
+    /// Installs a process-global in-memory writer, replacing any previously recorded events.
+    pub fn install() -> Self {
+        let serial = Self::hold_serial();
+        let writer = TransactionEventWriter::in_memory("test");
+        *TEST_WRITER_OVERLAY.lock().unwrap_or_else(|err| err.into_inner()) = Some(writer.clone());
+        Self { _serial: serial, writer }
+    }
+
+    /// Returns a snapshot of events recorded since this capture was installed.
+    pub fn events(&self) -> Vec<TransactionEvent> {
+        self.writer.recorded_events()
+    }
+
+    /// Returns the in-memory writer installed by an active capture.
+    pub fn installed_writer() -> Option<TransactionEventWriter> {
+        TEST_WRITER_OVERLAY.lock().unwrap_or_else(|err| err.into_inner()).clone()
+    }
+
+    /// Holds the capture serial lock without installing a writer.
+    pub fn hold_serial() -> MutexGuard<'static, ()> {
+        TEST_CAPTURE_SERIAL.lock().unwrap_or_else(|err| err.into_inner())
+    }
+}
+
+impl Drop for TransactionEventCapture {
+    fn drop(&mut self) {
+        *TEST_WRITER_OVERLAY.lock().unwrap_or_else(|err| err.into_inner()) = None;
+    }
+}

--- a/crates/common/observability-events/src/writer.rs
+++ b/crates/common/observability-events/src/writer.rs
@@ -4,7 +4,7 @@ use std::{
     io::{self, Write},
     path::{Path, PathBuf},
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
     },
     time::{SystemTime, UNIX_EPOCH},
@@ -70,13 +70,14 @@ struct WriterInner {
     dropped: Option<ErrorCounter>,
     observed_drops: AtomicUsize,
     _guard: Option<WorkerGuard>,
+    capture: Option<Mutex<Vec<TransactionEvent>>>,
     config: TransactionEventWriterConfig,
 }
 
 impl fmt::Debug for TransactionEventWriter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("TransactionEventWriter")
-            .field("enabled", &self.inner.writer.is_some())
+            .field("enabled", &(self.inner.writer.is_some() || self.inner.capture.is_some()))
             .field("config", &self.inner.config)
             .finish_non_exhaustive()
     }
@@ -168,6 +169,7 @@ impl TransactionEventWriter {
                 dropped: Some(dropped),
                 observed_drops: AtomicUsize::new(0),
                 _guard: Some(guard),
+                capture: None,
                 config,
             }),
         })
@@ -181,13 +183,56 @@ impl TransactionEventWriter {
                 dropped: None,
                 observed_drops: AtomicUsize::new(0),
                 _guard: None,
+                capture: None,
                 config,
             }),
         }
     }
 
+    /// Creates an in-memory writer that records events for later inspection.
+    pub fn in_memory(network: impl Into<String>) -> Self {
+        Self {
+            inner: Arc::new(WriterInner {
+                writer: None,
+                dropped: None,
+                observed_drops: AtomicUsize::new(0),
+                _guard: None,
+                capture: Some(Mutex::new(Vec::new())),
+                config: TransactionEventWriterConfig {
+                    enabled: true,
+                    file_path: PathBuf::from("<memory>"),
+                    queue_capacity: DEFAULT_QUEUE_CAPACITY,
+                    max_file_bytes: DEFAULT_MAX_FILE_BYTES,
+                    max_files: DEFAULT_MAX_FILES,
+                    required: false,
+                    producer: TransactionEventProducer::BaseRethNode,
+                    network: network.into(),
+                },
+            }),
+        }
+    }
+
+    /// Returns events recorded by an in-memory writer.
+    pub fn recorded_events(&self) -> Vec<TransactionEvent> {
+        self.inner
+            .capture
+            .as_ref()
+            .map(|capture| capture.lock().unwrap_or_else(|err| err.into_inner()).clone())
+            .unwrap_or_default()
+    }
+
     /// Attempts to enqueue one event without blocking the caller.
     pub fn try_write(&self, event: &TransactionEvent) -> Result<(), WriteEventError> {
+        if let Some(capture) = &self.inner.capture {
+            event.validate().map_err(|err| {
+                Metrics::dropped_events("validation").increment(1);
+                WriteEventError::Invalid(err)
+            })?;
+            capture.lock().unwrap_or_else(|err| err.into_inner()).push(event.clone());
+            Metrics::submitted_events().increment(1);
+            return Ok(());
+        }
+
         let Some(writer) = &self.inner.writer else {
             Metrics::dropped_events("disabled").increment(1);
             return Err(WriteEventError::Disabled);
@@ -489,9 +534,20 @@ mod tests {
                 dropped: Some(dropped),
                 observed_drops: AtomicUsize::new(0),
                 _guard: Some(guard),
+                capture: None,
                 config,
             }),
         }
+    }
+
+    #[test]
+    fn in_memory_writer_records_events() {
+        let writer = TransactionEventWriter::in_memory("test");
+        writer.try_write(&sample_event()).unwrap();
+        let events = writer.recorded_events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type, TransactionEventType::Pending);
+        assert_eq!(events[0].network.as_deref(), Some("base-mainnet"));
     }
 
     #[test]

--- a/crates/common/observability-events/src/writer.rs
+++ b/crates/common/observability-events/src/writer.rs
@@ -59,7 +59,34 @@ impl TransactionEventWriterConfig {
     }
 }
 
-/// Handle for appending transaction events to a file or an in-memory buffer.
+/// Shared buffer for events written by an in-memory [`TransactionEventWriter`].
+#[derive(Clone, Debug, Default)]
+pub struct TransactionEventRecorder {
+    events: Arc<Mutex<Vec<TransactionEvent>>>,
+}
+
+impl TransactionEventRecorder {
+    /// Creates an empty recorder.
+    pub fn new() -> Self {
+        Self { events: Arc::new(Mutex::new(Vec::new())) }
+    }
+
+    /// Returns a snapshot of recorded events.
+    pub fn events(&self) -> Vec<TransactionEvent> {
+        self.events.lock().unwrap_or_else(|err| err.into_inner()).clone()
+    }
+
+    /// Removes all recorded events.
+    pub fn clear(&self) {
+        self.events.lock().unwrap_or_else(|err| err.into_inner()).clear();
+    }
+
+    fn push(&self, event: TransactionEvent) {
+        self.events.lock().unwrap_or_else(|err| err.into_inner()).push(event);
+    }
+}
+
+/// Non-blocking handle for appending transaction events to JSONL.
 #[derive(Clone)]
 pub struct TransactionEventWriter {
     inner: Arc<WriterInner>,
@@ -79,7 +106,7 @@ enum WriterBackend {
         _guard: WorkerGuard,
     },
     Memory {
-        events: Mutex<Vec<TransactionEvent>>,
+        recorder: TransactionEventRecorder,
     },
 }
 
@@ -193,30 +220,13 @@ impl TransactionEventWriter {
         Self::new(WriterBackend::Disabled, config.network)
     }
 
-    /// Creates an in-memory writer that records events for later inspection.
-    pub fn in_memory(network: impl Into<String>) -> Self {
-        Self::new(WriterBackend::Memory { events: Mutex::new(Vec::new()) }, network)
+    /// Creates an in-memory writer that appends events to `recorder`.
+    pub fn in_memory(network: impl Into<String>, recorder: TransactionEventRecorder) -> Self {
+        Self::new(WriterBackend::Memory { recorder }, network)
     }
 
     fn new(backend: WriterBackend, network: impl Into<String>) -> Self {
         Self { inner: Arc::new(WriterInner { backend, network: network.into() }) }
-    }
-
-    /// Returns events recorded by an in-memory writer.
-    pub fn recorded_events(&self) -> Vec<TransactionEvent> {
-        match &self.inner.backend {
-            WriterBackend::Memory { events } => {
-                events.lock().unwrap_or_else(|err| err.into_inner()).clone()
-            }
-            WriterBackend::Disabled | WriterBackend::File { .. } => Vec::new(),
-        }
-    }
-
-    /// Clears events recorded by an in-memory writer.
-    pub fn clear_recorded_events(&self) {
-        if let WriterBackend::Memory { events } = &self.inner.backend {
-            events.lock().unwrap_or_else(|err| err.into_inner()).clear();
-        }
     }
 
     /// Attempts to enqueue one event without blocking the caller.
@@ -226,9 +236,9 @@ impl TransactionEventWriter {
                 Metrics::dropped_events("disabled").increment(1);
                 Err(WriteEventError::Disabled)
             }
-            WriterBackend::Memory { events } => {
+            WriterBackend::Memory { recorder } => {
                 Self::validate_event(event)?;
-                events.lock().unwrap_or_else(|err| err.into_inner()).push(event.clone());
+                recorder.push(event.clone());
                 Metrics::submitted_events().increment(1);
                 Ok(())
             }
@@ -538,27 +548,17 @@ mod tests {
 
     #[test]
     fn in_memory_writer_records_and_clears_events() {
-        let writer = TransactionEventWriter::in_memory("test");
+        let recorder = TransactionEventRecorder::new();
+        let writer = TransactionEventWriter::in_memory("test", recorder.clone());
         writer.try_write(&sample_event()).unwrap();
-        let events = writer.recorded_events();
+        let events = recorder.events();
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].event_type, TransactionEventType::Pending);
         assert_eq!(events[0].network.as_deref(), Some("base-mainnet"));
         assert_eq!(writer.network(), "test");
 
-        writer.clear_recorded_events();
-        assert!(writer.recorded_events().is_empty());
-    }
-
-    #[test]
-    fn disabled_writer_has_no_recorded_events() {
-        let disabled = TransactionEventWriter::disabled(TransactionEventWriterConfig::disabled(
-            TransactionEventProducer::BaseRethNode,
-            "base-devnet",
-            "disabled.jsonl",
-        ));
-        assert!(disabled.try_write(&sample_event()).is_err());
-        assert!(disabled.recorded_events().is_empty());
+        recorder.clear();
+        assert!(recorder.events().is_empty());
     }
 
     #[test]

--- a/crates/common/observability-events/src/writer.rs
+++ b/crates/common/observability-events/src/writer.rs
@@ -59,26 +59,40 @@ impl TransactionEventWriterConfig {
     }
 }
 
-/// Non-blocking handle for appending transaction events to JSONL.
+/// Handle for appending transaction events to a file or an in-memory buffer.
 #[derive(Clone)]
 pub struct TransactionEventWriter {
     inner: Arc<WriterInner>,
 }
 
 struct WriterInner {
-    writer: Option<NonBlocking>,
-    dropped: Option<ErrorCounter>,
-    observed_drops: AtomicUsize,
-    _guard: Option<WorkerGuard>,
-    capture: Option<Mutex<Vec<TransactionEvent>>>,
-    config: TransactionEventWriterConfig,
+    backend: WriterBackend,
+    network: String,
+}
+
+enum WriterBackend {
+    Disabled,
+    File {
+        writer: NonBlocking,
+        dropped: ErrorCounter,
+        observed_drops: AtomicUsize,
+        _guard: WorkerGuard,
+    },
+    Memory {
+        events: Mutex<Vec<TransactionEvent>>,
+    },
 }
 
 impl fmt::Debug for TransactionEventWriter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let backend = match &self.inner.backend {
+            WriterBackend::Disabled => "disabled",
+            WriterBackend::File { .. } => "file",
+            WriterBackend::Memory { .. } => "memory",
+        };
         f.debug_struct("TransactionEventWriter")
-            .field("enabled", &(self.inner.writer.is_some() || self.inner.capture.is_some()))
-            .field("config", &self.inner.config)
+            .field("backend", &backend)
+            .field("network", &self.inner.network)
             .finish_non_exhaustive()
     }
 }
@@ -163,118 +177,101 @@ impl TransactionEventWriter {
             .finish(MetricWriter::new(file));
         let dropped = writer.error_counter();
 
-        Ok(Self {
-            inner: Arc::new(WriterInner {
-                writer: Some(writer),
-                dropped: Some(dropped),
+        Ok(Self::new(
+            WriterBackend::File {
+                writer,
+                dropped,
                 observed_drops: AtomicUsize::new(0),
-                _guard: Some(guard),
-                capture: None,
-                config,
-            }),
-        })
+                _guard: guard,
+            },
+            config.network,
+        ))
     }
 
     /// Creates a disabled writer handle.
     pub fn disabled(config: TransactionEventWriterConfig) -> Self {
-        Self {
-            inner: Arc::new(WriterInner {
-                writer: None,
-                dropped: None,
-                observed_drops: AtomicUsize::new(0),
-                _guard: None,
-                capture: None,
-                config,
-            }),
-        }
+        Self::new(WriterBackend::Disabled, config.network)
     }
 
     /// Creates an in-memory writer that records events for later inspection.
     pub fn in_memory(network: impl Into<String>) -> Self {
-        Self {
-            inner: Arc::new(WriterInner {
-                writer: None,
-                dropped: None,
-                observed_drops: AtomicUsize::new(0),
-                _guard: None,
-                capture: Some(Mutex::new(Vec::new())),
-                config: TransactionEventWriterConfig {
-                    enabled: true,
-                    file_path: PathBuf::from("<memory>"),
-                    queue_capacity: DEFAULT_QUEUE_CAPACITY,
-                    max_file_bytes: DEFAULT_MAX_FILE_BYTES,
-                    max_files: DEFAULT_MAX_FILES,
-                    required: false,
-                    producer: TransactionEventProducer::BaseRethNode,
-                    network: network.into(),
-                },
-            }),
-        }
+        Self::new(WriterBackend::Memory { events: Mutex::new(Vec::new()) }, network)
+    }
+
+    fn new(backend: WriterBackend, network: impl Into<String>) -> Self {
+        Self { inner: Arc::new(WriterInner { backend, network: network.into() }) }
     }
 
     /// Returns events recorded by an in-memory writer.
     pub fn recorded_events(&self) -> Vec<TransactionEvent> {
-        self.inner
-            .capture
-            .as_ref()
-            .map(|capture| capture.lock().unwrap_or_else(|err| err.into_inner()).clone())
-            .unwrap_or_default()
+        match &self.inner.backend {
+            WriterBackend::Memory { events } => {
+                events.lock().unwrap_or_else(|err| err.into_inner()).clone()
+            }
+            WriterBackend::Disabled | WriterBackend::File { .. } => Vec::new(),
+        }
+    }
+
+    /// Clears events recorded by an in-memory writer.
+    pub fn clear_recorded_events(&self) {
+        if let WriterBackend::Memory { events } = &self.inner.backend {
+            events.lock().unwrap_or_else(|err| err.into_inner()).clear();
+        }
     }
 
     /// Attempts to enqueue one event without blocking the caller.
     pub fn try_write(&self, event: &TransactionEvent) -> Result<(), WriteEventError> {
-        if let Some(capture) = &self.inner.capture {
-            event.validate().map_err(|err| {
-                Metrics::dropped_events("validation").increment(1);
-                WriteEventError::Invalid(err)
-            })?;
-            capture.lock().unwrap_or_else(|err| err.into_inner()).push(event.clone());
-            Metrics::submitted_events().increment(1);
-            return Ok(());
+        match &self.inner.backend {
+            WriterBackend::Disabled => {
+                Metrics::dropped_events("disabled").increment(1);
+                Err(WriteEventError::Disabled)
+            }
+            WriterBackend::Memory { events } => {
+                Self::validate_event(event)?;
+                events.lock().unwrap_or_else(|err| err.into_inner()).push(event.clone());
+                Metrics::submitted_events().increment(1);
+                Ok(())
+            }
+            WriterBackend::File { writer, .. } => {
+                Self::validate_event(event)?;
+                let mut line = serde_json::to_vec(event).map_err(|err| {
+                    Metrics::dropped_events("serialization").increment(1);
+                    WriteEventError::Serialize(err)
+                })?;
+                line.push(b'\n');
+                let _ = writer.clone().write_all(&line);
+                self.observe_dropped_events();
+                Metrics::submitted_events().increment(1);
+                Ok(())
+            }
         }
+    }
 
-        let Some(writer) = &self.inner.writer else {
-            Metrics::dropped_events("disabled").increment(1);
-            return Err(WriteEventError::Disabled);
-        };
-
+    fn validate_event(event: &TransactionEvent) -> Result<(), WriteEventError> {
         event.validate().map_err(|err| {
             Metrics::dropped_events("validation").increment(1);
             WriteEventError::Invalid(err)
-        })?;
-
-        let mut line = serde_json::to_vec(event).map_err(|err| {
-            Metrics::dropped_events("serialization").increment(1);
-            WriteEventError::Serialize(err)
-        })?;
-        line.push(b'\n');
-
-        let _ = writer.clone().write_all(&line);
-        self.observe_dropped_events();
-        Metrics::submitted_events().increment(1);
-        Ok(())
+        })
     }
 
     /// Returns the configured network label for this writer.
     pub fn network(&self) -> &str {
-        &self.inner.config.network
+        &self.inner.network
     }
 
     fn observe_dropped_events(&self) -> usize {
-        let Some(dropped) = &self.inner.dropped else {
+        let WriterBackend::File { dropped, observed_drops, .. } = &self.inner.backend else {
             return 0;
         };
 
         loop {
             let current = dropped.dropped_lines();
-            let previous = self.inner.observed_drops.load(Ordering::Relaxed);
+            let previous = observed_drops.load(Ordering::Relaxed);
             if current <= previous {
                 return 0;
             }
 
-            if self
-                .inner
-                .observed_drops
+            if observed_drops
                 .compare_exchange_weak(previous, current, Ordering::Relaxed, Ordering::Relaxed)
                 .is_ok()
             {
@@ -528,26 +525,40 @@ mod tests {
             .finish(MetricWriter::new(sink));
         let dropped = writer.error_counter();
 
-        TransactionEventWriter {
-            inner: Arc::new(WriterInner {
-                writer: Some(writer),
-                dropped: Some(dropped),
+        TransactionEventWriter::new(
+            WriterBackend::File {
+                writer,
+                dropped,
                 observed_drops: AtomicUsize::new(0),
-                _guard: Some(guard),
-                capture: None,
-                config,
-            }),
-        }
+                _guard: guard,
+            },
+            config.network,
+        )
     }
 
     #[test]
-    fn in_memory_writer_records_events() {
+    fn in_memory_writer_records_and_clears_events() {
         let writer = TransactionEventWriter::in_memory("test");
         writer.try_write(&sample_event()).unwrap();
         let events = writer.recorded_events();
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].event_type, TransactionEventType::Pending);
         assert_eq!(events[0].network.as_deref(), Some("base-mainnet"));
+        assert_eq!(writer.network(), "test");
+
+        writer.clear_recorded_events();
+        assert!(writer.recorded_events().is_empty());
+    }
+
+    #[test]
+    fn disabled_writer_has_no_recorded_events() {
+        let disabled = TransactionEventWriter::disabled(TransactionEventWriterConfig::disabled(
+            TransactionEventProducer::BaseRethNode,
+            "base-devnet",
+            "disabled.jsonl",
+        ));
+        assert!(disabled.try_write(&sample_event()).is_err());
+        assert!(disabled.recorded_events().is_empty());
     }
 
     #[test]
@@ -804,15 +815,18 @@ mod tests {
         }
 
         let writer = writer_with_sink(SlowWriter, 0);
+        let WriterBackend::File { observed_drops, .. } = &writer.inner.backend else {
+            panic!("backpressure test requires a file-backed writer");
+        };
 
         for _ in 0..10_000 {
             writer.try_write(&sample_event()).unwrap();
-            if writer.inner.observed_drops.load(Ordering::Relaxed) > 0 {
+            if observed_drops.load(Ordering::Relaxed) > 0 {
                 break;
             }
         }
 
-        let dropped = writer.inner.observed_drops.load(Ordering::Relaxed);
+        let dropped = observed_drops.load(Ordering::Relaxed);
         assert!(dropped > 0, "lossy writer should report aggregate drops under backpressure");
     }
 

--- a/crates/common/observability-events/src/writer.rs
+++ b/crates/common/observability-events/src/writer.rs
@@ -1,10 +1,12 @@
+#[cfg(any(test, feature = "test-utils"))]
+use std::sync::Mutex;
 use std::{
     fmt,
     fs::{File, OpenOptions, create_dir_all, read_dir, remove_file, rename},
     io::{self, Write},
     path::{Path, PathBuf},
     sync::{
-        Arc, Mutex,
+        Arc,
         atomic::{AtomicUsize, Ordering},
     },
     time::{SystemTime, UNIX_EPOCH},
@@ -60,11 +62,13 @@ impl TransactionEventWriterConfig {
 }
 
 /// Shared buffer for events written by an in-memory [`TransactionEventWriter`].
+#[cfg(any(test, feature = "test-utils"))]
 #[derive(Clone, Debug, Default)]
 pub struct TransactionEventRecorder {
     events: Arc<Mutex<Vec<TransactionEvent>>>,
 }
 
+#[cfg(any(test, feature = "test-utils"))]
 impl TransactionEventRecorder {
     /// Creates an empty recorder.
     pub fn new() -> Self {
@@ -105,6 +109,7 @@ enum WriterBackend {
         observed_drops: AtomicUsize,
         _guard: WorkerGuard,
     },
+    #[cfg(any(test, feature = "test-utils"))]
     Memory {
         recorder: TransactionEventRecorder,
     },
@@ -115,6 +120,7 @@ impl fmt::Debug for TransactionEventWriter {
         let backend = match &self.inner.backend {
             WriterBackend::Disabled => "disabled",
             WriterBackend::File { .. } => "file",
+            #[cfg(any(test, feature = "test-utils"))]
             WriterBackend::Memory { .. } => "memory",
         };
         f.debug_struct("TransactionEventWriter")
@@ -221,6 +227,7 @@ impl TransactionEventWriter {
     }
 
     /// Creates an in-memory writer that appends events to `recorder`.
+    #[cfg(any(test, feature = "test-utils"))]
     pub fn in_memory(network: impl Into<String>, recorder: TransactionEventRecorder) -> Self {
         Self::new(WriterBackend::Memory { recorder }, network)
     }
@@ -236,6 +243,7 @@ impl TransactionEventWriter {
                 Metrics::dropped_events("disabled").increment(1);
                 Err(WriteEventError::Disabled)
             }
+            #[cfg(any(test, feature = "test-utils"))]
             WriterBackend::Memory { recorder } => {
                 Self::validate_event(event)?;
                 recorder.push(event.clone());

--- a/crates/execution/txpool-rpc/Cargo.toml
+++ b/crates/execution/txpool-rpc/Cargo.toml
@@ -36,5 +36,9 @@ tracing.workspace = true
 eyre.workspace = true
 tokio.workspace = true
 httpmock.workspace = true
+alloy-eips.workspace = true
+alloy-signer.workspace = true
 serde_json.workspace = true
+alloy-consensus.workspace = true
+alloy-signer-local.workspace = true
 reth-transaction-pool = { workspace = true, features = ["test-utils"] }

--- a/crates/execution/txpool-rpc/Cargo.toml
+++ b/crates/execution/txpool-rpc/Cargo.toml
@@ -33,6 +33,9 @@ serde.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+# workspace
+base-observability-events = { workspace = true, features = ["test-utils"] }
+
 eyre.workspace = true
 tokio.workspace = true
 httpmock.workspace = true

--- a/crates/execution/txpool-rpc/Cargo.toml
+++ b/crates/execution/txpool-rpc/Cargo.toml
@@ -40,8 +40,8 @@ eyre.workspace = true
 tokio.workspace = true
 httpmock.workspace = true
 alloy-eips.workspace = true
-alloy-signer.workspace = true
 serde_json.workspace = true
+alloy-signer.workspace = true
 alloy-consensus.workspace = true
 alloy-signer-local.workspace = true
 reth-transaction-pool = { workspace = true, features = ["test-utils"] }

--- a/crates/execution/txpool-rpc/src/rpc.rs
+++ b/crates/execution/txpool-rpc/src/rpc.rs
@@ -236,8 +236,15 @@ impl<Pool: TransactionPool + 'static> AdminTxPoolApiServer for AdminTxPoolApiImp
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::U256;
-    use base_observability_events::{TransactionEventBuilder, TransactionEventProducer};
+    use alloy_consensus::{SignableTransaction, TxEip1559};
+    use alloy_eips::eip2718::Encodable2718;
+    use alloy_primitives::{Address, Bytes, TxHash, TxKind, U256};
+    use alloy_signer::SignerSync;
+    use alloy_signer_local::PrivateKeySigner;
+    use base_observability_events::{
+        TransactionEventBuilder, TransactionEventCapture, TransactionEventProducer,
+        TransactionEventType,
+    };
     use httpmock::prelude::*;
     use reth_transaction_pool::{
         PoolTransaction, TransactionOrigin,
@@ -284,6 +291,22 @@ mod tests {
                 value: U256::from(5),
             },
         ]
+    }
+
+    fn signed_eip1559(signer: &PrivateKeySigner, nonce: u64, priority_fee: u128) -> Bytes {
+        let mut tx = TxEip1559 {
+            chain_id: 8453,
+            nonce,
+            gas_limit: 21_000,
+            max_fee_per_gas: 1_000_000_000,
+            max_priority_fee_per_gas: priority_fee,
+            to: TxKind::Call(Address::repeat_byte(0x11)),
+            value: U256::ZERO,
+            access_list: Default::default(),
+            input: Default::default(),
+        };
+        let signature = signer.sign_hash_sync(&tx.signature_hash()).expect("test signer");
+        tx.into_signed(signature).encoded_2718().into()
     }
 
     #[test]
@@ -353,6 +376,104 @@ mod tests {
         assert_eq!(event.event_type.to_string(), "TXPOOL_SEND_RAW_TRANSACTION_VALIDITY");
         assert_eq!(event.tx_hash, Some(tx_hash));
         assert!(event.data.contains_key("validity_predicates"));
+    }
+
+    #[tokio::test]
+    async fn send_raw_transaction_validity_emits_predicate_list_on_admission() {
+        let capture = TransactionEventCapture::install();
+        let signer = PrivateKeySigner::random();
+        let raw = signed_eip1559(&signer, 0, 1);
+        let rpc = SendRawTransactionValidityApiImpl::new(NoopTransactionPool::<
+            BasePooledTransaction,
+        >::new());
+        let request =
+            SendRawTransactionValidityRequest { tx: raw, validity: all_predicate_variants() };
+
+        let tx_hash = rpc.send_raw_transaction_validity(request).await;
+        let tx_hash = match tx_hash {
+            Ok(tx_hash) => tx_hash,
+            Err(_) => capture.events().first().and_then(|event| event.tx_hash).expect(
+                "admission event should fire before pool insertion even if the noop pool rejects",
+            ),
+        };
+
+        let events: Vec<_> = capture
+            .events()
+            .into_iter()
+            .filter(|event| {
+                event.event_type == TransactionEventType::TxpoolSendRawTransactionValidity
+                    && event.tx_hash == Some(tx_hash)
+            })
+            .collect();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].data["rpc_method"], "base_sendRawTransactionValidity");
+        assert_eq!(
+            events[0].data["validity_predicates"],
+            serde_json::to_value(all_predicate_variants()).unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn replacement_emits_a_second_admission_event_joinable_by_replacement_hash() {
+        let capture = TransactionEventCapture::install();
+        let signer = PrivateKeySigner::random();
+        let original = signed_eip1559(&signer, 0, 1);
+        let replacement = signed_eip1559(&signer, 0, 2);
+        let rpc = SendRawTransactionValidityApiImpl::new(NoopTransactionPool::<
+            BasePooledTransaction,
+        >::new());
+
+        let original_predicates = vec![ValidityPredicate::BlockNumber {
+            op: base_execution_txpool::ValidityOperator::GreaterThanOrEqual,
+            value: U256::from(1),
+        }];
+        let replacement_predicates = vec![ValidityPredicate::FlashblockIndex {
+            op: base_execution_txpool::ValidityOperator::LessThan,
+            value: U256::from(5),
+        }];
+
+        let _ = rpc
+            .send_raw_transaction_validity(SendRawTransactionValidityRequest {
+                tx: original,
+                validity: original_predicates.clone(),
+            })
+            .await;
+        let _ = rpc
+            .send_raw_transaction_validity(SendRawTransactionValidityRequest {
+                tx: replacement,
+                validity: replacement_predicates.clone(),
+            })
+            .await;
+
+        let admissions: Vec<_> = capture
+            .events()
+            .into_iter()
+            .filter(|event| {
+                event.event_type == TransactionEventType::TxpoolSendRawTransactionValidity
+            })
+            .collect();
+        assert_eq!(admissions.len(), 2, "each submit, including a replacement, emits admission");
+        assert_ne!(admissions[0].tx_hash, admissions[1].tx_hash);
+        assert_eq!(
+            admissions[0].data["validity_predicates"],
+            serde_json::to_value(&original_predicates).unwrap()
+        );
+        assert_eq!(
+            admissions[1].data["validity_predicates"],
+            serde_json::to_value(&replacement_predicates).unwrap()
+        );
+
+        let original_hash = admissions[0].tx_hash.expect("original admission has tx_hash");
+        let replacement_hash = admissions[1].tx_hash.expect("replacement admission has tx_hash");
+        let replaced = TransactionEventBuilder::new(
+            TransactionEventProducer::BaseRethNode,
+            TransactionEventType::Replaced,
+        )
+        .tx_hash(original_hash)
+        .data_field("replacement_hash", json!(format!("{replacement_hash:#x}")))
+        .build_with_network("base-devnet");
+        replaced.validate().expect("replacement event should be valid");
+        assert_eq!(replaced.data["replacement_hash"], format!("{replacement_hash:#x}"));
     }
 
     #[test]

--- a/crates/execution/txpool-rpc/src/rpc.rs
+++ b/crates/execution/txpool-rpc/src/rpc.rs
@@ -411,69 +411,6 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn replacement_emits_a_second_admission_event_joinable_by_replacement_hash() {
-        let capture = TransactionEventCapture::install();
-        let signer = PrivateKeySigner::random();
-        let original = signed_eip1559(&signer, 0, 1);
-        let replacement = signed_eip1559(&signer, 0, 2);
-        let rpc = SendRawTransactionValidityApiImpl::new(NoopTransactionPool::<
-            BasePooledTransaction,
-        >::new());
-
-        let original_predicates = vec![ValidityPredicate::BlockNumber {
-            op: base_execution_txpool::ValidityOperator::GreaterThanOrEqual,
-            value: U256::from(1),
-        }];
-        let replacement_predicates = vec![ValidityPredicate::FlashblockIndex {
-            op: base_execution_txpool::ValidityOperator::LessThan,
-            value: U256::from(5),
-        }];
-
-        let _ = rpc
-            .send_raw_transaction_validity(SendRawTransactionValidityRequest {
-                tx: original,
-                validity: original_predicates.clone(),
-            })
-            .await;
-        let _ = rpc
-            .send_raw_transaction_validity(SendRawTransactionValidityRequest {
-                tx: replacement,
-                validity: replacement_predicates.clone(),
-            })
-            .await;
-
-        let admissions: Vec<_> = capture
-            .events()
-            .into_iter()
-            .filter(|event| {
-                event.event_type == TransactionEventType::TxpoolSendRawTransactionValidity
-            })
-            .collect();
-        assert_eq!(admissions.len(), 2, "each submit, including a replacement, emits admission");
-        assert_ne!(admissions[0].tx_hash, admissions[1].tx_hash);
-        assert_eq!(
-            admissions[0].data["validity_predicates"],
-            serde_json::to_value(&original_predicates).unwrap()
-        );
-        assert_eq!(
-            admissions[1].data["validity_predicates"],
-            serde_json::to_value(&replacement_predicates).unwrap()
-        );
-
-        let original_hash = admissions[0].tx_hash.expect("original admission has tx_hash");
-        let replacement_hash = admissions[1].tx_hash.expect("replacement admission has tx_hash");
-        let replaced = TransactionEventBuilder::new(
-            TransactionEventProducer::BaseRethNode,
-            TransactionEventType::Replaced,
-        )
-        .tx_hash(original_hash)
-        .data_field("replacement_hash", json!(format!("{replacement_hash:#x}")))
-        .build_with_network("base-devnet");
-        replaced.validate().expect("replacement event should be valid");
-        assert_eq!(replaced.data["replacement_hash"], format!("{replacement_hash:#x}"));
-    }
-
     #[test]
     fn send_raw_transaction_validity_method_is_registered() {
         let rpc = SendRawTransactionValidityApiImpl::new(NoopTransactionPool::<

--- a/crates/execution/txpool-rpc/src/rpc.rs
+++ b/crates/execution/txpool-rpc/src/rpc.rs
@@ -294,7 +294,7 @@ mod tests {
     }
 
     fn signed_eip1559(signer: &PrivateKeySigner, nonce: u64, priority_fee: u128) -> Bytes {
-        let mut tx = TxEip1559 {
+        let tx = TxEip1559 {
             chain_id: 8453,
             nonce,
             gas_limit: 21_000,
@@ -389,13 +389,11 @@ mod tests {
         let request =
             SendRawTransactionValidityRequest { tx: raw, validity: all_predicate_variants() };
 
-        let tx_hash = rpc.send_raw_transaction_validity(request).await;
-        let tx_hash = match tx_hash {
-            Ok(tx_hash) => tx_hash,
-            Err(_) => capture.events().first().and_then(|event| event.tx_hash).expect(
+        let tx_hash = rpc.send_raw_transaction_validity(request).await.unwrap_or_else(|_| {
+            capture.events().first().and_then(|event| event.tx_hash).expect(
                 "admission event should fire before pool insertion even if the noop pool rejects",
-            ),
-        };
+            )
+        });
 
         let events: Vec<_> = capture
             .events()

--- a/crates/infra/audit/src/transaction_events.rs
+++ b/crates/infra/audit/src/transaction_events.rs
@@ -1339,6 +1339,12 @@ mod tests {
         );
         assert_eq!(
             TransactionEventRetentionClass::for_event_type(
+                TransactionEventType::TxpoolSendRawTransaction
+            ),
+            TransactionEventRetentionClass::Warm
+        );
+        assert_eq!(
+            TransactionEventRetentionClass::for_event_type(
                 TransactionEventType::TxpoolSendRawTransactionValidity
             ),
             TransactionEventRetentionClass::Warm
@@ -1421,6 +1427,52 @@ mod tests {
         assert_eq!(response.accepted, 2);
         assert_eq!(response.duplicate, 0);
         assert_eq!(response.rejected, 0);
+    }
+
+    #[tokio::test]
+    async fn accepts_at_lifecycle_event_types() {
+        let state = state(Arc::new(FakeSink::default()));
+        let mut admission = event("at-admission");
+        admission["producer"] = json!("base-reth-node");
+        admission["event_type"] = json!("TXPOOL_SEND_RAW_TRANSACTION_VALIDITY");
+        admission["data"] = json!({
+            "rpc_method": "base_sendRawTransactionValidity",
+            "validity_predicates": [{
+                "type": "block_number",
+                "params": { "op": ">=", "value": "0x64" }
+            }]
+        });
+        let mut deferred = event("at-deferred");
+        deferred["event_type"] = json!("BUILDER_DEFERRED");
+        deferred["data"] = json!({ "defer_reason": "validity_predicate_not_satisfied" });
+        let mut expired = event("at-expired");
+        expired["event_type"] = json!("BUILDER_EXPIRED");
+        expired["data"] = json!({ "expire_reason": "validity_predicate_expired" });
+
+        let (status, Json(response)) =
+            ingest_transaction_event_batch(&state, ndjson(vec![admission, deferred, expired]))
+                .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(response.status, TransactionEventBatchStatus::Accepted);
+        assert_eq!(response.accepted, 3);
+        assert_eq!(response.rejected, 0);
+        assert_eq!(
+            TransactionEventRetentionClass::for_event_type(
+                TransactionEventType::TxpoolSendRawTransactionValidity
+            ),
+            TransactionEventRetentionClass::for_event_type(
+                TransactionEventType::TxpoolSendRawTransaction
+            )
+        );
+        assert_eq!(
+            TransactionEventRetentionClass::for_event_type(TransactionEventType::BuilderDeferred),
+            TransactionEventRetentionClass::Hot
+        );
+        assert_eq!(
+            TransactionEventRetentionClass::for_event_type(TransactionEventType::BuilderExpired),
+            TransactionEventRetentionClass::Hot
+        );
     }
 
     #[tokio::test]

--- a/crates/infra/audit/tests/postgres_transaction_events.rs
+++ b/crates/infra/audit/tests/postgres_transaction_events.rs
@@ -307,6 +307,70 @@ async fn postgres_retention_uses_per_class_cutoffs() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn postgres_expires_at_lifecycle_events_with_peer_classes() -> anyhow::Result<()> {
+    let harness = PostgresHarness::new().await?;
+    PgTransactionEventSink::migrate(&harness.database_url).await?;
+    let sink = PgTransactionEventSink::connect(&harness.database_url, 1).await?;
+    let pool = PgPoolOptions::new().max_connections(1).connect(&harness.database_url).await?;
+    let event_prefix = unique_event_id();
+
+    let events = [
+        event_with_type(&format!("{event_prefix}-admission"), "TXPOOL_SEND_RAW_TRANSACTION"),
+        event_with_type(
+            &format!("{event_prefix}-validity-admission"),
+            "TXPOOL_SEND_RAW_TRANSACTION_VALIDITY",
+        ),
+        event_with_type(&format!("{event_prefix}-rejected"), "BUILDER_REJECTED"),
+        event_with_type(&format!("{event_prefix}-deferred"), "BUILDER_DEFERRED"),
+        event_with_type(&format!("{event_prefix}-expired"), "BUILDER_EXPIRED"),
+        event_with_type(&format!("{event_prefix}-included"), "BUILDER_INCLUDED"),
+    ];
+    sink.insert_events(&events).await?;
+    sqlx::query(
+        "UPDATE transaction_events SET ingested_at = now() - interval '4 days' \
+         WHERE event_id IN ($1, $2, $3)",
+    )
+    .bind(format!("{event_prefix}-rejected"))
+    .bind(format!("{event_prefix}-deferred"))
+    .bind(format!("{event_prefix}-expired"))
+    .execute(&pool)
+    .await?;
+    sqlx::query(
+        "UPDATE transaction_events SET ingested_at = now() - interval '8 days' \
+         WHERE event_id IN ($1, $2, $3)",
+    )
+    .bind(format!("{event_prefix}-admission"))
+    .bind(format!("{event_prefix}-validity-admission"))
+    .bind(format!("{event_prefix}-included"))
+    .execute(&pool)
+    .await?;
+
+    let outcome = sink
+        .expire_old_events(TransactionEventRetentionConfig {
+            hot_days: 3,
+            warm_days: 7,
+            cold_days: 30,
+            delete_batch_size: 10,
+            max_batches: 10,
+        })
+        .await?;
+    assert_eq!(outcome.hot_rows_deleted, 3);
+    assert_eq!(outcome.warm_rows_deleted, 2);
+    assert_eq!(outcome.cold_rows_deleted, 0);
+
+    let remaining: Vec<(String, String)> = sqlx::query_as(
+        "SELECT event_id, event_type FROM transaction_events \
+         WHERE event_id LIKE $1 ORDER BY event_id",
+    )
+    .bind(format!("{event_prefix}-%"))
+    .fetch_all(&pool)
+    .await?;
+    assert_eq!(remaining, vec![(format!("{event_prefix}-included"), "BUILDER_INCLUDED".into())]);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn postgres_retention_skips_when_another_replica_holds_lock() -> anyhow::Result<()> {
     let harness = PostgresHarness::new().await?;
     PgTransactionEventSink::migrate(&harness.database_url).await?;

--- a/docs/transaction-events/README.md
+++ b/docs/transaction-events/README.md
@@ -16,7 +16,10 @@ not the long-term archive. A background worker deletes rows by event type:
 high-volume proxy and builder-decision events default to 3 days, ingress and
 forwarding events default to 7 days, and failures, drops, inclusion, and
 flashblock events default to 30 days. Autovacuum reclaims the resulting table
-bloat.
+bloat. `TXPOOL_SEND_RAW_TRANSACTION_VALIDITY` uses the same warm window as
+`TXPOOL_SEND_RAW_TRANSACTION`. `BUILDER_DEFERRED` and `BUILDER_EXPIRED` use the
+same hot window as the other per-attempt builder decisions; deferral can fire
+once per flashblock for a parked validity transaction.
 
 ## Configuration Fields
 
@@ -196,11 +199,12 @@ one-time RPC-admission events, one per unique submit path. They fire after the
 transaction is decoded and before sequencer forwarding or pool insertion.
 `tx_hash` is the join key. They are distinct from `TXPOOL_PENDING` /
 `TXPOOL_QUEUED`, which record later subpool membership.
-`TXPOOL_SEND_RAW_TRANSACTION_VALIDITY` is the only event that records
+`TXPOOL_SEND_RAW_TRANSACTION_VALIDITY` is the **only** event that records
 `data.validity_predicates` (the serialized `balance`, `storage`,
-`block_number`, and `flashblock_index` list). Downstream lifecycle events do
-not repeat that list; join them back by `tx_hash`. A replacement is a fresh
-admission with its own `tx_hash` and/or predicate list;
+`block_number`, and `flashblock_index` list). Downstream lifecycle events —
+including `BUILDER_DEFERRED`, `BUILDER_EXPIRED`, `BUILDER_ACCEPTED`, and
+`BUILDER_INCLUDED` — must not repeat that list; join them back by `tx_hash`. A
+replacement is a fresh admission with its own `tx_hash` and/or predicate list;
 `TXPOOL_REPLACED.replacement_hash` links the outgoing transaction to the
 incoming one. `base_insertValidatedTransaction` uses
 `TXPOOL_VALIDATED_INSERT_ACCEPTED` / `TXPOOL_VALIDATED_INSERT_REJECTED`.
@@ -353,6 +357,94 @@ Routed to node:
   "data": {
     "backend": "reth-mainnet-0",
     "attempt_index": 0
+  }
+}
+```
+
+## Mempool / Builder Examples
+
+Validity admission. This is the only event that carries `data.validity_predicates`.
+Join later park, expiry, accept, and include events by `tx_hash`:
+
+```json
+{
+  "schema_version": "transaction-event/v1",
+  "event_id": "0x4c6d...",
+  "event_time": "2026-06-02T00:00:00.000000000Z",
+  "producer": "base-reth-node",
+  "event_type": "TXPOOL_SEND_RAW_TRANSACTION_VALIDITY",
+  "network": "base-mainnet",
+  "tx_hash": "0x3333333333333333333333333333333333333333333333333333333333333333",
+  "block_hash": null,
+  "block_number": null,
+  "payload_id": null,
+  "request_id": null,
+  "data": {
+    "rpc_method": "base_sendRawTransactionValidity",
+    "validity_predicates": [
+      {
+        "type": "storage",
+        "params": {
+          "address": "0xabababababababababababababababababababab",
+          "slot": "0x1",
+          "mask": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "op": "=",
+          "value": "0x1"
+        }
+      }
+    ]
+  }
+}
+```
+
+Parked (recoverable predicate, held for a later position or flashblock). Does
+not repeat the predicate list:
+
+```json
+{
+  "schema_version": "transaction-event/v1",
+  "event_id": "0x5d7e...",
+  "event_time": "2026-06-02T00:00:00.200000000Z",
+  "producer": "base-builder",
+  "event_type": "BUILDER_DEFERRED",
+  "network": "base-mainnet",
+  "tx_hash": "0x3333333333333333333333333333333333333333333333333333333333333333",
+  "block_hash": null,
+  "block_number": 123,
+  "payload_id": "0x0102030405060708",
+  "request_id": null,
+  "data": {
+    "builder_mode": "flashblocks",
+    "flashblock_index": 2,
+    "ordering_position": 4,
+    "defer_reason": "validity_predicate_not_satisfied",
+    "defer_detail": "a validity predicate is not satisfied by the current build state"
+  }
+}
+```
+
+Terminal builder-side expiry. A parking-capacity miss stays `BUILDER_REJECTED`
+with `validity_predicate_not_satisfied` instead:
+
+```json
+{
+  "schema_version": "transaction-event/v1",
+  "event_id": "0x6e8f...",
+  "event_time": "2026-06-02T00:00:00.400000000Z",
+  "producer": "base-builder",
+  "event_type": "BUILDER_EXPIRED",
+  "network": "base-mainnet",
+  "tx_hash": "0x4444444444444444444444444444444444444444444444444444444444444444",
+  "block_hash": null,
+  "block_number": 123,
+  "payload_id": "0x0102030405060708",
+  "request_id": null,
+  "data": {
+    "builder_mode": "flashblocks",
+    "flashblock_index": 0,
+    "ordering_position": 1,
+    "expire_reason": "validity_predicate_expired",
+    "expire_detail": "a validity predicate can no longer be satisfied at or after the current build position"
   }
 }
 ```


### PR DESCRIPTION
## Summary
- Assign `TXPOOL_SEND_RAW_TRANSACTION_VALIDITY` the same warm (7-day) Postgres retention as `TXPOOL_SEND_RAW_TRANSACTION`, and keep `BUILDER_DEFERRED` / `BUILDER_EXPIRED` on the hot (3-day) path with other per-attempt builder decisions — deferral can fire once per flashblock for a parked validity tx.
- Document that the predicate list lives only on the admission event (join later lifecycle events by `tx_hash`) and add JSON examples for admission, park, and expiry.
- Add emission and retention coverage: RPC predicate round-trip + replacement join, builder deferred/expired/rejected distinguishability and integration tests, and audit ingest + Postgres expiry against peer classes.

Fixes BASE-289, BASE-290. Parent: BASE-153.

## Test plan
- [ ] `cargo test -p base-observability-events --lib`
- [ ] `cargo test -p base-txpool-rpc --lib`
- [ ] `cargo test -p base-builder-core --lib deferred_rejected_and_expired non_parkable_iterator repark_in_the_same_flashblock`
- [ ] `cargo test -p base-builder-core --test transaction_events`
- [ ] `cargo test -p audit-archiver-lib --lib classifies_transaction_event_retention accepts_at_lifecycle_event_types retention_classes_partition_all_event_types`
- [ ] With Docker: `cargo test -p audit-archiver-lib --test postgres_transaction_events postgres_expires_at_lifecycle_events_with_peer_classes`