### PR TITLE
test(l3): add L3 integration smoke test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6339,6 +6339,7 @@ dependencies = [
  "alloy-signer-local 2.0.5",
  "alloy-sol-types",
  "async-trait",
+ "base-batcher-encoder",
  "base-batcher-service",
  "base-builder-core",
  "base-bundle-extension",

--- a/etc/systems/Cargo.toml
+++ b/etc/systems/Cargo.toml
@@ -20,6 +20,7 @@ base-flashblocks.workspace = true
 base-tx-forwarding.workspace = true
 base-txpool-tracing.workspace = true
 base-batcher-service.workspace = true
+base-batcher-encoder.workspace = true
 base-bundle-extension.workspace = true
 base-flashblocks-node.workspace = true
 base-consensus-rpc = { workspace = true, features = ["client"] }

--- a/etc/systems/src/l2/in_process_batcher.rs
+++ b/etc/systems/src/l2/in_process_batcher.rs
@@ -6,7 +6,9 @@
 
 use alloy_primitives::B256;
 use alloy_signer_local::PrivateKeySigner;
+use base_batcher_encoder::{DaType, EncoderConfig};
 use base_batcher_service::{BatcherConfig, BatcherService};
+use base_common_genesis::L1TxFormat;
 use base_runtime::TokioRuntime;
 use base_tx_manager::SignerConfig;
 use eyre::Result;
@@ -25,6 +27,10 @@ pub struct InProcessBatcherConfig {
     pub rollup_rpc_url: Url,
     /// Batcher private key for signing L1 transactions.
     pub batcher_key: B256,
+    /// L1 parent-chain transaction format. [`L1TxFormat::Base`] selects the L3 profile
+    /// (settling to a Base L1): batches are submitted via calldata rather than blobs, since a
+    /// Base parent chain exposes no blob DA endpoint.
+    pub l1_tx_format: L1TxFormat,
 }
 
 /// A running in-process batcher.
@@ -44,14 +50,23 @@ impl InProcessBatcher {
     pub async fn start(config: InProcessBatcherConfig) -> Result<Self> {
         let signer = PrivateKeySigner::from_bytes(&config.batcher_key)
             .map_err(|e| eyre::eyre!("invalid batcher key: {e}"))?;
+        let base_l1 = config.l1_tx_format == L1TxFormat::Base;
         let batcher_config = BatcherConfig {
             l1_rpc_url: vec![config.l1_rpc_url],
             l2_rpc_url: vec![config.l2_rpc_url],
             rollup_rpc_url: vec![config.rollup_rpc_url],
             signer: Some(SignerConfig::local(signer)),
-            // SystemTestStack defaults come from the shared batcher config:
-            // poll_interval: 1s, num_confirmations: 1, resubmission_timeout: 48s —
-            // all set by BatcherConfig::default().
+            l1_tx_format: config.l1_tx_format,
+            // A Base parent chain (L3) has no blob DA endpoint: submit via calldata and never fall
+            // back to blobs when throttling (both enforced by `BatcherConfig::validate`).
+            encoder_config: if base_l1 {
+                EncoderConfig { da_type: DaType::Calldata, ..EncoderConfig::default() }
+            } else {
+                EncoderConfig::default()
+            },
+            force_blobs_when_throttling: !base_l1,
+            // Remaining SystemTestStack defaults (poll_interval: 1s, num_confirmations: 1,
+            // resubmission_timeout: 48s) come from BatcherConfig::default().
             ..BatcherConfig::default()
         };
         let cancellation = CancellationToken::new();

--- a/etc/systems/src/l2/in_process_consensus.rs
+++ b/etc/systems/src/l2/in_process_consensus.rs
@@ -73,6 +73,9 @@ pub struct InProcessConsensusConfig {
     pub sequencer_stopped: bool,
     /// Number of L1 blocks to keep distance from the L1 head for the verifier.
     pub verifier_l1_confs: u64,
+    /// L1 parent-chain transaction format. [`L1TxFormat::Base`] makes the derivation pipeline
+    /// decode Base-format L1 blocks (the L3 profile); [`L1TxFormat::Ethereum`] is the default.
+    pub l1_tx_format: L1TxFormat,
 }
 
 /// A running in-process consensus node.
@@ -152,7 +155,7 @@ impl InProcessConsensus {
             trust_rpc: true,
             beacon: Some(config.l1_beacon_url),
             rpc_url: config.l1_rpc_url.clone(),
-            l1_tx_format: L1TxFormat::default(),
+            l1_tx_format: config.l1_tx_format,
             slot_duration_override: config.l1_slot_duration_override,
             verifier_l1_confs: config.verifier_l1_confs,
         };

--- a/etc/systems/src/l2/stack.rs
+++ b/etc/systems/src/l2/stack.rs
@@ -12,7 +12,7 @@ use alloy_genesis::ChainConfig;
 use alloy_primitives::B256;
 use alloy_rpc_types_engine::JwtSecret;
 use base_common_genesis::RollupConfig;
-use base_consensus_node::NodeMode;
+use base_consensus_node::{L1TxFormat, NodeMode};
 use base_tx_forwarding::TxForwardingConfig;
 use eyre::{Result, WrapErr};
 use url::Url;
@@ -65,6 +65,9 @@ pub struct L2StackConfig {
     pub verifier_l1_confs: u64,
     /// Consensus mode for the L2 client node.
     pub client_consensus_mode: L2ClientConsensusMode,
+    /// L1 parent-chain transaction format. [`L1TxFormat::Base`] selects the L3 profile: both
+    /// consensus nodes decode Base-format L1 blocks and the batcher submits via calldata.
+    pub l1_tx_format: L1TxFormat,
 }
 
 /// Running L2 client consensus node.
@@ -196,6 +199,7 @@ impl L2Stack {
             l1_slot_duration_override: Some(4),
             sequencer_stopped: true,
             verifier_l1_confs: 0,
+            l1_tx_format: config.l1_tx_format,
         };
         let builder_consensus = InProcessConsensus::start(builder_consensus_config)
             .await
@@ -208,6 +212,7 @@ impl L2Stack {
             l2_rpc_url: builder.rpc_url()?,
             rollup_rpc_url: builder_consensus.rpc_url(),
             batcher_key: config.batcher_key,
+            l1_tx_format: config.l1_tx_format,
         })
         .await
         .wrap_err("Failed to start in-process batcher")?;
@@ -261,6 +266,7 @@ impl L2Stack {
                     l1_slot_duration_override: Some(4),
                     sequencer_stopped: false,
                     verifier_l1_confs: config.verifier_l1_confs,
+                    l1_tx_format: config.l1_tx_format,
                 };
                 let client_consensus = InProcessConsensus::start(client_consensus_config)
                     .await

--- a/etc/systems/src/smoke.rs
+++ b/etc/systems/src/smoke.rs
@@ -9,6 +9,7 @@ use alloy_network::Ethereum;
 use alloy_provider::RootProvider;
 use alloy_rpc_client::RpcClient;
 use alloy_rpc_types_engine::JwtSecret;
+use base_common_genesis::L1TxFormat;
 use base_common_network::Base;
 use base_tx_forwarding::TxForwardingConfig;
 use eyre::{Result, WrapErr};
@@ -139,6 +140,7 @@ pub struct SystemTestStackBuilder {
     tx_forwarding_config: Option<TxForwardingConfig>,
     verifier_l1_confs: u64,
     client_consensus_mode: L2ClientConsensusMode,
+    l1_tx_format: L1TxFormat,
 }
 
 impl SystemTestStackBuilder {
@@ -213,6 +215,20 @@ impl SystemTestStackBuilder {
     /// client (validator) node's derivation pipeline.
     pub const fn with_verifier_l1_confs(mut self, confs: u64) -> Self {
         self.verifier_l1_confs = confs;
+        self
+    }
+
+    /// Sets the L1 parent-chain transaction format used by the L2 consensus nodes and batcher.
+    pub const fn with_l1_tx_format(mut self, l1_tx_format: L1TxFormat) -> Self {
+        self.l1_tx_format = l1_tx_format;
+        self
+    }
+
+    /// Configures the stack as an L3 — a Base chain settling to a Base L1. The consensus nodes
+    /// decode Base-format L1 blocks ([`L1TxFormat::Base`]) and the batcher submits batches via
+    /// calldata data-availability, since a Base parent chain has no blob DA endpoint.
+    pub const fn with_l3_profile(mut self) -> Self {
+        self.l1_tx_format = L1TxFormat::Base;
         self
     }
 
@@ -385,6 +401,7 @@ impl SystemTestStackBuilder {
             tx_forwarding_config: self.tx_forwarding_config,
             verifier_l1_confs: self.verifier_l1_confs,
             client_consensus_mode: self.client_consensus_mode,
+            l1_tx_format: self.l1_tx_format,
         };
 
         let l2_stack = L2Stack::start(l2_config).await.wrap_err("Failed to start L2 stack")?;

--- a/etc/systems/tests/l3_smoke.rs
+++ b/etc/systems/tests/l3_smoke.rs
@@ -27,6 +27,9 @@ const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(30);
 const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
 /// The client must derive the chain purely from L1 within this window.
 const CLIENT_SYNC_TIMEOUT: Duration = Duration::from_secs(90);
+/// The batcher must post at least one batch within this window. Submission lags block production:
+/// the batcher accumulates L2 blocks into a channel and only submits once the channel closes.
+const BATCH_SUBMISSION_TIMEOUT: Duration = Duration::from_secs(120);
 
 #[tokio::test]
 async fn l3_smoke_calldata_da_derivation() -> Result<()> {
@@ -81,10 +84,24 @@ async fn l3_smoke_calldata_da_derivation() -> Result<()> {
     //    Base-format client sync above, a positive nonce confirms the calldata-DA path: had the
     //    batcher posted blob transactions, the client's Base-format L1 decoding would have failed
     //    and step 2 would have timed out.
-    let batcher_l1_nonce = l1_provider
-        .get_transaction_count(BATCHER.address)
-        .await
-        .wrap_err("failed to read batcher L1 nonce")?;
+    //
+    //    Poll rather than sample once: batch submission lags block production because the batcher
+    //    accumulates L2 blocks into a channel and only posts once the channel closes, which can
+    //    happen after the client has already advanced past block 0.
+    let batcher_l1_nonce = timeout(BATCH_SUBMISSION_TIMEOUT, async {
+        loop {
+            let nonce = l1_provider
+                .get_transaction_count(BATCHER.address)
+                .await
+                .wrap_err("failed to read batcher L1 nonce")?;
+            if nonce > 0 {
+                return Ok::<_, eyre::Error>(nonce);
+            }
+            sleep(BLOCK_POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .wrap_err("batcher did not submit any L1 batch transaction")??;
     assert!(
         batcher_l1_nonce > 0,
         "batcher should have submitted at least one L1 batch transaction"

--- a/etc/systems/tests/l3_smoke.rs
+++ b/etc/systems/tests/l3_smoke.rs
@@ -1,0 +1,94 @@
+//! Smoke test for the L3 chain: a Base L2 that settles to a Base L1.
+//!
+//! Brings up the in-process [`SystemTestStack`](base_system_tests::SystemTestStack) in the L3
+//! profile ([`with_l3_profile`](base_system_tests::SystemTestStackBuilder::with_l3_profile)) and
+//! checks end-to-end liveness of the two properties that distinguish an L3 from a plain L2:
+//!
+//! 1. the derivation pipeline decodes **Base-format** L1 blocks (`L1TxFormat::Base`), and
+//! 2. the batcher submits batches via **calldata** data-availability — a Base parent chain has no
+//!    blob DA endpoint.
+//!
+//! Fidelity note: the system-test harness L1 is a standard Ethereum reth + lighthouse devnet, so
+//! this exercises the L3 *configuration and DA model* end-to-end, not Base-L1-native parent
+//! features (L1 deposits / EIP-8130 transactions on the parent), which would require a Base
+//! execution layer for L1. That lower-level decoding is covered by the component tests in
+//! `base-common-network` / `base-proof` (e.g. `base_format_block_decodes_and_drops_eip8130`).
+
+use std::time::Duration;
+
+use alloy_provider::Provider;
+use base_system_tests::{BATCHER, SystemTestStackBuilder};
+use eyre::{Result, WrapErr};
+use tokio::time::{sleep, timeout};
+
+const L1_CHAIN_ID: u64 = 1337;
+const L2_CHAIN_ID: u64 = 84538453;
+const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(30);
+const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
+/// The client must derive the chain purely from L1 within this window.
+const CLIENT_SYNC_TIMEOUT: Duration = Duration::from_secs(90);
+
+#[tokio::test]
+async fn l3_smoke_calldata_da_derivation() -> Result<()> {
+    base_node_runner::test_utils::init_silenced_tracing();
+
+    // Bring up the stack configured as an L3: Base-format L1 decoding + calldata batch submission.
+    let system = SystemTestStackBuilder::new()
+        .with_l1_chain_id(L1_CHAIN_ID)
+        .with_l2_chain_id(L2_CHAIN_ID)
+        .with_l3_profile()
+        .build()
+        .await
+        .wrap_err("failed to start L3 system stack")?;
+
+    let l1_provider = system.l1_provider().await?;
+    let builder_provider = system.l2_builder_provider()?;
+    let client_provider = system.l2_client_provider()?;
+
+    // 1. The sequencer produces L2 blocks under the L3 config (Base tx-format + calldata DA).
+    timeout(BLOCK_PRODUCTION_TIMEOUT, async {
+        loop {
+            if builder_provider.get_block_number().await? >= 3 {
+                return Ok::<_, eyre::Error>(());
+            }
+            sleep(BLOCK_POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .wrap_err("L2 sequencer did not produce blocks under the L3 profile")??;
+
+    // 2. The validator derives the chain from L1. This is the core L3 signal: the client's L1
+    //    provider is configured for Base-format decoding, and derivation only advances if the
+    //    batches it reads back from L1 decode cleanly. A Base-format provider cannot decode an
+    //    EIP-4844 blob transaction, so a healthy sync also proves the batcher posted calldata,
+    //    not blobs.
+    let client_block = timeout(CLIENT_SYNC_TIMEOUT, async {
+        loop {
+            let block = client_provider.get_block_number().await?;
+            if block > 0 {
+                return Ok::<_, eyre::Error>(block);
+            }
+            sleep(Duration::from_secs(2)).await;
+        }
+    })
+    .await
+    .wrap_err(
+        "client did not sync from L1 under the L3 profile (Base-format derivation stalled)",
+    )??;
+    assert!(client_block > 0, "client should derive at least one L2 block from L1");
+
+    // 3. The batcher actually submitted its batches to L1. Combined with the successful
+    //    Base-format client sync above, a positive nonce confirms the calldata-DA path: had the
+    //    batcher posted blob transactions, the client's Base-format L1 decoding would have failed
+    //    and step 2 would have timed out.
+    let batcher_l1_nonce = l1_provider
+        .get_transaction_count(BATCHER.address)
+        .await
+        .wrap_err("failed to read batcher L1 nonce")?;
+    assert!(
+        batcher_l1_nonce > 0,
+        "batcher should have submitted at least one L1 batch transaction"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
# Overview

Thread an L1TxFormat through the system-test stack so it can run in an L3 profile: consensus nodes decode Base-format L1 blocks and the batcher submits batches via calldata (no blob DA on a Base parent chain).

Add SystemTestStackBuilder::with_l3_profile() and the l3_smoke test, which brings up the stack as an L3 and checks block production, L1-derived client sync, and calldata batch submission.