### PR TITLE
refactor(tx-forwarding): Make Shutdown Timeout Configurable

### DIFF
--- a/crates/execution/tx-forwarding/src/service.rs
+++ b/crates/execution/tx-forwarding/src/service.rs
@@ -36,9 +36,6 @@ pub enum ForwardingSetupError {
     },
 }
 
-/// Default maximum time allowed for destination queues and in-flight requests to drain.
-const DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
-
 /// Owns transaction forwarding configuration and starts destination pipelines.
 #[derive(Debug)]
 pub struct TxForwardingService {
@@ -75,7 +72,7 @@ impl TxForwardingService {
                 reader_cancel,
                 reader_tasks: Vec::new(),
                 forwarder_tasks: Vec::new(),
-                shutdown_timeout: DEFAULT_SHUTDOWN_TIMEOUT,
+                shutdown_timeout: TxForwardingHandle::DEFAULT_SHUTDOWN_TIMEOUT,
             };
         }
 
@@ -130,7 +127,7 @@ impl TxForwardingService {
             reader_cancel,
             reader_tasks,
             forwarder_tasks,
-            shutdown_timeout: DEFAULT_SHUTDOWN_TIMEOUT,
+            shutdown_timeout: TxForwardingHandle::DEFAULT_SHUTDOWN_TIMEOUT,
         }
     }
 
@@ -180,7 +177,7 @@ impl TxForwardingService {
             reader_cancel: CancellationToken::new(),
             reader_tasks: Vec::new(),
             forwarder_tasks,
-            shutdown_timeout: DEFAULT_SHUTDOWN_TIMEOUT,
+            shutdown_timeout: TxForwardingHandle::DEFAULT_SHUTDOWN_TIMEOUT,
         })
     }
 }
@@ -194,6 +191,9 @@ pub struct TxForwardingHandle {
 }
 
 impl TxForwardingHandle {
+    /// Default maximum time allowed for destination queues and in-flight requests to drain.
+    pub const DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
+
     /// Overrides how long [`Self::shutdown`] lets forwarders drain before aborting them.
     #[must_use]
     pub const fn with_shutdown_timeout(mut self, timeout: Duration) -> Self {
@@ -372,7 +372,7 @@ mod tests {
             reader_cancel,
             reader_tasks: vec![reader_task],
             forwarder_tasks: vec![forwarder_task],
-            shutdown_timeout: DEFAULT_SHUTDOWN_TIMEOUT,
+            shutdown_timeout: TxForwardingHandle::DEFAULT_SHUTDOWN_TIMEOUT,
         };
 
         let report = handle.shutdown().await;
@@ -389,7 +389,7 @@ mod tests {
             reader_cancel: CancellationToken::new(),
             reader_tasks: vec![tokio::spawn(async { panic!("reader failed") })],
             forwarder_tasks: vec![tokio::spawn(async { panic!("forwarder failed") })],
-            shutdown_timeout: DEFAULT_SHUTDOWN_TIMEOUT,
+            shutdown_timeout: TxForwardingHandle::DEFAULT_SHUTDOWN_TIMEOUT,
         };
 
         let report = handle.shutdown().await;

--- a/crates/execution/tx-forwarding/src/service.rs
+++ b/crates/execution/tx-forwarding/src/service.rs
@@ -36,12 +36,8 @@ pub enum ForwardingSetupError {
     },
 }
 
-/// Maximum time allowed for destination queues and in-flight requests to drain.
-#[cfg(not(test))]
-const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
-/// Short deadline used by unit tests that verify forced shutdown.
-#[cfg(test)]
-const SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(50);
+/// Default maximum time allowed for destination queues and in-flight requests to drain.
+const DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Owns transaction forwarding configuration and starts destination pipelines.
 #[derive(Debug)]
@@ -79,6 +75,7 @@ impl TxForwardingService {
                 reader_cancel,
                 reader_tasks: Vec::new(),
                 forwarder_tasks: Vec::new(),
+                shutdown_timeout: DEFAULT_SHUTDOWN_TIMEOUT,
             };
         }
 
@@ -129,7 +126,12 @@ impl TxForwardingService {
             info!(builder_url = %builder_url, "started transaction forwarding destination");
         }
 
-        TxForwardingHandle { reader_cancel, reader_tasks, forwarder_tasks }
+        TxForwardingHandle {
+            reader_cancel,
+            reader_tasks,
+            forwarder_tasks,
+            shutdown_timeout: DEFAULT_SHUTDOWN_TIMEOUT,
+        }
     }
 
     /// Starts one forwarder per destination, driven by queues the caller owns.
@@ -178,6 +180,7 @@ impl TxForwardingService {
             reader_cancel: CancellationToken::new(),
             reader_tasks: Vec::new(),
             forwarder_tasks,
+            shutdown_timeout: DEFAULT_SHUTDOWN_TIMEOUT,
         })
     }
 }
@@ -187,9 +190,17 @@ pub struct TxForwardingHandle {
     reader_cancel: CancellationToken,
     reader_tasks: Vec<JoinHandle<()>>,
     forwarder_tasks: Vec<JoinHandle<()>>,
+    shutdown_timeout: Duration,
 }
 
 impl TxForwardingHandle {
+    /// Overrides how long [`Self::shutdown`] lets forwarders drain before aborting them.
+    #[must_use]
+    pub const fn with_shutdown_timeout(mut self, timeout: Duration) -> Self {
+        self.shutdown_timeout = timeout;
+        self
+    }
+
     /// Stops pool readers, drains each destination queue, and reports task outcomes.
     pub async fn shutdown(self) -> ShutdownReport {
         self.reader_cancel.cancel();
@@ -199,7 +210,7 @@ impl TxForwardingHandle {
         let mut task_failures = reader_results.len() - readers_completed;
 
         let mut forwarders: FuturesUnordered<_> = self.forwarder_tasks.into_iter().collect();
-        let deadline = tokio::time::Instant::now() + SHUTDOWN_TIMEOUT;
+        let deadline = tokio::time::Instant::now() + self.shutdown_timeout;
         let mut forwarders_completed = 0;
         let mut timed_out = false;
 
@@ -361,6 +372,7 @@ mod tests {
             reader_cancel,
             reader_tasks: vec![reader_task],
             forwarder_tasks: vec![forwarder_task],
+            shutdown_timeout: DEFAULT_SHUTDOWN_TIMEOUT,
         };
 
         let report = handle.shutdown().await;
@@ -377,6 +389,7 @@ mod tests {
             reader_cancel: CancellationToken::new(),
             reader_tasks: vec![tokio::spawn(async { panic!("reader failed") })],
             forwarder_tasks: vec![tokio::spawn(async { panic!("forwarder failed") })],
+            shutdown_timeout: DEFAULT_SHUTDOWN_TIMEOUT,
         };
 
         let report = handle.shutdown().await;
@@ -393,6 +406,7 @@ mod tests {
             reader_cancel: CancellationToken::new(),
             reader_tasks: Vec::new(),
             forwarder_tasks: vec![tokio::spawn(std::future::pending())],
+            shutdown_timeout: Duration::from_millis(50),
         };
 
         let report = handle.shutdown().await;


### PR DESCRIPTION
## Summary

The forwarding shutdown timeout was previously a module constant that forked on `cfg(test)` versus `cfg(not(test))` so a single test could force a short drain deadline. This replaces that fork with a `shutdown_timeout` field on `TxForwardingHandle`, seeded from a single `DEFAULT_SHUTDOWN_TIMEOUT` in every spawn path. Production behavior is now exactly what you read rather than a value that changes meaning between build configurations. A public `with_shutdown_timeout` builder method exposes this as a genuine knob for callers, and the one test that needs a short deadline sets the field directly.