### PR TITLE
feat(builder): emit validity inclusion and fee-revenue metrics

### DIFF
--- a/crates/builder/core/src/execution.rs
+++ b/crates/builder/core/src/execution.rs
@@ -12,7 +12,7 @@ use base_common_evm::BaseTransactionError;
 use derive_more::Display;
 use thiserror::Error;
 
-use crate::PredicateLoadTracker;
+use crate::{InclusionTracker, PredicateLoadTracker};
 
 /// Resource limits configuration for transaction and block constraints.
 ///
@@ -229,6 +229,8 @@ pub struct ExecutionInfo {
     pub rejected_txs: Vec<RejectedTransaction>,
     /// Validity-predicate state loads accumulated across the block's flashblock builds.
     pub predicate_loads: PredicateLoadTracker,
+    /// Validity inclusion and EIP-1559 fee revenue accumulated across the block.
+    pub inclusion: InclusionTracker,
 }
 
 impl ExecutionInfo {
@@ -246,6 +248,7 @@ impl ExecutionInfo {
             da_footprint_scalar: None,
             rejected_txs: Vec::new(),
             predicate_loads: PredicateLoadTracker::default(),
+            inclusion: InclusionTracker::default(),
         }
     }
 
@@ -550,6 +553,7 @@ mod tests {
         assert_eq!(info.cumulative_da_bytes_used, 0);
         assert_eq!(info.cumulative_uncompressed_bytes, 0);
         assert_eq!(info.total_fees, U256::ZERO);
+        assert_eq!(info.inclusion, InclusionTracker::default());
         assert!(info.executed_transactions.is_empty());
         assert!(info.executed_senders.is_empty());
         assert!(info.receipts.is_empty());

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -1614,6 +1614,7 @@ impl BasePayloadBuilderCtx {
                 .effective_tip_per_gas(base_fee)
                 .expect("fee is always valid; execution succeeded");
             info.total_fees += U256::from(miner_fee) * U256::from(gas_used);
+            info.inclusion.record(has_validity_predicates, gas_used, miner_fee, base_fee);
 
             // Per-tx tip-per-gas distribution (builder priority score), tagged
             // by flow cohort and bid mechanism. `X` for top-X-percentile share is

--- a/crates/builder/core/src/flashblocks/inclusion.rs
+++ b/crates/builder/core/src/flashblocks/inclusion.rs
@@ -1,0 +1,157 @@
+//! Per-block accounting of validity-transaction inclusion and fee revenue.
+//!
+//! Accumulates, across every committed mempool transaction in a block:
+//!
+//! - how many transactions were included, and the gas they consumed
+//! - EIP-1559 fee revenue, segmented by **flow** (`validity` vs `standard`) and
+//!   **fee kind** (priority fee, base fee, and coinbase tip)
+//!
+//! Priority fees are `effective_tip * gas_used` for every included mempool
+//! transaction, including EIP-8130 transactions that also pay a priority fee.
+//! Base fees are `base_fee * gas_used` for the same transactions.
+//!
+//! Sequencer and deposit transactions are not recorded here: they are not
+//! selected from the mempool and do not bid via priority fee.
+//!
+//! [`InclusionFlow::coinbase_tips`] is reserved for the statically-decoded
+//! EIP-8130 phase-0 coinbase tip. It is left at zero until that decoder exists.
+
+use alloy_primitives::U256;
+
+/// Metric `flow` label for validity-transaction fee revenue.
+pub const FLOW_VALIDITY: &str = "validity";
+/// Metric `flow` label for standard (non-validity) fee revenue.
+pub const FLOW_STANDARD: &str = "standard";
+
+/// Per-flow inclusion and EIP-1559 fee totals for one block.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct InclusionFlow {
+    /// Transactions committed to the payload in this flow.
+    pub txs: u64,
+    /// Gas consumed by those transactions.
+    pub gas: u64,
+    /// Base-fee revenue (`base_fee * gas_used`), in wei.
+    pub base_fees: U256,
+    /// Priority-fee revenue (`effective_tip * gas_used`), in wei.
+    pub priority_fees: U256,
+    /// Coinbase-tip revenue from EIP-8130 phase-0 bids, in wei.
+    ///
+    /// TODO: populate from the statically-decoded phase-0 coinbase tip once
+    /// that decoder exists. Remains zero until then.
+    pub coinbase_tips: U256,
+}
+
+impl InclusionFlow {
+    fn record(&mut self, gas_used: u64, miner_fee: u128, base_fee: u64) {
+        self.txs += 1;
+        self.gas += gas_used;
+        self.base_fees += U256::from(base_fee) * U256::from(gas_used);
+        self.priority_fees += U256::from(miner_fee) * U256::from(gas_used);
+    }
+
+    /// Base-fee revenue as `f64` wei for histogram emission.
+    pub fn base_fees_f64(&self) -> f64 {
+        wei_as_f64(self.base_fees)
+    }
+
+    /// Priority-fee revenue as `f64` wei for histogram emission.
+    pub fn priority_fees_f64(&self) -> f64 {
+        wei_as_f64(self.priority_fees)
+    }
+
+    /// Coinbase-tip revenue as `f64` wei for histogram emission.
+    pub fn coinbase_tips_f64(&self) -> f64 {
+        wei_as_f64(self.coinbase_tips)
+    }
+}
+
+/// Per-block accumulator for inclusion and EIP-1559 fee revenue, segmented by flow.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct InclusionTracker {
+    /// Standard (non-validity) mempool transactions.
+    pub standard: InclusionFlow,
+    /// Validity-gated mempool transactions.
+    pub validity: InclusionFlow,
+}
+
+impl InclusionTracker {
+    /// Records a mempool transaction that was committed to the payload.
+    ///
+    /// `is_validity` selects the [`Self::validity`] or [`Self::standard`] flow.
+    pub fn record(&mut self, is_validity: bool, gas_used: u64, miner_fee: u128, base_fee: u64) {
+        let flow = if is_validity { &mut self.validity } else { &mut self.standard };
+        flow.record(gas_used, miner_fee, base_fee);
+    }
+}
+
+/// Converts a wei total to `f64` for histogram emission.
+///
+/// Values that do not fit in `u128` saturate to [`f64::MAX`]. Integer
+/// precision is already lost above 2^53, which is acceptable for per-block
+/// revenue distributions.
+fn wei_as_f64(value: U256) -> f64 {
+    u128::try_from(value).map(|wei| wei as f64).unwrap_or(f64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn records_validity_inclusion_gas_and_fees() {
+        let mut tracker = InclusionTracker::default();
+        tracker.record(true, 21_000, 2, 10);
+
+        assert_eq!(tracker.validity.txs, 1);
+        assert_eq!(tracker.validity.gas, 21_000);
+        assert_eq!(tracker.validity.priority_fees_f64(), 42_000.0);
+        assert_eq!(tracker.validity.base_fees_f64(), 210_000.0);
+        assert_eq!(tracker.validity.coinbase_tips_f64(), 0.0);
+        assert_eq!(tracker.standard, InclusionFlow::default());
+    }
+
+    #[test]
+    fn records_standard_fees_without_validity_counts() {
+        let mut tracker = InclusionTracker::default();
+        tracker.record(false, 30_000, 3, 10);
+
+        assert_eq!(tracker.validity, InclusionFlow::default());
+        assert_eq!(tracker.standard.txs, 1);
+        assert_eq!(tracker.standard.gas, 30_000);
+        assert_eq!(tracker.standard.priority_fees_f64(), 90_000.0);
+        assert_eq!(tracker.standard.base_fees_f64(), 300_000.0);
+        assert_eq!(tracker.standard.coinbase_tips_f64(), 0.0);
+    }
+
+    #[test]
+    fn coinbase_tips_remain_zero_until_decoded() {
+        let mut tracker = InclusionTracker::default();
+        tracker.record(true, 50_000, 7, 10);
+        tracker.record(false, 21_000, 5, 10);
+
+        assert_eq!(tracker.validity.priority_fees_f64(), 350_000.0);
+        assert_eq!(tracker.standard.priority_fees_f64(), 105_000.0);
+        assert_eq!(tracker.validity.coinbase_tips_f64(), 0.0);
+        assert_eq!(tracker.standard.coinbase_tips_f64(), 0.0);
+    }
+
+    #[test]
+    fn accumulates_mixed_mempool_transactions_across_the_block() {
+        let mut tracker = InclusionTracker::default();
+        tracker.record(true, 21_000, 2, 10);
+        tracker.record(false, 10_000, 4, 10);
+        tracker.record(true, 9_000, 1, 10);
+        tracker.record(true, 8_000, 9, 10);
+
+        assert_eq!(tracker.validity.txs, 3);
+        assert_eq!(tracker.validity.gas, 38_000);
+        assert_eq!(tracker.validity.priority_fees_f64(), 123_000.0);
+        assert_eq!(tracker.validity.base_fees_f64(), 380_000.0);
+        assert_eq!(tracker.validity.coinbase_tips_f64(), 0.0);
+        assert_eq!(tracker.standard.txs, 1);
+        assert_eq!(tracker.standard.gas, 10_000);
+        assert_eq!(tracker.standard.priority_fees_f64(), 40_000.0);
+        assert_eq!(tracker.standard.base_fees_f64(), 100_000.0);
+        assert_eq!(tracker.standard.coinbase_tips_f64(), 0.0);
+    }
+}

--- a/crates/builder/core/src/flashblocks/inclusion.rs
+++ b/crates/builder/core/src/flashblocks/inclusion.rs
@@ -51,17 +51,17 @@ impl InclusionFlow {
 
     /// Base-fee revenue as `f64` wei for histogram emission.
     pub fn base_fees_f64(&self) -> f64 {
-        wei_as_f64(self.base_fees)
+        u128::try_from(self.base_fees).map(|wei| wei as f64).unwrap_or(f64::MAX)
     }
 
     /// Priority-fee revenue as `f64` wei for histogram emission.
     pub fn priority_fees_f64(&self) -> f64 {
-        wei_as_f64(self.priority_fees)
+        u128::try_from(self.priority_fees).map(|wei| wei as f64).unwrap_or(f64::MAX)
     }
 
     /// Coinbase-tip revenue as `f64` wei for histogram emission.
     pub fn coinbase_tips_f64(&self) -> f64 {
-        wei_as_f64(self.coinbase_tips)
+        u128::try_from(self.coinbase_tips).map(|wei| wei as f64).unwrap_or(f64::MAX)
     }
 }
 
@@ -82,15 +82,6 @@ impl InclusionTracker {
         let flow = if is_validity { &mut self.validity } else { &mut self.standard };
         flow.record(gas_used, miner_fee, base_fee);
     }
-}
-
-/// Converts a wei total to `f64` for histogram emission.
-///
-/// Values that do not fit in `u128` saturate to [`f64::MAX`]. Integer
-/// precision is already lost above 2^53, which is acceptable for per-block
-/// revenue distributions.
-fn wei_as_f64(value: U256) -> f64 {
-    u128::try_from(value).map(|wei| wei as f64).unwrap_or(f64::MAX)
 }
 
 #[cfg(test)]

--- a/crates/builder/core/src/flashblocks/mod.rs
+++ b/crates/builder/core/src/flashblocks/mod.rs
@@ -12,6 +12,9 @@ pub use predicate_index::{ParkedPredicateIndex, StateChangeEffects, ValidityPred
 mod predicate_loads;
 pub use predicate_loads::{PredicateLoadTracker, PredicateReadRecorder};
 
+mod inclusion;
+pub use inclusion::{FLOW_STANDARD, FLOW_VALIDITY, InclusionFlow, InclusionTracker};
+
 mod deadline;
 pub use deadline::PayloadJobDeadline;
 

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -934,6 +934,9 @@ where
         // Record validity-predicate state loads accumulated across the block's flashblocks.
         BuilderMetrics::record_predicate_loads(&info.predicate_loads);
 
+        // Record validity inclusion and EIP-1559 fee revenue for the block.
+        BuilderMetrics::record_inclusion(&info.inclusion);
+
         debug!(
             target: "payload_builder",
             message = message,

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -42,8 +42,9 @@ pub use rejection_cache::RejectionCache;
 mod flashblocks;
 pub use flashblocks::{
     BasePayloadBuilderCtx, BestFlashblocksTxs, BlockPayloadJob, BlockPayloadJobGenerator,
-    BuildArguments, FlashblockDiagnostics, FlashblockSelectionOutcome, FlashblocksExtraCtx,
-    FlashblocksServiceBuilder, ParkableBestPayloadTransactions, ParkablePayloadTransactions,
+    BuildArguments, FLOW_STANDARD, FLOW_VALIDITY, FlashblockDiagnostics,
+    FlashblockSelectionOutcome, FlashblocksExtraCtx, FlashblocksServiceBuilder, InclusionFlow,
+    InclusionTracker, ParkableBestPayloadTransactions, ParkablePayloadTransactions,
     ParkedPredicateIndex, PayloadBuilder, PayloadHandler, PayloadJobDeadline,
     PayloadTransactionInvalidated, PredicateLoadTracker, PredicateReadRecorder, ResolvePayload,
     StateChangeEffects, ValidityPredicateKey,

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -3,8 +3,8 @@
 use std::time::Duration;
 
 use crate::{
-    ExecutionInfo, FlashblockDiagnostics, ParkedPredicateIndex, PredicateLoadTracker,
-    ResourceLimits,
+    ExecutionInfo, FLOW_STANDARD, FLOW_VALIDITY, FlashblockDiagnostics, InclusionTracker,
+    ParkedPredicateIndex, PredicateLoadTracker, ResourceLimits,
 };
 
 const PRIORITY_FEE_THRESHOLDS_WEI: [(&str, u64); 3] =
@@ -145,6 +145,21 @@ base_metrics::define_metrics! {
         "Distinct storage slots read while evaluating validity predicates per block (predicate state footprint)"
     )]
     predicate_slots_loaded_unique: histogram,
+    #[describe("Transactions included per block, segmented by flow")]
+    #[label(flow)]
+    txs_included_per_block: histogram,
+    #[describe("Gas consumed by included transactions per block, segmented by flow")]
+    #[label(flow)]
+    tx_gas_used_per_block: histogram,
+    #[describe("Per-block EIP-1559 priority-fee revenue in wei, segmented by flow")]
+    #[label(flow)]
+    priority_fee_revenue_wei: histogram,
+    #[describe("Per-block EIP-1559 base-fee revenue in wei, segmented by flow")]
+    #[label(flow)]
+    base_fee_revenue_wei: histogram,
+    #[describe("Per-block EIP-8130 coinbase-tip revenue in wei, segmented by flow")]
+    #[label(flow)]
+    coinbase_tip_revenue_wei: histogram,
     #[describe("Validity predicate evaluation attempts")]
     #[label(outcome)]
     validity_predicate_evaluations_total: counter,
@@ -328,6 +343,25 @@ impl BuilderMetrics {
         Self::predicate_accounts_loaded_unique().record(tracker.unique_accounts() as f64);
         Self::predicate_slots_loaded_total().record(tracker.slot_reads() as f64);
         Self::predicate_slots_loaded_unique().record(tracker.unique_slots() as f64);
+    }
+
+    /// Records per-block inclusion and EIP-1559 fee revenue.
+    ///
+    /// Always emits one observation per built block, including zeros, so the
+    /// histograms describe the full per-block distribution. Each series is
+    /// labeled `flow=standard` then `flow=validity`. Coinbase-tip observations
+    /// are currently zero until the EIP-8130 phase-0 tip is decoded.
+    pub fn record_inclusion(tracker: &InclusionTracker) {
+        Self::txs_included_per_block(FLOW_STANDARD).record(tracker.standard.txs as f64);
+        Self::txs_included_per_block(FLOW_VALIDITY).record(tracker.validity.txs as f64);
+        Self::tx_gas_used_per_block(FLOW_STANDARD).record(tracker.standard.gas as f64);
+        Self::tx_gas_used_per_block(FLOW_VALIDITY).record(tracker.validity.gas as f64);
+        Self::priority_fee_revenue_wei(FLOW_STANDARD).record(tracker.standard.priority_fees_f64());
+        Self::priority_fee_revenue_wei(FLOW_VALIDITY).record(tracker.validity.priority_fees_f64());
+        Self::base_fee_revenue_wei(FLOW_STANDARD).record(tracker.standard.base_fees_f64());
+        Self::base_fee_revenue_wei(FLOW_VALIDITY).record(tracker.validity.base_fees_f64());
+        Self::coinbase_tip_revenue_wei(FLOW_STANDARD).record(tracker.standard.coinbase_tips_f64());
+        Self::coinbase_tip_revenue_wei(FLOW_VALIDITY).record(tracker.validity.coinbase_tips_f64());
     }
 
     /// Records payload builder metrics.
@@ -608,6 +642,116 @@ mod tests {
                 "base_builder_tip_per_gas_sum{flow=\"standard\",bid=\"coinbase_tip\"} 20"
             ),
             "expected 8130 standard sum 20, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn record_inclusion_emits_per_block_histograms_including_zeros() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+
+        let mut tracker = InclusionTracker::default();
+        tracker.record(true, 21_000, 2, 10);
+        tracker.record(false, 10_000, 4, 10);
+        tracker.record(true, 8_000, 9, 10);
+
+        metrics::with_local_recorder(&recorder, || {
+            BuilderMetrics::record_inclusion(&tracker);
+        });
+
+        let rendered = handle.render();
+        assert!(
+            rendered.contains("base_builder_txs_included_per_block_sum{flow=\"standard\"} 1"),
+            "expected one included standard tx, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("base_builder_txs_included_per_block_sum{flow=\"validity\"} 2"),
+            "expected two included validity txs, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("base_builder_tx_gas_used_per_block_sum{flow=\"standard\"} 10000"),
+            "expected 10000 standard gas, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("base_builder_tx_gas_used_per_block_sum{flow=\"validity\"} 29000"),
+            "expected 29000 validity gas, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("base_builder_priority_fee_revenue_wei_sum{flow=\"standard\"} 40000"),
+            "expected 40000 standard priority-fee wei, got: {rendered}"
+        );
+        assert!(
+            rendered
+                .contains("base_builder_priority_fee_revenue_wei_sum{flow=\"validity\"} 114000"),
+            "expected 114000 validity priority-fee wei, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("base_builder_base_fee_revenue_wei_sum{flow=\"standard\"} 100000"),
+            "expected 100000 standard base-fee wei, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("base_builder_base_fee_revenue_wei_sum{flow=\"validity\"} 290000"),
+            "expected 290000 validity base-fee wei, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("base_builder_coinbase_tip_revenue_wei_sum{flow=\"standard\"} 0"),
+            "expected coinbase tips to stay zero until decoded, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("base_builder_coinbase_tip_revenue_wei_sum{flow=\"validity\"} 0"),
+            "expected coinbase tips to stay zero until decoded, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn record_inclusion_emits_zero_observations_for_empty_blocks() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+
+        metrics::with_local_recorder(&recorder, || {
+            BuilderMetrics::record_inclusion(&InclusionTracker::default());
+        });
+
+        let rendered = handle.render();
+        assert!(
+            rendered.contains("base_builder_txs_included_per_block_count{flow=\"standard\"} 1"),
+            "empty blocks must still emit a standard inclusion observation, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("base_builder_txs_included_per_block_count{flow=\"validity\"} 1"),
+            "empty blocks must still emit a validity inclusion observation, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("base_builder_tx_gas_used_per_block_count{flow=\"standard\"} 1"),
+            "empty blocks must still emit a standard gas observation, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("base_builder_tx_gas_used_per_block_count{flow=\"validity\"} 1"),
+            "empty blocks must still emit a validity gas observation, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("base_builder_priority_fee_revenue_wei_count{flow=\"standard\"} 1"),
+            "empty blocks must still emit a standard-revenue observation, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("base_builder_priority_fee_revenue_wei_count{flow=\"validity\"} 1"),
+            "empty blocks must still emit a validity-revenue observation, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("base_builder_base_fee_revenue_wei_count{flow=\"standard\"} 1"),
+            "empty blocks must still emit a standard base-fee observation, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("base_builder_base_fee_revenue_wei_count{flow=\"validity\"} 1"),
+            "empty blocks must still emit a validity base-fee observation, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("base_builder_coinbase_tip_revenue_wei_count{flow=\"standard\"} 1"),
+            "empty blocks must still emit a standard coinbase-tip observation, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("base_builder_coinbase_tip_revenue_wei_count{flow=\"validity\"} 1"),
+            "empty blocks must still emit a validity coinbase-tip observation, got: {rendered}"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Emit per-block builder histograms for included txs, gas, priority-fee revenue, and base-fee revenue, labeled `flow=standard` then `flow=validity`.
- Accumulate those totals in the flashblocks build loop on `InclusionTracker` (BASE-241). Coinbase-tip revenue is reserved and currently zero until the EIP-8130 phase-0 tip is decoded (BASE-301).
