### PR TITLE
fix(flashblocks): recover pending state at canonical tip

### DIFF
--- a/crates/common/flashblocks/src/block.rs
+++ b/crates/common/flashblocks/src/block.rs
@@ -1,6 +1,6 @@
 //! Contains the [`Flashblock`] type used in Flashblocks.
 
-use std::io::Read;
+use std::{io::Read, mem::size_of};
 
 use alloy_rpc_types_engine::PayloadId;
 use bytes::Bytes;
@@ -40,13 +40,41 @@ impl Flashblock {
         let metadata: Metadata = serde_json::from_value(payload.metadata.clone())
             .map_err(FlashblockDecodeError::MetadataParse)?;
 
-        Ok(Self {
+        let flashblock = Self {
             payload_id: payload.payload_id,
             index: payload.index,
             base: payload.base,
             diff: payload.diff,
             metadata,
-        })
+        };
+        let retained_bytes = flashblock.estimated_retained_bytes();
+        if retained_bytes > MAX_DECOMPRESSED_FLASHBLOCK_BYTES {
+            return Err(FlashblockDecodeError::PayloadTooLarge {
+                given: retained_bytes,
+                max: MAX_DECOMPRESSED_FLASHBLOCK_BYTES,
+            });
+        }
+
+        Ok(flashblock)
+    }
+
+    /// Estimates heap and inline bytes retained by this decoded flashblock.
+    pub fn estimated_retained_bytes(&self) -> usize {
+        let base_bytes = self.base.as_ref().map_or(0, |base| base.extra_data.len());
+        let transaction_bytes = self.diff.transactions.iter().fold(0usize, |total, transaction| {
+            total
+                .saturating_add(size_of::<alloy_primitives::Bytes>())
+                .saturating_add(transaction.len())
+        });
+        size_of::<Self>()
+            .saturating_add(base_bytes)
+            .saturating_add(transaction_bytes)
+            .saturating_add(
+                self.diff
+                    .withdrawals
+                    .len()
+                    .saturating_mul(size_of::<alloy_rpc_types_eth::Withdrawal>()),
+            )
     }
 
     fn try_parse_message(bytes: Bytes) -> Result<String, FlashblockDecodeError> {

--- a/crates/common/flashblocks/src/block.rs
+++ b/crates/common/flashblocks/src/block.rs
@@ -47,7 +47,23 @@ impl Flashblock {
             diff: payload.diff,
             metadata,
         };
-        let retained_bytes = flashblock.estimated_retained_bytes();
+        let base_bytes = flashblock.base.as_ref().map_or(0, |base| base.extra_data.len());
+        let transaction_bytes =
+            flashblock.diff.transactions.iter().fold(0usize, |total, transaction| {
+                total
+                    .saturating_add(size_of::<alloy_primitives::Bytes>())
+                    .saturating_add(transaction.len())
+            });
+        let retained_bytes = size_of::<Self>()
+            .saturating_add(base_bytes)
+            .saturating_add(transaction_bytes)
+            .saturating_add(
+                flashblock
+                    .diff
+                    .withdrawals
+                    .len()
+                    .saturating_mul(size_of::<alloy_rpc_types_eth::Withdrawal>()),
+            );
         if retained_bytes > MAX_DECOMPRESSED_FLASHBLOCK_BYTES {
             return Err(FlashblockDecodeError::PayloadTooLarge {
                 given: retained_bytes,
@@ -56,25 +72,6 @@ impl Flashblock {
         }
 
         Ok(flashblock)
-    }
-
-    /// Estimates heap and inline bytes retained by this decoded flashblock.
-    pub fn estimated_retained_bytes(&self) -> usize {
-        let base_bytes = self.base.as_ref().map_or(0, |base| base.extra_data.len());
-        let transaction_bytes = self.diff.transactions.iter().fold(0usize, |total, transaction| {
-            total
-                .saturating_add(size_of::<alloy_primitives::Bytes>())
-                .saturating_add(transaction.len())
-        });
-        size_of::<Self>()
-            .saturating_add(base_bytes)
-            .saturating_add(transaction_bytes)
-            .saturating_add(
-                self.diff
-                    .withdrawals
-                    .len()
-                    .saturating_mul(size_of::<alloy_rpc_types_eth::Withdrawal>()),
-            )
     }
 
     fn try_parse_message(bytes: Bytes) -> Result<String, FlashblockDecodeError> {

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -174,7 +174,12 @@ pub struct RpcStandardNodeArgs {
     #[arg(long, alias = "websocket-url")]
     pub flashblocks_url: Option<Url>,
 
-    /// The max pending blocks depth.
+    /// Maximum number of pending blocks retained ahead of the canonical tip.
+    ///
+    /// Counts canonical block numbers, not flashblock messages. Pending that
+    /// is not based on the current tip, or that extends more than this many
+    /// blocks beyond it, is cleared until a matching index-0 flashblock
+    /// arrives.
     #[arg(
         long = "max-pending-blocks-depth",
         value_name = "MAX_PENDING_BLOCKS_DEPTH",

--- a/crates/execution/flashblocks-node/Cargo.toml
+++ b/crates/execution/flashblocks-node/Cargo.toml
@@ -17,8 +17,8 @@ base-flashblocks.workspace = true
 base-node-runner.workspace = true
 
 # reth
+reth-provider.workspace = true
 reth-chain-state.workspace = true
-reth-provider = { workspace = true, optional = true }
 reth-chainspec = { workspace = true, optional = true }
 reth-primitives-traits = { workspace = true, optional = true }
 base-execution-chainspec = { workspace = true, optional = true }
@@ -114,7 +114,6 @@ test-utils = [
 	"dep:eyre",
 	"dep:reth-chainspec",
 	"dep:reth-primitives-traits",
-	"dep:reth-provider",
 	"dep:reth-transaction-pool",
 	"reth-chain-state/test-utils",
 	"reth-chainspec/test-utils",

--- a/crates/execution/flashblocks-node/README.md
+++ b/crates/execution/flashblocks-node/README.md
@@ -36,7 +36,7 @@ If Flashblocks should be disabled, install the extension with `None` or skip ins
 When running the node binary, Flashblocks can be configured with the following CLI arguments:
 
 - `--flashblocks-url <WEBSOCKET_URL>`: The WebSocket URL to stream flashblock updates from (required to enable Flashblocks; `--websocket-url` is accepted as an alias)
-- `--max-pending-blocks-depth <MAX_PENDING_BLOCKS_DEPTH>`: Maximum number of pending flashblocks to retain in memory (default: 3)
+- `--max-pending-blocks-depth <MAX_PENDING_BLOCKS_DEPTH>`: Maximum number of pending **blocks** retained ahead of the canonical tip (default: `3`). This is not a flashblock-message count. If pending is not based on the current tip, or that depth is exceeded, the snapshot is cleared until an index-0 flashblock rooted at the tip arrives.
 - `--flashblocks.cached-execution`: Enable cached execution through the flashblocks-aware engine validator
 
 ### Example

--- a/crates/execution/flashblocks-node/src/extension.rs
+++ b/crates/execution/flashblocks-node/src/extension.rs
@@ -1,7 +1,7 @@
 //! Contains the [`FlashblocksExtension`] which wires up the flashblocks feature
 //! (canonical block subscription and RPC surface) on the Base node builder.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use base_flashblocks::{
     EthApiExt, EthApiOverrideServer, EthPubSub, EthPubSubApiServer, FlashblocksConfig,
@@ -10,6 +10,7 @@ use base_flashblocks::{
 use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
 use reth_chain_state::CanonStateSubscriptions;
 use reth_provider::{BlockNumReader, BlockReader, TransactionVariant};
+use tokio::time::{MissedTickBehavior, interval};
 use tokio_stream::{
     StreamExt,
     wrappers::{BroadcastStream, errors::BroadcastStreamRecvError},
@@ -59,20 +60,35 @@ impl BaseNodeExtension for FlashblocksExtension {
             let mut canonical_stream =
                 BroadcastStream::new(provider.subscribe_to_canonical_state());
             tokio::spawn(async move {
-                while let Some(result) = canonical_stream.next().await {
-                    match result {
-                        Ok(notification) => {
-                            let committed = notification.committed();
-                            for block in committed.blocks_iter() {
-                                state_for_canonical
-                                    .on_canonical_block_received(block.as_ref().clone());
+                let mut needs_resync = false;
+                let mut resync_interval = interval(Duration::from_millis(100));
+                resync_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+                loop {
+                    tokio::select! {
+                        result = canonical_stream.next() => {
+                            let Some(result) = result else {
+                                warn!("canonical state subscription closed");
+                                break;
+                            };
+                            match result {
+                                Ok(notification) => {
+                                    needs_resync = false;
+                                    let committed = notification.committed();
+                                    for block in committed.blocks_iter() {
+                                        state_for_canonical
+                                            .on_canonical_block_received(block.as_ref().clone());
+                                    }
+                                }
+                                Err(BroadcastStreamRecvError::Lagged(skipped)) => {
+                                    needs_resync = true;
+                                    warn!(
+                                        skipped,
+                                        "canonical state subscription lagged; resynchronizing from provider"
+                                    );
+                                }
                             }
                         }
-                        Err(BroadcastStreamRecvError::Lagged(skipped)) => {
-                            warn!(
-                                skipped,
-                                "canonical state subscription lagged; resynchronizing from provider"
-                            );
+                        _ = resync_interval.tick(), if needs_resync => {
                             let latest = provider.best_block_number().ok().and_then(|number| {
                                 provider
                                     .recovered_block(number.into(), TransactionVariant::WithHash)
@@ -81,13 +97,11 @@ impl BaseNodeExtension for FlashblocksExtension {
                             });
                             if let Some(block) = latest {
                                 state_for_canonical.on_canonical_block_received(block);
-                            } else {
-                                warn!("canonical state subscription could not load provider tip");
+                                needs_resync = false;
                             }
                         }
                     }
                 }
-                warn!("canonical state subscription closed");
             });
 
             Ok(())

--- a/crates/execution/flashblocks-node/src/extension.rs
+++ b/crates/execution/flashblocks-node/src/extension.rs
@@ -9,8 +9,12 @@ use base_flashblocks::{
 };
 use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
 use reth_chain_state::CanonStateSubscriptions;
-use tokio_stream::{StreamExt, wrappers::BroadcastStream};
-use tracing::info;
+use reth_provider::{BlockNumReader, BlockReader, TransactionVariant};
+use tokio_stream::{
+    StreamExt,
+    wrappers::{BroadcastStream, errors::BroadcastStreamRecvError},
+};
+use tracing::{info, warn};
 
 /// Helper struct that wires the Flashblocks feature (canonical subscription and RPC) into the node builder.
 #[derive(Debug)]
@@ -51,15 +55,39 @@ impl BaseNodeExtension for FlashblocksExtension {
             state_for_start.start(ctx.provider().clone());
             subscriber.start();
 
+            let provider = ctx.provider().clone();
             let mut canonical_stream =
-                BroadcastStream::new(ctx.provider().subscribe_to_canonical_state());
+                BroadcastStream::new(provider.subscribe_to_canonical_state());
             tokio::spawn(async move {
-                while let Some(Ok(notification)) = canonical_stream.next().await {
-                    let committed = notification.committed();
-                    for block in committed.blocks_iter() {
-                        state_for_canonical.on_canonical_block_received(block.as_ref().clone());
+                while let Some(result) = canonical_stream.next().await {
+                    match result {
+                        Ok(notification) => {
+                            let committed = notification.committed();
+                            for block in committed.blocks_iter() {
+                                state_for_canonical
+                                    .on_canonical_block_received(block.as_ref().clone());
+                            }
+                        }
+                        Err(BroadcastStreamRecvError::Lagged(skipped)) => {
+                            warn!(
+                                skipped,
+                                "canonical state subscription lagged; resynchronizing from provider"
+                            );
+                            let latest = provider.best_block_number().ok().and_then(|number| {
+                                provider
+                                    .recovered_block(number.into(), TransactionVariant::WithHash)
+                                    .ok()
+                                    .flatten()
+                            });
+                            if let Some(block) = latest {
+                                state_for_canonical.on_canonical_block_received(block);
+                            } else {
+                                warn!("canonical state subscription could not load provider tip");
+                            }
+                        }
                     }
                 }
+                warn!("canonical state subscription closed");
             });
 
             Ok(())

--- a/crates/execution/flashblocks-node/src/extension.rs
+++ b/crates/execution/flashblocks-node/src/extension.rs
@@ -74,9 +74,14 @@ impl BaseNodeExtension for FlashblocksExtension {
                                 Ok(notification) => {
                                     needs_resync = false;
                                     let committed = notification.committed();
+                                    let mut forwarded = false;
                                     for block in committed.blocks_iter() {
+                                        forwarded = true;
                                         state_for_canonical
                                             .on_canonical_block_received(block.as_ref().clone());
+                                    }
+                                    if !forwarded {
+                                        needs_resync = true;
                                     }
                                 }
                                 Err(BroadcastStreamRecvError::Lagged(skipped)) => {

--- a/crates/execution/flashblocks-node/src/test_harness.rs
+++ b/crates/execution/flashblocks-node/src/test_harness.rs
@@ -620,6 +620,9 @@ impl<'a> FlashblockBuilder<'a> {
         if self.auto_deposit {
             transactions.insert(0, build_unique_deposit_tx(canonical_block_num));
         }
+        let mut block_hash = [0; 32];
+        block_hash[16..24].copy_from_slice(&canonical_block_num.to_be_bytes());
+        block_hash[24..].copy_from_slice(&self.index.to_be_bytes());
 
         Flashblock {
             payload_id: PayloadId::new(canonical_block_num.to_be_bytes()),
@@ -628,7 +631,7 @@ impl<'a> FlashblockBuilder<'a> {
             diff: ExecutionPayloadFlashblockDeltaV1 {
                 state_root: B256::default(),
                 receipts_root: B256::default(),
-                block_hash: B256::random(),
+                block_hash: B256::from(block_hash),
                 gas_used: 0,
                 withdrawals: Vec::new(),
                 logs_bloom: Default::default(),

--- a/crates/execution/flashblocks-node/src/test_harness.rs
+++ b/crates/execution/flashblocks-node/src/test_harness.rs
@@ -588,13 +588,22 @@ impl<'a> FlashblockBuilder<'a> {
         let current_block = self.harness.node.latest_block();
         let canonical_block_num =
             self.canonical_block_number.unwrap_or_else(|| current_block.number) + 1;
+        let pending = self.harness.flashblocks.get_pending_blocks();
+        let parent_hash = pending
+            .as_ref()
+            .filter(|pending| {
+                pending.is_based_on_canonical(current_block.number, current_block.hash())
+                    && pending.latest_block_number().saturating_add(1) == canonical_block_num
+            })
+            .map(|pending| pending.latest_block_hash())
+            .unwrap_or_else(|| current_block.hash());
 
         let base = if self.index == 0 {
             Some(ExecutionPayloadBaseV1 {
                 parent_beacon_block_root: current_block
                     .parent_beacon_block_root()
                     .unwrap_or_default(),
-                parent_hash: current_block.hash(),
+                parent_hash,
                 fee_recipient: Address::random(),
                 prev_randao: B256::random(),
                 block_number: canonical_block_num,
@@ -613,13 +622,13 @@ impl<'a> FlashblockBuilder<'a> {
         }
 
         Flashblock {
-            payload_id: PayloadId::default(),
+            payload_id: PayloadId::new(canonical_block_num.to_be_bytes()),
             index: self.index,
             base,
             diff: ExecutionPayloadFlashblockDeltaV1 {
                 state_root: B256::default(),
                 receipts_root: B256::default(),
-                block_hash: B256::default(),
+                block_hash: B256::random(),
                 gas_used: 0,
                 withdrawals: Vec::new(),
                 logs_bloom: Default::default(),

--- a/crates/execution/flashblocks-node/tests/eip7702_tests.rs
+++ b/crates/execution/flashblocks-node/tests/eip7702_tests.rs
@@ -126,7 +126,7 @@ fn create_base_flashblock(setup: &TestSetup) -> Flashblock {
         index: 0,
         base: Some(ExecutionPayloadBaseV1 {
             parent_beacon_block_root: B256::default(),
-            parent_hash: B256::default(),
+            parent_hash: setup.harness.latest_block().hash(),
             fee_recipient: Address::ZERO,
             prev_randao: B256::default(),
             block_number: 1,

--- a/crates/execution/flashblocks-node/tests/eth_call_erc20.rs
+++ b/crates/execution/flashblocks-node/tests/eth_call_erc20.rs
@@ -76,7 +76,7 @@ impl Erc20TestSetup {
             index: 0,
             base: Some(ExecutionPayloadBaseV1 {
                 parent_beacon_block_root: B256::default(),
-                parent_hash: B256::default(),
+                parent_hash: self.harness.latest_block().hash(),
                 fee_recipient: Address::ZERO,
                 prev_randao: B256::default(),
                 block_number: 1,

--- a/crates/execution/flashblocks-node/tests/flashblocks_rpc.rs
+++ b/crates/execution/flashblocks-node/tests/flashblocks_rpc.rs
@@ -538,12 +538,13 @@ async fn test_blockhash_dependent_transaction_receipt_pending() -> Result<()> {
     let block_two_fb_base = FlashblockBuilder::new_base(&builder_setup).build();
     let block_two_fb_one = FlashblockBuilder::new(&builder_setup, 1).build();
     let block_two_fb_two = FlashblockBuilder::new(&builder_setup, 2).build();
+    let block_two_transactions = block_two_fb_base.diff.transactions.clone();
     client_setup.send_flashblock(block_two_fb_base.clone()).await;
     client_setup.send_flashblock(block_two_fb_one).await;
     client_setup.send_flashblock(block_two_fb_two).await;
     builder_setup
         .node
-        .build_block_from_transactions(block_two_fb_base.diff.transactions)
+        .build_block_from_transactions(block_two_transactions.clone())
         .await
         .expect("able to build canon block 2");
     let canon_block_two = builder_setup
@@ -554,9 +555,7 @@ async fn test_blockhash_dependent_transaction_receipt_pending() -> Result<()> {
         .try_into_recovered()
         .expect("able to recover block 2");
 
-    // Step 3. Builder builds flashblocks for block 3
-    // that contain a call to the contract
-    // It is processed by client before client has canon block 2
+    // Step 3. Builder builds flashblocks for block 3 that contain a call to the contract.
     let guard = ParentBlockhashGuardInstance::new(guard_address, builder_provider.clone());
     let txn = TransactionBuilder::default()
         .signer(Account::Deployer.signer_b256())
@@ -572,8 +571,21 @@ async fn test_blockhash_dependent_transaction_receipt_pending() -> Result<()> {
         .unwrap()
         .clone();
     let flashblock = FlashblockBuilder::new_base(&builder_setup).build();
+    client_setup
+        .node
+        .build_block_from_transactions(block_two_transactions)
+        .await
+        .expect("able to build client canon block 2");
+    let client_canon_block_two = client_setup
+        .provider
+        .block(BlockHashOrNumber::Number(2))
+        .expect("able to load client block 2")
+        .expect("client block 2 should be available")
+        .try_into_recovered()
+        .expect("able to recover client block 2");
+    assert_eq!(client_canon_block_two.hash(), canon_block_two.hash());
+    client_setup.flashblocks.on_canonical_block_received(client_canon_block_two);
     client_setup.send_flashblock(flashblock).await;
-    client_setup.flashblocks.on_canonical_block_received(canon_block_two);
     let flashblock = FlashblockBuilder::new(&builder_setup, 1)
         .with_transactions(vec![BaseTransactionSigned::Eip1559(txn.clone())])
         .build();

--- a/crates/execution/flashblocks-node/tests/flashblocks_rpc.rs
+++ b/crates/execution/flashblocks-node/tests/flashblocks_rpc.rs
@@ -281,7 +281,7 @@ impl TestSetup {
             index: 0,
             base: Some(ExecutionPayloadBaseV1 {
                 parent_beacon_block_root: TEST_PARENT_BEACON_BLOCK_ROOT,
-                parent_hash: B256::default(),
+                parent_hash: self.harness.latest_block().hash(),
                 fee_recipient: Address::ZERO,
                 prev_randao: B256::default(),
                 block_number: 1,

--- a/crates/execution/flashblocks-node/tests/state.rs
+++ b/crates/execution/flashblocks-node/tests/state.rs
@@ -10,7 +10,8 @@ use base_common_flashblocks::{
     ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, Flashblock, Metadata,
 };
 use base_flashblocks::{
-    FlashblocksAPI, FlashblocksReceiver, PendingBlocks, PendingBlocksAPI, PendingBlocksBuilder,
+    FlashblocksAPI, FlashblocksReceiver, MAX_FLASHBLOCKS_PER_PAYLOAD, PendingBlocks,
+    PendingBlocksAPI, PendingBlocksBuilder,
 };
 use base_flashblocks_node::test_harness::{FlashblockBuilder, FlashblocksBuilderTestHarness};
 use base_test_utils::Account;
@@ -1232,6 +1233,22 @@ async fn test_pending_depth_remains_bounded_during_canonical_stall() {
         Duration::from_secs(5),
         || test.flashblocks.get_pending_blocks().is_none(),
         "pending state must clear when it exceeds the configured depth",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_live_payload_flashblock_count_is_bounded() {
+    let test = FlashblocksBuilderTestHarness::new().await;
+    test.send_flashblock(FlashblockBuilder::new_base(&test).build()).await;
+    for index in 1..=MAX_FLASHBLOCKS_PER_PAYLOAD {
+        test.send_flashblock(FlashblockBuilder::new(&test, index).build()).await;
+    }
+
+    wait_until(
+        Duration::from_secs(5),
+        || test.flashblocks.get_pending_blocks().is_none(),
+        "pending state must clear when one payload exceeds the flashblock limit",
     )
     .await;
 }

--- a/crates/execution/flashblocks-node/tests/state.rs
+++ b/crates/execution/flashblocks-node/tests/state.rs
@@ -421,7 +421,7 @@ async fn test_metadata_receipts_are_optional() {
 }
 
 #[tokio::test]
-async fn test_flashblock_for_new_canonical_block_clears_older_flashblocks_if_non_zero_index() {
+async fn test_nonzero_unrepresented_block_does_not_clear_pending() {
     let test = FlashblocksBuilderTestHarness::new().await;
 
     test.send_flashblock(FlashblockBuilder::new_base(&test).build()).await;
@@ -435,8 +435,10 @@ async fn test_flashblock_for_new_canonical_block_clears_older_flashblocks_if_non
     test.send_flashblock(FlashblockBuilder::new(&test, 1).with_canonical_block_number(100).build())
         .await;
 
-    let current_block = test.flashblocks.get_pending_blocks().get_block(true);
-    assert!(current_block.is_none());
+    let current_block =
+        test.flashblocks.get_pending_blocks().get_block(true).expect("pending remains published");
+    assert_eq!(current_block.header().number, 1);
+    assert_eq!(current_block.transactions.len(), 1);
 }
 
 #[tokio::test]

--- a/crates/execution/flashblocks-node/tests/state.rs
+++ b/crates/execution/flashblocks-node/tests/state.rs
@@ -1037,6 +1037,44 @@ async fn test_wrong_parent_quarantine_is_scoped_to_payload() {
 }
 
 #[tokio::test]
+async fn test_wrong_internal_parent_does_not_extend_pending_sequence() {
+    let test = FlashblocksBuilderTestHarness::new().await;
+    test.send_flashblock(FlashblockBuilder::new_base(&test).build()).await;
+
+    let mut wrong_base = FlashblockBuilder::new_base(&test).with_canonical_block_number(1).build();
+    wrong_base.base.as_mut().expect("base flashblock has a base payload").parent_hash =
+        B256::repeat_byte(0x42);
+    let wrong_delta = FlashblockBuilder::new(&test, 1).with_canonical_block_number(1).build();
+    test.flashblocks.on_flashblock_received(wrong_base);
+    test.flashblocks.on_flashblock_received(wrong_delta);
+    sleep(Duration::from_millis(100)).await;
+
+    assert_eq!(
+        test.flashblocks
+            .get_pending_blocks()
+            .as_ref()
+            .expect("existing pending state remains available")
+            .latest_block_number(),
+        1
+    );
+
+    test.flashblocks.on_flashblock_received(
+        FlashblockBuilder::new_base(&test).with_canonical_block_number(1).build(),
+    );
+    wait_until(
+        Duration::from_secs(5),
+        || {
+            test.flashblocks
+                .get_pending_blocks()
+                .as_ref()
+                .is_some_and(|pending| pending.latest_block_number() == 2)
+        },
+        "a corrected base must extend the pending sequence",
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn test_current_base_immediately_recovers_stale_pending() {
     let mut test = FlashblocksBuilderTestHarness::new().await;
     test.send_flashblock(FlashblockBuilder::new_base(&test).build()).await;

--- a/crates/execution/flashblocks-node/tests/state.rs
+++ b/crates/execution/flashblocks-node/tests/state.rs
@@ -1011,51 +1011,6 @@ async fn test_wrong_parent_payload_does_not_contaminate_accepted_payload() {
 }
 
 #[tokio::test]
-async fn test_current_base_from_new_payload_replaces_pending() {
-    let test = FlashblocksBuilderTestHarness::new().await;
-    test.send_flashblock(FlashblockBuilder::new_base(&test).build()).await;
-
-    let replacement_payload = PayloadId::new([9; 8]);
-    let mut replacement = FlashblockBuilder::new_base(&test).build();
-    replacement.payload_id = replacement_payload;
-    test.flashblocks.on_flashblock_received(replacement);
-
-    wait_until(
-        Duration::from_secs(5),
-        || {
-            test.flashblocks.get_pending_blocks().as_ref().is_some_and(|pending| {
-                pending.latest_payload_id() == replacement_payload
-                    && pending.latest_flashblock_index() == 0
-            })
-        },
-        "a new current payload base must replace abandoned pending state",
-    )
-    .await;
-
-    let mut replacement_delta = FlashblockBuilder::new(&test, 1)
-        .with_transactions(vec![test.build_transaction_to_send_eth(
-            Account::Alice,
-            Account::Bob,
-            100_000,
-        )])
-        .build();
-    replacement_delta.payload_id = replacement_payload;
-    test.flashblocks.on_flashblock_received(replacement_delta);
-
-    wait_until(
-        Duration::from_secs(5),
-        || {
-            test.flashblocks
-                .get_pending_blocks()
-                .as_ref()
-                .is_some_and(|pending| pending.pending_transaction_count() == 2)
-        },
-        "deltas from the replacement payload must extend pending state",
-    )
-    .await;
-}
-
-#[tokio::test]
 async fn test_same_payload_base_retry_does_not_clear_deltas() {
     let test = FlashblocksBuilderTestHarness::new().await;
     let base = FlashblockBuilder::new_base(&test).build();

--- a/crates/execution/flashblocks-node/tests/state.rs
+++ b/crates/execution/flashblocks-node/tests/state.rs
@@ -987,7 +987,7 @@ async fn test_untracked_older_canonical_does_not_false_reorg() {
 }
 
 #[tokio::test]
-async fn test_wrong_parent_quarantine_is_scoped_to_payload() {
+async fn test_wrong_parent_payload_does_not_contaminate_accepted_payload() {
     let test = FlashblocksBuilderTestHarness::new().await;
     test.send_flashblock(FlashblockBuilder::new_base(&test).build()).await;
 
@@ -999,18 +999,18 @@ async fn test_wrong_parent_quarantine_is_scoped_to_payload() {
     second_wrong_parent.payload_id = PayloadId::new([2; 8]);
     second_wrong_parent.base.as_mut().expect("base flashblock has a base payload").parent_hash =
         B256::repeat_byte(0x43);
-    let mut quarantined_delta = FlashblockBuilder::new(&test, 1)
+    let mut rejected_delta = FlashblockBuilder::new(&test, 1)
         .with_transactions(vec![test.build_transaction_to_send_eth(
             Account::Alice,
             Account::Bob,
             50_000,
         )])
         .build();
-    quarantined_delta.payload_id = PayloadId::new([1; 8]);
+    rejected_delta.payload_id = PayloadId::new([1; 8]);
 
     test.flashblocks.on_flashblock_received(wrong_parent);
     test.flashblocks.on_flashblock_received(second_wrong_parent);
-    test.flashblocks.on_flashblock_received(quarantined_delta);
+    test.flashblocks.on_flashblock_received(rejected_delta);
     sleep(Duration::from_millis(100)).await;
     assert_eq!(
         test.flashblocks

--- a/crates/execution/flashblocks-node/tests/state.rs
+++ b/crates/execution/flashblocks-node/tests/state.rs
@@ -1037,6 +1037,51 @@ async fn test_wrong_parent_quarantine_is_scoped_to_payload() {
 }
 
 #[tokio::test]
+async fn test_current_base_from_new_payload_replaces_pending() {
+    let test = FlashblocksBuilderTestHarness::new().await;
+    test.send_flashblock(FlashblockBuilder::new_base(&test).build()).await;
+
+    let replacement_payload = PayloadId::new([9; 8]);
+    let mut replacement = FlashblockBuilder::new_base(&test).build();
+    replacement.payload_id = replacement_payload;
+    test.flashblocks.on_flashblock_received(replacement);
+
+    wait_until(
+        Duration::from_secs(5),
+        || {
+            test.flashblocks.get_pending_blocks().as_ref().is_some_and(|pending| {
+                pending.latest_payload_id() == replacement_payload
+                    && pending.latest_flashblock_index() == 0
+            })
+        },
+        "a new current payload base must replace abandoned pending state",
+    )
+    .await;
+
+    let mut replacement_delta = FlashblockBuilder::new(&test, 1)
+        .with_transactions(vec![test.build_transaction_to_send_eth(
+            Account::Alice,
+            Account::Bob,
+            100_000,
+        )])
+        .build();
+    replacement_delta.payload_id = replacement_payload;
+    test.flashblocks.on_flashblock_received(replacement_delta);
+
+    wait_until(
+        Duration::from_secs(5),
+        || {
+            test.flashblocks
+                .get_pending_blocks()
+                .as_ref()
+                .is_some_and(|pending| pending.pending_transaction_count() == 2)
+        },
+        "deltas from the replacement payload must extend pending state",
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn test_wrong_internal_parent_does_not_extend_pending_sequence() {
     let test = FlashblocksBuilderTestHarness::new().await;
     test.send_flashblock(FlashblockBuilder::new_base(&test).build()).await;
@@ -1070,6 +1115,24 @@ async fn test_wrong_internal_parent_does_not_extend_pending_sequence() {
                 .is_some_and(|pending| pending.latest_block_number() == 2)
         },
         "a corrected base must extend the pending sequence",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_pending_depth_remains_bounded_during_canonical_stall() {
+    let test = FlashblocksBuilderTestHarness::new().await;
+    for parent in 0..=5 {
+        test.send_flashblock(
+            FlashblockBuilder::new_base(&test).with_canonical_block_number(parent).build(),
+        )
+        .await;
+    }
+
+    wait_until(
+        Duration::from_secs(5),
+        || test.flashblocks.get_pending_blocks().is_none(),
+        "pending state must clear when it exceeds the configured depth",
     )
     .await;
 }

--- a/crates/execution/flashblocks-node/tests/state.rs
+++ b/crates/execution/flashblocks-node/tests/state.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, Instant};
 use alloy_consensus::{Header, Sealed};
 use alloy_network::BlockResponse;
 use alloy_primitives::{B256, U256};
+use alloy_rpc_types_engine::PayloadId;
 use base_common_flashblocks::{
     ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, Flashblock, Metadata,
 };
@@ -983,20 +984,22 @@ async fn test_untracked_older_canonical_does_not_false_reorg() {
 }
 
 #[tokio::test]
-async fn test_wrong_parent_base_quarantines_following_deltas() {
+async fn test_wrong_parent_quarantine_is_scoped_to_payload() {
     let test = FlashblocksBuilderTestHarness::new().await;
     test.send_flashblock(FlashblockBuilder::new_base(&test).build()).await;
 
     let mut wrong_parent = FlashblockBuilder::new_base(&test).build();
+    wrong_parent.payload_id = PayloadId::new([1; 8]);
     wrong_parent.base.as_mut().expect("base flashblock has a base payload").parent_hash =
         B256::repeat_byte(0x42);
-    let quarantined_delta = FlashblockBuilder::new(&test, 1)
+    let mut quarantined_delta = FlashblockBuilder::new(&test, 1)
         .with_transactions(vec![test.build_transaction_to_send_eth(
             Account::Alice,
             Account::Bob,
             50_000,
         )])
         .build();
+    quarantined_delta.payload_id = PayloadId::new([1; 8]);
 
     test.flashblocks.on_flashblock_received(wrong_parent);
     test.flashblocks.on_flashblock_received(quarantined_delta);
@@ -1010,7 +1013,6 @@ async fn test_wrong_parent_base_quarantines_following_deltas() {
         1
     );
 
-    test.flashblocks.on_flashblock_received(FlashblockBuilder::new_base(&test).build());
     test.flashblocks.on_flashblock_received(
         FlashblockBuilder::new(&test, 1)
             .with_transactions(vec![test.build_transaction_to_send_eth(
@@ -1029,7 +1031,29 @@ async fn test_wrong_parent_base_quarantines_following_deltas() {
                 .as_ref()
                 .is_some_and(|pending| pending.pending_transaction_count() == 2)
         },
-        "a valid base must release quarantine for its own deltas",
+        "a wrong build must not quarantine deltas from the accepted payload",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_current_base_immediately_recovers_stale_pending() {
+    let mut test = FlashblocksBuilderTestHarness::new().await;
+    test.send_flashblock(FlashblockBuilder::new_base(&test).build()).await;
+
+    let block_one = test.new_canonical_block_without_processing(vec![]).await;
+    let current_base = FlashblockBuilder::new_base(&test).build();
+    test.flashblocks.on_flashblock_received(current_base);
+
+    wait_until(
+        Duration::from_secs(5),
+        || {
+            test.flashblocks.get_pending_blocks().as_ref().is_some_and(|pending| {
+                pending.earliest_block_number() == block_one.number + 1
+                    && pending.parent_hash() == block_one.hash()
+            })
+        },
+        "the flashblock that discovers stale pending must also resume recovery",
     )
     .await;
 }

--- a/crates/execution/flashblocks-node/tests/state.rs
+++ b/crates/execution/flashblocks-node/tests/state.rs
@@ -1292,3 +1292,26 @@ async fn test_stale_queue_clears_pending_and_resumes_at_current_tip() {
     )
     .await;
 }
+
+#[tokio::test]
+async fn test_deferred_canonical_rejects_resume_against_stale_provider_tip() {
+    let client = FlashblocksBuilderTestHarness::new().await;
+    let mut builder = FlashblocksBuilderTestHarness::new().await;
+    let old_base = FlashblockBuilder::new_base(&client).build();
+    client.send_flashblock(old_base.clone()).await;
+
+    let canonical = builder.new_canonical_block_without_processing(vec![]).await;
+    client.flashblocks.on_canonical_block_received(canonical);
+    wait_until(
+        Duration::from_secs(5),
+        || client.flashblocks.get_pending_blocks().is_none(),
+        "canonical ahead of provider visibility must clear pending state",
+    )
+    .await;
+
+    client.send_flashblock(old_base).await;
+    assert!(
+        client.flashblocks.get_pending_blocks().is_none(),
+        "deferred canonical watermark must reject resume against the stale provider tip"
+    );
+}

--- a/crates/execution/flashblocks-node/tests/state.rs
+++ b/crates/execution/flashblocks-node/tests/state.rs
@@ -1082,6 +1082,49 @@ async fn test_current_base_from_new_payload_replaces_pending() {
 }
 
 #[tokio::test]
+async fn test_new_payload_replaces_latest_block_of_pending_chain() {
+    let test = FlashblocksBuilderTestHarness::new().await;
+    test.send_flashblock(FlashblockBuilder::new_base(&test).build()).await;
+
+    let block_two = FlashblockBuilder::new_base(&test).with_canonical_block_number(1).build();
+    test.send_flashblock(block_two.clone()).await;
+
+    let replacement_payload = PayloadId::new([8; 8]);
+    let mut replacement = block_two;
+    replacement.payload_id = replacement_payload;
+    test.flashblocks.on_flashblock_received(replacement);
+
+    wait_until(
+        Duration::from_secs(5),
+        || {
+            test.flashblocks.get_pending_blocks().as_ref().is_some_and(|pending| {
+                pending.earliest_block_number() == 1
+                    && pending.latest_block_number() == 2
+                    && pending.latest_payload_id() == replacement_payload
+            })
+        },
+        "a replacement payload must rebuild the latest pending suffix",
+    )
+    .await;
+
+    let mut replacement_delta =
+        FlashblockBuilder::new(&test, 1).with_canonical_block_number(1).build();
+    replacement_delta.payload_id = replacement_payload;
+    test.flashblocks.on_flashblock_received(replacement_delta);
+    wait_until(
+        Duration::from_secs(5),
+        || {
+            test.flashblocks
+                .get_pending_blocks()
+                .as_ref()
+                .is_some_and(|pending| pending.latest_flashblock_index() == 1)
+        },
+        "the replacement payload must accept its following deltas",
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn test_wrong_internal_parent_does_not_extend_pending_sequence() {
     let test = FlashblocksBuilderTestHarness::new().await;
     test.send_flashblock(FlashblockBuilder::new_base(&test).build()).await;

--- a/crates/execution/flashblocks-node/tests/state.rs
+++ b/crates/execution/flashblocks-node/tests/state.rs
@@ -650,40 +650,6 @@ async fn test_sequential_nonces_across_flashblocks() {
 }
 
 #[tokio::test]
-async fn test_cached_wrong_parent_flashblock_is_discarded_after_canonical_advance() {
-    let mut test = FlashblocksBuilderTestHarness::new().await;
-
-    // This payload claims block 2 while still carrying genesis as its parent.
-    test.send_flashblock(FlashblockBuilder::new_base(&test).with_canonical_block_number(1).build())
-        .await;
-
-    assert!(
-        test.flashblocks.get_pending_blocks().is_none(),
-        "pending state should be empty because canonical block 1 does not exist yet"
-    );
-
-    let block_one = test.new_canonical_block_without_processing(vec![]).await;
-    let block_one_number = block_one.number;
-    let block_one_hash = block_one.hash();
-    test.flashblocks.on_canonical_block_received(block_one);
-
-    let resume = FlashblockBuilder::new_base(&test).build();
-    test.flashblocks.on_flashblock_received(resume);
-
-    wait_until(
-        Duration::from_secs(5),
-        || {
-            test.flashblocks.get_pending_blocks().as_ref().is_some_and(|pending| {
-                pending.earliest_block_number() == block_one_number + 1
-                    && pending.parent_hash() == block_one_hash
-            })
-        },
-        "old-parent cache entry must be discarded before current pending resumes",
-    )
-    .await;
-}
-
-#[tokio::test]
 async fn test_cached_wrong_parent_sequence_does_not_contaminate_fresh_pending() {
     let mut test = FlashblocksBuilderTestHarness::new().await;
 

--- a/crates/execution/flashblocks-node/tests/state.rs
+++ b/crates/execution/flashblocks-node/tests/state.rs
@@ -1105,11 +1105,15 @@ async fn test_same_payload_base_retry_does_not_clear_deltas() {
     )
     .await;
 
+    let mut malformed_retry = base.clone();
+    malformed_retry.base.as_mut().expect("base flashblock has a base payload").parent_hash =
+        B256::repeat_byte(0x42);
+    test.flashblocks.on_flashblock_received(malformed_retry);
     test.flashblocks.on_flashblock_received(base);
-    sleep(Duration::from_millis(100)).await;
+    test.send_flashblock(FlashblockBuilder::new(&test, 2).build()).await;
     let pending = test.flashblocks.get_pending_blocks();
     let pending = pending.as_ref().expect("pending state remains published");
-    assert_eq!(pending.latest_flashblock_index(), 1);
+    assert_eq!(pending.latest_flashblock_index(), 2);
     assert_eq!(pending.pending_transaction_count(), 2);
 }
 

--- a/crates/execution/flashblocks-node/tests/state.rs
+++ b/crates/execution/flashblocks-node/tests/state.rs
@@ -1226,28 +1226,6 @@ async fn test_live_payload_flashblock_count_is_bounded() {
 }
 
 #[tokio::test]
-async fn test_current_base_immediately_recovers_stale_pending() {
-    let mut test = FlashblocksBuilderTestHarness::new().await;
-    test.send_flashblock(FlashblockBuilder::new_base(&test).build()).await;
-
-    let block_one = test.new_canonical_block_without_processing(vec![]).await;
-    let current_base = FlashblockBuilder::new_base(&test).build();
-    test.flashblocks.on_flashblock_received(current_base);
-
-    wait_until(
-        Duration::from_secs(5),
-        || {
-            test.flashblocks.get_pending_blocks().as_ref().is_some_and(|pending| {
-                pending.earliest_block_number() == block_one.number + 1
-                    && pending.parent_hash() == block_one.hash()
-            })
-        },
-        "the flashblock that discovers stale pending must also resume recovery",
-    )
-    .await;
-}
-
-#[tokio::test]
 async fn test_stale_queue_clears_pending_and_resumes_at_current_tip() {
     let mut test = FlashblocksBuilderTestHarness::new().await;
     test.send_flashblock(FlashblockBuilder::new_base(&test).build()).await;

--- a/crates/execution/flashblocks-node/tests/state.rs
+++ b/crates/execution/flashblocks-node/tests/state.rs
@@ -1,11 +1,20 @@
 //! Integration tests that stress Flashblocks state handling.
 
+use std::time::{Duration, Instant};
+
+use alloy_consensus::{Header, Sealed};
 use alloy_network::BlockResponse;
-use alloy_primitives::U256;
-use base_flashblocks::{FlashblocksAPI, PendingBlocksAPI};
+use alloy_primitives::{B256, U256};
+use base_common_flashblocks::{
+    ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, Flashblock, Metadata,
+};
+use base_flashblocks::{
+    FlashblocksAPI, FlashblocksReceiver, PendingBlocks, PendingBlocksAPI, PendingBlocksBuilder,
+};
 use base_flashblocks_node::test_harness::{FlashblockBuilder, FlashblocksBuilderTestHarness};
 use base_test_utils::Account;
 use reth_provider::{AccountReader, StateProviderFactory};
+use tokio::time::sleep;
 
 #[tokio::test]
 async fn test_state_overrides_persisted_across_flashblocks() {
@@ -303,25 +312,9 @@ async fn test_only_current_pending_state_cleared_upon_canonical_block_reorg() {
     )])
     .await;
 
-    let pending = test.flashblocks.get_pending_blocks().get_block(true);
-    assert!(pending.is_some());
-    let pending = pending.unwrap();
-    assert_eq!(pending.transactions.len(), 2);
-
-    let overrides = test
-        .flashblocks
-        .get_pending_blocks()
-        .get_state_overrides()
-        .expect("should be set from txn execution");
-
-    assert!(overrides.contains_key(&Account::Alice.address()));
-    assert_eq!(
-        overrides
-            .get(&Account::Bob.address())
-            .expect("should be set as txn receiver")
-            .balance
-            .expect("should be changed due to receiving funds"),
-        test.expected_pending_balance(Account::Bob, 100_000)
+    assert!(
+        test.flashblocks.get_pending_blocks().get_block(true).is_none(),
+        "a real overlapping transaction mismatch must clear pending state"
     );
 }
 
@@ -653,12 +646,10 @@ async fn test_sequential_nonces_across_flashblocks() {
 }
 
 #[tokio::test]
-async fn test_flashblock_cached_and_applied_after_canonical_block() {
+async fn test_cached_wrong_parent_flashblock_is_discarded_after_canonical_advance() {
     let mut test = FlashblocksBuilderTestHarness::new().await;
 
-    // Send a flashblock targeting block 2 (canonical_block_number=1) before
-    // canonical block 1 exists. This triggers MissingCanonicalHeader and should
-    // be cached by the processor.
+    // This payload claims block 2 while still carrying genesis as its parent.
     test.send_flashblock(FlashblockBuilder::new_base(&test).with_canonical_block_number(1).build())
         .await;
 
@@ -667,17 +658,29 @@ async fn test_flashblock_cached_and_applied_after_canonical_block() {
         "pending state should be empty because canonical block 1 does not exist yet"
     );
 
-    // Build canonical block 1 so the processor can replay the cached flashblock.
-    test.new_canonical_block(vec![]).await;
-    assert_eq!(test.node.latest_block().number, 1);
+    let block_one = test.new_canonical_block_without_processing(vec![]).await;
+    let block_one_number = block_one.number;
+    let block_one_hash = block_one.hash();
+    test.flashblocks.on_canonical_block_received(block_one);
 
-    let pending =
-        test.flashblocks.get_pending_blocks().get_block(true).expect("cached flashblock replayed");
-    assert_eq!(pending.header.number, 2, "replayed flashblock should produce pending block 2");
+    let resume = FlashblockBuilder::new_base(&test).build();
+    test.flashblocks.on_flashblock_received(resume);
+
+    wait_until(
+        Duration::from_secs(5),
+        || {
+            test.flashblocks.get_pending_blocks().as_ref().is_some_and(|pending| {
+                pending.earliest_block_number() == block_one_number + 1
+                    && pending.parent_hash() == block_one_hash
+            })
+        },
+        "old-parent cache entry must be discarded before current pending resumes",
+    )
+    .await;
 }
 
 #[tokio::test]
-async fn test_cached_flashblock_with_transactions_applied_after_canonical() {
+async fn test_cached_wrong_parent_sequence_does_not_contaminate_fresh_pending() {
     let mut test = FlashblocksBuilderTestHarness::new().await;
 
     let transfer_amount = 100_000u128;
@@ -701,31 +704,26 @@ async fn test_cached_flashblock_with_transactions_applied_after_canonical() {
     .await;
     assert!(test.flashblocks.get_pending_blocks().is_none());
 
-    // Provide canonical block 1 to unlock the cache.
-    test.new_canonical_block(vec![]).await;
+    let block_one = test.new_canonical_block_without_processing(vec![]).await;
+    let block_one_number = block_one.number;
+    let block_one_hash = block_one.hash();
+    let resume = FlashblockBuilder::new_base(&test).build();
 
-    let pending =
-        test.flashblocks.get_pending_blocks().get_block(true).expect("cached flashblocks replayed");
-    assert_eq!(pending.header.number, 2);
-    assert_eq!(pending.transactions.len(), 2, "deposit tx from base + Alice->Bob transfer");
+    test.flashblocks.on_canonical_block_received(block_one);
+    test.flashblocks.on_flashblock_received(resume);
 
-    let overrides = test
-        .flashblocks
-        .get_pending_blocks()
-        .get_state_overrides()
-        .expect("state overrides should exist after replayed flashblock execution");
-    assert!(
-        overrides.contains_key(&Account::Alice.address()),
-        "Alice should appear in overrides after sending ETH"
-    );
-    assert_eq!(
-        overrides
-            .get(&Account::Bob.address())
-            .expect("Bob should have state override")
-            .balance
-            .expect("balance should be overridden"),
-        test.expected_pending_balance(Account::Bob, transfer_amount)
-    );
+    wait_until(
+        Duration::from_secs(5),
+        || {
+            test.flashblocks.get_pending_blocks().as_ref().is_some_and(|pending| {
+                pending.earliest_block_number() == block_one_number + 1
+                    && pending.parent_hash() == block_one_hash
+                    && pending.pending_transaction_count() == 1
+            })
+        },
+        "old-parent cached deltas must not contaminate the fresh sequence",
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -850,4 +848,240 @@ async fn test_same_block_append_refreshes_pending_header() {
         after_second_append.header.transactions_root != first_transactions_root,
         "same-block append must publish a fresh header with updated transactions_root"
     );
+}
+
+fn dummy_flashblock(block_number: u64, parent_hash: B256) -> Flashblock {
+    Flashblock {
+        payload_id: Default::default(),
+        index: 0,
+        base: Some(ExecutionPayloadBaseV1 {
+            parent_beacon_block_root: B256::ZERO,
+            parent_hash,
+            fee_recipient: Default::default(),
+            prev_randao: B256::ZERO,
+            block_number,
+            gas_limit: 30_000_000,
+            timestamp: 1_700_000_000 + block_number,
+            extra_data: Default::default(),
+            base_fee_per_gas: U256::from(1_000_000_000u64),
+        }),
+        diff: ExecutionPayloadFlashblockDeltaV1::default(),
+        metadata: Metadata::new(block_number),
+    }
+}
+
+fn pending_spanning(
+    earliest: u64,
+    latest: u64,
+    parent_hash: B256,
+    suffix: Flashblock,
+) -> PendingBlocks {
+    let mut builder = PendingBlocksBuilder::new();
+    builder.with_header(Sealed::new_unchecked(
+        Header { number: earliest, parent_hash, ..Default::default() },
+        B256::ZERO,
+    ));
+    builder.with_header(Sealed::new_unchecked(
+        Header { number: latest, parent_hash: B256::ZERO, ..Default::default() },
+        B256::ZERO,
+    ));
+    builder.with_flashblocks([dummy_flashblock(earliest, parent_hash), suffix]);
+    builder.build().expect("pending snapshot should build")
+}
+
+async fn wait_until(timeout: Duration, mut check: impl FnMut() -> bool, failure: &str) {
+    let start = Instant::now();
+    loop {
+        if check() {
+            return;
+        }
+        assert!(start.elapsed() <= timeout, "{failure}");
+        sleep(Duration::from_millis(20)).await;
+    }
+}
+
+#[tokio::test]
+async fn test_matching_canonical_rebases_pending_onto_canonical_tip() {
+    let mut test = FlashblocksBuilderTestHarness::new().await;
+    let genesis_hash = test.node.latest_block().hash();
+    let block_one = test.new_canonical_block_without_processing(vec![]).await;
+    let suffix = FlashblockBuilder::new_base(&test).build();
+
+    test.flashblocks.set_pending_blocks_for_testing(Some(pending_spanning(
+        1,
+        2,
+        genesis_hash,
+        suffix,
+    )));
+    test.flashblocks.on_canonical_block_received(block_one.clone());
+
+    wait_until(
+        Duration::from_secs(5),
+        || {
+            test.flashblocks.get_pending_blocks().as_ref().is_some_and(|pending| {
+                pending.earliest_block_number() == 2 && pending.parent_hash() == block_one.hash()
+            })
+        },
+        "pending snapshot should rebase onto canonical block 1",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_wrong_parent_rebase_clears_pending_until_matching_resume() {
+    let mut test = FlashblocksBuilderTestHarness::new().await;
+    let genesis_hash = test.node.latest_block().hash();
+    let block_one = test.new_canonical_block_without_processing(vec![]).await;
+    let mut wrong_suffix = FlashblockBuilder::new_base(&test).build();
+    wrong_suffix.base.as_mut().expect("base flashblock has a base payload").parent_hash =
+        B256::repeat_byte(0x24);
+
+    test.flashblocks.set_pending_blocks_for_testing(Some(pending_spanning(
+        1,
+        2,
+        genesis_hash,
+        wrong_suffix,
+    )));
+    test.flashblocks.on_canonical_block_received(block_one.clone());
+
+    wait_until(
+        Duration::from_secs(5),
+        || test.flashblocks.get_pending_blocks().is_none(),
+        "wrong-parent suffix must clear pending during rebase",
+    )
+    .await;
+
+    test.flashblocks.on_flashblock_received(FlashblockBuilder::new_base(&test).build());
+    wait_until(
+        Duration::from_secs(5),
+        || {
+            test.flashblocks.get_pending_blocks().as_ref().is_some_and(|pending| {
+                pending.earliest_block_number() == 2 && pending.parent_hash() == block_one.hash()
+            })
+        },
+        "recovery must resume from a matching current base",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_untracked_older_canonical_does_not_false_reorg() {
+    let mut test = FlashblocksBuilderTestHarness::new().await;
+    let genesis = test.node.latest_block();
+    let block_one = test.new_canonical_block_without_processing(vec![]).await;
+    test.send_flashblock(FlashblockBuilder::new_base(&test).build()).await;
+
+    test.flashblocks.on_canonical_block_received(genesis);
+    sleep(Duration::from_millis(100)).await;
+
+    let pending = test.flashblocks.get_pending_blocks();
+    let pending =
+        pending.as_ref().expect("untracked canonical must not trigger an empty-vector reorg");
+    assert_eq!(pending.earliest_block_number(), 2);
+    assert_eq!(pending.latest_block_number(), 2);
+    assert_eq!(pending.parent_hash(), block_one.hash());
+}
+
+#[tokio::test]
+async fn test_wrong_parent_base_quarantines_following_deltas() {
+    let test = FlashblocksBuilderTestHarness::new().await;
+    test.send_flashblock(FlashblockBuilder::new_base(&test).build()).await;
+
+    let mut wrong_parent = FlashblockBuilder::new_base(&test).build();
+    wrong_parent.base.as_mut().expect("base flashblock has a base payload").parent_hash =
+        B256::repeat_byte(0x42);
+    let quarantined_delta = FlashblockBuilder::new(&test, 1)
+        .with_transactions(vec![test.build_transaction_to_send_eth(
+            Account::Alice,
+            Account::Bob,
+            50_000,
+        )])
+        .build();
+
+    test.flashblocks.on_flashblock_received(wrong_parent);
+    test.flashblocks.on_flashblock_received(quarantined_delta);
+    sleep(Duration::from_millis(100)).await;
+    assert_eq!(
+        test.flashblocks
+            .get_pending_blocks()
+            .as_ref()
+            .expect("healthy pending remains published")
+            .pending_transaction_count(),
+        1
+    );
+
+    test.flashblocks.on_flashblock_received(FlashblockBuilder::new_base(&test).build());
+    test.flashblocks.on_flashblock_received(
+        FlashblockBuilder::new(&test, 1)
+            .with_transactions(vec![test.build_transaction_to_send_eth(
+                Account::Alice,
+                Account::Bob,
+                100_000,
+            )])
+            .build(),
+    );
+
+    wait_until(
+        Duration::from_secs(5),
+        || {
+            test.flashblocks
+                .get_pending_blocks()
+                .as_ref()
+                .is_some_and(|pending| pending.pending_transaction_count() == 2)
+        },
+        "a valid base must release quarantine for its own deltas",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_stale_queue_clears_pending_and_resumes_at_current_tip() {
+    let mut test = FlashblocksBuilderTestHarness::new().await;
+    test.send_flashblock(FlashblockBuilder::new_base(&test).build()).await;
+
+    let mut stale_flashblocks = Vec::new();
+    for parent in 1..8 {
+        stale_flashblocks
+            .push(FlashblockBuilder::new_base(&test).with_canonical_block_number(parent).build());
+    }
+
+    let mut stale_canonicals = Vec::new();
+    for _ in 0..8 {
+        stale_canonicals.push(test.new_canonical_block_without_processing(vec![]).await);
+    }
+    let best = test.node.latest_block();
+
+    test.flashblocks.on_canonical_block_received(stale_canonicals.remove(0));
+    wait_until(
+        Duration::from_secs(5),
+        || test.flashblocks.get_pending_blocks().is_none(),
+        "provider-tip lag must clear the stale published snapshot",
+    )
+    .await;
+
+    for block in stale_canonicals {
+        test.flashblocks.on_canonical_block_received(block);
+    }
+    for flashblock in stale_flashblocks {
+        test.flashblocks.on_flashblock_received(flashblock);
+    }
+    sleep(Duration::from_millis(100)).await;
+    assert!(test.flashblocks.get_pending_blocks().is_none());
+
+    let resume = FlashblockBuilder::new_base(&test).build();
+    assert_eq!(resume.metadata.block_number, best.number + 1);
+    assert_eq!(resume.base.as_ref().map(|base| base.parent_hash), Some(best.hash()));
+    test.flashblocks.on_flashblock_received(resume);
+
+    wait_until(
+        Duration::from_secs(5),
+        || {
+            test.flashblocks.get_pending_blocks().as_ref().is_some_and(|pending| {
+                pending.earliest_block_number() == best.number + 1
+                    && pending.parent_hash() == best.hash()
+            })
+        },
+        "processor should resume only from the current tip child",
+    )
+    .await;
 }

--- a/crates/execution/flashblocks-node/tests/state.rs
+++ b/crates/execution/flashblocks-node/tests/state.rs
@@ -2,16 +2,13 @@
 
 use std::time::{Duration, Instant};
 
-use alloy_consensus::{Header, Sealed};
+use alloy_eips::Decodable2718;
 use alloy_network::BlockResponse;
 use alloy_primitives::{B256, U256};
 use alloy_rpc_types_engine::PayloadId;
-use base_common_flashblocks::{
-    ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, Flashblock, Metadata,
-};
+use base_common_consensus::BaseTxEnvelope;
 use base_flashblocks::{
-    FlashblocksAPI, FlashblocksReceiver, MAX_FLASHBLOCKS_PER_PAYLOAD, PendingBlocks,
-    PendingBlocksAPI, PendingBlocksBuilder,
+    FlashblocksAPI, FlashblocksReceiver, MAX_FLASHBLOCKS_PER_PAYLOAD, PendingBlocksAPI,
 };
 use base_flashblocks_node::test_harness::{FlashblockBuilder, FlashblocksBuilderTestHarness};
 use base_test_utils::Account;
@@ -820,45 +817,6 @@ async fn test_same_block_append_refreshes_pending_header() {
     );
 }
 
-fn dummy_flashblock(block_number: u64, parent_hash: B256) -> Flashblock {
-    Flashblock {
-        payload_id: Default::default(),
-        index: 0,
-        base: Some(ExecutionPayloadBaseV1 {
-            parent_beacon_block_root: B256::ZERO,
-            parent_hash,
-            fee_recipient: Default::default(),
-            prev_randao: B256::ZERO,
-            block_number,
-            gas_limit: 30_000_000,
-            timestamp: 1_700_000_000 + block_number,
-            extra_data: Default::default(),
-            base_fee_per_gas: U256::from(1_000_000_000u64),
-        }),
-        diff: ExecutionPayloadFlashblockDeltaV1::default(),
-        metadata: Metadata::new(block_number),
-    }
-}
-
-fn pending_spanning(
-    earliest: u64,
-    latest: u64,
-    parent_hash: B256,
-    suffix: Flashblock,
-) -> PendingBlocks {
-    let mut builder = PendingBlocksBuilder::new();
-    builder.with_header(Sealed::new_unchecked(
-        Header { number: earliest, parent_hash, ..Default::default() },
-        B256::ZERO,
-    ));
-    builder.with_header(Sealed::new_unchecked(
-        Header { number: latest, parent_hash: B256::ZERO, ..Default::default() },
-        B256::ZERO,
-    ));
-    builder.with_flashblocks([dummy_flashblock(earliest, parent_hash), suffix]);
-    builder.build().expect("pending snapshot should build")
-}
-
 async fn wait_until(timeout: Duration, mut check: impl FnMut() -> bool, failure: &str) {
     let start = Instant::now();
     loop {
@@ -873,16 +831,19 @@ async fn wait_until(timeout: Duration, mut check: impl FnMut() -> bool, failure:
 #[tokio::test]
 async fn test_matching_canonical_rebases_pending_onto_canonical_tip() {
     let mut test = FlashblocksBuilderTestHarness::new().await;
-    let genesis_hash = test.node.latest_block().hash();
-    let block_one = test.new_canonical_block_without_processing(vec![]).await;
-    let suffix = FlashblockBuilder::new_base(&test).build();
+    let mut builder = FlashblocksBuilderTestHarness::new().await;
+    let mut block_one_base = FlashblockBuilder::new_base(&test).build();
+    let mut deposit_bytes = block_one_base.diff.transactions[0].as_ref();
+    let deposit =
+        BaseTxEnvelope::decode_2718(&mut deposit_bytes).expect("deposit transaction should decode");
+    let expected_block_one =
+        builder.new_canonical_block_without_processing(vec![deposit.clone()]).await;
+    block_one_base.diff.block_hash = expected_block_one.hash();
+    test.send_flashblock(block_one_base).await;
+    test.send_flashblock(FlashblockBuilder::new_base(&builder).build()).await;
+    let block_one = test.new_canonical_block_without_processing(vec![deposit]).await;
+    assert_eq!(block_one.hash(), expected_block_one.hash());
 
-    test.flashblocks.set_pending_blocks_for_testing(Some(pending_spanning(
-        1,
-        2,
-        genesis_hash,
-        suffix,
-    )));
     test.flashblocks.on_canonical_block_received(block_one.clone());
 
     wait_until(
@@ -893,43 +854,6 @@ async fn test_matching_canonical_rebases_pending_onto_canonical_tip() {
             })
         },
         "pending snapshot should rebase onto canonical block 1",
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn test_wrong_parent_rebase_clears_pending_until_matching_resume() {
-    let mut test = FlashblocksBuilderTestHarness::new().await;
-    let genesis_hash = test.node.latest_block().hash();
-    let block_one = test.new_canonical_block_without_processing(vec![]).await;
-    let mut wrong_suffix = FlashblockBuilder::new_base(&test).build();
-    wrong_suffix.base.as_mut().expect("base flashblock has a base payload").parent_hash =
-        B256::repeat_byte(0x24);
-
-    test.flashblocks.set_pending_blocks_for_testing(Some(pending_spanning(
-        1,
-        2,
-        genesis_hash,
-        wrong_suffix,
-    )));
-    test.flashblocks.on_canonical_block_received(block_one.clone());
-
-    wait_until(
-        Duration::from_secs(5),
-        || test.flashblocks.get_pending_blocks().is_none(),
-        "wrong-parent suffix must clear pending during rebase",
-    )
-    .await;
-
-    test.flashblocks.on_flashblock_received(FlashblockBuilder::new_base(&test).build());
-    wait_until(
-        Duration::from_secs(5),
-        || {
-            test.flashblocks.get_pending_blocks().as_ref().is_some_and(|pending| {
-                pending.earliest_block_number() == 2 && pending.parent_hash() == block_one.hash()
-            })
-        },
-        "recovery must resume from a matching current base",
     )
     .await;
 }

--- a/crates/execution/flashblocks-node/tests/state.rs
+++ b/crates/execution/flashblocks-node/tests/state.rs
@@ -1315,3 +1315,53 @@ async fn test_deferred_canonical_rejects_resume_against_stale_provider_tip() {
         "deferred canonical watermark must reject resume against the stale provider tip"
     );
 }
+
+#[tokio::test]
+async fn test_deferred_canonical_replays_base_received_after_notification() {
+    let mut client = FlashblocksBuilderTestHarness::new().await;
+    let mut builder = FlashblocksBuilderTestHarness::new().await;
+    let canonical = builder.new_canonical_block_without_processing(vec![]).await;
+    let canonical_hash = canonical.hash();
+    let next_base = FlashblockBuilder::new_base(&builder).build();
+
+    client.flashblocks.on_canonical_block_received(canonical);
+    client.send_flashblock(next_base).await;
+    let client_canonical = client.new_canonical_block_without_processing(vec![]).await;
+    assert_eq!(client_canonical.hash(), canonical_hash);
+
+    wait_until(
+        Duration::from_secs(5),
+        || {
+            client.flashblocks.get_pending_blocks().as_ref().is_some_and(|pending| {
+                pending.earliest_block_number() == 2 && pending.parent_hash() == canonical_hash
+            })
+        },
+        "base received after an ahead canonical should replay when it becomes visible",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_deferred_canonical_preserves_base_received_before_notification() {
+    let mut client = FlashblocksBuilderTestHarness::new().await;
+    let mut builder = FlashblocksBuilderTestHarness::new().await;
+    let canonical = builder.new_canonical_block_without_processing(vec![]).await;
+    let canonical_hash = canonical.hash();
+    let next_base = FlashblockBuilder::new_base(&builder).build();
+
+    client.send_flashblock(next_base).await;
+    client.flashblocks.on_canonical_block_received(canonical);
+    let client_canonical = client.new_canonical_block_without_processing(vec![]).await;
+    assert_eq!(client_canonical.hash(), canonical_hash);
+
+    wait_until(
+        Duration::from_secs(5),
+        || {
+            client.flashblocks.get_pending_blocks().as_ref().is_some_and(|pending| {
+                pending.earliest_block_number() == 2 && pending.parent_hash() == canonical_hash
+            })
+        },
+        "base received before an ahead canonical should survive until provider visibility",
+    )
+    .await;
+}

--- a/crates/execution/flashblocks-node/tests/state.rs
+++ b/crates/execution/flashblocks-node/tests/state.rs
@@ -1071,16 +1071,32 @@ async fn test_same_payload_base_retry_does_not_clear_deltas() {
     )
     .await;
 
-    let mut malformed_retry = base.clone();
-    malformed_retry.base.as_mut().expect("base flashblock has a base payload").parent_hash =
-        B256::repeat_byte(0x42);
-    test.flashblocks.on_flashblock_received(malformed_retry);
     test.flashblocks.on_flashblock_received(base);
     test.send_flashblock(FlashblockBuilder::new(&test, 2).build()).await;
     let pending = test.flashblocks.get_pending_blocks();
     let pending = pending.as_ref().expect("pending state remains published");
     assert_eq!(pending.latest_flashblock_index(), 2);
     assert_eq!(pending.pending_transaction_count(), 2);
+}
+
+#[tokio::test]
+async fn test_conflicting_live_retransmissions_clear_pending() {
+    let test = FlashblocksBuilderTestHarness::new().await;
+    let base = FlashblockBuilder::new_base(&test).build();
+    test.send_flashblock(base.clone()).await;
+
+    let mut conflicting_base = base.clone();
+    conflicting_base.diff.state_root = B256::repeat_byte(0x11);
+    test.send_flashblock(conflicting_base).await;
+    assert!(test.flashblocks.get_pending_blocks().is_none());
+
+    test.send_flashblock(base).await;
+    let delta = FlashblockBuilder::new(&test, 1).build();
+    test.send_flashblock(delta.clone()).await;
+    let mut conflicting_delta = delta;
+    conflicting_delta.diff.state_root = B256::repeat_byte(0x22);
+    test.send_flashblock(conflicting_delta).await;
+    assert!(test.flashblocks.get_pending_blocks().is_none());
 }
 
 #[tokio::test]

--- a/crates/execution/flashblocks-node/tests/state.rs
+++ b/crates/execution/flashblocks-node/tests/state.rs
@@ -992,6 +992,10 @@ async fn test_wrong_parent_quarantine_is_scoped_to_payload() {
     wrong_parent.payload_id = PayloadId::new([1; 8]);
     wrong_parent.base.as_mut().expect("base flashblock has a base payload").parent_hash =
         B256::repeat_byte(0x42);
+    let mut second_wrong_parent = FlashblockBuilder::new_base(&test).build();
+    second_wrong_parent.payload_id = PayloadId::new([2; 8]);
+    second_wrong_parent.base.as_mut().expect("base flashblock has a base payload").parent_hash =
+        B256::repeat_byte(0x43);
     let mut quarantined_delta = FlashblockBuilder::new(&test, 1)
         .with_transactions(vec![test.build_transaction_to_send_eth(
             Account::Alice,
@@ -1002,6 +1006,7 @@ async fn test_wrong_parent_quarantine_is_scoped_to_payload() {
     quarantined_delta.payload_id = PayloadId::new([1; 8]);
 
     test.flashblocks.on_flashblock_received(wrong_parent);
+    test.flashblocks.on_flashblock_received(second_wrong_parent);
     test.flashblocks.on_flashblock_received(quarantined_delta);
     sleep(Duration::from_millis(100)).await;
     assert_eq!(
@@ -1082,6 +1087,30 @@ async fn test_current_base_from_new_payload_replaces_pending() {
 }
 
 #[tokio::test]
+async fn test_same_payload_base_retry_does_not_clear_deltas() {
+    let test = FlashblocksBuilderTestHarness::new().await;
+    let base = FlashblockBuilder::new_base(&test).build();
+    test.send_flashblock(base.clone()).await;
+    test.send_flashblock(
+        FlashblockBuilder::new(&test, 1)
+            .with_transactions(vec![test.build_transaction_to_send_eth(
+                Account::Alice,
+                Account::Bob,
+                100_000,
+            )])
+            .build(),
+    )
+    .await;
+
+    test.flashblocks.on_flashblock_received(base);
+    sleep(Duration::from_millis(100)).await;
+    let pending = test.flashblocks.get_pending_blocks();
+    let pending = pending.as_ref().expect("pending state remains published");
+    assert_eq!(pending.latest_flashblock_index(), 1);
+    assert_eq!(pending.pending_transaction_count(), 2);
+}
+
+#[tokio::test]
 async fn test_new_payload_replaces_latest_block_of_pending_chain() {
     let test = FlashblocksBuilderTestHarness::new().await;
     test.send_flashblock(FlashblockBuilder::new_base(&test).build()).await;
@@ -1120,6 +1149,33 @@ async fn test_new_payload_replaces_latest_block_of_pending_chain() {
                 .is_some_and(|pending| pending.latest_flashblock_index() == 1)
         },
         "the replacement payload must accept its following deltas",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_new_payload_replaces_earlier_block_and_discards_suffix() {
+    let test = FlashblocksBuilderTestHarness::new().await;
+    let block_one = FlashblockBuilder::new_base(&test).build();
+    test.send_flashblock(block_one.clone()).await;
+    test.send_flashblock(FlashblockBuilder::new_base(&test).with_canonical_block_number(1).build())
+        .await;
+
+    let replacement_payload = PayloadId::new([7; 8]);
+    let mut replacement = block_one;
+    replacement.payload_id = replacement_payload;
+    test.flashblocks.on_flashblock_received(replacement);
+
+    wait_until(
+        Duration::from_secs(5),
+        || {
+            test.flashblocks.get_pending_blocks().as_ref().is_some_and(|pending| {
+                pending.earliest_block_number() == 1
+                    && pending.latest_block_number() == 1
+                    && pending.latest_payload_id() == replacement_payload
+            })
+        },
+        "replacing an earlier payload must discard its abandoned pending suffix",
     )
     .await;
 }

--- a/crates/execution/flashblocks/README.md
+++ b/crates/execution/flashblocks/README.md
@@ -40,11 +40,11 @@ pending is cleared; in-flight work from the previous epoch is not published.
 
 Every update is preflighted against the provider's current canonical header:
 
-- **EnterRecovery** clears pending when it cannot safely track the tip.
-- **ResumeRecovery** accepts an index-0 flashblock whose parent hash is the
+- **`EnterRecovery`** clears pending when it cannot safely track the tip.
+- **`ResumeRecovery`** accepts an index-0 flashblock whose parent hash is the
   current tip and rebuilds pending from there.
-- **Skip** drops a stale update when pending is already tip-aligned.
-- **Process** applies the update when pending already tracks the tip.
+- **`Skip`** drops a stale update when pending is already tip-aligned.
+- **`Process`** applies the update when pending already tracks the tip.
 
 A canonical notification can arrive before the provider exposes that block.
 The processor stores it as a deferred canonical, keeps nearby cache entries,
@@ -53,11 +53,11 @@ the deferred block once it is visible.
 
 When a canonical block is applied, [`CanonicalBlockReconciler`] chooses:
 
-- **Keep** for untracked older canonicals so they are not treated as reorgs.
-- **Rebase** if canonical sits inside the pending chain and is still behind
+- **`Keep`** for untracked older canonicals so they are not treated as reorgs.
+- **`Rebase`** if canonical sits inside the pending chain and is still behind
   latest: drop flashblocks at or below that height and rebuild the suffix.
-- **CatchUp** if canonical has reached or passed pending latest.
-- **HandleReorg** on a real transaction-set or pending-anchor hash mismatch.
+- **`CatchUp`** if canonical has reached or passed pending latest.
+- **`HandleReorg`** on a real transaction-set or pending-anchor hash mismatch.
 
 Live and cached payloads stay scoped to one payload ID. Identical
 retransmissions are ignored; conflicting content for the same identity fails

--- a/crates/execution/flashblocks/README.md
+++ b/crates/execution/flashblocks/README.md
@@ -15,6 +15,59 @@ Flashblocks state management for Base nodes. Subscribes to flashblocks and combi
 - **`CanonicalBlockReconciler`**: Reconciles flashblock state with canonical chain updates.
 - **`ReorgDetector`**: Detects chain reorganizations affecting pending state.
 
+## Pending state
+
+Published pending state either tracks flashblocks built on the node's current
+canonical tip, or it is absent until it can. After a delay, overload, or
+restart, the processor does not keep a lagged overlay live for RPC.
+
+`max_pending_blocks_depth` is the maximum number of **blocks** the pending
+snapshot may extend beyond the provider's canonical tip. The node CLI default
+is `3` (canonical `N` may have pending `N+1` through `N+3`). If pending is not
+rooted at the current tip hash, or that depth is exceeded, the processor
+clears the snapshot and resumes only from an index-0 flashblock whose parent
+is the current tip.
+
+This depth is not a count of flashblock messages, and it is not the cache
+window. `FlashblockCache` may retain unpublished payloads a few blocks further
+ahead so they can be replayed after the matching canonical block arrives.
+
+## Recovery
+
+Canonical blocks and flashblocks share one bounded processor queue. Each update
+is stamped with a recovery epoch. If the queue is full, the epoch advances and
+pending is cleared; in-flight work from the previous epoch is not published.
+
+Every update is preflighted against the provider's current canonical header:
+
+- **EnterRecovery** clears pending when it cannot safely track the tip.
+- **ResumeRecovery** accepts an index-0 flashblock whose parent hash is the
+  current tip and rebuilds pending from there.
+- **Skip** drops a stale update when pending is already tip-aligned.
+- **Process** applies the update when pending already tracks the tip.
+
+A canonical notification can arrive before the provider exposes that block.
+The processor stores it as a deferred canonical, keeps nearby cache entries,
+and does not resume against the stale provider tip. A short retry reapplies
+the deferred block once it is visible.
+
+When a canonical block is applied, [`CanonicalBlockReconciler`] chooses:
+
+- **Keep** for untracked older canonicals so they are not treated as reorgs.
+- **Rebase** if canonical sits inside the pending chain and is still behind
+  latest: drop flashblocks at or below that height and rebuild the suffix.
+- **CatchUp** if canonical has reached or passed pending latest.
+- **HandleReorg** on a real transaction-set or pending-anchor hash mismatch.
+
+Live and cached payloads stay scoped to one payload ID. Identical
+retransmissions are ignored; conflicting content for the same identity fails
+closed into recovery. A height that saw conflicting fragments is tombstoned
+until canonical advances.
+
+If the canonical subscription lags or delivers an empty commit, the extension
+resyncs from the provider's latest recovered block instead of waiting for the
+next subscription event.
+
 ## RPC Extensions
 
 This crate provides pending-state-aware Ethereum RPC implementations used by

--- a/crates/execution/flashblocks/src/block_assembler.rs
+++ b/crates/execution/flashblocks/src/block_assembler.rs
@@ -73,6 +73,9 @@ impl BlockAssembler {
     pub fn assemble(flashblocks: &[Flashblock]) -> Result<AssembledBlock> {
         let first = flashblocks.first().ok_or(ProtocolError::EmptyFlashblocks)?;
         let base = first.base.clone().ok_or(ProtocolError::MissingBase)?;
+        if base.block_number == 0 || first.metadata.block_number == 0 {
+            return Err(ProtocolError::ZeroBlockNumber.into());
+        }
         if base.block_number != first.metadata.block_number {
             return Err(ProtocolError::BlockNumberMismatch {
                 base: base.block_number,
@@ -321,6 +324,19 @@ mod tests {
                 base: 100,
                 metadata: 101
             }))
+        ));
+    }
+
+    #[test]
+    fn test_assemble_rejects_block_zero() {
+        let mut flashblock = create_test_flashblock(0, true);
+        flashblock.base.as_mut().expect("test base exists").block_number = 0;
+        flashblock.metadata = Metadata::new(0);
+
+        let result = BlockAssembler::assemble(&[flashblock]);
+        assert!(matches!(
+            result,
+            Err(crate::StateProcessorError::Protocol(ProtocolError::ZeroBlockNumber))
         ));
     }
 }

--- a/crates/execution/flashblocks/src/block_assembler.rs
+++ b/crates/execution/flashblocks/src/block_assembler.rs
@@ -73,6 +73,13 @@ impl BlockAssembler {
     pub fn assemble(flashblocks: &[Flashblock]) -> Result<AssembledBlock> {
         let first = flashblocks.first().ok_or(ProtocolError::EmptyFlashblocks)?;
         let base = first.base.clone().ok_or(ProtocolError::MissingBase)?;
+        if base.block_number != first.metadata.block_number {
+            return Err(ProtocolError::BlockNumberMismatch {
+                base: base.block_number,
+                metadata: first.metadata.block_number,
+            }
+            .into());
+        }
         let latest_flashblock = flashblocks.last().ok_or(ProtocolError::EmptyFlashblocks)?;
 
         let transactions: Vec<Bytes> = flashblocks
@@ -299,6 +306,21 @@ mod tests {
         assert!(matches!(
             result,
             Err(crate::StateProcessorError::Protocol(ProtocolError::MissingBase))
+        ));
+    }
+
+    #[test]
+    fn test_assemble_rejects_mismatched_block_numbers() {
+        let mut flashblock = create_test_flashblock(0, true);
+        flashblock.metadata = Metadata::new(101);
+
+        let result = BlockAssembler::assemble(&[flashblock]);
+        assert!(matches!(
+            result,
+            Err(crate::StateProcessorError::Protocol(ProtocolError::BlockNumberMismatch {
+                base: 100,
+                metadata: 101
+            }))
         ));
     }
 }

--- a/crates/execution/flashblocks/src/cache.rs
+++ b/crates/execution/flashblocks/src/cache.rs
@@ -88,10 +88,12 @@ impl FlashblockCache {
 
     /// Inserts a flashblock into the cache.
     ///
-    /// Returns `true` if the flashblock was cached, `false` if it was rejected
-    /// because its block number exceeds the cache-ahead limit.
+    /// Returns `true` if the flashblock remains cached after enforcing admission
+    /// and global budget limits.
     pub fn insert(&mut self, flashblock: Flashblock) -> bool {
         let block_number = flashblock.metadata.block_number;
+        let payload_id = flashblock.payload_id;
+        let index = flashblock.index;
         if !self.is_cacheable(block_number) || flashblock.index >= MAX_FLASHBLOCKS_PER_PAYLOAD {
             return false;
         }
@@ -122,7 +124,7 @@ impl FlashblockCache {
         }
         payload.1.insert(flashblock.index, flashblock);
         while self.total_flashblocks() > MAX_TOTAL_CACHED_FLASHBLOCKS {
-            let oldest = self
+            let eviction_candidate = self
                 .entries
                 .iter()
                 .flat_map(|(block_number, by_payload)| {
@@ -133,17 +135,17 @@ impl FlashblockCache {
                 .max_by_key(|(base_sequence, block_number, _)| {
                     (*block_number, Reverse(*base_sequence))
                 });
-            let Some((_, oldest_block, oldest_payload)) = oldest else {
+            let Some((_, evicted_block, evicted_payload)) = eviction_candidate else {
                 break;
             };
-            if let Some(by_payload) = self.entries.get_mut(&oldest_block) {
-                by_payload.remove(&oldest_payload);
+            if let Some(by_payload) = self.entries.get_mut(&evicted_block) {
+                by_payload.remove(&evicted_payload);
                 if by_payload.is_empty() {
-                    self.entries.remove(&oldest_block);
+                    self.entries.remove(&evicted_block);
                 }
             }
         }
-        true
+        self.has_flashblock(block_number, payload_id, index)
     }
 
     /// Drains the newest cached payload whose base names `parent_hash`.
@@ -427,7 +429,7 @@ mod tests {
         }
         assert_eq!(cache.total_flashblocks(), MAX_TOTAL_CACHED_FLASHBLOCKS);
 
-        assert!(cache.insert(make_flashblock(16, 0)));
+        assert!(!cache.insert(make_flashblock(16, 0)));
         assert!(cache.drain(16, B256::ZERO).is_empty());
         assert_eq!(cache.total_flashblocks(), MAX_TOTAL_CACHED_FLASHBLOCKS);
     }

--- a/crates/execution/flashblocks/src/cache.rs
+++ b/crates/execution/flashblocks/src/cache.rs
@@ -79,6 +79,11 @@ impl FlashblockCache {
         self.entries.retain(|&bn, _| bn > block_number);
     }
 
+    /// Returns the latest canonical block number observed by this cache.
+    pub const fn latest_canonical_number(&self) -> Option<BlockNumber> {
+        self.latest_canonical
+    }
+
     /// Returns the number of distinct block numbers currently cached.
     pub fn len(&self) -> usize {
         self.entries.len()

--- a/crates/execution/flashblocks/src/cache.rs
+++ b/crates/execution/flashblocks/src/cache.rs
@@ -11,6 +11,12 @@ use base_common_flashblocks::Flashblock;
 /// to avoid unbounded memory growth during syncing.
 const MAX_CACHE_AHEAD_BLOCKS: u64 = 5;
 
+/// Maximum payload attempts retained for one block number.
+const MAX_PAYLOADS_PER_BLOCK: usize = 8;
+
+/// Maximum flashblock indices retained for one payload attempt.
+const MAX_FLASHBLOCKS_PER_PAYLOAD: u64 = 64;
+
 /// Flashblocks from one payload, keyed by their sequence index.
 pub type CachedPayloadFlashblocks = HashMap<u64, Flashblock>;
 
@@ -79,12 +85,21 @@ impl FlashblockCache {
     /// because its block number exceeds the cache-ahead limit.
     pub fn insert(&mut self, flashblock: Flashblock) -> bool {
         let block_number = flashblock.metadata.block_number;
-        if !self.is_cacheable(block_number) {
+        if !self.is_cacheable(block_number) || flashblock.index >= MAX_FLASHBLOCKS_PER_PAYLOAD {
             return false;
         }
         let min_block_number_to_retain = block_number.saturating_sub(MAX_CACHE_AHEAD_BLOCKS);
         self.entries.retain(|&bn, _| bn > min_block_number_to_retain);
         let by_payload = self.entries.entry(block_number).or_default();
+        if !by_payload.contains_key(&flashblock.payload_id)
+            && by_payload.len() >= MAX_PAYLOADS_PER_BLOCK
+            && let Some(oldest) = by_payload
+                .iter()
+                .min_by_key(|(_, (base_sequence, _))| *base_sequence)
+                .map(|(payload_id, _)| *payload_id)
+        {
+            by_payload.remove(&oldest);
+        }
         let payload = by_payload.entry(flashblock.payload_id).or_insert_with(|| {
             self.next_payload_sequence = self.next_payload_sequence.saturating_add(1);
             (self.next_payload_sequence, HashMap::new())
@@ -318,5 +333,26 @@ mod tests {
         let abandoned = cache.drain(11, B256::ZERO);
         assert_eq!(abandoned.len(), 3);
         assert!(abandoned.iter().all(|flashblock| flashblock.payload_id == PayloadId::new([1; 8])));
+    }
+
+    #[test]
+    fn cache_bounds_payload_attempts_and_indices() {
+        let mut cache = FlashblockCache::new(10);
+        for payload in 1u64..=9 {
+            let mut flashblock = make_flashblock(11, 0);
+            flashblock.payload_id = PayloadId::new(payload.to_be_bytes());
+            assert!(cache.insert(flashblock));
+        }
+
+        assert_eq!(cache.total_flashblocks(), MAX_PAYLOADS_PER_BLOCK);
+        let mut excessive_index = make_flashblock(11, MAX_FLASHBLOCKS_PER_PAYLOAD);
+        excessive_index.payload_id = PayloadId::new(9u64.to_be_bytes());
+        assert!(!cache.insert(excessive_index));
+
+        for expected in (2u64..=9).rev() {
+            let drained = cache.drain(11, B256::ZERO);
+            assert_eq!(drained[0].payload_id, PayloadId::new(expected.to_be_bytes()));
+        }
+        assert!(cache.is_empty());
     }
 }

--- a/crates/execution/flashblocks/src/cache.rs
+++ b/crates/execution/flashblocks/src/cache.rs
@@ -95,6 +95,18 @@ impl FlashblockCache {
             return false;
         }
         let by_payload = self.entries.entry(block_number).or_default();
+        if let Some(existing) = by_payload
+            .get(&flashblock.payload_id)
+            .and_then(|(_, by_index)| by_index.get(&flashblock.index))
+        {
+            if existing == &flashblock {
+                return true;
+            }
+            by_payload.remove(&flashblock.payload_id);
+            if flashblock.index != 0 {
+                return false;
+            }
+        }
         if !by_payload.contains_key(&flashblock.payload_id)
             && by_payload.len() >= MAX_PAYLOADS_PER_BLOCK
             && let Some(oldest) = by_payload
@@ -312,6 +324,34 @@ mod tests {
         let drained = cache.drain(11, B256::ZERO);
         assert_eq!(drained.len(), 1);
         assert_eq!(drained[0].diff.state_root, fb_new.diff.state_root);
+    }
+
+    #[test]
+    fn conflicting_base_retry_discards_cached_suffix() {
+        let mut cache = FlashblockCache::new(10);
+        let base = make_flashblock(11, 0);
+        assert!(cache.insert(base.clone()));
+        assert!(cache.insert(make_flashblock(11, 1)));
+
+        let mut replacement = base;
+        replacement.diff.state_root = B256::repeat_byte(0x11);
+        assert!(cache.insert(replacement.clone()));
+
+        let drained = cache.drain(11, B256::ZERO);
+        assert_eq!(drained, vec![replacement]);
+    }
+
+    #[test]
+    fn conflicting_delta_invalidates_cached_payload() {
+        let mut cache = FlashblockCache::new(10);
+        assert!(cache.insert(make_flashblock(11, 0)));
+        let delta = make_flashblock(11, 1);
+        assert!(cache.insert(delta.clone()));
+
+        let mut conflicting = delta;
+        conflicting.diff.state_root = B256::repeat_byte(0x22);
+        assert!(!cache.insert(conflicting));
+        assert!(cache.drain(11, B256::ZERO).is_empty());
     }
 
     #[test]

--- a/crates/execution/flashblocks/src/cache.rs
+++ b/crates/execution/flashblocks/src/cache.rs
@@ -15,7 +15,7 @@ const MAX_CACHE_AHEAD_BLOCKS: u64 = 5;
 const MAX_PAYLOADS_PER_BLOCK: usize = 8;
 
 /// Maximum flashblock indices retained for one payload attempt.
-const MAX_FLASHBLOCKS_PER_PAYLOAD: u64 = 16;
+pub const MAX_FLASHBLOCKS_PER_PAYLOAD: u64 = 16;
 
 /// Worst-case decoded bytes retained by the cache.
 const MAX_CACHE_BYTES: usize = 80 * 1024 * 1024;
@@ -94,8 +94,6 @@ impl FlashblockCache {
         if !self.is_cacheable(block_number) || flashblock.index >= MAX_FLASHBLOCKS_PER_PAYLOAD {
             return false;
         }
-        let min_block_number_to_retain = block_number.saturating_sub(MAX_CACHE_AHEAD_BLOCKS);
-        self.entries.retain(|&bn, _| bn > min_block_number_to_retain);
         let by_payload = self.entries.entry(block_number).or_default();
         if !by_payload.contains_key(&flashblock.payload_id)
             && by_payload.len() >= MAX_PAYLOADS_PER_BLOCK
@@ -256,6 +254,16 @@ mod tests {
         // Block 17 exceeds the limit
         assert!(!cache.insert(make_flashblock(17, 0)));
         assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn farther_insert_preserves_nearest_replay_candidate() {
+        let mut cache = FlashblockCache::new(10);
+        assert!(cache.insert(make_flashblock(11, 0)));
+        assert!(cache.insert(make_flashblock(16, 0)));
+
+        assert_eq!(cache.drain(11, B256::ZERO).len(), 1);
+        assert_eq!(cache.drain(16, B256::ZERO).len(), 1);
     }
 
     #[test]

--- a/crates/execution/flashblocks/src/cache.rs
+++ b/crates/execution/flashblocks/src/cache.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use alloy_primitives::{B256, BlockNumber};
 use alloy_rpc_types_engine::PayloadId;
-use base_common_flashblocks::Flashblock;
+use base_common_flashblocks::{Flashblock, MAX_DECOMPRESSED_FLASHBLOCK_BYTES};
 
 /// Maximum number of blocks ahead of the latest canonical block for which
 /// flashblocks may be cached. Flashblocks further ahead than this are rejected
@@ -15,7 +15,13 @@ const MAX_CACHE_AHEAD_BLOCKS: u64 = 5;
 const MAX_PAYLOADS_PER_BLOCK: usize = 8;
 
 /// Maximum flashblock indices retained for one payload attempt.
-const MAX_FLASHBLOCKS_PER_PAYLOAD: u64 = 64;
+const MAX_FLASHBLOCKS_PER_PAYLOAD: u64 = 16;
+
+/// Worst-case decoded bytes retained by the cache.
+const MAX_CACHE_BYTES: usize = 80 * 1024 * 1024;
+
+/// Maximum cached messages, derived from the decoder's per-message byte limit.
+const MAX_TOTAL_CACHED_FLASHBLOCKS: usize = MAX_CACHE_BYTES / MAX_DECOMPRESSED_FLASHBLOCK_BYTES;
 
 /// Flashblocks from one payload, keyed by their sequence index.
 pub type CachedPayloadFlashblocks = HashMap<u64, Flashblock>;
@@ -109,6 +115,26 @@ impl FlashblockCache {
             payload.0 = self.next_payload_sequence;
         }
         payload.1.insert(flashblock.index, flashblock);
+        while self.total_flashblocks() > MAX_TOTAL_CACHED_FLASHBLOCKS {
+            let oldest = self
+                .entries
+                .iter()
+                .flat_map(|(block_number, by_payload)| {
+                    by_payload.iter().map(move |(payload_id, (base_sequence, _))| {
+                        (*base_sequence, *block_number, *payload_id)
+                    })
+                })
+                .min_by_key(|(base_sequence, _, _)| *base_sequence);
+            let Some((_, oldest_block, oldest_payload)) = oldest else {
+                break;
+            };
+            if let Some(by_payload) = self.entries.get_mut(&oldest_block) {
+                by_payload.remove(&oldest_payload);
+                if by_payload.is_empty() {
+                    self.entries.remove(&oldest_block);
+                }
+            }
+        }
         true
     }
 
@@ -354,5 +380,24 @@ mod tests {
             assert_eq!(drained[0].payload_id, PayloadId::new(expected.to_be_bytes()));
         }
         assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn cache_enforces_global_decoded_byte_budget() {
+        let mut cache = FlashblockCache::new(10);
+        for block_number in 11u64..=13 {
+            for payload in 1u64..=8 {
+                let mut flashblock = make_flashblock(block_number, 0);
+                flashblock.payload_id =
+                    PayloadId::new((block_number * 100 + payload).to_be_bytes());
+                assert!(cache.insert(flashblock));
+            }
+        }
+
+        assert!(cache.total_flashblocks() <= MAX_TOTAL_CACHED_FLASHBLOCKS);
+        assert_eq!(
+            MAX_TOTAL_CACHED_FLASHBLOCKS * MAX_DECOMPRESSED_FLASHBLOCK_BYTES,
+            MAX_CACHE_BYTES
+        );
     }
 }

--- a/crates/execution/flashblocks/src/cache.rs
+++ b/crates/execution/flashblocks/src/cache.rs
@@ -1,6 +1,6 @@
 //! Cache for flashblocks that arrive before their canonical block.
 
-use std::collections::HashMap;
+use std::{cmp::Reverse, collections::HashMap};
 
 use alloy_primitives::{B256, BlockNumber};
 use alloy_rpc_types_engine::PayloadId;
@@ -122,7 +122,9 @@ impl FlashblockCache {
                         (*base_sequence, *block_number, *payload_id)
                     })
                 })
-                .min_by_key(|(base_sequence, _, _)| *base_sequence);
+                .max_by_key(|(base_sequence, block_number, _)| {
+                    (*block_number, Reverse(*base_sequence))
+                });
             let Some((_, oldest_block, oldest_payload)) = oldest else {
                 break;
             };
@@ -407,5 +409,22 @@ mod tests {
             MAX_TOTAL_CACHED_FLASHBLOCKS * MAX_DECOMPRESSED_FLASHBLOCK_BYTES,
             MAX_CACHE_BYTES
         );
+    }
+
+    #[test]
+    fn global_budget_evicts_farthest_block_first() {
+        let mut cache = FlashblockCache::new(10);
+        for payload in 1u64..=8 {
+            for index in 0..=1 {
+                let mut flashblock = make_flashblock(11, index);
+                flashblock.payload_id = PayloadId::new(payload.to_be_bytes());
+                assert!(cache.insert(flashblock));
+            }
+        }
+        assert_eq!(cache.total_flashblocks(), MAX_TOTAL_CACHED_FLASHBLOCKS);
+
+        assert!(cache.insert(make_flashblock(16, 0)));
+        assert!(cache.drain(16, B256::ZERO).is_empty());
+        assert_eq!(cache.total_flashblocks(), MAX_TOTAL_CACHED_FLASHBLOCKS);
     }
 }

--- a/crates/execution/flashblocks/src/cache.rs
+++ b/crates/execution/flashblocks/src/cache.rs
@@ -1,6 +1,9 @@
 //! Cache for flashblocks that arrive before their canonical block.
 
-use std::{cmp::Reverse, collections::HashMap};
+use std::{
+    cmp::Reverse,
+    collections::{HashMap, HashSet},
+};
 
 use alloy_primitives::{B256, BlockNumber};
 use alloy_rpc_types_engine::PayloadId;
@@ -46,6 +49,9 @@ pub struct FlashblockCache {
     /// Monotonic sequence assigned to newly observed payload bases.
     next_payload_sequence: u64,
 
+    /// Block numbers rejected after conflicting fragments were observed.
+    conflicted_blocks: HashSet<BlockNumber>,
+
     /// The latest canonical block number we have observed, used to decide
     /// whether a flashblock is close enough to cache.
     latest_canonical: Option<BlockNumber>,
@@ -57,6 +63,7 @@ impl FlashblockCache {
         Self {
             entries: HashMap::new(),
             next_payload_sequence: 0,
+            conflicted_blocks: HashSet::new(),
             latest_canonical: Some(latest_canonical),
         }
     }
@@ -94,19 +101,23 @@ impl FlashblockCache {
         if !self.is_cacheable(block_number) || flashblock.index >= MAX_FLASHBLOCKS_PER_PAYLOAD {
             return false;
         }
-        let by_payload = self.entries.entry(block_number).or_default();
-        if let Some(existing) = by_payload
-            .get(&flashblock.payload_id)
-            .and_then(|(_, by_index)| by_index.get(&flashblock.index))
-        {
-            if existing == &flashblock {
-                return true;
-            }
-            by_payload.remove(&flashblock.payload_id);
-            if flashblock.index != 0 {
-                return false;
-            }
+        if self.conflicted_blocks.contains(&block_number) {
+            return false;
         }
+        let existing = self
+            .entries
+            .get(&block_number)
+            .and_then(|by_payload| by_payload.get(&flashblock.payload_id))
+            .and_then(|(_, by_index)| by_index.get(&flashblock.index));
+        if existing == Some(&flashblock) {
+            return true;
+        }
+        if existing.is_some() {
+            self.entries.remove(&block_number);
+            self.conflicted_blocks.insert(block_number);
+            return false;
+        }
+        let by_payload = self.entries.entry(block_number).or_default();
         if !by_payload.contains_key(&flashblock.payload_id)
             && by_payload.len() >= MAX_PAYLOADS_PER_BLOCK
             && let Some(oldest) = by_payload
@@ -188,6 +199,7 @@ impl FlashblockCache {
     pub fn update_canonical(&mut self, block_number: BlockNumber) {
         self.latest_canonical = Some(block_number);
         self.entries.retain(|&bn, _| bn > block_number);
+        self.conflicted_blocks.retain(|bn| *bn > block_number);
     }
 
     /// Returns the latest canonical block number observed by this cache.
@@ -302,6 +314,7 @@ mod tests {
         let mut cache = FlashblockCache {
             entries: HashMap::new(),
             next_payload_sequence: 0,
+            conflicted_blocks: HashSet::new(),
             latest_canonical: None,
         };
         assert!(!cache.is_cacheable(1));
@@ -309,25 +322,19 @@ mod tests {
     }
 
     #[test]
-    fn duplicate_index_keeps_latest() {
+    fn exact_duplicate_is_ignored() {
         let mut cache = FlashblockCache::new(10);
-
-        let mut fb_old = make_flashblock(11, 0);
-        fb_old.diff.state_root = alloy_primitives::B256::ZERO;
-        let mut fb_new = make_flashblock(11, 0);
-        fb_new.diff.state_root = alloy_primitives::B256::with_last_byte(1);
-
-        assert!(cache.insert(fb_old));
-        assert!(cache.insert(fb_new.clone()));
+        let flashblock = make_flashblock(11, 0);
+        assert!(cache.insert(flashblock.clone()));
+        assert!(cache.insert(flashblock.clone()));
         assert_eq!(cache.total_flashblocks(), 1);
 
         let drained = cache.drain(11, B256::ZERO);
-        assert_eq!(drained.len(), 1);
-        assert_eq!(drained[0].diff.state_root, fb_new.diff.state_root);
+        assert_eq!(drained, vec![flashblock]);
     }
 
     #[test]
-    fn conflicting_base_retry_discards_cached_suffix() {
+    fn conflicting_base_tombstones_block_cache() {
         let mut cache = FlashblockCache::new(10);
         let base = make_flashblock(11, 0);
         assert!(cache.insert(base.clone()));
@@ -335,10 +342,13 @@ mod tests {
 
         let mut replacement = base;
         replacement.diff.state_root = B256::repeat_byte(0x11);
-        assert!(cache.insert(replacement.clone()));
+        assert!(!cache.insert(replacement));
+        assert!(!cache.insert(make_flashblock(11, 2)));
+        let mut new_payload = make_flashblock(11, 0);
+        new_payload.payload_id = PayloadId::new([9; 8]);
+        assert!(!cache.insert(new_payload));
 
-        let drained = cache.drain(11, B256::ZERO);
-        assert_eq!(drained, vec![replacement]);
+        assert!(cache.drain(11, B256::ZERO).is_empty());
     }
 
     #[test]

--- a/crates/execution/flashblocks/src/cache.rs
+++ b/crates/execution/flashblocks/src/cache.rs
@@ -51,7 +51,7 @@ pub struct FlashblockCache {
 
     /// The latest canonical block number we have observed, used to decide
     /// whether a flashblock is close enough to cache.
-    latest_canonical: Option<BlockNumber>,
+    latest_canonical: BlockNumber,
 }
 
 impl FlashblockCache {
@@ -61,7 +61,7 @@ impl FlashblockCache {
             entries: HashMap::new(),
             next_payload_sequence: 0,
             conflicted_blocks: HashSet::new(),
-            latest_canonical: Some(latest_canonical),
+            latest_canonical,
         }
     }
 
@@ -83,10 +83,7 @@ impl FlashblockCache {
     /// [`MAX_CACHE_AHEAD_BLOCKS`] of the latest known canonical block and is
     /// therefore eligible for caching.
     pub const fn is_cacheable(&self, block_number: BlockNumber) -> bool {
-        match self.latest_canonical {
-            Some(canonical) => block_number <= canonical + MAX_CACHE_AHEAD_BLOCKS + 1,
-            None => false,
-        }
+        block_number <= self.latest_canonical + MAX_CACHE_AHEAD_BLOCKS + 1
     }
 
     /// Inserts a flashblock into the cache.
@@ -185,13 +182,13 @@ impl FlashblockCache {
     /// Updates the latest canonical block number and evicts any cached entries
     /// at or below it (they can no longer be useful).
     pub fn update_canonical(&mut self, block_number: BlockNumber) {
-        self.latest_canonical = Some(block_number);
+        self.latest_canonical = block_number;
         self.entries.retain(|&bn, _| bn > block_number);
         self.conflicted_blocks.retain(|bn| *bn > block_number);
     }
 
     /// Returns the latest canonical block number observed by this cache.
-    pub const fn latest_canonical_number(&self) -> Option<BlockNumber> {
+    pub const fn latest_canonical_number(&self) -> BlockNumber {
         self.latest_canonical
     }
 
@@ -295,18 +292,6 @@ mod tests {
         assert!(cache.drain(11, B256::ZERO).is_empty());
         assert!(cache.drain(12, B256::ZERO).is_empty());
         assert_eq!(cache.drain(13, B256::ZERO).len(), 1);
-    }
-
-    #[test]
-    fn not_cacheable_without_canonical() {
-        let mut cache = FlashblockCache {
-            entries: HashMap::new(),
-            next_payload_sequence: 0,
-            conflicted_blocks: HashSet::new(),
-            latest_canonical: None,
-        };
-        assert!(!cache.is_cacheable(1));
-        assert!(!cache.insert(make_flashblock(1, 0)));
     }
 
     #[test]

--- a/crates/execution/flashblocks/src/cache.rs
+++ b/crates/execution/flashblocks/src/cache.rs
@@ -2,7 +2,8 @@
 
 use std::collections::HashMap;
 
-use alloy_primitives::BlockNumber;
+use alloy_primitives::{B256, BlockNumber};
+use alloy_rpc_types_engine::PayloadId;
 use base_common_flashblocks::Flashblock;
 
 /// Maximum number of blocks ahead of the latest canonical block for which
@@ -15,10 +16,8 @@ const MAX_CACHE_AHEAD_BLOCKS: u64 = 5;
 /// corresponding entries and feeds them through normal execution.
 #[derive(Debug)]
 pub struct FlashblockCache {
-    /// Flashblocks keyed by block number, then by flashblock index. Using a
-    /// nested map deduplicates by index — a later flashblock with the same
-    /// index silently replaces the earlier one.
-    entries: HashMap<BlockNumber, HashMap<u64, Flashblock>>,
+    /// Flashblocks keyed by block number, payload ID, then flashblock index.
+    entries: HashMap<BlockNumber, HashMap<PayloadId, HashMap<u64, Flashblock>>>,
 
     /// The latest canonical block number we have observed, used to decide
     /// whether a flashblock is close enough to cache.
@@ -32,8 +31,17 @@ impl FlashblockCache {
     }
 
     /// Returns `true` when the flashblock is cached.
-    pub fn has_flashblock(&self, block_number: BlockNumber, index: u64) -> bool {
-        self.entries.get(&block_number).and_then(|by_index| by_index.get(&index)).is_some()
+    pub fn has_flashblock(
+        &self,
+        block_number: BlockNumber,
+        payload_id: PayloadId,
+        index: u64,
+    ) -> bool {
+        self.entries
+            .get(&block_number)
+            .and_then(|by_payload| by_payload.get(&payload_id))
+            .and_then(|by_index| by_index.get(&index))
+            .is_some()
     }
 
     /// Returns `true` when the flashblock's block number is within
@@ -57,14 +65,32 @@ impl FlashblockCache {
         }
         let min_block_number_to_retain = block_number.saturating_sub(MAX_CACHE_AHEAD_BLOCKS);
         self.entries.retain(|&bn, _| bn > min_block_number_to_retain);
-        self.entries.entry(block_number).or_default().insert(flashblock.index, flashblock);
+        self.entries
+            .entry(block_number)
+            .or_default()
+            .entry(flashblock.payload_id)
+            .or_default()
+            .insert(flashblock.index, flashblock);
         true
     }
 
-    /// Drains all cached flashblocks for the given block number, returning them
-    /// sorted by index. Returns an empty `Vec` when nothing is cached.
-    pub fn drain(&mut self, block_number: BlockNumber) -> Vec<Flashblock> {
-        let Some(by_index) = self.entries.remove(&block_number) else {
+    /// Drains the most complete cached payload whose base names `parent_hash`.
+    ///
+    /// Flashblocks from different payload IDs are never combined.
+    pub fn drain(&mut self, block_number: BlockNumber, parent_hash: B256) -> Vec<Flashblock> {
+        let Some(by_payload) = self.entries.remove(&block_number) else {
+            return Vec::new();
+        };
+        let Some(by_index) = by_payload
+            .into_values()
+            .filter(|by_index| {
+                by_index
+                    .get(&0)
+                    .and_then(|flashblock| flashblock.base.as_ref())
+                    .is_some_and(|base| base.parent_hash == parent_hash)
+            })
+            .max_by_key(HashMap::len)
+        else {
             return Vec::new();
         };
         let mut flashblocks: Vec<Flashblock> = by_index.into_values().collect();
@@ -97,14 +123,16 @@ impl FlashblockCache {
     /// Returns the total number of individual flashblocks cached across all
     /// block numbers.
     pub fn total_flashblocks(&self) -> usize {
-        self.entries.values().map(|by_index| by_index.len()).sum()
+        self.entries.values().flat_map(HashMap::values).map(HashMap::len).sum()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use alloy_rpc_types_engine::PayloadId;
-    use base_common_flashblocks::{ExecutionPayloadFlashblockDeltaV1, Metadata};
+    use base_common_flashblocks::{
+        ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, Metadata,
+    };
 
     use super::*;
 
@@ -112,7 +140,11 @@ mod tests {
         Flashblock {
             payload_id: PayloadId::default(),
             index,
-            base: None,
+            base: (index == 0).then_some(ExecutionPayloadBaseV1 {
+                parent_hash: B256::ZERO,
+                block_number,
+                ..Default::default()
+            }),
             diff: ExecutionPayloadFlashblockDeltaV1::default(),
             metadata: Metadata::new(block_number),
         }
@@ -127,7 +159,7 @@ mod tests {
         assert_eq!(cache.len(), 1);
         assert_eq!(cache.total_flashblocks(), 2);
 
-        let drained = cache.drain(11);
+        let drained = cache.drain(11, B256::ZERO);
         assert_eq!(drained.len(), 2);
         // Should be sorted by index
         assert_eq!(drained[0].index, 0);
@@ -138,7 +170,7 @@ mod tests {
     #[test]
     fn drain_empty() {
         let mut cache = FlashblockCache::new(0);
-        let drained = cache.drain(42);
+        let drained = cache.drain(42, B256::ZERO);
         assert!(drained.is_empty());
     }
 
@@ -165,9 +197,9 @@ mod tests {
         // Advancing canonical to 12 should evict blocks 11 and 12
         cache.update_canonical(12);
         assert_eq!(cache.len(), 1);
-        assert!(cache.drain(11).is_empty());
-        assert!(cache.drain(12).is_empty());
-        assert_eq!(cache.drain(13).len(), 1);
+        assert!(cache.drain(11, B256::ZERO).is_empty());
+        assert!(cache.drain(12, B256::ZERO).is_empty());
+        assert_eq!(cache.drain(13, B256::ZERO).len(), 1);
     }
 
     #[test]
@@ -190,7 +222,7 @@ mod tests {
         assert!(cache.insert(fb_new.clone()));
         assert_eq!(cache.total_flashblocks(), 1);
 
-        let drained = cache.drain(11);
+        let drained = cache.drain(11, B256::ZERO);
         assert_eq!(drained.len(), 1);
         assert_eq!(drained[0].diff.state_root, fb_new.diff.state_root);
     }
@@ -205,10 +237,29 @@ mod tests {
         assert_eq!(cache.total_flashblocks(), 3);
         assert_eq!(cache.len(), 1);
 
-        let drained = cache.drain(11);
+        let drained = cache.drain(11, B256::ZERO);
         assert_eq!(drained.len(), 3);
         assert_eq!(drained[0].index, 0);
         assert_eq!(drained[1].index, 1);
         assert_eq!(drained[2].index, 2);
+    }
+
+    #[test]
+    fn payloads_are_not_mixed() {
+        let mut cache = FlashblockCache::new(10);
+        let mut first_base = make_flashblock(11, 0);
+        first_base.payload_id = PayloadId::new([1; 8]);
+        let mut first_delta = make_flashblock(11, 1);
+        first_delta.payload_id = PayloadId::new([1; 8]);
+        let mut second_delta = make_flashblock(11, 2);
+        second_delta.payload_id = PayloadId::new([2; 8]);
+
+        assert!(cache.insert(first_base));
+        assert!(cache.insert(first_delta));
+        assert!(cache.insert(second_delta));
+
+        let drained = cache.drain(11, B256::ZERO);
+        assert_eq!(drained.len(), 2);
+        assert!(drained.iter().all(|flashblock| flashblock.payload_id == PayloadId::new([1; 8])));
     }
 }

--- a/crates/execution/flashblocks/src/cache.rs
+++ b/crates/execution/flashblocks/src/cache.rs
@@ -11,13 +11,28 @@ use base_common_flashblocks::Flashblock;
 /// to avoid unbounded memory growth during syncing.
 const MAX_CACHE_AHEAD_BLOCKS: u64 = 5;
 
+/// Flashblocks from one payload, keyed by their sequence index.
+pub type CachedPayloadFlashblocks = HashMap<u64, Flashblock>;
+
+/// Cached payload sequence number and its flashblocks.
+pub type CachedPayload = (u64, CachedPayloadFlashblocks);
+
+/// Cached payload attempts keyed by payload ID.
+pub type CachedPayloads = HashMap<PayloadId, CachedPayload>;
+
 /// Buffers flashblocks that arrive before their parent canonical block has been
 /// processed. Once the canonical block lands, the caller drains the
 /// corresponding entries and feeds them through normal execution.
 #[derive(Debug)]
 pub struct FlashblockCache {
     /// Flashblocks keyed by block number, payload ID, then flashblock index.
-    entries: HashMap<BlockNumber, HashMap<PayloadId, HashMap<u64, Flashblock>>>,
+    ///
+    /// Each payload stores the arrival sequence of its index-zero base so a
+    /// replacement build is preferred over an older, longer attempt.
+    entries: HashMap<BlockNumber, CachedPayloads>,
+
+    /// Monotonic sequence assigned to newly observed payload bases.
+    next_payload_sequence: u64,
 
     /// The latest canonical block number we have observed, used to decide
     /// whether a flashblock is close enough to cache.
@@ -27,7 +42,11 @@ pub struct FlashblockCache {
 impl FlashblockCache {
     /// Creates a new cache initialized with the given canonical block number.
     pub fn new(latest_canonical: BlockNumber) -> Self {
-        Self { entries: HashMap::new(), latest_canonical: Some(latest_canonical) }
+        Self {
+            entries: HashMap::new(),
+            next_payload_sequence: 0,
+            latest_canonical: Some(latest_canonical),
+        }
     }
 
     /// Returns `true` when the flashblock is cached.
@@ -40,7 +59,7 @@ impl FlashblockCache {
         self.entries
             .get(&block_number)
             .and_then(|by_payload| by_payload.get(&payload_id))
-            .and_then(|by_index| by_index.get(&index))
+            .and_then(|(_, by_index)| by_index.get(&index))
             .is_some()
     }
 
@@ -65,34 +84,47 @@ impl FlashblockCache {
         }
         let min_block_number_to_retain = block_number.saturating_sub(MAX_CACHE_AHEAD_BLOCKS);
         self.entries.retain(|&bn, _| bn > min_block_number_to_retain);
-        self.entries
-            .entry(block_number)
-            .or_default()
-            .entry(flashblock.payload_id)
-            .or_default()
-            .insert(flashblock.index, flashblock);
+        let by_payload = self.entries.entry(block_number).or_default();
+        let payload = by_payload.entry(flashblock.payload_id).or_insert_with(|| {
+            self.next_payload_sequence = self.next_payload_sequence.saturating_add(1);
+            (self.next_payload_sequence, HashMap::new())
+        });
+        if flashblock.index == 0 && !payload.1.is_empty() {
+            self.next_payload_sequence = self.next_payload_sequence.saturating_add(1);
+            payload.0 = self.next_payload_sequence;
+        }
+        payload.1.insert(flashblock.index, flashblock);
         true
     }
 
-    /// Drains the most complete cached payload whose base names `parent_hash`.
+    /// Drains the newest cached payload whose base names `parent_hash`.
     ///
-    /// Flashblocks from different payload IDs are never combined.
+    /// Flashblocks from different payload IDs are never combined, and older
+    /// alternatives remain cached until one can be replayed successfully.
     pub fn drain(&mut self, block_number: BlockNumber, parent_hash: B256) -> Vec<Flashblock> {
-        let Some(by_payload) = self.entries.remove(&block_number) else {
+        let Some(payload_id) = self.entries.get(&block_number).and_then(|by_payload| {
+            by_payload
+                .iter()
+                .filter(|(_, (_, by_index))| {
+                    by_index
+                        .get(&0)
+                        .and_then(|flashblock| flashblock.base.as_ref())
+                        .is_some_and(|base| base.parent_hash == parent_hash)
+                })
+                .max_by_key(|(_, (base_sequence, _))| *base_sequence)
+                .map(|(payload_id, _)| *payload_id)
+        }) else {
             return Vec::new();
         };
-        let Some(by_index) = by_payload
-            .into_values()
-            .filter(|by_index| {
-                by_index
-                    .get(&0)
-                    .and_then(|flashblock| flashblock.base.as_ref())
-                    .is_some_and(|base| base.parent_hash == parent_hash)
-            })
-            .max_by_key(HashMap::len)
-        else {
-            return Vec::new();
-        };
+        let by_index = self
+            .entries
+            .get_mut(&block_number)
+            .and_then(|by_payload| by_payload.remove(&payload_id))
+            .map(|(_, by_index)| by_index)
+            .unwrap_or_default();
+        if self.entries.get(&block_number).is_some_and(HashMap::is_empty) {
+            self.entries.remove(&block_number);
+        }
         let mut flashblocks: Vec<Flashblock> = by_index.into_values().collect();
         flashblocks.sort_by_key(|fb| fb.index);
         flashblocks
@@ -123,7 +155,7 @@ impl FlashblockCache {
     /// Returns the total number of individual flashblocks cached across all
     /// block numbers.
     pub fn total_flashblocks(&self) -> usize {
-        self.entries.values().flat_map(HashMap::values).map(HashMap::len).sum()
+        self.entries.values().flat_map(HashMap::values).map(|(_, by_index)| by_index.len()).sum()
     }
 }
 
@@ -204,7 +236,11 @@ mod tests {
 
     #[test]
     fn not_cacheable_without_canonical() {
-        let mut cache = FlashblockCache { entries: HashMap::new(), latest_canonical: None };
+        let mut cache = FlashblockCache {
+            entries: HashMap::new(),
+            next_payload_sequence: 0,
+            latest_canonical: None,
+        };
         assert!(!cache.is_cacheable(1));
         assert!(!cache.insert(make_flashblock(1, 0)));
     }
@@ -261,5 +297,26 @@ mod tests {
         let drained = cache.drain(11, B256::ZERO);
         assert_eq!(drained.len(), 2);
         assert!(drained.iter().all(|flashblock| flashblock.payload_id == PayloadId::new([1; 8])));
+    }
+
+    #[test]
+    fn newest_base_wins_over_longer_abandoned_payload() {
+        let mut cache = FlashblockCache::new(10);
+        for index in 0..3 {
+            let mut flashblock = make_flashblock(11, index);
+            flashblock.payload_id = PayloadId::new([1; 8]);
+            assert!(cache.insert(flashblock));
+        }
+        let mut replacement = make_flashblock(11, 0);
+        replacement.payload_id = PayloadId::new([2; 8]);
+        assert!(cache.insert(replacement));
+
+        let replacement = cache.drain(11, B256::ZERO);
+        assert_eq!(replacement.len(), 1);
+        assert_eq!(replacement[0].payload_id, PayloadId::new([2; 8]));
+
+        let abandoned = cache.drain(11, B256::ZERO);
+        assert_eq!(abandoned.len(), 3);
+        assert!(abandoned.iter().all(|flashblock| flashblock.payload_id == PayloadId::new([1; 8])));
     }
 }

--- a/crates/execution/flashblocks/src/cache.rs
+++ b/crates/execution/flashblocks/src/cache.rs
@@ -14,9 +14,6 @@ use base_common_flashblocks::{Flashblock, MAX_DECOMPRESSED_FLASHBLOCK_BYTES};
 /// to avoid unbounded memory growth during syncing.
 const MAX_CACHE_AHEAD_BLOCKS: u64 = 5;
 
-/// Maximum payload attempts retained for one block number.
-const MAX_PAYLOADS_PER_BLOCK: usize = 8;
-
 /// Maximum flashblock indices retained for one payload attempt.
 pub const MAX_FLASHBLOCKS_PER_PAYLOAD: u64 = 16;
 
@@ -118,15 +115,6 @@ impl FlashblockCache {
             return false;
         }
         let by_payload = self.entries.entry(block_number).or_default();
-        if !by_payload.contains_key(&flashblock.payload_id)
-            && by_payload.len() >= MAX_PAYLOADS_PER_BLOCK
-            && let Some(oldest) = by_payload
-                .iter()
-                .min_by_key(|(_, (base_sequence, _))| *base_sequence)
-                .map(|(payload_id, _)| *payload_id)
-        {
-            by_payload.remove(&oldest);
-        }
         let payload = by_payload.entry(flashblock.payload_id).or_insert_with(|| {
             self.next_payload_sequence = self.next_payload_sequence.saturating_add(1);
             (self.next_payload_sequence, HashMap::new())
@@ -422,7 +410,7 @@ mod tests {
     }
 
     #[test]
-    fn cache_bounds_payload_attempts_and_indices() {
+    fn cache_bounds_payload_indices() {
         let mut cache = FlashblockCache::new(10);
         for payload in 1u64..=9 {
             let mut flashblock = make_flashblock(11, 0);
@@ -430,12 +418,12 @@ mod tests {
             assert!(cache.insert(flashblock));
         }
 
-        assert_eq!(cache.total_flashblocks(), MAX_PAYLOADS_PER_BLOCK);
+        assert_eq!(cache.total_flashblocks(), 9);
         let mut excessive_index = make_flashblock(11, MAX_FLASHBLOCKS_PER_PAYLOAD);
         excessive_index.payload_id = PayloadId::new(9u64.to_be_bytes());
         assert!(!cache.insert(excessive_index));
 
-        for expected in (2u64..=9).rev() {
+        for expected in (1u64..=9).rev() {
             let drained = cache.drain(11, B256::ZERO);
             assert_eq!(drained[0].payload_id, PayloadId::new(expected.to_be_bytes()));
         }

--- a/crates/execution/flashblocks/src/cache.rs
+++ b/crates/execution/flashblocks/src/cache.rs
@@ -431,25 +431,6 @@ mod tests {
     }
 
     #[test]
-    fn cache_enforces_global_decoded_byte_budget() {
-        let mut cache = FlashblockCache::new(10);
-        for block_number in 11u64..=13 {
-            for payload in 1u64..=8 {
-                let mut flashblock = make_flashblock(block_number, 0);
-                flashblock.payload_id =
-                    PayloadId::new((block_number * 100 + payload).to_be_bytes());
-                assert!(cache.insert(flashblock));
-            }
-        }
-
-        assert!(cache.total_flashblocks() <= MAX_TOTAL_CACHED_FLASHBLOCKS);
-        assert_eq!(
-            MAX_TOTAL_CACHED_FLASHBLOCKS * MAX_DECOMPRESSED_FLASHBLOCK_BYTES,
-            MAX_CACHE_BYTES
-        );
-    }
-
-    #[test]
     fn global_budget_evicts_farthest_block_first() {
         let mut cache = FlashblockCache::new(10);
         for payload in 1u64..=8 {

--- a/crates/execution/flashblocks/src/config.rs
+++ b/crates/execution/flashblocks/src/config.rs
@@ -9,8 +9,7 @@ use crate::FlashblocksState;
 pub struct FlashblocksConfig {
     /// The websocket endpoint that streams flashblock updates.
     pub websocket_url: Url,
-    /// Deprecated and ignored. Pending flashblocks are rebased onto the current canonical tip.
-    /// Kept so existing [`Self::new`] call sites remain source-compatible.
+    /// Maximum number of pending blocks retained ahead of the canonical tip.
     pub max_pending_blocks_depth: u64,
     /// Interval between upstream websocket ping frames.
     pub subscriber_ping_interval: Duration,

--- a/crates/execution/flashblocks/src/config.rs
+++ b/crates/execution/flashblocks/src/config.rs
@@ -9,7 +9,8 @@ use crate::FlashblocksState;
 pub struct FlashblocksConfig {
     /// The websocket endpoint that streams flashblock updates.
     pub websocket_url: Url,
-    /// Maximum number of pending flashblocks to retain in memory.
+    /// Deprecated and ignored. Pending flashblocks are rebased onto the current canonical tip.
+    /// Kept so existing [`Self::new`] call sites remain source-compatible.
     pub max_pending_blocks_depth: u64,
     /// Interval between upstream websocket ping frames.
     pub subscriber_ping_interval: Duration,

--- a/crates/execution/flashblocks/src/config.rs
+++ b/crates/execution/flashblocks/src/config.rs
@@ -10,6 +10,11 @@ pub struct FlashblocksConfig {
     /// The websocket endpoint that streams flashblock updates.
     pub websocket_url: Url,
     /// Maximum number of pending blocks retained ahead of the canonical tip.
+    ///
+    /// Counts canonical block numbers, not flashblock indices. When pending is
+    /// not based on the provider tip, or `latest - canonical` exceeds this
+    /// depth, the processor clears the snapshot until an index-0 flashblock
+    /// rooted at that tip arrives. The node CLI default is `3`.
     pub max_pending_blocks_depth: u64,
     /// Interval between upstream websocket ping frames.
     pub subscriber_ping_interval: Duration,

--- a/crates/execution/flashblocks/src/error.rs
+++ b/crates/execution/flashblocks/src/error.rs
@@ -27,6 +27,15 @@ pub enum ProtocolError {
         /// Parent block hash declared by the flashblock base.
         actual: B256,
     },
+
+    /// Base and metadata disagree on the block number.
+    #[error("flashblock block number mismatch: base {base}, metadata {metadata}")]
+    BlockNumberMismatch {
+        /// Block number declared by the base payload.
+        base: u64,
+        /// Block number declared by metadata.
+        metadata: u64,
+    },
 }
 
 /// Errors related to state provider and infrastructure operations.
@@ -201,6 +210,10 @@ mod tests {
             actual: B256::repeat_byte(0x22),
         },
         "invalid pending parent hash: expected 0x1111111111111111111111111111111111111111111111111111111111111111, got 0x2222222222222222222222222222222222222222222222222222222222222222"
+    )]
+    #[case::block_number_mismatch(
+        ProtocolError::BlockNumberMismatch { base: 11, metadata: 12 },
+        "flashblock block number mismatch: base 11, metadata 12"
     )]
     fn test_protocol_error_display(#[case] error: ProtocolError, #[case] expected: &str) {
         assert_eq!(error.to_string(), expected);

--- a/crates/execution/flashblocks/src/error.rs
+++ b/crates/execution/flashblocks/src/error.rs
@@ -36,6 +36,10 @@ pub enum ProtocolError {
         /// Block number declared by metadata.
         metadata: u64,
     },
+
+    /// Pending flashblocks cannot target genesis block zero.
+    #[error("flashblock block number must be greater than zero")]
+    ZeroBlockNumber,
 }
 
 /// Errors related to state provider and infrastructure operations.
@@ -214,6 +218,10 @@ mod tests {
     #[case::block_number_mismatch(
         ProtocolError::BlockNumberMismatch { base: 11, metadata: 12 },
         "flashblock block number mismatch: base 11, metadata 12"
+    )]
+    #[case::zero_block_number(
+        ProtocolError::ZeroBlockNumber,
+        "flashblock block number must be greater than zero"
     )]
     fn test_protocol_error_display(#[case] error: ProtocolError, #[case] expected: &str) {
         assert_eq!(error.to_string(), expected);

--- a/crates/execution/flashblocks/src/error.rs
+++ b/crates/execution/flashblocks/src/error.rs
@@ -18,6 +18,15 @@ pub enum ProtocolError {
     /// Cannot build from an empty flashblocks collection.
     #[error("empty flashblocks: cannot build state from zero flashblocks")]
     EmptyFlashblocks,
+
+    /// A pending block does not extend the preceding pending or canonical block.
+    #[error("invalid pending parent hash: expected {expected}, got {actual}")]
+    ParentHashMismatch {
+        /// Expected parent block hash.
+        expected: B256,
+        /// Parent block hash declared by the flashblock base.
+        actual: B256,
+    },
 }
 
 /// Errors related to state provider and infrastructure operations.
@@ -185,6 +194,13 @@ mod tests {
     #[case::empty_flashblocks(
         ProtocolError::EmptyFlashblocks,
         "empty flashblocks: cannot build state from zero flashblocks"
+    )]
+    #[case::parent_hash_mismatch(
+        ProtocolError::ParentHashMismatch {
+            expected: B256::repeat_byte(0x11),
+            actual: B256::repeat_byte(0x22),
+        },
+        "invalid pending parent hash: expected 0x1111111111111111111111111111111111111111111111111111111111111111, got 0x2222222222222222222222222222222222222222222222222222222222222222"
     )]
     fn test_protocol_error_display(#[case] error: ProtocolError, #[case] expected: &str) {
         assert_eq!(error.to_string(), expected);

--- a/crates/execution/flashblocks/src/lib.rs
+++ b/crates/execution/flashblocks/src/lib.rs
@@ -14,7 +14,7 @@ mod block_assembler;
 pub use block_assembler::{AssembledBlock, BlockAssembler};
 
 mod cache;
-pub use cache::FlashblockCache;
+pub use cache::{CachedPayload, CachedPayloadFlashblocks, CachedPayloads, FlashblockCache};
 
 mod error;
 pub use error::{

--- a/crates/execution/flashblocks/src/lib.rs
+++ b/crates/execution/flashblocks/src/lib.rs
@@ -14,7 +14,10 @@ mod block_assembler;
 pub use block_assembler::{AssembledBlock, BlockAssembler};
 
 mod cache;
-pub use cache::{CachedPayload, CachedPayloadFlashblocks, CachedPayloads, FlashblockCache};
+pub use cache::{
+    CachedPayload, CachedPayloadFlashblocks, CachedPayloads, FlashblockCache,
+    MAX_FLASHBLOCKS_PER_PAYLOAD,
+};
 
 mod error;
 pub use error::{

--- a/crates/execution/flashblocks/src/metrics.rs
+++ b/crates/execution/flashblocks/src/metrics.rs
@@ -20,6 +20,10 @@ base_metrics::define_metrics! {
     pending_clear_catchup: counter,
     #[describe("Number of times pending snapshot was cleared because of reorg")]
     pending_clear_reorg: counter,
+    #[describe("Number of queued flashblock or canonical events skipped as stale versus current tip")]
+    pending_stale_events_skipped: counter,
+    #[describe("Number of times the flashblock processor entered stale-queue recovery")]
+    pending_queue_recovery: counter,
     #[describe("Pending snapshot flashblock index (current)")]
     pending_snapshot_fb_index: gauge,
     #[describe("Pending snapshot block number (current)")]

--- a/crates/execution/flashblocks/src/metrics.rs
+++ b/crates/execution/flashblocks/src/metrics.rs
@@ -22,8 +22,8 @@ base_metrics::define_metrics! {
     pending_clear_reorg: counter,
     #[describe("Number of queued flashblock or canonical events skipped as stale versus current tip")]
     pending_stale_events_skipped: counter,
-    #[describe("Number of times the flashblock processor entered stale-queue recovery")]
-    pending_queue_recovery: counter,
+    #[describe("Number of times the flashblock processor entered recovery")]
+    pending_recovery_transitions: counter,
     #[describe("Pending snapshot flashblock index (current)")]
     pending_snapshot_fb_index: gauge,
     #[describe("Pending snapshot block number (current)")]

--- a/crates/execution/flashblocks/src/pending_blocks.rs
+++ b/crates/execution/flashblocks/src/pending_blocks.rs
@@ -464,6 +464,19 @@ impl PendingBlocks {
             .unwrap_or_default()
     }
 
+    /// Returns the expected parent hash for a pending block number.
+    #[inline]
+    pub fn expected_parent_hash(&self, block_number: BlockNumber) -> Option<B256> {
+        if block_number == self.earliest_block_number() {
+            return Some(self.parent_hash());
+        }
+        self.flashblocks
+            .iter()
+            .filter(|flashblock| flashblock.metadata.block_number.saturating_add(1) == block_number)
+            .last()
+            .map(|flashblock| flashblock.diff.block_hash)
+    }
+
     /// Returns the index of the latest flashblock.
     #[inline]
     pub const fn latest_flashblock_index(&self) -> u64 {

--- a/crates/execution/flashblocks/src/pending_blocks.rs
+++ b/crates/execution/flashblocks/src/pending_blocks.rs
@@ -454,6 +454,15 @@ impl PendingBlocks {
         self.flashblocks.iter().last().map(|flashblock| flashblock.payload_id).unwrap_or_default()
     }
 
+    /// Returns the payload ID represented for `block_number`.
+    #[inline]
+    pub fn payload_id_for_block(&self, block_number: BlockNumber) -> Option<PayloadId> {
+        self.flashblocks
+            .iter()
+            .find(|flashblock| flashblock.metadata.block_number == block_number)
+            .map(|flashblock| flashblock.payload_id)
+    }
+
     /// Returns the block hash reported by the latest flashblock.
     #[inline]
     pub fn latest_block_hash(&self) -> B256 {

--- a/crates/execution/flashblocks/src/pending_blocks.rs
+++ b/crates/execution/flashblocks/src/pending_blocks.rs
@@ -463,6 +463,21 @@ impl PendingBlocks {
             .map(|flashblock| flashblock.payload_id)
     }
 
+    /// Returns the flashblock with the requested block, payload, and sequence identity.
+    #[inline]
+    pub fn flashblock_for_identity(
+        &self,
+        block_number: BlockNumber,
+        payload_id: PayloadId,
+        index: u64,
+    ) -> Option<&Flashblock> {
+        self.flashblocks.iter().find(|flashblock| {
+            flashblock.metadata.block_number == block_number
+                && flashblock.payload_id == payload_id
+                && flashblock.index == index
+        })
+    }
+
     /// Returns the block hash reported by the latest flashblock.
     #[inline]
     pub fn latest_block_hash(&self) -> B256 {

--- a/crates/execution/flashblocks/src/pending_blocks.rs
+++ b/crates/execution/flashblocks/src/pending_blocks.rs
@@ -448,6 +448,22 @@ impl PendingBlocks {
         self.flashblocks.iter().next().map(|fb| fb.payload_id).unwrap_or_default()
     }
 
+    /// Returns the payload ID of the latest pending block.
+    #[inline]
+    pub fn latest_payload_id(&self) -> PayloadId {
+        self.flashblocks.iter().last().map(|flashblock| flashblock.payload_id).unwrap_or_default()
+    }
+
+    /// Returns the block hash reported by the latest flashblock.
+    #[inline]
+    pub fn latest_block_hash(&self) -> B256 {
+        self.flashblocks
+            .iter()
+            .last()
+            .map(|flashblock| flashblock.diff.block_hash)
+            .unwrap_or_default()
+    }
+
     /// Returns the index of the latest flashblock.
     #[inline]
     pub const fn latest_flashblock_index(&self) -> u64 {

--- a/crates/execution/flashblocks/src/pending_blocks.rs
+++ b/crates/execution/flashblocks/src/pending_blocks.rs
@@ -428,6 +428,14 @@ impl PendingBlocks {
         BlockNumberOrTag::Number(self.earliest_header.number - 1)
     }
 
+    /// Returns `true` when this snapshot is built directly on canonical `number` and `hash`.
+    #[inline]
+    pub fn is_based_on_canonical(&self, number: BlockNumber, hash: B256) -> bool {
+        matches!(self.canonical_block_number(), BlockNumberOrTag::Number(n) if n == number)
+            && self.parent_hash() == hash
+            && self.latest_block_number() > number
+    }
+
     /// Returns the earliest block number in the pending state.
     #[inline]
     pub fn earliest_block_number(&self) -> BlockNumber {

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -257,7 +257,7 @@ where
 
     fn invalidate_pending_for_recovery(&self, best_number: u64) {
         warn!(best = best_number, "flashblock processor entering recovery");
-        Metrics::pending_queue_recovery().increment(1);
+        Metrics::pending_recovery_transitions().increment(1);
         self.pending_blocks.swap(None);
         self.clear_live_state();
     }

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -475,7 +475,7 @@ where
                         };
                         update
                     }
-                    _ = deferred_interval.tick() => {
+                    _ = deferred_interval.tick(), if deferred_canonical.is_some() => {
                         let Some((deferred, _)) = deferred_canonical.as_ref() else {
                             continue;
                         };

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -1,7 +1,7 @@
 //! Flashblocks state processor.
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, VecDeque},
     sync::{Arc, Mutex as StdMutex, MutexGuard as StdMutexGuard},
     time::{Duration, Instant},
 };
@@ -44,6 +44,7 @@ use crate::{
 };
 
 type PendingExecutionDb = State<StateProviderDatabase<StateProviderBox>>;
+const MAX_QUARANTINED_PAYLOADS: usize = 8;
 
 #[derive(Debug)]
 struct LivePendingState {
@@ -179,7 +180,7 @@ pub struct StateProcessor<Client> {
     sender: Sender<Arc<PendingBlocks>>,
     cache: Arc<Mutex<FlashblockCache>>,
     live_state: StdMutex<Option<LivePendingState>>,
-    quarantined_flashblock: StdMutex<Option<(BlockNumber, PayloadId)>>,
+    quarantined_flashblocks: StdMutex<VecDeque<(BlockNumber, PayloadId)>>,
     max_pending_blocks_depth: u64,
 }
 
@@ -238,7 +239,7 @@ where
             sender,
             cache: Arc::new(Mutex::new(cache)),
             live_state: StdMutex::new(None),
-            quarantined_flashblock: StdMutex::new(None),
+            quarantined_flashblocks: StdMutex::new(VecDeque::new()),
             max_pending_blocks_depth,
         }
     }
@@ -258,7 +259,10 @@ where
         Metrics::pending_queue_recovery().increment(1);
         self.pending_blocks.swap(None);
         self.clear_live_state();
-        *self.quarantined_flashblock.lock().unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+        self.quarantined_flashblocks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clear();
         *self.cache.lock().await = FlashblockCache::new(best_number);
     }
 
@@ -266,17 +270,29 @@ where
         let StateUpdate::Flashblock(flashblock) = update else {
             return false;
         };
+        let identity = (flashblock.metadata.block_number, flashblock.payload_id);
         let mut quarantined =
-            self.quarantined_flashblock.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-        if *quarantined != Some((flashblock.metadata.block_number, flashblock.payload_id)) {
+            self.quarantined_flashblocks.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let Some(position) = quarantined.iter().position(|candidate| *candidate == identity) else {
             return false;
-        }
+        };
 
         if flashblock.index == 0 {
-            *quarantined = None;
+            quarantined.remove(position);
             false
         } else {
             true
+        }
+    }
+
+    fn quarantine_flashblock(&self, flashblock: &Flashblock) {
+        let identity = (flashblock.metadata.block_number, flashblock.payload_id);
+        let mut quarantined =
+            self.quarantined_flashblocks.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        quarantined.retain(|candidate| *candidate != identity);
+        quarantined.push_back(identity);
+        while quarantined.len() > MAX_QUARANTINED_PAYLOADS {
+            quarantined.pop_front();
         }
     }
 
@@ -314,19 +330,27 @@ where
         if let (StateUpdate::Flashblock(flashblock), Some(pending)) =
             (update, pending_blocks.as_ref())
         {
-            if flashblock.metadata.block_number == pending.latest_block_number()
-                && flashblock.payload_id != pending.latest_payload_id()
+            if pending_is_based_on_best
+                && let Some(payload_id) =
+                    pending.payload_id_for_block(flashblock.metadata.block_number)
             {
-                if flashblock.index == 0
-                    && flashblock.base.as_ref().is_some_and(|base| {
+                if flashblock.index == 0 {
+                    if flashblock.base.as_ref().is_none_or(|base| {
                         pending.expected_parent_hash(flashblock.metadata.block_number)
-                            == Some(base.parent_hash)
-                    })
-                {
-                    return Some((best, false));
+                            != Some(base.parent_hash)
+                    }) {
+                        self.quarantine_flashblock(flashblock);
+                        Metrics::pending_stale_events_skipped().increment(1);
+                        return None;
+                    }
+                    if flashblock.payload_id != payload_id {
+                        return Some((best, false));
+                    }
                 }
-                Metrics::pending_stale_events_skipped().increment(1);
-                return None;
+                if flashblock.payload_id != payload_id || flashblock.index == 0 {
+                    Metrics::pending_stale_events_skipped().increment(1);
+                    return None;
+                }
             }
 
             if pending_is_based_on_best
@@ -338,11 +362,7 @@ where
                     .as_ref()
                     .is_none_or(|base| base.parent_hash != pending.latest_block_hash())
             {
-                *self
-                    .quarantined_flashblock
-                    .lock()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner()) =
-                    Some((flashblock.metadata.block_number, flashblock.payload_id));
+                self.quarantine_flashblock(flashblock);
                 Metrics::pending_stale_events_skipped().increment(1);
                 return None;
             }
@@ -372,11 +392,7 @@ where
                         best.hash(),
                     )
                 {
-                    *self
-                        .quarantined_flashblock
-                        .lock()
-                        .unwrap_or_else(|poisoned| poisoned.into_inner()) =
-                        Some((flashblock.metadata.block_number, flashblock.payload_id));
+                    self.quarantine_flashblock(flashblock);
                 }
                 Metrics::pending_stale_events_skipped().increment(1);
                 None
@@ -771,16 +787,19 @@ where
         };
 
         if flashblock.index == 0
-            && flashblock.metadata.block_number == pending_blocks.latest_block_number()
-            && flashblock.payload_id != pending_blocks.latest_payload_id()
+            && let Some(payload_id) =
+                pending_blocks.payload_id_for_block(flashblock.metadata.block_number)
         {
+            if flashblock.payload_id == payload_id {
+                return Ok(prev_pending_blocks);
+            }
             let mut flashblocks = pending_blocks.get_flashblocks();
             flashblocks.retain(|existing| {
                 existing.metadata.block_number < flashblock.metadata.block_number
             });
             flashblocks.push(flashblock.clone());
             self.clear_live_state();
-            return self.build_pending_state(Some(Arc::clone(pending_blocks)), &flashblocks);
+            return self.build_pending_state(None, &flashblocks);
         }
 
         let validation_result = FlashblockSequenceValidator::validate(
@@ -868,6 +887,7 @@ where
 
         let mut live_state = self.lock_live_state();
         let Some(LivePendingState { mut db, state_overrides }) = live_state.take() else {
+            drop(live_state);
             warn!(
                 message = "live pending state unavailable, falling back to full rebuild",
                 block_number = flashblock.metadata.block_number,
@@ -1016,6 +1036,7 @@ where
 
         let mut live_state = self.lock_live_state();
         let Some(LivePendingState { mut db, state_overrides }) = live_state.take() else {
+            drop(live_state);
             warn!(
                 message = "live pending state unavailable, falling back to full rebuild",
                 block_number = flashblock.metadata.block_number,

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -351,6 +351,20 @@ where
                 && let Some(payload_id) =
                     pending.payload_id_for_block(flashblock.metadata.block_number)
             {
+                if flashblock.payload_id == payload_id
+                    && let Some(existing) = pending.flashblock_for_identity(
+                        flashblock.metadata.block_number,
+                        flashblock.payload_id,
+                        flashblock.index,
+                    )
+                {
+                    if existing != flashblock {
+                        self.enter_recovery(best.number());
+                        *recovering = true;
+                    }
+                    Metrics::pending_stale_events_skipped().increment(1);
+                    return None;
+                }
                 if flashblock.index == 0 {
                     if flashblock.base.as_ref().is_none_or(|base| {
                         pending.expected_parent_hash(flashblock.metadata.block_number)

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -257,12 +257,21 @@ where
                 <= self.max_pending_blocks_depth
     }
 
-    fn enter_recovery(&self, best_number: u64) {
+    fn invalidate_pending_for_recovery(&self, best_number: u64) {
         warn!(best = best_number, "flashblock processor entering recovery");
         Metrics::pending_queue_recovery().increment(1);
         self.pending_blocks.swap(None);
         self.clear_live_state();
+    }
+
+    fn enter_recovery(&self, best_number: u64) {
+        self.invalidate_pending_for_recovery(best_number);
         *self.lock_cache() = FlashblockCache::new(best_number);
+    }
+
+    fn enter_recovery_preserving_cache(&self, best_number: u64) {
+        self.invalidate_pending_for_recovery(best_number);
+        self.lock_cache().update_canonical(best_number);
     }
 
     async fn preflight_update(
@@ -300,11 +309,13 @@ where
             Metrics::pending_stale_events_skipped().increment(1);
             return None;
         }
-        if matches!(update, StateUpdate::Flashblock(_))
-            && deferred_canonical
-                .as_ref()
-                .is_some_and(|(block, _)| update.pending_anchor_number() <= block.number)
+        if let StateUpdate::Flashblock(flashblock) = update
+            && let Some((block, _)) = deferred_canonical.as_ref()
+            && update.pending_anchor_number() <= block.number
         {
+            if update.pending_anchor_number() == block.number {
+                self.lock_cache().insert(flashblock.clone());
+            }
             Metrics::pending_stale_events_skipped().increment(1);
             return None;
         }
@@ -426,12 +437,20 @@ where
                 None
             }
             UpdatePreflight::EnterRecovery => {
+                let canonical_ahead = matches!(
+                    update,
+                    StateUpdate::Canonical(block) if block.number > best.number()
+                );
                 if let StateUpdate::Canonical(block) = update
-                    && block.number > best.number()
+                    && canonical_ahead
                 {
                     *deferred_canonical = Some((block.clone(), enqueued_generation));
                 }
-                self.enter_recovery(best.number());
+                if canonical_ahead {
+                    self.enter_recovery_preserving_cache(best.number());
+                } else {
+                    self.enter_recovery(best.number());
+                }
                 *recovering = true;
                 Metrics::pending_stale_events_skipped().increment(1);
                 None

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -114,14 +114,12 @@ impl StateUpdate {
 
     fn preflight(
         &self,
-        best: Option<(u64, B256)>,
+        best: (u64, B256),
         has_pending: bool,
         pending_is_based_on_best: bool,
         recovering: bool,
     ) -> UpdatePreflight {
-        let Some((best_number, best_hash)) = best else {
-            return UpdatePreflight::Skip;
-        };
+        let (best_number, best_hash) = best;
 
         if recovering {
             if self.is_recovery_resume(best_number, best_hash) {
@@ -288,8 +286,7 @@ where
                 break best;
             }
             if provider_retries >= 20 {
-                let last_canonical =
-                    self.lock_cache().latest_canonical_number().unwrap_or_default();
+                let last_canonical = self.lock_cache().latest_canonical_number();
                 self.enter_recovery(last_canonical);
                 *recovering = true;
                 Metrics::pending_stale_events_skipped().increment(1);
@@ -417,7 +414,7 @@ where
         }
 
         let preflight = update.preflight(
-            Some((best.number(), best.hash())),
+            (best.number(), best.hash()),
             pending_blocks.is_some(),
             pending_is_based_on_best,
             *recovering,
@@ -554,17 +551,15 @@ where
 
                             let cached = {
                                 let mut cache = self.lock_cache();
-                                let cache_rolled_back = cache
-                                    .latest_canonical_number()
-                                    .is_some_and(|canonical| canonical > block.number)
+                                let cache_rolled_back = cache.latest_canonical_number()
+                                    > block.number
                                     && block.number == best.number()
                                     && block.hash() == best.hash();
                                 if cache_rolled_back {
                                     *cache = FlashblockCache::new(block.number);
                                 }
-                                let should_advance = cache
-                                    .latest_canonical_number()
-                                    .is_none_or(|canonical| block.number >= canonical);
+                                let should_advance =
+                                    block.number >= cache.latest_canonical_number();
                                 should_advance.then(|| {
                                     cache.update_canonical(block.number);
                                     let cached_block_number = block.number.saturating_add(1);
@@ -1490,7 +1485,7 @@ mod tests {
         let update = StateUpdate::Flashblock(flashblock(101, 0, best_hash));
 
         assert_eq!(
-            update.preflight(Some((best, best_hash)), true, false, false),
+            update.preflight((best, best_hash), true, false, false),
             UpdatePreflight::ResumeRecovery
         );
     }
@@ -1503,11 +1498,11 @@ mod tests {
         let resume = StateUpdate::Flashblock(flashblock(101, 0, best_hash));
 
         assert_eq!(
-            wrong_parent.preflight(Some((best, best_hash)), false, false, true),
+            wrong_parent.preflight((best, best_hash), false, false, true),
             UpdatePreflight::Skip
         );
         assert_eq!(
-            resume.preflight(Some((best, best_hash)), false, false, true),
+            resume.preflight((best, best_hash), false, false, true),
             UpdatePreflight::ResumeRecovery
         );
     }
@@ -1519,7 +1514,7 @@ mod tests {
         let future = StateUpdate::Flashblock(flashblock(102, 0, B256::repeat_byte(0xCD)));
 
         assert_eq!(
-            future.preflight(Some((best, best_hash)), false, false, true),
+            future.preflight((best, best_hash), false, false, true),
             UpdatePreflight::Process
         );
     }
@@ -1535,7 +1530,7 @@ mod tests {
         let best_hash = block.hash();
 
         assert_eq!(
-            StateUpdate::Canonical(block).preflight(Some((best, best_hash)), false, false, true),
+            StateUpdate::Canonical(block).preflight((best, best_hash), false, false, true),
             UpdatePreflight::Process
         );
     }
@@ -1551,7 +1546,7 @@ mod tests {
         let block = RecoveredBlock::new_sealed(SealedBlock::seal_slow(block), Vec::new());
 
         assert_eq!(
-            StateUpdate::Canonical(block).preflight(Some((best, best_hash)), true, true, false),
+            StateUpdate::Canonical(block).preflight((best, best_hash), true, true, false),
             UpdatePreflight::EnterRecovery
         );
     }
@@ -1562,9 +1557,6 @@ mod tests {
         let best_hash = B256::repeat_byte(0xAB);
         let stale = StateUpdate::Flashblock(flashblock(100, 0, B256::repeat_byte(0xCD)));
 
-        assert_eq!(
-            stale.preflight(Some((best, best_hash)), true, true, false),
-            UpdatePreflight::Skip
-        );
+        assert_eq!(stale.preflight((best, best_hash), true, true, false), UpdatePreflight::Skip);
     }
 }

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -142,10 +142,10 @@ impl StateUpdate {
             };
         }
 
-        // A canonical notification can race ahead of provider visibility. Processing it would
-        // rebase against state that cannot be read yet, so leave the tip-aligned snapshot intact.
+        // A canonical notification can race ahead of provider visibility. The existing snapshot
+        // is already stale once the notification arrives, so clear it and wait for a tip child.
         if matches!(self, Self::Canonical(block) if block.number > best_number) {
-            return UpdatePreflight::Skip;
+            return UpdatePreflight::EnterRecovery;
         }
 
         // A canonical tip update can rebase pending. A flashblock cannot safely extend a snapshot
@@ -180,6 +180,7 @@ pub struct StateProcessor<Client> {
     cache: Arc<Mutex<FlashblockCache>>,
     live_state: StdMutex<Option<LivePendingState>>,
     quarantined_flashblock: StdMutex<Option<(BlockNumber, PayloadId)>>,
+    max_pending_blocks_depth: u64,
 }
 
 impl<Client> StateProcessor<Client>
@@ -222,6 +223,7 @@ where
     pub fn new(
         client: Client,
         pending_blocks: Arc<ArcSwapOption<PendingBlocks>>,
+        max_pending_blocks_depth: u64,
         rx: Arc<Mutex<UnboundedReceiver<StateUpdate>>>,
         sender: Sender<Arc<PendingBlocks>>,
     ) -> Self {
@@ -237,11 +239,18 @@ where
             cache: Arc::new(Mutex::new(cache)),
             live_state: StdMutex::new(None),
             quarantined_flashblock: StdMutex::new(None),
+            max_pending_blocks_depth,
         }
     }
 
     fn best_canonical_header(&self) -> Option<SealedHeader> {
         self.client.sealed_header_by_number_or_tag(BlockNumberOrTag::Latest).ok().flatten()
+    }
+
+    fn pending_tracks_canonical_tip(&self, pending: &PendingBlocks, best: &SealedHeader) -> bool {
+        pending.is_based_on_canonical(best.number(), best.hash())
+            && pending.latest_block_number().saturating_sub(best.number())
+                <= self.max_pending_blocks_depth
     }
 
     async fn enter_recovery(&self, best_number: u64) {
@@ -282,6 +291,10 @@ where
                 break best;
             }
             if provider_retries >= 20 {
+                let last_canonical =
+                    self.cache.lock().await.latest_canonical_number().unwrap_or_default();
+                self.enter_recovery(last_canonical).await;
+                *recovering = true;
                 Metrics::pending_stale_events_skipped().increment(1);
                 return None;
             }
@@ -297,13 +310,18 @@ where
         let pending_blocks = self.pending_blocks.load_full();
         let pending_is_based_on_best = pending_blocks
             .as_ref()
-            .is_some_and(|pending| pending.is_based_on_canonical(best.number(), best.hash()));
+            .is_some_and(|pending| self.pending_tracks_canonical_tip(pending, &best));
         if let (StateUpdate::Flashblock(flashblock), Some(pending)) =
             (update, pending_blocks.as_ref())
         {
             if flashblock.metadata.block_number == pending.latest_block_number()
                 && flashblock.payload_id != pending.latest_payload_id()
             {
+                if flashblock.index == 0 && update.is_recovery_resume(best.number(), best.hash()) {
+                    self.enter_recovery(best.number()).await;
+                    *recovering = true;
+                    return Some((best, true));
+                }
                 Metrics::pending_stale_events_skipped().increment(1);
                 return None;
             }
@@ -397,10 +415,7 @@ where
                                     recovering = true;
                                     continue;
                                 };
-                                if !pending.is_based_on_canonical(
-                                    current_best.number(),
-                                    current_best.hash(),
-                                ) {
+                                if !self.pending_tracks_canonical_tip(pending, &current_best) {
                                     self.enter_recovery(current_best.number()).await;
                                     recovering = true;
                                     continue;
@@ -515,10 +530,7 @@ where
         let mut provider_retries = 0;
         let result = loop {
             let result = self.process_flashblock(prev_pending_blocks.clone(), &flashblock);
-            if !cache_on_missing_canonical_header
-                && matches!(result, Err(StateProcessorError::Provider(_)))
-                && provider_retries < 20
-            {
+            if matches!(result, Err(StateProcessorError::Provider(_))) && provider_retries < 20 {
                 provider_retries += 1;
                 sleep(Duration::from_millis(25)).await;
                 continue;
@@ -534,7 +546,7 @@ where
                         self.enter_recovery(expected_best.number()).await;
                         return (false, true);
                     };
-                    if !pb.is_based_on_canonical(current_best.number(), current_best.hash()) {
+                    if !self.pending_tracks_canonical_tip(pb, &current_best) {
                         self.enter_recovery(current_best.number()).await;
                         return (false, true);
                     }
@@ -570,6 +582,11 @@ where
                         }
                         // we should ignore this error since it doesn't necessarily indicate a problem
                         return (false, false);
+                    }
+                    StateProcessorError::Provider(_) => {
+                        error!(message = "provider remained unavailable while processing flashblock", error = %e);
+                        self.enter_recovery(expected_best.number()).await;
+                        return (false, true);
                     }
                     _ => {}
                 }
@@ -1386,7 +1403,7 @@ mod tests {
     }
 
     #[test]
-    fn preflight_skips_canonical_ahead_of_provider_visibility() {
+    fn preflight_enters_recovery_for_canonical_ahead_of_provider_visibility() {
         let best = 100;
         let best_hash = B256::repeat_byte(0xAB);
         let block = BaseBlock {
@@ -1397,7 +1414,7 @@ mod tests {
 
         assert_eq!(
             StateUpdate::Canonical(block).preflight(Some((best, best_hash)), true, true, false),
-            UpdatePreflight::Skip
+            UpdatePreflight::EnterRecovery
         );
     }
 

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -7,12 +7,12 @@ use std::{
 };
 
 use alloy_consensus::{
-    Block, BlockBody, Header,
+    Block, BlockBody, BlockHeader, Header,
     transaction::{Recovered, SignerRecoverable},
 };
 use alloy_eips::{BlockNumberOrTag, Decodable2718};
 use alloy_network::TransactionResponse;
-use alloy_primitives::{Address, BlockNumber};
+use alloy_primitives::{Address, B256, BlockNumber};
 use alloy_rpc_types_eth::state::StateOverride;
 use arc_swap::ArcSwapOption;
 use base_common_chains::Upgrades;
@@ -22,7 +22,7 @@ use base_execution_evm::{BaseEvmConfig, BaseNextBlockEnvAttributes};
 use rayon::prelude::*;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_evm::ConfigureEvm;
-use reth_primitives_traits::RecoveredBlock;
+use reth_primitives_traits::{RecoveredBlock, SealedHeader};
 use reth_provider::{BlockReaderIdExt, StateProviderBox, StateProviderFactory};
 use reth_revm::{State, database::StateProviderDatabase};
 use revm_database::states::bundle_state::BundleRetention;
@@ -56,16 +56,115 @@ pub enum StateUpdate {
     Flashblock(Flashblock),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UpdatePreflight {
+    Process,
+    ResumeRecovery,
+    Skip,
+    EnterRecovery,
+}
+
+impl StateUpdate {
+    /// Returns the canonical block number on which this update is anchored.
+    pub fn pending_anchor_number(&self) -> u64 {
+        match self {
+            Self::Canonical(block) => block.number,
+            Self::Flashblock(flashblock) => flashblock.metadata.block_number.saturating_sub(1),
+        }
+    }
+
+    /// Returns `true` for an index-zero flashblock built on the exact current canonical tip.
+    pub fn is_recovery_resume(&self, best_number: u64, best_hash: B256) -> bool {
+        match self {
+            Self::Flashblock(flashblock) => {
+                flashblock.index == 0
+                    && flashblock.metadata.block_number == best_number.saturating_add(1)
+                    && flashblock.base.as_ref().is_some_and(|base| base.parent_hash == best_hash)
+            }
+            Self::Canonical(_) => false,
+        }
+    }
+
+    fn flashblock_has_wrong_parent_at_tip(
+        flashblock: &Flashblock,
+        best_number: u64,
+        best_hash: B256,
+    ) -> bool {
+        flashblock.metadata.block_number.saturating_sub(1) == best_number
+            && flashblock.index == 0
+            && flashblock.base.as_ref().is_none_or(|base| base.parent_hash != best_hash)
+    }
+
+    fn is_stale_against(&self, best_number: u64, best_hash: B256) -> bool {
+        if self.pending_anchor_number() < best_number {
+            return true;
+        }
+
+        match self {
+            Self::Canonical(block) => block.number == best_number && block.hash() != best_hash,
+            Self::Flashblock(flashblock) => {
+                Self::flashblock_has_wrong_parent_at_tip(flashblock, best_number, best_hash)
+            }
+        }
+    }
+
+    fn preflight(
+        &self,
+        best: Option<(u64, B256)>,
+        has_pending: bool,
+        pending_is_based_on_best: bool,
+        recovering: bool,
+    ) -> UpdatePreflight {
+        let Some((best_number, best_hash)) = best else {
+            return UpdatePreflight::Skip;
+        };
+
+        if recovering {
+            if self.is_recovery_resume(best_number, best_hash) {
+                return UpdatePreflight::ResumeRecovery;
+            }
+
+            return match self {
+                Self::Canonical(block)
+                    if block.number == best_number && block.hash() == best_hash =>
+                {
+                    UpdatePreflight::Process
+                }
+                Self::Flashblock(_) if self.pending_anchor_number() > best_number => {
+                    UpdatePreflight::Process
+                }
+                _ => UpdatePreflight::Skip,
+            };
+        }
+
+        // A canonical tip update can rebase pending. A flashblock cannot safely extend a snapshot
+        // that is anchored behind the provider.
+        if matches!(self, Self::Flashblock(_)) && has_pending && !pending_is_based_on_best {
+            return UpdatePreflight::EnterRecovery;
+        }
+
+        if self.is_stale_against(best_number, best_hash) {
+            return if pending_is_based_on_best {
+                UpdatePreflight::Skip
+            } else {
+                UpdatePreflight::EnterRecovery
+            };
+        }
+
+        UpdatePreflight::Process
+    }
+}
+
 /// Processes flashblocks and canonical blocks to keep pending state updated.
 #[derive(Debug)]
 pub struct StateProcessor<Client> {
     rx: Arc<Mutex<UnboundedReceiver<StateUpdate>>>,
     pending_blocks: Arc<ArcSwapOption<PendingBlocks>>,
-    max_depth: u64,
     client: Client,
     sender: Sender<Arc<PendingBlocks>>,
     cache: Arc<Mutex<FlashblockCache>>,
     live_state: StdMutex<Option<LivePendingState>>,
+    quarantined_flashblock_block: StdMutex<Option<BlockNumber>>,
 }
 
 impl<Client> StateProcessor<Client>
@@ -108,7 +207,6 @@ where
     pub fn new(
         client: Client,
         pending_blocks: Arc<ArcSwapOption<PendingBlocks>>,
-        max_depth: u64,
         rx: Arc<Mutex<UnboundedReceiver<StateUpdate>>>,
         sender: Sender<Arc<PendingBlocks>>,
     ) -> Self {
@@ -119,44 +217,184 @@ where
         Self {
             pending_blocks,
             client,
-            max_depth,
             rx,
             sender,
             cache: Arc::new(Mutex::new(cache)),
             live_state: StdMutex::new(None),
+            quarantined_flashblock_block: StdMutex::new(None),
+        }
+    }
+
+    fn best_canonical_header(&self) -> Option<SealedHeader> {
+        self.client.sealed_header_by_number_or_tag(BlockNumberOrTag::Latest).ok().flatten()
+    }
+
+    async fn enter_recovery(&self, best_number: u64) {
+        warn!(best = best_number, "flashblock processor entering recovery");
+        Metrics::pending_queue_recovery().increment(1);
+        self.pending_blocks.swap(None);
+        self.clear_live_state();
+        *self
+            .quarantined_flashblock_block
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+        *self.cache.lock().await = FlashblockCache::new(best_number);
+    }
+
+    fn is_quarantined_flashblock(&self, update: &StateUpdate, best: &SealedHeader) -> bool {
+        let StateUpdate::Flashblock(flashblock) = update else {
+            return false;
+        };
+        let mut quarantined = self
+            .quarantined_flashblock_block
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if *quarantined != Some(flashblock.metadata.block_number) {
+            return false;
+        }
+
+        if update.is_recovery_resume(best.number(), best.hash()) {
+            *quarantined = None;
+            false
+        } else {
+            true
+        }
+    }
+
+    async fn preflight_update(
+        &self,
+        update: &StateUpdate,
+        recovering: &mut bool,
+    ) -> Option<(SealedHeader, bool)> {
+        let Some(best) = self.best_canonical_header() else {
+            Metrics::pending_stale_events_skipped().increment(1);
+            return None;
+        };
+
+        if self.is_quarantined_flashblock(update, &best) {
+            Metrics::pending_stale_events_skipped().increment(1);
+            return None;
+        }
+
+        let pending_blocks = self.pending_blocks.load_full();
+        let preflight = update.preflight(
+            Some((best.number(), best.hash())),
+            pending_blocks.is_some(),
+            pending_blocks
+                .as_ref()
+                .is_some_and(|pending| pending.is_based_on_canonical(best.number(), best.hash())),
+            *recovering,
+        );
+
+        match preflight {
+            UpdatePreflight::Process => Some((best, false)),
+            UpdatePreflight::ResumeRecovery => Some((best, true)),
+            UpdatePreflight::Skip => {
+                if let StateUpdate::Flashblock(flashblock) = update
+                    && StateUpdate::flashblock_has_wrong_parent_at_tip(
+                        flashblock,
+                        best.number(),
+                        best.hash(),
+                    )
+                {
+                    *self
+                        .quarantined_flashblock_block
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner()) =
+                        Some(flashblock.metadata.block_number);
+                }
+                Metrics::pending_stale_events_skipped().increment(1);
+                None
+            }
+            UpdatePreflight::EnterRecovery => {
+                self.enter_recovery(best.number()).await;
+                *recovering = true;
+                Metrics::pending_stale_events_skipped().increment(1);
+                None
+            }
         }
     }
 
     /// Processes updates from the queue until the channel closes.
     pub async fn start(&self) {
+        let mut recovering = false;
         while let Some(update) = self.rx.lock().await.recv().await {
+            let Some((best, resuming_recovery)) =
+                self.preflight_update(&update, &mut recovering).await
+            else {
+                continue;
+            };
+
             let prev_pending_blocks = self.pending_blocks.load_full();
             match update {
                 StateUpdate::Canonical(block) => {
                     debug!(message = "processing canonical block", block_number = block.number);
                     match self.process_canonical_block(prev_pending_blocks, &block) {
-                        Ok(new_pending_blocks) => {
+                        Ok((new_pending_blocks, requires_recovery)) => {
+                            if requires_recovery {
+                                self.enter_recovery(best.number()).await;
+                                recovering = true;
+                                continue;
+                            }
+
                             self.pending_blocks.swap(new_pending_blocks);
 
                             let mut cache = self.cache.lock().await;
-                            cache.update_canonical(block.number);
-                            let cached = cache.drain(block.number + 1);
-                            drop(cache);
+                            let should_advance = cache
+                                .latest_canonical_number()
+                                .is_none_or(|canonical| block.number >= canonical);
+                            if should_advance {
+                                cache.update_canonical(block.number);
+                                let cached = cache.drain(block.number + 1);
+                                // Recovery may replace the cache while replaying, so release this
+                                // lock before preflighting any cached payload.
+                                drop(cache);
 
-                            if !cached.is_empty() {
-                                debug!(
-                                    message = "replaying cached flashblocks after canonical block",
-                                    canonical_block = block.number,
-                                    cached_count = cached.len(),
-                                );
-                                for flashblock in cached {
-                                    let fb_prev = self.pending_blocks.load_full();
-                                    self.apply_flashblock(fb_prev, flashblock).await;
+                                if !cached.is_empty() {
+                                    debug!(
+                                        message =
+                                            "replaying cached flashblocks after canonical block",
+                                        canonical_block = block.number,
+                                        cached_count = cached.len(),
+                                    );
+                                    for flashblock in cached {
+                                        let cached_update = StateUpdate::Flashblock(flashblock);
+                                        let Some((_, cached_resuming_recovery)) = self
+                                            .preflight_update(&cached_update, &mut recovering)
+                                            .await
+                                        else {
+                                            if recovering {
+                                                break;
+                                            }
+                                            continue;
+                                        };
+                                        let StateUpdate::Flashblock(flashblock) = cached_update
+                                        else {
+                                            unreachable!("cached update is always a flashblock");
+                                        };
+
+                                        let fb_prev = self.pending_blocks.load_full();
+                                        let applied = self
+                                            .apply_flashblock(
+                                                fb_prev,
+                                                flashblock,
+                                                !cached_resuming_recovery,
+                                            )
+                                            .await;
+                                        if cached_resuming_recovery && applied {
+                                            recovering = false;
+                                        }
+                                        if recovering {
+                                            break;
+                                        }
+                                    }
                                 }
                             }
                         }
                         Err(e) => {
                             error!(message = "could not process canonical block", error = %e);
+                            self.enter_recovery(best.number()).await;
+                            recovering = true;
                         }
                     }
                 }
@@ -166,7 +404,12 @@ where
                         block_number = flashblock.metadata.block_number,
                         flashblock_index = flashblock.index
                     );
-                    self.apply_flashblock(prev_pending_blocks, flashblock).await;
+                    let applied = self
+                        .apply_flashblock(prev_pending_blocks, flashblock, !resuming_recovery)
+                        .await;
+                    if resuming_recovery && applied {
+                        recovering = false;
+                    }
                 }
             }
         }
@@ -176,25 +419,28 @@ where
         &self,
         prev_pending_blocks: Option<Arc<PendingBlocks>>,
         flashblock: Flashblock,
-    ) {
+        cache_on_missing_canonical_header: bool,
+    ) -> bool {
         let start_time = Instant::now();
         match self.process_flashblock(prev_pending_blocks, &flashblock) {
             Ok(new_pending_blocks) => {
+                let applied = new_pending_blocks.is_some();
                 if let Some(ref pb) = new_pending_blocks {
                     _ = self.sender.send(Arc::clone(pb));
                 }
                 self.pending_blocks.swap(new_pending_blocks);
                 Metrics::block_processing_duration().record(start_time.elapsed());
+                applied
             }
             Err(e) => {
                 match e {
                     StateProcessorError::Provider(ProviderError::MissingCanonicalHeader {
                         ..
-                    }) => {
+                    }) if cache_on_missing_canonical_header => {
                         let inserted = self.cache.lock().await.insert(flashblock);
                         if inserted {
                             debug!(message = "cached flashblock pending canonical block", error = %e);
-                            return;
+                            return false;
                         }
                     }
                     StateProcessorError::MissingFirstFlashblock => {
@@ -207,10 +453,10 @@ where
                             )
                             && cache.insert(flashblock)
                         {
-                            return;
+                            return false;
                         }
                         // we should ignore this error since it doesn't necessarily indicate a problem
-                        return;
+                        return false;
                     }
                     _ => {}
                 }
@@ -223,6 +469,7 @@ where
                     error!(message = "could not process Flashblock", error = %e);
                     Metrics::block_processing_error().increment(1);
                 }
+                false
             }
         }
     }
@@ -232,13 +479,13 @@ where
         &self,
         prev_pending_blocks: Option<Arc<PendingBlocks>>,
         block: &RecoveredBlock<BaseBlock>,
-    ) -> Result<Option<Arc<PendingBlocks>>> {
+    ) -> Result<(Option<Arc<PendingBlocks>>, bool)> {
         let pending_blocks = match &prev_pending_blocks {
             Some(pb) => pb,
             None => {
                 debug!(message = "no pending state to update with canonical block, skipping");
                 self.clear_live_state();
-                return Ok(None);
+                return Ok((None, false));
             }
         };
 
@@ -248,28 +495,61 @@ where
         Metrics::flashblocks_in_block().record(num_flashblocks_for_canon as f64);
         Metrics::pending_snapshot_height().set(pending_blocks.latest_block_number() as f64);
 
-        // Check for reorg by comparing transaction sets
-        let tracked_txns = pending_blocks.get_transactions_for_block(block.number);
-        let tracked_txn_hashes: Vec<_> = tracked_txns.map(|tx| tx.tx_hash()).collect();
-        let block_txn_hashes: Vec<_> = block.body().transactions().map(|tx| tx.tx_hash()).collect();
+        let earliest = pending_blocks.earliest_block_number();
+        let latest = pending_blocks.latest_block_number();
+        let anchor = earliest.saturating_sub(1);
+        let in_pending_interval = block.number >= earliest && block.number <= latest;
+        let is_pending_anchor = block.number == anchor;
 
-        let reorg_result = ReorgDetector::detect(&tracked_txn_hashes, &block_txn_hashes);
-        let reorg_detected = reorg_result.is_reorg();
+        // Only compare transaction sets for blocks represented in pending. An older queued
+        // canonical has no tracked transactions and must not look like a reorg.
+        let reorg_detected = if in_pending_interval {
+            let tracked_txn_hashes: Vec<_> = pending_blocks
+                .get_transactions_for_block(block.number)
+                .map(|tx| tx.tx_hash())
+                .collect();
+            let block_txn_hashes: Vec<_> =
+                block.body().transactions().map(|tx| tx.tx_hash()).collect();
+            let reorg_result = ReorgDetector::detect(&tracked_txn_hashes, &block_txn_hashes);
+            if reorg_result.is_reorg() {
+                warn!(
+                    tracked_txn_hashes = ?tracked_txn_hashes,
+                    block_txn_hashes = ?block_txn_hashes,
+                    "reorg detected, clearing pending flashblocks"
+                );
+            }
+            reorg_result.is_reorg()
+        } else if is_pending_anchor {
+            let pending_parent = pending_blocks.parent_hash();
+            let canonical_hash = block.hash();
+            if pending_parent != canonical_hash {
+                warn!(
+                    pending_parent_hash = %pending_parent,
+                    canonical_hash = %canonical_hash,
+                    canonical_block = block.number,
+                    "pending anchor hash mismatch, clearing pending flashblocks"
+                );
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
 
-        // Determine the reconciliation strategy
         let strategy = CanonicalBlockReconciler::reconcile(
-            Some(pending_blocks.earliest_block_number()),
-            Some(pending_blocks.latest_block_number()),
+            Some(earliest),
+            Some(latest),
             block.number,
-            self.max_depth,
             reorg_detected,
         );
 
-        match strategy {
+        let requires_recovery = matches!(strategy, ReconciliationStrategy::HandleReorg);
+        let pending_blocks = match strategy {
             ReconciliationStrategy::CatchUp => {
                 debug!(
                     message = "pending snapshot cleared because canonical caught up",
-                    latest_pending_block = pending_blocks.latest_block_number(),
+                    latest_pending_block = latest,
                     canonical_block = block.number,
                 );
                 Metrics::pending_clear_catchup().increment(1);
@@ -279,47 +559,58 @@ where
                 Ok(None)
             }
             ReconciliationStrategy::HandleReorg => {
-                warn!(
-                    message = "reorg detected, recomputing pending flashblocks going ahead of reorg",
-                    tracked_txn_hashes = ?tracked_txn_hashes,
-                    block_txn_hashes = ?block_txn_hashes,
-                );
                 Metrics::pending_clear_reorg().increment(1);
-
-                // If there is a reorg, we re-process all future flashblocks without reusing the existing pending state
-                flashblocks.retain(|flashblock| flashblock.metadata.block_number > block.number);
-                self.build_pending_state(None, &flashblocks)
+                self.clear_live_state();
+                Ok(None)
             }
-            ReconciliationStrategy::DepthLimitExceeded { depth, max_depth } => {
-                debug!(
-                    message = "pending blocks depth exceeds max depth, resetting pending blocks",
-                    pending_blocks_depth = depth,
-                    max_depth = max_depth,
-                );
-
+            ReconciliationStrategy::Rebase => {
                 flashblocks.retain(|flashblock| flashblock.metadata.block_number > block.number);
-                self.build_pending_state(None, &flashblocks)
+                if flashblocks.is_empty() {
+                    Metrics::pending_clear_catchup().increment(1);
+                    self.clear_live_state();
+                    Ok(None)
+                } else if flashblocks.first().is_none_or(|flashblock| {
+                    flashblock.index != 0
+                        || flashblock.metadata.block_number != block.number.saturating_add(1)
+                        || flashblock
+                            .base
+                            .as_ref()
+                            .is_none_or(|base| base.parent_hash != block.hash())
+                }) {
+                    warn!(
+                        canonical_block = block.number,
+                        "pending suffix does not start from canonical tip"
+                    );
+                    self.clear_live_state();
+                    return Ok((None, true));
+                } else {
+                    debug!(
+                        message = "rebasing pending flashblocks onto canonical block",
+                        canonical_block = block.number,
+                        remaining_flashblocks = flashblocks.len(),
+                    );
+                    self.clear_live_state();
+                    self.build_pending_state(None, &flashblocks)
+                }
             }
-            ReconciliationStrategy::Continue => {
+            ReconciliationStrategy::VerifyAnchor | ReconciliationStrategy::IgnoreUntracked => {
                 debug!(
-                    message = "canonical block behind latest pending block, continuing with existing pending state",
-                    latest_pending_block = pending_blocks.latest_block_number(),
-                    earliest_pending_block = pending_blocks.earliest_block_number(),
+                    message = "canonical block does not require pending rebuild",
+                    latest_pending_block = latest,
+                    earliest_pending_block = earliest,
                     canonical_block = block.number,
-                    pending_txns_for_block = ?tracked_txn_hashes.len(),
-                    canonical_txns_for_block = ?block_txn_hashes.len(),
+                    strategy = ?strategy,
                 );
-                // If no reorg, we can continue building on top of the existing pending state
-                // NOTE: We do not retain specific flashblocks here to avoid losing track of our "earliest" pending block number
-                self.build_pending_state(prev_pending_blocks, &flashblocks)
+                Ok(prev_pending_blocks)
             }
             ReconciliationStrategy::NoPendingState => {
-                // This case is already handled above, but included for completeness
                 debug!(message = "no pending state to update with canonical block, skipping");
                 self.clear_live_state();
                 Ok(None)
             }
-        }
+        }?;
+
+        Ok((pending_blocks, requires_recovery))
     }
 
     #[instrument(
@@ -843,5 +1134,134 @@ where
         }
 
         self.publish_pending_blocks(pending_blocks_builder, db, state_overrides)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, B256};
+    use alloy_rpc_types_engine::PayloadId;
+    use base_common_flashblocks::{
+        ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, Metadata,
+    };
+    use reth_primitives_traits::SealedBlock;
+
+    use super::*;
+
+    fn flashblock(block_number: u64, index: u64, parent_hash: B256) -> Flashblock {
+        Flashblock {
+            payload_id: PayloadId::default(),
+            index,
+            base: (index == 0).then_some(ExecutionPayloadBaseV1 {
+                parent_beacon_block_root: B256::ZERO,
+                parent_hash,
+                fee_recipient: Address::ZERO,
+                prev_randao: B256::ZERO,
+                block_number,
+                gas_limit: 30_000_000,
+                timestamp: 1_700_000_000,
+                extra_data: Default::default(),
+                base_fee_per_gas: Default::default(),
+            }),
+            diff: ExecutionPayloadFlashblockDeltaV1::default(),
+            metadata: Metadata::new(block_number),
+        }
+    }
+
+    #[test]
+    fn flashblock_anchor_is_parent_block() {
+        let update = StateUpdate::Flashblock(flashblock(101, 0, B256::ZERO));
+        assert_eq!(update.pending_anchor_number(), 100);
+        assert_eq!(
+            StateUpdate::Flashblock(flashblock(0, 0, B256::ZERO)).pending_anchor_number(),
+            0
+        );
+    }
+
+    #[test]
+    fn recovery_resume_requires_current_index_zero_and_parent_hash() {
+        let best = 100;
+        let best_hash = B256::repeat_byte(0xAB);
+        let resume = StateUpdate::Flashblock(flashblock(101, 0, best_hash));
+
+        assert!(resume.is_recovery_resume(best, best_hash));
+        assert!(!resume.is_recovery_resume(best, B256::repeat_byte(0xCD)));
+        assert!(
+            !StateUpdate::Flashblock(flashblock(101, 1, best_hash))
+                .is_recovery_resume(best, best_hash)
+        );
+        assert!(
+            !StateUpdate::Flashblock(flashblock(102, 0, best_hash))
+                .is_recovery_resume(best, best_hash)
+        );
+    }
+
+    #[test]
+    fn preflight_enters_recovery_for_stale_pending() {
+        let best = 100;
+        let best_hash = B256::repeat_byte(0xAB);
+        let update = StateUpdate::Flashblock(flashblock(101, 0, best_hash));
+
+        assert_eq!(
+            update.preflight(Some((best, best_hash)), true, false, false),
+            UpdatePreflight::EnterRecovery
+        );
+    }
+
+    #[test]
+    fn recovery_only_resumes_from_matching_tip_child() {
+        let best = 100;
+        let best_hash = B256::repeat_byte(0xAB);
+        let wrong_parent = StateUpdate::Flashblock(flashblock(101, 0, B256::repeat_byte(0xCD)));
+        let resume = StateUpdate::Flashblock(flashblock(101, 0, best_hash));
+
+        assert_eq!(
+            wrong_parent.preflight(Some((best, best_hash)), false, false, true),
+            UpdatePreflight::Skip
+        );
+        assert_eq!(
+            resume.preflight(Some((best, best_hash)), false, false, true),
+            UpdatePreflight::ResumeRecovery
+        );
+    }
+
+    #[test]
+    fn recovery_admits_future_flashblocks_for_bounded_caching() {
+        let best = 100;
+        let best_hash = B256::repeat_byte(0xAB);
+        let future = StateUpdate::Flashblock(flashblock(102, 0, B256::repeat_byte(0xCD)));
+
+        assert_eq!(
+            future.preflight(Some((best, best_hash)), false, false, true),
+            UpdatePreflight::Process
+        );
+    }
+
+    #[test]
+    fn recovery_processes_current_canonical_for_cache_replay() {
+        let best = 100;
+        let block = BaseBlock {
+            header: Header { number: best, ..Default::default() },
+            body: Default::default(),
+        };
+        let block = RecoveredBlock::new_sealed(SealedBlock::seal_slow(block), Vec::new());
+        let best_hash = block.hash();
+
+        assert_eq!(
+            StateUpdate::Canonical(block).preflight(Some((best, best_hash)), false, false, true),
+            UpdatePreflight::Process
+        );
+    }
+
+    #[test]
+    fn preflight_drops_late_work_without_clearing_fresh_pending() {
+        let best = 100;
+        let best_hash = B256::repeat_byte(0xAB);
+        let stale = StateUpdate::Flashblock(flashblock(100, 0, B256::repeat_byte(0xCD)));
+
+        assert_eq!(
+            stale.preflight(Some((best, best_hash)), true, true, false),
+            UpdatePreflight::Skip
+        );
     }
 }

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -3,7 +3,7 @@
 use std::{
     collections::BTreeMap,
     sync::{Arc, Mutex as StdMutex, MutexGuard as StdMutexGuard},
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use alloy_consensus::{
@@ -27,11 +27,15 @@ use reth_primitives_traits::{RecoveredBlock, SealedHeader};
 use reth_provider::{BlockReaderIdExt, StateProviderBox, StateProviderFactory};
 use reth_revm::{State, database::StateProviderDatabase};
 use revm_database::states::bundle_state::BundleRetention;
-use tokio::sync::{Mutex, broadcast::Sender, mpsc::UnboundedReceiver};
+use tokio::{
+    sync::{Mutex, broadcast::Sender, mpsc::UnboundedReceiver},
+    time::sleep,
+};
 
 use crate::{
     AssembledBlock, BlockAssembler, ExecutionError, FlashblockCache, PendingBlocks,
-    PendingBlocksBuilder, PendingStateBuilder, ProviderError, Result, StateProcessorError,
+    PendingBlocksBuilder, PendingStateBuilder, ProtocolError, ProviderError, Result,
+    StateProcessorError,
     metrics::Metrics,
     validation::{
         CanonicalBlockReconciler, FlashblockSequenceValidator, ReconciliationStrategy,
@@ -249,7 +253,7 @@ where
         *self.cache.lock().await = FlashblockCache::new(best_number);
     }
 
-    fn is_quarantined_flashblock(&self, update: &StateUpdate, best: &SealedHeader) -> bool {
+    fn is_quarantined_flashblock(&self, update: &StateUpdate) -> bool {
         let StateUpdate::Flashblock(flashblock) = update else {
             return false;
         };
@@ -259,7 +263,7 @@ where
             return false;
         }
 
-        if update.is_recovery_resume(best.number(), best.hash()) {
+        if flashblock.index == 0 {
             *quarantined = None;
             false
         } else {
@@ -272,12 +276,20 @@ where
         update: &StateUpdate,
         recovering: &mut bool,
     ) -> Option<(SealedHeader, bool)> {
-        let Some(best) = self.best_canonical_header() else {
-            Metrics::pending_stale_events_skipped().increment(1);
-            return None;
+        let mut provider_retries = 0;
+        let best = loop {
+            if let Some(best) = self.best_canonical_header() {
+                break best;
+            }
+            if provider_retries >= 20 {
+                Metrics::pending_stale_events_skipped().increment(1);
+                return None;
+            }
+            provider_retries += 1;
+            sleep(Duration::from_millis(25)).await;
         };
 
-        if self.is_quarantined_flashblock(update, &best) {
+        if self.is_quarantined_flashblock(update) {
             Metrics::pending_stale_events_skipped().increment(1);
             return None;
         }
@@ -286,6 +298,35 @@ where
         let pending_is_based_on_best = pending_blocks
             .as_ref()
             .is_some_and(|pending| pending.is_based_on_canonical(best.number(), best.hash()));
+        if let (StateUpdate::Flashblock(flashblock), Some(pending)) =
+            (update, pending_blocks.as_ref())
+        {
+            if flashblock.metadata.block_number == pending.latest_block_number()
+                && flashblock.payload_id != pending.latest_payload_id()
+            {
+                Metrics::pending_stale_events_skipped().increment(1);
+                return None;
+            }
+
+            if pending_is_based_on_best
+                && flashblock.index == 0
+                && flashblock.metadata.block_number
+                    == pending.latest_block_number().saturating_add(1)
+                && flashblock
+                    .base
+                    .as_ref()
+                    .is_none_or(|base| base.parent_hash != pending.latest_block_hash())
+            {
+                *self
+                    .quarantined_flashblock
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner()) =
+                    Some((flashblock.metadata.block_number, flashblock.payload_id));
+                Metrics::pending_stale_events_skipped().increment(1);
+                return None;
+            }
+        }
+
         let preflight = update.preflight(
             Some((best.number(), best.hash())),
             pending_blocks.is_some(),
@@ -374,10 +415,17 @@ where
                                 .is_none_or(|canonical| block.number >= canonical);
                             if should_advance {
                                 cache.update_canonical(block.number);
-                                let cached = cache.drain(block.number + 1);
+                                let cached_block_number = block.number.saturating_add(1);
+                                let mut cached = cache.drain(cached_block_number, block.hash());
                                 // Recovery may replace the cache while replaying, so release this
                                 // lock before preflighting any cached payload.
                                 drop(cache);
+
+                                if self.pending_blocks.load_full().is_some_and(|pending| {
+                                    pending.latest_block_number() >= cached_block_number
+                                }) {
+                                    cached.clear();
+                                }
 
                                 if !cached.is_empty() {
                                     debug!(
@@ -464,7 +512,21 @@ where
         expected_best: &SealedHeader,
     ) -> (bool, bool) {
         let start_time = Instant::now();
-        match self.process_flashblock(prev_pending_blocks, &flashblock) {
+        let mut provider_retries = 0;
+        let result = loop {
+            let result = self.process_flashblock(prev_pending_blocks.clone(), &flashblock);
+            if !cache_on_missing_canonical_header
+                && matches!(result, Err(StateProcessorError::Provider(_)))
+                && provider_retries < 20
+            {
+                provider_retries += 1;
+                sleep(Duration::from_millis(25)).await;
+                continue;
+            }
+            break result;
+        };
+
+        match result {
             Ok(new_pending_blocks) => {
                 let applied = new_pending_blocks.is_some();
                 if let Some(ref pb) = new_pending_blocks {
@@ -499,6 +561,7 @@ where
                         if flashblock.index > 0
                             && cache.has_flashblock(
                                 flashblock.metadata.block_number,
+                                flashblock.payload_id,
                                 flashblock.index - 1,
                             )
                             && cache.insert(flashblock)
@@ -909,6 +972,14 @@ where
         let Some(base) = flashblock.base.clone() else {
             return Err(StateProcessorError::MissingFirstFlashblock);
         };
+        let expected_parent = prev_pending_blocks.latest_block_hash();
+        if base.parent_hash != expected_parent {
+            return Err(ProtocolError::ParentHashMismatch {
+                expected: expected_parent,
+                actual: base.parent_hash,
+            }
+            .into());
+        }
 
         let mut live_state = self.lock_live_state();
         let Some(LivePendingState { mut db, state_overrides }) = live_state.take() else {
@@ -1047,6 +1118,7 @@ where
             .header_by_number(canonical_block)
             .map_err(|e| ProviderError::StateProvider(e.to_string()))?
             .ok_or(ProviderError::MissingCanonicalHeader { block_number: canonical_block })?;
+        let mut last_block_hash = last_block_header.hash_slow();
 
         let evm_config = BaseEvmConfig::base(self.client.chain_spec());
         let state_provider = self
@@ -1069,8 +1141,17 @@ where
         for (_block_number, flashblocks) in flashblocks_per_block {
             // Use BlockAssembler to reconstruct the block from flashblocks
             let assembled = BlockAssembler::assemble(&flashblocks)?;
+            if assembled.base.parent_hash != last_block_hash {
+                return Err(ProtocolError::ParentHashMismatch {
+                    expected: last_block_hash,
+                    actual: assembled.base.parent_hash,
+                }
+                .into());
+            }
             let latest_flashblock_tx_count =
                 flashblocks.last().map(|latest| latest.diff.transactions.len()).unwrap_or_default();
+            let latest_block_hash =
+                flashblocks.last().map(|latest| latest.diff.block_hash).unwrap_or_default();
             let latest_block_base = assembled.base.clone();
 
             pending_blocks_builder.with_flashblocks(assembled.flashblocks.clone());
@@ -1181,6 +1262,7 @@ where
 
             (db, state_overrides) = pending_state_builder.into_db_and_state_overrides();
             last_block_header = block_header;
+            last_block_hash = latest_block_hash;
         }
 
         self.publish_pending_blocks(pending_blocks_builder, db, state_overrides)

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -485,10 +485,13 @@ where
                         {
                             continue;
                         }
-                        deferred_canonical
+                        let Some(update) = deferred_canonical
                             .take()
                             .map(|(block, generation)| (StateUpdate::Canonical(block), generation))
-                            .expect("deferred canonical remains available")
+                        else {
+                            continue;
+                        };
+                        update
                     }
                 }
             };

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -180,7 +180,6 @@ pub struct StateProcessor<Client> {
     live_state: StdMutex<Option<LivePendingState>>,
     max_pending_blocks_depth: u64,
     recovery_epoch: Arc<StdMutex<u64>>,
-    deferred_canonical: StdMutex<Option<(RecoveredBlock<BaseBlock>, u64)>>,
 }
 
 impl<Client> StateProcessor<Client>
@@ -245,7 +244,6 @@ where
             live_state: StdMutex::new(None),
             max_pending_blocks_depth,
             recovery_epoch,
-            deferred_canonical: StdMutex::new(None),
         }
     }
 
@@ -272,6 +270,7 @@ where
         update: &StateUpdate,
         enqueued_generation: u64,
         observed_generation: &mut u64,
+        deferred_canonical: &mut Option<(RecoveredBlock<BaseBlock>, u64)>,
         recovering: &mut bool,
     ) -> Option<(SealedHeader, bool, u64)> {
         let mut provider_retries = 0;
@@ -408,11 +407,7 @@ where
                 if let StateUpdate::Canonical(block) = update
                     && block.number > best.number()
                 {
-                    *self
-                        .deferred_canonical
-                        .lock()
-                        .unwrap_or_else(|poisoned| poisoned.into_inner()) =
-                        Some((block.clone(), enqueued_generation));
+                    *deferred_canonical = Some((block.clone(), enqueued_generation));
                 }
                 self.enter_recovery(best.number());
                 *recovering = true;
@@ -427,6 +422,7 @@ where
         let mut recovering = false;
         let mut observed_generation =
             *self.recovery_epoch.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut deferred_canonical: Option<(RecoveredBlock<BaseBlock>, u64)> = None;
         let mut deferred_interval = interval(Duration::from_millis(100));
         deferred_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
         loop {
@@ -438,11 +434,7 @@ where
                     update
                 }
                 _ = deferred_interval.tick() => {
-                    let deferred = self
-                        .deferred_canonical
-                        .lock()
-                        .unwrap_or_else(|poisoned| poisoned.into_inner())
-                        .clone();
+                    let deferred = deferred_canonical.clone();
                     let Some((deferred, generation)) = deferred else {
                         continue;
                     };
@@ -452,9 +444,7 @@ where
                     {
                         continue;
                     }
-                    self.deferred_canonical
-                        .lock()
-                        .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    deferred_canonical
                         .take()
                         .map(|(block, _)| (StateUpdate::Canonical(block), generation))
                         .expect("deferred canonical remains available")
@@ -465,6 +455,7 @@ where
                     &update,
                     enqueued_generation,
                     &mut observed_generation,
+                    &mut deferred_canonical,
                     &mut recovering,
                 )
                 .await
@@ -566,6 +557,7 @@ where
                                                 &cached_update,
                                                 cached_enqueued_generation,
                                                 &mut observed_generation,
+                                                &mut deferred_canonical,
                                                 &mut recovering,
                                             )
                                             .await
@@ -800,12 +792,8 @@ where
             false
         };
 
-        let strategy = CanonicalBlockReconciler::reconcile(
-            Some(earliest),
-            Some(latest),
-            block.number,
-            reorg_detected,
-        );
+        let strategy =
+            CanonicalBlockReconciler::reconcile(earliest, latest, block.number, reorg_detected);
 
         let requires_recovery = matches!(strategy, ReconciliationStrategy::HandleReorg);
         let pending_blocks = match strategy {
@@ -865,11 +853,6 @@ where
                     strategy = ?strategy,
                 );
                 Ok(prev_pending_blocks)
-            }
-            ReconciliationStrategy::NoPendingState => {
-                debug!(message = "no pending state to update with canonical block, skipping");
-                self.clear_live_state();
-                Ok(None)
             }
         }?;
 

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -33,8 +33,8 @@ use tokio::{
 };
 
 use crate::{
-    AssembledBlock, BlockAssembler, ExecutionError, FlashblockCache, PendingBlocks,
-    PendingBlocksBuilder, PendingStateBuilder, ProtocolError, ProviderError, Result,
+    AssembledBlock, BlockAssembler, ExecutionError, FlashblockCache, MAX_FLASHBLOCKS_PER_PAYLOAD,
+    PendingBlocks, PendingBlocksBuilder, PendingStateBuilder, ProtocolError, ProviderError, Result,
     StateProcessorError,
     metrics::Metrics,
     validation::{
@@ -317,6 +317,14 @@ where
             provider_retries += 1;
             sleep(Duration::from_millis(25)).await;
         };
+
+        if matches!(update, StateUpdate::Flashblock(flashblock) if flashblock.index >= MAX_FLASHBLOCKS_PER_PAYLOAD)
+        {
+            self.enter_recovery(best.number()).await;
+            *recovering = true;
+            Metrics::pending_stale_events_skipped().increment(1);
+            return None;
+        }
 
         if self.is_quarantined_flashblock(update) {
             Metrics::pending_stale_events_skipped().increment(1);

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -1,7 +1,7 @@
 //! Flashblocks state processor.
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, VecDeque},
     sync::{Arc, Mutex as StdMutex, MutexGuard as StdMutexGuard},
     time::{Duration, Instant},
 };
@@ -437,31 +437,36 @@ where
         let mut observed_generation =
             *self.recovery_epoch.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
         let mut deferred_canonical: Option<(RecoveredBlock<BaseBlock>, u64)> = None;
+        let mut replay_updates = VecDeque::new();
         let mut deferred_interval = interval(Duration::from_millis(100));
         deferred_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
         loop {
-            let (update, enqueued_generation) = tokio::select! {
-                update = async { self.rx.lock().await.recv().await } => {
-                    let Some(update) = update else {
-                        break;
-                    };
-                    update
-                }
-                _ = deferred_interval.tick() => {
-                    let deferred = deferred_canonical.clone();
-                    let Some((deferred, generation)) = deferred else {
-                        continue;
-                    };
-                    if self
-                        .best_canonical_header()
-                        .is_none_or(|best| best.number() < deferred.number)
-                    {
-                        continue;
+            let (update, enqueued_generation) = if let Some(replay) = replay_updates.pop_front() {
+                replay
+            } else {
+                tokio::select! {
+                    update = async { self.rx.lock().await.recv().await } => {
+                        let Some(update) = update else {
+                            break;
+                        };
+                        update
                     }
-                    deferred_canonical
-                        .take()
-                        .map(|(block, _)| (StateUpdate::Canonical(block), generation))
-                        .expect("deferred canonical remains available")
+                    _ = deferred_interval.tick() => {
+                        let deferred = deferred_canonical.clone();
+                        let Some((deferred, generation)) = deferred else {
+                            continue;
+                        };
+                        if self
+                            .best_canonical_header()
+                            .is_none_or(|best| best.number() < deferred.number)
+                        {
+                            continue;
+                        }
+                        deferred_canonical
+                            .take()
+                            .map(|(block, _)| (StateUpdate::Canonical(block), generation))
+                            .expect("deferred canonical remains available")
+                    }
                 }
             };
             let Some((best, resuming_recovery, generation)) = self
@@ -556,57 +561,13 @@ where
                                         canonical_block = block.number,
                                         cached_count = cached.len(),
                                     );
-                                    for flashblock in cached {
-                                        let cached_update = StateUpdate::Flashblock(flashblock);
-                                        let cached_enqueued_generation = *self
-                                            .recovery_epoch
-                                            .lock()
-                                            .unwrap_or_else(|poisoned| poisoned.into_inner());
-                                        let Some((
-                                            cached_best,
-                                            cached_resuming_recovery,
-                                            cached_generation,
-                                        )) = self
-                                            .preflight_update(
-                                                &cached_update,
-                                                cached_enqueued_generation,
-                                                &mut observed_generation,
-                                                &mut deferred_canonical,
-                                                &mut recovering,
-                                            )
-                                            .await
-                                        else {
-                                            if recovering {
-                                                break;
-                                            }
-                                            continue;
-                                        };
-                                        let StateUpdate::Flashblock(flashblock) = cached_update
-                                        else {
-                                            unreachable!("cached update is always a flashblock");
-                                        };
-
-                                        let fb_prev = self.pending_blocks.load_full();
-                                        let (applied, requires_recovery) = self
-                                            .apply_flashblock(
-                                                fb_prev,
-                                                flashblock,
-                                                !cached_resuming_recovery,
-                                                &cached_best,
-                                                cached_generation,
-                                            )
-                                            .await;
-                                        if requires_recovery {
-                                            recovering = true;
-                                            break;
-                                        }
-                                        if applied {
-                                            recovering = false;
-                                        }
-                                        if recovering {
-                                            break;
-                                        }
-                                    }
+                                    let replay_generation = *self
+                                        .recovery_epoch
+                                        .lock()
+                                        .unwrap_or_else(|poisoned| poisoned.into_inner());
+                                    replay_updates.extend(cached.into_iter().map(|flashblock| {
+                                        (StateUpdate::Flashblock(flashblock), replay_generation)
+                                    }));
                                 }
                             }
                         }

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -186,6 +186,7 @@ pub struct StateProcessor<Client> {
     quarantined_flashblocks: StdMutex<VecDeque<(BlockNumber, PayloadId)>>,
     max_pending_blocks_depth: u64,
     recovery_generation: Arc<AtomicU64>,
+    recovery_fence: Arc<StdMutex<()>>,
     deferred_canonical: StdMutex<Option<RecoveredBlock<BaseBlock>>>,
 }
 
@@ -231,6 +232,7 @@ where
         pending_blocks: Arc<ArcSwapOption<PendingBlocks>>,
         max_pending_blocks_depth: u64,
         recovery_generation: Arc<AtomicU64>,
+        recovery_fence: Arc<StdMutex<()>>,
         rx: Arc<Mutex<Receiver<StateUpdate>>>,
         sender: Sender<Arc<PendingBlocks>>,
     ) -> Self {
@@ -248,6 +250,7 @@ where
             quarantined_flashblocks: StdMutex::new(VecDeque::new()),
             max_pending_blocks_depth,
             recovery_generation,
+            recovery_fence,
             deferred_canonical: StdMutex::new(None),
         }
     }
@@ -536,7 +539,18 @@ where
                                 }
                             }
 
+                            let fence = self
+                                .recovery_fence
+                                .lock()
+                                .unwrap_or_else(|poisoned| poisoned.into_inner());
+                            if self.recovery_generation.load(Ordering::Acquire) != generation {
+                                drop(fence);
+                                self.enter_recovery(best.number()).await;
+                                recovering = true;
+                                continue;
+                            }
                             self.pending_blocks.swap(new_pending_blocks);
+                            drop(fence);
 
                             let mut cache = self.cache.lock().await;
                             let cache_rolled_back = cache
@@ -683,9 +697,19 @@ where
                         self.enter_recovery(current_best.number()).await;
                         return (false, true);
                     }
+                }
+                let fence =
+                    self.recovery_fence.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+                if self.recovery_generation.load(Ordering::Acquire) != expected_generation {
+                    drop(fence);
+                    self.enter_recovery(expected_best.number()).await;
+                    return (false, true);
+                }
+                if let Some(ref pb) = new_pending_blocks {
                     _ = self.sender.send(Arc::clone(pb));
                 }
                 self.pending_blocks.swap(new_pending_blocks);
+                drop(fence);
                 Metrics::block_processing_duration().record(start_time.elapsed());
                 (applied, false)
             }

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -177,7 +177,7 @@ impl StateUpdate {
 /// Processes flashblocks and canonical blocks to keep pending state updated.
 #[derive(Debug)]
 pub struct StateProcessor<Client> {
-    rx: Arc<Mutex<Receiver<StateUpdate>>>,
+    rx: Arc<Mutex<Receiver<(StateUpdate, u64)>>>,
     pending_blocks: Arc<ArcSwapOption<PendingBlocks>>,
     client: Client,
     sender: Sender<Arc<PendingBlocks>>,
@@ -187,7 +187,8 @@ pub struct StateProcessor<Client> {
     max_pending_blocks_depth: u64,
     recovery_generation: Arc<AtomicU64>,
     recovery_fence: Arc<StdMutex<()>>,
-    deferred_canonical: StdMutex<Option<RecoveredBlock<BaseBlock>>>,
+    observed_generation: AtomicU64,
+    deferred_canonical: StdMutex<Option<(RecoveredBlock<BaseBlock>, u64)>>,
 }
 
 impl<Client> StateProcessor<Client>
@@ -233,13 +234,14 @@ where
         max_pending_blocks_depth: u64,
         recovery_generation: Arc<AtomicU64>,
         recovery_fence: Arc<StdMutex<()>>,
-        rx: Arc<Mutex<Receiver<StateUpdate>>>,
+        rx: Arc<Mutex<Receiver<(StateUpdate, u64)>>>,
         sender: Sender<Arc<PendingBlocks>>,
     ) -> Self {
         let cache = client
             .best_block_number()
             .map_or_else(|_| FlashblockCache::new(0), FlashblockCache::new);
 
+        let observed_generation = recovery_generation.load(Ordering::Acquire);
         Self {
             pending_blocks,
             client,
@@ -251,6 +253,7 @@ where
             max_pending_blocks_depth,
             recovery_generation,
             recovery_fence,
+            observed_generation: AtomicU64::new(observed_generation),
             deferred_canonical: StdMutex::new(None),
         }
     }
@@ -298,6 +301,15 @@ where
 
     fn quarantine_flashblock(&self, flashblock: &Flashblock) {
         let identity = (flashblock.metadata.block_number, flashblock.payload_id);
+        if self
+            .pending_blocks
+            .load_full()
+            .as_ref()
+            .and_then(|pending| pending.payload_id_for_block(identity.0))
+            == Some(identity.1)
+        {
+            return;
+        }
         let mut quarantined =
             self.quarantined_flashblocks.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
         quarantined.retain(|candidate| *candidate != identity);
@@ -310,6 +322,7 @@ where
     async fn preflight_update(
         &self,
         update: &StateUpdate,
+        enqueued_generation: u64,
         recovering: &mut bool,
     ) -> Option<(SealedHeader, bool, u64)> {
         let mut provider_retries = 0;
@@ -329,6 +342,14 @@ where
             sleep(Duration::from_millis(25)).await;
         };
         let generation = self.recovery_generation.load(Ordering::Acquire);
+        if self.observed_generation.swap(generation, Ordering::AcqRel) != generation {
+            self.enter_recovery(best.number()).await;
+            *recovering = true;
+        }
+        if enqueued_generation != generation {
+            Metrics::pending_stale_events_skipped().increment(1);
+            return None;
+        }
 
         if self.is_quarantined_flashblock(update) {
             Metrics::pending_stale_events_skipped().increment(1);
@@ -457,7 +478,8 @@ where
                     *self
                         .deferred_canonical
                         .lock()
-                        .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(block.clone());
+                        .unwrap_or_else(|poisoned| poisoned.into_inner()) =
+                        Some((block.clone(), enqueued_generation));
                 }
                 self.enter_recovery(best.number()).await;
                 *recovering = true;
@@ -473,7 +495,7 @@ where
         let mut deferred_interval = interval(Duration::from_millis(100));
         deferred_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
         loop {
-            let update = tokio::select! {
+            let (update, enqueued_generation) = tokio::select! {
                 update = async { self.rx.lock().await.recv().await } => {
                     let Some(update) = update else {
                         break;
@@ -486,7 +508,7 @@ where
                         .lock()
                         .unwrap_or_else(|poisoned| poisoned.into_inner())
                         .clone();
-                    let Some(deferred) = deferred else {
+                    let Some((deferred, generation)) = deferred else {
                         continue;
                     };
                     if self
@@ -499,12 +521,12 @@ where
                         .lock()
                         .unwrap_or_else(|poisoned| poisoned.into_inner())
                         .take()
-                        .map(StateUpdate::Canonical)
+                        .map(|(block, _)| (StateUpdate::Canonical(block), generation))
                         .expect("deferred canonical remains available")
                 }
             };
             let Some((best, resuming_recovery, generation)) =
-                self.preflight_update(&update, &mut recovering).await
+                self.preflight_update(&update, enqueued_generation, &mut recovering).await
             else {
                 continue;
             };
@@ -587,12 +609,18 @@ where
                                     );
                                     for flashblock in cached {
                                         let cached_update = StateUpdate::Flashblock(flashblock);
+                                        let cached_enqueued_generation =
+                                            self.recovery_generation.load(Ordering::Acquire);
                                         let Some((
                                             cached_best,
                                             cached_resuming_recovery,
                                             cached_generation,
                                         )) = self
-                                            .preflight_update(&cached_update, &mut recovering)
+                                            .preflight_update(
+                                                &cached_update,
+                                                cached_enqueued_generation,
+                                                &mut recovering,
+                                            )
                                             .await
                                         else {
                                             if recovering {

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -13,6 +13,7 @@ use alloy_consensus::{
 use alloy_eips::{BlockNumberOrTag, Decodable2718};
 use alloy_network::TransactionResponse;
 use alloy_primitives::{Address, B256, BlockNumber};
+use alloy_rpc_types_engine::PayloadId;
 use alloy_rpc_types_eth::state::StateOverride;
 use arc_swap::ArcSwapOption;
 use base_common_chains::Upgrades;
@@ -146,7 +147,11 @@ impl StateUpdate {
         // A canonical tip update can rebase pending. A flashblock cannot safely extend a snapshot
         // that is anchored behind the provider.
         if matches!(self, Self::Flashblock(_)) && has_pending && !pending_is_based_on_best {
-            return UpdatePreflight::EnterRecovery;
+            return if self.is_recovery_resume(best_number, best_hash) {
+                UpdatePreflight::ResumeRecovery
+            } else {
+                UpdatePreflight::EnterRecovery
+            };
         }
 
         if self.is_stale_against(best_number, best_hash) {
@@ -170,7 +175,7 @@ pub struct StateProcessor<Client> {
     sender: Sender<Arc<PendingBlocks>>,
     cache: Arc<Mutex<FlashblockCache>>,
     live_state: StdMutex<Option<LivePendingState>>,
-    quarantined_flashblock_block: StdMutex<Option<BlockNumber>>,
+    quarantined_flashblock: StdMutex<Option<(BlockNumber, PayloadId)>>,
 }
 
 impl<Client> StateProcessor<Client>
@@ -227,7 +232,7 @@ where
             sender,
             cache: Arc::new(Mutex::new(cache)),
             live_state: StdMutex::new(None),
-            quarantined_flashblock_block: StdMutex::new(None),
+            quarantined_flashblock: StdMutex::new(None),
         }
     }
 
@@ -240,10 +245,7 @@ where
         Metrics::pending_queue_recovery().increment(1);
         self.pending_blocks.swap(None);
         self.clear_live_state();
-        *self
-            .quarantined_flashblock_block
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+        *self.quarantined_flashblock.lock().unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
         *self.cache.lock().await = FlashblockCache::new(best_number);
     }
 
@@ -251,11 +253,9 @@ where
         let StateUpdate::Flashblock(flashblock) = update else {
             return false;
         };
-        let mut quarantined = self
-            .quarantined_flashblock_block
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if *quarantined != Some(flashblock.metadata.block_number) {
+        let mut quarantined =
+            self.quarantined_flashblock.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        if *quarantined != Some((flashblock.metadata.block_number, flashblock.payload_id)) {
             return false;
         }
 
@@ -283,18 +283,25 @@ where
         }
 
         let pending_blocks = self.pending_blocks.load_full();
+        let pending_is_based_on_best = pending_blocks
+            .as_ref()
+            .is_some_and(|pending| pending.is_based_on_canonical(best.number(), best.hash()));
         let preflight = update.preflight(
             Some((best.number(), best.hash())),
             pending_blocks.is_some(),
-            pending_blocks
-                .as_ref()
-                .is_some_and(|pending| pending.is_based_on_canonical(best.number(), best.hash())),
+            pending_is_based_on_best,
             *recovering,
         );
 
         match preflight {
             UpdatePreflight::Process => Some((best, false)),
-            UpdatePreflight::ResumeRecovery => Some((best, true)),
+            UpdatePreflight::ResumeRecovery => {
+                if pending_blocks.is_some() && !pending_is_based_on_best {
+                    self.enter_recovery(best.number()).await;
+                    *recovering = true;
+                }
+                Some((best, true))
+            }
             UpdatePreflight::Skip => {
                 if let StateUpdate::Flashblock(flashblock) = update
                     && StateUpdate::flashblock_has_wrong_parent_at_tip(
@@ -304,10 +311,10 @@ where
                     )
                 {
                     *self
-                        .quarantined_flashblock_block
+                        .quarantined_flashblock
                         .lock()
                         .unwrap_or_else(|poisoned| poisoned.into_inner()) =
-                        Some(flashblock.metadata.block_number);
+                        Some((flashblock.metadata.block_number, flashblock.payload_id));
                 }
                 Metrics::pending_stale_events_skipped().increment(1);
                 None
@@ -343,6 +350,22 @@ where
                                 continue;
                             }
 
+                            if let Some(pending) = &new_pending_blocks {
+                                let Some(current_best) = self.best_canonical_header() else {
+                                    self.enter_recovery(best.number()).await;
+                                    recovering = true;
+                                    continue;
+                                };
+                                if !pending.is_based_on_canonical(
+                                    current_best.number(),
+                                    current_best.hash(),
+                                ) {
+                                    self.enter_recovery(current_best.number()).await;
+                                    recovering = true;
+                                    continue;
+                                }
+                            }
+
                             self.pending_blocks.swap(new_pending_blocks);
 
                             let mut cache = self.cache.lock().await;
@@ -365,7 +388,7 @@ where
                                     );
                                     for flashblock in cached {
                                         let cached_update = StateUpdate::Flashblock(flashblock);
-                                        let Some((_, cached_resuming_recovery)) = self
+                                        let Some((cached_best, cached_resuming_recovery)) = self
                                             .preflight_update(&cached_update, &mut recovering)
                                             .await
                                         else {
@@ -380,13 +403,18 @@ where
                                         };
 
                                         let fb_prev = self.pending_blocks.load_full();
-                                        let applied = self
+                                        let (applied, requires_recovery) = self
                                             .apply_flashblock(
                                                 fb_prev,
                                                 flashblock,
                                                 !cached_resuming_recovery,
+                                                &cached_best,
                                             )
                                             .await;
+                                        if requires_recovery {
+                                            recovering = true;
+                                            break;
+                                        }
                                         if cached_resuming_recovery && applied {
                                             recovering = false;
                                         }
@@ -410,10 +438,17 @@ where
                         block_number = flashblock.metadata.block_number,
                         flashblock_index = flashblock.index
                     );
-                    let applied = self
-                        .apply_flashblock(prev_pending_blocks, flashblock, !resuming_recovery)
+                    let (applied, requires_recovery) = self
+                        .apply_flashblock(
+                            prev_pending_blocks,
+                            flashblock,
+                            !resuming_recovery,
+                            &best,
+                        )
                         .await;
-                    if resuming_recovery && applied {
+                    if requires_recovery {
+                        recovering = true;
+                    } else if resuming_recovery && applied {
                         recovering = false;
                     }
                 }
@@ -426,17 +461,26 @@ where
         prev_pending_blocks: Option<Arc<PendingBlocks>>,
         flashblock: Flashblock,
         cache_on_missing_canonical_header: bool,
-    ) -> bool {
+        expected_best: &SealedHeader,
+    ) -> (bool, bool) {
         let start_time = Instant::now();
         match self.process_flashblock(prev_pending_blocks, &flashblock) {
             Ok(new_pending_blocks) => {
                 let applied = new_pending_blocks.is_some();
                 if let Some(ref pb) = new_pending_blocks {
+                    let Some(current_best) = self.best_canonical_header() else {
+                        self.enter_recovery(expected_best.number()).await;
+                        return (false, true);
+                    };
+                    if !pb.is_based_on_canonical(current_best.number(), current_best.hash()) {
+                        self.enter_recovery(current_best.number()).await;
+                        return (false, true);
+                    }
                     _ = self.sender.send(Arc::clone(pb));
                 }
                 self.pending_blocks.swap(new_pending_blocks);
                 Metrics::block_processing_duration().record(start_time.elapsed());
-                applied
+                (applied, false)
             }
             Err(e) => {
                 match e {
@@ -446,7 +490,7 @@ where
                         let inserted = self.cache.lock().await.insert(flashblock);
                         if inserted {
                             debug!(message = "cached flashblock pending canonical block", error = %e);
-                            return false;
+                            return (false, false);
                         }
                     }
                     StateProcessorError::MissingFirstFlashblock => {
@@ -459,10 +503,10 @@ where
                             )
                             && cache.insert(flashblock)
                         {
-                            return false;
+                            return (false, false);
                         }
                         // we should ignore this error since it doesn't necessarily indicate a problem
-                        return false;
+                        return (false, false);
                     }
                     _ => {}
                 }
@@ -475,7 +519,7 @@ where
                     error!(message = "could not process Flashblock", error = %e);
                     Metrics::block_processing_error().increment(1);
                 }
-                false
+                (false, false)
             }
         }
     }
@@ -1203,14 +1247,14 @@ mod tests {
     }
 
     #[test]
-    fn preflight_enters_recovery_for_stale_pending() {
+    fn preflight_restarts_from_current_base_when_pending_is_stale() {
         let best = 100;
         let best_hash = B256::repeat_byte(0xAB);
         let update = StateUpdate::Flashblock(flashblock(101, 0, best_hash));
 
         assert_eq!(
             update.preflight(Some((best, best_hash)), true, false, false),
-            UpdatePreflight::EnterRecovery
+            UpdatePreflight::ResumeRecovery
         );
     }
 

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -2,7 +2,10 @@
 
 use std::{
     collections::{BTreeMap, VecDeque},
-    sync::{Arc, Mutex as StdMutex, MutexGuard as StdMutexGuard},
+    sync::{
+        Arc, Mutex as StdMutex, MutexGuard as StdMutexGuard,
+        atomic::{AtomicU64, Ordering},
+    },
     time::{Duration, Instant},
 };
 
@@ -29,7 +32,7 @@ use reth_revm::{State, database::StateProviderDatabase};
 use revm_database::states::bundle_state::BundleRetention;
 use tokio::{
     sync::{Mutex, broadcast::Sender, mpsc::Receiver},
-    time::sleep,
+    time::{MissedTickBehavior, interval, sleep},
 };
 
 use crate::{
@@ -182,6 +185,8 @@ pub struct StateProcessor<Client> {
     live_state: StdMutex<Option<LivePendingState>>,
     quarantined_flashblocks: StdMutex<VecDeque<(BlockNumber, PayloadId)>>,
     max_pending_blocks_depth: u64,
+    recovery_generation: Arc<AtomicU64>,
+    deferred_canonical: StdMutex<Option<RecoveredBlock<BaseBlock>>>,
 }
 
 impl<Client> StateProcessor<Client>
@@ -225,6 +230,7 @@ where
         client: Client,
         pending_blocks: Arc<ArcSwapOption<PendingBlocks>>,
         max_pending_blocks_depth: u64,
+        recovery_generation: Arc<AtomicU64>,
         rx: Arc<Mutex<Receiver<StateUpdate>>>,
         sender: Sender<Arc<PendingBlocks>>,
     ) -> Self {
@@ -241,6 +247,8 @@ where
             live_state: StdMutex::new(None),
             quarantined_flashblocks: StdMutex::new(VecDeque::new()),
             max_pending_blocks_depth,
+            recovery_generation,
+            deferred_canonical: StdMutex::new(None),
         }
     }
 
@@ -300,7 +308,7 @@ where
         &self,
         update: &StateUpdate,
         recovering: &mut bool,
-    ) -> Option<(SealedHeader, bool)> {
+    ) -> Option<(SealedHeader, bool, u64)> {
         let mut provider_retries = 0;
         let best = loop {
             if let Some(best) = self.best_canonical_header() {
@@ -317,6 +325,7 @@ where
             provider_retries += 1;
             sleep(Duration::from_millis(25)).await;
         };
+        let generation = self.recovery_generation.load(Ordering::Acquire);
 
         if self.is_quarantined_flashblock(update) {
             Metrics::pending_stale_events_skipped().increment(1);
@@ -327,6 +336,14 @@ where
         let pending_is_based_on_best = pending_blocks
             .as_ref()
             .is_some_and(|pending| self.pending_tracks_canonical_tip(pending, &best));
+        if let StateUpdate::Flashblock(flashblock) = update
+            && (flashblock.metadata.block_number == 0
+                || flashblock.base.as_ref().is_some_and(|base| base.block_number == 0))
+        {
+            self.quarantine_flashblock(flashblock);
+            Metrics::pending_stale_events_skipped().increment(1);
+            return None;
+        }
         if let StateUpdate::Flashblock(flashblock) = update
             && flashblock.index >= MAX_FLASHBLOCKS_PER_PAYLOAD
         {
@@ -377,7 +394,7 @@ where
                         return None;
                     }
                     if flashblock.payload_id != payload_id {
-                        return Some((best, false));
+                        return Some((best, false, generation));
                     }
                 }
                 if flashblock.payload_id != payload_id || flashblock.index == 0 {
@@ -409,13 +426,13 @@ where
         );
 
         match preflight {
-            UpdatePreflight::Process => Some((best, false)),
+            UpdatePreflight::Process => Some((best, false, generation)),
             UpdatePreflight::ResumeRecovery => {
                 if pending_blocks.is_some() && !pending_is_based_on_best {
                     self.enter_recovery(best.number()).await;
                     *recovering = true;
                 }
-                Some((best, true))
+                Some((best, true, generation))
             }
             UpdatePreflight::Skip => {
                 if let StateUpdate::Flashblock(flashblock) = update
@@ -431,6 +448,14 @@ where
                 None
             }
             UpdatePreflight::EnterRecovery => {
+                if let StateUpdate::Canonical(block) = update
+                    && block.number > best.number()
+                {
+                    *self
+                        .deferred_canonical
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(block.clone());
+                }
                 self.enter_recovery(best.number()).await;
                 *recovering = true;
                 Metrics::pending_stale_events_skipped().increment(1);
@@ -442,8 +467,40 @@ where
     /// Processes updates from the queue until the channel closes.
     pub async fn start(&self) {
         let mut recovering = false;
-        while let Some(update) = self.rx.lock().await.recv().await {
-            let Some((best, resuming_recovery)) =
+        let mut deferred_interval = interval(Duration::from_millis(100));
+        deferred_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        loop {
+            let update = tokio::select! {
+                update = async { self.rx.lock().await.recv().await } => {
+                    let Some(update) = update else {
+                        break;
+                    };
+                    update
+                }
+                _ = deferred_interval.tick() => {
+                    let deferred = self
+                        .deferred_canonical
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner())
+                        .clone();
+                    let Some(deferred) = deferred else {
+                        continue;
+                    };
+                    if self
+                        .best_canonical_header()
+                        .is_none_or(|best| best.number() < deferred.number)
+                    {
+                        continue;
+                    }
+                    self.deferred_canonical
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner())
+                        .take()
+                        .map(StateUpdate::Canonical)
+                        .expect("deferred canonical remains available")
+                }
+            };
+            let Some((best, resuming_recovery, generation)) =
                 self.preflight_update(&update, &mut recovering).await
             else {
                 continue;
@@ -455,6 +512,11 @@ where
                     debug!(message = "processing canonical block", block_number = block.number);
                     match self.process_canonical_block(prev_pending_blocks, &block) {
                         Ok((new_pending_blocks, requires_recovery)) => {
+                            if self.recovery_generation.load(Ordering::Acquire) != generation {
+                                self.enter_recovery(best.number()).await;
+                                recovering = true;
+                                continue;
+                            }
                             if requires_recovery {
                                 self.enter_recovery(best.number()).await;
                                 recovering = true;
@@ -511,7 +573,11 @@ where
                                     );
                                     for flashblock in cached {
                                         let cached_update = StateUpdate::Flashblock(flashblock);
-                                        let Some((cached_best, cached_resuming_recovery)) = self
+                                        let Some((
+                                            cached_best,
+                                            cached_resuming_recovery,
+                                            cached_generation,
+                                        )) = self
                                             .preflight_update(&cached_update, &mut recovering)
                                             .await
                                         else {
@@ -532,6 +598,7 @@ where
                                                 flashblock,
                                                 !cached_resuming_recovery,
                                                 &cached_best,
+                                                cached_generation,
                                             )
                                             .await;
                                         if requires_recovery {
@@ -567,6 +634,7 @@ where
                             flashblock,
                             !resuming_recovery,
                             &best,
+                            generation,
                         )
                         .await;
                     if requires_recovery {
@@ -585,6 +653,7 @@ where
         flashblock: Flashblock,
         cache_on_missing_canonical_header: bool,
         expected_best: &SealedHeader,
+        expected_generation: u64,
     ) -> (bool, bool) {
         let start_time = Instant::now();
         let mut provider_retries = 0;
@@ -600,6 +669,10 @@ where
 
         match result {
             Ok(new_pending_blocks) => {
+                if self.recovery_generation.load(Ordering::Acquire) != expected_generation {
+                    self.enter_recovery(expected_best.number()).await;
+                    return (false, true);
+                }
                 let applied = new_pending_blocks.is_some();
                 if let Some(ref pb) = new_pending_blocks {
                     let Some(current_best) = self.best_canonical_header() else {
@@ -1206,8 +1279,10 @@ where
                 .push(flashblock.clone());
         }
 
-        let earliest_block_number = flashblocks_per_block.keys().min().unwrap();
-        let canonical_block = earliest_block_number - 1;
+        let earliest_block_number =
+            *flashblocks_per_block.keys().min().ok_or(ProtocolError::EmptyFlashblocks)?;
+        let canonical_block =
+            earliest_block_number.checked_sub(1).ok_or(ProtocolError::ZeroBlockNumber)?;
         let mut last_block_header = self
             .client
             .header_by_number(canonical_block)

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -280,6 +280,12 @@ where
         deferred_canonical: &mut Option<(RecoveredBlock<BaseBlock>, u64)>,
         recovering: &mut bool,
     ) -> Option<(SealedHeader, bool, u64)> {
+        let generation =
+            *self.recovery_epoch.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        if enqueued_generation != generation {
+            Metrics::pending_stale_events_skipped().increment(1);
+            return None;
+        }
         let mut provider_retries = 0;
         let best = loop {
             if let Some(best) = self.best_canonical_header() {
@@ -295,16 +301,10 @@ where
             provider_retries += 1;
             sleep(Duration::from_millis(25)).await;
         };
-        let generation =
-            *self.recovery_epoch.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
         if *observed_generation != generation {
             *observed_generation = generation;
             self.enter_recovery(best.number());
             *recovering = true;
-        }
-        if enqueued_generation != generation {
-            Metrics::pending_stale_events_skipped().increment(1);
-            return None;
         }
         if let StateUpdate::Flashblock(flashblock) = update
             && let Some((block, _)) = deferred_canonical.as_ref()

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -137,6 +137,12 @@ impl StateUpdate {
             };
         }
 
+        // A canonical notification can race ahead of provider visibility. Processing it would
+        // rebase against state that cannot be read yet, so leave the tip-aligned snapshot intact.
+        if matches!(self, Self::Canonical(block) if block.number > best_number) {
+            return UpdatePreflight::Skip;
+        }
+
         // A canonical tip update can rebase pending. A flashblock cannot safely extend a snapshot
         // that is anchored behind the provider.
         if matches!(self, Self::Flashblock(_)) && has_pending && !pending_is_based_on_best {
@@ -1250,6 +1256,22 @@ mod tests {
         assert_eq!(
             StateUpdate::Canonical(block).preflight(Some((best, best_hash)), false, false, true),
             UpdatePreflight::Process
+        );
+    }
+
+    #[test]
+    fn preflight_skips_canonical_ahead_of_provider_visibility() {
+        let best = 100;
+        let best_hash = B256::repeat_byte(0xAB);
+        let block = BaseBlock {
+            header: Header { number: best + 1, ..Default::default() },
+            body: Default::default(),
+        };
+        let block = RecoveredBlock::new_sealed(SealedBlock::seal_slow(block), Vec::new());
+
+        assert_eq!(
+            StateUpdate::Canonical(block).preflight(Some((best, best_hash)), true, true, false),
+            UpdatePreflight::Skip
         );
     }
 

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -1,7 +1,7 @@
 //! Flashblocks state processor.
 
 use std::{
-    collections::{BTreeMap, VecDeque},
+    collections::BTreeMap,
     sync::{
         Arc, Mutex as StdMutex, MutexGuard as StdMutexGuard,
         atomic::{AtomicU64, Ordering},
@@ -16,7 +16,6 @@ use alloy_consensus::{
 use alloy_eips::{BlockNumberOrTag, Decodable2718};
 use alloy_network::TransactionResponse;
 use alloy_primitives::{Address, B256, BlockNumber};
-use alloy_rpc_types_engine::PayloadId;
 use alloy_rpc_types_eth::state::StateOverride;
 use arc_swap::ArcSwapOption;
 use base_common_chains::Upgrades;
@@ -47,7 +46,6 @@ use crate::{
 };
 
 type PendingExecutionDb = State<StateProviderDatabase<StateProviderBox>>;
-const MAX_QUARANTINED_PAYLOADS: usize = 8;
 
 #[derive(Debug)]
 struct LivePendingState {
@@ -183,7 +181,6 @@ pub struct StateProcessor<Client> {
     sender: Sender<Arc<PendingBlocks>>,
     cache: Arc<Mutex<FlashblockCache>>,
     live_state: StdMutex<Option<LivePendingState>>,
-    quarantined_flashblocks: StdMutex<VecDeque<(BlockNumber, PayloadId)>>,
     max_pending_blocks_depth: u64,
     recovery_generation: Arc<AtomicU64>,
     recovery_fence: Arc<StdMutex<()>>,
@@ -249,7 +246,6 @@ where
             sender,
             cache: Arc::new(Mutex::new(cache)),
             live_state: StdMutex::new(None),
-            quarantined_flashblocks: StdMutex::new(VecDeque::new()),
             max_pending_blocks_depth,
             recovery_generation,
             recovery_fence,
@@ -273,50 +269,7 @@ where
         Metrics::pending_queue_recovery().increment(1);
         self.pending_blocks.swap(None);
         self.clear_live_state();
-        self.quarantined_flashblocks
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .clear();
         *self.cache.lock().await = FlashblockCache::new(best_number);
-    }
-
-    fn is_quarantined_flashblock(&self, update: &StateUpdate) -> bool {
-        let StateUpdate::Flashblock(flashblock) = update else {
-            return false;
-        };
-        let identity = (flashblock.metadata.block_number, flashblock.payload_id);
-        let mut quarantined =
-            self.quarantined_flashblocks.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-        let Some(position) = quarantined.iter().position(|candidate| *candidate == identity) else {
-            return false;
-        };
-
-        if flashblock.index == 0 {
-            quarantined.remove(position);
-            false
-        } else {
-            true
-        }
-    }
-
-    fn quarantine_flashblock(&self, flashblock: &Flashblock) {
-        let identity = (flashblock.metadata.block_number, flashblock.payload_id);
-        if self
-            .pending_blocks
-            .load_full()
-            .as_ref()
-            .and_then(|pending| pending.payload_id_for_block(identity.0))
-            == Some(identity.1)
-        {
-            return;
-        }
-        let mut quarantined =
-            self.quarantined_flashblocks.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-        quarantined.retain(|candidate| *candidate != identity);
-        quarantined.push_back(identity);
-        while quarantined.len() > MAX_QUARANTINED_PAYLOADS {
-            quarantined.pop_front();
-        }
     }
 
     async fn preflight_update(
@@ -351,11 +304,6 @@ where
             return None;
         }
 
-        if self.is_quarantined_flashblock(update) {
-            Metrics::pending_stale_events_skipped().increment(1);
-            return None;
-        }
-
         let pending_blocks = self.pending_blocks.load_full();
         let pending_is_based_on_best = pending_blocks
             .as_ref()
@@ -364,7 +312,6 @@ where
             && (flashblock.metadata.block_number == 0
                 || flashblock.base.as_ref().is_some_and(|base| base.block_number == 0))
         {
-            self.quarantine_flashblock(flashblock);
             Metrics::pending_stale_events_skipped().increment(1);
             return None;
         }
@@ -389,7 +336,6 @@ where
                 .as_ref()
                 .is_none_or(|base| base.block_number != flashblock.metadata.block_number)
         {
-            self.quarantine_flashblock(flashblock);
             Metrics::pending_stale_events_skipped().increment(1);
             return None;
         }
@@ -413,7 +359,6 @@ where
                         pending.expected_parent_hash(flashblock.metadata.block_number)
                             != Some(base.parent_hash)
                     }) {
-                        self.quarantine_flashblock(flashblock);
                         Metrics::pending_stale_events_skipped().increment(1);
                         return None;
                     }
@@ -436,7 +381,6 @@ where
                     .as_ref()
                     .is_none_or(|base| base.parent_hash != pending.latest_block_hash())
             {
-                self.quarantine_flashblock(flashblock);
                 Metrics::pending_stale_events_skipped().increment(1);
                 return None;
             }
@@ -459,15 +403,6 @@ where
                 Some((best, true, generation))
             }
             UpdatePreflight::Skip => {
-                if let StateUpdate::Flashblock(flashblock) = update
-                    && StateUpdate::flashblock_has_wrong_parent_at_tip(
-                        flashblock,
-                        best.number(),
-                        best.hash(),
-                    )
-                {
-                    self.quarantine_flashblock(flashblock);
-                }
                 Metrics::pending_stale_events_skipped().increment(1);
                 None
             }
@@ -908,7 +843,7 @@ where
                     self.build_pending_state(None, &flashblocks)
                 }
             }
-            ReconciliationStrategy::VerifyAnchor | ReconciliationStrategy::IgnoreUntracked => {
+            ReconciliationStrategy::Keep => {
                 debug!(
                     message = "canonical block does not require pending rebuild",
                     latest_pending_block = latest,

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -476,8 +476,7 @@ where
                         update
                     }
                     _ = deferred_interval.tick() => {
-                        let deferred = deferred_canonical.clone();
-                        let Some((deferred, generation)) = deferred else {
+                        let Some((deferred, _)) = deferred_canonical.as_ref() else {
                             continue;
                         };
                         if self
@@ -488,7 +487,7 @@ where
                         }
                         deferred_canonical
                             .take()
-                            .map(|(block, _)| (StateUpdate::Canonical(block), generation))
+                            .map(|(block, generation)| (StateUpdate::Canonical(block), generation))
                             .expect("deferred canonical remains available")
                     }
                 }
@@ -637,7 +636,11 @@ where
         let mut provider_retries = 0;
         let result = loop {
             let result = self.process_flashblock(prev_pending_blocks.clone(), &flashblock);
-            if matches!(result, Err(StateProcessorError::Provider(_))) && provider_retries < 20 {
+            if matches!(
+                result,
+                Err(StateProcessorError::Provider(ProviderError::MissingCanonicalHeader { .. }))
+            ) && provider_retries < 20
+            {
                 provider_retries += 1;
                 sleep(Duration::from_millis(25)).await;
                 continue;
@@ -686,8 +689,8 @@ where
                         let inserted = self.lock_cache().insert(flashblock);
                         if inserted {
                             debug!(message = "cached flashblock pending canonical block", error = %e);
-                            return (false, false);
                         }
+                        return (false, false);
                     }
                     StateProcessorError::MissingFirstFlashblock => {
                         let mut cache = self.lock_cache();
@@ -817,7 +820,7 @@ where
                     Metrics::pending_clear_catchup().increment(1);
                     self.clear_live_state();
                     Ok(None)
-                } else if flashblocks.first().is_none_or(|flashblock| {
+                } else if flashblocks.first().is_some_and(|flashblock| {
                     flashblock.index != 0
                         || flashblock.metadata.block_number != block.number.saturating_add(1)
                         || flashblock

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -2,10 +2,7 @@
 
 use std::{
     collections::BTreeMap,
-    sync::{
-        Arc, Mutex as StdMutex, MutexGuard as StdMutexGuard,
-        atomic::{AtomicU64, Ordering},
-    },
+    sync::{Arc, Mutex as StdMutex, MutexGuard as StdMutexGuard},
     time::{Duration, Instant},
 };
 
@@ -182,9 +179,7 @@ pub struct StateProcessor<Client> {
     cache: Arc<Mutex<FlashblockCache>>,
     live_state: StdMutex<Option<LivePendingState>>,
     max_pending_blocks_depth: u64,
-    recovery_generation: Arc<AtomicU64>,
-    recovery_fence: Arc<StdMutex<()>>,
-    observed_generation: AtomicU64,
+    recovery_epoch: Arc<StdMutex<u64>>,
     deferred_canonical: StdMutex<Option<(RecoveredBlock<BaseBlock>, u64)>>,
 }
 
@@ -229,8 +224,7 @@ where
         client: Client,
         pending_blocks: Arc<ArcSwapOption<PendingBlocks>>,
         max_pending_blocks_depth: u64,
-        recovery_generation: Arc<AtomicU64>,
-        recovery_fence: Arc<StdMutex<()>>,
+        recovery_epoch: Arc<StdMutex<u64>>,
         rx: Arc<Mutex<Receiver<(StateUpdate, u64)>>>,
         sender: Sender<Arc<PendingBlocks>>,
     ) -> Self {
@@ -238,7 +232,6 @@ where
             .best_block_number()
             .map_or_else(|_| FlashblockCache::new(0), FlashblockCache::new);
 
-        let observed_generation = recovery_generation.load(Ordering::Acquire);
         Self {
             pending_blocks,
             client,
@@ -247,9 +240,7 @@ where
             cache: Arc::new(Mutex::new(cache)),
             live_state: StdMutex::new(None),
             max_pending_blocks_depth,
-            recovery_generation,
-            recovery_fence,
-            observed_generation: AtomicU64::new(observed_generation),
+            recovery_epoch,
             deferred_canonical: StdMutex::new(None),
         }
     }
@@ -276,6 +267,7 @@ where
         &self,
         update: &StateUpdate,
         enqueued_generation: u64,
+        observed_generation: &mut u64,
         recovering: &mut bool,
     ) -> Option<(SealedHeader, bool, u64)> {
         let mut provider_retries = 0;
@@ -294,8 +286,10 @@ where
             provider_retries += 1;
             sleep(Duration::from_millis(25)).await;
         };
-        let generation = self.recovery_generation.load(Ordering::Acquire);
-        if self.observed_generation.swap(generation, Ordering::AcqRel) != generation {
+        let generation =
+            *self.recovery_epoch.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        if *observed_generation != generation {
+            *observed_generation = generation;
             self.enter_recovery(best.number()).await;
             *recovering = true;
         }
@@ -427,6 +421,8 @@ where
     /// Processes updates from the queue until the channel closes.
     pub async fn start(&self) {
         let mut recovering = false;
+        let mut observed_generation =
+            *self.recovery_epoch.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
         let mut deferred_interval = interval(Duration::from_millis(100));
         deferred_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
         loop {
@@ -460,8 +456,14 @@ where
                         .expect("deferred canonical remains available")
                 }
             };
-            let Some((best, resuming_recovery, generation)) =
-                self.preflight_update(&update, enqueued_generation, &mut recovering).await
+            let Some((best, resuming_recovery, generation)) = self
+                .preflight_update(
+                    &update,
+                    enqueued_generation,
+                    &mut observed_generation,
+                    &mut recovering,
+                )
+                .await
             else {
                 continue;
             };
@@ -472,11 +474,6 @@ where
                     debug!(message = "processing canonical block", block_number = block.number);
                     match self.process_canonical_block(prev_pending_blocks, &block) {
                         Ok((new_pending_blocks, requires_recovery)) => {
-                            if self.recovery_generation.load(Ordering::Acquire) != generation {
-                                self.enter_recovery(best.number()).await;
-                                recovering = true;
-                                continue;
-                            }
                             if requires_recovery {
                                 self.enter_recovery(best.number()).await;
                                 recovering = true;
@@ -496,18 +493,23 @@ where
                                 }
                             }
 
-                            let fence = self
-                                .recovery_fence
-                                .lock()
-                                .unwrap_or_else(|poisoned| poisoned.into_inner());
-                            if self.recovery_generation.load(Ordering::Acquire) != generation {
-                                drop(fence);
+                            let stale_generation = {
+                                let epoch = self
+                                    .recovery_epoch
+                                    .lock()
+                                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                                if *epoch != generation {
+                                    true
+                                } else {
+                                    self.pending_blocks.swap(new_pending_blocks);
+                                    false
+                                }
+                            };
+                            if stale_generation {
                                 self.enter_recovery(best.number()).await;
                                 recovering = true;
                                 continue;
                             }
-                            self.pending_blocks.swap(new_pending_blocks);
-                            drop(fence);
 
                             let mut cache = self.cache.lock().await;
                             let cache_rolled_back = cache
@@ -544,8 +546,10 @@ where
                                     );
                                     for flashblock in cached {
                                         let cached_update = StateUpdate::Flashblock(flashblock);
-                                        let cached_enqueued_generation =
-                                            self.recovery_generation.load(Ordering::Acquire);
+                                        let cached_enqueued_generation = *self
+                                            .recovery_epoch
+                                            .lock()
+                                            .unwrap_or_else(|poisoned| poisoned.into_inner());
                                         let Some((
                                             cached_best,
                                             cached_resuming_recovery,
@@ -554,6 +558,7 @@ where
                                             .preflight_update(
                                                 &cached_update,
                                                 cached_enqueued_generation,
+                                                &mut observed_generation,
                                                 &mut recovering,
                                             )
                                             .await
@@ -646,10 +651,6 @@ where
 
         match result {
             Ok(new_pending_blocks) => {
-                if self.recovery_generation.load(Ordering::Acquire) != expected_generation {
-                    self.enter_recovery(expected_best.number()).await;
-                    return (false, true);
-                }
                 let applied = new_pending_blocks.is_some();
                 if let Some(ref pb) = new_pending_blocks {
                     let Some(current_best) = self.best_canonical_header() else {
@@ -661,18 +662,23 @@ where
                         return (false, true);
                     }
                 }
-                let fence =
-                    self.recovery_fence.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-                if self.recovery_generation.load(Ordering::Acquire) != expected_generation {
-                    drop(fence);
+                let stale_generation = {
+                    let epoch =
+                        self.recovery_epoch.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+                    if *epoch != expected_generation {
+                        true
+                    } else {
+                        if let Some(ref pb) = new_pending_blocks {
+                            _ = self.sender.send(Arc::clone(pb));
+                        }
+                        self.pending_blocks.swap(new_pending_blocks);
+                        false
+                    }
+                };
+                if stale_generation {
                     self.enter_recovery(expected_best.number()).await;
                     return (false, true);
                 }
-                if let Some(ref pb) = new_pending_blocks {
-                    _ = self.sender.send(Arc::clone(pb));
-                }
-                self.pending_blocks.swap(new_pending_blocks);
-                drop(fence);
                 Metrics::block_processing_duration().record(start_time.elapsed());
                 (applied, false)
             }

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -300,6 +300,14 @@ where
             Metrics::pending_stale_events_skipped().increment(1);
             return None;
         }
+        if matches!(update, StateUpdate::Flashblock(_))
+            && deferred_canonical
+                .as_ref()
+                .is_some_and(|(block, _)| update.pending_anchor_number() <= block.number)
+        {
+            Metrics::pending_stale_events_skipped().increment(1);
+            return None;
+        }
 
         let pending_blocks = self.pending_blocks.load_full();
         let pending_is_based_on_best = pending_blocks

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -176,7 +176,7 @@ pub struct StateProcessor<Client> {
     pending_blocks: Arc<ArcSwapOption<PendingBlocks>>,
     client: Client,
     sender: Sender<Arc<PendingBlocks>>,
-    cache: Arc<Mutex<FlashblockCache>>,
+    cache: StdMutex<FlashblockCache>,
     live_state: StdMutex<Option<LivePendingState>>,
     max_pending_blocks_depth: u64,
     recovery_epoch: Arc<StdMutex<u64>>,
@@ -193,6 +193,10 @@ where
 {
     fn lock_live_state(&self) -> StdMutexGuard<'_, Option<LivePendingState>> {
         self.live_state.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn lock_cache(&self) -> StdMutexGuard<'_, FlashblockCache> {
+        self.cache.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
     fn clear_live_state(&self) {
@@ -237,7 +241,7 @@ where
             client,
             rx,
             sender,
-            cache: Arc::new(Mutex::new(cache)),
+            cache: StdMutex::new(cache),
             live_state: StdMutex::new(None),
             max_pending_blocks_depth,
             recovery_epoch,
@@ -255,12 +259,12 @@ where
                 <= self.max_pending_blocks_depth
     }
 
-    async fn enter_recovery(&self, best_number: u64) {
+    fn enter_recovery(&self, best_number: u64) {
         warn!(best = best_number, "flashblock processor entering recovery");
         Metrics::pending_queue_recovery().increment(1);
         self.pending_blocks.swap(None);
         self.clear_live_state();
-        *self.cache.lock().await = FlashblockCache::new(best_number);
+        *self.lock_cache() = FlashblockCache::new(best_number);
     }
 
     async fn preflight_update(
@@ -277,8 +281,8 @@ where
             }
             if provider_retries >= 20 {
                 let last_canonical =
-                    self.cache.lock().await.latest_canonical_number().unwrap_or_default();
-                self.enter_recovery(last_canonical).await;
+                    self.lock_cache().latest_canonical_number().unwrap_or_default();
+                self.enter_recovery(last_canonical);
                 *recovering = true;
                 Metrics::pending_stale_events_skipped().increment(1);
                 return None;
@@ -290,7 +294,7 @@ where
             *self.recovery_epoch.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
         if *observed_generation != generation {
             *observed_generation = generation;
-            self.enter_recovery(best.number()).await;
+            self.enter_recovery(best.number());
             *recovering = true;
         }
         if enqueued_generation != generation {
@@ -317,7 +321,7 @@ where
                     && flashblock.payload_id == pending.latest_payload_id()
             });
             if extends_accepted_payload {
-                self.enter_recovery(best.number()).await;
+                self.enter_recovery(best.number());
                 *recovering = true;
             }
             Metrics::pending_stale_events_skipped().increment(1);
@@ -391,7 +395,7 @@ where
             UpdatePreflight::Process => Some((best, false, generation)),
             UpdatePreflight::ResumeRecovery => {
                 if pending_blocks.is_some() && !pending_is_based_on_best {
-                    self.enter_recovery(best.number()).await;
+                    self.enter_recovery(best.number());
                     *recovering = true;
                 }
                 Some((best, true, generation))
@@ -410,7 +414,7 @@ where
                         .unwrap_or_else(|poisoned| poisoned.into_inner()) =
                         Some((block.clone(), enqueued_generation));
                 }
-                self.enter_recovery(best.number()).await;
+                self.enter_recovery(best.number());
                 *recovering = true;
                 Metrics::pending_stale_events_skipped().increment(1);
                 None
@@ -475,19 +479,19 @@ where
                     match self.process_canonical_block(prev_pending_blocks, &block) {
                         Ok((new_pending_blocks, requires_recovery)) => {
                             if requires_recovery {
-                                self.enter_recovery(best.number()).await;
+                                self.enter_recovery(best.number());
                                 recovering = true;
                                 continue;
                             }
 
                             if let Some(pending) = &new_pending_blocks {
                                 let Some(current_best) = self.best_canonical_header() else {
-                                    self.enter_recovery(best.number()).await;
+                                    self.enter_recovery(best.number());
                                     recovering = true;
                                     continue;
                                 };
                                 if !self.pending_tracks_canonical_tip(pending, &current_best) {
-                                    self.enter_recovery(current_best.number()).await;
+                                    self.enter_recovery(current_best.number());
                                     recovering = true;
                                     continue;
                                 }
@@ -506,31 +510,34 @@ where
                                 }
                             };
                             if stale_generation {
-                                self.enter_recovery(best.number()).await;
+                                self.enter_recovery(best.number());
                                 recovering = true;
                                 continue;
                             }
 
-                            let mut cache = self.cache.lock().await;
-                            let cache_rolled_back = cache
-                                .latest_canonical_number()
-                                .is_some_and(|canonical| canonical > block.number)
-                                && block.number == best.number()
-                                && block.hash() == best.hash();
-                            if cache_rolled_back {
-                                *cache = FlashblockCache::new(block.number);
-                            }
-                            let should_advance = cache
-                                .latest_canonical_number()
-                                .is_none_or(|canonical| block.number >= canonical);
-                            if should_advance {
-                                cache.update_canonical(block.number);
-                                let cached_block_number = block.number.saturating_add(1);
-                                let mut cached = cache.drain(cached_block_number, block.hash());
-                                // Recovery may replace the cache while replaying, so release this
-                                // lock before preflighting any cached payload.
-                                drop(cache);
-
+                            let cached = {
+                                let mut cache = self.lock_cache();
+                                let cache_rolled_back = cache
+                                    .latest_canonical_number()
+                                    .is_some_and(|canonical| canonical > block.number)
+                                    && block.number == best.number()
+                                    && block.hash() == best.hash();
+                                if cache_rolled_back {
+                                    *cache = FlashblockCache::new(block.number);
+                                }
+                                let should_advance = cache
+                                    .latest_canonical_number()
+                                    .is_none_or(|canonical| block.number >= canonical);
+                                should_advance.then(|| {
+                                    cache.update_canonical(block.number);
+                                    let cached_block_number = block.number.saturating_add(1);
+                                    (
+                                        cached_block_number,
+                                        cache.drain(cached_block_number, block.hash()),
+                                    )
+                                })
+                            };
+                            if let Some((cached_block_number, mut cached)) = cached {
                                 if self.pending_blocks.load_full().is_some_and(|pending| {
                                     pending.latest_block_number() >= cached_block_number
                                 }) {
@@ -599,7 +606,7 @@ where
                         }
                         Err(e) => {
                             error!(message = "could not process canonical block", error = %e);
-                            self.enter_recovery(best.number()).await;
+                            self.enter_recovery(best.number());
                             recovering = true;
                         }
                     }
@@ -654,11 +661,11 @@ where
                 let applied = new_pending_blocks.is_some();
                 if let Some(ref pb) = new_pending_blocks {
                     let Some(current_best) = self.best_canonical_header() else {
-                        self.enter_recovery(expected_best.number()).await;
+                        self.enter_recovery(expected_best.number());
                         return (false, true);
                     };
                     if !self.pending_tracks_canonical_tip(pb, &current_best) {
-                        self.enter_recovery(current_best.number()).await;
+                        self.enter_recovery(current_best.number());
                         return (false, true);
                     }
                 }
@@ -676,7 +683,7 @@ where
                     }
                 };
                 if stale_generation {
-                    self.enter_recovery(expected_best.number()).await;
+                    self.enter_recovery(expected_best.number());
                     return (false, true);
                 }
                 Metrics::block_processing_duration().record(start_time.elapsed());
@@ -687,14 +694,14 @@ where
                     StateProcessorError::Provider(ProviderError::MissingCanonicalHeader {
                         ..
                     }) if cache_on_missing_canonical_header => {
-                        let inserted = self.cache.lock().await.insert(flashblock);
+                        let inserted = self.lock_cache().insert(flashblock);
                         if inserted {
                             debug!(message = "cached flashblock pending canonical block", error = %e);
                             return (false, false);
                         }
                     }
                     StateProcessorError::MissingFirstFlashblock => {
-                        let mut cache = self.cache.lock().await;
+                        let mut cache = self.lock_cache();
                         // this error should only occur for non-zero index flashblocks, but check here for index safety
                         if flashblock.index > 0
                             && cache.has_flashblock(
@@ -711,7 +718,7 @@ where
                     }
                     StateProcessorError::Provider(_) => {
                         error!(message = "provider remained unavailable while processing flashblock", error = %e);
-                        self.enter_recovery(expected_best.number()).await;
+                        self.enter_recovery(expected_best.number());
                         return (false, true);
                     }
                     _ => {}

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -28,7 +28,7 @@ use reth_provider::{BlockReaderIdExt, StateProviderBox, StateProviderFactory};
 use reth_revm::{State, database::StateProviderDatabase};
 use revm_database::states::bundle_state::BundleRetention;
 use tokio::{
-    sync::{Mutex, broadcast::Sender, mpsc::UnboundedReceiver},
+    sync::{Mutex, broadcast::Sender, mpsc::Receiver},
     time::sleep,
 };
 
@@ -174,7 +174,7 @@ impl StateUpdate {
 /// Processes flashblocks and canonical blocks to keep pending state updated.
 #[derive(Debug)]
 pub struct StateProcessor<Client> {
-    rx: Arc<Mutex<UnboundedReceiver<StateUpdate>>>,
+    rx: Arc<Mutex<Receiver<StateUpdate>>>,
     pending_blocks: Arc<ArcSwapOption<PendingBlocks>>,
     client: Client,
     sender: Sender<Arc<PendingBlocks>>,
@@ -225,7 +225,7 @@ where
         client: Client,
         pending_blocks: Arc<ArcSwapOption<PendingBlocks>>,
         max_pending_blocks_depth: u64,
-        rx: Arc<Mutex<UnboundedReceiver<StateUpdate>>>,
+        rx: Arc<Mutex<Receiver<StateUpdate>>>,
         sender: Sender<Arc<PendingBlocks>>,
     ) -> Self {
         let cache = client
@@ -318,14 +318,6 @@ where
             sleep(Duration::from_millis(25)).await;
         };
 
-        if matches!(update, StateUpdate::Flashblock(flashblock) if flashblock.index >= MAX_FLASHBLOCKS_PER_PAYLOAD)
-        {
-            self.enter_recovery(best.number()).await;
-            *recovering = true;
-            Metrics::pending_stale_events_skipped().increment(1);
-            return None;
-        }
-
         if self.is_quarantined_flashblock(update) {
             Metrics::pending_stale_events_skipped().increment(1);
             return None;
@@ -335,9 +327,42 @@ where
         let pending_is_based_on_best = pending_blocks
             .as_ref()
             .is_some_and(|pending| self.pending_tracks_canonical_tip(pending, &best));
+        if let StateUpdate::Flashblock(flashblock) = update
+            && flashblock.index >= MAX_FLASHBLOCKS_PER_PAYLOAD
+        {
+            let extends_accepted_payload = pending_blocks.as_ref().is_some_and(|pending| {
+                flashblock.metadata.block_number == pending.latest_block_number()
+                    && flashblock.payload_id == pending.latest_payload_id()
+            });
+            if extends_accepted_payload {
+                self.enter_recovery(best.number()).await;
+                *recovering = true;
+            }
+            Metrics::pending_stale_events_skipped().increment(1);
+            return None;
+        }
+        if let StateUpdate::Flashblock(flashblock) = update
+            && flashblock.index == 0
+            && flashblock
+                .base
+                .as_ref()
+                .is_none_or(|base| base.block_number != flashblock.metadata.block_number)
+        {
+            self.quarantine_flashblock(flashblock);
+            Metrics::pending_stale_events_skipped().increment(1);
+            return None;
+        }
         if let (StateUpdate::Flashblock(flashblock), Some(pending)) =
             (update, pending_blocks.as_ref())
         {
+            if pending_is_based_on_best
+                && flashblock.index > 0
+                && pending.payload_id_for_block(flashblock.metadata.block_number).is_none()
+            {
+                Metrics::pending_stale_events_skipped().increment(1);
+                return None;
+            }
+
             if pending_is_based_on_best
                 && let Some(payload_id) =
                     pending.payload_id_for_block(flashblock.metadata.block_number)
@@ -452,6 +477,14 @@ where
                             self.pending_blocks.swap(new_pending_blocks);
 
                             let mut cache = self.cache.lock().await;
+                            let cache_rolled_back = cache
+                                .latest_canonical_number()
+                                .is_some_and(|canonical| canonical > block.number)
+                                && block.number == best.number()
+                                && block.hash() == best.hash();
+                            if cache_rolled_back {
+                                *cache = FlashblockCache::new(block.number);
+                            }
                             let should_advance = cache
                                 .latest_canonical_number()
                                 .is_none_or(|canonical| block.number >= canonical);

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -317,10 +317,13 @@ where
             if flashblock.metadata.block_number == pending.latest_block_number()
                 && flashblock.payload_id != pending.latest_payload_id()
             {
-                if flashblock.index == 0 && update.is_recovery_resume(best.number(), best.hash()) {
-                    self.enter_recovery(best.number()).await;
-                    *recovering = true;
-                    return Some((best, true));
+                if flashblock.index == 0
+                    && flashblock.base.as_ref().is_some_and(|base| {
+                        pending.expected_parent_hash(flashblock.metadata.block_number)
+                            == Some(base.parent_hash)
+                    })
+                {
+                    return Some((best, false));
                 }
                 Metrics::pending_stale_events_skipped().increment(1);
                 return None;
@@ -478,7 +481,7 @@ where
                                             recovering = true;
                                             break;
                                         }
-                                        if cached_resuming_recovery && applied {
+                                        if applied {
                                             recovering = false;
                                         }
                                         if recovering {
@@ -511,7 +514,7 @@ where
                         .await;
                     if requires_recovery {
                         recovering = true;
-                    } else if resuming_recovery && applied {
+                    } else if applied {
                         recovering = false;
                     }
                 }
@@ -766,6 +769,19 @@ where
                 return Err(StateProcessorError::MissingFirstFlashblock);
             }
         };
+
+        if flashblock.index == 0
+            && flashblock.metadata.block_number == pending_blocks.latest_block_number()
+            && flashblock.payload_id != pending_blocks.latest_payload_id()
+        {
+            let mut flashblocks = pending_blocks.get_flashblocks();
+            flashblocks.retain(|existing| {
+                existing.metadata.block_number < flashblock.metadata.block_number
+            });
+            flashblocks.push(flashblock.clone());
+            self.clear_live_state();
+            return self.build_pending_state(Some(Arc::clone(pending_blocks)), &flashblocks);
+        }
 
         let validation_result = FlashblockSequenceValidator::validate(
             pending_blocks.latest_block_number(),

--- a/crates/execution/flashblocks/src/state.rs
+++ b/crates/execution/flashblocks/src/state.rs
@@ -1,9 +1,6 @@
 //! Flashblocks state management.
 
-use std::sync::{
-    Arc, Mutex as StdMutex,
-    atomic::{AtomicU64, Ordering},
-};
+use std::sync::{Arc, Mutex as StdMutex};
 
 use alloy_consensus::Header;
 use arc_swap::{ArcSwapOption, Guard};
@@ -35,8 +32,7 @@ pub struct FlashblocksState {
     rx: Arc<Mutex<mpsc::Receiver<(StateUpdate, u64)>>>,
     flashblock_sender: Sender<Arc<PendingBlocks>>,
     max_pending_blocks_depth: u64,
-    recovery_generation: Arc<AtomicU64>,
-    recovery_fence: Arc<StdMutex<()>>,
+    recovery_epoch: Arc<StdMutex<u64>>,
 }
 
 impl FlashblocksState {
@@ -55,8 +51,7 @@ impl FlashblocksState {
             rx: Arc::new(Mutex::new(rx)),
             flashblock_sender,
             max_pending_blocks_depth,
-            recovery_generation: Arc::new(AtomicU64::new(0)),
-            recovery_fence: Arc::new(StdMutex::new(())),
+            recovery_epoch: Arc::new(StdMutex::new(0)),
         }
     }
 
@@ -76,8 +71,7 @@ impl FlashblocksState {
             client,
             Arc::clone(&self.pending_blocks),
             self.max_pending_blocks_depth,
-            Arc::clone(&self.recovery_generation),
-            Arc::clone(&self.recovery_fence),
+            Arc::clone(&self.recovery_epoch),
             Arc::clone(&self.rx),
             self.flashblock_sender.clone(),
         );
@@ -90,15 +84,13 @@ impl FlashblocksState {
     /// Handles a canonical block being received.
     pub fn on_canonical_block_received(&self, block: RecoveredBlock<BaseBlock>) {
         let block_number = block.number;
-        let generation = self.recovery_generation.load(Ordering::Acquire);
-        match self.queue.try_send((StateUpdate::Canonical(block), generation)) {
+        let mut epoch = self.recovery_epoch.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        match self.queue.try_send((StateUpdate::Canonical(block), *epoch)) {
             Ok(_) => {
                 info!(message = "added canonical block to processing queue", block_number)
             }
             Err(e) => {
-                let _fence =
-                    self.recovery_fence.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-                self.recovery_generation.fetch_add(1, Ordering::AcqRel);
+                *epoch = epoch.saturating_add(1);
                 self.pending_blocks.swap(None);
                 error!(message = "could not add canonical block to processing queue", block_number, error = %e);
             }
@@ -110,8 +102,8 @@ impl FlashblocksReceiver for FlashblocksState {
     fn on_flashblock_received(&self, flashblock: Flashblock) {
         let flashblock_index = flashblock.index;
         let block_number = flashblock.metadata.block_number;
-        let generation = self.recovery_generation.load(Ordering::Acquire);
-        match self.queue.try_send((StateUpdate::Flashblock(flashblock), generation)) {
+        let mut epoch = self.recovery_epoch.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        match self.queue.try_send((StateUpdate::Flashblock(flashblock), *epoch)) {
             Ok(_) => {
                 debug!(
                     message = "added flashblock to processing queue",
@@ -119,9 +111,7 @@ impl FlashblocksReceiver for FlashblocksState {
                 );
             }
             Err(e) => {
-                let _fence =
-                    self.recovery_fence.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-                self.recovery_generation.fetch_add(1, Ordering::AcqRel);
+                *epoch = epoch.saturating_add(1);
                 self.pending_blocks.swap(None);
                 error!(message = "could not add flashblock to processing queue", block_number, flashblock_index, error = %e);
             }

--- a/crates/execution/flashblocks/src/state.rs
+++ b/crates/execution/flashblocks/src/state.rs
@@ -1,7 +1,7 @@
 //! Flashblocks state management.
 
 use std::sync::{
-    Arc,
+    Arc, Mutex as StdMutex,
     atomic::{AtomicU64, Ordering},
 };
 
@@ -36,6 +36,7 @@ pub struct FlashblocksState {
     flashblock_sender: Sender<Arc<PendingBlocks>>,
     max_pending_blocks_depth: u64,
     recovery_generation: Arc<AtomicU64>,
+    recovery_fence: Arc<StdMutex<()>>,
 }
 
 impl FlashblocksState {
@@ -55,6 +56,7 @@ impl FlashblocksState {
             flashblock_sender,
             max_pending_blocks_depth,
             recovery_generation: Arc::new(AtomicU64::new(0)),
+            recovery_fence: Arc::new(StdMutex::new(())),
         }
     }
 
@@ -75,6 +77,7 @@ impl FlashblocksState {
             Arc::clone(&self.pending_blocks),
             self.max_pending_blocks_depth,
             Arc::clone(&self.recovery_generation),
+            Arc::clone(&self.recovery_fence),
             Arc::clone(&self.rx),
             self.flashblock_sender.clone(),
         );
@@ -92,6 +95,8 @@ impl FlashblocksState {
                 info!(message = "added canonical block to processing queue", block_number)
             }
             Err(e) => {
+                let _fence =
+                    self.recovery_fence.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
                 self.recovery_generation.fetch_add(1, Ordering::AcqRel);
                 self.pending_blocks.swap(None);
                 error!(message = "could not add canonical block to processing queue", block_number, error = %e);
@@ -112,6 +117,8 @@ impl FlashblocksReceiver for FlashblocksState {
                 );
             }
             Err(e) => {
+                let _fence =
+                    self.recovery_fence.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
                 self.recovery_generation.fetch_add(1, Ordering::AcqRel);
                 self.pending_blocks.swap(None);
                 error!(message = "could not add flashblock to processing queue", block_number, flashblock_index, error = %e);

--- a/crates/execution/flashblocks/src/state.rs
+++ b/crates/execution/flashblocks/src/state.rs
@@ -28,8 +28,8 @@ const BUFFER_SIZE: usize = 20;
 #[derive(Debug)]
 pub struct FlashblocksState {
     pending_blocks: Arc<ArcSwapOption<PendingBlocks>>,
-    queue: mpsc::UnboundedSender<StateUpdate>,
-    rx: Arc<Mutex<mpsc::UnboundedReceiver<StateUpdate>>>,
+    queue: mpsc::Sender<StateUpdate>,
+    rx: Arc<Mutex<mpsc::Receiver<StateUpdate>>>,
     flashblock_sender: Sender<Arc<PendingBlocks>>,
     max_pending_blocks_depth: u64,
 }
@@ -40,7 +40,7 @@ impl FlashblocksState {
     /// The state is created without a client. Call [`start`](Self::start) with a client
     /// to spawn the state processor after the node is launched.
     pub fn new(max_pending_blocks_depth: u64) -> Self {
-        let (tx, rx) = mpsc::unbounded_channel::<StateUpdate>();
+        let (tx, rx) = mpsc::channel::<StateUpdate>(BUFFER_SIZE);
         let pending_blocks: Arc<ArcSwapOption<PendingBlocks>> = Arc::new(ArcSwapOption::new(None));
         let (flashblock_sender, _) = broadcast::channel(BUFFER_SIZE);
 
@@ -81,11 +81,12 @@ impl FlashblocksState {
     /// Handles a canonical block being received.
     pub fn on_canonical_block_received(&self, block: RecoveredBlock<BaseBlock>) {
         let block_number = block.number;
-        match self.queue.send(StateUpdate::Canonical(block)) {
+        match self.queue.try_send(StateUpdate::Canonical(block)) {
             Ok(_) => {
                 info!(message = "added canonical block to processing queue", block_number)
             }
             Err(e) => {
+                self.pending_blocks.swap(None);
                 error!(message = "could not add canonical block to processing queue", block_number, error = %e);
             }
         }
@@ -96,7 +97,7 @@ impl FlashblocksReceiver for FlashblocksState {
     fn on_flashblock_received(&self, flashblock: Flashblock) {
         let flashblock_index = flashblock.index;
         let block_number = flashblock.metadata.block_number;
-        match self.queue.send(StateUpdate::Flashblock(flashblock)) {
+        match self.queue.try_send(StateUpdate::Flashblock(flashblock)) {
             Ok(_) => {
                 debug!(
                     message = "added flashblock to processing queue",
@@ -104,6 +105,7 @@ impl FlashblocksReceiver for FlashblocksState {
                 );
             }
             Err(e) => {
+                self.pending_blocks.swap(None);
                 error!(message = "could not add flashblock to processing queue", block_number, flashblock_index, error = %e);
             }
         }

--- a/crates/execution/flashblocks/src/state.rs
+++ b/crates/execution/flashblocks/src/state.rs
@@ -31,8 +31,8 @@ const BUFFER_SIZE: usize = 20;
 #[derive(Debug)]
 pub struct FlashblocksState {
     pending_blocks: Arc<ArcSwapOption<PendingBlocks>>,
-    queue: mpsc::Sender<StateUpdate>,
-    rx: Arc<Mutex<mpsc::Receiver<StateUpdate>>>,
+    queue: mpsc::Sender<(StateUpdate, u64)>,
+    rx: Arc<Mutex<mpsc::Receiver<(StateUpdate, u64)>>>,
     flashblock_sender: Sender<Arc<PendingBlocks>>,
     max_pending_blocks_depth: u64,
     recovery_generation: Arc<AtomicU64>,
@@ -45,7 +45,7 @@ impl FlashblocksState {
     /// The state is created without a client. Call [`start`](Self::start) with a client
     /// to spawn the state processor after the node is launched.
     pub fn new(max_pending_blocks_depth: u64) -> Self {
-        let (tx, rx) = mpsc::channel::<StateUpdate>(BUFFER_SIZE);
+        let (tx, rx) = mpsc::channel::<(StateUpdate, u64)>(BUFFER_SIZE);
         let pending_blocks: Arc<ArcSwapOption<PendingBlocks>> = Arc::new(ArcSwapOption::new(None));
         let (flashblock_sender, _) = broadcast::channel(BUFFER_SIZE);
 
@@ -90,7 +90,8 @@ impl FlashblocksState {
     /// Handles a canonical block being received.
     pub fn on_canonical_block_received(&self, block: RecoveredBlock<BaseBlock>) {
         let block_number = block.number;
-        match self.queue.try_send(StateUpdate::Canonical(block)) {
+        let generation = self.recovery_generation.load(Ordering::Acquire);
+        match self.queue.try_send((StateUpdate::Canonical(block), generation)) {
             Ok(_) => {
                 info!(message = "added canonical block to processing queue", block_number)
             }
@@ -109,7 +110,8 @@ impl FlashblocksReceiver for FlashblocksState {
     fn on_flashblock_received(&self, flashblock: Flashblock) {
         let flashblock_index = flashblock.index;
         let block_number = flashblock.metadata.block_number;
-        match self.queue.try_send(StateUpdate::Flashblock(flashblock)) {
+        let generation = self.recovery_generation.load(Ordering::Acquire);
+        match self.queue.try_send((StateUpdate::Flashblock(flashblock), generation)) {
             Ok(_) => {
                 debug!(
                     message = "added flashblock to processing queue",

--- a/crates/execution/flashblocks/src/state.rs
+++ b/crates/execution/flashblocks/src/state.rs
@@ -31,7 +31,6 @@ pub struct FlashblocksState {
     queue: mpsc::UnboundedSender<StateUpdate>,
     rx: Arc<Mutex<mpsc::UnboundedReceiver<StateUpdate>>>,
     flashblock_sender: Sender<Arc<PendingBlocks>>,
-    max_pending_blocks_depth: u64,
 }
 
 impl FlashblocksState {
@@ -39,18 +38,15 @@ impl FlashblocksState {
     ///
     /// The state is created without a client. Call [`start`](Self::start) with a client
     /// to spawn the state processor after the node is launched.
-    pub fn new(max_pending_blocks_depth: u64) -> Self {
+    ///
+    /// `max_pending_blocks_depth` is accepted for call-site compatibility and ignored. Pending
+    /// state is rebased onto the current canonical tip instead of retaining a historical overlay.
+    pub fn new(_max_pending_blocks_depth: u64) -> Self {
         let (tx, rx) = mpsc::unbounded_channel::<StateUpdate>();
         let pending_blocks: Arc<ArcSwapOption<PendingBlocks>> = Arc::new(ArcSwapOption::new(None));
         let (flashblock_sender, _) = broadcast::channel(BUFFER_SIZE);
 
-        Self {
-            pending_blocks,
-            queue: tx,
-            rx: Arc::new(Mutex::new(rx)),
-            flashblock_sender,
-            max_pending_blocks_depth,
-        }
+        Self { pending_blocks, queue: tx, rx: Arc::new(Mutex::new(rx)), flashblock_sender }
     }
 
     /// Starts the flashblocks state processor with the given client.
@@ -68,7 +64,6 @@ impl FlashblocksState {
         let state_processor = StateProcessor::new(
             client,
             Arc::clone(&self.pending_blocks),
-            self.max_pending_blocks_depth,
             Arc::clone(&self.rx),
             self.flashblock_sender.clone(),
         );

--- a/crates/execution/flashblocks/src/state.rs
+++ b/crates/execution/flashblocks/src/state.rs
@@ -1,6 +1,9 @@
 //! Flashblocks state management.
 
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
 
 use alloy_consensus::Header;
 use arc_swap::{ArcSwapOption, Guard};
@@ -32,6 +35,7 @@ pub struct FlashblocksState {
     rx: Arc<Mutex<mpsc::Receiver<StateUpdate>>>,
     flashblock_sender: Sender<Arc<PendingBlocks>>,
     max_pending_blocks_depth: u64,
+    recovery_generation: Arc<AtomicU64>,
 }
 
 impl FlashblocksState {
@@ -50,6 +54,7 @@ impl FlashblocksState {
             rx: Arc::new(Mutex::new(rx)),
             flashblock_sender,
             max_pending_blocks_depth,
+            recovery_generation: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -69,6 +74,7 @@ impl FlashblocksState {
             client,
             Arc::clone(&self.pending_blocks),
             self.max_pending_blocks_depth,
+            Arc::clone(&self.recovery_generation),
             Arc::clone(&self.rx),
             self.flashblock_sender.clone(),
         );
@@ -86,6 +92,7 @@ impl FlashblocksState {
                 info!(message = "added canonical block to processing queue", block_number)
             }
             Err(e) => {
+                self.recovery_generation.fetch_add(1, Ordering::AcqRel);
                 self.pending_blocks.swap(None);
                 error!(message = "could not add canonical block to processing queue", block_number, error = %e);
             }
@@ -105,6 +112,7 @@ impl FlashblocksReceiver for FlashblocksState {
                 );
             }
             Err(e) => {
+                self.recovery_generation.fetch_add(1, Ordering::AcqRel);
                 self.pending_blocks.swap(None);
                 error!(message = "could not add flashblock to processing queue", block_number, flashblock_index, error = %e);
             }

--- a/crates/execution/flashblocks/src/state.rs
+++ b/crates/execution/flashblocks/src/state.rs
@@ -31,6 +31,7 @@ pub struct FlashblocksState {
     queue: mpsc::UnboundedSender<StateUpdate>,
     rx: Arc<Mutex<mpsc::UnboundedReceiver<StateUpdate>>>,
     flashblock_sender: Sender<Arc<PendingBlocks>>,
+    max_pending_blocks_depth: u64,
 }
 
 impl FlashblocksState {
@@ -38,15 +39,18 @@ impl FlashblocksState {
     ///
     /// The state is created without a client. Call [`start`](Self::start) with a client
     /// to spawn the state processor after the node is launched.
-    ///
-    /// `max_pending_blocks_depth` is accepted for call-site compatibility and ignored. Pending
-    /// state is rebased onto the current canonical tip instead of retaining a historical overlay.
-    pub fn new(_max_pending_blocks_depth: u64) -> Self {
+    pub fn new(max_pending_blocks_depth: u64) -> Self {
         let (tx, rx) = mpsc::unbounded_channel::<StateUpdate>();
         let pending_blocks: Arc<ArcSwapOption<PendingBlocks>> = Arc::new(ArcSwapOption::new(None));
         let (flashblock_sender, _) = broadcast::channel(BUFFER_SIZE);
 
-        Self { pending_blocks, queue: tx, rx: Arc::new(Mutex::new(rx)), flashblock_sender }
+        Self {
+            pending_blocks,
+            queue: tx,
+            rx: Arc::new(Mutex::new(rx)),
+            flashblock_sender,
+            max_pending_blocks_depth,
+        }
     }
 
     /// Starts the flashblocks state processor with the given client.
@@ -64,6 +68,7 @@ impl FlashblocksState {
         let state_processor = StateProcessor::new(
             client,
             Arc::clone(&self.pending_blocks),
+            self.max_pending_blocks_depth,
             Arc::clone(&self.rx),
             self.flashblock_sender.clone(),
         );

--- a/crates/execution/flashblocks/src/subscription.rs
+++ b/crates/execution/flashblocks/src/subscription.rs
@@ -4,19 +4,11 @@ use std::{sync::Arc, time::Duration};
 
 use base_common_flashblocks::Flashblock;
 use futures::{SinkExt as _, StreamExt};
-use tokio::{
-    sync::mpsc,
-    time::{Instant, interval_at},
-};
+use tokio::time::{Instant, interval_at};
 use tokio_tungstenite::{connect_async, tungstenite::protocol::Message};
 use url::Url;
 
 use crate::{FlashblocksReceiver, metrics::Metrics};
-
-#[derive(Debug)]
-enum ActorMessage {
-    BestPayload { payload: Flashblock },
-}
 
 /// Subscribes to flashblocks via WebSocket and forwards them to the receiver.
 #[derive(Debug)]
@@ -51,8 +43,7 @@ where
 
         let ws_url = self.ws_url.clone();
         let ping_period = self.ping_interval;
-
-        let (sender, mut mailbox) = mpsc::channel(100);
+        let flashblocks_state = Arc::clone(&self.flashblocks_state);
 
         tokio::spawn(async move {
             let mut backoff = Duration::from_secs(1);
@@ -79,9 +70,7 @@ where
                                             let bytes = msg.into_data();
                                             match Flashblock::try_decode_message(bytes) {
                                                 Ok(payload) => {
-                                                    let _ = sender.send(ActorMessage::BestPayload { payload }).await.map_err(|e| {
-                                                        error!(message = "Failed to publish message to channel", error = %e);
-                                                    });
+                                                    flashblocks_state.on_flashblock_received(payload);
                                                 }
                                                 Err(e) => {
                                                     error!(
@@ -155,17 +144,6 @@ where
 
                         backoff = Self::sleep(backoff).await;
                         continue;
-                    }
-                }
-            }
-        });
-
-        let flashblocks_state = Arc::clone(&self.flashblocks_state);
-        tokio::spawn(async move {
-            while let Some(message) = mailbox.recv().await {
-                match message {
-                    ActorMessage::BestPayload { payload } => {
-                        flashblocks_state.on_flashblock_received(payload);
                     }
                 }
             }

--- a/crates/execution/flashblocks/src/validation.rs
+++ b/crates/execution/flashblocks/src/validation.rs
@@ -154,10 +154,8 @@ pub enum ReconciliationStrategy {
     /// Canonical `N` is represented in pending and is still behind latest. Discard flashblocks at
     /// or below `N` and rebuild the future suffix from canonical `N`.
     Rebase,
-    /// Canonical `N` is the pending snapshot's anchor. Hash already verified; keep the snapshot.
-    VerifyAnchor,
-    /// Canonical `N` is older than the pending anchor. Do not treat an empty tx vector as a reorg.
-    IgnoreUntracked,
+    /// Canonical `N` does not require changing the pending snapshot.
+    Keep,
     /// No pending state exists (startup or after clear).
     NoPendingState,
 }
@@ -185,7 +183,7 @@ impl CanonicalBlockReconciler {
 
         let anchor = earliest.saturating_sub(1);
         if canonical_block_number < anchor {
-            return ReconciliationStrategy::IgnoreUntracked;
+            return ReconciliationStrategy::Keep;
         }
 
         if canonical_block_number > latest {
@@ -201,7 +199,7 @@ impl CanonicalBlockReconciler {
         }
 
         if canonical_block_number == anchor {
-            return ReconciliationStrategy::VerifyAnchor;
+            return ReconciliationStrategy::Keep;
         }
 
         ReconciliationStrategy::Rebase
@@ -331,10 +329,10 @@ mod tests {
     #[case(Some(100), Some(105), 105, true, ReconciliationStrategy::HandleReorg)]
     #[case(Some(100), Some(101), 100, false, ReconciliationStrategy::Rebase)]
     #[case(Some(100), Some(110), 105, false, ReconciliationStrategy::Rebase)]
-    #[case(Some(100), Some(105), 50, false, ReconciliationStrategy::IgnoreUntracked)]
-    #[case(Some(100), Some(105), 50, true, ReconciliationStrategy::IgnoreUntracked)]
-    #[case(Some(100), Some(105), 99, false, ReconciliationStrategy::VerifyAnchor)]
-    #[case(Some(100), Some(100), 99, false, ReconciliationStrategy::VerifyAnchor)]
+    #[case(Some(100), Some(105), 50, false, ReconciliationStrategy::Keep)]
+    #[case(Some(100), Some(105), 50, true, ReconciliationStrategy::Keep)]
+    #[case(Some(100), Some(105), 99, false, ReconciliationStrategy::Keep)]
+    #[case(Some(100), Some(100), 99, false, ReconciliationStrategy::Keep)]
     #[case(Some(100), Some(105), 99, true, ReconciliationStrategy::HandleReorg)]
     #[case(Some(100), Some(110), 102, true, ReconciliationStrategy::HandleReorg)]
     #[case(Some(100), Some(101), 100, true, ReconciliationStrategy::HandleReorg)]

--- a/crates/execution/flashblocks/src/validation.rs
+++ b/crates/execution/flashblocks/src/validation.rs
@@ -156,8 +156,6 @@ pub enum ReconciliationStrategy {
     Rebase,
     /// Canonical `N` does not require changing the pending snapshot.
     Keep,
-    /// No pending state exists (startup or after clear).
-    NoPendingState,
 }
 
 /// Determines reconciliation strategy for canonical block updates.
@@ -171,22 +169,17 @@ impl CanonicalBlockReconciler {
     /// the snapshot. A reorg is honored only when canonical is the pending anchor or overlaps the
     /// pending interval. Untracked older canonicals are ignored.
     pub const fn reconcile(
-        pending_earliest_block: Option<u64>,
-        pending_latest_block: Option<u64>,
+        pending_earliest_block: u64,
+        pending_latest_block: u64,
         canonical_block_number: u64,
         reorg_detected: bool,
     ) -> ReconciliationStrategy {
-        let (earliest, latest) = match (pending_earliest_block, pending_latest_block) {
-            (Some(e), Some(l)) => (e, l),
-            _ => return ReconciliationStrategy::NoPendingState,
-        };
-
-        let anchor = earliest.saturating_sub(1);
+        let anchor = pending_earliest_block.saturating_sub(1);
         if canonical_block_number < anchor {
             return ReconciliationStrategy::Keep;
         }
 
-        if canonical_block_number > latest {
+        if canonical_block_number > pending_latest_block {
             return ReconciliationStrategy::CatchUp;
         }
 
@@ -194,7 +187,7 @@ impl CanonicalBlockReconciler {
             return ReconciliationStrategy::HandleReorg;
         }
 
-        if canonical_block_number == latest {
+        if canonical_block_number == pending_latest_block {
             return ReconciliationStrategy::CatchUp;
         }
 
@@ -320,25 +313,22 @@ mod tests {
     // ==================== CanonicalBlockReconciler Tests ====================
 
     #[rstest]
-    #[case(None, None, 100, false, ReconciliationStrategy::NoPendingState)]
-    #[case(Some(100), None, 100, false, ReconciliationStrategy::NoPendingState)]
-    #[case(None, Some(100), 100, false, ReconciliationStrategy::NoPendingState)]
-    #[case(Some(100), Some(105), 105, false, ReconciliationStrategy::CatchUp)]
-    #[case(Some(100), Some(105), 110, false, ReconciliationStrategy::CatchUp)]
-    #[case(Some(100), Some(100), 100, false, ReconciliationStrategy::CatchUp)]
-    #[case(Some(100), Some(105), 105, true, ReconciliationStrategy::HandleReorg)]
-    #[case(Some(100), Some(101), 100, false, ReconciliationStrategy::Rebase)]
-    #[case(Some(100), Some(110), 105, false, ReconciliationStrategy::Rebase)]
-    #[case(Some(100), Some(105), 50, false, ReconciliationStrategy::Keep)]
-    #[case(Some(100), Some(105), 50, true, ReconciliationStrategy::Keep)]
-    #[case(Some(100), Some(105), 99, false, ReconciliationStrategy::Keep)]
-    #[case(Some(100), Some(100), 99, false, ReconciliationStrategy::Keep)]
-    #[case(Some(100), Some(105), 99, true, ReconciliationStrategy::HandleReorg)]
-    #[case(Some(100), Some(110), 102, true, ReconciliationStrategy::HandleReorg)]
-    #[case(Some(100), Some(101), 100, true, ReconciliationStrategy::HandleReorg)]
+    #[case(100, 105, 105, false, ReconciliationStrategy::CatchUp)]
+    #[case(100, 105, 110, false, ReconciliationStrategy::CatchUp)]
+    #[case(100, 100, 100, false, ReconciliationStrategy::CatchUp)]
+    #[case(100, 105, 105, true, ReconciliationStrategy::HandleReorg)]
+    #[case(100, 101, 100, false, ReconciliationStrategy::Rebase)]
+    #[case(100, 110, 105, false, ReconciliationStrategy::Rebase)]
+    #[case(100, 105, 50, false, ReconciliationStrategy::Keep)]
+    #[case(100, 105, 50, true, ReconciliationStrategy::Keep)]
+    #[case(100, 105, 99, false, ReconciliationStrategy::Keep)]
+    #[case(100, 100, 99, false, ReconciliationStrategy::Keep)]
+    #[case(100, 105, 99, true, ReconciliationStrategy::HandleReorg)]
+    #[case(100, 110, 102, true, ReconciliationStrategy::HandleReorg)]
+    #[case(100, 101, 100, true, ReconciliationStrategy::HandleReorg)]
     fn test_reconciler(
-        #[case] earliest: Option<u64>,
-        #[case] latest: Option<u64>,
+        #[case] earliest: u64,
+        #[case] latest: u64,
         #[case] canonical: u64,
         #[case] reorg: bool,
         #[case] expected: ReconciliationStrategy,

--- a/crates/execution/flashblocks/src/validation.rs
+++ b/crates/execution/flashblocks/src/validation.rs
@@ -149,17 +149,15 @@ impl ReorgDetector {
 pub enum ReconciliationStrategy {
     /// Canonical caught up or passed pending (canonical >= latest pending). Clear pending state.
     CatchUp,
-    /// Reorg detected (tx mismatch). Rebuild pending from canonical.
+    /// Overlap transaction mismatch or pending-anchor hash mismatch. Clear all pending state.
     HandleReorg,
-    /// Pending too far ahead of canonical.
-    DepthLimitExceeded {
-        /// Current depth of pending blocks.
-        depth: u64,
-        /// Configured maximum depth.
-        max_depth: u64,
-    },
-    /// No issues - continue building on pending state.
-    Continue,
+    /// Canonical `N` is represented in pending and is still behind latest. Discard flashblocks at
+    /// or below `N` and rebuild the future suffix from canonical `N`.
+    Rebase,
+    /// Canonical `N` is the pending snapshot's anchor. Hash already verified; keep the snapshot.
+    VerifyAnchor,
+    /// Canonical `N` is older than the pending anchor. Do not treat an empty tx vector as a reorg.
+    IgnoreUntracked,
     /// No pending state exists (startup or after clear).
     NoPendingState,
 }
@@ -171,38 +169,42 @@ pub struct CanonicalBlockReconciler;
 impl CanonicalBlockReconciler {
     /// Returns the appropriate [`ReconciliationStrategy`] based on pending vs canonical state.
     ///
-    /// Priority: `NoPendingState` → `CatchUp` → `HandleReorg` → `DepthLimitExceeded` → `Continue`
+    /// Pending is rebased onto the current canonical block whenever that block is represented in
+    /// the snapshot. A reorg is honored only when canonical is the pending anchor or overlaps the
+    /// pending interval. Untracked older canonicals are ignored.
     pub const fn reconcile(
         pending_earliest_block: Option<u64>,
         pending_latest_block: Option<u64>,
         canonical_block_number: u64,
-        max_depth: u64,
         reorg_detected: bool,
     ) -> ReconciliationStrategy {
-        // Check if pending state exists
         let (earliest, latest) = match (pending_earliest_block, pending_latest_block) {
             (Some(e), Some(l)) => (e, l),
             _ => return ReconciliationStrategy::NoPendingState,
         };
 
-        // Check if canonical has caught up or passed pending
-        if latest <= canonical_block_number {
+        let anchor = earliest.saturating_sub(1);
+        if canonical_block_number < anchor {
+            return ReconciliationStrategy::IgnoreUntracked;
+        }
+
+        if canonical_block_number > latest {
             return ReconciliationStrategy::CatchUp;
         }
 
-        // Check for reorg
         if reorg_detected {
             return ReconciliationStrategy::HandleReorg;
         }
 
-        // Check depth limit
-        let depth = canonical_block_number.saturating_sub(earliest);
-        if depth > max_depth {
-            return ReconciliationStrategy::DepthLimitExceeded { depth, max_depth };
+        if canonical_block_number == latest {
+            return ReconciliationStrategy::CatchUp;
         }
 
-        // No issues, continue building
-        ReconciliationStrategy::Continue
+        if canonical_block_number == anchor {
+            return ReconciliationStrategy::VerifyAnchor;
+        }
+
+        ReconciliationStrategy::Rebase
     }
 }
 
@@ -320,37 +322,30 @@ mod tests {
     // ==================== CanonicalBlockReconciler Tests ====================
 
     #[rstest]
-    // NoPendingState
-    #[case(None, None, 100, 10, false, ReconciliationStrategy::NoPendingState)]
-    #[case(Some(100), None, 100, 10, false, ReconciliationStrategy::NoPendingState)]
-    #[case(None, Some(100), 100, 10, false, ReconciliationStrategy::NoPendingState)]
-    // CatchUp: canonical >= latest pending
-    #[case(Some(100), Some(105), 105, 10, false, ReconciliationStrategy::CatchUp)]
-    #[case(Some(100), Some(105), 110, 10, false, ReconciliationStrategy::CatchUp)]
-    #[case(Some(100), Some(100), 100, 10, false, ReconciliationStrategy::CatchUp)]
-    #[case(Some(100), Some(105), 105, 10, true, ReconciliationStrategy::CatchUp)] // catchup > reorg priority
-    // HandleReorg
-    #[case(Some(100), Some(110), 102, 10, true, ReconciliationStrategy::HandleReorg)]
-    #[case(Some(100), Some(130), 120, 10, true, ReconciliationStrategy::HandleReorg)] // reorg > depth priority
-    // DepthLimitExceeded
-    #[case(Some(100), Some(120), 115, 10, false, ReconciliationStrategy::DepthLimitExceeded { depth: 15, max_depth: 10 })]
-    #[case(Some(100), Some(105), 101, 0, false, ReconciliationStrategy::DepthLimitExceeded { depth: 1, max_depth: 0 })]
-    // Continue
-    #[case(Some(100), Some(110), 105, 10, false, ReconciliationStrategy::Continue)]
-    #[case(Some(100), Some(120), 110, 10, false, ReconciliationStrategy::Continue)] // depth exactly at limit
-    #[case(Some(100), Some(105), 100, 10, false, ReconciliationStrategy::Continue)]
-    #[case(Some(100), Some(105), 100, 0, false, ReconciliationStrategy::Continue)] // zero depth ok with max_depth=0
-    #[case(Some(100), Some(100), 99, 10, false, ReconciliationStrategy::Continue)] // single pending block
+    #[case(None, None, 100, false, ReconciliationStrategy::NoPendingState)]
+    #[case(Some(100), None, 100, false, ReconciliationStrategy::NoPendingState)]
+    #[case(None, Some(100), 100, false, ReconciliationStrategy::NoPendingState)]
+    #[case(Some(100), Some(105), 105, false, ReconciliationStrategy::CatchUp)]
+    #[case(Some(100), Some(105), 110, false, ReconciliationStrategy::CatchUp)]
+    #[case(Some(100), Some(100), 100, false, ReconciliationStrategy::CatchUp)]
+    #[case(Some(100), Some(105), 105, true, ReconciliationStrategy::HandleReorg)]
+    #[case(Some(100), Some(101), 100, false, ReconciliationStrategy::Rebase)]
+    #[case(Some(100), Some(110), 105, false, ReconciliationStrategy::Rebase)]
+    #[case(Some(100), Some(105), 50, false, ReconciliationStrategy::IgnoreUntracked)]
+    #[case(Some(100), Some(105), 50, true, ReconciliationStrategy::IgnoreUntracked)]
+    #[case(Some(100), Some(105), 99, false, ReconciliationStrategy::VerifyAnchor)]
+    #[case(Some(100), Some(100), 99, false, ReconciliationStrategy::VerifyAnchor)]
+    #[case(Some(100), Some(105), 99, true, ReconciliationStrategy::HandleReorg)]
+    #[case(Some(100), Some(110), 102, true, ReconciliationStrategy::HandleReorg)]
+    #[case(Some(100), Some(101), 100, true, ReconciliationStrategy::HandleReorg)]
     fn test_reconciler(
         #[case] earliest: Option<u64>,
         #[case] latest: Option<u64>,
         #[case] canonical: u64,
-        #[case] max_depth: u64,
         #[case] reorg: bool,
         #[case] expected: ReconciliationStrategy,
     ) {
-        let result =
-            CanonicalBlockReconciler::reconcile(earliest, latest, canonical, max_depth, reorg);
+        let result = CanonicalBlockReconciler::reconcile(earliest, latest, canonical, reorg);
         assert_eq!(result, expected);
     }
 }


### PR DESCRIPTION
## Summary
- preflight canonical and flashblock updates against the provider's current canonical tip, clearing pending state when it cannot safely track that tip
- resume recovery only from an index-0 payload rooted at the current tip, while preserving bounded tip-child cache entries across provider-visibility races
- bound decoded ingress, processor backlog, live payload depth, and cached payload attempts; fence overflow recovery so stale in-flight work cannot republish
- recover canonical subscription lag by resynchronizing from the provider, and defer ahead-of-provider canonical notifications until they become visible
- isolate payload attempts and reject conflicting retransmissions, wrong internal parents, and inconsistent block identities without weakening genuine transaction-set reorg handling
- rebase valid pending suffixes and ignore untracked historical canonicals that previously produced false reorgs
- include provider traits in production builds for canonical resynchronization

## Test plan
- `cargo fmt --all`
- `cargo check -p base-reth-node --bin base-reth-node`
- `cargo test -p base-common-flashblocks -p base-flashblocks`
- `cargo test -p base-flashblocks-node --tests -- --test-threads=1`
- `cargo clippy -p base-common-flashblocks -p base-flashblocks -p base-flashblocks-node --all-targets --all-features -- -D warnings`
- PR `CI / Test`, build, format, clippy, CodeQL, and review checks pass

The integration coverage includes stale queued updates, queue-overflow fencing, provider visibility lag in both event orderings, canonical subscription resynchronization, replacement payloads, conflicting retransmissions, cache bounds, canonical rebasing, and real transaction-set mismatches.

## Devnet QA
- built commit-pinned `base` and `base-batcher` images and ran an isolated single-sequencer full stack with L1, builder, execution clients, consensus nodes, Engine API, flashblocks WebSocket, and batcher
- paused the flashblocks-enabled client while the builder advanced 12 canonical blocks; buffered flashblocks filled the bounded processor queue and reproduced the intended overload trigger
- observed `pending_recovery_transitions` increase from 1 to 2; pending remained within the configured depth, became absent at the caught-up canonical tip, then republished as a tip-child within about 3 seconds
- verified post-recovery L2 transactions through both builder and client, canonical hash parity across builder/client/RPC, ordered consensus labels, healthy services, and zero restarts
- no L2 reorg was injected on devnet; real transaction-set mismatch behavior is covered by integration tests
- the generic smoke script's unrelated L1 blob probe reported `unexpected eip-4844 sidecar after osaka`; L1 ETH and both L2 transaction checks passed

type=routine
risk=low
impact=sev5