### PR TITLE
fix(batcher): handle SourceError::NotReady in the polling select arm

### DIFF
--- a/crates/batcher/source/src/hybrid.rs
+++ b/crates/batcher/source/src/hybrid.rs
@@ -194,6 +194,17 @@ where
                             tracing::warn!(error = %msg, "polling source error, retrying on next tick");
                             // Transient provider error — continue to next tick.
                         }
+                        Err(SourceError::NotReady { requested, latest }) => {
+                            // The requested block has not been produced yet. Today this only
+                            // arises during sequential catchup (handled above), but a polling
+                            // source could emit it here too; treat it as transient and retry on
+                            // the next tick rather than killing the batcher.
+                            tracing::debug!(
+                                block = %requested,
+                                latest = %latest,
+                                "awaiting L2 block, retrying on next tick"
+                            );
+                        }
                         Err(e) => return Err(e),
                     }
                 }


### PR DESCRIPTION
The hybrid block source handled `NotReady` in the sequential catchup arm but let it fall through to `Err(e) => return Err(e)` in the `tokio::select!` polling arm. Today `NotReady` is only produced while catching up (so the polling arm is never reached with it), but a future `PollingSource` that emits it outside sequential mode would fatally kill the batcher.

Treat `NotReady` like a transient `Provider` error in the polling arm: log and continue to the next tick. Addresses review feedback from #4669.