### PR TITLE
feat(deps): pin reth through tagged base/reth backports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ crates/proof/zk/programs/succinct/elf/range-elf-embedded
 crates/proof/zk/programs/succinct/elf/aggregation-elf
 crates/proof/zk/programs/succinct/elf/*.bin
 /etc/scripts/local/__pycache__/
+/.tmp/
 
 crates/infra/load-tests/examples/*.yaml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6721,7 +6721,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -6741,7 +6741,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -9763,8 +9763,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -10656,7 +10656,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -10692,7 +10692,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.59.0",
 ]
 
 [[package]]
@@ -13175,7 +13175,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -14865,7 +14865,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -14898,7 +14898,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -14911,7 +14911,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -15024,7 +15024,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.3",
  "rustls 0.23.43",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -15064,7 +15064,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -15657,7 +15657,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15684,7 +15684,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15715,7 +15715,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -15735,7 +15735,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -15748,7 +15748,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -15837,7 +15837,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -15847,7 +15847,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -15898,7 +15898,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -15915,7 +15915,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -15929,7 +15929,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15942,7 +15942,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15967,7 +15967,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -15996,7 +15996,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16022,7 +16022,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-genesis",
@@ -16052,7 +16052,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16067,7 +16067,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16092,7 +16092,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16116,7 +16116,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -16140,7 +16140,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16175,7 +16175,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16232,7 +16232,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -16259,7 +16259,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16282,7 +16282,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16309,7 +16309,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -16365,7 +16365,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16395,7 +16395,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16413,7 +16413,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -16429,7 +16429,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16453,7 +16453,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -16464,7 +16464,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -16493,7 +16493,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -16519,7 +16519,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16535,7 +16535,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16551,7 +16551,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks 0.4.7",
@@ -16565,7 +16565,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16595,7 +16595,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16609,7 +16609,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -16619,7 +16619,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -16645,7 +16645,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16665,7 +16665,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -16683,7 +16683,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -16696,7 +16696,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16715,7 +16715,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16753,7 +16753,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-test-utils"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-eips 2.4.1",
  "eyre",
@@ -16785,7 +16785,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16799,7 +16799,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "serde",
  "serde_json",
@@ -16809,7 +16809,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16835,7 +16835,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "bytes",
  "futures",
@@ -16855,7 +16855,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "bitflags 2.13.1",
  "byteorder",
@@ -16872,7 +16872,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -16881,7 +16881,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "futures",
  "libc",
@@ -16895,7 +16895,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -16904,7 +16904,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -16918,7 +16918,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16977,7 +16977,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17002,7 +17002,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -17026,7 +17026,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17041,7 +17041,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -17055,7 +17055,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -17072,7 +17072,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -17096,7 +17096,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17164,7 +17164,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17219,7 +17219,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17268,7 +17268,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17292,7 +17292,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17316,7 +17316,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "bytes",
  "eyre",
@@ -17345,7 +17345,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -17357,7 +17357,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17381,7 +17381,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -17393,7 +17393,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17416,7 +17416,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17426,7 +17426,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-rpc-types-engine",
@@ -17469,7 +17469,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -17518,7 +17518,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17545,7 +17545,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -17561,7 +17561,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17576,7 +17576,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-dyn-abi",
@@ -17652,7 +17652,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-genesis",
@@ -17682,7 +17682,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-network 2.4.1",
  "alloy-provider",
@@ -17725,7 +17725,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-evm",
@@ -17745,7 +17745,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -17776,7 +17776,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-dyn-abi",
@@ -17823,7 +17823,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -17874,7 +17874,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.2",
@@ -17888,7 +17888,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -17919,7 +17919,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17970,7 +17970,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -17998,7 +17998,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -18012,7 +18012,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -18032,7 +18032,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -18047,7 +18047,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -18073,7 +18073,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18090,7 +18090,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18117,7 +18117,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -18138,7 +18138,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18154,7 +18154,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -18164,7 +18164,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "clap",
  "eyre",
@@ -18184,7 +18184,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -18203,7 +18203,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18246,7 +18246,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18272,7 +18272,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -18299,7 +18299,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -18315,7 +18315,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -18339,7 +18339,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"
+source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -22786,7 +22786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f7c95348f20c1c913d72157b3c6dee6ea3e30b3d19502c5a7f6d3f160dacbf"
 dependencies = [
  "cc",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -23691,7 +23691,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6721,7 +6721,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -6741,7 +6741,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -9763,8 +9763,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -10656,7 +10656,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -10692,7 +10692,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.59.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -13175,7 +13175,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -14865,7 +14865,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -14898,7 +14898,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -14911,7 +14911,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -15024,7 +15024,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.3",
  "rustls 0.23.43",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -15064,7 +15064,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -15657,7 +15657,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15684,7 +15684,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15715,7 +15715,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -15735,7 +15735,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -15748,7 +15748,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -15837,7 +15837,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -15847,7 +15847,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -15898,7 +15898,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -15915,7 +15915,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -15929,7 +15929,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15942,7 +15942,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15967,7 +15967,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -15996,7 +15996,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16022,7 +16022,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-genesis",
@@ -16052,7 +16052,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16067,7 +16067,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16092,7 +16092,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16116,7 +16116,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -16140,7 +16140,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16175,7 +16175,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16232,7 +16232,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -16259,7 +16259,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16282,7 +16282,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16309,7 +16309,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -16365,7 +16365,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16395,7 +16395,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16413,7 +16413,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -16429,7 +16429,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16453,7 +16453,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -16464,7 +16464,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -16493,7 +16493,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -16519,7 +16519,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16535,7 +16535,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16551,7 +16551,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks 0.4.7",
@@ -16565,7 +16565,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16595,7 +16595,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16609,7 +16609,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -16619,7 +16619,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -16645,7 +16645,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16665,7 +16665,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -16683,7 +16683,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -16696,7 +16696,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16715,7 +16715,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16753,7 +16753,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-test-utils"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-eips 2.4.1",
  "eyre",
@@ -16785,7 +16785,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16799,7 +16799,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "serde",
  "serde_json",
@@ -16809,7 +16809,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16835,7 +16835,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "bytes",
  "futures",
@@ -16855,7 +16855,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "bitflags 2.13.1",
  "byteorder",
@@ -16872,7 +16872,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -16881,7 +16881,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "futures",
  "libc",
@@ -16895,7 +16895,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -16904,7 +16904,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -16918,7 +16918,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16977,7 +16977,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17002,7 +17002,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -17026,7 +17026,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17041,7 +17041,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -17055,7 +17055,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -17072,7 +17072,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -17096,7 +17096,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17164,7 +17164,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17219,7 +17219,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17268,7 +17268,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17292,7 +17292,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17316,7 +17316,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "bytes",
  "eyre",
@@ -17345,7 +17345,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -17357,7 +17357,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17381,7 +17381,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -17393,7 +17393,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17416,7 +17416,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17426,7 +17426,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-rpc-types-engine",
@@ -17469,7 +17469,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -17518,7 +17518,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17545,7 +17545,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -17561,7 +17561,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17576,7 +17576,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-dyn-abi",
@@ -17652,7 +17652,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-genesis",
@@ -17682,7 +17682,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-network 2.4.1",
  "alloy-provider",
@@ -17725,7 +17725,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-evm",
@@ -17745,7 +17745,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -17776,7 +17776,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-dyn-abi",
@@ -17823,7 +17823,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -17874,7 +17874,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.2",
@@ -17888,7 +17888,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -17919,7 +17919,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17970,7 +17970,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -17998,7 +17998,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -18012,7 +18012,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -18032,7 +18032,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -18047,7 +18047,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -18073,7 +18073,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18090,7 +18090,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18117,7 +18117,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -18138,7 +18138,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18154,7 +18154,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -18164,7 +18164,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "clap",
  "eyre",
@@ -18184,7 +18184,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -18203,7 +18203,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18246,7 +18246,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18272,7 +18272,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -18299,7 +18299,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -18315,7 +18315,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -18339,7 +18339,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=v2.5.1-base.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -22786,7 +22786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f7c95348f20c1c913d72157b3c6dee6ea3e30b3d19502c5a7f6d3f160dacbf"
 dependencies = [
  "cc",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -23691,7 +23691,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,72 +315,72 @@ alloy-network-primitives = { version = "2.3.0", default-features = false }
 reth-zstd-compressors = { version = "0.6.0", default-features = false }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
 reth-codecs = { version = "0.6.0", default-features = false, features = ["alloy"] }
-reth-db = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-cli = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-ipc = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-evm = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-rpc = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-revm = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-trie = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-exex = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-tasks = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-ecies = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-db-api = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-discv4 = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-discv5 = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-trie-db = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-rpc-api = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-network = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-net-nat = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-tracing = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-eth-wire = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-provider = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-cli-util = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-node-api = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-db-common = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-rpc-layer = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-node-core = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-consensus = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-chainspec = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-cli-runner = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-rpc-convert = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-network-api = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-network-p2p = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-storage-api = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-rpc-eth-api = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-chain-state = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-trie-common = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-payload-util = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-node-builder = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-node-metrics = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-cli-commands = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-evm-ethereum = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-tracing-otlp = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-testing-utils = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-rpc-eth-types = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-network-peers = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-node-ethereum = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-rpc-engine-api = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-e2e-test-utils = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-eth-wire-types = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-payload-builder = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-execution-types = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-execution-cache = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-exex-test-utils = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-rpc-server-types = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-transaction-pool = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-execution-errors = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-payload-validator = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-payload-primitives = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-ethereum-primitives = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-basic-payload-builder = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-payload-builder-primitives = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
-reth-prune-types = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1", default-features = false }
-reth-stages-types = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1", default-features = false }
-reth-storage-errors = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1", default-features = false }
-reth-ethereum-forks = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1", default-features = false }
-reth-consensus-common = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1", default-features = false }
-reth-trie-parallel = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-db = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-cli = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-ipc = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-evm = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-rpc = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-revm = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-trie = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-exex = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-tasks = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-ecies = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-db-api = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-discv4 = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-discv5 = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-trie-db = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-rpc-api = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-network = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-net-nat = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-tracing = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-eth-wire = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-provider = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-cli-util = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-node-api = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-db-common = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-rpc-layer = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-node-core = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-consensus = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-chainspec = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-cli-runner = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-rpc-convert = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-network-api = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-network-p2p = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-storage-api = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-rpc-eth-api = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-chain-state = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-trie-common = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-payload-util = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-node-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-node-metrics = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-cli-commands = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-evm-ethereum = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-tracing-otlp = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-testing-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-rpc-eth-types = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-network-peers = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-node-ethereum = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-rpc-engine-api = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-e2e-test-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-eth-wire-types = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-payload-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-execution-types = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-execution-cache = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-exex-test-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-rpc-server-types = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-transaction-pool = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-execution-errors = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-payload-validator = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-payload-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-ethereum-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-basic-payload-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-payload-builder-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-prune-types = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1", default-features = false }
+reth-stages-types = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1", default-features = false }
+reth-storage-errors = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1", default-features = false }
+reth-ethereum-forks = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1", default-features = false }
+reth-consensus-common = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1", default-features = false }
+reth-trie-parallel = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
 
 # tokio
 tokio = "1.53.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,72 +315,72 @@ alloy-network-primitives = { version = "2.3.0", default-features = false }
 reth-zstd-compressors = { version = "0.6.0", default-features = false }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
 reth-codecs = { version = "0.6.0", default-features = false, features = ["alloy"] }
-reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-ipc = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-exex = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-ecies = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-discv4 = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-network = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-net-nat = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-eth-wire = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-db-common = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-rpc-layer = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-chain-state = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-payload-util = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-tracing-otlp = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-testing-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-exex-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1", default-features = false }
-reth-stages-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1", default-features = false }
-reth-storage-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1", default-features = false }
-reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1", default-features = false }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1", default-features = false }
-reth-trie-parallel = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-db = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-cli = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-ipc = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-evm = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-rpc = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-revm = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-trie = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-exex = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-tasks = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-ecies = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-db-api = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-discv4 = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-discv5 = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-trie-db = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-rpc-api = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-network = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-net-nat = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-tracing = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-eth-wire = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-provider = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-cli-util = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-node-api = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-db-common = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-rpc-layer = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-node-core = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-consensus = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-chainspec = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-cli-runner = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-rpc-convert = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-network-api = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-network-p2p = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-storage-api = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-rpc-eth-api = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-chain-state = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-trie-common = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-payload-util = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-node-builder = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-node-metrics = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-cli-commands = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-evm-ethereum = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-tracing-otlp = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-testing-utils = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-rpc-eth-types = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-network-peers = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-node-ethereum = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-rpc-engine-api = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-e2e-test-utils = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-eth-wire-types = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-payload-builder = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-execution-types = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-execution-cache = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-exex-test-utils = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-rpc-server-types = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-transaction-pool = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-execution-errors = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-payload-validator = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-payload-primitives = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-ethereum-primitives = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-basic-payload-builder = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-payload-builder-primitives = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
+reth-prune-types = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1", default-features = false }
+reth-stages-types = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1", default-features = false }
+reth-storage-errors = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1", default-features = false }
+reth-ethereum-forks = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1", default-features = false }
+reth-consensus-common = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1", default-features = false }
+reth-trie-parallel = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }
 
 # tokio
 tokio = "1.53.1"

--- a/Justfile
+++ b/Justfile
@@ -146,6 +146,27 @@ test-affected-ci base="main": install-nextest build::contracts
 hack:
     cargo hack check --feature-powerset --no-dev-deps
 
+# Apply etc/upstream-pins/reth.toml to every git-based reth-* workspace dep.
+# Workflow and limitations: etc/upstream-pins/README.md
+pin-reth:
+    python3 etc/scripts/local/pin-reth.py apply
+
+# Verify Cargo.toml and Cargo.lock match etc/upstream-pins/reth.toml
+check-reth-pin:
+    python3 etc/scripts/local/pin-reth.py check
+
+# Run unit tests for the Reth pin and release helpers
+pin-reth-test:
+    python3 etc/scripts/local/pin-reth.py test
+
+# Squash GitHub PRs (upstream or base/reth) onto an official tag, publish the fork tag, and pin it
+reth-prepare-release *args:
+    python3 etc/scripts/local/pin-reth.py prepare {{ args }}
+
+# Retarget the pin at an official Reth release that contains the carried *upstream* PRs
+reth-drop-pin *args:
+    python3 etc/scripts/local/pin-reth.py drop {{ args }}
+
 # Fixes any formatting issues
 format-fix:
     BASE_SUCCINCT_ELF_STUB=1 cargo fix --allow-dirty --allow-staged --workspace

--- a/Justfile
+++ b/Justfile
@@ -147,7 +147,7 @@ hack:
     cargo hack check --feature-powerset --no-dev-deps
 
 # Apply etc/upstream-pins/reth.toml to every git-based reth-* workspace dep.
-# Workflow and limitations: etc/upstream-pins/README.md
+# Workflow: etc/upstream-pins/README.md
 pin-reth:
     python3 etc/scripts/local/pin-reth.py apply
 
@@ -159,13 +159,9 @@ check-reth-pin:
 pin-reth-test:
     python3 etc/scripts/local/pin-reth.py test
 
-# Squash GitHub PRs (upstream or base/reth) onto an official tag, publish the fork tag, and pin it
+# Squash GitHub PRs onto an official tag, publish the fork tag, and pin it
 reth-prepare-release *args:
     python3 etc/scripts/local/pin-reth.py prepare {{ args }}
-
-# Retarget the pin at an official Reth release that contains the carried *upstream* PRs
-reth-drop-pin *args:
-    python3 etc/scripts/local/pin-reth.py drop {{ args }}
 
 # Fixes any formatting issues
 format-fix:

--- a/deny.toml
+++ b/deny.toml
@@ -257,6 +257,7 @@ unknown-git = "deny"
 # Allow git sources from known upstream repositories
 allow-git = [
     "https://github.com/paradigmxyz/reth",
+    "https://github.com/base/reth",
     "https://github.com/op-rs/op-reth",
     "https://github.com/ethereum-optimism/optimism",
 ]

--- a/etc/just/check.just
+++ b/etc/just/check.just
@@ -57,6 +57,10 @@ no-std-proof:
 crate-deps:
     {{justfile_directory()}}/etc/scripts/ci/check-crate-deps.sh
 
+# Verifies git-based reth-* workspace deps match etc/upstream-pins/reth.toml
+reth-pin:
+    python3 {{justfile_directory()}}/etc/scripts/local/pin-reth.py check
+
 [private]
 _build-contracts:
     cd {{justfile_directory()}}/crates/utilities/test-utils/contracts && forge soldeer install && forge build

--- a/etc/scripts/local/pin-reth.py
+++ b/etc/scripts/local/pin-reth.py
@@ -1,0 +1,928 @@
+#!/usr/bin/env python3
+"""Apply and verify the workspace Reth git pin.
+
+Reads `etc/upstream-pins/reth.toml` and keeps every git-based `reth-*`
+workspace dependency on one repository and one ref. Carried backports are
+whole GitHub PRs (upstream or the Base fork), each squashed to one fork
+commit. Crates.io Reth crates (`reth-codecs`, `reth-primitives-traits`,
+`reth-zstd-compressors`, …) are left unchanged.
+
+See `etc/upstream-pins/README.md` for the workflow and limitations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import tomllib
+import unittest
+from dataclasses import dataclass, field
+from pathlib import Path
+from urllib.parse import urlparse
+
+MANIFEST_REL = Path("etc/upstream-pins/reth.toml")
+CARGO_TOML = Path("Cargo.toml")
+CARGO_LOCK = Path("Cargo.lock")
+WORKSPACE_DEPS_HEADER = "[workspace.dependencies]"
+FULL_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+SHORT_SHA_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
+RETH_CRATE_RE = re.compile(r"^reth(?:-[A-Za-z0-9-]+)?$")
+GITHUB_PR_URL_RE = re.compile(
+    r"^https://github\.com/[^/]+/[^/]+/pull/\d+$",
+    re.IGNORECASE,
+)
+GIT_DEP_RE = re.compile(
+    r"^(?P<name>reth(?:-[A-Za-z0-9-]+)?)\s*=\s*\{\s*"
+    r'git\s*=\s*"(?P<git>[^"]+)"\s*,\s*'
+    r"(?P<kind>rev|tag)\s*=\s*\"(?P<value>[^\"]+)\""
+    r"(?P<rest>.*)$"
+)
+TOP_LEVEL_REV_RE = re.compile(r'(?m)^rev\s*=\s*"[0-9a-fA-F]*"')
+LOCK_SOURCE_RE = re.compile(
+    r'^source = "git\+(?P<url>[^"?#]+)(?:\?(?P<query>[^"#]*))?(?:#(?P<sha>[0-9a-fA-F]+))?"\s*$'
+)
+
+
+class PinError(RuntimeError):
+    """Raised when the Reth pin is invalid or cannot be applied."""
+
+
+@dataclass(frozen=True)
+class Patch:
+    """One GitHub PR squashed onto `upstream_base`.
+
+    `pr` is the full pull URL, including the repository: paradigmxyz/reth for
+    upstream backports, or the Base fork for patches that must not be opened
+    upstream. `head` is the PR tip (or merge commit) that the squash used.
+    """
+
+    pr: str
+    head: str
+
+
+@dataclass(frozen=True)
+class ResolvedPatch:
+    """A previously carried upstream PR that an official release now contains.
+
+    Do not record a base/reth PR here against an upstream tag. Those patches
+    never land in paradigmxyz/reth.
+    """
+
+    pr: str
+    release: str
+
+
+@dataclass(frozen=True)
+class UpstreamBase:
+    """Official Reth tag the pin is based on."""
+
+    tag: str
+    rev: str
+
+
+@dataclass
+class Pin:
+    """Parsed `etc/upstream-pins/reth.toml`."""
+
+    repository: str
+    reference: str
+    rev: str
+    upstream_base: UpstreamBase
+    patches: list[Patch] = field(default_factory=list)
+    resolved: list[ResolvedPatch] = field(default_factory=list)
+    raw: str = ""
+
+
+@dataclass(frozen=True)
+class GitDep:
+    """One git-based `reth-*` workspace dependency line."""
+
+    name: str
+    git: str
+    kind: str
+    value: str
+    rest: str
+    line: str
+
+
+def repo_root_from(start: Path | None = None) -> Path:
+    """Return the workspace root that contains the pin manifest."""
+    if start is not None:
+        return start.resolve()
+    return Path(__file__).resolve().parents[3]
+
+
+def normalize_git_url(url: str) -> str:
+    """Strip trailing slashes and a `.git` suffix for comparison."""
+    parsed = urlparse(url.strip())
+    path = parsed.path.rstrip("/")
+    if path.endswith(".git"):
+        path = path[: -len(".git")]
+    host = (parsed.netloc or "").lower()
+    return f"{parsed.scheme}://{host}{path}"
+
+
+def is_full_sha(value: str) -> bool:
+    """Return True when `value` is a 40-character hex SHA."""
+    return bool(FULL_SHA_RE.fullmatch(value))
+
+
+def cargo_ref(pin: Pin) -> tuple[str, str]:
+    """Return the Cargo.toml (`kind`, `value`) pair for this pin.
+
+    Official and fork tags stay as `tag =` so the manifest is self-documenting.
+    A raw SHA reference is written as `rev =`.
+    """
+    if is_full_sha(pin.reference):
+        return "rev", pin.rev
+    return "tag", pin.reference
+
+
+def load_pin(path: Path) -> Pin:
+    """Parse the pin manifest from disk."""
+    return parse_pin(path.read_text(encoding="utf-8"), path)
+
+
+def parse_pin(raw: str, path: Path) -> Pin:
+    """Parse a pin manifest from a TOML string."""
+    data = tomllib.loads(raw)
+    repository = data.get("repository")
+    reference = data.get("reference")
+    rev = data.get("rev")
+    if not isinstance(repository, str) or not repository:
+        raise PinError(f"{path}: missing string `repository`")
+    if not isinstance(reference, str) or not reference:
+        raise PinError(f"{path}: missing string `reference`")
+    if not isinstance(rev, str) or not is_full_sha(rev):
+        raise PinError(f"{path}: `rev` must be a 40-character commit SHA")
+    rev = rev.lower()
+    if is_full_sha(reference) and reference.lower() != rev:
+        raise PinError(f"{path}: `reference` SHA does not match `rev`")
+
+    base_data = data.get("upstream_base")
+    if not isinstance(base_data, dict):
+        raise PinError(f"{path}: missing `[upstream_base]`")
+    base_tag = base_data.get("tag")
+    base_rev = base_data.get("rev")
+    if not isinstance(base_tag, str) or not base_tag:
+        raise PinError(f"{path}: `[upstream_base].tag` is required")
+    if not isinstance(base_rev, str) or not is_full_sha(base_rev):
+        raise PinError(f"{path}: `[upstream_base].rev` must be a 40-character SHA")
+
+    patches: list[Patch] = []
+    seen_prs: set[str] = set()
+    for entry in data.get("patches") or []:
+        if not isinstance(entry, dict):
+            raise PinError(f"{path}: `[[patches]]` entries must be tables")
+        if "commit" in entry:
+            raise PinError(
+                f"{path}: `[[patches]]` records a whole PR squashed onto the "
+                "fork. Set `head` to the PR tip or merge commit; do not use "
+                "`commit` (that form only described single-commit PRs)"
+            )
+        pr = entry.get("pr")
+        head = entry.get("head")
+        if not isinstance(pr, str) or not pr:
+            raise PinError(f"{path}: `[[patches]].pr` is required")
+        pr = pr.rstrip("/")
+        if not GITHUB_PR_URL_RE.fullmatch(pr):
+            raise PinError(
+                f"{path}: `[[patches]].pr` must be a GitHub pull URL so the "
+                "repository is part of the identity (paradigmxyz/reth or "
+                "base/reth). Do not use a bare number."
+            )
+        if pr in seen_prs:
+            raise PinError(f"{path}: duplicate `[[patches]]` PR {pr}")
+        if not isinstance(head, str) or not SHORT_SHA_RE.fullmatch(head):
+            raise PinError(
+                f"{path}: `[[patches]].head` must be the PR tip or merge "
+                "commit SHA that was squashed"
+            )
+        seen_prs.add(pr)
+        patches.append(Patch(pr=pr, head=head.lower()))
+
+    resolved: list[ResolvedPatch] = []
+    seen_resolved: set[str] = set()
+    for entry in data.get("resolved") or []:
+        if not isinstance(entry, dict):
+            raise PinError(f"{path}: `[[resolved]]` entries must be tables")
+        pr = entry.get("pr")
+        release = entry.get("release")
+        if not isinstance(pr, str) or not pr:
+            raise PinError(f"{path}: `[[resolved]].pr` is required")
+        pr = pr.rstrip("/")
+        if not GITHUB_PR_URL_RE.fullmatch(pr):
+            raise PinError(
+                f"{path}: `[[resolved]].pr` must be a GitHub pull URL so the "
+                "repository is part of the identity"
+            )
+        if pr in seen_resolved:
+            raise PinError(f"{path}: duplicate `[[resolved]]` PR {pr}")
+        if not isinstance(release, str) or not release:
+            raise PinError(f"{path}: `[[resolved]].release` is required")
+        seen_resolved.add(pr)
+        resolved.append(ResolvedPatch(pr=pr, release=release))
+
+    return Pin(
+        repository=repository.rstrip("/"),
+        reference=reference,
+        rev=rev,
+        upstream_base=UpstreamBase(tag=base_tag, rev=base_rev.lower()),
+        patches=patches,
+        resolved=resolved,
+        raw=raw,
+    )
+
+
+def set_top_level_rev(raw: str, rev: str) -> str:
+    """Replace the top-level `rev` field without touching `[[patches]]`."""
+    updated, count = TOP_LEVEL_REV_RE.subn(f'rev = "{rev}"', raw, count=1)
+    if count != 1:
+        raise PinError("could not update top-level `rev` in the pin manifest")
+    return updated
+
+
+def workspace_deps_span(text: str) -> tuple[int, int]:
+    """Return the `[workspace.dependencies]` byte range."""
+    start = text.find(WORKSPACE_DEPS_HEADER)
+    if start < 0:
+        raise PinError("Cargo.toml is missing [workspace.dependencies]")
+    rest = text[start + len(WORKSPACE_DEPS_HEADER) :]
+    nxt = re.search(r"(?m)^\[", rest)
+    if nxt is None:
+        return start, len(text)
+    return start, start + len(WORKSPACE_DEPS_HEADER) + nxt.start()
+
+
+def parse_git_deps(cargo_toml: str) -> list[GitDep]:
+    """Return git-based `reth-*` entries from `[workspace.dependencies]`."""
+    start, end = workspace_deps_span(cargo_toml)
+    section = cargo_toml[start:end]
+    deps: list[GitDep] = []
+    for line in section.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        name = stripped.split("=", 1)[0].strip()
+        if not RETH_CRATE_RE.fullmatch(name):
+            continue
+        if "version" in stripped and "git" not in stripped:
+            continue
+        match = GIT_DEP_RE.match(stripped)
+        if match is None:
+            raise PinError(
+                f"workspace dependency `{name}` looks like a Reth crate but is "
+                "not a git `rev`/`tag` pin; crates.io Reth crates must use "
+                "`version =` with no `git`"
+            )
+        deps.append(
+            GitDep(
+                name=match.group("name"),
+                git=match.group("git"),
+                kind=match.group("kind"),
+                value=match.group("value"),
+                rest=match.group("rest"),
+                line=line,
+            )
+        )
+    if not deps:
+        raise PinError("no git-based `reth-*` workspace dependencies found")
+    return deps
+
+
+def require_uniform_git_deps(deps: list[GitDep]) -> GitDep:
+    """Fail when git Reth deps do not all share one repository and ref."""
+    urls = {normalize_git_url(dep.git) for dep in deps}
+    refs = {(dep.kind, dep.value) for dep in deps}
+    if len(urls) != 1 or len(refs) != 1:
+        details = ", ".join(f"{dep.name}={dep.kind}:{dep.value}@{dep.git}" for dep in deps)
+        raise PinError(f"mixed Reth git pins; all git `reth-*` crates must match: {details}")
+    return deps[0]
+
+
+def rewrite_git_deps(cargo_toml: str, pin: Pin) -> str:
+    """Rewrite every git `reth-*` workspace dep to `pin`."""
+    deps = parse_git_deps(cargo_toml)
+    require_uniform_git_deps(deps)
+    kind, value = cargo_ref(pin)
+    start, end = workspace_deps_span(cargo_toml)
+    section = cargo_toml[start:end]
+    lines: list[str] = []
+    for line in section.splitlines(keepends=True):
+        stripped = line.rstrip("\n")
+        newline = "\n" if line.endswith("\n") else ""
+        match = GIT_DEP_RE.match(stripped.strip())
+        if match is None:
+            lines.append(line)
+            continue
+        rest = match.group("rest")
+        new = (
+            f'{match.group("name")} = {{ git = "{pin.repository}", '
+            f'{kind} = "{value}"{rest}'
+        )
+        indent = stripped[: len(stripped) - len(stripped.lstrip())]
+        lines.append(f"{indent}{new}{newline}")
+    return cargo_toml[:start] + "".join(lines) + cargo_toml[end:]
+
+
+def lockfile_reth_sources(lockfile: str) -> list[tuple[str, str, str]]:
+    """Return `(url, query, sha)` for every git source whose path ends in `/reth`."""
+    found: list[tuple[str, str, str]] = []
+    for line in lockfile.splitlines():
+        match = LOCK_SOURCE_RE.match(line)
+        if match is None:
+            continue
+        url = match.group("url")
+        if not normalize_git_url(url).endswith("/reth"):
+            continue
+        found.append((url, match.group("query") or "", (match.group("sha") or "").lower()))
+    return found
+
+
+def verify_lockfile(lockfile: str, pin: Pin) -> None:
+    """Require every Reth git lock source to match `pin`."""
+    sources = lockfile_reth_sources(lockfile)
+    if not sources:
+        raise PinError("Cargo.lock has no git sources for a `/reth` repository")
+    kind, value = cargo_ref(pin)
+    expected_query = f"{kind}={value}"
+    expected_url = normalize_git_url(pin.repository)
+    for url, query, sha in sources:
+        if normalize_git_url(url) != expected_url:
+            raise PinError(
+                f"Cargo.lock still has Reth git source {url}; expected {pin.repository}"
+            )
+        if sha != pin.rev:
+            raise PinError(
+                f"Cargo.lock Reth git SHA is {sha or '<missing>'}; expected {pin.rev}"
+            )
+        if query != expected_query:
+            raise PinError(
+                f"Cargo.lock Reth git query is `{query}`; expected `{expected_query}`"
+            )
+
+
+def verify_cargo_toml(deps: list[GitDep], pin: Pin) -> None:
+    """Require workspace git Reth deps to match `pin`."""
+    sample = require_uniform_git_deps(deps)
+    if normalize_git_url(sample.git) != normalize_git_url(pin.repository):
+        raise PinError(
+            f"Cargo.toml pins {sample.git}; manifest repository is {pin.repository}"
+        )
+    kind, value = cargo_ref(pin)
+    if sample.kind != kind or sample.value != value:
+        raise PinError(
+            f"Cargo.toml pins {sample.kind} = {sample.value}; "
+            f"manifest wants {kind} = {value}"
+        )
+
+
+def commit_from_ls_remote(output: str, reference: str) -> str:
+    """Return the commit SHA for `reference` from `git ls-remote` output.
+
+    Annotated tags list the tag object at `refs/tags/<name>` and the commit at
+    `refs/tags/<name>^{}`. Prefer the peeled commit.
+    """
+    peeled: dict[str, str] = {}
+    plain: dict[str, str] = {}
+    for line in output.splitlines():
+        if not line.strip():
+            continue
+        sha, _, ref = line.partition("\t")
+        sha = sha.lower()
+        if ref.endswith("^{}"):
+            peeled[ref[: -len("^{}")]] = sha
+        else:
+            plain[ref] = sha
+    tag_ref = f"refs/tags/{reference}"
+    head_ref = f"refs/heads/{reference}"
+    if tag_ref in peeled:
+        return peeled[tag_ref]
+    if tag_ref in plain:
+        return plain[tag_ref]
+    if head_ref in plain:
+        return plain[head_ref]
+    if reference in plain:
+        return plain[reference]
+    if len(peeled) == 1:
+        return next(iter(peeled.values()))
+    if len(plain) == 1:
+        return next(iter(plain.values()))
+    raise PinError(f"could not resolve {reference}")
+
+
+def resolve_reference(repository: str, reference: str) -> str:
+    """Resolve `reference` to a full commit SHA with `git ls-remote`."""
+    if is_full_sha(reference):
+        return reference.lower()
+    result = subprocess.run(
+        [
+            "git",
+            "ls-remote",
+            repository,
+            f"refs/tags/{reference}",
+            f"refs/tags/{reference}^{{}}",
+            f"refs/heads/{reference}",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise PinError(
+            f"git ls-remote {repository} {reference} failed: {result.stderr.strip()}"
+        )
+    try:
+        return commit_from_ls_remote(result.stdout, reference)
+    except PinError as exc:
+        raise PinError(f"could not resolve {reference} on {repository}") from exc
+
+
+def previous_pin(root: Path) -> Pin | None:
+    """Load the last committed pin manifest, if any."""
+    result = subprocess.run(
+        ["git", "show", f"HEAD:{MANIFEST_REL.as_posix()}"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return parse_pin(result.stdout, MANIFEST_REL)
+
+
+def assert_patches_not_dropped(old: Pin, new: Pin) -> None:
+    """Fail when a carried PR disappears without a `[[resolved]]` entry."""
+    new_prs = {patch.pr for patch in new.patches}
+    resolved_prs = {item.pr for item in new.resolved}
+    dropped = [
+        patch
+        for patch in old.patches
+        if patch.pr not in new_prs and patch.pr not in resolved_prs
+    ]
+    if dropped:
+        details = ", ".join(patch.pr for patch in dropped)
+        raise PinError(
+            "carried PR removed without `[[resolved]]`: "
+            f"{details}. Upstream PRs record the official Reth tag that "
+            "contains them. Do not resolve a base/reth PR against an "
+            "upstream tag."
+        )
+
+
+def run_cargo(root: Path, args: list[str]) -> None:
+    """Run a cargo command at `root` and surface stderr on failure."""
+    result = subprocess.run(args, cwd=root, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        output = (result.stderr or result.stdout).strip()
+        raise PinError(f"`{' '.join(args)}` failed:\n{output}")
+
+
+def update_lockfile(root: Path, deps: list[GitDep]) -> None:
+    """Refresh Cargo.lock from any git-based Reth workspace crate."""
+    names = {dep.name for dep in deps}
+    package = "reth-chainspec" if "reth-chainspec" in names else deps[0].name
+    run_cargo(root, ["cargo", "update", "-p", package])
+
+
+def write_if_changed(path: Path, contents: str) -> bool:
+    """Write `contents` when they differ from the file on disk."""
+    current = path.read_text(encoding="utf-8") if path.exists() else None
+    if current == contents:
+        return False
+    path.write_text(contents, encoding="utf-8")
+    return True
+
+
+def apply_pin(root: Path, *, skip_lock: bool, offline: bool) -> None:
+    """Resolve, rewrite, and optionally refresh the lockfile."""
+    manifest_path = root / MANIFEST_REL
+    pin = load_pin(manifest_path)
+    old = previous_pin(root)
+    if old is not None:
+        assert_patches_not_dropped(old, pin)
+
+    if not offline:
+        resolved = resolve_reference(pin.repository, pin.reference)
+        if resolved != pin.rev:
+            pin.raw = set_top_level_rev(pin.raw, resolved)
+            pin.rev = resolved
+            write_if_changed(manifest_path, pin.raw)
+            print(f"updated {MANIFEST_REL} rev = {resolved}")
+
+    cargo_path = root / CARGO_TOML
+    cargo_toml = cargo_path.read_text(encoding="utf-8")
+    rewritten = rewrite_git_deps(cargo_toml, pin)
+    cargo_changed = write_if_changed(cargo_path, rewritten)
+    deps = parse_git_deps(rewritten)
+    if cargo_changed:
+        print(f"updated {len(deps)} git `reth-*` workspace dependencies")
+    else:
+        print(f"{CARGO_TOML} already matches {MANIFEST_REL}")
+
+    if skip_lock:
+        return
+    if cargo_changed:
+        update_lockfile(root, deps)
+    run_cargo(root, ["cargo", "metadata", "--format-version", "1", "--no-deps", "--locked"])
+    verify_lockfile((root / CARGO_LOCK).read_text(encoding="utf-8"), pin)
+    print(f"Reth pin is {pin.repository} {cargo_ref(pin)[0]}={cargo_ref(pin)[1]} ({pin.rev})")
+
+
+def check_pin(root: Path, *, skip_lock: bool, offline: bool) -> None:
+    """Verify the working tree matches the pin manifest."""
+    manifest_path = root / MANIFEST_REL
+    pin = load_pin(manifest_path)
+    old = previous_pin(root)
+    if old is not None:
+        assert_patches_not_dropped(old, pin)
+
+    if not offline:
+        resolved = resolve_reference(pin.repository, pin.reference)
+        if resolved != pin.rev:
+            raise PinError(
+                f"`reference` {pin.reference} resolves to {resolved}, "
+                f"but `rev` is {pin.rev}"
+            )
+
+    cargo_toml = (root / CARGO_TOML).read_text(encoding="utf-8")
+    deps = parse_git_deps(cargo_toml)
+    verify_cargo_toml(deps, pin)
+    if skip_lock:
+        print(f"{CARGO_TOML} matches {MANIFEST_REL} ({len(deps)} git `reth-*` crates)")
+        return
+    run_cargo(root, ["cargo", "metadata", "--format-version", "1", "--no-deps", "--locked"])
+    verify_lockfile((root / CARGO_LOCK).read_text(encoding="utf-8"), pin)
+    print(
+        f"Reth pin OK: {len(deps)} git crates -> {pin.repository} "
+        f"{cargo_ref(pin)[0]}={cargo_ref(pin)[1]} ({pin.rev})"
+    )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        help="workspace root (default: inferred from this script)",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="alias for the `check` command",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    apply_p = sub.add_parser("apply", help="rewrite workspace git deps from the manifest")
+    apply_p.add_argument("--skip-lock", action="store_true")
+    apply_p.add_argument("--offline", action="store_true")
+
+    check_p = sub.add_parser("check", help="verify Cargo.toml and Cargo.lock match the manifest")
+    check_p.add_argument("--skip-lock", action="store_true")
+    check_p.add_argument("--offline", action="store_true")
+
+    sub.add_parser("test", help="run unit tests")
+
+    prepare_p = sub.add_parser(
+        "prepare",
+        help="squash GitHub PRs onto a Reth tag, publish the fork tag, and pin it",
+    )
+    prepare_p.add_argument("--upstream", required=True, help="official Reth tag, for example v2.5.1")
+    prepare_p.add_argument(
+        "--pr",
+        action="append",
+        required=True,
+        help=(
+            "PR number on --upstream-repo, or a GitHub pull URL on that repo "
+            "or --fork (repeatable). Use a base/reth URL for Base-specific "
+            "patches instead of opening them upstream."
+        ),
+    )
+    prepare_p.add_argument("--line", help="consumer line, for example v1.3.0")
+    prepare_p.add_argument("--fork", default="https://github.com/base/reth")
+    prepare_p.add_argument("--upstream-repo", default="https://github.com/paradigmxyz/reth")
+    prepare_p.add_argument("--dry-run", action="store_true")
+    prepare_p.add_argument("--skip-push", action="store_true")
+    prepare_p.add_argument("--skip-lock", action="store_true")
+    prepare_p.add_argument("--no-commit", action="store_true")
+    prepare_p.add_argument("--no-pr", action="store_true")
+    prepare_p.add_argument("--base-branch", help="base/base PR target; pin commit is created from origin/<this> (default: releases/<line> or main)")
+
+    drop_p = sub.add_parser(
+        "drop",
+        help="retarget the pin at an official Reth release (upstream PRs only)",
+    )
+    drop_p.add_argument("--release", required=True, help="official Reth tag that contains the carried PRs")
+    drop_p.add_argument("--upstream-repo", default="https://github.com/paradigmxyz/reth")
+    drop_p.add_argument("--skip-lock", action="store_true")
+    drop_p.add_argument("--dry-run", action="store_true")
+    drop_p.add_argument("--no-commit", action="store_true")
+    drop_p.add_argument("--no-pr", action="store_true")
+    drop_p.add_argument("--skip-push", action="store_true")
+    drop_p.add_argument("--base-branch", help="base/base PR target; pin commit is created from origin/<this> (default: main)")
+
+    args = parser.parse_args(argv)
+    if args.check:
+        args.command = "check"
+    if not args.command:
+        args.command = "apply"
+    return args
+
+
+def load_release_mod():
+    """Load the sibling release helper."""
+    script_dir = str(Path(__file__).resolve().parent)
+    if script_dir not in sys.path:
+        sys.path.insert(0, script_dir)
+    import reth_release
+
+    return reth_release
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+    args = parse_args(argv)
+    command = args.command
+    if command == "test":
+        return run_tests()
+    root = repo_root_from(args.repo_root)
+    skip_lock = bool(getattr(args, "skip_lock", False))
+    offline = bool(getattr(args, "offline", False))
+    try:
+        if command in {"prepare", "drop"}:
+            release = load_release_mod()
+            try:
+                if command == "prepare":
+                    release.prepare_release(
+                        root,
+                        upstream_tag=args.upstream,
+                        pr_specs=args.pr,
+                        line=args.line,
+                        fork_url=args.fork,
+                        upstream_url=args.upstream_repo,
+                        dry_run=args.dry_run,
+                        skip_push=args.skip_push,
+                        skip_lock=skip_lock,
+                        no_commit=args.no_commit,
+                        no_pr=args.no_pr,
+                        base_branch=args.base_branch,
+                    )
+                else:
+                    release.drop_pin(
+                        root,
+                        release=args.release,
+                        upstream_url=args.upstream_repo,
+                        skip_lock=skip_lock,
+                        dry_run=args.dry_run,
+                        no_commit=args.no_commit,
+                        no_pr=args.no_pr,
+                        skip_push=args.skip_push,
+                        base_branch=args.base_branch,
+                    )
+            except release.ReleaseError as exc:
+                print(f"error: {exc}", file=sys.stderr)
+                return 1
+        elif command == "check":
+            check_pin(root, skip_lock=skip_lock, offline=offline)
+        else:
+            apply_pin(root, skip_lock=skip_lock, offline=offline)
+    except PinError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Unit tests
+# ---------------------------------------------------------------------------
+
+SAMPLE_CARGO = """[workspace.dependencies]
+# reth
+reth-zstd-compressors = { version = "0.6.0", default-features = false }
+reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1", default-features = false }
+"""
+
+SAMPLE_PIN = """repository = "https://github.com/paradigmxyz/reth"
+reference = "v2.5.1"
+rev = "6dec1b96b625584956883c34ad0eafbe550480ac"
+
+[upstream_base]
+tag = "v2.5.1"
+rev = "6dec1b96b625584956883c34ad0eafbe550480ac"
+"""
+
+
+def _pin_from(raw: str) -> Pin:
+    return parse_pin(raw, Path("reth.toml"))
+
+
+class PinRethTests(unittest.TestCase):
+    """Unit tests for pin parsing, rewrite, and lockfile checks."""
+
+    def test_parse_git_deps_skips_crates_io(self) -> None:
+        deps = parse_git_deps(SAMPLE_CARGO)
+        self.assertEqual([dep.name for dep in deps], ["reth-db", "reth-cli", "reth-prune-types"])
+        self.assertEqual({dep.kind for dep in deps}, {"tag"})
+
+    def test_rewrite_preserves_default_features_and_retargets(self) -> None:
+        pin = _pin_from(
+            SAMPLE_PIN.replace(
+                'repository = "https://github.com/paradigmxyz/reth"',
+                'repository = "https://github.com/base/reth"',
+            ).replace('reference = "v2.5.1"', 'reference = "v2.5.1-base.1"')
+        )
+        rewritten = rewrite_git_deps(SAMPLE_CARGO, pin)
+        self.assertIn(
+            'reth-db = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1" }',
+            rewritten,
+        )
+        self.assertIn(
+            'reth-prune-types = { git = "https://github.com/base/reth", tag = "v2.5.1-base.1", default-features = false }',
+            rewritten,
+        )
+        self.assertIn(
+            'reth-zstd-compressors = { version = "0.6.0", default-features = false }',
+            rewritten,
+        )
+
+    def test_rewrite_sha_reference_uses_rev(self) -> None:
+        sha = "2fa11e6417e638207aefc11b33028b000a2b1f68"
+        pin = _pin_from(
+            SAMPLE_PIN.replace(
+                'repository = "https://github.com/paradigmxyz/reth"',
+                'repository = "https://github.com/niran/reth"',
+            )
+            .replace('reference = "v2.5.1"', f'reference = "{sha}"')
+            .replace(
+                "6dec1b96b625584956883c34ad0eafbe550480ac",
+                sha,
+            )
+        )
+        rewritten = rewrite_git_deps(SAMPLE_CARGO, pin)
+        self.assertIn(
+            f'reth-db = {{ git = "https://github.com/niran/reth", rev = "{sha}" }}',
+            rewritten,
+        )
+        self.assertNotIn('tag = "v2.5.1"', rewritten)
+
+    def test_mixed_pins_are_rejected(self) -> None:
+        mixed = SAMPLE_CARGO.replace(
+            'reth-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }',
+            'reth-cli = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }',
+        )
+        deps = parse_git_deps(mixed)
+        with self.assertRaises(PinError):
+            require_uniform_git_deps(deps)
+
+    def test_lockfile_query_and_sha(self) -> None:
+        pin = _pin_from(SAMPLE_PIN)
+        lock = (
+            'source = "git+https://github.com/paradigmxyz/reth?'
+            'tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"\n'
+        )
+        verify_lockfile(lock, pin)
+
+    def test_lockfile_rejects_stale_fork(self) -> None:
+        pin = _pin_from(SAMPLE_PIN)
+        lock = (
+            'source = "git+https://github.com/niran/reth?'
+            'rev=2fa11e6417e638207aefc11b33028b000a2b1f68#'
+            '2fa11e6417e638207aefc11b33028b000a2b1f68"\n'
+        )
+        with self.assertRaises(PinError):
+            verify_lockfile(lock, pin)
+
+    def test_ls_remote_peels_annotated_tag(self) -> None:
+        output = (
+            "78b0eec35d6979681423815d49801236149d638f\trefs/tags/v2.5.1-base.1\n"
+            "d80b19e5b597f047268c6593300cbbe1f235631b\trefs/tags/v2.5.1-base.1^{}\n"
+        )
+        self.assertEqual(
+            commit_from_ls_remote(output, "v2.5.1-base.1"),
+            "d80b19e5b597f047268c6593300cbbe1f235631b",
+        )
+
+    def test_ls_remote_lightweight_tag(self) -> None:
+        output = (
+            "6dec1b96b625584956883c34ad0eafbe550480ac\trefs/tags/v2.5.1\n"
+        )
+        self.assertEqual(
+            commit_from_ls_remote(output, "v2.5.1"),
+            "6dec1b96b625584956883c34ad0eafbe550480ac",
+        )
+
+    def test_dropped_patch_requires_resolved(self) -> None:
+        old = _pin_from(
+            SAMPLE_PIN
+            + """
+[[patches]]
+pr = "https://github.com/paradigmxyz/reth/pull/26708"
+head = "0b5608325ca86fc2381b49de10b01c975e0ec99f"
+"""
+        )
+        new = _pin_from(SAMPLE_PIN)
+        with self.assertRaises(PinError):
+            assert_patches_not_dropped(old, new)
+        resolved = _pin_from(
+            SAMPLE_PIN
+            + """
+[[resolved]]
+pr = "https://github.com/paradigmxyz/reth/pull/26708"
+release = "v2.6.0"
+"""
+        )
+        assert_patches_not_dropped(old, resolved)
+
+    def test_patch_identity_is_pr_not_head(self) -> None:
+        old = _pin_from(
+            SAMPLE_PIN
+            + """
+[[patches]]
+pr = "https://github.com/paradigmxyz/reth/pull/26708"
+head = "0b5608325ca86fc2381b49de10b01c975e0ec99f"
+"""
+        )
+        updated_head = _pin_from(
+            SAMPLE_PIN
+            + """
+[[patches]]
+pr = "https://github.com/paradigmxyz/reth/pull/26708"
+head = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+"""
+        )
+        assert_patches_not_dropped(old, updated_head)
+
+    def test_commit_field_is_rejected(self) -> None:
+        with self.assertRaises(PinError):
+            _pin_from(
+                SAMPLE_PIN
+                + """
+[[patches]]
+pr = "https://github.com/paradigmxyz/reth/pull/26708"
+commit = "0b5608325ca86fc2381b49de10b01c975e0ec99f"
+"""
+            )
+
+    def test_duplicate_patch_pr_is_rejected(self) -> None:
+        with self.assertRaises(PinError):
+            _pin_from(
+                SAMPLE_PIN
+                + """
+[[patches]]
+pr = "https://github.com/paradigmxyz/reth/pull/26708"
+head = "0b5608325ca86fc2381b49de10b01c975e0ec99f"
+
+[[patches]]
+pr = "https://github.com/paradigmxyz/reth/pull/26708"
+head = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+"""
+            )
+
+    def test_patch_pr_must_be_github_url(self) -> None:
+        with self.assertRaises(PinError):
+            _pin_from(
+                SAMPLE_PIN
+                + """
+[[patches]]
+pr = "26708"
+head = "0b5608325ca86fc2381b49de10b01c975e0ec99f"
+"""
+            )
+
+    def test_fork_pr_is_valid_patch_identity(self) -> None:
+        pin = _pin_from(
+            SAMPLE_PIN
+            + """
+[[patches]]
+pr = "https://github.com/base/reth/pull/12"
+head = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+"""
+        )
+        self.assertEqual(pin.patches[0].pr, "https://github.com/base/reth/pull/12")
+
+    def test_normalize_git_url(self) -> None:
+        self.assertEqual(
+            normalize_git_url("https://github.com/paradigmxyz/reth.git/"),
+            "https://github.com/paradigmxyz/reth",
+        )
+
+
+def run_tests() -> int:
+    """Run colocated unit tests, including the release helper."""
+    loader = unittest.defaultTestLoader
+    suite = unittest.TestSuite()
+    suite.addTests(loader.loadTestsFromTestCase(PinRethTests))
+    release = load_release_mod()
+    suite.addTests(loader.loadTestsFromTestCase(release.ReleaseTests))
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    return 0 if result.wasSuccessful() else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/etc/scripts/local/pin-reth.py
+++ b/etc/scripts/local/pin-reth.py
@@ -189,11 +189,18 @@ def parse_pin(raw: str, path: Path) -> Pin:
 
 
 def set_top_level_rev(raw: str, rev: str) -> str:
-    """Replace the top-level `rev` field without touching `[[patches]]`."""
-    updated, count = TOP_LEVEL_REV_RE.subn(f'rev = "{rev}"', raw, count=1)
+    """Replace the top-level `rev` field without touching later tables.
+
+    Only the preamble before the first `[` section header is rewritten, so
+    `[upstream_base].rev` cannot be updated by accident.
+    """
+    match = re.search(r"(?m)^\[", raw)
+    preamble = raw if match is None else raw[: match.start()]
+    rest = "" if match is None else raw[match.start() :]
+    updated, count = TOP_LEVEL_REV_RE.subn(f'rev = "{rev}"', preamble)
     if count != 1:
         raise PinError("could not update top-level `rev` in the pin manifest")
-    return updated
+    return updated + rest
 
 
 def workspace_deps_span(text: str) -> tuple[int, int]:
@@ -696,6 +703,26 @@ head = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
             normalize_git_url("https://github.com/paradigmxyz/reth.git/"),
             "https://github.com/paradigmxyz/reth",
         )
+
+    def test_set_top_level_rev_skips_section_rev(self) -> None:
+        updated = set_top_level_rev(
+            SAMPLE_PIN, "d80b19e5b597f047268c6593300cbbe1f235631b"
+        )
+        self.assertIn(
+            'rev = "d80b19e5b597f047268c6593300cbbe1f235631b"',
+            updated.split("[upstream_base]", 1)[0],
+        )
+        self.assertIn(
+            'rev = "6dec1b96b625584956883c34ad0eafbe550480ac"',
+            updated.split("[upstream_base]", 1)[1],
+        )
+
+    def test_set_top_level_rev_rejects_section_only_rev(self) -> None:
+        with self.assertRaises(PinError):
+            set_top_level_rev(
+                '[upstream_base]\nrev = "6dec1b96b625584956883c34ad0eafbe550480ac"\n',
+                "d80b19e5b597f047268c6593300cbbe1f235631b",
+            )
 
 
 def run_tests() -> int:

--- a/etc/scripts/local/pin-reth.py
+++ b/etc/scripts/local/pin-reth.py
@@ -2,12 +2,11 @@
 """Apply and verify the workspace Reth git pin.
 
 Reads `etc/upstream-pins/reth.toml` and keeps every git-based `reth-*`
-workspace dependency on one repository and one ref. Carried backports are
-whole GitHub PRs (upstream or the Base fork), each squashed to one fork
-commit. Crates.io Reth crates (`reth-codecs`, `reth-primitives-traits`,
-`reth-zstd-compressors`, …) are left unchanged.
+workspace dependency on one repository and one ref. Crates.io Reth crates
+(`reth-codecs`, `reth-primitives-traits`, `reth-zstd-compressors`, …) are
+left unchanged.
 
-See `etc/upstream-pins/README.md` for the workflow and limitations.
+See `etc/upstream-pins/README.md`.
 """
 
 from __future__ import annotations
@@ -53,25 +52,12 @@ class PinError(RuntimeError):
 class Patch:
     """One GitHub PR squashed onto `upstream_base`.
 
-    `pr` is the full pull URL, including the repository: paradigmxyz/reth for
-    upstream backports, or the Base fork for patches that must not be opened
-    upstream. `head` is the PR tip (or merge commit) that the squash used.
+    `pr` is the full pull URL, including the repository. `head` is the PR tip
+    or merge commit that the squash used.
     """
 
     pr: str
     head: str
-
-
-@dataclass(frozen=True)
-class ResolvedPatch:
-    """A previously carried upstream PR that an official release now contains.
-
-    Do not record a base/reth PR here against an upstream tag. Those patches
-    never land in paradigmxyz/reth.
-    """
-
-    pr: str
-    release: str
 
 
 @dataclass(frozen=True)
@@ -91,7 +77,6 @@ class Pin:
     rev: str
     upstream_base: UpstreamBase
     patches: list[Patch] = field(default_factory=list)
-    resolved: list[ResolvedPatch] = field(default_factory=list)
     raw: str = ""
 
 
@@ -104,13 +89,10 @@ class GitDep:
     kind: str
     value: str
     rest: str
-    line: str
 
 
-def repo_root_from(start: Path | None = None) -> Path:
+def repo_root_from() -> Path:
     """Return the workspace root that contains the pin manifest."""
-    if start is not None:
-        return start.resolve()
     return Path(__file__).resolve().parents[3]
 
 
@@ -130,11 +112,7 @@ def is_full_sha(value: str) -> bool:
 
 
 def cargo_ref(pin: Pin) -> tuple[str, str]:
-    """Return the Cargo.toml (`kind`, `value`) pair for this pin.
-
-    Official and fork tags stay as `tag =` so the manifest is self-documenting.
-    A raw SHA reference is written as `rev =`.
-    """
+    """Return the Cargo.toml (`kind`, `value`) pair for this pin."""
     if is_full_sha(pin.reference):
         return "rev", pin.rev
     return "tag", pin.reference
@@ -178,9 +156,8 @@ def parse_pin(raw: str, path: Path) -> Pin:
             raise PinError(f"{path}: `[[patches]]` entries must be tables")
         if "commit" in entry:
             raise PinError(
-                f"{path}: `[[patches]]` records a whole PR squashed onto the "
-                "fork. Set `head` to the PR tip or merge commit; do not use "
-                "`commit` (that form only described single-commit PRs)"
+                f"{path}: `[[patches]]` records a whole PR. Set `head` to the "
+                "PR tip or merge commit; do not use `commit`"
             )
         pr = entry.get("pr")
         head = entry.get("head")
@@ -190,40 +167,16 @@ def parse_pin(raw: str, path: Path) -> Pin:
         if not GITHUB_PR_URL_RE.fullmatch(pr):
             raise PinError(
                 f"{path}: `[[patches]].pr` must be a GitHub pull URL so the "
-                "repository is part of the identity (paradigmxyz/reth or "
-                "base/reth). Do not use a bare number."
+                "repository is part of the identity"
             )
         if pr in seen_prs:
             raise PinError(f"{path}: duplicate `[[patches]]` PR {pr}")
         if not isinstance(head, str) or not SHORT_SHA_RE.fullmatch(head):
             raise PinError(
-                f"{path}: `[[patches]].head` must be the PR tip or merge "
-                "commit SHA that was squashed"
+                f"{path}: `[[patches]].head` must be the PR tip or merge commit SHA"
             )
         seen_prs.add(pr)
         patches.append(Patch(pr=pr, head=head.lower()))
-
-    resolved: list[ResolvedPatch] = []
-    seen_resolved: set[str] = set()
-    for entry in data.get("resolved") or []:
-        if not isinstance(entry, dict):
-            raise PinError(f"{path}: `[[resolved]]` entries must be tables")
-        pr = entry.get("pr")
-        release = entry.get("release")
-        if not isinstance(pr, str) or not pr:
-            raise PinError(f"{path}: `[[resolved]].pr` is required")
-        pr = pr.rstrip("/")
-        if not GITHUB_PR_URL_RE.fullmatch(pr):
-            raise PinError(
-                f"{path}: `[[resolved]].pr` must be a GitHub pull URL so the "
-                "repository is part of the identity"
-            )
-        if pr in seen_resolved:
-            raise PinError(f"{path}: duplicate `[[resolved]]` PR {pr}")
-        if not isinstance(release, str) or not release:
-            raise PinError(f"{path}: `[[resolved]].release` is required")
-        seen_resolved.add(pr)
-        resolved.append(ResolvedPatch(pr=pr, release=release))
 
     return Pin(
         repository=repository.rstrip("/"),
@@ -231,7 +184,6 @@ def parse_pin(raw: str, path: Path) -> Pin:
         rev=rev,
         upstream_base=UpstreamBase(tag=base_tag, rev=base_rev.lower()),
         patches=patches,
-        resolved=resolved,
         raw=raw,
     )
 
@@ -284,7 +236,6 @@ def parse_git_deps(cargo_toml: str) -> list[GitDep]:
                 kind=match.group("kind"),
                 value=match.group("value"),
                 rest=match.group("rest"),
-                line=line,
             )
         )
     if not deps:
@@ -440,39 +391,6 @@ def resolve_reference(repository: str, reference: str) -> str:
         raise PinError(f"could not resolve {reference} on {repository}") from exc
 
 
-def previous_pin(root: Path) -> Pin | None:
-    """Load the last committed pin manifest, if any."""
-    result = subprocess.run(
-        ["git", "show", f"HEAD:{MANIFEST_REL.as_posix()}"],
-        cwd=root,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if result.returncode != 0:
-        return None
-    return parse_pin(result.stdout, MANIFEST_REL)
-
-
-def assert_patches_not_dropped(old: Pin, new: Pin) -> None:
-    """Fail when a carried PR disappears without a `[[resolved]]` entry."""
-    new_prs = {patch.pr for patch in new.patches}
-    resolved_prs = {item.pr for item in new.resolved}
-    dropped = [
-        patch
-        for patch in old.patches
-        if patch.pr not in new_prs and patch.pr not in resolved_prs
-    ]
-    if dropped:
-        details = ", ".join(patch.pr for patch in dropped)
-        raise PinError(
-            "carried PR removed without `[[resolved]]`: "
-            f"{details}. Upstream PRs record the official Reth tag that "
-            "contains them. Do not resolve a base/reth PR against an "
-            "upstream tag."
-        )
-
-
 def run_cargo(root: Path, args: list[str]) -> None:
     """Run a cargo command at `root` and surface stderr on failure."""
     result = subprocess.run(args, cwd=root, capture_output=True, text=True, check=False)
@@ -497,21 +415,16 @@ def write_if_changed(path: Path, contents: str) -> bool:
     return True
 
 
-def apply_pin(root: Path, *, skip_lock: bool, offline: bool) -> None:
-    """Resolve, rewrite, and optionally refresh the lockfile."""
+def apply_pin(root: Path) -> None:
+    """Resolve, rewrite, and refresh the lockfile."""
     manifest_path = root / MANIFEST_REL
     pin = load_pin(manifest_path)
-    old = previous_pin(root)
-    if old is not None:
-        assert_patches_not_dropped(old, pin)
-
-    if not offline:
-        resolved = resolve_reference(pin.repository, pin.reference)
-        if resolved != pin.rev:
-            pin.raw = set_top_level_rev(pin.raw, resolved)
-            pin.rev = resolved
-            write_if_changed(manifest_path, pin.raw)
-            print(f"updated {MANIFEST_REL} rev = {resolved}")
+    resolved = resolve_reference(pin.repository, pin.reference)
+    if resolved != pin.rev:
+        pin.raw = set_top_level_rev(pin.raw, resolved)
+        pin.rev = resolved
+        write_if_changed(manifest_path, pin.raw)
+        print(f"updated {MANIFEST_REL} rev = {resolved}")
 
     cargo_path = root / CARGO_TOML
     cargo_toml = cargo_path.read_text(encoding="utf-8")
@@ -520,40 +433,26 @@ def apply_pin(root: Path, *, skip_lock: bool, offline: bool) -> None:
     deps = parse_git_deps(rewritten)
     if cargo_changed:
         print(f"updated {len(deps)} git `reth-*` workspace dependencies")
+        update_lockfile(root, deps)
     else:
         print(f"{CARGO_TOML} already matches {MANIFEST_REL}")
 
-    if skip_lock:
-        return
-    if cargo_changed:
-        update_lockfile(root, deps)
     run_cargo(root, ["cargo", "metadata", "--format-version", "1", "--no-deps", "--locked"])
     verify_lockfile((root / CARGO_LOCK).read_text(encoding="utf-8"), pin)
     print(f"Reth pin is {pin.repository} {cargo_ref(pin)[0]}={cargo_ref(pin)[1]} ({pin.rev})")
 
 
-def check_pin(root: Path, *, skip_lock: bool, offline: bool) -> None:
+def check_pin(root: Path) -> None:
     """Verify the working tree matches the pin manifest."""
-    manifest_path = root / MANIFEST_REL
-    pin = load_pin(manifest_path)
-    old = previous_pin(root)
-    if old is not None:
-        assert_patches_not_dropped(old, pin)
-
-    if not offline:
-        resolved = resolve_reference(pin.repository, pin.reference)
-        if resolved != pin.rev:
-            raise PinError(
-                f"`reference` {pin.reference} resolves to {resolved}, "
-                f"but `rev` is {pin.rev}"
-            )
-
-    cargo_toml = (root / CARGO_TOML).read_text(encoding="utf-8")
-    deps = parse_git_deps(cargo_toml)
+    pin = load_pin(root / MANIFEST_REL)
+    resolved = resolve_reference(pin.repository, pin.reference)
+    if resolved != pin.rev:
+        raise PinError(
+            f"`reference` {pin.reference} resolves to {resolved}, "
+            f"but `rev` is {pin.rev}"
+        )
+    deps = parse_git_deps((root / CARGO_TOML).read_text(encoding="utf-8"))
     verify_cargo_toml(deps, pin)
-    if skip_lock:
-        print(f"{CARGO_TOML} matches {MANIFEST_REL} ({len(deps)} git `reth-*` crates)")
-        return
     run_cargo(root, ["cargo", "metadata", "--format-version", "1", "--no-deps", "--locked"])
     verify_lockfile((root / CARGO_LOCK).read_text(encoding="utf-8"), pin)
     print(
@@ -565,28 +464,10 @@ def check_pin(root: Path, *, skip_lock: bool, offline: bool) -> None:
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse CLI arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--repo-root",
-        type=Path,
-        help="workspace root (default: inferred from this script)",
-    )
-    parser.add_argument(
-        "--check",
-        action="store_true",
-        help="alias for the `check` command",
-    )
     sub = parser.add_subparsers(dest="command")
-
-    apply_p = sub.add_parser("apply", help="rewrite workspace git deps from the manifest")
-    apply_p.add_argument("--skip-lock", action="store_true")
-    apply_p.add_argument("--offline", action="store_true")
-
-    check_p = sub.add_parser("check", help="verify Cargo.toml and Cargo.lock match the manifest")
-    check_p.add_argument("--skip-lock", action="store_true")
-    check_p.add_argument("--offline", action="store_true")
-
+    sub.add_parser("apply", help="rewrite workspace git deps from the manifest")
+    sub.add_parser("check", help="verify Cargo.toml and Cargo.lock match the manifest")
     sub.add_parser("test", help="run unit tests")
-
     prepare_p = sub.add_parser(
         "prepare",
         help="squash GitHub PRs onto a Reth tag, publish the fork tag, and pin it",
@@ -598,36 +479,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         required=True,
         help=(
             "PR number on --upstream-repo, or a GitHub pull URL on that repo "
-            "or --fork (repeatable). Use a base/reth URL for Base-specific "
-            "patches instead of opening them upstream."
+            "or --fork (repeatable)"
         ),
     )
     prepare_p.add_argument("--line", help="consumer line, for example v1.3.0")
     prepare_p.add_argument("--fork", default="https://github.com/base/reth")
     prepare_p.add_argument("--upstream-repo", default="https://github.com/paradigmxyz/reth")
-    prepare_p.add_argument("--dry-run", action="store_true")
     prepare_p.add_argument("--skip-push", action="store_true")
-    prepare_p.add_argument("--skip-lock", action="store_true")
-    prepare_p.add_argument("--no-commit", action="store_true")
-    prepare_p.add_argument("--no-pr", action="store_true")
-    prepare_p.add_argument("--base-branch", help="base/base PR target; pin commit is created from origin/<this> (default: releases/<line> or main)")
-
-    drop_p = sub.add_parser(
-        "drop",
-        help="retarget the pin at an official Reth release (upstream PRs only)",
-    )
-    drop_p.add_argument("--release", required=True, help="official Reth tag that contains the carried PRs")
-    drop_p.add_argument("--upstream-repo", default="https://github.com/paradigmxyz/reth")
-    drop_p.add_argument("--skip-lock", action="store_true")
-    drop_p.add_argument("--dry-run", action="store_true")
-    drop_p.add_argument("--no-commit", action="store_true")
-    drop_p.add_argument("--no-pr", action="store_true")
-    drop_p.add_argument("--skip-push", action="store_true")
-    drop_p.add_argument("--base-branch", help="base/base PR target; pin commit is created from origin/<this> (default: main)")
-
     args = parser.parse_args(argv)
-    if args.check:
-        args.command = "check"
     if not args.command:
         args.command = "apply"
     return args
@@ -646,59 +505,34 @@ def load_release_mod():
 def main(argv: list[str] | None = None) -> int:
     """CLI entrypoint."""
     args = parse_args(argv)
-    command = args.command
-    if command == "test":
+    if args.command == "test":
         return run_tests()
-    root = repo_root_from(args.repo_root)
-    skip_lock = bool(getattr(args, "skip_lock", False))
-    offline = bool(getattr(args, "offline", False))
+    root = repo_root_from()
     try:
-        if command in {"prepare", "drop"}:
+        if args.command == "prepare":
             release = load_release_mod()
             try:
-                if command == "prepare":
-                    release.prepare_release(
-                        root,
-                        upstream_tag=args.upstream,
-                        pr_specs=args.pr,
-                        line=args.line,
-                        fork_url=args.fork,
-                        upstream_url=args.upstream_repo,
-                        dry_run=args.dry_run,
-                        skip_push=args.skip_push,
-                        skip_lock=skip_lock,
-                        no_commit=args.no_commit,
-                        no_pr=args.no_pr,
-                        base_branch=args.base_branch,
-                    )
-                else:
-                    release.drop_pin(
-                        root,
-                        release=args.release,
-                        upstream_url=args.upstream_repo,
-                        skip_lock=skip_lock,
-                        dry_run=args.dry_run,
-                        no_commit=args.no_commit,
-                        no_pr=args.no_pr,
-                        skip_push=args.skip_push,
-                        base_branch=args.base_branch,
-                    )
+                release.prepare_release(
+                    root,
+                    upstream_tag=args.upstream,
+                    pr_specs=args.pr,
+                    line=args.line,
+                    fork_url=args.fork,
+                    upstream_url=args.upstream_repo,
+                    skip_push=args.skip_push,
+                )
             except release.ReleaseError as exc:
                 print(f"error: {exc}", file=sys.stderr)
                 return 1
-        elif command == "check":
-            check_pin(root, skip_lock=skip_lock, offline=offline)
+        elif args.command == "check":
+            check_pin(root)
         else:
-            apply_pin(root, skip_lock=skip_lock, offline=offline)
+            apply_pin(root)
     except PinError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
     return 0
 
-
-# ---------------------------------------------------------------------------
-# Unit tests
-# ---------------------------------------------------------------------------
 
 SAMPLE_CARGO = """[workspace.dependencies]
 # reth
@@ -759,10 +593,7 @@ class PinRethTests(unittest.TestCase):
                 'repository = "https://github.com/niran/reth"',
             )
             .replace('reference = "v2.5.1"', f'reference = "{sha}"')
-            .replace(
-                "6dec1b96b625584956883c34ad0eafbe550480ac",
-                sha,
-            )
+            .replace("6dec1b96b625584956883c34ad0eafbe550480ac", sha)
         )
         rewritten = rewrite_git_deps(SAMPLE_CARGO, pin)
         self.assertIn(
@@ -776,27 +607,24 @@ class PinRethTests(unittest.TestCase):
             'reth-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v2.5.1" }',
             'reth-cli = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }',
         )
-        deps = parse_git_deps(mixed)
         with self.assertRaises(PinError):
-            require_uniform_git_deps(deps)
+            require_uniform_git_deps(parse_git_deps(mixed))
 
     def test_lockfile_query_and_sha(self) -> None:
-        pin = _pin_from(SAMPLE_PIN)
         lock = (
             'source = "git+https://github.com/paradigmxyz/reth?'
             'tag=v2.5.1#6dec1b96b625584956883c34ad0eafbe550480ac"\n'
         )
-        verify_lockfile(lock, pin)
+        verify_lockfile(lock, _pin_from(SAMPLE_PIN))
 
     def test_lockfile_rejects_stale_fork(self) -> None:
-        pin = _pin_from(SAMPLE_PIN)
         lock = (
             'source = "git+https://github.com/niran/reth?'
             'rev=2fa11e6417e638207aefc11b33028b000a2b1f68#'
             '2fa11e6417e638207aefc11b33028b000a2b1f68"\n'
         )
         with self.assertRaises(PinError):
-            verify_lockfile(lock, pin)
+            verify_lockfile(lock, _pin_from(SAMPLE_PIN))
 
     def test_ls_remote_peels_annotated_tag(self) -> None:
         output = (
@@ -809,54 +637,11 @@ class PinRethTests(unittest.TestCase):
         )
 
     def test_ls_remote_lightweight_tag(self) -> None:
-        output = (
-            "6dec1b96b625584956883c34ad0eafbe550480ac\trefs/tags/v2.5.1\n"
-        )
+        output = "6dec1b96b625584956883c34ad0eafbe550480ac\trefs/tags/v2.5.1\n"
         self.assertEqual(
             commit_from_ls_remote(output, "v2.5.1"),
             "6dec1b96b625584956883c34ad0eafbe550480ac",
         )
-
-    def test_dropped_patch_requires_resolved(self) -> None:
-        old = _pin_from(
-            SAMPLE_PIN
-            + """
-[[patches]]
-pr = "https://github.com/paradigmxyz/reth/pull/26708"
-head = "0b5608325ca86fc2381b49de10b01c975e0ec99f"
-"""
-        )
-        new = _pin_from(SAMPLE_PIN)
-        with self.assertRaises(PinError):
-            assert_patches_not_dropped(old, new)
-        resolved = _pin_from(
-            SAMPLE_PIN
-            + """
-[[resolved]]
-pr = "https://github.com/paradigmxyz/reth/pull/26708"
-release = "v2.6.0"
-"""
-        )
-        assert_patches_not_dropped(old, resolved)
-
-    def test_patch_identity_is_pr_not_head(self) -> None:
-        old = _pin_from(
-            SAMPLE_PIN
-            + """
-[[patches]]
-pr = "https://github.com/paradigmxyz/reth/pull/26708"
-head = "0b5608325ca86fc2381b49de10b01c975e0ec99f"
-"""
-        )
-        updated_head = _pin_from(
-            SAMPLE_PIN
-            + """
-[[patches]]
-pr = "https://github.com/paradigmxyz/reth/pull/26708"
-head = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-"""
-        )
-        assert_patches_not_dropped(old, updated_head)
 
     def test_commit_field_is_rejected(self) -> None:
         with self.assertRaises(PinError):

--- a/etc/scripts/local/reth_release.py
+++ b/etc/scripts/local/reth_release.py
@@ -1,19 +1,11 @@
 """Build a squashed base/reth tag and pin it from base/base.
 
 `prepare` resolves GitHub PRs, recreates a backport branch from an official
-Reth tag, squash-picks each PR, tags the tip, writes the pin manifest, rewrites
-workspace git deps, and opens a base/base PR.
+Reth tag, squash-picks each PR, tags the tip, writes the pin manifest, and
+rewrites workspace git deps. It does not commit or open a base/base PR.
 
-PR identity includes the repository. Bare `--pr N` is a PR on `--upstream-repo`.
-A full URL may point at that repo or at `--fork` (default `base/reth`) so
-Base-specific patches do not have to be opened upstream.
-
-`drop` records upstream PRs in `[[resolved]]` and retargets the pin at an
-official Reth release. It refuses while `[[patches]]` still lists fork PRs:
-those never land in paradigmxyz/reth.
-
-Pin commits are created from `origin/<base>` (`releases/<line>` or `main`),
-not from the local HEAD. See `etc/upstream-pins/README.md`.
+Bare `--pr N` is a PR on `--upstream-repo`. A full URL may point at that repo
+or at `--fork` so Base-specific patches do not have to be opened upstream.
 """
 
 from __future__ import annotations
@@ -29,11 +21,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 MANIFEST_REL = Path("etc/upstream-pins/reth.toml")
-CARGO_TOML = Path("Cargo.toml")
-CARGO_LOCK = Path("Cargo.lock")
 FORK_CLONE_REL = Path(".tmp/base-reth")
-DEFAULT_UPSTREAM_REPO = "https://github.com/paradigmxyz/reth"
-DEFAULT_FORK_REPO = "https://github.com/base/reth"
 PR_SPEC_RE = re.compile(
     r"^(?:https://github\.com/(?P<owner>[^/]+)/(?P<name>[^/]+)/pull/)?"
     r"(?P<num>\d+)/?$",
@@ -42,7 +30,7 @@ PR_SPEC_RE = re.compile(
 
 
 class ReleaseError(RuntimeError):
-    """Raised when preparing or dropping a Reth fork pin fails."""
+    """Raised when preparing a Reth fork pin fails."""
 
 
 @dataclass(frozen=True)
@@ -91,7 +79,7 @@ def resolve_pr_repo(spec: PrSpec, *, upstream_url: str, fork_url: str) -> str:
     """Return `owner/repo` for a PR spec.
 
     Allowed sources are `--upstream-repo` and `--fork`. Bare numbers use
-    `--upstream-repo`. Fork PRs are the path for Base-specific patches.
+    `--upstream-repo`.
     """
     upstream = owner_repo(upstream_url)
     fork = owner_repo(fork_url)
@@ -117,8 +105,6 @@ def next_base_tag(upstream_tag: str, existing: list[str]) -> str:
     numbers: list[int] = []
     for tag in existing:
         name = tag.removeprefix("refs/tags/")
-        if name.startswith("refs/tags/"):
-            name = name[len("refs/tags/") :]
         if name.startswith(prefix) and name[len(prefix) :].isdigit():
             numbers.append(int(name[len(prefix) :]))
     return f"{prefix}{max(numbers, default=0) + 1}"
@@ -194,9 +180,8 @@ def fetch_pr(repo: str, number: int) -> PatchPr:
     )
     if not isinstance(data, dict):
         raise ReleaseError(f"unexpected gh pr view payload for {repo}#{number}")
-    commits_raw = data.get("commits") or []
     commits: list[str] = []
-    for entry in commits_raw:
+    for entry in data.get("commits") or []:
         if not isinstance(entry, dict):
             continue
         oid = entry.get("oid")
@@ -260,11 +245,7 @@ def already_squashed(clone: Path, upstream_tag: str, pr: PatchPr) -> bool:
     return any(line.startswith(needle) for line in log.splitlines())
 
 
-def squash_pr(
-    clone: Path,
-    pr: PatchPr,
-    env: dict[str, str],
-) -> None:
+def squash_pr(clone: Path, pr: PatchPr, env: dict[str, str]) -> None:
     """Cherry-pick every PR commit and squash them into one commit."""
     source = f"https://github.com/{pr.repo}"
     local_ref = f"refs/reths/{pr.repo.replace('/', '-')}-{pr.number}"
@@ -301,6 +282,23 @@ def squash_pr(
     run(["git", "commit", "-m", message], cwd=clone, env=env)
 
 
+def current_resolved(root: Path) -> list[tuple[str, str]]:
+    """Return existing `[[resolved]]` pairs from the pin manifest, if any."""
+    path = root / MANIFEST_REL
+    if not path.exists():
+        return []
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    pairs: list[tuple[str, str]] = []
+    for entry in data.get("resolved") or []:
+        if not isinstance(entry, dict):
+            continue
+        pr = entry.get("pr")
+        release = entry.get("release")
+        if isinstance(pr, str) and isinstance(release, str):
+            pairs.append((pr, release))
+    return pairs
+
+
 def render_manifest(
     *,
     repository: str,
@@ -314,25 +312,12 @@ def render_manifest(
     """Render `etc/upstream-pins/reth.toml`."""
     lines = [
         "# Authoritative Reth git pin for [workspace.dependencies].",
+        "# See etc/upstream-pins/README.md.",
         "#",
-        "# Workflow and limitations: etc/upstream-pins/README.md",
-        "#",
-        "# `just pin-reth` rewrites every git-based `reth-*` crate to this repository",
-        "# and reference, then refreshes Cargo.lock.",
-        "# `just check-reth-pin` verifies Cargo.toml and Cargo.lock match this file.",
+        "# `just pin-reth` rewrites git `reth-*` crates to this repository and",
+        "# reference. `just check-reth-pin` verifies Cargo.toml and Cargo.lock.",
         "# `just reth-prepare-release` builds the fork tag and writes this file.",
-        "#",
-        "# `reference` is the human-facing git ref (release tag, fork tag, or SHA).",
-        "# `rev` is the immutable commit that `reference` currently resolves to.",
-        "# Cargo.toml uses `tag =` when `reference` is not a SHA, and `rev =` otherwise.",
-        "#",
-        "# Each [[patches]] entry is a whole GitHub PR squashed to one fork commit.",
-        "# Identity is the PR URL, including the repository: paradigmxyz/reth for",
-        "# upstream backports, or the Base fork (`base/reth`) for patches that",
-        "# must not be opened upstream. `head` is the PR tip (or merge commit).",
-        "#",
-        "# `[[resolved]]` is only for upstream PRs that landed in an official",
-        "# Reth release. Do not record a base/reth PR against an upstream tag.",
+        "# To return to an official Reth tag, edit this file and run `just pin-reth`.",
         "",
         f'repository = "{repository}"',
         f'reference = "{reference}"',
@@ -343,26 +328,24 @@ def render_manifest(
         f'rev = "{upstream_rev}"',
         "",
     ]
-    if patches:
-        for pr in patches:
-            lines.extend(
-                [
-                    "[[patches]]",
-                    f'pr = "{pr.url}"',
-                    f'head = "{pr.head}"',
-                    "",
-                ]
-            )
-    if resolved:
-        for pr_url, release in resolved:
-            lines.extend(
-                [
-                    "[[resolved]]",
-                    f'pr = "{pr_url}"',
-                    f'release = "{release}"',
-                    "",
-                ]
-            )
+    for pr in patches:
+        lines.extend(
+            [
+                "[[patches]]",
+                f'pr = "{pr.url}"',
+                f'head = "{pr.head}"',
+                "",
+            ]
+        )
+    for pr_url, release in resolved:
+        lines.extend(
+            [
+                "[[resolved]]",
+                f'pr = "{pr_url}"',
+                f'release = "{release}"',
+                "",
+            ]
+        )
     return "\n".join(lines).rstrip() + "\n"
 
 
@@ -390,21 +373,12 @@ def git_identity_env(root: Path) -> dict[str, str]:
     return env
 
 
-def current_resolved(root: Path) -> list[tuple[str, str]]:
-    """Return existing `[[resolved]]` pairs from the pin manifest, if any."""
-    path = root / MANIFEST_REL
-    if not path.exists():
-        return []
-    data = tomllib.loads(path.read_text(encoding="utf-8"))
-    pairs: list[tuple[str, str]] = []
-    for entry in data.get("resolved") or []:
-        if not isinstance(entry, dict):
-            continue
-        pr = entry.get("pr")
-        release = entry.get("release")
-        if isinstance(pr, str) and isinstance(release, str):
-            pairs.append((pr, release))
-    return pairs
+def annotated_tag_message(upstream_tag: str, prs: list[PatchPr]) -> str:
+    """Body for the immutable fork tag."""
+    lines = [f"Reth {upstream_tag} plus squashed PRs.", ""]
+    for pr in prs:
+        lines.append(f"- {pr.url} ({pr.head[:12]})")
+    return "\n".join(lines)
 
 
 def prepare_release(
@@ -415,14 +389,9 @@ def prepare_release(
     line: str | None,
     fork_url: str,
     upstream_url: str,
-    dry_run: bool,
     skip_push: bool,
-    skip_lock: bool,
-    no_commit: bool,
-    no_pr: bool,
-    base_branch: str | None,
 ) -> None:
-    """Build the fork tag, write the pin, and open the base/base PR."""
+    """Build the fork tag, write the pin, and rewrite workspace git deps."""
     if not pr_specs:
         raise ReleaseError("pass at least one --pr")
     line = line or infer_line(root)
@@ -431,7 +400,13 @@ def prepare_release(
         repo = resolve_pr_repo(spec, upstream_url=upstream_url, fork_url=fork_url)
         prs.append(fetch_pr(repo, spec.number))
     clone = ensure_fork_clone(root, fork_url, upstream_url)
-    git(clone, "fetch", "upstream", f"refs/tags/{upstream_tag}:refs/tags/{upstream_tag}", "--force")
+    git(
+        clone,
+        "fetch",
+        "upstream",
+        f"refs/tags/{upstream_tag}:refs/tags/{upstream_tag}",
+        "--force",
+    )
     upstream_rev = git(clone, "rev-parse", f"{upstream_tag}^{{commit}}").strip().lower()
     fork_tag = next_base_tag(upstream_tag, existing_tags(clone))
     backport_branch = f"backport/{upstream_tag}/{line}"
@@ -454,8 +429,7 @@ def prepare_release(
         print(f"squashing {pr.url} ({len(pr.commits)} commits) onto {upstream_tag}")
         squash_pr(clone, pr, env)
     fork_rev = git(clone, "rev-parse", "HEAD").strip().lower()
-    existing_local_tag = git(clone, "tag", "--list", fork_tag).strip()
-    if existing_local_tag:
+    if git(clone, "tag", "--list", fork_tag).strip():
         git(clone, "tag", "-d", fork_tag)
     run(
         ["git", "tag", "-a", fork_tag, "-m", annotated_tag_message(upstream_tag, prs)],
@@ -463,14 +437,9 @@ def prepare_release(
         env=env,
     )
 
-    if not dry_run and not skip_push:
+    if not skip_push:
         git(clone, "push", "-u", "origin", backport_branch)
         git(clone, "push", "origin", f"refs/tags/{fork_tag}")
-
-    pin_branch = f"chore/reth-{fork_tag}"
-    target_branch = base_branch or default_base_branch(root, line)
-    if not no_commit and not dry_run:
-        checkout_from_origin(root, branch=pin_branch, base_branch=target_branch)
 
     manifest = render_manifest(
         repository=fork_url.rstrip("/").removesuffix(".git"),
@@ -484,232 +453,11 @@ def prepare_release(
     (root / MANIFEST_REL).parent.mkdir(parents=True, exist_ok=True)
     (root / MANIFEST_REL).write_text(manifest, encoding="utf-8")
     print(f"wrote {MANIFEST_REL} -> {fork_url} {fork_tag} ({fork_rev})")
-
-    apply_args = ["apply"]
-    if skip_lock:
-        apply_args.append("--skip-lock")
-    pin_reth(root, *apply_args)
-
-    if not no_commit and not dry_run:
-        commit_pin_files(root, fork_tag)
-        if not skip_push:
-            git(root, "push", "-u", "origin", "HEAD")
-            if not no_pr:
-                create_base_pr(
-                    root,
-                    fork_tag=fork_tag,
-                    prs=prs,
-                    base_branch=target_branch,
-                )
+    pin_reth(root, "apply")
     print(
         f"prepared {fork_tag} on {backport_branch} "
         f"({len(prs)} PR(s) squashed from {upstream_tag})"
     )
-
-
-def annotated_tag_message(upstream_tag: str, prs: list[PatchPr]) -> str:
-    """Body for the immutable fork tag."""
-    lines = [
-        f"Reth {upstream_tag} plus squashed PRs.",
-        "",
-    ]
-    for pr in prs:
-        lines.append(f"- {pr.url} ({pr.head[:12]})")
-    return "\n".join(lines)
-
-
-def default_base_branch(root: Path, line: str) -> str:
-    """Prefer `releases/<line>` when that branch exists on origin."""
-    release_branch = f"releases/{line}"
-    result = run(
-        ["git", "ls-remote", "--heads", "origin", release_branch],
-        cwd=root,
-        check=False,
-    )
-    if result.stdout.strip():
-        return release_branch
-    return "main"
-
-
-def checkout_from_origin(root: Path, *, branch: str, base_branch: str) -> None:
-    """Create `branch` at the current tip of `origin/{base_branch}`."""
-    fetch = run(["git", "fetch", "origin", base_branch], cwd=root, check=False)
-    if fetch.returncode != 0:
-        raise ReleaseError(
-            f"could not fetch origin {base_branch}:\n"
-            f"{(fetch.stderr or fetch.stdout).strip()}"
-        )
-    checkout = run(
-        ["git", "checkout", "-B", branch, "FETCH_HEAD"],
-        cwd=root,
-        check=False,
-    )
-    if checkout.returncode != 0:
-        raise ReleaseError(
-            f"could not create {branch} from origin/{base_branch}. "
-            "Commit or stash local changes that conflict with that branch, "
-            "then rerun.\n"
-            f"{(checkout.stderr or checkout.stdout).strip()}"
-        )
-
-
-def commit_pin_files(root: Path, fork_tag: str) -> None:
-    """Commit the pin manifest and rewritten Cargo files on the current branch."""
-    git(root, "add", str(MANIFEST_REL), str(CARGO_TOML), str(CARGO_LOCK))
-    cached = run(["git", "diff", "--cached", "--quiet"], cwd=root, check=False)
-    if cached.returncode == 0:
-        print("no pin file changes to commit")
-        return
-    git(
-        root,
-        "commit",
-        "-m",
-        f"chore(deps): pin reth {fork_tag}",
-    )
-
-
-def create_base_pr(
-    root: Path,
-    *,
-    fork_tag: str,
-    prs: list[PatchPr],
-    base_branch: str,
-) -> None:
-    """Open a base/base PR for the generated pin."""
-    rows = "\n".join(f"| {pr.url} | `{pr.head}` |" for pr in prs)
-    body = f"""## Summary
-
-Pin Reth git workspace deps to `{fork_tag}`.
-
-| PR | Head |
-| --- | --- |
-{rows}
-
-## Test plan
-
-- [x] `just pin-reth-test`
-- [x] `just check-reth-pin`
-- [ ] `cargo check --locked -p base-reth-node -p base-builder-bin -p base-consensus`
-"""
-    run(
-        [
-            "gh",
-            "pr",
-            "create",
-            "--base",
-            base_branch,
-            "--title",
-            f"chore(deps): pin reth {fork_tag}",
-            "--body",
-            body,
-        ],
-        cwd=root,
-    )
-
-
-def fork_only_patch_urls(patches: object, *, upstream_url: str) -> list[str]:
-    """Return PR URLs that are not on `--upstream-repo`.
-
-    `drop` cannot claim those landed in an official Reth release. Retiring
-    Base-specific fork PRs is a later step; until then they stay in
-    `[[patches]]`.
-    """
-    if not isinstance(patches, list):
-        return []
-    upstream = owner_repo(upstream_url).lower()
-    leftover: list[str] = []
-    for entry in patches:
-        if not isinstance(entry, dict) or not isinstance(entry.get("pr"), str):
-            continue
-        spec = parse_pr_spec(entry["pr"])
-        repo = (spec.repo or upstream).lower()
-        if repo != upstream:
-            leftover.append(entry["pr"])
-    return leftover
-
-
-def drop_pin(
-    root: Path,
-    *,
-    release: str,
-    upstream_url: str,
-    skip_lock: bool,
-    dry_run: bool,
-    no_commit: bool,
-    no_pr: bool,
-    skip_push: bool,
-    base_branch: str | None,
-) -> None:
-    """Retarget the pin at an official release that contains the carried PRs."""
-    path = root / MANIFEST_REL
-    data = tomllib.loads(path.read_text(encoding="utf-8"))
-    patches = data.get("patches") or []
-    if not patches:
-        raise ReleaseError("no [[patches]] to resolve")
-    leftover = fork_only_patch_urls(patches, upstream_url=upstream_url)
-    if leftover:
-        details = ", ".join(leftover)
-        raise ReleaseError(
-            "cannot drop the fork pin while carrying Base-specific PRs "
-            f"({details}). Those stay on the fork until they are replaced; "
-            "`drop` only records official Reth releases for "
-            f"{owner_repo(upstream_url)} PRs."
-        )
-    resolved = list(data.get("resolved") or [])
-    for entry in patches:
-        if not isinstance(entry, dict) or not isinstance(entry.get("pr"), str):
-            raise ReleaseError("each [[patches]] entry needs `pr`")
-        resolved.append({"pr": entry["pr"], "release": release})
-    dropped_prs: list[PatchPr] = []
-    for entry in patches:
-        if not isinstance(entry, dict) or not isinstance(entry.get("pr"), str):
-            continue
-        spec = parse_pr_spec(entry["pr"])
-        dropped_prs.append(
-            PatchPr(
-                number=spec.number,
-                repo=spec.repo or owner_repo(upstream_url),
-                url=entry["pr"],
-                title="",
-                head=str(entry.get("head") or "0" * 40),
-                commits=(),
-            )
-        )
-    clone = ensure_fork_clone(root, DEFAULT_FORK_REPO, upstream_url)
-    git(clone, "fetch", "upstream", f"refs/tags/{release}:refs/tags/{release}", "--force")
-    upstream_rev = git(clone, "rev-parse", f"{release}^{{commit}}").strip().lower()
-    resolved_pairs = [(str(item["pr"]), str(item["release"])) for item in resolved]
-    manifest = render_manifest(
-        repository=upstream_url.rstrip("/").removesuffix(".git"),
-        reference=release,
-        rev=upstream_rev,
-        upstream_tag=release,
-        upstream_rev=upstream_rev,
-        patches=[],
-        resolved=resolved_pairs,
-    )
-    pin_branch = f"chore/reth-{release}"
-    target_branch = base_branch or "main"
-    if not no_commit and not dry_run:
-        checkout_from_origin(root, branch=pin_branch, base_branch=target_branch)
-
-    path.write_text(manifest, encoding="utf-8")
-    apply_args = ["apply"]
-    if skip_lock:
-        apply_args.append("--skip-lock")
-    pin_reth(root, *apply_args)
-    if not no_commit and not dry_run:
-        commit_pin_files(root, release)
-        if not skip_push:
-            git(root, "push", "-u", "origin", "HEAD")
-            if not no_pr:
-                create_base_pr(
-                    root,
-                    fork_tag=release,
-                    prs=dropped_prs,
-                    base_branch=target_branch,
-                )
-    print(f"dropped fork pin; now tracking {upstream_url} {release} ({upstream_rev})")
 
 
 class ReleaseTests(unittest.TestCase):
@@ -775,34 +523,6 @@ class ReleaseTests(unittest.TestCase):
         self.assertEqual(squash_marker(fork), "backport(base/reth#26708):")
         self.assertNotEqual(squash_marker(upstream), squash_marker(fork))
 
-    def test_drop_refuses_fork_only_prs(self) -> None:
-        leftover = fork_only_patch_urls(
-            [
-                {
-                    "pr": "https://github.com/paradigmxyz/reth/pull/26708",
-                    "head": "0b5608325ca86fc2381b49de10b01c975e0ec99f",
-                },
-                {
-                    "pr": "https://github.com/base/reth/pull/12",
-                    "head": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-                },
-            ],
-            upstream_url="https://github.com/paradigmxyz/reth",
-        )
-        self.assertEqual(leftover, ["https://github.com/base/reth/pull/12"])
-        self.assertEqual(
-            fork_only_patch_urls(
-                [
-                    {
-                        "pr": "https://github.com/paradigmxyz/reth/pull/26708",
-                        "head": "0b5608325ca86fc2381b49de10b01c975e0ec99f",
-                    }
-                ],
-                upstream_url="https://github.com/paradigmxyz/reth",
-            ),
-            [],
-        )
-
     def test_next_base_tag(self) -> None:
         self.assertEqual(next_base_tag("v2.5.1", []), "v2.5.1-base.1")
         self.assertEqual(
@@ -838,10 +558,6 @@ class ReleaseTests(unittest.TestCase):
         )
         self.assertIn('repository = "https://github.com/base/reth"', text)
         self.assertIn("etc/upstream-pins/README.md", text)
-        self.assertIn('reference = "v2.5.1-base.1"', text)
-        self.assertIn("[[patches]]", text)
         self.assertIn(pr.url, text)
         self.assertIn(fork_pr.url, text)
-        self.assertIn(pr.head, text)
         self.assertNotIn("commit =", text)
-        self.assertIn("must not be opened upstream", text)

--- a/etc/scripts/local/reth_release.py
+++ b/etc/scripts/local/reth_release.py
@@ -1,0 +1,847 @@
+"""Build a squashed base/reth tag and pin it from base/base.
+
+`prepare` resolves GitHub PRs, recreates a backport branch from an official
+Reth tag, squash-picks each PR, tags the tip, writes the pin manifest, rewrites
+workspace git deps, and opens a base/base PR.
+
+PR identity includes the repository. Bare `--pr N` is a PR on `--upstream-repo`.
+A full URL may point at that repo or at `--fork` (default `base/reth`) so
+Base-specific patches do not have to be opened upstream.
+
+`drop` records upstream PRs in `[[resolved]]` and retargets the pin at an
+official Reth release. It refuses while `[[patches]]` still lists fork PRs:
+those never land in paradigmxyz/reth.
+
+Pin commits are created from `origin/<base>` (`releases/<line>` or `main`),
+not from the local HEAD. See `etc/upstream-pins/README.md`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tomllib
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+
+MANIFEST_REL = Path("etc/upstream-pins/reth.toml")
+CARGO_TOML = Path("Cargo.toml")
+CARGO_LOCK = Path("Cargo.lock")
+FORK_CLONE_REL = Path(".tmp/base-reth")
+DEFAULT_UPSTREAM_REPO = "https://github.com/paradigmxyz/reth"
+DEFAULT_FORK_REPO = "https://github.com/base/reth"
+PR_SPEC_RE = re.compile(
+    r"^(?:https://github\.com/(?P<owner>[^/]+)/(?P<name>[^/]+)/pull/)?"
+    r"(?P<num>\d+)/?$",
+    re.IGNORECASE,
+)
+
+
+class ReleaseError(RuntimeError):
+    """Raised when preparing or dropping a Reth fork pin fails."""
+
+
+@dataclass(frozen=True)
+class PrSpec:
+    """A `--pr` value before metadata is fetched.
+
+    `repo` is `owner/repo` from a full pull URL, or `None` when the spec is a
+    bare number (resolved against `--upstream-repo`).
+    """
+
+    number: int
+    repo: str | None
+
+
+@dataclass(frozen=True)
+class PatchPr:
+    """One GitHub PR to squash onto the backport branch.
+
+    `repo` is `owner/repo`. That is `paradigmxyz/reth` for upstream backports
+    and the Base fork for patches that should not be opened upstream.
+    """
+
+    number: int
+    repo: str
+    url: str
+    title: str
+    head: str
+    commits: tuple[str, ...]
+
+
+def parse_pr_spec(spec: str) -> PrSpec:
+    """Parse a PR number, and the repo when the spec is a GitHub pull URL."""
+    match = PR_SPEC_RE.fullmatch(spec.strip())
+    if match is None:
+        raise ReleaseError(
+            f"invalid PR spec {spec!r}; use a number on --upstream-repo "
+            "or a GitHub pull URL on that repo or --fork"
+        )
+    owner = match.group("owner")
+    name = match.group("name")
+    repo = f"{owner}/{name}" if owner and name else None
+    return PrSpec(number=int(match.group("num")), repo=repo)
+
+
+def resolve_pr_repo(spec: PrSpec, *, upstream_url: str, fork_url: str) -> str:
+    """Return `owner/repo` for a PR spec.
+
+    Allowed sources are `--upstream-repo` and `--fork`. Bare numbers use
+    `--upstream-repo`. Fork PRs are the path for Base-specific patches.
+    """
+    upstream = owner_repo(upstream_url)
+    fork = owner_repo(fork_url)
+    repo = spec.repo or upstream
+    allowed = {upstream.lower(), fork.lower()}
+    if repo.lower() not in allowed:
+        raise ReleaseError(
+            f"PR #{spec.number} is on {repo}; patches must come from "
+            f"{upstream} or {fork}. Pass a full pull URL on one of those "
+            "repos rather than opening a Base-specific change upstream."
+        )
+    return repo
+
+
+def squash_marker(pr: PatchPr) -> str:
+    """Subject prefix that identifies this PR on the backport branch."""
+    return f"backport({pr.repo}#{pr.number}):"
+
+
+def next_base_tag(upstream_tag: str, existing: list[str]) -> str:
+    """Return the next `{upstream_tag}-base.N` tag."""
+    prefix = f"{upstream_tag}-base."
+    numbers: list[int] = []
+    for tag in existing:
+        name = tag.removeprefix("refs/tags/")
+        if name.startswith("refs/tags/"):
+            name = name[len("refs/tags/") :]
+        if name.startswith(prefix) and name[len(prefix) :].isdigit():
+            numbers.append(int(name[len(prefix) :]))
+    return f"{prefix}{max(numbers, default=0) + 1}"
+
+
+def infer_line(root: Path) -> str:
+    """Infer the consumer line from the current git branch."""
+    branch = git(root, "rev-parse", "--abbrev-ref", "HEAD").strip()
+    if branch.startswith("releases/"):
+        return branch[len("releases/") :]
+    raise ReleaseError(
+        f"current branch is {branch}; pass --line (for example v1.3.0)"
+    )
+
+
+def owner_repo(url: str) -> str:
+    """Return `owner/repo` from an https GitHub URL."""
+    stripped = url.rstrip("/")
+    if stripped.endswith(".git"):
+        stripped = stripped[: -len(".git")]
+    marker = "github.com/"
+    idx = stripped.lower().find(marker)
+    if idx < 0:
+        raise ReleaseError(f"not a GitHub URL: {url}")
+    return stripped[idx + len(marker) :]
+
+
+def run(
+    args: list[str],
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Run a command and capture text output."""
+    result = subprocess.run(
+        args,
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        output = (result.stderr or result.stdout).strip()
+        raise ReleaseError(f"`{' '.join(args)}` failed:\n{output}")
+    return result
+
+
+def git(cwd: Path, *args: str, check: bool = True) -> str:
+    """Run git in `cwd` and return stdout."""
+    return run(["git", *args], cwd=cwd, check=check).stdout
+
+
+def gh_json(args: list[str]) -> object:
+    """Run `gh` and parse JSON stdout."""
+    result = run(["gh", *args])
+    return json.loads(result.stdout)
+
+
+def fetch_pr(repo: str, number: int) -> PatchPr:
+    """Load PR metadata and the ordered non-merge commit list."""
+    data = gh_json(
+        [
+            "pr",
+            "view",
+            str(number),
+            "--repo",
+            repo,
+            "--json",
+            "number,url,title,headRefOid,commits",
+        ]
+    )
+    if not isinstance(data, dict):
+        raise ReleaseError(f"unexpected gh pr view payload for {repo}#{number}")
+    commits_raw = data.get("commits") or []
+    commits: list[str] = []
+    for entry in commits_raw:
+        if not isinstance(entry, dict):
+            continue
+        oid = entry.get("oid")
+        if isinstance(oid, str):
+            commits.append(oid.lower())
+    if not commits:
+        raise ReleaseError(f"{repo}#{number} has no commits to squash")
+    head = data.get("headRefOid")
+    url = data.get("url")
+    title = data.get("title")
+    if not isinstance(head, str) or not isinstance(url, str) or not isinstance(title, str):
+        raise ReleaseError(f"{repo}#{number} is missing url, title, or headRefOid")
+    return PatchPr(
+        number=int(data.get("number") or number),
+        repo=repo,
+        url=url,
+        title=title,
+        head=head.lower(),
+        commits=tuple(commits),
+    )
+
+
+def ensure_fork_clone(root: Path, fork_url: str, upstream_url: str) -> Path:
+    """Clone or fetch the Reth fork under `.tmp/base-reth`."""
+    clone = root / FORK_CLONE_REL
+    clone.parent.mkdir(parents=True, exist_ok=True)
+    if not (clone / ".git").exists():
+        run(["git", "clone", fork_url, str(clone)])
+    git(clone, "remote", "set-url", "origin", fork_url)
+    remotes = git(clone, "remote").split()
+    if "upstream" not in remotes:
+        git(clone, "remote", "add", "upstream", upstream_url)
+    else:
+        git(clone, "remote", "set-url", "upstream", upstream_url)
+    git(clone, "fetch", "origin", "--tags", "--prune")
+    git(clone, "fetch", "upstream", "--tags", "--prune")
+    return clone
+
+
+def existing_tags(clone: Path) -> list[str]:
+    """List tag names from origin and the local clone."""
+    tags: set[str] = set()
+    remote = run(
+        ["git", "ls-remote", "--tags", "origin"],
+        cwd=clone,
+        check=False,
+    )
+    for line in remote.stdout.splitlines():
+        if not line.strip() or "^{}" in line:
+            continue
+        tags.add(line.split("\t", 1)[1].removeprefix("refs/tags/"))
+    local = git(clone, "tag", "--list")
+    tags.update(name for name in local.splitlines() if name)
+    return sorted(tags)
+
+
+def already_squashed(clone: Path, upstream_tag: str, pr: PatchPr) -> bool:
+    """Return True when this PR's squash marker is already on the branch."""
+    log = git(clone, "log", "--format=%s", f"{upstream_tag}..HEAD", check=False)
+    needle = squash_marker(pr)
+    return any(line.startswith(needle) for line in log.splitlines())
+
+
+def squash_pr(
+    clone: Path,
+    pr: PatchPr,
+    env: dict[str, str],
+) -> None:
+    """Cherry-pick every PR commit and squash them into one commit."""
+    source = f"https://github.com/{pr.repo}"
+    local_ref = f"refs/reths/{pr.repo.replace('/', '-')}-{pr.number}"
+    git(
+        clone,
+        "fetch",
+        source,
+        f"pull/{pr.number}/head:{local_ref}",
+        "--force",
+    )
+    result = run(
+        ["git", "cherry-pick", "-n", *pr.commits],
+        cwd=clone,
+        env=env,
+        check=False,
+    )
+    if result.returncode != 0:
+        run(["git", "cherry-pick", "--abort"], cwd=clone, check=False)
+        run(["git", "reset", "--hard"], cwd=clone, check=False)
+        raise ReleaseError(
+            f"{pr.repo}#{pr.number} does not apply cleanly onto this baseline. "
+            "Fix the PR against that baseline, then rerun prepare.\n"
+            f"{(result.stderr or result.stdout).strip()}"
+        )
+    cached = run(["git", "diff", "--cached", "--quiet"], cwd=clone, check=False)
+    if cached.returncode == 0:
+        raise ReleaseError(
+            f"{pr.repo}#{pr.number} produced an empty squash on this baseline"
+        )
+    message = (
+        f"{squash_marker(pr)} {pr.title}\n\n"
+        f"Squashed {pr.url} at {pr.head}."
+    )
+    run(["git", "commit", "-m", message], cwd=clone, env=env)
+
+
+def render_manifest(
+    *,
+    repository: str,
+    reference: str,
+    rev: str,
+    upstream_tag: str,
+    upstream_rev: str,
+    patches: list[PatchPr],
+    resolved: list[tuple[str, str]],
+) -> str:
+    """Render `etc/upstream-pins/reth.toml`."""
+    lines = [
+        "# Authoritative Reth git pin for [workspace.dependencies].",
+        "#",
+        "# Workflow and limitations: etc/upstream-pins/README.md",
+        "#",
+        "# `just pin-reth` rewrites every git-based `reth-*` crate to this repository",
+        "# and reference, then refreshes Cargo.lock.",
+        "# `just check-reth-pin` verifies Cargo.toml and Cargo.lock match this file.",
+        "# `just reth-prepare-release` builds the fork tag and writes this file.",
+        "#",
+        "# `reference` is the human-facing git ref (release tag, fork tag, or SHA).",
+        "# `rev` is the immutable commit that `reference` currently resolves to.",
+        "# Cargo.toml uses `tag =` when `reference` is not a SHA, and `rev =` otherwise.",
+        "#",
+        "# Each [[patches]] entry is a whole GitHub PR squashed to one fork commit.",
+        "# Identity is the PR URL, including the repository: paradigmxyz/reth for",
+        "# upstream backports, or the Base fork (`base/reth`) for patches that",
+        "# must not be opened upstream. `head` is the PR tip (or merge commit).",
+        "#",
+        "# `[[resolved]]` is only for upstream PRs that landed in an official",
+        "# Reth release. Do not record a base/reth PR against an upstream tag.",
+        "",
+        f'repository = "{repository}"',
+        f'reference = "{reference}"',
+        f'rev = "{rev}"',
+        "",
+        "[upstream_base]",
+        f'tag = "{upstream_tag}"',
+        f'rev = "{upstream_rev}"',
+        "",
+    ]
+    if patches:
+        for pr in patches:
+            lines.extend(
+                [
+                    "[[patches]]",
+                    f'pr = "{pr.url}"',
+                    f'head = "{pr.head}"',
+                    "",
+                ]
+            )
+    if resolved:
+        for pr_url, release in resolved:
+            lines.extend(
+                [
+                    "[[resolved]]",
+                    f'pr = "{pr_url}"',
+                    f'release = "{release}"',
+                    "",
+                ]
+            )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def pin_reth(root: Path, *args: str) -> None:
+    """Run the pin helper in this checkout."""
+    script = Path(__file__).with_name("pin-reth.py")
+    result = run([sys.executable, str(script), *args], cwd=root, check=False)
+    sys.stdout.write(result.stdout)
+    sys.stderr.write(result.stderr)
+    if result.returncode != 0:
+        raise ReleaseError("pin-reth failed")
+
+
+def git_identity_env(root: Path) -> dict[str, str]:
+    """Copy author identity from the base/base checkout into the fork clone."""
+    env = os.environ.copy()
+    name = git(root, "log", "-1", "--format=%an").strip()
+    email = git(root, "log", "-1", "--format=%ae").strip()
+    if name:
+        env.setdefault("GIT_AUTHOR_NAME", name)
+        env.setdefault("GIT_COMMITTER_NAME", name)
+    if email:
+        env.setdefault("GIT_AUTHOR_EMAIL", email)
+        env.setdefault("GIT_COMMITTER_EMAIL", email)
+    return env
+
+
+def current_resolved(root: Path) -> list[tuple[str, str]]:
+    """Return existing `[[resolved]]` pairs from the pin manifest, if any."""
+    path = root / MANIFEST_REL
+    if not path.exists():
+        return []
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    pairs: list[tuple[str, str]] = []
+    for entry in data.get("resolved") or []:
+        if not isinstance(entry, dict):
+            continue
+        pr = entry.get("pr")
+        release = entry.get("release")
+        if isinstance(pr, str) and isinstance(release, str):
+            pairs.append((pr, release))
+    return pairs
+
+
+def prepare_release(
+    root: Path,
+    *,
+    upstream_tag: str,
+    pr_specs: list[str],
+    line: str | None,
+    fork_url: str,
+    upstream_url: str,
+    dry_run: bool,
+    skip_push: bool,
+    skip_lock: bool,
+    no_commit: bool,
+    no_pr: bool,
+    base_branch: str | None,
+) -> None:
+    """Build the fork tag, write the pin, and open the base/base PR."""
+    if not pr_specs:
+        raise ReleaseError("pass at least one --pr")
+    line = line or infer_line(root)
+    prs: list[PatchPr] = []
+    for spec in (parse_pr_spec(item) for item in pr_specs):
+        repo = resolve_pr_repo(spec, upstream_url=upstream_url, fork_url=fork_url)
+        prs.append(fetch_pr(repo, spec.number))
+    clone = ensure_fork_clone(root, fork_url, upstream_url)
+    git(clone, "fetch", "upstream", f"refs/tags/{upstream_tag}:refs/tags/{upstream_tag}", "--force")
+    upstream_rev = git(clone, "rev-parse", f"{upstream_tag}^{{commit}}").strip().lower()
+    fork_tag = next_base_tag(upstream_tag, existing_tags(clone))
+    backport_branch = f"backport/{upstream_tag}/{line}"
+
+    env = git_identity_env(root)
+    remote_backport = run(
+        ["git", "ls-remote", "--heads", "origin", backport_branch],
+        cwd=clone,
+        check=False,
+    ).stdout.strip()
+    if remote_backport:
+        git(clone, "fetch", "origin", backport_branch)
+        git(clone, "checkout", "-B", backport_branch, f"origin/{backport_branch}")
+    else:
+        git(clone, "checkout", "-B", backport_branch, upstream_rev)
+    for pr in prs:
+        if already_squashed(clone, upstream_tag, pr):
+            print(f"already on {backport_branch}: {pr.url}")
+            continue
+        print(f"squashing {pr.url} ({len(pr.commits)} commits) onto {upstream_tag}")
+        squash_pr(clone, pr, env)
+    fork_rev = git(clone, "rev-parse", "HEAD").strip().lower()
+    existing_local_tag = git(clone, "tag", "--list", fork_tag).strip()
+    if existing_local_tag:
+        git(clone, "tag", "-d", fork_tag)
+    run(
+        ["git", "tag", "-a", fork_tag, "-m", annotated_tag_message(upstream_tag, prs)],
+        cwd=clone,
+        env=env,
+    )
+
+    if not dry_run and not skip_push:
+        git(clone, "push", "-u", "origin", backport_branch)
+        git(clone, "push", "origin", f"refs/tags/{fork_tag}")
+
+    pin_branch = f"chore/reth-{fork_tag}"
+    target_branch = base_branch or default_base_branch(root, line)
+    if not no_commit and not dry_run:
+        checkout_from_origin(root, branch=pin_branch, base_branch=target_branch)
+
+    manifest = render_manifest(
+        repository=fork_url.rstrip("/").removesuffix(".git"),
+        reference=fork_tag,
+        rev=fork_rev,
+        upstream_tag=upstream_tag,
+        upstream_rev=upstream_rev,
+        patches=prs,
+        resolved=current_resolved(root),
+    )
+    (root / MANIFEST_REL).parent.mkdir(parents=True, exist_ok=True)
+    (root / MANIFEST_REL).write_text(manifest, encoding="utf-8")
+    print(f"wrote {MANIFEST_REL} -> {fork_url} {fork_tag} ({fork_rev})")
+
+    apply_args = ["apply"]
+    if skip_lock:
+        apply_args.append("--skip-lock")
+    pin_reth(root, *apply_args)
+
+    if not no_commit and not dry_run:
+        commit_pin_files(root, fork_tag)
+        if not skip_push:
+            git(root, "push", "-u", "origin", "HEAD")
+            if not no_pr:
+                create_base_pr(
+                    root,
+                    fork_tag=fork_tag,
+                    prs=prs,
+                    base_branch=target_branch,
+                )
+    print(
+        f"prepared {fork_tag} on {backport_branch} "
+        f"({len(prs)} PR(s) squashed from {upstream_tag})"
+    )
+
+
+def annotated_tag_message(upstream_tag: str, prs: list[PatchPr]) -> str:
+    """Body for the immutable fork tag."""
+    lines = [
+        f"Reth {upstream_tag} plus squashed PRs.",
+        "",
+    ]
+    for pr in prs:
+        lines.append(f"- {pr.url} ({pr.head[:12]})")
+    return "\n".join(lines)
+
+
+def default_base_branch(root: Path, line: str) -> str:
+    """Prefer `releases/<line>` when that branch exists on origin."""
+    release_branch = f"releases/{line}"
+    result = run(
+        ["git", "ls-remote", "--heads", "origin", release_branch],
+        cwd=root,
+        check=False,
+    )
+    if result.stdout.strip():
+        return release_branch
+    return "main"
+
+
+def checkout_from_origin(root: Path, *, branch: str, base_branch: str) -> None:
+    """Create `branch` at the current tip of `origin/{base_branch}`."""
+    fetch = run(["git", "fetch", "origin", base_branch], cwd=root, check=False)
+    if fetch.returncode != 0:
+        raise ReleaseError(
+            f"could not fetch origin {base_branch}:\n"
+            f"{(fetch.stderr or fetch.stdout).strip()}"
+        )
+    checkout = run(
+        ["git", "checkout", "-B", branch, "FETCH_HEAD"],
+        cwd=root,
+        check=False,
+    )
+    if checkout.returncode != 0:
+        raise ReleaseError(
+            f"could not create {branch} from origin/{base_branch}. "
+            "Commit or stash local changes that conflict with that branch, "
+            "then rerun.\n"
+            f"{(checkout.stderr or checkout.stdout).strip()}"
+        )
+
+
+def commit_pin_files(root: Path, fork_tag: str) -> None:
+    """Commit the pin manifest and rewritten Cargo files on the current branch."""
+    git(root, "add", str(MANIFEST_REL), str(CARGO_TOML), str(CARGO_LOCK))
+    cached = run(["git", "diff", "--cached", "--quiet"], cwd=root, check=False)
+    if cached.returncode == 0:
+        print("no pin file changes to commit")
+        return
+    git(
+        root,
+        "commit",
+        "-m",
+        f"chore(deps): pin reth {fork_tag}",
+    )
+
+
+def create_base_pr(
+    root: Path,
+    *,
+    fork_tag: str,
+    prs: list[PatchPr],
+    base_branch: str,
+) -> None:
+    """Open a base/base PR for the generated pin."""
+    rows = "\n".join(f"| {pr.url} | `{pr.head}` |" for pr in prs)
+    body = f"""## Summary
+
+Pin Reth git workspace deps to `{fork_tag}`.
+
+| PR | Head |
+| --- | --- |
+{rows}
+
+## Test plan
+
+- [x] `just pin-reth-test`
+- [x] `just check-reth-pin`
+- [ ] `cargo check --locked -p base-reth-node -p base-builder-bin -p base-consensus`
+"""
+    run(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--base",
+            base_branch,
+            "--title",
+            f"chore(deps): pin reth {fork_tag}",
+            "--body",
+            body,
+        ],
+        cwd=root,
+    )
+
+
+def fork_only_patch_urls(patches: object, *, upstream_url: str) -> list[str]:
+    """Return PR URLs that are not on `--upstream-repo`.
+
+    `drop` cannot claim those landed in an official Reth release. Retiring
+    Base-specific fork PRs is a later step; until then they stay in
+    `[[patches]]`.
+    """
+    if not isinstance(patches, list):
+        return []
+    upstream = owner_repo(upstream_url).lower()
+    leftover: list[str] = []
+    for entry in patches:
+        if not isinstance(entry, dict) or not isinstance(entry.get("pr"), str):
+            continue
+        spec = parse_pr_spec(entry["pr"])
+        repo = (spec.repo or upstream).lower()
+        if repo != upstream:
+            leftover.append(entry["pr"])
+    return leftover
+
+
+def drop_pin(
+    root: Path,
+    *,
+    release: str,
+    upstream_url: str,
+    skip_lock: bool,
+    dry_run: bool,
+    no_commit: bool,
+    no_pr: bool,
+    skip_push: bool,
+    base_branch: str | None,
+) -> None:
+    """Retarget the pin at an official release that contains the carried PRs."""
+    path = root / MANIFEST_REL
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    patches = data.get("patches") or []
+    if not patches:
+        raise ReleaseError("no [[patches]] to resolve")
+    leftover = fork_only_patch_urls(patches, upstream_url=upstream_url)
+    if leftover:
+        details = ", ".join(leftover)
+        raise ReleaseError(
+            "cannot drop the fork pin while carrying Base-specific PRs "
+            f"({details}). Those stay on the fork until they are replaced; "
+            "`drop` only records official Reth releases for "
+            f"{owner_repo(upstream_url)} PRs."
+        )
+    resolved = list(data.get("resolved") or [])
+    for entry in patches:
+        if not isinstance(entry, dict) or not isinstance(entry.get("pr"), str):
+            raise ReleaseError("each [[patches]] entry needs `pr`")
+        resolved.append({"pr": entry["pr"], "release": release})
+    dropped_prs: list[PatchPr] = []
+    for entry in patches:
+        if not isinstance(entry, dict) or not isinstance(entry.get("pr"), str):
+            continue
+        spec = parse_pr_spec(entry["pr"])
+        dropped_prs.append(
+            PatchPr(
+                number=spec.number,
+                repo=spec.repo or owner_repo(upstream_url),
+                url=entry["pr"],
+                title="",
+                head=str(entry.get("head") or "0" * 40),
+                commits=(),
+            )
+        )
+    clone = ensure_fork_clone(root, DEFAULT_FORK_REPO, upstream_url)
+    git(clone, "fetch", "upstream", f"refs/tags/{release}:refs/tags/{release}", "--force")
+    upstream_rev = git(clone, "rev-parse", f"{release}^{{commit}}").strip().lower()
+    resolved_pairs = [(str(item["pr"]), str(item["release"])) for item in resolved]
+    manifest = render_manifest(
+        repository=upstream_url.rstrip("/").removesuffix(".git"),
+        reference=release,
+        rev=upstream_rev,
+        upstream_tag=release,
+        upstream_rev=upstream_rev,
+        patches=[],
+        resolved=resolved_pairs,
+    )
+    pin_branch = f"chore/reth-{release}"
+    target_branch = base_branch or "main"
+    if not no_commit and not dry_run:
+        checkout_from_origin(root, branch=pin_branch, base_branch=target_branch)
+
+    path.write_text(manifest, encoding="utf-8")
+    apply_args = ["apply"]
+    if skip_lock:
+        apply_args.append("--skip-lock")
+    pin_reth(root, *apply_args)
+    if not no_commit and not dry_run:
+        commit_pin_files(root, release)
+        if not skip_push:
+            git(root, "push", "-u", "origin", "HEAD")
+            if not no_pr:
+                create_base_pr(
+                    root,
+                    fork_tag=release,
+                    prs=dropped_prs,
+                    base_branch=target_branch,
+                )
+    print(f"dropped fork pin; now tracking {upstream_url} {release} ({upstream_rev})")
+
+
+class ReleaseTests(unittest.TestCase):
+    """Unit tests for PR specs, tag allocation, and manifest rendering."""
+
+    def test_parse_pr_spec_number_and_url(self) -> None:
+        self.assertEqual(parse_pr_spec("26708"), PrSpec(26708, None))
+        self.assertEqual(
+            parse_pr_spec("https://github.com/paradigmxyz/reth/pull/26766"),
+            PrSpec(26766, "paradigmxyz/reth"),
+        )
+        self.assertEqual(
+            parse_pr_spec("https://github.com/base/reth/pull/12"),
+            PrSpec(12, "base/reth"),
+        )
+
+    def test_parse_pr_spec_rejects_garbage(self) -> None:
+        with self.assertRaises(ReleaseError):
+            parse_pr_spec("not-a-pr")
+
+    def test_resolve_pr_repo_allows_upstream_and_fork(self) -> None:
+        upstream = "https://github.com/paradigmxyz/reth"
+        fork = "https://github.com/base/reth"
+        self.assertEqual(
+            resolve_pr_repo(PrSpec(26708, None), upstream_url=upstream, fork_url=fork),
+            "paradigmxyz/reth",
+        )
+        self.assertEqual(
+            resolve_pr_repo(
+                PrSpec(12, "base/reth"),
+                upstream_url=upstream,
+                fork_url=fork,
+            ),
+            "base/reth",
+        )
+
+    def test_resolve_pr_repo_rejects_other_repos(self) -> None:
+        with self.assertRaises(ReleaseError):
+            resolve_pr_repo(
+                PrSpec(1, "someone/reth"),
+                upstream_url="https://github.com/paradigmxyz/reth",
+                fork_url="https://github.com/base/reth",
+            )
+
+    def test_squash_marker_includes_repo(self) -> None:
+        upstream = PatchPr(
+            number=26708,
+            repo="paradigmxyz/reth",
+            url="https://github.com/paradigmxyz/reth/pull/26708",
+            title="engine handoff",
+            head="0b5608325ca86fc2381b49de10b01c975e0ec99f",
+            commits=("0b5608325ca86fc2381b49de10b01c975e0ec99f",),
+        )
+        fork = PatchPr(
+            number=26708,
+            repo="base/reth",
+            url="https://github.com/base/reth/pull/26708",
+            title="base-specific",
+            head="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            commits=("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",),
+        )
+        self.assertEqual(squash_marker(upstream), "backport(paradigmxyz/reth#26708):")
+        self.assertEqual(squash_marker(fork), "backport(base/reth#26708):")
+        self.assertNotEqual(squash_marker(upstream), squash_marker(fork))
+
+    def test_drop_refuses_fork_only_prs(self) -> None:
+        leftover = fork_only_patch_urls(
+            [
+                {
+                    "pr": "https://github.com/paradigmxyz/reth/pull/26708",
+                    "head": "0b5608325ca86fc2381b49de10b01c975e0ec99f",
+                },
+                {
+                    "pr": "https://github.com/base/reth/pull/12",
+                    "head": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                },
+            ],
+            upstream_url="https://github.com/paradigmxyz/reth",
+        )
+        self.assertEqual(leftover, ["https://github.com/base/reth/pull/12"])
+        self.assertEqual(
+            fork_only_patch_urls(
+                [
+                    {
+                        "pr": "https://github.com/paradigmxyz/reth/pull/26708",
+                        "head": "0b5608325ca86fc2381b49de10b01c975e0ec99f",
+                    }
+                ],
+                upstream_url="https://github.com/paradigmxyz/reth",
+            ),
+            [],
+        )
+
+    def test_next_base_tag(self) -> None:
+        self.assertEqual(next_base_tag("v2.5.1", []), "v2.5.1-base.1")
+        self.assertEqual(
+            next_base_tag("v2.5.1", ["v2.5.1-base.1", "v2.5.1-base.2", "v2.4.0-base.9"]),
+            "v2.5.1-base.3",
+        )
+
+    def test_render_manifest_records_prs(self) -> None:
+        pr = PatchPr(
+            number=26708,
+            repo="paradigmxyz/reth",
+            url="https://github.com/paradigmxyz/reth/pull/26708",
+            title="engine handoff",
+            head="0b5608325ca86fc2381b49de10b01c975e0ec99f",
+            commits=("0b5608325ca86fc2381b49de10b01c975e0ec99f",),
+        )
+        fork_pr = PatchPr(
+            number=12,
+            repo="base/reth",
+            url="https://github.com/base/reth/pull/12",
+            title="base-specific",
+            head="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            commits=("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",),
+        )
+        text = render_manifest(
+            repository="https://github.com/base/reth",
+            reference="v2.5.1-base.1",
+            rev="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            upstream_tag="v2.5.1",
+            upstream_rev="6dec1b96b625584956883c34ad0eafbe550480ac",
+            patches=[pr, fork_pr],
+            resolved=[],
+        )
+        self.assertIn('repository = "https://github.com/base/reth"', text)
+        self.assertIn("etc/upstream-pins/README.md", text)
+        self.assertIn('reference = "v2.5.1-base.1"', text)
+        self.assertIn("[[patches]]", text)
+        self.assertIn(pr.url, text)
+        self.assertIn(fork_pr.url, text)
+        self.assertIn(pr.head, text)
+        self.assertNotIn("commit =", text)
+        self.assertIn("must not be opened upstream", text)

--- a/etc/scripts/local/reth_release.py
+++ b/etc/scripts/local/reth_release.py
@@ -100,8 +100,12 @@ def squash_marker(pr: PatchPr) -> str:
 
 
 def next_base_tag(upstream_tag: str, existing: list[str]) -> str:
-    """Return the next `{upstream_tag}-base.N` tag."""
-    prefix = f"{upstream_tag}-base."
+    """Return the next `base-{upstream_tag}.N` tag.
+
+    Names must not match `v*`. `base/reth`'s release workflow builds
+    binaries for every `v*` tag.
+    """
+    prefix = f"base-{upstream_tag}."
     numbers: list[int] = []
     for tag in existing:
         name = tag.removeprefix("refs/tags/")
@@ -524,10 +528,13 @@ class ReleaseTests(unittest.TestCase):
         self.assertNotEqual(squash_marker(upstream), squash_marker(fork))
 
     def test_next_base_tag(self) -> None:
-        self.assertEqual(next_base_tag("v2.5.1", []), "v2.5.1-base.1")
+        self.assertEqual(next_base_tag("v2.5.1", []), "base-v2.5.1.1")
         self.assertEqual(
-            next_base_tag("v2.5.1", ["v2.5.1-base.1", "v2.5.1-base.2", "v2.4.0-base.9"]),
-            "v2.5.1-base.3",
+            next_base_tag(
+                "v2.5.1",
+                ["base-v2.5.1.1", "base-v2.5.1.2", "v2.5.1-base.1"],
+            ),
+            "base-v2.5.1.3",
         )
 
     def test_render_manifest_records_prs(self) -> None:
@@ -549,7 +556,7 @@ class ReleaseTests(unittest.TestCase):
         )
         text = render_manifest(
             repository="https://github.com/base/reth",
-            reference="v2.5.1-base.1",
+            reference="base-v2.5.1.1",
             rev="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             upstream_tag="v2.5.1",
             upstream_rev="6dec1b96b625584956883c34ad0eafbe550480ac",

--- a/etc/upstream-pins/README.md
+++ b/etc/upstream-pins/README.md
@@ -10,7 +10,6 @@ just pin-reth
 just check-reth-pin
 just pin-reth-test
 just reth-prepare-release --upstream v2.5.1 --pr 26708 --pr 26766
-just reth-drop-pin --release v2.6.0
 ```
 
 `--pr 26708` is a PR on `--upstream-repo` (default `paradigmxyz/reth`). A
@@ -19,57 +18,24 @@ full GitHub pull URL is fetched from that repository. Allowed sources are
 for Base-specific patches instead of opening them upstream.
 
 `--line` is inferred from `releases/<line>` when you are on that branch;
-otherwise pass it. `--fork` can point at a personal fork until `base/reth`
-is the tagged backport repo.
-
-Preview without pushing or opening a PR:
-
-```bash
-just reth-prepare-release --upstream v2.5.1 --pr 26708 --line v1.3.0 \
-  --dry-run --skip-push --no-commit --no-pr
-```
+otherwise pass it. `--skip-push` squashes and tags locally without
+publishing the fork.
 
 ## Workflow
 
 1. Decide the official Reth tag and the PRs to carry.
 2. Run `just reth-prepare-release`. It squashes each PR onto that tag in
-   the fork, publishes `vX.Y.Z-base.N`, rewrites this manifest and
-   Cargo.toml, and opens a `base/base` PR.
-3. Review and merge that PR. After merge, `just check-reth-pin` is the
-   local check that Cargo still matches this file.
-4. When an official Reth release contains **every** carried *upstream* PR
-   and no `base/reth` PRs remain, run `just reth-drop-pin --release vX.Y.Z`.
-
-The pin commit is created from `origin/releases/<line>` when that branch
-exists, otherwise `origin/main`. Override with `--base-branch`. Extra
-commits on the local HEAD are not included.
+   the fork, publishes `vX.Y.Z-base.N`, writes this manifest, and rewrites
+   Cargo.toml in the current tree.
+3. Commit and open the `base/base` PR yourself.
+4. After merge, `just check-reth-pin` confirms Cargo still matches this file.
+5. To return to an official Reth tag, point `repository`, `reference`, and
+   `rev` at `paradigmxyz/reth`, clear `[[patches]]` that landed in that
+   release, and run `just pin-reth`.
 
 A squash conflict is the only hard stop. Fix the PR against that official
-tag and rerun. There is no conflict-resolution loop.
+tag and rerun.
 
-## Limitations
-
-These are intentional. They are not handled automatically:
-
-- **`--pr` replaces the patch set.** Pass every PR you still want to
-  carry. Apply refuses to drop a carried PR unless it is listed in
-  `[[resolved]]`, so omitting one fails instead of appending.
-- **`reth-drop-pin` is all-or-nothing for upstream PRs.** It records every
-  `[[patches]]` entry as contained in `--release`. If only some landed,
-  rerun `reth-prepare-release` against the new official tag with the
-  leftover `--pr` list, and add `[[resolved]]` rows for the PRs that
-  landed. Drop refuses while any `base/reth` PR remains in `[[patches]]`.
-- **PRs already in `--upstream`.** If a PR is already in the official tag,
-  squash hits an empty diff and aborts. Do not pass it.
-- **Fork-only retirement.** Stopping a `base/reth` PR is manual. Do not
-  record it against an official Reth tag; those patches never land in
-  `paradigmxyz/reth`.
-- **CI.** `just check::reth-pin` exists but is not part of
-  `just check::all` or GitHub Actions.
-- **Generated PR body.** The helper does not run `just pin-reth-test` or
-  `cargo check`. Add Heimdall CMS fields if the target repo requires
-  them.
-- **Custom `--fork`.** `deny.toml` allows `paradigmxyz/reth` and
-  `base/reth`. A different fork URL needs its own `allow-git` entry.
-- **`base/reth` tags.** Protect `v*-base.*` tags so they cannot be moved
-  after publish.
+`--pr` replaces the patch set. Pass every PR you still want to carry.
+Protect `v*-base.*` tags on `base/reth` so they cannot be moved after
+publish.

--- a/etc/upstream-pins/README.md
+++ b/etc/upstream-pins/README.md
@@ -25,7 +25,7 @@ publishing the fork.
 
 1. Decide the official Reth tag and the PRs to carry.
 2. Run `just reth-prepare-release`. It squashes each PR onto that tag in
-   the fork, publishes `vX.Y.Z-base.N`, writes this manifest, and rewrites
+   the fork, publishes `base-vX.Y.Z.N`, writes this manifest, and rewrites
    Cargo.toml in the current tree.
 3. Commit and open the `base/base` PR yourself.
 4. After merge, `just check-reth-pin` confirms Cargo still matches this file.
@@ -37,5 +37,6 @@ A squash conflict is the only hard stop. Fix the PR against that official
 tag and rerun.
 
 `--pr` replaces the patch set. Pass every PR you still want to carry.
-Protect `v*-base.*` tags on `base/reth` so they cannot be moved after
+Backport tags are `base-vX.Y.Z.N` so they do not match `base/reth`'s
+`v*` release workflow. Protect those tags so they cannot be moved after
 publish.

--- a/etc/upstream-pins/README.md
+++ b/etc/upstream-pins/README.md
@@ -1,0 +1,75 @@
+# Reth workspace pin
+
+`reth.toml` is the source of truth for every git-based `reth-*` crate in
+`[workspace.dependencies]`. Do not edit those Cargo.toml lines by hand.
+
+## Commands
+
+```bash
+just pin-reth
+just check-reth-pin
+just pin-reth-test
+just reth-prepare-release --upstream v2.5.1 --pr 26708 --pr 26766
+just reth-drop-pin --release v2.6.0
+```
+
+`--pr 26708` is a PR on `--upstream-repo` (default `paradigmxyz/reth`). A
+full GitHub pull URL is fetched from that repository. Allowed sources are
+`--upstream-repo` and `--fork` (default `base/reth`). Use a `base/reth` URL
+for Base-specific patches instead of opening them upstream.
+
+`--line` is inferred from `releases/<line>` when you are on that branch;
+otherwise pass it. `--fork` can point at a personal fork until `base/reth`
+is the tagged backport repo.
+
+Preview without pushing or opening a PR:
+
+```bash
+just reth-prepare-release --upstream v2.5.1 --pr 26708 --line v1.3.0 \
+  --dry-run --skip-push --no-commit --no-pr
+```
+
+## Workflow
+
+1. Decide the official Reth tag and the PRs to carry.
+2. Run `just reth-prepare-release`. It squashes each PR onto that tag in
+   the fork, publishes `vX.Y.Z-base.N`, rewrites this manifest and
+   Cargo.toml, and opens a `base/base` PR.
+3. Review and merge that PR. After merge, `just check-reth-pin` is the
+   local check that Cargo still matches this file.
+4. When an official Reth release contains **every** carried *upstream* PR
+   and no `base/reth` PRs remain, run `just reth-drop-pin --release vX.Y.Z`.
+
+The pin commit is created from `origin/releases/<line>` when that branch
+exists, otherwise `origin/main`. Override with `--base-branch`. Extra
+commits on the local HEAD are not included.
+
+A squash conflict is the only hard stop. Fix the PR against that official
+tag and rerun. There is no conflict-resolution loop.
+
+## Limitations
+
+These are intentional. They are not handled automatically:
+
+- **`--pr` replaces the patch set.** Pass every PR you still want to
+  carry. Apply refuses to drop a carried PR unless it is listed in
+  `[[resolved]]`, so omitting one fails instead of appending.
+- **`reth-drop-pin` is all-or-nothing for upstream PRs.** It records every
+  `[[patches]]` entry as contained in `--release`. If only some landed,
+  rerun `reth-prepare-release` against the new official tag with the
+  leftover `--pr` list, and add `[[resolved]]` rows for the PRs that
+  landed. Drop refuses while any `base/reth` PR remains in `[[patches]]`.
+- **PRs already in `--upstream`.** If a PR is already in the official tag,
+  squash hits an empty diff and aborts. Do not pass it.
+- **Fork-only retirement.** Stopping a `base/reth` PR is manual. Do not
+  record it against an official Reth tag; those patches never land in
+  `paradigmxyz/reth`.
+- **CI.** `just check::reth-pin` exists but is not part of
+  `just check::all` or GitHub Actions.
+- **Generated PR body.** The helper does not run `just pin-reth-test` or
+  `cargo check`. Add Heimdall CMS fields if the target repo requires
+  them.
+- **Custom `--fork`.** `deny.toml` allows `paradigmxyz/reth` and
+  `base/reth`. A different fork URL needs its own `allow-git` entry.
+- **`base/reth` tags.** Protect `v*-base.*` tags so they cannot be moved
+  after publish.

--- a/etc/upstream-pins/reth.toml
+++ b/etc/upstream-pins/reth.toml
@@ -1,0 +1,36 @@
+# Authoritative Reth git pin for [workspace.dependencies].
+#
+# Workflow and limitations: etc/upstream-pins/README.md
+#
+# `just pin-reth` rewrites every git-based `reth-*` crate to this repository
+# and reference, then refreshes Cargo.lock.
+# `just check-reth-pin` verifies Cargo.toml and Cargo.lock match this file.
+# `just reth-prepare-release` builds the fork tag and writes this file.
+#
+# `reference` is the human-facing git ref (release tag, fork tag, or SHA).
+# `rev` is the immutable commit that `reference` currently resolves to.
+# Cargo.toml uses `tag =` when `reference` is not a SHA, and `rev =` otherwise.
+#
+# Each [[patches]] entry is a whole GitHub PR squashed to one fork commit.
+# Identity is the PR URL, including the repository: paradigmxyz/reth for
+# upstream backports, or the Base fork (`base/reth`) for patches that
+# must not be opened upstream. `head` is the PR tip (or merge commit).
+#
+# `[[resolved]]` is only for upstream PRs that landed in an official
+# Reth release. Do not record a base/reth PR against an upstream tag.
+
+repository = "https://github.com/base/reth"
+reference = "v2.5.1-base.1"
+rev = "d80b19e5b597f047268c6593300cbbe1f235631b"
+
+[upstream_base]
+tag = "v2.5.1"
+rev = "6dec1b96b625584956883c34ad0eafbe550480ac"
+
+[[patches]]
+pr = "https://github.com/paradigmxyz/reth/pull/26708"
+head = "f213ff930925e0912a2f6907cec0c62d473bc330"
+
+[[patches]]
+pr = "https://github.com/paradigmxyz/reth/pull/26766"
+head = "f47fd63a3762d8add2e07f1d4afa9363e60d0853"

--- a/etc/upstream-pins/reth.toml
+++ b/etc/upstream-pins/reth.toml
@@ -7,7 +7,7 @@
 # To return to an official Reth tag, edit this file and run `just pin-reth`.
 
 repository = "https://github.com/base/reth"
-reference = "v2.5.1-base.1"
+reference = "base-v2.5.1.1"
 rev = "d80b19e5b597f047268c6593300cbbe1f235631b"
 
 [upstream_base]

--- a/etc/upstream-pins/reth.toml
+++ b/etc/upstream-pins/reth.toml
@@ -1,23 +1,10 @@
 # Authoritative Reth git pin for [workspace.dependencies].
+# See etc/upstream-pins/README.md.
 #
-# Workflow and limitations: etc/upstream-pins/README.md
-#
-# `just pin-reth` rewrites every git-based `reth-*` crate to this repository
-# and reference, then refreshes Cargo.lock.
-# `just check-reth-pin` verifies Cargo.toml and Cargo.lock match this file.
+# `just pin-reth` rewrites git `reth-*` crates to this repository and
+# reference. `just check-reth-pin` verifies Cargo.toml and Cargo.lock.
 # `just reth-prepare-release` builds the fork tag and writes this file.
-#
-# `reference` is the human-facing git ref (release tag, fork tag, or SHA).
-# `rev` is the immutable commit that `reference` currently resolves to.
-# Cargo.toml uses `tag =` when `reference` is not a SHA, and `rev =` otherwise.
-#
-# Each [[patches]] entry is a whole GitHub PR squashed to one fork commit.
-# Identity is the PR URL, including the repository: paradigmxyz/reth for
-# upstream backports, or the Base fork (`base/reth`) for patches that
-# must not be opened upstream. `head` is the PR tip (or merge commit).
-#
-# `[[resolved]]` is only for upstream PRs that landed in an official
-# Reth release. Do not record a base/reth PR against an upstream tag.
+# To return to an official Reth tag, edit this file and run `just pin-reth`.
 
 repository = "https://github.com/base/reth"
 reference = "v2.5.1-base.1"


### PR DESCRIPTION
## Summary
- Pin git `reth-*` workspace crates to [`base/reth`](https://github.com/base/reth) `base-v2.5.1.1` (`d80b19e5`): official Reth 2.5.1 plus [reth#26708](https://github.com/paradigmxyz/reth/pull/26708) and [reth#26766](https://github.com/paradigmxyz/reth/pull/26766).
- Name backport tags `base-vX.Y.Z.N` so they do not match `base/reth`'s `v*` release workflow.
- Add `etc/upstream-pins/reth.toml` and `just reth-prepare-release` so later patched Reth ships go through immutable org-fork tags instead of a personal SHA. Prepare writes files in the current tree; open the `base/base` PR yourself. To return to official Reth, edit the manifest and run `just pin-reth`.

## Test plan
- [x] `just pin-reth-test`
- [x] `just check-reth-pin`
- [ ] `cargo check --locked -p base-reth-node -p base-builder-bin -p base-consensus`

type=routine
risk=low
impact=sev5