### PR TITLE
feat(builder): emit tip-per-gas distribution tagged by flow and bid

### DIFF
--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -861,6 +861,7 @@ impl BasePayloadBuilderCtx {
 
             let tx_hash = *tx.hash();
             let has_validity_predicates = !tx.validity_predicates().is_empty();
+            let is_eip8130 = tx.as_eip8130().is_some();
 
             // Defer without evaluating once this flashblock's predicate-eval time budget is
             // exhausted, rather than spending more IO on the naive per-transaction loop. The
@@ -1612,6 +1613,15 @@ impl BasePayloadBuilderCtx {
                 .effective_tip_per_gas(base_fee)
                 .expect("fee is always valid; execution succeeded");
             info.total_fees += U256::from(miner_fee) * U256::from(gas_used);
+
+            // Per-tx tip-per-gas distribution (builder priority score), tagged
+            // by flow cohort and bid mechanism. `X` for top-X-percentile share is
+            // left to Datadog percentile aggregations — do not bake it in here.
+            BuilderMetrics::record_tip_per_gas(
+                has_validity_predicates,
+                is_eip8130,
+                miner_fee as f64,
+            );
 
             // track minimum priority fee for diagnostics (saturate u128 -> u64)
             let fee_u64 = miner_fee.min(u64::MAX as u128) as u64;

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -861,7 +861,7 @@ impl BasePayloadBuilderCtx {
 
             let tx_hash = *tx.hash();
             let has_validity_predicates = !tx.validity_predicates().is_empty();
-            let has_statically_analyzable_tip =
+            let has_coinbase_tip =
                 tx.as_eip8130().is_some_and(|signed| signed.tx().coinbase_tip().is_some());
 
             // Defer without evaluating once this flashblock's predicate-eval time budget is
@@ -1620,7 +1620,7 @@ impl BasePayloadBuilderCtx {
             // left to Datadog percentile aggregations — do not bake it in here.
             BuilderMetrics::record_tip_per_gas(
                 has_validity_predicates,
-                has_statically_analyzable_tip,
+                has_coinbase_tip,
                 miner_fee as f64,
             );
 

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -861,7 +861,8 @@ impl BasePayloadBuilderCtx {
 
             let tx_hash = *tx.hash();
             let has_validity_predicates = !tx.validity_predicates().is_empty();
-            let is_eip8130 = tx.as_eip8130().is_some();
+            let has_statically_analyzable_tip =
+                tx.as_eip8130().is_some_and(|signed| signed.tx().coinbase_tip().is_some());
 
             // Defer without evaluating once this flashblock's predicate-eval time budget is
             // exhausted, rather than spending more IO on the naive per-transaction loop. The
@@ -1619,7 +1620,7 @@ impl BasePayloadBuilderCtx {
             // left to Datadog percentile aggregations — do not bake it in here.
             BuilderMetrics::record_tip_per_gas(
                 has_validity_predicates,
-                is_eip8130,
+                has_statically_analyzable_tip,
                 miner_fee as f64,
             );
 

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -372,11 +372,11 @@ impl BuilderMetrics {
     /// transaction, uses `bid=priority_fee`.
     pub fn record_tip_per_gas(
         has_validity_predicates: bool,
-        has_statically_analyzable_tip: bool,
+        has_coinbase_tip: bool,
         tip_per_gas: f64,
     ) {
         let flow = if has_validity_predicates { "validity" } else { "standard" };
-        let bid = if has_statically_analyzable_tip { "coinbase_tip" } else { "priority_fee" };
+        let bid = if has_coinbase_tip { "coinbase_tip" } else { "priority_fee" };
         Self::tip_per_gas(flow, bid).record(tip_per_gas);
     }
 }

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -366,16 +366,17 @@ impl BuilderMetrics {
     /// (`effective_tip_per_gas` / tip-per-gas-limit) — no execution result or
     /// price feed is required. Observations are tagged `flow=validity` only when
     /// the transaction carries validity predicates, otherwise `flow=standard`.
-    /// Bid mechanism is independent of flow: `bid=coinbase_tip` for EIP-8130,
-    /// `bid=priority_fee` otherwise. An 8130 transaction without predicates is
-    /// therefore `flow=standard, bid=coinbase_tip`.
+    /// Bid mechanism is independent of flow: `bid=coinbase_tip` only when
+    /// `TxEip8130::coinbase_tip` returns `Some` (a statically-analyzable
+    /// phase-0 coinbase tip). EIP-8130 without that, and every non-8130
+    /// transaction, uses `bid=priority_fee`.
     pub fn record_tip_per_gas(
         has_validity_predicates: bool,
-        is_eip8130: bool,
+        has_statically_analyzable_tip: bool,
         tip_per_gas: f64,
     ) {
         let flow = if has_validity_predicates { "validity" } else { "standard" };
-        let bid = if is_eip8130 { "coinbase_tip" } else { "priority_fee" };
+        let bid = if has_statically_analyzable_tip { "coinbase_tip" } else { "priority_fee" };
         Self::tip_per_gas(flow, bid).record(tip_per_gas);
     }
 }
@@ -550,36 +551,39 @@ mod tests {
             BuilderMetrics::record_tip_per_gas(false, false, 30.0);
             // Pre-8130 validity: flow=validity, bid=priority_fee.
             BuilderMetrics::record_tip_per_gas(true, false, 50.0);
-            // EIP-8130 with predicates: flow=validity, bid=coinbase_tip.
+            // EIP-8130 with predicates and a static phase-0 tip.
             BuilderMetrics::record_tip_per_gas(true, true, 80.0);
-            // EIP-8130 without predicates: flow=standard, bid=coinbase_tip.
+            // EIP-8130 without predicates, but with a static phase-0 tip.
             BuilderMetrics::record_tip_per_gas(false, true, 20.0);
+            // EIP-8130 without a statically-analyzable tip: bid=priority_fee.
+            BuilderMetrics::record_tip_per_gas(false, false, 5.0);
+            BuilderMetrics::record_tip_per_gas(true, false, 15.0);
         });
 
         let rendered = handle.render();
         assert!(
             rendered.contains(
-                "base_builder_tip_per_gas_count{bid=\"priority_fee\",flow=\"standard\"} 2"
+                "base_builder_tip_per_gas_count{bid=\"priority_fee\",flow=\"standard\"} 3"
             ),
-            "expected two standard priority-fee observations, got: {rendered}"
+            "expected three standard priority-fee observations, got: {rendered}"
         );
         assert!(
             rendered.contains(
-                "base_builder_tip_per_gas_sum{bid=\"priority_fee\",flow=\"standard\"} 40"
+                "base_builder_tip_per_gas_sum{bid=\"priority_fee\",flow=\"standard\"} 45"
             ),
-            "expected standard priority-fee sum 40, got: {rendered}"
+            "expected standard priority-fee sum 45, got: {rendered}"
         );
         assert!(
             rendered.contains(
-                "base_builder_tip_per_gas_count{bid=\"priority_fee\",flow=\"validity\"} 1"
+                "base_builder_tip_per_gas_count{bid=\"priority_fee\",flow=\"validity\"} 2"
             ),
-            "expected one pre-8130 validity observation, got: {rendered}"
+            "expected two validity priority-fee observations, got: {rendered}"
         );
         assert!(
             rendered.contains(
-                "base_builder_tip_per_gas_sum{bid=\"priority_fee\",flow=\"validity\"} 50"
+                "base_builder_tip_per_gas_sum{bid=\"priority_fee\",flow=\"validity\"} 65"
             ),
-            "expected pre-8130 validity sum 50, got: {rendered}"
+            "expected validity priority-fee sum 65, got: {rendered}"
         );
         assert!(
             rendered.contains(

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -563,49 +563,49 @@ mod tests {
         let rendered = handle.render();
         assert!(
             rendered.contains(
-                "base_builder_tip_per_gas_count{bid=\"priority_fee\",flow=\"standard\"} 3"
+                "base_builder_tip_per_gas_count{flow=\"standard\",bid=\"priority_fee\"} 3"
             ),
             "expected three standard priority-fee observations, got: {rendered}"
         );
         assert!(
             rendered.contains(
-                "base_builder_tip_per_gas_sum{bid=\"priority_fee\",flow=\"standard\"} 45"
+                "base_builder_tip_per_gas_sum{flow=\"standard\",bid=\"priority_fee\"} 45"
             ),
             "expected standard priority-fee sum 45, got: {rendered}"
         );
         assert!(
             rendered.contains(
-                "base_builder_tip_per_gas_count{bid=\"priority_fee\",flow=\"validity\"} 2"
+                "base_builder_tip_per_gas_count{flow=\"validity\",bid=\"priority_fee\"} 2"
             ),
             "expected two validity priority-fee observations, got: {rendered}"
         );
         assert!(
             rendered.contains(
-                "base_builder_tip_per_gas_sum{bid=\"priority_fee\",flow=\"validity\"} 65"
+                "base_builder_tip_per_gas_sum{flow=\"validity\",bid=\"priority_fee\"} 65"
             ),
             "expected validity priority-fee sum 65, got: {rendered}"
         );
         assert!(
             rendered.contains(
-                "base_builder_tip_per_gas_count{bid=\"coinbase_tip\",flow=\"validity\"} 1"
+                "base_builder_tip_per_gas_count{flow=\"validity\",bid=\"coinbase_tip\"} 1"
             ),
             "expected one 8130 validity observation, got: {rendered}"
         );
         assert!(
             rendered.contains(
-                "base_builder_tip_per_gas_sum{bid=\"coinbase_tip\",flow=\"validity\"} 80"
+                "base_builder_tip_per_gas_sum{flow=\"validity\",bid=\"coinbase_tip\"} 80"
             ),
             "expected 8130 validity sum 80, got: {rendered}"
         );
         assert!(
             rendered.contains(
-                "base_builder_tip_per_gas_count{bid=\"coinbase_tip\",flow=\"standard\"} 1"
+                "base_builder_tip_per_gas_count{flow=\"standard\",bid=\"coinbase_tip\"} 1"
             ),
             "expected one 8130 standard observation, got: {rendered}"
         );
         assert!(
             rendered.contains(
-                "base_builder_tip_per_gas_sum{bid=\"coinbase_tip\",flow=\"standard\"} 20"
+                "base_builder_tip_per_gas_sum{flow=\"standard\",bid=\"coinbase_tip\"} 20"
             ),
             "expected 8130 standard sum 20, got: {rendered}"
         );

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -242,6 +242,12 @@ base_metrics::define_metrics! {
     #[label(event_type)]
     #[label(reason)]
     builder_transaction_events_dropped: counter,
+    #[describe(
+        "Per-included-transaction tip per gas (the builder priority score), tagged by flow cohort and bid mechanism"
+    )]
+    #[label(name = "flow", default = ["standard", "validity"])]
+    #[label(name = "bid", default = ["coinbase_tip", "priority_fee"])]
+    tip_per_gas: histogram,
 }
 
 impl BuilderMetrics {
@@ -352,6 +358,25 @@ impl BuilderMetrics {
         for depth in index.bucket_depths() {
             Self::predicate_bucket_depth().record(depth as f64);
         }
+    }
+
+    /// Records one included transaction's tip per gas.
+    ///
+    /// The value is the builder's existing inclusion priority score
+    /// (`effective_tip_per_gas` / tip-per-gas-limit) — no execution result or
+    /// price feed is required. Observations are tagged `flow=validity` only when
+    /// the transaction carries validity predicates, otherwise `flow=standard`.
+    /// Bid mechanism is independent of flow: `bid=coinbase_tip` for EIP-8130,
+    /// `bid=priority_fee` otherwise. An 8130 transaction without predicates is
+    /// therefore `flow=standard, bid=coinbase_tip`.
+    pub fn record_tip_per_gas(
+        has_validity_predicates: bool,
+        is_eip8130: bool,
+        tip_per_gas: f64,
+    ) {
+        let flow = if has_validity_predicates { "validity" } else { "standard" };
+        let bid = if is_eip8130 { "coinbase_tip" } else { "priority_fee" };
+        Self::tip_per_gas(flow, bid).record(tip_per_gas);
     }
 }
 
@@ -512,5 +537,73 @@ mod tests {
         });
 
         assert!(!handle.render().contains("predicate_accounts_loaded_total"));
+    }
+
+    #[test]
+    fn record_tip_per_gas_tags_flow_and_bid() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+
+        metrics::with_local_recorder(&recorder, || {
+            // Standard EIP-1559: flow=standard, bid=priority_fee.
+            BuilderMetrics::record_tip_per_gas(false, false, 10.0);
+            BuilderMetrics::record_tip_per_gas(false, false, 30.0);
+            // Pre-8130 validity: flow=validity, bid=priority_fee.
+            BuilderMetrics::record_tip_per_gas(true, false, 50.0);
+            // EIP-8130 with predicates: flow=validity, bid=coinbase_tip.
+            BuilderMetrics::record_tip_per_gas(true, true, 80.0);
+            // EIP-8130 without predicates: flow=standard, bid=coinbase_tip.
+            BuilderMetrics::record_tip_per_gas(false, true, 20.0);
+        });
+
+        let rendered = handle.render();
+        assert!(
+            rendered.contains(
+                "base_builder_tip_per_gas_count{bid=\"priority_fee\",flow=\"standard\"} 2"
+            ),
+            "expected two standard priority-fee observations, got: {rendered}"
+        );
+        assert!(
+            rendered.contains(
+                "base_builder_tip_per_gas_sum{bid=\"priority_fee\",flow=\"standard\"} 40"
+            ),
+            "expected standard priority-fee sum 40, got: {rendered}"
+        );
+        assert!(
+            rendered.contains(
+                "base_builder_tip_per_gas_count{bid=\"priority_fee\",flow=\"validity\"} 1"
+            ),
+            "expected one pre-8130 validity observation, got: {rendered}"
+        );
+        assert!(
+            rendered.contains(
+                "base_builder_tip_per_gas_sum{bid=\"priority_fee\",flow=\"validity\"} 50"
+            ),
+            "expected pre-8130 validity sum 50, got: {rendered}"
+        );
+        assert!(
+            rendered.contains(
+                "base_builder_tip_per_gas_count{bid=\"coinbase_tip\",flow=\"validity\"} 1"
+            ),
+            "expected one 8130 validity observation, got: {rendered}"
+        );
+        assert!(
+            rendered.contains(
+                "base_builder_tip_per_gas_sum{bid=\"coinbase_tip\",flow=\"validity\"} 80"
+            ),
+            "expected 8130 validity sum 80, got: {rendered}"
+        );
+        assert!(
+            rendered.contains(
+                "base_builder_tip_per_gas_count{bid=\"coinbase_tip\",flow=\"standard\"} 1"
+            ),
+            "expected one 8130 standard observation, got: {rendered}"
+        );
+        assert!(
+            rendered.contains(
+                "base_builder_tip_per_gas_sum{bid=\"coinbase_tip\",flow=\"standard\"} 20"
+            ),
+            "expected 8130 standard sum 20, got: {rendered}"
+        );
     }
 }

--- a/crates/common/consensus/src/transaction/eip8130/tx.rs
+++ b/crates/common/consensus/src/transaction/eip8130/tx.rs
@@ -89,6 +89,34 @@ pub struct TxEip8130 {
 }
 
 impl TxEip8130 {
+    /// Statically-decoded phase-0 coinbase tip, if one can be recovered without
+    /// executing the transaction.
+    ///
+    /// EIP-8130 `calls` is an array of phases. Atomicity is per phase: if any
+    /// call in a phase reverts, that phase is discarded and later phases are
+    /// skipped. The bid therefore lives in **phase 0**; a tip in a later phase
+    /// is not statically meaningful.
+    ///
+    /// Protocol calls have no value field (`call = rlp([to, data])`). ETH
+    /// moves only when the account's wallet bytecode issues a `CALL`. The
+    /// statically-analyzable encoding is therefore:
+    ///
+    /// - the sender uses [`super::Eip8130Contracts::DEFAULT_ACCOUNT`]
+    ///   (auto-delegated for a code-less account, or explicitly delegated)
+    /// - phase 0 is the default account's ETH-transfer entrypoint
+    /// - invoked on the sender itself
+    /// - coinbase as recipient
+    /// - the tip as amount
+    ///
+    /// # TODO
+    /// Pin the DefaultAccount ETH-transfer selector and argument encoding
+    /// against [`super::Eip8130Contracts::DEFAULT_ACCOUNT`] and decode phase
+    /// 0. Until that static decode exists this returns [`None`].
+    pub fn coinbase_tip(&self) -> Option<U256> {
+        let _ = self;
+        None
+    }
+
     /// Encodes an `Option<Address>` as the AA wire format: zero-length byte
     /// string when `None`, 20-byte string when `Some`.
     fn encode_address_opt(addr: &Option<Address>, out: &mut dyn BufMut) {
@@ -1004,5 +1032,10 @@ mod tests {
             bare.size(),
             with_auth.size()
         );
+    }
+
+    #[test]
+    fn coinbase_tip_is_none_until_static_decode() {
+        assert_eq!(sample_tx().coinbase_tip(), None);
     }
 }

--- a/crates/common/consensus/src/transaction/eip8130/tx.rs
+++ b/crates/common/consensus/src/transaction/eip8130/tx.rs
@@ -109,10 +109,10 @@ impl TxEip8130 {
     /// - the tip as amount
     ///
     /// # TODO
-    /// Pin the DefaultAccount ETH-transfer selector and argument encoding
+    /// Pin the `DefaultAccount` ETH-transfer selector and argument encoding
     /// against [`super::Eip8130Contracts::DEFAULT_ACCOUNT`] and decode phase
     /// 0. Until that static decode exists this returns [`None`].
-    pub fn coinbase_tip(&self) -> Option<U256> {
+    pub const fn coinbase_tip(&self) -> Option<U256> {
         let _ = self;
         None
     }


### PR DESCRIPTION
## Summary
- Emit `base_builder_tip_per_gas` on each included transaction, tagged `flow=validity|standard` and `bid=coinbase_tip|priority_fee`.
- `flow=validity` only when the transaction has validity predicates; `bid=coinbase_tip` only when `TxEip8130::coinbase_tip()` returns `Some`.
- Adds a stub `TxEip8130::coinbase_tip()` (currently always `None`) for the phase-0 DefaultAccount static decode.

## Test plan
- [ ] `cargo test -p base-common-consensus coinbase_tip`
- [ ] `cargo test -p base-builder-core --lib metrics`
- [ ] Confirm Prometheus series names: `base_builder_tip_per_gas_*` with `flow` then `bid` labels