### PR TITLE
feat(builder): enforce resource-unit admission in Flashblocks

### DIFF
--- a/crates/builder/cli/src/args.rs
+++ b/crates/builder/cli/src/args.rs
@@ -11,7 +11,7 @@ use base_builder_core::{
 use base_builder_metering::{
     DEFAULT_METERING_STORE_MAX_CAPACITY, DEFAULT_METERING_STORE_TTL_SECS, MeteringStore,
 };
-use base_execution_cli::{ResourceMeteringArgs, ShadowIndexerArgs};
+use base_execution_cli::ShadowIndexerArgs;
 use base_node_core::{HasRollupArgs, RollupArgs};
 use base_observability_events::{
     DEFAULT_MAX_FILE_BYTES, DEFAULT_MAX_FILES, DEFAULT_QUEUE_CAPACITY, TransactionEventProducer,
@@ -180,9 +180,17 @@ pub struct Args {
     #[arg(long = "builder.execution-metering-mode", value_enum, default_value = "off")]
     pub execution_metering_mode: ExecutionMeteringMode,
 
-    /// Resource-metering schedule. Evaluated when `--builder.enable-resource-metering` is set.
-    #[command(flatten)]
-    pub resource_metering: ResourceMeteringArgs,
+    /// JSON file containing the startup resource-metering schedule.
+    ///
+    /// Resource metering runs when `--builder.enable-resource-metering` is set
+    /// and this schedule is non-empty. Per-dimension `dryRun` in the file
+    /// observes a budget without excluding transactions.
+    ///
+    /// Uses the same `--payload.resource-metering-schedule` flag as the native
+    /// payload builder so operators can share one schedule path. Builder
+    /// rejection-cache sizing stays on `--builder.rejection-cache-*`.
+    #[arg(long = "payload.resource-metering-schedule", env = "PAYLOAD_RESOURCE_METERING_SCHEDULE")]
+    pub resource_metering_schedule: Option<PathBuf>,
 
     /// How much extra time to wait for the block building job to complete and not get garbage collected
     #[arg(long = "builder.extra-block-deadline-secs", default_value = "20")]
@@ -356,7 +364,7 @@ impl Default for Args {
             state_root_gas_coefficient: None,
             state_root_gas_anchor_us: None,
             execution_metering_mode: ExecutionMeteringMode::Off,
-            resource_metering: ResourceMeteringArgs::default(),
+            resource_metering_schedule: None,
             extra_block_deadline_secs: 20,
             enable_resource_metering: false,
             enable_experimental_validity_transactions: false,
@@ -420,7 +428,7 @@ impl Args {
 
         let resource_metering = ResourceMeteringConfig::from_parts(
             self.enable_resource_metering,
-            self.resource_metering.resource_metering_schedule.as_deref(),
+            self.resource_metering_schedule.as_deref(),
             Arc::clone(&metering_provider),
         )?;
 
@@ -732,6 +740,30 @@ mod tests {
         assert_eq!(args.block_state_root_gas_limit, Some(1_000_000));
         assert_eq!(args.state_root_gas_coefficient, Some(0.1));
         assert_eq!(args.state_root_gas_anchor_us, Some(5_000));
+    }
+
+    #[test]
+    fn payload_resource_metering_schedule_flag_is_accepted() {
+        let args = CommandParser::parse_from([
+            "builder",
+            "--payload.resource-metering-schedule",
+            "/tmp/schedule.json",
+        ])
+        .args;
+        assert_eq!(
+            args.resource_metering_schedule.as_deref(),
+            Some(std::path::Path::new("/tmp/schedule.json"))
+        );
+    }
+
+    #[test]
+    fn payload_rejection_cache_flags_are_not_builder_cli() {
+        let result = CommandParser::try_parse_from([
+            "builder",
+            "--payload.rejection-cache-max-capacity",
+            "1",
+        ]);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/builder/cli/src/args.rs
+++ b/crates/builder/cli/src/args.rs
@@ -641,7 +641,7 @@ mod tests {
     fn metering_data_written_to_provider_is_readable_from_config() {
         let metering_provider: SharedMeteringProvider =
             Arc::new(MeteringStore::new(true, 100, Duration::from_secs(30)));
-        let args = Args { enable_resource_metering: true, ..Default::default() };
+        let args = Args { enable_resource_metering: false, ..Default::default() };
         let config = args
             .into_builder_config(Arc::clone(&metering_provider))
             .expect("conversion should succeed");

--- a/crates/builder/cli/src/args.rs
+++ b/crates/builder/cli/src/args.rs
@@ -1,14 +1,17 @@
 //! Builder CLI arguments and config conversion helpers.
 
 use core::{net::SocketAddr, time::Duration};
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
 use base_builder_core::{
     BuilderApiExtensionConfig, BuilderConfig, DEFAULT_MAX_VALIDITY_PREDICATES,
-    ExecutionMeteringMode, RejectionCache, ShadowValidityConfig, SharedMeteringProvider,
+    ExecutionMeteringMode, RejectionCache, ResourceMeteringConfig, ShadowValidityConfig,
+    SharedMeteringProvider,
 };
-use base_builder_metering::MeteringStore;
-use base_execution_cli::ShadowIndexerArgs;
+use base_builder_metering::{
+    DEFAULT_METERING_STORE_MAX_CAPACITY, DEFAULT_METERING_STORE_TTL_SECS, MeteringStore,
+};
+use base_execution_cli::{ResourceMeteringArgs, ShadowIndexerArgs};
 use base_node_core::{HasRollupArgs, RollupArgs};
 use base_observability_events::{
     DEFAULT_MAX_FILE_BYTES, DEFAULT_MAX_FILES, DEFAULT_QUEUE_CAPACITY, TransactionEventProducer,
@@ -177,11 +180,16 @@ pub struct Args {
     #[arg(long = "builder.execution-metering-mode", value_enum, default_value = "off")]
     pub execution_metering_mode: ExecutionMeteringMode,
 
+    /// Resource-metering schedule. Evaluated when `--builder.enable-resource-metering` is set.
+    #[command(flatten)]
+    pub resource_metering: ResourceMeteringArgs,
+
     /// How much extra time to wait for the block building job to complete and not get garbage collected
     #[arg(long = "builder.extra-block-deadline-secs", default_value = "20")]
     pub extra_block_deadline_secs: u64,
 
-    /// Whether to enable TIPS Resource Metering
+    /// Whether to enable TIPS resource metering and payload resource-metering
+    /// schedule evaluation.
     #[arg(long = "builder.enable-resource-metering", default_value = "false")]
     pub enable_resource_metering: bool,
 
@@ -242,21 +250,38 @@ pub struct Args {
     #[arg(long = "builder.max-rejected-txs-per-block", default_value = "500")]
     pub max_rejected_txs_per_block: usize,
 
-    /// Buffer size for tx data store (LRU eviction when full)
-    #[arg(long = "builder.tx-data-store-buffer-size", default_value = "10000")]
+    /// Buffer size for tx data store (LRU eviction when full).
+    ///
+    /// Also used as the [`MeteringStore`] capacity. Default matches
+    /// [`DEFAULT_METERING_STORE_MAX_CAPACITY`].
+    #[arg(
+        long = "builder.tx-data-store-buffer-size",
+        default_value_t = DEFAULT_METERING_STORE_MAX_CAPACITY as usize
+    )]
     pub tx_data_store_buffer_size: usize,
 
     /// TTL in seconds for entries in the metering store cache.
     /// Stale entries are evicted after this duration.
-    #[arg(long = "builder.metering-store-ttl-secs", default_value = "30")]
+    #[arg(
+        long = "builder.metering-store-ttl-secs",
+        default_value_t = DEFAULT_METERING_STORE_TTL_SECS
+    )]
     pub metering_store_ttl_secs: u64,
 
     /// Maximum number of entries in the rejection cache for permanently rejected transactions
-    #[arg(long = "builder.rejection-cache-max-capacity", default_value = "100000")]
+    #[arg(
+        long = "builder.rejection-cache-max-capacity",
+        default_value = "100000",
+        id = "builder_rejection_cache_max_capacity"
+    )]
     pub rejection_cache_max_capacity: u64,
 
     /// TTL in seconds for entries in the rejection cache
-    #[arg(long = "builder.rejection-cache-ttl-secs", default_value = "1800")]
+    #[arg(
+        long = "builder.rejection-cache-ttl-secs",
+        default_value = "1800",
+        id = "builder_rejection_cache_ttl_secs"
+    )]
     pub rejection_cache_ttl_secs: u64,
 
     /// Inverted sampling frequency in blocks. 1 - each block, 100 - every 100th block.
@@ -331,6 +356,7 @@ impl Default for Args {
             state_root_gas_coefficient: None,
             state_root_gas_anchor_us: None,
             execution_metering_mode: ExecutionMeteringMode::Off,
+            resource_metering: ResourceMeteringArgs::default(),
             extra_block_deadline_secs: 20,
             enable_resource_metering: false,
             enable_experimental_validity_transactions: false,
@@ -343,8 +369,8 @@ impl Default for Args {
             audit_archiver_url: None,
             rejected_tx_channel_size: 500,
             max_rejected_txs_per_block: 500,
-            tx_data_store_buffer_size: 10000,
-            metering_store_ttl_secs: 30,
+            tx_data_store_buffer_size: DEFAULT_METERING_STORE_MAX_CAPACITY as usize,
+            metering_store_ttl_secs: DEFAULT_METERING_STORE_TTL_SECS,
             rejection_cache_max_capacity: 100_000,
             rejection_cache_ttl_secs: 1800,
             sampling_ratio: 100,
@@ -392,6 +418,12 @@ impl Args {
             warn!("deprecated builder resource limit flags are ignored");
         }
 
+        let resource_metering = ResourceMeteringConfig::from_parts(
+            self.enable_resource_metering,
+            self.resource_metering.resource_metering_schedule.as_deref(),
+            Arc::clone(&metering_provider),
+        )?;
+
         let flashblocks_ws_addr = SocketAddr::new(
             self.flashblocks.flashblocks_addr.parse()?,
             self.flashblocks.flashblocks_port,
@@ -415,6 +447,7 @@ impl Args {
             metering_wait_duration: self.metering_wait_duration_ms.map(Duration::from_millis),
             predicate_eval_hard_cutoff: Duration::from_millis(self.predicate_eval_hard_cutoff_ms),
             metering_provider,
+            resource_metering,
             rejection_cache: RejectionCache::new(
                 self.rejection_cache_max_capacity,
                 Duration::from_secs(self.rejection_cache_ttl_secs),

--- a/crates/builder/core/src/config.rs
+++ b/crates/builder/core/src/config.rs
@@ -6,7 +6,10 @@ use core::{
 };
 use std::sync::Arc;
 
-use base_execution_payload_builder::config::{BaseDAConfig, GasLimitConfig};
+use base_execution_payload_builder::{
+    ResourceMeteringConfig,
+    config::{BaseDAConfig, GasLimitConfig},
+};
 
 use crate::{ExecutionMeteringMode, NoopMeteringProvider, RejectionCache, SharedMeteringProvider};
 
@@ -67,6 +70,11 @@ pub struct BuilderConfig {
     /// Resource metering provider
     pub metering_provider: SharedMeteringProvider,
 
+    /// Resource-metering schedule for payload admission.
+    ///
+    /// Per-dimension `dryRun` observes over-budget usage without excluding.
+    pub resource_metering: ResourceMeteringConfig,
+
     /// Cache of permanently rejected transaction hashes, shared across blocks.
     /// Transactions in this cache are skipped by the iterator without re-evaluation.
     pub rejection_cache: RejectionCache,
@@ -116,6 +124,7 @@ impl core::fmt::Debug for BuilderConfig {
             .field("metering_wait_duration", &self.metering_wait_duration)
             .field("predicate_eval_hard_cutoff", &self.predicate_eval_hard_cutoff)
             .field("metering_provider", &self.metering_provider)
+            .field("resource_metering", &self.resource_metering)
             .field("rejection_cache_size", &self.rejection_cache.entry_count())
             .field("audit_archiver_url", &self.audit_archiver_url)
             .field("rejected_tx_channel_size", &self.rejected_tx_channel_size)
@@ -143,6 +152,7 @@ impl Default for BuilderConfig {
             metering_wait_duration: None,
             predicate_eval_hard_cutoff: Duration::from_millis(10),
             metering_provider: Arc::new(NoopMeteringProvider),
+            resource_metering: ResourceMeteringConfig::default(),
             rejection_cache: RejectionCache::default(),
             audit_archiver_url: None,
             rejected_tx_channel_size: 500,

--- a/crates/builder/core/src/execution.rs
+++ b/crates/builder/core/src/execution.rs
@@ -9,6 +9,9 @@ use alloy_primitives::{Address, U256};
 use base_bundles::RejectedTransaction;
 use base_common_consensus::{BaseReceipt, BaseTransactionSigned};
 use base_common_evm::BaseTransactionError;
+use base_execution_payload_builder::{
+    ResourceThrottlingDecision, ResourceThrottlingLimitExceeded, ResourceThrottlingLimitScope,
+};
 use derive_more::Display;
 use thiserror::Error;
 
@@ -157,6 +160,10 @@ pub enum TxnExecutionError {
     /// Metering data has not yet arrived for this transaction.
     #[error("metering data pending")]
     MeteringDataPending,
+
+    /// Resource-throttling budget exceeded.
+    #[error("{0}")]
+    ResourceThrottling(ResourceThrottlingLimitExceeded),
 }
 
 impl TxnExecutionError {
@@ -167,14 +174,33 @@ impl TxnExecutionError {
     /// Transient rejections depend on cumulative block state (gas used, DA used, etc.) and may
     /// succeed in a future block or flashblock with different cumulative values.
     pub const fn is_permanent(&self) -> bool {
-        matches!(
-            self,
+        match self {
             Self::TransactionDASizeExceeded(_, _)
-                | Self::ExecutionMeteringLimitExceeded(
-                    ExecutionMeteringLimitExceeded::TransactionExecutionTime(_, _),
-                )
-                | Self::MaxGasUsageExceeded
-        )
+            | Self::ExecutionMeteringLimitExceeded(
+                ExecutionMeteringLimitExceeded::TransactionExecutionTime(_, _),
+            )
+            | Self::MaxGasUsageExceeded => true,
+            Self::ResourceThrottling(error) => {
+                matches!(error.scope, ResourceThrottlingLimitScope::Transaction)
+            }
+            _ => false,
+        }
+    }
+
+    /// Converts a resource-throttling exclude decision into a builder error.
+    ///
+    /// Returns `None` unless [`ResourceThrottlingDecision::should_exclude`] is
+    /// true, so allow, dry-run throttle, and calculation-failure outcomes fail
+    /// open.
+    pub fn from_resource_decision(decision: &ResourceThrottlingDecision) -> Option<Self> {
+        match decision {
+            ResourceThrottlingDecision::Throttle { error, .. } if decision.should_exclude() => {
+                Some(Self::ResourceThrottling(error.clone()))
+            }
+            ResourceThrottlingDecision::Allow(_)
+            | ResourceThrottlingDecision::Throttle { .. }
+            | ResourceThrottlingDecision::CalculationFailed => None,
+        }
     }
 }
 
@@ -221,6 +247,8 @@ pub struct ExecutionInfo {
     pub cumulative_uncompressed_bytes: u64,
     /// Tracks fees from executed mempool transactions
     pub total_fees: U256,
+    /// Cumulative resource-metering units for the current payload.
+    pub resource_metering_usage: Vec<u128>,
     /// Extra execution information for the Flashblocks builder
     pub extra: FlashblocksExecutionInfo,
     /// DA Footprint Scalar for Jovian
@@ -249,6 +277,7 @@ impl ExecutionInfo {
             rejected_txs: Vec::new(),
             predicate_loads: PredicateLoadTracker::default(),
             inclusion: InclusionTracker::default(),
+            resource_metering_usage: Vec::new(),
         }
     }
 
@@ -601,5 +630,73 @@ mod tests {
             TxResources { gas_limit: 21_000, uncompressed_size: 1_000_000, ..Default::default() };
 
         assert!(info.is_tx_over_limits(&tx, &limits).is_ok());
+    }
+
+    #[test]
+    fn resource_throttling_transaction_scope_is_permanent() {
+        let transaction_scope =
+            TxnExecutionError::ResourceThrottling(ResourceThrottlingLimitExceeded {
+                dimension: "cpu".into(),
+                scope: ResourceThrottlingLimitScope::Transaction,
+                used: 10,
+                transaction_cost: 10,
+                limit: 5,
+                dry_run: false,
+            });
+        assert!(transaction_scope.is_permanent());
+
+        let block_scope = TxnExecutionError::ResourceThrottling(ResourceThrottlingLimitExceeded {
+            dimension: "cpu".into(),
+            scope: ResourceThrottlingLimitScope::Block,
+            used: 10,
+            transaction_cost: 10,
+            limit: 5,
+            dry_run: false,
+        });
+        assert!(!block_scope.is_permanent());
+    }
+
+    #[test]
+    fn from_resource_decision_is_none_for_dry_run_and_calculation_failed() {
+        assert!(
+            TxnExecutionError::from_resource_decision(&ResourceThrottlingDecision::Allow(
+                Default::default(),
+            ))
+            .is_none()
+        );
+        assert!(
+            TxnExecutionError::from_resource_decision(
+                &ResourceThrottlingDecision::CalculationFailed
+            )
+            .is_none()
+        );
+        assert!(
+            TxnExecutionError::from_resource_decision(&ResourceThrottlingDecision::Throttle {
+                error: ResourceThrottlingLimitExceeded {
+                    dimension: "cpu".into(),
+                    scope: ResourceThrottlingLimitScope::Transaction,
+                    used: 1,
+                    transaction_cost: 1,
+                    limit: 1,
+                    dry_run: true,
+                },
+                usage: Default::default(),
+            })
+            .is_none()
+        );
+        assert!(matches!(
+            TxnExecutionError::from_resource_decision(&ResourceThrottlingDecision::Throttle {
+                error: ResourceThrottlingLimitExceeded {
+                    dimension: "cpu".into(),
+                    scope: ResourceThrottlingLimitScope::Block,
+                    used: 1,
+                    transaction_cost: 1,
+                    limit: 1,
+                    dry_run: false,
+                },
+                usage: Default::default(),
+            }),
+            Some(TxnExecutionError::ResourceThrottling(_))
+        ));
     }
 }

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -114,6 +114,8 @@ pub struct FlashblockDiagnostics {
     pub txs_rejected_uncompressed_size: u64,
     /// Number skipped because metering data has not yet arrived.
     pub txs_rejected_metering_data_pending: u64,
+    /// Number rejected by resource-metering budgets.
+    pub txs_rejected_resource_throttling: u64,
     /// Number rejected or skipped for other reasons.
     pub txs_rejected_other: u64,
     /// Minimum effective priority fee (tip per gas) among included transactions.
@@ -135,7 +137,7 @@ impl FlashblockDiagnostics {
     }
 
     /// Returns the rejection counts keyed by their metric/log reason labels.
-    pub const fn rejection_counts(&self) -> [(&'static str, u64); 7] {
+    pub const fn rejection_counts(&self) -> [(&'static str, u64); 8] {
         [
             ("gas_limit", self.txs_rejected_gas),
             ("da_size", self.txs_rejected_da),
@@ -143,6 +145,7 @@ impl FlashblockDiagnostics {
             ("execution_time", self.txs_rejected_execution_time),
             ("uncompressed_size", self.txs_rejected_uncompressed_size),
             ("metering_data_pending", self.txs_rejected_metering_data_pending),
+            ("resource_throttling", self.txs_rejected_resource_throttling),
             ("other", self.txs_rejected_other),
         ]
     }
@@ -163,6 +166,7 @@ impl FlashblockDiagnostics {
             + self.txs_rejected_execution_time
             + self.txs_rejected_uncompressed_size
             + self.txs_rejected_metering_data_pending
+            + self.txs_rejected_resource_throttling
             + self.txs_rejected_other
     }
 
@@ -196,6 +200,9 @@ impl FlashblockDiagnostics {
             }
             TxnExecutionError::MeteringDataPending => {
                 self.txs_rejected_metering_data_pending += 1;
+            }
+            TxnExecutionError::ResourceThrottling(_) => {
+                self.txs_rejected_resource_throttling += 1;
             }
             TxnExecutionError::SequencerTransaction
             | TxnExecutionError::NonceTooLow
@@ -635,6 +642,12 @@ impl BasePayloadBuilderCtx {
 
             // add gas used by the transaction to cumulative gas used, before creating the receipt
             let gas_used = result.tx_gas_used();
+            self.builder_config.resource_metering.account_unthrottled(
+                &sequencer_tx.tx_hash(),
+                gas_used,
+                &state,
+                &mut info.resource_metering_usage,
+            );
             info.cumulative_gas_used += gas_used;
 
             if !sequencer_tx.is_deposit() {
@@ -858,6 +871,7 @@ impl BasePayloadBuilderCtx {
         let mut validity_candidates_evaluated = 0_u64;
         let mut validity_candidates_deferred = 0_u64;
         let mut predicate_eval_cutoff_hit = false;
+        let resource_metering = &self.builder_config.resource_metering;
 
         while let Some(tx) = best_txs.next(()) {
             if self.cancel.is_cancelled() {
@@ -1182,6 +1196,32 @@ impl BasePayloadBuilderCtx {
                 || BuilderConsideredEventData::new(info, limits, Some(&tx_resources)),
             );
 
+            let (simulated, predicted) =
+                resource_metering.check_simulated_usage(&tx_hash, &info.resource_metering_usage);
+            if let Some(err) = TxnExecutionError::from_resource_decision(&predicted) {
+                diag.record_rejection(&err);
+                if err.is_permanent() {
+                    diag.permanently_rejected_txs.push(tx_hash);
+                }
+                self.emit_builder_decision_event(
+                    &payload_id,
+                    TransactionEventType::BuilderRejected,
+                    tx_hash,
+                    Some(ordering_position),
+                    || {
+                        BuilderRejectedEventData::from_error(
+                            &err,
+                            info,
+                            limits,
+                            Some(&tx_resources),
+                        )
+                    },
+                );
+                log_txn(Err(err));
+                best_txs.mark_invalid(tx.signer(), tx.nonce());
+                continue;
+            }
+
             // ensure we still have capacity for this transaction
             if let Err(err) = info.is_tx_over_limits(&tx_resources, limits) {
                 // Check if this is an execution metering limit that should be handled
@@ -1414,11 +1454,9 @@ impl BasePayloadBuilderCtx {
             let gas_used = result.tx_gas_used();
             let is_success = result.is_success();
             if is_success {
-                log_txn(Ok(TxnOutcome::Success));
                 num_txs_simulated_success += 1;
                 BuilderMetrics::successful_tx_gas_used().record(gas_used as f64);
             } else {
-                log_txn(Ok(TxnOutcome::Reverted));
                 num_txs_simulated_fail += 1;
                 reverted_gas_used += gas_used;
                 BuilderMetrics::reverted_tx_gas_used().record(gas_used as f64);
@@ -1455,11 +1493,55 @@ impl BasePayloadBuilderCtx {
                 continue;
             }
 
+            let mut pending_resource_usage = None;
+            if resource_metering.is_active() {
+                let decision = resource_metering.check_executed_usage(
+                    &tx_hash,
+                    gas_used,
+                    &state,
+                    simulated.as_ref(),
+                    &info.resource_metering_usage,
+                );
+                if let Some(err) = TxnExecutionError::from_resource_decision(&decision) {
+                    diag.record_rejection(&err);
+                    if err.is_permanent() {
+                        diag.permanently_rejected_txs.push(tx_hash);
+                    }
+                    self.emit_builder_decision_event(
+                        &payload_id,
+                        TransactionEventType::BuilderRejected,
+                        tx_hash,
+                        Some(ordering_position),
+                        || {
+                            BuilderRejectedEventData::from_error(
+                                &err,
+                                info,
+                                limits,
+                                Some(&tx_resources),
+                            )
+                        },
+                    );
+                    log_txn(Err(err));
+                    best_txs.mark_invalid(tx.signer(), tx.nonce());
+                    continue;
+                }
+                pending_resource_usage = decision.committed_usage();
+            }
+
+            log_txn(Ok(if is_success { TxnOutcome::Success } else { TxnOutcome::Reverted }));
+
             info.cumulative_gas_used += gas_used;
             // record tx da size
             info.cumulative_da_bytes_used += tx_da_size;
             // record uncompressed tx size
             info.cumulative_uncompressed_bytes += tx_uncompressed_size;
+            if let Some(usage) = pending_resource_usage {
+                resource_metering.apply_accounted_usage(
+                    &tx_hash,
+                    &usage,
+                    &mut info.resource_metering_usage,
+                );
+            }
 
             self.emit_builder_decision_event(
                 &payload_id,
@@ -1748,21 +1830,36 @@ impl BasePayloadBuilderCtx {
 
 #[cfg(test)]
 mod tests {
-    use alloy_consensus::{Header, TxEip1559};
+    use alloy_consensus::{Header, SignableTransaction, TxEip1559};
     use alloy_eips::Encodable2718;
-    use alloy_primitives::{Address, TxKind, U256};
+    use alloy_primitives::{Address, B256, Signature, TxHash, TxKind, U256};
     use alloy_signer_local::PrivateKeySigner;
-    use base_common_consensus::{BaseTransactionSigned, BaseTypedTransaction, TxDeposit};
+    use base_bundles::{MeterBundleResponse, OpcodeGas, TransactionResult};
+    use base_common_consensus::{
+        BaseTransactionSigned, BaseTxEnvelope, BaseTypedTransaction, TxDeposit,
+    };
     use base_execution_chainspec::BaseChainSpec;
+    use base_execution_payload_builder::{
+        ResourceMeteringConfig, ResourceMeteringDimension, ResourceMeteringOperation,
+        ResourceMeteringSchedule, ResourceMeteringUsage,
+    };
     use base_execution_txpool::BasePooledTransaction;
     use reth_chainspec::ChainSpec;
     use reth_payload_util::PayloadTransactions;
     use reth_primitives_traits::{Recovered, SealedHeader, WithEncoded};
     use reth_provider::noop::NoopProvider;
     use reth_revm::{State, database::StateProviderDatabase};
+    use reth_transaction_pool::PoolTransaction;
+    use revm::{
+        database::{CacheDB, EmptyDB},
+        state::{AccountInfo, EvmState},
+    };
 
     use super::*;
-    use crate::{ParkablePayloadTransactions, test_utils::sign_base_tx};
+    use crate::{
+        BestFlashblocksTxs, MeteringProvider, NoopMeteringProvider, ParkablePayloadTransactions,
+        RejectionCache, SharedMeteringProvider, test_utils::sign_base_tx,
+    };
 
     fn test_builder_context() -> BasePayloadBuilderCtx {
         let genesis: serde_json::Value = serde_json::json!({
@@ -2008,6 +2105,7 @@ mod tests {
                 ("execution_time", 0),
                 ("uncompressed_size", 0),
                 ("metering_data_pending", 0),
+                ("resource_throttling", 0),
                 ("other", 0),
             ]
         );
@@ -2145,5 +2243,341 @@ mod tests {
             .expect("invalid pre-include is skipped when no_tx_pool=false");
         assert_eq!(info.cumulative_gas_used, 0, "skipped tx should not consume gas");
         assert!(info.receipts.is_empty(), "skipped tx should not produce a receipt");
+    }
+
+    fn test_chain_spec() -> (Arc<BaseChainSpec>, Arc<SealedHeader>) {
+        let genesis: serde_json::Value = serde_json::json!({
+            "config": { "chainId": 901 },
+            "gasLimit": "0x1C9C380",
+            "timestamp": "0x0"
+        });
+        let genesis = serde_json::from_value(genesis).expect("valid genesis");
+        let inner =
+            ChainSpec::builder().chain(901.into()).genesis(genesis).cancun_activated().build();
+        let parent_header = Header { gas_limit: 30_000_000, timestamp: 0, ..Default::default() };
+        (Arc::new(BaseChainSpec::from(inner)), Arc::new(SealedHeader::seal_slow(parent_header)))
+    }
+
+    fn cpu_schedule(
+        block_limit: u64,
+        transaction_limit: Option<u64>,
+        dry_run: bool,
+    ) -> ResourceMeteringSchedule {
+        ResourceMeteringSchedule::new(vec![ResourceMeteringDimension {
+            name: "cpu".to_string(),
+            block_limit,
+            transaction_limit: transaction_limit.unwrap_or(block_limit),
+            base_gas_weight: 1,
+            operations: Vec::new(),
+            dry_run,
+        }])
+    }
+
+    fn metering_config(
+        schedule: ResourceMeteringSchedule,
+        provider: SharedMeteringProvider,
+    ) -> ResourceMeteringConfig {
+        ResourceMeteringConfig {
+            enabled: true,
+            schedule: Arc::new(schedule.compile().unwrap()),
+            provider,
+        }
+    }
+
+    fn meter_for(tx_hash: TxHash, gas_used: u64) -> MeterBundleResponse {
+        MeterBundleResponse {
+            results: vec![TransactionResult {
+                coinbase_diff: Default::default(),
+                eth_sent_to_coinbase: Default::default(),
+                from_address: Default::default(),
+                gas_fees: Default::default(),
+                gas_price: Default::default(),
+                gas_used,
+                to_address: None,
+                tx_hash,
+                value: Default::default(),
+                execution_time_us: 0,
+                opcode_gas: Vec::new(),
+            }],
+            ..Default::default()
+        }
+    }
+
+    fn overflowing_schedule() -> ResourceMeteringSchedule {
+        ResourceMeteringSchedule::new(vec![ResourceMeteringDimension {
+            name: "cpu".to_string(),
+            block_limit: 1,
+            transaction_limit: 1,
+            base_gas_weight: u64::MAX,
+            operations: vec![ResourceMeteringOperation {
+                name: "SSTORE".to_string(),
+                gas_used_weight: u64::MAX,
+                count_cost: 0,
+            }],
+            dry_run: false,
+        }])
+    }
+
+    fn overflowing_meter(tx_hash: TxHash) -> MeterBundleResponse {
+        MeterBundleResponse {
+            results: vec![TransactionResult {
+                coinbase_diff: Default::default(),
+                eth_sent_to_coinbase: Default::default(),
+                from_address: Default::default(),
+                gas_fees: Default::default(),
+                gas_price: Default::default(),
+                gas_used: u64::MAX,
+                to_address: None,
+                tx_hash,
+                value: Default::default(),
+                execution_time_us: 0,
+                opcode_gas: vec![OpcodeGas {
+                    contract_address: Default::default(),
+                    opcode: "SSTORE".to_string(),
+                    count: 1,
+                    gas_used: u64::MAX,
+                }],
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[derive(Debug)]
+    struct MapProvider(std::sync::Mutex<std::collections::HashMap<TxHash, MeterBundleResponse>>);
+
+    impl MeteringProvider for MapProvider {
+        fn get(&self, tx_hash: &TxHash) -> Option<MeterBundleResponse> {
+            self.0.lock().unwrap().get(tx_hash).cloned()
+        }
+    }
+
+    struct RecordingTransactions {
+        transactions: std::vec::IntoIter<BasePooledTransaction>,
+        invalid: Vec<(Address, u64)>,
+    }
+
+    impl PayloadTransactions for RecordingTransactions {
+        type Transaction = BasePooledTransaction;
+
+        fn next(&mut self, _ctx: ()) -> Option<Self::Transaction> {
+            self.transactions.next()
+        }
+
+        fn mark_invalid(&mut self, sender: Address, nonce: u64) {
+            self.invalid.push((sender, nonce));
+        }
+    }
+
+    impl ParkablePayloadTransactions for RecordingTransactions {
+        fn park_current(&mut self) -> bool {
+            false
+        }
+
+        fn mark_current_committed(&mut self) {}
+
+        fn promote(&mut self, _transaction_hash: TxHash) -> bool {
+            false
+        }
+
+        fn discard_parked(&mut self, _transaction_hash: TxHash) -> bool {
+            false
+        }
+    }
+
+    fn pool_transaction() -> BasePooledTransaction {
+        let envelope = BaseTxEnvelope::Eip1559(
+            TxEip1559 {
+                chain_id: 901,
+                nonce: 0,
+                gas_limit: 100_000,
+                max_fee_per_gas: 2_000_000_000,
+                max_priority_fee_per_gas: 1,
+                to: TxKind::Call(Address::repeat_byte(0x11)),
+                ..Default::default()
+            }
+            .into_signed(Signature::test_signature()),
+        );
+        let encoded_len = envelope.encode_2718_len();
+        BasePooledTransaction::new(
+            envelope.try_into_recovered().expect("test signature must recover"),
+            encoded_len,
+        )
+    }
+
+    fn generous_limits() -> ResourceLimits {
+        ResourceLimits { block_gas_limit: 30_000_000, ..Default::default() }
+    }
+
+    fn execute_pool_scan(
+        resource_metering: ResourceMeteringConfig,
+        tx: BasePooledTransaction,
+        rejection_cache: RejectionCache,
+    ) -> (ExecutionInfo, FlashblockDiagnostics, RejectionCache, Address) {
+        let (chain_spec, parent) = test_chain_spec();
+        let mut ctx = BasePayloadBuilderCtx::for_test(chain_spec, parent);
+        ctx.builder_config.resource_metering = resource_metering;
+        ctx.builder_config.rejection_cache = rejection_cache.clone();
+
+        let sender = tx.sender();
+        let mut db = CacheDB::<EmptyDB>::default();
+        db.insert_account_info(sender, AccountInfo { balance: U256::MAX, ..Default::default() });
+        let mut state = State::builder().with_database(db).with_bundle_update().build();
+
+        let inner =
+            RecordingTransactions { transactions: vec![tx].into_iter(), invalid: Vec::new() };
+        let mut best_txs = BestFlashblocksTxs::new(inner, rejection_cache.clone());
+        let mut info = ExecutionInfo::default();
+        let diag = ctx
+            .execute_best_transactions(&mut info, &mut state, &mut best_txs, &generous_limits())
+            .expect("flashblock scan must succeed");
+        if !diag.permanently_rejected_txs.is_empty() {
+            best_txs.mark_rejected(&diag.permanently_rejected_txs);
+        }
+        (info, diag, rejection_cache, sender)
+    }
+
+    #[test]
+    fn missing_meter_bundle_fails_open_and_executes() {
+        let tx = pool_transaction();
+        let (info, diag, cache, _) = execute_pool_scan(
+            metering_config(
+                cpu_schedule(1_000_000, Some(1_000_000), false),
+                Arc::new(NoopMeteringProvider),
+            ),
+            tx,
+            RejectionCache::default(),
+        );
+
+        assert_eq!(diag.txs_included, 1);
+        assert_eq!(info.executed_transactions.len(), 1);
+        assert!(!info.resource_metering_usage.is_empty());
+        assert!(diag.permanently_rejected_txs.is_empty());
+        assert_eq!(cache.entry_count(), 0);
+    }
+
+    #[test]
+    fn predicted_transaction_scope_exclude_is_permanent() {
+        let tx = pool_transaction();
+        let tx_hash = *tx.hash();
+        let provider: SharedMeteringProvider = Arc::new(MapProvider(std::sync::Mutex::new(
+            std::collections::HashMap::from([(tx_hash, meter_for(tx_hash, 21_000))]),
+        )));
+        let cache = RejectionCache::default();
+        let (info, diag, cache, _) = execute_pool_scan(
+            metering_config(cpu_schedule(1_000_000, Some(100), false), provider),
+            tx,
+            cache,
+        );
+
+        assert_eq!(diag.txs_included, 0);
+        assert!(info.executed_transactions.is_empty());
+        assert!(info.resource_metering_usage.is_empty());
+        assert_eq!(diag.permanently_rejected_txs, vec![tx_hash]);
+        assert!(cache.is_rejected(&tx_hash));
+    }
+
+    #[test]
+    fn executed_exclude_does_not_commit_or_account_usage() {
+        let tx = pool_transaction();
+        let tx_hash = *tx.hash();
+        let (info, diag, cache, _) = execute_pool_scan(
+            metering_config(
+                cpu_schedule(1_000_000, Some(100), false),
+                Arc::new(NoopMeteringProvider),
+            ),
+            tx,
+            RejectionCache::default(),
+        );
+
+        assert_eq!(diag.txs_included, 0);
+        assert!(info.executed_transactions.is_empty());
+        assert!(info.resource_metering_usage.is_empty());
+        assert_eq!(diag.permanently_rejected_txs, vec![tx_hash]);
+        assert!(cache.is_rejected(&tx_hash));
+    }
+
+    #[test]
+    fn dry_run_and_calculation_failed_do_not_exclude() {
+        let tx = pool_transaction();
+        let tx_hash = *tx.hash();
+        let dry_run_provider: SharedMeteringProvider =
+            Arc::new(MapProvider(std::sync::Mutex::new(std::collections::HashMap::from([(
+                tx_hash,
+                meter_for(tx_hash, 21_000),
+            )]))));
+        let (info, diag, cache, _) = execute_pool_scan(
+            metering_config(cpu_schedule(1_000_000, Some(100), true), dry_run_provider),
+            tx.clone(),
+            RejectionCache::default(),
+        );
+        assert_eq!(diag.txs_included, 1);
+        assert_eq!(info.executed_transactions.len(), 1);
+        assert!(!cache.is_rejected(&tx_hash));
+
+        let overflowing_provider: SharedMeteringProvider =
+            Arc::new(MapProvider(std::sync::Mutex::new(std::collections::HashMap::from([(
+                tx_hash,
+                overflowing_meter(tx_hash),
+            )]))));
+        let (info, diag, cache, _) = execute_pool_scan(
+            metering_config(overflowing_schedule(), overflowing_provider),
+            tx,
+            RejectionCache::default(),
+        );
+        assert_eq!(diag.txs_included, 1);
+        assert_eq!(info.executed_transactions.len(), 1);
+        assert!(!cache.is_rejected(&tx_hash));
+    }
+
+    #[test]
+    fn sequencer_path_accounts_unthrottled_usage() {
+        let (chain_spec, parent) = test_chain_spec();
+        let deposit = TxDeposit {
+            source_hash: B256::default(),
+            from: Address::repeat_byte(0x11),
+            to: TxKind::Call(Address::repeat_byte(0x11)),
+            mint: 0,
+            value: U256::default(),
+            gas_limit: 21_000,
+            is_system_transaction: false,
+            input: Default::default(),
+        };
+        let signer = PrivateKeySigner::random();
+        let recovered =
+            sign_base_tx(&signer, BaseTypedTransaction::Deposit(deposit)).expect("sign deposit");
+        let signed = recovered.into_inner();
+        let encoded = signed.encoded_2718().into();
+
+        let mut ctx = BasePayloadBuilderCtx::for_test(chain_spec, parent);
+        ctx.builder_config.resource_metering =
+            metering_config(cpu_schedule(100, Some(1), false), Arc::new(NoopMeteringProvider));
+        ctx.config.attributes.no_tx_pool = true;
+        ctx.config.attributes.transactions = vec![WithEncoded::new(encoded, signed)];
+
+        let db = StateProviderDatabase::new(NoopProvider::default());
+        let mut state = State::builder().with_database(db).with_bundle_update().build();
+        let info = ctx
+            .execute_sequencer_transactions(&mut state)
+            .expect("sequencer deposit must execute without throttling");
+        assert_eq!(info.executed_transactions.len(), 1);
+        assert!(
+            !info.resource_metering_usage.is_empty(),
+            "unthrottled sequencer txs still account usage"
+        );
+    }
+
+    #[test]
+    fn apply_accounted_usage_overflow_fails_open() {
+        let config = metering_config(
+            cpu_schedule(1_000_000, Some(1_000_000), false),
+            Arc::new(NoopMeteringProvider),
+        );
+        let mut cumulative = vec![u128::MAX];
+        config.account_unthrottled(&TxHash::ZERO, 21_000, &EvmState::default(), &mut cumulative);
+        assert_eq!(cumulative, vec![u128::MAX]);
+
+        let usage = ResourceMeteringUsage { values: vec![1] };
+        config.apply_accounted_usage(&TxHash::ZERO, &usage, &mut cumulative);
+        assert_eq!(cumulative, vec![u128::MAX]);
     }
 }

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -1218,7 +1218,7 @@ impl BasePayloadBuilderCtx {
                     },
                 );
                 log_txn(Err(err));
-                best_txs.mark_invalid(tx.signer(), tx.nonce());
+                Self::skip_current(best_txs, tx.signer(), tx.nonce(), replay_independent);
                 continue;
             }
 
@@ -1522,7 +1522,7 @@ impl BasePayloadBuilderCtx {
                         },
                     );
                     log_txn(Err(err));
-                    best_txs.mark_invalid(tx.signer(), tx.nonce());
+                    Self::skip_current(best_txs, tx.signer(), tx.nonce(), replay_independent);
                     continue;
                 }
                 pending_resource_usage = decision.committed_usage();

--- a/crates/builder/core/src/transaction_events.rs
+++ b/crates/builder/core/src/transaction_events.rs
@@ -443,6 +443,7 @@ pub(crate) const fn rejection_reason_code(err: &TxnExecutionError) -> &'static s
         TxnExecutionError::EvmError => "evm_error",
         TxnExecutionError::MaxGasUsageExceeded => "max_gas_usage_exceeded",
         TxnExecutionError::MeteringDataPending => "metering_data_pending",
+        TxnExecutionError::ResourceThrottling(_) => "resource_throttling",
     }
 }
 
@@ -555,6 +556,9 @@ fn serialize_builder_event_data<T: Serialize>(data: BuilderEventData<T>) -> Map<
 #[cfg(test)]
 mod tests {
     use alloy_primitives::B256;
+    use base_execution_payload_builder::{
+        ResourceThrottlingLimitExceeded, ResourceThrottlingLimitScope,
+    };
 
     use super::*;
 
@@ -648,6 +652,19 @@ mod tests {
                 ExecutionMeteringLimitExceeded::TransactionExecutionTime(1, 2),
             )),
             "tx_execution_time_exceeded"
+        );
+        assert_eq!(
+            rejection_reason_code(&TxnExecutionError::ResourceThrottling(
+                ResourceThrottlingLimitExceeded {
+                    dimension: "cpu".into(),
+                    scope: ResourceThrottlingLimitScope::Transaction,
+                    used: 1,
+                    transaction_cost: 1,
+                    limit: 1,
+                    dry_run: false,
+                },
+            )),
+            "resource_throttling"
         );
     }
 

--- a/crates/builder/core/tests/smoke.rs
+++ b/crates/builder/core/tests/smoke.rs
@@ -10,10 +10,13 @@ use alloy_primitives::TxHash;
 #[cfg(target_os = "linux")]
 use base_builder_core::test_utils::ExternalNode;
 use base_builder_core::{
-    BuilderConfig,
+    BuilderConfig, NoopMeteringProvider,
     test_utils::{
         TransactionBuilderExt, setup_test_instance, setup_test_instance_with_builder_config,
     },
+};
+use base_execution_payload_builder::{
+    ResourceMeteringConfig, ResourceMeteringDimension, ResourceMeteringSchedule,
 };
 use tokio::{join, task::yield_now};
 use tracing::info;
@@ -268,6 +271,43 @@ async fn metering_wait_duration_does_not_delay_txs_when_metering_is_disabled() -
     assert!(
         txs.hashes().any(|hash| hash == *tx.tx_hash()),
         "fresh tx should not be delayed when metering is disabled"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn missing_meter_bundle_fails_open_when_metering_is_enabled() -> eyre::Result<()> {
+    let schedule = ResourceMeteringSchedule::new(vec![ResourceMeteringDimension {
+        name: "cpu".to_string(),
+        block_limit: 1_000_000,
+        transaction_limit: 1_000_000,
+        base_gas_weight: 1,
+        operations: Vec::new(),
+        dry_run: false,
+    }]);
+    let mut config = BuilderConfig::for_tests();
+    config.resource_metering = ResourceMeteringConfig {
+        enabled: true,
+        schedule: std::sync::Arc::new(schedule.compile().expect("valid schedule")),
+        provider: std::sync::Arc::new(NoopMeteringProvider),
+    };
+    let rbuilder = setup_test_instance_with_builder_config(config).await?;
+    let driver = rbuilder.driver().await?;
+
+    let tx = driver
+        .create_transaction()
+        .random_valid_transfer()
+        .send()
+        .await
+        .expect("Failed to send transaction");
+
+    let block = driver.build_new_block_with_current_timestamp(None).await?;
+    let txs = block.transactions;
+
+    assert!(
+        txs.hashes().any(|hash| hash == *tx.tx_hash()),
+        "missing meterBundle data must fail open and still include the transaction"
     );
 
     Ok(())

--- a/crates/builder/multiplex/src/service_builder.rs
+++ b/crates/builder/multiplex/src/service_builder.rs
@@ -1,8 +1,6 @@
-use std::sync::Arc;
-
 use base_builder_core::{BuilderConfig, FlashblocksServiceBuilder, NodeBounds, PoolBounds};
 use base_execution_evm::BaseEvmConfig;
-use base_execution_payload_builder::{ResourceMeteringConfig, config::BaseBuilderConfig};
+use base_execution_payload_builder::config::BaseBuilderConfig;
 use base_node_core::{
     BaseConsensusBuilder, BaseEngineTypes, BaseExecutorBuilder, BaseNetworkBuilder,
     node::BasePoolBuilder,
@@ -60,20 +58,16 @@ impl MultiplexingServiceBuilder {
 
     /// Native payload settings copied from the shared builder config.
     ///
-    /// Cutover and basic-only modes spawn `BasePayloadBuilder`. The rejection
-    /// cache and metering provider must be the same objects Flashblocks uses,
-    /// otherwise permanently rejected hashes and `meterBundle` data diverge
-    /// after cutover.
+    /// Cutover and basic-only modes spawn `BasePayloadBuilder`. Metering and
+    /// the rejection cache must be the same objects Flashblocks uses, otherwise
+    /// admission and permanently rejected hashes diverge after cutover.
     fn native_payload_config(&self) -> BaseBuilderConfig {
         BaseBuilderConfig {
             da_config: self.builder_config.da_config.clone(),
             gas_limit_config: self.builder_config.gas_limit_config.clone(),
             manifest_precheck_enabled: self.builder_config.manifest_precheck_enabled,
             predicate_eval_hard_cutoff: self.builder_config.predicate_eval_hard_cutoff,
-            resource_metering: ResourceMeteringConfig {
-                provider: Arc::clone(&self.builder_config.metering_provider),
-                ..ResourceMeteringConfig::default()
-            },
+            resource_metering: self.builder_config.resource_metering.clone(),
             rejection_cache: self.builder_config.rejection_cache.clone(),
         }
     }
@@ -198,18 +192,22 @@ impl BasePayloadServiceBuilder for MultiplexingServiceBuilder {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use alloy_primitives::TxHash;
 
     use super::*;
 
     #[test]
-    fn native_payload_config_preserves_metering_provider_and_rejection_cache() {
-        let builder_config = BuilderConfig::default();
+    fn native_payload_config_preserves_metering_and_rejection_cache() {
+        let mut builder_config = BuilderConfig::default();
+        builder_config.resource_metering.enabled = true;
         let hash = TxHash::repeat_byte(0x11);
         builder_config.rejection_cache.insert(hash);
-        let provider = Arc::clone(&builder_config.metering_provider);
+        let provider = Arc::clone(&builder_config.resource_metering.provider);
 
         let native = MultiplexingServiceBuilder::new(builder_config).native_payload_config();
+        assert!(native.resource_metering.enabled);
         assert!(native.rejection_cache.contains_key(&hash));
         assert!(Arc::ptr_eq(&native.resource_metering.provider, &provider));
     }

--- a/crates/execution/payload/README.md
+++ b/crates/execution/payload/README.md
@@ -14,7 +14,7 @@ built payloads against consensus rules. Also provides data availability configur
 Resource metering is an optional payload-builder admission guardrail. A
 file-backed schedule prices named observations into independent resource-unit
 dimensions. Simulated `meterBundle` data is used only to skip candidates that
-are predicted to exceed a remaining budget. Committed usage is accounted from
+would exceed a remaining budget. Committed usage is accounted from
 executed results when they exist: actual gas used and net post-state effects
 (`STATE_NEW_STORAGE_SLOT`, `STATE_CHANGED_STORAGE_SLOT`,
 `STATE_CLEARED_STORAGE_SLOT`, `STATE_TOUCHED_ACCOUNT`, and
@@ -27,7 +27,7 @@ metering then excludes transactions whose accounted usage exceeds an enforced
 budget. A dimension may set
 `dryRun` to observe that budget without excluding. Block-scope skips apply
 only to the current payload scan; the transaction stays in the pool for a
-later block. Transaction-scope skips (predicted or executed) are permanent
+later block. Transaction-scope skips (simulated or executed) are permanent
 pool evictions and are recorded in a shared TTL rejection cache (30
 minutes), matching Flashblocks: later payload jobs skip that hash even if
 the transaction is re-gossiped into the pool. Nonce-lane descendants are

--- a/crates/execution/payload/README.md
+++ b/crates/execution/payload/README.md
@@ -11,6 +11,29 @@ verifies
 built payloads against consensus rules. Also provides data availability configuration via
 `BaseDAConfig` for fee calculation.
 
+Resource metering is an optional payload-builder admission guardrail. A
+file-backed schedule prices named observations into independent resource-unit
+dimensions. Simulated `meterBundle` data is used only to skip candidates that
+are predicted to exceed a remaining budget. Committed usage is accounted from
+executed results when they exist: actual gas used and net post-state effects
+(`STATE_NEW_STORAGE_SLOT`, `STATE_CHANGED_STORAGE_SLOT`,
+`STATE_CLEARED_STORAGE_SLOT`, `STATE_TOUCHED_ACCOUNT`, and
+`STATE_CHANGED_ACCOUNT` for balance, nonce, or code changes) replace simulated
+`STATE_*` rows. Other simulated opcode and precompile rows are kept;
+production execution does not attach opcode bags. Storage-only writes are
+counted by the `STATE_*_STORAGE_SLOT` operations, not `STATE_CHANGED_ACCOUNT`.
+Omitted `transactionLimit` compiles to that dimension’s `blockLimit`. Resource
+metering then excludes transactions whose accounted usage exceeds an enforced
+budget. A dimension may set
+`dryRun` to observe that budget without excluding. Block-scope skips apply
+only to the current payload scan; the transaction stays in the pool for a
+later block. Transaction-scope skips (predicted or executed) are permanent
+pool evictions and are recorded in a shared TTL rejection cache (30
+minutes), matching Flashblocks: later payload jobs skip that hash even if
+the transaction is re-gossiped into the pool. Nonce-lane descendants are
+skipped for the current scan; skipping those descendants across later jobs
+is Flashblocks-only. This does not change protocol gas, fees, or validity.
+
 ## Usage
 
 Add the dependency to your `Cargo.toml`:


### PR DESCRIPTION
## Summary
- Apply the same predicted and executed resource-unit schedule in the Flashblocks builder (`--builder.enable-resource-metering` plus the shared schedule env/flag).
- Sequencer transactions stay unthrottled but still add usage. Fail-open matches the native builder.
- Wall-clock execution-time admission remains in this PR and is removed in the follow-up.

Stacked on the native admission PR. Continues the split of #4428.

## Test plan
- [x] `cargo test --lib -p base-builder-core -p base-builder-cli`
- [ ] Confirm Flashblocks uses the same schedule file as the native builder
- [ ] Confirm missing `meterBundle` data fails open when metering is enabled

type=routine
risk=low
impact=sev5