### PR TITLE
feat(consensus): L1-free standalone sequencer

### DIFF
--- a/crates/consensus/protocol/src/info/variant.rs
+++ b/crates/consensus/protocol/src/info/variant.rs
@@ -16,7 +16,7 @@ use crate::{
     info::{
         L1BlockInfoBedrockBaseFields, L1BlockInfoEcotoneBaseFields as _, L1BlockInfoJovian,
         bedrock::L1BlockInfoBedrockOnlyFields as _, ecotone::L1BlockInfoEcotoneOnlyFields as _,
-        isthmus::L1BlockInfoIsthmusBaseFields as _,
+        isthmus::L1BlockInfoIsthmusBaseFields as _, jovian::L1BlockInfoJovianBaseFields as _,
     },
 };
 
@@ -202,8 +202,19 @@ impl L1BlockInfoTx {
             l2_block_time,
         )?;
 
+        let deposit_tx = l1_info.into_deposit_tx(rollup_config, l2_block_time);
+        Ok((l1_info, deposit_tx))
+    }
+
+    /// Converts this L1 block info into the deposit transaction placed first in an L2 block.
+    pub fn into_deposit_tx(
+        self,
+        rollup_config: &RollupConfig,
+        l2_block_time: u64,
+    ) -> Sealed<TxDeposit> {
+        let sequence_number = self.sequence_number();
         let source = DepositSourceDomain::L1Info(L1InfoDepositSource {
-            l1_block_hash: l1_info.block_hash(),
+            l1_block_hash: self.block_hash(),
             seq_number: sequence_number,
         });
 
@@ -215,7 +226,7 @@ impl L1BlockInfoTx {
             value: U256::ZERO,
             gas_limit: 150_000_000,
             is_system_transaction: true,
-            input: l1_info.encode_calldata(),
+            input: self.encode_calldata(),
         };
 
         // With the regolith upgrade, system transactions were deprecated, and we allocate
@@ -225,7 +236,7 @@ impl L1BlockInfoTx {
             deposit_tx.gas_limit = REGOLITH_SYSTEM_TX_GAS;
         }
 
-        Ok((l1_info, deposit_tx.seal_slow()))
+        deposit_tx.seal_slow()
     }
 
     /// Decodes the [`L1BlockInfoTx`] object from Ethereum transaction calldata.
@@ -387,6 +398,75 @@ impl L1BlockInfoTx {
             Self::Jovian(block) => block.sequence_number(),
         }
     }
+
+    /// Returns the L1 origin timestamp for the info transaction.
+    pub fn time(&self) -> u64 {
+        match self {
+            Self::Bedrock(block) => block.time(),
+            Self::Ecotone(block) => block.time(),
+            Self::Isthmus(block) => block.time(),
+            Self::Jovian(block) => block.time(),
+        }
+    }
+
+    /// Returns this L1 block info transaction with a different L2 sequence number.
+    ///
+    /// All L1 origin, fee, and system configuration fields are preserved. This is useful when
+    /// producing additional L2 blocks in the same sequencing epoch.
+    pub fn with_sequence_number(self, sequence_number: u64) -> Self {
+        match self {
+            Self::Bedrock(info) => Self::Bedrock(L1BlockInfoBedrock::new(
+                info.number(),
+                info.time(),
+                info.base_fee(),
+                info.block_hash(),
+                sequence_number,
+                info.batcher_address(),
+                info.l1_fee_overhead(),
+                info.l1_fee_scalar(),
+            )),
+            Self::Ecotone(info) => Self::Ecotone(L1BlockInfoEcotone::new(
+                info.number(),
+                info.time(),
+                info.base_fee(),
+                info.block_hash(),
+                sequence_number,
+                info.batcher_address(),
+                info.blob_base_fee(),
+                info.blob_base_fee_scalar(),
+                info.base_fee_scalar(),
+                info.empty_scalars(),
+                info.l1_fee_overhead(),
+            )),
+            Self::Isthmus(info) => Self::Isthmus(L1BlockInfoIsthmus::new(
+                info.number(),
+                info.time(),
+                info.base_fee(),
+                info.block_hash(),
+                sequence_number,
+                info.batcher_address(),
+                info.blob_base_fee(),
+                info.blob_base_fee_scalar(),
+                info.base_fee_scalar(),
+                info.operator_fee_scalar(),
+                info.operator_fee_constant(),
+            )),
+            Self::Jovian(info) => Self::Jovian(L1BlockInfoJovian::new(
+                info.number(),
+                info.time(),
+                info.base_fee(),
+                info.block_hash(),
+                sequence_number,
+                info.batcher_address(),
+                info.blob_base_fee(),
+                info.blob_base_fee_scalar(),
+                info.base_fee_scalar(),
+                info.operator_fee_scalar(),
+                info.operator_fee_constant(),
+                info.da_footprint_gas_scalar(),
+            )),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -518,6 +598,38 @@ mod tests {
 
         let isthmus = L1BlockInfoTx::Isthmus(L1BlockInfoIsthmus::new_from_sequence_number(101112));
         assert_eq!(isthmus.sequence_number(), 101112);
+    }
+
+    #[test]
+    fn test_l1_block_info_with_sequence_number() {
+        let variants = [
+            L1BlockInfoTx::Bedrock(L1BlockInfoBedrock::new_from_sequence_number(1)),
+            L1BlockInfoTx::Ecotone(L1BlockInfoEcotone::new_from_sequence_number(1)),
+            L1BlockInfoTx::Isthmus(L1BlockInfoIsthmus::new_from_sequence_number(1)),
+            L1BlockInfoTx::Jovian(L1BlockInfoJovian::new(
+                0,
+                0,
+                0,
+                B256::ZERO,
+                1,
+                Address::ZERO,
+                0,
+                0,
+                0,
+                0,
+                0,
+                L1BlockInfoJovian::DEFAULT_DA_FOOTPRINT_GAS_SCALAR,
+            )),
+        ];
+
+        for original in variants {
+            let updated = original.with_sequence_number(42);
+            assert_eq!(updated.sequence_number(), 42);
+            assert_eq!(updated.id(), original.id());
+            assert_eq!(updated.batcher_address(), original.batcher_address());
+            assert_eq!(updated.l1_base_fee(), original.l1_base_fee());
+            assert_eq!(updated.blob_base_fee(), original.blob_base_fee());
+        }
     }
 
     #[test]

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -71,6 +71,9 @@ where
     checkpoint_reader: Arc<dyn ForkchoiceCheckpointReader>,
     /// Writes checkpointed forkchoice state after engine state changes.
     checkpoint_writer: Arc<dyn CheckpointWriter>,
+    /// When set, engine resets are skipped and the bootstrapped L2 unsafe head is retained
+    /// instead of consulting L1 (there is no L1-info deposit to reconstruct the safe head from).
+    skip_reset: bool,
 }
 
 impl<EngineClient_, DerivationClient> EngineProcessor<EngineClient_, DerivationClient>
@@ -120,6 +123,19 @@ where
         )
     }
 
+    /// Constructs a processor whose engine resets are skipped, retaining the bootstrapped
+    /// execution head. Used by the L1-free standalone sequencer.
+    pub fn new_skip_reset(
+        client: Arc<EngineClient_>,
+        config: Arc<RollupConfig>,
+        derivation_client: DerivationClient,
+        engine: Engine<EngineClient_>,
+    ) -> Self {
+        let mut processor = Self::new(client, config, derivation_client, engine);
+        processor.skip_reset = true;
+        processor
+    }
+
     /// Constructs a new [`EngineProcessor`] with checkpoint persistence.
     pub fn new_with_checkpoint(
         client: Arc<EngineClient_>,
@@ -136,6 +152,7 @@ where
             derivation_client,
             el_sync_complete: false,
             engine,
+            skip_reset: false,
             last_finalized_head_checkpointed: L2BlockInfo::default(),
             last_safe_head_checkpointed: L2BlockInfo::default(),
             last_safe_head_sent: L2BlockInfo::default(),
@@ -145,6 +162,13 @@ where
 
     /// Resets the inner [`Engine`] without notifying derivation.
     pub async fn reset_engine_state(&mut self) -> Result<L2BlockInfo, EngineError> {
+        if self.skip_reset {
+            let head = self.engine.state().sync_state.unsafe_head();
+            if head != L2BlockInfo::default() {
+                return Ok(head);
+            }
+        }
+
         // Reset the engine, consulting the checkpoint reader if reth has pruned the labeled
         // safe / finalized block bodies (so the L1 info deposit cannot be reconstructed).
         let l2_safe_head = self

--- a/crates/consensus/service/src/lib.rs
+++ b/crates/consensus/service/src/lib.rs
@@ -19,6 +19,12 @@ pub use service::{
 mod follow;
 pub use follow::{FollowError, RemoteClient, RemoteL2Client, RemoteL2ClientError};
 
+mod standalone;
+pub use standalone::{
+    StandaloneAttributesBuilder, StandaloneDerivationClient, StandaloneOriginSelector,
+    StandalonePrefund, StandaloneSequencerNode, StandaloneUnsafePayloadGossipClient,
+};
+
 mod actors;
 pub use actors::{
     AlloyL1BlockFetcher, BlockStream, BuildOutcome, BuildPipelineState, BuildRequest,

--- a/crates/consensus/service/src/standalone.rs
+++ b/crates/consensus/service/src/standalone.rs
@@ -1,0 +1,489 @@
+//! L1-free sequencing components for extending an existing L2 snapshot.
+
+use std::sync::Arc;
+
+use alloy_eips::{BlockNumHash, eip2718::Encodable2718};
+use alloy_primitives::{Address, B256, Bytes, TxKind, U256, keccak256};
+use alloy_rpc_types_engine::PayloadAttributes;
+use async_trait::async_trait;
+use base_common_consensus::{Predeploys, TxDeposit};
+use base_common_genesis::{RollupConfig, SystemConfig};
+use base_common_rpc_types_engine::BasePayloadAttributes;
+use base_consensus_derive::{
+    AttributesBuilder, BuilderError, PipelineError, PipelineErrorKind, PipelineResult, Signal,
+};
+use base_consensus_engine::{Engine, EngineClient, EngineState};
+use base_protocol::{BaseTimeUpdateTx, BlockInfo, L1BlockInfoTx, L2BlockInfo};
+use tokio::sync::{mpsc, watch};
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    ConductorClient, DerivationClientResult, EngineActor, EngineDerivationClient, EngineProcessor,
+    L1OriginSelectorError, NodeActor, OriginSelector, PayloadBuilder, QueuedSequencerEngineClient,
+    RecoveryModeGuard, SequencerActor, SequencerEngineRequestCoordinator,
+    UnsafePayloadGossipClient, UnsafePayloadGossipClientError,
+};
+
+/// Builds payload attributes by extending the L1 epoch captured in an L2 snapshot.
+///
+/// This intentionally does not perform L1 derivation. It preserves the snapshot's L1 origin and
+/// fee parameters, increments the L2 sequence number, and reads transactions from the normal EL
+/// transaction pool. It is suitable for unsafe-chain development and benchmarking only.
+#[derive(Debug, Clone)]
+pub struct StandaloneAttributesBuilder {
+    rollup_config: Arc<RollupConfig>,
+    l1_info: L1BlockInfoTx,
+    system_config: SystemConfig,
+    prefund: Option<StandalonePrefund>,
+    boundary_sequence_number: u64,
+}
+
+/// One-time account funding applied to the first descendant of a snapshot boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StandalonePrefund {
+    /// Account receiving the minted ETH.
+    pub address: Address,
+    /// Amount of wei minted to the account.
+    pub amount: u128,
+}
+
+impl StandaloneAttributesBuilder {
+    /// Creates a standalone attributes builder from snapshot boundary metadata.
+    pub fn new(
+        rollup_config: Arc<RollupConfig>,
+        l1_info: L1BlockInfoTx,
+        system_config: SystemConfig,
+        prefund: Option<StandalonePrefund>,
+    ) -> Self {
+        Self {
+            rollup_config,
+            l1_info,
+            system_config,
+            prefund,
+            boundary_sequence_number: l1_info.sequence_number(),
+        }
+    }
+}
+
+#[async_trait]
+impl AttributesBuilder for StandaloneAttributesBuilder {
+    async fn prepare_payload_attributes(
+        &mut self,
+        l2_parent: L2BlockInfo,
+        epoch: BlockNumHash,
+    ) -> PipelineResult<BasePayloadAttributes> {
+        if epoch != self.l1_info.id() || l2_parent.l1_origin != epoch {
+            return Err(PipelineErrorKind::Reset(
+                BuilderError::Custom("standalone L1 origin does not match L2 parent".to_string())
+                    .into(),
+            ));
+        }
+
+        let next_l2_block_number = l2_parent.block_info.number.saturating_add(1);
+        let (next_l2_time, next_l2_timestamp_millis_part) =
+            self.rollup_config.l2_block_timestamp_parts(next_l2_block_number);
+        let l1_info = self.l1_info.with_sequence_number(l2_parent.seq_num.saturating_add(1));
+        let l1_info_deposit = l1_info.into_deposit_tx(&self.rollup_config, next_l2_time);
+        let mut encoded_l1_info = Vec::new();
+        l1_info_deposit.encode_2718(&mut encoded_l1_info);
+
+        let mut transactions = vec![Bytes::from(encoded_l1_info)];
+        // Sub-second progression is conveyed solely by a `BaseTimeUpdateTx` deposit in the
+        // transactions list (the payload attributes no longer carry a millis field). Denim is the
+        // upgrade that activates the native sub-second block cadence, matching the production
+        // stateful attributes builder.
+        if self.rollup_config.is_denim_active(next_l2_time) {
+            let base_time =
+                BaseTimeUpdateTx::new(next_l2_timestamp_millis_part).map_err(|error| {
+                    PipelineError::AttributesBuilder(BuilderError::BaseTimeUpdate(error)).crit()
+                })?;
+            let deposit = base_time.into_deposit_tx(next_l2_block_number);
+            let mut encoded = Vec::new();
+            deposit.encode_2718(&mut encoded);
+            transactions.push(encoded.into());
+        }
+
+        if let Some(prefund) =
+            self.prefund.filter(|_| l2_parent.seq_num == self.boundary_sequence_number)
+        {
+            let deposit = TxDeposit {
+                source_hash: keccak256(prefund.address),
+                from: prefund.address,
+                to: TxKind::Call(prefund.address),
+                mint: prefund.amount,
+                value: U256::ZERO,
+                gas_limit: 21_000,
+                is_system_transaction: false,
+                input: Bytes::new(),
+            };
+            let mut encoded = Vec::new();
+            deposit.encode_2718(&mut encoded);
+            transactions.push(encoded.into());
+        }
+
+        Ok(BasePayloadAttributes {
+            payload_attributes: PayloadAttributes {
+                timestamp: next_l2_time,
+                prev_randao: B256::ZERO,
+                suggested_fee_recipient: Predeploys::SEQUENCER_FEE_VAULT,
+                withdrawals: self.rollup_config.is_canyon_active(next_l2_time).then(Vec::new),
+                parent_beacon_block_root: self
+                    .rollup_config
+                    .is_ecotone_active(next_l2_time)
+                    .then_some(B256::ZERO),
+                slot_number: None,
+                target_gas_limit: None,
+            },
+            transactions: Some(transactions),
+            no_tx_pool: Some(false),
+            gas_limit: Some(self.system_config.gas_limit),
+            eip_1559_params: self.system_config.eip_1559_params(
+                &self.rollup_config,
+                l2_parent.block_info.timestamp,
+                next_l2_time,
+            ),
+            min_base_fee: self
+                .rollup_config
+                .is_jovian_active(next_l2_time)
+                .then(|| self.system_config.min_base_fee.unwrap_or_default()),
+        })
+    }
+}
+
+/// Selects the snapshot's captured L1 origin for every standalone L2 block.
+#[derive(Debug, Clone, Copy)]
+pub struct StandaloneOriginSelector {
+    origin: BlockInfo,
+}
+
+impl StandaloneOriginSelector {
+    /// Creates a fixed origin selector from a decoded L1 info transaction.
+    pub fn new(l1_info: L1BlockInfoTx) -> Self {
+        Self {
+            origin: BlockInfo::new(
+                l1_info.block_hash(),
+                l1_info.id().number,
+                B256::ZERO,
+                l1_info.time(),
+            ),
+        }
+    }
+}
+
+#[async_trait]
+impl OriginSelector for StandaloneOriginSelector {
+    async fn next_l1_origin(
+        &mut self,
+        unsafe_head: L2BlockInfo,
+    ) -> Result<BlockInfo, L1OriginSelectorError> {
+        if unsafe_head.l1_origin != self.origin.id() {
+            return Err(L1OriginSelectorError::OriginNotFound(unsafe_head.l1_origin.hash));
+        }
+
+        // Pool activation enforces maximum sequencer drift using the selected origin timestamp.
+        // Standalone mode intentionally has no advancing L1, so use the parent L2 timestamp as
+        // the advisory origin time while retaining the snapshot origin's exact number and hash.
+        Ok(BlockInfo { timestamp: unsafe_head.block_info.timestamp, ..self.origin })
+    }
+}
+
+/// Discards derivation notifications for an L1-free standalone sequencer.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct StandaloneDerivationClient;
+
+#[async_trait]
+impl EngineDerivationClient for StandaloneDerivationClient {
+    async fn notify_sync_completed(&self, _safe_head: L2BlockInfo) -> DerivationClientResult<()> {
+        Ok(())
+    }
+
+    async fn send_new_engine_safe_head(
+        &self,
+        _safe_head: L2BlockInfo,
+    ) -> DerivationClientResult<()> {
+        Ok(())
+    }
+
+    async fn send_signal(&self, _signal: Signal) -> DerivationClientResult<()> {
+        Ok(())
+    }
+}
+
+/// Discards unsafe payload gossip after the payload has been built locally.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct StandaloneUnsafePayloadGossipClient;
+
+#[async_trait]
+impl UnsafePayloadGossipClient for StandaloneUnsafePayloadGossipClient {
+    async fn schedule_execution_payload_gossip(
+        &self,
+        _payload: base_common_rpc_types_engine::BaseExecutionPayloadEnvelope,
+    ) -> Result<(), UnsafePayloadGossipClientError> {
+        Ok(())
+    }
+}
+
+/// An L1-free sequencer that extends the unsafe chain of an existing L2 snapshot.
+///
+/// This node runs the production engine and sequencer actors, but intentionally omits derivation,
+/// L1 watching, P2P, batching, and safe/finalized head advancement. It is intended only for local
+/// development and execution benchmarking.
+#[derive(Debug)]
+pub struct StandaloneSequencerNode<E: EngineClient> {
+    /// The snapshot-bound rollup configuration.
+    pub rollup_config: Arc<RollupConfig>,
+    /// The execution engine client connected to the snapshot-backed builder EL.
+    pub engine_client: Arc<E>,
+    /// The attributes builder seeded from the snapshot boundary.
+    pub attributes_builder: StandaloneAttributesBuilder,
+    /// The fixed-origin selector seeded from the snapshot boundary.
+    pub origin_selector: StandaloneOriginSelector,
+}
+
+impl<E: EngineClient + 'static> StandaloneSequencerNode<E> {
+    /// Creates an L1-free sequencer from validated snapshot boundary metadata.
+    pub fn new(
+        rollup_config: Arc<RollupConfig>,
+        engine_client: Arc<E>,
+        l1_info: L1BlockInfoTx,
+        system_config: SystemConfig,
+        prefund: Option<StandalonePrefund>,
+    ) -> Self {
+        Self {
+            attributes_builder: StandaloneAttributesBuilder::new(
+                Arc::clone(&rollup_config),
+                l1_info,
+                system_config,
+                prefund,
+            ),
+            origin_selector: StandaloneOriginSelector::new(l1_info),
+            rollup_config,
+            engine_client,
+        }
+    }
+
+    /// Runs the standalone sequencer until an actor fails or shutdown is requested.
+    pub async fn start(&self) -> Result<(), String> {
+        self.start_with_cancellation(CancellationToken::new()).await
+    }
+
+    /// Runs the standalone sequencer with a caller-provided cancellation token.
+    pub async fn start_with_cancellation(
+        &self,
+        cancellation: CancellationToken,
+    ) -> Result<(), String> {
+        let (engine_actor_request_tx, engine_actor_request_rx) = mpsc::channel(1024);
+        let (unsafe_head_tx, unsafe_head_rx) = watch::channel(L2BlockInfo::default());
+        let (engine_state_tx, engine_state_rx) = watch::channel(EngineState::default());
+        let (engine_queue_length_tx, _engine_queue_length_rx) = watch::channel(0);
+        let engine = Engine::new(EngineState::default(), engine_state_tx, engine_queue_length_tx);
+        let processor = EngineProcessor::new_skip_reset(
+            Arc::clone(&self.engine_client),
+            Arc::clone(&self.rollup_config),
+            StandaloneDerivationClient,
+            engine,
+        );
+        let coordinator =
+            SequencerEngineRequestCoordinator::new(processor, false, None, false, unsafe_head_tx);
+        let engine_actor =
+            EngineActor::new(cancellation.clone(), engine_actor_request_rx, coordinator);
+
+        let sequencer_engine_client = Arc::new(QueuedSequencerEngineClient {
+            engine_actor_request_tx,
+            unsafe_head_rx,
+            engine_state_rx,
+        });
+        let (_sequencer_admin_tx, sequencer_admin_rx) = mpsc::channel(1024);
+        let recovery_mode = RecoveryModeGuard::new(false);
+        let sequencer_actor: SequencerActor<_, ConductorClient, _, _, _> = SequencerActor {
+            admin_api_rx: sequencer_admin_rx,
+            builder: PayloadBuilder {
+                attributes_builder: self.attributes_builder.clone(),
+                engine_client: Arc::clone(&sequencer_engine_client),
+                origin_selector: self.origin_selector,
+                recovery_mode: recovery_mode.clone(),
+                rollup_config: Arc::clone(&self.rollup_config),
+            },
+            cancellation_token: cancellation.clone(),
+            conductor: None,
+            engine_client: sequencer_engine_client,
+            is_active: true,
+            shadow_blocks_per_cycle: None,
+            shadow_funding: None,
+            recovery_mode,
+            rollup_config: Arc::clone(&self.rollup_config),
+            unsafe_payload_gossip_client: StandaloneUnsafePayloadGossipClient,
+            sealer: None,
+            pending_stop: None,
+            seal_offset: base_protocol::DEFAULT_SEAL_OFFSET,
+        };
+
+        crate::service::spawn_and_wait!(
+            cancellation,
+            actors = [Some((sequencer_actor, ())), Some((engine_actor, ())),]
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_consensus::Transaction as _;
+    use alloy_eips::{BlockNumHash, eip2718::Decodable2718};
+    use alloy_primitives::{Address, B256, U256};
+    use base_common_consensus::BaseTxEnvelope;
+    use base_common_genesis::{RollupConfig, SystemConfig};
+    use base_consensus_derive::AttributesBuilder;
+    use base_protocol::{
+        BaseTimeUpdateTx, BlockInfo, L1BlockInfoBedrock, L1BlockInfoTx, L2BlockInfo,
+    };
+
+    use super::{StandaloneAttributesBuilder, StandaloneOriginSelector, StandalonePrefund};
+    use crate::OriginSelector;
+
+    fn snapshot_boundary() -> (L1BlockInfoTx, L2BlockInfo) {
+        let origin_hash = B256::repeat_byte(0x11);
+        let l1_info = L1BlockInfoTx::Bedrock(L1BlockInfoBedrock::new(
+            100,
+            1_000,
+            7,
+            origin_hash,
+            9,
+            Address::repeat_byte(0x22),
+            U256::from(3),
+            U256::from(4),
+        ));
+        let parent = L2BlockInfo::new(
+            BlockInfo::new(B256::repeat_byte(0x33), 200, B256::repeat_byte(0x44), 2_000),
+            BlockNumHash { number: 100, hash: origin_hash },
+            9,
+        );
+        (l1_info, parent)
+    }
+
+    fn anchored_rollup(parent: L2BlockInfo, first_timestamp: u64) -> RollupConfig {
+        let mut rollup = RollupConfig { block_time: 2, ..Default::default() };
+        rollup.genesis.l2.number = 0;
+        rollup.genesis.l2_time =
+            first_timestamp - parent.block_info.number.saturating_add(1) * rollup.block_time;
+        rollup
+    }
+
+    #[tokio::test]
+    async fn builds_next_block_in_snapshot_epoch() {
+        let (l1_info, parent) = snapshot_boundary();
+        let rollup = std::sync::Arc::new(anchored_rollup(parent, 2_002));
+        let mut builder = StandaloneAttributesBuilder::new(
+            std::sync::Arc::clone(&rollup),
+            l1_info,
+            SystemConfig { gas_limit: 30_000_000, ..Default::default() },
+            None,
+        );
+
+        let attributes = builder.prepare_payload_attributes(parent, l1_info.id()).await.unwrap();
+
+        assert_eq!(attributes.payload_attributes.timestamp, 2_000 + rollup.block_time);
+        assert_eq!(attributes.gas_limit, Some(30_000_000));
+        assert_eq!(attributes.no_tx_pool, Some(false));
+        let transactions = attributes.transactions.unwrap();
+        let mut encoded = transactions[0].as_ref();
+        let envelope = BaseTxEnvelope::decode_2718(&mut encoded).unwrap();
+        let deposit = envelope.as_deposit().unwrap();
+        let next_l1_info = L1BlockInfoTx::decode_calldata(deposit.input().as_ref()).unwrap();
+        assert_eq!(next_l1_info.id(), l1_info.id());
+        assert_eq!(next_l1_info.sequence_number(), 10);
+    }
+
+    #[tokio::test]
+    async fn prefunds_only_first_snapshot_descendant() {
+        let (l1_info, parent) = snapshot_boundary();
+        let address = Address::repeat_byte(0x55);
+        let mut builder = StandaloneAttributesBuilder::new(
+            std::sync::Arc::new(anchored_rollup(parent, 2_002)),
+            l1_info,
+            SystemConfig { gas_limit: 30_000_000, ..Default::default() },
+            Some(StandalonePrefund { address, amount: 1_000_000 }),
+        );
+
+        let first = builder.prepare_payload_attributes(parent, l1_info.id()).await.unwrap();
+        assert_eq!(first.transactions.unwrap().len(), 2);
+
+        let later_parent = L2BlockInfo { seq_num: parent.seq_num + 1, ..parent };
+        let later = builder.prepare_payload_attributes(later_parent, l1_info.id()).await.unwrap();
+        assert_eq!(later.transactions.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn first_descendant_uses_anchored_rollup_schedule() {
+        let (l1_info, parent) = snapshot_boundary();
+        let mut builder = StandaloneAttributesBuilder::new(
+            std::sync::Arc::new(anchored_rollup(parent, 10_000)),
+            l1_info,
+            SystemConfig { gas_limit: 30_000_000, ..Default::default() },
+            None,
+        );
+
+        let first = builder.prepare_payload_attributes(parent, l1_info.id()).await.unwrap();
+        assert_eq!(first.payload_attributes.timestamp, 10_000);
+    }
+
+    #[tokio::test]
+    async fn subsecond_descendants_include_base_time_progression() {
+        let (l1_info, parent) = snapshot_boundary();
+        let mut rollup = anchored_rollup(parent, 2_002);
+        rollup.set_upgrade_activation_timestamp(base_common_genesis::BaseUpgrade::Denim, 2_002);
+        let mut builder = StandaloneAttributesBuilder::new(
+            std::sync::Arc::new(rollup),
+            l1_info,
+            SystemConfig { gas_limit: 30_000_000, ..Default::default() },
+            None,
+        );
+
+        for (offset, expected) in
+            [(1, (2_002, 0)), (2, (2_002, 200)), (5, (2_002, 800)), (6, (2_003, 0))]
+        {
+            let block_parent = L2BlockInfo {
+                block_info: BlockInfo {
+                    number: parent.block_info.number + offset - 1,
+                    timestamp: expected.0,
+                    ..parent.block_info
+                },
+                seq_num: parent.seq_num + offset - 1,
+                ..parent
+            };
+            let attributes =
+                builder.prepare_payload_attributes(block_parent, l1_info.id()).await.unwrap();
+            assert_eq!(attributes.payload_attributes.timestamp, expected.0);
+            let transactions = attributes.transactions.unwrap();
+            let mut encoded = transactions[1].as_ref();
+            let envelope = BaseTxEnvelope::decode_2718(&mut encoded).unwrap();
+            let base_time =
+                BaseTimeUpdateTx::decode_calldata(envelope.as_deposit().unwrap().input().as_ref())
+                    .unwrap();
+            assert_eq!(base_time.timestamp_millis_part(), expected.1);
+        }
+    }
+
+    #[tokio::test]
+    async fn fixed_origin_rejects_another_epoch() {
+        let (l1_info, mut parent) = snapshot_boundary();
+        let mut selector = StandaloneOriginSelector::new(l1_info);
+        parent.l1_origin.hash = B256::repeat_byte(0xff);
+
+        let result = selector.next_l1_origin(parent).await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn fixed_origin_tracks_parent_time_for_pool_activation() {
+        let (l1_info, mut parent) = snapshot_boundary();
+        let mut selector = StandaloneOriginSelector::new(l1_info);
+        parent.block_info.timestamp = 10_000;
+
+        let origin = selector.next_l1_origin(parent).await.unwrap();
+
+        assert_eq!(origin.id(), l1_info.id());
+        assert_eq!(origin.timestamp, 10_000);
+    }
+}


### PR DESCRIPTION
## Summary

Adds an **L1-free standalone sequencer** to the consensus engine: a standalone attributes builder and origin selector that drive block production without an L1 chain. Sub-second (200ms) blocks are gated on the Denim upgrade via `BaseTimeUpdateTx` deposits.

This is **PR 1 of 3** splitting the combined PR #4180 into focused, independently-reviewable pieces.

## Stack

- **1/3 → this PR** · `base: main` · L1-free standalone sequencer (consensus)
- 2/3 · load-test measurement-blocks window
- 3/3 · snapshot-backed L1-free devnet + benchmark harness

## Changes

Two crates (4 files, +635/-4):

- **`base-consensus-node`** — `crates/consensus/service/src/standalone.rs` (new, +496): the standalone builder/origin-selector/derivation-client that produce L2 blocks without an L1.
- Plus the wiring/behavior changes to existing code described below.

### Changes to existing code (beyond `standalone.rs`)

**1. `crates/consensus/protocol/src/info/variant.rs` (base-protocol, derivation layer, +120/-4)**

- **Extracted `L1BlockInfoTx::into_deposit_tx(self, rollup_config, l2_block_time) -> Sealed<TxDeposit>`.** The logic that builds the first-in-block L1-info deposit transaction was previously inlined in the constructor that returns `(L1BlockInfoTx, Sealed<TxDeposit>)`; it is now a reusable public method, and the original path just calls `l1_info.into_deposit_tx(...)`. This lets the standalone sequencer mint the L1-info deposit for blocks it produces itself, without going through L1 derivation. Pure refactor — no behavior change on the existing derivation path.
- **New `L1BlockInfoTx::with_sequence_number(self, u64) -> Self`.** Returns the same L1 block info with a different L2 `sequence_number`, preserving every L1-origin, fee, and system-config field across all four hardfork variants (Bedrock/Ecotone/Isthmus/Jovian). L1-free sequencing keeps producing L2 blocks against a single synthetic origin, incrementing the sequence number each block; this is the helper that does that.
- **New `L1BlockInfoTx::time(&self) -> u64` enum dispatcher.** Adds a `time()` accessor alongside the existing per-variant dispatchers (`block_hash()`, `sequence_number()`, `id()`, …) so the origin selector reads `l1_info.time()` instead of hand-matching each variant. Future-proofs against new hardfork variants.
- Adds the `jovian::L1BlockInfoJovianBaseFields` import and a colocated unit test (`test_l1_block_info_with_sequence_number`) asserting the seq-number is updated while origin/batcher/fee fields are preserved.

**2. `crates/consensus/service/src/actors/engine/engine_request_processor.rs` (base-consensus-node, +22)**

- Adds a `skip_reset: bool` field to `EngineProcessor` and a `new_skip_reset(...)` constructor that flips it on; the existing `new_with_checkpoint` initializes it to `false`, so **default behavior is unchanged.**
- **Behavior change in `reset_engine_state()`:** when `skip_reset` is set and the engine already has a bootstrapped unsafe head (non-default), the reset short-circuits and returns that in-memory head instead of consulting the checkpoint reader / reconstructing an L1-derived safe head. Without an L1 there is no L1-info deposit to rebuild the safe head from, so this retains the bootstrapped L2 head rather than rewinding. Guarded entirely behind the `skip_reset` flag.

**3. `crates/consensus/service/src/lib.rs` (base-consensus-node, +6)**

- Declares the new `standalone` module and `pub use`-re-exports its public API (`StandaloneAttributesBuilder`, `StandaloneDerivationClient`, `StandaloneOriginSelector`, `StandalonePrefund`, `StandaloneSequencerNode`, `StandaloneUnsafePayloadGossipClient`). Wiring only.

## Verification

- `cargo clippy -p base-protocol -p base-consensus-node --all-targets --all-features -- -D warnings` → clean
- `cargo nextest run -p base-protocol -p base-consensus-node` → **554 passed, 0 skipped**
- Leaves `Cargo.lock` byte-identical to `main`

Split from #4180 (kept open for reference). Two intentional improvements over #4180: (1) the engine-reset flag/constructor are named `skip_reset`/`new_skip_reset` here (was `l1_free`/`new_l1_free` in #4180) to describe what the flag does rather than why it exists; (2) the origin selector uses a new `L1BlockInfoTx::time()` enum dispatcher instead of hand-matching each hardfork variant.
