### PR TITLE
fix(batcher): never batch the genesis block on a fresh chain

### DIFF
--- a/crates/batcher/service/src/service.rs
+++ b/crates/batcher/service/src/service.rs
@@ -759,22 +759,25 @@ impl BatcherService {
             .map_err(|e| eyre::eyre!("failed to fetch L2 latest block number: {e}"))?;
 
         // Advance the cursor past any L2 blocks that are already on L1 but not yet safe.
-        // Use the higher of the safe head and the scan result as the backfill start.
-        let cursor_start = safe_l2_number.max(scanned_highest.unwrap_or(0));
+        // Use the higher of the safe head and the scan result as the backfill start, and
+        // never below the rollup genesis block: genesis is the derivation anchor and is
+        // never batched (it carries no L1-info deposit), so the first batchable block is
+        // always genesis + 1.
+        let genesis_l2 = rollup_config.genesis.l2.number;
+        let cursor_start = safe_l2_number.max(scanned_highest.unwrap_or(0)).max(genesis_l2);
 
-        // Build the L2 polling source. If blocks between cursor_start+1 and latest
-        // were not yet submitted, use sequential catchup mode to avoid skipping them.
-        let poller = if cursor_start < latest_l2 {
-            info!(
-                safe_l2 = %safe_l2_number,
-                cursor_start = %cursor_start,
-                latest_l2 = %latest_l2,
-                "starting sequential backfill from cursor"
-            );
-            RpcPollingSource::new_from(Arc::clone(&l2_provider), cursor_start + 1)
-        } else {
-            RpcPollingSource::new(Arc::clone(&l2_provider))
-        };
+        // Always drive the L2 source in sequential catchup mode from cursor_start + 1.
+        // This waits for the first unbatched block to be produced rather than polling
+        // `Latest`, which on a fresh chain (only the genesis block present) would return
+        // the empty genesis block and fatally halt the batch composer.
+        info!(
+            safe_l2 = %safe_l2_number,
+            genesis_l2 = %genesis_l2,
+            cursor_start = %cursor_start,
+            latest_l2 = %latest_l2,
+            "starting sequential backfill from cursor"
+        );
+        let poller = RpcPollingSource::new_from(Arc::clone(&l2_provider), cursor_start + 1);
 
         // Assemble the hybrid L2 block source.
         let source = HybridBlockSource::new(

--- a/crates/batcher/service/src/source.rs
+++ b/crates/batcher/service/src/source.rs
@@ -21,23 +21,33 @@ pub struct RpcPollingSource {
     #[debug(skip)]
     provider: Arc<dyn Provider<Base> + Send + Sync>,
     /// When `Some(n)`, the next `unsafe_head` call fetches block `n`
-    /// sequentially (for startup catchup). Cleared when `n` is strictly
-    /// greater than the current latest (i.e. block `n` hasn't been produced yet).
+    /// sequentially (for startup catchup). Cleared when the chain has caught up
+    /// to the head, switching the source to `Latest` polling.
     #[debug(skip)]
     next_sequential: Mutex<Option<u64>>,
+    /// The lowest L2 block number this source will ever batch (the first target of
+    /// sequential catchup). While the chain head is below this floor — e.g. only the
+    /// un-batchable genesis block exists — the source waits rather than falling back to
+    /// `Latest` polling, which would return a block that must never reach the composer.
+    #[debug(skip)]
+    catchup_floor: Mutex<u64>,
 }
 
 impl RpcPollingSource {
     /// Create a new [`RpcPollingSource`] that polls `Latest` on every call.
     pub fn new(provider: Arc<dyn Provider<Base> + Send + Sync>) -> Self {
-        Self { provider, next_sequential: Mutex::new(None) }
+        Self { provider, next_sequential: Mutex::new(None), catchup_floor: Mutex::new(0) }
     }
 
     /// Create a new [`RpcPollingSource`] that begins sequential catchup from
     /// `start_from`, fetching blocks `start_from, start_from+1, …` in order
     /// before switching to `Latest` polling once it has caught up.
     pub fn new_from(provider: Arc<dyn Provider<Base> + Send + Sync>, start_from: u64) -> Self {
-        Self { provider, next_sequential: Mutex::new(Some(start_from)) }
+        Self {
+            provider,
+            next_sequential: Mutex::new(Some(start_from)),
+            catchup_floor: Mutex::new(start_from),
+        }
     }
 }
 
@@ -54,8 +64,19 @@ impl PollingSource for RpcPollingSource {
                 .map_err(|e| SourceError::Provider(e.to_string()))?;
 
             if n > latest_number {
-                // Block n hasn't been produced yet; switch to normal polling.
-                *self.next_sequential.lock().unwrap() = None;
+                let floor = *self.catchup_floor.lock().unwrap();
+                if latest_number >= floor {
+                    // The chain has produced at least the first batchable block and we have
+                    // delivered up to its head: catchup is complete, switch to `Latest` polling
+                    // to follow new blocks live.
+                    *self.next_sequential.lock().unwrap() = None;
+                } else {
+                    // The chain head is still below the first batchable block (only blocks below
+                    // the floor, e.g. genesis, exist). Stay in catchup and signal the caller to
+                    // wait, rather than falling back to `Latest` — which would return the
+                    // un-batchable genesis block and fatally halt the batch composer.
+                    return Err(SourceError::NotReady { requested: n, latest: latest_number });
+                }
             } else {
                 let block = self
                     .provider
@@ -87,6 +108,7 @@ impl PollingSource for RpcPollingSource {
 
     fn reset_catchup(&self, start_from: u64) {
         *self.next_sequential.lock().unwrap() = Some(start_from);
+        *self.catchup_floor.lock().unwrap() = start_from;
     }
 
     fn is_catching_up(&self) -> bool {

--- a/crates/batcher/source/src/error.rs
+++ b/crates/batcher/source/src/error.rs
@@ -9,6 +9,17 @@ pub enum SourceError {
     /// Provider or RPC error.
     #[error("provider error: {0}")]
     Provider(String),
+    /// The requested block has not been produced yet. Raised during sequential catchup when
+    /// the chain head is still below the first batchable block (e.g. only the genesis block
+    /// exists): the source signals the caller to wait rather than returning an earlier,
+    /// un-batchable block.
+    #[error("l2 block {requested} not yet produced (chain head at {latest})")]
+    NotReady {
+        /// The block number the source is waiting for.
+        requested: u64,
+        /// The current chain head block number.
+        latest: u64,
+    },
     /// The underlying channel or stream was closed.
     #[error("source closed")]
     Closed,

--- a/crates/batcher/source/src/hybrid.rs
+++ b/crates/batcher/source/src/hybrid.rs
@@ -154,6 +154,16 @@ where
                         tracing::warn!(error = %msg, "sequential catchup poll error, retrying");
                         self.clock.sleep(CATCHUP_RETRY_DELAY).await;
                     }
+                    Err(SourceError::NotReady { requested, latest }) => {
+                        // The target block has not been produced yet (e.g. the chain only has
+                        // the genesis block so far). Wait and retry without leaving catchup.
+                        tracing::debug!(
+                            block = %requested,
+                            latest = %latest,
+                            "awaiting L2 block for catchup"
+                        );
+                        self.clock.sleep(CATCHUP_RETRY_DELAY).await;
+                    }
                     Err(e) => return Err(e),
                 }
                 continue;


### PR DESCRIPTION
On a chain that only has the genesis block, the block source fell into `Latest` polling and fetched the genesis block, which carries no L1-info deposit. The batch composer rejects an empty block with a fatal `EmptyBlock` error, permanently halting the batcher before the sequencer produces the first real block — so no batches are ever submitted to L1.

Floor the backfill cursor at the rollup genesis L2 number and always drive the source in sequential catchup from `cursor_start + 1`, so it waits for the first batchable block instead of polling `Latest`. Add a `SourceError::NotReady` signal so the polling source waits (rather than falling back to `Latest`) while the chain head is still below the first batchable block, and handle it as a quiet catchup retry in the hybrid source.

(This bug was found via the integ test introduced in #4665.)