### PR TITLE
feat(load-tests): Block-Number Offset For Validity Predicates

### DIFF
--- a/crates/infra/load-tests/README.md
+++ b/crates/infra/load-tests/README.md
@@ -337,10 +337,14 @@ validity:
         key: sender
       op: ">="
       value: "0x0"
-    # build-position predicates carry only an operator and value:
+    # build-position predicates read the block/flashblock being built:
     - type: block_number
       op: ">="
-      value: "0x0"
+      value: "0x0"                # absolute block number
+    # ...or a runtime-resolved offset (current_block + offset at prepare time):
+    - type: block_number
+      op: ">="
+      offset: "10"
     - type: flashblock_index
       op: ">="
       value: "1"
@@ -350,11 +354,12 @@ Predicate addresses resolve per transaction: `sender` → the tx `from`,
 `recipient` → the tx `to` (falling back to `from` for contract creation), or a
 fixed `0x` address. Storage slots are either a `fixed` slot or a `mapping`
 slot, which computes the Solidity mapping slot `keccak256(key ++ mapping_slot)`
-so `balanceOf(key)` slots are expressible. The `block_number` and
-`flashblock_index` predicates carry only an `op` and `value` and read the
-build position rather than any address or slot. Values, slots, and masks accept
-hex (`0x...`) or decimal strings. At most 64 predicates may be attached per
-transaction.
+so `balanceOf(key)` slots are expressible. The `flashblock_index` predicate
+carries an `op` and `value`, and `block_number` carries an `op` plus exactly one
+of `value` (a fixed absolute block number) or `offset` (resolved to
+`current_block + offset` at prepare time); both read the build position rather
+than any address or slot. Values, slots, masks, and offsets accept hex (`0x...`)
+or decimal strings. At most 64 predicates may be attached per transaction.
 
 The final summary's `by_cohort` breakdown reports confirmed transactions split
 across the `plain` and `validity_pass` cohorts, so plain traffic can be compared
@@ -364,7 +369,26 @@ against validity traffic when the workload is enabled.
 
 To make the whole validity cohort become valid at the same future block —
 parking it in the pool until then and releasing it as one predictable spike —
-attach a lower-bound `block_number` predicate targeting a future block:
+attach a lower-bound `block_number` predicate targeting a future block.
+
+**Recommended: self-configuring `offset` form.** Give the `block_number`
+predicate an `offset` instead of an absolute `value`. The runner resolves it to
+`current_block + offset` once per prepare round, reading the chain height as
+each round of transactions is prepared, so it automatically accounts for the
+variable number of funding/setup blocks that run before measured submission
+begins:
+
+```yaml
+validity:
+  ratio: 1.0
+  predicates:
+    - type: block_number
+      op: ">="
+      offset: "10"     # resolves to current_block + 10 at prepare time
+```
+
+**Manual alternative: absolute `value` form.** You may instead hand-pick an
+absolute future block number:
 
 ```yaml
 validity:
@@ -375,14 +399,17 @@ validity:
       value: "12345"   # a block that is still in the future when submission starts
 ```
 
-Every validity transaction carries `block_number >= 12345`, so the builder skips
-them until block 12345 and then includes the accumulated backlog together. Choose
-the target relative to the block height **at which measured submission begins**,
-not run-invocation time: account funding and token setup run first and advance the
-chain by a variable number of blocks, so a target that is too low will already be
-satisfied by the time submission starts (no spike). Pick a value comfortably
-beyond the expected setup duration, and confirm the spike landed via the
-`by_cohort` / `fullest_block` breakdown in the summary.
+Either way, every validity transaction carries a lower-bound `block_number`
+predicate, so the builder skips them until the target block and then includes the
+accumulated backlog together. With the absolute form, choose the target relative
+to the block height **at which measured submission begins**, not run-invocation
+time: account funding and token setup run first and advance the chain by a
+variable number of blocks, so a target that is too low will already be satisfied
+by the time submission starts (no spike). Pick a value comfortably beyond the
+expected setup duration. The `offset` form avoids this guesswork. Either way,
+confirm the spike landed via the `by_cohort` / `fullest_block` breakdown in the
+summary. Exactly one of `value` or `offset` may be set on a `block_number`
+predicate; setting both or neither is a configuration error.
 
 **Required flags for end-to-end evaluation.** For predicates to actually be
 evaluated (not merely transported), the target environment must be configured so

--- a/crates/infra/load-tests/src/config/validity.rs
+++ b/crates/infra/load-tests/src/config/validity.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use super::parsing::{parse_address, parse_u256_hex_or_dec};
 use crate::{
-    runner::{PredicateAddress, SlotTemplate, ValidityPredicateTemplate},
+    runner::{BlockNumberBound, PredicateAddress, SlotTemplate, ValidityPredicateTemplate},
     utils::{BaselineError, Result},
 };
 
@@ -58,12 +58,22 @@ pub enum ValidityPredicateConfig {
         /// Right-hand comparison value (hex or decimal).
         value: String,
     },
-    /// Compares the number of the block being built with a value.
+    /// Compares the number of the block being built with a bound.
+    ///
+    /// Exactly one of `value` (a fixed absolute block number) or `offset` (a
+    /// runtime offset resolved to `current_block + offset` at prepare time)
+    /// must be set; setting zero or both is a configuration error.
     BlockNumber {
         /// Comparison operator (`<`, `<=`, `=`, `!=`, `>`, `>=`).
         op: String,
-        /// Right-hand comparison value (hex or decimal).
-        value: String,
+        /// Fixed absolute block number (hex or decimal). Mutually exclusive
+        /// with `offset`.
+        #[serde(default)]
+        value: Option<String>,
+        /// Runtime offset (hex or decimal) resolved to `current_block + offset`
+        /// at prepare time. Mutually exclusive with `value`.
+        #[serde(default)]
+        offset: Option<String>,
     },
     /// Compares the index of the flashblock being built with a value.
     FlashblockIndex {
@@ -189,10 +199,25 @@ impl ValidityPredicateConfig {
                     value: parse_u256_hex_or_dec(value, "validity storage value")?,
                 })
             }
-            Self::BlockNumber { op, value } => Ok(ValidityPredicateTemplate::BlockNumber {
-                op: parse_operator(op)?,
-                value: parse_u256_hex_or_dec(value, "validity block_number value")?,
-            }),
+            Self::BlockNumber { op, value, offset } => {
+                let bound = match (value, offset) {
+                    (Some(value), None) => BlockNumberBound::Absolute(parse_u256_hex_or_dec(
+                        value,
+                        "validity block_number value",
+                    )?),
+                    (None, Some(offset)) => BlockNumberBound::Offset(parse_u256_hex_or_dec(
+                        offset,
+                        "validity block_number offset",
+                    )?),
+                    _ => {
+                        return Err(BaselineError::Config(
+                            "block_number predicate requires exactly one of 'value' or 'offset'"
+                                .into(),
+                        ));
+                    }
+                };
+                Ok(ValidityPredicateTemplate::BlockNumber { op: parse_operator(op)?, bound })
+            }
             Self::FlashblockIndex { op, value } => Ok(ValidityPredicateTemplate::FlashblockIndex {
                 op: parse_operator(op)?,
                 value: parse_u256_hex_or_dec(value, "validity flashblock_index value")?,
@@ -322,12 +347,74 @@ mod tests {
 
     #[test]
     fn block_number_predicate_to_template() {
-        let config =
-            ValidityPredicateConfig::BlockNumber { op: ">=".into(), value: "0x100".into() };
+        let config = ValidityPredicateConfig::BlockNumber {
+            op: ">=".into(),
+            value: Some("0x100".into()),
+            offset: None,
+        };
         match config.to_template().unwrap() {
-            ValidityPredicateTemplate::BlockNumber { op, value } => {
+            ValidityPredicateTemplate::BlockNumber { op, bound } => {
                 assert_eq!(op, ValidityOperator::GreaterThanOrEqual);
-                assert_eq!(value, U256::from(0x100));
+                assert_eq!(bound, BlockNumberBound::Absolute(U256::from(0x100)));
+            }
+            other => panic!("expected block_number template, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn block_number_predicate_offset_to_template() {
+        let config = ValidityPredicateConfig::BlockNumber {
+            op: ">=".into(),
+            value: None,
+            offset: Some("10".into()),
+        };
+        match config.to_template().unwrap() {
+            ValidityPredicateTemplate::BlockNumber { op, bound } => {
+                assert_eq!(op, ValidityOperator::GreaterThanOrEqual);
+                assert_eq!(bound, BlockNumberBound::Offset(U256::from(10)));
+            }
+            other => panic!("expected block_number template, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn block_number_predicate_rejects_both_value_and_offset() {
+        let config = ValidityPredicateConfig::BlockNumber {
+            op: ">=".into(),
+            value: Some("1".into()),
+            offset: Some("10".into()),
+        };
+        let err = config.to_template().unwrap_err();
+        assert!(err.to_string().contains("exactly one of 'value' or 'offset'"));
+    }
+
+    #[test]
+    fn block_number_predicate_rejects_neither_value_nor_offset() {
+        let config =
+            ValidityPredicateConfig::BlockNumber { op: ">=".into(), value: None, offset: None };
+        let err = config.to_template().unwrap_err();
+        assert!(err.to_string().contains("exactly one of 'value' or 'offset'"));
+    }
+
+    #[test]
+    fn block_number_predicate_parses_from_yaml_offset_form() {
+        let config: ValidityPredicateConfig =
+            serde_yaml::from_str("type: block_number\nop: \">=\"\noffset: \"10\"\n").unwrap();
+        match config.to_template().unwrap() {
+            ValidityPredicateTemplate::BlockNumber { bound, .. } => {
+                assert_eq!(bound, BlockNumberBound::Offset(U256::from(10)));
+            }
+            other => panic!("expected block_number template, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn block_number_predicate_parses_from_yaml_value_form() {
+        let config: ValidityPredicateConfig =
+            serde_yaml::from_str("type: block_number\nop: \">=\"\nvalue: \"12345\"\n").unwrap();
+        match config.to_template().unwrap() {
+            ValidityPredicateTemplate::BlockNumber { bound, .. } => {
+                assert_eq!(bound, BlockNumberBound::Absolute(U256::from(12345)));
             }
             other => panic!("expected block_number template, got {other:?}"),
         }
@@ -347,7 +434,11 @@ mod tests {
 
     #[test]
     fn position_predicate_surfaces_bad_operator() {
-        let config = ValidityPredicateConfig::BlockNumber { op: "==".into(), value: "1".into() };
+        let config = ValidityPredicateConfig::BlockNumber {
+            op: "==".into(),
+            value: Some("1".into()),
+            offset: None,
+        };
         assert!(config.to_template().is_err());
     }
 

--- a/crates/infra/load-tests/src/lib.rs
+++ b/crates/infra/load-tests/src/lib.rs
@@ -45,16 +45,16 @@ pub use workload::{
 
 mod runner;
 pub use runner::{
-    AdaptiveBackoff, BatchTxError, BlockClock, BlockMatch, BlockObservation, BlockPulse,
-    BlockReceipt, BlockWatcher, DEFAULT_MAX_GAS_PRICE, DEFAULT_MAX_IN_FLIGHT_PER_SENDER,
-    DisplaySnapshot, FUNDING_MAX_FEE_BASE_FEE_MULTIPLIER, Fees, FlashblockInclusion,
-    FlashblockWatcher, GasPricer, InclusionPulse, InclusionSource, InjectLimit, InjectPlan,
-    LoadConfig, LoadRunner, LoadTestDisplay, LoadTestStage, MAX_FEE_BASE_FEE_MULTIPLIER,
-    MAX_SENDER_WORKER_COUNT, MAX_SIGNER_WORKER_COUNT, MIN_PRIORITY_FEE, MempoolDepthController,
-    PipelineQueue, PipelineStartConfig, PredicateAddress, PreparedBatch, PreparedTransaction,
-    PresignBuffer, QueuedSubmitFailures, ResultsTracker, SENDER_WORKERS_PER_RPC,
-    SIGNER_WORKERS_PER_RPC, SUBMIT_BATCH_QUEUE_BUFFER, SUBMIT_MAX_ATTEMPTS, SenderContext,
-    SentTransaction, SignedBatch, SignedTransaction, SignerContext, SlotTemplate,
+    AdaptiveBackoff, BatchTxError, BlockClock, BlockMatch, BlockNumberBound, BlockObservation,
+    BlockPulse, BlockReceipt, BlockWatcher, DEFAULT_MAX_GAS_PRICE,
+    DEFAULT_MAX_IN_FLIGHT_PER_SENDER, DisplaySnapshot, FUNDING_MAX_FEE_BASE_FEE_MULTIPLIER, Fees,
+    FlashblockInclusion, FlashblockWatcher, GasPricer, InclusionPulse, InclusionSource,
+    InjectLimit, InjectPlan, LoadConfig, LoadRunner, LoadTestDisplay, LoadTestStage,
+    MAX_FEE_BASE_FEE_MULTIPLIER, MAX_SENDER_WORKER_COUNT, MAX_SIGNER_WORKER_COUNT,
+    MIN_PRIORITY_FEE, MempoolDepthController, PipelineQueue, PipelineStartConfig, PredicateAddress,
+    PreparedBatch, PreparedTransaction, PresignBuffer, QueuedSubmitFailures, ResultsTracker,
+    SENDER_WORKERS_PER_RPC, SIGNER_WORKERS_PER_RPC, SUBMIT_BATCH_QUEUE_BUFFER, SUBMIT_MAX_ATTEMPTS,
+    SenderContext, SentTransaction, SignedBatch, SignedTransaction, SignerContext, SlotTemplate,
     SubmissionPipeline, SubmitCohort, SubmitEvent, TxConfig, TxType, ValidityPredicateTemplate,
     ValidityRouter,
 };

--- a/crates/infra/load-tests/src/runner/config.rs
+++ b/crates/infra/load-tests/src/runner/config.rs
@@ -36,6 +36,22 @@ pub enum SlotTemplate {
     },
 }
 
+/// Bound for a `block_number` validity predicate.
+///
+/// A block-number predicate may target a fixed absolute block height, or an
+/// offset that is resolved against the current chain height at submission time
+/// (`current_block + offset`). The offset form makes delayed-validity spikes
+/// self-configuring: it accounts for the variable number of funding/setup blocks
+/// that run before measured submission begins.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockNumberBound {
+    /// A fixed, absolute block number used as-is.
+    Absolute(U256),
+    /// An offset added to the current block height when the template is
+    /// resolved (`current_block + offset`).
+    Offset(U256),
+}
+
 /// A runtime validity predicate template with literal values pre-parsed.
 ///
 /// Addresses and slots may remain symbolic ([`PredicateAddress::Sender`],
@@ -68,13 +84,14 @@ pub enum ValidityPredicateTemplate {
     /// Block-number comparison template.
     ///
     /// Carries no address or slot: the block being built is read from the
-    /// builder's context, so this template resolves to the same predicate for
-    /// every transaction.
+    /// builder's context. The [`BlockNumberBound`] is either a fixed absolute
+    /// value (same predicate for every transaction) or an offset resolved
+    /// against the current chain height per prepare round.
     BlockNumber {
         /// Comparison operator.
         op: ValidityOperator,
-        /// Right-hand comparison value.
-        value: U256,
+        /// Right-hand comparison bound (absolute value or runtime offset).
+        bound: BlockNumberBound,
     },
     /// Flashblock-index comparison template.
     ///

--- a/crates/infra/load-tests/src/runner/mod.rs
+++ b/crates/infra/load-tests/src/runner/mod.rs
@@ -2,8 +2,8 @@
 
 mod config;
 pub use config::{
-    DEFAULT_MAX_GAS_PRICE, DEFAULT_MAX_IN_FLIGHT_PER_SENDER, LoadConfig, PredicateAddress,
-    SlotTemplate, TxConfig, TxType, ValidityPredicateTemplate,
+    BlockNumberBound, DEFAULT_MAX_GAS_PRICE, DEFAULT_MAX_IN_FLIGHT_PER_SENDER, LoadConfig,
+    PredicateAddress, SlotTemplate, TxConfig, TxType, ValidityPredicateTemplate,
 };
 
 mod backoff;

--- a/crates/infra/load-tests/src/runner/pacing.rs
+++ b/crates/infra/load-tests/src/runner/pacing.rs
@@ -1319,14 +1319,8 @@ impl LoadRunner {
         // happens once the enqueue loop returns (deadline reached or channel closed).
         loop {
             // Resolve offset-based block_number predicates against the chain
-            // height once per prepare round (not per transaction). Skip the
-            // extra read entirely unless an offset bound is actually configured,
-            // so absolute-only (and non-validity) runs keep their prior behavior.
-            let current_block = if config.validity_router.needs_current_block() {
-                Self::current_block_height(&config.query_client).await?
-            } else {
-                0
-            };
+            // height once per prepare round (not per transaction).
+            let current_block = Self::current_block_height(&config.query_client).await?;
             let sender_jobs = Self::build_sender_jobs(
                 &mut producer_state.generator,
                 &mut producer_state.recipient_keys,

--- a/crates/infra/load-tests/src/runner/pacing.rs
+++ b/crates/infra/load-tests/src/runner/pacing.rs
@@ -36,7 +36,7 @@ use super::{
 use crate::{
     BaselineError, Result,
     metrics::{MetricsCollector, MetricsSummary, PacingCycleObservation, PacingCycleSource},
-    rpc::BaseFeeExt,
+    rpc::{BaseFeeExt, QueryProvider},
     workload::{KeyStream, SeededRng, WorkloadGenerator},
 };
 
@@ -97,6 +97,9 @@ struct PresignConfig {
     fresh_recipient_ratio: f64,
     signed_chunk_tx: mpsc::Sender<Vec<Vec<SignedTransaction>>>,
     validity_router: ValidityRouter,
+    /// Query provider used to read the current block height per prepare round
+    /// when resolving offset-based `block_number` validity predicates.
+    query_client: QueryProvider,
 }
 
 struct EnqueueProgress {
@@ -632,6 +635,7 @@ impl LoadRunner {
                 fresh_recipient_ratio: self.config.fresh_recipient_ratio,
                 signed_chunk_tx,
                 validity_router: self.validity_router.clone(),
+                query_client: self.client.clone(),
             },
         ));
 
@@ -1159,12 +1163,25 @@ impl LoadRunner {
         }
     }
 
+    /// Reads the latest canonical block number, used to resolve offset-based
+    /// `block_number` validity predicates at prepare time.
+    async fn current_block_height(client: &QueryProvider) -> Result<u64> {
+        let block = client
+            .get_block_by_number(BlockNumberOrTag::Latest)
+            .hashes()
+            .await
+            .map_err(|e| BaselineError::Rpc(format!("failed to read latest block number: {e}")))?
+            .ok_or_else(|| BaselineError::Rpc("latest block is unavailable".into()))?;
+        Ok(block.header.number)
+    }
+
     fn build_sender_jobs(
         generator: &mut WorkloadGenerator,
         recipient_keys: &mut Option<KeyStream>,
         recipient_rng: &mut SeededRng,
         config: &PresignConfig,
         txs_per_sender: usize,
+        current_block: u64,
     ) -> Result<Vec<SenderJob>> {
         if config.sender_addresses.len() != config.sender_next_nonces.len() {
             return Err(BaselineError::Transaction(format!(
@@ -1201,7 +1218,8 @@ impl LoadRunner {
                 let value = tx_request.value.unwrap_or(U256::ZERO);
                 let data = tx_request.input.input().cloned().unwrap_or_default();
                 let gas_limit = tx_request.gas.unwrap_or(21_000);
-                let validity = config.validity_router.predicates_for(cohort, from, to_addr);
+                let validity =
+                    config.validity_router.predicates_for(cohort, current_block, from, to_addr);
 
                 prepared_txs.push(PreparedTransaction {
                     from,
@@ -1300,12 +1318,22 @@ impl LoadRunner {
         // `signed_chunk_rx` (detected below via the `send(...).is_err()` check), which
         // happens once the enqueue loop returns (deadline reached or channel closed).
         loop {
+            // Resolve offset-based block_number predicates against the chain
+            // height once per prepare round (not per transaction). Skip the
+            // extra read entirely unless an offset bound is actually configured,
+            // so absolute-only (and non-validity) runs keep their prior behavior.
+            let current_block = if config.validity_router.needs_current_block() {
+                Self::current_block_height(&config.query_client).await?
+            } else {
+                0
+            };
             let sender_jobs = Self::build_sender_jobs(
                 &mut producer_state.generator,
                 &mut producer_state.recipient_keys,
                 &mut producer_state.recipient_rng,
                 &config,
                 chunk_per_sender,
+                current_block,
             )?;
 
             let base_fee = *config.base_fee_rx.borrow_and_update();

--- a/crates/infra/load-tests/src/runner/validity_router.rs
+++ b/crates/infra/load-tests/src/runner/validity_router.rs
@@ -9,7 +9,10 @@
 use alloy_primitives::{Address, B256, U256, keccak256};
 use base_execution_txpool::ValidityPredicate;
 
-use super::{LoadConfig, PredicateAddress, SlotTemplate, SubmitCohort, ValidityPredicateTemplate};
+use super::{
+    BlockNumberBound, LoadConfig, PredicateAddress, SlotTemplate, SubmitCohort,
+    ValidityPredicateTemplate,
+};
 
 /// Salt mixed into the per-sender validity routing hash.
 const VALIDITY_SENDER_SALT: u64 = 0x7661_6c69_6469_7479; // "validity"
@@ -37,6 +40,24 @@ impl ValidityRouter {
         self.ratio <= 0.0
     }
 
+    /// Returns true when resolving this router's predicates requires the current
+    /// chain height, i.e. at least one [`BlockNumberBound::Offset`] template is
+    /// configured on the validity path. Absolute, balance, storage, and
+    /// flashblock-index predicates never read the current height, so absolute-only
+    /// configurations avoid the per-round latest-block fetch entirely.
+    pub fn needs_current_block(&self) -> bool {
+        !self.is_disabled()
+            && self.predicates.iter().any(|template| {
+                matches!(
+                    template,
+                    ValidityPredicateTemplate::BlockNumber {
+                        bound: BlockNumberBound::Offset(_),
+                        ..
+                    }
+                )
+            })
+    }
+
     /// Determines the submission cohort for a sender.
     ///
     /// The decision is deterministic in `(seed, sender)` so a sender's entire
@@ -53,15 +74,20 @@ impl ValidityRouter {
     /// Resolves the configured predicate templates into concrete predicates for
     /// a transaction. Returns an empty vector for the plain cohort, which carries
     /// no predicates.
+    ///
+    /// `current_block` is the latest chain height at prepare time, used to
+    /// resolve any [`BlockNumberBound::Offset`] into an absolute block number
+    /// (`current_block + offset`). Absolute bounds ignore it.
     pub fn predicates_for(
         &self,
         cohort: SubmitCohort,
+        current_block: u64,
         from: Address,
         to: Option<Address>,
     ) -> Vec<ValidityPredicate> {
         match cohort {
             SubmitCohort::ValidityPass => {
-                self.predicates.iter().map(|t| Self::resolve(t, from, to)).collect()
+                self.predicates.iter().map(|t| Self::resolve(t, current_block, from, to)).collect()
             }
             SubmitCohort::Plain => Vec::new(),
         }
@@ -70,6 +96,7 @@ impl ValidityRouter {
     /// Resolves a single template into a concrete predicate.
     fn resolve(
         template: &ValidityPredicateTemplate,
+        current_block: u64,
         from: Address,
         to: Option<Address>,
     ) -> ValidityPredicate {
@@ -90,10 +117,17 @@ impl ValidityRouter {
                     value: *value,
                 }
             }
-            // Position predicates read the build context, not `from`/`to`, so
-            // they resolve identically for every transaction.
-            ValidityPredicateTemplate::BlockNumber { op, value } => {
-                ValidityPredicate::BlockNumber { op: *op, value: *value }
+            // Position predicates read the build context, not `from`/`to`. An
+            // absolute bound resolves identically for every transaction; an
+            // offset bound resolves against the current chain height.
+            ValidityPredicateTemplate::BlockNumber { op, bound } => {
+                let value = match bound {
+                    BlockNumberBound::Absolute(value) => *value,
+                    BlockNumberBound::Offset(offset) => {
+                        U256::from(current_block).saturating_add(*offset)
+                    }
+                };
+                ValidityPredicate::BlockNumber { op: *op, value }
             }
             ValidityPredicateTemplate::FlashblockIndex { op, value } => {
                 ValidityPredicate::FlashblockIndex { op: *op, value: *value }
@@ -223,7 +257,7 @@ mod tests {
         let r = router(1.0, templates);
         let from = Address::repeat_byte(0xaa);
         let to = Address::repeat_byte(0xbb);
-        let predicates = r.predicates_for(SubmitCohort::ValidityPass, from, Some(to));
+        let predicates = r.predicates_for(SubmitCohort::ValidityPass, 0, from, Some(to));
         assert_eq!(predicates.len(), 2);
         match &predicates[0] {
             ValidityPredicate::Balance { address, .. } => assert_eq!(*address, from),
@@ -240,7 +274,7 @@ mod tests {
         let templates = vec![
             ValidityPredicateTemplate::BlockNumber {
                 op: ValidityOperator::GreaterThanOrEqual,
-                value: U256::from(100),
+                bound: BlockNumberBound::Absolute(U256::from(100)),
             },
             ValidityPredicateTemplate::FlashblockIndex {
                 op: ValidityOperator::Equal,
@@ -250,6 +284,7 @@ mod tests {
         let r = router(1.0, templates);
         let predicates = r.predicates_for(
             SubmitCohort::ValidityPass,
+            0,
             Address::repeat_byte(0xaa),
             Some(Address::repeat_byte(0xbb)),
         );
@@ -269,6 +304,126 @@ mod tests {
     }
 
     #[test]
+    fn absolute_block_number_bound_ignores_current_block() {
+        let templates = vec![ValidityPredicateTemplate::BlockNumber {
+            op: ValidityOperator::GreaterThanOrEqual,
+            bound: BlockNumberBound::Absolute(U256::from(12345)),
+        }];
+        let r = router(1.0, templates);
+        let predicates =
+            r.predicates_for(SubmitCohort::ValidityPass, 9_000, Address::repeat_byte(0xaa), None);
+        assert_eq!(
+            predicates,
+            vec![ValidityPredicate::BlockNumber {
+                op: ValidityOperator::GreaterThanOrEqual,
+                value: U256::from(12345),
+            }],
+        );
+    }
+
+    #[test]
+    fn offset_block_number_bound_resolves_against_current_block() {
+        let templates = vec![ValidityPredicateTemplate::BlockNumber {
+            op: ValidityOperator::GreaterThanOrEqual,
+            bound: BlockNumberBound::Offset(U256::from(10)),
+        }];
+        let r = router(1.0, templates);
+        let predicates =
+            r.predicates_for(SubmitCohort::ValidityPass, 1_000, Address::repeat_byte(0xaa), None);
+        assert_eq!(
+            predicates,
+            vec![ValidityPredicate::BlockNumber {
+                op: ValidityOperator::GreaterThanOrEqual,
+                value: U256::from(1_010),
+            }],
+        );
+    }
+
+    #[test]
+    fn offset_block_number_bound_saturates_instead_of_wrapping() {
+        let templates = vec![ValidityPredicateTemplate::BlockNumber {
+            op: ValidityOperator::GreaterThanOrEqual,
+            bound: BlockNumberBound::Offset(U256::MAX),
+        }];
+        let r = router(1.0, templates);
+        let predicates =
+            r.predicates_for(SubmitCohort::ValidityPass, 1_000, Address::repeat_byte(0xaa), None);
+        assert_eq!(
+            predicates,
+            vec![ValidityPredicate::BlockNumber {
+                op: ValidityOperator::GreaterThanOrEqual,
+                value: U256::MAX,
+            }],
+        );
+    }
+
+    #[test]
+    fn needs_current_block_only_with_an_offset_bound() {
+        let offset = router(
+            1.0,
+            vec![ValidityPredicateTemplate::BlockNumber {
+                op: ValidityOperator::GreaterThanOrEqual,
+                bound: BlockNumberBound::Offset(U256::from(10)),
+            }],
+        );
+        assert!(offset.needs_current_block(), "an offset bound requires the current height");
+
+        let absolute = router(
+            1.0,
+            vec![ValidityPredicateTemplate::BlockNumber {
+                op: ValidityOperator::GreaterThanOrEqual,
+                bound: BlockNumberBound::Absolute(U256::from(12345)),
+            }],
+        );
+        assert!(!absolute.needs_current_block(), "an absolute bound must not trigger the fetch");
+
+        let balance = router(
+            1.0,
+            vec![ValidityPredicateTemplate::Balance {
+                address: PredicateAddress::Sender,
+                op: ValidityOperator::GreaterThanOrEqual,
+                value: U256::ZERO,
+            }],
+        );
+        assert!(
+            !balance.needs_current_block(),
+            "non-position predicates must not trigger the fetch"
+        );
+    }
+
+    #[test]
+    fn disabled_router_never_needs_current_block() {
+        let r = router(
+            0.0,
+            vec![ValidityPredicateTemplate::BlockNumber {
+                op: ValidityOperator::GreaterThanOrEqual,
+                bound: BlockNumberBound::Offset(U256::from(10)),
+            }],
+        );
+        assert!(!r.needs_current_block(), "a disabled router routes nothing to the validity path");
+    }
+
+    #[test]
+    fn flashblock_index_resolves_independent_of_current_block() {
+        let templates = vec![ValidityPredicateTemplate::FlashblockIndex {
+            op: ValidityOperator::Equal,
+            value: U256::from(2),
+        }];
+        let r = router(1.0, templates);
+        let low = r.predicates_for(SubmitCohort::ValidityPass, 0, Address::repeat_byte(0xaa), None);
+        let high =
+            r.predicates_for(SubmitCohort::ValidityPass, 9_999, Address::repeat_byte(0xaa), None);
+        assert_eq!(low, high);
+        assert_eq!(
+            low,
+            vec![ValidityPredicate::FlashblockIndex {
+                op: ValidityOperator::Equal,
+                value: U256::from(2),
+            }],
+        );
+    }
+
+    #[test]
     fn plain_cohort_carries_no_predicates() {
         let templates = vec![ValidityPredicateTemplate::Balance {
             address: PredicateAddress::Sender,
@@ -277,7 +432,7 @@ mod tests {
         }];
         let r = router(1.0, templates);
         let from = Address::repeat_byte(0xaa);
-        assert!(r.predicates_for(SubmitCohort::Plain, from, None).is_empty());
+        assert!(r.predicates_for(SubmitCohort::Plain, 0, from, None).is_empty());
     }
 
     #[test]
@@ -289,7 +444,7 @@ mod tests {
         }];
         let r = router(1.0, templates);
         let from = Address::repeat_byte(0xaa);
-        let predicates = r.predicates_for(SubmitCohort::ValidityPass, from, None);
+        let predicates = r.predicates_for(SubmitCohort::ValidityPass, 0, from, None);
         match &predicates[0] {
             ValidityPredicate::Balance { address, .. } => assert_eq!(*address, from),
             other => panic!("expected balance, got {other:?}"),
@@ -311,7 +466,7 @@ mod tests {
             value: U256::ZERO,
         }];
         let r = router(1.0, templates);
-        let predicates = r.predicates_for(SubmitCohort::ValidityPass, Address::ZERO, None);
+        let predicates = r.predicates_for(SubmitCohort::ValidityPass, 0, Address::ZERO, None);
         let expected = {
             let mut preimage = [0u8; 64];
             preimage[12..32].copy_from_slice(key.as_slice());

--- a/crates/infra/load-tests/src/runner/validity_router.rs
+++ b/crates/infra/load-tests/src/runner/validity_router.rs
@@ -40,24 +40,6 @@ impl ValidityRouter {
         self.ratio <= 0.0
     }
 
-    /// Returns true when resolving this router's predicates requires the current
-    /// chain height, i.e. at least one [`BlockNumberBound::Offset`] template is
-    /// configured on the validity path. Absolute, balance, storage, and
-    /// flashblock-index predicates never read the current height, so absolute-only
-    /// configurations avoid the per-round latest-block fetch entirely.
-    pub fn needs_current_block(&self) -> bool {
-        !self.is_disabled()
-            && self.predicates.iter().any(|template| {
-                matches!(
-                    template,
-                    ValidityPredicateTemplate::BlockNumber {
-                        bound: BlockNumberBound::Offset(_),
-                        ..
-                    }
-                )
-            })
-    }
-
     /// Determines the submission cohort for a sender.
     ///
     /// The decision is deterministic in `(seed, sender)` so a sender's entire
@@ -355,52 +337,6 @@ mod tests {
                 value: U256::MAX,
             }],
         );
-    }
-
-    #[test]
-    fn needs_current_block_only_with_an_offset_bound() {
-        let offset = router(
-            1.0,
-            vec![ValidityPredicateTemplate::BlockNumber {
-                op: ValidityOperator::GreaterThanOrEqual,
-                bound: BlockNumberBound::Offset(U256::from(10)),
-            }],
-        );
-        assert!(offset.needs_current_block(), "an offset bound requires the current height");
-
-        let absolute = router(
-            1.0,
-            vec![ValidityPredicateTemplate::BlockNumber {
-                op: ValidityOperator::GreaterThanOrEqual,
-                bound: BlockNumberBound::Absolute(U256::from(12345)),
-            }],
-        );
-        assert!(!absolute.needs_current_block(), "an absolute bound must not trigger the fetch");
-
-        let balance = router(
-            1.0,
-            vec![ValidityPredicateTemplate::Balance {
-                address: PredicateAddress::Sender,
-                op: ValidityOperator::GreaterThanOrEqual,
-                value: U256::ZERO,
-            }],
-        );
-        assert!(
-            !balance.needs_current_block(),
-            "non-position predicates must not trigger the fetch"
-        );
-    }
-
-    #[test]
-    fn disabled_router_never_needs_current_block() {
-        let r = router(
-            0.0,
-            vec![ValidityPredicateTemplate::BlockNumber {
-                op: ValidityOperator::GreaterThanOrEqual,
-                bound: BlockNumberBound::Offset(U256::from(10)),
-            }],
-        );
-        assert!(!r.needs_current_block(), "a disabled router routes nothing to the validity path");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a runtime-resolved `offset` to the load-test `block_number` validity predicate, mutually exclusive with the absolute `value`. The runner resolves it to `current_block + offset` once per prepare round, reading the chain height as each round is prepared, so delayed-validity spikes self-configure instead of requiring a hand-tuned absolute target that accounts for the variable number of setup and funding blocks. The latest-block fetch fires only when an offset bound is actually configured, so absolute-only, balance, and storage runs keep their prior behavior with no extra RPC.

Follow-up to #4614. Resolves CHAIN-4874.