### PR TITLE
refactor(precompiles): Neutralize Bytecode Boundary Type

### DIFF
--- a/crates/common/evm/src/eip8130.rs
+++ b/crates/common/evm/src/eip8130.rs
@@ -56,7 +56,7 @@ use base_execution_eip8130::{
     DelegationEffect, FeeCheck, IntrinsicGas, IntrinsicGasInput, NonceMode, NonceValidator,
     TransactionAuthorizer,
 };
-use base_precompile_storage::{JournalStorageProvider, StorageCtx};
+use base_precompile_storage::{Bytecode as NeutralBytecode, JournalStorageProvider, StorageCtx};
 use revm::{
     Inspector,
     context::{BlockEnv, LocalContextTr, TxEnv, journaled_state::account::JournaledAccountTr},
@@ -1740,7 +1740,8 @@ impl Eip8130Executor {
         }
         let bytecode =
             Bytecode::new_raw_checked(code.clone()).map_err(BaseTransactionError::eip8130)?;
-        sctx.set_code(address, bytecode).map_err(BaseTransactionError::eip8130)
+        sctx.set_code(address, NeutralBytecode::from(&bytecode))
+            .map_err(BaseTransactionError::eip8130)
     }
 
     /// Auto-delegates a code-less sender to [`Eip8130Contracts::DEFAULT_ACCOUNT`]
@@ -1758,7 +1759,7 @@ impl Eip8130Executor {
             .map_err(BaseTransactionError::eip8130)?;
         if is_codeless {
             let target = Eip8130Contracts::DEFAULT_ACCOUNT;
-            sctx.set_code(sender, Bytecode::new_eip7702(target))
+            sctx.set_code(sender, NeutralBytecode::new_eip7702(target))
                 .map_err(BaseTransactionError::eip8130)?;
             // Same protocol-injected receipt log as an explicit delegation entry.
             AccountConfigurationEvents::emit_delegation_applied(sctx, sender, target)

--- a/crates/common/precompile-macros/src/layout.rs
+++ b/crates/common/precompile-macros/src/layout.rs
@@ -185,7 +185,7 @@ pub(crate) fn gen_constructor(
 
             #[inline(always)]
             fn __initialize(&mut self) -> ::base_precompile_storage::Result<()> {
-                let bytecode = ::revm::state::Bytecode::new_legacy(::alloy_primitives::Bytes::from_static(&[0xef]));
+                let bytecode = ::base_precompile_storage::Bytecode::new_legacy(::alloy_primitives::Bytes::from_static(&[0xef]));
                 self.storage.set_code(self.address, bytecode)?;
                 Ok(())
             }

--- a/crates/common/precompile-storage/src/lib.rs
+++ b/crates/common/precompile-storage/src/lib.rs
@@ -10,8 +10,8 @@ pub use error::{BasePrecompileError, DelegateCallNotAllowed, IntoPrecompileResul
 
 mod neutral;
 pub use neutral::{
-    AccountInfo, IntoEnginePrecompileResult, PrecompileError, PrecompileHalt, PrecompileOutput,
-    PrecompileResult, PrecompileStatus,
+    AccountInfo, Bytecode, IntoEnginePrecompileResult, PrecompileError, PrecompileHalt,
+    PrecompileOutput, PrecompileResult, PrecompileStatus,
 };
 
 mod packing;

--- a/crates/common/precompile-storage/src/neutral.rs
+++ b/crates/common/precompile-storage/src/neutral.rs
@@ -18,15 +18,89 @@
 use alloc::string::String;
 use core::result;
 
-use alloy_primitives::{B256, Bytes, U256};
+use alloy_primitives::{Address, B256, Bytes, U256};
 use revm::{
     precompile::{
         PrecompileError as RevmPrecompileError, PrecompileHalt as RevmPrecompileHalt,
         PrecompileOutput as RevmPrecompileOutput, PrecompileStatus as RevmPrecompileStatus,
     },
     primitives::KECCAK_EMPTY,
-    state::AccountInfo as RevmAccountInfo,
+    state::{AccountInfo as RevmAccountInfo, Bytecode as RevmBytecode},
 };
+
+/// Engine-neutral account bytecode.
+///
+/// Base-owned equivalent of the execution engine's bytecode type, covering the
+/// two representations Base writes and reads through `set_code` /
+/// `with_account_code`: legacy (analyzed) bytecode and EIP-7702 delegation
+/// designators. Conversions map one-to-one onto the corresponding `revm`
+/// constructors so neutralizing the callers is behavior preserving.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Bytecode {
+    /// Legacy bytecode, analyzed into a jump table on conversion to the engine type.
+    Legacy(Bytes),
+    /// EIP-7702 delegation designator pointing at the delegated address.
+    Eip7702(Address),
+}
+
+impl Default for Bytecode {
+    fn default() -> Self {
+        Self::Legacy(Bytes::new())
+    }
+}
+
+impl Bytecode {
+    /// Creates legacy bytecode from raw bytes.
+    pub const fn new_legacy(raw: Bytes) -> Self {
+        Self::Legacy(raw)
+    }
+
+    /// Creates an EIP-7702 delegation designator for `address`.
+    pub const fn new_eip7702(address: Address) -> Self {
+        Self::Eip7702(address)
+    }
+
+    /// Returns the EIP-7702 delegated address, if this is a delegation designator.
+    pub const fn eip7702_address(&self) -> Option<Address> {
+        match self {
+            Self::Eip7702(address) => Some(*address),
+            Self::Legacy(_) => None,
+        }
+    }
+
+    /// Returns whether the bytecode is empty.
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::Legacy(raw) => raw.is_empty(),
+            Self::Eip7702(_) => false,
+        }
+    }
+
+    /// Returns the original (unpadded) bytecode bytes.
+    pub fn original_bytes(&self) -> Bytes {
+        match self {
+            Self::Legacy(raw) => raw.clone(),
+            Self::Eip7702(address) => RevmBytecode::new_eip7702(*address).original_bytes(),
+        }
+    }
+}
+
+impl From<Bytecode> for RevmBytecode {
+    fn from(value: Bytecode) -> Self {
+        match value {
+            Bytecode::Legacy(raw) => Self::new_legacy(raw),
+            Bytecode::Eip7702(address) => Self::new_eip7702(address),
+        }
+    }
+}
+
+impl From<&RevmBytecode> for Bytecode {
+    fn from(value: &RevmBytecode) -> Self {
+        value
+            .eip7702_address()
+            .map_or_else(|| Self::Legacy(value.original_bytes()), Self::Eip7702)
+    }
+}
 
 /// Engine-neutral account information.
 ///
@@ -268,6 +342,23 @@ mod tests {
 
         let halt: RevmPrecompileOutput = PrecompileOutput::halt(PrecompileHalt::OutOfGas, 0).into();
         assert!(halt.is_halt());
+    }
+
+    #[test]
+    fn bytecode_conversions_are_faithful() {
+        let raw = Bytes::from_static(&[0x60, 0x00]);
+        let legacy: RevmBytecode = Bytecode::new_legacy(raw.clone()).into();
+        assert_eq!(legacy.original_bytes(), RevmBytecode::new_legacy(raw.clone()).original_bytes());
+        assert_eq!(Bytecode::from(&legacy), Bytecode::Legacy(raw));
+
+        let addr = Address::repeat_byte(0x11);
+        let delegation: RevmBytecode = Bytecode::new_eip7702(addr).into();
+        assert_eq!(delegation.eip7702_address(), Some(addr));
+        assert_eq!(Bytecode::from(&delegation), Bytecode::Eip7702(addr));
+        assert_eq!(Bytecode::new_eip7702(addr).eip7702_address(), Some(addr));
+
+        assert!(Bytecode::default().is_empty());
+        assert!(!Bytecode::new_eip7702(addr).is_empty());
     }
 
     #[test]

--- a/crates/common/precompile-storage/src/neutral.rs
+++ b/crates/common/precompile-storage/src/neutral.rs
@@ -80,7 +80,13 @@ impl Bytecode {
     pub fn original_bytes(&self) -> Bytes {
         match self {
             Self::Legacy(raw) => raw.clone(),
-            Self::Eip7702(address) => RevmBytecode::new_eip7702(*address).original_bytes(),
+            Self::Eip7702(address) => {
+                // EIP-7702 delegation designator: 0xEF0100 || 20-byte address.
+                let mut raw = [0u8; 23];
+                raw[..3].copy_from_slice(&[0xEF, 0x01, 0x00]);
+                raw[3..].copy_from_slice(address.as_slice());
+                Bytes::copy_from_slice(&raw)
+            }
         }
     }
 }

--- a/crates/common/precompile-storage/src/neutral.rs
+++ b/crates/common/precompile-storage/src/neutral.rs
@@ -102,9 +102,7 @@ impl From<Bytecode> for RevmBytecode {
 
 impl From<&RevmBytecode> for Bytecode {
     fn from(value: &RevmBytecode) -> Self {
-        value
-            .eip7702_address()
-            .map_or_else(|| Self::Legacy(value.original_bytes()), Self::Eip7702)
+        value.eip7702_address().map_or_else(|| Self::Legacy(value.original_bytes()), Self::Eip7702)
     }
 }
 

--- a/crates/common/precompile-storage/src/neutral.rs
+++ b/crates/common/precompile-storage/src/neutral.rs
@@ -101,6 +101,13 @@ impl From<Bytecode> for RevmBytecode {
 }
 
 impl From<&RevmBytecode> for Bytecode {
+    /// Converts a loaded engine bytecode into the neutral representation.
+    ///
+    /// revm's `BytecodeKind` has exactly two variants — `LegacyAnalyzed` and
+    /// `Eip7702` — so the non-delegation arm is always legacy, and folding it to
+    /// `Legacy(original_bytes())` is exact (there is no EOF variant to lose). If a
+    /// future engine adds more kinds, this fallback preserves the observable
+    /// surface Base reads (`original_bytes`, `is_empty`, `eip7702_address`).
     fn from(value: &RevmBytecode) -> Self {
         value.eip7702_address().map_or_else(|| Self::Legacy(value.original_bytes()), Self::Eip7702)
     }

--- a/crates/common/precompile-storage/src/storage_ctx.rs
+++ b/crates/common/precompile-storage/src/storage_ctx.rs
@@ -11,11 +11,11 @@ use core::{cell::RefCell, fmt};
 
 use alloy_primitives::{Address, B256, Bytes, LogData, U256};
 use alloy_sol_types::SolInterface;
-use revm::{context::journaled_state::JournalCheckpoint, state::Bytecode};
+use revm::context::journaled_state::JournalCheckpoint;
 
 use crate::{
     error::{BasePrecompileError, IntoPrecompileResult, Result},
-    neutral::{AccountInfo, PrecompileOutput, PrecompileResult},
+    neutral::{AccountInfo, Bytecode, PrecompileOutput, PrecompileResult},
     provider::{PrecompileStorageProvider, StorageFeatures},
 };
 
@@ -98,7 +98,8 @@ impl<'a> StorageCtx<'a> {
         let mut result: Option<Result<T>> = None;
         self.try_with_storage(|s| {
             s.with_account_code(address, &mut |code| {
-                result = Some(f(code));
+                let code = Bytecode::from(code);
+                result = Some(f(&code));
             })
         })?;
         result.unwrap_or_else(|| {
@@ -131,7 +132,7 @@ impl<'a> StorageCtx<'a> {
 
     /// Sets the bytecode at the given address.
     pub fn set_code(&self, address: Address, code: Bytecode) -> Result<()> {
-        self.try_with_storage(|s| s.set_code(address, code))
+        self.try_with_storage(|s| s.set_code(address, code.into()))
     }
 
     /// Performs an SLOAD (persistent storage read).

--- a/crates/common/precompiles/src/b20_factory/logic/v1.rs
+++ b/crates/common/precompiles/src/b20_factory/logic/v1.rs
@@ -6,7 +6,7 @@ use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_sol_types::{SolCall, SolEvent, SolValue};
 use base_common_genesis::BaseUpgrade;
 use base_precompile_storage::{BasePrecompileError, ContractStorage, Result};
-use revm::state::Bytecode;
+use base_precompile_storage::Bytecode;
 
 use crate::{
     ActivationRegistryStorage, AssetVersions, B20AssetInit, B20AssetStorage, B20AssetToken,

--- a/crates/common/precompiles/src/b20_factory/logic/v1.rs
+++ b/crates/common/precompiles/src/b20_factory/logic/v1.rs
@@ -5,8 +5,7 @@ use alloc::{string::ToString, vec::Vec};
 use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_sol_types::{SolCall, SolEvent, SolValue};
 use base_common_genesis::BaseUpgrade;
-use base_precompile_storage::{BasePrecompileError, ContractStorage, Result};
-use base_precompile_storage::Bytecode;
+use base_precompile_storage::{BasePrecompileError, Bytecode, ContractStorage, Result};
 
 use crate::{
     ActivationRegistryStorage, AssetVersions, B20AssetInit, B20AssetStorage, B20AssetToken,

--- a/crates/common/precompiles/src/b20_factory/storage.rs
+++ b/crates/common/precompiles/src/b20_factory/storage.rs
@@ -41,8 +41,7 @@ impl<'a> B20FactoryStorage<'a> {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Address, B256, Bytes, address, keccak256};
-    use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
-    use revm::state::Bytecode;
+    use base_precompile_storage::{Bytecode, HashMapStorageProvider, StorageCtx};
 
     use super::FACTORY_MARKER_CODE_HASH;
     use crate::{B20FactoryStorage, B20Variant};

--- a/crates/execution/eip8130/src/apply.rs
+++ b/crates/execution/eip8130/src/apply.rs
@@ -31,8 +31,7 @@ use base_common_consensus::{
     AccountChangeChannel, ChangeType, CreateEntry, Eip8130Constants, Eip8130Contracts,
     InitialActor, SignedChange,
 };
-use base_precompile_storage::{BasePrecompileError, StorageCtx};
-use revm::state::Bytecode;
+use base_precompile_storage::{BasePrecompileError, Bytecode, StorageCtx};
 
 use crate::{AccountConfigurationEvents, AccountConfigurationStorage, AccountState, ActorConfig};
 


### PR DESCRIPTION
## Summary

Adds a base-owned, EIP-7702-aware `Bytecode` type (legacy and delegation-designator variants) with field-exact conversions to and from revm, and switches the `StorageCtx` `set_code` and `with_account_code` API plus its enshrined-precompile and EIP-8130 callers to the neutral type. The deeply revm-coupled EIP-8130 executor keeps its own revm bytecode handling and converts only at the `StorageCtx` boundary, so behavior is preserved. This completes the precompile-boundary neutralization begun in the parent PR and is verified green by the EIP-8130 EIP-7702 delegation suite. Stacked on the precompile result and account type neutralization.