### PR TITLE
fix(consensus): validate blob encoding version byte

### DIFF
--- a/crates/consensus/derive/src/sources/blob_data.rs
+++ b/crates/consensus/derive/src/sources/blob_data.rs
@@ -2,7 +2,7 @@
 
 use alloc::{boxed::Box, vec};
 
-use alloy_eips::eip4844::{BYTES_PER_BLOB, Blob, VERSIONED_HASH_VERSION_KZG};
+use alloy_eips::eip4844::{BYTES_PER_BLOB, Blob};
 use alloy_primitives::Bytes;
 pub use base_protocol::BLOB_MAX_DATA_SIZE;
 
@@ -30,7 +30,7 @@ impl BlobData {
         let data = self.data.as_ref().ok_or(BlobDecodingError::MissingData)?;
 
         // Validate the blob encoding version
-        if data[VERSIONED_HASH_VERSION_KZG as usize] != BLOB_ENCODING_VERSION {
+        if data[0] != BLOB_ENCODING_VERSION {
             return Err(BlobDecodingError::InvalidEncodingVersion);
         }
 
@@ -214,14 +214,17 @@ mod tests {
 
     #[test]
     fn test_blob_data_decode_invalid_encoding_version() {
-        let blob_data = BlobData { data: Some(Bytes::from(vec![1u8; 32])), ..Default::default() };
+        let mut data = vec![0u8; 32];
+        data[0] = BLOB_ENCODING_VERSION + 1;
+        data[1] = BLOB_ENCODING_VERSION;
+        let blob_data = BlobData { data: Some(Bytes::from(data)), ..Default::default() };
         assert_eq!(blob_data.decode(), Err(BlobDecodingError::InvalidEncodingVersion));
     }
 
     #[test]
     fn test_blob_data_decode_invalid_length() {
         let mut data = vec![0u8; 32];
-        data[VERSIONED_HASH_VERSION_KZG as usize] = BLOB_ENCODING_VERSION;
+        data[0] = BLOB_ENCODING_VERSION;
         data[2] = 0xFF;
         data[3] = 0xFF;
         data[4] = 0xFF;
@@ -232,7 +235,7 @@ mod tests {
     #[test]
     fn test_blob_data_decode() {
         let mut data = vec![0u8; alloy_eips::eip4844::BYTES_PER_BLOB];
-        data[VERSIONED_HASH_VERSION_KZG as usize] = BLOB_ENCODING_VERSION;
+        data[0] = BLOB_ENCODING_VERSION;
         data[2] = 0x00;
         data[3] = 0x00;
         data[4] = 0x01;
@@ -243,7 +246,7 @@ mod tests {
     #[test]
     fn test_blob_data_decode_invalid_field_element() {
         let mut data = vec![0u8; alloy_eips::eip4844::BYTES_PER_BLOB + 10];
-        data[VERSIONED_HASH_VERSION_KZG as usize] = BLOB_ENCODING_VERSION;
+        data[0] = BLOB_ENCODING_VERSION;
         data[2] = 0x00;
         data[3] = 0x00;
         data[4] = 0x01;


### PR DESCRIPTION
## Summary

Fixes #4633.

`BlobData::decode()` was validating the blob encoding version using `VERSIONED_HASH_VERSION_KZG` as an array index, which points to `data[1]`.

The blob encoding version is stored at `data[0]`, so malformed blobs with an unsupported encoding version could incorrectly pass validation.

This change:
- validates `BLOB_ENCODING_VERSION` at `data[0]`
- removes the unrelated `VERSIONED_HASH_VERSION_KZG` import
- updates the affected tests
- adds a regression case where `data[0]` is invalid while `data[1]` remains valid

## Testing

Updated the existing `BlobData` decode tests to cover the correct encoding-version byte.