### PR TITLE
ci(docker): disable fail-fast on build-and-push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   build-and-push:
     strategy:
+      fail-fast: true
       matrix:
         settings:
           - arch: linux/amd64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   build-and-push:
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         settings:
           - arch: linux/amd64


### PR DESCRIPTION
## Summary
- Set `fail-fast: false` on the Docker `build-and-push` matrix so amd64 and arm64 both finish when one fails.

## Test plan
- [ ] Confirm `docker.yml` has `fail-fast: false` only under `build-and-push`
- [ ] After merge, a failed arch should leave the sibling running so both errors are visible