### PR TITLE
chore(proof): remove dead timestamp overflow error variants

### DIFF
--- a/crates/proof/proof/src/errors.rs
+++ b/crates/proof/proof/src/errors.rs
@@ -131,18 +131,6 @@ pub enum OracleProviderError {
         /// The configured rollup genesis L2 block number.
         genesis_block: u64,
     },
-    /// Computing the schedule L2 block timestamp overflowed `u64`.
-    #[error("L2 schedule block timestamp overflow for block {schedule_block}")]
-    L2ScheduleTimestampOverflow {
-        /// The L2 block number used to pin the upgrade schedule.
-        schedule_block: u64,
-    },
-    /// Computing the claimed L2 block timestamp overflowed `u64`.
-    #[error("L2 claim block timestamp overflow for block {claim_block}")]
-    L2ClaimTimestampOverflow {
-        /// The claimed L2 block number.
-        claim_block: u64,
-    },
     /// The rollup config has a zero L2 block time.
     #[error("L2 block time must be non-zero")]
     InvalidL2BlockTime,


### PR DESCRIPTION
Stacked on #4574.

Removes `L2ScheduleTimestampOverflow` and `L2ClaimTimestampOverflow` from `OracleProviderError` — their only call sites were the checked-arithmetic path in `boot.rs` that #4574 replaced with `RollupConfig::l2_block_timestamp()`.

Addresses https://github.com/base/base/pull/4574#discussion_r3857604011.