### PR TITLE
fix(tx-forwarding): Backport Batch Queued Forwarder Requests

### DIFF
--- a/crates/execution/tx-forwarding/README.md
+++ b/crates/execution/tx-forwarding/README.md
@@ -13,6 +13,8 @@ This crate provides:
 
 A slow builder backpressures only its own reader. Transactions are marked as recently sent only
 after that builder's queue accepts them, so another destination cannot suppress their delivery.
+Each forwarder sends an isolated request immediately, but drains any other requests already waiting
+for that destination into the same RPC batch up to the configured batch size.
 
 ## Forwarding without the pool
 

--- a/crates/execution/tx-forwarding/src/forwarder/config.rs
+++ b/crates/execution/tx-forwarding/src/forwarder/config.rs
@@ -6,9 +6,10 @@ use crate::config::{DEFAULT_MAX_BATCH_SIZE, DEFAULT_MAX_RPS};
 ///
 /// Each forwarder receives from its own queue and forwards transactions via
 /// `base_insertValidatedTransaction`.
-/// Under normal load, transactions are sent immediately (batch of 1). When the
-/// sliding window rate limit is hit, incoming transactions buffer and flush as
-/// a single batch once the window opens.
+/// An isolated request is sent immediately, but any other requests already
+/// waiting in the queue are drained into the same batch (capped at
+/// `max_batch_size`). When the sliding window rate limit is hit, incoming
+/// transactions buffer and flush as a single batch once the window opens.
 #[derive(Debug, Clone)]
 pub(crate) struct ForwarderConfig {
     /// Maximum RPC requests per second per forwarder (sliding window). 0 = unlimited.

--- a/crates/execution/tx-forwarding/src/forwarder/metrics.rs
+++ b/crates/execution/tx-forwarding/src/forwarder/metrics.rs
@@ -21,9 +21,15 @@ base_metrics::define_metrics! {
     #[describe("RPC round-trip latency in seconds (including retries)")]
     #[label(builder_url)]
     rpc_latency: histogram,
+    #[describe("Number of requests in each RPC batch")]
+    #[label(builder_url)]
+    batch_size: histogram,
     #[describe("Current number of transactions buffered and awaiting send")]
     #[label(builder_url)]
     buffer_size: gauge,
+    #[describe("Current number of transactions waiting in the destination channel")]
+    #[label(builder_url)]
+    queue_size: gauge,
 }
 
 impl ForwarderMetrics {

--- a/crates/execution/tx-forwarding/src/forwarder/task.rs
+++ b/crates/execution/tx-forwarding/src/forwarder/task.rs
@@ -529,6 +529,19 @@ mod tests {
         received.lock().unwrap().iter().map(|(_, params)| params.clone()).collect()
     }
 
+    /// Nonce of every recorded insert, in arrival order, recovered from the single `raw` byte
+    /// [`transaction`] encodes. Lets a `run`-driven test assert end-to-end delivery order without
+    /// observing internal batch boundaries the server never sees.
+    fn nonces(received: &Calls) -> Vec<u64> {
+        payloads(received)
+            .iter()
+            .map(|params| {
+                let raw = params["raw"].as_str().expect("raw hex string");
+                u64::from_str_radix(raw.trim_start_matches("0x"), 16).expect("single nonce byte")
+            })
+            .collect()
+    }
+
     fn forwarder<R: ForwardRequest>(
         url: url::Url,
         receiver: mpsc::Receiver<R>,
@@ -615,8 +628,12 @@ mod tests {
         assert_eq!(received.lock().unwrap().len(), 5);
     }
 
+    /// Focused unit test of `fill_buffer_from_queue`: a queue with more ready requests than
+    /// `max_batch_size` forms successive full batches (100, 100, 50), in submission order. The
+    /// server never sees batch boundaries, so this asserts them directly on the buffer; the
+    /// `run`-driven tests below cover the surrounding loop wiring end-to-end.
     #[tokio::test]
-    async fn ready_queue_is_drained_into_full_batches() {
+    async fn fill_buffer_from_queue_forms_capped_batches_in_order() {
         let (sender, receiver) = mpsc::channel(250);
         for nonce in 0..250 {
             sender.send(transaction::<NoExtensions>(nonce)).await.unwrap();
@@ -646,6 +663,53 @@ mod tests {
             hashes,
             (0..250).map(|nonce| B256::with_last_byte(nonce as u8)).collect::<Vec<_>>()
         );
+    }
+
+    /// The whole point of the change: an isolated request is forwarded without waiting to
+    /// accumulate a batch. The sender stays open, so the forwarder cannot be draining on shutdown;
+    /// if `run` blocked to fill a batch, the request would never arrive and the timeout would fire.
+    #[tokio::test]
+    async fn run_forwards_an_isolated_request_without_waiting() {
+        let (url, received, _server) = rpc_server().await;
+        let (sender, receiver) = mpsc::channel(8);
+        let forwarder =
+            forwarder::<InsertValidatedTransaction<NoExtensions>>(url, receiver, config(0, 100));
+        let task = tokio::spawn(forwarder.run());
+
+        sender.send(transaction(0)).await.unwrap();
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while received.lock().unwrap().is_empty() {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("isolated request was not forwarded promptly");
+
+        assert_eq!(nonces(&received), vec![0], "the lone request is sent on its own");
+
+        drop(sender);
+        task.await.unwrap();
+    }
+
+    /// End-to-end through `run`: a queue holding more than `max_batch_size` ready requests is
+    /// drained across successive batches and every request reaches the destination in submission
+    /// order. Exercises the real loop wiring — recv guard, queue drain, batch chunking, and the
+    /// final `flush_remaining` on channel close — that the focused unit test above bypasses.
+    #[tokio::test]
+    async fn run_batches_ready_requests_and_preserves_order() {
+        let (url, received, _server) = rpc_server().await;
+        let (sender, receiver) = mpsc::channel(250);
+        for nonce in 0..250 {
+            sender.send(transaction::<NoExtensions>(nonce)).await.unwrap();
+        }
+        drop(sender);
+
+        let forwarder =
+            forwarder::<InsertValidatedTransaction<NoExtensions>>(url, receiver, config(0, 100));
+        forwarder.run().await;
+
+        assert_eq!(nonces(&received), (0..250).collect::<Vec<_>>());
     }
 
     #[tokio::test]

--- a/crates/execution/tx-forwarding/src/forwarder/task.rs
+++ b/crates/execution/tx-forwarding/src/forwarder/task.rs
@@ -73,9 +73,10 @@ impl RateLimiter {
 /// Async forwarder task that receives requests from a destination queue and
 /// sends them to a single builder via RPC.
 ///
-/// Under normal load, each request is sent immediately as a batch of 1. When
-/// the sliding window rate limit (`max_rps`) is hit, incoming requests buffer
-/// and flush as a single batch (capped at `max_batch_size`) once the window
+/// Once one request is available, the forwarder drains all other immediately
+/// available requests into the same batch, capped at `max_batch_size`. This
+/// batches bursts without delaying an isolated request. If the sliding window
+/// rate limit (`max_rps`) is hit, requests continue buffering until the window
 /// opens.
 ///
 /// Requests are relayed in the order the queue yields them, and a batch
@@ -122,8 +123,19 @@ impl<R: ForwardRequest> DestinationForwarder<R> {
         );
 
         loop {
+            if self.buffer.is_empty() {
+                let request = self.receiver.recv().await;
+                if self.handle_recv(request) {
+                    break;
+                }
+            }
+
+            if self.fill_buffer_from_queue() {
+                break;
+            }
+
             match self.limiter.check_rate_limit() {
-                None if !self.buffer.is_empty() => {
+                None => {
                     self.flush_buffer().await;
                     continue;
                 }
@@ -143,20 +155,29 @@ impl<R: ForwardRequest> DestinationForwarder<R> {
                     }
                     continue;
                 }
-                _ => {}
-            }
-
-            let transaction = self.receiver.recv().await;
-            let closed = self.handle_recv(transaction);
-            if closed {
-                break;
-            }
-            if !self.buffer.is_empty() && self.limiter.check_rate_limit().is_none() {
-                self.flush_buffer().await;
             }
         }
 
         self.flush_remaining().await;
+    }
+
+    /// Fills the current batch from requests already waiting in the destination queue.
+    ///
+    /// Returns `true` when the queue is closed and all of its remaining requests are buffered.
+    fn fill_buffer_from_queue(&mut self) -> bool {
+        let mut closed = false;
+        while self.buffer.len() < self.buffer_limit {
+            match self.receiver.try_recv() {
+                Ok(request) => self.buffer.push(request),
+                Err(mpsc::error::TryRecvError::Empty) => break,
+                Err(mpsc::error::TryRecvError::Disconnected) => {
+                    closed = true;
+                    break;
+                }
+            }
+        }
+        self.update_pending_metrics();
+        closed
     }
 
     /// Returns `true` if the channel is closed and the forwarder should shut down.
@@ -164,11 +185,11 @@ impl<R: ForwardRequest> DestinationForwarder<R> {
         match request {
             Some(request) => {
                 self.buffer.push(request);
-                ForwarderMetrics::buffer_size(Arc::clone(&self.url_label))
-                    .set(self.buffer.len() as f64);
+                self.update_pending_metrics();
                 false
             }
             None => {
+                self.update_pending_metrics();
                 info!(
                     builder_url = %self.builder_url,
                     buffered = self.buffer.len(),
@@ -177,6 +198,11 @@ impl<R: ForwardRequest> DestinationForwarder<R> {
                 true
             }
         }
+    }
+
+    fn update_pending_metrics(&self) {
+        ForwarderMetrics::buffer_size(Arc::clone(&self.url_label)).set(self.buffer.len() as f64);
+        ForwarderMetrics::queue_size(Arc::clone(&self.url_label)).set(self.receiver.len() as f64);
     }
 
     async fn flush_remaining(&mut self) {
@@ -197,6 +223,8 @@ impl<R: ForwardRequest> DestinationForwarder<R> {
         if batch.is_empty() {
             return;
         }
+
+        ForwarderMetrics::batch_size(Arc::clone(&self.url_label)).record(batch.len() as f64);
 
         trace!(
             builder_url = %self.builder_url,
@@ -585,6 +613,39 @@ mod tests {
         forwarder.flush_buffer().await;
         assert!(forwarder.buffer.is_empty());
         assert_eq!(received.lock().unwrap().len(), 5);
+    }
+
+    #[tokio::test]
+    async fn ready_queue_is_drained_into_full_batches() {
+        let (sender, receiver) = mpsc::channel(250);
+        for nonce in 0..250 {
+            sender.send(transaction::<NoExtensions>(nonce)).await.unwrap();
+        }
+        drop(sender);
+
+        let url = url::Url::parse("http://builder.test").unwrap();
+        let mut forwarder = forwarder(url, receiver, config(0, 100));
+        let mut batch_sizes = Vec::new();
+        let mut hashes = Vec::new();
+
+        loop {
+            let request = forwarder.receiver.recv().await;
+            if forwarder.handle_recv(request) {
+                break;
+            }
+            let closed = forwarder.fill_buffer_from_queue();
+            batch_sizes.push(forwarder.buffer.len());
+            hashes.extend(forwarder.buffer.drain(..).map(|request| request.tx_hash));
+            if closed {
+                break;
+            }
+        }
+
+        assert_eq!(batch_sizes, [100, 100, 50]);
+        assert_eq!(
+            hashes,
+            (0..250).map(|nonce| B256::with_last_byte(nonce as u8)).collect::<Vec<_>>()
+        );
     }
 
     #[tokio::test]

--- a/crates/execution/tx-forwarding/src/forwarder/task.rs
+++ b/crates/execution/tx-forwarding/src/forwarder/task.rs
@@ -665,8 +665,8 @@ mod tests {
         );
     }
 
-    /// The whole point of the change: an isolated request is forwarded without waiting to
-    /// accumulate a batch. The sender stays open, so the forwarder cannot be draining on shutdown;
+    /// An isolated request is forwarded without waiting to accumulate a batch. The sender stays
+    /// open, so the forwarder cannot be draining on shutdown;
     /// if `run` blocked to fill a batch, the request would never arrive and the timeout would fire.
     #[tokio::test]
     async fn run_forwards_an_isolated_request_without_waiting() {


### PR DESCRIPTION
## Summary

Backports #4566 onto the releases/v1.3.0 branch. The destination forwarder now drains requests already waiting in each builder's independent queue into FIFO RPC batches up to the configured maximum, while isolated requests still send without intentional delay. This removes the singleton-RPC bottleneck that drove 10-20 second queue waits under validity traffic, and adds batch-size and queue-depth metrics. Unit tests cover 100/100/50 batch formation and ordering; patched three-builder devnet testing reduced sampled p99 queue wait to 87-112 ms. The existing four-second resend behavior is unchanged and can still generate already-imported responses for transactions that remain pending.

The three commits (excluding the intermediate `main` merge commit) cherry-picked cleanly onto the release branch, and `cargo test -p base-tx-forwarding` passes all 31 tests.

Note: #4566 is still open against `main` at the time this backport was opened.
