### PR TITLE
feat(common): statically decode EIP-8130 coinbase tips

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3537,6 +3537,7 @@ dependencies = [
  "alloy-serde 2.4.1",
  "alloy-signer 2.4.1",
  "alloy-signer-local 2.4.1",
+ "alloy-sol-types",
  "arbitrary",
  "bincode 2.0.1",
  "bytes",

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -870,8 +870,9 @@ impl BasePayloadBuilderCtx {
 
             let tx_hash = *tx.hash();
             let has_validity_predicates = !tx.validity_predicates().is_empty();
-            let has_coinbase_tip =
-                tx.as_eip8130().is_some_and(|signed| signed.tx().coinbase_tip().is_some());
+            let has_coinbase_tip = tx
+                .as_eip8130()
+                .is_some_and(|signed| signed.tx().coinbase_tip(tx.sender()).is_some());
 
             // Defer without evaluating once this flashblock's predicate-eval time budget is
             // exhausted, rather than spending more IO on the naive per-transaction loop. The

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -13,7 +13,9 @@ use alloy_primitives::{BlockHash, Bytes, TxHash, U256};
 use alloy_rpc_types_eth::Withdrawals;
 use base_bundles::{MeterBundleResponse, RejectedTransaction, RejectionReason};
 use base_common_chains::Upgrades;
-use base_common_consensus::{BaseReceipt, BaseTransactionSigned, DepositReceipt, OpTxType};
+use base_common_consensus::{
+    BaseReceipt, BaseTransactionSigned, CoinbaseTip, DepositReceipt, OpTxType,
+};
 use base_common_evm::{BaseReceiptBuilder, BaseSpecId, L1BlockInfo};
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_eip8130::IntrinsicGas;
@@ -872,7 +874,7 @@ impl BasePayloadBuilderCtx {
             let has_validity_predicates = !tx.validity_predicates().is_empty();
             let has_coinbase_tip = tx
                 .as_eip8130()
-                .is_some_and(|signed| signed.tx().coinbase_tip(tx.sender()).is_some());
+                .is_some_and(|signed| CoinbaseTip::decode(signed.tx(), tx.sender()).is_some());
 
             // Defer without evaluating once this flashblock's predicate-eval time budget is
             // exhausted, rather than spending more IO on the naive per-transaction loop. The

--- a/crates/common/consensus/Cargo.toml
+++ b/crates/common/consensus/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 alloy-rlp.workspace = true
 alloy-eips.workspace = true
 alloy-consensus.workspace = true
+alloy-sol-types.workspace = true
 alloy-primitives = { workspace = true, features = ["rlp"] }
 
 # compat
@@ -67,6 +68,7 @@ std = [
 	"alloy-rlp/std",
 	"alloy-rpc-types-eth?/std",
 	"alloy-serde?/std",
+	"alloy-sol-types/std",
 	"reth-codecs?/std",
 	"reth-primitives-traits?/std",
 	"reth-zstd-compressors?/std",

--- a/crates/common/consensus/src/lib.rs
+++ b/crates/common/consensus/src/lib.rs
@@ -32,8 +32,8 @@ pub use transaction::{
     BaseTransactionInfo, BaseTxEnvelope, BaseTypedTransaction, Call, ChangeType, CreateEntry,
     DEPOSIT_TX_TYPE_ID, Delegation, DepositInfo, DepositTransaction, EIP8130_REJECTION_MSG,
     EIP8130_TX_TYPE_ID, Eip8130Constants, Eip8130Contracts, Eip8130Signed, Eip8130StaticError,
-    Eip8130TimestampError, InitialActor, OpTxType, Scope, SignedAccountChanges, SignedChange,
-    TxDeposit, TxEip8130,
+    Eip8130TimestampError, IDefaultAccount, InitialActor, OpTxType, Scope, SignedAccountChanges,
+    SignedChange, TxDeposit, TxEip8130,
 };
 
 mod extra;

--- a/crates/common/consensus/src/lib.rs
+++ b/crates/common/consensus/src/lib.rs
@@ -29,11 +29,11 @@ mod transaction;
 pub use transaction::serde_deposit_tx_rpc;
 pub use transaction::{
     AccountChange, AccountChangeChannel, BasePooledTransaction, BaseTransaction,
-    BaseTransactionInfo, BaseTxEnvelope, BaseTypedTransaction, Call, ChangeType, CreateEntry,
-    DEPOSIT_TX_TYPE_ID, Delegation, DepositInfo, DepositTransaction, EIP8130_REJECTION_MSG,
-    EIP8130_TX_TYPE_ID, Eip8130Constants, Eip8130Contracts, Eip8130Signed, Eip8130StaticError,
-    Eip8130TimestampError, IDefaultAccount, InitialActor, OpTxType, Scope, SignedAccountChanges,
-    SignedChange, TxDeposit, TxEip8130,
+    BaseTransactionInfo, BaseTxEnvelope, BaseTypedTransaction, Call, ChangeType, CoinbaseTip,
+    CreateEntry, DEPOSIT_TX_TYPE_ID, Delegation, DepositInfo, DepositTransaction,
+    EIP8130_REJECTION_MSG, EIP8130_TX_TYPE_ID, Eip8130Constants, Eip8130Contracts, Eip8130Signed,
+    Eip8130StaticError, Eip8130TimestampError, IDefaultAccount, InitialActor, OpTxType, Scope,
+    SignedAccountChanges, SignedChange, TxDeposit, TxEip8130,
 };
 
 mod extra;

--- a/crates/common/consensus/src/transaction/eip8130/addresses.rs
+++ b/crates/common/consensus/src/transaction/eip8130/addresses.rs
@@ -22,6 +22,7 @@
 //! [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
 
 use alloy_primitives::{Address, B256, address, b256, keccak256};
+use alloy_sol_types::sol;
 
 /// Canonical [EIP-8130] contract addresses and the node authenticator allowlist.
 ///
@@ -198,6 +199,24 @@ impl Eip8130Contracts {
     #[must_use]
     pub fn erc1167_proxy_code_hash(implementation: Address) -> B256 {
         keccak256(Self::erc1167_proxy_runtime(implementation))
+    }
+}
+
+sol! {
+    /// ABI of [`Eip8130Contracts::DEFAULT_ACCOUNT`] (`execute` / `executeBatch`).
+    interface IDefaultAccount {
+        /// Inner call of `executeBatch`.
+        struct Call {
+            address target;
+            uint256 value;
+            bytes data;
+        }
+
+        /// Single call from the account; equivalent to a one-element batch.
+        function execute(address target, uint256 value, bytes data) external;
+
+        /// Ordered batch of calls from the account.
+        function executeBatch(Call[] calls) external;
     }
 }
 

--- a/crates/common/consensus/src/transaction/eip8130/coinbase_tip.rs
+++ b/crates/common/consensus/src/transaction/eip8130/coinbase_tip.rs
@@ -1,0 +1,291 @@
+//! Static decode of a phase-0 `DefaultAccount` transfer to the Sequencer Fee Vault.
+
+use alloy_primitives::{Address, U256};
+use alloy_sol_types::SolCall;
+
+use super::{
+    IDefaultAccount, TxEip8130, account_changes::AccountChange, addresses::Eip8130Contracts,
+};
+use crate::Predeploys;
+
+/// Recovers a statically-analyzable phase-0 coinbase tip from an EIP-8130 body.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct CoinbaseTip;
+
+impl CoinbaseTip {
+    /// Statically decoded phase-0 coinbase tip, if one can be recovered without
+    /// executing the transaction.
+    ///
+    /// EIP-8130 `calls` are grouped into phases. A revert discards that phase
+    /// and skips later ones, so only a tip in **phase 0** is statically
+    /// meaningful. Protocol calls carry no value (`call = rlp([to, data])`);
+    /// ETH moves only when wallet bytecode issues a `CALL`.
+    ///
+    /// Returns [`Some`] when the sender uses
+    /// [`Eip8130Contracts::DEFAULT_ACCOUNT`] (EOA auto-delegation, or an
+    /// explicit delegation to that implementation), phase 0 contains exactly
+    /// one call invoked on `resolved_sender`, and the calldata is
+    /// `DefaultAccount.execute` (or a one-element `executeBatch`) transferring
+    /// ETH to [`Predeploys::SEQUENCER_FEE_VAULT`] with empty calldata.
+    ///
+    /// `resolved_sender` is the account that will dispatch the call: the
+    /// explicit [`TxEip8130::sender`] when present, otherwise the recovered EOA.
+    /// The protocol call's `to` must equal that address, matching execution
+    /// (`from` is the sender; `execute` must run on the sender itself).
+    #[must_use]
+    pub fn decode(tx: &TxEip8130, resolved_sender: Address) -> Option<U256> {
+        if !Self::statically_uses_default_account(tx) {
+            return None;
+        }
+        if tx.sender.is_some_and(|sender| sender != resolved_sender) {
+            return None;
+        }
+        let [call] = tx.calls.first()?.as_slice() else {
+            return None;
+        };
+        if call.to != resolved_sender {
+            return None;
+        }
+        let (recipient, amount) = Self::default_account_eth_transfer(&call.data)?;
+        (recipient == Predeploys::SEQUENCER_FEE_VAULT).then_some(amount)
+    }
+
+    /// Whether the unsigned body statically implies
+    /// [`Eip8130Contracts::DEFAULT_ACCOUNT`] as the sender's wallet.
+    ///
+    /// A `Create` installs caller-supplied bytecode, so it is never the
+    /// default account. A `Delegation` is default only when its target is
+    /// [`Eip8130Contracts::DEFAULT_ACCOUNT`] (multiple delegations are invalid
+    /// and treated as not default). With neither entry, only the EOA path
+    /// (`sender == None`) auto-delegates; a configured sender's existing code
+    /// is not visible here.
+    fn statically_uses_default_account(tx: &TxEip8130) -> bool {
+        let mut explicit_target = None;
+        for change in &tx.account_changes {
+            match change {
+                AccountChange::Create(_) => return false,
+                AccountChange::Delegation(delegation) => {
+                    if explicit_target.is_some() {
+                        return false;
+                    }
+                    explicit_target = Some(delegation.target);
+                }
+                AccountChange::ConfigChange(_) => {}
+            }
+        }
+        explicit_target.map_or_else(
+            || tx.sender.is_none(),
+            |target| target == Eip8130Contracts::DEFAULT_ACCOUNT,
+        )
+    }
+
+    /// Recipient and amount of a pure ETH transfer encoded as
+    /// `execute(target, value, "")` or a one-element `executeBatch` of the same
+    /// shape.
+    fn default_account_eth_transfer(calldata: &[u8]) -> Option<(Address, U256)> {
+        if let Ok(call) = IDefaultAccount::executeCall::abi_decode_validate(calldata) {
+            return call.data.is_empty().then_some((call.target, call.value));
+        }
+        let batch = IDefaultAccount::executeBatchCall::abi_decode_validate(calldata).ok()?;
+        let [inner] = batch.calls.as_slice() else {
+            return None;
+        };
+        inner.data.is_empty().then_some((inner.target, inner.value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, B256, Bytes, U256, address, bytes};
+    use alloy_sol_types::SolCall;
+
+    use super::CoinbaseTip;
+    use crate::{
+        Predeploys,
+        transaction::eip8130::{
+            Call, IDefaultAccount, TxEip8130,
+            account_changes::{
+                AccountChange, AccountChangeChannel, CreateEntry, Delegation, SignedAccountChanges,
+            },
+            addresses::Eip8130Contracts,
+        },
+    };
+
+    const SENDER: Address = address!("0x00000000000000000000000000000000000000bb");
+    const COINBASE: Address = Predeploys::SEQUENCER_FEE_VAULT;
+    const OTHER_RECIPIENT: Address = address!("0x00000000000000000000000000000000000000cc");
+    const TIP_AMOUNT: u64 = 123;
+
+    fn encode_execute(target: Address, value: U256, data: &[u8]) -> Bytes {
+        Bytes::from(
+            IDefaultAccount::executeCall { target, value, data: data.to_vec().into() }.abi_encode(),
+        )
+    }
+
+    fn encode_execute_batch_one(target: Address, value: U256) -> Bytes {
+        Bytes::from(
+            IDefaultAccount::executeBatchCall {
+                calls: vec![IDefaultAccount::Call { target, value, data: Default::default() }],
+            }
+            .abi_encode(),
+        )
+    }
+
+    fn execute_call(to: Address) -> Call {
+        Call { to, data: encode_execute(COINBASE, U256::from(TIP_AMOUNT), &[]) }
+    }
+
+    fn eoa_with_phase0(calls: Vec<Call>) -> TxEip8130 {
+        TxEip8130 { sender: None, calls: vec![calls], ..Default::default() }
+    }
+
+    #[test]
+    fn coinbase_tip_execute_encoding_matches_canonical_abi() {
+        assert_eq!(
+            encode_execute(COINBASE, U256::from(TIP_AMOUNT), &[]).as_ref(),
+            bytes!("b61d27f60000000000000000000000004200000000000000000000000000000000000011000000000000000000000000000000000000000000000000000000000000007b00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000")
+                .as_ref(),
+        );
+        assert_eq!(
+            encode_execute_batch_one(COINBASE, U256::from(TIP_AMOUNT)).as_ref(),
+            bytes!("34fcd5be0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000200000000000000000000000004200000000000000000000000000000000000011000000000000000000000000000000000000000000000000000000000000007b00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000")
+                .as_ref(),
+        );
+    }
+
+    #[test]
+    fn coinbase_tip_eoa_execute_returns_amount() {
+        let tx = eoa_with_phase0(vec![execute_call(SENDER)]);
+        assert_eq!(CoinbaseTip::decode(&tx, SENDER), Some(U256::from(TIP_AMOUNT)));
+        let other = eoa_with_phase0(vec![Call {
+            to: SENDER,
+            data: encode_execute(OTHER_RECIPIENT, U256::from(TIP_AMOUNT), &[]),
+        }]);
+        assert_eq!(CoinbaseTip::decode(&other, SENDER), None);
+        let not_self = eoa_with_phase0(vec![execute_call(COINBASE)]);
+        assert_eq!(CoinbaseTip::decode(&not_self, SENDER), None);
+    }
+
+    #[test]
+    fn coinbase_tip_eoa_execute_batch_single_send_returns_amount() {
+        let tx = eoa_with_phase0(vec![Call {
+            to: SENDER,
+            data: encode_execute_batch_one(COINBASE, U256::from(TIP_AMOUNT)),
+        }]);
+        assert_eq!(CoinbaseTip::decode(&tx, SENDER), Some(U256::from(TIP_AMOUNT)));
+        let other = eoa_with_phase0(vec![Call {
+            to: SENDER,
+            data: encode_execute_batch_one(OTHER_RECIPIENT, U256::from(TIP_AMOUNT)),
+        }]);
+        assert_eq!(CoinbaseTip::decode(&other, SENDER), None);
+    }
+
+    #[test]
+    fn coinbase_tip_explicit_sender_requires_self_call_and_default_delegation() {
+        let delegated = TxEip8130 {
+            sender: Some(SENDER),
+            account_changes: vec![AccountChange::Delegation(Delegation {
+                target: Eip8130Contracts::DEFAULT_ACCOUNT,
+            })],
+            calls: vec![vec![execute_call(SENDER)]],
+            ..Default::default()
+        };
+        assert_eq!(CoinbaseTip::decode(&delegated, SENDER), Some(U256::from(TIP_AMOUNT)));
+
+        let not_self = TxEip8130 { calls: vec![vec![execute_call(COINBASE)]], ..delegated.clone() };
+        assert_eq!(CoinbaseTip::decode(&not_self, SENDER), None);
+        assert_eq!(CoinbaseTip::decode(&delegated, OTHER_RECIPIENT), None);
+
+        let no_delegation = TxEip8130 { account_changes: vec![], ..delegated };
+        assert_eq!(CoinbaseTip::decode(&no_delegation, SENDER), None);
+    }
+
+    #[test]
+    fn coinbase_tip_rejects_non_default_account() {
+        let other_impl = TxEip8130 {
+            sender: Some(SENDER),
+            account_changes: vec![AccountChange::Delegation(Delegation {
+                target: Eip8130Contracts::CANONICAL_HIGH_RATE_PAYER_ACCOUNT,
+            })],
+            calls: vec![vec![execute_call(SENDER)]],
+            ..Default::default()
+        };
+        assert_eq!(CoinbaseTip::decode(&other_impl, SENDER), None);
+
+        let cleared = TxEip8130 {
+            account_changes: vec![AccountChange::Delegation(Delegation { target: Address::ZERO })],
+            ..other_impl
+        };
+        assert_eq!(CoinbaseTip::decode(&cleared, SENDER), None);
+
+        let created = TxEip8130 {
+            sender: None,
+            account_changes: vec![AccountChange::Create(CreateEntry {
+                user_salt: B256::ZERO,
+                code: bytes!("01"),
+                initial_actors: vec![],
+            })],
+            calls: vec![vec![execute_call(SENDER)]],
+            ..Default::default()
+        };
+        assert_eq!(CoinbaseTip::decode(&created, SENDER), None);
+    }
+
+    #[test]
+    fn coinbase_tip_requires_single_phase0_eth_transfer() {
+        let call = execute_call(SENDER);
+
+        assert_eq!(
+            CoinbaseTip::decode(&eoa_with_phase0(vec![call.clone(), call.clone()]), SENDER),
+            None
+        );
+        assert_eq!(CoinbaseTip::decode(&eoa_with_phase0(vec![]), SENDER), None);
+
+        let later_phase =
+            TxEip8130 { sender: None, calls: vec![vec![], vec![call]], ..Default::default() };
+        assert_eq!(CoinbaseTip::decode(&later_phase, SENDER), None);
+
+        let with_calldata = eoa_with_phase0(vec![Call {
+            to: SENDER,
+            data: encode_execute(COINBASE, U256::from(TIP_AMOUNT), &[0x01]),
+        }]);
+        assert_eq!(CoinbaseTip::decode(&with_calldata, SENDER), None);
+
+        let wrong_selector = eoa_with_phase0(vec![Call { to: SENDER, data: bytes!("deadbeef") }]);
+        assert_eq!(CoinbaseTip::decode(&wrong_selector, SENDER), None);
+
+        let configured = TxEip8130 { sender: Some(SENDER), ..Default::default() };
+        assert_eq!(CoinbaseTip::decode(&configured, SENDER), None);
+    }
+
+    #[test]
+    fn coinbase_tip_config_change_does_not_block_eoa_auto_delegation() {
+        let tx = TxEip8130 {
+            sender: None,
+            account_changes: vec![AccountChange::ConfigChange(SignedAccountChanges {
+                channel: AccountChangeChannel::Local,
+                sequence: 0,
+                changes: vec![],
+                signature: Bytes::new(),
+            })],
+            calls: vec![vec![execute_call(SENDER)]],
+            ..Default::default()
+        };
+        assert_eq!(CoinbaseTip::decode(&tx, SENDER), Some(U256::from(TIP_AMOUNT)));
+    }
+
+    #[test]
+    fn coinbase_tip_rejects_truncated_or_dirty_calldata() {
+        let mut truncated = encode_execute(COINBASE, U256::from(TIP_AMOUNT), &[]).to_vec();
+        truncated.truncate(truncated.len().saturating_sub(32));
+        let truncated_tx = eoa_with_phase0(vec![Call { to: SENDER, data: Bytes::from(truncated) }]);
+        assert_eq!(CoinbaseTip::decode(&truncated_tx, SENDER), None);
+
+        // High bytes of the address word must be zero; `abi_decode_validate` rejects
+        // that dirty padding even though a lenient decoder would still yield a tip.
+        let mut dirty = encode_execute(COINBASE, U256::from(TIP_AMOUNT), &[]).to_vec();
+        dirty[4] = 0xff;
+        let dirty_tx = eoa_with_phase0(vec![Call { to: SENDER, data: Bytes::from(dirty) }]);
+        assert_eq!(CoinbaseTip::decode(&dirty_tx, SENDER), None);
+    }
+}

--- a/crates/common/consensus/src/transaction/eip8130/mod.rs
+++ b/crates/common/consensus/src/transaction/eip8130/mod.rs
@@ -10,7 +10,7 @@ mod constants;
 pub use constants::Eip8130Constants;
 
 mod addresses;
-pub use addresses::Eip8130Contracts;
+pub use addresses::{Eip8130Contracts, IDefaultAccount};
 
 mod call;
 pub use call::Call;

--- a/crates/common/consensus/src/transaction/eip8130/mod.rs
+++ b/crates/common/consensus/src/transaction/eip8130/mod.rs
@@ -2,7 +2,8 @@
 //!
 //! Provides type-only plumbing for the new transaction kind:
 //! [`TxEip8130`] (unsigned), [`Eip8130Signed`] (signed envelope), [`AccountChange`]
-//! (tagged-union account-mutation entries), and [`Call`] (per-call payload).
+//! (tagged-union account-mutation entries), and [`Call`] (per-call payload),
+//! plus [`CoinbaseTip`] for static phase-0 tip recovery.
 //!
 //! [EIP-8130]: https://eips.ethereum.org/EIPS/eip-8130
 
@@ -23,6 +24,9 @@ pub use account_changes::{
 
 mod tx;
 pub use tx::TxEip8130;
+
+mod coinbase_tip;
+pub use coinbase_tip::CoinbaseTip;
 
 mod signed;
 pub use signed::{Eip8130Signed, Eip8130StaticError, Eip8130TimestampError};

--- a/crates/common/consensus/src/transaction/eip8130/tx.rs
+++ b/crates/common/consensus/src/transaction/eip8130/tx.rs
@@ -15,11 +15,16 @@ use alloy_primitives::{
     Address, B256, Bytes, ChainId, Signature, TxKind, U256, bytes::BufMut, keccak256,
 };
 use alloy_rlp::{Decodable, Encodable, Header, length_of_length};
+use alloy_sol_types::SolCall;
 #[cfg(feature = "reth")]
 use reth_codecs::Compact;
 
-use crate::transaction::eip8130::{
-    account_changes::AccountChange, call::Call, constants::Eip8130Constants,
+use crate::{
+    Predeploys,
+    transaction::eip8130::{
+        IDefaultAccount, account_changes::AccountChange, addresses::Eip8130Contracts, call::Call,
+        constants::Eip8130Constants,
+    },
 };
 
 /// Unsigned body of an [EIP-8130] Account Abstraction transaction.
@@ -89,32 +94,77 @@ pub struct TxEip8130 {
 }
 
 impl TxEip8130 {
-    /// Statically-decoded phase-0 coinbase tip, if one can be recovered without
+    /// Statically decoded phase-0 coinbase tip, if one can be recovered without
     /// executing the transaction.
     ///
-    /// EIP-8130 `calls` is an array of phases. Atomicity is per phase: if any
-    /// call in a phase reverts, that phase is discarded and later phases are
-    /// skipped. The bid therefore lives in **phase 0**; a tip in a later phase
-    /// is not statically meaningful.
+    /// EIP-8130 `calls` are grouped into phases. A revert discards that phase
+    /// and skips later ones, so only a tip in **phase 0** is statically
+    /// meaningful. Protocol calls carry no value (`call = rlp([to, data])`);
+    /// ETH moves only when wallet bytecode issues a `CALL`.
     ///
-    /// Protocol calls have no value field (`call = rlp([to, data])`). ETH
-    /// moves only when the account's wallet bytecode issues a `CALL`. The
-    /// statically-analyzable encoding is therefore:
+    /// Returns [`Some`] when the sender uses
+    /// [`Eip8130Contracts::DEFAULT_ACCOUNT`] (EOA auto-delegation, or an
+    /// explicit delegation to that implementation), phase 0 contains exactly
+    /// one call, that call is invoked on the sender when the sender is
+    /// explicit, and the calldata is `DefaultAccount.execute` (or a
+    /// one-element `executeBatch`) transferring ETH to
+    /// [`Predeploys::SEQUENCER_FEE_VAULT`] with empty calldata.
+    #[must_use]
+    pub fn coinbase_tip(&self) -> Option<U256> {
+        if !self.statically_uses_default_account() {
+            return None;
+        }
+        let [call] = self.calls.first()?.as_slice() else {
+            return None;
+        };
+        if self.sender.is_some_and(|sender| call.to != sender) {
+            return None;
+        }
+        let (recipient, amount) = Self::default_account_eth_transfer(&call.data)?;
+        (recipient == Predeploys::SEQUENCER_FEE_VAULT).then_some(amount)
+    }
+
+    /// Whether the unsigned body statically implies
+    /// [`Eip8130Contracts::DEFAULT_ACCOUNT`] as the sender's wallet.
     ///
-    /// - the sender uses [`super::Eip8130Contracts::DEFAULT_ACCOUNT`]
-    ///   (auto-delegated for a code-less account, or explicitly delegated)
-    /// - phase 0 is the default account's ETH-transfer entrypoint
-    /// - invoked on the sender itself
-    /// - coinbase as recipient
-    /// - the tip as amount
-    ///
-    /// # TODO
-    /// Pin the `DefaultAccount` ETH-transfer selector and argument encoding
-    /// against [`super::Eip8130Contracts::DEFAULT_ACCOUNT`] and decode phase
-    /// 0. Until that static decode exists this returns [`None`].
-    pub const fn coinbase_tip(&self) -> Option<U256> {
-        let _ = self;
-        None
+    /// A `Create` installs caller-supplied bytecode, so it is never the
+    /// default account. A `Delegation` is default only when its target is
+    /// [`Eip8130Contracts::DEFAULT_ACCOUNT`] (multiple delegations are invalid
+    /// and treated as not default). With neither entry, only the EOA path
+    /// (`sender == None`) auto-delegates; a configured sender's existing code
+    /// is not visible here.
+    fn statically_uses_default_account(&self) -> bool {
+        let mut explicit_target = None;
+        for change in &self.account_changes {
+            match change {
+                AccountChange::Create(_) => return false,
+                AccountChange::Delegation(delegation) => {
+                    if explicit_target.is_some() {
+                        return false;
+                    }
+                    explicit_target = Some(delegation.target);
+                }
+                AccountChange::ConfigChange(_) => {}
+            }
+        }
+        explicit_target.map_or_else(
+            || self.sender.is_none(),
+            |target| target == Eip8130Contracts::DEFAULT_ACCOUNT,
+        )
+    }
+
+    /// Recipient and amount of a pure ETH transfer encoded as
+    /// `execute(target, value, "")` or a one-element `executeBatch` of the same
+    /// shape.
+    fn default_account_eth_transfer(calldata: &[u8]) -> Option<(Address, U256)> {
+        if let Ok(call) = IDefaultAccount::executeCall::abi_decode(calldata) {
+            return call.data.is_empty().then_some((call.target, call.value));
+        }
+        let batch = IDefaultAccount::executeBatchCall::abi_decode(calldata).ok()?;
+        let [inner] = batch.calls.as_slice() else {
+            return None;
+        };
+        inner.data.is_empty().then_some((inner.target, inner.value))
     }
 
     /// Encodes an `Option<Address>` as the AA wire format: zero-length byte
@@ -637,7 +687,12 @@ mod tests {
     use reth_codecs::Compact;
 
     use super::*;
-    use crate::transaction::eip8130::account_changes::Delegation;
+    use crate::{
+        Predeploys,
+        transaction::eip8130::account_changes::{
+            AccountChangeChannel, CreateEntry, Delegation, SignedAccountChanges,
+        },
+    };
 
     fn sample_tx() -> TxEip8130 {
         TxEip8130 {
@@ -1034,8 +1089,175 @@ mod tests {
         );
     }
 
+    const COINBASE: Address = Predeploys::SEQUENCER_FEE_VAULT;
+    const OTHER_RECIPIENT: Address = address!("0x00000000000000000000000000000000000000cc");
+    const TIP_AMOUNT: u64 = 123;
+
+    fn encode_execute(target: Address, value: U256, data: &[u8]) -> Bytes {
+        Bytes::from(
+            IDefaultAccount::executeCall { target, value, data: data.to_vec().into() }.abi_encode(),
+        )
+    }
+
+    fn encode_execute_batch_one(target: Address, value: U256) -> Bytes {
+        Bytes::from(
+            IDefaultAccount::executeBatchCall {
+                calls: vec![IDefaultAccount::Call { target, value, data: Default::default() }],
+            }
+            .abi_encode(),
+        )
+    }
+
+    fn execute_call(to: Address) -> Call {
+        Call { to, data: encode_execute(COINBASE, U256::from(TIP_AMOUNT), &[]) }
+    }
+
+    fn eoa_with_phase0(calls: Vec<Call>) -> TxEip8130 {
+        TxEip8130 { sender: None, calls: vec![calls], ..Default::default() }
+    }
+
     #[test]
-    fn coinbase_tip_is_none_until_static_decode() {
+    fn coinbase_tip_execute_encoding_matches_canonical_abi() {
+        assert_eq!(
+            encode_execute(COINBASE, U256::from(TIP_AMOUNT), &[]).as_ref(),
+            bytes!("b61d27f60000000000000000000000004200000000000000000000000000000000000011000000000000000000000000000000000000000000000000000000000000007b00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000")
+                .as_ref(),
+        );
+        assert_eq!(
+            encode_execute_batch_one(COINBASE, U256::from(TIP_AMOUNT)).as_ref(),
+            bytes!("34fcd5be0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000200000000000000000000000004200000000000000000000000000000000000011000000000000000000000000000000000000000000000000000000000000007b00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000")
+                .as_ref(),
+        );
+    }
+
+    #[test]
+    fn coinbase_tip_eoa_execute_returns_amount() {
+        let sender = address!("0x00000000000000000000000000000000000000bb");
+        let tx = eoa_with_phase0(vec![execute_call(sender)]);
+        assert_eq!(tx.coinbase_tip(), Some(U256::from(TIP_AMOUNT)));
+        let other = eoa_with_phase0(vec![Call {
+            to: sender,
+            data: encode_execute(OTHER_RECIPIENT, U256::from(TIP_AMOUNT), &[]),
+        }]);
+        assert_eq!(other.coinbase_tip(), None);
+    }
+
+    #[test]
+    fn coinbase_tip_eoa_execute_batch_single_send_returns_amount() {
+        let sender = address!("0x00000000000000000000000000000000000000bb");
+        let tx = eoa_with_phase0(vec![Call {
+            to: sender,
+            data: encode_execute_batch_one(COINBASE, U256::from(TIP_AMOUNT)),
+        }]);
+        assert_eq!(tx.coinbase_tip(), Some(U256::from(TIP_AMOUNT)));
+        let other = eoa_with_phase0(vec![Call {
+            to: sender,
+            data: encode_execute_batch_one(OTHER_RECIPIENT, U256::from(TIP_AMOUNT)),
+        }]);
+        assert_eq!(other.coinbase_tip(), None);
+    }
+
+    #[test]
+    fn coinbase_tip_explicit_sender_requires_self_call_and_default_delegation() {
+        let sender = address!("0x00000000000000000000000000000000000000bb");
+        let delegated = TxEip8130 {
+            sender: Some(sender),
+            account_changes: vec![AccountChange::Delegation(Delegation {
+                target: Eip8130Contracts::DEFAULT_ACCOUNT,
+            })],
+            calls: vec![vec![execute_call(sender)]],
+            ..Default::default()
+        };
+        assert_eq!(delegated.coinbase_tip(), Some(U256::from(TIP_AMOUNT)));
+
+        let not_self =
+            TxEip8130 { calls: vec![vec![execute_call(COINBASE)]], ..delegated.clone() };
+        assert_eq!(not_self.coinbase_tip(), None);
+
+        let no_delegation = TxEip8130 { account_changes: vec![], ..delegated };
+        assert_eq!(no_delegation.coinbase_tip(), None);
+    }
+
+    #[test]
+    fn coinbase_tip_rejects_non_default_account() {
+        let sender = address!("0x00000000000000000000000000000000000000bb");
+        let other_impl = TxEip8130 {
+            sender: Some(sender),
+            account_changes: vec![AccountChange::Delegation(Delegation {
+                target: Eip8130Contracts::CANONICAL_HIGH_RATE_PAYER_ACCOUNT,
+            })],
+            calls: vec![vec![execute_call(sender)]],
+            ..Default::default()
+        };
+        assert_eq!(other_impl.coinbase_tip(), None);
+
+        let cleared = TxEip8130 {
+            account_changes: vec![AccountChange::Delegation(Delegation { target: Address::ZERO })],
+            ..other_impl
+        };
+        assert_eq!(cleared.coinbase_tip(), None);
+
+        let created = TxEip8130 {
+            sender: None,
+            account_changes: vec![AccountChange::Create(CreateEntry {
+                user_salt: B256::ZERO,
+                code: bytes!("01"),
+                initial_actors: vec![],
+            })],
+            calls: vec![vec![execute_call(sender)]],
+            ..Default::default()
+        };
+        assert_eq!(created.coinbase_tip(), None);
+    }
+
+    #[test]
+    fn coinbase_tip_requires_single_phase0_eth_transfer() {
+        let sender = address!("0x00000000000000000000000000000000000000bb");
+        let call = execute_call(sender);
+
+        assert_eq!(eoa_with_phase0(vec![call.clone(), call.clone()]).coinbase_tip(), None);
+        assert_eq!(eoa_with_phase0(vec![]).coinbase_tip(), None);
+
+        let later_phase =
+            TxEip8130 { sender: None, calls: vec![vec![], vec![call]], ..Default::default() };
+        assert_eq!(later_phase.coinbase_tip(), None);
+
+        let with_calldata = eoa_with_phase0(vec![Call {
+            to: sender,
+            data: encode_execute(COINBASE, U256::from(TIP_AMOUNT), &[0x01]),
+        }]);
+        assert_eq!(with_calldata.coinbase_tip(), None);
+
+        let wrong_selector = eoa_with_phase0(vec![Call { to: sender, data: bytes!("deadbeef") }]);
+        assert_eq!(wrong_selector.coinbase_tip(), None);
+
         assert_eq!(sample_tx().coinbase_tip(), None);
+    }
+
+    #[test]
+    fn coinbase_tip_config_change_does_not_block_eoa_auto_delegation() {
+        let tx = TxEip8130 {
+            sender: None,
+            account_changes: vec![AccountChange::ConfigChange(SignedAccountChanges {
+                channel: AccountChangeChannel::Local,
+                sequence: 0,
+                changes: vec![],
+                signature: Bytes::new(),
+            })],
+            calls: vec![vec![execute_call(address!("0x00000000000000000000000000000000000000bb"))]],
+            ..Default::default()
+        };
+        assert_eq!(tx.coinbase_tip(), Some(U256::from(TIP_AMOUNT)));
+    }
+
+    #[test]
+    fn coinbase_tip_rejects_truncated_calldata() {
+        let mut data = encode_execute(COINBASE, U256::from(TIP_AMOUNT), &[]).to_vec();
+        data.truncate(data.len().saturating_sub(32));
+        let tx = eoa_with_phase0(vec![Call {
+            to: address!("0x00000000000000000000000000000000000000bb"),
+            data: Bytes::from(data),
+        }]);
+        assert_eq!(tx.coinbase_tip(), None);
     }
 }

--- a/crates/common/consensus/src/transaction/eip8130/tx.rs
+++ b/crates/common/consensus/src/transaction/eip8130/tx.rs
@@ -105,19 +105,26 @@ impl TxEip8130 {
     /// Returns [`Some`] when the sender uses
     /// [`Eip8130Contracts::DEFAULT_ACCOUNT`] (EOA auto-delegation, or an
     /// explicit delegation to that implementation), phase 0 contains exactly
-    /// one call, that call is invoked on the sender when the sender is
-    /// explicit, and the calldata is `DefaultAccount.execute` (or a
-    /// one-element `executeBatch`) transferring ETH to
-    /// [`Predeploys::SEQUENCER_FEE_VAULT`] with empty calldata.
+    /// one call invoked on `resolved_sender`, and the calldata is
+    /// `DefaultAccount.execute` (or a one-element `executeBatch`) transferring
+    /// ETH to [`Predeploys::SEQUENCER_FEE_VAULT`] with empty calldata.
+    ///
+    /// `resolved_sender` is the account that will dispatch the call: the
+    /// explicit [`Self::sender`] when present, otherwise the recovered EOA.
+    /// The protocol call's `to` must equal that address, matching execution
+    /// (`from` is the sender; `execute` must run on the sender itself).
     #[must_use]
-    pub fn coinbase_tip(&self) -> Option<U256> {
+    pub fn coinbase_tip(&self, resolved_sender: Address) -> Option<U256> {
         if !self.statically_uses_default_account() {
+            return None;
+        }
+        if self.sender.is_some_and(|sender| sender != resolved_sender) {
             return None;
         }
         let [call] = self.calls.first()?.as_slice() else {
             return None;
         };
-        if self.sender.is_some_and(|sender| call.to != sender) {
+        if call.to != resolved_sender {
             return None;
         }
         let (recipient, amount) = Self::default_account_eth_transfer(&call.data)?;
@@ -157,10 +164,10 @@ impl TxEip8130 {
     /// `execute(target, value, "")` or a one-element `executeBatch` of the same
     /// shape.
     fn default_account_eth_transfer(calldata: &[u8]) -> Option<(Address, U256)> {
-        if let Ok(call) = IDefaultAccount::executeCall::abi_decode(calldata) {
+        if let Ok(call) = IDefaultAccount::executeCall::abi_decode_validate(calldata) {
             return call.data.is_empty().then_some((call.target, call.value));
         }
-        let batch = IDefaultAccount::executeBatchCall::abi_decode(calldata).ok()?;
+        let batch = IDefaultAccount::executeBatchCall::abi_decode_validate(calldata).ok()?;
         let [inner] = batch.calls.as_slice() else {
             return None;
         };
@@ -1089,6 +1096,7 @@ mod tests {
         );
     }
 
+    const SENDER: Address = address!("0x00000000000000000000000000000000000000bb");
     const COINBASE: Address = Predeploys::SEQUENCER_FEE_VAULT;
     const OTHER_RECIPIENT: Address = address!("0x00000000000000000000000000000000000000cc");
     const TIP_AMOUNT: u64 = 123;
@@ -1132,70 +1140,68 @@ mod tests {
 
     #[test]
     fn coinbase_tip_eoa_execute_returns_amount() {
-        let sender = address!("0x00000000000000000000000000000000000000bb");
-        let tx = eoa_with_phase0(vec![execute_call(sender)]);
-        assert_eq!(tx.coinbase_tip(), Some(U256::from(TIP_AMOUNT)));
+        let tx = eoa_with_phase0(vec![execute_call(SENDER)]);
+        assert_eq!(tx.coinbase_tip(SENDER), Some(U256::from(TIP_AMOUNT)));
         let other = eoa_with_phase0(vec![Call {
-            to: sender,
+            to: SENDER,
             data: encode_execute(OTHER_RECIPIENT, U256::from(TIP_AMOUNT), &[]),
         }]);
-        assert_eq!(other.coinbase_tip(), None);
+        assert_eq!(other.coinbase_tip(SENDER), None);
+        let not_self = eoa_with_phase0(vec![execute_call(COINBASE)]);
+        assert_eq!(not_self.coinbase_tip(SENDER), None);
     }
 
     #[test]
     fn coinbase_tip_eoa_execute_batch_single_send_returns_amount() {
-        let sender = address!("0x00000000000000000000000000000000000000bb");
         let tx = eoa_with_phase0(vec![Call {
-            to: sender,
+            to: SENDER,
             data: encode_execute_batch_one(COINBASE, U256::from(TIP_AMOUNT)),
         }]);
-        assert_eq!(tx.coinbase_tip(), Some(U256::from(TIP_AMOUNT)));
+        assert_eq!(tx.coinbase_tip(SENDER), Some(U256::from(TIP_AMOUNT)));
         let other = eoa_with_phase0(vec![Call {
-            to: sender,
+            to: SENDER,
             data: encode_execute_batch_one(OTHER_RECIPIENT, U256::from(TIP_AMOUNT)),
         }]);
-        assert_eq!(other.coinbase_tip(), None);
+        assert_eq!(other.coinbase_tip(SENDER), None);
     }
 
     #[test]
     fn coinbase_tip_explicit_sender_requires_self_call_and_default_delegation() {
-        let sender = address!("0x00000000000000000000000000000000000000bb");
         let delegated = TxEip8130 {
-            sender: Some(sender),
+            sender: Some(SENDER),
             account_changes: vec![AccountChange::Delegation(Delegation {
                 target: Eip8130Contracts::DEFAULT_ACCOUNT,
             })],
-            calls: vec![vec![execute_call(sender)]],
+            calls: vec![vec![execute_call(SENDER)]],
             ..Default::default()
         };
-        assert_eq!(delegated.coinbase_tip(), Some(U256::from(TIP_AMOUNT)));
+        assert_eq!(delegated.coinbase_tip(SENDER), Some(U256::from(TIP_AMOUNT)));
 
-        let not_self =
-            TxEip8130 { calls: vec![vec![execute_call(COINBASE)]], ..delegated.clone() };
-        assert_eq!(not_self.coinbase_tip(), None);
+        let not_self = TxEip8130 { calls: vec![vec![execute_call(COINBASE)]], ..delegated.clone() };
+        assert_eq!(not_self.coinbase_tip(SENDER), None);
+        assert_eq!(delegated.coinbase_tip(OTHER_RECIPIENT), None);
 
         let no_delegation = TxEip8130 { account_changes: vec![], ..delegated };
-        assert_eq!(no_delegation.coinbase_tip(), None);
+        assert_eq!(no_delegation.coinbase_tip(SENDER), None);
     }
 
     #[test]
     fn coinbase_tip_rejects_non_default_account() {
-        let sender = address!("0x00000000000000000000000000000000000000bb");
         let other_impl = TxEip8130 {
-            sender: Some(sender),
+            sender: Some(SENDER),
             account_changes: vec![AccountChange::Delegation(Delegation {
                 target: Eip8130Contracts::CANONICAL_HIGH_RATE_PAYER_ACCOUNT,
             })],
-            calls: vec![vec![execute_call(sender)]],
+            calls: vec![vec![execute_call(SENDER)]],
             ..Default::default()
         };
-        assert_eq!(other_impl.coinbase_tip(), None);
+        assert_eq!(other_impl.coinbase_tip(SENDER), None);
 
         let cleared = TxEip8130 {
             account_changes: vec![AccountChange::Delegation(Delegation { target: Address::ZERO })],
             ..other_impl
         };
-        assert_eq!(cleared.coinbase_tip(), None);
+        assert_eq!(cleared.coinbase_tip(SENDER), None);
 
         let created = TxEip8130 {
             sender: None,
@@ -1204,34 +1210,33 @@ mod tests {
                 code: bytes!("01"),
                 initial_actors: vec![],
             })],
-            calls: vec![vec![execute_call(sender)]],
+            calls: vec![vec![execute_call(SENDER)]],
             ..Default::default()
         };
-        assert_eq!(created.coinbase_tip(), None);
+        assert_eq!(created.coinbase_tip(SENDER), None);
     }
 
     #[test]
     fn coinbase_tip_requires_single_phase0_eth_transfer() {
-        let sender = address!("0x00000000000000000000000000000000000000bb");
-        let call = execute_call(sender);
+        let call = execute_call(SENDER);
 
-        assert_eq!(eoa_with_phase0(vec![call.clone(), call.clone()]).coinbase_tip(), None);
-        assert_eq!(eoa_with_phase0(vec![]).coinbase_tip(), None);
+        assert_eq!(eoa_with_phase0(vec![call.clone(), call.clone()]).coinbase_tip(SENDER), None);
+        assert_eq!(eoa_with_phase0(vec![]).coinbase_tip(SENDER), None);
 
         let later_phase =
             TxEip8130 { sender: None, calls: vec![vec![], vec![call]], ..Default::default() };
-        assert_eq!(later_phase.coinbase_tip(), None);
+        assert_eq!(later_phase.coinbase_tip(SENDER), None);
 
         let with_calldata = eoa_with_phase0(vec![Call {
-            to: sender,
+            to: SENDER,
             data: encode_execute(COINBASE, U256::from(TIP_AMOUNT), &[0x01]),
         }]);
-        assert_eq!(with_calldata.coinbase_tip(), None);
+        assert_eq!(with_calldata.coinbase_tip(SENDER), None);
 
-        let wrong_selector = eoa_with_phase0(vec![Call { to: sender, data: bytes!("deadbeef") }]);
-        assert_eq!(wrong_selector.coinbase_tip(), None);
+        let wrong_selector = eoa_with_phase0(vec![Call { to: SENDER, data: bytes!("deadbeef") }]);
+        assert_eq!(wrong_selector.coinbase_tip(SENDER), None);
 
-        assert_eq!(sample_tx().coinbase_tip(), None);
+        assert_eq!(sample_tx().coinbase_tip(sample_tx().sender.unwrap()), None);
     }
 
     #[test]
@@ -1244,20 +1249,24 @@ mod tests {
                 changes: vec![],
                 signature: Bytes::new(),
             })],
-            calls: vec![vec![execute_call(address!("0x00000000000000000000000000000000000000bb"))]],
+            calls: vec![vec![execute_call(SENDER)]],
             ..Default::default()
         };
-        assert_eq!(tx.coinbase_tip(), Some(U256::from(TIP_AMOUNT)));
+        assert_eq!(tx.coinbase_tip(SENDER), Some(U256::from(TIP_AMOUNT)));
     }
 
     #[test]
-    fn coinbase_tip_rejects_truncated_calldata() {
-        let mut data = encode_execute(COINBASE, U256::from(TIP_AMOUNT), &[]).to_vec();
-        data.truncate(data.len().saturating_sub(32));
-        let tx = eoa_with_phase0(vec![Call {
-            to: address!("0x00000000000000000000000000000000000000bb"),
-            data: Bytes::from(data),
-        }]);
-        assert_eq!(tx.coinbase_tip(), None);
+    fn coinbase_tip_rejects_truncated_or_dirty_calldata() {
+        let mut truncated = encode_execute(COINBASE, U256::from(TIP_AMOUNT), &[]).to_vec();
+        truncated.truncate(truncated.len().saturating_sub(32));
+        let truncated_tx = eoa_with_phase0(vec![Call { to: SENDER, data: Bytes::from(truncated) }]);
+        assert_eq!(truncated_tx.coinbase_tip(SENDER), None);
+
+        // High bytes of the address word must be zero; `abi_decode_validate` rejects
+        // that dirty padding even though a lenient decoder would still yield a tip.
+        let mut dirty = encode_execute(COINBASE, U256::from(TIP_AMOUNT), &[]).to_vec();
+        dirty[4] = 0xff;
+        let dirty_tx = eoa_with_phase0(vec![Call { to: SENDER, data: Bytes::from(dirty) }]);
+        assert_eq!(dirty_tx.coinbase_tip(SENDER), None);
     }
 }

--- a/crates/common/consensus/src/transaction/eip8130/tx.rs
+++ b/crates/common/consensus/src/transaction/eip8130/tx.rs
@@ -15,16 +15,11 @@ use alloy_primitives::{
     Address, B256, Bytes, ChainId, Signature, TxKind, U256, bytes::BufMut, keccak256,
 };
 use alloy_rlp::{Decodable, Encodable, Header, length_of_length};
-use alloy_sol_types::SolCall;
 #[cfg(feature = "reth")]
 use reth_codecs::Compact;
 
-use crate::{
-    Predeploys,
-    transaction::eip8130::{
-        IDefaultAccount, account_changes::AccountChange, addresses::Eip8130Contracts, call::Call,
-        constants::Eip8130Constants,
-    },
+use crate::transaction::eip8130::{
+    account_changes::AccountChange, call::Call, constants::Eip8130Constants,
 };
 
 /// Unsigned body of an [EIP-8130] Account Abstraction transaction.
@@ -94,86 +89,6 @@ pub struct TxEip8130 {
 }
 
 impl TxEip8130 {
-    /// Statically decoded phase-0 coinbase tip, if one can be recovered without
-    /// executing the transaction.
-    ///
-    /// EIP-8130 `calls` are grouped into phases. A revert discards that phase
-    /// and skips later ones, so only a tip in **phase 0** is statically
-    /// meaningful. Protocol calls carry no value (`call = rlp([to, data])`);
-    /// ETH moves only when wallet bytecode issues a `CALL`.
-    ///
-    /// Returns [`Some`] when the sender uses
-    /// [`Eip8130Contracts::DEFAULT_ACCOUNT`] (EOA auto-delegation, or an
-    /// explicit delegation to that implementation), phase 0 contains exactly
-    /// one call invoked on `resolved_sender`, and the calldata is
-    /// `DefaultAccount.execute` (or a one-element `executeBatch`) transferring
-    /// ETH to [`Predeploys::SEQUENCER_FEE_VAULT`] with empty calldata.
-    ///
-    /// `resolved_sender` is the account that will dispatch the call: the
-    /// explicit [`Self::sender`] when present, otherwise the recovered EOA.
-    /// The protocol call's `to` must equal that address, matching execution
-    /// (`from` is the sender; `execute` must run on the sender itself).
-    #[must_use]
-    pub fn coinbase_tip(&self, resolved_sender: Address) -> Option<U256> {
-        if !self.statically_uses_default_account() {
-            return None;
-        }
-        if self.sender.is_some_and(|sender| sender != resolved_sender) {
-            return None;
-        }
-        let [call] = self.calls.first()?.as_slice() else {
-            return None;
-        };
-        if call.to != resolved_sender {
-            return None;
-        }
-        let (recipient, amount) = Self::default_account_eth_transfer(&call.data)?;
-        (recipient == Predeploys::SEQUENCER_FEE_VAULT).then_some(amount)
-    }
-
-    /// Whether the unsigned body statically implies
-    /// [`Eip8130Contracts::DEFAULT_ACCOUNT`] as the sender's wallet.
-    ///
-    /// A `Create` installs caller-supplied bytecode, so it is never the
-    /// default account. A `Delegation` is default only when its target is
-    /// [`Eip8130Contracts::DEFAULT_ACCOUNT`] (multiple delegations are invalid
-    /// and treated as not default). With neither entry, only the EOA path
-    /// (`sender == None`) auto-delegates; a configured sender's existing code
-    /// is not visible here.
-    fn statically_uses_default_account(&self) -> bool {
-        let mut explicit_target = None;
-        for change in &self.account_changes {
-            match change {
-                AccountChange::Create(_) => return false,
-                AccountChange::Delegation(delegation) => {
-                    if explicit_target.is_some() {
-                        return false;
-                    }
-                    explicit_target = Some(delegation.target);
-                }
-                AccountChange::ConfigChange(_) => {}
-            }
-        }
-        explicit_target.map_or_else(
-            || self.sender.is_none(),
-            |target| target == Eip8130Contracts::DEFAULT_ACCOUNT,
-        )
-    }
-
-    /// Recipient and amount of a pure ETH transfer encoded as
-    /// `execute(target, value, "")` or a one-element `executeBatch` of the same
-    /// shape.
-    fn default_account_eth_transfer(calldata: &[u8]) -> Option<(Address, U256)> {
-        if let Ok(call) = IDefaultAccount::executeCall::abi_decode_validate(calldata) {
-            return call.data.is_empty().then_some((call.target, call.value));
-        }
-        let batch = IDefaultAccount::executeBatchCall::abi_decode_validate(calldata).ok()?;
-        let [inner] = batch.calls.as_slice() else {
-            return None;
-        };
-        inner.data.is_empty().then_some((inner.target, inner.value))
-    }
-
     /// Encodes an `Option<Address>` as the AA wire format: zero-length byte
     /// string when `None`, 20-byte string when `Some`.
     fn encode_address_opt(addr: &Option<Address>, out: &mut dyn BufMut) {
@@ -694,12 +609,7 @@ mod tests {
     use reth_codecs::Compact;
 
     use super::*;
-    use crate::{
-        Predeploys,
-        transaction::eip8130::account_changes::{
-            AccountChangeChannel, CreateEntry, Delegation, SignedAccountChanges,
-        },
-    };
+    use crate::transaction::eip8130::account_changes::Delegation;
 
     fn sample_tx() -> TxEip8130 {
         TxEip8130 {
@@ -1094,179 +1004,5 @@ mod tests {
             bare.size(),
             with_auth.size()
         );
-    }
-
-    const SENDER: Address = address!("0x00000000000000000000000000000000000000bb");
-    const COINBASE: Address = Predeploys::SEQUENCER_FEE_VAULT;
-    const OTHER_RECIPIENT: Address = address!("0x00000000000000000000000000000000000000cc");
-    const TIP_AMOUNT: u64 = 123;
-
-    fn encode_execute(target: Address, value: U256, data: &[u8]) -> Bytes {
-        Bytes::from(
-            IDefaultAccount::executeCall { target, value, data: data.to_vec().into() }.abi_encode(),
-        )
-    }
-
-    fn encode_execute_batch_one(target: Address, value: U256) -> Bytes {
-        Bytes::from(
-            IDefaultAccount::executeBatchCall {
-                calls: vec![IDefaultAccount::Call { target, value, data: Default::default() }],
-            }
-            .abi_encode(),
-        )
-    }
-
-    fn execute_call(to: Address) -> Call {
-        Call { to, data: encode_execute(COINBASE, U256::from(TIP_AMOUNT), &[]) }
-    }
-
-    fn eoa_with_phase0(calls: Vec<Call>) -> TxEip8130 {
-        TxEip8130 { sender: None, calls: vec![calls], ..Default::default() }
-    }
-
-    #[test]
-    fn coinbase_tip_execute_encoding_matches_canonical_abi() {
-        assert_eq!(
-            encode_execute(COINBASE, U256::from(TIP_AMOUNT), &[]).as_ref(),
-            bytes!("b61d27f60000000000000000000000004200000000000000000000000000000000000011000000000000000000000000000000000000000000000000000000000000007b00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000")
-                .as_ref(),
-        );
-        assert_eq!(
-            encode_execute_batch_one(COINBASE, U256::from(TIP_AMOUNT)).as_ref(),
-            bytes!("34fcd5be0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000200000000000000000000000004200000000000000000000000000000000000011000000000000000000000000000000000000000000000000000000000000007b00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000")
-                .as_ref(),
-        );
-    }
-
-    #[test]
-    fn coinbase_tip_eoa_execute_returns_amount() {
-        let tx = eoa_with_phase0(vec![execute_call(SENDER)]);
-        assert_eq!(tx.coinbase_tip(SENDER), Some(U256::from(TIP_AMOUNT)));
-        let other = eoa_with_phase0(vec![Call {
-            to: SENDER,
-            data: encode_execute(OTHER_RECIPIENT, U256::from(TIP_AMOUNT), &[]),
-        }]);
-        assert_eq!(other.coinbase_tip(SENDER), None);
-        let not_self = eoa_with_phase0(vec![execute_call(COINBASE)]);
-        assert_eq!(not_self.coinbase_tip(SENDER), None);
-    }
-
-    #[test]
-    fn coinbase_tip_eoa_execute_batch_single_send_returns_amount() {
-        let tx = eoa_with_phase0(vec![Call {
-            to: SENDER,
-            data: encode_execute_batch_one(COINBASE, U256::from(TIP_AMOUNT)),
-        }]);
-        assert_eq!(tx.coinbase_tip(SENDER), Some(U256::from(TIP_AMOUNT)));
-        let other = eoa_with_phase0(vec![Call {
-            to: SENDER,
-            data: encode_execute_batch_one(OTHER_RECIPIENT, U256::from(TIP_AMOUNT)),
-        }]);
-        assert_eq!(other.coinbase_tip(SENDER), None);
-    }
-
-    #[test]
-    fn coinbase_tip_explicit_sender_requires_self_call_and_default_delegation() {
-        let delegated = TxEip8130 {
-            sender: Some(SENDER),
-            account_changes: vec![AccountChange::Delegation(Delegation {
-                target: Eip8130Contracts::DEFAULT_ACCOUNT,
-            })],
-            calls: vec![vec![execute_call(SENDER)]],
-            ..Default::default()
-        };
-        assert_eq!(delegated.coinbase_tip(SENDER), Some(U256::from(TIP_AMOUNT)));
-
-        let not_self = TxEip8130 { calls: vec![vec![execute_call(COINBASE)]], ..delegated.clone() };
-        assert_eq!(not_self.coinbase_tip(SENDER), None);
-        assert_eq!(delegated.coinbase_tip(OTHER_RECIPIENT), None);
-
-        let no_delegation = TxEip8130 { account_changes: vec![], ..delegated };
-        assert_eq!(no_delegation.coinbase_tip(SENDER), None);
-    }
-
-    #[test]
-    fn coinbase_tip_rejects_non_default_account() {
-        let other_impl = TxEip8130 {
-            sender: Some(SENDER),
-            account_changes: vec![AccountChange::Delegation(Delegation {
-                target: Eip8130Contracts::CANONICAL_HIGH_RATE_PAYER_ACCOUNT,
-            })],
-            calls: vec![vec![execute_call(SENDER)]],
-            ..Default::default()
-        };
-        assert_eq!(other_impl.coinbase_tip(SENDER), None);
-
-        let cleared = TxEip8130 {
-            account_changes: vec![AccountChange::Delegation(Delegation { target: Address::ZERO })],
-            ..other_impl
-        };
-        assert_eq!(cleared.coinbase_tip(SENDER), None);
-
-        let created = TxEip8130 {
-            sender: None,
-            account_changes: vec![AccountChange::Create(CreateEntry {
-                user_salt: B256::ZERO,
-                code: bytes!("01"),
-                initial_actors: vec![],
-            })],
-            calls: vec![vec![execute_call(SENDER)]],
-            ..Default::default()
-        };
-        assert_eq!(created.coinbase_tip(SENDER), None);
-    }
-
-    #[test]
-    fn coinbase_tip_requires_single_phase0_eth_transfer() {
-        let call = execute_call(SENDER);
-
-        assert_eq!(eoa_with_phase0(vec![call.clone(), call.clone()]).coinbase_tip(SENDER), None);
-        assert_eq!(eoa_with_phase0(vec![]).coinbase_tip(SENDER), None);
-
-        let later_phase =
-            TxEip8130 { sender: None, calls: vec![vec![], vec![call]], ..Default::default() };
-        assert_eq!(later_phase.coinbase_tip(SENDER), None);
-
-        let with_calldata = eoa_with_phase0(vec![Call {
-            to: SENDER,
-            data: encode_execute(COINBASE, U256::from(TIP_AMOUNT), &[0x01]),
-        }]);
-        assert_eq!(with_calldata.coinbase_tip(SENDER), None);
-
-        let wrong_selector = eoa_with_phase0(vec![Call { to: SENDER, data: bytes!("deadbeef") }]);
-        assert_eq!(wrong_selector.coinbase_tip(SENDER), None);
-
-        assert_eq!(sample_tx().coinbase_tip(sample_tx().sender.unwrap()), None);
-    }
-
-    #[test]
-    fn coinbase_tip_config_change_does_not_block_eoa_auto_delegation() {
-        let tx = TxEip8130 {
-            sender: None,
-            account_changes: vec![AccountChange::ConfigChange(SignedAccountChanges {
-                channel: AccountChangeChannel::Local,
-                sequence: 0,
-                changes: vec![],
-                signature: Bytes::new(),
-            })],
-            calls: vec![vec![execute_call(SENDER)]],
-            ..Default::default()
-        };
-        assert_eq!(tx.coinbase_tip(SENDER), Some(U256::from(TIP_AMOUNT)));
-    }
-
-    #[test]
-    fn coinbase_tip_rejects_truncated_or_dirty_calldata() {
-        let mut truncated = encode_execute(COINBASE, U256::from(TIP_AMOUNT), &[]).to_vec();
-        truncated.truncate(truncated.len().saturating_sub(32));
-        let truncated_tx = eoa_with_phase0(vec![Call { to: SENDER, data: Bytes::from(truncated) }]);
-        assert_eq!(truncated_tx.coinbase_tip(SENDER), None);
-
-        // High bytes of the address word must be zero; `abi_decode_validate` rejects
-        // that dirty padding even though a lenient decoder would still yield a tip.
-        let mut dirty = encode_execute(COINBASE, U256::from(TIP_AMOUNT), &[]).to_vec();
-        dirty[4] = 0xff;
-        let dirty_tx = eoa_with_phase0(vec![Call { to: SENDER, data: Bytes::from(dirty) }]);
-        assert_eq!(dirty_tx.coinbase_tip(SENDER), None);
     }
 }

--- a/crates/common/consensus/src/transaction/mod.rs
+++ b/crates/common/consensus/src/transaction/mod.rs
@@ -7,7 +7,7 @@ mod eip8130;
 pub use eip8130::{
     AccountChange, AccountChangeChannel, Call, ChangeType, CreateEntry, Delegation,
     Eip8130Constants, Eip8130Contracts, Eip8130Signed, Eip8130StaticError, Eip8130TimestampError,
-    InitialActor, Scope, SignedAccountChanges, SignedChange, TxEip8130,
+    IDefaultAccount, InitialActor, Scope, SignedAccountChanges, SignedChange, TxEip8130,
 };
 
 mod tx_type;

--- a/crates/common/consensus/src/transaction/mod.rs
+++ b/crates/common/consensus/src/transaction/mod.rs
@@ -5,7 +5,7 @@ pub use deposit::{DepositTransaction, TxDeposit};
 
 mod eip8130;
 pub use eip8130::{
-    AccountChange, AccountChangeChannel, Call, ChangeType, CreateEntry, Delegation,
+    AccountChange, AccountChangeChannel, Call, ChangeType, CoinbaseTip, CreateEntry, Delegation,
     Eip8130Constants, Eip8130Contracts, Eip8130Signed, Eip8130StaticError, Eip8130TimestampError,
     IDefaultAccount, InitialActor, Scope, SignedAccountChanges, SignedChange, TxEip8130,
 };

--- a/crates/execution/payload/src/builder.rs
+++ b/crates/execution/payload/src/builder.rs
@@ -11,7 +11,7 @@ use alloy_primitives::{B256, U256};
 use alloy_rpc_types_debug::ExecutionWitness;
 use alloy_rpc_types_engine::PayloadId;
 use base_common_chains::Upgrades;
-use base_common_consensus::{BaseTransaction, Predeploys};
+use base_common_consensus::{BaseTransaction, CoinbaseTip, Predeploys};
 use base_common_evm::L1BlockInfo;
 use base_execution_eip8130::IntrinsicGas;
 use base_execution_txpool::{
@@ -860,8 +860,9 @@ where
 
             let tx_hash = *tx.hash();
             let has_validity_predicates = !tx.validity_predicates().is_empty();
-            let has_coinbase_tip =
-                tx.as_eip8130().is_some_and(|signed| signed.tx().coinbase_tip().is_some());
+            let has_coinbase_tip = tx
+                .as_eip8130()
+                .is_some_and(|signed| CoinbaseTip::decode(signed.tx(), tx.sender()).is_some());
             if has_validity_predicates {
                 validity_consideration_index += 1;
                 emit_native_validity_event!(


### PR DESCRIPTION
## Summary
- Add `CoinbaseTip::decode` to recover a phase-0 DefaultAccount ETH transfer to the Sequencer Fee Vault (`block.coinbase` on OP Stack / Base) from an EIP-8130 tx without executing the transaction.
- Pin the DefaultAccount `execute` / `executeBatch` ABI via `sol!` so selectors and encoding stay generated rather than hand-written.

First slice of [BASE-145](https://linear.app/coinbase/issue/BASE-145/implement-unified-priority-scoring-for-sts-priorityfeepergas-and-ats); a follow-up can use the decoded tip in transaction ordering.
