### PR TITLE
fix(tx-manager): retry nonce-too-high on initial publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3038,6 +3038,7 @@ dependencies = [
  "base-tx-manager",
  "clap",
  "eyre",
+ "humantime",
  "serde",
  "tracing",
  "url",

--- a/bin/batcher/Cargo.toml
+++ b/bin/batcher/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 [dependencies]
 url.workspace = true
 eyre.workspace = true
+humantime.workspace = true
 base-protocol.workspace = true
 base-cli-utils.workspace = true
 base-tx-manager.workspace = true

--- a/bin/batcher/src/cli.rs
+++ b/bin/batcher/src/cli.rs
@@ -10,7 +10,7 @@ use base_batcher_core::ThrottleConfig;
 use base_batcher_service::{BatcherConfig, BatcherService};
 use base_cli_utils::{LogConfig, RuntimeManager};
 use base_runtime::TokioRuntime;
-use base_tx_manager::SignerConfig;
+use base_tx_manager::{SignerConfig, TxManagerConfig};
 use clap::{Args, Parser};
 use tracing::info;
 use url::Url;
@@ -155,7 +155,7 @@ pub(crate) struct BatcherArgs {
 
     /// Number of L1 confirmations before a tx is considered finalized.
     #[arg(long = "num-confirmations", default_value = "1", env = "BATCHER_NUM_CONFIRMATIONS")]
-    pub num_confirmations: usize,
+    pub num_confirmations: u64,
 
     /// Timeout before resubmitting a transaction (seconds).
     #[arg(
@@ -164,6 +164,19 @@ pub(crate) struct BatcherArgs {
         env = "BATCHER_RESUBMISSION_TIMEOUT"
     )]
     pub resubmission_timeout_secs: u64,
+
+    /// Maximum retries when an RPC temporarily rejects an ordered nonce.
+    #[arg(long = "publish-max-retries", default_value = "10", env = "BATCHER_PUBLISH_MAX_RETRIES")]
+    pub publish_max_retries: usize,
+
+    /// Delay between nonce-too-high publication retries.
+    #[arg(
+        long = "publish-retry-delay",
+        default_value = "1s",
+        env = "BATCHER_PUBLISH_RETRY_DELAY",
+        value_parser = humantime::parse_duration
+    )]
+    pub publish_retry_delay: Duration,
 
     /// DA backlog threshold in bytes at which throttling activates.
     ///
@@ -291,6 +304,14 @@ impl BatcherArgs {
             max_l1_tx_size_bytes: self.max_l1_tx_size_bytes,
         };
         encoder_config.validate()?;
+        let tx_manager = TxManagerConfig {
+            num_confirmations: self.num_confirmations,
+            resubmission_timeout: Duration::from_secs(self.resubmission_timeout_secs),
+            publish_max_retries: self.publish_max_retries,
+            publish_retry_delay: self.publish_retry_delay,
+            ..TxManagerConfig::default()
+        };
+        tx_manager.validate()?;
         Ok(BatcherConfig {
             l1_rpc_url: self.l1_rpc_url,
             l1_ws_url: self.l1_ws_url,
@@ -303,8 +324,7 @@ impl BatcherArgs {
             poll_interval: Duration::from_secs(self.poll_interval_secs),
             encoder_config,
             max_pending_transactions: self.max_pending_transactions,
-            num_confirmations: self.num_confirmations,
-            resubmission_timeout: Duration::from_secs(self.resubmission_timeout_secs),
+            tx_manager,
             throttle: if self.no_throttle {
                 None
             } else {
@@ -504,6 +524,15 @@ mod tests {
         let config = cli.args.into_config().expect("config should build");
 
         assert!(config.stopped);
+    }
+
+    #[test]
+    fn into_config_sets_publish_retry_policy() {
+        let cli = parse_cli(&["--publish-max-retries", "12", "--publish-retry-delay", "250ms"]);
+        let config = cli.args.into_config().expect("config should build");
+
+        assert_eq!(config.tx_manager.publish_max_retries, 12);
+        assert_eq!(config.tx_manager.publish_retry_delay, Duration::from_millis(250));
     }
 
     #[test]

--- a/crates/batcher/service/src/config.rs
+++ b/crates/batcher/service/src/config.rs
@@ -5,7 +5,7 @@ use std::{net::SocketAddr, time::Duration};
 use alloy_primitives::Address;
 use base_batcher_core::ThrottleConfig;
 use base_batcher_encoder::EncoderConfig;
-use base_tx_manager::SignerConfig;
+use base_tx_manager::{SignerConfig, TxManagerConfig};
 use url::Url;
 
 /// Full batcher configuration combining RPC endpoints, identity, encoding
@@ -69,10 +69,8 @@ pub struct BatcherConfig {
     pub encoder_config: EncoderConfig,
     /// Maximum number of in-flight (unconfirmed) transactions.
     pub max_pending_transactions: usize,
-    /// Number of L1 confirmations before a tx is considered finalized.
-    pub num_confirmations: usize,
-    /// Timeout before resubmitting a transaction.
-    pub resubmission_timeout: Duration,
+    /// Transaction manager configuration.
+    pub tx_manager: TxManagerConfig,
     /// Throttle configuration (optional).
     pub throttle: Option<ThrottleConfig>,
     /// Number of recent L1 blocks to inspect for a confirmed batcher transaction.
@@ -128,8 +126,7 @@ impl Default for BatcherConfig {
             poll_interval: Duration::from_secs(1),
             encoder_config: EncoderConfig::default(),
             max_pending_transactions: 1,
-            num_confirmations: 1,
-            resubmission_timeout: Duration::from_secs(48),
+            tx_manager: TxManagerConfig { num_confirmations: 1, ..TxManagerConfig::default() },
             throttle: Some(ThrottleConfig::default()),
             check_recent_txs_depth: 0,
             admin_addr: None,

--- a/crates/batcher/service/src/service.rs
+++ b/crates/batcher/service/src/service.rs
@@ -21,7 +21,7 @@ use base_consensus_rpc::RollupNodeApiClient;
 use base_protocol::BlockInfo;
 use base_retry::{DEFAULT_UNBOUNDED_MAX_DELAY, RetryConfig};
 use base_runtime::TokioRuntime;
-use base_tx_manager::{BaseTxMetrics, SimpleTxManager, TxManagerConfig};
+use base_tx_manager::{BaseTxMetrics, SimpleTxManager};
 use futures::{
     StreamExt,
     future::BoxFuture,
@@ -671,15 +671,11 @@ impl BatcherService {
         let l1_chain_id =
             Self::rpc_retry("l1-chain-id", retry, rpc_timeout, || l1_provider.get_chain_id())
                 .await?;
-        let tx_manager_config = TxManagerConfig {
-            resubmission_timeout: self.config.resubmission_timeout,
-            num_confirmations: self.config.num_confirmations as u64,
-            ..TxManagerConfig::default()
-        };
+        let drain_timeout = self.config.tx_manager.resubmission_timeout * 2;
         let tx_manager = SimpleTxManager::new(
             l1_provider,
             signer_config,
-            tx_manager_config,
+            self.config.tx_manager,
             l1_chain_id,
             Arc::new(BaseTxMetrics::new("batcher")),
         )
@@ -723,7 +719,7 @@ impl BatcherService {
             base_batcher_core::BatchDriverConfig {
                 inbox: effective_batch_inbox,
                 max_pending_transactions: self.config.max_pending_transactions,
-                drain_timeout: self.config.resubmission_timeout * 2,
+                drain_timeout,
                 force_blobs_when_throttling: self.config.force_blobs_when_throttling,
             },
             DaThrottle::new(throttle, throttle_client),

--- a/crates/utilities/tx-manager/README.md
+++ b/crates/utilities/tx-manager/README.md
@@ -36,6 +36,8 @@ confirmation.
 
 - **`TxManagerError`** — error variants categorized as critical (non-retryable),
   fee/replacement (retryable via fee bumps), or infrastructure (transient/retryable).
+  `NonceTooHigh` is transient because concurrent publications can reach RPC
+  backends out of order; the same signed transaction is retried.
 - **`RpcErrorClassifier`** — classifies alloy `TransportError`s into `TxManagerError` variants.
 - **`RevertDisplay`** — display wrapper for decoded revert reasons.
 - **`TxManagerResult<T>`** — result type alias.

--- a/crates/utilities/tx-manager/src/config.rs
+++ b/crates/utilities/tx-manager/src/config.rs
@@ -113,6 +113,10 @@ pub struct TxManagerConfig {
     pub network_timeout: Duration,
     /// Fee-bump resubmission timeout.
     pub resubmission_timeout: Duration,
+    /// Maximum attempts to publish when an RPC reports a transient nonce gap.
+    pub publish_max_retries: usize,
+    /// Delay between transient nonce-gap publication attempts.
+    pub publish_retry_delay: Duration,
     /// Receipt polling interval.
     pub receipt_query_interval: Duration,
     /// Overall send timeout (zero = disabled).
@@ -136,6 +140,8 @@ impl Default for TxManagerConfig {
             min_basefee: 0,
             network_timeout: Duration::from_secs(10),
             resubmission_timeout: Duration::from_secs(48),
+            publish_max_retries: 10,
+            publish_retry_delay: Duration::from_secs(1),
             receipt_query_interval: Duration::from_secs(12),
             tx_send_timeout: Duration::ZERO,
             tx_not_in_mempool_timeout: Duration::from_secs(120),
@@ -157,6 +163,8 @@ impl TxManagerConfig {
     /// - `min_blob_fee` must be >= 1
     /// - `network_timeout` must be > 0
     /// - `resubmission_timeout` must be > 0
+    /// - `publish_max_retries` must be >= 1
+    /// - `publish_retry_delay` must be > 0
     /// - `receipt_query_interval` must be > 0
     /// - `confirmation_timeout` must be > 0
     pub fn validate(&self) -> Result<(), ConfigError> {
@@ -184,10 +192,16 @@ impl TxManagerConfig {
             )+};
         }
 
-        reject_zero!(num_confirmations, safe_abort_nonce_too_low_count, fee_limit_multiplier);
+        reject_zero!(
+            num_confirmations,
+            safe_abort_nonce_too_low_count,
+            fee_limit_multiplier,
+            publish_max_retries,
+        );
         reject_zero_duration!(
             network_timeout,
             resubmission_timeout,
+            publish_retry_delay,
             receipt_query_interval,
             confirmation_timeout,
         );
@@ -303,6 +317,27 @@ mod tests {
         assert!(
             matches!(err, ConfigError::OutOfRange { field: "min_blob_fee", .. }),
             "expected OutOfRange for min_blob_fee, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validation_rejects_zero_publish_max_retries() {
+        let config = TxManagerConfig { publish_max_retries: 0, ..TxManagerConfig::default() };
+        let err = config.validate().unwrap_err();
+        assert!(
+            matches!(err, ConfigError::OutOfRange { field: "publish_max_retries", .. }),
+            "expected OutOfRange for publish_max_retries, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validation_rejects_zero_publish_retry_delay() {
+        let config =
+            TxManagerConfig { publish_retry_delay: Duration::ZERO, ..TxManagerConfig::default() };
+        let err = config.validate().unwrap_err();
+        assert!(
+            matches!(err, ConfigError::OutOfRange { field: "publish_retry_delay", .. }),
+            "expected OutOfRange for publish_retry_delay, got: {err}"
         );
     }
 }

--- a/crates/utilities/tx-manager/src/error.rs
+++ b/crates/utilities/tx-manager/src/error.rs
@@ -209,7 +209,8 @@ impl TxManagerError {
     pub const fn is_retryable(&self) -> bool {
         matches!(
             self,
-            Self::Underpriced
+            Self::NonceTooHigh
+                | Self::Underpriced
                 | Self::ReplacementUnderpriced
                 | Self::FeeTooLow
                 | Self::MaxFeePerGasTooLow
@@ -437,7 +438,7 @@ mod tests {
 
     #[rstest]
     #[case::nonce_too_low(TxManagerError::NonceTooLow, false)]
-    #[case::nonce_too_high(TxManagerError::NonceTooHigh, false)]
+    #[case::nonce_too_high(TxManagerError::NonceTooHigh, true)]
     #[case::insufficient_funds(TxManagerError::InsufficientFunds, false)]
     #[case::intrinsic_gas_too_low(TxManagerError::IntrinsicGasTooLow, false)]
     #[case::execution_reverted(TxManagerError::ExecutionReverted { reason: None, data: None }, false)]

--- a/crates/utilities/tx-manager/src/macros.rs
+++ b/crates/utilities/tx-manager/src/macros.rs
@@ -128,6 +128,23 @@ macro_rules! define_tx_manager_cli {
             )]
             pub resubmission_timeout: ::std::time::Duration,
 
+            /// Maximum retries when an RPC temporarily rejects an ordered nonce.
+            #[arg(
+                long = "tx-manager.publish-max-retries",
+                env = concat!($prefix, "_", "PUBLISH_MAX_RETRIES"),
+                default_value = "10"
+            )]
+            pub publish_max_retries: usize,
+
+            /// Delay between nonce-too-high publication retries (e.g., "1s").
+            #[arg(
+                long = "tx-manager.publish-retry-delay",
+                env = concat!($prefix, "_", "PUBLISH_RETRY_DELAY"),
+                default_value = "1s",
+                value_parser = ::humantime::parse_duration
+            )]
+            pub publish_retry_delay: ::std::time::Duration,
+
             /// Interval between receipt query attempts (e.g., "12s").
             #[arg(
                 long = "tx-manager.receipt-query-interval",
@@ -197,6 +214,8 @@ macro_rules! define_tx_manager_cli {
                     min_basefee: cli.min_basefee,
                     network_timeout: cli.network_timeout,
                     resubmission_timeout: cli.resubmission_timeout,
+                    publish_max_retries: cli.publish_max_retries,
+                    publish_retry_delay: cli.publish_retry_delay,
                     receipt_query_interval: cli.receipt_query_interval,
                     tx_send_timeout: cli.tx_send_timeout,
                     tx_not_in_mempool_timeout: cli.tx_not_in_mempool_timeout,

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -248,6 +248,12 @@ where
     /// Fixed delay between retry attempts in [`Self::prepare`].
     pub const PREPARE_RETRY_DELAY: Duration = Duration::from_secs(2);
 
+    /// Maximum retries when an RPC temporarily rejects an ordered nonce.
+    pub const PUBLISH_MAX_RETRIES: usize = 30;
+
+    /// Fixed delay between nonce-too-high publication retries.
+    pub const PUBLISH_RETRY_DELAY: Duration = Duration::from_secs(2);
+
     /// Creates a new [`SimpleTxManager`] with an injected runtime.
     ///
     /// This mirrors [`Self::new`] but lets deterministic tests control
@@ -956,8 +962,11 @@ where
     /// When `send_tx` exits with an error, the nonce manager may be reset
     /// to prevent stale-counter gaps on the next call:
     ///
-    /// * **Pre-publish errors** (no tx was ever sent): the nonce is always
-    ///   reset so the next attempt re-fetches from the chain.
+    /// * **Pre-publish errors** from `send` reset the cache. `send_async`
+    ///   recycles its pre-reserved nonce instead so concurrent reservations
+    ///   remain valid.
+    /// * **`NonceTooHigh`** is retried with the same signed transaction before
+    ///   reaching cleanup.
     /// * **`SendTimeout`**: the nonce is always reset — even after a
     ///   successful publish — because the timeout may have cancelled
     ///   `prepare()` mid-flight during a fee bump, leaking a nonce from
@@ -1016,10 +1025,7 @@ where
         }
 
         if Self::should_reset_nonce_on_send_error(&result, &send_state, nonce_override) {
-            // Three policies (see should_reset_nonce_on_send_error):
-            // • NonceTooHigh — always reset, even with nonce_override.
-            //   No tx entered the mempool; reserved_high_water protects
-            //   concurrent reservations from collision after reset.
+            // Two policies (see should_reset_nonce_on_send_error):
             // • SendTimeout — always reset. The timeout may have cancelled
             //   prepare() after it reserved a nonce but before the tx reached
             //   the mempool, leaking the nonce manager's internal counter.
@@ -1048,10 +1054,6 @@ where
     ) -> bool {
         match result {
             Ok(_) => false,
-            // Always reset on NonceTooHigh — the publish failed, no tx
-            // entered the mempool, and reserved_high_water protects
-            // concurrent reservations from collision after reset.
-            Err(TxManagerError::NonceTooHigh) => true,
             // When a nonce_override was used, the nonce was irrevocably
             // consumed at reserve_nonce() time. Resetting the nonce manager
             // would corrupt concurrent send_async reservations.
@@ -1083,12 +1085,8 @@ where
         send_state: &SendState,
     ) -> bool {
         match result {
-            // Nonce errors indicate the nonce is genuinely invalid, not a
-            // transient failure.  Returning it to the reuse pool would
-            // cause an infinite retry loop: after a reset() the chain
-            // nonce is re-fetched, but advance_nonce() pops
-            // returned_nonces first, reissuing the same invalid value.
-            Ok(_) | Err(TxManagerError::NonceTooHigh | TxManagerError::NonceTooLow) => false,
+            // A too-low nonce was already consumed and must not be reused.
+            Ok(_) | Err(TxManagerError::NonceTooLow) => false,
             Err(_) => !send_state.has_published(),
         }
     }
@@ -1112,7 +1110,7 @@ where
         // the need for a separate suggest_gas_price_caps() call.
         let prepared =
             self.prepare_with_initial_caps(candidate, None, None, nonce_override, None).await?;
-        let tx_hash = self.publish_tx(send_state, &prepared.raw_tx, None).await?;
+        let tx_hash = self.publish_tx_with_nonce_retry(send_state, &prepared.raw_tx).await?;
         let mut bump = BumpState::from_prepared(prepared, tx_hash);
 
         // Receipt delivery channel — mpsc because fee bumps may spawn
@@ -1363,6 +1361,30 @@ where
                 None
             }
         }
+    }
+
+    /// Publishes the initial transaction, retrying a transient nonce gap.
+    ///
+    /// Concurrent sends reserve nonces in order but may reach different RPC
+    /// backends out of order. Retrying the same signed transaction lets the
+    /// lower nonce propagate without serializing receipt confirmation or fee
+    /// bumping.
+    async fn publish_tx_with_nonce_retry(
+        &self,
+        send_state: &SendState,
+        raw_tx: &Bytes,
+    ) -> TxManagerResult<B256> {
+        (|| self.publish_tx(send_state, raw_tx, None))
+            .retry(
+                ConstantBuilder::default()
+                    .with_delay(Self::PUBLISH_RETRY_DELAY)
+                    .with_max_times(Self::PUBLISH_MAX_RETRIES),
+            )
+            .when(|error| matches!(error, TxManagerError::NonceTooHigh))
+            .notify(|error, delay| {
+                warn!(error = %error, ?delay, "retrying initial transaction publication");
+            })
+            .await
     }
 
     /// Broadcasts a raw transaction to the network.
@@ -1801,7 +1823,7 @@ mod tests {
     use alloy_consensus::TxEip1559;
     use alloy_network::EthereumWallet;
     use alloy_node_bindings::Anvil;
-    use alloy_primitives::{Address, B256, TxKind, U256};
+    use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
     use alloy_provider::{ProviderBuilder, RootProvider};
     use alloy_signer_local::PrivateKeySigner;
     use alloy_transport::mock::Asserter;
@@ -1834,6 +1856,37 @@ mod tests {
         .await
         .expect("should create manager");
         (manager, anvil)
+    }
+
+    #[tokio::test]
+    async fn publish_tx_retries_nonce_too_high() {
+        let asserter = Asserter::new();
+        let expected_hash = B256::with_last_byte(0x42);
+        asserter.push_success(&1u64);
+        asserter.push_failure_msg("nonce too high");
+        asserter.push_success(&expected_hash);
+
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let wallet = EthereumWallet::from(PrivateKeySigner::random());
+        let manager = SimpleTxManager::from_wallet(
+            provider,
+            wallet,
+            TxManagerConfig::default(),
+            1,
+            Arc::new(NoopTxMetrics),
+        )
+        .await
+        .expect("should construct manager");
+        let send_state = SendState::new(3).expect("should construct send state");
+
+        let hash = manager
+            .publish_tx_with_nonce_retry(&send_state, &Bytes::from_static(&[0x02]))
+            .await
+            .expect("nonce-too-high publication should be retried");
+
+        assert_eq!(hash, expected_hash);
+        assert!(send_state.has_published());
+        assert!(send_state.critical_error().is_none());
     }
 
     fn decode_eip1559(prepared: &PreparedTx) -> TxEip1559 {
@@ -2094,7 +2147,7 @@ mod tests {
     #[case::timeout_after_publish(true, Err(TxManagerError::SendTimeout), None, true)]
     #[case::success(false, Ok(()), None, false)]
     #[case::nonce_too_high_no_override(false, Err(TxManagerError::NonceTooHigh), None, true)]
-    #[case::nonce_too_high_with_override(false, Err(TxManagerError::NonceTooHigh), Some(42), true)]
+    #[case::nonce_too_high_with_override(false, Err(TxManagerError::NonceTooHigh), Some(42), false)]
     #[case::nonce_override_timeout(false, Err(TxManagerError::SendTimeout), Some(42), false)]
     #[case::nonce_override_pre_publish_error(
         false,
@@ -2128,7 +2181,7 @@ mod tests {
     #[case::success(false, Ok(()), false)]
     #[case::timeout_no_publish(false, Err(TxManagerError::SendTimeout), true)]
     #[case::timeout_after_publish(true, Err(TxManagerError::SendTimeout), false)]
-    #[case::nonce_too_high(false, Err(TxManagerError::NonceTooHigh), false)]
+    #[case::nonce_too_high(false, Err(TxManagerError::NonceTooHigh), true)]
     #[case::nonce_too_low(false, Err(TxManagerError::NonceTooLow), false)]
     fn should_return_reserved_nonce(
         #[case] has_publish: bool,

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -956,9 +956,11 @@ where
     /// When `send_tx` exits with an error, the nonce manager may be reset
     /// to prevent stale-counter gaps on the next call:
     ///
-    /// * **Pre-publish errors** from `send` reset the cache. `send_async`
-    ///   recycles its pre-reserved nonce instead so concurrent reservations
-    ///   remain valid.
+    /// * **Pre-publish errors** before signing reset the cache. After a nonce
+    ///   is signed, it is returned to the reuse pool instead so concurrent
+    ///   `send()` calls cannot rewind past an in-flight higher nonce.
+    ///   `send_async` recycles its pre-reserved nonce so concurrent
+    ///   reservations remain valid.
     /// * **`NonceTooHigh`** is retried with the same signed transaction before
     ///   reaching cleanup.
     /// * **`SendTimeout`**: the nonce is always reset — even after a
@@ -1023,16 +1025,15 @@ where
             // • SendTimeout — always reset. The timeout may have cancelled
             //   prepare() after it reserved a nonce but before the tx reached
             //   the mempool, leaking the nonce manager's internal counter.
-            // • Other errors — reset only when no tx was ever published.
-            //   Once a tx may be pending, re-fetching the latest nonce could
-            //   conflict with the in-flight transaction.
+            // • Other errors — reset only when no nonce was ever signed, so
+            //   the cache cannot rewind past a nonce another task is using.
             self.nonce_manager.reset().await;
         }
 
-        // Return pre-reserved nonces that were never published so they can
-        // be reissued by subsequent send/send_async calls, preventing
-        // irrecoverable nonce gaps.
-        if let Some(n) = nonce_override
+        // Return nonces that never reached the mempool so they can be
+        // reissued. `send_async` reserves its nonce up front, `send` records
+        // the one it signed with.
+        if let Some(n) = nonce_override.or_else(|| send_state.assigned_nonce())
             && Self::should_return_reserved_nonce(&result, &send_state)
         {
             self.nonce_manager.return_reserved_nonce(n).await;
@@ -1056,14 +1057,15 @@ where
             // prepare() mid-flight during a fee bump, leaking a nonce
             // from the nonce manager's internal counter.
             Err(TxManagerError::SendTimeout) => true,
-            // For other errors, reset only if nothing was ever published.
-            // Once a transaction is pending, the next send_tx will re-sync
-            // via the chain's pending nonce anyway.
-            Err(_) => !send_state.has_published(),
+            // Reset only when this send never signed a nonce. A signed nonce
+            // goes back to the reuse pool instead, so a concurrent `send()`
+            // cannot rewind the cache past an in-flight higher nonce while a
+            // `NonceTooHigh` retry is still sleeping.
+            Err(_) => send_state.assigned_nonce().is_none(),
         }
     }
 
-    /// Returns `true` when a pre-reserved nonce should be returned to the
+    /// Returns `true` when an unpublished nonce should be returned to the
     /// nonce manager's reuse pool.
     ///
     /// A nonce is eligible for return when BOTH of these hold:
@@ -1071,9 +1073,6 @@ where
     /// 2. No transaction was ever successfully published — if a tx was
     ///    published, the nonce may be in the mempool and must not be
     ///    reused.
-    ///
-    /// The caller is responsible for checking that a nonce override exists
-    /// (i.e. the send came from `send_async`, not `send`).
     fn should_return_reserved_nonce<T>(
         result: &TxManagerResult<T>,
         send_state: &SendState,
@@ -1104,6 +1103,7 @@ where
         // the need for a separate suggest_gas_price_caps() call.
         let prepared =
             self.prepare_with_initial_caps(candidate, None, None, nonce_override, None).await?;
+        send_state.record_assigned_nonce(prepared.nonce);
         let tx_hash = self.publish_tx_with_nonce_retry(send_state, &prepared.raw_tx).await?;
         let mut bump = BumpState::from_prepared(prepared, tx_hash);
 
@@ -1368,17 +1368,34 @@ where
         send_state: &SendState,
         raw_tx: &Bytes,
     ) -> TxManagerResult<B256> {
-        (|| self.publish_tx(send_state, raw_tx, None))
-            .retry(
-                ConstantBuilder::default()
-                    .with_delay(self.config.publish_retry_delay)
-                    .with_max_times(self.config.publish_max_retries),
-            )
-            .when(|error| matches!(error, TxManagerError::NonceTooHigh))
-            .notify(|error, delay| {
-                warn!(error = %error, ?delay, "retrying initial transaction publication");
-            })
-            .await
+        let mut remaining_retries = self.config.publish_max_retries;
+        let mut is_retry = false;
+        loop {
+            if self.is_closed() {
+                return Err(TxManagerError::ChannelClosed);
+            }
+            if is_retry && let Some(err) = send_state.critical_error_at(self.runtime.now()) {
+                return Err(err);
+            }
+
+            match self.publish_tx(send_state, raw_tx, None).await {
+                Ok(tx_hash) => return Ok(tx_hash),
+                Err(TxManagerError::NonceTooHigh) if remaining_retries > 0 => {
+                    remaining_retries -= 1;
+                    if let Some(err) = send_state.critical_error_at(self.runtime.now()) {
+                        return Err(err);
+                    }
+                    warn!(
+                        error = %TxManagerError::NonceTooHigh,
+                        delay = ?self.config.publish_retry_delay,
+                        "retrying initial transaction publication"
+                    );
+                    self.runtime.sleep(self.config.publish_retry_delay).await;
+                    is_retry = true;
+                }
+                Err(error) => return Err(error),
+            }
+        }
     }
 
     /// Broadcasts a raw transaction to the network.
@@ -1883,6 +1900,117 @@ mod tests {
         assert!(send_state.critical_error().is_none());
     }
 
+    #[tokio::test]
+    async fn publish_retry_stops_after_close() {
+        let asserter = Asserter::new();
+        asserter.push_success(&1u64);
+        asserter.push_failure_msg("nonce too high");
+        asserter.push_success(&B256::with_last_byte(0x42));
+
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let wallet = EthereumWallet::from(PrivateKeySigner::random());
+        let config = TxManagerConfig {
+            publish_max_retries: 2,
+            publish_retry_delay: Duration::from_millis(20),
+            ..TxManagerConfig::default()
+        };
+        let manager =
+            SimpleTxManager::from_wallet(provider, wallet, config, 1, Arc::new(NoopTxMetrics))
+                .await
+                .expect("should construct manager");
+        let send_state = SendState::new(3).expect("should construct send state");
+
+        let closing = manager.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+            closing.close();
+        });
+
+        let err = manager
+            .publish_tx_with_nonce_retry(&send_state, &Bytes::from_static(&[0x02]))
+            .await
+            .expect_err("closed manager must not retry publication");
+        assert_eq!(err, TxManagerError::ChannelClosed);
+        assert!(!send_state.has_published());
+    }
+
+    #[test]
+    fn publish_retry_uses_injected_runtime_sleep() {
+        Runner::start(Config::seeded(0), |ctx| async move {
+            let asserter = Asserter::new();
+            let expected_hash = B256::with_last_byte(0x42);
+            asserter.push_success(&1u64);
+            asserter.push_failure_msg("nonce too high");
+            asserter.push_success(&expected_hash);
+
+            let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+            let wallet = EthereumWallet::from(PrivateKeySigner::random());
+            let config = TxManagerConfig {
+                publish_max_retries: 2,
+                publish_retry_delay: Duration::from_secs(1),
+                ..TxManagerConfig::default()
+            };
+            let manager = SimpleTxManager::from_wallet_with_runtime(
+                ctx.clone(),
+                provider,
+                wallet,
+                config,
+                1,
+                Arc::new(NoopTxMetrics),
+            )
+            .await
+            .expect("should construct manager");
+            let send_state = SendState::new(3).expect("should construct send state");
+
+            let hash = manager
+                .publish_tx_with_nonce_retry(&send_state, &Bytes::from_static(&[0x02]))
+                .await
+                .expect("injected runtime should drive the nonce-too-high retry");
+
+            assert_eq!(hash, expected_hash);
+            assert_eq!(ctx.now(), Duration::from_secs(1));
+            assert!(send_state.has_published());
+        });
+    }
+
+    #[test]
+    fn publish_retry_honors_mempool_deadline() {
+        Runner::start(Config::seeded(0), |ctx| async move {
+            let asserter = Asserter::new();
+            asserter.push_success(&1u64);
+            asserter.push_failure_msg("nonce too high");
+            asserter.push_success(&B256::with_last_byte(0x42));
+
+            let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+            let wallet = EthereumWallet::from(PrivateKeySigner::random());
+            let config = TxManagerConfig {
+                publish_max_retries: 2,
+                publish_retry_delay: Duration::from_secs(2),
+                ..TxManagerConfig::default()
+            };
+            let manager = SimpleTxManager::from_wallet_with_runtime(
+                ctx.clone(),
+                provider,
+                wallet,
+                config,
+                1,
+                Arc::new(NoopTxMetrics),
+            )
+            .await
+            .expect("should construct manager");
+            let send_state = SendState::new(3).expect("should construct send state");
+            send_state.set_runtime_mempool_deadline(ctx.now() + Duration::from_secs(1));
+
+            let err = manager
+                .publish_tx_with_nonce_retry(&send_state, &Bytes::from_static(&[0x02]))
+                .await
+                .expect_err("retry must not publish after the mempool deadline");
+
+            assert_eq!(err, TxManagerError::MempoolDeadlineExpired);
+            assert!(!send_state.has_published());
+        });
+    }
+
     fn decode_eip1559(prepared: &PreparedTx) -> TxEip1559 {
         match prepared.to_envelope().expect("should decode as valid TxEnvelope") {
             TxEnvelope::Eip1559(signed) => signed.strip_signature(),
@@ -2157,6 +2285,8 @@ mod tests {
     ) {
         let send_state = crate::SendState::new(3).expect("should create send state");
         if has_publish {
+            // Publishing is only reachable once a nonce has been signed.
+            send_state.record_assigned_nonce(0);
             send_state.record_successful_publish();
         }
         assert_eq!(
@@ -2166,6 +2296,26 @@ mod tests {
                 nonce_override,
             ),
             expected,
+        );
+    }
+
+    #[test]
+    fn signed_send_nonce_is_recycled_instead_of_resetting_the_cache() {
+        let send_state = crate::SendState::new(3).expect("should create send state");
+        send_state.record_assigned_nonce(4);
+        let result = Err::<(), _>(TxManagerError::NonceTooHigh);
+
+        assert!(
+            !SimpleTxManager::<RootProvider>::should_reset_nonce_on_send_error(
+                &result,
+                &send_state,
+                None,
+            ),
+            "resetting would rewind the cache past a concurrent in-flight send nonce",
+        );
+        assert!(
+            SimpleTxManager::<RootProvider>::should_return_reserved_nonce(&result, &send_state),
+            "the signed but unpublished nonce must go back to the reuse pool",
         );
     }
 

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -248,12 +248,6 @@ where
     /// Fixed delay between retry attempts in [`Self::prepare`].
     pub const PREPARE_RETRY_DELAY: Duration = Duration::from_secs(2);
 
-    /// Maximum retries when an RPC temporarily rejects an ordered nonce.
-    pub const PUBLISH_MAX_RETRIES: usize = 30;
-
-    /// Fixed delay between nonce-too-high publication retries.
-    pub const PUBLISH_RETRY_DELAY: Duration = Duration::from_secs(2);
-
     /// Creates a new [`SimpleTxManager`] with an injected runtime.
     ///
     /// This mirrors [`Self::new`] but lets deterministic tests control
@@ -1377,8 +1371,8 @@ where
         (|| self.publish_tx(send_state, raw_tx, None))
             .retry(
                 ConstantBuilder::default()
-                    .with_delay(Self::PUBLISH_RETRY_DELAY)
-                    .with_max_times(Self::PUBLISH_MAX_RETRIES),
+                    .with_delay(self.config.publish_retry_delay)
+                    .with_max_times(self.config.publish_max_retries),
             )
             .when(|error| matches!(error, TxManagerError::NonceTooHigh))
             .notify(|error, delay| {
@@ -1868,15 +1862,15 @@ mod tests {
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
         let wallet = EthereumWallet::from(PrivateKeySigner::random());
-        let manager = SimpleTxManager::from_wallet(
-            provider,
-            wallet,
-            TxManagerConfig::default(),
-            1,
-            Arc::new(NoopTxMetrics),
-        )
-        .await
-        .expect("should construct manager");
+        let config = TxManagerConfig {
+            publish_max_retries: 2,
+            publish_retry_delay: Duration::from_millis(1),
+            ..TxManagerConfig::default()
+        };
+        let manager =
+            SimpleTxManager::from_wallet(provider, wallet, config, 1, Arc::new(NoopTxMetrics))
+                .await
+                .expect("should construct manager");
         let send_state = SendState::new(3).expect("should construct send state");
 
         let hash = manager

--- a/crates/utilities/tx-manager/src/send_state.rs
+++ b/crates/utilities/tx-manager/src/send_state.rs
@@ -34,6 +34,7 @@ struct SendStateInner {
     bump_fees: bool,
     bump_count: u64,
     mempool_deadline: Option<MempoolDeadline>,
+    assigned_nonce: Option<u64>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -64,6 +65,7 @@ impl SendState {
                 bump_fees: false,
                 bump_count: 0,
                 mempool_deadline: None,
+                assigned_nonce: None,
             }),
             safe_abort_nonce_too_low_count,
         })
@@ -246,6 +248,19 @@ impl SendState {
     pub fn has_published(&self) -> bool {
         let inner = self.inner.lock().expect("SendState mutex poisoned");
         inner.has_published
+    }
+
+    /// Records the nonce assigned to this send after signing.
+    pub fn record_assigned_nonce(&self, nonce: u64) {
+        let mut inner = self.inner.lock().expect("SendState mutex poisoned");
+        inner.assigned_nonce = Some(nonce);
+    }
+
+    /// Returns the nonce assigned after signing, if preparation succeeded.
+    #[must_use]
+    pub fn assigned_nonce(&self) -> Option<u64> {
+        let inner = self.inner.lock().expect("SendState mutex poisoned");
+        inner.assigned_nonce
     }
 }
 

--- a/crates/utilities/tx-manager/src/send_state.rs
+++ b/crates/utilities/tx-manager/src/send_state.rs
@@ -30,7 +30,6 @@ struct SendStateInner {
     mined_txs: Vec<B256>,
     has_published: bool,
     nonce_too_low_count: u64,
-    nonce_too_high: bool,
     already_reserved: bool,
     bump_fees: bool,
     bump_count: u64,
@@ -61,7 +60,6 @@ impl SendState {
                 mined_txs: Vec::new(),
                 has_published: false,
                 nonce_too_low_count: 0,
-                nonce_too_high: false,
                 already_reserved: false,
                 bump_fees: false,
                 bump_count: 0,
@@ -74,8 +72,9 @@ impl SendState {
     /// Processes a send error, updating internal state accordingly.
     ///
     /// - [`TxManagerError::NonceTooLow`] increments the nonce-too-low counter.
+    /// - [`TxManagerError::NonceTooHigh`] is transient and leaves no state.
     /// - [`TxManagerError::AlreadyReserved`] sets the already-reserved flag.
-    /// - Any [retryable](TxManagerError::is_retryable) error sets the
+    /// - Any other [retryable](TxManagerError::is_retryable) error sets the
     ///   bump-fees flag for the next send attempt.
     /// - Other critical errors are no-ops (handled at a higher level).
     ///
@@ -87,9 +86,10 @@ impl SendState {
             TxManagerError::NonceTooLow => {
                 inner.nonce_too_low_count += 1;
             }
-            TxManagerError::NonceTooHigh => {
-                inner.nonce_too_high = true;
-            }
+            // A higher nonce can reach an RPC before a lower concurrent
+            // publication has propagated. Retrying the same signed
+            // transaction requires no persistent state change.
+            TxManagerError::NonceTooHigh => {}
             TxManagerError::AlreadyReserved => {
                 inner.already_reserved = true;
             }
@@ -133,21 +133,18 @@ impl SendState {
     /// 1. If any transaction is mined, returns `None` (wait for confirmation).
     /// 2. If the nonce slot was already reserved, returns
     ///    [`TxManagerError::AlreadyReserved`].
-    /// 3. If a nonce-too-high error was seen, returns
-    ///    [`TxManagerError::NonceTooHigh`] (immediate abort — the nonce is
-    ///    ahead of chain state and no tx entered the mempool).
-    /// 4. If no successful publish has occurred and a nonce-too-low error was
+    /// 3. If no successful publish has occurred and a nonce-too-low error was
     ///    seen, returns [`TxManagerError::NonceTooLow`] (immediate abort).
-    /// 5. If nonce-too-low errors have reached the threshold, returns
+    /// 4. If nonce-too-low errors have reached the threshold, returns
     ///    [`TxManagerError::NonceTooLow`].
-    /// 6. If the mempool deadline has expired *and* no transaction has been
+    /// 5. If the mempool deadline has expired *and* no transaction has been
     ///    successfully published, returns
     ///    [`TxManagerError::MempoolDeadlineExpired`]. Once a publish has
     ///    succeeded the tx is in the mempool and the deadline's purpose is
     ///    served — further waiting is governed by the receipt timeout and
     ///    bump cycle, not by aborting (which would leak a pre-reserved nonce
     ///    and stall publication on lower nonces still live on L1).
-    /// 7. Otherwise, returns `None`.
+    /// 6. Otherwise, returns `None`.
     #[must_use]
     pub fn critical_error(&self) -> Option<TxManagerError> {
         self.critical_error_with(None)
@@ -167,9 +164,6 @@ impl SendState {
         }
         if inner.already_reserved {
             return Some(TxManagerError::AlreadyReserved);
-        }
-        if inner.nonce_too_high {
-            return Some(TxManagerError::NonceTooHigh);
         }
         if !inner.has_published && inner.nonce_too_low_count > 0 {
             return Some(TxManagerError::NonceTooLow);
@@ -555,31 +549,10 @@ mod tests {
     // ── NonceTooHigh ───────────────────────────────────────────────────
 
     #[test]
-    fn nonce_too_high_triggers_immediate_abort() {
+    fn nonce_too_high_is_transient() {
         let state = SendState::new(3).unwrap();
         state.process_send_error(&TxManagerError::NonceTooHigh);
-        assert_eq!(state.critical_error(), Some(TxManagerError::NonceTooHigh));
-    }
-
-    #[test]
-    fn mined_tx_suppresses_nonce_too_high_abort() {
-        let state = SendState::new(3).unwrap();
-        state.process_send_error(&TxManagerError::NonceTooHigh);
-        assert_eq!(state.critical_error(), Some(TxManagerError::NonceTooHigh));
-
-        state.tx_mined(B256::with_last_byte(1));
         assert!(state.critical_error().is_none());
-    }
-
-    #[test]
-    fn nonce_too_high_takes_priority_over_nonce_too_low() {
-        let state = SendState::new(3).unwrap();
-        state.process_send_error(&TxManagerError::NonceTooHigh);
-        state.process_send_error(&TxManagerError::NonceTooLow);
-
-        // NonceTooHigh (priority 3) wins over pre-publish NonceTooLow
-        // (priority 4).
-        assert_eq!(state.critical_error(), Some(TxManagerError::NonceTooHigh));
     }
 
     #[test]

--- a/crates/utilities/tx-manager/tests/custom_prefix.rs
+++ b/crates/utilities/tx-manager/tests/custom_prefix.rs
@@ -26,6 +26,8 @@ fn env_vars_use_custom_prefix() {
         ("tx-manager.min-basefee", "CUSTOM_PREFIX_MIN_BASEFEE"),
         ("tx-manager.network-timeout", "CUSTOM_PREFIX_NETWORK_TIMEOUT"),
         ("tx-manager.resubmission-timeout", "CUSTOM_PREFIX_RESUBMISSION_TIMEOUT"),
+        ("tx-manager.publish-max-retries", "CUSTOM_PREFIX_PUBLISH_MAX_RETRIES"),
+        ("tx-manager.publish-retry-delay", "CUSTOM_PREFIX_PUBLISH_RETRY_DELAY"),
         ("tx-manager.receipt-query-interval", "CUSTOM_PREFIX_RECEIPT_QUERY_INTERVAL"),
         ("tx-manager.tx-send-timeout", "CUSTOM_PREFIX_TX_SEND_TIMEOUT"),
         ("tx-manager.tx-not-in-mempool-timeout", "CUSTOM_PREFIX_TX_NOT_IN_MEMPOOL_TIMEOUT"),


### PR DESCRIPTION
## Summary
- `NonceTooHigh` at initial publish is now transient: retry the same signed transaction (30 attempts, 2s delay) instead of aborting and resetting the nonce.
- Concurrent publications reserve nonces in order but can reach different RPC backends out of order; retrying lets the lower nonce propagate without serializing receipt confirmation or fee bumping.
- Drops the abort-on-`NonceTooHigh` path in `SendState` (state flag, `critical_error` branch, nonce reset/reuse policies), since it no longer surfaces as a critical error.

## Test plan
- [x] `cargo test -p base-tx-manager --all-features`
- [x] `cargo clippy -p base-tx-manager --all-features --all-targets`
