### PR TITLE
fix(node): disable txpool gossip

### DIFF
--- a/crates/execution/node/src/args.rs
+++ b/crates/execution/node/src/args.rs
@@ -345,10 +345,6 @@ pub struct RollupArgs {
     #[arg(long = "rollup.sequencer", visible_aliases = ["rollup.sequencer-http", "rollup.sequencer-ws"])]
     pub sequencer: Option<String>,
 
-    /// Enable transaction pool gossip
-    #[arg(long = "rollup.enable-tx-pool-gossip")]
-    pub enable_txpool_gossip: bool,
-
     /// enables discovery v4 if provided
     #[arg(long = "rollup.discovery.v4", default_value = "false")]
     pub discovery_v4: bool,
@@ -505,7 +501,6 @@ impl Default for RollupArgs {
     fn default() -> Self {
         Self {
             sequencer: None,
-            enable_txpool_gossip: false,
             discovery_v4: false,
             sequencer_headers: Vec::new(),
             min_suggested_priority_fee: 1_000_000,
@@ -552,7 +547,6 @@ mod tests {
     fn test_parse_rollup_default_args() {
         let default_args = RollupArgs::default();
         let args = CommandParser::<RollupArgs>::parse_from(["reth"]).args;
-        assert!(!args.enable_txpool_gossip);
         assert_eq!(args, default_args);
     }
 
@@ -577,24 +571,11 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_rollup_enable_txpool_args() {
-        let expected_args = RollupArgs { enable_txpool_gossip: true, ..Default::default() };
-        let args =
-            CommandParser::<RollupArgs>::parse_from(["reth", "--rollup.enable-tx-pool-gossip"])
-                .args;
-        assert_eq!(args, expected_args);
-    }
-
-    #[test]
     fn test_parse_rollup_many_args() {
-        let expected_args = RollupArgs {
-            enable_txpool_gossip: true,
-            sequencer: Some("http://host:port".into()),
-            ..Default::default()
-        };
+        let expected_args =
+            RollupArgs { sequencer: Some("http://host:port".into()), ..Default::default() };
         let args = CommandParser::<RollupArgs>::parse_from([
             "reth",
-            "--rollup.enable-tx-pool-gossip",
             "--rollup.sequencer-http",
             "http://host:port",
         ])

--- a/crates/execution/node/src/args.rs
+++ b/crates/execution/node/src/args.rs
@@ -345,9 +345,9 @@ pub struct RollupArgs {
     #[arg(long = "rollup.sequencer", visible_aliases = ["rollup.sequencer-http", "rollup.sequencer-ws"])]
     pub sequencer: Option<String>,
 
-    /// Disable transaction pool gossip
-    #[arg(long = "rollup.disable-tx-pool-gossip")]
-    pub disable_txpool_gossip: bool,
+    /// Enable transaction pool gossip
+    #[arg(long = "rollup.enable-tx-pool-gossip")]
+    pub enable_txpool_gossip: bool,
 
     /// enables discovery v4 if provided
     #[arg(long = "rollup.discovery.v4", default_value = "false")]
@@ -505,7 +505,7 @@ impl Default for RollupArgs {
     fn default() -> Self {
         Self {
             sequencer: None,
-            disable_txpool_gossip: false,
+            enable_txpool_gossip: false,
             discovery_v4: false,
             sequencer_headers: Vec::new(),
             min_suggested_priority_fee: 1_000_000,
@@ -552,6 +552,7 @@ mod tests {
     fn test_parse_rollup_default_args() {
         let default_args = RollupArgs::default();
         let args = CommandParser::<RollupArgs>::parse_from(["reth"]).args;
+        assert!(!args.enable_txpool_gossip);
         assert_eq!(args, default_args);
     }
 
@@ -576,10 +577,10 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_rollup_disable_txpool_args() {
-        let expected_args = RollupArgs { disable_txpool_gossip: true, ..Default::default() };
+    fn test_parse_rollup_enable_txpool_args() {
+        let expected_args = RollupArgs { enable_txpool_gossip: true, ..Default::default() };
         let args =
-            CommandParser::<RollupArgs>::parse_from(["reth", "--rollup.disable-tx-pool-gossip"])
+            CommandParser::<RollupArgs>::parse_from(["reth", "--rollup.enable-tx-pool-gossip"])
                 .args;
         assert_eq!(args, expected_args);
     }
@@ -587,13 +588,13 @@ mod tests {
     #[test]
     fn test_parse_rollup_many_args() {
         let expected_args = RollupArgs {
-            disable_txpool_gossip: true,
+            enable_txpool_gossip: true,
             sequencer: Some("http://host:port".into()),
             ..Default::default()
         };
         let args = CommandParser::<RollupArgs>::parse_from([
             "reth",
-            "--rollup.disable-tx-pool-gossip",
+            "--rollup.enable-tx-pool-gossip",
             "--rollup.sequencer-http",
             "http://host:port",
         ])

--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -250,7 +250,6 @@ impl BaseNode {
         Node: FullNodeTypes<Types: BaseNodeTypes>,
     {
         let RollupArgs {
-            enable_txpool_gossip,
             discovery_v4,
             txpool_ordering,
             max_inflight_delegated_slots,
@@ -282,7 +281,7 @@ impl BaseNode {
                     .with_da_config(self.da_config.clone())
                     .with_gas_limit_config(self.gas_limit_config.clone()),
             ))
-            .network(BaseNetworkBuilder::new(enable_txpool_gossip, !discovery_v4))
+            .network(BaseNetworkBuilder::new(!discovery_v4))
             .consensus(BaseConsensusBuilder::default())
     }
 
@@ -1153,16 +1152,14 @@ where
 /// A basic Base network builder.
 #[derive(Debug, Clone, Default)]
 pub struct BaseNetworkBuilder {
-    /// Enable transaction pool gossip
-    pub enable_txpool_gossip: bool,
     /// Disable discovery v4
     pub disable_discovery_v4: bool,
 }
 
 impl BaseNetworkBuilder {
     /// Creates a new `BaseNetworkBuilder`.
-    pub const fn new(enable_txpool_gossip: bool, disable_discovery_v4: bool) -> Self {
-        Self { enable_txpool_gossip, disable_discovery_v4 }
+    pub const fn new(disable_discovery_v4: bool) -> Self {
+        Self { disable_discovery_v4 }
     }
 
     /// Runs a future on the current runtime, or creates one when needed.
@@ -1322,7 +1319,6 @@ impl BaseNetworkBuilder {
         Node: FullNodeTypes<Types: NodeTypes<ChainSpec: Hardforks>>,
         NetworkP: NetworkPrimitives,
     {
-        let enable_txpool_gossip = self.enable_txpool_gossip;
         let discovery_config = BaseDiscoveryConfig::new(self.disable_discovery_v4);
         let args = &ctx.config().network;
         let network_builder = ctx
@@ -1348,7 +1344,7 @@ impl BaseNetworkBuilder {
 
         let mut network_config = ctx.build_network_config(network_builder);
 
-        network_config.tx_gossip_disabled = !enable_txpool_gossip;
+        network_config.tx_gossip_disabled = true;
 
         Ok(network_config)
     }

--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -250,7 +250,7 @@ impl BaseNode {
         Node: FullNodeTypes<Types: BaseNodeTypes>,
     {
         let RollupArgs {
-            disable_txpool_gossip,
+            enable_txpool_gossip,
             discovery_v4,
             txpool_ordering,
             max_inflight_delegated_slots,
@@ -282,7 +282,7 @@ impl BaseNode {
                     .with_da_config(self.da_config.clone())
                     .with_gas_limit_config(self.gas_limit_config.clone()),
             ))
-            .network(BaseNetworkBuilder::new(disable_txpool_gossip, !discovery_v4))
+            .network(BaseNetworkBuilder::new(enable_txpool_gossip, !discovery_v4))
             .consensus(BaseConsensusBuilder::default())
     }
 
@@ -1153,16 +1153,16 @@ where
 /// A basic Base network builder.
 #[derive(Debug, Clone, Default)]
 pub struct BaseNetworkBuilder {
-    /// Disable transaction pool gossip
-    pub disable_txpool_gossip: bool,
+    /// Enable transaction pool gossip
+    pub enable_txpool_gossip: bool,
     /// Disable discovery v4
     pub disable_discovery_v4: bool,
 }
 
 impl BaseNetworkBuilder {
     /// Creates a new `BaseNetworkBuilder`.
-    pub const fn new(disable_txpool_gossip: bool, disable_discovery_v4: bool) -> Self {
-        Self { disable_txpool_gossip, disable_discovery_v4 }
+    pub const fn new(enable_txpool_gossip: bool, disable_discovery_v4: bool) -> Self {
+        Self { enable_txpool_gossip, disable_discovery_v4 }
     }
 
     /// Runs a future on the current runtime, or creates one when needed.
@@ -1322,7 +1322,7 @@ impl BaseNetworkBuilder {
         Node: FullNodeTypes<Types: NodeTypes<ChainSpec: Hardforks>>,
         NetworkP: NetworkPrimitives,
     {
-        let disable_txpool_gossip = self.disable_txpool_gossip;
+        let enable_txpool_gossip = self.enable_txpool_gossip;
         let discovery_config = BaseDiscoveryConfig::new(self.disable_discovery_v4);
         let args = &ctx.config().network;
         let network_builder = ctx
@@ -1348,10 +1348,7 @@ impl BaseNetworkBuilder {
 
         let mut network_config = ctx.build_network_config(network_builder);
 
-        // When `sequencer_endpoint` is configured, the node will forward all transactions to a
-        // Sequencer node for execution and inclusion on L1, and disable its own txpool
-        // gossip to prevent other parties in the network from learning about them.
-        network_config.tx_gossip_disabled = disable_txpool_gossip;
+        network_config.tx_gossip_disabled = !enable_txpool_gossip;
 
         Ok(network_config)
     }

--- a/crates/execution/node/src/proof_history.rs
+++ b/crates/execution/node/src/proof_history.rs
@@ -46,7 +46,7 @@ pub async fn launch_node_with_proof_history(
 ) -> eyre::Result<(), ErrReport> {
     let RollupArgs {
         sequencer,
-        disable_txpool_gossip,
+        enable_txpool_gossip,
         discovery_v4,
         sequencer_headers,
         min_suggested_priority_fee,
@@ -70,7 +70,7 @@ pub async fn launch_node_with_proof_history(
     // Start from a plain BaseNode builder
     let mut node_builder = builder.node(BaseNode::new(RollupArgs {
         sequencer,
-        disable_txpool_gossip,
+        enable_txpool_gossip,
         discovery_v4,
         sequencer_headers,
         min_suggested_priority_fee,

--- a/crates/execution/node/src/proof_history.rs
+++ b/crates/execution/node/src/proof_history.rs
@@ -46,7 +46,6 @@ pub async fn launch_node_with_proof_history(
 ) -> eyre::Result<(), ErrReport> {
     let RollupArgs {
         sequencer,
-        enable_txpool_gossip,
         discovery_v4,
         sequencer_headers,
         min_suggested_priority_fee,
@@ -70,7 +69,6 @@ pub async fn launch_node_with_proof_history(
     // Start from a plain BaseNode builder
     let mut node_builder = builder.node(BaseNode::new(RollupArgs {
         sequencer,
-        enable_txpool_gossip,
         discovery_v4,
         sequencer_headers,
         min_suggested_priority_fee,

--- a/crates/execution/node/tests/it/priority.rs
+++ b/crates/execution/node/tests/it/priority.rs
@@ -92,7 +92,7 @@ fn build_components<Node>(
 where
     Node: FullNodeTypes<Types: BaseNodeTypes>,
 {
-    let RollupArgs { disable_txpool_gossip, discovery_v4, .. } = RollupArgs::default();
+    let RollupArgs { enable_txpool_gossip, discovery_v4, .. } = RollupArgs::default();
     ComponentsBuilder::default()
         .node_types::<Node>()
         .pool(BasePoolBuilder::default())
@@ -100,7 +100,7 @@ where
         .payload(BasePayloadServiceBuilder::new(
             BasePayloadBuilder::new().with_transactions(CustomTxPriority { chain_id }),
         ))
-        .network(BaseNetworkBuilder::new(disable_txpool_gossip, !discovery_v4))
+        .network(BaseNetworkBuilder::new(enable_txpool_gossip, !discovery_v4))
         .consensus(BaseConsensusBuilder::default())
 }
 

--- a/crates/execution/node/tests/it/priority.rs
+++ b/crates/execution/node/tests/it/priority.rs
@@ -92,7 +92,7 @@ fn build_components<Node>(
 where
     Node: FullNodeTypes<Types: BaseNodeTypes>,
 {
-    let RollupArgs { enable_txpool_gossip, discovery_v4, .. } = RollupArgs::default();
+    let RollupArgs { discovery_v4, .. } = RollupArgs::default();
     ComponentsBuilder::default()
         .node_types::<Node>()
         .pool(BasePoolBuilder::default())
@@ -100,7 +100,7 @@ where
         .payload(BasePayloadServiceBuilder::new(
             BasePayloadBuilder::new().with_transactions(CustomTxPriority { chain_id }),
         ))
-        .network(BaseNetworkBuilder::new(enable_txpool_gossip, !discovery_v4))
+        .network(BaseNetworkBuilder::new(!discovery_v4))
         .consensus(BaseConsensusBuilder::default())
 }
 

--- a/crates/execution/runner/src/node.rs
+++ b/crates/execution/runner/src/node.rs
@@ -86,7 +86,6 @@ impl BaseNode {
         Node: FullNodeTypes<Types: BaseNodeTypes>,
     {
         let RollupArgs {
-            enable_txpool_gossip,
             discovery_v4,
             max_inflight_delegated_slots,
             mempool_sender_limit,
@@ -113,7 +112,7 @@ impl BaseNode {
                     .with_gas_limit_config(self.gas_limit_config.clone())
                     .with_manifest_precheck_enabled(self.manifest_precheck_enabled),
             ))
-            .network(BaseNetworkBuilder::new(enable_txpool_gossip, !discovery_v4))
+            .network(BaseNetworkBuilder::new(!discovery_v4))
             .consensus(BaseConsensusBuilder::default())
     }
 

--- a/crates/execution/runner/src/node.rs
+++ b/crates/execution/runner/src/node.rs
@@ -86,7 +86,7 @@ impl BaseNode {
         Node: FullNodeTypes<Types: BaseNodeTypes>,
     {
         let RollupArgs {
-            disable_txpool_gossip,
+            enable_txpool_gossip,
             discovery_v4,
             max_inflight_delegated_slots,
             mempool_sender_limit,
@@ -113,7 +113,7 @@ impl BaseNode {
                     .with_gas_limit_config(self.gas_limit_config.clone())
                     .with_manifest_precheck_enabled(self.manifest_precheck_enabled),
             ))
-            .network(BaseNetworkBuilder::new(disable_txpool_gossip, !discovery_v4))
+            .network(BaseNetworkBuilder::new(enable_txpool_gossip, !discovery_v4))
             .consensus(BaseConsensusBuilder::default())
     }
 

--- a/docs/guides/P2P.md
+++ b/docs/guides/P2P.md
@@ -648,7 +648,7 @@ let network_builder = ctx
     });
 
 let mut network_config = ctx.build_network_config(network_builder);
-network_config.tx_gossip_disabled = disable_txpool_gossip;
+network_config.tx_gossip_disabled = !enable_txpool_gossip;
 ```
 
 Notice that discv4 is disabled by default for Base (`--rollup.discovery.v4` defaults to false) while
@@ -712,11 +712,10 @@ rollup flags defined in
 are:
 
 `--rollup.sequencer` sets the sequencer endpoint for transaction forwarding.
-`--rollup.disable-tx-pool-gossip` disables transaction gossip on the DevP2P network (this is a
-separate flag — setting the sequencer endpoint does not automatically disable gossip, so operators
-typically set both). `--rollup.discovery.v4` enables the legacy discv4 discovery protocol (disabled
-by default since Base uses discv5). `--rollup.txpool-ordering` selects between `coinbase-tip` and
-`timestamp` ordering strategies.
+Transaction gossip on the DevP2P network is disabled by default;
+`--rollup.enable-tx-pool-gossip` explicitly enables it. `--rollup.discovery.v4` enables the legacy
+discv4 discovery protocol (disabled by default since Base uses discv5).
+`--rollup.txpool-ordering` selects between `coinbase-tip` and `timestamp` ordering strategies.
 
 The standard reth network flags still apply: `--network.addr` and `--network.port` control the RLPx
 bind address (default port 30303), `--network.discovery.disable-discovery` turns off all peer

--- a/docs/guides/P2P.md
+++ b/docs/guides/P2P.md
@@ -648,7 +648,7 @@ let network_builder = ctx
     });
 
 let mut network_config = ctx.build_network_config(network_builder);
-network_config.tx_gossip_disabled = !enable_txpool_gossip;
+network_config.tx_gossip_disabled = true;
 ```
 
 Notice that discv4 is disabled by default for Base (`--rollup.discovery.v4` defaults to false) while
@@ -712,8 +712,7 @@ rollup flags defined in
 are:
 
 `--rollup.sequencer` sets the sequencer endpoint for transaction forwarding.
-Transaction gossip on the DevP2P network is disabled by default;
-`--rollup.enable-tx-pool-gossip` explicitly enables it. `--rollup.discovery.v4` enables the legacy
+Transaction gossip on the DevP2P network is disabled. `--rollup.discovery.v4` enables the legacy
 discv4 discovery protocol (disabled by default since Base uses discv5).
 `--rollup.txpool-ordering` selects between `coinbase-tip` and `timestamp` ordering strategies.
 

--- a/etc/scripts/node/execution-entrypoint
+++ b/etc/scripts/node/execution-entrypoint
@@ -95,7 +95,6 @@ exec "$BINARY" node \
   --max-outbound-peers=100 \
   --chain "$RETH_CHAIN" \
   --rollup.sequencer-http="$RETH_SEQUENCER_HTTP" \
-  --rollup.disable-tx-pool-gossip \
   --discovery.port="$DISCOVERY_PORT" \
   --discovery.v5.port="$V5_DISCOVERY_PORT" \
   --port="$P2P_PORT" \


### PR DESCRIPTION
## Summary
- always disable EL txpool gossip in the Reth network configuration
- remove the txpool gossip CLI and builder configuration entirely
- update node construction, entrypoint configuration, and P2P documentation
