### PR TITLE
feat(execution): require zero millisecond part on first Denim block

### DIFF
--- a/crates/execution/consensus/src/error.rs
+++ b/crates/execution/consensus/src/error.rs
@@ -17,6 +17,14 @@ pub enum BaseConsensusError {
         /// The child's full-millisecond timestamp.
         child_timestamp_ms: u128,
     },
+    /// The first Denim-active block claimed a non-zero millisecond component.
+    #[error(
+        "invalid BaseTime activation claim: first Denim block must have millisecond part 0, got {timestamp_millis_part}"
+    )]
+    BaseTimeActivationMillisNonZero {
+        /// The claimed sub-second millisecond component.
+        timestamp_millis_part: u16,
+    },
     /// Block body has non-empty withdrawals list (l1 withdrawals).
     #[error("non-empty block body withdrawals list")]
     WithdrawalsNonEmpty,

--- a/crates/execution/node/src/engine.rs
+++ b/crates/execution/node/src/engine.rs
@@ -179,6 +179,16 @@ where
                 .timestamp_millis_part();
 
         if !self.chain_spec().is_denim_active_at_timestamp(parent_header.timestamp()) {
+            // The legacy parent has no millisecond component to anchor the 200ms progression
+            // check, so the activation block must claim exactly 0 instead.
+            if child_millis != 0 {
+                return Err(ConsensusError::other(
+                    BaseConsensusError::BaseTimeActivationMillisNonZero {
+                        timestamp_millis_part: child_millis,
+                    },
+                )
+                .into());
+            }
             return Ok(());
         }
 
@@ -922,8 +932,8 @@ mod tests {
     }
 
     #[test]
-    fn post_execution_accepts_valid_claim_on_first_active_block() {
-        let block = base_time_block(DENIM_TIMESTAMP, 400, EMPTY_ROOT_HASH);
+    fn post_execution_accepts_zero_claim_on_first_active_block() {
+        let block = base_time_block(DENIM_TIMESTAMP, 0, EMPTY_ROOT_HASH);
         let parent = SealedHeader::seal_slow(Header {
             timestamp: DENIM_TIMESTAMP - 1,
             ..Default::default()
@@ -938,6 +948,34 @@ mod tests {
             || Ok(Box::new(parent_state(0))),
         )
         .unwrap();
+    }
+
+    #[test]
+    fn post_execution_rejects_nonzero_claim_on_first_active_block() {
+        for millis_part in [200, 400, 600, 800] {
+            let block = base_time_block(DENIM_TIMESTAMP, millis_part, EMPTY_ROOT_HASH);
+            let parent = SealedHeader::seal_slow(Header {
+                timestamp: DENIM_TIMESTAMP - 1,
+                ..Default::default()
+            });
+            let state_updates = HashedPostState::default();
+            let error = PayloadValidator::<BaseEngineTypes>::
+                validate_block_post_execution_with_hashed_state(
+                    &denim_validator(),
+                    || &state_updates,
+                    &block,
+                    &parent,
+                    || Ok(Box::new(parent_state(0))),
+                )
+                .unwrap_err();
+
+            assert!(matches!(
+                base_consensus_error(&error),
+                Some(BaseConsensusError::BaseTimeActivationMillisNonZero {
+                    timestamp_millis_part,
+                }) if *timestamp_millis_part == millis_part
+            ));
+        }
     }
 
     #[test]


### PR DESCRIPTION
- The first Denim-active block has a legacy parent with no millisecond component to anchor the 200ms progression check, so its BaseTime claim was previously unconstrained beyond slot alignment.
- Enforce that the activation block claims exactly 0, matching the deterministic schedule in `RollupConfig::l2_block_timestamp_millis`, which anchors the activation block at whole seconds.