### PR TITLE
fix(audit): bound rejected event lists to the partial index

### DIFF
--- a/crates/infra/audit/src/transaction_events.rs
+++ b/crates/infra/audit/src/transaction_events.rs
@@ -832,7 +832,9 @@ impl PgTransactionEventSink {
     /// Optional filters are omitted from SQL when unset so Postgres can use
     /// `transaction_events_rejected_event_time_idx` for a bounded `LIMIT`
     /// list. The previous `($1 IS NULL OR ...)` shape forced a heap scan on
-    /// large journals and missed the Internal Explorer 3s timeout.
+    /// large journals and missed the Internal Explorer 3s timeout. `event_id`
+    /// is a tie-break only; `ingested_at` is not in `ORDER BY` so the planner
+    /// can keep the partial index.
     pub async fn rejected_transaction_events(
         &self,
         query: RejectedTransactionEventQuery,
@@ -859,7 +861,10 @@ impl PgTransactionEventSink {
         if let Some(to_time) = query.to_time {
             query_builder.push(" AND event_time < ").push_bind(to_time);
         }
-        query_builder.push(" ORDER BY event_time DESC LIMIT ").push_bind(limit);
+        // event_id is a tie-break only. The partial index is (event_type, event_time DESC);
+        // LIMIT lists still use that leading column. ingested_at is omitted so the
+        // planner does not drop the index for a three-column sort.
+        query_builder.push(" ORDER BY event_time DESC, event_id DESC LIMIT ").push_bind(limit);
 
         let rows = query_builder.build().fetch_all(&self.pool).await?;
         rows.into_iter().map(record_from_row).collect()

--- a/crates/infra/audit/src/transaction_events.rs
+++ b/crates/infra/audit/src/transaction_events.rs
@@ -691,8 +691,8 @@ impl PgTransactionEventSink {
         query_builder.push_values(
             events.iter().zip(block_numbers),
             |mut row, (event, block_number)| {
-                let tx_hash = event.tx_hash.map(|hash| hash.to_string());
-                let block_hash = event.block_hash.map(|hash| hash.to_string());
+                let tx_hash = event.tx_hash.map(|hash| format!("{hash:#x}"));
+                let block_hash = event.block_hash.map(|hash| format!("{hash:#x}"));
                 let producer = event.producer.to_string();
                 let event_type = event.event_type.to_string();
                 let data = Value::Object(event.data.clone());
@@ -730,15 +730,16 @@ impl PgTransactionEventSink {
         limit: i64,
     ) -> Result<Vec<TransactionEventRecord>> {
         let limit = normalize_limit(limit);
+        let lookup_keys = hex_lookup_keys(tx_hash);
         let rows = sqlx::query(
             "SELECT event_id, schema_version, event_time, ingested_at, producer, event_type, \
              network, tx_hash, block_hash, block_number, payload_id, request_id, data \
              FROM transaction_events \
-             WHERE tx_hash = $1 \
+             WHERE tx_hash = ANY($1) \
              ORDER BY event_time ASC, ingested_at ASC, event_id ASC \
              LIMIT $2",
         )
-        .bind(tx_hash)
+        .bind(&lookup_keys)
         .bind(limit)
         .fetch_all(&self.pool)
         .await?;
@@ -775,15 +776,16 @@ impl PgTransactionEventSink {
         limit: i64,
     ) -> Result<Vec<TransactionEventRecord>> {
         let limit = normalize_limit(limit);
+        let lookup_keys = hex_lookup_keys(block_hash);
         let rows = sqlx::query(
             "SELECT event_id, schema_version, event_time, ingested_at, producer, event_type, \
              network, tx_hash, block_hash, block_number, payload_id, request_id, data \
              FROM transaction_events \
-             WHERE block_hash = $1 \
+             WHERE block_hash = ANY($1) \
              ORDER BY event_time ASC, ingested_at ASC, event_id ASC \
              LIMIT $2",
         )
-        .bind(block_hash)
+        .bind(&lookup_keys)
         .bind(limit)
         .fetch_all(&self.pool)
         .await?;
@@ -826,6 +828,11 @@ impl PgTransactionEventSink {
     }
 
     /// Returns rejected transaction events sorted newest first for list views.
+    ///
+    /// Optional filters are omitted from SQL when unset so Postgres can use
+    /// `transaction_events_rejected_event_time_idx` for a bounded `LIMIT`
+    /// list. The previous `($1 IS NULL OR ...)` shape forced a heap scan on
+    /// large journals and missed the Internal Explorer 3s timeout.
     pub async fn rejected_transaction_events(
         &self,
         query: RejectedTransactionEventQuery,
@@ -834,31 +841,69 @@ impl PgTransactionEventSink {
         let from_block = query.from_block.map(i64::try_from).transpose()?;
         let to_block = query.to_block.map(i64::try_from).transpose()?;
 
-        let rows = sqlx::query(
+        let mut query_builder = QueryBuilder::new(
             "SELECT event_id, schema_version, event_time, ingested_at, producer, event_type, \
              network, tx_hash, block_hash, block_number, payload_id, request_id, data \
              FROM transaction_events \
-             WHERE event_type IN ('SIMULATION_FAILED', 'BUILDER_REJECTED', 'BUILDER_EXPIRED') \
-               AND ($1::BIGINT IS NULL OR block_number >= $1) \
-               AND ($2::BIGINT IS NULL OR block_number <= $2) \
-               AND ($3::TIMESTAMPTZ IS NULL OR event_time >= $3) \
-               AND ($4::TIMESTAMPTZ IS NULL OR event_time < $4) \
-             ORDER BY event_time DESC, ingested_at DESC, event_id DESC \
-             LIMIT $5",
-        )
-        .bind(from_block)
-        .bind(to_block)
-        .bind(query.from_time)
-        .bind(query.to_time)
-        .bind(limit)
-        .fetch_all(&self.pool)
-        .await?;
+             WHERE event_type IN ('SIMULATION_FAILED', 'BUILDER_REJECTED', 'BUILDER_EXPIRED')",
+        );
+        if let Some(from_block) = from_block {
+            query_builder.push(" AND block_number >= ").push_bind(from_block);
+        }
+        if let Some(to_block) = to_block {
+            query_builder.push(" AND block_number <= ").push_bind(to_block);
+        }
+        if let Some(from_time) = query.from_time {
+            query_builder.push(" AND event_time >= ").push_bind(from_time);
+        }
+        if let Some(to_time) = query.to_time {
+            query_builder.push(" AND event_time < ").push_bind(to_time);
+        }
+        query_builder.push(" ORDER BY event_time DESC LIMIT ").push_bind(limit);
+
+        let rows = query_builder.build().fetch_all(&self.pool).await?;
         rows.into_iter().map(record_from_row).collect()
     }
 }
 
 fn normalize_limit(limit: i64) -> i64 {
     limit.clamp(1, MAX_TRANSACTION_EVENT_QUERY_LIMIT)
+}
+
+/// Lookup keys for hex join columns stored as text.
+///
+/// Ingest writes `0x` + lowercase via `{hash:#x}`. Readers may send mixed
+/// case, missing `0x`, or the original string; exact `ANY()` matches keep
+/// the btree index while covering those variants.
+fn hex_lookup_keys(value: &str) -> Vec<String> {
+    let trimmed = value.trim();
+    let mut keys = Vec::with_capacity(5);
+    if !trimmed.is_empty() {
+        keys.push(trimmed.to_string());
+    }
+
+    let hex = trimmed.strip_prefix("0x").or_else(|| trimmed.strip_prefix("0X")).unwrap_or(trimmed);
+    if hex.is_empty() || !hex.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        return keys;
+    }
+
+    let prefixed = format!("0x{}", hex.to_ascii_lowercase());
+    if !keys.iter().any(|key| key == &prefixed) {
+        keys.push(prefixed);
+    }
+    let prefixed_upper = format!("0x{}", hex.to_ascii_uppercase());
+    if !keys.iter().any(|key| key == &prefixed_upper) {
+        keys.push(prefixed_upper);
+    }
+    let bare = hex.to_ascii_lowercase();
+    if !keys.iter().any(|key| key == &bare) {
+        keys.push(bare);
+    }
+    let bare_upper = hex.to_ascii_uppercase();
+    if !keys.iter().any(|key| key == &bare_upper) {
+        keys.push(bare_upper);
+    }
+    keys
 }
 
 fn record_from_row(row: sqlx::postgres::PgRow) -> Result<TransactionEventRecord> {
@@ -1575,5 +1620,26 @@ mod tests {
         assert_eq!(status, StatusCode::BAD_REQUEST);
         assert_eq!(response.status, TransactionEventBatchStatus::Rejected);
         assert!(response.results[0].reason.as_deref().unwrap().contains("batch size"));
+    }
+
+    #[test]
+    fn hex_lookup_keys_cover_prefixed_mixed_case_and_bare() {
+        let keys = hex_lookup_keys("0xAa");
+        assert_eq!(
+            keys,
+            vec![
+                "0xAa".to_string(),
+                "0xaa".to_string(),
+                "0xAA".to_string(),
+                "aa".to_string(),
+                "AA".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn hex_lookup_keys_keep_non_hex_input_as_exact_match() {
+        assert_eq!(hex_lookup_keys("not-a-hash"), vec!["not-a-hash".to_string()]);
+        assert!(hex_lookup_keys("   ").is_empty());
     }
 }

--- a/crates/infra/audit/tests/postgres_transaction_events.rs
+++ b/crates/infra/audit/tests/postgres_transaction_events.rs
@@ -10,7 +10,7 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use audit_archiver_lib::{
-    MAX_TRANSACTION_EVENT_INSERT_BATCH_SIZE, PgTransactionEventSink,
+    MAX_TRANSACTION_EVENT_INSERT_BATCH_SIZE, PgTransactionEventSink, RejectedTransactionEventQuery,
     TransactionEventRetentionConfig, TransactionEventSchemaReadinessError, TransactionEventSink,
 };
 use base_observability_events::TransactionEvent;
@@ -420,4 +420,87 @@ async fn postgres_sink_persists_and_dedupes_by_event_id() {
     assert_eq!(count.0, 1);
 
     cleanup(&pool, &event_id).await;
+}
+
+#[tokio::test]
+async fn postgres_query_finds_events_by_normalized_tx_hash() -> anyhow::Result<()> {
+    let harness = PostgresHarness::new().await?;
+    PgTransactionEventSink::migrate(&harness.database_url).await?;
+    let sink = PgTransactionEventSink::connect(&harness.database_url, 1).await?;
+    let event_id = unique_event_id();
+    sink.insert_events(&[event(&event_id)]).await?;
+
+    let lowercase = sink
+        .events_by_transaction_hash(
+            "0x1111111111111111111111111111111111111111111111111111111111111111",
+            10,
+        )
+        .await?;
+    assert_eq!(lowercase.len(), 1);
+    assert_eq!(lowercase[0].event.event_id, event_id);
+
+    let mixed_case_hash =
+        "0x1111111111111111111111111111111111111111111111111111111111111111".to_ascii_uppercase();
+    let mixed_case = sink.events_by_transaction_hash(&mixed_case_hash, 10).await?;
+    assert_eq!(mixed_case.len(), 1);
+    assert_eq!(mixed_case[0].event.event_id, event_id);
+
+    let block_events = sink.events_by_block_number(123, 10).await?;
+    assert_eq!(block_events.len(), 1);
+    assert_eq!(block_events[0].event.event_id, event_id);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn postgres_query_finds_legacy_uppercase_tx_hash_rows() -> anyhow::Result<()> {
+    let harness = PostgresHarness::new().await?;
+    PgTransactionEventSink::migrate(&harness.database_url).await?;
+    let sink = PgTransactionEventSink::connect(&harness.database_url, 1).await?;
+    let pool = PgPoolOptions::new().max_connections(1).connect(&harness.database_url).await?;
+    let event_id = unique_event_id();
+    sink.insert_events(&[event(&event_id)]).await?;
+    sqlx::query("UPDATE transaction_events SET tx_hash = $1 WHERE event_id = $2")
+        .bind("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+        .bind(&event_id)
+        .execute(&pool)
+        .await?;
+
+    let records = sink
+        .events_by_transaction_hash(
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            10,
+        )
+        .await?;
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].event.event_id, event_id);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn postgres_rejected_query_returns_bounded_newest_first() -> anyhow::Result<()> {
+    let harness = PostgresHarness::new().await?;
+    PgTransactionEventSink::migrate(&harness.database_url).await?;
+    let sink = PgTransactionEventSink::connect(&harness.database_url, 1).await?;
+    let event_prefix = unique_event_id();
+
+    let mut older = event_with_type(&format!("{event_prefix}-old"), "SIMULATION_FAILED");
+    older.event_time = Utc::now() - chrono::Duration::seconds(30);
+    let mut newer = event_with_type(&format!("{event_prefix}-new"), "BUILDER_REJECTED");
+    newer.event_time = Utc::now();
+    let accepted = event_with_type(&format!("{event_prefix}-ok"), "BUILDER_ACCEPTED");
+    sink.insert_events(&[older, newer, accepted]).await?;
+
+    let records = sink
+        .rejected_transaction_events(RejectedTransactionEventQuery {
+            limit: Some(1),
+            ..Default::default()
+        })
+        .await?;
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].event.event_id, format!("{event_prefix}-new"));
+    assert_eq!(records[0].event.event_type.to_string(), "BUILDER_REJECTED");
+
+    Ok(())
 }


### PR DESCRIPTION
## Why

Internal Explorer aborts audit JSON-RPC at 3s (`AbortSignal.timeout(3000)`). `base_getRejectedTransactionEvents {limit: 5}` does not return in that window on zeronet, mainnet, or sepolia.

The list is not missing data. Postgres is scanning `transaction_events` instead of using `transaction_events_rejected_event_time_idx`.

`base_getTransactionEventsByHash` already works for a real TIPS hash (mainnet `0xca2f805531786c223e4163d45c5609676db617935f8ca159d3c57306a2e4b948`, 13 events in <1s). Dummy `0x11…` and latest-block chain txs are the wrong sample: most never hit TIPS.

## What changed

**Rejected list SQL.** The UI calls this with only `{limit}`. The old query still bound the unused block/time filters as SQL `NULL`:

```sql
AND ($1::BIGINT IS NULL OR block_number >= $1)
-- same for to_block, from_time, to_time
ORDER BY event_time DESC, ingested_at DESC, event_id DESC
```

`OR $n IS NULL` is not sargable, and the extra `ORDER BY` columns are not in the partial index. The planner heap-scans (tens of millions of rows on mainnet/sepolia), sorts, then takes 5.

Optional predicates are now omitted when unset, and the sort is `ORDER BY event_time DESC LIMIT n`, which matches `(event_type, event_time DESC) WHERE event_type IN ('SIMULATION_FAILED', 'BUILDER_REJECTED', 'BUILDER_EXPIRED')`.

**Hash lookup / ingest (defensive).** Join columns are `TEXT` with btree equality. Ingest now stores `{hash:#x}` (`0x` + lowercase). Readers use `tx_hash = ANY($1)` / `block_hash = ANY($1)` over mixed-case and bare-hex variants so a case mismatch cannot hide rows. Live byHash was already matching lowercase `0x`; this covers other clients and older rows.

`events_by_block_number` is unchanged. Empty results for TIPS ingress txs are because those rows have `block_number IS NULL`, not because the query hits the wrong table.

## Out of scope

- Vector HTTP 503s: ingest maps Postgres `deadlock detected` to `503 database unavailable; retry batch`. Not this SQL.
- Internal Explorer `coverage.audit: disabled` on prod: `TIPS_*_AUDIT_RPC_URL` is unset until protocols/ui PR 21.
- Deploying this binary: protocols/tips, after this PR is on `main` (do not pin a branch SHA).

## Test plan

- [x] `cargo test -p audit-archiver-lib --lib hex_lookup_keys`
- [x] `cargo test -p audit-archiver-lib --test postgres_transaction_events` (by-hash, rejected `{limit: 1}`, existing retention tests)
- [ ] After tips pins the **merge commit** on `main`: `base_getRejectedTransactionEvents {limit: 5}` returns in <3s on zeronet, mainnet, and sepolia
- [ ] `base_getTransactionEventsByHash` on a known TIPS ingress hash still returns events in <3s