### PR TITLE
chore(shadow): Take discrete Postgres connection params for the shadow indexer

### DIFF
--- a/bin/shadow-metrics/src/main.rs
+++ b/bin/shadow-metrics/src/main.rs
@@ -111,13 +111,22 @@ async fn main() -> Result<()> {
 async fn run_server(args: Args) -> Result<()> {
     let http_addr = SocketAddr::from(([0, 0, 0, 0], args.http_port));
 
-    let connection = args.postgres_host.as_ref().map(|host| PgConnectionParams {
-        host: host.clone(),
-        port: args.postgres_port,
-        database: args.postgres_database.clone(),
-        username: args.postgres_user.clone(),
-        password: args.postgres_password.clone().unwrap_or_default(),
-    });
+    let connection = match (&args.postgres_host, &args.postgres_password) {
+        (Some(host), Some(password)) => Some(PgConnectionParams {
+            host: host.clone(),
+            port: args.postgres_port,
+            database: args.postgres_database.clone(),
+            username: args.postgres_user.clone(),
+            password: password.clone(),
+        }),
+        // Connecting with an empty password would surface as an opaque Postgres auth
+        // failure rather than a configuration error.
+        (Some(_), None) => anyhow::bail!(
+            "--postgres-host (env SHADOW_METRICS_POSTGRES_HOST) requires --postgres-password (env \
+             SHADOW_METRICS_POSTGRES_PASSWORD)"
+        ),
+        (None, _) => None,
+    };
 
     let store = match &connection {
         Some(connection) => {

--- a/bin/shadow-metrics/src/main.rs
+++ b/bin/shadow-metrics/src/main.rs
@@ -19,8 +19,9 @@ use axum::{
 };
 use base_cli_utils::LogConfig;
 use base_shadow_metrics::{
-    DEFAULT_MAX_ROWS_PER_POLL, DEFAULT_POLL_INTERVAL_SECS, ShadowMetricsReader,
-    ShadowMetricsReaderConfig, ShadowMetricsStore, api_router,
+    DEFAULT_DATABASE, DEFAULT_MAX_ROWS_PER_POLL, DEFAULT_POLL_INTERVAL_SECS, DEFAULT_PORT,
+    DEFAULT_USERNAME, PgConnectionParams, ShadowMetricsReader, ShadowMetricsReaderConfig,
+    ShadowMetricsStore, api_router,
 };
 use clap::Parser;
 use tokio::net::TcpListener;
@@ -45,9 +46,25 @@ struct Args {
     #[command(flatten)]
     metrics: MetricsArgs,
 
-    /// Postgres URL; unset disables reader and database readiness checks.
-    #[arg(long, env = "SHADOW_METRICS_POSTGRES_URL")]
-    postgres_url: Option<String>,
+    /// Postgres host; unset disables reader and database readiness checks.
+    #[arg(long, env = "SHADOW_METRICS_POSTGRES_HOST")]
+    postgres_host: Option<String>,
+
+    /// Password for the Postgres role.
+    #[arg(long, env = "SHADOW_METRICS_POSTGRES_PASSWORD")]
+    postgres_password: Option<String>,
+
+    /// Postgres port.
+    #[arg(long, env = "SHADOW_METRICS_POSTGRES_PORT", default_value_t = DEFAULT_PORT)]
+    postgres_port: u16,
+
+    /// Postgres database name.
+    #[arg(long, env = "SHADOW_METRICS_POSTGRES_DATABASE", default_value = DEFAULT_DATABASE)]
+    postgres_database: String,
+
+    /// Postgres role to authenticate as.
+    #[arg(long, env = "SHADOW_METRICS_POSTGRES_USER", default_value = DEFAULT_USERNAME)]
+    postgres_user: String,
 
     /// Maximum Postgres pool connections.
     #[arg(long, env = "SHADOW_METRICS_POSTGRES_MAX_CONNECTIONS", default_value = "10")]
@@ -94,17 +111,26 @@ async fn main() -> Result<()> {
 async fn run_server(args: Args) -> Result<()> {
     let http_addr = SocketAddr::from(([0, 0, 0, 0], args.http_port));
 
-    let store = if let Some(postgres_url) = &args.postgres_url {
-        Some(ShadowMetricsStore::connect(postgres_url, args.postgres_max_connections).await?)
-    } else {
-        None
+    let connection = args.postgres_host.as_ref().map(|host| PgConnectionParams {
+        host: host.clone(),
+        port: args.postgres_port,
+        database: args.postgres_database.clone(),
+        username: args.postgres_user.clone(),
+        password: args.postgres_password.clone().unwrap_or_default(),
+    });
+
+    let store = match &connection {
+        Some(connection) => {
+            Some(ShadowMetricsStore::connect(connection, args.postgres_max_connections).await?)
+        }
+        None => None,
     };
 
     info!(
         http_addr = %http_addr,
         metrics_addr = %args.metrics.addr,
         metrics_port = args.metrics.port,
-        postgres_enabled = args.postgres_url.is_some(),
+        postgres_enabled = connection.is_some(),
         poll_interval_secs = args.poll_interval_secs,
         max_rows_per_poll = args.max_rows_per_poll,
         "Starting shadow-metrics service"

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -15,7 +15,9 @@ use base_observability_events::{
 };
 use base_proofs_extension::ProofsHistoryExtension;
 use base_shadow_indexer::{ShadowIndexerConfig, ShadowIndexerExtension};
-use base_shadow_indexer_db::ShadowDbConfig;
+use base_shadow_indexer_db::{
+    DEFAULT_DATABASE, DEFAULT_PORT, DEFAULT_USERNAME, PgConnectionParams, ShadowDbConfig,
+};
 use base_tx_forwarding::{
     DEFAULT_MAX_BATCH_SIZE, DEFAULT_MAX_RPS, DEFAULT_RESEND_AFTER_MS, TxForwardingConfig,
     TxForwardingExtension,
@@ -91,14 +93,50 @@ pub struct ShadowIndexerArgs {
     #[arg(long = "enable-shadow-indexer", env = "ENABLE_SHADOW_INDEXER")]
     pub enable_shadow_indexer: bool,
 
-    /// `PostgreSQL` connection URL for the shadow indexer database.
+    /// Host of the shadow indexer database.
     #[arg(
-        long = "shadow-indexer.database-url",
-        env = "SHADOW_INDEXER_DATABASE_URL",
-        value_name = "SHADOW_INDEXER_DATABASE_URL",
+        long = "shadow-indexer.db-host",
+        env = "SHADOW_INDEXER_DB_HOST",
+        value_name = "SHADOW_INDEXER_DB_HOST",
         requires = "enable_shadow_indexer"
     )]
-    pub shadow_indexer_database_url: Option<String>,
+    pub shadow_indexer_db_host: Option<String>,
+
+    /// Password for the shadow indexer database role.
+    #[arg(
+        long = "shadow-indexer.db-password",
+        env = "SHADOW_INDEXER_DB_PASSWORD",
+        value_name = "SHADOW_INDEXER_DB_PASSWORD",
+        requires = "enable_shadow_indexer"
+    )]
+    pub shadow_indexer_db_password: Option<String>,
+
+    /// Port of the shadow indexer database.
+    #[arg(
+        long = "shadow-indexer.db-port",
+        env = "SHADOW_INDEXER_DB_PORT",
+        default_value_t = DEFAULT_PORT,
+        requires = "enable_shadow_indexer"
+    )]
+    pub shadow_indexer_db_port: u16,
+
+    /// Name of the shadow indexer database.
+    #[arg(
+        long = "shadow-indexer.db-name",
+        env = "SHADOW_INDEXER_DB_NAME",
+        default_value = DEFAULT_DATABASE,
+        requires = "enable_shadow_indexer"
+    )]
+    pub shadow_indexer_db_name: String,
+
+    /// Role to authenticate to the shadow indexer database as.
+    #[arg(
+        long = "shadow-indexer.db-user",
+        env = "SHADOW_INDEXER_DB_USER",
+        default_value = DEFAULT_USERNAME,
+        requires = "enable_shadow_indexer"
+    )]
+    pub shadow_indexer_db_user: String,
 
     /// Maximum number of open shadow indexer database connections.
     #[arg(
@@ -124,7 +162,11 @@ impl Default for ShadowIndexerArgs {
     fn default() -> Self {
         Self {
             enable_shadow_indexer: false,
-            shadow_indexer_database_url: None,
+            shadow_indexer_db_host: None,
+            shadow_indexer_db_password: None,
+            shadow_indexer_db_port: DEFAULT_PORT,
+            shadow_indexer_db_name: DEFAULT_DATABASE.to_string(),
+            shadow_indexer_db_user: DEFAULT_USERNAME.to_string(),
             shadow_indexer_max_connections: DEFAULT_SHADOW_INDEXER_MAX_CONNECTIONS,
             shadow_indexer_connection_timeout: humantime::parse_duration(
                 DEFAULT_SHADOW_INDEXER_CONNECTION_TIMEOUT,
@@ -312,21 +354,39 @@ impl TryFrom<&ShadowIndexerArgs> for ShadowIndexerConfig {
     type Error = eyre::Error;
 
     fn try_from(args: &ShadowIndexerArgs) -> eyre::Result<Self> {
-        let url = if args.enable_shadow_indexer {
-            args.shadow_indexer_database_url.clone().ok_or_else(|| {
-                eyre::eyre!(
-                    "--enable-shadow-indexer (env ENABLE_SHADOW_INDEXER) requires \
-                     --shadow-indexer.database-url (env SHADOW_INDEXER_DATABASE_URL)"
-                )
-            })?
+        let connection = if args.enable_shadow_indexer {
+            let require = |value: &Option<String>, flag: &str, env: &str| {
+                value.clone().ok_or_else(|| {
+                    eyre::eyre!(
+                        "--enable-shadow-indexer (env ENABLE_SHADOW_INDEXER) requires {flag} (env \
+                         {env})"
+                    )
+                })
+            };
+
+            PgConnectionParams {
+                host: require(
+                    &args.shadow_indexer_db_host,
+                    "--shadow-indexer.db-host",
+                    "SHADOW_INDEXER_DB_HOST",
+                )?,
+                port: args.shadow_indexer_db_port,
+                database: args.shadow_indexer_db_name.clone(),
+                username: args.shadow_indexer_db_user.clone(),
+                password: require(
+                    &args.shadow_indexer_db_password,
+                    "--shadow-indexer.db-password",
+                    "SHADOW_INDEXER_DB_PASSWORD",
+                )?,
+            }
         } else {
-            String::new()
+            PgConnectionParams::default()
         };
 
         Ok(Self {
             enabled: args.enable_shadow_indexer,
             db: ShadowDbConfig {
-                url,
+                connection,
                 max_connections: args.shadow_indexer_max_connections,
                 connection_timeout: args.shadow_indexer_connection_timeout,
             },

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -977,8 +977,16 @@ mod tests {
         let args = CommandParser::<StandardNodeArgs>::parse_from([
             "reth",
             "--enable-shadow-indexer",
-            "--shadow-indexer.database-url",
-            "postgres://localhost/shadow",
+            "--shadow-indexer.db-host",
+            "shadow.example.internal",
+            "--shadow-indexer.db-password",
+            "hunter2",
+            "--shadow-indexer.db-port",
+            "6543",
+            "--shadow-indexer.db-name",
+            "shadow",
+            "--shadow-indexer.db-user",
+            "writer",
             "--shadow-indexer.max-connections",
             "9",
             "--shadow-indexer.connection-timeout",
@@ -988,39 +996,76 @@ mod tests {
 
         assert!(args.shadow_indexer.enable_shadow_indexer);
         assert_eq!(
-            args.shadow_indexer.shadow_indexer_database_url.as_deref(),
-            Some("postgres://localhost/shadow")
+            args.shadow_indexer.shadow_indexer_db_host.as_deref(),
+            Some("shadow.example.internal")
         );
+        assert_eq!(args.shadow_indexer.shadow_indexer_db_password.as_deref(), Some("hunter2"));
+        assert_eq!(args.shadow_indexer.shadow_indexer_db_port, 6543);
+        assert_eq!(args.shadow_indexer.shadow_indexer_db_name, "shadow");
+        assert_eq!(args.shadow_indexer.shadow_indexer_db_user, "writer");
         assert_eq!(args.shadow_indexer.shadow_indexer_max_connections, 9);
         assert_eq!(args.shadow_indexer.shadow_indexer_connection_timeout, Duration::from_secs(45));
     }
 
     #[test]
-    fn test_shadow_indexer_database_url_requires_enable_flag() {
+    fn test_standard_node_args_defaults_shadow_indexer_connection_fields() {
+        let args = CommandParser::<StandardNodeArgs>::parse_from([
+            "reth",
+            "--enable-shadow-indexer",
+            "--shadow-indexer.db-host",
+            "shadow.example.internal",
+            "--shadow-indexer.db-password",
+            "hunter2",
+        ])
+        .args;
+
+        let config = ShadowIndexerConfig::try_from(&args.shadow_indexer)
+            .expect("host and password are enough to build the config");
+
+        assert_eq!(config.db.connection.port, DEFAULT_PORT);
+        assert_eq!(config.db.connection.database, DEFAULT_DATABASE);
+        assert_eq!(config.db.connection.username, DEFAULT_USERNAME);
+    }
+
+    #[test]
+    fn test_shadow_indexer_db_host_requires_enable_flag() {
         let error = CommandParser::<StandardNodeArgs>::try_parse_from([
             "reth",
-            "--shadow-indexer.database-url",
-            "postgres://localhost/shadow",
+            "--shadow-indexer.db-host",
+            "shadow.example.internal",
         ])
-        .expect_err("shadow indexer database url should require the enable flag");
+        .expect_err("shadow indexer db host should require the enable flag");
 
         assert!(error.to_string().contains("--enable-shadow-indexer"));
     }
 
     #[test]
-    fn test_shadow_indexer_config_requires_database_url_when_enabled() {
+    fn test_shadow_indexer_config_requires_db_host_when_enabled() {
         let args =
             ShadowIndexerArgs { enable_shadow_indexer: true, ..ShadowIndexerArgs::default() };
         let error = ShadowIndexerConfig::try_from(&args)
-            .expect_err("enabled shadow indexer should require a database url");
+            .expect_err("enabled shadow indexer should require a db host");
 
-        assert!(error.to_string().contains("--shadow-indexer.database-url"));
+        assert!(error.to_string().contains("--shadow-indexer.db-host"));
+    }
+
+    #[test]
+    fn test_shadow_indexer_config_requires_db_password_when_enabled() {
+        let args = ShadowIndexerArgs {
+            enable_shadow_indexer: true,
+            shadow_indexer_db_host: Some("shadow.example.internal".to_string()),
+            ..ShadowIndexerArgs::default()
+        };
+        let error = ShadowIndexerConfig::try_from(&args)
+            .expect_err("enabled shadow indexer should require a db password");
+
+        assert!(error.to_string().contains("--shadow-indexer.db-password"));
     }
 
     #[test]
     fn test_shadow_indexer_config_disabled_by_default() {
         let config = ShadowIndexerConfig::try_from(&ShadowIndexerArgs::default())
-            .expect("disabled shadow indexer config should build without a url");
+            .expect("disabled shadow indexer config should build without connection details");
 
         assert!(!config.enabled);
         assert_eq!(config.builder_version, env!("CARGO_PKG_VERSION"));

--- a/crates/execution/shadow-indexer-db/src/config.rs
+++ b/crates/execution/shadow-indexer-db/src/config.rs
@@ -1,13 +1,67 @@
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use sqlx::{PgPool, postgres::PgPoolOptions};
+use sqlx::{
+    PgPool,
+    postgres::{PgConnectOptions, PgPoolOptions},
+};
+
+/// Default Postgres port.
+pub const DEFAULT_PORT: u16 = 5432;
+/// Default shadow indexer database name.
+pub const DEFAULT_DATABASE: &str = "shadow_metrics";
+/// Default role owning the shadow indexer schema.
+pub const DEFAULT_USERNAME: &str = "app";
+
+/// Postgres connection parameters.
+///
+/// Discrete fields rather than a URL: the driver receives the password as a protocol
+/// value, so a generated RDS password containing `@` or `/` needs no escaping and cannot
+/// silently truncate a DSN.
+#[derive(Clone, Debug)]
+pub struct PgConnectionParams {
+    /// Database host.
+    pub host: String,
+    /// Database port.
+    pub port: u16,
+    /// Database name.
+    pub database: String,
+    /// Role to authenticate as.
+    pub username: String,
+    /// Password for `username`.
+    pub password: String,
+}
+
+impl Default for PgConnectionParams {
+    fn default() -> Self {
+        Self {
+            host: String::new(),
+            port: DEFAULT_PORT,
+            database: DEFAULT_DATABASE.to_string(),
+            username: DEFAULT_USERNAME.to_string(),
+            password: String::new(),
+        }
+    }
+}
+
+impl PgConnectionParams {
+    /// Build driver connect options.
+    #[must_use]
+    pub fn connect_options(&self) -> PgConnectOptions {
+        PgConnectOptions::new()
+            .host(&self.host)
+            .port(self.port)
+            .database(&self.database)
+            .username(&self.username)
+            .password(&self.password)
+    }
+}
 
 /// Configuration for the shadow indexer database.
 #[derive(Clone, Debug)]
 pub struct ShadowDbConfig {
-    /// Database connection URL.
-    pub url: String,
+    /// Connection parameters.
+    pub connection: PgConnectionParams,
     /// Maximum number of open connections.
     pub max_connections: u32,
     /// Timeout when acquiring a connection.
@@ -24,7 +78,7 @@ impl ShadowDbConfig {
         let pool = PgPoolOptions::new()
             .max_connections(self.max_connections)
             .acquire_timeout(self.connection_timeout)
-            .connect(&self.url)
+            .connect_with(self.connection.connect_options())
             .await
             .context("failed to connect to shadow indexer database")?;
 

--- a/crates/execution/shadow-indexer-db/src/config.rs
+++ b/crates/execution/shadow-indexer-db/src/config.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{fmt, time::Duration};
 
 use anyhow::{Context, Result};
 use sqlx::{
@@ -18,7 +18,7 @@ pub const DEFAULT_USERNAME: &str = "app";
 /// Discrete fields rather than a URL: the driver receives the password as a protocol
 /// value, so a generated RDS password containing `@` or `/` needs no escaping and cannot
 /// silently truncate a DSN.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct PgConnectionParams {
     /// Database host.
     pub host: String,
@@ -41,6 +41,19 @@ impl Default for PgConnectionParams {
             username: DEFAULT_USERNAME.to_string(),
             password: String::new(),
         }
+    }
+}
+
+/// Redacts the password so tracing a [`ShadowDbConfig`] cannot leak it into logs.
+impl fmt::Debug for PgConnectionParams {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PgConnectionParams")
+            .field("host", &self.host)
+            .field("port", &self.port)
+            .field("database", &self.database)
+            .field("username", &self.username)
+            .field("password", &"[REDACTED]")
+            .finish()
     }
 }
 

--- a/crates/execution/shadow-indexer-db/src/lib.rs
+++ b/crates/execution/shadow-indexer-db/src/lib.rs
@@ -1,7 +1,9 @@
 #![doc = include_str!("../README.md")]
 
 mod config;
-pub use config::ShadowDbConfig;
+pub use config::{
+    DEFAULT_DATABASE, DEFAULT_PORT, DEFAULT_USERNAME, PgConnectionParams, ShadowDbConfig,
+};
 
 mod cursor;
 pub use cursor::{ShadowBlockCursor, ShadowMetricsCursorRepo};

--- a/crates/execution/shadow-indexer/src/writer.rs
+++ b/crates/execution/shadow-indexer/src/writer.rs
@@ -178,7 +178,8 @@ mod tests {
 
     use anyhow::anyhow;
     use base_shadow_indexer_db::{
-        ShadowBlockPayload, ShadowBlockRow, ShadowCanonicalRef, ShadowDbConfig, ShadowFlushOutcome,
+        PgConnectionParams, ShadowBlockPayload, ShadowBlockRow, ShadowCanonicalRef, ShadowDbConfig,
+        ShadowFlushOutcome,
     };
     use chrono::{DateTime, Utc};
     use reth_primitives_traits::RecoveredBlock;
@@ -191,7 +192,7 @@ mod tests {
         ShadowWriter {
             rx,
             db_config: ShadowDbConfig {
-                url: String::new(),
+                connection: PgConnectionParams::default(),
                 max_connections: 1,
                 connection_timeout: Duration::from_secs(1),
             },

--- a/crates/infra/shadow-metrics/src/lib.rs
+++ b/crates/infra/shadow-metrics/src/lib.rs
@@ -23,4 +23,7 @@ mod stats;
 pub use stats::ShadowBlockStats;
 
 mod store;
+pub use base_shadow_indexer_db::{
+    DEFAULT_DATABASE, DEFAULT_PORT, DEFAULT_USERNAME, PgConnectionParams,
+};
 pub use store::{ShadowMetricsSchemaReadinessError, ShadowMetricsStore};

--- a/crates/infra/shadow-metrics/src/store.rs
+++ b/crates/infra/shadow-metrics/src/store.rs
@@ -1,6 +1,7 @@
 //! Postgres access for shadow metrics.
 
 use anyhow::Result;
+use base_shadow_indexer_db::PgConnectionParams;
 use sqlx::{PgPool, postgres::PgPoolOptions};
 
 /// Schema readiness failure.
@@ -47,14 +48,14 @@ impl ShadowMetricsStore {
     ///
     /// # Errors
     /// Returns an error when the pool cannot connect.
-    pub async fn connect(database_url: &str, max_connections: u32) -> Result<Self> {
+    pub async fn connect(connection: &PgConnectionParams, max_connections: u32) -> Result<Self> {
         let max_connections = max_connections.max(1);
         let pool = PgPoolOptions::new()
             .max_connections(max_connections)
             .min_connections(max_connections)
             .max_lifetime(None)
             .idle_timeout(None)
-            .connect(database_url)
+            .connect_with(connection.connect_options())
             .await?;
         Ok(Self { pool })
     }

--- a/etc/systems/tests/shadow_indexer.rs
+++ b/etc/systems/tests/shadow_indexer.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use base_node_runner::FromExtensionConfig;
 use base_shadow_indexer::{ShadowIndexerConfig, ShadowIndexerExtension};
-use base_shadow_indexer_db::{ShadowBlockRepo, ShadowDbConfig};
+use base_shadow_indexer_db::{PgConnectionParams, ShadowBlockRepo, ShadowDbConfig};
 use base_system_tests::{SystemTestProviderExt, SystemTestStackBuilder};
 use eyre::{Result, WrapErr, ensure};
 use sqlx::postgres::PgPoolOptions;
@@ -31,10 +31,16 @@ const DB_POLL_INTERVAL: Duration = Duration::from_millis(500);
 async fn shadow_indexer_persists_no_canonical_blocks() -> Result<()> {
     let container = Postgres::default().with_tag(POSTGRES_TAG).start().await?;
     let port = container.get_host_port_ipv4(5432).await?;
-    let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
+    let connection = PgConnectionParams {
+        host: "127.0.0.1".to_string(),
+        port,
+        database: "postgres".to_string(),
+        username: "postgres".to_string(),
+        password: "postgres".to_string(),
+    };
 
     let db_config = ShadowDbConfig {
-        url: url.clone(),
+        connection: connection.clone(),
         max_connections: 5,
         connection_timeout: Duration::from_secs(5),
     };
@@ -62,7 +68,7 @@ async fn shadow_indexer_persists_no_canonical_blocks() -> Result<()> {
     let pool = PgPoolOptions::new()
         .max_connections(5)
         .acquire_timeout(Duration::from_secs(5))
-        .connect(&url)
+        .connect_with(connection.connect_options())
         .await?;
 
     let shadow_blocks: Option<String> =

--- a/etc/systems/tests/shadow_metrics_reader.rs
+++ b/etc/systems/tests/shadow_metrics_reader.rs
@@ -7,8 +7,8 @@ use alloy_primitives::{Address, Signature};
 use anyhow::Result;
 use base_common_consensus::{BaseTxEnvelope, TxDeposit};
 use base_shadow_indexer_db::{
-    ShadowBlockCursor, ShadowBlockPayload, ShadowBlockRepo, ShadowBlockRow, ShadowCanonicalRef,
-    ShadowDbConfig, ShadowMetricsCursorRepo, ShadowWrite,
+    PgConnectionParams, ShadowBlockCursor, ShadowBlockPayload, ShadowBlockRepo, ShadowBlockRow,
+    ShadowCanonicalRef, ShadowDbConfig, ShadowMetricsCursorRepo, ShadowWrite,
 };
 use base_shadow_metrics::{ShadowMetricsReader, ShadowMetricsReaderConfig, ShadowMetricsStore};
 use chrono::Utc;
@@ -35,11 +35,19 @@ impl TestDatabase {
     async fn start() -> Result<Self> {
         let container = Postgres::default().with_tag(POSTGRES_TAG).start().await?;
         let port = container.get_host_port_ipv4(5432).await?;
-        let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
-        let pool =
-            ShadowDbConfig { url, max_connections: 5, connection_timeout: Duration::from_secs(5) }
-                .init_pool()
-                .await?;
+        let pool = ShadowDbConfig {
+            connection: PgConnectionParams {
+                host: "127.0.0.1".to_string(),
+                port,
+                database: "postgres".to_string(),
+                username: "postgres".to_string(),
+                password: "postgres".to_string(),
+            },
+            max_connections: 5,
+            connection_timeout: Duration::from_secs(5),
+        }
+        .init_pool()
+        .await?;
 
         Ok(Self { _container: container, pool })
     }


### PR DESCRIPTION
The shadow indexer and the shadow-metrics reader both took a composed Postgres URL, so each deployment assembled one in shell first. These now take host/port/database/user/password and hand them to `PgConnectOptions`, so the password travels as a protocol field and there is nothing to escape.

**Breaking.** `SHADOW_INDEXER_DATABASE_URL` and `SHADOW_METRICS_POSTGRES_URL` are removed in favour of `SHADOW_INDEXER_DB_HOST`/`_PASSWORD` and `SHADOW_METRICS_POSTGRES_HOST`/`_PASSWORD`; port, database and user default to `5432`, `shadow_metrics`, `app`.