### PR TITLE
feat(builder): Txpool Prewarming For Block Building

### DIFF
--- a/crates/builder/cli/src/args.rs
+++ b/crates/builder/cli/src/args.rs
@@ -271,6 +271,16 @@ pub struct Args {
     )]
     pub manifest_precheck_enabled: bool,
 
+    /// Whether to run the best-effort txpool prewarmer that speculatively executes the pool's
+    /// best transactions against the canonical head to seed the build cache. Disable with
+    /// `--builder.txpool-prewarm=false`.
+    #[arg(
+        long = "builder.txpool-prewarm",
+        default_value_t = true,
+        action = clap::ArgAction::Set
+    )]
+    pub txpool_prewarm_enabled: bool,
+
     /// Flashblocks configuration
     #[command(flatten)]
     pub flashblocks: FlashblocksArgs,
@@ -347,6 +357,7 @@ impl Default for Args {
             rejection_cache_ttl_secs: 1800,
             sampling_ratio: 100,
             manifest_precheck_enabled: true,
+            txpool_prewarm_enabled: true,
             flashblocks: FlashblocksArgs::default(),
             payload_builder_cutover: false,
             basic_payload_builder: false,
@@ -421,6 +432,7 @@ impl Args {
             rejected_tx_channel_size: self.rejected_tx_channel_size,
             max_rejected_txs_per_block: self.max_rejected_txs_per_block,
             manifest_precheck_enabled: self.manifest_precheck_enabled,
+            txpool_prewarm_enabled: self.txpool_prewarm_enabled,
         })
     }
 }

--- a/crates/builder/core/src/config.rs
+++ b/crates/builder/core/src/config.rs
@@ -86,6 +86,10 @@ pub struct BuilderConfig {
     /// Whether to drop EIP-8130 transactions whose captured authorization
     /// predicates are positively stale before executing them.
     pub manifest_precheck_enabled: bool,
+
+    /// Whether to run the best-effort txpool prewarmer that speculatively executes the pool's
+    /// best transactions against the canonical head, seeding the build cache to flatten IO wait.
+    pub txpool_prewarm_enabled: bool,
 }
 
 impl BuilderConfig {
@@ -121,6 +125,7 @@ impl core::fmt::Debug for BuilderConfig {
             .field("rejected_tx_channel_size", &self.rejected_tx_channel_size)
             .field("max_rejected_txs_per_block", &self.max_rejected_txs_per_block)
             .field("manifest_precheck_enabled", &self.manifest_precheck_enabled)
+            .field("txpool_prewarm_enabled", &self.txpool_prewarm_enabled)
             .finish()
     }
 }
@@ -148,6 +153,7 @@ impl Default for BuilderConfig {
             rejected_tx_channel_size: 500,
             max_rejected_txs_per_block: 500,
             manifest_precheck_enabled: true,
+            txpool_prewarm_enabled: true,
         }
     }
 }

--- a/crates/builder/core/src/flashblocks/mod.rs
+++ b/crates/builder/core/src/flashblocks/mod.rs
@@ -31,5 +31,8 @@ pub use context::{
 
 mod payload;
 
+mod prewarm;
+pub use prewarm::{PrewarmHandle, TxPoolPrewarmer};
+
 mod service;
 pub use service::FlashblocksServiceBuilder;

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -55,7 +55,7 @@ use tracing::{debug, error, info, metadata::Level, span, warn};
 use crate::{
     BuilderConfig, BuilderMetrics, ExecutionInfo, PayloadBuilder, ResourceLimits,
     flashblocks::{
-        FlashblocksExtraCtx,
+        FlashblocksExtraCtx, PrewarmHandle,
         best_txs::{BestFlashblocksTxs, ParkableBestPayloadTransactions},
         context::BasePayloadBuilderCtx,
         generator::BuildArguments,
@@ -124,6 +124,8 @@ pub(super) struct BasePayloadBuilder<Pool, Client> {
     /// The outbound channels the builder emits built payloads, flashblocks, and rejected
     /// transactions to.
     pub outputs: BuilderOutputs,
+    /// Handle onto the txpool prewarmer's latest snapshot, used to seed the build cache.
+    pub prewarm: PrewarmHandle,
     /// Last flashblock emitted by this builder instance.
     last_emitted_flashblock_id: Arc<LastEmittedFlashblockId>,
 }
@@ -136,6 +138,7 @@ impl<Pool, Client> BasePayloadBuilder<Pool, Client> {
         client: Client,
         config: BuilderConfig,
         outputs: BuilderOutputs,
+        prewarm: PrewarmHandle,
     ) -> Self {
         Self {
             evm_config,
@@ -143,6 +146,7 @@ impl<Pool, Client> BasePayloadBuilder<Pool, Client> {
             client,
             config,
             outputs,
+            prewarm,
             last_emitted_flashblock_id: Arc::default(),
         }
     }
@@ -289,11 +293,20 @@ where
 
         let mut state_provider = self.client.state_by_block_hash(ctx.parent().hash())?;
         if let Some(execution_cache) = execution_cache {
-            state_provider = Box::new(CachedStateProvider::new(
-                state_provider,
-                execution_cache.cache().clone(),
-                Some(CachedStateMetrics::zeroed(CachedStateMetricsSource::Builder)),
-            ));
+            // Seed the cache with the txpool prewarm snapshot when building from the pool. Sequencer
+            // (`no_tx_pool`) blocks never touch the mempool, so a pool-derived snapshot is useless
+            // there and is skipped.
+            let txpool_snapshot = (!ctx.attributes().no_tx_pool)
+                .then(|| self.prewarm.snapshot_for(ctx.parent().hash()))
+                .flatten();
+            state_provider = Box::new(
+                CachedStateProvider::new(
+                    state_provider,
+                    execution_cache.cache().clone(),
+                    Some(CachedStateMetrics::zeroed(CachedStateMetricsSource::Builder)),
+                )
+                .with_txpool_snapshot(txpool_snapshot),
+            );
         }
         let db = StateProviderDatabase::new(state_provider);
 

--- a/crates/builder/core/src/flashblocks/prewarm.rs
+++ b/crates/builder/core/src/flashblocks/prewarm.rs
@@ -1,0 +1,306 @@
+//! Speculative txpool prewarming for the flashblocks builder.
+//!
+//! Block building executes the pool's best transactions single-threaded, stalling on the
+//! synchronous state IO (MDBX + trie reads) each execution incurs. This module runs a best-effort
+//! prewarmer that speculatively executes those same transactions against the canonical head state
+//! on a blocking thread, recording every state read into a [`CachedReads`]. It periodically freezes
+//! that cache into an immutable [`TxPoolPrewarmCacheSnapshot`] keyed by parent hash.
+//!
+//! The builder consults the snapshot as the first tier of its [`CachedStateProvider`](
+//! reth_execution_cache::CachedStateProvider) (see [`PrewarmHandle::snapshot_for`]), so reads the
+//! prewarmer already performed become cache hits instead of disk stalls, flattening the IO wait
+//! that would otherwise be fully incurred during the single-threaded build.
+//!
+//! Warming runs continuously against the current canonical head: by the time a forkchoice update
+//! asks the builder to build the next block on that head, a hot snapshot is already available. A
+//! new canonical head cancels the previous warming pass and starts a fresh one. Warming is
+//! out-of-context by design — nonce, balance, and base-fee checks are disabled so viability never
+//! gates which state is warmed — and its execution results are discarded; only the reads are kept.
+//!
+//! This mirrors reth's engine-side txpool prewarmer (`reth`'s `txpool_prewarm` worker), whose
+//! orchestration types are `pub(crate)` and so cannot be reused directly, while reusing reth's
+//! public [`TxPoolPrewarmCacheSnapshot`] and snapshot cache tier.
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use alloy_evm::{Evm, EvmEnv};
+use alloy_primitives::B256;
+use base_common_consensus::BasePrimitives;
+use base_common_evm::BaseSpecId;
+use base_execution_evm::BaseEvmConfig;
+use futures::StreamExt;
+use parking_lot::RwLock;
+use reth_evm::ConfigureEvm;
+use reth_execution_cache::TxPoolPrewarmCacheSnapshot;
+use reth_provider::{CanonStateNotificationStream, StateProviderFactory};
+use reth_revm::{State, cached::CachedReads, context::Block, database::StateProviderDatabase};
+use reth_tasks::Runtime;
+use reth_transaction_pool::{BestTransactionsAttributes, PoolTransaction};
+use tracing::{debug, trace};
+
+use crate::traits::{ClientBounds, PoolBounds};
+
+/// Maximum time a single warming batch executes before releasing the state provider and publishing.
+const REFRESH_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Upper bound on how long a single warming pass keeps warming one parent.
+///
+/// A new canonical head normally cancels the pass well before this; the cap only bounds a stalled
+/// or silent canonical stream so a blocking worker cannot spin forever on stale state.
+const MAX_WARM_LIFETIME: Duration = Duration::from_secs(4);
+
+/// A cheap, cloneable handle onto the freshest published prewarm snapshot.
+///
+/// The builder holds one of these and calls [`Self::snapshot_for`] at the top of each build to seed
+/// its cache. Cloning shares the same underlying slot the [`TxPoolPrewarmer`] publishes into.
+#[derive(Clone, Debug)]
+pub struct PrewarmHandle {
+    /// The latest published snapshot, replaced in place by the warming worker.
+    latest: Arc<RwLock<Option<TxPoolPrewarmCacheSnapshot>>>,
+}
+
+impl PrewarmHandle {
+    /// Returns a handle that never yields a snapshot.
+    ///
+    /// Used when prewarming is disabled, so the builder degrades to its uncached behavior.
+    pub fn noop() -> Self {
+        Self { latest: Arc::new(RwLock::new(None)) }
+    }
+
+    /// Returns the latest snapshot, but only when it was warmed against `parent_hash`.
+    ///
+    /// A snapshot warmed against a different parent describes the wrong state and is discarded, so
+    /// the builder falls back to its execution cache and disk.
+    pub fn snapshot_for(&self, parent_hash: B256) -> Option<TxPoolPrewarmCacheSnapshot> {
+        self.latest.read().clone().filter(|snapshot| snapshot.parent_hash() == parent_hash)
+    }
+}
+
+/// Best-effort txpool state prewarmer for the flashblocks builder.
+///
+/// Drives a warming worker off canonical head notifications; the worker executes the pool's best
+/// transactions against the head state and publishes [`TxPoolPrewarmCacheSnapshot`]s that the
+/// builder consumes through a [`PrewarmHandle`].
+pub struct TxPoolPrewarmer<Pool, Client> {
+    /// The transaction pool speculative transactions are drawn from.
+    pool: Pool,
+    /// The client used to open a state provider for the parent being warmed.
+    client: Client,
+    /// Configures the EVM used for speculative execution.
+    evm_config: BaseEvmConfig,
+    /// Runtime used to spawn the async driver and blocking warming passes.
+    runtime: Runtime,
+    /// The slot the worker publishes snapshots into and [`PrewarmHandle`]s read from.
+    latest: Arc<RwLock<Option<TxPoolPrewarmCacheSnapshot>>>,
+}
+
+impl<Pool, Client> std::fmt::Debug for TxPoolPrewarmer<Pool, Client> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TxPoolPrewarmer").finish_non_exhaustive()
+    }
+}
+
+impl<Pool, Client> TxPoolPrewarmer<Pool, Client>
+where
+    Pool: PoolBounds,
+    Client: ClientBounds + StateProviderFactory + Send + Sync + 'static,
+{
+    /// Creates a new prewarmer. Call [`Self::spawn`] to start warming.
+    pub fn new(pool: Pool, client: Client, evm_config: BaseEvmConfig, runtime: Runtime) -> Self {
+        Self { pool, client, evm_config, runtime, latest: Arc::new(RwLock::new(None)) }
+    }
+
+    /// Returns a handle onto the snapshots this prewarmer publishes.
+    ///
+    /// The handle can be obtained before [`Self::spawn`] and shared with the builder.
+    pub fn handle(&self) -> PrewarmHandle {
+        PrewarmHandle { latest: Arc::clone(&self.latest) }
+    }
+
+    /// Spawns the async driver that warms each new canonical head until the stream ends.
+    pub fn spawn(self, stream: CanonStateNotificationStream<BasePrimitives>) {
+        let runtime = self.runtime.clone();
+        runtime.spawn_task(self.drive(stream));
+    }
+
+    /// Consumes canonical head notifications, restarting the warming pass for each new head.
+    async fn drive(self, mut stream: CanonStateNotificationStream<BasePrimitives>) {
+        // Cancels the in-flight warming pass when a new head arrives or the stream ends.
+        let mut previous: Option<Arc<AtomicBool>> = None;
+        while let Some(notification) = stream.next().await {
+            let committed = notification.committed();
+            let tip = committed.tip();
+            let parent_hash = tip.hash();
+            let evm_env = match self.evm_config.evm_env(tip.header()) {
+                Ok(evm_env) => evm_env,
+                Err(error) => {
+                    debug!(
+                        target: "payload_builder",
+                        parent_hash = %parent_hash,
+                        ?error,
+                        "failed to build prewarm evm env",
+                    );
+                    continue;
+                }
+            };
+
+            if let Some(cancel) = previous.take() {
+                cancel.store(true, Ordering::Relaxed);
+            }
+            let cancel = Arc::new(AtomicBool::new(false));
+            previous = Some(Arc::clone(&cancel));
+
+            let pool = self.pool.clone();
+            let client = self.client.clone();
+            let evm_config = self.evm_config.clone();
+            let latest = Arc::clone(&self.latest);
+            self.runtime.spawn_blocking(move || {
+                Self::warm(parent_hash, evm_env, pool, client, evm_config, latest, cancel);
+            });
+        }
+
+        if let Some(cancel) = previous.take() {
+            cancel.store(true, Ordering::Relaxed);
+        }
+    }
+
+    /// Speculatively executes the pool's best transactions against `parent_hash`'s state,
+    /// publishing a fresh snapshot each time the recorded reads grow.
+    ///
+    /// Runs until `cancel` is set (a new head arrived), the pass exceeds [`MAX_WARM_LIFETIME`], or
+    /// the parent state becomes unavailable.
+    fn warm(
+        parent_hash: B256,
+        evm_env: EvmEnv<BaseSpecId>,
+        pool: Pool,
+        client: Client,
+        evm_config: BaseEvmConfig,
+        latest: Arc<RwLock<Option<TxPoolPrewarmCacheSnapshot>>>,
+        cancel: Arc<AtomicBool>,
+    ) {
+        let attributes = BestTransactionsAttributes::new(
+            evm_env.block_env.basefee,
+            evm_env.block_env.blob_gasprice().map(|price| price as u64),
+        );
+
+        let lifetime_deadline = Instant::now() + MAX_WARM_LIFETIME;
+        let mut cache = CachedReads::default();
+        // Cache entry counts as of the last publication; the cache only grows, so a change means it
+        // holds unpublished reads worth republishing.
+        let mut published = (0usize, 0usize, 0usize);
+        let mut best = pool.best_transactions_with_attributes(attributes);
+
+        while !cancel.load(Ordering::Relaxed) && Instant::now() < lifetime_deadline {
+            let state_provider = match client.state_by_block_hash(parent_hash) {
+                Ok(state_provider) => state_provider,
+                Err(error) => {
+                    trace!(
+                        target: "payload_builder",
+                        parent_hash = %parent_hash,
+                        ?error,
+                        "no state available for prewarm parent",
+                    );
+                    return;
+                }
+            };
+
+            let mut state = State::builder()
+                .with_database(cache.as_db_mut(StateProviderDatabase::new(state_provider)))
+                .build();
+
+            // Warming is out of context by design: transaction viability is the pool's business,
+            // so nonce, balance, and (one-block-stale) base-fee checks must not gate which state
+            // gets warmed.
+            let mut env = evm_env.clone();
+            env.cfg_env.disable_nonce_check = true;
+            env.cfg_env.disable_balance_check = true;
+            env.cfg_env.disable_base_fee = true;
+            let mut evm = evm_config.evm_with_env(&mut state, env);
+
+            let batch_deadline = Instant::now() + REFRESH_INTERVAL;
+            let mut exhausted = false;
+            while !cancel.load(Ordering::Relaxed) && Instant::now() < batch_deadline {
+                let Some(transaction) = best.next() else {
+                    exhausted = true;
+                    break;
+                };
+                let recovered = transaction.transaction.clone_into_consensus();
+                if let Err(error) = evm.transact(&recovered) {
+                    trace!(
+                        target: "payload_builder",
+                        tx_hash = ?transaction.hash(),
+                        ?error,
+                        "speculative prewarm execution failed",
+                    );
+                }
+            }
+
+            // Drop the EVM and state so the mutable borrow of `cache` is released before it is read.
+            drop(evm);
+            drop(state);
+
+            let counts = (
+                cache.accounts.len(),
+                cache.accounts.values().map(|account| account.storage.len()).sum::<usize>(),
+                cache.contracts.len(),
+            );
+            if counts != published {
+                *latest.write() =
+                    Some(TxPoolPrewarmCacheSnapshot::new(parent_hash, Arc::new(cache.clone())));
+                published = counts;
+                let (accounts, storage, bytecodes) = counts;
+                debug!(
+                    target: "payload_builder",
+                    parent_hash = %parent_hash,
+                    accounts,
+                    storage,
+                    bytecodes,
+                    "published txpool prewarm snapshot",
+                );
+            }
+
+            if exhausted {
+                // Pool is drained for now; wait for maintenance to surface more pending
+                // transactions, then reopen a fresh iterator against the same parent.
+                std::thread::sleep(REFRESH_INTERVAL);
+                best = pool.best_transactions_with_attributes(attributes);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::B256;
+    use reth_execution_cache::TxPoolPrewarmCacheSnapshot;
+    use reth_revm::cached::CachedReads;
+    use std::sync::Arc;
+
+    use super::PrewarmHandle;
+
+    #[test]
+    fn noop_handle_never_yields_a_snapshot() {
+        let handle = PrewarmHandle::noop();
+        assert!(handle.snapshot_for(B256::repeat_byte(0x01)).is_none());
+    }
+
+    #[test]
+    fn snapshot_is_returned_only_for_its_parent() {
+        let handle = PrewarmHandle::noop();
+        let parent = B256::repeat_byte(0x01);
+        *handle.latest.write() =
+            Some(TxPoolPrewarmCacheSnapshot::new(parent, Arc::new(CachedReads::default())));
+
+        assert!(handle.snapshot_for(parent).is_some(), "matching parent hits");
+        assert!(
+            handle.snapshot_for(B256::repeat_byte(0x02)).is_none(),
+            "a snapshot for another parent is discarded",
+        );
+    }
+}

--- a/crates/builder/core/src/flashblocks/prewarm.rs
+++ b/crates/builder/core/src/flashblocks/prewarm.rs
@@ -24,7 +24,7 @@
 use std::{
     sync::{
         Arc,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicU64, Ordering},
     },
     time::{Duration, Instant},
 };
@@ -87,6 +87,10 @@ impl PrewarmHandle {
 /// Drives a warming worker off canonical head notifications; the worker executes the pool's best
 /// transactions against the head state and publishes [`TxPoolPrewarmCacheSnapshot`]s that the
 /// builder consumes through a [`PrewarmHandle`].
+///
+/// Cloning is cheap — every field is an [`Arc`] or an `Arc`-backed handle — and each warming pass
+/// runs on a clone so it can be moved onto a blocking thread.
+#[derive(Clone)]
 pub struct TxPoolPrewarmer<Pool, Client> {
     /// The transaction pool speculative transactions are drawn from.
     pool: Pool,
@@ -98,6 +102,10 @@ pub struct TxPoolPrewarmer<Pool, Client> {
     runtime: Runtime,
     /// The slot the worker publishes snapshots into and [`PrewarmHandle`]s read from.
     latest: Arc<RwLock<Option<TxPoolPrewarmCacheSnapshot>>>,
+    /// Monotonic head counter. Each new canonical head bumps it; a warming pass runs and publishes
+    /// only while it still holds the current epoch, so a superseded pass can neither keep working
+    /// nor overwrite a fresher snapshot.
+    epoch: Arc<AtomicU64>,
 }
 
 impl<Pool, Client> std::fmt::Debug for TxPoolPrewarmer<Pool, Client> {
@@ -113,7 +121,14 @@ where
 {
     /// Creates a new prewarmer. Call [`Self::spawn`] to start warming.
     pub fn new(pool: Pool, client: Client, evm_config: BaseEvmConfig, runtime: Runtime) -> Self {
-        Self { pool, client, evm_config, runtime, latest: Arc::new(RwLock::new(None)) }
+        Self {
+            pool,
+            client,
+            evm_config,
+            runtime,
+            latest: Arc::new(RwLock::new(None)),
+            epoch: Arc::new(AtomicU64::new(0)),
+        }
     }
 
     /// Returns a handle onto the snapshots this prewarmer publishes.
@@ -131,9 +146,11 @@ where
 
     /// Consumes canonical head notifications, restarting the warming pass for each new head.
     async fn drive(self, mut stream: CanonStateNotificationStream<BasePrimitives>) {
-        // Cancels the in-flight warming pass when a new head arrives or the stream ends.
-        let mut previous: Option<Arc<AtomicBool>> = None;
         while let Some(notification) = stream.next().await {
+            // `committed()` yields the new canonical chain for both commits and reorgs, so its tip
+            // is always the head the builder will build on next, including immediately after a
+            // reorg. We read only the tip's absolute state (never the execution-outcome diff), so
+            // unlike `state_diff_maintain` reorgs need no special-casing here.
             let committed = notification.committed();
             let tip = committed.tip();
             let parent_hash = tip.hash();
@@ -150,40 +167,24 @@ where
                 }
             };
 
-            if let Some(cancel) = previous.take() {
-                cancel.store(true, Ordering::Relaxed);
-            }
-            let cancel = Arc::new(AtomicBool::new(false));
-            previous = Some(Arc::clone(&cancel));
+            // Claim the next epoch. This supersedes any in-flight pass: it observes the bump and
+            // stops, and can no longer publish over the snapshot this new pass produces.
+            let epoch = self.epoch.fetch_add(1, Ordering::Relaxed).wrapping_add(1);
 
-            let pool = self.pool.clone();
-            let client = self.client.clone();
-            let evm_config = self.evm_config.clone();
-            let latest = Arc::clone(&self.latest);
-            self.runtime.spawn_blocking(move || {
-                Self::warm(parent_hash, evm_env, pool, client, evm_config, latest, cancel);
-            });
+            let worker = self.clone();
+            self.runtime.spawn_blocking(move || worker.warm(parent_hash, evm_env, epoch));
         }
 
-        if let Some(cancel) = previous.take() {
-            cancel.store(true, Ordering::Relaxed);
-        }
+        // Supersede the final pass so it stops once the stream ends.
+        self.epoch.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Speculatively executes the pool's best transactions against `parent_hash`'s state,
     /// publishing a fresh snapshot each time the recorded reads grow.
     ///
-    /// Runs until `cancel` is set (a new head arrived), the pass exceeds [`MAX_WARM_LIFETIME`], or
+    /// Runs until a newer head supersedes this `epoch`, the pass exceeds [`MAX_WARM_LIFETIME`], or
     /// the parent state becomes unavailable.
-    fn warm(
-        parent_hash: B256,
-        evm_env: EvmEnv<BaseSpecId>,
-        pool: Pool,
-        client: Client,
-        evm_config: BaseEvmConfig,
-        latest: Arc<RwLock<Option<TxPoolPrewarmCacheSnapshot>>>,
-        cancel: Arc<AtomicBool>,
-    ) {
+    fn warm(&self, parent_hash: B256, evm_env: EvmEnv<BaseSpecId>, epoch: u64) {
         let attributes = BestTransactionsAttributes::new(
             evm_env.block_env.basefee,
             evm_env.block_env.blob_gasprice().map(|price| price as u64),
@@ -194,10 +195,14 @@ where
         // Cache entry counts as of the last publication; the cache only grows, so a change means it
         // holds unpublished reads worth republishing.
         let mut published = (0usize, 0usize, 0usize);
-        let mut best = pool.best_transactions_with_attributes(attributes);
+        let mut best = self.pool.best_transactions_with_attributes(attributes);
 
-        while !cancel.load(Ordering::Relaxed) && Instant::now() < lifetime_deadline {
-            let state_provider = match client.state_by_block_hash(parent_hash) {
+        while self.epoch.load(Ordering::Relaxed) == epoch && Instant::now() < lifetime_deadline {
+            // Reopen the state provider each batch rather than holding one for the whole pass: a
+            // pass can span up to `MAX_WARM_LIFETIME`, and keeping a single MDBX read transaction
+            // open that long would pin the freelist. `CachedReads` already serves prior reads, so
+            // only genuine misses reach the freshly opened provider.
+            let state_provider = match self.client.state_by_block_hash(parent_hash) {
                 Ok(state_provider) => state_provider,
                 Err(error) => {
                     trace!(
@@ -221,11 +226,11 @@ where
             env.cfg_env.disable_nonce_check = true;
             env.cfg_env.disable_balance_check = true;
             env.cfg_env.disable_base_fee = true;
-            let mut evm = evm_config.evm_with_env(&mut state, env);
+            let mut evm = self.evm_config.evm_with_env(&mut state, env);
 
             let batch_deadline = Instant::now() + REFRESH_INTERVAL;
             let mut exhausted = false;
-            while !cancel.load(Ordering::Relaxed) && Instant::now() < batch_deadline {
+            while self.epoch.load(Ordering::Relaxed) == epoch && Instant::now() < batch_deadline {
                 let Some(transaction) = best.next() else {
                     exhausted = true;
                     break;
@@ -250,26 +255,31 @@ where
                 cache.accounts.values().map(|account| account.storage.len()).sum::<usize>(),
                 cache.contracts.len(),
             );
-            if counts != published {
-                *latest.write() =
-                    Some(TxPoolPrewarmCacheSnapshot::new(parent_hash, Arc::new(cache.clone())));
-                published = counts;
-                let (accounts, storage, bytecodes) = counts;
-                debug!(
-                    target: "payload_builder",
-                    parent_hash = %parent_hash,
-                    accounts,
-                    storage,
-                    bytecodes,
-                    "published txpool prewarm snapshot",
-                );
+            if counts != published && self.epoch.load(Ordering::Relaxed) == epoch {
+                let mut latest = self.latest.write();
+                // Re-check under the write lock so a superseded pass can never overwrite the
+                // snapshot the current pass published for the new head.
+                if self.epoch.load(Ordering::Relaxed) == epoch {
+                    *latest =
+                        Some(TxPoolPrewarmCacheSnapshot::new(parent_hash, Arc::new(cache.clone())));
+                    published = counts;
+                    let (accounts, storage, bytecodes) = counts;
+                    debug!(
+                        target: "payload_builder",
+                        parent_hash = %parent_hash,
+                        accounts,
+                        storage,
+                        bytecodes,
+                        "published txpool prewarm snapshot",
+                    );
+                }
             }
 
             if exhausted {
                 // Pool is drained for now; wait for maintenance to surface more pending
                 // transactions, then reopen a fresh iterator against the same parent.
                 std::thread::sleep(REFRESH_INTERVAL);
-                best = pool.best_transactions_with_attributes(attributes);
+                best = self.pool.best_transactions_with_attributes(attributes);
             }
         }
     }

--- a/crates/builder/core/src/flashblocks/prewarm.rs
+++ b/crates/builder/core/src/flashblocks/prewarm.rs
@@ -49,6 +49,10 @@ use crate::traits::{ClientBounds, PoolBounds};
 /// Maximum time a single warming batch executes before releasing the state provider and publishing.
 const REFRESH_INTERVAL: Duration = Duration::from_millis(100);
 
+/// Poll slice used while idling on a drained pool, so a superseded pass stops promptly instead of
+/// blocking the whole [`REFRESH_INTERVAL`].
+const IDLE_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
 /// Upper bound on how long a single warming pass keeps warming one parent.
 ///
 /// A new canonical head normally cancels the pass well before this; the cap only bounds a stalled
@@ -168,15 +172,17 @@ where
             };
 
             // Claim the next epoch. This supersedes any in-flight pass: it observes the bump and
-            // stops, and can no longer publish over the snapshot this new pass produces.
-            let epoch = self.epoch.fetch_add(1, Ordering::Relaxed).wrapping_add(1);
+            // stops, and can no longer publish over the snapshot this new pass produces. `Release`
+            // here pairs with the worker's `Acquire` loads so the bump is seen promptly on
+            // weakly-ordered targets.
+            let epoch = self.epoch.fetch_add(1, Ordering::Release).wrapping_add(1);
 
             let worker = self.clone();
             self.runtime.spawn_blocking(move || worker.warm(parent_hash, evm_env, epoch));
         }
 
         // Supersede the final pass so it stops once the stream ends.
-        self.epoch.fetch_add(1, Ordering::Relaxed);
+        self.epoch.fetch_add(1, Ordering::Release);
     }
 
     /// Speculatively executes the pool's best transactions against `parent_hash`'s state,
@@ -197,7 +203,7 @@ where
         let mut published = (0usize, 0usize, 0usize);
         let mut best = self.pool.best_transactions_with_attributes(attributes);
 
-        while self.epoch.load(Ordering::Relaxed) == epoch && Instant::now() < lifetime_deadline {
+        while self.epoch.load(Ordering::Acquire) == epoch && Instant::now() < lifetime_deadline {
             // Reopen the state provider each batch rather than holding one for the whole pass: a
             // pass can span up to `MAX_WARM_LIFETIME`, and keeping a single MDBX read transaction
             // open that long would pin the freelist. `CachedReads` already serves prior reads, so
@@ -230,7 +236,7 @@ where
 
             let batch_deadline = Instant::now() + REFRESH_INTERVAL;
             let mut exhausted = false;
-            while self.epoch.load(Ordering::Relaxed) == epoch && Instant::now() < batch_deadline {
+            while self.epoch.load(Ordering::Acquire) == epoch && Instant::now() < batch_deadline {
                 let Some(transaction) = best.next() else {
                     exhausted = true;
                     break;
@@ -255,11 +261,11 @@ where
                 cache.accounts.values().map(|account| account.storage.len()).sum::<usize>(),
                 cache.contracts.len(),
             );
-            if counts != published && self.epoch.load(Ordering::Relaxed) == epoch {
+            if counts != published && self.epoch.load(Ordering::Acquire) == epoch {
                 let mut latest = self.latest.write();
                 // Re-check under the write lock so a superseded pass can never overwrite the
                 // snapshot the current pass published for the new head.
-                if self.epoch.load(Ordering::Relaxed) == epoch {
+                if self.epoch.load(Ordering::Acquire) == epoch {
                     *latest =
                         Some(TxPoolPrewarmCacheSnapshot::new(parent_hash, Arc::new(cache.clone())));
                     published = counts;
@@ -277,8 +283,13 @@ where
 
             if exhausted {
                 // Pool is drained for now; wait for maintenance to surface more pending
-                // transactions, then reopen a fresh iterator against the same parent.
-                std::thread::sleep(REFRESH_INTERVAL);
+                // transactions before reopening a fresh iterator against the same parent. Sleep in
+                // short slices so a superseded pass exits promptly instead of blocking the whole
+                // interval.
+                let wake = Instant::now() + REFRESH_INTERVAL;
+                while self.epoch.load(Ordering::Acquire) == epoch && Instant::now() < wake {
+                    std::thread::sleep(IDLE_POLL_INTERVAL);
+                }
                 best = self.pool.best_transactions_with_attributes(attributes);
             }
         }

--- a/crates/builder/core/src/flashblocks/prewarm.rs
+++ b/crates/builder/core/src/flashblocks/prewarm.rs
@@ -277,10 +277,11 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use alloy_primitives::B256;
     use reth_execution_cache::TxPoolPrewarmCacheSnapshot;
     use reth_revm::cached::CachedReads;
-    use std::sync::Arc;
 
     use super::PrewarmHandle;
 

--- a/crates/builder/core/src/flashblocks/service.rs
+++ b/crates/builder/core/src/flashblocks/service.rs
@@ -19,7 +19,7 @@ use reth_provider::CanonStateSubscriptions;
 use tracing::info;
 
 use super::{
-    PayloadHandler,
+    PayloadHandler, PrewarmHandle, TxPoolPrewarmer,
     generator::BlockPayloadJobGenerator,
     payload::{BasePayloadBuilder, BuilderOutputs},
 };
@@ -67,12 +67,33 @@ impl FlashblocksServiceBuilder {
 
         let ws_pub: Arc<WebSocketPublisher> =
             WebSocketPublisher::new(self.config.flashblocks_ws_addr)?.into();
+
+        let evm_config = BaseEvmConfig::base(ctx.chain_spec());
+
+        // Start the best-effort txpool prewarmer, which warms the canonical head state so the build
+        // loop reads it from an in-memory snapshot instead of stalling on disk IO.
+        let prewarm = if self.config.txpool_prewarm_enabled {
+            let prewarmer = TxPoolPrewarmer::new(
+                pool.clone(),
+                ctx.provider().clone(),
+                evm_config.clone(),
+                ctx.task_executor().clone(),
+            );
+            let handle = prewarmer.handle();
+            prewarmer.spawn(ctx.provider().canonical_state_stream());
+            info!("Txpool prewarmer started");
+            handle
+        } else {
+            PrewarmHandle::noop()
+        };
+
         let payload_builder = BasePayloadBuilder::new(
-            BaseEvmConfig::base(ctx.chain_spec()),
+            evm_config,
             pool,
             ctx.provider().clone(),
             self.config.clone(),
             BuilderOutputs { payload_tx: built_payload_tx, ws_pub, rejected_tx_sender },
+            prewarm,
         );
         let payload_generator = BlockPayloadJobGenerator::with_builder(
             ctx.provider().clone(),

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -45,8 +45,8 @@ pub use flashblocks::{
     BuildArguments, FlashblockDiagnostics, FlashblockSelectionOutcome, FlashblocksExtraCtx,
     FlashblocksServiceBuilder, ParkableBestPayloadTransactions, ParkablePayloadTransactions,
     ParkedPredicateIndex, PayloadBuilder, PayloadHandler, PayloadJobDeadline,
-    PayloadTransactionInvalidated, PredicateLoadTracker, PredicateReadRecorder, ResolvePayload,
-    StateChangeEffects, ValidityPredicateKey,
+    PayloadTransactionInvalidated, PredicateLoadTracker, PredicateReadRecorder, PrewarmHandle,
+    ResolvePayload, StateChangeEffects, TxPoolPrewarmer, ValidityPredicateKey,
 };
 
 mod extension;


### PR DESCRIPTION
## Summary

Implements a best-effort txpool prewarmer for the flashblocks builder (BASE-165). A background worker speculatively executes the pool's best transactions against the canonical head state on a blocking thread, recording every state read and publishing an immutable `TxPoolPrewarmCacheSnapshot` keyed by parent hash. The builder consumes that snapshot as the first tier of its `CachedStateProvider` via `with_txpool_snapshot`, so reads the prewarmer already performed become in-memory cache hits instead of the synchronous disk stalls otherwise incurred during the single-threaded build. Warming runs continuously against the current head, is out-of-context by design (nonce, balance, and base-fee checks disabled), discards execution results, and is gated behind `--builder.txpool-prewarm` (default on) with a fail-open path that degrades to today's behavior whenever no matching snapshot is available.
