### PR TITLE
feat(load-tests): update b20 workload to send between accounts

### DIFF
--- a/crates/infra/load-tests/README.md
+++ b/crates/infra/load-tests/README.md
@@ -238,13 +238,14 @@ The `PrecompileLooper` contract enables batch testing by calling a precompile mu
 B-20 precompile tokens can be load-tested to benchmark the precompile's `transfer` performance.
 Each sender creates and owns its own B-20 token: during setup every sender sends one `createB20`
 factory tx (in parallel) whose privileged init calls grant the sender `BURN_ROLE` and mint its
-supply, during the load phase each sender transfers its own token, and during teardown each sender
-burns its remaining balance. A fresh per-run salt keeps each run's token addresses distinct.
+supply, during the load phase each sender transfers its own token to its pair partner (alice <-> bob;
+odd sender counts get one extra funded account so nobody self-transfers), and during teardown each
+sender burns its remaining balance. A fresh per-run salt keeps each run's token addresses distinct.
 
 Requires Beryl activation (B-20 factory and token features must be active on the target chain).
 
 ```yaml
-# Each sender creates and transfers its own B-20 token per run
+# Each sender creates its own B-20 token and transfers it to its pair partner
 transactions:
   - weight: 100
     type: b20

--- a/crates/infra/load-tests/src/runner/config.rs
+++ b/crates/infra/load-tests/src/runner/config.rs
@@ -135,8 +135,8 @@ pub enum TxType {
         /// Looper contract address (required when iterations > 1).
         looper_contract: Option<Address>,
     },
-    /// B-20 precompile token transfer. Each sender creates and transfers its own token, created
-    /// per run during setup.
+    /// B-20 precompile token transfer. Each sender creates its own token per run during setup and
+    /// transfers it to a funded pair partner (alice <-> bob).
     B20,
     /// Osaka (Base Azul) opcode or precompile transaction.
     Osaka {

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -439,7 +439,7 @@ impl LoadRunner {
     /// Index of the paired B-20 counterparty (`0<->1`, `2<->3`, ...).
     ///
     /// Odd leftover senders pair with the previous account so the index stays in range.
-    pub(super) fn b20_partner_index(sender_index: usize, sender_count: usize) -> usize {
+    pub(super) const fn b20_partner_index(sender_index: usize, sender_count: usize) -> usize {
         if sender_count < 2 {
             sender_index
         } else if (sender_index ^ 1) < sender_count {

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -78,6 +78,15 @@ impl LoadRunner {
         )
     )]
     pub fn new(config: LoadConfig) -> Result<Self> {
+        let requested_account_count = config.account_count;
+        let config = Self::with_b20_pair_accounts(config);
+        if config.account_count != requested_account_count {
+            info!(
+                requested = requested_account_count,
+                account_count = config.account_count,
+                "B-20 pairs senders; added one funded partner account"
+            );
+        }
         config.validate()?;
 
         let client = RpcProviders::query(config.query_rpc.clone())?;
@@ -265,7 +274,11 @@ impl LoadRunner {
                 self.b20_run_salt,
             )?;
             let sender_index = type_index % accounts.len();
-            let recipient_index = (sender_index + 1) % accounts.len();
+            let recipient_index = if matches!(tx_config.tx_type, TxType::B20) {
+                Self::b20_partner_index(sender_index, accounts.len())
+            } else {
+                (sender_index + 1) % accounts.len()
+            };
             let account = &accounts[sender_index];
             let from = account.address;
             let to = accounts[recipient_index].address;
@@ -413,6 +426,29 @@ impl LoadRunner {
         self.config.transactions.iter().any(|t| matches!(t.tx_type, TxType::B20))
     }
 
+    /// Ensures B-20 workloads have even sender count so every alice has a funded bob.
+    fn with_b20_pair_accounts(mut config: LoadConfig) -> LoadConfig {
+        if config.transactions.iter().any(|t| matches!(t.tx_type, TxType::B20))
+            && config.account_count % 2 == 1
+        {
+            config.account_count = config.account_count.saturating_add(1);
+        }
+        config
+    }
+
+    /// Index of the paired B-20 counterparty (`0<->1`, `2<->3`, ...).
+    ///
+    /// Odd leftover senders pair with the previous account so the index stays in range.
+    pub(super) fn b20_partner_index(sender_index: usize, sender_count: usize) -> usize {
+        if sender_count < 2 {
+            sender_index
+        } else if (sender_index ^ 1) < sender_count {
+            sender_index ^ 1
+        } else {
+            sender_index - 1
+        }
+    }
+
     /// Recovers real-token balances before native ETH drain.
     pub async fn recover_real_tokens(
         &self,
@@ -516,6 +552,47 @@ impl std::fmt::Debug for LoadRunner {
 #[cfg(test)]
 mod tests {
     use super::{LoadConfig, LoadRunner};
+    use crate::runner::{TxConfig, TxType};
+
+    #[test]
+    fn b20_odd_sender_count_adds_funded_partner() {
+        let config = LoadConfig {
+            account_count: 1,
+            transactions: vec![TxConfig { weight: 100, tx_type: TxType::B20 }],
+            ..LoadConfig::devnet()
+        };
+        let runner = LoadRunner::new(config).expect("valid config");
+        assert_eq!(runner.accounts.len(), 2, "single B-20 sender must get a funded bob");
+        assert_eq!(runner.config.account_count, 2);
+    }
+
+    #[test]
+    fn b20_even_sender_count_unchanged() {
+        let config = LoadConfig {
+            account_count: 10,
+            transactions: vec![TxConfig { weight: 100, tx_type: TxType::B20 }],
+            ..LoadConfig::devnet()
+        };
+        let runner = LoadRunner::new(config).expect("valid config");
+        assert_eq!(runner.accounts.len(), 10, "even B-20 sender count must stay unchanged");
+    }
+
+    #[test]
+    fn non_b20_odd_sender_count_unchanged() {
+        let config = LoadConfig { account_count: 1, ..LoadConfig::devnet() };
+        let runner = LoadRunner::new(config).expect("valid config");
+        assert_eq!(runner.accounts.len(), 1, "ETH transfer workloads must not add a partner");
+    }
+
+    #[test]
+    fn b20_partner_index_pairs_neighbors() {
+        assert_eq!(LoadRunner::b20_partner_index(0, 1), 0, "lone sender has no partner");
+        assert_eq!(LoadRunner::b20_partner_index(0, 2), 1, "alice -> bob");
+        assert_eq!(LoadRunner::b20_partner_index(1, 2), 0, "bob -> alice");
+        assert_eq!(LoadRunner::b20_partner_index(2, 4), 3);
+        assert_eq!(LoadRunner::b20_partner_index(3, 4), 2);
+        assert_eq!(LoadRunner::b20_partner_index(2, 3), 1, "odd leftover pairs with previous");
+    }
 
     #[test]
     fn fresh_recipient_seed_mode_randomizes_across_runs_even_below_ratio_one() {

--- a/crates/infra/load-tests/src/runner/pacing.rs
+++ b/crates/infra/load-tests/src/runner/pacing.rs
@@ -1188,7 +1188,7 @@ impl LoadRunner {
             for _ in 0..txs_per_sender {
                 let payload = generator.select_payload()?;
                 let sender_pool_recipient =
-                    if payload.name() == "b20" { pair_recipient } else { ring_recipient };
+                    if payload.uses_pair_recipient() { pair_recipient } else { ring_recipient };
                 let to = if payload.uses_runner_recipient() {
                     Self::select_recipient(
                         recipient_keys,

--- a/crates/infra/load-tests/src/runner/pacing.rs
+++ b/crates/infra/load-tests/src/runner/pacing.rs
@@ -1180,11 +1180,15 @@ impl LoadRunner {
         }
         let mut sender_jobs = Vec::with_capacity(sender_count);
         for (sender_index, from) in config.sender_addresses.iter().copied().enumerate() {
-            let sender_pool_recipient = config.sender_addresses[(sender_index + 1) % sender_count];
+            let ring_recipient = config.sender_addresses[(sender_index + 1) % sender_count];
+            let pair_index = Self::b20_partner_index(sender_index, sender_count);
+            let pair_recipient = config.sender_addresses[pair_index];
             let cohort = config.validity_router.cohort_for_sender(from);
             let mut prepared_txs = Vec::with_capacity(txs_per_sender);
             for _ in 0..txs_per_sender {
                 let payload = generator.select_payload()?;
+                let sender_pool_recipient =
+                    if payload.name() == "b20" { pair_recipient } else { ring_recipient };
                 let to = if payload.uses_runner_recipient() {
                     Self::select_recipient(
                         recipient_keys,

--- a/crates/infra/load-tests/src/workload/generator.rs
+++ b/crates/infra/load-tests/src/workload/generator.rs
@@ -29,6 +29,11 @@ impl SelectedPayload {
     pub(crate) fn uses_runner_recipient(&self) -> bool {
         self.payload.uses_runner_recipient()
     }
+
+    /// Returns the payload type name (for example `"b20"`).
+    pub(crate) fn name(&self) -> &'static str {
+        self.payload.name()
+    }
 }
 
 /// Generates transaction workloads from configured payloads.

--- a/crates/infra/load-tests/src/workload/generator.rs
+++ b/crates/infra/load-tests/src/workload/generator.rs
@@ -30,9 +30,9 @@ impl SelectedPayload {
         self.payload.uses_runner_recipient()
     }
 
-    /// Returns the payload type name (for example `"b20"`).
-    pub(crate) fn name(&self) -> &'static str {
-        self.payload.name()
+    /// Returns true when the runner recipient should be this sender's pair partner.
+    pub(crate) fn uses_pair_recipient(&self) -> bool {
+        self.payload.uses_pair_recipient()
     }
 }
 

--- a/crates/infra/load-tests/src/workload/payloads/b20.rs
+++ b/crates/infra/load-tests/src/workload/payloads/b20.rs
@@ -96,6 +96,10 @@ impl Payload for B20TransferPayload {
         true
     }
 
+    fn uses_pair_recipient(&self) -> bool {
+        true
+    }
+
     fn generate(&self, rng: &mut SeededRng, from: Address, to: Address) -> TransactionRequest {
         let run_salt =
             self.run_salt().expect("b20 run salt must be set by prepare before generate");
@@ -191,6 +195,16 @@ mod tests {
             tx.input.input().expect("input set").as_ref(),
             expected.abi_encode().as_slice(),
             "calldata must be a transfer of the chosen amount to the recipient"
+        );
+    }
+
+    #[test]
+    fn b20_payload_uses_pair_recipient() {
+        let payload = B20TransferPayload::pending(U256::from(1), U256::from(1));
+        assert!(payload.uses_runner_recipient(), "B-20 transfers consume the runner recipient");
+        assert!(
+            payload.uses_pair_recipient(),
+            "B-20 transfers target the pair partner, not a ring"
         );
     }
 

--- a/crates/infra/load-tests/src/workload/payloads/b20.rs
+++ b/crates/infra/load-tests/src/workload/payloads/b20.rs
@@ -42,7 +42,8 @@ pub(crate) fn b20_token_for(sender: Address, run_salt: B256) -> Address {
 /// Generates B-20 precompile token transfer transactions.
 ///
 /// During the load phase, each generated transaction calls `transfer(address,uint256)` on the
-/// sender's own B-20 token precompile. The B-20 `transfer` selector is ERC-20 compatible, so this
+/// sender's own B-20 token precompile, sending to the runner-supplied recipient (the paired
+/// counterparty: alice <-> bob). The B-20 `transfer` selector is ERC-20 compatible, so this
 /// exercises the precompile's state-mutation code path (balance updates, event emission) under
 /// sustained load.
 ///

--- a/crates/infra/load-tests/src/workload/payloads/mod.rs
+++ b/crates/infra/load-tests/src/workload/payloads/mod.rs
@@ -54,6 +54,12 @@ pub trait Payload: Send + Sync + std::fmt::Debug {
     /// Returns true when this payload uses the runner-supplied recipient address.
     fn uses_runner_recipient(&self) -> bool;
 
+    /// Returns true when the runner recipient should be this sender's pair partner (alice <-> bob)
+    /// rather than the next sender in a ring.
+    fn uses_pair_recipient(&self) -> bool {
+        false
+    }
+
     /// Generates a transaction request.
     fn generate(&self, rng: &mut SeededRng, from: Address, to: Address) -> TransactionRequest;
 

--- a/crates/infra/load-tests/src/workload/payloads/transfer.rs
+++ b/crates/infra/load-tests/src/workload/payloads/transfer.rs
@@ -67,5 +67,6 @@ mod tests {
         let payload = TransferPayload::default();
         assert_eq!(payload.name(), "transfer");
         assert!(payload.uses_runner_recipient());
+        assert!(!payload.uses_pair_recipient());
     }
 }


### PR DESCRIPTION
Odd sender counts get one extra funded account so B-20 load no longer self-transfers.