### PR TITLE
fix(eip8130): allow AuthorizeActor while locked when expiry outlives unlock

### DIFF
--- a/crates/execution/eip8130/src/account_config.rs
+++ b/crates/execution/eip8130/src/account_config.rs
@@ -95,20 +95,36 @@ impl AccountConfigurationStorage<'_> {
     /// Resolves the *live* effective [`ActorConfig`] for `(account, actor_id)`,
     /// mirroring `Keystore._resolveActorConfig`: expired actors read as
     /// [`ActorConfig::EMPTY`], so an expired slot is treated as a new add.
-    pub fn resolve_live_actor_config(
+    ///
+    /// The inline self is resolved against the supplied in-memory `state` rather
+    /// than persisted storage. A batch applier threads an evolving [`AccountState`]
+    /// whose inline self fields (`default_eoa_scope`/`default_eoa_expiry`/
+    /// `DEFAULT_EOA_REVOKED`) are flushed only at the end of the batch, so an
+    /// earlier op's inline-self rewrite is not yet in storage; resolving self from
+    /// storage would miss it and let a second self identity/scope rewrite slip past
+    /// a live-entry guard. The explicit `actor_config` slot (including a non-k1
+    /// self) is written eagerly, so it is still read from storage. Mirrors
+    /// `Keystore._resolveActorConfig`, whose reads see prior in-batch writes.
+    pub fn resolve_live_actor_config_with_state(
         &self,
         account: Address,
         actor_id: B256,
+        state: &AccountState,
         now: u64,
     ) -> Result<ActorConfig> {
-        let config = self.resolve_actor_config(account, actor_id)?;
-        if config.is_empty() {
-            return Ok(ActorConfig::EMPTY);
-        }
-        if config.expiry != 0 && now > config.expiry {
-            return Ok(ActorConfig::EMPTY);
-        }
-        Ok(config)
+        let stored = self.actor_config_slot(account, actor_id)?;
+        let config = if !stored.is_empty() {
+            stored
+        } else if actor_id == Self::self_actor_id(account) && !state.default_eoa_revoked() {
+            ActorConfig {
+                authenticator: Eip8130Constants::K1_AUTHENTICATOR,
+                scope: state.default_eoa_scope,
+                expiry: state.default_eoa_expiry,
+            }
+        } else {
+            ActorConfig::EMPTY
+        };
+        Ok(if config.is_expired(now) { ActorConfig::EMPTY } else { config })
     }
 
     /// Mirrors `AccountConfiguration.isActor`: `true` for any live actor — an
@@ -315,6 +331,15 @@ impl ActorConfig {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.authenticator == Address::ZERO
+    }
+
+    /// `true` when this config carries a bounded expiry (`expiry != 0`) that has
+    /// already lapsed at `now`. Mirrors `Keystore._isExpired`: the boundary is
+    /// strict (`now > expiry`), so a grant with `expiry == now` is still live for
+    /// that second. A zero expiry (no expiry) is never expired.
+    #[must_use]
+    pub const fn is_expired(&self, now: u64) -> bool {
+        self.expiry != 0 && now > self.expiry
     }
 
     /// Packs this config into its raw storage word — the exact inverse of

--- a/crates/execution/eip8130/src/account_config.rs
+++ b/crates/execution/eip8130/src/account_config.rs
@@ -92,6 +92,25 @@ impl AccountConfigurationStorage<'_> {
         Ok(ActorConfig::EMPTY)
     }
 
+    /// Resolves the *live* effective [`ActorConfig`] for `(account, actor_id)`,
+    /// mirroring `Keystore._resolveActorConfig`: expired actors read as
+    /// [`ActorConfig::EMPTY`], so an expired slot is treated as a new add.
+    pub fn resolve_live_actor_config(
+        &self,
+        account: Address,
+        actor_id: B256,
+        now: u64,
+    ) -> Result<ActorConfig> {
+        let config = self.resolve_actor_config(account, actor_id)?;
+        if config.is_empty() {
+            return Ok(ActorConfig::EMPTY);
+        }
+        if config.expiry != 0 && now > config.expiry {
+            return Ok(ActorConfig::EMPTY);
+        }
+        Ok(config)
+    }
+
     /// Mirrors `AccountConfiguration.isActor`: `true` for any live actor — an
     /// explicit `actor_config` entry, or the inline secp256k1 self while its
     /// `DEFAULT_EOA_REVOKED` flag is unset. Both cases collapse to "the resolved
@@ -430,10 +449,10 @@ impl AccountState {
         self.flags & Eip8130Constants::FLAG_CONTRACT_ESTABLISHED != 0
     }
 
-    /// Mirrors `AccountConfiguration._isLocked`: configuration is frozen while
-    /// `FLAG_LOCKED` is set, except once an unlock has been initiated
-    /// (`FLAG_UNLOCK_INITIATED`), when it stays frozen only until `now` reaches
-    /// the stored `unlocks_at` (`lock_union`).
+    /// Mirrors `AccountConfiguration._isLocked`: revoke and lock-delay changes are
+    /// frozen unless an initiated unlock's timestamp has elapsed; `AuthorizeActor`
+    /// may still add a new actor or re-lease a live one (expiry only) when the
+    /// granted expiry outlives the unlock floor.
     #[must_use]
     pub const fn is_locked(&self, now: u64) -> bool {
         if self.flags & Eip8130Constants::FLAG_LOCKED == 0 {
@@ -443,6 +462,19 @@ impl AccountState {
             return true; // hard-locked, no pending unlock
         }
         now < self.lock_union // pending unlock: frozen until the timestamp elapses
+    }
+
+    /// The soonest timestamp the account can be unlocked. Mirrors
+    /// `Keystore._unlockFloor`. Only meaningful while [`Self::is_locked`] is
+    /// `true`: hard-locked accounts use `now + delay`; pending unlock uses
+    /// `unlocks_at` (`lock_union`).
+    #[must_use]
+    pub const fn unlock_floor(&self, now: u64) -> u64 {
+        if self.flags & Eip8130Constants::FLAG_UNLOCK_INITIATED != 0 {
+            self.lock_union
+        } else {
+            now.saturating_add(self.lock_union & 0xFFFF)
+        }
     }
 
     /// Mirrors `AccountConfiguration.getLockStatus`, deriving the human-readable

--- a/crates/execution/eip8130/src/apply.rs
+++ b/crates/execution/eip8130/src/apply.rs
@@ -442,8 +442,11 @@ impl AccountChangeApplier {
                     // Applies one `AuthorizeActor` op: JIT expiry skip, locked-account
                     // policy, then `_authorizeActor`. Mirrors `Keystore._applyAuthorize`.
                     let (actor_id, config, policy_data) = Self::decode_authorize(&change.payload)?;
-                    // Replayable JIT path: drop an already-lapsed grant without reverting.
-                    if is_unsequenced && config.expiry != 0 && config.expiry <= now {
+                    // Replayable JIT path: drop an already-lapsed grant without
+                    // reverting. Uses the canonical `_isExpired` boundary (`now >
+                    // expiry`), so a grant with `expiry == now` is still live for
+                    // that second and installs rather than being dropped here.
+                    if is_unsequenced && config.is_expired(now) {
                         continue;
                     }
                     if locked {
@@ -595,7 +598,7 @@ impl AccountChangeApplier {
     /// Locked-account guard for `AuthorizeActor`. Mirrors `Keystore._applyAuthorize`'s
     /// `locked` block:
     ///
-    /// - **No live entry** ([`AccountConfigurationStorage::resolve_live_actor_config`]
+    /// - **No live entry** ([`AccountConfigurationStorage::resolve_live_actor_config_with_state`]
     ///   empty — unknown, revoked, disabled, or expired): a new add is allowed once
     ///   the grant's expiry outlives the unlock floor (`expiry == 0` always passes).
     /// - **Live entry** (slot populated and not expired): only an expiry rewrite is
@@ -615,7 +618,12 @@ impl AccountChangeApplier {
             return Err(ApplyError::ExpiryDoesNotOutliveUnlock);
         }
 
-        let current = storage.resolve_live_actor_config(account, actor_id, now)?;
+        // Resolve the current live config against the evolving in-batch `state`, not
+        // persisted storage: an earlier op's inline-self rewrite lands in `state`
+        // and is flushed only at batch end, so a storage read would miss it and let
+        // a second self identity/scope rewrite slip past the live-entry guard.
+        let current =
+            storage.resolve_live_actor_config_with_state(account, actor_id, state, now)?;
         if current.is_empty() {
             return Ok(());
         }
@@ -1289,6 +1297,40 @@ mod tests {
     }
 
     #[test]
+    fn locked_self_release_uses_evolving_state_within_batch() {
+        // Two AuthorizeActor ops on the inline self in one locked batch: the first
+        // is a fresh add (self starts revoked), the second rewrites the scope. The
+        // second must be rejected as a live-entry identity change — the applier
+        // resolves the self against the evolving in-batch `AccountState`, not the
+        // stale persisted slot, so an add-then-mutate cannot slip past the lock.
+        let now = 1_000u64;
+        let delay = 3_600u64;
+        let expiry = now + delay + 100; // outlives the hard-lock floor (now + delay)
+        let self_id = AccountConfigurationStorage::self_actor_id(ACCOUNT);
+        with_storage(|acc| {
+            // Locked with the inline self revoked, so the first op is a new add.
+            let mut state = acc.get_account_state(ACCOUNT).unwrap();
+            state.flags = Eip8130Constants::FLAG_LOCKED | Eip8130Constants::DEFAULT_EOA_REVOKED;
+            state.lock_union = delay;
+            acc.set_account_state(ACCOUNT, state).unwrap();
+
+            let add =
+                ActorConfig { authenticator: K1, scope: Eip8130Constants::SCOPE_SENDER, expiry };
+            let rescope = ActorConfig { authenticator: K1, scope: 0, expiry };
+            let err = AccountChangeApplier::apply_config_change(
+                acc,
+                ACCOUNT,
+                &[authorize_op(self_id, &add, &[]), authorize_op(self_id, &rescope, &[])],
+                AccountChangeChannel::Local,
+                0,
+                now,
+            )
+            .unwrap_err();
+            assert_eq!(err, ApplyError::AccountIsLocked);
+        });
+    }
+
+    #[test]
     fn locked_expired_actor_is_treated_as_new_add() {
         let now = 10_000u64;
         with_storage(|acc| {
@@ -1377,19 +1419,22 @@ mod tests {
             .unwrap();
             assert_eq!(acc.actor_config_slot(ACCOUNT, NON_SELF).unwrap(), unauthorized);
         });
-        // `expiry == now` is not strictly in the future, so it is skipped too.
+        // `expiry == now` is still live for that second (canonical `_isExpired`
+        // is strict, `now > expiry`), so the JIT grant installs rather than being
+        // dropped.
         with_storage(|acc| {
-            let at_now = [authorize_op(NON_SELF, &expiring(now), &[])];
+            let at_now = expiring(now);
+            let ops = [authorize_op(NON_SELF, &at_now, &[])];
             AccountChangeApplier::apply_config_change(
                 acc,
                 ACCOUNT,
-                &at_now,
+                &ops,
                 AccountChangeChannel::Local,
                 jit,
                 now,
             )
             .unwrap();
-            assert_eq!(acc.actor_config_slot(ACCOUNT, NON_SELF).unwrap(), unauthorized);
+            assert_eq!(acc.actor_config_slot(ACCOUNT, NON_SELF).unwrap(), at_now);
         });
     }
 

--- a/crates/execution/eip8130/src/apply.rs
+++ b/crates/execution/eip8130/src/apply.rs
@@ -439,16 +439,31 @@ impl AccountChangeApplier {
         for change in changes {
             match change.change_type {
                 ChangeType::AuthorizeActor => {
+                    // Applies one `AuthorizeActor` op: JIT expiry skip, locked-account
+                    // policy, then `_authorizeActor`. Mirrors `Keystore._applyAuthorize`.
                     let (actor_id, config, policy_data) = Self::decode_authorize(&change.payload)?;
-                    Self::apply_authorize_op(
+                    // Replayable JIT path: drop an already-lapsed grant without reverting.
+                    if is_unsequenced && config.expiry != 0 && config.expiry <= now {
+                        continue;
+                    }
+                    if locked {
+                        Self::enforce_locked_authorize_rules(
+                            storage,
+                            account,
+                            actor_id,
+                            &config,
+                            &policy_data,
+                            state,
+                            now,
+                        )?;
+                    }
+                    Self::authorize_actor_with_account_state(
                         storage,
                         account,
                         actor_id,
                         config,
                         &policy_data,
                         state,
-                        now,
-                        is_unsequenced,
                     )?;
                 }
                 ChangeType::RevokeActor => {
@@ -575,43 +590,6 @@ impl AccountChangeApplier {
             return Ok(());
         }
         Self::authorize_non_self_actor(storage, account, actor_id, config, policy_data)
-    }
-
-    /// Applies one `AuthorizeActor` op: JIT expiry skip, locked-account policy,
-    /// then `_authorizeActor`. Mirrors `Keystore._applyAuthorize`.
-    fn apply_authorize_op(
-        storage: &mut AccountConfigurationStorage<'_>,
-        account: Address,
-        actor_id: B256,
-        config: ActorConfig,
-        policy_data: &[u8],
-        state: &mut AccountState,
-        now: u64,
-        is_unsequenced: bool,
-    ) -> Result<(), ApplyError> {
-        // Replayable JIT path: drop an already-lapsed grant without reverting.
-        if is_unsequenced && config.expiry != 0 && config.expiry <= now {
-            return Ok(());
-        }
-        if state.is_locked(now) {
-            Self::enforce_locked_authorize_rules(
-                storage,
-                account,
-                actor_id,
-                &config,
-                policy_data,
-                state,
-                now,
-            )?;
-        }
-        Self::authorize_actor_with_account_state(
-            storage,
-            account,
-            actor_id,
-            config,
-            policy_data,
-            state,
-        )
     }
 
     /// Locked-account guard for `AuthorizeActor`. Mirrors `Keystore._applyAuthorize`'s
@@ -1314,20 +1292,10 @@ mod tests {
     fn locked_expired_actor_is_treated_as_new_add() {
         let now = 10_000u64;
         with_storage(|acc| {
-            AccountChangeApplier::authorize_actor(
-                acc,
-                ACCOUNT,
-                NON_SELF,
-                expiring(now - 1),
-                &[],
-            )
-            .unwrap();
+            AccountChangeApplier::authorize_actor(acc, ACCOUNT, NON_SELF, expiring(now - 1), &[])
+                .unwrap();
             set_hard_locked(acc, 3_600);
-            let replacement = ActorConfig {
-                authenticator: K1,
-                scope: 0,
-                expiry: now + 3_601,
-            };
+            let replacement = ActorConfig { authenticator: K1, scope: 0, expiry: now + 3_601 };
             AccountChangeApplier::apply_config_change(
                 acc,
                 ACCOUNT,

--- a/crates/execution/eip8130/src/apply.rs
+++ b/crates/execution/eip8130/src/apply.rs
@@ -440,32 +440,15 @@ impl AccountChangeApplier {
             match change.change_type {
                 ChangeType::AuthorizeActor => {
                     let (actor_id, config, policy_data) = Self::decode_authorize(&change.payload)?;
-                    // Skip an already-lapsed grant on the replayable JIT path
-                    // (per-change; live siblings still apply). A `0` clock disables
-                    // the skip via the `expiry != 0 && expiry <= 0` guard; both the
-                    // verifying and estimation pipelines pass the real block
-                    // timestamp so the skip is applied identically.
-                    if is_unsequenced && config.expiry != 0 && config.expiry <= now {
-                        continue;
-                    }
-                    if locked {
-                        Self::enforce_locked_authorize_rules(
-                            storage,
-                            account,
-                            actor_id,
-                            &config,
-                            &policy_data,
-                            state,
-                            now,
-                        )?;
-                    }
-                    Self::authorize_actor_with_account_state(
+                    Self::apply_authorize_op(
                         storage,
                         account,
                         actor_id,
                         config,
                         &policy_data,
                         state,
+                        now,
+                        is_unsequenced,
                     )?;
                 }
                 ChangeType::RevokeActor => {
@@ -594,9 +577,52 @@ impl AccountChangeApplier {
         Self::authorize_non_self_actor(storage, account, actor_id, config, policy_data)
     }
 
-    /// Locked-account guard for `AuthorizeActor`. The grant must outlive the unlock
-    /// floor; a live actor may only have its expiry rewritten — authenticator,
-    /// scope, and policy stay frozen. An unknown or expired actor id is a new add.
+    /// Applies one `AuthorizeActor` op: JIT expiry skip, locked-account policy,
+    /// then `_authorizeActor`. Mirrors `Keystore._applyAuthorize`.
+    fn apply_authorize_op(
+        storage: &mut AccountConfigurationStorage<'_>,
+        account: Address,
+        actor_id: B256,
+        config: ActorConfig,
+        policy_data: &[u8],
+        state: &mut AccountState,
+        now: u64,
+        is_unsequenced: bool,
+    ) -> Result<(), ApplyError> {
+        // Replayable JIT path: drop an already-lapsed grant without reverting.
+        if is_unsequenced && config.expiry != 0 && config.expiry <= now {
+            return Ok(());
+        }
+        if state.is_locked(now) {
+            Self::enforce_locked_authorize_rules(
+                storage,
+                account,
+                actor_id,
+                &config,
+                policy_data,
+                state,
+                now,
+            )?;
+        }
+        Self::authorize_actor_with_account_state(
+            storage,
+            account,
+            actor_id,
+            config,
+            policy_data,
+            state,
+        )
+    }
+
+    /// Locked-account guard for `AuthorizeActor`. Mirrors `Keystore._applyAuthorize`'s
+    /// `locked` block:
+    ///
+    /// - **No live entry** ([`AccountConfigurationStorage::resolve_live_actor_config`]
+    ///   empty — unknown, revoked, disabled, or expired): a new add is allowed once
+    ///   the grant's expiry outlives the unlock floor (`expiry == 0` always passes).
+    /// - **Live entry** (slot populated and not expired): only an expiry rewrite is
+    ///   allowed; authenticator, scope, and policy (manager + commitment) must match
+    ///   the stored values. The new expiry must still outlive the unlock floor.
     fn enforce_locked_authorize_rules(
         storage: &AccountConfigurationStorage<'_>,
         account: Address,
@@ -606,13 +632,16 @@ impl AccountChangeApplier {
         state: &AccountState,
         now: u64,
     ) -> Result<(), ApplyError> {
-        if config.expiry != 0 && config.expiry <= state.unlock_floor(now) {
+        let unlock_floor = state.unlock_floor(now);
+        if config.expiry != 0 && config.expiry <= unlock_floor {
             return Err(ApplyError::ExpiryDoesNotOutliveUnlock);
         }
+
         let current = storage.resolve_live_actor_config(account, actor_id, now)?;
         if current.is_empty() {
             return Ok(());
         }
+
         let (manager, commitment) = Self::slice_policy(config.scope, policy_data)?;
         if config.authenticator != current.authenticator
             || config.scope != current.scope
@@ -1309,6 +1338,54 @@ mod tests {
             )
             .unwrap();
             assert_eq!(acc.actor_config_slot(ACCOUNT, NON_SELF).unwrap(), replacement);
+        });
+    }
+
+    #[test]
+    fn locked_authorize_reverts_when_expiry_at_pending_unlock_floor() {
+        let now = 1_000u64;
+        let delay = 3_600u64;
+        with_storage(|acc| {
+            let mut state = acc.get_account_state(ACCOUNT).unwrap();
+            state.flags = Eip8130Constants::FLAG_LOCKED | Eip8130Constants::FLAG_UNLOCK_INITIATED;
+            state.lock_union = now + delay;
+            acc.set_account_state(ACCOUNT, state).unwrap();
+
+            let config = expiring(now + delay);
+            let err = AccountChangeApplier::apply_config_change(
+                acc,
+                ACCOUNT,
+                &[authorize_op(NON_SELF, &config, &[])],
+                AccountChangeChannel::Local,
+                0,
+                now,
+            )
+            .unwrap_err();
+            assert_eq!(err, ApplyError::ExpiryDoesNotOutliveUnlock);
+        });
+    }
+
+    #[test]
+    fn locked_authorize_succeeds_when_expiry_above_pending_unlock_floor() {
+        let now = 1_000u64;
+        let delay = 3_600u64;
+        with_storage(|acc| {
+            let mut state = acc.get_account_state(ACCOUNT).unwrap();
+            state.flags = Eip8130Constants::FLAG_LOCKED | Eip8130Constants::FLAG_UNLOCK_INITIATED;
+            state.lock_union = now + delay;
+            acc.set_account_state(ACCOUNT, state).unwrap();
+
+            let config = expiring(now + delay + 1);
+            AccountChangeApplier::apply_config_change(
+                acc,
+                ACCOUNT,
+                &[authorize_op(NON_SELF, &config, &[])],
+                AccountChangeChannel::Local,
+                0,
+                now,
+            )
+            .unwrap();
+            assert_eq!(acc.actor_config_slot(ACCOUNT, NON_SELF).unwrap(), config);
         });
     }
 

--- a/crates/execution/eip8130/src/apply.rs
+++ b/crates/execution/eip8130/src/apply.rs
@@ -85,6 +85,16 @@ pub enum ApplyError {
     #[error("unsupported account-change op in the enshrined apply path")]
     UnsupportedChangeType,
 
+    /// The operation is not permitted while the account is locked. Mirrors
+    /// `Keystore.AccountIsLocked`.
+    #[error("account is locked")]
+    AccountIsLocked,
+
+    /// An `AuthorizeActor` while locked carried an expiry that does not outlive
+    /// the unlock floor. Mirrors `Keystore.ExpiryDoesNotOutliveUnlock`.
+    #[error("authorize expiry does not outlive the unlock floor")]
+    ExpiryDoesNotOutliveUnlock,
+
     /// A signed batch carried no changes. Mirrors `applySignedAccountChanges`'s
     /// `revert EmptyChangeSet()`: an empty batch would otherwise consume (advance)
     /// a channel's sequence without altering any configuration. Rejected before
@@ -423,6 +433,7 @@ impl AccountChangeApplier {
         // retains an expired grant inert. Computed once for the whole batch.
         let is_unsequenced = matches!(channel, AccountChangeChannel::Local)
             && sequence as u32 == Eip8130Constants::UNSEQUENCED;
+        let locked = state.is_locked(now);
 
         let mut revoke_discount_slots = 0u32;
         for change in changes {
@@ -437,6 +448,17 @@ impl AccountChangeApplier {
                     if is_unsequenced && config.expiry != 0 && config.expiry <= now {
                         continue;
                     }
+                    if locked {
+                        Self::enforce_locked_authorize_rules(
+                            storage,
+                            account,
+                            actor_id,
+                            &config,
+                            &policy_data,
+                            state,
+                            now,
+                        )?;
+                    }
                     Self::authorize_actor_with_account_state(
                         storage,
                         account,
@@ -447,6 +469,9 @@ impl AccountChangeApplier {
                     )?;
                 }
                 ChangeType::RevokeActor => {
+                    if locked {
+                        return Err(ApplyError::AccountIsLocked);
+                    }
                     let actor_id = Self::decode_revoke(&change.payload)?;
                     revoke_discount_slots = revoke_discount_slots.saturating_add(
                         Self::revoke_actor_with_account_state(storage, account, actor_id, state)?,
@@ -567,6 +592,36 @@ impl AccountChangeApplier {
             return Ok(());
         }
         Self::authorize_non_self_actor(storage, account, actor_id, config, policy_data)
+    }
+
+    /// Locked-account guard for `AuthorizeActor`. The grant must outlive the unlock
+    /// floor; a live actor may only have its expiry rewritten — authenticator,
+    /// scope, and policy stay frozen. An unknown or expired actor id is a new add.
+    fn enforce_locked_authorize_rules(
+        storage: &AccountConfigurationStorage<'_>,
+        account: Address,
+        actor_id: B256,
+        config: &ActorConfig,
+        policy_data: &[u8],
+        state: &AccountState,
+        now: u64,
+    ) -> Result<(), ApplyError> {
+        if config.expiry != 0 && config.expiry <= state.unlock_floor(now) {
+            return Err(ApplyError::ExpiryDoesNotOutliveUnlock);
+        }
+        let current = storage.resolve_live_actor_config(account, actor_id, now)?;
+        if current.is_empty() {
+            return Ok(());
+        }
+        let (manager, commitment) = Self::slice_policy(config.scope, policy_data)?;
+        if config.authenticator != current.authenticator
+            || config.scope != current.scope
+            || manager != storage.get_policy_manager(account, actor_id)?
+            || commitment != storage.get_policy_commitment(account, actor_id)?
+        {
+            return Err(ApplyError::AccountIsLocked);
+        }
+        Ok(())
     }
 
     /// Authorizes an actor while applying inline-self changes to `state` without
@@ -1073,6 +1128,188 @@ mod tests {
 
     fn expiring(expiry: u64) -> ActorConfig {
         ActorConfig { authenticator: AUTHENTICATOR, scope: 0, expiry }
+    }
+
+    fn set_hard_locked(acc: &mut AccountConfigurationStorage<'_>, delay: u64) {
+        let mut state = acc.get_account_state(ACCOUNT).unwrap();
+        state.flags = Eip8130Constants::FLAG_LOCKED;
+        state.lock_union = delay;
+        acc.set_account_state(ACCOUNT, state).unwrap();
+    }
+
+    #[test]
+    fn locked_authorize_succeeds_when_expiry_outlives_hard_lock_floor() {
+        let now = 1_000u64;
+        let delay = 3_600u64;
+        with_storage(|acc| {
+            set_hard_locked(acc, delay);
+            let config = expiring(now + delay + 1);
+            AccountChangeApplier::apply_config_change(
+                acc,
+                ACCOUNT,
+                &[authorize_op(NON_SELF, &config, &[])],
+                AccountChangeChannel::Local,
+                0,
+                now,
+            )
+            .unwrap();
+            assert_eq!(acc.actor_config_slot(ACCOUNT, NON_SELF).unwrap(), config);
+        });
+    }
+
+    #[test]
+    fn locked_authorize_reverts_when_expiry_at_hard_lock_floor() {
+        let now = 1_000u64;
+        let delay = 3_600u64;
+        with_storage(|acc| {
+            set_hard_locked(acc, delay);
+            let config = expiring(now + delay);
+            let err = AccountChangeApplier::apply_config_change(
+                acc,
+                ACCOUNT,
+                &[authorize_op(NON_SELF, &config, &[])],
+                AccountChangeChannel::Local,
+                0,
+                now,
+            )
+            .unwrap_err();
+            assert_eq!(err, ApplyError::ExpiryDoesNotOutliveUnlock);
+        });
+    }
+
+    #[test]
+    fn locked_authorize_allows_unbounded_expiry() {
+        let now = 1_000u64;
+        with_storage(|acc| {
+            set_hard_locked(acc, 3_600);
+            let config = ungated(AUTHENTICATOR, Eip8130Constants::SCOPE_SENDER);
+            AccountChangeApplier::apply_config_change(
+                acc,
+                ACCOUNT,
+                &[authorize_op(NON_SELF, &config, &[])],
+                AccountChangeChannel::Local,
+                0,
+                now,
+            )
+            .unwrap();
+            assert_eq!(acc.actor_config_slot(ACCOUNT, NON_SELF).unwrap(), config);
+        });
+    }
+
+    #[test]
+    fn locked_revoke_is_rejected() {
+        let now = 1_000u64;
+        with_storage(|acc| {
+            AccountChangeApplier::authorize_actor(
+                acc,
+                ACCOUNT,
+                NON_SELF,
+                ungated(AUTHENTICATOR, Eip8130Constants::SCOPE_SENDER),
+                &[],
+            )
+            .unwrap();
+            set_hard_locked(acc, 3_600);
+            let err = AccountChangeApplier::apply_config_change(
+                acc,
+                ACCOUNT,
+                &[revoke_op(NON_SELF)],
+                AccountChangeChannel::Local,
+                0,
+                now,
+            )
+            .unwrap_err();
+            assert_eq!(err, ApplyError::AccountIsLocked);
+        });
+    }
+
+    #[test]
+    fn locked_reauthorize_allows_expiry_only_re_lease() {
+        let now = 1_000u64;
+        let delay = 3_600u64;
+        with_storage(|acc| {
+            AccountChangeApplier::authorize_actor(
+                acc,
+                ACCOUNT,
+                NON_SELF,
+                expiring(now + 86_400),
+                &[],
+            )
+            .unwrap();
+            set_hard_locked(acc, delay);
+            let shorter = expiring(now + delay + 1);
+            AccountChangeApplier::apply_config_change(
+                acc,
+                ACCOUNT,
+                &[authorize_op(NON_SELF, &shorter, &[])],
+                AccountChangeChannel::Local,
+                0,
+                now,
+            )
+            .unwrap();
+            assert_eq!(acc.actor_config_slot(ACCOUNT, NON_SELF).unwrap(), shorter);
+        });
+    }
+
+    #[test]
+    fn locked_reauthorize_rejects_scope_change() {
+        let now = 1_000u64;
+        with_storage(|acc| {
+            AccountChangeApplier::authorize_actor(
+                acc,
+                ACCOUNT,
+                NON_SELF,
+                expiring(now + 86_400),
+                &[],
+            )
+            .unwrap();
+            set_hard_locked(acc, 3_600);
+            let widened = ActorConfig {
+                authenticator: AUTHENTICATOR,
+                scope: Eip8130Constants::SCOPE_SENDER,
+                expiry: now + 86_400,
+            };
+            let err = AccountChangeApplier::apply_config_change(
+                acc,
+                ACCOUNT,
+                &[authorize_op(NON_SELF, &widened, &[])],
+                AccountChangeChannel::Local,
+                0,
+                now,
+            )
+            .unwrap_err();
+            assert_eq!(err, ApplyError::AccountIsLocked);
+        });
+    }
+
+    #[test]
+    fn locked_expired_actor_is_treated_as_new_add() {
+        let now = 10_000u64;
+        with_storage(|acc| {
+            AccountChangeApplier::authorize_actor(
+                acc,
+                ACCOUNT,
+                NON_SELF,
+                expiring(now - 1),
+                &[],
+            )
+            .unwrap();
+            set_hard_locked(acc, 3_600);
+            let replacement = ActorConfig {
+                authenticator: K1,
+                scope: 0,
+                expiry: now + 3_601,
+            };
+            AccountChangeApplier::apply_config_change(
+                acc,
+                ACCOUNT,
+                &[authorize_op(NON_SELF, &replacement, &[])],
+                AccountChangeChannel::Local,
+                0,
+                now,
+            )
+            .unwrap();
+            assert_eq!(acc.actor_config_slot(ACCOUNT, NON_SELF).unwrap(), replacement);
+        });
     }
 
     #[test]

--- a/crates/execution/eip8130/src/config.rs
+++ b/crates/execution/eip8130/src/config.rs
@@ -62,13 +62,15 @@ impl ConfigChangeAuthorizer {
     /// Authorizes a batch using an already-loaded packed account state for its
     /// lock, channel epoch/sequence gate, and inline-self authentication.
     ///
-    /// Enforces (in order): the account lock; the channel's epoch/sequence gate
+    /// Enforces (in order): the channel's epoch/sequence gate
     /// ([`AccountChangeChannel::Local`] splits `sequence` into
     /// `localEpoch(high) || localSequence(low)` with the
     /// [`Eip8130Constants::UNSEQUENCED`] JIT sentinel, while
     /// [`AccountChangeChannel::Multichain`] is a plain monotonic counter); the
     /// digest reconstruction and signature authentication; and the flat admin
-    /// (`scope == 0`) gate that governs every signed account change.
+    /// (`scope == 0`) gate that governs every signed account change. Per-op lock
+    /// policy (`AuthorizeActor` add/re-lease above the unlock floor;
+    /// `RevokeActor` rejected) is enforced in [`crate::AccountChangeApplier`].
     pub fn authorize_with_account_state(
         storage: &AccountConfigurationStorage<'_>,
         account: Address,
@@ -77,12 +79,6 @@ impl ConfigChangeAuthorizer {
         now: u64,
         state: &AccountState,
     ) -> Result<ResolvedActor, TxAuthError> {
-        // Locked accounts reject authority ops (`AccountIsLocked`). Lock/Unlock
-        // themselves are standalone and handled by their own apply preconditions.
-        if state.is_locked(now) {
-            return Err(TxAuthError::AccountLocked);
-        }
-
         Self::check_channel_sequence(change, state)?;
 
         // Reconstruct the digest, authenticate the signature, and require admin scope.
@@ -368,7 +364,7 @@ mod tests {
     }
 
     #[test]
-    fn locked_account_is_rejected() {
+    fn locked_account_batch_still_authorizes_signature() {
         let k = key(0x11);
         let account = addr(&k);
         let change =
@@ -379,10 +375,9 @@ mod tests {
                 .at_mut(&account)
                 .write(pack_state(0, 0, Eip8130Constants::FLAG_LOCKED, 0))
                 .unwrap();
-            assert_eq!(
-                ConfigChangeAuthorizer::authorize(acc, account, LOCAL, &change, NOW),
-                Err(TxAuthError::AccountLocked),
-            );
+            let resolved =
+                ConfigChangeAuthorizer::authorize(acc, account, LOCAL, &change, NOW).unwrap();
+            assert!(resolved.is_admin());
         });
     }
 

--- a/crates/execution/eip8130/src/tx_error.rs
+++ b/crates/execution/eip8130/src/tx_error.rs
@@ -34,9 +34,10 @@ pub enum TxAuthError {
         scope: u16,
     },
 
-    /// A config change or delegation targets a locked account. Both operations
-    /// are rejected while locked. Mirrors `AccountConfiguration`'s
-    /// `onlyUnlocked` modifier.
+    /// A config change or delegation targets a locked account in a way the
+    /// keystore rejects (`RevokeActor`, delegation). `AuthorizeActor` while locked
+    /// is permitted when the grant outlives the unlock floor; see
+    /// [`crate::AccountChangeApplier`]. Mirrors `Keystore.AccountIsLocked`.
     #[error("account is locked")]
     AccountLocked,
 

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -1554,6 +1554,10 @@ where
             ApplyError::InvalidChangePayload => "account-change op payload must be empty",
             ApplyError::EpochSaturated => "local epoch is saturated",
             ApplyError::UnsupportedChangeType => "unsupported account-change op",
+            ApplyError::AccountIsLocked => "account is locked",
+            ApplyError::ExpiryDoesNotOutliveUnlock => {
+                "authorize expiry does not outlive the unlock floor"
+            }
             ApplyError::InvalidActorId => "actor id bytes32(0) is reserved",
             ApplyError::InvalidAuthenticator => "actor authenticator is not canonical",
             ApplyError::MalformedPolicyData => "actor policy data is malformed",


### PR DESCRIPTION
## Summary
- Mirror [base/eip-8130#90](https://github.com/base/eip-8130/pull/90): while locked, `AuthorizeActor` is permitted for a new add or expiry-only re-lease when the granted expiry outlives the unlock floor (`now + delay` hard-locked, `unlocksAt` pending unlock; `expiry == 0` always passes).
- Live actors keep frozen authenticator/scope/policy under lock; `RevokeActor` and delegation still revert `AccountIsLocked`; grants at or below the unlock floor revert `ExpiryDoesNotOutliveUnlock`.
- Move lock enforcement from the config authorizer into the apply path so batch signature auth still runs while per-op lock policy is enforced at apply time.

## Test plan
- [x] `cargo test -p base-execution-eip8130` (202 tests)
- [x] Hard-locked: expiry at floor → `ExpiryDoesNotOutliveUnlock`; above floor / unbounded → lands
- [x] Locked re-lease: expiry-only succeeds; scope rewrite → `AccountIsLocked`
- [x] Locked revoke → `AccountIsLocked`; expired actor id treated as new add
- [x] Config authorizer still validates locked batch signatures (apply rejects revoke)