### PR TITLE
feat(shadow-builder): fund accounts in shadow sequencing cycles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3950,6 +3950,7 @@ dependencies = [
  "base-consensus-sources",
  "base-health",
  "base-metrics",
+ "base-node-runner",
  "base-protocol",
  "base-upgrade-signal",
  "bytes",

--- a/actions/harness/src/sequencer/driver.rs
+++ b/actions/harness/src/sequencer/driver.rs
@@ -277,6 +277,7 @@ impl<E: SequencerEngineBackend> L2Sequencer<E> {
             engine_client,
             is_active: false,
             shadow_blocks_per_cycle: None,
+            shadow_funding: None,
             recovery_mode: RecoveryModeGuard::new(false),
             rollup_config: self.actor_rollup_config(),
             seal_offset: base_protocol::DEFAULT_SEAL_OFFSET,

--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -374,6 +374,21 @@ impl ConsensusNodeArgs {
         Ok(())
     }
 
+    /// Validates that synthetic account funding is confined to shadow sequencers.
+    pub fn validate_shadow_funding(&self) -> eyre::Result<()> {
+        let sequencer = &self.config.sequencer_flags;
+        if sequencer.shadow_funding_amount.is_some() && sequencer.shadow_funding_address.is_none() {
+            eyre::bail!("shadow funding amount requires a shadow funding address");
+        }
+        if sequencer.shadow_funding_address.is_some()
+            && (!self.config.node_mode.is_sequencer()
+                || sequencer.shadow_blocks_per_cycle.is_none())
+        {
+            eyre::bail!("shadow funding is only supported in shadow sequencer mode");
+        }
+        Ok(())
+    }
+
     /// Validates that the dangerous DA batcher sender override is only used by validators.
     pub fn validate_da_batcher_sender_override(&self) -> eyre::Result<()> {
         if self.config.l1_rpc_args.l1_da_batcher_sender_override.is_some()
@@ -417,6 +432,7 @@ impl ConsensusNodeArgs {
         startup_mode: UpgradeSignalStartupMode,
     ) -> eyre::Result<RollupNode> {
         self.validate_sequencer_key()?;
+        self.validate_shadow_funding()?;
         self.validate_da_batcher_sender_override()?;
         if let Some(sender) = self.config.l1_rpc_args.l1_da_batcher_sender_override {
             warn!(
@@ -929,6 +945,45 @@ mod tests {
         );
 
         assert!(args.validate_sequencer_key().is_ok());
+    }
+
+    #[test]
+    fn shadow_funding_is_rejected_outside_shadow_sequencer_mode() {
+        let args = ConsensusNodeArgs::new(
+            ConsensusChainArgs { l2_chain_id: Chain::from(8453_u64) },
+            ConsensusNodeConfigArgs {
+                node_mode: NodeMode::Sequencer,
+                sequencer_flags: SequencerArgs {
+                    shadow_funding_address: Some(address!(
+                        "2222222222222222222222222222222222222222"
+                    )),
+                    ..SequencerArgs::default()
+                },
+                ..default_node_config_args()
+            },
+        );
+
+        assert!(args.validate_shadow_funding().is_err());
+    }
+
+    #[test]
+    fn shadow_funding_is_accepted_in_shadow_sequencer_mode() {
+        let args = ConsensusNodeArgs::new(
+            ConsensusChainArgs { l2_chain_id: Chain::from(8453_u64) },
+            ConsensusNodeConfigArgs {
+                node_mode: NodeMode::Sequencer,
+                sequencer_flags: SequencerArgs {
+                    shadow_blocks_per_cycle: std::num::NonZeroU64::new(10),
+                    shadow_funding_address: Some(address!(
+                        "2222222222222222222222222222222222222222"
+                    )),
+                    ..SequencerArgs::default()
+                },
+                ..default_node_config_args()
+            },
+        );
+
+        assert!(args.validate_shadow_funding().is_ok());
     }
 
     #[test]

--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -380,6 +380,12 @@ impl ConsensusNodeArgs {
         if sequencer.shadow_funding_amount.is_some() && sequencer.shadow_funding_address.is_none() {
             eyre::bail!("shadow funding amount requires a shadow funding address");
         }
+        if sequencer
+            .shadow_funding_amount
+            .is_some_and(|amount| amount > alloy_primitives::U256::from(u128::MAX))
+        {
+            eyre::bail!("shadow funding amount exceeds u128::MAX (TxDeposit::mint limit)");
+        }
         if sequencer.shadow_funding_address.is_some()
             && (!self.config.node_mode.is_sequencer()
                 || sequencer.shadow_blocks_per_cycle.is_none())
@@ -984,6 +990,27 @@ mod tests {
         );
 
         assert!(args.validate_shadow_funding().is_ok());
+    }
+
+    #[test]
+    fn shadow_funding_above_deposit_mint_limit_is_rejected() {
+        let args = ConsensusNodeArgs::new(
+            ConsensusChainArgs { l2_chain_id: Chain::from(8453_u64) },
+            ConsensusNodeConfigArgs {
+                node_mode: NodeMode::Sequencer,
+                sequencer_flags: SequencerArgs {
+                    shadow_blocks_per_cycle: std::num::NonZeroU64::new(10),
+                    shadow_funding_address: Some(address!(
+                        "2222222222222222222222222222222222222222"
+                    )),
+                    shadow_funding_amount: Some(U256::from(u128::MAX) + U256::from(1)),
+                    ..SequencerArgs::default()
+                },
+                ..default_node_config_args()
+            },
+        );
+
+        assert!(args.validate_shadow_funding().is_err());
     }
 
     #[test]

--- a/crates/consensus/cli/src/sequencer.rs
+++ b/crates/consensus/cli/src/sequencer.rs
@@ -5,7 +5,11 @@ use std::{
     time::Duration,
 };
 
-use base_consensus_node::SequencerConfig;
+use alloy_primitives::{
+    Address, U256,
+    utils::{Unit, parse_ether},
+};
+use base_consensus_node::{SequencerConfig, ShadowFunding};
 use base_protocol::DEFAULT_SEAL_OFFSET;
 use clap::Parser;
 use url::Url;
@@ -58,6 +62,23 @@ pub struct SequencerArgs {
     )]
     pub shadow_blocks_per_cycle: Option<NonZeroU64>,
 
+    /// Account to fund in the first private block of every shadow sequencing cycle.
+    #[arg(
+        long = "sequencer.shadow-funding-address",
+        env = "BASE_NODE_SEQUENCER_SHADOW_FUNDING_ADDRESS",
+        requires = "shadow_blocks_per_cycle"
+    )]
+    pub shadow_funding_address: Option<Address>,
+
+    /// ETH to mint into the shadow funding account. Defaults to 10,000 ETH when funding is enabled.
+    #[arg(
+        long = "sequencer.shadow-funding-amount-eth",
+        env = "BASE_NODE_SEQUENCER_SHADOW_FUNDING_AMOUNT_ETH",
+        requires = "shadow_funding_address",
+        value_parser = parse_ether
+    )]
+    pub shadow_funding_amount: Option<U256>,
+
     /// Conductor service RPC endpoint. Providing this value enables the conductor service.
     #[arg(long = "conductor.rpc", env = "BASE_NODE_CONDUCTOR_RPC")]
     pub conductor_rpc: Option<Url>,
@@ -97,6 +118,13 @@ impl SequencerArgs {
             sequencer_stopped: self.stopped,
             sequencer_recovery_mode: self.recover,
             shadow_blocks_per_cycle: self.shadow_blocks_per_cycle,
+            shadow_funding: self.shadow_funding_address.map(|address| {
+                ShadowFunding::new(
+                    address,
+                    self.shadow_funding_amount
+                        .unwrap_or_else(|| U256::from(10_000) * Unit::ETHER.wei()),
+                )
+            }),
             conductor_rpc_url: self.conductor_rpc.clone(),
             conductor_binary_commit: self.conductor_binary_commit,
             conductor_rpc_timeout: self.conductor_rpc_timeout,
@@ -111,6 +139,11 @@ impl SequencerArgs {
 mod tests {
     use std::{num::NonZeroU64, time::Duration};
 
+    use alloy_primitives::{
+        Address, U256, address,
+        utils::{Unit, parse_ether},
+    };
+    use base_consensus_node::ShadowFunding;
     use clap::Parser;
 
     use super::{SequencerArgs, SequencerConfig};
@@ -169,6 +202,54 @@ mod tests {
 
         assert_eq!(args.shadow_blocks_per_cycle, NonZeroU64::new(12));
         assert_eq!(args.config().shadow_blocks_per_cycle, NonZeroU64::new(12));
+    }
+
+    #[test]
+    fn defaults_shadow_funding_to_ten_thousand_eth() {
+        let funding_address = address!("1111111111111111111111111111111111111111");
+        let args = SequencerArgs::parse_from([
+            "base-consensus",
+            "--sequencer.shadow-blocks-per-cycle",
+            "12",
+            "--sequencer.shadow-funding-address",
+            "0x1111111111111111111111111111111111111111",
+        ]);
+
+        assert_eq!(
+            args.config().shadow_funding,
+            Some(ShadowFunding::new(funding_address, U256::from(10_000) * Unit::ETHER.wei()))
+        );
+    }
+
+    #[test]
+    fn parses_configured_shadow_funding_amount_in_eth() {
+        let args = SequencerArgs::parse_from([
+            "base-consensus",
+            "--sequencer.shadow-blocks-per-cycle",
+            "12",
+            "--sequencer.shadow-funding-address",
+            "0x1111111111111111111111111111111111111111",
+            "--sequencer.shadow-funding-amount-eth",
+            "12345",
+        ]);
+
+        let amount = parse_ether("12345").unwrap();
+        assert_eq!(args.shadow_funding_amount, Some(amount));
+        assert_eq!(
+            args.config().shadow_funding,
+            Some(ShadowFunding::new(Address::repeat_byte(0x11), amount))
+        );
+    }
+
+    #[test]
+    fn rejects_shadow_funding_without_shadow_mode() {
+        let result = SequencerArgs::try_parse_from([
+            "base-consensus",
+            "--sequencer.shadow-funding-address",
+            "0x1111111111111111111111111111111111111111",
+        ]);
+
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/consensus/service/Cargo.toml
+++ b/crates/consensus/service/Cargo.toml
@@ -91,6 +91,7 @@ httpmock.workspace = true
 tempfile.workspace = true
 arbitrary.workspace = true
 alloy-network.workspace = true
+base-node-runner = { workspace = true, features = ["test-utils"] }
 base-common-rpc-types.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 alloy-primitives = { workspace = true, features = ["k256"] }

--- a/crates/consensus/service/src/actors/mod.rs
+++ b/crates/consensus/service/src/actors/mod.rs
@@ -66,8 +66,8 @@ pub use sequencer::{
     PreparedL1Origin, QueuedSequencerEngineClient, RecoveryModeGuard, ScheduledTicker, SealState,
     SealStepError, SealStepOutcome, SequencerActor, SequencerActorError, SequencerAdminQuery,
     SequencerConfig, SequencerEngineClient, SequencerEngineRequestCoordinator,
-    SequencerEngineState, ShadowCycle, ShadowReconciliationGate, ShadowReconciliationTask,
-    ShadowSequencingState, UnsealedPayloadHandle,
+    SequencerEngineState, ShadowCycle, ShadowFunding, ShadowReconciliationGate,
+    ShadowReconciliationTask, ShadowSequencingState, UnsealedPayloadHandle,
 };
 #[cfg(test)]
 pub use sequencer::{MockConductor, MockOriginSelector, MockSequencerEngineClient};

--- a/crates/consensus/service/src/actors/sequencer/actor.rs
+++ b/crates/consensus/service/src/actors/sequencer/actor.rs
@@ -34,6 +34,7 @@ use crate::{
             l1_origin::OriginSelector,
             recovery::RecoveryModeGuard,
             seal::{PayloadSealer, SealStepError, SealStepOutcome},
+            shadow_funding::ShadowFunding,
         },
     },
 };
@@ -72,6 +73,8 @@ pub struct SequencerActor<
     pub is_active: bool,
     /// Number of private blocks to build per shadow sequencing cycle.
     pub shadow_blocks_per_cycle: Option<NonZeroU64>,
+    /// Optional account funding injected into the first private block of every shadow cycle.
+    pub shadow_funding: Option<ShadowFunding>,
     /// Shared recovery mode flag.
     pub recovery_mode: RecoveryModeGuard,
     /// The rollup configuration.
@@ -292,7 +295,7 @@ where
         let canonical_head = self.engine_client.get_unsafe_head().await?;
         *shadow = Some(ShadowSequencingState::new(canonical_head)?);
         if self.is_active {
-            let outcome = self.builder.build_on(canonical_head).await?;
+            let outcome = self.builder.build_on(canonical_head, self.shadow_funding).await?;
             Self::apply_eager_build_outcome(outcome, pipeline, build_ticker);
         } else {
             pipeline.next_payload_to_seal = None;
@@ -413,7 +416,7 @@ where
                     .cycle
                     .reconcile(head)?;
                 if self.is_active {
-                    let outcome = self.builder.build_on(head).await?;
+                    let outcome = self.builder.build_on(head, self.shadow_funding).await?;
                     Self::apply_eager_build_outcome(outcome, pipeline, build_ticker);
                 }
             }
@@ -538,9 +541,10 @@ where
         &mut self,
         pipeline: &mut BuildPipelineState,
         build_ticker: &mut ScheduledTicker,
+        shadow_funding: Option<ShadowFunding>,
     ) -> Result<(), SequencerActorError> {
         let parent = pipeline.pending_build_parent.take().expect("caller checked Some");
-        let outcome = self.builder.build_on(parent).await?;
+        let outcome = self.builder.build_on(parent, shadow_funding).await?;
         self.schedule_build_outcome(outcome, pipeline, build_ticker);
         Ok(())
     }
@@ -551,6 +555,7 @@ where
         &mut self,
         pipeline: &mut BuildPipelineState,
         build_ticker: &mut ScheduledTicker,
+        shadow_funding: Option<ShadowFunding>,
     ) -> Result<(), SequencerActorError> {
         let handle = pipeline.next_payload_to_seal.take().expect("caller checked Some");
         let handle_block_number = handle.block_number();
@@ -567,7 +572,7 @@ where
             None => {
                 // Stale build or non-fatal seal error: rebuild immediately on the current unsafe
                 // head.
-                let outcome = self.builder.build().await?;
+                let outcome = self.builder.build(shadow_funding).await?;
                 self.schedule_build_outcome(outcome, pipeline, build_ticker);
             }
         }
@@ -579,8 +584,9 @@ where
         &mut self,
         pipeline: &mut BuildPipelineState,
         build_ticker: &mut ScheduledTicker,
+        shadow_funding: Option<ShadowFunding>,
     ) -> Result<(), SequencerActorError> {
-        let outcome = self.builder.build().await?;
+        let outcome = self.builder.build(shadow_funding).await?;
         self.schedule_build_outcome(outcome, pipeline, build_ticker);
         Ok(())
     }
@@ -592,13 +598,14 @@ where
         &mut self,
         pipeline: &mut BuildPipelineState,
         build_ticker: &mut ScheduledTicker,
+        shadow_funding: Option<ShadowFunding>,
     ) -> Result<(), SequencerActorError> {
         if pipeline.pending_build_parent.is_some() {
-            self.start_pending_child_build(pipeline, build_ticker).await
+            self.start_pending_child_build(pipeline, build_ticker, shadow_funding).await
         } else if pipeline.next_payload_to_seal.is_some() {
-            self.advance_seal_or_rebuild(pipeline, build_ticker).await
+            self.advance_seal_or_rebuild(pipeline, build_ticker, shadow_funding).await
         } else {
-            self.build_fresh(pipeline, build_ticker).await
+            self.build_fresh(pipeline, build_ticker, shadow_funding).await
         }
     }
 }
@@ -710,7 +717,11 @@ where
                 // sealer arm complete all three steps (commit → gossip → insert) before the
                 // next block starts, so the canonical head actually advances.
                 _ = build_ticker.tick(), if self.is_active && self.sealer.is_none() && shadow.as_ref().is_none_or(|s| !s.is_awaiting_reconciliation()) => {
-                    self.handle_build_tick(&mut pipeline, &mut build_ticker).await?;
+                    let shadow_funding = shadow
+                        .as_ref()
+                        .filter(|state| state.cycle.is_at_start())
+                        .and(self.shadow_funding);
+                    self.handle_build_tick(&mut pipeline, &mut build_ticker, shadow_funding).await?;
                 }
             }
         }

--- a/crates/consensus/service/src/actors/sequencer/build.rs
+++ b/crates/consensus/service/src/actors/sequencer/build.rs
@@ -21,6 +21,7 @@ use crate::{
             error::SequencerActorError,
             l1_origin::{L1OriginSelectorError, OriginSelector},
             recovery::RecoveryModeGuard,
+            shadow_funding::ShadowFunding,
         },
     },
 };
@@ -78,9 +79,10 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
     /// Uses the engine's current unsafe head (from the watch channel) as the parent.
     pub async fn build(
         &mut self,
+        shadow_funding: Option<ShadowFunding>,
     ) -> Result<BuildOutcome<UnsealedPayloadHandle>, SequencerActorError> {
         let unsafe_head = self.engine_client.get_unsafe_head().await?;
-        self.build_on(unsafe_head).await
+        self.build_on(unsafe_head, shadow_funding).await
     }
 
     /// Starts building the next L2 block on top of an explicit `parent`, returning a handle to
@@ -92,6 +94,7 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
     pub async fn build_on(
         &mut self,
         parent: L2BlockInfo,
+        shadow_funding: Option<ShadowFunding>,
     ) -> Result<BuildOutcome<UnsealedPayloadHandle>, SequencerActorError> {
         let l1_origin = match self.get_next_payload_l1_origin(parent).await? {
             BuildOutcome::Ready(l1_origin) => l1_origin,
@@ -109,7 +112,9 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
 
         let attributes_build_start = Instant::now();
 
-        let Some(attributes_with_parent) = self.build_attributes(parent, l1_origin).await? else {
+        let Some(attributes_with_parent) =
+            self.build_attributes(parent, l1_origin, shadow_funding).await?
+        else {
             return Ok(BuildOutcome::Deferred);
         };
 
@@ -196,6 +201,7 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
         &mut self,
         unsafe_head: L2BlockInfo,
         l1_origin: BlockInfo,
+        shadow_funding: Option<ShadowFunding>,
     ) -> Result<Option<AttributesWithParent>, SequencerActorError> {
         let mut attributes = match self
             .attributes_builder
@@ -232,6 +238,13 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
                 return Err(err.into());
             }
         };
+
+        if let Some(funding) = shadow_funding {
+            attributes
+                .transactions
+                .get_or_insert_default()
+                .push(funding.transaction(unsafe_head.block_info.hash));
+        }
 
         self.rollup_config.log_upgrade_activation(
             unsafe_head.block_info.number.saturating_add(1),

--- a/crates/consensus/service/src/actors/sequencer/config.rs
+++ b/crates/consensus/service/src/actors/sequencer/config.rs
@@ -6,6 +6,8 @@ use std::{num::NonZeroU64, time::Duration};
 
 use url::Url;
 
+use super::ShadowFunding;
+
 /// Default conductor RPC timeout (1 second), matching the CLI default.
 const DEFAULT_CONDUCTOR_RPC_TIMEOUT: Duration = Duration::from_secs(1);
 
@@ -22,6 +24,8 @@ pub struct SequencerConfig {
     ///
     /// When [`None`], the node runs as a normal sequencer.
     pub shadow_blocks_per_cycle: Option<NonZeroU64>,
+    /// Optional account funding for the first private block of each shadow cycle.
+    pub shadow_funding: Option<ShadowFunding>,
     /// The [`Url`] for the conductor RPC endpoint. If [`Some`], enables the conductor service.
     pub conductor_rpc_url: Option<Url>,
     /// Use the conductor's SSZ-binary commit endpoint (`POST /commit-unsafe-payload`)
@@ -64,6 +68,7 @@ impl Default for SequencerConfig {
             sequencer_stopped: false,
             sequencer_recovery_mode: false,
             shadow_blocks_per_cycle: None,
+            shadow_funding: None,
             conductor_rpc_url: None,
             conductor_binary_commit: false,
             conductor_rpc_timeout: DEFAULT_CONDUCTOR_RPC_TIMEOUT,

--- a/crates/consensus/service/src/actors/sequencer/mod.rs
+++ b/crates/consensus/service/src/actors/sequencer/mod.rs
@@ -24,6 +24,9 @@ pub use seal::{PayloadSealer, SealState, SealStepError, SealStepOutcome};
 mod shadow_cycle;
 pub use shadow_cycle::{ShadowCycle, ShadowReconciliationTask};
 
+mod shadow_funding;
+pub use shadow_funding::ShadowFunding;
+
 mod engine_request_coordinator;
 pub use engine_request_coordinator::SequencerEngineRequestCoordinator;
 

--- a/crates/consensus/service/src/actors/sequencer/shadow_cycle.rs
+++ b/crates/consensus/service/src/actors/sequencer/shadow_cycle.rs
@@ -38,6 +38,11 @@ impl ShadowCycle {
         Ok(Self::Building { next_height, built: 0 })
     }
 
+    /// Returns whether no private block has yet been inserted in this cycle.
+    pub const fn is_at_start(self) -> bool {
+        matches!(self, Self::Building { built: 0, .. })
+    }
+
     /// Returns the reconciliation target when private building has reached its cycle limit.
     pub const fn reconciliation_target(self) -> Option<L2BlockInfo> {
         match self {
@@ -144,7 +149,9 @@ mod tests {
     #[test]
     fn reaches_reconciliation_after_configured_insertions() {
         let mut cycle = ShadowCycle::building(head(10)).unwrap();
+        assert!(cycle.is_at_start());
         assert!(!cycle.record_insertion(head(11), 2).unwrap());
+        assert!(!cycle.is_at_start());
         assert!(cycle.record_insertion(head(12), 2).unwrap());
         assert_eq!(cycle.reconciliation_target(), Some(head(12)));
     }
@@ -154,5 +161,6 @@ mod tests {
         let mut cycle = ShadowCycle::AwaitingReconciliation { shadow_head: head(12) };
         cycle.reconcile(head(12)).unwrap();
         assert_eq!(cycle, ShadowCycle::Building { next_height: 13, built: 0 });
+        assert!(cycle.is_at_start());
     }
 }

--- a/crates/consensus/service/src/actors/sequencer/shadow_funding.rs
+++ b/crates/consensus/service/src/actors/sequencer/shadow_funding.rs
@@ -1,0 +1,71 @@
+//! Shadow-sequencer account funding transaction construction.
+
+use alloy_eips::Encodable2718;
+use alloy_primitives::{Address, B256, Bytes, TxKind, U256, keccak256};
+use base_common_consensus::{BaseTxEnvelope, TxDeposit};
+
+/// Funding injected into the first private block of each shadow sequencing cycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ShadowFunding {
+    /// Account credited by the synthetic deposit.
+    pub address: Address,
+    /// Amount credited in wei.
+    pub amount: U256,
+}
+
+impl ShadowFunding {
+    /// Creates a shadow funding configuration.
+    pub const fn new(address: Address, amount: U256) -> Self {
+        Self { address, amount }
+    }
+
+    /// Encodes the synthetic deposit transaction for a cycle beginning at `parent_hash`.
+    pub fn transaction(self, parent_hash: B256) -> Bytes {
+        let source_hash = keccak256(
+            [
+                b"base-shadow-sequencer-funding-v1".as_slice(),
+                parent_hash.as_slice(),
+                self.address.as_slice(),
+                &self.amount.to_be_bytes::<32>(),
+            ]
+            .concat(),
+        );
+        BaseTxEnvelope::from(TxDeposit {
+            source_hash,
+            from: self.address,
+            to: TxKind::Call(self.address),
+            mint: self.amount.to::<u128>(),
+            value: U256::ZERO,
+            gas_limit: 21_000,
+            is_system_transaction: false,
+            input: Bytes::new(),
+        })
+        .encoded_2718()
+        .into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, B256, utils::parse_ether};
+    use alloy_provider::Provider;
+    use base_node_runner::test_utils::TestHarness;
+
+    use super::ShadowFunding;
+
+    #[tokio::test]
+    async fn funding_transaction_mints_configured_balance_in_execution_layer() {
+        let harness = TestHarness::new().await.unwrap();
+        let address = Address::repeat_byte(0x42);
+        let amount = parse_ether("12345").unwrap();
+        let balance_before = harness.provider().get_balance(address).await.unwrap();
+        let funding = ShadowFunding::new(address, amount);
+
+        harness
+            .build_block_from_transactions(vec![funding.transaction(B256::repeat_byte(0x11))])
+            .await
+            .unwrap();
+
+        assert_eq!(harness.provider().get_balance(address).await.unwrap(), balance_before + amount);
+    }
+}

--- a/crates/consensus/service/src/actors/sequencer/shadow_funding.rs
+++ b/crates/consensus/service/src/actors/sequencer/shadow_funding.rs
@@ -34,7 +34,7 @@ impl ShadowFunding {
             source_hash,
             from: self.address,
             to: TxKind::Call(self.address),
-            mint: self.amount.to::<u128>(),
+            mint: self.amount.try_into().expect("shadow funding amount must fit in u128"),
             value: U256::ZERO,
             gas_limit: 21_000,
             is_system_transaction: false,

--- a/crates/consensus/service/src/actors/sequencer/shadow_funding.rs
+++ b/crates/consensus/service/src/actors/sequencer/shadow_funding.rs
@@ -34,7 +34,7 @@ impl ShadowFunding {
             source_hash,
             from: self.address,
             to: TxKind::Call(self.address),
-            mint: self.amount.try_into().expect("shadow funding amount must fit in u128"),
+            mint: self.amount.to::<u128>(),
             value: U256::ZERO,
             gas_limit: 21_000,
             is_system_transaction: false,

--- a/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
@@ -7,9 +7,10 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use alloy_primitives::B256;
+use alloy_primitives::{Address, B256, utils::parse_ether};
 use alloy_rpc_types_engine::ExecutionPayloadV1;
 use alloy_transport::TransportErrorKind;
+use base_common_consensus::BaseTxEnvelope;
 use base_common_genesis::{BaseUpgradeConfig, ChainGenesis, RollupConfig, UpgradeConfig};
 use base_common_rpc_types_engine::{
     BaseExecutionPayload, BaseExecutionPayloadEnvelope, BasePayloadAttributes,
@@ -24,7 +25,7 @@ use tokio::sync::{mpsc, oneshot};
 use crate::{
     ConductorError, L1OriginSelectorError, NodeActor, ResetReason, ScheduledTicker, SealState,
     SealStepError, SealStepOutcome, SequencerActor, SequencerActorError, SequencerAdminQuery,
-    UnsafePayloadGossipClientError, UnsealedPayloadHandle,
+    ShadowFunding, UnsafePayloadGossipClientError, UnsealedPayloadHandle,
     actors::{
         MockConductor, MockOriginSelector, MockSequencerEngineClient,
         MockUnsafePayloadGossipClient,
@@ -203,6 +204,75 @@ async fn test_on_time_or_late_insert_starts_child_build_immediately(#[case] seco
     assert_eq!(
         tokio::time::timeout(Duration::from_millis(1), build_rx.recv()).await.unwrap().unwrap(),
         inserted_head.block_info.number
+    );
+
+    cancellation_token.cancel();
+    actor_task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn shadow_funding_only_applies_to_first_private_block() {
+    let block_time = 2;
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+    let initial_head = head_at_timestamp(0, B256::ZERO, now - block_time);
+    let inserted_head = head_at_timestamp(1, B256::ZERO, now);
+    let funding = ShadowFunding::new(Address::repeat_byte(0x44), parse_ether("12345").unwrap());
+
+    let (build_tx, mut build_rx) = mpsc::unbounded_channel();
+
+    let mut client = MockSequencerEngineClient::new();
+    client.expect_reset_engine_forkchoice_coordinated().times(1).return_once(|_| Ok(()));
+    client.expect_get_unsafe_head().times(3).returning(move || Ok(initial_head));
+    client.expect_start_build_block().times(2).returning(move |attributes| {
+        build_tx
+            .send((
+                attributes.parent().block_info.number,
+                attributes.attributes.transactions.as_ref().is_some_and(|txs| !txs.is_empty()),
+            ))
+            .unwrap();
+        Ok(Default::default())
+    });
+    client.expect_get_sealed_payload().times(1).return_once(|_, _| Ok(dummy_envelope()));
+    client.expect_insert_unsafe_payload().times(1).return_once(move |_| Ok(inserted_head));
+
+    let mut origin_selector = MockOriginSelector::new();
+    origin_selector.expect_next_l1_origin().times(2).returning(|_| Ok(BlockInfo::default()));
+
+    let rollup_config = Arc::new(RollupConfig {
+        block_time,
+        genesis: ChainGenesis {
+            l2_time: initial_head
+                .block_info
+                .timestamp
+                .saturating_sub(initial_head.block_info.number.saturating_mul(block_time)),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let engine_client = Arc::new(client);
+
+    let mut actor = test_actor();
+    actor.builder.attributes_builder = TestAttributesBuilder {
+        attributes: vec![
+            Ok(attributes_at(inserted_head.block_info.timestamp + block_time)),
+            Ok(attributes_at(inserted_head.block_info.timestamp)),
+        ],
+    };
+    actor.builder.engine_client = Arc::clone(&engine_client);
+    actor.builder.origin_selector = origin_selector;
+    actor.builder.rollup_config = Arc::clone(&rollup_config);
+    actor.engine_client = engine_client;
+    actor.rollup_config = rollup_config;
+    actor.shadow_blocks_per_cycle = NonZeroU64::new(2);
+    actor.shadow_funding = Some(funding);
+
+    let cancellation_token = actor.cancellation_token.clone();
+    let actor_task = tokio::spawn(actor.start(()));
+
+    assert_eq!(build_rx.recv().await.unwrap(), (initial_head.block_info.number, true));
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(1), build_rx.recv()).await.unwrap().unwrap(),
+        (inserted_head.block_info.number, false)
     );
 
     cancellation_token.cancel();
@@ -605,6 +675,45 @@ async fn test_build_retries_are_paced_after_immediate_budget(
 // --- build tests ---
 
 #[tokio::test]
+async fn shadow_funding_is_included_in_payload_attributes() {
+    let unsafe_head = head_at_with_hash(10, B256::repeat_byte(0x22));
+    let l1_origin = BlockInfo::default();
+    let mut client = MockSequencerEngineClient::new();
+    client.expect_get_unsafe_head().times(1).return_once(move || Ok(unsafe_head));
+    client.expect_start_build_block().times(1).return_once(|_| Ok(Default::default()));
+
+    let mut origin_selector = MockOriginSelector::new();
+    origin_selector.expect_next_l1_origin().times(1).return_once(move |_| Ok(l1_origin));
+
+    let address = Address::repeat_byte(0x44);
+    let amount = parse_ether("12345").unwrap();
+    let mut actor = test_actor();
+    actor.builder.origin_selector = origin_selector;
+    actor.builder.engine_client = Arc::new(client);
+    actor.builder.attributes_builder =
+        TestAttributesBuilder { attributes: vec![Ok(BasePayloadAttributes::default())] };
+
+    let crate::BuildOutcome::Ready(handle) =
+        actor.builder.build(Some(ShadowFunding::new(address, amount))).await.unwrap()
+    else {
+        panic!("shadow payload build should start");
+    };
+    let transaction = handle
+        .attributes_with_parent
+        .attributes
+        .decoded_transactions()
+        .next()
+        .expect("funding transaction should be present")
+        .unwrap();
+    let BaseTxEnvelope::Deposit(deposit) = transaction else {
+        panic!("funding transaction should be a deposit");
+    };
+
+    assert_eq!(deposit.from, address);
+    assert_eq!(deposit.mint, amount.to::<u128>());
+}
+
+#[tokio::test]
 async fn test_orphaned_l1_origin_resets_once_without_starting_block_build() {
     let unsafe_head = L2BlockInfo::default();
     let mut client = MockSequencerEngineClient::new();
@@ -628,7 +737,7 @@ async fn test_orphaned_l1_origin_resets_once_without_starting_block_build() {
     actor.builder.origin_selector = origin_selector;
     actor.builder.engine_client = Arc::new(client);
 
-    assert!(matches!(actor.builder.build().await.unwrap(), crate::BuildOutcome::Deferred));
+    assert!(matches!(actor.builder.build(None).await.unwrap(), crate::BuildOutcome::Deferred));
 }
 
 #[tokio::test]
@@ -656,7 +765,7 @@ async fn test_orphaned_l1_origin_propagates_engine_reset_failure() {
     actor.builder.engine_client = Arc::new(client);
 
     assert!(matches!(
-        actor.builder.build().await,
+        actor.builder.build(None).await,
         Err(SequencerActorError::EngineError(EngineClientError::ResetForkchoiceError(error)))
             if error == "mock reset failure"
     ));
@@ -691,7 +800,7 @@ async fn test_build_unsealed_payload_prepare_payload_attributes_error(
     actor.builder.engine_client = Arc::new(client);
     actor.builder.attributes_builder = attributes_builder;
 
-    let result = actor.builder.build().await;
+    let result = actor.builder.build(None).await;
     if expect_err {
         assert!(result.is_err());
         assert!(matches!(

--- a/crates/consensus/service/src/actors/sequencer/tests/test_util.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/test_util.rs
@@ -42,6 +42,7 @@ pub(super) fn test_actor() -> SequencerActor<
         engine_client,
         is_active: true,
         shadow_blocks_per_cycle: None,
+        shadow_funding: None,
         recovery_mode,
         rollup_config,
         seal_offset: base_protocol::DEFAULT_SEAL_OFFSET,

--- a/crates/consensus/service/src/lib.rs
+++ b/crates/consensus/service/src/lib.rs
@@ -46,7 +46,7 @@ pub use actors::{
     RpcActor, RpcActorError, RpcContext, ScheduledTicker, SealState, SealStepError,
     SealStepOutcome, SequencerActor, SequencerActorError, SequencerAdminQuery, SequencerConfig,
     SequencerEngineClient, SequencerEngineRequestCoordinator, SequencerEngineState, ShadowCycle,
-    ShadowReconciliationGate, ShadowReconciliationTask, ShadowSequencingState,
+    ShadowFunding, ShadowReconciliationGate, ShadowReconciliationTask, ShadowSequencingState,
     UnsafePayloadGossipClient, UnsafePayloadGossipClientError, UnsealedPayloadHandle,
     UpgradeSignalMetricsActor, UpgradeSignalNodeConfig, ValidatorEngineRequestHandler,
 };

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -615,6 +615,7 @@ impl RollupNode {
                     engine_client,
                     is_active: self.sequencer_config.sequencer_stopped.not(),
                     shadow_blocks_per_cycle: self.sequencer_config.shadow_blocks_per_cycle,
+                    shadow_funding: self.sequencer_config.shadow_funding,
                     recovery_mode,
                     rollup_config: Arc::clone(&self.config),
                     seal_offset: self.sequencer_config.seal_offset,


### PR DESCRIPTION
## Summary

- add optional synthetic deposit funding to the first private block of every shadow sequencing cycle
- configure the recipient and ETH-denominated amount through sequencer flags or environment variables, defaulting to 10,000 ETH
- reject funding configuration outside shadow sequencer mode
- cover CLI validation, cycle gating, payload injection, and execution-layer balance updates

## Configuration

- `BASE_NODE_SEQUENCER_SHADOW_FUNDING_ADDRESS`
- `BASE_NODE_SEQUENCER_SHADOW_FUNDING_AMOUNT_ETH` (defaults to `10000`)