### PR TITLE
chore(toolchain): Bump Rust To 1.96

### DIFF
--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -32,7 +32,7 @@ jobs:
           # recorded in the result artifact and PR comment.
           - fork: Beryl
             key: beryl
-            base_anvil_ref: 8d0f5b8ae60edd30caa52609bc8677e0b631e2d7
+            base_anvil_ref: cecddfa558e5ed99db6fd836ab1c8cd0213dce26
             base_std_ref: v1.0.0
           - fork: Cobalt
             key: cobalt

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -36,7 +36,7 @@ jobs:
             base_std_ref: v1.0.0
           - fork: Cobalt
             key: cobalt
-            base_anvil_ref: 9df661bc39c6fb96ef28bfd5ff5d345931f133d3
+            base_anvil_ref: fb00db40ee7e12ba271b5b0b546af7a669b7075e
             base_std_ref: e30b34212689186b27acd3d340ba0d75d31495e9
     env:
       FORK_NAME: ${{ matrix.fork }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 version = "0.0.0"
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.96"
 license = "MIT"
 homepage = "https://github.com/base/base"
 repository = "https://github.com/base/base"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Summary

Bumps the pinned Rust toolchain from 1.95.0 to 1.96.0 in rust-toolchain.toml. This unblocks depending on crates that require Rust 1.96 or newer, notably the EVM2 engine we plan to integrate, and keeps the workspace on a current stable compiler. This is a toolchain pin bump only with no source changes; a full workspace build and clippy sweep on 1.96 is being validated in CI.