### PR TITLE
ci: do not block l3-family PRs on base-std fork tests

### DIFF
--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -144,6 +144,15 @@ jobs:
 
       - name: Run base-std fork tests
         shell: bash
+        # The `l3` branch is a temporary Base-on-Base fork whose B-20 / PolicyRegistry
+        # precompiles intentionally diverge from the base-std `main` spec, so this
+        # conformance suite fails branch-wide on the l3 family and cannot be reconciled
+        # here without a large precompile change. Do not let it block PRs targeting an
+        # l3-family branch, while keeping enforcement intact for `main` and everywhere
+        # else. The suite still runs and the divergence is reported in the PR comment
+        # below (see the "Comment fork test results" step), so the signal is preserved.
+        # Remove this once the l3 precompiles are reconciled with the base-std spec.
+        continue-on-error: ${{ startsWith(github.base_ref, 'l3') }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
The base-std interface (fork) tests run the base-std `main` Solidity spec suite against base/base's precompiles. The `l3` branch is a temporary Base-on-Base fork whose B-20 / PolicyRegistry precompiles diverge from that spec, so the suite fails branch-wide (124 failing conformance tests) and cannot be reconciled without a large precompile change.

Mark the fork-test step `continue-on-error` when the PR targets an l3-family branch (`startsWith(github.base_ref, 'l3')`), so it no longer blocks l3 work while enforcement stays intact for `main` and every other branch. The suite still runs and its pass/fail counts are still posted to the PR comment, so the divergence remains visible. Remove this once the l3 precompiles are reconciled with the base-std spec.