### PR TITLE
refactor(shadow-indexer): drop the reorged_out column

### DIFF
--- a/crates/execution/shadow-indexer-db/migrations/0004_drop_reorged_out.sql
+++ b/crates/execution/shadow-indexer-db/migrations/0004_drop_reorged_out.sql
@@ -1,0 +1,19 @@
+-- The flag now only separates canonical rows left behind by builds that predate
+-- #4624. Dropping it makes those indistinguishable from reorged rows, and the
+-- reader's cursor never advanced over them, so they would surface as shadow
+-- blocks. Abort rather than let that happen silently.
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+LOCK TABLE shadow_blocks IN ACCESS EXCLUSIVE MODE;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM shadow_blocks WHERE NOT reorged_out) THEN
+    RAISE EXCEPTION
+      'cannot drop shadow_blocks.reorged_out: legacy canonical rows remain';
+  END IF;
+END
+$$;
+
+ALTER TABLE shadow_blocks DROP COLUMN reorged_out;

--- a/crates/execution/shadow-indexer-db/src/models.rs
+++ b/crates/execution/shadow-indexer-db/src/models.rs
@@ -12,8 +12,6 @@ pub struct ShadowBlockRow {
     pub number: i64,
     /// Raw block hash.
     pub hash: Vec<u8>,
-    /// Whether block was reorged out.
-    pub reorged_out: bool,
     /// Replacement block hash after reorg.
     pub canonical_hash: Option<Vec<u8>>,
     /// Creation time.

--- a/crates/execution/shadow-indexer-db/src/repo.rs
+++ b/crates/execution/shadow-indexer-db/src/repo.rs
@@ -52,7 +52,7 @@ impl ShadowBlockRepo {
     /// # Errors
     /// Returns an error when the insert fails.
     pub async fn insert_batch(&self, rows: &[ShadowBlockRow]) -> Result<usize> {
-        // Six binds per row; 4,000 stays below Postgres's 65,535-parameter limit.
+        // Five binds per row; 4,000 stays below Postgres's 65,535-parameter limit.
         const CHUNK_SIZE: usize = 4_000;
 
         if rows.is_empty() {
@@ -67,13 +67,12 @@ impl ShadowBlockRepo {
         for chunk in deduped.chunks(CHUNK_SIZE) {
             let mut query_builder: QueryBuilder<'_, Postgres> = QueryBuilder::new(
                 "INSERT INTO shadow_blocks \
-                 (number, hash, reorged_out, canonical_hash, created_at, payload) ",
+                 (number, hash, canonical_hash, created_at, payload) ",
             );
 
             query_builder.push_values(chunk, |mut row, entry| {
                 row.push_bind(entry.number)
                     .push_bind(&entry.hash)
-                    .push_bind(entry.reorged_out)
                     .push_bind(&entry.canonical_hash)
                     .push_bind(entry.created_at)
                     .push_bind(Json(&entry.payload));
@@ -81,7 +80,6 @@ impl ShadowBlockRepo {
 
             query_builder.push(
                 " ON CONFLICT (number, hash) DO UPDATE SET \
-                 reorged_out = EXCLUDED.reorged_out, \
                  canonical_hash = EXCLUDED.canonical_hash, \
                  payload = EXCLUDED.payload, \
                  updated_at = now()",
@@ -113,7 +111,10 @@ impl ShadowBlockRepo {
     /// Returns an error when the query fails.
     pub async fn list_by_number_range(&self, start: i64, end: i64) -> Result<Vec<ShadowBlockRow>> {
         let rows = query_as::<_, ShadowBlockRow>(
-            "SELECT * FROM shadow_blocks WHERE number BETWEEN $1 AND $2 ORDER BY number, created_at",
+            "SELECT number, hash, canonical_hash, created_at, updated_at, payload \
+             FROM shadow_blocks \
+             WHERE number BETWEEN $1 AND $2 \
+             ORDER BY number, created_at",
         )
         .bind(start)
         .bind(end)
@@ -126,6 +127,7 @@ impl ShadowBlockRepo {
 
     /// Lists reorged rows after a composite cursor.
     ///
+    /// Every persisted row is reorged out, so the table needs no predicate beyond the cursor.
     /// Unwinds remain in the query so Rust can count them and advance past them.
     ///
     /// # Errors
@@ -136,10 +138,9 @@ impl ShadowBlockRepo {
         limit: i64,
     ) -> Result<Vec<ShadowBlockRow>> {
         let rows = query_as::<_, ShadowBlockRow>(
-            "SELECT number, hash, reorged_out, canonical_hash, created_at, updated_at, payload \
+            "SELECT number, hash, canonical_hash, created_at, updated_at, payload \
              FROM shadow_blocks \
-             WHERE reorged_out = true \
-               AND (updated_at, number, hash) > ($1, $2, $3) \
+             WHERE (updated_at, number, hash) > ($1, $2, $3) \
              ORDER BY updated_at, number, hash \
              LIMIT $4",
         )
@@ -186,7 +187,7 @@ impl ShadowBlockRepo {
              payload#>'{block,block,header,header}' AS header, \
              payload#>'{block,block,body,transactions}' AS transactions \
              FROM shadow_blocks \
-             WHERE reorged_out = true AND canonical_hash = $1 \
+             WHERE canonical_hash = $1 \
              ORDER BY number DESC, created_at DESC \
              LIMIT $2",
         )
@@ -217,7 +218,7 @@ impl ShadowBlockRepo {
              payload#>'{block,block,header,header}' AS header, \
              payload#>'{block,block,body,transactions}' AS transactions \
              FROM shadow_blocks \
-             WHERE reorged_out = true AND canonical_hash = ANY($1) \
+             WHERE canonical_hash = ANY($1) \
              ORDER BY number DESC, created_at DESC \
              LIMIT $2",
         )
@@ -230,16 +231,17 @@ impl ShadowBlockRepo {
         Ok(rows)
     }
 
-    /// Returns the block with a given hash, whether canonical or reorged out (shadow).
-    ///
-    /// Prefers a canonical row if the same hash somehow exists in both states.
+    /// Returns the reorged-out block with a given hash.
     ///
     /// # Errors
     /// Returns an error when the query fails.
     pub async fn get_by_block_hash(&self, hash: &[u8]) -> Result<Option<ShadowBlockRow>> {
         let row = query_as::<_, ShadowBlockRow>(
-            "SELECT * FROM shadow_blocks WHERE hash = $1 \
-             ORDER BY reorged_out, number DESC LIMIT 1",
+            "SELECT number, hash, canonical_hash, created_at, updated_at, payload \
+             FROM shadow_blocks \
+             WHERE hash = $1 \
+             ORDER BY number DESC \
+             LIMIT 1",
         )
         .bind(hash)
         .fetch_optional(&self.pool)
@@ -260,7 +262,7 @@ impl ShadowBlockRepo {
              payload#>'{block,block,header,header}' AS header, \
              payload#>'{block,block,body,transactions}' AS transactions \
              FROM shadow_blocks \
-             WHERE reorged_out = true AND canonical_hash IS NOT NULL AND hash = $1 \
+             WHERE canonical_hash IS NOT NULL AND hash = $1 \
              ORDER BY number DESC \
              LIMIT 1",
         )
@@ -280,12 +282,11 @@ mod tests {
     use super::*;
     use crate::ShadowBlockPayload;
 
-    fn sample_row(number: i64, hash: &[u8], reorged_out: bool) -> ShadowBlockRow {
+    fn sample_row(number: i64, hash: &[u8], canonical_hash: Option<Vec<u8>>) -> ShadowBlockRow {
         ShadowBlockRow {
             number,
             hash: hash.to_vec(),
-            reorged_out,
-            canonical_hash: None,
+            canonical_hash,
             created_at: Utc::now(),
             updated_at: Utc::now(),
             payload: ShadowBlockPayload {
@@ -299,9 +300,9 @@ mod tests {
     #[test]
     fn dedupe_collapses_duplicate_number_hash_to_last_write() {
         let rows = vec![
-            sample_row(1, &[0xaa], false),
-            sample_row(2, &[0xbb], false),
-            sample_row(1, &[0xaa], true),
+            sample_row(1, &[0xaa], None),
+            sample_row(2, &[0xbb], None),
+            sample_row(1, &[0xaa], Some(vec![0xcc])),
         ];
 
         let deduped = ShadowBlockRepo::dedupe_last_write_wins(&rows);
@@ -311,12 +312,12 @@ mod tests {
             .iter()
             .find(|row| row.number == 1 && row.hash == [0xaa])
             .expect("duplicated key survives");
-        assert!(kept.reorged_out, "duplicate key keeps the last write");
+        assert_eq!(kept.canonical_hash, Some(vec![0xcc]), "duplicate key keeps the last write");
     }
 
     #[test]
     fn dedupe_keeps_same_number_with_distinct_hash() {
-        let rows = vec![sample_row(1, &[0xaa], true), sample_row(1, &[0xbb], false)];
+        let rows = vec![sample_row(1, &[0xaa], None), sample_row(1, &[0xbb], None)];
 
         let deduped = ShadowBlockRepo::dedupe_last_write_wins(&rows);
 
@@ -325,7 +326,7 @@ mod tests {
 
     #[test]
     fn payload_json_paths_expose_header_and_transactions() {
-        let payload = sample_row(1, &[0xaa], false).payload;
+        let payload = sample_row(1, &[0xaa], None).payload;
         let value = serde_json::to_value(&payload).expect("payload to json");
 
         let header_value = json_path(&value, &["block", "block", "header", "header"]);

--- a/crates/execution/shadow-indexer/src/exex.rs
+++ b/crates/execution/shadow-indexer/src/exex.rs
@@ -127,9 +127,6 @@ impl ShadowIndexerExEx {
         Ok(ShadowBlockRow {
             number,
             hash: block.hash().as_slice().to_vec(),
-            // Always set: only reorged-out and reverted blocks are persisted now. The column
-            // stays so the reader keeps filtering out canonical rows written by earlier builds.
-            reorged_out: true,
             canonical_hash,
             created_at: now,
             updated_at: now,
@@ -271,7 +268,6 @@ mod tests {
         assert_eq!(rows.len(), old.blocks().len(), "only old-chain blocks are emitted");
 
         for row in &rows {
-            assert!(row.reorged_out, "every persisted row is reorged out");
             assert_eq!(row.hash.as_slice(), block_hash(row.number as u64, 0).as_slice());
             assert_eq!(
                 row.canonical_hash,
@@ -314,7 +310,6 @@ mod tests {
         let rows = drain(rx);
         assert_eq!(rows.iter().map(|row| row.number).collect::<Vec<_>>(), vec![4, 5, 6]);
         for row in &rows {
-            assert!(row.reorged_out, "reverted rows are marked reorged out");
             assert_eq!(
                 row.canonical_hash, None,
                 "reverted rows have no replacement canonical hash"

--- a/crates/execution/shadow-indexer/src/writer.rs
+++ b/crates/execution/shadow-indexer/src/writer.rs
@@ -168,7 +168,6 @@ mod tests {
         ShadowBlockRow {
             number,
             hash: b"hash".to_vec(),
-            reorged_out: true,
             canonical_hash: None,
             created_at,
             updated_at: created_at,

--- a/crates/infra/shadow-metrics/src/api.rs
+++ b/crates/infra/shadow-metrics/src/api.rs
@@ -257,7 +257,9 @@ fn block_detail(row: &ShadowBlockRow) -> BlockDetail {
         gas_used: header.gas_used,
         gas_limit: header.gas_limit,
         base_fee_per_gas: header.base_fee_per_gas,
-        reorged_out: row.reorged_out,
+        // Retained at a constant so the response shape survives the column drop: the table
+        // only ever holds reorged-out blocks.
+        reorged_out: true,
         canonical_hash: row.canonical_hash.as_ref().map(hex::encode_prefixed),
         tx_count: block.body().transactions.len(),
         transactions,
@@ -340,18 +342,17 @@ mod tests {
     const RECIPIENT: Address = Address::repeat_byte(0x11);
 
     fn sample_row() -> ShadowBlockRow {
-        sample_row_with(false, None)
+        sample_row_with(None)
     }
 
-    fn sample_row_with(reorged_out: bool, canonical_hash: Option<Vec<u8>>) -> ShadowBlockRow {
-        sample_row_full(42, 21_000, "test", reorged_out, canonical_hash)
+    fn sample_row_with(canonical_hash: Option<Vec<u8>>) -> ShadowBlockRow {
+        sample_row_full(42, 21_000, "test", canonical_hash)
     }
 
     fn sample_row_full(
         number: i64,
         gas_used: u64,
         builder_version: &str,
-        reorged_out: bool,
         canonical_hash: Option<Vec<u8>>,
     ) -> ShadowBlockRow {
         let deposit = TxDeposit {
@@ -376,7 +377,6 @@ mod tests {
         ShadowBlockRow {
             number,
             hash: vec![0xab; 32],
-            reorged_out,
             canonical_hash,
             created_at: now,
             updated_at: now,
@@ -414,15 +414,15 @@ mod tests {
     }
 
     #[test]
-    fn block_detail_marks_canonical_row() {
+    fn block_detail_omits_canonical_hash_when_unreconciled() {
         let detail = block_detail(&sample_row());
-        assert!(!detail.reorged_out);
+        assert!(detail.reorged_out);
         assert!(detail.canonical_hash.is_none());
     }
 
     #[test]
     fn block_detail_exposes_shadow_status_and_replacement_hash() {
-        let detail = block_detail(&sample_row_with(true, Some(vec![0xcd; 32])));
+        let detail = block_detail(&sample_row_with(Some(vec![0xcd; 32])));
         assert!(detail.reorged_out);
         assert_eq!(
             detail.canonical_hash.as_deref(),
@@ -454,7 +454,7 @@ mod tests {
 
     #[test]
     fn shadow_block_summary_reports_shadow_only_fields() {
-        let shadow = sample_row_full(100, 30_000, "shadow", true, Some(vec![0xcd; 32]));
+        let shadow = sample_row_full(100, 30_000, "shadow", Some(vec![0xcd; 32]));
         let summary = shadow_block_summary(&sample_summary_row(&shadow));
 
         assert_eq!(summary.number, 100);

--- a/etc/systems/tests/shadow_metrics_reader.rs
+++ b/etc/systems/tests/shadow_metrics_reader.rs
@@ -95,12 +95,7 @@ impl ShadowBlockFixture {
         self
     }
 
-    fn into_row(
-        self,
-        hash_seed: u8,
-        reorged_out: bool,
-        canonical_hash_seed: Option<u8>,
-    ) -> ShadowBlockRow {
+    fn into_row(self, hash_seed: u8, canonical_hash_seed: Option<u8>) -> ShadowBlockRow {
         let number = self.number;
         let payload = self.into_payload();
         let now = Utc::now();
@@ -108,7 +103,6 @@ impl ShadowBlockFixture {
         ShadowBlockRow {
             number,
             hash: vec![hash_seed; 32],
-            reorged_out,
             canonical_hash: canonical_hash_seed.map(|seed| vec![seed; 32]),
             created_at: now,
             updated_at: now,
@@ -160,8 +154,8 @@ async fn emits_only_reconciled_shadow_row_once() -> Result<()> {
     let mut reader = database.reader(DEFAULT_TEST_MAX_ROWS).await?;
     let repo = ShadowBlockRepo::new(database.pool.clone());
     let rows = [
-        ShadowBlockFixture::new(7).builder_version("shadow").into_row(0x11, true, Some(0x91)),
-        ShadowBlockFixture::new(7).builder_version("canonical").into_row(0x12, false, None),
+        ShadowBlockFixture::new(7).builder_version("shadow").into_row(0x11, Some(0x91)),
+        ShadowBlockFixture::new(7).builder_version("canonical").into_row(0x12, None),
     ];
     repo.insert_batch(&rows).await?;
 
@@ -179,12 +173,12 @@ async fn emits_unreconciled_row_after_reconciliation() -> Result<()> {
     let database = TestDatabase::start().await?;
     let mut reader = database.reader(DEFAULT_TEST_MAX_ROWS).await?;
     let repo = ShadowBlockRepo::new(database.pool.clone());
-    repo.insert_batch(&[ShadowBlockFixture::new(11).into_row(0x21, false, None)]).await?;
+    repo.insert_batch(&[ShadowBlockFixture::new(11).into_row(0x21, None)]).await?;
 
     assert!(reader.poll_once().await?.is_empty());
 
     sleep(Duration::from_millis(2)).await;
-    repo.insert_batch(&[ShadowBlockFixture::new(11).into_row(0x21, true, Some(0xa1))]).await?;
+    repo.insert_batch(&[ShadowBlockFixture::new(11).into_row(0x21, Some(0xa1))]).await?;
 
     let emitted = reader.poll_once().await?;
     assert_eq!(emitted.len(), 1);
@@ -199,7 +193,7 @@ async fn skips_unwind_and_advances_cursor() -> Result<()> {
     let database = TestDatabase::start().await?;
     let mut reader = database.reader(DEFAULT_TEST_MAX_ROWS).await?;
     ShadowBlockRepo::new(database.pool.clone())
-        .insert_batch(&[ShadowBlockFixture::new(21).into_row(0x31, true, None)])
+        .insert_batch(&[ShadowBlockFixture::new(21).into_row(0x31, None)])
         .await?;
 
     assert!(reader.poll_once().await?.is_empty());
@@ -222,12 +216,12 @@ async fn poison_payload_fails_the_whole_poll() -> Result<()> {
     let cursor_repo = ShadowMetricsCursorRepo::new(database.pool.clone());
     let initial_cursor =
         cursor_repo.load().await?.expect("reader initialization persists a cursor");
-    repo.insert_batch(&[ShadowBlockFixture::new(31).into_row(0x41, true, Some(0xb1))]).await?;
+    repo.insert_batch(&[ShadowBlockFixture::new(31).into_row(0x41, Some(0xb1))]).await?;
     sleep(Duration::from_millis(2)).await;
     sqlx::query(
         "INSERT INTO shadow_blocks \
-         (number, hash, reorged_out, canonical_hash, payload) \
-         VALUES ($1, $2, true, $3, $4)",
+         (number, hash, canonical_hash, payload) \
+         VALUES ($1, $2, $3, $4)",
     )
     .bind(32_i64)
     .bind(vec![0x42_u8; 32])
@@ -236,7 +230,7 @@ async fn poison_payload_fails_the_whole_poll() -> Result<()> {
     .execute(&database.pool)
     .await?;
     sleep(Duration::from_millis(2)).await;
-    repo.insert_batch(&[ShadowBlockFixture::new(33).into_row(0x43, true, Some(0xb3))]).await?;
+    repo.insert_batch(&[ShadowBlockFixture::new(33).into_row(0x43, Some(0xb3))]).await?;
 
     let error = reader.poll_once().await.expect_err("poison payload must fail the whole poll");
     let error_chain = format!("{error:#}");
@@ -263,7 +257,7 @@ async fn counts_deposits_but_excludes_them_from_fee_ordering() -> Result<()> {
             .base_fee_per_gas(0)
             .deposits(2)
             .tips(&[30, 20, 40])
-            .into_row(0x51, true, Some(0xc1))])
+            .into_row(0x51, Some(0xc1))])
         .await?;
 
     let emitted = reader.poll_once().await?;
@@ -282,13 +276,11 @@ async fn counts_sawtooth_boundaries_and_accepts_non_increasing_fees() -> Result<
     let mut reader = database.reader(DEFAULT_TEST_MAX_ROWS).await?;
     ShadowBlockRepo::new(database.pool.clone())
         .insert_batch(&[
-            ShadowBlockFixture::new(51).tips(&[100, 90, 80, 120, 110, 100, 130, 120]).into_row(
-                0x61,
-                true,
-                Some(0xd1),
-            ),
-            ShadowBlockFixture::new(52).tips(&[120, 110, 100, 90]).into_row(0x62, true, Some(0xd2)),
-            ShadowBlockFixture::new(53).tips(&[50, 50, 40]).into_row(0x63, true, Some(0xd3)),
+            ShadowBlockFixture::new(51)
+                .tips(&[100, 90, 80, 120, 110, 100, 130, 120])
+                .into_row(0x61, Some(0xd1)),
+            ShadowBlockFixture::new(52).tips(&[120, 110, 100, 90]).into_row(0x62, Some(0xd2)),
+            ShadowBlockFixture::new(53).tips(&[50, 50, 40]).into_row(0x63, Some(0xd3)),
         ])
         .await?;
 
@@ -330,11 +322,7 @@ async fn respects_poll_cap_and_advances_by_cap() -> Result<()> {
     let mut reader = database.reader(MAX_ROWS).await?;
     let rows = (1_u8..=7)
         .map(|offset| {
-            ShadowBlockFixture::new(60 + i64::from(offset)).into_row(
-                offset,
-                true,
-                Some(0xe0 + offset),
-            )
+            ShadowBlockFixture::new(60 + i64::from(offset)).into_row(offset, Some(0xe0 + offset))
         })
         .collect::<Vec<_>>();
     ShadowBlockRepo::new(database.pool.clone()).insert_batch(&rows).await?;
@@ -370,7 +358,6 @@ async fn drains_timestamp_tie_group_without_loss_or_duplicates() -> Result<()> {
         .map(|(index, number)| {
             ShadowBlockFixture::new(number).into_row(
                 u8::try_from(index + 1).expect("fixture hash seed fits in u8"),
-                true,
                 Some(0xf1),
             )
         })
@@ -411,8 +398,8 @@ async fn resumes_from_persisted_cursor_after_restart() -> Result<()> {
     let mut reader = database.reader(MAX_ROWS).await?;
     ShadowBlockRepo::new(database.pool.clone())
         .insert_batch(&[
-            ShadowBlockFixture::new(201).into_row(0x71, true, Some(0x81)),
-            ShadowBlockFixture::new(202).into_row(0x72, true, Some(0x82)),
+            ShadowBlockFixture::new(201).into_row(0x71, Some(0x81)),
+            ShadowBlockFixture::new(202).into_row(0x72, Some(0x82)),
         ])
         .await?;
 


### PR DESCRIPTION
Every row the ExEx writes has set `reorged_out = true` since #4624 stopped persisting canonical blocks, so the flag only still separates canonical rows left behind by older builds. Migration `0004` drops the column but aborts if any of those rows remain, because the metrics reader's cursor never advanced over them and they would otherwise surface as shadow blocks.

The `reorgedOut` field in the `/blocks` API response from #4571 is kept and pinned to `true` so the response shape does not change. Say the word if you would rather drop it from the payload.

**Do not merge yet** — blocked on:

1. #4644 and #4573 landing first (both add `reorged_out` predicates that this PR would delete out from under them).
2. `SELECT count(*) FROM shadow_blocks WHERE NOT reorged_out` returning 0 in production.
3. Deselecting `reorged_out` in DataPilot pipeline 12181 and dropping it from Snowflake, before this migration runs.

Note the migration applies fleet-wide from the first upgraded node, and old binaries cannot start against the new schema.