### PR TITLE
fix(shadow-indexer): extend pending migration timeout

### DIFF
--- a/crates/execution/shadow-indexer-db/src/config.rs
+++ b/crates/execution/shadow-indexer-db/src/config.rs
@@ -1,8 +1,9 @@
-use std::{fmt, time::Duration};
+use std::{borrow::Cow, fmt, time::Duration};
 
 use anyhow::{Context, Result};
 use sqlx::{
     PgPool,
+    migrate::Migrator,
     postgres::{PgConnectOptions, PgPoolOptions},
 };
 
@@ -95,10 +96,21 @@ impl ShadowDbConfig {
             .await
             .context("failed to connect to shadow indexer database")?;
 
-        sqlx::migrate!("./migrations")
-            .run(&pool)
-            .await
-            .context("failed to run shadow indexer database migrations")?;
+        // Migration 7 is already recorded with its original checksum in some environments, while
+        // larger databases still need longer than its embedded five-minute timeout. Keep the
+        // recorded checksum stable, but execute pending copies with a thirty-minute timeout.
+        let mut migrations = sqlx::migrate!("./migrations").iter().cloned().collect::<Vec<_>>();
+        for migration in &mut migrations {
+            if migration.version == 7 {
+                migration.sql = Cow::Owned(migration.sql.replace(
+                    "SET LOCAL statement_timeout = '300s';",
+                    "SET LOCAL statement_timeout = '1800s';",
+                ));
+            }
+        }
+        let migrator = Migrator { migrations: Cow::Owned(migrations), ..Migrator::DEFAULT };
+
+        migrator.run(&pool).await.context("failed to run shadow indexer database migrations")?;
 
         Ok(pool)
     }

--- a/crates/execution/shadow-indexer/src/writer.rs
+++ b/crates/execution/shadow-indexer/src/writer.rs
@@ -15,6 +15,7 @@ const BATCH_SIZE: usize = 100;
 const FLUSH_INTERVAL: Duration = Duration::from_secs(1);
 const MAX_FLUSH_ATTEMPTS: usize = 3;
 const RETRY_BACKOFF: Duration = Duration::from_millis(200);
+const DB_INIT_RETRY_BACKOFF: Duration = Duration::from_secs(5);
 
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
@@ -46,10 +47,8 @@ impl ShadowWriter {
         builder_version: String,
     ) {
         let writer = Self { rx, db_config, builder_version };
-        // Spawned as a critical task on purpose: this runs only on shadow canary nodes, where an
-        // unrecoverable writer failure (pool init panic, or the task ending) should fail-fast and
-        // take the node down rather than let it run without shadow indexing. On normal nodes the
-        // extension is disabled and this is never spawned.
+        // Spawned as a critical task so an unexpected task exit still takes down shadow canaries.
+        // Database initialization failures are retried in-place below and do not exit the task.
         executor.spawn_critical_task("shadow-indexer-writer", async move {
             writer.run().await;
         });
@@ -58,9 +57,20 @@ impl ShadowWriter {
     async fn run(mut self) {
         info!(target: "base::shadow-indexer", "Starting shadow indexer writer");
 
-        let pool = self.db_config.init_pool().await.unwrap_or_else(|error| {
-            panic!("failed to initialize shadow indexer database pool: {error:?}")
-        });
+        let pool = loop {
+            match self.db_config.init_pool().await {
+                Ok(pool) => break pool,
+                Err(error) => {
+                    error!(
+                        target: "base::shadow-indexer",
+                        error = ?error,
+                        retry_backoff = ?DB_INIT_RETRY_BACKOFF,
+                        "Failed to initialize shadow indexer database pool; retrying"
+                    );
+                    sleep(DB_INIT_RETRY_BACKOFF).await;
+                }
+            }
+        };
         let repo = ShadowBlockRepo::new(pool);
         let mut interval = interval(FLUSH_INTERVAL);
         interval.set_missed_tick_behavior(MissedTickBehavior::Delay);

--- a/crates/execution/shadow-indexer/src/writer.rs
+++ b/crates/execution/shadow-indexer/src/writer.rs
@@ -15,7 +15,6 @@ const BATCH_SIZE: usize = 100;
 const FLUSH_INTERVAL: Duration = Duration::from_secs(1);
 const MAX_FLUSH_ATTEMPTS: usize = 3;
 const RETRY_BACKOFF: Duration = Duration::from_millis(200);
-const DB_INIT_RETRY_BACKOFF: Duration = Duration::from_secs(5);
 
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
@@ -47,8 +46,10 @@ impl ShadowWriter {
         builder_version: String,
     ) {
         let writer = Self { rx, db_config, builder_version };
-        // Spawned as a critical task so an unexpected task exit still takes down shadow canaries.
-        // Database initialization failures are retried in-place below and do not exit the task.
+        // Spawned as a critical task on purpose: this runs only on shadow canary nodes, where an
+        // unrecoverable writer failure (pool init panic, or the task ending) should fail-fast and
+        // take the node down rather than let it run without shadow indexing. On normal nodes the
+        // extension is disabled and this is never spawned.
         executor.spawn_critical_task("shadow-indexer-writer", async move {
             writer.run().await;
         });
@@ -57,20 +58,9 @@ impl ShadowWriter {
     async fn run(mut self) {
         info!(target: "base::shadow-indexer", "Starting shadow indexer writer");
 
-        let pool = loop {
-            match self.db_config.init_pool().await {
-                Ok(pool) => break pool,
-                Err(error) => {
-                    error!(
-                        target: "base::shadow-indexer",
-                        error = ?error,
-                        retry_backoff = ?DB_INIT_RETRY_BACKOFF,
-                        "Failed to initialize shadow indexer database pool; retrying"
-                    );
-                    sleep(DB_INIT_RETRY_BACKOFF).await;
-                }
-            }
-        };
+        let pool = self.db_config.init_pool().await.unwrap_or_else(|error| {
+            panic!("failed to initialize shadow indexer database pool: {error:?}")
+        });
         let repo = ShadowBlockRepo::new(pool);
         let mut interval = interval(FLUSH_INTERVAL);
         interval.set_missed_tick_behavior(MissedTickBehavior::Delay);


### PR DESCRIPTION
## Summary
- execute pending shadow-indexer migration 7 with a 30-minute statement timeout
- retain migration 7's original SQLx checksum for databases where it is already applied
- keep database initialization fail-fast instead of retrying arbitrary migration failures

## Root cause
Migration 7's populated-table rewrite exceeded its embedded 300-second PostgreSQL statement timeout on mainnet. The resulting panic in the critical `shadow-indexer-writer` task shut down the execution client; the consensus client's `IncompleteMessage` Engine API error was fallout from that shutdown.

Migration 7 is already applied on zeronet but remains pending on mainnet. Editing the migration file would change its SQLx checksum and break zeronet with `VersionMismatch(7)`. The migration runner therefore preserves the embedded migration's original checksum while substituting a 1,800-second timeout in the SQL executed for pending databases. SQLx continues validating the original checksum on already-migrated databases and records that same checksum when applying the adjusted SQL to mainnet.

## Validation
- `cargo test -p base-shadow-indexer-db --lib`
- `cargo test -p base-shadow-indexer --lib`
- `cargo clippy -p base-shadow-indexer-db -p base-shadow-indexer --lib --tests -- -D warnings`
- `cargo test -p base-system-tests --test shadow_metrics_reader` exercised fresh-database migration successfully in all 16 cases; 15 tests passed and one unrelated existing timestamp precision assertion failed (`437015000ns` read from Postgres versus `437015155ns` supplied by the test)
