### PR TITLE
feat(audit): delete expired transaction events by ctid

### DIFF
--- a/crates/infra/audit/src/transaction_events.rs
+++ b/crates/infra/audit/src/transaction_events.rs
@@ -611,15 +611,18 @@ impl PgTransactionEventSink {
                 let cutoff = Utc::now() - Duration::days(i64::from(config.class_days(class)));
                 let event_types = class.event_type_labels();
                 while batches < u64::from(config.max_batches) {
+                    // Delete by ctid via Tid Scan so the batch is not a second
+                    // primary-key lookup. ANY(ARRAY(ctid)) keeps that plan as
+                    // catch-up shrinks the heap; USING ctid can seq-scan.
                     let deleted = sqlx::query(
                         "WITH doomed AS ( \
-                            SELECT event_id \
+                            SELECT ctid \
                             FROM transaction_events \
                             WHERE event_type = ANY($1) AND ingested_at < $2 \
                             LIMIT $3 \
                          ) \
                          DELETE FROM transaction_events \
-                         WHERE event_id IN (SELECT event_id FROM doomed)",
+                         WHERE ctid = ANY (ARRAY(SELECT ctid FROM doomed)::tid[])",
                     )
                     .bind(&event_types)
                     .bind(cutoff)


### PR DESCRIPTION
## Summary
- One-pass heap delete by `ctid` so retention catch-up is not a second PK lookup per batch.
- Current SQL selected matching `event_id`s from `(event_type, ingested_at)`, then `DELETE ... WHERE event_id IN (...)`. EXPLAIN on a large-heap analog (`seq_page_cost=100`) is Nested Loop + `Index Scan using transaction_events_pkey` — an extra text-PK lookup and heap fetch for every row.
- New SQL keeps `$1` event types, `$2` cutoff, `$3` batch size:

```sql
WITH doomed AS (
    SELECT ctid
    FROM transaction_events
    WHERE event_type = ANY($1) AND ingested_at < $2
    LIMIT $3
)
DELETE FROM transaction_events
WHERE ctid = ANY (ARRAY(SELECT ctid FROM doomed)::tid[])
```

- Used `ctid = ANY(ARRAY(...))` instead of `DELETE ... USING doomed WHERE t.ctid = d.ctid`. Both avoid the PK lookup on a large heap (Nested Loop + Tid Scan). USING can hash-join a sequential scan of the whole table on a medium-size heap, and that plan can return as catch-up shrinks the table. `ANY(ARRAY(ctid))` stayed a Tid Scan in both shapes (~5× faster on an 82 MB stand-in: 8–19 ms vs ~40 ms).
- Unchanged: retention interval, batch-size defaults (10_000 / 1_000), Helm, session advisory lock, hot→warm→cold order, shared `max_batches`, metric increment after each batch, lock-detach-on-unlock-failure.

After merge, pin this revision from `protocols/tips` branch `niran/sepolia-retention-catchup`.

## Test plan
- [x] `cargo +nightly fmt -p audit-archiver-lib`
- [x] `cargo clippy -p audit-archiver-lib --all-features --all-targets -- -D warnings`
- [x] `cargo test -p audit-archiver-lib --lib` (23 passed)
- [x] `cargo test -p audit-archiver-lib --test postgres_transaction_events` (11 passed, including expire tests with `delete_batch_size` 1 and 10; ignored `DATABASE_URL` test not run)
- [ ] Pin this revision on Sepolia and confirm catch-up is no longer a second PK lookup per batch

type=routine
risk=low
impact=sev5