### PR TITLE
docs(precompiles): fix inverted seizable wording on ensure_seizable and related comments

### DIFF
--- a/crates/common/precompiles/src/common/core_storage.rs
+++ b/crates/common/precompiles/src/common/core_storage.rs
@@ -82,7 +82,9 @@ pub struct B20CoreStorage {
     pub nonces: Mapping<Address, U256>, // offset 13
     // The base-std mock keeps an `initialized` bootstrap flag as its last field; this impl checks
     // factory-init via deployed marker bytecode instead, so it stores no such field.
-    /// Seizable-account policy ID, consulted against `from` by the seize operations.
+    /// Seize-holder policy ID, consulted against `from` by the seize operations. `from` is
+    /// seizable only when NOT authorized by this policy; the unset always-allow default keeps
+    /// seizure closed until an issuer configures it.
     #[accessor]
     #[mutator]
     pub seize_holder_policy_id: u64, // slot 14, offset 0

--- a/crates/common/precompiles/src/common/ops/guards.rs
+++ b/crates/common/precompiles/src/common/ops/guards.rs
@@ -106,12 +106,13 @@ impl B20Guards {
         }
     }
 
-    /// Ensures `account` is seizable, i.e. a member of the current seize-holder policy.
+    /// Ensures `account` is seizable, i.e. NOT authorized by the current seize-holder policy.
     ///
     /// Mirrors [`Self::ensure_blocked`] but consults `SEIZE_HOLDER_POLICY` instead of the
     /// transfer-sender policy: an account is seizable only when the configured registry policy does
-    /// not authorize it. Used by `seizeWithMemo`. Enforced unconditionally, including in the factory
-    /// bootstrap window. Reverts `AccountNotSeizable` (distinct from `ensure_blocked`'s
+    /// not authorize it, so the unset always-allow default keeps seizure closed until an issuer
+    /// configures the slot. Used by `seizeWithMemo`. Enforced unconditionally, including in the
+    /// factory bootstrap window. Reverts `AccountNotSeizable` (distinct from `ensure_blocked`'s
     /// `AccountNotBlocked`) so the seize path and the deprecated `burnBlocked` report separately.
     pub fn ensure_seizable<T: Token + ?Sized>(token: &T, account: Address) -> Result<()> {
         let policy_scope = B20PolicyType::SeizeHolder.id();

--- a/crates/common/precompiles/src/common/ops/roles.rs
+++ b/crates/common/precompiles/src/common/ops/roles.rs
@@ -24,8 +24,10 @@ pub enum B20TokenRole {
     Burn,
     /// Role required for `burnBlocked`; permits burning from blocked accounts without `BURN_ROLE`.
     BurnBlocked,
-    /// Role required for `seizeWithMemo`; permits reassigning a blocked account's
-    /// balance without `TRANSFER_SENDER_POLICY` authorization.
+    /// Role required for `seizeWithMemo`; permits reassigning a seizable account's balance
+    /// without going through the normal transfer policy checks. An account is seizable when it
+    /// is NOT authorized by `SEIZE_HOLDER_POLICY`; the unset always-allow default keeps seizure
+    /// closed until an issuer configures the policy.
     Seize,
     /// Role required for `pause`.
     Pause,


### PR DESCRIPTION
## Summary
- Fixes BOP-556: the doc comments on `ensure_seizable`, `B20TokenRole::Seize`, and `seize_holder_policy_id` described seizability backwards, reading as if policy membership/authorization makes an account seizable.
- The actual semantics (and the existing guard logic) are the opposite: authorization means the account is **not** seizable, and the unset always-allow default keeps seizure closed until an issuer explicitly configures the `SEIZE_HOLDER_POLICY` slot.
- Comment-only change — no behavioral/runtime changes. `ensure_seizable`'s logic already reverts `AccountNotSeizable` when the account *is* authorized, which was correct; only the prose was misleading.

Ref: https://linear.app/coinbase/issue/BOP-556/8-inverted-seizable-wording-on-ensure-seizable-and-related-comments

## Test plan
- [x] `cargo check -p base-common-precompiles`
- [x] Reviewed diff — comment-only change, no logic touched