### PR TITLE
fix(eip8130): remove FLAG_CONTRACT_ESTABLISHED

### DIFF
--- a/crates/common/consensus/src/transaction/eip8130/constants.rs
+++ b/crates/common/consensus/src/transaction/eip8130/constants.rs
@@ -152,19 +152,6 @@ impl Eip8130Constants {
     /// is never a valid authenticator selector; addresses below this are reserved.
     pub const K1_AUTHENTICATOR: Address = address!("0x0000000000000000000000000000000000000001");
 
-    /// `AccountState.flags` bit (spec `CONTRACT_ESTABLISHED`): set on every
-    /// account the keystore establishes — `createAccount` (mirrored by the
-    /// node's create path) and `importAccount` — marking it
-    /// "keystore-established, not a proven address key."
-    ///
-    /// Permanent once set and never consulted during authentication. The protocol
-    /// reads it for code-delegation gating: an account may have **empty code yet
-    /// retain EIP-8130 state** (e.g. an EIP-6780 same-transaction `SELFDESTRUCT`),
-    /// so empty code alone must never be read as proof of a known EOA key. The
-    /// node therefore rejects a delegation onto an empty-code account that carries
-    /// this flag (it is not a proven-key EOA and must not be re-delegated as one).
-    pub const FLAG_CONTRACT_ESTABLISHED: u8 = 0x01;
-
     /// `AccountState.flags` bit that disables the implicit default-EOA path.
     ///
     /// The implicit default EOA is a [`Self::K1_AUTHENTICATOR`] signature whose
@@ -173,21 +160,21 @@ impl Eip8130Constants {
     /// `createAccount`/`importAccount` (disabled by default), and by authorizing
     /// or revoking the self-actor; once set it is never cleared (monotonic), so
     /// an explicit self-actor entry always implies the flag is set.
-    pub const DEFAULT_EOA_REVOKED: u8 = 0x02;
+    pub const DEFAULT_EOA_REVOKED: u8 = 0x01;
 
     /// `AccountState.flags` bit (spec `LOCKED`): when set, actor configuration is
     /// frozen — every config change and delegation is rejected on both the native
     /// and EVM paths. The only permitted operation is `applySignedLockChanges`'s
     /// unlock op. Set/cleared exclusively through the EVM `applySignedLockChanges`
     /// entry point.
-    pub const FLAG_LOCKED: u8 = 0x04;
+    pub const FLAG_LOCKED: u8 = 0x02;
 
     /// `AccountState.flags` bit (spec `UNLOCK_INITIATED`): selects how the packed
     /// `lock_union` field is interpreted. While clear, `lock_union` holds the
     /// configured `unlock_delay` (seconds, `uint16` range); while set, it holds
     /// `unlocks_at` (the timestamp at which the pending unlock takes effect). Only
     /// meaningful when [`Self::FLAG_LOCKED`] is set.
-    pub const FLAG_UNLOCK_INITIATED: u8 = 0x08;
+    pub const FLAG_UNLOCK_INITIATED: u8 = 0x04;
 
     /// Exact byte length of a policy-bearing actor's `policyData`:
     /// `manager (20) || commitment (32)`. Required when `scope & SCOPE_POLICY`

--- a/crates/common/evm/src/eip8130.rs
+++ b/crates/common/evm/src/eip8130.rs
@@ -1757,20 +1757,6 @@ impl Eip8130Executor {
             .with_account_info(sender, |info| Ok(info.is_empty_code_hash()))
             .map_err(BaseTransactionError::eip8130)?;
         if is_codeless {
-            // Same guard as an explicit delegation's `DelegationEffect::install`:
-            // empty code on a keystore-established account (e.g. an imported
-            // account whose delegation was later cleared, or an EIP-6780
-            // same-transaction `SELFDESTRUCT`) is not proof of a key-backed EOA,
-            // so it must not be auto-delegated to `DEFAULT_ACCOUNT` as if it were
-            // one. Fail closed, mirroring `ApplyError::ContractEstablishedCodeless`.
-            let contract_established = AccountConfigurationStorage::new(sctx)
-                .is_contract_established(sender)
-                .map_err(BaseTransactionError::eip8130)?;
-            if contract_established {
-                return Err(BaseTransactionError::eip8130(
-                    ApplyError::ContractEstablishedCodeless { account: sender },
-                ));
-            }
             let target = Eip8130Contracts::DEFAULT_ACCOUNT;
             sctx.set_code(sender, Bytecode::new_eip7702(target))
                 .map_err(BaseTransactionError::eip8130)?;
@@ -2039,33 +2025,32 @@ mod tests {
     }
 
     #[test]
-    fn auto_delegate_skips_contract_established_codeless_sender() {
-        // Auto-delegation carries the same `FLAG_CONTRACT_ESTABLISHED` guard as an
-        // explicit `DelegationEffect::install`: a plain codeless EOA is delegated
-        // to `DEFAULT_ACCOUNT`, but a keystore-established codeless account (e.g.
-        // an imported account whose delegation was cleared) must fail closed.
+    fn auto_delegate_codeless_sender_delegates_to_default_account() {
+        // A codeless sender is auto-delegated to `DEFAULT_ACCOUNT` so it can
+        // dispatch its calls; a sender that already has code is left untouched.
         let plain = address!("0x00000000000000000000000000000000000000c1");
-        let established = address!("0x00000000000000000000000000000000000000c2");
+        let coded = address!("0x00000000000000000000000000000000000000c2");
         let mut provider = HashMapStorageProvider::new(CHAIN_ID);
         StorageCtx::enter(&mut provider, |ctx| {
-            // A non-established codeless sender is auto-delegated.
             assert!(
                 Eip8130Executor::auto_delegate_codeless_sender(ctx, plain).unwrap(),
-                "plain codeless EOA must be auto-delegated"
+                "codeless EOA must be auto-delegated"
             );
-
-            // Mark a codeless account keystore-established: auto-delegation must
-            // reject it rather than resurrect it as a DEFAULT_ACCOUNT delegate.
-            let mut acc = AccountConfigurationStorage::new(ctx);
-            let mut state = acc.get_account_state(established).unwrap();
-            state.flags = Eip8130Constants::FLAG_CONTRACT_ESTABLISHED;
-            acc.set_account_state(established, state).unwrap();
-            let err = Eip8130Executor::auto_delegate_codeless_sender(ctx, established).unwrap_err();
+            ctx.set_code(coded, Bytecode::new_raw(Bytes::from_static(&[0x60, 0x00]))).unwrap();
             assert!(
-                err.to_string().contains("contract-established"),
-                "expected ContractEstablishedCodeless, got: {err}"
+                !Eip8130Executor::auto_delegate_codeless_sender(ctx, coded).unwrap(),
+                "a sender with code must not be auto-delegated"
             );
         });
+
+        assert_eq!(
+            provider
+                .get_account_info(plain)
+                .and_then(|info| info.code.as_ref())
+                .and_then(Bytecode::eip7702_address),
+            Some(Eip8130Contracts::DEFAULT_ACCOUNT),
+            "codeless sender must delegate to DEFAULT_ACCOUNT"
+        );
     }
 
     #[test]

--- a/crates/execution/eip8130/src/account_config.rs
+++ b/crates/execution/eip8130/src/account_config.rs
@@ -183,13 +183,6 @@ impl AccountConfigurationStorage<'_> {
         Ok(self.get_account_state(account)?.is_locked(now))
     }
 
-    /// Mirrors `AccountConfiguration.isContractEstablished`: `true` once the
-    /// account has been keystore-established (create/import). Used to gate code
-    /// delegation onto an empty-code account (see [`crate::DelegationEffect`]).
-    pub fn is_contract_established(&self, account: Address) -> Result<bool> {
-        Ok(self.get_account_state(account)?.contract_established())
-    }
-
     /// Mirrors `AccountConfiguration.getLockStatus`.
     pub fn get_lock_status(&self, account: Address, now: u64) -> Result<LockStatus> {
         Ok(self.get_account_state(account)?.lock_status(now))
@@ -364,12 +357,9 @@ pub struct AccountState {
     /// value also marks the account initialized.
     pub local_epoch: u64,
     /// Account flags bitfield: bit 0
-    /// ([`Eip8130Constants::FLAG_CONTRACT_ESTABLISHED`]) marks a
-    /// keystore-established account (create/import) that must not be treated as a
-    /// proven-key EOA even when its code is empty; bit 1
     /// ([`Eip8130Constants::DEFAULT_EOA_REVOKED`]) disables the inline secp256k1
-    /// self key; bit 2 ([`Eip8130Constants::FLAG_LOCKED`]) freezes actor
-    /// configuration; bit 3 ([`Eip8130Constants::FLAG_UNLOCK_INITIATED`]) selects
+    /// self key; bit 1 ([`Eip8130Constants::FLAG_LOCKED`]) freezes actor
+    /// configuration; bit 2 ([`Eip8130Constants::FLAG_UNLOCK_INITIATED`]) selects
     /// the `lock_union` interpretation.
     pub flags: u8,
     /// `uint48` lock union: `unlock_delay` (seconds) while `FLAG_UNLOCK_INITIATED`
@@ -420,14 +410,6 @@ impl AccountState {
     #[must_use]
     pub const fn default_eoa_revoked(&self) -> bool {
         self.flags & Eip8130Constants::DEFAULT_EOA_REVOKED != 0
-    }
-
-    /// `true` when this account was keystore-established (create/import) and so
-    /// must not be treated as a proven-key EOA — even with empty code. Mirrors
-    /// `Keystore.isContractEstablished` (the `FLAG_CONTRACT_ESTABLISHED` bit).
-    #[must_use]
-    pub const fn contract_established(&self) -> bool {
-        self.flags & Eip8130Constants::FLAG_CONTRACT_ESTABLISHED != 0
     }
 
     /// Mirrors `AccountConfiguration._isLocked`: configuration is frozen while

--- a/crates/execution/eip8130/src/apply.rs
+++ b/crates/execution/eip8130/src/apply.rs
@@ -205,18 +205,6 @@ pub enum ApplyError {
         account: Address,
     },
 
-    /// A delegation targeted an empty-code account that is
-    /// [`Eip8130Constants::FLAG_CONTRACT_ESTABLISHED`]. Empty code on a
-    /// keystore-established account (e.g. after an EIP-6780 same-transaction
-    /// `SELFDESTRUCT`) is not proof of a key-backed EOA, so it must not be
-    /// (re)delegated as if it were one — doing so would resurrect a CREATE2
-    /// address that no private key controls.
-    #[error("delegation cannot target empty-code contract-established account {account}")]
-    ContractEstablishedCodeless {
-        /// The keystore-established account whose empty code cannot be delegated.
-        account: Address,
-    },
-
     /// A channel sequence would overflow `u64`.
     #[error("account-change sequence overflow")]
     SequenceOverflow,
@@ -267,23 +255,11 @@ impl DelegationEffect {
     /// contract bytecode is left unchanged and rejected with
     /// [`ApplyError::NonDelegatableCode`].
     pub fn install(&self, sctx: StorageCtx<'_>) -> Result<(), ApplyError> {
-        let (can_replace, code_is_empty) = sctx.with_account_code(self.account, |code| {
-            let bytes = code.original_bytes();
-            let slice = bytes.as_ref();
-            Ok((Self::can_replace_code(slice), slice.is_empty()))
+        let can_replace = sctx.with_account_code(self.account, |code| {
+            Ok(Self::can_replace_code(code.original_bytes().as_ref()))
         })?;
         if !can_replace {
             return Err(ApplyError::NonDelegatableCode { account: self.account });
-        }
-
-        // Empty code on a keystore-established account is not proof of a key-backed
-        // EOA (e.g. an EIP-6780 same-transaction SELFDESTRUCT leaves EIP-8130 state
-        // behind empty code), so it must not be (re)delegated as if it were one.
-        // Reading the AccountConfiguration flag mirrors `Keystore.isContractEstablished`.
-        if code_is_empty
-            && AccountConfigurationStorage::new(sctx).is_contract_established(self.account)?
-        {
-            return Err(ApplyError::ContractEstablishedCodeless { account: self.account });
         }
 
         let code = if self.target.is_zero() {
@@ -796,17 +772,13 @@ impl AccountChangeApplier {
             return Err(ApplyError::AlreadyCreated { account: address });
         }
 
-        // Mark initialized, disable the implicit default-EOA path by default
+        // Mark initialized and disable the implicit default-EOA path by default
         // (a created account has contract code, so the recovered==account path is
-        // unreachable), and flag the account keystore-established so a later empty-
-        // code state (e.g. an EIP-6780 SELFDESTRUCT) is never mistaken for a
-        // proven-key EOA. Mirrors `createAccount`'s
-        // `flags = FLAG_REVOKE_DEFAULT_EOA | FLAG_CONTRACT_ESTABLISHED`. Written
-        // before initializing actors so a self-actorId k1 initial actor can
+        // unreachable). Mirrors `createAccount`'s `flags = FLAG_REVOKE_DEFAULT_EOA`.
+        // Written before initializing actors so a self-actorId k1 initial actor can
         // re-enable the inline self.
         state.local_sequence = 1;
-        state.flags =
-            Eip8130Constants::DEFAULT_EOA_REVOKED | Eip8130Constants::FLAG_CONTRACT_ESTABLISHED;
+        state.flags = Eip8130Constants::DEFAULT_EOA_REVOKED;
         storage.set_account_state(address, state)?;
 
         Self::initialize_actors(storage, address, &entry.initial_actors)?;
@@ -1007,7 +979,7 @@ impl AccountChangeApplier {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{LogData, U256, address, b256};
+    use alloy_primitives::{LogData, address, b256};
     use alloy_sol_types::SolEvent;
     use base_precompile_storage::{HashMapStorageProvider, PrecompileStorageProvider, StorageCtx};
     use revm::state::Bytecode;
@@ -2046,22 +2018,10 @@ mod tests {
         );
     }
 
-    /// Marks `account` keystore-established (`FLAG_CONTRACT_ESTABLISHED`) in the
-    /// `AccountConfiguration` storage, leaving every other state field zero.
-    fn mark_contract_established(storage: &mut HashMapStorageProvider) {
-        StorageCtx::enter(storage, |sctx| {
-            let mut cfg = AccountConfigurationStorage::new(sctx);
-            let mut state = AccountState::from_word(U256::ZERO);
-            state.flags = Eip8130Constants::FLAG_CONTRACT_ESTABLISHED;
-            cfg.set_account_state(ACCOUNT, state).unwrap();
-        });
-    }
-
     #[test]
-    fn apply_create_flags_account_contract_established() {
-        // A created account is marked keystore-established so a later empty-code
-        // state can never be mistaken for a proven-key EOA. Mirrors
-        // `createAccount`'s `FLAG_REVOKE_DEFAULT_EOA | FLAG_CONTRACT_ESTABLISHED`.
+    fn apply_create_flags_revokes_default_eoa() {
+        // A created account disables the implicit default-EOA path. Mirrors
+        // `createAccount`'s `flags = FLAG_REVOKE_DEFAULT_EOA`.
         let signer = address!("0x00000000000000000000000000000000000000a1");
         let actor_id = AccountConfigurationStorage::self_actor_id(signer);
         let entry = CreateEntry {
@@ -2072,39 +2032,14 @@ mod tests {
         with_storage(|acc| {
             let created = AccountChangeApplier::apply_create(acc, &entry).unwrap();
             let state = acc.get_account_state(created.address).unwrap();
-            assert!(state.contract_established(), "create must set FLAG_CONTRACT_ESTABLISHED");
-            assert!(state.default_eoa_revoked(), "create must still revoke the default EOA");
+            assert!(state.default_eoa_revoked(), "create must revoke the default EOA");
         });
     }
 
     #[test]
-    fn delegation_effect_install_rejects_empty_code_contract_established_account() {
-        // Empty code on a keystore-established account is a self-destructed CREATE2
-        // account, not a proven-key EOA — a delegation onto it is rejected.
-        let target = Address::repeat_byte(0x55);
-        let mut storage = HashMapStorageProvider::new(1);
-        mark_contract_established(&mut storage);
-
-        let error = StorageCtx::enter(&mut storage, |sctx| {
-            DelegationEffect::new(ACCOUNT, target).install(sctx)
-        })
-        .unwrap_err();
-
-        assert_eq!(error, ApplyError::ContractEstablishedCodeless { account: ACCOUNT });
-        // No delegation code was written.
-        assert!(
-            storage
-                .get_account_info(ACCOUNT)
-                .and_then(|info| info.code.as_ref())
-                .and_then(Bytecode::eip7702_address)
-                .is_none()
-        );
-    }
-
-    #[test]
-    fn delegation_effect_install_allows_empty_code_non_established_account() {
-        // A genuine (non-established) empty-code EOA may still be delegated: the
-        // guard only fires for keystore-established accounts.
+    fn delegation_effect_install_allows_empty_code_account() {
+        // An empty-code account may be delegated: the only code-shape guard is
+        // that ordinary contract bytecode is rejected.
         let target = Address::repeat_byte(0x56);
         let mut storage = HashMapStorageProvider::new(1);
 
@@ -2123,13 +2058,11 @@ mod tests {
     }
 
     #[test]
-    fn delegation_effect_install_allows_redelegation_of_established_delegate() {
-        // An established account that already carries a delegation indicator
-        // (e.g. an imported 7702 delegate — genuinely once an EOA) may be
-        // re-delegated: the codeless guard is scoped to *empty* code only.
+    fn delegation_effect_install_allows_redelegation_of_existing_delegate() {
+        // An account that already carries a delegation indicator may be
+        // re-delegated: existing delegation code is replaceable.
         let target = Address::repeat_byte(0x57);
         let mut storage = HashMapStorageProvider::new(1);
-        mark_contract_established(&mut storage);
         storage.set_code(ACCOUNT, Bytecode::new_eip7702(Address::repeat_byte(0x11))).unwrap();
 
         StorageCtx::enter(&mut storage, |sctx| {

--- a/crates/execution/eip8130/src/transaction.rs
+++ b/crates/execution/eip8130/src/transaction.rs
@@ -211,14 +211,9 @@ impl TransactionAuthorizer {
     /// [`DelegationEffect::can_replace_code`], enforced when
     /// [`DelegationEffect::install`] runs in both the mempool overlay and block
     /// execution (ordinary contract code is rejected with
-    /// [`ApplyError::NonDelegatableCode`]). `install` additionally rejects a
-    /// delegation onto an **empty-code, keystore-established** account
-    /// (`FLAG_CONTRACT_ESTABLISHED`) with
-    /// [`ApplyError::ContractEstablishedCodeless`]: empty code there is a
-    /// self-destructed CREATE2 account, not a proven-key EOA, so it must not be
-    /// re-delegated. Allowing any admin actor here is therefore safe: an admin key
-    /// can only (re)delegate a genuinely EOA-shaped account, never repoint a
-    /// deployed smart account's code nor resurrect a keystore-established one.
+    /// [`ApplyError::NonDelegatableCode`]). Allowing any admin actor here is
+    /// therefore safe: an admin key can only (re)delegate a genuinely EOA-shaped
+    /// account, never repoint a deployed smart account's code.
     ///
     /// [`DelegationEffect::can_replace_code`]: crate::DelegationEffect::can_replace_code
     /// [`DelegationEffect::install`]: crate::DelegationEffect::install

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -1572,9 +1572,6 @@ where
             ApplyError::MultipleDelegations => "at most one delegation is allowed",
             ApplyError::CreateAndDelegation => "create and delegation may not coexist",
             ApplyError::NonDelegatableCode { .. } => "delegation sender has non-delegation code",
-            ApplyError::ContractEstablishedCodeless { .. } => {
-                "delegation target is an empty-code keystore-established account"
-            }
             ApplyError::SequenceOverflow => "config change sequence overflow",
             ApplyError::EmptyChangeSet => "signed account-change batch is empty",
         }


### PR DESCRIPTION
## Summary
Mirrors keystore [base/eip-8130#92](https://github.com/base/eip-8130/pull/92), which removes `FLAG_CONTRACT_ESTABLISHED` / `isContractEstablished` from the Keystore and restores the original flag layout.

- Drop `FLAG_CONTRACT_ESTABLISHED` (was `0x01`) and shift the remaining flags down to match the keystore: `DEFAULT_EOA_REVOKED` `0x01`, `FLAG_LOCKED` `0x02`, `FLAG_UNLOCK_INITIATED` `0x04`.
- The node's create path now sets only `DEFAULT_EOA_REVOKED` (mirrors `createAccount`'s `flags = FLAG_REVOKE_DEFAULT_EOA`).
- Remove `AccountState::contract_established()` and `AccountConfigurationStorage::is_contract_established()`.

## Behavioral note
Removing the flag also removes the node-only `ApplyError::ContractEstablishedCodeless` delegation guard. Previously an empty-code, keystore-established account (e.g. a self-destructed CREATE2 account) was rejected from both explicit delegation (`DelegationEffect::install`) and auto-delegation (`auto_delegate_codeless_sender`). With the flag gone there is no state to distinguish such an account from a plain EOA, so these accounts are now delegatable like any other empty-code account — consistent with the keystore dropping the distinction. Ordinary contract bytecode is still rejected via `NonDelegatableCode`.

## Test plan
- [x] `cargo test -p base-execution-eip8130 -p base-execution-txpool -p base-common-evm`
- [x] `cargo clippy` (per-crate) + `cargo fmt --check` on touched crates
- [ ] Confirm the EIP-8130 account-state flag table matches (no `CONTRACT_ESTABLISHED` bit; `DEFAULT_EOA_REVOKED` at `0x01`)