### PR TITLE
fix(derive): reject span batches at Denim

### DIFF
--- a/actions/harness/src/engine.rs
+++ b/actions/harness/src/engine.rs
@@ -208,6 +208,13 @@ impl ActionEngineClient {
                 "beryl activation timestamp ({beryl}) must be <= cobalt activation timestamp ({cobalt})",
             );
         }
+        if let Some(denim) = hf.base.denim {
+            let cobalt = hf.base.cobalt.expect("denim requires cobalt to be configured");
+            assert!(
+                cobalt <= denim,
+                "cobalt activation timestamp ({cobalt}) must be <= denim activation timestamp ({denim})",
+            );
+        }
 
         // Base Azul requires Osaka (the EL counterpart).
         genesis.config.osaka_time = hf.base.azul;
@@ -220,6 +227,9 @@ impl ActionEngineClient {
         }
         if let Some(ts) = hf.base.cobalt {
             base.insert("cobalt".to_string(), serde_json::json!(ts));
+        }
+        if let Some(ts) = hf.base.denim {
+            base.insert("denim".to_string(), serde_json::json!(ts));
         }
         if base.is_empty() {
             genesis.config.extra_fields.remove("base");
@@ -1047,5 +1057,47 @@ impl SequencerEngineClient for ActionEngineClient {
 impl crate::SequencerEngineBackend for ActionEngineClient {
     fn block_hash_registry(&self) -> SharedBlockHashRegistry {
         self.block_registry.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base_common_genesis::{BaseUpgradeConfig, UpgradeConfig};
+
+    use super::*;
+
+    #[test]
+    fn build_genesis_propagates_denim_activation() {
+        let config = RollupConfig {
+            upgrades: UpgradeConfig {
+                base: BaseUpgradeConfig {
+                    azul: Some(42),
+                    beryl: Some(42),
+                    cobalt: Some(42),
+                    denim: Some(42),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let genesis = ActionEngineClient::build_genesis_for_rollup(&config);
+
+        assert_eq!(genesis.config.extra_fields["base"]["denim"], serde_json::json!(42));
+    }
+
+    #[test]
+    #[should_panic(expected = "denim requires cobalt to be configured")]
+    fn build_genesis_requires_cobalt_before_denim() {
+        let config = RollupConfig {
+            upgrades: UpgradeConfig {
+                base: BaseUpgradeConfig { denim: Some(42), ..Default::default() },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        ActionEngineClient::build_genesis_for_rollup(&config);
     }
 }

--- a/actions/harness/tests/batcher/upgrade_transitions.rs
+++ b/actions/harness/tests/batcher/upgrade_transitions.rs
@@ -6,7 +6,7 @@ use base_action_harness::{
     SharedL1Chain, TestRollupConfigBuilder,
 };
 use base_batcher_encoder::{DaType, EncoderConfig};
-use base_common_genesis::{RollupConfig, UpgradeConfig};
+use base_common_genesis::{BaseUpgradeConfig, RollupConfig, UpgradeConfig};
 use tracing_subscriber::EnvFilter;
 
 // ---------------------------------------------------------------------------
@@ -199,7 +199,83 @@ async fn mixed_singular_and_span_batches_after_delta() {
 }
 
 // ---------------------------------------------------------------------------
-// C. Granite channel timeout enforcement
+// C. Span batches stop at Denim and recover through production SingleBatch
+// ---------------------------------------------------------------------------
+
+/// A historical Span fixture may derive its pre-Denim prefix, but the cached
+/// tail must be discarded before the first Denim block. Resubmitting that tail
+/// through the production `SingleBatch` batcher must derive across Denim's 200ms
+/// block cadence.
+#[tokio::test]
+async fn span_batch_stops_at_denim_and_recovers_with_single_batches() {
+    let batcher_cfg = BatcherConfig {
+        encoder: EncoderConfig { da_type: DaType::Calldata, ..EncoderConfig::default() },
+        ..BatcherConfig::default()
+    };
+    let upgrades = UpgradeConfig {
+        regolith_time: Some(0),
+        canyon_time: Some(0),
+        delta_time: Some(0),
+        ecotone_time: Some(0),
+        fjord_time: Some(0),
+        granite_time: Some(0),
+        holocene_time: Some(0),
+        isthmus_time: Some(0),
+        jovian_time: Some(0),
+        base: BaseUpgradeConfig {
+            azul: Some(0),
+            beryl: Some(0),
+            cobalt: Some(0),
+            denim: Some(6),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let rollup_cfg =
+        TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_upgrades(upgrades).build();
+    assert_eq!(
+        (3..=8).map(|number| rollup_cfg.l2_block_timestamp_parts(number)).collect::<Vec<_>>(),
+        vec![(6, 0), (6, 200), (6, 400), (6, 600), (6, 800), (7, 0)]
+    );
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut builder = h.create_l2_sequencer(l1_chain);
+    let mut blocks = Vec::new();
+    for _ in 0..8 {
+        blocks.push(builder.build_next_block_with_single_transaction().await);
+    }
+
+    let (mut node, chain) = h.create_test_rollup_node_from_sequencer(
+        &mut builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
+
+    h.submit_span_batch_calldata(&batcher_cfg, &blocks, 100).expect("span fixture submission");
+    chain.push(h.l1.tip().clone());
+
+    node.initialize().await;
+    node.run_until_idle().await;
+    assert_eq!(
+        node.l2_safe_number(),
+        2,
+        "only blocks before Denim activation at block 3 may derive from the span"
+    );
+
+    let mut source = ActionL2Source::new();
+    for block in blocks.into_iter().skip(2) {
+        source.push(block);
+    }
+    Batcher::new(source, &h.rollup_config, batcher_cfg).advance(&mut h.l1).await;
+    chain.push(h.l1.tip().clone());
+
+    let recovered = node.run_until_idle().await;
+    assert_eq!(recovered, 6, "the SingleBatch path must recover all post-Denim blocks");
+    assert_eq!(node.l2_safe_number(), 8, "safe head must advance across Denim");
+}
+
+// ---------------------------------------------------------------------------
+// D. Granite channel timeout enforcement
 //
 // Verifies that the post-Granite 50-block channel timeout is enforced.
 // ---------------------------------------------------------------------------
@@ -345,7 +421,7 @@ async fn granite_channel_timeout_enforced() {
 }
 
 // ---------------------------------------------------------------------------
-// D. Jovian SingleBatch transition block is deposit-only
+// E. Jovian SingleBatch transition block is deposit-only
 // ---------------------------------------------------------------------------
 
 /// When a `SingleBatch` is submitted for the first Jovian upgrade block (block 3

--- a/crates/consensus/derive/src/stages/batch/batch_queue.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_queue.rs
@@ -299,6 +299,14 @@ where
     /// Returns the next valid batch upon the given safe head.
     /// Also returns the boolean that indicates if the batch is the last block in the batch.
     async fn next_batch(&mut self, parent: L2BlockInfo) -> PipelineResult<SingleBatch> {
+        let next = parent.block_info.number.saturating_add(1);
+        if self.cfg.is_denim_active(self.cfg.l2_block_timestamp(next))
+            && !self.next_spans.is_empty()
+        {
+            warn!(target: "batch_queue", next_block_number = next, cached_batches = self.next_spans.len(), "Dropping cached span batches after Denim activation");
+            self.next_spans.clear();
+        }
+
         if !self.next_spans.is_empty() {
             // There are cached singular batches derived from the span batch.
             // Check if the next cached batch matches the given parent block.
@@ -502,7 +510,9 @@ mod tests {
     use alloy_eips::BlockNumHash;
     use alloy_primitives::{B256, address, b256};
     use base_common_consensus::BaseBlock;
-    use base_common_genesis::{ChainGenesis, RollupConfig, SystemConfig, UpgradeConfig};
+    use base_common_genesis::{
+        BaseUpgradeConfig, ChainGenesis, RollupConfig, SystemConfig, UpgradeConfig,
+    };
     use base_protocol::{BatchReader, BatchValidationProvider, SpanBatch, SpanBatchElement};
     use tracing::Level;
 
@@ -580,6 +590,29 @@ mod tests {
         let next = bq.pop_next_batch(parent).unwrap();
         assert_eq!(next.timestamp, second.timestamp);
         assert_eq!(next.parent_hash, parent.block_info.hash);
+        assert!(bq.next_spans.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_cached_span_is_not_emitted_at_denim() {
+        let cfg = Arc::new(RollupConfig {
+            block_time: 2,
+            upgrades: UpgradeConfig {
+                base: BaseUpgradeConfig { denim: Some(6), ..Default::default() },
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let mock = TestNextBatchProvider::new(vec![]);
+        let fetcher = TestL2ChainProvider::default();
+        let mut bq = BatchQueue::new(cfg, mock, fetcher);
+        bq.next_spans.push_back(SingleBatch { timestamp: 6, ..Default::default() });
+        let parent = L2BlockInfo {
+            block_info: BlockInfo { number: 2, timestamp: 4, ..Default::default() },
+            ..Default::default()
+        };
+
+        assert!(bq.next_batch(parent).await.is_err());
         assert!(bq.next_spans.is_empty());
     }
 

--- a/crates/consensus/derive/src/stages/batch/batch_queue.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_queue.rs
@@ -299,7 +299,7 @@ where
     /// Returns the next valid batch upon the given safe head.
     /// Also returns the boolean that indicates if the batch is the last block in the batch.
     async fn next_batch(&mut self, parent: L2BlockInfo) -> PipelineResult<SingleBatch> {
-        let next = parent.block_info.number.saturating_add(1);
+        let next = parent.block_info.number + 1;
         if self.cfg.is_denim_active(self.cfg.l2_block_timestamp(next))
             && !self.next_spans.is_empty()
         {

--- a/crates/consensus/derive/src/stages/batch/batch_stream.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_stream.rs
@@ -131,6 +131,15 @@ where
             return self.prev.next_batch().await;
         }
 
+        let next = parent.block_info.number.saturating_add(1);
+        if self.config.is_denim_active(self.config.l2_block_timestamp(next))
+            && (self.span.is_some() || !self.buffer.is_empty())
+        {
+            warn!(target: "batch_span", next_block_number = next, "Dropping cached span state after Denim activation");
+            self.flush();
+            return Err(PipelineError::NotEnoughData.temp());
+        }
+
         // If the buffer is empty, attempt to pull a batch from the previous stage.
         if self.buffer.is_empty() {
             // Safety: bubble up any errors from the batch reader.
@@ -258,7 +267,7 @@ mod tests {
     use alloy_eips::{BlockNumHash, NumHash};
     use alloy_primitives::{FixedBytes, b256};
     use base_common_consensus::BaseBlock;
-    use base_common_genesis::{ChainGenesis, SystemConfig, UpgradeConfig};
+    use base_common_genesis::{BaseUpgradeConfig, ChainGenesis, SystemConfig, UpgradeConfig};
     use base_protocol::{SingleBatch, SpanBatchElement};
 
     use super::*;
@@ -418,6 +427,53 @@ mod tests {
         let err = stream.next_batch(Default::default(), &mock_origins).await.unwrap_err();
         assert_eq!(err, PipelineError::Eof.temp());
         assert_eq!(stream.span_buffer_size(), 0);
+        assert!(stream.span.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_crossing_span_stops_before_first_denim_block() {
+        let span = SpanBatch {
+            batches: vec![
+                SpanBatchElement { epoch_num: 1, timestamp: 2, ..Default::default() },
+                SpanBatchElement { epoch_num: 1, timestamp: 4, ..Default::default() },
+                SpanBatchElement { epoch_num: 1, timestamp: 6, ..Default::default() },
+                SpanBatchElement { epoch_num: 1, timestamp: 8, ..Default::default() },
+            ],
+            ..Default::default()
+        };
+        let origins = [BlockInfo { number: 1, ..Default::default() }];
+        let config = Arc::new(RollupConfig {
+            block_time: 2,
+            upgrades: UpgradeConfig {
+                delta_time: Some(0),
+                holocene_time: Some(0),
+                base: BaseUpgradeConfig { denim: Some(6), ..Default::default() },
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let prev = TestBatchStreamProvider::new(vec![Ok(Batch::Span(span))]);
+        let mut stream = BatchStream::new(prev, config, TestL2ChainProvider::default());
+
+        let first = stream.next_batch(L2BlockInfo::default(), &origins).await.unwrap();
+        assert_eq!(first.timestamp(), 2);
+
+        let second_parent = L2BlockInfo {
+            block_info: BlockInfo { number: 1, timestamp: 2, ..Default::default() },
+            ..Default::default()
+        };
+        let second = stream.next_batch(second_parent, &origins).await.unwrap();
+        assert_eq!(second.timestamp(), 4);
+
+        let denim_parent = L2BlockInfo {
+            block_info: BlockInfo { number: 2, timestamp: 4, ..Default::default() },
+            ..Default::default()
+        };
+        assert_eq!(
+            stream.next_batch(denim_parent, &origins).await,
+            Err(PipelineError::NotEnoughData.temp())
+        );
+        assert!(stream.buffer.is_empty());
         assert!(stream.span.is_none());
     }
 

--- a/crates/consensus/derive/src/stages/batch/batch_stream.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_stream.rs
@@ -131,7 +131,7 @@ where
             return self.prev.next_batch().await;
         }
 
-        let next = parent.block_info.number.saturating_add(1);
+        let next = parent.block_info.number + 1;
         if self.config.is_denim_active(self.config.l2_block_timestamp(next))
             && (self.span.is_some() || !self.buffer.is_empty())
         {

--- a/crates/consensus/protocol/src/batch/span.rs
+++ b/crates/consensus/protocol/src/batch/span.rs
@@ -1073,23 +1073,24 @@ mod tests {
             ..Default::default()
         };
         let mut fetcher = TestBatchValidator::default();
+        let l1_origins = [BlockInfo::default()];
 
         let pre_denim_parent = L2BlockInfo {
             block_info: BlockInfo { number: 40, timestamp: 100, ..Default::default() },
             ..Default::default()
         };
-        assert_eq!(
+        assert_ne!(
             batch
                 .check_batch_prefix(
                     &cfg,
-                    &[],
+                    &l1_origins,
                     pre_denim_parent,
                     &BlockInfo::default(),
                     &mut fetcher,
                 )
                 .await
                 .0,
-            BatchValidity::Undecided
+            BatchValidity::Drop(BatchDropReason::SpanBatchPostDenim)
         );
 
         let denim_parent = L2BlockInfo {
@@ -1100,7 +1101,7 @@ mod tests {
             batch
                 .check_batch_prefix(
                     &cfg,
-                    &[BlockInfo::default()],
+                    &l1_origins,
                     denim_parent,
                     &BlockInfo::default(),
                     &mut fetcher,

--- a/crates/consensus/protocol/src/batch/span.rs
+++ b/crates/consensus/protocol/src/batch/span.rs
@@ -592,7 +592,7 @@ impl SpanBatch {
             warn!(target: "batch_span", "empty span batch, cannot proceed with batch checking");
             return (BatchValidity::Undecided, None);
         }
-        let next = l2_safe_head.block_info.number.saturating_add(1);
+        let next = l2_safe_head.block_info.number + 1;
         if cfg.is_denim_active(cfg.l2_block_timestamp(next)) {
             warn!(target: "batch_span", next_block_number = next, "Dropping span batch after Denim activation");
             return (BatchValidity::Drop(BatchDropReason::SpanBatchPostDenim), None);

--- a/crates/consensus/protocol/src/batch/span.rs
+++ b/crates/consensus/protocol/src/batch/span.rs
@@ -588,6 +588,10 @@ impl SpanBatch {
         inclusion_block: &BlockInfo,
         fetcher: &mut BF,
     ) -> (BatchValidity, Option<L2BlockInfo>) {
+        if l1_origins.is_empty() {
+            warn!(target: "batch_span", "missing L1 block input, cannot proceed with batch checking");
+            return (BatchValidity::Undecided, None);
+        }
         if self.batches.is_empty() {
             warn!(target: "batch_span", "empty span batch, cannot proceed with batch checking");
             return (BatchValidity::Undecided, None);
@@ -596,10 +600,6 @@ impl SpanBatch {
         if cfg.is_denim_active(cfg.l2_block_timestamp(next)) {
             warn!(target: "batch_span", next_block_number = next, "Dropping span batch after Denim activation");
             return (BatchValidity::Drop(BatchDropReason::SpanBatchPostDenim), None);
-        }
-        if l1_origins.is_empty() {
-            warn!(target: "batch_span", "missing L1 block input, cannot proceed with batch checking");
-            return (BatchValidity::Undecided, None);
         }
 
         let epoch = l1_origins[0];
@@ -934,7 +934,7 @@ mod tests {
         let l2_safe_head = L2BlockInfo::default();
         let inclusion_block = BlockInfo::default();
         let mut fetcher: TestBatchValidator = TestBatchValidator::default();
-        let batch = SpanBatch { batches: vec![SpanBatchElement::default()], ..Default::default() };
+        let batch = SpanBatch::default();
         assert_eq!(
             batch.check_batch(&cfg, &l1_blocks, l2_safe_head, &inclusion_block, &mut fetcher).await,
             BatchValidity::Undecided
@@ -1098,7 +1098,13 @@ mod tests {
         };
         assert_eq!(
             batch
-                .check_batch_prefix(&cfg, &[], denim_parent, &BlockInfo::default(), &mut fetcher,)
+                .check_batch_prefix(
+                    &cfg,
+                    &[BlockInfo::default()],
+                    denim_parent,
+                    &BlockInfo::default(),
+                    &mut fetcher,
+                )
                 .await
                 .0,
             BatchValidity::Drop(BatchDropReason::SpanBatchPostDenim)

--- a/crates/consensus/protocol/src/batch/span.rs
+++ b/crates/consensus/protocol/src/batch/span.rs
@@ -588,18 +588,22 @@ impl SpanBatch {
         inclusion_block: &BlockInfo,
         fetcher: &mut BF,
     ) -> (BatchValidity, Option<L2BlockInfo>) {
-        if l1_origins.is_empty() {
-            warn!(target: "batch_span", "missing L1 block input, cannot proceed with batch checking");
-            return (BatchValidity::Undecided, None);
-        }
         if self.batches.is_empty() {
             warn!(target: "batch_span", "empty span batch, cannot proceed with batch checking");
             return (BatchValidity::Undecided, None);
         }
+        let next = l2_safe_head.block_info.number.saturating_add(1);
+        if cfg.is_denim_active(cfg.l2_block_timestamp(next)) {
+            warn!(target: "batch_span", next_block_number = next, "Dropping span batch after Denim activation");
+            return (BatchValidity::Drop(BatchDropReason::SpanBatchPostDenim), None);
+        }
+        if l1_origins.is_empty() {
+            warn!(target: "batch_span", "missing L1 block input, cannot proceed with batch checking");
+            return (BatchValidity::Undecided, None);
+        }
 
         let epoch = l1_origins[0];
-        let next_timestamp =
-            cfg.l2_block_timestamp(l2_safe_head.block_info.number.saturating_add(1));
+        let next_timestamp = cfg.l2_block_timestamp(next);
 
         let starting_epoch_num = self.starting_epoch_num();
         let mut batch_origin = epoch;
@@ -930,7 +934,7 @@ mod tests {
         let l2_safe_head = L2BlockInfo::default();
         let inclusion_block = BlockInfo::default();
         let mut fetcher: TestBatchValidator = TestBatchValidator::default();
-        let batch = SpanBatch::default();
+        let batch = SpanBatch { batches: vec![SpanBatchElement::default()], ..Default::default() };
         assert_eq!(
             batch.check_batch(&cfg, &l1_blocks, l2_safe_head, &inclusion_block, &mut fetcher).await,
             BatchValidity::Undecided
@@ -1047,6 +1051,58 @@ mod tests {
             block.timestamp
         );
         assert!(logs[0].contains(&str));
+    }
+
+    #[tokio::test]
+    async fn test_check_batch_prefix_rejects_first_denim_block_with_nonzero_genesis() {
+        let cfg = RollupConfig {
+            block_time: 2,
+            genesis: ChainGenesis {
+                l2: BlockNumHash { number: 40, ..Default::default() },
+                l2_time: 100,
+                ..Default::default()
+            },
+            upgrades: UpgradeConfig {
+                base: BaseUpgradeConfig { denim: Some(104), ..Default::default() },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let batch = SpanBatch {
+            batches: vec![SpanBatchElement { timestamp: 1, ..Default::default() }],
+            ..Default::default()
+        };
+        let mut fetcher = TestBatchValidator::default();
+
+        let pre_denim_parent = L2BlockInfo {
+            block_info: BlockInfo { number: 40, timestamp: 100, ..Default::default() },
+            ..Default::default()
+        };
+        assert_eq!(
+            batch
+                .check_batch_prefix(
+                    &cfg,
+                    &[],
+                    pre_denim_parent,
+                    &BlockInfo::default(),
+                    &mut fetcher,
+                )
+                .await
+                .0,
+            BatchValidity::Undecided
+        );
+
+        let denim_parent = L2BlockInfo {
+            block_info: BlockInfo { number: 41, timestamp: 102, ..Default::default() },
+            ..Default::default()
+        };
+        assert_eq!(
+            batch
+                .check_batch_prefix(&cfg, &[], denim_parent, &BlockInfo::default(), &mut fetcher,)
+                .await
+                .0,
+            BatchValidity::Drop(BatchDropReason::SpanBatchPostDenim)
+        );
     }
 
     #[tokio::test]

--- a/crates/consensus/protocol/src/batch/validity.rs
+++ b/crates/consensus/protocol/src/batch/validity.rs
@@ -50,6 +50,8 @@ pub enum BatchDropReason {
     // === Span batch specific drops ===
     /// Span batch received before Delta upgrade.
     SpanBatchPreDelta,
+    /// Span batch would produce a block after Denim activation.
+    SpanBatchPostDenim,
     /// Span batch has no new blocks after safe head (Holocene inactive).
     SpanBatchNoNewBlocksPreHolocene,
     /// Span batch timestamp is misaligned with block time.
@@ -98,6 +100,7 @@ impl core::fmt::Display for BatchDropReason {
             Self::Eip8130PreCobalt => write!(f, "EIP-8130 transaction before Cobalt activation"),
             Self::NonEmptyTransitionBlock => write!(f, "non-empty batch in transition block"),
             Self::SpanBatchPreDelta => write!(f, "span batch received before Delta upgrade"),
+            Self::SpanBatchPostDenim => write!(f, "span batch received after Denim activation"),
             Self::SpanBatchNoNewBlocksPreHolocene => {
                 write!(f, "span batch has no new blocks after safe head")
             }


### PR DESCRIPTION
- Reject new and cached Span batches before they can produce a Denim-active L2 block while preserving historical pre-Denim derivation.
- Flush crossing Span tails and cover recovery through the production SingleBatch path across Denim’s 200ms cadence.