### PR TITLE
test(systems): add in-process prover-service and ZK host

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6235,8 +6235,12 @@ dependencies = [
  "base-node-core",
  "base-node-runner",
  "base-optimism-rpc",
+ "base-proof-zk-backend",
+ "base-proof-zk-host",
  "base-protocol",
+ "base-prover-service",
  "base-prover-service-client",
+ "base-prover-service-db",
  "base-prover-service-protocol",
  "base-runtime",
  "base-shadow-indexer",
@@ -6278,6 +6282,7 @@ dependencies = [
  "tokio-util",
  "tower 0.5.3",
  "tracing",
+ "tracing-subscriber",
  "url",
 ]
 

--- a/bin/prover/zk-host/src/cli.rs
+++ b/bin/prover/zk-host/src/cli.rs
@@ -179,6 +179,8 @@ impl WorkerArgs {
             range_gas_limit: self.range_gas_limit,
             aggregation_cycle_limit: self.aggregation_cycle_limit,
             aggregation_gas_limit: self.aggregation_gas_limit,
+            l1_config_dir: None,
+            l2_config_dir: None,
         }
     }
 }

--- a/crates/proof/zk/backend/src/succinct/builder.rs
+++ b/crates/proof/zk/backend/src/succinct/builder.rs
@@ -1,6 +1,9 @@
 //! Backend construction for Succinct ZK provers.
 
-use std::{collections::HashMap, error::Error, fmt, future::Future, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap, error::Error, fmt, future::Future, path::PathBuf, sync::Arc,
+    time::Duration,
+};
 
 use base_proof_zk_host::{ZkBackend, ZkProver};
 use base_proof_zk_witness::fetcher::{OPSuccinctDataFetcher, RPCConfig};
@@ -97,6 +100,14 @@ pub struct SuccinctRpcConfig {
     pub l2_rpc: Url,
     /// Default sequence window for L1 head calculations.
     pub default_sequence_window: u64,
+    /// Directory containing `<chain_id>.json` L1 chain configs.
+    ///
+    /// When unset, the witness fetcher falls back to `L1_CONFIG_DIR`, then `configs/L1`.
+    pub l1_config_dir: Option<PathBuf>,
+    /// Directory where fetched L2 rollup configs are written.
+    ///
+    /// When unset, the witness fetcher falls back to `L2_CONFIG_DIR`, then `configs/L2`.
+    pub l2_config_dir: Option<PathBuf>,
 }
 
 /// Configuration for all Succinct proving backends available to one worker.
@@ -134,6 +145,14 @@ pub struct SuccinctZkProversConfig {
     pub aggregation_cycle_limit: u64,
     /// Gas limit for aggregation proof requests.
     pub aggregation_gas_limit: u64,
+    /// Directory containing `<chain_id>.json` L1 chain configs.
+    ///
+    /// When unset, the witness fetcher falls back to `L1_CONFIG_DIR`, then `configs/L1`.
+    pub l1_config_dir: Option<PathBuf>,
+    /// Directory where fetched L2 rollup configs are written.
+    ///
+    /// When unset, the witness fetcher falls back to `L2_CONFIG_DIR`, then `configs/L2`.
+    pub l2_config_dir: Option<PathBuf>,
 }
 
 impl fmt::Debug for SuccinctZkProversConfig {
@@ -221,6 +240,8 @@ impl SuccinctZkProversConfig {
                     l1_beacon_rpc: l1_beacon_rpc.clone(),
                     l2_rpc: l2_rpc.clone(),
                     default_sequence_window: self.default_sequence_window,
+                    l1_config_dir: self.l1_config_dir.clone(),
+                    l2_config_dir: self.l2_config_dir.clone(),
                 }))
             }
             _ => Err(SuccinctZkProverBuildError::config(
@@ -401,6 +422,8 @@ impl SuccinctZkProverBuilder {
             l1_beacon_rpc: Some(rpc.l1_beacon_rpc),
             l2_rpc: rpc.l2_rpc,
             l2_node_rpc: rpc.base_consensus_rpc,
+            l1_config_dir: rpc.l1_config_dir,
+            l2_config_dir: rpc.l2_config_dir,
         };
         let Some(fetcher) = Self::complete_unless_cancelled(
             cancel,
@@ -470,6 +493,8 @@ mod tests {
             range_gas_limit: 1_000_000_000_000,
             aggregation_cycle_limit: 1_000_000_000_000,
             aggregation_gas_limit: 1_000_000_000_000,
+            l1_config_dir: None,
+            l2_config_dir: None,
         }
     }
 

--- a/crates/proof/zk/witness/src/fetcher.rs
+++ b/crates/proof/zk/witness/src/fetcher.rs
@@ -1,7 +1,7 @@
 use std::{
     cmp::{Ordering, min},
     env, fmt, fs,
-    path::PathBuf,
+    path::{Path, PathBuf},
     str::FromStr,
     sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
@@ -88,17 +88,17 @@ pub struct RPCConfig {
 impl RPCConfig {
     /// Directory containing `<chain_id>.json` L1 chain configs.
     pub fn l1_config_directory(&self) -> PathBuf {
-        resolve_config_dir(self.l1_config_dir.as_ref(), "L1_CONFIG_DIR", "configs/L1")
+        resolve_config_dir(self.l1_config_dir.as_deref(), "L1_CONFIG_DIR", "configs/L1")
     }
 
     /// Directory where fetched L2 rollup configs are written.
     pub fn l2_config_directory(&self) -> PathBuf {
-        resolve_config_dir(self.l2_config_dir.as_ref(), "L2_CONFIG_DIR", "configs/L2")
+        resolve_config_dir(self.l2_config_dir.as_deref(), "L2_CONFIG_DIR", "configs/L2")
     }
 }
 
-fn resolve_config_dir(explicit: Option<&PathBuf>, env_name: &str, default: &str) -> PathBuf {
-    explicit.cloned().unwrap_or_else(|| {
+fn resolve_config_dir(explicit: Option<&Path>, env_name: &str, default: &str) -> PathBuf {
+    explicit.map(Path::to_path_buf).unwrap_or_else(|| {
         env::var_os(env_name).map(PathBuf::from).unwrap_or_else(|| PathBuf::from(default))
     })
 }

--- a/crates/proof/zk/witness/src/fetcher.rs
+++ b/crates/proof/zk/witness/src/fetcher.rs
@@ -75,6 +75,32 @@ pub struct RPCConfig {
     // TODO(fakedev9999): Make optional if possible.
     /// L2 consensus node RPC URL.
     pub l2_node_rpc: Url,
+    /// Directory containing `<chain_id>.json` L1 chain configs.
+    ///
+    /// When unset, [`Self::l1_config_directory`] falls back to `L1_CONFIG_DIR`, then `configs/L1`.
+    pub l1_config_dir: Option<PathBuf>,
+    /// Directory where fetched L2 rollup configs are written.
+    ///
+    /// When unset, [`Self::l2_config_directory`] falls back to `L2_CONFIG_DIR`, then `configs/L2`.
+    pub l2_config_dir: Option<PathBuf>,
+}
+
+impl RPCConfig {
+    /// Directory containing `<chain_id>.json` L1 chain configs.
+    pub fn l1_config_directory(&self) -> PathBuf {
+        resolve_config_dir(self.l1_config_dir.as_ref(), "L1_CONFIG_DIR", "configs/L1")
+    }
+
+    /// Directory where fetched L2 rollup configs are written.
+    pub fn l2_config_directory(&self) -> PathBuf {
+        resolve_config_dir(self.l2_config_dir.as_ref(), "L2_CONFIG_DIR", "configs/L2")
+    }
+}
+
+fn resolve_config_dir(explicit: Option<&PathBuf>, env_name: &str, default: &str) -> PathBuf {
+    explicit.cloned().unwrap_or_else(|| {
+        env::var_os(env_name).map(PathBuf::from).unwrap_or_else(|| PathBuf::from(default))
+    })
 }
 
 /// The mode corresponding to the chain we are fetching data for.
@@ -115,6 +141,8 @@ pub fn get_rpcs_from_env() -> RPCConfig {
         l1_beacon_rpc,
         l2_rpc: Url::parse(&l2_rpc).expect("L2_RPC must be a valid URL"),
         l2_node_rpc: Url::parse(&l2_node_rpc).expect("L2_NODE_RPC must be a valid URL"),
+        l1_config_dir: None,
+        l2_config_dir: None,
     }
 }
 
@@ -196,7 +224,7 @@ impl OPSuccinctDataFetcher {
         }
 
         // Fetch and save L1 config based on the rollup config's L1 chain ID
-        let l1_config_path = Self::fetch_and_save_l1_config(&rollup_config).await?;
+        let l1_config_path = Self::fetch_and_save_l1_config(&rollup_config, &rpc_config).await?;
 
         Ok(Self {
             rpc_config,
@@ -363,9 +391,7 @@ impl OPSuccinctDataFetcher {
         let rollup_config: RollupConfig =
             Self::fetch_rpc_data(&rpc_config.l2_node_rpc, "optimism_rollupConfig", vec![]).await?;
 
-        // Create configs directory if it doesn't exist
-        let default_dir = PathBuf::from("configs/L2");
-        let l2_config_dir = env::var("L2_CONFIG_DIR").map(PathBuf::from).unwrap_or(default_dir);
+        let l2_config_dir = rpc_config.l2_config_directory();
         fs::create_dir_all(&l2_config_dir)?;
 
         // Save rollup config to a file named by chain ID
@@ -386,9 +412,11 @@ impl OPSuccinctDataFetcher {
     }
 
     /// Fetch and save the L1 config based on the rollup config's L1 chain ID.
-    async fn fetch_and_save_l1_config(rollup_config: &RollupConfig) -> Result<PathBuf> {
-        let default_dir = PathBuf::from("configs/L1");
-        let l1_config_dir = env::var("L1_CONFIG_DIR").map(PathBuf::from).unwrap_or(default_dir);
+    async fn fetch_and_save_l1_config(
+        rollup_config: &RollupConfig,
+        rpc_config: &RPCConfig,
+    ) -> Result<PathBuf> {
+        let l1_config_dir = rpc_config.l1_config_directory();
 
         // Check if the L1 config file exists. If it does, return the path to the file.
         let l1_config_path = l1_config_dir.join(format!("{}.json", rollup_config.l1_chain_id));
@@ -827,5 +855,28 @@ impl OPSuccinctDataFetcher {
         };
 
         Ok(HostConfig { request, prover, data_dir: None })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rpc_config(l1: Option<PathBuf>, l2: Option<PathBuf>) -> RPCConfig {
+        RPCConfig {
+            l1_rpc: "http://l1".parse().unwrap(),
+            l1_beacon_rpc: None,
+            l2_rpc: "http://l2".parse().unwrap(),
+            l2_node_rpc: "http://l2-node".parse().unwrap(),
+            l1_config_dir: l1,
+            l2_config_dir: l2,
+        }
+    }
+
+    #[test]
+    fn explicit_config_dirs_win_over_defaults() {
+        let rpc = rpc_config(Some(PathBuf::from("/tmp/l1")), Some(PathBuf::from("/tmp/l2")));
+        assert_eq!(rpc.l1_config_directory(), PathBuf::from("/tmp/l1"));
+        assert_eq!(rpc.l2_config_directory(), PathBuf::from("/tmp/l2"));
     }
 }

--- a/etc/systems/Cargo.toml
+++ b/etc/systems/Cargo.toml
@@ -105,9 +105,9 @@ async-trait.workspace = true
 tracing = { workspace = true, features = ["std"] }
 serde_json = { workspace = true, features = ["std"] }
 serde = { workspace = true, features = ["derive", "std"] }
-sqlx = { workspace = true, features = ["runtime-tokio", "postgres", "migrate", "tls-native-tls"] }
-testcontainers = { workspace = true, features = ["blocking", "host-port-exposure"] }
 testcontainers-modules = { workspace = true, features = ["postgres"] }
+testcontainers = { workspace = true, features = ["blocking", "host-port-exposure"] }
+sqlx = { workspace = true, features = ["runtime-tokio", "postgres", "migrate", "macros", "tls-native-tls"] }
 
 [features]
 default = [ "upgrade-signal" ]

--- a/etc/systems/Cargo.toml
+++ b/etc/systems/Cargo.toml
@@ -72,10 +72,10 @@ base-common-rpc-types.workspace = true
 base-common-precompiles.workspace = true
 
 # proof
-base-prover-service.workspace = true
 base-proof-zk-host.workspace = true
-base-prover-service-db.workspace = true
+base-prover-service.workspace = true
 base-proof-zk-backend.workspace = true
+base-prover-service-db.workspace = true
 base-prover-service-client.workspace = true
 base-prover-service-protocol = { workspace = true, features = ["rpc-server"] }
 
@@ -105,7 +105,7 @@ async-trait.workspace = true
 tracing = { workspace = true, features = ["std"] }
 serde_json = { workspace = true, features = ["std"] }
 serde = { workspace = true, features = ["derive", "std"] }
-sqlx = { workspace = true, features = ["runtime-tokio", "postgres", "tls-native-tls"] }
+sqlx = { workspace = true, features = ["runtime-tokio", "postgres", "migrate", "tls-native-tls"] }
 testcontainers = { workspace = true, features = ["blocking", "host-port-exposure"] }
 testcontainers-modules = { workspace = true, features = ["postgres"] }
 

--- a/etc/systems/Cargo.toml
+++ b/etc/systems/Cargo.toml
@@ -158,7 +158,6 @@ futures.workspace = true
 indicatif.workspace = true
 tokio-tungstenite.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
-testcontainers-modules = { workspace = true, features = ["postgres"] }
 
 [[bench]]
 name = "b20_zk_proving"

--- a/etc/systems/Cargo.toml
+++ b/etc/systems/Cargo.toml
@@ -71,13 +71,21 @@ base-common-network.workspace = true
 base-common-rpc-types.workspace = true
 base-common-precompiles.workspace = true
 
+# proof
+base-prover-service.workspace = true
+base-proof-zk-host.workspace = true
+base-prover-service-db.workspace = true
+base-proof-zk-backend.workspace = true
+base-prover-service-client.workspace = true
+base-prover-service-protocol = { workspace = true, features = ["rpc-server"] }
+
 # tokio
 tokio-util.workspace = true
 tokio = { workspace = true, features = ["full", "rt-multi-thread", "macros"] }
 
 # rpc
 axum = { workspace = true, features = ["http1", "tokio"] }
-jsonrpsee = { workspace = true, features = ["http-client"] }
+jsonrpsee = { workspace = true, features = ["http-client", "server"] }
 reth-rpc-layer.workspace = true
 tower.workspace = true
 
@@ -97,7 +105,9 @@ async-trait.workspace = true
 tracing = { workspace = true, features = ["std"] }
 serde_json = { workspace = true, features = ["std"] }
 serde = { workspace = true, features = ["derive", "std"] }
+sqlx = { workspace = true, features = ["runtime-tokio", "postgres", "tls-native-tls"] }
 testcontainers = { workspace = true, features = ["blocking", "host-port-exposure"] }
+testcontainers-modules = { workspace = true, features = ["postgres"] }
 
 [features]
 default = [ "upgrade-signal" ]
@@ -129,8 +139,6 @@ base-common-rpc-types-engine.workspace = true
 
 # proof
 base-optimism-rpc.workspace = true
-base-prover-service-client.workspace = true
-base-prover-service-protocol.workspace = true
 
 # execution
 base-shadow-indexer.workspace = true
@@ -149,6 +157,7 @@ anyhow.workspace = true
 futures.workspace = true
 indicatif.workspace = true
 tokio-tungstenite.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 testcontainers-modules = { workspace = true, features = ["postgres"] }
 
 [[bench]]

--- a/etc/systems/src/lib.rs
+++ b/etc/systems/src/lib.rs
@@ -57,6 +57,9 @@ pub use l2::{
 mod network;
 pub use network::{ensure_network_exists, ensure_network_exists_with_name, network_name};
 
+mod prover_service;
+pub use prover_service::InProcessProverService;
+
 mod rpc;
 pub use rpc::{SystemTestProviderExt, SystemTestRpcClient};
 
@@ -82,3 +85,6 @@ pub use upgrade_signal::{MockProtocolVersionsClient, UpgradeSignalStackOptions};
 
 mod urls;
 pub use urls::SystemTestUrls;
+
+mod zk_host;
+pub use zk_host::InProcessZkHost;

--- a/etc/systems/src/prover_service.rs
+++ b/etc/systems/src/prover_service.rs
@@ -1,0 +1,159 @@
+//! In-process prover-service JSON-RPC server backed by a Postgres testcontainer.
+
+use std::{
+    fs,
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+use base_prover_service::{
+    ProverServiceServer, ServerConfig, StatusPoller, WorkerApiConfig, WorkerQueueConfig,
+};
+use base_prover_service_db::{DatabaseConfig, ProofRequestRepo};
+use base_prover_service_protocol::{ProverRequesterApiServer, ProverWorkerApiServer};
+use eyre::{Result, WrapErr, ensure};
+use jsonrpsee::server::{Server, ServerHandle};
+use sqlx::Executor;
+use testcontainers::{ContainerAsync, runners::AsyncRunner};
+use testcontainers_modules::postgres::Postgres;
+use tokio::task::JoinHandle;
+use tracing::info;
+use url::Url;
+
+/// Production default shared with the prover-service binary.
+const MAX_PROOF_RETRIES: i32 = 3;
+/// Dry-run SP1 execute can outlive the production 300s default lock.
+const DEFAULT_LOCK_DURATION_SECONDS: u32 = 1800;
+const MAX_LOCK_DURATION_SECONDS: u32 = 3600;
+const STATUS_POLLER_INTERVAL_SECS: u64 = 30;
+const STUCK_REQUEST_TIMEOUT_MINS: i32 = 10;
+
+/// In-process prover-service requester and worker JSON-RPC on one listen address.
+pub struct InProcessProverService {
+    /// Shared requester and worker JSON-RPC URL.
+    url: Url,
+    server_handle: Option<ServerHandle>,
+    status_handle: JoinHandle<()>,
+    _postgres: ContainerAsync<Postgres>,
+}
+
+impl std::fmt::Debug for InProcessProverService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InProcessProverService").field("url", &self.url).finish_non_exhaustive()
+    }
+}
+
+impl InProcessProverService {
+    /// Starts Postgres, applies prover-service migrations, and binds JSON-RPC on `127.0.0.1:0`.
+    pub async fn start() -> Result<Self> {
+        let postgres = Postgres::default()
+            .start()
+            .await
+            .wrap_err("failed to start prover-service Postgres testcontainer")?;
+        let port = postgres
+            .get_host_port_ipv4(5432)
+            .await
+            .wrap_err("failed to map prover-service Postgres port")?;
+        let database_url =
+            format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres?sslmode=disable");
+
+        let db_config = DatabaseConfig {
+            url: database_url,
+            max_connections: 5,
+            connection_timeout: Duration::from_secs(5),
+        };
+        let pool = db_config.init_pool().await.map_err(|error| {
+            eyre::eyre!("failed to connect to prover-service Postgres: {error}")
+        })?;
+        apply_prover_migrations(&pool).await?;
+        let repo = ProofRequestRepo::new(pool);
+
+        let server_config = ServerConfig {
+            max_proof_retries: MAX_PROOF_RETRIES,
+            worker: WorkerApiConfig::new(DEFAULT_LOCK_DURATION_SECONDS, MAX_LOCK_DURATION_SECONDS),
+            worker_queue: WorkerQueueConfig::default(),
+        };
+        let status_poller = StatusPoller::new(
+            repo.clone(),
+            STATUS_POLLER_INTERVAL_SECS,
+            STUCK_REQUEST_TIMEOUT_MINS,
+            MAX_PROOF_RETRIES,
+            server_config.worker_queue,
+        );
+        let status_handle = tokio::spawn(async move {
+            status_poller.run().await;
+        });
+
+        let server = ProverServiceServer::new(repo, server_config);
+        let mut module = ProverWorkerApiServer::into_rpc(server.clone());
+        module
+            .merge(ProverRequesterApiServer::into_rpc(server))
+            .wrap_err("requester and worker namespaces should not collide")?;
+
+        let addr: SocketAddr =
+            "127.0.0.1:0".parse().wrap_err("test listen address should parse")?;
+        let rpc_server = Server::builder()
+            .build(addr)
+            .await
+            .wrap_err("failed to bind prover-service JSON-RPC")?;
+        let local_addr = rpc_server
+            .local_addr()
+            .wrap_err("failed to read prover-service JSON-RPC listen address")?;
+        let server_handle = rpc_server.start(module);
+        let url = Url::parse(&format!("http://{local_addr}"))
+            .wrap_err("failed to parse prover-service JSON-RPC URL")?;
+        info!(url = %url, "started in-process prover-service");
+
+        Ok(Self { url, server_handle: Some(server_handle), status_handle, _postgres: postgres })
+    }
+
+    /// Returns the shared requester and worker JSON-RPC URL.
+    pub const fn url(&self) -> &Url {
+        &self.url
+    }
+}
+
+impl Drop for InProcessProverService {
+    fn drop(&mut self) {
+        self.status_handle.abort();
+        if let Some(handle) = self.server_handle.take() {
+            let _ = handle.stop();
+        }
+    }
+}
+
+async fn apply_prover_migrations(pool: &sqlx::PgPool) -> Result<()> {
+    let migrations_dir = prover_migrations_dir()?;
+    let mut files = fs::read_dir(&migrations_dir)
+        .wrap_err_with(|| {
+            format!("failed to read prover migrations at {}", migrations_dir.display())
+        })?
+        .filter_map(std::result::Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "sql"))
+        .collect::<Vec<_>>();
+    files.sort();
+    ensure!(
+        !files.is_empty(),
+        "no prover-service SQL migrations found in {}",
+        migrations_dir.display()
+    );
+
+    for path in files {
+        let sql = fs::read_to_string(&path)
+            .wrap_err_with(|| format!("failed to read migration {}", path.display()))?;
+        pool.execute(sqlx::raw_sql(&sql)).await.wrap_err_with(|| {
+            format!("failed to apply prover-service migration {}", path.display())
+        })?;
+    }
+    Ok(())
+}
+
+fn prover_migrations_dir() -> Result<PathBuf> {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let dir = manifest_dir.join("../../crates/proof/prover-service/db/migrations");
+    dir.canonicalize().wrap_err_with(|| {
+        format!("prover-service migrations directory not found at {}", dir.display())
+    })
+}

--- a/etc/systems/src/prover_service.rs
+++ b/etc/systems/src/prover_service.rs
@@ -129,7 +129,11 @@ async fn apply_prover_migrations(pool: &sqlx::PgPool) -> Result<()> {
         .wrap_err_with(|| {
             format!("failed to read prover migrations at {}", migrations_dir.display())
         })?
-        .filter_map(std::result::Result::ok)
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .wrap_err_with(|| {
+            format!("failed to list prover migrations in {}", migrations_dir.display())
+        })?
+        .into_iter()
         .map(|entry| entry.path())
         .filter(|path| path.extension().is_some_and(|ext| ext == "sql"))
         .collect::<Vec<_>>();

--- a/etc/systems/src/prover_service.rs
+++ b/etc/systems/src/prover_service.rs
@@ -1,23 +1,18 @@
 //! In-process prover-service JSON-RPC server backed by a Postgres testcontainer.
 
 use std::{
-    fs,
     net::SocketAddr,
     path::{Path, PathBuf},
     time::Duration,
 };
 
-use base_prover_service::{
-    ProverServiceServer, ServerConfig, StatusPoller, WorkerApiConfig, WorkerQueueConfig,
-};
+use base_prover_service::{ProverServiceServer, ServerConfig, WorkerApiConfig, WorkerQueueConfig};
 use base_prover_service_db::{DatabaseConfig, ProofRequestRepo};
 use base_prover_service_protocol::{ProverRequesterApiServer, ProverWorkerApiServer};
-use eyre::{Result, WrapErr, ensure};
+use eyre::{Result, WrapErr};
 use jsonrpsee::server::{Server, ServerHandle};
-use sqlx::Executor;
 use testcontainers::{ContainerAsync, runners::AsyncRunner};
 use testcontainers_modules::postgres::Postgres;
-use tokio::task::JoinHandle;
 use tracing::info;
 use url::Url;
 
@@ -26,15 +21,12 @@ const MAX_PROOF_RETRIES: i32 = 3;
 /// Dry-run SP1 execute can outlive the production 300s default lock.
 const DEFAULT_LOCK_DURATION_SECONDS: u32 = 1800;
 const MAX_LOCK_DURATION_SECONDS: u32 = 3600;
-const STATUS_POLLER_INTERVAL_SECS: u64 = 30;
-const STUCK_REQUEST_TIMEOUT_MINS: i32 = 10;
 
 /// In-process prover-service requester and worker JSON-RPC on one listen address.
 pub struct InProcessProverService {
     /// Shared requester and worker JSON-RPC URL.
     url: Url,
     server_handle: Option<ServerHandle>,
-    status_handle: JoinHandle<()>,
     _postgres: ContainerAsync<Postgres>,
 }
 
@@ -74,16 +66,6 @@ impl InProcessProverService {
             worker: WorkerApiConfig::new(DEFAULT_LOCK_DURATION_SECONDS, MAX_LOCK_DURATION_SECONDS),
             worker_queue: WorkerQueueConfig::default(),
         };
-        let status_poller = StatusPoller::new(
-            repo.clone(),
-            STATUS_POLLER_INTERVAL_SECS,
-            STUCK_REQUEST_TIMEOUT_MINS,
-            MAX_PROOF_RETRIES,
-            server_config.worker_queue,
-        );
-        let status_handle = tokio::spawn(async move {
-            status_poller.run().await;
-        });
 
         let server = ProverServiceServer::new(repo, server_config);
         let mut module = ProverWorkerApiServer::into_rpc(server.clone());
@@ -105,7 +87,7 @@ impl InProcessProverService {
             .wrap_err("failed to parse prover-service JSON-RPC URL")?;
         info!(url = %url, "started in-process prover-service");
 
-        Ok(Self { url, server_handle: Some(server_handle), status_handle, _postgres: postgres })
+        Ok(Self { url, server_handle: Some(server_handle), _postgres: postgres })
     }
 
     /// Returns the shared requester and worker JSON-RPC URL.
@@ -116,7 +98,6 @@ impl InProcessProverService {
 
 impl Drop for InProcessProverService {
     fn drop(&mut self) {
-        self.status_handle.abort();
         if let Some(handle) = self.server_handle.take() {
             let _ = handle.stop();
         }
@@ -125,32 +106,14 @@ impl Drop for InProcessProverService {
 
 async fn apply_prover_migrations(pool: &sqlx::PgPool) -> Result<()> {
     let migrations_dir = prover_migrations_dir()?;
-    let mut files = fs::read_dir(&migrations_dir)
+    sqlx::migrate::Migrator::new(migrations_dir.as_path())
+        .await
         .wrap_err_with(|| {
-            format!("failed to read prover migrations at {}", migrations_dir.display())
+            format!("failed to load prover-service migrations from {}", migrations_dir.display())
         })?
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .wrap_err_with(|| {
-            format!("failed to list prover migrations in {}", migrations_dir.display())
-        })?
-        .into_iter()
-        .map(|entry| entry.path())
-        .filter(|path| path.extension().is_some_and(|ext| ext == "sql"))
-        .collect::<Vec<_>>();
-    files.sort();
-    ensure!(
-        !files.is_empty(),
-        "no prover-service SQL migrations found in {}",
-        migrations_dir.display()
-    );
-
-    for path in files {
-        let sql = fs::read_to_string(&path)
-            .wrap_err_with(|| format!("failed to read migration {}", path.display()))?;
-        pool.execute(sqlx::raw_sql(&sql)).await.wrap_err_with(|| {
-            format!("failed to apply prover-service migration {}", path.display())
-        })?;
-    }
+        .run(pool)
+        .await
+        .wrap_err("failed to apply prover-service migrations")?;
     Ok(())
 }
 

--- a/etc/systems/src/prover_service.rs
+++ b/etc/systems/src/prover_service.rs
@@ -1,10 +1,6 @@
 //! In-process prover-service JSON-RPC server backed by a Postgres testcontainer.
 
-use std::{
-    net::SocketAddr,
-    path::{Path, PathBuf},
-    time::Duration,
-};
+use std::{net::SocketAddr, time::Duration};
 
 use base_prover_service::{ProverServiceServer, ServerConfig, WorkerApiConfig, WorkerQueueConfig};
 use base_prover_service_db::{DatabaseConfig, ProofRequestRepo};
@@ -58,7 +54,10 @@ impl InProcessProverService {
         let pool = db_config.init_pool().await.map_err(|error| {
             eyre::eyre!("failed to connect to prover-service Postgres: {error}")
         })?;
-        apply_prover_migrations(&pool).await?;
+        sqlx::migrate!("../../crates/proof/prover-service/db/migrations")
+            .run(&pool)
+            .await
+            .wrap_err("failed to apply prover-service migrations")?;
         let repo = ProofRequestRepo::new(pool);
 
         let server_config = ServerConfig {
@@ -102,25 +101,4 @@ impl Drop for InProcessProverService {
             let _ = handle.stop();
         }
     }
-}
-
-async fn apply_prover_migrations(pool: &sqlx::PgPool) -> Result<()> {
-    let migrations_dir = prover_migrations_dir()?;
-    sqlx::migrate::Migrator::new(migrations_dir.as_path())
-        .await
-        .wrap_err_with(|| {
-            format!("failed to load prover-service migrations from {}", migrations_dir.display())
-        })?
-        .run(pool)
-        .await
-        .wrap_err("failed to apply prover-service migrations")?;
-    Ok(())
-}
-
-fn prover_migrations_dir() -> Result<PathBuf> {
-    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let dir = manifest_dir.join("../../crates/proof/prover-service/db/migrations");
-    dir.canonicalize().wrap_err_with(|| {
-        format!("prover-service migrations directory not found at {}", dir.display())
-    })
 }

--- a/etc/systems/src/zk_host.rs
+++ b/etc/systems/src/zk_host.rs
@@ -30,7 +30,7 @@ const RANGE_GAS_LIMIT: u64 = 1_000_000_000_000;
 pub struct InProcessZkHost {
     cancel: CancellationToken,
     join: Option<JoinHandle<()>>,
-    /// Keeps `L1_CONFIG_DIR` / `L2_CONFIG_DIR` on disk for the host lifetime.
+    /// Keeps OP Succinct L1/L2 config files on disk for the host lifetime.
     _config_dir: TempDir,
 }
 
@@ -82,6 +82,8 @@ impl InProcessZkHost {
             range_gas_limit: RANGE_GAS_LIMIT,
             aggregation_cycle_limit: RANGE_CYCLE_LIMIT,
             aggregation_gas_limit: RANGE_GAS_LIMIT,
+            l1_config_dir: Some(config_dir.path().join("L1")),
+            l2_config_dir: Some(config_dir.path().join("L2")),
         };
         let Some(provers) = config
             .build_until_cancelled(&cancel)
@@ -121,11 +123,11 @@ impl InProcessZkHost {
         Ok(Self { cancel, join: Some(join), _config_dir: config_dir })
     }
 
-    /// Writes the stack's L1 chain config for OP Succinct and points the fetcher at it.
+    /// Writes the stack's L1 chain config into a temp dir for the OP Succinct fetcher.
     ///
     /// System-test L1 is chain 1337, which is not in the built-in `L1_CONFIGS` map. The
-    /// fetcher reads `<L1_CONFIG_DIR>/<chain_id>.json` before that map. `L2_CONFIG_DIR`
-    /// is set so rollup config is not written into the process cwd.
+    /// fetcher reads `<l1_config_dir>/<chain_id>.json` before that map. L2 configs are
+    /// written to a sibling directory so rollup config is not written into the process cwd.
     fn install_succinct_chain_configs(stack: &SystemTestStack) -> Result<TempDir> {
         let genesis: serde_json::Value = serde_json::from_str(
             &stack.l1_genesis().read_el_genesis().wrap_err("failed to read L1 genesis")?,
@@ -148,12 +150,6 @@ impl InProcessZkHost {
         )
         .wrap_err("failed to write L1 chain config for succinct fetcher")?;
 
-        // SAFETY: only one in-process ZK host runs at a time in these tests, and the
-        // directories live as long as this host.
-        unsafe {
-            std::env::set_var("L1_CONFIG_DIR", &l1_dir);
-            std::env::set_var("L2_CONFIG_DIR", &l2_dir);
-        }
         info!(chain_id, "installed succinct L1/L2 config directories");
         Ok(dir)
     }

--- a/etc/systems/src/zk_host.rs
+++ b/etc/systems/src/zk_host.rs
@@ -1,0 +1,169 @@
+//! In-process ZK host that claims jobs from [`crate::InProcessProverService`].
+
+use std::{fs, time::Duration};
+
+use base_proof_zk_backend::SuccinctZkProversConfig;
+use base_proof_zk_host::{ProofGeneratorHeartbeatConfig, ZkHost, ZkHostConfig};
+use base_prover_service_client::{ProverServiceClientConfig, ProverWorkerClient};
+use base_prover_service_protocol::ZkBackend;
+use eyre::{OptionExt, Result, WrapErr, bail, ensure};
+use nanoid::nanoid;
+use tempfile::TempDir;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+use url::Url;
+
+use crate::SystemTestStack;
+
+/// Short discovery poll so tests do not wait on the production 5s interval.
+const DISCOVERY_POLL_INTERVAL: Duration = Duration::from_millis(200);
+/// Dry-run SP1 execute can outlive the production 300s default lock.
+const LOCK_DURATION_SECONDS: u32 = 1800;
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
+const MAX_CONSECUTIVE_HEARTBEAT_FAILURES: u32 = 5;
+const DEFAULT_SEQUENCE_WINDOW: u64 = 50;
+const RANGE_CYCLE_LIMIT: u64 = 1_000_000_000_000;
+const RANGE_GAS_LIMIT: u64 = 1_000_000_000_000;
+
+/// In-process SP1 ZK host bound to a live [`SystemTestStack`].
+pub struct InProcessZkHost {
+    cancel: CancellationToken,
+    join: Option<JoinHandle<()>>,
+    /// Keeps `L1_CONFIG_DIR` / `L2_CONFIG_DIR` on disk for the host lifetime.
+    _config_dir: TempDir,
+}
+
+impl std::fmt::Debug for InProcessZkHost {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InProcessZkHost").finish_non_exhaustive()
+    }
+}
+
+impl InProcessZkHost {
+    /// Starts a ZK host that claims from `prover_service_url` using `backend`.
+    ///
+    /// Only [`ZkBackend::DryRun`] is supported: cluster and network need remote credentials.
+    pub async fn start(
+        stack: &SystemTestStack,
+        prover_service_url: &Url,
+        backend: ZkBackend,
+    ) -> Result<Self> {
+        if backend != ZkBackend::DryRun {
+            bail!("InProcessZkHost only supports ZkBackend::DryRun, got {backend}");
+        }
+
+        let config_dir = Self::install_succinct_chain_configs(stack)?;
+        let cancel = CancellationToken::new();
+        let l2_rpc = stack.l2_rpc_url().wrap_err("failed to read L2 builder RPC URL")?;
+        let urls = stack.urls().await.wrap_err("failed to read system test RPC URLs")?;
+        let l1_rpc = stack.l1_rpc_url().await.wrap_err("failed to read L1 RPC URL")?;
+        let l1_beacon = Url::parse(
+            &stack.l1_stack().beacon_url().await.wrap_err("failed to read L1 beacon URL")?,
+        )
+        .wrap_err("failed to parse L1 beacon URL")?;
+        let base_consensus_rpc = Url::parse(&urls.l2_builder_consensus_rpc)
+            .wrap_err("failed to parse L2 builder consensus RPC URL")?;
+
+        let config = SuccinctZkProversConfig {
+            base_consensus_rpc: Some(base_consensus_rpc),
+            l1_rpc: Some(l1_rpc),
+            l1_beacon_rpc: Some(l1_beacon),
+            l2_rpc: Some(l2_rpc),
+            default_sequence_window: DEFAULT_SEQUENCE_WINDOW,
+            cluster_rpc: None,
+            cluster_timeout_hours: 24,
+            s3_bucket: None,
+            s3_region: None,
+            network_private_key: None,
+            use_kms_requester: false,
+            network_timeout_hours: 24,
+            range_cycle_limit: RANGE_CYCLE_LIMIT,
+            range_gas_limit: RANGE_GAS_LIMIT,
+            aggregation_cycle_limit: RANGE_CYCLE_LIMIT,
+            aggregation_gas_limit: RANGE_GAS_LIMIT,
+        };
+        let Some(provers) = config
+            .build_until_cancelled(&cancel)
+            .await
+            .wrap_err("failed to initialize dry-run ZK backend")?
+        else {
+            bail!("dry-run ZK backend initialization was cancelled");
+        };
+        ensure!(
+            provers.contains_key(&ZkBackend::DryRun),
+            "dry-run ZK backend was not enabled after initialization"
+        );
+
+        let client_config = ProverServiceClientConfig::new(prover_service_url.as_str())
+            .with_request_timeout(Duration::from_secs(30));
+        let client = ProverWorkerClient::connect(&client_config)
+            .wrap_err("failed to connect ZK host to in-process prover-service")?;
+
+        let worker_id = format!("system-test-zk-host-{}", nanoid!());
+        let host_config = ZkHostConfig::sp1(worker_id.clone())
+            .with_job_discovery_poll_interval(DISCOVERY_POLL_INTERVAL)
+            .with_job_discovery_lock_duration_seconds(LOCK_DURATION_SECONDS)
+            .with_proof_generator_heartbeat(
+                ProofGeneratorHeartbeatConfig::with_max_consecutive_failures(
+                    HEARTBEAT_INTERVAL,
+                    LOCK_DURATION_SECONDS,
+                    MAX_CONSECUTIVE_HEARTBEAT_FAILURES,
+                ),
+            );
+        let host = ZkHost::new(client, provers, host_config);
+        let run_cancel = cancel.clone();
+        let join = tokio::spawn(async move {
+            host.run_until_cancelled(run_cancel).await;
+        });
+        info!(worker_id = %worker_id, "started in-process ZK host");
+
+        Ok(Self { cancel, join: Some(join), _config_dir: config_dir })
+    }
+
+    /// Writes the stack's L1 chain config for OP Succinct and points the fetcher at it.
+    ///
+    /// System-test L1 is chain 1337, which is not in the built-in `L1_CONFIGS` map. The
+    /// fetcher reads `<L1_CONFIG_DIR>/<chain_id>.json` before that map. `L2_CONFIG_DIR`
+    /// is set so rollup config is not written into the process cwd.
+    fn install_succinct_chain_configs(stack: &SystemTestStack) -> Result<TempDir> {
+        let genesis: serde_json::Value = serde_json::from_str(
+            &stack.l1_genesis().read_el_genesis().wrap_err("failed to read L1 genesis")?,
+        )
+        .wrap_err("failed to parse L1 genesis")?;
+        let config = genesis.get("config").ok_or_eyre("L1 genesis is missing config")?;
+        let chain_id = config
+            .get("chainId")
+            .and_then(serde_json::Value::as_u64)
+            .ok_or_eyre("L1 genesis config is missing chainId")?;
+
+        let dir = tempfile::tempdir().wrap_err("failed to create succinct config directory")?;
+        let l1_dir = dir.path().join("L1");
+        let l2_dir = dir.path().join("L2");
+        fs::create_dir_all(&l1_dir).wrap_err("failed to create succinct L1 config directory")?;
+        fs::create_dir_all(&l2_dir).wrap_err("failed to create succinct L2 config directory")?;
+        fs::write(
+            l1_dir.join(format!("{chain_id}.json")),
+            serde_json::to_vec_pretty(config).wrap_err("failed to encode L1 chain config")?,
+        )
+        .wrap_err("failed to write L1 chain config for succinct fetcher")?;
+
+        // SAFETY: only one in-process ZK host runs at a time in these tests, and the
+        // directories live as long as this host.
+        unsafe {
+            std::env::set_var("L1_CONFIG_DIR", &l1_dir);
+            std::env::set_var("L2_CONFIG_DIR", &l2_dir);
+        }
+        info!(chain_id, "installed succinct L1/L2 config directories");
+        Ok(dir)
+    }
+}
+
+impl Drop for InProcessZkHost {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+        if let Some(join) = self.join.take() {
+            join.abort();
+        }
+    }
+}

--- a/etc/systems/src/zk_host.rs
+++ b/etc/systems/src/zk_host.rs
@@ -123,8 +123,13 @@ impl InProcessZkHost {
         let join = tokio::spawn(async move {
             host.run_until_cancelled(run_cancel).await;
         });
-        timeout(FIRST_WORKER_POLL_TIMEOUT, first_poll_rx.wait_for(|ready| *ready))
-            .await
+        let first_poll =
+            timeout(FIRST_WORKER_POLL_TIMEOUT, first_poll_rx.wait_for(|ready| *ready)).await;
+        if !matches!(first_poll, Ok(Ok(_))) {
+            cancel.cancel();
+            join.abort();
+        }
+        first_poll
             .wrap_err("in-process ZK host did not complete a worker poll")?
             .wrap_err("in-process ZK host stopped before the first worker poll")?;
         info!(worker_id = %worker_id, "started in-process ZK host");

--- a/etc/systems/src/zk_host.rs
+++ b/etc/systems/src/zk_host.rs
@@ -2,14 +2,21 @@
 
 use std::{fs, time::Duration};
 
+use async_trait::async_trait;
 use base_proof_zk_backend::SuccinctZkProversConfig;
 use base_proof_zk_host::{ProofGeneratorHeartbeatConfig, ZkHost, ZkHostConfig};
-use base_prover_service_client::{ProverServiceClientConfig, ProverWorkerClient};
-use base_prover_service_protocol::ZkBackend;
+use base_prover_service_client::{
+    ProverServiceClientConfig, ProverServiceClientError, ProverWorkerClient, ProverWorkerProvider,
+};
+use base_prover_service_protocol::{
+    GetNextProofRequest, GetNextProofResponse, GetProofSessionRequest, GetProofSessionResponse,
+    HeartbeatRequest, HeartbeatResponse, RecordProofSessionRequest, RecordProofSessionResponse,
+    WorkerSubmitProofRequest, WorkerSubmitProofResponse, ZkBackend,
+};
 use eyre::{OptionExt, Result, WrapErr, bail, ensure};
 use nanoid::nanoid;
 use tempfile::TempDir;
-use tokio::task::JoinHandle;
+use tokio::{sync::watch, task::JoinHandle, time::timeout};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 use url::Url;
@@ -25,6 +32,8 @@ const MAX_CONSECUTIVE_HEARTBEAT_FAILURES: u32 = 5;
 const DEFAULT_SEQUENCE_WINDOW: u64 = 50;
 const RANGE_CYCLE_LIMIT: u64 = 1_000_000_000_000;
 const RANGE_GAS_LIMIT: u64 = 1_000_000_000_000;
+/// Bound for the first worker `get_next_proof` after spawn.
+const FIRST_WORKER_POLL_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// In-process SP1 ZK host bound to a live [`SystemTestStack`].
 pub struct InProcessZkHost {
@@ -41,18 +50,12 @@ impl std::fmt::Debug for InProcessZkHost {
 }
 
 impl InProcessZkHost {
-    /// Starts a ZK host that claims from `prover_service_url` using `backend`.
+    /// Starts a dry-run ZK host that claims from `prover_service_url`.
     ///
-    /// Only [`ZkBackend::DryRun`] is supported: cluster and network need remote credentials.
-    pub async fn start(
-        stack: &SystemTestStack,
-        prover_service_url: &Url,
-        backend: ZkBackend,
-    ) -> Result<Self> {
-        if backend != ZkBackend::DryRun {
-            bail!("InProcessZkHost only supports ZkBackend::DryRun, got {backend}");
-        }
-
+    /// Returns after the host has completed one successful worker poll so the
+    /// worker namespace and host wiring are exercised. Cluster and network
+    /// backends are not supported here.
+    pub async fn start(stack: &SystemTestStack, prover_service_url: &Url) -> Result<Self> {
         let config_dir = Self::install_succinct_chain_configs(stack)?;
         let cancel = CancellationToken::new();
         let l2_rpc = stack.l2_rpc_url().wrap_err("failed to read L2 builder RPC URL")?;
@@ -99,8 +102,10 @@ impl InProcessZkHost {
 
         let client_config = ProverServiceClientConfig::new(prover_service_url.as_str())
             .with_request_timeout(Duration::from_secs(30));
-        let client = ProverWorkerClient::connect(&client_config)
+        let inner = ProverWorkerClient::connect(&client_config)
             .wrap_err("failed to connect ZK host to in-process prover-service")?;
+        let (first_poll, mut first_poll_rx) = watch::channel(false);
+        let client = FirstPollWorker { inner, first_poll };
 
         let worker_id = format!("system-test-zk-host-{}", nanoid!());
         let host_config = ZkHostConfig::sp1(worker_id.clone())
@@ -118,6 +123,10 @@ impl InProcessZkHost {
         let join = tokio::spawn(async move {
             host.run_until_cancelled(run_cancel).await;
         });
+        timeout(FIRST_WORKER_POLL_TIMEOUT, first_poll_rx.wait_for(|ready| *ready))
+            .await
+            .wrap_err("in-process ZK host did not complete a worker poll")?
+            .wrap_err("in-process ZK host stopped before the first worker poll")?;
         info!(worker_id = %worker_id, "started in-process ZK host");
 
         Ok(Self { cancel, join: Some(join), _config_dir: config_dir })
@@ -141,9 +150,7 @@ impl InProcessZkHost {
 
         let dir = tempfile::tempdir().wrap_err("failed to create succinct config directory")?;
         let l1_dir = dir.path().join("L1");
-        let l2_dir = dir.path().join("L2");
         fs::create_dir_all(&l1_dir).wrap_err("failed to create succinct L1 config directory")?;
-        fs::create_dir_all(&l2_dir).wrap_err("failed to create succinct L2 config directory")?;
         fs::write(
             l1_dir.join(format!("{chain_id}.json")),
             serde_json::to_vec_pretty(config).wrap_err("failed to encode L1 chain config")?,
@@ -161,5 +168,58 @@ impl Drop for InProcessZkHost {
         if let Some(join) = self.join.take() {
             join.abort();
         }
+    }
+}
+
+/// Forwards worker RPCs and records the first successful [`get_next_proof`](ProverWorkerProvider::get_next_proof).
+#[derive(Clone, Debug)]
+struct FirstPollWorker {
+    inner: ProverWorkerClient,
+    first_poll: watch::Sender<bool>,
+}
+
+impl FirstPollWorker {
+    fn mark_polled(&self) {
+        let _ = self.first_poll.send(true);
+    }
+}
+
+#[async_trait]
+impl ProverWorkerProvider for FirstPollWorker {
+    async fn get_next_proof(
+        &self,
+        request: GetNextProofRequest,
+    ) -> Result<GetNextProofResponse, ProverServiceClientError> {
+        let response = self.inner.get_next_proof(request).await?;
+        self.mark_polled();
+        Ok(response)
+    }
+
+    async fn heartbeat(
+        &self,
+        request: HeartbeatRequest,
+    ) -> Result<HeartbeatResponse, ProverServiceClientError> {
+        self.inner.heartbeat(request).await
+    }
+
+    async fn submit_proof(
+        &self,
+        request: WorkerSubmitProofRequest,
+    ) -> Result<WorkerSubmitProofResponse, ProverServiceClientError> {
+        self.inner.submit_proof(request).await
+    }
+
+    async fn get_proof_session(
+        &self,
+        request: GetProofSessionRequest,
+    ) -> Result<GetProofSessionResponse, ProverServiceClientError> {
+        self.inner.get_proof_session(request).await
+    }
+
+    async fn record_proof_session(
+        &self,
+        request: RecordProofSessionRequest,
+    ) -> Result<RecordProofSessionResponse, ProverServiceClientError> {
+        self.inner.record_proof_session(request).await
     }
 }

--- a/etc/systems/src/zk_host.rs
+++ b/etc/systems/src/zk_host.rs
@@ -178,12 +178,6 @@ struct FirstPollWorker {
     first_poll: watch::Sender<bool>,
 }
 
-impl FirstPollWorker {
-    fn mark_polled(&self) {
-        let _ = self.first_poll.send(true);
-    }
-}
-
 #[async_trait]
 impl ProverWorkerProvider for FirstPollWorker {
     async fn get_next_proof(
@@ -191,7 +185,7 @@ impl ProverWorkerProvider for FirstPollWorker {
         request: GetNextProofRequest,
     ) -> Result<GetNextProofResponse, ProverServiceClientError> {
         let response = self.inner.get_next_proof(request).await?;
-        self.mark_polled();
+        let _ = self.first_poll.send(true);
         Ok(response)
     }
 

--- a/etc/systems/tests/activation_registry.rs
+++ b/etc/systems/tests/activation_registry.rs
@@ -3,18 +3,12 @@
 mod common;
 
 use alloy_primitives::{Address, B256, LogData};
-use alloy_provider::RootProvider;
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::{SolCall, SolEvent};
-use base_common_network::Base;
 use base_common_precompiles::{ActivationFeature, ActivationRegistryStorage, IActivationRegistry};
 use base_common_rpc_types::BaseTransactionReceipt;
-use base_system_tests::{
-    ANVIL_ACCOUNT_5, ANVIL_ACCOUNT_6, B20PrecompileClient, SystemTestStack, SystemTestStackBuilder,
-};
+use base_system_tests::{ANVIL_ACCOUNT_5, ANVIL_ACCOUNT_6, B20PrecompileClient};
 use eyre::{Result, WrapErr};
-
-const BASE_COBALT_ACTIVATION_BLOCK: u64 = 5;
 
 /// `isActivated` returns `false` for every feature id by default.
 #[tokio::test]
@@ -90,7 +84,7 @@ async fn test_activation_registry_set_admin_reverts_before_cobalt() -> Result<()
 /// At Cobalt, `setAdmin` updates the stored admin and future activation authority.
 #[tokio::test]
 async fn test_activation_registry_cobalt_admin_rotation() -> Result<()> {
-    let (_system, provider) = start_cobalt_system().await?;
+    let (_system, provider) = common::start_cobalt_system().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse system test admin private key")?;
     let new_admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_6.private_key)
@@ -290,20 +284,6 @@ async fn is_activated(client: &B20PrecompileClient<'_>, feature: B256) -> Result
         .await?;
     IActivationRegistry::isActivatedCall::abi_decode_returns(output.as_ref())
         .wrap_err("Failed to decode isActivated")
-}
-
-async fn start_cobalt_system() -> Result<(SystemTestStack, RootProvider<Base>)> {
-    let system = SystemTestStackBuilder::new()
-        .with_l1_chain_id(common::L1_CHAIN_ID)
-        .with_l2_chain_id(common::L2_CHAIN_ID)
-        .with_base_azul_activation_block(common::BASE_AZUL_ACTIVATION_BLOCK)
-        .with_base_beryl_activation_block(common::BASE_BERYL_ACTIVATION_BLOCK)
-        .with_base_cobalt_activation_block(BASE_COBALT_ACTIVATION_BLOCK)
-        .build()
-        .await?;
-    let provider = system.l2_builder_provider()?;
-    common::wait_for_block(&provider, BASE_COBALT_ACTIVATION_BLOCK + 1).await?;
-    Ok((system, provider))
 }
 
 async fn admin_address(client: &B20PrecompileClient<'_>) -> Result<Address> {

--- a/etc/systems/tests/activation_registry.rs
+++ b/etc/systems/tests/activation_registry.rs
@@ -1,5 +1,7 @@
 //! System tests for the activation registry precompile over Base node RPC.
 
+#[path = "common/cobalt.rs"]
+mod cobalt;
 mod common;
 
 use alloy_primitives::{Address, B256, LogData};
@@ -84,7 +86,7 @@ async fn test_activation_registry_set_admin_reverts_before_cobalt() -> Result<()
 /// At Cobalt, `setAdmin` updates the stored admin and future activation authority.
 #[tokio::test]
 async fn test_activation_registry_cobalt_admin_rotation() -> Result<()> {
-    let (_system, provider) = common::start_cobalt_system().await?;
+    let (_system, provider) = cobalt::start_cobalt_system().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse system test admin private key")?;
     let new_admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_6.private_key)

--- a/etc/systems/tests/activation_registry.rs
+++ b/etc/systems/tests/activation_registry.rs
@@ -1,5 +1,7 @@
 //! System tests for the activation registry precompile over Base node RPC.
 
+#[path = "common/beryl.rs"]
+mod beryl;
 #[path = "common/cobalt.rs"]
 mod cobalt;
 mod common;
@@ -15,13 +17,13 @@ use eyre::{Result, WrapErr};
 /// `isActivated` returns `false` for every feature id by default.
 #[tokio::test]
 async fn test_activation_registry_is_activated_default() -> Result<()> {
-    let (_system, provider) = common::start_beryl_system().await?;
+    let (_system, provider) = beryl::start_beryl_system().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse system test private key")?;
-    common::wait_for_balance(&provider, admin.address()).await?;
+    beryl::wait_for_balance(&provider, admin.address()).await?;
 
     let client = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
-        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+        .with_receipt_timeout(beryl::TX_RECEIPT_TIMEOUT);
 
     let output = client
         .call(
@@ -40,13 +42,13 @@ async fn test_activation_registry_is_activated_default() -> Result<()> {
 /// `admin()` returns the generated system test activation admin address.
 #[tokio::test]
 async fn test_activation_registry_admin() -> Result<()> {
-    let (_system, provider) = common::start_beryl_system().await?;
+    let (_system, provider) = beryl::start_beryl_system().await?;
     let caller = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse system test private key")?;
-    common::wait_for_balance(&provider, caller.address()).await?;
+    beryl::wait_for_balance(&provider, caller.address()).await?;
 
     let client = B20PrecompileClient::new(&provider, &caller, common::L2_CHAIN_ID)
-        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+        .with_receipt_timeout(beryl::TX_RECEIPT_TIMEOUT);
 
     let output =
         client.call(ActivationRegistryStorage::ADDRESS, IActivationRegistry::adminCall {}).await?;
@@ -61,13 +63,13 @@ async fn test_activation_registry_admin() -> Result<()> {
 /// `setAdmin` stays disabled while Beryl is active but Cobalt is not.
 #[tokio::test]
 async fn test_activation_registry_set_admin_reverts_before_cobalt() -> Result<()> {
-    let (_system, provider) = common::start_beryl_system().await?;
+    let (_system, provider) = beryl::start_beryl_system().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse system test private key")?;
-    common::wait_for_balance(&provider, admin.address()).await?;
+    beryl::wait_for_balance(&provider, admin.address()).await?;
 
     let client = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
-        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+        .with_receipt_timeout(beryl::TX_RECEIPT_TIMEOUT);
 
     let succeeded = client
         .try_send_call(
@@ -91,13 +93,13 @@ async fn test_activation_registry_cobalt_admin_rotation() -> Result<()> {
         .wrap_err("Failed to parse system test admin private key")?;
     let new_admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_6.private_key)
         .wrap_err("Failed to parse system test new admin private key")?;
-    common::wait_for_balance(&provider, admin.address()).await?;
-    common::wait_for_balance(&provider, new_admin.address()).await?;
+    beryl::wait_for_balance(&provider, admin.address()).await?;
+    beryl::wait_for_balance(&provider, new_admin.address()).await?;
 
     let admin_client = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
-        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+        .with_receipt_timeout(beryl::TX_RECEIPT_TIMEOUT);
     let new_admin_client = B20PrecompileClient::new(&provider, &new_admin, common::L2_CHAIN_ID)
-        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+        .with_receipt_timeout(beryl::TX_RECEIPT_TIMEOUT);
 
     assert_eq!(admin_address(&admin_client).await?, admin.address());
 
@@ -142,13 +144,13 @@ async fn test_activation_registry_cobalt_admin_rotation() -> Result<()> {
 /// Admin activate/deactivate transitions update state, emit events, and reject repeated calls.
 #[tokio::test]
 async fn test_activation_registry_admin_lifecycle() -> Result<()> {
-    let (_system, provider) = common::start_beryl_system().await?;
+    let (_system, provider) = beryl::start_beryl_system().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse system test private key")?;
-    common::wait_for_balance(&provider, admin.address()).await?;
+    beryl::wait_for_balance(&provider, admin.address()).await?;
 
     let client = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
-        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+        .with_receipt_timeout(beryl::TX_RECEIPT_TIMEOUT);
     let feature = ActivationFeature::B20Stablecoin.id();
 
     assert!(!is_activated(&client, feature).await?, "feature should start inactive");
@@ -209,13 +211,13 @@ async fn test_activation_registry_admin_lifecycle() -> Result<()> {
 /// Calling `activate` from a non-admin account reverts with `Unauthorized`.
 #[tokio::test]
 async fn test_activation_registry_unauthorized_activate_reverts() -> Result<()> {
-    let (_system, provider) = common::start_beryl_system().await?;
+    let (_system, provider) = beryl::start_beryl_system().await?;
     let non_admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_6.private_key)
         .wrap_err("Failed to parse system test private key")?;
-    common::wait_for_balance(&provider, non_admin.address()).await?;
+    beryl::wait_for_balance(&provider, non_admin.address()).await?;
 
     let client = B20PrecompileClient::new(&provider, &non_admin, common::L2_CHAIN_ID)
-        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+        .with_receipt_timeout(beryl::TX_RECEIPT_TIMEOUT);
 
     let succeeded = client
         .try_send_call(
@@ -244,13 +246,13 @@ async fn test_activation_registry_unauthorized_activate_reverts() -> Result<()> 
 /// `checkActivated` reverts before activation and succeeds while the feature is active.
 #[tokio::test]
 async fn test_activation_registry_check_activated_gate() -> Result<()> {
-    let (_system, provider) = common::start_beryl_system().await?;
+    let (_system, provider) = beryl::start_beryl_system().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse system test private key")?;
-    common::wait_for_balance(&provider, admin.address()).await?;
+    beryl::wait_for_balance(&provider, admin.address()).await?;
 
     let client = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
-        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+        .with_receipt_timeout(beryl::TX_RECEIPT_TIMEOUT);
     let feature = ActivationFeature::B20Asset.id();
 
     assert!(

--- a/etc/systems/tests/b20_precompile.rs
+++ b/etc/systems/tests/b20_precompile.rs
@@ -1,5 +1,7 @@
 //! System tests for B-20 precompiles over Base node RPC.
 
+#[path = "common/beryl.rs"]
+mod beryl;
 mod common;
 
 use alloy_primitives::{Address, B256, Bytes, LogData, U256, keccak256};
@@ -63,7 +65,7 @@ async fn activated_feature_client<'a>(
     features: impl IntoIterator<Item = ActivationFeature>,
 ) -> Result<B20PrecompileClient<'a>> {
     let b20 = B20PrecompileClient::new(provider, admin, common::L2_CHAIN_ID)
-        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+        .with_receipt_timeout(beryl::TX_RECEIPT_TIMEOUT);
     for feature in features {
         b20.activate_feature(feature.id()).await?;
     }
@@ -72,12 +74,12 @@ async fn activated_feature_client<'a>(
 
 #[tokio::test]
 async fn test_b20_factory_create_and_transfer_via_rpc() -> Result<()> {
-    let (_system, provider) = common::start_beryl_system().await?;
+    let (_system, provider) = beryl::start_beryl_system().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse system test private key")?;
     let recipient = ANVIL_ACCOUNT_6.address;
 
-    common::wait_for_balance(&provider, admin.address()).await?;
+    beryl::wait_for_balance(&provider, admin.address()).await?;
 
     let b20 = activated_b20_client(&provider, &admin).await?;
     let salt = B256::repeat_byte(0x42);
@@ -93,7 +95,7 @@ async fn test_b20_factory_create_and_transfer_via_rpc() -> Result<()> {
 
     let (token, create_receipt) =
         b20.create_token_with_receipt(B20Variant::Asset, params, salt).await?;
-    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
+    b20.wait_for_token_code(token, beryl::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
     assert_b20_created_log(
         &create_receipt,
         token,
@@ -131,10 +133,10 @@ async fn test_b20_factory_create_and_transfer_via_rpc() -> Result<()> {
 
 #[tokio::test]
 async fn test_b20_token_metadata() -> Result<()> {
-    let (_system, provider) = common::start_beryl_system().await?;
+    let (_system, provider) = beryl::start_beryl_system().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse admin key")?;
-    common::wait_for_balance(&provider, admin.address()).await?;
+    beryl::wait_for_balance(&provider, admin.address()).await?;
 
     let b20 = activated_b20_client(&provider, &admin).await?;
     let salt = B256::repeat_byte(0x10);
@@ -147,7 +149,7 @@ async fn test_b20_token_metadata() -> Result<()> {
     );
 
     let token = b20.create_token(B20Variant::Asset, params, salt).await?;
-    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
+    b20.wait_for_token_code(token, beryl::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     assert_eq!(b20.name(token).await?, "Metadata Token");
     assert_eq!(b20.symbol(token).await?, "META");
@@ -158,18 +160,18 @@ async fn test_b20_token_metadata() -> Result<()> {
 
 #[tokio::test]
 async fn test_b20_approve_and_transfer_from() -> Result<()> {
-    let (_system, provider) = common::start_beryl_system().await?;
+    let (_system, provider) = beryl::start_beryl_system().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse admin key")?;
     let spender =
         PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_7.private_key).wrap_err("spender key")?;
     let recipient = ANVIL_ACCOUNT_6.address;
-    common::wait_for_balance(&provider, admin.address()).await?;
-    common::wait_for_balance(&provider, spender.address()).await?;
+    beryl::wait_for_balance(&provider, admin.address()).await?;
+    beryl::wait_for_balance(&provider, spender.address()).await?;
 
     let b20_admin = activated_b20_client(&provider, &admin).await?;
     let b20_spender = B20PrecompileClient::new(&provider, &spender, common::L2_CHAIN_ID)
-        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+        .with_receipt_timeout(beryl::TX_RECEIPT_TIMEOUT);
 
     let salt = B256::repeat_byte(0x11);
     let params = B20PrecompileClient::token_params(
@@ -181,7 +183,7 @@ async fn test_b20_approve_and_transfer_from() -> Result<()> {
     );
     let token = b20_admin.create_token(B20Variant::Asset, params, salt).await?;
     b20_admin
-        .wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL)
+        .wait_for_token_code(token, beryl::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL)
         .await?;
 
     let approve_amount = U256::from(APPROVE_AMOUNT);
@@ -210,10 +212,10 @@ async fn test_b20_approve_and_transfer_from() -> Result<()> {
 
 #[tokio::test]
 async fn test_b20_mint_and_burn() -> Result<()> {
-    let (_system, provider) = common::start_beryl_system().await?;
+    let (_system, provider) = beryl::start_beryl_system().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse admin key")?;
-    common::wait_for_balance(&provider, admin.address()).await?;
+    beryl::wait_for_balance(&provider, admin.address()).await?;
 
     let b20 = activated_b20_client(&provider, &admin).await?;
     let salt = B256::repeat_byte(0x12);
@@ -225,7 +227,7 @@ async fn test_b20_mint_and_burn() -> Result<()> {
         admin.address(),
     );
     let token = b20.create_token(B20Variant::Asset, params, salt).await?;
-    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
+    b20.wait_for_token_code(token, beryl::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     let supply_before = b20.total_supply(token).await?;
 
@@ -268,13 +270,13 @@ async fn test_b20_mint_and_burn() -> Result<()> {
 
 #[tokio::test]
 async fn test_b20_stablecoin_create_and_currency_via_rpc() -> Result<()> {
-    let (_system, provider) = common::start_beryl_system().await?;
+    let (_system, provider) = beryl::start_beryl_system().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse admin key")?;
-    common::wait_for_balance(&provider, admin.address()).await?;
+    beryl::wait_for_balance(&provider, admin.address()).await?;
 
     let b20 = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
-        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+        .with_receipt_timeout(beryl::TX_RECEIPT_TIMEOUT);
     b20.activate_feature(ActivationFeature::B20Stablecoin.id()).await?;
 
     let salt = B256::repeat_byte(0x19);
@@ -301,7 +303,7 @@ async fn test_b20_stablecoin_create_and_currency_via_rpc() -> Result<()> {
         "create B-20 stablecoin",
     )
     .await?;
-    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
+    b20.wait_for_token_code(token, beryl::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     let output = b20.call(token, IB20Stablecoin::currencyCall {}).await?;
     let currency = IB20Stablecoin::currencyCall::abi_decode_returns(output.as_ref())
@@ -341,12 +343,12 @@ async fn test_b20_stablecoin_create_and_currency_via_rpc() -> Result<()> {
 
 #[tokio::test]
 async fn test_b20_asset_extension_via_rpc() -> Result<()> {
-    let (_system, provider) = common::start_beryl_system().await?;
+    let (_system, provider) = beryl::start_beryl_system().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse admin key")?;
     let bob = ANVIL_ACCOUNT_6.address;
     let carol = ANVIL_ACCOUNT_7.address;
-    common::wait_for_balance(&provider, admin.address()).await?;
+    beryl::wait_for_balance(&provider, admin.address()).await?;
 
     let b20 = activated_b20_client(&provider, &admin).await?;
     let salt = B256::repeat_byte(0x1b);
@@ -358,7 +360,7 @@ async fn test_b20_asset_extension_via_rpc() -> Result<()> {
         admin.address(),
     );
     let token = b20.create_token(B20Variant::Asset, params, salt).await?;
-    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
+    b20.wait_for_token_code(token, beryl::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     assert_eq!(asset_word(&b20, token, IB20Asset::multiplierCall {}).await?, WAD);
     assert_eq!(
@@ -457,11 +459,11 @@ async fn test_b20_asset_extension_via_rpc() -> Result<()> {
 
 #[tokio::test]
 async fn test_b20_transfer_with_memo() -> Result<()> {
-    let (_system, provider) = common::start_beryl_system().await?;
+    let (_system, provider) = beryl::start_beryl_system().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse admin key")?;
     let recipient = ANVIL_ACCOUNT_6.address;
-    common::wait_for_balance(&provider, admin.address()).await?;
+    beryl::wait_for_balance(&provider, admin.address()).await?;
 
     let b20 = activated_b20_client(&provider, &admin).await?;
     let salt = B256::repeat_byte(0x13);
@@ -473,7 +475,7 @@ async fn test_b20_transfer_with_memo() -> Result<()> {
         admin.address(),
     );
     let token = b20.create_token(B20Variant::Asset, params, salt).await?;
-    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
+    b20.wait_for_token_code(token, beryl::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     let memo = B256::repeat_byte(0xde);
     let amount = U256::from(MEMO_TRANSFER_AMOUNT);
@@ -487,10 +489,10 @@ async fn test_b20_transfer_with_memo() -> Result<()> {
 
 #[tokio::test]
 async fn test_b20_supply_cap() -> Result<()> {
-    let (_system, provider) = common::start_beryl_system().await?;
+    let (_system, provider) = beryl::start_beryl_system().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse admin key")?;
-    common::wait_for_balance(&provider, admin.address()).await?;
+    beryl::wait_for_balance(&provider, admin.address()).await?;
 
     let b20 = activated_b20_client(&provider, &admin).await?;
     let salt = B256::repeat_byte(0x14);
@@ -504,7 +506,7 @@ async fn test_b20_supply_cap() -> Result<()> {
     params.supply_cap = U256::from(INITIAL_SUPPLY_CAP);
 
     let token = b20.create_token(B20Variant::Asset, params, salt).await?;
-    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
+    b20.wait_for_token_code(token, beryl::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     assert_eq!(b20.supply_cap(token).await?, U256::from(INITIAL_SUPPLY_CAP));
 
@@ -539,10 +541,10 @@ async fn test_b20_supply_cap() -> Result<()> {
 
 #[tokio::test]
 async fn test_b20_metadata_updates() -> Result<()> {
-    let (_system, provider) = common::start_beryl_system().await?;
+    let (_system, provider) = beryl::start_beryl_system().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse admin key")?;
-    common::wait_for_balance(&provider, admin.address()).await?;
+    beryl::wait_for_balance(&provider, admin.address()).await?;
 
     let b20 = activated_b20_client(&provider, &admin).await?;
     let salt = B256::repeat_byte(0x15);
@@ -554,7 +556,7 @@ async fn test_b20_metadata_updates() -> Result<()> {
         admin.address(),
     );
     let token = b20.create_token(B20Variant::Asset, params, salt).await?;
-    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
+    b20.wait_for_token_code(token, beryl::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     b20.send_call(
         token,
@@ -576,11 +578,11 @@ async fn test_b20_metadata_updates() -> Result<()> {
 
 #[tokio::test]
 async fn test_b20_pause_and_unpause() -> Result<()> {
-    let (_system, provider) = common::start_beryl_system().await?;
+    let (_system, provider) = beryl::start_beryl_system().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse admin key")?;
     let recipient = ANVIL_ACCOUNT_6.address;
-    common::wait_for_balance(&provider, admin.address()).await?;
+    beryl::wait_for_balance(&provider, admin.address()).await?;
 
     let b20 = activated_b20_client(&provider, &admin).await?;
     let salt = B256::repeat_byte(0x16);
@@ -592,7 +594,7 @@ async fn test_b20_pause_and_unpause() -> Result<()> {
         admin.address(),
     );
     let token = b20.create_token(B20Variant::Asset, params, salt).await?;
-    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
+    b20.wait_for_token_code(token, beryl::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     // Transfer succeeds before pause.
     b20.transfer(token, recipient, U256::from(PAUSE_TRANSFER_AMOUNT)).await?;
@@ -637,10 +639,10 @@ async fn test_b20_pause_and_unpause() -> Result<()> {
 
 #[tokio::test]
 async fn test_b20_factory_predict_and_is_b20() -> Result<()> {
-    let (_system, provider) = common::start_beryl_system().await?;
+    let (_system, provider) = beryl::start_beryl_system().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse admin key")?;
-    common::wait_for_balance(&provider, admin.address()).await?;
+    beryl::wait_for_balance(&provider, admin.address()).await?;
 
     let b20 = activated_b20_client(&provider, &admin).await?;
     let salt = B256::repeat_byte(0x17);
@@ -658,7 +660,7 @@ async fn test_b20_factory_predict_and_is_b20() -> Result<()> {
     assert_eq!(local_prediction, rpc_prediction, "local and RPC predictions should match");
 
     let token = b20.create_token(B20Variant::Asset, params, salt).await?;
-    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
+    b20.wait_for_token_code(token, beryl::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     assert_eq!(token, rpc_prediction, "created token address should match prediction");
 
@@ -674,10 +676,10 @@ async fn test_b20_factory_predict_and_is_b20() -> Result<()> {
 
 #[tokio::test]
 async fn test_b20_stablecoin_variant_create_via_rpc() -> Result<()> {
-    let (_system, provider) = common::start_beryl_system().await?;
+    let (_system, provider) = beryl::start_beryl_system().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse admin key")?;
-    common::wait_for_balance(&provider, admin.address()).await?;
+    beryl::wait_for_balance(&provider, admin.address()).await?;
 
     let b20 =
         activated_feature_client(&provider, &admin, [ActivationFeature::B20Stablecoin]).await?;
@@ -700,7 +702,7 @@ async fn test_b20_stablecoin_variant_create_via_rpc() -> Result<()> {
 
     let (token, receipt) =
         b20.create_token_with_receipt(B20Variant::Stablecoin, params, salt).await?;
-    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
+    b20.wait_for_token_code(token, beryl::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     assert_eq!(token, rpc_prediction, "created stablecoin address should match prediction");
     assert_b20_created_log(
@@ -736,9 +738,9 @@ async fn test_beryl_precompiles_do_not_execute_before_activation_block() -> Resu
     let (_system, provider) = start_beryl_system_before_activation().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse admin key")?;
-    common::wait_for_balance(&provider, admin.address()).await?;
+    beryl::wait_for_balance(&provider, admin.address()).await?;
     let b20 = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
-        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+        .with_receipt_timeout(beryl::TX_RECEIPT_TIMEOUT);
     let salt = B256::repeat_byte(0x1a);
     let params = B20PrecompileClient::token_params(
         "Pre-Beryl Token",
@@ -772,17 +774,17 @@ async fn test_beryl_precompiles_do_not_execute_before_activation_block() -> Resu
 
     let token_after_beryl = b20.create_token(B20Variant::Asset, params, salt).await?;
     assert_eq!(token_after_beryl, token, "post-Beryl creation should use the same address");
-    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
+    b20.wait_for_token_code(token, beryl::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     Ok(())
 }
 
 #[tokio::test]
 async fn test_b20_create_token_duplicate_reverts() -> Result<()> {
-    let (_system, provider) = common::start_beryl_system().await?;
+    let (_system, provider) = beryl::start_beryl_system().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse admin key")?;
-    common::wait_for_balance(&provider, admin.address()).await?;
+    beryl::wait_for_balance(&provider, admin.address()).await?;
 
     let b20 = activated_b20_client(&provider, &admin).await?;
     let salt = B256::repeat_byte(0x18);
@@ -795,7 +797,7 @@ async fn test_b20_create_token_duplicate_reverts() -> Result<()> {
     );
 
     let token = b20.create_token(B20Variant::Asset, params.clone(), salt).await?;
-    b20.wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
+    b20.wait_for_token_code(token, beryl::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
 
     let succeeded = b20
         .try_send_call(

--- a/etc/systems/tests/common/beryl.rs
+++ b/etc/systems/tests/common/beryl.rs
@@ -1,0 +1,53 @@
+//! Beryl stack helpers. Path-included only by tests that activate Beryl.
+
+use std::time::Duration;
+
+use alloy_primitives::{Address, U256};
+use alloy_provider::{Provider, RootProvider};
+use base_common_network::Base;
+use base_system_tests::{SystemTestStack, SystemTestStackBuilder};
+use eyre::{Result, WrapErr};
+use tokio::time::{sleep, timeout};
+
+use super::common::{
+    BASE_AZUL_ACTIVATION_BLOCK, BASE_BERYL_ACTIVATION_BLOCK, BLOCK_POLL_INTERVAL, L1_CHAIN_ID,
+    L2_CHAIN_ID, wait_for_block,
+};
+
+/// Receipt wait used by B-20 / registry tests.
+pub(crate) const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Starts a system test stack with Beryl active at block 3 and waits for block 4.
+///
+/// The returned [`SystemTestStack`] must be kept alive for the duration of the test;
+/// dropping it shuts down the underlying containers.
+pub(crate) async fn start_beryl_system() -> Result<(SystemTestStack, RootProvider<Base>)> {
+    let system = SystemTestStackBuilder::new()
+        .with_l1_chain_id(L1_CHAIN_ID)
+        .with_l2_chain_id(L2_CHAIN_ID)
+        .with_base_azul_activation_block(BASE_AZUL_ACTIVATION_BLOCK)
+        .with_base_beryl_activation_block(BASE_BERYL_ACTIVATION_BLOCK)
+        .build()
+        .await?;
+    let provider = system.l2_builder_provider()?;
+    wait_for_block(&provider, BASE_BERYL_ACTIVATION_BLOCK + 1).await?;
+    Ok((system, provider))
+}
+
+/// Polls until `address` has a non-zero ETH balance on the L2.
+pub(crate) async fn wait_for_balance(
+    provider: &RootProvider<Base>,
+    address: Address,
+) -> Result<()> {
+    timeout(Duration::from_secs(15), async {
+        loop {
+            let balance = provider.get_balance(address).await?;
+            if balance > U256::ZERO {
+                return Ok::<_, eyre::Error>(());
+            }
+            sleep(BLOCK_POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .wrap_err("Timed out waiting for funded system test account")?
+}

--- a/etc/systems/tests/common/cobalt.rs
+++ b/etc/systems/tests/common/cobalt.rs
@@ -1,0 +1,45 @@
+//! Cobalt stack helper. Not a `common` submodule so Beryl-only test binaries do not compile it.
+
+use std::time::Duration;
+
+use alloy_provider::{Provider, RootProvider};
+use base_common_network::Base;
+use base_system_tests::{SystemTestStack, SystemTestStackBuilder};
+use eyre::{Result, WrapErr};
+use tokio::time::{sleep, timeout};
+
+const L1_CHAIN_ID: u64 = 1337;
+const L2_CHAIN_ID: u64 = 84538453;
+const BASE_AZUL_ACTIVATION_BLOCK: u64 = 0;
+const BASE_BERYL_ACTIVATION_BLOCK: u64 = 3;
+const BASE_COBALT_ACTIVATION_BLOCK: u64 = 5;
+const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(30);
+const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Starts a system test stack with Cobalt active at block 5 and waits for block 6.
+///
+/// The returned [`SystemTestStack`] must be kept alive for the duration of the test;
+/// dropping it shuts down the underlying containers.
+pub(crate) async fn start_cobalt_system() -> Result<(SystemTestStack, RootProvider<Base>)> {
+    let system = SystemTestStackBuilder::new()
+        .with_l1_chain_id(L1_CHAIN_ID)
+        .with_l2_chain_id(L2_CHAIN_ID)
+        .with_base_azul_activation_block(BASE_AZUL_ACTIVATION_BLOCK)
+        .with_base_beryl_activation_block(BASE_BERYL_ACTIVATION_BLOCK)
+        .with_base_cobalt_activation_block(BASE_COBALT_ACTIVATION_BLOCK)
+        .build()
+        .await?;
+    let provider = system.l2_builder_provider()?;
+    timeout(BLOCK_PRODUCTION_TIMEOUT, async {
+        loop {
+            let block = provider.get_block_number().await?;
+            if block > BASE_COBALT_ACTIVATION_BLOCK {
+                return Ok::<_, eyre::Error>(block);
+            }
+            sleep(BLOCK_POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .wrap_err("Block production timed out")??;
+    Ok((system, provider))
+}

--- a/etc/systems/tests/common/cobalt.rs
+++ b/etc/systems/tests/common/cobalt.rs
@@ -1,20 +1,16 @@
-//! Cobalt stack helper. Not a `common` submodule so Beryl-only test binaries do not compile it.
+//! Cobalt stack helper. Path-included only by tests that activate Cobalt.
 
-use std::time::Duration;
-
-use alloy_provider::{Provider, RootProvider};
+use alloy_provider::RootProvider;
 use base_common_network::Base;
 use base_system_tests::{SystemTestStack, SystemTestStackBuilder};
-use eyre::{Result, WrapErr};
-use tokio::time::{sleep, timeout};
+use eyre::Result;
 
-const L1_CHAIN_ID: u64 = 1337;
-const L2_CHAIN_ID: u64 = 84538453;
-const BASE_AZUL_ACTIVATION_BLOCK: u64 = 0;
-const BASE_BERYL_ACTIVATION_BLOCK: u64 = 3;
-const BASE_COBALT_ACTIVATION_BLOCK: u64 = 5;
-const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(30);
-const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
+use super::common::{
+    BASE_AZUL_ACTIVATION_BLOCK, BASE_BERYL_ACTIVATION_BLOCK, L1_CHAIN_ID, L2_CHAIN_ID,
+    wait_for_block,
+};
+
+pub(crate) const BASE_COBALT_ACTIVATION_BLOCK: u64 = 5;
 
 /// Starts a system test stack with Cobalt active at block 5 and waits for block 6.
 ///
@@ -30,16 +26,6 @@ pub(crate) async fn start_cobalt_system() -> Result<(SystemTestStack, RootProvid
         .build()
         .await?;
     let provider = system.l2_builder_provider()?;
-    timeout(BLOCK_PRODUCTION_TIMEOUT, async {
-        loop {
-            let block = provider.get_block_number().await?;
-            if block > BASE_COBALT_ACTIVATION_BLOCK {
-                return Ok::<_, eyre::Error>(block);
-            }
-            sleep(BLOCK_POLL_INTERVAL).await;
-        }
-    })
-    .await
-    .wrap_err("Block production timed out")??;
+    wait_for_block(&provider, BASE_COBALT_ACTIVATION_BLOCK + 1).await?;
     Ok((system, provider))
 }

--- a/etc/systems/tests/common/mod.rs
+++ b/etc/systems/tests/common/mod.rs
@@ -17,6 +17,7 @@ pub(crate) const BASE_BERYL_ACTIVATION_BLOCK: u64 = 3;
 pub(crate) const BASE_COBALT_ACTIVATION_BLOCK: u64 = 5;
 pub(crate) const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(30);
 pub(crate) const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
+#[allow(dead_code)]
 pub(crate) const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Starts a system test stack with Beryl active at block 3 and waits for block 4.
@@ -80,6 +81,7 @@ pub(crate) async fn wait_for_block(provider: &RootProvider<Base>, min_block: u64
 }
 
 /// Polls until `address` has a non-zero ETH balance on the L2.
+#[allow(dead_code)]
 pub(crate) async fn wait_for_balance(
     provider: &RootProvider<Base>,
     address: Address,

--- a/etc/systems/tests/common/mod.rs
+++ b/etc/systems/tests/common/mod.rs
@@ -13,6 +13,8 @@ pub(crate) const L1_CHAIN_ID: u64 = 1337;
 pub(crate) const L2_CHAIN_ID: u64 = 84538453;
 pub(crate) const BASE_AZUL_ACTIVATION_BLOCK: u64 = 0;
 pub(crate) const BASE_BERYL_ACTIVATION_BLOCK: u64 = 3;
+#[allow(dead_code)]
+pub(crate) const BASE_COBALT_ACTIVATION_BLOCK: u64 = 5;
 pub(crate) const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(30);
 pub(crate) const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
 pub(crate) const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(60);
@@ -21,6 +23,7 @@ pub(crate) const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(60);
 ///
 /// The returned [`SystemTestStack`] must be kept alive for the duration of the test;
 /// dropping it shuts down the underlying containers.
+#[allow(dead_code)]
 pub(crate) async fn start_beryl_system() -> Result<(SystemTestStack, RootProvider<Base>)> {
     let system = SystemTestStackBuilder::new()
         .with_l1_chain_id(L1_CHAIN_ID)
@@ -31,6 +34,33 @@ pub(crate) async fn start_beryl_system() -> Result<(SystemTestStack, RootProvide
         .await?;
     let provider = system.l2_builder_provider()?;
     wait_for_block(&provider, BASE_BERYL_ACTIVATION_BLOCK + 1).await?;
+    Ok((system, provider))
+}
+
+/// Starts a system test stack with Cobalt active at block 5 and waits for block 6.
+///
+/// The returned [`SystemTestStack`] must be kept alive for the duration of the test;
+/// dropping it shuts down the underlying containers.
+#[allow(dead_code)]
+pub(crate) async fn start_cobalt_system() -> Result<(SystemTestStack, RootProvider<Base>)> {
+    start_cobalt_stack(SystemTestStackBuilder::new()).await
+}
+
+/// Same as [`start_cobalt_system`], with extra [`SystemTestStackBuilder`] options applied first.
+#[allow(dead_code)]
+pub(crate) async fn start_cobalt_stack(
+    builder: SystemTestStackBuilder,
+) -> Result<(SystemTestStack, RootProvider<Base>)> {
+    let system = builder
+        .with_l1_chain_id(L1_CHAIN_ID)
+        .with_l2_chain_id(L2_CHAIN_ID)
+        .with_base_azul_activation_block(BASE_AZUL_ACTIVATION_BLOCK)
+        .with_base_beryl_activation_block(BASE_BERYL_ACTIVATION_BLOCK)
+        .with_base_cobalt_activation_block(BASE_COBALT_ACTIVATION_BLOCK)
+        .build()
+        .await?;
+    let provider = system.l2_builder_provider()?;
+    wait_for_block(&provider, BASE_COBALT_ACTIVATION_BLOCK + 1).await?;
     Ok((system, provider))
 }
 

--- a/etc/systems/tests/common/mod.rs
+++ b/etc/systems/tests/common/mod.rs
@@ -13,18 +13,14 @@ pub(crate) const L1_CHAIN_ID: u64 = 1337;
 pub(crate) const L2_CHAIN_ID: u64 = 84538453;
 pub(crate) const BASE_AZUL_ACTIVATION_BLOCK: u64 = 0;
 pub(crate) const BASE_BERYL_ACTIVATION_BLOCK: u64 = 3;
-#[allow(dead_code)]
-pub(crate) const BASE_COBALT_ACTIVATION_BLOCK: u64 = 5;
 pub(crate) const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(30);
 pub(crate) const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
-#[allow(dead_code)]
 pub(crate) const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Starts a system test stack with Beryl active at block 3 and waits for block 4.
 ///
 /// The returned [`SystemTestStack`] must be kept alive for the duration of the test;
 /// dropping it shuts down the underlying containers.
-#[allow(dead_code)]
 pub(crate) async fn start_beryl_system() -> Result<(SystemTestStack, RootProvider<Base>)> {
     let system = SystemTestStackBuilder::new()
         .with_l1_chain_id(L1_CHAIN_ID)
@@ -35,33 +31,6 @@ pub(crate) async fn start_beryl_system() -> Result<(SystemTestStack, RootProvide
         .await?;
     let provider = system.l2_builder_provider()?;
     wait_for_block(&provider, BASE_BERYL_ACTIVATION_BLOCK + 1).await?;
-    Ok((system, provider))
-}
-
-/// Starts a system test stack with Cobalt active at block 5 and waits for block 6.
-///
-/// The returned [`SystemTestStack`] must be kept alive for the duration of the test;
-/// dropping it shuts down the underlying containers.
-#[allow(dead_code)]
-pub(crate) async fn start_cobalt_system() -> Result<(SystemTestStack, RootProvider<Base>)> {
-    start_cobalt_stack(SystemTestStackBuilder::new()).await
-}
-
-/// Same as [`start_cobalt_system`], with extra [`SystemTestStackBuilder`] options applied first.
-#[allow(dead_code)]
-pub(crate) async fn start_cobalt_stack(
-    builder: SystemTestStackBuilder,
-) -> Result<(SystemTestStack, RootProvider<Base>)> {
-    let system = builder
-        .with_l1_chain_id(L1_CHAIN_ID)
-        .with_l2_chain_id(L2_CHAIN_ID)
-        .with_base_azul_activation_block(BASE_AZUL_ACTIVATION_BLOCK)
-        .with_base_beryl_activation_block(BASE_BERYL_ACTIVATION_BLOCK)
-        .with_base_cobalt_activation_block(BASE_COBALT_ACTIVATION_BLOCK)
-        .build()
-        .await?;
-    let provider = system.l2_builder_provider()?;
-    wait_for_block(&provider, BASE_COBALT_ACTIVATION_BLOCK + 1).await?;
     Ok((system, provider))
 }
 
@@ -81,7 +50,6 @@ pub(crate) async fn wait_for_block(provider: &RootProvider<Base>, min_block: u64
 }
 
 /// Polls until `address` has a non-zero ETH balance on the L2.
-#[allow(dead_code)]
 pub(crate) async fn wait_for_balance(
     provider: &RootProvider<Base>,
     address: Address,

--- a/etc/systems/tests/common/mod.rs
+++ b/etc/systems/tests/common/mod.rs
@@ -2,10 +2,8 @@
 
 use std::time::Duration;
 
-use alloy_primitives::{Address, U256};
 use alloy_provider::{Provider, RootProvider};
 use base_common_network::Base;
-use base_system_tests::{SystemTestStack, SystemTestStackBuilder};
 use eyre::{Result, WrapErr};
 use tokio::time::{sleep, timeout};
 
@@ -15,24 +13,6 @@ pub(crate) const BASE_AZUL_ACTIVATION_BLOCK: u64 = 0;
 pub(crate) const BASE_BERYL_ACTIVATION_BLOCK: u64 = 3;
 pub(crate) const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(30);
 pub(crate) const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
-pub(crate) const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(60);
-
-/// Starts a system test stack with Beryl active at block 3 and waits for block 4.
-///
-/// The returned [`SystemTestStack`] must be kept alive for the duration of the test;
-/// dropping it shuts down the underlying containers.
-pub(crate) async fn start_beryl_system() -> Result<(SystemTestStack, RootProvider<Base>)> {
-    let system = SystemTestStackBuilder::new()
-        .with_l1_chain_id(L1_CHAIN_ID)
-        .with_l2_chain_id(L2_CHAIN_ID)
-        .with_base_azul_activation_block(BASE_AZUL_ACTIVATION_BLOCK)
-        .with_base_beryl_activation_block(BASE_BERYL_ACTIVATION_BLOCK)
-        .build()
-        .await?;
-    let provider = system.l2_builder_provider()?;
-    wait_for_block(&provider, BASE_BERYL_ACTIVATION_BLOCK + 1).await?;
-    Ok((system, provider))
-}
 
 /// Polls until the L2 block number reaches `min_block`.
 pub(crate) async fn wait_for_block(provider: &RootProvider<Base>, min_block: u64) -> Result<u64> {
@@ -47,22 +27,4 @@ pub(crate) async fn wait_for_block(provider: &RootProvider<Base>, min_block: u64
     })
     .await
     .wrap_err("Block production timed out")?
-}
-
-/// Polls until `address` has a non-zero ETH balance on the L2.
-pub(crate) async fn wait_for_balance(
-    provider: &RootProvider<Base>,
-    address: Address,
-) -> Result<()> {
-    timeout(Duration::from_secs(15), async {
-        loop {
-            let balance = provider.get_balance(address).await?;
-            if balance > U256::ZERO {
-                return Ok::<_, eyre::Error>(());
-            }
-            sleep(BLOCK_POLL_INTERVAL).await;
-        }
-    })
-    .await
-    .wrap_err("Timed out waiting for funded system test account")?
 }

--- a/etc/systems/tests/in_process_zk.rs
+++ b/etc/systems/tests/in_process_zk.rs
@@ -1,0 +1,45 @@
+//! Starts the in-process prover-service and ZK host against a live stack.
+
+mod common;
+
+use std::time::Duration;
+
+use base_prover_service_client::{ProofRequesterClient, ProverServiceClientConfig};
+use base_prover_service_protocol::{GetProofRequest, ZkBackend};
+use base_system_tests::{InProcessProverService, InProcessZkHost};
+use eyre::{Result, WrapErr, ensure};
+use tracing::info;
+use tracing_subscriber::EnvFilter;
+
+/// Boots Postgres + prover JSON-RPC + a DryRun ZK host. Does not execute SP1.
+#[tokio::test(flavor = "multi_thread")]
+async fn in_process_prover_and_zk_host_start() -> Result<()> {
+    let _ = tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .try_init();
+
+    info!("starting Cobalt stack");
+    let (system, _provider) = common::start_cobalt_system().await?;
+
+    info!("starting in-process prover-service");
+    let service = InProcessProverService::start().await?;
+    let client = ProofRequesterClient::connect(
+        &ProverServiceClientConfig::new(service.url().as_str())
+            .with_request_timeout(Duration::from_secs(30)),
+    )
+    .wrap_err("failed to connect requester client to in-process prover-service")?;
+    let missing = client
+        .get_proof(GetProofRequest { session_id: "missing-in-process-zk-smoke".to_owned() })
+        .await;
+    ensure!(missing.is_err(), "get_proof for an unknown session must fail");
+    info!(url = %service.url(), "prover-service accepted JSON-RPC");
+
+    info!("starting in-process ZK host");
+    let _host = InProcessZkHost::start(&system, service.url(), ZkBackend::DryRun).await?;
+    info!("in-process ZK host started");
+
+    Ok(())
+}

--- a/etc/systems/tests/in_process_zk.rs
+++ b/etc/systems/tests/in_process_zk.rs
@@ -11,7 +11,7 @@ use eyre::{Result, WrapErr, ensure};
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 
-/// Boots Postgres + prover JSON-RPC + a DryRun ZK host. Does not execute SP1.
+/// Boots Postgres + prover JSON-RPC + a `DryRun` ZK host. Does not execute SP1.
 #[tokio::test(flavor = "multi_thread")]
 async fn in_process_prover_and_zk_host_start() -> Result<()> {
     let _ = tracing_subscriber::fmt()

--- a/etc/systems/tests/in_process_zk.rs
+++ b/etc/systems/tests/in_process_zk.rs
@@ -1,13 +1,14 @@
 //! Starts the in-process prover-service and ZK host against a live stack.
 
-mod common;
+#[path = "common/cobalt.rs"]
+mod cobalt;
 
 use std::time::Duration;
 
 use base_prover_service_client::{ProofRequesterClient, ProverServiceClientConfig};
-use base_prover_service_protocol::{GetProofRequest, ZkBackend};
+use base_prover_service_protocol::GetProofRequest;
 use base_system_tests::{InProcessProverService, InProcessZkHost};
-use eyre::{Result, WrapErr, ensure};
+use eyre::{Result, WrapErr, bail, ensure};
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 
@@ -22,7 +23,7 @@ async fn in_process_prover_and_zk_host_start() -> Result<()> {
         .try_init();
 
     info!("starting Cobalt stack");
-    let (system, _provider) = common::start_cobalt_system().await?;
+    let (system, _provider) = cobalt::start_cobalt_system().await?;
 
     info!("starting in-process prover-service");
     let service = InProcessProverService::start().await?;
@@ -31,15 +32,18 @@ async fn in_process_prover_and_zk_host_start() -> Result<()> {
             .with_request_timeout(Duration::from_secs(30)),
     )
     .wrap_err("failed to connect requester client to in-process prover-service")?;
-    let missing = client
+    let Err(error) = client
         .get_proof(GetProofRequest { session_id: "missing-in-process-zk-smoke".to_owned() })
-        .await;
-    ensure!(missing.is_err(), "get_proof for an unknown session must fail");
+        .await
+    else {
+        bail!("get_proof for an unknown session must fail");
+    };
+    ensure!(error.is_not_found(), "get_proof missing session should be not-found, got {error}");
     info!(url = %service.url(), "prover-service accepted JSON-RPC");
 
     info!("starting in-process ZK host");
-    let _host = InProcessZkHost::start(&system, service.url(), ZkBackend::DryRun).await?;
-    info!("in-process ZK host started");
+    let _host = InProcessZkHost::start(&system, service.url()).await?;
+    info!("in-process ZK host polled the worker API");
 
     Ok(())
 }

--- a/etc/systems/tests/in_process_zk.rs
+++ b/etc/systems/tests/in_process_zk.rs
@@ -2,6 +2,7 @@
 
 #[path = "common/cobalt.rs"]
 mod cobalt;
+mod common;
 
 use std::time::Duration;
 

--- a/etc/systems/tests/policy_registry.rs
+++ b/etc/systems/tests/policy_registry.rs
@@ -1,5 +1,7 @@
 //! System tests for the policy registry precompile over Base node RPC.
 
+#[path = "common/beryl.rs"]
+mod beryl;
 mod common;
 
 use alloy_primitives::{Address, LogData};
@@ -13,13 +15,13 @@ use eyre::{Result, WrapErr};
 /// `createPolicy` emits the expected policy-registry events over RPC receipts.
 #[tokio::test]
 async fn test_policy_registry_create_policy_emits_events() -> Result<()> {
-    let (_system, provider) = common::start_beryl_system().await?;
+    let (_system, provider) = beryl::start_beryl_system().await?;
     let caller = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse system test private key")?;
-    common::wait_for_balance(&provider, caller.address()).await?;
+    beryl::wait_for_balance(&provider, caller.address()).await?;
 
     let client = B20PrecompileClient::new(&provider, &caller, common::L2_CHAIN_ID)
-        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+        .with_receipt_timeout(beryl::TX_RECEIPT_TIMEOUT);
     client.activate_feature(ActivationFeature::PolicyRegistry.id()).await?;
 
     let call = IPolicyRegistry::createPolicyCall {
@@ -60,13 +62,13 @@ async fn test_policy_registry_create_policy_emits_events() -> Result<()> {
 /// `policyExists(ALWAYS_ALLOW_ID)` returns `true` once the policy registry is active.
 #[tokio::test]
 async fn test_policy_registry_policy_exists() -> Result<()> {
-    let (_system, provider) = common::start_beryl_system().await?;
+    let (_system, provider) = beryl::start_beryl_system().await?;
     let caller = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse system test private key")?;
-    common::wait_for_balance(&provider, caller.address()).await?;
+    beryl::wait_for_balance(&provider, caller.address()).await?;
 
     let client = B20PrecompileClient::new(&provider, &caller, common::L2_CHAIN_ID)
-        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+        .with_receipt_timeout(beryl::TX_RECEIPT_TIMEOUT);
     client.activate_feature(ActivationFeature::PolicyRegistry.id()).await?;
 
     let output = client
@@ -86,18 +88,18 @@ async fn test_policy_registry_policy_exists() -> Result<()> {
 /// Custom policy creation, membership, admin transfer, renounce, and error paths round-trip over RPC.
 #[tokio::test]
 async fn test_policy_registry_lifecycle_and_error_paths() -> Result<()> {
-    let (_system, provider) = common::start_beryl_system().await?;
+    let (_system, provider) = beryl::start_beryl_system().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse policy admin key")?;
     let next_admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_6.private_key)
         .wrap_err("Failed to parse next policy admin key")?;
-    common::wait_for_balance(&provider, admin.address()).await?;
-    common::wait_for_balance(&provider, next_admin.address()).await?;
+    beryl::wait_for_balance(&provider, admin.address()).await?;
+    beryl::wait_for_balance(&provider, next_admin.address()).await?;
 
     let client = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
-        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+        .with_receipt_timeout(beryl::TX_RECEIPT_TIMEOUT);
     let next_admin_client = B20PrecompileClient::new(&provider, &next_admin, common::L2_CHAIN_ID)
-        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+        .with_receipt_timeout(beryl::TX_RECEIPT_TIMEOUT);
     client.activate_feature(ActivationFeature::PolicyRegistry.id()).await?;
 
     let allowlist_id = create_policy(
@@ -253,13 +255,13 @@ async fn test_policy_registry_lifecycle_and_error_paths() -> Result<()> {
 /// View calls remain available while write calls are gated when the policy registry is deactivated.
 #[tokio::test]
 async fn test_policy_registry_deactivated_views_and_write_gate() -> Result<()> {
-    let (_system, provider) = common::start_beryl_system().await?;
+    let (_system, provider) = beryl::start_beryl_system().await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse policy admin key")?;
-    common::wait_for_balance(&provider, admin.address()).await?;
+    beryl::wait_for_balance(&provider, admin.address()).await?;
 
     let client = B20PrecompileClient::new(&provider, &admin, common::L2_CHAIN_ID)
-        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+        .with_receipt_timeout(beryl::TX_RECEIPT_TIMEOUT);
     client.activate_feature(ActivationFeature::PolicyRegistry.id()).await?;
 
     let blocklist_id = create_policy(

--- a/etc/systems/tests/policy_transfer.rs
+++ b/etc/systems/tests/policy_transfer.rs
@@ -6,6 +6,8 @@
 //!     slot via `updatePolicy`.
 //!   - Exercises the full transfer-gate cycle: blocked → allowed (or vice versa).
 
+#[path = "common/beryl.rs"]
+mod beryl;
 mod common;
 
 use alloy_primitives::{Address, B256, U256};
@@ -34,7 +36,7 @@ async fn activated_client<'a>(
     admin: &'a PrivateKeySigner,
 ) -> Result<B20PrecompileClient<'a>> {
     let client = B20PrecompileClient::new(provider, admin, common::L2_CHAIN_ID)
-        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+        .with_receipt_timeout(beryl::TX_RECEIPT_TIMEOUT);
     client.activate_feature(ActivationFeature::B20Asset.id()).await?;
     client.activate_feature(ActivationFeature::PolicyRegistry.id()).await?;
     Ok(client)
@@ -88,7 +90,7 @@ async fn create_token(
         B20PrecompileClient::token_params(name, symbol, admin, U256::from(INITIAL_SUPPLY), admin);
     let token = client.create_token(B20Variant::Asset, params, salt).await?;
     client
-        .wait_for_token_code(token, common::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL)
+        .wait_for_token_code(token, beryl::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL)
         .await?;
     Ok(token)
 }
@@ -121,15 +123,15 @@ async fn set_transfer_sender_policy(
 ///   5. Assert the transfer now succeeds.
 #[tokio::test]
 async fn test_allowlist_gates_transfer() -> Result<()> {
-    let (_system, provider) = common::start_beryl_system().await?;
+    let (_system, provider) = beryl::start_beryl_system().await?;
 
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key).wrap_err("admin key")?;
     let non_member =
         PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_7.private_key).wrap_err("non-member key")?;
     let recipient = ANVIL_ACCOUNT_6.address;
 
-    common::wait_for_balance(&provider, admin.address()).await?;
-    common::wait_for_balance(&provider, non_member.address()).await?;
+    beryl::wait_for_balance(&provider, admin.address()).await?;
+    beryl::wait_for_balance(&provider, non_member.address()).await?;
 
     let client = activated_client(&provider, &admin).await?;
 
@@ -176,7 +178,7 @@ async fn test_allowlist_gates_transfer() -> Result<()> {
 
     // Non-member is not on the allowlist: transfer must revert.
     let non_member_client = B20PrecompileClient::new(&provider, &non_member, common::L2_CHAIN_ID)
-        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+        .with_receipt_timeout(beryl::TX_RECEIPT_TIMEOUT);
     let blocked = non_member_client
         .try_send_call(
             token,
@@ -231,15 +233,15 @@ async fn test_allowlist_gates_transfer() -> Result<()> {
 ///   5. Assert their transfer now reverts.
 #[tokio::test]
 async fn test_blocklist_gates_transfer() -> Result<()> {
-    let (_system, provider) = common::start_beryl_system().await?;
+    let (_system, provider) = beryl::start_beryl_system().await?;
 
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key).wrap_err("admin key")?;
     let blocked_sender =
         PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_7.private_key).wrap_err("blocked key")?;
     let recipient = ANVIL_ACCOUNT_6.address;
 
-    common::wait_for_balance(&provider, admin.address()).await?;
-    common::wait_for_balance(&provider, blocked_sender.address()).await?;
+    beryl::wait_for_balance(&provider, admin.address()).await?;
+    beryl::wait_for_balance(&provider, blocked_sender.address()).await?;
 
     let client = activated_client(&provider, &admin).await?;
 
@@ -272,7 +274,7 @@ async fn test_blocklist_gates_transfer() -> Result<()> {
 
     // Transfer from the (not-yet-blocked) sender must succeed.
     let sender_client = B20PrecompileClient::new(&provider, &blocked_sender, common::L2_CHAIN_ID)
-        .with_receipt_timeout(common::TX_RECEIPT_TIMEOUT);
+        .with_receipt_timeout(beryl::TX_RECEIPT_TIMEOUT);
     let first_transfer = sender_client
         .try_send_call(
             token,
@@ -321,12 +323,12 @@ async fn test_blocklist_gates_transfer() -> Result<()> {
 /// slot makes ALL transfers revert unconditionally.
 #[tokio::test]
 async fn test_always_block_policy_blocks_transfer() -> Result<()> {
-    let (_system, provider) = common::start_beryl_system().await?;
+    let (_system, provider) = beryl::start_beryl_system().await?;
 
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key).wrap_err("admin key")?;
     let anyone = ANVIL_ACCOUNT_6.address;
 
-    common::wait_for_balance(&provider, admin.address()).await?;
+    beryl::wait_for_balance(&provider, admin.address()).await?;
 
     let client = activated_client(&provider, &admin).await?;
 


### PR DESCRIPTION
## Summary
Add `InProcessProverService` (Postgres testcontainer + JSON-RPC) and `InProcessZkHost` (DryRun only) so system tests can boot the prove stack without cluster/network credentials.

Made with [Cursor](https://cursor.com)