### PR TITLE
refactor(precompiles): Neutralize Precompile Boundary Types

### DIFF
--- a/crates/common/precompile-storage/src/error.rs
+++ b/crates/common/precompile-storage/src/error.rs
@@ -8,10 +8,9 @@ sol! {
     /// Precompile cannot be executed via delegatecall or callcode.
     error DelegateCallNotAllowed();
 }
-use revm::{
-    context::journaled_state::JournalLoadError,
-    precompile::{PrecompileError, PrecompileHalt, PrecompileOutput, PrecompileResult},
-};
+use revm::context::journaled_state::JournalLoadError;
+
+use crate::neutral::{PrecompileError, PrecompileHalt, PrecompileOutput, PrecompileResult};
 
 /// Top-level error type for all Base native precompile operations.
 #[derive(

--- a/crates/common/precompile-storage/src/lib.rs
+++ b/crates/common/precompile-storage/src/lib.rs
@@ -8,6 +8,12 @@ extern crate self as base_precompile_storage;
 mod error;
 pub use error::{BasePrecompileError, DelegateCallNotAllowed, IntoPrecompileResult, Result};
 
+mod neutral;
+pub use neutral::{
+    AccountInfo, IntoEnginePrecompileResult, PrecompileError, PrecompileHalt, PrecompileOutput,
+    PrecompileResult, PrecompileStatus,
+};
+
 mod packing;
 pub use packing::{
     FieldLocation, PackedSlot, Word, calc_element_loc, calc_element_offset, calc_element_slot,

--- a/crates/common/precompile-storage/src/neutral.rs
+++ b/crates/common/precompile-storage/src/neutral.rs
@@ -1,0 +1,284 @@
+//! Engine-neutral precompile boundary types.
+//!
+//! Base-owned equivalents of the execution-engine types that surface at the
+//! precompile boundary: the precompile result/output/error/halt types and the
+//! `AccountInfo`/`Bytecode` state types read and written by native precompiles.
+//!
+//! The enshrined precompile logic (b20, policy, nonce, tx-context) is written
+//! against these types instead of naming `revm` directly, so the same logic can
+//! be reused across execution engines. This module is the single place that
+//! knows how to convert a base type into a concrete engine type: today only the
+//! `revm` conversions exist; an EVM2 backend adds the parallel conversions here
+//! without touching any enshrined logic.
+//!
+//! The conversions are exact, field-for-field mirrors of the corresponding
+//! `revm` constructors so that neutralizing the shared logic is behavior
+//! preserving.
+
+use alloc::string::String;
+use core::result;
+
+use alloy_primitives::{B256, Bytes, U256};
+use revm::{
+    precompile::{
+        PrecompileError as RevmPrecompileError, PrecompileHalt as RevmPrecompileHalt,
+        PrecompileOutput as RevmPrecompileOutput, PrecompileStatus as RevmPrecompileStatus,
+    },
+    primitives::KECCAK_EMPTY,
+    state::AccountInfo as RevmAccountInfo,
+};
+
+/// Engine-neutral account information.
+///
+/// Mirrors the fields the enshrined precompiles read; the closure callbacks in
+/// [`crate::StorageCtx`] only observe `balance`, `nonce`, `code_hash`, and
+/// [`AccountInfo::is_empty_code_hash`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AccountInfo {
+    /// Account balance.
+    pub balance: U256,
+    /// Account nonce.
+    pub nonce: u64,
+    /// Hash of the account bytecode, or [`KECCAK_EMPTY`] for an empty account.
+    pub code_hash: B256,
+}
+
+impl Default for AccountInfo {
+    fn default() -> Self {
+        Self { balance: U256::ZERO, nonce: 0, code_hash: KECCAK_EMPTY }
+    }
+}
+
+impl AccountInfo {
+    /// Returns true if the code hash is the Keccak256 hash of the empty string.
+    ///
+    /// Matches `revm`'s `AccountInfo::is_empty_code_hash`.
+    pub fn is_empty_code_hash(&self) -> bool {
+        self.code_hash == KECCAK_EMPTY
+    }
+}
+
+impl From<&RevmAccountInfo> for AccountInfo {
+    fn from(value: &RevmAccountInfo) -> Self {
+        Self { balance: value.balance, nonce: value.nonce, code_hash: value.code_hash }
+    }
+}
+
+/// Non-fatal precompile halt reason.
+///
+/// Neutral enshrined logic only ever halts with [`PrecompileHalt::OutOfGas`];
+/// the stock-crypto precompile wrappers keep using the engine's own halt enum
+/// directly.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum PrecompileHalt {
+    /// The precompile ran out of gas.
+    OutOfGas,
+}
+
+impl From<PrecompileHalt> for RevmPrecompileHalt {
+    fn from(value: PrecompileHalt) -> Self {
+        match value {
+            PrecompileHalt::OutOfGas => Self::OutOfGas,
+        }
+    }
+}
+
+/// Status of a precompile execution.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum PrecompileStatus {
+    /// Precompile executed successfully.
+    Success,
+    /// Precompile reverted (non-fatal, returns remaining gas).
+    Revert,
+    /// Precompile halted with a specific reason.
+    Halt(PrecompileHalt),
+}
+
+impl From<PrecompileStatus> for RevmPrecompileStatus {
+    fn from(value: PrecompileStatus) -> Self {
+        match value {
+            PrecompileStatus::Success => Self::Success,
+            PrecompileStatus::Revert => Self::Revert,
+            PrecompileStatus::Halt(reason) => Self::Halt(reason.into()),
+        }
+    }
+}
+
+/// Fatal precompile error that halts EVM execution.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum PrecompileError {
+    /// Unrecoverable error that halts EVM execution.
+    Fatal(String),
+}
+
+impl From<PrecompileError> for RevmPrecompileError {
+    fn from(value: PrecompileError) -> Self {
+        match value {
+            PrecompileError::Fatal(msg) => Self::Fatal(msg),
+        }
+    }
+}
+
+/// Rich precompile execution output with gas accounting and status support.
+///
+/// Field-for-field mirror of `revm`'s `PrecompileOutput` so the [`From`]
+/// conversion is a plain copy and neutralizing the shared logic preserves
+/// behavior exactly, including the EIP-8037 state-gas accounting fields.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct PrecompileOutput {
+    /// Status of the precompile execution.
+    pub status: PrecompileStatus,
+    /// Regular gas used by the precompile.
+    pub gas_used: u64,
+    /// Gas refunded by the precompile.
+    pub gas_refunded: i64,
+    /// State gas used by the precompile.
+    pub state_gas_used: i64,
+    /// State gas drawn from regular gas because the reservoir was empty.
+    pub state_gas_spilled: u64,
+    /// Reservoir gas for EIP-8037.
+    pub reservoir: u64,
+    /// Output bytes.
+    pub bytes: Bytes,
+}
+
+impl PrecompileOutput {
+    /// Returns a new successful precompile output.
+    pub const fn new(gas_used: u64, bytes: Bytes, reservoir: u64) -> Self {
+        Self {
+            status: PrecompileStatus::Success,
+            gas_used,
+            gas_refunded: 0,
+            state_gas_used: 0,
+            state_gas_spilled: 0,
+            reservoir,
+            bytes,
+        }
+    }
+
+    /// Returns a new halted precompile output with the given halt reason.
+    pub const fn halt(reason: PrecompileHalt, reservoir: u64) -> Self {
+        Self {
+            status: PrecompileStatus::Halt(reason),
+            gas_used: 0,
+            gas_refunded: 0,
+            state_gas_used: 0,
+            state_gas_spilled: 0,
+            reservoir,
+            bytes: Bytes::new(),
+        }
+    }
+
+    /// Returns a new reverted precompile output.
+    pub const fn revert(gas_used: u64, bytes: Bytes, reservoir: u64) -> Self {
+        Self {
+            status: PrecompileStatus::Revert,
+            gas_used,
+            gas_refunded: 0,
+            state_gas_used: 0,
+            state_gas_spilled: 0,
+            reservoir,
+            bytes,
+        }
+    }
+
+    /// Returns `true` if the precompile execution was successful.
+    pub const fn is_success(&self) -> bool {
+        matches!(self.status, PrecompileStatus::Success)
+    }
+
+    /// Returns `true` if the precompile reverted.
+    pub const fn is_revert(&self) -> bool {
+        matches!(self.status, PrecompileStatus::Revert)
+    }
+
+    /// Returns `true` if the precompile halted.
+    pub const fn is_halt(&self) -> bool {
+        matches!(self.status, PrecompileStatus::Halt(_))
+    }
+}
+
+impl From<PrecompileOutput> for RevmPrecompileOutput {
+    fn from(value: PrecompileOutput) -> Self {
+        Self {
+            status: value.status.into(),
+            gas_used: value.gas_used,
+            gas_refunded: value.gas_refunded,
+            state_gas_used: value.state_gas_used,
+            state_gas_spilled: value.state_gas_spilled,
+            reservoir: value.reservoir,
+            bytes: value.bytes,
+        }
+    }
+}
+
+/// Result of a native precompile execution.
+pub type PrecompileResult = result::Result<PrecompileOutput, PrecompileError>;
+
+/// Extension trait converting a base [`PrecompileResult`] into the engine result.
+///
+/// Applied at the single precompile-dispatch boundary (the `base_precompile!`
+/// macro) where a native precompile hands its result back to the engine.
+pub trait IntoEnginePrecompileResult {
+    /// Converts a base precompile result into the `revm` precompile result.
+    fn into_revm(self) -> revm::precompile::PrecompileResult;
+}
+
+impl IntoEnginePrecompileResult for PrecompileResult {
+    fn into_revm(self) -> revm::precompile::PrecompileResult {
+        self.map(Into::into).map_err(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn precompile_output_conversion_is_field_exact() {
+        let base = PrecompileOutput {
+            status: PrecompileStatus::Success,
+            gas_used: 500,
+            gas_refunded: 200,
+            state_gas_used: 30,
+            state_gas_spilled: 20,
+            reservoir: 10,
+            bytes: Bytes::from_static(&[1, 2, 3]),
+        };
+        let revm: RevmPrecompileOutput = base.clone().into();
+        assert_eq!(revm.gas_used, 500);
+        assert_eq!(revm.gas_refunded, 200);
+        assert_eq!(revm.state_gas_used, 30);
+        assert_eq!(revm.state_gas_spilled, 20);
+        assert_eq!(revm.reservoir, 10);
+        assert_eq!(revm.bytes, base.bytes);
+        assert!(revm.is_success());
+    }
+
+    #[test]
+    fn revert_and_halt_map_to_matching_status() {
+        let revert: RevmPrecompileOutput =
+            PrecompileOutput::revert(7, Bytes::new(), 3).into();
+        assert!(revert.is_revert());
+        assert_eq!(revert.gas_used, 7);
+
+        let halt: RevmPrecompileOutput =
+            PrecompileOutput::halt(PrecompileHalt::OutOfGas, 0).into();
+        assert!(halt.is_halt());
+    }
+
+    #[test]
+    fn account_info_reads_match_revm() {
+        let revm = RevmAccountInfo {
+            balance: U256::from(42u64),
+            nonce: 7,
+            code_hash: KECCAK_EMPTY,
+            code: None,
+            ..RevmAccountInfo::default()
+        };
+        let base = AccountInfo::from(&revm);
+        assert_eq!(base.balance, U256::from(42u64));
+        assert_eq!(base.nonce, 7);
+        assert!(base.is_empty_code_hash());
+    }
+}

--- a/crates/common/precompile-storage/src/neutral.rs
+++ b/crates/common/precompile-storage/src/neutral.rs
@@ -262,13 +262,11 @@ mod tests {
 
     #[test]
     fn revert_and_halt_map_to_matching_status() {
-        let revert: RevmPrecompileOutput =
-            PrecompileOutput::revert(7, Bytes::new(), 3).into();
+        let revert: RevmPrecompileOutput = PrecompileOutput::revert(7, Bytes::new(), 3).into();
         assert!(revert.is_revert());
         assert_eq!(revert.gas_used, 7);
 
-        let halt: RevmPrecompileOutput =
-            PrecompileOutput::halt(PrecompileHalt::OutOfGas, 0).into();
+        let halt: RevmPrecompileOutput = PrecompileOutput::halt(PrecompileHalt::OutOfGas, 0).into();
         assert!(halt.is_halt());
     }
 

--- a/crates/common/precompile-storage/src/neutral.rs
+++ b/crates/common/precompile-storage/src/neutral.rs
@@ -144,6 +144,11 @@ pub struct PrecompileOutput {
 
 impl PrecompileOutput {
     /// Returns a new successful precompile output.
+    ///
+    /// `reservoir` is the EIP-8037 state-gas reservoir field; Base's call sites
+    /// (`StorageCtx::success_output`, `IntoPrecompileResult::into_precompile_result`)
+    /// pass the transaction's cumulative state gas here, matching the field the
+    /// engine's frame handler reads. The name mirrors the underlying engine type.
     pub const fn new(gas_used: u64, bytes: Bytes, reservoir: u64) -> Self {
         Self {
             status: PrecompileStatus::Success,

--- a/crates/common/precompile-storage/src/storage_ctx.rs
+++ b/crates/common/precompile-storage/src/storage_ctx.rs
@@ -11,14 +11,11 @@ use core::{cell::RefCell, fmt};
 
 use alloy_primitives::{Address, B256, Bytes, LogData, U256};
 use alloy_sol_types::SolInterface;
-use revm::{
-    context::journaled_state::JournalCheckpoint,
-    precompile::{PrecompileOutput, PrecompileResult},
-    state::{AccountInfo, Bytecode},
-};
+use revm::{context::journaled_state::JournalCheckpoint, state::Bytecode};
 
 use crate::{
     error::{BasePrecompileError, IntoPrecompileResult, Result},
+    neutral::{AccountInfo, PrecompileOutput, PrecompileResult},
     provider::{PrecompileStorageProvider, StorageFeatures},
 };
 
@@ -81,7 +78,8 @@ impl<'a> StorageCtx<'a> {
         let mut result: Option<Result<T>> = None;
         self.try_with_storage(|s| {
             s.with_account_info(address, &mut |info| {
-                result = Some(f(info));
+                let info = AccountInfo::from(info);
+                result = Some(f(&info));
             })
         })?;
         result.unwrap_or_else(|| {
@@ -379,7 +377,10 @@ impl StorageCtx<'_> {
         address: Address,
         f: impl FnOnce(Option<&AccountInfo>) -> T,
     ) -> T {
-        self.with_hashmap(|storage| f(storage.get_account_info(address)))
+        self.with_hashmap(|storage| {
+            let info = storage.get_account_info(address).map(AccountInfo::from);
+            f(info.as_ref())
+        })
     }
 
     /// Executes a closure with emitted events from the test storage provider.

--- a/crates/common/precompiles/src/activation/dispatch.rs
+++ b/crates/common/precompiles/src/activation/dispatch.rs
@@ -3,7 +3,7 @@
 use alloy_primitives::Bytes;
 use alloy_sol_types::SolCall;
 use base_precompile_storage::{BasePrecompileError, StorageCtx};
-use revm::precompile::PrecompileResult;
+use base_precompile_storage::PrecompileResult;
 
 use crate::{
     ActivationAdminConfig, ActivationRegistryStorage, BerylCallRecorder, BerylMetricLabels,

--- a/crates/common/precompiles/src/activation/dispatch.rs
+++ b/crates/common/precompiles/src/activation/dispatch.rs
@@ -2,8 +2,7 @@
 
 use alloy_primitives::Bytes;
 use alloy_sol_types::SolCall;
-use base_precompile_storage::{BasePrecompileError, StorageCtx};
-use base_precompile_storage::PrecompileResult;
+use base_precompile_storage::{BasePrecompileError, PrecompileResult, StorageCtx};
 
 use crate::{
     ActivationAdminConfig, ActivationRegistryStorage, BerylCallRecorder, BerylMetricLabels,

--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -249,9 +249,9 @@ mod tests {
     use alloy_primitives::{Address, B256, U256, address, keccak256, uint};
     use alloy_sol_types::{SolCall, SolEvent};
     use base_precompile_storage::{
-        BasePrecompileError, HashMapStorageProvider, Result, StorageCtx, StorageKey,
+        BasePrecompileError, HashMapStorageProvider, PrecompileOutput, Result, StorageCtx,
+        StorageKey,
     };
-    use base_precompile_storage::PrecompileOutput;
     use rstest::rstest;
 
     use crate::{

--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -2,8 +2,7 @@
 
 use alloy_primitives::{Address, B256, Bytes, address, b256};
 use base_precompile_macros::contract;
-use base_precompile_storage::{BasePrecompileError, Handler, Mapping, Result};
-use revm::precompile::PrecompileResult;
+use base_precompile_storage::{BasePrecompileError, Handler, Mapping, PrecompileResult, Result};
 
 use crate::IActivationRegistry;
 
@@ -121,7 +120,7 @@ impl ActivationRegistryStorage<'_> {
     /// Reverts unless the feature is activated.
     ///
     /// Both the activated and deactivated paths return `Ok`; callers must inspect
-    /// [`revm::precompile::PrecompileOutput::reverted`] to distinguish an activated feature from an
+    /// [`base_precompile_storage::PrecompileOutput::is_revert`] to distinguish an activated feature from an
     /// ABI revert.
     pub fn assert_activated(&self, feature: B256) -> PrecompileResult {
         self.storage.result_output(self.ensure_activated(feature), |()| Bytes::new())
@@ -252,7 +251,7 @@ mod tests {
     use base_precompile_storage::{
         BasePrecompileError, HashMapStorageProvider, Result, StorageCtx, StorageKey,
     };
-    use revm::precompile::PrecompileOutput;
+    use base_precompile_storage::PrecompileOutput;
     use rstest::rstest;
 
     use crate::{

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -12,7 +12,7 @@ use alloy_primitives::{Bytes, U256};
 use alloy_sol_types::{SolCall, SolValue};
 use base_common_genesis::BaseUpgrade;
 use base_precompile_storage::{BasePrecompileError, StorageCtx};
-use revm::precompile::PrecompileResult;
+use base_precompile_storage::PrecompileResult;
 
 use crate::{
     AssetAccounting, AssetCall, AssetVersion, AssetVersions, B20AssetStorage, B20AssetToken,

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -11,8 +11,7 @@
 use alloy_primitives::{Bytes, U256};
 use alloy_sol_types::{SolCall, SolValue};
 use base_common_genesis::BaseUpgrade;
-use base_precompile_storage::{BasePrecompileError, StorageCtx};
-use base_precompile_storage::PrecompileResult;
+use base_precompile_storage::{BasePrecompileError, PrecompileResult, StorageCtx};
 
 use crate::{
     AssetAccounting, AssetCall, AssetVersion, AssetVersions, B20AssetStorage, B20AssetToken,

--- a/crates/common/precompiles/src/b20_factory/dispatch.rs
+++ b/crates/common/precompiles/src/b20_factory/dispatch.rs
@@ -8,8 +8,7 @@
 use alloy_primitives::{Address, Bytes, keccak256};
 use alloy_sol_types::{SolCall, SolValue};
 use base_common_genesis::BaseUpgrade;
-use base_precompile_storage::{BasePrecompileError, Result, StorageCtx};
-use base_precompile_storage::PrecompileResult;
+use base_precompile_storage::{BasePrecompileError, PrecompileResult, Result, StorageCtx};
 
 use crate::{
     B20FactoryStorage, B20Variant, BerylAuxiliaryMetrics, BerylCallRecorder, BerylMetricLabels,

--- a/crates/common/precompiles/src/b20_factory/dispatch.rs
+++ b/crates/common/precompiles/src/b20_factory/dispatch.rs
@@ -9,7 +9,7 @@ use alloy_primitives::{Address, Bytes, keccak256};
 use alloy_sol_types::{SolCall, SolValue};
 use base_common_genesis::BaseUpgrade;
 use base_precompile_storage::{BasePrecompileError, Result, StorageCtx};
-use revm::precompile::PrecompileResult;
+use base_precompile_storage::PrecompileResult;
 
 use crate::{
     B20FactoryStorage, B20Variant, BerylAuxiliaryMetrics, BerylCallRecorder, BerylMetricLabels,

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -12,7 +12,7 @@ use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_sol_types::{SolCall, SolInterface, SolValue};
 use base_common_genesis::BaseUpgrade;
 use base_precompile_storage::{BasePrecompileError, StorageCtx};
-use revm::precompile::PrecompileResult;
+use base_precompile_storage::PrecompileResult;
 
 use crate::{
     B20PolicyType, B20StablecoinToken, B20TokenRole, B20Variant, BerylCallRecorder,

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -11,8 +11,7 @@ use alloc::string::ToString;
 use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_sol_types::{SolCall, SolInterface, SolValue};
 use base_common_genesis::BaseUpgrade;
-use base_precompile_storage::{BasePrecompileError, StorageCtx};
-use base_precompile_storage::PrecompileResult;
+use base_precompile_storage::{BasePrecompileError, PrecompileResult, StorageCtx};
 
 use crate::{
     B20PolicyType, B20StablecoinToken, B20TokenRole, B20Variant, BerylCallRecorder,

--- a/crates/common/precompiles/src/macros.rs
+++ b/crates/common/precompiles/src/macros.rs
@@ -14,10 +14,12 @@ macro_rules! base_precompile {
             ::revm::precompile::PrecompileId::Custom($id.into()),
             move |input| {
                 if !input.is_direct_call() {
-                    return ::base_precompile_storage::BasePrecompileError::revert(
-                        ::base_precompile_storage::DelegateCallNotAllowed {},
-                    )
-                    .into_precompile_result(0, 0);
+                    return ::base_precompile_storage::IntoEnginePrecompileResult::into_revm(
+                        ::base_precompile_storage::BasePrecompileError::revert(
+                            ::base_precompile_storage::DelegateCallNotAllowed {},
+                        )
+                        .into_precompile_result(0, 0),
+                    );
                 }
 
                 let $calldata: ::alloy_primitives::Bytes = input.data.to_vec().into();
@@ -27,7 +29,9 @@ macro_rules! base_precompile {
                     $storage_features,
                 );
 
-                ::base_precompile_storage::StorageCtx::enter(&mut provider, |$ctx| $impl)
+                ::base_precompile_storage::IntoEnginePrecompileResult::into_revm(
+                    ::base_precompile_storage::StorageCtx::enter(&mut provider, |$ctx| $impl),
+                )
             },
         )
     }};

--- a/crates/common/precompiles/src/metrics.rs
+++ b/crates/common/precompiles/src/metrics.rs
@@ -6,8 +6,9 @@ use std::time::Instant;
 
 use alloy_primitives::Bytes;
 use alloy_sol_types::{SolCall, SolError};
-use base_precompile_storage::{BasePrecompileError, Result, StorageCtx};
-use revm::precompile::{PrecompileError, PrecompileOutput, PrecompileResult};
+use base_precompile_storage::{
+    BasePrecompileError, PrecompileError, PrecompileOutput, PrecompileResult, Result, StorageCtx,
+};
 
 use crate::{IActivationRegistry, IB20, IB20Asset, IB20Factory, IB20Stablecoin, IPolicyRegistry};
 
@@ -239,7 +240,7 @@ impl BerylErrorKind {
     /// Classifies a raw precompile error into a bounded metric label.
     pub const fn from_precompile_error(error: &PrecompileError) -> Self {
         match error {
-            PrecompileError::Fatal(_) | PrecompileError::FatalAny(_) => Self::Fatal,
+            PrecompileError::Fatal(_) => Self::Fatal,
         }
     }
 
@@ -657,7 +658,7 @@ impl BerylAuxiliaryMetrics {
 mod tests {
     use alloy_primitives::{Address, B256, U256};
     use alloy_sol_types::{SolCall, SolError};
-    use base_precompile_storage::BasePrecompileError;
+    use base_precompile_storage::{BasePrecompileError, PrecompileError, PrecompileOutput};
 
     use crate::{
         BerylCallOutcome, BerylCallRecorder, BerylErrorKind, BerylMetricLabels, BerylSelector,
@@ -730,9 +731,9 @@ mod tests {
 
     #[test]
     fn result_outcomes_are_classified() {
-        let success = Ok(revm::precompile::PrecompileOutput::new(1, Default::default(), 0));
-        let revert = Ok(revm::precompile::PrecompileOutput::revert(1, Default::default(), 0));
-        let fatal = Err(revm::precompile::PrecompileError::Fatal("boom".into()));
+        let success = Ok(PrecompileOutput::new(1, Default::default(), 0));
+        let revert = Ok(PrecompileOutput::revert(1, Default::default(), 0));
+        let fatal = Err(PrecompileError::Fatal("boom".into()));
 
         assert_eq!(BerylCallOutcome::from_result(&success), BerylCallOutcome::Success);
         assert_eq!(BerylCallOutcome::from_result(&revert), BerylCallOutcome::Revert);

--- a/crates/common/precompiles/src/nonce/dispatch.rs
+++ b/crates/common/precompiles/src/nonce/dispatch.rs
@@ -2,8 +2,9 @@
 
 use alloy_primitives::Bytes;
 use alloy_sol_types::SolCall;
-use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, StorageCtx};
-use base_precompile_storage::PrecompileResult;
+use base_precompile_storage::{
+    BasePrecompileError, IntoPrecompileResult, PrecompileResult, StorageCtx,
+};
 
 use crate::{
     INonceManager::{self, INonceManagerCalls as C},

--- a/crates/common/precompiles/src/nonce/dispatch.rs
+++ b/crates/common/precompiles/src/nonce/dispatch.rs
@@ -3,7 +3,7 @@
 use alloy_primitives::Bytes;
 use alloy_sol_types::SolCall;
 use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, StorageCtx};
-use revm::precompile::PrecompileResult;
+use base_precompile_storage::PrecompileResult;
 
 use crate::{
     INonceManager::{self, INonceManagerCalls as C},
@@ -66,7 +66,7 @@ mod tests {
     fn dispatch(
         storage: &mut HashMapStorageProvider,
         calldata: &[u8],
-    ) -> revm::precompile::PrecompileOutput {
+    ) -> base_precompile_storage::PrecompileOutput {
         StorageCtx::enter(storage, |ctx| NonceManagerStorage::new(ctx).dispatch(ctx, calldata))
             .expect("dispatch should not fail fatally")
     }

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -2,7 +2,7 @@ use alloy_primitives::{Bytes, U256};
 use alloy_sol_types::SolCall;
 use base_common_genesis::BaseUpgrade;
 use base_precompile_storage::{BasePrecompileError, StorageCtx};
-use revm::precompile::PrecompileResult;
+use base_precompile_storage::PrecompileResult;
 
 use crate::{
     ActivationFeature, ActivationRegistryStorage, BerylAuxiliaryMetrics, BerylCallRecorder,
@@ -207,8 +207,7 @@ mod tests {
     use alloy_primitives::{Address, Bytes, address};
     use alloy_sol_types::{SolCall, SolError, SolValue};
     use base_common_genesis::BaseUpgrade;
-    use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
-    use revm::precompile::PrecompileOutput;
+    use base_precompile_storage::{HashMapStorageProvider, PrecompileOutput, StorageCtx};
 
     use crate::{
         ActivationAdminConfig, ActivationFeature, ActivationRegistryStorage, BerylErrorKind,

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -1,8 +1,7 @@
 use alloy_primitives::{Bytes, U256};
 use alloy_sol_types::SolCall;
 use base_common_genesis::BaseUpgrade;
-use base_precompile_storage::{BasePrecompileError, StorageCtx};
-use base_precompile_storage::PrecompileResult;
+use base_precompile_storage::{BasePrecompileError, PrecompileResult, StorageCtx};
 
 use crate::{
     ActivationFeature, ActivationRegistryStorage, BerylAuxiliaryMetrics, BerylCallRecorder,

--- a/crates/common/precompiles/src/tx_context/dispatch.rs
+++ b/crates/common/precompiles/src/tx_context/dispatch.rs
@@ -2,8 +2,9 @@
 
 use alloy_primitives::Bytes;
 use alloy_sol_types::SolCall;
-use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, StorageCtx};
-use base_precompile_storage::PrecompileResult;
+use base_precompile_storage::{
+    BasePrecompileError, IntoPrecompileResult, PrecompileResult, StorageCtx,
+};
 
 use crate::{
     ITransactionContext::{self, ITransactionContextCalls as C},

--- a/crates/common/precompiles/src/tx_context/dispatch.rs
+++ b/crates/common/precompiles/src/tx_context/dispatch.rs
@@ -3,7 +3,7 @@
 use alloy_primitives::Bytes;
 use alloy_sol_types::SolCall;
 use base_precompile_storage::{BasePrecompileError, IntoPrecompileResult, StorageCtx};
-use revm::precompile::PrecompileResult;
+use base_precompile_storage::PrecompileResult;
 
 use crate::{
     ITransactionContext::{self, ITransactionContextCalls as C},


### PR DESCRIPTION
## Summary

Introduces base-owned equivalents of the revm precompile result types (`PrecompileResult`, `PrecompileOutput`, `PrecompileError`, `PrecompileHalt`, `PrecompileStatus`) and `AccountInfo`, each with a field-exact conversion to its revm counterpart, and rewrites the enshrined precompile logic and the `StorageCtx` result API to name these engine-neutral types instead of revm. The single base-to-revm conversion happens at the precompile dispatch boundary, so the crypto wrappers and the provider layer stay on revm unchanged. This change is behavior preserving and adds no new dependency, verified green by the full precompile and EIP-8130 test suites, and it shrinks the eventual EVM2 migration by letting the shared token logic compile against either execution engine. Bytecode neutralization is intentionally deferred to a follow-up because it carries EIP-7702 delegation semantics used by the EIP-8130 executor.