### PR TITLE
test(systems): inline sim e2e (7/n)

### DIFF
--- a/crates/execution/txpool/src/inline_sim.rs
+++ b/crates/execution/txpool/src/inline_sim.rs
@@ -229,33 +229,38 @@ async fn meter_job<F>(job: InlineSimJob, meter: Arc<F>, timeout: Duration) -> In
 where
     F: Fn(Recovered<BaseTxEnvelope>) -> Result<MeterBundleResponse, String> + Send + Sync + 'static,
 {
-    let recovered = job.transaction.clone_into_consensus();
     InlineSimMetrics::sim_workers_busy().increment(1.0);
 
     // `--inline-simulation-timeout-ms` only chooses real vs Default metering.
     // spawn_blocking cannot be cancelled. The worker joins so blocking tasks
     // stay bounded by worker count and do not pile up.
-    let handle = tokio::task::spawn_blocking(move || meter(recovered));
-    let job = match future::select(handle, Box::pin(tokio::time::sleep(timeout))).await {
-        Either::Left((Ok(Ok(metering)), _)) => InlineSimJob {
-            origin: job.origin,
-            transaction: job.transaction.with_metering(metering),
-            inserted: job.inserted,
-        },
-        Either::Left((Ok(Err(error)), _)) => {
-            warn!(error = %error, hash = %job.transaction.hash(), "inline sim meter_bundle failed");
-            InlineSimQueue::with_default_metering(job, "meter")
-        }
-        Either::Left((Err(join_error), _)) => {
-            warn!(error = %join_error, hash = %job.transaction.hash(), "inline sim worker task failed");
-            InlineSimQueue::with_default_metering(job, "join")
-        }
-        Either::Right((_, handle)) => {
-            warn!(hash = %job.transaction.hash(), "inline sim meter_bundle timed out");
-            let waited = Instant::now();
-            let _ = handle.await;
-            InlineSimMetrics::sim_timeout_wait_seconds().record(waited.elapsed().as_secs_f64());
-            InlineSimQueue::with_default_metering(job, "timeout")
+    // `sleep(0)` is not Ready on first poll, so a zero deadline skips meter.
+    let job = if timeout.is_zero() {
+        InlineSimQueue::with_default_metering(job, "timeout")
+    } else {
+        let recovered = job.transaction.clone_into_consensus();
+        let handle = tokio::task::spawn_blocking(move || meter(recovered));
+        match future::select(handle, Box::pin(tokio::time::sleep(timeout))).await {
+            Either::Left((Ok(Ok(metering)), _)) => InlineSimJob {
+                origin: job.origin,
+                transaction: job.transaction.with_metering(metering),
+                inserted: job.inserted,
+            },
+            Either::Left((Ok(Err(error)), _)) => {
+                warn!(error = %error, hash = %job.transaction.hash(), "inline sim meter_bundle failed");
+                InlineSimQueue::with_default_metering(job, "meter")
+            }
+            Either::Left((Err(join_error), _)) => {
+                warn!(error = %join_error, hash = %job.transaction.hash(), "inline sim worker task failed");
+                InlineSimQueue::with_default_metering(job, "join")
+            }
+            Either::Right((_, handle)) => {
+                warn!(hash = %job.transaction.hash(), "inline sim meter_bundle timed out");
+                let waited = Instant::now();
+                let _ = handle.await;
+                InlineSimMetrics::sim_timeout_wait_seconds().record(waited.elapsed().as_secs_f64());
+                InlineSimQueue::with_default_metering(job, "timeout")
+            }
         }
     };
 
@@ -429,6 +434,19 @@ mod tests {
             out.transaction.metering(),
             Some(&MeterBundleResponse::default()),
             "timed-out meter_bundle must still insert with default metering"
+        );
+    }
+
+    #[tokio::test]
+    async fn meter_job_timeout_zero_uses_default() {
+        let job = sim_job();
+
+        let out = meter_job(job, Arc::new(|_| Ok(metering())), Duration::ZERO).await;
+
+        assert_eq!(
+            out.transaction.metering(),
+            Some(&MeterBundleResponse::default()),
+            "timeout 0 must attach Default without racing spawn_blocking"
         );
     }
 

--- a/etc/systems/src/l2/in_process_client.rs
+++ b/etc/systems/src/l2/in_process_client.rs
@@ -2,10 +2,16 @@
 //!
 //! Replaces Docker-based `ClientContainer` with an in-process node for faster tests.
 
-use std::{any::Any, net::SocketAddr, path::PathBuf, sync::Arc};
+use std::{
+    any::Any,
+    net::{Ipv4Addr, SocketAddr},
+    path::PathBuf,
+    sync::Arc,
+};
 
 use alloy_primitives::hex::ToHexExt;
 use alloy_rpc_types_engine::JwtSecret;
+use base_builder_core::test_utils::get_available_port;
 use base_bundle_extension::BundleExtension;
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_cli::{
@@ -25,7 +31,7 @@ use reth_db::{
 };
 use reth_node_builder::{Node, NodeBuilder, NodeConfig, NodeHandle};
 use reth_node_core::{
-    args::{DatadirArgs, DiscoveryArgs, NetworkArgs, RpcServerArgs},
+    args::{DatadirArgs, DiscoveryArgs, MetricArgs, NetworkArgs, RpcServerArgs},
     dirs::{DataDirPath, MaybePlatformPath},
     exit::NodeExitFuture,
 };
@@ -80,6 +86,7 @@ pub struct InProcessClient {
     http_api_addr: SocketAddr,
     ws_api_addr: SocketAddr,
     engine_addr: SocketAddr,
+    metrics_addr: Option<SocketAddr>,
     chain_spec: Arc<BaseChainSpec>,
     _node_exit_future: NodeExitFuture,
     _node: Box<dyn Any + Sync + Send>,
@@ -100,6 +107,7 @@ impl std::fmt::Debug for InProcessClient {
             .field("http_api_addr", &self.http_api_addr)
             .field("ws_api_addr", &self.ws_api_addr)
             .field("engine_addr", &self.engine_addr)
+            .field("metrics_addr", &self.metrics_addr)
             .finish_non_exhaustive()
     }
 }
@@ -169,9 +177,14 @@ impl InProcessClient {
             rpc_args.auth_port = port;
         }
 
-        // Configure rollup args with sequencer URL
-        let rollup_args =
-            RollupArgs { sequencer: Some(config.builder_rpc_url.clone()), ..Default::default() };
+        // Sequencer HTTP short-circuits `eth_sendRawTransaction` before the pool.
+        // Forwarding tests (and inline sim) need sendRaw to insert locally so
+        // TxForwardingExtension can `insertValidatedTransaction` on the builder.
+        let sequencer = match &config.tx_forwarding_config {
+            Some(fwd) if fwd.enabled => None,
+            _ => Some(config.builder_rpc_url.clone()),
+        };
+        let rollup_args = RollupArgs { sequencer, ..Default::default() };
 
         let base_node = BaseNode::new(rollup_args.clone());
 
@@ -185,6 +198,17 @@ impl InProcessClient {
             && config.p2p_port.is_none()
         {
             node_config = node_config.with_unused_ports();
+        }
+
+        let metrics_addr = config.tx_forwarding_config.as_ref().and_then(|fwd| {
+            fwd.inline_simulation
+                .then(|| SocketAddr::from((Ipv4Addr::LOCALHOST, get_available_port())))
+        });
+        if let Some(addr) = metrics_addr {
+            node_config = node_config.with_metrics(MetricArgs {
+                prometheus: Some(addr),
+                ..Default::default()
+            });
         }
 
         let datadir_path = MaybePlatformPath::<DataDirPath>::from(db_path.clone());
@@ -228,6 +252,7 @@ impl InProcessClient {
             http_api_addr,
             ws_api_addr,
             engine_addr,
+            metrics_addr,
             chain_spec,
             _node_exit_future: node_exit_future,
             _node: Box::new(node_handle),
@@ -240,6 +265,14 @@ impl InProcessClient {
     /// schedule applied at startup.
     pub const fn chain_spec(&self) -> &Arc<BaseChainSpec> {
         &self.chain_spec
+    }
+
+    /// Returns the Prometheus metrics URL. Bound when inline simulation is enabled.
+    pub fn metrics_url(&self) -> Result<Url> {
+        let addr =
+            self.metrics_addr.ok_or_else(|| eyre!("client metrics endpoint is not enabled"))?;
+        Url::parse(&format!("http://{addr}/"))
+            .map_err(|e| eyre!("Failed to build metrics URL: {e}"))
     }
 
     /// Returns the HTTP RPC URL for the client.
@@ -316,7 +349,7 @@ impl InProcessClient {
         extensions.push(Box::new(TxPoolExtension::new(txpool_config)));
 
         // TxForwarding extension (optional - forwards txs to builder RPC)
-        if let Some(ref tx_fwd_config) = config.tx_forwarding_config {
+        if let Some(mut tx_fwd_config) = config.tx_forwarding_config.clone() {
             if config.enable_experimental_validity_transactions
                 && tx_fwd_config.enabled
                 && !tx_fwd_config.builder_urls.is_empty()
@@ -325,7 +358,11 @@ impl InProcessClient {
                     DEFAULT_MAX_VALIDITY_PREDICATES,
                 )));
             }
-            extensions.push(Box::new(TxForwardingExtension::from_config(tx_fwd_config.clone())));
+            if tx_fwd_config.inline_simulation {
+                tx_fwd_config = tx_fwd_config
+                    .with_flashblocks_state(Some(Arc::clone(&flashblocks_config.state)));
+            }
+            extensions.push(Box::new(TxForwardingExtension::from_config(tx_fwd_config)));
         }
 
         // Upgrade signal runtime extension (optional - live L1 schedule polling)

--- a/etc/systems/tests/tx_forwarding.rs
+++ b/etc/systems/tests/tx_forwarding.rs
@@ -17,7 +17,7 @@ use base_common_rpc_types::BaseTransactionRequest;
 use base_execution_txpool::{NoExtensions, ValidatedTransaction};
 use base_system_tests::{
     ANVIL_ACCOUNT_1, ANVIL_ACCOUNT_2, ANVIL_ACCOUNT_3, ANVIL_ACCOUNT_4, SystemTestProviderExt,
-    SystemTestStackBuilder,
+    SystemTestStack, SystemTestStackBuilder,
 };
 use base_tx_forwarding::TxForwardingConfig;
 use base_txpool_rpc::SendRawTransactionValidityRequest;
@@ -57,6 +57,121 @@ fn create_signed_eip1559_tx(
     let raw_tx: Bytes = signed_tx.encoded_2718().into();
 
     Ok((sender, raw_tx, tx_hash))
+}
+
+const DEAD: &str = "0x000000000000000000000000000000000000dEaD";
+/// Reth's Prometheus recorder prefixes every key with `reth.`.
+const INLINE_SIM_SECONDS: &str = "reth_inline_simulation_sim_seconds_count";
+const INLINE_SIM_DEFAULTS: &str = "reth_inline_simulation_sim_default_inserts";
+const INLINE_SIM_QUEUE_FULL: &str = "reth_inline_simulation_sim_queue_full";
+const INLINE_SIM_FAILURES: &str = "reth_inline_simulation_sim_failures";
+
+/// Process-global Prometheus counters; serialize the scrapers.
+static INLINE_SIM_E2E: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Boots L1+L2 with forwarding, then waits until both EL nodes have produced a few blocks.
+async fn boot_forwarding_stack(forwarding: TxForwardingConfig) -> Result<SystemTestStack> {
+    let system = SystemTestStackBuilder::new()
+        .with_l1_chain_id(L1_CHAIN_ID)
+        .with_l2_chain_id(L2_CHAIN_ID)
+        .with_tx_forwarding(forwarding)
+        .build()
+        .await?;
+    let builder = system.l2_builder_provider()?;
+    let client = system.l2_client_provider()?;
+    builder.wait_for_block(3, Duration::from_secs(15)).await?;
+    client.wait_for_block(3, Duration::from_secs(15)).await?;
+    Ok(system)
+}
+
+/// Signs with an Anvil genesis account.
+fn anvil_signer(private_key: &[u8]) -> Result<PrivateKeySigner> {
+    let hex = format!("0x{}", hex::encode(private_key));
+    hex.parse().map_err(|e| eyre::eyre!("invalid private key: {e:?}"))
+}
+
+/// Parses a Prometheus counter/gauge/histogram `_count` line. Missing series is 0.
+fn prometheus_value(body: &str, name: &str, label: Option<&str>) -> f64 {
+    let mut total = 0.0;
+    let mut found = false;
+    for line in body.lines() {
+        if line.starts_with('#') {
+            continue;
+        }
+        let Some((metric, value)) = line.rsplit_once(' ') else {
+            continue;
+        };
+        let (base, labels) = match metric.split_once('{') {
+            Some((base, rest)) => (base, Some(rest.trim_end_matches('}'))),
+            None => (metric, None),
+        };
+        if base != name {
+            continue;
+        }
+        if let Some(want) = label {
+            if !labels.is_some_and(|got| got.contains(want)) {
+                continue;
+            }
+        }
+        if let Ok(v) = value.parse::<f64>() {
+            total += v;
+            found = true;
+        }
+    }
+    if found { total } else { 0.0 }
+}
+
+/// Scrapes the client's Prometheus exporter, retrying until it accepts connections.
+async fn scrape_metrics(url: &url::Url) -> Result<String> {
+    let mut last_err = None;
+    for _ in 0..30 {
+        match reqwest::get(url.clone()).await {
+            Ok(resp) => {
+                return resp.text().await.wrap_err("metrics body");
+            }
+            Err(err) => {
+                last_err = Some(err);
+                sleep(Duration::from_millis(100)).await;
+            }
+        }
+    }
+    Err(eyre::eyre!("metrics scrape failed: {last_err:?}"))
+}
+
+/// Polls until `name` is at least `before + min_delta`.
+async fn wait_metric_delta(
+    url: &url::Url,
+    name: &str,
+    label: Option<&str>,
+    before: f64,
+    min_delta: f64,
+) -> Result<f64> {
+    match timeout(Duration::from_secs(10), async {
+        loop {
+            let body = scrape_metrics(url).await?;
+            let now = prometheus_value(&body, name, label);
+            if now - before >= min_delta {
+                return Ok::<_, eyre::Error>(now);
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    {
+        Ok(inner) => inner,
+        Err(_) => {
+            let body = scrape_metrics(url).await.unwrap_or_default();
+            let sample: String = body
+                .lines()
+                .filter(|line| line.contains("inline_simulation") || line.contains("sim_"))
+                .take(40)
+                .collect::<Vec<_>>()
+                .join("\n");
+            eyre::bail!(
+                "{name} did not increase (before={before}). matching scrape lines:\n{sample}"
+            )
+        }
+    }
 }
 
 /// Tests that a single transaction can be inserted via `base_insertValidatedTransaction`.
@@ -248,6 +363,238 @@ async fn test_tx_forwarding_pipeline_system() -> Result<()> {
     .wrap_err("Failed to get transaction receipt")?;
 
     // Verify the transaction was included
+    assert_eq!(receipt.inner.transaction_hash, expected_tx_hash);
+    assert!(receipt.inner.block_number.is_some(), "Receipt should have block number");
+    assert_eq!(receipt.inner.from, sender);
+    assert_eq!(receipt.inner.to, Some(recipient));
+
+    Ok(())
+}
+
+/// Same pipeline as [`test_tx_forwarding_pipeline_system`] with inline simulation on.
+///
+/// `sendRaw` on the client waits for meter_bundle plus pool insert, then the
+/// forwarder sends the tx to the builder. Scrapes Prometheus so this is not just
+/// the OG insert path.
+#[tokio::test]
+async fn test_tx_forwarding_pipeline_with_inline_simulation() -> Result<()> {
+    let _guard = INLINE_SIM_E2E.lock().await;
+    let forwarding = TxForwardingConfig::new(vec![])
+        .with_resend_after_ms(2000)
+        .with_max_batch_size(100)
+        .with_inline_simulation(true);
+
+    let system = boot_forwarding_stack(forwarding).await?;
+    let builder_provider = system.l2_builder_provider()?;
+    let client_provider = system.l2_client_provider()?;
+    let metrics = system.l2_stack().client().metrics_url()?;
+
+    let signer = anvil_signer(ANVIL_ACCOUNT_1.private_key.as_slice())?;
+    let sender = signer.address();
+    client_provider.wait_for_balance(sender, Duration::from_secs(15)).await?;
+
+    let before = scrape_metrics(&metrics).await?;
+    let seconds_before =
+        prometheus_value(&before, INLINE_SIM_SECONDS, None);
+    let defaults_before =
+        prometheus_value(&before, INLINE_SIM_DEFAULTS, None);
+
+    let nonce = client_provider.get_transaction_count(sender).await?;
+    let recipient: Address = DEAD.parse()?;
+    let (_, raw_tx, expected_tx_hash) =
+        create_signed_eip1559_tx(&signer, L2_CHAIN_ID, nonce, recipient)?;
+
+    let pending_tx = client_provider
+        .send_raw_transaction(&raw_tx)
+        .await
+        .wrap_err("Failed to send transaction to client")?;
+    assert_eq!(*pending_tx.tx_hash(), expected_tx_hash, "Transaction hash mismatch");
+
+    let seconds_after = wait_metric_delta(
+        &metrics,
+        INLINE_SIM_SECONDS,
+        None,
+        seconds_before,
+        1.0,
+    )
+    .await?;
+    assert!(
+        seconds_after - seconds_before >= 1.0,
+        "meter_bundle must run; sim_seconds_count {seconds_before} -> {seconds_after}"
+    );
+
+    let after = scrape_metrics(&metrics).await?;
+    let defaults_after =
+        prometheus_value(&after, INLINE_SIM_DEFAULTS, None);
+    assert_eq!(
+        defaults_after, defaults_before,
+        "this tx must insert real metering, not MeterBundleResponse::default"
+    );
+
+    let receipt = builder_provider.wait_for_receipt(expected_tx_hash, TX_RECEIPT_TIMEOUT).await?;
+    assert_eq!(receipt.inner.transaction_hash, expected_tx_hash);
+    assert!(receipt.inner.block_number.is_some(), "Receipt should have block number");
+    assert_eq!(receipt.inner.from, sender);
+    assert_eq!(receipt.inner.to, Some(recipient));
+
+    Ok(())
+}
+
+/// Flag on: cheap validate still rejects a tx that cannot pay, without waiting on the oneshot.
+#[tokio::test]
+async fn test_inline_simulation_rejects_unfunded_sender() -> Result<()> {
+    let _guard = INLINE_SIM_E2E.lock().await;
+    let forwarding = TxForwardingConfig::new(vec![])
+        .with_resend_after_ms(2000)
+        .with_max_batch_size(100)
+        .with_inline_simulation(true);
+
+    let system = boot_forwarding_stack(forwarding).await?;
+    let client_provider = system.l2_client_provider()?;
+    let signer = PrivateKeySigner::random();
+    let recipient: Address = DEAD.parse()?;
+    let (_, raw_tx, _) = create_signed_eip1559_tx(&signer, L2_CHAIN_ID, 0, recipient)?;
+
+    let err = timeout(Duration::from_secs(15), client_provider.send_raw_transaction(&raw_tx))
+        .await
+        .wrap_err("unfunded sendRaw hung on the inline-sim oneshot")?
+        .expect_err("unfunded sender must fail cheap validate");
+    assert!(
+        !err.to_string().is_empty(),
+        "RPC error should describe the rejected transaction"
+    );
+
+    Ok(())
+}
+
+/// Capacity 1 + one worker: concurrent sendRaws from four senders overflow the queue.
+/// Full falls back to unmetered insert; hashes still return and txs still land.
+#[tokio::test]
+async fn test_inline_simulation_queue_full_still_forwards() -> Result<()> {
+    let _guard = INLINE_SIM_E2E.lock().await;
+    let forwarding = TxForwardingConfig::new(vec![])
+        .with_resend_after_ms(2000)
+        .with_max_batch_size(100)
+        .with_inline_simulation(true)
+        .with_inline_simulation_workers(1)
+        .with_inline_simulation_queue_capacity(1);
+
+    let system = boot_forwarding_stack(forwarding).await?;
+    let builder_provider = system.l2_builder_provider()?;
+    let client_provider = system.l2_client_provider()?;
+    let metrics = system.l2_stack().client().metrics_url()?;
+    let recipient: Address = DEAD.parse()?;
+
+    let accounts = [&*ANVIL_ACCOUNT_1, &*ANVIL_ACCOUNT_2, &*ANVIL_ACCOUNT_3, &*ANVIL_ACCOUNT_4];
+    let mut raws = Vec::new();
+    for account in accounts {
+        let signer = anvil_signer(account.private_key.as_slice())?;
+        client_provider.wait_for_balance(signer.address(), Duration::from_secs(15)).await?;
+        let nonce = client_provider.get_transaction_count(signer.address()).await?;
+        let (_, raw_tx, hash) =
+            create_signed_eip1559_tx(&signer, L2_CHAIN_ID, nonce, recipient)?;
+        raws.push((signer.address(), raw_tx, hash));
+    }
+
+    let before = scrape_metrics(&metrics).await?;
+    let full_before = prometheus_value(&before, INLINE_SIM_QUEUE_FULL, None);
+
+    let (r0, r1, r2, r3) = tokio::join!(
+        client_provider.send_raw_transaction(&raws[0].1),
+        client_provider.send_raw_transaction(&raws[1].1),
+        client_provider.send_raw_transaction(&raws[2].1),
+        client_provider.send_raw_transaction(&raws[3].1),
+    );
+    for (i, result) in [r0, r1, r2, r3].into_iter().enumerate() {
+        let pending = result.wrap_err_with(|| format!("sendRaw {i} failed"))?;
+        assert_eq!(*pending.tx_hash(), raws[i].2, "hash mismatch for sendRaw {i}");
+    }
+
+    let full_after = wait_metric_delta(
+        &metrics,
+        INLINE_SIM_QUEUE_FULL,
+        None,
+        full_before,
+        1.0,
+    )
+    .await?;
+    assert!(
+        full_after - full_before >= 1.0,
+        "at least one concurrent sendRaw must overflow the 1-slot queue; {full_before} -> {full_after}"
+    );
+
+    for (sender, _, hash) in &raws {
+        let receipt = builder_provider.wait_for_receipt(*hash, TX_RECEIPT_TIMEOUT).await?;
+        assert_eq!(receipt.inner.transaction_hash, *hash);
+        assert_eq!(receipt.inner.from, *sender);
+        assert_eq!(receipt.inner.to, Some(recipient));
+    }
+
+    Ok(())
+}
+
+/// Timeout 0ms: sleep(0) wins vs spawn_blocking, so the worker inserts Default metering.
+/// The tx still returns a hash and still lands on the builder.
+#[tokio::test]
+async fn test_inline_simulation_timeout_still_forwards() -> Result<()> {
+    let _guard = INLINE_SIM_E2E.lock().await;
+    let forwarding = TxForwardingConfig::new(vec![])
+        .with_resend_after_ms(2000)
+        .with_max_batch_size(100)
+        .with_inline_simulation(true)
+        .with_inline_simulation_timeout_ms(0);
+
+    let system = boot_forwarding_stack(forwarding).await?;
+    let builder_provider = system.l2_builder_provider()?;
+    let client_provider = system.l2_client_provider()?;
+    let metrics = system.l2_stack().client().metrics_url()?;
+
+    let signer = anvil_signer(ANVIL_ACCOUNT_1.private_key.as_slice())?;
+    let sender = signer.address();
+    client_provider.wait_for_balance(sender, Duration::from_secs(15)).await?;
+
+    let before = scrape_metrics(&metrics).await?;
+    let timeout_before = prometheus_value(
+        &before,
+        INLINE_SIM_FAILURES,
+        Some(r#"reason="timeout""#),
+    );
+    let defaults_before =
+        prometheus_value(&before, INLINE_SIM_DEFAULTS, None);
+
+    let nonce = client_provider.get_transaction_count(sender).await?;
+    let recipient: Address = DEAD.parse()?;
+    let (_, raw_tx, expected_tx_hash) =
+        create_signed_eip1559_tx(&signer, L2_CHAIN_ID, nonce, recipient)?;
+
+    let pending_tx = client_provider
+        .send_raw_transaction(&raw_tx)
+        .await
+        .wrap_err("Failed to send transaction to client")?;
+    assert_eq!(*pending_tx.tx_hash(), expected_tx_hash, "Transaction hash mismatch");
+
+    let timeout_after = wait_metric_delta(
+        &metrics,
+        INLINE_SIM_FAILURES,
+        Some(r#"reason="timeout""#),
+        timeout_before,
+        1.0,
+    )
+    .await?;
+    assert!(
+        timeout_after - timeout_before >= 1.0,
+        "timeout=0 must count a timeout failure; {timeout_before} -> {timeout_after}"
+    );
+
+    let after = scrape_metrics(&metrics).await?;
+    let defaults_after =
+        prometheus_value(&after, INLINE_SIM_DEFAULTS, None);
+    assert!(
+        defaults_after - defaults_before >= 1.0,
+        "timed-out sim must insert MeterBundleResponse::default; {defaults_before} -> {defaults_after}"
+    );
+
+    let receipt = builder_provider.wait_for_receipt(expected_tx_hash, TX_RECEIPT_TIMEOUT).await?;
     assert_eq!(receipt.inner.transaction_hash, expected_tx_hash);
     assert!(receipt.inner.block_number.is_some(), "Receipt should have block number");
     assert_eq!(receipt.inner.from, sender);


### PR DESCRIPTION
## Motivation

PR6's sendRaw path was untested end-to-end: inclusion still passed if sequencer HTTP forwarded past the sim queue. These e2es scrape Prometheus so we know meter_bundle actually ran, and they cover queue-full and timeout=0.

## Changes

- Disable sequencer HTTP on in-process clients when tx-forwarding is on, so `sendRaw` inserts locally and `TxForwardingExtension` does `insertValidatedTransaction`
- Bind a Prometheus port on the in-process client when inline sim is on
- `timeout_ms=0` inserts `MeterBundleResponse::default` without racing `spawn_blocking` (`tokio::time::sleep(0)` is not Ready on first poll)
- Copy flashblocks pending state onto the forwarding config for in-process meter_bundle

## Tests

| Test Name | Description |
|---|---|
| `test_tx_forwarding_pipeline_with_inline_simulation` | `sim_seconds_count` += 1, `sim_default_inserts` unchanged, tx lands on builder |
| `test_inline_simulation_rejects_unfunded_sender` | unfunded signer errors from cheap validate, does not hang on the oneshot |
| `test_inline_simulation_queue_full_still_forwards` | workers=1, capacity=1, 4 concurrent sendRaws → `sim_queue_full` += 1, all included |
| `test_inline_simulation_timeout_still_forwards` | timeout_ms=0 → timeout failure + default insert, tx still lands |
| `meter_job_timeout_zero_uses_default` | unit: zero deadline attaches Default without racing spawn_blocking |

Stacked on #4609 (`will.law/inline-sim-workers`).


Made with [Cursor](https://cursor.com)